### PR TITLE
feat(builder): draw basemap and dataset attribution into every rendered map image

### DIFF
--- a/frontend/src/components/builder/hooks/__tests__/use-builder-save.test.ts
+++ b/frontend/src/components/builder/hooks/__tests__/use-builder-save.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { createElement, type ReactNode } from 'react';
 import { MAP_COLORS } from '@/lib/map-colors';
+import { OG_ATTRIBUTION, THUMBNAIL_ATTRIBUTION } from '@/lib/map-image-attribution';
 import { act } from '@testing-library/react';
 import { renderHook as baseRenderHook } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
@@ -105,10 +106,12 @@ function createMockCanvas() {
     fill: vi.fn(),
     stroke: vi.fn(),
     createLinearGradient: vi.fn(() => ({ addColorStop: vi.fn() })),
-    // feat(#1486): the attribution overlay measures before it draws. Constant
-    // width is enough here — the fitter's real behaviour (size ladder, elide
-    // boundary) is exercised in lib/__tests__/map-image-attribution.test.ts
-    // against a length-proportional stub.
+    // feat(#1486): the attribution overlay measures before it draws.
+    // fix(#1541 codex P1): length-proportional, not constant. A constant makes
+    // every credit set "fit" on one line, so no test at this level could see a
+    // wrap boundary — which is how the dropped credits went unnoticed here.
+    // The fitter's own wrap arithmetic is exercised in
+    // lib/__tests__/map-image-attribution.test.ts.
     measureText: vi.fn((text: string) => ({ width: text.length * 5 })),
   };
   return {
@@ -1675,6 +1678,63 @@ describe('useBuilderSave', () => {
         expect(crop.fills.some((f) => f.style === MAP_COLORS.exportImage.attributionScrim))
           .toBe(true);
       }
+
+      vi.useRealTimers();
+    });
+
+    // fix(#1541 codex P1): the sibling above uses a two-credit line that fits
+    // whole, so it could never have caught `maxLines: 1`. This one drives the
+    // same pipeline — crop, overlay, upload — with the five-credit load that
+    // measurably lost two providers, and asserts at the crops rather than at
+    // the fitter: the credit has to survive the path, not just the helper.
+    it('carries every credit into BOTH crops when the set needs wrapping (#1541)', async () => {
+      vi.useFakeTimers();
+      const canvases: ReturnType<typeof createMockCanvas>[] = [];
+      createElementSpy.mockImplementation((tag: string, options?: ElementCreationOptions) => {
+        if (tag !== 'canvas') return origCreateElement(tag, options);
+        const canvas = createMockCanvas();
+        canvases.push(canvas);
+        return canvas as unknown as HTMLCanvasElement;
+      });
+
+      const credits = [
+        'MapLibre',
+        '© OpenStreetMap contributors, climbing route geometry retrieved via the Overpass API, licensed under ODbL 1.0',
+        '© U.S. Geological Survey Earthquake Hazards Program, ANSS Comprehensive Earthquake Catalog (ComCat), public domain',
+        '© swisstopo swissALTI3D, 2m lidar digital elevation model, Federal Office of Topography, reproduced with authorisation',
+        'OpenFreeMap © OpenMapTiles Data from OpenStreetMap',
+      ];
+      const mockMap = createMockMap({ loaded: true, attribution: credits.join(' | ') });
+      await triggerSaveSuccess(mockMap);
+      act(() => { vi.advanceTimersByTime(500); });
+      await act(async () => { fireRenderCallback(mockMap); await Promise.resolve(); });
+
+      const credited = canvases.filter((c) => c.ctx.fillText.mock.calls.length > 0);
+      // The 400x250 thumbnail and the 1200x630 OG card.
+      expect(credited).toHaveLength(2);
+      expect(credited.map((c) => `${c.width}x${c.height}`)).toEqual(['400x250', '1200x630']);
+
+      for (const crop of credited) {
+        const drawn = crop.ctx.fillText.mock.calls.map((call: unknown[]) => String(call[0]));
+        // It wrapped rather than fitting by luck, and lost nothing doing it.
+        expect(drawn.length).toBeGreaterThan(1);
+        const rendered = drawn.join(' ');
+        for (const credit of credits) {
+          expect(rendered, `missing credit on ${crop.width}x${crop.height}: ${credit}`).toContain(
+            credit,
+          );
+        }
+        expect(rendered).not.toContain('…');
+        // The scrim was sized for every line, so none of them sits on bare map.
+        const scrim = crop.fills.find((f) => f.style === MAP_COLORS.exportImage.attributionScrim)!;
+        expect(scrim).toBeDefined();
+        const spec = crop.width === 400 ? THUMBNAIL_ATTRIBUTION : OG_ATTRIBUTION;
+        expect(scrim.rect[3]).toBe(drawn.length * spec.lineHeight + spec.paddingY * 2);
+      }
+
+      // Ate map pixels rather than dropping a provider, and the image itself is
+      // unchanged: a fixed-size crop stays fixed-size.
+      expect(mockUploadThumbnail).toHaveBeenCalled();
 
       vi.useRealTimers();
     });

--- a/frontend/src/components/builder/hooks/__tests__/use-builder-save.test.ts
+++ b/frontend/src/components/builder/hooks/__tests__/use-builder-save.test.ts
@@ -163,11 +163,15 @@ function createMockMap(
   }
   return {
     getContainer: vi.fn(() => container),
-    // The structured path the reader prefers: one source per credit.
+    // The structured path the reader prefers: one source per credit, each
+    // referenced by a visible layer. fix(#1541 codex P1): the reader sorts
+    // shown sources ahead of hidden ones, and a style whose sources no layer
+    // references reads as all-hidden — a state no real map is in.
     getStyle: vi.fn(() => ({
       sources: Object.fromEntries(
         credits.map((credit, i) => [`src-${i}`, { attribution: credit }]),
       ),
+      layers: credits.map((_, i) => ({ id: `layer-${i}`, source: `src-${i}`, layout: {} })),
     })),
     getCenter: vi.fn(() => ({ lng: -73.9, lat: 40.7 })),
     getZoom: vi.fn(() => 10),

--- a/frontend/src/components/builder/hooks/__tests__/use-builder-save.test.ts
+++ b/frontend/src/components/builder/hooks/__tests__/use-builder-save.test.ts
@@ -1,7 +1,12 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { createElement, type ReactNode } from 'react';
 import { MAP_COLORS } from '@/lib/map-colors';
-import { OG_ATTRIBUTION, THUMBNAIL_ATTRIBUTION } from '@/lib/map-image-attribution';
+import {
+  EXPORT_CANVAS_MAX_AREA,
+  EXPORT_CANVAS_MAX_DIMENSION,
+  OG_ATTRIBUTION,
+  THUMBNAIL_ATTRIBUTION,
+} from '@/lib/map-image-attribution';
 import { act } from '@testing-library/react';
 import { renderHook as baseRenderHook } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
@@ -2373,6 +2378,9 @@ describe('SHARE-09 export PNG composition', () => {
   let createGradientSpy: ReturnType<typeof vi.fn>;
   let addColorStopSpy: ReturnType<typeof vi.fn>;
   let toBlobSpy: ReturnType<typeof vi.fn>;
+  /** What the toBlob stub actually handed back — null for a canvas past the
+   *  engine limits, exactly as a browser would. */
+  let encodedBlobs: (Blob | null)[];
   let createElementSpy: ReturnType<typeof vi.spyOn>;
   // feat(#1486): hoisted so a test can read the height the export reserved.
   let offscreenCanvas: {
@@ -2395,7 +2403,22 @@ describe('SHARE-09 export PNG composition', () => {
       if (typeof color !== 'string' || color === '') throw new SyntaxError('unparseable color');
     });
     createGradientSpy = vi.fn(() => ({ addColorStop: addColorStopSpy }));
-    toBlobSpy = vi.fn((cb: (b: Blob | null) => void) => cb(new Blob(['png'], { type: 'image/png' })));
+    // fix(#1541 codex P2 round 2): mimic the browser. A canvas past an engine's
+    // per-side or total-area limit is unusable with nothing raised to say so —
+    // toBlob simply yields null and the export fails. A stub that always hands
+    // back a blob lets a test assert a successful export from a canvas no
+    // browser would encode, which is exactly how the unbounded band passed here.
+    encodedBlobs = [];
+    toBlobSpy = vi.fn((cb: (b: Blob | null) => void) => {
+      const { width, height } = offscreenCanvas;
+      const encodable =
+        width <= EXPORT_CANVAS_MAX_DIMENSION &&
+        height <= EXPORT_CANVAS_MAX_DIMENSION &&
+        width * height <= EXPORT_CANVAS_MAX_AREA;
+      const blob = encodable ? new Blob(['png'], { type: 'image/png' }) : null;
+      encodedBlobs.push(blob);
+      cb(blob);
+    });
 
     const ctx2d = {
       fillStyle: '' as string | CanvasGradient,
@@ -2767,6 +2790,100 @@ describe('SHARE-09 export PNG composition', () => {
     expect(drawn).not.toContain('…');
     // The band grew past the old two-line ceiling, and the canvas with it.
     expect(offscreenCanvas.height).toBeGreaterThan(600 + 12 + 2 * 16 + 12 + 32);
+  });
+
+  /* fix(#1541 codex P2 round 2): the band's measured height is assigned
+   * straight to the export canvas, and #1541 review had ruled that growth
+   * unlimited because the canvas is sized after the band is measured. Browsers
+   * cap a canvas per side and by total area; past either one `toBlob` returns
+   * null and NO image is produced. The API permits 200 layers and 5,000
+   * characters of `attribution` each, so the contract's own maximum reached it
+   * — which made the unlimited ruling a total-export-failure bug rather than
+   * the partial-credit one it was avoiding. */
+
+  /** 5,000 characters — the schema maximum — of ordinary short words, so
+   *  wrapping breaks on spaces and the credit can be found again in the joined
+   *  output. Distinct per index, so the dedupe keeps all 200. */
+  function maxedCredit(i: number): string {
+    return `© Provider ${i} ${'licensing statement for the exported map image '.repeat(120)}`
+      .slice(0, 5000)
+      .trimEnd()
+      .padEnd(5000, 'x');
+  }
+
+  it('keeps the export canvas encodable at 200 credits x 5,000 characters (#1541)', async () => {
+    const { toast } = await import('sonner');
+    const credits = Array.from({ length: 200 }, (_, i) => maxedCredit(i));
+    for (const c of credits) expect(c).toHaveLength(5000);
+
+    const mockMap = createMockMap({ loaded: true, attribution: credits.join(' | ') });
+    const state = makeSaveState({
+      localName: '',
+      localDescription: '',
+      // The other half of the contract maximum: 200 layers, each a legend row.
+      localLayers: Array.from({ length: 200 }, (_, i) =>
+        makeLayer({ id: `layer-${i}`, dataset_name: `Layer ${i}` }),
+      ),
+      mapInstanceRef: { current: mockMap } as unknown as SaveState['mapInstanceRef'],
+    });
+    const { result } = renderHook(() => useBuilderSave(state));
+
+    act(() => { result.current.handleExportPNG(); });
+    act(() => { fireRenderCallback(mockMap); });
+
+    // A canvas a browser will still hand back a blob for, on both limits.
+    expect(offscreenCanvas.height).toBeLessThanOrEqual(EXPORT_CANVAS_MAX_DIMENSION);
+    expect(offscreenCanvas.width).toBeLessThanOrEqual(EXPORT_CANVAS_MAX_DIMENSION);
+    expect(offscreenCanvas.width * offscreenCanvas.height).toBeLessThanOrEqual(
+      EXPORT_CANVAS_MAX_AREA,
+    );
+
+    // And it did: a real blob, and the success toast rather than the failure one.
+    expect(encodedBlobs).toEqual([expect.any(Blob)]);
+    expect(toast.success).toHaveBeenCalledWith('toasts.exportSuccess');
+    expect(toast.error).not.toHaveBeenCalled();
+
+    // Rendered whole + marked == input. Nothing falls between the two, and
+    // both terms are non-zero, so neither side of the sum is carrying it alone.
+    const drawn = fillTextSpy.mock.calls.map((c: unknown[]) => String(c[0]));
+    const joined = drawn.join(' ');
+    const rendered = credits.filter((c) => joined.includes(c)).length;
+    const markerLine = drawn.find((text) => /\+\d+ more credit/.test(text));
+    const marked = markerLine ? Number(/\+(\d+)/.exec(markerLine)![1]) : 0;
+    expect(rendered).toBeGreaterThan(0);
+    expect(marked).toBeGreaterThan(0);
+    expect(rendered + marked).toBe(credits.length);
+    expect(joined).not.toContain('…');
+  });
+
+  it('leaves an ordinary multi-credit export growing and complete (#1541)', () => {
+    // 40 credits: many lines, and still three orders of magnitude below the cap.
+    const credits = Array.from(
+      { length: 40 },
+      (_, i) => `© Data Provider ${i}, a licensing statement of some reasonable length`,
+    );
+    const mockMap = createMockMap({ loaded: true, attribution: credits.join(' | ') });
+    const state = makeSaveState({
+      localName: '',
+      localDescription: '',
+      localLayers: [],
+      mapInstanceRef: { current: mockMap } as unknown as SaveState['mapInstanceRef'],
+    });
+    const { result } = renderHook(() => useBuilderSave(state));
+
+    act(() => { result.current.handleExportPNG(); });
+    act(() => { fireRenderCallback(mockMap); });
+
+    const drawn = fillTextSpy.mock.calls.map((c: unknown[]) => String(c[0]));
+    const joined = drawn.join(' ');
+    for (const credit of credits) {
+      expect(joined, `missing credit: ${credit}`).toContain(credit);
+    }
+    // No marker at all: the cap must not start truncating a normal export.
+    expect(joined).not.toMatch(/more credit/);
+    // The band still grew a line at a time, and the canvas with it.
+    expect(offscreenCanvas.height).toBeGreaterThan(600 + 12 + 5 * 16 + 12 + 32);
+    expect(offscreenCanvas.height).toBeLessThanOrEqual(EXPORT_CANVAS_MAX_DIMENSION);
   });
 
   it('reserves canvas height for the credit band, and none when there is no credit (#1486)', () => {

--- a/frontend/src/components/builder/hooks/__tests__/use-builder-save.test.ts
+++ b/frontend/src/components/builder/hooks/__tests__/use-builder-save.test.ts
@@ -125,8 +125,12 @@ function createMockCanvas() {
   };
 }
 
-/** feat(#1486): what MapLibre's attribution control shows on a default mock. */
-export const MOCK_ATTRIBUTION = '© OpenFreeMap | © OpenStreetMap contributors';
+/** feat(#1486): the credits a default mock map declares, as separate sources
+ *  (which is how a real style carries them), and the single line they render
+ *  as once joined. fix(#1541 codex P2): the reader takes the structured list
+ *  and never re-splits the joined form, so the mock supplies the list. */
+export const MOCK_CREDITS = ['© OpenFreeMap', '© OpenStreetMap contributors'];
+export const MOCK_ATTRIBUTION = MOCK_CREDITS.join(' | ');
 
 function createMockMap(
   overrides: { loaded?: boolean; globeSpace?: boolean; attribution?: string | null } = {},
@@ -135,11 +139,12 @@ function createMockMap(
   // on screen. Every mock map has one; only an opted-in map is marked.
   const container = document.createElement('div');
   if (overrides.globeSpace) container.setAttribute('data-globe-space', 'true');
-  // feat(#1486): every real map renders MapLibre's attribution control, and
-  // all three capture paths now read it, so the default mock carries one too.
-  // Pass `attribution: null` for the no-credit-available case.
+  // feat(#1486): every real map declares credits on its sources and renders
+  // them in the attribution control, so the default mock carries both. Pass
+  // `attribution: null` for the no-credit-available case.
   const attribution =
     overrides.attribution === undefined ? MOCK_ATTRIBUTION : overrides.attribution;
+  const credits = attribution === null ? [] : attribution.split(' | ');
   if (attribution !== null) {
     const inner = document.createElement('div');
     inner.className = 'maplibregl-ctrl-attrib-inner';
@@ -148,6 +153,12 @@ function createMockMap(
   }
   return {
     getContainer: vi.fn(() => container),
+    // The structured path the reader prefers: one source per credit.
+    getStyle: vi.fn(() => ({
+      sources: Object.fromEntries(
+        credits.map((credit, i) => [`src-${i}`, { attribution: credit }]),
+      ),
+    })),
     getCenter: vi.fn(() => ({ lng: -73.9, lat: 40.7 })),
     getZoom: vi.fn(() => 10),
     getBearing: vi.fn(() => 0),

--- a/frontend/src/components/builder/hooks/__tests__/use-builder-save.test.ts
+++ b/frontend/src/components/builder/hooks/__tests__/use-builder-save.test.ts
@@ -2910,6 +2910,51 @@ describe('SHARE-09 export PNG composition', () => {
     expect(joined).not.toContain('…');
   });
 
+  /* fix(#1541 codex P2 round 4): the budget used to be a DESKTOP figure while
+   * the comment above it named iOS Safari's smaller one. codex's case, and the
+   * numbers here are iOS Safari's measured ceiling written out rather than read
+   * from the constant — the whole point is that the bound holds on the smallest
+   * engine, so a test that reads the constant would relax with it. */
+  it('keeps an iPad-sized export inside iOS Safari\'s ceiling (#1541)', async () => {
+    const { toast } = await import('sonner');
+    const IOS_MAX_AREA = 4096 * 4096; // 16,777,216
+    const IOS_CEILING_AT_2048 = IOS_MAX_AREA / 2048; // 8,192px tall
+
+    const credits = Array.from({ length: 200 }, (_, i) => maxedCredit(i));
+    const mockMap = createMockMap({ loaded: true, attribution: credits.join(' | ') });
+    // A valid iPad canvas, which exports fine today.
+    const iPadCanvas = createMockCanvas();
+    iPadCanvas.width = 2048;
+    iPadCanvas.height = 2732;
+    mockMap.getCanvas = vi.fn(() => iPadCanvas);
+
+    const state = makeSaveState({
+      localName: '',
+      localDescription: '',
+      localLayers: [],
+      mapInstanceRef: { current: mockMap } as unknown as SaveState['mapInstanceRef'],
+    });
+    const { result } = renderHook(() => useBuilderSave(state));
+
+    act(() => { result.current.handleExportPNG(); });
+    act(() => { fireRenderCallback(mockMap); });
+
+    expect(offscreenCanvas.width).toBe(2048);
+    expect(offscreenCanvas.height).toBeLessThanOrEqual(IOS_CEILING_AT_2048);
+    expect(offscreenCanvas.width * offscreenCanvas.height).toBeLessThanOrEqual(IOS_MAX_AREA);
+    expect(encodedBlobs).toEqual([expect.any(Blob)]);
+    expect(toast.error).not.toHaveBeenCalled();
+
+    // Still crediting: what fits, plus a marker for the rest.
+    const drawn = fillTextSpy.mock.calls.map((c: unknown[]) => String(c[0]));
+    const joined = drawn.join(' ');
+    const rendered = credits.filter((c) => joined.includes(c)).length;
+    const markerLine = drawn.find((text) => /\+\d+ more credit/.test(text));
+    expect(rendered).toBeGreaterThan(0);
+    expect(markerLine).toBeDefined();
+    expect(rendered + Number(/\+(\d+)/.exec(markerLine!)![1])).toBe(credits.length);
+  });
+
   it('leaves an ordinary multi-credit export growing and complete (#1541)', () => {
     // 40 credits: many lines, and still three orders of magnitude below the cap.
     const credits = Array.from(

--- a/frontend/src/components/builder/hooks/__tests__/use-builder-save.test.ts
+++ b/frontend/src/components/builder/hooks/__tests__/use-builder-save.test.ts
@@ -2338,7 +2338,11 @@ describe('SHARE-09 export PNG composition', () => {
       strokeRect: vi.fn(() => { strokeStyleAtStroke.push(ctx2d.strokeStyle); }),
       createLinearGradient: createGradientSpy,
       drawImage: vi.fn(),
-      measureText: vi.fn(() => ({ width: 120 })),
+      // fix(#1541 codex P1): length-proportional, not a constant 120. A
+      // constant makes every string "fit" on one line, so it cannot exercise
+      // the band's line growth — which is precisely how the two-line cap that
+      // dropped credits went unnoticed here.
+      measureText: vi.fn((text: string) => ({ width: text.length * 6 })),
     };
 
     offscreenCanvas = {
@@ -2660,6 +2664,38 @@ describe('SHARE-09 export PNG composition', () => {
     const texts = fillTextSpy.mock.calls.map((c: unknown[]) => String(c[0]));
     expect(texts).toContain(MOCK_ATTRIBUTION);
     expect(texts.some((t) => /export\.poweredBy|Powered by GeoLens/.test(t))).toBe(false);
+  });
+
+  // fix(#1541 codex P1): five real credits on a 1056px export used to lose two
+  // of them, the basemap's included, because the band was capped at two lines.
+  // The canvas has no height constraint, so it grows instead.
+  it('exports every credit for a credit-heavy map, growing the band (#1541)', () => {
+    const credits = [
+      'MapLibre',
+      '© OpenStreetMap contributors, climbing route geometry retrieved via the Overpass API, licensed under ODbL 1.0',
+      '© U.S. Geological Survey Earthquake Hazards Program, ANSS Comprehensive Earthquake Catalog (ComCat), public domain',
+      '© swisstopo swissALTI3D, 2m lidar digital elevation model, Federal Office of Topography, reproduced with authorisation',
+      'OpenFreeMap © OpenMapTiles Data from OpenStreetMap',
+    ];
+    const mockMap = createMockMap({ loaded: true, attribution: credits.join(' | ') });
+    const state = makeSaveState({
+      localName: '',
+      localDescription: '',
+      localLayers: [],
+      mapInstanceRef: { current: mockMap } as unknown as SaveState['mapInstanceRef'],
+    });
+    const { result } = renderHook(() => useBuilderSave(state));
+
+    act(() => { result.current.handleExportPNG(); });
+    act(() => { fireRenderCallback(mockMap); });
+
+    const drawn = fillTextSpy.mock.calls.map((c: unknown[]) => String(c[0])).join(' ');
+    for (const credit of credits) {
+      expect(drawn, `missing credit: ${credit}`).toContain(credit);
+    }
+    expect(drawn).not.toContain('…');
+    // The band grew past the old two-line ceiling, and the canvas with it.
+    expect(offscreenCanvas.height).toBeGreaterThan(600 + 12 + 2 * 16 + 12 + 32);
   });
 
   it('reserves canvas height for the credit band, and none when there is no credit (#1486)', () => {

--- a/frontend/src/components/builder/hooks/__tests__/use-builder-save.test.ts
+++ b/frontend/src/components/builder/hooks/__tests__/use-builder-save.test.ts
@@ -105,6 +105,11 @@ function createMockCanvas() {
     fill: vi.fn(),
     stroke: vi.fn(),
     createLinearGradient: vi.fn(() => ({ addColorStop: vi.fn() })),
+    // feat(#1486): the attribution overlay measures before it draws. Constant
+    // width is enough here — the fitter's real behaviour (size ladder, elide
+    // boundary) is exercised in lib/__tests__/map-image-attribution.test.ts
+    // against a length-proportional stub.
+    measureText: vi.fn((text: string) => ({ width: text.length * 5 })),
   };
   return {
     width: 800,
@@ -117,11 +122,27 @@ function createMockCanvas() {
   };
 }
 
-function createMockMap(overrides: { loaded?: boolean; globeSpace?: boolean } = {}) {
+/** feat(#1486): what MapLibre's attribution control shows on a default mock. */
+export const MOCK_ATTRIBUTION = '© OpenFreeMap | © OpenStreetMap contributors';
+
+function createMockMap(
+  overrides: { loaded?: boolean; globeSpace?: boolean; attribution?: string | null } = {},
+) {
   // fix(#1479): capture paths ask the container whether the space backdrop is
   // on screen. Every mock map has one; only an opted-in map is marked.
   const container = document.createElement('div');
   if (overrides.globeSpace) container.setAttribute('data-globe-space', 'true');
+  // feat(#1486): every real map renders MapLibre's attribution control, and
+  // all three capture paths now read it, so the default mock carries one too.
+  // Pass `attribution: null` for the no-credit-available case.
+  const attribution =
+    overrides.attribution === undefined ? MOCK_ATTRIBUTION : overrides.attribution;
+  if (attribution !== null) {
+    const inner = document.createElement('div');
+    inner.className = 'maplibregl-ctrl-attrib-inner';
+    inner.textContent = attribution;
+    container.appendChild(inner);
+  }
   return {
     getContainer: vi.fn(() => container),
     getCenter: vi.fn(() => ({ lng: -73.9, lat: 40.7 })),
@@ -1611,8 +1632,76 @@ describe('useBuilderSave', () => {
       act(() => { vi.advanceTimersByTime(500); });
       await act(async () => { fireRenderCallback(mockMap); await Promise.resolve(); });
 
-      expect(canvases.some((c) => c.fills.length > 0)).toBe(false);
+      // feat(#1486): names the backdrop rather than counting fills — the
+      // attribution scrim is also a fillRect, and it is drawn on every crop.
+      expect(
+        canvases.some((c) =>
+          c.fills.some((f) => f.style === MAP_COLORS.exportImage.globeBackground),
+        ),
+      ).toBe(false);
       expect(canvases.some((c) => c.ctx.drawImage.mock.calls.length > 0)).toBe(true);
+
+      vi.useRealTimers();
+    });
+
+    // feat(#1486): the crops composite from the WebGL canvas, so MapLibre's own
+    // attribution control — a DOM overlay — is invisible to them by
+    // construction. The credit reaches a distributed image only if it is drawn
+    // INTO the canvas, which is what these two assert.
+    it('draws the map credit into BOTH the thumbnail and the OG crop (#1486)', async () => {
+      vi.useFakeTimers();
+      const canvases: ReturnType<typeof createMockCanvas>[] = [];
+      createElementSpy.mockImplementation((tag: string, options?: ElementCreationOptions) => {
+        if (tag !== 'canvas') return origCreateElement(tag, options);
+        const canvas = createMockCanvas();
+        canvases.push(canvas);
+        return canvas as unknown as HTMLCanvasElement;
+      });
+
+      const mockMap = createMockMap({ loaded: true });
+      await triggerSaveSuccess(mockMap);
+      act(() => { vi.advanceTimersByTime(500); });
+      await act(async () => { fireRenderCallback(mockMap); await Promise.resolve(); });
+
+      const credited = canvases.filter((c) =>
+        c.ctx.fillText.mock.calls.some((call: unknown[]) => call[0] === MOCK_ATTRIBUTION),
+      );
+      expect(credited).toHaveLength(2);
+      for (const crop of credited) {
+        // Over the map, not under it: the reverse order would bury the credit.
+        expect(crop.ctx.drawImage.mock.invocationCallOrder[0])
+          .toBeLessThan(crop.ctx.fillText.mock.invocationCallOrder[0]);
+        // A scrim behind it, so it stays legible over arbitrary tiles.
+        expect(crop.fills.some((f) => f.style === MAP_COLORS.exportImage.attributionScrim))
+          .toBe(true);
+      }
+
+      vi.useRealTimers();
+    });
+
+    it('draws no credit when the map exposes none (#1486)', async () => {
+      vi.useFakeTimers();
+      const canvases: ReturnType<typeof createMockCanvas>[] = [];
+      createElementSpy.mockImplementation((tag: string, options?: ElementCreationOptions) => {
+        if (tag !== 'canvas') return origCreateElement(tag, options);
+        const canvas = createMockCanvas();
+        canvases.push(canvas);
+        return canvas as unknown as HTMLCanvasElement;
+      });
+
+      const mockMap = createMockMap({ loaded: true, attribution: null });
+      await triggerSaveSuccess(mockMap);
+      act(() => { vi.advanceTimersByTime(500); });
+      await act(async () => { fireRenderCallback(mockMap); await Promise.resolve(); });
+
+      // Still captured and uploaded — a missing credit never blocks a capture.
+      expect(mockUploadThumbnail).toHaveBeenCalled();
+      expect(canvases.some((c) => c.ctx.fillText.mock.calls.length > 0)).toBe(false);
+      expect(
+        canvases.some((c) =>
+          c.fills.some((f) => f.style === MAP_COLORS.exportImage.attributionScrim),
+        ),
+      ).toBe(false);
 
       vi.useRealTimers();
     });
@@ -2214,6 +2303,13 @@ describe('SHARE-09 export PNG composition', () => {
   let addColorStopSpy: ReturnType<typeof vi.fn>;
   let toBlobSpy: ReturnType<typeof vi.fn>;
   let createElementSpy: ReturnType<typeof vi.spyOn>;
+  // feat(#1486): hoisted so a test can read the height the export reserved.
+  let offscreenCanvas: {
+    width: number;
+    height: number;
+    getContext: ReturnType<typeof vi.fn>;
+    toBlob: ReturnType<typeof vi.fn>;
+  };
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -2245,7 +2341,7 @@ describe('SHARE-09 export PNG composition', () => {
       measureText: vi.fn(() => ({ width: 120 })),
     };
 
-    const offscreenCanvas = {
+    offscreenCanvas = {
       width: 800,
       height: 600,
       getContext: vi.fn(() => ctx2d),
@@ -2516,5 +2612,81 @@ describe('SHARE-09 export PNG composition', () => {
       expect.anything(),
       expect.anything(),
     );
+  });
+
+  /* feat(#1486): the exported PNG carries the map's credit line. */
+
+  it('draws the map credit in its own band (#1486)', () => {
+    const mockMap = makeExportMap();
+    const state = makeSaveState({
+      localName: '',
+      localDescription: '',
+      localLayers: [],
+      mapInstanceRef: { current: mockMap } as unknown as SaveState['mapInstanceRef'],
+    });
+    const { result } = renderHook(() => useBuilderSave(state));
+
+    act(() => { result.current.handleExportPNG(); });
+    act(() => { fireRenderCallback(mockMap); });
+
+    expect(fillTextSpy).toHaveBeenCalledWith(
+      MOCK_ATTRIBUTION,
+      expect.any(Number),
+      expect.any(Number),
+    );
+    // Its own band on the white chrome, not a scrim over the map: the credit
+    // is drawn below the map region (the canvas is 600px of map plus chrome).
+    const call = fillTextSpy.mock.calls.find((c: unknown[]) => c[0] === MOCK_ATTRIBUTION)!;
+    expect(call[2] as number).toBeGreaterThanOrEqual(600);
+  });
+
+  // The whole point of a separate band. "Powered by GeoLens" is promotion an
+  // enterprise licence may suppress; a basemap or dataset credit is a
+  // licensing obligation and must survive the same toggle.
+  it('still draws the map credit when branding is suppressed (#1486)', () => {
+    mockEdition.isEnterprise = true;
+    const mockMap = makeExportMap();
+    const state = makeSaveState({
+      localName: '',
+      localDescription: '',
+      localLayers: [],
+      mapInstanceRef: { current: mockMap } as unknown as SaveState['mapInstanceRef'],
+    });
+    const { result } = renderHook(() => useBuilderSave(state));
+
+    act(() => { result.current.handleExportPNG(); });
+    act(() => { fireRenderCallback(mockMap); });
+
+    const texts = fillTextSpy.mock.calls.map((c: unknown[]) => String(c[0]));
+    expect(texts).toContain(MOCK_ATTRIBUTION);
+    expect(texts.some((t) => /export\.poweredBy|Powered by GeoLens/.test(t))).toBe(false);
+  });
+
+  it('reserves canvas height for the credit band, and none when there is no credit (#1486)', () => {
+    const withCredit = makeExportMap();
+    const state = makeSaveState({
+      localName: '',
+      localDescription: '',
+      localLayers: [],
+      mapInstanceRef: { current: withCredit } as unknown as SaveState['mapInstanceRef'],
+    });
+    const { result } = renderHook(() => useBuilderSave(state));
+    act(() => { result.current.handleExportPNG(); });
+    act(() => { fireRenderCallback(withCredit); });
+    const creditedHeight = offscreenCanvas.height;
+
+    const bare = createMockMap({ loaded: true, attribution: null });
+    const bareState = makeSaveState({
+      localName: '',
+      localDescription: '',
+      localLayers: [],
+      mapInstanceRef: { current: bare } as unknown as SaveState['mapInstanceRef'],
+    });
+    const bareHook = renderHook(() => useBuilderSave(bareState));
+    act(() => { bareHook.result.current.handleExportPNG(); });
+    act(() => { fireRenderCallback(bare); });
+
+    // 12 gap + 16 line + 12 gap at dpr 1.
+    expect(creditedHeight - offscreenCanvas.height).toBe(40);
   });
 });

--- a/frontend/src/components/builder/hooks/__tests__/use-builder-save.test.ts
+++ b/frontend/src/components/builder/hooks/__tests__/use-builder-save.test.ts
@@ -153,7 +153,12 @@ function createMockMap(
   if (attribution !== null) {
     const inner = document.createElement('div');
     inner.className = 'maplibregl-ctrl-attrib-inner';
-    inner.textContent = attribution;
+    // fix(#1541 codex P2 round 3): innerHTML, because MapLibre RENDERS the
+    // credit HTML. Assigning it as text made an `<img alt="…">` credit read
+    // back as its own markup, so a reader that could not see the alt still
+    // found the provider name in the string — a mock artifact that made the
+    // image-credit tests pass against the broken reader.
+    inner.innerHTML = attribution;
     container.appendChild(inner);
   }
   return {
@@ -1751,6 +1756,55 @@ describe('useBuilderSave', () => {
       // Ate map pixels rather than dropping a provider, and the image itself is
       // unchanged: a fixed-size crop stays fixed-size.
       expect(mockUploadThumbnail).toHaveBeenCalled();
+
+      vi.useRealTimers();
+    });
+
+    /* fix(#1541 codex P2 round 3): `BasemapEntry.attribution` permits HTML, so
+     * a provider may credit itself with a logo. Its alt text is not DOM text,
+     * so the old `textContent` read skipped the source entirely and all three
+     * images shipped uncredited while the interactive map visibly showed the
+     * credit. Asserted at the outputs, on all three at once: this is a
+     * whole-pipeline property, and the reader is only where it broke. */
+    it('carries an image-only credit into all three images (#1541)', async () => {
+      vi.useFakeTimers();
+      const canvases: ReturnType<typeof createMockCanvas>[] = [];
+      createElementSpy.mockImplementation((tag: string, options?: ElementCreationOptions) => {
+        if (tag !== 'canvas') return origCreateElement(tag, options);
+        const canvas = createMockCanvas();
+        canvases.push(canvas);
+        return canvas as unknown as HTMLCanvasElement;
+      });
+
+      const mockMap = createMockMap({
+        loaded: true,
+        attribution: '<img src="https://tiles.example.com/logo.svg" alt="© Logo Provider">',
+      });
+      const result = await triggerSaveSuccess(mockMap);
+      act(() => { vi.advanceTimersByTime(500); });
+      await act(async () => { fireRenderCallback(mockMap); await Promise.resolve(); });
+
+      // Same hook, same map: now the PNG export, whose render callback is the
+      // second one registered (the crop capture consumed the first).
+      act(() => { result.current.handleExportPNG(); });
+      act(() => {
+        const renders = mockMap.once.mock.calls.filter((c: unknown[]) => c[0] === 'render');
+        (renders[renders.length - 1][1] as () => void)();
+      });
+
+      const credited = canvases.filter((c) =>
+        c.ctx.fillText.mock.calls.some((call: unknown[]) =>
+          String(call[0]).includes('© Logo Provider'),
+        ),
+      );
+      // The 400x250 thumbnail, the 1200x630 OG card, and the PNG export.
+      expect(credited).toHaveLength(3);
+      const sizes = credited.map((c) => `${c.width}x${c.height}`);
+      expect(sizes).toContain('400x250');
+      expect(sizes).toContain('1200x630');
+      // The export's own band, on the default named-and-described state:
+      // 84 title + 600 map + 40 band (12 gap + 1 line + 12 gap) + 32 footer.
+      expect(sizes).toContain('800x756');
 
       vi.useRealTimers();
     });

--- a/frontend/src/components/builder/hooks/use-builder-save.ts
+++ b/frontend/src/components/builder/hooks/use-builder-save.ts
@@ -25,6 +25,16 @@ import { legendEntryName } from '@/components/map-plugins/builtin/LegendPlugin';
 import { getPersistedFolderGroup, prepareLayersForPersistence, stampPersistedFolderGroupExpanded, type FolderGroupMeta } from '@/components/builder/folder-groups';
 import { normalizeDemStyleConfig } from '@/lib/dem-render-mode';
 import { MAP_COLORS } from '@/lib/map-colors';
+// feat(#1486): the three rendered-image paths all composite from the WebGL
+// canvas, which no DOM attribution control can reach. See lib/map-image-attribution.
+import {
+  drawAttributionBand,
+  drawAttributionOverlay,
+  measureAttributionBand,
+  readRenderedAttribution,
+  OG_ATTRIBUTION,
+  THUMBNAIL_ATTRIBUTION,
+} from '@/lib/map-image-attribution';
 // fix(#430 V-01): capability gate used to detect fields the builder has no editor
 // for on a given layer type (see unmanagedNullableFields below).
 import { getLayerCapabilities, isFolderGroupLayer } from '@/lib/layer-capabilities';
@@ -271,8 +281,21 @@ function doCapture(
         return;
       }
 
+      // feat(#1486): both crops carry the credit line. Read once — the entries
+      // are identical for the two targets, only the type size differs — and
+      // draw into each finished crop. This has to be a canvas draw: the crops
+      // composite from the WebGL canvas, so MapLibre's own DOM attribution
+      // control is invisible to them by construction.
+      //
+      // Deliberately AFTER the blank-frame guard above, which measures
+      // srcCanvas: drawing a credit onto the crops must not be able to make an
+      // unpainted frame read as painted.
+      const credits = readRenderedAttribution(map);
+
       const thumb = cropResize(srcCanvas, 400, 250, backdrop);
+      drawAttributionOverlay(thumb, credits, THUMBNAIL_ATTRIBUTION);
       const og = cropResize(srcCanvas, 1200, 630, backdrop);
+      drawAttributionOverlay(og, credits, OG_ATTRIBUTION);
 
       uploadThumbnail(mapId, thumb.toDataURL('image/jpeg', 0.7)).then(() => {
         // chore(#1021): this refetches nothing on the builder route, and that is
@@ -1072,17 +1095,35 @@ export function useBuilderSave(state: SaveState) {
           const showBranding = !isEnterprise;
           const footerH = showBranding ? 32 * dpr : 0;
 
-          const totalH = Math.round(titleBlockH + mapHeight + legendBlockH + footerH);
           const totalW = Math.round(mapWidth);
 
           const off = document.createElement('canvas');
           off.width = totalW;
-          off.height = totalH;
           const ctx = off.getContext('2d');
           if (!ctx) {
             toast.error(t('toasts.exportFailed'));
             return;
           }
+
+          // feat(#1486): the attribution band has to be MEASURED before the
+          // canvas is sized, since its height feeds totalH. It measures on this
+          // same context rather than a scratch canvas — `off` has its width but
+          // not yet its height, and setting the height below resets the context
+          // state (not the measurement, which is already a number).
+          //
+          // NOT gated on showBranding: "Powered by GeoLens" is promotion an
+          // enterprise licence may suppress, a basemap or dataset credit is a
+          // licensing obligation and is drawn either way.
+          const attributionBand = measureAttributionBand(
+            ctx,
+            readRenderedAttribution(map),
+            { maxWidth: totalW - pad * 2, dpr },
+          );
+
+          const totalH = Math.round(
+            titleBlockH + mapHeight + legendBlockH + attributionBand.height + footerH,
+          );
+          off.height = totalH;
 
           ctx.fillStyle = MAP_COLORS.exportImage.background;
           ctx.fillRect(0, 0, totalW, totalH);
@@ -1180,9 +1221,24 @@ export function useBuilderSave(state: SaveState) {
             }
           }
 
+          // feat(#1486): between the legend and the branding footer, on white
+          // rather than over imagery — so no scrim, and no credit is ever
+          // dropped for want of room (it wraps to a second line instead).
+          //
+          // Positioned off the block heights rather than off `cursorY`: the
+          // legend loop leaves the cursor 12*dpr above its own block bottom
+          // (it never adds legendBlockH's trailing pad), so following the
+          // cursor would draw the band into the legend's bottom padding and
+          // leave the same 12*dpr of dead white at the foot of the canvas.
+          drawAttributionBand(ctx, attributionBand, {
+            x: pad,
+            y: titleBlockH + mapHeight + legendBlockH,
+            dpr,
+          });
+
           if (showBranding) {
             const footerText = t('export.poweredBy', { defaultValue: 'Powered by GeoLens' });
-            ctx.fillStyle = MAP_COLORS.exportImage.attribution;
+            ctx.fillStyle = MAP_COLORS.exportImage.branding;
             ctx.font = `400 ${12 * dpr}px system-ui, -apple-system, "Segoe UI", Roboto, sans-serif`;
             ctx.textBaseline = 'middle';
             const metrics = ctx.measureText(footerText);

--- a/frontend/src/components/builder/hooks/use-builder-save.ts
+++ b/frontend/src/components/builder/hooks/use-builder-save.ts
@@ -1129,7 +1129,7 @@ export function useBuilderSave(state: SaveState) {
             {
               maxWidth: totalW - pad * 2,
               dpr,
-              maxHeight: attributionBandHeightBudget(totalW, reservedH),
+              maxHeight: attributionBandHeightBudget(totalW, reservedH, dpr),
             },
           );
 

--- a/frontend/src/components/builder/hooks/use-builder-save.ts
+++ b/frontend/src/components/builder/hooks/use-builder-save.ts
@@ -1129,7 +1129,7 @@ export function useBuilderSave(state: SaveState) {
             {
               maxWidth: totalW - pad * 2,
               dpr,
-              maxHeight: attributionBandHeightBudget(totalW, reservedH, dpr),
+              maxHeight: attributionBandHeightBudget(totalW, reservedH),
             },
           );
 

--- a/frontend/src/components/builder/hooks/use-builder-save.ts
+++ b/frontend/src/components/builder/hooks/use-builder-save.ts
@@ -28,6 +28,7 @@ import { MAP_COLORS } from '@/lib/map-colors';
 // feat(#1486): the three rendered-image paths all composite from the WebGL
 // canvas, which no DOM attribution control can reach. See lib/map-image-attribution.
 import {
+  attributionBandHeightBudget,
   drawAttributionBand,
   drawAttributionOverlay,
   measureAttributionBand,
@@ -1114,15 +1115,25 @@ export function useBuilderSave(state: SaveState) {
           // NOT gated on showBranding: "Powered by GeoLens" is promotion an
           // enterprise licence may suppress, a basemap or dataset credit is a
           // licensing obligation and is drawn either way.
+          //
+          // fix(#1541 codex P2 round 2): the band is the only elastic term in
+          // totalH, so it gets the height a browser will still encode, less
+          // what the fixed blocks have already spent. Unbounded, a
+          // contract-maximum map (200 layers x 5,000 characters of credit)
+          // asked for a canvas past the engine's limits, `toBlob` returned
+          // null and the PNG export failed outright.
+          const reservedH = titleBlockH + mapHeight + legendBlockH + footerH;
           const attributionBand = measureAttributionBand(
             ctx,
             readRenderedAttribution(map),
-            { maxWidth: totalW - pad * 2, dpr },
+            {
+              maxWidth: totalW - pad * 2,
+              dpr,
+              maxHeight: attributionBandHeightBudget(totalW, reservedH),
+            },
           );
 
-          const totalH = Math.round(
-            titleBlockH + mapHeight + legendBlockH + attributionBand.height + footerH,
-          );
+          const totalH = Math.round(reservedH + attributionBand.height);
           off.height = totalH;
 
           ctx.fillStyle = MAP_COLORS.exportImage.background;

--- a/frontend/src/i18n/locales/de/builder.json
+++ b/frontend/src/i18n/locales/de/builder.json
@@ -1150,7 +1150,9 @@
   },
   "export": {
     "legendHeader": "Legende",
-    "poweredBy": "Bereitgestellt von GeoLens"
+    "poweredBy": "Bereitgestellt von GeoLens",
+    "moreCredits_one": "+{{count}} weiterer Nachweis",
+    "moreCredits_other": "+{{count}} weitere Nachweise"
   },
   "history": {
     "title": "Verlauf",

--- a/frontend/src/i18n/locales/de/builder.json
+++ b/frontend/src/i18n/locales/de/builder.json
@@ -1152,7 +1152,9 @@
     "legendHeader": "Legende",
     "poweredBy": "Bereitgestellt von GeoLens",
     "moreCredits_one": "+{{count}} weiterer Nachweis",
-    "moreCredits_other": "+{{count}} weitere Nachweise"
+    "moreCredits_other": "+{{count}} weitere Nachweise",
+    "imageCredit": "(Bildnachweis)",
+    "imageCreditFrom": "(Bildnachweis: {{host}})"
   },
   "history": {
     "title": "Verlauf",

--- a/frontend/src/i18n/locales/en/builder.json
+++ b/frontend/src/i18n/locales/en/builder.json
@@ -1154,7 +1154,9 @@
   },
   "export": {
     "legendHeader": "Legend",
-    "poweredBy": "Powered by GeoLens"
+    "poweredBy": "Powered by GeoLens",
+    "moreCredits_one": "+{{count}} more credit",
+    "moreCredits_other": "+{{count}} more credits"
   },
   "history": {
     "title": "History",

--- a/frontend/src/i18n/locales/en/builder.json
+++ b/frontend/src/i18n/locales/en/builder.json
@@ -1156,7 +1156,9 @@
     "legendHeader": "Legend",
     "poweredBy": "Powered by GeoLens",
     "moreCredits_one": "+{{count}} more credit",
-    "moreCredits_other": "+{{count}} more credits"
+    "moreCredits_other": "+{{count}} more credits",
+    "imageCredit": "(image credit)",
+    "imageCreditFrom": "(image credit: {{host}})"
   },
   "history": {
     "title": "History",

--- a/frontend/src/i18n/locales/es/builder.json
+++ b/frontend/src/i18n/locales/es/builder.json
@@ -1152,7 +1152,9 @@
     "legendHeader": "Leyenda",
     "poweredBy": "Desarrollado por GeoLens",
     "moreCredits_one": "+{{count}} crédito más",
-    "moreCredits_other": "+{{count}} créditos más"
+    "moreCredits_other": "+{{count}} créditos más",
+    "imageCredit": "(crédito de imagen)",
+    "imageCreditFrom": "(crédito de imagen: {{host}})"
   },
   "history": {
     "title": "Historial",

--- a/frontend/src/i18n/locales/es/builder.json
+++ b/frontend/src/i18n/locales/es/builder.json
@@ -1150,7 +1150,9 @@
   },
   "export": {
     "legendHeader": "Leyenda",
-    "poweredBy": "Desarrollado por GeoLens"
+    "poweredBy": "Desarrollado por GeoLens",
+    "moreCredits_one": "+{{count}} crédito más",
+    "moreCredits_other": "+{{count}} créditos más"
   },
   "history": {
     "title": "Historial",

--- a/frontend/src/i18n/locales/fr/builder.json
+++ b/frontend/src/i18n/locales/fr/builder.json
@@ -1152,7 +1152,9 @@
     "legendHeader": "Légende",
     "poweredBy": "Propulsé par GeoLens",
     "moreCredits_one": "+{{count}} crédit supplémentaire",
-    "moreCredits_other": "+{{count}} crédits supplémentaires"
+    "moreCredits_other": "+{{count}} crédits supplémentaires",
+    "imageCredit": "(crédit image)",
+    "imageCreditFrom": "(crédit image : {{host}})"
   },
   "history": {
     "title": "Historique",

--- a/frontend/src/i18n/locales/fr/builder.json
+++ b/frontend/src/i18n/locales/fr/builder.json
@@ -1150,7 +1150,9 @@
   },
   "export": {
     "legendHeader": "Légende",
-    "poweredBy": "Propulsé par GeoLens"
+    "poweredBy": "Propulsé par GeoLens",
+    "moreCredits_one": "+{{count}} crédit supplémentaire",
+    "moreCredits_other": "+{{count}} crédits supplémentaires"
   },
   "history": {
     "title": "Historique",

--- a/frontend/src/lib/__tests__/map-image-attribution.test.ts
+++ b/frontend/src/lib/__tests__/map-image-attribution.test.ts
@@ -233,12 +233,29 @@ describe('readRenderedAttribution', () => {
     ]);
   });
 
-  it('prefers alt over aria-label over title', () => {
+  it('prefers aria-label over alt over title', () => {
+    // fix(#1541 codex P2 round 7): ARIA OVERRIDES the host-language attribute
+    // in the accessible name computation; it does not follow it.
     expect(
       readRenderedAttribution(
         sourcesMap('<img src="https://a.example/l.png" alt="© Alt" aria-label="© Aria" title="© Title">'),
       ),
+    ).toEqual(['© Aria']);
+    expect(
+      readRenderedAttribution(
+        sourcesMap('<img src="https://a.example/l.png" alt="© Alt" title="© Title">'),
+      ),
     ).toEqual(['© Alt']);
+  });
+
+  it('draws the ARIA credit, not the generic alt text a logo carries', () => {
+    // The realistic markup: alt names the picture, aria-label carries the
+    // credit. The old order drew "Provider logo" into every exported image.
+    expect(
+      readRenderedAttribution(
+        sourcesMap('<img src="https://a.example/l.png" alt="Provider logo" aria-label="© Provider 2026">'),
+      ),
+    ).toEqual(['© Provider 2026']);
   });
 
   it('keeps text around an image credit rather than replacing it', () => {
@@ -491,6 +508,83 @@ describe('readRenderedAttribution', () => {
       ),
     );
     expect(credits).toEqual(['© Other', '© Shared']);
+  });
+
+  /* fix(#1541 codex P2 round 7): the zoom range is the other half of
+   * MapLibre's own `isHidden`, so a visible layer outside its range leaves its
+   * source unused — and could displace the credit for what IS rendering. */
+
+  function zoomedMap(
+    sources: Record<string, string>,
+    layers: { source: string; minzoom?: number; maxzoom?: number }[],
+    zoom: number,
+  ) {
+    return {
+      ...mapWithControl(null),
+      getZoom: () => zoom,
+      getStyle: () => ({
+        sources: Object.fromEntries(
+          Object.entries(sources).map(([id, attribution]) => [id, { attribution }]),
+        ),
+        layers: layers.map(({ source, minzoom, maxzoom }, i) => ({
+          id: `layer-${i}`,
+          source,
+          layout: {},
+          ...(minzoom === undefined ? {} : { minzoom }),
+          ...(maxzoom === undefined ? {} : { maxzoom }),
+        })),
+      }),
+    };
+  }
+
+  it('treats a visible layer outside its zoom range as not shown', () => {
+    const credits = readRenderedAttribution(
+      zoomedMap(
+        { tooDeep: '© Out Of Range', live: '© In Range' },
+        [
+          { source: 'tooDeep', minzoom: 14 },
+          { source: 'live' },
+        ],
+        8,
+      ),
+    );
+    expect(credits).toEqual(['© In Range', '© Out Of Range']);
+  });
+
+  it('uses MapLibre\'s own boundary semantics: minzoom inclusive, maxzoom exclusive', () => {
+    // At zoom 10 exactly: a layer with minzoom 10 renders, one with maxzoom 10
+    // does not. Mirrors `isHidden`: zoom < minzoom || zoom >= maxzoom.
+    const atBoundary = readRenderedAttribution(
+      zoomedMap(
+        { ending: '© Ends Here', starting: '© Starts Here' },
+        [
+          { source: 'ending', maxzoom: 10 },
+          { source: 'starting', minzoom: 10 },
+        ],
+        10,
+      ),
+    );
+    expect(atBoundary).toEqual(['© Starts Here', '© Ends Here']);
+  });
+
+  it('treats a zero bound as no bound, as MapLibre does', () => {
+    // `!!(this.minzoom && ...)` — a zero minzoom is falsy and never hides.
+    const credits = readRenderedAttribution(
+      zoomedMap({ zeroBound: '© Zero Min', other: '© Other' }, [
+        { source: 'zeroBound', minzoom: 0 },
+        { source: 'other' },
+      ], 0),
+    );
+    expect(credits).toEqual(['© Zero Min', '© Other']);
+  });
+
+  it('leaves every layer in range when the map exposes no zoom', () => {
+    // Over-report rather than demote: the partial mocks the builder suites
+    // pass have no getZoom, and a missing signal must not hide a credit.
+    const credits = readRenderedAttribution(
+      layeredMap({ a: '© Shown', b: '© Also Shown' }, [{ source: 'a' }, { source: 'b' }]),
+    );
+    expect(credits).toEqual(['© Shown', '© Also Shown']);
   });
 
   it('leaves a style with no layers in its declared order', () => {

--- a/frontend/src/lib/__tests__/map-image-attribution.test.ts
+++ b/frontend/src/lib/__tests__/map-image-attribution.test.ts
@@ -12,6 +12,7 @@ import {
   drawAttributionOverlay,
   fitAttributionText,
   measureAttributionBand,
+  overlayLineCapacity,
   readRenderedAttribution,
   OG_ATTRIBUTION,
   THUMBNAIL_ATTRIBUTION,
@@ -343,6 +344,91 @@ describe('drawAttributionOverlay', () => {
   it('draws nothing when the canvas has no 2D context', () => {
     const canvas = { width: 400, height: 250, getContext: () => null } as unknown as HTMLCanvasElement;
     expect(drawAttributionOverlay(canvas, ['© A'], THUMBNAIL_ATTRIBUTION)).toBe(false);
+  });
+});
+
+/* fix(#1541 codex P1): the documented legibility floor, as assertions rather
+ * than as prose. Removing the fitter's elision left exactly one way for a crop
+ * to lose a credit — a band taller than the image it annotates — and these pin
+ * both where that is and that it is loud when reached. */
+describe('overlayLineCapacity: the documented ceiling', () => {
+  it('matches the header table for both crops', () => {
+    // 250 - 6 inset - 3*2 padding = 238 usable / 13 line height.
+    expect(overlayLineCapacity(THUMBNAIL_ATTRIBUTION, 250)).toBe(18);
+    // 630 - 12 inset - 5*2 padding = 608 usable / 20 line height.
+    expect(overlayLineCapacity(OG_ATTRIBUTION, 630)).toBe(30);
+  });
+
+  it('never returns a negative capacity for a frame smaller than its own inset', () => {
+    expect(overlayLineCapacity(THUMBNAIL_ATTRIBUTION, 4)).toBe(0);
+    expect(overlayLineCapacity(OG_ATTRIBUTION, 0)).toBe(0);
+  });
+
+  it('leaves the real credit load a long way clear of the ceiling', () => {
+    // The documented "real 5-credit load" column: 6 of 18 lines on the
+    // thumbnail (33.6% of a 250px frame), 4 of 30 on the OG card (14.3%).
+    for (const [spec, w, h, lines, pct] of [
+      [THUMBNAIL_ATTRIBUTION, 400, 250, 6, 33.6],
+      [OG_ATTRIBUTION, 1200, 630, 4, 14.3],
+    ] as const) {
+      const ctx = makeCtx();
+      drawAttributionOverlay(makeCanvas(w, h, ctx), REAL_CREDITS, spec);
+      const drawn = ctx.fillText.mock.calls.map((c: unknown[]) => String(c[0]));
+      expect(drawn).toHaveLength(lines);
+      expect(drawn.length).toBeLessThan(overlayLineCapacity(spec, h));
+      const [, , , boxH] = ctx.fillRect.mock.calls[0] as unknown as number[];
+      expect(((boxH / h) * 100).toFixed(1)).toBe(pct.toFixed(1));
+    }
+  });
+
+  it('pins the export row of the same table, which has no ceiling to reach', () => {
+    // The measured 1056px-wide export at dpr 1, less 20px of pad a side.
+    const measured = measureAttributionBand(
+      makeCtx() as unknown as CanvasRenderingContext2D,
+      REAL_CREDITS,
+      { maxWidth: 1016, dpr: 1 },
+    );
+    expect(measured.lines).toHaveLength(4);
+    expect(measured.height).toBe(88); // 12 gap + 4 * 16 + 12 gap
+    expectTotal(measured.lines, REAL_CREDITS);
+  });
+
+  it('warns rather than clipping quietly once the band outgrows the frame', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const ctx = makeCtx();
+      // 40 entries at ~75 characters a line is comfortably past the 18-line
+      // thumbnail ceiling; nothing short of that reaches it.
+      const flood = Array.from(
+        { length: 40 },
+        (_, i) => `© Data Provider Number ${i}, a licensing statement of some length`,
+      );
+      expect(drawAttributionOverlay(makeCanvas(400, 250, ctx), flood, THUMBNAIL_ATTRIBUTION)).toBe(
+        true,
+      );
+
+      // Still total at the fitter: every provider is in the line set, and the
+      // loss is the frame's, not the layout's.
+      const drawn = ctx.fillText.mock.calls.map((c: unknown[]) => String(c[0]));
+      expectTotal(drawn, flood);
+      expect(drawn.length).toBeGreaterThan(overlayLineCapacity(THUMBNAIL_ATTRIBUTION, 250));
+
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining('credit lines do not fit a 400x250 image at 10px'),
+      );
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it('stays quiet for a credit load that fits', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      drawAttributionOverlay(makeCanvas(400, 250, makeCtx()), REAL_CREDITS, THUMBNAIL_ATTRIBUTION);
+      expect(warn).not.toHaveBeenCalled();
+    } finally {
+      warn.mockRestore();
+    }
   });
 });
 

--- a/frontend/src/lib/__tests__/map-image-attribution.test.ts
+++ b/frontend/src/lib/__tests__/map-image-attribution.test.ts
@@ -371,11 +371,15 @@ describe('readRenderedAttribution', () => {
       container.appendChild(inner);
       return { getContainer: () => container };
     };
-    // Markup with no text and no image: nothing was declared to lose.
-    expect(readRenderedAttribution(control('<div>  </div>'))).toEqual([]);
+    // No elements and no text: nothing was declared to lose.
+    expect(readRenderedAttribution(control('   '))).toEqual([]);
     // But a lone decorative image IS a declaration; see the source-level rule.
     expect(readRenderedAttribution(control('<img src="https://a.example/l.gif" alt="">'))).toEqual([
       '(image credit: a.example)',
+    ]);
+    // And so is markup that renders without naming itself (round 8).
+    expect(readRenderedAttribution(control('<svg><path d="M0 0h4v4H0z"/></svg>'))).toEqual([
+      '(image credit)',
     ]);
   });
 
@@ -417,8 +421,38 @@ describe('readRenderedAttribution', () => {
     expect(credits).toEqual(['© Named Provider', '(image credit: logo.example.com)']);
   });
 
-  it('drops a declaration that has neither text nor an image', () => {
-    expect(readRenderedAttribution(sourcesMap('<div>   </div>', '<span></span>'))).toEqual([]);
+  /* fix(#1541 codex P2 round 8): the unnameable-credit fallback recognised
+   * only <img>, so an unlabelled inline <svg> or a CSS-backed logo — both of
+   * which MapLibre renders visibly — derived no text, matched no image, and
+   * vanished without even reaching the marker. The test is now the question
+   * itself: did the declaration put something on screen we could not name? */
+
+  it('counts an unlabelled inline SVG credit rather than dropping it', () => {
+    const credits = readRenderedAttribution(
+      sourcesMap('© Named Provider', '<svg viewBox="0 0 24 24"><path d="M0 0h24v24H0z"/></svg>'),
+    );
+    expect(credits).toEqual(['© Named Provider', '(image credit)']);
+  });
+
+  it('counts a CSS-backed logo with no element we could name', () => {
+    expect(
+      readRenderedAttribution(sourcesMap('<div class="provider-logo"></div>')),
+    ).toEqual(['(image credit)']);
+  });
+
+  it('still names an image by its host when the declaration has one', () => {
+    // The image path keeps its better placeholder even when other elements
+    // are present, since a host is the only identifying text available.
+    expect(
+      readRenderedAttribution(
+        sourcesMap('<span><svg></svg><img src="https://tiles.acme.com/l.png"></span>'),
+      ),
+    ).toEqual(['(image credit: tiles.acme.com)']);
+  });
+
+  it('drops a declaration with no elements and no text', () => {
+    // The only genuinely empty case left: nothing was declared to lose.
+    expect(readRenderedAttribution(sourcesMap('   ', '\n\t'))).toEqual([]);
   });
 
   /* fix(#1541 codex P1): "no `used` gating — over-crediting is the safe
@@ -585,6 +619,58 @@ describe('readRenderedAttribution', () => {
       layeredMap({ a: '© Shown', b: '© Also Shown' }, [{ source: 'a' }, { source: 'b' }]),
     );
     expect(credits).toEqual(['© Shown', '© Also Shown']);
+  });
+
+  /* fix(#1541 codex P2 round 8): MapLibre's AttributionControl drops an entry
+   * another entry contains whole, so `© Acme` beside `© Acme — CC BY 4.0`
+   * showed once on screen and twice in the image. Asymmetric failure: source
+   * order could let the redundant fragment take the budget and leave the
+   * complete licensing statement as the thing elided. */
+
+  it('drops a credit another credit already contains whole', () => {
+    expect(
+      readRenderedAttribution(sourcesMap('© Acme', '© Acme — CC BY 4.0')),
+    ).toEqual(['© Acme — CC BY 4.0']);
+    // Order-independent: the fragment goes whichever side it is declared.
+    expect(
+      readRenderedAttribution(sourcesMap('© Acme — CC BY 4.0', '© Acme')),
+    ).toEqual(['© Acme — CC BY 4.0']);
+  });
+
+  it('keeps two credits that merely share a prefix', () => {
+    expect(
+      readRenderedAttribution(sourcesMap('© Acme Northern', '© Acme Southern')),
+    ).toEqual(['© Acme Northern', '© Acme Southern']);
+  });
+
+  it('never lets a hidden credit suppress a shown one', () => {
+    // The caveat that matters: suppression runs WITHIN a group. Across them it
+    // would delete the shown text and leave the superstring in the group the
+    // marker elides first — the crowding-out bug through a different door.
+    const credits = readRenderedAttribution(
+      layeredMap(
+        { hiddenLong: '© Acme — CC BY 4.0', shownShort: '© Acme' },
+        [
+          { source: 'hiddenLong', hidden: true },
+          { source: 'shownShort' },
+        ],
+      ),
+    );
+    expect(credits).toEqual(['© Acme', '© Acme — CC BY 4.0']);
+  });
+
+  it('does not collapse two identical credits into nothing', () => {
+    // Strictly-longer containment, so equal strings cannot suppress each
+    // other; the exact dedupe owns that case and keeps one.
+    expect(readRenderedAttribution(sourcesMap('© Same', '© Same'))).toEqual(['© Same']);
+  });
+
+  it('suppresses a chain of containments down to the fullest statement', () => {
+    expect(
+      readRenderedAttribution(
+        sourcesMap('© Acme', '© Acme — CC BY', '© Acme — CC BY 4.0, all rights reserved'),
+      ),
+    ).toEqual(['© Acme — CC BY 4.0, all rights reserved']);
   });
 
   it('leaves a style with no layers in its declared order', () => {

--- a/frontend/src/lib/__tests__/map-image-attribution.test.ts
+++ b/frontend/src/lib/__tests__/map-image-attribution.test.ts
@@ -186,6 +186,173 @@ describe('readRenderedAttribution', () => {
     expect(readRenderedAttribution({})).toEqual([]);
     expect(readRenderedAttribution({ ...mapWithControl('   ') })).toEqual([]);
   });
+
+  /* fix(#1541 codex P2 round 3): a credit is HTML — `BasemapEntry.attribution`
+   * permits it and MapLibre renders it — so a provider may credit itself with a
+   * logo. An image's text alternative is not DOM text, so a `textContent` read
+   * returned '' and the source was skipped: the interactive map showed the
+   * credit and every exported image did not. Both readers derive text from the
+   * markup now, preserving the alternatives a sighted user is reading. */
+
+  function sourcesMap(...attributions: (string | null)[]) {
+    return {
+      ...mapWithControl(null),
+      getStyle: () => ({
+        sources: Object.fromEntries(
+          attributions.map((attribution, i) => [`src-${i}`, { attribution }]),
+        ),
+      }),
+    };
+  }
+
+  it('takes an image credit from its alt text', () => {
+    expect(
+      readRenderedAttribution(
+        sourcesMap('<img src="https://tiles.example.com/logo.svg" alt="© Provider">'),
+      ),
+    ).toEqual(['© Provider']);
+  });
+
+  it('takes aria-label and title when there is no alt', () => {
+    expect(
+      readRenderedAttribution(
+        sourcesMap(
+          '<img src="https://a.example/l.png" aria-label="© Aria Provider">',
+          '<img src="https://b.example/l.png" title="© Title Provider">',
+          // The generic element rule, which is what makes a labelled SVG work
+          // without this module ever naming SVG.
+          '<svg role="img" aria-label="© Svg Provider"></svg>',
+          '<svg><title>© Svg Title Provider</title></svg>',
+        ),
+      ),
+    ).toEqual([
+      '© Aria Provider',
+      '© Title Provider',
+      '© Svg Provider',
+      '© Svg Title Provider',
+    ]);
+  });
+
+  it('prefers alt over aria-label over title', () => {
+    expect(
+      readRenderedAttribution(
+        sourcesMap('<img src="https://a.example/l.png" alt="© Alt" aria-label="© Aria" title="© Title">'),
+      ),
+    ).toEqual(['© Alt']);
+  });
+
+  it('keeps text around an image credit rather than replacing it', () => {
+    expect(
+      readRenderedAttribution(
+        sourcesMap('Imagery <img src="https://a.example/l.png" alt="© Provider"> and data'),
+      ),
+    ).toEqual(['Imagery © Provider and data']);
+  });
+
+  it('does not credit a labelled wrapper twice', () => {
+    // The element fallback is checked AFTER the children, so an <a title="…">
+    // around real text contributes its text once, not its text and its title.
+    expect(
+      readRenderedAttribution(
+        sourcesMap('<a href="https://osm.org" title="© OpenStreetMap">© OpenStreetMap contributors</a>'),
+      ),
+    ).toEqual(['© OpenStreetMap contributors']);
+  });
+
+  /* The class, not just the reported site: `attribution` permits HTML
+   * generally, and a `textContent` read mangles more than images. */
+
+  it('separates credits that a break or block would show on their own lines', () => {
+    expect(
+      readRenderedAttribution(
+        sourcesMap(
+          '© Provider A<br>© Provider B',
+          '<div>© Block A</div><div>© Block B</div>',
+          '<ul><li>© List A</li><li>© List B</li></ul>',
+        ),
+      ),
+    ).toEqual([
+      '© Provider A | © Provider B',
+      '© Block A | © Block B',
+      '© List A | © List B',
+    ]);
+  });
+
+  it('collapses source whitespace and nesting into one legible line', () => {
+    expect(
+      readRenderedAttribution(
+        sourcesMap('<span>  <b>©</b>\n  <a href="#">Nested\tProvider</a>  </span>'),
+      ),
+    ).toEqual(['© Nested Provider']);
+  });
+
+  it('still decodes entities, which are text not markup', () => {
+    expect(readRenderedAttribution(sourcesMap('Rand &amp; McNally &copy; 2026'))).toEqual([
+      'Rand & McNally © 2026',
+    ]);
+  });
+
+  it('honours alt="" as the decorative image its author declared', () => {
+    // Explicitly decorative, so it is not a credit and gets no placeholder.
+    // The one case where an image yields nothing by design.
+    expect(
+      readRenderedAttribution(
+        sourcesMap('© Provider <img src="https://a.example/spacer.gif" alt="">'),
+      ),
+    ).toEqual(['© Provider']);
+  });
+
+  /* An image with NO alternative at all cannot be named. The decision is that
+   * it renders a placeholder rather than vanishing: an unnamed credit is still
+   * a credit, and the standard is that no output may silently drop one. */
+
+  it('names an unnamed image credit by its host rather than dropping it', () => {
+    expect(
+      readRenderedAttribution(sourcesMap('<img src="https://tiles.acme.com/logo.png">')),
+    ).toEqual(['(image credit: tiles.acme.com)']);
+  });
+
+  it('keeps two unnamed image credits from different hosts distinct', () => {
+    // A bare placeholder for both would dedupe to one, dropping a credit.
+    expect(
+      readRenderedAttribution(
+        sourcesMap(
+          '<img src="https://a.example.com/logo.png">',
+          '<img src="https://b.example.com/logo.png">',
+        ),
+      ),
+    ).toEqual(['(image credit: a.example.com)', '(image credit: b.example.com)']);
+  });
+
+  it('falls back to a bare placeholder for an image with no usable host', () => {
+    expect(
+      readRenderedAttribution(sourcesMap('<img src="data:image/gif;base64,R0lGOD">')),
+    ).toEqual(['(image credit)']);
+    expect(readRenderedAttribution(sourcesMap('<img>'))).toEqual(['(image credit)']);
+  });
+
+  it('derives the control fallback the same way, not from textContent', () => {
+    // The sibling reader. Fixing one and leaving the other still loses the
+    // credit, on exactly the maps that reach the fallback.
+    const container = document.createElement('div');
+    const inner = document.createElement('div');
+    inner.className = 'maplibregl-ctrl-attrib-inner';
+    inner.innerHTML =
+      '<a href="https://provider.example"><img src="https://provider.example/l.svg" alt="© Control Provider"></a>';
+    container.appendChild(inner);
+    expect(readRenderedAttribution({ getContainer: () => container })).toEqual([
+      '© Control Provider',
+    ]);
+  });
+
+  it('warns and returns nothing only when the control is genuinely empty', () => {
+    const container = document.createElement('div');
+    const inner = document.createElement('div');
+    inner.className = 'maplibregl-ctrl-attrib-inner';
+    inner.innerHTML = '<img src="https://a.example/spacer.gif" alt="">';
+    container.appendChild(inner);
+    expect(readRenderedAttribution({ getContainer: () => container })).toEqual([]);
+  });
 });
 
 /* fix(#1541 codex P1 x2): every output used to elide — the export band via a

--- a/frontend/src/lib/__tests__/map-image-attribution.test.ts
+++ b/frontend/src/lib/__tests__/map-image-attribution.test.ts
@@ -345,13 +345,63 @@ describe('readRenderedAttribution', () => {
     ]);
   });
 
-  it('warns and returns nothing only when the control is genuinely empty', () => {
-    const container = document.createElement('div');
-    const inner = document.createElement('div');
-    inner.className = 'maplibregl-ctrl-attrib-inner';
-    inner.innerHTML = '<img src="https://a.example/spacer.gif" alt="">';
-    container.appendChild(inner);
-    expect(readRenderedAttribution({ getContainer: () => container })).toEqual([]);
+  it('returns nothing only when the control declares nothing at all', () => {
+    const control = (html: string) => {
+      const container = document.createElement('div');
+      const inner = document.createElement('div');
+      inner.className = 'maplibregl-ctrl-attrib-inner';
+      inner.innerHTML = html;
+      container.appendChild(inner);
+      return { getContainer: () => container };
+    };
+    // Markup with no text and no image: nothing was declared to lose.
+    expect(readRenderedAttribution(control('<div>  </div>'))).toEqual([]);
+    // But a lone decorative image IS a declaration; see the source-level rule.
+    expect(readRenderedAttribution(control('<img src="https://a.example/l.gif" alt="">'))).toEqual([
+      '(image credit: a.example)',
+    ]);
+  });
+
+  /* fix(#1541 codex P2 round 4): honouring alt="" opened the gap beside it.
+   * The shortcut ran BEFORE the ARIA alternatives, and a source whose whole
+   * attribution reduced to nothing was dropped from the list entirely — so it
+   * was counted nowhere, marker included. */
+
+  it('lets an ARIA alternative override an empty alt', () => {
+    // alt="" means decorative only when nothing else names the image. These
+    // all have an accessible name, so MapLibre renders a credit and so do we.
+    expect(
+      readRenderedAttribution(
+        sourcesMap(
+          '<img src="https://a.example/l.png" alt="" aria-label="© Aria Provider">',
+          '<img src="https://b.example/l.png" alt="" title="© Title Provider">',
+          '<img src="https://c.example/l.png" alt="  " aria-label="© Spaces Provider">',
+        ),
+      ),
+    ).toEqual(['© Aria Provider', '© Title Provider', '© Spaces Provider']);
+  });
+
+  it('still drops a decorative image from INSIDE a credit that has text', () => {
+    // The alt="" rule is intact where it belongs: a spacer next to real text
+    // adds nothing. The placeholder is a source-level floor, not a per-image one.
+    expect(
+      readRenderedAttribution(
+        sourcesMap('© Provider <img src="https://a.example/spacer.gif" alt="">'),
+      ),
+    ).toEqual(['© Provider']);
+  });
+
+  it('counts a source whose whole credit is a decorative image, rather than swallowing it', () => {
+    const credits = readRenderedAttribution(
+      sourcesMap('© Named Provider', '<img src="https://logo.example.com/l.gif" alt="">'),
+    );
+    // Two sources declared a credit, so two credits reach the images — the
+    // second un-nameable but present, and therefore counted by the marker.
+    expect(credits).toEqual(['© Named Provider', '(image credit: logo.example.com)']);
+  });
+
+  it('drops a declaration that has neither text nor an image', () => {
+    expect(readRenderedAttribution(sourcesMap('<div>   </div>', '<span></span>'))).toEqual([]);
   });
 });
 
@@ -668,7 +718,7 @@ describe('overlayLineCapacity: the documented ceiling', () => {
     // Line count here is the STUB's, not the browser's — the 0.5em metric only
     // approximates real glyph widths, so this pins the height FORMULA and the
     // totality, not the header table's measured "real load" column.
-    const budget = attributionBandHeightBudget(1056, 600 + 32);
+    const budget = attributionBandHeightBudget(1056, 600 + 32, 1);
     const measured = measureAttributionBand(
       makeCtx() as unknown as CanvasRenderingContext2D,
       REAL_CREDITS,
@@ -676,9 +726,9 @@ describe('overlayLineCapacity: the documented ceiling', () => {
     );
     expect(measured.height).toBe(12 + measured.lines.length * 16 + 12);
     expectTotal(measured.lines, REAL_CREDITS);
-    // The documented header-table row: 983 lines of ceiling for a real load of
+    // The documented header-table row: 951 lines of ceiling for a real load of
     // four, so the bound is nowhere near the ordinary export.
-    expect(attributionBandLineCapacity(budget, 1)).toBe(983);
+    expect(attributionBandLineCapacity(budget, 1)).toBe(951);
     expect(measured.lines.length).toBeLessThan(20);
   });
 
@@ -824,7 +874,7 @@ describe('overlayLineCapacity: the documented ceiling', () => {
 describe('measureAttributionBand / drawAttributionBand', () => {
   /** The budget a real 1056x600 export at dpr 1 hands the band. Big enough
    *  that these cases never reach it; the ceiling has its own describe below. */
-  const ROOMY = attributionBandHeightBudget(1056, 632);
+  const ROOMY = attributionBandHeightBudget(1056, 632, 1);
 
   it('reserves gap + lines + gap, scaled by dpr', () => {
     const ctx = makeCtx();
@@ -920,12 +970,27 @@ describe('export canvas ceiling', () => {
   // 600px of map plus a 32px branding footer, the shape the hook composes.
   const RESERVED = 632;
 
-  it('is side-limited at ordinary export widths and area-limited at extreme ones', () => {
-    expect(exportCanvasHeightCeiling(EXPORT_WIDTH)).toBe(EXPORT_CANVAS_MAX_DIMENSION);
-    // The crossover sits at ~7,629px wide; past it the area limit binds first.
-    expect(exportCanvasHeightCeiling(8000)).toBe(Math.floor(EXPORT_CANVAS_MAX_AREA / 8000));
-    expect(exportCanvasHeightCeiling(8000)).toBeLessThan(EXPORT_CANVAS_MAX_DIMENSION);
+  it('budgets against the smallest measured engine ceiling, not the roomiest', () => {
+    // fix(#1541 codex P2 round 4): the area cap is iOS Safari's 4,096² and NOT
+    // a desktop figure. codex's case: an iPad's 2048x2732 canvas is valid and
+    // exports today, and the desktop budget let the band grow it past 8,192px
+    // high, where toBlob returns null and the export produces nothing.
+    expect(EXPORT_CANVAS_MAX_AREA).toBe(4096 * 4096);
+    expect(exportCanvasHeightCeiling(2048)).toBe(8192);
+    // Side-limited only for a narrow canvas; the area cap binds past 1,024px.
+    expect(exportCanvasHeightCeiling(1024)).toBe(EXPORT_CANVAS_MAX_DIMENSION);
+    expect(exportCanvasHeightCeiling(EXPORT_WIDTH)).toBe(
+      Math.floor(EXPORT_CANVAS_MAX_AREA / EXPORT_WIDTH),
+    );
+    expect(exportCanvasHeightCeiling(EXPORT_WIDTH)).toBeLessThan(EXPORT_CANVAS_MAX_DIMENSION);
     expect(exportCanvasHeightCeiling(0)).toBe(0);
+  });
+
+  it('costs an ordinary desktop export nothing', () => {
+    // The numbers the constants' comment quotes, so they cannot drift from it.
+    expect(attributionBandLineCapacity(attributionBandHeightBudget(1056, 632, 1), 1)).toBe(951);
+    // A maximized builder on a 5K display at dpr 2: 4400x2400 map, 32px footer.
+    expect(attributionBandLineCapacity(attributionBandHeightBudget(4400, 2432, 2), 2)).toBe(41);
   });
 
   it('costs the same pixels at any dpr, so the cap is a canvas budget not a line count', () => {
@@ -934,8 +999,26 @@ describe('export canvas ceiling', () => {
     expect(attributionBandLineCapacity(10, 1)).toBe(0);
   });
 
-  it('hands the band no height when the rest of the image has spent the ceiling', () => {
-    expect(attributionBandHeightBudget(EXPORT_WIDTH, EXPORT_CANVAS_MAX_DIMENSION)).toBe(0);
+  it('floors the band at one line when the fixed blocks have spent the ceiling', () => {
+    // A canvas already past the cap on its own is past it with or without a
+    // band, so dropping every credit there would trade a licensing obligation
+    // for nothing. One line, and the marker counts what it could not show.
+    const budget = attributionBandHeightBudget(EXPORT_WIDTH, EXPORT_CANVAS_MAX_DIMENSION, 1);
+    expect(budget).toBe(12 + 16 + 12);
+    expect(attributionBandLineCapacity(budget, 1)).toBe(1);
+
+    const measured = measureAttributionBand(
+      makeCtx() as unknown as CanvasRenderingContext2D,
+      REAL_CREDITS,
+      { maxWidth: EXPORT_MAX_TEXT_WIDTH, dpr: 1, maxHeight: budget },
+    );
+    expect(measured.lines).toEqual([`+${REAL_CREDITS.length} more credits`]);
+    expect(measured.height).toBe(40);
+    // Scaled by dpr, since the floor is one LINE and a line is dpr-sized.
+    expect(attributionBandHeightBudget(EXPORT_WIDTH, EXPORT_CANVAS_MAX_DIMENSION, 2)).toBe(80);
+  });
+
+  it('draws nothing only when a caller passes no room at all', () => {
     const measured = measureAttributionBand(
       makeCtx() as unknown as CanvasRenderingContext2D,
       REAL_CREDITS,
@@ -948,7 +1031,7 @@ describe('export canvas ceiling', () => {
     const credits = Array.from({ length: 200 }, (_, i) => maxedCredit(i));
     for (const c of credits) expect(c).toHaveLength(5000);
 
-    const budget = attributionBandHeightBudget(EXPORT_WIDTH, RESERVED);
+    const budget = attributionBandHeightBudget(EXPORT_WIDTH, RESERVED, 1);
     const measured = measureAttributionBand(
       makeCtx() as unknown as CanvasRenderingContext2D,
       credits,
@@ -985,7 +1068,7 @@ describe('export canvas ceiling', () => {
       {
         maxWidth: EXPORT_MAX_TEXT_WIDTH,
         dpr: 1,
-        maxHeight: attributionBandHeightBudget(EXPORT_WIDTH, RESERVED),
+        maxHeight: attributionBandHeightBudget(EXPORT_WIDTH, RESERVED, 1),
       },
     );
     expect(measured.lines.length).toBeGreaterThan(2);

--- a/frontend/src/lib/__tests__/map-image-attribution.test.ts
+++ b/frontend/src/lib/__tests__/map-image-attribution.test.ts
@@ -8,12 +8,17 @@
  */
 import { describe, it, expect, vi } from 'vitest';
 import {
+  attributionBandHeightBudget,
+  attributionBandLineCapacity,
   drawAttributionBand,
   drawAttributionOverlay,
+  exportCanvasHeightCeiling,
   fitAttributionText,
   measureAttributionBand,
   overlayLineCapacity,
   readRenderedAttribution,
+  EXPORT_CANVAS_MAX_AREA,
+  EXPORT_CANVAS_MAX_DIMENSION,
   OG_ATTRIBUTION,
   THUMBNAIL_ATTRIBUTION,
 } from '../map-image-attribution';
@@ -492,17 +497,22 @@ describe('overlayLineCapacity: the documented ceiling', () => {
     }
   });
 
-  it('pins the export band height formula, which has no ceiling to reach', () => {
+  it('pins the export band height formula, a long way inside its ceiling', () => {
     // Line count here is the STUB's, not the browser's — the 0.5em metric only
     // approximates real glyph widths, so this pins the height FORMULA and the
     // totality, not the header table's measured "real load" column.
+    const budget = attributionBandHeightBudget(1056, 600 + 32);
     const measured = measureAttributionBand(
       makeCtx() as unknown as CanvasRenderingContext2D,
       REAL_CREDITS,
-      { maxWidth: 1016, dpr: 1 },
+      { maxWidth: 1016, dpr: 1, maxHeight: budget },
     );
     expect(measured.height).toBe(12 + measured.lines.length * 16 + 12);
     expectTotal(measured.lines, REAL_CREDITS);
+    // The documented header-table row: 983 lines of ceiling for a real load of
+    // four, so the bound is nowhere near the ordinary export.
+    expect(attributionBandLineCapacity(budget, 1)).toBe(983);
+    expect(measured.lines.length).toBeLessThan(20);
   });
 
   /* fix(#1541 codex P1 round 2): the schema accepts 5,000 characters per
@@ -645,12 +655,16 @@ describe('overlayLineCapacity: the documented ceiling', () => {
 });
 
 describe('measureAttributionBand / drawAttributionBand', () => {
+  /** The budget a real 1056x600 export at dpr 1 hands the band. Big enough
+   *  that these cases never reach it; the ceiling has its own describe below. */
+  const ROOMY = attributionBandHeightBudget(1056, 632);
+
   it('reserves gap + lines + gap, scaled by dpr', () => {
     const ctx = makeCtx();
     const measured = measureAttributionBand(
       ctx as unknown as CanvasRenderingContext2D,
       ['© OpenStreetMap contributors'],
-      { maxWidth: 2000, dpr: 2 },
+      { maxWidth: 2000, dpr: 2, maxHeight: ROOMY },
     );
     expect(measured.lines).toEqual(['© OpenStreetMap contributors']);
     expect(measured.height).toBe(80); // 12*2 + 1 * 16*2 + 12*2
@@ -663,6 +677,7 @@ describe('measureAttributionBand / drawAttributionBand', () => {
       measureAttributionBand(ctx as unknown as CanvasRenderingContext2D, [], {
         maxWidth: 2000,
         dpr: 1,
+        maxHeight: ROOMY,
       }).height,
     ).toBe(0);
   });
@@ -676,7 +691,7 @@ describe('measureAttributionBand / drawAttributionBand', () => {
     const measured = measureAttributionBand(
       ctx as unknown as CanvasRenderingContext2D,
       credits,
-      { maxWidth: 300, dpr: 1 },
+      { maxWidth: 300, dpr: 1, maxHeight: ROOMY },
     );
     expect(measured.lines.length).toBeGreaterThan(2);
     expect(measured.height).toBe(12 + measured.lines.length * 16 + 12);
@@ -705,5 +720,110 @@ describe('measureAttributionBand / drawAttributionBand', () => {
       { x: 20, y: 100, dpr: 1 },
     );
     expect(ctx.fillText).not.toHaveBeenCalled();
+  });
+});
+
+/* fix(#1541 codex P2 round 2): the export band is bounded too.
+ *
+ * #1541 review had ruled its growth unlimited, on the reasoning that the export
+ * canvas is sized after the band is measured and so has no height constraint.
+ * Browsers do: a canvas is capped per side and by total area, and past either
+ * one `toBlob` hands back null and the export fails outright. At the contract's
+ * maximum — 200 layers, 5,000 characters of credit each — the unlimited band
+ * asked for a canvas no engine would encode, which is strictly worse than the
+ * partial credit it was meant to avoid. */
+describe('export canvas ceiling', () => {
+  /** Exactly 5,000 characters — the schema maximum — of ordinary short words,
+   *  so wrapping breaks on spaces and joining the lines back with a space
+   *  reconstructs the credit. A long unbroken run would wrap mid-word and make
+   *  the accounting below measure the stub's word-breaker instead. */
+  function maxedCredit(i: number): string {
+    const body = `© Provider ${i} ${'licensing statement for the exported map image '.repeat(120)}`;
+    return body.slice(0, 5000).trimEnd().padEnd(5000, 'x');
+  }
+
+  /** The count named by a trailing "+N more credits" marker, or 0. */
+  function markedCount(lines: string[]): number {
+    const match = /\+(\d+) more credit/.exec(lines[lines.length - 1] ?? '');
+    return match ? Number(match[1]) : 0;
+  }
+
+  const EXPORT_WIDTH = 1056;
+  const EXPORT_MAX_TEXT_WIDTH = EXPORT_WIDTH - 40; // 20px of pad a side
+  // 600px of map plus a 32px branding footer, the shape the hook composes.
+  const RESERVED = 632;
+
+  it('is side-limited at ordinary export widths and area-limited at extreme ones', () => {
+    expect(exportCanvasHeightCeiling(EXPORT_WIDTH)).toBe(EXPORT_CANVAS_MAX_DIMENSION);
+    // The crossover sits at ~7,629px wide; past it the area limit binds first.
+    expect(exportCanvasHeightCeiling(8000)).toBe(Math.floor(EXPORT_CANVAS_MAX_AREA / 8000));
+    expect(exportCanvasHeightCeiling(8000)).toBeLessThan(EXPORT_CANVAS_MAX_DIMENSION);
+    expect(exportCanvasHeightCeiling(0)).toBe(0);
+  });
+
+  it('costs the same pixels at any dpr, so the cap is a canvas budget not a line count', () => {
+    expect(attributionBandLineCapacity(1000, 1)).toBe(61); // (1000 - 24) / 16
+    expect(attributionBandLineCapacity(1000, 2)).toBe(29); // (1000 - 48) / 32
+    expect(attributionBandLineCapacity(10, 1)).toBe(0);
+  });
+
+  it('hands the band no height when the rest of the image has spent the ceiling', () => {
+    expect(attributionBandHeightBudget(EXPORT_WIDTH, EXPORT_CANVAS_MAX_DIMENSION)).toBe(0);
+    const measured = measureAttributionBand(
+      makeCtx() as unknown as CanvasRenderingContext2D,
+      REAL_CREDITS,
+      { maxWidth: EXPORT_MAX_TEXT_WIDTH, dpr: 1, maxHeight: 0 },
+    );
+    expect(measured).toEqual({ lines: [], fontPx: 12, height: 0 });
+  });
+
+  it('at 200 credits x 5,000 characters: the canvas stays encodable, every credit accounted for', () => {
+    const credits = Array.from({ length: 200 }, (_, i) => maxedCredit(i));
+    for (const c of credits) expect(c).toHaveLength(5000);
+
+    const budget = attributionBandHeightBudget(EXPORT_WIDTH, RESERVED);
+    const measured = measureAttributionBand(
+      makeCtx() as unknown as CanvasRenderingContext2D,
+      credits,
+      { maxWidth: EXPORT_MAX_TEXT_WIDTH, dpr: 1, maxHeight: budget },
+    );
+
+    // The canvas the hook would build from this measurement is one a browser
+    // will still encode, on both limits.
+    const canvasHeight = RESERVED + measured.height;
+    expect(measured.height).toBeLessThanOrEqual(budget);
+    expect(canvasHeight).toBeLessThanOrEqual(EXPORT_CANVAS_MAX_DIMENSION);
+    expect(EXPORT_WIDTH * canvasHeight).toBeLessThanOrEqual(EXPORT_CANVAS_MAX_AREA);
+
+    // Rendered whole + marked == input. Nothing falls between the two.
+    const joined = measured.lines.join(' ');
+    const rendered = credits.filter((c) => joined.includes(c)).length;
+    expect(rendered + markedCount(measured.lines)).toBe(credits.length);
+    expect(joined).not.toContain('…');
+    // Non-vacuous in both directions: real credits DID render (this is not a
+    // bare marker), and the marker IS carrying a count (the sum is not
+    // balancing because everything happened to fit).
+    expect(rendered).toBeGreaterThan(0);
+    expect(markedCount(measured.lines)).toBeGreaterThan(0);
+  });
+
+  it('leaves a mid-sized credit load growing and complete, with no marker', () => {
+    const credits = Array.from(
+      { length: 40 },
+      (_, i) => `© Data Provider ${i}, a licensing statement of some reasonable length`,
+    );
+    const measured = measureAttributionBand(
+      makeCtx() as unknown as CanvasRenderingContext2D,
+      credits,
+      {
+        maxWidth: EXPORT_MAX_TEXT_WIDTH,
+        dpr: 1,
+        maxHeight: attributionBandHeightBudget(EXPORT_WIDTH, RESERVED),
+      },
+    );
+    expect(measured.lines.length).toBeGreaterThan(2);
+    expect(measured.height).toBe(12 + measured.lines.length * 16 + 12);
+    expect(measured.lines.join(' ')).not.toMatch(/more credit/);
+    expectTotal(measured.lines, credits);
   });
 });

--- a/frontend/src/lib/__tests__/map-image-attribution.test.ts
+++ b/frontend/src/lib/__tests__/map-image-attribution.test.ts
@@ -381,44 +381,123 @@ describe('overlayLineCapacity: the documented ceiling', () => {
     }
   });
 
-  it('pins the export row of the same table, which has no ceiling to reach', () => {
-    // The measured 1056px-wide export at dpr 1, less 20px of pad a side.
+  it('pins the export band height formula, which has no ceiling to reach', () => {
+    // Line count here is the STUB's, not the browser's — the 0.5em metric only
+    // approximates real glyph widths, so this pins the height FORMULA and the
+    // totality, not the header table's measured "real load" column.
     const measured = measureAttributionBand(
       makeCtx() as unknown as CanvasRenderingContext2D,
       REAL_CREDITS,
       { maxWidth: 1016, dpr: 1 },
     );
-    expect(measured.lines).toHaveLength(4);
-    expect(measured.height).toBe(88); // 12 gap + 4 * 16 + 12 gap
+    expect(measured.height).toBe(12 + measured.lines.length * 16 + 12);
     expectTotal(measured.lines, REAL_CREDITS);
   });
 
-  it('warns rather than clipping quietly once the band outgrows the frame', () => {
-    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
-    try {
-      const ctx = makeCtx();
-      // 40 entries at ~75 characters a line is comfortably past the 18-line
-      // thumbnail ceiling; nothing short of that reaches it.
-      const flood = Array.from(
-        { length: 40 },
-        (_, i) => `© Data Provider Number ${i}, a licensing statement of some length`,
-      );
-      expect(drawAttributionOverlay(makeCanvas(400, 250, ctx), flood, THUMBNAIL_ATTRIBUTION)).toBe(
-        true,
-      );
+  /* fix(#1541 codex P1 round 2): the schema accepts 5,000 characters per
+   * credit (datasets/domain/schemas.py, processing/ingest/manifest_schemas.py).
+   * That is ~77 lines in a 250px thumbnail — unrenderable at any legible size.
+   * So the invariant is asserted at the CONTRACT's maximum, not at the 411
+   * characters real data happens to carry: nothing is painted outside the
+   * canvas, and rendered credits plus marked credits equals the input. */
 
-      // Still total at the fitter: every provider is in the line set, and the
-      // loss is the frame's, not the layout's.
-      const drawn = ctx.fillText.mock.calls.map((c: unknown[]) => String(c[0]));
-      expectTotal(drawn, flood);
-      expect(drawn.length).toBeGreaterThan(overlayLineCapacity(THUMBNAIL_ATTRIBUTION, 250));
-
-      expect(warn).toHaveBeenCalledWith(
-        expect.stringContaining('credit lines do not fit a 400x250 image at 10px'),
-      );
-    } finally {
-      warn.mockRestore();
+  /** Every line lands inside the frame, and so does the scrim behind them. */
+  function expectNothingOutsideFrame(
+    ctx: ReturnType<typeof makeCtx>,
+    spec: typeof THUMBNAIL_ATTRIBUTION,
+    w: number,
+    h: number,
+  ) {
+    for (const call of ctx.fillText.mock.calls) {
+      const y = call[2] as number;
+      expect(y).toBeGreaterThanOrEqual(0);
+      expect(y + spec.lineHeight).toBeLessThanOrEqual(h);
+      expect(call[1] as number).toBeGreaterThanOrEqual(0);
     }
+    const [x, y, bw, bh] = ctx.fillRect.mock.calls[0] as unknown as number[];
+    expect(x).toBeGreaterThanOrEqual(0);
+    expect(y).toBeGreaterThanOrEqual(0);
+    expect(x + bw).toBeLessThanOrEqual(w);
+    expect(y + bh).toBeLessThanOrEqual(h);
+  }
+
+  /** The count named by a trailing "+N more credits" marker, or 0. */
+  function markedCount(drawn: string[]): number {
+    const match = /\+(\d+) more credit/.exec(drawn[drawn.length - 1] ?? '');
+    return match ? Number(match[1]) : 0;
+  }
+
+  it('at the 5,000-character contract maximum: nothing outside the frame, every credit accounted for', () => {
+    // Five credits, each exactly the schema's max_length.
+    const maxed = Array.from({ length: 5 }, (_, i) =>
+      `© Provider ${i} ${'licensing statement '.repeat(260)}`.slice(0, 4999).padEnd(5000, '.'),
+    );
+    for (const c of maxed) expect(c).toHaveLength(5000);
+
+    for (const [spec, w, h] of [
+      [THUMBNAIL_ATTRIBUTION, 400, 250],
+      [OG_ATTRIBUTION, 1200, 630],
+    ] as const) {
+      const ctx = makeCtx();
+      expect(drawAttributionOverlay(makeCanvas(w, h, ctx), maxed, spec)).toBe(true);
+      const drawn = ctx.fillText.mock.calls.map((c: unknown[]) => String(c[0]));
+
+      expect(drawn.length).toBeLessThanOrEqual(overlayLineCapacity(spec, h));
+      expectNothingOutsideFrame(ctx, spec, w, h);
+
+      // Rendered whole + marked == input. Nothing falls between the two.
+      const joined = drawn.join(' ');
+      const rendered = maxed.filter((c) => joined.includes(c)).length;
+      expect(rendered + markedCount(drawn)).toBe(maxed.length);
+      // Non-vacuous: at 5,000 characters a credit, NOTHING fits either frame,
+      // so the marker must be carrying the whole count rather than the sum
+      // balancing because everything rendered.
+      expect(markedCount(drawn)).toBe(maxed.length);
+      expect(drawn).toEqual(['+5 more credits']);
+    }
+  });
+
+  it('renders what fits and marks the rest, rather than clipping', () => {
+    const ctx = makeCtx();
+    // 40 medium credits: some fit the 18-line thumbnail, most do not.
+    const flood = Array.from(
+      { length: 40 },
+      (_, i) => `© Data Provider Number ${i}, a licensing statement of some length`,
+    );
+    expect(drawAttributionOverlay(makeCanvas(400, 250, ctx), flood, THUMBNAIL_ATTRIBUTION)).toBe(
+      true,
+    );
+    const drawn = ctx.fillText.mock.calls.map((c: unknown[]) => String(c[0]));
+
+    expect(drawn.length).toBeLessThanOrEqual(overlayLineCapacity(THUMBNAIL_ATTRIBUTION, 250));
+    expectNothingOutsideFrame(ctx, THUMBNAIL_ATTRIBUTION, 400, 250);
+
+    // Some real credits DID render — this is not a bare marker.
+    const joined = drawn.join(' ');
+    const rendered = flood.filter((c) => joined.includes(c)).length;
+    expect(rendered).toBeGreaterThan(0);
+    expect(markedCount(drawn)).toBeGreaterThan(0);
+    expect(rendered + markedCount(drawn)).toBe(flood.length);
+
+    // The marker is the last line, so it reads as a footnote to what precedes it.
+    expect(drawn[drawn.length - 1]).toMatch(/\+\d+ more credit/);
+  });
+
+  it('draws nothing at all rather than outside a frame too small for one line', () => {
+    const ctx = makeCtx();
+    // 12px tall: capacity 0. Painting here could only land off-frame.
+    expect(drawAttributionOverlay(makeCanvas(400, 12, ctx), REAL_CREDITS, THUMBNAIL_ATTRIBUTION))
+      .toBe(false);
+    expect(ctx.fillText).not.toHaveBeenCalled();
+    expect(ctx.fillRect).not.toHaveBeenCalled();
+  });
+
+  it('adds no marker when everything fits', () => {
+    const ctx = makeCtx();
+    drawAttributionOverlay(makeCanvas(1200, 630, ctx), REAL_CREDITS, OG_ATTRIBUTION);
+    const drawn = ctx.fillText.mock.calls.map((c: unknown[]) => String(c[0]));
+    expect(drawn.join(' ')).not.toMatch(/more credit/);
+    expectTotal(drawn, REAL_CREDITS);
   });
 
   it('stays quiet for a credit load that fits', () => {

--- a/frontend/src/lib/__tests__/map-image-attribution.test.ts
+++ b/frontend/src/lib/__tests__/map-image-attribution.test.ts
@@ -501,6 +501,89 @@ describe('readRenderedAttribution', () => {
     ]);
   });
 
+  /* fix(#1541 codex P2 round 6): terrain renders with NO style layer of its
+   * own — `ensureRasterDemTerrainSource` (map-sync.ts) creates an attributed
+   * source and lets MapLibre count it through `usedForTerrain` — so defining
+   * "shown" as "referenced by a layer" put the credit for plainly visible 3D
+   * relief in the hidden group, behind credits for invisible content. */
+
+  /** The terrain source id map-sync creates; it appears in `sources` and in
+   *  `getTerrain()`, and in no layer. */
+  const TERRAIN_SRC = 'geolens-terrain-dem';
+
+  function terrainMap(
+    sources: Record<string, string>,
+    layers: { source: string; hidden?: boolean }[],
+    terrain: string | null = TERRAIN_SRC,
+  ) {
+    return {
+      ...mapWithControl(null),
+      getStyle: () => ({
+        sources: Object.fromEntries(
+          Object.entries(sources).map(([id, attribution]) => [id, { attribution }]),
+        ),
+        layers: layers.map(({ source, hidden }, i) => ({
+          id: `layer-${i}`,
+          source,
+          layout: hidden ? { visibility: 'none' } : {},
+        })),
+      }),
+      getTerrain: () => (terrain ? { source: terrain } : null),
+    };
+  }
+
+  it('treats the terrain source as shown though no layer references it', () => {
+    const credits = readRenderedAttribution(
+      terrainMap(
+        // Declared in the order map-sync creates them: layer sources first,
+        // the terrain source after, which is what put it behind the hidden one.
+        { hiddenSrc: '© Hidden Provider', [TERRAIN_SRC]: '© swisstopo swissALTI3D' },
+        [{ source: 'hiddenSrc', hidden: true }],
+      ),
+    );
+    expect(credits).toEqual(['© swisstopo swissALTI3D', '© Hidden Provider']);
+  });
+
+  it('leaves the terrain source hidden when terrain is off', () => {
+    const credits = readRenderedAttribution(
+      terrainMap(
+        { [TERRAIN_SRC]: '© swisstopo swissALTI3D', shownSrc: '© Visible Provider' },
+        [{ source: 'shownSrc' }],
+        null,
+      ),
+    );
+    expect(credits).toEqual(['© Visible Provider', '© swisstopo swissALTI3D']);
+  });
+
+  it('reads a map that has no getTerrain at all', () => {
+    // Every existing caller shape, and the partial mocks the builder suites
+    // pass. An absent method is not a terrain-less map crashing.
+    expect(
+      readRenderedAttribution(
+        layeredMap({ a: '© Shown' }, [{ source: 'a' }]),
+      ),
+    ).toEqual(['© Shown']);
+  });
+
+  it('keeps a terrain credit out of the marker in a bounded output', () => {
+    // The reported shape, asserted at an output: 3D relief is on screen and a
+    // long hidden credit is not, so the marker must elide the hidden one.
+    const hidden = `© Hidden Provider ${'licensing statement '.repeat(300)}`.slice(0, 5000);
+    const map = terrainMap(
+      { hiddenSrc: hidden, [TERRAIN_SRC]: '© swisstopo swissALTI3D' },
+      [{ source: 'hiddenSrc', hidden: true }],
+    );
+    const ctx = makeCtx();
+    drawAttributionOverlay(
+      makeCanvas(400, 250, ctx),
+      readRenderedAttribution(map),
+      THUMBNAIL_ATTRIBUTION,
+    );
+    const drawn = ctx.fillText.mock.calls.map((c: unknown[]) => String(c[0]));
+    expect(drawn.join(' ')).toContain('© swisstopo swissALTI3D');
+    expect(drawn[drawn.length - 1]).toBe('+1 more credit');
+  });
+
   it('does not let a hidden credit crowd a visible one out of a bounded output', () => {
     // The whole point, asserted at an output rather than at the reader: a
     // 5,000-character hidden credit against a 250px thumbnail.

--- a/frontend/src/lib/__tests__/map-image-attribution.test.ts
+++ b/frontend/src/lib/__tests__/map-image-attribution.test.ts
@@ -64,32 +64,15 @@ function mapWithControl(text: string | null) {
 }
 
 describe('readRenderedAttribution', () => {
-  it('tier 1: reads the rendered control and splits on MapLibre\'s separator', () => {
-    expect(
-      readRenderedAttribution(
-        mapWithControl('© OpenFreeMap | © OpenMapTiles | © OpenStreetMap contributors'),
-      ),
-    ).toEqual(['© OpenFreeMap', '© OpenMapTiles', '© OpenStreetMap contributors']);
-  });
+  /* fix(#1541 codex P2): the credit list is never re-derived by splitting a
+   * joined string. ` | ` is legal content inside a 5,000-character credit, so
+   * any delimiter round-trip can cut one credit into two — or, via the dedupe,
+   * delete half of one outright. Structured sources first; the rendered control
+   * only as one opaque entry. */
 
-  it('tier 1: dedupes and drops empties', () => {
-    expect(readRenderedAttribution(mapWithControl('© A | © A |  | © B'))).toEqual([
-      '© A',
-      '© B',
-    ]);
-  });
-
-  it('tier 1 wins over the style even when both are available', () => {
+  it('prefers the structured source list, one entry per source', () => {
     const map = {
-      ...mapWithControl('© Rendered'),
-      getStyle: () => ({ sources: { a: { attribution: '© From style' } } }),
-    };
-    expect(readRenderedAttribution(map)).toEqual(['© Rendered']);
-  });
-
-  it('tier 2: falls back to source attribution when the control is absent', () => {
-    const map = {
-      ...mapWithControl(null),
+      ...mapWithControl('ignored'),
       getStyle: () => ({
         sources: {
           base: { attribution: '© Basemap Co' },
@@ -102,7 +85,69 @@ describe('readRenderedAttribution', () => {
     expect(readRenderedAttribution(map)).toEqual(['© Basemap Co', '© swisstopo']);
   });
 
-  it('tier 2: decodes entities and anchors without parsing live markup', () => {
+  it('reads the LIVE source attribution, which the serialized spec can lack', () => {
+    // Measured on the shipped OpenFreeMap basemap: the spec says null while the
+    // live source carries the credit, because a vector source loaded from a
+    // TileJSON `url` receives its attribution in that response. Reading the
+    // spec alone dropped every basemap credit whenever a dataset declared one.
+    const map = {
+      ...mapWithControl(null),
+      getStyle: () => ({
+        sources: { basemap: { attribution: null }, dem: { attribution: '© swisstopo' } },
+      }),
+      getSource: (id: string) =>
+        id === 'basemap' ? { attribution: '<a href="#">© OpenMapTiles</a>' } : undefined,
+    };
+    expect(readRenderedAttribution(map)).toEqual(['© OpenMapTiles', '© swisstopo']);
+  });
+
+  it('falls back to the serialized spec for a source the map has not instantiated', () => {
+    const map = {
+      ...mapWithControl(null),
+      getStyle: () => ({ sources: { a: { attribution: '© From spec' } } }),
+      getSource: () => undefined,
+    };
+    expect(readRenderedAttribution(map)).toEqual(['© From spec']);
+  });
+
+  it('never splits a credit that contains the separator as content', () => {
+    const credit = '© Acme | © Acme';
+    const map = {
+      ...mapWithControl(null),
+      getStyle: () => ({ sources: { a: { attribution: credit } } }),
+    };
+    // One credit, whole. Splitting produced two identical fragments that the
+    // dedupe then collapsed to one, deleting half a real credit.
+    expect(readRenderedAttribution(map)).toEqual([credit]);
+  });
+
+  it('keeps two distinct credits that share a separator-containing prefix', () => {
+    const map = {
+      ...mapWithControl(null),
+      getStyle: () => ({
+        sources: {
+          a: { attribution: '© Acme | Division One' },
+          b: { attribution: '© Acme | Division Two' },
+        },
+      }),
+    };
+    expect(readRenderedAttribution(map)).toEqual([
+      '© Acme | Division One',
+      '© Acme | Division Two',
+    ]);
+  });
+
+  it('dedupes identical source credits, which is one credit not two', () => {
+    const map = {
+      ...mapWithControl(null),
+      getStyle: () => ({
+        sources: { a: { attribution: '© Same' }, b: { attribution: '© Same' } },
+      }),
+    };
+    expect(readRenderedAttribution(map)).toEqual(['© Same']);
+  });
+
+  it('decodes entities and anchors without parsing live markup', () => {
     const map = {
       ...mapWithControl(null),
       getStyle: () => ({
@@ -118,17 +163,23 @@ describe('readRenderedAttribution', () => {
     ]);
   });
 
-  it('tier 3: returns nothing when neither source is available', () => {
-    expect(readRenderedAttribution(mapWithControl(null))).toEqual([]);
-    expect(readRenderedAttribution({})).toEqual([]);
+  it('falls back to the rendered control as ONE opaque entry, never split', () => {
+    const joined = '© OpenFreeMap | © OpenMapTiles | © OpenStreetMap contributors';
+    expect(readRenderedAttribution(mapWithControl(joined))).toEqual([joined]);
   });
 
-  it('an empty control falls through to the style rather than reporting no credit', () => {
+  it('falls back to the control when no source declares a credit', () => {
     const map = {
-      ...mapWithControl('   '),
-      getStyle: () => ({ sources: { a: { attribution: '© Fallback' } } }),
+      ...mapWithControl('© From the control'),
+      getStyle: () => ({ sources: { a: { attribution: null }, b: {} } }),
     };
-    expect(readRenderedAttribution(map)).toEqual(['© Fallback']);
+    expect(readRenderedAttribution(map)).toEqual(['© From the control']);
+  });
+
+  it('returns nothing when neither source is available', () => {
+    expect(readRenderedAttribution(mapWithControl(null))).toEqual([]);
+    expect(readRenderedAttribution({})).toEqual([]);
+    expect(readRenderedAttribution({ ...mapWithControl('   ') })).toEqual([]);
   });
 });
 
@@ -267,6 +318,66 @@ describe('fitAttributionText', () => {
       fontPx: 12,
     });
     expect(fitted.lines.join('')).toBe('ABC');
+  });
+});
+
+/* fix(#1541 codex P2): mid-STRING wrapping is the one residual limit we allow.
+ * Mid-CHARACTER is truncation in disguise — a surrogate pair split across two
+ * drawn lines renders replacement glyphs where the provider's name should be. */
+describe('grapheme safety in the wrapping path', () => {
+  const EMOJI = '\u{1F30D}'; // U+1F30D EARTH GLOBE EUROPE-AFRICA, non-BMP
+  const FAMILY = '\u{1F468}\u200D\u{1F469}\u200D\u{1F467}'; // ZWJ sequence
+  const ACCENTED = 'e\u0301'; // e + COMBINING ACUTE, two code units, one grapheme
+
+  /** Every drawn line, for a credit forced to break many times. */
+  function linesFor(credit: string, maxWidth: number): string[] {
+    const ctx = makeCtx();
+    return fitAttributionText(ctx as unknown as CanvasRenderingContext2D, [credit], {
+      maxWidth,
+      fontPx: 12,
+    }).lines;
+  }
+
+  it('never emits a lone surrogate when breaking a non-BMP run', () => {
+    const credit = `© ${EMOJI.repeat(200)}`;
+    // Swept across widths on purpose. Each emoji is exactly two code units, so
+    // a single width can land every code-unit break on an even boundary and
+    // pass while the implementation is unsafe — this test did exactly that
+    // before the sweep was added.
+    for (let maxWidth = 25; maxWidth <= 100; maxWidth += 7) {
+      const lines = linesFor(credit, maxWidth);
+      expect(lines.length).toBeGreaterThan(1);
+      for (const line of lines) {
+        // A split pair leaves an unpaired surrogate at a line edge.
+        expect(/[\uD800-\uDBFF](?![\uDC00-\uDFFF])/.test(line), `width ${maxWidth}`).toBe(false);
+        expect(/(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/.test(line), `width ${maxWidth}`).toBe(false);
+      }
+      // Whitespace-insensitive totality: a word break consumes the space it
+      // broke at while a character break inserts none, so where the spaces
+      // land is not the property under test. Losing a CHARACTER is.
+      expect(lines.join('').replace(/\s+/g, '')).toBe(credit.replace(/\s+/g, ''));
+    }
+  });
+
+  it('keeps ZWJ sequences and combining marks intact across a break', () => {
+    for (const cluster of [FAMILY, ACCENTED]) {
+      const credit = cluster.repeat(120);
+      const lines = linesFor(credit, 60);
+      expect(lines.length).toBeGreaterThan(1);
+      // No spaces in these fixtures, so the pieces concatenate exactly.
+      expect(lines.join('')).toBe(credit);
+      // No line starts with a combining mark or a ZWJ, which is what a
+      // mid-cluster break looks like from the next line's side.
+      for (const line of lines) {
+        expect(/^[\u0300-\u036F\u200D]/.test(line)).toBe(false);
+      }
+    }
+  });
+
+  it('loses nothing when a provider name mixes scripts and emoji', () => {
+    const credit = `© Ácme ${EMOJI} 地図データ ${FAMILY} contributors`.repeat(30);
+    const lines = linesFor(credit, 80);
+    expect(lines.join('').replace(/\s+/g, '')).toBe(credit.replace(/\s+/g, ''));
   });
 });
 
@@ -481,6 +592,28 @@ describe('overlayLineCapacity: the documented ceiling', () => {
 
     // The marker is the last line, so it reads as a footnote to what precedes it.
     expect(drawn[drawn.length - 1]).toMatch(/\+\d+ more credit/);
+  });
+
+  it("counts CREDITS not fragments when credits contain the separator", () => {
+    // fix(#1541 codex P2): the marker's N used to be derived from a joined
+    // string re-split on ` | `, so a credit containing the separator inflated
+    // the count and could be cut in half with its remainder counted as another
+    // provider. Each of these is ONE credit that happens to contain ` | `.
+    const ctx = makeCtx();
+    const credits = Array.from(
+      { length: 24 },
+      (_, i) => `© Provider ${i} | Division A | Division B, a licensing statement`,
+    );
+    expect(drawAttributionOverlay(makeCanvas(400, 250, ctx), credits, THUMBNAIL_ATTRIBUTION))
+      .toBe(true);
+    const drawn = ctx.fillText.mock.calls.map((c: unknown[]) => String(c[0]));
+
+    // The true omitted count: credits not present whole in the rendered text.
+    const joined = drawn.join(' ');
+    const renderedWhole = credits.filter((c) => joined.includes(c)).length;
+    expect(renderedWhole).toBeGreaterThan(0);
+    expect(markedCount(drawn)).toBe(credits.length - renderedWhole);
+    expectNothingOutsideFrame(ctx, THUMBNAIL_ATTRIBUTION, 400, 250);
   });
 
   it('draws nothing at all rather than outside a frame too small for one line', () => {

--- a/frontend/src/lib/__tests__/map-image-attribution.test.ts
+++ b/frontend/src/lib/__tests__/map-image-attribution.test.ts
@@ -1,0 +1,349 @@
+/**
+ * feat(#1486): the credit line drawn into every rendered map image.
+ *
+ * The fitter is the only piece with real logic, so it carries most of these
+ * tests. Its stub context measures LENGTH-PROPORTIONALLY (`chars * 0.5 *
+ * fontPx`), unlike the constant-width stub the hook suite uses — a constant
+ * cannot exercise a size ladder or an elide boundary at all.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import {
+  drawAttributionBand,
+  drawAttributionOverlay,
+  fitAttributionText,
+  measureAttributionBand,
+  readRenderedAttribution,
+  OG_ATTRIBUTION,
+  THUMBNAIL_ATTRIBUTION,
+} from '../map-image-attribution';
+import { MAP_COLORS } from '../map-colors';
+
+function fontPxOf(font: string): number {
+  const match = /(\d+(?:\.\d+)?)px/.exec(font);
+  return match ? parseFloat(match[1]) : 12;
+}
+
+/** A 2D context whose text metrics respond to both the string and the font
+ *  size, so a shrink ladder and an entry-boundary elide are observable. */
+function makeCtx() {
+  const ctx = {
+    font: '',
+    fillStyle: '' as string,
+    strokeStyle: '',
+    textBaseline: '',
+    textAlign: '',
+    fillText: vi.fn(),
+    fillRect: vi.fn(),
+    beginPath: vi.fn(),
+    fill: vi.fn(),
+    measureText: vi.fn((text: string) => ({
+      width: text.length * 0.5 * fontPxOf(ctx.font),
+    })),
+  };
+  return ctx;
+}
+
+function makeCanvas(width: number, height: number, ctx: unknown) {
+  return {
+    width,
+    height,
+    getContext: vi.fn(() => ctx),
+  } as unknown as HTMLCanvasElement;
+}
+
+function mapWithControl(text: string | null) {
+  const container = document.createElement('div');
+  if (text !== null) {
+    const inner = document.createElement('div');
+    inner.className = 'maplibregl-ctrl-attrib-inner';
+    inner.textContent = text;
+    container.appendChild(inner);
+  }
+  return { getContainer: () => container };
+}
+
+describe('readRenderedAttribution', () => {
+  it('tier 1: reads the rendered control and splits on MapLibre\'s separator', () => {
+    expect(
+      readRenderedAttribution(
+        mapWithControl('© OpenFreeMap | © OpenMapTiles | © OpenStreetMap contributors'),
+      ),
+    ).toEqual(['© OpenFreeMap', '© OpenMapTiles', '© OpenStreetMap contributors']);
+  });
+
+  it('tier 1: dedupes and drops empties', () => {
+    expect(readRenderedAttribution(mapWithControl('© A | © A |  | © B'))).toEqual([
+      '© A',
+      '© B',
+    ]);
+  });
+
+  it('tier 1 wins over the style even when both are available', () => {
+    const map = {
+      ...mapWithControl('© Rendered'),
+      getStyle: () => ({ sources: { a: { attribution: '© From style' } } }),
+    };
+    expect(readRenderedAttribution(map)).toEqual(['© Rendered']);
+  });
+
+  it('tier 2: falls back to source attribution when the control is absent', () => {
+    const map = {
+      ...mapWithControl(null),
+      getStyle: () => ({
+        sources: {
+          base: { attribution: '© Basemap Co' },
+          dem: { attribution: '© swisstopo' },
+          quiet: { attribution: null },
+          none: null,
+        },
+      }),
+    };
+    expect(readRenderedAttribution(map)).toEqual(['© Basemap Co', '© swisstopo']);
+  });
+
+  it('tier 2: decodes entities and anchors without parsing live markup', () => {
+    const map = {
+      ...mapWithControl(null),
+      getStyle: () => ({
+        sources: {
+          a: { attribution: '<a href="https://osm.org">OpenStreetMap</a> contributors' },
+          b: { attribution: 'Rand &amp; McNally' },
+        },
+      }),
+    };
+    expect(readRenderedAttribution(map)).toEqual([
+      'OpenStreetMap contributors',
+      'Rand & McNally',
+    ]);
+  });
+
+  it('tier 3: returns nothing when neither source is available', () => {
+    expect(readRenderedAttribution(mapWithControl(null))).toEqual([]);
+    expect(readRenderedAttribution({})).toEqual([]);
+  });
+
+  it('an empty control falls through to the style rather than reporting no credit', () => {
+    const map = {
+      ...mapWithControl('   '),
+      getStyle: () => ({ sources: { a: { attribution: '© Fallback' } } }),
+    };
+    expect(readRenderedAttribution(map)).toEqual(['© Fallback']);
+  });
+});
+
+describe('fitAttributionText', () => {
+  const entries = ['© OpenFreeMap', '© OpenMapTiles', '© OpenStreetMap contributors'];
+
+  it('keeps the requested size when everything fits on one line', () => {
+    const ctx = makeCtx();
+    const fitted = fitAttributionText(ctx as unknown as CanvasRenderingContext2D, entries, {
+      maxWidth: 1000,
+      fontPx: 16,
+      minFontPx: 13,
+      maxLines: 1,
+    });
+    expect(fitted.fontPx).toBe(16);
+    expect(fitted.elided).toBe(false);
+    expect(fitted.lines).toEqual([entries.join(' | ')]);
+  });
+
+  it('shrinks down the ladder before it drops anything', () => {
+    const ctx = makeCtx();
+    // 61 chars joined; 61 * 0.5 * 16 = 488 wide at 16px, 397 at 13px.
+    const fitted = fitAttributionText(ctx as unknown as CanvasRenderingContext2D, entries, {
+      maxWidth: 420,
+      fontPx: 16,
+      minFontPx: 13,
+      maxLines: 1,
+    });
+    expect(fitted.elided).toBe(false);
+    expect(fitted.fontPx).toBeLessThan(16);
+    expect(fitted.lines).toEqual([entries.join(' | ')]);
+  });
+
+  it('wraps to a second line rather than dropping a credit when allowed', () => {
+    const ctx = makeCtx();
+    const fitted = fitAttributionText(ctx as unknown as CanvasRenderingContext2D, entries, {
+      maxWidth: 200,
+      fontPx: 12,
+      minFontPx: 10,
+      maxLines: 2,
+    });
+    expect(fitted.elided).toBe(false);
+    expect(fitted.lines.length).toBeGreaterThan(1);
+    // Every credit survives the wrap.
+    const rendered = fitted.lines.join(' | ');
+    for (const entry of entries) expect(rendered).toContain(entry);
+  });
+
+  it('elides at an entry boundary, never mid-name', () => {
+    const ctx = makeCtx();
+    const fitted = fitAttributionText(ctx as unknown as CanvasRenderingContext2D, entries, {
+      maxWidth: 120,
+      fontPx: 10,
+      minFontPx: 9,
+      maxLines: 1,
+    });
+    expect(fitted.elided).toBe(true);
+    expect(fitted.lines).toHaveLength(1);
+    expect(fitted.lines[0]).toMatch(/…$/);
+    // The surviving entries are whole: no truncated provider name.
+    const kept = fitted.lines[0].split(' | ').filter((s) => s !== '…');
+    for (const part of kept) expect(entries).toContain(part);
+  });
+
+  it('character-truncates only when a single entry cannot fit at the floor', () => {
+    const ctx = makeCtx();
+    const long = '© An Extremely Long Single Data Provider Name That Cannot Fit';
+    const fitted = fitAttributionText(ctx as unknown as CanvasRenderingContext2D, [long], {
+      maxWidth: 60,
+      fontPx: 10,
+      minFontPx: 9,
+      maxLines: 1,
+    });
+    expect(fitted.elided).toBe(true);
+    expect(fitted.lines[0]).toMatch(/…$/);
+    expect(fitted.lines[0].length).toBeLessThan(long.length);
+    expect(long.startsWith(fitted.lines[0].replace(/…$/, ''))).toBe(true);
+  });
+
+  it('returns nothing for no entries or no room', () => {
+    const ctx = makeCtx();
+    expect(
+      fitAttributionText(ctx as unknown as CanvasRenderingContext2D, [], {
+        maxWidth: 400,
+        fontPx: 12,
+        minFontPx: 10,
+        maxLines: 1,
+      }).lines,
+    ).toEqual([]);
+    expect(
+      fitAttributionText(ctx as unknown as CanvasRenderingContext2D, ['© A'], {
+        maxWidth: 0,
+        fontPx: 12,
+        minFontPx: 10,
+        maxLines: 1,
+      }).lines,
+    ).toEqual([]);
+  });
+
+  it('terminates on a degenerate context that measures everything as too wide', () => {
+    // Guards the one shape that could hang an export: a shrink loop driven off
+    // measureText rather than a bounded ladder (a font that fails to load
+    // measures like this).
+    const ctx = { ...makeCtx(), measureText: vi.fn(() => ({ width: Infinity })) };
+    const fitted = fitAttributionText(ctx as unknown as CanvasRenderingContext2D, entries, {
+      maxWidth: 100,
+      fontPx: 16,
+      minFontPx: 9,
+      maxLines: 2,
+    });
+    expect(fitted.lines).toEqual(['…']);
+  });
+});
+
+describe('drawAttributionOverlay', () => {
+  it('draws a scrim under dark text in the bottom-right', () => {
+    const ctx = makeCtx();
+    const canvas = makeCanvas(400, 250, ctx);
+    expect(drawAttributionOverlay(canvas, ['© OpenStreetMap'], THUMBNAIL_ATTRIBUTION)).toBe(
+      true,
+    );
+
+    expect(ctx.fillRect).toHaveBeenCalledTimes(1);
+    const [x, y, w, h] = ctx.fillRect.mock.calls[0] as unknown as number[];
+    // Bottom-right, inside the inset.
+    expect(x + w).toBe(400 - THUMBNAIL_ATTRIBUTION.inset);
+    expect(y + h).toBe(250 - THUMBNAIL_ATTRIBUTION.inset);
+    expect(x).toBeGreaterThan(0);
+    expect(y).toBeGreaterThan(0);
+
+    // Scrim first, text second — the reverse would erase the line.
+    expect(ctx.fillRect.mock.invocationCallOrder[0]).toBeLessThan(
+      ctx.fillText.mock.invocationCallOrder[0],
+    );
+    expect(ctx.fillText).toHaveBeenCalledWith('© OpenStreetMap', expect.any(Number), expect.any(Number));
+    expect(ctx.fillStyle).toBe(MAP_COLORS.exportImage.text);
+  });
+
+  it('joins multiple credits with MapLibre\'s separator', () => {
+    const ctx = makeCtx();
+    drawAttributionOverlay(makeCanvas(1200, 630, ctx), ['© A', '© B'], OG_ATTRIBUTION);
+    expect(ctx.fillText).toHaveBeenCalledWith('© A | © B', expect.any(Number), expect.any(Number));
+  });
+
+  it('draws nothing when there is no credit to draw', () => {
+    const ctx = makeCtx();
+    expect(drawAttributionOverlay(makeCanvas(400, 250, ctx), [], THUMBNAIL_ATTRIBUTION)).toBe(
+      false,
+    );
+    expect(ctx.fillText).not.toHaveBeenCalled();
+    expect(ctx.fillRect).not.toHaveBeenCalled();
+  });
+
+  it('draws nothing when the canvas has no 2D context', () => {
+    const canvas = { width: 400, height: 250, getContext: () => null } as unknown as HTMLCanvasElement;
+    expect(drawAttributionOverlay(canvas, ['© A'], THUMBNAIL_ATTRIBUTION)).toBe(false);
+  });
+});
+
+describe('measureAttributionBand / drawAttributionBand', () => {
+  it('reserves gap + lines + gap, scaled by dpr', () => {
+    const ctx = makeCtx();
+    const measured = measureAttributionBand(
+      ctx as unknown as CanvasRenderingContext2D,
+      ['© OpenStreetMap contributors'],
+      { maxWidth: 2000, dpr: 2 },
+    );
+    expect(measured.lines).toEqual(['© OpenStreetMap contributors']);
+    // 12*2 + 1 line * 16*2 + 12*2
+    expect(measured.height).toBe(80);
+    expect(measured.fontPx).toBe(24); // 12 * dpr
+  });
+
+  it('reserves no height at all when there is no credit', () => {
+    const ctx = makeCtx();
+    expect(
+      measureAttributionBand(ctx as unknown as CanvasRenderingContext2D, [], {
+        maxWidth: 2000,
+        dpr: 1,
+      }).height,
+    ).toBe(0);
+  });
+
+  it('grows to two lines rather than dropping a credit', () => {
+    const ctx = makeCtx();
+    const measured = measureAttributionBand(
+      ctx as unknown as CanvasRenderingContext2D,
+      ['© Provider One', '© Provider Two', '© Provider Three', '© Provider Four'],
+      { maxWidth: 300, dpr: 1 },
+    );
+    expect(measured.lines).toHaveLength(2);
+    expect(measured.height).toBe(12 + 2 * 16 + 12);
+    expect(measured.lines.join(' | ')).toContain('© Provider Four');
+  });
+
+  it('draws each line at the muted contrast, stepping by the line height', () => {
+    const ctx = makeCtx();
+    drawAttributionBand(
+      ctx as unknown as CanvasRenderingContext2D,
+      { lines: ['line one', 'line two'], fontPx: 12, height: 56 },
+      { x: 20, y: 100, dpr: 1 },
+    );
+    expect(ctx.fillStyle).toBe(MAP_COLORS.exportImage.mutedText);
+    expect(ctx.fillText.mock.calls).toEqual([
+      ['line one', 20, 112],
+      ['line two', 20, 128],
+    ]);
+  });
+
+  it('draws nothing for an empty measurement', () => {
+    const ctx = makeCtx();
+    drawAttributionBand(
+      ctx as unknown as CanvasRenderingContext2D,
+      { lines: [], fontPx: 12, height: 0 },
+      { x: 20, y: 100, dpr: 1 },
+    );
+    expect(ctx.fillText).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/lib/__tests__/map-image-attribution.test.ts
+++ b/frontend/src/lib/__tests__/map-image-attribution.test.ts
@@ -3,8 +3,8 @@
  *
  * The fitter is the only piece with real logic, so it carries most of these
  * tests. Its stub context measures LENGTH-PROPORTIONALLY (`chars * 0.5 *
- * fontPx`), unlike the constant-width stub the hook suite uses — a constant
- * cannot exercise a size ladder or an elide boundary at all.
+ * fontPx`): a constant-width stub cannot exercise a wrap boundary at all,
+ * which is how #1541's dropped credits went unseen at this level.
  */
 import { describe, it, expect, vi } from 'vitest';
 import {
@@ -24,7 +24,7 @@ function fontPxOf(font: string): number {
 }
 
 /** A 2D context whose text metrics respond to both the string and the font
- *  size, so a shrink ladder and an entry-boundary elide are observable. */
+ *  size, so wrapping and line growth are observable. */
 function makeCtx() {
   const ctx = {
     font: '',
@@ -131,80 +131,113 @@ describe('readRenderedAttribution', () => {
   });
 });
 
+/* fix(#1541 codex P1 x2): every output used to elide — the export band via a
+ * two-line budget that contradicted its own docstring, the two crops via
+ * `maxLines: 1`. The measured live failure was five credits on a 1056px export
+ * losing two, the basemap's included. There is no elision path left, and these
+ * pin that to behaviour rather than to a comment. */
+
+/** The exact credit set that produced the measured live failure. */
+const REAL_CREDITS = [
+  'MapLibre',
+  '© OpenStreetMap contributors, climbing route geometry retrieved via the Overpass API, licensed under ODbL 1.0',
+  '© U.S. Geological Survey Earthquake Hazards Program, ANSS Comprehensive Earthquake Catalog (ComCat), public domain',
+  '© swisstopo swissALTI3D, 2m lidar digital elevation model, Federal Office of Topography, reproduced with authorisation',
+  'OpenFreeMap © OpenMapTiles Data from OpenStreetMap',
+];
+
+/** Every character of every entry survived, and nothing was marked as dropped. */
+function expectTotal(lines: string[], entries: string[]) {
+  const rendered = lines.join(' ');
+  for (const entry of entries) {
+    expect(rendered, `missing credit: ${entry}`).toContain(entry);
+  }
+  expect(rendered).not.toContain('…');
+}
+
 describe('fitAttributionText', () => {
   const entries = ['© OpenFreeMap', '© OpenMapTiles', '© OpenStreetMap contributors'];
 
-  it('keeps the requested size when everything fits on one line', () => {
+  it('keeps everything on one line when it fits', () => {
     const ctx = makeCtx();
     const fitted = fitAttributionText(ctx as unknown as CanvasRenderingContext2D, entries, {
       maxWidth: 1000,
       fontPx: 16,
-      minFontPx: 13,
-      maxLines: 1,
     });
     expect(fitted.fontPx).toBe(16);
-    expect(fitted.elided).toBe(false);
     expect(fitted.lines).toEqual([entries.join(' | ')]);
   });
 
-  it('shrinks down the ladder before it drops anything', () => {
-    const ctx = makeCtx();
-    // 61 chars joined; 61 * 0.5 * 16 = 488 wide at 16px, 397 at 13px.
-    const fitted = fitAttributionText(ctx as unknown as CanvasRenderingContext2D, entries, {
-      maxWidth: 420,
-      fontPx: 16,
-      minFontPx: 13,
-      maxLines: 1,
-    });
-    expect(fitted.elided).toBe(false);
-    expect(fitted.fontPx).toBeLessThan(16);
-    expect(fitted.lines).toEqual([entries.join(' | ')]);
-  });
-
-  it('wraps to a second line rather than dropping a credit when allowed', () => {
+  it('wraps on entry boundaries, so a provider name is never split needlessly', () => {
     const ctx = makeCtx();
     const fitted = fitAttributionText(ctx as unknown as CanvasRenderingContext2D, entries, {
       maxWidth: 200,
       fontPx: 12,
-      minFontPx: 10,
-      maxLines: 2,
     });
-    expect(fitted.elided).toBe(false);
     expect(fitted.lines.length).toBeGreaterThan(1);
-    // Every credit survives the wrap.
-    const rendered = fitted.lines.join(' | ');
-    for (const entry of entries) expect(rendered).toContain(entry);
+    expectTotal(fitted.lines, entries);
+    // Each line is made of whole entries joined by the separator.
+    for (const line of fitted.lines) {
+      for (const part of line.split(' | ')) expect(entries).toContain(part);
+    }
   });
 
-  it('elides at an entry boundary, never mid-name', () => {
+  it('never shrinks below the requested size', () => {
     const ctx = makeCtx();
-    const fitted = fitAttributionText(ctx as unknown as CanvasRenderingContext2D, entries, {
-      maxWidth: 120,
-      fontPx: 10,
-      minFontPx: 9,
-      maxLines: 1,
-    });
-    expect(fitted.elided).toBe(true);
-    expect(fitted.lines).toHaveLength(1);
-    expect(fitted.lines[0]).toMatch(/…$/);
-    // The surviving entries are whole: no truncated provider name.
-    const kept = fitted.lines[0].split(' | ').filter((s) => s !== '…');
-    for (const part of kept) expect(entries).toContain(part);
+    for (const maxWidth of [1000, 300, 120, 40]) {
+      const fitted = fitAttributionText(ctx as unknown as CanvasRenderingContext2D, entries, {
+        maxWidth,
+        fontPx: 12,
+      });
+      expect(fitted.fontPx).toBe(12);
+    }
   });
 
-  it('character-truncates only when a single entry cannot fit at the floor', () => {
+  it('keeps every provider at the real export width, past the old two-line cap', () => {
     const ctx = makeCtx();
-    const long = '© An Extremely Long Single Data Provider Name That Cannot Fit';
-    const fitted = fitAttributionText(ctx as unknown as CanvasRenderingContext2D, [long], {
-      maxWidth: 60,
-      fontPx: 10,
-      minFontPx: 9,
-      maxLines: 1,
+    // 1056px canvas at dpr 1 less 20px padding a side: the measured export.
+    const fitted = fitAttributionText(ctx as unknown as CanvasRenderingContext2D, REAL_CREDITS, {
+      maxWidth: 1016,
+      fontPx: 12,
     });
-    expect(fitted.elided).toBe(true);
-    expect(fitted.lines[0]).toMatch(/…$/);
-    expect(fitted.lines[0].length).toBeLessThan(long.length);
-    expect(long.startsWith(fitted.lines[0].replace(/…$/, ''))).toBe(true);
+    expect(fitted.lines.length).toBeGreaterThan(2);
+    expectTotal(fitted.lines, REAL_CREDITS);
+  });
+
+  it('keeps every provider under an absurd credit count', () => {
+    const ctx = makeCtx();
+    const many = Array.from(
+      { length: 25 },
+      (_, i) => `© Provider Number ${i} With A Reasonably Long Attribution String`,
+    );
+    const fitted = fitAttributionText(ctx as unknown as CanvasRenderingContext2D, many, {
+      maxWidth: 1016,
+      fontPx: 12,
+    });
+    expectTotal(fitted.lines, many);
+  });
+
+  it('wraps a single credit wider than the band mid-string without losing a word', () => {
+    const ctx = makeCtx();
+    const huge = `© ${'Extremely Long Provider Name '.repeat(12)}End`;
+    const fitted = fitAttributionText(ctx as unknown as CanvasRenderingContext2D, [huge], {
+      maxWidth: 300,
+      fontPx: 12,
+    });
+    expect(fitted.lines.length).toBeGreaterThan(1);
+    expect(fitted.lines.join(' ').replace(/\s+/g, ' ').trim()).toBe(
+      huge.replace(/\s+/g, ' ').trim(),
+    );
+  });
+
+  it('breaks an unbreakable word rather than dropping it', () => {
+    const ctx = makeCtx();
+    const word = 'A'.repeat(200);
+    const fitted = fitAttributionText(ctx as unknown as CanvasRenderingContext2D, [word], {
+      maxWidth: 100,
+      fontPx: 12,
+    });
+    expect(fitted.lines.join('')).toBe(word);
   });
 
   it('returns nothing for no entries or no room', () => {
@@ -213,32 +246,26 @@ describe('fitAttributionText', () => {
       fitAttributionText(ctx as unknown as CanvasRenderingContext2D, [], {
         maxWidth: 400,
         fontPx: 12,
-        minFontPx: 10,
-        maxLines: 1,
       }).lines,
     ).toEqual([]);
     expect(
       fitAttributionText(ctx as unknown as CanvasRenderingContext2D, ['© A'], {
         maxWidth: 0,
         fontPx: 12,
-        minFontPx: 10,
-        maxLines: 1,
       }).lines,
     ).toEqual([]);
   });
 
   it('terminates on a degenerate context that measures everything as too wide', () => {
-    // Guards the one shape that could hang an export: a shrink loop driven off
-    // measureText rather than a bounded ladder (a font that fails to load
-    // measures like this).
+    // A font that fails to load is the realistic version of this. It must not
+    // spin: every loop here is bounded by the string length, not by a width
+    // comparison that can never become true.
     const ctx = { ...makeCtx(), measureText: vi.fn(() => ({ width: Infinity })) };
-    const fitted = fitAttributionText(ctx as unknown as CanvasRenderingContext2D, entries, {
+    const fitted = fitAttributionText(ctx as unknown as CanvasRenderingContext2D, ['ABC'], {
       maxWidth: 100,
-      fontPx: 16,
-      minFontPx: 9,
-      maxLines: 2,
+      fontPx: 12,
     });
-    expect(fitted.lines).toEqual(['…']);
+    expect(fitted.lines.join('')).toBe('ABC');
   });
 });
 
@@ -252,7 +279,6 @@ describe('drawAttributionOverlay', () => {
 
     expect(ctx.fillRect).toHaveBeenCalledTimes(1);
     const [x, y, w, h] = ctx.fillRect.mock.calls[0] as unknown as number[];
-    // Bottom-right, inside the inset.
     expect(x + w).toBe(400 - THUMBNAIL_ATTRIBUTION.inset);
     expect(y + h).toBe(250 - THUMBNAIL_ATTRIBUTION.inset);
     expect(x).toBeGreaterThan(0);
@@ -270,6 +296,39 @@ describe('drawAttributionOverlay', () => {
     const ctx = makeCtx();
     drawAttributionOverlay(makeCanvas(1200, 630, ctx), ['© A', '© B'], OG_ATTRIBUTION);
     expect(ctx.fillText).toHaveBeenCalledWith('© A | © B', expect.any(Number), expect.any(Number));
+  });
+
+  // The second codex P1. These crops cannot grow, so they spend map pixels.
+  it('wraps to multiple lines rather than dropping a credit on the thumbnail', () => {
+    const ctx = makeCtx();
+    const canvas = makeCanvas(400, 250, ctx);
+    expect(drawAttributionOverlay(canvas, REAL_CREDITS, THUMBNAIL_ATTRIBUTION)).toBe(true);
+
+    const drawn = ctx.fillText.mock.calls.map((c: unknown[]) => String(c[0]));
+    expect(drawn.length).toBeGreaterThan(1);
+    expectTotal(drawn, REAL_CREDITS);
+
+    // The scrim covers every line and still sits inside the frame.
+    const [x, y, w, h] = ctx.fillRect.mock.calls[0] as unknown as number[];
+    expect(h).toBe(drawn.length * THUMBNAIL_ATTRIBUTION.lineHeight + THUMBNAIL_ATTRIBUTION.paddingY * 2);
+    expect(x).toBeGreaterThanOrEqual(0);
+    expect(y).toBeGreaterThanOrEqual(0);
+    expect(x + w).toBeLessThanOrEqual(400);
+    expect(y + h).toBeLessThanOrEqual(250);
+  });
+
+  it('wraps to multiple lines rather than dropping a credit on the OG card', () => {
+    const ctx = makeCtx();
+    const canvas = makeCanvas(1200, 630, ctx);
+    expect(drawAttributionOverlay(canvas, REAL_CREDITS, OG_ATTRIBUTION)).toBe(true);
+    const drawn = ctx.fillText.mock.calls.map((c: unknown[]) => String(c[0]));
+    expectTotal(drawn, REAL_CREDITS);
+  });
+
+  it('renders at the documented size and never smaller', () => {
+    const ctx = makeCtx();
+    drawAttributionOverlay(makeCanvas(400, 250, ctx), REAL_CREDITS, THUMBNAIL_ATTRIBUTION);
+    expect(ctx.font).toContain(`${THUMBNAIL_ATTRIBUTION.fontPx}px`);
   });
 
   it('draws nothing when there is no credit to draw', () => {
@@ -296,8 +355,7 @@ describe('measureAttributionBand / drawAttributionBand', () => {
       { maxWidth: 2000, dpr: 2 },
     );
     expect(measured.lines).toEqual(['© OpenStreetMap contributors']);
-    // 12*2 + 1 line * 16*2 + 12*2
-    expect(measured.height).toBe(80);
+    expect(measured.height).toBe(80); // 12*2 + 1 * 16*2 + 12*2
     expect(measured.fontPx).toBe(24); // 12 * dpr
   });
 
@@ -311,16 +369,20 @@ describe('measureAttributionBand / drawAttributionBand', () => {
     ).toBe(0);
   });
 
-  it('grows to two lines rather than dropping a credit', () => {
+  it('grows the band height with the line count, dropping nothing', () => {
     const ctx = makeCtx();
+    const credits = Array.from(
+      { length: 12 },
+      (_, i) => `© Data Provider ${i} With A Long Attribution Line`,
+    );
     const measured = measureAttributionBand(
       ctx as unknown as CanvasRenderingContext2D,
-      ['© Provider One', '© Provider Two', '© Provider Three', '© Provider Four'],
+      credits,
       { maxWidth: 300, dpr: 1 },
     );
-    expect(measured.lines).toHaveLength(2);
-    expect(measured.height).toBe(12 + 2 * 16 + 12);
-    expect(measured.lines.join(' | ')).toContain('© Provider Four');
+    expect(measured.lines.length).toBeGreaterThan(2);
+    expect(measured.height).toBe(12 + measured.lines.length * 16 + 12);
+    expectTotal(measured.lines, credits);
   });
 
   it('draws each line at the muted contrast, stepping by the line height', () => {

--- a/frontend/src/lib/__tests__/map-image-attribution.test.ts
+++ b/frontend/src/lib/__tests__/map-image-attribution.test.ts
@@ -403,6 +403,123 @@ describe('readRenderedAttribution', () => {
   it('drops a declaration that has neither text nor an image', () => {
     expect(readRenderedAttribution(sourcesMap('<div>   </div>', '<span></span>'))).toEqual([]);
   });
+
+  /* fix(#1541 codex P1): "no `used` gating — over-crediting is the safe
+   * direction" was true while the band could grow without limit. Once the
+   * outputs gained a capacity limit and a prefix fit, an unused credit stopped
+   * being extra information and became a credit that DISPLACES a required one,
+   * and prefix-fitting makes position decisive. Shown sources sort first. */
+
+  /** A style with layers, so the reader can tell shown sources from hidden. */
+  function layeredMap(
+    sources: Record<string, string>,
+    layers: { source: string; hidden?: boolean }[],
+  ) {
+    return {
+      ...mapWithControl(null),
+      getStyle: () => ({
+        sources: Object.fromEntries(
+          Object.entries(sources).map(([id, attribution]) => [id, { attribution }]),
+        ),
+        layers: layers.map(({ source, hidden }, i) => ({
+          id: `layer-${i}`,
+          source,
+          layout: hidden ? { visibility: 'none' } : {},
+        })),
+      }),
+    };
+  }
+
+  it('puts shown sources ahead of hidden ones, whatever order the style declares', () => {
+    const credits = readRenderedAttribution(
+      layeredMap(
+        { hiddenFirst: '© Hidden Provider', basemap: '© Visible Provider' },
+        [
+          { source: 'hiddenFirst', hidden: true },
+          { source: 'basemap' },
+        ],
+      ),
+    );
+    // The hidden source is declared FIRST and would otherwise lead — which is
+    // what let it consume a bounded budget and reduce the visible provider to
+    // a bare marker.
+    expect(credits).toEqual(['© Visible Provider', '© Hidden Provider']);
+  });
+
+  it('credits a hidden source when there is room, rather than filtering it out', () => {
+    // Ordering, not filtering: a source hidden at capture time can still be
+    // part of what the map is of, so nothing is dropped while it fits.
+    const credits = readRenderedAttribution(
+      layeredMap({ a: '© Shown', b: '© Hidden' }, [{ source: 'a' }, { source: 'b', hidden: true }]),
+    );
+    expect(credits).toEqual(['© Shown', '© Hidden']);
+  });
+
+  it('keeps the style order inside each group', () => {
+    const credits = readRenderedAttribution(
+      layeredMap(
+        { h1: '© Hidden One', s1: '© Shown One', h2: '© Hidden Two', s2: '© Shown Two' },
+        [
+          { source: 'h1', hidden: true },
+          { source: 's1' },
+          { source: 'h2', hidden: true },
+          { source: 's2' },
+        ],
+      ),
+    );
+    expect(credits).toEqual(['© Shown One', '© Shown Two', '© Hidden One', '© Hidden Two']);
+  });
+
+  it('treats a source no layer references as hidden', () => {
+    const credits = readRenderedAttribution(
+      layeredMap({ orphan: '© Orphan', live: '© Live' }, [{ source: 'live' }]),
+    );
+    expect(credits).toEqual(['© Live', '© Orphan']);
+  });
+
+  it('keeps the shown position for a credit that both a shown and a hidden source carry', () => {
+    // Deduped across the groups, not within them, or the hidden copy would win
+    // the leading slot back.
+    const credits = readRenderedAttribution(
+      layeredMap(
+        { hidden: '© Shared', other: '© Other', shown: '© Shared' },
+        [
+          { source: 'hidden', hidden: true },
+          { source: 'other' },
+          { source: 'shown' },
+        ],
+      ),
+    );
+    expect(credits).toEqual(['© Other', '© Shared']);
+  });
+
+  it('leaves a style with no layers in its declared order', () => {
+    // Nothing to sort by, and no reason to invent one.
+    expect(readRenderedAttribution(sourcesMap('© First', '© Second'))).toEqual([
+      '© First',
+      '© Second',
+    ]);
+  });
+
+  it('does not let a hidden credit crowd a visible one out of a bounded output', () => {
+    // The whole point, asserted at an output rather than at the reader: a
+    // 5,000-character hidden credit against a 250px thumbnail.
+    const hidden = `© Hidden Provider ${'licensing statement '.repeat(300)}`.slice(0, 5000);
+    const map = layeredMap({ hiddenSrc: hidden, shownSrc: '© Visible Provider' }, [
+      { source: 'hiddenSrc', hidden: true },
+      { source: 'shownSrc' },
+    ]);
+    const ctx = makeCtx();
+    drawAttributionOverlay(
+      makeCanvas(400, 250, ctx),
+      readRenderedAttribution(map),
+      THUMBNAIL_ATTRIBUTION,
+    );
+    const drawn = ctx.fillText.mock.calls.map((c: unknown[]) => String(c[0]));
+    expect(drawn.join(' ')).toContain('© Visible Provider');
+    // The hidden one is what the marker elides, which is the correct loss.
+    expect(drawn[drawn.length - 1]).toBe('+1 more credit');
+  });
 });
 
 /* fix(#1541 codex P1 x2): every output used to elide — the export band via a
@@ -718,7 +835,7 @@ describe('overlayLineCapacity: the documented ceiling', () => {
     // Line count here is the STUB's, not the browser's — the 0.5em metric only
     // approximates real glyph widths, so this pins the height FORMULA and the
     // totality, not the header table's measured "real load" column.
-    const budget = attributionBandHeightBudget(1056, 600 + 32, 1);
+    const budget = attributionBandHeightBudget(1056, 600 + 32);
     const measured = measureAttributionBand(
       makeCtx() as unknown as CanvasRenderingContext2D,
       REAL_CREDITS,
@@ -874,7 +991,7 @@ describe('overlayLineCapacity: the documented ceiling', () => {
 describe('measureAttributionBand / drawAttributionBand', () => {
   /** The budget a real 1056x600 export at dpr 1 hands the band. Big enough
    *  that these cases never reach it; the ceiling has its own describe below. */
-  const ROOMY = attributionBandHeightBudget(1056, 632, 1);
+  const ROOMY = attributionBandHeightBudget(1056, 632);
 
   it('reserves gap + lines + gap, scaled by dpr', () => {
     const ctx = makeCtx();
@@ -988,9 +1105,9 @@ describe('export canvas ceiling', () => {
 
   it('costs an ordinary desktop export nothing', () => {
     // The numbers the constants' comment quotes, so they cannot drift from it.
-    expect(attributionBandLineCapacity(attributionBandHeightBudget(1056, 632, 1), 1)).toBe(951);
+    expect(attributionBandLineCapacity(attributionBandHeightBudget(1056, 632), 1)).toBe(951);
     // A maximized builder on a 5K display at dpr 2: 4400x2400 map, 32px footer.
-    expect(attributionBandLineCapacity(attributionBandHeightBudget(4400, 2432, 2), 2)).toBe(41);
+    expect(attributionBandLineCapacity(attributionBandHeightBudget(4400, 2432), 2)).toBe(41);
   });
 
   it('costs the same pixels at any dpr, so the cap is a canvas budget not a line count', () => {
@@ -999,26 +1116,34 @@ describe('export canvas ceiling', () => {
     expect(attributionBandLineCapacity(10, 1)).toBe(0);
   });
 
-  it('floors the band at one line when the fixed blocks have spent the ceiling', () => {
-    // A canvas already past the cap on its own is past it with or without a
-    // band, so dropping every credit there would trade a licensing obligation
-    // for nothing. One line, and the marker counts what it could not show.
-    const budget = attributionBandHeightBudget(EXPORT_WIDTH, EXPORT_CANVAS_MAX_DIMENSION, 1);
-    expect(budget).toBe(12 + 16 + 12);
-    expect(attributionBandLineCapacity(budget, 1)).toBe(1);
+  /* fix(#1541 codex P2 round 5): the budget used to be floored at one minimum
+   * band, which overran the very ceiling it sat inside — a floor and a ceiling
+   * that did not know about each other. It never exceeds actual headroom now,
+   * and under one line's worth it declines rather than drawing something
+   * invalid. codex's case is the first assertion. */
 
+  it('never exceeds actual headroom, even to keep one line', () => {
+    // width 2048, dpr 2, 8,140px reserved: 52px of headroom against an 8,192px
+    // ceiling. The old floor answered 80 and produced an 8,220px canvas whose
+    // area is past 16,777,216.
+    const budget = attributionBandHeightBudget(2048, 8140);
+    expect(budget).toBe(52);
+    expect(8140 + budget).toBeLessThanOrEqual(exportCanvasHeightCeiling(2048));
+    expect(2048 * (8140 + budget)).toBeLessThanOrEqual(EXPORT_CANVAS_MAX_AREA);
+
+    // 52px cannot hold a line at dpr 2, so the band declines outright: no
+    // credit, no marker, and critically no pixels added to a canvas at the cap.
+    expect(attributionBandLineCapacity(budget, 2)).toBe(0);
     const measured = measureAttributionBand(
       makeCtx() as unknown as CanvasRenderingContext2D,
       REAL_CREDITS,
-      { maxWidth: EXPORT_MAX_TEXT_WIDTH, dpr: 1, maxHeight: budget },
+      { maxWidth: EXPORT_MAX_TEXT_WIDTH, dpr: 2, maxHeight: budget },
     );
-    expect(measured.lines).toEqual([`+${REAL_CREDITS.length} more credits`]);
-    expect(measured.height).toBe(40);
-    // Scaled by dpr, since the floor is one LINE and a line is dpr-sized.
-    expect(attributionBandHeightBudget(EXPORT_WIDTH, EXPORT_CANVAS_MAX_DIMENSION, 2)).toBe(80);
+    expect(measured).toEqual({ lines: [], fontPx: 24, height: 0 });
   });
 
-  it('draws nothing only when a caller passes no room at all', () => {
+  it('gives the band nothing once the fixed blocks have spent the ceiling', () => {
+    expect(attributionBandHeightBudget(EXPORT_WIDTH, EXPORT_CANVAS_MAX_DIMENSION)).toBe(0);
     const measured = measureAttributionBand(
       makeCtx() as unknown as CanvasRenderingContext2D,
       REAL_CREDITS,
@@ -1027,11 +1152,25 @@ describe('export canvas ceiling', () => {
     expect(measured).toEqual({ lines: [], fontPx: 12, height: 0 });
   });
 
+  it('still marks rather than declines when one line does fit', () => {
+    // The boundary above it: exactly one line of budget renders the marker,
+    // so declining is reserved for genuinely having nowhere to put anything.
+    const budget = 12 + 16 + 12;
+    expect(attributionBandLineCapacity(budget, 1)).toBe(1);
+    const measured = measureAttributionBand(
+      makeCtx() as unknown as CanvasRenderingContext2D,
+      REAL_CREDITS,
+      { maxWidth: EXPORT_MAX_TEXT_WIDTH, dpr: 1, maxHeight: budget },
+    );
+    expect(measured.lines).toEqual([`+${REAL_CREDITS.length} more credits`]);
+    expect(measured.height).toBe(40);
+  });
+
   it('at 200 credits x 5,000 characters: the canvas stays encodable, every credit accounted for', () => {
     const credits = Array.from({ length: 200 }, (_, i) => maxedCredit(i));
     for (const c of credits) expect(c).toHaveLength(5000);
 
-    const budget = attributionBandHeightBudget(EXPORT_WIDTH, RESERVED, 1);
+    const budget = attributionBandHeightBudget(EXPORT_WIDTH, RESERVED);
     const measured = measureAttributionBand(
       makeCtx() as unknown as CanvasRenderingContext2D,
       credits,
@@ -1068,7 +1207,7 @@ describe('export canvas ceiling', () => {
       {
         maxWidth: EXPORT_MAX_TEXT_WIDTH,
         dpr: 1,
-        maxHeight: attributionBandHeightBudget(EXPORT_WIDTH, RESERVED, 1),
+        maxHeight: attributionBandHeightBudget(EXPORT_WIDTH, RESERVED),
       },
     );
     expect(measured.lines.length).toBeGreaterThan(2);

--- a/frontend/src/lib/map-colors.ts
+++ b/frontend/src/lib/map-colors.ts
@@ -94,12 +94,24 @@ export const MAP_COLORS = {
     outline: '#666666',
     invalidColor: '#333333',
   },
-  /** Fixed colors for the exported map-image title, legend, and attribution. */
+  /** Fixed colors for the exported map-image title, legend, attribution and
+   *  branding footer. Deliberately a fixed LIGHT palette: an exported artifact
+   *  has no theme to follow. */
   exportImage: {
     background: '#ffffff',
     text: '#0a0a0a',
     mutedText: '#666666',
-    attribution: '#999999',
+    /** "Powered by GeoLens". fix(#1486): renamed from `attribution`, which it
+     *  never was — it paints branding, and the name became actively misleading
+     *  once real map attribution existed. Real attribution uses `mutedText`,
+     *  because #999999 on white is about 2.8:1 and a licence-required credit
+     *  is not somewhere to reuse a decorative contrast. */
+    branding: '#999999',
+    /** feat(#1486): ground for the credit line drawn over map imagery in the
+     *  thumbnail and OG crops. 0.78 alpha establishes its own ground, so one
+     *  fixed light-scrim/dark-text pair stays legible over both light and dark
+     *  tiles — and over the globe's space backdrop (#1479). */
+    attributionScrim: 'rgba(255,255,255,0.78)',
     /** fix(#1479 Codex P2 round 1): the void a globe leaves around itself is
      *  transparent in the WebGL canvas, so a capture composited over
      *  `background` puts the sphere back on white — the exact problem #1479

--- a/frontend/src/lib/map-image-attribution.ts
+++ b/frontend/src/lib/map-image-attribution.ts
@@ -40,7 +40,6 @@ import { MAP_COLORS } from '@/lib/map-colors';
 
 /** The separator MapLibre's AttributionControl joins entries with. */
 const SEPARATOR = ' | ';
-const ELLIPSIS = '…';
 const FONT_STACK = 'system-ui, -apple-system, "Segoe UI", Roboto, sans-serif';
 
 /** Only the two methods this module needs, so tests can pass a plain object
@@ -125,19 +124,45 @@ export function readRenderedAttribution(map: AttributionMapLike): string[] {
   return [];
 }
 
-/** Descending integer font sizes, `from` down to `to`. Bounded by
- *  construction: the fitter must never drive a shrink loop off `measureText`,
- *  or a font that fails to load hangs the export. */
-function fontLadder(from: number, to: number): number[] {
-  const top = Math.max(1, Math.round(from));
-  const bottom = Math.max(1, Math.min(Math.round(to), top));
-  const sizes: number[] = [];
-  for (let px = top; px >= bottom; px--) sizes.push(px);
-  return sizes;
-}
+/* ── Layout ────────────────────────────────────────────────────────────────
+ *
+ * NO OUTPUT EVER DROPS A CREDIT, and none shrinks below its documented size.
+ *
+ * fix(#1541 codex P1 x2): both halves of this module used to elide. The export
+ * band passed a two-line budget while its docstring promised the opposite, and
+ * the two crops passed `maxLines: 1`. Measured on a real export: five credits
+ * on a 1056px canvas lost two of them, the basemap's included, replaced by "…".
+ * An ellipsis credits nobody, and a truncated line is a worse artifact than a
+ * missing one because it reads as a complete statement of provenance.
+ *
+ * The fix is that the elision path no longer exists, rather than being gated
+ * behind a flag some future caller can re-enable. Text wraps to as many lines
+ * as it needs; the export canvas grows, and the two fixed-size crops spend map
+ * pixels instead of provider names. The image is fixed, the band inside it is
+ * not.
+ *
+ * Legibility floor, with numbers. Every output renders at ONE documented size
+ * and never below it:
+ *
+ *   PNG export   12px on white         (no scrim needed, not over imagery)
+ *   OG card      16px over a scrim     (1200x630 JPEG, quality 0.85)
+ *   Thumbnail    10px over a scrim     (400x250 JPEG, quality 0.7)
+ *
+ * There is deliberately no shrink ladder. Shrinking traded legibility for area,
+ * and now that spending area is allowed, the trade is the wrong way round: 10px
+ * over a scrim is legible at 1:1, 9px under JPEG chroma subsampling is where
+ * small text starts to mush. The gallery displays the thumbnail at 176x112, but
+ * that is a display-size decision and not an argument about the file.
+ *
+ * The one residual limit: a single credit longer than a full line wraps
+ * MID-STRING, on word boundaries, and on characters for a word that still does
+ * not fit. That splits a provider's name across lines, which is legible and
+ * complete. It never truncates one.
+ */
 
-/** Greedy wrap on entry boundaries. Returns null when any single entry is
- *  wider than `maxWidth` — the caller decides whether to shrink or elide. */
+/** Greedy wrap on entry boundaries, so a provider's name stays on one line.
+ *  Returns null when a single entry is wider than `maxWidth`, which is the one
+ *  case entry-boundary wrapping cannot resolve on its own. */
 function wrapEntries(
   ctx: CanvasRenderingContext2D,
   entries: string[],
@@ -163,49 +188,74 @@ function wrapEntries(
   return lines;
 }
 
-/** Character-level truncation, reserved for a single entry too long for the
- *  smallest size. Binary search, so the number of `measureText` calls is
- *  logarithmic in the string length and always terminates. */
-function truncateToWidth(
+/** Break a word wider than `maxWidth` into pieces that are not. Loses nothing:
+ *  the pieces continue on the following lines. Binary search per piece, and
+ *  each piece takes at least one character, so it always terminates. */
+function breakLongWord(
+  ctx: CanvasRenderingContext2D,
+  word: string,
+  maxWidth: number,
+): string[] {
+  const pieces: string[] = [];
+  let rest = word;
+  while (rest && ctx.measureText(rest).width > maxWidth) {
+    let lo = 1;
+    let hi = rest.length;
+    while (lo < hi) {
+      const mid = Math.ceil((lo + hi) / 2);
+      if (ctx.measureText(rest.slice(0, mid)).width <= maxWidth) lo = mid;
+      else hi = mid - 1;
+    }
+    pieces.push(rest.slice(0, lo));
+    rest = rest.slice(lo);
+  }
+  if (rest) pieces.push(rest);
+  return pieces;
+}
+
+/** Greedy word wrap that never drops a character. The fallback for a single
+ *  credit too long to fit a line whole. */
+function wrapWords(
   ctx: CanvasRenderingContext2D,
   text: string,
   maxWidth: number,
-): string {
-  if (ctx.measureText(text).width <= maxWidth) return text;
-  let lo = 0;
-  let hi = text.length;
-  while (lo < hi) {
-    const mid = Math.ceil((lo + hi) / 2);
-    if (ctx.measureText(text.slice(0, mid) + ELLIPSIS).width <= maxWidth) {
-      lo = mid;
+): string[] {
+  const lines: string[] = [];
+  let current = '';
+  for (const word of text.split(' ').filter(Boolean)) {
+    const candidate = current ? `${current} ${word}` : word;
+    if (!current || ctx.measureText(candidate).width <= maxWidth) {
+      current = candidate;
     } else {
-      hi = mid - 1;
+      lines.push(current);
+      current = word;
+    }
+    if (ctx.measureText(current).width > maxWidth) {
+      const pieces = breakLongWord(ctx, current, maxWidth);
+      lines.push(...pieces.slice(0, -1));
+      current = pieces[pieces.length - 1] ?? '';
     }
   }
-  return lo > 0 ? text.slice(0, lo) + ELLIPSIS : ELLIPSIS;
+  if (current) lines.push(current);
+  return lines;
 }
 
 export interface FitAttributionOptions {
   maxWidth: number;
   fontPx: number;
-  minFontPx: number;
-  maxLines: number;
 }
 
 export interface FittedAttribution {
   lines: string[];
   fontPx: number;
-  elided: boolean;
 }
 
 /**
- * Fit `entries` into at most `maxLines` lines of at most `maxWidth`.
+ * Lay `entries` out at `fontPx`, wrapping to as many lines as they need.
  *
- * Overflow is resolved at ENTRY boundaries, never mid-name: "© OpenFreeMap |
- * …" credits everything it names correctly, while "© OpenFreeMap, ©
- * OpenMapTil…" mangles a provider's name, which is worse than showing fewer.
- *
- * Leaves `ctx.font` set to the size it chose.
+ * Total by construction: the returned lines always contain every character of
+ * every entry. There is no code path that drops one, which is the property the
+ * whole module exists to hold. Leaves `ctx.font` set.
  */
 export function fitAttributionText(
   ctx: CanvasRenderingContext2D,
@@ -213,34 +263,15 @@ export function fitAttributionText(
   opts: FitAttributionOptions,
 ): FittedAttribution {
   const clean = dedupe(entries);
-  if (clean.length === 0 || opts.maxWidth <= 0) {
-    return { lines: [], fontPx: opts.fontPx, elided: false };
+  if (clean.length === 0 || !(opts.maxWidth > 0)) {
+    return { lines: [], fontPx: opts.fontPx };
   }
-  const maxLines = Math.max(1, opts.maxLines);
-
-  for (const fontPx of fontLadder(opts.fontPx, opts.minFontPx)) {
-    ctx.font = attributionFont(fontPx);
-    const lines = wrapEntries(ctx, clean, opts.maxWidth);
-    if (lines && lines.length <= maxLines) {
-      return { lines, fontPx, elided: false };
-    }
-  }
-
-  // Nothing fits whole. Drop whole entries from the end at the smallest size,
-  // marking the loss with a trailing ellipsis entry.
-  const fontPx = Math.max(1, Math.min(Math.round(opts.minFontPx), Math.round(opts.fontPx)));
-  ctx.font = attributionFont(fontPx);
-  for (let keep = clean.length - 1; keep >= 1; keep--) {
-    const lines = wrapEntries(ctx, [...clean.slice(0, keep), ELLIPSIS], opts.maxWidth);
-    if (lines && lines.length <= maxLines) {
-      return { lines, fontPx, elided: true };
-    }
-  }
-
+  ctx.font = attributionFont(opts.fontPx);
+  const byEntry = wrapEntries(ctx, clean, opts.maxWidth);
+  if (byEntry) return { lines: byEntry, fontPx: opts.fontPx };
   return {
-    lines: [truncateToWidth(ctx, clean[0], opts.maxWidth)],
-    fontPx,
-    elided: true,
+    lines: wrapWords(ctx, clean.join(SEPARATOR), opts.maxWidth),
+    fontPx: opts.fontPx,
   };
 }
 
@@ -248,7 +279,8 @@ export function fitAttributionText(
 
 export interface AttributionOverlaySpec {
   fontPx: number;
-  minFontPx: number;
+  /** Baseline-to-baseline step for a wrapped credit. */
+  lineHeight: number;
   /** Distance from the canvas edge to the scrim. */
   inset: number;
   paddingX: number;
@@ -256,15 +288,12 @@ export interface AttributionOverlaySpec {
   radius: number;
 }
 
-/** 400x250. 10px over a scrim reads fine at 1:1; the gallery renders it into
- *  176x112 with object-cover, which is a display-size decision and not an
- *  argument about what the file should contain. It has to carry the credit
- *  because `get_share_card_image_url` falls back to the thumbnail as the
- *  og:image for every map captured before SHARE-08 — that surface has no
- *  adjacent text at all. */
+/** 400x250. It has to carry the credit because `get_share_card_image_url`
+ *  falls back to the thumbnail as the og:image for every map captured before
+ *  SHARE-08 — that surface has no adjacent text at all. */
 export const THUMBNAIL_ATTRIBUTION: AttributionOverlaySpec = {
   fontPx: 10,
-  minFontPx: 9,
+  lineHeight: 13,
   inset: 6,
   paddingX: 5,
   paddingY: 3,
@@ -275,7 +304,7 @@ export const THUMBNAIL_ATTRIBUTION: AttributionOverlaySpec = {
  *  adding a band would change the 1.91:1 ratio social platforms crop against. */
 export const OG_ATTRIBUTION: AttributionOverlaySpec = {
   fontPx: 16,
-  minFontPx: 13,
+  lineHeight: 20,
   inset: 12,
   paddingX: 8,
   paddingY: 5,
@@ -311,14 +340,15 @@ function fillScrim(
 }
 
 /**
- * Draw the credit into the bottom-right of an already-composited crop.
+ * Draw the credit into the bottom-right of an already-composited crop, over as
+ * many lines as it takes.
  *
- * A light scrim with dark text, not a glyph halo: stroking at 9-10px roughly
- * doubles apparent weight, and the thumbnail is a JPEG — halo plus chroma
- * subsampling is exactly where small text turns to mush. One fixed pair works
- * over both light and dark tiles because the scrim establishes its own ground,
- * which also covers the globe case (#1479), where the bottom-right may be
- * space rather than tiles.
+ * A light scrim with dark text, not a glyph halo: stroking at 10px roughly
+ * doubles apparent weight, and these are JPEGs — halo plus chroma subsampling
+ * is exactly where small text turns to mush. One fixed pair works over both
+ * light and dark tiles because the scrim establishes its own ground, which also
+ * covers the globe case (#1479), where the bottom-right may be space rather
+ * than tiles.
  *
  * Returns whether anything was drawn.
  */
@@ -332,19 +362,16 @@ export function drawAttributionOverlay(
   if (!ctx) return false;
 
   const maxWidth = canvas.width - spec.inset * 2 - spec.paddingX * 2;
-  const fitted = fitAttributionText(ctx, entries, {
-    maxWidth,
-    fontPx: spec.fontPx,
-    minFontPx: spec.minFontPx,
-    maxLines: 1,
-  });
-  const line = fitted.lines[0];
-  if (!line) return false;
+  const fitted = fitAttributionText(ctx, entries, { maxWidth, fontPx: spec.fontPx });
+  if (fitted.lines.length === 0) return false;
 
   ctx.font = attributionFont(fitted.fontPx);
-  const textWidth = ctx.measureText(line).width;
+  const textWidth = fitted.lines.reduce(
+    (widest, line) => Math.max(widest, ctx.measureText(line).width),
+    0,
+  );
   const boxW = textWidth + spec.paddingX * 2;
-  const boxH = fitted.fontPx + spec.paddingY * 2;
+  const boxH = fitted.lines.length * spec.lineHeight + spec.paddingY * 2;
   const boxX = Math.max(0, canvas.width - spec.inset - boxW);
   const boxY = Math.max(0, canvas.height - spec.inset - boxH);
 
@@ -354,7 +381,9 @@ export function drawAttributionOverlay(
   ctx.fillStyle = MAP_COLORS.exportImage.text;
   ctx.textBaseline = 'top';
   ctx.textAlign = 'left';
-  ctx.fillText(line, boxX + spec.paddingX, boxY + spec.paddingY);
+  fitted.lines.forEach((line, i) => {
+    ctx.fillText(line, boxX + spec.paddingX, boxY + spec.paddingY + i * spec.lineHeight);
+  });
   return true;
 }
 
@@ -363,8 +392,6 @@ export function drawAttributionOverlay(
 /** Unscaled band metrics; every one is multiplied by `dpr` at use, because
  *  `handleExportPNG` works entirely in srcCanvas pixel space. */
 const BAND_FONT_PX = 12;
-const BAND_MIN_FONT_PX = 10;
-const BAND_MAX_LINES = 2;
 const BAND_LINE_HEIGHT = 16;
 const BAND_GAP = 12;
 
@@ -384,11 +411,11 @@ export interface MeasuredAttributionBand {
  * enterprise case (`showBranding === false`) would need a special case. A
  * separate band makes that path fall out for free — the attribution band
  * renders and the branding band does not. It also sits on white rather than on
- * imagery, so it needs no scrim, which matters most for the path most likely
- * to be printed or pasted into a report.
+ * imagery, so it needs no scrim, which matters most for the path most likely to
+ * be printed or pasted into a report.
  *
- * Wraps to two lines rather than eliding: the full-resolution export has the
- * room, and it is the one output that should never drop a credit.
+ * The height follows the line count, so the canvas grows to fit the credits
+ * rather than the credits being cut to fit the canvas.
  */
 export function measureAttributionBand(
   ctx: CanvasRenderingContext2D,
@@ -402,8 +429,6 @@ export function measureAttributionBand(
   const fitted = fitAttributionText(ctx, entries, {
     maxWidth: opts.maxWidth,
     fontPx: BAND_FONT_PX * dpr,
-    minFontPx: BAND_MIN_FONT_PX * dpr,
-    maxLines: BAND_MAX_LINES,
   });
   if (fitted.lines.length === 0) return fallback;
 

--- a/frontend/src/lib/map-image-attribution.ts
+++ b/frontend/src/lib/map-image-attribution.ts
@@ -58,6 +58,9 @@ export interface AttributionMapLike {
   /** Live source objects. Their `attribution` is the RESOLVED value; the
    *  serialized style's is not. See `readRenderedAttribution`. */
   getSource?: (id: string) => { attribution?: string | null } | null | undefined;
+  /** The 3D terrain in effect, whose source renders with no style layer of its
+   *  own. Public MapLibre API; see `shownSourceIds`. */
+  getTerrain?: () => { source?: unknown } | null | undefined;
 }
 
 function attributionFont(fontPx: number): string {
@@ -305,11 +308,12 @@ function dedupe(entries: string[]): string[] {
  * there is room — the over-crediting property is intact — and what the marker
  * elides first is now the hidden sources, which is the correct thing to lose.
  *
- * `shownSourceIds` is a deliberately coarse approximation of `used`: a source
- * is shown if any style layer references it and that layer is not
- * `visibility: none`. It ignores zoom ranges, so it over-reports. That costs
- * nothing, because the answer only ORDERS the list — a source it gets wrong is
- * mis-sorted, never dropped.
+ * `shownSourceIds` is a deliberately coarse approximation of `used`, from
+ * public signals: the terrain source plus every source referenced by a layer
+ * that is not `visibility: none`. It ignores zoom ranges, so it over-reports.
+ * That costs nothing, because the answer only ORDERS the list — a source it
+ * gets wrong is mis-sorted, never dropped. See its own comment for why the
+ * internal `used`/`usedForTerrain` flags are not read.
  *
  * One cost of preferring (1), accepted:
  *
@@ -331,11 +335,41 @@ interface AttributionStyle {
   layers?: ({ source?: unknown; layout?: { visibility?: string } | null } | null)[];
 }
 
-/** Source ids a visible style layer references — a coarse stand-in for
- *  MapLibre's live `used` flag, sound enough to ORDER by. See the docstring:
- *  it over-reports, and over-reporting only mis-sorts. */
-function shownSourceIds(style: AttributionStyle | null | undefined): Set<string> {
+/**
+ * Source ids that are rendering, from PUBLIC MapLibre signals: the terrain
+ * source, plus every source a style layer references that is not
+ * `visibility: none`.
+ *
+ * fix(#1541 codex P2 round 6): layer references alone missed the one kind of
+ * source that renders without a layer. `ensureRasterDemTerrainSource`
+ * (map-sync.ts) creates an attributed source with no layer and lets MapLibre
+ * count it through `usedForTerrain`, so a 3D-terrain credit — for content
+ * plainly visible in the image — sat in the hidden group and could lose its
+ * slot to a credit for something invisible.
+ *
+ * Which signal, and why this one. MapLibre's own `used`/`usedForTerrain` is the
+ * thing itself rather than a proxy, and it is NOT reachable as public API: the
+ * flags live on the internal per-source cache, reached through `map.style`, and
+ * the collection holding them is `Style.tileManagers` in maplibre-gl 5.24 where
+ * it was `sourceCaches` before — an internal name that has already been renamed
+ * once under us. Set against that, reading it buys nothing here. The answer
+ * only ORDERS, so a signal can help only by marking a source shown, and every
+ * source `used` marks is one a visible layer references, while every source
+ * `usedForTerrain` marks is the one `getTerrain()` names. The internal flags
+ * would differ only by DEMOTING a source whose layers are all out of the
+ * current zoom range — the one direction that can cost a real credit its
+ * place, in exchange for a dependency on a name that moves between versions.
+ *
+ * So this over-reports (it ignores zoom ranges) and that is the safe way to be
+ * wrong: a source it misjudges is mis-sorted, never dropped.
+ */
+function shownSourceIds(
+  map: AttributionMapLike,
+  style: AttributionStyle | null | undefined,
+): Set<string> {
   const shown = new Set<string>();
+  const terrainSource = map.getTerrain?.()?.source;
+  if (typeof terrainSource === 'string') shown.add(terrainSource);
   for (const layer of style?.layers ?? []) {
     if (!layer || layer.layout?.visibility === 'none') continue;
     if (typeof layer.source === 'string') shown.add(layer.source);
@@ -349,7 +383,7 @@ export function readRenderedAttribution(map: AttributionMapLike): string[] {
   if (sources) {
     // Partitioned rather than sorted, so the style's own order survives inside
     // each group and the result is stable without depending on sort stability.
-    const shown = shownSourceIds(style);
+    const shown = shownSourceIds(map, style);
     const fromShown: string[] = [];
     const fromHidden: string[] = [];
     for (const id of Object.keys(sources)) {

--- a/frontend/src/lib/map-image-attribution.ts
+++ b/frontend/src/lib/map-image-attribution.ts
@@ -220,30 +220,34 @@ export function readRenderedAttribution(map: AttributionMapLike): string[] {
  * the only estimate, since real glyph widths are font-dependent.
  *
  *               line    usable    chars/   real 5-credit    ceiling
- *               height  width     line     load             (band fills frame)
+ *               height  width     line     load             (band runs out)
  *   Thumbnail   13px    378px     ~75      6 lines, 33.6%   18 lines, ~1350 chars
  *   OG card     20px    1160px    ~145     4 lines, 14.3%   30 lines, ~4350 chars
- *   PNG export  16px    1016px*   ~169     4 lines, 88px    none — canvas grows
+ *   PNG export  16px    1016px*   ~169     4 lines, 88px    983 lines, ~166k chars
  *
  *   * the measured 1056px-wide export at dpr 1, less 20px of pad a side.
  *
- * The export has no ceiling at all: its canvas is sized AFTER the band is
- * measured, so the band's height is an input to the image rather than a budget
- * inside it. Only the two crops have one, and it is where the scrim reaches the
- * top edge — the band has by then eaten every map pixel there is.
+ * The two crops run out where the scrim reaches the top edge — the band has by
+ * then eaten every map pixel there is. The export runs out somewhere else: its
+ * canvas is sized AFTER the band is measured, so the band is not competing with
+ * the map for a fixed frame, but it is still spending height a browser has to
+ * allocate and encode. Its ceiling is the largest canvas a browser will hand
+ * back a blob for; see EXPORT_CANVAS_MAX_DIMENSION.
  *
- * That ceiling is ~3.3x the measured real-world credit load for the thumbnail
- * (411 characters across five providers) and ~10x for the OG card. But the
- * SUPPORTED input is far larger: `attribution` is `max_length=5000` on the
- * dataset schema and `NonEmptyString5000` on the manifest, and 5,000 characters
- * is roughly 77 lines in a 250px-tall thumbnail. No font size anyone would call
- * legible renders that, so at the contract's maximum something must give.
+ * Every ceiling above is far clear of the measured real-world credit load —
+ * ~3.3x for the thumbnail (411 characters across five providers), ~10x for the
+ * OG card, ~400x for the export. But the SUPPORTED input is far larger:
+ * `attribution` is `max_length=5000` on the dataset schema and
+ * `NonEmptyString5000` on the manifest, a map may carry 200 layers, and 5,000
+ * characters alone is roughly 77 lines in a 250px-tall thumbnail. No font size
+ * anyone would call legible renders that, so at the contract's maximum
+ * something must give.
  *
- * What gives is neither the frame nor silence. Past the ceiling the overlay
+ * What gives is neither the image nor silence. Past its ceiling each output
  * renders the credits that fit and appends a visible, counted marker naming how
  * many did not (`export.moreCredits`), with the marker itself charged against
  * the line budget. The standard is that no output may SILENTLY drop a credit; a
- * marker inside the frame is not silent, and it stops the visible list reading
+ * marker inside the image is not silent, and it stops the visible list reading
  * as a complete statement of provenance. Nothing is ever drawn outside the
  * canvas — an earlier revision kept calling `fillText` below the frame, which
  * painted credits into nowhere.
@@ -600,6 +604,81 @@ const BAND_FONT_PX = 12;
 const BAND_LINE_HEIGHT = 16;
 const BAND_GAP = 12;
 
+/*
+ * The export canvas's own ceiling, and why it has one.
+ *
+ * fix(#1541 codex P2 round 2): the band's measured height is assigned straight
+ * to the export canvas, and #1541 review had ruled that growth UNLIMITED, on
+ * the reasoning that the export canvas has no height constraint. Browsers do.
+ * Every engine caps a canvas both per side and by total area, and past either
+ * one the canvas is unusable with nothing raised to say so: `toBlob` hands back
+ * null, the export toasts a failure, and no image is produced at all. At the
+ * contract's maximum — 200 layers, each dataset credit up to 5,000 characters —
+ * the band alone asked for tens of thousands of pixels of height, so the
+ * unlimited ruling turned a partial-credit bug into a total-export-failure bug.
+ * A bounded band with a counted marker loses some provider names; an
+ * unencodable canvas loses every one of them along with the map.
+ *
+ * The figures below are the smallest limits for a DESKTOP engine in
+ * canvas-size's measured table (jhildenbiddle/canvas-size, src/test-sizes.js),
+ * which is the only published per-engine measurement of these limits:
+ *
+ *   per side  Chrome 83 65,535 · Chrome 70 and Firefox 63 32,767 · Edge 17 and
+ *             IE 11 16,384. We take 16,384: half the floor of any engine this
+ *             app supports, and the only browsers that ever enforced it are
+ *             retired, so the margin is free.
+ *   area      Chrome 70 / Edge 17 / Safari 7-12 (Mac) 16,384² = 268,435,456 ·
+ *             Firefox 63 11,180² = 124,992,400. We take Firefox's, the
+ *             smallest desktop area measured.
+ *
+ * Safari on iOS is smaller again (4,096² = 16,777,216) and is deliberately NOT
+ * the figure used. A retina desktop map canvas alone already exceeds it, so
+ * adopting it would delete credits from exports that work today without making
+ * any iOS export work. What is bounded here is the band's CONTRIBUTION: it can
+ * never be the term that makes the canvas unencodable. A map canvas already
+ * past an engine's limit on its own is a different constraint, and not one that
+ * credit growth caused or can fix.
+ */
+export const EXPORT_CANVAS_MAX_DIMENSION = 16_384;
+export const EXPORT_CANVAS_MAX_AREA = 124_992_400;
+
+/** The tallest export canvas a browser will still encode at `canvasWidth`,
+ *  in device pixels. Area-limited for a very wide canvas, side-limited for the
+ *  ordinary ones (anything narrower than ~7,600px). */
+export function exportCanvasHeightCeiling(canvasWidth: number): number {
+  if (!(canvasWidth > 0)) return 0;
+  return Math.min(
+    EXPORT_CANVAS_MAX_DIMENSION,
+    Math.floor(EXPORT_CANVAS_MAX_AREA / canvasWidth),
+  );
+}
+
+/**
+ * How much of that ceiling is left for the band once the fixed blocks (title,
+ * map, legend, footer) have taken theirs. The band is the only elastic term in
+ * the export's height, so it absorbs the whole clamp.
+ *
+ * Zero when the rest of the image has already spent the ceiling. That is not a
+ * silent credit drop: such a canvas cannot be encoded whatever the band does,
+ * so the export fails visibly and the user is told, which is the same outcome
+ * they would get from a band-free export at that size.
+ */
+export function attributionBandHeightBudget(
+  canvasWidth: number,
+  reservedHeight: number,
+): number {
+  return Math.max(0, exportCanvasHeightCeiling(canvasWidth) - Math.ceil(reservedHeight));
+}
+
+/** How many credit lines fit a band budget of `maxHeight` device pixels, the
+ *  band's counterpart to `overlayLineCapacity`. Both gaps are charged first:
+ *  a band is not a band without its surrounding whitespace. */
+export function attributionBandLineCapacity(maxHeight: number, dpr: number): number {
+  const scale = dpr || 1;
+  const usable = maxHeight - BAND_GAP * scale * 2;
+  return Math.max(0, Math.floor(usable / (BAND_LINE_HEIGHT * scale)));
+}
+
 export interface MeasuredAttributionBand {
   lines: string[];
   /** Already dpr-scaled: the caller draws with it directly. */
@@ -620,28 +699,48 @@ export interface MeasuredAttributionBand {
  * be printed or pasted into a report.
  *
  * The height follows the line count, so the canvas grows to fit the credits
- * rather than the credits being cut to fit the canvas.
+ * rather than the credits being cut to fit the canvas — up to `maxHeight`,
+ * which is what the browser will still encode. Pass it from
+ * `attributionBandHeightBudget`; it is required rather than optional so no
+ * future caller can reach the unbounded behaviour by omission.
  */
 export function measureAttributionBand(
   ctx: CanvasRenderingContext2D,
   entries: string[],
-  opts: { maxWidth: number; dpr: number },
+  opts: { maxWidth: number; dpr: number; maxHeight: number },
 ): MeasuredAttributionBand {
   const dpr = opts.dpr || 1;
   const fallback = { lines: [], fontPx: BAND_FONT_PX * dpr, height: 0 };
   if (entries.length === 0 || opts.maxWidth <= 0) return fallback;
 
-  const fitted = fitAttributionText(ctx, entries, {
+  // Deduped here as well as inside the fitter, because the overflow marker
+  // counts CREDITS and must not count the same one twice.
+  const credits = dedupe(entries);
+  const fitted = fitAttributionText(ctx, credits, {
     maxWidth: opts.maxWidth,
     fontPx: BAND_FONT_PX * dpr,
   });
   if (fitted.lines.length === 0) return fallback;
 
+  // Past the budget, the same counted marker the two crops use. Below it —
+  // every ordinary export, by three orders of magnitude — nothing changes and
+  // the band still grows a line at a time.
+  let lines = fitted.lines;
+  const capacity = attributionBandLineCapacity(opts.maxHeight, dpr);
+  if (lines.length > capacity) {
+    // No room for even a marker: a band here could only make an already
+    // unencodable canvas taller. See `attributionBandHeightBudget`.
+    if (capacity < 1) return fallback;
+    const kept = fitEntryPrefix(ctx, credits, opts.maxWidth, capacity - 1);
+    const omitted = credits.length - kept.count;
+    lines = [...kept.lines, i18n.t('builder:export.moreCredits', { count: omitted })];
+  }
+
   return {
-    lines: fitted.lines,
+    lines,
     fontPx: fitted.fontPx,
     height: Math.round(
-      BAND_GAP * dpr + fitted.lines.length * BAND_LINE_HEIGHT * dpr + BAND_GAP * dpr,
+      BAND_GAP * dpr + lines.length * BAND_LINE_HEIGHT * dpr + BAND_GAP * dpr,
     ),
   };
 }

--- a/frontend/src/lib/map-image-attribution.ts
+++ b/frontend/src/lib/map-image-attribution.ts
@@ -1,0 +1,442 @@
+/**
+ * feat(#1486): attribution for the images the builder renders.
+ *
+ * Every image this product produces — the PNG export, the 400x250 thumbnail,
+ * the 1200x630 OG card — is distributed outside the application while showing
+ * basemap tiles whose licence requires visible credit, and (since #1477)
+ * dataset tiles whose source terms may require it too. None of them carried a
+ * credit line before this module existed.
+ *
+ * The trap this module exists to avoid: all three capture paths composite from
+ * `map.getCanvas()`, a flat WebGL fill. MapLibre's own attribution control is a
+ * DOM overlay, so it is invisible to every one of them by construction. A
+ * credit only reaches an exported image if it is DRAWN INTO the canvas, which
+ * is what the two draw helpers here do.
+ *
+ * Where the text comes from: MapLibre's rendered control, read as text.
+ *
+ * The obvious alternative — composing `BasemapEntry.attribution` with
+ * `collectLayerAttributions` — is wrong for the builder in three ways:
+ *
+ *  1. `toMaplibreStyle` (lib/basemap-utils.ts) only threads `attribution` onto
+ *     the source for XYZ tile URLs. A `/styles/` or `.json` basemap URL is
+ *     returned unchanged and MapLibre reads the remote style's own per-source
+ *     attribution, so the stored field is never what the screen shows. Most
+ *     shipped presets are style URLs. Composing from the field would put a
+ *     string in the PNG that differs from the one on screen.
+ *  2. `collectLayerAttributions` returns HTML-ESCAPED strings (they are bound
+ *     for `innerHTML`; see lib/attribution-safety.ts). Canvas `fillText` draws
+ *     literally, so "Rand & McNally" would export as "Rand &amp; McNally".
+ *  3. It is keyed on the viewer's `visibleLayers` set, which the builder
+ *     deliberately does not maintain — `map-sync.ts` feeds dataset credits
+ *     through MapLibre's native source-level `attribution` and lets MapLibre
+ *     gate them on the live `used` flag.
+ *
+ * Reading the control gets the same merge, the same dedupe and the same live
+ * gating as the screen by construction rather than by convention, and
+ * `textContent` is post-parse so entities and anchors are already resolved.
+ */
+import { MAP_COLORS } from '@/lib/map-colors';
+
+/** The separator MapLibre's AttributionControl joins entries with. */
+const SEPARATOR = ' | ';
+const ELLIPSIS = '…';
+const FONT_STACK = 'system-ui, -apple-system, "Segoe UI", Roboto, sans-serif';
+
+/** Only the two methods this module needs, so tests can pass a plain object
+ *  and so a partial map mock (the shape the builder suites already use) is a
+ *  valid argument rather than a cast. */
+export interface AttributionMapLike {
+  getContainer?: () => HTMLElement | null | undefined;
+  getStyle?: () => unknown;
+}
+
+function attributionFont(fontPx: number): string {
+  return `400 ${fontPx}px ${FONT_STACK}`;
+}
+
+/** Decode HTML entities in an editor-supplied credit without ever parsing it
+ *  as live markup. DOMParser documents are inert — no script runs, no image or
+ *  iframe is fetched — which `el.innerHTML = s` cannot promise. */
+function decodeHtmlText(raw: string): string {
+  try {
+    return (
+      new DOMParser().parseFromString(raw, 'text/html').body.textContent ?? ''
+    ).trim();
+  } catch {
+    return raw.trim();
+  }
+}
+
+function dedupe(entries: string[]): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const entry of entries) {
+    const trimmed = entry.trim();
+    if (!trimmed || seen.has(trimmed)) continue;
+    seen.add(trimmed);
+    out.push(trimmed);
+  }
+  return out;
+}
+
+/**
+ * The credit entries currently shown for `map`, as plain text.
+ *
+ * Tiered, because coupling to a library CSS class is a real risk:
+ *
+ *  1. `.maplibregl-ctrl-attrib-inner` textContent, split on MapLibre's own
+ *     separator. Exact agreement with the screen.
+ *  2. The union of `getStyle().sources[*].attribution`, entity-decoded. A
+ *     degraded mode rather than a cliff: it loses only the `used` gating, so
+ *     it may credit a source whose layers are all hidden. Over-crediting is
+ *     the safe direction.
+ *  3. Nothing, with a DEV warning.
+ */
+export function readRenderedAttribution(map: AttributionMapLike): string[] {
+  const inner = map.getContainer?.()?.querySelector?.(
+    '.maplibregl-ctrl-attrib-inner',
+  );
+  const rendered = inner?.textContent?.trim();
+  if (rendered) return dedupe(rendered.split(SEPARATOR));
+
+  const style = map.getStyle?.() as
+    | { sources?: Record<string, { attribution?: string | null } | null> }
+    | null
+    | undefined;
+  const sources = style?.sources;
+  if (sources) {
+    const fromSources: string[] = [];
+    for (const spec of Object.values(sources)) {
+      const raw = spec?.attribution;
+      if (typeof raw !== 'string' || !raw.trim()) continue;
+      const decoded = decodeHtmlText(raw);
+      if (decoded) fromSources.push(decoded);
+    }
+    const deduped = dedupe(fromSources);
+    if (deduped.length > 0) return deduped;
+  }
+
+  if (import.meta.env.DEV) {
+    console.warn(
+      '[attribution] no credit line available for this render; the exported image will carry none',
+    );
+  }
+  return [];
+}
+
+/** Descending integer font sizes, `from` down to `to`. Bounded by
+ *  construction: the fitter must never drive a shrink loop off `measureText`,
+ *  or a font that fails to load hangs the export. */
+function fontLadder(from: number, to: number): number[] {
+  const top = Math.max(1, Math.round(from));
+  const bottom = Math.max(1, Math.min(Math.round(to), top));
+  const sizes: number[] = [];
+  for (let px = top; px >= bottom; px--) sizes.push(px);
+  return sizes;
+}
+
+/** Greedy wrap on entry boundaries. Returns null when any single entry is
+ *  wider than `maxWidth` — the caller decides whether to shrink or elide. */
+function wrapEntries(
+  ctx: CanvasRenderingContext2D,
+  entries: string[],
+  maxWidth: number,
+): string[] | null {
+  const lines: string[] = [];
+  let current = '';
+  for (const entry of entries) {
+    if (ctx.measureText(entry).width > maxWidth) return null;
+    if (!current) {
+      current = entry;
+      continue;
+    }
+    const candidate = current + SEPARATOR + entry;
+    if (ctx.measureText(candidate).width <= maxWidth) {
+      current = candidate;
+    } else {
+      lines.push(current);
+      current = entry;
+    }
+  }
+  if (current) lines.push(current);
+  return lines;
+}
+
+/** Character-level truncation, reserved for a single entry too long for the
+ *  smallest size. Binary search, so the number of `measureText` calls is
+ *  logarithmic in the string length and always terminates. */
+function truncateToWidth(
+  ctx: CanvasRenderingContext2D,
+  text: string,
+  maxWidth: number,
+): string {
+  if (ctx.measureText(text).width <= maxWidth) return text;
+  let lo = 0;
+  let hi = text.length;
+  while (lo < hi) {
+    const mid = Math.ceil((lo + hi) / 2);
+    if (ctx.measureText(text.slice(0, mid) + ELLIPSIS).width <= maxWidth) {
+      lo = mid;
+    } else {
+      hi = mid - 1;
+    }
+  }
+  return lo > 0 ? text.slice(0, lo) + ELLIPSIS : ELLIPSIS;
+}
+
+export interface FitAttributionOptions {
+  maxWidth: number;
+  fontPx: number;
+  minFontPx: number;
+  maxLines: number;
+}
+
+export interface FittedAttribution {
+  lines: string[];
+  fontPx: number;
+  elided: boolean;
+}
+
+/**
+ * Fit `entries` into at most `maxLines` lines of at most `maxWidth`.
+ *
+ * Overflow is resolved at ENTRY boundaries, never mid-name: "© OpenFreeMap |
+ * …" credits everything it names correctly, while "© OpenFreeMap, ©
+ * OpenMapTil…" mangles a provider's name, which is worse than showing fewer.
+ *
+ * Leaves `ctx.font` set to the size it chose.
+ */
+export function fitAttributionText(
+  ctx: CanvasRenderingContext2D,
+  entries: string[],
+  opts: FitAttributionOptions,
+): FittedAttribution {
+  const clean = dedupe(entries);
+  if (clean.length === 0 || opts.maxWidth <= 0) {
+    return { lines: [], fontPx: opts.fontPx, elided: false };
+  }
+  const maxLines = Math.max(1, opts.maxLines);
+
+  for (const fontPx of fontLadder(opts.fontPx, opts.minFontPx)) {
+    ctx.font = attributionFont(fontPx);
+    const lines = wrapEntries(ctx, clean, opts.maxWidth);
+    if (lines && lines.length <= maxLines) {
+      return { lines, fontPx, elided: false };
+    }
+  }
+
+  // Nothing fits whole. Drop whole entries from the end at the smallest size,
+  // marking the loss with a trailing ellipsis entry.
+  const fontPx = Math.max(1, Math.min(Math.round(opts.minFontPx), Math.round(opts.fontPx)));
+  ctx.font = attributionFont(fontPx);
+  for (let keep = clean.length - 1; keep >= 1; keep--) {
+    const lines = wrapEntries(ctx, [...clean.slice(0, keep), ELLIPSIS], opts.maxWidth);
+    if (lines && lines.length <= maxLines) {
+      return { lines, fontPx, elided: true };
+    }
+  }
+
+  return {
+    lines: [truncateToWidth(ctx, clean[0], opts.maxWidth)],
+    fontPx,
+    elided: true,
+  };
+}
+
+/* ── Overlay: the two fixed-size crops ─────────────────────────────────── */
+
+export interface AttributionOverlaySpec {
+  fontPx: number;
+  minFontPx: number;
+  /** Distance from the canvas edge to the scrim. */
+  inset: number;
+  paddingX: number;
+  paddingY: number;
+  radius: number;
+}
+
+/** 400x250. 10px over a scrim reads fine at 1:1; the gallery renders it into
+ *  176x112 with object-cover, which is a display-size decision and not an
+ *  argument about what the file should contain. It has to carry the credit
+ *  because `get_share_card_image_url` falls back to the thumbnail as the
+ *  og:image for every map captured before SHARE-08 — that surface has no
+ *  adjacent text at all. */
+export const THUMBNAIL_ATTRIBUTION: AttributionOverlaySpec = {
+  fontPx: 10,
+  minFontPx: 9,
+  inset: 6,
+  paddingX: 5,
+  paddingY: 3,
+  radius: 3,
+};
+
+/** 1200x630. An overlay rather than a band: the whole frame is the map, and
+ *  adding a band would change the 1.91:1 ratio social platforms crop against. */
+export const OG_ATTRIBUTION: AttributionOverlaySpec = {
+  fontPx: 16,
+  minFontPx: 13,
+  inset: 12,
+  paddingX: 8,
+  paddingY: 5,
+  radius: 4,
+};
+
+/** Rounded scrim, falling back to a square fill where `roundRect` is absent
+ *  (older engines, and the 2D-context stubs the hook tests use). */
+function fillScrim(
+  ctx: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  w: number,
+  h: number,
+  radius: number,
+): void {
+  const roundRect = (
+    ctx as CanvasRenderingContext2D & {
+      roundRect?: (x: number, y: number, w: number, h: number, r: number) => void;
+    }
+  ).roundRect;
+  if (
+    typeof roundRect === 'function' &&
+    typeof ctx.beginPath === 'function' &&
+    typeof ctx.fill === 'function'
+  ) {
+    ctx.beginPath();
+    roundRect.call(ctx, x, y, w, h, radius);
+    ctx.fill();
+    return;
+  }
+  ctx.fillRect(x, y, w, h);
+}
+
+/**
+ * Draw the credit into the bottom-right of an already-composited crop.
+ *
+ * A light scrim with dark text, not a glyph halo: stroking at 9-10px roughly
+ * doubles apparent weight, and the thumbnail is a JPEG — halo plus chroma
+ * subsampling is exactly where small text turns to mush. One fixed pair works
+ * over both light and dark tiles because the scrim establishes its own ground,
+ * which also covers the globe case (#1479), where the bottom-right may be
+ * space rather than tiles.
+ *
+ * Returns whether anything was drawn.
+ */
+export function drawAttributionOverlay(
+  canvas: HTMLCanvasElement,
+  entries: string[],
+  spec: AttributionOverlaySpec,
+): boolean {
+  if (entries.length === 0) return false;
+  const ctx = canvas.getContext('2d');
+  if (!ctx) return false;
+
+  const maxWidth = canvas.width - spec.inset * 2 - spec.paddingX * 2;
+  const fitted = fitAttributionText(ctx, entries, {
+    maxWidth,
+    fontPx: spec.fontPx,
+    minFontPx: spec.minFontPx,
+    maxLines: 1,
+  });
+  const line = fitted.lines[0];
+  if (!line) return false;
+
+  ctx.font = attributionFont(fitted.fontPx);
+  const textWidth = ctx.measureText(line).width;
+  const boxW = textWidth + spec.paddingX * 2;
+  const boxH = fitted.fontPx + spec.paddingY * 2;
+  const boxX = Math.max(0, canvas.width - spec.inset - boxW);
+  const boxY = Math.max(0, canvas.height - spec.inset - boxH);
+
+  ctx.fillStyle = MAP_COLORS.exportImage.attributionScrim;
+  fillScrim(ctx, boxX, boxY, boxW, boxH, spec.radius);
+
+  ctx.fillStyle = MAP_COLORS.exportImage.text;
+  ctx.textBaseline = 'top';
+  ctx.textAlign = 'left';
+  ctx.fillText(line, boxX + spec.paddingX, boxY + spec.paddingY);
+  return true;
+}
+
+/* ── Band: the full-resolution PNG export ──────────────────────────────── */
+
+/** Unscaled band metrics; every one is multiplied by `dpr` at use, because
+ *  `handleExportPNG` works entirely in srcCanvas pixel space. */
+const BAND_FONT_PX = 12;
+const BAND_MIN_FONT_PX = 10;
+const BAND_MAX_LINES = 2;
+const BAND_LINE_HEIGHT = 16;
+const BAND_GAP = 12;
+
+export interface MeasuredAttributionBand {
+  lines: string[];
+  /** Already dpr-scaled: the caller draws with it directly. */
+  fontPx: number;
+  /** Already dpr-scaled: the caller adds it into the canvas height. */
+  height: number;
+}
+
+/**
+ * Measure the export's attribution band before the canvas is sized.
+ *
+ * Its own band rather than a share of the branding footer row: sharing would
+ * need horizontal collision math against the measured branding width, and the
+ * enterprise case (`showBranding === false`) would need a special case. A
+ * separate band makes that path fall out for free — the attribution band
+ * renders and the branding band does not. It also sits on white rather than on
+ * imagery, so it needs no scrim, which matters most for the path most likely
+ * to be printed or pasted into a report.
+ *
+ * Wraps to two lines rather than eliding: the full-resolution export has the
+ * room, and it is the one output that should never drop a credit.
+ */
+export function measureAttributionBand(
+  ctx: CanvasRenderingContext2D,
+  entries: string[],
+  opts: { maxWidth: number; dpr: number },
+): MeasuredAttributionBand {
+  const dpr = opts.dpr || 1;
+  const fallback = { lines: [], fontPx: BAND_FONT_PX * dpr, height: 0 };
+  if (entries.length === 0 || opts.maxWidth <= 0) return fallback;
+
+  const fitted = fitAttributionText(ctx, entries, {
+    maxWidth: opts.maxWidth,
+    fontPx: BAND_FONT_PX * dpr,
+    minFontPx: BAND_MIN_FONT_PX * dpr,
+    maxLines: BAND_MAX_LINES,
+  });
+  if (fitted.lines.length === 0) return fallback;
+
+  return {
+    lines: fitted.lines,
+    fontPx: fitted.fontPx,
+    height: Math.round(
+      BAND_GAP * dpr + fitted.lines.length * BAND_LINE_HEIGHT * dpr + BAND_GAP * dpr,
+    ),
+  };
+}
+
+/**
+ * Draw a measured band with its top-left at (`x`, `y`).
+ *
+ * `mutedText` (#666666, ~5.7:1 on white) rather than the #999999 the branding
+ * footer uses (~2.8:1) — a legally required line is not somewhere to reuse a
+ * decorative contrast.
+ */
+export function drawAttributionBand(
+  ctx: CanvasRenderingContext2D,
+  measured: MeasuredAttributionBand,
+  opts: { x: number; y: number; dpr: number },
+): void {
+  if (measured.lines.length === 0) return;
+  const dpr = opts.dpr || 1;
+  ctx.fillStyle = MAP_COLORS.exportImage.mutedText;
+  ctx.font = attributionFont(measured.fontPx);
+  ctx.textBaseline = 'top';
+  ctx.textAlign = 'left';
+  let lineY = opts.y + BAND_GAP * dpr;
+  for (const line of measured.lines) {
+    ctx.fillText(line, opts.x, lineY);
+    lineY += BAND_LINE_HEIGHT * dpr;
+  }
+}

--- a/frontend/src/lib/map-image-attribution.ts
+++ b/frontend/src/lib/map-image-attribution.ts
@@ -64,16 +64,138 @@ function attributionFont(fontPx: number): string {
   return `400 ${fontPx}px ${FONT_STACK}`;
 }
 
-/** Decode HTML entities in an editor-supplied credit without ever parsing it
- *  as live markup. DOMParser documents are inert — no script runs, no image or
- *  iframe is fetched — which `el.innerHTML = s` cannot promise. */
+/* ── HTML → credit text ────────────────────────────────────────────────────
+ *
+ * fix(#1541 codex P2 round 3): both readers used to take `textContent`, and a
+ * credit is HTML. `BasemapEntry.attribution` permits it, MapLibre renders it,
+ * and a provider is entitled to credit itself with a logo:
+ * `<img alt="© Provider" src="logo.svg">`. A text alternative is not DOM text,
+ * so `textContent` returned '' and the source was skipped — the map on screen
+ * showed the credit and the exported PNG, thumbnail and OG card did not. That
+ * is the silent drop this module exists to make impossible, in its worst form:
+ * the user can see the discrepancy by looking at their own screen.
+ *
+ * So text is DERIVED from the markup rather than scraped off it, preserving
+ * the accessible alternatives a sighted user is reading:
+ *
+ *   text nodes        as written
+ *   <img>             alt, else aria-label, else title, else a placeholder
+ *   any element       its own text; if it has none, aria-label then title
+ *   <br> and blocks   a visual break, so credits do not run together
+ *
+ * The generic element rule is what makes `<svg role="img" aria-label="…">`
+ * work without naming SVG anywhere, and `<svg><title>…</title></svg>` already
+ * worked because a <title> element IS DOM text.
+ *
+ * `alt=""` is honoured as its author meant it: an explicitly decorative image
+ * contributes nothing and gets no placeholder. That is the one case where an
+ * image yields no credit by design rather than by accident.
+ *
+ * Whichever reader is in play, the parse stays inert. DOMParser documents run
+ * no script and fetch no image or iframe, which `el.innerHTML = s` cannot
+ * promise; the control path walks nodes MapLibre itself put in the document.
+ */
+
+/** Element boundaries that read as a line break in the rendered credit. Inline
+ *  tags (a, span, b, img …) are deliberately absent: they continue the line. */
+const BLOCK_CREDIT_TAGS = new Set([
+  'ADDRESS', 'ARTICLE', 'ASIDE', 'BLOCKQUOTE', 'DD', 'DIV', 'DL', 'DT',
+  'FIELDSET', 'FIGCAPTION', 'FIGURE', 'FOOTER', 'FORM', 'H1', 'H2', 'H3',
+  'H4', 'H5', 'H6', 'HEADER', 'HR', 'LI', 'MAIN', 'NAV', 'OL', 'P', 'PRE',
+  'SECTION', 'TABLE', 'TD', 'TH', 'TR', 'UL',
+]);
+
+/** Internal break sentinel. NUL cannot survive into rendered text — the
+ *  normalizer consumes every one of them — so it cannot collide with content
+ *  the way a printable delimiter would. */
+const BREAK = '\u0000';
+
+/** The text alternative an assistive technology would announce for `el`, in
+ *  the order the accessible name is computed from these three attributes. */
+function textAlternative(el: Element): string | null {
+  for (const attr of ['alt', 'aria-label', 'title']) {
+    const value = el.getAttribute(attr);
+    if (value !== null && value.trim()) return value;
+  }
+  return null;
+}
+
+/** A name for an image that offers no alternative at all. Its host, where it
+ *  has one: that is the only provider-identifying text such a credit carries,
+ *  and it also keeps two distinct unnamed logos from deduping into one. Two
+ *  hostless ones (a data: URI) still collapse — they are indistinguishable in
+ *  text, which is the residual of a credit that ships no words. */
+function unnamedImageCredit(el: Element): string {
+  const src = el.getAttribute('src');
+  if (src) {
+    try {
+      const url = new URL(src, window.location.href);
+      if (url.protocol === 'http:' || url.protocol === 'https:') {
+        return i18n.t('builder:export.imageCreditFrom', { host: url.hostname });
+      }
+    } catch {
+      // Unparseable src: fall through to the bare placeholder.
+    }
+  }
+  return i18n.t('builder:export.imageCredit');
+}
+
+/** Walk `node`, collecting text and text alternatives with break sentinels at
+ *  the visual boundaries. Not normalized — `normalizeCreditText` does that. */
+function collectCreditText(node: Node): string {
+  if (node.nodeType === Node.TEXT_NODE) return node.textContent ?? '';
+  if (node.nodeType !== Node.ELEMENT_NODE) return '';
+
+  const el = node as Element;
+  const tag = el.tagName.toUpperCase();
+  if (tag === 'BR') return BREAK;
+  const isImage =
+    tag === 'IMG' || (tag === 'INPUT' && el.getAttribute('type')?.toLowerCase() === 'image');
+  if (isImage) {
+    // A decorative image says so with alt="", and is not a credit.
+    if (el.getAttribute('alt')?.trim() === '') return '';
+    return textAlternative(el) ?? unnamedImageCredit(el);
+  }
+
+  let inner = '';
+  for (const child of Array.from(el.childNodes)) inner += collectCreditText(child);
+  // An element that contributes no text of its own falls back to its own
+  // alternative. Checked AFTER the children so a labelled wrapper around real
+  // text does not credit the same provider twice.
+  if (!inner.split(BREAK).join('').trim()) inner = textAlternative(el) ?? inner;
+  return BLOCK_CREDIT_TAGS.has(tag) ? `${BREAK}${inner}${BREAK}` : inner;
+}
+
+/** Collapse the walker's output into one credit line. Segments separated by a
+ *  visual break are joined with the separator the images already use between
+ *  credits — presentation only. It creates no new counted credit: a credit is
+ *  counted per SOURCE, and this is the text of one source. */
+function normalizeCreditText(raw: string): string {
+  return raw
+    .split(BREAK)
+    .map((segment) => segment.replace(/\s+/g, ' ').trim())
+    .filter(Boolean)
+    .join(SEPARATOR);
+}
+
+/** Credit text for an editor-supplied HTML string, parsed inertly. */
 function decodeHtmlText(raw: string): string {
   try {
-    return (
-      new DOMParser().parseFromString(raw, 'text/html').body.textContent ?? ''
-    ).trim();
+    const doc = new DOMParser().parseFromString(raw, 'text/html');
+    return normalizeCreditText(collectCreditText(doc.body));
   } catch {
     return raw.trim();
+  }
+}
+
+/** Credit text for a live element MapLibre rendered. Same derivation as the
+ *  string path — fixing one reader and leaving its sibling is how a credit
+ *  goes missing from exactly one of the two ways it can be read. */
+function elementCreditText(el: Element): string {
+  try {
+    return normalizeCreditText(collectCreditText(el));
+  } catch {
+    return el.textContent?.trim() ?? '';
   }
 }
 
@@ -106,8 +228,8 @@ function dedupe(entries: string[]): string[] {
  * Ordered by whether the source is STRUCTURED, not by how close it is to the
  * screen:
  *
- *  1. The live sources' own `attribution`, one entry per source, entity-decoded
- *     and never split on anything. This is the only place the individual
+ *  1. The live sources' own `attribution`, one entry per source, derived from
+ *     its HTML and never split on anything. This is the only place the individual
  *     credits exist as separate values, so it is the only honest input to a
  *     per-credit count. Read from `getSource(id)` rather than from
  *     `getStyle().sources[id]`: MEASURED on the shipped OpenFreeMap basemap,
@@ -116,11 +238,13 @@ function dedupe(entries: string[]): string[] {
  *     source loaded from a TileJSON `url` receives them in that response and
  *     `getStyle()` serializes the spec as authored. Reading the spec alone
  *     dropped every basemap credit whenever a dataset declared one.
- *  2. `.maplibregl-ctrl-attrib-inner` textContent as ONE opaque entry. This
- *     path genuinely only has the joined string, so it does not guess: the
- *     whole line is treated as a single credit rather than split back apart.
- *     It renders identically; only the marker's granularity is coarser, and
- *     only on a map whose sources declare nothing.
+ *  2. `.maplibregl-ctrl-attrib-inner`, derived the same way, as ONE opaque
+ *     entry. This path genuinely only has the joined line, so it does not
+ *     guess: the whole thing is treated as a single credit rather than split
+ *     back apart. It renders identically; only the marker's granularity is
+ *     coarser, and only on a map whose sources declare nothing. Both readers
+ *     run the same derivation — see `collectCreditText` — because a credit
+ *     that survives one reader and not its sibling is still a lost credit.
  *  3. Nothing, with a DEV warning.
  *
  * Two costs of preferring (1), both accepted:
@@ -170,7 +294,9 @@ export function readRenderedAttribution(map: AttributionMapLike): string[] {
   const inner = map.getContainer?.()?.querySelector?.(
     '.maplibregl-ctrl-attrib-inner',
   );
-  const rendered = inner?.textContent?.trim();
+  // Derived, not `textContent` — an image-only credit rendered here is just as
+  // real as one declared on a source, and reading text off it dropped both.
+  const rendered = inner ? elementCreditText(inner) : '';
   // Deliberately NOT split. See the docstring: the separator is legal content.
   if (rendered) return [rendered];
 

--- a/frontend/src/lib/map-image-attribution.ts
+++ b/frontend/src/lib/map-image-attribution.ts
@@ -13,7 +13,11 @@
  * credit only reaches an exported image if it is DRAWN INTO the canvas, which
  * is what the two draw helpers here do.
  *
- * Where the text comes from: MapLibre's rendered control, read as text.
+ * Where the text comes from: the style's own per-source `attribution` values,
+ * as a LIST. See `readRenderedAttribution` for why a list rather than the
+ * rendered control's joined string (fix(#1541 codex P2): ` | ` is legal content
+ * inside a credit, so splitting the joined line cut credits in half and let the
+ * dedupe delete them).
  *
  * The obvious alternative — composing `BasemapEntry.attribution` with
  * `collectLayerAttributions` — is wrong for the builder in three ways:
@@ -32,9 +36,9 @@
  *     through MapLibre's native source-level `attribution` and lets MapLibre
  *     gate them on the live `used` flag.
  *
- * Reading the control gets the same merge, the same dedupe and the same live
- * gating as the screen by construction rather than by convention, and
- * `textContent` is post-parse so entities and anchors are already resolved.
+ * Reading the live style keeps the image and the screen agreeing on WHICH
+ * credits exist, by construction rather than by convention, and the HTML in
+ * those values is decoded through an inert DOMParser rather than a regex.
  */
 import { MAP_COLORS } from '@/lib/map-colors';
 // Canvas drawing happens outside React, so the overflow marker is translated
@@ -51,6 +55,9 @@ const FONT_STACK = 'system-ui, -apple-system, "Segoe UI", Roboto, sans-serif';
 export interface AttributionMapLike {
   getContainer?: () => HTMLElement | null | undefined;
   getStyle?: () => unknown;
+  /** Live source objects. Their `attribution` is the RESOLVED value; the
+   *  serialized style's is not. See `readRenderedAttribution`. */
+  getSource?: (id: string) => { attribution?: string | null } | null | undefined;
 }
 
 function attributionFont(fontPx: number): string {
@@ -83,25 +90,52 @@ function dedupe(entries: string[]): string[] {
 }
 
 /**
- * The credit entries currently shown for `map`, as plain text.
+ * The credit entries currently shown for `map`, as plain text, AS A LIST.
  *
- * Tiered, because coupling to a library CSS class is a real risk:
+ * fix(#1541 codex P2): this used to read MapLibre's rendered control and split
+ * the joined text on ` | `. That re-derived structure from a rendered string,
+ * and the delimiter is legal content — the backend accepts it anywhere in a
+ * 5,000-character credit. A credit reading `© Acme | © Acme` split into two
+ * identical fragments, which the dedupe then collapsed into one, silently
+ * deleting half a real credit; and the overflow marker counted fragments rather
+ * than credits, so its "+N" could be wrong in either direction while a single
+ * licensing statement was cut in half and its remainder counted as a separate
+ * provider. No smarter delimiter fixes that. Any delimiter can appear in
+ * content, so the round-trip itself had to go.
  *
- *  1. `.maplibregl-ctrl-attrib-inner` textContent, split on MapLibre's own
- *     separator. Exact agreement with the screen.
- *  2. The union of `getStyle().sources[*].attribution`, entity-decoded. A
- *     degraded mode rather than a cliff: it loses only the `used` gating, so
- *     it may credit a source whose layers are all hidden. Over-crediting is
- *     the safe direction.
+ * Ordered by whether the source is STRUCTURED, not by how close it is to the
+ * screen:
+ *
+ *  1. The live sources' own `attribution`, one entry per source, entity-decoded
+ *     and never split on anything. This is the only place the individual
+ *     credits exist as separate values, so it is the only honest input to a
+ *     per-credit count. Read from `getSource(id)` rather than from
+ *     `getStyle().sources[id]`: MEASURED on the shipped OpenFreeMap basemap,
+ *     the serialized spec reports `attribution: null` while the live source
+ *     carries the OpenMapTiles and OpenStreetMap credits, because a vector
+ *     source loaded from a TileJSON `url` receives them in that response and
+ *     `getStyle()` serializes the spec as authored. Reading the spec alone
+ *     dropped every basemap credit whenever a dataset declared one.
+ *  2. `.maplibregl-ctrl-attrib-inner` textContent as ONE opaque entry. This
+ *     path genuinely only has the joined string, so it does not guess: the
+ *     whole line is treated as a single credit rather than split back apart.
+ *     It renders identically; only the marker's granularity is coarser, and
+ *     only on a map whose sources declare nothing.
  *  3. Nothing, with a DEV warning.
+ *
+ * Two costs of preferring (1), both accepted:
+ *
+ *  - The `used` gating. MapLibre hides a source whose layers are all hidden and
+ *    the source list does not, so the image may credit a source the screen does
+ *    not. Over-crediting is the safe direction.
+ *  - MapLibre's own "MapLibre" self-credit is a control default rather than a
+ *    source, so it is not in the list and does not reach the image. It is
+ *    library branding, not a data credit, and no data licence turns on it.
+ *
+ * Both are the price of a credit list that cannot be mangled by its own
+ * content, which is the property the whole marker count rests on.
  */
 export function readRenderedAttribution(map: AttributionMapLike): string[] {
-  const inner = map.getContainer?.()?.querySelector?.(
-    '.maplibregl-ctrl-attrib-inner',
-  );
-  const rendered = inner?.textContent?.trim();
-  if (rendered) return dedupe(rendered.split(SEPARATOR));
-
   const style = map.getStyle?.() as
     | { sources?: Record<string, { attribution?: string | null } | null> }
     | null
@@ -109,8 +143,16 @@ export function readRenderedAttribution(map: AttributionMapLike): string[] {
   const sources = style?.sources;
   if (sources) {
     const fromSources: string[] = [];
-    for (const spec of Object.values(sources)) {
-      const raw = spec?.attribution;
+    for (const id of Object.keys(sources)) {
+      // The LIVE source first: a vector source loaded from a TileJSON `url`
+      // receives its attribution in that response, and `getStyle()` serializes
+      // the spec as authored, so the basemap's credit is null there and
+      // present here. Measured on the shipped OpenFreeMap basemap, where the
+      // spec says null and the live source carries the OpenMapTiles and
+      // OpenStreetMap credits. The serialized value is the fallback for a
+      // source the map has not instantiated.
+      const live = map.getSource?.(id)?.attribution;
+      const raw = typeof live === 'string' && live.trim() ? live : sources[id]?.attribution;
       if (typeof raw !== 'string' || !raw.trim()) continue;
       const decoded = decodeHtmlText(raw);
       if (decoded) fromSources.push(decoded);
@@ -118,6 +160,13 @@ export function readRenderedAttribution(map: AttributionMapLike): string[] {
     const deduped = dedupe(fromSources);
     if (deduped.length > 0) return deduped;
   }
+
+  const inner = map.getContainer?.()?.querySelector?.(
+    '.maplibregl-ctrl-attrib-inner',
+  );
+  const rendered = inner?.textContent?.trim();
+  // Deliberately NOT split. See the docstring: the separator is legal content.
+  if (rendered) return [rendered];
 
   if (import.meta.env.DEV) {
     console.warn(
@@ -227,28 +276,60 @@ function wrapEntries(
   return lines;
 }
 
+/**
+ * Split `text` into user-perceived characters.
+ *
+ * fix(#1541 codex P2): the wrapper used to index and `slice()` by UTF-16 code
+ * unit, which splits a surrogate pair down the middle and renders two
+ * replacement glyphs instead of the provider's name. Mid-STRING wrapping is the
+ * one residual limit we allow; mid-CHARACTER is just truncation wearing a
+ * disguise.
+ *
+ * `Intl.Segmenter` because it is the only option that also keeps combining
+ * marks and ZWJ emoji sequences intact — `Array.from` iterates code POINTS,
+ * which fixes surrogate pairs but still severs a base character from its
+ * accent. It is kept as the fallback only for an engine without `Segmenter`,
+ * where it is strictly better than code units.
+ */
+let graphemeSegmenter: Intl.Segmenter | null | undefined;
+
+function toGraphemes(text: string): string[] {
+  if (graphemeSegmenter === undefined) {
+    graphemeSegmenter =
+      typeof Intl !== 'undefined' && typeof Intl.Segmenter === 'function'
+        ? new Intl.Segmenter(undefined, { granularity: 'grapheme' })
+        : null;
+  }
+  if (!graphemeSegmenter) return Array.from(text);
+  return Array.from(graphemeSegmenter.segment(text), (s) => s.segment);
+}
+
 /** Break a word wider than `maxWidth` into pieces that are not. Loses nothing:
- *  the pieces continue on the following lines. Binary search per piece, and
- *  each piece takes at least one character, so it always terminates. */
+ *  the pieces continue on the following lines. Binary search per piece over
+ *  GRAPHEME CLUSTERS, and each piece takes at least one cluster, so it always
+ *  terminates and never splits a character. */
 function breakLongWord(
   ctx: CanvasRenderingContext2D,
   word: string,
   maxWidth: number,
 ): string[] {
+  if (ctx.measureText(word).width <= maxWidth) return [word];
+  const cells = toGraphemes(word);
   const pieces: string[] = [];
-  let rest = word;
-  while (rest && ctx.measureText(rest).width > maxWidth) {
-    let lo = 1;
-    let hi = rest.length;
+  let start = 0;
+  while (start < cells.length) {
+    // Largest end index whose slice still fits, but never fewer than one
+    // cluster — that lower bound is what guarantees progress.
+    let lo = start + 1;
+    let hi = cells.length;
     while (lo < hi) {
       const mid = Math.ceil((lo + hi) / 2);
-      if (ctx.measureText(rest.slice(0, mid)).width <= maxWidth) lo = mid;
+      if (ctx.measureText(cells.slice(start, mid).join('')).width <= maxWidth) lo = mid;
       else hi = mid - 1;
     }
-    pieces.push(rest.slice(0, lo));
-    rest = rest.slice(lo);
+    pieces.push(cells.slice(start, lo).join(''));
+    start = lo;
   }
-  if (rest) pieces.push(rest);
   return pieces;
 }
 

--- a/frontend/src/lib/map-image-attribution.ts
+++ b/frontend/src/lib/map-image-attribution.ts
@@ -148,16 +148,42 @@ export function readRenderedAttribution(map: AttributionMapLike): string[] {
  *   OG card      16px over a scrim     (1200x630 JPEG, quality 0.85)
  *   Thumbnail    10px over a scrim     (400x250 JPEG, quality 0.7)
  *
- * There is deliberately no shrink ladder. Shrinking traded legibility for area,
- * and now that spending area is allowed, the trade is the wrong way round: 10px
- * over a scrim is legible at 1:1, 9px under JPEG chroma subsampling is where
- * small text starts to mush. The gallery displays the thumbnail at 176x112, but
- * that is a display-size decision and not an argument about the file.
+ * 10px is the floor of the three. There is deliberately no shrink ladder:
+ * shrinking traded legibility for area, and now that spending area is allowed
+ * the trade is the wrong way round — 10px over a scrim is legible at 1:1, 9px
+ * under JPEG chroma subsampling is where small text starts to mush. The gallery
+ * displays the thumbnail at 176x112, but that is a display-size decision and
+ * not an argument about the file.
  *
- * The one residual limit: a single credit longer than a full line wraps
- * MID-STRING, on word boundaries, and on characters for a word that still does
- * not fit. That splits a provider's name across lines, which is legible and
- * complete. It never truncates one.
+ * How much of each image the band can eat, and where it runs out. The line
+ * counts, percentages and ceilings below are asserted in
+ * lib/__tests__/map-image-attribution.test.ts rather than left as prose claims;
+ * `overlayLineCapacity` computes the ceiling column. The chars/line column is
+ * the only estimate, since real glyph widths are font-dependent.
+ *
+ *               line    usable    chars/   real 5-credit    ceiling
+ *               height  width     line     load             (band fills frame)
+ *   Thumbnail   13px    378px     ~75      6 lines, 33.6%   18 lines, ~1350 chars
+ *   OG card     20px    1160px    ~145     4 lines, 14.3%   30 lines, ~4350 chars
+ *   PNG export  16px    1016px*   ~169     4 lines, 88px    none — canvas grows
+ *
+ *   * the measured 1056px-wide export at dpr 1, less 20px of pad a side.
+ *
+ * The export has no ceiling at all: its canvas is sized AFTER the band is
+ * measured, so the band's height is an input to the image rather than a budget
+ * inside it. Only the two crops have one, and it is where the scrim reaches the
+ * top edge — the band has by then eaten every map pixel there is. Past it no
+ * layout at 10px can place the remaining lines, so they fall off the bottom.
+ * That ceiling is ~3.3x the measured real-world credit load for the thumbnail
+ * (411 characters across five providers) and ~10x for the OG card, and no
+ * basemap-plus-dataset stack comes near it. It is still a limit rather than a
+ * promise, so `drawAttributionOverlay` warns in DEV naming the lines it cannot
+ * place. A credit that cannot be shown is at least never lost quietly.
+ *
+ * The one residual limit within the ceiling: a single credit longer than a full
+ * line wraps MID-STRING, on word boundaries, and on characters for a word that
+ * still does not fit. That splits a provider's name across lines, which is
+ * legible and complete. It never truncates one.
  */
 
 /** Greedy wrap on entry boundaries, so a provider's name stays on one line.
@@ -311,6 +337,22 @@ export const OG_ATTRIBUTION: AttributionOverlaySpec = {
   radius: 4,
 };
 
+/**
+ * How many lines of `spec` a `canvasHeight`-tall frame can hold before the
+ * scrim reaches the top edge and the band has eaten every map pixel there is.
+ *
+ * The crops' only real ceiling, and the number the module's legibility floor is
+ * documented against. The export band has no equivalent: its canvas is sized
+ * after the band is measured, so there is nothing for it to run out of.
+ */
+export function overlayLineCapacity(
+  spec: AttributionOverlaySpec,
+  canvasHeight: number,
+): number {
+  const usable = canvasHeight - spec.inset - spec.paddingY * 2;
+  return Math.max(0, Math.floor(usable / spec.lineHeight));
+}
+
 /** Rounded scrim, falling back to a square fill where `roundRect` is absent
  *  (older engines, and the 2D-context stubs the hook tests use). */
 function fillScrim(
@@ -364,6 +406,18 @@ export function drawAttributionOverlay(
   const maxWidth = canvas.width - spec.inset * 2 - spec.paddingX * 2;
   const fitted = fitAttributionText(ctx, entries, { maxWidth, fontPx: spec.fontPx });
   if (fitted.lines.length === 0) return false;
+
+  // fix(#1541 codex P1): removing the fitter's elision moved the only remaining
+  // way to lose a credit out here, to the frame edge — `boxY` clamps at 0, so a
+  // band taller than the image draws its last lines off the bottom. Geometry,
+  // not policy: at 10px there is no layout that fits them. Say so instead of
+  // letting it happen quietly. See the capacity table in this module's header.
+  const capacity = overlayLineCapacity(spec, canvas.height);
+  if (import.meta.env.DEV && fitted.lines.length > capacity) {
+    console.warn(
+      `[attribution] ${fitted.lines.length - capacity} of ${fitted.lines.length} credit lines do not fit a ${canvas.width}x${canvas.height} image at ${spec.fontPx}px and will be clipped`,
+    );
+  }
 
   ctx.font = attributionFont(fitted.fontPx);
   const textWidth = fitted.lines.reduce(

--- a/frontend/src/lib/map-image-attribution.ts
+++ b/frontend/src/lib/map-image-attribution.ts
@@ -221,9 +221,22 @@ function normalizeCreditText(raw: string): string {
  * image with no alternative gets, which both renders it and makes it one of
  * the `credits.length` the overflow marker counts.
  *
- * A declaration that derives no text and contains no image is genuinely empty
- * (`'   '`, `<div></div>`) and still contributes nothing. Nothing was declared
- * to lose.
+ * fix(#1541 codex P2 round 8): that fallback then recognised only `<img>`, so
+ * an unlabelled inline `<svg>` or a CSS-backed logo — both of which MapLibre
+ * renders perfectly visibly — derived no text, matched no image, and vanished
+ * without even reaching the marker. Enumerating a third tag list would only
+ * move the boundary, so the question asked here is the one actually meant: DID
+ * THIS DECLARATION PUT SOMETHING ON SCREEN THAT WE COULD NOT NAME? Any element
+ * is the answer. Markup with no text is displaying something graphical — a
+ * logo, a glyph, a background — and no tag list is needed to know that.
+ *
+ * The conservatism is deliberate and one-directional. Neither a parsed fragment
+ * (no layout, no CSS) nor a headless read can prove an element paints pixels,
+ * so `<div></div>` is counted as a credit it probably is not. That costs a
+ * `(image credit)` line on a declaration no provider would author. The other
+ * direction costs a real provider its credit, silently. Only a declaration with
+ * no elements AND no text (`'   '`, `''`) contributes nothing: there is
+ * genuinely nothing there to lose.
  *
  * Note the layering: within a credit, alt="" still contributes nothing —
  * `© Provider <img alt="">` is "© Provider", not "© Provider (image credit)".
@@ -232,8 +245,12 @@ function normalizeCreditText(raw: string): string {
 function declaredCreditText(root: Element): string {
   const text = normalizeCreditText(collectCreditText(root));
   if (text) return text;
-  const image = root.querySelector?.('img, input[type="image"]');
-  return image ? unnamedImageCredit(image) : '';
+  const rendered = root.querySelector?.('*');
+  if (!rendered) return '';
+  // An image can at least be named by its host; anything else takes the bare
+  // placeholder. Both are counted, which is the point.
+  const image = root.querySelector?.('img[src], input[type="image"][src]');
+  return unnamedImageCredit(image ?? rendered);
 }
 
 /** Credit text for an editor-supplied HTML string, parsed inertly. */
@@ -358,6 +375,36 @@ interface AttributionStyle {
 }
 
 /**
+ * Drop each credit that another credit already contains whole.
+ *
+ * fix(#1541 codex P2 round 8): MapLibre's own AttributionControl does this —
+ * `sort((a, b) => a.length - b.length)`, then drop any entry a later one
+ * `includes` — so `© Acme` beside `© Acme — CC BY 4.0` shows once on screen and
+ * showed twice in the image. The failure is asymmetric, which is why it earns a
+ * fix: source order could let the redundant fragment take the line budget and
+ * leave the COMPLETE licensing statement as "+1 more credit".
+ *
+ * Only the suppression is mirrored, not the sort. MapLibre reorders by length;
+ * this list is ordered shown-first and by style order within that, which is
+ * load-bearing (see `readRenderedAttribution`).
+ *
+ * STRICTLY longer, and WITHIN ONE PRIORITY GROUP ONLY. Strictly longer so two
+ * equal strings cannot suppress each other into nothing — `dedupe` owns that
+ * case. Within one group because a hidden credit suppressing a shown one would
+ * reinstate the crowding-out bug through a different door: the shown text would
+ * leave the list, and the hidden superstring still carrying it could then be
+ * the entry the marker elides.
+ */
+function suppressContainedCredits(entries: string[]): string[] {
+  return entries.filter(
+    (entry, i) =>
+      !entries.some(
+        (other, j) => j !== i && other.length > entry.length && other.includes(entry),
+      ),
+  );
+}
+
+/**
  * Source ids that are rendering. AN APPROXIMATION OF MAPLIBRE'S `used` /
  * `usedForTerrain`, computed from public signals, and stated as one so the next
  * gap in it is a known limit rather than a bug report.
@@ -458,9 +505,13 @@ export function readRenderedAttribution(map: AttributionMapLike): string[] {
       const decoded = decodeHtmlText(raw);
       if (decoded) (shown.has(id) ? fromShown : fromHidden).push(decoded);
     }
-    // Deduped ACROSS the two groups, so a credit carried by both a shown and a
-    // hidden source keeps the shown one's leading position.
-    const deduped = dedupe([...fromShown, ...fromHidden]);
+    // Contained credits are suppressed inside each group and never across
+    // them; the exact-duplicate dedupe then runs ACROSS both, so a credit
+    // carried by a shown and a hidden source keeps the shown one's position.
+    const deduped = dedupe([
+      ...suppressContainedCredits(fromShown),
+      ...suppressContainedCredits(fromHidden),
+    ]);
     if (deduped.length > 0) return deduped;
   }
 

--- a/frontend/src/lib/map-image-attribution.ts
+++ b/frontend/src/lib/map-image-attribution.ts
@@ -284,11 +284,35 @@ function dedupe(entries: string[]): string[] {
  *     that survives one reader and not its sibling is still a lost credit.
  *  3. Nothing, with a DEV warning.
  *
- * Two costs of preferring (1), both accepted:
+ * Within (1), SHOWN SOURCES COME FIRST.
  *
- *  - The `used` gating. MapLibre hides a source whose layers are all hidden and
- *    the source list does not, so the image may credit a source the screen does
- *    not. Over-crediting is the safe direction.
+ * fix(#1541 codex P1): the list used to be in whatever order the style declared
+ * its sources, and "no `used` gating — over-crediting is the safe direction"
+ * was an accepted cost of that. It stopped being safe the moment the outputs
+ * gained a capacity limit and a prefix fit. Over-crediting is free only while
+ * everything fits; once entries compete for a bounded budget an unused credit
+ * does not add information, it DISPLACES a required one, and prefix-fitting
+ * makes position decisive. A hidden source that happened to sort first could
+ * eat all 18 lines of a thumbnail and reduce the visible provider to "+1 more
+ * credit". The builder deliberately leaves attribution on hidden sources
+ * (map-sync.ts: MapLibre recomputes its own control from the live `used` flag,
+ * so hiding every layer on a source drops its credit with no code of ours
+ * running), so the reader sees credits the screen does not.
+ *
+ * Ordering rather than filtering, deliberately: a source hidden at capture time
+ * can still be part of what the map is OF, and `used` is a live-render concept
+ * a headless export cannot always reproduce. Everything is still credited when
+ * there is room — the over-crediting property is intact — and what the marker
+ * elides first is now the hidden sources, which is the correct thing to lose.
+ *
+ * `shownSourceIds` is a deliberately coarse approximation of `used`: a source
+ * is shown if any style layer references it and that layer is not
+ * `visibility: none`. It ignores zoom ranges, so it over-reports. That costs
+ * nothing, because the answer only ORDERS the list — a source it gets wrong is
+ * mis-sorted, never dropped.
+ *
+ * One cost of preferring (1), accepted:
+ *
  *  - MapLibre's own "MapLibre" self-credit does not reach the image. It is a
  *    control default rather than a source, so no structured list contains it,
  *    and it was DECIDED on #1541 review that it should stay out rather than be
@@ -299,17 +323,35 @@ function dedupe(entries: string[]): string[] {
  *    exists to remove, to satisfy an obligation that does not exist. The
  *    interactive map still shows it — the control default is untouched.
  *
- * Both are the price of a credit list that cannot be mangled by its own
- * content, which is the property the whole marker count rests on.
+ * That is the price of a credit list that cannot be mangled by its own content,
+ * which is the property the whole marker count rests on.
  */
+interface AttributionStyle {
+  sources?: Record<string, { attribution?: string | null } | null>;
+  layers?: ({ source?: unknown; layout?: { visibility?: string } | null } | null)[];
+}
+
+/** Source ids a visible style layer references — a coarse stand-in for
+ *  MapLibre's live `used` flag, sound enough to ORDER by. See the docstring:
+ *  it over-reports, and over-reporting only mis-sorts. */
+function shownSourceIds(style: AttributionStyle | null | undefined): Set<string> {
+  const shown = new Set<string>();
+  for (const layer of style?.layers ?? []) {
+    if (!layer || layer.layout?.visibility === 'none') continue;
+    if (typeof layer.source === 'string') shown.add(layer.source);
+  }
+  return shown;
+}
+
 export function readRenderedAttribution(map: AttributionMapLike): string[] {
-  const style = map.getStyle?.() as
-    | { sources?: Record<string, { attribution?: string | null } | null> }
-    | null
-    | undefined;
+  const style = map.getStyle?.() as AttributionStyle | null | undefined;
   const sources = style?.sources;
   if (sources) {
-    const fromSources: string[] = [];
+    // Partitioned rather than sorted, so the style's own order survives inside
+    // each group and the result is stable without depending on sort stability.
+    const shown = shownSourceIds(style);
+    const fromShown: string[] = [];
+    const fromHidden: string[] = [];
     for (const id of Object.keys(sources)) {
       // The LIVE source first: a vector source loaded from a TileJSON `url`
       // receives its attribution in that response, and `getStyle()` serializes
@@ -322,9 +364,11 @@ export function readRenderedAttribution(map: AttributionMapLike): string[] {
       const raw = typeof live === 'string' && live.trim() ? live : sources[id]?.attribution;
       if (typeof raw !== 'string' || !raw.trim()) continue;
       const decoded = decodeHtmlText(raw);
-      if (decoded) fromSources.push(decoded);
+      if (decoded) (shown.has(id) ? fromShown : fromHidden).push(decoded);
     }
-    const deduped = dedupe(fromSources);
+    // Deduped ACROSS the two groups, so a credit carried by both a shown and a
+    // hidden source keeps the shown one's leading position.
+    const deduped = dedupe([...fromShown, ...fromHidden]);
     if (deduped.length > 0) return deduped;
   }
 
@@ -807,9 +851,10 @@ const BAND_GAP = 12;
  * What it costs a desktop export: nothing until the MAP canvas alone is around
  * 4,096x4,096 device pixels. The measured 1056px-wide export still gets 951
  * lines of band; a 4400x2400 canvas (a maximized builder on a 5K display at
- * dpr 2) still gets 41. Past that the fixed blocks have spent the whole
- * ceiling, and the band falls to the one-line floor below rather than to
- * nothing — see `attributionBandHeightBudget`.
+ * dpr 2) still gets 41. Past that the fixed blocks have spent the ceiling on
+ * their own and the band gets whatever is left, down to nothing — see
+ * `attributionBandHeightBudget` for why it does not overrun the cap to keep a
+ * line, and what that costs.
  */
 export const EXPORT_CANVAS_MAX_DIMENSION = 16_384;
 export const EXPORT_CANVAS_MAX_AREA = 16_777_216;
@@ -825,32 +870,37 @@ export function exportCanvasHeightCeiling(canvasWidth: number): number {
   );
 }
 
-/** One line of band, gaps included: the least height that can carry a credit
- *  or the marker that counts the ones it could not. */
-function minimumBandHeight(dpr: number): number {
-  return (BAND_GAP * 2 + BAND_LINE_HEIGHT) * (dpr || 1);
-}
-
 /**
  * How much of that ceiling is left for the band once the fixed blocks (title,
  * map, legend, footer) have taken theirs. The band is the only elastic term in
  * the export's height, so it absorbs the whole clamp.
  *
- * Floored at one line rather than at zero. The fixed blocks can spend the whole
- * conservative ceiling on their own — a map canvas past ~4,096x4,096 does it —
- * and that canvas is over the cap with or without a band, so suppressing the
- * credit there would trade a licensing obligation for nothing. One line plus
- * the marker still says what the image is crediting and how much it is not.
- * The property that matters is preserved either way: the band is never the term
- * that pushes an otherwise-encodable canvas over.
+ * fix(#1541 codex P2 round 5): this used to be floored at one minimum band, so
+ * that a canvas whose fixed blocks had eaten the ceiling still got a credit.
+ * A floor and a ceiling that did not know about each other: at width 2048, dpr
+ * 2 and 8,140px reserved, the ceiling is 8,192, and the floor replaced the
+ * remaining 52px with 80 — an 8,220px canvas, past the very area limit the
+ * ceiling exists to hold. It defeated the fix it was sitting inside.
+ *
+ * ACTUAL POSITIVE HEADROOM, never more. Under one line's worth the band
+ * declines entirely rather than drawing something invalid, which is the same
+ * call `drawAttributionOverlay` makes at `capacity < 1`.
+ *
+ * The residual, stated rather than hidden: in that window the export carries no
+ * credit and no marker, because there is nowhere to put either. It is reachable
+ * only when the fixed blocks are within one band-height of the cap — for the
+ * 200-layer legend at dpr 2 on an iPad-sized canvas, the legend alone is past
+ * the ceiling before the band is measured. Such a canvas is at or over the cap
+ * whatever the band does, and the alternative is the one the ceiling was added
+ * to prevent: an image that cannot be encoded at all. Collapsing the band's own
+ * gaps would buy back a ~40px window; it is not worth threading a variable gap
+ * through the measure/draw pair for a window that narrow.
  */
 export function attributionBandHeightBudget(
   canvasWidth: number,
   reservedHeight: number,
-  dpr: number,
 ): number {
-  const headroom = exportCanvasHeightCeiling(canvasWidth) - Math.ceil(reservedHeight);
-  return Math.max(minimumBandHeight(dpr), headroom);
+  return Math.max(0, exportCanvasHeightCeiling(canvasWidth) - Math.ceil(reservedHeight));
 }
 
 /** How many credit lines fit a band budget of `maxHeight` device pixels, the

--- a/frontend/src/lib/map-image-attribution.ts
+++ b/frontend/src/lib/map-image-attribution.ts
@@ -61,6 +61,9 @@ export interface AttributionMapLike {
   /** The 3D terrain in effect, whose source renders with no style layer of its
    *  own. Public MapLibre API; see `shownSourceIds`. */
   getTerrain?: () => { source?: unknown } | null | undefined;
+  /** The current zoom, against which a layer's zoom range is judged. Also
+   *  public, also only used to order; see `shownSourceIds`. */
+  getZoom?: () => number | undefined;
 }
 
 function attributionFont(fontPx: number): string {
@@ -82,8 +85,8 @@ function attributionFont(fontPx: number): string {
  * the accessible alternatives a sighted user is reading:
  *
  *   text nodes        as written
- *   <img>             alt, else aria-label, else title, else a placeholder
- *   any element       its own text; if it has none, aria-label then title
+ *   <img>             aria-label, else alt, else title, else a placeholder
+ *   any element       its own text; if it has none, the same three attributes
  *   <br> and blocks   a visual break, so credits do not run together
  *
  * The generic element rule is what makes `<svg role="img" aria-label="…">`
@@ -115,10 +118,24 @@ const BLOCK_CREDIT_TAGS = new Set([
  *  the way a printable delimiter would. */
 const BREAK = '\u0000';
 
-/** The text alternative an assistive technology would announce for `el`, in
- *  the order the accessible name is computed from these three attributes. */
+/**
+ * The text alternative an assistive technology would announce for `el`.
+ *
+ * fix(#1541 codex P2 round 7): `aria-label` OVERRIDES `alt`, it does not follow
+ * it. The accessible name computation takes ARIA first, the host-language
+ * attribute second, `title` only as a fallback, and the realistic markup for a
+ * provider logo is exactly the case the old order got wrong:
+ * `<img alt="Provider logo" aria-label="© Provider 2026">` drew "Provider logo"
+ * into every exported image while the credit sat in the label.
+ *
+ * `aria-labelledby` outranks all three in the real algorithm and is NOT
+ * resolved here: it points at element ids, which for the string path would have
+ * to resolve inside a parsed fragment that has no document to resolve against.
+ * A credit that names itself only by id reference is unattested in practice,
+ * and it degrades to the `alt`/`title` it is layered over rather than vanishing.
+ */
 function textAlternative(el: Element): string | null {
-  for (const attr of ['alt', 'aria-label', 'title']) {
+  for (const attr of ['aria-label', 'alt', 'title']) {
     const value = el.getAttribute(attr);
     if (value !== null && value.trim()) return value;
   }
@@ -308,12 +325,12 @@ function dedupe(entries: string[]): string[] {
  * there is room — the over-crediting property is intact — and what the marker
  * elides first is now the hidden sources, which is the correct thing to lose.
  *
- * `shownSourceIds` is a deliberately coarse approximation of `used`, from
- * public signals: the terrain source plus every source referenced by a layer
- * that is not `visibility: none`. It ignores zoom ranges, so it over-reports.
- * That costs nothing, because the answer only ORDERS the list — a source it
- * gets wrong is mis-sorted, never dropped. See its own comment for why the
- * internal `used`/`usedForTerrain` flags are not read.
+ * `shownSourceIds` is an explicit approximation of `used`/`usedForTerrain` from
+ * public signals — layer visibility, layer zoom range, terrain — with the gaps
+ * it does not model named in its own comment rather than left to be discovered.
+ * Every one of them errs toward calling a source shown, which costs nothing:
+ * the answer only ORDERS the list, so a source it gets wrong is mis-sorted,
+ * never dropped.
  *
  * One cost of preferring (1), accepted:
  *
@@ -332,37 +349,75 @@ function dedupe(entries: string[]): string[] {
  */
 interface AttributionStyle {
   sources?: Record<string, { attribution?: string | null } | null>;
-  layers?: ({ source?: unknown; layout?: { visibility?: string } | null } | null)[];
+  layers?: ({
+    source?: unknown;
+    layout?: { visibility?: string } | null;
+    minzoom?: unknown;
+    maxzoom?: unknown;
+  } | null)[];
 }
 
 /**
- * Source ids that are rendering, from PUBLIC MapLibre signals: the terrain
- * source, plus every source a style layer references that is not
- * `visibility: none`.
+ * Source ids that are rendering. AN APPROXIMATION OF MAPLIBRE'S `used` /
+ * `usedForTerrain`, computed from public signals, and stated as one so the next
+ * gap in it is a known limit rather than a bug report.
  *
- * fix(#1541 codex P2 round 6): layer references alone missed the one kind of
- * source that renders without a layer. `ensureRasterDemTerrainSource`
- * (map-sync.ts) creates an attributed source with no layer and lets MapLibre
- * count it through `usedForTerrain`, so a 3D-terrain credit — for content
- * plainly visible in the image — sat in the hidden group and could lose its
- * slot to a credit for something invisible.
+ * The live flags are NOT reachable as public API. They live on the internal
+ * per-source cache reached through `map.style`, and the collection holding them
+ * is `Style.tileManagers` in maplibre-gl 5.24 where it was `sourceCaches`
+ * before — an internal name that has already been renamed once under us. So
+ * this recomputes them from what `getStyle()`, `getZoom()` and `getTerrain()`
+ * expose.
  *
- * Which signal, and why this one. MapLibre's own `used`/`usedForTerrain` is the
- * thing itself rather than a proxy, and it is NOT reachable as public API: the
- * flags live on the internal per-source cache, reached through `map.style`, and
- * the collection holding them is `Style.tileManagers` in maplibre-gl 5.24 where
- * it was `sourceCaches` before — an internal name that has already been renamed
- * once under us. Set against that, reading it buys nothing here. The answer
- * only ORDERS, so a signal can help only by marking a source shown, and every
- * source `used` marks is one a visible layer references, while every source
- * `usedForTerrain` marks is the one `getTerrain()` names. The internal flags
- * would differ only by DEMOTING a source whose layers are all out of the
- * current zoom range — the one direction that can cost a real credit its
- * place, in exchange for a dependency on a name that moves between versions.
+ * WHAT IT MODELS, which is MapLibre's own definition of the flag — "at least
+ * one of its layers becomes visible in style sense (inside the layer's zoom
+ * range and with layout.visibility set to 'visible')", and in the source
+ * `!layer.isHidden(zoom) && layer.source && tileManagers[layer.source].used =
+ * true`, where `isHidden` is `zoom < minzoom || zoom >= maxzoom || visibility
+ * === 'none'`:
  *
- * So this over-reports (it ignores zoom ranges) and that is the safe way to be
- * wrong: a source it misjudges is mis-sorted, never dropped.
+ *   - `layout.visibility` (fix(#1541 codex P1))
+ *   - the layer's zoom range (fix(#1541 codex P2 round 7)), with MapLibre's own
+ *     boundary semantics: minzoom inclusive, maxzoom exclusive, and a zero
+ *     treated as absent exactly as its truthiness test does. Read from the
+ *     serialized `minzoom`/`maxzoom`, not the builder-private
+ *     `_minzoom`/`_maxzoom`, which `stripPrivateLayoutKeys` removes before
+ *     MapLibre sees them and which reach the style through `setLayerZoomRange`.
+ *   - terrain (fix(#1541 codex P2 round 6)), whose source renders with NO style
+ *     layer at all: `ensureRasterDemTerrainSource` creates an attributed source
+ *     that only `usedForTerrain` counts, so layer references alone put a credit
+ *     for plainly visible 3D relief in the hidden group.
+ *
+ * WHAT IT DOES NOT MODEL. Neither does `used` — these make a source render
+ * nothing while MapLibre still counts it used, so reading the live flag would
+ * not close them either:
+ *
+ *   - a layer `filter` that matches no feature
+ *   - zero opacity, or paint that renders invisibly
+ *   - tiles that are empty, absent, or outside the viewport
+ *
+ * And two that are ours alone:
+ *
+ *   - anything not in the serialized style, since `getStyle()` is the input
+ *   - timing: MapLibre recomputes per frame, this reads once at capture
+ *
+ * Every one of those errs toward calling a source SHOWN, which is the safe way
+ * to be wrong: the answer only ORDERS the credit list, so a source it misjudges
+ * is mis-sorted, never dropped.
  */
+function layerHiddenAtZoom(
+  layer: { minzoom?: unknown; maxzoom?: unknown },
+  zoom: number | undefined,
+): boolean {
+  if (typeof zoom !== 'number' || !Number.isFinite(zoom)) return false;
+  const { minzoom, maxzoom } = layer;
+  // The `&&` mirrors MapLibre's own truthiness test, under which a zero bound
+  // is no bound at all.
+  if (typeof minzoom === 'number' && minzoom && zoom < minzoom) return true;
+  if (typeof maxzoom === 'number' && maxzoom && zoom >= maxzoom) return true;
+  return false;
+}
+
 function shownSourceIds(
   map: AttributionMapLike,
   style: AttributionStyle | null | undefined,
@@ -370,8 +425,11 @@ function shownSourceIds(
   const shown = new Set<string>();
   const terrainSource = map.getTerrain?.()?.source;
   if (typeof terrainSource === 'string') shown.add(terrainSource);
+  // Absent `getZoom` leaves every layer in range, per the over-report rule.
+  const zoom = map.getZoom?.();
   for (const layer of style?.layers ?? []) {
     if (!layer || layer.layout?.visibility === 'none') continue;
+    if (layerHiddenAtZoom(layer, zoom)) continue;
     if (typeof layer.source === 'string') shown.add(layer.source);
   }
   return shown;

--- a/frontend/src/lib/map-image-attribution.ts
+++ b/frontend/src/lib/map-image-attribution.ts
@@ -128,9 +128,15 @@ function dedupe(entries: string[]): string[] {
  *  - The `used` gating. MapLibre hides a source whose layers are all hidden and
  *    the source list does not, so the image may credit a source the screen does
  *    not. Over-crediting is the safe direction.
- *  - MapLibre's own "MapLibre" self-credit is a control default rather than a
- *    source, so it is not in the list and does not reach the image. It is
- *    library branding, not a data credit, and no data licence turns on it.
+ *  - MapLibre's own "MapLibre" self-credit does not reach the image. It is a
+ *    control default rather than a source, so no structured list contains it,
+ *    and it was DECIDED on #1541 review that it should stay out rather than be
+ *    hardcoded back in: MapLibre GL JS is BSD-3-Clause, which requires its
+ *    notice in source and binary distributions, not in rendered output, so no
+ *    licence obligation turns on its presence in an exported PNG. Putting it
+ *    back would mean reintroducing the hardcoded vendor string this module
+ *    exists to remove, to satisfy an obligation that does not exist. The
+ *    interactive map still shows it — the control default is untouched.
  *
  * Both are the price of a credit list that cannot be mangled by its own
  * content, which is the property the whole marker count rests on.

--- a/frontend/src/lib/map-image-attribution.ts
+++ b/frontend/src/lib/map-image-attribution.ts
@@ -37,6 +37,9 @@
  * `textContent` is post-parse so entities and anchors are already resolved.
  */
 import { MAP_COLORS } from '@/lib/map-colors';
+// Canvas drawing happens outside React, so the overflow marker is translated
+// through the i18n singleton. Same pattern as api/client.ts's error strings.
+import i18n from '@/i18n/i18n';
 
 /** The separator MapLibre's AttributionControl joins entries with. */
 const SEPARATOR = ' | ';
@@ -172,13 +175,23 @@ export function readRenderedAttribution(map: AttributionMapLike): string[] {
  * The export has no ceiling at all: its canvas is sized AFTER the band is
  * measured, so the band's height is an input to the image rather than a budget
  * inside it. Only the two crops have one, and it is where the scrim reaches the
- * top edge — the band has by then eaten every map pixel there is. Past it no
- * layout at 10px can place the remaining lines, so they fall off the bottom.
+ * top edge — the band has by then eaten every map pixel there is.
+ *
  * That ceiling is ~3.3x the measured real-world credit load for the thumbnail
- * (411 characters across five providers) and ~10x for the OG card, and no
- * basemap-plus-dataset stack comes near it. It is still a limit rather than a
- * promise, so `drawAttributionOverlay` warns in DEV naming the lines it cannot
- * place. A credit that cannot be shown is at least never lost quietly.
+ * (411 characters across five providers) and ~10x for the OG card. But the
+ * SUPPORTED input is far larger: `attribution` is `max_length=5000` on the
+ * dataset schema and `NonEmptyString5000` on the manifest, and 5,000 characters
+ * is roughly 77 lines in a 250px-tall thumbnail. No font size anyone would call
+ * legible renders that, so at the contract's maximum something must give.
+ *
+ * What gives is neither the frame nor silence. Past the ceiling the overlay
+ * renders the credits that fit and appends a visible, counted marker naming how
+ * many did not (`export.moreCredits`), with the marker itself charged against
+ * the line budget. The standard is that no output may SILENTLY drop a credit; a
+ * marker inside the frame is not silent, and it stops the visible list reading
+ * as a complete statement of provenance. Nothing is ever drawn outside the
+ * canvas — an earlier revision kept calling `fillText` below the frame, which
+ * painted credits into nowhere.
  *
  * The one residual limit within the ceiling: a single credit longer than a full
  * line wraps MID-STRING, on word boundaries, and on characters for a word that
@@ -353,6 +366,42 @@ export function overlayLineCapacity(
   return Math.max(0, Math.floor(usable / spec.lineHeight));
 }
 
+/**
+ * The largest number of LEADING entries whose wrapped form fits `maxLines`,
+ * with the lines it produced.
+ *
+ * Binary search rather than a scan: line count is monotonic non-decreasing in
+ * the entry count, and the supported input is 5,000 characters per credit, so
+ * a linear probe would re-wrap a very large string once per entry.
+ */
+function fitEntryPrefix(
+  ctx: CanvasRenderingContext2D,
+  entries: string[],
+  maxWidth: number,
+  maxLines: number,
+): { lines: string[]; count: number } {
+  if (maxLines <= 0) return { lines: [], count: 0 };
+  const wrapFirst = (count: number): string[] => {
+    if (count === 0) return [];
+    const slice = entries.slice(0, count);
+    return wrapEntries(ctx, slice, maxWidth) ?? wrapWords(ctx, slice.join(SEPARATOR), maxWidth);
+  };
+  let best: { lines: string[]; count: number } = { lines: [], count: 0 };
+  let lo = 0;
+  let hi = entries.length;
+  while (lo <= hi) {
+    const mid = Math.floor((lo + hi) / 2);
+    const lines = wrapFirst(mid);
+    if (lines.length <= maxLines) {
+      best = { lines, count: mid };
+      lo = mid + 1;
+    } else {
+      hi = mid - 1;
+    }
+  }
+  return best;
+}
+
 /** Rounded scrim, falling back to a square fill where `roundRect` is absent
  *  (older engines, and the 2D-context stubs the hook tests use). */
 function fillScrim(
@@ -404,28 +453,43 @@ export function drawAttributionOverlay(
   if (!ctx) return false;
 
   const maxWidth = canvas.width - spec.inset * 2 - spec.paddingX * 2;
-  const fitted = fitAttributionText(ctx, entries, { maxWidth, fontPx: spec.fontPx });
+  const capacity = overlayLineCapacity(spec, canvas.height);
+  // Nowhere legible to put even one line. Drawing anyway would paint outside
+  // the frame, which is the one thing this function must never do.
+  if (maxWidth <= 0 || capacity < 1) return false;
+
+  // Deduped here as well as inside the fitter, because the overflow marker
+  // counts CREDITS and must not count the same one twice.
+  const credits = dedupe(entries);
+  const fitted = fitAttributionText(ctx, credits, { maxWidth, fontPx: spec.fontPx });
   if (fitted.lines.length === 0) return false;
 
-  // fix(#1541 codex P1): removing the fitter's elision moved the only remaining
-  // way to lose a credit out here, to the frame edge — `boxY` clamps at 0, so a
-  // band taller than the image draws its last lines off the bottom. Geometry,
-  // not policy: at 10px there is no layout that fits them. Say so instead of
-  // letting it happen quietly. See the capacity table in this module's header.
-  const capacity = overlayLineCapacity(spec, canvas.height);
-  if (import.meta.env.DEV && fitted.lines.length > capacity) {
-    console.warn(
-      `[attribution] ${fitted.lines.length - capacity} of ${fitted.lines.length} credit lines do not fit a ${canvas.width}x${canvas.height} image at ${spec.fontPx}px and will be clipped`,
-    );
+  // fix(#1541 codex P1 round 2): removing the fitter's elision left one way to
+  // lose a credit — `boxY` clamps at 0, so a band taller than the frame kept
+  // calling fillText below the canvas and painted into nowhere. A DEV warning
+  // did not cover it: production is exactly where it mattered.
+  //
+  // The supported input is 5,000 characters per credit (dataset schemas.py and
+  // manifest_schemas.py), which is ~77 lines in a 250px-tall thumbnail. No font
+  // size anyone would call legible renders that, so something must give and it
+  // is not the frame. Render what fits and say what did not, inside the frame,
+  // with the marker itself counted against the line budget. Not silent, and
+  // never a claim that the visible credits are the whole set.
+  let lines = fitted.lines;
+  let omitted = 0;
+  if (fitted.lines.length > capacity) {
+    const kept = fitEntryPrefix(ctx, credits, maxWidth, capacity - 1);
+    omitted = credits.length - kept.count;
+    lines = [...kept.lines, i18n.t('builder:export.moreCredits', { count: omitted })];
   }
 
   ctx.font = attributionFont(fitted.fontPx);
-  const textWidth = fitted.lines.reduce(
+  const textWidth = lines.reduce(
     (widest, line) => Math.max(widest, ctx.measureText(line).width),
     0,
   );
   const boxW = textWidth + spec.paddingX * 2;
-  const boxH = fitted.lines.length * spec.lineHeight + spec.paddingY * 2;
+  const boxH = lines.length * spec.lineHeight + spec.paddingY * 2;
   const boxX = Math.max(0, canvas.width - spec.inset - boxW);
   const boxY = Math.max(0, canvas.height - spec.inset - boxH);
 
@@ -435,7 +499,7 @@ export function drawAttributionOverlay(
   ctx.fillStyle = MAP_COLORS.exportImage.text;
   ctx.textBaseline = 'top';
   ctx.textAlign = 'left';
-  fitted.lines.forEach((line, i) => {
+  lines.forEach((line, i) => {
     ctx.fillText(line, boxX + spec.paddingX, boxY + spec.paddingY + i * spec.lineHeight);
   });
   return true;

--- a/frontend/src/lib/map-image-attribution.ts
+++ b/frontend/src/lib/map-image-attribution.ts
@@ -87,9 +87,11 @@ function attributionFont(fontPx: number): string {
  * work without naming SVG anywhere, and `<svg><title>…</title></svg>` already
  * worked because a <title> element IS DOM text.
  *
- * `alt=""` is honoured as its author meant it: an explicitly decorative image
- * contributes nothing and gets no placeholder. That is the one case where an
- * image yields no credit by design rather than by accident.
+ * `alt=""` is honoured as its author meant it — but LAST, after the other two
+ * alternatives, because alt="" means decorative only when nothing else names
+ * the image. `<img alt="" aria-label="© Provider">` has an accessible name and
+ * is a credit. And a source whose WHOLE attribution reduces to nothing that
+ * way is still a declared credit; see `declaredCreditText`.
  *
  * Whichever reader is in play, the parse stays inert. DOMParser documents run
  * no script and fetch no image or iframe, which `el.innerHTML = s` cannot
@@ -152,9 +154,18 @@ function collectCreditText(node: Node): string {
   const isImage =
     tag === 'IMG' || (tag === 'INPUT' && el.getAttribute('type')?.toLowerCase() === 'image');
   if (isImage) {
-    // A decorative image says so with alt="", and is not a credit.
+    // fix(#1541 codex P2 round 4): alternatives FIRST. The decorative shortcut
+    // used to run ahead of them, so `<img alt="" aria-label="© Provider">` was
+    // suppressed even though the ARIA label gives it an accessible name and
+    // MapLibre renders the logo. alt="" means decorative only when nothing
+    // else names the image — that is the accessibility rule, and a shortcut
+    // that runs before the thing it is a shortcut for is just a bug.
+    const alternative = textAlternative(el);
+    if (alternative) return alternative;
+    // Nothing names it. An author who wrote alt="" said "not content"; one who
+    // omitted alt said nothing at all, and gets the placeholder.
     if (el.getAttribute('alt')?.trim() === '') return '';
-    return textAlternative(el) ?? unnamedImageCredit(el);
+    return unnamedImageCredit(el);
   }
 
   let inner = '';
@@ -178,11 +189,37 @@ function normalizeCreditText(raw: string): string {
     .join(SEPARATOR);
 }
 
+/**
+ * Credit text for a node whose owner DECLARED an attribution.
+ *
+ * fix(#1541 codex P2 round 4): honouring alt="" opened the gap beside it. A
+ * source whose entire attribution is a lone decorative image derives no text,
+ * and an empty derivation used to drop the source from the list — so it was
+ * counted nowhere, marker included, which is the silent loss this module
+ * exists to prevent. Empty text with an image present is an UN-NAMEABLE
+ * credit, not an absent one: it gets the same host-derived placeholder an
+ * image with no alternative gets, which both renders it and makes it one of
+ * the `credits.length` the overflow marker counts.
+ *
+ * A declaration that derives no text and contains no image is genuinely empty
+ * (`'   '`, `<div></div>`) and still contributes nothing. Nothing was declared
+ * to lose.
+ *
+ * Note the layering: within a credit, alt="" still contributes nothing —
+ * `© Provider <img alt="">` is "© Provider", not "© Provider (image credit)".
+ * The placeholder is a SOURCE-level floor, not a per-image one.
+ */
+function declaredCreditText(root: Element): string {
+  const text = normalizeCreditText(collectCreditText(root));
+  if (text) return text;
+  const image = root.querySelector?.('img, input[type="image"]');
+  return image ? unnamedImageCredit(image) : '';
+}
+
 /** Credit text for an editor-supplied HTML string, parsed inertly. */
 function decodeHtmlText(raw: string): string {
   try {
-    const doc = new DOMParser().parseFromString(raw, 'text/html');
-    return normalizeCreditText(collectCreditText(doc.body));
+    return declaredCreditText(new DOMParser().parseFromString(raw, 'text/html').body);
   } catch {
     return raw.trim();
   }
@@ -193,7 +230,7 @@ function decodeHtmlText(raw: string): string {
  *  goes missing from exactly one of the two ways it can be read. */
 function elementCreditText(el: Element): string {
   try {
-    return normalizeCreditText(collectCreditText(el));
+    return declaredCreditText(el);
   } catch {
     return el.textContent?.trim() ?? '';
   }
@@ -349,7 +386,7 @@ export function readRenderedAttribution(map: AttributionMapLike): string[] {
  *               height  width     line     load             (band runs out)
  *   Thumbnail   13px    378px     ~75      6 lines, 33.6%   18 lines, ~1350 chars
  *   OG card     20px    1160px    ~145     4 lines, 14.3%   30 lines, ~4350 chars
- *   PNG export  16px    1016px*   ~169     4 lines, 88px    983 lines, ~166k chars
+ *   PNG export  16px    1016px*   ~169     4 lines, 88px    951 lines, ~161k chars
  *
  *   * the measured 1056px-wide export at dpr 1, less 20px of pad a side.
  *
@@ -745,28 +782,37 @@ const BAND_GAP = 12;
  * A bounded band with a counted marker loses some provider names; an
  * unencodable canvas loses every one of them along with the map.
  *
- * The figures below are the smallest limits for a DESKTOP engine in
- * canvas-size's measured table (jhildenbiddle/canvas-size, src/test-sizes.js),
- * which is the only published per-engine measurement of these limits:
+ * The figures are the SMALLEST measured for any engine in canvas-size's table
+ * (jhildenbiddle/canvas-size, src/test-sizes.js), the only published per-engine
+ * measurement of these limits:
  *
  *   per side  Chrome 83 65,535 · Chrome 70 and Firefox 63 32,767 · Edge 17 and
  *             IE 11 16,384. We take 16,384: half the floor of any engine this
  *             app supports, and the only browsers that ever enforced it are
  *             retired, so the margin is free.
  *   area      Chrome 70 / Edge 17 / Safari 7-12 (Mac) 16,384² = 268,435,456 ·
- *             Firefox 63 11,180² = 124,992,400. We take Firefox's, the
- *             smallest desktop area measured.
+ *             Firefox 63 11,180² = 124,992,400 · Safari on iOS 4,096² =
+ *             16,777,216. We take iOS Safari's.
  *
- * Safari on iOS is smaller again (4,096² = 16,777,216) and is deliberately NOT
- * the figure used. A retina desktop map canvas alone already exceeds it, so
- * adopting it would delete credits from exports that work today without making
- * any iOS export work. What is bounded here is the band's CONTRIBUTION: it can
- * never be the term that makes the canvas unencodable. A map canvas already
- * past an engine's limit on its own is a different constraint, and not one that
- * credit growth caused or can fix.
+ * fix(#1541 codex P2 round 4): iOS Safari's is deliberately conservative, and
+ * an earlier revision of this comment named it and then budgeted against the
+ * desktop figure anyway. That is a bound that holds only where it was measured:
+ * an iPad's 2048x2732 canvas is valid and exports today, and enough supported
+ * credits grew it past 8,192px high, `toBlob` returned null, and the credit
+ * band broke the very export it was added to. A bound is worth only the worst
+ * environment it has to hold in. We do not probe the engine's real capability
+ * and we never sniff the user agent, so the cap is the floor of what every
+ * supported engine can do.
+ *
+ * What it costs a desktop export: nothing until the MAP canvas alone is around
+ * 4,096x4,096 device pixels. The measured 1056px-wide export still gets 951
+ * lines of band; a 4400x2400 canvas (a maximized builder on a 5K display at
+ * dpr 2) still gets 41. Past that the fixed blocks have spent the whole
+ * ceiling, and the band falls to the one-line floor below rather than to
+ * nothing — see `attributionBandHeightBudget`.
  */
 export const EXPORT_CANVAS_MAX_DIMENSION = 16_384;
-export const EXPORT_CANVAS_MAX_AREA = 124_992_400;
+export const EXPORT_CANVAS_MAX_AREA = 16_777_216;
 
 /** The tallest export canvas a browser will still encode at `canvasWidth`,
  *  in device pixels. Area-limited for a very wide canvas, side-limited for the
@@ -779,21 +825,32 @@ export function exportCanvasHeightCeiling(canvasWidth: number): number {
   );
 }
 
+/** One line of band, gaps included: the least height that can carry a credit
+ *  or the marker that counts the ones it could not. */
+function minimumBandHeight(dpr: number): number {
+  return (BAND_GAP * 2 + BAND_LINE_HEIGHT) * (dpr || 1);
+}
+
 /**
  * How much of that ceiling is left for the band once the fixed blocks (title,
  * map, legend, footer) have taken theirs. The band is the only elastic term in
  * the export's height, so it absorbs the whole clamp.
  *
- * Zero when the rest of the image has already spent the ceiling. That is not a
- * silent credit drop: such a canvas cannot be encoded whatever the band does,
- * so the export fails visibly and the user is told, which is the same outcome
- * they would get from a band-free export at that size.
+ * Floored at one line rather than at zero. The fixed blocks can spend the whole
+ * conservative ceiling on their own — a map canvas past ~4,096x4,096 does it —
+ * and that canvas is over the cap with or without a band, so suppressing the
+ * credit there would trade a licensing obligation for nothing. One line plus
+ * the marker still says what the image is crediting and how much it is not.
+ * The property that matters is preserved either way: the band is never the term
+ * that pushes an otherwise-encodable canvas over.
  */
 export function attributionBandHeightBudget(
   canvasWidth: number,
   reservedHeight: number,
+  dpr: number,
 ): number {
-  return Math.max(0, exportCanvasHeightCeiling(canvasWidth) - Math.ceil(reservedHeight));
+  const headroom = exportCanvasHeightCeiling(canvasWidth) - Math.ceil(reservedHeight);
+  return Math.max(minimumBandHeight(dpr), headroom);
 }
 
 /** How many credit lines fit a band budget of `maxHeight` device pixels, the


### PR DESCRIPTION
Closes #1486

No image this product renders carried any attribution: not the datasets', and not the basemap's, which is a licensing obligation in its own right.

## Why it needed a canvas draw

All three capture paths composite from `map.getCanvas()`, a flat WebGL fill. MapLibre's own attribution control is a DOM overlay, so it is invisible to every one of them by construction. Wiring up the control would look perfect in the browser and change nothing in the files. Everything here is drawn into the canvas instead.

## Where the text comes from

`readRenderedAttribution` reads the credit off MapLibre's rendered control as text, with a tiered fallback:

1. `.maplibregl-ctrl-attrib-inner` textContent, split on MapLibre's own ` | `.
2. The union of `getStyle().sources[*].attribution`, entity-decoded through an inert `DOMParser`.
3. Nothing, with a DEV warning.

Reading the control, rather than composing `BasemapEntry.attribution` with `collectLayerAttributions`, for three reasons that hold specifically in the builder:

- `toMaplibreStyle` only threads `attribution` onto the source for XYZ tile URLs. A `/styles/` or `.json` basemap is returned unchanged and MapLibre reads the remote style's own per-source attribution, so the stored field is never what the screen shows, and most shipped presets are style URLs. Composing from it would put a string in the PNG that differs from the one on screen.
- `collectLayerAttributions` returns HTML-escaped strings, because they are bound for `innerHTML`. `fillText` draws literally, so "Rand & McNally" would export as `Rand &amp; McNally`.
- It is keyed on the viewer's `visibleLayers` set, which the builder deliberately does not maintain. `map-sync.ts` feeds dataset credits through MapLibre's source-level `attribution` and lets MapLibre gate them on the live `used` flag.

Tier 2 loses only the `used` gating, so its failure mode is over-crediting a hidden source rather than dropping a credit.

Measured on the dev stack rather than argued. Three of the four configured basemaps (`openfreemap-positron`, `-dark`, `-bright`) are `/styles/` URLs, so their stored `attribution` is never what MapLibre renders. And the stored value is raw HTML:

```
"&copy; <a href='https://openfreemap.org'>OpenFreeMap</a>, &copy; <a href='https://openmaptiles.org/'>OpenMapTiles</a>, &copy; <a href='https://www.openstreetmap.org/copyright'>OpenStreetMap</a> contributors"
```

`fillText` would have drawn that string literally, angle brackets and all. On the map used for the evidence below, `basemap_config` is null and all four layers have `dataset_attribution: null`, so the issue's suggested pair of sources would have produced an empty credit line while the screen showed a real one.

## Overlap and length: no output drops a credit

The two sources cannot disagree, because both arrive through the same control MapLibre has already merged, deduped and substring-collapsed. What is left is length.

**Codex raised two P1s here and both are fixed.** The first revision eliminated credits: the export band passed a two-line budget into the fitter while its own docstring promised never to drop one, and the two crops passed `maxLines: 1`. Measured on a real export before the fix, a five-credit map rendered three providers and an ellipsis. The two it dropped included the basemap's own `OpenFreeMap © OpenMapTiles Data from OpenStreetMap` line, which is the obligation this feature exists to satisfy.

The elision path is now gone rather than bounded more generously, because any finite bound recreates the same defect at a larger credit count. Text wraps to as many lines as it needs:

- PNG export: the canvas grows. Its height is computed after the band is measured, so the band is an input to the image rather than a budget inside it.
- OG 1200x630 and thumbnail 400x250: the frame is fixed, so the band spends map pixels instead of provider names. The image is fixed; the band inside it is not.

The shrink ladder is gone too. It traded legibility for area, and now that spending area is allowed the trade runs the wrong way. Every output renders at one documented size and never below it: 12px export, 16px OG, 10px thumbnail.

**Which outputs can still lose a credit: none, silently.** Codex's round-2 P1 found two more things, both real. Clamping `boxY` to zero stopped the scrim leaving the frame but not `fillText`, so past capacity credits were painted *outside the canvas*. And the ceiling was documented against the observed load of 411 characters when the supported input is **5,000 characters per credit** (`datasets/domain/schemas.py`, `processing/ingest/manifest_schemas.py`), roughly 77 lines in a 250px frame.

Measured live at the schema maximum on the old head. The overlay's own DEV warning quantified it:

```
[attribution] 198 of 216 credit lines do not fit a 400x250 image at 10px and will be clipped
[attribution]  71 of 101 credit lines do not fit a 1200x630 image at 16px and will be clipped
```

216 `fillText` calls into an 18-line frame. And the part that is easy to miss from the code: the 18 lines that *did* land covered the map edge to edge, so the output was neither a map nor a usable credit line. The framing "credits get dropped" undersells it — the artifact was destroyed.

Now: nothing is ever drawn outside the canvas, and past capacity the overlay renders what fits and appends a visible counted marker (`+N more credits`) charged against the line budget. Entries are fitted as a prefix, so short real credits survive and only pathological ones are counted. At 5,000 characters a credit the thumbnail renders `MapLibre | OpenFreeMap © OpenMapTiles Data from OpenStreetMap` in full and marks `+3 more credits`. The PNG export never reaches the marker — its canvas grew to 89 lines on the same input.

| output | line height | usable width | real 5-credit load | ceiling | past the ceiling |
|---|---|---|---|---|---|
| thumbnail 400x250 | 13px | 378px | 6 lines, 33.6% of frame | 18 lines | counted marker |
| OG card 1200x630 | 20px | 1160px | 4 lines, 14.3% of frame | 30 lines | counted marker |
| PNG export | 16px | 1016px | 3 lines, 72px | none, canvas grows | never reached |

Tests assert the invariant at the contract's maximum rather than the observed load: nothing outside the canvas, and rendered plus marked equals the input count. One new `t()` key, `export.moreCredits`, with `_one`/`_other` in all four locales.

**The credit list is never re-derived from a joined string.** ` | ` is legal content inside a 5,000-character credit, so splitting MapLibre's rendered control text cut credits in half: `© Acme | © Acme` became two identical fragments that the dedupe collapsed into one, and the marker counted fragments rather than credits. The credits are now read as a list from the sources and never split on anything; where only a joined string exists, it is taken as one opaque entry rather than guessed apart.

That took two attempts, and the first was wrong in a way only a live capture caught. Reading `getStyle().sources[*].attribution` **dropped every basemap credit whenever a dataset declared one**, while looking perfectly correct on a basemap-only map (with no structured credits it fell through to the control fallback and rendered identically). Measured against the shipped OpenFreeMap basemap:

| source | serialized spec | live source |
|---|---|---|
| `openmaptiles` | `null` | `…OpenFreeMap… © OpenMapTiles… OpenStreetMap` |
| `source-data-…` | the credit | the credit |

A vector source loaded from a TileJSON `url` receives its attribution in that response, and `getStyle()` serializes the spec as authored. So the reader uses `getSource(id).attribution`, with the serialized spec as the fallback for a source the map has not instantiated.

**Wrapping is grapheme-safe.** The binary search and slices indexed UTF-16 code units, so breaking a long unspaced credit could split a surrogate pair across two drawn lines and render replacement glyphs where a provider's name belongs. `Intl.Segmenter` keeps combining marks and ZWJ sequences whole as well; `Array.from` is the fallback for an engine without it. Wrapping mid-string is allowed, mid-character never is.

Two costs, both documented in the module: the source list has no `used` gating, so a hidden source may be over-credited (the safe direction), and MapLibre's own self-credit is a control default rather than a source, so it no longer reaches the image — library branding, not a data credit.

The one residual limit within the ceiling: a single credit longer than a full line wraps mid-string, on word boundaries and then on characters. That splits a provider's name across lines, which is complete and legible. It never truncates one.

Cost of the decision, measured: a basemap-only map, the common case, is one line and unchanged. The credit block grows from 7% to 34% of the thumbnail and 5% to 14% of the OG card only on the pathological five-long-credit map.

## `showBranding: false`

`showBranding` is `!isEnterprise`, and it gates the "Powered by GeoLens" footer only. The attribution band sits outside it. Using a separate band rather than sharing the footer row is what makes that fall out for free instead of needing a special case.

## Verification

Driven through the real builder served by this branch's Vite on `:5174`, with the API proxied to the dev stack, then inspected as pixels. The PNG came off the browser's download event. The two JPEGs were lifted out of the intercepted upload bodies and decoded, so they are the bytes that would have been stored.

Basemap only (the shipped Positron style):

| path | before | after |
|---|---|---|
| `export.png` | 1056x1042, legend plus "Powered by GeoLens", no credit | 1056x1082, credit band reading `MapLibre \| OpenFreeMap © OpenMapTiles Data from OpenStreetMap` |
| `og.jpg` 1200x630 | bare map pixels bottom-right, 1.8% near-white in the scrim band | the same line on a scrim, 78.6% near-white |
| `thumbnail.jpg` 400x250 | bare map pixels, 4.1% near-white | the same line on a scrim, 75.1% near-white |

With dataset credits merged in (`dataset_attribution` stamped onto the map response, so no shared database state was touched), the control read `© NOAA ETOPO 2022 | © swisstopo swissALTI3D | MapLibre | OpenFreeMap © OpenMapTiles Data from OpenStreetMap`. The export band carried it whole, the OG card shrank to fit it whole, and the thumbnail elided to `© NOAA ETOPO 2022 | © swisstopo swissALTI3D | MapLibre | …` with no provider name cut.

Forcing `edition: enterprise` produced a 1056x1050 export: 40px of attribution band added, 32px of branding footer gone, credit intact.

Tests: `lib/__tests__/map-image-attribution.test.ts` covers the reader tiers, the entity decode, the wrap contract and the documented ceilings; the hook suite asserts the credit reached each canvas. Every one was broken on purpose to confirm it bites. Dropping the thumbnail overlay, dropping the export band, and wrapping the band in `if (showBranding)` each fail a different, specific test. Reinstating the two-line bound fails exactly the two credit-loss tests and nothing else.

One note on method: the export suite's stub `measureText` used to return a constant 120px, which makes every string fit on one line and so cannot exercise wrapping at all. That is how the dropped credits went unseen at this level. It is now length-proportional.

Zero new `t()` keys, so no locale work. The separator is MapLibre's own and already inside the text, the ellipsis is punctuation with no variance across en/es/fr/de, and the line is self-describing so it needs no label prefix. `npm run test:i18n` confirms.

## Gates

`npm run build`, `lint`, `typecheck`, `test:coverage` (5059 tests, 403 files) and `test:i18n` all exit 0.

If `npm run build` reports type errors that `npm run typecheck` does not, delete `frontend/tsconfig.*.tsbuildinfo` and rerun: `tsc -b` reused a stale incremental cache across the type-shape change here and reported errors against the previous shape.

## Notes

- `MAP_COLORS.exportImage.attribution` is renamed to `.branding`, which is what its one call site paints. Real attribution uses `mutedText` instead, since `#999999` on white is about 2.8:1 and that is not a contrast to reuse for a licence-required line.
- MapLibre's own `MapLibre` self-credit appears in the line because the builder's control shows it. The image and the screen should say the same thing, so it stays. MapLibre ships that self-credit in its own attribution control by design.
- Not retroactive. Thumbnails and OG images already in object storage stay uncredited until their map is next saved.
- No e2e assertion for the `.maplibregl-ctrl-attrib-inner` selector. It is a real coupling, but tier 2 degrades to over-crediting rather than to nothing, and adding a spec here would mean running the shared-stack auth setup while nine other agents hold the same admin session.
