### PR TITLE
fix(settings): evict a settings batch's cache keys as one step

### DIFF
--- a/backend/app/core/persistent_config.py
+++ b/backend/app/core/persistent_config.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import logging
 import time
 import uuid
+from collections.abc import Sequence
 from typing import Any, Generic, TypeVar, cast
 
 import structlog
@@ -269,15 +270,20 @@ class PersistentConfig(Generic[T]):
     async def apply_side_effects(self, value: T) -> None:
         """Post-commit cache invalidation + runtime hooks for a value change.
 
-        Called automatically by set()/reset() when they own the commit; callers
-        batching with ``commit=False`` invoke this per key AFTER their terminal
-        commit (fix #430 codex r3 — never before, see set() above).
+        Called automatically by set()/reset() when they own the commit. A caller
+        batching with ``commit=False`` must NOT loop over this per key — use
+        ``apply_side_effects_batch`` after its terminal commit, which evicts the
+        whole batch in one step (fix #1543) and never before the commit
+        (fix #430 codex r3, see set() above).
         """
-        # Invalidate cache
-        cache = _get_cache_safe()
-        if cache is not None:
-            await cache.delete(f"{_CACHE_PREFIX}{self.key}")
+        await apply_side_effects_batch([(self, value)])
 
+    def _apply_local_side_effects(self, value: T) -> None:
+        """The process-local half of apply_side_effects.
+
+        Deliberately synchronous: this runs once per key of a batch, and having
+        no await in it is what keeps a whole batch's worth uninterleavable.
+        """
         # BUG-025: the public-URL keys are also memoized in a separate 60s
         # module cache in public_urls. Clear it so the new value is reflected
         # immediately (PUT response, tile-config, OGC self-links, share links).
@@ -361,6 +367,51 @@ class PersistentConfig(Generic[T]):
             "basemap_proxy_rate_limit",
         ):
             _sync_rate_limit_cache[self.key] = (value, time.monotonic())
+
+
+# ---------------------------------------------------------------------------
+# Batched post-commit side effects
+# ---------------------------------------------------------------------------
+
+
+async def apply_side_effects_batch(
+    items: Sequence[tuple[PersistentConfig[Any], Any]],
+) -> None:
+    """Apply the post-commit side effects of a whole settings batch at once.
+
+    fix(#1543): the per-key loop this replaces evicted ``config:`` entries one
+    at a time. Between the first and last eviction the cache held the new value
+    for the keys already evicted (``get`` falls through to the committed row)
+    and the old value for the rest, so a concurrent reader could resolve a pair
+    of settings that was never committed together — the embedding
+    model/dimensions pair being the case that surfaced it. One ``delete_many``
+    collapses that span to nothing: a single variadic ``DEL`` on Valkey, an
+    await-free loop of pops in memory.
+
+    Ordering the deletes differently is not a fix (it mismatches the other way)
+    and evicting before the commit is worse (a concurrent reader repopulates
+    the cache with the pre-commit value, which then survives its full TTL
+    instead of being transient). Hence: commit first, then evict, as one step.
+
+    Everything after the eviction is synchronous by construction — see
+    ``_apply_local_side_effects``.
+
+    Scope, stated plainly: this makes the WRITER atomic. It does not make a
+    reader atomic. Callers that resolve two keys with two ``get`` calls take
+    their samples at two different instants and can still straddle this whole
+    step, seeing one key's committed-new value and another's cached-old one.
+    Closing that needs the reader to resolve the set in one operation;
+    ``get_uncached`` is the per-key opt-out available today (#1539).
+    """
+    if not items:
+        return
+
+    cache = _get_cache_safe()
+    if cache is not None:
+        await cache.delete_many(*(f"{_CACHE_PREFIX}{cfg.key}" for cfg, _ in items))
+
+    for cfg, value in items:
+        cfg._apply_local_side_effects(value)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/app/core/persistent_config.py
+++ b/backend/app/core/persistent_config.py
@@ -402,6 +402,17 @@ async def apply_side_effects_batch(
     step, seeing one key's committed-new value and another's cached-old one.
     Closing that needs the reader to resolve the set in one operation;
     ``get_uncached`` is the per-key opt-out available today (#1539).
+
+    That distinction decides what this function does for #1539's residue. The
+    backfill gate reads model and dimensions uncached but takes its endpoint
+    from ``EmbeddingProviderExtension.resolve_runtime_config``, which has no
+    uncached variant, so the endpoint stays cached. What is fixed here is the
+    eviction span: a PUT changing ``embedding_base_url`` beside
+    ``embedding_model`` no longer serves a base URL the writer has committed
+    past. The larger exposure is untouched and is not an eviction problem —
+    an uncached read is always current while a cached one may lag it by a full
+    ``_CACHE_TTL``, however atomically the entry was evicted. Only reading the
+    endpoint uncached closes that, and that needs the protocol widened.
     """
     if not items:
         return

--- a/backend/app/modules/settings/router.py
+++ b/backend/app/modules/settings/router.py
@@ -25,6 +25,7 @@ from app.core.persistent_config import (
     ENTERPRISE_ONLY_TABS,
     PASSWORD_LOGIN_ENABLED,
     _registry,
+    apply_side_effects_batch,
 )
 from app.platform.ratelimit import limiter
 from app.core.public_urls import _is_env_only, get_public_api_url, get_public_app_url
@@ -494,8 +495,12 @@ async def update_settings(
     # invalidation, _on_change runtime hooks, sync rate-limit warm) so a
     # rollback can't leave process-local state diverged from the DB. Apply
     # them now that the batch is durable.
-    for key, value in validated_settings.items():
-        await registry_map[key].apply_side_effects(value)
+    # fix(#1543): as ONE step, not a per-key loop — the loop left a window in
+    # which a reader saw the already-evicted keys at their new values and the
+    # rest at their cached old ones.
+    await apply_side_effects_batch(
+        [(registry_map[key], value) for key, value in validated_settings.items()]
+    )
 
     # Rebuild column + index when embedding dimensions change. An auto-detected
     # width reaches this branch too (#1529): it was added to validated_settings
@@ -609,10 +614,10 @@ async def reset_settings(
         )
 
     # The setting deletes and their audit rows form one transaction. Runtime
-    # caches/hooks are changed only after that transaction is durable.
+    # caches/hooks are changed only after that transaction is durable, and in
+    # one step so no reader sees a half-reset batch (fix #1543).
     await db.commit()
-    for cfg in configs_to_reset:
-        await cfg.apply_side_effects(cfg.env_default)
+    await apply_side_effects_batch([(cfg, cfg.env_default) for cfg in configs_to_reset])
 
     # Phase 279 ADMIN-09 (L-01): Intentional second SELECT. cfg.reset() writes
     # the env_default value back to AppSetting; we re-read to capture the

--- a/backend/app/modules/settings/router.py
+++ b/backend/app/modules/settings/router.py
@@ -526,9 +526,14 @@ async def update_settings(
                     db, old_model_value, user_id=user.id, ip_address=ip, commit=False
                 )
             await db.commit()
-            await EMBEDDING_DIMS.apply_side_effects(old_dims_value)
+            # fix(#1543): and in ONE step, for the same reason the rollback is
+            # one transaction. Evicting the two keys in sequence would put the
+            # mismatched pair back into readable state on the way out of a
+            # rollback whose whole purpose is to prevent it.
+            rolled_back: list[tuple] = [(EMBEDDING_DIMS, old_dims_value)]
             if rollback_model:
-                await EMBEDDING_MODEL.apply_side_effects(old_model_value)
+                rolled_back.append((EMBEDDING_MODEL, old_model_value))
+            await apply_side_effects_batch(rolled_back)
             logger.exception(
                 "Embedding column rebuild failed, rolling back the embedding pair",
                 old_dims=old_dims_value,

--- a/backend/app/platform/cache/memory.py
+++ b/backend/app/platform/cache/memory.py
@@ -40,6 +40,12 @@ class InMemoryCacheProvider:
     async def delete(self, key: str) -> None:
         self._store.pop(key, None)
 
+    async def delete_many(self, *keys: str) -> None:
+        # fix(#1543): no await inside the loop, so on a single event loop there
+        # is no instant at which some of `keys` are gone and the rest are not.
+        for key in keys:
+            self._store.pop(key, None)
+
     async def delete_pattern(self, pattern: str) -> None:
         keys_to_delete = [k for k in self._store if fnmatch.fnmatch(k, pattern)]
         for k in keys_to_delete:

--- a/backend/app/platform/cache/provider.py
+++ b/backend/app/platform/cache/provider.py
@@ -29,6 +29,18 @@ class CacheProvider(Protocol):
         """Delete key. No error if missing."""
         ...
 
+    async def delete_many(self, *keys: str) -> None:
+        """Delete several keys as ONE operation. No error if any is missing.
+
+        fix(#1543): the contract is atomicity, not batching for speed. No
+        reader may observe the cache with some of ``keys`` evicted and the rest
+        still present, so an implementation must not await between individual
+        evictions. ``delete_pattern`` is not a substitute — it is a scan plus
+        per-key deletes, so it is both non-atomic and wider than the caller
+        asked for.
+        """
+        ...
+
     async def delete_pattern(self, pattern: str) -> None:
         """Delete all keys matching glob pattern (e.g. 'settings:*')."""
         ...

--- a/backend/app/platform/cache/redis.py
+++ b/backend/app/platform/cache/redis.py
@@ -102,6 +102,26 @@ class RedisCacheProvider:
             self._record_failure()
             await self._fallback.delete(key)
 
+    async def delete_many(self, *keys: str) -> None:
+        # fix(#1543): DEL is variadic and executes as one command, so the whole
+        # batch is evicted in a single round-trip that no concurrent client can
+        # observe half-applied. Looping over `delete` instead would put a
+        # network round-trip between every pair of keys.
+        if not keys:
+            return
+        if self._is_circuit_open():
+            await self._fallback.delete_many(*keys)
+            return
+        try:
+            await self._client.delete(*keys)
+            self._record_success()
+        except Exception:  # broad: redis circuit breaker — any Redis error falls back to in-memory cache
+            logger.warning(
+                "redis_cache_delete_many_failed", keys=list(keys), exc_info=True
+            )
+            self._record_failure()
+            await self._fallback.delete_many(*keys)
+
     async def delete_pattern(self, pattern: str) -> None:
         if self._is_circuit_open():
             await self._fallback.delete_pattern(pattern)

--- a/backend/app/platform/config_ops/service.py
+++ b/backend/app/platform/config_ops/service.py
@@ -1015,7 +1015,11 @@ async def import_config(
     Preview and apply consume the same preflight plan. Overwrite additionally
     requires the signed token returned by a matching, current dry-run.
     """
-    from app.core.persistent_config import ENTERPRISE_ONLY_TABS, _registry
+    from app.core.persistent_config import (
+        ENTERPRISE_ONLY_TABS,
+        _registry,
+        apply_side_effects_batch,
+    )
     from app.modules.audit.service import (
         AuditEvent,
         audit_emit,
@@ -1103,8 +1107,10 @@ async def import_config(
     # Single commit for config changes and all associated audit rows.
     await db.commit()
 
-    for cfg, committed_value in deferred_side_effects:
-        await cfg.apply_side_effects(committed_value)
+    # fix(#1543): one eviction for the whole import. An import touches far more
+    # keys than a PUT, so the per-key loop here held the widest mismatch window
+    # of the three batch call sites.
+    await apply_side_effects_batch(deferred_side_effects)
 
     logger.info(
         "config_imported",

--- a/backend/tests/test_config_ops_unit.py
+++ b/backend/tests/test_config_ops_unit.py
@@ -523,7 +523,7 @@ async def test_import_result_and_audit_report_exact_account_link_deletions():
             AsyncMock(),
         ),
         patch(
-            "app.core.persistent_config.PersistentConfig.apply_side_effects",
+            "app.core.persistent_config.apply_side_effects_batch",
             AsyncMock(),
         ),
         patch("app.modules.audit.service.audit_emit", AsyncMock()) as audit_emit,

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -2663,7 +2663,14 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # pre-commit value for a full TTL — and the limit of what a writer-side fix
     # can do, since a reader calling get() once per key still samples at two
     # instants and can straddle the whole step.
-    "backend/app/core/persistent_config.py": 1007,
+    # fix(#1543 follow-up): +11 recording which half of #1539's endpoint
+    # residue this closes. #1543 is that residue's named owner, and the split
+    # is not guessable from the code: the eviction span is fixed here, while
+    # the cached-vs-uncached TTL lag that dominates it is not an eviction
+    # problem at all and needs EmbeddingProviderExtension widened. Without the
+    # note the next reader assumes an atomic eviction covered both.
+    # Cap 1007 -> 1018, exact.
+    "backend/app/core/persistent_config.py": 1018,
     # feat(#1219): first entry — crossed _RATCHET_INCLUSION_LOC, exactly as
     # the inclusion rule's own comment predicted for this file ("watched by
     # nothing until they cross 1000. The threshold catches them then"). The

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -2581,7 +2581,13 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # carve-out history, because none of them has ever had to argue for a
     # line: that is the gap #958 was filed about. The next change to any of
     # them writes the first entry.
-    "backend/app/platform/config_ops/service.py": 1201,
+    # fix(#1543): +6 — config import applies the whole batch's post-commit side
+    # effects through apply_side_effects_batch instead of a per-key loop, so its
+    # cache eviction is one step. Four of the six are the widened import; the
+    # other two say why the loop is gone, which matters most here: an import
+    # touches far more keys than a settings PUT, so it held the widest version
+    # of the mismatch window. Cap 1201 -> 1207, exact.
+    "backend/app/platform/config_ops/service.py": 1207,
     # fix(#1335): jobs/router.py's 2047 lines carried the sweep SQL
     # constants and every stale-job recovery/sweep handler alongside the
     # plain CRUD routes. The two were split along that seam: the sweep
@@ -2646,6 +2652,18 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # security posture was once keyed off a flag documented as log-format only;
     # an under-documented coupling is the same mistake. Cap 1104 -> 1107, exact.
     "backend/app/core/config.py": 1107,
+    # fix(#1543): first entry — crossed _RATCHET_INCLUSION_LOC on the change
+    # that gave PersistentConfig a batch eviction. The code is small
+    # (apply_side_effects_batch, plus splitting the process-local half of
+    # apply_side_effects out into a synchronous _apply_local_side_effects so a
+    # batch of them cannot interleave). Most of the lines are the docstring,
+    # and deliberately: it records the two fixes that look right and are not —
+    # reordering the deletes, which mismatches the other way, and evicting
+    # before the commit, which lets a reader repopulate the cache with the
+    # pre-commit value for a full TTL — and the limit of what a writer-side fix
+    # can do, since a reader calling get() once per key still samples at two
+    # instants and can straddle the whole step.
+    "backend/app/core/persistent_config.py": 1007,
     # feat(#1219): first entry — crossed _RATCHET_INCLUSION_LOC, exactly as
     # the inclusion rule's own comment predicted for this file ("watched by
     # nothing until they cross 1000. The threshold catches them then"). The

--- a/backend/tests/test_persistent_config_batch_eviction_1543.py
+++ b/backend/tests/test_persistent_config_batch_eviction_1543.py
@@ -1,0 +1,319 @@
+"""fix(#1543): a settings batch evicts its cache keys as one step.
+
+``update_settings`` commits the whole batch and only then invalidates the cache.
+While that invalidation ran one key at a time, a reader landing in the middle
+resolved the already-evicted keys from the committed row and the rest from the
+still-warm cache — a pair of settings that was never committed together. The
+embedding model/dimensions pair is what surfaced it; the contract belongs to
+``PersistentConfig``, so these tests use an unrelated pair to say so.
+
+The window is microseconds wide, so racing for it is a coin flip. These tests
+drive it instead: the probe cache below suspends the writer *inside* the
+eviction and reads the pair at that exact point, which is the state any
+concurrent reader scheduled there would observe.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+import fakeredis.aioredis
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import delete
+
+from app.platform.cache.memory import InMemoryCacheProvider
+from app.platform.cache.redis import RedisCacheProvider
+
+# A genuinely paired setting: a model name is only meaningful against the
+# provider it belongs to, so a mixed pair is a configuration that never existed.
+_OLD = ("anthropic", "claude-old-model")
+_NEW = ("openai_compatible", "gpt-new-model")
+
+
+class _EvictionProbeCache:
+    """Delegating cache provider that runs a hook at the start of each eviction.
+
+    Stands in for the real Valkey provider, whose ``delete`` is a network
+    round-trip. That round-trip is a real suspension point, and a suspension
+    point inside the eviction is precisely what lets another task run between
+    two keys of one batch. The in-memory provider has no such point, which is
+    why the window cannot be raced for locally and has to be driven.
+
+    The hook only reads, so it never re-enters the eviction methods.
+    """
+
+    def __init__(self, inner: Any) -> None:
+        self._inner = inner
+        self.on_evict: Callable[[], Awaitable[None]] | None = None
+
+    async def _suspend(self) -> None:
+        if self.on_evict is not None:
+            await self.on_evict()
+
+    async def get(self, key: str) -> Any | None:
+        return await self._inner.get(key)
+
+    async def set(self, key: str, value: Any, ttl: int = 300) -> None:
+        await self._inner.set(key, value, ttl)
+
+    async def delete(self, key: str) -> None:
+        await self._suspend()
+        await self._inner.delete(key)
+
+    async def delete_many(self, *keys: str) -> None:
+        await self._suspend()
+        await self._inner.delete_many(*keys)
+
+    async def delete_pattern(self, pattern: str) -> None:
+        await self._inner.delete_pattern(pattern)
+
+    async def health_check(self) -> None:
+        await self._inner.health_check()
+
+
+@pytest.fixture
+async def probe_cache(client: AsyncClient):
+    """Install the probe over the live cache provider for one test."""
+    from app.platform.cache import init_cache
+    from app.platform.cache import provider as cache_provider
+
+    init_cache()
+    original = cache_provider._cache_provider
+    probe = _EvictionProbeCache(original)
+    cache_provider._cache_provider = probe
+    try:
+        yield probe
+    finally:
+        cache_provider._cache_provider = original
+
+
+@pytest.fixture(autouse=True)
+async def _clean_settings(client: AsyncClient):
+    """Drop the DB overrides and cache entries this module writes."""
+    yield
+    from app.api.main import app
+    from app.core.db.models import AppSetting
+    from app.core.dependencies import get_db
+    from app.platform.cache import get_cache
+
+    async for db in app.dependency_overrides[get_db]():
+        await db.execute(delete(AppSetting))
+        await db.commit()
+
+    try:
+        cache = get_cache()
+    except RuntimeError:
+        return
+    await cache.delete("config:llm_provider")
+    await cache.delete("config:llm_model")
+
+
+# ---------------------------------------------------------------------------
+# The window itself
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_paired_settings_are_never_observed_mismatched(
+    client: AsyncClient,
+    admin_auth_header: dict[str, str],
+    test_db_session,
+    probe_cache: _EvictionProbeCache,
+):
+    """A reader inside the eviction only ever sees a pair that was committed.
+
+    Restoring the per-key eviction loop makes this fail with the mixed pair
+    ``("openai_compatible", "claude-old-model")``: the new provider, read from
+    the committed row because its key was already evicted, beside the old model,
+    still served from the cache because its key had not been evicted yet.
+    """
+    from app.core.persistent_config import LLM_MODEL, LLM_PROVIDER
+
+    observations: list[tuple[str, str]] = []
+
+    async def read_the_pair() -> None:
+        # Start a fresh statement snapshot. Under READ COMMITTED this session
+        # sees the batch's commit even though it opened before the request.
+        await test_db_session.rollback()
+        provider = await LLM_PROVIDER.get(test_db_session)
+        model = await LLM_MODEL.get(test_db_session)
+        observations.append((provider, model))
+
+    # Commit the old pair, then read it once so both keys are cached. A reader
+    # that lands before an eviction has to get a cache hit for the window to
+    # exist at all — an unwarmed cache reads everything from the DB and is
+    # trivially consistent.
+    await LLM_PROVIDER.set(test_db_session, _OLD[0])
+    await LLM_MODEL.set(test_db_session, _OLD[1])
+    await read_the_pair()
+    assert observations == [_OLD]
+
+    probe_cache.on_evict = read_the_pair
+    try:
+        response = await client.put(
+            "/api/settings/",
+            json={"settings": {"llm_provider": _NEW[0], "llm_model": _NEW[1]}},
+            headers=admin_auth_header,
+        )
+    finally:
+        probe_cache.on_evict = None
+    assert response.status_code == 200, response.text
+
+    during_eviction = observations[1:]
+    # Without this the test is vacuous: no reader ran, so nothing was proved.
+    assert during_eviction, "the probe never ran — the eviction path was not taken"
+    assert all(pair in (_OLD, _NEW) for pair in during_eviction), (
+        "a reader inside the eviction saw a pair that was never committed "
+        f"together: {during_eviction}"
+    )
+
+    # And the eviction actually happened — otherwise "never evict anything"
+    # would satisfy the assertion above.
+    await read_the_pair()
+    assert observations[-1] == _NEW
+
+
+@pytest.mark.anyio
+async def test_settings_reset_evicts_its_batch_in_one_step(
+    client: AsyncClient,
+    admin_auth_header: dict[str, str],
+    test_db_session,
+    probe_cache: _EvictionProbeCache,
+):
+    """POST /settings/reset is the other batch writer and has the same window."""
+    from app.core.persistent_config import LLM_MODEL, LLM_PROVIDER
+
+    observations: list[tuple[str, str]] = []
+
+    async def read_the_pair() -> None:
+        await test_db_session.rollback()
+        observations.append(
+            (
+                await LLM_PROVIDER.get(test_db_session),
+                await LLM_MODEL.get(test_db_session),
+            )
+        )
+
+    await LLM_PROVIDER.set(test_db_session, _OLD[0])
+    await LLM_MODEL.set(test_db_session, _OLD[1])
+    await read_the_pair()
+    assert observations == [_OLD]
+
+    defaults = (LLM_PROVIDER.env_default, LLM_MODEL.env_default)
+
+    probe_cache.on_evict = read_the_pair
+    try:
+        response = await client.post(
+            "/api/settings/reset/",
+            json={"keys": ["llm_provider", "llm_model"]},
+            headers=admin_auth_header,
+        )
+    finally:
+        probe_cache.on_evict = None
+    assert response.status_code == 200, response.text
+
+    during_eviction = observations[1:]
+    assert during_eviction, "the probe never ran — the eviction path was not taken"
+    assert all(pair in (_OLD, defaults) for pair in during_eviction), (
+        "a reader inside the reset's eviction saw a mix of overridden and "
+        f"default values: {during_eviction}"
+    )
+
+    await read_the_pair()
+    assert observations[-1] == defaults
+
+
+# ---------------------------------------------------------------------------
+# The provider contract the fix rests on
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_memory_delete_many_evicts_without_suspending():
+    """The in-memory provider evicts a whole batch in one uninterrupted step.
+
+    Driving the coroutine by hand is the assertion: a coroutine that never
+    suspends raises StopIteration on its first ``send``, so there is no point
+    at which the event loop could hand control to a reader.
+    """
+    cache = InMemoryCacheProvider()
+    await cache.set("config:a", 1, ttl=60)
+    await cache.set("config:b", 2, ttl=60)
+
+    coro = cache.delete_many("config:a", "config:b")
+    with pytest.raises(StopIteration):
+        coro.send(None)
+
+    assert await cache.get("config:a") is None
+    assert await cache.get("config:b") is None
+
+
+@pytest.fixture
+def redis_cache():
+    """RedisCacheProvider backed by fakeredis (mirrors test_cache.py)."""
+    provider = RedisCacheProvider.__new__(RedisCacheProvider)
+    provider._client = fakeredis.aioredis.FakeRedis(decode_responses=True)
+    provider._max_failures = 5
+    provider._cooldown_seconds = 30
+    provider._failure_count = 0
+    provider._circuit_open_until = 0.0
+    provider._fallback = InMemoryCacheProvider()
+    return provider
+
+
+@pytest.mark.anyio
+async def test_redis_delete_many_is_one_variadic_del(redis_cache):
+    """DEL is variadic, so the batch is one command no client sees half-done.
+
+    A loop over ``delete`` would put a network round-trip between every pair of
+    keys, which is the window on a real Valkey deployment — and a much wider one
+    than the in-memory measurement suggests.
+    """
+    issued: list[tuple[str, ...]] = []
+    real_delete = redis_cache._client.delete
+
+    async def recording_delete(*keys: str):
+        issued.append(keys)
+        return await real_delete(*keys)
+
+    redis_cache._client.delete = recording_delete
+
+    await redis_cache.set("config:a", 1, ttl=60)
+    await redis_cache.set("config:b", 2, ttl=60)
+    await redis_cache.delete_many("config:a", "config:b")
+
+    assert issued == [("config:a", "config:b")]
+    assert await redis_cache.get("config:a") is None
+    assert await redis_cache.get("config:b") is None
+
+
+@pytest.mark.anyio
+async def test_redis_delete_many_skips_an_empty_batch(redis_cache):
+    """DEL with no arguments is a protocol error, so an empty batch is a no-op."""
+    issued: list[tuple[str, ...]] = []
+
+    async def recording_delete(*keys: str):
+        issued.append(keys)
+        return 0
+
+    redis_cache._client.delete = recording_delete
+
+    await redis_cache.delete_many()
+
+    assert issued == []
+
+
+@pytest.mark.anyio
+async def test_redis_delete_many_falls_back_as_one_step(redis_cache):
+    """An open circuit routes the batch to the in-memory fallback, still whole."""
+    await redis_cache._fallback.set("config:a", 1, ttl=60)
+    await redis_cache._fallback.set("config:b", 2, ttl=60)
+    redis_cache._failure_count = redis_cache._max_failures
+    redis_cache._circuit_open_until = float("inf")
+
+    await redis_cache.delete_many("config:a", "config:b")
+
+    assert await redis_cache._fallback.get("config:a") is None
+    assert await redis_cache._fallback.get("config:b") is None


### PR DESCRIPTION
Closes #1543.

## The window

`update_settings` commits the whole batch, then invalidates each key's cache entry one at a time. Between the first and last eviction a reader resolves the already-evicted keys from the committed row and the rest from the still-warm cache, so it sees a pair of settings that was never committed together. Measured at 1.8µs for an in-memory model-only save and 40µs at four keys in one PUT; on Valkey every eviction is a network round-trip, so it is materially wider there.

The embedding model/dimensions pair is what surfaced it, but the window belongs to `PersistentConfig`, so the tests use an unrelated pair to say so.

## What changed

A variadic `delete_many` on the `CacheProvider` contract, with the batch writers going through a new `apply_side_effects_batch`. Both provider paths are made atomic by the same change, which is what made this the smallest option that works:

- Valkey: `DEL k1 k2 ...` is one command, a single round-trip no client can observe half-applied. `delete_pattern` is not a shortcut here. It is `scan_iter` plus per-key deletes, so it is non-atomic *and* wider than the caller asked for.
- In memory: the pops run with no await between them, so nothing can be scheduled mid-batch.

The process-local half of `apply_side_effects` (the `_on_change` hook, the sync rate-limit warm, the public-URL memo clear) moved into a synchronous `_apply_local_side_effects` for the same reason: no await, no interleaving.

Four call sites: `PUT /settings`, `POST /settings/reset`, config import, and the embedding rebuild-failure rollback. That last one arrived with #1538 while this branch was open; it commits both halves of the pair in one transaction and then evicted their two keys in sequence, putting the mismatched pair back into readable state on the way out of a rollback that exists to prevent it.

## Two fixes that look right and are not

Reordering the deletes mismatches the other way.

Evicting before the commit is worse. A concurrent reader repopulates the cache with the pre-commit value, and that entry then lives its full 30s TTL instead of being transient.

## Scope, and what is still open

This makes the **writer** atomic. It does not make a **reader** atomic. A caller resolving two keys with two `get()` calls samples at two different instants and can straddle the whole commit-then-evict step, seeing one key's new value beside another's old one. That residual is reachable on Valkey, where every `cache.get` yields, and it is why `generate_embeddings`, `resolve_runtime_config` and `probe.py` all still read the pair with two separate awaits. No writer-side change can close it; the reader has to resolve the set in one operation.

### Which half of #1539's endpoint residue this closes

#1539 makes the backfill gate read the embedding model and dimensions uncached and leaves the endpoint cached, because the only path to the endpoint is `EmbeddingProviderExtension.resolve_runtime_config` (`backend/app/platform/extensions/protocols.py:371`), which has no uncached variant. The shipped implementation reads `EMBEDDING_BASE_URL` and `OPENAI_BASE_URL` through `PersistentConfig.get` (`backend/app/platform/extensions/defaults_ai_openai.py:435-438`). #1543 is that residue's named owner, so to be exact about the split:

**Closed here: the eviction span.** A PUT changing `embedding_base_url` alongside `embedding_model` used to evict the two keys in sequence. For the length of that span the gate paired an uncached (therefore already-new) model with a base URL still served from a cache entry the writer had committed past. That span is now zero. At any instant the endpoint entry is either present and pre-commit, or absent.

**Not closed here, and not closable by an eviction fix.** The dominant exposure is the 30s `_CACHE_TTL`, which is not an eviction problem. An uncached read is always current; a cached one may lag it by a full TTL however atomically the entry was evicted, because the next reader is free to repopulate. The stale-repopulation race behaves the same way: a reader whose DB read landed pre-commit writes that value back after the eviction, and it then lives its full TTL. Only reading the endpoint uncached closes either, and that needs `EmbeddingProviderExtension` widened. That is a protocol change and belongs in its own issue, not here.

`_capture_embedding_config` in `backend/app/processing/embeddings/backfill.py` defends against the general reader straddle per-caller, by reading the pair twice and comparing. `get_uncached` is the other per-key opt-out. #1539's uncached reads are untouched and still needed.

## Tests

`backend/tests/test_persistent_config_batch_eviction_1543.py`. The window is microseconds wide, so racing for it is a coin flip; the tests drive it instead. A probe cache wraps the live provider and suspends the writer inside the eviction, which is where a real Valkey round-trip suspends it, then reads the pair at that exact point through the real `PersistentConfig.get` on a separate session.

Restoring the per-key eviction turns both endpoint tests red:

```
E  AssertionError: a reader inside the eviction saw a pair that was never committed
   together: [('anthropic', 'claude-old-model'), ('openai_compatible', 'claude-old-model')]
E  AssertionError: a reader inside the reset's eviction saw a mix of overridden and
   default values: [('anthropic', 'claude-old-model'), ('openai_compatible', 'claude-old-model')]
```

Each test also asserts the probe actually ran (otherwise it proves nothing) and that the new pair is visible afterwards (otherwise "never evict anything" would pass). Four provider-level tests cover the `delete_many` contract: one variadic DEL against fakeredis, the empty-batch guard (`DEL` with no arguments is a protocol error), the circuit-open fallback, and the in-memory path driven by hand to show it never suspends.

## Verification

- `cd backend && uv run ruff check . && uv run ruff format --check .` — clean
- `uv run pytest tests/test_layering.py -q` — 47 passed (two ratchets raised: `persistent_config.py` enters `_MODULE_LOC_CAPS` at 1007 having crossed the 1000-line inclusion threshold, `config_ops/service.py` 1201 → 1207)
- `uv run pytest tests/test_persistent_config_batch_eviction_1543.py tests/test_settings_router.py tests/test_persistent_config.py tests/test_cache.py tests/test_config_ops_unit.py tests/test_config_ops.py tests/test_settings_admin.py -q` — 189 passed
- New file run three times with random ordering and once under `-n 4`: stable

https://claude.ai/code/session_01UM7M9D4sWb23hzNeCHQnyB
