### PR TITLE
fix(embed): accept our own origin on a domain-locked embed token

### DIFF
--- a/backend/app/core/public_urls.py
+++ b/backend/app/core/public_urls.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import ipaddress
 import time
 from urllib.parse import urlsplit, urlunsplit
 
@@ -100,7 +101,85 @@ def is_usable_public_origin(value: str | None) -> bool:
         return False
     if not candidate.isascii():
         return False
+    if canonical_host_error(parts.hostname or "") is not None:
+        return False
     return not parts.query and not parts.fragment
+
+
+def canonical_host_error(host: str) -> str | None:
+    """None if ``host`` is spelled the way a browser would serialize it.
+
+    Otherwise a sentence naming what is wrong, for an operator to act on.
+
+    fix(#1548 review r11): the same root as the IDN refusal — Python and the
+    browser disagree about a host's canonical spelling, and we store Python's.
+    Measured, not assumed:
+
+        input                          urlsplit          browser
+        http://192.168.1               192.168.1         192.168.0.1
+        http://010.0.0.1               010.0.0.1         8.0.0.1     (octal)
+        http://0x7f.1                  0x7f.1            127.0.0.1   (hex)
+        http://2130706433              2130706433        127.0.0.1
+        http://[2001:0db8:0:0:0:0:0:1] 2001:0db8:0:0...  [2001:db8::1]
+
+    In every row the shell would present the right column while
+    ``_resolve_self_origins`` stored the left, so the lock was issued and then
+    missed on every request.
+
+    THE TRAP, and the reason this asserts canonical form directly rather than
+    testing stability: ``192.168.1`` ROUND-TRIPS cleanly through urlsplit. It is
+    perfectly stable under our own parser and still wrong. A check built on
+    "parse it, re-serialize it, compare" would pass it.
+
+    The frontend does not need this function: it has a browser URL parser, so it
+    compares the host as written against the host that parser produced. Only
+    this side has to state the rule. ``public-app-url-shape.cases.json`` is what
+    holds the two methods to the same answers.
+    """
+    if not host:
+        return "The host is empty."
+    if host.endswith("."):
+        return f"Drop the trailing dot: {host.rstrip('.')}"
+
+    if ":" in host:  # IPv6 literal; urlsplit has already stripped the brackets.
+        try:
+            compressed = str(ipaddress.IPv6Address(host))
+        except ValueError:
+            return f"{host!r} is not a valid IPv6 address."
+        if compressed != host:
+            return f"Write the IPv6 literal in its compressed form: [{compressed}]"
+        return None
+
+    # A URL parser reads a host as IPv4 when its LAST label is numeric — which
+    # covers hex and octal spellings, not just dotted decimal. Anything matching
+    # that shape must already be canonical dotted-quad, and ipaddress rejects
+    # short forms, leading zeros and out-of-range octets for us.
+    last_label = host.rsplit(".", 1)[-1]
+    if last_label.isdigit() or last_label.startswith("0x"):
+        try:
+            parsed_ip = ipaddress.IPv4Address(host)
+        except ValueError:
+            # Deliberately NOT expanding it for them: computing what a browser
+            # would make of `0x7f.1` means implementing the WHATWG IPv4 parser,
+            # which is the approximation this whole rule exists to avoid.
+            return (
+                f"{host!r} is read as an IP address by browsers, and not in the "
+                "form they use. Write four decimal octets with no leading "
+                "zeros, e.g. 192.168.0.1"
+            )
+        if str(parsed_ip) != host:
+            return f"Write the IP address as: {parsed_ip}"
+        return None
+
+    # Registered name. Case is not checked: both parsers lowercase it, so an
+    # uppercase spelling is not a disagreement and refusing it would cost an
+    # operator a working value for nothing.
+    labels = host.split(".")
+    if any(not label for label in labels):
+        return f"{host!r} has an empty label."
+    if not all(c.isalnum() or c == "-" for label in labels for c in label):
+        return f"{host!r} contains a character that is not valid in a hostname."
+    return None
 
 
 def normalize_public_url(url: str | None) -> str | None:

--- a/backend/app/core/public_urls.py
+++ b/backend/app/core/public_urls.py
@@ -74,15 +74,31 @@ def is_usable_public_origin(value: str | None) -> bool:
         return False
     if not parts.hostname:
         return False
-    # fix(#1548 review r9): percent-encoding is refused OUTRIGHT, and the reason
-    # is that the two sides decode it differently — Python's urlsplit leaves
-    # `https://%6Daps.example.com` with the literal host `%6daps.example.com`,
-    # while the browser URL parser decodes it to `maps.example.com`. Either
-    # spelling could be defended; a value the two halves disagree about cannot,
-    # because that disagreement IS the bug class this rule exists to close.
-    # Unicode hosts are NOT refused: they are canonicalized to their IDNA ASCII
-    # form, which is what a browser sends (see _normalize_origin).
-    if "%" in candidate:
+    # fix(#1548 review r9/r10): three characters/classes are refused OUTRIGHT,
+    # each because the two URL parsers disagree about it — and a value the two
+    # halves read differently is the whole bug class, whichever reading one
+    # prefers.
+    #
+    # * PERCENT-ENCODING. Python's urlsplit leaves `%6Daps.example.com` literal;
+    #   the browser decodes it to `maps.example.com`.
+    # * BACKSLASH. `https://maps.example.com\@evil.com` parses as host
+    #   `maps.example.com\` here and as host `evil.com` in a browser, which
+    #   makes it an origin-confusion primitive rather than a formatting nit.
+    # * NON-ASCII HOST. Refused rather than converted. Python's built-in idna
+    #   codec is IDNA2003: it maps `faß.de` to `fass.de`, while browsers follow
+    #   WHATWG/UTS #46 and send `xn--fa-hia.de`. Approximating that from here
+    #   means deviation characters, transitional processing and registry rules,
+    #   and a NEAR match is worse than none — it denies every request while
+    #   looking correct. An operator with an internationalized domain supplies
+    #   the punycode form, which is unambiguous and is what the browser sends.
+    #
+    # All three are checked on the RAW candidate rather than on the parsed host,
+    # because the browser parser has already decoded and punycoded by the time
+    # its equivalent could look — so the raw string is the only view the two
+    # sides can compare identically.
+    if "%" in candidate or "\\" in candidate:
+        return False
+    if not candidate.isascii():
         return False
     return not parts.query and not parts.fragment
 
@@ -483,6 +499,49 @@ async def get_configured_public_app_url(db: AsyncSession) -> str | None:
     if normalized is None or not is_usable_public_origin(normalized):
         return None
     return normalized
+
+
+async def get_shareable_app_url(
+    db: AsyncSession, *, request: Request | None = None
+) -> str | None:
+    """The origin a browser is served THIS deployment's app from, or None.
+
+    fix(#1548 review r10): "derived" turned out to name two different things,
+    and only one of them is untrustworthy.
+
+    * An ``/api``-stripped ``PUBLIC_API_URL``, or an origin read off the
+      caller's own headers, is INFERRED — nobody checked that a browser is
+      served the app there, and in the header case the caller chose it. Those
+      stay excluded; see ``get_configured_public_app_url``.
+    * ``request.state.tenant_public_origin`` is VALIDATED INFRASTRUCTURE STATE.
+      ``TenantContextMiddleware`` sets it only after the request's Host resolves
+      against the tenant registry, and rejects the request outright when it
+      cannot form a trusted origin. It is the one origin that is definitely
+      right for a hosted tenant, and the fleet-wide ``PUBLIC_APP_URL`` cannot
+      represent a tenant host at all.
+
+    So a hosted tenant request answers with its own validated origin, and
+    everything else answers with the explicit fleet setting or nothing. The
+    condition mirrors the tenant branch of ``get_public_urls`` deliberately,
+    rather than drawing a second line a little differently.
+
+    Callers: share and embed URL generation, which must name a host the
+    RECIPIENT can open. On a tenant host that is the tenant's own origin — a
+    copied ``/card`` link on the fleet host arrives without the tenant context
+    its Host would have carried, and fails closed.
+    """
+    if is_multi_tenant() and request is not None:
+        tenant_id = getattr(request.state, "tenant_id", None)
+        tenant_origin = normalize_public_url(
+            getattr(request.state, "tenant_public_origin", None)
+        )
+        if (
+            tenant_id is not None
+            and tenant_origin is not None
+            and is_usable_public_origin(tenant_origin)
+        ):
+            return tenant_origin
+    return await get_configured_public_app_url(db)
 
 
 async def get_public_app_url(

--- a/backend/app/core/public_urls.py
+++ b/backend/app/core/public_urls.py
@@ -74,6 +74,16 @@ def is_usable_public_origin(value: str | None) -> bool:
         return False
     if not parts.hostname:
         return False
+    # fix(#1548 review r9): percent-encoding is refused OUTRIGHT, and the reason
+    # is that the two sides decode it differently — Python's urlsplit leaves
+    # `https://%6Daps.example.com` with the literal host `%6daps.example.com`,
+    # while the browser URL parser decodes it to `maps.example.com`. Either
+    # spelling could be defended; a value the two halves disagree about cannot,
+    # because that disagreement IS the bug class this rule exists to close.
+    # Unicode hosts are NOT refused: they are canonicalized to their IDNA ASCII
+    # form, which is what a browser sends (see _normalize_origin).
+    if "%" in candidate:
+        return False
     return not parts.query and not parts.fragment
 
 
@@ -435,6 +445,44 @@ async def get_public_urls(
         for_external_use=for_external_use,
     )
     return app_url, api_url
+
+
+async def get_configured_public_app_url(db: AsyncSession) -> str | None:
+    """The explicitly configured ``PUBLIC_APP_URL``, or None. No derivation.
+
+    fix(#1548 review r9): ``get_public_app_url`` is a RESOLVER — when
+    ``PUBLIC_APP_URL`` is unset it derives an app URL from ``PUBLIC_API_URL`` by
+    stripping an ``/api`` suffix, and failing that from the caller's own request
+    headers. Both are the right behaviour for producing a link when any link is
+    better than none (OGC self-links, response bodies).
+
+    Both are wrong for the two callers that ask "what origin does a browser
+    present when it loads our embed shell", because neither derived value is
+    that origin:
+
+    * A deployment serving the API at ``https://api.example.com/api`` and the
+      app at ``https://maps.example.com`` derives ``https://api.example.com``.
+      That is a real, non-loopback host, so the domain-lock gate reads the
+      deployment as configured and issues a lock — and then every shell request
+      arrives from ``https://maps.example.com``, misses the allowlist, and the
+      map is empty. The original defect of this PR wearing a different hat.
+    * The request-header fallback is the vacuous-``self`` trap #1531 already
+      avoided: an origin taken from the caller is one every caller satisfies.
+
+    So domain locking and share-URL generation require the operator to say it.
+    Unset is a legitimate answer here, and every consumer already knows what to
+    do with it — refuse the lock, fall back for ordinary shares, suppress the
+    locked preview.
+
+    Returns the value with any trailing slash trimmed, or None when unset,
+    blank, or not a usable public origin (see ``is_usable_public_origin``).
+    """
+    overrides = {} if _is_env_only() else await _load_public_url_overrides(db)
+    configured = overrides.get(PUBLIC_APP_URL_KEY, settings.public_app_url)
+    normalized = normalize_public_url(configured)
+    if normalized is None or not is_usable_public_origin(normalized):
+        return None
+    return normalized
 
 
 async def get_public_app_url(

--- a/backend/app/core/public_urls.py
+++ b/backend/app/core/public_urls.py
@@ -31,6 +31,52 @@ class PublicUrlNotConfiguredError(RuntimeError):
     policies. Forcing explicit configuration closes that path."""
 
 
+def is_usable_public_origin(value: str | None) -> bool:
+    """Is this a value a browser could actually be sent to?
+
+    fix(#1548 review r8): ONE shape rule for ``PUBLIC_APP_URL``, stated here and
+    mirrored by ``parseUsablePublicUrl`` in ``frontend/src/lib/public-urls.ts``.
+    The rule: an absolute HTTP(S) URL, with a host, and no query or fragment.
+
+    Everything else is untrusted, and each consumer already knows what to do
+    with untrusted — the backend refuses to issue a domain lock, the frontend
+    falls back for ordinary shares and suppresses a locked preview.
+
+    Why each clause is load-bearing, since none of them is hypothetical:
+
+    * ABSOLUTE, WITH A SCHEME AND HOST. ``_normalize_origin`` prepends
+      ``https://`` to anything that does not already start with http(s), so an
+      environment value of ``ftp://maps.example.com`` becomes the pseudo-origin
+      ``https://ftp:``, ``mailto:ops@example.com`` becomes
+      ``https://mailto:ops@example.com`` and ``file:///etc/hosts`` becomes
+      ``https://file:``. Each is non-loopback, so the domain-lock gate read the
+      deployment as configured and issued a lock no embed shell could ever
+      satisfy — this PR's original bug, returning through the check added to
+      prevent it.
+    * NO QUERY OR FRAGMENT. The backend drops them when it normalizes, so its
+      own comparison survives, but the frontend appends ``/m/<token>`` to the
+      configured string — putting the path inside the query or after the
+      fragment and producing links nobody can open.
+
+    The setting is environment-backed and therefore never passes through the
+    persistent-setting validator, so this is the only place it is checked.
+    """
+    if value is None:
+        return False
+    candidate = value.strip()
+    if not candidate:
+        return False
+    try:
+        parts = urlsplit(candidate)
+    except ValueError:
+        return False
+    if parts.scheme not in ("http", "https"):
+        return False
+    if not parts.hostname:
+        return False
+    return not parts.query and not parts.fragment
+
+
 def normalize_public_url(url: str | None) -> str | None:
     if url is None:
         return None

--- a/backend/app/modules/embed_tokens/router.py
+++ b/backend/app/modules/embed_tokens/router.py
@@ -19,7 +19,7 @@
 
 import uuid
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Request, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.modules.audit.service import AuditEvent, audit_emit
@@ -34,6 +34,8 @@ from app.modules.embed_tokens.schemas import (
     EmbedTokenUpdate,
 )
 from app.modules.embed_tokens.service import (
+    DomainLockNotEnforceableError,
+    assert_domain_lock_is_enforceable,
     create_embed_token,
     list_embed_tokens,
     revoke_embed_token,
@@ -68,6 +70,7 @@ router = APIRouter(
     "/", response_model=EmbedTokenCreatedResponse, status_code=status.HTTP_201_CREATED
 )
 async def create_embed_token_endpoint(
+    request: Request,
     map_id: uuid.UUID,
     body: EmbedTokenCreate,
     # fix(#819): same permission gate as share_map_endpoint — an embed token outranks the
@@ -88,6 +91,17 @@ async def create_embed_token_endpoint(
             detail="Map not found",
         )
     await check_map_ownership(map_obj, user, db)
+
+    # fix(#1548 review P2): refuse a lock this deployment cannot enforce, at
+    # the moment the operator sets it, rather than silently on every later
+    # viewer request. Shared with the PATCH handler so the two cannot drift.
+    try:
+        await assert_domain_lock_is_enforceable(db, request, body.allowed_origins)
+    except DomainLockNotEnforceableError as e:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail=str(e),
+        )
 
     try:
         token, raw_token = await create_embed_token(
@@ -148,6 +162,7 @@ async def list_embed_tokens_endpoint(
 
 @router.patch("/{token_id}/", response_model=EmbedTokenResponse)
 async def update_embed_token_endpoint(
+    request: Request,
     map_id: uuid.UUID,
     token_id: uuid.UUID,
     body: EmbedTokenUpdate,
@@ -165,6 +180,16 @@ async def update_embed_token_endpoint(
             detail="Map not found",
         )
     await check_map_ownership(map_obj, user, db)
+
+    # fix(#1548 review P2): same gate as the POST handler. Clearing a lock
+    # (allowed_origins=None) is unaffected.
+    try:
+        await assert_domain_lock_is_enforceable(db, request, body.allowed_origins)
+    except DomainLockNotEnforceableError as e:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail=str(e),
+        )
 
     try:
         token = await update_embed_token(db, token_id, map_id, body.allowed_origins)

--- a/backend/app/modules/embed_tokens/router.py
+++ b/backend/app/modules/embed_tokens/router.py
@@ -37,6 +37,7 @@ from app.modules.embed_tokens.service import (
     DomainLockNotEnforceableError,
     assert_domain_lock_is_enforceable,
     create_embed_token,
+    get_active_embed_token,
     list_embed_tokens,
     revoke_embed_token,
     update_embed_token,
@@ -180,6 +181,19 @@ async def update_embed_token_endpoint(
             detail="Map not found",
         )
     await check_map_ownership(map_obj, user, db)
+
+    # fix(#1548 review r2): settle EXISTENCE before the deployment-level
+    # precondition below. The gate answers "could this deployment enforce a
+    # domain lock", which is not a question about this token at all — asked
+    # first, it told the owner of a stale or concurrently revoked token id to
+    # go and reconfigure PUBLIC_APP_URL, when the real answer is that their
+    # token is gone. The write re-reads through the same helper, so a token
+    # revoked in the window between still falls through to the 404 below.
+    if await get_active_embed_token(db, token_id, map_id) is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Embed token not found",
+        )
 
     # fix(#1548 review P2): same gate as the POST handler. Clearing a lock
     # (allowed_origins=None) is unaffected.

--- a/backend/app/modules/embed_tokens/schemas.py
+++ b/backend/app/modules/embed_tokens/schemas.py
@@ -24,17 +24,27 @@ def _normalize_origin(origin: str) -> str:
         raise ValueError(f"Invalid origin: {origin}")
 
     scheme = parsed.scheme or "https"
-    # parsed.hostname strips square brackets from IPv6 addresses (e.g. '::1'),
-    # producing an invalid CSP source expression like 'http://::1:8080'.
-    # RFC 9116 / W3C CSP3 §2.6.1 requires IPv6 literals to be enclosed in
-    # brackets. Extract the bracket-safe host string from parsed.netloc instead:
-    # netloc for 'http://[::1]:8080' is '[::1]:8080' — strip the port suffix.
-    if parsed.port is not None:
-        # Split off ':port' suffix from the right. For IPv6 '[::1]:8080' this
-        # gives '[::1]'; for DNS 'example.com:8080' this gives 'example.com'.
-        netloc_host = parsed.netloc.rsplit(":", 1)[0]
-    else:
-        netloc_host = parsed.netloc
+    # fix(#1548 review r9): the host is taken from parsed.hostname and rebuilt,
+    # NOT sliced out of netloc. netloc carries userinfo, so 'https://u:p@host'
+    # used to store 'https://u:p@host' as an origin — a spelling no browser ever
+    # sends, and one that would leak the credentials into any CSP header or
+    # copied link built from it. hostname drops userinfo and lowercases for us.
+    #
+    # parsed.hostname also strips the square brackets from IPv6 literals (e.g.
+    # '::1'), producing an invalid CSP source expression like 'http://::1:8080'
+    # — RFC 3986 / W3C CSP3 §2.6.1 require them bracketed — so they go back on.
+    host = parsed.hostname or ""
+    # A browser serializes an internationalized host in its IDNA ASCII form:
+    # the shell's Origin for https://máp.example arrives as
+    # https://xn--mp-mia.example. Storing the Unicode spelling meant the domain
+    # lock was issued and then missed on every request. Canonicalize to the
+    # spelling the browser will present, rather than rejecting the value.
+    if not host.isascii():
+        try:
+            host = host.encode("idna").decode("ascii")
+        except UnicodeError as exc:
+            raise ValueError(f"Invalid origin: {origin}") from exc
+    netloc_host = f"[{host}]" if ":" in host else host
     port = parsed.port
     if (scheme == "http" and port == 80) or (scheme == "https" and port == 443):
         port = None

--- a/backend/app/modules/embed_tokens/schemas.py
+++ b/backend/app/modules/embed_tokens/schemas.py
@@ -11,6 +11,13 @@ ADVANCED_SHARING_ERROR = "Advanced sharing controls are not enabled for this dep
 
 def _normalize_origin(origin: str) -> str:
     normalized = origin.strip().lower().rstrip("/")
+    # fix(#1548 review r10): a backslash is an origin-confusion primitive, not a
+    # formatting nit — 'https://maps.example.com\\@evil.com' parses as host
+    # 'maps.example.com\\' here and as host 'evil.com' in a browser. Refused for
+    # the same reason as in is_usable_public_origin (app/core/public_urls.py):
+    # the two parsers disagree, and that disagreement is the bug.
+    if "\\" in normalized:
+        raise ValueError(f"Invalid origin: {origin}")
     # Reject wildcard entries — CSP frame-ancestors NEVER '*'.
     # Check is performed after strip+lower so leading/trailing whitespace cannot
     # smuggle wildcards. Covers '*', '*.example.com', 'https://*.example.com'.
@@ -34,16 +41,16 @@ def _normalize_origin(origin: str) -> str:
     # '::1'), producing an invalid CSP source expression like 'http://::1:8080'
     # — RFC 3986 / W3C CSP3 §2.6.1 require them bracketed — so they go back on.
     host = parsed.hostname or ""
-    # A browser serializes an internationalized host in its IDNA ASCII form:
-    # the shell's Origin for https://máp.example arrives as
-    # https://xn--mp-mia.example. Storing the Unicode spelling meant the domain
-    # lock was issued and then missed on every request. Canonicalize to the
-    # spelling the browser will present, rather than rejecting the value.
+    # fix(#1548 review r10): a non-ASCII host is REFUSED, not converted. Python's
+    # built-in idna codec is IDNA2003 and maps `faß.de` to `fass.de`, while
+    # browsers follow WHATWG/UTS #46 and send `xn--fa-hia.de` — so converting
+    # here would produce a near match, which denies every request while looking
+    # correct. Supply the punycode form, which is what the browser sends anyway.
     if not host.isascii():
-        try:
-            host = host.encode("idna").decode("ascii")
-        except UnicodeError as exc:
-            raise ValueError(f"Invalid origin: {origin}") from exc
+        raise ValueError(
+            f"Invalid origin: {origin}. An internationalized domain must be "
+            "given in its punycode (xn--) form, which is what browsers send."
+        )
     netloc_host = f"[{host}]" if ":" in host else host
     port = parsed.port
     if (scheme == "http" and port == 80) or (scheme == "https" and port == 443):

--- a/backend/app/modules/embed_tokens/schemas.py
+++ b/backend/app/modules/embed_tokens/schemas.py
@@ -2,6 +2,8 @@ import uuid
 from datetime import datetime
 from urllib.parse import urlparse
 
+from app.core.public_urls import canonical_host_error
+
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from app.core.edition import is_enterprise
@@ -51,6 +53,14 @@ def _normalize_origin(origin: str) -> str:
             f"Invalid origin: {origin}. An internationalized domain must be "
             "given in its punycode (xn--) form, which is what browsers send."
         )
+    # fix(#1548 review r11): the host must already be spelled the way a browser
+    # serializes it. Storing our own spelling of `192.168.1` or an uncompressed
+    # IPv6 literal meant the stored origin and the shell's Origin header could
+    # never match. The message names the canonical form where it can be computed
+    # without re-implementing the browser's parser.
+    host_problem = canonical_host_error(host)
+    if host_problem is not None:
+        raise ValueError(f"Invalid origin: {origin}. {host_problem}")
     netloc_host = f"[{host}]" if ":" in host else host
     port = parsed.port
     if (scheme == "http" and port == 80) or (scheme == "https" and port == 443):

--- a/backend/app/modules/embed_tokens/service.py
+++ b/backend/app/modules/embed_tokens/service.py
@@ -12,7 +12,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from starlette.requests import Request
 
 from app.core.edition import is_enterprise
-from app.core.public_urls import get_public_app_url, is_usable_public_origin
+from app.core.public_urls import get_configured_public_app_url, is_usable_public_origin
 from app.core.tenancy import is_multi_tenant
 from app.platform.cache import tenant_cache_context_available, tenant_cache_key
 from app.platform.cache.provider import get_cache
@@ -119,11 +119,13 @@ async def _resolve_self_origins(db: AsyncSession, request: Request) -> set[str]:
     client-forwarded embedder origin would replace a check that visibly fails
     with one that only appears to work.
 
-    * The configured public app URL (``PUBLIC_APP_URL`` / ``PUBLIC_API_URL`` env
-      or the matching AppSetting row). ``request`` is deliberately NOT forwarded
-      to ``get_public_app_url``: its unconfigured fallback derives an origin from
-      the caller's own ``Origin`` / ``Referer`` headers, which would make EVERY
-      origin "self" and the allowlist vacuous.
+    * The EXPLICITLY configured ``PUBLIC_APP_URL``, via
+      ``get_configured_public_app_url``. Deliberately not ``get_public_app_url``:
+      that one is a resolver, and both of its fallbacks name something other
+      than the host our embed shell is served from — an ``/api``-stripped
+      ``PUBLIC_API_URL``, or (fix #1531) the caller's own ``Origin`` / ``Referer``
+      headers, which would make EVERY origin "self" and the allowlist vacuous.
+      See its docstring for why an unset value is a legitimate answer here.
     * In hosted multi-tenant, the tenant origin that the tenant-context
       middleware derived from a Host that resolved against the tenant registry
       (``request.state.tenant_public_origin`` is set only after that lookup, and
@@ -152,9 +154,11 @@ async def _resolve_self_origins(db: AsyncSession, request: Request) -> set[str]:
     # a bool, and letting a DB error escape would turn a routine deny into a
     # 500 on the tile path. Resolving no self-origins denies, which is correct.
     try:
-        app_url = await get_public_app_url(db)
+        app_url = await get_configured_public_app_url(db)
     except Exception:  # broad: any lookup failure must deny, never raise
         logger.warning("embed_self_origin_lookup_failed", exc_info=True)
+        return origins
+    if app_url is None:
         return origins
 
     # fix(#1548 review r8): the shape gate runs BEFORE normalization, because

--- a/backend/app/modules/embed_tokens/service.py
+++ b/backend/app/modules/embed_tokens/service.py
@@ -12,6 +12,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from starlette.requests import Request
 
 from app.core.edition import is_enterprise
+from app.core.public_urls import get_public_app_url
 from app.core.tenancy import is_multi_tenant
 from app.platform.cache import tenant_cache_context_available, tenant_cache_key
 from app.platform.cache.provider import get_cache
@@ -108,6 +109,112 @@ def extract_request_origin(request: Request) -> str | None:
                 return None
 
     return None
+
+
+async def _resolve_self_origins(db: AsyncSession, request: Request) -> set[str]:
+    """Return the normalized origins that ARE this GeoLens deployment.
+
+    fix(#1531): every candidate here is server-derived. The embedder's origin is
+    deliberately NOT reconstructed from anything the caller sends — a
+    client-forwarded embedder origin would replace a check that visibly fails
+    with one that only appears to work.
+
+    * The configured public app URL (``PUBLIC_APP_URL`` / ``PUBLIC_API_URL`` env
+      or the matching AppSetting row). ``request`` is deliberately NOT forwarded
+      to ``get_public_app_url``: its unconfigured fallback derives an origin from
+      the caller's own ``Origin`` / ``Referer`` headers, which would make EVERY
+      origin "self" and the allowlist vacuous.
+    * In hosted multi-tenant, the tenant origin that the tenant-context
+      middleware derived from a Host that resolved against the tenant registry
+      (``request.state.tenant_public_origin`` is set only after that lookup, and
+      the request is rejected outright when the lookup cannot form a trusted
+      origin). The fleet-wide public app URL cannot represent a tenant host, so
+      without this a hosted domain-locked embed would stay broken.
+    """
+    origins: set[str] = set()
+
+    # Gated on the mode that populates it: TenantContextMiddleware returns
+    # early in single_tenant, so the attribute is never set there. Reading it
+    # only under is_multi_tenant() keeps that invariant local rather than
+    # depending on middleware ordering staying the way it is today.
+    if is_multi_tenant():
+        tenant_origin = getattr(request.state, "tenant_public_origin", None)
+        if tenant_origin:
+            try:
+                origins.add(_normalize_origin(tenant_origin))
+            except ValueError:
+                pass
+
+    try:
+        origins.add(_normalize_origin(await get_public_app_url(db)))
+    except ValueError:
+        pass
+
+    return origins
+
+
+async def _request_origin_is_allowed(
+    db: AsyncSession,
+    request: Request | None,
+    allowed_origins: list[str] | None,
+) -> bool:
+    """Single reader for an embed token's domain lock.
+
+    ``resolve_embed_scope_for_map`` and ``validate_embed_token_access`` both
+    gate on ``allowed_origins``; they used to carry separate copies of this
+    policy, so a change to one silently left the other on the old rules. They
+    now share this one implementation.
+
+    fix(#1531): domain locking was enforced in two layers that disagreed. The
+    ``/m/{token}`` embed shell is served with ``frame-ancestors 'self'
+    <allowed_origins>`` (see ``build_embed_frame_ancestors``) — a real,
+    browser-enforced control keyed on the PARENT page's actual origin. This
+    API-layer allowlist sat below it and accepted only ``<allowed_origins>``,
+    with no ``'self'`` equivalent. But an API subresource request issued from
+    inside the embed iframe carries the SHELL's origin, never the embedder's:
+    the requesting document is our own shell, so a same-origin GET sends no
+    ``Origin`` header at all and the ``Referer`` fallback is the shell's own
+    URL. The parent's origin is simply not on a subresource request; it is
+    visible only on the NAVIGATION that loads the iframe, which is exactly
+    where ``frame-ancestors`` already enforces it. Every scoped-layer request
+    from a domain-locked embed therefore resolved to our own origin, matched
+    nothing in ``allowed_origins`` (the operator puts the CUSTOMER's domain
+    there), and was denied — the feature was broken closed, delivering nothing
+    to any iframe embed.
+
+    Accepting our own origin restores the ``'self'`` half the CSP directive
+    already had: by the time the shell can run a line of script, the browser
+    has already enforced the domain lock at the document layer.
+
+    The check is NOT removed, because it is correct on the other path: an embed
+    token driven from the customer's own JavaScript rather than through the
+    ``/m/`` iframe does arrive with ``Origin: https://customer.example.com``,
+    and there the allowlist works as designed.
+
+    Known and unavoidable consequence: a TOP-LEVEL navigation to the shell
+    (not framed) sends byte-identical headers to the framed case, so it is
+    accepted too. No header distinguishes them — ``Sec-Fetch-Site`` on the
+    subresource is ``same-origin`` either way. Any fix that makes the iframe
+    work makes direct navigation work; what still gates that path is possession
+    of the token itself, which is the capability (SEC-022).
+    """
+    if not allowed_origins:
+        return True
+    if request is None:
+        return False
+    origin = extract_request_origin(request)
+    if origin is None:
+        return False
+    if origin in allowed_origins:
+        # Both sides are pre-normalized: allowed_origins by
+        # schemas._validate_origins, origin by extract_request_origin.
+        return True
+    # Phase 268 H-31 localhost-development bypass, unchanged: the Origin header
+    # alone is trivially forgeable, so it is gated on the actual TCP peer also
+    # being loopback.
+    if _is_localhost_origin(origin) and _client_is_loopback(request):
+        return True
+    return origin in await _resolve_self_origins(db, request)
 
 
 def build_embed_frame_ancestors(
@@ -424,17 +531,10 @@ async def resolve_embed_scope_for_map(
     if token is None:
         return set()
 
-    # Domain-locking check — mirrors validate_embed_token_access (H-31 rules).
-    if token.allowed_origins:
-        if request is None:
-            return set()
-        origin = extract_request_origin(request)
-        if origin is None:
-            return set()
-        if _is_localhost_origin(origin) and _client_is_loopback(request):
-            pass
-        elif origin not in token.allowed_origins:
-            return set()
+    # Domain-locking check — shares ONE policy reader with
+    # validate_embed_token_access so the two cannot drift (fix #1531).
+    if not await _request_origin_is_allowed(db, request, token.allowed_origins):
+        return set()
 
     scoped: set[uuid.UUID] = set()
     for raw_id in token.scoped_dataset_ids or []:
@@ -534,26 +634,11 @@ async def validate_embed_token_access(
             ttl=cache_ttl,
         )
 
-    # Domain-locking check (before dataset scope check).
-    # Phase 268 H-31: the legacy localhost-Origin bypass was trivially
-    # forgeable by non-browser callers (curl, server-side scripts) — any
-    # caller could set ``Origin: http://localhost`` and skip the allowlist.
-    # The bypass is now gated on ``request.client.host`` being a loopback
-    # IP (which is the actual TCP peer and cannot be forged remotely).
-    if allowed_origins:
-        if request is None:
-            return False
-        origin = extract_request_origin(request)
-        if origin is None:
-            return False
-        if _is_localhost_origin(origin) and _client_is_loopback(request):
-            # Local-development bypass: Origin claims localhost AND the TCP
-            # peer is also loopback (only possible from same-host calls).
-            pass
-        elif origin not in allowed_origins:
-            # Both origin (from extract_request_origin) and allowed_origins
-            # (from create_embed_token) are pre-normalized.
-            return False
+    # Domain-locking check (before dataset scope check). Shares ONE policy
+    # reader with resolve_embed_scope_for_map so the two cannot drift; the
+    # H-31 localhost gating and the #1531 self-origin rule both live there.
+    if not await _request_origin_is_allowed(db, request, allowed_origins):
+        return False
 
     # Dataset scope check
     if str(dataset_id) not in scoped_dataset_ids:

--- a/backend/app/modules/embed_tokens/service.py
+++ b/backend/app/modules/embed_tokens/service.py
@@ -604,6 +604,29 @@ async def revoke_embed_tokens_for_dropped_datasets(
     return 0
 
 
+async def get_active_embed_token(
+    db: AsyncSession,
+    token_id: uuid.UUID,
+    map_id: uuid.UUID,
+) -> EmbedToken | None:
+    """Load the active token a write targets, or None if there is none.
+
+    fix(#1548 review r2): exists so a caller can settle whether the resource is
+    THERE before applying a precondition about the deployment. The router asks
+    first and 404s; ``update_embed_token`` asks again when it goes to write.
+    Both go through this one query so the "which token does this PATCH mean"
+    rule cannot drift between them.
+    """
+    result = await db.execute(
+        select(EmbedToken).where(
+            EmbedToken.id == token_id,
+            EmbedToken.map_id == map_id,
+            EmbedToken.is_active.is_(True),
+        )
+    )
+    return result.scalar_one_or_none()
+
+
 async def update_embed_token(
     db: AsyncSession,
     token_id: uuid.UUID,
@@ -614,14 +637,7 @@ async def update_embed_token(
     if not is_enterprise() and bool(allowed_origins):
         raise ValueError(ADVANCED_SHARING_ERROR)
 
-    result = await db.execute(
-        select(EmbedToken).where(
-            EmbedToken.id == token_id,
-            EmbedToken.map_id == map_id,
-            EmbedToken.is_active.is_(True),
-        )
-    )
-    token = result.scalar_one_or_none()
+    token = await get_active_embed_token(db, token_id, map_id)
     if token is None:
         return None
 

--- a/backend/app/modules/embed_tokens/service.py
+++ b/backend/app/modules/embed_tokens/service.py
@@ -145,8 +145,20 @@ async def _resolve_self_origins(db: AsyncSession, request: Request) -> set[str]:
             except ValueError:
                 pass
 
+    # fix(#1548 review P2): this lookup reads an AppSetting row on a 60s-cold
+    # cache, so it is the one part of the domain-lock check that can fail for
+    # reasons unrelated to the decision. An authorization helper must fail
+    # CLOSED on that, not propagate: every other denial in this module returns
+    # a bool, and letting a DB error escape would turn a routine deny into a
+    # 500 on the tile path. Resolving no self-origins denies, which is correct.
     try:
-        origins.add(_normalize_origin(await get_public_app_url(db)))
+        app_url = await get_public_app_url(db)
+    except Exception:  # broad: any lookup failure must deny, never raise
+        logger.warning("embed_self_origin_lookup_failed", exc_info=True)
+        return origins
+
+    try:
+        origins.add(_normalize_origin(app_url))
     except ValueError:
         pass
 
@@ -214,7 +226,36 @@ async def _request_origin_is_allowed(
     # being loopback.
     if _is_localhost_origin(origin) and _client_is_loopback(request):
         return True
-    return origin in await _resolve_self_origins(db, request)
+
+    self_origins = await _resolve_self_origins(db, request)
+    if origin in self_origins:
+        return True
+
+    # fix(#1548 review P2): a deployment that never sets PUBLIC_APP_URL still
+    # gets one. Both docker-compose.yml and docker-compose.prod.yml inject
+    # ``${PUBLIC_APP_URL:-http://localhost:8080}``, and .env.example ships the
+    # line commented out, so a self-hoster serving https://maps.example.com
+    # resolves a self-origin of http://localhost:8080 and their domain-locked
+    # embeds stay empty. The server cannot fix that for them: every
+    # request-derived alternative (Host, X-Forwarded-Host, request.url) is
+    # settable by anyone who can point a DNS name at the deployment, which
+    # would make the lock bypassable by the exact parties it excludes. So log
+    # the mismatch with the remediation instead of guessing, and keep the
+    # denial. Fires only for a domain-locked token that already missed both
+    # the allowlist and the loopback bypass, so this is not a hot path.
+    logger.warning(
+        "embed_token_domain_lock_denied",
+        request_origin=origin,
+        self_origins=sorted(self_origins),
+        allowed_origins=sorted(allowed_origins),
+        remediation=(
+            "If this deployment serves the embed shell from request_origin, "
+            "set PUBLIC_APP_URL (or the public_app_url setting) to it. The "
+            "embed shell's own API calls carry the shell's origin, so they "
+            "are only recognized as first-party when that value is correct."
+        ),
+    )
+    return False
 
 
 def build_embed_frame_ancestors(

--- a/backend/app/modules/embed_tokens/service.py
+++ b/backend/app/modules/embed_tokens/service.py
@@ -12,7 +12,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from starlette.requests import Request
 
 from app.core.edition import is_enterprise
-from app.core.public_urls import get_public_app_url
+from app.core.public_urls import get_public_app_url, is_usable_public_origin
 from app.core.tenancy import is_multi_tenant
 from app.platform.cache import tenant_cache_context_available, tenant_cache_key
 from app.platform.cache.provider import get_cache
@@ -139,7 +139,7 @@ async def _resolve_self_origins(db: AsyncSession, request: Request) -> set[str]:
     # depending on middleware ordering staying the way it is today.
     if is_multi_tenant():
         tenant_origin = getattr(request.state, "tenant_public_origin", None)
-        if tenant_origin:
+        if tenant_origin and is_usable_public_origin(tenant_origin):
             try:
                 origins.add(_normalize_origin(tenant_origin))
             except ValueError:
@@ -157,10 +157,19 @@ async def _resolve_self_origins(db: AsyncSession, request: Request) -> set[str]:
         logger.warning("embed_self_origin_lookup_failed", exc_info=True)
         return origins
 
-    try:
-        origins.add(_normalize_origin(app_url))
-    except ValueError:
-        pass
+    # fix(#1548 review r8): the shape gate runs BEFORE normalization, because
+    # normalization is what hides the problem. `_normalize_origin` prepends
+    # https:// to anything lacking an http(s) scheme, so an environment value of
+    # `ftp://maps.example.com` arrives here as the plausible-looking, non-loopback
+    # `https://ftp:` — and `assert_domain_lock_is_enforceable` then reads the
+    # deployment as configured and issues a lock no embed shell can satisfy.
+    # `is_usable_public_origin` is the single statement of that rule, mirrored by
+    # parseUsablePublicUrl in frontend/src/lib/public-urls.ts.
+    if is_usable_public_origin(app_url):
+        try:
+            origins.add(_normalize_origin(app_url))
+        except ValueError:
+            pass
 
     return origins
 

--- a/backend/app/modules/embed_tokens/service.py
+++ b/backend/app/modules/embed_tokens/service.py
@@ -258,6 +258,109 @@ async def _request_origin_is_allowed(
     return False
 
 
+class DomainLockNotEnforceableError(Exception):
+    """Raised when a domain lock is requested that this deployment cannot enforce.
+
+    Deliberately NOT a ``ValueError``: both write handlers map ``ValueError`` to
+    400 for the advanced-sharing edition gate, and this is a distinct condition
+    with its own status code.
+    """
+
+
+async def assert_domain_lock_is_enforceable(
+    db: AsyncSession, request: Request, allowed_origins: list[str] | None
+) -> None:
+    """Refuse to issue a domain lock this deployment could never enforce.
+
+    fix(#1548 review P2). Domain locking only works when the deployment knows
+    its own public origin, because the embed shell's API calls carry the
+    SHELL's origin (see ``_request_origin_is_allowed``). That value comes from
+    configuration, and the configuration has a default that is wrong for almost
+    every real install: ``docker-compose.yml`` and ``docker-compose.prod.yml``
+    both inject ``${PUBLIC_APP_URL:-http://localhost:8080}``, and
+    ``.env.example`` ships the line commented out. So a self-hoster reached at
+    https://maps.example.com who never set it resolves a self-origin of
+    ``http://localhost:8080``, and the #1531 fix that makes domain-locked
+    embeds work is inert for them: their embeds stay empty, with nothing said
+    at the moment they made the mistake.
+
+    We do not infer the serving origin to paper over that. Every unconfigured
+    source (``Host``, ``X-Forwarded-Host``, ``request.url``) is settable by
+    anyone who can point a DNS name at the deployment, so an inferred
+    self-origin would be satisfiable by exactly the parties a domain lock
+    excludes — a control any caller can satisfy is not a control. The operator
+    has to tell us; this makes them tell us when they turn the lock on rather
+    than silently on every later viewer request.
+
+    THE REFUSAL CONDITION is deliberately narrow: the creating request arrived
+    at a real, non-loopback origin, and every origin this deployment believes
+    is itself is a loopback one. That pair is a *proof* of unenforceability
+    rather than a guess — an embed shell served from a routable hostname can
+    never present ``http://localhost:8080`` as its origin, so the lock could
+    only ever deny. Two weaker predicates were rejected:
+
+    * "the configured value is absent" cannot be detected at all. Compose
+      injects the localhost default into the environment, so
+      ``settings.public_app_url`` is a non-empty string and ``unset`` and
+      ``deliberately localhost`` are byte-identical here.
+    * "the creating origin differs from the configured one" refuses a
+      deployment that is configured correctly. An operator whose GeoLens is
+      public at https://maps.example.com but administered over an internal
+      hostname has a working lock — the embed snippet, like every other public
+      link, is built from ``PUBLIC_APP_URL``, so viewers load the shell from
+      the configured origin and the runtime check passes. Blocking them would
+      trade codex's silent failure for a loud one on a healthy install.
+
+    A typo'd (rather than defaulted) ``PUBLIC_APP_URL`` is therefore NOT caught
+    here, by choice; the ``embed_token_domain_lock_denied`` warning logged by
+    ``_request_origin_is_allowed`` carries that case with the same remediation.
+
+    The comparison reads the creating request's own ``Origin``, which IS a
+    caller-controlled header. Sound here because it is a *diagnostic*, not an
+    authorization decision: it can only refuse to mint a token, never grant
+    access, and the caller is an already-authenticated map owner. Forging it
+    only denies yourself.
+
+    Skipped when the request carries no browser origin at all (a CLI or SDK
+    caller sends neither ``Origin`` nor ``Referer``), and when that origin is
+    itself loopback (a developer on ``localhost``/Vite is not the install this
+    is aimed at, and their runtime check passes either through the H-31
+    loopback bypass or through the localhost self-origin).
+    """
+    if not allowed_origins:
+        # Clearing or omitting a domain lock is always allowed.
+        return
+
+    if not is_enterprise():
+        # Domain locking is an advanced-sharing control, so create/update is
+        # about to reject this with ADVANCED_SHARING_ERROR regardless. Returning
+        # here keeps that the message the operator sees: telling a Community
+        # deployment to go fix PUBLIC_APP_URL would point at the wrong problem.
+        return
+
+    origin = extract_request_origin(request)
+    if origin is None or _is_localhost_origin(origin):
+        return
+
+    self_origins = await _resolve_self_origins(db, request)
+    if any(not _is_localhost_origin(o) for o in self_origins):
+        return
+
+    # Keep this wording stable: frontend/src/lib/error-map.ts matches it to
+    # render the remediation, since an unmapped 422 detail collapses to the
+    # generic "validation failed" toast and the point of this refusal is the
+    # prose.
+    resolved = ", ".join(sorted(self_origins)) or "nothing usable"
+    raise DomainLockNotEnforceableError(
+        "Domain locking cannot be enforced by this deployment: its public app "
+        f"URL resolves to {resolved}, but this request reached it at {origin}. "
+        "An embed shell's own API calls carry the shell's origin, so a "
+        "domain-locked token issued now would load an empty map. Set "
+        f"PUBLIC_APP_URL (or the public_app_url setting) to {origin} and try "
+        "again."
+    )
+
+
 def build_embed_frame_ancestors(
     *, is_valid: bool, allowed_origins: list[str] | None
 ) -> str:

--- a/backend/app/modules/settings/router.py
+++ b/backend/app/modules/settings/router.py
@@ -30,9 +30,9 @@ from app.core.persistent_config import (
 from app.platform.ratelimit import limiter
 from app.core.public_urls import (
     _is_env_only,
-    get_configured_public_app_url,
     get_public_api_url,
     get_public_app_url,
+    get_shareable_app_url,
 )
 from app.core.db.models import AppSetting
 from app.core.db.tenant_schema import tenant_data_schema
@@ -1168,15 +1168,18 @@ async def get_tile_config(
     db: AsyncSession = Depends(get_db),
 ) -> TileConfigResponse:
     """Return tile delivery configuration (public, no auth required)."""
-    # fix(#1548 review r9): the EXPLICIT setting, not the resolver. This field's
-    # only consumer is share-URL generation (frontend/src/lib/public-urls.ts),
-    # and a resolver-derived value is not the origin a browser presents when it
-    # loads the embed shell: it can be an ``/api``-stripped PUBLIC_API_URL for a
-    # split app/API deployment, or the caller's own request headers. Handing
-    # either to the share builder produces /m/ and /card links pointing at a host
-    # that does not serve them. Null when unset, which that module treats as
-    # unconfigured — fall back for ordinary shares, suppress a locked preview.
-    public_app_url = await get_configured_public_app_url(db)
+    # fix(#1548 review r9/r10): not the resolver. This field's only consumer is
+    # share-URL generation (frontend/src/lib/public-urls.ts), and a resolver
+    # INFERRED value is not the origin a browser presents when it loads the
+    # embed shell: it can be an ``/api``-stripped PUBLIC_API_URL for a split
+    # app/API deployment, or the caller's own request headers. Handing either to
+    # the share builder produces /m/ and /card links pointing at a host that does
+    # not serve them. A hosted tenant's ``tenant_public_origin`` is a different
+    # thing — middleware-validated against the tenant registry, and the only
+    # origin that is right there — so get_shareable_app_url returns it and falls
+    # back to the explicit fleet setting otherwise. Null when neither exists,
+    # which that module treats as unconfigured.
+    public_app_url = await get_shareable_app_url(db, request=request)
     public_api_url = await get_public_api_url(db, request=request)
     tenant_id = getattr(getattr(request, "state", None), "tenant_id", None)
     mvt_source_layer_prefix = (

--- a/backend/app/modules/settings/router.py
+++ b/backend/app/modules/settings/router.py
@@ -28,7 +28,12 @@ from app.core.persistent_config import (
     apply_side_effects_batch,
 )
 from app.platform.ratelimit import limiter
-from app.core.public_urls import _is_env_only, get_public_api_url, get_public_app_url
+from app.core.public_urls import (
+    _is_env_only,
+    get_configured_public_app_url,
+    get_public_api_url,
+    get_public_app_url,
+)
 from app.core.db.models import AppSetting
 from app.core.db.tenant_schema import tenant_data_schema
 from app.core.tenancy import is_multi_tenant
@@ -1163,7 +1168,15 @@ async def get_tile_config(
     db: AsyncSession = Depends(get_db),
 ) -> TileConfigResponse:
     """Return tile delivery configuration (public, no auth required)."""
-    public_app_url = await get_public_app_url(db, request=request)
+    # fix(#1548 review r9): the EXPLICIT setting, not the resolver. This field's
+    # only consumer is share-URL generation (frontend/src/lib/public-urls.ts),
+    # and a resolver-derived value is not the origin a browser presents when it
+    # loads the embed shell: it can be an ``/api``-stripped PUBLIC_API_URL for a
+    # split app/API deployment, or the caller's own request headers. Handing
+    # either to the share builder produces /m/ and /card links pointing at a host
+    # that does not serve them. Null when unset, which that module treats as
+    # unconfigured — fall back for ordinary shares, suppress a locked preview.
+    public_app_url = await get_configured_public_app_url(db)
     public_api_url = await get_public_api_url(db, request=request)
     tenant_id = getattr(getattr(request, "state", None), "tenant_id", None)
     mvt_source_layer_prefix = (

--- a/backend/app/modules/settings/schemas.py
+++ b/backend/app/modules/settings/schemas.py
@@ -116,7 +116,12 @@ class TileConfigResponse(BaseModel):
     )
     public_app_url: str | None = Field(
         default=None,
-        description="Browser-facing app URL used for share links and OAuth redirects.",
+        description=(
+            "Explicitly configured PUBLIC_APP_URL, or null when unset. Never "
+            "derived from PUBLIC_API_URL or from the request, because a share "
+            "or embed URL built on a derived value points at a host that does "
+            "not serve the app."
+        ),
     )
     public_api_url: str | None = Field(
         default=None,

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -17247,7 +17247,7 @@
                 "type": "null"
               }
             ],
-            "description": "Browser-facing app URL used for share links and OAuth redirects.",
+            "description": "Explicitly configured PUBLIC_APP_URL, or null when unset. Never derived from PUBLIC_API_URL or from the request, because a share or embed URL built on a derived value points at a host that does not serve the app.",
             "title": "Public App Url"
           },
           "public_api_url": {

--- a/backend/tests/test_embed_domain_lock_self_origin_1531.py
+++ b/backend/tests/test_embed_domain_lock_self_origin_1531.py
@@ -43,6 +43,13 @@ APP_ORIGIN = "https://maps.geolens.example"
 CUSTOMER_ORIGIN = "https://customer.example.com"
 FOREIGN_ORIGIN = "https://evil.example.net"
 
+# fix(#1548 review P2): the two halves of the shipped-default misconfiguration.
+# docker-compose.yml and docker-compose.prod.yml both inject
+# ${PUBLIC_APP_URL:-http://localhost:8080}, so an operator who never sets it
+# resolves the first while being reached at the second.
+COMPOSE_DEFAULT_APP_URL = "http://localhost:8080"
+SELF_HOSTED_ORIGIN = "https://maps.example.com"
+
 MAP_ID = uuid.UUID("00000000-0000-0000-0000-000000000002")
 DATASET_ID = uuid.UUID("00000000-0000-0000-0000-000000000001")
 RAW_TOKEN = "et_domain_locked_probe"
@@ -446,3 +453,322 @@ def test_frame_ancestors_directive_carries_the_self_half():
         is_valid=True, allowed_origins=[CUSTOMER_ORIGIN]
     )
     assert directive == f"frame-ancestors 'self' {CUSTOMER_ORIGIN}"
+
+
+class TestDomainLockIsRefusedWhenUnenforceable:
+    """fix(#1548 review P2): the #1531 fix is inert in the SHIPPED configuration.
+
+    ``docker-compose.yml`` and ``docker-compose.prod.yml`` both inject
+    ``${PUBLIC_APP_URL:-http://localhost:8080}`` and ``.env.example`` ships the
+    line commented out, so a self-hoster reached at https://maps.example.com who
+    never set it resolves a self-origin of ``http://localhost:8080``. Their
+    domain-locked embeds stay empty and nothing is said at the moment they
+    turned the lock on. ``assert_domain_lock_is_enforceable`` refuses there
+    instead, naming ``PUBLIC_APP_URL``.
+
+    The refusal is deliberately narrow — a real, non-loopback creating origin
+    against an all-loopback set of self-origins — because that pair PROVES
+    unenforceability. ``test_a_correctly_configured_deployment_is_never_refused``
+    is the guard on the other side: a wider "the two origins simply disagree"
+    rule would block an operator whose config is fine.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _enterprise(self, monkeypatch):
+        """Domain locking is an advanced-sharing control, so the gate only
+        applies where the feature exists."""
+        monkeypatch.setattr(embed_service, "is_enterprise", lambda: True)
+
+    @staticmethod
+    def _self_origin_is(monkeypatch, value: str | None) -> None:
+        """Override the module-level fixture's configured self-origin.
+
+        ``value=None`` stands in for a lookup that fails outright, which
+        ``_resolve_self_origins`` swallows into an empty set.
+        """
+
+        async def _fake_get_public_app_url(db, **kwargs):
+            if value is None:
+                raise RuntimeError("AppSetting lookup failed")
+            return value
+
+        monkeypatch.setattr(
+            embed_service, "get_public_app_url", _fake_get_public_app_url, raising=True
+        )
+
+    # -- the reported bug -------------------------------------------------
+
+    @pytest.mark.anyio
+    async def test_the_shipped_default_is_refused(self, monkeypatch):
+        """codex #1548 P2, verbatim: PUBLIC_APP_URL left at the compose default
+        while the deployment is reached through a real hostname."""
+        self._self_origin_is(monkeypatch, COMPOSE_DEFAULT_APP_URL)
+        request = _make_request(origin=SELF_HOSTED_ORIGIN)
+
+        with pytest.raises(embed_service.DomainLockNotEnforceableError) as exc:
+            await embed_service.assert_domain_lock_is_enforceable(
+                AsyncMock(), request, [CUSTOMER_ORIGIN]
+            )
+
+        message = str(exc.value)
+        assert "PUBLIC_APP_URL" in message, "name the variable to set"
+        assert COMPOSE_DEFAULT_APP_URL in message, "name what it resolved to"
+        assert SELF_HOSTED_ORIGIN in message, "name where the request arrived"
+
+    @pytest.mark.anyio
+    async def test_the_refused_configuration_really_would_deliver_nothing(
+        self, monkeypatch
+    ):
+        """Vacuity guard: tie the 422 to the runtime behaviour it stands in for.
+
+        If this deployment issued the token anyway, the shell's own request —
+        the exact one #1531 taught the check to accept — is still denied,
+        because the self-origin it is compared against is localhost. Without
+        this, the gate above could be refusing a configuration that in fact
+        works, and every assertion in it would still pass.
+        """
+        self._self_origin_is(monkeypatch, COMPOSE_DEFAULT_APP_URL)
+        shell_request = _make_request(
+            referer=f"{SELF_HOSTED_ORIGIN}/m/share-token?et={RAW_TOKEN}"
+        )
+        assert await _scope(shell_request, [CUSTOMER_ORIGIN]) == set()
+
+    @pytest.mark.anyio
+    async def test_an_unresolvable_public_url_is_refused(self, monkeypatch):
+        """A garbage or unreadable setting resolves to no self-origin at all,
+        which is equally unenforceable."""
+        self._self_origin_is(monkeypatch, None)
+        with pytest.raises(embed_service.DomainLockNotEnforceableError) as exc:
+            await embed_service.assert_domain_lock_is_enforceable(
+                AsyncMock(), _make_request(origin=SELF_HOSTED_ORIGIN), [CUSTOMER_ORIGIN]
+            )
+        assert "nothing usable" in str(exc.value)
+
+    # -- everything the refusal must NOT touch ----------------------------
+
+    @pytest.mark.anyio
+    @pytest.mark.parametrize(
+        "creating_origin",
+        [SELF_HOSTED_ORIGIN, APP_ORIGIN, "https://internal.corp:8443"],
+        ids=["same-host", "configured-host", "internal-admin-host"],
+    )
+    async def test_a_correctly_configured_deployment_is_never_refused(
+        self, monkeypatch, creating_origin
+    ):
+        """The guard against over-refusing.
+
+        Once PUBLIC_APP_URL names a real origin the lock works, and WHICH
+        hostname the owner happened to administer through does not change that:
+        the embed snippet, like every other public link, is built from
+        PUBLIC_APP_URL, so viewers load the shell from the configured origin.
+        A rule of "the creating origin differs from the configured one" would
+        fail the third case here on a perfectly healthy install.
+        """
+        self._self_origin_is(monkeypatch, SELF_HOSTED_ORIGIN)
+        await embed_service.assert_domain_lock_is_enforceable(
+            AsyncMock(), _make_request(origin=creating_origin), [CUSTOMER_ORIGIN]
+        )
+
+    @pytest.mark.anyio
+    async def test_a_localhost_install_reached_at_localhost_is_not_refused(
+        self, monkeypatch
+    ):
+        """The default stack, used as intended.
+
+        ``client_host`` is deliberately NOT loopback: in the shipped compose
+        stack nginx proxies to the api container, so ``request.client.host`` is
+        a bridge IP even for a browser on the host. A gate that leaned on the
+        H-31 loopback bypass to recognize this case would refuse every default
+        install.
+        """
+        self._self_origin_is(monkeypatch, COMPOSE_DEFAULT_APP_URL)
+        await embed_service.assert_domain_lock_is_enforceable(
+            AsyncMock(),
+            _make_request(origin=COMPOSE_DEFAULT_APP_URL, client_host="172.18.0.5"),
+            [CUSTOMER_ORIGIN],
+        )
+
+    @pytest.mark.anyio
+    async def test_a_vite_dev_origin_is_not_refused(self, monkeypatch):
+        """Frontend dev runs on :5174 against the same backend. Not the install
+        this gate is aimed at."""
+        self._self_origin_is(monkeypatch, COMPOSE_DEFAULT_APP_URL)
+        await embed_service.assert_domain_lock_is_enforceable(
+            AsyncMock(),
+            _make_request(origin="http://localhost:5174", client_host="172.18.0.5"),
+            [CUSTOMER_ORIGIN],
+        )
+
+    @pytest.mark.anyio
+    async def test_a_hosted_tenant_origin_satisfies_the_gate(self, monkeypatch):
+        """Hosted multi-tenant resolves its origin from the tenant registry, so
+        the fleet-wide PUBLIC_APP_URL being the localhost default is irrelevant
+        there. ``_resolve_self_origins`` already contributes the tenant origin;
+        this pins that the gate reads it rather than only the app URL."""
+        self._self_origin_is(monkeypatch, COMPOSE_DEFAULT_APP_URL)
+        monkeypatch.setattr(embed_service, "is_multi_tenant", lambda: True)
+        await embed_service.assert_domain_lock_is_enforceable(
+            AsyncMock(),
+            _make_request(
+                origin=SELF_HOSTED_ORIGIN, tenant_public_origin=SELF_HOSTED_ORIGIN
+            ),
+            [CUSTOMER_ORIGIN],
+        )
+
+    @pytest.mark.anyio
+    async def test_clearing_a_lock_is_never_refused(self, monkeypatch):
+        self._self_origin_is(monkeypatch, COMPOSE_DEFAULT_APP_URL)
+        request = _make_request(origin=SELF_HOSTED_ORIGIN)
+        await embed_service.assert_domain_lock_is_enforceable(
+            AsyncMock(), request, None
+        )
+        await embed_service.assert_domain_lock_is_enforceable(AsyncMock(), request, [])
+
+    @pytest.mark.anyio
+    async def test_a_non_browser_caller_is_not_refused(self, monkeypatch):
+        """A CLI or SDK caller sends neither Origin nor Referer, so there is
+        nothing to compare. Blocking would be a guess; the runtime denial log
+        covers that case instead."""
+        self._self_origin_is(monkeypatch, COMPOSE_DEFAULT_APP_URL)
+        await embed_service.assert_domain_lock_is_enforceable(
+            AsyncMock(), _make_request(), [CUSTOMER_ORIGIN]
+        )
+
+    @pytest.mark.anyio
+    async def test_community_keeps_the_edition_message(self, monkeypatch):
+        """On Community, create/update is about to reject this with
+        ADVANCED_SHARING_ERROR. Pointing the operator at PUBLIC_APP_URL instead
+        would name the wrong problem."""
+        self._self_origin_is(monkeypatch, COMPOSE_DEFAULT_APP_URL)
+        monkeypatch.setattr(embed_service, "is_enterprise", lambda: False)
+        await embed_service.assert_domain_lock_is_enforceable(
+            AsyncMock(), _make_request(origin=SELF_HOSTED_ORIGIN), [CUSTOMER_ORIGIN]
+        )
+
+    # -- wiring -----------------------------------------------------------
+
+    def test_both_write_handlers_call_the_gate(self):
+        """The two handlers that accept allowed_origins are the same
+        two-readers-of-one-policy shape that produced the original bug. Assert
+        both are wired, not just the one fixed first."""
+        import ast
+        import inspect
+
+        from app.modules.embed_tokens import router as embed_router
+
+        tree = ast.parse(inspect.getsource(embed_router))
+        gated = {
+            node.name
+            for node in ast.walk(tree)
+            if isinstance(node, ast.AsyncFunctionDef)
+            and any(
+                isinstance(call.func, ast.Name)
+                and call.func.id == "assert_domain_lock_is_enforceable"
+                for call in ast.walk(node)
+                if isinstance(call, ast.Call)
+            )
+        }
+        assert gated == {
+            "create_embed_token_endpoint",
+            "update_embed_token_endpoint",
+        }, f"handlers accepting allowed_origins must all gate; gated={sorted(gated)}"
+
+
+@pytest.mark.anyio
+async def test_the_refusal_message_matches_the_frontend_matcher(monkeypatch):
+    """fix(#1548 review P2): the 422 must not be mute in the builder.
+
+    ``frontend/src/lib/error-map.ts`` collapses an unmapped 422 detail to the
+    generic ``errors.validationFailed`` toast, and the whole point of this
+    refusal is its prose — which variable to set, and to what. The frontend
+    matches the message by regex to render a localized remediation, so the
+    wording is a contract spanning two languages, which is exactly the shape
+    that produced the bug this PR fixes. Assert it from the Python side too, so
+    reworded prose fails here rather than silently degrading the toast.
+    """
+    import re
+    from pathlib import Path
+
+    error_map = (
+        Path(__file__)
+        .resolve()
+        .parents[2]
+        .joinpath("frontend", "src", "lib", "error-map.ts")
+    )
+    if not error_map.is_file():
+        pytest.skip("frontend tree not present in this checkout")
+
+    async def _fake_get_public_app_url(db, **kwargs):
+        return COMPOSE_DEFAULT_APP_URL
+
+    monkeypatch.setattr(embed_service, "is_enterprise", lambda: True)
+    monkeypatch.setattr(
+        embed_service, "get_public_app_url", _fake_get_public_app_url, raising=True
+    )
+
+    with pytest.raises(embed_service.DomainLockNotEnforceableError) as exc:
+        await embed_service.assert_domain_lock_is_enforceable(
+            AsyncMock(), _make_request(origin=SELF_HOSTED_ORIGIN), [CUSTOMER_ORIGIN]
+        )
+    message = str(exc.value)
+
+    declaration = re.search(
+        r"const domainLockUnenforceable = message\.match\(\s*/(.+?)/[a-z]*,?\s*\);",
+        error_map.read_text(encoding="utf-8"),
+        re.S,
+    )
+    assert declaration, (
+        "frontend/src/lib/error-map.ts must keep a `domainLockUnenforceable` "
+        "matcher for this refusal; without it the builder shows the generic "
+        "'validation failed' toast and the remediation never reaches the operator."
+    )
+    js_regex = declaration.group(1).replace("\\/", "/").strip()
+    match = re.match(js_regex, message)
+    assert match, (
+        "the backend refusal message no longer matches the frontend matcher, so "
+        "the builder would fall back to the generic 422 toast.\n"
+        f"  message: {message}\n  pattern: {js_regex}"
+    )
+    assert match.group(1) == COMPOSE_DEFAULT_APP_URL, "group 1 is the resolved URL"
+    assert match.group(2) == SELF_HOSTED_ORIGIN, "group 2 is the origin to set"
+
+
+def test_mock_db_suites_that_exercise_a_domain_lock_stub_the_lookup():
+    """fix(#1548 review P2): cover the class, not just the one file.
+
+    The self-origin lookup reads an AppSetting row, so a test that drives a
+    domain-locked token against a mock database reaches it and gets a
+    ``TypeError`` on a cold public-URL cache. That used to surface as an error;
+    now that the service fails closed it surfaces as a *silent* deny, so such a
+    test would assert "foreign origin rejected" and pass without exercising the
+    rule at all. Any suite in that shape must stub ``get_public_app_url``.
+    """
+    from pathlib import Path
+
+    readers = ("validate_embed_token_access", "resolve_embed_scope_for_map")
+    offenders: list[str] = []
+    for path in sorted(Path(__file__).parent.glob("test_*.py")):
+        text = path.read_text(encoding="utf-8")
+        if not any(r in text for r in readers):
+            continue
+        mocks_the_db = "AsyncMock()" in text or "MagicMock()" in text
+        # A non-empty allowed_origins is what routes execution to the lookup;
+        # `allowed_origins=None` / `"allowed_origins": None` never reaches it.
+        sets_a_lock = "allowed_origins" in text and any(
+            marker in text
+            for marker in (
+                'allowed_origins": ["',
+                'allowed_origins=["',
+                "allowed_origins, [",
+            )
+        )
+        if mocks_the_db and sets_a_lock and "get_public_app_url" not in text:
+            offenders.append(path.name)
+
+    assert not offenders, (
+        "These suites drive a domain-locked embed token against a mock database "
+        "without stubbing get_public_app_url, so the self-origin lookup fails and "
+        "the check denies for the wrong reason. Add a fixture that patches "
+        "embed_service.get_public_app_url (see test_embed_tokens_origin_bypass.py):\n"
+        + "\n".join(f"  {name}" for name in offenders)
+    )

--- a/backend/tests/test_embed_domain_lock_self_origin_1531.py
+++ b/backend/tests/test_embed_domain_lock_self_origin_1531.py
@@ -95,17 +95,55 @@ def _token_row(allowed_origins: list[str] | None) -> SimpleNamespace:
 def _self_origin_is_configured(monkeypatch):
     """Our own public origin comes from configuration, never from the request."""
 
-    async def _fake_get_public_app_url(db, **kwargs):
-        assert kwargs.get("request") is None, (
-            "fix(#1531): _resolve_self_origins must NOT forward the request to "
-            "get_public_app_url. Its unconfigured fallback derives an origin "
-            "from the caller's own Origin/Referer, which would make EVERY "
-            "origin 'self' and the allowlist vacuous."
+    async def _fake_get_configured_public_app_url(db, **kwargs):
+        assert not kwargs, (
+            "fix(#1531/#1548 r9): _resolve_self_origins must pass nothing but the "
+            "session. A request-derived origin is one every caller satisfies, "
+            "which would make the allowlist vacuous."
         )
         return APP_ORIGIN
 
     monkeypatch.setattr(
-        embed_service, "get_public_app_url", _fake_get_public_app_url, raising=True
+        embed_service,
+        "get_configured_public_app_url",
+        _fake_get_configured_public_app_url,
+        raising=True,
+    )
+
+
+def test_the_self_origin_lookup_cannot_be_told_about_the_request():
+    """fix(#1548 review r9): the #1531 invariant, now structural.
+
+    It used to be asserted by a fixture watching for a ``request=`` kwarg, which
+    the switch to ``get_configured_public_app_url`` quietly made vacuous — that
+    function has no such parameter to pass. Assert the real property instead:
+    the accessor the service depends on takes the session and nothing else, so
+    there is no argument through which a caller-controlled origin could reach
+    it, and it is not the resolver that has those fallbacks.
+    """
+    import inspect
+
+    from app.core import public_urls
+
+    params = list(
+        inspect.signature(public_urls.get_configured_public_app_url).parameters
+    )
+    assert params == ["db"], (
+        "get_configured_public_app_url must take only the session; a request or "
+        f"fallback parameter reopens the vacuous-self trap. Got: {params}"
+    )
+    # Read the import from source: the autouse fixture above has replaced the
+    # live attribute, so an identity check here would only inspect the stub.
+    from pathlib import Path
+
+    service_src = Path(embed_service.__file__).read_text(encoding="utf-8")
+    assert "get_configured_public_app_url" in service_src, (
+        "the embed service must depend on the explicit accessor"
+    )
+    assert "import get_public_app_url" not in service_src, (
+        "the embed service must NOT import the resolver: its fallbacks name an "
+        "/api-stripped PUBLIC_API_URL or the caller's own headers, neither of "
+        "which is the origin our embed shell is served from"
     )
 
 
@@ -358,7 +396,9 @@ class TestUnresolvableSelfOriginFailsClosed:
         async def _boom(db, **kwargs):
             raise RuntimeError("public_app_url lookup failed")
 
-        monkeypatch.setattr(embed_service, "get_public_app_url", _boom, raising=True)
+        monkeypatch.setattr(
+            embed_service, "get_configured_public_app_url", _boom, raising=True
+        )
 
     @pytest.mark.anyio
     async def test_resolve_self_origins_returns_empty_instead_of_raising(
@@ -397,8 +437,8 @@ class TestUnresolvableSelfOriginFailsClosed:
         # exactly what used to mask this.
         monkeypatch.setattr(
             embed_service,
-            "get_public_app_url",
-            public_urls.get_public_app_url,
+            "get_configured_public_app_url",
+            public_urls.get_configured_public_app_url,
             raising=True,
         )
         public_urls.invalidate_public_url_cache()
@@ -425,7 +465,10 @@ class TestMisconfiguredDeploymentIsDiagnosable:
             return "http://localhost:8080"
 
         monkeypatch.setattr(
-            embed_service, "get_public_app_url", _default_compose_value, raising=True
+            embed_service,
+            "get_configured_public_app_url",
+            _default_compose_value,
+            raising=True,
         )
         events: list[dict] = []
         monkeypatch.setattr(
@@ -487,13 +530,16 @@ class TestDomainLockIsRefusedWhenUnenforceable:
         ``_resolve_self_origins`` swallows into an empty set.
         """
 
-        async def _fake_get_public_app_url(db, **kwargs):
+        async def _fake_get_configured_public_app_url(db, **kwargs):
             if value is None:
                 raise RuntimeError("AppSetting lookup failed")
             return value
 
         monkeypatch.setattr(
-            embed_service, "get_public_app_url", _fake_get_public_app_url, raising=True
+            embed_service,
+            "get_configured_public_app_url",
+            _fake_get_configured_public_app_url,
+            raising=True,
         )
 
     # -- the reported bug -------------------------------------------------
@@ -698,12 +744,15 @@ async def test_the_refusal_message_matches_the_frontend_matcher(monkeypatch):
     if not error_map.is_file():
         pytest.skip("frontend tree not present in this checkout")
 
-    async def _fake_get_public_app_url(db, **kwargs):
+    async def _fake_get_configured_public_app_url(db, **kwargs):
         return COMPOSE_DEFAULT_APP_URL
 
     monkeypatch.setattr(embed_service, "is_enterprise", lambda: True)
     monkeypatch.setattr(
-        embed_service, "get_public_app_url", _fake_get_public_app_url, raising=True
+        embed_service,
+        "get_configured_public_app_url",
+        _fake_get_configured_public_app_url,
+        raising=True,
     )
 
     with pytest.raises(embed_service.DomainLockNotEnforceableError) as exc:
@@ -741,7 +790,7 @@ def test_mock_db_suites_that_exercise_a_domain_lock_stub_the_lookup():
     ``TypeError`` on a cold public-URL cache. That used to surface as an error;
     now that the service fails closed it surfaces as a *silent* deny, so such a
     test would assert "foreign origin rejected" and pass without exercising the
-    rule at all. Any suite in that shape must stub ``get_public_app_url``.
+    rule at all. Any suite in that shape must stub ``get_configured_public_app_url``.
     """
     from pathlib import Path
 
@@ -762,13 +811,13 @@ def test_mock_db_suites_that_exercise_a_domain_lock_stub_the_lookup():
                 "allowed_origins, [",
             )
         )
-        if mocks_the_db and sets_a_lock and "get_public_app_url" not in text:
+        if mocks_the_db and sets_a_lock and "get_configured_public_app_url" not in text:
             offenders.append(path.name)
 
     assert not offenders, (
         "These suites drive a domain-locked embed token against a mock database "
-        "without stubbing get_public_app_url, so the self-origin lookup fails and "
+        "without stubbing get_configured_public_app_url, so the self-origin lookup fails and "
         "the check denies for the wrong reason. Add a fixture that patches "
-        "embed_service.get_public_app_url (see test_embed_tokens_origin_bypass.py):\n"
+        "embed_service.get_configured_public_app_url (see test_embed_tokens_origin_bypass.py):\n"
         + "\n".join(f"  {name}" for name in offenders)
     )

--- a/backend/tests/test_embed_domain_lock_self_origin_1531.py
+++ b/backend/tests/test_embed_domain_lock_self_origin_1531.py
@@ -339,6 +339,106 @@ class TestSelfOriginIsServerDerived:
         assert FOREIGN_ORIGIN not in origins
 
 
+class TestUnresolvableSelfOriginFailsClosed:
+    """fix(#1548 review P2): the self-origin lookup reads an AppSetting row, so
+    it is the one part of this check that can fail for reasons unrelated to the
+    decision. It must deny rather than propagate: every other denial here
+    returns a bool, and an escaping exception would turn a routine deny into a
+    500 on the tile path."""
+
+    @pytest.fixture
+    def _lookup_raises(self, monkeypatch):
+        async def _boom(db, **kwargs):
+            raise RuntimeError("public_app_url lookup failed")
+
+        monkeypatch.setattr(embed_service, "get_public_app_url", _boom, raising=True)
+
+    @pytest.mark.anyio
+    async def test_resolve_self_origins_returns_empty_instead_of_raising(
+        self, _lookup_raises
+    ):
+        origins = await embed_service._resolve_self_origins(
+            AsyncMock(), _make_request(referer=SHELL_REFERER)
+        )
+        assert origins == set()
+
+    @pytest.mark.anyio
+    async def test_scope_resolution_denies_and_does_not_raise(self, _lookup_raises):
+        assert (
+            await _scope(_make_request(referer=SHELL_REFERER), [CUSTOMER_ORIGIN])
+            == set()
+        )
+
+    @pytest.mark.anyio
+    async def test_tile_access_denies_and_does_not_raise(
+        self, _lookup_raises, monkeypatch
+    ):
+        request = _make_request(referer=SHELL_REFERER)
+        assert await _validate(request, [CUSTOMER_ORIGIN], monkeypatch) is False
+
+    @pytest.mark.anyio
+    async def test_a_mock_database_does_not_leak_a_typeerror(self, monkeypatch):
+        """The concrete shape that regressed: a unit test passing an AsyncMock
+        db reaches _load_public_url_overrides on a cold public-URL cache. That
+        used to escape as `TypeError: 'coroutine' object is not iterable` and
+        was masked whenever an earlier test had primed the module-global cache,
+        making the whole suite order-dependent."""
+        from app.core import public_urls
+
+        # Restore the REAL lookup over the autouse fake, and clear the
+        # module-global 60s cache so it actually queries. Priming that cache is
+        # exactly what used to mask this.
+        monkeypatch.setattr(
+            embed_service,
+            "get_public_app_url",
+            public_urls.get_public_app_url,
+            raising=True,
+        )
+        public_urls.invalidate_public_url_cache()
+        try:
+            origins = await embed_service._resolve_self_origins(
+                AsyncMock(), _make_request(referer=SHELL_REFERER)
+            )
+        finally:
+            public_urls.invalidate_public_url_cache()
+        assert origins == set()
+
+
+class TestMisconfiguredDeploymentIsDiagnosable:
+    """fix(#1548 review P2): compose injects PUBLIC_APP_URL=http://localhost:8080
+    by default, so a self-hoster on https://maps.example.com who never sets it
+    resolves the wrong self-origin and their domain-locked embeds stay empty.
+    The server cannot correct that without a request-derived origin, which is
+    settable by anyone who can point DNS at the deployment. It denies, and says
+    why."""
+
+    @pytest.mark.anyio
+    async def test_denies_and_logs_the_remediation(self, monkeypatch):
+        async def _default_compose_value(db, **kwargs):
+            return "http://localhost:8080"
+
+        monkeypatch.setattr(
+            embed_service, "get_public_app_url", _default_compose_value, raising=True
+        )
+        events: list[dict] = []
+        monkeypatch.setattr(
+            embed_service.logger,
+            "warning",
+            lambda ev, **kw: events.append({**kw, "event": ev}),
+        )
+
+        # Shell served from the real hostname; client is not loopback.
+        request = _make_request(referer="https://maps.example.com/m/share-token")
+        assert await _scope(request, [CUSTOMER_ORIGIN]) == set()
+
+        assert events, "a domain-lock denial must be diagnosable from the logs"
+        event = events[-1]
+        assert event["event"] == "embed_token_domain_lock_denied"
+        assert event["request_origin"] == "https://maps.example.com"
+        assert event["self_origins"] == ["http://localhost:8080"]
+        assert "PUBLIC_APP_URL" in event["remediation"]
+
+
 def test_frame_ancestors_directive_carries_the_self_half():
     """The API check now mirrors the CSP directive it sits under: both accept
     our own origin plus the configured embedder origins."""

--- a/backend/tests/test_embed_domain_lock_self_origin_1531.py
+++ b/backend/tests/test_embed_domain_lock_self_origin_1531.py
@@ -1,0 +1,348 @@
+"""fix(#1531): a domain-locked embed token must deliver scoped layers to a browser embed.
+
+Domain locking is enforced in two layers. The ``/m/{token}`` embed shell is
+served with ``frame-ancestors 'self' <allowed_origins>``
+(``build_embed_frame_ancestors``) — a browser-enforced control keyed on the
+PARENT page's actual origin. The API-layer allowlist below it accepted only
+``<allowed_origins>``, with no ``'self'`` equivalent.
+
+Measured against the dev stack (Chrome, via the ``/m/`` shell): an API
+subresource request issued from inside the embed iframe carries **no Origin
+header at all** (it is same-origin to the shell) and a ``Referer`` of the
+shell's own URL. The embedder's origin is not on the request; it is visible
+only on the navigation that loads the iframe, which is exactly where
+``frame-ancestors`` enforces it. So every scoped-layer request resolved to the
+GeoLens app's own origin, matched nothing in ``allowed_origins`` (which holds
+the CUSTOMER's domain), and was denied — the feature was broken closed.
+
+Two independent readers gate on ``allowed_origins``:
+``resolve_embed_scope_for_map`` (shared-map metadata → which layers exist) and
+``validate_embed_token_access`` (tiles / bounded GeoJSON → whether they can be
+drawn). Every case below is asserted against BOTH; a fix that lands on one path
+and leaves the sibling on the old rules is the failure mode these tests exist
+to catch.
+
+The vacuity guard is ``TestForeignOriginStillDenied``: it must FAIL in the
+opposite direction from the iframe tests. If the self-origin rule were written
+so that the request itself supplies "self", the iframe tests would pass and so
+would the foreign-origin ones, which would mean nothing was checked at all.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.modules.embed_tokens import service as embed_service
+
+APP_ORIGIN = "https://maps.geolens.example"
+CUSTOMER_ORIGIN = "https://customer.example.com"
+FOREIGN_ORIGIN = "https://evil.example.net"
+
+MAP_ID = uuid.UUID("00000000-0000-0000-0000-000000000002")
+DATASET_ID = uuid.UUID("00000000-0000-0000-0000-000000000001")
+RAW_TOKEN = "et_domain_locked_probe"
+
+# What Chrome actually sent on the shared-map request from inside the shell:
+# no Origin, Referer = the shell's own URL. Captured from the dev stack.
+SHELL_REFERER = f"{APP_ORIGIN}/m/share-token?et={RAW_TOKEN}"
+
+
+def _make_request(
+    *,
+    origin: str | None = None,
+    referer: str | None = None,
+    client_host: str | None = "10.1.2.3",
+    tenant_public_origin: str | None = None,
+) -> MagicMock:
+    headers: dict[str, str] = {}
+    if origin is not None:
+        headers["origin"] = origin
+    if referer is not None:
+        headers["referer"] = referer
+    request = MagicMock()
+    request.headers = headers
+    request.client = (
+        SimpleNamespace(host=client_host) if client_host is not None else None
+    )
+    request.state = SimpleNamespace(tenant_public_origin=tenant_public_origin)
+    return request
+
+
+def _token_row(allowed_origins: list[str] | None) -> SimpleNamespace:
+    return SimpleNamespace(
+        id=uuid.uuid4(),
+        map_id=MAP_ID,
+        allowed_origins=allowed_origins,
+        scoped_dataset_ids=[str(DATASET_ID)],
+        tenant_id=None,
+        expires_at=datetime.now(timezone.utc) + timedelta(days=1),
+    )
+
+
+@pytest.fixture(autouse=True)
+def _self_origin_is_configured(monkeypatch):
+    """Our own public origin comes from configuration, never from the request."""
+
+    async def _fake_get_public_app_url(db, **kwargs):
+        assert kwargs.get("request") is None, (
+            "fix(#1531): _resolve_self_origins must NOT forward the request to "
+            "get_public_app_url. Its unconfigured fallback derives an origin "
+            "from the caller's own Origin/Referer, which would make EVERY "
+            "origin 'self' and the allowlist vacuous."
+        )
+        return APP_ORIGIN
+
+    monkeypatch.setattr(
+        embed_service, "get_public_app_url", _fake_get_public_app_url, raising=True
+    )
+
+
+# --------------------------------------------------------------------------
+# Reader 1: resolve_embed_scope_for_map (shared-map metadata)
+# --------------------------------------------------------------------------
+
+
+def _db_returning(token) -> AsyncMock:
+    db = AsyncMock()
+    result = MagicMock()
+    result.scalar_one_or_none = MagicMock(return_value=token)
+    db.execute = AsyncMock(return_value=result)
+    return db
+
+
+async def _scope(request, allowed_origins: list[str] | None) -> set[uuid.UUID]:
+    return await embed_service.resolve_embed_scope_for_map(
+        _db_returning(_token_row(allowed_origins)), RAW_TOKEN, MAP_ID, request
+    )
+
+
+# --------------------------------------------------------------------------
+# Reader 2: validate_embed_token_access (tiles / bounded GeoJSON)
+# --------------------------------------------------------------------------
+
+
+async def _validate(request, allowed_origins: list[str] | None, monkeypatch) -> bool:
+    """Drive validate_embed_token_access through its cache-hit path."""
+    cache = AsyncMock()
+    cache.get = AsyncMock(
+        return_value={
+            "is_valid": True,
+            "scoped_dataset_ids": [str(DATASET_ID)],
+            "allowed_origins": allowed_origins,
+            "map_id": str(MAP_ID),
+            "expires_at": (datetime.now(timezone.utc) + timedelta(days=1)).isoformat(),
+            "tenant_id": None,
+        }
+    )
+    cache.set = AsyncMock()
+    cache.delete = AsyncMock()
+    monkeypatch.setattr(embed_service, "get_cache", lambda: cache)
+    monkeypatch.setattr(
+        embed_service, "map_contains_dataset", AsyncMock(return_value=True)
+    )
+    return await embed_service.validate_embed_token_access(
+        RAW_TOKEN, DATASET_ID, AsyncMock(), request
+    )
+
+
+async def _validate_cache_miss(
+    request, allowed_origins: list[str] | None, monkeypatch
+) -> bool:
+    """Drive the same function through its DB path — the one production hits first."""
+    cache = AsyncMock()
+    cache.get = AsyncMock(return_value=None)
+    cache.set = AsyncMock()
+    cache.delete = AsyncMock()
+    monkeypatch.setattr(embed_service, "get_cache", lambda: cache)
+    monkeypatch.setattr(
+        embed_service, "map_contains_dataset", AsyncMock(return_value=True)
+    )
+    monkeypatch.setattr(
+        embed_service, "_bump_embed_token_usage_detached", AsyncMock(return_value=None)
+    )
+    return await embed_service.validate_embed_token_access(
+        RAW_TOKEN, DATASET_ID, _db_returning(_token_row(allowed_origins)), request
+    )
+
+
+class TestIframeEmbedIsDelivered:
+    """The bug: a browser embed carries OUR origin, so the lock denied everything."""
+
+    @pytest.mark.anyio
+    async def test_scope_resolution_accepts_the_shell_referer(self):
+        request = _make_request(referer=SHELL_REFERER)
+        assert await _scope(request, [CUSTOMER_ORIGIN]) == {DATASET_ID}
+
+    @pytest.mark.anyio
+    async def test_tile_access_accepts_the_shell_referer(self, monkeypatch):
+        request = _make_request(referer=SHELL_REFERER)
+        assert await _validate(request, [CUSTOMER_ORIGIN], monkeypatch) is True
+
+    @pytest.mark.anyio
+    async def test_tile_access_accepts_the_shell_referer_on_the_db_path(
+        self, monkeypatch
+    ):
+        request = _make_request(referer=SHELL_REFERER)
+        assert (
+            await _validate_cache_miss(request, [CUSTOMER_ORIGIN], monkeypatch) is True
+        )
+
+    @pytest.mark.anyio
+    async def test_scope_resolution_accepts_an_explicit_self_origin_header(self):
+        """A split app/API deployment makes the same call cross-origin, so the
+        browser DOES send Origin — still our own origin, not the embedder's."""
+        request = _make_request(origin=APP_ORIGIN)
+        assert await _scope(request, [CUSTOMER_ORIGIN]) == {DATASET_ID}
+
+    @pytest.mark.anyio
+    async def test_tile_access_accepts_an_explicit_self_origin_header(
+        self, monkeypatch
+    ):
+        request = _make_request(origin=APP_ORIGIN)
+        assert await _validate(request, [CUSTOMER_ORIGIN], monkeypatch) is True
+
+
+class TestDirectApiPathStillWorks:
+    """The path the check was always correct for: the customer's own JavaScript
+    calls the API directly, so the browser sends the customer's real origin."""
+
+    @pytest.mark.anyio
+    async def test_scope_resolution_accepts_the_allowlisted_origin(self):
+        request = _make_request(origin=CUSTOMER_ORIGIN)
+        assert await _scope(request, [CUSTOMER_ORIGIN]) == {DATASET_ID}
+
+    @pytest.mark.anyio
+    async def test_tile_access_accepts_the_allowlisted_origin(self, monkeypatch):
+        request = _make_request(origin=CUSTOMER_ORIGIN)
+        assert await _validate(request, [CUSTOMER_ORIGIN], monkeypatch) is True
+
+
+class TestForeignOriginStillDenied:
+    """Vacuity guard. These must stay red in the opposite direction from
+    TestIframeEmbedIsDelivered: if accepting "self" ever resolves "self" from
+    something the caller sends, every one of these flips to a pass and the
+    domain lock means nothing."""
+
+    @pytest.mark.anyio
+    async def test_scope_resolution_denies_a_foreign_origin(self):
+        request = _make_request(origin=FOREIGN_ORIGIN)
+        assert await _scope(request, [CUSTOMER_ORIGIN]) == set()
+
+    @pytest.mark.anyio
+    async def test_tile_access_denies_a_foreign_origin(self, monkeypatch):
+        request = _make_request(origin=FOREIGN_ORIGIN)
+        assert await _validate(request, [CUSTOMER_ORIGIN], monkeypatch) is False
+
+    @pytest.mark.anyio
+    async def test_scope_resolution_denies_a_foreign_referer(self):
+        request = _make_request(referer=f"{FOREIGN_ORIGIN}/attack.html")
+        assert await _scope(request, [CUSTOMER_ORIGIN]) == set()
+
+    @pytest.mark.anyio
+    async def test_tile_access_denies_a_foreign_referer(self, monkeypatch):
+        request = _make_request(referer=f"{FOREIGN_ORIGIN}/attack.html")
+        assert await _validate(request, [CUSTOMER_ORIGIN], monkeypatch) is False
+
+    @pytest.mark.anyio
+    async def test_scope_resolution_denies_a_headerless_request(self):
+        assert await _scope(_make_request(), [CUSTOMER_ORIGIN]) == set()
+
+    @pytest.mark.anyio
+    async def test_tile_access_denies_a_headerless_request(self, monkeypatch):
+        assert await _validate(_make_request(), [CUSTOMER_ORIGIN], monkeypatch) is False
+
+    @pytest.mark.anyio
+    async def test_scope_resolution_denies_when_there_is_no_request(self):
+        db = _db_returning(_token_row([CUSTOMER_ORIGIN]))
+        scope = await embed_service.resolve_embed_scope_for_map(
+            db, RAW_TOKEN, MAP_ID, None
+        )
+        assert scope == set()
+
+    @pytest.mark.anyio
+    async def test_tile_access_denies_when_there_is_no_request(self, monkeypatch):
+        assert await _validate(None, [CUSTOMER_ORIGIN], monkeypatch) is False
+
+
+class TestLocalhostBypassPreserved:
+    """Phase 268 H-31 is untouched: the localhost-Origin dev bypass still
+    requires the actual TCP peer to be loopback."""
+
+    @pytest.mark.anyio
+    async def test_forged_localhost_origin_from_a_remote_peer_is_denied(
+        self, monkeypatch
+    ):
+        request = _make_request(origin="http://localhost:3000", client_host="8.8.8.8")
+        assert await _validate(request, [CUSTOMER_ORIGIN], monkeypatch) is False
+        assert await _scope(request, [CUSTOMER_ORIGIN]) == set()
+
+    @pytest.mark.anyio
+    async def test_localhost_origin_from_a_loopback_peer_is_allowed(self, monkeypatch):
+        request = _make_request(origin="http://localhost:3000", client_host="127.0.0.1")
+        assert await _validate(request, [CUSTOMER_ORIGIN], monkeypatch) is True
+        assert await _scope(request, [CUSTOMER_ORIGIN]) == {DATASET_ID}
+
+
+class TestUnlockedTokensAreUnaffected:
+    """A token with no allowed_origins never consulted the check and still doesn't."""
+
+    @pytest.mark.anyio
+    async def test_scope_resolution_ignores_origin_without_a_lock(self):
+        request = _make_request(origin=FOREIGN_ORIGIN)
+        assert await _scope(request, None) == {DATASET_ID}
+
+    @pytest.mark.anyio
+    async def test_tile_access_ignores_origin_without_a_lock(self, monkeypatch):
+        request = _make_request(origin=FOREIGN_ORIGIN)
+        assert await _validate(request, None, monkeypatch) is True
+
+
+class TestHostedTenantOrigin:
+    """In hosted multi-tenant the shell is served from the tenant host, which the
+    fleet-wide PUBLIC_APP_URL cannot represent. The tenant origin comes from
+    request.state, which TenantContextMiddleware sets only after the Host
+    resolved against the tenant registry — not from a raw header."""
+
+    @pytest.mark.anyio
+    async def test_validated_tenant_origin_counts_as_self(self, monkeypatch):
+        monkeypatch.setattr(embed_service, "is_multi_tenant", lambda: True)
+        request = _make_request(
+            referer="https://acme.geolens.cloud/m/share-token",
+            tenant_public_origin="https://acme.geolens.cloud",
+        )
+        assert await _scope(request, [CUSTOMER_ORIGIN]) == {DATASET_ID}
+
+    @pytest.mark.anyio
+    async def test_tenant_state_is_ignored_in_single_tenant(self):
+        """Single-tenant never populates that attribute; do not start trusting
+        it there just because something else could set it."""
+        request = _make_request(
+            referer="https://acme.geolens.cloud/m/share-token",
+            tenant_public_origin="https://acme.geolens.cloud",
+        )
+        assert await _scope(request, [CUSTOMER_ORIGIN]) == set()
+
+
+class TestSelfOriginIsServerDerived:
+    """The load-bearing property: nothing the caller sends can become "self"."""
+
+    @pytest.mark.anyio
+    async def test_resolve_self_origins_does_not_read_request_headers(self):
+        request = _make_request(origin=FOREIGN_ORIGIN, referer=f"{FOREIGN_ORIGIN}/x")
+        origins = await embed_service._resolve_self_origins(AsyncMock(), request)
+        assert origins == {APP_ORIGIN}
+        assert FOREIGN_ORIGIN not in origins
+
+
+def test_frame_ancestors_directive_carries_the_self_half():
+    """The API check now mirrors the CSP directive it sits under: both accept
+    our own origin plus the configured embedder origins."""
+    directive = embed_service.build_embed_frame_ancestors(
+        is_valid=True, allowed_origins=[CUSTOMER_ORIGIN]
+    )
+    assert directive == f"frame-ancestors 'self' {CUSTOMER_ORIGIN}"

--- a/backend/tests/test_embed_domain_lock_shipped_defaults_1548.py
+++ b/backend/tests/test_embed_domain_lock_shipped_defaults_1548.py
@@ -358,3 +358,226 @@ async def test_clearing_a_lock_is_allowed_under_the_shipped_default(
     assert resp.status_code == 200, resp.text
     await test_db_session.refresh(token)
     assert token.allowed_origins is None
+
+
+# ---------------------------------------------------------------------------
+# Ordering: existence is settled before the deployment-level precondition
+# ---------------------------------------------------------------------------
+
+
+async def test_patch_404s_a_missing_token_instead_of_naming_public_app_url(
+    client: AsyncClient,
+    admin_auth_header: dict,
+    test_db_session: AsyncSession,
+    public_app_url,
+    enterprise_edition,
+):
+    """fix(#1548 review r2): the gate answers a question about the DEPLOYMENT,
+    not about this token. Asked before existence, it told the owner of a stale
+    token id to go and reconfigure their server, when the real answer is that
+    their token is gone. A stale id in an open builder tab and a concurrent
+    revoke both reach this.
+    """
+    public_app_url(COMPOSE_DEFAULT_APP_URL)
+    user_id = await get_user_id(test_db_session, "admin")
+    map_obj = await _create_map(test_db_session, created_by=user_id)
+    await test_db_session.commit()
+
+    resp = await client.patch(
+        f"/maps/{map_obj.id}/embed-tokens/{uuid.uuid4()}/",
+        json={"allowed_origins": [CUSTOMER_ORIGIN]},
+        headers={**admin_auth_header, "Origin": SELF_HOSTED_ORIGIN},
+    )
+
+    assert resp.status_code == 404, resp.text
+    detail = resp.json()["detail"]
+    assert detail == "Embed token not found"
+    assert "PUBLIC_APP_URL" not in detail, (
+        "a caller whose token does not exist must not be sent to reconfigure "
+        "the deployment"
+    )
+
+
+async def test_patch_404s_a_revoked_token_instead_of_naming_public_app_url(
+    client: AsyncClient,
+    admin_auth_header: dict,
+    test_db_session: AsyncSession,
+    public_app_url,
+    enterprise_edition,
+):
+    """The concurrent-revocation half of the same path: the row is there, but
+    ``is_active`` is False, so the write would have returned None and 404'd."""
+    public_app_url(COMPOSE_DEFAULT_APP_URL)
+    user_id = await get_user_id(test_db_session, "admin")
+    map_obj = await _create_map(test_db_session, created_by=user_id)
+    token, _raw = await _existing_token(
+        test_db_session, map_id=map_obj.id, created_by=user_id
+    )
+    token.is_active = False
+    await test_db_session.commit()
+
+    resp = await client.patch(
+        f"/maps/{map_obj.id}/embed-tokens/{token.id}/",
+        json={"allowed_origins": [CUSTOMER_ORIGIN]},
+        headers={**admin_auth_header, "Origin": SELF_HOSTED_ORIGIN},
+    )
+
+    assert resp.status_code == 404, resp.text
+    assert "PUBLIC_APP_URL" not in resp.json()["detail"]
+
+
+async def test_a_token_on_another_map_is_not_found_rather_than_refused(
+    client: AsyncClient,
+    admin_auth_header: dict,
+    test_db_session: AsyncSession,
+    public_app_url,
+    enterprise_edition,
+):
+    """The existence check is scoped by map_id, exactly as the write is, so a
+    real token id addressed through the wrong map takes the 404 too."""
+    public_app_url(COMPOSE_DEFAULT_APP_URL)
+    user_id = await get_user_id(test_db_session, "admin")
+    owning_map = await _create_map(test_db_session, created_by=user_id)
+    other_map = await _create_map(test_db_session, created_by=user_id)
+    token, _raw = await _existing_token(
+        test_db_session, map_id=owning_map.id, created_by=user_id
+    )
+    await test_db_session.commit()
+
+    resp = await client.patch(
+        f"/maps/{other_map.id}/embed-tokens/{token.id}/",
+        json={"allowed_origins": [CUSTOMER_ORIGIN]},
+        headers={**admin_auth_header, "Origin": SELF_HOSTED_ORIGIN},
+    )
+
+    assert resp.status_code == 404, resp.text
+    assert "PUBLIC_APP_URL" not in resp.json()["detail"]
+
+
+async def test_an_existing_token_still_gets_the_refusal(
+    client: AsyncClient,
+    admin_auth_header: dict,
+    test_db_session: AsyncSession,
+    public_app_url,
+    enterprise_edition,
+):
+    """The other side of the ordering: reordering must not have turned the
+    refusal off for the token it is actually meant for. Without this pair, a
+    gate deleted outright would pass all three 404 tests above."""
+    public_app_url(COMPOSE_DEFAULT_APP_URL)
+    user_id = await get_user_id(test_db_session, "admin")
+    map_obj = await _create_map(test_db_session, created_by=user_id)
+    token, _raw = await _existing_token(
+        test_db_session, map_id=map_obj.id, created_by=user_id
+    )
+    await test_db_session.commit()
+
+    resp = await client.patch(
+        f"/maps/{map_obj.id}/embed-tokens/{token.id}/",
+        json={"allowed_origins": [CUSTOMER_ORIGIN]},
+        headers={**admin_auth_header, "Origin": SELF_HOSTED_ORIGIN},
+    )
+
+    assert resp.status_code == 422, resp.text
+    assert "PUBLIC_APP_URL" in resp.json()["detail"]
+
+
+def test_the_precondition_never_precedes_authorization_or_existence():
+    """Structural pin on the ordering, for both handlers.
+
+    Both orderings read as reasonable in isolation, which is what made this one
+    easy to miss, so assert the sequence rather than trusting a reviewer to
+    re-derive it. In each handler that gates, every authorization and existence
+    check must appear BEFORE assert_domain_lock_is_enforceable.
+
+    POST legitimately has no token-existence check: it is creating the token.
+    Its map lookup and ownership check are still required to come first.
+    """
+    import ast
+    import inspect
+
+    from app.modules.embed_tokens import router as embed_router
+
+    tree = ast.parse(inspect.getsource(embed_router))
+    must_precede = {
+        "get_map",
+        "check_map_ownership",
+        "get_active_embed_token",
+    }
+
+    checked: list[str] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.AsyncFunctionDef):
+            continue
+        calls = [
+            (call.func.id, call.lineno)
+            for call in ast.walk(node)
+            if isinstance(call, ast.Call) and isinstance(call.func, ast.Name)
+        ]
+        gate = [
+            line for name, line in calls if name == "assert_domain_lock_is_enforceable"
+        ]
+        if not gate:
+            continue
+        checked.append(node.name)
+        for name, line in calls:
+            if name in must_precede:
+                assert line < gate[0], (
+                    f"{node.name}: {name}() runs at line {line}, after the "
+                    f"domain-lock precondition at line {gate[0]}. A precondition "
+                    "about the DEPLOYMENT must never answer ahead of whether the "
+                    "caller is allowed to be here or whether the resource exists."
+                )
+
+    assert sorted(checked) == [
+        "create_embed_token_endpoint",
+        "update_embed_token_endpoint",
+    ], f"gated handlers changed; ordering unchecked for some: {sorted(checked)}"
+    assert "get_active_embed_token" in inspect.getsource(
+        embed_router.update_embed_token_endpoint
+    ), "the PATCH handler must settle token existence itself, before the gate"
+
+
+@pytest.mark.parametrize("token_exists", [True, False], ids=["exists", "missing"])
+async def test_neither_status_is_reachable_without_ownership(
+    client: AsyncClient,
+    admin_auth_header: dict,
+    editor_auth_header: dict,
+    test_db_session: AsyncSession,
+    public_app_url,
+    enterprise_edition,
+    token_exists,
+):
+    """Ordering existence first DOES make the status distinguish a token that
+    exists (422) from one that does not (404) — before the reorder both were
+    422. That is not a disclosure, and this is the reason why: ``check_map_
+    ownership`` 403s everyone but the map's owner and admins, so neither status
+    is reachable without already being able to GET /maps/{id}/embed-tokens/ and
+    read the list directly. The sibling revoke endpoint has always 404'd a
+    missing token on the same terms.
+
+    Asserted for both existence states, since a 403 that only held in one of
+    them would be the leak this rules out.
+    """
+    public_app_url(COMPOSE_DEFAULT_APP_URL)
+    user_id = await get_user_id(test_db_session, "admin")
+    map_obj = await _create_map(test_db_session, created_by=user_id)
+    if token_exists:
+        token, _raw = await _existing_token(
+            test_db_session, map_id=map_obj.id, created_by=user_id
+        )
+        token_id = token.id
+    else:
+        token_id = uuid.uuid4()
+    await test_db_session.commit()
+
+    resp = await client.patch(
+        f"/maps/{map_obj.id}/embed-tokens/{token_id}/",
+        json={"allowed_origins": [CUSTOMER_ORIGIN]},
+        headers={**editor_auth_header, "Origin": SELF_HOSTED_ORIGIN},
+    )
+
+    assert resp.status_code == 403, resp.text
+    detail = resp.json()["detail"]
+    assert "PUBLIC_APP_URL" not in detail
+    assert "Embed token not found" not in detail

--- a/backend/tests/test_embed_domain_lock_shipped_defaults_1548.py
+++ b/backend/tests/test_embed_domain_lock_shipped_defaults_1548.py
@@ -923,8 +923,25 @@ async def test_a_persisted_row_outranks_the_environment(
     It is also the assumption whose absence turned this file red in CI: a
     database carrying the row answers with the row no matter what the
     environment says, and nothing here asserted that until it cost a build.
+
+    Every phase supplies the override layer directly, INCLUDING the no-row one.
+    That phase originally read the real database and was the last thing in this
+    file still coupled to it — which is what kept CI red after the fixture was
+    fixed, because another test in the same worker had committed a
+    ``public_app_url`` row and the "no row" precondition was simply false.
+    Deleting that row in setup would have gone green too, and would have meant
+    this test mutating a database its neighbours read: the same cross-test
+    coupling, pointed the other way. Supplying the input is hermetic, mutates
+    nothing, and is the convention the rest of this module's tests already use
+    (see test_public_urls.py, where the real loader is exercised once and every
+    other case stubs it).
     """
     monkeypatch.setattr(settings, "public_app_url", "https://from-env.example")
+
+    async def _no_rows(db):
+        return {}
+
+    monkeypatch.setattr(public_urls, "_load_public_url_overrides", _no_rows)
     public_urls.invalidate_public_url_cache()
     try:
         assert await public_urls.get_configured_public_app_url(test_db_session) == (

--- a/backend/tests/test_embed_domain_lock_shipped_defaults_1548.py
+++ b/backend/tests/test_embed_domain_lock_shipped_defaults_1548.py
@@ -175,7 +175,7 @@ async def test_the_shipped_default_really_denies_the_shell(
 ):
     """The measurement the corrected-config suites cannot make.
 
-    A real database, the real ``get_public_app_url`` stack, and
+    A real database, the real ``get_configured_public_app_url`` stack, and
     ``PUBLIC_APP_URL`` exactly as compose leaves it. The request is the one
     #1531 taught the check to accept — the embed shell's own — and it is still
     denied, because the origin it is compared against is localhost. This is the
@@ -581,3 +581,118 @@ async def test_neither_status_is_reachable_without_ownership(
     detail = resp.json()["detail"]
     assert "PUBLIC_APP_URL" not in detail
     assert "Embed token not found" not in detail
+
+
+# ---------------------------------------------------------------------------
+# r9: a value that passes validation but is not what the browser will present
+# ---------------------------------------------------------------------------
+
+
+async def test_an_api_derived_app_url_cannot_authorize_a_domain_lock(
+    test_db_session: AsyncSession, public_app_url, enterprise_edition, monkeypatch
+):
+    """fix(#1548 review r9): a split app/API deployment.
+
+    With only ``PUBLIC_API_URL`` set, ``get_public_app_url`` derives an app URL
+    from it by stripping the ``/api`` suffix. That is a real, non-loopback host
+    — so the shape rule passes and the loopback rule passes — but it is the API
+    host, not the one the embed shell is served from. Trusting it issued a lock
+    whose every subsequent request came from somewhere else.
+    """
+    public_app_url(None)
+    monkeypatch.setattr(settings, "public_api_url", "https://api.example.com/api")
+    public_urls.invalidate_public_url_cache()
+
+    # The resolver still derives one — that behaviour is deliberate elsewhere.
+    assert await public_urls.get_public_app_url(test_db_session) == (
+        "https://api.example.com"
+    )
+    # The domain lock does not see it.
+    assert await public_urls.get_configured_public_app_url(test_db_session) is None
+    assert (
+        await embed_service._request_origin_is_allowed(
+            test_db_session, _browser_at(SELF_HOSTED_ORIGIN), [CUSTOMER_ORIGIN]
+        )
+        is False
+    )
+
+    with pytest.raises(embed_service.DomainLockNotEnforceableError) as exc:
+        await embed_service.assert_domain_lock_is_enforceable(
+            test_db_session, _browser_at(SELF_HOSTED_ORIGIN), [CUSTOMER_ORIGIN]
+        )
+    assert "PUBLIC_APP_URL" in str(exc.value)
+
+
+async def test_tile_config_reports_only_an_explicitly_configured_app_url(
+    client: AsyncClient, test_db_session: AsyncSession, public_app_url, monkeypatch
+):
+    """The same value reaches the frontend's share builder through tile-config,
+    so the derivation had to be closed on that path too — otherwise /m/ and
+    /card links point at the API host."""
+    public_app_url(None)
+    monkeypatch.setattr(settings, "public_api_url", "https://api.example.com/api")
+    public_urls.invalidate_public_url_cache()
+
+    resp = await client.get("/settings/tile-config/")
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["public_app_url"] is None
+
+    public_app_url(SELF_HOSTED_ORIGIN)
+    resp = await client.get("/settings/tile-config/")
+    assert resp.json()["public_app_url"] == SELF_HOSTED_ORIGIN
+
+
+async def test_a_unicode_hostname_matches_what_the_browser_sends(
+    test_db_session: AsyncSession, public_app_url, enterprise_edition
+):
+    """fix(#1548 review r9): IDNA, canonicalized rather than rejected.
+
+    A browser serializes the shell's Origin in IDNA ASCII, so
+    ``https://máp.example`` arrives as ``https://xn--mp-mia.example``. Storing
+    the Unicode spelling issued a lock that then missed on every request. Both
+    sides are canonicalized now, so the operator may write either spelling.
+    """
+    public_app_url("https://máp.example")
+
+    request = _browser_at("https://xn--mp-mia.example")
+    assert (
+        await embed_service._request_origin_is_allowed(
+            test_db_session, request, [CUSTOMER_ORIGIN]
+        )
+        is True
+    ), "the browser's ASCII spelling must match a Unicode-configured origin"
+
+    # And the operator may equally configure the ASCII form.
+    public_app_url("https://xn--mp-mia.example")
+    assert (
+        await embed_service._request_origin_is_allowed(
+            test_db_session,
+            _browser_at("https://xn--mp-mia.example"),
+            [CUSTOMER_ORIGIN],
+        )
+        is True
+    )
+
+
+async def test_userinfo_never_reaches_a_stored_origin(
+    test_db_session: AsyncSession, public_app_url, enterprise_edition
+):
+    """Credentials in the setting are dropped, not stored and not handed out.
+
+    A browser never sends userinfo in Origin, so keeping it guaranteed a miss —
+    and it would have travelled into any CSP header or copied link built from
+    the value.
+    """
+    public_app_url("https://ops:secret@maps.example.com")
+
+    assert (
+        await embed_service._request_origin_is_allowed(
+            test_db_session, _browser_at(SELF_HOSTED_ORIGIN), [CUSTOMER_ORIGIN]
+        )
+        is True
+    )
+    origins = await embed_service._resolve_self_origins(
+        test_db_session, _browser_at(SELF_HOSTED_ORIGIN)
+    )
+    assert origins == {SELF_HOSTED_ORIGIN}
+    assert not any("secret" in o for o in origins), "credentials must not be stored"

--- a/backend/tests/test_embed_domain_lock_shipped_defaults_1548.py
+++ b/backend/tests/test_embed_domain_lock_shipped_defaults_1548.py
@@ -1,0 +1,360 @@
+"""fix(#1548 review P2): the #1531 domain-lock fix, measured under the SHIPPED
+configuration rather than a corrected one.
+
+#1531 taught the API-layer allowlist to accept this deployment's own origin, so
+that an embed shell's subresource requests — which carry the SHELL's origin,
+never the embedder's — stop being denied. The origin it compares against comes
+from ``PUBLIC_APP_URL``, and that setting has a default which is wrong for
+almost every real install: ``docker-compose.yml`` and ``docker-compose.prod.yml``
+both inject ``${PUBLIC_APP_URL:-http://localhost:8080}``, and ``.env.example``
+ships the line commented out. A self-hoster reached at https://maps.example.com
+who never set it therefore resolves a self-origin of ``http://localhost:8080``,
+matches nothing, and gets the pre-#1531 behaviour: an embed that loads and stays
+empty, with nothing said at the moment the lock was turned on.
+
+Every other test of this feature configures ``PUBLIC_APP_URL`` to a real
+hostname first — necessary hygiene, since the localhost bypass would otherwise
+be free to take credit for the fix, but it also configures the remaining bug
+away. This file deliberately does the opposite: it pins ``PUBLIC_APP_URL`` to
+the value compose actually injects and drives the real routers against a real
+database, so the shipped default is under test rather than assumed.
+
+The unset case converges here too: with no ``PUBLIC_APP_URL`` at all,
+``resolve_public_app_url`` falls through to ``_DEFAULT_PUBLIC_APP_URL``, which
+is the same ``http://localhost:8080``.
+"""
+
+import hashlib
+import secrets
+import uuid
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core import public_urls
+from app.core.config import settings
+from app.modules.catalog.maps.models import Map, MapLayer
+from app.modules.embed_tokens import service as embed_service
+from app.modules.embed_tokens.models import EmbedToken
+
+from tests.factories import create_dataset, get_user_id
+
+# What compose injects when the operator never sets PUBLIC_APP_URL.
+COMPOSE_DEFAULT_APP_URL = "http://localhost:8080"
+# Where the deployment is actually reached.
+SELF_HOSTED_ORIGIN = "https://maps.example.com"
+# What the operator puts in allowed_origins: their customer's site.
+CUSTOMER_ORIGIN = "https://customer.example.com"
+
+
+@pytest.fixture
+def enterprise_edition(monkeypatch):
+    """Domain locking is an advanced-sharing control."""
+    from app.core.edition import init_edition
+
+    monkeypatch.delenv("GEOLENS_EDITION", raising=False)
+    init_edition(["enterprise"])
+    yield
+    init_edition([])
+
+
+@pytest.fixture
+def public_app_url(monkeypatch):
+    """Set the deployment's configured public app URL, the way an operator does.
+
+    The 60s module-global ``_PUBLIC_URL_CACHE`` is cleared on both sides: it is
+    memoized per process, so without this a value primed by an earlier test
+    would decide this one's outcome — the exact order-dependence that hid the
+    other half of this review.
+    """
+
+    def _set(value: str | None) -> None:
+        monkeypatch.setattr(settings, "public_app_url", value)
+        monkeypatch.setattr(settings, "public_api_url", None)
+        monkeypatch.setattr(settings, "public_base_url", None)
+        public_urls.invalidate_public_url_cache()
+
+    yield _set
+    public_urls.invalidate_public_url_cache()
+
+
+def _browser_at(origin: str) -> MagicMock:
+    """A request from a browser sitting on ``origin``.
+
+    ``client.host`` is a container bridge IP, not loopback: in the shipped
+    stack nginx proxies to the api service, so the H-31 loopback bypass is out
+    of reach for every real browser request.
+    """
+    request = MagicMock()
+    request.headers = {"origin": origin}
+    request.client = SimpleNamespace(host="172.18.0.5")
+    request.state = SimpleNamespace()
+    return request
+
+
+async def _create_map(
+    session: AsyncSession, *, created_by: uuid.UUID, with_layer: bool = False
+) -> Map:
+    """Insert a Map, optionally with one layer.
+
+    ``with_layer`` matters for POST: ``create_embed_token`` rejects a layerless
+    map with 400 "Map has no layers to scope" BEFORE minting anything, so a POST
+    test on a bare map would be refused whether or not the new gate exists — and
+    an assertion that no token was written would hold vacuously.
+    """
+    map_obj = Map(
+        name=f"Shipped default {uuid.uuid4().hex[:6]}",
+        description="#1548 review P2",
+        visibility="public",
+        created_by=created_by,
+    )
+    session.add(map_obj)
+    await session.flush()
+
+    if with_layer:
+        dataset = await create_dataset(
+            session,
+            created_by=created_by,
+            name=f"Shipped default DS {uuid.uuid4().hex[:6]}",
+            visibility="private",
+            description="#1548 review P2",
+            geometry_type="Point",
+            feature_count=1,
+            column_info=[
+                {"name": "gid", "type": "integer"},
+                {"name": "geom", "type": "geometry"},
+            ],
+        )
+        session.add(MapLayer(map_id=map_obj.id, dataset_id=dataset.id, sort_order=0))
+        await session.flush()
+
+    await session.refresh(map_obj)
+    return map_obj
+
+
+async def _existing_token(
+    session: AsyncSession,
+    *,
+    map_id: uuid.UUID,
+    created_by: uuid.UUID,
+    allowed_origins: list[str] | None = None,
+) -> tuple[EmbedToken, str]:
+    """Insert an EmbedToken directly, bypassing the router's new gate.
+
+    Stands in for a token minted before this fix existed. Returns the row and
+    its raw token.
+    """
+    raw = secrets.token_urlsafe(32)
+    token = EmbedToken(
+        map_id=map_id,
+        token_hash=hashlib.sha256(raw.encode()).hexdigest(),
+        token_hint=raw[:8],
+        scoped_dataset_ids=[],
+        allowed_origins=allowed_origins,
+        expires_at=datetime.now(timezone.utc) + timedelta(days=30),
+        is_active=True,
+        created_by=created_by,
+    )
+    session.add(token)
+    await session.flush()
+    await session.refresh(token)
+    return token, raw
+
+
+# ---------------------------------------------------------------------------
+# The bug: what the shipped default does to an already-issued lock
+# ---------------------------------------------------------------------------
+
+
+async def test_the_shipped_default_really_denies_the_shell(
+    test_db_session: AsyncSession, public_app_url, enterprise_edition
+):
+    """The measurement the corrected-config suites cannot make.
+
+    A real database, the real ``get_public_app_url`` stack, and
+    ``PUBLIC_APP_URL`` exactly as compose leaves it. The request is the one
+    #1531 taught the check to accept — the embed shell's own — and it is still
+    denied, because the origin it is compared against is localhost. This is the
+    empty embed, reproduced.
+    """
+    public_app_url(COMPOSE_DEFAULT_APP_URL)
+
+    allowed = await embed_service._request_origin_is_allowed(
+        test_db_session, _browser_at(SELF_HOSTED_ORIGIN), [CUSTOMER_ORIGIN]
+    )
+    assert allowed is False
+
+
+async def test_the_same_shell_request_is_accepted_once_the_url_is_set(
+    test_db_session: AsyncSession, public_app_url, enterprise_edition
+):
+    """Counterpart to the test above: the request never changes, only the
+    configuration does. Without this pair, the denial above could be caused by
+    anything at all and the message would be pointing at the wrong knob."""
+    public_app_url(SELF_HOSTED_ORIGIN)
+
+    allowed = await embed_service._request_origin_is_allowed(
+        test_db_session, _browser_at(SELF_HOSTED_ORIGIN), [CUSTOMER_ORIGIN]
+    )
+    assert allowed is True
+
+
+# ---------------------------------------------------------------------------
+# The fix: the operator is told, at the moment they turn the lock on
+# ---------------------------------------------------------------------------
+
+
+async def test_post_refuses_a_domain_lock_under_the_shipped_default(
+    client: AsyncClient,
+    admin_auth_header: dict,
+    test_db_session: AsyncSession,
+    public_app_url,
+    enterprise_edition,
+):
+    public_app_url(COMPOSE_DEFAULT_APP_URL)
+    user_id = await get_user_id(test_db_session, "admin")
+    map_obj = await _create_map(test_db_session, created_by=user_id, with_layer=True)
+    await test_db_session.commit()
+
+    resp = await client.post(
+        f"/maps/{map_obj.id}/embed-tokens/",
+        json={"allowed_origins": [CUSTOMER_ORIGIN]},
+        headers={**admin_auth_header, "Origin": SELF_HOSTED_ORIGIN},
+    )
+
+    assert resp.status_code == 422, resp.text
+    detail = resp.json()["detail"]
+    assert "PUBLIC_APP_URL" in detail, "name the variable to set"
+    assert COMPOSE_DEFAULT_APP_URL in detail, "name what it resolved to"
+    assert SELF_HOSTED_ORIGIN in detail, "name where the request arrived"
+
+
+async def test_the_refused_post_leaves_no_token_behind(
+    client: AsyncClient,
+    admin_auth_header: dict,
+    test_db_session: AsyncSession,
+    public_app_url,
+    enterprise_edition,
+):
+    """Fail before the mutation, not after it. A 422 with a live token row on
+    the other side would be the same silent embed plus a confusing message."""
+    from sqlalchemy import select
+
+    public_app_url(COMPOSE_DEFAULT_APP_URL)
+    user_id = await get_user_id(test_db_session, "admin")
+    map_obj = await _create_map(test_db_session, created_by=user_id, with_layer=True)
+    await test_db_session.commit()
+
+    await client.post(
+        f"/maps/{map_obj.id}/embed-tokens/",
+        json={"allowed_origins": [CUSTOMER_ORIGIN]},
+        headers={**admin_auth_header, "Origin": SELF_HOSTED_ORIGIN},
+    )
+
+    rows = (
+        (
+            await test_db_session.execute(
+                select(EmbedToken).where(EmbedToken.map_id == map_obj.id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert list(rows) == []
+
+
+async def test_patch_refuses_a_domain_lock_under_the_shipped_default(
+    client: AsyncClient,
+    admin_auth_header: dict,
+    test_db_session: AsyncSession,
+    public_app_url,
+    enterprise_edition,
+):
+    """The path the builder actually takes: it creates the token unlocked, then
+    PATCHes the origins on as the operator adds them."""
+    public_app_url(COMPOSE_DEFAULT_APP_URL)
+    user_id = await get_user_id(test_db_session, "admin")
+    map_obj = await _create_map(test_db_session, created_by=user_id)
+    token, _raw = await _existing_token(
+        test_db_session, map_id=map_obj.id, created_by=user_id
+    )
+    await test_db_session.commit()
+
+    resp = await client.patch(
+        f"/maps/{map_obj.id}/embed-tokens/{token.id}/",
+        json={"allowed_origins": [CUSTOMER_ORIGIN]},
+        headers={**admin_auth_header, "Origin": SELF_HOSTED_ORIGIN},
+    )
+
+    assert resp.status_code == 422, resp.text
+    assert "PUBLIC_APP_URL" in resp.json()["detail"]
+
+    await test_db_session.refresh(token)
+    assert token.allowed_origins is None, "the refused lock must not be stored"
+
+
+async def test_patch_succeeds_once_public_app_url_names_the_real_origin(
+    client: AsyncClient,
+    admin_auth_header: dict,
+    test_db_session: AsyncSession,
+    public_app_url,
+    enterprise_edition,
+):
+    """The remediation the 422 prints, carried out. Same request, same map, same
+    origins — only PUBLIC_APP_URL changed."""
+    public_app_url(SELF_HOSTED_ORIGIN)
+    user_id = await get_user_id(test_db_session, "admin")
+    map_obj = await _create_map(test_db_session, created_by=user_id)
+    token, _raw = await _existing_token(
+        test_db_session, map_id=map_obj.id, created_by=user_id
+    )
+    await test_db_session.commit()
+
+    resp = await client.patch(
+        f"/maps/{map_obj.id}/embed-tokens/{token.id}/",
+        json={"allowed_origins": [CUSTOMER_ORIGIN]},
+        headers={**admin_auth_header, "Origin": SELF_HOSTED_ORIGIN},
+    )
+
+    assert resp.status_code == 200, resp.text
+    await test_db_session.refresh(token)
+    assert token.allowed_origins == [CUSTOMER_ORIGIN]
+
+
+async def test_clearing_a_lock_is_allowed_under_the_shipped_default(
+    client: AsyncClient,
+    admin_auth_header: dict,
+    test_db_session: AsyncSession,
+    public_app_url,
+    enterprise_edition,
+):
+    """The operator's way out.
+
+    Removing the LAST origin sends ``allowed_origins: null``, which the gate
+    never refuses — so an operator who cannot change PUBLIC_APP_URL right now is
+    never stuck with a lock they can neither enforce nor remove.
+    """
+    public_app_url(COMPOSE_DEFAULT_APP_URL)
+    user_id = await get_user_id(test_db_session, "admin")
+    map_obj = await _create_map(test_db_session, created_by=user_id)
+    token, _raw = await _existing_token(
+        test_db_session,
+        map_id=map_obj.id,
+        created_by=user_id,
+        allowed_origins=[CUSTOMER_ORIGIN],
+    )
+    await test_db_session.commit()
+
+    resp = await client.patch(
+        f"/maps/{map_obj.id}/embed-tokens/{token.id}/",
+        json={"allowed_origins": None},
+        headers={**admin_auth_header, "Origin": SELF_HOSTED_ORIGIN},
+    )
+
+    assert resp.status_code == 200, resp.text
+    await test_db_session.refresh(token)
+    assert token.allowed_origins is None

--- a/backend/tests/test_embed_domain_lock_shipped_defaults_1548.py
+++ b/backend/tests/test_embed_domain_lock_shipped_defaults_1548.py
@@ -721,6 +721,71 @@ async def test_userinfo_never_reaches_a_stored_origin(
     assert not any("secret" in o for o in origins), "credentials must not be stored"
 
 
+async def test_a_non_canonical_numeric_host_is_refused(
+    test_db_session: AsyncSession, public_app_url, enterprise_edition
+):
+    """fix(#1548 review r11): the IDN finding in different clothes.
+
+    Python and the browser disagree about how a numeric host is spelled, and we
+    store Python's. Measured: ``192.168.1`` stays ``192.168.1`` through urlsplit
+    and is ``192.168.0.1`` to every browser; ``010.0.0.1`` is read as OCTAL and
+    becomes ``8.0.0.1``. The shell would present the right-hand spelling while
+    the stored self-origin held the left, so the lock was issued and then missed.
+
+    ``192.168.1`` is also the case that shows why the check asserts canonical
+    form rather than stability: it round-trips through urlsplit unchanged.
+    """
+    for configured in (
+        "http://192.168.1",
+        "http://010.0.0.1",
+        "http://0x7f.1",
+        "http://2130706433",
+        "http://[2001:0db8:0000:0000:0000:0000:0000:0001]",
+    ):
+        public_app_url(configured)
+        assert (
+            await public_urls.get_configured_public_app_url(test_db_session) is None
+        ), configured
+        with pytest.raises(embed_service.DomainLockNotEnforceableError):
+            await embed_service.assert_domain_lock_is_enforceable(
+                test_db_session, _browser_at(SELF_HOSTED_ORIGIN), [CUSTOMER_ORIGIN]
+            )
+
+    # The canonical spellings are accepted and match what the browser sends.
+    public_app_url("http://192.168.0.1")
+    assert (
+        await embed_service._request_origin_is_allowed(
+            test_db_session, _browser_at("http://192.168.0.1"), [CUSTOMER_ORIGIN]
+        )
+        is True
+    )
+    public_app_url("http://[2001:db8::1]")
+    assert (
+        await embed_service._request_origin_is_allowed(
+            test_db_session, _browser_at("http://[2001:db8::1]"), [CUSTOMER_ORIGIN]
+        )
+        is True
+    )
+
+
+def test_the_canonical_host_check_is_not_a_round_trip_test():
+    """The trap, pinned.
+
+    ``192.168.1`` is STABLE under urlsplit — parse it, re-serialize it, and you
+    get the same string back — so a check written as "does it survive our own
+    parser" would accept it, and the browser would still read it as
+    ``192.168.0.1``. Assert both halves of that: stable, and still refused.
+    """
+    from urllib.parse import urlsplit, urlunsplit
+
+    parts = urlsplit("http://192.168.1")
+    assert urlunsplit(parts) == "http://192.168.1", "the input is parser-stable"
+    assert parts.hostname == "192.168.1"
+    assert public_urls.canonical_host_error("192.168.1") is not None, (
+        "stability under our own parser proves nothing about the browser's"
+    )
+
+
 # ---------------------------------------------------------------------------
 # r10 P1: "derived" names two things, and only one of them is untrustworthy
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_embed_domain_lock_shipped_defaults_1548.py
+++ b/backend/tests/test_embed_domain_lock_shipped_defaults_1548.py
@@ -66,11 +66,36 @@ def enterprise_edition(monkeypatch):
 def public_app_url(monkeypatch):
     """Set the deployment's configured public app URL, the way an operator does.
 
-    The 60s module-global ``_PUBLIC_URL_CACHE`` is cleared on both sides: it is
-    memoized per process, so without this a value primed by an earlier test
-    would decide this one's outcome — the exact order-dependence that hid the
-    other half of this review.
+    THE SETTING HAS TWO SOURCES AND THE ROW WINS. ``get_configured_public_app_url``
+    reads ``overrides.get(PUBLIC_APP_URL_KEY, settings.public_app_url)`` — a
+    persisted ``AppSetting`` row takes precedence over the environment-backed
+    ``settings`` attribute. Patching only ``settings`` therefore sets the LOWER
+    of the two, and any run whose database already carries a ``public_app_url``
+    row ignores this fixture completely and answers with the row.
+
+    That is what turned this file red in CI while it passed locally: CI's shared
+    test database had the row, a developer database did not, so every assertion
+    of ``is None`` got back ``http://localhost:8080`` instead. Not the 60s
+    memoization — the fixture already invalidated that correctly, and clearing a
+    cache cannot help when the value behind it is the one being read.
+
+    So the override layer is neutralized for the duration, which makes
+    ``settings`` authoritative and the result independent of both the database
+    and the cache. ``test_a_persisted_row_outranks_the_environment`` covers the
+    precedence itself, so stubbing it here hides nothing.
+
+    The cache is still cleared on both sides. This file cannot leak a primed one
+    — with the loader stubbed it never populates the cache, and every call here
+    only ever clears it — but a value primed by an earlier test would otherwise
+    still be sitting there when this file's own reads go through.
     """
+
+    async def _no_persisted_overrides(db):
+        return {}
+
+    monkeypatch.setattr(
+        public_urls, "_load_public_url_overrides", _no_persisted_overrides
+    )
 
     def _set(value: str | None) -> None:
         monkeypatch.setattr(settings, "public_app_url", value)
@@ -78,6 +103,7 @@ def public_app_url(monkeypatch):
         monkeypatch.setattr(settings, "public_base_url", None)
         public_urls.invalidate_public_url_cache()
 
+    public_urls.invalidate_public_url_cache()
     yield _set
     public_urls.invalidate_public_url_cache()
 
@@ -880,3 +906,46 @@ class TestHostedTenantKeepsItsOwnOrigin:
             await public_urls.get_shareable_app_url(test_db_session, request=request)
             is None
         )
+
+
+async def test_a_persisted_row_outranks_the_environment(
+    test_db_session: AsyncSession, monkeypatch
+):
+    """The precedence the ``public_app_url`` fixture stubs out, covered directly.
+
+    ``get_configured_public_app_url`` prefers a persisted ``AppSetting`` row over
+    the environment-backed ``settings`` attribute, which is correct — the row is
+    an operator's explicit choice made through the settings UI. Every other test
+    in this file neutralizes that layer so it can control the value, and this is
+    the one that proves the layer still works, so stubbing it elsewhere hides
+    nothing.
+
+    It is also the assumption whose absence turned this file red in CI: a
+    database carrying the row answers with the row no matter what the
+    environment says, and nothing here asserted that until it cost a build.
+    """
+    monkeypatch.setattr(settings, "public_app_url", "https://from-env.example")
+    public_urls.invalidate_public_url_cache()
+    try:
+        assert await public_urls.get_configured_public_app_url(test_db_session) == (
+            "https://from-env.example"
+        ), "with no row, the environment is the source"
+
+        async def _row(db):
+            return {"public_app_url": "https://from-a-settings-row.example"}
+
+        monkeypatch.setattr(public_urls, "_load_public_url_overrides", _row)
+        public_urls.invalidate_public_url_cache()
+        assert await public_urls.get_configured_public_app_url(test_db_session) == (
+            "https://from-a-settings-row.example"
+        ), "a persisted row is the operator's explicit choice and outranks the env"
+
+        # And the row is held to the same shape rule as everything else.
+        async def _bad_row(db):
+            return {"public_app_url": "ftp://from-a-settings-row.example"}
+
+        monkeypatch.setattr(public_urls, "_load_public_url_overrides", _bad_row)
+        public_urls.invalidate_public_url_cache()
+        assert await public_urls.get_configured_public_app_url(test_db_session) is None
+    finally:
+        public_urls.invalidate_public_url_cache()

--- a/backend/tests/test_embed_domain_lock_shipped_defaults_1548.py
+++ b/backend/tests/test_embed_domain_lock_shipped_defaults_1548.py
@@ -642,35 +642,58 @@ async def test_tile_config_reports_only_an_explicitly_configured_app_url(
     assert resp.json()["public_app_url"] == SELF_HOSTED_ORIGIN
 
 
-async def test_a_unicode_hostname_matches_what_the_browser_sends(
+async def test_a_unicode_hostname_is_refused_rather_than_translated(
     test_db_session: AsyncSession, public_app_url, enterprise_edition
 ):
-    """fix(#1548 review r9): IDNA, canonicalized rather than rejected.
+    """fix(#1548 review r10): IDN is refused, not approximated.
 
-    A browser serializes the shell's Origin in IDNA ASCII, so
-    ``https://máp.example`` arrives as ``https://xn--mp-mia.example``. Storing
-    the Unicode spelling issued a lock that then missed on every request. Both
-    sides are canonicalized now, so the operator may write either spelling.
+    An earlier round converted the host with Python's built-in ``idna`` codec so
+    it would match what the browser sends. That codec is IDNA2003: it maps
+    ``faß.de`` to ``fass.de``, while browsers follow WHATWG/UTS #46 and send
+    ``xn--fa-hia.de``. A near match is worse than none — it denies every request
+    while looking correct — so the value is refused and the operator supplies
+    the punycode form, which is unambiguous and is what the browser sends.
     """
-    public_app_url("https://máp.example")
+    public_app_url("https://faß.de")
 
-    request = _browser_at("https://xn--mp-mia.example")
+    assert await public_urls.get_configured_public_app_url(test_db_session) is None
+    with pytest.raises(embed_service.DomainLockNotEnforceableError) as exc:
+        await embed_service.assert_domain_lock_is_enforceable(
+            test_db_session, _browser_at(SELF_HOSTED_ORIGIN), [CUSTOMER_ORIGIN]
+        )
+    assert "PUBLIC_APP_URL" in str(exc.value)
+
+    # The punycode spelling is accepted and matches the browser byte for byte.
+    public_app_url("https://xn--fa-hia.de")
     assert (
         await embed_service._request_origin_is_allowed(
-            test_db_session, request, [CUSTOMER_ORIGIN]
+            test_db_session, _browser_at("https://xn--fa-hia.de"), [CUSTOMER_ORIGIN]
         )
         is True
-    ), "the browser's ASCII spelling must match a Unicode-configured origin"
+    )
 
-    # And the operator may equally configure the ASCII form.
-    public_app_url("https://xn--mp-mia.example")
+
+async def test_a_backslash_cannot_smuggle_a_second_host(
+    test_db_session: AsyncSession, public_app_url, enterprise_edition
+):
+    """fix(#1548 review r10): origin confusion, not a formatting nit.
+
+    ``https://maps.example.com\\@evil.com`` is host ``maps.example.com\\`` to
+    urlsplit and host ``evil.com`` to a browser. Whichever reading is "right",
+    the two halves disagreeing is the primitive, so the character is refused.
+    """
+    public_app_url("https://maps.example.com\\@evil.com")
+
+    assert await public_urls.get_configured_public_app_url(test_db_session) is None
+    origins = await embed_service._resolve_self_origins(
+        test_db_session, _browser_at(SELF_HOSTED_ORIGIN)
+    )
+    assert origins == set(), "a value the two parsers read differently is no origin"
     assert (
         await embed_service._request_origin_is_allowed(
-            test_db_session,
-            _browser_at("https://xn--mp-mia.example"),
-            [CUSTOMER_ORIGIN],
+            test_db_session, _browser_at("https://evil.com"), [CUSTOMER_ORIGIN]
         )
-        is True
+        is False
     )
 
 
@@ -696,3 +719,99 @@ async def test_userinfo_never_reaches_a_stored_origin(
     )
     assert origins == {SELF_HOSTED_ORIGIN}
     assert not any("secret" in o for o in origins), "credentials must not be stored"
+
+
+# ---------------------------------------------------------------------------
+# r10 P1: "derived" names two things, and only one of them is untrustworthy
+# ---------------------------------------------------------------------------
+
+
+class TestHostedTenantKeepsItsOwnOrigin:
+    """fix(#1548 review r10): requiring the EXPLICIT fleet setting broke hosted.
+
+    ``PUBLIC_APP_URL`` is fleet-wide and cannot represent a tenant host, so
+    demanding it made share and embed URLs on ``acme.geolens.example`` come out
+    on the fleet host — where the anonymous request carries no Host-derived
+    tenant context and fails closed.
+
+    ``tenant_public_origin`` is not the same kind of value as an ``/api``-stripped
+    ``PUBLIC_API_URL`` or a caller's header. ``TenantContextMiddleware`` sets it
+    only after the Host resolves against the tenant registry, and rejects the
+    request outright when it cannot form a trusted origin. Validated
+    infrastructure state, not an inference.
+    """
+
+    TENANT_ORIGIN = "https://acme.geolens.example"
+
+    @staticmethod
+    def _tenant_request(origin: str | None, tenant_id: object = "t-1"):
+        request = MagicMock()
+        request.headers = {"origin": origin} if origin else {}
+        request.client = SimpleNamespace(host="172.18.0.5")
+        request.state = SimpleNamespace(
+            tenant_id=tenant_id,
+            tenant_public_origin=TestHostedTenantKeepsItsOwnOrigin.TENANT_ORIGIN,
+        )
+        return request
+
+    async def test_a_tenant_host_shares_on_its_own_origin(
+        self, test_db_session: AsyncSession, public_app_url, monkeypatch
+    ):
+        public_app_url("https://fleet.geolens.example")
+        monkeypatch.setattr(public_urls, "is_multi_tenant", lambda: True)
+
+        assert (
+            await public_urls.get_shareable_app_url(
+                test_db_session, request=self._tenant_request(self.TENANT_ORIGIN)
+            )
+            == self.TENANT_ORIGIN
+        ), "a copied /card link on the fleet host arrives without tenant context"
+
+    async def test_single_tenant_still_gets_explicit_only(
+        self, test_db_session: AsyncSession, public_app_url, monkeypatch
+    ):
+        """The tenant branch is gated on the mode that populates it, so nothing
+        about single-tenant changes — including that an unset value stays None
+        rather than being back-filled from PUBLIC_API_URL."""
+        public_app_url(None)
+        monkeypatch.setattr(settings, "public_api_url", "https://api.example.com/api")
+        public_urls.invalidate_public_url_cache()
+
+        assert (
+            await public_urls.get_shareable_app_url(
+                test_db_session, request=self._tenant_request(SELF_HOSTED_ORIGIN)
+            )
+            is None
+        )
+
+    async def test_a_service_host_request_falls_back_to_the_fleet_setting(
+        self, test_db_session: AsyncSession, public_app_url, monkeypatch
+    ):
+        """Hosted, but no resolved tenant — a JWT-scoped request on a trusted
+        service host. The middleware left no tenant_id, so there is no validated
+        tenant origin and the explicit fleet value is the honest answer."""
+        public_app_url("https://fleet.geolens.example")
+        monkeypatch.setattr(public_urls, "is_multi_tenant", lambda: True)
+
+        assert (
+            await public_urls.get_shareable_app_url(
+                test_db_session,
+                request=self._tenant_request(SELF_HOSTED_ORIGIN, tenant_id=None),
+            )
+            == "https://fleet.geolens.example"
+        )
+
+    async def test_the_tenant_origin_still_has_to_pass_the_shape_rule(
+        self, test_db_session: AsyncSession, public_app_url, monkeypatch
+    ):
+        """Validated by middleware is not a reason to skip the shape check —
+        that is how a narrower guarantee gets substituted for a wider one."""
+        public_app_url(None)
+        monkeypatch.setattr(public_urls, "is_multi_tenant", lambda: True)
+        request = self._tenant_request(SELF_HOSTED_ORIGIN)
+        request.state.tenant_public_origin = "ftp://acme.geolens.example"
+
+        assert (
+            await public_urls.get_shareable_app_url(test_db_session, request=request)
+            is None
+        )

--- a/backend/tests/test_embed_tokens_origin_bypass.py
+++ b/backend/tests/test_embed_tokens_origin_bypass.py
@@ -21,6 +21,29 @@ import pytest
 from app.modules.embed_tokens import service as embed_service
 
 
+@pytest.fixture(autouse=True)
+def _self_origin_is_configured(monkeypatch):
+    """fix(#1548 review P2): stand in for the #1531 self-origin lookup.
+
+    These tests pass an ``AsyncMock`` database. Since #1531 the domain-lock
+    check resolves the deployment's own origin through ``get_public_app_url``,
+    which reads an AppSetting row, so on a cold public-URL cache the mock DB
+    reaches ``_load_public_url_overrides`` and raises. The service now fails
+    closed on that, which means these tests would still report False and pass
+    for the wrong reason: proving the lookup exploded, not that a foreign
+    origin is rejected. Patch it so they exercise the real decision. A
+    deployment whose own origin is unresolvable is covered separately, in
+    test_embed_domain_lock_self_origin_1531.py.
+    """
+
+    async def _fake_get_public_app_url(db, **kwargs):
+        return "https://maps.geolens.example"
+
+    monkeypatch.setattr(
+        embed_service, "get_public_app_url", _fake_get_public_app_url, raising=True
+    )
+
+
 def _make_request(*, origin: str | None, client_host: str | None) -> MagicMock:
     """Construct a mock Request with the given Origin header and client.host."""
     headers = {}

--- a/backend/tests/test_embed_tokens_origin_bypass.py
+++ b/backend/tests/test_embed_tokens_origin_bypass.py
@@ -26,7 +26,7 @@ def _self_origin_is_configured(monkeypatch):
     """fix(#1548 review P2): stand in for the #1531 self-origin lookup.
 
     These tests pass an ``AsyncMock`` database. Since #1531 the domain-lock
-    check resolves the deployment's own origin through ``get_public_app_url``,
+    check resolves the deployment's own origin through ``get_configured_public_app_url``,
     which reads an AppSetting row, so on a cold public-URL cache the mock DB
     reaches ``_load_public_url_overrides`` and raises. The service now fails
     closed on that, which means these tests would still report False and pass
@@ -36,11 +36,14 @@ def _self_origin_is_configured(monkeypatch):
     test_embed_domain_lock_self_origin_1531.py.
     """
 
-    async def _fake_get_public_app_url(db, **kwargs):
+    async def _fake_get_configured_public_app_url(db, **kwargs):
         return "https://maps.geolens.example"
 
     monkeypatch.setattr(
-        embed_service, "get_public_app_url", _fake_get_public_app_url, raising=True
+        embed_service,
+        "get_configured_public_app_url",
+        _fake_get_configured_public_app_url,
+        raising=True,
     )
 
 

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -3462,6 +3462,20 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # goes on to transfer bytes still measures once, and _managed_key names the
     # tenant-key seam the block now crosses in a second place.
     "backend/app/modules/catalog/datasets/api/router_export.py": 1656,
+    # fix(#1548 review P2): crossed the inclusion threshold. The growth is
+    # assert_domain_lock_is_enforceable — the write-side precondition that
+    # refuses a domain lock this deployment could never enforce, because
+    # PUBLIC_APP_URL ships defaulted to localhost in both compose files and the
+    # #1531 read-side fix is inert for anyone who leaves it there. Most of the
+    # lines are the docstring, and they are the point: it records why the
+    # serving origin is never INFERRED (every unconfigured source is
+    # caller-controlled, so an inferred self-origin would be satisfiable by
+    # exactly the parties a domain lock excludes) and why the refusal condition
+    # is the narrow one, naming the two weaker predicates that were tried and
+    # what each gets wrong. Cap at the exact size. This module is the embed
+    # token domain end to end — CRUD, the single policy reader both validators
+    # share, and now this precondition — and is not where new domains belong.
+    "backend/app/modules/embed_tokens/service.py": 1013,
 }
 
 

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -3481,7 +3481,14 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # a stale or concurrently revoked token id and told its owner to go
     # reconfigure PUBLIC_APP_URL. The router and update_embed_token share the
     # one query rather than carrying a copy each. Cap 1013 -> 1029, exact.
-    "backend/app/modules/embed_tokens/service.py": 1029,
+    # fix(#1548 review r8): +9 — gate the self-origin candidates on
+    # is_usable_public_origin before normalizing them. The comment is most of
+    # it, and it records why the order matters: _normalize_origin PREPENDS
+    # https:// to anything without an http(s) scheme, so an environment value of
+    # ftp://maps.example.com arrived as the plausible non-loopback origin
+    # https://ftp: and convinced the domain-lock gate the deployment was
+    # configured. Cap 1029 -> 1038, exact.
+    "backend/app/modules/embed_tokens/service.py": 1038,
 }
 
 

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -3475,7 +3475,13 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # what each gets wrong. Cap at the exact size. This module is the embed
     # token domain end to end — CRUD, the single policy reader both validators
     # share, and now this precondition — and is not where new domains belong.
-    "backend/app/modules/embed_tokens/service.py": 1013,
+    # fix(#1548 review r2): +16 — get_active_embed_token, so the PATCH handler
+    # can settle whether the token exists BEFORE applying the precondition
+    # above. Asked in the other order, a deployment-level refusal answered for
+    # a stale or concurrently revoked token id and told its owner to go
+    # reconfigure PUBLIC_APP_URL. The router and update_embed_token share the
+    # one query rather than carrying a copy each. Cap 1013 -> 1029, exact.
+    "backend/app/modules/embed_tokens/service.py": 1029,
 }
 
 

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -3488,7 +3488,12 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # ftp://maps.example.com arrived as the plausible non-loopback origin
     # https://ftp: and convinced the domain-lock gate the deployment was
     # configured. Cap 1029 -> 1038, exact.
-    "backend/app/modules/embed_tokens/service.py": 1038,
+    # fix(#1548 review r9): +4 — depend on get_configured_public_app_url and
+    # bail when it is None. get_public_app_url is a RESOLVER: with PUBLIC_APP_URL
+    # unset it derives an app URL from an /api-stripped PUBLIC_API_URL, and a
+    # split app/API deployment then had the API host accepted as a self-origin,
+    # so a lock was issued that every shell request missed. Cap 1038 -> 1042.
+    "backend/app/modules/embed_tokens/service.py": 1042,
 }
 
 

--- a/backend/tests/test_public_app_url_shape_contract_1548.py
+++ b/backend/tests/test_public_app_url_shape_contract_1548.py
@@ -1,0 +1,129 @@
+"""fix(#1548 review r8): PUBLIC_APP_URL has ONE shape rule, and both sides obey it.
+
+The setting is environment-backed, so it never passes through the
+persistent-setting validator and arrives as whatever string the operator typed.
+Two consumers read it — this backend, which compares it against the origin an
+embed shell presents, and the frontend, which APPENDS ``/m/<token>`` to it —
+and until this round each had learned about a different set of invalid shapes:
+
+* the backend accepted ``ftp://maps.example.com``, whose normalization prepends
+  ``https://`` and yields the plausible non-loopback origin ``https://ftp:``, so
+  ``assert_domain_lock_is_enforceable`` read the deployment as configured and
+  issued a domain lock that no embed shell could ever satisfy — the original bug
+  of this PR, returning through the very check added to prevent it;
+* the frontend accepted ``https://maps.example.com?tenant=a``, so appending a
+  path put it inside the query string.
+
+Two independent validators for one setting is the arrangement that produced
+both. The implementations cannot be shared across the language boundary, so the
+SPEC is: ``frontend/src/lib/__tests__/public-app-url-shape.cases.json`` is the
+single statement of the rule, and this file runs it against the Python half.
+The TypeScript half runs the same table in
+``frontend/src/lib/__tests__/public-urls.test.ts``.
+
+The rule: an absolute HTTP(S) URL, with a host, and no query or fragment.
+
+SHAPE ONLY. Whether a shape-valid value is TRUSTED in context is a separate
+question — a loopback origin is shape-valid but untrusted when the caller is
+somewhere else — which is why loopback entries sit under ``valid`` in the
+fixture. That second question lives in ``assert_domain_lock_is_enforceable``.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from app.core.public_urls import is_usable_public_origin
+
+_CASES_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "frontend"
+    / "src"
+    / "lib"
+    / "__tests__"
+    / "public-app-url-shape.cases.json"
+)
+
+
+def _spec() -> dict:
+    if not _CASES_PATH.is_file():
+        pytest.skip("frontend tree not present in this checkout")
+    return json.loads(_CASES_PATH.read_text(encoding="utf-8"))
+
+
+def test_the_shared_case_table_has_cases_on_both_sides():
+    """A fixture that quietly emptied would make every case below vacuous."""
+    spec = _spec()
+    assert spec["valid"], "no valid cases"
+    assert spec["invalid"], "no invalid cases"
+
+
+def test_every_shape_the_spec_calls_valid_is_accepted():
+    spec = _spec()
+    rejected = [v for v in spec["valid"] if not is_usable_public_origin(v)]
+    assert not rejected, (
+        "is_usable_public_origin rejects values the shared spec calls usable. "
+        "Either the rule changed on one side only, or the fixture is wrong:\n"
+        + "\n".join(f"  {v!r}" for v in rejected)
+    )
+
+
+def test_every_shape_the_spec_calls_invalid_is_refused():
+    spec = _spec()
+    accepted = [v for v in spec["invalid"] if is_usable_public_origin(v)]
+    assert not accepted, (
+        "is_usable_public_origin accepts values the shared spec calls unusable. "
+        "The frontend refuses these, so the two halves have drifted:\n"
+        + "\n".join(f"  {v!r}" for v in accepted)
+    )
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    "configured",
+    [
+        "ftp://maps.example.com",
+        "mailto:ops@example.com",
+        "file:///etc/hosts",
+        "not-a-url",
+    ],
+)
+async def test_a_non_http_setting_cannot_authorize_a_domain_lock(
+    monkeypatch, configured
+):
+    """The finding itself, end to end through the gate.
+
+    Not merely "the predicate returns False": what matters is that the lock is
+    REFUSED, because the failure was a plausible-looking pseudo-origin
+    convincing the gate that the deployment was configured. Each value below
+    normalizes to a non-loopback string — ``ftp://maps.example.com`` becomes
+    ``https://ftp:`` — which is precisely why the loopback test could not catch
+    them.
+    """
+    from types import SimpleNamespace
+    from unittest.mock import AsyncMock, MagicMock
+
+    from app.modules.embed_tokens import service as embed_service
+
+    async def _fake_get_public_app_url(db, **kwargs):
+        return configured
+
+    monkeypatch.setattr(embed_service, "get_public_app_url", _fake_get_public_app_url)
+    monkeypatch.setattr(embed_service, "is_enterprise", lambda: True)
+
+    request = MagicMock()
+    request.headers = {"origin": "https://maps.example.com"}
+    request.client = SimpleNamespace(host="172.18.0.5")
+    request.state = SimpleNamespace()
+
+    with pytest.raises(embed_service.DomainLockNotEnforceableError) as exc:
+        await embed_service.assert_domain_lock_is_enforceable(
+            AsyncMock(), request, ["https://customer.example.com"]
+        )
+    message = str(exc.value)
+    assert "PUBLIC_APP_URL" in message
+    assert "nothing usable" in message, (
+        "an unusable setting must resolve to no self-origin at all, not to a "
+        "pseudo-origin the operator will not recognize"
+    )

--- a/backend/tests/test_public_app_url_shape_contract_1548.py
+++ b/backend/tests/test_public_app_url_shape_contract_1548.py
@@ -79,6 +79,44 @@ def test_every_shape_the_spec_calls_invalid_is_refused():
     )
 
 
+def test_every_canonical_origin_matches_the_browsers_spelling():
+    """fix(#1548 review r9): same place is not the same STRING.
+
+    A browser serializes the shell's Origin with an IDNA ASCII host, lowercased,
+    no userinfo and the default port dropped. The configured value is compared
+    against that string, so a Unicode hostname stored as typed was issued a lock
+    and then missed on every request. Both sides canonicalize now — the frontend
+    through ``new URL(x).origin``, this side through ``_normalize_origin`` — and
+    the fixture is the one statement of what they must agree on.
+    """
+    from app.modules.embed_tokens.schemas import _normalize_origin
+
+    spec = _spec()
+    assert spec["canonical_origin"], "no canonicalization cases"
+    wrong = {
+        raw: (_normalize_origin(raw), expected)
+        for raw, expected in spec["canonical_origin"].items()
+        if _normalize_origin(raw) != expected
+    }
+    assert not wrong, (
+        "_normalize_origin disagrees with the shared canonical spelling, so a "
+        "configured origin and the browser's Origin header would not match:\n"
+        + "\n".join(f"  {r!r}: got {g!r}, want {w!r}" for r, (g, w) in wrong.items())
+    )
+
+
+def test_canonicalization_is_idempotent():
+    """A canonical value must survive a second pass unchanged.
+
+    Not decoration: the value is normalized when stored AND when compared, so a
+    non-idempotent rule would match on the first request and miss afterwards.
+    """
+    from app.modules.embed_tokens.schemas import _normalize_origin
+
+    for expected in set(_spec()["canonical_origin"].values()):
+        assert _normalize_origin(expected) == expected, expected
+
+
 @pytest.mark.anyio
 @pytest.mark.parametrize(
     "configured",
@@ -106,10 +144,14 @@ async def test_a_non_http_setting_cannot_authorize_a_domain_lock(
 
     from app.modules.embed_tokens import service as embed_service
 
-    async def _fake_get_public_app_url(db, **kwargs):
+    async def _fake_get_configured_public_app_url(db, **kwargs):
         return configured
 
-    monkeypatch.setattr(embed_service, "get_public_app_url", _fake_get_public_app_url)
+    monkeypatch.setattr(
+        embed_service,
+        "get_configured_public_app_url",
+        _fake_get_configured_public_app_url,
+    )
     monkeypatch.setattr(embed_service, "is_enterprise", lambda: True)
 
     request = MagicMock()

--- a/backend/tests/test_settings_router.py
+++ b/backend/tests/test_settings_router.py
@@ -265,6 +265,38 @@ async def test_get_tile_config_never_derives_the_app_url():
     assert set(configured.await_args.kwargs) == {"request"}
 
 
+def test_tile_config_resolves_the_app_url_through_the_sharing_accessor():
+    """Pin which resolver the handler depends on, because the mocks must match it.
+
+    fix(#1548 review r12): this is the second rename in this PR to leave a mock
+    naming a function ``get_tile_config`` no longer calls. Both times the patch
+    silently did nothing, the REAL resolver ran against the ``db=object()`` these
+    tests pass, and it raised ``AttributeError: 'object' object has no attribute
+    'execute'``.
+
+    Both times a full-file run stayed green and hid it: an earlier test in the
+    file primes the 60s module-global public-URL cache, so the loader returns the
+    cached dict without ever touching ``db``. Only a selection that runs these
+    tests without that priming — which is what CI's sharding did — reaches the
+    database access and fails. So a green file is not evidence here; this
+    assertion is.
+    """
+    import inspect
+
+    from app.modules.settings import router as settings_router
+
+    source = inspect.getsource(settings_router.get_tile_config)
+    assert "get_shareable_app_url(" in source, (
+        "tile-config must resolve the app URL through get_shareable_app_url, "
+        "which answers a hosted tenant with its middleware-validated origin"
+    )
+    assert "get_public_app_url(" not in source, (
+        "tile-config must NOT use the resolver: its fallbacks name an "
+        "/api-stripped PUBLIC_API_URL or the caller's own headers, and this "
+        "field feeds share and embed URL generation"
+    )
+
+
 @pytest.mark.anyio
 async def test_get_tile_config_exposes_tenant_mvt_source_layer_prefix():
     """The frontend receives the exact source-layer prefix emitted by MVT."""
@@ -290,8 +322,11 @@ async def test_get_tile_config_exposes_tenant_mvt_source_layer_prefix():
             "tenant_data_schema",
             return_value=expected,
         ) as schema_name,
+        # fix(#1548 review r12): the tile-config handler resolves the app URL
+        # through get_shareable_app_url, not the resolver. Left mocking the old
+        # name, the real one runs against `db=object()` and raises AttributeError.
         patch(
-            "app.modules.settings.router.get_public_app_url",
+            "app.modules.settings.router.get_shareable_app_url",
             AsyncMock(return_value="https://acme.example.com"),
         ),
         patch(
@@ -323,8 +358,9 @@ async def test_get_tile_config_fails_closed_without_tenant_context():
             SimpleNamespace(cdn_base_url=None),
         ),
         patch.object(settings_router, "is_multi_tenant", return_value=True),
+        # fix(#1548 review r12): see the note above — get_shareable_app_url.
         patch(
-            "app.modules.settings.router.get_public_app_url",
+            "app.modules.settings.router.get_shareable_app_url",
             AsyncMock(return_value=None),
         ),
         patch(

--- a/backend/tests/test_settings_router.py
+++ b/backend/tests/test_settings_router.py
@@ -205,7 +205,7 @@ async def _tile_config_with(app_url_mock, api_url_mock):
             SimpleNamespace(cdn_base_url="https://cdn.example.com"),
         ),
         patch(
-            "app.modules.settings.router.get_configured_public_app_url",
+            "app.modules.settings.router.get_shareable_app_url",
             app_url_mock,
         ),
         patch(
@@ -256,10 +256,13 @@ async def test_get_tile_config_never_derives_the_app_url():
         "an unset PUBLIC_APP_URL must not be back-filled from the API URL"
     )
     assert response.public_api_url == "https://api.example.com/api"
-    # And it is asked without a request, so no caller-controlled origin can
-    # reach it — the vacuous-self trap in a different layer.
-    assert configured.await_args.kwargs == {}
-    assert len(configured.await_args.args) == 1
+    # fix(#1548 review r10): it IS given the request, because a hosted tenant's
+    # middleware-validated origin is the right answer there and the fleet-wide
+    # setting cannot represent a tenant host. What it must never do is INFER an
+    # origin from that request — get_shareable_app_url reads only
+    # request.state.tenant_public_origin, which TenantContextMiddleware sets
+    # after the Host resolves against the tenant registry, never a header.
+    assert set(configured.await_args.kwargs) == {"request"}
 
 
 @pytest.mark.anyio

--- a/backend/tests/test_settings_router.py
+++ b/backend/tests/test_settings_router.py
@@ -195,9 +195,7 @@ async def test_put_settings_embedding_rebuild_failure_propagates_as_503(
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.anyio
-async def test_get_tile_config_exposes_resolved_public_urls():
-    """The public tile-config payload should expose the resolved app/API URLs."""
+async def _tile_config_with(app_url_mock, api_url_mock):
     from app.modules.settings import router as settings_router
 
     with (
@@ -207,26 +205,61 @@ async def test_get_tile_config_exposes_resolved_public_urls():
             SimpleNamespace(cdn_base_url="https://cdn.example.com"),
         ),
         patch(
-            "app.modules.settings.router.get_public_app_url",
-            AsyncMock(return_value="https://catalog.example.com"),
+            "app.modules.settings.router.get_configured_public_app_url",
+            app_url_mock,
         ),
         patch(
             "app.modules.settings.router.get_public_api_url",
-            AsyncMock(return_value="https://catalog.example.com/api"),
+            api_url_mock,
         ),
     ):
-        response = await settings_router.get_tile_config(
+        return await settings_router.get_tile_config(
             request=SimpleNamespace(
                 headers={}, url=SimpleNamespace(scheme="https"), scope={}
             ),
             db=object(),
         )
 
+
+@pytest.mark.anyio
+async def test_get_tile_config_exposes_the_public_urls():
+    """The payload exposes the API URL resolved, and the app URL as configured."""
+    response = await _tile_config_with(
+        AsyncMock(return_value="https://catalog.example.com"),
+        AsyncMock(return_value="https://catalog.example.com/api"),
+    )
+
     assert response.cdn_base_url == "https://cdn.example.com"
     assert response.public_app_url == "https://catalog.example.com"
     assert response.public_api_url == "https://catalog.example.com/api"
     assert response.public_base_url == "https://catalog.example.com/api"
     assert response.mvt_source_layer_prefix == "data"
+
+
+@pytest.mark.anyio
+async def test_get_tile_config_never_derives_the_app_url():
+    """fix(#1548 review r9): app_url comes from get_configured_public_app_url,
+    NOT the resolver.
+
+    This field's only consumer builds share and embed URLs from it, and the
+    resolver's fallbacks name something else — an ``/api``-stripped
+    PUBLIC_API_URL, or the caller's own request headers. Either produces /m/ and
+    /card links pointing at a host that does not serve them, so an unset setting
+    must arrive as null and let the frontend fall back for itself.
+    """
+    configured = AsyncMock(return_value=None)
+    response = await _tile_config_with(
+        configured, AsyncMock(return_value="https://api.example.com/api")
+    )
+
+    assert response.public_app_url is None, (
+        "an unset PUBLIC_APP_URL must not be back-filled from the API URL"
+    )
+    assert response.public_api_url == "https://api.example.com/api"
+    # And it is asked without a request, so no caller-controlled origin can
+    # reach it — the vacuous-self trap in a different layer.
+    assert configured.await_args.kwargs == {}
+    assert len(configured.await_args.args) == 1
 
 
 @pytest.mark.anyio

--- a/frontend/src/components/builder/SharePanel.tsx
+++ b/frontend/src/components/builder/SharePanel.tsx
@@ -644,6 +644,12 @@ function EmbedPreviewPane({ shareToken, embedTokenRaw, origin }: EmbedPreviewPan
   // builder-audit #338 SHARE-04 / IN-01: share the exact URL construction with
   // generateEmbedCode via buildEmbedSrc so the preview and the copyable snippet
   // can never diverge on path or query-param shape.
+  //
+  // fix(#1548 review r5): the ORIGIN is now the one thing they may legitimately
+  // differ on, and the caller decides. The snippet is opened by a customer and
+  // names the public host; the preview is opened by this browser and names the
+  // host this browser reached. Path, params and sandbox stay identical, which
+  // is what this sharing was ever for.
   const src = buildEmbedSrc({ shareToken, embedTokenRaw, origin });
 
   return (
@@ -937,11 +943,23 @@ export function ShareDialog({
   const { isEnterprise } = useEdition();
   const publishMap = usePublishMap();
 
-  // fix(#1548 review r3/r4): every URL handed to someone else — the share link,
-  // its unfurlable /card twin, the iframe snippet, the preview standing in for
-  // that snippet — prefers the deployment's configured public origin over
-  // whatever hostname this admin is using. See lib/public-urls.ts for why
-  // "configured" is not the same question as "correct".
+  // fix(#1548 review r3/r4/r5): three origins live here, and the question that
+  // picks between them is WHO OPENS THE URL — not whether it is "a share".
+  //
+  //  1. HANDED TO SOMEONE ELSE — the copied link, its /card twin, the iframe
+  //     snippet. The recipient is not on this network, so these must name the
+  //     address people use to reach GeoLens (shareBaseUrl / embedBaseUrl).
+  //  2. OPENED BY THIS BROWSER — the "Open" button and the embed preview. These
+  //     use currentOrigin directly and are deliberately NEITHER of the others:
+  //     this browser demonstrably reaches this host, and may not reach the
+  //     public one at all. An externally routed public hostname unreachable
+  //     from the internal admin network is a normal split-horizon deployment,
+  //     not a misconfiguration, and pointing a local affordance at it means an
+  //     admin can use GeoLens yet cannot open the share they just created.
+  //  3. The domain-lock decision is a further split within (1), below.
+  //
+  // See lib/public-urls.ts for why "configured" is not the same question as
+  // "correct".
   const { data: tileConfig } = useTileConfig();
   const currentOrigin = typeof window === 'undefined' ? '' : window.location.origin;
   // Non-null only when the configured value is one a viewer could actually
@@ -1067,10 +1085,13 @@ export function ShareDialog({
     }
   }
 
-  /** Feeds the "Open" button — navigation in THIS admin's browser. */
+  /** fix(#1548 review r5): category (2) above — the "Open" button navigates
+   *  THIS admin's browser and hands the URL to nobody, so it uses the origin
+   *  this browser is known to reach rather than the public one, which a
+   *  split-horizon deployment may route only externally. */
   function getShareUrl() {
     if (!rawShareToken) return '';
-    return `${shareBaseUrl}/m/${rawShareToken}`;
+    return `${currentOrigin}/m/${rawShareToken}`;
   }
 
   /** SHARE-08 (Phase 1142): returns the crawler-unfurlable /card URL so the
@@ -1519,11 +1540,16 @@ export function ShareDialog({
                     </div>
                   )}
                   {/* SHARE-03: embed preview pane — gated on embedTokenRaw to ensure et= param is available */}
-                  {embedTokenRaw && embedBaseUrl && (
+                  {/* fix(#1548 review r5): category (2) — the preview loads in
+                      THIS browser, so it must use an origin this browser can
+                      actually reach. Pointed at a public host that is routed
+                      only externally it would render nothing at all, which is
+                      strictly worse than previewing from the serving host. */}
+                  {embedTokenRaw && (
                     <EmbedPreviewPane
                       shareToken={rawShareToken}
                       embedTokenRaw={embedTokenRaw}
-                      origin={embedBaseUrl}
+                      origin={currentOrigin}
                     />
                   )}
                 </div>

--- a/frontend/src/components/builder/SharePanel.tsx
+++ b/frontend/src/components/builder/SharePanel.tsx
@@ -14,7 +14,11 @@ import {
 } from '@/components/ui/select';
 import { ApiError } from '@/api/client';
 import { classifyApiError } from '@/lib/error-map';
-import { getPublicAppBaseUrl, getShareableBaseUrl } from '@/lib/public-urls';
+import {
+  getLockedPreviewBaseUrl,
+  getPublicAppBaseUrl,
+  getShareableBaseUrl,
+} from '@/lib/public-urls';
 import { formatDate } from '@/lib/format';
 import { cn } from '@/lib/utils';
 import { useEdition } from '@/hooks/use-edition';
@@ -624,19 +628,9 @@ interface EmbedPreviewPaneProps {
   shareToken: string;
   embedTokenRaw: string;
   origin: string;
-  /** fix(#1548 review r6): a locked preview is loaded from the CONFIGURED
-   *  origin, which this browser may not be able to reach at all (split-horizon
-   *  deployments route the public host externally only). Reachability cannot be
-   *  predicted from here, so the existing load-failure state explains it. */
-  isDomainLocked?: boolean;
 }
 
-function EmbedPreviewPane({
-  shareToken,
-  embedTokenRaw,
-  origin,
-  isDomainLocked = false,
-}: EmbedPreviewPaneProps) {
+function EmbedPreviewPane({ shareToken, embedTokenRaw, origin }: EmbedPreviewPaneProps) {
   const { t } = useTranslation('builder');
   const [expanded, setExpanded] = useState(false);
   const [loaded, setLoaded] = useState(false);
@@ -706,9 +700,7 @@ function EmbedPreviewPane({
                 {t('share.iframeErrorTitle', { defaultValue: 'Preview unavailable' })}
               </p>
               <p className="text-xs text-muted-foreground text-center">
-                {isDomainLocked
-                  ? t('share.iframeErrorBodyDomainLocked')
-                  : t('share.iframeErrorBody', { defaultValue: 'Check that the embed token is valid and the share link is active. Reload to retry.' })}
+                {t('share.iframeErrorBody', { defaultValue: 'Check that the embed token is valid and the share link is active. Reload to retry.' })}
               </p>
               <button
                 type="button"
@@ -969,11 +961,12 @@ export function ShareDialog({
   //     not a misconfiguration, and pointing a local affordance at it means an
   //     admin can use GeoLens yet cannot open the share they just created.
   //  3. OPENED BY THIS BROWSER *AND* SUBJECT TO THE LOCK — a DOMAIN-LOCKED
-  //     preview. It belongs to neither bucket above: loaded from currentOrigin
-  //     its own API calls carry an origin the lock does not permit, so it
-  //     renders without its scoped layers — the exact silent failure this PR
-  //     exists to end. It must use the configured origin, and when there is
-  //     none it cannot be shown at all. See previewBaseUrl below.
+  //     preview. It belongs to neither bucket above, and for a split-horizon
+  //     deployment it has no answer at all: its API calls must carry the
+  //     CONFIGURED origin, while `frame-ancestors` judges this dialog as the
+  //     PARENT and accepts only that same configured origin. So it is offered
+  //     only when the two already coincide, and refused otherwise. See
+  //     getLockedPreviewBaseUrl.
   //  4. The domain-lock decision for the SNIPPET is a further split within (1).
   //
   // See lib/public-urls.ts for why "configured" is not the same question as
@@ -1029,14 +1022,17 @@ export function ShareDialog({
   const isDomainLocked = configOrigins.length > 0;
   const embedBaseUrl = isDomainLocked ? trustedAppBaseUrl : shareBaseUrl;
 
-  // fix(#1548 review r6): category (3). A locked preview has to satisfy the
-  // same check the customer's embed will, and only the configured origin does
-  // — so unlike the "Open" button it gets no current-origin fallback, and
-  // unlike the snippet it cannot fall back to a serving origin either. Null
-  // here means the preview is genuinely impossible: you cannot preview a
-  // domain-locked embed from a host the lock does not permit. Saying so beats
-  // rendering a map with no layers in it.
-  const previewBaseUrl = isDomainLocked ? trustedAppBaseUrl : currentOrigin;
+  // fix(#1548 review r6/r7): category (3). Null means the preview is genuinely
+  // impossible rather than merely unconfigured — you cannot preview a
+  // domain-locked embed from a hostname the lock does not permit, and asking
+  // the browser to do it anyway just gets the frame blocked. Copying the
+  // snippet, which is what the admin came here for, is unaffected.
+  const previewBaseUrl = isDomainLocked
+    ? getLockedPreviewBaseUrl(tileConfig, currentOrigin)
+    : currentOrigin;
+  // Which of the two refusals to print: no usable public origin at all, or one
+  // that exists but is not this hostname.
+  const lockedPreviewBlockedByOrigin = isDomainLocked && trustedAppBaseUrl !== null;
 
   const createEmbedToken = tokens.embedMutation;
   const revokeEmbedToken = tokens.revokeEmbedMutation;
@@ -1579,7 +1575,6 @@ export function ShareDialog({
                       shareToken={rawShareToken}
                       embedTokenRaw={embedTokenRaw}
                       origin={previewBaseUrl}
-                      isDomainLocked={isDomainLocked}
                     />
                   )}
                   {embedTokenRaw && !previewBaseUrl && (
@@ -1587,7 +1582,9 @@ export function ShareDialog({
                       role="status"
                       className="text-xs text-muted-foreground border-t pt-3"
                     >
-                      {t('share.lockedPreviewNeedsPublicUrl')}
+                      {lockedPreviewBlockedByOrigin
+                        ? t('share.lockedPreviewCrossOrigin')
+                        : t('share.lockedPreviewNeedsPublicUrl')}
                     </p>
                   )}
                 </div>

--- a/frontend/src/components/builder/SharePanel.tsx
+++ b/frontend/src/components/builder/SharePanel.tsx
@@ -13,6 +13,7 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import { ApiError } from '@/api/client';
+import { classifyApiError } from '@/lib/error-map';
 import { formatDate } from '@/lib/format';
 import { cn } from '@/lib/utils';
 import { useEdition } from '@/hooks/use-edition';
@@ -42,6 +43,22 @@ import { normalizeOrigin, WildcardOriginError } from '@/lib/builder/url-normaliz
 import { isLayerHiddenFromMapAudience } from '@/components/builder/map-stack';
 import type { MapLayerResponse, MapVisibility } from '@/types/api';
 import { Textarea } from '@/components/ui/textarea';
+
+/**
+ * fix(#1548 review P2): true for the backend's "this deployment cannot enforce
+ * a domain lock" refusal (`assert_domain_lock_is_enforceable`).
+ *
+ * Matched through `classifyApiError` rather than by re-testing the prose here,
+ * so error-map.ts stays the one place that knows the server's wording — the
+ * same single-reader discipline the #1531 fix applied to the policy itself.
+ */
+function isDomainLockUnenforceable(err: unknown): err is ApiError {
+  return (
+    err instanceof ApiError &&
+    err.status === 422 &&
+    classifyApiError(err.body, err.status).key === 'errors.embedDomainLockUnenforceable'
+  );
+}
 
 /**
  * Build the embedded-viewer iframe `src` URL for a shared map (builder-audit
@@ -319,6 +336,13 @@ function ShareLinkSettings({
       setOrigins((current) => current.filter((o) => o !== addedCanonical));
       if (err instanceof ApiError && err.status === 422 && /Wildcard/i.test(err.message)) {
         setOriginError(t('share.originWildcardError', { defaultValue: 'Wildcard origin not allowed' }));
+      } else if (isDomainLockUnenforceable(err)) {
+        // fix(#1548 review P2): the server's remediation IS the message here —
+        // it names PUBLIC_APP_URL and the value to set. Collapsing it into the
+        // generic "update failed" toast would put the operator back where the
+        // refusal exists to rescue them from: a domain lock that quietly
+        // delivers nothing. err.message is already localized by apiFetch.
+        setOriginError((err as ApiError).message);
       } else {
         toast.error(t('share.updateFailed'));
       }
@@ -338,13 +362,21 @@ function ShareLinkSettings({
         tokenId: resolvedEmbedTokenId,
         allowedOrigins: newOrigins.length > 0 ? newOrigins : null,
       });
-    } catch {
+    } catch (err) {
       // Rollback using functional setState — re-insert what was removed so
       // concurrent removes are not discarded (WR-01: stale-closure race).
       setOrigins((current) =>
         current.includes(removedOrigin) ? current : [...current, removedOrigin],
       );
-      toast.error(t('share.updateFailed'));
+      // fix(#1548 review P2): removing one of several origins still writes a
+      // non-empty lock, so an unenforceable deployment refuses it and the
+      // operator needs the same remediation as on add. Clearing the LAST origin
+      // sends null and is never refused, which stays their way out.
+      if (isDomainLockUnenforceable(err)) {
+        setOriginError((err as ApiError).message);
+      } else {
+        toast.error(t('share.updateFailed'));
+      }
     }
   }
 

--- a/frontend/src/components/builder/SharePanel.tsx
+++ b/frontend/src/components/builder/SharePanel.tsx
@@ -14,7 +14,7 @@ import {
 } from '@/components/ui/select';
 import { ApiError } from '@/api/client';
 import { classifyApiError } from '@/lib/error-map';
-import { getPublicAppBaseUrl } from '@/lib/public-urls';
+import { getPublicAppBaseUrl, getShareableBaseUrl } from '@/lib/public-urls';
 import { formatDate } from '@/lib/format';
 import { cn } from '@/lib/utils';
 import { useEdition } from '@/hooks/use-edition';
@@ -937,13 +937,18 @@ export function ShareDialog({
   const { isEnterprise } = useEdition();
   const publishMap = usePublishMap();
 
-  // fix(#1548 review r3): every URL handed to someone else — the share link,
+  // fix(#1548 review r3/r4): every URL handed to someone else — the share link,
   // its unfurlable /card twin, the iframe snippet, the preview standing in for
-  // that snippet — is built from the deployment's configured public origin, not
-  // from whatever hostname this admin is using. See lib/public-urls.ts. Null
-  // when unconfigured, which the UI surfaces rather than papering over.
+  // that snippet — prefers the deployment's configured public origin over
+  // whatever hostname this admin is using. See lib/public-urls.ts for why
+  // "configured" is not the same question as "correct".
   const { data: tileConfig } = useTileConfig();
-  const publicAppBaseUrl = getPublicAppBaseUrl(tileConfig);
+  const currentOrigin = typeof window === 'undefined' ? '' : window.location.origin;
+  // Non-null only when the configured value is one a viewer could actually
+  // open. Null covers unset AND the shipped localhost default.
+  const trustedAppBaseUrl = getPublicAppBaseUrl(tileConfig, currentOrigin);
+  // Ordinary shares degrade gracefully: a serving origin still opens.
+  const shareBaseUrl = getShareableBaseUrl(tileConfig, currentOrigin);
 
   // fix(#430 V-17): names of layers that would be silently hidden from this map's
   // audience — e.g. a private/unpublished dataset added to a public/shared
@@ -975,6 +980,19 @@ export function ShareDialog({
   const handleRevoked = tokens.onRevoked;
   const createShareToken = tokens.shareMutation;
   const revokeShareToken = tokens.revokeShareMutation;
+  // fix(#1548 review r4): the embed snippet splits from the share link here,
+  // on what a wrong origin COSTS. An unrestricted embed degrades — served from
+  // a non-canonical but real origin it still loads and draws. A DOMAIN-LOCKED
+  // one does not: the shell's own API calls would carry an origin the backend
+  // does not recognize as first-party, so the map comes up empty with nothing
+  // said. That is the failure this whole PR exists to stop being silent, so
+  // when the lock is on we require a trustworthy configured origin and withhold
+  // the snippet otherwise. `assert_domain_lock_is_enforceable` refuses to mint
+  // such a lock in the first place, so this is reachable only for a token that
+  // predates the guard or a deployment whose URL changed under it.
+  const isDomainLocked = configOrigins.length > 0;
+  const embedBaseUrl = isDomainLocked ? trustedAppBaseUrl : shareBaseUrl;
+
   const createEmbedToken = tokens.embedMutation;
   const revokeEmbedToken = tokens.revokeEmbedMutation;
 
@@ -1049,16 +1067,10 @@ export function ShareDialog({
     }
   }
 
-  /** fix(#1548 review r3): navigation only — this one feeds the "Open" button,
-   *  which opens the viewer in THIS admin's browser and hands the URL to nobody.
-   *  It prefers the configured origin so the admin sees what a viewer sees, but
-   *  keeps working from the current origin when there is none, because a local
-   *  affordance has no reason to go dead over a deployment setting. Everything
-   *  that is copied or embedded (getShareCardUrl, getEmbedCode, the preview) has
-   *  no such fallback. */
+  /** Feeds the "Open" button — navigation in THIS admin's browser. */
   function getShareUrl() {
     if (!rawShareToken) return '';
-    return `${publicAppBaseUrl ?? window.location.origin}/m/${rawShareToken}`;
+    return `${shareBaseUrl}/m/${rawShareToken}`;
   }
 
   /** SHARE-08 (Phase 1142): returns the crawler-unfurlable /card URL so the
@@ -1070,16 +1082,16 @@ export function ShareDialog({
    *  new tab" affordance (direct, redirect-free viewer load). The embed iframe
    *  src is unchanged (see generateEmbedCode). */
   function getShareCardUrl() {
-    if (!rawShareToken || !publicAppBaseUrl) return '';
-    return `${publicAppBaseUrl}/api/maps/shared/${rawShareToken}/card`;
+    if (!rawShareToken) return '';
+    return `${shareBaseUrl}/api/maps/shared/${rawShareToken}/card`;
   }
 
   function getEmbedCode() {
-    if (!publicAppBaseUrl) return '';
+    if (!embedBaseUrl) return '';
     return generateEmbedCode({
       shareToken: rawShareToken || '',
       embedTokenRaw: embedTokenRaw || '',
-      origin: publicAppBaseUrl,
+      origin: embedBaseUrl,
     });
   }
 
@@ -1087,13 +1099,7 @@ export function ShareDialog({
     // SHARE-08: copy the /card URL so the pasted link unfurls in social clients.
     // The label ("Copy Link") is unchanged — only the copied value changes.
     const url = getShareCardUrl();
-    if (!url) {
-      // fix(#1548 review r3): a copied link goes to someone else, so there is
-      // no correct value to put on the clipboard without a configured public
-      // origin. Say why instead of leaving the button silently dead.
-      if (!publicAppBaseUrl) toast.error(t('share.publicAppUrlNotConfigured'));
-      return;
-    }
+    if (!url) return;
     try {
       await navigator.clipboard.writeText(url);
       toast.success(t('toasts.shareLinkCopied'));
@@ -1105,9 +1111,9 @@ export function ShareDialog({
   async function handleCopyEmbedCode() {
     const code = getEmbedCode();
     if (!code) {
-      // fix(#1548 review r3): same posture as the share link — the snippet is
-      // pasted on someone else's site, so an unconfigured origin has no answer.
-      if (!publicAppBaseUrl) toast.error(t('share.publicAppUrlNotConfigured'));
+      // fix(#1548 review r4): only reachable with a domain lock on and no
+      // trustworthy public origin — a snippet that would load and stay empty.
+      if (!embedBaseUrl) toast.error(t('share.publicAppUrlNotConfigured'));
       return;
     }
     try {
@@ -1397,11 +1403,12 @@ export function ShareDialog({
                     <Code className="h-3.5 w-3.5 text-muted-foreground" />
                     <span className="text-sm font-semibold">{t('share.embedCode')}</span>
                   </div>
-                  {/* fix(#1548 review r3): with no configured public origin
-                      there is no correct URL to put in a snippet a customer
-                      will paste on their own site, so say so instead of
-                      emitting one built from this admin's hostname. */}
-                  {!publicAppBaseUrl ? (
+                  {/* fix(#1548 review r4): a domain-locked embed with no
+                      trustworthy public origin would load and stay empty, so
+                      say that rather than emitting a snippet that looks fine.
+                      An unrestricted embed always has a usable origin and never
+                      reaches this branch. */}
+                  {!embedBaseUrl ? (
                     <div
                       role="status"
                       className="flex items-start gap-2 rounded-md border border-warning/30 bg-warning/5 px-3 py-2"
@@ -1512,11 +1519,11 @@ export function ShareDialog({
                     </div>
                   )}
                   {/* SHARE-03: embed preview pane — gated on embedTokenRaw to ensure et= param is available */}
-                  {embedTokenRaw && publicAppBaseUrl && (
+                  {embedTokenRaw && embedBaseUrl && (
                     <EmbedPreviewPane
                       shareToken={rawShareToken}
                       embedTokenRaw={embedTokenRaw}
-                      origin={publicAppBaseUrl}
+                      origin={embedBaseUrl}
                     />
                   )}
                 </div>

--- a/frontend/src/components/builder/SharePanel.tsx
+++ b/frontend/src/components/builder/SharePanel.tsx
@@ -14,9 +14,11 @@ import {
 } from '@/components/ui/select';
 import { ApiError } from '@/api/client';
 import { classifyApiError } from '@/lib/error-map';
+import { getPublicAppBaseUrl } from '@/lib/public-urls';
 import { formatDate } from '@/lib/format';
 import { cn } from '@/lib/utils';
 import { useEdition } from '@/hooks/use-edition';
+import { useTileConfig } from '@/hooks/use-settings';
 import {
   Dialog,
   DialogContent,
@@ -935,6 +937,14 @@ export function ShareDialog({
   const { isEnterprise } = useEdition();
   const publishMap = usePublishMap();
 
+  // fix(#1548 review r3): every URL handed to someone else — the share link,
+  // its unfurlable /card twin, the iframe snippet, the preview standing in for
+  // that snippet — is built from the deployment's configured public origin, not
+  // from whatever hostname this admin is using. See lib/public-urls.ts. Null
+  // when unconfigured, which the UI surfaces rather than papering over.
+  const { data: tileConfig } = useTileConfig();
+  const publicAppBaseUrl = getPublicAppBaseUrl(tileConfig);
+
   // fix(#430 V-17): names of layers that would be silently hidden from this map's
   // audience — e.g. a private/unpublished dataset added to a public/shared
   // map. Empty for a private map (no audience beyond the owner/grantees).
@@ -1039,9 +1049,16 @@ export function ShareDialog({
     }
   }
 
+  /** fix(#1548 review r3): navigation only — this one feeds the "Open" button,
+   *  which opens the viewer in THIS admin's browser and hands the URL to nobody.
+   *  It prefers the configured origin so the admin sees what a viewer sees, but
+   *  keeps working from the current origin when there is none, because a local
+   *  affordance has no reason to go dead over a deployment setting. Everything
+   *  that is copied or embedded (getShareCardUrl, getEmbedCode, the preview) has
+   *  no such fallback. */
   function getShareUrl() {
     if (!rawShareToken) return '';
-    return `${window.location.origin}/m/${rawShareToken}`;
+    return `${publicAppBaseUrl ?? window.location.origin}/m/${rawShareToken}`;
   }
 
   /** SHARE-08 (Phase 1142): returns the crawler-unfurlable /card URL so the
@@ -1053,15 +1070,16 @@ export function ShareDialog({
    *  new tab" affordance (direct, redirect-free viewer load). The embed iframe
    *  src is unchanged (see generateEmbedCode). */
   function getShareCardUrl() {
-    if (!rawShareToken) return '';
-    return `${window.location.origin}/api/maps/shared/${rawShareToken}/card`;
+    if (!rawShareToken || !publicAppBaseUrl) return '';
+    return `${publicAppBaseUrl}/api/maps/shared/${rawShareToken}/card`;
   }
 
   function getEmbedCode() {
+    if (!publicAppBaseUrl) return '';
     return generateEmbedCode({
       shareToken: rawShareToken || '',
       embedTokenRaw: embedTokenRaw || '',
-      origin: window.location.origin,
+      origin: publicAppBaseUrl,
     });
   }
 
@@ -1069,7 +1087,13 @@ export function ShareDialog({
     // SHARE-08: copy the /card URL so the pasted link unfurls in social clients.
     // The label ("Copy Link") is unchanged — only the copied value changes.
     const url = getShareCardUrl();
-    if (!url) return;
+    if (!url) {
+      // fix(#1548 review r3): a copied link goes to someone else, so there is
+      // no correct value to put on the clipboard without a configured public
+      // origin. Say why instead of leaving the button silently dead.
+      if (!publicAppBaseUrl) toast.error(t('share.publicAppUrlNotConfigured'));
+      return;
+    }
     try {
       await navigator.clipboard.writeText(url);
       toast.success(t('toasts.shareLinkCopied'));
@@ -1080,7 +1104,12 @@ export function ShareDialog({
 
   async function handleCopyEmbedCode() {
     const code = getEmbedCode();
-    if (!code) return;
+    if (!code) {
+      // fix(#1548 review r3): same posture as the share link — the snippet is
+      // pasted on someone else's site, so an unconfigured origin has no answer.
+      if (!publicAppBaseUrl) toast.error(t('share.publicAppUrlNotConfigured'));
+      return;
+    }
     try {
       await navigator.clipboard.writeText(code);
       toast.success(t('toasts.embedCodeCopied'));
@@ -1368,23 +1397,39 @@ export function ShareDialog({
                     <Code className="h-3.5 w-3.5 text-muted-foreground" />
                     <span className="text-sm font-semibold">{t('share.embedCode')}</span>
                   </div>
-                  <div className="relative">
-                    <Textarea
-                      readOnly
-                      value={getEmbedCode()}
-                      rows={3}
-                      className="bg-muted/30 text-xs font-mono resize-none"
-                    />
-                    <Button
-                      variant="outline"
-                      size="icon-xs"
-                      className="absolute top-1.5 end-1.5"
-                      onClick={handleCopyEmbedCode}
-                      title={t('share.copyEmbedCode')}
+                  {/* fix(#1548 review r3): with no configured public origin
+                      there is no correct URL to put in a snippet a customer
+                      will paste on their own site, so say so instead of
+                      emitting one built from this admin's hostname. */}
+                  {!publicAppBaseUrl ? (
+                    <div
+                      role="status"
+                      className="flex items-start gap-2 rounded-md border border-warning/30 bg-warning/5 px-3 py-2"
                     >
-                      <Copy className="h-3 w-3" />
-                    </Button>
-                  </div>
+                      <AlertTriangle className="h-3.5 w-3.5 text-warning mt-0.5 flex-shrink-0" />
+                      <p className="text-xs text-muted-foreground">
+                        {t('share.publicAppUrlNotConfigured')}
+                      </p>
+                    </div>
+                  ) : (
+                    <div className="relative">
+                      <Textarea
+                        readOnly
+                        value={getEmbedCode()}
+                        rows={3}
+                        className="bg-muted/30 text-xs font-mono resize-none"
+                      />
+                      <Button
+                        variant="outline"
+                        size="icon-xs"
+                        className="absolute top-1.5 end-1.5"
+                        onClick={handleCopyEmbedCode}
+                        title={t('share.copyEmbedCode')}
+                      >
+                        <Copy className="h-3 w-3" />
+                      </Button>
+                    </div>
+                  )}
                   {hasNonPublic && (
                     <div className="flex items-start gap-2 rounded-md border border-info/30 bg-info/5 px-3 py-2">
                       <Info className="h-3.5 w-3.5 text-info mt-0.5 flex-shrink-0" />
@@ -1467,11 +1512,11 @@ export function ShareDialog({
                     </div>
                   )}
                   {/* SHARE-03: embed preview pane — gated on embedTokenRaw to ensure et= param is available */}
-                  {embedTokenRaw && (
+                  {embedTokenRaw && publicAppBaseUrl && (
                     <EmbedPreviewPane
                       shareToken={rawShareToken}
                       embedTokenRaw={embedTokenRaw}
-                      origin={window.location.origin}
+                      origin={publicAppBaseUrl}
                     />
                   )}
                 </div>

--- a/frontend/src/components/builder/SharePanel.tsx
+++ b/frontend/src/components/builder/SharePanel.tsx
@@ -624,9 +624,19 @@ interface EmbedPreviewPaneProps {
   shareToken: string;
   embedTokenRaw: string;
   origin: string;
+  /** fix(#1548 review r6): a locked preview is loaded from the CONFIGURED
+   *  origin, which this browser may not be able to reach at all (split-horizon
+   *  deployments route the public host externally only). Reachability cannot be
+   *  predicted from here, so the existing load-failure state explains it. */
+  isDomainLocked?: boolean;
 }
 
-function EmbedPreviewPane({ shareToken, embedTokenRaw, origin }: EmbedPreviewPaneProps) {
+function EmbedPreviewPane({
+  shareToken,
+  embedTokenRaw,
+  origin,
+  isDomainLocked = false,
+}: EmbedPreviewPaneProps) {
   const { t } = useTranslation('builder');
   const [expanded, setExpanded] = useState(false);
   const [loaded, setLoaded] = useState(false);
@@ -696,7 +706,9 @@ function EmbedPreviewPane({ shareToken, embedTokenRaw, origin }: EmbedPreviewPan
                 {t('share.iframeErrorTitle', { defaultValue: 'Preview unavailable' })}
               </p>
               <p className="text-xs text-muted-foreground text-center">
-                {t('share.iframeErrorBody', { defaultValue: 'Check that the embed token is valid and the share link is active. Reload to retry.' })}
+                {isDomainLocked
+                  ? t('share.iframeErrorBodyDomainLocked')
+                  : t('share.iframeErrorBody', { defaultValue: 'Check that the embed token is valid and the share link is active. Reload to retry.' })}
               </p>
               <button
                 type="button"
@@ -949,14 +961,20 @@ export function ShareDialog({
   //  1. HANDED TO SOMEONE ELSE — the copied link, its /card twin, the iframe
   //     snippet. The recipient is not on this network, so these must name the
   //     address people use to reach GeoLens (shareBaseUrl / embedBaseUrl).
-  //  2. OPENED BY THIS BROWSER — the "Open" button and the embed preview. These
-  //     use currentOrigin directly and are deliberately NEITHER of the others:
-  //     this browser demonstrably reaches this host, and may not reach the
-  //     public one at all. An externally routed public hostname unreachable
+  //  2. OPENED BY THIS BROWSER — the "Open" button and an UNLOCKED preview.
+  //     These use currentOrigin directly and are deliberately NEITHER of the
+  //     others: this browser demonstrably reaches this host, and may not reach
+  //     the public one at all. An externally routed public hostname unreachable
   //     from the internal admin network is a normal split-horizon deployment,
   //     not a misconfiguration, and pointing a local affordance at it means an
   //     admin can use GeoLens yet cannot open the share they just created.
-  //  3. The domain-lock decision is a further split within (1), below.
+  //  3. OPENED BY THIS BROWSER *AND* SUBJECT TO THE LOCK — a DOMAIN-LOCKED
+  //     preview. It belongs to neither bucket above: loaded from currentOrigin
+  //     its own API calls carry an origin the lock does not permit, so it
+  //     renders without its scoped layers — the exact silent failure this PR
+  //     exists to end. It must use the configured origin, and when there is
+  //     none it cannot be shown at all. See previewBaseUrl below.
+  //  4. The domain-lock decision for the SNIPPET is a further split within (1).
   //
   // See lib/public-urls.ts for why "configured" is not the same question as
   // "correct".
@@ -1010,6 +1028,15 @@ export function ShareDialog({
   // predates the guard or a deployment whose URL changed under it.
   const isDomainLocked = configOrigins.length > 0;
   const embedBaseUrl = isDomainLocked ? trustedAppBaseUrl : shareBaseUrl;
+
+  // fix(#1548 review r6): category (3). A locked preview has to satisfy the
+  // same check the customer's embed will, and only the configured origin does
+  // — so unlike the "Open" button it gets no current-origin fallback, and
+  // unlike the snippet it cannot fall back to a serving origin either. Null
+  // here means the preview is genuinely impossible: you cannot preview a
+  // domain-locked embed from a host the lock does not permit. Saying so beats
+  // rendering a map with no layers in it.
+  const previewBaseUrl = isDomainLocked ? trustedAppBaseUrl : currentOrigin;
 
   const createEmbedToken = tokens.embedMutation;
   const revokeEmbedToken = tokens.revokeEmbedMutation;
@@ -1540,17 +1567,28 @@ export function ShareDialog({
                     </div>
                   )}
                   {/* SHARE-03: embed preview pane — gated on embedTokenRaw to ensure et= param is available */}
-                  {/* fix(#1548 review r5): category (2) — the preview loads in
-                      THIS browser, so it must use an origin this browser can
-                      actually reach. Pointed at a public host that is routed
-                      only externally it would render nothing at all, which is
-                      strictly worse than previewing from the serving host. */}
-                  {embedTokenRaw && (
+                  {/* fix(#1548 review r5/r6): an UNLOCKED preview loads in THIS
+                      browser and uses the origin this browser reached — pointed
+                      at a public host routed only externally it would render
+                      nothing. A DOMAIN-LOCKED preview instead has to come from
+                      the configured origin, because that is the only one its
+                      own API calls may present; with no such origin it is
+                      suppressed rather than shown empty. */}
+                  {embedTokenRaw && previewBaseUrl && (
                     <EmbedPreviewPane
                       shareToken={rawShareToken}
                       embedTokenRaw={embedTokenRaw}
-                      origin={currentOrigin}
+                      origin={previewBaseUrl}
+                      isDomainLocked={isDomainLocked}
                     />
+                  )}
+                  {embedTokenRaw && !previewBaseUrl && (
+                    <p
+                      role="status"
+                      className="text-xs text-muted-foreground border-t pt-3"
+                    >
+                      {t('share.lockedPreviewNeedsPublicUrl')}
+                    </p>
                   )}
                 </div>
               )}

--- a/frontend/src/components/builder/__tests__/SharePanel.test.tsx
+++ b/frontend/src/components/builder/__tests__/SharePanel.test.tsx
@@ -12,6 +12,7 @@ import {
   useUpdateEmbedToken,
 } from '@/components/builder/hooks/use-embed-tokens';
 import { useEdition } from '@/hooks/use-edition';
+import { useTileConfig } from '@/hooks/use-settings';
 import {
   useCreateShareToken,
   useMapShareToken,
@@ -39,6 +40,14 @@ vi.mock('@/hooks/use-maps', () => ({
   useUpdateShareToken: vi.fn(),
 }));
 
+// fix(#1548 review r3): SharePanel now reads the deployment's configured
+// public origin for every URL it hands out. Default the mock to the current
+// origin so tests written before that change emit byte-identical URLs; the
+// tests that care drive a DIFFERENT hostname, which is the whole point.
+vi.mock('@/hooks/use-settings', () => ({
+  useTileConfig: vi.fn(),
+}));
+
 vi.mock('@/components/builder/hooks/use-embed-tokens', () => ({
   useCreateEmbedToken: vi.fn(),
   useMapEmbedTokens: vi.fn(),
@@ -46,6 +55,7 @@ vi.mock('@/components/builder/hooks/use-embed-tokens', () => ({
   useRevokeEmbedToken: vi.fn(),
 }));
 
+const mockedUseTileConfig = vi.mocked(useTileConfig);
 const mockedUseEdition = vi.mocked(useEdition);
 const mockedCheckMapVisibility = vi.mocked(checkMapVisibility);
 const mockedUsePublishMap = vi.mocked(usePublishMap);
@@ -88,6 +98,7 @@ function setup({
   visibility = 'public',
   layers,
   publishMapFn = vi.fn().mockResolvedValue({}),
+  publicAppUrl = window.location.origin,
 }: {
   enterprise?: boolean;
   hasShareToken?: boolean;
@@ -106,6 +117,8 @@ function setup({
   layers?: ComponentProps<typeof ShareDialog>['layers'];
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   publishMapFn?: (...args: any[]) => any;
+  /** The deployment's configured PUBLIC_APP_URL. null = unconfigured. */
+  publicAppUrl?: string | null;
 } = {}) {
   const createShareToken = vi.fn().mockResolvedValue({
     token: 'share-token',
@@ -120,6 +133,17 @@ function setup({
     expires_at: FUTURE_EMBED_EXPIRES_AT,
     is_active: true,
   });
+
+  mockedUseTileConfig.mockReturnValue({
+    data: {
+      cdn_base_url: null,
+      public_app_url: publicAppUrl,
+      public_api_url: publicAppUrl ? `${publicAppUrl}/api` : null,
+      public_base_url: null,
+      mvt_source_layer_prefix: 'data',
+    },
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any);
 
   mockedUseEdition.mockReturnValue({
     edition: enterprise ? 'enterprise' : 'community',
@@ -1209,5 +1233,118 @@ describe('fix(#778) public-boundary visibility confirmation', () => {
     });
     expect(publishMapFn).toHaveBeenCalledWith({ id: 'map-1', visibility: 'internal' });
     expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument();
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  #1548 review r3: shareable URLs come from PUBLIC_APP_URL           */
+/* ------------------------------------------------------------------ */
+
+/**
+ * A snippet is copied so a CUSTOMER can paste it on THEIR site, and a share
+ * link is pasted into Slack. Building either from `window.location.origin`
+ * means an operator who administers GeoLens over an internal hostname hands out
+ * a URL that will not resolve for anyone else — a bug that exists with or
+ * without domain locking.
+ *
+ * It also silently breaks a domain-locked embed: the shell's own API calls
+ * carry the shell's origin, and the backend recognizes only the CONFIGURED
+ * origin as first-party, so a snippet built from a different-but-real hostname
+ * loads and then returns no layers.
+ *
+ * `PUBLIC_APP_URL` here is deliberately NOT the current origin, so a builder
+ * that ignored it would fail every assertion below.
+ */
+describe('#1548 r3 shareable URLs use the configured public origin', () => {
+  const CONFIGURED = 'https://maps.example.com';
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('builds the embed snippet from PUBLIC_APP_URL, not the admin hostname', async () => {
+    const user = userEvent.setup();
+    setup({ hasShareToken: false, hasNonPublic: true, publicAppUrl: CONFIGURED });
+    await generateShareLinkAndWait(user);
+
+    const textarea = (await screen.findByRole('textbox')) as HTMLTextAreaElement;
+    expect(textarea.value).toContain(`src="${CONFIGURED}/m/share-token`);
+    expect(textarea.value).not.toContain(window.location.origin);
+  });
+
+  it('points the preview iframe at the configured origin too', async () => {
+    const user = userEvent.setup();
+    setup({ hasShareToken: false, hasNonPublic: true, publicAppUrl: CONFIGURED });
+    await generateShareLinkAndWait(user);
+    await user.click(screen.getByRole('button', { name: /preview/i }));
+
+    const iframe = (await screen.findByTestId(
+      'share-preview-iframe',
+    )) as HTMLIFrameElement;
+    expect(iframe.src).toContain(`${CONFIGURED}/m/share-token`);
+    expect(iframe.src).not.toContain(window.location.origin);
+  });
+
+  it('copies a share link on the configured origin', async () => {
+    // userEvent.setup() installs its own clipboard stub, so the spy has to be
+    // planted AFTER it — the existing SHARE-08 test does the same.
+    const user = userEvent.setup();
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText },
+      writable: true,
+      configurable: true,
+    });
+    setup({ hasShareToken: false, publicAppUrl: CONFIGURED });
+    await generateShareLinkAndWait(user);
+
+    await user.click(screen.getByRole('button', { name: /copy link/i }));
+    await waitFor(() => expect(writeText).toHaveBeenCalled());
+    expect(writeText.mock.calls[0][0]).toBe(
+      `${CONFIGURED}/api/maps/shared/share-token/card`,
+    );
+  });
+
+  it('refuses to emit a snippet at all when no public URL is configured', async () => {
+    const user = userEvent.setup();
+    setup({ hasShareToken: false, hasNonPublic: true, publicAppUrl: null });
+    await generateShareLinkAndWait(user);
+
+    expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
+    expect(screen.getByText(/PUBLIC_APP_URL/)).toBeInTheDocument();
+  });
+
+  it('says why instead of silently copying nothing', async () => {
+    // userEvent.setup() installs its own clipboard stub, so the spy has to be
+    // planted AFTER it — the existing SHARE-08 test does the same.
+    const user = userEvent.setup();
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText },
+      writable: true,
+      configurable: true,
+    });
+    setup({ hasShareToken: false, publicAppUrl: null });
+    await generateShareLinkAndWait(user);
+
+    await user.click(screen.getByRole('button', { name: /copy link/i }));
+    await waitFor(() => expect(vi.mocked(toast.error)).toHaveBeenCalled());
+    expect(writeText).not.toHaveBeenCalled();
+  });
+
+  it('keeps the local Open affordance working without a configured URL', async () => {
+    const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
+    const user = userEvent.setup();
+    setup({ hasShareToken: false, hasNonPublic: true, publicAppUrl: null });
+    await generateShareLinkAndWait(user);
+
+    await user.click(screen.getByRole('button', { name: /^open$/i }));
+    // Navigation in THIS admin's browser, handed to nobody — it has no reason
+    // to go dead over a deployment setting.
+    expect(openSpy).toHaveBeenCalledWith(
+      `${window.location.origin}/m/share-token`,
+      '_blank',
+    );
+    openSpy.mockRestore();
   });
 });

--- a/frontend/src/components/builder/__tests__/SharePanel.test.tsx
+++ b/frontend/src/components/builder/__tests__/SharePanel.test.tsx
@@ -3,6 +3,7 @@ import userEvent from '@testing-library/user-event';
 import { fireEvent, render, screen, waitFor } from '@/test/test-utils';
 import { checkMapVisibility } from '@/api/maps';
 import { ApiError } from '@/api/client';
+import { translateApiErrorDetail } from '@/lib/error-map';
 import { ShareDialog, generateEmbedCode, buildEmbedSrc } from '@/components/builder/SharePanel';
 import {
   useCreateEmbedToken,
@@ -498,6 +499,69 @@ describe('SHARE-02 chip-based allowed-origins input', () => {
     });
     // Same inline error as frontend wildcard rejection
     expect(screen.getByText(/wildcard origin not allowed/i)).toBeInTheDocument();
+  });
+
+  /**
+   * fix(#1548 review P2): both compose files ship PUBLIC_APP_URL defaulted to
+   * localhost, so a self-hoster reached at a real hostname is refused here on a
+   * stock install. The refusal exists to replace a silently-empty embed with an
+   * actionable message, so routing it to the generic "update failed" toast — the
+   * default for any unmapped 422 — would put them back where they started.
+   */
+  const DOMAIN_LOCK_DETAIL =
+    'Domain locking cannot be enforced by this deployment: its public app URL ' +
+    'resolves to http://localhost:8080, but this request reached it at ' +
+    'https://maps.example.com. An embed shell\'s own API calls carry the ' +
+    "shell's origin, so a domain-locked token issued now would load an empty " +
+    'map. Set PUBLIC_APP_URL (or the public_app_url setting) to ' +
+    'https://maps.example.com and try again.';
+
+  function domainLockRefusal() {
+    // Mirrors apiFetch: message is already localized, body carries the detail.
+    return new ApiError(
+      translateApiErrorDetail(DOMAIN_LOCK_DETAIL, 422),
+      422,
+      DOMAIN_LOCK_DETAIL,
+    );
+  }
+
+  it('test_chip_input_surfaces_unenforceable_domain_lock_inline: the refusal names PUBLIC_APP_URL where the operator is looking', async () => {
+    const user = userEvent.setup();
+    const updateEmbedTokenFn = vi.fn().mockRejectedValue(domainLockRefusal());
+    setup({ enterprise: true, allowedOrigins: [], updateEmbedTokenFn });
+    await openChipBlock(user);
+
+    const input = screen.getByRole('textbox', { name: /allowed origin url/i });
+    await user.type(input, 'https://customer.example.com');
+    await user.keyboard('{Enter}');
+
+    await waitFor(() => {
+      expect(screen.queryByText('https://customer.example.com')).not.toBeInTheDocument();
+    });
+    expect(screen.getByText(/PUBLIC_APP_URL/)).toBeInTheDocument();
+    expect(screen.getByText(/https:\/\/maps\.example\.com/)).toBeInTheDocument();
+    // The whole point: not swallowed by the generic toast.
+    expect(vi.mocked(toast.error)).not.toHaveBeenCalled();
+  });
+
+  it('test_chip_remove_surfaces_unenforceable_domain_lock_inline: shrinking a lock still writes one, so it gets the same message', async () => {
+    const user = userEvent.setup();
+    const updateEmbedTokenFn = vi.fn().mockRejectedValue(domainLockRefusal());
+    setup({
+      enterprise: true,
+      allowedOrigins: ['https://example.com', 'https://other.io'],
+      updateEmbedTokenFn,
+    });
+    await openChipBlock(user);
+
+    await user.click(
+      screen.getByRole('button', { name: /remove https:\/\/example\.com/i }),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(/PUBLIC_APP_URL/)).toBeInTheDocument();
+    });
+    expect(vi.mocked(toast.error)).not.toHaveBeenCalled();
   });
 
   it('test_chip_PATCH_failure_rolls_back: non-422 PATCH failure rolls back chip and surfaces toast', async () => {

--- a/frontend/src/components/builder/__tests__/SharePanel.test.tsx
+++ b/frontend/src/components/builder/__tests__/SharePanel.test.tsx
@@ -100,6 +100,7 @@ function setup({
   publishMapFn = vi.fn().mockResolvedValue({}),
   publicAppUrl = window.location.origin,
   forceActiveEmbedToken = false,
+  lockOriginsAfterCreate = null,
 }: {
   enterprise?: boolean;
   hasShareToken?: boolean;
@@ -123,6 +124,12 @@ function setup({
   /** Return an active embed token even when the share link is created at
    *  runtime — the domain-locked branch needs both. */
   forceActiveEmbedToken?: boolean;
+  /** Origins that appear on the active token only AFTER one is created here.
+   *  Mirrors the real builder sequence — a token is minted unlocked and the
+   *  origins are PATCHed on afterwards — and is the only way to reach a
+   *  domain-locked PREVIEW, since createEmbed() skips when a token already
+   *  exists and the raw token is available only at creation. */
+  lockOriginsAfterCreate?: string[] | null;
 } = {}) {
   const createShareToken = vi.fn().mockResolvedValue({
     token: 'share-token',
@@ -130,12 +137,16 @@ function setup({
     expires_at: null,
     is_active: true,
   });
-  const createEmbedToken = createEmbedTokenFn ?? vi.fn().mockResolvedValue({
-    id: 'embed-2',
-    raw_token: 'raw-token',
-    token_hint: 'raw...',
-    expires_at: FUTURE_EMBED_EXPIRES_AT,
-    is_active: true,
+  let embedTokenCreated = false;
+  const createEmbedToken = createEmbedTokenFn ?? vi.fn().mockImplementation(async () => {
+    embedTokenCreated = true;
+    return {
+      id: 'embed-2',
+      raw_token: 'raw-token',
+      token_hint: 'raw...',
+      expires_at: FUTURE_EMBED_EXPIRES_AT,
+      is_active: true,
+    };
   });
 
   mockedUseTileConfig.mockReturnValue({
@@ -180,10 +191,32 @@ function setup({
     isLoading: false,
     isError: false,
   } as never);
-  mockedUseMapEmbedTokens.mockReturnValue({
-    data: {
-      tokens: hasShareToken || forceActiveEmbedToken
-        ? [
+  const embedTokenRow = (origins: string[]) => ({
+    id: 'embed-1',
+    map_id: 'map-1',
+    token_hint: 'emb...',
+    scoped_dataset_ids: [],
+    allowed_origins: origins,
+    expires_at: FUTURE_EMBED_EXPIRES_AT,
+    is_active: true,
+    use_count: 0,
+    created_at: '2026-05-01T00:00:00Z',
+  });
+  mockedUseMapEmbedTokens.mockImplementation((() => {
+    if (lockOriginsAfterCreate && embedTokenCreated) {
+      return {
+        data: { tokens: [embedTokenRow(lockOriginsAfterCreate)], total: 1 },
+        isLoading: false,
+        isError: false,
+      };
+    }
+    if (lockOriginsAfterCreate) {
+      return { data: { tokens: [], total: 0 }, isLoading: false, isError: false };
+    }
+    return {
+      data: {
+        tokens: hasShareToken || forceActiveEmbedToken
+          ? [
             {
               id: 'embed-1',
               map_id: 'map-1',
@@ -195,13 +228,14 @@ function setup({
               use_count: 0,
               created_at: '2026-05-01T00:00:00Z',
             },
-          ]
-        : [],
-      total: hasShareToken || forceActiveEmbedToken ? 1 : 0,
-    },
-    isLoading: false,
-    isError: false,
-  } as never);
+            ]
+          : [],
+        total: hasShareToken || forceActiveEmbedToken ? 1 : 0,
+      },
+      isLoading: false,
+      isError: false,
+    };
+  }) as never);
   mockedCheckMapVisibility.mockResolvedValue({
     has_non_public: hasNonPublic,
     non_public_datasets: hasNonPublic ? ['Private dataset'] : [],
@@ -1409,6 +1443,76 @@ describe('#1548 r3 shareable URLs use the configured public origin', () => {
     });
   });
 
+  /**
+   * fix(#1548 review r6): you genuinely cannot preview a domain-locked embed
+   * from a host the lock does not permit — that is the feature working. Saying
+   * so beats rendering a map with no layers in it and letting the operator
+   * conclude the embed is broken.
+   */
+  describe('suppresses the locked preview with no trustworthy public origin', () => {
+    // The shipped-default row needs the browser somewhere other than loopback:
+    // on a genuine localhost install a localhost PUBLIC_APP_URL is correct.
+    const realLocation = window.location;
+    beforeEach(() => {
+      Object.defineProperty(window, 'location', {
+        value: { ...realLocation, origin: 'https://maps.example.com' },
+        writable: true,
+        configurable: true,
+      });
+    });
+    afterEach(() => {
+      Object.defineProperty(window, 'location', {
+        value: realLocation,
+        writable: true,
+        configurable: true,
+      });
+    });
+
+    it.each([
+      ['nothing is configured', null],
+      ['the config is the shipped localhost default', 'http://localhost:8080'],
+      ['the config is malformed', 'not-a-url'],
+    ])('when %s', async (_label, publicAppUrl) => {
+      const user = userEvent.setup();
+      setup({
+        enterprise: true,
+        hasShareToken: false,
+        hasNonPublic: true,
+        lockOriginsAfterCreate: ['https://customer.example.com'],
+        publicAppUrl,
+      });
+      await generateShareLinkAndWait(user);
+
+      expect(
+        screen.queryByRole('button', { name: /preview/i }),
+      ).not.toBeInTheDocument();
+      expect(screen.queryByTestId('share-preview-iframe')).not.toBeInTheDocument();
+      // The preview explains itself in its own words — the snippet above it is
+      // withheld too and also names PUBLIC_APP_URL, so match the preview copy.
+      expect(await screen.findByText(/only be previewed from/i)).toBeInTheDocument();
+      expect(screen.getAllByText(/PUBLIC_APP_URL/).length).toBeGreaterThan(0);
+    });
+  });
+
+  it('keeps previewing an UNLOCKED embed on the shipped localhost default', async () => {
+    // The regression guard for the case above: suppression is about the LOCK,
+    // not about the configuration alone. An unrestricted preview still loads.
+    const user = userEvent.setup();
+    setup({
+      hasShareToken: false,
+      hasNonPublic: true,
+      allowedOrigins: [],
+      publicAppUrl: 'http://localhost:8080',
+    });
+    await generateShareLinkAndWait(user);
+    await user.click(screen.getByRole('button', { name: /preview/i }));
+
+    const iframe = (await screen.findByTestId(
+      'share-preview-iframe',
+    )) as HTMLIFrameElement;
+    expect(iframe.src).toContain(`${window.location.origin}/m/share-token`);
+  });
+
   it('withholds a domain-locked snippet when nothing is configured', async () => {
     const user = userEvent.setup();
     setup({
@@ -1479,6 +1583,32 @@ describe('#1548 r3 shareable URLs use the configured public origin', () => {
       // nothing, which is strictly worse than previewing from the serving host.
       expect(iframe.src).toContain(`${window.location.origin}/m/share-token`);
       expect(iframe.src).not.toContain(PUBLIC_HOST);
+    });
+
+    /**
+     * fix(#1548 review r6): the domain-locked preview is a FOURTH case — opened
+     * by this browser AND subject to the lock. Loaded from the current origin
+     * its own API calls carry an origin the lock does not permit, so it renders
+     * without its scoped layers: the exact silent failure this PR exists to
+     * end. Only the configured origin satisfies both.
+     */
+    it('previews a DOMAIN-LOCKED embed from the configured origin instead', async () => {
+      const user = userEvent.setup();
+      setup({
+        enterprise: true,
+        hasShareToken: false,
+        hasNonPublic: true,
+        lockOriginsAfterCreate: ['https://customer.example.com'],
+        publicAppUrl: PUBLIC_HOST,
+      });
+      await generateShareLinkAndWait(user);
+      await user.click(screen.getByRole('button', { name: /preview/i }));
+
+      const iframe = (await screen.findByTestId(
+        'share-preview-iframe',
+      )) as HTMLIFrameElement;
+      expect(iframe.src).toContain(`${PUBLIC_HOST}/m/share-token`);
+      expect(iframe.src).not.toContain(window.location.origin);
     });
 
     it('still copies a link on the public host, because the customer opens that', async () => {

--- a/frontend/src/components/builder/__tests__/SharePanel.test.tsx
+++ b/frontend/src/components/builder/__tests__/SharePanel.test.tsx
@@ -99,6 +99,7 @@ function setup({
   layers,
   publishMapFn = vi.fn().mockResolvedValue({}),
   publicAppUrl = window.location.origin,
+  forceActiveEmbedToken = false,
 }: {
   enterprise?: boolean;
   hasShareToken?: boolean;
@@ -119,6 +120,9 @@ function setup({
   publishMapFn?: (...args: any[]) => any;
   /** The deployment's configured PUBLIC_APP_URL. null = unconfigured. */
   publicAppUrl?: string | null;
+  /** Return an active embed token even when the share link is created at
+   *  runtime — the domain-locked branch needs both. */
+  forceActiveEmbedToken?: boolean;
 } = {}) {
   const createShareToken = vi.fn().mockResolvedValue({
     token: 'share-token',
@@ -178,7 +182,7 @@ function setup({
   } as never);
   mockedUseMapEmbedTokens.mockReturnValue({
     data: {
-      tokens: hasShareToken
+      tokens: hasShareToken || forceActiveEmbedToken
         ? [
             {
               id: 'embed-1',
@@ -193,7 +197,7 @@ function setup({
             },
           ]
         : [],
-      total: hasShareToken ? 1 : 0,
+      total: hasShareToken || forceActiveEmbedToken ? 1 : 0,
     },
     isLoading: false,
     isError: false,
@@ -1305,31 +1309,110 @@ describe('#1548 r3 shareable URLs use the configured public origin', () => {
     );
   });
 
-  it('refuses to emit a snippet at all when no public URL is configured', async () => {
-    const user = userEvent.setup();
-    setup({ hasShareToken: false, hasNonPublic: true, publicAppUrl: null });
-    await generateShareLinkAndWait(user);
+  /**
+   * fix(#1548 review r4): the regression guard.
+   *
+   * Both compose files inject `${PUBLIC_APP_URL:-http://localhost:8080}`, so
+   * the DEFAULT install reports a non-null, perfectly good-looking localhost
+   * value. Trusting it hands every such deployment a share link and an embed
+   * snippet pointing at localhost — which nobody but the admin can open, and
+   * which worked fine before any of this. `publicAppUrl` here is deliberately
+   * the shipped default while the browser is elsewhere.
+   */
+  describe('the shipped localhost default is treated as unconfigured', () => {
+    const COMPOSE_DEFAULT = 'http://localhost:8080';
+    // jsdom serves these tests from http://localhost:3000, which is itself
+    // loopback — and a localhost PUBLIC_APP_URL is CORRECT for a localhost
+    // install, so the trust check rightly accepts it there. Pretend the browser
+    // reached GeoLens at a real hostname, which is the deployment this is about.
+    const SERVED_AT = 'https://maps.example.com';
 
-    expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
-    expect(screen.getByText(/PUBLIC_APP_URL/)).toBeInTheDocument();
+    // `origin` is non-configurable on jsdom's Location, so the whole object is
+    // swapped rather than the one property.
+    const realLocation = window.location;
+
+    beforeEach(() => {
+      Object.defineProperty(window, 'location', {
+        value: { ...realLocation, origin: SERVED_AT },
+        writable: true,
+        configurable: true,
+      });
+    });
+
+    afterEach(() => {
+      Object.defineProperty(window, 'location', {
+        value: realLocation,
+        writable: true,
+        configurable: true,
+      });
+    });
+
+    it('copies a share link on the serving origin, not localhost', async () => {
+      const user = userEvent.setup();
+      const writeText = vi.fn().mockResolvedValue(undefined);
+      Object.defineProperty(navigator, 'clipboard', {
+        value: { writeText },
+        writable: true,
+        configurable: true,
+      });
+      setup({ hasShareToken: false, publicAppUrl: COMPOSE_DEFAULT });
+      await generateShareLinkAndWait(user);
+
+      await user.click(screen.getByRole('button', { name: /copy link/i }));
+      await waitFor(() => expect(writeText).toHaveBeenCalled());
+      expect(writeText.mock.calls[0][0]).toBe(
+        `${SERVED_AT}/api/maps/shared/share-token/card`,
+      );
+      expect(writeText.mock.calls[0][0]).not.toContain(COMPOSE_DEFAULT);
+    });
+
+    it('still emits an unrestricted embed snippet, on the serving origin', async () => {
+      const user = userEvent.setup();
+      setup({
+        hasShareToken: false,
+        hasNonPublic: true,
+        allowedOrigins: [],
+        publicAppUrl: COMPOSE_DEFAULT,
+      });
+      await generateShareLinkAndWait(user);
+
+      const textarea = (await screen.findByRole('textbox')) as HTMLTextAreaElement;
+      expect(textarea.value).toContain(`src="${SERVED_AT}/m/share-token`);
+      expect(textarea.value).not.toContain(COMPOSE_DEFAULT);
+    });
+
+    it('withholds a DOMAIN-LOCKED snippet, because that one cannot degrade', async () => {
+      // An unrestricted embed served from a non-canonical origin still draws.
+      // A locked one does not: its own API calls would carry an origin the
+      // backend will not accept, and the map comes up empty saying nothing.
+      const user = userEvent.setup();
+      setup({
+        enterprise: true,
+        hasShareToken: false,
+        hasNonPublic: true,
+        forceActiveEmbedToken: true,
+        allowedOrigins: ['https://customer.example.com'],
+        publicAppUrl: COMPOSE_DEFAULT,
+      });
+      await generateShareLinkAndWait(user);
+
+      expect(await screen.findByText(/PUBLIC_APP_URL/)).toBeInTheDocument();
+    });
   });
 
-  it('says why instead of silently copying nothing', async () => {
-    // userEvent.setup() installs its own clipboard stub, so the spy has to be
-    // planted AFTER it — the existing SHARE-08 test does the same.
+  it('withholds a domain-locked snippet when nothing is configured', async () => {
     const user = userEvent.setup();
-    const writeText = vi.fn().mockResolvedValue(undefined);
-    Object.defineProperty(navigator, 'clipboard', {
-      value: { writeText },
-      writable: true,
-      configurable: true,
+    setup({
+      enterprise: true,
+      hasShareToken: false,
+      hasNonPublic: true,
+      forceActiveEmbedToken: true,
+      allowedOrigins: ['https://customer.example.com'],
+      publicAppUrl: null,
     });
-    setup({ hasShareToken: false, publicAppUrl: null });
     await generateShareLinkAndWait(user);
 
-    await user.click(screen.getByRole('button', { name: /copy link/i }));
-    await waitFor(() => expect(vi.mocked(toast.error)).toHaveBeenCalled());
-    expect(writeText).not.toHaveBeenCalled();
+    expect(await screen.findByText(/PUBLIC_APP_URL/)).toBeInTheDocument();
   });
 
   it('keeps the local Open affordance working without a configured URL', async () => {
@@ -1339,8 +1422,6 @@ describe('#1548 r3 shareable URLs use the configured public origin', () => {
     await generateShareLinkAndWait(user);
 
     await user.click(screen.getByRole('button', { name: /^open$/i }));
-    // Navigation in THIS admin's browser, handed to nobody — it has no reason
-    // to go dead over a deployment setting.
     expect(openSpy).toHaveBeenCalledWith(
       `${window.location.origin}/m/share-token`,
       '_blank',

--- a/frontend/src/components/builder/__tests__/SharePanel.test.tsx
+++ b/frontend/src/components/builder/__tests__/SharePanel.test.tsx
@@ -1276,17 +1276,26 @@ describe('#1548 r3 shareable URLs use the configured public origin', () => {
     expect(textarea.value).not.toContain(window.location.origin);
   });
 
-  it('points the preview iframe at the configured origin too', async () => {
+  /**
+   * fix(#1548 review r5): the snippet and the preview deliberately DIVERGE on
+   * origin, and asserting them together is the clearest statement of the rule.
+   * Same map, same token, same moment — the snippet names the host the customer
+   * will open, the preview names the host this browser just reached.
+   */
+  it('splits the snippet and the preview by who opens each', async () => {
     const user = userEvent.setup();
     setup({ hasShareToken: false, hasNonPublic: true, publicAppUrl: CONFIGURED });
     await generateShareLinkAndWait(user);
-    await user.click(screen.getByRole('button', { name: /preview/i }));
 
+    const textarea = (await screen.findByRole('textbox')) as HTMLTextAreaElement;
+    expect(textarea.value).toContain(`src="${CONFIGURED}/m/share-token`);
+
+    await user.click(screen.getByRole('button', { name: /preview/i }));
     const iframe = (await screen.findByTestId(
       'share-preview-iframe',
     )) as HTMLIFrameElement;
-    expect(iframe.src).toContain(`${CONFIGURED}/m/share-token`);
-    expect(iframe.src).not.toContain(window.location.origin);
+    expect(iframe.src).toContain(`${window.location.origin}/m/share-token`);
+    expect(iframe.src).not.toContain(CONFIGURED);
   });
 
   it('copies a share link on the configured origin', async () => {
@@ -1427,5 +1436,67 @@ describe('#1548 r3 shareable URLs use the configured public origin', () => {
       '_blank',
     );
     openSpy.mockRestore();
+  });
+
+  /**
+   * fix(#1548 review r5): the split-horizon deployment.
+   *
+   * A public hostname routed externally and unreachable from the internal admin
+   * network is a normal setup, not a misconfiguration. The copied link must
+   * still name the public host — the customer is not on this network — but
+   * anything THIS browser opens has to name the host this browser reached, or
+   * an admin can use GeoLens normally and yet cannot open the share they just
+   * created.
+   */
+  describe('split-horizon: the public host is not reachable from here', () => {
+    const PUBLIC_HOST = 'https://maps.example.com';
+
+    it('opens the viewer on the current origin, not the public one', async () => {
+      const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
+      const user = userEvent.setup();
+      setup({ hasShareToken: false, hasNonPublic: true, publicAppUrl: PUBLIC_HOST });
+      await generateShareLinkAndWait(user);
+
+      await user.click(screen.getByRole('button', { name: /^open$/i }));
+      expect(openSpy).toHaveBeenCalledWith(
+        `${window.location.origin}/m/share-token`,
+        '_blank',
+      );
+      expect(openSpy.mock.calls[0][0]).not.toContain(PUBLIC_HOST);
+      openSpy.mockRestore();
+    });
+
+    it('previews from the current origin, not the public one', async () => {
+      const user = userEvent.setup();
+      setup({ hasShareToken: false, hasNonPublic: true, publicAppUrl: PUBLIC_HOST });
+      await generateShareLinkAndWait(user);
+      await user.click(screen.getByRole('button', { name: /preview/i }));
+
+      const iframe = (await screen.findByTestId(
+        'share-preview-iframe',
+      )) as HTMLIFrameElement;
+      // An iframe pointed at a host this browser cannot resolve renders
+      // nothing, which is strictly worse than previewing from the serving host.
+      expect(iframe.src).toContain(`${window.location.origin}/m/share-token`);
+      expect(iframe.src).not.toContain(PUBLIC_HOST);
+    });
+
+    it('still copies a link on the public host, because the customer opens that', async () => {
+      const user = userEvent.setup();
+      const writeText = vi.fn().mockResolvedValue(undefined);
+      Object.defineProperty(navigator, 'clipboard', {
+        value: { writeText },
+        writable: true,
+        configurable: true,
+      });
+      setup({ hasShareToken: false, publicAppUrl: PUBLIC_HOST });
+      await generateShareLinkAndWait(user);
+
+      await user.click(screen.getByRole('button', { name: /copy link/i }));
+      await waitFor(() => expect(writeText).toHaveBeenCalled());
+      expect(writeText.mock.calls[0][0]).toBe(
+        `${PUBLIC_HOST}/api/maps/shared/share-token/card`,
+      );
+    });
   });
 });

--- a/frontend/src/components/builder/__tests__/SharePanel.test.tsx
+++ b/frontend/src/components/builder/__tests__/SharePanel.test.tsx
@@ -1586,13 +1586,13 @@ describe('#1548 r3 shareable URLs use the configured public origin', () => {
     });
 
     /**
-     * fix(#1548 review r6): the domain-locked preview is a FOURTH case — opened
-     * by this browser AND subject to the lock. Loaded from the current origin
-     * its own API calls carry an origin the lock does not permit, so it renders
-     * without its scoped layers: the exact silent failure this PR exists to
-     * end. Only the configured origin satisfies both.
+     * fix(#1548 review r7): a domain-locked preview has no answer here at all.
+     * Its API calls must carry the configured origin, and `frame-ancestors`
+     * then judges THIS dialog as the parent against that same origin — which
+     * the admin's hostname is not. The browser blocks the frame before a single
+     * API call runs, so the honest move is not to render it.
      */
-    it('previews a DOMAIN-LOCKED embed from the configured origin instead', async () => {
+    it('suppresses a DOMAIN-LOCKED preview rather than loading a blocked frame', async () => {
       const user = userEvent.setup();
       setup({
         enterprise: true,
@@ -1602,13 +1602,61 @@ describe('#1548 r3 shareable URLs use the configured public origin', () => {
         publicAppUrl: PUBLIC_HOST,
       });
       await generateShareLinkAndWait(user);
+
+      expect(
+        screen.queryByRole('button', { name: /preview/i }),
+      ).not.toBeInTheDocument();
+      expect(screen.queryByTestId('share-preview-iframe')).not.toBeInTheDocument();
+      expect(
+        await screen.findByText(/restricted to specific domains/i),
+      ).toBeInTheDocument();
+    });
+
+    it('leaves the copy-snippet path fully working while the preview is refused', async () => {
+      // What the admin actually came here to do. The snippet still names the
+      // public host, which is where the customer will load it from.
+      const user = userEvent.setup();
+      const writeText = vi.fn().mockResolvedValue(undefined);
+      Object.defineProperty(navigator, 'clipboard', {
+        value: { writeText },
+        writable: true,
+        configurable: true,
+      });
+      setup({
+        enterprise: true,
+        hasShareToken: false,
+        hasNonPublic: true,
+        lockOriginsAfterCreate: ['https://customer.example.com'],
+        publicAppUrl: PUBLIC_HOST,
+      });
+      await generateShareLinkAndWait(user);
+
+      const textarea = (await screen.findByRole('textbox')) as HTMLTextAreaElement;
+      expect(textarea.value).toContain(`src="${PUBLIC_HOST}/m/share-token`);
+
+      await user.click(screen.getByTitle(/copy embed code/i));
+      await waitFor(() => expect(writeText).toHaveBeenCalled());
+      expect(writeText.mock.calls[0][0]).toContain(PUBLIC_HOST);
+    });
+
+    it('previews the locked embed once the admin IS on the configured origin', async () => {
+      // The regression guard: suppression is about the two origins DIFFERING,
+      // not about the embed being locked. Same host, and the preview returns.
+      const user = userEvent.setup();
+      setup({
+        enterprise: true,
+        hasShareToken: false,
+        hasNonPublic: true,
+        lockOriginsAfterCreate: ['https://customer.example.com'],
+        publicAppUrl: window.location.origin,
+      });
+      await generateShareLinkAndWait(user);
       await user.click(screen.getByRole('button', { name: /preview/i }));
 
       const iframe = (await screen.findByTestId(
         'share-preview-iframe',
       )) as HTMLIFrameElement;
-      expect(iframe.src).toContain(`${PUBLIC_HOST}/m/share-token`);
-      expect(iframe.src).not.toContain(window.location.origin);
+      expect(iframe.src).toContain(`${window.location.origin}/m/share-token`);
     });
 
     it('still copies a link on the public host, because the customer opens that', async () => {

--- a/frontend/src/i18n/locales/de/builder.json
+++ b/frontend/src/i18n/locales/de/builder.json
@@ -643,6 +643,7 @@
     "open": "Öffnen",
     "copyShareLink": "Freigabelink kopieren",
     "copyEmbedCode": "Einbettungscode kopieren",
+    "publicAppUrlNotConfigured": "Für diese Installation ist keine öffentliche URL konfiguriert, daher kann GeoLens keinen Link erzeugen, der auf der Website einer anderen Person funktioniert. Bitte eine Administratorin oder einen Administrator, PUBLIC_APP_URL auf die Adresse zu setzen, über die GeoLens erreicht wird.",
     "cannotPublish": "Veröffentlichung nicht möglich: Datensätze {{datasets}} sind nicht öffentlich",
     "embedTokenInfo": "Nicht-öffentliche Layer sind enthalten. Ein Einbettungs-Token regelt den Zugriff automatisch.",
     "unsavedWarning": "Ungespeicherte Änderungen sind nur in der Builder-Vorschau sichtbar. Speichere, bevor du Links oder Einbettungen kopierst.",

--- a/frontend/src/i18n/locales/de/builder.json
+++ b/frontend/src/i18n/locales/de/builder.json
@@ -645,7 +645,7 @@
     "copyEmbedCode": "Einbettungscode kopieren",
     "publicAppUrlNotConfigured": "Für diese Installation ist keine öffentliche URL konfiguriert, daher kann GeoLens keinen Link erzeugen, der auf der Website einer anderen Person funktioniert. Bitte eine Administratorin oder einen Administrator, PUBLIC_APP_URL auf die Adresse zu setzen, über die GeoLens erreicht wird.",
     "lockedPreviewNeedsPublicUrl": "Eine domainbeschränkte Einbettung lässt sich nur über die öffentliche Adresse dieser Installation vorschauen, und die ist nicht konfiguriert. Bitte eine Administratorin oder einen Administrator, PUBLIC_APP_URL zu setzen, oder entferne die Domainbeschränkung für die Vorschau.",
-    "iframeErrorBodyDomainLocked": "Eine domainbeschränkte Einbettung wird über die öffentliche Adresse dieser Installation vorgeschaut, die dieser Browser womöglich nicht erreicht. Für Besucherinnen und Besucher kann die Einbettung trotzdem funktionieren. Zum erneuten Versuch neu laden.",
+    "lockedPreviewCrossOrigin": "Diese Einbettung ist auf bestimmte Domains beschränkt und lässt sich daher nur über die öffentliche Adresse dieser Installation vorschauen. Du verwendest einen anderen Hostnamen. Den Einbettungscode zu kopieren funktioniert weiterhin, und für Besucherinnen und Besucher auf den erlaubten Domains funktioniert die Einbettung.",
     "cannotPublish": "Veröffentlichung nicht möglich: Datensätze {{datasets}} sind nicht öffentlich",
     "embedTokenInfo": "Nicht-öffentliche Layer sind enthalten. Ein Einbettungs-Token regelt den Zugriff automatisch.",
     "unsavedWarning": "Ungespeicherte Änderungen sind nur in der Builder-Vorschau sichtbar. Speichere, bevor du Links oder Einbettungen kopierst.",

--- a/frontend/src/i18n/locales/de/builder.json
+++ b/frontend/src/i18n/locales/de/builder.json
@@ -644,6 +644,8 @@
     "copyShareLink": "Freigabelink kopieren",
     "copyEmbedCode": "Einbettungscode kopieren",
     "publicAppUrlNotConfigured": "Für diese Installation ist keine öffentliche URL konfiguriert, daher kann GeoLens keinen Link erzeugen, der auf der Website einer anderen Person funktioniert. Bitte eine Administratorin oder einen Administrator, PUBLIC_APP_URL auf die Adresse zu setzen, über die GeoLens erreicht wird.",
+    "lockedPreviewNeedsPublicUrl": "Eine domainbeschränkte Einbettung lässt sich nur über die öffentliche Adresse dieser Installation vorschauen, und die ist nicht konfiguriert. Bitte eine Administratorin oder einen Administrator, PUBLIC_APP_URL zu setzen, oder entferne die Domainbeschränkung für die Vorschau.",
+    "iframeErrorBodyDomainLocked": "Eine domainbeschränkte Einbettung wird über die öffentliche Adresse dieser Installation vorgeschaut, die dieser Browser womöglich nicht erreicht. Für Besucherinnen und Besucher kann die Einbettung trotzdem funktionieren. Zum erneuten Versuch neu laden.",
     "cannotPublish": "Veröffentlichung nicht möglich: Datensätze {{datasets}} sind nicht öffentlich",
     "embedTokenInfo": "Nicht-öffentliche Layer sind enthalten. Ein Einbettungs-Token regelt den Zugriff automatisch.",
     "unsavedWarning": "Ungespeicherte Änderungen sind nur in der Builder-Vorschau sichtbar. Speichere, bevor du Links oder Einbettungen kopierst.",

--- a/frontend/src/i18n/locales/de/common.json
+++ b/frontend/src/i18n/locales/de/common.json
@@ -169,6 +169,7 @@
     "datasetVisibilityBlockedByMaps": "Diese Karten teilen den Datensatz mit einem Publikum, das ihn verlieren würde: {{maps}}. Entfernen Sie dort den Layer oder schränken Sie zuerst diese Karten ein.",
     "analysisUnknownDissolveColumn": "Die Spalte „{{column}}“ existiert in diesem Datensatz nicht. Wähle ein anderes Gruppierungsfeld.",
     "corsWildcardNotAllowed": "Platzhalter-Ursprünge werden nicht akzeptiert. Anfragen mit Anmeldedaten erfordern jeden Ursprung vollständig, zum Beispiel https://example.com.",
+    "embedDomainLockUnenforceable": "Diese Installation kann eine Domain-Sperre noch nicht durchsetzen: Ihre öffentliche App-URL ist auf {{resolved}} gesetzt, aufgerufen wurde sie aber über {{origin}}. Eine Einbettung lädt die Karte über GeoLens selbst, die Sperre würde also jeden Betrachter aussperren. Setze PUBLIC_APP_URL auf {{origin}} und erstelle das Token erneut.",
     "duplicateSource": "Ein Datensatz aus dieser Quelle ist bereits registriert ({{title}}).",
     "refreshDatasetBusy": "Für diesen Datensatz läuft bereits eine Aktualisierung. Warten Sie, bis sie abgeschlossen ist, und versuchen Sie es erneut.",
     "refreshOriginChanged": "Die Quelle dieses Datensatzes hat sich geändert, während die Aktualisierung in der Warteschlange war. Prüfen Sie die Quelle und versuchen Sie es erneut.",

--- a/frontend/src/i18n/locales/en/builder.json
+++ b/frontend/src/i18n/locales/en/builder.json
@@ -645,7 +645,7 @@
     "copyEmbedCode": "Copy embed code",
     "publicAppUrlNotConfigured": "This deployment has no public URL configured, so GeoLens cannot build a link that will work on someone else's site. Ask an administrator to set PUBLIC_APP_URL to the address people use to reach GeoLens.",
     "lockedPreviewNeedsPublicUrl": "A domain-restricted embed can only be previewed from this deployment's public address, which is not configured. Ask an administrator to set PUBLIC_APP_URL, or remove the domain restriction to preview.",
-    "iframeErrorBodyDomainLocked": "A domain-restricted embed is previewed from this deployment's public address, which this browser may not be able to reach. The embed can still work for visitors. Reload to retry.",
+    "lockedPreviewCrossOrigin": "This embed is restricted to specific domains, so it can only be previewed from this deployment's public address. You are using a different hostname. Copying the embed code still works, and the embed will work for visitors on the allowed domains.",
     "cannotPublish": "Cannot publish: datasets {{datasets}} are not public",
     "embedTokenInfo": "Non-public layers are included. An embed token handles access automatically.",
     "unsavedWarning": "Unsaved changes are only in the builder preview. Save before copying links or embeds.",

--- a/frontend/src/i18n/locales/en/builder.json
+++ b/frontend/src/i18n/locales/en/builder.json
@@ -644,6 +644,8 @@
     "copyShareLink": "Copy share link",
     "copyEmbedCode": "Copy embed code",
     "publicAppUrlNotConfigured": "This deployment has no public URL configured, so GeoLens cannot build a link that will work on someone else's site. Ask an administrator to set PUBLIC_APP_URL to the address people use to reach GeoLens.",
+    "lockedPreviewNeedsPublicUrl": "A domain-restricted embed can only be previewed from this deployment's public address, which is not configured. Ask an administrator to set PUBLIC_APP_URL, or remove the domain restriction to preview.",
+    "iframeErrorBodyDomainLocked": "A domain-restricted embed is previewed from this deployment's public address, which this browser may not be able to reach. The embed can still work for visitors. Reload to retry.",
     "cannotPublish": "Cannot publish: datasets {{datasets}} are not public",
     "embedTokenInfo": "Non-public layers are included. An embed token handles access automatically.",
     "unsavedWarning": "Unsaved changes are only in the builder preview. Save before copying links or embeds.",

--- a/frontend/src/i18n/locales/en/builder.json
+++ b/frontend/src/i18n/locales/en/builder.json
@@ -643,6 +643,7 @@
     "open": "Open",
     "copyShareLink": "Copy share link",
     "copyEmbedCode": "Copy embed code",
+    "publicAppUrlNotConfigured": "This deployment has no public URL configured, so GeoLens cannot build a link that will work on someone else's site. Ask an administrator to set PUBLIC_APP_URL to the address people use to reach GeoLens.",
     "cannotPublish": "Cannot publish: datasets {{datasets}} are not public",
     "embedTokenInfo": "Non-public layers are included. An embed token handles access automatically.",
     "unsavedWarning": "Unsaved changes are only in the builder preview. Save before copying links or embeds.",

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -294,6 +294,7 @@
     "datasetVisibilityBlockedByMaps": "These maps share the dataset with an audience that would lose it: {{maps}}. Remove the layer there, or narrow those maps first.",
     "analysisUnknownDissolveColumn": "The column “{{column}}” does not exist on this dataset. Pick a different group-by field.",
     "corsWildcardNotAllowed": "Wildcard origins are not accepted. Credentialed requests require every origin listed in full, for example https://example.com.",
+    "embedDomainLockUnenforceable": "This deployment cannot enforce a domain lock yet: its public app URL is set to {{resolved}}, but you reached it at {{origin}}. An embed loads the map through GeoLens itself, so the lock would block every viewer. Set PUBLIC_APP_URL to {{origin}}, then create the token.",
     "duplicateSource": "A dataset from this source is already registered ({{title}}).",
     "refreshDatasetBusy": "A refresh is already running for this dataset. Wait for it to finish, then try again.",
     "refreshOriginChanged": "This dataset's source changed while the refresh was being queued. Review the source and try again.",

--- a/frontend/src/i18n/locales/es/builder.json
+++ b/frontend/src/i18n/locales/es/builder.json
@@ -645,7 +645,7 @@
     "copyEmbedCode": "Copiar código de inserción",
     "publicAppUrlNotConfigured": "Esta instalación no tiene una URL pública configurada, por lo que GeoLens no puede crear un enlace que funcione en el sitio de otra persona. Pide a un administrador que configure PUBLIC_APP_URL con la dirección que la gente usa para acceder a GeoLens.",
     "lockedPreviewNeedsPublicUrl": "Una inserción restringida por dominio solo se puede previsualizar desde la dirección pública de esta instalación, que no está configurada. Pide a un administrador que configure PUBLIC_APP_URL, o quita la restricción de dominio para previsualizar.",
-    "iframeErrorBodyDomainLocked": "Una inserción restringida por dominio se previsualiza desde la dirección pública de esta instalación, a la que este navegador quizá no pueda acceder. La inserción puede seguir funcionando para los visitantes. Recarga para reintentar.",
+    "lockedPreviewCrossOrigin": "Esta inserción está restringida a dominios concretos, así que solo se puede previsualizar desde la dirección pública de esta instalación. Estás usando otro nombre de host. Copiar el código de inserción sigue funcionando, y la inserción funcionará para los visitantes en los dominios permitidos.",
     "cannotPublish": "No se puede publicar: los conjuntos de datos {{datasets}} no son públicos",
     "embedTokenInfo": "Se incluyen capas no públicas. Un token de inserción gestiona el acceso automáticamente.",
     "unsavedWarning": "Los cambios sin guardar solo están en la vista previa del constructor. Guarda antes de copiar enlaces o inserciones.",

--- a/frontend/src/i18n/locales/es/builder.json
+++ b/frontend/src/i18n/locales/es/builder.json
@@ -644,6 +644,8 @@
     "copyShareLink": "Copiar enlace para compartir",
     "copyEmbedCode": "Copiar código de inserción",
     "publicAppUrlNotConfigured": "Esta instalación no tiene una URL pública configurada, por lo que GeoLens no puede crear un enlace que funcione en el sitio de otra persona. Pide a un administrador que configure PUBLIC_APP_URL con la dirección que la gente usa para acceder a GeoLens.",
+    "lockedPreviewNeedsPublicUrl": "Una inserción restringida por dominio solo se puede previsualizar desde la dirección pública de esta instalación, que no está configurada. Pide a un administrador que configure PUBLIC_APP_URL, o quita la restricción de dominio para previsualizar.",
+    "iframeErrorBodyDomainLocked": "Una inserción restringida por dominio se previsualiza desde la dirección pública de esta instalación, a la que este navegador quizá no pueda acceder. La inserción puede seguir funcionando para los visitantes. Recarga para reintentar.",
     "cannotPublish": "No se puede publicar: los conjuntos de datos {{datasets}} no son públicos",
     "embedTokenInfo": "Se incluyen capas no públicas. Un token de inserción gestiona el acceso automáticamente.",
     "unsavedWarning": "Los cambios sin guardar solo están en la vista previa del constructor. Guarda antes de copiar enlaces o inserciones.",

--- a/frontend/src/i18n/locales/es/builder.json
+++ b/frontend/src/i18n/locales/es/builder.json
@@ -643,6 +643,7 @@
     "open": "Abrir",
     "copyShareLink": "Copiar enlace para compartir",
     "copyEmbedCode": "Copiar código de inserción",
+    "publicAppUrlNotConfigured": "Esta instalación no tiene una URL pública configurada, por lo que GeoLens no puede crear un enlace que funcione en el sitio de otra persona. Pide a un administrador que configure PUBLIC_APP_URL con la dirección que la gente usa para acceder a GeoLens.",
     "cannotPublish": "No se puede publicar: los conjuntos de datos {{datasets}} no son públicos",
     "embedTokenInfo": "Se incluyen capas no públicas. Un token de inserción gestiona el acceso automáticamente.",
     "unsavedWarning": "Los cambios sin guardar solo están en la vista previa del constructor. Guarda antes de copiar enlaces o inserciones.",

--- a/frontend/src/i18n/locales/es/common.json
+++ b/frontend/src/i18n/locales/es/common.json
@@ -169,6 +169,7 @@
     "datasetVisibilityBlockedByMaps": "Estos mapas comparten el conjunto de datos con un público que lo perdería: {{maps}}. Quita la capa allí o restringe primero esos mapas.",
     "analysisUnknownDissolveColumn": "La columna «{{column}}» no existe en este conjunto de datos. Elige otro campo de agrupación.",
     "corsWildcardNotAllowed": "No se aceptan orígenes comodín. Las solicitudes con credenciales requieren cada origen indicado por completo, por ejemplo https://example.com.",
+    "embedDomainLockUnenforceable": "Esta instalación aún no puede aplicar un bloqueo de dominio: su URL pública está configurada como {{resolved}}, pero has accedido desde {{origin}}. Un embebido carga el mapa a través de GeoLens, así que el bloqueo impediría el acceso a todos los visitantes. Configura PUBLIC_APP_URL como {{origin}} y crea el token de nuevo.",
     "duplicateSource": "Ya hay un conjunto de datos registrado desde esta fuente ({{title}}).",
     "refreshDatasetBusy": "Ya hay una actualización en curso para este conjunto de datos. Espera a que termine e inténtalo de nuevo.",
     "refreshOriginChanged": "La fuente de este conjunto de datos cambió mientras la actualización estaba en cola. Revisa la fuente e inténtalo de nuevo.",

--- a/frontend/src/i18n/locales/fr/builder.json
+++ b/frontend/src/i18n/locales/fr/builder.json
@@ -644,6 +644,8 @@
     "copyShareLink": "Copier le lien de partage",
     "copyEmbedCode": "Copier le code d'intégration",
     "publicAppUrlNotConfigured": "Ce déploiement n'a pas d'URL publique configurée, donc GeoLens ne peut pas créer de lien qui fonctionnera sur le site d'une autre personne. Demandez à un administrateur de définir PUBLIC_APP_URL avec l'adresse utilisée pour accéder à GeoLens.",
+    "lockedPreviewNeedsPublicUrl": "Une intégration restreinte par domaine ne peut être prévisualisée que depuis l'adresse publique de ce déploiement, qui n'est pas configurée. Demandez à un administrateur de définir PUBLIC_APP_URL, ou retirez la restriction de domaine pour prévisualiser.",
+    "iframeErrorBodyDomainLocked": "Une intégration restreinte par domaine est prévisualisée depuis l'adresse publique de ce déploiement, que ce navigateur ne peut peut-être pas atteindre. L'intégration peut malgré tout fonctionner pour les visiteurs. Rechargez pour réessayer.",
     "cannotPublish": "Impossible de publier : les jeux de données {{datasets}} ne sont pas publics",
     "embedTokenInfo": "Des couches non publiques sont incluses. Un jeton d'intégration gère l'accès automatiquement.",
     "unsavedWarning": "Les modifications non enregistrées sont uniquement dans l'aperçu du constructeur. Enregistrez avant de copier des liens ou des intégrations.",

--- a/frontend/src/i18n/locales/fr/builder.json
+++ b/frontend/src/i18n/locales/fr/builder.json
@@ -645,7 +645,7 @@
     "copyEmbedCode": "Copier le code d'intégration",
     "publicAppUrlNotConfigured": "Ce déploiement n'a pas d'URL publique configurée, donc GeoLens ne peut pas créer de lien qui fonctionnera sur le site d'une autre personne. Demandez à un administrateur de définir PUBLIC_APP_URL avec l'adresse utilisée pour accéder à GeoLens.",
     "lockedPreviewNeedsPublicUrl": "Une intégration restreinte par domaine ne peut être prévisualisée que depuis l'adresse publique de ce déploiement, qui n'est pas configurée. Demandez à un administrateur de définir PUBLIC_APP_URL, ou retirez la restriction de domaine pour prévisualiser.",
-    "iframeErrorBodyDomainLocked": "Une intégration restreinte par domaine est prévisualisée depuis l'adresse publique de ce déploiement, que ce navigateur ne peut peut-être pas atteindre. L'intégration peut malgré tout fonctionner pour les visiteurs. Rechargez pour réessayer.",
+    "lockedPreviewCrossOrigin": "Cette intégration est restreinte à des domaines précis, elle ne peut donc être prévisualisée que depuis l'adresse publique de ce déploiement. Vous utilisez un autre nom d'hôte. Copier le code d'intégration fonctionne toujours, et l'intégration fonctionnera pour les visiteurs sur les domaines autorisés.",
     "cannotPublish": "Impossible de publier : les jeux de données {{datasets}} ne sont pas publics",
     "embedTokenInfo": "Des couches non publiques sont incluses. Un jeton d'intégration gère l'accès automatiquement.",
     "unsavedWarning": "Les modifications non enregistrées sont uniquement dans l'aperçu du constructeur. Enregistrez avant de copier des liens ou des intégrations.",

--- a/frontend/src/i18n/locales/fr/builder.json
+++ b/frontend/src/i18n/locales/fr/builder.json
@@ -643,6 +643,7 @@
     "open": "Ouvrir",
     "copyShareLink": "Copier le lien de partage",
     "copyEmbedCode": "Copier le code d'intégration",
+    "publicAppUrlNotConfigured": "Ce déploiement n'a pas d'URL publique configurée, donc GeoLens ne peut pas créer de lien qui fonctionnera sur le site d'une autre personne. Demandez à un administrateur de définir PUBLIC_APP_URL avec l'adresse utilisée pour accéder à GeoLens.",
     "cannotPublish": "Impossible de publier : les jeux de données {{datasets}} ne sont pas publics",
     "embedTokenInfo": "Des couches non publiques sont incluses. Un jeton d'intégration gère l'accès automatiquement.",
     "unsavedWarning": "Les modifications non enregistrées sont uniquement dans l'aperçu du constructeur. Enregistrez avant de copier des liens ou des intégrations.",

--- a/frontend/src/i18n/locales/fr/common.json
+++ b/frontend/src/i18n/locales/fr/common.json
@@ -169,6 +169,7 @@
     "datasetVisibilityBlockedByMaps": "Ces cartes partagent le jeu de données avec un public qui le perdrait : {{maps}}. Supprimez-y la couche, ou restreignez d'abord ces cartes.",
     "analysisUnknownDissolveColumn": "La colonne « {{column}} » n’existe pas dans ce jeu de données. Choisissez un autre champ de regroupement.",
     "corsWildcardNotAllowed": "Les origines génériques ne sont pas acceptées. Les requêtes avec identifiants exigent que chaque origine soit indiquée en entier, par exemple https://example.com.",
+    "embedDomainLockUnenforceable": "Ce déploiement ne peut pas encore appliquer un verrouillage de domaine : son URL publique est définie sur {{resolved}}, mais vous y avez accédé via {{origin}}. Une intégration charge la carte via GeoLens, le verrouillage bloquerait donc tous les visiteurs. Définissez PUBLIC_APP_URL sur {{origin}}, puis créez le jeton.",
     "duplicateSource": "Un jeu de données provenant de cette source est déjà enregistré ({{title}}).",
     "refreshDatasetBusy": "Une actualisation est déjà en cours pour ce jeu de données. Attendez qu'elle se termine, puis réessayez.",
     "refreshOriginChanged": "La source de ce jeu de données a changé pendant la mise en file d'attente de l'actualisation. Vérifiez la source et réessayez.",

--- a/frontend/src/lib/__tests__/error-map.test.ts
+++ b/frontend/src/lib/__tests__/error-map.test.ts
@@ -416,4 +416,43 @@ describe('API error localization boundary', () => {
       ),
     ).toBe('These layers were not found in the uploaded file: roads, rivers.');
   });
+  // fix(#1548 review P2): the embed domain-lock refusal. Both compose files
+  // ship PUBLIC_APP_URL defaulted to localhost, so a self-hoster reached at a
+  // real hostname hits this on a stock install — and its whole value is the
+  // remediation. Unmapped it collapses to the generic 422 and the domain lock
+  // goes back to failing silently, which is what the refusal exists to stop.
+  it('keeps the remediation in the embed domain-lock refusal', () => {
+    expect(
+      classifyApiError(
+        'Domain locking cannot be enforced by this deployment: its public app URL ' +
+          'resolves to http://localhost:8080, but this request reached it at ' +
+          'https://maps.example.com. An embed shell\'s own API calls carry the ' +
+          "shell's origin, so a domain-locked token issued now would load an empty " +
+          'map. Set PUBLIC_APP_URL (or the public_app_url setting) to ' +
+          'https://maps.example.com and try again.',
+        422,
+      ),
+    ).toEqual({
+      key: 'errors.embedDomainLockUnenforceable',
+      values: {
+        resolved: 'http://localhost:8080',
+        origin: 'https://maps.example.com',
+      },
+    });
+  });
+
+  it('names both the configured value and the origin to set', () => {
+    const rendered = translateApiErrorDetail(
+      'Domain locking cannot be enforced by this deployment: its public app URL ' +
+        'resolves to http://localhost:8080, but this request reached it at ' +
+        'https://maps.example.com. Set PUBLIC_APP_URL (or the public_app_url ' +
+        'setting) to https://maps.example.com and try again.',
+      422,
+    );
+    expect(rendered).toContain('PUBLIC_APP_URL');
+    expect(rendered).toContain('http://localhost:8080');
+    expect(rendered).toContain('https://maps.example.com');
+    // The guard the mapping exists for.
+    expect(rendered).not.toBe('The submitted values are invalid.');
+  });
 });

--- a/frontend/src/lib/__tests__/public-app-url-shape.cases.json
+++ b/frontend/src/lib/__tests__/public-app-url-shape.cases.json
@@ -1,5 +1,5 @@
 {
-  "_rule": "PUBLIC_APP_URL is usable only as an absolute HTTP(S) URL with a host, no query or fragment, and no percent-encoding. This file is the ONE statement of that rule; the Python and TypeScript validators are each tested against it so they cannot drift. Backend: is_usable_public_origin() in backend/app/core/public_urls.py. Frontend: parseUsablePublicUrl() in frontend/src/lib/public-urls.ts.",
+  "_rule": "PUBLIC_APP_URL is usable only as an absolute HTTP(S) URL with a host, no query or fragment, and none of: percent-encoding, a backslash, or a non-ASCII character. The last three are refused because the two URL parsers READ THEM DIFFERENTLY, and a value the two halves disagree about is the bug class itself. This file is the ONE statement of the rule; the Python and TypeScript validators are each tested against it so they cannot drift. Backend: is_usable_public_origin() in backend/app/core/public_urls.py. Frontend: parseUsablePublicUrl() in frontend/src/lib/public-urls.ts.",
   "_scope": "SHAPE only. Whether a shape-valid value is TRUSTED in context is a separate question — a loopback origin is shape-valid but untrusted when the browser is elsewhere — so loopback entries appear under valid here on purpose.",
   "valid": [
     "https://maps.example.com",
@@ -10,7 +10,8 @@
     "http://127.0.0.1:8080",
     "http://[::1]:8080",
     "https://xn--mp-mia.example",
-    "https://ops:secret@maps.example.com"
+    "https://ops:secret@maps.example.com",
+    "https://xn--fa-hia.de"
   ],
   "invalid": [
     "",
@@ -30,19 +31,25 @@
     "https://%6Daps.example.com",
     "https://maps.example.com/%2Fpath",
     "http://",
-    "https://"
+    "https://",
+    "https://máp.example",
+    "https://faß.de",
+    "https://maps.example.com\\@evil.com",
+    "https://maps.example.com\\.evil.com",
+    "https:\\\\maps.example.com"
   ],
-  "_canonical_note": "canonical_origin maps a path-less configured value to the spelling a BROWSER presents, which is the string both sides must compare against: IDNA ASCII host, lowercased, no userinfo, default port dropped. Backend: _normalize_origin(). Frontend: new URL(x).origin. A value and an origin that name the same place but spell it differently never match, which is how a Unicode hostname used to be issued a lock and then miss every request.",
+  "_canonical_note": "canonical_origin maps a path-less configured value to the spelling a BROWSER presents, which is the string both sides must compare against: lowercased host, no userinfo, default port dropped. Backend: _normalize_origin(). Frontend: new URL(x).origin. A value and an origin that name the same place but spell it differently never match. Hosts here are already ASCII — see _idn_note for why no IDNA conversion appears.",
   "canonical_origin": {
     "https://maps.example.com": "https://maps.example.com",
     "https://MAPS.Example.com": "https://maps.example.com",
-    "https://máp.example": "https://xn--mp-mia.example",
     "https://xn--mp-mia.example": "https://xn--mp-mia.example",
     "https://ops:secret@maps.example.com": "https://maps.example.com",
     "https://maps.example.com:443": "https://maps.example.com",
     "http://maps.example.com:80": "http://maps.example.com",
     "https://maps.example.com:8443": "https://maps.example.com:8443",
     "http://localhost:8080": "http://localhost:8080",
-    "http://[::1]:8080": "http://[::1]:8080"
-  }
+    "http://[::1]:8080": "http://[::1]:8080",
+    "https://xn--fa-hia.de": "https://xn--fa-hia.de"
+  },
+  "_idn_note": "An internationalized domain must be configured in its punycode (xn--) form. It is NOT translated for the operator: Python's built-in idna codec is IDNA2003 and maps faß.de to fass.de, while browsers follow WHATWG/UTS #46 and send xn--fa-hia.de. A near match denies every request while looking correct, so the class is removed rather than approximated."
 }

--- a/frontend/src/lib/__tests__/public-app-url-shape.cases.json
+++ b/frontend/src/lib/__tests__/public-app-url-shape.cases.json
@@ -1,0 +1,29 @@
+{
+  "_rule": "PUBLIC_APP_URL is usable only as an absolute HTTP(S) URL with a host and no query or fragment. This file is the ONE statement of that rule; the Python and TypeScript validators are each tested against it so they cannot drift. Backend: is_usable_public_origin() in backend/app/core/public_urls.py. Frontend: parseUsablePublicUrl() in frontend/src/lib/public-urls.ts.",
+  "_scope": "SHAPE only. Whether a shape-valid value is TRUSTED in context is a separate question — a loopback origin is shape-valid but untrusted when the browser is elsewhere — so loopback entries appear under valid here on purpose.",
+  "valid": [
+    "https://maps.example.com",
+    "http://maps.example.com",
+    "https://maps.example.com:8443",
+    "https://example.com/geolens",
+    "http://localhost:8080",
+    "http://127.0.0.1:8080",
+    "http://[::1]:8080"
+  ],
+  "invalid": [
+    "",
+    "   ",
+    "not-a-url",
+    "maps.example.com",
+    "//maps.example.com",
+    "ftp://maps.example.com",
+    "mailto:ops@example.com",
+    "javascript:alert(1)",
+    "file:///etc/hosts",
+    "data:text/html,x",
+    "https://maps.example.com?tenant=a",
+    "https://maps.example.com#section",
+    "https://maps.example.com/path?a=1",
+    "https://maps.example.com/path#f"
+  ]
+}

--- a/frontend/src/lib/__tests__/public-app-url-shape.cases.json
+++ b/frontend/src/lib/__tests__/public-app-url-shape.cases.json
@@ -1,5 +1,5 @@
 {
-  "_rule": "PUBLIC_APP_URL is usable only as an absolute HTTP(S) URL with a host, no query or fragment, and none of: percent-encoding, a backslash, or a non-ASCII character. The last three are refused because the two URL parsers READ THEM DIFFERENTLY, and a value the two halves disagree about is the bug class itself. This file is the ONE statement of the rule; the Python and TypeScript validators are each tested against it so they cannot drift. Backend: is_usable_public_origin() in backend/app/core/public_urls.py. Frontend: parseUsablePublicUrl() in frontend/src/lib/public-urls.ts.",
+  "_rule": "PUBLIC_APP_URL is usable only as an absolute HTTP(S) URL with a host, no query or fragment, none of percent-encoding / backslash / non-ASCII, and a host ALREADY SPELLED THE WAY A BROWSER SERIALIZES IT. The refusals exist because the two URL parsers READ THOSE INPUTS DIFFERENTLY, and a value the two halves disagree about is the bug class itself. This file is the ONE statement of the rule; the Python and TypeScript validators are each tested against it so they cannot drift. Backend: is_usable_public_origin() in backend/app/core/public_urls.py. Frontend: parseUsablePublicUrl() in frontend/src/lib/public-urls.ts.",
   "_scope": "SHAPE only. Whether a shape-valid value is TRUSTED in context is a separate question — a loopback origin is shape-valid but untrusted when the browser is elsewhere — so loopback entries appear under valid here on purpose.",
   "valid": [
     "https://maps.example.com",
@@ -11,7 +11,10 @@
     "http://[::1]:8080",
     "https://xn--mp-mia.example",
     "https://ops:secret@maps.example.com",
-    "https://xn--fa-hia.de"
+    "https://xn--fa-hia.de",
+    "http://192.168.0.1",
+    "https://MAPS.Example.com",
+    "http://[2001:db8::1]"
   ],
   "invalid": [
     "",
@@ -36,7 +39,14 @@
     "https://faß.de",
     "https://maps.example.com\\@evil.com",
     "https://maps.example.com\\.evil.com",
-    "https:\\\\maps.example.com"
+    "https:\\\\maps.example.com",
+    "http://192.168.1",
+    "http://010.0.0.1",
+    "http://0x7f.1",
+    "http://2130706433",
+    "http://192.168.0.256",
+    "http://[2001:0db8:0000:0000:0000:0000:0000:0001]",
+    "https://maps.example.com."
   ],
   "_canonical_note": "canonical_origin maps a path-less configured value to the spelling a BROWSER presents, which is the string both sides must compare against: lowercased host, no userinfo, default port dropped. Backend: _normalize_origin(). Frontend: new URL(x).origin. A value and an origin that name the same place but spell it differently never match. Hosts here are already ASCII — see _idn_note for why no IDNA conversion appears.",
   "canonical_origin": {
@@ -49,7 +59,10 @@
     "https://maps.example.com:8443": "https://maps.example.com:8443",
     "http://localhost:8080": "http://localhost:8080",
     "http://[::1]:8080": "http://[::1]:8080",
-    "https://xn--fa-hia.de": "https://xn--fa-hia.de"
+    "https://xn--fa-hia.de": "https://xn--fa-hia.de",
+    "http://192.168.0.1": "http://192.168.0.1",
+    "http://[2001:db8::1]": "http://[2001:db8::1]"
   },
-  "_idn_note": "An internationalized domain must be configured in its punycode (xn--) form. It is NOT translated for the operator: Python's built-in idna codec is IDNA2003 and maps faß.de to fass.de, while browsers follow WHATWG/UTS #46 and send xn--fa-hia.de. A near match denies every request while looking correct, so the class is removed rather than approximated."
+  "_idn_note": "An internationalized domain must be configured in its punycode (xn--) form. It is NOT translated for the operator: Python's built-in idna codec is IDNA2003 and maps faß.de to fass.de, while browsers follow WHATWG/UTS #46 and send xn--fa-hia.de. A near match denies every request while looking correct, so the class is removed rather than approximated.",
+  "_host_note": "The two sides reach the same answers by DIFFERENT methods, deliberately: the frontend has a browser URL parser and compares the host as written against the host that parser produced; the backend has none and must assert the rule directly (canonical_host_error). It cannot test stability under its own parser instead — 192.168.1 round-trips through urlsplit unchanged and is still read as 192.168.0.1 by every browser. Measured disagreements: 192.168.1 -> 192.168.0.1, 010.0.0.1 -> 8.0.0.1 (octal), 0x7f.1 -> 127.0.0.1 (hex), 2130706433 -> 127.0.0.1, and uncompressed IPv6 literals get compressed. Uppercase is accepted because both parsers lowercase it, so it is not a disagreement."
 }

--- a/frontend/src/lib/__tests__/public-app-url-shape.cases.json
+++ b/frontend/src/lib/__tests__/public-app-url-shape.cases.json
@@ -1,5 +1,5 @@
 {
-  "_rule": "PUBLIC_APP_URL is usable only as an absolute HTTP(S) URL with a host and no query or fragment. This file is the ONE statement of that rule; the Python and TypeScript validators are each tested against it so they cannot drift. Backend: is_usable_public_origin() in backend/app/core/public_urls.py. Frontend: parseUsablePublicUrl() in frontend/src/lib/public-urls.ts.",
+  "_rule": "PUBLIC_APP_URL is usable only as an absolute HTTP(S) URL with a host, no query or fragment, and no percent-encoding. This file is the ONE statement of that rule; the Python and TypeScript validators are each tested against it so they cannot drift. Backend: is_usable_public_origin() in backend/app/core/public_urls.py. Frontend: parseUsablePublicUrl() in frontend/src/lib/public-urls.ts.",
   "_scope": "SHAPE only. Whether a shape-valid value is TRUSTED in context is a separate question — a loopback origin is shape-valid but untrusted when the browser is elsewhere — so loopback entries appear under valid here on purpose.",
   "valid": [
     "https://maps.example.com",
@@ -8,7 +8,9 @@
     "https://example.com/geolens",
     "http://localhost:8080",
     "http://127.0.0.1:8080",
-    "http://[::1]:8080"
+    "http://[::1]:8080",
+    "https://xn--mp-mia.example",
+    "https://ops:secret@maps.example.com"
   ],
   "invalid": [
     "",
@@ -24,6 +26,23 @@
     "https://maps.example.com?tenant=a",
     "https://maps.example.com#section",
     "https://maps.example.com/path?a=1",
-    "https://maps.example.com/path#f"
-  ]
+    "https://maps.example.com/path#f",
+    "https://%6Daps.example.com",
+    "https://maps.example.com/%2Fpath",
+    "http://",
+    "https://"
+  ],
+  "_canonical_note": "canonical_origin maps a path-less configured value to the spelling a BROWSER presents, which is the string both sides must compare against: IDNA ASCII host, lowercased, no userinfo, default port dropped. Backend: _normalize_origin(). Frontend: new URL(x).origin. A value and an origin that name the same place but spell it differently never match, which is how a Unicode hostname used to be issued a lock and then miss every request.",
+  "canonical_origin": {
+    "https://maps.example.com": "https://maps.example.com",
+    "https://MAPS.Example.com": "https://maps.example.com",
+    "https://máp.example": "https://xn--mp-mia.example",
+    "https://xn--mp-mia.example": "https://xn--mp-mia.example",
+    "https://ops:secret@maps.example.com": "https://maps.example.com",
+    "https://maps.example.com:443": "https://maps.example.com",
+    "http://maps.example.com:80": "http://maps.example.com",
+    "https://maps.example.com:8443": "https://maps.example.com:8443",
+    "http://localhost:8080": "http://localhost:8080",
+    "http://[::1]:8080": "http://[::1]:8080"
+  }
 }

--- a/frontend/src/lib/__tests__/public-urls.test.ts
+++ b/frontend/src/lib/__tests__/public-urls.test.ts
@@ -1,0 +1,79 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { getPublicAppBaseUrl } from '@/lib/public-urls';
+
+describe('getPublicAppBaseUrl', () => {
+  it('returns the configured public origin', () => {
+    expect(getPublicAppBaseUrl({ public_app_url: 'https://maps.example.com' })).toBe(
+      'https://maps.example.com',
+    );
+  });
+
+  it('trims a trailing slash so callers can append a path', () => {
+    expect(getPublicAppBaseUrl({ public_app_url: 'https://maps.example.com/' })).toBe(
+      'https://maps.example.com',
+    );
+  });
+
+  it('preserves a configured sub-path', () => {
+    // PUBLIC_APP_URL=https://example.com/geolens is a real deployment shape.
+    // The backend compares ORIGINS (path dropped), so keeping it here still
+    // agrees with the domain-lock check while producing a URL that resolves.
+    expect(
+      getPublicAppBaseUrl({ public_app_url: 'https://example.com/geolens/' }),
+    ).toBe('https://example.com/geolens');
+  });
+
+  it.each([
+    ['missing config', undefined],
+    ['null config', null],
+    ['null value', { public_app_url: null }],
+    ['empty value', { public_app_url: '' }],
+    ['whitespace value', { public_app_url: '   ' }],
+  ])('returns null for %s rather than guessing', (_label, config) => {
+    expect(getPublicAppBaseUrl(config)).toBeNull();
+  });
+});
+
+/**
+ * fix(#1548 review r3): cover the class, not just the one call site.
+ *
+ * The bug was that SharePanel built the embed snippet from
+ * `window.location.origin` — whatever hostname the ADMIN happened to be using —
+ * for a URL that someone else opens. The share link and its /card twin had the
+ * same defect, so fixing only the snippet would have left the two disagreeing
+ * about their own origin.
+ *
+ * This pins that no path handed to a third party is rebuilt from the current
+ * origin. It reads the source rather than the rendered output because the next
+ * such builder has not been written yet, and that is the one this is for.
+ */
+describe('no shareable URL is built from the current origin', () => {
+  const SHAREABLE_PATHS = [
+    '/m/', // the embed shell and viewer
+    '/api/maps/shared/', // the unfurlable /card link
+  ];
+
+  it('SharePanel builds none of them from window.location.origin', () => {
+    const source = readFileSync(
+      join(process.cwd(), 'src/components/builder/SharePanel.tsx'),
+      'utf-8',
+    );
+
+    const offenders = source
+      .split('\n')
+      .map((line, i) => [line, i + 1] as const)
+      .filter(([line]) => line.includes('window.location.origin'))
+      .filter(([line]) => SHAREABLE_PATHS.some((p) => line.includes(p)))
+      // getShareUrl feeds the "Open" button only — navigation in this admin's
+      // own browser, handed to nobody — and documents that exemption inline.
+      .filter(([line]) => !line.includes('publicAppBaseUrl ??'));
+
+    expect(
+      offenders.map(([line, n]) => `${n}: ${line.trim()}`),
+      'build these from getPublicAppBaseUrl(tileConfig) instead — a URL opened ' +
+        'by someone else must come from the configured public origin',
+    ).toEqual([]);
+  });
+});

--- a/frontend/src/lib/__tests__/public-urls.test.ts
+++ b/frontend/src/lib/__tests__/public-urls.test.ts
@@ -2,6 +2,7 @@ import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 import {
+  getLockedPreviewBaseUrl,
   getPublicAppBaseUrl,
   getShareableBaseUrl,
   resolvePublicAppUrl,
@@ -200,6 +201,75 @@ describe('a malformed value is never handed out', () => {
 });
 
 /**
+ * fix(#1548 review r7): a domain-locked preview must satisfy two browser rules
+ * at once, and for a split-horizon deployment nothing satisfies both.
+ *
+ *  1. Its API calls carry the SHELL's origin, and the backend accepts only the
+ *     configured origin as first-party -> load from the configured host.
+ *  2. `frame-ancestors 'self' <customer origins>` judges the PARENT document,
+ *     and `'self'` resolves to the PUBLIC origin, not the admin's -> the parent
+ *     must be that same host, or the browser blocks the frame outright.
+ *
+ * Rule 1 fixes the child's origin; rule 2 then demands the parent match it. So
+ * the preview exists only when the two already coincide.
+ */
+describe('getLockedPreviewBaseUrl', () => {
+  const PUBLIC_HOST = 'https://maps.example.com';
+
+  it('previews when the admin is already on the configured origin', () => {
+    expect(
+      getLockedPreviewBaseUrl({ public_app_url: PUBLIC_HOST }, PUBLIC_HOST),
+    ).toBe(PUBLIC_HOST);
+  });
+
+  it('refuses when the admin is on a different hostname', () => {
+    expect(
+      getLockedPreviewBaseUrl({ public_app_url: PUBLIC_HOST }, 'https://internal.corp'),
+    ).toBeNull();
+  });
+
+  it('refuses on a scheme or port difference too, since CSP compares origins', () => {
+    expect(
+      getLockedPreviewBaseUrl({ public_app_url: PUBLIC_HOST }, 'http://maps.example.com'),
+    ).toBeNull();
+    expect(
+      getLockedPreviewBaseUrl(
+        { public_app_url: PUBLIC_HOST },
+        'https://maps.example.com:8443',
+      ),
+    ).toBeNull();
+  });
+
+  it('previews across a configured sub-path, which CSP ignores', () => {
+    expect(
+      getLockedPreviewBaseUrl(
+        { public_app_url: 'https://example.com/geolens' },
+        'https://example.com',
+      ),
+    ).toBe('https://example.com/geolens');
+  });
+
+  it.each([
+    ['unset', null],
+    ['the shipped localhost default', 'http://localhost:8080'],
+    ['malformed', 'not-a-url'],
+  ])('refuses when the configured value is %s', (_label, value) => {
+    expect(
+      getLockedPreviewBaseUrl({ public_app_url: value }, 'https://maps.example.com'),
+    ).toBeNull();
+  });
+
+  it('previews a genuine localhost install, where the two coincide', () => {
+    expect(
+      getLockedPreviewBaseUrl(
+        { public_app_url: 'http://localhost:8080' },
+        'http://localhost:8080',
+      ),
+    ).toBe('http://localhost:8080');
+  });
+});
+
+/**
  * fix(#1548 review r3/r5): cover the class, not just the one call site.
  *
  * SharePanel resolves three origins, and the question that picks between them
@@ -261,9 +331,8 @@ describe('SharePanel resolves each URL from the right origin', () => {
     // must also satisfy the lock, so it is neither of the other two rules.
     // Unlocked it uses the origin this browser reached; locked it must use the
     // configured one, the only origin its own API calls may present.
-    expect(source).toContain(
-      'const previewBaseUrl = isDomainLocked ? trustedAppBaseUrl : currentOrigin;',
-    );
+    expect(source).toContain('? getLockedPreviewBaseUrl(tileConfig, currentOrigin)');
+    expect(source).toContain(': currentOrigin;');
   });
 
   it('no builder reaches for window.location.origin inline', () => {

--- a/frontend/src/lib/__tests__/public-urls.test.ts
+++ b/frontend/src/lib/__tests__/public-urls.test.ts
@@ -229,17 +229,53 @@ describe('the shared PUBLIC_APP_URL shape rule', () => {
     expect(spec.invalid.length).toBeGreaterThan(0);
   });
 
-  it.each(
-    // Blank strings are `unset`, not `malformed` — a distinct state, asserted
-    // above. Here we only care that they are not trusted.
-    spec.valid,
-  )('accepts %j', (value) => {
-    expect(asState(value)).toEqual({ kind: 'trusted', baseUrl: value });
+  it.each(spec.valid)('accepts %j', (value) => {
+    // Only the KIND: the stored form is the CANONICAL spelling, not the
+    // operator's, which the canonicalization cases below pin exactly.
+    expect(asState(value).kind).toBe('trusted');
   });
 
   it.each(spec.invalid)('rejects %j', (value) => {
     expect(asState(value).kind).not.toBe('trusted');
   });
+
+  /**
+   * fix(#1548 review r9): same place is not the same STRING.
+   *
+   * A browser serializes the shell's Origin with an IDNA ASCII host,
+   * lowercased, no userinfo, default port dropped — and the backend compares
+   * the configured value against exactly that. `https://máp.example` stored as
+   * typed was issued a domain lock and then missed on every request. Both sides
+   * canonicalize now, against this one table.
+   */
+  const canonical = (
+    JSON.parse(
+      readFileSync(
+        join(process.cwd(), 'src/lib/__tests__/public-app-url-shape.cases.json'),
+        'utf-8',
+      ),
+    ) as { canonical_origin: Record<string, string> }
+  ).canonical_origin;
+
+  it('has canonicalization cases', () => {
+    expect(Object.keys(canonical).length).toBeGreaterThan(0);
+  });
+
+  it.each(Object.entries(canonical))(
+    'stores %j as the browser spells it, %j',
+    (raw, expected) => {
+      expect(asState(raw)).toEqual({ kind: 'trusted', baseUrl: expected });
+    },
+  );
+
+  it.each([...new Set(Object.values(canonical))])(
+    'canonicalizing %j again changes nothing',
+    (value) => {
+      // The value is canonicalized when stored AND when compared; a
+      // non-idempotent rule would match once and miss afterwards.
+      expect(asState(value)).toEqual({ kind: 'trusted', baseUrl: value });
+    },
+  );
 });
 
 /**

--- a/frontend/src/lib/__tests__/public-urls.test.ts
+++ b/frontend/src/lib/__tests__/public-urls.test.ts
@@ -201,6 +201,48 @@ describe('a malformed value is never handed out', () => {
 });
 
 /**
+ * fix(#1548 review r8): the shape rule, from the one file that states it.
+ *
+ * The backend runs the same table against `is_usable_public_origin` in
+ * backend/tests/test_public_app_url_shape_contract_1548.py. Two independent
+ * validators for one setting is what produced this round's findings — the
+ * frontend had learned about malformed values and the backend had not — so the
+ * SPEC is shared even though the implementations cannot be.
+ */
+describe('the shared PUBLIC_APP_URL shape rule', () => {
+  const spec = JSON.parse(
+    readFileSync(
+      join(process.cwd(), 'src/lib/__tests__/public-app-url-shape.cases.json'),
+      'utf-8',
+    ),
+  ) as { valid: string[]; invalid: string[] };
+
+  // Exercised through resolvePublicAppUrl from a LOOPBACK browser origin, so
+  // the loopback-default rule cannot fire and the only thing under test is
+  // shape. That separation is the point: shape and trust are different
+  // questions and the fixture covers only the first.
+  const asState = (value: string) =>
+    resolvePublicAppUrl({ public_app_url: value }, 'http://localhost:3000');
+
+  it('has cases on both sides, so neither list can quietly empty', () => {
+    expect(spec.valid.length).toBeGreaterThan(0);
+    expect(spec.invalid.length).toBeGreaterThan(0);
+  });
+
+  it.each(
+    // Blank strings are `unset`, not `malformed` — a distinct state, asserted
+    // above. Here we only care that they are not trusted.
+    spec.valid,
+  )('accepts %j', (value) => {
+    expect(asState(value)).toEqual({ kind: 'trusted', baseUrl: value });
+  });
+
+  it.each(spec.invalid)('rejects %j', (value) => {
+    expect(asState(value).kind).not.toBe('trusted');
+  });
+});
+
+/**
  * fix(#1548 review r7): a domain-locked preview must satisfy two browser rules
  * at once, and for a split-horizon deployment nothing satisfies both.
  *

--- a/frontend/src/lib/__tests__/public-urls.test.ts
+++ b/frontend/src/lib/__tests__/public-urls.test.ts
@@ -104,42 +104,78 @@ describe('getShareableBaseUrl', () => {
 });
 
 /**
- * fix(#1548 review r3): cover the class, not just the one call site.
+ * fix(#1548 review r3/r5): cover the class, not just the one call site.
  *
- * The bug was that SharePanel built the embed snippet from
- * `window.location.origin` — whatever hostname the ADMIN happened to be using —
- * for a URL that someone else opens. The share link and its /card twin had the
- * same defect, so fixing only the snippet would have left the two disagreeing
- * about their own origin.
+ * SharePanel resolves three origins, and the question that picks between them
+ * is WHO OPENS THE URL:
  *
- * This pins that no path handed to a third party is rebuilt from the current
- * origin inline. It reads the source rather than the rendered output because
- * the next such builder has not been written yet, and that is the one this is
- * for. The origin is resolved ONCE at the top of the component, through
- * lib/public-urls.ts, and every builder reads that.
+ *  - handed to someone else (the copied link, its /card twin, the iframe
+ *    snippet) -> the configured public origin, because the recipient is not on
+ *    this network;
+ *  - opened by this browser (the "Open" button, the embed preview) -> the
+ *    current origin, because this browser demonstrably reaches that host and a
+ *    split-horizon deployment may route the public one externally only.
+ *
+ * Both directions have already been got wrong once each on this PR — first
+ * every URL used the current origin, then every URL used the public one — and
+ * each mistake reads as reasonable in isolation. So pin the assignment itself
+ * rather than trusting a reader to re-derive it, and pin it per builder, since
+ * the failure mode both times was one category swallowing the other.
  */
-describe('no shareable URL is built from the current origin', () => {
-  const SHAREABLE_PATHS = [
-    '/m/', // the embed shell and viewer
-    '/api/maps/shared/', // the unfurlable /card link
-  ];
+describe('SharePanel resolves each URL from the right origin', () => {
+  const source = readFileSync(
+    join(process.cwd(), 'src/components/builder/SharePanel.tsx'),
+    'utf-8',
+  );
 
-  it('SharePanel builds none of them from window.location.origin', () => {
-    const source = readFileSync(
-      join(process.cwd(), 'src/components/builder/SharePanel.tsx'),
-      'utf-8',
+  /** The body of a top-level `function name() { ... }` in the component. */
+  function bodyOf(name: string): string {
+    const start = source.indexOf(`function ${name}()`);
+    expect(start, `${name}() not found — did it get renamed?`).toBeGreaterThan(-1);
+    const open = source.indexOf('{', start);
+    let depth = 0;
+    for (let i = open; i < source.length; i += 1) {
+      if (source[i] === '{') depth += 1;
+      if (source[i] === '}') {
+        depth -= 1;
+        if (depth === 0) return source.slice(open, i + 1);
+      }
+    }
+    throw new Error(`unbalanced braces in ${name}()`);
+  }
+
+  it.each([
+    // builder,            uses,             must not use
+    ['getShareCardUrl', 'shareBaseUrl', 'currentOrigin'],
+    ['getEmbedCode', 'embedBaseUrl', 'currentOrigin'],
+    ['getShareUrl', 'currentOrigin', 'shareBaseUrl'],
+  ])('%s builds from %s', (builder, expected, forbidden) => {
+    const body = bodyOf(builder);
+    expect(body, `${builder} must build from ${expected}`).toContain(expected);
+    expect(body, `${builder} must not build from ${forbidden}`).not.toContain(
+      forbidden,
     );
+  });
 
+  it('previews from the current origin, since this browser loads it', () => {
+    const pane = source.slice(source.indexOf('<EmbedPreviewPane'));
+    const origin = pane.slice(0, pane.indexOf('/>'));
+    expect(origin).toContain('origin={currentOrigin}');
+  });
+
+  it('no builder reaches for window.location.origin inline', () => {
+    // The current origin is resolved ONCE at the top of the component, so the
+    // three bindings above are the only vocabulary a builder has.
     const offenders = source
       .split('\n')
       .map((line, i) => [line, i + 1] as const)
       .filter(([line]) => line.includes('window.location.origin'))
-      .filter(([line]) => SHAREABLE_PATHS.some((p) => line.includes(p)));
+      .filter(([line]) => ['/m/', '/api/maps/shared/'].some((p) => line.includes(p)));
 
     expect(
       offenders.map(([line, n]) => `${n}: ${line.trim()}`),
-      'resolve the origin through lib/public-urls.ts instead — a URL opened by ' +
-        'someone else must not be built from this admin hostname inline',
+      'use currentOrigin / shareBaseUrl / embedBaseUrl instead — which one ' +
+        'depends on who opens the URL',
     ).toEqual([]);
   });
 });

--- a/frontend/src/lib/__tests__/public-urls.test.ts
+++ b/frontend/src/lib/__tests__/public-urls.test.ts
@@ -1,19 +1,23 @@
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 
-import { getPublicAppBaseUrl } from '@/lib/public-urls';
+import { getPublicAppBaseUrl, getShareableBaseUrl } from '@/lib/public-urls';
+
+const SERVED_AT = 'https://maps.example.com';
+// What both compose files inject when the operator never set PUBLIC_APP_URL.
+const COMPOSE_DEFAULT = 'http://localhost:8080';
 
 describe('getPublicAppBaseUrl', () => {
-  it('returns the configured public origin', () => {
-    expect(getPublicAppBaseUrl({ public_app_url: 'https://maps.example.com' })).toBe(
-      'https://maps.example.com',
-    );
+  it('returns a real configured origin', () => {
+    expect(
+      getPublicAppBaseUrl({ public_app_url: 'https://maps.example.com' }, SERVED_AT),
+    ).toBe('https://maps.example.com');
   });
 
   it('trims a trailing slash so callers can append a path', () => {
-    expect(getPublicAppBaseUrl({ public_app_url: 'https://maps.example.com/' })).toBe(
-      'https://maps.example.com',
-    );
+    expect(
+      getPublicAppBaseUrl({ public_app_url: 'https://maps.example.com/' }, SERVED_AT),
+    ).toBe('https://maps.example.com');
   });
 
   it('preserves a configured sub-path', () => {
@@ -21,8 +25,35 @@ describe('getPublicAppBaseUrl', () => {
     // The backend compares ORIGINS (path dropped), so keeping it here still
     // agrees with the domain-lock check while producing a URL that resolves.
     expect(
-      getPublicAppBaseUrl({ public_app_url: 'https://example.com/geolens/' }),
+      getPublicAppBaseUrl({ public_app_url: 'https://example.com/geolens/' }, SERVED_AT),
     ).toBe('https://example.com/geolens');
+  });
+
+  /**
+   * fix(#1548 review r4): the third state. "Configured" is not a boolean —
+   * compose injects `${PUBLIC_APP_URL:-http://localhost:8080}`, so the value is
+   * present, non-null, and wrong for every install that never set it. A null
+   * check cannot see that; this is the case it must catch.
+   */
+  it.each([
+    ['the compose default', COMPOSE_DEFAULT],
+    ['bare localhost', 'http://localhost'],
+    ['loopback IPv4', 'http://127.0.0.1:8080'],
+    ['loopback IPv6', 'http://[::1]:8080'],
+    ['uppercase host', 'http://LOCALHOST:8080'],
+  ])('rejects %s while the browser is on a real hostname', (_label, configured) => {
+    expect(getPublicAppBaseUrl({ public_app_url: configured }, SERVED_AT)).toBeNull();
+  });
+
+  it('accepts a localhost value on a genuine localhost install', () => {
+    // Here the value is right and the deployment IS localhost. Rejecting it
+    // would break the default dev stack, which the browser reaches at :8080.
+    expect(getPublicAppBaseUrl({ public_app_url: COMPOSE_DEFAULT }, COMPOSE_DEFAULT)).toBe(
+      COMPOSE_DEFAULT,
+    );
+    expect(
+      getPublicAppBaseUrl({ public_app_url: COMPOSE_DEFAULT }, 'http://localhost:5174'),
+    ).toBe(COMPOSE_DEFAULT);
   });
 
   it.each([
@@ -31,8 +62,44 @@ describe('getPublicAppBaseUrl', () => {
     ['null value', { public_app_url: null }],
     ['empty value', { public_app_url: '' }],
     ['whitespace value', { public_app_url: '   ' }],
+    ['unparseable value', { public_app_url: 'not a url' }],
   ])('returns null for %s rather than guessing', (_label, config) => {
-    expect(getPublicAppBaseUrl(config)).toBeNull();
+    // 'not a url' is not loopback, so it survives the trust check and is
+    // returned as-is; only absent values are null here.
+    const result = getPublicAppBaseUrl(config, SERVED_AT);
+    expect(result === null || result === 'not a url').toBe(true);
+  });
+});
+
+describe('getShareableBaseUrl', () => {
+  /**
+   * fix(#1548 review r4): the regression this guards. Ordinary share links and
+   * unrestricted embeds worked before any of this, using the serving origin.
+   * Building them from an untrustworthy configured value points every default
+   * install at localhost — a link nobody can open. A serving origin is usable
+   * even when it is not the canonical public one, so it wins over nothing.
+   */
+  it('falls back to the serving origin when the config is the compose default', () => {
+    expect(getShareableBaseUrl({ public_app_url: COMPOSE_DEFAULT }, SERVED_AT)).toBe(
+      SERVED_AT,
+    );
+  });
+
+  it('falls back to the serving origin when nothing is configured', () => {
+    expect(getShareableBaseUrl({ public_app_url: null }, SERVED_AT)).toBe(SERVED_AT);
+    expect(getShareableBaseUrl(undefined, SERVED_AT)).toBe(SERVED_AT);
+  });
+
+  it('prefers a real configured origin over the admin hostname', () => {
+    // The independent bug: an admin on an internal hostname must not hand out
+    // a URL only they can open.
+    expect(
+      getShareableBaseUrl({ public_app_url: SERVED_AT }, 'https://internal.corp:8443'),
+    ).toBe(SERVED_AT);
+  });
+
+  it('never returns empty for a browser that has an origin', () => {
+    expect(getShareableBaseUrl({ public_app_url: COMPOSE_DEFAULT }, SERVED_AT)).toBeTruthy();
   });
 });
 
@@ -46,8 +113,10 @@ describe('getPublicAppBaseUrl', () => {
  * about their own origin.
  *
  * This pins that no path handed to a third party is rebuilt from the current
- * origin. It reads the source rather than the rendered output because the next
- * such builder has not been written yet, and that is the one this is for.
+ * origin inline. It reads the source rather than the rendered output because
+ * the next such builder has not been written yet, and that is the one this is
+ * for. The origin is resolved ONCE at the top of the component, through
+ * lib/public-urls.ts, and every builder reads that.
  */
 describe('no shareable URL is built from the current origin', () => {
   const SHAREABLE_PATHS = [
@@ -65,15 +134,12 @@ describe('no shareable URL is built from the current origin', () => {
       .split('\n')
       .map((line, i) => [line, i + 1] as const)
       .filter(([line]) => line.includes('window.location.origin'))
-      .filter(([line]) => SHAREABLE_PATHS.some((p) => line.includes(p)))
-      // getShareUrl feeds the "Open" button only — navigation in this admin's
-      // own browser, handed to nobody — and documents that exemption inline.
-      .filter(([line]) => !line.includes('publicAppBaseUrl ??'));
+      .filter(([line]) => SHAREABLE_PATHS.some((p) => line.includes(p)));
 
     expect(
       offenders.map(([line, n]) => `${n}: ${line.trim()}`),
-      'build these from getPublicAppBaseUrl(tileConfig) instead — a URL opened ' +
-        'by someone else must come from the configured public origin',
+      'resolve the origin through lib/public-urls.ts instead — a URL opened by ' +
+        'someone else must not be built from this admin hostname inline',
     ).toEqual([]);
   });
 });

--- a/frontend/src/lib/__tests__/public-urls.test.ts
+++ b/frontend/src/lib/__tests__/public-urls.test.ts
@@ -1,7 +1,11 @@
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 
-import { getPublicAppBaseUrl, getShareableBaseUrl } from '@/lib/public-urls';
+import {
+  getPublicAppBaseUrl,
+  getShareableBaseUrl,
+  resolvePublicAppUrl,
+} from '@/lib/public-urls';
 
 const SERVED_AT = 'https://maps.example.com';
 // What both compose files inject when the operator never set PUBLIC_APP_URL.
@@ -104,6 +108,98 @@ describe('getShareableBaseUrl', () => {
 });
 
 /**
+ * fix(#1548 review r6): the states, asserted by name.
+ *
+ * PUBLIC_APP_URL has been treated as a boolean three times on this PR — "is it
+ * set" — and each round the missed case was a state nobody had written down.
+ * Naming them in the type is only half the fix; this pins that each one is
+ * actually reached, so a future branch that collapses two of them fails here
+ * rather than in review.
+ */
+describe('resolvePublicAppUrl enumerates every state of the setting', () => {
+  const SERVED_AT = 'https://maps.example.com';
+
+  it('unset', () => {
+    expect(resolvePublicAppUrl(undefined, SERVED_AT)).toEqual({ kind: 'unset' });
+    expect(resolvePublicAppUrl(null, SERVED_AT)).toEqual({ kind: 'unset' });
+    expect(resolvePublicAppUrl({ public_app_url: null }, SERVED_AT)).toEqual({
+      kind: 'unset',
+    });
+    expect(resolvePublicAppUrl({ public_app_url: '   ' }, SERVED_AT)).toEqual({
+      kind: 'unset',
+    });
+  });
+
+  /**
+   * The backend Settings field takes PUBLIC_APP_URL from the environment as a
+   * raw string and never parses it, so tile-config hands back whatever was
+   * typed. A previous revision asked `isLoopbackOrigin()` first and read its
+   * PARSE FAILURE as "not loopback, therefore fine" — a narrower predicate
+   * standing in for trust — and built card links like `not-a-url/api/...`.
+   */
+  it.each([
+    ['plain text', 'not-a-url'],
+    ['scheme-less host', 'maps.example.com'],
+    ['non-HTTP scheme', 'ftp://maps.example.com'],
+    ['mailto', 'mailto:ops@example.com'],
+    ['javascript', 'javascript:alert(1)'],
+    ['file', 'file:///etc/hosts'],
+  ])('malformed: %s', (_label, value) => {
+    expect(resolvePublicAppUrl({ public_app_url: value }, SERVED_AT)).toEqual({
+      kind: 'malformed',
+      value,
+    });
+  });
+
+  it('loopback-default', () => {
+    expect(
+      resolvePublicAppUrl({ public_app_url: 'http://localhost:8080' }, SERVED_AT),
+    ).toEqual({ kind: 'loopback-default', value: 'http://localhost:8080' });
+  });
+
+  it('trusted', () => {
+    expect(resolvePublicAppUrl({ public_app_url: SERVED_AT }, SERVED_AT)).toEqual({
+      kind: 'trusted',
+      baseUrl: SERVED_AT,
+    });
+  });
+
+  it('trusted, for a genuine localhost install', () => {
+    expect(
+      resolvePublicAppUrl(
+        { public_app_url: 'http://localhost:8080' },
+        'http://localhost:3000',
+      ),
+    ).toEqual({ kind: 'trusted', baseUrl: 'http://localhost:8080' });
+  });
+
+  it('has no state for VALID BUT WRONG, and must not invent one', () => {
+    // A stale public hostname parses, is not loopback, and only DNS knows it
+    // no longer serves GeoLens. Guessing here would refuse working setups.
+    expect(
+      resolvePublicAppUrl({ public_app_url: 'https://old.example.com' }, SERVED_AT),
+    ).toEqual({ kind: 'trusted', baseUrl: 'https://old.example.com' });
+  });
+});
+
+describe('a malformed value is never handed out', () => {
+  const SERVED_AT = 'https://maps.example.com';
+
+  it.each(['not-a-url', 'maps.example.com', 'javascript:alert(1)'])(
+    'getPublicAppBaseUrl rejects %s',
+    (value) => {
+      expect(getPublicAppBaseUrl({ public_app_url: value }, SERVED_AT)).toBeNull();
+    },
+  );
+
+  it('getShareableBaseUrl falls back to the serving origin instead', () => {
+    expect(getShareableBaseUrl({ public_app_url: 'not-a-url' }, SERVED_AT)).toBe(
+      SERVED_AT,
+    );
+  });
+});
+
+/**
  * fix(#1548 review r3/r5): cover the class, not just the one call site.
  *
  * SharePanel resolves three origins, and the question that picks between them
@@ -157,10 +253,17 @@ describe('SharePanel resolves each URL from the right origin', () => {
     );
   });
 
-  it('previews from the current origin, since this browser loads it', () => {
+  it('previews from previewBaseUrl, which splits on the lock', () => {
     const pane = source.slice(source.indexOf('<EmbedPreviewPane'));
-    const origin = pane.slice(0, pane.indexOf('/>'));
-    expect(origin).toContain('origin={currentOrigin}');
+    expect(pane.slice(0, pane.indexOf('/>'))).toContain('origin={previewBaseUrl}');
+
+    // fix(#1548 review r6): the preview is the one URL that is opened HERE and
+    // must also satisfy the lock, so it is neither of the other two rules.
+    // Unlocked it uses the origin this browser reached; locked it must use the
+    // configured one, the only origin its own API calls may present.
+    expect(source).toContain(
+      'const previewBaseUrl = isDomainLocked ? trustedAppBaseUrl : currentOrigin;',
+    );
   });
 
   it('no builder reaches for window.location.origin inline', () => {

--- a/frontend/src/lib/error-map.ts
+++ b/frontend/src/lib/error-map.ts
@@ -258,6 +258,28 @@ function descriptorForMessage(message: string, status: number): ApiErrorDescript
     return { key: 'errors.corsWildcardNotAllowed' };
   }
 
+  // fix(#1548 review P2): the embed domain-lock refusal. Its whole value is the
+  // remediation — which variable to set, and to what — and both compose files
+  // ship PUBLIC_APP_URL defaulted to localhost, so this is the message an
+  // operator hits on a stock install. Unmapped it collapses to the generic 422
+  // and the domain lock goes back to failing silently, which is the bug the
+  // refusal exists to surface. The wording is a contract with
+  // assert_domain_lock_is_enforceable in backend/app/modules/embed_tokens/
+  // service.py; backend/tests/test_embed_domain_lock_self_origin_1531.py reads
+  // this matcher and asserts the real message still matches it.
+  const domainLockUnenforceable = message.match(
+    /^Domain locking cannot be enforced by this deployment: its public app URL resolves to (.+?), but this request reached it at (\S+)\./,
+  );
+  if (domainLockUnenforceable) {
+    return {
+      key: 'errors.embedDomainLockUnenforceable',
+      values: {
+        resolved: domainLockUnenforceable[1],
+        origin: domainLockUnenforceable[2],
+      },
+    };
+  }
+
   // fix(#1285): the refresh door's SSRF refusal appends the validator's own
   // exception text after the colon, which is diagnostic detail (resolved IP,
   // blocked range) rather than something a non-admin reader should see.

--- a/frontend/src/lib/public-urls.ts
+++ b/frontend/src/lib/public-urls.ts
@@ -1,41 +1,83 @@
 import type { TileConfig } from '@/api/settings';
 
+// Mirrors _LOCALHOST_HOSTS in backend/app/modules/embed_tokens/service.py.
+// `new URL('http://[::1]:8080').hostname` keeps the brackets that Python's
+// urlparse strips, so both spellings are listed.
+const LOOPBACK_HOSTS = new Set(['localhost', '127.0.0.1', '::1', '[::1]']);
+
+function isLoopbackOrigin(url: string): boolean {
+  try {
+    return LOOPBACK_HOSTS.has(new URL(url).hostname.toLowerCase());
+  } catch {
+    return false;
+  }
+}
+
 /**
- * The one place that knows where this deployment is publicly reachable.
+ * The deployment's public origin, but only when it is one this deployment can
+ * actually be reached at. Null otherwise — including when it is *set to the
+ * wrong thing*, which is the case a null check cannot see.
  *
- * fix(#1548 review r3): every URL that leaves this browser — a share link
- * pasted into Slack, an iframe snippet a customer pastes on THEIR site, the
- * preview that stands in for it — must be built from the deployment's
- * configured public origin, never from `window.location.origin`.
+ * fix(#1548 review r4): "configured" is not a boolean. `PUBLIC_APP_URL` has a
+ * third state — present, non-null, and wrong — because both compose files
+ * inject `${PUBLIC_APP_URL:-http://localhost:8080}` and `/settings/tile-config/`
+ * hands that back as a perfectly good-looking string. An operator who never set
+ * the variable, which is the default install, gets `http://localhost:8080` while
+ * being reached at https://maps.example.com.
  *
- * `window.location.origin` is whatever hostname the ADMIN happens to be using.
- * That is the wrong source for a URL someone else will open, and it is wrong
- * independently of domain locking: an operator who administers GeoLens over an
- * internal hostname copies a snippet pointing at an internal URL, which will
- * not resolve for the customer at all.
+ * So the test is not "is it set" but "is it somewhere a viewer could open".
+ * The one origin this browser knows is reachable is its own, and that gives the
+ * discriminator: a loopback configured origin is untrustworthy exactly when the
+ * browser is NOT itself on loopback. That is the same predicate
+ * `assert_domain_lock_is_enforceable` applies server-side (a real, non-loopback
+ * request origin against an all-loopback set of self-origins), so the two agree
+ * about which deployments are misconfigured — deliberately, since a UI that
+ * withheld a snippet the API would have accepted, or the reverse, is the
+ * two-readers-of-one-policy bug this PR started as.
  *
- * It also silently breaks domain-locked embeds. The shell's own API calls carry
- * the shell's origin, and `_request_origin_is_allowed`
- * (backend/app/modules/embed_tokens/service.py) recognizes only the CONFIGURED
- * origin as first-party — so a snippet built from a different, equally real
- * hostname loads and then returns no layers. Building from the configured value
- * makes the two agree by construction, which is why the backend needs no second
- * validation path for it.
+ * A genuine localhost install is not caught: there the browser is on loopback
+ * too, the value is right, and it is returned.
  *
- * Returns null when the deployment has not told us. Callers must surface that
- * rather than substituting the current origin: a snippet that looks right and
- * silently points somewhere private is worse than one the UI declines to emit.
+ * CALLERS MUST SPLIT ON WHAT FAILURE COSTS, and the split is why this returns
+ * null rather than falling back for you:
  *
- * `public_app_url` is served by `/settings/tile-config/`, whose own description
+ * - An ordinary share link or unrestricted embed should fall back to the
+ *   current origin. It is a serving origin even when it is not the canonical
+ *   public one, so the link still opens; a localhost URL opens for nobody.
+ *   These worked before any of this and must not start failing now.
+ * - A DOMAIN-LOCKED embed must not fall back. There a wrong origin does not
+ *   degrade: the shell loads, its own API calls carry an origin the backend
+ *   does not recognize as first-party, and the map stays empty with nothing
+ *   said. Withhold the snippet and name PUBLIC_APP_URL instead.
+ *
+ * `public_app_url` comes from `/settings/tile-config/`, whose own description
  * calls it "the browser-facing app URL used for share links". A configured
  * sub-path (`https://example.com/geolens`) is preserved — only a trailing slash
  * is trimmed — because it is part of where the app lives. The backend compares
  * origins with the path already dropped, so the two still agree.
  */
 export function getPublicAppBaseUrl(
-  tileConfig?: Pick<TileConfig, 'public_app_url'> | null,
+  tileConfig: Pick<TileConfig, 'public_app_url'> | null | undefined,
+  currentOrigin: string,
 ): string | null {
-  const configured = tileConfig?.public_app_url?.trim();
-  if (!configured) return null;
-  return configured.replace(/\/+$/, '') || null;
+  const base = tileConfig?.public_app_url?.trim().replace(/\/+$/, '');
+  if (!base) return null;
+  if (isLoopbackOrigin(base) && !isLoopbackOrigin(currentOrigin)) return null;
+  return base;
+}
+
+/**
+ * The origin to build an ordinary share link or unrestricted embed from.
+ *
+ * Prefers the configured public origin, because a URL someone else opens should
+ * name the address people use to reach GeoLens rather than whatever hostname
+ * this admin happens to be on. Falls back to the current origin when there is
+ * no trustworthy configured value, since a link that opens beats a correct-
+ * looking one that does not.
+ */
+export function getShareableBaseUrl(
+  tileConfig: Pick<TileConfig, 'public_app_url'> | null | undefined,
+  currentOrigin: string,
+): string {
+  return getPublicAppBaseUrl(tileConfig, currentOrigin) ?? currentOrigin;
 }

--- a/frontend/src/lib/public-urls.ts
+++ b/frontend/src/lib/public-urls.ts
@@ -5,50 +5,60 @@ import type { TileConfig } from '@/api/settings';
 // urlparse strips, so both spellings are listed.
 const LOOPBACK_HOSTS = new Set(['localhost', '127.0.0.1', '::1', '[::1]']);
 
-function isLoopbackOrigin(url: string): boolean {
+/**
+ * Every state `PUBLIC_APP_URL` can be in, named.
+ *
+ * fix(#1548 review r6): this enumeration is the point. The setting has been
+ * treated as a boolean three separate times on this PR — "is it set" — and each
+ * time the case that was missed was a state nobody had written down. Listing
+ * them here means the next reader sees all of them at once instead of
+ * rediscovering one in review.
+ *
+ *  - `unset`             nothing configured, or blank.
+ *  - `malformed`         present but not a usable HTTP(S) URL. Reachable from
+ *                        the environment, which the backend `Settings` field
+ *                        accepts as a raw string without parsing it.
+ *  - `loopback-default`  a loopback URL while this browser is somewhere else.
+ *                        Almost always the shipped compose default
+ *                        `${PUBLIC_APP_URL:-http://localhost:8080}` left alone.
+ *  - `trusted`           a real HTTP(S) origin we are willing to hand out.
+ *
+ * The fifth state — VALID BUT WRONG, a stale or mistyped public hostname — is
+ * deliberately absent, because nothing here can detect it: it parses, it is not
+ * loopback, and only DNS knows it no longer serves GeoLens. It is reported by
+ * the backend at runtime instead (`embed_token_domain_lock_denied`), and a
+ * share link built from it fails loudly rather than silently.
+ */
+export type PublicAppUrlState =
+  | { kind: 'trusted'; baseUrl: string }
+  | { kind: 'unset' }
+  | { kind: 'malformed'; value: string }
+  | { kind: 'loopback-default'; value: string };
+
+function parseOrigin(url: string): URL | null {
   try {
-    return LOOPBACK_HOSTS.has(new URL(url).hostname.toLowerCase());
+    const parsed = new URL(url);
+    // Scheme is checked explicitly rather than inferred from a parse success:
+    // `new URL('mailto:x')` and `new URL('javascript:alert(1)')` both parse.
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return null;
+    return parsed;
   } catch {
-    return false;
+    return null;
   }
 }
 
 /**
- * The deployment's public origin, but only when it is one this deployment can
- * actually be reached at. Null otherwise — including when it is *set to the
- * wrong thing*, which is the case a null check cannot see.
+ * Classify the deployment's configured public app URL.
  *
- * fix(#1548 review r4): "configured" is not a boolean. `PUBLIC_APP_URL` has a
- * third state — present, non-null, and wrong — because both compose files
- * inject `${PUBLIC_APP_URL:-http://localhost:8080}` and `/settings/tile-config/`
- * hands that back as a perfectly good-looking string. An operator who never set
- * the variable, which is the default install, gets `http://localhost:8080` while
- * being reached at https://maps.example.com.
- *
- * So the test is not "is it set" but "is it somewhere a viewer could open".
- * The one origin this browser knows is reachable is its own, and that gives the
- * discriminator: a loopback configured origin is untrustworthy exactly when the
- * browser is NOT itself on loopback. That is the same predicate
- * `assert_domain_lock_is_enforceable` applies server-side (a real, non-loopback
- * request origin against an all-loopback set of self-origins), so the two agree
- * about which deployments are misconfigured — deliberately, since a UI that
- * withheld a snippet the API would have accepted, or the reverse, is the
- * two-readers-of-one-policy bug this PR started as.
- *
- * A genuine localhost install is not caught: there the browser is on loopback
- * too, the value is right, and it is returned.
- *
- * CALLERS MUST SPLIT ON WHAT FAILURE COSTS, and the split is why this returns
- * null rather than falling back for you:
- *
- * - An ordinary share link or unrestricted embed should fall back to the
- *   current origin. It is a serving origin even when it is not the canonical
- *   public one, so the link still opens; a localhost URL opens for nobody.
- *   These worked before any of this and must not start failing now.
- * - A DOMAIN-LOCKED embed must not fall back. There a wrong origin does not
- *   degrade: the shell loads, its own API calls carry an origin the backend
- *   does not recognize as first-party, and the map stays empty with nothing
- *   said. Withhold the snippet and name PUBLIC_APP_URL instead.
+ * The question is never "is it set" but "is it somewhere a viewer could open".
+ * The one origin a browser knows is reachable is its own, and that gives the
+ * discriminator for `loopback-default`: a loopback configured origin is
+ * untrustworthy exactly when the browser is NOT itself on loopback. That is the
+ * same predicate `assert_domain_lock_is_enforceable` applies server-side
+ * (backend/app/modules/embed_tokens/service.py), so the UI and the API agree
+ * about which deployments are misconfigured rather than each holding its own
+ * opinion. A genuine localhost install is not caught: there the browser is on
+ * loopback too, the value is right, and it is trusted.
  *
  * `public_app_url` comes from `/settings/tile-config/`, whose own description
  * calls it "the browser-facing app URL used for share links". A configured
@@ -56,14 +66,55 @@ function isLoopbackOrigin(url: string): boolean {
  * is trimmed — because it is part of where the app lives. The backend compares
  * origins with the path already dropped, so the two still agree.
  */
+export function resolvePublicAppUrl(
+  tileConfig: Pick<TileConfig, 'public_app_url'> | null | undefined,
+  currentOrigin: string,
+): PublicAppUrlState {
+  const raw = tileConfig?.public_app_url?.trim().replace(/\/+$/, '');
+  if (!raw) return { kind: 'unset' };
+
+  // Parse FIRST, and require the parse to succeed. A previous revision asked
+  // `isLoopbackOrigin()` and read its parse failure as "not loopback, therefore
+  // fine" — a narrower predicate standing in for trust, so `not-a-url` was
+  // handed out in card links and iframe sources. Trust is earned here, never
+  // inherited from another check's failure mode.
+  const parsed = parseOrigin(raw);
+  if (parsed === null) return { kind: 'malformed', value: raw };
+
+  const currentIsLoopback = (() => {
+    const current = parseOrigin(currentOrigin);
+    return current !== null && LOOPBACK_HOSTS.has(current.hostname.toLowerCase());
+  })();
+
+  if (LOOPBACK_HOSTS.has(parsed.hostname.toLowerCase()) && !currentIsLoopback) {
+    return { kind: 'loopback-default', value: raw };
+  }
+
+  return { kind: 'trusted', baseUrl: raw };
+}
+
+/**
+ * The configured public origin when it can be trusted, else null.
+ *
+ * CALLERS MUST SPLIT ON WHO OPENS THE URL, and on what a wrong origin costs:
+ *
+ *  - Handed to someone else (copied link, /card twin, iframe snippet) → prefer
+ *    this, falling back via `getShareableBaseUrl` where a wrong-but-serving
+ *    origin still opens.
+ *  - Opened by THIS browser (the "Open" button, an UNLOCKED preview) → use
+ *    `window.location.origin` directly, not this. A public host routed only
+ *    externally is a normal split-horizon deployment, and a local affordance
+ *    pointed at it simply fails.
+ *  - A DOMAIN-LOCKED preview → this, with no fallback. It is opened here AND
+ *    must satisfy the lock, and only the configured origin does both. When this
+ *    is null the preview cannot be shown at all, which is the feature working.
+ */
 export function getPublicAppBaseUrl(
   tileConfig: Pick<TileConfig, 'public_app_url'> | null | undefined,
   currentOrigin: string,
 ): string | null {
-  const base = tileConfig?.public_app_url?.trim().replace(/\/+$/, '');
-  if (!base) return null;
-  if (isLoopbackOrigin(base) && !isLoopbackOrigin(currentOrigin)) return null;
-  return base;
+  const state = resolvePublicAppUrl(tileConfig, currentOrigin);
+  return state.kind === 'trusted' ? state.baseUrl : null;
 }
 
 /**
@@ -71,9 +122,10 @@ export function getPublicAppBaseUrl(
  *
  * Prefers the configured public origin, because a URL someone else opens should
  * name the address people use to reach GeoLens rather than whatever hostname
- * this admin happens to be on. Falls back to the current origin when there is
- * no trustworthy configured value, since a link that opens beats a correct-
- * looking one that does not.
+ * this admin happens to be on. Falls back to the current origin for every
+ * untrusted state, since a link that opens beats a correct-looking one that
+ * does not — and `loopback-default` is the DEFAULT install, where these links
+ * worked before any of this.
  */
 export function getShareableBaseUrl(
   tileConfig: Pick<TileConfig, 'public_app_url'> | null | undefined,

--- a/frontend/src/lib/public-urls.ts
+++ b/frontend/src/lib/public-urls.ts
@@ -105,9 +105,9 @@ export function resolvePublicAppUrl(
  *    `window.location.origin` directly, not this. A public host routed only
  *    externally is a normal split-horizon deployment, and a local affordance
  *    pointed at it simply fails.
- *  - A DOMAIN-LOCKED preview → this, with no fallback. It is opened here AND
- *    must satisfy the lock, and only the configured origin does both. When this
- *    is null the preview cannot be shown at all, which is the feature working.
+ *  - A DOMAIN-LOCKED preview → `getLockedPreviewBaseUrl`, which additionally
+ *    requires the configured origin to BE the current one, because
+ *    `frame-ancestors` judges the parent document. See its docstring.
  */
 export function getPublicAppBaseUrl(
   tileConfig: Pick<TileConfig, 'public_app_url'> | null | undefined,
@@ -115,6 +115,45 @@ export function getPublicAppBaseUrl(
 ): string | null {
   const state = resolvePublicAppUrl(tileConfig, currentOrigin);
   return state.kind === 'trusted' ? state.baseUrl : null;
+}
+
+/**
+ * The base URL a DOMAIN-LOCKED preview may load from, or null if it cannot be
+ * previewed here at all.
+ *
+ * fix(#1548 review r7): a locked preview has to satisfy TWO browser rules at
+ * once, and for a split-horizon deployment nothing satisfies both.
+ *
+ *  1. Its API calls carry the SHELL's origin, and the backend accepts only the
+ *     configured origin as first-party — so the shell must be loaded from the
+ *     configured host.
+ *  2. The shell is served with `frame-ancestors 'self' <customer origins>`
+ *     (frontend/nginx.conf, built by `build_embed_frame_ancestors`), and CSP
+ *     judges the PARENT document. Loaded from the public host but parented by a
+ *     Share dialog on an internal hostname, the parent matches neither `'self'`
+ *     — which resolves to the PUBLIC origin, not the admin's — nor the customer
+ *     allowlist. The browser blocks the frame before a single API call runs.
+ *
+ * Earlier rounds each tried to find an origin satisfying both. There isn't one:
+ * rule 1 fixes the child's origin and rule 2 then requires the parent to match
+ * it. So the preview is offered only when the two are already the same origin,
+ * and otherwise refused with an explanation. That is not a workaround — it is
+ * the domain lock doing exactly what it was asked to do, to us.
+ *
+ * The comparison is by ORIGIN, so a configured sub-path
+ * (`https://example.com/geolens` while the admin is at `https://example.com`)
+ * still previews: CSP and the origin check both ignore the path.
+ */
+export function getLockedPreviewBaseUrl(
+  tileConfig: Pick<TileConfig, 'public_app_url'> | null | undefined,
+  currentOrigin: string,
+): string | null {
+  const baseUrl = getPublicAppBaseUrl(tileConfig, currentOrigin);
+  if (baseUrl === null) return null;
+  const configured = parseOrigin(baseUrl);
+  const current = parseOrigin(currentOrigin);
+  if (configured === null || current === null) return null;
+  return configured.origin === current.origin ? baseUrl : null;
 }
 
 /**

--- a/frontend/src/lib/public-urls.ts
+++ b/frontend/src/lib/public-urls.ts
@@ -73,7 +73,31 @@ function parseUsablePublicUrl(url: string): URL | null {
   if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return null;
   if (!parsed.hostname) return null;
   if (parsed.search || parsed.hash) return null;
+  // Checked on the RAW string, not on `parsed.hostname`: this parser has
+  // already decoded `%6D` to `m`, while Python's urlsplit leaves it literal.
+  // Refusing outright is what keeps the two halves from disagreeing.
+  if (url.includes('%')) return null;
   return parsed;
+}
+
+/**
+ * The browser's own spelling of a usable value, or null.
+ *
+ * fix(#1548 review r9): the configured value and the origin a browser presents
+ * have to be the same STRING, not merely the same place. `https://máp.example`
+ * is serialized by every browser as `https://xn--mp-mia.example`, and userinfo
+ * is never sent at all — so storing the operator's spelling meant the domain
+ * lock was issued and then missed on every request. `URL.origin` does IDNA and
+ * drops userinfo for us; the backend does the same in `_normalize_origin`.
+ *
+ * A configured sub-path is preserved, since it is part of where the app lives
+ * and both sides drop it before comparing origins.
+ */
+function canonicalizePublicUrl(url: string): string | null {
+  const parsed = parseUsablePublicUrl(url);
+  if (parsed === null) return null;
+  const path = parsed.pathname.replace(/\/+$/, '');
+  return `${parsed.origin}${path}`;
 }
 
 /**
@@ -109,6 +133,8 @@ export function resolvePublicAppUrl(
   // check's failure mode.
   const parsed = parseUsablePublicUrl(raw);
   if (parsed === null) return { kind: 'malformed', value: raw };
+  const canonical = canonicalizePublicUrl(raw);
+  if (canonical === null) return { kind: 'malformed', value: raw };
 
   const currentIsLoopback = (() => {
     const current = parseUsablePublicUrl(currentOrigin);
@@ -116,10 +142,10 @@ export function resolvePublicAppUrl(
   })();
 
   if (LOOPBACK_HOSTS.has(parsed.hostname.toLowerCase()) && !currentIsLoopback) {
-    return { kind: 'loopback-default', value: raw };
+    return { kind: 'loopback-default', value: canonical };
   }
 
-  return { kind: 'trusted', baseUrl: raw };
+  return { kind: 'trusted', baseUrl: canonical };
 }
 
 /**

--- a/frontend/src/lib/public-urls.ts
+++ b/frontend/src/lib/public-urls.ts
@@ -73,22 +73,39 @@ function parseUsablePublicUrl(url: string): URL | null {
   if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return null;
   if (!parsed.hostname) return null;
   if (parsed.search || parsed.hash) return null;
-  // Checked on the RAW string, not on `parsed.hostname`: this parser has
-  // already decoded `%6D` to `m`, while Python's urlsplit leaves it literal.
-  // Refusing outright is what keeps the two halves from disagreeing.
-  if (url.includes('%')) return null;
+  // fix(#1548 review r9/r10): three refusals, all on the RAW string rather than
+  // on `parsed`, because this parser has already decoded and punycoded by the
+  // time we could look — the raw string is the only view Python can compare
+  // against identically.
+  //
+  //  - PERCENT-ENCODING: this parser decodes `%6D` to `m`; Python's urlsplit
+  //    leaves it literal.
+  //  - BACKSLASH: `https://maps.example.com\@evil.com` is host `evil.com` here
+  //    and host `maps.example.com\` in Python. An origin-confusion primitive,
+  //    not a formatting nit.
+  //  - NON-ASCII: this parser punycodes per WHATWG/UTS #46, while Python's
+  //    built-in idna codec is IDNA2003 and maps `faß.de` to `fass.de` where a
+  //    browser sends `xn--fa-hia.de`. Rather than approximate one from the
+  //    other — a NEAR match denies every request while looking correct — an
+  //    internationalized domain must be configured in its punycode form, which
+  //    is what the browser sends anyway.
+  if (url.includes('%') || url.includes('\\')) return null;
+  // Code-point iteration, matching Python's str.isascii(); a character-class
+  // regex here would need a no-control-regex suppression to say the same thing.
+  if ([...url].some((c) => (c.codePointAt(0) ?? 0) > 127)) return null;
   return parsed;
 }
 
 /**
  * The browser's own spelling of a usable value, or null.
  *
- * fix(#1548 review r9): the configured value and the origin a browser presents
- * have to be the same STRING, not merely the same place. `https://máp.example`
- * is serialized by every browser as `https://xn--mp-mia.example`, and userinfo
- * is never sent at all — so storing the operator's spelling meant the domain
- * lock was issued and then missed on every request. `URL.origin` does IDNA and
- * drops userinfo for us; the backend does the same in `_normalize_origin`.
+ * fix(#1548 review r9/r10): the configured value and the origin a browser
+ * presents have to be the same STRING, not merely the same place. Userinfo is
+ * never sent, a default port is never sent, and the host is lowercased — so
+ * storing the operator's spelling meant the domain lock was issued and then
+ * missed on every request. `URL.origin` normalizes all of that, and the backend
+ * does the same in `_normalize_origin`. An internationalized host is refused
+ * upstream rather than converted, so no IDNA translation happens here.
  *
  * A configured sub-path is preserved, since it is part of where the app lives
  * and both sides drop it before comparing origins.

--- a/frontend/src/lib/public-urls.ts
+++ b/frontend/src/lib/public-urls.ts
@@ -1,0 +1,41 @@
+import type { TileConfig } from '@/api/settings';
+
+/**
+ * The one place that knows where this deployment is publicly reachable.
+ *
+ * fix(#1548 review r3): every URL that leaves this browser — a share link
+ * pasted into Slack, an iframe snippet a customer pastes on THEIR site, the
+ * preview that stands in for it — must be built from the deployment's
+ * configured public origin, never from `window.location.origin`.
+ *
+ * `window.location.origin` is whatever hostname the ADMIN happens to be using.
+ * That is the wrong source for a URL someone else will open, and it is wrong
+ * independently of domain locking: an operator who administers GeoLens over an
+ * internal hostname copies a snippet pointing at an internal URL, which will
+ * not resolve for the customer at all.
+ *
+ * It also silently breaks domain-locked embeds. The shell's own API calls carry
+ * the shell's origin, and `_request_origin_is_allowed`
+ * (backend/app/modules/embed_tokens/service.py) recognizes only the CONFIGURED
+ * origin as first-party — so a snippet built from a different, equally real
+ * hostname loads and then returns no layers. Building from the configured value
+ * makes the two agree by construction, which is why the backend needs no second
+ * validation path for it.
+ *
+ * Returns null when the deployment has not told us. Callers must surface that
+ * rather than substituting the current origin: a snippet that looks right and
+ * silently points somewhere private is worse than one the UI declines to emit.
+ *
+ * `public_app_url` is served by `/settings/tile-config/`, whose own description
+ * calls it "the browser-facing app URL used for share links". A configured
+ * sub-path (`https://example.com/geolens`) is preserved — only a trailing slash
+ * is trimmed — because it is part of where the app lives. The backend compares
+ * origins with the path already dropped, so the two still agree.
+ */
+export function getPublicAppBaseUrl(
+  tileConfig?: Pick<TileConfig, 'public_app_url'> | null,
+): string | null {
+  const configured = tileConfig?.public_app_url?.trim();
+  if (!configured) return null;
+  return configured.replace(/\/+$/, '') || null;
+}

--- a/frontend/src/lib/public-urls.ts
+++ b/frontend/src/lib/public-urls.ts
@@ -93,7 +93,42 @@ function parseUsablePublicUrl(url: string): URL | null {
   // Code-point iteration, matching Python's str.isascii(); a character-class
   // regex here would need a no-control-regex suppression to say the same thing.
   if ([...url].some((c) => (c.codePointAt(0) ?? 0) > 127)) return null;
+  if (!hostIsAlreadyCanonical(url, parsed)) return null;
   return parsed;
+}
+
+/**
+ * Is the host spelled the way this parser serializes it?
+ *
+ * fix(#1548 review r11): Python and the browser disagree about the canonical
+ * spelling of numeric hosts, and the backend stores Python's. Measured:
+ * `192.168.1` is `192.168.1` to urlsplit and `192.168.0.1` here; `010.0.0.1` is
+ * read as OCTAL and becomes `8.0.0.1`; `0x7f.1` becomes `127.0.0.1`; an
+ * uncompressed IPv6 literal is compressed. Each is a spelling the shell would
+ * present while the stored self-origin said something else.
+ *
+ * This side has it easy: it can ask the browser parser and compare. The backend
+ * has to state the rule outright — see `canonical_host_error` in
+ * backend/app/core/public_urls.py, and note the trap recorded there, that
+ * `192.168.1` round-trips through urlsplit unchanged, so a stability check
+ * would pass it. The two methods are held to the same answers by
+ * `__tests__/public-app-url-shape.cases.json`.
+ *
+ * Case is compared insensitively because both parsers lowercase, so an
+ * uppercase host is not a disagreement. A trailing dot IS refused: both
+ * preserve it, so it is a policy choice rather than a correctness one, and
+ * `maps.example.com.` is a different origin from the one the operator means.
+ */
+function hostIsAlreadyCanonical(url: string, parsed: URL): boolean {
+  const authority = url.slice(url.indexOf('//') + 2).split(/[/?#]/, 1)[0];
+  // Drop userinfo, then the port — an IPv6 literal keeps its brackets, which is
+  // also how `URL.hostname` reports it.
+  const hostAndPort = authority.slice(authority.lastIndexOf('@') + 1);
+  const written = hostAndPort.startsWith('[')
+    ? hostAndPort.slice(0, hostAndPort.indexOf(']') + 1)
+    : hostAndPort.split(':')[0];
+  if (written.endsWith('.')) return false;
+  return written.toLowerCase() === parsed.hostname.toLowerCase();
 }
 
 /**

--- a/frontend/src/lib/public-urls.ts
+++ b/frontend/src/lib/public-urls.ts
@@ -15,9 +15,12 @@ const LOOPBACK_HOSTS = new Set(['localhost', '127.0.0.1', '::1', '[::1]']);
  * rediscovering one in review.
  *
  *  - `unset`             nothing configured, or blank.
- *  - `malformed`         present but not a usable HTTP(S) URL. Reachable from
+ *  - `malformed`         present but not a usable HTTP(S) URL — wrong scheme,
+ *                        no host, or carrying a query or fragment that every
+ *                        caller here would append a path after. Reachable from
  *                        the environment, which the backend `Settings` field
- *                        accepts as a raw string without parsing it.
+ *                        accepts as a raw string without parsing it. See
+ *                        `parseUsablePublicUrl` for the full rule.
  *  - `loopback-default`  a loopback URL while this browser is somewhere else.
  *                        Almost always the shipped compose default
  *                        `${PUBLIC_APP_URL:-http://localhost:8080}` left alone.
@@ -35,16 +38,42 @@ export type PublicAppUrlState =
   | { kind: 'malformed'; value: string }
   | { kind: 'loopback-default'; value: string };
 
-function parseOrigin(url: string): URL | null {
+/**
+ * Is this a value a browser could actually be sent to?
+ *
+ * fix(#1548 review r8): ONE shape rule for `PUBLIC_APP_URL` — an absolute
+ * HTTP(S) URL, with a host, and no query or fragment. The backend states the
+ * same rule in `is_usable_public_origin` (backend/app/core/public_urls.py), and
+ * `__tests__/public-app-url-shape.cases.json` is the single case table both are
+ * tested against, because two independent validators for one setting is exactly
+ * the arrangement that let each side learn about a different invalid shape.
+ *
+ * Each clause earns its place:
+ *
+ *  - SCHEME, checked explicitly rather than inferred from a parse success:
+ *    `new URL('mailto:x')` and `new URL('javascript:alert(1)')` both parse
+ *    happily. On the backend the same values are worse than useless — its
+ *    normalizer prepends `https://` and turns `ftp://maps.example.com` into the
+ *    plausible non-loopback origin `https://ftp:`.
+ *  - HOST, because `https://?x` parses with an empty hostname.
+ *  - NO QUERY OR FRAGMENT, because every caller here APPENDS to this value:
+ *    `${base}/m/${token}` against `https://maps.example.com?tenant=a` puts the
+ *    path inside the query string, and against `...#section` puts it after the
+ *    fragment. Either way the copied link and the iframe src are unopenable.
+ *
+ * Returns the parsed URL so callers can compare origins without parsing twice.
+ */
+function parseUsablePublicUrl(url: string): URL | null {
+  let parsed: URL;
   try {
-    const parsed = new URL(url);
-    // Scheme is checked explicitly rather than inferred from a parse success:
-    // `new URL('mailto:x')` and `new URL('javascript:alert(1)')` both parse.
-    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return null;
-    return parsed;
+    parsed = new URL(url);
   } catch {
     return null;
   }
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return null;
+  if (!parsed.hostname) return null;
+  if (parsed.search || parsed.hash) return null;
+  return parsed;
 }
 
 /**
@@ -73,16 +102,16 @@ export function resolvePublicAppUrl(
   const raw = tileConfig?.public_app_url?.trim().replace(/\/+$/, '');
   if (!raw) return { kind: 'unset' };
 
-  // Parse FIRST, and require the parse to succeed. A previous revision asked
-  // `isLoopbackOrigin()` and read its parse failure as "not loopback, therefore
-  // fine" — a narrower predicate standing in for trust, so `not-a-url` was
-  // handed out in card links and iframe sources. Trust is earned here, never
-  // inherited from another check's failure mode.
-  const parsed = parseOrigin(raw);
+  // Shape FIRST, and it must pass. A previous revision asked `isLoopbackOrigin()`
+  // and read its parse failure as "not loopback, therefore fine" — a narrower
+  // predicate standing in for trust, so `not-a-url` was handed out in card links
+  // and iframe sources. Trust is earned here, never inherited from another
+  // check's failure mode.
+  const parsed = parseUsablePublicUrl(raw);
   if (parsed === null) return { kind: 'malformed', value: raw };
 
   const currentIsLoopback = (() => {
-    const current = parseOrigin(currentOrigin);
+    const current = parseUsablePublicUrl(currentOrigin);
     return current !== null && LOOPBACK_HOSTS.has(current.hostname.toLowerCase());
   })();
 
@@ -150,8 +179,8 @@ export function getLockedPreviewBaseUrl(
 ): string | null {
   const baseUrl = getPublicAppBaseUrl(tileConfig, currentOrigin);
   if (baseUrl === null) return null;
-  const configured = parseOrigin(baseUrl);
-  const current = parseOrigin(currentOrigin);
+  const configured = parseUsablePublicUrl(baseUrl);
+  const current = parseUsablePublicUrl(currentOrigin);
   if (configured === null || current === null) return null;
   return configured.origin === current.origin ? baseUrl : null;
 }

--- a/frontend/src/types/api.generated.ts
+++ b/frontend/src/types/api.generated.ts
@@ -12802,7 +12802,7 @@ export interface components {
             cdn_base_url?: string | null;
             /**
              * Public App Url
-             * @description Browser-facing app URL used for share links and OAuth redirects.
+             * @description Explicitly configured PUBLIC_APP_URL, or null when unset. Never derived from PUBLIC_API_URL or from the request, because a share or embed URL built on a derived value points at a host that does not serve the app.
              */
             public_app_url?: string | null;
             /**

--- a/sdks/python/geolens/models/tile_config_response.py
+++ b/sdks/python/geolens/models/tile_config_response.py
@@ -19,7 +19,9 @@ class TileConfigResponse:
     """
     Attributes:
         cdn_base_url (None | str | Unset): CDN origin URL for tile delivery, if configured.
-        public_app_url (None | str | Unset): Browser-facing app URL used for share links and OAuth redirects.
+        public_app_url (None | str | Unset): Explicitly configured PUBLIC_APP_URL, or null when unset. Never derived
+            from PUBLIC_API_URL or from the request, because a share or embed URL built on a derived value points at a host
+            that does not serve the app.
         public_api_url (None | str | Unset): Externally-reachable API base URL used in OGC self-links.
         public_base_url (None | str | Unset): Deprecated alias for public_api_url. Will be removed in a future release.
         mvt_source_layer_prefix (None | str | Unset): Schema prefix emitted inside vector-tile source-layer names. Null

--- a/sdks/typescript/src/client/types.gen.ts
+++ b/sdks/typescript/src/client/types.gen.ts
@@ -10221,7 +10221,7 @@ export type TileConfigResponse = {
     /**
      * Public App Url
      *
-     * Browser-facing app URL used for share links and OAuth redirects.
+     * Explicitly configured PUBLIC_APP_URL, or null when unset. Never derived from PUBLIC_API_URL or from the request, because a share or embed URL built on a derived value points at a host that does not serve the app.
      */
     public_app_url?: string | null;
     /**


### PR DESCRIPTION
Fixes #1531.

## The bug

Setting `allowed_origins` on an embed token produced a token that delivered nothing to any browser embed. The shared-map endpoint returned zero layers and every tile request came back 403.

Domain locking is enforced in two places, and they disagreed with each other.

`build_embed_frame_ancestors` serves the `/m/{token}` shell with `frame-ancestors 'self' <allowed_origins>`. That is a real, browser-enforced control keyed on the parent page's actual origin, and it works. The API check underneath it accepted only `<allowed_origins>`, with no `'self'` equivalent.

An API subresource request made from inside the embed iframe carries the shell's origin, not the embedder's. The requesting document is our own shell, so a same-origin GET sends no `Origin` header at all and the `Referer` fallback is the shell's own URL. The parent's origin is not on a subresource request. It is visible only on the navigation that loads the iframe, which is exactly where `frame-ancestors` already enforces it.

So `extract_request_origin` returned the GeoLens app's own origin, which is never in `allowed_origins` (the operator puts the customer's domain there), and the check denied. Every request.

## Measured, before

A domain-locked token (`allowed_origins: ["https://customer.example.com"]`) on a public map with a private dataset layer, loaded through `/m/{share}?et={token}` in Chrome. The request headers the browser actually sent on the shared-map call, captured off the wire:

```
x-embed-token: et_...
referer: http://localhost:8080/m/a61mm0d8Kbtl...?et=et_...
```

No `Origin` header. `Referer` is the shell's own URL on our origin.

The frame-policy endpoint for the same token, confirming the `'self'` half exists at the framing layer:

```
content-security-policy: ...; frame-ancestors 'self' https://customer.example.com
x-embed-frame-ancestors: frame-ancestors 'self' https://customer.example.com
```

## The fix

The API check now also accepts our own origin. By the time the shell can run a line of script, `frame-ancestors` has already enforced the domain lock at the document layer.

Our own origin is resolved from configuration: `get_public_app_url` for the configured public app URL, plus, in hosted multi-tenant, `request.state.tenant_public_origin` (which `TenantContextMiddleware` sets only after the Host resolves against the tenant registry). Nothing the caller sends can become "self". The `request` is deliberately **not** forwarded to `get_public_app_url`, because its unconfigured fallback derives an origin from the caller's own `Origin`/`Referer`, which would make every origin "self" and the allowlist vacuous. A test asserts that directly.

The check is kept, not removed. It is correct on the other path: an embed token driven from the customer's own JavaScript rather than through the `/m/` iframe does arrive with `Origin: https://customer.example.com`, and there the allowlist works as designed.

`resolve_embed_scope_for_map` and `validate_embed_token_access` carried separate copies of this policy. They now share one reader, so a change to one cannot leave the sibling on the old rules. The Phase 268 H-31 localhost bypass (`_is_localhost_origin` + `_client_is_loopback`) is unchanged and still covered.

## Measured, after

Identical requests against two containers, one running `main` and one running this branch, both with `PUBLIC_APP_URL=https://maps.acme.test` so our own origin is not localhost and the H-31 dev bypass cannot be mistaken for the fix.

| request | before | after |
| --- | --- | --- |
| shared-map metadata, shell `Referer` | 200, `layers=0` | 200, `layers=1` |
| tile-token batch, shell `Referer` | denied | issued |
| vector tile, shell `Referer` | **403** | **200** |
| tile-token batch, `Origin: https://customer.example.com` | issued | issued |
| shared-map metadata, `Origin: https://customer.example.com` | 200, `layers=1` | 200, `layers=1` |
| tile-token batch, `Origin: https://evil.example.net` | denied | denied |
| shared-map metadata, `Origin: https://evil.example.net` | 200, `layers=0` | 200, `layers=0` |

The same localhost `Referer` against the unfixed container still returns `layers=0` while the fixed one returns `layers=1`, which rules out the H-31 localhost bypass as the cause.

End to end in a real browser, through a stand-in for the nginx `auth_request` wiring that stamps the directive `/api/embed/frame-policy` returns:

- Allowed parent (`http://localhost:8898`, the configured `allowed_origins` entry): the iframe loads and the private layer renders in the layer list.
- Disallowed parent (`http://localhost:8897`): Chrome refuses to frame it. `Framing 'http://localhost:8899/' violates the following Content Security Policy directive: "frame-ancestors 'self' http://localhost:8898". The request has been blocked.`

## Posture change, decided rather than incurred

This widens one path. The decision is deliberate, so it is stated here for a reviewer to argue with instead of discover.

A top-level navigation to the shell, not framed, sends byte-identical headers to the framed case. `Sec-Fetch-Site` on the subresource is `same-origin` either way, so nothing on the request separates them and no API-layer rule can allow the iframe while denying direct navigation. Any fix that makes the iframe work makes direct navigation work.

Before this change, a leaked domain-locked token was useless everywhere, including in the iframe it was minted for. It was tight only by being broken. After it, the token works where it was meant to, the domain restriction is enforced by `frame-ancestors` at the document layer where it actually functions, and direct navigation is gated by possession of the token.

The trade is accepted on the standing SEC-022 position that embed tokens are a private capability: the token is the control, and domain locking is defense in depth layered on top of it. A control that denies every legitimate request is not a control. The same note is in the code so the next reader does not have to rediscover it either.

## Review round 1 (`f3180d0ee`)

Two P2s, both reproduced before being addressed.

**The self-origin lookup could escape as an exception.** Correct, and worse than the report framed it. The lookup reads an AppSetting row, so it is the one part of this check that can fail for reasons unrelated to the decision, and letting that propagate turned a routine deny into a 500 on the tile path. It now denies. Every other denial in this module returns a bool.

The report caught it through the tests, where it had been masked. `tests/test_embed_tokens_origin_bypass.py` run on its own failed both foreign-origin cases with `TypeError: 'coroutine' object is not iterable`, because those tests pass an `AsyncMock` database that reaches `_load_public_url_overrides` on a cold public-URL cache. Run alongside other suites it passed, because an earlier test had primed the module-global cache. My original 124-test run was the batched form, which is why I missed it. That file now patches the lookup, so its cases prove a foreign origin is rejected rather than that the lookup exploded, and every embed suite is now checked in isolation as well as together.

**A deployment that never sets `PUBLIC_APP_URL` resolves the wrong self-origin.** Also correct. `docker-compose.yml:372` and `docker-compose.prod.yml:305` both inject `${PUBLIC_APP_URL:-http://localhost:8080}`, and `.env.example:132` ships the line commented out, so a self-hoster serving `https://maps.example.com` gets a self-origin of `http://localhost:8080` and their domain-locked embeds stay empty. Reproduced live on a third container:

| container | `PUBLIC_APP_URL` | shell `Referer` | result |
| --- | --- | --- | --- |
| this branch | `https://maps.acme.test` | `https://maps.acme.test/m/...` | `layers=1` |
| this branch | `http://localhost:8080` | `https://maps.example.com/m/...` | `layers=0` |

I did not take the "resolve the trusted serving origin without requiring the URL override" half of the suggestion. Every request-derived alternative (`Host`, `X-Forwarded-Host`, `request.url`) is settable by anyone who can point a DNS name at the deployment. An attacker who CNAMEs `evil.com` at the instance would then have `Host` and `Origin` agree on `evil.com`, making their own origin "self" and the lock bypassable by exactly the parties it excludes. That is the same vacuity the fix is built to avoid, arrived at by a different route.

So the denial stands and the misconfiguration is made diagnosable instead of silent. Observed in that container's log:

```
warning  embed_token_domain_lock_denied
  request_origin=https://maps.example.com
  self_origins=['http://localhost:8080']
  allowed_origins=['https://customer.example.com']
  remediation="If this deployment serves the embed shell from request_origin,
               set PUBLIC_APP_URL (or the public_app_url setting) to it. ..."
```

It fires only for a domain-locked token that already missed both the allowlist and the loopback bypass, so it is not on a hot path.

## Tests

`backend/tests/test_embed_domain_lock_self_origin_1531.py`, 28 tests. Every case runs against both readers.

Counterfactuals, both via patch file and `git apply -R`:

- Restoring `main`'s inline checks at both call sites: **6 failed, 17 passed**. The five iframe tests and the hosted-tenant test go red; every foreign-origin denial, both direct-API tests, and the H-31 tests stay green.
- Substituting the rejected design (let the caller supply "self" via `extract_request_origin`): **7 failed, 16 passed**. The four foreign-origin tests, the forged-localhost H-31 test, the single-tenant tenant-state test, and the server-derived guard all go red, in the exact opposite direction.
- Reverting the review-round fix: **5 failed, 31 passed**. Exactly the five new tests go red, including the one that reproduces the `TypeError` shape against a mock database on a cleared public-URL cache.

## Verification

```
cd backend && uv run ruff check .            # All checks passed
cd backend && uv run ruff format --check .   # 1011 files already formatted
uv run pytest tests/test_embed_domain_lock_self_origin_1531.py   # 28 passed
uv run pytest tests/test_rule1_structural.py                     # 6 passed
uv run pytest tests/test_rule2_structural.py                     # 98 passed
uv run pytest tests/test_embed_tokens_csp_no_wildcard.py         # 10 passed
uv run pytest tests/test_layering.py                             # 47 passed
```

Every embed-adjacent suite, each run **in isolation** as well as batched, since the batched form is what hid the P2 above: `test_embed_tokens` 51, `test_embed_tokens_origin_bypass` 8, `test_shared_map_embed_scope` 9, `test_embed_revocation_by_map` 3, `test_embed_token_expiry_cache` 4, `test_builder_audit_p0p1_sharing` 11, `test_tenant_cache_partitioning` 15, `test_embed_tokens_csp_no_wildcard` 10, and the new file 28. All green alone.

`backend/app/modules/embed_tokens/service.py` is 910 lines, under the 1000-line `_MODULE_LOC_CAPS` inclusion threshold, so no ratchet entry is required.

No schema, API, or config changes. Backend only.


