### PR TITLE
fix(cog): honour If-None-Match: * on a COG with no stored digest

### DIFF
--- a/backend/app/modules/catalog/datasets/api/router_export.py
+++ b/backend/app/modules/catalog/datasets/api/router_export.py
@@ -1109,9 +1109,13 @@ async def download_cog(
                 detail="COG has changed since the version you hold",
                 headers={"ETag": etag} if etag is not None else None,
             )
-        if etag is not None and _if_none_match_matches(
-            request.headers.get("if-none-match"), etag
-        ):
+        # fix(#1554): evaluated whatever `etag` is. The old `etag is not None`
+        # guard was the right test for a specific tag and the wrong one for
+        # `*`, which asks whether a current representation exists rather than
+        # which one it is — so a legacy row with no `sha256` answered a
+        # wildcard revalidation with the whole COG. The stat above is what
+        # makes that existence question answerable here.
+        if _if_none_match_matches(request.headers.get("if-none-match"), etag):
             return _cog_not_modified(etag)
 
     # 6. Audit log. user_id may be None for anonymous downloads (KNOWN-01).
@@ -1334,7 +1338,7 @@ def _if_match_passes(if_match: str | None, etag: str | None) -> bool:
     return etag is not None and etag in candidates
 
 
-def _if_none_match_matches(if_none_match: str | None, etag: str) -> bool:
+def _if_none_match_matches(if_none_match: str | None, etag: str | None) -> bool:
     """Does the client already hold this representation? RFC 9110 section 13.1.2.
 
     WEAK comparison, unlike ``If-Range`` above, and the difference is not an
@@ -1342,15 +1346,34 @@ def _if_none_match_matches(if_none_match: str | None, etag: str) -> bool:
     equivalent, while a resumed range needs them byte-identical. The spec picks
     a different comparison function for each, so this route does too.
 
-    ``*`` matches any current representation, which by the time this is called
-    is exactly the one whose ETag was passed in. A list is a list: a client may
-    hold several versions and offer all of them.
+    ``*`` matches any current representation, and fix(#1554) is that it does so
+    even when ``etag`` is None. The section says "if the field value is '*',
+    the condition is false if the origin server has a current representation" —
+    a statement about the RESOURCE, with no clause about the server being able
+    to name it. A row predating the ``sha256`` column has bytes in storage, the
+    caller stat'd them before asking, and answering 200 there transfers a
+    multi-gigabyte COG to tell a cache what it already knew.
+
+    The wildcard is checked before ``etag`` for that reason, and the specific
+    tags after it are still refused when there is nothing to compare: a
+    representation this route holds no entity-tag for matches no entity-tag,
+    so the condition is true and the client gets the bytes it asked for.
+
+    A match is answered 304 unconditionally because this path serves GET and
+    HEAD only (``test_the_cog_download_answers_only_safe_methods`` pins that).
+    The same section makes ``*`` a 412 for a method that would create or
+    replace a representation, which is a different answer this route has no
+    caller for.
+
+    A list is a list: a client may hold several versions and offer all of them.
     """
     if not if_none_match:
         return False
     candidates = [tag.strip() for tag in if_none_match.split(",")]
     if "*" in candidates:
         return True
+    if etag is None:
+        return False
     return any(_without_weak_prefix(tag) == etag for tag in candidates)
 
 
@@ -1358,7 +1381,7 @@ def _without_weak_prefix(tag: str) -> str:
     return tag[2:] if tag.startswith("W/") else tag
 
 
-def _cog_not_modified(etag: str) -> Response:
+def _cog_not_modified(etag: str | None) -> Response:
     """304: the client's copy is current, so send it nothing else.
 
     The ETag goes back per RFC 9110 section 15.4.5, and ``Accept-Ranges``
@@ -1367,11 +1390,18 @@ def _cog_not_modified(etag: str) -> Response:
     starlette's ``init_headers`` skips the length for 304 (and 204) exactly as
     the spec requires, which is why this response does not need the explicit
     header ``_cog_head_response`` has to pass.
+
+    fix(#1554): ``etag`` may be None, and then the 304 carries none. Section
+    15.4.5 asks for the header fields a 200 would have sent, and the 200 for a
+    row with no stored digest sends no validator either (``_cog_headers`` omits
+    it for the same reason). Minting one to fill the slot would be worse than
+    the blank: it would authorize the resume ``_range_bound_to_this_version``
+    refuses on exactly these rows.
     """
-    return Response(
-        status_code=status.HTTP_304_NOT_MODIFIED,
-        headers={"ETag": etag, "Accept-Ranges": "bytes"},
-    )
+    headers = {"Accept-Ranges": "bytes"}
+    if etag is not None:
+        headers["ETag"] = etag
+    return Response(status_code=status.HTTP_304_NOT_MODIFIED, headers=headers)
 
 
 def _cog_etag(raster_asset) -> str | None:

--- a/backend/tests/test_cog_head_ranges_1528.py
+++ b/backend/tests/test_cog_head_ranges_1528.py
@@ -58,6 +58,12 @@ from tests.factories import get_user_id
 # test_range_spanning_multiple_chunks_is_byte_exact).
 _COG_BYTES = bytes(range(256)) * 800  # 204_800 bytes, every byte value present
 
+# The route's registered path, as the app sees it. Asserted against the OpenAPI
+# document by `test_cog_head_stays_out_of_the_openapi_schema`, so a rename that
+# broke `test_the_cog_download_answers_only_safe_methods` breaks that one too
+# rather than leaving a method scan quietly matching nothing.
+_COG_DOWNLOAD_PATH = "/datasets/{dataset_id}/download/cog"
+
 
 async def _raster_dataset(
     session,
@@ -2399,6 +2405,320 @@ async def test_a_remote_cog_publishes_no_validator(
 
 
 # ---------------------------------------------------------------------------
+# fix(#1554): the wildcard, on rows this route can publish no validator for
+# ---------------------------------------------------------------------------
+
+
+async def test_a_wildcard_revalidation_is_304_on_a_row_with_no_digest(
+    client: AsyncClient, admin_auth_header: dict, test_db_session
+):
+    """fix(#1554): ``If-None-Match: *`` asks about existence, not about a digest.
+
+    RFC 9110 section 13.1.2: for GET and HEAD, ``*`` matches when ANY current
+    representation of the target resource exists. Nothing in that sentence is
+    conditional on the server being able to emit an entity-tag, and a 304 does
+    not need to carry one when the 200 it replaces would not have carried one
+    either (section 15.4.5 asks for the header fields the 200 would send).
+
+    fix(#1540 review P2) evaluated ``If-None-Match`` only when the row had a
+    ``sha256`` to compare against, which is the right guard for a specific tag
+    and the wrong one for the wildcard. On a legacy row the client got 200 —
+    multiple gigabytes of COG, transferred to answer a question it had already
+    been told the answer to by its own cache.
+
+    All three shapes, like ``test_if_none_match_answers_304_for_every_request
+    _shape``: section 13.2.2 evaluates If-None-Match ahead of Range, so the
+    ranged request is a 304 too rather than a 206 of a slice.
+    """
+    dataset, raster_asset = await _raster_dataset(test_db_session, sha256=None)
+    await get_storage().put(raster_asset.asset_uri, _COG_BYTES)
+    url = f"/datasets/{dataset.id}/download/cog"
+    wildcard = {**admin_auth_header, "If-None-Match": "*"}
+
+    head = await client.head(url, headers=wildcard)
+    whole = await client.get(url, headers=wildcard)
+    sliced = await client.get(url, headers={**wildcard, "Range": "bytes=0-99"})
+
+    for name, resp in (("HEAD", head), ("GET", whole), ("ranged GET", sliced)):
+        assert resp.status_code == 304, (
+            f"a wildcard revalidating {name} on a digest-less row got "
+            f"{resp.status_code} and {len(resp.content)} bytes; the object "
+            f"exists, so `*` matches it whether or not this route can name it."
+        )
+        assert resp.content == b"", f"the 304 for {name} carried a body"
+        assert "content-length" not in resp.headers, (
+            f"the 304 for {name} carried content-length="
+            f"{resp.headers.get('content-length')!r}"
+        )
+        assert "etag" not in resp.headers, (
+            f"the 304 for {name} carried etag={resp.headers.get('etag')!r}. "
+            f"There is no stored digest to name, and an invented validator "
+            f"would authorize resumes this route cannot vouch for — the same "
+            f"call `test_a_row_with_no_digest_refuses_a_conditional_range` "
+            f"makes about the 200."
+        )
+
+
+async def test_a_wildcard_revalidation_is_304_on_s3_without_a_digest_too(
+    client: AsyncClient, admin_auth_header: dict, test_db_session, s3_storage
+):
+    """The wildcard is answered above the storage branching, so s3 gets it.
+
+    Sibling of ``test_if_none_match_answers_304_on_s3_too``, on the rows that
+    publish no validator. It is worth more here than anywhere else: without it
+    the GET is a 302 the client follows to the bucket, which then bills the
+    whole object as egress to answer a revalidation.
+
+    ``history == []`` is the half that separates the fix from a redirect that
+    happens to end in a 304 somewhere else. Nothing behind that redirect knows
+    about this route's preconditions — MEASURED in
+    ``test_cog_s3_head_wire_1540.py``: a presigned GET ignores ``If-None-Match``
+    outright.
+    """
+    dataset, raster_asset = await _raster_dataset(
+        test_db_session,
+        storage_backend="s3",
+        asset_uri=f"rasters/{uuid.uuid4().hex[:8]}/src.cog.tif",
+        sha256=None,
+    )
+    await s3_storage.put(raster_asset.asset_uri, _COG_BYTES)
+    url = f"/datasets/{dataset.id}/download/cog"
+    wildcard = {**admin_auth_header, "If-None-Match": "*"}
+
+    revalidated = await client.get(url, headers=wildcard, follow_redirects=True)
+    probed = await client.head(url, headers=wildcard, follow_redirects=True)
+
+    assert revalidated.history == [], (
+        f"the wildcard GET was redirected to "
+        f"{[r.headers.get('location') for r in revalidated.history]}; the "
+        f"bucket does not evaluate this route's preconditions, so that "
+        f"redirect ends in the whole COG."
+    )
+    assert revalidated.status_code == 304, (
+        f"a wildcard revalidating GET on s3 returned {revalidated.status_code} "
+        f"and {len(revalidated.content)} bytes"
+    )
+    assert probed.status_code == 304, (
+        f"a wildcard revalidating HEAD on s3 returned {probed.status_code}"
+    )
+
+
+async def test_a_wildcard_is_the_only_tag_that_matches_a_digest_less_row(
+    client: AsyncClient, admin_auth_header: dict, test_db_session
+):
+    """The vacuity guard for the wildcard: everything else still downloads.
+
+    "No digest" must not collapse into "matches anything". A specific tag
+    against a row with no ``sha256`` cannot be compared — RFC 9110 section
+    13.1.2 evaluates If-None-Match with the weak comparison function, and a
+    representation with no entity-tag matches no tag at all — so the condition
+    is true and the client gets the bytes.
+
+    That is the same answer this route gave before fix(#1554), and it is the
+    half a wrong fix breaks: reading "unverifiable" as "unchanged" hands every
+    client holding a stale copy of a legacy COG a 304 forever.
+
+    The weak spelling and the list are here because the wildcard branch runs
+    before both, so a fix that short-circuits too early takes them with it.
+    """
+    dataset, raster_asset = await _raster_dataset(test_db_session, sha256=None)
+    await get_storage().put(raster_asset.asset_uri, _COG_BYTES)
+    url = f"/datasets/{dataset.id}/download/cog"
+
+    shapes = {
+        "a foreign strong tag": '"a-cog-from-last-week"',
+        "a foreign weak tag": 'W/"a-cog-from-last-week"',
+        "a list of them": '"one-from-monday", W/"one-from-tuesday"',
+    }
+    for name, header in shapes.items():
+        resp = await client.get(
+            url, headers={**admin_auth_header, "If-None-Match": header}
+        )
+        assert resp.status_code == 200, (
+            f"If-None-Match with {name} returned {resp.status_code} for a row "
+            f"with no digest. Nothing was compared, so nothing matched, and "
+            f"the client needs the bytes."
+        )
+        assert resp.content == _COG_BYTES, (
+            f"If-None-Match with {name} answered 200 with "
+            f"{len(resp.content)} of {len(_COG_BYTES)} bytes"
+        )
+
+
+async def test_a_wildcard_revalidation_for_bytes_that_are_gone_is_still_404(
+    client: AsyncClient, admin_auth_header: dict, test_db_session
+):
+    """``*`` matches a representation that EXISTS, so the stat still comes first.
+
+    The catalog row can outlive its stored bytes, and the unconditional GET has
+    always answered 404 for that (``test_head_cog_matches_get_on_missing
+    _object``). fix(#1540 review P2) moved the stat above the precondition block
+    so a validator could not talk a cache into keeping a copy of something that
+    is gone; the wildcard has to stay behind that same stat.
+
+    This is the wrong fix that reads most naturally: `*` asks whether a current
+    representation exists, the RasterAsset row looks like the answer, and
+    answering from the row alone turns a deleted object into 304 — the exact
+    lie section 13.2.1's ordering exists to prevent, now reachable without the
+    client knowing any digest at all.
+
+    Sibling of ``test_a_conditional_request_for_bytes_that_are_gone_is_a_404``,
+    which covers the specific-tag spelling on a row that has a digest.
+    """
+    dataset, _ = await _raster_dataset(
+        test_db_session, sha256=None
+    )  # no bytes ever written to storage
+    url = f"/datasets/{dataset.id}/download/cog"
+    wildcard = {**admin_auth_header, "If-None-Match": "*"}
+
+    unconditional = await client.get(url, headers=admin_auth_header)
+    revalidated = await client.get(url, headers=wildcard)
+    probed = await client.head(url, headers=wildcard)
+
+    assert unconditional.status_code == 404, (
+        f"precondition: the plain GET should 404, got {unconditional.status_code}"
+    )
+    assert revalidated.status_code == 404, (
+        f"a wildcard GET answered {revalidated.status_code} for an object that "
+        f"is gone. `*` matches a representation that exists; there is none."
+    )
+    assert probed.status_code == 404, (
+        f"HEAD and GET must agree on a missing object under the wildcard too, "
+        f"got HEAD {probed.status_code} vs GET {revalidated.status_code}"
+    )
+
+
+async def test_the_cog_download_answers_only_safe_methods(client: AsyncClient):
+    """Why ``*`` may be a 304 here at all, pinned as a test.
+
+    RFC 9110 section 13.1.2 gives ``If-None-Match: *`` two different answers.
+    For GET and HEAD a match is 304. For any other method — one that would
+    create or modify a representation — a match is 412, because the client is
+    saying "only do this if it does not already exist".
+
+    This path answers GET and HEAD and nothing else, which is what makes the
+    single unconditional 304 above correct rather than a coincidence. Adding a
+    PUT that reuses ``download_cog``'s precondition block would need the second
+    answer, and would fail here first.
+
+    The walk goes through ``iter_route_contexts`` for the reason
+    ``test_rule1_structural.py`` documents: fastapi's ``include_router`` is
+    lazy, so a scan of ``app.routes`` alone sees a fraction of the table and
+    would answer "no methods at all" for this path — which is why the assertion
+    is written to fail on the empty set rather than pass over it.
+    """
+    from fastapi.routing import iter_route_contexts
+
+    from app.api.main import app
+
+    methods: set[str] = set()
+    for ctx in iter_route_contexts(app.routes):
+        if (ctx.path or ctx.route.path) == _COG_DOWNLOAD_PATH:
+            methods |= set(getattr(ctx.route, "methods", None) or ())
+
+    assert methods == {"GET", "HEAD"}, (
+        f"the COG download path answers {sorted(methods)}. `If-None-Match: *` "
+        f"is answered 304 unconditionally, which RFC 9110 section 13.1.2 only "
+        f"licenses for GET and HEAD."
+    )
+
+
+async def test_an_unverifiable_if_range_on_s3_is_ignored_rather_than_honoured(
+    client: AsyncClient, admin_auth_header: dict, test_db_session, s3_storage
+):
+    """RFC 9110 section 13.1.5 has one answer for a validator that does not match.
+
+    Ignore the Range and serve the complete representation. Not 206 — that is
+    the splice fix(#1540 review P2) closed — and not 412, which the section
+    gives ``If-Range`` no license for at all: unlike ``If-Match`` it is an
+    optimization the server may decline, so refusing the request outright would
+    break a client that was only trying to save bandwidth.
+
+    ``test_a_row_with_no_digest_refuses_a_conditional_range`` makes this call
+    for local storage. The s3 branch decides it in its own code — the bucket
+    cannot be asked to, since a presigned GET answers a non-matching If-Range
+    with a 206 anyway — so "ignore it" has to mean the same thing on both, and
+    here that means NOT redirecting: the client re-sends its Range across the
+    hop and the bucket honours it.
+    """
+    dataset, raster_asset = await _raster_dataset(
+        test_db_session,
+        storage_backend="s3",
+        asset_uri=f"rasters/{uuid.uuid4().hex[:8]}/src.cog.tif",
+        sha256=None,
+    )
+    await s3_storage.put(raster_asset.asset_uri, _COG_BYTES)
+
+    resumed = await client.get(
+        f"/datasets/{dataset.id}/download/cog",
+        headers={
+            **admin_auth_header,
+            "Range": "bytes=100-199",
+            "If-Range": '"whatever-the-client-remembers"',
+        },
+        follow_redirects=True,
+    )
+
+    assert resumed.history == [], (
+        f"the unverifiable resume was redirected to "
+        f"{[r.headers.get('location') for r in resumed.history]}; the client "
+        f"re-sends its Range across a 302 and the bucket answers 206, which is "
+        f"the partial response this branch just decided not to send."
+    )
+    assert resumed.status_code == 200, (
+        f"an If-Range this route cannot check answered {resumed.status_code}; "
+        f"section 13.1.5 says ignore the Range, which is 200 with the whole "
+        f"representation."
+    )
+    assert resumed.content == _COG_BYTES
+    assert "content-range" not in resumed.headers
+
+
+async def test_a_row_with_no_digest_refuses_a_specific_if_match_on_s3_too(
+    client: AsyncClient, admin_auth_header: dict, test_db_session, s3_storage
+):
+    """RFC 9110 section 13.1.1, on the backend whose pass-path is a redirect.
+
+    A specific tag can never match a representation this route holds no entity
+    tag for, so the condition is false and the answer is 412 — the same call
+    ``test_a_row_with_no_digest_refuses_a_specific_if_match_but_allows_star``
+    makes for local storage. ``*`` is the other question, and the object exists,
+    so the request proceeds: on s3 that is the ordinary presigned redirect.
+
+    Both spellings are asserted together because the precondition block sits
+    above the storage branching, and "evaluated for local, skipped for s3" is
+    the shape this route has had to be corrected into twice already.
+    """
+    dataset, raster_asset = await _raster_dataset(
+        test_db_session,
+        storage_backend="s3",
+        asset_uri=f"rasters/{uuid.uuid4().hex[:8]}/src.cog.tif",
+        sha256=None,
+    )
+    await s3_storage.put(raster_asset.asset_uri, _COG_BYTES)
+    url = f"/datasets/{dataset.id}/download/cog"
+
+    specific = await client.get(
+        url,
+        headers={**admin_auth_header, "If-Match": '"a-cog-from-last-week"'},
+        follow_redirects=False,
+    )
+    star = await client.get(
+        url, headers={**admin_auth_header, "If-Match": "*"}, follow_redirects=False
+    )
+
+    assert specific.status_code == 412, (
+        f"a tag this route cannot check returned {specific.status_code} on s3; "
+        f"unverifiable must not mean honoured, and a 302 here hands the "
+        f"precondition to a bucket that does not evaluate it."
+    )
+    assert star.status_code == 302, (
+        f"If-Match: * returned {star.status_code} for an object that exists; "
+        f"the request should proceed to the ordinary redirect."
+    )
+
+
+# ---------------------------------------------------------------------------
 # API surface
 # ---------------------------------------------------------------------------
 
@@ -2411,7 +2731,7 @@ async def test_cog_head_stays_out_of_the_openapi_schema(client: AsyncClient):
     ``headDownloadCog`` to both SDKs and the CLI for no gain.
     """
     spec = (await client.get("/openapi.json")).json()
-    methods = spec["paths"]["/datasets/{dataset_id}/download/cog"]
+    methods = spec["paths"][_COG_DOWNLOAD_PATH]
 
     assert set(methods) == {"get"}, (
         f"The COG download path publishes {sorted(methods)}; the HEAD route "

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -3478,7 +3478,19 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # stat is handed down through _cog_size_once so a conditional request that
     # goes on to transfer bytes still measures once, and _managed_key names the
     # tenant-key seam the block now crosses in a second place.
-    "backend/app/modules/catalog/datasets/api/router_export.py": 1656,
+    #
+    # fix(#1554): +30, and 3 of them are code. `If-None-Match: *` is evaluated
+    # whatever the row's digest is, because RFC 9110 section 13.1.2 makes the
+    # wildcard a question about whether a representation EXISTS rather than
+    # about which one it is — so a row predating the sha256 column answered a
+    # revalidation by transferring the whole COG. The rest is the reasoning
+    # this route keeps needing on hand: why the wildcard is checked before the
+    # digest and the specific tags after it, why a 304 with no ETag is the
+    # right answer rather than a gap to fill, and why an unconditional 304 is
+    # licensed here at all (this path serves GET and HEAD, and the section
+    # gives `*` a different answer for anything that would create a
+    # representation). Cap 1656 -> 1686, exact.
+    "backend/app/modules/catalog/datasets/api/router_export.py": 1686,
     # fix(#1548 review P2): crossed the inclusion threshold. The growth is
     # assert_domain_lock_is_enforceable — the write-side precondition that
     # refuses a domain lock this deployment could never enforce, because


### PR DESCRIPTION
`RasterAsset` rows that predate the `sha256` column carry no digest, so `_cog_etag`
returns None and this route publishes no validator for them. The precondition block
#1540 landed read that as "nothing to compare against" and skipped `If-None-Match`
outright:

```python
if etag is not None and _if_none_match_matches(request.headers.get("if-none-match"), etag):
    return _cog_not_modified(etag)
```

That is the right guard for a specific tag and the wrong one for `*`. RFC 9110
§13.1.2 defines the wildcard as a question about the resource: "if the field value
is `*`, the condition is false if the origin server has a current representation
for the target resource." No clause about the server being able to *name* that
representation. A client revalidating a legacy COG with `If-None-Match: *` was
answered 200 and handed the whole object back. For a multi-gigabyte raster that is
the entire cost the header exists to save.

Three lines of code:

1. the wildcard is evaluated whatever `etag` is;
2. a specific tag against a digest-less row still gets the bytes, because a
   representation this route holds no entity-tag for matches no entity-tag, so the
   condition is true;
3. the 304 carries no ETag when the 200 it replaces would not have carried one
   either. §15.4.5 asks for the header fields the 200 would send, and `_cog_headers`
   omits the validator on these rows for its own reasons. Minting one to fill the
   slot would be worse than leaving it blank: it would authorize the resume
   `_range_bound_to_this_version` deliberately refuses here.

## The ordering matters, and it is the wrong fix that reads most naturally

`*` matches a representation that **exists**. A catalog row can outlive its stored
bytes, and the unconditional GET has always answered 404 for that, so answering the
wildcard from the row alone would tell a cache to keep serving a representation that
is gone. #1540's last round moved the stat above the precondition block for exactly
this reason (§13.2.1 puts preconditions after the normal request checks); the
wildcard stays behind it, and
`test_a_wildcard_revalidation_for_bytes_that_are_gone_is_still_404` fails if anyone
hoists it.

The unconditional 304 is licensed because this path serves GET and HEAD and nothing
else. §13.1.2 gives `*` the other answer, 412, for a method that would create or
replace a representation. `test_the_cog_download_answers_only_safe_methods` walks
the flattened route table so a future PUT reusing this block fails there before it
can inherit the wrong one.

## The other two conditionals were checked and left alone

Both were already right, so this PR adds their missing s3 coverage rather than
changing them.

**If-Match, §13.1.1.** `*` passes on a digest-less row (a representation exists), a
specific tag is 412 (this route holds no entity tag, so nothing can match, and
unverifiable is not a pass). `test_a_row_with_no_digest_refuses_a_specific_if_match_but_allows_star`
covered local storage; the s3 half is new, because the s3 pass-path is a presigned
redirect and "evaluated for local, skipped for s3" is a shape this route has had to
be corrected into twice.

**If-Range, §13.1.5.** A validator this route cannot check means ignore the Range
and serve the complete representation with 200. Never a 206, and never a 412, which
the section gives `If-Range` no license for at all: it is an optimization a server
may decline, so refusing outright would break a client that was only trying to save
bandwidth. `test_a_row_with_no_digest_refuses_a_conditional_range` covered local; on
s3 "ignore it" additionally has to mean *not redirecting*, since the client re-sends
its Range across the hop and the bucket honours it. That is asserted with
`history == []`.

## Every reader of the two values

Per the wave protocol, the values are the published validator and the object's
existence, and these are all the places either is read.

- `_cog_headers` (200, 206, HEAD) and the 416 and 412 handlers already omit the ETag
  when there is none. Unchanged.
- `_cog_not_modified` did not, and now does. It was the only reader that assumed a
  non-None validator.
- `_if_match_passes` and `_range_bound_to_this_version` already took `str | None`.
  Unchanged.
- The audit row: a 304 writes none, which is the documented rule (nothing was
  transferred, same call HEAD makes). Legacy rows now reach that path, so a wildcard
  revalidation on one stops writing a `dataset.download_cog` row. It was never a
  download, and it stops being logged as one.
- CORS: no header name is added or removed, and `test_cors_range_headers_1540.py`
  re-derives the coupling from the route's own source and passes.
- The object store never sees a 304 request. It is answered before the storage
  branching, so nothing about the bucket's own validators is involved.
- nginx adds no ETag on `/api/` and strips none of these headers (established in
  #1540, unchanged here).
- Future readers: if the digests are ever backfilled onto these rows, the wildcard
  path keeps working and the 304 simply starts carrying an ETag again. Nothing here
  depends on `sha256` staying NULL.

## Items from #1554

Done: the one deferred item, plus the If-Match and If-Range audits above.

Left out, with reasons:

- **The s3 "ignore the Range" branch proxies the whole object through the API.** Real,
  but it is #1540's design and not specific to this issue: any foreign `If-Range`
  selects it on any row, digest or no digest. The alternative is a redirect the
  bucket answers with a 206 of whatever it currently holds, which is the splice
  #1540 exists to prevent. Changing it means either serving every s3 range from this
  process or publishing the bucket's ETag, both larger than #1554.
- **Variant-specific validators and Last-Modified.** #1540 declined both on the
  record (a `Vary` story for the first, one-second granularity for the second) and
  nothing in the wildcard case changes that reasoning.
- **#1532**, cached export artifacts, is a different route.

`openapi.json` does not move. The HEAD route is still `include_in_schema=False` and
the published GET description is untouched, so neither SDK nor the CLI churns.

## Verification

`test_layering.py` raises `router_export.py` 1656 to 1686 in this commit, exact, with
the reason in the comment. Three of the 30 lines are code.

Red, with the fix reverted:

```
FAILED test_a_wildcard_revalidation_is_304_on_a_row_with_no_digest
E  AssertionError: a wildcard revalidating HEAD on a digest-less row got 200 and 0
   bytes; the object exists, so `*` matches it whether or not this route can name it.
E  assert 200 == 304

FAILED test_a_wildcard_revalidation_is_304_on_s3_without_a_digest_too
E  AssertionError: the wildcard GET was redirected to
   ['https://cog-1540.s3.amazonaws.com/rasters/8ffacfa7/src.cog.tif?AWSAccessKeyId=...'];
   the bucket does not evaluate this route's preconditions, so that redirect ends in
   the whole COG.
E  assert [<Response [302 Found]>] == []

2 failed, 6 passed
```

The other five new tests pin behaviour this PR did not change, so there is no fix to
revert for them. Each was checked against the wrong fix it exists to catch, by
mutating the source and confirming it goes red:

```
# _if_none_match_matches: `if etag is None: return True`  (unverifiable = unchanged)
FAILED test_a_wildcard_is_the_only_tag_that_matches_a_digest_less_row
E  AssertionError: If-None-Match with a foreign strong tag returned 304 for a row
   with no digest. Nothing was compared, so nothing matched, and the client needs
   the bytes.

# download_cog: answer the wildcard from the row, above the stat
FAILED test_a_wildcard_revalidation_for_bytes_that_are_gone_is_still_404
E  AssertionError: a wildcard GET answered 304 for an object that is gone.
   `*` matches a representation that exists; there is none.

# _range_bound_to_this_version: `if etag is None: return True`  (cannot check, honour it)
FAILED test_a_row_with_no_digest_refuses_a_conditional_range
E  AssertionError: a conditional range with nothing to check against returned 206;
   unverifiable must not mean honoured.
FAILED test_an_unverifiable_if_range_on_s3_is_ignored_rather_than_honoured
E  AssertionError: the unverifiable resume was redirected to [...]; the client
   re-sends its Range across a 302 and the bucket answers 206, which is the partial
   response this branch just decided not to send.

# _this_service_owns_the_bytes: `== "local"`  (preconditions skipped for s3)
FAILED test_a_row_with_no_digest_refuses_a_specific_if_match_on_s3_too
E  AssertionError: a tag this route cannot check returned 302 on s3; unverifiable
   must not mean honoured, and a 302 here hands the precondition to a bucket that
   does not evaluate it.
FAILED test_head_cog_on_s3_is_answered_from_object_metadata
FAILED test_if_none_match_answers_304_on_s3_too
FAILED test_s3_keeps_redirecting_everything_that_is_not_a_stale_resume
FAILED test_a_wildcard_revalidation_is_304_on_s3_without_a_digest_too
```

`test_the_cog_download_answers_only_safe_methods` demonstrated its own failure mode
on the first run: written against `app.routes` it reported `answers []`, because
fastapi's `include_router` is lazy. It goes through `iter_route_contexts` now, the
way `test_rule1_structural.py` does, and the assertion is written so an empty match
fails rather than passes.

Green:

```
$ cd backend && uv run pytest tests/test_cog_head_ranges_1528.py -q
82 passed in 52.37s

$ uv run pytest tests/test_cog_head_ranges_1528.py tests/test_cors_range_headers_1540.py \
    tests/test_cog_vsicurl_1528.py tests/test_storage_get_stream.py \
    tests/test_rule1_structural.py tests/test_rule2_structural.py -q
203 passed in 63.46s

$ uv run pytest tests/test_layering.py -q
47 passed in 9.13s

$ uv run ruff check . && uv run ruff format --check .
All checks passed!
1024 files already formatted

$ PYTHONPATH=. uv run python scripts/dump_openapi.py --check
EXIT=0
```

`test_cog_s3_head_wire_1540.py` still skips its four cases without a live S3 endpoint,
as designed.

Closes #1554
