### PR TITLE
fix(jobs): close a backfill's audit trail from the two settlers that still skip it

### DIFF
--- a/backend/app/modules/admin/backfill_jobs.py
+++ b/backend/app/modules/admin/backfill_jobs.py
@@ -440,6 +440,22 @@ async def _recover_unsettled(
         if observed is not None and observed.status in _TERMINAL_STATUSES:
             # Settled already. Whether by this run's own committed write or by
             # another actor, the trail must describe what the row says.
+            #
+            # fix(#1556 review, codex P2): status-matching is deliberately
+            # enough HERE, unlike in `_undispatched_settle_write_landed`, and
+            # the difference is worth stating because the two reads look
+            # identical. This one is reached only after this worker took the
+            # delivery, so "did the operation run at all" is already answered.
+            # `complete` has exactly one producer for a backfill row — this
+            # attempt's own fenced `_finalize` — so matching it proves
+            # authorship. `failed` has several producers, but every one of
+            # them records the same `outcome`, differing only in `error_code`,
+            # and each is a true description of a run that ended without
+            # success. Where they do differ the residual imprecision points
+            # the safe way: `worker_cancelled` warns that a force run's
+            # vectors may already be gone, which is the conservative claim.
+            # The dispatch cleanup had neither property, which is why it needs
+            # evidence of its own write rather than a matching status.
             state.row_attempted = True
             state.row_applied = observed.status == state.status
             if not state.row_applied:
@@ -494,8 +510,26 @@ async def _fail_undispatched_pending_row(job_uuid: uuid.UUID) -> bool:
         return bool(result.rowcount)
 
 
-async def _undispatched_row_was_failed(job_uuid: uuid.UUID) -> bool:
-    """Ask the row whether the lost write landed, on a fresh connection.
+async def _undispatched_settle_write_landed(job_uuid: uuid.UUID) -> bool:
+    """Ask the row for evidence of THIS write, on a fresh connection.
+
+    fix(#1556 review, codex P2): observing `status == "failed"` is observing
+    the state this write would have produced, not evidence that it produced
+    it — and `failed` is a state four other actors also write. The reachable
+    case: the dispatch DID land, a worker claimed the job and finalized it
+    `failed`, and only then was the request cancelled. The fenced update
+    matches nothing (the row is no longer `pending`) and its acknowledgement
+    is lost as well, so a status-only read calls the WORKER's failure this
+    cleanup's write and records `dispatch_cancelled` — which says the run
+    never started and nothing was deleted, over a force regenerate that ran
+    and failed after deleting every vector. Terminal entries are unique per
+    job id (migration 0051), so that entry then refuses the worker's real
+    `backfill_failed`: a lie that also evicts the truth.
+
+    ``UNDISPATCHED_RUN_MESSAGE`` is written at exactly one site, this one, and
+    once the row is terminal no other writer can overwrite it (every one of
+    them is fenced on a live status). So it is a marker only this write can
+    have left, which is the fact the caller actually needs.
 
     Bounded separately, like ``_release_caller_transaction``: this runs during
     a shutdown that has already lost one database round trip, and a second one
@@ -506,12 +540,11 @@ async def _undispatched_row_was_failed(job_uuid: uuid.UUID) -> bool:
     async def _read() -> bool:
         async with async_session() as fresh:
             observed = await fresh.get(IngestJob, job_uuid)
-        # `failed` is the status THIS write produces. Any other terminal status
-        # is somebody else's decision about the row, and a live one means the
-        # write did not land — in both cases the trail belongs to whoever owns
-        # the row now, which is the same rule `_recover_unsettled` applies at
-        # the other end of the run.
-        return observed is not None and observed.status == "failed"
+        return (
+            observed is not None
+            and observed.status == "failed"
+            and observed.error_message == UNDISPATCHED_RUN_MESSAGE
+        )
 
     return await asyncio.wait_for(_read(), timeout=5)
 
@@ -542,7 +575,10 @@ async def settle_undispatched_run(
     ``failed``, which every sweeper skips because it is terminal. Nothing
     would ever have closed the trail, so the run would keep ``requested`` as
     its last word over a job the database records as failed. Same rule as
-    ``_recover_unsettled``: when the answer is lost, read the row.
+    ``_recover_unsettled``: when the answer is lost, read the row — and read
+    it for evidence of THIS write rather than for the state this write would
+    have produced, because ``failed`` is a state four other actors also
+    reach. See ``_undispatched_settle_write_landed``.
     """
     try:
         settled = await _fail_undispatched_pending_row(job_uuid)
@@ -552,12 +588,13 @@ async def settle_undispatched_run(
             job_id=audit_context["job_id"],
             exc_info=True,
         )
-        settled = await _undispatched_row_was_failed(job_uuid)
+        settled = await _undispatched_settle_write_landed(job_uuid)
     if not settled:
         # A worker took it, or the lost write never landed after all. Leave
-        # both records to whoever owns the row now — for a row still
-        # ``pending`` that is the stale-pending sweep, which closes the status
-        # and the trail in one transaction.
+        # both records to whoever owns the row now — a worker that claimed the
+        # delivery closes its own trail, and a row still ``pending`` is closed
+        # by the stale-pending sweep, which writes the status and the entry in
+        # one transaction.
         logger.info(
             "embedding_backfill_dispatch_cancel_found_run_in_progress",
             job_id=audit_context["job_id"],

--- a/backend/app/modules/admin/backfill_jobs.py
+++ b/backend/app/modules/admin/backfill_jobs.py
@@ -470,6 +470,52 @@ async def _recover_unsettled(
         )
 
 
+UNDISPATCHED_RUN_MESSAGE = (
+    "Embedding backfill was cancelled before it could be queued. "
+    "Nothing was deleted; start the backfill again."
+)
+
+
+async def _fail_undispatched_pending_row(job_uuid: uuid.UUID) -> bool:
+    """Fail the still-``pending`` row and report whether it took the update."""
+    from app.core.db import async_session
+
+    async with async_session() as session:
+        result = await session.execute(
+            update(IngestJob)
+            .where(IngestJob.id == job_uuid, IngestJob.status == "pending")
+            .values(
+                status="failed",
+                completed_at=datetime.now(timezone.utc),
+                error_message=UNDISPATCHED_RUN_MESSAGE,
+            )
+        )
+        await session.commit()
+        return bool(result.rowcount)
+
+
+async def _undispatched_row_was_failed(job_uuid: uuid.UUID) -> bool:
+    """Ask the row whether the lost write landed, on a fresh connection.
+
+    Bounded separately, like ``_release_caller_transaction``: this runs during
+    a shutdown that has already lost one database round trip, and a second one
+    hanging must not extend the drain.
+    """
+    from app.core.db import async_session
+
+    async def _read() -> bool:
+        async with async_session() as fresh:
+            observed = await fresh.get(IngestJob, job_uuid)
+        # `failed` is the status THIS write produces. Any other terminal status
+        # is somebody else's decision about the row, and a live one means the
+        # write did not land — in both cases the trail belongs to whoever owns
+        # the row now, which is the same rule `_recover_unsettled` applies at
+        # the other end of the run.
+        return observed is not None and observed.status == "failed"
+
+    return await asyncio.wait_for(_read(), timeout=5)
+
+
 async def settle_undispatched_run(
     job_uuid: uuid.UUID, *, audit_context: dict[str, Any]
 ) -> None:
@@ -488,25 +534,30 @@ async def settle_undispatched_run(
     after all — the dispatch may well have reached the queue before the
     cancellation landed, which is precisely why this is fenced rather than
     unconditional.
-    """
-    from app.core.db import async_session
 
-    async with async_session() as session:
-        result = await session.execute(
-            update(IngestJob)
-            .where(IngestJob.id == job_uuid, IngestJob.status == "pending")
-            .values(
-                status="failed",
-                completed_at=datetime.now(timezone.utc),
-                error_message=(
-                    "Embedding backfill was cancelled before it could be queued. "
-                    "Nothing was deleted; start the backfill again."
-                ),
-            )
+    fix(#1556): the settle's own commit is the last awaited commit on this
+    lifecycle that still sat outside the recovery boundary. It runs under the
+    cancellation that triggered it, so losing its acknowledgement is the
+    ordinary case rather than the exotic one — and the row it leaves behind is
+    ``failed``, which every sweeper skips because it is terminal. Nothing
+    would ever have closed the trail, so the run would keep ``requested`` as
+    its last word over a job the database records as failed. Same rule as
+    ``_recover_unsettled``: when the answer is lost, read the row.
+    """
+    try:
+        settled = await _fail_undispatched_pending_row(job_uuid)
+    except BaseException:  # broad: a lost acknowledgement is the case recovered here
+        logger.warning(
+            "embedding_backfill_dispatch_settle_unacknowledged",
+            job_id=audit_context["job_id"],
+            exc_info=True,
         )
-        await session.commit()
-    if not result.rowcount:
-        # A worker took it. Leave both records to whoever owns it now.
+        settled = await _undispatched_row_was_failed(job_uuid)
+    if not settled:
+        # A worker took it, or the lost write never landed after all. Leave
+        # both records to whoever owns the row now — for a row still
+        # ``pending`` that is the stale-pending sweep, which closes the status
+        # and the trail in one transaction.
         logger.info(
             "embedding_backfill_dispatch_cancel_found_run_in_progress",
             job_id=audit_context["job_id"],

--- a/backend/app/platform/jobs/router.py
+++ b/backend/app/platform/jobs/router.py
@@ -784,6 +784,9 @@ __all__ = [
     "TemporalParseKey",
     "_RECHECK_TRANSFER_MARGIN_SECONDS",
     "_reap_stale_generation_storage",
+    # fix(#1556): the worker's startup recovery settles the same rows this
+    # module's sweep does, so it needs the same helper through the same façade.
+    "audit_settled_embedding_backfill",
     "fail_stale_jobs",
     "get_retry_capability",
     "post_expiry_sweep_after_seconds",

--- a/backend/app/platform/jobs/worker.py
+++ b/backend/app/platform/jobs/worker.py
@@ -78,7 +78,10 @@ async def _recover_stale_jobs_for_current_scope() -> None:
     """
     from app.core.db import async_session
     from app.platform.jobs.models import IngestJob
-    from app.platform.jobs.router import JOB_TIMEOUT_SECONDS
+    from app.platform.jobs.router import (
+        JOB_TIMEOUT_SECONDS,
+        audit_settled_embedding_backfill,
+    )
 
     now = datetime.now(timezone.utc)
     stale_cutoff = now - timedelta(seconds=JOB_TIMEOUT_SECONDS)
@@ -130,6 +133,24 @@ async def _recover_stale_jobs_for_current_scope() -> None:
                 "Recovered stale running job",
                 job_id=str(job.id),
             )
+            # fix(#1556): this pass is the FOURTH actor that can settle an
+            # embedding backfill row, and #1550 taught only three of them
+            # (the worker's own exits, the status poll, the lifespan sweep)
+            # to close the audit trail. It is also the one that matters most
+            # for the case the trail exists for: after a hard kill the row is
+            # usually reached by the restarted worker's startup pass, not by
+            # the 5-minute lifespan sweep, and once this pass has made the row
+            # terminal no later sweep will look at it again. Emitted on this
+            # session so the status change and the entry commit as one, the
+            # same rule `fail_stale_jobs` follows. A no-op for every other
+            # kind of job.
+            await audit_settled_embedding_backfill(
+                session,
+                job_id=job.id,
+                user_metadata=job.user_metadata,
+                created_by=job.created_by,
+                error_code="worker_lost",
+            )
 
         # Recover orphaned pending jobs (never queued).
         # fix(#1235 review r2): through the shared clauses, which this site
@@ -160,6 +181,18 @@ async def _recover_stale_jobs_for_current_scope() -> None:
             log.warning(
                 "Recovered orphaned pending job",
                 job_id=str(job.id),
+            )
+            # fix(#1556): the other half, same reason. A backfill whose
+            # dispatch never landed is `pending` with no queue row, which is
+            # exactly what this clause reaps — and the unique index counts
+            # pending, so the row is holding the single active-backfill slot
+            # while its trail still reads `requested`.
+            await audit_settled_embedding_backfill(
+                session,
+                job_id=job.id,
+                user_metadata=job.user_metadata,
+                created_by=job.created_by,
+                error_code="never_started",
             )
 
         # GAP-002: sweep VRT assets stuck in status='regenerating' past the timeout.

--- a/backend/tests/test_embedding_backfill_queue_1542.py
+++ b/backend/tests/test_embedding_backfill_queue_1542.py
@@ -2004,6 +2004,110 @@ async def test_a_dispatch_settle_that_lost_its_answer_and_its_write_audits_nothi
     assert terminal == [], f"the settle claimed a run it did not settle: {terminal}"
 
 
+@pytest.mark.anyio
+async def test_a_lost_ack_does_not_claim_a_failure_another_actor_wrote(
+    client: AsyncClient,
+    admin_auth_header: dict,
+    test_db_session: AsyncSession,
+    monkeypatch,
+):
+    """Read the row for evidence of YOUR write, not for the state you'd produce.
+
+    The dispatch DID land. A worker claimed the job, the backfill failed, and
+    `_finalize` committed `failed` — and only then was the request cancelled.
+    The settle's fenced update matches nothing, because the row is no longer
+    `pending`, and its acknowledgement is lost as well. A status-only read then
+    calls the worker's failure this cleanup's write and records
+    `dispatch_cancelled`, which says the run never started and nothing was
+    deleted, over a force regenerate that ran and failed after deleting every
+    vector.
+
+    Terminal entries are unique per job id, so that entry does not merely sit
+    alongside the truth. It evicts it: the worker's real `backfill_failed` is
+    refused by the index and swallowed. The last two assertions are that
+    eviction, driven rather than reasoned about — the worker's own entry is
+    held until after the cleanup has had its chance, which is exactly the
+    window between `_finalize`'s commit and `_emit_terminal_audit`.
+    """
+
+    async def _provider_is_down(session, *, force=False):
+        raise RuntimeError("provider down")
+
+    monkeypatch.setattr(backfill_module, "backfill_embeddings", _provider_is_down)
+
+    real_terminal_audit = backfill_jobs._emit_terminal_audit
+    held: dict = {}
+
+    async def _hold_the_workers_terminal_audit(**kwargs):
+        # First call is the worker's. Its row write has committed; its own
+        # entry has not landed yet, which is the live window.
+        if not held:
+            held.update(kwargs)
+            return
+        await real_terminal_audit(**kwargs)
+
+    monkeypatch.setattr(
+        backfill_jobs, "_emit_terminal_audit", _hold_the_workers_terminal_audit
+    )
+
+    settles = {"n": 0}
+    real_fail = backfill_jobs._fail_undispatched_pending_row
+
+    async def _matches_nothing_then_loses_the_answer(job_uuid):
+        settles["n"] += 1
+        applied = await real_fail(job_uuid)
+        assert applied is False, "the row was still pending — wrong arrangement"
+        raise asyncio.CancelledError()
+
+    monkeypatch.setattr(
+        backfill_jobs,
+        "_fail_undispatched_pending_row",
+        _matches_nothing_then_loses_the_answer,
+    )
+
+    async def _worker_finalizes_it_then_the_request_is_cancelled(_task, /, **kwargs):
+        # The delivery genuinely reached a worker, which claimed the job and
+        # committed `failed`. Only then does the request die.
+        await run_embedding_backfill(**kwargs)
+        raise asyncio.CancelledError()
+
+    with patch.object(
+        admin_router,
+        "defer_async_with_tenant",
+        AsyncMock(side_effect=_worker_finalizes_it_then_the_request_is_cancelled),
+    ):
+        raised: BaseException | None = None
+        try:
+            await client.post(_FORCE_URL, headers=admin_auth_header)
+        except BaseException as exc:  # noqa: BLE001 - transport re-wrap
+            raised = exc
+        assert raised is not None, "the cancellation did not propagate"
+
+    settled = await _latest_backfill_row(test_db_session)
+    job_id = str(settled.id)
+    # Non-vacuity: the row is terminal, and it is the WORKER's terminal write —
+    # the same status this cleanup's write would have produced, under a
+    # different message.
+    assert settled.status == "failed"
+    assert settled.error_message == backfill_jobs.BACKFILL_FAILED_MESSAGE
+    assert settles["n"] == 1, "the dispatch settle never ran"
+    assert held, "the worker never reached its terminal audit"
+
+    terminal = await _terminal_audit_entries(client, admin_auth_header, job_id)
+    assert not any(
+        e["details"].get("error_code") == "dispatch_cancelled" for e in terminal
+    ), f"the cleanup claimed a failure the worker wrote: {terminal}"
+
+    # The worker's held entry now lands, which it cannot do if the cleanup took
+    # the one terminal slot for this run.
+    await real_terminal_audit(**held)
+    terminal = await _terminal_audit_entries(client, admin_auth_header, job_id)
+    assert len(terminal) == 1, terminal
+    assert terminal[0]["details"]["error_code"] == "backfill_failed", (
+        f"the run's real outcome was evicted by the dispatch cleanup: {terminal}"
+    )
+
+
 # ---------------------------------------------------------------------------
 # The fourth actor: the worker's own startup recovery (#1556)
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_embedding_backfill_queue_1542.py
+++ b/backend/tests/test_embedding_backfill_queue_1542.py
@@ -117,6 +117,55 @@ async def _in_flight_job(session: AsyncSession, *, force: bool = True) -> Ingest
     return job
 
 
+async def _stale_job(
+    session: AsyncSession, *, status: str, backfill: bool
+) -> IngestJob:
+    """A job the shared sweep settles: abandoned `running`, or old `pending`.
+
+    Both halves of the pass have their own UPDATE, their own message and their
+    own audit call site, so a fix applied to one of them says nothing about the
+    other.
+    """
+    old = datetime.now(timezone.utc) - timedelta(hours=3)
+    job = IngestJob(
+        source_filename="embedding-backfill" if backfill else "ordinary-upload.geojson",
+        file_path="",
+        created_by=await get_user_id(session, "admin"),
+        status=status,
+        created_at=old,
+        started_at=old if status == "running" else None,
+        heartbeat_at=old if status == "running" else None,
+        user_metadata=(
+            {
+                EMBEDDING_BACKFILL_METADATA_KEY: {
+                    "force": True,
+                    "operation_id": f"sweep-pin-{uuid.uuid4().hex[:8]}",
+                }
+            }
+            if backfill
+            else {"file_type": "vector"}
+        ),
+    )
+    session.add(job)
+    await session.commit()
+    await session.refresh(job)
+    return job
+
+
+async def _audit_entries_naming(session: AsyncSession, job_id: str) -> int:
+    """How many audit rows of ANY action name this job."""
+    from app.modules.audit.models import AuditLog
+
+    session.expire_all()
+    return (
+        await session.execute(
+            select(func.count())
+            .select_from(AuditLog)
+            .where(AuditLog.details["job_id"].astext == job_id)
+        )
+    ).scalar_one()
+
+
 async def _load_job(session: AsyncSession, job_id) -> IngestJob:
     session.expire_all()
     job = await session.get(IngestJob, uuid.UUID(str(job_id)))
@@ -1433,53 +1482,56 @@ async def test_a_status_poll_that_settles_a_dead_run_also_closes_the_trail(
 
 
 @pytest.mark.anyio
-async def test_the_sweeper_does_not_audit_ordinary_ingest_jobs(
+@pytest.mark.parametrize(
+    "job_status,error_code",
+    [("running", "worker_lost"), ("pending", "never_started")],
+)
+async def test_the_shared_sweep_settles_an_ingest_job_without_auditing_it(
     client: AsyncClient,
     admin_auth_header: dict,
     test_db_session: AsyncSession,
+    job_status: str,
+    error_code: str,
 ):
-    """The helper is a no-op for every other kind of job.
+    """The sweep is shared; only the backfill semantics were taught to it.
 
     A blanket "audit whatever the sweep touched" would put embedding-backfill
-    entries over uploads, which is a different fabricated record.
+    entries over uploads, which is a different fabricated record. An ordinary
+    ingest job's own semantics on this path are "no audit entry at all" — a
+    background sweep is not an operator action, and `embedding.backfill` is the
+    only action this pass can write — so the assertion is that nothing in the
+    log names the upload.
+
+    A real backfill is swept in the SAME pass as the counterfactual. Without it
+    "no entries appeared for the upload" would hold just as well in a build
+    where the audit hook never fires at all, which is the opposite bug and the
+    one #1550 fixed; with it, the pass has to pick one row and not the other.
+    Both halves of the sweep are exercised because each has its own UPDATE,
+    its own message and its own call site.
     """
-    from app.modules.audit.models import AuditLog
     from app.platform.jobs.sweep import fail_stale_jobs
 
-    stale = IngestJob(
-        source_filename="ordinary-upload.geojson",
-        file_path="",
-        created_by=await get_user_id(test_db_session, "admin"),
-        status="running",
-        started_at=datetime.now(timezone.utc) - timedelta(hours=3),
-        heartbeat_at=datetime.now(timezone.utc) - timedelta(hours=3),
-        user_metadata={"file_type": "vector"},
-    )
-    test_db_session.add(stale)
-    await test_db_session.commit()
-    await test_db_session.refresh(stale)
+    upload = await _stale_job(test_db_session, status=job_status, backfill=False)
+    backfill = await _stale_job(test_db_session, status=job_status, backfill=True)
+    upload_id, backfill_id = str(upload.id), str(backfill.id)
 
-    before = (
-        await test_db_session.execute(
-            select(func.count())
-            .select_from(AuditLog)
-            .where(AuditLog.action == "embedding.backfill")
-        )
-    ).scalar_one()
+    assert await _audit_entries_naming(test_db_session, upload_id) == 0
 
     await fail_stale_jobs(test_db_session)
 
-    settled = await _load_job(test_db_session, stale.id)
-    # Non-vacuity: the sweep really did settle a row, it just was not a backfill.
-    assert settled.status == "failed"
-    after = (
-        await test_db_session.execute(
-            select(func.count())
-            .select_from(AuditLog)
-            .where(AuditLog.action == "embedding.backfill")
-        )
-    ).scalar_one()
-    assert after == before
+    # Non-vacuity: the pass really settled BOTH rows, so both had an outcome to
+    # record and exactly one of them should have one recorded.
+    assert (await _load_job(test_db_session, upload_id)).status == "failed", (
+        "the sweep no longer closes an ordinary ingest job it used to close"
+    )
+    assert (await _load_job(test_db_session, backfill_id)).status == "failed"
+
+    assert await _audit_entries_naming(test_db_session, upload_id) == 0, (
+        "the shared sweep wrote an audit entry for an ordinary upload"
+    )
+    terminal = await _terminal_audit_entries(client, admin_auth_header, backfill_id)
+    assert len(terminal) == 1, terminal
+    assert terminal[0]["details"]["error_code"] == error_code
 
 
 @pytest.mark.anyio
@@ -1804,3 +1856,210 @@ async def test_a_cancelled_dispatch_does_not_leave_the_slot_held(
     with patch.object(admin_router, "defer_async_with_tenant", AsyncMock()):
         again = await client.post(_FORCE_URL, headers=admin_auth_header)
     assert again.status_code == 200, again.text
+
+
+async def _latest_backfill_row(session: AsyncSession) -> IngestJob:
+    session.expire_all()
+    job = (
+        (
+            await session.execute(
+                select(IngestJob)
+                .where(IngestJob.user_metadata.has_key(EMBEDDING_BACKFILL_METADATA_KEY))
+                .order_by(IngestJob.created_at.desc())
+                .limit(1)
+            )
+        )
+        .scalars()
+        .first()
+    )
+    assert job is not None
+    return job
+
+
+@pytest.mark.anyio
+async def test_a_lost_ack_on_the_dispatch_settle_still_closes_the_trail(
+    client: AsyncClient,
+    admin_auth_header: dict,
+    test_db_session: AsyncSession,
+    monkeypatch,
+):
+    """The write lands; the caller never hears that it did — at the OTHER end.
+
+    `_recover_unsettled` covers this class at the end of a run. The dispatch end
+    had the same shape and no recovery: `settle_undispatched_run` failed the
+    pending row, committed, and decided from the statement's own rowcount
+    whether it owed a terminal entry. Losing that acknowledgement is the
+    ORDINARY case here rather than the exotic one, because this code only runs
+    under the cancellation that triggered it — and the row it leaves behind is
+    `failed`, which every sweeper skips because it is terminal. So nothing
+    emitted the entry and nothing ever would: the trail keeps `requested` as its
+    last word over a job the database records as failed.
+    """
+    monkeypatch.setattr(backfill_module, "backfill_embeddings", AsyncMock())
+
+    real_fail = backfill_jobs._fail_undispatched_pending_row
+    calls = {"n": 0}
+
+    async def _commits_then_loses_the_answer(job_uuid):
+        calls["n"] += 1
+        await real_fail(job_uuid)  # the row really does become `failed`...
+        raise asyncio.CancelledError()  # ...and the caller never learns it
+
+    monkeypatch.setattr(
+        backfill_jobs, "_fail_undispatched_pending_row", _commits_then_loses_the_answer
+    )
+
+    async def _cancelled_mid_dispatch(_task, /, **kwargs):
+        raise asyncio.CancelledError()
+
+    with patch.object(
+        admin_router,
+        "defer_async_with_tenant",
+        AsyncMock(side_effect=_cancelled_mid_dispatch),
+    ):
+        # Same transport note as the test above: httpx re-wraps a cancellation,
+        # so what matters is that no response came back.
+        raised: BaseException | None = None
+        try:
+            await client.post(_FORCE_URL, headers=admin_auth_header)
+        except BaseException as exc:  # noqa: BLE001 - see comment above
+            raised = exc
+        assert raised is not None, "the cancellation did not propagate"
+
+    # Non-vacuity: the settle ran and its answer was genuinely lost.
+    assert calls["n"] == 1, "the dispatch settle never ran — nothing lost an answer"
+
+    stranded = await _latest_backfill_row(test_db_session)
+    assert stranded.status == "failed", (
+        "the undispatched run never reached a terminal row"
+    )
+    assert stranded.error_message == backfill_jobs.UNDISPATCHED_RUN_MESSAGE
+
+    terminal = await _terminal_audit_entries(
+        client, admin_auth_header, str(stranded.id)
+    )
+    assert len(terminal) == 1, terminal
+    assert terminal[0]["details"]["error_code"] == "dispatch_cancelled"
+
+
+@pytest.mark.anyio
+async def test_a_dispatch_settle_that_lost_its_answer_and_its_write_audits_nothing(
+    client: AsyncClient,
+    admin_auth_header: dict,
+    test_db_session: AsyncSession,
+    monkeypatch,
+):
+    """The counterfactual: the same lost answer over a write that never landed.
+
+    Reading the row is only right if it discriminates. A settle whose write was
+    fenced out — a worker picked the delivery up after all, so the row is no
+    longer `pending` — must record nothing, exactly as it does when the answer
+    comes back as zero rows. Otherwise the recovery above would just be an
+    unconditional "audit it anyway" wearing a read.
+    """
+    monkeypatch.setattr(backfill_module, "backfill_embeddings", AsyncMock())
+
+    calls = {"n": 0}
+
+    async def _the_worker_took_it_first(job_uuid):
+        # The fenced UPDATE matches nothing because the row is already running,
+        # and then the answer is lost as well.
+        calls["n"] += 1
+        from app.core.db import async_session
+
+        async with async_session() as other:
+            await other.execute(
+                update(IngestJob)
+                .where(IngestJob.id == job_uuid)
+                .values(status="running", heartbeat_at=datetime.now(timezone.utc))
+            )
+            await other.commit()
+        raise asyncio.CancelledError()
+
+    monkeypatch.setattr(
+        backfill_jobs, "_fail_undispatched_pending_row", _the_worker_took_it_first
+    )
+
+    async def _cancelled_mid_dispatch(_task, /, **kwargs):
+        raise asyncio.CancelledError()
+
+    with patch.object(
+        admin_router,
+        "defer_async_with_tenant",
+        AsyncMock(side_effect=_cancelled_mid_dispatch),
+    ):
+        raised: BaseException | None = None
+        try:
+            await client.post(_FORCE_URL, headers=admin_auth_header)
+        except BaseException as exc:  # noqa: BLE001 - transport re-wrap
+            raised = exc
+        assert raised is not None, "the cancellation did not propagate"
+
+    assert calls["n"] == 1, "the dispatch settle never ran"
+    live = await _latest_backfill_row(test_db_session)
+    # Non-vacuity: the row really is owned by somebody else now.
+    assert live.status == "running"
+
+    terminal = await _terminal_audit_entries(client, admin_auth_header, str(live.id))
+    assert terminal == [], f"the settle claimed a run it did not settle: {terminal}"
+
+
+# ---------------------------------------------------------------------------
+# The fourth actor: the worker's own startup recovery (#1556)
+# ---------------------------------------------------------------------------
+#
+# `fail_stale_jobs`, the status poll and the worker's exits were taught to close
+# the trail. `recover_stale_jobs` — the pass a restarting worker runs before it
+# accepts a single delivery — settles the same rows with the same predicates and
+# was not. It is also the pass that actually reaches a hard-killed run: a worker
+# that dies is usually back in seconds, and once its startup pass has made the
+# row terminal no later sweep will look at that row again.
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    "job_status,error_code",
+    [("running", "worker_lost"), ("pending", "never_started")],
+)
+async def test_the_worker_startup_recovery_closes_the_trail_it_settles(
+    client: AsyncClient,
+    admin_auth_header: dict,
+    test_db_session: AsyncSession,
+    job_status: str,
+    error_code: str,
+):
+    """A hard kill's recovery is the restarted worker's, not the 5-minute sweep.
+
+    Both settle the row; only one of them was closing the trail. Whichever gets
+    there first is the last actor the run will ever have, because a terminal row
+    drops out of every other sweep's predicate — so the trail sits at
+    `requested` forever, over a force run that may have deleted every vector.
+    """
+    from app.platform.jobs.worker import recover_stale_jobs
+
+    upload = await _stale_job(test_db_session, status=job_status, backfill=False)
+    backfill = await _stale_job(test_db_session, status=job_status, backfill=True)
+    upload_id, backfill_id = str(upload.id), str(backfill.id)
+
+    assert (
+        await _terminal_audit_entries(client, admin_auth_header, backfill_id) == []
+    ), "the run already had a terminal entry before the recovery — vacuous"
+
+    await recover_stale_jobs()
+
+    # Non-vacuity: the recovery genuinely settled both rows. If the advisory
+    # lock was held elsewhere it skips the pass entirely, and this says so.
+    assert (await _load_job(test_db_session, backfill_id)).status == "failed", (
+        "the startup recovery did not settle the row — nothing to close a trail for"
+    )
+    assert (await _load_job(test_db_session, upload_id)).status == "failed"
+
+    terminal = await _terminal_audit_entries(client, admin_auth_header, backfill_id)
+    assert len(terminal) == 1, terminal
+    assert terminal[0]["details"]["outcome"] == "failed"
+    assert terminal[0]["details"]["error_code"] == error_code
+    # The same discrimination the shared sweep owes: the ordinary upload
+    # settled in the same pass gets no entry of any kind.
+    assert await _audit_entries_naming(test_db_session, upload_id) == 0, (
+        "the startup recovery wrote an audit entry for an ordinary upload"
+    )

--- a/backend/tests/test_worker.py
+++ b/backend/tests/test_worker.py
@@ -147,6 +147,11 @@ async def test_recover_stale_jobs_marks_running_as_failed():
     fake_job.error_message = None
     fake_job.completed_at = None
     fake_job.started_at = None
+    # fix(#1556): recovery now closes an embedding backfill's audit trail, and
+    # it decides whether a row is one by reading `user_metadata`. A bare
+    # MagicMock attribute is truthy, so a double without this claims to be a
+    # backfill — an ordinary upload's metadata is what this double stands for.
+    fake_job.user_metadata = {"file_type": "vector"}
 
     # Two extra empty results for the GAP-002 VRT stale sweep
     # (stale regenerating RasterAssets, stale VrtGeneration rows).
@@ -171,6 +176,7 @@ async def test_recover_stale_jobs_marks_orphaned_pending_as_failed():
     fake_job.status = "pending"
     fake_job.error_message = None
     fake_job.completed_at = None
+    fake_job.user_metadata = {"file_type": "vector"}  # see #1556 note above
 
     # Two extra empty results for the GAP-002 VRT stale sweep.
     mock_session = _make_mock_session([], [fake_job], [], [], [])
@@ -232,6 +238,7 @@ async def test_recover_stale_jobs_logs_individual_job_ids():
     job1.error_message = None
     job1.completed_at = None
     job1.started_at = None
+    job1.user_metadata = {"file_type": "vector"}  # see #1556 note above
 
     job2 = MagicMock()
     job2.id = uuid4()
@@ -239,6 +246,7 @@ async def test_recover_stale_jobs_logs_individual_job_ids():
     job2.error_message = None
     job2.completed_at = None
     job2.started_at = None
+    job2.user_metadata = {"file_type": "vector"}  # see #1556 note above
 
     # Two extra empty results for the GAP-002 VRT stale sweep.
     mock_session = _make_mock_session([job1, job2], [], [], [], [])


### PR DESCRIPTION
#1550 settled on two rules: recovery decides outcomes by observing the row rather than by reading a fence result or an in-process flag, and one operation gets one terminal audit entry, whoever writes it first. It applied them to the actors it knew about. This PR works the first two candidates in #1556 and finds one settler and one commit that were still outside both rules.

## The worker's startup recovery settled backfill rows without closing the trail

`platform/jobs/sweep.py` names three sharers of the stale-job predicates: the lifespan sweeper, the admin cleanup endpoint, and the worker's own startup recovery. #1550 taught the audit close to the first two (and to `get_job_status`, the path that actually fires while anything is polling). `recover_stale_jobs` in `platform/jobs/worker.py` was not taught, and it flips the same `running` and `pending` rows to `failed` with the same predicates.

It is also the pass that reaches a hard-killed run in practice. A worker under `restart: unless-stopped` is back in seconds and runs `recover_stale_jobs()` before it accepts a single delivery, while the lifespan sweep is up to five minutes away. Whichever gets there first is the last actor the run will ever have, because every sweep's predicate is `pending`/`running` and a terminal row drops out of all of them. So a force regenerate whose worker was killed after the DELETE kept `requested` as its last word, permanently, over a catalog whose vectors are gone. That is the exact case #1550 added `audit_settled_embedding_backfill` for.

Both halves of the pass now call it, on the recovery's own session, so the status change and the entry commit as one transaction.

## The dispatch settle's commit sat outside the recovery boundary

`settle_undispatched_run` failed the still-`pending` row, committed, and then decided from the statement's own rowcount whether it owed a terminal entry. That is in-process state describing what the database did, which is the thing #1550 spent four review rounds removing from the other end of the run.

Losing that acknowledgement is the ordinary case here rather than the exotic one: this function only ever runs under the cancellation that triggered it, inside a `wait_for(timeout=15)` that will cancel it again. And the row it leaves behind is `failed`, which no sweeper looks at, so nothing downstream would ever have closed the trail either. It now catches the lost answer and reads the row, applying the same rule `_recover_unsettled` applies: `failed` is the status this write produces, so it is the one that lets the run claim `dispatch_cancelled`; any other terminal status is somebody else's decision and a live one means the write did not land.

## Decisions worth review

- **`except BaseException` around the settle write, then one more await.** It can swallow the `wait_for` cancellation and spend up to 5 s more on a SELECT during a drain. Bounded deliberately and separately, the same shape `_release_caller_transaction` already uses one layer up, and the route re-raises the original cancellation regardless.
- **Reading the row, not the error.** A connection error and a cancellation are the same fact here (the write may or may not have applied), so there is one handler rather than one per exception type.
- **`audit_settled_embedding_backfill` reached through `platform/jobs/router.py`.** `worker.py` already imports `JOB_TIMEOUT_SECONDS`, `stale_pending_clauses` and `sweep_stale_vrt_assets` through that façade; the name is now in its `__all__` alongside them.
- **Files touched outside the assigned set.** `platform/jobs/worker.py` is where the missed settler lives and `platform/jobs/router.py` gained one `__all__` entry. `tests/test_worker.py` needed three test doubles fixed: a bare `MagicMock` attribute is truthy, so a fake job without `user_metadata` claimed to be a backfill and reached `session.begin_nested()` on a mock session. Setting `{"file_type": "vector"}` is what those doubles always stood for.

## The shared sweep needed no change, and now says so

`fail_stale_jobs` was already correct for other job types: the helper returns early unless `user_metadata` carries the `embedding_backfill` marker. The old pin asserted that the global count of `embedding.backfill` rows did not move, which holds just as well in a build where the audit hook never fires at all, which is the opposite bug and the one #1550 fixed.

The replacement sweeps an ordinary upload and a real backfill in the *same pass*, on both halves, and asserts that the upload gains no audit row of any action naming it while the backfill gains exactly one with the right `error_code`, so the predicate has to discriminate rather than merely stay quiet. It also asserts the upload is still closed, which is the "fails to close an ingest job it used to close" direction. The worker-recovery tests carry the same pair. A counterfactual that never fires is worth having here because the sweep is shared and the next person to edit it will not know this.

## Every commit on the backfill lifecycle, and what a lost acknowledgement does

| Commit | On a lost acknowledgement |
| --- | --- |
| Route: job row + `requested` audit (`admin/router.py`) | **Observed from the row.** It is durably `pending` with no dispatch behind it, which is what `stale_pending_clauses` reaps and, since #1550, closes with `never_started`. Correct but slow: the slot is held for `pending_job_timeout_seconds` (1 h default). Deliberately not shortened here, see below. |
| `claim_job_attempt_and_start_heartbeat` | **Observed from the row.** `_recover_unsettled` reads the live status and terminalizes from it, which is why `_TerminalState.expected_status` exists. Pinned by `test_a_lost_claim_commit_does_not_strand_the_run_in_pending`. |
| Per-batch commits inside `backfill_embeddings` | Not a row/trail question. An exception ends the run through `decide_failed`, a cancellation through the `BaseException` guard; either way the terminal state comes from `_settle`. Committed batches stay committed, which is what a re-run is for. (Owned by another branch; read, not touched.) |
| Heartbeat renewal (`renew_ingest_job_heartbeat`) | **Fire-and-forget by design, and safe.** No outcome is inferred from a renewal: `maintain_ingest_job_heartbeat` swallows the failure and tries again 30 s later against a 60-minute lease, so one lost answer costs one of ~120 renewals. The backfill writes no progress either: `claim_job_attempt_and_start_heartbeat` is called without `job`/`current_step`, and `backfill_embeddings` never sees the job row. |
| `_finalize` | **Observed from the row.** Pinned by `test_a_lost_commit_acknowledgement_is_not_read_as_failure`. |
| `audit_emit_durable`'s own session | Recovery re-emits with `state.audited` still False; migration 0051's unique index refuses the duplicate and `_emit_outcome_audit` contains the `IntegrityError`. One entry either way. |
| `settle_undispatched_run` | **Was a defect.** Fixed here. |
| `get_job_status`'s commit | Atomic: the fenced UPDATE and the audit row are one transaction, so a lost answer leaves both or neither and the next poll re-observes. |
| `fail_stale_jobs`'s commit | Same shape; the next pass is five minutes away. |
| `recover_stale_jobs`'s commit | Atomic on the status changes, but there was no audit row in the transaction to be atomic with. **Was a defect.** Fixed here. |
| `resolve_ingest_job_attempt`'s adopt commit | Unreachable for a backfill: the route always sends an attempt id. A stranded adopt would return `None` and the task emits `attempt_unresolvable`. |

On the route's own commit: the neighbouring `except asyncio.CancelledError` covers the dispatch call, not this line, and extending it means reading `job.id` after a flush that may itself have been interrupted. The sweeper already observes the row, which is the rule's own test for correct, so this is flagged rather than built.

## Looked at and found clean

- The audit hook is gated on `user_metadata['embedding_backfill']`, and nothing else writes that key. `create_fan_out_jobs` clones parent metadata wholesale, but a backfill never fans out, and `/jobs/{id}/retry` refuses backfills outright (`_retry_capability`), so the marker cannot spread onto an ingest row.
- Migration 0051's index is pinned to `action = 'embedding.backfill'` and excludes `requested`, so no other audit action is constrained and the `requested`/terminal pair still coexists. Migration 0050's is pinned to backfill rows in a slot-holding status, so an upload and a backfill can be in flight together as before.
- Every other terminal writer of an `IngestJob` (`router_reupload.py`, `tasks_common.py`, `tasks_vector.py`, the retention purge) is keyed to its own job kind and cannot reach a backfill row; there is no job-cancel endpoint. `defer_guard`'s rollback does run on a backfill, and the route already closes that trail (#1550).
- `asyncio.CancelledError` on every handler touched: the new `except BaseException` in `settle_undispatched_run` catches it on purpose, and the recovery it guards is a plain read.

## Out of scope

The third candidate in #1556 (run history, progress, estimate-before-start from #1542) is untouched, so the issue stays open. `Refs #1556` rather than `Closes`.

## Verification

Red, worker startup recovery, with the two `audit_settled_embedding_backfill` calls removed from `recover_stale_jobs`:

```
$ pytest tests/test_embedding_backfill_queue_1542.py -k startup_recovery --tb=line
E   AssertionError: []
tests/test_embedding_backfill_queue_1542.py:2058: AssertionError: []
E   AssertionError: []
tests/test_embedding_backfill_queue_1542.py:2058: AssertionError: []
FAILED test_the_worker_startup_recovery_closes_the_trail_it_settles[running-worker_lost]
FAILED test_the_worker_startup_recovery_closes_the_trail_it_settles[pending-never_started]
2 failed, 35 deselected in 4.85s
```

Red, dispatch settle, with the observation fallback removed from `settle_undispatched_run`:

```
$ pytest tests/test_embedding_backfill_queue_1542.py -k "lost_ack_on_the_dispatch or lost_its_answer" --tb=line
E   AssertionError: []
tests/test_embedding_backfill_queue_1542.py:1939: AssertionError: []
FAILED test_a_lost_ack_on_the_dispatch_settle_still_closes_the_trail
1 failed, 1 passed, 35 deselected in 5.67s
```

The one that passes there is the counterfactual sibling, which asserts absence and so holds in the broken build too. It only earns its keep once the fix is in, which is the point of running it.

Green:

```
$ pytest tests/test_embedding_backfill_queue_1542.py
37 passed in 24.96s

$ pytest tests/test_worker.py tests/test_tenant_job_recovery.py tests/test_vrt_stale_sweep_gap002.py tests/test_stale_pending_reaper.py
84 passed in 12.06s

$ pytest tests/test_jobs_router.py tests/test_ingest_job_attempt_fencing.py tests/test_admin_user_operations.py \
         tests/test_presigned_staging_reap_1202.py tests/test_staging_orphan_reconcile_1249.py
135 passed in 39.97s

$ pytest tests/test_rule1_structural.py tests/test_rule2_structural.py tests/test_audit_action_registry.py \
         tests/test_audit.py tests/test_admin_lifecycle_hardening.py tests/test_admin_jobs_retry_capability.py
136 passed in 26.29s

$ pytest tests/test_layering.py
47 passed in 9.47s

$ uv run ruff check . && uv run ruff format --check .
All checks passed!
1024 files already formatted
```

Also run once with `pytest-randomly` active (the default) rather than `-p no:randomly`, so the new sweep and recovery tests are not order-dependent: 51 passed.

No route or schema change, so `backend/openapi.json` and the SDKs are untouched. No migration.

Refs #1556


---

## Review round 2: the cleanup must match its own marker

Finding accepted. `_undispatched_row_was_failed` observed `status == "failed"`, which is the state this write would have produced rather than evidence that it produced it, and `failed` is a state four other actors also write.

The reachable case: the dispatch did land, a worker claimed the job and finalized it `failed`, and only then was the request cancelled. The fenced update matches nothing, its acknowledgement is lost as well, and the status-only read called the worker's failure this cleanup's write. It recorded `dispatch_cancelled`, which says the run never started and nothing was deleted, over a force regenerate that ran and failed after deleting every vector. Terminal entries being unique per job id makes it worse than a stray entry: it takes the one slot and the worker's real `backfill_failed` is refused by the index and swallowed.

`UNDISPATCHED_RUN_MESSAGE` is written at one site, this one, and no other writer can overwrite it once the row is terminal, because every one of them is fenced on a live status. The read now requires it. The helper is renamed `_undispatched_settle_write_landed` to say what it actually answers.

### `_recover_unsettled` reads the row the same way, and is left alone

Checked, as asked. It is not the same defect, for two independent reasons, and there is now a comment at the site recording them so the next reader does not propagate the wrong rule in either direction.

It is reached only after this worker took the delivery, so "did the operation run at all" is already answered. `complete` has exactly one producer for a backfill row, this attempt's own fenced `_finalize` (every other writer of `complete` in `backend/app/processing/` belongs to a different job kind, dispatched from a different route and fenced on its own attempt id), so matching it proves authorship. `failed` does have several producers, but all of them record the same `outcome` and differ only in `error_code`, and each is a true description of a run that ended without success. Where they differ, the residual imprecision points the safe way: `worker_cancelled` warns that a force run's vectors may already be gone, which is the conservative claim, while the dispatch cleanup's `dispatch_cancelled` asserted the opposite. That asymmetry is why one needed evidence of its own write and the other does not.

### Verification

Red, with the marker check removed and the status-only read restored:

```
$ pytest tests/test_embedding_backfill_queue_1542.py -k another_actor_wrote --tb=line
E   AssertionError: the cleanup claimed a failure the worker wrote:
    [{... 'action': 'embedding.backfill', 'details': {'force': True,
      'job_id': '6c0e1d0a-7d44-4a31-b50b-476bbc0672bd', 'outcome': 'failed',
      'error_code': 'dispatch_cancelled', ...}}]
FAILED test_a_lost_ack_does_not_claim_a_failure_another_actor_wrote
1 failed, 37 deselected in 5.89s
```

The test drives the eviction rather than reasoning about it: the worker's own terminal audit is held between `_finalize`'s commit and `_emit_terminal_audit`, which is the live window, and released after the cleanup has had its chance. On the fixed build it lands and the run's single terminal entry is `backfill_failed`; on the broken one the slot is already taken.

Green:

```
$ pytest tests/test_embedding_backfill_queue_1542.py tests/test_worker.py tests/test_layering.py
99 passed in 38.56s

$ pytest tests/test_jobs_router.py tests/test_tenant_job_recovery.py tests/test_vrt_stale_sweep_gap002.py \
         tests/test_stale_pending_reaper.py tests/test_ingest_job_attempt_fencing.py \
         tests/test_admin_user_operations.py tests/test_audit.py tests/test_audit_action_registry.py
158 passed in 56.03s

$ uv run ruff check . && uv run ruff format --check .
All checks passed!
1024 files already formatted
```

Plus one run with `pytest-randomly` active: 38 passed.
