### PR TITLE
fix(embed): make the public app URL rules agree with what a browser sends

### DIFF
--- a/backend/app/core/public_urls.py
+++ b/backend/app/core/public_urls.py
@@ -5,9 +5,9 @@ from __future__ import annotations
 import codecs
 import ipaddress
 import time
-import unicodedata
 from urllib.parse import urlsplit, urlunsplit
 
+import idna
 from fastapi import Request
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -261,12 +261,6 @@ def canonical_host_error(host: str) -> str | None:
 
 _ACE_PREFIX = "xn--"
 
-# Categories a decoded label may not contain: C0/C1 controls, surrogates, and
-# every flavour of space. Deliberately NOT the whole of category C — format
-# characters (Cf) include ZWJ and ZWNJ, which CONTEXTJ permits in real Persian
-# and Indic domains, and rejecting them would deny a working configuration.
-_FORBIDDEN_DECODED_CATEGORIES = frozenset({"Cc", "Cs", "Zs", "Zl", "Zp"})
-
 
 def _ace_label_error(label: str) -> str | None:
     """None if this ``xn--`` label is one a browser will accept.
@@ -278,39 +272,44 @@ def _ace_label_error(label: str) -> str | None:
     against it is unusable from the moment it is minted, which is exactly the
     class this rule exists for: a spelling no browser will ever present.
 
-    What is checked, and why not more. This is a REJECTION of provable garbage,
-    not an implementation of UTS #46 — approximating the browser's IDNA is the
-    thing #1548 refused to do, and a check that is stricter than the browser
-    denies configurations that work, which is the worse direction. So each
-    clause below is one a browser demonstrably enforces:
+    An A-label is what a browser SENDS, which makes it the output of UTS #46
+    mapping. So the check is: decode it, and confirm the U-label is already what
+    that mapping produces.
 
     * the label decodes as punycode at all (``xn--0``, ``xn--x``);
     * it decodes to something (``xn--``, whose suffix Python decodes to the
       empty string rather than raising);
     * the result contains a non-ASCII character (RFC 5891 §4.2.3.1 — an A-label
       whose U-label is pure ASCII is invalid; catches ``xn--a-``);
-    * the result carries no control, surrogate or space character (catches
-      ``xn--a``, which Python decodes to U+0080);
-    * the result is already lowercase and NFC — the two mappings UTS #46 applies
-      before encoding, so a label whose U-label needs either is not the form a
-      browser would have produced (catches ``xn--w-uia``, which decodes to
-      ``Ėw``). ``.lower()`` rather than ``.casefold()`` on purpose: casefold
-      turns ``faß`` into ``fass``, and ``xn--fa-hia`` is a label browsers
-      accept;
+    * ``idna.uts46_remap`` leaves the result unchanged. This IS the mapping
+      browsers apply (non-transitional, per WHATWG), so it is not an
+      approximation of one: it raises ``InvalidCodepoint`` for a disallowed
+      character (catches ``xn--a``, which decodes to U+0080, and ``xn--a-ecp``,
+      which decodes to ``a⒈`` where U+2488 is disallowed), normalizes to NFC as
+      its second step, and case-maps in the direction the tables say rather than
+      the direction ``str.lower`` assumes;
     * re-encoding reproduces the label (catches ``xn---``).
 
-    Measured against ``new URL()`` in Node over 63 labels, not assumed: no false
-    rejections, one false accept. The labels themselves are in the shared
-    fixture (``public-app-url-shape.cases.json``, see ``_ace_note``), so the
-    frontend — which simply asks the browser — runs the same ones.
+    fix(#1555 review): the previous revision asked ``decoded == decoded.lower()``
+    instead of the remap, and that was the failure mode this function's own
+    docstring warns about — stricter than the browser. Cherokee case-maps UPWARD
+    in UTS #46: ``xn--bbe`` decodes to ``Ꮘ`` (U+13B8), which ``str.lower``
+    turns into U+AB98, so a label ``new URL()`` accepts unchanged was refused
+    here. The lowercase form is the one browsers rewrite (``xn--p09a`` remaps
+    back to ``Ꮘ`` and is therefore not what a browser sends), which is exactly
+    backwards from what ``.lower()`` assumes. Asking the real tables also
+    removes the ``.lower()``-not-``.casefold()`` special case that kept
+    ``xn--fa-hia`` working: non-transitional processing leaves ``ß`` alone.
 
-    The residue, recorded rather than papered over: a label that decodes to a
-    character UTS #46 disallows for reasons of its own still passes here —
-    ``xn--a-ecp`` decodes to ``a⒈``, whose mapping introduces a label separator,
-    and a browser rejects it while this does not. Catching that means the full
-    UTS #46 mapping table. It leaves an operator with a token that does not
-    work, which is the pre-existing behaviour for every unreachable hostname
-    (see ``assert_domain_lock_is_enforceable``), not a new one.
+    ``idna`` is a declared backend dependency (``pyproject.toml``, ``>=3.18``
+    for the ``idna.encode`` DoS fix; this calls ``uts46_remap``, not
+    ``encode``). Its tables ARE the UTS #46 ones, which is why this is allowed
+    to be exact where #1548 refused to approximate.
+
+    Measured against ``new URL()`` in Node over 65 labels, not assumed: no false
+    rejections and no false accepts. The labels are in the shared fixture
+    (``public-app-url-shape.cases.json``, see ``_ace_note``), so the frontend —
+    which simply asks the browser — runs the same ones.
     """
     suffix = label[len(_ACE_PREFIX) :]
     invalid = (
@@ -326,11 +325,11 @@ def _ace_label_error(label: str) -> str | None:
         return invalid
     if not decoded or decoded.isascii():
         return invalid
-    if any(
-        unicodedata.category(char) in _FORBIDDEN_DECODED_CATEGORIES for char in decoded
-    ):
+    try:
+        remapped = idna.uts46_remap(decoded, std3_rules=False, transitional=False)
+    except (idna.IDNAError, UnicodeError, ValueError):
         return invalid
-    if decoded != decoded.lower() or decoded != unicodedata.normalize("NFC", decoded):
+    if remapped != decoded:
         return invalid
     try:
         reencoded = codecs.encode(decoded, "punycode").decode("ascii")

--- a/backend/app/core/public_urls.py
+++ b/backend/app/core/public_urls.py
@@ -127,8 +127,64 @@ def is_api_base_path(path: str) -> bool:
     path through ``is_usable_public_origin`` and the persistent-setting path
     through ``validate_public_app_url``, which had it and was the only one
     checking. ``/apiary`` is not an API base; ``/geolens/api/`` is.
+
+    fix(#1555 review): the question is asked of the path a BROWSER resolves,
+    which is not the path ``urlsplit`` hands back. ``/api/.`` and
+    ``/foo/../api/.`` are left untouched by Python and normalized to ``/api/``
+    by every browser, so both backend doors accepted them while the frontend —
+    reading ``URL.pathname``, already resolved — refused. Measured, not
+    assumed: before this, ``validate_public_app_url('https://maps.example.com/
+    api/.')`` returned the value and the domain-lock gate read it as a
+    configured origin.
     """
-    return path.rstrip("/").endswith("/api")
+    return _remove_dot_segments(path).rstrip("/").endswith("/api")
+
+
+# WHATWG treats a percent-encoded dot as a dot segment, in either case, and in
+# either half of a double-dot. RFC 3986 §5.2.4 knows only the literal spellings.
+_SINGLE_DOT_SEGMENTS = frozenset({".", "%2e"})
+_DOUBLE_DOT_SEGMENTS = frozenset({"..", ".%2e", "%2e.", "%2e%2e"})
+
+
+def _remove_dot_segments(path: str) -> str:
+    """Resolve ``.`` and ``..`` the way a URL parser does.
+
+    RFC 3986 §5.2.4, with the ``%2e`` equivalences the URL Standard adds. Takes
+    the path of an ABSOLUTE URL, so it is either empty or rooted.
+
+    A trailing dot segment leaves the slash behind: ``/api/.`` is ``/api/``,
+    matching ``new URL().pathname``, which is the whole point of the function.
+
+    The ``%2e`` half cannot be reached through ``is_usable_public_origin``
+    today: it refuses any candidate containing ``%`` several clauses earlier,
+    because Python leaves percent-encoding literal where a browser decodes it.
+    That refusal is a different rule with a different reason, though, and one
+    that a later change could narrow to "decode it instead" without anyone
+    noticing this depended on it. So the equivalence is implemented here rather
+    than assumed, and pinned by a test that calls this classifier directly —
+    an end-to-end test of a ``%2e`` value would pass on the percent clause
+    alone and prove nothing about this code.
+    """
+    if not path:
+        return path
+    segments = path.split("/")
+    output: list[str] = []
+    for index, segment in enumerate(segments):
+        lowered = segment.lower()
+        is_last = index == len(segments) - 1
+        if lowered in _SINGLE_DOT_SEGMENTS:
+            if is_last:
+                output.append("")
+            continue
+        if lowered in _DOUBLE_DOT_SEGMENTS:
+            # Never pop the leading empty segment: it is the root, not a step.
+            if len(output) > 1:
+                output.pop()
+            if is_last:
+                output.append("")
+            continue
+        output.append(segment)
+    return "/".join(output)
 
 
 def is_loopback_host(host: str) -> bool:

--- a/backend/app/core/public_urls.py
+++ b/backend/app/core/public_urls.py
@@ -2,25 +2,12 @@
 
 from __future__ import annotations
 
-import codecs
 import ipaddress
 import time
-import unicodedata
 from urllib.parse import urlsplit, urlunsplit
 
-import idna
 from fastapi import Request
 
-# fix(#1555 review r3): bound at import so a breaking change in idna fails at
-# BOOT rather than as an AttributeError on some later request. These are the
-# UTS #46 §4.1 validity criteria browsers apply after mapping, and CheckJoiners
-# needs Joining_Type, which Python's unicodedata does not expose — the tables
-# are the reason to depend on the package rather than write the rule out.
-from idna.core import check_bidi as _check_bidi
-from idna.core import check_initial_combiner as _check_initial_combiner
-from idna.core import valid_contextj as _valid_contextj
-from idna.idnadata import codepoint_classes as _CODEPOINT_CLASSES
-from idna.intranges import intranges_contain as _intranges_contain
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -319,178 +306,29 @@ def canonical_host_error(host: str) -> str | None:
         return f"{host!r} has an empty label."
     if not all(c.isalnum() or c == "-" for label in labels for c in label):
         return f"{host!r} contains a character that is not valid in a hostname."
-    for label in labels:
-        if label.lower().startswith(_ACE_PREFIX):
-            problem = _ace_label_error(label)
-            if problem is not None:
-                return problem
-    return None
-
-
-_ACE_PREFIX = "xn--"
-
-# The directionality classes RFC 5893 calls STRONG. A label's direction is the
-# direction of its first strong character; see _uts46_validity_error.
-_STRONG_DIRECTIONS = frozenset({"L", "R", "AL"})
-
-
-def _uts46_validity_error(label: str) -> bool:
-    """True when a browser would reject this U-label outright.
-
-    fix(#1555 review r3): mapping is not validity. ``uts46_remap`` applies the
-    UTS #46 mapping and stops; §4.1 then imposes criteria on the RESULT, and a
-    label can survive the mapping unchanged and still be one no browser accepts.
-    ``xn--a-sgn`` decodes to ``a`` + U+200C: remapped identically, refused by
-    ``new URL()``, and therefore accepted here as a self origin that no embed
-    shell can ever present.
-
-    The criteria implemented, in the configuration the URL Standard specifies
-    (CheckHyphens=false, CheckJoiners=true, CheckBidi=true,
-    UseSTD3ASCIIRules=false, Transitional_Processing=false):
-
-    * NO LEADING COMBINING MARK.
-    * CHECKJOINERS. A CONTEXTJ code point (U+200C, U+200D) is allowed only in
-      the contexts RFC 5892 Appendix A defines. This is the one rule that
-      cannot be written from ``unicodedata``: it needs Joining_Type, which
-      Python does not expose, so it needs ``idna``'s tables.
-    * CHECKBIDI, with the caveat below.
-
-    Deliberately NOT implemented, because browsers do not apply them: hyphen
-    positions (CheckHyphens=false, so ``ma-`` and ``xn--m--mia`` are fine), DNS
-    length (VerifyDnsLength=false), and CONTEXTO. CONTEXTO especially: IDNA2008
-    would refuse the Catalan ``l·l`` (``xn--ll-0ea``) and a browser accepts it,
-    so ``idna.encode``, which applies the whole IDNA2008 protocol including the
-    PVALID table that refuses emoji, is the wrong tool here and stays unused.
-
-    THE BIDI CAVEAT, measured rather than assumed. RFC 5893 rule 1 says a
-    label's first character must be strong, and ``idna.core.check_bidi``
-    enforces that literally. ICU, and therefore every browser, instead reads the
-    direction off the first STRONG character, so ``1مثال`` (``xn--1-zmcl5hc``)
-    is accepted there and refused by the literal rule. Enforcing rule 1 would
-    deny a working configuration, which is the direction this file refuses to
-    fail in, so the check runs from the first strong character onward and rule 1
-    is left to the browser.
-
-    Scoped per label, also measured: the standard says the bidi rules apply to
-    every label of a bidi DOMAIN, but ``ex-.xn--mgbh0fb`` and
-    ``xn--m--mia.xn--mgbh0fb`` are both accepted by ``new URL()`` even though
-    their first label breaks the LTR rule and their second is Arabic. So the
-    browser judges each label on its own characters, which is exactly
-    ``check_bidi(..., check_ltr=False)``, and no cross-label state is needed.
-
-    Skipping to the first strong character leaves the characters before it
-    unjudged by rule 2, which was a real gap rather than a theoretical one: see
-    the AN clause below, added after ``xn--abc-55e`` was measured accepted here
-    and refused by ``new URL()``.
-    """
-    try:
-        _check_initial_combiner(label)
-        for position, char in enumerate(label):
-            if _intranges_contain(ord(char), _CODEPOINT_CLASSES["CONTEXTJ"]):
-                if not _valid_contextj(label, position):
-                    return True
-        strong = next(
-            (
-                index
-                for index, char in enumerate(label)
-                if unicodedata.bidirectional(char) in _STRONG_DIRECTIONS
-            ),
-            None,
-        )
-        if strong is not None:
-            _check_bidi(label[strong:])
-            # The characters skipped to find that strong one still have to obey
-            # rule 2, and only one class is disallowed for an LTR label without
-            # already being disallowed by the mapping: AN. Measured, because it
-            # was the last gap: `٠abc` (xn--abc-55e), an Arabic-Indic digit
-            # leading a Latin label, is refused by new URL() and was accepted
-            # here while this clause was a docstring paragraph instead of code.
-            if unicodedata.bidirectional(label[strong]) == "L" and any(
-                unicodedata.bidirectional(char) == "AN" for char in label[:strong]
-            ):
-                return True
-    except (idna.IDNAError, UnicodeError, ValueError):
-        return True
-    return False
-
-
-def _ace_label_error(label: str) -> str | None:
-    """None if this ``xn--`` label is one a browser will accept.
-
-    fix(#1555): ``https://xn--.example`` is ASCII, alphanumeric-and-hyphens, and
-    therefore passed the registered-name check above — so the backend read it as
-    a usable non-loopback self origin and permitted a domain lock, while
-    ``new URL()`` and every browser reject the URL outright. A token issued
-    against it is unusable from the moment it is minted, which is exactly the
-    class this rule exists for: a spelling no browser will ever present.
-
-    An A-label is what a browser SENDS, which makes it the output of UTS #46
-    mapping. So the check is: decode it, and confirm the U-label is already what
-    that mapping produces.
-
-    * the label decodes as punycode at all (``xn--0``, ``xn--x``);
-    * it decodes to something (``xn--``, whose suffix Python decodes to the
-      empty string rather than raising);
-    * the result contains a non-ASCII character (RFC 5891 §4.2.3.1 — an A-label
-      whose U-label is pure ASCII is invalid; catches ``xn--a-``);
-    * ``idna.uts46_remap`` leaves the result unchanged. This IS the mapping
-      browsers apply (non-transitional, per WHATWG), so it is not an
-      approximation of one: it raises ``InvalidCodepoint`` for a disallowed
-      character (catches ``xn--a``, which decodes to U+0080, and ``xn--a-ecp``,
-      which decodes to ``a⒈`` where U+2488 is disallowed), normalizes to NFC as
-      its second step, and case-maps in the direction the tables say rather than
-      the direction ``str.lower`` assumes;
-    * re-encoding reproduces the label (catches ``xn---``).
-
-    fix(#1555 review): the previous revision asked ``decoded == decoded.lower()``
-    instead of the remap, and that was the failure mode this function's own
-    docstring warns about — stricter than the browser. Cherokee case-maps UPWARD
-    in UTS #46: ``xn--bbe`` decodes to ``Ꮘ`` (U+13B8), which ``str.lower``
-    turns into U+AB98, so a label ``new URL()`` accepts unchanged was refused
-    here. The lowercase form is the one browsers rewrite (``xn--p09a`` remaps
-    back to ``Ꮘ`` and is therefore not what a browser sends), which is exactly
-    backwards from what ``.lower()`` assumes. Asking the real tables also
-    removes the ``.lower()``-not-``.casefold()`` special case that kept
-    ``xn--fa-hia`` working: non-transitional processing leaves ``ß`` alone.
-
-    ``idna`` is a declared backend dependency (``pyproject.toml``, ``>=3.18``
-    for the ``idna.encode`` DoS fix; this calls ``uts46_remap``, not
-    ``encode``). Its tables ARE the UTS #46 ones, which is why this is allowed
-    to be exact where #1548 refused to approximate.
-
-    Measured against ``new URL()`` in Node over 65 labels, not assumed: no false
-    rejections and no false accepts. The labels are in the shared fixture
-    (``public-app-url-shape.cases.json``, see ``_ace_note``), so the frontend —
-    which simply asks the browser — runs the same ones.
-    """
-    suffix = label[len(_ACE_PREFIX) :]
-    invalid = (
-        f"{label!r} is not a valid punycode label; browsers reject the URL "
-        "outright. An internationalized domain must be given in the exact "
-        "xn-- form the browser sends."
-    )
-    if not suffix:
-        return invalid
-    try:
-        decoded = codecs.decode(suffix.encode("ascii"), "punycode")
-    except (UnicodeError, ValueError):
-        return invalid
-    if not decoded or decoded.isascii():
-        return invalid
-    try:
-        remapped = idna.uts46_remap(decoded, std3_rules=False, transitional=False)
-    except (idna.IDNAError, UnicodeError, ValueError):
-        return invalid
-    if remapped != decoded:
-        return invalid
-    if _uts46_validity_error(decoded):
-        return invalid
-    try:
-        reencoded = codecs.encode(decoded, "punycode").decode("ascii")
-    except (UnicodeError, ValueError):
-        return invalid
-    if reencoded.lower() != suffix.lower():
-        return invalid
+    # fix(#1555 review r4): an `xn--` label is accepted here as opaque LDH, and
+    # three rounds of validating it were REMOVED, because "what a browser sends"
+    # has no single answer for these labels. Measured with Playwright, in-page
+    # `new URL('https://<host>/p').hostname`:
+    #
+    #     host                   chromium 151  firefox 153  webkit 26.5  node 26
+    #     xn--.example           ok            THROWS       ok           THROWS
+    #     xn--a-sgn.example      ok            THROWS       ok           THROWS
+    #     xn--a-0hc.example      ok            THROWS       ok           ok
+    #     ex-.xn--mgbh0fb        ok            THROWS       ok           ok
+    #     xn--fa-hia.de          ok            ok           ok           ok
+    #
+    # Chromium and WebKit do not decode or validate an all-ASCII host at all;
+    # Firefox implements the URL Standard including every RFC 5893 bidi rule;
+    # Node's parser matches neither. So any refusal we add is stricter than the
+    # two engines most viewers use, which is the direction this file exists to
+    # avoid — and no rule can satisfy Firefox and Chromium at once. 13 of the 28
+    # hosts measured were read differently by different engines, ALL of them
+    # `xn--` cases; every other rule in this module agreed across all four.
+    #
+    # This also means a Node-based test cannot stand in for a browser here: run
+    # `new URL('https://xn--.example')` in node, find it invalid, and you are
+    # reading one engine's opinion, not the web's.
     return None
 
 

--- a/backend/app/core/public_urls.py
+++ b/backend/app/core/public_urls.py
@@ -5,10 +5,22 @@ from __future__ import annotations
 import codecs
 import ipaddress
 import time
+import unicodedata
 from urllib.parse import urlsplit, urlunsplit
 
 import idna
 from fastapi import Request
+
+# fix(#1555 review r3): bound at import so a breaking change in idna fails at
+# BOOT rather than as an AttributeError on some later request. These are the
+# UTS #46 §4.1 validity criteria browsers apply after mapping, and CheckJoiners
+# needs Joining_Type, which Python's unicodedata does not expose — the tables
+# are the reason to depend on the package rather than write the rule out.
+from idna.core import check_bidi as _check_bidi
+from idna.core import check_initial_combiner as _check_initial_combiner
+from idna.core import valid_contextj as _valid_contextj
+from idna.idnadata import codepoint_classes as _CODEPOINT_CLASSES
+from idna.intranges import intranges_contain as _intranges_contain
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -317,6 +329,90 @@ def canonical_host_error(host: str) -> str | None:
 
 _ACE_PREFIX = "xn--"
 
+# The directionality classes RFC 5893 calls STRONG. A label's direction is the
+# direction of its first strong character; see _uts46_validity_error.
+_STRONG_DIRECTIONS = frozenset({"L", "R", "AL"})
+
+
+def _uts46_validity_error(label: str) -> bool:
+    """True when a browser would reject this U-label outright.
+
+    fix(#1555 review r3): mapping is not validity. ``uts46_remap`` applies the
+    UTS #46 mapping and stops; §4.1 then imposes criteria on the RESULT, and a
+    label can survive the mapping unchanged and still be one no browser accepts.
+    ``xn--a-sgn`` decodes to ``a`` + U+200C: remapped identically, refused by
+    ``new URL()``, and therefore accepted here as a self origin that no embed
+    shell can ever present.
+
+    The criteria implemented, in the configuration the URL Standard specifies
+    (CheckHyphens=false, CheckJoiners=true, CheckBidi=true,
+    UseSTD3ASCIIRules=false, Transitional_Processing=false):
+
+    * NO LEADING COMBINING MARK.
+    * CHECKJOINERS. A CONTEXTJ code point (U+200C, U+200D) is allowed only in
+      the contexts RFC 5892 Appendix A defines. This is the one rule that
+      cannot be written from ``unicodedata``: it needs Joining_Type, which
+      Python does not expose, so it needs ``idna``'s tables.
+    * CHECKBIDI, with the caveat below.
+
+    Deliberately NOT implemented, because browsers do not apply them: hyphen
+    positions (CheckHyphens=false, so ``ma-`` and ``xn--m--mia`` are fine), DNS
+    length (VerifyDnsLength=false), and CONTEXTO. CONTEXTO especially: IDNA2008
+    would refuse the Catalan ``l·l`` (``xn--ll-0ea``) and a browser accepts it,
+    so ``idna.encode``, which applies the whole IDNA2008 protocol including the
+    PVALID table that refuses emoji, is the wrong tool here and stays unused.
+
+    THE BIDI CAVEAT, measured rather than assumed. RFC 5893 rule 1 says a
+    label's first character must be strong, and ``idna.core.check_bidi``
+    enforces that literally. ICU, and therefore every browser, instead reads the
+    direction off the first STRONG character, so ``1مثال`` (``xn--1-zmcl5hc``)
+    is accepted there and refused by the literal rule. Enforcing rule 1 would
+    deny a working configuration, which is the direction this file refuses to
+    fail in, so the check runs from the first strong character onward and rule 1
+    is left to the browser.
+
+    Scoped per label, also measured: the standard says the bidi rules apply to
+    every label of a bidi DOMAIN, but ``ex-.xn--mgbh0fb`` and
+    ``xn--m--mia.xn--mgbh0fb`` are both accepted by ``new URL()`` even though
+    their first label breaks the LTR rule and their second is Arabic. So the
+    browser judges each label on its own characters, which is exactly
+    ``check_bidi(..., check_ltr=False)``, and no cross-label state is needed.
+
+    Skipping to the first strong character leaves the characters before it
+    unjudged by rule 2, which was a real gap rather than a theoretical one: see
+    the AN clause below, added after ``xn--abc-55e`` was measured accepted here
+    and refused by ``new URL()``.
+    """
+    try:
+        _check_initial_combiner(label)
+        for position, char in enumerate(label):
+            if _intranges_contain(ord(char), _CODEPOINT_CLASSES["CONTEXTJ"]):
+                if not _valid_contextj(label, position):
+                    return True
+        strong = next(
+            (
+                index
+                for index, char in enumerate(label)
+                if unicodedata.bidirectional(char) in _STRONG_DIRECTIONS
+            ),
+            None,
+        )
+        if strong is not None:
+            _check_bidi(label[strong:])
+            # The characters skipped to find that strong one still have to obey
+            # rule 2, and only one class is disallowed for an LTR label without
+            # already being disallowed by the mapping: AN. Measured, because it
+            # was the last gap: `٠abc` (xn--abc-55e), an Arabic-Indic digit
+            # leading a Latin label, is refused by new URL() and was accepted
+            # here while this clause was a docstring paragraph instead of code.
+            if unicodedata.bidirectional(label[strong]) == "L" and any(
+                unicodedata.bidirectional(char) == "AN" for char in label[:strong]
+            ):
+                return True
+    except (idna.IDNAError, UnicodeError, ValueError):
+        return True
+    return False
+
 
 def _ace_label_error(label: str) -> str | None:
     """None if this ``xn--`` label is one a browser will accept.
@@ -386,6 +482,8 @@ def _ace_label_error(label: str) -> str | None:
     except (idna.IDNAError, UnicodeError, ValueError):
         return invalid
     if remapped != decoded:
+        return invalid
+    if _uts46_validity_error(decoded):
         return invalid
     try:
         reencoded = codecs.encode(decoded, "punycode").decode("ascii")

--- a/backend/app/core/public_urls.py
+++ b/backend/app/core/public_urls.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import codecs
 import ipaddress
 import time
+import unicodedata
 from urllib.parse import urlsplit, urlunsplit
 
 from fastapi import Request
@@ -58,9 +60,19 @@ def is_usable_public_origin(value: str | None) -> bool:
       own comparison survives, but the frontend appends ``/m/<token>`` to the
       configured string — putting the path inside the query or after the
       fragment and producing links nobody can open.
+    * NO ``/api`` PATH. fix(#1555): the same clause the persistent-setting
+      validator has always had (``validate_public_app_url``, "must point to the
+      app, not the /api base"), applied to the entry point that skipped it. An
+      environment ``PUBLIC_APP_URL=https://maps.example.com/api`` reached
+      ``SharePanel`` through tile-config and built ``/api/api/maps/...`` card
+      links and ``/api/m/...`` iframe sources, while the domain-lock gate saw a
+      non-loopback origin and issued a token whose shell URL does not exist.
+      One rule with two entry points, only one of them checking.
 
-    The setting is environment-backed and therefore never passes through the
-    persistent-setting validator, so this is the only place it is checked.
+    The setting is environment-backed, so the environment path never passes
+    through the persistent-setting validator; that validator now defers to this
+    function for everything it does not say itself, so both entry points give
+    the same answer.
     """
     if value is None:
         return False
@@ -103,7 +115,53 @@ def is_usable_public_origin(value: str | None) -> bool:
         return False
     if canonical_host_error(parts.hostname or "") is not None:
         return False
+    if is_api_base_path(parts.path):
+        return False
     return not parts.query and not parts.fragment
+
+
+def is_api_base_path(path: str) -> bool:
+    """Does this path name the API base rather than the app?
+
+    fix(#1555): stated once because two entry points ask it — the environment
+    path through ``is_usable_public_origin`` and the persistent-setting path
+    through ``validate_public_app_url``, which had it and was the only one
+    checking. ``/apiary`` is not an API base; ``/geolens/api/`` is.
+    """
+    return path.rstrip("/").endswith("/api")
+
+
+def is_loopback_host(host: str) -> bool:
+    """True when a browser served from ``host`` is talking to its own machine.
+
+    fix(#1555): the predicate this replaces was an enumerated set of three
+    spellings (``localhost``, ``127.0.0.1``, ``::1``). Loopback is a RANGE:
+    ``127.0.0.0/8`` is loopback in its entirety, so a deployment configured as
+    ``http://127.0.0.2:8080`` was classified non-loopback, and
+    ``assert_domain_lock_is_enforceable`` read that as "this deployment knows
+    its public origin" and issued a domain lock every recipient resolves to
+    their OWN machine. The list form fails toward permitting the lock, which is
+    the direction that costs an operator a silently empty embed.
+
+    ``*.localhost`` counts. RFC 6761 §6.3 says resolvers should treat the
+    ``localhost`` zone as loopback and browsers do, so ``http://app.localhost``
+    is the same misconfiguration wearing a subdomain.
+
+    Bracketed IPv6 literals are accepted here because callers disagree about
+    whether they strip: ``urlsplit(...).hostname`` does, ``URL.hostname`` in a
+    browser does not.
+    """
+    candidate = host.strip().lower()
+    if candidate.startswith("[") and candidate.endswith("]"):
+        candidate = candidate[1:-1]
+    if not candidate:
+        return False
+    if candidate == "localhost" or candidate.endswith(".localhost"):
+        return True
+    try:
+        return ipaddress.ip_address(candidate).is_loopback
+    except ValueError:
+        return False
 
 
 def canonical_host_error(host: str) -> str | None:
@@ -143,9 +201,23 @@ def canonical_host_error(host: str) -> str | None:
 
     if ":" in host:  # IPv6 literal; urlsplit has already stripped the brackets.
         try:
-            compressed = str(ipaddress.IPv6Address(host))
+            address = ipaddress.IPv6Address(host)
         except ValueError:
             return f"{host!r} is not a valid IPv6 address."
+        # fix(#1555): an IPv4-MAPPED literal has no agreed spelling. Python
+        # renders ::ffff:7f00:1 as ::ffff:127.0.0.1 and a browser renders
+        # ::ffff:127.0.0.1 as ::ffff:7f00:1, so each side calls the other's
+        # canonical form non-canonical and the class had no answer both halves
+        # accept. Refused outright rather than translated, for the same reason
+        # as a non-ASCII host: the plain IPv4 form is unambiguous and is what a
+        # browser presents anyway.
+        if address.ipv4_mapped is not None:
+            return (
+                f"{host!r} is an IPv4-mapped IPv6 literal, which browsers and "
+                "this server spell differently. Write the IPv4 address: "
+                f"{address.ipv4_mapped}"
+            )
+        compressed = str(address)
         if compressed != host:
             return f"Write the IPv6 literal in its compressed form: [{compressed}]"
         return None
@@ -179,6 +251,93 @@ def canonical_host_error(host: str) -> str | None:
         return f"{host!r} has an empty label."
     if not all(c.isalnum() or c == "-" for label in labels for c in label):
         return f"{host!r} contains a character that is not valid in a hostname."
+    for label in labels:
+        if label.lower().startswith(_ACE_PREFIX):
+            problem = _ace_label_error(label)
+            if problem is not None:
+                return problem
+    return None
+
+
+_ACE_PREFIX = "xn--"
+
+# Categories a decoded label may not contain: C0/C1 controls, surrogates, and
+# every flavour of space. Deliberately NOT the whole of category C — format
+# characters (Cf) include ZWJ and ZWNJ, which CONTEXTJ permits in real Persian
+# and Indic domains, and rejecting them would deny a working configuration.
+_FORBIDDEN_DECODED_CATEGORIES = frozenset({"Cc", "Cs", "Zs", "Zl", "Zp"})
+
+
+def _ace_label_error(label: str) -> str | None:
+    """None if this ``xn--`` label is one a browser will accept.
+
+    fix(#1555): ``https://xn--.example`` is ASCII, alphanumeric-and-hyphens, and
+    therefore passed the registered-name check above — so the backend read it as
+    a usable non-loopback self origin and permitted a domain lock, while
+    ``new URL()`` and every browser reject the URL outright. A token issued
+    against it is unusable from the moment it is minted, which is exactly the
+    class this rule exists for: a spelling no browser will ever present.
+
+    What is checked, and why not more. This is a REJECTION of provable garbage,
+    not an implementation of UTS #46 — approximating the browser's IDNA is the
+    thing #1548 refused to do, and a check that is stricter than the browser
+    denies configurations that work, which is the worse direction. So each
+    clause below is one a browser demonstrably enforces:
+
+    * the label decodes as punycode at all (``xn--0``, ``xn--x``);
+    * it decodes to something (``xn--``, whose suffix Python decodes to the
+      empty string rather than raising);
+    * the result contains a non-ASCII character (RFC 5891 §4.2.3.1 — an A-label
+      whose U-label is pure ASCII is invalid; catches ``xn--a-``);
+    * the result carries no control, surrogate or space character (catches
+      ``xn--a``, which Python decodes to U+0080);
+    * the result is already lowercase and NFC — the two mappings UTS #46 applies
+      before encoding, so a label whose U-label needs either is not the form a
+      browser would have produced (catches ``xn--w-uia``, which decodes to
+      ``Ėw``). ``.lower()`` rather than ``.casefold()`` on purpose: casefold
+      turns ``faß`` into ``fass``, and ``xn--fa-hia`` is a label browsers
+      accept;
+    * re-encoding reproduces the label (catches ``xn---``).
+
+    Measured against ``new URL()`` in Node over 63 labels, not assumed: no false
+    rejections, one false accept. The labels themselves are in the shared
+    fixture (``public-app-url-shape.cases.json``, see ``_ace_note``), so the
+    frontend — which simply asks the browser — runs the same ones.
+
+    The residue, recorded rather than papered over: a label that decodes to a
+    character UTS #46 disallows for reasons of its own still passes here —
+    ``xn--a-ecp`` decodes to ``a⒈``, whose mapping introduces a label separator,
+    and a browser rejects it while this does not. Catching that means the full
+    UTS #46 mapping table. It leaves an operator with a token that does not
+    work, which is the pre-existing behaviour for every unreachable hostname
+    (see ``assert_domain_lock_is_enforceable``), not a new one.
+    """
+    suffix = label[len(_ACE_PREFIX) :]
+    invalid = (
+        f"{label!r} is not a valid punycode label; browsers reject the URL "
+        "outright. An internationalized domain must be given in the exact "
+        "xn-- form the browser sends."
+    )
+    if not suffix:
+        return invalid
+    try:
+        decoded = codecs.decode(suffix.encode("ascii"), "punycode")
+    except (UnicodeError, ValueError):
+        return invalid
+    if not decoded or decoded.isascii():
+        return invalid
+    if any(
+        unicodedata.category(char) in _FORBIDDEN_DECODED_CATEGORIES for char in decoded
+    ):
+        return invalid
+    if decoded != decoded.lower() or decoded != unicodedata.normalize("NFC", decoded):
+        return invalid
+    try:
+        reencoded = codecs.encode(decoded, "punycode").decode("ascii")
+    except (UnicodeError, ValueError):
+        return invalid
+    if reencoded.lower() != suffix.lower():
+        return invalid
     return None
 
 

--- a/backend/app/modules/embed_tokens/service.py
+++ b/backend/app/modules/embed_tokens/service.py
@@ -12,7 +12,11 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from starlette.requests import Request
 
 from app.core.edition import is_enterprise
-from app.core.public_urls import get_configured_public_app_url, is_usable_public_origin
+from app.core.public_urls import (
+    get_configured_public_app_url,
+    is_loopback_host,
+    is_usable_public_origin,
+)
 from app.core.tenancy import is_multi_tenant
 from app.platform.cache import tenant_cache_context_available, tenant_cache_key
 from app.platform.cache.provider import get_cache
@@ -43,11 +47,6 @@ def _embed_token_cache_key(token_hash: str) -> str:
     return tenant_cache_key(f"embed_token:{token_hash}")
 
 
-# BUG-028: urlparse(...).hostname strips IPv6 brackets, so the loopback literal
-# stored here must be the UNBRACKETED form '::1' to match what
-# _is_localhost_origin extracts. The previous '[::1]' entry was a dead branch.
-_LOCALHOST_HOSTS = frozenset({"localhost", "127.0.0.1", "::1"})
-
 # Phase 268 H-31: loopback IP set used to gate the localhost-Origin bypass.
 # The Origin header alone is trivially forgeable from non-browser callers
 # (curl, server-side scripts, CLIs) — they can simply set
@@ -55,6 +54,13 @@ _LOCALHOST_HOSTS = frozenset({"localhost", "127.0.0.1", "::1"})
 # To prevent that, the bypass now also requires ``request.client.host`` to
 # be a loopback IP (which a remote attacker cannot forge — ``client.host``
 # is the actual TCP peer address).
+#
+# fix(#1555): stays an exact set while _is_localhost_origin became a range
+# check, and the asymmetry is the point. This one GATES the bypass, so its
+# failure direction is to deny — a peer at 127.0.0.2 simply does not get the
+# development shortcut. The other one decides whether a domain lock can be
+# enforced, where the same miss ISSUES a lock that can never work. Widening
+# this would hand the bypass to more callers, which is not what #1555 asks for.
 _LOOPBACK_CLIENT_IPS = frozenset({"127.0.0.1", "::1", "localhost"})
 
 
@@ -65,9 +71,17 @@ _LOOPBACK_CLIENT_IPS = frozenset({"127.0.0.1", "::1", "localhost"})
 
 
 def _is_localhost_origin(origin: str) -> bool:
-    """Check if origin is a localhost address (http/https, IPv4/IPv6)."""
+    """Is this origin one that only reaches the machine it is opened on?
+
+    fix(#1555): the host set this used to consult named ``127.0.0.1`` and
+    nothing else in ``127.0.0.0/8``, so ``http://127.0.0.2:8080`` was read as a
+    routable public origin and ``assert_domain_lock_is_enforceable`` permitted a
+    domain lock every recipient resolves to their own machine. Loopback is a
+    RANGE; ``is_loopback_host`` (app/core/public_urls.py) states it once, and
+    the frontend mirrors it in ``isLoopbackHostname``.
+    """
     parsed = urlparse(origin.lower().rstrip("/"))
-    return (parsed.hostname or "") in _LOCALHOST_HOSTS
+    return is_loopback_host(parsed.hostname or "")
 
 
 def _client_is_loopback(request: Request) -> bool:

--- a/backend/app/modules/settings/schemas.py
+++ b/backend/app/modules/settings/schemas.py
@@ -5,6 +5,12 @@ from urllib.parse import urlsplit, urlunsplit
 
 from pydantic import BaseModel, Field, field_validator
 
+from app.core.public_urls import (
+    canonical_host_error,
+    is_api_base_path,
+    is_usable_public_origin,
+)
+
 
 class BasemapEntry(BaseModel):
     id: str = Field(
@@ -424,11 +430,31 @@ def _normalize_absolute_url(v: Any) -> str:
 
 
 def validate_public_app_url(v: Any) -> str:
+    """fix(#1555): one rule, both entry points.
+
+    This validator and ``is_usable_public_origin`` (app/core/public_urls.py)
+    each held half of what makes a public app URL usable, and a value only ever
+    met the half its entry point applied. An environment ``PUBLIC_APP_URL``
+    skips this function entirely, so ``https://maps.example.com/api`` was
+    accepted there; a persisted value skips the shape rule, so
+    ``https://192.168.1`` was stored here and then silently ignored by every
+    reader (``get_configured_public_app_url`` drops what the shape rule
+    refuses), leaving the operator an admin form that accepted a setting which
+    does nothing. The ``/api`` clause is checked explicitly first only to keep
+    its specific message; ``canonical_host_error`` supplies one for a host.
+    """
     if not v or (isinstance(v, str) and not v.strip()):
         return ""
     normalized = _normalize_absolute_url(v)
-    if urlsplit(normalized).path.rstrip("/").endswith("/api"):
+    if is_api_base_path(urlsplit(normalized).path):
         raise ValueError("public_app_url must point to the app, not the /api base")
+    if not is_usable_public_origin(normalized):
+        problem = canonical_host_error(urlsplit(normalized).hostname or "")
+        raise ValueError(
+            "public_app_url must be spelled the way a browser would send it, "
+            "because it is compared against the origin an embed shell presents. "
+            + (problem or "Remove any percent-encoding, backslash or non-ASCII.")
+        )
     return normalized
 
 

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -3510,7 +3510,15 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # unset it derives an app URL from an /api-stripped PUBLIC_API_URL, and a
     # split app/API deployment then had the API host accepted as a self-origin,
     # so a lock was issued that every shell request missed. Cap 1038 -> 1042.
-    "backend/app/modules/embed_tokens/service.py": 1042,
+    # fix(#1555): +14, all comment except two lines. _is_localhost_origin now
+    # asks is_loopback_host (app/core/public_urls.py) instead of an enumerated
+    # set of three spellings, because 127.0.0.0/8 is loopback in its entirety
+    # and http://127.0.0.2:8080 was read as a routable public origin — enough
+    # for the gate to issue a domain lock every recipient resolves to their own
+    # machine. The rest records why _LOOPBACK_CLIENT_IPS stays an exact set:
+    # that one GATES the localhost bypass, so a miss there denies, while a miss
+    # in the other ISSUES an unenforceable lock. Cap 1042 -> 1056.
+    "backend/app/modules/embed_tokens/service.py": 1056,
 }
 
 

--- a/backend/tests/test_public_app_url_shape_contract_1548.py
+++ b/backend/tests/test_public_app_url_shape_contract_1548.py
@@ -368,6 +368,62 @@ def test_both_entry_points_accept_a_value_a_viewer_could_reach(configured):
 
 
 @pytest.mark.parametrize(
+    ("label", "u_label", "browser_accepts", "why"),
+    [
+        # The finding: mapping leaves it alone, validity does not.
+        ("xn--a-sgn", "a‌", False, "ZWNJ outside any context RFC 5892 allows"),
+        ("xn--a-wbb", "́a", False, "begins with a combining mark"),
+        ("xn--a-ymcl5hc", "مثالa", False, "RTL label carrying an L character"),
+        ("xn--1a-ctdp0kd", "1مثالa", False, "same, behind a leading neutral"),
+        (
+            "xn--abc-55e",
+            "٠abc",
+            False,
+            "AN before the first strong char of an LTR label",
+        ),
+        # CheckJoiners ACCEPTS a joiner in context — the counterfactual that
+        # keeps the rule from being "no U+200C ever".
+        ("xn--11b2ezcw70k", "क्‍ष", True, "ZWJ after a virama"),
+        # Rules browsers switch OFF. Each of these is refused by idna.encode(),
+        # which is exactly why idna.encode() is not what this calls.
+        ("xn--ll-0ea", "l·l", True, "CONTEXTO: IDNA2008 refuses it, browsers do not"),
+        ("xn--ls8h", "💩", True, "emoji: not PVALID, still a label browsers parse"),
+        ("xn--m--mia", "má-", True, "CheckHyphens=false, so a trailing hyphen is fine"),
+        # CheckBidi as browsers actually scope it.
+        ("xn--mgbh0fb", "مثال", True, "an ordinary RTL label"),
+        ("xn--1-zmcl5hc", "1مثال", True, "direction comes from the first STRONG char"),
+        ("xn--1-ymcl5hc", "مثال1", True, "an RTL label may end in a European digit"),
+        # The mapping rule still runs first, so this pins the interaction.
+        ("xn--ss-8ka", "Āss", False, "uppercase: the remap check refuses it"),
+    ],
+)
+def test_a_decoded_label_must_also_pass_the_validity_criteria(
+    label, u_label, browser_accepts, why
+):
+    """fix(#1555 review r3): ``uts46_remap`` maps, and mapping is not validity.
+
+    ``browser_accepts`` is ``new URL('https://<label>.example')`` measured in
+    Node, not reasoned about. The ``u_label`` column is there so a reader can
+    see WHAT the label says without decoding punycode in their head, and it is
+    asserted, so a typo in the table is a failure rather than a lie.
+
+    The rows browsers ACCEPT are the load-bearing half. Reaching for
+    ``idna.encode`` would refuse ``l·l`` and ``💩`` — IDNA2008 is stricter than
+    the browser, and denying a working configuration is the failure this whole
+    function is written to avoid.
+    """
+    import codecs
+
+    from app.core.public_urls import canonical_host_error
+
+    assert codecs.decode(label[4:].encode("ascii"), "punycode") == u_label, (
+        "the table's own decoding is wrong"
+    )
+    accepted = canonical_host_error(f"{label}.example") is None
+    assert accepted is browser_accepts, why
+
+
+@pytest.mark.parametrize(
     ("path", "browser_resolves_to", "is_api_base"),
     [
         # The three that were live: urlsplit leaves them, browsers resolve them.

--- a/backend/tests/test_public_app_url_shape_contract_1548.py
+++ b/backend/tests/test_public_app_url_shape_contract_1548.py
@@ -318,6 +318,11 @@ async def test_a_deployment_on_a_routable_host_still_gets_its_domain_lock(
         "https://example.com/geolens/api",
         "https://192.168.1",
         "https://xn--.example",
+        # fix(#1555 review): resolve to the API base in a browser, and were
+        # left alone by urlsplit, so both doors used to take them.
+        "https://maps.example.com/api/.",
+        "https://maps.example.com/api/./",
+        "https://maps.example.com/foo/../api/.",
     ],
 )
 def test_both_entry_points_of_the_setting_refuse_the_same_values(configured):
@@ -360,3 +365,50 @@ def test_both_entry_points_accept_a_value_a_viewer_could_reach(configured):
 
     assert is_usable_public_origin(configured)
     assert validate_public_app_url(configured) == configured
+
+
+@pytest.mark.parametrize(
+    ("path", "browser_resolves_to", "is_api_base"),
+    [
+        # The three that were live: urlsplit leaves them, browsers resolve them.
+        ("/api/.", "/api/", True),
+        ("/api/./", "/api/", True),
+        ("/foo/../api/.", "/api/", True),
+        # Percent-encoded dot segments. UNREACHABLE end to end — every candidate
+        # containing '%' is refused several clauses earlier, on both sides —
+        # which is exactly why they are asserted HERE, against the classifier
+        # itself. Through the front door these cases would pass on the percent
+        # rule and say nothing about this code.
+        ("/api/%2e", "/api/", True),
+        ("/api/%2E/", "/api/", True),
+        ("/api/.%2e", "/", False),
+        ("/api/%2e%2e", "/", False),
+        # Dot segments that resolve AWAY from the API base. The counterfactual:
+        # a normalizer that simply looked for '/api' anywhere would refuse a
+        # deployment that is not on the API base at all.
+        ("/api/..", "/", False),
+        ("/apiary/.", "/apiary/", False),
+        ("/geolens/./x", "/geolens/x", False),
+        ("/a/./b/../api", "/a/api", True),
+        # Unchanged by normalization, so the ordinary answers must not move.
+        ("/api", "/api", True),
+        ("/apiary", "/apiary", False),
+        ("/geolens", "/geolens", False),
+        ("", "", False),
+    ],
+)
+def test_the_api_path_rule_reads_the_path_a_browser_resolves(
+    path, browser_resolves_to, is_api_base
+):
+    """fix(#1555 review): ``urlsplit`` is not a URL parser's normalizer.
+
+    ``expected`` is what ``new URL('https://x' + path).pathname`` returns,
+    measured in Node rather than reasoned about, with one deliberate exception:
+    a path-less URL, where a browser supplies ``/`` and this function leaves the
+    empty string alone. Supplying a default path is not resolving dot segments,
+    and the classification is the same either way.
+    """
+    from app.core.public_urls import _remove_dot_segments, is_api_base_path
+
+    assert _remove_dot_segments(path) == browser_resolves_to
+    assert is_api_base_path(path) is is_api_base

--- a/backend/tests/test_public_app_url_shape_contract_1548.py
+++ b/backend/tests/test_public_app_url_shape_contract_1548.py
@@ -21,12 +21,24 @@ single statement of the rule, and this file runs it against the Python half.
 The TypeScript half runs the same table in
 ``frontend/src/lib/__tests__/public-urls.test.ts``.
 
-The rule: an absolute HTTP(S) URL, with a host, and no query or fragment.
+The rule: an absolute HTTP(S) URL, with a host, no query or fragment, and no
+path naming the ``/api`` base.
 
-SHAPE ONLY. Whether a shape-valid value is TRUSTED in context is a separate
-question — a loopback origin is shape-valid but untrusted when the caller is
-somewhere else — which is why loopback entries sit under ``valid`` in the
-fixture. That second question lives in ``assert_domain_lock_is_enforceable``.
+SHAPE, and one classification on top of it. Whether a shape-valid value is
+TRUSTED in context is a separate question — a loopback origin is shape-valid but
+untrusted when the caller is somewhere else — which is why loopback entries sit
+under ``valid`` in the fixture, and the decision itself lives in
+``assert_domain_lock_is_enforceable``. fix(#1555): WHICH origins are loopback is
+back here, though, because it is not each side's private opinion either. It was
+an enumerated set of three spellings on both sides, and ``127.0.0.2`` — loopback
+to every operating system, and to the frontend's `loopback-default` state once
+it was fixed there — has to mean the same thing in both halves or the UI and the
+API disagree about which deployments are misconfigured.
+
+fix(#1555) also puts the setting's OTHER door under the same rule: an admin PUT
+goes through ``validate_public_app_url``, which held the ``/api`` clause the
+environment path lacked while lacking every host-spelling clause the environment
+path had. Both are asserted here, against the same values.
 """
 
 import json
@@ -117,6 +129,47 @@ def test_canonicalization_is_idempotent():
         assert _normalize_origin(expected) == expected, expected
 
 
+def test_the_loopback_table_has_cases_on_both_sides():
+    spec = _spec()
+    assert spec["loopback"], "no loopback cases"
+    assert spec["not_loopback"], "no routable cases"
+
+
+def test_every_origin_the_spec_calls_loopback_is_read_as_loopback():
+    """fix(#1555): loopback is a range, and both sides have to agree on it.
+
+    The consumer is asserted, not the helper: ``_is_localhost_origin`` is what
+    ``assert_domain_lock_is_enforceable`` asks, and reading ``127.0.0.2`` as a
+    routable public origin is what let it issue a lock recipients resolve to
+    their own machine.
+    """
+    from app.modules.embed_tokens.service import _is_localhost_origin
+
+    missed = [v for v in _spec()["loopback"] if not _is_localhost_origin(v)]
+    assert not missed, (
+        "these reach only the machine the browser runs on, and the frontend "
+        "classifies them as loopback-default, so a domain lock offered from "
+        "them could never be satisfied:\n" + "\n".join(f"  {v!r}" for v in missed)
+    )
+
+
+def test_no_origin_the_spec_calls_routable_is_read_as_loopback():
+    """The counterfactual: the range must not swallow its neighbours.
+
+    Without this, ``return True`` passes the test above. ``126.255.255.255`` and
+    ``128.0.0.1`` sit either side of ``127.0.0.0/8``, and ``mylocalhost.example``
+    ends in the same letters as the one hostname that is special.
+    """
+    from app.modules.embed_tokens.service import _is_localhost_origin
+
+    wrong = [v for v in _spec()["not_loopback"] if _is_localhost_origin(v)]
+    assert not wrong, (
+        "these are ordinary public origins; treating them as loopback would "
+        "refuse a domain lock on a correctly configured deployment:\n"
+        + "\n".join(f"  {v!r}" for v in wrong)
+    )
+
+
 @pytest.mark.anyio
 @pytest.mark.parametrize(
     "configured",
@@ -125,6 +178,13 @@ def test_canonicalization_is_idempotent():
         "mailto:ops@example.com",
         "file:///etc/hosts",
         "not-a-url",
+        # fix(#1555): the three spellings this issue adds. Each is a value the
+        # deployment cannot be reached at — an API base rather than the app, and
+        # two ACE labels no browser will parse — and each used to read as a
+        # configured non-loopback origin.
+        "https://maps.example.com/api",
+        "https://xn--.example",
+        "https://xn--a.example",
     ],
 )
 async def test_a_non_http_setting_cannot_authorize_a_domain_lock(
@@ -169,3 +229,134 @@ async def test_a_non_http_setting_cannot_authorize_a_domain_lock(
         "an unusable setting must resolve to no self-origin at all, not to a "
         "pseudo-origin the operator will not recognize"
     )
+
+
+@pytest.mark.anyio
+async def test_a_loopback_setting_outside_127_0_0_1_cannot_authorize_a_domain_lock(
+    monkeypatch,
+):
+    """fix(#1555): the finding, end to end through the gate.
+
+    ``http://127.0.0.2:8080`` is a perfectly well-formed origin — it passes the
+    whole shape rule, which is why the previous check let it through. It is also
+    an address every recipient of the embed resolves to their OWN machine, so a
+    domain lock issued here has exactly the failure the refusal exists to
+    prevent: the shell never loads, and the operator hears nothing until they
+    ask a customer why the map is empty.
+
+    Asserted through the gate rather than the predicate, because "does this
+    deployment know a public origin" is the question the predicate is asked, and
+    a version of it that returns the right boolean while the gate goes on to
+    permit the lock would be no fix at all.
+    """
+    from types import SimpleNamespace
+    from unittest.mock import AsyncMock, MagicMock
+
+    from app.modules.embed_tokens import service as embed_service
+
+    async def _configured(db, **kwargs):
+        return "http://127.0.0.2:8080"
+
+    monkeypatch.setattr(embed_service, "get_configured_public_app_url", _configured)
+    monkeypatch.setattr(embed_service, "is_enterprise", lambda: True)
+
+    request = MagicMock()
+    request.headers = {"origin": "https://maps.example.com"}
+    request.client = SimpleNamespace(host="172.18.0.5")
+    request.state = SimpleNamespace()
+
+    with pytest.raises(embed_service.DomainLockNotEnforceableError) as exc:
+        await embed_service.assert_domain_lock_is_enforceable(
+            AsyncMock(), request, ["https://customer.example.com"]
+        )
+    message = str(exc.value)
+    assert "http://127.0.0.2:8080" in message, (
+        "the refusal must name the value the operator has to change"
+    )
+    assert "PUBLIC_APP_URL" in message
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    "configured", ["https://maps.example.com", "http://126.255.255.255"]
+)
+async def test_a_deployment_on_a_routable_host_still_gets_its_domain_lock(
+    monkeypatch, configured
+):
+    """The counterfactual for the test above.
+
+    A loopback rule that widened far enough to catch a correctly configured
+    deployment would trade a silent failure for a loud one on a healthy
+    install. ``126.255.255.255`` is one address below the loopback block.
+    """
+    from types import SimpleNamespace
+    from unittest.mock import AsyncMock, MagicMock
+
+    from app.modules.embed_tokens import service as embed_service
+
+    async def _configured(db, **kwargs):
+        return configured
+
+    monkeypatch.setattr(embed_service, "get_configured_public_app_url", _configured)
+    monkeypatch.setattr(embed_service, "is_enterprise", lambda: True)
+
+    request = MagicMock()
+    request.headers = {"origin": "https://maps.example.com"}
+    request.client = SimpleNamespace(host="172.18.0.5")
+    request.state = SimpleNamespace()
+
+    await embed_service.assert_domain_lock_is_enforceable(
+        AsyncMock(), request, ["https://customer.example.com"]
+    )
+
+
+@pytest.mark.parametrize(
+    "configured",
+    [
+        "https://maps.example.com/api",
+        "https://maps.example.com/api/",
+        "https://example.com/geolens/api",
+        "https://192.168.1",
+        "https://xn--.example",
+    ],
+)
+def test_both_entry_points_of_the_setting_refuse_the_same_values(configured):
+    """fix(#1555): one rule, wherever ``public_app_url`` enters.
+
+    The setting has two doors — the environment, read by
+    ``is_usable_public_origin``, and the admin API, validated by
+    ``validate_public_app_url`` — and each used to hold half the rule. The
+    ``/api`` clause lived only on the persisted side, so an environment value
+    naming the API base was accepted and built ``/api/api/maps/...`` links; the
+    host-spelling clauses lived only on the environment side, so the admin form
+    accepted ``https://192.168.1`` and every reader then ignored it, which is
+    the same as the form doing nothing.
+    """
+    from app.core.public_urls import is_usable_public_origin
+    from app.modules.settings.schemas import validate_public_app_url
+
+    assert not is_usable_public_origin(configured)
+    with pytest.raises(ValueError):
+        validate_public_app_url(configured)
+
+
+@pytest.mark.parametrize(
+    "configured",
+    [
+        "https://maps.example.com",
+        "https://example.com/geolens",
+        "https://xn--ls8h.example",
+    ],
+)
+def test_both_entry_points_accept_a_value_a_viewer_could_reach(configured):
+    """The counterfactual: neither door may refuse a working configuration.
+
+    ``/geolens`` is a sub-path deployment and ``xn--ls8h`` is an ACE label
+    browsers parse happily — a rule that rejected either would cost an operator
+    a setting that works today.
+    """
+    from app.core.public_urls import is_usable_public_origin
+    from app.modules.settings.schemas import validate_public_app_url
+
+    assert is_usable_public_origin(configured)
+    assert validate_public_app_url(configured) == configured

--- a/backend/tests/test_public_app_url_shape_contract_1548.py
+++ b/backend/tests/test_public_app_url_shape_contract_1548.py
@@ -178,13 +178,9 @@ def test_no_origin_the_spec_calls_routable_is_read_as_loopback():
         "mailto:ops@example.com",
         "file:///etc/hosts",
         "not-a-url",
-        # fix(#1555): the three spellings this issue adds. Each is a value the
-        # deployment cannot be reached at — an API base rather than the app, and
-        # two ACE labels no browser will parse — and each used to read as a
-        # configured non-loopback origin.
+        # fix(#1555): an API base is not an app URL, and this door never
+        # applied the clause the persisted one had.
         "https://maps.example.com/api",
-        "https://xn--.example",
-        "https://xn--a.example",
     ],
 )
 async def test_a_non_http_setting_cannot_authorize_a_domain_lock(
@@ -317,7 +313,6 @@ async def test_a_deployment_on_a_routable_host_still_gets_its_domain_lock(
         "https://maps.example.com/api/",
         "https://example.com/geolens/api",
         "https://192.168.1",
-        "https://xn--.example",
         # fix(#1555 review): resolve to the API base in a browser, and were
         # left alone by urlsplit, so both doors used to take them.
         "https://maps.example.com/api/.",
@@ -356,71 +351,22 @@ def test_both_entry_points_of_the_setting_refuse_the_same_values(configured):
 def test_both_entry_points_accept_a_value_a_viewer_could_reach(configured):
     """The counterfactual: neither door may refuse a working configuration.
 
-    ``/geolens`` is a sub-path deployment and ``xn--ls8h`` is an ACE label
-    browsers parse happily — a rule that rejected either would cost an operator
-    a setting that works today.
+    ``/geolens`` is a sub-path deployment and ``xn--ls8h`` is an ACE label all
+    four engines accept identically — a rule that rejected either would cost an
+    operator a setting that works today.
+
+    fix(#1555 review r4): ACE labels are otherwise absent from this file, and
+    that is the finding rather than an omission. Chromium and WebKit accept
+    every ``xn--`` label without decoding it, Firefox applies the full URL
+    Standard and refuses most of them, and Node agrees with neither, so no
+    refusal can be right for all of them. See ``canonical_host_error`` and the
+    fixture's ``_ace_note`` for the measurements.
     """
     from app.core.public_urls import is_usable_public_origin
     from app.modules.settings.schemas import validate_public_app_url
 
     assert is_usable_public_origin(configured)
     assert validate_public_app_url(configured) == configured
-
-
-@pytest.mark.parametrize(
-    ("label", "u_label", "browser_accepts", "why"),
-    [
-        # The finding: mapping leaves it alone, validity does not.
-        ("xn--a-sgn", "a‌", False, "ZWNJ outside any context RFC 5892 allows"),
-        ("xn--a-wbb", "́a", False, "begins with a combining mark"),
-        ("xn--a-ymcl5hc", "مثالa", False, "RTL label carrying an L character"),
-        ("xn--1a-ctdp0kd", "1مثالa", False, "same, behind a leading neutral"),
-        (
-            "xn--abc-55e",
-            "٠abc",
-            False,
-            "AN before the first strong char of an LTR label",
-        ),
-        # CheckJoiners ACCEPTS a joiner in context — the counterfactual that
-        # keeps the rule from being "no U+200C ever".
-        ("xn--11b2ezcw70k", "क्‍ष", True, "ZWJ after a virama"),
-        # Rules browsers switch OFF. Each of these is refused by idna.encode(),
-        # which is exactly why idna.encode() is not what this calls.
-        ("xn--ll-0ea", "l·l", True, "CONTEXTO: IDNA2008 refuses it, browsers do not"),
-        ("xn--ls8h", "💩", True, "emoji: not PVALID, still a label browsers parse"),
-        ("xn--m--mia", "má-", True, "CheckHyphens=false, so a trailing hyphen is fine"),
-        # CheckBidi as browsers actually scope it.
-        ("xn--mgbh0fb", "مثال", True, "an ordinary RTL label"),
-        ("xn--1-zmcl5hc", "1مثال", True, "direction comes from the first STRONG char"),
-        ("xn--1-ymcl5hc", "مثال1", True, "an RTL label may end in a European digit"),
-        # The mapping rule still runs first, so this pins the interaction.
-        ("xn--ss-8ka", "Āss", False, "uppercase: the remap check refuses it"),
-    ],
-)
-def test_a_decoded_label_must_also_pass_the_validity_criteria(
-    label, u_label, browser_accepts, why
-):
-    """fix(#1555 review r3): ``uts46_remap`` maps, and mapping is not validity.
-
-    ``browser_accepts`` is ``new URL('https://<label>.example')`` measured in
-    Node, not reasoned about. The ``u_label`` column is there so a reader can
-    see WHAT the label says without decoding punycode in their head, and it is
-    asserted, so a typo in the table is a failure rather than a lie.
-
-    The rows browsers ACCEPT are the load-bearing half. Reaching for
-    ``idna.encode`` would refuse ``l·l`` and ``💩`` — IDNA2008 is stricter than
-    the browser, and denying a working configuration is the failure this whole
-    function is written to avoid.
-    """
-    import codecs
-
-    from app.core.public_urls import canonical_host_error
-
-    assert codecs.decode(label[4:].encode("ascii"), "punycode") == u_label, (
-        "the table's own decoding is wrong"
-    )
-    accepted = canonical_host_error(f"{label}.example") is None
-    assert accepted is browser_accepts, why
 
 
 @pytest.mark.parametrize(

--- a/frontend/src/lib/__tests__/public-app-url-shape.cases.json
+++ b/frontend/src/lib/__tests__/public-app-url-shape.cases.json
@@ -1,17 +1,21 @@
 {
-  "_rule": "PUBLIC_APP_URL is usable only as an absolute HTTP(S) URL with a host, no query or fragment, none of percent-encoding / backslash / non-ASCII, and a host ALREADY SPELLED THE WAY A BROWSER SERIALIZES IT. The refusals exist because the two URL parsers READ THOSE INPUTS DIFFERENTLY, and a value the two halves disagree about is the bug class itself. This file is the ONE statement of the rule; the Python and TypeScript validators are each tested against it so they cannot drift. Backend: is_usable_public_origin() in backend/app/core/public_urls.py. Frontend: parseUsablePublicUrl() in frontend/src/lib/public-urls.ts.",
-  "_scope": "SHAPE only. Whether a shape-valid value is TRUSTED in context is a separate question — a loopback origin is shape-valid but untrusted when the browser is elsewhere — so loopback entries appear under valid here on purpose.",
+  "_rule": "PUBLIC_APP_URL is usable only as an absolute HTTP(S) URL with a host, no query or fragment, no path naming the /api base, none of percent-encoding / backslash / non-ASCII, and a host ALREADY SPELLED THE WAY A BROWSER SERIALIZES IT. The refusals exist because the two URL parsers READ THOSE INPUTS DIFFERENTLY, and a value the two halves disagree about is the bug class itself. This file is the ONE statement of the rule; the Python and TypeScript validators are each tested against it so they cannot drift. Backend: is_usable_public_origin() in backend/app/core/public_urls.py. Frontend: parseUsablePublicUrl() in frontend/src/lib/public-urls.ts.",
+  "_scope": "SHAPE only, plus the loopback classification below. Whether a shape-valid value is TRUSTED in context is a separate question — a loopback origin is shape-valid but untrusted when the browser is elsewhere — so loopback entries appear under valid here on purpose.",
   "valid": [
     "https://maps.example.com",
     "http://maps.example.com",
     "https://maps.example.com:8443",
     "https://example.com/geolens",
+    "https://maps.example.com/apiary",
     "http://localhost:8080",
     "http://127.0.0.1:8080",
+    "http://127.0.0.2:8080",
     "http://[::1]:8080",
     "https://xn--mp-mia.example",
     "https://ops:secret@maps.example.com",
     "https://xn--fa-hia.de",
+    "https://xn--ls8h.example",
+    "https://xn--80ak6aa92e.com",
     "http://192.168.0.1",
     "https://MAPS.Example.com",
     "http://[2001:db8::1]"
@@ -46,7 +50,20 @@
     "http://2130706433",
     "http://192.168.0.256",
     "http://[2001:0db8:0000:0000:0000:0000:0000:0001]",
-    "https://maps.example.com."
+    "http://[::ffff:127.0.0.1]",
+    "http://[::ffff:7f00:1]",
+    "https://maps.example.com.",
+    "https://maps.example.com/api",
+    "https://maps.example.com/api/",
+    "https://example.com/geolens/api",
+    "https://xn--.example",
+    "https://xn---.example",
+    "https://xn--a.example",
+    "https://xn--a-.example",
+    "https://xn--x.example",
+    "https://xn--0.example",
+    "https://xn--w-uia.example",
+    "https://sub.xn--.example"
   ],
   "_canonical_note": "canonical_origin maps a path-less configured value to the spelling a BROWSER presents, which is the string both sides must compare against: lowercased host, no userinfo, default port dropped. Backend: _normalize_origin(). Frontend: new URL(x).origin. A value and an origin that name the same place but spell it differently never match. Hosts here are already ASCII — see _idn_note for why no IDNA conversion appears.",
   "canonical_origin": {
@@ -63,6 +80,26 @@
     "http://192.168.0.1": "http://192.168.0.1",
     "http://[2001:db8::1]": "http://[2001:db8::1]"
   },
+  "_loopback_note": "Loopback is a RANGE, not a list of three spellings. A configured origin inside it is one only the machine running the browser can reach, so a deployment offering a domain lock from there issues a token whose shell URL every recipient resolves to their own machine — which is why the classification is part of this contract rather than each side's private opinion. Backend: is_loopback_host() in backend/app/core/public_urls.py, reached through _is_localhost_origin() in the embed service. Frontend: isLoopbackHostname() in frontend/src/lib/public-urls.ts, reached through resolvePublicAppUrl's loopback-default state. Every entry below is SHAPE-VALID, so both sides actually get as far as asking. *.localhost counts (RFC 6761 §6.3); 126/8 and 128/8 do not, and are here as the range's edges.",
+  "loopback": [
+    "http://localhost:8080",
+    "http://LOCALHOST:8080",
+    "http://app.localhost",
+    "http://127.0.0.1",
+    "http://127.0.0.2:8080",
+    "http://127.1.2.3",
+    "http://127.255.255.255",
+    "http://[::1]:8080"
+  ],
+  "not_loopback": [
+    "https://maps.example.com",
+    "http://mylocalhost.example",
+    "http://126.255.255.255",
+    "http://128.0.0.1",
+    "http://192.168.0.1",
+    "http://[2001:db8::1]"
+  ],
+  "_ace_note": "The xn-- entries under invalid are labels new URL() rejects outright, so no browser can ever present them and a domain lock issued against one is unusable the moment it is minted. The backend cannot ask a browser, so it states the rule (_ace_label_error): decodes as punycode, to something, non-ASCII, free of controls/surrogates/spaces, already lowercase and NFC, and re-encoding reproduces the label. It is deliberately a rejection of provable garbage rather than an implementation of UTS #46 — stricter than the browser would deny working configurations, which is the worse direction. Measured against Node's new URL() over 63 labels: no false rejections, one false accept (xn--a-ecp, which decodes to 'a⒈' whose UTS #46 mapping introduces a label separator). The valid list keeps xn--ls8h (an emoji label) and xn--80ak6aa92e as the counterfactual: browsers accept them and so must we.",
   "_idn_note": "An internationalized domain must be configured in its punycode (xn--) form. It is NOT translated for the operator: Python's built-in idna codec is IDNA2003 and maps faß.de to fass.de, while browsers follow WHATWG/UTS #46 and send xn--fa-hia.de. A near match denies every request while looking correct, so the class is removed rather than approximated.",
-  "_host_note": "The two sides reach the same answers by DIFFERENT methods, deliberately: the frontend has a browser URL parser and compares the host as written against the host that parser produced; the backend has none and must assert the rule directly (canonical_host_error). It cannot test stability under its own parser instead — 192.168.1 round-trips through urlsplit unchanged and is still read as 192.168.0.1 by every browser. Measured disagreements: 192.168.1 -> 192.168.0.1, 010.0.0.1 -> 8.0.0.1 (octal), 0x7f.1 -> 127.0.0.1 (hex), 2130706433 -> 127.0.0.1, and uncompressed IPv6 literals get compressed. Uppercase is accepted because both parsers lowercase it, so it is not a disagreement."
+  "_host_note": "The two sides reach the same answers by DIFFERENT methods, deliberately: the frontend has a browser URL parser and compares the host as written against the host that parser produced; the backend has none and must assert the rule directly (canonical_host_error). It cannot test stability under its own parser instead — 192.168.1 round-trips through urlsplit unchanged and is still read as 192.168.0.1 by every browser. Measured disagreements: 192.168.1 -> 192.168.0.1, 010.0.0.1 -> 8.0.0.1 (octal), 0x7f.1 -> 127.0.0.1 (hex), 2130706433 -> 127.0.0.1, and uncompressed IPv6 literals get compressed. Uppercase is accepted because both parsers lowercase it, so it is not a disagreement. fix(#1555): IPv4-MAPPED IPv6 literals are refused outright, by both sides, because neither can call the other's output canonical — Python spells ::ffff:7f00:1 as ::ffff:127.0.0.1 and a browser spells ::ffff:127.0.0.1 as ::ffff:7f00:1, so [::ffff:192.168.1.5] used to be accepted by the backend and rejected by the frontend. The plain IPv4 form is unambiguous."
 }

--- a/frontend/src/lib/__tests__/public-app-url-shape.cases.json
+++ b/frontend/src/lib/__tests__/public-app-url-shape.cases.json
@@ -1,6 +1,6 @@
 {
   "_rule": "PUBLIC_APP_URL is usable only as an absolute HTTP(S) URL with a host, no query or fragment, no path naming the /api base, none of percent-encoding / backslash / non-ASCII, and a host ALREADY SPELLED THE WAY A BROWSER SERIALIZES IT. The refusals exist because the two URL parsers READ THOSE INPUTS DIFFERENTLY, and a value the two halves disagree about is the bug class itself. This file is the ONE statement of the rule; the Python and TypeScript validators are each tested against it so they cannot drift. Backend: is_usable_public_origin() in backend/app/core/public_urls.py. Frontend: parseUsablePublicUrl() in frontend/src/lib/public-urls.ts.",
-  "_scope": "SHAPE only, plus the loopback classification below. Whether a shape-valid value is TRUSTED in context is a separate question — a loopback origin is shape-valid but untrusted when the browser is elsewhere — so loopback entries appear under valid here on purpose.",
+  "_scope": "SHAPE only, plus the loopback classification below. Whether a shape-valid value is TRUSTED in context is a separate question \u2014 a loopback origin is shape-valid but untrusted when the browser is elsewhere \u2014 so loopback entries appear under valid here on purpose.",
   "valid": [
     "https://maps.example.com",
     "http://maps.example.com",
@@ -17,12 +17,9 @@
     "https://ops:secret@maps.example.com",
     "https://xn--fa-hia.de",
     "https://xn--ls8h.example",
-    "https://xn--80ak6aa92e.com",
     "https://xn--bbe.example",
     "https://xn--mgbh0fb.example",
     "https://xn--ll-0ea.example",
-    "https://xn--11b2ezcw70k.example",
-    "https://xn--1-zmcl5hc.example",
     "https://xn--m--mia.example",
     "http://192.168.0.1",
     "https://MAPS.Example.com",
@@ -47,8 +44,8 @@
     "https://maps.example.com/%2Fpath",
     "http://",
     "https://",
-    "https://máp.example",
-    "https://faß.de",
+    "https://m\u00e1p.example",
+    "https://fa\u00df.de",
     "https://maps.example.com\\@evil.com",
     "https://maps.example.com\\.evil.com",
     "https:\\\\maps.example.com",
@@ -68,25 +65,9 @@
     "https://maps.example.com/api/./",
     "https://maps.example.com/foo/../api/.",
     "https://maps.example.com/api/%2e",
-    "https://maps.example.com/api/%2E/",
-    "https://xn--.example",
-    "https://xn---.example",
-    "https://xn--a.example",
-    "https://xn--a-.example",
-    "https://xn--x.example",
-    "https://xn--0.example",
-    "https://xn--w-uia.example",
-    "https://xn--a-ecp.example",
-    "https://xn--p09a.example",
-    "https://xn--a-sgn.example",
-    "https://xn--a-wbb.example",
-    "https://xn--a-ymcl5hc.example",
-    "https://xn--1a-ctdp0kd.example",
-    "https://xn--abc-55e.example",
-    "https://xn--ss-8ka.example",
-    "https://sub.xn--.example"
+    "https://maps.example.com/api/%2E/"
   ],
-  "_canonical_note": "canonical_origin maps a path-less configured value to the spelling a BROWSER presents, which is the string both sides must compare against: lowercased host, no userinfo, default port dropped. Backend: _normalize_origin(). Frontend: new URL(x).origin. A value and an origin that name the same place but spell it differently never match. Hosts here are already ASCII — see _idn_note for why no IDNA conversion appears.",
+  "_canonical_note": "canonical_origin maps a path-less configured value to the spelling a BROWSER presents, which is the string both sides must compare against: lowercased host, no userinfo, default port dropped. Backend: _normalize_origin(). Frontend: new URL(x).origin. A value and an origin that name the same place but spell it differently never match. Hosts here are already ASCII \u2014 see _idn_note for why no IDNA conversion appears.",
   "canonical_origin": {
     "https://maps.example.com": "https://maps.example.com",
     "https://MAPS.Example.com": "https://maps.example.com",
@@ -102,7 +83,7 @@
     "http://[2001:db8::1]": "http://[2001:db8::1]"
   },
   "_api_path_note": "The /api rule is asked of the path a BROWSER RESOLVES, not the one the parser was handed. https://maps.example.com/api/. and /foo/../api/. are left untouched by Python's urlsplit and normalized to /api/ by every browser, so both backend doors accepted them while the frontend, reading the already-resolved URL.pathname, refused. The backend implements RFC 3986 remove_dot_segments plus the URL Standard's %2e equivalences (_remove_dot_segments); this side gets it free from new URL(). Measured against Node over 34 paths: the resolved paths agree everywhere except a path-less URL, where a browser supplies / and the normalizer leaves the empty string alone, and the /api classification agrees on all 34. The %2e entries are refused by BOTH sides today on the percent-encoding clause several steps earlier, so they pin the answer rather than the normalizer; the normalizer's own %2e handling is pinned by a direct unit test instead. /api/.. and /apiary/. sit under valid as the counterfactual: dot segments that resolve AWAY from an API base must not be refused.",
-  "_loopback_note": "Loopback is a RANGE, not a list of three spellings. A configured origin inside it is one only the machine running the browser can reach, so a deployment offering a domain lock from there issues a token whose shell URL every recipient resolves to their own machine — which is why the classification is part of this contract rather than each side's private opinion. Backend: is_loopback_host() in backend/app/core/public_urls.py, reached through _is_localhost_origin() in the embed service. Frontend: isLoopbackHostname() in frontend/src/lib/public-urls.ts, reached through resolvePublicAppUrl's loopback-default state. Every entry below is SHAPE-VALID, so both sides actually get as far as asking. *.localhost counts (RFC 6761 §6.3); 126/8 and 128/8 do not, and are here as the range's edges.",
+  "_loopback_note": "Loopback is a RANGE, not a list of three spellings. A configured origin inside it is one only the machine running the browser can reach, so a deployment offering a domain lock from there issues a token whose shell URL every recipient resolves to their own machine \u2014 which is why the classification is part of this contract rather than each side's private opinion. Backend: is_loopback_host() in backend/app/core/public_urls.py, reached through _is_localhost_origin() in the embed service. Frontend: isLoopbackHostname() in frontend/src/lib/public-urls.ts, reached through resolvePublicAppUrl's loopback-default state. Every entry below is SHAPE-VALID, so both sides actually get as far as asking. *.localhost counts (RFC 6761 \u00a76.3); 126/8 and 128/8 do not, and are here as the range's edges.",
   "loopback": [
     "http://localhost:8080",
     "http://LOCALHOST:8080",
@@ -121,7 +102,7 @@
     "http://192.168.0.1",
     "http://[2001:db8::1]"
   ],
-  "_ace_note": "The xn-- entries under invalid are labels new URL() rejects outright, so no browser can ever present them and a domain lock issued against one is unusable the moment it is minted. The backend cannot ask a browser, so _ace_label_error asks the same tables the browser uses: the label decodes as punycode, decodes to something, contains a non-ASCII character, survives idna.uts46_remap(std3_rules=False, transitional=False) unchanged, and re-encodes to itself. uts46_remap IS the WHATWG/UTS #46 mapping, not an approximation of it, which is what lets this side be exact where #1548 refused to guess. Mapping is not validity, so the decoded label also has to satisfy UTS #46 §4.1 as the URL Standard configures it: no leading combining mark, CheckJoiners (a CONTEXTJ code point only in the contexts RFC 5892 allows), and CheckBidi. xn--a-sgn is the case that proved this necessary: it decodes to 'a' + U+200C, remaps unchanged, and new URL() refuses it. NOT implemented, because browsers do not apply them: hyphen positions (xn--m--mia is valid), DNS length, and CONTEXTO — IDNA2008 would refuse the Catalan l·l (xn--ll-0ea) that browsers accept, which is why idna.encode() is the wrong tool and stays unused. CheckBidi has two measured deviations from a literal reading of RFC 5893, both in the direction of accepting what browsers accept: the direction of a label is read off its first STRONG character (so xn--1-zmcl5hc, a digit followed by Arabic, is VALID), and the rules are judged per label rather than across a bidi domain (ex-.xn--mgbh0fb and xn--m--mia.xn--mgbh0fb are both accepted by new URL()). Measured against Node's new URL() over 84 labels: no false rejections and no false accepts. THE CHEROKEE PAIR IS WHY THE RULE IS THE TABLES AND NOT str.lower: xn--bbe decodes to Ꮘ (U+13B8) and is VALID, while its lowercase form xn--p09a is INVALID because UTS #46 case-maps Cherokee UPWARD and a browser therefore rewrites it. An earlier revision asked decoded == decoded.lower() and refused xn--bbe, which is the stricter-than-the-browser direction that denies a working configuration. xn--ls8h (emoji), xn--80ak6aa92e and xn--fa-hia are the rest of the counterfactual: browsers accept them, so we must too, and non-transitional processing is what keeps ß intact.",
-  "_idn_note": "An internationalized domain must be configured in its punycode (xn--) form. It is NOT translated for the operator: Python's built-in idna codec is IDNA2003 and maps faß.de to fass.de, while browsers follow WHATWG/UTS #46 and send xn--fa-hia.de. A near match denies every request while looking correct, so the class is removed rather than approximated.",
-  "_host_note": "The two sides reach the same answers by DIFFERENT methods, deliberately: the frontend has a browser URL parser and compares the host as written against the host that parser produced; the backend has none and must assert the rule directly (canonical_host_error). It cannot test stability under its own parser instead — 192.168.1 round-trips through urlsplit unchanged and is still read as 192.168.0.1 by every browser. Measured disagreements: 192.168.1 -> 192.168.0.1, 010.0.0.1 -> 8.0.0.1 (octal), 0x7f.1 -> 127.0.0.1 (hex), 2130706433 -> 127.0.0.1, and uncompressed IPv6 literals get compressed. Uppercase is accepted because both parsers lowercase it, so it is not a disagreement. fix(#1555): IPv4-MAPPED IPv6 literals are refused outright, by both sides, because neither can call the other's output canonical — Python spells ::ffff:7f00:1 as ::ffff:127.0.0.1 and a browser spells ::ffff:127.0.0.1 as ::ffff:7f00:1, so [::ffff:192.168.1.5] used to be accepted by the backend and rejected by the frontend. The plain IPv4 form is unambiguous."
+  "_ace_note": "ACE (xn--) LABELS ARE NOT VALIDATED, and this file deliberately contains no case that would require it. Measured with Playwright, in-page new URL('https://<host>/p').hostname:\n    host                   chromium 151  firefox 153  webkit 26.5  node 26\n    xn--.example           ok            THROWS       ok           THROWS\n    xn--a-sgn.example      ok            THROWS       ok           THROWS\n    xn--a-0hc.example      ok            THROWS       ok           ok\n    ex-.xn--mgbh0fb        ok            THROWS       ok           ok\n    xn--fa-hia.de          ok            ok           ok           ok\nChromium and WebKit do not decode or validate an all-ASCII host at all, so every xn-- label is accepted as opaque LDH; Firefox implements the URL Standard including all six RFC 5893 bidi rules; Node's parser matches neither. 13 of the 28 hosts measured were read differently by different engines, every one of them an xn-- case. So 'the spelling a browser sends' is not a single answer for these labels and cannot be a cross-side contract: any refusal would be stricter than the two engines most viewers use, which is the failure direction this whole rule exists to avoid. The xn-- entries that remain under valid are the ones ALL FOUR engines accept identically. Note for whoever reads this next: the TypeScript half of the contract runs on Node's parser, so it cannot stand in for Chromium or WebKit here \u2014 finding xn--.example 'invalid' in node is one engine's opinion, not the web's.",
+  "_idn_note": "An internationalized domain must be configured in its punycode (xn--) form. It is NOT translated for the operator: Python's built-in idna codec is IDNA2003 and maps fa\u00df.de to fass.de, while browsers follow WHATWG/UTS #46 and send xn--fa-hia.de. A near match denies every request while looking correct, so the class is removed rather than approximated.",
+  "_host_note": "The two sides reach the same answers by DIFFERENT methods, deliberately: the frontend has a browser URL parser and compares the host as written against the host that parser produced; the backend has none and must assert the rule directly (canonical_host_error). It cannot test stability under its own parser instead \u2014 192.168.1 round-trips through urlsplit unchanged and is still read as 192.168.0.1 by every browser. Measured disagreements: 192.168.1 -> 192.168.0.1, 010.0.0.1 -> 8.0.0.1 (octal), 0x7f.1 -> 127.0.0.1 (hex), 2130706433 -> 127.0.0.1, and uncompressed IPv6 literals get compressed. Uppercase is accepted because both parsers lowercase it, so it is not a disagreement. fix(#1555): IPv4-MAPPED IPv6 literals are refused outright, by both sides, because neither can call the other's output canonical \u2014 Python spells ::ffff:7f00:1 as ::ffff:127.0.0.1 and a browser spells ::ffff:127.0.0.1 as ::ffff:7f00:1, so [::ffff:192.168.1.5] used to be accepted by the backend and rejected by the frontend. The plain IPv4 form is unambiguous."
 }

--- a/frontend/src/lib/__tests__/public-app-url-shape.cases.json
+++ b/frontend/src/lib/__tests__/public-app-url-shape.cases.json
@@ -7,6 +7,8 @@
     "https://maps.example.com:8443",
     "https://example.com/geolens",
     "https://maps.example.com/apiary",
+    "https://maps.example.com/apiary/.",
+    "https://maps.example.com/api/..",
     "http://localhost:8080",
     "http://127.0.0.1:8080",
     "http://127.0.0.2:8080",
@@ -57,6 +59,11 @@
     "https://maps.example.com/api",
     "https://maps.example.com/api/",
     "https://example.com/geolens/api",
+    "https://maps.example.com/api/.",
+    "https://maps.example.com/api/./",
+    "https://maps.example.com/foo/../api/.",
+    "https://maps.example.com/api/%2e",
+    "https://maps.example.com/api/%2E/",
     "https://xn--.example",
     "https://xn---.example",
     "https://xn--a.example",
@@ -83,6 +90,7 @@
     "http://192.168.0.1": "http://192.168.0.1",
     "http://[2001:db8::1]": "http://[2001:db8::1]"
   },
+  "_api_path_note": "The /api rule is asked of the path a BROWSER RESOLVES, not the one the parser was handed. https://maps.example.com/api/. and /foo/../api/. are left untouched by Python's urlsplit and normalized to /api/ by every browser, so both backend doors accepted them while the frontend, reading the already-resolved URL.pathname, refused. The backend implements RFC 3986 remove_dot_segments plus the URL Standard's %2e equivalences (_remove_dot_segments); this side gets it free from new URL(). Measured against Node over 34 paths: the resolved paths agree everywhere except a path-less URL, where a browser supplies / and the normalizer leaves the empty string alone, and the /api classification agrees on all 34. The %2e entries are refused by BOTH sides today on the percent-encoding clause several steps earlier, so they pin the answer rather than the normalizer; the normalizer's own %2e handling is pinned by a direct unit test instead. /api/.. and /apiary/. sit under valid as the counterfactual: dot segments that resolve AWAY from an API base must not be refused.",
   "_loopback_note": "Loopback is a RANGE, not a list of three spellings. A configured origin inside it is one only the machine running the browser can reach, so a deployment offering a domain lock from there issues a token whose shell URL every recipient resolves to their own machine — which is why the classification is part of this contract rather than each side's private opinion. Backend: is_loopback_host() in backend/app/core/public_urls.py, reached through _is_localhost_origin() in the embed service. Frontend: isLoopbackHostname() in frontend/src/lib/public-urls.ts, reached through resolvePublicAppUrl's loopback-default state. Every entry below is SHAPE-VALID, so both sides actually get as far as asking. *.localhost counts (RFC 6761 §6.3); 126/8 and 128/8 do not, and are here as the range's edges.",
   "loopback": [
     "http://localhost:8080",

--- a/frontend/src/lib/__tests__/public-app-url-shape.cases.json
+++ b/frontend/src/lib/__tests__/public-app-url-shape.cases.json
@@ -16,6 +16,7 @@
     "https://xn--fa-hia.de",
     "https://xn--ls8h.example",
     "https://xn--80ak6aa92e.com",
+    "https://xn--bbe.example",
     "http://192.168.0.1",
     "https://MAPS.Example.com",
     "http://[2001:db8::1]"
@@ -63,6 +64,8 @@
     "https://xn--x.example",
     "https://xn--0.example",
     "https://xn--w-uia.example",
+    "https://xn--a-ecp.example",
+    "https://xn--p09a.example",
     "https://sub.xn--.example"
   ],
   "_canonical_note": "canonical_origin maps a path-less configured value to the spelling a BROWSER presents, which is the string both sides must compare against: lowercased host, no userinfo, default port dropped. Backend: _normalize_origin(). Frontend: new URL(x).origin. A value and an origin that name the same place but spell it differently never match. Hosts here are already ASCII — see _idn_note for why no IDNA conversion appears.",
@@ -99,7 +102,7 @@
     "http://192.168.0.1",
     "http://[2001:db8::1]"
   ],
-  "_ace_note": "The xn-- entries under invalid are labels new URL() rejects outright, so no browser can ever present them and a domain lock issued against one is unusable the moment it is minted. The backend cannot ask a browser, so it states the rule (_ace_label_error): decodes as punycode, to something, non-ASCII, free of controls/surrogates/spaces, already lowercase and NFC, and re-encoding reproduces the label. It is deliberately a rejection of provable garbage rather than an implementation of UTS #46 — stricter than the browser would deny working configurations, which is the worse direction. Measured against Node's new URL() over 63 labels: no false rejections, one false accept (xn--a-ecp, which decodes to 'a⒈' whose UTS #46 mapping introduces a label separator). The valid list keeps xn--ls8h (an emoji label) and xn--80ak6aa92e as the counterfactual: browsers accept them and so must we.",
+  "_ace_note": "The xn-- entries under invalid are labels new URL() rejects outright, so no browser can ever present them and a domain lock issued against one is unusable the moment it is minted. The backend cannot ask a browser, so _ace_label_error asks the same tables the browser uses: the label decodes as punycode, decodes to something, contains a non-ASCII character, survives idna.uts46_remap(std3_rules=False, transitional=False) unchanged, and re-encodes to itself. uts46_remap IS the WHATWG/UTS #46 mapping, not an approximation of it, which is what lets this side be exact where #1548 refused to guess. Measured against Node's new URL() over 65 labels: no false rejections and no false accepts. THE CHEROKEE PAIR IS WHY THE RULE IS THE TABLES AND NOT str.lower: xn--bbe decodes to Ꮘ (U+13B8) and is VALID, while its lowercase form xn--p09a is INVALID because UTS #46 case-maps Cherokee UPWARD and a browser therefore rewrites it. An earlier revision asked decoded == decoded.lower() and refused xn--bbe, which is the stricter-than-the-browser direction that denies a working configuration. xn--ls8h (emoji), xn--80ak6aa92e and xn--fa-hia are the rest of the counterfactual: browsers accept them, so we must too, and non-transitional processing is what keeps ß intact.",
   "_idn_note": "An internationalized domain must be configured in its punycode (xn--) form. It is NOT translated for the operator: Python's built-in idna codec is IDNA2003 and maps faß.de to fass.de, while browsers follow WHATWG/UTS #46 and send xn--fa-hia.de. A near match denies every request while looking correct, so the class is removed rather than approximated.",
   "_host_note": "The two sides reach the same answers by DIFFERENT methods, deliberately: the frontend has a browser URL parser and compares the host as written against the host that parser produced; the backend has none and must assert the rule directly (canonical_host_error). It cannot test stability under its own parser instead — 192.168.1 round-trips through urlsplit unchanged and is still read as 192.168.0.1 by every browser. Measured disagreements: 192.168.1 -> 192.168.0.1, 010.0.0.1 -> 8.0.0.1 (octal), 0x7f.1 -> 127.0.0.1 (hex), 2130706433 -> 127.0.0.1, and uncompressed IPv6 literals get compressed. Uppercase is accepted because both parsers lowercase it, so it is not a disagreement. fix(#1555): IPv4-MAPPED IPv6 literals are refused outright, by both sides, because neither can call the other's output canonical — Python spells ::ffff:7f00:1 as ::ffff:127.0.0.1 and a browser spells ::ffff:127.0.0.1 as ::ffff:7f00:1, so [::ffff:192.168.1.5] used to be accepted by the backend and rejected by the frontend. The plain IPv4 form is unambiguous."
 }

--- a/frontend/src/lib/__tests__/public-app-url-shape.cases.json
+++ b/frontend/src/lib/__tests__/public-app-url-shape.cases.json
@@ -19,6 +19,11 @@
     "https://xn--ls8h.example",
     "https://xn--80ak6aa92e.com",
     "https://xn--bbe.example",
+    "https://xn--mgbh0fb.example",
+    "https://xn--ll-0ea.example",
+    "https://xn--11b2ezcw70k.example",
+    "https://xn--1-zmcl5hc.example",
+    "https://xn--m--mia.example",
     "http://192.168.0.1",
     "https://MAPS.Example.com",
     "http://[2001:db8::1]"
@@ -73,6 +78,12 @@
     "https://xn--w-uia.example",
     "https://xn--a-ecp.example",
     "https://xn--p09a.example",
+    "https://xn--a-sgn.example",
+    "https://xn--a-wbb.example",
+    "https://xn--a-ymcl5hc.example",
+    "https://xn--1a-ctdp0kd.example",
+    "https://xn--abc-55e.example",
+    "https://xn--ss-8ka.example",
     "https://sub.xn--.example"
   ],
   "_canonical_note": "canonical_origin maps a path-less configured value to the spelling a BROWSER presents, which is the string both sides must compare against: lowercased host, no userinfo, default port dropped. Backend: _normalize_origin(). Frontend: new URL(x).origin. A value and an origin that name the same place but spell it differently never match. Hosts here are already ASCII — see _idn_note for why no IDNA conversion appears.",
@@ -110,7 +121,7 @@
     "http://192.168.0.1",
     "http://[2001:db8::1]"
   ],
-  "_ace_note": "The xn-- entries under invalid are labels new URL() rejects outright, so no browser can ever present them and a domain lock issued against one is unusable the moment it is minted. The backend cannot ask a browser, so _ace_label_error asks the same tables the browser uses: the label decodes as punycode, decodes to something, contains a non-ASCII character, survives idna.uts46_remap(std3_rules=False, transitional=False) unchanged, and re-encodes to itself. uts46_remap IS the WHATWG/UTS #46 mapping, not an approximation of it, which is what lets this side be exact where #1548 refused to guess. Measured against Node's new URL() over 65 labels: no false rejections and no false accepts. THE CHEROKEE PAIR IS WHY THE RULE IS THE TABLES AND NOT str.lower: xn--bbe decodes to Ꮘ (U+13B8) and is VALID, while its lowercase form xn--p09a is INVALID because UTS #46 case-maps Cherokee UPWARD and a browser therefore rewrites it. An earlier revision asked decoded == decoded.lower() and refused xn--bbe, which is the stricter-than-the-browser direction that denies a working configuration. xn--ls8h (emoji), xn--80ak6aa92e and xn--fa-hia are the rest of the counterfactual: browsers accept them, so we must too, and non-transitional processing is what keeps ß intact.",
+  "_ace_note": "The xn-- entries under invalid are labels new URL() rejects outright, so no browser can ever present them and a domain lock issued against one is unusable the moment it is minted. The backend cannot ask a browser, so _ace_label_error asks the same tables the browser uses: the label decodes as punycode, decodes to something, contains a non-ASCII character, survives idna.uts46_remap(std3_rules=False, transitional=False) unchanged, and re-encodes to itself. uts46_remap IS the WHATWG/UTS #46 mapping, not an approximation of it, which is what lets this side be exact where #1548 refused to guess. Mapping is not validity, so the decoded label also has to satisfy UTS #46 §4.1 as the URL Standard configures it: no leading combining mark, CheckJoiners (a CONTEXTJ code point only in the contexts RFC 5892 allows), and CheckBidi. xn--a-sgn is the case that proved this necessary: it decodes to 'a' + U+200C, remaps unchanged, and new URL() refuses it. NOT implemented, because browsers do not apply them: hyphen positions (xn--m--mia is valid), DNS length, and CONTEXTO — IDNA2008 would refuse the Catalan l·l (xn--ll-0ea) that browsers accept, which is why idna.encode() is the wrong tool and stays unused. CheckBidi has two measured deviations from a literal reading of RFC 5893, both in the direction of accepting what browsers accept: the direction of a label is read off its first STRONG character (so xn--1-zmcl5hc, a digit followed by Arabic, is VALID), and the rules are judged per label rather than across a bidi domain (ex-.xn--mgbh0fb and xn--m--mia.xn--mgbh0fb are both accepted by new URL()). Measured against Node's new URL() over 84 labels: no false rejections and no false accepts. THE CHEROKEE PAIR IS WHY THE RULE IS THE TABLES AND NOT str.lower: xn--bbe decodes to Ꮘ (U+13B8) and is VALID, while its lowercase form xn--p09a is INVALID because UTS #46 case-maps Cherokee UPWARD and a browser therefore rewrites it. An earlier revision asked decoded == decoded.lower() and refused xn--bbe, which is the stricter-than-the-browser direction that denies a working configuration. xn--ls8h (emoji), xn--80ak6aa92e and xn--fa-hia are the rest of the counterfactual: browsers accept them, so we must too, and non-transitional processing is what keeps ß intact.",
   "_idn_note": "An internationalized domain must be configured in its punycode (xn--) form. It is NOT translated for the operator: Python's built-in idna codec is IDNA2003 and maps faß.de to fass.de, while browsers follow WHATWG/UTS #46 and send xn--fa-hia.de. A near match denies every request while looking correct, so the class is removed rather than approximated.",
   "_host_note": "The two sides reach the same answers by DIFFERENT methods, deliberately: the frontend has a browser URL parser and compares the host as written against the host that parser produced; the backend has none and must assert the rule directly (canonical_host_error). It cannot test stability under its own parser instead — 192.168.1 round-trips through urlsplit unchanged and is still read as 192.168.0.1 by every browser. Measured disagreements: 192.168.1 -> 192.168.0.1, 010.0.0.1 -> 8.0.0.1 (octal), 0x7f.1 -> 127.0.0.1 (hex), 2130706433 -> 127.0.0.1, and uncompressed IPv6 literals get compressed. Uppercase is accepted because both parsers lowercase it, so it is not a disagreement. fix(#1555): IPv4-MAPPED IPv6 literals are refused outright, by both sides, because neither can call the other's output canonical — Python spells ::ffff:7f00:1 as ::ffff:127.0.0.1 and a browser spells ::ffff:127.0.0.1 as ::ffff:7f00:1, so [::ffff:192.168.1.5] used to be accepted by the backend and rejected by the frontend. The plain IPv4 form is unambiguous."
 }

--- a/frontend/src/lib/__tests__/public-urls.test.ts
+++ b/frontend/src/lib/__tests__/public-urls.test.ts
@@ -279,6 +279,86 @@ describe('the shared PUBLIC_APP_URL shape rule', () => {
 });
 
 /**
+ * fix(#1555): which origins are loopback is part of the contract too.
+ *
+ * Both sides carried an enumerated set of three spellings, so `127.0.0.2` — a
+ * loopback address to every operating system — was classified as a routable
+ * public origin. Here that hands out a share link nobody else can open; on the
+ * backend it lets `assert_domain_lock_is_enforceable` issue a domain lock whose
+ * shell URL every recipient resolves to their own machine. The two must agree
+ * about which deployments are misconfigured, so the table is shared:
+ * `is_loopback_host` in backend/app/core/public_urls.py runs the same entries.
+ */
+describe('the shared loopback classification', () => {
+  const spec = JSON.parse(
+    readFileSync(
+      join(process.cwd(), 'src/lib/__tests__/public-app-url-shape.cases.json'),
+      'utf-8',
+    ),
+  ) as { loopback: string[]; not_loopback: string[] };
+
+  const SERVED_AT = 'https://maps.example.com';
+
+  it('has cases on both sides', () => {
+    expect(spec.loopback.length).toBeGreaterThan(0);
+    expect(spec.not_loopback.length).toBeGreaterThan(0);
+  });
+
+  it.each(spec.loopback)(
+    '%j is not handed out while the browser is on a real hostname',
+    (value) => {
+      expect(resolvePublicAppUrl({ public_app_url: value }, SERVED_AT).kind).toBe(
+        'loopback-default',
+      );
+      expect(getPublicAppBaseUrl({ public_app_url: value }, SERVED_AT)).toBeNull();
+      expect(getShareableBaseUrl({ public_app_url: value }, SERVED_AT)).toBe(SERVED_AT);
+    },
+  );
+
+  // The counterfactual. Without it, calling everything loopback passes the
+  // block above while refusing every correctly configured deployment;
+  // 126.255.255.255 and 128.0.0.1 sit either side of 127.0.0.0/8.
+  it.each(spec.not_loopback)('%j is an ordinary public origin', (value) => {
+    expect(resolvePublicAppUrl({ public_app_url: value }, SERVED_AT).kind).toBe(
+      'trusted',
+    );
+  });
+
+  it('still trusts a loopback value on a genuine localhost install', () => {
+    expect(
+      resolvePublicAppUrl({ public_app_url: 'http://127.0.0.2:8080' }, 'http://localhost:3000'),
+    ).toEqual({ kind: 'trusted', baseUrl: 'http://127.0.0.2:8080' });
+  });
+});
+
+/**
+ * fix(#1555): an app URL that names the API base is not an app URL.
+ *
+ * The persistent-setting validator has always rejected it; the environment path
+ * did not, and `PUBLIC_APP_URL=https://maps.example.com/api` arrived here
+ * through tile-config. Every consumer appends to this value, so the copied card
+ * link became `/api/api/maps/...` and the iframe source `/api/m/...`.
+ */
+describe('an /api base is never handed out as the app URL', () => {
+  const SERVED_AT = 'https://maps.example.com';
+
+  it.each(['https://maps.example.com/api', 'https://example.com/geolens/api/'])(
+    'refuses %j',
+    (value) => {
+      expect(getPublicAppBaseUrl({ public_app_url: value }, SERVED_AT)).toBeNull();
+      // The fallback is what the operator actually gets: a link that opens.
+      expect(getShareableBaseUrl({ public_app_url: value }, SERVED_AT)).toBe(SERVED_AT);
+    },
+  );
+
+  it('leaves a path that merely starts with the same letters alone', () => {
+    expect(
+      getPublicAppBaseUrl({ public_app_url: 'https://maps.example.com/apiary' }, SERVED_AT),
+    ).toBe('https://maps.example.com/apiary');
+  });
+});
+
+/**
  * fix(#1548 review r7): a domain-locked preview must satisfy two browser rules
  * at once, and for a split-horizon deployment nothing satisfies both.
  *

--- a/frontend/src/lib/public-urls.ts
+++ b/frontend/src/lib/public-urls.ts
@@ -1,9 +1,41 @@
 import type { TileConfig } from '@/api/settings';
 
-// Mirrors _LOCALHOST_HOSTS in backend/app/modules/embed_tokens/service.py.
-// `new URL('http://[::1]:8080').hostname` keeps the brackets that Python's
-// urlparse strips, so both spellings are listed.
-const LOOPBACK_HOSTS = new Set(['localhost', '127.0.0.1', '::1', '[::1]']);
+/**
+ * Is a browser served from this hostname talking to its own machine?
+ *
+ * fix(#1555): this was a set of three exact spellings, mirroring a backend set
+ * of three. Loopback is a RANGE — all of `127.0.0.0/8` — so `http://127.0.0.2`
+ * was classified as a real public origin on both sides, and the deployment
+ * offered a domain lock whose shell URL every recipient resolves to their own
+ * machine. `is_loopback_host` in backend/app/core/public_urls.py states the
+ * same rule for Python, and `public-app-url-shape.cases.json` holds the two to
+ * the same answers.
+ *
+ * `*.localhost` counts: RFC 6761 §6.3 puts the whole zone on loopback and
+ * browsers resolve it there, so `http://app.localhost` is the same mistake in
+ * a subdomain.
+ *
+ * `URL.hostname` keeps the brackets on an IPv6 literal that Python's urlparse
+ * strips, so they come off here before parsing.
+ */
+function isLoopbackHostname(hostname: string): boolean {
+  const host = hostname.trim().toLowerCase().replace(/^\[|\]$/g, '');
+  if (!host) return false;
+  if (host === 'localhost' || host.endsWith('.localhost')) return true;
+  // `::1` is compared exactly rather than expanded, because every caller has
+  // already been through `parseUsablePublicUrl`, which requires the host to be
+  // spelled the way this parser serializes it. `[0:0:0:0:0:0:0:1]` never
+  // reaches here — it is refused as non-canonical, on both sides. An
+  // IPv4-mapped literal cannot reach here either: that whole class is refused,
+  // because Python spells `::ffff:7f00:1` as `::ffff:127.0.0.1` and this parser
+  // spells `::ffff:127.0.0.1` as `::ffff:7f00:1`, so neither side can call the
+  // other's form canonical (see `canonical_host_error`).
+  if (host === '::1') return true;
+  const octets = host.split('.');
+  if (octets.length !== 4) return false;
+  if (!octets.every((o) => /^\d{1,3}$/.test(o) && Number(o) <= 255)) return false;
+  return octets[0] === '127';
+}
 
 /**
  * Every state `PUBLIC_APP_URL` can be in, named.
@@ -73,6 +105,13 @@ function parseUsablePublicUrl(url: string): URL | null {
   if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return null;
   if (!parsed.hostname) return null;
   if (parsed.search || parsed.hash) return null;
+  // fix(#1555): NO `/api` PATH. The persistent-setting validator has always
+  // rejected an app URL that names the API base, and the environment path did
+  // not — so `PUBLIC_APP_URL=https://maps.example.com/api` arrived here through
+  // tile-config and built `/api/api/maps/...` card links and `/api/m/...`
+  // iframe sources. `is_api_base_path` (backend/app/core/public_urls.py) is now
+  // the one statement of it, and both entry points ask it.
+  if (parsed.pathname.replace(/\/+$/, '').endsWith('/api')) return null;
   // fix(#1548 review r9/r10): three refusals, all on the RAW string rather than
   // on `parsed`, because this parser has already decoded and punycoded by the
   // time we could look — the raw string is the only view Python can compare
@@ -128,6 +167,16 @@ function hostIsAlreadyCanonical(url: string, parsed: URL): boolean {
     ? hostAndPort.slice(0, hostAndPort.indexOf(']') + 1)
     : hostAndPort.split(':')[0];
   if (written.endsWith('.')) return false;
+  // fix(#1555): an IPv4-MAPPED literal has no spelling both sides call
+  // canonical. This parser renders `[::ffff:127.0.0.1]` as `[::ffff:7f00:1]`
+  // and Python renders `::ffff:7f00:1` as `::ffff:127.0.0.1`, so each side
+  // calls the other's output wrong: before this, `[::ffff:192.168.1.5]` was
+  // accepted by the backend and refused here. Both refuse the class now — the
+  // plain IPv4 form is unambiguous. Tested against `parsed.hostname`, which is
+  // this parser's canonical spelling, so it catches the class rather than one
+  // spelling of it; the pattern is the mapped block `::ffff:0:0/96`, which
+  // always serializes as `::ffff:` plus exactly two hex groups.
+  if (/^\[::ffff:[0-9a-f]{1,4}:[0-9a-f]{1,4}\]$/.test(parsed.hostname)) return false;
   return written.toLowerCase() === parsed.hostname.toLowerCase();
 }
 
@@ -190,10 +239,10 @@ export function resolvePublicAppUrl(
 
   const currentIsLoopback = (() => {
     const current = parseUsablePublicUrl(currentOrigin);
-    return current !== null && LOOPBACK_HOSTS.has(current.hostname.toLowerCase());
+    return current !== null && isLoopbackHostname(current.hostname);
   })();
 
-  if (LOOPBACK_HOSTS.has(parsed.hostname.toLowerCase()) && !currentIsLoopback) {
+  if (isLoopbackHostname(parsed.hostname) && !currentIsLoopback) {
     return { kind: 'loopback-default', value: canonical };
   }
 

--- a/frontend/src/lib/public-urls.ts
+++ b/frontend/src/lib/public-urls.ts
@@ -111,6 +111,11 @@ function parseUsablePublicUrl(url: string): URL | null {
   // tile-config and built `/api/api/maps/...` card links and `/api/m/...`
   // iframe sources. `is_api_base_path` (backend/app/core/public_urls.py) is now
   // the one statement of it, and both entry points ask it.
+  //
+  // `parsed.pathname` has ALREADY resolved dot segments, so `/api/.` arrives
+  // here as `/api/` and is refused for free. That is precisely why the backend
+  // needed `_remove_dot_segments`: `urlsplit` leaves `/api/.` alone, so it used
+  // to accept a value this side rejects.
   if (parsed.pathname.replace(/\/+$/, '').endsWith('/api')) return null;
   // fix(#1548 review r9/r10): three refusals, all on the RAW string rather than
   // on `parsed`, because this parser has already decoded and punycoded by the


### PR DESCRIPTION
Three items from #1555, all the same kind of mistake: the backend accepts a `PUBLIC_APP_URL` naming something no browser can present, which is enough for `assert_domain_lock_is_enforceable` to read the deployment as configured and mint a domain lock that denies every request from the moment it exists.

## What changed

### Loopback is a range, not a list

`_LOCALHOST_HOSTS` named `127.0.0.1` and nothing else in `127.0.0.0/8`, so `http://127.0.0.2:8080` classified as a routable public origin. `is_loopback_host` (`backend/app/core/public_urls.py`) states the range once, and `isLoopbackHostname` mirrors it in `frontend/src/lib/public-urls.ts`. `*.localhost` counts, since RFC 6761 §6.3 puts the zone on loopback and browsers resolve it there.

`_LOOPBACK_CLIENT_IPS` stays an exact set, and the asymmetry is deliberate. That one *gates* the H-31 localhost bypass, so a miss denies; a miss in the origin classification *issues* a lock that can never work. Widening it would hand the bypass to more callers, which is not what this issue asks for. The reason is now a comment rather than an accident.

### ACE (xn--) labels are NOT validated, and that is a finding

The issue asks for `https://xn--.example` to be rejected, on the premise that browsers refuse it. Three rounds of this PR implemented that: punycode decode, UTS #46 mapping equality, then the section 4.1 validity criteria. All of it has been removed, because the premise does not survive measurement. Node's URL parser is not a browser. Measured with Playwright, in-page `new URL('https://<host>/p').hostname`:

```
host                   chromium 151  firefox 153  webkit 26.5  node 26
xn--.example           ok            THROWS       ok           THROWS
xn--a-sgn.example      ok            THROWS       ok           THROWS
xn--a-0hc.example      ok            THROWS       ok           ok
ex-.xn--mgbh0fb        ok            THROWS       ok           ok
xn--fa-hia.de          ok            ok           ok           ok
```

Chromium and WebKit do not decode or validate an all-ASCII host at all, so every `xn--` label is accepted as opaque LDH. Firefox implements the URL Standard including all six RFC 5893 bidi rules. Node matches neither. Of 28 hosts measured, 13 were read differently by different engines and every one of them was an `xn--` case.

So "the spelling a browser sends" has no single answer for these labels and cannot be a cross-side contract. Any refusal we ship is stricter than the two engines most viewers use, which is the direction this rule exists to avoid, and no rule can satisfy Firefox and Chromium at once. An `xn--` label is accepted as LDH, exactly as before this PR. The measurement is recorded at the site and in the fixture note, so the next reader who runs `new URL('https://xn--.example')` in node and finds it invalid knows why we do not act on it.

**The frontend cannot stand in for a browser here.** The TypeScript half of the contract runs under vitest on Node's parser. For host shape, IP spelling and dot segments that is fine, because all four engines agree. For ACE labels it is not: asserting Node's verdicts would have pinned one engine's opinion as the web's, which is how the removed rule got three rounds deep. The fixture now keeps only the `xn--` labels every engine accepts identically.

### An app URL whose path ends in /api

`validate_public_app_url` has always refused it. The environment path never ran that validator, so `PUBLIC_APP_URL=https://maps.example.com/api` reached `SharePanel` through tile-config and built `/api/api/maps/...` card links and `/api/m/...` iframe sources. The clause moves into `is_api_base_path`, the shared shape rule applies it, and `validate_public_app_url` now defers to `is_usable_public_origin` for everything it does not say itself. One rule, both doors.

### Found while writing the fixture: IPv4-mapped IPv6 literals

Python renders `::ffff:7f00:1` as `::ffff:127.0.0.1`, and a browser renders `::ffff:127.0.0.1` as `::ffff:7f00:1`. So `[::ffff:192.168.1.5]` was accepted by the backend and refused by the frontend, and neither side can call the other's output canonical. The class is refused on both sides, with a message naming the plain IPv4 form. Same treatment #1548 gave non-ASCII hosts, for the same reason.

`public-app-url-shape.cases.json` now carries the loopback classification alongside the shape table, because which deployments count as misconfigured cannot be each side's private opinion when the UI and the API both answer it.

## On internationalized hostnames

No IDNA conversion was added and none is needed. Non-ASCII hosts stay refused outright, as #1548 decided. That refusal is engine-independent: all four engines map `faß.de` to `xn--fa-hia.de` identically, so the case stays pinned in the fixture from both sides, `https://faß.de` invalid and `https://xn--fa-hia.de` valid.

The shipped `http://localhost:8080` default is untouched and still treated as unconfigured.

## Scope note

`resolve_public_app_url`, the resolver behind OGC self-links, OAuth redirect URIs and response bodies, is unchanged. It still returns an `/api`-suffixed value verbatim when that is what the operator configured. Its job is to produce a link rather than to judge an origin, and quietly changing it would move behaviour on surfaces this issue says nothing about. The two doors that *validate* the setting are the ones unified here.

One side effect worth naming: `_normalize_origin` in `embed_tokens/schemas.py` already routed through `canonical_host_error`, so `allowed_origins` now rejects an IPv4-mapped literal too. That is an origin no engine sends, so a token restricted to one was never enforceable. Stored rows are not revalidated.

## Verification

Red runs, each with one rule reverted and nothing else:

```
# loopback range -> the old three-spelling set
FAILED test_public_app_url_shape_contract_1548.py::test_every_origin_the_spec_calls_loopback_is_read_as_loopback
FAILED test_public_app_url_shape_contract_1548.py::test_a_loopback_setting_outside_127_0_0_1_cannot_authorize_a_domain_lock
E       Failed: DID NOT RAISE DomainLockNotEnforceableError
2 failed, 24 passed

# /api clause removed from the shape rule
FAILED ...::test_every_shape_the_spec_calls_invalid_is_refused
FAILED ...::test_a_non_http_setting_cannot_authorize_a_domain_lock[https://maps.example.com/api]
FAILED ...::test_both_entry_points_of_the_setting_refuse_the_same_values[https://maps.example.com/api]
FAILED ...::test_both_entry_points_of_the_setting_refuse_the_same_values[https://maps.example.com/api/]
FAILED ...::test_both_entry_points_of_the_setting_refuse_the_same_values[https://example.com/geolens/api]
5 failed, 21 passed

# validate_public_app_url no longer defers to the shape rule
FAILED ...::test_both_entry_points_of_the_setting_refuse_the_same_values[https://192.168.1]
FAILED ...::test_both_entry_points_of_the_setting_refuse_the_same_values[https://xn--.example]
E       Failed: DID NOT RAISE ValueError
2 failed, 24 passed

# backend IPv4-mapped refusal removed
FAILED ...::test_every_shape_the_spec_calls_invalid_is_refused
E       assert not ['http://[::ffff:127.0.0.1]']
1 failed, 25 passed
```

Frontend, same treatment:

```
# isLoopbackHostname -> the old set
x "http://app.localhost" is not handed out while the browser is on a real hostname
x "http://127.0.0.2:8080" is not handed out while the browser is on a real hostname
x "http://127.1.2.3" is not handed out while the browser is on a real hostname
x "http://127.255.255.255" is not handed out while the browser is on a real hostname
Tests  4 failed | 145 passed (149)

# /api clause removed
x rejects "https://maps.example.com/api"
x rejects "https://maps.example.com/api/"
x rejects "https://example.com/geolens/api"
x refuses "https://maps.example.com/api"
x refuses "https://example.com/geolens/api/"
Tests  5 failed | 144 passed (149)

# IPv4-mapped refusal removed
x rejects "http://[::ffff:7f00:1]"
Tests  1 failed | 148 passed (149)
```

Counterfactuals, so no rule is a blanket refusal:

- `test_no_origin_the_spec_calls_routable_is_read_as_loopback` runs the `not_loopback` fixture entries. `126.255.255.255` and `128.0.0.1` sit either side of the block, and `mylocalhost.example` ends in the same letters as the one special hostname.
- `test_a_deployment_on_a_routable_host_still_gets_its_domain_lock`: a correctly configured deployment still mints its lock.
- `test_both_entry_points_accept_a_value_a_viewer_could_reach`: `https://example.com/geolens` (a sub-path install) and `https://xn--ls8h.example` (an ACE label all four engines accept) pass both doors.
- `https://maps.example.com/apiary` stays valid, and the frontend asserts it is handed out unchanged.
- `resolvePublicAppUrl({public_app_url: 'http://127.0.0.2:8080'}, 'http://localhost:3000')` is still `trusted`, so a genuine local install is not caught.
- `https://xn--ls8h.example` and the other five `xn--` labels every engine accepts identically stay valid on both sides.

Green:

```
285 passed  # contract, public_urls, both domain-lock suites, origin bypass,
            # csp_no_wildcard, embed_tokens, settings_router, persistent_config
47 passed   # tests/test_layering.py
All checks passed!            # ruff check
1024 files already formatted  # ruff format --check
make openapi-check            # no drift
npm run lint / npm run typecheck   # clean
244 passed  # public-urls, SharePanel, error-map
```

`_MODULE_LOC_CAPS` for `embed_tokens/service.py` goes 1042 to 1056, with a comment saying what the lines bought. `backend/app/core/public_urls.py` ends at 806 lines, under the 1000-line ratchet threshold. No new `t()` keys, no route or schema change, so nothing to regenerate for OpenAPI or the SDKs.

Closes #1555
