### PR TITLE
fix(embeddings): stop rendering a traceback per failed record in the backfill

### DIFF
--- a/backend/app/processing/embeddings/backfill.py
+++ b/backend/app/processing/embeddings/backfill.py
@@ -59,25 +59,36 @@ def _compact_error(exc: BaseException) -> str:
     buried in one traceback among thousands: a provider error names its
     endpoint, and an endpoint can carry a key in its query string.
 
-    fix(#1577 review, codex P1): redact BEFORE truncating. The redactor
-    recognises userinfo by its terminating `@`, so a cut that lands between the
-    password and that `@` leaves `https://alice:hunter2` behind, which
-    `redact_url_credentials` then reads as a host and a port and passes through
-    untouched. Truncating last also costs nothing extra on the path this fix is
-    about: the two passes above already walk the whole message, and the
-    `DBAPIError` case redacts 73 characters of driver message where the old
-    order redacted the full 200. The redactor is linear (0.0028 ms at 73
-    characters, 13 ms at 100 KB), so a message large enough to matter would have
-    to be pathological — and it could not be helped by a cheaper cut first,
-    since a cut before redaction is the bug being fixed, at whatever offset.
+    fix(#1577 reviews r1 and r2, codex P1 twice): THE REDACTOR RUNS FIRST, ON
+    THE RAW STRING. Nothing may be inserted above it. Both rounds found the same
+    bug at a different transformation, because every one of them can break the
+    pattern the redactor matches on:
+
+    - Truncating first (r1) cuts the `@` that terminates userinfo, leaving
+      `https://alice:hunter2`, which reads as a host and a port and passes
+      through untouched.
+    - Collapsing whitespace first (r2) turns a tab, CR or LF inside a URL into a
+      space, and `URL_LIKE_RE` stops at whitespace. `https://alice:hun\\nter2@…`
+      becomes `https://alice:hun ter2@…` and the match dies before the `@`. A
+      split in the HOST is worse still: the match ends there and a query-string
+      key further along is never even reached.
+
+    The `[SQL:` cut moved below for the same reason — it is a cut, and the rule
+    cannot have exceptions and still be a rule. Cost of redacting the untrimmed
+    string instead: measured below.
+
+    What is left above the redactor is choosing `orig` over `exc` and calling
+    `str()`. Neither can split a match: `orig` is a different, shorter string
+    rather than a mangled one, so it can only omit a credential the SQL tail
+    would have carried, never expose a split one. A driver that itself hands us
+    a message already cut mid-URL is out of reach of any ordering here.
     """
     origin = getattr(exc, "orig", None)
-    message = str(origin if origin is not None else exc)
+    message = redact_url_credentials(str(origin if origin is not None else exc))
     marker = message.find("[SQL:")
     if marker != -1:
         message = message[:marker]
     message = " ".join(message.split())
-    message = redact_url_credentials(message)
     if len(message) > _MAX_ERROR_CHARS:
         message = message[: _MAX_ERROR_CHARS - 3] + "..."
     return message

--- a/backend/app/processing/embeddings/backfill.py
+++ b/backend/app/processing/embeddings/backfill.py
@@ -58,6 +58,18 @@ def _compact_error(exc: BaseException) -> str:
     Redacted because this message now reaches the log on its own rather than
     buried in one traceback among thousands: a provider error names its
     endpoint, and an endpoint can carry a key in its query string.
+
+    fix(#1577 review, codex P1): redact BEFORE truncating. The redactor
+    recognises userinfo by its terminating `@`, so a cut that lands between the
+    password and that `@` leaves `https://alice:hunter2` behind, which
+    `redact_url_credentials` then reads as a host and a port and passes through
+    untouched. Truncating last also costs nothing extra on the path this fix is
+    about: the two passes above already walk the whole message, and the
+    `DBAPIError` case redacts 73 characters of driver message where the old
+    order redacted the full 200. The redactor is linear (0.0028 ms at 73
+    characters, 13 ms at 100 KB), so a message large enough to matter would have
+    to be pathological — and it could not be helped by a cheaper cut first,
+    since a cut before redaction is the bug being fixed, at whatever offset.
     """
     origin = getattr(exc, "orig", None)
     message = str(origin if origin is not None else exc)
@@ -65,9 +77,10 @@ def _compact_error(exc: BaseException) -> str:
     if marker != -1:
         message = message[:marker]
     message = " ".join(message.split())
+    message = redact_url_credentials(message)
     if len(message) > _MAX_ERROR_CHARS:
         message = message[: _MAX_ERROR_CHARS - 3] + "..."
-    return redact_url_credentials(message)
+    return message
 
 
 def _error_fields(exc: BaseException, traced: set[str]) -> dict[str, Any]:

--- a/backend/app/processing/embeddings/backfill.py
+++ b/backend/app/processing/embeddings/backfill.py
@@ -19,6 +19,7 @@ from sqlalchemy import delete, select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.persistent_config import AI_ENABLED, EMBEDDING_DIMS
+from app.core.url_redaction import redact_url_credentials
 from app.platform.extensions import get_processing_port
 from app.processing.embeddings.models import RecordEmbedding
 from app.processing.embeddings.service import (
@@ -38,6 +39,72 @@ _BATCH_SIZE = 128
 # Text for the force-path pre-flight embedding. Short, so the call is cheap,
 # and constant, so a provider's cache can serve it.
 _PREFLIGHT_TEXT = "geolens embedding preflight"
+
+# fix(#1544): how much of a caught exception's message survives into a log line.
+# Everything an operator acts on is at the front ("expected 1536 dimensions, not
+# 768"); the tail is the statement and its bound parameters, one of which is the
+# vector.
+_MAX_ERROR_CHARS = 200
+
+
+def _compact_error(exc: BaseException) -> str:
+    """Describe an exception in one short line, without its bound parameters.
+
+    Prefers the driver's own message (`DBAPIError.orig`), which names the actual
+    failure and carries neither the statement nor the parameters. For anything
+    else — a provider error, say — cut at the marker SQLAlchemy puts before the
+    statement, collapse to one line, truncate.
+
+    Redacted because this message now reaches the log on its own rather than
+    buried in one traceback among thousands: a provider error names its
+    endpoint, and an endpoint can carry a key in its query string.
+    """
+    origin = getattr(exc, "orig", None)
+    message = str(origin if origin is not None else exc)
+    marker = message.find("[SQL:")
+    if marker != -1:
+        message = message[:marker]
+    message = " ".join(message.split())
+    if len(message) > _MAX_ERROR_CHARS:
+        message = message[: _MAX_ERROR_CHARS - 3] + "..."
+    return redact_url_credentials(message)
+
+
+def _error_fields(exc: BaseException, traced: set[str]) -> dict[str, Any]:
+    """Log fields for a caught exception; MUTATES `traced` to spend the traceback.
+
+    fix(#1544): a failing backfill used to cost more than a succeeding one, and
+    all of it was inside the log formatter. Measured end to end on the #1533
+    failure shape — a run where every insert fails the column's typmod, so the
+    batch falls into this retry and every record raises a `DataError` out of the
+    ORM flush. `exc_info=True` per record cost 964 ms and 60.6 KiB of output per
+    record under the dev console renderer, and 3.1 ms and 12.7 KiB under the JSON
+    renderer production uses. A 200-record run took 194 s before and 1.5 s after;
+    a 1,000-record one wrote 12.4 MB of log output before and 0.35 MB after.
+
+    The vector is in that rendering, but it is not the expensive part: SQLAlchemy
+    already truncates a long bound parameter to about 150 characters a side, so
+    the ~6 KB vector reaches the log as ~440 characters. The traceback is what
+    costs — 33 frames over a three-exception chain, 12 KB of text before any
+    renderer decorates it — which is why this drops the traceback rather than
+    only the parameters.
+
+    One traceback per distinct exception type per run, not per run: the same type
+    raised repeatedly on this path has the same stack, while a second type is a
+    second failure mode and its stack is new information. Types are tracked by
+    qualified name so two `DataError`s from different libraries stay distinct.
+    The set is owned by `backfill_embeddings`, so the budget spans the whole run
+    rather than resetting at each batch boundary, and one type first seen at the
+    batch level does not then spend a second traceback on the retry path.
+    """
+    error_type = f"{type(exc).__module__}.{type(exc).__qualname__}"
+    first_of_type = error_type not in traced
+    traced.add(error_type)
+    return {
+        "error_type": error_type,
+        "error": _compact_error(exc),
+        "exc_info": first_of_type,
+    }
 
 
 async def _snapshot_embedding_config(
@@ -201,6 +268,7 @@ async def _retry_batch_per_record(
     model_name: str,
     embedding_dims: int | None,
     base_url: str | None,
+    traced_errors: set[str],
 ) -> tuple[int, int]:
     """Re-embed a failed batch one record at a time; return (created, errors).
 
@@ -213,6 +281,9 @@ async def _retry_batch_per_record(
 
     `created` is the run's running total, passed in only so an abort message
     can say how many records the run had written before it stopped.
+
+    `traced_errors` is the run's traceback budget, shared with the batch handler
+    that calls this. See `_error_fields`.
     """
     made = 0
     failed = 0
@@ -257,13 +328,13 @@ async def _retry_batch_per_record(
             # prevent. It stops the run, as on the batch path.
             await session.rollback()
             raise
-        except Exception:  # broad: same isolation, per record
+        except Exception as exc:  # broad: same isolation, per record
             await session.rollback()
             failed += 1
             logger.warning(
                 "Backfill: error processing record",
                 record_id=record_id,
-                exc_info=True,
+                **_error_fields(exc, traced_errors),
             )
     return made, failed
 
@@ -612,6 +683,8 @@ async def backfill_embeddings(session: AsyncSession, *, force: bool = False) -> 
 
     created = 0
     errors = 0
+    # fix(#1544): the run's traceback budget, one per distinct exception type.
+    traced_errors: set[str] = set()
 
     for start in range(0, len(items), _BATCH_SIZE):
         # fix(#1525 review r4, codex P2): the pin protects each batch from the
@@ -672,13 +745,18 @@ async def backfill_embeddings(session: AsyncSession, *, force: bool = False) -> 
             # exists to prevent.
             await session.rollback()
             raise
-        except Exception:  # broad: per-batch backfill is isolated; embedding API/DB errors are counted not raised
+        except Exception as exc:  # broad: per-batch backfill is isolated; embedding API/DB errors are counted not raised
             await session.rollback()
+            # fix(#1544): the same treatment `_retry_batch_per_record` gives a
+            # record, sharing its budget. One batch failure is 1/128th the volume
+            # of the retry storm it opens, but a batch that fails usually fails
+            # every one of its records too, so the two paths raise the same type
+            # and the run should pay for that stack once between them, not twice.
             logger.warning(
                 "Backfill: batch failed, retrying records individually",
                 batch_start=start,
                 batch_size=len(batch),
-                exc_info=True,
+                **_error_fields(exc, traced_errors),
             )
             made, failed = await _retry_batch_per_record(
                 session,
@@ -688,6 +766,7 @@ async def backfill_embeddings(session: AsyncSession, *, force: bool = False) -> 
                 model_name=model_name,
                 embedding_dims=embedding_dims,
                 base_url=base_url,
+                traced_errors=traced_errors,
             )
             created += made
             errors += failed

--- a/backend/tests/test_embedding_backfill_log_volume_1544.py
+++ b/backend/tests/test_embedding_backfill_log_volume_1544.py
@@ -348,6 +348,45 @@ def test_compact_error_redacts_userinfo_the_truncation_point_would_have_entered(
     assert "hun" not in compact, compact
 
 
+@pytest.mark.parametrize("whitespace", ["\n", "\r", "\t"], ids=["lf", "cr", "tab"])
+@pytest.mark.parametrize(
+    "template",
+    [
+        "provider error: https://alice:hun{ws}ter2@example.com/v1 failed",
+        "provider error: https://example.com/v1?api_key=hun{ws}ter2 failed",
+        "provider error: https://exam{ws}ple.com/v1?api_key=hunter2 failed",
+    ],
+    ids=["in-userinfo", "in-query-value", "in-host"],
+)
+def test_compact_error_redacts_a_credential_whitespace_would_have_split(
+    template, whitespace
+):
+    """Collapsing whitespace before redacting hides the credential (#1577 review r2).
+
+    `URL_LIKE_RE` stops at whitespace, so turning a tab, CR or LF inside a URL
+    into a space ends the match early. Split the userinfo and the terminating
+    `@` falls outside it; split the host and the match dies before the query
+    string is reached at all, which leaves a whole `api_key=` value in the
+    clear. The redactor handles all three itself, because `urlsplit` strips
+    those characters from a URL before parsing it — but only if it is handed
+    the raw string.
+    """
+    from app.core.url_redaction import redact_url_credentials
+    from app.processing.embeddings.backfill import _compact_error
+
+    raw = template.format(ws=whitespace)
+
+    compact = _compact_error(RuntimeError(raw))
+
+    assert "ter2" not in compact, compact
+
+    # Counterfactual, run here rather than described: the other order really
+    # does leak this exact input, so the assertion above is testing the ordering
+    # and not the redactor's own competence.
+    collapsed_first = redact_url_credentials(" ".join(raw.split()))
+    assert "ter2" in collapsed_first, collapsed_first
+
+
 def test_compact_error_truncates_a_long_message():
     """Whatever the exception, one log line stays one log line."""
     from app.processing.embeddings.backfill import _compact_error

--- a/backend/tests/test_embedding_backfill_log_volume_1544.py
+++ b/backend/tests/test_embedding_backfill_log_volume_1544.py
@@ -264,19 +264,88 @@ async def test_per_record_line_names_the_failure_without_the_vector():
 
 
 def test_compact_error_redacts_a_credential_in_an_endpoint():
-    """A provider error names its endpoint, and an endpoint can carry a key."""
+    """A provider error names its endpoint, and an endpoint can carry a key.
+
+    Asserted as equality on the whole line rather than as a substring. It pins
+    the redactor's actual output, which a containment check does not, and it
+    keeps the endpoint visible without writing `"…example.com" in compact` —
+    a shape CodeQL flags as incomplete URL sanitization wherever it appears
+    (fix(#1577 review)).
+    """
     from app.processing.embeddings.backfill import _compact_error
 
     exc = RuntimeError(
         "embedding request failed: POST "
         "https://embeddings.example.com/v1/embeddings?api_key=hunter2 returned 401"
     )
-    compact = _compact_error(exc)
 
-    assert "hunter2" not in compact
-    assert "embeddings.example.com" in compact, "the endpoint itself is still useful"
+    assert _compact_error(exc) == (
+        "embedding request failed: POST "
+        "https://embeddings.example.com/v1/embeddings?api_key=%3Credacted%3E "
+        "returned 401"
+    )
     # Counterfactual: the secret is genuinely in the message being logged.
     assert "hunter2" in str(exc)
+
+
+def _message_placing_at_past_the_truncation_point(url: str, offset: int) -> str:
+    """A message whose truncation point falls `offset` characters before `url`'s `@`.
+
+    The prefix length is computed from `_MAX_ERROR_CHARS` rather than written
+    down, so the test keeps testing the boundary if that constant moves.
+    """
+    from app.processing.embeddings.backfill import _MAX_ERROR_CHARS
+
+    return "x" * (_MAX_ERROR_CHARS - 3 - url.index("@") + offset) + url
+
+
+def test_compact_error_redacts_userinfo_the_truncation_point_would_have_split():
+    """The order of redact and truncate is load-bearing (#1577 review, codex P1).
+
+    The redactor recognises userinfo by its terminating `@`. Truncate first and
+    a message long enough to push that `@` one character past the cut leaves
+    `https://alice:hunter2` behind, which parses as a host and a port and
+    survives redaction intact — on every compact line, which is the fast path
+    this whole change exists to make cheap.
+    """
+    from app.processing.embeddings.backfill import _MAX_ERROR_CHARS, _compact_error
+
+    url = "https://alice:hunter2@example.com/v1"
+    message = _message_placing_at_past_the_truncation_point(url, 0)
+    cut = _MAX_ERROR_CHARS - 3
+
+    # Non-vacuity: the `@` sits exactly one character past the cut, and the
+    # whole password sits before it. Truncating first therefore hands the
+    # redactor a string it cannot recognise as carrying userinfo.
+    assert message.index("@") == cut
+    assert message[:cut].endswith("https://alice:hunter2")
+
+    compact = _compact_error(RuntimeError(message))
+
+    assert "hunter2" not in compact, compact
+    assert compact.endswith("..."), "the message was long enough to be truncated"
+
+
+def test_compact_error_redacts_userinfo_the_truncation_point_would_have_entered():
+    """The neighbouring boundary: the cut lands inside the password, not after it.
+
+    Truncating first leaves a fragment (`https://alice:hun`) that carries part
+    of the secret and all of the username. Redacting first leaves neither, so
+    no `user:` fragment reaches the log at any cut position.
+    """
+    from app.processing.embeddings.backfill import _MAX_ERROR_CHARS, _compact_error
+
+    url = "https://alice:hunter2@example.com/v1"
+    message = _message_placing_at_past_the_truncation_point(url, 4)
+    cut = _MAX_ERROR_CHARS - 3
+
+    # Non-vacuity: the cut lands three characters into the password.
+    assert message[:cut].endswith("https://alice:hun")
+
+    compact = _compact_error(RuntimeError(message))
+
+    assert "alice:" not in compact, compact
+    assert "hun" not in compact, compact
 
 
 def test_compact_error_truncates_a_long_message():

--- a/backend/tests/test_embedding_backfill_log_volume_1544.py
+++ b/backend/tests/test_embedding_backfill_log_volume_1544.py
@@ -1,0 +1,289 @@
+"""A failing backfill must not cost more than a succeeding one (#1544).
+
+`_retry_batch_per_record` logged `exc_info=True` once per failed record. The
+exception it renders is the insert that just failed, so the rendering carries
+the statement and its bound parameters — one of which is the generated vector —
+and a full traceback through asyncpg, greenlet and the ORM flush. Measured, one
+such rendering costs 964 ms and 60.6 KiB of output under the dev console
+renderer and 3.1 ms and 12.7 KiB under the JSON renderer production uses. Once
+per record, on a path reached whenever a batch insert fails (#1533) and
+therefore usually failing every record in the batch, that is the slowest part of
+the whole run, and it buries the one thing an operator went to the logs for.
+
+What these tests hold:
+
+  - the run's log volume grows by a small constant per failed record, not by a
+    traceback (the property; measured through the app's own JSON renderer);
+  - one traceback per distinct exception type per run, shared between the batch
+    handler and the per-record handler;
+  - the per-record line still names the record, the exception type and what went
+    wrong, and carries neither the statement nor the vector.
+
+Unit tests using mocks — no running database required.
+"""
+
+import uuid
+from contextlib import ExitStack
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+import structlog
+from sqlalchemy.exc import DBAPIError
+
+from tests._logging_state import configured_logging
+
+# A vector wide enough to be recognisable in a rendered SQL parameter list, and
+# narrow enough to keep the fixture readable. The real one is 1536 floats.
+_VECTOR_LITERAL = "[" + ",".join(f"{0.001 * i:.6f}" for i in range(256)) + "]"
+
+_DRIVER_MESSAGE = (
+    "<class 'asyncpg.exceptions.DataError'>: expected 1536 dimensions, not 768"
+)
+
+
+class _DriverError(Exception):
+    """Stands in for the asyncpg error SQLAlchemy wraps."""
+
+
+def _dimension_mismatch() -> DBAPIError:
+    """The exception the #1533 failure raises out of the per-record insert.
+
+    Built rather than provoked so the test needs no database, but built with the
+    real class and the real shape: driver error, statement, bound parameters with
+    the vector among them. `str()` of it is what the old code handed the log
+    formatter.
+    """
+    return DBAPIError(
+        "INSERT INTO catalog.record_embeddings (record_id, embedding, "
+        "model_name, content_hash) VALUES ($1::UUID, $2, $3::VARCHAR, "
+        "$4::VARCHAR) RETURNING catalog.record_embeddings.id",
+        (uuid.uuid4(), _VECTOR_LITERAL, "text-embedding-3-small", "0" * 64),
+        _DriverError(_DRIVER_MESSAGE),
+    )
+
+
+def _make_record(title="Test Dataset"):
+    """A minimal Record double with content that builds a non-empty text."""
+    record = MagicMock()
+    record.id = uuid.uuid4()
+    record.title = title
+    record.summary = "A geospatial dataset with several feature classes."
+    record.lineage_summary = None
+    record.keywords = []
+    return record
+
+
+def _make_query_result(records):
+    result = MagicMock()
+    result.unique.return_value.scalars.return_value.all.return_value = records
+    return result
+
+
+def _patch_backfill_gates(stack: ExitStack) -> None:
+    """Patch the run-level PersistentConfig gates, as the sibling suite does."""
+    from app.core.persistent_config import EMBEDDING_MODEL
+    from app.processing.embeddings import backfill as backfill_module
+
+    stack.enter_context(
+        patch.object(backfill_module.AI_ENABLED, "get", AsyncMock(return_value=True))
+    )
+    stack.enter_context(
+        patch.object(EMBEDDING_MODEL, "get", AsyncMock(return_value="test-model"))
+    )
+    stack.enter_context(
+        patch.object(
+            backfill_module.EMBEDDING_DIMS, "get", AsyncMock(return_value=1536)
+        )
+    )
+
+
+async def _run_with_failing_commit(n_records: int, commit_error_factory):
+    """Drive a full run of `n_records` where every insert fails on commit.
+
+    The provider answers normally; the batch commit raises, so the run falls into
+    the per-record retry, where each record's commit raises in turn. That is the
+    #1533 shape and the one that made this expensive.
+    """
+    from app.processing.embeddings.backfill import backfill_embeddings
+
+    records = [_make_record(title=f"Dataset {i}") for i in range(n_records)]
+
+    def _fail(*_args, **_kwargs):
+        # `side_effect` raises only what it IS, not what it returns, so the
+        # factory's exception has to be raised here. Returning it instead makes
+        # every commit succeed and every assertion below pass vacuously.
+        raise commit_error_factory()
+
+    session = AsyncMock()
+    session.execute = AsyncMock(return_value=_make_query_result(records))
+    session.commit = AsyncMock(side_effect=_fail)
+
+    with ExitStack() as stack:
+        _patch_backfill_gates(stack)
+        mock_batch = stack.enter_context(
+            patch(
+                "app.processing.embeddings.backfill.generate_embeddings_batch",
+                new_callable=AsyncMock,
+            )
+        )
+        mock_batch.side_effect = lambda texts, *a, **kw: [[0.1] * 1536] * len(texts)
+        return await backfill_embeddings(session)
+
+
+@pytest.mark.asyncio
+async def test_log_volume_per_failed_record_stays_small():
+    """The property: a run's log output grows by a line per failure, not a traceback.
+
+    Measured against the app's own JSON renderer — the production posture, and
+    the one #1544 said had never been sized — by running the same failure at two
+    record counts and taking the slope. A traceback per record puts that slope
+    around 12 KiB; a compact line puts it under a few hundred bytes.
+
+    The slope is what is asserted rather than the total, because the total also
+    contains the run's fixed lines (start, progress, complete) and the single
+    traceback the run is still allowed to spend. Those are constants and cancel.
+
+    Only the backfill module's own lines are counted. The mocked session hands
+    `PersistentConfig` a `MagicMock` where a settings row would be, so each drift
+    check logs a validation failure that a real database never produces; leaving
+    those in would measure the test double.
+    """
+    import io
+    import json
+    import logging
+
+    def _backfill_bytes(rendered: str) -> int:
+        total = 0
+        for line in rendered.splitlines():
+            event = json.loads(line)
+            if event.get("logger") == "app.processing.embeddings.backfill":
+                total += len(line)
+        return total
+
+    sizes = {}
+    for n_records in (4, 24):
+        with configured_logging(json_logs=True, log_level="INFO"):
+            sink = io.StringIO()
+            logging.getLogger().handlers[0].setStream(sink)
+            await _run_with_failing_commit(n_records, _dimension_mismatch)
+            sizes[n_records] = _backfill_bytes(sink.getvalue())
+
+    per_record = (sizes[24] - sizes[4]) / 20
+    assert per_record < 1024, (
+        f"each additional failed record adds {per_record:.0f} bytes of log output "
+        f"(4 records -> {sizes[4]} bytes, 24 -> {sizes[24]}); a traceback per record "
+        "costs about 2.9 KiB with this test's shallow stack and about 12 KiB with "
+        "the real one, against roughly 350 bytes for a compact line"
+    )
+
+
+@pytest.mark.asyncio
+async def test_one_traceback_for_a_run_of_identical_failures():
+    """Twelve failures of one type spend one traceback between all of them."""
+    with structlog.testing.capture_logs() as captured:
+        result = await _run_with_failing_commit(12, _dimension_mismatch)
+
+    assert result["errors"] == 12, result
+
+    per_record = [
+        event
+        for event in captured
+        if event["event"] == "Backfill: error processing record"
+    ]
+    assert len(per_record) == 12, "one line per failed record"
+
+    with_traceback = [event for event in captured if event.get("exc_info")]
+    assert len(with_traceback) == 1, (
+        "expected exactly one traceback for the run, got "
+        f"{[event['event'] for event in with_traceback]}"
+    )
+    # It is the batch handler that sees the type first, so it is the one that
+    # spends it; every per-record line after that is compact.
+    assert (
+        with_traceback[0]["event"]
+        == "Backfill: batch failed, retrying records individually"
+    )
+    assert all(event["exc_info"] is False for event in per_record)
+
+
+@pytest.mark.asyncio
+async def test_a_second_failure_mode_gets_its_own_traceback():
+    """The counterfactual for the test above: suppression is per type, not blanket.
+
+    A budget of one traceback per RUN would hide the second failure mode
+    entirely. Two types among the same records must produce two tracebacks, and
+    no more.
+    """
+    errors = [_dimension_mismatch() for _ in range(6)]
+    errors[3] = RuntimeError("provider refused the input")
+    errors[4] = RuntimeError("provider refused the input")
+    # +1 for the batch commit that opens the retry path.
+    sequence = iter([_dimension_mismatch(), *errors])
+
+    with structlog.testing.capture_logs() as captured:
+        await _run_with_failing_commit(6, lambda: next(sequence))
+
+    with_traceback = [event for event in captured if event.get("exc_info")]
+    assert len(with_traceback) == 2, [event["error_type"] for event in with_traceback]
+    assert {event["error_type"] for event in with_traceback} == {
+        "sqlalchemy.exc.DBAPIError",
+        "builtins.RuntimeError",
+    }
+
+
+@pytest.mark.asyncio
+async def test_per_record_line_names_the_failure_without_the_vector():
+    """The compact line has to stay useful: what failed, on which record, why."""
+    records_seen = []
+
+    with structlog.testing.capture_logs() as captured:
+        await _run_with_failing_commit(3, _dimension_mismatch)
+
+    per_record = [
+        event
+        for event in captured
+        if event["event"] == "Backfill: error processing record"
+    ]
+    assert len(per_record) == 3
+
+    for event in per_record:
+        records_seen.append(event["record_id"])
+        assert event["error_type"] == "sqlalchemy.exc.DBAPIError"
+        assert "expected 1536 dimensions, not 768" in event["error"]
+        assert "[SQL:" not in event["error"]
+        assert "0.001000,0.002000" not in event["error"]
+        assert len(event["error"]) <= 200
+
+    assert len(set(records_seen)) == 3, "each line names its own record"
+
+    # Counterfactual: those assertions are only worth something because the
+    # rendering the old code handed the formatter really does carry both.
+    rendered = str(_dimension_mismatch())
+    assert "[SQL:" in rendered
+    assert "0.001000,0.002000" in rendered
+
+
+def test_compact_error_redacts_a_credential_in_an_endpoint():
+    """A provider error names its endpoint, and an endpoint can carry a key."""
+    from app.processing.embeddings.backfill import _compact_error
+
+    exc = RuntimeError(
+        "embedding request failed: POST "
+        "https://embeddings.example.com/v1/embeddings?api_key=hunter2 returned 401"
+    )
+    compact = _compact_error(exc)
+
+    assert "hunter2" not in compact
+    assert "embeddings.example.com" in compact, "the endpoint itself is still useful"
+    # Counterfactual: the secret is genuinely in the message being logged.
+    assert "hunter2" in str(exc)
+
+
+def test_compact_error_truncates_a_long_message():
+    """Whatever the exception, one log line stays one log line."""
+    from app.processing.embeddings.backfill import _compact_error
+
+    compact = _compact_error(RuntimeError("x" * 5000))
+
+    assert len(compact) == 200
+    assert compact.endswith("...")


### PR DESCRIPTION
## What

`_retry_batch_per_record` logged `exc_info=True` once per failed record. Each failure now logs one compact line (record id, the exception's qualified type, the driver's own message truncated to 200 characters), and the full traceback is spent once per distinct exception type per run, shared with the batch handler.

## Why

The exception the formatter is handed is the insert that just failed. Rendering it walks a 33-frame traceback over a three-exception chain (`DBAPIError`, the SQLAlchemy asyncpg wrapper, `asyncpg.DataError`), which is 12 KB of text before any renderer decorates it, plus the statement and its bound parameters. The retry path is reached whenever a batch insert fails, and a batch that fails on the column's typmod fails every one of its records, so that rendering gets paid for per record.

## What I measured

End to end, driving the real `backfill_embeddings` over N records where every insert fails a `vector(1536)` column with 768-float vectors, which is the #1533 shape. The provider stub succeeds, so the failure is a real `DataError` out of a real ORM flush against a scratch database. The two arms differ only in what the handlers pass to `logger.warning`.

| renderer | | ms/record | log bytes/record | run |
| --- | --- | --- | --- | --- |
| dev console (`ConsoleRenderer` + rich) | before | 972 | 60.6 KiB | 200 records: 194 s |
| | after | 7.7 | 0.7 KiB | 200 records: 1.5 s |
| JSON (production) | before | 6.2 | 12.7 KiB | 1,000 records: 6.2 s, 12.4 MB |
| | after | 3.1 | 0.4 KiB | 1,000 records: 3.1 s, 0.35 MB |

Both arms pay the failing database round trip, so the "after" numbers are not pure formatter time. Subtracting it, the formatting cost per record drops from about 964 ms to under a millisecond in development, and from about 3.1 ms to about 0.02 ms in production.

#1544 asked for a production figure, since the ten-minute observation was made against the pretty renderer. Here it is: roughly 3.1 ms and 12.7 KiB per failed record under the JSON renderer. Ten thousand failing records therefore cost about 31 s of formatting and 127 MB of log output, sitting on top of a run whose own database and ORM work is about 20 s.

### On the vector

The issue's premise is half right, and the wrong half changes the fix. The vector is inline in `[parameters: ...]`, but SQLAlchemy already truncates a long bound parameter to about 150 characters a side, so a 1536-float vector reaches the log as roughly 440 characters rather than 6 KB:

```
[parameters: (UUID('a9d2ae39-...'), '[0.0,0.001,0.002, ... (5752 characters truncated) ... ,0.088]',
 'text-embedding-3-small', '000...')]
```

Keeping the traceback and stripping only the parameters would have removed about 3% of the cost. The traceback is the expensive part, so that is what this drops.

### The other `exc_info=True` calls on this path

The batch handler (`Backfill: batch failed, retrying records individually`) has the same problem at 1/128th the volume. It gets the same treatment and shares the same budget, because a batch that fails usually fails all of its records, so both handlers raise the same type and the run should pay for that stack once between them rather than once each.

`_preflight_embedding` runs once per force run and reports a provider error rather than a statement, so it carries neither a traceback storm nor a vector. Left alone. `service.py:316`, `service.py:428` and `helpers.py:83` are off this path and not per record. Also left alone.

## Decisions worth review

One traceback per distinct exception type, not one per run. A run of a single failure mode gets one stack; a second mode gets its own, because that stack is new information. Types are keyed by qualified name (`sqlalchemy.exc.DBAPIError`), so two `DataError`s from different libraries stay distinct. `_error_fields` mutates the set it is handed, which is documented at the function, and it is why the budget lives on `backfill_embeddings` instead of resetting at each batch boundary.

The message comes from `DBAPIError.orig`, which is the driver's own text ("expected 1536 dimensions, not 768") with no statement and no parameters attached. An exception without an `orig` is cut at the `[SQL:` marker, collapsed to one line and truncated.

URL credentials are redacted. A provider error names its endpoint, and an endpoint can carry a key in its query string. Under the old code that string only ever appeared inside a traceback; it is now a field of its own, so it goes through `redact_url_credentials`. Nothing is worse than before (this is strictly less than what the traceback already printed), but a new field deserved the pass.

`_retry_batch_per_record` grew a `traced_errors` parameter rather than reading a module-level set. Two concurrent runs would otherwise share a budget, and the second would silently lose its tracebacks.

## Verification

New file: `backend/tests/test_embedding_backfill_log_volume_1544.py`.

The load-bearing test measures the property rather than the line I touched. It runs the same all-failing backfill at 4 and 24 records through the app's own JSON renderer and asserts the slope, bytes per additional failed record, stays under 1 KiB. A traceback per record puts that slope in the thousands. Only lines from the backfill logger are counted: the mocked session hands `PersistentConfig` a `MagicMock` where a settings row would be, and each drift check then logs a validation failure that a real database never produces.

Red, with both call sites reverted to `exc_info=True` and nothing else changed:

```
E       AssertionError: each additional failed record adds 2919 bytes of log output
        (4 records -> 13777 bytes, 24 -> 72164)
E       assert 2919.35 < 1024

E       AssertionError: expected exactly one traceback for the run, got
        ['Backfill: batch failed, retrying records individually',
         'Backfill: error processing record', ... x12]
E       assert 13 == 1

FAILED tests/test_embedding_backfill_log_volume_1544.py::test_log_volume_per_failed_record_stays_small
FAILED tests/test_embedding_backfill_log_volume_1544.py::test_one_traceback_for_a_run_of_identical_failures
FAILED tests/test_embedding_backfill_log_volume_1544.py::test_a_second_failure_mode_gets_its_own_traceback
FAILED tests/test_embedding_backfill_log_volume_1544.py::test_per_record_line_names_the_failure_without_the_vector
4 failed, 2 passed, 8 warnings in 2.92s
```

The two that stay green in the red run are unit tests of `_compact_error`, a function that does not exist before this change. They cover truncation and redaction, not the volume claim.

The red slope is 2,919 bytes against the 12 KiB measured above because the test builds its `DBAPIError` rather than provoking one, so its traceback is shallow. That understates the fix, which is the safe direction for a regression gate.

Green:

```
141 passed, 57 warnings in 42.84s
```

(the new file plus `test_embedding_backfill{,_force_guard,_model_pinning,_base_url_pinning,_model_scope,_queue_1542}.py`, `test_embedding_pipeline.py`, `test_embedding_service.py`, `test_layering.py`)

```
$ uv run ruff check . && uv run ruff format --check .
All checks passed!
1025 files already formatted
```

## Readers of the values involved

The change adds no state that outlives a run and touches no stored value. `traced_errors` is a local set on `backfill_embeddings`, read and written by that one call stack, and a second concurrent run gets its own. Nothing about a record, an embedding or a configuration key is read or written differently. The only observable change is the shape of two log events. The counts the function returns are untouched, and `test_embedding_backfill.py`'s existing `processed`/`created`/`errors` assertions cover that and still pass.

Closes #1544

---

## Review round 1 (39fea90e0)

Two changes, both in the compact-message helper and its tests.

**`_compact_error` redacts before truncating.** `redact_url_credentials` recognises userinfo by its terminating `@`, so truncating first meant a message long enough to push that `@` one character past the cut left `https://alice:hunter2` behind. That parses as a host and a port and came back from the redactor untouched, putting the credential on every compact per-record line, which is the fast path this PR exists to make cheap. Red output for the two new boundary tests, on the old order:

```
E   AssertionError: xxx...xxxhttps://alice:hunter2...
E   assert 'hunter2' not in 'xxxxxxxxxxx...e:hunter2...'

E   AssertionError: xxx...xxxhttps://alice:hun...
E   assert 'alice:' not in 'xxxxxxxxxxx...alice:hun...'

FAILED ...::test_compact_error_redacts_userinfo_the_truncation_point_would_have_split
FAILED ...::test_compact_error_redacts_userinfo_the_truncation_point_would_have_entered
2 failed, 6 passed
```

Both tests compute their prefix from `_MAX_ERROR_CHARS`, so they keep landing on the boundary if that constant moves. One puts the `@` exactly one character past the cut; the other puts the cut three characters into the password, which leaks a fragment and the username rather than the whole secret.

The reorder is not a cost. The marker cut and the whitespace collapse already walk the whole message, and the `DBAPIError` case now redacts 73 characters of driver message where the old order redacted the full 200. Measured, the redactor is linear:

```
driver message (the DBAPIError path)   len=     73  median  0.0028 ms
200 chars (what the old order redacted) len=    200  median  0.0217 ms
provider error with an endpoint         len=    104  median  0.0056 ms
5,000 chars                             len=   5000  median  0.6774 ms
100,000 chars                           len= 100000  median 13.4484 ms
```

A message large enough to matter would have to be pathological, and a cheaper pre-truncation could not help: a cut before redaction is the bug, at whatever offset.

**The endpoint test asserts equality on the whole line.** It pins the redactor's real output (`?api_key=%3Credacted%3E`), which the previous `"embeddings.example.com" in compact` did not, and drops the substring shape CodeQL reads as incomplete URL sanitization.

Green after both: `143 passed`, ruff clean.

Note on the base: `origin/main` moved to f0d20dac7 (#1574) while this was in review. This branch stays on 93d77f689 so the push is a fast-forward rather than a force. #1574 touches `router_export.py` and the COG tests, so there is nothing to conflict with here.

---

## Review round 2 (b1b9088e0)

Same class as round 1, one transformation further up. `" ".join(message.split())` ran before the redactor, and `URL_LIKE_RE` stops at whitespace, so a tab, CR or LF inside a URL became a space and ended the match early. `urlsplit` strips those characters itself, so the redactor handles all three unaided, but only if it is handed the raw string.

Verified before changing anything, on the three whitespace characters and three positions:

```
--- userinfo split by LF
  collapse->redact : 'provider error: https://alice:hun ter2@example.com/v1 failed'   leaks: True
  redact->collapse : 'provider error: https://redacted@example.com/v1 failed'          leaks: False
--- query secret split by LF
  collapse->redact : '...?api_key=%3Credacted%3E ter2 failed'                          leaks: True
  redact->collapse : '...?api_key=%3Credacted%3E failed'                               leaks: False
--- host split by LF
  collapse->redact : 'provider error: https://exam ple.com/v1?api_key=hunter2 failed'  leaks: True
  redact->collapse : 'provider error: https://example.com/v1?api_key=%3Credacted%3E failed'  leaks: False
```

The host case is the worst of the three: the match dies at the split and the query-string key further along is never reached, so a whole `api_key=` value survives.

Every transformation now runs below the redactor, the `[SQL:` cut included. That cut is a cut, and the rule stops being a rule once it has exceptions.

**Cost of moving the `[SQL:` cut.** None where it matters. The per-record retry path redacts `exc.orig`, which carries no `[SQL:` marker at all, so the cut was never doing anything there:

```
the DBAPIError path uses exc.orig, 73 chars (no [SQL:]: True)
exc.orig (what the retry storm actually redacts)     len=    73  median  0.0028 ms
full str(exc) incl. SQL + truncated vector params    len=   688  median  0.0244 ms
that message trimmed at [SQL: first (old order)      len=    93  median  0.0034 ms
```

So the hot path is unchanged at 0.0028 ms, and the only path the cut ever applied to costs 0.021 ms more.

**What is left above the redactor**, having re-read the function line by line with the question "could this change what the redactor matches?": choosing `orig` over `exc`, and `str()`. Neither can split a match. `orig` is a shorter string rather than a mangled one, so it can only omit a credential the statement tail would have carried, never expose a split one. A driver that hands us a message already cut mid-URL is beyond any ordering here, and is stated as a bounded residual in the docstring rather than papered over.

Nine parametrized cases, three whitespace characters against userinfo, a query-string value and the host. Each carries its own counterfactual, running the other order on the same input to prove it leaks rather than asserting it does. Red on the round-1 order:

```
FAILED ...::test_compact_error_redacts_a_credential_whitespace_would_have_split[in-userinfo-lf]
FAILED ...[in-userinfo-cr]  FAILED ...[in-userinfo-tab]
FAILED ...[in-query-value-lf]  FAILED ...[in-query-value-cr]  FAILED ...[in-query-value-tab]
FAILED ...[in-host-lf]  FAILED ...[in-host-cr]  FAILED ...[in-host-tab]
9 failed, 8 passed
```

Green after: `152 passed`, ruff clean.
