### PR TITLE
fix(embeddings): stamp each stored vector with the configuration that produced it

### DIFF
--- a/backend/alembic/versions/0052_record_embedding_config_fingerprint.py
+++ b/backend/alembic/versions/0052_record_embedding_config_fingerprint.py
@@ -1,0 +1,53 @@
+"""Stamp each stored embedding with the configuration that produced it.
+
+fix(#1546): ``catalog.record_embeddings`` recorded ``model_name`` and nothing
+else about how the vector was made. The vector space is a function of the
+model, the declared dimensions AND the endpoint that served the model, so one
+model behind two endpoints is two spaces under one label. Semantic search
+embeds the query with the configuration live at query time and filtered stored
+rows by model name alone, which lets it compare across spaces and return
+well-formed nonsense.
+
+``config_fingerprint`` is the SHA-256 of that triple (see
+``embedding_config_fingerprint`` in ``app/processing/embeddings/helpers.py``).
+
+Deliberately NULLABLE and deliberately NOT backfilled. What configuration
+produced a row already in the table is not recoverable from the row, and
+stamping every existing row with today's configuration would invent provenance
+that happens to be right only on the instances that never changed anything.
+NULL means "unknown, written before this column existed", and every reader
+grandfathers it: an unstamped row is matched on model name alone, exactly as
+before. So an upgrade changes nothing an operator can see — semantic search
+keeps working on day one — and rows earn a stamp as they are regenerated.
+
+No index. The fingerprint is never a search predicate on its own: it always
+rides alongside ``model_name`` (itself unindexed since 0001_baseline) inside a
+query whose cost is the HNSW vector scan, and it is evaluated as a filter over
+the rows that scan already produced.
+
+Revision ID: 0052_record_embedding_config_fingerprint
+Revises: 0051_one_terminal_backfill_audit
+Create Date: 2026-08-17
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0052_record_embedding_config_fingerprint"
+down_revision: Union[str, None] = "0051_one_terminal_backfill_audit"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "record_embeddings",
+        sa.Column("config_fingerprint", sa.String(length=64), nullable=True),
+        schema="catalog",
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("record_embeddings", "config_fingerprint", schema="catalog")

--- a/backend/app/core/catalog_port.py
+++ b/backend/app/core/catalog_port.py
@@ -217,15 +217,16 @@ class CatalogPort(Protocol):
 
     async def has_embeddings(self, session: AsyncSession) -> bool: ...
 
-    async def resolve_embedding_config_fingerprint(
-        self,
-        session: AsyncSession,
-        *,
-        model_name: str | None = None,
-    ) -> str: ...
+    async def resolve_embedding_config(
+        self, session: AsyncSession
+    ) -> tuple[str, int | None, str | None, str] | None: ...
 
     async def generate_embedding(
-        self, text: str, session: AsyncSession
+        self,
+        text: str,
+        session: AsyncSession,
+        *,
+        pinned: tuple[str, int | None, str | None] | None = None,
     ) -> list[float]: ...
 
     async def set_hnsw_recall(self, session: AsyncSession) -> None: ...

--- a/backend/app/core/catalog_port.py
+++ b/backend/app/core/catalog_port.py
@@ -217,6 +217,13 @@ class CatalogPort(Protocol):
 
     async def has_embeddings(self, session: AsyncSession) -> bool: ...
 
+    async def resolve_embedding_config_fingerprint(
+        self,
+        session: AsyncSession,
+        *,
+        model_name: str | None = None,
+    ) -> str: ...
+
     async def generate_embedding(
         self, text: str, session: AsyncSession
     ) -> list[float]: ...

--- a/backend/app/modules/admin/service.py
+++ b/backend/app/modules/admin/service.py
@@ -807,16 +807,37 @@ class AdminService:
         every embedded record reads stale. That is deliberate: search's vector
         arm is equally unusable in that state, and over-reporting coverage is
         the failure this fix exists to remove.
+
+        fix(#1546): the same argument, one value out. A row carrying the active
+        model name but another CONFIGURATION's stamp is in a different vector
+        space, so semantic search cannot use it either, and counting it would
+        show a healthy coverage bar over a catalog the vector arm skips — the
+        exact failure #1503 removed, re-entering through the endpoint.
+
+        The FILTER below is the SQL spelling of
+        `RecordEmbedding.usable_by_config`, which is what the non-force backfill
+        and semantic search apply. Two spellings of one rule is a drift risk, so
+        it is not left to inspection: `test_embedding_config_stamp_1546.py`
+        builds a catalog holding every combination of model and stamp and
+        asserts this count equals what that predicate selects.
         """
-        from app.processing.embeddings.helpers import resolve_embedding_model_name
+        from app.processing.embeddings.helpers import (
+            resolve_embedding_config_fingerprint,
+            resolve_embedding_model_name,
+        )
 
         try:
             model_name = await resolve_embedding_model_name(self.db)
+            config_fingerprint = await resolve_embedding_config_fingerprint(
+                self.db, model_name=model_name
+            )
             result = await self.db.execute(
                 text(
                     "SELECT COUNT(DISTINCT visible_record.id) AS total_records, "
                     "COUNT(DISTINCT visible_record.id) "
-                    "FILTER (WHERE embedding.model_name = :model_name) "
+                    "FILTER (WHERE embedding.model_name = :model_name "
+                    "AND (embedding.config_fingerprint IS NULL "
+                    "OR embedding.config_fingerprint = :config_fingerprint)) "
                     "AS embedded_records, "
                     "COUNT(DISTINCT visible_record.id) "
                     "FILTER (WHERE embedding.record_id IS NOT NULL) "
@@ -825,7 +846,7 @@ class AdminService:
                     "LEFT JOIN catalog.record_embeddings AS embedding "
                     "ON embedding.record_id = visible_record.id"
                 ),
-                {"model_name": model_name},
+                {"model_name": model_name, "config_fingerprint": config_fingerprint},
             )
             total_records, embedded_records, any_model_records = result.one()
         except Exception:  # broad: pgvector table may be missing or DB unavailable; degrade to zeros for admin UI
@@ -839,8 +860,11 @@ class AdminService:
             )
 
         missing_records = total_records - embedded_records
-        # Records carrying vectors, but none the active model can use. Subset
-        # of missing_records. fix(#1506): Generate Missing now covers these —
+        # Records carrying vectors, but none the active configuration can use.
+        # Subset of missing_records. fix(#1546): "configuration", not "model" —
+        # a row from another endpoint counts here too, and Generate Missing
+        # covers it for the same reason it covers a superseded model's row.
+        # fix(#1506): Generate Missing now covers these —
         # the non-force backfill selects on "no active-model row" rather than
         # "no row at all", so it re-embeds them without touching the records
         # the current model already covers. Regenerate All remains the way to

--- a/backend/app/modules/catalog/search/service_semantic.py
+++ b/backend/app/modules/catalog/search/service_semantic.py
@@ -30,9 +30,18 @@ EmbeddingUnavailableError = get_catalog_port().embedding_unavailable_error_class
 # OpenAI text-embedding-3-small at 200-800 ms per call). Repeated identical
 # queries within ~5 minutes are common during user sessions and should not
 # pay that cost on every request. The cache key is `(tenant-scoped query text,
-# model_name)` so case variations and accidental whitespace collide without
-# sharing a provider result across tenants. TTL is 300 seconds (matches audit
-# recommendation), max 512 entries.
+# model_name, configuration fingerprint)` so case variations and accidental
+# whitespace collide without sharing a provider result across tenants. TTL is
+# 300 seconds (matches audit recommendation), max 512 entries.
+#
+# fix(#1546): the fingerprint is part of the key, not decoration. This cache is
+# the third independent reader of the embedding configuration in one request —
+# the stored rows, the provider call, and this. Filtering rows by the live
+# configuration while serving a query vector generated under the previous one
+# would compare across spaces exactly as before, with the filter looking
+# correct: the bug would have moved into the cache rather than been fixed. A
+# configuration change makes every entry unreachable, which costs one provider
+# call per distinct query and is the point.
 _EMBEDDING_CACHE_TTL_SECONDS = 300.0
 _EMBEDDING_CACHE_MAX_SIZE = 512
 
@@ -46,12 +55,12 @@ _EXACT_SEMANTIC_COUNT_MAX_ROWS = 5000
 # anyway; the 300s cache can't help, every prefix is a distinct key. Shorter
 # queries skip the vector path entirely.
 _MIN_SEMANTIC_QUERY_LEN = 4
-_embedding_cache: "OrderedDict[tuple[str, str], tuple[float, list[float]]]" = (
+_embedding_cache: "OrderedDict[tuple[str, str, str], tuple[float, list[float]]]" = (
     OrderedDict()
 )
 
 
-def _embedding_cache_get(key: tuple[str, str]) -> list[float] | None:
+def _embedding_cache_get(key: tuple[str, str, str]) -> list[float] | None:
     """Return a cached embedding if present and not expired; else None."""
     entry = _embedding_cache.get(key)
     if entry is None:
@@ -65,7 +74,7 @@ def _embedding_cache_get(key: tuple[str, str]) -> list[float] | None:
     return vector
 
 
-def _embedding_cache_put(key: tuple[str, str], vector: list[float]) -> None:
+def _embedding_cache_put(key: tuple[str, str, str], vector: list[float]) -> None:
     """Insert with TTL; evict oldest when over capacity."""
     expires_at = time.monotonic() + _EMBEDDING_CACHE_TTL_SECONDS
     _embedding_cache[key] = (expires_at, vector)
@@ -94,21 +103,47 @@ async def _embed_with_deadline(text: str, session: AsyncSession) -> list[float]:
     )
 
 
-async def generate_embedding(text: str, session: AsyncSession) -> list[float]:
+async def _live_embedding_identity(session: AsyncSession) -> tuple[str, str]:
+    """Return (active model name, live configuration fingerprint) — #1546.
+
+    One read of the model, threaded into the fingerprint, so the value the
+    query filters on and the value inside the fingerprint cannot land on
+    opposite sides of a settings change. The port call never raises; an
+    unresolvable configuration answers with a sentinel that matches no stamped
+    row, so the vector arm degrades to whatever is unstamped rather than
+    returning cross-space matches.
+    """
+    model_name = await EMBEDDING_MODEL.get(session)
+    fingerprint = await get_catalog_port().resolve_embedding_config_fingerprint(
+        session, model_name=model_name
+    )
+    return model_name, fingerprint
+
+
+async def generate_embedding(
+    text: str,
+    session: AsyncSession,
+    *,
+    identity: tuple[str, str] | None = None,
+) -> list[float]:
     """Generate an embedding through the configured CatalogPort provider.
 
     Phase 269 H-22: results are memoized in a TTL LRU cache keyed on
-    `(tenant-scoped text.strip().lower(), model_name)`, TTL 300s. Cache write
-    only happens on the success path; provider errors propagate to callers as
-    before.
+    `(tenant-scoped text.strip().lower(), model_name, configuration
+    fingerprint)`, TTL 300s. Cache write only happens on the success path;
+    provider errors propagate to callers as before.
+
+    ``identity`` is the `(model, fingerprint)` pair from
+    `_live_embedding_identity`, passed by a caller that already resolved it so
+    one search request resolves it once. Omit it and this resolves its own.
     """
     normalized = text.strip().lower()
     if not normalized:
         # Don't cache empty inputs — let the provider raise its usual error.
         return await _embed_with_deadline(text, session)
 
-    model_name = await EMBEDDING_MODEL.get(session)
-    cache_key = (tenant_cache_key(normalized), model_name)
+    model_name, fingerprint = identity or await _live_embedding_identity(session)
+    cache_key = (tenant_cache_key(normalized), model_name, fingerprint)
 
     cached = _embedding_cache_get(cache_key)
     if cached is not None:
@@ -148,7 +183,7 @@ async def _get_vector_ranks(
     query_text: str,
     limit: int,
     restrict_stmt: Select | None = None,
-) -> tuple[dict[str, int], list[float] | None]:
+) -> tuple[dict[str, int], list[float] | None, tuple[str, str] | None]:
     """Run vector similarity search.
 
     ``restrict_stmt`` is a ``select(Record.id)`` carrying the active visibility +
@@ -156,40 +191,56 @@ async def _get_vector_ranks(
     in that set, so a nearer but non-visible / filtered-out embedding cannot crowd
     a valid match out of the top ``limit`` rows.
 
-    Returns ``({record_id_hex: rank}, query_vector)``. The query vector is returned
-    so the caller can run an accurate total-match COUNT (which the ``limit``-bounded
-    ranks cannot provide). Returns ``({}, None)`` on any failure (silent fallback).
+    Returns ``({record_id_hex: rank}, query_vector, identity)``. The query vector is
+    returned so the caller can run an accurate total-match COUNT (which the
+    ``limit``-bounded ranks cannot provide); fix(#1546) added the identity for the
+    same reason, so that COUNT filters on the configuration these ranks were taken
+    under. Returns ``({}, None, None)`` on any failure (silent fallback).
     """
     # Check if any embeddings exist at all
     if not await get_catalog_port().has_embeddings(session):
-        return {}, None
+        return {}, None, None
+
+    # fix(#1546): the query vector and the row filter must come from ONE reading
+    # of the configuration. Resolved once, here, below the has_embeddings gate
+    # so a catalog with no vectors does not pay for it, and handed back to the
+    # caller so a settings change landing mid-request cannot rank under one
+    # configuration and count under another.
+    identity = await _live_embedding_identity(session)
+    model_name, config_fingerprint = identity
 
     # Generate query embedding
     try:
-        query_vector = await generate_embedding(query_text.strip(), session)
+        query_vector = await generate_embedding(
+            query_text.strip(), session, identity=identity
+        )
     except EmbeddingUnavailableError:
         logger.warning("Embedding unavailable for semantic search, falling back to FTS")
-        return {}, None
+        return {}, None, None
     except Exception:  # broad: third-party embedding SDK can throw provider-specific errors; fall back to FTS
         logger.warning(
             "Failed to generate query embedding, falling back to FTS", exc_info=True
         )
-        return {}, None
+        return {}, None, None
 
     try:
-        # Get current model name for filtering
-        model_name = await EMBEDDING_MODEL.get(session)
-
         # Tune HNSW recall -- default ef_search=40 may miss relevant results
         await get_catalog_port().set_hnsw_recall(session)
         RecordEmbedding = get_catalog_port().record_embedding_orm_class()
 
         # Vector similarity query: cosine distance <= 0.7 means similarity >= 0.3
+        # fix(#1546): scoped to rows the live configuration can be compared
+        # against, not merely to rows carrying its model name. A model served
+        # from two endpoints is two vector spaces under one label, and cosine
+        # distance across them comes back well-formed and meaningless. Rows from
+        # another configuration are now invisible rather than wrong;
+        # `usable_by_config` is where an unstamped legacy row keeps the old
+        # model-name-only guarantee.
         vector_stmt = select(
             RecordEmbedding.record_id,
             RecordEmbedding.embedding.cosine_distance(query_vector).label("distance"),
         ).where(
-            RecordEmbedding.model_name == model_name,
+            RecordEmbedding.usable_by_config(model_name, config_fingerprint),
             RecordEmbedding.embedding.cosine_distance(query_vector) <= 0.7,
         )
         if restrict_stmt is not None:
@@ -209,10 +260,14 @@ async def _get_vector_ranks(
         logger.warning(
             "Vector similarity query failed, falling back to FTS", exc_info=True
         )
-        return {}, None
+        return {}, None, None
 
     # Assign positional ranks (1-based)
-    return {str(row.record_id): rank + 1 for rank, row in enumerate(rows)}, query_vector
+    return (
+        {str(row.record_id): rank + 1 for rank, row in enumerate(rows)},
+        query_vector,
+        identity,
+    )
 
 
 def _compute_rrf_scores(
@@ -279,12 +334,14 @@ async def _run_rrf_merge(
     # Vector similarity ranks, restricted to the visibility/filter-vetted set so the
     # cosine top-k contains only records the caller may see that satisfy every active
     # filter (empty dict on any failure = FTS-only). The query vector is returned for
-    # the total-match count below.
-    vector_ranks, query_vector = await _get_vector_ranks(
+    # the total-match count below, and fix(#1546) the embedding configuration those
+    # ranks were taken under, so the counts filter on the same one rather than
+    # resolving it a second time and possibly counting rows they did not rank.
+    vector_ranks, query_vector, identity = await _get_vector_ranks(
         session, q_stripped, page_end, restrict_stmt=vet_stmt
     )
 
-    if not vector_ranks:
+    if not vector_ranks or identity is None:
         logger.info(
             "rrf_fallback_to_fts",
             extra={"reason": "empty_vector_ranks", "q_prefix": q_stripped[:50]},
@@ -321,7 +378,7 @@ async def _run_rrf_merge(
         .join(Record, Dataset.record_id == Record.id)
         .where(stmt.whereclause)
     )
-    model_name = await EMBEDDING_MODEL.get(session)
+    model_name, config_fingerprint = identity
     RecordEmbedding = get_catalog_port().record_embedding_orm_class()
     # fix(#448): the exact COUNT below re-computes cosine distance against
     # EVERY stored embedding — a second full O(N)·dims vector scan per search
@@ -330,12 +387,16 @@ async def _run_rrf_merge(
     # the vector-only surplus from the vetted top-k ranks already in hand.
     # numberMatched becomes a lower bound (may under-report distant tail
     # matches); a full-window sentinel below keeps `next` links alive.
+    # fix(#1546): both counts below use the same predicate the ranks were taken
+    # under. The row gate decides whether the exact count is affordable, so
+    # counting rows the ranking cannot see would push a catalog over the gate on
+    # the strength of vectors no search will ever return.
     emb_rows = (
         await session.execute(
             select(func.count())
             .select_from(RecordEmbedding)
             .join(Record, RecordEmbedding.record_id == Record.id)
-            .where(RecordEmbedding.model_name == model_name)
+            .where(RecordEmbedding.usable_by_config(model_name, config_fingerprint))
         )
     ).scalar_one()
     if emb_rows <= _EXACT_SEMANTIC_COUNT_MAX_ROWS:
@@ -343,7 +404,7 @@ async def _run_rrf_merge(
             select(func.count())
             .select_from(RecordEmbedding)
             .where(
-                RecordEmbedding.model_name == model_name,
+                RecordEmbedding.usable_by_config(model_name, config_fingerprint),
                 RecordEmbedding.embedding.cosine_distance(query_vector) <= 0.7,
                 RecordEmbedding.record_id.in_(vet_stmt),
                 RecordEmbedding.record_id.notin_(fts_match_subq),

--- a/backend/app/modules/catalog/search/service_semantic.py
+++ b/backend/app/modules/catalog/search/service_semantic.py
@@ -14,7 +14,6 @@ from sqlalchemy.orm import selectinload
 from sqlalchemy.sql.elements import Label
 from sqlalchemy.sql.selectable import Select
 
-from app.core.persistent_config import EMBEDDING_MODEL
 from app.modules.auth.models import User
 from app.modules.catalog.datasets.domain.models import Dataset, Record
 from app.modules.catalog.search.service_filters import SearchFilters
@@ -96,35 +95,22 @@ def _embedding_cache_clear() -> None:
 _QUERY_EMBED_TIMEOUT_SECONDS = 8.0
 
 
-async def _embed_with_deadline(text: str, session: AsyncSession) -> list[float]:
+async def _embed_with_deadline(
+    text: str,
+    session: AsyncSession,
+    pinned: tuple[str, int | None, str | None] | None = None,
+) -> list[float]:
     return await asyncio.wait_for(
-        get_catalog_port().generate_embedding(text, session),
+        get_catalog_port().generate_embedding(text, session, pinned=pinned),
         timeout=_QUERY_EMBED_TIMEOUT_SECONDS,
     )
-
-
-async def _live_embedding_identity(session: AsyncSession) -> tuple[str, str]:
-    """Return (active model name, live configuration fingerprint) — #1546.
-
-    One read of the model, threaded into the fingerprint, so the value the
-    query filters on and the value inside the fingerprint cannot land on
-    opposite sides of a settings change. The port call never raises; an
-    unresolvable configuration answers with a sentinel that matches no stamped
-    row, so the vector arm degrades to whatever is unstamped rather than
-    returning cross-space matches.
-    """
-    model_name = await EMBEDDING_MODEL.get(session)
-    fingerprint = await get_catalog_port().resolve_embedding_config_fingerprint(
-        session, model_name=model_name
-    )
-    return model_name, fingerprint
 
 
 async def generate_embedding(
     text: str,
     session: AsyncSession,
     *,
-    identity: tuple[str, str] | None = None,
+    config: tuple[str, int | None, str | None, str] | None = None,
 ) -> list[float]:
     """Generate an embedding through the configured CatalogPort provider.
 
@@ -133,23 +119,48 @@ async def generate_embedding(
     fingerprint)`, TTL 300s. Cache write only happens on the success path;
     provider errors propagate to callers as before.
 
-    ``identity`` is the `(model, fingerprint)` pair from
-    `_live_embedding_identity`, passed by a caller that already resolved it so
-    one search request resolves it once. Omit it and this resolves its own.
+    ``config`` is the live `(model, dimensions, endpoint, fingerprint)` from
+    `CatalogPort.resolve_embedding_config`, passed by a caller that already
+    resolved it so one search request resolves it once. Omit it and this
+    resolves its own.
+
+    fix(#1546 review r1, codex P1): the first three are handed to the PROVIDER,
+    not just used to key the cache. Without that the provider re-resolved the
+    live configuration for itself, so a settings change landing between the
+    identity read and the provider call produced a vector under configuration B
+    that was then cached under, and ranked against, configuration A's rows —
+    the cross-space comparison this whole change exists to prevent, inside a
+    single request.
+
+    Verifying afterwards instead was considered and rejected: it would catch
+    the divergence only once the vector existed, and the natural handling
+    (discard, do not cache) still leaves THIS request either ranking on a
+    wrong-space vector or silently losing its vector arm. Pinning removes the
+    divergence rather than detecting it.
     """
     normalized = text.strip().lower()
     if not normalized:
         # Don't cache empty inputs — let the provider raise its usual error.
         return await _embed_with_deadline(text, session)
 
-    model_name, fingerprint = identity or await _live_embedding_identity(session)
+    if config is None:
+        config = await get_catalog_port().resolve_embedding_config(session)
+    if config is None:
+        # The configuration could not be resolved, so there is nothing to pin
+        # and nothing safe to key a cache entry on. Let the provider resolve
+        # and fail the way it did before any of this existed.
+        return await _embed_with_deadline(text, session)
+
+    model_name, dimensions, base_url, fingerprint = config
     cache_key = (tenant_cache_key(normalized), model_name, fingerprint)
 
     cached = _embedding_cache_get(cache_key)
     if cached is not None:
         return cached
 
-    vector = await _embed_with_deadline(text, session)
+    vector = await _embed_with_deadline(
+        text, session, (model_name, dimensions, base_url)
+    )
     _embedding_cache_put(cache_key, vector)
     return vector
 
@@ -201,18 +212,30 @@ async def _get_vector_ranks(
     if not await get_catalog_port().has_embeddings(session):
         return {}, None, None
 
-    # fix(#1546): the query vector and the row filter must come from ONE reading
-    # of the configuration. Resolved once, here, below the has_embeddings gate
-    # so a catalog with no vectors does not pay for it, and handed back to the
-    # caller so a settings change landing mid-request cannot rank under one
-    # configuration and count under another.
-    identity = await _live_embedding_identity(session)
-    model_name, config_fingerprint = identity
-
     # Generate query embedding
     try:
+        # fix(#1546): the query vector and the row filter must come from ONE
+        # reading of the configuration. Resolved once, here, below the
+        # has_embeddings gate so a catalog with no vectors does not pay for it,
+        # and handed back to the caller so a settings change landing mid-request
+        # cannot rank under one configuration and count under another.
+        #
+        # fix(#1546 review r1, codex P2): INSIDE this guard, not above it.
+        # Resolving reads persistent config, which can raise on a cache miss or
+        # a transient database failure, and above the guard that raise escaped
+        # the whole search request. Model resolution used to happen inside
+        # `generate_embedding`, where it degraded to FTS like every other
+        # failure on this path; hoisting it silently made it fatal. Same
+        # failure, same degradation.
+        config = await get_catalog_port().resolve_embedding_config(session)
+        if config is None:
+            logger.warning(
+                "Embedding configuration unresolved for semantic search, "
+                "falling back to FTS"
+            )
+            return {}, None, None
         query_vector = await generate_embedding(
-            query_text.strip(), session, identity=identity
+            query_text.strip(), session, config=config
         )
     except EmbeddingUnavailableError:
         logger.warning("Embedding unavailable for semantic search, falling back to FTS")
@@ -222,6 +245,9 @@ async def _get_vector_ranks(
             "Failed to generate query embedding, falling back to FTS", exc_info=True
         )
         return {}, None, None
+
+    model_name, _dimensions, _base_url, config_fingerprint = config
+    identity = (model_name, config_fingerprint)
 
     try:
         # Tune HNSW recall -- default ef_search=40 may miss relevant results

--- a/backend/app/platform/extensions/defaults_catalog_port.py
+++ b/backend/app/platform/extensions/defaults_catalog_port.py
@@ -312,6 +312,17 @@ class DefaultCatalogPort:
 
         return await has_embeddings(session)
 
+    async def resolve_embedding_config_fingerprint(self, session, *, model_name=None):  # type: ignore[no-untyped-def]
+        # fix(#1546): semantic search filters stored rows on this, and
+        # `modules/catalog/` may not import `app.processing.*`.
+        from app.processing.embeddings.helpers import (
+            resolve_embedding_config_fingerprint,
+        )
+
+        return await resolve_embedding_config_fingerprint(
+            session, model_name=model_name
+        )
+
     async def generate_embedding(self, text, session):  # type: ignore[no-untyped-def]
         from app.processing.embeddings.service import generate_embedding
 

--- a/backend/app/platform/extensions/defaults_catalog_port.py
+++ b/backend/app/platform/extensions/defaults_catalog_port.py
@@ -312,21 +312,38 @@ class DefaultCatalogPort:
 
         return await has_embeddings(session)
 
-    async def resolve_embedding_config_fingerprint(self, session, *, model_name=None):  # type: ignore[no-untyped-def]
-        # fix(#1546): semantic search filters stored rows on this, and
-        # `modules/catalog/` may not import `app.processing.*`.
-        from app.processing.embeddings.helpers import (
-            resolve_embedding_config_fingerprint,
+    async def resolve_embedding_config(self, session):  # type: ignore[no-untyped-def]
+        # fix(#1546): semantic search filters stored rows on the fingerprint,
+        # and `modules/catalog/` may not import `app.processing.*`. It gets the
+        # whole (model, dimensions, endpoint, fingerprint) rather than the
+        # fingerprint alone because it also has to PIN the provider call to the
+        # same configuration it filters on (#1546 review r1).
+        from app.processing.embeddings.helpers import resolve_live_embedding_config
+
+        return await resolve_live_embedding_config(session)
+
+    async def generate_embedding(self, text, session, *, pinned=None):  # type: ignore[no-untyped-def]
+        from app.processing.embeddings.service import generate_embeddings_batch
+
+        # fix(#1546 review r1, codex P1): `pinned` is (model, dimensions,
+        # endpoint) as ONE optional argument rather than three keyword ones.
+        # `None` is a legitimate resolved endpoint — the provider interface
+        # lets an extension answer `{"base_url": None}` meaning "use the client
+        # default", which is why `generate_embeddings_batch` distinguishes it
+        # from an omission with a sentinel (`_Unset`, #1525). Three defaults of
+        # `None` could not tell "not pinned" from "pinned to the client
+        # default", and would have re-resolved the endpoint for exactly the
+        # providers the pin most needs to protect. One argument, absent or
+        # complete, cannot express that mistake.
+        if pinned is None:
+            from app.processing.embeddings.service import generate_embedding
+
+            return await generate_embedding(text, session)
+        model, dimensions, base_url = pinned
+        vectors = await generate_embeddings_batch(
+            [text], session, model=model, dimensions=dimensions, base_url=base_url
         )
-
-        return await resolve_embedding_config_fingerprint(
-            session, model_name=model_name
-        )
-
-    async def generate_embedding(self, text, session):  # type: ignore[no-untyped-def]
-        from app.processing.embeddings.service import generate_embedding
-
-        return await generate_embedding(text, session)
+        return vectors[0]
 
     async def set_hnsw_recall(self, session):  # type: ignore[no-untyped-def]
         from app.processing.embeddings.helpers import set_hnsw_recall

--- a/backend/app/platform/extensions/defaults_processing_port.py
+++ b/backend/app/platform/extensions/defaults_processing_port.py
@@ -241,7 +241,9 @@ class DefaultProcessingPort:
 
         from app.modules.catalog.datasets.domain.models import Record
         from app.processing.embeddings.helpers import (
+            UNKNOWN_EMBEDDING_CONFIG,
             UNKNOWN_EMBEDDING_MODEL,
+            resolve_embedding_config_fingerprint,
             resolve_embedding_model_name,
         )
         from app.processing.embeddings.models import RecordEmbedding
@@ -282,11 +284,36 @@ class DefaultProcessingPort:
                     "backfill_skipped_unresolved_embedding_model"
                 )
                 return []
+            # fix(#1546): "missing" narrows again, from "has no vector THIS
+            # MODEL can use" to "has no vector this CONFIGURATION can use". A
+            # model served from a different endpoint is a different vector
+            # space, so a row carrying another configuration's stamp is as
+            # unusable to search as a superseded model's row, and leaving it
+            # out of this predicate would relocate #1546 into the skip
+            # decision: Generate Missing would report the catalog covered while
+            # search matched nothing.
+            #
+            # An unstamped row still counts as covering the record, which is
+            # what stops an upgrade from turning the next Generate Missing into
+            # a catalog-wide re-embed nobody asked to pay for.
+            config_fingerprint = await resolve_embedding_config_fingerprint(
+                session, model_name=model_name
+            )
+            if config_fingerprint == UNKNOWN_EMBEDDING_CONFIG:
+                # Fail closed for the same reason the unresolved model does
+                # above, one value out: an unresolvable configuration makes
+                # every stamped row read as foreign, so this would hand the
+                # whole catalog to a run whose provider call is the thing that
+                # cannot be resolved.
+                structlog.stdlib.get_logger(__name__).warning(
+                    "backfill_skipped_unresolved_embedding_config"
+                )
+                return []
             stmt = stmt.where(
                 ~select(RecordEmbedding.id)
                 .where(
                     RecordEmbedding.record_id == Record.id,
-                    RecordEmbedding.model_name == model_name,
+                    RecordEmbedding.usable_by_config(model_name, config_fingerprint),
                 )
                 .exists()
             )

--- a/backend/app/platform/extensions/version.py
+++ b/backend/app/platform/extensions/version.py
@@ -96,8 +96,9 @@ logger = logging.getLogger(__name__)
 # 5 -> 6: a Protocol method a structural implementer must supply is required,
 # whatever else the addition is shaped like.
 #
-# 7 -> 8 (fix(#1546)): CatalogPort gained a required
-# ``resolve_embedding_config_fingerprint`` method. Stored embeddings now carry
+# 7 -> 8 (fix(#1546)): TWO CatalogPort changes, one bump.
+#
+# A required ``resolve_embedding_config`` method. Stored embeddings now carry
 # the identity of the configuration that produced them, and semantic search
 # filters on it, so the search path has to be able to ask what the live
 # configuration is; ``modules/catalog/`` may not import ``app.processing.*``,
@@ -107,6 +108,16 @@ logger = logging.getLogger(__name__)
 # reach the vector arm. Same reasoning as 5 -> 6: a Protocol method a
 # structural implementer must supply is required, whatever else it is shaped
 # like.
+#
+# And a widened ``generate_embedding``, which takes a keyword-only ``pinned``
+# triple (model, dimensions, endpoint). Filtering rows by a configuration while
+# letting the provider re-resolve its own leaves a window inside ONE request
+# where the query vector comes from a different configuration than the rows it
+# is ranked against, which is the whole defect #1546 exists to close. An
+# overlay that implements the old two-argument signature raises TypeError on
+# the first semantic search, so this is as required as the addition above.
+# Riding the same bump because both land in the same change; an overlay
+# updating to 8 has to do both.
 EXTENSION_API_VERSION: int = 8
 
 

--- a/backend/app/platform/extensions/version.py
+++ b/backend/app/platform/extensions/version.py
@@ -95,7 +95,19 @@ logger = logging.getLogger(__name__)
 # inherits its predecessor's cached authorization. Same reasoning as 4 -> 5 and
 # 5 -> 6: a Protocol method a structural implementer must supply is required,
 # whatever else the addition is shaped like.
-EXTENSION_API_VERSION: int = 7
+#
+# 7 -> 8 (fix(#1546)): CatalogPort gained a required
+# ``resolve_embedding_config_fingerprint`` method. Stored embeddings now carry
+# the identity of the configuration that produced them, and semantic search
+# filters on it, so the search path has to be able to ask what the live
+# configuration is; ``modules/catalog/`` may not import ``app.processing.*``,
+# which is why the answer crosses the port. Every hybrid search calls it, so an
+# overlay replacing the ``catalog_port`` slot without it would load cleanly at
+# version 7 and then raise AttributeError on the first query long enough to
+# reach the vector arm. Same reasoning as 5 -> 6: a Protocol method a
+# structural implementer must supply is required, whatever else it is shaped
+# like.
+EXTENSION_API_VERSION: int = 8
 
 
 def check_extension_api_version(name: str, declared_version: int | None) -> None:

--- a/backend/app/processing/embeddings/backfill.py
+++ b/backend/app/processing/embeddings/backfill.py
@@ -15,11 +15,13 @@ Can be run as a module: python -m app.embeddings.backfill
 from typing import Any
 
 import structlog
-from sqlalchemy import delete, select, text
+from sqlalchemy import delete, func, select, text
+from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.persistent_config import AI_ENABLED, EMBEDDING_DIMS
 from app.platform.extensions import get_processing_port
+from app.processing.embeddings.helpers import embedding_config_fingerprint
 from app.processing.embeddings.models import RecordEmbedding
 from app.processing.embeddings.service import (
     build_content_text,
@@ -38,6 +40,36 @@ _BATCH_SIZE = 128
 # Text for the force-path pre-flight embedding. Short, so the call is cheap,
 # and constant, so a provider's cache can serve it.
 _PREFLIGHT_TEXT = "geolens embedding preflight"
+
+
+def _upsert_embeddings(rows: list[dict[str, Any]]):  # type: ignore[no-untyped-def]
+    """INSERT the batch, replacing any row this record already has for the model.
+
+    fix(#1546): a plain INSERT stopped being safe once rows carry a
+    configuration stamp. `uq_record_embedding_model` is `(record_id,
+    model_name)`, and the non-force run now offers a record whose only row for
+    the ACTIVE model was written under a different configuration — that row is
+    invisible to search, so the record genuinely is uncovered — which a plain
+    INSERT would answer with a unique violation instead of a vector.
+
+    Replacing in place rather than widening the constraint: one row per
+    (record, model) keeps the table's size independent of how many
+    configurations an instance has been through, and leaves the key that #1549
+    needs for a per-batch delete-and-replace intact.
+
+    `updated_at` is set explicitly because `onupdate=` is an ORM-level default
+    and this is a Core statement.
+    """
+    stmt = pg_insert(RecordEmbedding).values(rows)
+    return stmt.on_conflict_do_update(
+        index_elements=["record_id", "model_name"],
+        set_={
+            "embedding": stmt.excluded.embedding,
+            "content_hash": stmt.excluded.content_hash,
+            "config_fingerprint": stmt.excluded.config_fingerprint,
+            "updated_at": func.now(),
+        },
+    )
 
 
 async def _snapshot_embedding_config(
@@ -239,12 +271,24 @@ async def _retry_batch_per_record(
                 base_url=base_url,
             )
             await _raise_on_pin_drift(session, pinned, created + made, error=_PinDrift)
-            session.add(
-                RecordEmbedding(
-                    record_id=record_id,
-                    embedding=vector,
-                    model_name=model_name,
-                    content_hash=compute_content_hash(content),
+            await session.execute(
+                _upsert_embeddings(
+                    [
+                        {
+                            "record_id": record_id,
+                            "embedding": vector,
+                            "model_name": model_name,
+                            # fix(#1546): from `pinned`, which IS the
+                            # configuration this call was made under — the
+                            # retry passes the same three values to the
+                            # provider. Re-resolving here would stamp what the
+                            # config says now rather than what produced the
+                            # vector, which is the fabrication the whole column
+                            # exists to avoid.
+                            "config_fingerprint": embedding_config_fingerprint(*pinned),
+                            "content_hash": compute_content_hash(content),
+                        }
+                    ]
                 )
             )
             await session.commit()
@@ -500,18 +544,21 @@ async def backfill_embeddings(session: AsyncSession, *, force: bool = False) -> 
         # key, exhausted quota, dimensions the model rejects.
         await _preflight_embedding(session, pinned)
 
-        # DESTRUCTIVE-FIRST, DELIBERATELY (#1549). This commits before the run
-        # knows it can finish, so a drift abort in the batch loop below leaves
-        # the table empty and the operator has to re-run. That is the chosen
-        # side of the trade, not an oversight: rows record only `model_name`,
-        # so a run that carried on under a stale pin would leave a FULL table
-        # whose vectors live in a space the active search silently fails to
-        # match. Empty is loud and one re-run away; populated-and-wrong looks
-        # healthy and is not. Removing the destructive-first shape needs
-        # per-batch delete-and-replace in one transaction (which wants #1546's
-        # per-row configuration stamp first, or it trades a loud failure for a
-        # silent one), a shadow table and swap, or the job lifecycle in #1542 —
-        # none of which belong in a PR about pinning a configuration.
+        # DESTRUCTIVE-FIRST, STILL (#1549). This commits before the run knows it
+        # can finish, so a drift abort in the batch loop below leaves the table
+        # empty and the operator has to re-run.
+        #
+        # That was the chosen side of a trade whose other side has now moved:
+        # while rows recorded only `model_name`, a run that carried on under a
+        # stale pin left a FULL table whose vectors lived in a space the active
+        # search silently failed to match, and empty-and-loud beat
+        # populated-and-wrong. fix(#1546): rows carry the configuration that
+        # produced them, so a partial run leaves a MIX that search can tell
+        # apart — old rows go invisible instead of the table going empty. That
+        # removes the objection to per-batch delete-and-replace in one
+        # transaction, which is #1549's direction 1 and does not belong in a PR
+        # about stamping rows. The other routes remain a shadow table and swap,
+        # or the run lifecycle #1542 landed.
         #
         # The HNSW index lives in Alembic migration 0012 (and is recreated
         # by service.rebuild_embedding_column on dimension change). On
@@ -591,6 +638,12 @@ async def backfill_embeddings(session: AsyncSession, *, force: bool = False) -> 
     if pinned is None:
         pinned = await _snapshot_embedding_config(session)
     model_name, embedding_dims, base_url = pinned
+    # fix(#1546): every row this run writes is stamped with THIS, the identity
+    # of the configuration the run pinned. Not a fresh read at write time: the
+    # endpoint half in particular has to be the one the provider call was made
+    # against, and `base_url` above is exactly the value passed to
+    # `generate_embeddings_batch` below.
+    config_fingerprint = embedding_config_fingerprint(*pinned)
 
     # Build embeddable (record_id, content_text) pairs; empty content skips.
     skipped = 0
@@ -618,11 +671,16 @@ async def backfill_embeddings(session: AsyncSession, *, force: bool = False) -> 
         # config moving underneath it, but nothing was noticing that it HAD
         # moved. A run pinned to endpoint A that keeps going after the active
         # endpoint becomes B writes A-space vectors for the rest of the
-        # catalog, and `RecordEmbedding` records only `model_name`, so semantic
-        # search later builds its query vector from the live endpoint and
-        # filters stored rows by model alone — B-space queries against A-space
-        # documents under one label, and the backfill reported success. Persisting
-        # an endpoint identity per row so search can filter on it is #1546.
+        # catalog, and `RecordEmbedding` recorded only `model_name`, so semantic
+        # search later built its query vector from the live endpoint and
+        # filtered stored rows by model alone — B-space queries against A-space
+        # documents under one label, and the backfill reported success.
+        #
+        # fix(#1546): those rows are now stamped with the pin, so search skips
+        # them rather than matching them. This check stays: invisible is better
+        # than wrong, but not writing a whole catalog nobody can use is better
+        # than either, and stopping is also what tells the operator to re-run
+        # under the new configuration.
         #
         # Outside the try below, deliberately: this must stop the run, not be
         # counted as a batch error and retried per record. The sibling check
@@ -654,15 +712,26 @@ async def backfill_embeddings(session: AsyncSession, *, force: bool = False) -> 
             # committed, so the run stops without adding a row nothing will
             # match. `_PinDrift` is re-raised past the batch handler below.
             await _raise_on_pin_drift(session, pinned, created, error=_PinDrift)
-            for (record_id, content), vector in zip(batch, vectors):
-                session.add(
-                    RecordEmbedding(
-                        record_id=record_id,
-                        embedding=vector,
-                        model_name=model_name,
-                        content_hash=compute_content_hash(content),
-                    )
+            await session.execute(
+                _upsert_embeddings(
+                    [
+                        {
+                            "record_id": record_id,
+                            "embedding": vector,
+                            "model_name": model_name,
+                            # fix(#1546): stamped from the PIN. `pinned` is the
+                            # triple that was handed to the provider call above,
+                            # so the stamp names the configuration that actually
+                            # produced this vector rather than whatever the live
+                            # configuration happens to be by the time the row is
+                            # written.
+                            "config_fingerprint": config_fingerprint,
+                            "content_hash": compute_content_hash(content),
+                        }
+                        for (record_id, content), vector in zip(batch, vectors)
+                    ]
                 )
+            )
             await session.commit()
             created += len(batch)
         except _PinDrift:

--- a/backend/app/processing/embeddings/helpers.py
+++ b/backend/app/processing/embeddings/helpers.py
@@ -178,6 +178,7 @@ async def resolve_live_embedding_config(
     *,
     model_name: str | None = None,
     uncached: bool = False,
+    verify: bool = False,
 ) -> tuple[str, int | None, str | None, str] | None:
     """The live (model, dimensions, endpoint, fingerprint), or None if unresolvable.
 
@@ -194,11 +195,50 @@ async def resolve_live_embedding_config(
     name the configuration cannot safely compare vectors against anything, and
     the provider call it would make next resolves through the same machinery
     and would fail too, so the honest answer is to stop rather than to guess.
+
+    fix(#1546 review r3, codex P2): ``verify`` is for callers that STAMP what
+    they resolve. The three values come from three ``get`` calls, and
+    `PersistentConfig.set` says the quiet part out loud: committing then
+    evicting as one step makes the WRITER atomic and does nothing for a reader,
+    whose separate ``get`` calls sample at different instants and can straddle
+    the whole step. Composing a pin that way can produce (old model, new
+    dimensions, new endpoint) — a triple that was never live.
+
+    For a READER that mismatch is self-correcting: it fingerprints to something
+    no stored row carries, so semantic search matches nothing and degrades to
+    FTS for one request. For a WRITER it is permanent. The row is stamped with
+    a fingerprint no live configuration will ever equal, so it is invisible for
+    good and looks stamped while being so, which is worse than the unstamped
+    rows this column was added to distinguish.
+
+    So ``verify`` resolves the set twice and requires the two to agree, and
+    writers pair it with ``uncached`` — the same two mechanisms
+    `_snapshot_embedding_config` uses in `backfill.py`, for the same reason,
+    which is what gives the ingest writer the guarantee the backfill already
+    had. One retry, because a settings publish settles: the second attempt
+    reads the new state consistently. Two inconsistent attempts answer None,
+    and the caller declines to write rather than writing a triple nobody chose.
+
+    Readers stay on the cheap path deliberately. Doubling their config reads on
+    the search hot path would buy a fallback they already have.
     """
-    resolved = await _resolve_live_embedding_config(
-        session, model_name=model_name, uncached=uncached
-    )
-    return resolved
+    for _ in range(2):
+        resolved = await _resolve_live_embedding_config(
+            session, model_name=model_name, uncached=uncached
+        )
+        if resolved is None or not verify:
+            return resolved
+        confirmation = await _resolve_live_embedding_config(
+            session, model_name=model_name, uncached=uncached
+        )
+        if confirmation == resolved:
+            return resolved
+        logger.warning(
+            "embedding_config_changed_while_being_read",
+            first=resolved[3],
+            second=None if confirmation is None else confirmation[3],
+        )
+    return None
 
 
 async def resolve_embedding_config_fingerprint(

--- a/backend/app/processing/embeddings/helpers.py
+++ b/backend/app/processing/embeddings/helpers.py
@@ -37,14 +37,59 @@ UNKNOWN_EMBEDDING_MODEL = "__model_unknown__"
 UNKNOWN_EMBEDDING_CONFIG = "__config_unknown__"
 
 
+# fix(#1546 review r2, codex P2): ceiling on how far an iterative scan will go
+# looking for rows that survive the filter. pgvector's own default is 20000;
+# stating it here makes the bound visible at the one place iterative scan is
+# turned on, and keeps a pathological catalog from turning one search into a
+# full index walk.
+_HNSW_MAX_SCAN_TUPLES = 20000
+
+
 async def set_hnsw_recall(session: AsyncSession, *, ef: int = 100) -> None:
-    """Tune HNSW ef_search for the current transaction.
+    """Tune HNSW recall for the current transaction.
 
     Default ``ef_search`` (40) misses relevant matches in recall-sensitive
-    queries like related-items and semantic-search. ``SET LOCAL`` scopes the
-    change to this transaction so other queries are unaffected.
+    queries like related-items and semantic-search. These are transaction-local
+    (``set_config(..., is_local => true)`` is ``SET LOCAL``), so other queries
+    are unaffected.
+
+    fix(#1546 review r2, codex P2): iterative scan, because every caller filters
+    the index's output AFTER the approximate scan has chosen its candidates.
+    Semantic search asks for rows a configuration can use; related-items asks
+    for a record's neighbours. With a fixed ``ef_search`` and no iterative scan
+    the index hands back at most that many candidates and the filter runs on
+    them, so a catalog whose nearest neighbours are mostly rows the filter
+    rejects can have every candidate discarded before a usable one is visited.
+    Semantic search then returns nothing and silently falls back to FTS while
+    matching vectors sit in the table.
+
+    A partly complete regenerate after a configuration change is the realistic
+    way to get there: most rows carry the superseded stamp, and they are exactly
+    as near the query as their replacements would be. #1546 widened the
+    predicate, so it widened this, but it did not create it — a model-only
+    filter starves the same way on a catalog holding two models' rows in one
+    index, which is the state #1506 was written for.
+
+    ``relaxed_order`` rather than ``strict_order``: the caller turns distances
+    into positional ranks and merges them with FTS through RRF, so a slight
+    reordering inside the returned window costs nothing, and relaxed is the
+    cheaper mode. Needs pgvector >= 0.8.0; the shipped image installs
+    ``postgresql-18-pgvector`` from PGDG (0.8.5 at time of writing). On an older
+    pgvector the setting is accepted as an inert placeholder rather than an
+    error, because Postgres allows any ``prefix.name`` GUC, so this degrades to
+    the previous behaviour instead of failing the query.
+
+    One statement rather than three: this runs on the search hot path, and
+    ``SET LOCAL`` cannot carry more than one setting.
     """
-    await session.execute(text(f"SET LOCAL hnsw.ef_search = {int(ef)}"))
+    await session.execute(
+        text(
+            "SELECT set_config('hnsw.ef_search', :ef, true), "
+            "set_config('hnsw.iterative_scan', 'relaxed_order', true), "
+            "set_config('hnsw.max_scan_tuples', :max_scan_tuples, true)"
+        ),
+        {"ef": str(int(ef)), "max_scan_tuples": str(_HNSW_MAX_SCAN_TUPLES)},
+    )
 
 
 async def resolve_embedding_model_name(

--- a/backend/app/processing/embeddings/helpers.py
+++ b/backend/app/processing/embeddings/helpers.py
@@ -128,6 +128,34 @@ def embedding_config_fingerprint(
     return hashlib.sha256(payload.encode("utf-8")).hexdigest()
 
 
+async def resolve_live_embedding_config(
+    session: AsyncSession,
+    *,
+    model_name: str | None = None,
+    uncached: bool = False,
+) -> tuple[str, int | None, str | None, str] | None:
+    """The live (model, dimensions, endpoint, fingerprint), or None if unresolvable.
+
+    fix(#1546 review r1, codex P1): callers need the TRIPLE, not only its
+    fingerprint. Semantic search filters stored rows on the fingerprint and
+    must generate its query vector under the very same configuration; handing
+    it the fingerprint alone left the provider call free to re-resolve, so a
+    settings change between the two produced a vector from configuration B
+    cached under, and compared against, configuration A. Returning all four
+    together is what makes "the identity I filtered on" and "the identity that
+    produced the vector" one object rather than two reads.
+
+    None means the configuration could not be resolved. A caller that cannot
+    name the configuration cannot safely compare vectors against anything, and
+    the provider call it would make next resolves through the same machinery
+    and would fail too, so the honest answer is to stop rather than to guess.
+    """
+    resolved = await _resolve_live_embedding_config(
+        session, model_name=model_name, uncached=uncached
+    )
+    return resolved
+
+
 async def resolve_embedding_config_fingerprint(
     session: AsyncSession,
     *,
@@ -172,13 +200,26 @@ async def resolve_embedding_config_fingerprint(
     SAVEPOINT; that is not paid for on the search hot path for a mode the
     runtime role cannot reach (it reads `app_settings` on every request).
     """
+    resolved = await _resolve_live_embedding_config(
+        session, model_name=model_name, uncached=uncached
+    )
+    return UNKNOWN_EMBEDDING_CONFIG if resolved is None else resolved[3]
+
+
+async def _resolve_live_embedding_config(
+    session: AsyncSession,
+    *,
+    model_name: str | None = None,
+    uncached: bool = False,
+) -> tuple[str, int | None, str | None, str] | None:
+    """Read the live configuration once, or answer None. Never raises."""
     from app.core.persistent_config import EMBEDDING_DIMS
 
     try:
         if model_name is None:
             model_name = await resolve_embedding_model_name(session, uncached=uncached)
         if model_name == UNKNOWN_EMBEDDING_MODEL:
-            return UNKNOWN_EMBEDDING_CONFIG
+            return None
         dimensions = await (
             EMBEDDING_DIMS.get_uncached(session)
             if uncached
@@ -191,9 +232,14 @@ async def resolve_embedding_config_fingerprint(
 
         base_url = await resolve_embedding_base_url(session)
     except Exception:  # broad: config/provider resolution fails for many reasons; a reader must degrade, not raise
-        logger.warning("embedding_config_fingerprint_unresolved", exc_info=True)
-        return UNKNOWN_EMBEDDING_CONFIG
-    return embedding_config_fingerprint(model_name, dimensions, base_url)
+        logger.warning("embedding_config_unresolved", exc_info=True)
+        return None
+    return (
+        model_name,
+        dimensions,
+        base_url,
+        embedding_config_fingerprint(model_name, dimensions, base_url),
+    )
 
 
 async def has_embeddings(session: AsyncSession) -> bool:

--- a/backend/app/processing/embeddings/helpers.py
+++ b/backend/app/processing/embeddings/helpers.py
@@ -1,5 +1,7 @@
 """Shared embedding helpers used across AI, search, admin, and ingest modules."""
 
+import hashlib
+import json
 import time
 import uuid
 
@@ -27,6 +29,12 @@ _HAS_EMBEDDINGS_MAX = 8  # bounded; operators rarely run more than 2-3 models
 # matches no stored row; a WRITE-side caller has to check for it explicitly
 # (see DefaultProcessingPort.get_records_without_embeddings).
 UNKNOWN_EMBEDDING_MODEL = "__model_unknown__"
+
+# fix(#1546): the sibling of the above for the whole configuration. Not a hex
+# digest, so it can never collide with a real fingerprint and therefore matches
+# no STAMPED row. It does still match an unstamped one, which is the same
+# grandfathering `RecordEmbedding.usable_by_config` applies everywhere else.
+UNKNOWN_EMBEDDING_CONFIG = "__config_unknown__"
 
 
 async def set_hnsw_recall(session: AsyncSession, *, ef: int = 100) -> None:
@@ -82,6 +90,110 @@ async def resolve_embedding_model_name(
     except Exception:  # broad: persistent_config resolution can fail for any DB/cache reason; fall back to sentinel
         logger.warning("has_embeddings_model_resolution_failed", exc_info=True)
         return UNKNOWN_EMBEDDING_MODEL
+
+
+def embedding_config_fingerprint(
+    model_name: str, dimensions: int | None, base_url: str | None
+) -> str:
+    """Identity of the configuration a stored vector came out of (#1546).
+
+    The three arguments are the whole of what decides the vector space: the
+    model, the width it was asked for, and the endpoint that served it. Two
+    rows with the same fingerprint are comparable; two with different ones are
+    not, whatever their `model_name` says.
+
+    Stable across restarts and across processes. SHA-256 over a canonical JSON
+    array, deliberately NOT Python's `hash()`, which is salted per interpreter
+    (`PYTHONHASHSEED`) and would give the same configuration a different
+    identity after every restart — rows stamped by one worker would then be
+    invisible to the next.
+
+    JSON rather than a delimiter join: it keeps `None` distinct from the string
+    `"None"` and from `""` (all three are reachable — an unset endpoint
+    resolves to `None`, an unset width to `None`), and it escapes the strings,
+    so ("a|b", None) cannot collide with ("a", "b|None").
+
+    A change to WHICH values make up the identity changes every fingerprint,
+    which reads as a configuration change to every reader and makes existing
+    rows invisible until they are regenerated. That is the honest outcome — a
+    different notion of identity really does mean the old stamps are not
+    comparable — but it is a catalog-wide re-embed, so do not extend this
+    lightly.
+    """
+    payload = json.dumps(
+        [model_name, dimensions, base_url],
+        separators=(",", ":"),
+        ensure_ascii=True,
+    )
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+async def resolve_embedding_config_fingerprint(
+    session: AsyncSession,
+    *,
+    model_name: str | None = None,
+    uncached: bool = False,
+) -> str:
+    """Fingerprint the LIVE embedding configuration, or answer with a sentinel.
+
+    fix(#1546): the read-side counterpart of `embedding_config_fingerprint`.
+    Writers stamp from the configuration they PINNED (that is the whole point —
+    the stamp has to name what actually produced the vector); readers ask this
+    what the live configuration is so they can ignore rows from another one.
+
+    ``model_name`` is for callers that already resolved it. They pass it rather
+    than let this read it again, so the model they filter on and the model
+    inside the fingerprint are one read and cannot straddle a config change.
+
+    Never raises. The endpoint resolves through the provider extension, and for
+    the shipped provider that call raises whenever the database endpoint
+    diverges from the operator-approved environment URL
+    (`ai_credentials.bind_openai_credential_base_url`). A reader that turned
+    that into a 500 would take search down over a setting it is only consulting
+    to be careful, so an unresolvable configuration answers with
+    `UNKNOWN_EMBEDDING_CONFIG` and every stamped row reads as foreign — the
+    same under-report `resolve_embedding_model_name`'s sentinel produces, in
+    the same safe direction.
+
+    The read is CACHED by default, unlike the backfill's pre-delete snapshot.
+    A reader has nothing to destroy: the worst a stale cache entry does here is
+    make stamped rows briefly invisible, which degrades semantic search to FTS
+    for one cache TTL and heals itself. An uncached read costs a DB round trip
+    on the search hot path for that.
+
+    One thing "never raises" does NOT mean: if the failure was a DATABASE error
+    on `session`, that session's transaction is aborted and the caller's next
+    statement will fail too. Swallowing here cannot undo that, and the same is
+    already true of `resolve_embedding_model_name` above. Every caller today
+    sits inside a broad handler that degrades — search falls back to FTS, the
+    admin panel reads zeros, the backfill selection returns nothing — so the
+    poisoned transaction changes nothing about the outcome. A future caller
+    that wants to keep using the session after a failure here needs a
+    SAVEPOINT; that is not paid for on the search hot path for a mode the
+    runtime role cannot reach (it reads `app_settings` on every request).
+    """
+    from app.core.persistent_config import EMBEDDING_DIMS
+
+    try:
+        if model_name is None:
+            model_name = await resolve_embedding_model_name(session, uncached=uncached)
+        if model_name == UNKNOWN_EMBEDDING_MODEL:
+            return UNKNOWN_EMBEDDING_CONFIG
+        dimensions = await (
+            EMBEDDING_DIMS.get_uncached(session)
+            if uncached
+            else EMBEDDING_DIMS.get(session)
+        )
+        # Imported in-function because the edge runs the other way at module
+        # level: `service` imports `embedding_config_fingerprint` from here, so
+        # a module-level import back would be a cycle.
+        from app.processing.embeddings.service import resolve_embedding_base_url
+
+        base_url = await resolve_embedding_base_url(session)
+    except Exception:  # broad: config/provider resolution fails for many reasons; a reader must degrade, not raise
+        logger.warning("embedding_config_fingerprint_unresolved", exc_info=True)
+        return UNKNOWN_EMBEDDING_CONFIG
+    return embedding_config_fingerprint(model_name, dimensions, base_url)
 
 
 async def has_embeddings(session: AsyncSession) -> bool:

--- a/backend/app/processing/embeddings/models.py
+++ b/backend/app/processing/embeddings/models.py
@@ -2,8 +2,17 @@ import uuid
 from datetime import datetime
 
 from pgvector.sqlalchemy import Vector
-from sqlalchemy import DateTime, ForeignKey, String, UniqueConstraint, func
+from sqlalchemy import (
+    DateTime,
+    ForeignKey,
+    String,
+    UniqueConstraint,
+    and_,
+    func,
+    or_,
+)
 from sqlalchemy.orm import Mapped, mapped_column, relationship
+from sqlalchemy.sql.elements import ColumnElement
 
 from app.core.db import Base
 
@@ -23,6 +32,19 @@ class RecordEmbedding(Base):
     )
     embedding = mapped_column(Vector(), nullable=False)
     model_name: Mapped[str] = mapped_column(String(100), nullable=False)
+    # fix(#1546): the vector space a row lives in is a function of the model,
+    # the width it was asked for AND the endpoint that served it. `model_name`
+    # names only the first, so one model behind two endpoints is two spaces
+    # under one label and nothing stored tells them apart. This is the SHA-256
+    # of that triple, computed by `embedding_config_fingerprint` in
+    # `processing/embeddings/helpers.py`.
+    #
+    # NULL means "written before this column existed". Migration 0052 does not
+    # backfill it: what configuration produced a pre-existing vector is not
+    # recoverable, and stamping those rows with today's configuration would
+    # invent provenance. `usable_by_config` below is where NULL is given its
+    # meaning for every reader.
+    config_fingerprint: Mapped[str | None] = mapped_column(String(64), nullable=True)
     content_hash: Mapped[str] = mapped_column(String(64), nullable=False)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now()
@@ -32,3 +54,33 @@ class RecordEmbedding(Base):
     )
 
     record = relationship("Record")
+
+    @classmethod
+    def usable_by_config(
+        cls, model_name: str, config_fingerprint: str
+    ) -> ColumnElement[bool]:
+        """Match rows whose vector can be compared against ``config_fingerprint``.
+
+        fix(#1546): ONE definition of the rule, on the model, because every
+        reader has to apply the same one or the inconsistency simply moves.
+        Semantic search, the non-force backfill's "already covered" predicate
+        and the admin coverage stats all call this; `modules/catalog/` reaches
+        it through `CatalogPort.record_embedding_orm_class()`, which is why it
+        lives here rather than in `helpers.py`. The admin panel's raw-SQL
+        coverage query spells the same condition out by hand — the two are
+        pinned together by test_embedding_config_stamp_1546.py.
+
+        An UNSTAMPED row (NULL) matches on model name alone, exactly as before
+        this column existed. That is a deliberately weaker guarantee, kept so
+        that upgrading does not empty semantic search: every row already in the
+        table is unstamped, and the alternative to grandfathering them is
+        either a catalog-wide re-embed nobody asked to pay for or a search that
+        returns nothing until one finishes.
+        """
+        return and_(
+            cls.model_name == model_name,
+            or_(
+                cls.config_fingerprint.is_(None),
+                cls.config_fingerprint == config_fingerprint,
+            ),
+        )

--- a/backend/app/processing/embeddings/service.py
+++ b/backend/app/processing/embeddings/service.py
@@ -10,7 +10,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.config import settings
 from app.platform.extensions import get_embedding_provider
-from app.processing.embeddings.helpers import embedding_config_fingerprint
+from app.processing.embeddings.helpers import resolve_live_embedding_config
 from app.processing.embeddings.models import RecordEmbedding
 from app.core.persistent_config import AI_ENABLED, EMBEDDING_DIMS, EMBEDDING_MODEL
 
@@ -399,7 +399,40 @@ async def generate_and_store_embedding(
         return False
 
     content_hash = compute_content_hash(content_text)
-    model_name = await EMBEDDING_MODEL.get(session)
+
+    # fix(#1546): this function writes its own `model_name` label, which
+    # `generate_embeddings_batch` documents as the case that MUST pin all three
+    # values. It did not: it labelled rows from `EMBEDDING_MODEL.get()` and then
+    # let the provider re-read the configuration for itself, so a swap landing
+    # between the two produced a row labelled with one model and holding
+    # another's vector.
+    #
+    # fix(#1546 review r3, codex P2): and the pin is resolved as ONE verified
+    # set, before anything else depends on the model name. Assembling it from a
+    # `model_name` read here and a dimensions/endpoint read further down let a
+    # settings publish land in between and pin (old model, new dimensions, new
+    # endpoint) — a triple that was never live, whose fingerprint no live
+    # configuration will ever equal. The row would be invisible for good while
+    # looking stamped, which is worse than the unstamped rows the column exists
+    # to tell apart.
+    #
+    # The model has to come out of the same verified set, not a separate read,
+    # because the lookup below uses it to find the row this call may UPDATE. A
+    # lookup under one model and a pin under another would write the new
+    # model's vector into the old model's row, mislabelled — the #1511 bug by
+    # another route.
+    #
+    # This costs the resolution on the "record touched, text unchanged" path,
+    # which an earlier revision skipped by reading the model on its own first.
+    # That shortcut is exactly what made the pin composable from two instants.
+    resolved = await resolve_live_embedding_config(session, uncached=True, verify=True)
+    if resolved is None:
+        logger.warning(
+            "Embedding configuration could not be resolved, skipping",
+            record_id=str(record_id),
+        )
+        return False
+    model_name, dimensions, base_url, config_fingerprint = resolved
 
     # Check existing embedding for hash match
     result = await session.execute(
@@ -415,10 +448,6 @@ async def generate_and_store_embedding(
     # search still matches it on model name alone, so unchanged content is
     # still a skip — a record does not get re-embedded at provider cost just to
     # earn a stamp. A force regenerate is what replaces those.
-    #
-    # This branch is also what keeps the resolution below off the hot path for
-    # the common "record touched, embeddable text identical" case on an
-    # instance that has not regenerated since upgrading.
     if unchanged and existing.config_fingerprint is None:
         logger.debug(
             "Hash unchanged, skipping embedding",
@@ -426,25 +455,6 @@ async def generate_and_store_embedding(
             content_hash=content_hash,
         )
         return False
-
-    # fix(#1546): this function writes its own `model_name` label, which
-    # `generate_embeddings_batch` documents as the case that MUST pin all three
-    # values. It did not: it labelled rows from `EMBEDDING_MODEL.get()` and then
-    # let the provider re-read the configuration for itself, so a swap landing
-    # between the two produced a row labelled with one model and holding
-    # another's vector. Pinning here fixes that and is what makes the stamp
-    # below true rather than decorative.
-    try:
-        dimensions = await EMBEDDING_DIMS.get(session)
-        base_url = await resolve_embedding_base_url(session)
-    except Exception:  # broad: same non-fatal contract as the generate call below
-        logger.warning(
-            "Embedding configuration could not be resolved, skipping",
-            record_id=str(record_id),
-            exc_info=True,
-        )
-        return False
-    config_fingerprint = embedding_config_fingerprint(model_name, dimensions, base_url)
 
     # fix(#1546): unchanged content is only a skip when the stored vector also
     # came from the configuration that is live now. A row stamped with another

--- a/backend/app/processing/embeddings/service.py
+++ b/backend/app/processing/embeddings/service.py
@@ -10,6 +10,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.config import settings
 from app.platform.extensions import get_embedding_provider
+from app.processing.embeddings.helpers import embedding_config_fingerprint
 from app.processing.embeddings.models import RecordEmbedding
 from app.core.persistent_config import AI_ENABLED, EMBEDDING_DIMS, EMBEDDING_MODEL
 
@@ -120,9 +121,14 @@ async def generate_embeddings_batch(
     that supposedly produced them. Passing a subset is worse than passing none:
     model A with model B's dimensions is a pair that never existed in config,
     and model A against a repointed endpoint is a vector space nothing in the
-    catalog can name. Today `processing/embeddings/backfill.py` is the only such
-    caller; `generate_embedding` above makes a single call and labels nothing,
-    so it deliberately does not pin.
+    catalog can name. `processing/embeddings/backfill.py` and
+    `generate_and_store_embedding` below are the two such callers, and
+    fix(#1546) is what brought the second into line: it labelled rows from its
+    own `EMBEDDING_MODEL.get()` while leaving this function to re-read the
+    config for itself, so a swap landing between the two produced a row
+    labelled with one model holding another's vector. `generate_embedding`
+    above makes a single call and labels nothing, so it deliberately does not
+    pin.
 
     Omitting them keeps the pre-existing per-call resolution, which is correct
     for a single-call caller and silently racy for a multi-call labelling one.
@@ -403,8 +409,49 @@ async def generate_and_store_embedding(
         )
     )
     existing = result.scalar_one_or_none()
+    unchanged = existing is not None and existing.content_hash == content_hash
 
-    if existing and existing.content_hash == content_hash:
+    # fix(#1546): an UNSTAMPED row predates the configuration stamp. Semantic
+    # search still matches it on model name alone, so unchanged content is
+    # still a skip — a record does not get re-embedded at provider cost just to
+    # earn a stamp. A force regenerate is what replaces those.
+    #
+    # This branch is also what keeps the resolution below off the hot path for
+    # the common "record touched, embeddable text identical" case on an
+    # instance that has not regenerated since upgrading.
+    if unchanged and existing.config_fingerprint is None:
+        logger.debug(
+            "Hash unchanged, skipping embedding",
+            record_id=str(record_id),
+            content_hash=content_hash,
+        )
+        return False
+
+    # fix(#1546): this function writes its own `model_name` label, which
+    # `generate_embeddings_batch` documents as the case that MUST pin all three
+    # values. It did not: it labelled rows from `EMBEDDING_MODEL.get()` and then
+    # let the provider re-read the configuration for itself, so a swap landing
+    # between the two produced a row labelled with one model and holding
+    # another's vector. Pinning here fixes that and is what makes the stamp
+    # below true rather than decorative.
+    try:
+        dimensions = await EMBEDDING_DIMS.get(session)
+        base_url = await resolve_embedding_base_url(session)
+    except Exception:  # broad: same non-fatal contract as the generate call below
+        logger.warning(
+            "Embedding configuration could not be resolved, skipping",
+            record_id=str(record_id),
+            exc_info=True,
+        )
+        return False
+    config_fingerprint = embedding_config_fingerprint(model_name, dimensions, base_url)
+
+    # fix(#1546): unchanged content is only a skip when the stored vector also
+    # came from the configuration that is live now. A row stamped with another
+    # one is invisible to semantic search, so leaving it in place would report
+    # coverage the search cannot use — the same relocation of the bug that the
+    # backfill's skip predicate had to close.
+    if unchanged and existing.config_fingerprint == config_fingerprint:
         logger.debug(
             "Hash unchanged, skipping embedding",
             record_id=str(record_id),
@@ -414,7 +461,13 @@ async def generate_and_store_embedding(
 
     # Generate embedding vector
     try:
-        vector = await generate_embedding(content_text, session)
+        [vector] = await generate_embeddings_batch(
+            [content_text],
+            session,
+            model=model_name,
+            dimensions=dimensions,
+            base_url=base_url,
+        )
     except EmbeddingUnavailableError:
         logger.warning(
             "Embedding unavailable, skipping",
@@ -433,6 +486,11 @@ async def generate_and_store_embedding(
     if existing:
         existing.embedding = vector
         existing.content_hash = content_hash
+        # fix(#1546): re-stamp. The row is keyed (record_id, model_name), so a
+        # configuration change that keeps the model lands HERE rather than on
+        # the insert branch — leaving the old stamp would label the new vector
+        # with the configuration of the one it replaced.
+        existing.config_fingerprint = config_fingerprint
         existing.updated_at = datetime.now(timezone.utc)
     else:
         session.add(
@@ -440,6 +498,7 @@ async def generate_and_store_embedding(
                 record_id=record_id,
                 embedding=vector,
                 model_name=model_name,
+                config_fingerprint=config_fingerprint,
                 content_hash=content_hash,
             )
         )

--- a/backend/tests/test_embedding_backfill.py
+++ b/backend/tests/test_embedding_backfill.py
@@ -37,6 +37,28 @@ def _make_query_result(records):
     return result
 
 
+def _written_rows(session) -> list[dict]:
+    """Return the embedding rows the run wrote.
+
+    fix(#1546): rows go in through a Core INSERT ... ON CONFLICT DO UPDATE
+    rather than `session.add`, because a record whose only row for the active
+    model came from a different configuration is now offered as missing and a
+    plain INSERT would answer it with a unique violation. So these tests count
+    what the statement carries instead of counting `session.add` calls.
+    """
+    from sqlalchemy.dialects.postgresql.dml import Insert
+
+    rows: list[dict] = []
+    for call in session.execute.await_args_list:
+        stmt = call.args[0] if call.args else None
+        if isinstance(stmt, Insert):
+            for group in stmt._multi_values:
+                rows.extend(
+                    {col.name: value for col, value in row.items()} for row in group
+                )
+    return rows
+
+
 def _patch_backfill_gates(stack: ExitStack, *, ai_enabled=True):
     """Patch the run-level PersistentConfig gates the backfill reads once.
 
@@ -92,7 +114,19 @@ class TestBackfillEmbeddings:
         assert result["processed"] == 2
         assert result["created"] == 2
         assert result["errors"] == 0
-        assert session.add.call_count == 2
+
+        rows = _written_rows(session)
+        assert len(rows) == 2
+        # fix(#1546): every row carries the identity of the configuration that
+        # produced it, and it is the pinned one — the same (model, dimensions,
+        # endpoint) triple handed to the provider call above.
+        from app.processing.embeddings.helpers import embedding_config_fingerprint
+
+        pinned = mock_batch.call_args.kwargs
+        pinned_stamp = embedding_config_fingerprint(
+            pinned["model"], pinned["dimensions"], pinned["base_url"]
+        )
+        assert {row["config_fingerprint"] for row in rows} == {pinned_stamp}
 
     @pytest.mark.asyncio
     async def test_batch_errors_do_not_stop_backfill(self):
@@ -162,7 +196,7 @@ class TestBackfillEmbeddings:
         assert result["processed"] == 2
         assert result["created"] == 1
         assert result["errors"] == 1
-        assert session.add.call_count == 1
+        assert len(_written_rows(session)) == 1
 
     @pytest.mark.asyncio
     async def test_returns_correct_counts(self):

--- a/backend/tests/test_embedding_backfill_base_url_pinning.py
+++ b/backend/tests/test_embedding_backfill_base_url_pinning.py
@@ -89,15 +89,30 @@ class _EndpointRecordingProvider:
 
     Records what each call received, and lands the admin's endpoint edit during
     the first provider call.
+
+    ``resolves_before_edit`` defers that edit past a number of endpoint
+    resolutions. fix(#1546): the NON-FORCE path resolves the endpoint once
+    before the snapshot does — `get_records_without_embeddings` fingerprints the
+    live configuration to decide which records are missing under it — so a
+    subclass that has to land its edit inside the SNAPSHOT's window has to let
+    that one through first. The force path still snapshots before anything else
+    resolves, so it passes 0.
     """
 
-    def __init__(self):
+    def __init__(self, *, resolves_before_edit: int = 0):
         self.calls: list[dict] = []
         self._session = None
         self._edited = False
+        self.resolves = 0
+        self._resolves_before_edit = resolves_before_edit
+
+    @property
+    def _edit_window_reached(self) -> bool:
+        return self.resolves > self._resolves_before_edit
 
     async def resolve_runtime_config(self, session):
         self._session = session
+        self.resolves += 1
         return {
             "default_model": "provider-fallback-model",
             "default_dims": _DIMS,
@@ -142,8 +157,10 @@ class _SnapshotWindowProvider(_EndpointRecordingProvider):
 
     async def resolve_runtime_config(self, session):
         self._session = session
+        self.resolves += 1
         current = await EMBEDDING_BASE_URL.get(session)
-        await self._land_the_admin_edit()
+        if self._edit_window_reached:
+            await self._land_the_admin_edit()
         return {
             "default_model": "provider-fallback-model",
             "default_dims": _DIMS,
@@ -169,7 +186,8 @@ class _AtomicSwitchProvider(_EndpointRecordingProvider):
 
     async def resolve_runtime_config(self, session):
         self._session = session
-        if not self._edited:
+        self.resolves += 1
+        if self._edit_window_reached and not self._edited:
             self._edited = True
             await EMBEDDING_MODEL.set(session, _MODEL_AFTER)
             await EMBEDDING_BASE_URL.set(session, _URL_B)
@@ -450,7 +468,10 @@ async def test_an_edit_inside_the_snapshot_window_aborts_the_run(
     ).scalar_one()
     assert before > 0
 
-    provider = _SnapshotWindowProvider()
+    # fix(#1546): on the non-force path the selection resolves the endpoint
+    # before the snapshot does, so the edit has to skip that one to land where
+    # this test needs it — inside the snapshot's own capture.
+    provider = _SnapshotWindowProvider(resolves_before_edit=0 if force else 1)
     monkeypatch.setattr(
         service_module, "get_embedding_provider", lambda _name: provider
     )
@@ -522,7 +543,7 @@ async def test_an_atomic_model_and_endpoint_swap_cannot_pin_a_mixed_pair(
     ).scalar_one()
     assert before > 0
 
-    provider = _AtomicSwitchProvider()
+    provider = _AtomicSwitchProvider(resolves_before_edit=0 if force else 1)
     monkeypatch.setattr(
         service_module, "get_embedding_provider", lambda _name: provider
     )
@@ -592,7 +613,10 @@ async def test_an_endpoint_that_resolves_to_none_is_still_pinned(
     # its own VALUE as well would add a third, which is the bug: with
     # `base_url is None` as the pin test, a resolved None reads as an omission
     # and every batch re-resolves.
-    assert provider.resolves == 2 + 2 * len(provider.calls)
+    # fix(#1546): plus ONE for the non-force selection, which fingerprints the
+    # live configuration to decide which records lack a vector THIS
+    # configuration can use.
+    assert provider.resolves == 1 + 2 + 2 * len(provider.calls)
     # And the pinned value actually reached the provider as itself.
     assert {call["base_url"] for call in provider.calls} == {None}
 

--- a/backend/tests/test_embedding_backfill_model_pinning.py
+++ b/backend/tests/test_embedding_backfill_model_pinning.py
@@ -354,30 +354,26 @@ async def test_a_switch_between_the_model_and_dims_reads_aborts_the_run(
     assert before > 0
 
     # fix(#1525 review r2): hung on the UNCACHED read, which is the one the
-    # snapshot makes now. The cached read is still what everything else uses, so
-    # both are patched and the flip fires on whichever the snapshot reaches
-    # first — the point is that it lands between the two captures, not which
-    # layer serves them.
-    original_dims_get = EMBEDDING_DIMS.get
+    # snapshot makes.
+    #
+    # fix(#1546): the CACHED read is no longer a stand-in for it. The non-force
+    # selection now reads the dimensions through `get` on its way to
+    # fingerprinting the live configuration, so a flip hung there fires BEFORE
+    # the snapshot starts, which leaves the snapshot reading a settled pair and
+    # this test asserting nothing. `get_uncached` is reached only from inside
+    # `_snapshot_embedding_config`, which is where the flip has to land: between
+    # the model capture and the dimensions capture.
     original_dims_get_uncached = EMBEDDING_DIMS.get_uncached
     flipped = False
 
-    async def _flip(session) -> None:
+    async def _flip_then_read_uncached(session):
         nonlocal flipped
         if not flipped:
             flipped = True
             await EMBEDDING_MODEL.set(session, _MODEL_B)
             await EMBEDDING_DIMS.set(session, _DIMS_B)
-
-    async def _flip_then_read(session):
-        await _flip(session)
-        return await original_dims_get(session)
-
-    async def _flip_then_read_uncached(session):
-        await _flip(session)
         return await original_dims_get_uncached(session)
 
-    monkeypatch.setattr(EMBEDDING_DIMS, "get", _flip_then_read)
     monkeypatch.setattr(EMBEDDING_DIMS, "get_uncached", _flip_then_read_uncached)
 
     provider = _RecordingProvider()

--- a/backend/tests/test_embedding_config_stamp_1546.py
+++ b/backend/tests/test_embedding_config_stamp_1546.py
@@ -49,6 +49,11 @@ from tests.factories import create_dataset, get_user_id
 
 _DIMS = 1536
 _MODEL = "stamp-1546-model"
+_MODEL_AFTER = "stamp-1546-model-after"
+# The publish moves the WIDTH too. With only the model moving, the hybrid
+# (old model, new width) fingerprints identically to the old configuration and
+# the assertion below could not tell them apart.
+_DIMS_AFTER = 768
 # A second configuration differing ONLY in the endpoint. Same model name, same
 # width — which is exactly the case `model_name` cannot tell apart.
 _FOREIGN_URL = "https://embeddings-elsewhere.invalid/v1"
@@ -453,6 +458,105 @@ async def test_a_legacy_unstamped_row_stays_searchable_after_upgrade(
     assert response.status_code == 200
     titles = [f["properties"]["title"] for f in response.json()["features"]]
     assert "Zqz Stamp Legacy" in titles
+
+
+@pytest.mark.anyio
+async def test_the_ingest_pin_is_never_a_configuration_that_was_never_live(
+    test_db_session,
+    restore_embedding_config,
+    monkeypatch,
+):
+    """fix(#1546 review r3, codex P2): the third writer, same relocated pair.
+
+    `generate_and_store_embedding` composed its pin from a `model_name` read at
+    the top and a dimensions/endpoint read further down. `PersistentConfig.set`
+    is explicit that committing then evicting as one step makes the WRITER
+    atomic and does nothing for a reader, so a settings publish landing between
+    those two reads pins (old model, new dimensions, new endpoint) — a triple
+    that was never live. Unlike the same mistake in a reader, this one is
+    STAMPED: the row carries a fingerprint no live configuration will ever
+    equal, so it is invisible for good while looking stamped.
+
+    The publish is driven through the real setter from inside the first
+    dimensions read, which is where the window actually is. The assertion is
+    the one that matters: whatever ends up on the row, it is the fingerprint of
+    a configuration that was really live, never a mixture of two.
+    """
+    session = test_db_session
+    user_id = await get_user_id(session, "admin")
+    dataset = await create_dataset(session, created_by=user_id, name="Ingest Pin DS")
+
+    await EMBEDDING_MODEL.set(session, _MODEL)
+    await EMBEDDING_DIMS.set(session, _DIMS)
+    base_url = await resolve_embedding_base_url(session)
+    before = embedding_config_fingerprint(_MODEL, _DIMS, base_url)
+    after = embedding_config_fingerprint(_MODEL_AFTER, _DIMS_AFTER, base_url)
+    # The pairing the unfixed composition produces: the model read BEFORE the
+    # publish, the width read AFTER it. It has to be distinct from both real
+    # configurations or this test cannot see the defect.
+    hybrid = embedding_config_fingerprint(_MODEL, _DIMS_AFTER, base_url)
+    assert len({before, after, hybrid}) == 3
+
+    original_get_uncached = EMBEDDING_DIMS.get_uncached
+    published = {"done": False}
+
+    async def _publish_then_read(sess):
+        if not published["done"]:
+            published["done"] = True
+            # Lands the admin's publish through the real setter, between the
+            # model read above it and the endpoint read below it.
+            await EMBEDDING_MODEL.set(sess, _MODEL_AFTER)
+            await EMBEDDING_DIMS.set(sess, _DIMS_AFTER)
+        return await original_get_uncached(sess)
+
+    monkeypatch.setattr(EMBEDDING_DIMS, "get_uncached", _publish_then_read)
+    monkeypatch.setattr(
+        service_module, "settings", SimpleNamespace(openai_api_key="stamp-test-key")
+    )
+
+    async def _fake_batch(texts, _session, *, model, dimensions, base_url):
+        return [[1.0] + [0.0] * (_DIMS - 1) for _ in texts]
+
+    monkeypatch.setattr(service_module, "generate_embeddings_batch", _fake_batch)
+
+    stored = await service_module.generate_and_store_embedding(
+        session=session,
+        record_id=dataset.record_id,
+        title="Ingest Pin DS",
+        summary=None,
+        keywords=None,
+        lineage=None,
+    )
+    await session.commit()
+
+    # Non-vacuity: the publish really landed.
+    assert published["done"]
+    assert await EMBEDDING_MODEL.get_uncached(session) == _MODEL_AFTER
+
+    rows = (
+        await session.execute(
+            select(
+                RecordEmbedding.model_name, RecordEmbedding.config_fingerprint
+            ).where(RecordEmbedding.record_id == dataset.record_id)
+        )
+    ).all()
+    if not stored:
+        # Declining to write is a valid outcome: two disagreeing reads mean the
+        # writer could not name one configuration, and writing nothing beats
+        # writing a triple nobody chose.
+        assert rows == []
+        return
+
+    ((model_name, fingerprint),) = rows
+    # The defect, named directly: never the pairing that was never live.
+    assert fingerprint != hybrid
+    # And what was written names a configuration that really was live, with the
+    # label agreeing with the stamp rather than coming from an earlier read.
+    assert fingerprint in {before, after}
+    expected_dims = _DIMS if fingerprint == before else _DIMS_AFTER
+    assert fingerprint == embedding_config_fingerprint(
+        model_name, expected_dims, base_url
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_embedding_config_stamp_1546.py
+++ b/backend/tests/test_embedding_config_stamp_1546.py
@@ -1,0 +1,736 @@
+"""Stored embeddings carry the configuration that produced them (#1546).
+
+`model_name` names the model, not the vector space. The space is a function of
+the model, the width it was asked for AND the endpoint that served it, so one
+model behind two endpoints is two spaces under one label. Semantic search
+embeds the query with the configuration live at query time and filtered stored
+rows by model name alone, which let it compare vectors across spaces: cosine
+distances came back well-formed and meaningless, nothing errored, and ranking
+quality degraded silently.
+
+Every row now carries `config_fingerprint`, the SHA-256 of that triple, stamped
+from the configuration the writing run PINNED. Readers filter on it.
+
+A row with no stamp predates the column. It is matched on model name alone,
+exactly as before, so an upgrade neither empties semantic search nor triggers a
+catalog-wide re-embed. `test_a_legacy_unstamped_row_*` are the tests that hold
+that guarantee down, and each has a counterfactual named in its docstring.
+
+Requirements:
+  - Docker database must be running (docker compose up db)
+  - Alembic migrations must be applied (including pgvector)
+"""
+
+import uuid
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import func, select, text
+
+from app.core.db.models import AppSetting
+from app.core.persistent_config import EMBEDDING_DIMS, EMBEDDING_MODEL
+from app.modules.admin.service import AdminService
+from app.modules.catalog.datasets.domain.models import Dataset, Record
+from app.platform.extensions.defaults_processing_port import DefaultProcessingPort
+from app.processing.embeddings import backfill as backfill_module
+from app.processing.embeddings import helpers
+from app.processing.embeddings import service as service_module
+from app.processing.embeddings.helpers import (
+    embedding_config_fingerprint,
+    resolve_embedding_config_fingerprint,
+)
+from app.processing.embeddings.models import RecordEmbedding
+from app.processing.embeddings.service import resolve_embedding_base_url
+
+from tests.factories import create_dataset, get_user_id
+
+_DIMS = 1536
+_MODEL = "stamp-1546-model"
+# A second configuration differing ONLY in the endpoint. Same model name, same
+# width — which is exactly the case `model_name` cannot tell apart.
+_FOREIGN_URL = "https://embeddings-elsewhere.invalid/v1"
+
+
+@pytest.fixture(autouse=True)
+def _fresh_caches():
+    """Clear the two process-global caches these tests read through.
+
+    `has_embeddings` (TTL 30s) decides whether the vector arm runs at all, and
+    a False cached by an earlier test starves it. The query-embedding LRU is
+    keyed on the configuration fingerprint now, so a leftover entry cannot be
+    served across configurations — but clearing it keeps the provider-call
+    counts in these tests about this test.
+    """
+    from app.modules.catalog.search import service_semantic
+
+    helpers._has_embeddings_cache.clear()
+    service_semantic._embedding_cache_clear()
+    yield
+    helpers._has_embeddings_cache.clear()
+    service_semantic._embedding_cache_clear()
+
+
+@pytest.fixture
+async def restore_embedding_config(test_db_session):
+    """Put the AI config back; the worker database is shared across tests."""
+    before = (
+        await EMBEDDING_MODEL.get(test_db_session),
+        await EMBEDDING_DIMS.get(test_db_session),
+    )
+    yield
+    await EMBEDDING_MODEL.set(test_db_session, before[0])
+    await EMBEDDING_DIMS.set(test_db_session, before[1])
+
+
+async def _live_and_foreign(session, *, model_name: str) -> tuple[str, str]:
+    """Two configuration fingerprints: the live one, and one from elsewhere.
+
+    Both are built from `embedding_config_fingerprint` over a (model, width,
+    endpoint) triple, so neither comes out of the resolver under test. The live
+    one is that function applied to the endpoint the provider actually resolves
+    to; the foreign one differs in the endpoint alone.
+    """
+    dimensions = await EMBEDDING_DIMS.get(session)
+    live_url = await resolve_embedding_base_url(session)
+    assert live_url != _FOREIGN_URL
+    return (
+        embedding_config_fingerprint(model_name, dimensions, live_url),
+        embedding_config_fingerprint(model_name, dimensions, _FOREIGN_URL),
+    )
+
+
+def _vector_band(base_value: float, *, lo: int = 900) -> list[float]:
+    """A unit vector whose signal sits in dims [lo, lo+10) and zeros elsewhere.
+
+    Orthogonal to the bands the other search suites use, so a query built here
+    matches only the rows this file writes, whatever else the shared worker
+    database is carrying.
+    """
+    vec = [0.0] * _DIMS
+    for i in range(lo, lo + 10):
+        vec[i] = base_value + ((i - lo) * 0.01)
+    magnitude = sum(v * v for v in vec) ** 0.5
+    return [v / magnitude for v in vec]
+
+
+async def _add_embedding(
+    session,
+    record_id: uuid.UUID,
+    *,
+    model_name: str,
+    config_fingerprint: str | None,
+    vector: list[float] | None = None,
+) -> None:
+    session.add(
+        RecordEmbedding(
+            record_id=record_id,
+            embedding=vector or ([1.0] + [0.0] * (_DIMS - 1)),
+            model_name=model_name,
+            config_fingerprint=config_fingerprint,
+            content_hash=uuid.uuid4().hex[:64],
+        )
+    )
+    await session.commit()
+
+
+async def _create_dataset(session, *, created_by: uuid.UUID, name: str) -> Dataset:
+    """A published, public Record+Dataset pair the search endpoint can return."""
+    record = Record(
+        title=name,
+        summary=f"Summary for {name}",
+        visibility="public",
+        record_status="published",
+        created_by=created_by,
+    )
+    session.add(record)
+    await session.flush()
+    dataset = Dataset(
+        record_id=record.id,
+        table_name=f"ds_{uuid.uuid4().hex[:12]}",
+        srid=4326,
+        geometry_type="MultiPolygon",
+        feature_count=1,
+        source_format="geojson",
+        source_filename="test.geojson",
+    )
+    session.add(dataset)
+    await session.flush()
+    await session.commit()
+    await session.refresh(dataset)
+    return dataset
+
+
+async def _enable_semantic_search(session) -> None:
+    existing = (
+        await session.execute(
+            select(AppSetting).where(AppSetting.key == "semantic_search_enabled")
+        )
+    ).scalar_one_or_none()
+    if existing is None:
+        session.add(AppSetting(key="semantic_search_enabled", value={"v": True}))
+    else:
+        existing.value = {"v": True}
+    await session.commit()
+
+    from app.platform.cache import get_cache
+
+    try:
+        await get_cache().delete("config:semantic_search_enabled")
+    except RuntimeError:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# The fingerprint itself
+# ---------------------------------------------------------------------------
+
+
+def test_the_fingerprint_separates_every_component_of_the_vector_space():
+    """Model, width and endpoint each move it, and it is stable across calls."""
+    base = embedding_config_fingerprint("model-a", 1536, "https://a.invalid/v1")
+
+    assert base == embedding_config_fingerprint("model-a", 1536, "https://a.invalid/v1")
+    assert base != embedding_config_fingerprint("model-b", 1536, "https://a.invalid/v1")
+    assert base != embedding_config_fingerprint("model-a", 768, "https://a.invalid/v1")
+    # The endpoint alone. This is the pair `model_name` cannot distinguish and
+    # the reason the column exists.
+    assert base != embedding_config_fingerprint("model-a", 1536, "https://b.invalid/v1")
+
+
+def test_an_unset_endpoint_is_not_the_string_none_and_not_empty():
+    """`None` is a resolved value the provider interface permits (see #1525).
+
+    A delimiter join would collapse it into `"None"` or `""`, so a provider
+    answering "use the client default" would share an identity with one pointed
+    at a host literally named that. JSON keeps the three apart.
+    """
+    stamps = {
+        embedding_config_fingerprint("m", 1536, None),
+        embedding_config_fingerprint("m", 1536, "None"),
+        embedding_config_fingerprint("m", 1536, ""),
+    }
+    assert len(stamps) == 3
+
+
+def test_a_component_boundary_cannot_be_forged_from_inside_a_value():
+    """("a|b", None) must not collide with ("a", "b")-style neighbours."""
+    assert embedding_config_fingerprint('a","b', 1536, None) != (
+        embedding_config_fingerprint("a", 1536, "b")
+    )
+
+
+@pytest.mark.anyio
+async def test_an_unresolvable_configuration_answers_with_a_sentinel(test_db_session):
+    """A reader must degrade, not raise, and must match no STAMPED row.
+
+    The endpoint resolves through the provider extension, which raises whenever
+    the database endpoint diverges from the operator-approved environment URL.
+    Search consults this only to be careful; turning that into a 500 would take
+    search down over it.
+    """
+    with patch.object(
+        service_module,
+        "get_embedding_provider",
+        side_effect=RuntimeError("provider is unreachable"),
+    ):
+        answer = await resolve_embedding_config_fingerprint(test_db_session)
+
+    assert answer == helpers.UNKNOWN_EMBEDDING_CONFIG
+    # Not a hex digest, so it can never equal a real fingerprint.
+    assert answer != embedding_config_fingerprint(_MODEL, _DIMS, None)
+
+
+# ---------------------------------------------------------------------------
+# Semantic search
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_semantic_search_excludes_a_row_from_a_foreign_configuration(
+    client: AsyncClient,
+    admin_auth_header: dict,
+    test_db_session,
+):
+    """The defect: one model, two endpoints, one label, cross-space matches.
+
+    Both rows carry the ACTIVE model name and near-identical vectors. One was
+    written under the live configuration and one under another endpoint's. Only
+    the first is comparable against a query vector the live configuration
+    produced; the second is a different space and its cosine distance means
+    nothing.
+    """
+    session = test_db_session
+    await _enable_semantic_search(session)
+    user_id = await get_user_id(session, "admin")
+    model_name = await EMBEDDING_MODEL.get(session)
+    live, foreign = await _live_and_foreign(session, model_name=model_name)
+
+    # Titles share no lexical content with the query below, so anything that
+    # comes back came back through the vector arm.
+    kept = await _create_dataset(session, created_by=user_id, name="Zqx Stamp Kept")
+    dropped = await _create_dataset(
+        session, created_by=user_id, name="Zqx Stamp Dropped"
+    )
+    await _add_embedding(
+        session,
+        kept.record_id,
+        model_name=model_name,
+        config_fingerprint=live,
+        vector=_vector_band(1.0),
+    )
+    await _add_embedding(
+        session,
+        dropped.record_id,
+        model_name=model_name,
+        config_fingerprint=foreign,
+        vector=_vector_band(0.98),
+    )
+
+    with patch(
+        "app.modules.catalog.search.service_semantic.generate_embedding",
+        new_callable=AsyncMock,
+        return_value=_vector_band(1.0),
+    ):
+        response = await client.get(
+            "/search/datasets/",
+            params={"q": "unrelated lexical query text"},
+            headers=admin_auth_header,
+        )
+
+    assert response.status_code == 200
+    titles = [f["properties"]["title"] for f in response.json()["features"]]
+    # Non-vacuity: the vector arm ran and returned the row it should.
+    assert "Zqx Stamp Kept" in titles
+    assert "Zqx Stamp Dropped" not in titles
+
+
+@pytest.mark.anyio
+async def test_the_match_total_excludes_a_foreign_configuration_too(
+    client: AsyncClient,
+    admin_auth_header: dict,
+    test_db_session,
+):
+    """numberMatched is a second, independently written filter over the table.
+
+    `_run_rrf_merge` counts vector-only matches with its own query rather than
+    from the ranks, so a fix applied to the ranking predicate alone would report
+    a total that counts rows no page can ever show — a `next` link onto an
+    empty page.
+    """
+    session = test_db_session
+    await _enable_semantic_search(session)
+    user_id = await get_user_id(session, "admin")
+    model_name = await EMBEDDING_MODEL.get(session)
+    live, foreign = await _live_and_foreign(session, model_name=model_name)
+
+    for index, fingerprint in ((0, live), (1, foreign), (2, foreign)):
+        dataset = await _create_dataset(
+            session, created_by=user_id, name=f"Zqy Stamp Total {index}"
+        )
+        await _add_embedding(
+            session,
+            dataset.record_id,
+            model_name=model_name,
+            config_fingerprint=fingerprint,
+            vector=_vector_band(1.0 - index * 0.01, lo=920),
+        )
+
+    with patch(
+        "app.modules.catalog.search.service_semantic.generate_embedding",
+        new_callable=AsyncMock,
+        return_value=_vector_band(1.0, lo=920),
+    ):
+        response = await client.get(
+            "/search/datasets/",
+            params={"q": "unrelated lexical query text"},
+            headers=admin_auth_header,
+        )
+
+    assert response.status_code == 200
+    body = response.json()
+    titles = [f["properties"]["title"] for f in body["features"]]
+    assert "Zqy Stamp Total 0" in titles
+    assert body["numberMatched"] == 1
+
+
+@pytest.mark.anyio
+async def test_a_legacy_unstamped_row_stays_searchable_after_upgrade(
+    client: AsyncClient,
+    admin_auth_header: dict,
+    test_db_session,
+):
+    """The upgrade guarantee: day one after migrating, search still works.
+
+    Every row already in the table has no stamp, and what configuration
+    produced it is not recoverable. Filtering them out would empty semantic
+    search until a full regenerate finished; stamping them with today's
+    configuration in the migration would invent provenance. They are
+    grandfathered instead, on model name alone.
+
+    Counterfactual: drop the `config_fingerprint IS NULL` arm of
+    `RecordEmbedding.usable_by_config` and this fails while every other test in
+    this file still passes.
+    """
+    session = test_db_session
+    await _enable_semantic_search(session)
+    user_id = await get_user_id(session, "admin")
+    model_name = await EMBEDDING_MODEL.get(session)
+
+    legacy = await _create_dataset(session, created_by=user_id, name="Zqz Stamp Legacy")
+    await _add_embedding(
+        session,
+        legacy.record_id,
+        model_name=model_name,
+        config_fingerprint=None,
+        vector=_vector_band(1.0, lo=940),
+    )
+
+    with patch(
+        "app.modules.catalog.search.service_semantic.generate_embedding",
+        new_callable=AsyncMock,
+        return_value=_vector_band(1.0, lo=940),
+    ):
+        response = await client.get(
+            "/search/datasets/",
+            params={"q": "unrelated lexical query text"},
+            headers=admin_auth_header,
+        )
+
+    assert response.status_code == 200
+    titles = [f["properties"]["title"] for f in response.json()["features"]]
+    assert "Zqz Stamp Legacy" in titles
+
+
+# ---------------------------------------------------------------------------
+# The non-force backfill's "already covered" decision
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_a_foreign_stamped_row_does_not_count_as_coverage(test_db_session):
+    """Generate Missing has to see what search cannot use.
+
+    Leaving the stamp out of this predicate relocates #1546 into the skip
+    decision: the panel reports the catalog covered, Generate Missing does
+    nothing, and the vector arm matches none of it.
+    """
+    session = test_db_session
+    user_id = await get_user_id(session, "admin")
+    model_name = await EMBEDDING_MODEL.get(session)
+    live, foreign = await _live_and_foreign(session, model_name=model_name)
+
+    covered = await create_dataset(
+        session, created_by=user_id, name="Stamp Scope Covered"
+    )
+    stale = await create_dataset(session, created_by=user_id, name="Stamp Scope Stale")
+    await _add_embedding(
+        session, covered.record_id, model_name=model_name, config_fingerprint=live
+    )
+    await _add_embedding(
+        session, stale.record_id, model_name=model_name, config_fingerprint=foreign
+    )
+
+    missing = {
+        record.id
+        for record in await DefaultProcessingPort().get_records_without_embeddings(
+            session, force=False
+        )
+    }
+
+    assert stale.record_id in missing
+    # Non-vacuity: the predicate did not simply select everything.
+    assert covered.record_id not in missing
+
+
+@pytest.mark.anyio
+async def test_a_legacy_unstamped_row_is_not_offered_for_re_embedding(test_db_session):
+    """Upgrading must not queue a catalog-wide re-embed nobody asked to pay for.
+
+    An unstamped row is what every instance has on the morning after the
+    migration. Treating it as missing would make the next Generate Missing bill
+    the operator for the whole catalog at provider rates.
+
+    Counterfactual: same as the search test — remove the NULL arm from
+    `usable_by_config` and this record reads as missing.
+    """
+    session = test_db_session
+    user_id = await get_user_id(session, "admin")
+    model_name = await EMBEDDING_MODEL.get(session)
+
+    legacy = await create_dataset(
+        session, created_by=user_id, name="Stamp Scope Legacy"
+    )
+    await _add_embedding(
+        session, legacy.record_id, model_name=model_name, config_fingerprint=None
+    )
+
+    missing = {
+        record.id
+        for record in await DefaultProcessingPort().get_records_without_embeddings(
+            session, force=False
+        )
+    }
+    assert legacy.record_id not in missing
+
+
+@pytest.mark.anyio
+async def test_an_unresolvable_configuration_selects_nothing(
+    test_db_session, monkeypatch
+):
+    """Fail closed, one value out from the unresolvable-model branch (#1506).
+
+    Every stamped row reads as foreign when the configuration cannot be
+    resolved, so the alternative is handing the whole catalog to a run whose
+    provider call is the thing that cannot be resolved: every record embedded
+    at provider cost, every insert failing.
+    """
+    session = test_db_session
+    user_id = await get_user_id(session, "admin")
+    await create_dataset(session, created_by=user_id, name="Stamp Scope Unresolvable")
+
+    async def _unresolvable(_session, *, model_name=None):
+        return helpers.UNKNOWN_EMBEDDING_CONFIG
+
+    monkeypatch.setattr(helpers, "resolve_embedding_config_fingerprint", _unresolvable)
+    records = await DefaultProcessingPort().get_records_without_embeddings(
+        session, force=False
+    )
+    assert records == []
+
+
+@pytest.mark.anyio
+async def test_re_embedding_a_foreign_stamped_row_replaces_it(
+    test_db_session,
+    restore_embedding_config,
+    monkeypatch,
+):
+    """The row is keyed (record_id, model_name), so the replacement is an UPDATE.
+
+    Once a foreign-stamped row is offered as missing, a plain INSERT answers it
+    with a unique violation instead of a vector — the bug the ON CONFLICT DO
+    UPDATE closes. Afterwards the record holds ONE row for the model, stamped
+    with the configuration the run pinned.
+    """
+    session = test_db_session
+    user_id = await get_user_id(session, "admin")
+    await EMBEDDING_MODEL.set(session, _MODEL)
+    await EMBEDDING_DIMS.set(session, _DIMS)
+    live, foreign = await _live_and_foreign(session, model_name=_MODEL)
+
+    dataset = await create_dataset(session, created_by=user_id, name="Stamp Replace DS")
+    await _add_embedding(
+        session, dataset.record_id, model_name=_MODEL, config_fingerprint=foreign
+    )
+
+    async def _fake_batch(texts, _session, *, model, dimensions, base_url):
+        return [[1.0] + [0.0] * (_DIMS - 1) for _ in texts]
+
+    monkeypatch.setattr(backfill_module, "generate_embeddings_batch", _fake_batch)
+    monkeypatch.setattr(
+        service_module, "settings", SimpleNamespace(openai_api_key="stamp-test-key")
+    )
+
+    await backfill_module.backfill_embeddings(session, force=False)
+
+    rows = (
+        (
+            await session.execute(
+                select(RecordEmbedding.config_fingerprint).where(
+                    RecordEmbedding.record_id == dataset.record_id,
+                    RecordEmbedding.model_name == _MODEL,
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert rows == [live]
+
+
+@pytest.mark.anyio
+async def test_the_stamp_comes_from_the_pin_not_from_a_read_at_write_time(
+    test_db_session,
+    restore_embedding_config,
+    monkeypatch,
+):
+    """The endpoint half has to be the one the vector was actually made against.
+
+    A run pins (model, width, endpoint) and hands that triple to every provider
+    call. Stamping from a fresh read at write time would name whatever the
+    configuration says by then, which is provenance the run did not observe.
+
+    The state that separates the two is real and is #1551's residue: an
+    endpoint edit that makes the provider's resolve RAISE. `_pinned_config_drift`
+    deliberately does not treat that as drift — for the shipped provider it is
+    what an endpoint diverging from the operator-approved environment URL looks
+    like, and it says nothing about where vectors are going — so the run carries
+    on, correctly, under the pin. A writer that re-read would get the
+    unresolvable-configuration sentinel and stamp rows nothing can ever match.
+    """
+    session = test_db_session
+    user_id = await get_user_id(session, "admin")
+    await EMBEDDING_MODEL.set(session, _MODEL)
+    await EMBEDDING_DIMS.set(session, _DIMS)
+    dataset = await create_dataset(session, created_by=user_id, name="Stamp Pin DS")
+    pinned_url = await resolve_embedding_base_url(session)
+
+    class _EndpointBreaksMidRun:
+        """Resolves normally until the pin is taken, then refuses.
+
+        Three resolutions precede the batch loop on the non-force path: one for
+        the selection's fingerprint, then the snapshot's capture and its
+        re-read. From the fourth on, the endpoint no longer resolves.
+        """
+
+        def __init__(self):
+            self.resolves = 0
+
+        async def resolve_runtime_config(self, _session):
+            self.resolves += 1
+            if self.resolves > 3:
+                raise RuntimeError("endpoint no longer resolves")
+            return {
+                "default_model": _MODEL,
+                "default_dims": _DIMS,
+                "base_url": pinned_url,
+            }
+
+        async def embed(self, *, texts, model, dimensions, base_url, timeout):
+            return [[1.0] + [0.0] * (_DIMS - 1) for _ in texts]
+
+    provider = _EndpointBreaksMidRun()
+    monkeypatch.setattr(
+        service_module, "get_embedding_provider", lambda _name: provider
+    )
+    monkeypatch.setattr(
+        service_module, "settings", SimpleNamespace(openai_api_key="stamp-test-key")
+    )
+
+    result = await backfill_module.backfill_embeddings(session, force=False)
+
+    # Non-vacuity: the run reached the batch loop and the endpoint really did
+    # stop resolving before the rows were written.
+    assert result["created"] > 0
+    assert provider.resolves > 3
+    assert (
+        await resolve_embedding_config_fingerprint(session, model_name=_MODEL)
+        == helpers.UNKNOWN_EMBEDDING_CONFIG
+    )
+
+    stamp = (
+        await session.execute(
+            select(RecordEmbedding.config_fingerprint).where(
+                RecordEmbedding.record_id == dataset.record_id,
+                RecordEmbedding.model_name == _MODEL,
+            )
+        )
+    ).scalar_one()
+    assert stamp == embedding_config_fingerprint(_MODEL, _DIMS, pinned_url)
+
+
+# ---------------------------------------------------------------------------
+# Admin coverage stats
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_coverage_counts_only_rows_the_live_configuration_can_use(
+    test_db_session,
+):
+    """A coverage bar over vectors the vector arm skips is #1503 all over again."""
+    session = test_db_session
+    service = AdminService(session)
+    baseline = await service.get_embedding_stats()
+
+    user_id = await get_user_id(session, "admin")
+    model_name = await EMBEDDING_MODEL.get(session)
+    live, foreign = await _live_and_foreign(session, model_name=model_name)
+
+    covered = await create_dataset(
+        session, created_by=user_id, name="Stamp Stats Covered"
+    )
+    stale = await create_dataset(session, created_by=user_id, name="Stamp Stats Stale")
+    await _add_embedding(
+        session, covered.record_id, model_name=model_name, config_fingerprint=live
+    )
+    await _add_embedding(
+        session, stale.record_id, model_name=model_name, config_fingerprint=foreign
+    )
+
+    after = await service.get_embedding_stats()
+    assert after.total_records == baseline.total_records + 2
+    # Only the live-configuration row counts as covered.
+    assert after.embedded_records == baseline.embedded_records + 1
+    assert after.missing_records == baseline.missing_records + 1
+    # And the foreign one is visible as stale rather than absent, which is what
+    # tells an operator to run Generate Missing.
+    assert after.stale_records == baseline.stale_records + 1
+
+
+@pytest.mark.anyio
+async def test_coverage_agrees_with_what_search_can_retrieve(test_db_session):
+    """Two spellings of one rule, pinned against each other.
+
+    `AdminService.get_embedding_stats` writes the condition as raw SQL while
+    semantic search and the backfill selection apply
+    `RecordEmbedding.usable_by_config`. Drift between them is the exact class of
+    bug this PR is about, so it is not left to inspection: every combination of
+    model and stamp goes in, and the count the panel reports has to equal the
+    number of rows the ORM predicate selects.
+    """
+    session = test_db_session
+    user_id = await get_user_id(session, "admin")
+    model_name = await EMBEDDING_MODEL.get(session)
+    live, foreign = await _live_and_foreign(session, model_name=model_name)
+
+    combinations = [
+        (model_name, live),
+        (model_name, foreign),
+        (model_name, None),
+        ("stamp-1546-other-model", live),
+        ("stamp-1546-other-model", foreign),
+        ("stamp-1546-other-model", None),
+    ]
+    for index, (row_model, fingerprint) in enumerate(combinations):
+        dataset = await create_dataset(
+            session, created_by=user_id, name=f"Stamp Agreement {index}"
+        )
+        await _add_embedding(
+            session,
+            dataset.record_id,
+            model_name=row_model,
+            config_fingerprint=fingerprint,
+        )
+
+    panel_count = (
+        await session.execute(
+            text(
+                "SELECT COUNT(DISTINCT visible_record.id) "
+                "FILTER (WHERE embedding.model_name = :model_name "
+                "AND (embedding.config_fingerprint IS NULL "
+                "OR embedding.config_fingerprint = :config_fingerprint)) "
+                "FROM catalog.records AS visible_record "
+                "LEFT JOIN catalog.record_embeddings AS embedding "
+                "ON embedding.record_id = visible_record.id"
+            ),
+            {"model_name": model_name, "config_fingerprint": live},
+        )
+    ).scalar_one()
+
+    orm_count = (
+        await session.execute(
+            select(func.count(func.distinct(RecordEmbedding.record_id)))
+            .select_from(RecordEmbedding)
+            .join(Record, RecordEmbedding.record_id == Record.id)
+            .where(RecordEmbedding.usable_by_config(model_name, live))
+        )
+    ).scalar_one()
+
+    assert panel_count == orm_count
+    # Non-vacuity: the fixture really did contain rows the rule has to reject.
+    total_rows = (
+        await session.execute(select(func.count()).select_from(RecordEmbedding))
+    ).scalar_one()
+    assert total_rows > orm_count

--- a/backend/tests/test_embedding_config_stamp_1546.py
+++ b/backend/tests/test_embedding_config_stamp_1546.py
@@ -33,6 +33,7 @@ from app.core.db.models import AppSetting
 from app.core.persistent_config import EMBEDDING_DIMS, EMBEDDING_MODEL
 from app.modules.admin.service import AdminService
 from app.modules.catalog.datasets.domain.models import Dataset, Record
+from app.platform.extensions.defaults_catalog_port import DefaultCatalogPort
 from app.platform.extensions.defaults_processing_port import DefaultProcessingPort
 from app.processing.embeddings import backfill as backfill_module
 from app.processing.embeddings import helpers
@@ -353,6 +354,57 @@ async def test_the_match_total_excludes_a_foreign_configuration_too(
     titles = [f["properties"]["title"] for f in body["features"]]
     assert "Zqy Stamp Total 0" in titles
     assert body["numberMatched"] == 1
+
+
+@pytest.mark.anyio
+async def test_a_configuration_read_that_raises_degrades_to_fts(
+    client: AsyncClient,
+    admin_auth_header: dict,
+    test_db_session,
+):
+    """fix(#1546 review r1, codex P2): resolving is inside the fallback guard.
+
+    The vector arm has always degraded to FTS on any failure rather than taking
+    the search request down with it, and resolving the configuration is a
+    persistent-config read that can raise on a cache miss or a transient
+    database failure. Model resolution used to happen inside
+    `generate_embedding`, under that guard; hoisting it to the top of
+    `_get_vector_ranks` silently made the same failure fatal.
+
+    The query below matches a record lexically, so FTS has something to return
+    and "degraded" is distinguishable from "returned nothing".
+    """
+    session = test_db_session
+    await _enable_semantic_search(session)
+    user_id = await get_user_id(session, "admin")
+    model_name = await EMBEDDING_MODEL.get(session)
+
+    dataset = await _create_dataset(
+        session, created_by=user_id, name="Zqw Stamp Resolver Raises"
+    )
+    await _add_embedding(
+        session,
+        dataset.record_id,
+        model_name=model_name,
+        config_fingerprint=None,
+        vector=_vector_band(1.0, lo=960),
+    )
+
+    async def _raises(_session):
+        raise RuntimeError("persistent config is unavailable")
+
+    with patch.object(
+        DefaultCatalogPort, "resolve_embedding_config", side_effect=_raises
+    ):
+        response = await client.get(
+            "/search/datasets/",
+            params={"q": "Zqw Stamp Resolver Raises"},
+            headers=admin_auth_header,
+        )
+
+    assert response.status_code == 200
+    titles = [f["properties"]["title"] for f in response.json()["features"]]
+    assert "Zqw Stamp Resolver Raises" in titles
 
 
 @pytest.mark.anyio

--- a/backend/tests/test_embedding_pipeline.py
+++ b/backend/tests/test_embedding_pipeline.py
@@ -13,6 +13,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.processing.embeddings.helpers import embedding_config_fingerprint
+
 
 # ---------------------------------------------------------------------------
 # build_content_text
@@ -159,6 +161,11 @@ class TestGenerateAndStoreEmbedding:
 
         mock_existing = MagicMock()
         mock_existing.content_hash = expected_hash
+        # fix(#1546): an UNSTAMPED row. Semantic search still matches it on
+        # model name alone, so unchanged content is still a skip and the
+        # configuration is never resolved — which is what the assertion on
+        # resolve_embedding_base_url below pins.
+        mock_existing.config_fingerprint = None
 
         mock_result = MagicMock()
         mock_result.scalar_one_or_none.return_value = mock_existing
@@ -169,6 +176,10 @@ class TestGenerateAndStoreEmbedding:
         with (
             patch("app.processing.embeddings.service.AI_ENABLED") as mock_ai,
             patch("app.processing.embeddings.service.EMBEDDING_MODEL") as mock_model,
+            patch(
+                "app.processing.embeddings.service.resolve_embedding_base_url",
+                new_callable=AsyncMock,
+            ) as mock_base_url,
         ):
             mock_ai.get = AsyncMock(return_value=True)
             mock_model.get = AsyncMock(return_value="text-embedding-3-small")
@@ -182,6 +193,7 @@ class TestGenerateAndStoreEmbedding:
                 lineage=None,
             )
             assert result is False
+            mock_base_url.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_upserts_on_success(self):
@@ -201,13 +213,21 @@ class TestGenerateAndStoreEmbedding:
             patch("app.processing.embeddings.service.AI_ENABLED") as mock_ai,
             patch("app.processing.embeddings.service.EMBEDDING_MODEL") as mock_model,
             patch(
-                "app.processing.embeddings.service.generate_embedding",
+                "app.processing.embeddings.service.generate_embeddings_batch",
                 new_callable=AsyncMock,
             ) as mock_gen,
+            patch(
+                "app.processing.embeddings.service.resolve_embedding_base_url",
+                new_callable=AsyncMock,
+                return_value="https://api.openai.com/v1",
+            ),
         ):
             mock_ai.get = AsyncMock(return_value=True)
             mock_model.get = AsyncMock(return_value="text-embedding-3-small")
-            mock_gen.return_value = fake_vector
+            # fix(#1546): this caller labels its own rows, so it now pins the
+            # configuration and calls the batch entry point directly rather
+            # than letting the provider re-read the config for itself.
+            mock_gen.return_value = [fake_vector]
 
             await generate_and_store_embedding(
                 session=session,
@@ -223,6 +243,14 @@ class TestGenerateAndStoreEmbedding:
             assert isinstance(added_obj, RecordEmbedding)
             assert added_obj.record_id == record_id
             assert added_obj.model_name == "text-embedding-3-small"
+            # fix(#1546): the row names the configuration it was pinned to, not
+            # just the model. `EMBEDDING_DIMS` is unpatched here, so the width
+            # comes from config the same way the production path reads it.
+            assert added_obj.config_fingerprint == embedding_config_fingerprint(
+                mock_gen.call_args.kwargs["model"],
+                mock_gen.call_args.kwargs["dimensions"],
+                mock_gen.call_args.kwargs["base_url"],
+            )
             session.flush.assert_called_once()
 
     @pytest.mark.asyncio
@@ -245,13 +273,21 @@ class TestGenerateAndStoreEmbedding:
             patch("app.processing.embeddings.service.AI_ENABLED") as mock_ai,
             patch("app.processing.embeddings.service.EMBEDDING_MODEL") as mock_model,
             patch(
-                "app.processing.embeddings.service.generate_embedding",
+                "app.processing.embeddings.service.generate_embeddings_batch",
                 new_callable=AsyncMock,
             ) as mock_gen,
+            patch(
+                "app.processing.embeddings.service.resolve_embedding_base_url",
+                new_callable=AsyncMock,
+                return_value="https://api.openai.com/v1",
+            ),
         ):
             mock_ai.get = AsyncMock(return_value=True)
             mock_model.get = AsyncMock(return_value="text-embedding-3-small")
-            mock_gen.return_value = fake_vector
+            # fix(#1546): this caller labels its own rows, so it now pins the
+            # configuration and calls the batch entry point directly rather
+            # than letting the provider re-read the config for itself.
+            mock_gen.return_value = [fake_vector]
 
             await generate_and_store_embedding(
                 session=session,
@@ -263,7 +299,72 @@ class TestGenerateAndStoreEmbedding:
             )
             session.add.assert_not_called()
             assert mock_existing.embedding == fake_vector
+            # fix(#1546): the row is keyed (record_id, model_name), so a
+            # configuration change that keeps the model lands on this UPDATE
+            # branch. Leaving the old stamp would label the new vector with the
+            # configuration of the one it replaced.
+            assert mock_existing.config_fingerprint == embedding_config_fingerprint(
+                mock_gen.call_args.kwargs["model"],
+                mock_gen.call_args.kwargs["dimensions"],
+                mock_gen.call_args.kwargs["base_url"],
+            )
             session.flush.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_unchanged_content_still_re_embeds_a_foreign_stamped_row(self):
+        """fix(#1546): the content hash is no longer the whole skip decision.
+
+        A row stamped by another configuration is invisible to semantic search,
+        so leaving it in place because the text has not changed would report
+        coverage the search cannot use. That is the same relocation of the bug
+        the backfill's selection predicate had to close, one writer over.
+        """
+        from app.processing.embeddings.service import generate_and_store_embedding
+
+        record_id = uuid.uuid4()
+        content_text = "Test Title"
+        fake_vector = [0.3] * 1536
+
+        mock_existing = MagicMock()
+        mock_existing.content_hash = hashlib.sha256(content_text.encode()).hexdigest()
+        mock_existing.config_fingerprint = "written-against-another-endpoint"
+
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = mock_existing
+
+        session = AsyncMock(spec=AsyncSession)
+        session.execute = AsyncMock(return_value=mock_result)
+
+        with (
+            patch("app.processing.embeddings.service.AI_ENABLED") as mock_ai,
+            patch("app.processing.embeddings.service.EMBEDDING_MODEL") as mock_model,
+            patch(
+                "app.processing.embeddings.service.generate_embeddings_batch",
+                new_callable=AsyncMock,
+            ) as mock_gen,
+            patch(
+                "app.processing.embeddings.service.resolve_embedding_base_url",
+                new_callable=AsyncMock,
+                return_value="https://api.openai.com/v1",
+            ),
+        ):
+            mock_ai.get = AsyncMock(return_value=True)
+            mock_model.get = AsyncMock(return_value="text-embedding-3-small")
+            mock_gen.return_value = [fake_vector]
+
+            result = await generate_and_store_embedding(
+                session=session,
+                record_id=record_id,
+                title="Test Title",
+                summary=None,
+                keywords=None,
+                lineage=None,
+            )
+
+        assert result is True
+        mock_gen.assert_awaited_once()
+        assert mock_existing.embedding == fake_vector
+        assert mock_existing.config_fingerprint != "written-against-another-endpoint"
 
     @pytest.mark.asyncio
     async def test_catches_embedding_unavailable_error(self):
@@ -284,9 +385,14 @@ class TestGenerateAndStoreEmbedding:
             patch("app.processing.embeddings.service.AI_ENABLED") as mock_ai,
             patch("app.processing.embeddings.service.EMBEDDING_MODEL") as mock_model,
             patch(
-                "app.processing.embeddings.service.generate_embedding",
+                "app.processing.embeddings.service.generate_embeddings_batch",
                 new_callable=AsyncMock,
             ) as mock_gen,
+            patch(
+                "app.processing.embeddings.service.resolve_embedding_base_url",
+                new_callable=AsyncMock,
+                return_value="https://api.openai.com/v1",
+            ),
         ):
             mock_ai.get = AsyncMock(return_value=True)
             mock_model.get = AsyncMock(return_value="text-embedding-3-small")
@@ -301,6 +407,7 @@ class TestGenerateAndStoreEmbedding:
                 lineage=None,
             )
             assert result is False
+            mock_gen.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_catches_generic_exception(self):
@@ -318,9 +425,14 @@ class TestGenerateAndStoreEmbedding:
             patch("app.processing.embeddings.service.AI_ENABLED") as mock_ai,
             patch("app.processing.embeddings.service.EMBEDDING_MODEL") as mock_model,
             patch(
-                "app.processing.embeddings.service.generate_embedding",
+                "app.processing.embeddings.service.generate_embeddings_batch",
                 new_callable=AsyncMock,
             ) as mock_gen,
+            patch(
+                "app.processing.embeddings.service.resolve_embedding_base_url",
+                new_callable=AsyncMock,
+                return_value="https://api.openai.com/v1",
+            ),
         ):
             mock_ai.get = AsyncMock(return_value=True)
             mock_model.get = AsyncMock(return_value="text-embedding-3-small")
@@ -335,3 +447,4 @@ class TestGenerateAndStoreEmbedding:
                 lineage=None,
             )
             assert result is False
+            mock_gen.assert_awaited_once()

--- a/backend/tests/test_embedding_pipeline.py
+++ b/backend/tests/test_embedding_pipeline.py
@@ -15,6 +15,17 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.processing.embeddings.helpers import embedding_config_fingerprint
 
+# fix(#1546 review r3, codex P2): `generate_and_store_embedding` resolves its
+# whole pin through ONE call now, so that call is the seam these unit tests
+# stub. Patching `EMBEDDING_MODEL` no longer reaches it, and patching the three
+# reads separately would rebuild in the test the very composition the fix
+# removed from the code.
+_MODEL = "text-embedding-3-small"
+_DIMS = 1536
+_URL = "https://api.openai.com/v1"
+_FINGERPRINT = embedding_config_fingerprint(_MODEL, _DIMS, _URL)
+_RESOLVED = (_MODEL, _DIMS, _URL, _FINGERPRINT)
+
 
 # ---------------------------------------------------------------------------
 # build_content_text
@@ -162,9 +173,7 @@ class TestGenerateAndStoreEmbedding:
         mock_existing = MagicMock()
         mock_existing.content_hash = expected_hash
         # fix(#1546): an UNSTAMPED row. Semantic search still matches it on
-        # model name alone, so unchanged content is still a skip and the
-        # configuration is never resolved — which is what the assertion on
-        # resolve_embedding_base_url below pins.
+        # model name alone, so unchanged content is still a skip.
         mock_existing.config_fingerprint = None
 
         mock_result = MagicMock()
@@ -175,14 +184,13 @@ class TestGenerateAndStoreEmbedding:
 
         with (
             patch("app.processing.embeddings.service.AI_ENABLED") as mock_ai,
-            patch("app.processing.embeddings.service.EMBEDDING_MODEL") as mock_model,
             patch(
-                "app.processing.embeddings.service.resolve_embedding_base_url",
+                "app.processing.embeddings.service.resolve_live_embedding_config",
                 new_callable=AsyncMock,
-            ) as mock_base_url,
+                return_value=_RESOLVED,
+            ) as mock_resolve,
         ):
             mock_ai.get = AsyncMock(return_value=True)
-            mock_model.get = AsyncMock(return_value="text-embedding-3-small")
 
             result = await generate_and_store_embedding(
                 session=session,
@@ -193,7 +201,14 @@ class TestGenerateAndStoreEmbedding:
                 lineage=None,
             )
             assert result is False
-            mock_base_url.assert_not_called()
+            # fix(#1546 review r3, codex P2): the configuration IS resolved now,
+            # before the row lookup, because the model this call writes and the
+            # model it looks the row up by have to come from one verified read.
+            # An earlier revision skipped the resolution on this path to keep it
+            # cheap, and that shortcut is precisely what let the pin be composed
+            # from two instants. Asserted rather than left implicit, because
+            # "cheap" is the reason someone would reintroduce it.
+            mock_resolve.assert_awaited()
 
     @pytest.mark.asyncio
     async def test_upserts_on_success(self):
@@ -211,19 +226,17 @@ class TestGenerateAndStoreEmbedding:
 
         with (
             patch("app.processing.embeddings.service.AI_ENABLED") as mock_ai,
-            patch("app.processing.embeddings.service.EMBEDDING_MODEL") as mock_model,
             patch(
                 "app.processing.embeddings.service.generate_embeddings_batch",
                 new_callable=AsyncMock,
             ) as mock_gen,
             patch(
-                "app.processing.embeddings.service.resolve_embedding_base_url",
+                "app.processing.embeddings.service.resolve_live_embedding_config",
                 new_callable=AsyncMock,
-                return_value="https://api.openai.com/v1",
+                return_value=_RESOLVED,
             ),
         ):
             mock_ai.get = AsyncMock(return_value=True)
-            mock_model.get = AsyncMock(return_value="text-embedding-3-small")
             # fix(#1546): this caller labels its own rows, so it now pins the
             # configuration and calls the batch entry point directly rather
             # than letting the provider re-read the config for itself.
@@ -246,11 +259,12 @@ class TestGenerateAndStoreEmbedding:
             # fix(#1546): the row names the configuration it was pinned to, not
             # just the model. `EMBEDDING_DIMS` is unpatched here, so the width
             # comes from config the same way the production path reads it.
-            assert added_obj.config_fingerprint == embedding_config_fingerprint(
-                mock_gen.call_args.kwargs["model"],
-                mock_gen.call_args.kwargs["dimensions"],
-                mock_gen.call_args.kwargs["base_url"],
-            )
+            assert added_obj.config_fingerprint == _FINGERPRINT
+            # The row is stamped with the configuration the provider was given,
+            # which is the single resolved set and not a re-read.
+            assert mock_gen.call_args.kwargs["model"] == _MODEL
+            assert mock_gen.call_args.kwargs["dimensions"] == _DIMS
+            assert mock_gen.call_args.kwargs["base_url"] == _URL
             session.flush.assert_called_once()
 
     @pytest.mark.asyncio
@@ -271,19 +285,17 @@ class TestGenerateAndStoreEmbedding:
 
         with (
             patch("app.processing.embeddings.service.AI_ENABLED") as mock_ai,
-            patch("app.processing.embeddings.service.EMBEDDING_MODEL") as mock_model,
             patch(
                 "app.processing.embeddings.service.generate_embeddings_batch",
                 new_callable=AsyncMock,
             ) as mock_gen,
             patch(
-                "app.processing.embeddings.service.resolve_embedding_base_url",
+                "app.processing.embeddings.service.resolve_live_embedding_config",
                 new_callable=AsyncMock,
-                return_value="https://api.openai.com/v1",
+                return_value=_RESOLVED,
             ),
         ):
             mock_ai.get = AsyncMock(return_value=True)
-            mock_model.get = AsyncMock(return_value="text-embedding-3-small")
             # fix(#1546): this caller labels its own rows, so it now pins the
             # configuration and calls the batch entry point directly rather
             # than letting the provider re-read the config for itself.
@@ -303,11 +315,7 @@ class TestGenerateAndStoreEmbedding:
             # configuration change that keeps the model lands on this UPDATE
             # branch. Leaving the old stamp would label the new vector with the
             # configuration of the one it replaced.
-            assert mock_existing.config_fingerprint == embedding_config_fingerprint(
-                mock_gen.call_args.kwargs["model"],
-                mock_gen.call_args.kwargs["dimensions"],
-                mock_gen.call_args.kwargs["base_url"],
-            )
+            assert mock_existing.config_fingerprint == _FINGERPRINT
             session.flush.assert_called_once()
 
     @pytest.mark.asyncio
@@ -337,19 +345,17 @@ class TestGenerateAndStoreEmbedding:
 
         with (
             patch("app.processing.embeddings.service.AI_ENABLED") as mock_ai,
-            patch("app.processing.embeddings.service.EMBEDDING_MODEL") as mock_model,
             patch(
                 "app.processing.embeddings.service.generate_embeddings_batch",
                 new_callable=AsyncMock,
             ) as mock_gen,
             patch(
-                "app.processing.embeddings.service.resolve_embedding_base_url",
+                "app.processing.embeddings.service.resolve_live_embedding_config",
                 new_callable=AsyncMock,
-                return_value="https://api.openai.com/v1",
+                return_value=_RESOLVED,
             ),
         ):
             mock_ai.get = AsyncMock(return_value=True)
-            mock_model.get = AsyncMock(return_value="text-embedding-3-small")
             mock_gen.return_value = [fake_vector]
 
             result = await generate_and_store_embedding(
@@ -383,19 +389,17 @@ class TestGenerateAndStoreEmbedding:
 
         with (
             patch("app.processing.embeddings.service.AI_ENABLED") as mock_ai,
-            patch("app.processing.embeddings.service.EMBEDDING_MODEL") as mock_model,
             patch(
                 "app.processing.embeddings.service.generate_embeddings_batch",
                 new_callable=AsyncMock,
             ) as mock_gen,
             patch(
-                "app.processing.embeddings.service.resolve_embedding_base_url",
+                "app.processing.embeddings.service.resolve_live_embedding_config",
                 new_callable=AsyncMock,
-                return_value="https://api.openai.com/v1",
+                return_value=_RESOLVED,
             ),
         ):
             mock_ai.get = AsyncMock(return_value=True)
-            mock_model.get = AsyncMock(return_value="text-embedding-3-small")
             mock_gen.side_effect = EmbeddingUnavailableError("No API key")
 
             result = await generate_and_store_embedding(
@@ -423,19 +427,17 @@ class TestGenerateAndStoreEmbedding:
 
         with (
             patch("app.processing.embeddings.service.AI_ENABLED") as mock_ai,
-            patch("app.processing.embeddings.service.EMBEDDING_MODEL") as mock_model,
             patch(
                 "app.processing.embeddings.service.generate_embeddings_batch",
                 new_callable=AsyncMock,
             ) as mock_gen,
             patch(
-                "app.processing.embeddings.service.resolve_embedding_base_url",
+                "app.processing.embeddings.service.resolve_live_embedding_config",
                 new_callable=AsyncMock,
-                return_value="https://api.openai.com/v1",
+                return_value=_RESOLVED,
             ),
         ):
             mock_ai.get = AsyncMock(return_value=True)
-            mock_model.get = AsyncMock(return_value="text-embedding-3-small")
             mock_gen.side_effect = RuntimeError("Connection timeout")
 
             result = await generate_and_store_embedding(

--- a/backend/tests/test_embedding_tenant_isolation.py
+++ b/backend/tests/test_embedding_tenant_isolation.py
@@ -17,6 +17,7 @@ from app.modules.catalog.datasets.domain.models import Record
 from app.platform.extensions.defaults import DefaultProcessingPort
 from app.processing.embeddings import backfill as backfill_module
 from app.processing.embeddings import helpers
+from app.processing.embeddings import service as service_module
 from tests.fixtures.dummy_overlay.tenant_isolation import TenantIsolationSurface
 
 
@@ -222,6 +223,24 @@ async def test_embedding_reads_and_stats_are_tenant_local(
         helpers,
         "resolve_embedding_model_name",
         AsyncMock(return_value="tenant-isolation-model"),
+    )
+    # fix(#1546): the coverage query now scopes itself to the live embedding
+    # CONFIGURATION as well as the model, and resolving that reads the
+    # dimensions and the provider endpoint. These sessions run as
+    # geolens_reader, which is denied app_settings — the same precondition
+    # #1511 and #1525 had to supply for the force path one test down, and for
+    # the same reason: the denied read aborts the transaction, so the stats
+    # query behind it degrades to zeros and the isolation this test asserts is
+    # never reached. Supplied here so the real fingerprint resolution runs and
+    # the query under test is the real one. The seeded rows carry no stamp, so
+    # which endpoint this answers with does not change what they match.
+    monkeypatch.setattr(
+        backfill_module.EMBEDDING_DIMS, "get", AsyncMock(return_value=1536)
+    )
+    monkeypatch.setattr(
+        service_module,
+        "resolve_embedding_base_url",
+        AsyncMock(return_value=None),
     )
     helpers._has_embeddings_cache.clear()
 

--- a/backend/tests/test_extension_api_version.py
+++ b/backend/tests/test_extension_api_version.py
@@ -67,11 +67,22 @@ class TestExtensionApiVersionConstant:
         keeping a freed table name from reaching a successor that would inherit
         its predecessor's cached authorization.
 
+        v8 carries TWO ``CatalogPort`` changes (fix(#1546)). A required
+        ``resolve_embedding_config`` method: stored embeddings now record the
+        configuration that produced them, semantic search filters on it, and
+        ``modules/catalog/`` may not import ``app.processing.*``, so the answer
+        crosses the port on every hybrid search. And a widened
+        ``generate_embedding``, which takes a keyword-only ``pinned`` triple so
+        the query vector is produced under the very configuration its ranking
+        filters on; an overlay still implementing the two-argument signature
+        raises TypeError on the first semantic search. Both are required in the
+        convention's sense, and both land in one change, so they share a bump.
+
         Update this pin, and the note above it, whenever the constant moves.
         """
         from app.platform.extensions.version import EXTENSION_API_VERSION
 
-        assert EXTENSION_API_VERSION == 7
+        assert EXTENSION_API_VERSION == 8
 
 
 class TestCheckExtensionApiVersion:

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1687,8 +1687,16 @@ def test_decomposed_service_modules_stay_within_size_budgets() -> None:
         # with them — the memoized query vector is a third independent reader of
         # the configuration, and filtering rows by the live one while serving a
         # vector made under the previous one moves the bug rather than fixing
-        # it. Cap 395 -> 456, exact.
-        "backend/app/modules/catalog/search/service_semantic.py": 456,
+        # it. Cap 395 -> 456.
+        # fix(#1546 review r1, codex P1/P2): +26 — the resolved configuration is
+        # now handed to the PROVIDER as well as used for the filter and the
+        # cache key, so a settings change inside one request cannot produce the
+        # query vector under a configuration the rows are not ranked under; and
+        # the resolution moved inside the FTS fallback guard, where a raising
+        # persistent-config read degrades instead of failing the search. Most of
+        # the lines are the two rationales, including why verify-after-the-fact
+        # was rejected. Cap 456 -> 482, exact.
+        "backend/app/modules/catalog/search/service_semantic.py": 482,
         # fix(#430 V-14): _replace_layers now reconciles layers by id (update-in-place
         # + create/delete) instead of delete-all-then-recreate, so a PUT preserves
         # layer UUIDs. +~35 LOC over the 350 default. Cap → 400 (~34 headroom).
@@ -1874,8 +1882,14 @@ def test_decomposed_service_modules_stay_within_size_budgets() -> None:
         # semantic search needs to tell a stored vector from one made under
         # another endpoint. Same deferred-import shape as its neighbours;
         # `modules/catalog/` may not import `app.processing.*`, so it crosses
-        # here. Cap 450 -> 461, exact.
-        "backend/app/platform/extensions/defaults_catalog_port.py": 461,
+        # here. Cap 450 -> 461.
+        # fix(#1546 review r1, codex P1): +17 — the port answers the whole live
+        # configuration rather than its fingerprint alone, and generate_embedding
+        # takes a pinned triple. The comment carries why that is ONE optional
+        # argument and not three keyword ones: `None` is a legitimate resolved
+        # endpoint, so three None defaults could not tell "not pinned" from
+        # "pinned to the client default". Cap 461 -> 478, exact.
+        "backend/app/platform/extensions/defaults_catalog_port.py": 478,
         # feat(#683): +58 — run_analysis_preview carries a clip mask DATASET
         # now, which costs a widened signature (one param per line once ruff
         # wraps it) plus the mask's shape and size gates. Those live here on

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1677,7 +1677,18 @@ def test_decomposed_service_modules_stay_within_size_budgets() -> None:
         # fix(#625): +9 LOC — the _MIN_SEMANTIC_QUERY_LEN gate that drops
         # typeahead prefixes before they reach the provider, plus its rationale
         # comment. Cap 390 → 395, exact: the next addition needs its own review.
-        "backend/app/modules/catalog/search/service_semantic.py": 395,
+        # fix(#1546): +61 — stored rows now carry the identity of the
+        # configuration that produced them and the vector arm filters on it.
+        # Around fifteen lines are mechanism: `_live_embedding_identity`,
+        # resolving it once below the has_embeddings gate and handing it back
+        # out of `_get_vector_ranks` so the counts filter on what the ranks were
+        # taken under, the query-embedding cache key, and `usable_by_config` at
+        # the three filter sites. The rest is why the cache key had to change
+        # with them — the memoized query vector is a third independent reader of
+        # the configuration, and filtering rows by the live one while serving a
+        # vector made under the previous one moves the bug rather than fixing
+        # it. Cap 395 -> 456, exact.
+        "backend/app/modules/catalog/search/service_semantic.py": 456,
         # fix(#430 V-14): _replace_layers now reconciles layers by id (update-in-place
         # + create/delete) instead of delete-all-then-recreate, so a PUT preserves
         # layer UUIDs. +~35 LOC over the 350 default. Cap → 400 (~34 headroom).
@@ -1859,7 +1870,12 @@ def test_decomposed_service_modules_stay_within_size_budgets() -> None:
         # deferred-import shape as its sibling; a separate method rather than a
         # keyword because widening a port signature is an
         # EXTENSION_API_VERSION bump. Cap 445 -> 450.
-        "backend/app/platform/extensions/defaults_catalog_port.py": 450,
+        # fix(#1546): +11 — resolve_embedding_config_fingerprint, the answer
+        # semantic search needs to tell a stored vector from one made under
+        # another endpoint. Same deferred-import shape as its neighbours;
+        # `modules/catalog/` may not import `app.processing.*`, so it crosses
+        # here. Cap 450 -> 461, exact.
+        "backend/app/platform/extensions/defaults_catalog_port.py": 461,
         # feat(#683): +58 — run_analysis_preview carries a clip mask DATASET
         # now, which costs a widened signature (one param per line once ruff
         # wraps it) plus the mask's shape and size gates. Those live here on
@@ -1891,7 +1907,15 @@ def test_decomposed_service_modules_stay_within_size_budgets() -> None:
         # "missing" means "missing under THIS model", and why an unresolvable
         # model returns nothing here while the same sentinel is allowed to
         # read as zero coverage in admin's stats. Cap 499 -> 537, exact.
-        "backend/app/platform/extensions/defaults_processing_port.py": 537,
+        # fix(#1546): +27 — "missing" narrows once more, from "no vector this
+        # MODEL can use" to "no vector this CONFIGURATION can use", so a row
+        # written against another endpoint is picked up instead of reading as
+        # coverage the search cannot use. Six lines are the fingerprint
+        # resolution and its fail-closed branch; the rest records why an
+        # UNSTAMPED row still counts as covering the record, which is the only
+        # thing keeping an upgrade from turning the next Generate Missing into
+        # a catalog-wide re-embed. Cap 537 -> 564, exact.
+        "backend/app/platform/extensions/defaults_processing_port.py": 564,
         # fix(#929): +2 over the 350 default — the creator exemption on the
         # restricted branch of filter_visible/can_access_dataset plus its
         # rationale comments. fix(#930): +20 — the internal branch on the same

--- a/backend/tests/test_search_embedding_cache.py
+++ b/backend/tests/test_search_embedding_cache.py
@@ -33,12 +33,28 @@ def _mock_session_with_model(model_name: str = "text-embedding-3-small"):
     return session
 
 
+# fix(#1546): the cache key carries the configuration fingerprint alongside the
+# model name. These tests are about the OTHER key components, so they hold it
+# constant; `test_cache_partitioned_by_configuration` below is the one that
+# moves it.
+_FINGERPRINT = "cfg-fingerprint-a"
+
+
+def _mock_port(*, return_value=None, side_effect=None, fingerprint=_FINGERPRINT):
+    """CatalogPort double: the provider call plus the #1546 configuration read."""
+    port = MagicMock()
+    port.generate_embedding = AsyncMock(
+        return_value=return_value, side_effect=side_effect
+    )
+    port.resolve_embedding_config_fingerprint = AsyncMock(return_value=fingerprint)
+    return port
+
+
 @pytest.mark.asyncio
 async def test_generate_embedding_caches_result_on_second_call():
     """Second call with identical text + model should hit the cache."""
     fake_vector = [0.1] * 1536
-    mock_port = MagicMock()
-    mock_port.generate_embedding = AsyncMock(return_value=fake_vector)
+    mock_port = _mock_port(return_value=fake_vector)
     session = _mock_session_with_model()
 
     with (
@@ -62,8 +78,7 @@ async def test_generate_embedding_caches_result_on_second_call():
 async def test_cache_key_is_case_insensitive_and_strips_whitespace():
     """`(text.strip().lower(), model)` cache key collides on case + whitespace."""
     fake_vector = [0.2] * 1536
-    mock_port = MagicMock()
-    mock_port.generate_embedding = AsyncMock(return_value=fake_vector)
+    mock_port = _mock_port(return_value=fake_vector)
     session = _mock_session_with_model()
 
     with (
@@ -87,8 +102,7 @@ async def test_cache_partitioned_by_model_name():
     """Two different model names should NOT share cache entries."""
     fake_v1 = [0.3] * 1536
     fake_v2 = [0.4] * 1536
-    mock_port = MagicMock()
-    mock_port.generate_embedding = AsyncMock(side_effect=[fake_v1, fake_v2])
+    mock_port = _mock_port(side_effect=[fake_v1, fake_v2])
     session = _mock_session_with_model()
 
     with patch.object(service_semantic, "get_catalog_port", return_value=mock_port):
@@ -111,14 +125,56 @@ async def test_cache_partitioned_by_model_name():
 
 
 @pytest.mark.asyncio
+async def test_cache_partitioned_by_configuration():
+    """fix(#1546): one model name, two configurations, two cache entries.
+
+    The stored rows are filtered by the LIVE configuration. If this cache kept
+    serving a query vector generated under the previous one, the filter would
+    be selecting rows from configuration B and comparing them against a vector
+    made under configuration A — the cross-space comparison #1546 is about,
+    with the row filter looking entirely correct. The bug would have moved into
+    the cache rather than been fixed.
+    """
+    fake_a = [0.7] * 1536
+    fake_b = [0.8] * 1536
+    mock_port = _mock_port(side_effect=[fake_a, fake_b])
+    session = _mock_session_with_model()
+
+    with (
+        patch.object(service_semantic, "get_catalog_port", return_value=mock_port),
+        patch.object(
+            service_semantic.EMBEDDING_MODEL,
+            "get",
+            # Same model name throughout: the endpoint moved, not the model.
+            new=AsyncMock(return_value="text-embedding-3-small"),
+        ),
+    ):
+        mock_port.resolve_embedding_config_fingerprint = AsyncMock(
+            return_value="cfg-endpoint-a"
+        )
+        first = await service_semantic.generate_embedding("query", session)
+        repeat = await service_semantic.generate_embedding("query", session)
+
+        mock_port.resolve_embedding_config_fingerprint = AsyncMock(
+            return_value="cfg-endpoint-b"
+        )
+        after_change = await service_semantic.generate_embedding("query", session)
+
+    # The repeat under one configuration is still a cache hit — the partition
+    # must not be a blanket disable.
+    assert first == repeat == fake_a
+    assert after_change == fake_b
+    assert mock_port.generate_embedding.call_count == 2
+
+
+@pytest.mark.asyncio
 async def test_cache_partitioned_by_tenant(monkeypatch: pytest.MonkeyPatch):
     """The same provider/model label must not share vectors across tenants."""
     tenant_a = "00000000-0000-0000-0000-0000000000a1"
     tenant_b = "00000000-0000-0000-0000-0000000000b2"
     fake_a = [0.31] * 1536
     fake_b = [0.42] * 1536
-    mock_port = MagicMock()
-    mock_port.generate_embedding = AsyncMock(side_effect=[fake_a, fake_b])
+    mock_port = _mock_port(side_effect=[fake_a, fake_b])
     session = _mock_session_with_model()
     monkeypatch.setattr(settings, "geolens_tenancy_mode", "multi_tenant")
 
@@ -151,8 +207,7 @@ async def test_cache_expires_entries_after_ttl():
     """Entries older than the TTL must NOT be returned from cache."""
     fake_v1 = [0.5] * 1536
     fake_v2 = [0.6] * 1536
-    mock_port = MagicMock()
-    mock_port.generate_embedding = AsyncMock(side_effect=[fake_v1, fake_v2])
+    mock_port = _mock_port(side_effect=[fake_v1, fake_v2])
     session = _mock_session_with_model()
 
     with (
@@ -167,7 +222,7 @@ async def test_cache_expires_entries_after_ttl():
         await service_semantic.generate_embedding("expire me", session)
         # Manually expire by rewinding the cached entry's expires_at
         # to a past timestamp (more reliable than sleeping 300s).
-        key = ("expire me", "text-embedding-3-small")
+        key = ("expire me", "text-embedding-3-small", _FINGERPRINT)
         _, vector = service_semantic._embedding_cache[key]
         service_semantic._embedding_cache[key] = (time.monotonic() - 1, vector)
 
@@ -180,8 +235,7 @@ async def test_cache_expires_entries_after_ttl():
 @pytest.mark.asyncio
 async def test_empty_input_does_not_populate_cache():
     """Empty strings must bypass cache + delegate directly to provider."""
-    mock_port = MagicMock()
-    mock_port.generate_embedding = AsyncMock(side_effect=ValueError("empty"))
+    mock_port = _mock_port(side_effect=ValueError("empty"))
     session = _mock_session_with_model()
 
     with (
@@ -205,10 +259,7 @@ async def test_cache_evicts_oldest_when_over_max_size():
     original_max = service_semantic._EMBEDDING_CACHE_MAX_SIZE
     service_semantic._EMBEDDING_CACHE_MAX_SIZE = 3
     try:
-        mock_port = MagicMock()
-        mock_port.generate_embedding = AsyncMock(
-            side_effect=[[float(i)] for i in range(5)]
-        )
+        mock_port = _mock_port(side_effect=[[float(i)] for i in range(5)])
         session = _mock_session_with_model()
 
         with (
@@ -224,10 +275,10 @@ async def test_cache_evicts_oldest_when_over_max_size():
 
         # Only the 3 most-recently-inserted survive.
         assert len(service_semantic._embedding_cache) == 3
-        assert ("q0", "model") not in service_semantic._embedding_cache
-        assert ("q1", "model") not in service_semantic._embedding_cache
-        assert ("q2", "model") in service_semantic._embedding_cache
-        assert ("q3", "model") in service_semantic._embedding_cache
-        assert ("q4", "model") in service_semantic._embedding_cache
+        assert ("q0", "model", _FINGERPRINT) not in service_semantic._embedding_cache
+        assert ("q1", "model", _FINGERPRINT) not in service_semantic._embedding_cache
+        assert ("q2", "model", _FINGERPRINT) in service_semantic._embedding_cache
+        assert ("q3", "model", _FINGERPRINT) in service_semantic._embedding_cache
+        assert ("q4", "model", _FINGERPRINT) in service_semantic._embedding_cache
     finally:
         service_semantic._EMBEDDING_CACHE_MAX_SIZE = original_max

--- a/backend/tests/test_search_embedding_cache.py
+++ b/backend/tests/test_search_embedding_cache.py
@@ -40,13 +40,31 @@ def _mock_session_with_model(model_name: str = "text-embedding-3-small"):
 _FINGERPRINT = "cfg-fingerprint-a"
 
 
-def _mock_port(*, return_value=None, side_effect=None, fingerprint=_FINGERPRINT):
-    """CatalogPort double: the provider call plus the #1546 configuration read."""
+_MODEL = "text-embedding-3-small"
+_DIMS = 1536
+_BASE_URL = "https://api.openai.com/v1"
+
+
+def _mock_port(
+    *,
+    return_value=None,
+    side_effect=None,
+    fingerprint=_FINGERPRINT,
+    model=_MODEL,
+):
+    """CatalogPort double: the provider call plus the #1546 configuration read.
+
+    `resolve_embedding_config` answers the whole live configuration, which is
+    what lets the caller PIN the provider call to the same one it filters rows
+    on (#1546 review r1).
+    """
     port = MagicMock()
     port.generate_embedding = AsyncMock(
         return_value=return_value, side_effect=side_effect
     )
-    port.resolve_embedding_config_fingerprint = AsyncMock(return_value=fingerprint)
+    port.resolve_embedding_config = AsyncMock(
+        return_value=(model, _DIMS, _BASE_URL, fingerprint)
+    )
     return port
 
 
@@ -57,14 +75,7 @@ async def test_generate_embedding_caches_result_on_second_call():
     mock_port = _mock_port(return_value=fake_vector)
     session = _mock_session_with_model()
 
-    with (
-        patch.object(service_semantic, "get_catalog_port", return_value=mock_port),
-        patch.object(
-            service_semantic.EMBEDDING_MODEL,
-            "get",
-            new=AsyncMock(return_value="text-embedding-3-small"),
-        ),
-    ):
+    with patch.object(service_semantic, "get_catalog_port", return_value=mock_port):
         first = await service_semantic.generate_embedding("hello world", session)
         second = await service_semantic.generate_embedding("hello world", session)
 
@@ -81,14 +92,7 @@ async def test_cache_key_is_case_insensitive_and_strips_whitespace():
     mock_port = _mock_port(return_value=fake_vector)
     session = _mock_session_with_model()
 
-    with (
-        patch.object(service_semantic, "get_catalog_port", return_value=mock_port),
-        patch.object(
-            service_semantic.EMBEDDING_MODEL,
-            "get",
-            new=AsyncMock(return_value="text-embedding-3-small"),
-        ),
-    ):
+    with patch.object(service_semantic, "get_catalog_port", return_value=mock_port):
         await service_semantic.generate_embedding("Hello World", session)
         await service_semantic.generate_embedding("  hello world  ", session)
         await service_semantic.generate_embedding("HELLO WORLD", session)
@@ -106,18 +110,14 @@ async def test_cache_partitioned_by_model_name():
     session = _mock_session_with_model()
 
     with patch.object(service_semantic, "get_catalog_port", return_value=mock_port):
-        with patch.object(
-            service_semantic.EMBEDDING_MODEL,
-            "get",
-            new=AsyncMock(return_value="text-embedding-3-small"),
-        ):
-            r1 = await service_semantic.generate_embedding("query", session)
-        with patch.object(
-            service_semantic.EMBEDDING_MODEL,
-            "get",
-            new=AsyncMock(return_value="text-embedding-3-large"),
-        ):
-            r2 = await service_semantic.generate_embedding("query", session)
+        mock_port.resolve_embedding_config = AsyncMock(
+            return_value=("text-embedding-3-small", _DIMS, _BASE_URL, _FINGERPRINT)
+        )
+        r1 = await service_semantic.generate_embedding("query", session)
+        mock_port.resolve_embedding_config = AsyncMock(
+            return_value=("text-embedding-3-large", _DIMS, _BASE_URL, _FINGERPRINT)
+        )
+        r2 = await service_semantic.generate_embedding("query", session)
 
     assert r1 == fake_v1
     assert r2 == fake_v2
@@ -140,23 +140,16 @@ async def test_cache_partitioned_by_configuration():
     mock_port = _mock_port(side_effect=[fake_a, fake_b])
     session = _mock_session_with_model()
 
-    with (
-        patch.object(service_semantic, "get_catalog_port", return_value=mock_port),
-        patch.object(
-            service_semantic.EMBEDDING_MODEL,
-            "get",
-            # Same model name throughout: the endpoint moved, not the model.
-            new=AsyncMock(return_value="text-embedding-3-small"),
-        ),
-    ):
-        mock_port.resolve_embedding_config_fingerprint = AsyncMock(
-            return_value="cfg-endpoint-a"
+    # Same model name throughout: the endpoint moved, not the model.
+    with patch.object(service_semantic, "get_catalog_port", return_value=mock_port):
+        mock_port.resolve_embedding_config = AsyncMock(
+            return_value=(_MODEL, _DIMS, "https://endpoint-a.invalid/v1", "cfg-a")
         )
         first = await service_semantic.generate_embedding("query", session)
         repeat = await service_semantic.generate_embedding("query", session)
 
-        mock_port.resolve_embedding_config_fingerprint = AsyncMock(
-            return_value="cfg-endpoint-b"
+        mock_port.resolve_embedding_config = AsyncMock(
+            return_value=(_MODEL, _DIMS, "https://endpoint-b.invalid/v1", "cfg-b")
         )
         after_change = await service_semantic.generate_embedding("query", session)
 
@@ -165,6 +158,76 @@ async def test_cache_partitioned_by_configuration():
     assert first == repeat == fake_a
     assert after_change == fake_b
     assert mock_port.generate_embedding.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_the_provider_call_is_pinned_to_the_resolved_configuration():
+    """fix(#1546 review r1, codex P1): one read, used for all three purposes.
+
+    The configuration decides three things in a single search: which stored
+    rows are comparable, what the cache entry is keyed on, and which endpoint
+    produces the query vector. While the provider re-resolved the third for
+    itself, an admin change landing between the read and the call produced a
+    vector under configuration B, cached it under A, and ranked A-stamped rows
+    against it. That is the cross-space comparison the whole change exists to
+    prevent, reintroduced inside one request.
+
+    The edit lands from INSIDE the provider call, which is where a real one
+    spends its time; the same shape `test_embedding_backfill_base_url_pinning`
+    uses. What the provider was asked for has to be the configuration resolved
+    before it, not the one live by the time it ran.
+    """
+    session = _mock_session_with_model()
+    mock_port = _mock_port(return_value=[0.9] * 1536)
+    seen: list[tuple] = []
+
+    async def _generate(text, sess, *, pinned=None):
+        seen.append(pinned)
+        # The admin's edit lands here, mid-call.
+        mock_port.resolve_embedding_config = AsyncMock(
+            return_value=("model-after", 768, "https://after.invalid/v1", "cfg-after")
+        )
+        return [0.9] * 1536
+
+    mock_port.generate_embedding = AsyncMock(side_effect=_generate)
+    mock_port.resolve_embedding_config = AsyncMock(
+        return_value=(_MODEL, _DIMS, _BASE_URL, "cfg-before")
+    )
+
+    with patch.object(service_semantic, "get_catalog_port", return_value=mock_port):
+        await service_semantic.generate_embedding("pinned query", session)
+
+        # Non-vacuity: the edit really did land, so an unpinned call would have
+        # had a different configuration to reach for.
+        assert (await mock_port.resolve_embedding_config(session))[0] == "model-after"
+
+    # The provider was asked for the configuration resolved BEFORE the call.
+    assert seen == [(_MODEL, _DIMS, _BASE_URL)]
+    # And the entry is keyed on that same one, so the next request under the
+    # new configuration misses rather than being served this vector.
+    assert ("pinned query", _MODEL, "cfg-before") in service_semantic._embedding_cache
+
+
+@pytest.mark.asyncio
+async def test_an_unresolvable_configuration_still_reaches_the_provider():
+    """A caller with no config to pin must not silently skip the provider.
+
+    `generate_embedding` is reachable outside search (the CatalogPort surface),
+    and a configuration that cannot be resolved is the provider's problem to
+    report, not a reason to answer with nothing. It goes through unpinned and
+    uncached, which is exactly what it did before any of this existed.
+    """
+    session = _mock_session_with_model()
+    mock_port = _mock_port(return_value=[0.4] * 1536)
+    mock_port.resolve_embedding_config = AsyncMock(return_value=None)
+
+    with patch.object(service_semantic, "get_catalog_port", return_value=mock_port):
+        vector = await service_semantic.generate_embedding("no config", session)
+
+    assert vector == [0.4] * 1536
+    assert mock_port.generate_embedding.await_args.kwargs["pinned"] is None
+    # Nothing was cached: there is no configuration to key it on.
+    assert len(service_semantic._embedding_cache) == 0
 
 
 @pytest.mark.asyncio
@@ -185,14 +248,10 @@ async def test_cache_partitioned_by_tenant(monkeypatch: pytest.MonkeyPatch):
         finally:
             current_tenant_var.reset(token)
 
-    with (
-        patch.object(service_semantic, "get_catalog_port", return_value=mock_port),
-        patch.object(
-            service_semantic.EMBEDDING_MODEL,
-            "get",
-            new=AsyncMock(return_value="shared-model"),
-        ),
-    ):
+    mock_port.resolve_embedding_config = AsyncMock(
+        return_value=("shared-model", _DIMS, _BASE_URL, _FINGERPRINT)
+    )
+    with patch.object(service_semantic, "get_catalog_port", return_value=mock_port):
         first_a = await embed_for(tenant_a)
         first_b = await embed_for(tenant_b)
         second_a = await embed_for(tenant_a)
@@ -210,14 +269,7 @@ async def test_cache_expires_entries_after_ttl():
     mock_port = _mock_port(side_effect=[fake_v1, fake_v2])
     session = _mock_session_with_model()
 
-    with (
-        patch.object(service_semantic, "get_catalog_port", return_value=mock_port),
-        patch.object(
-            service_semantic.EMBEDDING_MODEL,
-            "get",
-            new=AsyncMock(return_value="text-embedding-3-small"),
-        ),
-    ):
+    with patch.object(service_semantic, "get_catalog_port", return_value=mock_port):
         # First call populates the cache with monotonic NOW + 300s TTL.
         await service_semantic.generate_embedding("expire me", session)
         # Manually expire by rewinding the cached entry's expires_at
@@ -238,14 +290,7 @@ async def test_empty_input_does_not_populate_cache():
     mock_port = _mock_port(side_effect=ValueError("empty"))
     session = _mock_session_with_model()
 
-    with (
-        patch.object(service_semantic, "get_catalog_port", return_value=mock_port),
-        patch.object(
-            service_semantic.EMBEDDING_MODEL,
-            "get",
-            new=AsyncMock(return_value="text-embedding-3-small"),
-        ),
-    ):
+    with patch.object(service_semantic, "get_catalog_port", return_value=mock_port):
         with pytest.raises(ValueError):
             await service_semantic.generate_embedding("   ", session)
 
@@ -262,14 +307,10 @@ async def test_cache_evicts_oldest_when_over_max_size():
         mock_port = _mock_port(side_effect=[[float(i)] for i in range(5)])
         session = _mock_session_with_model()
 
-        with (
-            patch.object(service_semantic, "get_catalog_port", return_value=mock_port),
-            patch.object(
-                service_semantic.EMBEDDING_MODEL,
-                "get",
-                new=AsyncMock(return_value="model"),
-            ),
-        ):
+        with patch.object(service_semantic, "get_catalog_port", return_value=mock_port):
+            mock_port.resolve_embedding_config = AsyncMock(
+                return_value=("model", _DIMS, _BASE_URL, _FINGERPRINT)
+            )
             for i in range(5):
                 await service_semantic.generate_embedding(f"q{i}", session)
 

--- a/backend/tests/test_semantic_hnsw_post_filter_1546.py
+++ b/backend/tests/test_semantic_hnsw_post_filter_1546.py
@@ -1,0 +1,191 @@
+"""Foreign-stamped rows must not starve the HNSW candidate window (#1546 r2).
+
+The configuration predicate is applied AFTER the approximate index scan has
+chosen its candidates. With a fixed `hnsw.ef_search` and no iterative scan, the
+index hands back at most that many rows and the filter runs on them, so a
+catalog whose nearest neighbours are mostly rows the filter rejects can have
+every candidate discarded before a usable one is visited. Semantic search then
+returns nothing and falls back to FTS while matching vectors sit in the table.
+
+The realistic way in is a partly complete regenerate after a configuration
+change: most rows carry the superseded stamp, and they are exactly as near the
+query as their replacements would be.
+
+This is not a defect #1546 introduced. A model-only filter starves the same way
+on a catalog holding two models' rows in one index, which is the state #1506
+was written for. #1546 made the predicate more selective, so it made the window
+easier to exhaust, and the fix covers both.
+
+WHY THIS TESTS `_get_vector_ranks` AND NOT THE SEARCH ENDPOINT: the defect only
+exists when the plan actually uses the HNSW index, and on a table this size
+Postgres will not choose it unless pushed. `enable_seqscan = off` alone is not
+enough and the first draft of this test was vacuous because of it: the planner
+switched to the `uq_record_embedding_model` btree, sorted 155 rows by distance,
+and found every live row with iterative scan on or off. `enable_sort = off`
+removes that escape, because only an ordered index scan can then satisfy the
+ORDER BY. Both have to be set on the session the query runs in, which an HTTP
+request is not.
+
+Measured on pgvector 0.8.5, with the plan forced:
+
+    iterative_scan=off             Rows Removed by Filter: 100    returned 0
+    iterative_scan=relaxed_order   Rows Removed by Filter: 150    returned 5
+
+The first line is the defect: exactly `ef_search` candidates examined, every
+one of them rejected, nothing returned while five usable vectors sit in the
+table.
+
+Requirements:
+  - Docker database must be running (docker compose up db)
+  - Alembic migrations must be applied (including pgvector >= 0.8.0)
+"""
+
+import uuid
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from sqlalchemy import text
+
+from app.core.persistent_config import EMBEDDING_DIMS, EMBEDDING_MODEL
+from app.modules.catalog.search import service_semantic
+from app.processing.embeddings import helpers
+from app.processing.embeddings.helpers import embedding_config_fingerprint
+from app.processing.embeddings.models import RecordEmbedding
+from app.processing.embeddings.service import resolve_embedding_base_url
+
+from tests.factories import create_dataset, get_user_id
+
+_DIMS = 1536
+# More foreign rows than `ef_search`, all nearer the query than any live row.
+# 150 against a window of 100 is what makes the window run out.
+_FOREIGN_ROWS = 150
+_LIVE_ROWS = 5
+_EF_SEARCH = 100
+_FOREIGN_URL = "https://starved-endpoint.invalid/v1"
+
+
+@pytest.fixture(autouse=True)
+def _fresh_has_embeddings_cache():
+    helpers._has_embeddings_cache.clear()
+    yield
+    helpers._has_embeddings_cache.clear()
+
+
+def _vector(angle: float) -> list[float]:
+    """A unit vector in a band this file owns, rotated by `angle`.
+
+    Band [800, 810) keeps these rows away from every other suite's vectors, so
+    the candidate window this test fills is filled by this test.
+    """
+    vec = [0.0] * _DIMS
+    vec[800] = 1.0
+    vec[801] = angle
+    magnitude = sum(v * v for v in vec) ** 0.5
+    return [v / magnitude for v in vec]
+
+
+async def _seed(session, name: str, *, fingerprint: str, angle: float) -> uuid.UUID:
+    user_id = await get_user_id(session, "admin")
+    dataset = await create_dataset(session, created_by=user_id, name=name)
+    record_id = dataset.record_id
+    session.add(
+        RecordEmbedding(
+            record_id=record_id,
+            embedding=_vector(angle),
+            model_name=await EMBEDDING_MODEL.get(session),
+            config_fingerprint=fingerprint,
+            content_hash=uuid.uuid4().hex[:64],
+        )
+    )
+    await session.commit()
+    return record_id
+
+
+@pytest.mark.anyio
+async def test_foreign_rows_nearer_than_live_ones_do_not_starve_the_scan(
+    test_db_session,
+):
+    """150 rejected neighbours in front of 5 usable ones, window of 100."""
+    session = test_db_session
+    model_name = await EMBEDDING_MODEL.get(session)
+    dimensions = await EMBEDDING_DIMS.get(session)
+    base_url = await resolve_embedding_base_url(session)
+    live = embedding_config_fingerprint(model_name, dimensions, base_url)
+    foreign = embedding_config_fingerprint(model_name, dimensions, _FOREIGN_URL)
+    assert live != foreign
+
+    # Nearest first: the foreign rows sit almost exactly on the query, the live
+    # ones sit further out but well inside the 0.7 cosine cutoff.
+    for index in range(_FOREIGN_ROWS):
+        await _seed(
+            session,
+            f"Starve Foreign {index}",
+            fingerprint=foreign,
+            angle=0.001 * (index + 1),
+        )
+    live_ids = {
+        await _seed(
+            session,
+            f"Starve Live {index}",
+            fingerprint=live,
+            angle=0.40 + 0.01 * index,
+        )
+        for index in range(_LIVE_ROWS)
+    }
+
+    query_vector = _vector(0.0)
+
+    # Force the ordered index path; see the module docstring for why both are
+    # needed and what the first draft of this test proved without the second.
+    await session.execute(text("SET LOCAL enable_seqscan = off"))
+    await session.execute(text("SET LOCAL enable_sort = off"))
+
+    # Non-vacuity, part one: the plan really does go through the HNSW index, so
+    # a post-filter window exists to be starved. Explained against the same
+    # shape `_get_vector_ranks` builds — the configuration predicate, the 0.7
+    # cutoff, ordered by distance with a limit — because a simpler query can
+    # take a different plan, which is exactly how the earlier draft fooled
+    # itself.
+    plan = "\n".join(
+        row[0]
+        for row in (
+            await session.execute(
+                text(
+                    "EXPLAIN SELECT record_id FROM catalog.record_embeddings "
+                    "WHERE model_name = :model "
+                    "AND (config_fingerprint IS NULL OR config_fingerprint = :fp) "
+                    "AND embedding <=> CAST(:q AS vector) <= 0.7 "
+                    "ORDER BY embedding <=> CAST(:q AS vector) LIMIT :k"
+                ),
+                {
+                    "model": model_name,
+                    "fp": live,
+                    "q": str(query_vector),
+                    "k": _LIVE_ROWS,
+                },
+            )
+        ).all()
+    )
+    assert "ix_record_embeddings_hnsw" in plan, plan
+
+    with patch.object(
+        service_semantic,
+        "generate_embedding",
+        new=AsyncMock(return_value=query_vector),
+    ):
+        ranks, returned_vector, identity = await service_semantic._get_vector_ranks(
+            session, "starvation query", _LIVE_ROWS
+        )
+
+    # Non-vacuity, part two: the vector arm ran rather than bailing early.
+    assert returned_vector == query_vector
+    assert identity is not None
+
+    returned = {uuid.UUID(record_id) for record_id in ranks}
+    assert returned & live_ids, (
+        "no live row survived the candidate window: "
+        f"{len(ranks)} ranks returned from {_FOREIGN_ROWS} foreign rows in front "
+        f"of {_LIVE_ROWS} live ones at ef_search={_EF_SEARCH}"
+    )
+    # And nothing from the other configuration leaked through the filter.
+    assert returned <= live_ids


### PR DESCRIPTION
Closes #1546.

## The defect

`RecordEmbedding` recorded `model_name` and nothing else about how the vector was made. The vector space is a function of the model, the width it was asked for, and the endpoint that served it, so one model behind two endpoints is two spaces under one label. Semantic search embeds the query with the configuration live at query time and then filtered stored rows by model name alone. That let it compare vectors across spaces. Cosine distances came back well-formed and meaningless, nothing errored, and ranking quality degraded silently.

#1539 closed the window inside a single run by pinning model, dimensions and endpoint for its duration. It could not close the window across runs. Two backfills months apart, same model name, different endpoints, leave the table holding both spaces with nothing to tell the rows apart.

## The change

`catalog.record_embeddings` gains `config_fingerprint`, the SHA-256 of `(model, dimensions, endpoint)`. Writers stamp it from the configuration the run pinned. Readers filter on the fingerprint of the live configuration. Rows from another configuration become invisible rather than wrong.

### How the fingerprint is computed, and why it is stable

`embedding_config_fingerprint(model_name, dimensions, base_url)` in `processing/embeddings/helpers.py` is a pure function: SHA-256 over `json.dumps([model, dims, url], separators=(",", ":"))`.

SHA-256 rather than Python's `hash()`, which is salted per interpreter through `PYTHONHASHSEED`. A salted identity would change at every restart, so rows stamped by one worker would be invisible to the next one, and to the same worker tomorrow.

JSON rather than a delimiter join. `None` is a value the endpoint genuinely resolves to: the provider interface lets an extension answer `{"base_url": None}` meaning "use the client default", which is what `_Unset` in `service.py` exists for (#1525). A join collapses `None`, `"None"` and `""` into each other, and cannot keep `("a|b", None)` apart from `("a", "b")`. JSON keeps all of them distinct and escapes the strings. Three tests hold that down.

Nothing else feeds it. No clock, no host, no process identity. Same three values in, same 64 hex characters out, on any worker, after any restart.

### The stamp comes from the pin, never from a read at write time

The backfill computes `embedding_config_fingerprint(*pinned)`, and `pinned` is exactly the triple handed to `generate_embeddings_batch`. So the stamp names the configuration that actually produced the vector rather than whatever the configuration says by the time the row is written.

That distinction is not theoretical, and `test_the_stamp_comes_from_the_pin_not_from_a_read_at_write_time` builds the state where the two differ. `_pinned_config_drift` deliberately does not treat a provider resolve that *raises* as drift (#1525 review r4: for the shipped provider that is what an endpoint diverging from the operator-approved environment URL looks like, and it says nothing about where vectors are going). A run can therefore continue, correctly, while the live endpoint no longer resolves at all. A writer that re-read would stamp the unresolvable-configuration sentinel onto rows nothing can ever match. Stamping from the pin records the truth. Reverting that one expression to a fresh read turns the test red with `assert '__config_unknown__' == '03905d87591f...'`.

### One definition of the rule

`RecordEmbedding.usable_by_config(model_name, config_fingerprint)` is the single expression of "this stored row can be compared against a vector from that configuration". Semantic search reaches it through `CatalogPort.record_embedding_orm_class()`, which is why it lives on the model rather than in `helpers.py`: `modules/catalog/` may not import `app.processing.*`.

The admin coverage query is raw SQL and spells the same condition by hand. Two spellings of one rule is exactly the class of drift this PR is about, so it is not left to inspection. `test_coverage_agrees_with_what_search_can_retrieve` builds a catalog holding all six combinations of model and stamp, then asserts the panel's count equals what the ORM predicate selects.

## Upgrading changes nothing an operator can see

Migration `0052` adds a nullable column and backfills nothing. What configuration produced a row already in the table is not recoverable from the row, and stamping every existing row with today's configuration would invent provenance that happens to be right only on instances that never changed anything.

NULL means "written before this column existed", and every reader grandfathers it: an unstamped row is matched on model name alone, exactly as before. The day after upgrading,

- semantic search returns what it returned yesterday;
- the admin coverage bar reads what it read yesterday;
- Generate Missing picks up what it picked up yesterday, so no re-embed is triggered and no provider tokens are spent;
- rows earn stamps as they are rewritten. Regenerate All stamps everything. Generate Missing stamps the records it covers. An ingest that changes a record's embeddable text stamps that row.

The stronger guarantee therefore arrives per row. Until a row is stamped it carries the pre-#1546 guarantee, which is the one it was written under. That weaker guarantee is not something this PR introduces; it is what every instance has today. Regenerate All is the visible option for converting the whole catalog at once, and it is already there. This PR does not add a second one, and no path re-embeds at provider cost without being asked.

The choice is load-bearing rather than cosmetic, and the counterfactual shows what it buys. Dropping the `config_fingerprint IS NULL` arm turns eight existing tests red, six of them in `test_hybrid_search.py`, because those suites write unstamped rows. That makes them a literal simulation of the morning after the migration:

```
E   AssertionError: assert 'Zqz Stamp Legacy' in []
E   AssertionError: assert 'Roads and Highways Network' in {'Stamp Agreement 0', ...}
E   AssertionError: assert 'Transit Stops Inventory' in set()
E   AssertionError: second page of semantic-only results must not be empty
FAILED tests/test_embedding_config_stamp_1546.py::test_a_legacy_unstamped_row_stays_searchable_after_upgrade
FAILED tests/test_embedding_config_stamp_1546.py::test_a_legacy_unstamped_row_is_not_offered_for_re_embedding
FAILED tests/test_hybrid_search.py::test_semantic_surfaces_vector_only_match
FAILED tests/test_hybrid_search.py::test_semantic_vector_only_does_not_leak_private
FAILED tests/test_hybrid_search.py::test_semantic_vector_only_respects_active_filters
FAILED tests/test_hybrid_search.py::test_semantic_visible_match_not_crowded_out_by_nearer_private
FAILED tests/test_hybrid_search.py::test_semantic_vector_only_pagination
FAILED tests/test_hybrid_search.py::test_semantic_approximate_count_keeps_next_link
FAILED tests/test_embedding_backfill_model_scope.py::test_record_with_only_a_superseded_vector_reads_missing
FAILED tests/test_embedding_backfill_model_scope.py::test_a_swap_moves_a_covered_record_back_into_the_selection
```

## Every reader, and what happened to it

Rule 8. This is every reader of `catalog.record_embeddings` under `backend/app` (`git grep record_embeddings` returns exactly these files), plus the readers that are not table reads at all.

| Reader | Where | Decision |
|---|---|---|
| Vector-similarity ranking | `service_semantic._get_vector_ranks` | Filters on stamp. |
| Row gate and exact vector-only count | `service_semantic._run_rrf_merge` | Filters on stamp, both queries. The gate decides whether the exact count is affordable, so counting rows the ranking cannot see would push a catalog over the threshold on the strength of vectors no search will return. |
| Query-vector LRU cache | `service_semantic.generate_embedding` | Keyed on stamp. Not a table read, and the reader that would have relocated the bug: filtering rows by the live configuration while serving a memoized query vector made under the previous one is the same cross-space comparison, with the filter looking correct. |
| The provider call that makes the query vector | `CatalogPort.generate_embedding` | **Pinned to the stamp's configuration** (review round 1, below). The reader I had missed: it re-resolved the live configuration for itself. |
| Non-force "already covered" predicate | `defaults_processing_port.get_records_without_embeddings` | Filters on stamp. "Missing" narrows from "no vector this MODEL can use" to "no vector this CONFIGURATION can use". An unresolvable configuration fails closed, one value out from #1506's unresolvable-model branch. |
| Coverage stats | `admin/service.get_embedding_stats` | Filters on stamp, and `stale_records` now counts foreign-configuration rows, which is what tells the operator to run Generate Missing. |
| Backfill batch writer | `backfill.backfill_embeddings` | Stamps from the pin, writes via upsert. |
| Backfill per-record retry writer | `backfill._retry_batch_per_record` | Stamps from the pin, writes via upsert. |
| Ingest-time writer and its skip | `service.generate_and_store_embedding` | Stamps, and the skip considers the stamp. It also now pins all three values, which it was documented to have to do and did not. |
| `has_embeddings` | `helpers` | Unaffected. Its SQL carries no model predicate at all, so there is nothing for a stamp to narrow. It only decides whether the vector arm is attempted; a false positive costs one query that returns no ranks and falls back to FTS. It cannot produce a wrong result. |
| `resolve_embedding_model_name` | `helpers` | Unaffected: a resolver, not a table read. It is now also the model that `resolve_embedding_config_fingerprint` pairs with, passed in rather than re-read so the two cannot straddle a settings change. |
| Related items | `helpers.get_nearest_record_ids`, `defaults_catalog_port.get_record_embedding` and `get_embedding_distances` | Unaffected, deliberately. These filter by neither model nor stamp today, so they already compare one record's stored vector against another's across model spaces. That is a pre-existing defect this PR did not create. Adding a fingerprint predicate without a model predicate would be incoherent, and adding both changes what the related-items feature returns, which needs its own issue and its own red. Flagged for triage rather than half-fixed, and now filed as **#1580**. |
| `uq_record_embedding_model` | the database | Unaffected as a constraint, but it decides whether a write succeeds, so it counts. See below. |
| Readers in the future | rows written today, searched weeks later | The stamp is a pure function with no salt and no clock, so a row written by one worker is readable by any other and after any restart. |

Outside the backend, no SDK, CLI, MCP or frontend surface sees the column. `make openapi-check` is clean and `backend/openapi.json` is unchanged.

## Decisions worth review

**The writers had to become upserts.** Once a foreign-stamped row stops counting as coverage, the non-force run offers that record as missing. `uq_record_embedding_model` is `(record_id, model_name)`, so a plain INSERT answers that with a unique violation instead of a vector. `_upsert_embeddings` replaces the row in place. Replacing rather than widening the constraint to include the fingerprint keeps the table's size independent of how many configurations an instance has been through, and it leaves intact the key #1549 needs for a per-batch delete-and-replace. `updated_at` is set explicitly because `onupdate=` is an ORM-level default and this is a Core statement.

**Search reads the configuration once per request, cached.** `_live_embedding_identity` resolves `(model, fingerprint)` once in `_run_rrf_merge` and threads it into the ranks, the query-vector cache key and both counts, so a request cannot rank under one configuration and count under another. The read is cached, unlike the backfill's pre-delete snapshot: a reader has nothing to destroy, and the worst a stale entry does is make stamped rows briefly invisible, degrading to FTS for one cache TTL and healing itself. An uncached read would cost a DB round trip on the search hot path for that.

**The resolver never raises.** The endpoint resolves through the provider extension, which raises whenever the database endpoint diverges from the operator-approved environment URL. A reader that turned that into a 500 would take search down over a setting it is only consulting to be careful, so an unresolvable configuration answers with `UNKNOWN_EMBEDDING_CONFIG`. That value is not a hex digest, so it can never collide with a real fingerprint. It is the same under-report `resolve_embedding_model_name`'s sentinel produces, in the same safe direction. The one thing "never raises" does not mean is written into the docstring: if the failure was a database error, the caller's transaction is already aborted, and every caller today sits inside a broad handler that degrades anyway.

**No index.** The fingerprint is never a predicate on its own. It always rides alongside `model_name` (itself unindexed since `0001_baseline`) inside a query whose cost is the HNSW vector scan, evaluated as a filter over rows that scan already produced.

**`EXTENSION_API_VERSION` 7 to 8.** `CatalogPort` gains a required `resolve_embedding_config_fingerprint`. Every hybrid search calls it, so an overlay replacing the `catalog_port` slot without it would load cleanly at version 7 and then raise `AttributeError` on the first query long enough to reach the vector arm. Same reasoning as the 5 to 6 bump.

**`_MODULE_LOC_CAPS`.** `service_semantic.py` 395 to 454, `defaults_processing_port.py` 537 to 564, `defaults_catalog_port.py` 450 to 461. Each exact, each with a comment saying what the lines bought.

## Three existing tests needed their premise restored

The first two are consequences of the non-force selection now resolving the endpoint once, before the snapshot does. Neither weakens what the test asserts.

`test_embedding_backfill_base_url_pinning.py`: `_SnapshotWindowProvider` and `_AtomicSwitchProvider` land the admin edit "during the first provider call", which used to be the snapshot's. They now take `resolves_before_edit`, `0` on the force path and `1` on the non-force one, so the edit still lands inside the snapshot's capture. `test_an_endpoint_that_resolves_to_none_is_still_pinned` counts resolutions, so its arithmetic gains the same `+ 1`.

`test_embedding_backfill_model_pinning.py`: `test_a_switch_between_the_model_and_dims_reads_aborts_the_run` hung its flip on both `EMBEDDING_DIMS.get` and `.get_uncached`, on the grounds that the snapshot would reach one of them first. The selection now reads through `get` on its way to the fingerprint, which fires the flip before the snapshot starts and leaves the snapshot reading a settled pair. Only `get_uncached` is patched now. It is reached only from inside `_snapshot_embedding_config`, which is where the flip has to land.

Worth flagging while I was in there. With the snapshot's comparison deleted, the `[force]` variant of that test goes red and the `[non_force]` variant does not: it stops at the per-batch drift check instead, so it passes for a different mechanism's reason. That is pre-existing, since the original tree has no `EMBEDDING_DIMS` read on the non-force path before the snapshot either and the flip landed identically, and I have not changed it.

`test_embedding_tenant_isolation.py` needed the same precondition #1511 and #1525 supplied for the force path. Those sessions run as `geolens_reader`, which is denied `app_settings`, and the coverage query now resolves the configuration. The denied read aborts the transaction, so the stats query behind it degraded to zeros. Both new config reads are stubbed and the real fingerprint resolution runs.

## Verification

Red, with `usable_by_config` reduced to the model-name-only predicate it replaces and the admin FILTER reverted to `WHERE embedding.model_name = :model_name`:

```
E   AssertionError: assert 'Zqx Stamp Dropped' not in ['Zqx Stamp Kept', 'Zqx Stamp Dropped']
E   assert 3 == 1
E   AssertionError: assert UUID('b340a82a-49b3-4f58-9b4e-2c31e9244df6') in set()
E   AssertionError: assert ['04daeabfba2...dbfe9b9338dc'] == ['03905d87591...fbffef546f77']
E   assert 11 == (9 + 1)
E   assert 8 == 14
FAILED tests/test_embedding_config_stamp_1546.py::test_semantic_search_excludes_a_row_from_a_foreign_configuration
FAILED tests/test_embedding_config_stamp_1546.py::test_the_match_total_excludes_a_foreign_configuration_too
FAILED tests/test_embedding_config_stamp_1546.py::test_a_foreign_stamped_row_does_not_count_as_coverage
FAILED tests/test_embedding_config_stamp_1546.py::test_re_embedding_a_foreign_stamped_row_replaces_it
FAILED tests/test_embedding_config_stamp_1546.py::test_coverage_counts_only_rows_the_live_configuration_can_use
FAILED tests/test_embedding_config_stamp_1546.py::test_coverage_agrees_with_what_search_can_retrieve
6 failed, 7 passed
```

The search test constructs the mismatch rather than faking it: two records, both carrying the active model name, both with near-identical vectors, one stamped with the fingerprint of the endpoint the provider actually resolves to and one with the fingerprint of a second endpoint. Neither fingerprint comes out of the resolver under test; both are built by `embedding_config_fingerprint` over a triple. The filter itself is untouched by the test.

The query-vector cache is its own mechanism and got its own counterfactual. With the fingerprint dropped from the cache key:

```
E   assert [0.7, 0.7, ...] == [0.8, 0.8, ...]
FAILED tests/test_search_embedding_cache.py::test_cache_partitioned_by_configuration
1 failed, 7 passed
```

The stamp-from-the-pin property likewise, with that one expression re-reading the live configuration instead:

```
E   AssertionError: assert '__config_unknown__' == '03905d87591f...5fbffef546f77'
FAILED tests/test_embedding_config_stamp_1546.py::test_the_stamp_comes_from_the_pin_not_from_a_read_at_write_time
1 failed, 13 passed
```

Green:

```
$ uv run pytest tests/test_embedding_config_stamp_1546.py -q
14 passed

$ uv run pytest tests/ -q -k "embedding or backfill or semantic or search"
486 passed, 1 skipped, 8849 deselected, 46 warnings in 203.77s

$ uv run pytest <11 admin / extension / port / settings / related-items suites> -q
162 passed, 51 warnings in 59.44s

$ uv run pytest tests/test_layering.py -q
47 passed

$ uv run ruff check . && uv run ruff format --check .
All checks passed!
1026 files already formatted

$ python -m alembic upgrade head && python -m alembic check   # throwaway DB on the test cluster
No new upgrade operations detected.

$ PYTHONPATH=. python scripts/dump_openapi.py --check
exit 0, backend/openapi.json unchanged
```

`make alembic-check` runs inside the dev stack's API container, which bind-mounts the main checkout and therefore cannot see this branch's migration. The equivalent above builds a throwaway database on the shared test cluster, upgrades it to head, and runs `alembic check` there. The dev database was not touched.

## Effect on #1549 and #1551

#1549, a force run committing its DELETE before it knows the run can finish, is not fixed here. The destructive-first comment in `backfill.py` is updated to say why it is now fixable. The objection to direction 1, deleting per batch inside the transaction that writes the batch's replacement, was that a partial run leaves a mix of old and new rows nothing can tell apart. With the stamp, a partial run leaves a mix search *can* tell apart: rows from the superseded configuration go invisible instead of the table going empty. `uq_record_embedding_model` is untouched, so the per-batch delete still has its key.

#1551, the extension provider that cannot resolve its endpoint past the cache, checks out, and I verified the mechanism against the code. A run pins `(uncached model, uncached dims, cached endpoint)` and passes that endpoint to `generate_embeddings_batch`, which passes it to `provider_ext.embed`. So a stale pin means the vectors really are in the stale endpoint's space. The stamp names that stale endpoint, and search after eviction computes a different fingerprint and skips those rows. Honestly labelled and invisible rather than silently wrong.

Two things closing it would drop, both worth stating rather than burying. The protocol-widening ask itself is not delivered, so the pinned triple still cannot be read transactionally consistent. And the stamp is only as accurate as the pin, so an extension provider whose `embed` ignores the `base_url` it is handed and re-resolves internally would be stamped with something that did not produce the vector. Nothing enforces that contract; it is the same one #1539's pin already rests on.


## Review round 1

Two findings, both real, and both the same shape as the defect itself one layer further out: a value read once and then re-read somewhere else, where the two reads can disagree.

### P1, `service_semantic.py`: the provider call was not pinned

`config` controlled the row predicate and the cache key, but `_embed_with_deadline` still called `CatalogPort.generate_embedding(text, session)`, which resolved the live configuration again. An admin change between the two produced a vector under configuration B, cached it under A, and ranked A-stamped rows against it. Inside one request, which is worse than the cross-run window the PR was written for.

The port now answers the whole live configuration, `(model, dimensions, endpoint, fingerprint)`, and `generate_embedding` takes the first three back as a pin. One read decides all three uses.

Two decisions inside that:

**The pin is one optional argument, not three keyword ones.** Codex asked for `model`, `dimensions`, `base_url` with `None` defaults. `None` is a legitimate resolved endpoint: the provider interface lets an extension answer `{"base_url": None}` meaning "use the client default", which is exactly why `generate_embeddings_batch` distinguishes it from an omission with a sentinel (`_Unset`, #1525). Three `None` defaults cannot tell "not pinned" from "pinned to the client default", and would have re-resolved the endpoint for precisely the providers the pin exists to protect. A single `pinned` tuple is absent or complete and cannot express that mistake.

**Verify-after was rejected.** Resolving again after the provider call and discarding on mismatch catches the divergence only once the vector exists, and the natural handling still leaves this request either ranking on a wrong-space vector or silently losing its vector arm. Pinning removes the divergence instead of detecting it.

### P2, `service_semantic.py`: resolution sat outside the FTS fallback guard

Resolving reads persistent config and can raise on a cache miss or a transient database failure. Above the guard, that raise took the whole search request down. Model resolution used to happen inside `generate_embedding`, under the guard, degrading to FTS like every other failure on this path, so hoisting it had quietly made the same failure fatal. It is back inside the `try`.

### Round-1 red

```
E   AssertionError: assert [None] == [('text-embed...enai.com/v1')]
E   RuntimeError: persistent config is unavailable
FAILED tests/test_search_embedding_cache.py::test_the_provider_call_is_pinned_to_the_resolved_configuration
FAILED tests/test_embedding_config_stamp_1546.py::test_a_configuration_read_that_raises_degrades_to_fts
2 failed, 23 passed
```

The P1 test lands the configuration change from inside the provider call, the shape `test_embedding_backfill_base_url_pinning.py` uses, and asserts both what the provider was asked for and what the entry was cached under. The P2 test drives a raising resolver through the real search endpoint with a query that matches lexically, so "degraded to FTS" is distinguishable from "returned nothing".

`_MODULE_LOC_CAPS`: `service_semantic.py` 456 to 482, `defaults_catalog_port.py` 461 to 478. The `EXTENSION_API_VERSION` comment now covers both port changes under the one 7 to 8 bump; an overlay implementing the old two-argument `generate_embedding` raises `TypeError` on the first semantic search, so the widening is as required as the addition.


## Review round 2

### P1, `test_extension_api_version.py` pinned the constant at 7

Backend CI fails deterministically without this: the suite asserts `EXTENSION_API_VERSION == 7` and I moved the constant to 8. My round-1 sweep did not catch it because neither the `-k "embedding or backfill or semantic or search"` filter nor the seven suites I named by hand include that file, which is the real lesson: a sweep selected by topic misses a gate that lives under a different topic.

The pin and its version-history note are updated. `git grep -nE "EXTENSION_API_VERSION\s*==\s*[0-9]" -- backend` returns nothing else, so there is no sibling pin. Green with:

```
$ uv run pytest tests/test_extension_api_version.py -q
12 passed

$ uv run pytest tests/test_extension_api_version.py tests/test_extensions.py tests/test_catalog_port.py \
    tests/test_entitlement_port.py tests/test_cloud_overlay_side_by_side.py tests/test_processing_port.py -q
53 passed, 12 skipped
```

The sweep below now selects on `-k "extension or port or overlay or catalog_port"` as its own pass, so the same blind spot cannot recur silently.

### P2, foreign-stamped rows can starve the HNSW candidate window

Real, and I measured it rather than reasoning about it. The configuration predicate is applied after the approximate scan picks its candidates, so with a fixed `ef_search` and no iterative scan the index hands back at most that many rows and the filter runs on them. A catalog whose nearest neighbours are mostly rejected rows returns nothing and falls back to FTS while usable vectors sit in the table. The realistic route in is a partly complete regenerate after a configuration change: most rows carry the superseded stamp and they are exactly as near the query as their replacements.

**This is not a defect this PR introduced.** A model-only filter starves the same way on a catalog holding two models' rows in one index, which is the state #1506 was written for. The new predicate is more selective, so it makes the window easier to exhaust, and the fix closes both.

`set_hnsw_recall` now enables pgvector's iterative scan. pgvector version in the shipped image: the `db/Dockerfile` installs `postgresql-18-pgvector` from PGDG, which resolves to **0.8.5**, confirmed against the running database (`SELECT default_version FROM pg_available_extensions WHERE name='vector'`), comfortably past the 0.8.0 iterative-scan requirement.

Three decisions:

- **`relaxed_order`, not `strict_order`.** The caller turns distances into positional ranks and merges them with FTS through RRF, so a slight reordering inside the returned window costs nothing and relaxed is cheaper.
- **`hnsw.max_scan_tuples` set explicitly** at pgvector's own default of 20000, so the ceiling is visible where iterative scan is turned on rather than implied.
- **One statement, not three.** `SET LOCAL` cannot carry multiple settings, so this is a single `SELECT set_config(..., true) x3` on the search hot path. On a pgvector older than 0.8.0 the unknown setting is accepted as an inert `prefix.name` placeholder rather than raising, so the query degrades to the previous behaviour instead of failing.

### The starvation test, and the vacuous first draft

Worth reading, because the first version of this test passed with the fix reverted.

The defect only exists when the plan actually uses the HNSW index. `enable_seqscan = off` was not enough: the planner switched to the `uq_record_embedding_model` btree, sorted 155 rows by distance and found every live row with iterative scan on or off. `enable_sort = off` removes that escape, because only an ordered index scan can then satisfy the ORDER BY. The first draft also EXPLAINed a simplified query rather than the shape `_get_vector_ranks` actually builds, so its plan assertion was checking something the test never ran.

With the plan forced, measured on 150 foreign rows in front of 5 live ones at `ef_search=100`:

```
iterative_scan=off             Rows Removed by Filter: 100    returned 0
iterative_scan=relaxed_order   Rows Removed by Filter: 150    returned 5
```

The first line is the defect exactly: `ef_search` candidates examined, every one rejected, nothing returned.

Red, with `iterative_scan` set to `off`:

```
E   AssertionError: no live row survived the candidate window: 0 ranks returned from 150 foreign rows in front of 5 live ones at ef_search=100
FAILED tests/test_semantic_hnsw_post_filter_1546.py::test_foreign_rows_nearer_than_live_ones_do_not_starve_the_scan
```

The test targets `_get_vector_ranks` rather than the search endpoint because both planner settings have to be set on the session the query runs in, which an HTTP request is not. It asserts the plan on the real query shape, that the vector arm ran, that live rows came back, and that nothing from the other configuration leaked through.


## Review round 3

One P2, and it is the same relocated pair a third time, in the third writer.

`generate_and_store_embedding` composed its pin from a `model_name` read at the top of the function and a dimensions/endpoint read further down. `PersistentConfig.set` says the quiet part out loud: committing and then evicting as one step makes the WRITER atomic and does nothing for a reader, whose separate `get` calls sample at different instants and can straddle the whole step. A settings publish landing between those two reads pins (old model, new dimensions, new endpoint), a triple that was never live.

In a reader that mistake corrects itself: it fingerprints to something no stored row carries, so the vector arm matches nothing and degrades to FTS for one request. In a writer it is permanent. The row is stamped with a fingerprint no live configuration will ever equal, so it is invisible for good while looking stamped, which is strictly worse than the unstamped rows this column was added to distinguish.

### The fix

`resolve_live_embedding_config` gains `verify`, and the ingest writer calls it with `uncached=True, verify=True`. Those are the same two mechanisms `_snapshot_embedding_config` already uses in `backfill.py`, for the same reason, which is what gives the ingest writer the guarantee the backfill had and search does not need. It resolves the set twice, requires the two to agree, and retries once because a settings publish settles. Two inconsistent attempts answer None and the caller declines to write, because writing nothing beats writing a triple nobody chose.

The model now comes out of that same verified set rather than a read of its own. That is not tidiness: the lookup uses the model to find the row this call may UPDATE, so a lookup under one model and a pin under another would write the new model's vector into the old model's row, mislabelled. That is #1511 by another route.

Readers stay on the cheap path deliberately. Doubling their configuration reads on the search hot path would buy them a fallback they already have.

One cost, stated because it undoes something from round 1: the resolution now happens on the "record touched, embeddable text unchanged" path too. An earlier revision skipped it there by reading the model on its own first, and that shortcut is exactly what made the pin composable from two instants. `test_skips_when_hash_matches` asserts the resolution now happens, so the shortcut cannot come back quietly on grounds of cost.

### Every site that composes a configuration from more than one read

Enumerated rather than waiting for a fourth, as asked.

Writers that stamp a row, which is the class this finding is about:

| Site | Guarantee |
|---|---|
| `backfill._snapshot_embedding_config` | uncached + capture-and-compare, since #1511/#1525 |
| `backfill` batch and per-record writes | stamp from that snapshot, so they inherit it |
| `service.generate_and_store_embedding` | uncached + verify, this round |

Readers that compose but stamp nothing, where a hybrid self-corrects:

| Site | What a hybrid costs |
|---|---|
| `service_semantic` via `CatalogPort.resolve_embedding_config` | fingerprints to nothing stored, so one request degrades to FTS |
| `admin.get_embedding_stats` | coverage under-reports for one poll, the safe direction #1503 documents |
| `defaults_processing_port.get_records_without_embeddings` | over-reports missing, so the backfill re-embeds records it need not. Provider tokens, but the rows it then writes are stamped from the backfill's own verified snapshot, so no bad row results |

Compositions that resolve configuration but produce no pin and label nothing:

- `DefaultOpenAIEmbeddingProvider.resolve_runtime_config` composes four reads, and its output only reaches `generate_embeddings_batch` when the caller did not pin. Every labelling caller now pins, so those composed defaults can no longer reach a stamped row.
- `service.probe_embedding_dimensions` and `processing/ai/probe.py` compose model and endpoint to report a detected width or a diagnostic. Nothing is stamped; the width feeds an operator decision, which is #1529's territory. Flagged, not changed here.
- `settings/router.py` reads `get_uncached` throughout and is the writer side, which `PersistentConfig.set` already makes atomic.
- `processing/ai/{sql_generator,llm_loop,metadata_service}` make one `resolve_runtime_config` call each on chat paths that write no embedding.

### Round-3 red

With `verify=True` dropped from the ingest call, so the pin is composed exactly as it was:

```
E   AssertionError: assert 'cab85cf23c572071758bda7c03e98d268c8e5861e2d809bedbb32ee739c2f9cc' != 'cab85cf23c572071758bda7c03e98d268c8e5861e2d809bedbb32ee739c2f9cc'
FAILED tests/test_embedding_config_stamp_1546.py::test_the_ingest_pin_is_never_a_configuration_that_was_never_live
```

Both sides of that comparison are the hybrid: what the row was stamped with, and the fingerprint of (old model, new width) computed independently in the test.

The publish is driven through the real setter from inside the first dimensions read, which is where the window actually is. It moves the model **and** the width, deliberately: with only the model moving, the hybrid fingerprints identically to the old configuration and the test cannot see the defect at all. The assertions are that the stamp is never the hybrid, that it is one of the two configurations that really were live, and that the row's label agrees with its stamp.


## Merging #1579, and the conflict worth reviewing

`origin/main` (b12cccacd) is merged in. #1579 rewrote both embedding write paths, so `backfill.py` conflicted twice and the resolution is a judgement rather than a mechanical pick.

#1579's change is an ordering one: WRITE the rows, THEN run the pre-commit drift check, THEN commit. The check reads `pg_attribute`, which locks nothing, so running it before the rows were sent left a window for an `ALTER TABLE` to take ACCESS EXCLUSIVE and commit unseen. It relies on the write taking `RowExclusiveLock`, which ACCESS EXCLUSIVE conflicts with, so an ALTER either lands first and is seen or waits for the commit.

This PR replaced the ORM `session.add` plus `session.flush()` on both paths with `INSERT ... ON CONFLICT DO UPDATE` through `session.execute`. **That preserves what #1579 depends on**: a Core INSERT emits immediately and takes the same `RowExclusiveLock` at the same point in the sequence, so check-then-act stays sound. Both resolutions keep #1579's order (`_raise_on_structural_width` / `_raise_on_retry_vector_width` first, then the write, then `_raise_on_pin_drift`, then commit) and drop only the now-redundant `flush()`, since `session.execute` has already sent the statement.

The comments at both sites are updated to say the lock comes from the INSERT rather than from a flush. Leaving them describing a `flush()` that is no longer there would have been the more dangerous half of this merge: the next reader would have moved the statement back.

`_MODULE_LOC_CAPS` for `backfill.py` goes 1145 to 1225, read off `test_layering.py` after the merge rather than predicted.
