### PR TITLE
fix(embeddings): stop a backfill when the embedding column moves by any route

### DIFF
--- a/backend/app/processing/embeddings/backfill.py
+++ b/backend/app/processing/embeddings/backfill.py
@@ -164,6 +164,29 @@ class _AnomalousVectorWidth(RuntimeError):
     """
 
 
+def _column_rejects_width(generated: int, pinned_column_dims: int | None) -> str | None:
+    """Describe a generated width the column will not take, or None if it will.
+
+    The fit test on its own, with no opinion about what the mismatch MEANS. Its
+    two callers supply that: agreement across a batch on one path, a storage
+    read on the other. Splitting it out is what stops the two rules from having
+    to share one predicate, which is how a change meant for the batch path
+    silently disarmed the retry path once already.
+
+    `isinstance` rather than `is not None`, because `scalar_one_or_none` answers
+    `int | None` and -1 means an unconstrained `vector`, which accepts any width
+    and so can never mismatch.
+    """
+    if not isinstance(pinned_column_dims, int) or pinned_column_dims <= 0:
+        return None
+    if generated == pinned_column_dims:
+        return None
+    return (
+        f"the model produced {generated}-dimension vectors but "
+        f"catalog.record_embeddings.embedding is vector({pinned_column_dims})"
+    )
+
+
 def _structural_width_mismatch(
     vectors: list[list[float]], pinned_column_dims: int | None
 ) -> str | None:
@@ -201,26 +224,29 @@ def _structural_width_mismatch(
     already wrong, or that has just been rebuilt, produces exactly that. Mixed
     widths mean one bad input among good ones, so this returns None and lets the
     batch fail into the per-record retry, where each vector is judged alone.
-
-    An empty `vectors` yields no width to agree on, so it is not structural
-    either; the batch simply fails and is retried.
-
-    `isinstance` rather than `is not None`, because `scalar_one_or_none` answers
-    `int | None` and -1 means an unconstrained `vector`, which accepts any width
-    and so can never mismatch.
     """
-    if not isinstance(pinned_column_dims, int) or pinned_column_dims <= 0:
+    # fix(#1579 review r2, codex P2): TWO vectors minimum. Agreement is the
+    # evidence, and one input agrees with itself vacuously — the same reason
+    # `_raise_on_retry_vector_width` asks storage instead of counting widths.
+    # A final batch of one, which is any catalog sized 1 mod _BATCH_SIZE, was
+    # otherwise read as structural and stopped the whole run over a single bad
+    # record: the isolation bug the previous round fixed on the retry path,
+    # surviving at the one batch size where the batch path cannot tell the two
+    # apart either.
+    #
+    # It falls through instead of growing a branch here. The insert fails, the
+    # record is retried, and the retry rule decides it from storage, which is
+    # the evidence that does work for one input. The cost is one extra provider
+    # call for that one record, which is what a mixed-width batch already pays.
+    #
+    # An empty response lands here too, and for the same reason rather than by
+    # accident: no vectors, no agreement, nothing structural to claim.
+    if len(vectors) < 2:
         return None
     widths = {len(vector) for vector in vectors}
     if len(widths) != 1:
         return None
-    generated = widths.pop()
-    if generated == pinned_column_dims:
-        return None
-    return (
-        f"the model produced {generated}-dimension vectors but "
-        f"catalog.record_embeddings.embedding is vector({pinned_column_dims})"
-    )
+    return _column_rejects_width(widths.pop(), pinned_column_dims)
 
 
 def _raise_on_structural_width(
@@ -260,8 +286,12 @@ async def _raise_on_retry_vector_width(
     nobody is stopped from reordering — and getting it wrong silently converts a
     structural storm into ten thousand counted errors, which is the outcome this
     whole PR exists to prevent.
+
+    Calls the fit test directly rather than `_structural_width_mismatch`, which
+    now requires two vectors to have an opinion. Routing one vector through the
+    batch rule made this check silently answer None for every record.
     """
-    detail = _structural_width_mismatch([vector], pinned_column_dims)
+    detail = _column_rejects_width(len(vector), pinned_column_dims)
     if detail is None:
         return
     if await _live_column_dims(session) == pinned_column_dims:

--- a/backend/app/processing/embeddings/backfill.py
+++ b/backend/app/processing/embeddings/backfill.py
@@ -153,6 +153,74 @@ async def _live_column_dims(session: AsyncSession) -> int | None:
     ).scalar_one_or_none()
 
 
+def _generated_width_mismatch(
+    vector: list[float], pinned_column_dims: int | None
+) -> str | None:
+    """Describe a generated vector the column will not accept, or None if it will.
+
+    fix(#1533): the sibling class to drift, and the one the non-force path is
+    otherwise blind to. Drift is a width that MOVES; this is a width that was
+    already wrong when the run started, which every comparison guard is
+    correctly silent about because nothing changed. The force path catches it in
+    `_preflight_embedding`, ahead of the DELETE. The non-force path has no
+    pre-flight, so the first batch insert failed the typmod, the batch was
+    retried per record, and each retry spent a provider call before dying on the
+    same error.
+
+    Deliberately NOT a pre-flight on the non-force path, which is the obvious
+    symmetry and is wrong twice over. It costs a provider call per run, on a
+    path that destroys nothing and therefore has nothing to promise. Worse, it
+    aborts a run that a single transient provider failure would otherwise
+    survive: `test_batch_errors_do_not_stop_backfill` and
+    `test_failed_batch_retries_per_record` pin the #449 contract that a failed
+    batch is retried per record and only the bad records count, and a pre-flight
+    consuming the first provider call turns a partial success into no run at
+    all. Measured on the tree: adding one there fails 5 of the 7 tests in
+    `test_embedding_backfill.py`, two of them for that reason rather than for
+    test-double churn.
+
+    Asking the vector the provider ACTUALLY returned costs nothing extra, and it
+    answers the same question the pre-flight asks: will storage take this.
+
+    `isinstance` rather than `is not None`, because `scalar_one_or_none` answers
+    `int | None` and -1 means an unconstrained `vector`, which accepts any width
+    and so can never mismatch.
+    """
+    if not isinstance(pinned_column_dims, int) or pinned_column_dims <= 0:
+        return None
+    generated = len(vector)
+    if generated == pinned_column_dims:
+        return None
+    return (
+        f"the model produced {generated}-dimension vectors but "
+        f"catalog.record_embeddings.embedding is vector({pinned_column_dims})"
+    )
+
+
+async def _raise_on_generated_width(
+    vector: list[float],
+    pinned_column_dims: int | None,
+    processed: int,
+    error: type[RuntimeError],
+) -> None:
+    """Stop the run if the provider's vectors do not fit the column.
+
+    Raises `_PinDrift` from both call sites, so the broad handlers re-raise it
+    rather than retrying the batch record by record. Retrying is precisely the
+    behaviour this exists to prevent: every record would fail the same typmod,
+    one paid provider call at a time.
+    """
+    detail = _generated_width_mismatch(vector, pinned_column_dims)
+    if detail is None:
+        return
+    logger.error("backfill_aborted_width_mismatch", detail=detail, processed=processed)
+    raise error(
+        f"Embedding regeneration stopped after {processed} records: {detail}. "
+        "Re-save the embedding configuration in Settings so the column is "
+        "rebuilt, then re-run."
+    )
+
+
 async def _snapshot_embedding_config(
     session: AsyncSession,
 ) -> tuple[str, int | None, str | None]:
@@ -288,6 +356,11 @@ class _PinDrift(RuntimeError):
     per-record one instead of counting it as a bad input. It is a
     `RuntimeError`, so every caller that already treats this module's aborts as
     one — the admin route included — is unaffected.
+
+    fix(#1533): also carries the generated-width mismatch, which is not drift.
+    The name is narrower than the job: what the two handlers need is "a
+    run-stopping condition discovered with a batch already generated", and both
+    conditions want exactly the same treatment from them.
     """
 
 
@@ -380,6 +453,12 @@ async def _retry_batch_per_record(
                 created + made,
                 pinned_column_dims=pinned_column_dims,
                 error=_PinDrift,
+            )
+            # fix(#1533): per vector on this path, not per batch. This loop is
+            # where a mismatch costs a provider call per record, so it is the
+            # one that has to stop on the first.
+            await _raise_on_generated_width(
+                vector, pinned_column_dims, created + made, _PinDrift
             )
             session.add(
                 RecordEmbedding(
@@ -847,6 +926,14 @@ async def backfill_embeddings(session: AsyncSession, *, force: bool = False) -> 
                 created,
                 pinned_column_dims=pinned_column_dims,
                 error=_PinDrift,
+            )
+            # fix(#1533): the first vector stands in for the batch. A provider
+            # answering one width for one input and another for the next is not
+            # a shape worth a per-vector loop here, and it is not missed either:
+            # the odd insert fails, the batch drops into the retry loop, and
+            # every vector is checked on its own down there.
+            await _raise_on_generated_width(
+                vectors[0], pinned_column_dims, created, _PinDrift
             )
             for (record_id, content), vector in zip(batch, vectors):
                 session.add(

--- a/backend/app/processing/embeddings/backfill.py
+++ b/backend/app/processing/embeddings/backfill.py
@@ -266,47 +266,57 @@ def _raise_on_structural_width(
 
 async def _raise_on_retry_vector_width(
     session: AsyncSession,
+    pinned: tuple[str, int | None, str | None],
     vector: list[float],
     pinned_column_dims: int | None,
     processed: int,
 ) -> None:
-    """Judge one retried record's vector: bad record, or a column that moved?
+    """The retry's post-call bracket, plus a judgement on the vector it returned.
 
-    fix(#1579 review, codex P2): the retry path has one input, so agreement
-    across inputs — the signal the batch path reads — carries no information
-    here. The evidence has to come from storage instead: if the live column
-    still is what the run pinned, a vector that does not fit it is one bad
-    record and the caller counts it (#449). If the column has moved, every
-    remaining record will fail the same way and the run stops.
+    Two questions, in this order, because the second only makes sense once the
+    first is answered:
 
-    The read costs 0.32 ms against the ~3 ms the drift checks around it already
-    spend per record. It was paid even when a drift check sat immediately above
-    and could only agree with it, because a guard whose correctness rests on a
-    neighbouring call's position is one reorder away from silently converting a
-    structural storm into ten thousand counted errors.
+    1. Is the pinned configuration still the active one? This is the post-call
+       bracket #1525 review r6 installed on this path, restored here. It went
+       missing when the r3 review moved the batch's post-call check below the
+       flush so it could hold the relation lock: the check is still there, but
+       it now sits after an insert that raises on its own when the column has
+       moved to a different fixed width, so it never runs.
+    2. Does THIS vector fit that column? A mismatch against a column that has
+       not moved is one bad record, raised as `_AnomalousVectorWidth` so the
+       caller counts it and carries on (#449).
 
-    fix(#1579 review r3): that reorder then happened, for an unrelated reason —
-    the post-call drift check moved below the flush so it could hold the
-    relation lock. The nearest preceding one is now the PRE-call check, on the
-    far side of a provider round trip, so this read is no longer redundant at
-    all. It is the only thing standing between a column that moved during that
-    call and ten thousand counted errors.
+    fix(#1579 review r4, codex P2): the earlier revision asked (2) first and
+    returned early when the vector matched, so (1) went unasked whenever the
+    provider answered at the pinned width. A column that moved to a DIFFERENT
+    fixed width during the provider call then reached the flush, which raised
+    the typmod error, which the broad handler counted as a bad record. Every
+    record but the last was covered anyway, by the next one's pre-call check —
+    but on the last there is no next one, and the run reported "complete with
+    one error" for a configuration change. A misreport rather than a bad row,
+    and narrow, but the rule is easier to hold when it has no exceptions.
 
-    Calls the fit test directly rather than `_structural_width_mismatch`, which
-    now requires two vectors to have an opinion. Routing one vector through the
-    batch rule made this check silently answer None for every record.
+    Asking `_raise_on_pin_drift` rather than reading the width here and
+    phrasing the abort locally. The cheaper read (0.32 ms against ~3 ms) would
+    put a second author of "the column moved" in the module, and two places
+    that decide the same thing drift apart. One rule, one message.
+
+    Cost is one more full drift check per retried record: about 9 ms against the
+    ~0.22 s that record's provider call costs, so roughly 4% of a legitimate
+    per-record retry, and nothing at all on the storm this PR exists to stop,
+    which now ends on its first record.
     """
+    await _raise_on_pin_drift(
+        session,
+        pinned,
+        processed,
+        pinned_column_dims=pinned_column_dims,
+        error=_PinDrift,
+    )
     detail = _column_rejects_width(len(vector), pinned_column_dims)
     if detail is None:
         return
-    if await _live_column_dims(session) == pinned_column_dims:
-        raise _AnomalousVectorWidth(detail)
-    logger.error("backfill_aborted_width_mismatch", detail=detail, processed=processed)
-    raise _PinDrift(
-        f"Embedding regeneration stopped after {processed} records: {detail}. "
-        "Re-save the embedding configuration in Settings so the column is "
-        "rebuilt, then re-run."
-    )
+    raise _AnomalousVectorWidth(detail)
 
 
 async def _snapshot_embedding_config(
@@ -546,9 +556,9 @@ async def _retry_batch_per_record(
             # Ahead of the insert, deliberately: it decides NOT to write, so it
             # needs no lock, and putting it after the flush would let the flush
             # raise the typmod error first and turn a named abort into a counted
-            # one.
+            # one. It carries the post-call drift bracket for the same reason.
             await _raise_on_retry_vector_width(
-                session, vector, pinned_column_dims, created + made
+                session, pinned, vector, pinned_column_dims, created + made
             )
             session.add(
                 RecordEmbedding(

--- a/backend/app/processing/embeddings/backfill.py
+++ b/backend/app/processing/embeddings/backfill.py
@@ -153,10 +153,21 @@ async def _live_column_dims(session: AsyncSession) -> int | None:
     ).scalar_one_or_none()
 
 
-def _generated_width_mismatch(
-    vector: list[float], pinned_column_dims: int | None
+class _AnomalousVectorWidth(RuntimeError):
+    """ONE record's vector does not fit a column that has not moved.
+
+    fix(#1579 review, codex P2): a bad record, not a broken run. Deliberately
+    NOT a `_PinDrift`, so the per-record handler counts it and carries on, which
+    is the #449 isolation this module has defended since. It is named rather
+    than a bare `RuntimeError` only so the compact per-record log line says what
+    happened (#1544 puts the qualified type in `error_type`).
+    """
+
+
+def _structural_width_mismatch(
+    vectors: list[list[float]], pinned_column_dims: int | None
 ) -> str | None:
-    """Describe a generated vector the column will not accept, or None if it will.
+    """Describe vectors that UNIFORMLY do not fit the column, or None otherwise.
 
     fix(#1533): the sibling class to drift, and the one the non-force path is
     otherwise blind to. Drift is a width that MOVES; this is a width that was
@@ -179,8 +190,20 @@ def _generated_width_mismatch(
     `test_embedding_backfill.py`, two of them for that reason rather than for
     test-double churn.
 
-    Asking the vector the provider ACTUALLY returned costs nothing extra, and it
-    answers the same question the pre-flight asks: will storage take this.
+    Asking the vectors the provider ACTUALLY returned costs nothing extra, and
+    it answers the same question the pre-flight asks: will storage take this.
+
+    fix(#1579 review, codex P2): UNIFORMLY is the whole distinction, and an
+    earlier revision missed it — any single wrong-width vector stopped the run,
+    which broke the same #449 isolation the paragraph above defends. What makes
+    a mismatch structural is AGREEMENT ACROSS INPUTS: a provider does not answer
+    one anomalous width for all 128 texts by accident, whereas a column that was
+    already wrong, or that has just been rebuilt, produces exactly that. Mixed
+    widths mean one bad input among good ones, so this returns None and lets the
+    batch fail into the per-record retry, where each vector is judged alone.
+
+    An empty `vectors` yields no width to agree on, so it is not structural
+    either; the batch simply fails and is retried.
 
     `isinstance` rather than `is not None`, because `scalar_one_or_none` answers
     `int | None` and -1 means an unconstrained `vector`, which accepts any width
@@ -188,7 +211,10 @@ def _generated_width_mismatch(
     """
     if not isinstance(pinned_column_dims, int) or pinned_column_dims <= 0:
         return None
-    generated = len(vector)
+    widths = {len(vector) for vector in vectors}
+    if len(widths) != 1:
+        return None
+    generated = widths.pop()
     if generated == pinned_column_dims:
         return None
     return (
@@ -197,24 +223,51 @@ def _generated_width_mismatch(
     )
 
 
-async def _raise_on_generated_width(
-    vector: list[float],
-    pinned_column_dims: int | None,
-    processed: int,
-    error: type[RuntimeError],
+def _raise_on_structural_width(
+    vectors: list[list[float]], pinned_column_dims: int | None, processed: int
 ) -> None:
-    """Stop the run if the provider's vectors do not fit the column.
-
-    Raises `_PinDrift` from both call sites, so the broad handlers re-raise it
-    rather than retrying the batch record by record. Retrying is precisely the
-    behaviour this exists to prevent: every record would fail the same typmod,
-    one paid provider call at a time.
-    """
-    detail = _generated_width_mismatch(vector, pinned_column_dims)
+    """Stop the run when a whole batch's vectors do not fit the column."""
+    detail = _structural_width_mismatch(vectors, pinned_column_dims)
     if detail is None:
         return
     logger.error("backfill_aborted_width_mismatch", detail=detail, processed=processed)
-    raise error(
+    raise _PinDrift(
+        f"Embedding regeneration stopped after {processed} records: {detail}. "
+        "Re-save the embedding configuration in Settings so the column is "
+        "rebuilt, then re-run."
+    )
+
+
+async def _raise_on_retry_vector_width(
+    session: AsyncSession,
+    vector: list[float],
+    pinned_column_dims: int | None,
+    processed: int,
+) -> None:
+    """Judge one retried record's vector: bad record, or a column that moved?
+
+    fix(#1579 review, codex P2): the retry path has one input, so agreement
+    across inputs — the signal the batch path reads — carries no information
+    here. The evidence has to come from storage instead: if the live column
+    still is what the run pinned, a vector that does not fit it is one bad
+    record and the caller counts it (#449). If the column has moved, every
+    remaining record will fail the same way and the run stops.
+
+    The post-call drift check two lines up already compares those same two
+    widths, so today this read can only agree with it. It is paid anyway, at
+    0.32 ms against the ~3 ms that check already spends per record, because the
+    alternative is a guard whose correctness depends on a neighbouring call
+    nobody is stopped from reordering — and getting it wrong silently converts a
+    structural storm into ten thousand counted errors, which is the outcome this
+    whole PR exists to prevent.
+    """
+    detail = _structural_width_mismatch([vector], pinned_column_dims)
+    if detail is None:
+        return
+    if await _live_column_dims(session) == pinned_column_dims:
+        raise _AnomalousVectorWidth(detail)
+    logger.error("backfill_aborted_width_mismatch", detail=detail, processed=processed)
+    raise _PinDrift(
         f"Embedding regeneration stopped after {processed} records: {detail}. "
         "Re-save the embedding configuration in Settings so the column is "
         "rebuilt, then re-run."
@@ -357,10 +410,12 @@ class _PinDrift(RuntimeError):
     `RuntimeError`, so every caller that already treats this module's aborts as
     one — the admin route included — is unaffected.
 
-    fix(#1533): also carries the generated-width mismatch, which is not drift.
-    The name is narrower than the job: what the two handlers need is "a
+    fix(#1533): also carries a STRUCTURAL generated-width mismatch, which is not
+    drift. The name is narrower than the job: what the two handlers need is "a
     run-stopping condition discovered with a batch already generated", and both
-    conditions want exactly the same treatment from them.
+    conditions want exactly the same treatment from them. An ISOLATED width
+    mismatch is `_AnomalousVectorWidth` instead, precisely so it does NOT get
+    this treatment.
     """
 
 
@@ -456,9 +511,11 @@ async def _retry_batch_per_record(
             )
             # fix(#1533): per vector on this path, not per batch. This loop is
             # where a mismatch costs a provider call per record, so it is the
-            # one that has to stop on the first.
-            await _raise_on_generated_width(
-                vector, pinned_column_dims, created + made, _PinDrift
+            # one that has to stop on the first — but only when the column has
+            # moved. One record's vector against a column that has not moved is
+            # a bad record, and the handler below counts it (#1579 review).
+            await _raise_on_retry_vector_width(
+                session, vector, pinned_column_dims, created + made
             )
             session.add(
                 RecordEmbedding(
@@ -927,14 +984,12 @@ async def backfill_embeddings(session: AsyncSession, *, force: bool = False) -> 
                 pinned_column_dims=pinned_column_dims,
                 error=_PinDrift,
             )
-            # fix(#1533): the first vector stands in for the batch. A provider
-            # answering one width for one input and another for the next is not
-            # a shape worth a per-vector loop here, and it is not missed either:
-            # the odd insert fails, the batch drops into the retry loop, and
-            # every vector is checked on its own down there.
-            await _raise_on_generated_width(
-                vectors[0], pinned_column_dims, created, _PinDrift
-            )
+            # fix(#1533): the whole batch, not the first vector. Agreement
+            # across inputs is what makes a width mismatch structural rather
+            # than one bad record, so a batch of mixed widths deliberately does
+            # NOT stop here: it fails its insert, drops into the retry loop, and
+            # every vector is judged on its own down there (#1579 review).
+            _raise_on_structural_width(vectors, pinned_column_dims, created)
             for (record_id, content), vector in zip(batch, vectors):
                 session.add(
                     RecordEmbedding(

--- a/backend/app/processing/embeddings/backfill.py
+++ b/backend/app/processing/embeddings/backfill.py
@@ -279,13 +279,18 @@ async def _raise_on_retry_vector_width(
     record and the caller counts it (#449). If the column has moved, every
     remaining record will fail the same way and the run stops.
 
-    The post-call drift check two lines up already compares those same two
-    widths, so today this read can only agree with it. It is paid anyway, at
-    0.32 ms against the ~3 ms that check already spends per record, because the
-    alternative is a guard whose correctness depends on a neighbouring call
-    nobody is stopped from reordering — and getting it wrong silently converts a
-    structural storm into ten thousand counted errors, which is the outcome this
-    whole PR exists to prevent.
+    The read costs 0.32 ms against the ~3 ms the drift checks around it already
+    spend per record. It was paid even when a drift check sat immediately above
+    and could only agree with it, because a guard whose correctness rests on a
+    neighbouring call's position is one reorder away from silently converting a
+    structural storm into ten thousand counted errors.
+
+    fix(#1579 review r3): that reorder then happened, for an unrelated reason —
+    the post-call drift check moved below the flush so it could hold the
+    relation lock. The nearest preceding one is now the PRE-call check, on the
+    far side of a provider round trip, so this read is no longer redundant at
+    all. It is the only thing standing between a column that moved during that
+    call and ten thousand counted errors.
 
     Calls the fit test directly rather than `_structural_width_mismatch`, which
     now requires two vectors to have an opinion. Routing one vector through the
@@ -532,18 +537,16 @@ async def _retry_batch_per_record(
                 dimensions=embedding_dims,
                 base_url=base_url,
             )
-            await _raise_on_pin_drift(
-                session,
-                pinned,
-                created + made,
-                pinned_column_dims=pinned_column_dims,
-                error=_PinDrift,
-            )
             # fix(#1533): per vector on this path, not per batch. This loop is
             # where a mismatch costs a provider call per record, so it is the
             # one that has to stop on the first — but only when the column has
             # moved. One record's vector against a column that has not moved is
             # a bad record, and the handler below counts it (#1579 review).
+            #
+            # Ahead of the insert, deliberately: it decides NOT to write, so it
+            # needs no lock, and putting it after the flush would let the flush
+            # raise the typmod error first and turn a named abort into a counted
+            # one.
             await _raise_on_retry_vector_width(
                 session, vector, pinned_column_dims, created + made
             )
@@ -554,6 +557,17 @@ async def _retry_batch_per_record(
                     model_name=model_name,
                     content_hash=compute_content_hash(content),
                 )
+            )
+            # fix(#1579 review r3, codex P2): flush BEFORE the post-call check,
+            # so the check runs holding the lock its answer depends on. See the
+            # same reorder on the batch path.
+            await session.flush()
+            await _raise_on_pin_drift(
+                session,
+                pinned,
+                created + made,
+                pinned_column_dims=pinned_column_dims,
+                error=_PinDrift,
             )
             await session.commit()
             made += 1
@@ -999,6 +1013,44 @@ async def backfill_embeddings(session: AsyncSession, *, force: bool = False) -> 
                 dimensions=embedding_dims,
                 base_url=base_url,
             )
+            # fix(#1533): the whole batch, not the first vector. Agreement
+            # across inputs is what makes a width mismatch structural rather
+            # than one bad record, so a batch of mixed widths deliberately does
+            # NOT stop here: it fails its insert, drops into the retry loop, and
+            # every vector is judged on its own down there (#1579 review).
+            #
+            # Ahead of the inserts because it decides not to write at all, so
+            # unlike the drift check below it needs no lock to be sound.
+            _raise_on_structural_width(vectors, pinned_column_dims, created)
+            for (record_id, content), vector in zip(batch, vectors):
+                session.add(
+                    RecordEmbedding(
+                        record_id=record_id,
+                        embedding=vector,
+                        model_name=model_name,
+                        content_hash=compute_content_hash(content),
+                    )
+                )
+            # fix(#1579 review r3, codex P2): FLUSH, then check, then commit.
+            # The check reads `pg_attribute`, which locks nothing, so checking
+            # before the rows were sent left a window in which an `ALTER TABLE`
+            # could take ACCESS EXCLUSIVE, commit, and be missed entirely. When
+            # that ALTER widened the column to an unconstrained `vector` the
+            # old-width inserts then SUCCEEDED, and the run reported success
+            # over a column that had moved under it — the one outcome
+            # `_pinned_config_drift` says a widening change must not produce.
+            #
+            # The flush takes RowExclusiveLock on the relation, which ACCESS
+            # EXCLUSIVE conflicts with. So an ALTER that landed first is seen by
+            # the check (and these rows roll back with the abort), and one that
+            # arrives after waits for our commit. Check-then-act is only sound
+            # while the thing checked cannot move, and this is what stops it
+            # moving.
+            #
+            # A flush that RAISES because the column moved to a different fixed
+            # width is not lost: the batch handler retries per record, and the
+            # retry's pre-call check reads the new width and stops the run.
+            await session.flush()
             # fix(#1525 review r5, codex P2): and again before ACCEPTING the
             # batch, not only before requesting it. The check above has no
             # successor for the LAST batch, so an edit landing during that
@@ -1014,21 +1066,6 @@ async def backfill_embeddings(session: AsyncSession, *, force: bool = False) -> 
                 pinned_column_dims=pinned_column_dims,
                 error=_PinDrift,
             )
-            # fix(#1533): the whole batch, not the first vector. Agreement
-            # across inputs is what makes a width mismatch structural rather
-            # than one bad record, so a batch of mixed widths deliberately does
-            # NOT stop here: it fails its insert, drops into the retry loop, and
-            # every vector is judged on its own down there (#1579 review).
-            _raise_on_structural_width(vectors, pinned_column_dims, created)
-            for (record_id, content), vector in zip(batch, vectors):
-                session.add(
-                    RecordEmbedding(
-                        record_id=record_id,
-                        embedding=vector,
-                        model_name=model_name,
-                        content_hash=compute_content_hash(content),
-                    )
-                )
             await session.commit()
             created += len(batch)
         except _PinDrift:

--- a/backend/app/processing/embeddings/backfill.py
+++ b/backend/app/processing/embeddings/backfill.py
@@ -40,6 +40,28 @@ _BATCH_SIZE = 128
 _PREFLIGHT_TEXT = "geolens embedding preflight"
 
 
+async def _live_column_dims(session: AsyncSession) -> int | None:
+    """Read the declared width of the embedding column, straight from storage.
+
+    pgvector puts the declared dimension straight in `atttypmod` (no -4 offset),
+    and -1 means an unconstrained `vector`, which accepts any width.
+
+    Storage rather than `EMBEDDING_DIMS`, because the two are written by
+    different code at different times and the whole point of asking is that they
+    can disagree. Measured on the scratch catalog: 0.32 ms median, against 2.7 ms
+    for the config reads it runs beside.
+    """
+    return (
+        await session.execute(
+            text(
+                "SELECT atttypmod FROM pg_attribute "
+                "WHERE attrelid = 'catalog.record_embeddings'::regclass "
+                "AND attname = 'embedding' AND NOT attisdropped"
+            )
+        )
+    ).scalar_one_or_none()
+
+
 async def _snapshot_embedding_config(
     session: AsyncSession,
 ) -> tuple[str, int | None, str | None]:
@@ -118,12 +140,18 @@ async def _snapshot_embedding_config(
 
     # fix(#1525 review r2, codex P1): read the pinned values straight from the
     # DB. `PersistentConfig.get` answers from a PER-KEY cache, and
-    # `update_settings` commits the whole batch and only then evicts each key in
-    # turn (settings/router.py:338-345). During that eviction, reads of two
-    # different keys can land on opposite sides of one committed update, and
-    # comparing them cannot see it: two reads through the same stale entry agree
-    # with each other perfectly. `get_uncached` neither reads nor writes the
-    # cache, so these observe the committed state instead.
+    # `update_settings` commits the whole batch of setting writes before any
+    # cache entry is evicted (`apply_side_effects_batch`, after the commit in
+    # `update_settings`). A cached read can therefore land on the far side of a
+    # committed update, and comparing two of them cannot see it: two reads
+    # through the same stale entry agree with each other perfectly.
+    # `get_uncached` neither reads nor writes the cache, so these observe the
+    # committed state instead.
+    #
+    # The eviction was a per-key loop when this was written, which made the
+    # window wider still: two keys could be read on opposite sides of one
+    # update. #1543 made it a single batched step, which narrows the window
+    # without closing it, and does not change what these reads have to do.
     model_name = await resolve_embedding_model_name(session, uncached=True)
     if model_name == UNKNOWN_EMBEDDING_MODEL:
         # Loud, not silent: the admin route maps this to a 502 and a "failed"
@@ -177,10 +205,11 @@ async def _raise_on_pin_drift(
     pinned: tuple[str, int | None, str | None],
     processed: int,
     *,
+    pinned_column_dims: int | None,
     error: type[RuntimeError] = RuntimeError,
 ) -> None:
     """Stop the run if the configuration it pinned is no longer the active one."""
-    drift = await _pinned_config_drift(session, pinned)
+    drift = await _pinned_config_drift(session, pinned, pinned_column_dims)
     if drift is None:
         return
     logger.error("backfill_aborted_pin_drift", detail=drift, processed=processed)
@@ -201,6 +230,7 @@ async def _retry_batch_per_record(
     model_name: str,
     embedding_dims: int | None,
     base_url: str | None,
+    pinned_column_dims: int | None,
 ) -> tuple[int, int]:
     """Re-embed a failed batch one record at a time; return (created, errors).
 
@@ -213,6 +243,11 @@ async def _retry_batch_per_record(
 
     `created` is the run's running total, passed in only so an abort message
     can say how many records the run had written before it stopped.
+
+    `pinned_column_dims` is the storage width the run pinned, carried in so the
+    bracketing below covers it too. fix(#1533): a width that moves is what puts
+    this loop in its worst state, because the batch insert that failed and sent
+    the run here fails again for every record, one provider call at a time.
     """
     made = 0
     failed = 0
@@ -230,7 +265,13 @@ async def _retry_batch_per_record(
             # The check before the call is not redundant with the one after the
             # previous record's: that record may have FAILED, in which case its
             # post-call check never ran either.
-            await _raise_on_pin_drift(session, pinned, created + made, error=_PinDrift)
+            await _raise_on_pin_drift(
+                session,
+                pinned,
+                created + made,
+                pinned_column_dims=pinned_column_dims,
+                error=_PinDrift,
+            )
             [vector] = await generate_embeddings_batch(
                 [content],
                 session,
@@ -238,7 +279,13 @@ async def _retry_batch_per_record(
                 dimensions=embedding_dims,
                 base_url=base_url,
             )
-            await _raise_on_pin_drift(session, pinned, created + made, error=_PinDrift)
+            await _raise_on_pin_drift(
+                session,
+                pinned,
+                created + made,
+                pinned_column_dims=pinned_column_dims,
+                error=_PinDrift,
+            )
             session.add(
                 RecordEmbedding(
                     record_id=record_id,
@@ -269,7 +316,9 @@ async def _retry_batch_per_record(
 
 
 async def _pinned_config_drift(
-    session: AsyncSession, pinned: tuple[str, int | None, str | None]
+    session: AsyncSession,
+    pinned: tuple[str, int | None, str | None],
+    pinned_column_dims: int | None,
 ) -> str | None:
     """Describe how the live config has left the pinned one, or None if it has not.
 
@@ -280,6 +329,17 @@ async def _pinned_config_drift(
 
     Read the same way `_snapshot_embedding_config` reads, for the same reason:
     a cached read can agree with a stale entry and report no drift.
+
+    fix(#1533): the storage width is checked alongside the settings, because the
+    settings are only ONE of the routes it moves by. `update_settings` publishes
+    `embedding_dims` and then rebuilds the column, so the dimensions comparison
+    above catches that route within a batch. It catches nothing else, and the
+    column moves without a settings write in an ENV_ONLY_CONFIG deployment
+    (there is no settings row and no rebuild ever fires), after a hand
+    `ALTER TABLE`, after a restored dump, and after a rebuild that failed
+    partway. Measured on 1,000 records with the width moved by hand and the
+    settings row untouched: 1,009 provider calls and 1,000 errors reported as if
+    the provider were broken, against 2 calls and a named cause with this check.
 
     Two states are deliberately NOT treated as drift, because neither is
     evidence that the pinned configuration stopped being the right one:
@@ -312,6 +372,25 @@ async def _pinned_config_drift(
             f"the embedding dimensions changed from {dimensions!r} to {active_dims!r}"
         )
 
+    # fix(#1533): BEFORE the endpoint block, not after it, and not because of
+    # message quality. That block returns None from its `except`, so a
+    # deployment where the endpoint cannot be resolved would never reach a check
+    # placed below it — and an endpoint that will not resolve is exactly the
+    # kind of half-configured install where a column gets altered by hand. The
+    # settings comparisons stay ahead of this one so that when both have moved,
+    # the message names the admin action rather than its consequence.
+    #
+    # Any change counts, including one that widens the column or drops the
+    # constraint. A run that carried on would leave the table holding two vector
+    # widths under one model label, and the inserts that make that happen are
+    # the ones that SUCCEED, so nothing else would report it.
+    active_column_dims = await _live_column_dims(session)
+    if active_column_dims != pinned_column_dims:
+        return (
+            f"the embedding column width changed from vector({pinned_column_dims}) "
+            f"to vector({active_column_dims})"
+        )
+
     try:
         active_base_url = await resolve_embedding_base_url(session)
     except (
@@ -326,7 +405,9 @@ async def _pinned_config_drift(
 
 
 async def _preflight_embedding(
-    session: AsyncSession, pinned: tuple[str, int | None, str | None]
+    session: AsyncSession,
+    pinned: tuple[str, int | None, str | None],
+    pinned_column_dims: int | None,
 ) -> None:
     """Generate one throwaway embedding to prove regeneration can work.
 
@@ -397,19 +478,17 @@ async def _preflight_embedding(
     # deployments, where the model comes from the environment, no settings
     # write happens, and therefore no rebuild is ever triggered.
     #
-    # Read the width off the live column rather than trusting EMBEDDING_DIMS:
-    # the setting is what disagreed with storage in the first place. pgvector
-    # puts the declared dimension straight in atttypmod (no -4 offset), and -1
-    # means an unconstrained `vector`, which accepts any width.
-    column_dims = (
-        await session.execute(
-            text(
-                "SELECT atttypmod FROM pg_attribute "
-                "WHERE attrelid = 'catalog.record_embeddings'::regclass "
-                "AND attname = 'embedding' AND NOT attisdropped"
-            )
-        )
-    ).scalar_one_or_none()
+    # The width comes off the live column rather than EMBEDDING_DIMS (the
+    # setting is what disagreed with storage in the first place), and it is the
+    # caller's read rather than one of this function's own.
+    #
+    # fix(#1533): one read, deliberately. The caller pins that same value and
+    # stops the run if the column stops matching it, so what this proves is not
+    # "the width fitted a moment ago" but "the width fits, and the run will not
+    # outlive it". Reading storage twice would put a window between the two: a
+    # rebuild landing inside it passes this check against the old width and gets
+    # pinned at the new one, so nothing afterwards has anything to notice.
+    column_dims = pinned_column_dims
 
     generated = len(vectors[0])
     if column_dims is not None and column_dims > 0 and generated != column_dims:
@@ -448,6 +527,11 @@ async def backfill_embeddings(session: AsyncSession, *, force: bool = False) -> 
     port = get_processing_port()
 
     pinned: tuple[str, int | None, str | None] | None = None
+    # fix(#1533): the storage width the run commits to, pinned beside the config
+    # rather than inside it. It is not configuration — it is read off
+    # `pg_attribute` rather than `PersistentConfig`, and the two disagree often
+    # enough that this whole check exists.
+    pinned_column_dims: int | None = None
 
     if force:
         Record = port.get_record_orm_class()
@@ -485,6 +569,7 @@ async def backfill_embeddings(session: AsyncSession, *, force: bool = False) -> 
         # could not cover this branch: by the time that query runs on the force
         # path the vectors are already gone.
         pinned = await _snapshot_embedding_config(session)
+        pinned_column_dims = await _live_column_dims(session)
 
         # fix(#1511 review r3, codex P1): the checks above test proxies for
         # "regeneration will work". This one tests the property itself, because
@@ -498,7 +583,7 @@ async def backfill_embeddings(session: AsyncSession, *, force: bool = False) -> 
         # One real embedding proves the live config can produce a vector, and
         # covers the modes nobody has enumerated yet: provider down, revoked
         # key, exhausted quota, dimensions the model rejects.
-        await _preflight_embedding(session, pinned)
+        await _preflight_embedding(session, pinned, pinned_column_dims)
 
         # DESTRUCTIVE-FIRST, DELIBERATELY (#1549). This commits before the run
         # knows it can finish, so a drift abort in the batch loop below leaves
@@ -588,8 +673,12 @@ async def backfill_embeddings(session: AsyncSession, *, force: bool = False) -> 
     # name a model, and a model served by two endpoints is two vector spaces
     # under one label; on the shipped provider the same edit instead makes every
     # remaining batch raise, which abandons the rest of the catalog.
+    # fix(#1533): the storage width is pinned in the same two places and for the
+    # same reason. On the force path it is the value the pre-flight was measured
+    # against, so it is read up there rather than re-read here.
     if pinned is None:
         pinned = await _snapshot_embedding_config(session)
+        pinned_column_dims = await _live_column_dims(session)
     model_name, embedding_dims, base_url = pinned
 
     # Build embeddable (record_id, content_text) pairs; empty content skips.
@@ -634,7 +723,9 @@ async def backfill_embeddings(session: AsyncSession, *, force: bool = False) -> 
         # batches would then only surface after the next batch had already been
         # generated and paid for. One config read per batch is the cheaper half
         # of that trade.
-        await _raise_on_pin_drift(session, pinned, created)
+        await _raise_on_pin_drift(
+            session, pinned, created, pinned_column_dims=pinned_column_dims
+        )
 
         batch = items[start : start + _BATCH_SIZE]
         try:
@@ -653,7 +744,13 @@ async def backfill_embeddings(session: AsyncSession, *, force: bool = False) -> 
             # Checking here means the batch in flight is discarded rather than
             # committed, so the run stops without adding a row nothing will
             # match. `_PinDrift` is re-raised past the batch handler below.
-            await _raise_on_pin_drift(session, pinned, created, error=_PinDrift)
+            await _raise_on_pin_drift(
+                session,
+                pinned,
+                created,
+                pinned_column_dims=pinned_column_dims,
+                error=_PinDrift,
+            )
             for (record_id, content), vector in zip(batch, vectors):
                 session.add(
                     RecordEmbedding(
@@ -688,6 +785,7 @@ async def backfill_embeddings(session: AsyncSession, *, force: bool = False) -> 
                 model_name=model_name,
                 embedding_dims=embedding_dims,
                 base_url=base_url,
+                pinned_column_dims=pinned_column_dims,
             )
             created += made
             errors += failed

--- a/backend/tests/test_embedding_backfill_column_drift_1533.py
+++ b/backend/tests/test_embedding_backfill_column_drift_1533.py
@@ -488,3 +488,105 @@ async def test_a_one_record_batch_does_not_read_as_structural(
     assert await _embedding_count(test_db_session) == result["created"]
     # The column never moved, which is what made the one mismatch isolated.
     assert await _column_dims() == start_width
+
+
+@pytest.mark.anyio
+async def test_the_pre_commit_check_holds_the_relation_lock(
+    test_db_session, monkeypatch
+):
+    """Check-then-act is only sound while the thing checked cannot move.
+
+    fix(#1579 review r3, codex P2): the pre-commit drift check reads
+    `pg_attribute`, which locks nothing. Running it before the rows were sent
+    left a window in which an `ALTER TABLE` could take ACCESS EXCLUSIVE, commit,
+    and be missed entirely — and when that ALTER widens the column to an
+    unconstrained `vector`, the old-width inserts then SUCCEED and the run
+    reports success over a column that moved under it. That is exactly the
+    outcome `_pinned_config_drift` says a widening change must not produce.
+
+    Flushing first takes RowExclusiveLock on the relation, which ACCESS
+    EXCLUSIVE conflicts with, so the check reads a width that cannot change
+    until this transaction ends.
+
+    The ALTER is fired deterministically, the instant the check returns, rather
+    than raced: the window is a known one and constructing it beats hoping to
+    hit it. What proves the two sides genuinely contended is not the ordering
+    but the outcome — Postgres reports `lock_not_available`, which it can only
+    do if something else was holding a conflicting lock at that moment.
+    """
+    from sqlalchemy import text as sa_text
+    from sqlalchemy.ext.asyncio import create_async_engine
+
+    from app.core.config import settings as app_settings
+
+    start_width = await _column_dims()
+    await _seed(test_db_session, "Lock Window", start_width)
+
+    outcome: list[str] = []
+
+    async def _widen_column_from_another_connection() -> None:
+        """What a hand `ALTER` does, from a connection this run does not own."""
+        engine = create_async_engine(
+            app_settings.test_database_url, isolation_level="AUTOCOMMIT"
+        )
+        try:
+            async with engine.connect() as conn:
+                await conn.execute(sa_text("SET lock_timeout = '750ms'"))
+                await conn.execute(
+                    sa_text(
+                        "ALTER TABLE catalog.record_embeddings "
+                        "ALTER COLUMN embedding TYPE vector USING embedding::vector"
+                    )
+                )
+            outcome.append("committed")
+        except Exception as exc:  # noqa: BLE001 - the outcome IS the assertion
+            # Matched on the message rather than the exception class: the
+            # asyncpg dialect wraps every driver error in one adapter type, so
+            # the class name alone cannot tell a lock timeout from anything else.
+            message = str(getattr(exc, "orig", exc))
+            outcome.append(
+                "blocked" if "lock timeout" in message else f"other: {message[:160]}"
+            )
+        finally:
+            await engine.dispose()
+
+    original_check = backfill_module._raise_on_pin_drift
+
+    async def _check_then_widen(*args, **kwargs):
+        await original_check(*args, **kwargs)
+        # The SECOND call is the pre-commit one on either ordering: the first is
+        # the batch loop's own pre-flight check, before any provider call.
+        if len(outcome) == 0 and getattr(_check_then_widen, "seen", 0) == 1:
+            await _widen_column_from_another_connection()
+        _check_then_widen.seen = getattr(_check_then_widen, "seen", 0) + 1
+
+    _check_then_widen.seen = 0
+    monkeypatch.setattr(backfill_module, "_raise_on_pin_drift", _check_then_widen)
+
+    _pin_model(monkeypatch)
+    monkeypatch.setattr(
+        backfill_module,
+        "generate_embeddings_batch",
+        _provider([], start_width),
+    )
+
+    try:
+        result = await backfill_module.backfill_embeddings(test_db_session, force=True)
+
+        # Non-vacuity first: the ALTER really was attempted, in the window.
+        assert outcome, "the hook never fired, so nothing was tested"
+
+        # Then the damage, before the mechanism. An unguarded tree fails here,
+        # on a run that reported success over a column it no longer matches,
+        # rather than on the lock error being absent.
+        assert await _column_dims() == start_width, (
+            "the column moved during the run and the run did not notice"
+        )
+        assert result["created"] > 0, result
+
+        # And the mechanism that prevented it. Postgres can only answer this
+        # while something else holds a conflicting lock, so it is also the
+        # evidence that the two sides genuinely overlapped.
+        assert outcome == ["blocked"], outcome
+    finally:
+        await _set_column_dims(test_db_session, start_width)

--- a/backend/tests/test_embedding_backfill_column_drift_1533.py
+++ b/backend/tests/test_embedding_backfill_column_drift_1533.py
@@ -439,3 +439,52 @@ async def test_one_anomalous_vector_width_costs_one_record_not_the_run(
 
     # And the column never moved, which is what made it isolated.
     assert await _column_dims() == start_width
+
+
+@pytest.mark.anyio
+async def test_a_one_record_batch_does_not_read_as_structural(
+    test_db_session, monkeypatch
+):
+    """One input agrees with itself, which is no evidence at all (#1579 review r2).
+
+    The batch rule calls a width mismatch structural when every vector in the
+    batch shares it. With a single-record batch that test is vacuous: one
+    anomalous vector satisfies it, and the run stopped over one bad record —
+    the same isolation bug as the retry path had, surviving at the one batch
+    size where the batch path has no more evidence than the retry path does.
+
+    A catalog sized 1 mod `_BATCH_SIZE` produces exactly that batch as its last.
+    `_BATCH_SIZE` is patched to 1 rather than seeding 129 records: it makes
+    EVERY batch a singleton, so the anomalous record lands in one whatever order
+    the run selects records in, and it does not depend on how many records other
+    tests left on this worker's database.
+    """
+    start_width = await _column_dims()
+    odd_width = 768 if start_width != 768 else 384
+    odd_marker = "Singleton Batch Anomaly"
+
+    user_id = await get_user_id(test_db_session, "admin")
+    for index in range(_SEEDED):
+        await create_dataset(
+            test_db_session, created_by=user_id, name=f"Singleton Good {index}"
+        )
+    await create_dataset(test_db_session, created_by=user_id, name=odd_marker)
+    await test_db_session.commit()
+
+    _pin_model(monkeypatch)
+    monkeypatch.setattr(backfill_module, "_BATCH_SIZE", 1)
+
+    async def _embed(texts, _session, **_kwargs):
+        return [
+            [0.1] * (odd_width if odd_marker in text else start_width) for text in texts
+        ]
+
+    monkeypatch.setattr(backfill_module, "generate_embeddings_batch", _embed)
+
+    result = await backfill_module.backfill_embeddings(test_db_session, force=True)
+
+    assert result["errors"] == 1, result
+    assert result["created"] >= _SEEDED, result
+    assert await _embedding_count(test_db_session) == result["created"]
+    # The column never moved, which is what made the one mismatch isolated.
+    assert await _column_dims() == start_width

--- a/backend/tests/test_embedding_backfill_column_drift_1533.py
+++ b/backend/tests/test_embedding_backfill_column_drift_1533.py
@@ -590,3 +590,79 @@ async def test_the_pre_commit_check_holds_the_relation_lock(
         assert outcome == ["blocked"], outcome
     finally:
         await _set_column_dims(test_db_session, start_width)
+
+
+@pytest.mark.anyio
+async def test_a_move_during_the_last_retry_is_drift_not_a_counted_error(
+    test_db_session, monkeypatch
+):
+    """The last retried record has no successor to catch what it missed.
+
+    fix(#1579 review r4, codex P2): the retry's width judgement asked "does this
+    vector fit?" before "is the column still the one we pinned?", and returned
+    early when the vector matched. A column that moved to a DIFFERENT fixed
+    width during the provider call therefore went unnoticed: the flush raised
+    the typmod error, the broad handler counted it as a bad record, and the run
+    finished reporting one error where it should have reported a configuration
+    change. Every other record is covered by the next one's pre-call check. The
+    last one has no next.
+
+    Reaching that state needs a retry loop with exactly one record in it, so the
+    run is set up as a non-force run over a catalog where exactly one record
+    lacks a vector: every other record is given one first. The batch call then
+    fails for a reason of its own, which is what opens the retry loop, and the
+    ALTER fires during the retry's own provider call.
+    """
+    from sqlalchemy import text as sa_text
+
+    start_width = await _column_dims()
+    moved_width = 768 if start_width != 768 else 384
+
+    # Every existing record gets a vector under the pinned model, so the
+    # non-force selection below is exactly the one record seeded after it.
+    await test_db_session.execute(
+        sa_text(
+            "INSERT INTO catalog.record_embeddings "
+            "(record_id, embedding, model_name, content_hash) "
+            "SELECT r.id, (SELECT ('[' || string_agg('0.01', ',') || ']')"
+            f"::vector({start_width}) FROM generate_series(1, {start_width})), "
+            f"'{_MODEL}', md5(r.id::text) FROM catalog.records r "
+            "ON CONFLICT (record_id, model_name) DO NOTHING"
+        )
+    )
+    user_id = await get_user_id(test_db_session, "admin")
+    await create_dataset(test_db_session, created_by=user_id, name="Last Retry Move")
+    await test_db_session.commit()
+
+    _pin_model(monkeypatch)
+    calls: list[int] = []
+
+    async def _embed(texts, _session, **_kwargs):
+        calls.append(len(texts))
+        if len(calls) == 1:
+            # The batch's own call. Failing it is what opens the retry loop.
+            raise RuntimeError("provider rejected this batch")
+        if len(calls) == 2:
+            # The retry's call for the only record there is. The column moves
+            # while it is in flight.
+            await test_db_session.commit()
+            await _set_column_dims(test_db_session, moved_width)
+        return [[0.1] * start_width for _ in texts]
+
+    monkeypatch.setattr(backfill_module, "generate_embeddings_batch", _embed)
+
+    try:
+        with pytest.raises(
+            RuntimeError, match="embedding column width changed"
+        ) as caught:
+            await backfill_module.backfill_embeddings(test_db_session)
+
+        # The message names the width it moved TO, so the operator is told what
+        # happened rather than that one record failed.
+        assert f"vector({moved_width})" in str(caught.value), str(caught.value)
+        # Non-vacuity: the run really did reach the retry loop, and the ALTER
+        # really did fire inside it.
+        assert calls == [1, 1], calls
+        assert await _column_dims() == moved_width
+    finally:
+        await _set_column_dims(test_db_session, start_width)

--- a/backend/tests/test_embedding_backfill_column_drift_1533.py
+++ b/backend/tests/test_embedding_backfill_column_drift_1533.py
@@ -1,0 +1,326 @@
+"""A backfill must stop when the column moves under it, by ANY route (#1533).
+
+#1539 made the run notice that the configuration it pinned had stopped being
+the active one, by re-reading `EMBEDDING_MODEL`, `EMBEDDING_DIMS` and the
+endpoint at every batch boundary. That closes the settings route: `update_settings`
+commits `embedding_dims` and only then calls `rebuild_embedding_column`, so the
+dimensions comparison sees the change within one batch. Measured on the real
+`backfill_embeddings` over 1,000 records with the rebuild landing during the
+first batch: 2 provider calls, run aborted, cause named.
+
+It closes nothing else. The declared width of `catalog.record_embeddings.embedding`
+moves with no settings write at all in an `ENV_ONLY_CONFIG` deployment (no
+settings row, no rebuild ever fires), after a hand `ALTER TABLE`, after a
+restored dump, and after a rebuild that failed partway. The same measurement
+with the width moved by hand and the settings row untouched: 1,009 provider
+calls, 1,000 errors, and a result an operator cannot tell apart from a broken
+provider.
+
+So the drift check reads the live width off `pg_attribute` and compares it with
+the width the run pinned at the start. The tests below hold that:
+
+  - a hand `ALTER` stops the run after one batch, and names the column;
+  - it stops the RETRY path too, which is where the amplification lives: a batch
+    that fails for a reason of its own re-embeds every record individually, one
+    provider call each, and a check that only runs at batch boundaries never
+    sees them;
+  - a healthy run is not disturbed by the new check;
+  - the settings route still reports itself as a settings change, because both
+    comparisons fire there and the one naming the admin's action is the more
+    useful message.
+
+What none of this buys is data. The force path's DELETE commits before any of
+these checks can run, so the vectors are gone either way. What is bought is the
+work not done and a failure an operator can read.
+
+Requirements:
+  - Docker database must be running (docker compose up db)
+  - Alembic migrations must be applied
+"""
+
+import uuid
+
+import pytest
+from sqlalchemy import func, select
+
+from app.core.persistent_config import EMBEDDING_DIMS
+from app.processing.embeddings import backfill as backfill_module
+from app.processing.embeddings import helpers
+from app.processing.embeddings.models import RecordEmbedding
+
+from tests.alembic_helpers import fresh_query
+from tests.factories import create_dataset, get_user_id
+
+_MODEL = "column-drift-active-model"
+
+# Enough records that the run's one batch carries several of them, so "the batch
+# ran and nothing after it" is distinguishable from "one record was retried".
+_SEEDED = 3
+
+
+async def _column_dims() -> int:
+    """The declared width of the embedding column, read outside the test session."""
+    rows = await fresh_query(
+        "SELECT atttypmod FROM pg_attribute "
+        "WHERE attrelid = 'catalog.record_embeddings'::regclass "
+        "AND attname = 'embedding' AND NOT attisdropped"
+    )
+    return rows[0][0]
+
+
+async def _set_column_dims(session, new_dims: int) -> None:
+    """Move the column width the way anything but the settings route moves it.
+
+    The statements are `rebuild_embedding_column`'s, minus the settings write:
+    the rows go (a `vector` column cannot be retyped under them), the index goes
+    and comes back, and `app_settings` is never touched. That is what an
+    `ENV_ONLY_CONFIG` deployment, a hand `ALTER`, and a restored dump all look
+    like from the column's side.
+
+    The session is released first because this needs `ACCESS EXCLUSIVE` and the
+    test session holds `ACCESS SHARE` for as long as its transaction is open —
+    one bare SELECT is enough to open one, and this test file counts rows. The
+    `lock_timeout` is the backstop: a missed release fails the test in ten
+    seconds instead of hanging the worker on a lock nothing will release.
+    """
+    from sqlalchemy import text as sa_text
+    from sqlalchemy.ext.asyncio import create_async_engine
+
+    from app.core.config import settings as app_settings
+
+    await session.rollback()
+    engine = create_async_engine(
+        app_settings.test_database_url, isolation_level="AUTOCOMMIT"
+    )
+    try:
+        async with engine.connect() as conn:
+            await conn.execute(sa_text("SET lock_timeout = '10s'"))
+            await conn.execute(sa_text("DELETE FROM catalog.record_embeddings"))
+            await conn.execute(
+                sa_text("DROP INDEX IF EXISTS catalog.ix_record_embeddings_hnsw")
+            )
+            await conn.execute(
+                sa_text(
+                    f"ALTER TABLE catalog.record_embeddings "
+                    f"ALTER COLUMN embedding TYPE vector({new_dims}) "
+                    f"USING embedding::vector({new_dims})"
+                )
+            )
+            await conn.execute(
+                sa_text(
+                    "CREATE INDEX ix_record_embeddings_hnsw "
+                    "ON catalog.record_embeddings USING hnsw "
+                    "(embedding vector_cosine_ops) WITH (m=16, ef_construction=64)"
+                )
+            )
+    finally:
+        await engine.dispose()
+
+
+async def _embedding_count(session) -> int:
+    result = await session.execute(select(func.count()).select_from(RecordEmbedding))
+    return result.scalar_one()
+
+
+async def _seed(session, name: str, width: int) -> None:
+    """`_SEEDED` datasets, each with an embedding, so the force DELETE has work."""
+    user_id = await get_user_id(session, "admin")
+    for index in range(_SEEDED):
+        dataset = await create_dataset(
+            session, created_by=user_id, name=f"{name} {index}"
+        )
+        session.add(
+            RecordEmbedding(
+                record_id=dataset.record_id,
+                embedding=[1.0] + [0.0] * (width - 1),
+                model_name=_MODEL,
+                content_hash=uuid.uuid4().hex[:64],
+            )
+        )
+    await session.commit()
+
+
+def _pin_model(monkeypatch) -> None:
+    """Pin what the snapshot and the drift check resolve, as the sibling suite does."""
+
+    async def _resolve(_session, **_kwargs):
+        return _MODEL
+
+    monkeypatch.setattr(helpers, "resolve_embedding_model_name", _resolve)
+
+
+def _provider(calls: list[int], width: int, *, on_first_batch=None, fail_batch=False):
+    """A stub that records its call sizes and can move the column mid-call.
+
+    The hook fires DURING the first real batch's provider call, which is the
+    window the issue's measurement identified: the force DELETE has committed
+    and no batch has been inserted yet.
+
+    "First real batch" is the SECOND call, by position. Not by input count: the
+    force path's pre-flight is always call one and a batch can legitimately hold
+    a single record, so sizing the calls would leave the hook unfired on a small
+    catalog and the test passing for the wrong reason.
+    """
+
+    async def _embed(texts, _session, **_kwargs):
+        calls.append(len(texts))
+        first_real_batch = len(calls) == 2
+        if first_real_batch and on_first_batch is not None:
+            await on_first_batch()
+        if first_real_batch and fail_batch:
+            raise RuntimeError("provider rejected this batch")
+        return [[0.1] * width for _ in texts]
+
+    return _embed
+
+
+@pytest.mark.anyio
+async def test_hand_altered_column_stops_the_run_after_one_batch(
+    test_db_session, monkeypatch
+):
+    """The route #1539's guard cannot see: the column moves, the settings do not."""
+    start_width = await _column_dims()
+    moved_width = 768 if start_width != 768 else 384
+    await _seed(test_db_session, "Column Drift Batch Path", start_width)
+    assert await _embedding_count(test_db_session) > 0
+
+    _pin_model(monkeypatch)
+    calls: list[int] = []
+
+    async def _move_column():
+        # The backfill's session holds an open read transaction at this point,
+        # and ALTER TABLE needs ACCESS EXCLUSIVE. Committing first is what lets
+        # the DDL through, and is what happens in production anyway, where the
+        # two run in different processes.
+        await test_db_session.commit()
+        await _set_column_dims(test_db_session, moved_width)
+
+    monkeypatch.setattr(
+        backfill_module,
+        "generate_embeddings_batch",
+        _provider(calls, start_width, on_first_batch=_move_column),
+    )
+
+    try:
+        with pytest.raises(RuntimeError, match="embedding column width changed"):
+            await backfill_module.backfill_embeddings(test_db_session, force=True)
+
+        # Pre-flight, then the one batch that discovers the move. Nothing after.
+        assert len(calls) == 2, calls
+        assert calls[0] == 1, "the first call is the force path's pre-flight"
+        assert calls[1] >= _SEEDED, (
+            "the second call carried the whole batch, so no per-record retry ran"
+        )
+        assert await _embedding_count(test_db_session) == 0
+    finally:
+        await _set_column_dims(test_db_session, start_width)
+
+    # The settings row was never in play. Without this the test would also pass
+    # against a guard that only reads settings, which is the thing it exists to
+    # rule out.
+    assert await EMBEDDING_DIMS.get_uncached(test_db_session) != moved_width
+
+
+@pytest.mark.anyio
+async def test_hand_altered_column_stops_the_per_record_retry_path(
+    test_db_session, monkeypatch
+):
+    """The batch fails for its own reason, and the retry loop must not run on.
+
+    This is where the cost is. A per-batch check alone is nearly useless here:
+    the width moves during the first batch's provider call, that batch fails
+    into the retry loop, and every record then makes its own provider call
+    before dying on the same typmod. Measured without the bracketing: 1,009
+    provider calls for 1,000 records.
+    """
+    start_width = await _column_dims()
+    moved_width = 768 if start_width != 768 else 384
+    await _seed(test_db_session, "Column Drift Retry Path", start_width)
+
+    _pin_model(monkeypatch)
+    calls: list[int] = []
+
+    async def _move_column():
+        await test_db_session.commit()
+        await _set_column_dims(test_db_session, moved_width)
+
+    monkeypatch.setattr(
+        backfill_module,
+        "generate_embeddings_batch",
+        _provider(calls, start_width, on_first_batch=_move_column, fail_batch=True),
+    )
+
+    try:
+        with pytest.raises(RuntimeError, match="embedding column width changed"):
+            await backfill_module.backfill_embeddings(test_db_session, force=True)
+
+        # Pre-flight, then the batch that failed. The retry loop stopped on its
+        # FIRST record, before spending a call on it.
+        assert len(calls) == 2, calls
+        assert await _embedding_count(test_db_session) == 0
+    finally:
+        await _set_column_dims(test_db_session, start_width)
+
+
+@pytest.mark.anyio
+async def test_a_healthy_force_run_is_not_stopped_by_the_new_check(
+    test_db_session, monkeypatch
+):
+    """Counterfactual: the aborts above are the moved column's doing.
+
+    A check that read the width wrong, or compared it against `EMBEDDING_DIMS`
+    rather than against what the run observed, would abort here too — an
+    `ENV_ONLY_CONFIG` deployment whose setting and column disagree at rest is a
+    normal state, not drift.
+    """
+    start_width = await _column_dims()
+    await _seed(test_db_session, "Column Drift Healthy Run", start_width)
+
+    _pin_model(monkeypatch)
+    calls: list[int] = []
+    monkeypatch.setattr(
+        backfill_module, "generate_embeddings_batch", _provider(calls, start_width)
+    )
+
+    result = await backfill_module.backfill_embeddings(test_db_session, force=True)
+
+    assert result["errors"] == 0, result
+    assert result["created"] > 0, result
+    assert await _embedding_count(test_db_session) == result["created"]
+
+
+@pytest.mark.anyio
+async def test_the_settings_route_still_reports_itself_as_a_settings_change(
+    test_db_session, monkeypatch
+):
+    """Both comparisons fire on the settings route; the useful one wins.
+
+    `update_settings` publishes `embedding_dims` and then rebuilds the column,
+    so by the time a run notices, both have moved. The message that names the
+    admin's action is worth more than the one that names its consequence, which
+    is why the settings comparisons stay ahead of the column read.
+    """
+    start_width = await _column_dims()
+    await _seed(test_db_session, "Column Drift Settings Route", start_width)
+
+    _pin_model(monkeypatch)
+    pinned_dims = await EMBEDDING_DIMS.get_uncached(test_db_session)
+    calls: list[int] = []
+
+    async def _publish_new_dims():
+        await test_db_session.commit()
+        await EMBEDDING_DIMS.set(test_db_session, (pinned_dims or 1536) + 8)
+
+    monkeypatch.setattr(
+        backfill_module,
+        "generate_embeddings_batch",
+        _provider(calls, start_width, on_first_batch=_publish_new_dims),
+    )
+
+    try:
+        with pytest.raises(RuntimeError, match="embedding dimensions changed"):
+            await backfill_module.backfill_embeddings(test_db_session, force=True)
+        assert len(calls) == 2, calls
+    finally:
+        await EMBEDDING_DIMS.set(test_db_session, pinned_dims)
+        await test_db_session.commit()

--- a/backend/tests/test_embedding_backfill_column_drift_1533.py
+++ b/backend/tests/test_embedding_backfill_column_drift_1533.py
@@ -374,3 +374,68 @@ async def test_a_non_force_run_stops_instead_of_retrying_a_width_it_cannot_store
         assert len(calls) == 1, calls
     finally:
         await _set_column_dims(test_db_session, start_width)
+
+
+@pytest.mark.anyio
+async def test_one_anomalous_vector_width_costs_one_record_not_the_run(
+    test_db_session, monkeypatch
+):
+    """Isolated is not structural (#1579 review, codex P2).
+
+    The width guards exist to stop a run that cannot store ANY of its vectors.
+    A provider handing back one anomalous width while the column sits exactly
+    where the run pinned it is a different thing: one bad record among good
+    ones, which #449 says costs one error and nothing else.
+
+    An earlier revision could not tell them apart. Every mismatch raised
+    `_PinDrift`, the per-record handler rethrew it, and one odd vector abandoned
+    the rest of the catalog — a regression of the isolation this file's own
+    docstring defends.
+
+    The batch here holds mixed widths, so it is not structural and must not stop
+    at the batch check. It fails its insert on the odd row, drops into the
+    per-record retry, and each vector is judged alone against a column that has
+    not moved.
+    """
+    start_width = await _column_dims()
+    odd_width = 768 if start_width != 768 else 384
+    odd_marker = "Anomalous Width Record"
+
+    user_id = await get_user_id(test_db_session, "admin")
+    for index in range(_SEEDED):
+        await create_dataset(
+            test_db_session, created_by=user_id, name=f"Isolation Good {index}"
+        )
+    await create_dataset(test_db_session, created_by=user_id, name=odd_marker)
+    await test_db_session.commit()
+
+    _pin_model(monkeypatch)
+    calls: list[int] = []
+
+    async def _embed(texts, _session, **_kwargs):
+        # Keyed on content, not call order: the force path's pre-flight is its
+        # own single-text call and must come back at the column's width, or the
+        # run aborts before the batch this test is about.
+        calls.append(len(texts))
+        return [
+            [0.1] * (odd_width if odd_marker in text else start_width) for text in texts
+        ]
+
+    monkeypatch.setattr(backfill_module, "generate_embeddings_batch", _embed)
+
+    result = await backfill_module.backfill_embeddings(test_db_session, force=True)
+
+    assert result["errors"] == 1, result
+    assert result["created"] >= _SEEDED, result
+    assert await _embedding_count(test_db_session) == result["created"]
+
+    # Non-vacuity: the batch really did fail and retry per record, so the
+    # per-record judgement is what produced that single error rather than the
+    # batch check having quietly let everything through.
+    assert len(calls) > 2, calls
+    assert calls[0] == 1, "the pre-flight"
+    assert calls[1] > 1, "the batch"
+    assert set(calls[2:]) == {1}, "then one call per record, individually"
+
+    # And the column never moved, which is what made it isolated.
+    assert await _column_dims() == start_width

--- a/backend/tests/test_embedding_backfill_column_drift_1533.py
+++ b/backend/tests/test_embedding_backfill_column_drift_1533.py
@@ -324,3 +324,53 @@ async def test_the_settings_route_still_reports_itself_as_a_settings_change(
     finally:
         await EMBEDDING_DIMS.set(test_db_session, pinned_dims)
         await test_db_session.commit()
+
+
+@pytest.mark.anyio
+async def test_a_non_force_run_stops_instead_of_retrying_a_width_it_cannot_store(
+    test_db_session, monkeypatch
+):
+    """The sibling class: the column is already wrong when the run starts.
+
+    Not drift. Nothing moves during this run, so every check above is silent and
+    correct to be. The force path catches this state in its pre-flight, before
+    the DELETE. The non-force path has no pre-flight, so the first batch insert
+    fails the typmod, every record is retried individually, and each retry
+    spends a provider call before dying on the same error.
+
+    A pre-flight here would cost a provider call per run and would abort a run
+    that a single transient provider failure could otherwise survive, which is
+    the #449 contract two tests in `test_embedding_backfill.py` pin. Comparing
+    the width the provider actually produced against the width the run pinned
+    costs no call at all and stops before the first insert.
+    """
+    start_width = await _column_dims()
+    moved_width = 768 if start_width != 768 else 384
+
+    # Records with NO embedding, so the non-force path selects them.
+    user_id = await get_user_id(test_db_session, "admin")
+    for index in range(_SEEDED):
+        await create_dataset(
+            test_db_session, created_by=user_id, name=f"Non-force Width {index}"
+        )
+    await test_db_session.commit()
+
+    await _set_column_dims(test_db_session, moved_width)
+
+    _pin_model(monkeypatch)
+    calls: list[int] = []
+    monkeypatch.setattr(
+        backfill_module, "generate_embeddings_batch", _provider(calls, start_width)
+    )
+
+    try:
+        with pytest.raises(
+            RuntimeError, match="catalog.record_embeddings.embedding is vector"
+        ):
+            await backfill_module.backfill_embeddings(test_db_session)
+
+        # One batch call, and no per-record retry after it.
+        assert calls == [len(calls) and calls[0]], calls
+        assert len(calls) == 1, calls
+    finally:
+        await _set_column_dims(test_db_session, start_width)

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -2758,6 +2758,30 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # note the next reader assumes an atomic eviction covered both.
     # Cap 1007 -> 1018, exact.
     "backend/app/core/persistent_config.py": 1018,
+    # fix(#1533): first entry — crossed _RATCHET_INCLUSION_LOC on the change
+    # that made the run notice the embedding column moving under it. Two
+    # guards, both small: _live_column_dims (one pg_attribute read, shared with
+    # the pre-flight so a rebuild cannot land between two reads of the same
+    # width) and _generated_width_mismatch (the width the provider ACTUALLY
+    # returned, checked against the width the run pinned, before the insert).
+    # Most of the lines are comment, and they are the part worth keeping. They
+    # record why the baseline is the width the run OBSERVED rather than
+    # EMBEDDING_DIMS — the two legitimately disagree at rest under
+    # ENV_ONLY_CONFIG, so comparing them aborts a healthy run — and why the
+    # column read sits ahead of the endpoint block, which returns None from its
+    # except and would otherwise skip every check below it on exactly the
+    # half-configured install where a column gets altered by hand. The third
+    # note is the one a reader would otherwise re-derive: the obvious symmetry
+    # of running the force path's pre-flight on the non-force path too costs a
+    # provider call per run and breaks the #449 partial-success contract that
+    # test_batch_errors_do_not_stop_backfill and
+    # test_failed_batch_retries_per_record pin.
+    # fix(#1544): the same file also carries the compact-error helpers, whose
+    # docstrings record the ordering invariant two review rounds found the hard
+    # way — the redactor runs first, on the raw string, because truncation and
+    # whitespace collapse each break the pattern it matches on.
+    # Cap 1013, exact.
+    "backend/app/processing/embeddings/backfill.py": 1013,
     # feat(#1219): first entry — crossed _RATCHET_INCLUSION_LOC, exactly as
     # the inclusion rule's own comment predicted for this file ("watched by
     # nothing until they cross 1000. The threshold catches them then"). The

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -2810,7 +2810,15 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # flush's RowExclusiveLock is what closes it, and the comment says so at the
     # call site because the reason a statement sits where it does is invisible
     # from the statement itself. Cap 1098 -> 1135, exact.
-    "backend/app/processing/embeddings/backfill.py": 1135,
+    # fix(#1533 review r4, codex P2): +10 net. The retry's width judgement asked
+    # "does this vector fit" before "is the column still the pinned one", and
+    # returned early when the vector matched — so a column that moved during the
+    # provider call for the LAST retried record was counted as a bad record
+    # rather than named as drift, there being no next record whose pre-call
+    # check would catch it. It now runs the drift bracket first and reuses
+    # _raise_on_pin_drift rather than phrasing the abort locally, so the module
+    # keeps ONE author of "the column moved". Cap 1135 -> 1145, exact.
+    "backend/app/processing/embeddings/backfill.py": 1145,
     # feat(#1219): first entry — crossed _RATCHET_INCLUSION_LOC, exactly as
     # the inclusion rule's own comment predicted for this file ("watched by
     # nothing until they cross 1000. The threshold catches them then"). The

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -2800,7 +2800,17 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # cannot share a predicate: the first attempt at this fix routed one vector
     # through the batch rule and silently disarmed the retry check.
     # Cap 1068 -> 1098, exact.
-    "backend/app/processing/embeddings/backfill.py": 1098,
+    # fix(#1533 review r3, codex P2): +37, almost entirely comment. The code is
+    # a reorder — flush the pending rows, THEN run the pre-commit drift check,
+    # THEN commit — on both the batch and the retry path. The check reads
+    # pg_attribute, which locks nothing, so running it before the rows were sent
+    # left a window for an ALTER TABLE to take ACCESS EXCLUSIVE and commit
+    # unseen; widening to an unconstrained vector then let the old-width inserts
+    # succeed and the run report success over a column that had moved. The
+    # flush's RowExclusiveLock is what closes it, and the comment says so at the
+    # call site because the reason a statement sits where it does is invisible
+    # from the statement itself. Cap 1098 -> 1135, exact.
+    "backend/app/processing/embeddings/backfill.py": 1135,
     # feat(#1219): first entry — crossed _RATCHET_INCLUSION_LOC, exactly as
     # the inclusion rule's own comment predicted for this file ("watched by
     # nothing until they cross 1000. The threshold catches them then"). The

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -2762,7 +2762,7 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # that made the run notice the embedding column moving under it. Two
     # guards, both small: _live_column_dims (one pg_attribute read, shared with
     # the pre-flight so a rebuild cannot land between two reads of the same
-    # width) and _generated_width_mismatch (the width the provider ACTUALLY
+    # width) and _structural_width_mismatch (the width the provider ACTUALLY
     # returned, checked against the width the run pinned, before the insert).
     # Most of the lines are comment, and they are the part worth keeping. They
     # record why the baseline is the width the run OBSERVED rather than
@@ -2780,8 +2780,18 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # docstrings record the ordering invariant two review rounds found the hard
     # way — the redactor runs first, on the raw string, because truncation and
     # whitespace collapse each break the pattern it matches on.
-    # Cap 1013, exact.
-    "backend/app/processing/embeddings/backfill.py": 1013,
+    # fix(#1533 review, codex P2): +55 separating a STRUCTURAL width mismatch
+    # from an ISOLATED one. The first revision stopped the run on any
+    # wrong-width vector, which broke the same #449 isolation the note above
+    # defends: one anomalous vector abandoned every remaining record. The lines
+    # are _AnomalousVectorWidth (counted by the per-record handler rather than
+    # rethrown), the batch check reading agreement ACROSS inputs instead of the
+    # first vector, and the retry check asking storage — one input carries no
+    # agreement, so the evidence has to come from whether the column moved.
+    # The comments carry the part that is not visible in the code: why the
+    # retry-path read is paid at all when the drift check two lines up already
+    # compares the same two widths. Cap 1013 -> 1068, exact.
+    "backend/app/processing/embeddings/backfill.py": 1068,
     # feat(#1219): first entry — crossed _RATCHET_INCLUSION_LOC, exactly as
     # the inclusion rule's own comment predicted for this file ("watched by
     # nothing until they cross 1000. The threshold catches them then"). The

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -2791,7 +2791,16 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # The comments carry the part that is not visible in the code: why the
     # retry-path read is paid at all when the drift check two lines up already
     # compares the same two widths. Cap 1013 -> 1068, exact.
-    "backend/app/processing/embeddings/backfill.py": 1068,
+    # fix(#1533 review r2, codex P2): +30 for the same lesson one batch size
+    # further in. A single-record batch — any catalog sized 1 mod _BATCH_SIZE —
+    # made "every vector agrees" vacuously true, so one anomalous vector in the
+    # final batch stopped the run. _column_rejects_width splits the fit test
+    # away from what a mismatch MEANS, so the batch rule can demand two vectors
+    # while the retry rule keeps judging one, and the comment says why they
+    # cannot share a predicate: the first attempt at this fix routed one vector
+    # through the batch rule and silently disarmed the retry check.
+    # Cap 1068 -> 1098, exact.
+    "backend/app/processing/embeddings/backfill.py": 1098,
     # feat(#1219): first entry — crossed _RATCHET_INCLUSION_LOC, exactly as
     # the inclusion rule's own comment predicted for this file ("watched by
     # nothing until they cross 1000. The threshold catches them then"). The


### PR DESCRIPTION
## What

The backfill's drift check now also compares the live width of `catalog.record_embeddings.embedding`, read off `pg_attribute`, against the width the run pinned at the start. It runs at every batch boundary and around every provider call on the per-record retry path, exactly where the settings comparisons already run.

## Step 1: is the settings route already closed?

The issue's option A predates #1539, so before adding anything I checked whether #1539's guard already covers the route the issue describes. It does.

I adapted the `.planning/harness-1533/` harness (copy in scratch, its own scratch database, dropped after) to move the width by two routes rather than one, and to be able to force the per-record retry path on demand. The settings route now does what `update_settings` does: commit `embedding_dims`, then call the rebuild.

| 1,000 records, rebuild fires during batch 1 | provider calls | created | outcome |
| --- | --- | --- | --- |
| control, nothing interfering | 9 | 1,000 | completes |
| settings route, on `origin/main` | 2 | 0 | aborts: "the embedding dimensions changed from 1536 to 768" |

So the settings route is closed and this PR does not touch it. #1539's guard reads `EMBEDDING_DIMS` uncached at each batch boundary, and `update_settings` commits that setting before it calls `rebuild_embedding_column`, so the change is visible within one batch.

## Step 2: the route-independent residue

The width also moves with no settings write of any kind: an `ENV_ONLY_CONFIG` deployment (no settings row, so no rebuild ever fires), a hand `ALTER TABLE`, a restored dump, a rebuild that failed partway. #1539's guard reads settings, so it is blind to all of them.

Same harness, same 1,000 records, width moved by hand with `app_settings` untouched:

| | provider calls | created | stored | outcome |
| --- | --- | --- | --- | --- |
| `origin/main` | 1,009 | 0 | 0 | `{'errors': 1000}`, indistinguishable from a broken provider |
| this branch | 2 | 0 | 0 | aborts: "the embedding column width changed from vector(1536) to vector(768)" |
| `origin/main`, batch 1 also rejected by the provider | 1,009 | 0 | 0 | `{'errors': 1000}` |
| this branch, same | 2 | 0 | 0 | same abort, from the retry path's first record |

That last pair is the one that matters. A per-batch check on its own is nearly useless when the width moves during the first batch's provider call: that batch fails into `_retry_batch_per_record`, and every record then makes its own provider call before dying on the same typmod. The bracketing inside the retry loop is what stops it, and it stops before spending a call on the first record.

No data is preserved by any of this. The force path's DELETE commits before any check can run, so the vectors are gone either way, and the harness confirms 0 rows stored in every failing arm. What is bought is the work not done and a failure an operator can read.

## Cost

The check runs twice per batch and twice per retried record on an operation that can run for forty minutes, so it was measured rather than assumed. Direct timing against the scratch catalog, 200 samples each:

```
_live_column_dims (the added read)           median  0.321 ms   p95 0.766 ms
_pinned_config_drift (with the read)         median  3.140 ms   p95 4.745 ms
_pinned_config_drift (read stubbed out)      median  2.712 ms   p95 4.720 ms
```

0.43 ms added per drift check, against 2.7 ms that check already spent. Two checks per batch:

| records | batches | checks | added |
| --- | --- | --- | --- |
| 10,000 | 79 | 158 | 0.068 s |
| 50,000 | 391 | 782 | 0.334 s |
| 100,000 | 782 | 1,564 | 0.669 s |

Against the ~109 s a clean 10,000-record regenerate takes (measured in the issue), that is 0.06%. An end-to-end A/B of the control run at 10,000 records could not resolve it: 22.28 s and 16.86 s with the check, 18.61 s and 16.85 s without, so the run-to-run spread is two orders of magnitude larger than the effect. On the retry path the added cost is 0.64 ms per record against a 0.22 s single-text provider call, or 0.3%.

## Decisions worth review

The baseline is the width the run observed, not `EMBEDDING_DIMS`. Comparing storage against the setting would need no new plumbing and would be wrong: the two legitimately disagree at rest on an `ENV_ONLY_CONFIG` deployment, and `EMBEDDING_DIMS` can be `None`. Every batch would then abort a run that was healthy from the first record. The test `test_a_healthy_force_run_is_not_stopped_by_the_new_check` guards exactly that.

The check sits ahead of the endpoint block and behind the settings comparisons. The endpoint block returns `None` from its `except`, so a check placed after it never runs on a deployment where the endpoint will not resolve, and an endpoint that will not resolve is the kind of half-configured install where a column gets altered by hand. The settings comparisons stay in front so that on the settings route, where both have moved, the message names the admin's action rather than its consequence. A test pins that message.

Any change counts, including widening the column or dropping the constraint. Those inserts would succeed, which is the problem: the run would finish reporting success with the table holding two vector widths under one model label, and nothing else would report it.

The width is pinned beside the config triple, not inside it. It is storage state read from `pg_attribute`, not configuration read from `PersistentConfig`, and the whole reason for the check is that those two disagree. Widening `_snapshot_embedding_config`'s tuple would also have made the function's contract, and its long docstring about capturing three values in one window, say something it does not mean.

The pre-flight now takes the pinned width instead of reading storage itself. One read rather than two, and this is a correctness point rather than a saving: with two reads, a rebuild landing between them passes the pre-flight against the old width and gets pinned at the new one, so the batch loop has nothing left to notice.

## What I did not do

The non-force path has no pre-flight, so a width that is already wrong when a non-force run starts still produces the same per-record storm. That is the pre-existing-state class #1519's pre-flight covers on the force path, not drift, and closing it means comparing the first batch's generated width against the column instead of retrying. It is a real gap and it is not this PR.

## Verification

New file: `backend/tests/test_embedding_backfill_column_drift_1533.py`, four DB-backed tests. The column DDL runs on its own AUTOCOMMIT connection with a `lock_timeout`, and the original width and index are restored in a `finally`.

Red, on `origin/main`'s `backfill.py` with the tests unchanged:

```
E   Failed: DID NOT RAISE RuntimeError

FAILED tests/test_embedding_backfill_column_drift_1533.py::test_hand_altered_column_stops_the_run_after_one_batch
FAILED tests/test_embedding_backfill_column_drift_1533.py::test_hand_altered_column_stops_the_per_record_retry_path
2 failed, 2 passed, 45 warnings in 16.40s
```

The two that pass in the red run are the ones that should: the healthy-run control, and the settings-route test that #1539 already satisfies. The red run also prints the full rendered insert failure per record, vector and all, which is #1544.

Green:

```
164 passed, 49 warnings in 47.69s
```

(the new file plus `test_embedding_backfill{,_force_guard,_model_pinning,_base_url_pinning,_model_scope,_queue_1542}.py`, `test_embedding_pipeline.py`, `test_embedding_service.py`, `test_embedding_vector_migration_config.py`, `test_layering.py`)

```
$ uv run ruff check . && uv run ruff format --check .
All checks passed!
1025 files already formatted
```

## Readers of the values involved

The values are the pinned storage width and the live one, and both are read in one place. Enumerated:

- Database: `pg_attribute.atttypmod`, through `_live_column_dims`, now the only reader of that catalog in this module. The pre-flight's own copy is gone.
- Cache: none. `atttypmod` is not routed through `PersistentConfig`, so there is no per-key cache to go stale, which is the difference between this check and the settings comparisons beside it.
- Per-process memoization: none added. The pinned width is a local on `backfill_embeddings`, so two concurrent runs cannot share one.
- The provider call: bracketed on both paths, before and after the batch call and before and after each retried record's call. The pre-flight's generated-width comparison uses the same pinned value.
- Each exit path: the batch loop's pre-check raises `RuntimeError` and stops the run; the post-call check and both retry-path checks raise `_PinDrift`, which the batch handler re-raises rather than counting as an error and the record handler re-raises rather than counting as a bad input. No path converts drift into a counted error.
- Future readers: semantic search filters stored rows by `model_name` alone, so a table holding two widths under one label is not something a later reader can untangle. That is why a widening change is treated as drift rather than tolerated. Persisting a per-row configuration stamp is #1546.

## Also

Refreshes the stale citation in `_snapshot_embedding_config`. It pointed at `settings/router.py:338-345` for a per-key cache eviction loop that #1543 replaced with a single batched step. The reads it justifies are unaffected; only the mechanism it describes had moved.

Closes #1533

---

## Update (d47efc837): merged main, and closed the non-force gap

`origin/main` (5671eb3bb) is merged in rather than rebased, since the branch is public. Both sides had added a keyword to `_retry_batch_per_record` and a paragraph to its docstring, #1533's `pinned_column_dims` and #1544's `traced_errors`, so the conflict resolution keeps both. The drift checks still bracket the retry's provider call on either side, and the traceback budget still threads through to the per-record handler.

### The non-force gap, no longer left open

The "What I did not do" section above said a width that is already wrong when a non-force run starts still storms per record. That is closed here, but not the way the symmetry suggests.

**Why not a pre-flight on the non-force path.** It is one line, and I measured it before judging it: adding `_preflight_embedding` to the non-force branch fails 5 of the 7 tests in `test_embedding_backfill.py`. Three are test-double churn. Two are not. `test_batch_errors_do_not_stop_backfill` and `test_failed_batch_retries_per_record` pin the #449 contract that a failed batch is retried per record and only the bad records count, and a pre-flight consumes the first provider call, so one transient provider failure would abort a run that used to finish with partial success. It also burns a call on a run whose records all have empty content, which `test_skips_records_with_empty_content` asserts costs zero today. The force path can afford to abort because it is about to destroy data. The non-force path destroys nothing, so refusing to start is strictly worse than a partial run, and that is the same trade #1511 review r5 already made in the other direction.

**What it does instead.** Compare the width the provider actually returned against the width the run pinned, after the call and before the insert. No extra provider call, no change to the provider-failure contract, and the abort names both widths. Per vector on the retry path, because that is the loop where a mismatch costs a call per record; the first vector stands in for a batch, and a provider answering ragged widths is not missed either, since the odd insert fails into the retry loop where every vector is checked on its own.

Red on a non-force run against an already-wrong column:

```
E   Failed: DID NOT RAISE RuntimeError
warning  Backfill: batch failed, retrying records individually  batch_size=3 batch_start=0
         error="<class 'asyncpg.exceptions.DataError'>: expected 768 dimensions, not 1536"
```

Green: one provider call, and `the model produced 1536-dimension vectors but catalog.record_embeddings.embedding is vector(768)`. The existing `test_a_healthy_force_run_is_not_stopped_by_the_new_check` doubles as this guard's counterfactual, since its stub generates exactly the column width.

### Module size

`backfill.py` crosses `_RATCHET_INCLUSION_LOC` with this change, so it joins `_MODULE_LOC_CAPS` at 1013 with a note recording what the lines bought: the two guards are small, and most of the added lines are the comments explaining why the baseline is the observed width rather than `EMBEDDING_DIMS`, why the column read sits ahead of the endpoint block, and why the pre-flight symmetry is not taken.

**Green after all of it:**

```
188 passed, 57 warnings in 47.63s
```

(the drift file, `test_embedding_backfill_log_volume_1544.py` now that #1544 is on main, the six sibling backfill suites, `test_embedding_pipeline.py`, `test_embedding_service.py`, `test_embedding_vector_migration_config.py`, `test_layering.py`)

```
$ uv run ruff check . && uv run ruff format --check .
All checks passed!
1026 files already formatted
```

---

## Review round 1 (8375b7438): structural versus isolated

The width guard stopped the run on any vector that did not fit the column. On the per-record retry path that meant one anomalous vector abandoned every remaining record, which is a regression of the #449 isolation this description defends two sections up. Real, and mine.

What makes a mismatch structural is **agreement across inputs**. A provider does not answer one anomalous width for all 128 texts by accident, whereas a column that was already wrong, or has just been rebuilt, produces exactly that.

- **Batch path** reads the whole batch. A uniform width the column rejects stops the run. Mixed widths do not, and the batch fails into the per-record retry the way it always did. As a side effect this also stops indexing `vectors[0]` on a provider that returned nothing.
- **Retry path** has one input, so agreement carries no information and the evidence has to come from storage. A mismatch against a column that still is what the run pinned is one bad record, raised as `_AnomalousVectorWidth` so the per-record handler counts it and continues. A mismatch against a column that has moved stops the run.

There is no counter for a "compatible" provider returning the wrong width for every retried record against an unmoved column. That is the batch case one level down, and the batch check catches it before the retry loop is ever entered.

**On the retry path's storage read.** It is redundant today: the post-call drift check two lines above compares those same two widths, so it can only agree. It is paid anyway, at 0.32 ms against the ~3 ms that check already spends per record. The alternative is a guard whose correctness rests on a neighbouring call that nobody is stopped from reordering, and getting that wrong silently converts a structural storm into ten thousand counted errors, which is the outcome this PR exists to prevent.

**Red**, on d47efc837 with the tests unchanged:

```
E   app.processing.embeddings.backfill._PinDrift: Embedding regeneration stopped
    after 18 records: the model produced 768-dimension vectors but
    catalog.record_embeddings.embedding is vector(1536).
warning  Backfill: batch failed, retrying records individually  batch_size=19 batch_start=0

FAILED ...::test_one_anomalous_vector_width_costs_one_record_not_the_run
1 failed, 5 passed
```

One odd vector, 18 records already created, and the run walks away from the rest. The other five pass, including both storm tests, which is what makes the fix surgical rather than a loosening.

**Green:** `errors == 1`, the rest created, and the test asserts the shape that produced it (pre-flight, then a multi-input batch, then one call per record) so it cannot pass by the batch check having quietly let everything through. Both storm tests stay at one and two provider calls.

```
189 passed, 57 warnings in 50.55s
```

`backfill.py` 1013 -> 1068 in `_MODULE_LOC_CAPS`, note extended with what the 55 lines bought.

---

## Review round 2 (70c033308): the same lesson, one batch size in

The batch rule calls a mismatch structural when every vector in the batch shares it. With a single-record batch that test is vacuous — one anomalous vector satisfies it — so the run stopped over one bad record. Same isolation bug as round 1, surviving at the one batch size where the batch path has no more evidence than the retry path does, and reachable on any catalog sized 1 mod `_BATCH_SIZE` as its final batch.

The batch rule now requires two vectors before it will claim agreement. A singleton falls through rather than growing a branch: the insert fails, the record is retried, and the retry rule decides it from storage, which is the evidence that does work for one input. The cost is one extra provider call for that one record, which is what a mixed-width batch already pays. An empty provider response lands in the same place for the same reason rather than by accident, which was the other half of the review question.

**The fit test moved into `_column_rejects_width`**, separate from what a mismatch means. Its two callers supply that: agreement across a batch on one path, a storage read on the other. That split is not cosmetic. My first attempt put the two-vector guard inside the shared predicate, which left the retry path calling it with one vector and silently answering `None` for every record — the guard would have been disarmed and every test still green, because no test exercised the retry path against an unmoved column expecting an abort. Caught it before running anything, but it is the second time in this PR that one predicate serving two rules has gone wrong, hence the separation.

**Red**, on 8375b7438 with the tests unchanged:

```
E   app.processing.embeddings.backfill._PinDrift: Embedding regeneration stopped
    after 22 records: the model produced 768-dimension vectors but
    catalog.record_embeddings.embedding is vector(1536).

FAILED ...::test_a_one_record_batch_does_not_read_as_structural
1 failed, 6 passed
```

The test patches `_BATCH_SIZE` to 1 rather than seeding 129 records. That makes every batch a singleton, so the anomalous record lands in one whatever order the run selects in, and the test does not depend on how many records other tests left on the worker's database. The sibling suite already patches the same constant for the same kind of control.

Six of seven pass in the red run, both storm tests among them.

**Green:** `190 passed`, ruff clean. `backfill.py` 1068 -> 1098 in `_MODULE_LOC_CAPS`.

### Noticed while checking the empty-response path, not fixed here

`created += len(batch)` counts the whole batch as created regardless of how many rows were actually added, and `zip(batch, vectors)` truncates silently. A provider returning fewer vectors than texts therefore reports records as created that were never written. It predates this PR and is a different class from the width guards, so it is left alone rather than folded in.

---

## Review round 3 (e836f379f): the check has to hold the lock

The pre-commit drift check reads `pg_attribute`, which locks nothing, and it ran before the batch's rows had been sent. An `ALTER TABLE` could take ACCESS EXCLUSIVE, commit inside that window, and be missed entirely. When the ALTER widened the column to an unconstrained `vector` the old-width inserts then **succeeded**, and the run reported success over a column that had moved under it. That is the outcome `_pinned_config_drift` explicitly says a widening change must not produce, since those are the inserts nothing else reports. Check-then-act, without holding the thing checked.

Flushing first takes RowExclusiveLock on the relation, which ACCESS EXCLUSIVE conflicts with. An ALTER that landed before the flush is seen by the check and the flushed rows roll back with the abort; one that arrives after waits for the commit.

Both paths take the same order. On the retry path the width check stays ahead of the insert: it decides not to write at all, so it needs no lock, and putting it after the flush would let the typmod error raise first and turn a named abort into a counted one. A flush that raises because the column moved to a different fixed width is not lost either — the batch handler retries per record and the retry's pre-call check reads the new width and stops the run.

The reorder also cashes a cheque written last round. `_raise_on_retry_vector_width`'s storage read was justified as "paid anyway, so that no reorder can silently disarm it" when a drift check sat immediately above it and could only agree. That reorder has now happened, for an unrelated reason, and the read is the only thing left standing between a column that moved during the provider call and ten thousand counted errors.

**Red**, on 70c033308 with the tests unchanged:

```
    assert await _column_dims() == start_width, (
E   AssertionError: the column moved during the run and the run did not notice
E   assert -1 == 1536

FAILED ...::test_the_pre_commit_check_holds_the_relation_lock
1 failed, 7 passed
```

The run completed, reported records created, and the column reads `-1`. Assertions are ordered so the red lands on the damage rather than on the absence of a lock error.

**Green:** the ALTER comes back `lock_not_available`, the column is unchanged, the run completes.

On the test's honesty: the ALTER is fired deterministically the instant the check returns, rather than raced. The window is a known one and constructing it beats hoping to hit it. What proves the two sides genuinely contended is not the ordering but the outcome — Postgres can only answer `lock_not_available` while something else holds a conflicting lock. It is matched on the message rather than the exception class, because the asyncpg dialect wraps every driver error in one adapter type.

```
191 passed, 57 warnings in 55.97s
```

`backfill.py` 1098 -> 1135 in `_MODULE_LOC_CAPS`.

---

## Review round 4 (1f6a6de88): order the two questions

The retry path's width judgement asked "does this vector fit the pinned width" first, and returned early when it did — so "is the pinned width still the live one" went unasked whenever the provider answered at the expected width. A column that moved to a different fixed width during that provider call then reached the flush, which raised the typmod error, which the broad handler counted as a bad record.

Every record but the last is covered anyway, by the next one's pre-call check. The last has no next, so the run reported "complete with one error" for what was a configuration change. A misreport rather than a bad row, and narrow, but the rule is easier to hold when it has no exceptions.

The underlying cause is that round 3 took something away without putting it back. The post-call drift bracket #1525 review r6 installed on this path is still in the code, but r3 moved it below the flush so it could hold the relation lock, and the flush raises on its own when the column has moved — so the bracket never runs. This restores one ahead of the vector judgement, which is the order the two questions have to be asked in: the second only means anything once the first is answered.

It calls `_raise_on_pin_drift` rather than reading the width here and phrasing the abort locally. The cheaper read (0.32 ms against ~3 ms) would put a second author of "the column moved" in the module, and two places that decide the same thing drift apart. One rule, one message. The cost is one more full drift check per retried record: about 9 ms against the ~0.22 s that record's provider call costs, so roughly 4% of a legitimate per-record retry and nothing at all on the storm, which now ends on its first record.

**Red**, on e836f379f with the tests unchanged:

```
E   Failed: DID NOT RAISE RuntimeError
warning  Backfill: batch failed, retrying records individually  batch_size=1
         error='provider rejected this batch'
                 failed = 1

FAILED ...::test_a_move_during_the_last_retry_is_drift_not_a_counted_error
1 failed, 8 passed
```

Reaching the state needs a retry loop with exactly one record in it, so the test gives every existing record a vector first and seeds exactly one without, then fails the batch call to open the retry loop and fires the ALTER during the retry's own call. `calls == [1, 1]` pins that it really got there.

**Green:** the run raises, and the message names the width the column moved to. `192 passed`, ruff clean. `backfill.py` 1135 -> 1145 in `_MODULE_LOC_CAPS`.

### Where this stops

Five rounds have each narrowed the same window, and the returns are diminishing: this one was a misreport on one record in one ordering, with no wrong row and no wasted provider spend. The remaining surface is of that shape. If another round finds a narrower misreport with no data consequence, it belongs in a follow-up rather than here, and this PR should merge on the guarantees it already carries: a column that moves by any route stops the run and names the cause, an already-wrong column stops it before the per-record storm, and one bad vector costs one record.
