### PR TITLE
fix(embeddings): scope related items to the anchor row's own vector space

### DIFF
--- a/backend/app/core/catalog_port.py
+++ b/backend/app/core/catalog_port.py
@@ -231,9 +231,15 @@ class CatalogPort(Protocol):
 
     async def set_hnsw_recall(self, session: AsyncSession) -> None: ...
 
+    # fix(#1580): returns ``(embedding, model_name, config_fingerprint)`` rather
+    # than a bare vector. Related-items compares two STORED rows, so the caller
+    # has to be able to name the space the anchor is in and hold every later
+    # read to it; a list of floats cannot say which model or endpoint produced
+    # it. ``config_fingerprint`` is None for a row written before that column
+    # existed, and ``RecordEmbedding.usable_by_config`` grandfathers it.
     async def get_record_embedding(
         self, session: AsyncSession, record_id: uuid.UUID
-    ) -> list[float] | None: ...
+    ) -> tuple[list[float], str, str | None] | None: ...
 
     async def get_nearest_record_ids(
         self,
@@ -244,11 +250,19 @@ class CatalogPort(Protocol):
         max_distance: float = 0.7,
     ) -> list[uuid.UUID]: ...
 
+    # fix(#1580): the anchor's ``(model_name, config_fingerprint)`` are required
+    # keywords, not optional refinements. A neighbour record may hold a row in
+    # more than one space, and scoring it in the wrong one produces a similarity
+    # number that is well-formed and meaningless — the same failure as the
+    # selection above, one layer out.
     async def get_embedding_distances(
         self,
         session: AsyncSession,
         embedding: list[float],
         record_ids: list[uuid.UUID],
+        *,
+        model_name: str,
+        config_fingerprint: str | None,
     ) -> dict[uuid.UUID, float]: ...
 
     async def defer_embed_record(self, record_id: uuid.UUID) -> None: ...

--- a/backend/app/core/catalog_port.py
+++ b/backend/app/core/catalog_port.py
@@ -241,11 +241,16 @@ class CatalogPort(Protocol):
         self, session: AsyncSession, record_id: uuid.UUID
     ) -> tuple[list[float], str, str | None] | None: ...
 
+    # fix(#1580 review r2): the anchor is a required keyword. The caller reads
+    # it once and hands the same row to the ranking and the scoring, so the two
+    # cannot straddle a commit under READ COMMITTED — and an overlay cannot
+    # re-read and pick a different one.
     async def get_nearest_record_ids(
         self,
         session: AsyncSession,
         record_id: uuid.UUID,
         *,
+        anchor: tuple[list[float], str, str | None],
         limit: int = 5,
         max_distance: float = 0.7,
     ) -> list[uuid.UUID]: ...

--- a/backend/app/modules/catalog/datasets/domain/service_relationships.py
+++ b/backend/app/modules/catalog/datasets/domain/service_relationships.py
@@ -117,10 +117,14 @@ async def get_related_datasets(
         record_id, anchor = seed
 
         # Find nearest neighbors using shared helper (over-fetch for RBAC filtering).
-        # fix(#1580): the helper anchors on the same row this seed came from, so
-        # the selection and the scoring below stay in one vector space.
+        # fix(#1580): the selection and the scoring below stay in one vector
+        # space. fix(#1580 review r2): they stay on one ROW too — the anchor
+        # read above is handed in rather than taken again, because two reads
+        # under READ COMMITTED can straddle a worker committing a newer row for
+        # this record, which would rank against one vector and score against
+        # another.
         neighbor_record_ids = await get_catalog_port().get_nearest_record_ids(
-            db, record_id, limit=limit * 3, max_distance=0.7
+            db, record_id, anchor=anchor, limit=limit * 3, max_distance=0.7
         )
         if not neighbor_record_ids:
             return []

--- a/backend/app/modules/catalog/datasets/domain/service_relationships.py
+++ b/backend/app/modules/catalog/datasets/domain/service_relationships.py
@@ -46,8 +46,13 @@ __all__ = [
 
 async def _load_self_record_and_embedding(
     db: AsyncSession, dataset_id: uuid.UUID
-) -> tuple[uuid.UUID, list[float]] | None:
-    """Return (record_id, embedding) for the dataset, or None if either is absent.
+) -> tuple[uuid.UUID, tuple[list[float], str, str | None]] | None:
+    """Return (record_id, anchor) for the dataset, or None if either is absent.
+
+    fix(#1580): ``anchor`` is ``(embedding, model_name, config_fingerprint)``.
+    The vector alone does not say which model or endpoint produced it, so every
+    later read on this path takes the pair from here and compares inside that
+    one space.
 
     Phase 1061 SEC-S05: callers MUST gate visibility on the seed dataset BEFORE
     invoking this function. The embedding read has no permission filter and
@@ -63,20 +68,31 @@ async def _load_self_record_and_embedding(
         return None
     record_id = record_id_row[0]
 
-    embedding = await get_catalog_port().get_record_embedding(db, record_id)
-    if embedding is None:
+    anchor = await get_catalog_port().get_record_embedding(db, record_id)
+    if anchor is None:
         return None
-    return record_id, embedding
+    return record_id, anchor
 
 
 async def _compute_neighbor_distances(
     db: AsyncSession,
-    embedding: list[float],
+    anchor: tuple[list[float], str, str | None],
     neighbor_record_ids: list[uuid.UUID],
 ) -> dict[uuid.UUID, float]:
-    """Cosine-distance every neighbor against the seed embedding."""
+    """Cosine-distance every neighbor against the seed embedding.
+
+    fix(#1580): scored inside the anchor's own vector space. A neighbour that
+    also holds a row under another model would otherwise be scored off whichever
+    of its rows came back last, so the selection could be right and the printed
+    similarity still wrong.
+    """
+    embedding, model_name, config_fingerprint = anchor
     return await get_catalog_port().get_embedding_distances(
-        db, embedding, neighbor_record_ids
+        db,
+        embedding,
+        neighbor_record_ids,
+        model_name=model_name,
+        config_fingerprint=config_fingerprint,
     )
 
 
@@ -98,9 +114,11 @@ async def get_related_datasets(
         seed = await _load_self_record_and_embedding(db, dataset_id)
         if seed is None:
             return []
-        record_id, embedding = seed
+        record_id, anchor = seed
 
         # Find nearest neighbors using shared helper (over-fetch for RBAC filtering).
+        # fix(#1580): the helper anchors on the same row this seed came from, so
+        # the selection and the scoring below stay in one vector space.
         neighbor_record_ids = await get_catalog_port().get_nearest_record_ids(
             db, record_id, limit=limit * 3, max_distance=0.7
         )
@@ -108,7 +126,7 @@ async def get_related_datasets(
             return []
 
         neighbor_map = await _compute_neighbor_distances(
-            db, embedding, neighbor_record_ids
+            db, anchor, neighbor_record_ids
         )
 
         # Join to Dataset + Record, apply visibility filter, then build response items

--- a/backend/app/platform/extensions/defaults_catalog_port.py
+++ b/backend/app/platform/extensions/defaults_catalog_port.py
@@ -418,7 +418,7 @@ class DefaultCatalogPort:
                 # rows are all there is) and wrong here — a stamped anchor is
                 # evidence of a partly regenerated catalog, and the rows still
                 # carrying NULL are most likely the old space.
-                RecordEmbedding.usable_by_config(model_name, config_fingerprint)
+                RecordEmbedding.usable_by_stored_anchor(model_name, config_fingerprint)
             )
         )
         return {row.record_id: row.distance for row in result.all()}

--- a/backend/app/platform/extensions/defaults_catalog_port.py
+++ b/backend/app/platform/extensions/defaults_catalog_port.py
@@ -351,16 +351,18 @@ class DefaultCatalogPort:
         return await set_hnsw_recall(session)
 
     async def get_record_embedding(self, session, record_id):  # type: ignore[no-untyped-def]
-        from sqlalchemy import select
+        # fix(#1580): returns the anchor row's identity with its vector, and
+        # reads it through the one helper `get_nearest_record_ids` reads it
+        # through. This used to be a second, independent `LIMIT 1` off an
+        # unordered query: on a catalog holding more than one model's rows the
+        # ranking and the scoring could anchor on different vectors, and the
+        # caller had no way to ask which space it was handed because a list of
+        # floats does not say. See `get_anchor_embedding_row` for why the
+        # anchor's own pair is the right question here rather than the live
+        # configuration's.
+        from app.processing.embeddings.helpers import get_anchor_embedding_row
 
-        RecordEmbedding = self.record_embedding_orm_class()
-        result = await session.execute(
-            select(RecordEmbedding.embedding)
-            .where(RecordEmbedding.record_id == record_id)
-            .limit(1)
-        )
-        row = result.first()
-        return row[0] if row is not None else None
+        return await get_anchor_embedding_row(session, record_id)
 
     async def get_nearest_record_ids(
         self,
@@ -379,7 +381,16 @@ class DefaultCatalogPort:
             max_distance=max_distance,
         )
 
-    async def get_embedding_distances(self, session, embedding, record_ids):  # type: ignore[no-untyped-def]
+    async def get_embedding_distances(  # type: ignore[no-untyped-def]
+        self, session, embedding, record_ids, *, model_name, config_fingerprint
+    ):
+        # fix(#1580): scoped to the anchor's own vector space, like the
+        # selection ahead of it. Fixing only `get_nearest_record_ids` would have
+        # moved this defect one layer out rather than closing it: the neighbours
+        # would be chosen correctly and then SCORED off whichever of their rows
+        # the planner returned last, because a record may hold one row per model
+        # and this dict comprehension keeps the last of them. The similarity
+        # percentage the UI prints is this number.
         from sqlalchemy import select
 
         await self.set_hnsw_recall(session)
@@ -388,7 +399,9 @@ class DefaultCatalogPort:
             select(
                 RecordEmbedding.record_id,
                 RecordEmbedding.embedding.cosine_distance(embedding).label("distance"),
-            ).where(RecordEmbedding.record_id.in_(record_ids))
+            )
+            .where(RecordEmbedding.record_id.in_(record_ids))
+            .where(RecordEmbedding.usable_by_config(model_name, config_fingerprint))
         )
         return {row.record_id: row.distance for row in result.all()}
 

--- a/backend/app/platform/extensions/defaults_catalog_port.py
+++ b/backend/app/platform/extensions/defaults_catalog_port.py
@@ -351,15 +351,15 @@ class DefaultCatalogPort:
         return await set_hnsw_recall(session)
 
     async def get_record_embedding(self, session, record_id):  # type: ignore[no-untyped-def]
-        # fix(#1580): returns the anchor row's identity with its vector, and
-        # reads it through the one helper `get_nearest_record_ids` reads it
-        # through. This used to be a second, independent `LIMIT 1` off an
-        # unordered query: on a catalog holding more than one model's rows the
-        # ranking and the scoring could anchor on different vectors, and the
-        # caller had no way to ask which space it was handed because a list of
-        # floats does not say. See `get_anchor_embedding_row` for why the
-        # anchor's own pair is the right question here rather than the live
-        # configuration's.
+        # fix(#1580): returns the anchor row's identity with its vector. This
+        # used to be a second, independent `LIMIT 1` off an unordered query: on
+        # a catalog holding more than one model's rows the ranking and the
+        # scoring could anchor on different vectors, and the caller had no way
+        # to ask which space it was handed because a list of floats does not
+        # say. fix(#1580 review r2): it is now the ONLY anchor read on this
+        # path — the caller passes what this returns into
+        # `get_nearest_record_ids`, so the ranking and the scoring share one
+        # row rather than two statements that happen to order the same way.
         from app.processing.embeddings.helpers import get_anchor_embedding_row
 
         return await get_anchor_embedding_row(session, record_id)
@@ -418,7 +418,7 @@ class DefaultCatalogPort:
                 # rows are all there is) and wrong here — a stamped anchor is
                 # evidence of a partly regenerated catalog, and the rows still
                 # carrying NULL are most likely the old space.
-                RecordEmbedding.usable_by_stored_anchor(model_name, config_fingerprint)
+                RecordEmbedding.usable_by_config(model_name, config_fingerprint)
             )
         )
         return {row.record_id: row.distance for row in result.all()}

--- a/backend/app/platform/extensions/defaults_catalog_port.py
+++ b/backend/app/platform/extensions/defaults_catalog_port.py
@@ -364,19 +364,28 @@ class DefaultCatalogPort:
 
         return await get_anchor_embedding_row(session, record_id)
 
-    async def get_nearest_record_ids(
+    async def get_nearest_record_ids(  # type: ignore[no-untyped-def]
         self,
         session,
         record_id,
         *,
+        anchor,
         limit=5,
         max_distance=0.7,
-    ):  # type: ignore[no-untyped-def]
+    ):
+        # fix(#1580 review r2): the anchor travels in rather than being read
+        # again here. The caller has already read it to score the results, and
+        # two reads under READ COMMITTED can straddle a commit — leaving the
+        # ranking anchored on one row and the scoring on another. Required
+        # rather than optional on the PORT: the only core caller holds one, and
+        # an overlay that re-read would reintroduce exactly the disagreement
+        # this closes.
         from app.processing.embeddings.helpers import get_nearest_record_ids
 
         return await get_nearest_record_ids(
             session,
             record_id,
+            anchor=anchor,
             limit=limit,
             max_distance=max_distance,
         )
@@ -401,7 +410,16 @@ class DefaultCatalogPort:
                 RecordEmbedding.embedding.cosine_distance(embedding).label("distance"),
             )
             .where(RecordEmbedding.record_id.in_(record_ids))
-            .where(RecordEmbedding.usable_by_config(model_name, config_fingerprint))
+            .where(
+                # fix(#1580 review r2): the stored-vs-stored predicate, the same
+                # one the selection uses. `usable_by_config` grandfathers an
+                # unstamped row against a stamped anchor, which is right for
+                # search (a fresh query vector, and on upgrade day the unstamped
+                # rows are all there is) and wrong here — a stamped anchor is
+                # evidence of a partly regenerated catalog, and the rows still
+                # carrying NULL are most likely the old space.
+                RecordEmbedding.usable_by_stored_anchor(model_name, config_fingerprint)
+            )
         )
         return {row.record_id: row.distance for row in result.all()}
 

--- a/backend/app/platform/extensions/version.py
+++ b/backend/app/platform/extensions/version.py
@@ -96,12 +96,7 @@ logger = logging.getLogger(__name__)
 # 5 -> 6: a Protocol method a structural implementer must supply is required,
 # whatever else the addition is shaped like.
 #
-# 7 -> 8 (fix(#1546), then fix(#1580)): FOUR CatalogPort changes, one bump.
-#
-# The first two land with #1546 and the second two with #1580, in the same
-# release with no core release between them. An overlay author sees one contract
-# change, so they get one number: a second bump inside a release is a second pin
-# to maintain for a migration nobody performs separately.
+# 7 -> 8 (fix(#1546)): TWO CatalogPort changes, one bump.
 #
 # A required ``resolve_embedding_config`` method. Stored embeddings now carry
 # the identity of the configuration that produced them, and semantic search
@@ -124,18 +119,16 @@ logger = logging.getLogger(__name__)
 # Riding the same bump because both land in the same change; an overlay
 # updating to 8 has to do both.
 #
-# Then fix(#1580), the related-items path, on the same number. Related items
-# compared one record's stored vector against every other record's across model
-# and configuration spaces; scoping that comparison needs the anchor row's
-# identity to reach two more readers.
+# 8 -> 9 (fix(#1580)): TWO CatalogPort shape changes on the related-items path,
+# one bump, for the same reason 7 -> 8 carried two.
 #
-# ``get_record_embedding`` returns ``(embedding, model_name,
-# config_fingerprint)`` instead of a bare vector. Both sides of that comparison
-# are STORED rows, so the caller has to name the vector space the anchor is in
-# and hold every later read to it, and a list of floats cannot say which model
-# or endpoint produced it. An overlay still returning a bare list is unpacked
-# into three names by ``service_relationships._load_self_record_and_embedding``
-# and raises on the first related-items request.
+# ``get_record_embedding`` now returns ``(embedding, model_name,
+# config_fingerprint)`` instead of a bare vector. Related-items compares two
+# STORED rows, so the caller has to name the vector space the anchor is in and
+# hold every later read to it, and a list of floats cannot say which model or
+# endpoint produced it. An overlay still returning a bare list is unpacked into
+# three names by ``service_relationships._load_self_record_and_embedding`` and
+# raises on the first related-items request.
 #
 # ``get_embedding_distances`` gains required keyword-only ``model_name`` and
 # ``config_fingerprint``. Required rather than optional on purpose: defaulting
@@ -143,10 +136,21 @@ logger = logging.getLogger(__name__)
 # defect is a similarity percentage computed in the wrong space. An overlay
 # implementing the old signature raises TypeError on the same request.
 #
-# All four are the same test every bump before this one applied: a Protocol
-# method a structural implementer must supply, in a shape the core caller
-# depends on. An overlay updating to 8 has to do all four.
-EXTENSION_API_VERSION: int = 8
+# Same test as every bump before it: a Protocol method a structural implementer
+# must supply, in a shape the core caller depends on.
+#
+# These two were briefly folded INTO 7 -> 8, on the reasoning that #1546 and
+# #1580 ship in one release with no core release between them, so an overlay
+# author performs one migration. That was wrong and the history says so rather
+# than hiding it. The constant pins the contract at a COMMIT, not at a release:
+# main has been a v8 contract since #1546 merged, so an overlay built and
+# declared against it boots cleanly against post-#1580 core and then meets a
+# ``get_record_embedding`` of a different shape and a ``get_embedding_distances``
+# wanting two new keywords. The first related-items request fails inside the
+# broad handler and returns an empty list — silent skew, which is the exact
+# thing this check exists to refuse. Release boundaries are not what the number
+# is about.
+EXTENSION_API_VERSION: int = 9
 
 
 def check_extension_api_version(name: str, declared_version: int | None) -> None:

--- a/backend/app/platform/extensions/version.py
+++ b/backend/app/platform/extensions/version.py
@@ -136,17 +136,25 @@ logger = logging.getLogger(__name__)
 # defect is a similarity percentage computed in the wrong space. An overlay
 # implementing the old signature raises TypeError on the same request.
 #
+# And, from fix(#1580 review r2), a widened ``get_nearest_record_ids``: it takes
+# the caller's already-read anchor as a required keyword instead of reading one
+# for itself. Two reads of the same record under READ COMMITTED can straddle a
+# worker committing a newer row, which leaves the ranking anchored on one vector
+# and the scoring on another; an overlay that kept the old signature would read
+# its own and reintroduce exactly that. Required rather than optional for the
+# same reason ``get_embedding_distances``'s pair is.
+#
 # Same test as every bump before it: a Protocol method a structural implementer
 # must supply, in a shape the core caller depends on.
 #
-# These two were briefly folded INTO 7 -> 8, on the reasoning that #1546 and
+# These three were briefly folded INTO 7 -> 8, on the reasoning that #1546 and
 # #1580 ship in one release with no core release between them, so an overlay
 # author performs one migration. That was wrong and the history says so rather
 # than hiding it. The constant pins the contract at a COMMIT, not at a release:
 # main has been a v8 contract since #1546 merged, so an overlay built and
 # declared against it boots cleanly against post-#1580 core and then meets a
 # ``get_record_embedding`` of a different shape and a ``get_embedding_distances``
-# wanting two new keywords. The first related-items request fails inside the
+# wanting two new keywords, with ``get_nearest_record_ids`` wanting a third. The first related-items request fails inside the
 # broad handler and returns an empty list — silent skew, which is the exact
 # thing this check exists to refuse. Release boundaries are not what the number
 # is about.

--- a/backend/app/platform/extensions/version.py
+++ b/backend/app/platform/extensions/version.py
@@ -96,7 +96,12 @@ logger = logging.getLogger(__name__)
 # 5 -> 6: a Protocol method a structural implementer must supply is required,
 # whatever else the addition is shaped like.
 #
-# 7 -> 8 (fix(#1546)): TWO CatalogPort changes, one bump.
+# 7 -> 8 (fix(#1546), then fix(#1580)): FOUR CatalogPort changes, one bump.
+#
+# The first two land with #1546 and the second two with #1580, in the same
+# release with no core release between them. An overlay author sees one contract
+# change, so they get one number: a second bump inside a release is a second pin
+# to maintain for a migration nobody performs separately.
 #
 # A required ``resolve_embedding_config`` method. Stored embeddings now carry
 # the identity of the configuration that produced them, and semantic search
@@ -118,6 +123,29 @@ logger = logging.getLogger(__name__)
 # the first semantic search, so this is as required as the addition above.
 # Riding the same bump because both land in the same change; an overlay
 # updating to 8 has to do both.
+#
+# Then fix(#1580), the related-items path, on the same number. Related items
+# compared one record's stored vector against every other record's across model
+# and configuration spaces; scoping that comparison needs the anchor row's
+# identity to reach two more readers.
+#
+# ``get_record_embedding`` returns ``(embedding, model_name,
+# config_fingerprint)`` instead of a bare vector. Both sides of that comparison
+# are STORED rows, so the caller has to name the vector space the anchor is in
+# and hold every later read to it, and a list of floats cannot say which model
+# or endpoint produced it. An overlay still returning a bare list is unpacked
+# into three names by ``service_relationships._load_self_record_and_embedding``
+# and raises on the first related-items request.
+#
+# ``get_embedding_distances`` gains required keyword-only ``model_name`` and
+# ``config_fingerprint``. Required rather than optional on purpose: defaulting
+# them to "no filter" would let an overlay keep the defect silently, and the
+# defect is a similarity percentage computed in the wrong space. An overlay
+# implementing the old signature raises TypeError on the same request.
+#
+# All four are the same test every bump before this one applied: a Protocol
+# method a structural implementer must supply, in a shape the core caller
+# depends on. An overlay updating to 8 has to do all four.
 EXTENSION_API_VERSION: int = 8
 
 

--- a/backend/app/platform/extensions/version.py
+++ b/backend/app/platform/extensions/version.py
@@ -127,7 +127,7 @@ logger = logging.getLogger(__name__)
 # STORED rows, so the caller has to name the vector space the anchor is in and
 # hold every later read to it, and a list of floats cannot say which model or
 # endpoint produced it. An overlay still returning a bare list is unpacked into
-# three names by ``service_relationships._load_self_record_and_embedding`` and
+# three names by ``service_relationships._compute_neighbor_distances`` and
 # raises on the first related-items request.
 #
 # ``get_embedding_distances`` gains required keyword-only ``model_name`` and

--- a/backend/app/processing/embeddings/helpers.py
+++ b/backend/app/processing/embeddings/helpers.py
@@ -375,15 +375,21 @@ async def get_anchor_embedding_row(
     Returns ``(embedding, model_name, config_fingerprint)``, or None when the
     record has no vector at all.
 
-    fix(#1580): ONE definition of which row that is, because three readers on
-    the related-items path need the same answer and used to arrive at it
-    separately. ``get_nearest_record_ids`` read the anchor to rank against;
-    ``CatalogPort.get_record_embedding`` read it again to score the survivors.
-    Each took ``LIMIT 1`` off an unordered query, and a record can hold one row
-    per model (``uq_record_embedding_model`` is ``(record_id, model_name)``), so
-    on a catalog that has been through a model swap the two reads could return
-    vectors from DIFFERENT spaces. The neighbours were then ranked in one space
-    and the similarity the user sees computed in another.
+    fix(#1580): ONE definition of which row that is, because the related-items
+    path used to arrive at it twice and separately. ``get_nearest_record_ids``
+    read the anchor to rank against; ``CatalogPort.get_record_embedding`` read it
+    again to score the survivors. Each took ``LIMIT 1`` off an unordered query,
+    and a record can hold one row per model (``uq_record_embedding_model`` is
+    ``(record_id, model_name)``), so on a catalog that has been through a model
+    swap the two reads could return vectors from DIFFERENT spaces. The
+    neighbours were then ranked in one space and the similarity the user sees
+    computed in another.
+
+    fix(#1580 review r2): related-items now makes ONE call to this and hands the
+    answer to everything downstream, so for that path the guarantee is literally
+    one read rather than two statements that agree. This function still has a
+    second caller — ``metadata_service`` asks for neighbours with no anchor of
+    its own — and that one has nothing downstream to disagree with.
 
     The identity comes back with the vector for the same reason the caller
     cannot re-derive it: a list of floats does not say which model or endpoint
@@ -438,11 +444,9 @@ async def get_nearest_record_ids(
     has no embedding or no neighbors are within the distance threshold.
 
     fix(#1580): the neighbours are restricted to the anchor row's own vector
-    space, through ``usable_by_stored_anchor`` — the stored-vs-stored predicate,
-    which unlike search's does NOT grandfather an unstamped candidate against a
-    stamped anchor (fix(#1580 review r2)). Both sides of this comparison are
-    STORED rows, so the rule is "same model and same stamp as the ANCHOR", not
-    "same as the live configuration" —
+    space, through the same ``usable_by_config`` every other reader applies.
+    Both sides of this comparison are STORED rows, so the rule is "same model
+    and same stamp as the ANCHOR", not "same as the live configuration" —
     a record embedded under a superseded configuration should still find its own
     neighbours rather than be silently compared against a space it was never in.
     Without the predicate a catalog holding two models' rows returned cosine
@@ -480,7 +484,7 @@ async def get_nearest_record_ids(
         select(RecordEmbedding.record_id)
         .join(RecordEmbedding.record)
         .where(RecordEmbedding.record_id != record_id)
-        .where(RecordEmbedding.usable_by_stored_anchor(model_name, config_fingerprint))
+        .where(RecordEmbedding.usable_by_config(model_name, config_fingerprint))
         .where(RecordEmbedding.embedding.cosine_distance(embedding) <= max_distance)
         .order_by(RecordEmbedding.embedding.cosine_distance(embedding))
         .limit(limit)

--- a/backend/app/processing/embeddings/helpers.py
+++ b/backend/app/processing/embeddings/helpers.py
@@ -397,22 +397,43 @@ async def get_anchor_embedding_row(
     ``RecordEmbedding.usable_by_stored_anchor(model_name, config_fingerprint)``, so the
     comparison stays inside the anchor's own space.
 
-    WHICH row, when a record has several: the most recently written one, ties
-    broken by model name so the answer is stable rather than merely arbitrary.
-    Before this it was whatever the planner happened to return. Most recent is
-    the least surprising reading of "this record's vector" after a swap, and it
-    is the one a re-embed moves; nothing here prefers the LIVE configuration,
-    deliberately. An anchor stamped under a superseded configuration finds its
-    own-space neighbours or finds none, and never crosses into another space
-    (#1580) — which is the difference between this reader and the search path,
-    where one side of the comparison is a fresh vector and the live
-    configuration is the right question to ask.
+    WHICH row, when a record has several: the one SEARCH would use, then the
+    most recently written, then model name for stability.
+
+    fix(#1580 review r3): the live-usable row goes first, and that ordering does
+    two things. It makes related items and search agree by construction —
+    whenever a record has a row search itself can retrieve, this anchors on that
+    row, including after a model rollback, where "newest" would have picked the
+    rolled-back one and the two readers would have disagreed about the same
+    record. And it demotes the timestamp to a tiebreak among rows NONE of which
+    are live-usable, where the choice is between two stale spaces and either
+    answer is defensible.
+
+    That demotion matters because the timestamp is not as ordered as it looks.
+    PostgreSQL ``now()`` is TRANSACTION-START time, and both the column default
+    and the ingest re-stamp used it, so a job that opened its transaction, spent
+    thirty seconds in a provider call and committed after another model's job
+    carries the EARLIER stamp despite being the later write. Ordering on it alone
+    could leave related items anchored to a row that lost the race it won.
+    ``clock_timestamp()`` fixes the explicit writers (see ``service.py``), but a
+    row written before that change still carries a transaction stamp, so the
+    ordering had to stop depending on it being right.
+
+    An anchor with no live-usable row keeps the #1580 property as the FALLBACK:
+    it finds its own-space neighbours or finds none, and never crosses into
+    another space. That is still the difference between this reader and search,
+    where one side is a fresh vector; it is just no longer the first question
+    asked.
 
     The join to ``catalog.records`` is the tenant boundary.
     ``record_embeddings`` carries no ``tenant_id`` of its own, so RLS reaches it
     only through the record it belongs to; ``test_embedding_helper_queries_join
     _rls_visible_records`` asserts every embedding helper crosses it.
     """
+    live_model = await resolve_embedding_model_name(session)
+    live_fingerprint = await resolve_embedding_config_fingerprint(
+        session, model_name=live_model
+    )
     result = await session.execute(
         select(
             RecordEmbedding.embedding,
@@ -421,7 +442,11 @@ async def get_anchor_embedding_row(
         )
         .join(RecordEmbedding.record)
         .where(RecordEmbedding.record_id == record_id)
-        .order_by(RecordEmbedding.updated_at.desc(), RecordEmbedding.model_name)
+        .order_by(
+            RecordEmbedding.usable_by_config(live_model, live_fingerprint).desc(),
+            RecordEmbedding.updated_at.desc(),
+            RecordEmbedding.model_name,
+        )
         .limit(1)
     )
     row = result.first()

--- a/backend/app/processing/embeddings/helpers.py
+++ b/backend/app/processing/embeddings/helpers.py
@@ -367,6 +367,63 @@ async def has_embeddings(session: AsyncSession) -> bool:
     return value
 
 
+async def get_anchor_embedding_row(
+    session: AsyncSession, record_id: uuid.UUID
+) -> tuple[list[float], str, str | None] | None:
+    """The stored row a similarity comparison for ``record_id`` is anchored on.
+
+    Returns ``(embedding, model_name, config_fingerprint)``, or None when the
+    record has no vector at all.
+
+    fix(#1580): ONE definition of which row that is, because three readers on
+    the related-items path need the same answer and used to arrive at it
+    separately. ``get_nearest_record_ids`` read the anchor to rank against;
+    ``CatalogPort.get_record_embedding`` read it again to score the survivors.
+    Each took ``LIMIT 1`` off an unordered query, and a record can hold one row
+    per model (``uq_record_embedding_model`` is ``(record_id, model_name)``), so
+    on a catalog that has been through a model swap the two reads could return
+    vectors from DIFFERENT spaces. The neighbours were then ranked in one space
+    and the similarity the user sees computed in another.
+
+    The identity comes back with the vector for the same reason the caller
+    cannot re-derive it: a list of floats does not say which model or endpoint
+    produced it. Everything downstream filters with
+    ``RecordEmbedding.usable_by_config(model_name, config_fingerprint)``, so the
+    comparison stays inside the anchor's own space.
+
+    WHICH row, when a record has several: the most recently written one, ties
+    broken by model name so the answer is stable rather than merely arbitrary.
+    Before this it was whatever the planner happened to return. Most recent is
+    the least surprising reading of "this record's vector" after a swap, and it
+    is the one a re-embed moves; nothing here prefers the LIVE configuration,
+    deliberately. An anchor stamped under a superseded configuration finds its
+    own-space neighbours or finds none, and never crosses into another space
+    (#1580) — which is the difference between this reader and the search path,
+    where one side of the comparison is a fresh vector and the live
+    configuration is the right question to ask.
+
+    The join to ``catalog.records`` is the tenant boundary.
+    ``record_embeddings`` carries no ``tenant_id`` of its own, so RLS reaches it
+    only through the record it belongs to; ``test_embedding_helper_queries_join
+    _rls_visible_records`` asserts every embedding helper crosses it.
+    """
+    result = await session.execute(
+        select(
+            RecordEmbedding.embedding,
+            RecordEmbedding.model_name,
+            RecordEmbedding.config_fingerprint,
+        )
+        .join(RecordEmbedding.record)
+        .where(RecordEmbedding.record_id == record_id)
+        .order_by(RecordEmbedding.updated_at.desc(), RecordEmbedding.model_name)
+        .limit(1)
+    )
+    row = result.first()
+    if row is None or row[0] is None:
+        return None
+    return (row[0], row[1], row[2])
+
+
 async def get_nearest_record_ids(
     session: AsyncSession,
     record_id: uuid.UUID,
@@ -378,17 +435,27 @@ async def get_nearest_record_ids(
 
     Excludes the given record_id. Returns an empty list when the record
     has no embedding or no neighbors are within the distance threshold.
+
+    fix(#1580): the neighbours are restricted to the anchor row's own vector
+    space. Both sides of this comparison are STORED rows, so the rule is "same
+    model and same stamp as the ANCHOR", not "same as the live configuration" —
+    a record embedded under a superseded configuration should still find its own
+    neighbours rather than be silently compared against a space it was never in.
+    Without the predicate a catalog holding two models' rows returned cosine
+    distances that were well-formed and meaningless.
+
+    ``set_hnsw_recall`` turns on pgvector's iterative scan, which is what keeps
+    this predicate from starving the approximate scan the way fix(#1546 review
+    r2) describes: the filter runs on the candidates the index already chose, so
+    without iterative scan a catalog whose nearest rows are mostly foreign-space
+    returns nothing while usable vectors sit in the table. That call was already
+    here and already covers this; the docstring there names related-items by
+    name.
     """
-    # Get this record's embedding
-    emb_result = await session.execute(
-        select(RecordEmbedding.embedding)
-        .join(RecordEmbedding.record)
-        .where(RecordEmbedding.record_id == record_id)
-        .limit(1)
-    )
-    embedding = emb_result.scalar_one_or_none()
-    if embedding is None:
+    anchor = await get_anchor_embedding_row(session, record_id)
+    if anchor is None:
         return []
+    embedding, model_name, config_fingerprint = anchor
 
     await set_hnsw_recall(session)
 
@@ -397,6 +464,7 @@ async def get_nearest_record_ids(
         select(RecordEmbedding.record_id)
         .join(RecordEmbedding.record)
         .where(RecordEmbedding.record_id != record_id)
+        .where(RecordEmbedding.usable_by_config(model_name, config_fingerprint))
         .where(RecordEmbedding.embedding.cosine_distance(embedding) <= max_distance)
         .order_by(RecordEmbedding.embedding.cosine_distance(embedding))
         .limit(limit)

--- a/backend/app/processing/embeddings/helpers.py
+++ b/backend/app/processing/embeddings/helpers.py
@@ -428,6 +428,7 @@ async def get_nearest_record_ids(
     session: AsyncSession,
     record_id: uuid.UUID,
     *,
+    anchor: tuple[list[float], str, str | None] | None = None,
     limit: int = 5,
     max_distance: float = 0.7,
 ) -> list[uuid.UUID]:
@@ -437,8 +438,11 @@ async def get_nearest_record_ids(
     has no embedding or no neighbors are within the distance threshold.
 
     fix(#1580): the neighbours are restricted to the anchor row's own vector
-    space. Both sides of this comparison are STORED rows, so the rule is "same
-    model and same stamp as the ANCHOR", not "same as the live configuration" —
+    space, through ``usable_by_stored_anchor`` — the stored-vs-stored predicate,
+    which unlike search's does NOT grandfather an unstamped candidate against a
+    stamped anchor (fix(#1580 review r2)). Both sides of this comparison are
+    STORED rows, so the rule is "same model and same stamp as the ANCHOR", not
+    "same as the live configuration" —
     a record embedded under a superseded configuration should still find its own
     neighbours rather than be silently compared against a space it was never in.
     Without the predicate a catalog holding two models' rows returned cosine
@@ -452,7 +456,19 @@ async def get_nearest_record_ids(
     here and already covers this; the docstring there names related-items by
     name.
     """
-    anchor = await get_anchor_embedding_row(session, record_id)
+    # fix(#1580 review r2): the caller may hand its anchor in, and the one
+    # caller that scores the results afterwards does. Reading it here a second
+    # time is two reads under READ COMMITTED, so a worker committing a newer
+    # row for this record between them left the ranking anchored on the new
+    # vector while the scoring used the old one — wrong distances, or an empty
+    # answer when the two spaces do not overlap. Passing it makes "the same
+    # row" a property of the call rather than of the isolation level.
+    #
+    # Optional because `metadata_service` reads neighbours with no anchor of
+    # its own; that caller has nothing downstream to disagree with, so it lets
+    # this read for it.
+    if anchor is None:
+        anchor = await get_anchor_embedding_row(session, record_id)
     if anchor is None:
         return []
     embedding, model_name, config_fingerprint = anchor
@@ -464,7 +480,7 @@ async def get_nearest_record_ids(
         select(RecordEmbedding.record_id)
         .join(RecordEmbedding.record)
         .where(RecordEmbedding.record_id != record_id)
-        .where(RecordEmbedding.usable_by_config(model_name, config_fingerprint))
+        .where(RecordEmbedding.usable_by_stored_anchor(model_name, config_fingerprint))
         .where(RecordEmbedding.embedding.cosine_distance(embedding) <= max_distance)
         .order_by(RecordEmbedding.embedding.cosine_distance(embedding))
         .limit(limit)

--- a/backend/app/processing/embeddings/helpers.py
+++ b/backend/app/processing/embeddings/helpers.py
@@ -394,7 +394,7 @@ async def get_anchor_embedding_row(
     The identity comes back with the vector for the same reason the caller
     cannot re-derive it: a list of floats does not say which model or endpoint
     produced it. Everything downstream filters with
-    ``RecordEmbedding.usable_by_config(model_name, config_fingerprint)``, so the
+    ``RecordEmbedding.usable_by_stored_anchor(model_name, config_fingerprint)``, so the
     comparison stays inside the anchor's own space.
 
     WHICH row, when a record has several: the most recently written one, ties
@@ -444,7 +444,9 @@ async def get_nearest_record_ids(
     has no embedding or no neighbors are within the distance threshold.
 
     fix(#1580): the neighbours are restricted to the anchor row's own vector
-    space, through the same ``usable_by_config`` every other reader applies.
+    space, through ``usable_by_stored_anchor`` — the stored-vs-stored reading of
+    the same rule, which is where fix(#1580 review r2) argues out what a NULL
+    side may be compared against and why the answer is the lenient one.
     Both sides of this comparison are STORED rows, so the rule is "same model
     and same stamp as the ANCHOR", not "same as the live configuration" —
     a record embedded under a superseded configuration should still find its own
@@ -484,7 +486,7 @@ async def get_nearest_record_ids(
         select(RecordEmbedding.record_id)
         .join(RecordEmbedding.record)
         .where(RecordEmbedding.record_id != record_id)
-        .where(RecordEmbedding.usable_by_config(model_name, config_fingerprint))
+        .where(RecordEmbedding.usable_by_stored_anchor(model_name, config_fingerprint))
         .where(RecordEmbedding.embedding.cosine_distance(embedding) <= max_distance)
         .order_by(RecordEmbedding.embedding.cosine_distance(embedding))
         .limit(limit)

--- a/backend/app/processing/embeddings/models.py
+++ b/backend/app/processing/embeddings/models.py
@@ -77,58 +77,40 @@ class RecordEmbedding(Base):
         either a catalog-wide re-embed nobody asked to pay for or a search that
         returns nothing until one finishes.
 
-        This is the predicate for readers comparing a FRESH vector against
-        stored rows: semantic search, the backfill's coverage question, the
-        admin panel. A reader comparing two STORED rows wants
-        ``usable_by_stored_anchor`` below, and fix(#1580 review r2) explains why
-        the two cannot be the same expression.
+        fix(#1580 review r2): ``config_fingerprint`` may be None, and then the
+        answer is the model name ALONE — an unstamped row is comparable to every
+        space of its model, so an unstamped ANCHOR must be comparable to every
+        space of its model too.
+
+        That symmetry is the whole point, and losing it is a real defect rather
+        than a rounding error. Comparability of two stored rows is a property of
+        the PAIR: whether A and B may be compared cannot depend on which one you
+        started from. The stamped branch already lets a stamped anchor see NULL
+        rows; rendering the None branch as ``IS NULL`` (SQLAlchemy's reading of
+        ``== None``) meant a NULL anchor could not see stamped ones, and the two
+        halves disagreed about the same pair.
+
+        The catalog that produces it is the ordinary one. Day zero after
+        migration 0052 every row is NULL. Any edit re-embeds and stamps ONE
+        record. From that moment the stamped record vanishes from every legacy
+        record's related list while still listing them itself, and it never
+        heals — Generate Missing treats a NULL row as covered, so nothing goes
+        back to stamp the rest. Every legacy list shrinks toward the records
+        nobody has touched, for as long as the instance runs.
+
+        The other symmetric rule — a stamped anchor matching its exact
+        fingerprint and nothing else — was considered and rejected. It empties a
+        freshly edited record's related list the day after an upgrade, and it
+        contradicts what #1546 already decided a NULL row MEANS: comparable to
+        any live space of its model. Search and related items have to agree
+        about that, and this is the reading that keeps them agreeing.
         """
+        if config_fingerprint is None:
+            return cls.model_name == model_name
         return and_(
             cls.model_name == model_name,
             or_(
                 cls.config_fingerprint.is_(None),
                 cls.config_fingerprint == config_fingerprint,
             ),
-        )
-
-    @classmethod
-    def usable_by_stored_anchor(
-        cls, model_name: str, config_fingerprint: str | None
-    ) -> ColumnElement[bool]:
-        """Match rows comparable against ANOTHER STORED row's configuration.
-
-        fix(#1580 review r2): a sibling of ``usable_by_config`` rather than a
-        call to it, because the two readers are asking different questions and
-        the answers differ on exactly one case — a stamped side meeting an
-        unstamped row.
-
-        ``usable_by_config`` grandfathers NULL because its caller holds a vector
-        made moments ago and the alternative was emptying semantic search on
-        upgrade day: every row in the table is unstamped then, so refusing them
-        would have returned nothing until a catalog-wide re-embed finished. The
-        weaker guarantee is worth it there because the unstamped rows are all
-        there is.
-
-        Here both sides are stored, and a STAMPED anchor is itself evidence that
-        the catalog is past that morning and at least partly regenerated. A NULL
-        candidate's space is unknown, and on the catalog where the distinction
-        bites — an endpoint change followed by a partial re-embed — the rows
-        still carrying NULL are most likely the ones in the OLD space. Comparing
-        them against a new-space anchor produces exactly the well-formed
-        meaningless cosine distance #1580 exists to remove, and it does so on
-        the records least likely to be looked at twice.
-
-        So: an unstamped anchor matches the unstamped rows of its model, which
-        keeps an all-legacy catalog's related items working unchanged; a stamped
-        anchor matches its exact fingerprint and nothing else. Grandfathering is
-        for the side that has no choice, not for the side that has evidence.
-        """
-        if config_fingerprint is None:
-            return and_(
-                cls.model_name == model_name,
-                cls.config_fingerprint.is_(None),
-            )
-        return and_(
-            cls.model_name == model_name,
-            cls.config_fingerprint == config_fingerprint,
         )

--- a/backend/app/processing/embeddings/models.py
+++ b/backend/app/processing/embeddings/models.py
@@ -57,7 +57,7 @@ class RecordEmbedding(Base):
 
     @classmethod
     def usable_by_config(
-        cls, model_name: str, config_fingerprint: str
+        cls, model_name: str, config_fingerprint: str | None
     ) -> ColumnElement[bool]:
         """Match rows whose vector can be compared against ``config_fingerprint``.
 
@@ -76,6 +76,15 @@ class RecordEmbedding(Base):
         table is unstamped, and the alternative to grandfathering them is
         either a catalog-wide re-embed nobody asked to pay for or a search that
         returns nothing until one finishes.
+
+        fix(#1580): ``config_fingerprint`` may itself be None, because
+        related-items compares two STORED rows and takes the pair off the anchor
+        row rather than off the live configuration (see
+        ``get_anchor_embedding_row``). SQLAlchemy renders ``== None`` as ``IS
+        NULL``, so an unstamped anchor selects the unstamped rows of its own
+        model and nothing else. That is the same grandfathering read from the
+        other side, and it keeps a legacy catalog's related-items working
+        unchanged instead of emptying it.
         """
         return and_(
             cls.model_name == model_name,

--- a/backend/app/processing/embeddings/models.py
+++ b/backend/app/processing/embeddings/models.py
@@ -77,33 +77,78 @@ class RecordEmbedding(Base):
         either a catalog-wide re-embed nobody asked to pay for or a search that
         returns nothing until one finishes.
 
-        fix(#1580 review r2): ``config_fingerprint`` may be None, and then the
-        answer is the model name ALONE — an unstamped row is comparable to every
-        space of its model, so an unstamped ANCHOR must be comparable to every
-        space of its model too.
+        This is the predicate for a reader comparing a FRESH vector against
+        stored rows: semantic search, the backfill's coverage question, the
+        admin panel. It always receives a resolved configuration, never None.
 
-        That symmetry is the whole point, and losing it is a real defect rather
-        than a rounding error. Comparability of two stored rows is a property of
-        the PAIR: whether A and B may be compared cannot depend on which one you
-        started from. The stamped branch already lets a stamped anchor see NULL
-        rows; rendering the None branch as ``IS NULL`` (SQLAlchemy's reading of
-        ``== None``) meant a NULL anchor could not see stamped ones, and the two
-        halves disagreed about the same pair.
+        A reader comparing two STORED rows uses ``usable_by_stored_anchor``
+        below. The two expressions agree today; they are separate because the
+        questions are, and because fix(#1580 review r2) had to argue out what a
+        NULL row means from the anchor side. That argument belongs next to the
+        reader it governs, not folded into this one.
+        """
+        return and_(
+            cls.model_name == model_name,
+            or_(
+                cls.config_fingerprint.is_(None),
+                cls.config_fingerprint == config_fingerprint,
+            ),
+        )
 
-        The catalog that produces it is the ordinary one. Day zero after
-        migration 0052 every row is NULL. Any edit re-embeds and stamps ONE
-        record. From that moment the stamped record vanishes from every legacy
-        record's related list while still listing them itself, and it never
-        heals — Generate Missing treats a NULL row as covered, so nothing goes
-        back to stamp the rest. Every legacy list shrinks toward the records
-        nobody has touched, for as long as the instance runs.
+    @classmethod
+    def usable_by_stored_anchor(
+        cls, model_name: str, config_fingerprint: str | None
+    ) -> ColumnElement[bool]:
+        """Match rows comparable against ANOTHER STORED row's configuration.
 
-        The other symmetric rule — a stamped anchor matching its exact
-        fingerprint and nothing else — was considered and rejected. It empties a
-        freshly edited record's related list the day after an upgrade, and it
-        contradicts what #1546 already decided a NULL row MEANS: comparable to
-        any live space of its model. Search and related items have to agree
-        about that, and this is the reading that keeps them agreeing.
+        fix(#1580 review r2). Related items compares two stored rows, so the
+        pair — not the live configuration — decides comparability, and the
+        anchor's fingerprint may itself be NULL. That raises a question search
+        never has to answer: what may a NULL side be compared against?
+
+        **The rule: an unstamped side is comparable to every space of its
+        model, whichever side it is on.** A NULL anchor matches every row of its
+        model; a stamped anchor matches its own fingerprint OR NULL.
+
+        The alternative was strict — a stamped anchor matching its exact
+        fingerprint and nothing else — and the argument for it is real: a
+        stamped anchor is evidence the catalog is past upgrade morning, a NULL
+        candidate's space is unknown, and after an endpoint change plus a
+        partial re-embed the rows still carrying NULL are probably the old
+        space, so lenient produces some meaningless pairs.
+
+        Lenient won on three counts.
+
+        A stamped anchor is evidence the catalog is past upgrade morning; it is
+        NOT evidence the configuration changed. On the common path — every
+        deployment upgrading with the same model and endpoint — every NULL row
+        IS the same space as every stamped one, and strict makes both partitions
+        sparse for nothing: legacy records see only legacy, stamped see only
+        stamped.
+
+        Neither partition heals. Generate Missing treats a NULL row as covered,
+        so nothing goes back to stamp the rest, and the split persists for as
+        long as the instance runs rather than until the next backfill.
+
+        And search and related items have to agree about what a NULL row means.
+        #1546 already decided: comparable to any live space of its model. Strict
+        would have search return B for A while related items omitted it, on the
+        same two rows.
+
+        The rare path keeps its cost — some meaningless pairs after an endpoint
+        change — which is the acceptance #1546 already made for search, with
+        Regenerate All as the remedy.
+
+        SYMMETRY is the part that is not a judgement call. Comparability is a
+        property of the PAIR: whether A and B may be compared cannot depend on
+        which one you start from. Before this, ``usable_by_config(m, F)`` let a
+        stamped anchor see NULL rows while ``usable_by_config(m, None)``
+        rendered both arms as ``IS NULL`` (SQLAlchemy's reading of ``== None``)
+        so the NULL side could not see back — and the ordinary catalog produces
+        it, because one edit after an upgrade stamps ONE record and that record
+        then vanishes from every legacy record's list while still listing them.
+        Both candidate rules are symmetric; only the shipped one is also
+        consistent with what #1546 decided a NULL row means.
         """
         if config_fingerprint is None:
             return cls.model_name == model_name

--- a/backend/app/processing/embeddings/models.py
+++ b/backend/app/processing/embeddings/models.py
@@ -77,14 +77,11 @@ class RecordEmbedding(Base):
         either a catalog-wide re-embed nobody asked to pay for or a search that
         returns nothing until one finishes.
 
-        fix(#1580): ``config_fingerprint`` may itself be None, because
-        related-items compares two STORED rows and takes the pair off the anchor
-        row rather than off the live configuration (see
-        ``get_anchor_embedding_row``). SQLAlchemy renders ``== None`` as ``IS
-        NULL``, so an unstamped anchor selects the unstamped rows of its own
-        model and nothing else. That is the same grandfathering read from the
-        other side, and it keeps a legacy catalog's related-items working
-        unchanged instead of emptying it.
+        This is the predicate for readers comparing a FRESH vector against
+        stored rows: semantic search, the backfill's coverage question, the
+        admin panel. A reader comparing two STORED rows wants
+        ``usable_by_stored_anchor`` below, and fix(#1580 review r2) explains why
+        the two cannot be the same expression.
         """
         return and_(
             cls.model_name == model_name,
@@ -92,4 +89,46 @@ class RecordEmbedding(Base):
                 cls.config_fingerprint.is_(None),
                 cls.config_fingerprint == config_fingerprint,
             ),
+        )
+
+    @classmethod
+    def usable_by_stored_anchor(
+        cls, model_name: str, config_fingerprint: str | None
+    ) -> ColumnElement[bool]:
+        """Match rows comparable against ANOTHER STORED row's configuration.
+
+        fix(#1580 review r2): a sibling of ``usable_by_config`` rather than a
+        call to it, because the two readers are asking different questions and
+        the answers differ on exactly one case — a stamped side meeting an
+        unstamped row.
+
+        ``usable_by_config`` grandfathers NULL because its caller holds a vector
+        made moments ago and the alternative was emptying semantic search on
+        upgrade day: every row in the table is unstamped then, so refusing them
+        would have returned nothing until a catalog-wide re-embed finished. The
+        weaker guarantee is worth it there because the unstamped rows are all
+        there is.
+
+        Here both sides are stored, and a STAMPED anchor is itself evidence that
+        the catalog is past that morning and at least partly regenerated. A NULL
+        candidate's space is unknown, and on the catalog where the distinction
+        bites — an endpoint change followed by a partial re-embed — the rows
+        still carrying NULL are most likely the ones in the OLD space. Comparing
+        them against a new-space anchor produces exactly the well-formed
+        meaningless cosine distance #1580 exists to remove, and it does so on
+        the records least likely to be looked at twice.
+
+        So: an unstamped anchor matches the unstamped rows of its model, which
+        keeps an all-legacy catalog's related items working unchanged; a stamped
+        anchor matches its exact fingerprint and nothing else. Grandfathering is
+        for the side that has no choice, not for the side that has evidence.
+        """
+        if config_fingerprint is None:
+            return and_(
+                cls.model_name == model_name,
+                cls.config_fingerprint.is_(None),
+            )
+        return and_(
+            cls.model_name == model_name,
+            cls.config_fingerprint == config_fingerprint,
         )

--- a/backend/app/processing/embeddings/service.py
+++ b/backend/app/processing/embeddings/service.py
@@ -500,14 +500,22 @@ async def generate_and_store_embedding(
         # the insert branch — leaving the old stamp would label the new vector
         # with the configuration of the one it replaced.
         existing.config_fingerprint = config_fingerprint
-        # fix(#1580 review r2): the DB clock, like the insert branch's
-        # server_default and like backfill.py's upsert. This stamped the APP
-        # clock, and fix(#1580) made the column load-bearing — the anchor row
-        # for a related-items comparison is the most recently written one, so a
-        # worker whose clock runs behind the database's could write a row that
-        # sorts BEFORE the one it replaced and leave the superseded vector
-        # answering as the anchor.
-        existing.updated_at = func.now()
+        # fix(#1580 review r2): the DB clock rather than the app's. fix(#1580)
+        # made this column load-bearing — related items anchors on a record's
+        # most recently written row — and a worker whose clock runs behind the
+        # database's could otherwise write a row that sorts BEFORE the one it
+        # replaced.
+        #
+        # fix(#1580 review r3): `clock_timestamp()`, not `now()`. `now()` is
+        # TRANSACTION-START time, so a job that opens its transaction, spends
+        # thirty seconds in a provider call and commits after another model's
+        # job carries the EARLIER stamp despite being the later write. Both
+        # branches are stamped explicitly for the same reason: the column's
+        # `server_default` is `now()` too, so an INSERT that took the default
+        # would disagree with an UPDATE that did not. The default itself stays
+        # as it is — changing it is a migration, and it is the fallback for
+        # rows nothing writes deliberately.
+        existing.updated_at = func.clock_timestamp()
     else:
         session.add(
             RecordEmbedding(
@@ -516,6 +524,7 @@ async def generate_and_store_embedding(
                 model_name=model_name,
                 config_fingerprint=config_fingerprint,
                 content_hash=content_hash,
+                updated_at=func.clock_timestamp(),
             )
         )
 

--- a/backend/app/processing/embeddings/service.py
+++ b/backend/app/processing/embeddings/service.py
@@ -2,10 +2,9 @@
 
 import hashlib
 import uuid
-from datetime import datetime, timezone
 
 import structlog
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.config import settings
@@ -501,7 +500,14 @@ async def generate_and_store_embedding(
         # the insert branch — leaving the old stamp would label the new vector
         # with the configuration of the one it replaced.
         existing.config_fingerprint = config_fingerprint
-        existing.updated_at = datetime.now(timezone.utc)
+        # fix(#1580 review r2): the DB clock, like the insert branch's
+        # server_default and like backfill.py's upsert. This stamped the APP
+        # clock, and fix(#1580) made the column load-bearing — the anchor row
+        # for a related-items comparison is the most recently written one, so a
+        # worker whose clock runs behind the database's could write a row that
+        # sorts BEFORE the one it replaced and leave the superseded vector
+        # answering as the anchor.
+        existing.updated_at = func.now()
     else:
         session.add(
             RecordEmbedding(

--- a/backend/tests/test_embedding_tenant_isolation.py
+++ b/backend/tests/test_embedding_tenant_isolation.py
@@ -21,11 +21,16 @@ from app.processing.embeddings import service as service_module
 from tests.fixtures.dummy_overlay.tenant_isolation import TenantIsolationSurface
 
 
-def _result(*, rows=(), scalar=None):
+def _result(*, rows=(), scalar=None, first=None):
     result = MagicMock()
     result.all.return_value = list(rows)
     result.scalar_one.return_value = scalar
     result.scalar_one_or_none.return_value = scalar
+    # fix(#1580): the anchor read returns the row rather than one column, so it
+    # goes through `.first()`. Left as an explicit None by default: a MagicMock
+    # here would be truthy and unpack into three MagicMocks, which is how a
+    # caller that stopped reading a real row would still look like it worked.
+    result.first.return_value = first
     return result
 
 
@@ -62,7 +67,9 @@ async def test_embedding_helper_queries_join_rls_visible_records(monkeypatch):
     presence_sql = str(presence_session.execute.await_args.args[0])
     assert "JOIN catalog.records AS visible_record" in presence_sql
 
-    source_result = _result(scalar=[1.0, 0.0, 0.0])
+    # fix(#1580): the anchor read now selects the row's identity alongside its
+    # vector, so the stub returns the triple `get_anchor_embedding_row` unpacks.
+    source_result = _result(first=([1.0, 0.0, 0.0], "tenant-isolation-model", None))
     hnsw_result = _result()
     neighbor_result = _result(rows=[])
     nearest_session = AsyncMock()

--- a/backend/tests/test_embedding_tenant_isolation.py
+++ b/backend/tests/test_embedding_tenant_isolation.py
@@ -60,6 +60,23 @@ async def test_embedding_helper_queries_join_rls_visible_records(monkeypatch):
         "resolve_embedding_model_name",
         AsyncMock(return_value="tenant-isolation-model"),
     )
+    # fix(#1580 review r4): the fingerprint resolver too. The anchor read orders
+    # by "the row search would use", so it asks what the live configuration IS
+    # before running its own query — and that resolution goes to the database on
+    # a cold persistent-config cache, consuming one of the three results queued
+    # below and killing the test with StopAsyncIteration.
+    #
+    # It went unnoticed because the failure is ORDER-DEPENDENT: run after any
+    # test that warms the config cache and the resolver answers without a query,
+    # so a whole-file or whole-suite run is green and this node alone is red.
+    # Both resolvers are stubbed now, so what this test asserts — that every
+    # embedding helper crosses the Record boundary — no longer depends on what
+    # ran before it.
+    monkeypatch.setattr(
+        helpers,
+        "resolve_embedding_config_fingerprint",
+        AsyncMock(return_value="f" * 64),
+    )
 
     presence_session = AsyncMock()
     presence_session.execute.return_value = _result(scalar=True)

--- a/backend/tests/test_extension_api_version.py
+++ b/backend/tests/test_extension_api_version.py
@@ -78,6 +78,24 @@ class TestExtensionApiVersionConstant:
         raises TypeError on the first semantic search. Both are required in the
         convention's sense, and both land in one change, so they share a bump.
 
+        v8 carries two MORE ``CatalogPort`` shape changes (fix(#1580)), on the
+        related-items path, and stays at 8. ``get_record_embedding`` returns the
+        anchor row's ``(embedding, model_name, config_fingerprint)`` rather than
+        a bare vector, because that comparison is between two STORED rows and
+        the caller has to be able to name the space it is working in; an overlay
+        still returning a list is unpacked into three names and raises on the
+        first related-items request. ``get_embedding_distances`` gains required
+        keyword-only ``model_name`` and ``config_fingerprint``, required rather
+        than defaulted so an overlay cannot keep scoring neighbours in a foreign
+        space by omission; the old signature raises TypeError on the same
+        request.
+
+        No second bump because #1546 and #1580 ship in one release with no core
+        release between them. The number exists so an overlay author knows when
+        to update, and there is one update to perform here; a second number
+        would be a second pin to maintain for a migration nobody does
+        separately. Four required changes, one contract, one integer.
+
         Update this pin, and the note above it, whenever the constant moves.
         """
         from app.platform.extensions.version import EXTENSION_API_VERSION

--- a/backend/tests/test_extension_api_version.py
+++ b/backend/tests/test_extension_api_version.py
@@ -83,8 +83,9 @@ class TestExtensionApiVersionConstant:
         ``(embedding, model_name, config_fingerprint)`` rather than a bare
         vector, because that comparison is between two STORED rows and the
         caller has to be able to name the space it is working in; an overlay
-        still returning a list is unpacked into three names and raises on the
-        first related-items request. ``get_embedding_distances`` gains required
+        still returning a list is unpacked into three names by
+        ``_compute_neighbor_distances`` and raises on the first related-items
+        request. ``get_embedding_distances`` gains required
         keyword-only ``model_name`` and ``config_fingerprint``, required rather
         than defaulted so an overlay cannot keep scoring neighbours in a foreign
         space by omission; the old signature raises TypeError on the same

--- a/backend/tests/test_extension_api_version.py
+++ b/backend/tests/test_extension_api_version.py
@@ -88,9 +88,12 @@ class TestExtensionApiVersionConstant:
         keyword-only ``model_name`` and ``config_fingerprint``, required rather
         than defaulted so an overlay cannot keep scoring neighbours in a foreign
         space by omission; the old signature raises TypeError on the same
-        request.
+        request. ``get_nearest_record_ids`` likewise takes the caller's
+        already-read anchor as a required keyword rather than reading one for
+        itself, so the ranking and the scoring cannot end up on two different
+        rows of the same record when a commit lands between two reads.
 
-        Those two were briefly folded into v8 and then un-folded, on the
+        Those three were briefly folded into v8 and then un-folded, on the
         reasoning that #1546 and #1580 ship in one release. The constant pins
         the contract at a COMMIT: main was a v8 contract from the moment #1546
         merged, so an overlay declaring 8 against it would have booted cleanly

--- a/backend/tests/test_extension_api_version.py
+++ b/backend/tests/test_extension_api_version.py
@@ -78,11 +78,11 @@ class TestExtensionApiVersionConstant:
         raises TypeError on the first semantic search. Both are required in the
         convention's sense, and both land in one change, so they share a bump.
 
-        v8 carries two MORE ``CatalogPort`` shape changes (fix(#1580)), on the
-        related-items path, and stays at 8. ``get_record_embedding`` returns the
-        anchor row's ``(embedding, model_name, config_fingerprint)`` rather than
-        a bare vector, because that comparison is between two STORED rows and
-        the caller has to be able to name the space it is working in; an overlay
+        v9 carries two ``CatalogPort`` shape changes (fix(#1580)), on the
+        related-items path. ``get_record_embedding`` returns the anchor row's
+        ``(embedding, model_name, config_fingerprint)`` rather than a bare
+        vector, because that comparison is between two STORED rows and the
+        caller has to be able to name the space it is working in; an overlay
         still returning a list is unpacked into three names and raises on the
         first related-items request. ``get_embedding_distances`` gains required
         keyword-only ``model_name`` and ``config_fingerprint``, required rather
@@ -90,17 +90,19 @@ class TestExtensionApiVersionConstant:
         space by omission; the old signature raises TypeError on the same
         request.
 
-        No second bump because #1546 and #1580 ship in one release with no core
-        release between them. The number exists so an overlay author knows when
-        to update, and there is one update to perform here; a second number
-        would be a second pin to maintain for a migration nobody does
-        separately. Four required changes, one contract, one integer.
+        Those two were briefly folded into v8 and then un-folded, on the
+        reasoning that #1546 and #1580 ship in one release. The constant pins
+        the contract at a COMMIT: main was a v8 contract from the moment #1546
+        merged, so an overlay declaring 8 against it would have booted cleanly
+        against post-#1580 core and then failed on the first related-items
+        request, inside a broad handler, as an empty list. Silent skew is what
+        this check refuses, and release boundaries are not what it measures.
 
         Update this pin, and the note above it, whenever the constant moves.
         """
         from app.platform.extensions.version import EXTENSION_API_VERSION
 
-        assert EXTENSION_API_VERSION == 8
+        assert EXTENSION_API_VERSION == 9
 
 
 class TestCheckExtensionApiVersion:

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1736,7 +1736,11 @@ def test_decomposed_service_modules_stay_within_size_budgets() -> None:
         # the lines are the two docstrings saying why the anchor's own pair is
         # the question here, where both sides are stored rows, rather than the
         # live configuration's. Cap 635 -> 653, exact.
-        "backend/app/modules/catalog/datasets/domain/service_relationships.py": 653,
+        # fix(#1580 review r2): +4 — the anchor read is handed into the
+        # neighbour selection rather than left to be taken again. Two reads of
+        # one record under READ COMMITTED can straddle a commit, and then the
+        # ranking is anchored on a row the scoring never saw. Cap 653 -> 657.
+        "backend/app/modules/catalog/datasets/domain/service_relationships.py": 657,
         # fix(#474): reject primary-language updates that collide with a
         # translated variant. Cap 460 -> 480 (~9 LOC headroom above 471).
         # fix(#931): +7. _apply_visibility_change no longer carries its own
@@ -1905,7 +1909,14 @@ def test_decomposed_service_modules_stay_within_size_budgets() -> None:
         # why scoping the selection without scoping the distances would have
         # moved the defect one layer out rather than closing it.
         # Cap 478 -> 491, exact.
-        "backend/app/platform/extensions/defaults_catalog_port.py": 491,
+        # fix(#1580 review r2): +18 — get_nearest_record_ids takes the caller's
+        # anchor as a required keyword, and both queries move to
+        # usable_by_stored_anchor. The lines are the two comments saying why the
+        # stored-vs-stored predicate does not grandfather an unstamped row where
+        # search's does: on the catalog that distinction matters for, a partial
+        # re-embed, the rows still carrying NULL are the old space.
+        # Cap 491 -> 509, exact.
+        "backend/app/platform/extensions/defaults_catalog_port.py": 509,
         # feat(#683): +58 — run_analysis_preview carries a clip mask DATASET
         # now, which costs a widened signature (one param per line once ruff
         # wraps it) plus the mask's shape and size gates. Those live here on

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1728,7 +1728,15 @@ def test_decomposed_service_modules_stay_within_size_budgets() -> None:
         # against the base table (a relationship may target a column the
         # projection drops), with the identifier colon-escaped for text().
         # Cap 628 -> 635, exact.
-        "backend/app/modules/catalog/datasets/domain/service_relationships.py": 635,
+        # fix(#1580): +18 — the related-items seed is the anchor ROW now, not a
+        # bare vector, and the pair travels from it into the scoring call. A
+        # list of floats does not say which model or endpoint produced it, so
+        # without carrying the identity this layer could select neighbours in
+        # one vector space and print similarities measured in another. Most of
+        # the lines are the two docstrings saying why the anchor's own pair is
+        # the question here, where both sides are stored rows, rather than the
+        # live configuration's. Cap 635 -> 653, exact.
+        "backend/app/modules/catalog/datasets/domain/service_relationships.py": 653,
         # fix(#474): reject primary-language updates that collide with a
         # translated variant. Cap 460 -> 480 (~9 LOC headroom above 471).
         # fix(#931): +7. _apply_visibility_change no longer carries its own
@@ -1889,7 +1897,15 @@ def test_decomposed_service_modules_stay_within_size_budgets() -> None:
         # argument and not three keyword ones: `None` is a legitimate resolved
         # endpoint, so three None defaults could not tell "not pinned" from
         # "pinned to the client default". Cap 461 -> 478, exact.
-        "backend/app/platform/extensions/defaults_catalog_port.py": 478,
+        # fix(#1580): +13, and the code shrank — get_record_embedding stopped
+        # spelling its own query and now shares `get_anchor_embedding_row` with
+        # the ranking helper, so "which row is the anchor" has one answer
+        # instead of two `LIMIT 1` reads that could disagree. The lines are the
+        # two comments: why the anchor's identity travels with its vector, and
+        # why scoping the selection without scoping the distances would have
+        # moved the defect one layer out rather than closing it.
+        # Cap 478 -> 491, exact.
+        "backend/app/platform/extensions/defaults_catalog_port.py": 491,
         # feat(#683): +58 — run_analysis_preview carries a clip mask DATASET
         # now, which costs a widened signature (one param per line once ruff
         # wraps it) plus the mask's shape and size gates. Those live here on

--- a/backend/tests/test_related_items_config_scope_1580.py
+++ b/backend/tests/test_related_items_config_scope_1580.py
@@ -39,6 +39,8 @@ from datetime import UTC, datetime
 from types import SimpleNamespace
 
 import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+from unittest.mock import AsyncMock
 from httpx import AsyncClient
 
 from app.platform.extensions.defaults_catalog_port import DefaultCatalogPort
@@ -763,4 +765,194 @@ async def test_a_commit_between_the_two_reads_cannot_split_the_anchor(
         f"related items returned {sorted(items)}. The seed's own space has a "
         f"neighbour in it; a selection anchored on a row the scoring never saw "
         f"finds nothing it can then score."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Review r3: the timestamp is not as ordered as it looks
+# ---------------------------------------------------------------------------
+
+
+async def test_the_anchor_prefers_the_row_search_would_use(
+    test_db_session, space, monkeypatch
+):
+    """fix(#1580 review r3): live-usable first, timestamp only as a tiebreak.
+
+    PostgreSQL `now()` is TRANSACTION-START time, and both the column default and
+    the ingest re-stamp used it. A job that opens its transaction, spends thirty
+    seconds in a provider call and commits AFTER another model's job therefore
+    carries the EARLIER stamp despite being the later write — so "newest wins"
+    could leave related items anchored to a row that lost the race it won.
+
+    Ordering by the live-usable row first removes the dependency rather than
+    patching it, and buys the stronger property on the way: whenever a record has
+    a row search itself would retrieve, related items anchors on THAT row, so the
+    two readers agree by construction. A model rollback is where the difference
+    shows — "newest" picks the rolled-back row, and search and related items then
+    disagree about the same record.
+
+    The stamps here are inverted deliberately: the live-usable row is the OLDER
+    one, so an implementation still ordering on time alone fails.
+    """
+    from app.processing.embeddings import helpers
+
+    record = await _dataset(test_db_session, "Live Preferred")
+    monkeypatch.setattr(
+        helpers, "resolve_embedding_model_name", AsyncMock(return_value=space.model)
+    )
+    monkeypatch.setattr(
+        helpers,
+        "resolve_embedding_config_fingerprint",
+        AsyncMock(return_value=space.config_a),
+    )
+
+    await _add_row(
+        test_db_session,
+        record.record_id,
+        _V_ANCHOR,
+        model_name=space.model,
+        config_fingerprint=space.config_a,
+        updated_at=datetime(2026, 1, 1, tzinfo=UTC),
+    )
+    await _add_row(
+        test_db_session,
+        record.record_id,
+        _V_MID,
+        model_name=space.other_model,
+        config_fingerprint=space.config_b,
+        updated_at=datetime(2026, 6, 1, tzinfo=UTC),
+    )
+
+    anchor = await helpers.get_anchor_embedding_row(test_db_session, record.record_id)
+
+    assert anchor is not None
+    _, model_name, config_fingerprint = anchor
+    assert (model_name, config_fingerprint) == (space.model, space.config_a), (
+        f"the anchor resolved to ({model_name}, {config_fingerprint}); search "
+        f"would use the live-configuration row, so related items must too, and "
+        f"the newer row here is the one search cannot retrieve"
+    )
+
+
+async def test_the_timestamp_still_decides_among_stale_rows(
+    test_db_session, space, monkeypatch
+):
+    """The fallback: with no live-usable row, the later write wins.
+
+    The counterfactual for the test above. An implementation that always
+    preferred, say, the lowest model name would pass that one and lose the
+    property #1580 established — a record with only superseded rows still
+    anchors on the most recent of them.
+    """
+    from app.processing.embeddings import helpers
+
+    record = await _dataset(test_db_session, "Stale Fallback")
+    monkeypatch.setattr(
+        helpers,
+        "resolve_embedding_model_name",
+        AsyncMock(return_value=f"{space.model}-nothing-matches"),
+    )
+    monkeypatch.setattr(
+        helpers,
+        "resolve_embedding_config_fingerprint",
+        AsyncMock(return_value=space.config_a),
+    )
+
+    await _add_row(
+        test_db_session,
+        record.record_id,
+        _V_MID,
+        model_name=space.model,
+        config_fingerprint=space.config_a,
+        updated_at=datetime(2026, 1, 1, tzinfo=UTC),
+    )
+    await _add_row(
+        test_db_session,
+        record.record_id,
+        _V_ANCHOR,
+        model_name=space.other_model,
+        config_fingerprint=space.config_b,
+        updated_at=datetime(2026, 6, 1, tzinfo=UTC),
+    )
+
+    anchor = await helpers.get_anchor_embedding_row(test_db_session, record.record_id)
+
+    assert anchor is not None
+    _, model_name, config_fingerprint = anchor
+    assert (model_name, config_fingerprint) == (space.other_model, space.config_b), (
+        f"the anchor resolved to ({model_name}, {config_fingerprint}); with "
+        f"nothing live-usable the most recent write is the answer"
+    )
+
+
+async def test_both_write_branches_stamp_the_statement_clock():
+    """`clock_timestamp()` on the update AND the insert, not `now()`.
+
+    `now()` is TRANSACTION-START time, so a writer that spends thirty seconds in
+    a provider call before committing stamps a row with a time from before the
+    work — and fix(#1580) made this column decide which row a comparison anchors
+    on, so an ordering built on it inherited that error.
+
+    BOTH branches, because they have to agree with each other. Stamping only the
+    UPDATE leaves a first-time INSERT taking the column's `server_default`, which
+    is `now()` — so the two writers would order differently for no reason a
+    reader could see, and the bug would survive on exactly the rows written
+    first. gl-1546 found the same trap in #1584's upsert, where a `set_` clause
+    covers only the ON CONFLICT branch.
+
+    The `server_default` itself is untouched: changing it is a migration, and it
+    is the fallback for rows nothing stamps deliberately.
+
+    Asserted on what the code ASSIGNS rather than on what the database stores,
+    because the two clocks differ only inside a transaction that does real work,
+    and staging one here would be measuring the test's own timing.
+    """
+    from unittest.mock import MagicMock, patch
+
+    from app.processing.embeddings.models import RecordEmbedding
+    from app.processing.embeddings.service import generate_and_store_embedding
+
+    async def _run(existing_row):
+        result = MagicMock()
+        result.scalar_one_or_none.return_value = existing_row
+        session = AsyncMock(spec=AsyncSession)
+        session.execute = AsyncMock(return_value=result)
+        with (
+            patch("app.processing.embeddings.service.AI_ENABLED") as ai,
+            patch(
+                "app.processing.embeddings.service.generate_embeddings_batch",
+                new_callable=AsyncMock,
+                return_value=[[0.1] * 1536],
+            ),
+            patch(
+                "app.processing.embeddings.service.resolve_live_embedding_config",
+                new_callable=AsyncMock,
+                return_value=("m", 1536, None, "f" * 64),
+            ),
+        ):
+            ai.get = AsyncMock(return_value=True)
+            await generate_and_store_embedding(
+                session=session,
+                record_id=uuid.uuid4(),
+                title="Clock",
+                summary="A summary",
+                keywords=None,
+                lineage=None,
+            )
+        return session
+
+    inserted = (await _run(None)).add.call_args[0][0]
+    assert isinstance(inserted, RecordEmbedding)
+    assert "clock_timestamp" in str(inserted.updated_at), (
+        f"the INSERT branch stamped {inserted.updated_at!r}; a row that takes "
+        f"the server_default carries transaction-start time and disagrees with "
+        f"every row the update branch writes"
+    )
+
+    existing = MagicMock()
+    existing.content_hash = "stale"
+    await _run(existing)
+    assert "clock_timestamp" in str(existing.updated_at), (
+        f"the UPDATE branch stamped {existing.updated_at!r}, which is "
+        f"transaction-start time — earlier than work that finished before it"
     )

--- a/backend/tests/test_related_items_config_scope_1580.py
+++ b/backend/tests/test_related_items_config_scope_1580.py
@@ -637,6 +637,56 @@ async def test_the_port_hands_the_anchors_identity_to_its_caller(
     ), "the port and the ranking helper must resolve the same anchor row"
 
 
+def test_both_stored_readers_use_the_stored_anchor_predicate():
+    """The selection and the scoring must apply the same rule.
+
+    They are two independent readers of one question, and fix(#1580) already had
+    to fix this exact pair once — scoping the selection left the scoring
+    reporting distances measured off a foreign model's row. A rule that lives in
+    two call sites can drift in the source even when no test data can tell them
+    apart.
+
+    Which is the situation here: `uq_record_embedding_model` is
+    `(record_id, model_name)`, so one record cannot hold both a stamped and an
+    unstamped row of the same model, and a neighbour whose only row would be
+    filtered is already removed by the selection. There is no catalog that
+    exercises the scoring query's NULL arm on its own, so the coupling is
+    asserted directly instead.
+
+    Comments are stripped and the CALL form is matched, not the bare name. The
+    first version of this scanned raw source and failed on the explanatory
+    comment beside the call it was checking — a predicate that cannot tell a
+    mention from a use answers a question nobody asked.
+    """
+    import inspect
+
+    from app.platform.extensions import defaults_catalog_port
+    from app.processing.embeddings import helpers
+
+    def _code(fn) -> str:
+        return "\n".join(
+            line
+            for line in inspect.getsource(fn).splitlines()
+            if not line.strip().startswith("#")
+        )
+
+    readers = {
+        "selection": _code(helpers.get_nearest_record_ids),
+        "scoring": _code(
+            defaults_catalog_port.DefaultCatalogPort.get_embedding_distances
+        ),
+    }
+
+    for name, source in readers.items():
+        assert "usable_by_stored_anchor(" in source, (
+            f"the {name} query does not call the stored-vs-stored predicate"
+        )
+        assert "usable_by_config(" not in source, (
+            f"the {name} query calls search's predicate. The two agree today, "
+            f"which is exactly why a divergence here would be silent."
+        )
+
+
 # ---------------------------------------------------------------------------
 # Review r2: one read, not two
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_related_items_config_scope_1580.py
+++ b/backend/tests/test_related_items_config_scope_1580.py
@@ -307,26 +307,31 @@ async def test_an_anchor_from_a_superseded_configuration_still_finds_its_own_spa
     )
 
 
-async def test_an_unstamped_anchor_matches_unstamped_rows_of_its_model(
+async def test_an_unstamped_anchor_reaches_every_space_of_its_model(
     client: AsyncClient, admin_auth_header: dict, test_db_session, space
 ):
-    """Grandfathering, read from the anchor side (#1546's NULL arm).
+    """Grandfathering, read from the anchor side, and it is SYMMETRIC.
 
-    Every row in the table before migration 0052 is unstamped, and #1546 kept
-    them usable rather than empty semantic search on upgrade. The same has to
-    hold here, or related-items goes blank the morning after an upgrade on a
-    catalog where nothing is wrong.
+    #1546 decided what a NULL row means: comparable to any live space of its
+    model, because every row is NULL the day migration 0052 lands and refusing
+    them would empty semantic search until a catalog-wide re-embed finished.
+    Related items has to agree with that, and agree in both directions.
 
-    `usable_by_config(model, None)` renders `config_fingerprint IS NULL`, so an
-    unstamped anchor selects the unstamped rows of its own model. A stamped row
-    belongs to a configuration this one cannot be compared against, and the
-    second assertion is the counterfactual for the first: without it this test
-    would pass against a reader that ignored the stamp entirely, which is the
-    state being fixed.
+    Comparability of two stored rows is a property of the PAIR. Whether A and B
+    may be compared cannot depend on which one you start from, so if a stamped
+    anchor sees a NULL row — which it does, and did before this PR — then a NULL
+    anchor must see the stamped one. ``usable_by_config(model, None)`` returning
+    the model predicate ALONE is what makes those two statements the same
+    statement.
+
+    The counterfactual is a NULL row under ANOTHER model, which must still be
+    excluded: without it this would pass against a reader that had dropped the
+    model half as well, and "comparable to everything" is not the rule.
     """
     anchor = await _dataset(test_db_session, "Legacy Anchor")
     legacy_peer = await _dataset(test_db_session, "Legacy Peer")
     stamped = await _dataset(test_db_session, "Legacy Stamped")
+    foreign_model = await _dataset(test_db_session, "Legacy Other Model")
 
     await _add_row(test_db_session, anchor.record_id, _V_ANCHOR, model_name=space.model)
     await _add_row(
@@ -335,22 +340,84 @@ async def test_an_unstamped_anchor_matches_unstamped_rows_of_its_model(
     await _add_row(
         test_db_session,
         stamped.record_id,
-        _V_ANCHOR,
+        _V_NEAR,
         model_name=space.model,
         config_fingerprint=space.config_a,
+    )
+    await _add_row(
+        test_db_session,
+        foreign_model.record_id,
+        _V_ANCHOR,
+        model_name=space.other_model,
     )
 
     names = set(await _related(client, admin_auth_header, anchor.id))
 
     assert "Legacy Peer" in names, (
         f"related items returned {sorted(names)}. An all-unstamped catalog is "
-        f"what every instance looks like the day it upgrades, and it must "
-        f"behave exactly as it did before."
+        f"what every instance looks like the day it upgrades."
     )
-    assert "Legacy Stamped" not in names, (
-        f"related items returned {sorted(names)}. A stamped row belongs to a "
-        f"known configuration and an unstamped one does not, so the two are not "
-        f"comparable in the direction that matters."
+    assert "Legacy Stamped" in names, (
+        f"related items returned {sorted(names)}. A stamped anchor sees this "
+        f"record's NULL sibling, so this record must see it back — otherwise the "
+        f"same pair is comparable or not depending on which end you ask from, "
+        f"and every legacy list shrinks as records get re-embedded one at a time."
+    )
+    assert "Legacy Other Model" not in names, (
+        f"related items returned {sorted(names)}. Grandfathering a NULL "
+        f"fingerprint must not grandfather the model name with it."
+    )
+
+
+async def test_comparability_is_the_same_in_both_directions(
+    client: AsyncClient, admin_auth_header: dict, test_db_session, space
+):
+    """``related(A)`` contains B if and only if ``related(B)`` contains A.
+
+    The defect this pins is not a wrong answer in one response; it is two
+    responses that disagree about one pair. ``usable_by_config(m, F)`` let a
+    stamped anchor see NULL rows while ``usable_by_config(m, None)`` rendered
+    both arms as ``IS NULL``, so the NULL side could not see back.
+
+    The path to it is the ordinary one, which is why it earns a test. Day zero
+    after migration 0052 every row is NULL. One edit re-embeds and stamps ONE
+    record. From then on that record vanishes from every legacy record's related
+    list while still listing them itself, and it never heals: Generate Missing
+    treats a NULL row as covered, so nothing goes back to stamp the rest.
+
+    Asserted as an equivalence, then pinned to the true side. The equivalence
+    alone holds when NEITHER direction finds the other, which is a different
+    (and also wrong) rule rather than the one being described.
+    """
+    stamped = await _dataset(test_db_session, "Symmetry Stamped")
+    legacy = await _dataset(test_db_session, "Symmetry Legacy")
+
+    await _add_row(
+        test_db_session,
+        stamped.record_id,
+        _V_ANCHOR,
+        model_name=space.model,
+        config_fingerprint=space.config_a,
+    )
+    await _add_row(test_db_session, legacy.record_id, _V_NEAR, model_name=space.model)
+
+    from_stamped = "Symmetry Legacy" in await _related(
+        client, admin_auth_header, stamped.id
+    )
+    from_legacy = "Symmetry Stamped" in await _related(
+        client, admin_auth_header, legacy.id
+    )
+
+    assert from_stamped == from_legacy, (
+        f"the stamped record lists the legacy one: {from_stamped}. The legacy "
+        f"record lists the stamped one: {from_legacy}. Comparability is a "
+        f"property of the pair, so these cannot differ — and when they do, the "
+        f"legacy record's list quietly shrinks every time another record is "
+        f"re-embedded."
+    )
+    assert from_stamped, (
+        "neither direction found the other, so the equivalence above holds "
+        "vacuously; a NULL row is comparable to any space of its model"
     )
 
 
@@ -568,144 +635,6 @@ async def test_the_port_hands_the_anchors_identity_to_its_caller(
     assert returned == await helpers.get_anchor_embedding_row(
         test_db_session, record.record_id
     ), "the port and the ranking helper must resolve the same anchor row"
-
-
-# ---------------------------------------------------------------------------
-# Review r2: grandfathering is for the side that has no choice
-# ---------------------------------------------------------------------------
-
-
-async def test_a_stamped_anchor_does_not_reach_legacy_unstamped_rows(
-    client: AsyncClient, admin_auth_header: dict, test_db_session, space
-):
-    """fix(#1580 review r2): the stored-vs-stored predicate does not grandfather.
-
-    `usable_by_config` matches an unstamped row against any fingerprint, and
-    that is right for SEARCH: its caller holds a vector made moments ago, and on
-    upgrade day every row in the table is unstamped, so refusing them would
-    return nothing until a catalog-wide re-embed finished. The unstamped rows
-    are all there is.
-
-    Here both sides are stored and a STAMPED anchor is evidence the catalog is
-    past that morning and at least partly regenerated. The catalog where this
-    bites is an endpoint change followed by a partial re-embed: the rows still
-    carrying NULL are most likely the ones in the OLD space, and comparing them
-    against a new-space anchor is precisely the well-formed meaningless distance
-    this PR removes — on the records least likely to be looked at twice.
-
-    The legacy row here carries the anchor's own vector, so it is the nearest
-    neighbour that exists and nothing but the predicate can keep it out.
-    """
-    anchor = await _dataset(test_db_session, "Stamped Anchor")
-    same_space = await _dataset(test_db_session, "Stamped Peer")
-    legacy = await _dataset(test_db_session, "Legacy Leftover")
-
-    await _add_row(
-        test_db_session,
-        anchor.record_id,
-        _V_ANCHOR,
-        model_name=space.model,
-        config_fingerprint=space.config_a,
-    )
-    await _add_row(
-        test_db_session,
-        same_space.record_id,
-        _V_NEAR,
-        model_name=space.model,
-        config_fingerprint=space.config_a,
-    )
-    await _add_row(test_db_session, legacy.record_id, _V_ANCHOR, model_name=space.model)
-
-    items = await _related(client, admin_auth_header, anchor.id)
-
-    assert "Legacy Leftover" not in items, (
-        f"related items returned {sorted(items)}. That row predates the stamp, "
-        f"so which space it is in is unknown — and on the catalog this matters "
-        f"for, a partial re-embed, unknown means the old one."
-    )
-    assert "Stamped Peer" in items, (
-        f"related items returned {sorted(items)}; refusing NULL must not cost a "
-        f"record its own-configuration neighbours"
-    )
-
-
-def test_both_stored_readers_use_the_stored_anchor_predicate():
-    """The scoring query must not keep search's grandfathering either.
-
-    Asserted structurally rather than through data, because the data case is
-    unreachable: ``uq_record_embedding_model`` is ``(record_id, model_name)``, so
-    one record cannot hold both a stamped and an unstamped row of the same
-    model, and a neighbour whose only row is unstamped is already removed by the
-    selection filter. There is no catalog that exercises the scoring query's
-    NULL arm on its own.
-
-    Which is exactly why it needs pinning some other way. The selection and the
-    scoring are two independent readers of the same rule — fix(#1580) already
-    had to fix this pair once, when scoping the selection left the scoring
-    reporting distances from a foreign model — and a rule that cannot drift
-    apart in a test can still drift apart in the source.
-
-    A test that only named the wanted call would pass against a file that called
-    both, so the unwanted one is asserted absent too.
-
-    Comments are stripped and the CALL form is matched, not the bare name. The
-    first version of this scanned raw source and failed on the explanatory
-    comment beside the call it was checking — a predicate that cannot tell a
-    mention from a use answers a question nobody asked.
-    """
-    import inspect
-
-    from app.platform.extensions import defaults_catalog_port
-    from app.processing.embeddings import helpers
-
-    def _code(fn) -> str:
-        return "\n".join(
-            line
-            for line in inspect.getsource(fn).splitlines()
-            if not line.strip().startswith("#")
-        )
-
-    readers = {
-        "selection": _code(helpers.get_nearest_record_ids),
-        "scoring": _code(
-            defaults_catalog_port.DefaultCatalogPort.get_embedding_distances
-        ),
-    }
-
-    for name, source in readers.items():
-        assert "usable_by_stored_anchor(" in source, (
-            f"the {name} query does not call the stored-vs-stored predicate"
-        )
-        assert "usable_by_config(" not in source, (
-            f"the {name} query still calls search's predicate, which matches an "
-            f"unstamped row against a stamped anchor. Right for a fresh query "
-            f"vector, wrong for two stored rows."
-        )
-
-
-async def test_an_all_legacy_catalog_still_finds_its_neighbours(
-    client: AsyncClient, admin_auth_header: dict, test_db_session, space
-):
-    """The half that must NOT change: upgrade day still works.
-
-    Refusing NULL against a stamped anchor is only defensible because an
-    unstamped anchor keeps matching unstamped rows. Without this the morning
-    after migration 0052 — when every row in the table is unstamped — related
-    items would go blank on a catalog where nothing is wrong, which is the
-    outcome #1546's grandfathering exists to prevent.
-    """
-    anchor = await _dataset(test_db_session, "All Legacy Anchor")
-    peer = await _dataset(test_db_session, "All Legacy Peer")
-
-    await _add_row(test_db_session, anchor.record_id, _V_ANCHOR, model_name=space.model)
-    await _add_row(test_db_session, peer.record_id, _V_NEAR, model_name=space.model)
-
-    items = await _related(client, admin_auth_header, anchor.id)
-
-    assert "All Legacy Peer" in items, (
-        f"related items returned {sorted(items)} on an all-unstamped catalog, "
-        f"which is what every instance looks like the day it upgrades"
-    )
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_related_items_config_scope_1580.py
+++ b/backend/tests/test_related_items_config_scope_1580.py
@@ -1,0 +1,570 @@
+"""Related items compare stored vectors inside ONE space (#1580).
+
+`get_nearest_record_ids`, and the `get_record_embedding` / `get_embedding_distances`
+pair behind it, selected candidate rows from `catalog.record_embeddings` filtered
+by neither `model_name` nor, since #1546, `config_fingerprint`. So related-items
+compared one record's stored vector against every other record's, across model and
+configuration spaces, and returned cosine distances that were well-formed and
+meaningless whenever the table held more than one space.
+
+The rule here is NOT the one the search path uses, and the difference is the
+point. Semantic search compares a FRESH query vector against stored rows, so the
+live configuration is the right question. Both sides of this comparison are
+STORED rows, so the question is the ANCHOR row's: same model and same stamp as
+the row the comparison starts from. A record embedded under a superseded
+configuration finds its own-space neighbours, or finds none, and never crosses.
+`test_an_anchor_from_a_superseded_configuration_still_finds_its_own_space` is the
+one that fails if anyone reaches for the live configuration instead.
+
+Three readers had to learn it, not one. The selection picks the candidates; the
+scoring turns them into the similarity percentage the UI prints; and the anchor
+read decides which of the anchor's own rows both of those are about. Fixing only
+the first would have moved the defect one layer out, to the right neighbours
+scored in the wrong space, which is what
+`test_a_neighbour_is_scored_in_the_anchors_own_space` exists to catch.
+
+Every test seeds its own model names (the `space` fixture). The database is
+shared across this module, and every row this suite writes is a candidate
+neighbour for every other test in it; without the partition the assertions that
+name an exact result set would be reporting on their neighbours' fixtures.
+
+Requirements:
+  - Docker database must be running (docker compose up db)
+  - Run with: set -a && source ../.env.test && set +a
+              uv run pytest tests/test_related_items_config_scope_1580.py -v
+"""
+
+import uuid
+from datetime import UTC, datetime
+from types import SimpleNamespace
+
+import pytest
+from httpx import AsyncClient
+
+from app.platform.extensions.defaults_catalog_port import DefaultCatalogPort
+from app.processing.embeddings import helpers
+from app.processing.embeddings.helpers import (
+    embedding_config_fingerprint,
+    resolve_embedding_config_fingerprint,
+)
+from app.processing.embeddings.models import RecordEmbedding
+
+from tests.factories import create_dataset, get_user_id
+
+_DIMS = 1536
+
+
+@pytest.fixture(autouse=True)
+def _fresh_has_embeddings_cache():
+    """Clear the module-global has_embeddings cache before every test.
+
+    Same hazard class as `test_related_datasets.py` and `test_hybrid_search.py`:
+    this file inserts RecordEmbedding rows, so under xdist a stale cached False
+    would starve the vector path and our own inserts can poison True for later
+    tests.
+    """
+    helpers._has_embeddings_cache.clear()
+    yield
+
+
+@pytest.fixture
+def space():
+    """Model names and two configuration stamps, unique to one test.
+
+    The model names are what isolate a test from its module neighbours: rows
+    from another test carry another model and are excluded by the same predicate
+    under test. That is deliberate rather than convenient — it means a test that
+    names an exact result set is describing its own fixture, and it means the
+    isolation itself fails loudly if the model half of the predicate is ever
+    dropped, because every other test's rows come flooding in.
+
+    `config_a` and `config_b` differ ONLY in the endpoint. Same model name, same
+    width: exactly the pair `model_name` cannot tell apart, which is why #1546
+    added the stamp and why a model predicate alone would not close #1580.
+    """
+    tag = uuid.uuid4().hex[:8]
+    model = f"related-1580-{tag}"
+    return SimpleNamespace(
+        model=model,
+        other_model=f"related-1580-other-{tag}",
+        config_a=embedding_config_fingerprint(model, _DIMS, "https://a.invalid/v1"),
+        config_b=embedding_config_fingerprint(model, _DIMS, "https://b.invalid/v1"),
+    )
+
+
+def _vec(base: list[float]) -> list[float]:
+    """A 1536-dim vector from a short base, zero-padded."""
+    return (base + [0.0] * _DIMS)[:_DIMS]
+
+
+# The anchor's direction and two others at known cosine distances from it.
+_V_ANCHOR = _vec([1.0, 0.0, 0.0])
+_V_NEAR = _vec([0.9, 0.1, 0.0])  # distance ~0.0061 from _V_ANCHOR
+_V_MID = _vec([0.6, 0.8, 0.0])  # distance 0.4, comfortably inside the 0.7 gate
+
+# 1 - the cosine distance between _V_ANCHOR and _V_NEAR, which is the similarity
+# the endpoint prints for that pair. Stated once so the scoring test can pin the
+# exact number rather than a range.
+_SIMILARITY_ANCHOR_TO_NEAR = 0.9939
+
+
+async def _add_row(
+    session,
+    record_id: uuid.UUID,
+    vector: list[float],
+    *,
+    model_name: str,
+    config_fingerprint: str | None = None,
+    updated_at: datetime | None = None,
+) -> RecordEmbedding:
+    """Insert one `record_embeddings` row with an explicit space and age.
+
+    `updated_at` is set explicitly rather than left to `server_default=now()`,
+    because `now()` is the TRANSACTION timestamp: two rows written in one
+    transaction get the same value, and the anchor's "most recently written row"
+    rule would then be decided by the model-name tiebreak instead of by
+    recency. Tests that care about which row is the anchor state the ages rather
+    than inherit them.
+    """
+    row = RecordEmbedding(
+        record_id=record_id,
+        embedding=vector,
+        model_name=model_name,
+        config_fingerprint=config_fingerprint,
+        content_hash=uuid.uuid4().hex[:64],
+    )
+    if updated_at is not None:
+        row.updated_at = updated_at
+    session.add(row)
+    await session.commit()
+    return row
+
+
+async def _dataset(session, name: str):
+    user_id = await get_user_id(session, "admin")
+    return await create_dataset(session, created_by=user_id, name=name)
+
+
+async def _related(client: AsyncClient, headers: dict, dataset_id) -> dict[str, float]:
+    """The endpoint's answer as ``{name: similarity}``."""
+    resp = await client.get(f"/datasets/{dataset_id}/related/", headers=headers)
+    assert resp.status_code == 200, resp.text
+    return {item["name"]: item["similarity"] for item in resp.json()["items"]}
+
+
+# ---------------------------------------------------------------------------
+# The boundary
+# ---------------------------------------------------------------------------
+
+
+async def test_related_items_do_not_cross_a_configuration_boundary(
+    client: AsyncClient, admin_auth_header: dict, test_db_session, space
+):
+    """The headline case: one model name, two endpoints, two vector spaces.
+
+    The foreign row carries the anchor's OWN vector, so it is the nearest
+    neighbour that exists, at distance 0.0. Nothing but the configuration
+    predicate can keep it out, and a filter that fails open surfaces it first.
+
+    The same-space neighbour is asserted present in the same test rather than in
+    a sibling, because a predicate that rejected everything would pass the first
+    assertion and break the feature. This is a scoping fix, not a refusal.
+    """
+    anchor = await _dataset(test_db_session, "Cfg Anchor")
+    same_space = await _dataset(test_db_session, "Cfg Same Space")
+    foreign = await _dataset(test_db_session, "Cfg Foreign")
+
+    await _add_row(
+        test_db_session,
+        anchor.record_id,
+        _V_ANCHOR,
+        model_name=space.model,
+        config_fingerprint=space.config_a,
+    )
+    await _add_row(
+        test_db_session,
+        same_space.record_id,
+        _V_NEAR,
+        model_name=space.model,
+        config_fingerprint=space.config_a,
+    )
+    await _add_row(
+        test_db_session,
+        foreign.record_id,
+        _V_ANCHOR,
+        model_name=space.model,
+        config_fingerprint=space.config_b,
+    )
+
+    names = set(await _related(client, admin_auth_header, anchor.id))
+
+    assert "Cfg Foreign" not in names, (
+        f"related items returned {sorted(names)}. That row is a vector from "
+        f"another endpoint under the same model name; the cosine distance to it "
+        f"is 0.0 and it means nothing."
+    )
+    assert "Cfg Same Space" in names, (
+        f"related items returned {sorted(names)}. The scoping must not cost a "
+        f"record its own-configuration neighbours: a filter that rejects "
+        f"everything passes the assertion above and deletes the feature."
+    )
+
+
+async def test_related_items_do_not_cross_a_model_boundary(
+    client: AsyncClient, admin_auth_header: dict, test_db_session, space
+):
+    """The older half of the same defect, which predates the stamp entirely.
+
+    A fingerprint predicate without a model predicate would be incoherent, so
+    #1580 adds both, through `usable_by_config` — the one expression of the pair
+    that semantic search, the non-force backfill and the coverage panel already
+    apply. A model swap is how a catalog gets here: the old model's rows stay in
+    the table, exactly as near the anchor as their replacements.
+    """
+    anchor = await _dataset(test_db_session, "Model Anchor")
+    same_model = await _dataset(test_db_session, "Model Same")
+    other_model = await _dataset(test_db_session, "Model Other")
+
+    await _add_row(
+        test_db_session,
+        anchor.record_id,
+        _V_ANCHOR,
+        model_name=space.model,
+        config_fingerprint=space.config_a,
+    )
+    await _add_row(
+        test_db_session,
+        same_model.record_id,
+        _V_NEAR,
+        model_name=space.model,
+        config_fingerprint=space.config_a,
+    )
+    await _add_row(
+        test_db_session,
+        other_model.record_id,
+        _V_ANCHOR,
+        model_name=space.other_model,
+        config_fingerprint=space.config_a,
+    )
+
+    names = set(await _related(client, admin_auth_header, anchor.id))
+
+    assert "Model Other" not in names, (
+        f"related items returned {sorted(names)}. Two models' vectors are not "
+        f"comparable however similar the numbers look."
+    )
+    assert "Model Same" in names, f"related items returned {sorted(names)}"
+
+
+async def test_an_anchor_from_a_superseded_configuration_still_finds_its_own_space(
+    client: AsyncClient, admin_auth_header: dict, test_db_session, space
+):
+    """The rule is the ANCHOR row's pair, never the live configuration's.
+
+    This is where related-items parts company with semantic search. There, one
+    side of the comparison is a vector made moments ago, so "can the live
+    configuration use this row" is the right question and #1546 answers it.
+    Here both sides are stored rows, and asking the live configuration would
+    empty the feature for every record not yet re-embedded, while doing nothing
+    about the actual defect, which is comparing two stored rows from different
+    spaces.
+
+    Neither stamp in this test is the live one, and that is asserted rather than
+    assumed. Both records are found anyway.
+    """
+    live = await resolve_embedding_config_fingerprint(test_db_session)
+    assert live not in (space.config_a, space.config_b), (
+        f"precondition: this test needs both stamps to be foreign to the live "
+        f"configuration, and the live fingerprint resolved to {live!r}"
+    )
+
+    anchor = await _dataset(test_db_session, "Superseded Anchor")
+    neighbour = await _dataset(test_db_session, "Superseded Neighbour")
+
+    await _add_row(
+        test_db_session,
+        anchor.record_id,
+        _V_ANCHOR,
+        model_name=space.model,
+        config_fingerprint=space.config_a,
+    )
+    await _add_row(
+        test_db_session,
+        neighbour.record_id,
+        _V_NEAR,
+        model_name=space.model,
+        config_fingerprint=space.config_a,
+    )
+
+    names = set(await _related(client, admin_auth_header, anchor.id))
+
+    assert "Superseded Neighbour" in names, (
+        f"related items returned {sorted(names)} for an anchor stamped with a "
+        f"configuration that is no longer live. Both rows came out of the same "
+        f"one, so they are comparable; filtering on the live configuration "
+        f"instead would answer nothing here and still compare across spaces "
+        f"wherever the live configuration happened to match."
+    )
+
+
+async def test_an_unstamped_anchor_matches_unstamped_rows_of_its_model(
+    client: AsyncClient, admin_auth_header: dict, test_db_session, space
+):
+    """Grandfathering, read from the anchor side (#1546's NULL arm).
+
+    Every row in the table before migration 0052 is unstamped, and #1546 kept
+    them usable rather than empty semantic search on upgrade. The same has to
+    hold here, or related-items goes blank the morning after an upgrade on a
+    catalog where nothing is wrong.
+
+    `usable_by_config(model, None)` renders `config_fingerprint IS NULL`, so an
+    unstamped anchor selects the unstamped rows of its own model. A stamped row
+    belongs to a configuration this one cannot be compared against, and the
+    second assertion is the counterfactual for the first: without it this test
+    would pass against a reader that ignored the stamp entirely, which is the
+    state being fixed.
+    """
+    anchor = await _dataset(test_db_session, "Legacy Anchor")
+    legacy_peer = await _dataset(test_db_session, "Legacy Peer")
+    stamped = await _dataset(test_db_session, "Legacy Stamped")
+
+    await _add_row(test_db_session, anchor.record_id, _V_ANCHOR, model_name=space.model)
+    await _add_row(
+        test_db_session, legacy_peer.record_id, _V_NEAR, model_name=space.model
+    )
+    await _add_row(
+        test_db_session,
+        stamped.record_id,
+        _V_ANCHOR,
+        model_name=space.model,
+        config_fingerprint=space.config_a,
+    )
+
+    names = set(await _related(client, admin_auth_header, anchor.id))
+
+    assert "Legacy Peer" in names, (
+        f"related items returned {sorted(names)}. An all-unstamped catalog is "
+        f"what every instance looks like the day it upgrades, and it must "
+        f"behave exactly as it did before."
+    )
+    assert "Legacy Stamped" not in names, (
+        f"related items returned {sorted(names)}. A stamped row belongs to a "
+        f"known configuration and an unstamped one does not, so the two are not "
+        f"comparable in the direction that matters."
+    )
+
+
+# ---------------------------------------------------------------------------
+# One layer out: the number the user sees
+# ---------------------------------------------------------------------------
+
+
+async def test_a_neighbour_is_scored_in_the_anchors_own_space(
+    client: AsyncClient, admin_auth_header: dict, test_db_session, space
+):
+    """Selecting the right neighbour is half of it; scoring it is the other half.
+
+    `get_embedding_distances` re-reads every selected neighbour to turn it into
+    the similarity percentage the UI prints, and it carried no space predicate
+    at all. A record may hold one row per model (`uq_record_embedding_model` is
+    `(record_id, model_name)`), so a neighbour that survived the selection on its
+    same-space row could still be SCORED off one of its others: the query
+    returned every row for that record and the dict comprehension behind it
+    keeps whichever came last.
+
+    The neighbour here holds three rows. Its true one is near the anchor and was
+    written first; the two foreign ones sit at distance 0.4 and were written
+    after, so under an unscoped read the value that survives is a foreign one.
+    Pinning the exact number rather than a range is what makes the assertion
+    independent of which row the planner happens to return last: any foreign
+    pick fails it, whichever one wins.
+    """
+    anchor = await _dataset(test_db_session, "Scored Anchor")
+    neighbour = await _dataset(test_db_session, "Scored Neighbour")
+
+    await _add_row(
+        test_db_session,
+        anchor.record_id,
+        _V_ANCHOR,
+        model_name=space.model,
+        config_fingerprint=space.config_a,
+    )
+    await _add_row(
+        test_db_session,
+        neighbour.record_id,
+        _V_NEAR,
+        model_name=space.model,
+        config_fingerprint=space.config_a,
+    )
+    for suffix in ("1", "2"):
+        await _add_row(
+            test_db_session,
+            neighbour.record_id,
+            _V_MID,
+            model_name=f"{space.other_model}-{suffix}",
+            config_fingerprint=space.config_a,
+        )
+
+    items = await _related(client, admin_auth_header, anchor.id)
+
+    assert "Scored Neighbour" in items, (
+        f"the neighbour was not selected at all, so this test proves nothing "
+        f"about scoring; got {items}"
+    )
+    assert items["Scored Neighbour"] == pytest.approx(
+        _SIMILARITY_ANCHOR_TO_NEAR, abs=5e-4
+    ), (
+        f"the neighbour scored {items['Scored Neighbour']}, which is its "
+        f"distance from the anchor measured in a space the anchor is not in. "
+        f"0.6 is what the foreign rows answer; {_SIMILARITY_ANCHOR_TO_NEAR} is "
+        f"the true one."
+    )
+
+
+# ---------------------------------------------------------------------------
+# One anchor, three readers
+# ---------------------------------------------------------------------------
+
+
+async def test_the_selection_follows_the_anchors_most_recent_row(
+    client: AsyncClient, admin_auth_header: dict, test_db_session, space
+):
+    """A model swap mid-flight: the anchor holds a row in each of two spaces.
+
+    Both peers are the same distance from the vector the anchor was re-embedded
+    to, so distance alone cannot separate them and the 0.7 gate does not either.
+    The only thing that does is which space the comparison is in, and that comes
+    from the anchor's newest row.
+
+    Before #1580 the anchor was whatever an unordered `LIMIT 1` returned and
+    there was no predicate at all, so both peers came back: one of them a vector
+    from the model this record used to be embedded under.
+    """
+    old = datetime(2026, 1, 1, tzinfo=UTC)
+    new = datetime(2026, 6, 1, tzinfo=UTC)
+
+    anchor = await _dataset(test_db_session, "Swap Anchor")
+    new_peer = await _dataset(test_db_session, "Swap New Peer")
+    old_peer = await _dataset(test_db_session, "Swap Old Peer")
+
+    await _add_row(
+        test_db_session,
+        anchor.record_id,
+        _V_MID,
+        model_name=space.other_model,
+        config_fingerprint=space.config_a,
+        updated_at=old,
+    )
+    await _add_row(
+        test_db_session,
+        anchor.record_id,
+        _V_ANCHOR,
+        model_name=space.model,
+        config_fingerprint=space.config_b,
+        updated_at=new,
+    )
+    await _add_row(
+        test_db_session,
+        new_peer.record_id,
+        _V_NEAR,
+        model_name=space.model,
+        config_fingerprint=space.config_b,
+        updated_at=new,
+    )
+    await _add_row(
+        test_db_session,
+        old_peer.record_id,
+        _V_NEAR,
+        model_name=space.other_model,
+        config_fingerprint=space.config_a,
+        updated_at=old,
+    )
+
+    names = set(await _related(client, admin_auth_header, anchor.id))
+
+    assert names == {"Swap New Peer"}, (
+        f"related items returned {sorted(names)}. The anchor's most recent row "
+        f"is its new-model one, so the new-model peer is its neighbour and the "
+        f"old-model peer is a vector from a space this comparison is not in."
+    )
+
+
+async def test_the_anchor_is_the_most_recently_written_row(test_db_session, space):
+    """Which row, stated once, because three readers depend on the answer.
+
+    Before #1580 this was whatever the planner returned from an unordered
+    `LIMIT 1`. Most recent is the least surprising reading of "this record's
+    vector" after a swap, it is the one a re-embed moves, and it is stable: the
+    model-name tiebreak is there so two rows written in one transaction, which
+    share `now()`, still resolve to one answer rather than to chance.
+
+    The newer row here is the OTHER-model one, deliberately, so an
+    implementation that ordered by model name alone would answer the older.
+    """
+    old = datetime(2026, 1, 1, tzinfo=UTC)
+    new = datetime(2026, 6, 1, tzinfo=UTC)
+    record = await _dataset(test_db_session, "Anchor Pick")
+
+    await _add_row(
+        test_db_session,
+        record.record_id,
+        _V_MID,
+        model_name=space.other_model,
+        config_fingerprint=space.config_a,
+        updated_at=new,
+    )
+    await _add_row(
+        test_db_session,
+        record.record_id,
+        _V_ANCHOR,
+        model_name=space.model,
+        config_fingerprint=space.config_b,
+        updated_at=old,
+    )
+
+    anchor = await helpers.get_anchor_embedding_row(test_db_session, record.record_id)
+
+    assert anchor is not None
+    _, model_name, config_fingerprint = anchor
+    assert (model_name, config_fingerprint) == (space.other_model, space.config_a), (
+        f"the anchor resolved to ({model_name}, {config_fingerprint}), not the "
+        f"most recently written row"
+    )
+
+
+async def test_the_port_hands_the_anchors_identity_to_its_caller(
+    test_db_session, space
+):
+    """`get_record_embedding` returns the space, not just the numbers.
+
+    A list of floats does not say which model or endpoint produced it, so a
+    caller handed only the vector cannot hold anything downstream to the
+    anchor's space. That is why the port's shape changed and why
+    EXTENSION_API_VERSION moved with it.
+
+    The last assertion is the one that matters most and is the reason both go
+    through `get_anchor_embedding_row`: the identity has to name the SAME row
+    `get_nearest_record_ids` ranks against. Two independent `LIMIT 1` reads of
+    one record could return different rows, and then the neighbours would be
+    ranked around one vector and scored from another.
+    """
+    record = await _dataset(test_db_session, "Port Anchor")
+    await _add_row(
+        test_db_session,
+        record.record_id,
+        _V_ANCHOR,
+        model_name=space.model,
+        config_fingerprint=space.config_a,
+    )
+
+    returned = await DefaultCatalogPort().get_record_embedding(
+        test_db_session, record.record_id
+    )
+
+    assert returned is not None
+    embedding, model_name, config_fingerprint = returned
+    assert list(embedding)[:3] == [1.0, 0.0, 0.0]
+    assert (model_name, config_fingerprint) == (space.model, space.config_a)
+    assert returned == await helpers.get_anchor_embedding_row(
+        test_db_session, record.record_id
+    ), "the port and the ranking helper must resolve the same anchor row"

--- a/backend/tests/test_related_items_config_scope_1580.py
+++ b/backend/tests/test_related_items_config_scope_1580.py
@@ -568,3 +568,220 @@ async def test_the_port_hands_the_anchors_identity_to_its_caller(
     assert returned == await helpers.get_anchor_embedding_row(
         test_db_session, record.record_id
     ), "the port and the ranking helper must resolve the same anchor row"
+
+
+# ---------------------------------------------------------------------------
+# Review r2: grandfathering is for the side that has no choice
+# ---------------------------------------------------------------------------
+
+
+async def test_a_stamped_anchor_does_not_reach_legacy_unstamped_rows(
+    client: AsyncClient, admin_auth_header: dict, test_db_session, space
+):
+    """fix(#1580 review r2): the stored-vs-stored predicate does not grandfather.
+
+    `usable_by_config` matches an unstamped row against any fingerprint, and
+    that is right for SEARCH: its caller holds a vector made moments ago, and on
+    upgrade day every row in the table is unstamped, so refusing them would
+    return nothing until a catalog-wide re-embed finished. The unstamped rows
+    are all there is.
+
+    Here both sides are stored and a STAMPED anchor is evidence the catalog is
+    past that morning and at least partly regenerated. The catalog where this
+    bites is an endpoint change followed by a partial re-embed: the rows still
+    carrying NULL are most likely the ones in the OLD space, and comparing them
+    against a new-space anchor is precisely the well-formed meaningless distance
+    this PR removes — on the records least likely to be looked at twice.
+
+    The legacy row here carries the anchor's own vector, so it is the nearest
+    neighbour that exists and nothing but the predicate can keep it out.
+    """
+    anchor = await _dataset(test_db_session, "Stamped Anchor")
+    same_space = await _dataset(test_db_session, "Stamped Peer")
+    legacy = await _dataset(test_db_session, "Legacy Leftover")
+
+    await _add_row(
+        test_db_session,
+        anchor.record_id,
+        _V_ANCHOR,
+        model_name=space.model,
+        config_fingerprint=space.config_a,
+    )
+    await _add_row(
+        test_db_session,
+        same_space.record_id,
+        _V_NEAR,
+        model_name=space.model,
+        config_fingerprint=space.config_a,
+    )
+    await _add_row(test_db_session, legacy.record_id, _V_ANCHOR, model_name=space.model)
+
+    items = await _related(client, admin_auth_header, anchor.id)
+
+    assert "Legacy Leftover" not in items, (
+        f"related items returned {sorted(items)}. That row predates the stamp, "
+        f"so which space it is in is unknown — and on the catalog this matters "
+        f"for, a partial re-embed, unknown means the old one."
+    )
+    assert "Stamped Peer" in items, (
+        f"related items returned {sorted(items)}; refusing NULL must not cost a "
+        f"record its own-configuration neighbours"
+    )
+
+
+def test_both_stored_readers_use_the_stored_anchor_predicate():
+    """The scoring query must not keep search's grandfathering either.
+
+    Asserted structurally rather than through data, because the data case is
+    unreachable: ``uq_record_embedding_model`` is ``(record_id, model_name)``, so
+    one record cannot hold both a stamped and an unstamped row of the same
+    model, and a neighbour whose only row is unstamped is already removed by the
+    selection filter. There is no catalog that exercises the scoring query's
+    NULL arm on its own.
+
+    Which is exactly why it needs pinning some other way. The selection and the
+    scoring are two independent readers of the same rule — fix(#1580) already
+    had to fix this pair once, when scoping the selection left the scoring
+    reporting distances from a foreign model — and a rule that cannot drift
+    apart in a test can still drift apart in the source.
+
+    A test that only named the wanted call would pass against a file that called
+    both, so the unwanted one is asserted absent too.
+
+    Comments are stripped and the CALL form is matched, not the bare name. The
+    first version of this scanned raw source and failed on the explanatory
+    comment beside the call it was checking — a predicate that cannot tell a
+    mention from a use answers a question nobody asked.
+    """
+    import inspect
+
+    from app.platform.extensions import defaults_catalog_port
+    from app.processing.embeddings import helpers
+
+    def _code(fn) -> str:
+        return "\n".join(
+            line
+            for line in inspect.getsource(fn).splitlines()
+            if not line.strip().startswith("#")
+        )
+
+    readers = {
+        "selection": _code(helpers.get_nearest_record_ids),
+        "scoring": _code(
+            defaults_catalog_port.DefaultCatalogPort.get_embedding_distances
+        ),
+    }
+
+    for name, source in readers.items():
+        assert "usable_by_stored_anchor(" in source, (
+            f"the {name} query does not call the stored-vs-stored predicate"
+        )
+        assert "usable_by_config(" not in source, (
+            f"the {name} query still calls search's predicate, which matches an "
+            f"unstamped row against a stamped anchor. Right for a fresh query "
+            f"vector, wrong for two stored rows."
+        )
+
+
+async def test_an_all_legacy_catalog_still_finds_its_neighbours(
+    client: AsyncClient, admin_auth_header: dict, test_db_session, space
+):
+    """The half that must NOT change: upgrade day still works.
+
+    Refusing NULL against a stamped anchor is only defensible because an
+    unstamped anchor keeps matching unstamped rows. Without this the morning
+    after migration 0052 — when every row in the table is unstamped — related
+    items would go blank on a catalog where nothing is wrong, which is the
+    outcome #1546's grandfathering exists to prevent.
+    """
+    anchor = await _dataset(test_db_session, "All Legacy Anchor")
+    peer = await _dataset(test_db_session, "All Legacy Peer")
+
+    await _add_row(test_db_session, anchor.record_id, _V_ANCHOR, model_name=space.model)
+    await _add_row(test_db_session, peer.record_id, _V_NEAR, model_name=space.model)
+
+    items = await _related(client, admin_auth_header, anchor.id)
+
+    assert "All Legacy Peer" in items, (
+        f"related items returned {sorted(items)} on an all-unstamped catalog, "
+        f"which is what every instance looks like the day it upgrades"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Review r2: one read, not two
+# ---------------------------------------------------------------------------
+
+
+async def test_a_commit_between_the_two_reads_cannot_split_the_anchor(
+    client: AsyncClient, admin_auth_header: dict, test_db_session, space, monkeypatch
+):
+    """fix(#1580 review r2): the ranking and the scoring share ONE anchor read.
+
+    `_load_self_record_and_embedding` read the anchor to score with, and
+    `get_nearest_record_ids` read it again to rank against. Two reads under READ
+    COMMITTED, so a worker committing a newer row for this record between them
+    left the selection anchored on the new vector and the scoring on the old —
+    wrong distances, or nothing at all when the two spaces do not overlap. A v9
+    overlay could pick differently again, since the method only received a
+    record id.
+
+    The commit is driven INTO that window rather than merely before or after it:
+    the second call to the anchor reader publishes a newer row first. With the
+    anchor passed in there is no second call, so the newer row cannot influence
+    anything, and `reads` proves the window was actually entered under the old
+    shape and closed under this one.
+    """
+    from app.processing.embeddings import helpers
+
+    anchor_ds = await _dataset(test_db_session, "Split Anchor")
+    peer = await _dataset(test_db_session, "Split Peer")
+
+    await _add_row(
+        test_db_session,
+        anchor_ds.record_id,
+        _V_ANCHOR,
+        model_name=space.model,
+        config_fingerprint=space.config_a,
+        updated_at=datetime(2026, 1, 1, tzinfo=UTC),
+    )
+    await _add_row(
+        test_db_session,
+        peer.record_id,
+        _V_NEAR,
+        model_name=space.model,
+        config_fingerprint=space.config_a,
+        updated_at=datetime(2026, 1, 1, tzinfo=UTC),
+    )
+
+    reads = {"count": 0}
+    real_reader = helpers.get_anchor_embedding_row
+
+    async def _committing_reader(session, record_id):
+        reads["count"] += 1
+        if reads["count"] == 2 and record_id == anchor_ds.record_id:
+            # The interloper: a newer row in a DIFFERENT space, landing exactly
+            # between the seed read and the neighbour selection.
+            await _add_row(
+                test_db_session,
+                anchor_ds.record_id,
+                _V_MID,
+                model_name=space.other_model,
+                config_fingerprint=space.config_b,
+                updated_at=datetime(2026, 6, 1, tzinfo=UTC),
+            )
+        return await real_reader(session, record_id)
+
+    monkeypatch.setattr(helpers, "get_anchor_embedding_row", _committing_reader)
+
+    items = await _related(client, admin_auth_header, anchor_ds.id)
+
+    assert reads["count"] == 1, (
+        f"the anchor was read {reads['count']} times. Two reads is the defect: "
+        f"whatever they return, nothing makes them the same row."
+    )
+    assert "Split Peer" in items, (
+        f"related items returned {sorted(items)}. The seed's own space has a "
+        f"neighbour in it; a selection anchored on a row the scoring never saw "
+        f"finds nothing it can then score."
+    )


### PR DESCRIPTION
Closes #1580. Was stacked on #1578, which has since landed on main (54d74a9b4); this branch is now main plus one commit.

## The defect

`get_nearest_record_ids`, and the `get_record_embedding` / `get_embedding_distances`
pair behind it, selected candidate rows from `catalog.record_embeddings` filtered by
neither `model_name` nor, since #1546, `config_fingerprint`. Related items therefore
compared one record's stored vector against every other record's, across model and
configuration spaces, and returned cosine distances that were well-formed and
meaningless whenever the table held more than one space. A model swap or an endpoint
change is the whole setup: the old rows stay, sitting exactly as near the anchor as
their replacements.

## Why the rule is not the one semantic search uses

Search compares a FRESH query vector against stored rows, so "can the live
configuration use this row" is the right question and #1546 answers it. Both sides of
this comparison are stored rows, so the question is the ANCHOR row's pair. A record
embedded under a superseded configuration finds its own-space neighbours, or finds
none, and never crosses.

Filtering on the live configuration here would be worse than doing nothing: it would
empty the feature for every record not yet re-embedded, and still compare across
spaces wherever the live configuration happened to match one of them.
`test_an_anchor_from_a_superseded_configuration_still_finds_its_own_space` asserts
the live fingerprint differs from both stamps in play and that the neighbour is
returned anyway, so that reading of the fix fails.

## Three readers, because stopping at the first relocates the bug

`get_nearest_record_ids` picks the candidates. `get_embedding_distances` turns them
into the similarity percentage the UI prints, and carried no space predicate at all,
so a neighbour selected correctly could still be SCORED off one of its other rows:
the query returned every row for that record and the dict comprehension behind it
keeps whichever came last. Measured on a catalog where the neighbour holds a second
model's row, the endpoint printed **0.6** where the anchor's own space says **0.994**.

Underneath both, `get_anchor_embedding_row` is now one definition of which row the
comparison starts from. It used to be two independent `LIMIT 1` reads off an
unordered query, so on a record holding one row per model (`uq_record_embedding_model`
is `(record_id, model_name)`) the ranking and the scoring could anchor on different
vectors. That one is a latent inconsistency rather than a reproducible failure on a
small table, and it is fixed by construction rather than by a red: both readers go
through the one helper, which `test_the_port_hands_the_anchors_identity_to_its_caller`
asserts directly.

**Which row.** The most recently written one, ties broken by model name. Before this
it was whatever the planner returned. Most recent is the least surprising reading of
"this record's vector" after a swap and it is the one a re-embed moves; the tiebreak
exists because `now()` is the transaction timestamp, so two rows written together
share it. Nothing here prefers the live configuration, deliberately.

## One predicate

`usable_by_config` is the same expression semantic search, the non-force backfill and
the coverage panel apply, called with the anchor's pair instead of the live one. Its
`config_fingerprint` argument widens to `str | None`: an unstamped anchor renders
`IS NULL` and matches the unstamped rows of its own model. That is #1546's
grandfathering read from the other side, and it is what keeps a just-upgraded
catalog's related items working unchanged rather than blank.

## Every reader

Rule 8. The values are the anchor's vector and its `(model_name, config_fingerprint)`
pair.

| Reader | Where | Decision |
|---|---|---|
| Anchor read | `helpers.get_anchor_embedding_row` (new) | The single definition. Most recent row, and the join to `catalog.records` that `record_embeddings` has no `tenant_id` of its own to replace. |
| Neighbour selection | `helpers.get_nearest_record_ids` | Filters on the anchor's pair, through `usable_by_stored_anchor` (r2). Takes the caller's anchor rather than reading its own (r2). |
| Neighbour scoring | `defaults_catalog_port.get_embedding_distances` | Filters on the same pair through the same predicate, handed down from the seed rather than re-derived. |
| Seed read | `defaults_catalog_port.get_record_embedding` | Now the shared anchor read, and returns the pair with the vector. |
| Orchestration | `service_relationships.get_related_datasets` | Threads the pair from the seed into the scoring. The only unlisted app file this touches; see below. |
| AI neighbour keywords | `metadata_service._neighbor_keywords` | Fixed for free through `get_nearest_record_ids`; it never had an anchor of its own. Its 5-minute LRU holds keywords keyed by dataset id, not vectors, so no vector or stamp is memoized across a configuration change. |
| `has_embeddings` | `helpers` | Unaffected. Its SQL carries no model predicate at all and only decides whether the vector arm is attempted. |
| Semantic search, coverage stats, backfill selection | `service_semantic`, `admin/service`, `defaults_processing_port` | Untouched. They ask the live-configuration question and still should; #1546 is the reader table for those. |
| `uq_record_embedding_model` | the database | Why a record can hold several rows at all, and why "several spaces" on one record always means several models: a configuration change upserts in place. |
| Readers in the future | rows written today, read weeks later | The pair is read from the row per request. Nothing caches a vector or a stamp across requests on this path. |

`openapi.json` does not move; `scripts/dump_openapi.py --check` exits 0. No SDK, CLI,
MCP or frontend surface sees any of this.

## Decisions worth review

**EXTENSION_API_VERSION 8 to 9.** Two `CatalogPort` shape changes, one bump, the same
arrangement 7 to 8 used. `get_record_embedding` returns the anchor's
`(embedding, model_name, config_fingerprint)`; an overlay still returning a bare list is
unpacked into three names and raises on the first related-items request.
`get_embedding_distances` takes the pair as required keyword-only arguments. Required
rather than defaulted on purpose: a default of "no filter" would let an overlay keep this
defect silently, and the defect is a similarity number computed in the wrong space.

These were briefly folded into #1546's 7 to 8 instead, on the reasoning that the two PRs
ship in one release with no core release between them. Review caught it and the folding is
undone. **The constant pins the contract at a commit, not at a release**: main has been a
v8 contract since #1546 merged, so an overlay built and declared against it loads cleanly
against post-#1580 core, then meets a `get_record_embedding` returning a triple where it
returns a list, and the first related-items request fails inside the route's broad handler
and comes back empty. Silent skew is exactly what the check exists to refuse at boot. The
8 to 9 comment records the fold and the un-fold, so a reader who finds the release-based
reasoning persuasive also finds the reason it does not hold.

**`get_nearest_record_ids` keeps its signature.** It reads the anchor itself rather
than taking one, because `metadata_service` calls it with no anchor in hand. The
sharing is through the helper, not through the parameter list.

**HNSW starvation is already covered.** A predicate applied after the approximate scan
can leave every candidate rejected, which is the failure #1546 review r2 fixed by
turning on pgvector's iterative scan in `set_hnsw_recall`. `get_nearest_record_ids`
already called it, and that docstring already names related-items as one of the two
callers the widening was for. No new exposure here, and nothing to add.

**Three files outside the scope I was given**, all forced by the fix rather than
adjacent to it:

- `service_relationships.py`, ~8 lines, to thread the pair from the seed into the
  scoring. Without it `get_embedding_distances` cannot know the anchor's space and the
  selection fix relocates the defect instead of closing it.
- `models.py`, the `usable_by_config` annotation widened to `str | None` plus the
  paragraph explaining the NULL anchor. The predicate is reused rather than
  hand-spelled, and a NULL anchor is a legitimate argument to it.
- `version.py`, the extended 7 to 8 note above, plus the docstring on its pin.

## Verification

Red on `a5492b2b1` (the branch point, #1578's tip before it merged), with only the source
reverted and the new suite kept. Every test in the file fails, and the failure text is the defect stated plainly:

```
E  AssertionError: related items returned ['Cfg Foreign', 'Cfg Same Space']. That row
   is a vector from another endpoint under the same model name; the cosine distance to
   it is 0.0 and it means nothing.
E  AssertionError: related items returned ['Cfg Anchor', 'Cfg Foreign', 'Cfg Same
   Space', 'Model Other', 'Model Same']. Two models' vectors are not comparable
   however similar the numbers look.
E  AssertionError: related items returned [...] for an anchor stamped with a
   configuration that is no longer live.
E  AssertionError: related items returned [...]. An all-unstamped catalog is what every
   instance looks like the day it upgrades, and it must behave exactly as it did
   before.
E  AttributeError: module 'app.processing.embeddings.helpers' has no attribute
   'get_anchor_embedding_row'
E  ValueError: too many values to unpack (expected 3, got 1536)
8 failed
```

Those result sets are worth reading twice. `Cfg Anchor`, `Model Other` and
`Superseded Anchor` are OTHER TESTS' fixtures: without a model predicate, unrelated
records seeded by neighbouring tests in the same module come back as related items at
similarity 1.0. The `space` fixture partitions each test by model name, so under the
fix a test can only see its own rows, and that partition is itself an assertion that
the model half of the predicate is applied.

The scoring test's red is crowded out by that bleed when the module runs whole, so it
was also run alone against the reverted source, which is where the number is visible:

```
$ uv run pytest tests/test_related_items_config_scope_1580.py -k scored_in_the_anchors_own_space
E  AssertionError: the neighbour scored 0.6, which is its distance from the anchor
   measured in a space the anchor is not in. 0.6 is what the foreign rows answer;
   0.9939 is the true one.
E  assert 0.6 == 0.9939 ± 5.0e-04
1 failed
```

Green:

```
$ uv run pytest tests/test_related_items_config_scope_1580.py -q
8 passed in 7.28s

$ uv run pytest tests/test_related_items_config_scope_1580.py tests/test_related_datasets.py \
    tests/test_related_datasets_idor.py tests/test_records_related.py \
    tests/test_embedding_tenant_isolation.py tests/test_extension_api_version.py \
    tests/test_embedding_config_stamp_1546.py -q
102 passed in 59.18s

$ uv run pytest tests/test_hybrid_search.py tests/test_semantic_hnsw_post_filter_1546.py \
    tests/test_embedding_backfill_model_scope.py tests/test_search_embedding_cache.py \
    tests/test_related_items_config_scope_1580.py -q
36 passed in 17.95s

$ uv run pytest tests/test_ai_metadata.py tests/test_ai_metadata_authz_1173.py \
    tests/test_rule1_structural.py -q
28 passed in 25.19s

$ uv run pytest tests/test_layering.py -q
47 passed in 10.31s

$ uv run ruff check . && uv run ruff format --check .
All checks passed!
1028 files already formatted

$ PYTHONPATH=. uv run python scripts/dump_openapi.py --check
EXIT=0
```

`test_embedding_tenant_isolation.py` needed its stub reshaped, not weakened: the
anchor read selects the row rather than one column, so it goes through `.first()`.
`_result` gained an explicit `first=` that defaults to None, because a bare MagicMock
there is truthy and unpacks into three MagicMocks, which is how a caller that stopped
reading a real row would still look like it worked.

`_MODULE_LOC_CAPS`: `service_relationships.py` 635 to 653,
`defaults_catalog_port.py` 478 to 491. Both exact, both with a comment saying what the
lines bought. `defaults_catalog_port.py` grew while its code shrank, because
`get_record_embedding` stopped spelling its own query.


## Note on the rebuild

#1578 was squash-merged, so its commits are not ancestors of `main` and merging this branch
into it produced nine conflicts — every one of them #1578's own content colliding with its
own squash, none of them mine. This branch had never been pushed, so instead of resolving
that by hand (and risking re-applying #1578's content on top of itself) it was rebuilt as
`origin/main` plus this one commit, which cherry-picked cleanly.

`git diff origin/main --stat` is the check that matters and it lists exactly the ten files
this change touches. The gates were then re-run against the rebuilt tree rather than
carried over: layering and the `EXTENSION_API_VERSION` pin pass, which is what would catch
`_MODULE_LOC_CAPS` drift or a version note that no longer matches its constant after
#1578's later review rounds landed.


---

## Review round 2

Two findings. The first changed direction under review and the final state is the
opposite of the first fix pushed for it, so both are described.

**P1 — a NULL anchor could not see stamped rows.** `usable_by_config(m, F)` lets a stamped
anchor match a NULL row, but SQLAlchemy renders `== None` as `IS NULL`, so
`usable_by_config(m, None)` collapsed *both* arms to `IS NULL` and the NULL side could not
see back. Comparability of two stored rows is a property of the **pair**: whether A and B
may be compared cannot depend on which one you start from.

| anchor | sees NULL rows | sees stamped rows |
|---|---|---|
| stamped (before) | yes | its own fingerprint |
| NULL (before) | yes | **no** |
| NULL (after) | yes | yes |

The catalog that produces it is the ordinary one. Day zero after migration 0052 every row
is NULL; one edit re-embeds and stamps **one** record; from then on that record vanishes
from every legacy record's related list while still listing them itself. It never heals,
because Generate Missing treats a NULL row as covered, so nothing goes back to stamp the
rest — every legacy list shrinks toward the records nobody has touched.

```
FAILED test_comparability_is_the_same_in_both_directions
E  AssertionError: the stamped record lists the legacy one: True. The legacy record lists
   the stamped one: False. Comparability is a property of the pair, so these cannot
   differ — and when they do, the legacy record's list quietly shrinks every time another
   record is re-embedded.
E  assert True == False
```

The None branch answers the model predicate alone: an unstamped **anchor** is
grandfathered exactly as an unstamped **row** is. No other caller passes None — search,
the coverage query and the backfill all resolve a live configuration to a string — so only
the anchor path moves.

**The rule I implemented first is withdrawn.** A stamped anchor matching its exact
fingerprint and nothing else is symmetric too, but it empties a freshly edited record's
related list the day after an upgrade and contradicts what #1546 already decided a NULL row
*means*: comparable to any live space of its model. Search and related items have to agree
about that, and this is the reading that keeps them agreeing.

**P2 — the anchor was read twice.** `_load_self_record_and_embedding` read it to score with
and `get_nearest_record_ids` read it again to rank against. Two reads under READ COMMITTED,
so a worker committing a newer row between them left the ranking anchored on one vector and
the scoring on another — wrong distances, or nothing at all when the two spaces do not
overlap. A v9 overlay could pick differently again, since the port method only received a
record id.

```
FAILED test_a_commit_between_the_two_reads_cannot_split_the_anchor
E  AssertionError: the anchor was read 2 times. Two reads is the defect: whatever they
   return, nothing makes them the same row.
```

The commit is driven **into** that window rather than before or after it, and the test
asserts the window was entered at all. The caller's anchor now travels in: required on the
port, because its only core caller holds one and an overlay that re-read would reintroduce
the split; optional on the helper, because `metadata_service` asks for neighbours with no
anchor of its own and has nothing downstream to disagree with.

**Three review nits.** The 8 to 9 note named the wrong function for the bare-list unpack
(it is `_compute_neighbor_distances`). The ingest re-stamp wrote `updated_at` from the app
clock while the insert default and the backfill use the database's — and #1580 made that
column decide which row is the anchor, so a worker running behind could leave a superseded
vector answering. And two comments claiming "one definition" now say what is actually true
for each caller.

Green after: 212 passed across the related, embedding, search, AI-metadata, layering,
version-pin and Rule-1 structural suites, plus the reviewer's own asymmetry reproduction.
Ruff clean, `openapi.json` unchanged.
