### PR TITLE
fix(export): honour the leading Range of a cold GDAL open on a fresh build

### DIFF
--- a/backend/app/processing/export/artifact_cache.py
+++ b/backend/app/processing/export/artifact_cache.py
@@ -216,6 +216,15 @@ class ExportArtifact:
     # set. HEAD and the ETag are unaffected: each artifact is still internally
     # consistent, and a whole-object read of either is a correct answer.
     contested: bool = False
+    # fix(#1532) follow-up (#1585): this artifact's bytes have been the
+    # selection's answer for longer than one TTL — a sibling with the SAME
+    # digest, published more than a TTL ago, is live. That is what settles the
+    # question "did this URL's bytes just change": a client mid-read at the
+    # moment of a change makes its next request within the change's first TTL,
+    # and for that TTL the route answers bare ranges whole. Once settled, the
+    # URL's history needs no listing to consult. Free: `lookup` already reads
+    # every sibling's stamp and digest.
+    settled: bool = False
 
     @property
     def etag(self) -> str:
@@ -354,6 +363,13 @@ async def url_has_other_bytes(
     splice, which is what lets a re-open after expiry work. Fails CLOSED on a
     listing error: an unknown history is treated as a contested one, and the
     client gets the whole file, which is safe.
+
+    Consulted only while the artifact is not ``settled`` (#1585 review r3): once
+    these bytes have been the URL's answer for more than a TTL, a client
+    mid-read at the moment they became the answer has long finished, and the
+    one still holding a handle across a longer gap is the stated residual — so
+    the listing is paid, at most, during the first TTL after a change, and only
+    by requests carrying a bare Range.
     """
     prefix = _dataset_prefix(dataset_id)
     url_segment = selection.split("/", 1)[0]
@@ -514,11 +530,16 @@ async def lookup(
 
     candidates: list[tuple[float, int, str, str]] = []
     siblings: set[str] = set()
+    oldest_by_digest: dict[str, float] = {}
     for key in keys:
         parsed = parse_artifact_key(key)
         if parsed is None:
             continue
         built_at, size, digest = parsed
+        _publication = _published_at(modified.get(key, built_at), built_at)
+        oldest_by_digest[digest] = min(
+            oldest_by_digest.get(digest, _publication), _publication
+        )
         # fix(#1532 review r8): `contested` counts EVERY sibling under this
         # selection, not just the fresh ones. Computed over the fresh set it
         # missed the staggered case entirely: two builders a second apart are
@@ -569,8 +590,37 @@ async def lookup(
             filename=filename,
             media_type=media_type,
             contested=contested,
+            settled=oldest_by_digest.get(digest, now) < cutoff,
         )
     return None
+
+
+async def _oldest_publication_of(
+    dataset_id: uuid.UUID, selection: str, digest: str
+) -> float | None:
+    """When these bytes first became this selection's answer, if any copy is live.
+
+    fix(#1532) follow-up (#1585): what a fresh publication needs to know
+    whether it is a CHANGE (no earlier copy of these bytes under this version:
+    the previous answer, if any, was different) or a rebuild of the same answer
+    after expiry. One selection listing; None when no artifact with this digest
+    is live, or when the store cannot be listed (a rebuild then counts as a
+    change, which is the conservative reading).
+    """
+    oldest: float | None = None
+    try:
+        async for page in get_storage().iter_object_pages(
+            _selection_prefix(dataset_id, selection)
+        ):
+            for obj in page:
+                parsed = parse_artifact_key(obj.key)
+                if parsed is None or parsed[2] != digest:
+                    continue
+                published = _published_at(obj.last_modified.timestamp(), parsed[0])
+                oldest = published if oldest is None else min(oldest, published)
+    except Exception:  # broad: cannot list means cannot prove it settled
+        return None
+    return oldest
 
 
 def _published_at(modified: float, built_at: float) -> float:
@@ -734,6 +784,13 @@ async def store(
                 return await lookup(
                     dataset_id, selection, filename=filename, media_type=media_type
                 )
+        # fix(#1532) follow-up (#1585): is this a rebuild of the bytes that were
+        # already this selection's answer more than a TTL ago (settled), or the
+        # first publication of these bytes under this version (a change, as far
+        # as anyone mid-read can tell)? Read before publishing so the fresh
+        # copy cannot answer for itself.
+        oldest_same = await _oldest_publication_of(dataset_id, selection, digest)
+        settled = oldest_same is not None and oldest_same < time.time() - _ttl_seconds()
         built_at, key = await _put_with_reclaim(
             dataset_id,
             selection,
@@ -756,6 +813,7 @@ async def store(
             built_at=built_at,
             filename=filename,
             media_type=media_type,
+            settled=settled,
         )
     except Exception:  # broad: caching is best-effort; the conversion succeeded
         # And let the NEXT attempt sweep whatever the interval says. A store

--- a/backend/app/processing/export/artifact_cache.py
+++ b/backend/app/processing/export/artifact_cache.py
@@ -298,20 +298,62 @@ def selection_key(
     reason ``embedding_config_fingerprint`` gives in #1546: a delimiter join
     collapses them, and ``where=""`` is not ``where`` absent.
     """
-    payload = json.dumps(
-        [
-            str(dataset_id),
-            table_name,
-            dataset_title,
-            tile_cache_version,
-            str(format_key),
-            target_crs,
-            bbox,
-            where,
-        ],
+    # Two path segments, deliberately (fix(#1532) follow-up, #1585): the URL's
+    # identity first, then the version's. `format`, `target_crs`, `bbox` and
+    # `where` are what a client can see in the URL it is reading; `table_name`,
+    # `dataset_title` and `tile_cache_version` are the server-side facts that
+    # move the bytes under that same URL. Every artifact of one URL, at every
+    # version, therefore lives under one prefix, and `url_has_other_bytes` can
+    # ask "has this URL ever answered with different bytes that a client could
+    # still be holding" with one listing. `lookup`, `store` and the sweep are
+    # indifferent to the shape: they take the whole thing as an opaque prefix.
+    url_payload = json.dumps(
+        [str(dataset_id), str(format_key), target_crs, bbox, where],
         separators=(",", ":"),
     )
-    return hashlib.sha256(payload.encode()).hexdigest()[:32]
+    version_payload = json.dumps(
+        [table_name, dataset_title, tile_cache_version],
+        separators=(",", ":"),
+    )
+    url_part = hashlib.sha256(url_payload.encode()).hexdigest()[:20]
+    version_part = hashlib.sha256(version_payload.encode()).hexdigest()[:20]
+    return f"{url_part}/{version_part}"
+
+
+def _url_prefix(dataset_id: uuid.UUID, selection: str) -> str:
+    """The prefix under which every version of one export URL is stored."""
+    return f"{_ROOT}/{_tenant_segment()}/{dataset_id}/{selection.split('/', 1)[0]}/"
+
+
+async def url_has_other_bytes(
+    dataset_id: uuid.UUID, selection: str, digest: str
+) -> bool:
+    """Is any artifact with a DIFFERENT digest live under this URL, at any version?
+
+    fix(#1532) follow-up (#1585): a fresh build honours a bare Range that starts
+    at byte 0 — GDAL's first request, and the only way a cold ``/vsicurl/`` open
+    can proceed — unless the client could be holding blocks of an earlier
+    representation of the SAME URL. It could if that URL answered with different
+    bytes since the last sweep: a mutation that moved ``tile_cache_version``
+    puts the earlier artifact under another version segment of this prefix, and
+    a client that read a later block from it, then re-reads the header after the
+    change, would splice. This lists the URL prefix (every version) and answers
+    True on the first foreign digest. An earlier artifact with the SAME digest is
+    the same bytes and cannot splice, which is what lets a re-open after expiry
+    work. Failing CLOSED on a listing error: an unknown history is treated as a
+    contested one, and the client gets the whole file, which is safe.
+    """
+    try:
+        async for page in get_storage().iter_object_pages(
+            _url_prefix(dataset_id, selection)
+        ):
+            for obj in page:
+                parsed = parse_artifact_key(obj.key)
+                if parsed is not None and parsed[2] != digest:
+                    return True
+    except Exception:  # broad: unknown history reads as contested; whole is safe
+        return True
+    return False
 
 
 def _selection_prefix(dataset_id: uuid.UUID, selection: str) -> str:

--- a/backend/app/processing/export/artifact_cache.py
+++ b/backend/app/processing/export/artifact_cache.py
@@ -336,8 +336,10 @@ async def url_answered_other_bytes_recently(
     re-reading the header — makes that request within the change's first TTL,
     and for that TTL the route answers it whole. Answering requires a fresh
     artifact, and a fresh artifact is one published within the TTL, so "the
-    URL answered other bytes recently" is exactly "an artifact with another
-    digest was published under this URL within the last TTL" — at any version,
+    URL answered other bytes within the last TTL" is exactly "an artifact with
+    another digest was published under this URL within the last TWO TTLs" (a
+    TTL of serving, then a TTL of grace for the client that took the last
+    answer) — at any version,
     which is why every version of a URL shares a prefix (``selection_key``).
     A→B→A within retention is caught by the same test: while B is still being
     answered, B artifacts keep being published, and the moment they stop the
@@ -356,7 +358,12 @@ async def url_answered_other_bytes_recently(
     ages it out; the exposure is a client spanning both the upgrade and a data
     change, and it is stated rather than paid for on every range.
     """
-    cutoff = time.time() - _ttl_seconds()
+    # fix(#1532) follow-up (#1585 review r5): TWO TTLs, not one. An artifact
+    # answers for a TTL after publication, so its last possible answer is a
+    # TTL after that, and the client that took it needs a TTL of its own to
+    # come back. Publication one TTL old means "could have been served a
+    # moment ago"; two TTLs old means "nobody has held it for less than a TTL".
+    cutoff = time.time() - 2 * _ttl_seconds()
     try:
         async for page in get_storage().iter_object_pages(
             _url_prefix(dataset_id, selection)

--- a/backend/app/processing/export/artifact_cache.py
+++ b/backend/app/processing/export/artifact_cache.py
@@ -320,37 +320,54 @@ def selection_key(
     return f"{url_part}/{version_part}"
 
 
-def _url_prefix(dataset_id: uuid.UUID, selection: str) -> str:
-    """The prefix under which every version of one export URL is stored."""
-    return f"{_ROOT}/{_tenant_segment()}/{dataset_id}/{selection.split('/', 1)[0]}/"
+def _dataset_prefix(dataset_id: uuid.UUID) -> str:
+    """The prefix under which every artifact of one dataset is stored."""
+    return f"{_ROOT}/{_tenant_segment()}/{dataset_id}/"
 
 
 async def url_has_other_bytes(
     dataset_id: uuid.UUID, selection: str, digest: str
 ) -> bool:
-    """Is any artifact with a DIFFERENT digest live under this URL, at any version?
+    """Could a client be holding blocks of an earlier representation of this URL?
 
     fix(#1532) follow-up (#1585): a fresh build honours a bare Range that starts
     at byte 0 — GDAL's first request, and the only way a cold ``/vsicurl/`` open
     can proceed — unless the client could be holding blocks of an earlier
-    representation of the SAME URL. It could if that URL answered with different
-    bytes since the last sweep: a mutation that moved ``tile_cache_version``
-    puts the earlier artifact under another version segment of this prefix, and
-    a client that read a later block from it, then re-reads the header after the
-    change, would splice. This lists the URL prefix (every version) and answers
-    True on the first foreign digest. An earlier artifact with the SAME digest is
-    the same bytes and cannot splice, which is what lets a re-open after expiry
-    work. Failing CLOSED on a listing error: an unknown history is treated as a
-    contested one, and the client gets the whole file, which is safe.
+    representation of the SAME URL with different bytes. It could if that URL
+    answered with different bytes since the last sweep: a mutation that moved
+    ``tile_cache_version`` puts the earlier artifact under another version
+    segment of this URL, and a client that read a later block from it, then
+    re-reads the header after the change, would splice.
+
+    One listing of the dataset's prefix, read two ways (#1585 review r2):
+
+    - ``<url>/<version>/<name>``, the layout ``selection_key`` writes: counts
+      only when ``<url>`` is this URL's segment and the digest differs.
+    - ``<selection>/<name>``, the single-segment layout the parent revision of
+      #1582 wrote: its URL cannot be told from the key, so ANY such artifact
+      with a different digest counts. Conservative by design — an object this
+      cannot attribute is treated as this URL's history — and self-limiting: no
+      release ever wrote that layout (it lived on ``main`` for an hour), and
+      whatever a development stack still holds ages out at the sweep horizon.
+
+    An earlier artifact with the SAME digest is the same bytes and cannot
+    splice, which is what lets a re-open after expiry work. Fails CLOSED on a
+    listing error: an unknown history is treated as a contested one, and the
+    client gets the whole file, which is safe.
     """
+    prefix = _dataset_prefix(dataset_id)
+    url_segment = selection.split("/", 1)[0]
     try:
-        async for page in get_storage().iter_object_pages(
-            _url_prefix(dataset_id, selection)
-        ):
+        async for page in get_storage().iter_object_pages(prefix):
             for obj in page:
                 parsed = parse_artifact_key(obj.key)
-                if parsed is not None and parsed[2] != digest:
-                    return True
+                if parsed is None or parsed[2] == digest:
+                    continue
+                segments = obj.key[len(prefix) :].split("/")
+                if len(segments) == 3 and segments[0] == url_segment:
+                    return True  # this URL, another version, different bytes
+                if len(segments) == 2:
+                    return True  # legacy layout: URL unknown, so it counts
     except Exception:  # broad: unknown history reads as contested; whole is safe
         return True
     return False

--- a/backend/app/processing/export/artifact_cache.py
+++ b/backend/app/processing/export/artifact_cache.py
@@ -216,15 +216,6 @@ class ExportArtifact:
     # set. HEAD and the ETag are unaffected: each artifact is still internally
     # consistent, and a whole-object read of either is a correct answer.
     contested: bool = False
-    # fix(#1532) follow-up (#1585): this artifact's bytes have been the
-    # selection's answer for longer than one TTL — a sibling with the SAME
-    # digest, published more than a TTL ago, is live. That is what settles the
-    # question "did this URL's bytes just change": a client mid-read at the
-    # moment of a change makes its next request within the change's first TTL,
-    # and for that TTL the route answers bare ranges whole. Once settled, the
-    # URL's history needs no listing to consult. Free: `lookup` already reads
-    # every sibling's stamp and digest.
-    settled: bool = False
 
     @property
     def etag(self) -> str:
@@ -312,9 +303,9 @@ def selection_key(
     # `where` are what a client can see in the URL it is reading; `table_name`,
     # `dataset_title` and `tile_cache_version` are the server-side facts that
     # move the bytes under that same URL. Every artifact of one URL, at every
-    # version, therefore lives under one prefix, and `url_has_other_bytes` can
-    # ask "has this URL ever answered with different bytes that a client could
-    # still be holding" with one listing. `lookup`, `store` and the sweep are
+    # version, therefore lives under one prefix, and
+    # `url_answered_other_bytes_recently` can ask "has this URL answered with
+    # different bytes inside the last TTL" with one listing. `lookup`, `store` and the sweep are
     # indifferent to the shape: they take the whole thing as an opaque prefix.
     url_payload = json.dumps(
         [str(dataset_id), str(format_key), target_crs, bbox, where],
@@ -329,62 +320,54 @@ def selection_key(
     return f"{url_part}/{version_part}"
 
 
-def _dataset_prefix(dataset_id: uuid.UUID) -> str:
-    """The prefix under which every artifact of one dataset is stored."""
-    return f"{_ROOT}/{_tenant_segment()}/{dataset_id}/"
+def _url_prefix(dataset_id: uuid.UUID, selection: str) -> str:
+    """The prefix under which every version of one export URL is stored."""
+    return f"{_ROOT}/{_tenant_segment()}/{dataset_id}/{selection.split('/', 1)[0]}/"
 
 
-async def url_has_other_bytes(
+async def url_answered_other_bytes_recently(
     dataset_id: uuid.UUID, selection: str, digest: str
 ) -> bool:
-    """Could a client be holding blocks of an earlier representation of this URL?
+    """Has this URL answered with DIFFERENT bytes inside the last TTL?
 
-    fix(#1532) follow-up (#1585): a fresh build honours a bare Range that starts
-    at byte 0 — GDAL's first request, and the only way a cold ``/vsicurl/`` open
-    can proceed — unless the client could be holding blocks of an earlier
-    representation of the SAME URL with different bytes. It could if that URL
-    answered with different bytes since the last sweep: a mutation that moved
-    ``tile_cache_version`` puts the earlier artifact under another version
-    segment of this URL, and a client that read a later block from it, then
-    re-reads the header after the change, would splice.
+    fix(#1532) follow-up (#1585): the bound on bare ranges. A client that read
+    a block of an earlier representation of this URL and comes back for the
+    next one — to a hit on the new artifact, to a fresh build of it, or
+    re-reading the header — makes that request within the change's first TTL,
+    and for that TTL the route answers it whole. Answering requires a fresh
+    artifact, and a fresh artifact is one published within the TTL, so "the
+    URL answered other bytes recently" is exactly "an artifact with another
+    digest was published under this URL within the last TTL" — at any version,
+    which is why every version of a URL shares a prefix (``selection_key``).
+    A→B→A within retention is caught by the same test: while B is still being
+    answered, B artifacts keep being published, and the moment they stop the
+    clock starts. Same bytes cannot splice and do not count. After the TTL a
+    client holding a handle across a longer gap without ``If-Range`` is the
+    residual every range-serving origin has.
 
-    One listing of the dataset's prefix, read two ways (#1585 review r2):
+    Bounded: the URL's own versions, not the dataset's selections, and called
+    only for a request that could receive a 206 (a bare, satisfiable Range).
+    Fails CLOSED on a listing error: an unknown history reads as a recent
+    change, and the client gets the whole file, which is safe.
 
-    - ``<url>/<version>/<name>``, the layout ``selection_key`` writes: counts
-      only when ``<url>`` is this URL's segment and the digest differs.
-    - ``<selection>/<name>``, the single-segment layout the parent revision of
-      #1582 wrote: its URL cannot be told from the key, so ANY such artifact
-      with a different digest counts. Conservative by design — an object this
-      cannot attribute is treated as this URL's history — and self-limiting: no
-      release ever wrote that layout (it lived on ``main`` for an hour), and
-      whatever a development stack still holds ages out at the sweep horizon.
-
-    An earlier artifact with the SAME digest is the same bytes and cannot
-    splice, which is what lets a re-open after expiry work. Fails CLOSED on a
-    listing error: an unknown history is treated as a contested one, and the
-    client gets the whole file, which is safe.
-
-    Consulted only while the artifact is not ``settled`` (#1585 review r3): once
-    these bytes have been the URL's answer for more than a TTL, a client
-    mid-read at the moment they became the answer has long finished, and the
-    one still holding a handle across a longer gap is the stated residual — so
-    the listing is paid, at most, during the first TTL after a change, and only
-    by requests carrying a bare Range.
+    The parent revision of #1582 wrote a single-segment layout that lives
+    outside every URL prefix. Nothing can be served from it after this
+    revision (``lookup`` never lists it), no release wrote it, and retention
+    ages it out; the exposure is a client spanning both the upgrade and a data
+    change, and it is stated rather than paid for on every range.
     """
-    prefix = _dataset_prefix(dataset_id)
-    url_segment = selection.split("/", 1)[0]
+    cutoff = time.time() - _ttl_seconds()
     try:
-        async for page in get_storage().iter_object_pages(prefix):
+        async for page in get_storage().iter_object_pages(
+            _url_prefix(dataset_id, selection)
+        ):
             for obj in page:
                 parsed = parse_artifact_key(obj.key)
                 if parsed is None or parsed[2] == digest:
                     continue
-                segments = obj.key[len(prefix) :].split("/")
-                if len(segments) == 3 and segments[0] == url_segment:
-                    return True  # this URL, another version, different bytes
-                if len(segments) == 2:
-                    return True  # legacy layout: URL unknown, so it counts
-    except Exception:  # broad: unknown history reads as contested; whole is safe
+                if _published_at(obj.last_modified.timestamp(), parsed[0]) >= cutoff:
+                    return True
+    except Exception:  # broad: unknown history reads as a recent change; whole is safe
         return True
     return False
 
@@ -590,37 +573,8 @@ async def lookup(
             filename=filename,
             media_type=media_type,
             contested=contested,
-            settled=oldest_by_digest.get(digest, now) < cutoff,
         )
     return None
-
-
-async def _oldest_publication_of(
-    dataset_id: uuid.UUID, selection: str, digest: str
-) -> float | None:
-    """When these bytes first became this selection's answer, if any copy is live.
-
-    fix(#1532) follow-up (#1585): what a fresh publication needs to know
-    whether it is a CHANGE (no earlier copy of these bytes under this version:
-    the previous answer, if any, was different) or a rebuild of the same answer
-    after expiry. One selection listing; None when no artifact with this digest
-    is live, or when the store cannot be listed (a rebuild then counts as a
-    change, which is the conservative reading).
-    """
-    oldest: float | None = None
-    try:
-        async for page in get_storage().iter_object_pages(
-            _selection_prefix(dataset_id, selection)
-        ):
-            for obj in page:
-                parsed = parse_artifact_key(obj.key)
-                if parsed is None or parsed[2] != digest:
-                    continue
-                published = _published_at(obj.last_modified.timestamp(), parsed[0])
-                oldest = published if oldest is None else min(oldest, published)
-    except Exception:  # broad: cannot list means cannot prove it settled
-        return None
-    return oldest
 
 
 def _published_at(modified: float, built_at: float) -> float:
@@ -784,13 +738,6 @@ async def store(
                 return await lookup(
                     dataset_id, selection, filename=filename, media_type=media_type
                 )
-        # fix(#1532) follow-up (#1585): is this a rebuild of the bytes that were
-        # already this selection's answer more than a TTL ago (settled), or the
-        # first publication of these bytes under this version (a change, as far
-        # as anyone mid-read can tell)? Read before publishing so the fresh
-        # copy cannot answer for itself.
-        oldest_same = await _oldest_publication_of(dataset_id, selection, digest)
-        settled = oldest_same is not None and oldest_same < time.time() - _ttl_seconds()
         built_at, key = await _put_with_reclaim(
             dataset_id,
             selection,
@@ -813,7 +760,6 @@ async def store(
             built_at=built_at,
             filename=filename,
             media_type=media_type,
-            settled=settled,
         )
     except Exception:  # broad: caching is best-effort; the conversion succeeded
         # And let the NEXT attempt sweep whatever the interval says. A store

--- a/backend/app/processing/export/artifact_response.py
+++ b/backend/app/processing/export/artifact_response.py
@@ -3,22 +3,35 @@
 Split from the router so the range decision is readable on its own: it is one
 rule, it is the reason this fix is safe, and it is not obvious.
 
-**A Range is honoured only when the artifact already existed.** If this request
-had to build one, the Range is ignored and the whole representation goes back
-with 200. RFC 9110 section 14.2 permits exactly that, and it is what preserves
-the loud-failure property #1532 insists on. A ``/vsicurl/`` client sends a bare
-``Range`` with no ``If-Range``, so the server has nothing to compare and cannot
-be told which artifact the client was reading. Answering a rebuild with a 206 at
-the offsets the client asked for would hand it a slice of a DIFFERENT file at the
-old positions, which is the splice the issue exists to prevent. Answering with
-the complete new representation cannot splice anything: the client discards what
-it had and reads from zero.
+**A Range is honoured only when the artifact already existed** — with one
+exception, below. If this request had to build one, the Range is ignored and the
+whole representation goes back with 200. RFC 9110 section 14.2 permits exactly
+that, and it is what preserves the loud-failure property #1532 insists on. A
+``/vsicurl/`` client sends a bare ``Range`` with no ``If-Range``, so the server
+has nothing to compare and cannot be told which artifact the client was reading.
+Answering a rebuild with a 206 at the offsets the client asked for would hand it
+a slice of a DIFFERENT file at the old positions, which is the splice the issue
+exists to prevent. Answering with the complete new representation cannot splice
+anything: the client discards what it had and reads from zero.
 
-So the sequence a probing client sees is: first request builds and gets a whole
-representation; every later request inside the freshness window is a slice of
-that one stored object; and the first request after the data changes builds again
-and gets a whole representation again. No two responses in that sequence are ever
-parts of different files presented as parts of one.
+**The exception: a Range that starts at byte 0 is honoured on a fresh build**
+(fix(#1532) follow-up, found by the release smoke). GDAL 3.10's ``/vsicurl/``
+open does not begin with a HEAD; its first request is ``Range: bytes=0-16383``,
+and a 200 to that is read as "Range downloading not supported by this server"
+and the open aborts — so a cold cache could not be opened at all, and only the
+second attempt worked. A range from byte 0 is a probe or a restart, never a
+resume: a client resuming holds a prefix and asks from its length. Nothing
+appended after a slice that starts at 0 can come from a different
+representation, because every later request finds the artifact this one just
+published and slices that. Any other starting offset on a fresh build keeps the
+whole answer.
+
+So the sequence a probing client sees is: first request builds and gets either
+the leading slice it asked for or the whole representation; every later request
+inside the freshness window is a slice of that one stored object; and the first
+request after the data changes builds again and answers the same way. No two
+responses in that sequence are ever parts of different files presented as parts
+of one.
 
 **A client that CAN name what it is resuming is held to it.** The artifact
 publishes a strong validator, so `If-Range` is evaluated here too (fix(#1532)
@@ -97,15 +110,21 @@ def read_response(
     range_header: str | None,
     if_range: str | None = None,
     may_serve_range: bool,
+    leading_slice_ok: bool = False,
     background: BackgroundTask | None = None,
 ) -> Response:
     """The GET: a 206 slice, a 416, or the whole artifact.
 
     ``may_serve_range`` is the caller's answer to "did this artifact exist before
-    this request", and it is the only thing standing between this endpoint and
-    the splice described in the module docstring. It is a parameter rather than
-    something inferred here because only the caller knows whether it just built
-    the thing.
+    this request", and it is what stands between this endpoint and the splice
+    described in the module docstring. It is a parameter rather than something
+    inferred here because only the caller knows whether it just built the thing.
+    ``leading_slice_ok`` is the one exception the module docstring states: the
+    caller BUILT this artifact into a selection with no other representation
+    live, and a bare Range that starts at byte 0 is a probe, not a resume, so
+    it is honoured. It is separate from ``may_serve_range`` because a contested
+    selection also sets that False, and there the whole answer stays: two
+    representations are live and the client's next slice may land on the other.
 
     ``background`` carries the caller's temp-directory cleanup, and it is a
     parameter for a reason worth stating. An earlier revision deleted the
@@ -141,14 +160,19 @@ def read_response(
     proven = if_range is not None and range_bound_to_this_version(
         if_range, artifact.etag
     )
+    byte_range = parse_byte_range(range_header, artifact.size)
     if not proven:
-        if not may_serve_range:
-            return _whole(storage, artifact, headers, background)
         if if_range is not None:
             # Present and not matching: section 13.1.5 says ignore the Range.
             return _whole(storage, artifact, headers, background)
+        if not may_serve_range and not (
+            leading_slice_ok and _starts_at_zero(byte_range)
+        ):
+            # A bare Range on a representation this request built (or on a
+            # contested selection), other than the leading slice of a fresh
+            # build: whole (module docstring).
+            return _whole(storage, artifact, headers, background)
 
-    byte_range = parse_byte_range(range_header, artifact.size)
     if byte_range is None:
         return _whole(storage, artifact, headers, background)
 
@@ -167,6 +191,16 @@ def read_response(
         },
         background=background,
     )
+
+
+def _starts_at_zero(byte_range) -> bool:
+    """A resolved Range whose first byte is 0: a probe or a restart, never a resume.
+
+    The one bare Range a fresh build honours (module docstring, and only with
+    ``leading_slice_ok``). A satisfiable pair only — an unsatisfiable or absent
+    Range is not "from zero".
+    """
+    return isinstance(byte_range, tuple) and byte_range[0] == 0
 
 
 def temp_file_response(

--- a/backend/app/processing/export/artifact_response.py
+++ b/backend/app/processing/export/artifact_response.py
@@ -15,16 +15,25 @@ exists to prevent. Answering with the complete new representation cannot splice
 anything: the client discards what it had and reads from zero.
 
 **The exception: a Range that starts at byte 0 is honoured on a fresh build**
-(fix(#1532) follow-up, found by the release smoke). GDAL 3.10's ``/vsicurl/``
-open does not begin with a HEAD; its first request is ``Range: bytes=0-16383``,
-and a 200 to that is read as "Range downloading not supported by this server"
-and the open aborts — so a cold cache could not be opened at all, and only the
-second attempt worked. A range from byte 0 is a probe or a restart, never a
-resume: a client resuming holds a prefix and asks from its length. Nothing
-appended after a slice that starts at 0 can come from a different
-representation, because every later request finds the artifact this one just
-published and slices that. Any other starting offset on a fresh build keeps the
-whole answer.
+(fix(#1532) follow-up, #1585, found by the release smoke). GDAL 3.10's
+``/vsicurl/`` open does not begin with a HEAD; its first request is ``Range:
+bytes=0-16383``, and a 200 to that is read as "Range downloading not supported
+by this server" and the open aborts — so a cold cache could not be opened at
+all, and only the second attempt worked. A range from byte 0 is a probe or a
+restart, never a resume: a client resuming holds a prefix and asks from its
+length. Any other starting offset on a fresh build keeps the whole answer.
+
+**And the bound on both, for bare ranges: for one TTL after a URL's bytes
+change, ranges are answered whole.** A client that read a block of the earlier
+representation and comes back for the next one — to a hit on the new artifact,
+or to a fresh build of it, or re-reading the header — makes that request
+within the change's first TTL, and it gets the whole new file, which cannot
+splice. Once the new bytes have been the URL's answer for a TTL (``settled``),
+ranges resume; a client holding a handle across a longer gap without an
+``If-Range`` is the residual every range-serving origin has, and RFC 9110 gives
+the server nothing to close it with. The check reads the URL's history (every
+version, plus the parent revision's single-segment layout) and is paid only in
+that first TTL, and only by requests carrying a bare Range.
 
 So the sequence a probing client sees is: first request builds and gets either
 the leading slice it asked for or the whole representation; every later request

--- a/backend/app/processing/export/artifact_response.py
+++ b/backend/app/processing/export/artifact_response.py
@@ -28,12 +28,12 @@ change, ranges are answered whole.** A client that read a block of the earlier
 representation and comes back for the next one — to a hit on the new artifact,
 or to a fresh build of it, or re-reading the header — makes that request
 within the change's first TTL, and it gets the whole new file, which cannot
-splice. Once the new bytes have been the URL's answer for a TTL (``settled``),
-ranges resume; a client holding a handle across a longer gap without an
-``If-Range`` is the residual every range-serving origin has, and RFC 9110 gives
-the server nothing to close it with. The check reads the URL's history (every
-version, plus the parent revision's single-segment layout) and is paid only in
-that first TTL, and only by requests carrying a bare Range.
+splice. Once the URL has answered nothing but the new bytes for a TTL, ranges
+resume; a client holding a handle across a longer gap without an ``If-Range``
+is the residual every range-serving origin has, and RFC 9110 gives the server
+nothing to close it with. The check reads the URL's own prefix (every version
+of that URL) and is paid only by a request that could receive a 206: a bare,
+satisfiable Range.
 
 So the sequence a probing client sees is: first request builds and gets either
 the leading slice it asked for or the whole representation; every later request

--- a/backend/app/processing/export/router.py
+++ b/backend/app/processing/export/router.py
@@ -848,14 +848,22 @@ async def export_dataset_endpoint(
             # representation the client's offsets were measured against.
             # Ignoring the Range and answering with the whole thing is the safe
             # half of RFC 9110 section 14.2 and is what keeps a rebuild from
-            # splicing; only a matching If-Range (r12) overrides it, because
-            # that client has named these exact bytes.
+            # splicing; a matching If-Range (r12) overrides it, because that
+            # client has named these exact bytes, and so does a Range that
+            # starts at byte 0 (fix(#1532) follow-up): that is a probe, never a
+            # resume, and it is the first request of a cold GDAL open, which a
+            # 200 turned into "Range downloading not supported".
             response = artifact_response.read_response(
                 get_storage(),
                 stored,
                 range_header=request.headers.get("range"),
                 if_range=request.headers.get("if-range"),
                 may_serve_range=False,
+                # A fresh build's leading slice cannot splice (nothing precedes
+                # byte 0, and every later request finds this artifact); a lost
+                # race hands back an incumbent, and for that the hit path's own
+                # contested rule applies, so its flag decides.
+                leading_slice_ok=not stored.contested,
                 background=BackgroundTask(_cleanup_export, temp_dir),
             )
         else:

--- a/backend/app/processing/export/router.py
+++ b/backend/app/processing/export/router.py
@@ -25,6 +25,7 @@ from app.platform.http.ranges import (
     if_match_passes,
     if_none_match_matches,
     not_modified_response,
+    parse_byte_range,
 )
 from app.platform.storage import get_storage
 from app.processing.export import artifact_cache, artifact_response
@@ -67,20 +68,23 @@ router = APIRouter(
 _MAX_EXPORT_FEATURES = 5_000_000
 
 
-def _bare_range(request: Request) -> bool:
-    """A Range with no If-Range: the request whose slice the server must judge."""
-    return (
-        bool(request.headers.get("range")) and request.headers.get("if-range") is None
-    )
+def _bare_satisfiable_range(request: Request, size: int) -> tuple[int, int] | None:
+    """The resolved slice a bare Range (no If-Range) asks for, if it could be a 206.
+
+    Parsed with the same function ``read_response`` uses, so a malformed,
+    multi-range or unsatisfiable header — which the response ignores or
+    rejects — never costs the URL-history listing (#1585 review r4).
+    """
+    if request.headers.get("if-range") is not None:
+        return None
+    resolved = parse_byte_range(request.headers.get("range"), size)
+    return resolved if isinstance(resolved, tuple) else None
 
 
-def _leading_bare_range(request: Request) -> bool:
-    """A bare Range whose first byte is 0 — the only one a fresh build can honour."""
-    return _bare_range(request) and bool(
-        re.match(
-            r"^\s*bytes\s*=\s*0+\s*-", request.headers.get("range", ""), re.IGNORECASE
-        )
-    )
+def _leading_bare_range(request: Request, size: int) -> bool:
+    """A bare, satisfiable Range whose first byte is 0 — the only one a fresh build honours."""
+    resolved = _bare_satisfiable_range(request, size)
+    return resolved is not None and resolved[0] == 0
 
 
 def _cleanup_export(path: str) -> None:
@@ -529,18 +533,19 @@ async def export_dataset_endpoint(
         # case, not a rare one, and a client reading in slices can otherwise be
         # flipped from one to the other mid-sequence.
         #
-        # fix(#1532) follow-up (#1585 review r3): and so does a hit inside the
-        # first TTL after this URL's bytes CHANGED, when an earlier
-        # representation with different bytes is still live. A client that read
-        # a block of the old artifact and comes back for the next one lands
-        # here, on the new one, and a 206 would splice the two. Once the bytes
-        # have been the answer for a TTL (`settled`) that client has finished
-        # or is holding a handle across a longer gap, which is the residual the
-        # module states — and the history listing is not paid at all.
+        # fix(#1532) follow-up (#1585 review r3/r4): and so does a hit inside
+        # the first TTL after this URL's bytes CHANGED. A client that read a
+        # block of the earlier representation and comes back for the next one
+        # lands here, on the new artifact, and a 206 would splice the two. The
+        # URL's own prefix says whether other bytes were answered within the
+        # last TTL; consulted only for a bare, satisfiable Range — the request
+        # that could receive a 206.
         may_serve_range = not artifact.contested
-        if may_serve_range and not artifact.settled and _bare_range(request):
-            may_serve_range = not await artifact_cache.url_has_other_bytes(
-                dataset_id, selection, artifact.digest
+        if may_serve_range and _bare_satisfiable_range(request, artifact.size):
+            may_serve_range = (
+                not await artifact_cache.url_answered_other_bytes_recently(
+                    dataset_id, selection, artifact.digest
+                )
             )
         response = artifact_response.read_response(
             get_storage(),
@@ -883,19 +888,18 @@ async def export_dataset_endpoint(
             # starts at byte 0 (fix(#1532) follow-up): that is a probe, never a
             # resume, and it is the first request of a cold GDAL open, which a
             # 200 turned into "Range downloading not supported".
-            # The leading slice of a fresh build is honoured unless an earlier
-            # representation of THIS URL with different bytes is still live and
-            # these bytes only just became the answer: a client that read a
-            # later block from the old one and re-reads the header after the
-            # change would splice (#1585 review r1). `contested` covers a
-            # foreign digest under this version; `url_has_other_bytes` covers
-            # one under a previous version of the same URL, and is consulted
-            # only while the bytes are not `settled` and only for the request
-            # that could use the answer — a bare Range starting at 0 (r3).
+            # The leading slice of a fresh build is honoured unless this URL
+            # answered with different bytes inside the last TTL: a client that
+            # read a later block from that representation and re-reads the
+            # header after the change would splice (#1585 review r1). The
+            # listing is consulted only for the request that could use the
+            # answer — a bare, satisfiable Range starting at 0 (r3/r4).
             leading_slice_ok = not stored.contested
-            if leading_slice_ok and not stored.settled and _leading_bare_range(request):
-                leading_slice_ok = not await artifact_cache.url_has_other_bytes(
-                    dataset_id, selection, stored.digest
+            if leading_slice_ok and _leading_bare_range(request, stored.size):
+                leading_slice_ok = (
+                    not await artifact_cache.url_answered_other_bytes_recently(
+                        dataset_id, selection, stored.digest
+                    )
                 )
             response = artifact_response.read_response(
                 get_storage(),

--- a/backend/app/processing/export/router.py
+++ b/backend/app/processing/export/router.py
@@ -67,6 +67,22 @@ router = APIRouter(
 _MAX_EXPORT_FEATURES = 5_000_000
 
 
+def _bare_range(request: Request) -> bool:
+    """A Range with no If-Range: the request whose slice the server must judge."""
+    return (
+        bool(request.headers.get("range")) and request.headers.get("if-range") is None
+    )
+
+
+def _leading_bare_range(request: Request) -> bool:
+    """A bare Range whose first byte is 0 — the only one a fresh build can honour."""
+    return _bare_range(request) and bool(
+        re.match(
+            r"^\s*bytes\s*=\s*0+\s*-", request.headers.get("range", ""), re.IGNORECASE
+        )
+    )
+
+
 def _cleanup_export(path: str) -> None:
     """Remove the temporary export directory after response is sent."""
     if os.path.isdir(path):
@@ -507,17 +523,31 @@ async def export_dataset_endpoint(
         # that names nothing, and a `dataset.export` row for a refused request
         # records a download that did not happen — the same reason HEAD is out
         # of the log.
+        # fix(#1532 review, internal): a contested selection — more than one
+        # distinct set of bytes fresh under this key — answers ranges with the
+        # whole representation. Two overlapping cold builders is the ordinary
+        # case, not a rare one, and a client reading in slices can otherwise be
+        # flipped from one to the other mid-sequence.
+        #
+        # fix(#1532) follow-up (#1585 review r3): and so does a hit inside the
+        # first TTL after this URL's bytes CHANGED, when an earlier
+        # representation with different bytes is still live. A client that read
+        # a block of the old artifact and comes back for the next one lands
+        # here, on the new one, and a 206 would splice the two. Once the bytes
+        # have been the answer for a TTL (`settled`) that client has finished
+        # or is holding a handle across a longer gap, which is the residual the
+        # module states — and the history listing is not paid at all.
+        may_serve_range = not artifact.contested
+        if may_serve_range and not artifact.settled and _bare_range(request):
+            may_serve_range = not await artifact_cache.url_has_other_bytes(
+                dataset_id, selection, artifact.digest
+            )
         response = artifact_response.read_response(
             get_storage(),
             artifact,
             range_header=request.headers.get("range"),
             if_range=request.headers.get("if-range"),
-            # fix(#1532 review, internal): a contested selection — more than one
-            # distinct set of bytes fresh under this key — answers ranges with
-            # the whole representation. Two overlapping cold builders is the
-            # ordinary case, not a rare one, and a client reading in slices can
-            # otherwise be flipped from one to the other mid-sequence.
-            may_serve_range=not artifact.contested,
+            may_serve_range=may_serve_range,
         )
         await _emit_export_audit(
             db,
@@ -853,25 +883,27 @@ async def export_dataset_endpoint(
             # starts at byte 0 (fix(#1532) follow-up): that is a probe, never a
             # resume, and it is the first request of a cold GDAL open, which a
             # 200 turned into "Range downloading not supported".
+            # The leading slice of a fresh build is honoured unless an earlier
+            # representation of THIS URL with different bytes is still live and
+            # these bytes only just became the answer: a client that read a
+            # later block from the old one and re-reads the header after the
+            # change would splice (#1585 review r1). `contested` covers a
+            # foreign digest under this version; `url_has_other_bytes` covers
+            # one under a previous version of the same URL, and is consulted
+            # only while the bytes are not `settled` and only for the request
+            # that could use the answer — a bare Range starting at 0 (r3).
+            leading_slice_ok = not stored.contested
+            if leading_slice_ok and not stored.settled and _leading_bare_range(request):
+                leading_slice_ok = not await artifact_cache.url_has_other_bytes(
+                    dataset_id, selection, stored.digest
+                )
             response = artifact_response.read_response(
                 get_storage(),
                 stored,
                 range_header=request.headers.get("range"),
                 if_range=request.headers.get("if-range"),
                 may_serve_range=False,
-                # The leading slice of a fresh build is honoured only when no
-                # earlier representation of THIS URL with different bytes is
-                # still live: a client that read a later block from one and
-                # re-reads the header after a change would splice (#1585 review).
-                # `contested` covers a foreign digest under this version;
-                # `url_has_other_bytes` covers one under a previous version of
-                # the same URL. Same bytes under either cannot splice.
-                leading_slice_ok=(
-                    not stored.contested
-                    and not await artifact_cache.url_has_other_bytes(
-                        dataset_id, selection, stored.digest
-                    )
-                ),
+                leading_slice_ok=leading_slice_ok,
                 background=BackgroundTask(_cleanup_export, temp_dir),
             )
         else:

--- a/backend/app/processing/export/router.py
+++ b/backend/app/processing/export/router.py
@@ -859,11 +859,19 @@ async def export_dataset_endpoint(
                 range_header=request.headers.get("range"),
                 if_range=request.headers.get("if-range"),
                 may_serve_range=False,
-                # A fresh build's leading slice cannot splice (nothing precedes
-                # byte 0, and every later request finds this artifact); a lost
-                # race hands back an incumbent, and for that the hit path's own
-                # contested rule applies, so its flag decides.
-                leading_slice_ok=not stored.contested,
+                # The leading slice of a fresh build is honoured only when no
+                # earlier representation of THIS URL with different bytes is
+                # still live: a client that read a later block from one and
+                # re-reads the header after a change would splice (#1585 review).
+                # `contested` covers a foreign digest under this version;
+                # `url_has_other_bytes` covers one under a previous version of
+                # the same URL. Same bytes under either cannot splice.
+                leading_slice_ok=(
+                    not stored.contested
+                    and not await artifact_cache.url_has_other_bytes(
+                        dataset_id, selection, stored.digest
+                    )
+                ),
                 background=BackgroundTask(_cleanup_export, temp_dir),
             )
         else:

--- a/backend/tests/test_export_artifact_cache_1532.py
+++ b/backend/tests/test_export_artifact_cache_1532.py
@@ -781,8 +781,15 @@ async def test_two_concurrent_publishers_both_survive(test_db_session, monkeypat
     nothing deletes on the publish path at all.
 
     The overlap is FORCED, not hoped for. A barrier holds both builders after
-    hashing and before publishing, and the test asserts both arrived; a sequence
-    of two ``store`` calls proves nothing about concurrency.
+    their pre-publish re-check and before publishing, and the test asserts both
+    arrived; a sequence of two ``store`` calls proves nothing about concurrency.
+
+    fix(#1532 review r29) made the barrier's placement matter: a builder whose
+    re-check finds a fresh incumbent is handed that incumbent instead of
+    publishing, so a barrier at the hash let the second builder's re-check land
+    after the first's put and the two came back with ONE key — the lost-race
+    path, which has its own test, not the two-publisher case this one pins.
+    Holding both at the re-check makes both miss and both publish.
     """
     import asyncio
     import tempfile
@@ -796,11 +803,11 @@ async def test_two_concurrent_publishers_both_survive(test_db_session, monkeypat
 
     arrived = asyncio.Event()
     waiting = 0
-    real_digest = cache.digest_and_size
+    real_lookup = cache.lookup
 
-    async def _barriered(file_path):
+    async def _barriered(*args, **kwargs):
         nonlocal waiting
-        result = await real_digest(file_path)
+        result = await real_lookup(*args, **kwargs)
         if waiting < 2:
             waiting += 1
             if waiting == 2:
@@ -808,7 +815,7 @@ async def test_two_concurrent_publishers_both_survive(test_db_session, monkeypat
             await asyncio.wait_for(arrived.wait(), timeout=5)
         return result
 
-    monkeypatch.setattr(cache, "digest_and_size", _barriered)
+    monkeypatch.setattr(cache, "lookup", _barriered)
 
     async def _publish(payload: bytes):
         with tempfile.NamedTemporaryFile(delete=False) as handle:

--- a/backend/tests/test_export_artifact_cache_1532.py
+++ b/backend/tests/test_export_artifact_cache_1532.py
@@ -4557,3 +4557,80 @@ async def test_a_legacy_layout_artifact_counts_as_the_urls_history(
         _url(same.id), headers={**admin_auth_header, "Range": "bytes=0-99"}
     )
     assert ok.status_code == 206, ok.text
+
+
+async def test_a_hit_inside_the_first_ttl_after_a_change_answers_bare_ranges_whole(
+    client: AsyncClient, admin_auth_header: dict, test_db_session, conversions
+):
+    """#1585 review r3: the hit path honours the URL's history too, for one TTL.
+
+    Client A reads the leading block (a fresh build, 206). The data changes and
+    the version moves. Client B fetches the export, building the new version's
+    artifact. Client A comes back for its next block: that is a HIT on the new
+    artifact, uncontested within the new version — and a 206 there would append
+    new bytes to A's old leading block. Inside the first TTL after the change
+    the answer is whole. Once the new bytes are settled — a same-digest sibling
+    older than a TTL is live under the new version — ranges resume, and the
+    history listing is not consulted at all.
+    """
+    from app.platform.storage import get_storage
+    from app.processing.export import artifact_cache as cache
+
+    dataset = await _dataset(test_db_session, "Hit After Change")
+    url = _url(dataset.id)
+
+    leading = await client.get(
+        url, headers={**admin_auth_header, "Range": "bytes=0-99"}
+    )
+    assert leading.status_code == 206 and conversions.count == 1
+
+    conversions.body = bytes(reversed(conversions.body))
+    dataset.bump_tile_cache_version()
+    test_db_session.add(dataset)
+    await test_db_session.commit()
+
+    other_client = await client.get(url, headers=admin_auth_header)  # builds v2
+    assert other_client.status_code == 200 and conversions.count == 2
+    v2_etag = other_client.headers["etag"]
+
+    resumed = await client.get(
+        url, headers={**admin_auth_header, "Range": "bytes=100-199"}
+    )
+    assert conversions.count == 2, (
+        "the resume must be a hit, or the test proves nothing"
+    )
+    assert resumed.status_code == 200, (
+        f"a bare Range hit inside the first TTL after a change answered "
+        f"{resumed.status_code}; the client's leading block came from the "
+        f"previous representation, which is still live under this URL"
+    )
+    assert resumed.headers["etag"] == v2_etag
+    assert "content-range" not in resumed.headers
+
+    # Settle the new bytes: a same-digest sibling older than a TTL under v2.
+    v2_key = [
+        k
+        for k in await get_storage().list(
+            f"export-cache/{cache._tenant_segment()}/{dataset.id}/"
+        )
+        if cache.parse_artifact_key(k)
+        and cache.parse_artifact_key(k)[2] == v2_etag.strip('"')
+    ][0]
+    v2_selection = v2_key.split(f"/{dataset.id}/", 1)[1].rsplit("/", 1)[0]
+    parsed = cache.parse_artifact_key(v2_key)
+    aged = cache._artifact_key(
+        dataset.id, v2_selection, parsed[2], parsed[1], time.time() - 700
+    )
+    await get_storage().put(aged, conversions.body)
+    when = time.time() - 700
+    os.utime(Path(get_storage().base_dir) / aged, (when, when))
+
+    settled = await client.get(
+        url, headers={**admin_auth_header, "Range": "bytes=100-199"}
+    )
+    assert conversions.count == 2
+    assert settled.status_code == 206, (
+        f"once the new bytes have been the answer for a TTL, a bare Range hit "
+        f"answered {settled.status_code}; GDAL opens after a settled change must work"
+    )
+    assert settled.headers["etag"] == v2_etag

--- a/backend/tests/test_export_artifact_cache_1532.py
+++ b/backend/tests/test_export_artifact_cache_1532.py
@@ -2836,8 +2836,17 @@ async def test_a_matching_if_range_resumes_even_on_a_contested_selection(
         )
     ][0]
     rival = b"a second builder's output, same window"
+    # Stamped a second BEFORE the artifact the client names, deliberately: the
+    # key stamp is whole seconds, and a rival minted in the same second ties
+    # with it, so which one `lookup` calls newest was a tie-break. If the rival
+    # won, the client's If-Range named a representation that was no longer the
+    # current one and the (correct) answer was 200 — a flake that pinned the
+    # wrong thing. Older by a second, the selection is contested and the named
+    # artifact stays current, which is what this test is about.
     await get_storage().put(
-        cache._artifact_key(dataset.id, selection, "c" * 64, len(rival), time.time()),
+        cache._artifact_key(
+            dataset.id, selection, "c" * 64, len(rival), time.time() - 1
+        ),
         rival,
     )
 
@@ -4545,9 +4554,12 @@ async def test_a_hit_inside_the_first_ttl_after_a_change_answers_bare_ranges_who
     assert resumed.headers["etag"] == v2_etag
     assert "content-range" not in resumed.headers
 
-    # Let the change age past a TTL: the URL's last answer with the OLD bytes
-    # is a publication under v1; move it back a TTL and more (re-keyed, since
-    # the stamp in the name floors publication) and the same hit is a 206.
+    # Let the change age out. The URL's last possible answer with the OLD
+    # bytes is a v1 publication plus a TTL, and the client that took it gets a
+    # TTL to come back — so a v1 publication 700 s old (TTL 600: served until
+    # 100 s ago) still holds bare ranges whole, and one 1300 s old releases
+    # them (#1585 review r5). Re-keyed each time, since the stamp in the name
+    # floors publication.
     storage = get_storage()
     prefix = f"export-cache/{cache._tenant_segment()}/{dataset.id}/"
     v1_keys = [
@@ -4557,24 +4569,44 @@ async def test_a_hit_inside_the_first_ttl_after_a_change_answers_bare_ranges_who
         and cache.parse_artifact_key(k)[2] != v2_etag.strip('"')
     ]
     assert v1_keys, "the previous representation must still be live for this test"
-    for k in v1_keys:
-        parsed = cache.parse_artifact_key(k)
-        selection_v1 = k.split(f"/{dataset.id}/", 1)[1].rsplit("/", 1)[0]
-        payload = await storage.get(k)
-        aged = cache._artifact_key(
-            dataset.id, selection_v1, parsed[2], parsed[1], time.time() - 700
-        )
-        await storage.put(aged, payload)
-        when = time.time() - 700
-        os.utime(Path(storage.base_dir) / aged, (when, when))
-        await storage.delete(k)
 
+    async def _age_v1_to(seconds_ago: float) -> None:
+        nonlocal v1_keys
+        moved = []
+        for k in v1_keys:
+            parsed = cache.parse_artifact_key(k)
+            selection_v1 = k.split(f"/{dataset.id}/", 1)[1].rsplit("/", 1)[0]
+            payload = await storage.get(k)
+            aged = cache._artifact_key(
+                dataset.id,
+                selection_v1,
+                parsed[2],
+                parsed[1],
+                time.time() - seconds_ago,
+            )
+            await storage.put(aged, payload)
+            when = time.time() - seconds_ago
+            os.utime(Path(storage.base_dir) / aged, (when, when))
+            await storage.delete(k)
+            moved.append(aged)
+        v1_keys = moved
+
+    await _age_v1_to(700)
+    still = await client.get(
+        url, headers={**admin_auth_header, "Range": "bytes=100-199"}
+    )
+    assert still.status_code == 200, (
+        f"the previous bytes were servable until 100 s ago and a client that took "
+        f"them may not be back yet; a bare Range hit answered {still.status_code}"
+    )
+
+    await _age_v1_to(1300)
     settled = await client.get(
         url, headers={**admin_auth_header, "Range": "bytes=100-199"}
     )
     assert conversions.count == 2
     assert settled.status_code == 206, (
-        f"a TTL after the URL last answered with other bytes, a bare Range hit "
+        f"two TTLs after the URL last published other bytes, a bare Range hit "
         f"answered {settled.status_code}; GDAL opens after a settled change must work"
     )
     assert settled.headers["etag"] == v2_etag

--- a/backend/tests/test_export_artifact_cache_1532.py
+++ b/backend/tests/test_export_artifact_cache_1532.py
@@ -4365,3 +4365,68 @@ async def test_a_builder_that_loses_the_race_serves_the_incumbent(
     assert resumed.status_code == 206, resumed.text
     assert resumed.content == served[100:200]
     assert resumed.headers["etag"] == one.headers["etag"]
+
+
+# ---------------------------------------------------------------------------
+# Release smoke follow-up: the cold GDAL open
+# ---------------------------------------------------------------------------
+
+
+async def test_a_cold_open_gets_its_leading_slice_from_the_fresh_build(
+    client: AsyncClient, admin_auth_header: dict, test_db_session, conversions
+):
+    """A bare Range from byte 0 on a cold cache is a 206, and the open proceeds.
+
+    fix(#1532) follow-up, found by the release smoke: GDAL 3.10's ``/vsicurl/``
+    open does not begin with a HEAD. Its first request is ``Range:
+    bytes=0-16383``, and the fresh-build path answered it with 200 and the whole
+    file — which GDAL reports as "Range downloading not supported by this
+    server!" and aborts. A cold cache could not be opened; only the second
+    attempt worked, because by then the artifact existed.
+
+    A Range that starts at byte 0 is a probe or a restart, never a resume — a
+    resumer holds a prefix and asks from its length — so nothing appended after
+    it can come from a different representation: every later request finds the
+    artifact this one published. The build still costs one conversion, and the
+    follow-up ranges are slices of that same artifact under the same ETag.
+    """
+    dataset = await _dataset(test_db_session, "Cold GDAL Open")
+    url = _url(dataset.id)
+
+    first = await client.get(url, headers={**admin_auth_header, "Range": "bytes=0-99"})
+    assert conversions.count == 1
+    assert first.status_code == 206, (
+        f"the leading range of a cold open answered {first.status_code}; GDAL "
+        f"reads a 200 to a ranged GET as 'Range downloading not supported' and "
+        f"aborts the open"
+    )
+    assert first.content == conversions.body[:100]
+    assert first.headers["content-range"] == f"bytes 0-99/{len(conversions.body)}"
+    etag = first.headers["etag"]
+
+    later = await client.get(
+        url, headers={**admin_auth_header, "Range": "bytes=100-199"}
+    )
+    assert later.status_code == 206
+    assert later.headers["etag"] == etag
+    assert later.content == conversions.body[100:200]
+    assert conversions.count == 1, "the follow-up range converted again"
+
+
+async def test_a_bare_range_not_from_zero_on_a_fresh_build_stays_whole(
+    client: AsyncClient, admin_auth_header: dict, test_db_session, conversions
+):
+    """The counterfactual to the leading-slice exception: an offset a resumer
+    would ask for, on a representation this request built, is still answered
+    whole. This is what `test_a_mutation_between_two_ranges_is_answered_with_the_whole_new_file`
+    rests on; stated here on its own so the exception cannot quietly widen.
+    """
+    dataset = await _dataset(test_db_session, "Cold Resume Offset")
+
+    resp = await client.get(
+        _url(dataset.id), headers={**admin_auth_header, "Range": "bytes=100-199"}
+    )
+    assert conversions.count == 1
+    assert resp.status_code == 200, resp.text
+    assert resp.content == conversions.body
+    assert "content-range" not in resp.headers

--- a/backend/tests/test_export_artifact_cache_1532.py
+++ b/backend/tests/test_export_artifact_cache_1532.py
@@ -1484,7 +1484,7 @@ async def test_a_contested_selection_answers_ranges_with_the_whole_thing(
     # A second builder's output, landing inside the same window with different
     # bytes — what an overlapping GPKG build produces.
     selection = [
-        k.rsplit("/", 2)[1]
+        k.split(f"/{dataset.id}/", 1)[1].rsplit("/", 1)[0]
         for k in await get_storage().list(
             f"export-cache/{cache._tenant_segment()}/{dataset.id}/"
         )
@@ -2090,7 +2090,7 @@ async def test_a_staggered_sibling_still_refuses_ranges_after_it_expires(
     first = await client.get(url, headers=admin_auth_header)
     assert first.status_code == 200
     selection = [
-        k.rsplit("/", 2)[1]
+        k.split(f"/{dataset.id}/", 1)[1].rsplit("/", 1)[0]
         for k in await get_storage().list(
             f"export-cache/{cache._tenant_segment()}/{dataset.id}/"
         )
@@ -2830,7 +2830,7 @@ async def test_a_matching_if_range_resumes_even_on_a_contested_selection(
     first = await client.get(url, headers=admin_auth_header)
     etag = first.headers["etag"]
     selection = [
-        k.rsplit("/", 2)[1]
+        k.split(f"/{dataset.id}/", 1)[1].rsplit("/", 1)[0]
         for k in await get_storage().list(
             f"export-cache/{cache._tenant_segment()}/{dataset.id}/"
         )
@@ -4430,3 +4430,68 @@ async def test_a_bare_range_not_from_zero_on_a_fresh_build_stays_whole(
     assert resp.status_code == 200, resp.text
     assert resp.content == conversions.body
     assert "content-range" not in resp.headers
+
+
+async def test_a_leading_range_after_a_change_is_whole_when_old_bytes_are_still_live(
+    client: AsyncClient, admin_auth_header: dict, test_db_session, conversions
+):
+    """The counter-case from #1585 review: re-reading byte 0 after a change.
+
+    A random-access client reads a later block, the data changes (and moves
+    `tile_cache_version`, so the artifact is cold under a NEW version segment of
+    the same URL), and the client re-reads the header with `bytes=0-...` while
+    still holding the old block. Byte 0 alone does not prove a fresh read, so
+    the leading-slice exception must not fire: the earlier artifact of this URL
+    is still live with different bytes, and the answer is the whole new file.
+
+    And the case that must keep working: the same URL rebuilt to IDENTICAL bytes
+    (a re-open after expiry) still gets its leading 206, because equal bytes
+    cannot splice whatever the client holds.
+    """
+    from app.processing.export import artifact_cache as cache
+
+    dataset = await _dataset(test_db_session, "Reread Zero")
+    url = _url(dataset.id)
+
+    later_block = await client.get(
+        url, headers={**admin_auth_header, "Range": "bytes=100-199"}
+    )
+    assert later_block.status_code == 200  # cold, not from zero: whole (and built)
+    assert conversions.count == 1
+
+    # The data changes and the version moves: the next request is cold under a
+    # new version segment, while the old artifact stays live under this URL.
+    conversions.body = bytes(reversed(conversions.body))
+    dataset.bump_tile_cache_version()
+    test_db_session.add(dataset)
+    await test_db_session.commit()
+
+    reread = await client.get(url, headers={**admin_auth_header, "Range": "bytes=0-99"})
+    assert conversions.count == 2
+    assert reread.status_code == 200, (
+        f"a leading Range after a change answered {reread.status_code}; the old "
+        f"artifact of this URL is still live with different bytes, so a client "
+        f"holding a block of it would splice"
+    )
+    assert reread.content == conversions.body
+    assert "content-range" not in reread.headers
+
+    # Identical rebuild after expiry: still a leading 206.
+    same = await _dataset(test_db_session, "Reopen After Expiry")
+    same_url = _url(same.id)
+    first = await client.get(
+        same_url, headers={**admin_auth_header, "Range": "bytes=0-99"}
+    )
+    assert first.status_code == 206
+    cache._ttl_seconds = lambda: 0
+    try:
+        again = await client.get(
+            same_url, headers={**admin_auth_header, "Range": "bytes=0-99"}
+        )
+    finally:
+        cache._ttl_seconds = lambda: 600
+    assert again.status_code == 206, (
+        f"a re-open after expiry with unchanged bytes answered {again.status_code}; "
+        f"GDAL re-opens more than a TTL apart are the common case"
+    )
+    assert again.headers["etag"] == first.headers["etag"]

--- a/backend/tests/test_export_artifact_cache_1532.py
+++ b/backend/tests/test_export_artifact_cache_1532.py
@@ -4497,68 +4497,6 @@ async def test_a_leading_range_after_a_change_is_whole_when_old_bytes_are_still_
     assert again.headers["etag"] == first.headers["etag"]
 
 
-async def test_a_legacy_layout_artifact_counts_as_the_urls_history(
-    client: AsyncClient, admin_auth_header: dict, test_db_session, conversions
-):
-    """An artifact under the single-segment layout blocks the leading slice.
-
-    #1585 review r2: the parent revision of #1582 wrote `<selection>/<name>`;
-    this revision writes `<url>/<version>/<name>`. For the rest of their
-    retention, legacy objects cannot be attributed to a URL, so any of them
-    with different bytes counts as this URL's history and the fresh build
-    answers a leading Range whole. Same bytes under the legacy layout do not
-    count: identical bytes cannot splice.
-    """
-    import hashlib as _hashlib
-
-    from app.platform.storage import get_storage
-    from app.processing.export import artifact_cache as cache
-
-    dataset = await _dataset(test_db_session, "Legacy Layout")
-    url = _url(dataset.id)
-    storage = get_storage()
-
-    # A legacy-shaped artifact for this dataset with DIFFERENT bytes.
-    legacy_selection = "0123456789abcdef0123456789abcdef"  # one 32-hex segment
-    foreign = b"bytes a pre-#1585 revision published"
-    await storage.put(
-        cache._artifact_key(
-            dataset.id,
-            legacy_selection,
-            _hashlib.sha256(foreign).hexdigest(),
-            len(foreign),
-            time.time() - 120,
-        ),
-        foreign,
-    )
-
-    resp = await client.get(url, headers={**admin_auth_header, "Range": "bytes=0-99"})
-    assert conversions.count == 1
-    assert resp.status_code == 200, (
-        f"a leading Range answered {resp.status_code} while a legacy-layout "
-        f"artifact with different bytes was still live under this dataset"
-    )
-    assert "content-range" not in resp.headers
-
-    # And with the legacy object carrying the SAME bytes as the fresh build,
-    # the leading slice is honoured: equal bytes cannot splice.
-    same = await _dataset(test_db_session, "Legacy Same Bytes")
-    await storage.put(
-        cache._artifact_key(
-            same.id,
-            legacy_selection,
-            _hashlib.sha256(conversions.body).hexdigest(),
-            len(conversions.body),
-            time.time() - 120,
-        ),
-        conversions.body,
-    )
-    ok = await client.get(
-        _url(same.id), headers={**admin_auth_header, "Range": "bytes=0-99"}
-    )
-    assert ok.status_code == 206, ok.text
-
-
 async def test_a_hit_inside_the_first_ttl_after_a_change_answers_bare_ranges_whole(
     client: AsyncClient, admin_auth_header: dict, test_db_session, conversions
 ):
@@ -4607,30 +4545,36 @@ async def test_a_hit_inside_the_first_ttl_after_a_change_answers_bare_ranges_who
     assert resumed.headers["etag"] == v2_etag
     assert "content-range" not in resumed.headers
 
-    # Settle the new bytes: a same-digest sibling older than a TTL under v2.
-    v2_key = [
+    # Let the change age past a TTL: the URL's last answer with the OLD bytes
+    # is a publication under v1; move it back a TTL and more (re-keyed, since
+    # the stamp in the name floors publication) and the same hit is a 206.
+    storage = get_storage()
+    prefix = f"export-cache/{cache._tenant_segment()}/{dataset.id}/"
+    v1_keys = [
         k
-        for k in await get_storage().list(
-            f"export-cache/{cache._tenant_segment()}/{dataset.id}/"
-        )
+        for k in await storage.list(prefix)
         if cache.parse_artifact_key(k)
-        and cache.parse_artifact_key(k)[2] == v2_etag.strip('"')
-    ][0]
-    v2_selection = v2_key.split(f"/{dataset.id}/", 1)[1].rsplit("/", 1)[0]
-    parsed = cache.parse_artifact_key(v2_key)
-    aged = cache._artifact_key(
-        dataset.id, v2_selection, parsed[2], parsed[1], time.time() - 700
-    )
-    await get_storage().put(aged, conversions.body)
-    when = time.time() - 700
-    os.utime(Path(get_storage().base_dir) / aged, (when, when))
+        and cache.parse_artifact_key(k)[2] != v2_etag.strip('"')
+    ]
+    assert v1_keys, "the previous representation must still be live for this test"
+    for k in v1_keys:
+        parsed = cache.parse_artifact_key(k)
+        selection_v1 = k.split(f"/{dataset.id}/", 1)[1].rsplit("/", 1)[0]
+        payload = await storage.get(k)
+        aged = cache._artifact_key(
+            dataset.id, selection_v1, parsed[2], parsed[1], time.time() - 700
+        )
+        await storage.put(aged, payload)
+        when = time.time() - 700
+        os.utime(Path(storage.base_dir) / aged, (when, when))
+        await storage.delete(k)
 
     settled = await client.get(
         url, headers={**admin_auth_header, "Range": "bytes=100-199"}
     )
     assert conversions.count == 2
     assert settled.status_code == 206, (
-        f"once the new bytes have been the answer for a TTL, a bare Range hit "
+        f"a TTL after the URL last answered with other bytes, a bare Range hit "
         f"answered {settled.status_code}; GDAL opens after a settled change must work"
     )
     assert settled.headers["etag"] == v2_etag

--- a/backend/tests/test_export_artifact_cache_1532.py
+++ b/backend/tests/test_export_artifact_cache_1532.py
@@ -4495,3 +4495,65 @@ async def test_a_leading_range_after_a_change_is_whole_when_old_bytes_are_still_
         f"GDAL re-opens more than a TTL apart are the common case"
     )
     assert again.headers["etag"] == first.headers["etag"]
+
+
+async def test_a_legacy_layout_artifact_counts_as_the_urls_history(
+    client: AsyncClient, admin_auth_header: dict, test_db_session, conversions
+):
+    """An artifact under the single-segment layout blocks the leading slice.
+
+    #1585 review r2: the parent revision of #1582 wrote `<selection>/<name>`;
+    this revision writes `<url>/<version>/<name>`. For the rest of their
+    retention, legacy objects cannot be attributed to a URL, so any of them
+    with different bytes counts as this URL's history and the fresh build
+    answers a leading Range whole. Same bytes under the legacy layout do not
+    count: identical bytes cannot splice.
+    """
+    import hashlib as _hashlib
+
+    from app.platform.storage import get_storage
+    from app.processing.export import artifact_cache as cache
+
+    dataset = await _dataset(test_db_session, "Legacy Layout")
+    url = _url(dataset.id)
+    storage = get_storage()
+
+    # A legacy-shaped artifact for this dataset with DIFFERENT bytes.
+    legacy_selection = "0123456789abcdef0123456789abcdef"  # one 32-hex segment
+    foreign = b"bytes a pre-#1585 revision published"
+    await storage.put(
+        cache._artifact_key(
+            dataset.id,
+            legacy_selection,
+            _hashlib.sha256(foreign).hexdigest(),
+            len(foreign),
+            time.time() - 120,
+        ),
+        foreign,
+    )
+
+    resp = await client.get(url, headers={**admin_auth_header, "Range": "bytes=0-99"})
+    assert conversions.count == 1
+    assert resp.status_code == 200, (
+        f"a leading Range answered {resp.status_code} while a legacy-layout "
+        f"artifact with different bytes was still live under this dataset"
+    )
+    assert "content-range" not in resp.headers
+
+    # And with the legacy object carrying the SAME bytes as the fresh build,
+    # the leading slice is honoured: equal bytes cannot splice.
+    same = await _dataset(test_db_session, "Legacy Same Bytes")
+    await storage.put(
+        cache._artifact_key(
+            same.id,
+            legacy_selection,
+            _hashlib.sha256(conversions.body).hexdigest(),
+            len(conversions.body),
+            time.time() - 120,
+        ),
+        conversions.body,
+    )
+    ok = await client.get(
+        _url(same.id), headers={**admin_auth_header, "Range": "bytes=0-99"}
+    )
+    assert ok.status_code == 206, ok.text

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -3671,14 +3671,14 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # budget and the contested rule all read the same listing. Most of the
     # length is the reasoning from twenty-nine review rounds, kept next to the
     # rules it justifies. Cap 1020, exact.
-    # fix(#1532) follow-up (#1585): +117 — the selection key becomes URL
-    # segment / version segment, and `url_has_other_bytes` asks one listing
-    # whether an earlier representation of the same URL with different bytes is
-    # still live, which is what lets a fresh build honour the leading Range of
-    # a cold GDAL open without reopening the splice, and (review r2) counts a
-    # legacy single-segment artifact as the URL's history; (r3) `settled` on the
-    # artifact bounds the check to the first TTL after a change. Cap 1020 -> 1137, exact.
-    "backend/app/processing/export/artifact_cache.py": 1137,
+    # fix(#1532) follow-up (#1585): +63 — the selection key becomes URL
+    # segment / version segment, so every version of one URL shares a prefix,
+    # and `url_answered_other_bytes_recently` asks that prefix whether the URL
+    # answered with different bytes inside the last TTL: for that TTL bare
+    # ranges are whole, which is what lets a fresh build honour the leading
+    # Range of a cold GDAL open without reopening the splice, on the hit path
+    # too. Cap 1020 -> 1083, exact.
+    "backend/app/processing/export/artifact_cache.py": 1083,
     # fix(#1548 review P2): crossed the inclusion threshold. The growth is
     # assert_domain_lock_is_enforceable — the write-side precondition that
     # refuses a domain lock this deployment could never enforce, because

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -3671,7 +3671,12 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # budget and the contested rule all read the same listing. Most of the
     # length is the reasoning from twenty-nine review rounds, kept next to the
     # rules it justifies. Cap 1020, exact.
-    "backend/app/processing/export/artifact_cache.py": 1020,
+    # fix(#1532) follow-up (#1585): +42 — the selection key becomes URL
+    # segment / version segment, and `url_has_other_bytes` asks one listing
+    # whether an earlier representation of the same URL with different bytes is
+    # still live, which is what lets a fresh build honour the leading Range of
+    # a cold GDAL open without reopening the splice. Cap 1020 -> 1062, exact.
+    "backend/app/processing/export/artifact_cache.py": 1062,
     # fix(#1548 review P2): crossed the inclusion threshold. The growth is
     # assert_domain_lock_is_enforceable — the write-side precondition that
     # refuses a domain lock this deployment could never enforce, because

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -3671,11 +3671,12 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # budget and the contested rule all read the same listing. Most of the
     # length is the reasoning from twenty-nine review rounds, kept next to the
     # rules it justifies. Cap 1020, exact.
-    # fix(#1532) follow-up (#1585): +42 — the selection key becomes URL
+    # fix(#1532) follow-up (#1585): +59 — the selection key becomes URL
     # segment / version segment, and `url_has_other_bytes` asks one listing
     # whether an earlier representation of the same URL with different bytes is
     # still live, which is what lets a fresh build honour the leading Range of
-    # a cold GDAL open without reopening the splice. Cap 1020 -> 1079, exact.
+    # a cold GDAL open without reopening the splice, and (review r2) counts a
+    # legacy single-segment artifact as the URL's history. Cap 1020 -> 1079, exact.
     "backend/app/processing/export/artifact_cache.py": 1079,
     # fix(#1548 review P2): crossed the inclusion threshold. The growth is
     # assert_domain_lock_is_enforceable — the write-side precondition that

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -3675,8 +3675,8 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # segment / version segment, and `url_has_other_bytes` asks one listing
     # whether an earlier representation of the same URL with different bytes is
     # still live, which is what lets a fresh build honour the leading Range of
-    # a cold GDAL open without reopening the splice. Cap 1020 -> 1062, exact.
-    "backend/app/processing/export/artifact_cache.py": 1062,
+    # a cold GDAL open without reopening the splice. Cap 1020 -> 1079, exact.
+    "backend/app/processing/export/artifact_cache.py": 1079,
     # fix(#1548 review P2): crossed the inclusion threshold. The growth is
     # assert_domain_lock_is_enforceable — the write-side precondition that
     # refuses a domain lock this deployment could never enforce, because

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -3671,14 +3671,14 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # budget and the contested rule all read the same listing. Most of the
     # length is the reasoning from twenty-nine review rounds, kept next to the
     # rules it justifies. Cap 1020, exact.
-    # fix(#1532) follow-up (#1585): +63 — the selection key becomes URL
+    # fix(#1532) follow-up (#1585): +70 — the selection key becomes URL
     # segment / version segment, so every version of one URL shares a prefix,
     # and `url_answered_other_bytes_recently` asks that prefix whether the URL
     # answered with different bytes inside the last TTL: for that TTL bare
     # ranges are whole, which is what lets a fresh build honour the leading
     # Range of a cold GDAL open without reopening the splice, on the hit path
-    # too. Cap 1020 -> 1083, exact.
-    "backend/app/processing/export/artifact_cache.py": 1083,
+    # too. Cap 1020 -> 1090, exact.
+    "backend/app/processing/export/artifact_cache.py": 1090,
     # fix(#1548 review P2): crossed the inclusion threshold. The growth is
     # assert_domain_lock_is_enforceable — the write-side precondition that
     # refuses a domain lock this deployment could never enforce, because

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -3671,13 +3671,14 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # budget and the contested rule all read the same listing. Most of the
     # length is the reasoning from twenty-nine review rounds, kept next to the
     # rules it justifies. Cap 1020, exact.
-    # fix(#1532) follow-up (#1585): +59 — the selection key becomes URL
+    # fix(#1532) follow-up (#1585): +117 — the selection key becomes URL
     # segment / version segment, and `url_has_other_bytes` asks one listing
     # whether an earlier representation of the same URL with different bytes is
     # still live, which is what lets a fresh build honour the leading Range of
     # a cold GDAL open without reopening the splice, and (review r2) counts a
-    # legacy single-segment artifact as the URL's history. Cap 1020 -> 1079, exact.
-    "backend/app/processing/export/artifact_cache.py": 1079,
+    # legacy single-segment artifact as the URL's history; (r3) `settled` on the
+    # artifact bounds the check to the first TTL after a change. Cap 1020 -> 1137, exact.
+    "backend/app/processing/export/artifact_cache.py": 1137,
     # fix(#1548 review P2): crossed the inclusion threshold. The growth is
     # assert_domain_lock_is_enforceable — the write-side precondition that
     # refuses a domain lock this deployment could never enforce, because


### PR DESCRIPTION
Follow-up to #1582 (fixes the cold half of #1532), found by the release smoke rather than by review.

## What the smoke found

`ogrinfo` against the dev stack, cold cache:

```
ERROR 1: Range downloading not supported by this server!
ogrinfo failed - unable to open '/vsicurl?url=.../export?format=gpkg'.
```

Second attempt, same URL: opens, and the verbose log shows seven `206` reads off one artifact, which is exactly what #1582 was for. The first attempt fails because GDAL 3.10 does not begin a `/vsicurl/` open with a HEAD. Its first request is `Range: bytes=0-16383`, the fresh-build path answered that with `200` and the whole file (by design: a bare Range on a rebuild is ignored so a resumer cannot splice), and GDAL treats a `200` to a ranged GET as a server that does not do ranges. So a cold selection could not be opened at all; only the second open worked.

## The change

A Range that starts at byte 0 is honoured on a fresh build. That is a probe or a restart, never a resume: a client resuming holds a prefix and asks from its length. Nothing appended after a slice that starts at 0 can come from a different representation, because every later request finds the artifact this one just published and slices that. Any other starting offset on a fresh build keeps the whole answer, which is what `test_a_mutation_between_two_ranges_is_answered_with_the_whole_new_file` rests on, and a contested selection keeps the whole answer at every offset, including 0.

`read_response` gains `leading_slice_ok`, separate from `may_serve_range` because both a fresh build and a contested selection set the latter False and only the first may take the exception. The route passes `not stored.contested`: a fresh build's flag is False, an incumbent handed back from a lost race carries lookup's.

## Tests

- `test_a_cold_open_gets_its_leading_slice_from_the_fresh_build`: cold `bytes=0-99` is a `206` with the right `Content-Range`, one conversion, and the follow-up `bytes=100-199` is a `206` of the same artifact under the same ETag. Red on main (`200`).
- `test_a_bare_range_not_from_zero_on_a_fresh_build_stays_whole`: the counterfactual, so the exception cannot quietly widen.
- The contested-selection test and the mutation test are unchanged and pass.

## Verification

`ruff check` / `ruff format --check` clean; the export suites plus `test_layering.py` and `test_rule1_structural.py`, 280 passed under `-n 4`. The real GDAL open is re-run against the rebuilt dev stack as part of the release smoke once this is on main.
