### PR TITLE
test(embeddings): assert the anomalous-width retry as a shape, not a position

### DIFF
--- a/backend/tests/test_embedding_backfill_column_drift_1533.py
+++ b/backend/tests/test_embedding_backfill_column_drift_1533.py
@@ -410,13 +410,13 @@ async def test_one_anomalous_vector_width_costs_one_record_not_the_run(
     await test_db_session.commit()
 
     _pin_model(monkeypatch)
-    calls: list[int] = []
+    seen: list[list[str]] = []
 
     async def _embed(texts, _session, **_kwargs):
         # Keyed on content, not call order: the force path's pre-flight is its
         # own single-text call and must come back at the column's width, or the
         # run aborts before the batch this test is about.
-        calls.append(len(texts))
+        seen.append(list(texts))
         return [
             [0.1] * (odd_width if odd_marker in text else start_width) for text in texts
         ]
@@ -424,6 +424,7 @@ async def test_one_anomalous_vector_width_costs_one_record_not_the_run(
     monkeypatch.setattr(backfill_module, "generate_embeddings_batch", _embed)
 
     result = await backfill_module.backfill_embeddings(test_db_session, force=True)
+    calls = [len(texts) for texts in seen]
 
     assert result["errors"] == 1, result
     assert result["created"] >= _SEEDED, result
@@ -433,22 +434,29 @@ async def test_one_anomalous_vector_width_costs_one_record_not_the_run(
     # per-record judgement is what produced that single error rather than the
     # batch check having quietly let everything through.
     #
-    # Asserted as a SHAPE rather than by position: the anomalous record lands
-    # in whichever batch the run's ordering puts it, and on a busy xdist worker
-    # the database already holds records earlier tests committed, so full-size
-    # batches that succeed can precede it (seen at batch_start=256 in CI). What
-    # is invariant is that exactly one batch of more than one record is followed
-    # by that many single-record calls — the retry of the batch that failed.
+    # Anchored on the anomalous record's TEXT rather than on a call position or
+    # a batch size: on a busy xdist worker the database already holds records
+    # earlier tests committed, so the odd record lands in whichever batch the
+    # accumulated count puts it (seen at batch_start=256 in CI), and at 127 mod
+    # `_BATCH_SIZE` prior records it is a batch of one all by itself. Whatever
+    # the batch, the odd record is embedded exactly twice: once in that batch,
+    # once alone in the retry, and every record of the failed batch is
+    # re-embedded alone right after it.
     assert calls[0] == 1, "the pre-flight"
-    retried = [
-        i
-        for i, size in enumerate(calls[1:], start=1)
-        if size > 1 and calls[i + 1 : i + 1 + size] == [1] * size
+    marker_calls = [
+        i for i, texts in enumerate(seen) if any(odd_marker in t for t in texts)
     ]
-    assert len(retried) == 1, (
-        f"expected exactly one batch to fail and be retried record by record; "
+    assert len(marker_calls) == 2, (
+        "expected the anomalous record to be embedded in its batch and once more "
+        f"alone in the retry; it appeared in calls {marker_calls} of sizes {calls}"
+    )
+    failed_batch, retry = marker_calls
+    size = calls[failed_batch]
+    assert calls[failed_batch + 1 : failed_batch + 1 + size] == [1] * size, (
+        f"expected the failed batch of {size} to be retried record by record; "
         f"call sizes were {calls}"
     )
+    assert calls[retry] == 1, calls
 
     # And the column never moved, which is what made it isolated.
     assert await _column_dims() == start_width

--- a/backend/tests/test_embedding_backfill_column_drift_1533.py
+++ b/backend/tests/test_embedding_backfill_column_drift_1533.py
@@ -432,10 +432,23 @@ async def test_one_anomalous_vector_width_costs_one_record_not_the_run(
     # Non-vacuity: the batch really did fail and retry per record, so the
     # per-record judgement is what produced that single error rather than the
     # batch check having quietly let everything through.
-    assert len(calls) > 2, calls
+    #
+    # Asserted as a SHAPE rather than by position: the anomalous record lands
+    # in whichever batch the run's ordering puts it, and on a busy xdist worker
+    # the database already holds records earlier tests committed, so full-size
+    # batches that succeed can precede it (seen at batch_start=256 in CI). What
+    # is invariant is that exactly one batch of more than one record is followed
+    # by that many single-record calls — the retry of the batch that failed.
     assert calls[0] == 1, "the pre-flight"
-    assert calls[1] > 1, "the batch"
-    assert set(calls[2:]) == {1}, "then one call per record, individually"
+    retried = [
+        i
+        for i, size in enumerate(calls[1:], start=1)
+        if size > 1 and calls[i + 1 : i + 1 + size] == [1] * size
+    ]
+    assert len(retried) == 1, (
+        f"expected exactly one batch to fail and be retried record by record; "
+        f"call sizes were {calls}"
+    )
 
     # And the column never moved, which is what made it isolated.
     assert await _column_dims() == start_width


### PR DESCRIPTION
Test-only. `test_one_anomalous_vector_width_costs_one_record_not_the_run` asserted the shape of the provider calls by position: pre-flight, one batch, then only single-record calls. That holds when the anomalous record is in the first batch, which is true on an empty database and false on a busy xdist worker whose database already holds records earlier tests committed. CI hit it on #1585's run at `batch_start=256`: two full batches succeeded before the one carrying the odd record failed, so `set(calls[2:]) == {1}` saw a 128 and failed a run whose behaviour was correct.

The invariant is that exactly one batch of more than one record is followed by that many single-record calls, the retry of the batch that failed. That is what the test asserts now, wherever the record lands.

Verified: the file alone (9 passed) and the whole `-k embedding` selection on one worker so records accumulate before this test (240 passed).
