### PR TITLE
ci(release): dispatch a geolens-release event to the site after the Release publishes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -185,20 +185,20 @@ jobs:
         # INSIDE the run script rather than in this `if:`, on purpose: a step
         # this `if:` skips shows as a bare grey "skipped" in the run, which is
         # how a missing SITE_DISPATCH_TOKEN would go unnoticed indefinitely
-        # (this file already learned that lesson once, see the release-notes
-        # fallback around line 90 for #1530 and its history). Running the
-        # step and having it log a ::notice::/::warning:: and a step-summary
-        # line keeps the same "never fail the release over this" behavior
-        # visible instead of silent.
+        # (this file already learned that lesson once, for #1530). Running
+        # the step and having it log a ::notice::/::warning:: and a
+        # step-summary line keeps the same "never fail the release over
+        # this" behavior visible instead of silent.
         if: ${{ !contains(env.TAG, '-') }}
         env:
           # Two different tokens for two different targets: reading THIS
-          # repo's latest release needs only the default token; dispatching
-          # to getgeolens.com needs a PAT scoped there (SITE_DISPATCH_TOKEN
-          # has no read access here, and the default token has no access
-          # there). Fine-grained PAT, Contents: read/write on
-          # geolens-io/getgeolens.com; absent = skipped with a ::notice::.
-          RELEASE_READ_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # repo's latest release needs only the default GITHUB_TOKEN;
+          # dispatching to getgeolens.com needs a PAT scoped there
+          # (SITE_DISPATCH_TOKEN has no read access here, and the default
+          # token has no access there). Fine-grained PAT, Contents:
+          # read/write on geolens-io/getgeolens.com; absent = skipped with
+          # a ::notice::.
+          DEFAULT_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SITE_DISPATCH_TOKEN: ${{ secrets.SITE_DISPATCH_TOKEN }}
         # The release is already published by this point in the job. A failed
         # dispatch must never fail the release on the site repo's account —
@@ -206,22 +206,33 @@ jobs:
         # gap and the manual sync step still exists as a fallback.
         continue-on-error: true
         run: |
+          # A small heading so these lines read as their own section in the
+          # job summary rather than trailing off the "Generate release
+          # notes" step's own ### warning block above them.
+          summary() {
+            { echo "### Site dispatch"; echo "- $1"; } >> "$GITHUB_STEP_SUMMARY"
+          }
+
           # prod-smoke.yml runs tag smokes in parallel and this workflow has
           # no concurrency group, so an older tag's smoke can finish after a
           # newer one's (or a re-run replays an old tag's smoke) and reach
           # this step after a newer release already published. Dispatching
           # then would tell the site to sync backwards. Only the actual
           # latest release may dispatch.
-          LATEST="$(GH_TOKEN="$RELEASE_READ_TOKEN" gh api "repos/${GITHUB_REPOSITORY}/releases/latest" --jq .tag_name)"
+          if ! LATEST="$(GH_TOKEN="$DEFAULT_TOKEN" gh api "repos/${GITHUB_REPOSITORY}/releases/latest" --jq .tag_name)"; then
+            echo "::warning title=Site not notified::Could not read the latest release for ${TAG}, so the site dispatch was skipped."
+            summary "skipped (could not read the latest release)"
+            exit 1
+          fi
           if [ "$LATEST" != "$TAG" ]; then
             echo "::notice title=Not the latest release::Skipping the site dispatch for ${TAG} — the latest published release is ${LATEST}. A newer tag's smoke likely finished first, or this is a re-run of an older tag."
-            echo "- Site dispatch: skipped, ${TAG} is not the latest release (${LATEST} is)" >> "$GITHUB_STEP_SUMMARY"
+            summary "skipped, ${TAG} is not the latest release (${LATEST} is)"
             exit 0
           fi
 
           if [ -z "$SITE_DISPATCH_TOKEN" ]; then
             echo "::notice title=Site not notified::SITE_DISPATCH_TOKEN is not configured, so ${TAG} was not dispatched to getgeolens.com. Add it as a fine-grained PAT with Contents: read/write on geolens-io/getgeolens.com to enable this."
-            echo "- Site dispatch: skipped (no SITE_DISPATCH_TOKEN)" >> "$GITHUB_STEP_SUMMARY"
+            summary "skipped (no SITE_DISPATCH_TOKEN)"
             exit 0
           fi
 
@@ -229,7 +240,7 @@ jobs:
             -f event_type=geolens-release \
             -f "client_payload[version]=${TAG}"; then
             echo "::warning title=Site dispatch failed::Could not notify geolens-io/getgeolens.com of release ${TAG}. The GeoLens release itself published fine; the site will pick up the contract sync on its next scheduled release-drift check instead."
-            echo "- Site dispatch: FAILED for ${TAG} (see the warning above)" >> "$GITHUB_STEP_SUMMARY"
+            summary "FAILED for ${TAG} (see the warning above)"
             exit 1
           fi
-          echo "- Site dispatch: notified getgeolens.com of ${TAG}" >> "$GITHUB_STEP_SUMMARY"
+          summary "notified getgeolens.com of ${TAG}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -172,35 +172,64 @@ jobs:
           ( cd scripts && sha256sum install.sh ) > SHA256SUMS
           gh release upload "${TAG}" SHA256SUMS --clobber
 
-      # CI-1: the site repo listens for this dispatch to run release-drift
-      # immediately and to open its docs-contract sync PR (see
-      # getgeolens.com's release-sync.yml). GitHub's docs list the contexts
-      # available to `jobs.<job_id>.steps.if` as github, needs, strategy,
-      # matrix, job, runner, env, vars, steps, and inputs; `secrets` is not
-      # among them (see
-      # https://docs.github.com/en/actions/reference/workflows-and-actions/contexts).
-      # So the presence check goes through the `env` context instead: set the
-      # secret as a step env var, then gate on `env.SITE_DISPATCH_TOKEN`.
+      # CI-1 (see geolens-io/getgeolens.com#108): the site repo listens for
+      # this dispatch to run release-drift immediately and to open its
+      # docs-contract sync PR (getgeolens.com#108, release-sync.yml).
       - name: Notify the site of the release
         # Only GA tags (no `-` suffix) dispatch — same shape as the
         # IS_PRERELEASE case pattern in "Create release" above. A prerelease
         # never becomes the "latest" release the site's install one-liner and
         # archive link follow, so the site has nothing to sync for one.
-        # Skipped, not failed, when the secret isn't configured — this repo's
-        # release must work for anyone who hasn't set up the site's PAT.
-        if: env.SITE_DISPATCH_TOKEN != '' && !contains(env.TAG, '-')
+        #
+        # Everything else (the missing-secret case, the stale-tag case) stays
+        # INSIDE the run script rather than in this `if:`, on purpose: a step
+        # this `if:` skips shows as a bare grey "skipped" in the run, which is
+        # how a missing SITE_DISPATCH_TOKEN would go unnoticed indefinitely
+        # (this file already learned that lesson once, see the release-notes
+        # fallback around line 90 for #1530 and its history). Running the
+        # step and having it log a ::notice::/::warning:: and a step-summary
+        # line keeps the same "never fail the release over this" behavior
+        # visible instead of silent.
+        if: ${{ !contains(env.TAG, '-') }}
         env:
+          # Two different tokens for two different targets: reading THIS
+          # repo's latest release needs only the default token; dispatching
+          # to getgeolens.com needs a PAT scoped there (SITE_DISPATCH_TOKEN
+          # has no read access here, and the default token has no access
+          # there). Fine-grained PAT, Contents: read/write on
+          # geolens-io/getgeolens.com; absent = skipped with a ::notice::.
+          RELEASE_READ_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SITE_DISPATCH_TOKEN: ${{ secrets.SITE_DISPATCH_TOKEN }}
-          GH_TOKEN: ${{ secrets.SITE_DISPATCH_TOKEN }}
         # The release is already published by this point in the job. A failed
         # dispatch must never fail the release on the site repo's account —
         # worst case, the site's own nightly release-drift check catches the
         # gap and the manual sync step still exists as a fallback.
         continue-on-error: true
         run: |
-          if ! gh api repos/geolens-io/getgeolens.com/dispatches \
+          # prod-smoke.yml runs tag smokes in parallel and this workflow has
+          # no concurrency group, so an older tag's smoke can finish after a
+          # newer one's (or a re-run replays an old tag's smoke) and reach
+          # this step after a newer release already published. Dispatching
+          # then would tell the site to sync backwards. Only the actual
+          # latest release may dispatch.
+          LATEST="$(GH_TOKEN="$RELEASE_READ_TOKEN" gh api "repos/${GITHUB_REPOSITORY}/releases/latest" --jq .tag_name)"
+          if [ "$LATEST" != "$TAG" ]; then
+            echo "::notice title=Not the latest release::Skipping the site dispatch for ${TAG} — the latest published release is ${LATEST}. A newer tag's smoke likely finished first, or this is a re-run of an older tag."
+            echo "- Site dispatch: skipped, ${TAG} is not the latest release (${LATEST} is)" >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          if [ -z "$SITE_DISPATCH_TOKEN" ]; then
+            echo "::notice title=Site not notified::SITE_DISPATCH_TOKEN is not configured, so ${TAG} was not dispatched to getgeolens.com. Add it as a fine-grained PAT with Contents: read/write on geolens-io/getgeolens.com to enable this."
+            echo "- Site dispatch: skipped (no SITE_DISPATCH_TOKEN)" >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          if ! GH_TOKEN="$SITE_DISPATCH_TOKEN" gh api repos/geolens-io/getgeolens.com/dispatches \
             -f event_type=geolens-release \
             -f "client_payload[version]=${TAG}"; then
             echo "::warning title=Site dispatch failed::Could not notify geolens-io/getgeolens.com of release ${TAG}. The GeoLens release itself published fine; the site will pick up the contract sync on its next scheduled release-drift check instead."
+            echo "- Site dispatch: FAILED for ${TAG} (see the warning above)" >> "$GITHUB_STEP_SUMMARY"
             exit 1
           fi
+          echo "- Site dispatch: notified getgeolens.com of ${TAG}" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -205,6 +205,7 @@ jobs:
         # worst case, the site's own nightly release-drift check catches the
         # gap and the manual sync step still exists as a fallback.
         continue-on-error: true
+        timeout-minutes: 5
         run: |
           # A small heading so these lines read as their own section in the
           # job summary rather than trailing off the "Generate release
@@ -220,8 +221,8 @@ jobs:
           # then would tell the site to sync backwards. Only the actual
           # latest release may dispatch.
           if ! LATEST="$(GH_TOKEN="$DEFAULT_TOKEN" gh api "repos/${GITHUB_REPOSITORY}/releases/latest" --jq .tag_name)"; then
-            echo "::warning title=Site not notified::Could not read the latest release for ${TAG}, so the site dispatch was skipped."
-            summary "skipped (could not read the latest release)"
+            echo "::warning title=Site dispatch failed::Could not read the latest release for ${TAG}, so the site dispatch did not run."
+            summary "FAILED for ${TAG} (could not read the latest release)"
             exit 1
           fi
           if [ "$LATEST" != "$TAG" ]; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -171,3 +171,36 @@ jobs:
           # install.sh and SHA256SUMS are downloaded into the same directory.
           ( cd scripts && sha256sum install.sh ) > SHA256SUMS
           gh release upload "${TAG}" SHA256SUMS --clobber
+
+      # CI-1: the site repo listens for this dispatch to run release-drift
+      # immediately and to open its docs-contract sync PR (see
+      # getgeolens.com's release-sync.yml). GitHub's docs list the contexts
+      # available to `jobs.<job_id>.steps.if` as github, needs, strategy,
+      # matrix, job, runner, env, vars, steps, and inputs; `secrets` is not
+      # among them (see
+      # https://docs.github.com/en/actions/reference/workflows-and-actions/contexts).
+      # So the presence check goes through the `env` context instead: set the
+      # secret as a step env var, then gate on `env.SITE_DISPATCH_TOKEN`.
+      - name: Notify the site of the release
+        # Only GA tags (no `-` suffix) dispatch — same shape as the
+        # IS_PRERELEASE case pattern in "Create release" above. A prerelease
+        # never becomes the "latest" release the site's install one-liner and
+        # archive link follow, so the site has nothing to sync for one.
+        # Skipped, not failed, when the secret isn't configured — this repo's
+        # release must work for anyone who hasn't set up the site's PAT.
+        if: env.SITE_DISPATCH_TOKEN != '' && !contains(env.TAG, '-')
+        env:
+          SITE_DISPATCH_TOKEN: ${{ secrets.SITE_DISPATCH_TOKEN }}
+          GH_TOKEN: ${{ secrets.SITE_DISPATCH_TOKEN }}
+        # The release is already published by this point in the job. A failed
+        # dispatch must never fail the release on the site repo's account —
+        # worst case, the site's own nightly release-drift check catches the
+        # gap and the manual sync step still exists as a fallback.
+        continue-on-error: true
+        run: |
+          if ! gh api repos/geolens-io/getgeolens.com/dispatches \
+            -f event_type=geolens-release \
+            -f "client_payload[version]=${TAG}"; then
+            echo "::warning title=Site dispatch failed::Could not notify geolens-io/getgeolens.com of release ${TAG}. The GeoLens release itself published fine; the site will pick up the contract sync on its next scheduled release-drift check instead."
+            exit 1
+          fi

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -72,7 +72,13 @@ commit:
    Contents: read/write on `geolens-io/getgeolens.com`. Absent, the step is a
    no-op logged as a `::notice::` rather than a failure — the release still
    publishes normally, and the site's own scheduled `release-drift` check
-   catches the gap on its own cadence.
+   catches the gap on its own cadence. Getting an actual sync PR (not just the
+   dispatch) also needs a `RELEASE_SYNC_TOKEN` secret on the site repo itself,
+   same scope plus Pull requests: read/write — one fine-grained PAT with both
+   scopes can be stored under both names. Until that sync PR merges, the
+   site's `release-drift` job (which also runs on this dispatch) is expected
+   to go red and file or comment on its `nightly-red` issue (site #95) — that
+   is the intended signal that a sync is pending, not a regression.
 4. SDK and CLI publishes pause for one-click approval before they ship; image
    and release builds do not.
 5. `verify-published.yml` runs after the publishes complete and confirms every

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -63,9 +63,19 @@ commit:
    CI (`make version-check` is part of it).
 2. Tag the merge commit `vX.Y.Z`. The tag auto-builds the GitHub Release and the
    GHCR images, and triggers the PyPI/npm publishes.
-3. SDK and CLI publishes pause for one-click approval before they ship; image
+3. Once the Release job publishes a GA tag as the latest release, it dispatches
+   a `geolens-release` event to `geolens-io/getgeolens.com` (see
+   `.github/workflows/release.yml`'s "Notify the site of the release" step),
+   which runs that repo's `release-drift` check immediately and opens a PR
+   syncing the vendored docs contract, OpenAPI snapshot, and installer. This
+   needs the `SITE_DISPATCH_TOKEN` secret on this repo: a fine-grained PAT with
+   Contents: read/write on `geolens-io/getgeolens.com`. Absent, the step is a
+   no-op logged as a `::notice::` rather than a failure — the release still
+   publishes normally, and the site's own scheduled `release-drift` check
+   catches the gap on its own cadence.
+4. SDK and CLI publishes pause for one-click approval before they ship; image
    and release builds do not.
-4. `verify-published.yml` runs after the publishes complete and confirms every
+5. `verify-published.yml` runs after the publishes complete and confirms every
    surface matches.
 
 The maintainer owns the tag cut and the publish approval. This document does not


### PR DESCRIPTION
## Summary

CI-1: getgeolens.com already declares `repository_dispatch: [geolens-release]` for its release-drift check, and a companion PR there (geolens-io/getgeolens.com#108) adds a `release-sync.yml` that opens a docs-contract PR on that same event. Nothing on this side ever fired the event, so the site's contract, OpenAPI snapshot, and installer sync stayed a manual step after every release.

This adds one step to `release.yml`'s `release` job, after the GitHub Release and its uploads (install script, SHA256SUMS) succeed. It checks that the dispatched tag is actually the latest published release, then fires the dispatch:

```yaml
- name: Notify the site of the release
  if: ${{ !contains(env.TAG, '-') }}
  env:
    RELEASE_READ_TOKEN: ${{ secrets.GITHUB_TOKEN }}
    SITE_DISPATCH_TOKEN: ${{ secrets.SITE_DISPATCH_TOKEN }}
  continue-on-error: true
  run: |
    LATEST="$(GH_TOKEN="$RELEASE_READ_TOKEN" gh api "repos/${GITHUB_REPOSITORY}/releases/latest" --jq .tag_name)"
    if [ "$LATEST" != "$TAG" ]; then
      echo "::notice ...skipping, not the latest release..."
      exit 0
    fi
    if [ -z "$SITE_DISPATCH_TOKEN" ]; then
      echo "::notice ...SITE_DISPATCH_TOKEN not set..."
      exit 0
    fi
    GH_TOKEN="$SITE_DISPATCH_TOKEN" gh api repos/geolens-io/getgeolens.com/dispatches \
      -f event_type=geolens-release \
      -f "client_payload[version]=${TAG}"
```

A few things worth calling out:

- **A monotonicity guard.** `release.yml` has no `concurrency:` group and `prod-smoke.yml` runs tag smokes in parallel, so an older tag's smoke can finish after a newer tag's release already published, or a re-run can replay an old tag's smoke. Dispatching in either case would tell the site to sync backwards. The step reads this repo's actual latest release first and skips (with a visible `::notice::`) unless the dispatched tag matches it.
- **Only GA tags dispatch.** `!contains(env.TAG, '-')` mirrors the `case "${TAG}" in *-*)` prerelease check already used a few lines up in the "Create release" step. A prerelease never gets promoted to the "latest" release that the site's install one-liner and archive link follow, so there's nothing for the site to sync.
- **Missing secret skips, but visibly.** An earlier version of this gated the whole step's `if:` on the secret being present, since `secrets` isn't in the context list GitHub documents for `jobs.<job_id>.steps.if` (`github, needs, strategy, matrix, job, runner, env, vars, steps, inputs`, per the [contexts reference](https://docs.github.com/en/actions/reference/workflows-and-actions/contexts)), so it went through `env` instead. The problem: a step skipped by `if:` shows as a bare grey "skipped" in the run, which is exactly how a missing token would go unnoticed. This file already hit that failure mode once, with the CHANGELOG-derived release notes fallback a bit further up (`#1530` and its history). Now the step always runs, and the missing-secret and stale-tag cases log a `::notice::` plus a `$GITHUB_STEP_SUMMARY` line from inside the script instead.
- **Two tokens, because they read different repos.** Checking this repo's latest release and dispatching to the site both need `gh api` calls, but `SITE_DISPATCH_TOKEN` has no read access here and the default token has no access on the site repo. The step takes `RELEASE_READ_TOKEN` (the default `GITHUB_TOKEN`) and `SITE_DISPATCH_TOKEN` as separate env vars and picks the right one per call.
- **A dispatch failure with the secret present warns instead of failing the job** (`continue-on-error: true` plus a `::warning::` and a step-summary line), because the release is already published by this point. Worst case, the site's own scheduled `release-drift` check catches the gap.

Also documents the secret in `RELEASE.md`'s "Cutting a release" steps, and cites the receiver PR (geolens-io/getgeolens.com#108) from the inline comment per the repo's finding-id convention.

## What Ian needs to add

Secret **`SITE_DISPATCH_TOKEN`** on this repo (geolens-io/geolens): a fine-grained PAT scoped to `Contents: read/write` on `geolens-io/getgeolens.com`, since a repository dispatch write requires contents write on the target repo.

## Verification

- `actionlint .github/workflows/release.yml`: one pre-existing SC2016 info finding on line 66 (unrelated to this change, confirmed present on `main` before this diff by stashing and re-running, and again after this revision). No new findings from the step.
- Extracted the new step's script into a standalone file with fake tokens and ran `shellcheck` on it directly: clean.
- `git diff --stat`: only `.github/workflows/release.yml` and `RELEASE.md` changed.
