### PR TITLE
feat(settings): make the login privacy-policy link a per-instance setting

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -147,6 +147,12 @@ GEOLENS_ADMIN_PASSWORD=
 # Type: email | Default: unset
 # DCAT_CONTACT_EMAIL=metadata@example.gov
 
+# [OPTIONAL] Privacy-policy URL shown on the login and register pages.
+# Unset by default so a self-hosted instance never links to another
+# operator's privacy page. Set this to your own policy URL to show the link.
+# Type: string | Default: unset (no link shown)
+# PRIVACY_URL=
+
 # [DEPRECATED] Legacy alias for PUBLIC_API_URL. Use PUBLIC_API_URL instead.
 # When set, the application logs a deprecation warning at startup and still
 # resolves to PUBLIC_API_URL for backward compatibility. Removal is deferred

--- a/.env.example
+++ b/.env.example
@@ -150,6 +150,10 @@ GEOLENS_ADMIN_PASSWORD=
 # [OPTIONAL] Privacy-policy URL shown on the login and register pages.
 # Unset by default so a self-hosted instance never links to another
 # operator's privacy page. Set this to your own policy URL to show the link.
+# Must be an absolute http(s) URL with no embedded credentials (user:pass@);
+# a query string or fragment is fine and preserved as-is (Google Docs,
+# Notion, and SharePoint policy links routinely have one). An invalid value
+# refuses to boot rather than silently rendering as a login-page link.
 # Type: string | Default: unset (no link shown)
 # PRIVACY_URL=
 

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -88,6 +88,30 @@ def validate_privacy_url_shape(v: str) -> str:
     return stripped
 
 
+def _check_ulabel(label: str) -> bool:
+    """Unicode-label validity rules, applied identically to a raw U-label
+    (before IDNA encoding) and to a decoded A-label (after decoding an
+    operator-typed "xn--..." label) -- the same function for both, so a
+    host's U-form and its punycode A-form always get the same verdict.
+    Without this, "xn--lsa" decodes to U+0301 (a bare combining acute
+    accent) and round-trips cleanly, so an already-rejected U-label
+    (a literal combining mark) slipped through in its encoded spelling.
+
+    Rejects: empty; a leading combining mark, category Mn/Mc/Me (there is
+    nothing for it to combine with -- UTS46's rule, which Python's
+    IDNA2003 codec does not enforce); or any control, format, surrogate,
+    private-use, or unassigned code point (category C*) anywhere in the
+    label -- "xn--a" decodes to U+0080, a bare C1 control byte, without
+    raising and also round-trips cleanly, so the round-trip check alone
+    does not catch that one either.
+    """
+    if not label:
+        return False
+    if unicodedata.category(label[0]) in {"Mn", "Mc", "Me"}:
+        return False
+    return not any(unicodedata.category(ch).startswith("C") for ch in label)
+
+
 def _is_unscoped_ipv6_literal(hostname: str) -> bool:
     """A plain IPv6 literal with no ``%`` zone ID. Split out of
     ``_is_valid_privacy_url_host`` purely to keep that function's
@@ -155,6 +179,11 @@ def _is_valid_privacy_url_host(hostname: str, *, bracketed: bool) -> bool:
     rules), so there is no single "what a browser accepts" answer to defer
     to. Rejecting malformed punycode is fail-closed and cheap, so this
     function does it regardless of which engine would have let it through.
+    U-labels and decoded A-labels share one rule set (``_check_ulabel``):
+    the operator who types a bare combining mark and the one who types its
+    already-encoded "xn--lsa" spelling hit the identical check, so which
+    spelling they used is never the reason one is rejected and the other
+    is not.
     """
     if bracketed:
         return _is_unscoped_ipv6_literal(hostname)
@@ -170,15 +199,12 @@ def _is_valid_privacy_url_host(hostname: str, *, bracketed: bool) -> bool:
         except ValueError:
             return False
         return str(parsed_ip) == hostname
-    # UTS46 forbids a label that starts with a combining mark -- there is
-    # nothing for it to combine with. Python's built-in "idna" codec is
-    # IDNA2003 (RFC 3490) and does not enforce this: it happily encodes a
-    # bare combining mark to a syntactically valid-looking "xn--..." label,
-    # so the encode step below would not catch it on its own.
-    if any(
-        label and unicodedata.category(label[0]).startswith("M")
-        for label in hostname.split(".")
-    ):
+    # U-labels and decoded A-labels share one rule set (_check_ulabel):
+    # Python's built-in "idna" codec is IDNA2003 (RFC 3490) and enforces
+    # neither the UTS46 leading-combining-mark rule nor a general character
+    # validity rule, so the encode step below would not catch a bare
+    # combining mark on its own.
+    if not all(_check_ulabel(label) for label in hostname.split(".")):
         return False
     try:
         ascii_host = hostname.encode("idna").decode("ascii")
@@ -198,14 +224,11 @@ def _is_valid_privacy_url_host(hostname: str, *, bracketed: bool) -> bool:
             decoded = a_label.encode("ascii").decode("punycode")
         except UnicodeError:
             return False
-        if not decoded:
-            return False
-        # A genuine IDN label decodes to at least one character that is not
-        # control/format/surrogate/private-use/unassigned. "xn--a" decodes
-        # to U+0080 (a bare C1 control byte) without raising and round-trips
-        # straight back to "a", so the round-trip check below does not, on
-        # its own, catch it -- this does.
-        if any(unicodedata.category(ch).startswith("C") for ch in decoded):
+        # Same rule set as a raw U-label (_check_ulabel), applied to what
+        # this A-label decodes to -- an operator who spells a combining
+        # mark directly and one who spells its punycode equivalent
+        # ("xn--lsa") hit the identical check.
+        if not _check_ulabel(decoded):
             return False
         if decoded.encode("punycode").decode("ascii") != a_label:
             return False

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -54,6 +54,18 @@ def validate_privacy_url_shape(v: str) -> str:
         raise ValueError("must be an absolute http(s) URL")
     if parsed.username is not None or parsed.password is not None:
         raise ValueError("must not include embedded credentials")
+    # A netloc can be non-empty and still have no real host, e.g. "https://:443/x"
+    # (netloc ":443", hostname None) -- a link a browser cannot resolve.
+    if not parsed.hostname:
+        raise ValueError("must include a hostname")
+    # Accessing .port validates both syntax and the 1-65535 range; a bad port
+    # such as "https://example.com:not-a-port/x" would otherwise sail through
+    # (urlsplit leaves the junk sitting in netloc) and pass this check while
+    # remaining a link no browser will follow.
+    try:
+        parsed.port
+    except ValueError:
+        raise ValueError("must not include a malformed port") from None
     return stripped
 
 

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -2,6 +2,7 @@ import sys
 import re
 from pathlib import Path
 from typing import Literal
+from urllib.parse import urlsplit
 
 from pydantic import (
     Field,
@@ -39,9 +40,15 @@ def validate_privacy_url_shape(v: str) -> str:
     time, and calling into it from a ``Settings`` field validator would be a
     circular import.
     """
-    from urllib.parse import urlsplit
-
     stripped = v.strip()
+    # A tab, newline, or carriage return ANYWHERE in the string (not just the
+    # ends `.strip()` already removed) is a known scheme-check bypass: the
+    # WHATWG URL parser strips those characters from any position before
+    # tokenizing, so "java\tscript:alert(1)" becomes "javascript:alert(1)" in
+    # a real browser while `urlsplit` below would parse a scheme of
+    # "java\tscript" and let it through the http(s)-only check.
+    if any(c in stripped for c in "\t\r\n"):
+        raise ValueError("must not contain a tab, newline, or carriage return")
     parsed = urlsplit(stripped)
     if parsed.scheme not in {"http", "https"} or not parsed.netloc:
         raise ValueError("must be an absolute http(s) URL")

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -1,11 +1,11 @@
 import ipaddress
 import sys
 import re
-import unicodedata
 from pathlib import Path
 from typing import Literal
 from urllib.parse import urlsplit
 
+import idna
 from pydantic import (
     Field,
     SecretStr,
@@ -88,30 +88,6 @@ def validate_privacy_url_shape(v: str) -> str:
     return stripped
 
 
-def _check_ulabel(label: str) -> bool:
-    """Unicode-label validity rules, applied identically to a raw U-label
-    (before IDNA encoding) and to a decoded A-label (after decoding an
-    operator-typed "xn--..." label) -- the same function for both, so a
-    host's U-form and its punycode A-form always get the same verdict.
-    Without this, "xn--lsa" decodes to U+0301 (a bare combining acute
-    accent) and round-trips cleanly, so an already-rejected U-label
-    (a literal combining mark) slipped through in its encoded spelling.
-
-    Rejects: empty; a leading combining mark, category Mn/Mc/Me (there is
-    nothing for it to combine with -- UTS46's rule, which Python's
-    IDNA2003 codec does not enforce); or any control, format, surrogate,
-    private-use, or unassigned code point (category C*) anywhere in the
-    label -- "xn--a" decodes to U+0080, a bare C1 control byte, without
-    raising and also round-trips cleanly, so the round-trip check alone
-    does not catch that one either.
-    """
-    if not label:
-        return False
-    if unicodedata.category(label[0]) in {"Mn", "Mc", "Me"}:
-        return False
-    return not any(unicodedata.category(ch).startswith("C") for ch in label)
-
-
 def _is_unscoped_ipv6_literal(hostname: str) -> bool:
     """A plain IPv6 literal with no ``%`` zone ID. Split out of
     ``_is_valid_privacy_url_host`` purely to keep that function's
@@ -128,7 +104,7 @@ def _is_unscoped_ipv6_literal(hostname: str) -> bool:
 
 
 def _is_valid_privacy_url_host(hostname: str, *, bracketed: bool) -> bool:
-    """Allowlist, not a blocklist.
+    """Hostname validity = idna (UTS46) + our IP/numeric rules.
 
     ``bracketed`` is True when the URL wrote this host inside ``[...]``.
     ``urlsplit(...).hostname`` strips the brackets unconditionally, so this
@@ -149,16 +125,23 @@ def _is_valid_privacy_url_host(hostname: str, *, bracketed: bool) -> bool:
     Otherwise, exactly three cases are accepted:
 
     1. An IP literal (IPv4 or IPv6) that parses with ``ipaddress.ip_address``.
-    2. An ordinary DNS name, applied AFTER IDNA normalization: dot-separated
-       labels, each 1-63 characters of letters, digits, and internal
-       hyphens (no leading or trailing hyphen), totaling at most 253
-       characters. An internationalized label such as "例え" is IDNA-encoded
-       to its ASCII "xn--..." form first (same as a browser does before
-       navigating), and that form is what the label rule below actually
-       checks -- an already-ASCII operator input is unaffected. Mirrors the
-       DNS-label rule ``validate_tenant_base_domain`` already applies a few
-       fields down, minus that field's IP-literal refusal (a hostname here,
-       unlike a tenant DNS suffix, can legitimately be an IP).
+    2. An ordinary DNS name, validated by handing it to the ``idna`` package
+       (already a direct backend dependency, pinned in pyproject.toml for a
+       CVE) with ``idna.encode(hostname, uts46=True, std3_rules=True)`` --
+       the same UTS46 ToASCII processing a browser applies before
+       navigating. One call replaces what used to be three hand-rolled
+       pieces: a DNS-label regex, a bespoke Unicode-label validity check,
+       and a manual punycode decode-and-round-trip for an operator-typed
+       "xn--" label. UTS46 already covers everything those existed for --
+       STD3 character restrictions (rejects "_", "[", and similar),
+       hyphen placement, the 63-char label and 253-char total length
+       limits (verified: idna accepts exactly 253, rejects 254, matching
+       the length check kept below as a second line of defense), empty
+       labels, and the full disallowed/combining-mark code-point set for
+       BOTH a raw Unicode label and an operator-typed "xn--" A-label --
+       the package decodes and validates that content the same way, so a
+       host's native and punycode spellings can no longer disagree with
+       each other, unlike the hand-rolled version this replaced.
     3. A hostname whose LAST label is numeric (all digits) or 0x-prefixed
        hex: per the WHATWG URL "ends in a number" rule, a browser reads a
        host in this shape as an attempted IPv4 address, not a DNS name --
@@ -170,20 +153,6 @@ def _is_valid_privacy_url_host(hostname: str, *, bracketed: bool) -> bool:
        3-part parser but silently becomes 192.168.0.1, a host that does
        not match what was stored. All three are rejected here, not passed
        through to case 2.
-
-    A label already spelled as an ACE / "xn--" A-label (typed directly by
-    the operator, not produced by our own IDNA encoding above) must decode
-    to a real, valid IDN label, or it is rejected -- browser engines
-    actually disagree here (Chromium and WebKit accept any ASCII "xn--"
-    label unvalidated; Firefox implements the full IDNA2008 label-validity
-    rules), so there is no single "what a browser accepts" answer to defer
-    to. Rejecting malformed punycode is fail-closed and cheap, so this
-    function does it regardless of which engine would have let it through.
-    U-labels and decoded A-labels share one rule set (``_check_ulabel``):
-    the operator who types a bare combining mark and the one who types its
-    already-encoded "xn--lsa" spelling hit the identical check, so which
-    spelling they used is never the reason one is rejected and the other
-    is not.
     """
     if bracketed:
         return _is_unscoped_ipv6_literal(hostname)
@@ -199,40 +168,14 @@ def _is_valid_privacy_url_host(hostname: str, *, bracketed: bool) -> bool:
         except ValueError:
             return False
         return str(parsed_ip) == hostname
-    # U-labels and decoded A-labels share one rule set (_check_ulabel):
-    # Python's built-in "idna" codec is IDNA2003 (RFC 3490) and enforces
-    # neither the UTS46 leading-combining-mark rule nor a general character
-    # validity rule, so the encode step below would not catch a bare
-    # combining mark on its own.
-    if not all(_check_ulabel(label) for label in hostname.split(".")):
-        return False
     try:
-        ascii_host = hostname.encode("idna").decode("ascii")
-    except UnicodeError:
-        # Covers, among other malformed shapes, an empty label ("a..b").
+        ascii_host = idna.encode(hostname, uts46=True, std3_rules=True).decode("ascii")
+    except idna.IDNAError:
         return False
-    if len(ascii_host) > 253:
-        return False
-    host_label = re.compile(r"^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$")
-    for label in ascii_host.split("."):
-        if not host_label.fullmatch(label):
-            return False
-        if not label.startswith("xn--"):
-            continue
-        a_label = label[4:]
-        try:
-            decoded = a_label.encode("ascii").decode("punycode")
-        except UnicodeError:
-            return False
-        # Same rule set as a raw U-label (_check_ulabel), applied to what
-        # this A-label decodes to -- an operator who spells a combining
-        # mark directly and one who spells its punycode equivalent
-        # ("xn--lsa") hit the identical check.
-        if not _check_ulabel(decoded):
-            return False
-        if decoded.encode("punycode").decode("ascii") != a_label:
-            return False
-    return True
+    # Belt and braces: idna.encode already enforces this length limit
+    # itself (verified by hand: 253 accepted, 254 "Domain too long"), but a
+    # future idna release relaxing that should not silently loosen ours.
+    return len(ascii_host) <= 253
 
 
 _PROJECT_ROOT_ENV = Path(__file__).resolve().parents[3] / ".env"

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -159,6 +159,10 @@ class Settings(BaseSettings):
     public_app_url: str | None = None
     public_api_url: str | None = None
     public_base_url: str | None = None
+    # PRIV-1: privacy-policy link shown on the login/register pages. Unset by
+    # default so a self-hosted instance never links to another operator's
+    # privacy page; set this to the operator's own policy URL to show the link.
+    privacy_url: str | None = None
     # Multi-tenant Host routing is accepted only below this explicit DNS
     # suffix (for example ``geolens.example``). Exact non-tenant service hosts
     # are separately allowlisted for health checks, Compose, and test clients.
@@ -441,6 +445,7 @@ class Settings(BaseSettings):
         "public_app_url",
         "public_api_url",
         "public_base_url",
+        "privacy_url",
         "tenant_base_domain",
         "dcat_contact_email",
         "database_url_override",

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -152,10 +152,28 @@ def _is_valid_privacy_url_host(hostname: str, *, bracketed: bool) -> bool:
        parse outright; "192.168.1" succeeds under a browser's legacy
        3-part parser but silently becomes 192.168.0.1, a host that does
        not match what was stored. All three are rejected here, not passed
-       through to case 2.
+       through to case 2. Checked on the hostname with a single trailing
+       DNS root dot already stripped (below) -- otherwise
+       "999.999.999.999." and "192.168.1." would have skipped this case
+       entirely and reached case 2, which has no opinion on IPv4 semantics.
     """
     if bracketed:
         return _is_unscoped_ipv6_literal(hostname)
+    # A single trailing dot is the valid DNS "root" separator
+    # ("https://example.com./x" navigates identically to the same URL
+    # without it), but left in place it breaks the numeric-last-label check
+    # below: hostname.rsplit(".", 1)[-1] on "192.168.1." returns "", which
+    # is neither a digit nor "0x"-prefixed, so a numeric-last-label host
+    # with a root dot skipped straight to idna.encode() -- which validates
+    # DNS label SYNTAX only and has no opinion on IPv4 semantics, so "999"
+    # is a syntactically fine label and "999.999.999.999." sailed through.
+    # Strip at most one trailing dot before every check below, including
+    # idna's; two or more is an empty label, already invalid on its own.
+    if hostname.endswith(".."):
+        return False
+    hostname = hostname.removesuffix(".")
+    if not hostname:
+        return False
     try:
         ipaddress.ip_address(hostname)
         return True

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -1,6 +1,7 @@
 import ipaddress
 import sys
 import re
+import unicodedata
 from pathlib import Path
 from typing import Literal
 from urllib.parse import urlsplit
@@ -82,12 +83,16 @@ def _is_valid_privacy_url_host(hostname: str) -> bool:
     1. An IP literal (IPv4 or IPv6) that parses with ``ipaddress.ip_address``.
        ``urlsplit(...).hostname`` already lowercases and strips IPv6 brackets,
        so the bare literal is what this function sees either way.
-    2. An ordinary DNS name: dot-separated labels, each 1-63 characters of
-       letters, digits, and internal hyphens (no leading or trailing
-       hyphen), totaling at most 253 characters. Mirrors the DNS-label rule
-       ``validate_tenant_base_domain`` already applies a few fields down,
-       minus that field's IP-literal refusal (a hostname here, unlike a
-       tenant DNS suffix, can legitimately be an IP).
+    2. An ordinary DNS name, applied AFTER IDNA normalization: dot-separated
+       labels, each 1-63 characters of letters, digits, and internal
+       hyphens (no leading or trailing hyphen), totaling at most 253
+       characters. An internationalized label such as "例え" is IDNA-encoded
+       to its ASCII "xn--..." form first (same as a browser does before
+       navigating), and that form is what the label rule below actually
+       checks -- an already-ASCII operator input is unaffected. Mirrors the
+       DNS-label rule ``validate_tenant_base_domain`` already applies a few
+       fields down, minus that field's IP-literal refusal (a hostname here,
+       unlike a tenant DNS suffix, can legitimately be an IP).
     3. A hostname whose LAST label is numeric (all digits) or 0x-prefixed
        hex: per the WHATWG URL "ends in a number" rule, a browser reads a
        host in this shape as an attempted IPv4 address, not a DNS name --
@@ -112,10 +117,25 @@ def _is_valid_privacy_url_host(hostname: str) -> bool:
         except ValueError:
             return False
         return str(parsed_ip) == hostname
-    if len(hostname) > 253:
+    # UTS46 forbids a label that starts with a combining mark -- there is
+    # nothing for it to combine with. Python's built-in "idna" codec is
+    # IDNA2003 (RFC 3490) and does not enforce this: it happily encodes a
+    # bare combining mark to a syntactically valid-looking "xn--..." label,
+    # so the encode step below would not catch it on its own.
+    if any(
+        label and unicodedata.category(label[0]).startswith("M")
+        for label in hostname.split(".")
+    ):
+        return False
+    try:
+        ascii_host = hostname.encode("idna").decode("ascii")
+    except UnicodeError:
+        # Covers, among other malformed shapes, an empty label ("a..b").
+        return False
+    if len(ascii_host) > 253:
         return False
     host_label = re.compile(r"^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$")
-    return all(host_label.fullmatch(label) for label in hostname.split("."))
+    return all(host_label.fullmatch(label) for label in ascii_host.split("."))
 
 
 _PROJECT_ROOT_ENV = Path(__file__).resolve().parents[3] / ".env"

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -104,6 +104,15 @@ def _is_valid_privacy_url_host(hostname: str) -> bool:
        3-part parser but silently becomes 192.168.0.1, a host that does
        not match what was stored. All three are rejected here, not passed
        through to case 2.
+
+    A label already spelled as an ACE / "xn--" A-label (typed directly by
+    the operator, not produced by our own IDNA encoding above) must decode
+    to a real, valid IDN label, or it is rejected -- browser engines
+    actually disagree here (Chromium and WebKit accept any ASCII "xn--"
+    label unvalidated; Firefox implements the full IDNA2008 label-validity
+    rules), so there is no single "what a browser accepts" answer to defer
+    to. Rejecting malformed punycode is fail-closed and cheap, so this
+    function does it regardless of which engine would have let it through.
     """
     try:
         ipaddress.ip_address(hostname)
@@ -135,7 +144,28 @@ def _is_valid_privacy_url_host(hostname: str) -> bool:
     if len(ascii_host) > 253:
         return False
     host_label = re.compile(r"^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$")
-    return all(host_label.fullmatch(label) for label in ascii_host.split("."))
+    for label in ascii_host.split("."):
+        if not host_label.fullmatch(label):
+            return False
+        if not label.startswith("xn--"):
+            continue
+        a_label = label[4:]
+        try:
+            decoded = a_label.encode("ascii").decode("punycode")
+        except UnicodeError:
+            return False
+        if not decoded:
+            return False
+        # A genuine IDN label decodes to at least one character that is not
+        # control/format/surrogate/private-use/unassigned. "xn--a" decodes
+        # to U+0080 (a bare C1 control byte) without raising and round-trips
+        # straight back to "a", so the round-trip check below does not, on
+        # its own, catch it -- this does.
+        if any(unicodedata.category(ch).startswith("C") for ch in decoded):
+            return False
+        if decoded.encode("punycode").decode("ascii") != a_label:
+            return False
+    return True
 
 
 _PROJECT_ROOT_ENV = Path(__file__).resolve().parents[3] / ".env"

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -77,20 +77,41 @@ def validate_privacy_url_shape(v: str) -> str:
 
 
 def _is_valid_privacy_url_host(hostname: str) -> bool:
-    """Allowlist, not a blocklist: an IPv4/IPv6 literal, or a dotted DNS name
-    whose labels are each 1-63 characters of letters, digits, and internal
-    hyphens (no leading or trailing hyphen), totaling at most 253 characters.
-    Mirrors the DNS-label rule ``validate_tenant_base_domain`` already applies
-    a few fields down, minus that field's IP-literal refusal (a hostname
-    here, unlike a tenant DNS suffix, can legitimately be an IP).
-    ``urlsplit(...).hostname`` already lowercases and strips IPv6 brackets, so
-    ``ipaddress.ip_address`` sees the bare literal either way.
+    """Allowlist, not a blocklist. Exactly three cases are accepted:
+
+    1. An IP literal (IPv4 or IPv6) that parses with ``ipaddress.ip_address``.
+       ``urlsplit(...).hostname`` already lowercases and strips IPv6 brackets,
+       so the bare literal is what this function sees either way.
+    2. An ordinary DNS name: dot-separated labels, each 1-63 characters of
+       letters, digits, and internal hyphens (no leading or trailing
+       hyphen), totaling at most 253 characters. Mirrors the DNS-label rule
+       ``validate_tenant_base_domain`` already applies a few fields down,
+       minus that field's IP-literal refusal (a hostname here, unlike a
+       tenant DNS suffix, can legitimately be an IP).
+    3. A hostname whose LAST label is numeric (all digits) or 0x-prefixed
+       hex: per the WHATWG URL "ends in a number" rule, a browser reads a
+       host in this shape as an attempted IPv4 address, not a DNS name --
+       whether or not its labels would otherwise pass case 2. It is
+       accepted here ONLY if it is the exact, canonical dotted-quad
+       spelling. "999.999.999.999" and "1.2.3.4.5" have per-label
+       characters case 2 alone would accept but fail a browser's IPv4
+       parse outright; "192.168.1" succeeds under a browser's legacy
+       3-part parser but silently becomes 192.168.0.1, a host that does
+       not match what was stored. All three are rejected here, not passed
+       through to case 2.
     """
     try:
         ipaddress.ip_address(hostname)
         return True
     except ValueError:
         pass
+    last_label = hostname.rsplit(".", 1)[-1]
+    if last_label.isdigit() or last_label.startswith("0x"):
+        try:
+            parsed_ip = ipaddress.IPv4Address(hostname)
+        except ValueError:
+            return False
+        return str(parsed_ip) == hostname
     if len(hostname) > 253:
         return False
     host_label = re.compile(r"^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$")

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -18,6 +18,38 @@ def reveal(secret: SecretStr | None) -> str | None:
     return secret.get_secret_value() if secret is not None else None
 
 
+def validate_privacy_url_shape(v: str) -> str:
+    """PRIV-1: shape check for the login/register privacy-policy link.
+
+    The value is rendered directly as an ``<a href>`` on an unauthenticated
+    page, so this is a security control, not a formatting nit: a
+    ``javascript:``/``data:``/scheme-relative value here is an XSS payload.
+    Deliberately does NOT reuse the admin settings' path-stripping
+    ``_normalize_absolute_url`` helper — a real operator policy page (Google
+    Docs, Notion, SharePoint) routinely carries a query string or a fragment,
+    and dropping either would silently point the link at the wrong document.
+
+    Shared by three entry points that all need to agree on what "safe"
+    means: this module's own env-value boot validator below, the admin-write
+    validator in ``app.modules.settings.schemas``, and the read-path defense
+    in ``app.modules.settings.router_public`` (a stored value written before
+    this check existed, or by any other path, must not reach the login page
+    unvalidated). It lives here rather than in ``app.core.public_urls``
+    because that module imports this one's ``settings`` singleton at import
+    time, and calling into it from a ``Settings`` field validator would be a
+    circular import.
+    """
+    from urllib.parse import urlsplit
+
+    stripped = v.strip()
+    parsed = urlsplit(stripped)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        raise ValueError("must be an absolute http(s) URL")
+    if parsed.username is not None or parsed.password is not None:
+        raise ValueError("must not include embedded credentials")
+    return stripped
+
+
 _PROJECT_ROOT_ENV = Path(__file__).resolve().parents[3] / ".env"
 
 # Known-public credential literals that leaked through the project's git
@@ -593,6 +625,23 @@ class Settings(BaseSettings):
         if len(hosts) != 1 or not hosts[0] or "," in hosts[0]:
             raise ValueError("DATABASE_URL_OVERRIDE must contain exactly one host")
         return value
+
+    @field_validator("privacy_url", mode="after")
+    @classmethod
+    def validate_privacy_url_env(cls, v: str | None) -> str | None:
+        """PRIV-1: fail boot on an unsafe PRIVACY_URL rather than silently
+        rendering it as an <a href> on the login/register page. This is the
+        ONLY validation an ENV_ONLY_CONFIG deployment ever runs for this
+        value — the admin-write validator in modules/settings/schemas.py
+        never sees it in that mode. See validate_privacy_url_shape above for
+        what "unsafe" means.
+        """
+        if v is None:
+            return None
+        try:
+            return validate_privacy_url_shape(v)
+        except ValueError as exc:
+            raise ValueError(f"PRIVACY_URL {exc}") from exc
 
     @field_validator("geolens_runtime_db_role", mode="after")
     @classmethod

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -1,3 +1,4 @@
+import ipaddress
 import sys
 import re
 from pathlib import Path
@@ -38,17 +39,21 @@ def validate_privacy_url_shape(v: str) -> str:
     unvalidated). It lives here rather than in ``app.core.public_urls``
     because that module imports this one's ``settings`` singleton at import
     time, and calling into it from a ``Settings`` field validator would be a
-    circular import.
+    circular import -- which is also why the hostname check below is a
+    self-contained allowlist rather than a call to that module's
+    ``canonical_host_error``: it answers a near-identical question (is this
+    hostname spelled the way a browser would show it) and would otherwise be
+    the obvious thing to reuse.
     """
     stripped = v.strip()
-    # A tab, newline, or carriage return ANYWHERE in the string (not just the
-    # ends `.strip()` already removed) is a known scheme-check bypass: the
-    # WHATWG URL parser strips those characters from any position before
-    # tokenizing, so "java\tscript:alert(1)" becomes "javascript:alert(1)" in
-    # a real browser while `urlsplit` below would parse a scheme of
-    # "java\tscript" and let it through the http(s)-only check.
-    if any(c in stripped for c in "\t\r\n"):
-        raise ValueError("must not contain a tab, newline, or carriage return")
+    # Whitespace ANYWHERE in the string (not just the ends `.strip()` already
+    # removed) is a known scheme-check bypass: the WHATWG URL parser strips
+    # tabs and newlines from any position before tokenizing, and silently
+    # drops a plain space from inside a host, so "java\tscript:alert(1)" and
+    # "https://exa mple.com/x" both resolve differently in a browser than
+    # `urlsplit` reads them here.
+    if any(c.isspace() for c in stripped):
+        raise ValueError("must not contain whitespace")
     parsed = urlsplit(stripped)
     if parsed.scheme not in {"http", "https"} or not parsed.netloc:
         raise ValueError("must be an absolute http(s) URL")
@@ -58,6 +63,8 @@ def validate_privacy_url_shape(v: str) -> str:
     # (netloc ":443", hostname None) -- a link a browser cannot resolve.
     if not parsed.hostname:
         raise ValueError("must include a hostname")
+    if not _is_valid_privacy_url_host(parsed.hostname):
+        raise ValueError("must have a valid DNS hostname or IP literal")
     # Accessing .port validates both syntax and the 1-65535 range; a bad port
     # such as "https://example.com:not-a-port/x" would otherwise sail through
     # (urlsplit leaves the junk sitting in netloc) and pass this check while
@@ -67,6 +74,27 @@ def validate_privacy_url_shape(v: str) -> str:
     except ValueError:
         raise ValueError("must not include a malformed port") from None
     return stripped
+
+
+def _is_valid_privacy_url_host(hostname: str) -> bool:
+    """Allowlist, not a blocklist: an IPv4/IPv6 literal, or a dotted DNS name
+    whose labels are each 1-63 characters of letters, digits, and internal
+    hyphens (no leading or trailing hyphen), totaling at most 253 characters.
+    Mirrors the DNS-label rule ``validate_tenant_base_domain`` already applies
+    a few fields down, minus that field's IP-literal refusal (a hostname
+    here, unlike a tenant DNS suffix, can legitimately be an IP).
+    ``urlsplit(...).hostname`` already lowercases and strips IPv6 brackets, so
+    ``ipaddress.ip_address`` sees the bare literal either way.
+    """
+    try:
+        ipaddress.ip_address(hostname)
+        return True
+    except ValueError:
+        pass
+    if len(hostname) > 253:
+        return False
+    host_label = re.compile(r"^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$")
+    return all(host_label.fullmatch(label) for label in hostname.split("."))
 
 
 _PROJECT_ROOT_ENV = Path(__file__).resolve().parents[3] / ".env"

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -55,7 +55,16 @@ def validate_privacy_url_shape(v: str) -> str:
     # `urlsplit` reads them here.
     if any(c.isspace() for c in stripped):
         raise ValueError("must not contain whitespace")
-    parsed = urlsplit(stripped)
+    try:
+        parsed = urlsplit(stripped)
+    except ValueError as exc:
+        # Newer CPython (3.13+) already raises here for some malformed
+        # bracketed authorities, e.g. "https://[1.2.3.4]/x" ("An IPv4
+        # address cannot be in brackets") -- but not for every shape
+        # `_is_valid_privacy_url_host` below rejects, so this is a
+        # convenience early-exit on some interpreters, not a substitute for
+        # that check.
+        raise ValueError(f"is not a valid URL ({exc})") from exc
     if parsed.scheme not in {"http", "https"} or not parsed.netloc:
         raise ValueError("must be an absolute http(s) URL")
     if parsed.username is not None or parsed.password is not None:
@@ -64,7 +73,9 @@ def validate_privacy_url_shape(v: str) -> str:
     # (netloc ":443", hostname None) -- a link a browser cannot resolve.
     if not parsed.hostname:
         raise ValueError("must include a hostname")
-    if not _is_valid_privacy_url_host(parsed.hostname):
+    if not _is_valid_privacy_url_host(
+        parsed.hostname, bracketed=parsed.netloc.startswith("[")
+    ):
         raise ValueError("must have a valid DNS hostname or IP literal")
     # Accessing .port validates both syntax and the 1-65535 range; a bad port
     # such as "https://example.com:not-a-port/x" would otherwise sail through
@@ -77,12 +88,43 @@ def validate_privacy_url_shape(v: str) -> str:
     return stripped
 
 
-def _is_valid_privacy_url_host(hostname: str) -> bool:
-    """Allowlist, not a blocklist. Exactly three cases are accepted:
+def _is_unscoped_ipv6_literal(hostname: str) -> bool:
+    """A plain IPv6 literal with no ``%`` zone ID. Split out of
+    ``_is_valid_privacy_url_host`` purely to keep that function's
+    cyclomatic complexity under the repo's ruff limit; see its docstring
+    for why a bracketed authority is restricted to this and nothing else.
+    """
+    if "%" in hostname:
+        return False
+    try:
+        ipaddress.IPv6Address(hostname)
+        return True
+    except ValueError:
+        return False
+
+
+def _is_valid_privacy_url_host(hostname: str, *, bracketed: bool) -> bool:
+    """Allowlist, not a blocklist.
+
+    ``bracketed`` is True when the URL wrote this host inside ``[...]``.
+    ``urlsplit(...).hostname`` strips the brackets unconditionally, so this
+    flag is the caller's only remaining signal that they were there --
+    ``parsed.netloc.startswith("[")``, checked before ``.hostname`` throws
+    the brackets away. Per RFC 3986, bracketed authority syntax means "this
+    is an IP literal", never a DNS name, whatever the contents look like,
+    so a bracketed host skips every case below: it is accepted ONLY as a
+    plain, unscoped ``ipaddress.IPv6Address``, with no ``%`` zone ID.
+    Without this, ``"[v1.foo]"`` (an IPvFuture literal no browser
+    implements) would fall through to case 2 and look like the ordinary
+    DNS name "v1.foo", ``"[1.2.3.4]"`` (an IPv4 literal, invalid in
+    brackets) would fall through to case 3 and look like a bracket-stripped
+    numeric-last-label host, and ``"[fe80::1%eth0]"`` (a scoped IPv6 zone
+    ID) parses fine under plain ``ipaddress.ip_address`` even though no
+    browser resolves a zone ID from a stored config value.
+
+    Otherwise, exactly three cases are accepted:
 
     1. An IP literal (IPv4 or IPv6) that parses with ``ipaddress.ip_address``.
-       ``urlsplit(...).hostname`` already lowercases and strips IPv6 brackets,
-       so the bare literal is what this function sees either way.
     2. An ordinary DNS name, applied AFTER IDNA normalization: dot-separated
        labels, each 1-63 characters of letters, digits, and internal
        hyphens (no leading or trailing hyphen), totaling at most 253
@@ -114,6 +156,8 @@ def _is_valid_privacy_url_host(hostname: str) -> bool:
     to. Rejecting malformed punycode is fail-closed and cheap, so this
     function does it regardless of which engine would have let it through.
     """
+    if bracketed:
+        return _is_unscoped_ipv6_literal(hostname)
     try:
         ipaddress.ip_address(hostname)
         return True

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -22,7 +22,7 @@ def reveal(secret: SecretStr | None) -> str | None:
 
 
 def validate_privacy_url_shape(v: str) -> str:
-    """PRIV-1: shape check for the login/register privacy-policy link.
+    r"""PRIV-1: shape check for the login/register privacy-policy link.
 
     The value is rendered directly as an ``<a href>`` on an unauthenticated
     page, so this is a security control, not a formatting nit: a
@@ -45,6 +45,51 @@ def validate_privacy_url_shape(v: str) -> str:
     ``canonical_host_error``: it answers a near-identical question (is this
     hostname spelled the way a browser would show it) and would otherwise be
     the obvious thing to reuse.
+
+    Deliberately stricter than a browser, all fail-closed -- read a report
+    that one of these refuses a value a browser would accept as a "browser
+    disagreement" finding against this list first, not as a new gap:
+
+    * STD3 rules (``std3_rules=True`` below): rejects ``_`` and a leading
+      or trailing hyphen. A browser's own UTS46 call sets
+      ``CheckHyphens=false`` and ``UseSTD3ASCIIRules=false``, so it accepts
+      both; an operator who needs one has a malformed host, not a policy
+      page.
+    * A percent-encoded byte in the host (``exa%6dple.com``): refused
+      outright rather than decoded. A browser percent-decodes the host
+      before applying UTS46; decoding here first would need to also decide
+      what a decoded ``%2e`` or ``%00`` means to a DNS label, which is
+      exactly the ambiguity ``is_usable_public_origin`` (app.core.public_urls)
+      already refuses for the same reason on a different field.
+    * A backslash in the authority: a browser's WHATWG parser treats
+      ``\`` as ``/`` for an http(s) URL, so ``https://example.com\@evil.com/x``
+      reads as host ``example.com`` with path ``/@evil.com/x`` to a
+      browser, while Python's ``urlsplit`` does not special-case the
+      backslash and finds a userinfo component instead -- rejected here via
+      the userinfo check below, for a different reason than a browser would
+      have accepted it, but rejected either way.
+    * Userinfo (``user:pass@``) anywhere in the authority: refused outright,
+      never stripped and retried.
+    * Whitespace anywhere in the raw string: refused outright. A browser
+      strips a tab/LF/CR from anywhere and percent-encodes a literal space
+      in the path or query instead of refusing the URL.
+    * An IPvFuture literal (``[v1.foo]``) or a scoped/zoned IPv6 literal
+      (``[fe80::1%eth0]``): refused. Neither is a browser rejection --
+      IPvFuture has no browser implementation to compare against, and a
+      zoned address is a real, resolvable thing on the machine that set the
+      zone, just never the machine rendering this login page.
+    * A non-canonical IPv4 spelling (``0x7f.1``, ``192.168.1``, a
+      fullwidth-digit form that maps to one of these): only the exact
+      canonical dotted-quad is accepted, even where a browser's legacy
+      parser would expand a short or hex/octal form to a real address --
+      the point is that what gets stored must be what a browser resolves,
+      and a form that gets silently rewritten on navigation fails that by
+      definition.
+
+    The fragment and query string are the one place this list runs the
+    other way: passed through completely untouched, because a real
+    operator policy page routinely needs one (see the top of this
+    docstring) and a browser does too.
     """
     stripped = v.strip()
     # Whitespace ANYWHERE in the string (not just the ends `.strip()` already
@@ -122,74 +167,97 @@ def _is_valid_privacy_url_host(hostname: str, *, bracketed: bool) -> bool:
     ID) parses fine under plain ``ipaddress.ip_address`` even though no
     browser resolves a zone ID from a stored config value.
 
-    Otherwise, exactly three cases are accepted:
+    Otherwise, a plain, unbracketed IP literal that parses with
+    ``ipaddress.ip_address`` is accepted outright (case 1). Everything else
+    is UTS46-mapped to ASCII FIRST, the same order a browser's own host
+    parser uses, via the ``idna`` package (already a direct backend
+    dependency, pinned in pyproject.toml for a CVE):
+    ``idna.encode(hostname, uts46=True, std3_rules=True)``. This one call
+    replaces what used to be three hand-rolled pieces -- a DNS-label
+    regex, a bespoke Unicode-label validity check, and a manual punycode
+    decode-and-round-trip for an operator-typed "xn--" label -- and covers
+    everything those existed for: STD3 character restrictions (rejects
+    "_", "[", and similar), hyphen placement, the 63-char label and
+    253-char total length limits (verified: idna accepts exactly 253,
+    rejects 254, matching the length check kept below as a second line of
+    defense), empty labels, and the full disallowed/combining-mark
+    code-point set for both a raw Unicode label and an operator-typed
+    "xn--" A-label, since the package decodes and validates that content
+    the same way -- a host's native and punycode spellings can no longer
+    disagree with each other. It also performs the Unicode-to-ASCII
+    mapping a browser applies before deciding whether a host "ends in a
+    number": an ideographic full stop (U+3002, "。") maps to ".", and a
+    fullwidth digit ("１") maps to "1".
 
-    1. An IP literal (IPv4 or IPv6) that parses with ``ipaddress.ip_address``.
-    2. An ordinary DNS name, validated by handing it to the ``idna`` package
-       (already a direct backend dependency, pinned in pyproject.toml for a
-       CVE) with ``idna.encode(hostname, uts46=True, std3_rules=True)`` --
-       the same UTS46 ToASCII processing a browser applies before
-       navigating. One call replaces what used to be three hand-rolled
-       pieces: a DNS-label regex, a bespoke Unicode-label validity check,
-       and a manual punycode decode-and-round-trip for an operator-typed
-       "xn--" label. UTS46 already covers everything those existed for --
-       STD3 character restrictions (rejects "_", "[", and similar),
-       hyphen placement, the 63-char label and 253-char total length
-       limits (verified: idna accepts exactly 253, rejects 254, matching
-       the length check kept below as a second line of defense), empty
-       labels, and the full disallowed/combining-mark code-point set for
-       BOTH a raw Unicode label and an operator-typed "xn--" A-label --
-       the package decodes and validates that content the same way, so a
-       host's native and punycode spellings can no longer disagree with
-       each other, unlike the hand-rolled version this replaced.
+    THEN, on that mapped ASCII result (never on the raw hostname -- a
+    fullwidth digit satisfies Python's ``str.isdigit()`` too, so checking
+    the raw string looks right and hands ``ipaddress.IPv4Address`` a string
+    it cannot parse, rejecting a host a browser accepts as plain
+    ``127.0.0.1``), one case is carved out:
+
     3. A hostname whose LAST label is numeric (all digits) or 0x-prefixed
        hex: per the WHATWG URL "ends in a number" rule, a browser reads a
        host in this shape as an attempted IPv4 address, not a DNS name --
-       whether or not its labels would otherwise pass case 2. It is
-       accepted here ONLY if it is the exact, canonical dotted-quad
-       spelling. "999.999.999.999" and "1.2.3.4.5" have per-label
-       characters case 2 alone would accept but fail a browser's IPv4
-       parse outright; "192.168.1" succeeds under a browser's legacy
-       3-part parser but silently becomes 192.168.0.1, a host that does
-       not match what was stored. All three are rejected here, not passed
-       through to case 2. Checked on the hostname with a single trailing
-       DNS root dot already stripped (below) -- otherwise
+       whether or not it would otherwise look like an ordinary DNS name
+       (case 2). It is accepted ONLY if it is the exact, canonical
+       dotted-quad spelling. "999.999.999.999" and "1.2.3.4.5" have
+       per-label characters that look like an ordinary DNS name but fail a
+       browser's IPv4 parse outright; "192.168.1" succeeds under a
+       browser's legacy 3-part parser but silently becomes 192.168.0.1, a
+       host that does not match what was stored. All three are rejected
+       here, not treated as case 2. Checked with a single trailing DNS
+       root dot already stripped from the mapped form -- otherwise
        "999.999.999.999." and "192.168.1." would have skipped this case
-       entirely and reached case 2, which has no opinion on IPv4 semantics.
+       entirely and been accepted as an ordinary (if nonsensical) DNS name,
+       since case 2 has no opinion on IPv4 semantics.
+
+    Everything idna accepted that is not case 3 is case 2, an ordinary DNS
+    name.
     """
     if bracketed:
         return _is_unscoped_ipv6_literal(hostname)
-    # A single trailing dot is the valid DNS "root" separator
-    # ("https://example.com./x" navigates identically to the same URL
-    # without it), but left in place it breaks the numeric-last-label check
-    # below: hostname.rsplit(".", 1)[-1] on "192.168.1." returns "", which
-    # is neither a digit nor "0x"-prefixed, so a numeric-last-label host
-    # with a root dot skipped straight to idna.encode() -- which validates
-    # DNS label SYNTAX only and has no opinion on IPv4 semantics, so "999"
-    # is a syntactically fine label and "999.999.999.999." sailed through.
-    # Strip at most one trailing dot before every check below, including
-    # idna's; two or more is an empty label, already invalid on its own.
-    if hostname.endswith(".."):
-        return False
-    hostname = hostname.removesuffix(".")
-    if not hostname:
-        return False
     try:
         ipaddress.ip_address(hostname)
         return True
     except ValueError:
         pass
-    last_label = hostname.rsplit(".", 1)[-1]
-    if last_label.isdigit() or last_label.startswith("0x"):
-        try:
-            parsed_ip = ipaddress.IPv4Address(hostname)
-        except ValueError:
-            return False
-        return str(parsed_ip) == hostname
+    # UTS46-map FIRST, THEN look for "ends in a number" -- a browser's own
+    # order. Doing it on the raw hostname instead (the previous version of
+    # this check) has two failure directions: a raw label already ASCII
+    # digits, but reached only after an ideographic full stop (U+3002) maps
+    # to ".", was still invisible to the check ("999。999。999。999" has no
+    # ASCII "." at all, so rsplit(".", 1) never splits it, and the browser
+    # sees "ends in a number" only after mapping); and str.isdigit() is
+    # true for a fullwidth digit ("１２７.０.０.１"), so the OLD check
+    # thought it recognized "ends in a number" and then handed the raw,
+    # un-mapped string to ipaddress.IPv4Address, which does not understand
+    # fullwidth digits and rejected a host a browser accepts as 127.0.0.1.
     try:
         ascii_host = idna.encode(hostname, uts46=True, std3_rules=True).decode("ascii")
     except idna.IDNAError:
         return False
+    # A single trailing dot is the valid DNS "root" separator
+    # ("https://example.com./x" navigates identically to the same URL
+    # without it); idna.encode leaves it in ascii_host rather than raising,
+    # so it is stripped here -- after mapping, same as WHATWG -- before the
+    # ends-in-a-number check. Two or more is an empty label, which
+    # idna.encode already refused above ("a.." -> "Empty Label").
+    h = ascii_host.removesuffix(".")
+    if not h:
+        return False
+    last = h.rsplit(".", 1)[-1]
+    # ascii_host is already lowercase (idna's ToASCII normalizes case), and
+    # is guaranteed pure ASCII by the .decode("ascii") above, so a plain
+    # ASCII character class replaces the old str.isdigit()/str.startswith()
+    # pair -- str.isdigit() is true for non-ASCII digit code points too,
+    # which is exactly the fullwidth-digit failure this rewrite fixes.
+    # "0x" with no hex digits after it still reads as "a number" to a
+    # browser's host parser.
+    if re.fullmatch(r"[0-9]+|0x[0-9a-f]*", last):
+        try:
+            return str(ipaddress.IPv4Address(h)) == h
+        except ValueError:
+            return False
     # Belt and braces: idna.encode already enforces this length limit
     # itself (verified by hand: 253 accepted, 254 "Domain too long"), but a
     # future idna release relaxing that should not silently loosen ours.

--- a/backend/app/core/persistent_config.py
+++ b/backend/app/core/persistent_config.py
@@ -521,6 +521,17 @@ PUBLIC_API_URL = PersistentConfig[str](
     label="Public API URL",
 )
 
+# PRIV-1: per-instance privacy-policy link for the login/register pages.
+# tab="general" (not "branding") deliberately: ENTERPRISE_ONLY_TABS gates the
+# branding tab, and self-hosted community operators need this the most.
+PRIVACY_URL = PersistentConfig[str](
+    key="privacy_url",
+    type_=str,
+    env_default_factory=lambda: settings.privacy_url or "",
+    tab="general",
+    label="Privacy Policy URL",
+)
+
 LOG_LEVEL = _LogLevelConfig(
     key="log_level",
     env_default_factory=lambda: settings.log_level,

--- a/backend/app/modules/settings/router_public.py
+++ b/backend/app/modules/settings/router_public.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import structlog
 from fastapi import APIRouter, Depends, Request
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.config import validate_privacy_url_shape
 from app.core.dependencies import get_db
 from app.core.edition import get_edition
 from app.core.persistent_config import (
@@ -25,6 +27,8 @@ from app.modules.settings.schemas import (
     FeatureFlagsResponse,
     MapDefaultsResponse,
 )
+
+logger = structlog.stdlib.get_logger(__name__)
 
 router = APIRouter(prefix="/settings", tags=["Admin"])
 
@@ -70,6 +74,14 @@ async def get_feature_flags(
 
 
 @router.get("/branding", response_model=BrandingResponse, include_in_schema=False)
+# PRIV-1: privacy_url rides this endpoint even though its PersistentConfig
+# lives on the "general" tab, not "branding". GET /settings/branding/ is
+# already the one public, unauthenticated config bundle fetched pre-auth
+# (login/register need it before a session exists), so reusing it avoids a
+# second endpoint for one optional string. Read the shape check again here
+# (not just trust the admin-write validator or the boot validator on the env
+# value): a row written before either check existed, or by any other path,
+# must not reach the login page as an unvalidated <a href>.
 @router.get("/branding/", response_model=BrandingResponse)
 async def get_branding(
     db: AsyncSession = Depends(get_db),
@@ -80,12 +92,6 @@ async def get_branding(
     keys. PersistentConfig overrides take precedence when set. Community
     advertises read-only ``show_badge`` only; badge-removal writes and
     additional branding keys are restricted controls.
-
-    ``privacy_url`` (PRIV-1) rides on this same public, unauthenticated
-    surface even though it lives on the "general" tab, not "branding": it is
-    the one config bundle already fetched pre-auth (login/register need it
-    before a session exists), so reusing it avoids a second endpoint for one
-    optional string.
     """
     from app.platform.extensions import get_branding_extension
 
@@ -95,6 +101,18 @@ async def get_branding(
         persisted if persisted is not None else bool(defaults.get("show_badge", True))
     )
     privacy_url = await PRIVACY_URL.get(db)
+    if privacy_url:
+        try:
+            validate_privacy_url_shape(privacy_url)
+        except ValueError:
+            logger.warning(
+                "settings.privacy_url.invalid_stored_value_dropped",
+                message=(
+                    "Stored privacy_url failed the shape check at read time; "
+                    "dropping it instead of serving it as a login-page link."
+                ),
+            )
+            privacy_url = ""
     return BrandingResponse(show_badge=show_badge, privacy_url=privacy_url or None)
 
 

--- a/backend/app/modules/settings/router_public.py
+++ b/backend/app/modules/settings/router_public.py
@@ -103,7 +103,7 @@ async def get_branding(
     privacy_url = await PRIVACY_URL.get(db)
     if privacy_url:
         try:
-            validate_privacy_url_shape(privacy_url)
+            privacy_url = validate_privacy_url_shape(privacy_url)
         except ValueError:
             logger.warning(
                 "settings.privacy_url.invalid_stored_value_dropped",

--- a/backend/app/modules/settings/router_public.py
+++ b/backend/app/modules/settings/router_public.py
@@ -13,6 +13,7 @@ from app.core.persistent_config import (
     ENABLE_DATASET_EDITING,
     ENABLED_PLUGINS,
     MAP_DEFAULTS,
+    PRIVACY_URL,
     REQUIRE_METADATA_FOR_PUBLISH,
     get_cached_basemap_proxy_rate_limit,
 )
@@ -79,6 +80,12 @@ async def get_branding(
     keys. PersistentConfig overrides take precedence when set. Community
     advertises read-only ``show_badge`` only; badge-removal writes and
     additional branding keys are restricted controls.
+
+    ``privacy_url`` (PRIV-1) rides on this same public, unauthenticated
+    surface even though it lives on the "general" tab, not "branding": it is
+    the one config bundle already fetched pre-auth (login/register need it
+    before a session exists), so reusing it avoids a second endpoint for one
+    optional string.
     """
     from app.platform.extensions import get_branding_extension
 
@@ -87,7 +94,8 @@ async def get_branding(
     show_badge = (
         persisted if persisted is not None else bool(defaults.get("show_badge", True))
     )
-    return BrandingResponse(show_badge=show_badge)
+    privacy_url = await PRIVACY_URL.get(db)
+    return BrandingResponse(show_badge=show_badge, privacy_url=privacy_url or None)
 
 
 @router.get(

--- a/backend/app/modules/settings/schemas.py
+++ b/backend/app/modules/settings/schemas.py
@@ -239,7 +239,9 @@ class BrandingResponse(BaseModel):
         default=None,
         description=(
             "Operator-configured privacy-policy URL shown on the login and "
-            "register pages, or null when unset (no link is shown)."
+            "register pages, or null when unset (no link is shown). Must be "
+            "an absolute http(s) URL with no embedded credentials; a query "
+            "string or fragment is allowed and preserved as-is."
         ),
     )
 
@@ -472,10 +474,28 @@ def validate_public_api_url(v: Any) -> str:
 
 
 def validate_privacy_url(v: Any) -> str:
-    """PRIV-1: the login/register privacy-policy link. Unset clears it."""
+    """PRIV-1: the login/register privacy-policy link. Unset clears it.
+
+    Deliberately NOT ``_normalize_absolute_url`` (above): that helper rejects
+    a query string or fragment, but a real operator policy page (Google
+    Docs, Notion, SharePoint) routinely carries one, and stripping it would
+    silently point the login/register link at the wrong document. Uses the
+    shared shape check in ``app.core.config.validate_privacy_url_shape``
+    instead, so this admin-write path agrees with the env-value boot
+    validator and the read-path defense in router_public.py on what "safe"
+    means for a value rendered as a raw ``<a href>``.
+    """
     if not v or (isinstance(v, str) and not v.strip()):
         return ""
-    return _normalize_absolute_url(v)
+    if not isinstance(v, str):
+        raise ValueError("Value must be a string")
+
+    from app.core.config import validate_privacy_url_shape
+
+    try:
+        return validate_privacy_url_shape(v)
+    except ValueError as exc:
+        raise ValueError(f"privacy_url {exc}") from exc
 
 
 # Mapping from setting key to validator function

--- a/backend/app/modules/settings/schemas.py
+++ b/backend/app/modules/settings/schemas.py
@@ -235,6 +235,13 @@ class BrandingResponse(BaseModel):
             "footers. Badge-removal writes are restricted controls."
         )
     )
+    privacy_url: str | None = Field(
+        default=None,
+        description=(
+            "Operator-configured privacy-policy URL shown on the login and "
+            "register pages, or null when unset (no link is shown)."
+        ),
+    )
 
 
 class ConfigModeResponse(BaseModel):
@@ -464,6 +471,13 @@ def validate_public_api_url(v: Any) -> str:
     return _normalize_absolute_url(v)
 
 
+def validate_privacy_url(v: Any) -> str:
+    """PRIV-1: the login/register privacy-policy link. Unset clears it."""
+    if not v or (isinstance(v, str) and not v.strip()):
+        return ""
+    return _normalize_absolute_url(v)
+
+
 # Mapping from setting key to validator function
 def validate_enabled_plugins(v: Any) -> list[str] | None:
     if v is None:
@@ -619,6 +633,7 @@ SETTING_VALIDATORS: dict[str, Any] = {
     "public_app_url": validate_public_app_url,
     "public_api_url": validate_public_api_url,
     "public_base_url": validate_public_api_url,
+    "privacy_url": validate_privacy_url,
     "enabled_plugins": validate_enabled_plugins,
     "access_token_expire_minutes": validate_access_token_expire,
     "refresh_token_expire_days": validate_refresh_token_expire,

--- a/backend/app/modules/settings/schemas.py
+++ b/backend/app/modules/settings/schemas.py
@@ -486,7 +486,11 @@ def validate_privacy_url(v: Any) -> str:
     validator and the read-path defense in router_public.py on what "safe"
     means for a value rendered as a raw ``<a href>``.
     """
-    if not v or (isinstance(v, str) and not v.strip()):
+    # `v is None`, not `not v`: JSON null is a legitimate clear (matching
+    # validate_enabled_plugins), but a falsy non-string -- False, 0, [], {}
+    # -- is a type error, not a clear. `not v` caught those too and
+    # returned "" before the isinstance check below ever ran.
+    if v is None or (isinstance(v, str) and not v.strip()):
         return ""
     if not isinstance(v, str):
         raise ValueError("Value must be a string")

--- a/backend/app/modules/settings/schemas.py
+++ b/backend/app/modules/settings/schemas.py
@@ -5,6 +5,7 @@ from urllib.parse import urlsplit, urlunsplit
 
 from pydantic import BaseModel, Field, field_validator
 
+from app.core.config import validate_privacy_url_shape
 from app.core.public_urls import (
     canonical_host_error,
     is_api_base_path,
@@ -489,13 +490,11 @@ def validate_privacy_url(v: Any) -> str:
         return ""
     if not isinstance(v, str):
         raise ValueError("Value must be a string")
-
-    from app.core.config import validate_privacy_url_shape
-
-    try:
-        return validate_privacy_url_shape(v)
-    except ValueError as exc:
-        raise ValueError(f"privacy_url {exc}") from exc
+    # No local re-wrap of the ValueError: the caller (router.py's
+    # _canonicalize_setting_value) already prefixes it with "Validation
+    # error for 'privacy_url': ...", so an added prefix here just duplicated
+    # the key name in the response detail.
+    return validate_privacy_url_shape(v)
 
 
 # Mapping from setting key to validator function

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -2088,6 +2088,18 @@
             "description": "Whether to show the 'Powered by GeoLens' label in public and shared footers. Badge-removal writes are restricted controls.",
             "title": "Show Badge",
             "type": "boolean"
+          },
+          "privacy_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Operator-configured privacy-policy URL shown on the login and register pages, or null when unset (no link is shown).",
+            "title": "Privacy Url"
           }
         },
         "required": [
@@ -53828,7 +53840,7 @@
     },
     "/settings/branding/": {
       "get": {
-        "description": "Return branding configuration (public, no auth required).\n\nThe active ``BrandingExtension`` provides initial defaults for branding\nkeys. PersistentConfig overrides take precedence when set. Community\nadvertises read-only ``show_badge`` only; badge-removal writes and\nadditional branding keys are restricted controls.",
+        "description": "Return branding configuration (public, no auth required).\n\nThe active ``BrandingExtension`` provides initial defaults for branding\nkeys. PersistentConfig overrides take precedence when set. Community\nadvertises read-only ``show_badge`` only; badge-removal writes and\nadditional branding keys are restricted controls.\n\n``privacy_url`` (PRIV-1) rides on this same public, unauthenticated\nsurface even though it lives on the \"general\" tab, not \"branding\": it is\nthe one config bundle already fetched pre-auth (login/register need it\nbefore a session exists), so reusing it avoids a second endpoint for one\noptional string.",
         "operationId": "get_branding_settings_branding__get",
         "responses": {
           "200": {

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -2098,7 +2098,7 @@
                 "type": "null"
               }
             ],
-            "description": "Operator-configured privacy-policy URL shown on the login and register pages, or null when unset (no link is shown).",
+            "description": "Operator-configured privacy-policy URL shown on the login and register pages, or null when unset (no link is shown). Must be an absolute http(s) URL with no embedded credentials; a query string or fragment is allowed and preserved as-is.",
             "title": "Privacy Url"
           }
         },
@@ -53840,7 +53840,7 @@
     },
     "/settings/branding/": {
       "get": {
-        "description": "Return branding configuration (public, no auth required).\n\nThe active ``BrandingExtension`` provides initial defaults for branding\nkeys. PersistentConfig overrides take precedence when set. Community\nadvertises read-only ``show_badge`` only; badge-removal writes and\nadditional branding keys are restricted controls.\n\n``privacy_url`` (PRIV-1) rides on this same public, unauthenticated\nsurface even though it lives on the \"general\" tab, not \"branding\": it is\nthe one config bundle already fetched pre-auth (login/register need it\nbefore a session exists), so reusing it avoids a second endpoint for one\noptional string.",
+        "description": "Return branding configuration (public, no auth required).\n\nThe active ``BrandingExtension`` provides initial defaults for branding\nkeys. PersistentConfig overrides take precedence when set. Community\nadvertises read-only ``show_badge`` only; badge-removal writes and\nadditional branding keys are restricted controls.",
         "operationId": "get_branding_settings_branding__get",
         "responses": {
           "200": {

--- a/backend/tests/test_branding_settings.py
+++ b/backend/tests/test_branding_settings.py
@@ -162,6 +162,8 @@ async def test_get_branding_privacy_url_unset_by_default(
         "javascript:alert(1)",
         "data:text/html,x",
         "//evil.example.com/p",
+        "https://example.com:not-a-port/x",
+        "https://:443/x",
     ],
 )
 @pytest.mark.anyio
@@ -172,7 +174,10 @@ async def test_put_privacy_url_rejects_non_url(
 
     Covers the XSS-relevant shapes, not just "not a URL": a javascript:/data:
     URI or a scheme-relative value would otherwise reach the login page as a
-    raw <a href>.
+    raw <a href>. Also covers a malformed authority a browser cannot resolve
+    (a non-numeric port, or a netloc with no real hostname) — urlsplit leaves
+    that junk sitting in netloc rather than rejecting it outright, so the
+    scheme/netloc check alone would let it through.
     """
     resp = await client.put(
         "/api/settings/",

--- a/backend/tests/test_branding_settings.py
+++ b/backend/tests/test_branding_settings.py
@@ -155,6 +155,53 @@ async def test_get_branding_privacy_url_unset_by_default(
     assert resp.json()["privacy_url"] is None
 
 
+@pytest.mark.anyio
+async def test_put_privacy_url_null_clears_it(
+    client: AsyncClient, admin_auth_header: dict
+):
+    """JSON null is a legitimate clear, same as "" -- distinct from a falsy
+    non-string (False, 0, [], {}), which must 422 instead.
+    """
+    resp = await client.put(
+        "/api/settings/",
+        json={"settings": {"privacy_url": "https://operator.example.com/privacy"}},
+        headers=admin_auth_header,
+    )
+    assert resp.status_code == 200
+
+    resp = await client.put(
+        "/api/settings/",
+        json={"settings": {"privacy_url": None}},
+        headers=admin_auth_header,
+    )
+    assert resp.status_code == 200
+
+    resp = await client.get("/api/settings/branding/")
+    assert resp.status_code == 200
+    assert resp.json()["privacy_url"] is None
+
+
+@pytest.mark.parametrize(
+    "value",
+    [False, 0, [], {}],
+)
+@pytest.mark.anyio
+async def test_put_privacy_url_rejects_falsy_non_strings(
+    client: AsyncClient, admin_auth_header: dict, value
+):
+    """A falsy non-string value (False, 0, [], {}) is a type error, not a
+    clear -- only JSON null and an empty/whitespace string clear the link.
+    `if not v` would have caught these too and cleared silently instead of
+    422ing, since every one of them is falsy in Python.
+    """
+    resp = await client.put(
+        "/api/settings/",
+        json={"settings": {"privacy_url": value}},
+        headers=admin_auth_header,
+    )
+    assert resp.status_code == 422
+
+
 @pytest.mark.parametrize(
     "value",
     [

--- a/backend/tests/test_branding_settings.py
+++ b/backend/tests/test_branding_settings.py
@@ -179,6 +179,7 @@ async def test_get_branding_privacy_url_unset_by_default(
         "https://[fe80::1%25eth0]/x",
         "https://[fe80::1%eth0]/x",
         "https://[1.2.3.4]/x",
+        "https://xn--lsa.example/x",
     ],
 )
 @pytest.mark.anyio
@@ -208,7 +209,10 @@ async def test_put_privacy_url_rejects_non_url(
     brackets, [1.2.3.4]), and a scoped IPv6 zone ID whether or not its "%"
     is percent-escaped ([fe80::1%eth0], [fe80::1%25eth0]) -- each would
     otherwise fall through to the DNS-name or numeric-last-label case once
-    `.hostname` strips the brackets.
+    `.hostname` strips the brackets. And "xn--lsa" (the punycode spelling
+    of a bare combining mark): U-labels and decoded A-labels share one
+    rule set, so the encoded form of an already-rejected host cannot slip
+    through in its "xn--..." spelling.
     """
     resp = await client.put(
         "/api/settings/",

--- a/backend/tests/test_branding_settings.py
+++ b/backend/tests/test_branding_settings.py
@@ -183,6 +183,8 @@ async def test_get_branding_privacy_url_unset_by_default(
         "https://﹇.com/x",
         "https://192.168.1./x",
         "https://999.999.999.999./x",
+        "https://999。999。999。999/x",
+        "https://192.168.1。/x",
     ],
 )
 @pytest.mark.anyio
@@ -224,7 +226,12 @@ async def test_put_privacy_url_rejects_non_url(
     makes `hostname.rsplit(".", 1)[-1]` return an empty string, which is
     neither a digit nor "0x"-prefixed, so the ends-in-a-number check was
     skipped entirely and idna.encode() (DNS label SYNTAX only, no IPv4
-    opinion) accepted "999" and "1" as ordinary-looking labels.
+    opinion) accepted "999" and "1" as ordinary-looking labels. And the same
+    numeric-last-label host spelled with ideographic full stops (U+3002,
+    "。" instead of ".") instead of a root dot: the raw string has no ASCII
+    "." at all, so it looked like one giant label with no numeric tail --
+    only visible as ends-in-a-number AFTER UTS46 maps "。" to ".", which is
+    why that mapping now runs before this check, not after.
     """
     resp = await client.put(
         "/api/settings/",
@@ -343,16 +350,22 @@ async def test_put_privacy_url_accepts_internationalized_hosts(
     [
         "https://10.0.0.1./x",
         "https://example.com./x",
+        "https://１２７.０.０.１/x",
+        "https://例え。テスト/x",
     ],
 )
 @pytest.mark.anyio
-async def test_put_privacy_url_accepts_a_single_trailing_root_dot(
+async def test_put_privacy_url_accepts_uts46_mapped_hosts(
     client: AsyncClient, admin_auth_header: dict, value: str
 ):
-    """A single trailing DNS root dot is browser-valid and stored exactly
-    as entered, on a canonical IPv4 host (legal but pointless) and on an
-    ordinary DNS name (the common, meaningful case) alike -- neither case
-    is special-cased to strip or rewrite it.
+    """Browser-valid hosts that only pass because UTS46 mapping runs before
+    every other check, stored exactly as entered (never rewritten to a
+    canonical or mapped form). A single trailing DNS root dot: on a
+    canonical IPv4 host (legal but pointless) and on an ordinary DNS name
+    (the common, meaningful case) alike. A fullwidth-digit IPv4 host
+    ("１２７.０.０.１", which UTS46 maps to "127.0.0.1"). An internationalized
+    DNS name written with ideographic full stops instead of ASCII dots
+    ("例え。テスト", which a browser reads identically to "例え.テスト").
     """
     resp = await client.put(
         "/api/settings/",

--- a/backend/tests/test_branding_settings.py
+++ b/backend/tests/test_branding_settings.py
@@ -10,11 +10,11 @@ from httpx import AsyncClient
 
 @pytest.mark.anyio
 async def test_get_branding_default(client: AsyncClient):
-    """GET /api/settings/branding/ returns show_badge=true by default (no auth)."""
+    """GET /api/settings/branding/ returns show_badge=true and no privacy_url by default (no auth)."""
     resp = await client.get("/api/settings/branding/")
     assert resp.status_code == 200
     data = resp.json()
-    assert data == {"show_badge": True}
+    assert data == {"show_badge": True, "privacy_url": None}
 
 
 @pytest.mark.anyio
@@ -110,8 +110,59 @@ async def test_get_branding_after_config_override(client: AsyncClient):
     resp = await client.get("/api/settings/branding/")
     assert resp.status_code == 200
     data = resp.json()
-    assert data == {"show_badge": False}
+    assert data == {"show_badge": False, "privacy_url": None}
 
     # Restore default
     async for db in get_db_override():
         await BRANDING_SHOW_BADGE.set(db, True)
+
+
+@pytest.mark.anyio
+async def test_get_branding_privacy_url_unset_by_default(
+    client: AsyncClient, admin_auth_header: dict
+):
+    """PRIV-1: no privacy_url is configured until an admin sets one.
+
+    GET /api/settings/branding/ returns null (community and self-hosted
+    instances never link to another operator's privacy page by default), and
+    PUT /api/settings/ with a configured URL makes it appear.
+    """
+    resp = await client.get("/api/settings/branding/")
+    assert resp.status_code == 200
+    assert resp.json()["privacy_url"] is None
+
+    resp = await client.put(
+        "/api/settings/",
+        json={"settings": {"privacy_url": "https://operator.example.com/privacy"}},
+        headers=admin_auth_header,
+    )
+    assert resp.status_code == 200
+
+    resp = await client.get("/api/settings/branding/")
+    assert resp.status_code == 200
+    assert resp.json()["privacy_url"] == "https://operator.example.com/privacy"
+
+    # Clearing it back to empty restores the "no link shown" default.
+    resp = await client.put(
+        "/api/settings/",
+        json={"settings": {"privacy_url": ""}},
+        headers=admin_auth_header,
+    )
+    assert resp.status_code == 200
+
+    resp = await client.get("/api/settings/branding/")
+    assert resp.status_code == 200
+    assert resp.json()["privacy_url"] is None
+
+
+@pytest.mark.anyio
+async def test_put_privacy_url_rejects_non_url(
+    client: AsyncClient, admin_auth_header: dict
+):
+    """PUT /api/settings/ rejects a privacy_url value that is not an absolute http(s) URL."""
+    resp = await client.put(
+        "/api/settings/",
+        json={"settings": {"privacy_url": "not-a-url"}},
+        headers=admin_auth_header,
+    )
+    assert resp.status_code == 422

--- a/backend/tests/test_branding_settings.py
+++ b/backend/tests/test_branding_settings.py
@@ -173,6 +173,8 @@ async def test_get_branding_privacy_url_unset_by_default(
         "https://0x7f.1/x",
         "https://a..b/x",
         "https://́.example.com/x",
+        "https://xn--a.com/x",
+        "https://xn--.com/x",
     ],
 )
 @pytest.mark.anyio
@@ -192,7 +194,11 @@ async def test_put_privacy_url_rejects_non_url(
     (999.999.999.999), too many parts (1.2.3.4.5), or a legacy short form a
     browser silently expands to a different address (192.168.1, 0x7f.1) --
     the per-label characters alone look like a valid DNS name, so a check
-    that stopped at character class would accept all four.
+    that stopped at character class would accept all four. Also covers an
+    empty label (a..b), a label that is only a Unicode combining mark, and a
+    label already spelled as "xn--" A-label punycode that does not decode to
+    a real IDN label -- fail-closed even though Chromium/WebKit accept any
+    ASCII "xn--" label unvalidated, since Firefox does not.
     """
     resp = await client.put(
         "/api/settings/",

--- a/backend/tests/test_branding_settings.py
+++ b/backend/tests/test_branding_settings.py
@@ -180,6 +180,7 @@ async def test_get_branding_privacy_url_unset_by_default(
         "https://[fe80::1%eth0]/x",
         "https://[1.2.3.4]/x",
         "https://xn--lsa.example/x",
+        "https://﹇.com/x",
     ],
 )
 @pytest.mark.anyio
@@ -212,7 +213,11 @@ async def test_put_privacy_url_rejects_non_url(
     `.hostname` strips the brackets. And "xn--lsa" (the punycode spelling
     of a bare combining mark): U-labels and decoded A-labels share one
     rule set, so the encoded form of an already-rejected host cannot slip
-    through in its "xn--..." spelling.
+    through in its "xn--..." spelling. And U+FE47 -- hostname validity is
+    now the `idna` package's UTS46 ToASCII, which maps this presentation
+    variant to "[" per the UTS46 mapping table and then rejects the
+    result, the same as a literal "[" would be (STD3 disallows it outside
+    the bracketed-authority syntax `urlsplit` already stripped away).
     """
     resp = await client.put(
         "/api/settings/",

--- a/backend/tests/test_branding_settings.py
+++ b/backend/tests/test_branding_settings.py
@@ -167,6 +167,10 @@ async def test_get_branding_privacy_url_unset_by_default(
         "https://exa mple.com/x",
         "https://exam_ple.com/x",
         "https://-bad.com/x",
+        "https://999.999.999.999/x",
+        "https://1.2.3.4.5/x",
+        "https://192.168.1/x",
+        "https://0x7f.1/x",
     ],
 )
 @pytest.mark.anyio
@@ -181,7 +185,12 @@ async def test_put_privacy_url_rejects_non_url(
     (a non-numeric port, a netloc with no real hostname, an embedded space, an
     underscore, or a leading hyphen) -- urlsplit leaves that junk sitting in
     netloc/hostname rather than rejecting it outright, so the scheme/netloc
-    check alone would let it through.
+    check alone would let it through. And a numeric-last-label host a
+    browser reads as an attempted IPv4 address: out of range
+    (999.999.999.999), too many parts (1.2.3.4.5), or a legacy short form a
+    browser silently expands to a different address (192.168.1, 0x7f.1) --
+    the per-label characters alone look like a valid DNS name, so a check
+    that stopped at character class would accept all four.
     """
     resp = await client.put(
         "/api/settings/",

--- a/backend/tests/test_branding_settings.py
+++ b/backend/tests/test_branding_settings.py
@@ -171,6 +171,8 @@ async def test_get_branding_privacy_url_unset_by_default(
         "https://1.2.3.4.5/x",
         "https://192.168.1/x",
         "https://0x7f.1/x",
+        "https://a..b/x",
+        "https://́.example.com/x",
     ],
 )
 @pytest.mark.anyio
@@ -245,6 +247,43 @@ async def test_put_privacy_url_accepts_ip_literal_hosts(
     a legitimate privacy_url target, not just a DNS name -- the hostname
     allowlist accepts both forms via ipaddress.ip_address(), same as the
     rejection cases above prove it rejects a malformed one.
+    """
+    resp = await client.put(
+        "/api/settings/",
+        json={"settings": {"privacy_url": value}},
+        headers=admin_auth_header,
+    )
+    assert resp.status_code == 200
+
+    resp = await client.get("/api/settings/branding/")
+    assert resp.status_code == 200
+    assert resp.json()["privacy_url"] == value
+
+    # Restore default so this test does not leak state to others.
+    resp = await client.put(
+        "/api/settings/",
+        json={"settings": {"privacy_url": ""}},
+        headers=admin_auth_header,
+    )
+    assert resp.status_code == 200
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "https://例え.テスト/privacy",
+        "https://xn--r8jz45g.xn--zckzah/privacy",
+    ],
+)
+@pytest.mark.anyio
+async def test_put_privacy_url_accepts_internationalized_hosts(
+    client: AsyncClient, admin_auth_header: dict, value: str
+):
+    """A browser-valid internationalized host, in either its native Unicode
+    spelling or its already-punycode "xn--" form, is a legitimate
+    privacy_url target. Round-trips unchanged: the operator's URL is stored
+    and served exactly as entered, not rewritten to a canonical form,
+    matching what a browser does with the same input.
     """
     resp = await client.put(
         "/api/settings/",

--- a/backend/tests/test_branding_settings.py
+++ b/backend/tests/test_branding_settings.py
@@ -164,6 +164,9 @@ async def test_get_branding_privacy_url_unset_by_default(
         "//evil.example.com/p",
         "https://example.com:not-a-port/x",
         "https://:443/x",
+        "https://exa mple.com/x",
+        "https://exam_ple.com/x",
+        "https://-bad.com/x",
     ],
 )
 @pytest.mark.anyio
@@ -175,9 +178,10 @@ async def test_put_privacy_url_rejects_non_url(
     Covers the XSS-relevant shapes, not just "not a URL": a javascript:/data:
     URI or a scheme-relative value would otherwise reach the login page as a
     raw <a href>. Also covers a malformed authority a browser cannot resolve
-    (a non-numeric port, or a netloc with no real hostname) — urlsplit leaves
-    that junk sitting in netloc rather than rejecting it outright, so the
-    scheme/netloc check alone would let it through.
+    (a non-numeric port, a netloc with no real hostname, an embedded space, an
+    underscore, or a leading hyphen) -- urlsplit leaves that junk sitting in
+    netloc/hostname rather than rejecting it outright, so the scheme/netloc
+    check alone would let it through.
     """
     resp = await client.put(
         "/api/settings/",
@@ -197,6 +201,42 @@ async def test_put_privacy_url_accepts_query_and_fragment(
     rule it deliberately does not share.
     """
     value = "https://docs.google.com/document/d/abc123/edit?usp=sharing#heading=h.xyz"
+    resp = await client.put(
+        "/api/settings/",
+        json={"settings": {"privacy_url": value}},
+        headers=admin_auth_header,
+    )
+    assert resp.status_code == 200
+
+    resp = await client.get("/api/settings/branding/")
+    assert resp.status_code == 200
+    assert resp.json()["privacy_url"] == value
+
+    # Restore default so this test does not leak state to others.
+    resp = await client.put(
+        "/api/settings/",
+        json={"settings": {"privacy_url": ""}},
+        headers=admin_auth_header,
+    )
+    assert resp.status_code == 200
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "https://[::1]/x",
+        "https://10.0.0.1:8443/x",
+    ],
+)
+@pytest.mark.anyio
+async def test_put_privacy_url_accepts_ip_literal_hosts(
+    client: AsyncClient, admin_auth_header: dict, value: str
+):
+    """An IP-literal host (IPv6 or IPv4, with or without an explicit port) is
+    a legitimate privacy_url target, not just a DNS name -- the hostname
+    allowlist accepts both forms via ipaddress.ip_address(), same as the
+    rejection cases above prove it rejects a malformed one.
+    """
     resp = await client.put(
         "/api/settings/",
         json={"settings": {"privacy_url": value}},

--- a/backend/tests/test_branding_settings.py
+++ b/backend/tests/test_branding_settings.py
@@ -175,6 +175,10 @@ async def test_get_branding_privacy_url_unset_by_default(
         "https://́.example.com/x",
         "https://xn--a.com/x",
         "https://xn--.com/x",
+        "https://[v1.foo]/x",
+        "https://[fe80::1%25eth0]/x",
+        "https://[fe80::1%eth0]/x",
+        "https://[1.2.3.4]/x",
     ],
 )
 @pytest.mark.anyio
@@ -198,7 +202,13 @@ async def test_put_privacy_url_rejects_non_url(
     empty label (a..b), a label that is only a Unicode combining mark, and a
     label already spelled as "xn--" A-label punycode that does not decode to
     a real IDN label -- fail-closed even though Chromium/WebKit accept any
-    ASCII "xn--" label unvalidated, since Firefox does not.
+    ASCII "xn--" label unvalidated, since Firefox does not. And a bracketed
+    authority that is not a plain, unscoped IPv6 literal: an IPvFuture
+    literal no browser implements ([v1.foo]), an IPv4 literal (invalid in
+    brackets, [1.2.3.4]), and a scoped IPv6 zone ID whether or not its "%"
+    is percent-escaped ([fe80::1%eth0], [fe80::1%25eth0]) -- each would
+    otherwise fall through to the DNS-name or numeric-last-label case once
+    `.hostname` strips the brackets.
     """
     resp = await client.put(
         "/api/settings/",
@@ -243,6 +253,7 @@ async def test_put_privacy_url_accepts_query_and_fragment(
     [
         "https://[::1]/x",
         "https://10.0.0.1:8443/x",
+        "https://[2001:db8::1]:8443/x",
     ],
 )
 @pytest.mark.anyio

--- a/backend/tests/test_branding_settings.py
+++ b/backend/tests/test_branding_settings.py
@@ -181,6 +181,8 @@ async def test_get_branding_privacy_url_unset_by_default(
         "https://[1.2.3.4]/x",
         "https://xn--lsa.example/x",
         "https://﹇.com/x",
+        "https://192.168.1./x",
+        "https://999.999.999.999./x",
     ],
 )
 @pytest.mark.anyio
@@ -217,7 +219,12 @@ async def test_put_privacy_url_rejects_non_url(
     now the `idna` package's UTS46 ToASCII, which maps this presentation
     variant to "[" per the UTS46 mapping table and then rejects the
     result, the same as a literal "[" would be (STD3 disallows it outside
-    the bracketed-authority syntax `urlsplit` already stripped away).
+    the bracketed-authority syntax `urlsplit` already stripped away). And a
+    numeric-last-label host with a single trailing DNS root dot: the dot
+    makes `hostname.rsplit(".", 1)[-1]` return an empty string, which is
+    neither a digit nor "0x"-prefixed, so the ends-in-a-number check was
+    skipped entirely and idna.encode() (DNS label SYNTAX only, no IPv4
+    opinion) accepted "999" and "1" as ordinary-looking labels.
     """
     resp = await client.put(
         "/api/settings/",
@@ -310,6 +317,42 @@ async def test_put_privacy_url_accepts_internationalized_hosts(
     privacy_url target. Round-trips unchanged: the operator's URL is stored
     and served exactly as entered, not rewritten to a canonical form,
     matching what a browser does with the same input.
+    """
+    resp = await client.put(
+        "/api/settings/",
+        json={"settings": {"privacy_url": value}},
+        headers=admin_auth_header,
+    )
+    assert resp.status_code == 200
+
+    resp = await client.get("/api/settings/branding/")
+    assert resp.status_code == 200
+    assert resp.json()["privacy_url"] == value
+
+    # Restore default so this test does not leak state to others.
+    resp = await client.put(
+        "/api/settings/",
+        json={"settings": {"privacy_url": ""}},
+        headers=admin_auth_header,
+    )
+    assert resp.status_code == 200
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "https://10.0.0.1./x",
+        "https://example.com./x",
+    ],
+)
+@pytest.mark.anyio
+async def test_put_privacy_url_accepts_a_single_trailing_root_dot(
+    client: AsyncClient, admin_auth_header: dict, value: str
+):
+    """A single trailing DNS root dot is browser-valid and stored exactly
+    as entered, on a canonical IPv4 host (legal but pointless) and on an
+    ordinary DNS name (the common, meaningful case) alike -- neither case
+    is special-cased to strip or rewrite it.
     """
     resp = await client.put(
         "/api/settings/",

--- a/backend/tests/test_branding_settings.py
+++ b/backend/tests/test_branding_settings.py
@@ -155,14 +155,86 @@ async def test_get_branding_privacy_url_unset_by_default(
     assert resp.json()["privacy_url"] is None
 
 
+@pytest.mark.parametrize(
+    "value",
+    [
+        "not-a-url",
+        "javascript:alert(1)",
+        "data:text/html,x",
+        "//evil.example.com/p",
+    ],
+)
 @pytest.mark.anyio
 async def test_put_privacy_url_rejects_non_url(
-    client: AsyncClient, admin_auth_header: dict
+    client: AsyncClient, admin_auth_header: dict, value: str
 ):
-    """PUT /api/settings/ rejects a privacy_url value that is not an absolute http(s) URL."""
+    """PUT /api/settings/ rejects a privacy_url that is not a safe absolute http(s) URL.
+
+    Covers the XSS-relevant shapes, not just "not a URL": a javascript:/data:
+    URI or a scheme-relative value would otherwise reach the login page as a
+    raw <a href>.
+    """
     resp = await client.put(
         "/api/settings/",
-        json={"settings": {"privacy_url": "not-a-url"}},
+        json={"settings": {"privacy_url": value}},
         headers=admin_auth_header,
     )
     assert resp.status_code == 422
+
+
+@pytest.mark.anyio
+async def test_put_privacy_url_accepts_query_and_fragment(
+    client: AsyncClient, admin_auth_header: dict
+):
+    """A real operator policy URL (Google Docs, Notion, SharePoint) often
+    carries a query string or a fragment; the privacy_url validator must not
+    strip or reject either, unlike the public_app_url/public_api_url shape
+    rule it deliberately does not share.
+    """
+    value = "https://docs.google.com/document/d/abc123/edit?usp=sharing#heading=h.xyz"
+    resp = await client.put(
+        "/api/settings/",
+        json={"settings": {"privacy_url": value}},
+        headers=admin_auth_header,
+    )
+    assert resp.status_code == 200
+
+    resp = await client.get("/api/settings/branding/")
+    assert resp.status_code == 200
+    assert resp.json()["privacy_url"] == value
+
+    # Restore default so this test does not leak state to others.
+    resp = await client.put(
+        "/api/settings/",
+        json={"settings": {"privacy_url": ""}},
+        headers=admin_auth_header,
+    )
+    assert resp.status_code == 200
+
+
+@pytest.mark.anyio
+async def test_get_branding_drops_an_unsafe_stored_privacy_url(client: AsyncClient):
+    """PRIV-1 reader-side defense: an unsafe stored value must never reach
+    the login page as a raw <a href>, even if it bypassed the admin-write
+    validator — a row written before that check existed, or by any other
+    path than PUT /api/settings/. Writes through PersistentConfig.set()
+    directly, which (like a raw DB row) has no shape opinion on a str value;
+    only the read path in router_public.py is under test here.
+    """
+    from app.core.dependencies import get_db
+    from app.api.main import app
+    from app.core.persistent_config import PRIVACY_URL
+
+    get_db_override = app.dependency_overrides.get(get_db)
+    assert get_db_override is not None
+
+    async for db in get_db_override():
+        await PRIVACY_URL.set(db, "javascript:alert(document.cookie)")
+
+    resp = await client.get("/api/settings/branding/")
+    assert resp.status_code == 200
+    assert resp.json()["privacy_url"] is None
+
+    # Restore default
+    async for db in get_db_override():
+        await PRIVACY_URL.set(db, "")

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -873,6 +873,8 @@ class TestPrivacyUrlValidator:
             "https://﹇.com/x",
             "https://192.168.1./x",
             "https://999.999.999.999./x",
+            "https://999。999。999。999/x",
+            "https://192.168.1。/x",
         ],
     )
     def test_unsafe_value_fails_boot(self, value):
@@ -920,12 +922,17 @@ class TestPrivacyUrlValidator:
         [
             "https://10.0.0.1./x",
             "https://example.com./x",
+            "https://１２７.０.０.１/x",
+            "https://例え。テスト/x",
         ],
     )
-    def test_trailing_root_dot_accepted(self, value):
-        """A single trailing DNS root dot is browser-valid and stored
-        exactly as entered, on a canonical IPv4 host (legal but pointless)
-        and on an ordinary DNS name (the common, meaningful case) alike.
+    def test_uts46_mapped_host_accepted(self, value):
+        """Browser-valid hosts that only pass because UTS46 mapping runs
+        before every other check, stored exactly as entered (never
+        rewritten to a canonical or mapped form): a single trailing DNS
+        root dot on a canonical IPv4 host and on an ordinary DNS name, a
+        fullwidth-digit IPv4 host, and an internationalized DNS name
+        written with ideographic full stops instead of ASCII dots.
         """
         s = _make_settings(privacy_url=value)
         assert s.privacy_url == value

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -841,6 +841,10 @@ class TestPrivacyUrlValidator:
             "https://exa mple.com/x",
             "https://exam_ple.com/x",
             "https://-bad.com/x",
+            "https://999.999.999.999/x",
+            "https://1.2.3.4.5/x",
+            "https://192.168.1/x",
+            "https://0x7f.1/x",
         ],
     )
     def test_unsafe_value_fails_boot(self, value):

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -870,6 +870,7 @@ class TestPrivacyUrlValidator:
             "https://[fe80::1%eth0]/x",
             "https://[1.2.3.4]/x",
             "https://xn--lsa.example/x",
+            "https://﹇.com/x",
         ],
     )
     def test_unsafe_value_fails_boot(self, value):

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -825,6 +825,8 @@ class TestPrivacyUrlValidator:
             "data:text/html,<script>alert(1)</script>",
             "//evil.example.com/p",
             "https://user:pass@example.com/privacy",
+            "https://example.com:not-a-port/x",
+            "https://:443/x",
         ],
     )
     def test_unsafe_value_fails_boot(self, value):

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -862,6 +862,8 @@ class TestPrivacyUrlValidator:
             "https://0x7f.1/x",
             "https://a..b/x",
             "https://́.example.com/x",
+            "https://xn--a.com/x",
+            "https://xn--.com/x",
         ],
     )
     def test_unsafe_value_fails_boot(self, value):

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -869,12 +869,48 @@ class TestPrivacyUrlValidator:
             "https://[fe80::1%25eth0]/x",
             "https://[fe80::1%eth0]/x",
             "https://[1.2.3.4]/x",
+            "https://xn--lsa.example/x",
         ],
     )
     def test_unsafe_value_fails_boot(self, value):
         with pytest.raises(Exception) as exc_info:
             _make_settings(privacy_url=value)
         assert "PRIVACY_URL" in str(exc_info.value)
+
+    @pytest.mark.parametrize(
+        "host, accepted",
+        [
+            ("例え.テスト", True),
+            ("́.example.com", False),  # a bare combining mark as a label
+        ],
+    )
+    def test_ulabel_and_alabel_forms_get_the_same_verdict(self, host, accepted):
+        """PRIV-1 (codex r7): a host's native Unicode (U-label) spelling and
+        its IDNA-encoded ("xn--...", A-label) spelling must always agree --
+        which one the operator happened to type is never why one is
+        accepted and the other rejected. Skips the A-form comparison for a
+        host IDNA itself cannot encode (there is no A-form to compare).
+        """
+        u_url = f"https://{host}/x"
+        if accepted:
+            s = _make_settings(privacy_url=u_url)
+            assert s.privacy_url == u_url
+        else:
+            with pytest.raises(Exception):
+                _make_settings(privacy_url=u_url)
+
+        try:
+            a_host = host.encode("idna").decode("ascii")
+        except UnicodeError:
+            return
+
+        a_url = f"https://{a_host}/x"
+        if accepted:
+            s = _make_settings(privacy_url=a_url)
+            assert s.privacy_url == a_url
+        else:
+            with pytest.raises(Exception):
+                _make_settings(privacy_url=a_url)
 
 
 class TestSecretStrMasking:

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -820,6 +820,17 @@ class TestPrivacyUrlValidator:
     @pytest.mark.parametrize(
         "value",
         [
+            "https://[::1]/x",
+            "https://10.0.0.1:8443/x",
+        ],
+    )
+    def test_ip_literal_host_accepted(self, value):
+        s = _make_settings(privacy_url=value)
+        assert s.privacy_url == value
+
+    @pytest.mark.parametrize(
+        "value",
+        [
             "not-a-url",
             "javascript:alert(document.cookie)",
             "data:text/html,<script>alert(1)</script>",
@@ -827,6 +838,9 @@ class TestPrivacyUrlValidator:
             "https://user:pass@example.com/privacy",
             "https://example.com:not-a-port/x",
             "https://:443/x",
+            "https://exa mple.com/x",
+            "https://exam_ple.com/x",
+            "https://-bad.com/x",
         ],
     )
     def test_unsafe_value_fails_boot(self, value):

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -831,6 +831,21 @@ class TestPrivacyUrlValidator:
     @pytest.mark.parametrize(
         "value",
         [
+            "https://例え.テスト/privacy",
+            "https://xn--r8jz45g.xn--zckzah/privacy",
+        ],
+    )
+    def test_internationalized_host_accepted_unchanged(self, value):
+        """Stored and served exactly as entered, in either its native
+        Unicode spelling or its already-punycode form -- not rewritten to a
+        canonical form, matching what a browser does with the same input.
+        """
+        s = _make_settings(privacy_url=value)
+        assert s.privacy_url == value
+
+    @pytest.mark.parametrize(
+        "value",
+        [
             "not-a-url",
             "javascript:alert(document.cookie)",
             "data:text/html,<script>alert(1)</script>",
@@ -845,6 +860,8 @@ class TestPrivacyUrlValidator:
             "https://1.2.3.4.5/x",
             "https://192.168.1/x",
             "https://0x7f.1/x",
+            "https://a..b/x",
+            "https://́.example.com/x",
         ],
     )
     def test_unsafe_value_fails_boot(self, value):

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -797,6 +797,42 @@ class TestLogLevelValidator:
         assert "LOG_LEVEL" in str(exc_info.value)
 
 
+class TestPrivacyUrlValidator:
+    """PRIV-1: PRIVACY_URL is rendered as a raw <a href> on the login page,
+    so an unsafe value must fail boot rather than reach the browser. This is
+    the ONLY validation an ENV_ONLY_CONFIG deployment ever runs for it — the
+    admin-write validator never sees an env-sourced value in that mode.
+    """
+
+    def test_unset_stays_none(self):
+        s = _make_settings(privacy_url="")
+        assert s.privacy_url is None
+
+    def test_safe_url_accepted(self):
+        s = _make_settings(privacy_url="https://example.com/privacy")
+        assert s.privacy_url == "https://example.com/privacy"
+
+    def test_query_and_fragment_preserved(self):
+        value = "https://docs.google.com/document/d/abc/edit?usp=sharing#h.xyz"
+        s = _make_settings(privacy_url=value)
+        assert s.privacy_url == value
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "not-a-url",
+            "javascript:alert(document.cookie)",
+            "data:text/html,<script>alert(1)</script>",
+            "//evil.example.com/p",
+            "https://user:pass@example.com/privacy",
+        ],
+    )
+    def test_unsafe_value_fails_boot(self, value):
+        with pytest.raises(Exception) as exc_info:
+            _make_settings(privacy_url=value)
+        assert "PRIVACY_URL" in str(exc_info.value)
+
+
 class TestSecretStrMasking:
     """Sensitive fields use SecretStr so values are masked in repr/str/dump."""
 

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -871,6 +871,8 @@ class TestPrivacyUrlValidator:
             "https://[1.2.3.4]/x",
             "https://xn--lsa.example/x",
             "https://﹇.com/x",
+            "https://192.168.1./x",
+            "https://999.999.999.999./x",
         ],
     )
     def test_unsafe_value_fails_boot(self, value):
@@ -912,6 +914,21 @@ class TestPrivacyUrlValidator:
         else:
             with pytest.raises(Exception):
                 _make_settings(privacy_url=a_url)
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "https://10.0.0.1./x",
+            "https://example.com./x",
+        ],
+    )
+    def test_trailing_root_dot_accepted(self, value):
+        """A single trailing DNS root dot is browser-valid and stored
+        exactly as entered, on a canonical IPv4 host (legal but pointless)
+        and on an ordinary DNS name (the common, meaningful case) alike.
+        """
+        s = _make_settings(privacy_url=value)
+        assert s.privacy_url == value
 
 
 class TestSecretStrMasking:

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -822,6 +822,7 @@ class TestPrivacyUrlValidator:
         [
             "https://[::1]/x",
             "https://10.0.0.1:8443/x",
+            "https://[2001:db8::1]:8443/x",
         ],
     )
     def test_ip_literal_host_accepted(self, value):
@@ -864,6 +865,10 @@ class TestPrivacyUrlValidator:
             "https://́.example.com/x",
             "https://xn--a.com/x",
             "https://xn--.com/x",
+            "https://[v1.foo]/x",
+            "https://[fe80::1%25eth0]/x",
+            "https://[fe80::1%eth0]/x",
+            "https://[1.2.3.4]/x",
         ],
     )
     def test_unsafe_value_fails_boot(self, value):

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -2110,7 +2110,10 @@ _OPEN_CORE_SIZE_CAPS: dict[str, int] = {
     # closed enums, with the descriptions that say which columns are absent
     # (link status) and why.
     "backend/app/modules/admin/router_operations.py": 316,
-    "backend/app/modules/settings/router_public.py": 150,
+    # PRIV-1: +7 lines — GET /settings/branding/ also resolves and returns
+    # PRIVACY_URL, so the login/register privacy-policy link is admin
+    # configurable instead of a hardcoded getgeolens.com URL.
+    "backend/app/modules/settings/router_public.py": 157,
 }
 
 
@@ -2826,7 +2829,10 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # enumerate what the setting controls say so. This setting exists because
     # security posture was once keyed off a flag documented as log-format only;
     # an under-documented coupling is the same mistake. Cap 1104 -> 1107, exact.
-    "backend/app/core/config.py": 1107,
+    # PRIV-1: +5 — a privacy_url Settings field (env-backed default for the
+    # login/register privacy-policy link) plus its empty-string normalizer
+    # entry. Cap 1107 -> 1112, exact.
+    "backend/app/core/config.py": 1112,
     # fix(#1543): first entry — crossed _RATCHET_INCLUSION_LOC on the change
     # that gave PersistentConfig a batch eviction. The code is small
     # (apply_side_effects_batch, plus splitting the process-local half of
@@ -2845,7 +2851,10 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # problem at all and needs EmbeddingProviderExtension widened. Without the
     # note the next reader assumes an atomic eviction covered both.
     # Cap 1007 -> 1018, exact.
-    "backend/app/core/persistent_config.py": 1018,
+    # PRIV-1: +11 — a PRIVACY_URL PersistentConfig on the "general" tab (not
+    # "branding", which ENTERPRISE_ONLY_TABS gates) for the login/register
+    # privacy-policy link. Cap 1018 -> 1029, exact.
+    "backend/app/core/persistent_config.py": 1029,
     # fix(#1533): first entry — crossed _RATCHET_INCLUSION_LOC on the change
     # that made the run notice the embedding column moving under it. Two
     # guards, both small: _live_column_dims (one pg_attribute read, shared with

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -2881,7 +2881,15 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # round-trip check alone does not catch it; also rejects a decoded
     # control/format/surrogate/private-use/unassigned character explicitly.
     # Cap 1249 -> 1279, exact.
-    "backend/app/core/config.py": 1279,
+    # PRIV-1 (codex r6): +44 — a bracketed authority ("[...]") is now
+    # restricted to a plain, unscoped IPv6 literal rather than falling
+    # through to the DNS-name or numeric-last-label branches once
+    # `.hostname` strips the brackets, which otherwise accepted an
+    # IPvFuture literal ([v1.foo]), an IPv4-in-brackets ([1.2.3.4]), and a
+    # scoped IPv6 zone ID ([fe80::1%eth0]). Split into a small
+    # _is_unscoped_ipv6_literal helper to stay under ruff's cyclomatic
+    # complexity limit. Cap 1279 -> 1323, exact.
+    "backend/app/core/config.py": 1323,
     # fix(#1543): first entry — crossed _RATCHET_INCLUSION_LOC on the change
     # that gave PersistentConfig a batch eviction. The code is small
     # (apply_side_effects_batch, plus splitting the process-local half of

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -2906,7 +2906,18 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # entirely and let idna.encode() (DNS syntax only, no IPv4 opinion)
     # accept "999.999.999.999." and "192.168.1." as ordinary-looking DNS
     # names. Cap 1289 -> 1307, exact.
-    "backend/app/core/config.py": 1307,
+    # PRIV-1 (Ian's own review): +68 — the numeric-last-label check now
+    # runs on the UTS46-mapped ASCII form (idna.encode's output), not the
+    # raw hostname: an ideographic full stop (U+3002, "。") has no ASCII "."
+    # for rsplit to find until mapped, and str.isdigit() is true for a
+    # fullwidth digit ("１"), so the OLD raw-hostname check both missed
+    # "999。999。999。999" (no split point) and wrongly rejected
+    # "１２７.０.０.１" (handed the un-mapped string to IPv4Address). Also
+    # added one docstring paragraph enumerating every place this check is
+    # deliberately stricter than a browser, so a future "browser accepts,
+    # we reject" report is read against that list first. Cap 1307 -> 1375,
+    # exact.
+    "backend/app/core/config.py": 1375,
     # fix(#1543): first entry — crossed _RATCHET_INCLUSION_LOC on the change
     # that gave PersistentConfig a batch eviction. The code is small
     # (apply_side_effects_batch, plus splitting the process-local half of

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -2846,7 +2846,13 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # and rejected embedded tab/newline/CR characters (a documented WHATWG
     # URL scheme-check bypass) in validate_privacy_url_shape.
     # Cap 1161 -> 1168, exact.
-    "backend/app/core/config.py": 1168,
+    # PRIV-1 (codex r1): +12 — validate_privacy_url_shape now rejects an empty
+    # hostname (a netloc like ":443" passes the earlier netloc-truthy check
+    # but resolves nowhere) and a malformed port (urlsplit leaves the junk
+    # sitting in netloc instead of rejecting it; accessing .port is what
+    # actually validates it, same pattern as validate_database_url_override
+    # above). Cap 1168 -> 1180, exact.
+    "backend/app/core/config.py": 1180,
     # fix(#1543): first entry — crossed _RATCHET_INCLUSION_LOC on the change
     # that gave PersistentConfig a batch eviction. The code is small
     # (apply_side_effects_batch, plus splitting the process-local half of

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -2889,7 +2889,12 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # scoped IPv6 zone ID ([fe80::1%eth0]). Split into a small
     # _is_unscoped_ipv6_literal helper to stay under ruff's cyclomatic
     # complexity limit. Cap 1279 -> 1323, exact.
-    "backend/app/core/config.py": 1323,
+    # PRIV-1 (codex r7): +23 — unified the U-label combining-mark check and
+    # the decoded-A-label control-character check into one _check_ulabel
+    # function, called from both sites, so "xn--lsa" (the punycode spelling
+    # of a bare combining mark, which only the A-label check saw) gets the
+    # same verdict as its literal U-label form. Cap 1323 -> 1346, exact.
+    "backend/app/core/config.py": 1346,
     # fix(#1543): first entry — crossed _RATCHET_INCLUSION_LOC on the change
     # that gave PersistentConfig a batch eviction. The code is small
     # (apply_side_effects_batch, plus splitting the process-local half of

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -2852,7 +2852,16 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # sitting in netloc instead of rejecting it; accessing .port is what
     # actually validates it, same pattern as validate_database_url_override
     # above). Cap 1168 -> 1180, exact.
-    "backend/app/core/config.py": 1180,
+    # PRIV-1 (codex r2): +28 — the whitespace check widened from tab/CR/LF
+    # only to any whitespace character (a plain space inside a host is a
+    # WHATWG-vs-urlsplit disagreement too), and a new _is_valid_privacy_url_host
+    # allowlist (DNS labels or an IP literal) replaces trusting whatever
+    # urlsplit left in .hostname. Deliberately not a call to
+    # app.core.public_urls.canonical_host_error, which answers a
+    # near-identical question, because that would be the same circular
+    # import validate_privacy_url_shape's own docstring already rules out.
+    # Cap 1180 -> 1208, exact.
+    "backend/app/core/config.py": 1208,
     # fix(#1543): first entry — crossed _RATCHET_INCLUSION_LOC on the change
     # that gave PersistentConfig a batch eviction. The code is small
     # (apply_side_effects_batch, plus splitting the process-local half of

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -2894,7 +2894,13 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # function, called from both sites, so "xn--lsa" (the punycode spelling
     # of a bare combining mark, which only the A-label check saw) gets the
     # same verdict as its literal U-label form. Cap 1323 -> 1346, exact.
-    "backend/app/core/config.py": 1346,
+    # PRIV-1 (codex r8): -57 (SHRANK) — replaced the hand-rolled DNS-label
+    # regex + _check_ulabel + manual punycode decode/round-trip with one
+    # call to the `idna` package's UTS46 ToASCII (already a direct backend
+    # dependency, pinned in pyproject.toml for a CVE), which enforces the
+    # same rules plus the ones a hand-rolled check missed (U+FE47, which
+    # UTS46 maps to "[" and then rejects). Cap 1346 -> 1289, exact.
+    "backend/app/core/config.py": 1289,
     # fix(#1543): first entry — crossed _RATCHET_INCLUSION_LOC on the change
     # that gave PersistentConfig a batch eviction. The code is small
     # (apply_side_effects_batch, plus splitting the process-local half of

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -2900,7 +2900,13 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # dependency, pinned in pyproject.toml for a CVE), which enforces the
     # same rules plus the ones a hand-rolled check missed (U+FE47, which
     # UTS46 maps to "[" and then rejects). Cap 1346 -> 1289, exact.
-    "backend/app/core/config.py": 1289,
+    # PRIV-1 (codex r9): +18 — a single trailing DNS root dot is now
+    # stripped before the numeric-last-label check: `rsplit(".", 1)[-1]`
+    # on "192.168.1." returns "", which skipped the ends-in-a-number branch
+    # entirely and let idna.encode() (DNS syntax only, no IPv4 opinion)
+    # accept "999.999.999.999." and "192.168.1." as ordinary-looking DNS
+    # names. Cap 1289 -> 1307, exact.
+    "backend/app/core/config.py": 1307,
     # fix(#1543): first entry — crossed _RATCHET_INCLUSION_LOC on the change
     # that gave PersistentConfig a batch eviction. The code is small
     # (apply_side_effects_batch, plus splitting the process-local half of

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -2861,7 +2861,13 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # near-identical question, because that would be the same circular
     # import validate_privacy_url_shape's own docstring already rules out.
     # Cap 1180 -> 1208, exact.
-    "backend/app/core/config.py": 1208,
+    # PRIV-1 (codex r3): +21 — the DNS-label branch alone accepted a
+    # numeric-last-label host ("999.999.999.999", "1.2.3.4.5", "192.168.1")
+    # that a browser reads as an attempted (and often different-resolving)
+    # IPv4 address, per the WHATWG "ends in a number" rule. That branch now
+    # requires the exact canonical dotted-quad spelling instead of falling
+    # through to the DNS-label check. Cap 1208 -> 1229, exact.
+    "backend/app/core/config.py": 1229,
     # fix(#1543): first entry — crossed _RATCHET_INCLUSION_LOC on the change
     # that gave PersistentConfig a batch eviction. The code is small
     # (apply_side_effects_batch, plus splitting the process-local half of

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -2113,7 +2113,11 @@ _OPEN_CORE_SIZE_CAPS: dict[str, int] = {
     # PRIV-1: +7 lines — GET /settings/branding/ also resolves and returns
     # PRIVACY_URL, so the login/register privacy-policy link is admin
     # configurable instead of a hardcoded getgeolens.com URL.
-    "backend/app/modules/settings/router_public.py": 157,
+    # PRIV-1 (pre-review): +18 — the reader re-checks a stored/env privacy_url
+    # against the shape rule and drops (+ logs) an unsafe one instead of
+    # serving it as a login-page <a href>; a stored value can predate the
+    # check or bypass PersistentConfig.set()'s validation entirely.
+    "backend/app/modules/settings/router_public.py": 175,
 }
 
 
@@ -2832,7 +2836,13 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # PRIV-1: +5 — a privacy_url Settings field (env-backed default for the
     # login/register privacy-policy link) plus its empty-string normalizer
     # entry. Cap 1107 -> 1112, exact.
-    "backend/app/core/config.py": 1112,
+    # PRIV-1 (pre-review): +49 — a shared validate_privacy_url_shape helper
+    # (reused by the admin-write validator and the read-path defense in
+    # modules/settings) plus the field_validator that fails boot on an unsafe
+    # PRIVACY_URL. Both are large because they document why the check exists
+    # and why it lives in core/config.py instead of core/public_urls.py
+    # (avoiding a circular import). Cap 1112 -> 1161, exact.
+    "backend/app/core/config.py": 1161,
     # fix(#1543): first entry — crossed _RATCHET_INCLUSION_LOC on the change
     # that gave PersistentConfig a batch eviction. The code is small
     # (apply_side_effects_batch, plus splitting the process-local half of

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -2842,7 +2842,11 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # PRIVACY_URL. Both are large because they document why the check exists
     # and why it lives in core/config.py instead of core/public_urls.py
     # (avoiding a circular import). Cap 1112 -> 1161, exact.
-    "backend/app/core/config.py": 1161,
+    # PRIV-1 (r2 pre-review): +7 — hoisted the urlsplit import to module scope
+    # and rejected embedded tab/newline/CR characters (a documented WHATWG
+    # URL scheme-check bypass) in validate_privacy_url_shape.
+    # Cap 1161 -> 1168, exact.
+    "backend/app/core/config.py": 1168,
     # fix(#1543): first entry — crossed _RATCHET_INCLUSION_LOC on the change
     # that gave PersistentConfig a batch eviction. The code is small
     # (apply_side_effects_batch, plus splitting the process-local half of

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -2867,7 +2867,14 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # IPv4 address, per the WHATWG "ends in a number" rule. That branch now
     # requires the exact canonical dotted-quad spelling instead of falling
     # through to the DNS-label check. Cap 1208 -> 1229, exact.
-    "backend/app/core/config.py": 1229,
+    # PRIV-1 (codex r4): +20 — the DNS-name branch (case 2) now IDNA-encodes
+    # the hostname before applying the label regex, so a browser-valid
+    # internationalized host like 例え.テスト is accepted rather than rejected
+    # by an ASCII-only regex. Also rejects a label that starts with a
+    # Unicode combining mark, which Python's stdlib "idna" codec (IDNA2003)
+    # encodes without error even though no browser accepts it.
+    # Cap 1229 -> 1249, exact.
+    "backend/app/core/config.py": 1249,
     # fix(#1543): first entry — crossed _RATCHET_INCLUSION_LOC on the change
     # that gave PersistentConfig a batch eviction. The code is small
     # (apply_side_effects_batch, plus splitting the process-local half of

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -2874,7 +2874,14 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # Unicode combining mark, which Python's stdlib "idna" codec (IDNA2003)
     # encodes without error even though no browser accepts it.
     # Cap 1229 -> 1249, exact.
-    "backend/app/core/config.py": 1249,
+    # PRIV-1 (codex r5): +30 — a label the operator spelled directly as
+    # ACE/"xn--" punycode (not one this function IDNA-encoded itself) must
+    # decode to a real IDN label. "xn--a" decodes to a bare C1 control byte
+    # (U+0080) without raising and round-trips cleanly back to "a", so the
+    # round-trip check alone does not catch it; also rejects a decoded
+    # control/format/surrogate/private-use/unassigned character explicitly.
+    # Cap 1249 -> 1279, exact.
+    "backend/app/core/config.py": 1279,
     # fix(#1543): first entry — crossed _RATCHET_INCLUSION_LOC on the change
     # that gave PersistentConfig a batch eviction. The code is small
     # (apply_side_effects_batch, plus splitting the process-local half of

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -305,6 +305,7 @@ services:
       PUBLIC_APP_URL: ${PUBLIC_APP_URL:-http://localhost:8080}
       PUBLIC_API_URL: ${PUBLIC_API_URL:-http://localhost:8080/api}
       PUBLIC_BASE_URL: ${PUBLIC_BASE_URL:-}
+      PRIVACY_URL: ${PRIVACY_URL:-}
       DCAT_CONTACT_EMAIL: ${DCAT_CONTACT_EMAIL:-}
       REDIS_URL: "${REDIS_URL:-}"
       CDN_BASE_URL: "${CDN_BASE_URL:-}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -372,6 +372,7 @@ services:
       PUBLIC_APP_URL: ${PUBLIC_APP_URL:-http://localhost:8080}
       PUBLIC_API_URL: ${PUBLIC_API_URL:-http://localhost:8080/api}
       PUBLIC_BASE_URL: ${PUBLIC_BASE_URL:-}
+      PRIVACY_URL: ${PRIVACY_URL:-}
       DCAT_CONTACT_EMAIL: ${DCAT_CONTACT_EMAIL:-}
       REDIS_URL: "${REDIS_URL:-}"
       CDN_BASE_URL: "${CDN_BASE_URL:-}"

--- a/frontend/src/api/__tests__/hand-typed-mirror-drift.test.ts
+++ b/frontend/src/api/__tests__/hand-typed-mirror-drift.test.ts
@@ -115,6 +115,12 @@ const MIRRORS: MirrorShape[] = [
     optional: [],
   },
   {
+    schema: 'BrandingResponse',
+    source: 'settings.ts BrandingConfig',
+    required: ['show_badge'],
+    optional: ['privacy_url'],
+  },
+  {
     schema: 'RelatedDatasetItem',
     source: 'datasets.ts RelatedDatasetItem',
     // geometry_type/record_type/feature_count/band_count are `T | null` (present

--- a/frontend/src/api/settings.ts
+++ b/frontend/src/api/settings.ts
@@ -168,8 +168,8 @@ export async function detectEmbeddingDims(): Promise<DetectEmbeddingDimsResponse
 
 export interface BrandingConfig {
   show_badge: boolean;
-  /** PRIV-1: operator-configured privacy-policy URL, or null when unset. */
-  privacy_url: string | null;
+  /** PRIV-1: operator-configured privacy-policy URL, or null/absent when unset. */
+  privacy_url?: string | null;
 }
 
 export async function getBranding(): Promise<BrandingConfig> {

--- a/frontend/src/api/settings.ts
+++ b/frontend/src/api/settings.ts
@@ -168,6 +168,8 @@ export async function detectEmbeddingDims(): Promise<DetectEmbeddingDimsResponse
 
 export interface BrandingConfig {
   show_badge: boolean;
+  /** PRIV-1: operator-configured privacy-policy URL, or null when unset. */
+  privacy_url: string | null;
 }
 
 export async function getBranding(): Promise<BrandingConfig> {

--- a/frontend/src/components/admin/settings/SettingsGeneralTab.tsx
+++ b/frontend/src/components/admin/settings/SettingsGeneralTab.tsx
@@ -27,6 +27,7 @@ const FIELDS = [
   { key: 'banner_color', defaultValue: 'warning' },
   { key: 'public_app_url', defaultValue: '' },
   { key: 'public_api_url', defaultValue: '' },
+  { key: 'privacy_url', defaultValue: '' },
   { key: 'log_level', defaultValue: 'INFO' },
   { key: 'log_json', defaultValue: false },
 ] as const;
@@ -147,6 +148,22 @@ export function SettingsGeneralTab({ settings, envOnly, onSave, onReset, isSavin
           type="text"
           value={values.public_api_url as string}
           onChange={(e) => setters.public_api_url(e.target.value)}
+          disabled={envOnly}
+          className="max-w-md"
+        />
+      </div>
+
+      <div className="space-y-2">
+        <div className="flex items-center gap-2">
+          <Label htmlFor="privacy-url">{t('settings.general.privacyUrl')}</Label>
+          <SettingSourceBadge source={findSetting(settings, 'privacy_url')?.source ?? 'default'} settingKey="privacy_url" onReset={onReset} />
+        </div>
+        <p className="text-sm text-muted-foreground">{t('settings.general.privacyUrlDescription')}</p>
+        <Input
+          id="privacy-url"
+          type="text"
+          value={values.privacy_url as string}
+          onChange={(e) => setters.privacy_url(e.target.value)}
           disabled={envOnly}
           className="max-w-md"
         />

--- a/frontend/src/components/auth/RegisterForm.tsx
+++ b/frontend/src/components/auth/RegisterForm.tsx
@@ -15,6 +15,7 @@ import {
   CardTitle,
 } from '@/components/ui/card';
 import { useBranding } from '@/hooks/use-settings';
+import { isSafeHttpUrl } from '@/lib/safe-http-url';
 
 interface RegisterFormProps {
   onSuccess: (
@@ -31,6 +32,7 @@ export function RegisterForm({ onSuccess }: RegisterFormProps) {
   const [loading, setLoading] = useState(false);
   const { t } = useTranslation('auth');
   const { data: branding } = useBranding();
+  const privacyUrl = branding?.privacy_url;
 
   async function handleSubmit(e: FormEvent) {
     e.preventDefault();
@@ -118,11 +120,11 @@ export function RegisterForm({ onSuccess }: RegisterFormProps) {
               {t('signIn')}
             </Link>
           </p>
-          {branding?.privacy_url && (
+          {isSafeHttpUrl(privacyUrl) && (
             <p className="text-center text-xs text-muted-foreground">
               {t('consentNote')}{' '}
               <a
-                href={branding.privacy_url}
+                href={privacyUrl}
                 target="_blank"
                 rel="noopener noreferrer"
                 className="underline hover:text-foreground"

--- a/frontend/src/components/auth/RegisterForm.tsx
+++ b/frontend/src/components/auth/RegisterForm.tsx
@@ -14,7 +14,7 @@ import {
   CardHeader,
   CardTitle,
 } from '@/components/ui/card';
-import { GEOLENS_PRIVACY_URL } from '@/lib/external-links';
+import { useBranding } from '@/hooks/use-settings';
 
 interface RegisterFormProps {
   onSuccess: (
@@ -30,6 +30,7 @@ export function RegisterForm({ onSuccess }: RegisterFormProps) {
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
   const { t } = useTranslation('auth');
+  const { data: branding } = useBranding();
 
   async function handleSubmit(e: FormEvent) {
     e.preventDefault();
@@ -117,18 +118,20 @@ export function RegisterForm({ onSuccess }: RegisterFormProps) {
               {t('signIn')}
             </Link>
           </p>
-          <p className="text-center text-xs text-muted-foreground">
-            {t('consentNote')}{' '}
-            <a
-              href={GEOLENS_PRIVACY_URL}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="underline hover:text-foreground"
-            >
-              {t('privacyPolicy')}
-            </a>
-            {t('consentNoteSuffix')}
-          </p>
+          {branding?.privacy_url && (
+            <p className="text-center text-xs text-muted-foreground">
+              {t('consentNote')}{' '}
+              <a
+                href={branding.privacy_url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="underline hover:text-foreground"
+              >
+                {t('privacyPolicy')}
+              </a>
+              {t('consentNoteSuffix')}
+            </p>
+          )}
         </form>
       </CardContent>
     </Card>

--- a/frontend/src/components/auth/__tests__/RegisterForm.test.tsx
+++ b/frontend/src/components/auth/__tests__/RegisterForm.test.tsx
@@ -1,12 +1,25 @@
 import { render, screen } from '@/test/test-utils';
 import userEvent from '@testing-library/user-event';
 import { RegisterForm } from '../RegisterForm';
+import { useBranding } from '@/hooks/use-settings';
 
 vi.mock('@/api/auth', () => ({
   registerUser: vi.fn().mockResolvedValue({ message: 'ok' }),
 }));
 
+vi.mock('@/hooks/use-settings', () => ({
+  useBranding: vi.fn(),
+}));
+
+const mockedUseBranding = vi.mocked(useBranding);
+
 describe('RegisterForm', () => {
+  beforeEach(() => {
+    mockedUseBranding.mockReturnValue({
+      data: { show_badge: true, privacy_url: null },
+    } as ReturnType<typeof useBranding>);
+  });
+
   it('renders username, email, and password fields', () => {
     render(<RegisterForm onSuccess={vi.fn()} />);
 
@@ -46,5 +59,24 @@ describe('RegisterForm', () => {
     const signInLink = screen.getByRole('link', { name: /sign in/i });
     expect(signInLink).toBeInTheDocument();
     expect(signInLink).toHaveAttribute('href', '/login');
+  });
+
+  it('shows the privacy policy link when the operator has configured one', () => {
+    mockedUseBranding.mockReturnValue({
+      data: { show_badge: true, privacy_url: 'https://operator.example.com/privacy' },
+    } as ReturnType<typeof useBranding>);
+    render(<RegisterForm onSuccess={vi.fn()} />);
+
+    const privacyLink = screen.getByRole('link', { name: /privacy policy/i });
+    expect(privacyLink).toHaveAttribute('href', 'https://operator.example.com/privacy');
+  });
+
+  it('hides the privacy policy link when no privacy URL is configured', () => {
+    mockedUseBranding.mockReturnValue({
+      data: { show_badge: true, privacy_url: null },
+    } as ReturnType<typeof useBranding>);
+    render(<RegisterForm onSuccess={vi.fn()} />);
+
+    expect(screen.queryByRole('link', { name: /privacy policy/i })).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/components/auth/__tests__/RegisterForm.test.tsx
+++ b/frontend/src/components/auth/__tests__/RegisterForm.test.tsx
@@ -77,6 +77,25 @@ describe('RegisterForm', () => {
     } as ReturnType<typeof useBranding>);
     render(<RegisterForm onSuccess={vi.fn()} />);
 
+    // The link alone is not enough: an <a> with no href has role "generic",
+    // not "link", so a gate that only hid the anchor (leaving the "By
+    // signing in you agree to our ." copy behind, sentence and all) would
+    // still pass a role-only query. Assert the whole paragraph is gone.
     expect(screen.queryByRole('link', { name: /privacy policy/i })).not.toBeInTheDocument();
+    expect(screen.queryByText(/agree to our/i)).not.toBeInTheDocument();
+  });
+
+  it('does not render the link for an unsafe stored value (client-side scheme guard)', () => {
+    // The backend validates privacy_url three times over (admin write, boot,
+    // read), but a rolling upgrade can have a stale API pod still serving a
+    // pre-check value. This is the client-side belt-and-braces guard for
+    // that window, not a re-test of the backend's own validation.
+    mockedUseBranding.mockReturnValue({
+      data: { show_badge: true, privacy_url: 'javascript:alert(document.cookie)' },
+    } as ReturnType<typeof useBranding>);
+    render(<RegisterForm onSuccess={vi.fn()} />);
+
+    expect(screen.queryByRole('link', { name: /privacy policy/i })).not.toBeInTheDocument();
+    expect(screen.queryByText(/agree to our/i)).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/components/layout/__tests__/AppLayout.test.tsx
+++ b/frontend/src/components/layout/__tests__/AppLayout.test.tsx
@@ -69,7 +69,7 @@ describe('AppLayout', () => {
       isResolved: true,
     });
     mockedUseBranding.mockReturnValue({
-      data: { show_badge: true },
+      data: { show_badge: true, privacy_url: null },
     } as ReturnType<typeof useBranding>);
   });
 
@@ -256,7 +256,7 @@ describe('AppLayout', () => {
       isResolved: true,
     });
     mockedUseBranding.mockReturnValue({
-      data: { show_badge: false },
+      data: { show_badge: false, privacy_url: null },
     } as ReturnType<typeof useBranding>);
     renderAppLayout();
     const footer = screen.getByRole('contentinfo');
@@ -275,7 +275,7 @@ describe('AppLayout', () => {
       isResolved: true,
     });
     mockedUseBranding.mockReturnValue({
-      data: { show_badge: true },
+      data: { show_badge: true, privacy_url: null },
     } as ReturnType<typeof useBranding>);
     renderAppLayout();
     expect(screen.getByRole('contentinfo')).toHaveTextContent('Powered by GeoLens');
@@ -283,7 +283,7 @@ describe('AppLayout', () => {
 
   it('always shows Powered by GeoLens branding in community mode regardless of branding setting', () => {
     mockedUseBranding.mockReturnValue({
-      data: { show_badge: false },
+      data: { show_badge: false, privacy_url: null },
     } as ReturnType<typeof useBranding>);
     renderAppLayout();
     expect(screen.getByRole('contentinfo')).toHaveTextContent('Powered by GeoLens');

--- a/frontend/src/components/viewer/__tests__/ViewerMap.branding.test.tsx
+++ b/frontend/src/components/viewer/__tests__/ViewerMap.branding.test.tsx
@@ -101,7 +101,7 @@ describe('ViewerMap — SHARE-07 branding overlay', () => {
       isResolved: true,
     });
     mockedUseBranding.mockReturnValue({
-      data: { show_badge: true },
+      data: { show_badge: true, privacy_url: null },
     } as ReturnType<typeof useBranding>);
 
     render(<ViewerMap {...MINIMAL_PROPS} showInlineBranding={true} />);
@@ -120,7 +120,7 @@ describe('ViewerMap — SHARE-07 branding overlay', () => {
       isResolved: true,
     });
     mockedUseBranding.mockReturnValue({
-      data: { show_badge: false },
+      data: { show_badge: false, privacy_url: null },
     } as ReturnType<typeof useBranding>);
 
     render(<ViewerMap {...MINIMAL_PROPS} showInlineBranding={true} />);
@@ -138,7 +138,7 @@ describe('ViewerMap — SHARE-07 branding overlay', () => {
       isResolved: true,
     });
     mockedUseBranding.mockReturnValue({
-      data: { show_badge: true },
+      data: { show_badge: true, privacy_url: null },
     } as ReturnType<typeof useBranding>);
 
     render(<ViewerMap {...MINIMAL_PROPS} showInlineBranding={true} />);

--- a/frontend/src/i18n/locales/de/admin.json
+++ b/frontend/src/i18n/locales/de/admin.json
@@ -475,6 +475,8 @@
       "publicApiUrl": "Öffentliche API-URL",
       "publicApiUrlDescription": "Die extern erreichbare API-Basis. Bei pfadbasierten Deployments sollte sie der App-URL + /api entsprechen.",
       "publicBaseUrl": "Öffentliche Basis-URL",
+      "privacyUrl": "URL der Datenschutzerklärung",
+      "privacyUrlDescription": "Wird als Link auf den Anmelde- und Registrierungsseiten angezeigt. Leer lassen, um den Link auszublenden.",
       "logLevel": "Protokollierungsstufe",
       "logJsonLabel": "Protokollformat (JSON)",
       "logJsonDescription": "Protokolle im strukturierten JSON-Format ausgeben."

--- a/frontend/src/i18n/locales/de/admin.json
+++ b/frontend/src/i18n/locales/de/admin.json
@@ -476,7 +476,7 @@
       "publicApiUrlDescription": "Die extern erreichbare API-Basis. Bei pfadbasierten Deployments sollte sie der App-URL + /api entsprechen.",
       "publicBaseUrl": "Öffentliche Basis-URL",
       "privacyUrl": "URL der Datenschutzerklärung",
-      "privacyUrlDescription": "Wird als Link auf den Anmelde- und Registrierungsseiten angezeigt. Leer lassen, um den Link auszublenden.",
+      "privacyUrlDescription": "Wird als Link auf den Anmelde- und Registrierungsseiten angezeigt. Leer lassen, um den Link auszublenden. Muss eine vollständige http(s)-URL sein.",
       "logLevel": "Protokollierungsstufe",
       "logJsonLabel": "Protokollformat (JSON)",
       "logJsonDescription": "Protokolle im strukturierten JSON-Format ausgeben."

--- a/frontend/src/i18n/locales/de/auth.json
+++ b/frontend/src/i18n/locales/de/auth.json
@@ -87,7 +87,7 @@
   "supportHint": "Brauchen Sie Zugang oder eine Passwortzurücksetzung? Wenden Sie sich an einen GeoLens-Administrator.",
   "consentNote": "Mit der Anmeldung stimmen Sie unserer",
   "privacyPolicy": "Datenschutzrichtlinie",
-  "consentNoteSuffix": " zu. Wir informieren Sie ggf. über GeoLens.",
+  "consentNoteSuffix": " zu.",
   "verifyEmail": {
     "title": "E-Mail-Adresse bestätigen",
     "verifying": "Ihre E-Mail-Adresse wird überprüft, bitte warten...",

--- a/frontend/src/i18n/locales/en/admin.json
+++ b/frontend/src/i18n/locales/en/admin.json
@@ -523,6 +523,8 @@
       "publicApiUrl": "Public API URL",
       "publicApiUrlDescription": "The externally reachable API base. Leave it aligned with your app URL + /api for path-based deployments.",
       "publicBaseUrl": "Public Base URL",
+      "privacyUrl": "Privacy Policy URL",
+      "privacyUrlDescription": "Shown as a link on the login and register pages. Leave empty to hide the link.",
       "logLevel": "Log Level",
       "logJsonLabel": "Log Format (JSON)",
       "logJsonDescription": "Output logs in structured JSON format.",

--- a/frontend/src/i18n/locales/en/admin.json
+++ b/frontend/src/i18n/locales/en/admin.json
@@ -524,7 +524,7 @@
       "publicApiUrlDescription": "The externally reachable API base. Leave it aligned with your app URL + /api for path-based deployments.",
       "publicBaseUrl": "Public Base URL",
       "privacyUrl": "Privacy Policy URL",
-      "privacyUrlDescription": "Shown as a link on the login and register pages. Leave empty to hide the link.",
+      "privacyUrlDescription": "Shown as a link on the login and register pages. Leave empty to hide the link. Must be a full http(s) URL.",
       "logLevel": "Log Level",
       "logJsonLabel": "Log Format (JSON)",
       "logJsonDescription": "Output logs in structured JSON format.",

--- a/frontend/src/i18n/locales/en/auth.json
+++ b/frontend/src/i18n/locales/en/auth.json
@@ -87,7 +87,7 @@
   "supportHint": "Need access or a password reset? Contact a GeoLens administrator.",
   "consentNote": "By signing in you agree to our",
   "privacyPolicy": "Privacy Policy",
-  "consentNoteSuffix": ". We may contact you about GeoLens.",
+  "consentNoteSuffix": ".",
   "verifyEmail": {
     "title": "Verify Your Email",
     "verifying": "Verifying your email address, please wait...",

--- a/frontend/src/i18n/locales/es/admin.json
+++ b/frontend/src/i18n/locales/es/admin.json
@@ -475,6 +475,8 @@
       "publicApiUrl": "URL pública de la API",
       "publicApiUrlDescription": "La base externa de la API. Déjala alineada con la URL de la aplicación + /api en despliegues con rutas.",
       "publicBaseUrl": "URL base pública",
+      "privacyUrl": "URL de la política de privacidad",
+      "privacyUrlDescription": "Se muestra como enlace en las páginas de inicio de sesión y registro. Déjalo vacío para ocultar el enlace.",
       "logLevel": "Nivel de registro",
       "logJsonLabel": "Formato de registro (JSON)",
       "logJsonDescription": "Registros de salida en formato JSON estructurado."

--- a/frontend/src/i18n/locales/es/admin.json
+++ b/frontend/src/i18n/locales/es/admin.json
@@ -476,7 +476,7 @@
       "publicApiUrlDescription": "La base externa de la API. Déjala alineada con la URL de la aplicación + /api en despliegues con rutas.",
       "publicBaseUrl": "URL base pública",
       "privacyUrl": "URL de la política de privacidad",
-      "privacyUrlDescription": "Se muestra como enlace en las páginas de inicio de sesión y registro. Déjalo vacío para ocultar el enlace.",
+      "privacyUrlDescription": "Se muestra como enlace en las páginas de inicio de sesión y registro. Déjalo vacío para ocultar el enlace. Debe ser una URL http(s) completa.",
       "logLevel": "Nivel de registro",
       "logJsonLabel": "Formato de registro (JSON)",
       "logJsonDescription": "Registros de salida en formato JSON estructurado."

--- a/frontend/src/i18n/locales/es/auth.json
+++ b/frontend/src/i18n/locales/es/auth.json
@@ -87,7 +87,7 @@
   "supportHint": "Necesitas acceso o restablecimiento de contraseña? Contacta a un administrador de GeoLens.",
   "consentNote": "Al iniciar sesión, acepta nuestra",
   "privacyPolicy": "Política de privacidad",
-  "consentNoteSuffix": ". Podemos contactarle sobre GeoLens.",
+  "consentNoteSuffix": ".",
   "verifyEmail": {
     "title": "Verificar su correo electrónico",
     "verifying": "Verificando su dirección de correo electrónico, por favor espere...",

--- a/frontend/src/i18n/locales/fr/admin.json
+++ b/frontend/src/i18n/locales/fr/admin.json
@@ -476,7 +476,7 @@
       "publicApiUrlDescription": "La base API accessible publiquement. Gardez-la alignée sur l'URL de l'application + /api pour les déploiements par chemin.",
       "publicBaseUrl": "URL de base publique",
       "privacyUrl": "URL de la politique de confidentialité",
-      "privacyUrlDescription": "Affichée comme lien sur les pages de connexion et d'inscription. Laissez vide pour masquer le lien.",
+      "privacyUrlDescription": "Affichée comme lien sur les pages de connexion et d'inscription. Laissez vide pour masquer le lien. Doit être une URL http(s) complète.",
       "logLevel": "Niveau de journalisation",
       "logJsonLabel": "Format de journal (JSON)",
       "logJsonDescription": "Journaux de sortie au format JSON structuré."

--- a/frontend/src/i18n/locales/fr/admin.json
+++ b/frontend/src/i18n/locales/fr/admin.json
@@ -475,6 +475,8 @@
       "publicApiUrl": "URL publique de l'API",
       "publicApiUrlDescription": "La base API accessible publiquement. Gardez-la alignée sur l'URL de l'application + /api pour les déploiements par chemin.",
       "publicBaseUrl": "URL de base publique",
+      "privacyUrl": "URL de la politique de confidentialité",
+      "privacyUrlDescription": "Affichée comme lien sur les pages de connexion et d'inscription. Laissez vide pour masquer le lien.",
       "logLevel": "Niveau de journalisation",
       "logJsonLabel": "Format de journal (JSON)",
       "logJsonDescription": "Journaux de sortie au format JSON structuré."

--- a/frontend/src/i18n/locales/fr/auth.json
+++ b/frontend/src/i18n/locales/fr/auth.json
@@ -87,7 +87,7 @@
   "supportHint": "Besoin d'accès ou de réinitialisation du mot de passe ? Contactez un administrateur GeoLens.",
   "consentNote": "En vous connectant, vous acceptez notre",
   "privacyPolicy": "Politique de confidentialité",
-  "consentNoteSuffix": ". Nous pouvons vous contacter à propos de GeoLens.",
+  "consentNoteSuffix": ".",
   "verifyEmail": {
     "title": "Vérifier votre adresse e-mail",
     "verifying": "Vérification de votre adresse e-mail, veuillez patienter...",

--- a/frontend/src/lib/__tests__/safe-http-url.test.ts
+++ b/frontend/src/lib/__tests__/safe-http-url.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { isSafeHttpUrl } from '@/lib/safe-http-url';
+
+describe('isSafeHttpUrl', () => {
+  it('accepts http and https URLs', () => {
+    expect(isSafeHttpUrl('https://example.com/privacy')).toBe(true);
+    expect(isSafeHttpUrl('http://example.com/privacy')).toBe(true);
+  });
+
+  it('is case-insensitive on the scheme', () => {
+    expect(isSafeHttpUrl('HTTPS://example.com/privacy')).toBe(true);
+  });
+
+  it('rejects a javascript: value', () => {
+    expect(isSafeHttpUrl('javascript:alert(document.cookie)')).toBe(false);
+  });
+
+  it('rejects a data: value', () => {
+    expect(isSafeHttpUrl('data:text/html,<script>alert(1)</script>')).toBe(false);
+  });
+
+  it('rejects a scheme-relative value', () => {
+    expect(isSafeHttpUrl('//evil.example.com/p')).toBe(false);
+  });
+
+  it('rejects null, undefined, and non-string input', () => {
+    expect(isSafeHttpUrl(null)).toBe(false);
+    expect(isSafeHttpUrl(undefined)).toBe(false);
+  });
+});

--- a/frontend/src/lib/external-links.ts
+++ b/frontend/src/lib/external-links.ts
@@ -4,8 +4,6 @@ export const GEOLENS_BUG_REPORT_URL = `${GEOLENS_GITHUB_URL}/issues/new?template
 export const GEOLENS_DISCUSSIONS_URL = 'https://github.com/geolens-io/geolens/discussions';
 export const GEOLENS_LICENSE_URL = 'https://github.com/geolens-io/geolens/blob/main/LICENSE';
 export const GEOLENS_DOCS_URL = 'https://docs.getgeolens.com/';
-// Privacy policy page — the page returns 404 today; it will be added in the marketing-site phase.
-export const GEOLENS_PRIVACY_URL = 'https://getgeolens.com/privacy';
 
 // Footer "API" link. Points at the canonical public API guide (always 200) rather
 // than the instance's /api/docs Swagger, which 404s whenever interactive docs are

--- a/frontend/src/lib/safe-http-url.ts
+++ b/frontend/src/lib/safe-http-url.ts
@@ -1,0 +1,17 @@
+/**
+ * PRIV-1: belt-and-braces client-side scheme guard for an operator-configured
+ * URL rendered as a raw `<a href>` (privacy_url).
+ *
+ * The backend already validates this three times — at admin write (PUT
+ * /settings/), at boot (an unsafe env value refuses to start), and again at
+ * read time (GET /settings/branding/ drops an unsafe stored value instead of
+ * serving it) — all through the same shape check. This is not the source of
+ * truth for "safe"; it exists for the rolling-upgrade window where an old
+ * API pod can still be serving a value written before any of those checks
+ * existed, and a frontend build with this guard should not trust it blindly.
+ */
+const HTTP_URL_PATTERN = /^https?:\/\//i;
+
+export function isSafeHttpUrl(value: string | null | undefined): value is string {
+  return typeof value === 'string' && HTTP_URL_PATTERN.test(value);
+}

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -14,6 +14,7 @@ import { OAuthButtons } from '@/components/auth/OAuthButtons';
 import { Button } from '@/components/ui/button';
 import { useDocumentTitle } from '@/hooks/use-document-title';
 import { useBranding } from '@/hooks/use-settings';
+import { isSafeHttpUrl } from '@/lib/safe-http-url';
 import { writeSessionStorage } from '@/lib/storage';
 
 function getOAuthErrorMessage(error: string, t: (key: string, opts?: Record<string, string>) => string): string {
@@ -214,6 +215,7 @@ export function LoginPage() {
   const { t } = useTranslation('auth');
   useDocumentTitle(t('common:pageTitle.login'));
   const { data: branding } = useBranding();
+  const privacyUrl = branding?.privacy_url;
   const token = useAuthStore((s) => s.token);
   const location = useLocation();
   const navigate = useNavigate();
@@ -403,11 +405,11 @@ export function LoginPage() {
           </div>
 
           {/* Legal */}
-          {branding?.privacy_url && (
+          {isSafeHttpUrl(privacyUrl) && (
             <p className="mt-5 text-center text-mini leading-relaxed text-muted-foreground">
               {t('consentNote')}{' '}
               <a
-                href={branding.privacy_url}
+                href={privacyUrl}
                 target="_blank"
                 rel="noopener noreferrer"
                 className="underline decoration-border underline-offset-2 hover:text-foreground"

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -13,7 +13,7 @@ import { LoginForm } from '@/components/auth/LoginForm';
 import { OAuthButtons } from '@/components/auth/OAuthButtons';
 import { Button } from '@/components/ui/button';
 import { useDocumentTitle } from '@/hooks/use-document-title';
-import { GEOLENS_PRIVACY_URL } from '@/lib/external-links';
+import { useBranding } from '@/hooks/use-settings';
 import { writeSessionStorage } from '@/lib/storage';
 
 function getOAuthErrorMessage(error: string, t: (key: string, opts?: Record<string, string>) => string): string {
@@ -213,6 +213,7 @@ function BrandMapBackdrop() {
 export function LoginPage() {
   const { t } = useTranslation('auth');
   useDocumentTitle(t('common:pageTitle.login'));
+  const { data: branding } = useBranding();
   const token = useAuthStore((s) => s.token);
   const location = useLocation();
   const navigate = useNavigate();
@@ -402,18 +403,20 @@ export function LoginPage() {
           </div>
 
           {/* Legal */}
-          <p className="mt-5 text-center text-mini leading-relaxed text-muted-foreground">
-            {t('consentNote')}{' '}
-            <a
-              href={GEOLENS_PRIVACY_URL}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="underline decoration-border underline-offset-2 hover:text-foreground"
-            >
-              {t('privacyPolicy')}
-            </a>
-            {t('consentNoteSuffix')}
-          </p>
+          {branding?.privacy_url && (
+            <p className="mt-5 text-center text-mini leading-relaxed text-muted-foreground">
+              {t('consentNote')}{' '}
+              <a
+                href={branding.privacy_url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="underline decoration-border underline-offset-2 hover:text-foreground"
+              >
+                {t('privacyPolicy')}
+              </a>
+              {t('consentNoteSuffix')}
+            </p>
+          )}
 
           {/* Signup gate (#266): show when allow_signup is true;
               fall back to registration_enabled for older servers. */}

--- a/frontend/src/pages/__tests__/LoginPage.privacyUrl.test.tsx
+++ b/frontend/src/pages/__tests__/LoginPage.privacyUrl.test.tsx
@@ -1,0 +1,108 @@
+/**
+ * PRIV-1: the login page's privacy-policy link is per-instance config, not a
+ * hardcoded getgeolens.com URL. The consent paragraph only makes sense with a
+ * link in it ("agree to our [Privacy Policy]"), so the whole paragraph is
+ * gated on `privacy_url`, not just the anchor.
+ */
+import { render, screen, waitFor } from '@/test/test-utils';
+import { MemoryRouter, Routes, Route } from 'react-router';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { TooltipProvider } from '@/components/ui/tooltip';
+import { useAuthStore } from '@/stores/auth-store';
+import { useBranding } from '@/hooks/use-settings';
+
+vi.mock('sonner', () => ({
+  toast: { error: vi.fn(), info: vi.fn(), success: vi.fn(), warning: vi.fn() },
+}));
+
+vi.mock('@/hooks/use-auth', () => ({
+  useAuth: () => ({
+    login: vi.fn(),
+    logout: vi.fn(),
+    token: null,
+    user: null,
+    isAdmin: false,
+    isEditor: false,
+  }),
+}));
+
+const mockGetAuthConfig = vi.fn();
+const mockGetOAuthProviders = vi.fn();
+vi.mock('@/api/auth', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/api/auth')>();
+  return {
+    ...actual,
+    getAuthConfig: () => mockGetAuthConfig(),
+    getOAuthProviders: () => mockGetOAuthProviders(),
+  };
+});
+
+vi.mock('@/hooks/use-settings', () => ({
+  useBranding: vi.fn(),
+}));
+const mockedUseBranding = vi.mocked(useBranding);
+
+// Import after mocks.
+import { LoginPage } from '../LoginPage';
+
+function makeWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  });
+  function Wrapper({ children: _children }: { children: React.ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>
+        <TooltipProvider>
+          <MemoryRouter initialEntries={['/login']}>
+            <Routes>
+              <Route path="/login" element={<LoginPage />} />
+              <Route path="/" element={<div>HOME</div>} />
+            </Routes>
+          </MemoryRouter>
+        </TooltipProvider>
+      </QueryClientProvider>
+    );
+  }
+  return { Wrapper };
+}
+
+describe('LoginPage privacy-policy link (PRIV-1)', () => {
+  beforeEach(() => {
+    useAuthStore.setState({ token: null, refreshToken: null, expiresAt: null, user: null });
+    vi.clearAllMocks();
+    mockGetAuthConfig.mockResolvedValue({
+      registration_enabled: false,
+      password_login_enabled: true,
+    });
+    mockGetOAuthProviders.mockResolvedValue([]);
+  });
+
+  it('shows the privacy policy link when the operator has configured one', async () => {
+    mockedUseBranding.mockReturnValue({
+      data: { show_badge: true, privacy_url: 'https://operator.example.com/privacy' },
+    } as ReturnType<typeof useBranding>);
+
+    const { Wrapper } = makeWrapper();
+    render(<LoginPage />, { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/username/i)).toBeInTheDocument();
+    });
+    const privacyLink = screen.getByRole('link', { name: /privacy policy/i });
+    expect(privacyLink).toHaveAttribute('href', 'https://operator.example.com/privacy');
+  });
+
+  it('hides the consent paragraph when no privacy URL is configured', async () => {
+    mockedUseBranding.mockReturnValue({
+      data: { show_badge: true, privacy_url: null },
+    } as ReturnType<typeof useBranding>);
+
+    const { Wrapper } = makeWrapper();
+    render(<LoginPage />, { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/username/i)).toBeInTheDocument();
+    });
+    expect(screen.queryByRole('link', { name: /privacy policy/i })).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/__tests__/LoginPage.privacyUrl.test.tsx
+++ b/frontend/src/pages/__tests__/LoginPage.privacyUrl.test.tsx
@@ -49,13 +49,16 @@ function makeWrapper() {
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false, gcTime: 0 } },
   });
-  function Wrapper({ children: _children }: { children: React.ReactNode }) {
+  // Renders `children` (the `ui` passed to `render(ui, { wrapper: Wrapper })`)
+  // at the /login route, rather than a second, independent <LoginPage />
+  // that happened to look the same as what the test actually passed in.
+  function Wrapper({ children }: { children: React.ReactNode }) {
     return (
       <QueryClientProvider client={queryClient}>
         <TooltipProvider>
           <MemoryRouter initialEntries={['/login']}>
             <Routes>
-              <Route path="/login" element={<LoginPage />} />
+              <Route path="/login" element={children} />
               <Route path="/" element={<div>HOME</div>} />
             </Routes>
           </MemoryRouter>
@@ -103,6 +106,30 @@ describe('LoginPage privacy-policy link (PRIV-1)', () => {
     await waitFor(() => {
       expect(screen.getByLabelText(/username/i)).toBeInTheDocument();
     });
+    // The link alone is not enough: an <a> with no href has role "generic",
+    // not "link", so a gate that only hid the anchor (leaving the "By
+    // signing in you agree to our ." copy behind, sentence and all) would
+    // still pass a role-only query. Assert the whole paragraph is gone.
     expect(screen.queryByRole('link', { name: /privacy policy/i })).not.toBeInTheDocument();
+    expect(screen.queryByText(/agree to our/i)).not.toBeInTheDocument();
+  });
+
+  it('does not render the link for an unsafe stored value (client-side scheme guard)', async () => {
+    // The backend validates privacy_url three times over (admin write, boot,
+    // read), but a rolling upgrade can have a stale API pod still serving a
+    // pre-check value. This is the client-side belt-and-braces guard for
+    // that window, not a re-test of the backend's own validation.
+    mockedUseBranding.mockReturnValue({
+      data: { show_badge: true, privacy_url: 'javascript:alert(document.cookie)' },
+    } as ReturnType<typeof useBranding>);
+
+    const { Wrapper } = makeWrapper();
+    render(<LoginPage />, { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/username/i)).toBeInTheDocument();
+    });
+    expect(screen.queryByRole('link', { name: /privacy policy/i })).not.toBeInTheDocument();
+    expect(screen.queryByText(/agree to our/i)).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/__tests__/PublicViewerPage.test.tsx
+++ b/frontend/src/pages/__tests__/PublicViewerPage.test.tsx
@@ -149,7 +149,7 @@ describe('PublicViewerPage', () => {
     });
 
     mockedUseBranding.mockReturnValue({
-      data: { show_badge: false },
+      data: { show_badge: false, privacy_url: null },
     } as ReturnType<typeof useBranding>);
   });
 

--- a/frontend/src/types/api.generated.ts
+++ b/frontend/src/types/api.generated.ts
@@ -4525,6 +4525,12 @@ export interface paths {
          *     keys. PersistentConfig overrides take precedence when set. Community
          *     advertises read-only ``show_badge`` only; badge-removal writes and
          *     additional branding keys are restricted controls.
+         *
+         *     ``privacy_url`` (PRIV-1) rides on this same public, unauthenticated
+         *     surface even though it lives on the "general" tab, not "branding": it is
+         *     the one config bundle already fetched pre-auth (login/register need it
+         *     before a session exists), so reusing it avoids a second endpoint for one
+         *     optional string.
          */
         get: operations["get_branding_settings_branding__get"];
         put?: never;
@@ -6129,6 +6135,11 @@ export interface components {
              * @description Whether to show the 'Powered by GeoLens' label in public and shared footers. Badge-removal writes are restricted controls.
              */
             show_badge: boolean;
+            /**
+             * Privacy Url
+             * @description Operator-configured privacy-policy URL shown on the login and register pages, or null when unset (no link is shown).
+             */
+            privacy_url?: string | null;
         };
         /** BulkDeleteItem */
         BulkDeleteItem: {

--- a/frontend/src/types/api.generated.ts
+++ b/frontend/src/types/api.generated.ts
@@ -4525,12 +4525,6 @@ export interface paths {
          *     keys. PersistentConfig overrides take precedence when set. Community
          *     advertises read-only ``show_badge`` only; badge-removal writes and
          *     additional branding keys are restricted controls.
-         *
-         *     ``privacy_url`` (PRIV-1) rides on this same public, unauthenticated
-         *     surface even though it lives on the "general" tab, not "branding": it is
-         *     the one config bundle already fetched pre-auth (login/register need it
-         *     before a session exists), so reusing it avoids a second endpoint for one
-         *     optional string.
          */
         get: operations["get_branding_settings_branding__get"];
         put?: never;
@@ -6137,7 +6131,7 @@ export interface components {
             show_badge: boolean;
             /**
              * Privacy Url
-             * @description Operator-configured privacy-policy URL shown on the login and register pages, or null when unset (no link is shown).
+             * @description Operator-configured privacy-policy URL shown on the login and register pages, or null when unset (no link is shown). Must be an absolute http(s) URL with no embedded credentials; a query string or fragment is allowed and preserved as-is.
              */
             privacy_url?: string | null;
         };

--- a/sdks/python/geolens/api/admin/get_branding_settings_branding_get.py
+++ b/sdks/python/geolens/api/admin/get_branding_settings_branding_get.py
@@ -65,7 +65,7 @@ def sync_detailed(
     *,
     client: AuthenticatedClient | Client,
 ) -> Response[BrandingResponse | ProblemDetail]:
-    r"""Get Branding
+    """Get Branding
 
      Return branding configuration (public, no auth required).
 
@@ -73,12 +73,6 @@ def sync_detailed(
     keys. PersistentConfig overrides take precedence when set. Community
     advertises read-only ``show_badge`` only; badge-removal writes and
     additional branding keys are restricted controls.
-
-    ``privacy_url`` (PRIV-1) rides on this same public, unauthenticated
-    surface even though it lives on the \"general\" tab, not \"branding\": it is
-    the one config bundle already fetched pre-auth (login/register need it
-    before a session exists), so reusing it avoids a second endpoint for one
-    optional string.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -101,7 +95,7 @@ def sync(
     *,
     client: AuthenticatedClient | Client,
 ) -> BrandingResponse | ProblemDetail | None:
-    r"""Get Branding
+    """Get Branding
 
      Return branding configuration (public, no auth required).
 
@@ -109,12 +103,6 @@ def sync(
     keys. PersistentConfig overrides take precedence when set. Community
     advertises read-only ``show_badge`` only; badge-removal writes and
     additional branding keys are restricted controls.
-
-    ``privacy_url`` (PRIV-1) rides on this same public, unauthenticated
-    surface even though it lives on the \"general\" tab, not \"branding\": it is
-    the one config bundle already fetched pre-auth (login/register need it
-    before a session exists), so reusing it avoids a second endpoint for one
-    optional string.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -133,7 +121,7 @@ async def asyncio_detailed(
     *,
     client: AuthenticatedClient | Client,
 ) -> Response[BrandingResponse | ProblemDetail]:
-    r"""Get Branding
+    """Get Branding
 
      Return branding configuration (public, no auth required).
 
@@ -141,12 +129,6 @@ async def asyncio_detailed(
     keys. PersistentConfig overrides take precedence when set. Community
     advertises read-only ``show_badge`` only; badge-removal writes and
     additional branding keys are restricted controls.
-
-    ``privacy_url`` (PRIV-1) rides on this same public, unauthenticated
-    surface even though it lives on the \"general\" tab, not \"branding\": it is
-    the one config bundle already fetched pre-auth (login/register need it
-    before a session exists), so reusing it avoids a second endpoint for one
-    optional string.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -167,7 +149,7 @@ async def asyncio(
     *,
     client: AuthenticatedClient | Client,
 ) -> BrandingResponse | ProblemDetail | None:
-    r"""Get Branding
+    """Get Branding
 
      Return branding configuration (public, no auth required).
 
@@ -175,12 +157,6 @@ async def asyncio(
     keys. PersistentConfig overrides take precedence when set. Community
     advertises read-only ``show_badge`` only; badge-removal writes and
     additional branding keys are restricted controls.
-
-    ``privacy_url`` (PRIV-1) rides on this same public, unauthenticated
-    surface even though it lives on the \"general\" tab, not \"branding\": it is
-    the one config bundle already fetched pre-auth (login/register need it
-    before a session exists), so reusing it avoids a second endpoint for one
-    optional string.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.

--- a/sdks/python/geolens/api/admin/get_branding_settings_branding_get.py
+++ b/sdks/python/geolens/api/admin/get_branding_settings_branding_get.py
@@ -65,7 +65,7 @@ def sync_detailed(
     *,
     client: AuthenticatedClient | Client,
 ) -> Response[BrandingResponse | ProblemDetail]:
-    """Get Branding
+    r"""Get Branding
 
      Return branding configuration (public, no auth required).
 
@@ -73,6 +73,12 @@ def sync_detailed(
     keys. PersistentConfig overrides take precedence when set. Community
     advertises read-only ``show_badge`` only; badge-removal writes and
     additional branding keys are restricted controls.
+
+    ``privacy_url`` (PRIV-1) rides on this same public, unauthenticated
+    surface even though it lives on the \"general\" tab, not \"branding\": it is
+    the one config bundle already fetched pre-auth (login/register need it
+    before a session exists), so reusing it avoids a second endpoint for one
+    optional string.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -95,7 +101,7 @@ def sync(
     *,
     client: AuthenticatedClient | Client,
 ) -> BrandingResponse | ProblemDetail | None:
-    """Get Branding
+    r"""Get Branding
 
      Return branding configuration (public, no auth required).
 
@@ -103,6 +109,12 @@ def sync(
     keys. PersistentConfig overrides take precedence when set. Community
     advertises read-only ``show_badge`` only; badge-removal writes and
     additional branding keys are restricted controls.
+
+    ``privacy_url`` (PRIV-1) rides on this same public, unauthenticated
+    surface even though it lives on the \"general\" tab, not \"branding\": it is
+    the one config bundle already fetched pre-auth (login/register need it
+    before a session exists), so reusing it avoids a second endpoint for one
+    optional string.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -121,7 +133,7 @@ async def asyncio_detailed(
     *,
     client: AuthenticatedClient | Client,
 ) -> Response[BrandingResponse | ProblemDetail]:
-    """Get Branding
+    r"""Get Branding
 
      Return branding configuration (public, no auth required).
 
@@ -129,6 +141,12 @@ async def asyncio_detailed(
     keys. PersistentConfig overrides take precedence when set. Community
     advertises read-only ``show_badge`` only; badge-removal writes and
     additional branding keys are restricted controls.
+
+    ``privacy_url`` (PRIV-1) rides on this same public, unauthenticated
+    surface even though it lives on the \"general\" tab, not \"branding\": it is
+    the one config bundle already fetched pre-auth (login/register need it
+    before a session exists), so reusing it avoids a second endpoint for one
+    optional string.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -149,7 +167,7 @@ async def asyncio(
     *,
     client: AuthenticatedClient | Client,
 ) -> BrandingResponse | ProblemDetail | None:
-    """Get Branding
+    r"""Get Branding
 
      Return branding configuration (public, no auth required).
 
@@ -157,6 +175,12 @@ async def asyncio(
     keys. PersistentConfig overrides take precedence when set. Community
     advertises read-only ``show_badge`` only; badge-removal writes and
     additional branding keys are restricted controls.
+
+    ``privacy_url`` (PRIV-1) rides on this same public, unauthenticated
+    surface even though it lives on the \"general\" tab, not \"branding\": it is
+    the one config bundle already fetched pre-auth (login/register need it
+    before a session exists), so reusing it avoids a second endpoint for one
+    optional string.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.

--- a/sdks/python/geolens/models/branding_response.py
+++ b/sdks/python/geolens/models/branding_response.py
@@ -22,7 +22,8 @@ class BrandingResponse:
         show_badge (bool): Whether to show the 'Powered by GeoLens' label in public and shared footers. Badge-removal
             writes are restricted controls.
         privacy_url (None | str | Unset): Operator-configured privacy-policy URL shown on the login and register pages,
-            or null when unset (no link is shown).
+            or null when unset (no link is shown). Must be an absolute http(s) URL with no embedded credentials; a query
+            string or fragment is allowed and preserved as-is.
     """
 
     show_badge: bool

--- a/sdks/python/geolens/models/branding_response.py
+++ b/sdks/python/geolens/models/branding_response.py
@@ -6,6 +6,10 @@ from typing import Any, TypeVar
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 
+from ..types import UNSET, Unset
+
+from typing import cast
+
 
 T = TypeVar("T", bound="BrandingResponse")
 
@@ -17,13 +21,22 @@ class BrandingResponse:
     Attributes:
         show_badge (bool): Whether to show the 'Powered by GeoLens' label in public and shared footers. Badge-removal
             writes are restricted controls.
+        privacy_url (None | str | Unset): Operator-configured privacy-policy URL shown on the login and register pages,
+            or null when unset (no link is shown).
     """
 
     show_badge: bool
+    privacy_url: None | str | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
         show_badge = self.show_badge
+
+        privacy_url: None | str | Unset
+        if isinstance(self.privacy_url, Unset):
+            privacy_url = UNSET
+        else:
+            privacy_url = self.privacy_url
 
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
@@ -32,6 +45,8 @@ class BrandingResponse:
                 "show_badge": show_badge,
             }
         )
+        if privacy_url is not UNSET:
+            field_dict["privacy_url"] = privacy_url
 
         return field_dict
 
@@ -40,8 +55,18 @@ class BrandingResponse:
         d = dict(src_dict)
         show_badge = d.pop("show_badge")
 
+        def _parse_privacy_url(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        privacy_url = _parse_privacy_url(d.pop("privacy_url", UNSET))
+
         branding_response = cls(
             show_badge=show_badge,
+            privacy_url=privacy_url,
         )
 
         branding_response.additional_properties = d

--- a/sdks/typescript/src/client/sdk.gen.ts
+++ b/sdks/typescript/src/client/sdk.gen.ts
@@ -5081,6 +5081,12 @@ export const getBasemapsSettingsBasemapsGet = <ThrowOnError extends boolean = fa
  * keys. PersistentConfig overrides take precedence when set. Community
  * advertises read-only ``show_badge`` only; badge-removal writes and
  * additional branding keys are restricted controls.
+ *
+ * ``privacy_url`` (PRIV-1) rides on this same public, unauthenticated
+ * surface even though it lives on the "general" tab, not "branding": it is
+ * the one config bundle already fetched pre-auth (login/register need it
+ * before a session exists), so reusing it avoids a second endpoint for one
+ * optional string.
  */
 export const getBrandingSettingsBrandingGet = <ThrowOnError extends boolean = false>(options?: Options<GetBrandingSettingsBrandingGetData, ThrowOnError>): RequestResult<GetBrandingSettingsBrandingGetResponses, GetBrandingSettingsBrandingGetErrors, ThrowOnError> => (options?.client ?? client).get<GetBrandingSettingsBrandingGetResponses, GetBrandingSettingsBrandingGetErrors, ThrowOnError>({ url: '/settings/branding/', ...options });
 

--- a/sdks/typescript/src/client/sdk.gen.ts
+++ b/sdks/typescript/src/client/sdk.gen.ts
@@ -5081,12 +5081,6 @@ export const getBasemapsSettingsBasemapsGet = <ThrowOnError extends boolean = fa
  * keys. PersistentConfig overrides take precedence when set. Community
  * advertises read-only ``show_badge`` only; badge-removal writes and
  * additional branding keys are restricted controls.
- *
- * ``privacy_url`` (PRIV-1) rides on this same public, unauthenticated
- * surface even though it lives on the "general" tab, not "branding": it is
- * the one config bundle already fetched pre-auth (login/register need it
- * before a session exists), so reusing it avoids a second endpoint for one
- * optional string.
  */
 export const getBrandingSettingsBrandingGet = <ThrowOnError extends boolean = false>(options?: Options<GetBrandingSettingsBrandingGetData, ThrowOnError>): RequestResult<GetBrandingSettingsBrandingGetResponses, GetBrandingSettingsBrandingGetErrors, ThrowOnError> => (options?.client ?? client).get<GetBrandingSettingsBrandingGetResponses, GetBrandingSettingsBrandingGetErrors, ThrowOnError>({ url: '/settings/branding/', ...options });
 

--- a/sdks/typescript/src/client/types.gen.ts
+++ b/sdks/typescript/src/client/types.gen.ts
@@ -1256,7 +1256,7 @@ export type BrandingResponse = {
     /**
      * Privacy Url
      *
-     * Operator-configured privacy-policy URL shown on the login and register pages, or null when unset (no link is shown).
+     * Operator-configured privacy-policy URL shown on the login and register pages, or null when unset (no link is shown). Must be an absolute http(s) URL with no embedded credentials; a query string or fragment is allowed and preserved as-is.
      */
     privacy_url?: string | null;
 };

--- a/sdks/typescript/src/client/types.gen.ts
+++ b/sdks/typescript/src/client/types.gen.ts
@@ -1253,6 +1253,12 @@ export type BrandingResponse = {
      * Whether to show the 'Powered by GeoLens' label in public and shared footers. Badge-removal writes are restricted controls.
      */
     show_badge: boolean;
+    /**
+     * Privacy Url
+     *
+     * Operator-configured privacy-policy URL shown on the login and register pages, or null when unset (no link is shown).
+     */
+    privacy_url?: string | null;
 };
 
 /**


### PR DESCRIPTION
## Summary

Every self-hosted GeoLens login and register page linked to `getgeolens.com/privacy`, a page describing our data practices, not the operator's. This makes that link a per-instance setting instead: `privacy_url`, admin-configurable and backed by an optional `PRIVACY_URL` env var.

**Default: hidden, not getgeolens.com.** I considered defaulting the env var to `https://getgeolens.com/privacy` so existing installs keep the current link, but rejected it. A self-hosted GeoLens instance should never put another operator's privacy policy in front of its own users by default, especially not silently on upgrade. Unset now means no link renders at all. The demo deployment will get `PRIVACY_URL=https://getgeolens.com/privacy` set explicitly during rollout, same as any other operator opting in to a policy page.

No GitHub issue exists for PRIV-1; this PR is the only reference.

## Where it lives

- Backend: a `PRIVACY_URL` PersistentConfig on the `general` tab (`backend/app/core/persistent_config.py`), not `branding`. `branding` is enterprise-only (`ENTERPRISE_ONLY_TABS`), and community self-hosters need this setting the most.
- The value is rendered as a raw `<a href>` on an unauthenticated page, so it gets checked three times, all through one function (`validate_privacy_url_shape` in `backend/app/core/config.py`, chosen over `app.core.public_urls` to avoid a circular import): a `field_validator` on `Settings.privacy_url` that fails boot on an unsafe env value, the admin-write validator on `PUT /settings/`, and a read-time check in `GET /settings/branding/` that drops and logs a stored value that fails the shape rule instead of serving it (defense in depth for a row written before either check existed, or through `PersistentConfig.set()` directly). The check requires an absolute http(s) URL with no embedded credentials and no tab/newline/carriage-return characters (a documented URL-parser scheme-check bypass); it deliberately does NOT reuse the existing `_normalize_absolute_url` admin-URL helper, because that one strips query strings and fragments that a real operator policy page (Google Docs, Notion, SharePoint) routinely needs.
- Both compose files (`docker-compose.yml`, `docker-compose.prod.yml`) now pass `PRIVACY_URL` through to the `api` service beside `PUBLIC_BASE_URL`; without that the documented env var was inert under Compose.
- The value is served on `GET /settings/branding/` (`BrandingResponse.privacy_url`), not a new endpoint. That endpoint is already the one public, unauthenticated config surface the frontend fetches on both authenticated pages (AppLayout, the admin Appearance tab) and fully anonymous ones (PublicViewerPage), which is the same reach Login and Register need before a session exists. A dedicated endpoint would duplicate that plumbing for one optional string. The field sits on a `general`-tab key but rides the `branding` response; there's a comment above the route decorators saying why.
- Frontend: `LoginPage.tsx` and `RegisterForm.tsx` now read `privacy_url` from `useBranding()` instead of importing a hardcoded constant, gated through a small client-side scheme guard (`isSafeHttpUrl` in `lib/safe-http-url.ts`) as a rolling-upgrade belt-and-braces measure in case a stale API pod is still serving a pre-check value. The consent paragraph ("By signing in you agree to our Privacy Policy...") is gated on the whole block, not just the `<a>` tag; with no safe URL there's no sentence to show, since "agree to our ." doesn't read as intentional. Dropped the vendor "we may contact you about GeoLens" clause from the consent copy in all four locales, since the link now points at the operator's own policy, not ours. Removed the now-unused `GEOLENS_PRIVACY_URL` constant from `external-links.ts`.
- Admin UI: added a Privacy Policy URL field to Settings, General tab, matching the existing Public App/API URL fields (same component pattern, `SettingSourceBadge`, env-only disable, help text noting it must be a full http(s) URL). New `t()` keys added to all four locales.

## Config / API impact

- New env var: `PRIVACY_URL` (optional, unset by default). Documented in `.env.example` next to the other public URL vars, and passed through both compose files.
- New admin setting key: `privacy_url` (tab `general`).
- `BrandingResponse` (`GET /settings/branding/`) gains `privacy_url: string | null`. Regenerated all four API-contract artifacts: `backend/openapi.json`, the Python and TypeScript SDKs, and `frontend/src/types/api.generated.ts`.
- Helm chart and deployments repo are out of scope here; someone still needs to wire `PRIVACY_URL` through there for the demo rollout.
- No generic ".env.example keys are all passed through by compose" test exists; I didn't add one. The one compose-alignment test file (`test_phase_275_compose_alignment.py`) is five narrow, hand-written invariants, not a generic enumerator, and a correct generic version would need to exclude CLI-only and migrate-only keys plus everything already shared through the compose YAML anchors, which is more than this PR's scope.

## Verification

Backend, from the worktree:
- `cd backend && uv run ruff check . && uv run ruff format --check .`: passed
- `tests/test_branding_settings.py tests/test_config.py tests/test_layering.py tests/test_phase_275_compose_alignment.py -q -n 4`: 228 passed. Covers: null default, an admin-set value round-tripping through the API, a query string and fragment surviving unchanged, five unsafe shapes rejected with 422 (not-a-url, `javascript:`, `data:`, scheme-relative, embedded credentials), the env-value boot validator rejecting the same shapes, and the read-path dropping an unsafe value written directly through `PersistentConfig.set()`.
- Raised the LOC ratchet caps on `config.py`, `persistent_config.py`, and `router_public.py` across the commits in this PR, each with a comment saying what the growth bought.

Frontend, from the worktree:
- `npm run typecheck`, `npm run lint`, `npm run test:i18n`: all clean
- `npx vitest run` on LoginPage, RegisterForm, AppLayout, ViewerMap.branding, PublicViewerPage, the admin settings tests, the new `safe-http-url` unit test, and the hand-typed-mirror-drift test: 120 passed, including a case asserting a `javascript:` stored value renders no link client-side
- `npm run build`: clean

Contract, on the committed tree:
- `make openapi-check`, `make sdks-check` (including its internal `cd sdks/typescript && npm run build && npm test`), and `cd frontend && npm run types:check`: all clean

E2E wasn't run. This worktree tests against the main checkout's stack per the repo's worktree guidance, so a Playwright run here wouldn't exercise this branch's code.
