### PR TITLE
fix(extensions): pin the default ports to their Protocol signatures

### DIFF
--- a/backend/app/core/catalog_port.py
+++ b/backend/app/core/catalog_port.py
@@ -88,6 +88,17 @@ class CatalogPort(Protocol):
         self, storage_method: Any, created_at: Any, *args: Any
     ) -> str: ...
 
+    # fix(#1590): DefaultCatalogPort.finalize_presigned_object also accepts
+    # `replacing_dataset_id: uuid.UUID | None = None`, which the reupload
+    # door (router_reupload.py, #1290 admission parity) already passes
+    # through this port. It is not declared here because version.py's
+    # 2 -> 3 precedent holds: an overlay that implements a method must
+    # accept a keyword the Protocol adds, so adding it is a signature change
+    # and therefore an EXTENSION_API_VERSION bump, not a no-op optional
+    # addition — and a signature-drift cleanup does not get to force that
+    # bump on its own. A full-replacement `catalog_port` overlay would
+    # TypeError on `replacing_dataset_id` today; add the keyword here at the
+    # next bump and drop this comment.
     async def finalize_presigned_object(
         self,
         *,

--- a/backend/app/core/catalog_port.py
+++ b/backend/app/core/catalog_port.py
@@ -57,6 +57,12 @@ class CatalogPort(Protocol):
     # when the flow is a replacement and the uploader when it is a creation, so
     # it is nullable: an ownerless dataset has no owner to name (#1293 — the
     # policy is stated in app.modules.quota.service).
+    #
+    # fix(#1590): DefaultCatalogPort.verify_completed_presigned_upload also
+    # accepts `replacing_dataset_id: uuid.UUID | None = None` — the same
+    # deferred addition as `finalize_presigned_object` later in this file,
+    # which forwards it here internally. See that method's comment for why
+    # it is not declared on the Protocol yet.
     async def verify_completed_presigned_upload(
         self,
         *,

--- a/backend/app/platform/extensions/defaults_ai_anthropic.py
+++ b/backend/app/platform/extensions/defaults_ai_anthropic.py
@@ -198,20 +198,71 @@ class DefaultAnthropicProvider:
 
         raise ToolLoopExhaustedError("Max tool rounds exceeded without final response")
 
-    async def stream(self, **kwargs):  # type: ignore[no-untyped-def]
+    # fix(#1590): explicit keyword-only signature instead of a bare
+    # **kwargs shim, matching AIProviderExtension.stream exactly.
+    async def stream(  # type: ignore[no-untyped-def]
+        self,
+        *,
+        model,
+        system_prompt,
+        user_message,
+        tools,
+        tool_executor,
+        action_collector=None,
+        history=None,
+        max_rounds=None,
+        max_tokens=4096,
+        base_url=None,
+        temperature=0.5,
+    ):
         raise NotImplementedError(
             "DefaultAnthropicProvider.stream() not implemented in community "
             "edition; use complete() (Phase 226 D-03 — true LLM-token "
             "streaming is deferred to a follow-up phase)."
         )
 
-    async def stream_chat_events(self, **kwargs):  # type: ignore[no-untyped-def]
-        kwargs.pop("base_url", None)
+    # fix(#1590): explicit keyword-only signature instead of a bare
+    # **kwargs shim, matching AIProviderExtension.stream_chat_events
+    # exactly. `base_url` is accepted (the Protocol declares it) but unused
+    # here — Anthropic's streaming client resolves its own endpoint, same as
+    # `complete()`'s `del temperature` a few lines up for a different unused
+    # keyword.
+    async def stream_chat_events(  # type: ignore[no-untyped-def]
+        self,
+        *,
+        message,
+        system_prompt,
+        session,
+        user,
+        user_roles,
+        layers,
+        model,
+        base_url=None,
+        history=None,
+        port,
+        map_id=None,
+        tools=None,
+        restrict_tables=None,
+    ):
+        del base_url
         from app.processing.ai.llm_loop import get_anthropic_client
         from app.processing.ai.streaming import _stream_anthropic_chat
 
-        kwargs["client"] = get_anthropic_client()
-        async for event in _stream_anthropic_chat(**kwargs):
+        async for event in _stream_anthropic_chat(
+            message=message,
+            system_prompt=system_prompt,
+            session=session,
+            user=user,
+            user_roles=user_roles,
+            layers=layers,
+            model=model,
+            history=history,
+            client=get_anthropic_client(),
+            port=port,
+            map_id=map_id,
+            tools=tools,
+            restrict_tables=restrict_tables,
+        ):
             yield event
 
     async def structured_complete(  # type: ignore[no-untyped-def]

--- a/backend/app/platform/extensions/defaults_ai_anthropic.py
+++ b/backend/app/platform/extensions/defaults_ai_anthropic.py
@@ -225,8 +225,7 @@ class DefaultAnthropicProvider:
     # **kwargs shim, matching AIProviderExtension.stream_chat_events
     # exactly. `base_url` is accepted (the Protocol declares it) but unused
     # here — Anthropic's streaming client resolves its own endpoint, same as
-    # `complete()`'s `del temperature` a few lines up for a different unused
-    # keyword.
+    # `del temperature` in `complete()` above for a different unused keyword.
     async def stream_chat_events(  # type: ignore[no-untyped-def]
         self,
         *,

--- a/backend/app/platform/extensions/defaults_ai_openai.py
+++ b/backend/app/platform/extensions/defaults_ai_openai.py
@@ -229,24 +229,72 @@ class DefaultOpenAICompatibleProvider:
 
         raise ToolLoopExhaustedError("Max tool rounds exceeded without final response")
 
-    async def stream(self, **kwargs):  # type: ignore[no-untyped-def]
+    # fix(#1590): explicit keyword-only signature instead of a bare
+    # **kwargs shim, matching AIProviderExtension.stream exactly.
+    async def stream(  # type: ignore[no-untyped-def]
+        self,
+        *,
+        model,
+        system_prompt,
+        user_message,
+        tools,
+        tool_executor,
+        action_collector=None,
+        history=None,
+        max_rounds=None,
+        max_tokens=4096,
+        base_url=None,
+        temperature=0.5,
+    ):
         raise NotImplementedError(
             "DefaultOpenAICompatibleProvider.stream() not implemented in "
             "community edition; use complete() (Phase 226 D-03)."
         )
 
-    async def stream_chat_events(self, **kwargs):  # type: ignore[no-untyped-def]
+    # fix(#1590): explicit keyword-only signature instead of a bare
+    # **kwargs shim, matching AIProviderExtension.stream_chat_events
+    # exactly.
+    async def stream_chat_events(  # type: ignore[no-untyped-def]
+        self,
+        *,
+        message,
+        system_prompt,
+        session,
+        user,
+        user_roles,
+        layers,
+        model,
+        base_url=None,
+        history=None,
+        port,
+        map_id=None,
+        tools=None,
+        restrict_tables=None,
+    ):
         from app.core.ai_credentials import bind_openai_credential_base_url
         from app.core.config import settings
         from app.processing.ai.llm_loop import get_openai_client
         from app.processing.ai.streaming import _stream_openai_chat
 
-        base_url = bind_openai_credential_base_url(
-            kwargs.pop("base_url", None) or settings.openai_base_url,
+        resolved_base_url = bind_openai_credential_base_url(
+            base_url or settings.openai_base_url,
             purpose="chat",
         )
-        kwargs["client"] = get_openai_client(base_url)
-        async for event in _stream_openai_chat(**kwargs):
+        async for event in _stream_openai_chat(
+            message=message,
+            system_prompt=system_prompt,
+            session=session,
+            user=user,
+            user_roles=user_roles,
+            layers=layers,
+            model=model,
+            history=history,
+            client=get_openai_client(resolved_base_url),
+            port=port,
+            map_id=map_id,
+            tools=tools,
+            restrict_tables=restrict_tables,
+        ):
             yield event
 
     async def structured_complete(  # type: ignore[no-untyped-def]

--- a/backend/app/platform/extensions/defaults_catalog_port.py
+++ b/backend/app/platform/extensions/defaults_catalog_port.py
@@ -76,18 +76,34 @@ class DefaultCatalogPort:
 
         return UploadResponse
 
-    async def abort_presigned_multipart_upload(
+    async def abort_presigned_multipart_upload(  # type: ignore[no-untyped-def]
         self, storage, *, key, upload_id, job_id
-    ):  # type: ignore[no-untyped-def]
+    ):
         from app.processing.ingest.presigned import abort_presigned_multipart_upload
 
         return await abort_presigned_multipart_upload(
             storage, key=key, upload_id=upload_id, job_id=job_id
         )
 
-    async def verify_completed_presigned_upload(
-        self, *, db, storage, key, expected_size, user_id, request, job_id
-    ):  # type: ignore[no-untyped-def]
+    # fix(#1590): explicit keyword-only signature instead of a bare
+    # **kwargs shim, so a missing or misspelled keyword surfaces here
+    # instead of deep inside the service call. `replacing_dataset_id` is a
+    # structural superset over CatalogPort's declared params — see the
+    # comment on CatalogPort.verify_completed_presigned_upload for why it
+    # is not on the Protocol yet, and test_port_signature_parity_1590.py's
+    # EXPECTED_SUPERSET_PARAMS for how the structural test tracks it.
+    async def verify_completed_presigned_upload(  # type: ignore[no-untyped-def]
+        self,
+        *,
+        db,
+        storage,
+        key,
+        expected_size,
+        user_id,
+        request,
+        job_id,
+        replacing_dataset_id=None,
+    ):
         from app.processing.ingest.presigned import verify_completed_presigned_upload
 
         return await verify_completed_presigned_upload(
@@ -98,6 +114,7 @@ class DefaultCatalogPort:
             user_id=user_id,
             request=request,
             job_id=job_id,
+            replacing_dataset_id=replacing_dataset_id,
         )
 
     async def lock_presigned_job(self, db, job_id):  # type: ignore[no-untyped-def]
@@ -134,7 +151,7 @@ class DefaultCatalogPort:
     # comment on CatalogPort.finalize_presigned_object for why it is not on
     # the Protocol yet, and test_port_signature_parity_1590.py's
     # EXPECTED_SUPERSET_PARAMS for how the structural test tracks it.
-    async def finalize_presigned_object(
+    async def finalize_presigned_object(  # type: ignore[no-untyped-def]
         self,
         *,
         db,
@@ -146,7 +163,7 @@ class DefaultCatalogPort:
         user_id,
         request,
         replacing_dataset_id=None,
-    ):  # type: ignore[no-untyped-def]
+    ):
         from app.processing.ingest.presigned import finalize_presigned_object
 
         return await finalize_presigned_object(

--- a/backend/app/platform/extensions/defaults_catalog_port.py
+++ b/backend/app/platform/extensions/defaults_catalog_port.py
@@ -76,15 +76,29 @@ class DefaultCatalogPort:
 
         return UploadResponse
 
-    async def abort_presigned_multipart_upload(self, storage, **kwargs):  # type: ignore[no-untyped-def]
+    async def abort_presigned_multipart_upload(
+        self, storage, *, key, upload_id, job_id
+    ):  # type: ignore[no-untyped-def]
         from app.processing.ingest.presigned import abort_presigned_multipart_upload
 
-        return await abort_presigned_multipart_upload(storage, **kwargs)
+        return await abort_presigned_multipart_upload(
+            storage, key=key, upload_id=upload_id, job_id=job_id
+        )
 
-    async def verify_completed_presigned_upload(self, **kwargs):  # type: ignore[no-untyped-def]
+    async def verify_completed_presigned_upload(
+        self, *, db, storage, key, expected_size, user_id, request, job_id
+    ):  # type: ignore[no-untyped-def]
         from app.processing.ingest.presigned import verify_completed_presigned_upload
 
-        return await verify_completed_presigned_upload(**kwargs)
+        return await verify_completed_presigned_upload(
+            db=db,
+            storage=storage,
+            key=key,
+            expected_size=expected_size,
+            user_id=user_id,
+            request=request,
+            job_id=job_id,
+        )
 
     async def lock_presigned_job(self, db, job_id):  # type: ignore[no-untyped-def]
         from app.processing.ingest.presigned import lock_presigned_job
@@ -113,10 +127,39 @@ class DefaultCatalogPort:
 
         return sign_url_with_deadline(storage_method, created_at, *args)
 
-    async def finalize_presigned_object(self, **kwargs):  # type: ignore[no-untyped-def]
+    # fix(#1590): explicit keyword-only signature instead of a bare
+    # **kwargs shim, so a missing or misspelled keyword surfaces here
+    # instead of deep inside the service call. `replacing_dataset_id` is a
+    # structural superset over CatalogPort's declared params — see the
+    # comment on CatalogPort.finalize_presigned_object for why it is not on
+    # the Protocol yet, and test_port_signature_parity_1590.py's
+    # EXPECTED_SUPERSET_PARAMS for how the structural test tracks it.
+    async def finalize_presigned_object(
+        self,
+        *,
+        db,
+        storage,
+        job_id,
+        logical_key,
+        expected_size,
+        filename,
+        user_id,
+        request,
+        replacing_dataset_id=None,
+    ):  # type: ignore[no-untyped-def]
         from app.processing.ingest.presigned import finalize_presigned_object
 
-        return await finalize_presigned_object(**kwargs)
+        return await finalize_presigned_object(
+            db=db,
+            storage=storage,
+            job_id=job_id,
+            logical_key=logical_key,
+            expected_size=expected_size,
+            filename=filename,
+            user_id=user_id,
+            request=request,
+            replacing_dataset_id=replacing_dataset_id,
+        )
 
     def visibility_default(self) -> str:
         return "private"

--- a/backend/app/platform/extensions/defaults_processing_port.py
+++ b/backend/app/platform/extensions/defaults_processing_port.py
@@ -518,9 +518,9 @@ class DefaultProcessingPort:
 
         return RecordDistribution
 
-    def compute_schema_diff(
+    def compute_schema_diff(  # type: ignore[no-untyped-def]
         self, old_columns, new_columns, old_feature_count, new_feature_count
-    ):  # type: ignore[no-untyped-def]
+    ):
         from app.modules.catalog.datasets.domain.service import compute_schema_diff
 
         return compute_schema_diff(

--- a/backend/app/platform/extensions/defaults_processing_port.py
+++ b/backend/app/platform/extensions/defaults_processing_port.py
@@ -518,10 +518,14 @@ class DefaultProcessingPort:
 
         return RecordDistribution
 
-    def compute_schema_diff(self, old_columns, new_columns, old_count, new_count):  # type: ignore[no-untyped-def]
+    def compute_schema_diff(
+        self, old_columns, new_columns, old_feature_count, new_feature_count
+    ):  # type: ignore[no-untyped-def]
         from app.modules.catalog.datasets.domain.service import compute_schema_diff
 
-        return compute_schema_diff(old_columns, new_columns, old_count, new_count)
+        return compute_schema_diff(
+            old_columns, new_columns, old_feature_count, new_feature_count
+        )
 
     def get_attribute_metadata_orm_class(self):  # type: ignore[no-untyped-def]
         from app.modules.catalog.datasets.domain.models import AttributeMetadata

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1921,18 +1921,17 @@ def test_decomposed_service_modules_stay_within_size_budgets() -> None:
         # search's does: on the catalog that distinction matters for, a partial
         # re-embed, the rows still carrying NULL are the old space.
         # Cap 491 -> 509, exact.
-        # fix(#1590): +43 — pin abort_presigned_multipart_upload,
+        # fix(#1590): +60 — pin abort_presigned_multipart_upload,
         # verify_completed_presigned_upload, and finalize_presigned_object to
         # CatalogPort's explicit keyword-only signatures instead of a bare
         # **kwargs shim, so a missing keyword surfaces at the port boundary
         # rather than deep in the service call.
-        # finalize_presigned_object also keeps accepting
-        # replacing_dataset_id: uuid.UUID | None = None, a structural
-        # superset the Protocol does not declare yet (see the comment on
-        # CatalogPort.finalize_presigned_object in core/catalog_port.py —
-        # adding it there is a version bump, not a cleanup). Cap
-        # 509 -> 552, exact.
-        "backend/app/platform/extensions/defaults_catalog_port.py": 552,
+        # verify_completed_presigned_upload and finalize_presigned_object
+        # also keep accepting replacing_dataset_id: uuid.UUID | None = None,
+        # a structural superset the Protocol does not declare yet (see the
+        # comments on both methods in core/catalog_port.py — adding it there
+        # is a version bump, not a cleanup). Cap 509 -> 569, exact.
+        "backend/app/platform/extensions/defaults_catalog_port.py": 569,
         # feat(#683): +58 — run_analysis_preview carries a clip mask DATASET
         # now, which costs a widened signature (one param per line once ruff
         # wraps it) plus the mask's shape and size gates. Those live here on

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1864,7 +1864,12 @@ def test_decomposed_service_modules_stay_within_size_budgets() -> None:
         # split time. Caps exact (zero headroom): each class moved verbatim
         # from the 1815-LOC defaults.py, and regrowth toward another god
         # module should get its own review.
-        "backend/app/platform/extensions/defaults_ai_openai.py": 444,
+        # fix(#1590): +48 — stream and stream_chat_events pinned to explicit
+        # keyword-only signatures matching AIProviderExtension instead of a
+        # bare **kwargs shim, so a missing keyword surfaces at the port
+        # boundary rather than inside _stream_openai_chat. Cap 444 -> 492,
+        # exact.
+        "backend/app/platform/extensions/defaults_ai_openai.py": 492,
         # fix(#1207): +15 — three delegations for the shared presigned-completion
         # helpers (lock/assemble-check/finalize) the reupload door reaches through
         # the port. Three lines each, matching the existing entries.
@@ -1916,7 +1921,18 @@ def test_decomposed_service_modules_stay_within_size_budgets() -> None:
         # search's does: on the catalog that distinction matters for, a partial
         # re-embed, the rows still carrying NULL are the old space.
         # Cap 491 -> 509, exact.
-        "backend/app/platform/extensions/defaults_catalog_port.py": 509,
+        # fix(#1590): +43 — pin abort_presigned_multipart_upload,
+        # verify_completed_presigned_upload, and finalize_presigned_object to
+        # CatalogPort's explicit keyword-only signatures instead of a bare
+        # **kwargs shim, so a missing keyword surfaces at the port boundary
+        # rather than deep in the service call.
+        # finalize_presigned_object also keeps accepting
+        # replacing_dataset_id: uuid.UUID | None = None, a structural
+        # superset the Protocol does not declare yet (see the comment on
+        # CatalogPort.finalize_presigned_object in core/catalog_port.py —
+        # adding it there is a version bump, not a cleanup). Cap
+        # 509 -> 552, exact.
+        "backend/app/platform/extensions/defaults_catalog_port.py": 552,
         # feat(#683): +58 — run_analysis_preview carries a clip mask DATASET
         # now, which costs a widened signature (one param per line once ruff
         # wraps it) plus the mask's shape and size gates. Those live here on
@@ -1956,7 +1972,11 @@ def test_decomposed_service_modules_stay_within_size_budgets() -> None:
         # UNSTAMPED row still counts as covering the record, which is the only
         # thing keeping an upgrade from turning the next Generate Missing into
         # a catalog-wide re-embed. Cap 537 -> 564, exact.
-        "backend/app/platform/extensions/defaults_processing_port.py": 564,
+        # fix(#1590): +4 — compute_schema_diff's parameters renamed to match
+        # ProcessingPort's old_feature_count/new_feature_count so a keyword
+        # caller fails against the Protocol, not just the default. Cap
+        # 564 -> 568, exact.
+        "backend/app/platform/extensions/defaults_processing_port.py": 568,
         # fix(#929): +2 over the 350 default — the creator exemption on the
         # restricted branch of filter_visible/can_access_dataset plus its
         # rationale comments. fix(#930): +20 — the internal branch on the same

--- a/backend/tests/test_port_signature_parity_1590.py
+++ b/backend/tests/test_port_signature_parity_1590.py
@@ -5,19 +5,31 @@ be drop-in replacements: an overlay swaps one in under the same registry key,
 and any keyword-forwarding caller (the port's own in-tree callers, or a
 future overlay that wraps a default and forwards by name) should see exactly
 the call surface the Protocol promises. A default that renames a parameter,
-or widens it to a bare ``**kwargs``, breaks that promise silently —
-``runtime_checkable`` only verifies attribute PRESENCE (PEP 544), not
-signatures, so nothing catches the drift until a keyword caller hits a
-TypeError deep in a forwarding chain.
+reorders a positional one, or widens the signature to a bare ``**kwargs``,
+breaks that promise silently — ``runtime_checkable`` only verifies attribute
+PRESENCE (PEP 544), not signatures, so nothing catches the drift until a
+positional or keyword caller hits a TypeError, or worse, a silently swapped
+argument, deep in a forwarding chain.
 
 This walks every Protocol the registry actually ships a default for — the
 same 16-class set ``app.platform.extensions.defaults.__all__`` carries (see
-``test_extensions.py::test_pre_pr_wildcard_surface_is_intact``) — paired with
-each one's Protocol, and asserts every Protocol method's parameter matches
-the default implementation's: same name, same kind, at minimum. A bare
-``**kwargs`` shim changes the KIND (VAR_KEYWORD vs KEYWORD_ONLY) for every
-Protocol parameter, so this is exactly the shape of drift #1590 found: it
-would have caught it before a keyword caller did.
+``test_extensions.py::test_pre_pr_wildcard_surface_is_intact``, and
+``test_pair_map_covers_every_default_the_facade_exports`` below, which pins
+the pair map against that same ``__all__`` so a newly added default cannot
+go unswept by omission) — paired with each one's Protocol, and asserts:
+
+- every Protocol parameter exists on the default with the same NAME and KIND;
+- the ORDERED sequence of POSITIONAL_ONLY/POSITIONAL_OR_KEYWORD parameter
+  names matches, because name+kind alone would not catch two positional
+  parameters swapping places (same names, same kinds, wrong order: every
+  positional caller's arguments land in the other slot);
+- when a Protocol parameter has a default, the implementation's corresponding
+  parameter has one too (a caller relying on the Protocol's declared
+  optionality shouldn't have to learn the default made it required).
+
+A bare ``**kwargs`` shim fails the first check immediately (VAR_KEYWORD is a
+different parameter KIND than the KEYWORD_ONLY parameters it stands in for),
+which is exactly the shape of drift #1590 found.
 
 A default MAY carry additional parameters the Protocol does not declare, but
 only in the narrow shape that keeps them non-breaking: KEYWORD_ONLY, with a
@@ -25,12 +37,13 @@ default value (never a bare ``**kwargs``/``*args`` catch-all, never a
 required extra). Adding a REQUIRED Protocol parameter is a signature change
 that needs an EXTENSION_API_VERSION bump (version.py's 2 -> 3 precedent); an
 optional superset on the DEFAULT alone does not, because an overlay that
-never heard of the extra keyword is unaffected. Today's one instance —
-``DefaultCatalogPort.finalize_presigned_object``'s ``replacing_dataset_id``
-— is deliberate (see the comment on ``CatalogPort.finalize_presigned_object``
-in ``core/catalog_port.py``) and pinned below via
-``EXPECTED_SUPERSET_PARAMS`` so a *new* undocumented superset still fails
-loud instead of passing silently.
+never heard of the extra keyword is unaffected. Today's two instances,
+``DefaultCatalogPort.finalize_presigned_object`` and
+``.verify_completed_presigned_upload``'s ``replacing_dataset_id``, are
+deliberate (see the comments on ``CatalogPort.finalize_presigned_object`` and
+``.verify_completed_presigned_upload`` in ``core/catalog_port.py``) and
+pinned below via ``EXPECTED_SUPERSET_PARAMS`` so a *new* undocumented
+superset still fails loud instead of passing silently.
 """
 
 from __future__ import annotations
@@ -44,7 +57,13 @@ import inspect
 #: addition is deliberate) rather than widening the sweep's tolerance.
 EXPECTED_SUPERSET_PARAMS = [
     "DefaultCatalogPort.finalize_presigned_object: +replacing_dataset_id",
+    "DefaultCatalogPort.verify_completed_presigned_upload: +replacing_dataset_id",
 ]
+
+_POSITIONAL_KINDS = (
+    inspect.Parameter.POSITIONAL_ONLY,
+    inspect.Parameter.POSITIONAL_OR_KEYWORD,
+)
 
 
 def _protocol_member_names(protocol_cls: type) -> list[str]:
@@ -159,6 +178,36 @@ def _protocol_default_pairs() -> list[tuple[type, type, str]]:
     ]
 
 
+def test_pair_map_covers_every_default_the_facade_exports() -> None:
+    """The pair map must fail toward REPORTING an unpaired default, not toward silence.
+
+    fix(#1590 review): a hand-written list of (Protocol, default) pairs only
+    catches drift in whatever it already knows to check. A new Default*
+    class added to the registry facade without a matching entry in
+    ``_protocol_default_pairs()`` would sweep clean by omission, not by
+    conformance — the signature test below would simply never look at it.
+    This pins the pair map's label set against
+    ``app.platform.extensions.defaults.__all__`` (the same facade surface
+    ``test_pre_pr_wildcard_surface_is_intact`` treats as canonical), so an
+    unpaired default fails loud here instead of silently going unchecked.
+    """
+    from app.platform.extensions import defaults as defaults_facade
+
+    facade_default_names = {
+        name for name in defaults_facade.__all__ if name.startswith("Default")
+    }
+    paired_labels = {label for _, _, label in _protocol_default_pairs()}
+
+    missing = facade_default_names - paired_labels
+    assert not missing, (
+        "These Default* classes are exported by the registry facade "
+        "(app.platform.extensions.defaults.__all__) but have no "
+        "(Protocol, default) pairing in _protocol_default_pairs() — add one "
+        "so the signature sweep actually covers them instead of skipping "
+        f"them by omission: {sorted(missing)}"
+    )
+
+
 def test_default_implementations_match_their_protocol_signatures() -> None:
     """Every default's methods must accept exactly what its Protocol promises.
 
@@ -174,7 +223,8 @@ def test_default_implementations_match_their_protocol_signatures() -> None:
     drift anywhere in the registry, not just the sites found by hand. A
     future ``**kwargs`` shim fails it immediately (VAR_KEYWORD is a
     different parameter KIND than the KEYWORD_ONLY parameters it stands in
-    for), and so does a rename or a dropped parameter.
+    for), and so does a rename, a dropped parameter, a positional reorder
+    that keeps the same names, or a default silently becoming required.
     """
     mismatches: list[str] = []
     superset_params: list[str] = []
@@ -198,6 +248,37 @@ def test_default_implementations_match_their_protocol_signatures() -> None:
                         f"kind on the default (default params: "
                         f"{[(d.name, d.kind.name) for d in default_params]})"
                     )
+                    continue
+                if (
+                    pp.default is not inspect.Parameter.empty
+                    and dp.default is inspect.Parameter.empty
+                ):
+                    mismatches.append(
+                        f"{label}.{name}: Protocol parameter {pp.name!r} has "
+                        f"a default ({pp.default!r}) but the default "
+                        "implementation's does not — a caller relying on "
+                        "the Protocol's optionality would have to start "
+                        "passing it explicitly"
+                    )
+
+            # Name+kind matching alone would miss two positional parameters
+            # swapping places (e.g. old_feature_count/new_feature_count
+            # trading positions): both still resolve by name, but every
+            # positional caller's arguments would land in the other slot.
+            protocol_positional = [
+                pp.name for pp in protocol_params if pp.kind in _POSITIONAL_KINDS
+            ]
+            default_positional = [
+                dp.name for dp in default_params if dp.kind in _POSITIONAL_KINDS
+            ]
+            if protocol_positional != default_positional:
+                mismatches.append(
+                    f"{label}.{name}: positional parameter ORDER differs "
+                    f"(protocol={protocol_positional}, "
+                    f"default={default_positional}) — a positional caller "
+                    "binds by position, so even a same-name-set swap "
+                    "changes which value lands where"
+                )
 
             protocol_names = {pp.name for pp in protocol_params}
             for dp in default_params:
@@ -230,9 +311,10 @@ def test_default_implementations_match_their_protocol_signatures() -> None:
 
     assert not mismatches, (
         "Default implementation(s) drifted from their Protocol's parameters "
-        "(names/kinds must match; annotations and defaults are excluded). A "
-        "default MAY carry extra KEYWORD_ONLY parameters that have "
-        "defaults — nothing else:\n\n" + "\n".join(mismatches)
+        "(names, kinds, positional order, and optionality must match; "
+        "annotations and default VALUES are excluded). A default MAY carry "
+        "extra KEYWORD_ONLY parameters that have defaults — nothing else:\n\n"
+        + "\n".join(mismatches)
     )
 
     assert sorted(superset_params) == sorted(EXPECTED_SUPERSET_PARAMS), (

--- a/backend/tests/test_port_signature_parity_1590.py
+++ b/backend/tests/test_port_signature_parity_1590.py
@@ -1,0 +1,248 @@
+"""Structural signature-parity sweep for #1590.
+
+Default* implementations of the extension registry's Protocols are meant to
+be drop-in replacements: an overlay swaps one in under the same registry key,
+and any keyword-forwarding caller (the port's own in-tree callers, or a
+future overlay that wraps a default and forwards by name) should see exactly
+the call surface the Protocol promises. A default that renames a parameter,
+or widens it to a bare ``**kwargs``, breaks that promise silently —
+``runtime_checkable`` only verifies attribute PRESENCE (PEP 544), not
+signatures, so nothing catches the drift until a keyword caller hits a
+TypeError deep in a forwarding chain.
+
+This walks every Protocol the registry actually ships a default for — the
+same 16-class set ``app.platform.extensions.defaults.__all__`` carries (see
+``test_extensions.py::test_pre_pr_wildcard_surface_is_intact``) — paired with
+each one's Protocol, and asserts every Protocol method's parameter matches
+the default implementation's: same name, same kind, at minimum. A bare
+``**kwargs`` shim changes the KIND (VAR_KEYWORD vs KEYWORD_ONLY) for every
+Protocol parameter, so this is exactly the shape of drift #1590 found: it
+would have caught it before a keyword caller did.
+
+A default MAY carry additional parameters the Protocol does not declare, but
+only in the narrow shape that keeps them non-breaking: KEYWORD_ONLY, with a
+default value (never a bare ``**kwargs``/``*args`` catch-all, never a
+required extra). Adding a REQUIRED Protocol parameter is a signature change
+that needs an EXTENSION_API_VERSION bump (version.py's 2 -> 3 precedent); an
+optional superset on the DEFAULT alone does not, because an overlay that
+never heard of the extra keyword is unaffected. Today's one instance —
+``DefaultCatalogPort.finalize_presigned_object``'s ``replacing_dataset_id``
+— is deliberate (see the comment on ``CatalogPort.finalize_presigned_object``
+in ``core/catalog_port.py``) and pinned below via
+``EXPECTED_SUPERSET_PARAMS`` so a *new* undocumented superset still fails
+loud instead of passing silently.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+#: "{DefaultLabel}.{method}: +{param_name}" for every extra KEYWORD_ONLY,
+#: defaulted parameter a default implementation is known to carry beyond
+#: its Protocol. Anything found during the sweep that is not listed here is
+#: treated as drift, not a superset — update this list (and confirm the
+#: addition is deliberate) rather than widening the sweep's tolerance.
+EXPECTED_SUPERSET_PARAMS = [
+    "DefaultCatalogPort.finalize_presigned_object: +replacing_dataset_id",
+]
+
+
+def _protocol_member_names(protocol_cls: type) -> list[str]:
+    """Names declared directly on the Protocol body — not typing's own machinery.
+
+    ``vars(protocol_cls)`` holds only what the class body defines, so this
+    naturally excludes inherited Protocol/Generic/object internals without an
+    explicit denylist. Typing still stamps sunder attributes like
+    ``_is_protocol`` on the class itself; every one of those starts with
+    ``_``, and no real Protocol member in this codebase does, so filtering the
+    leading underscore is sufficient.
+    """
+    names = []
+    for name, value in vars(protocol_cls).items():
+        if name.startswith("_"):
+            continue
+        if callable(value) or isinstance(value, property):
+            names.append(name)
+    return sorted(names)
+
+
+def _member_params(owner_cls: type, name: str) -> list[inspect.Parameter]:
+    """Every parameter of ``owner_cls``'s member ``name`` except ``self``.
+
+    Unwraps ``@property`` to its getter, since ``CatalogPort`` declares
+    ``priority_queue_threshold_bytes`` that way.
+    """
+    value = getattr(owner_cls, name)
+    if isinstance(value, property):
+        value = value.fget
+    sig = inspect.signature(value)
+    return [p for p in sig.parameters.values() if p.name != "self"]
+
+
+def _protocol_default_pairs() -> list[tuple[type, type, str]]:
+    """(Protocol, default class, label) for every Default* the registry publishes.
+
+    Pairs the 16-class set ``test_pre_pr_wildcard_surface_is_intact`` already
+    treats as "every Default* the facade exports" with each one's Protocol.
+    ``AIProviderExtension`` appears twice (Anthropic + OpenAI-compatible are
+    two named entries in the same ``ai_providers`` dispatch dict).
+    """
+    from app.core.catalog_port import CatalogPort
+    from app.core.identity import IdentityExtension
+    from app.core.processing_port import ProcessingPort
+    from app.platform.extensions.defaults import (
+        DefaultAnthropicProvider,
+        DefaultAuditSink,
+        DefaultAuthExtension,
+        DefaultBillingExtension,
+        DefaultBrandingExtension,
+        DefaultCatalogPort,
+        DefaultConnectorExtension,
+        DefaultDataServingExtension,
+        DefaultEntitlementPort,
+        DefaultIdentityExtension,
+        DefaultNotificationSink,
+        DefaultOpenAICompatibleProvider,
+        DefaultOpenAIEmbeddingProvider,
+        DefaultPermissionExtension,
+        DefaultProcessingPort,
+        DefaultWorkflowExtension,
+    )
+    from app.platform.extensions.protocols import (
+        AIProviderExtension,
+        AuditSink,
+        AuthExtension,
+        BillingExtension,
+        BrandingExtension,
+        ConnectorExtension,
+        DataServingExtension,
+        EmbeddingProviderExtension,
+        EntitlementPort,
+        NotificationSink,
+        PermissionExtension,
+        WorkflowExtension,
+    )
+
+    return [
+        (CatalogPort, DefaultCatalogPort, "DefaultCatalogPort"),
+        (ProcessingPort, DefaultProcessingPort, "DefaultProcessingPort"),
+        (IdentityExtension, DefaultIdentityExtension, "DefaultIdentityExtension"),
+        (BrandingExtension, DefaultBrandingExtension, "DefaultBrandingExtension"),
+        (AuthExtension, DefaultAuthExtension, "DefaultAuthExtension"),
+        (AuditSink, DefaultAuditSink, "DefaultAuditSink"),
+        (BillingExtension, DefaultBillingExtension, "DefaultBillingExtension"),
+        (ConnectorExtension, DefaultConnectorExtension, "DefaultConnectorExtension"),
+        (
+            DataServingExtension,
+            DefaultDataServingExtension,
+            "DefaultDataServingExtension",
+        ),
+        (EntitlementPort, DefaultEntitlementPort, "DefaultEntitlementPort"),
+        (NotificationSink, DefaultNotificationSink, "DefaultNotificationSink"),
+        (
+            PermissionExtension,
+            DefaultPermissionExtension,
+            "DefaultPermissionExtension",
+        ),
+        (WorkflowExtension, DefaultWorkflowExtension, "DefaultWorkflowExtension"),
+        (AIProviderExtension, DefaultAnthropicProvider, "DefaultAnthropicProvider"),
+        (
+            AIProviderExtension,
+            DefaultOpenAICompatibleProvider,
+            "DefaultOpenAICompatibleProvider",
+        ),
+        (
+            EmbeddingProviderExtension,
+            DefaultOpenAIEmbeddingProvider,
+            "DefaultOpenAIEmbeddingProvider",
+        ),
+    ]
+
+
+def test_default_implementations_match_their_protocol_signatures() -> None:
+    """Every default's methods must accept exactly what its Protocol promises.
+
+    fix(#1590): four default methods had drifted from their Protocol — a
+    renamed parameter pair (``compute_schema_diff``) and three bare
+    ``**kwargs`` shims (the presigned-upload trio) that only failed once a
+    keyword caller or a forwarding overlay hit the gap. The same sweep also
+    caught the identical ``**kwargs`` shape on
+    ``DefaultAnthropicProvider``/``DefaultOpenAICompatibleProvider``'s
+    ``stream``/``stream_chat_events``, not named in #1590 but the same bug.
+
+    This is the general form of that check: it catches the same class of
+    drift anywhere in the registry, not just the sites found by hand. A
+    future ``**kwargs`` shim fails it immediately (VAR_KEYWORD is a
+    different parameter KIND than the KEYWORD_ONLY parameters it stands in
+    for), and so does a rename or a dropped parameter.
+    """
+    mismatches: list[str] = []
+    superset_params: list[str] = []
+
+    for protocol_cls, default_cls, label in _protocol_default_pairs():
+        for name in _protocol_member_names(protocol_cls):
+            if not hasattr(default_cls, name):
+                mismatches.append(f"{label}.{name}: missing entirely")
+                continue
+
+            protocol_params = _member_params(protocol_cls, name)
+            default_params = _member_params(default_cls, name)
+            default_by_name = {p.name: p for p in default_params}
+
+            for pp in protocol_params:
+                dp = default_by_name.get(pp.name)
+                if dp is None or dp.kind != pp.kind:
+                    mismatches.append(
+                        f"{label}.{name}: Protocol parameter {pp.name!r} "
+                        f"({pp.kind.name}) is missing or has a different "
+                        f"kind on the default (default params: "
+                        f"{[(d.name, d.kind.name) for d in default_params]})"
+                    )
+
+            protocol_names = {pp.name for pp in protocol_params}
+            for dp in default_params:
+                if dp.name in protocol_names:
+                    continue
+                # An unnamed catch-all is exactly the shim #1590 found — it
+                # is never a legitimate superset, no matter what it's called.
+                if dp.kind in (
+                    inspect.Parameter.VAR_KEYWORD,
+                    inspect.Parameter.VAR_POSITIONAL,
+                ):
+                    mismatches.append(
+                        f"{label}.{name}: default accepts a {dp.kind.name} "
+                        f"catch-all ({dp.name!r}) the Protocol does not "
+                        "declare — a **kwargs/*args shim, not a superset"
+                    )
+                elif (
+                    dp.kind != inspect.Parameter.KEYWORD_ONLY
+                    or dp.default is inspect.Parameter.empty
+                ):
+                    mismatches.append(
+                        f"{label}.{name}: default has an extra parameter "
+                        f"{dp.name!r} ({dp.kind.name}, "
+                        f"default={'<required>' if dp.default is inspect.Parameter.empty else dp.default!r}) "
+                        "that is not a keyword-only parameter with a default "
+                        "— not a valid superset shape"
+                    )
+                else:
+                    superset_params.append(f"{label}.{name}: +{dp.name}")
+
+    assert not mismatches, (
+        "Default implementation(s) drifted from their Protocol's parameters "
+        "(names/kinds must match; annotations and defaults are excluded). A "
+        "default MAY carry extra KEYWORD_ONLY parameters that have "
+        "defaults — nothing else:\n\n" + "\n".join(mismatches)
+    )
+
+    assert sorted(superset_params) == sorted(EXPECTED_SUPERSET_PARAMS), (
+        "A default implementation gained or lost an undocumented superset "
+        "parameter (a keyword-only parameter with a default that its "
+        "Protocol does not declare). If this is deliberate, update "
+        "EXPECTED_SUPERSET_PARAMS in this file — and if the new parameter "
+        "should really be REQUIRED, it belongs on the Protocol behind an "
+        "EXTENSION_API_VERSION bump instead (see core/catalog_port.py's "
+        "#1590 comment on finalize_presigned_object for the precedent).\n"
+        f"  found:    {sorted(superset_params)}\n"
+        f"  expected: {sorted(EXPECTED_SUPERSET_PARAMS)}"
+    )

--- a/backend/tests/test_processing_port.py
+++ b/backend/tests/test_processing_port.py
@@ -275,7 +275,9 @@ class FakeProcessingPort:
     def get_attribute_metadata_orm_class(self):
         return MagicMock
 
-    def compute_schema_diff(self, old_columns, new_columns, old_count, new_count):
+    def compute_schema_diff(
+        self, old_columns, new_columns, old_feature_count, new_feature_count
+    ):
         return {}
 
     async def resolve_stac_binding(


### PR DESCRIPTION
## Summary

Four default port implementations had drifted from the parameter names and kinds their Protocols declare:

- `DefaultProcessingPort.compute_schema_diff` named its last two parameters `old_count`/`new_count`; `ProcessingPort` declares `old_feature_count`/`new_feature_count`.
- `DefaultCatalogPort.abort_presigned_multipart_upload`, `.verify_completed_presigned_upload`, and `.finalize_presigned_object` all took bare `**kwargs` where `CatalogPort` declares explicit keyword-only parameters.

Every in-tree caller passes these positionally or with matching keywords, so nothing broke today. But a keyword caller, or an overlay that forwards a call by name, would hit a `TypeError` against the default instead of the Protocol it's supposed to implement. Closes #1590.

While building the structural test, the same sweep also found the identical `**kwargs` shape on `DefaultAnthropicProvider` and `DefaultOpenAICompatibleProvider`'s `stream`/`stream_chat_events`, against `AIProviderExtension`. Not named in #1590, but the same bug, so it's fixed in this PR rather than filed separately.

## The `replacing_dataset_id` exception

Both `verify_completed_presigned_upload` and `finalize_presigned_object`'s service functions take an additional `replacing_dataset_id: uuid.UUID | None = None`, which the reupload door (`router_reupload.py`, the #1290 admission-parity fix) already forwards through the port. That parameter isn't declared on `CatalogPort` itself, and this PR doesn't add it there. Per `version.py`'s existing precedent (the 2 -> 3 bump for `run_analysis_preview`'s `mask_dataset` keyword), adding an optional parameter that an overlay would nonetheless have to accept is a signature change and needs its own `EXTENSION_API_VERSION` bump. A signature-drift cleanup shouldn't get to force that bump on its own.

Instead, both `DefaultCatalogPort` methods accept `replacing_dataset_id` as an extra defaulted keyword-only parameter: a structural superset of the Protocol, not a rename or a widening. A comment on both Protocol methods and both defaults marks this as deferred. A full-replacement `catalog_port` overlay would `TypeError` on this keyword today, and the fix is to add it to `CatalogPort` at the next real bump. Left a note on #1590 recording this for whoever does that bump.

## Structural test

Added `backend/tests/test_port_signature_parity_1590.py`. It walks every Protocol the extension registry ships a default for (the same 16-class set `test_extensions.py`'s `test_pre_pr_wildcard_surface_is_intact` already treats as "every `Default*` the facade exports") and asserts each Protocol method's parameters match the default's: same name and kind, the same ordered sequence of positional parameter names (name+kind matching alone would pass a same-name positional swap and silently invert every positional caller's arguments), and the same optionality (a Protocol default value must survive onto the implementation, so a caller relying on it doesn't have to start passing the argument explicitly). A default may carry extra parameters beyond what its Protocol declares, but only if they're keyword-only with a default value. A bare `**kwargs`/`*args` catch-all still fails immediately, because that's exactly the shape of bug this test exists to catch. The two legitimate exceptions today, both `replacing_dataset_id` parameters, are pinned by name in `EXPECTED_SUPERSET_PARAMS`, so a new undocumented superset parameter fails loud instead of passing silently.

A separate test pins the pair map's label set against `app.platform.extensions.defaults.__all__`, so a new `Default*` class added to the registry facade without a matching pairing here fails loud instead of quietly going unswept.

Ran it red-first against the unmodified tree (all 8 mismatches, including the four AI-provider ones) before applying any fix, then confirmed green after.

## Verification

- `cd backend && uv run ruff check . && uv run ruff format --check .`: clean, full backend.
- `tests/test_layering.py -q`: 47 passed. Three module LOC caps grew and were raised with `fix(#1590)` comments: `defaults_catalog_port.py` 509 -> 569, `defaults_processing_port.py` 564 -> 568, `defaults_ai_openai.py` 444 -> 492.
- `tests/test_port_signature_parity_1590.py`: passes; ran red-first before the fixes to confirm it actually catches the drift.
- Targeted suites for every touched port (`test_dataset_refresh_runs.py`, `test_presigned_completion_size.py`, `test_presigned_content_validation_1202.py`, `test_processing_port.py`, `test_raster_replace_1221.py`, `test_reupload.py`, `test_tenant_staging_storage_keys.py`, `test_upload_size_limit.py`): 334 passed.
- `test_ai_provider_extension.py`, `test_ai_credential_binding.py`, `test_extensions.py`: 43 passed (these cover the AI provider defaults, which weren't in the presigned/schema-diff grep list but got touched too).
- No `EXTENSION_API_VERSION` bump: the Protocols themselves are unchanged.

## Review round 1

A pre-review caught: `verify_completed_presigned_upload` had dropped `replacing_dataset_id` when its `**kwargs` shim was replaced, asymmetric with `finalize_presigned_object` right next to it; the structural test's pair list needed its own coverage check against the facade's `__all__`; the test needed a positional-order check and an optionality check; `FakeProcessingPort.compute_schema_diff` in `test_processing_port.py` still used the pre-fix parameter names; and a couple of formatting/wording nits. All fixed in this push.
