### PR TITLE
fix(ai): expand a geolens_buffer marker server-side instead of transcribing the buffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and releases use semantic versioning.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Metric-buffer questions in chat stop failing at the sandbox.** Asking for a
+  buffer in metres made the assistant reproduce a 3 000-character PostGIS
+  expression character for character, and it got that wrong often enough that
+  roughly every other such question came back as a refused query rather than an
+  answer. The assistant now writes a short call and the server renders the
+  expression itself, so the shape can no longer be wrong (#1589).
+
 ## [1.14.0] - 2026-08-18
 
 ### Added

--- a/backend/app/platform/analysis_sql/__init__.py
+++ b/backend/app/platform/analysis_sql/__init__.py
@@ -154,9 +154,10 @@ def render_geometry_expr(
 #   before; the fix is not "remember not to run --fix".
 # - It is the list a reviewer diffs against the pre-split module. A symbol that
 #   silently stopped being importable would break `service_analysis.py`,
-#   `tasks.py`, `router_analysis.py`, `schemas.py`, the sandbox validator or
-#   the NL->SQL prompt at import time — and #1089 leaves all of them untouched
-#   on purpose, so nothing else in this PR would catch it.
+#   `tasks.py`, `router_analysis.py`, `schemas.py`, the sandbox validator, the
+#   NL->SQL prompt or its buffer-marker expander at import time — and #1089
+#   leaves all of them untouched on purpose, so nothing else in this PR would
+#   catch it.
 #
 # So this is the pre-split API verbatim, 35 names, neither added to nor taken
 # from. The six per-family `render_*_expr` helpers `render_geometry_expr`

--- a/backend/app/platform/analysis_sql/transform.py
+++ b/backend/app/platform/analysis_sql/transform.py
@@ -31,11 +31,15 @@ from .shared import (
 
 
 # fix(#1001): this function has a SECOND consumer that most edits here will
-# not have in mind. The NL->SQL prompt embeds its output verbatim
-# (``processing/ai/sql_generator.py`` renders it at import time), and the SQL
-# sandbox admits the sixteen amplification-prone functions below ONLY inside a
-# subtree that is exactly what this renderer emits — ``_matches_canonical_buffer``
-# in ``platform/sandbox/validator.py`` re-renders the template and compares.
+# not have in mind. The NL->SQL surface renders its output for every metric
+# buffer a chat question asks for — fix(#1589): the model writes a short
+# ``geolens_buffer(<geom>, <metres>)`` marker and
+# ``processing/ai/buffer_marker.py`` calls this function to expand it, where
+# the prompt used to embed the rendered text and ask the model to copy it —
+# and the SQL sandbox admits the sixteen amplification-prone functions below
+# ONLY inside a subtree that is exactly what this renderer emits —
+# ``_matches_canonical_buffer`` in ``platform/sandbox/validator.py``
+# re-renders the template and compares.
 # The match follows a shape change automatically, because both sides call this
 # function; what it cannot follow is a NEW function name that is itself unsafe
 # outside the template, since the exemption would then cover it. Weigh that

--- a/backend/app/platform/sandbox/validator.py
+++ b/backend/app/platform/sandbox/validator.py
@@ -381,11 +381,11 @@ def _validate_function_cost(func: exp.Func, fn_name: str, sql: str) -> None:
 # ---------------------------------------------------------------------------
 # fix(#1001): the canonical geodesic buffer, recognized whole.
 #
-# The NL->SQL prompt mandates render_geodesic_buffer's output verbatim for
-# metric buffers (sql_generator.py renders it at import time), and that
-# expression needs sixteen function names the fail-closed allowlist does not
-# carry — the banding, seam-splitting and dissolve machinery. So every buffer
-# question in the NL->SQL surface was refused.
+# Every metric buffer on the NL->SQL surface is render_geodesic_buffer's
+# output — fix(#1589): expanded from a geolens_buffer() marker by
+# processing/ai/buffer_marker.py before validation, where the prompt used to
+# embed the text — and it needs sixteen function names the fail-closed
+# allowlist does not carry. So every buffer question there was refused.
 #
 # Admitting those names globally is not an option: st_dump, st_dumpsegments,
 # st_segmentize and generate_series are the row/vertex amplification classes

--- a/backend/app/processing/ai/buffer_marker.py
+++ b/backend/app/processing/ai/buffer_marker.py
@@ -1,10 +1,12 @@
 """Expand the NL->SQL prompt's ``geolens_buffer`` marker (fix(#1589)).
 
-The prompt used to embed ``render_geodesic_buffer``'s rendered output — 3 088
-characters of banding, seam-splitting and dissolve machinery — and ask the
-model to reproduce it exactly (#1001). The nightly evals say the light model
-manages that about half the time: six of the nine runs between 08-12 and 08-18
-failed, every one of them a sandbox refusal of a dropped parenthesis
+The prompt used to embed ``render_geodesic_buffer``'s rendered output twice —
+a 3 017-character ``<GEOM>``/``<METERS>`` template and a 3 073-character worked
+example, 6 090 characters of banding, seam-splitting and dissolve machinery in
+a 16 786-character prompt — and ask the model to reproduce it exactly (#1001).
+The nightly evals say the light model manages that about half the time: six of
+the nine runs between 08-12 and 08-18 failed, every one a sandbox refusal of a
+dropped parenthesis
 (``invalid_query``) or a paraphrase back to the bare
 ``ST_Buffer(geom::geography, N)::geometry`` form (``disallowed spatial
 function``). None of them was a wrong answer that ran. Product-side, a
@@ -82,10 +84,23 @@ def _fail(message: str) -> SandboxError:
     """A marker problem, in the sandbox's own vocabulary.
 
     ``invalid_query`` is the existing category for "this SQL cannot run", and
-    every consumer already maps it: ``chat_actions._execute_chat_tool`` turns
-    it into the ERROR_MESSAGES line, ``query_router`` into a 422. A new
-    category would have to be added to both for no gain.
+    ``chat_actions._execute_chat_tool`` already maps it. A new category would
+    have to be added there for no gain.
+
+    fix(#1589 review r1): be clear about who reads ``message``. Nobody outside
+    the server does. ``_execute_chat_tool`` replaces it with the generic
+    ``ERROR_MESSAGES["invalid_query"]`` line ("I couldn't generate a valid
+    query for that."), so neither the user nor the model ever sees the
+    specific text — which is why it is logged here rather than only raised.
+    The audiences are this log line, and pytest when an eval trips one.
+
+    Surfacing it to the MODEL, so it could correct its own call, is a real
+    option and deliberately not taken here: it means widening which sandbox
+    messages are considered safe to echo into a chat turn, which is a change
+    to a shared error path and belongs with the repair-pass work in #1589
+    rather than smuggled in beside it.
     """
+    logger.info("sql.buffer_marker_rejected", reason=message)
     return SandboxError("invalid_query", message)
 
 
@@ -244,6 +259,52 @@ def _contains_marker(text: str) -> bool:
     return False
 
 
+def _without_comments(text: str) -> str:
+    """``text`` with its comments replaced by a space, literals untouched.
+
+    fix(#1589 review r1): the scanner SKIPS comments when it splits the
+    arguments, which is right, but the slice it hands back still contains them
+    and ``render_geodesic_buffer`` interpolates that slice into a much larger
+    expression. Both comment forms then break the query in a way the model
+    cannot see:
+
+    - a block comment (``geolens_buffer(s.geom_4326 /* the stop */, 500)``)
+      rides into the scaffold and perturbs the text
+      ``_matches_canonical_buffer`` re-renders and compares, so the exemption
+      is not granted and the buffer's own functions are refused as
+      "disallowed spatial function";
+    - a line comment (``geolens_buffer(s.geom_4326 -- the stop\\n, 500)``)
+      lands mid-expression and comments out everything the renderer emits
+      after it, up to the next newline — which in a single-line render is the
+      entire tail. "Invalid SQL syntax".
+
+    Both fail closed, and both are exactly the class of failure this change
+    exists to remove: the model wrote a correct call and got a sandbox
+    refusal. PostgreSQL treats a comment as whitespace, so dropping one is
+    semantics-preserving; the replacement is a SPACE rather than nothing so
+    ``a/*x*/b`` cannot fuse into one identifier.
+    """
+    if "--" not in text and "/*" not in text:
+        return text
+    kept: list[str] = []
+    i = 0
+    while i < len(text):
+        past = _skip_comment(text, i)
+        if past is not None:
+            kept.append(" ")
+            i = past
+            continue
+        # A literal is opaque: a `--` inside 'a--b' is data, not a comment.
+        past = _skip_quoted(text, i)
+        if past is not None:
+            kept.append(text[i:past])
+            i = past
+            continue
+        kept.append(text[i])
+        i += 1
+    return "".join(kept)
+
+
 def _checked_geometry(raw: str) -> str:
     """The geometry argument, checked for SYNTAX and nothing else.
 
@@ -253,17 +314,20 @@ def _checked_geometry(raw: str) -> str:
     expression is an acceptable buffer INPUT — bounded, allowlisted, resolvable
     to a stored column — belongs to ``_is_bounded_geometry_source`` and the
     function allowlist, in one place, for the reasons #1002 recorded.
+
+    Comments are dropped rather than passed through; ``_without_comments`` has
+    the why.
     """
-    geom = raw.strip()
+    geom = _without_comments(raw).strip()
     if not geom:
         raise _fail(f"{_MARKER}() needs a geometry expression")
     if _contains_marker(geom):
         # Innermost-first expansion would render fine and then be refused: the
         # validator exempts a buffer only when its input resolves to a stored
         # geometry, and a buffer is not one. The prompt says the same ("a
-        # nested buffer ... is refused"), so refusing here trades a sandbox
-        # error about spatial functions the model never wrote for a sentence
-        # about the thing it actually did.
+        # nested buffer ... is refused"). Refusing here rather than rendering
+        # ~6 KB that cannot pass is the whole benefit; the specific reason
+        # reaches the server log, not the model (see _fail).
         raise _fail(f"{_MARKER}() cannot be nested inside another {_MARKER}()")
     try:
         parsed = [stmt for stmt in sqlglot.parse(geom, dialect="postgres") if stmt]

--- a/backend/app/processing/ai/buffer_marker.py
+++ b/backend/app/processing/ai/buffer_marker.py
@@ -1,0 +1,366 @@
+"""Expand the NL->SQL prompt's ``geolens_buffer`` marker (fix(#1589)).
+
+The prompt used to embed ``render_geodesic_buffer``'s rendered output — 3 088
+characters of banding, seam-splitting and dissolve machinery — and ask the
+model to reproduce it exactly (#1001). The nightly evals say the light model
+manages that about half the time: six of the nine runs between 08-12 and 08-18
+failed, every one of them a sandbox refusal of a dropped parenthesis
+(``invalid_query``) or a paraphrase back to the bare
+``ST_Buffer(geom::geography, N)::geometry`` form (``disallowed spatial
+function``). None of them was a wrong answer that ran. Product-side, a
+metric-buffer question in chat failed at the sandbox roughly every other time.
+
+So the model now writes ``geolens_buffer(<geom>, <metres>)`` and this module
+substitutes the canonical render before anything else sees the SQL. The
+expression's shape can no longer be wrong, because the model no longer writes
+it — the class of failure is removed rather than made rarer.
+
+Where this sits in the trust model, stated plainly because it is the question a
+reader will have: expanding a marker is not a new privilege. It produces
+exactly the text a model was previously asked to type, and the sandbox treats
+it exactly as it treated that text. ``_matches_canonical_buffer`` in
+``platform/sandbox/validator.py`` still re-renders the template around the
+extracted input and compares ASTs, still refuses anything that is not a match,
+and still validates the geometry argument as ordinary SQL under the full
+allowlist. This module therefore decides SYNTAX only: it reads two arguments
+and checks that the distance is a plain in-range number. Whether a geometry
+argument is an ACCEPTABLE input stays the sandbox's single decision. #1002 is
+three rounds of evidence for what happens when two layers both try to answer
+that question.
+
+Deliberately NOT applied to the raw ``POST /api/query/`` endpoint
+(``query_router.py``), which takes SQL a person wrote. There the marker is an
+unknown function and stays one. ``tests/test_ai_buffer_marker_1589.py`` pins
+the call site as a closed list.
+"""
+
+from __future__ import annotations
+
+import math
+import re
+
+import sqlglot
+import structlog
+from sqlglot import exp
+
+from app.platform.analysis_sql import MAX_BUFFER_METERS, render_geodesic_buffer
+from app.platform.sandbox import SandboxError
+
+logger = structlog.stdlib.get_logger(__name__)
+
+_MARKER = "geolens_buffer"
+
+# Characters PostgreSQL admits inside an unquoted identifier after the first.
+# ``$`` is one of them, which is why the token boundary cannot be ``\w``.
+_IDENT_CHARS = re.compile(r"[A-Za-z0-9_$]")
+
+# A plain decimal number and nothing else: no sign, no cast, no arithmetic, no
+# ``_`` digit separators (``float("1_000")`` accepts those, so the regex has to
+# be the gate rather than the float call), no ``NaN``/``Infinity`` spelling.
+# The distance is interpolated straight into SQL text by
+# ``render_geodesic_buffer``, so this is that argument's injection boundary and
+# it is an allowlist.
+_DISTANCE = re.compile(r"\A(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+)?\Z")
+
+# A dollar-quote opener: ``$$`` or ``$tag$``. Distinguishes one from a
+# positional parameter (``$1``), which is not a quote at all.
+_DOLLAR_OPEN = re.compile(r"\$(?:[A-Za-z_][A-Za-z0-9_]*)?\$")
+
+# How many markers one statement may carry.
+#
+# Not an arbitrary round number: it is the validator's
+# ``_MAX_BUFFER_MATCH_ATTEMPTS``. That constant bounds how many buffer-shaped
+# subtrees the sandbox will re-render and verify, and past it no exemption is
+# granted — so a ninth expansion could only ever produce ~3 KB more SQL that is
+# then refused. Expanding it would cost the parse and buy a worse error.
+# ``test_the_marker_cap_matches_the_validators_verification_budget`` fails if
+# either number moves alone.
+MAX_BUFFER_MARKERS = 8
+
+
+def _fail(message: str) -> SandboxError:
+    """A marker problem, in the sandbox's own vocabulary.
+
+    ``invalid_query`` is the existing category for "this SQL cannot run", and
+    every consumer already maps it: ``chat_actions._execute_chat_tool`` turns
+    it into the ERROR_MESSAGES line, ``query_router`` into a 422. A new
+    category would have to be added to both for no gain.
+    """
+    return SandboxError("invalid_query", message)
+
+
+def _skip_comment(sql: str, i: int) -> int | None:
+    """Index just past the comment starting at ``i``; None when none does."""
+    if sql.startswith("--", i):
+        end = sql.find("\n", i)
+        return len(sql) if end == -1 else end + 1
+    if sql.startswith("/*", i):
+        # PostgreSQL block comments nest, so a naive find("*/") would end this
+        # one early and read the rest of an inner comment as code.
+        depth, j = 1, i + 2
+        while j < len(sql):
+            if sql.startswith("/*", j):
+                depth += 1
+                j += 2
+            elif sql.startswith("*/", j):
+                depth -= 1
+                j += 2
+                if depth == 0:
+                    return j
+            else:
+                j += 1
+        raise _fail("Query has an unterminated comment")
+    return None
+
+
+def _is_ident_at(sql: str, i: int) -> bool:
+    """Whether ``sql[i]`` is an identifier character (out of range: no)."""
+    return 0 <= i < len(sql) and _IDENT_CHARS.match(sql[i]) is not None
+
+
+def _skip_quoted(sql: str, i: int) -> int | None:
+    """Index just past the literal starting at ``i``; None when none does.
+
+    Handles single-quoted strings (``''`` escapes), ``E''`` escape strings
+    (backslash escapes), quoted identifiers and dollar-quoted strings. Not
+    handled: ``U&'...'``, whose ``UESCAPE`` clause can redefine the escape
+    character. Nothing teaches the model that form, and the failure direction
+    is safe — a mis-read produces either a refusal here or SQL the sandbox
+    parses and validates in full.
+    """
+    ch = sql[i]
+    if ch in ("'", '"'):
+        # An E-string prefix changes the escaping rules, so it is read here
+        # rather than passing as an ordinary identifier character.
+        escaped = (
+            ch == "'" and i > 0 and sql[i - 1] in "Ee" and not _is_ident_at(sql, i - 2)
+        )
+        j = i + 1
+        while j < len(sql):
+            if escaped and sql[j] == "\\":
+                j += 2
+                continue
+            if sql[j] == ch:
+                if j + 1 < len(sql) and sql[j + 1] == ch:
+                    j += 2
+                    continue
+                return j + 1
+            j += 1
+        raise _fail("Query has an unterminated string literal")
+    if ch == "$":
+        opener = _DOLLAR_OPEN.match(sql, i)
+        if opener is None:
+            return None
+        end = sql.find(opener.group(0), opener.end())
+        if end == -1:
+            raise _fail("Query has an unterminated string literal")
+        return end + len(opener.group(0))
+    return None
+
+
+def _skip_non_code(sql: str, i: int) -> int | None:
+    """Index just past the literal or comment at ``i``; None when neither.
+
+    The argument split has to see the SQL the way PostgreSQL does, because
+    every character this skips is one that would otherwise read as structure:
+    ``'Elm (North), Ward 2'`` carries both the separator and the terminator the
+    scanner looks for, and a comment can carry an unbalanced parenthesis.
+    """
+    comment = _skip_comment(sql, i)
+    if comment is not None:
+        return comment
+    return _skip_quoted(sql, i)
+
+
+def _marker_starts_at(sql: str, i: int) -> bool:
+    """Whether a bare ``geolens_buffer`` token begins at ``i``.
+
+    Case-insensitive, whole-token, and unqualified: ``geolens_buffer_x`` is a
+    different name, and ``public.geolens_buffer`` names some other schema's
+    function — substituting our expression for that would answer a different
+    question than the one asked.
+    """
+    if sql[i : i + len(_MARKER)].lower() != _MARKER:
+        return False
+    if _is_ident_at(sql, i - 1) or sql[i - 1 : i] == ".":
+        return False
+    return not _is_ident_at(sql, i + len(_MARKER))
+
+
+def _next_code_char(sql: str, i: int) -> int | None:
+    """Index of the next character that is neither whitespace nor a comment."""
+    while i < len(sql):
+        if sql[i].isspace():
+            i += 1
+            continue
+        past = _skip_comment(sql, i)
+        if past is None:
+            return i
+        i = past
+    return None
+
+
+def _split_call_args(sql: str, open_paren: int) -> tuple[list[str], int]:
+    """Arguments of the call whose ``(`` is at ``open_paren``, and its end.
+
+    Balanced-parenthesis scanning over code positions only. Returns the raw
+    argument slices (unstripped) and the index just past the closing ``)``.
+    """
+    depth = 1
+    start = open_paren + 1
+    args: list[str] = []
+    i = start
+    while i < len(sql):
+        past = _skip_non_code(sql, i)
+        if past is not None:
+            i = past
+            continue
+        ch = sql[i]
+        if ch == "(":
+            depth += 1
+        elif ch == ")":
+            depth -= 1
+            if depth == 0:
+                args.append(sql[start:i])
+                return args, i + 1
+        elif ch == "," and depth == 1:
+            args.append(sql[start:i])
+            start = i + 1
+        i += 1
+    raise _fail(f"Query has an unclosed {_MARKER}() call")
+
+
+def _contains_marker(text: str) -> bool:
+    """Whether ``text`` holds a ``geolens_buffer`` token at a code position."""
+    i = 0
+    while i < len(text):
+        past = _skip_non_code(text, i)
+        if past is not None:
+            i = past
+            continue
+        if _marker_starts_at(text, i):
+            return True
+        i += 1
+    return False
+
+
+def _checked_geometry(raw: str) -> str:
+    """The geometry argument, checked for SYNTAX and nothing else.
+
+    One expression, and not a bare statement. That is the whole contract: it
+    keeps a structurally broken argument from becoming a confusing sandbox
+    error two layers later, and it stops there on purpose. Deciding whether the
+    expression is an acceptable buffer INPUT — bounded, allowlisted, resolvable
+    to a stored column — belongs to ``_is_bounded_geometry_source`` and the
+    function allowlist, in one place, for the reasons #1002 recorded.
+    """
+    geom = raw.strip()
+    if not geom:
+        raise _fail(f"{_MARKER}() needs a geometry expression")
+    if _contains_marker(geom):
+        # Innermost-first expansion would render fine and then be refused: the
+        # validator exempts a buffer only when its input resolves to a stored
+        # geometry, and a buffer is not one. The prompt says the same ("a
+        # nested buffer ... is refused"), so refusing here trades a sandbox
+        # error about spatial functions the model never wrote for a sentence
+        # about the thing it actually did.
+        raise _fail(f"{_MARKER}() cannot be nested inside another {_MARKER}()")
+    try:
+        parsed = [stmt for stmt in sqlglot.parse(geom, dialect="postgres") if stmt]
+    except Exception as exc:  # broad: any sqlglot failure is a refusal
+        raise _fail(
+            f"{_MARKER}()'s geometry argument is not a valid expression"
+        ) from exc
+    if len(parsed) != 1 or (
+        isinstance(parsed[0], exp.Query) and not isinstance(parsed[0], exp.Subquery)
+    ):
+        raise _fail(f"{_MARKER}()'s geometry argument is not a single expression")
+    return geom
+
+
+def _checked_distance(raw: str) -> float:
+    """The distance argument as a float, or a refusal.
+
+    A literal only. ``render_geodesic_buffer`` interpolates this value into SQL
+    text and does NOT bound it — ``render_buffer_expr`` is the caller that
+    does, and it is not on this path — so the range check has to happen here.
+    The bounds are that function's: greater than zero, at most
+    ``MAX_BUFFER_METERS``. A zero-metre buffer is refused rather than rendered
+    empty, which is what the analysis surface does with the same number.
+    """
+    text = raw.strip()
+    if not _DISTANCE.match(text):
+        raise _fail(f"{_MARKER}()'s distance must be a plain number of metres")
+    distance = float(text)
+    if not math.isfinite(distance) or not 0 < distance <= MAX_BUFFER_METERS:
+        raise _fail(
+            f"{_MARKER}()'s distance must be between 0 and {MAX_BUFFER_METERS:g} metres"
+        )
+    return distance
+
+
+def expand_buffer_markers(sql: str) -> str:
+    """Replace every ``geolens_buffer(geom, metres)`` with the real expression.
+
+    Returns ``sql`` itself when it carries no marker, so the far more common
+    no-buffer path costs one substring search and changes nothing.
+
+    Raises:
+        SandboxError: category ``invalid_query``, for a malformed marker — bad
+            arity, a distance that is not a plain in-range number, an unclosed
+            call, a nested marker, or more markers than the sandbox will
+            verify.
+    """
+    if _MARKER not in sql.lower():
+        return sql
+
+    pieces: list[str] = []
+    consumed = 0
+    markers = 0
+    i = 0
+    while i < len(sql):
+        past = _skip_non_code(sql, i)
+        if past is not None:
+            i = past
+            continue
+        if not _marker_starts_at(sql, i):
+            i += 1
+            continue
+
+        # A bare ``geolens_buffer`` that is not a call is left alone: it is a
+        # name the sandbox refuses on its own terms, and guessing at what the
+        # model meant is not this module's job.
+        after = _next_code_char(sql, i + len(_MARKER))
+        if after is None or sql[after] != "(":
+            i += len(_MARKER)
+            continue
+
+        markers += 1
+        if markers > MAX_BUFFER_MARKERS:
+            raise _fail(f"Query uses more than {MAX_BUFFER_MARKERS} {_MARKER}() calls")
+
+        args, end = _split_call_args(sql, after)
+        if len(args) != 2:
+            raise _fail(
+                f"{_MARKER}() takes exactly two arguments: a geometry and a "
+                "distance in metres"
+            )
+        geom = _checked_geometry(args[0])
+        distance = _checked_distance(args[1])
+
+        pieces.append(sql[consumed:i])
+        pieces.append(render_geodesic_buffer(geom, distance))
+        consumed = end
+        i = end
+
+    if not pieces:
+        return sql
+    pieces.append(sql[consumed:])
+    expanded = "".join(pieces)
+    # Nightly eval triage is the reason this line exists: when a buffer
+    # question fails, the first thing worth knowing is whether the model asked
+    # for a buffer at all, and after expansion the SQL no longer says.
+    logger.info(
+        "sql.buffer_markers_expanded", markers=markers, sql_length=len(expanded)
+    )
+    return expanded

--- a/backend/app/processing/ai/buffer_marker.py
+++ b/backend/app/processing/ai/buffer_marker.py
@@ -187,17 +187,27 @@ def _skip_non_code(sql: str, i: int) -> int | None:
     return _skip_quoted(sql, i)
 
 
-def _marker_starts_at(sql: str, i: int) -> bool:
+def _marker_starts_at(sql: str, i: int, previous: str) -> bool:
     """Whether a bare ``geolens_buffer`` token begins at ``i``.
 
     Case-insensitive, whole-token, and unqualified: ``geolens_buffer_x`` is a
     different name, and ``public.geolens_buffer`` names some other schema's
     function — substituting our expression for that would answer a different
     question than the one asked.
+
+    ``previous`` is the last character before ``i`` that was neither whitespace
+    nor part of a comment, which the callers track as they scan. fix(#1589
+    review r2): reading ``sql[i - 1]`` for the qualifier instead made the rule
+    untrue for ``public./**/geolens_buffer(…)`` and ``public. geolens_buffer(…)``
+    — the first because the scan had skipped the comment and saw ``/``, the
+    second because it saw a space. Both are qualified names in PostgreSQL. The
+    ADJACENCY half stays positional on purpose: ``xgeolens_buffer`` is one
+    identifier, while ``x geolens_buffer`` is two, so a space matters there and
+    not here.
     """
     if sql[i : i + len(_MARKER)].lower() != _MARKER:
         return False
-    if _is_ident_at(sql, i - 1) or sql[i - 1 : i] == ".":
+    if _is_ident_at(sql, i - 1) or previous == ".":
         return False
     return not _is_ident_at(sql, i + len(_MARKER))
 
@@ -246,15 +256,28 @@ def _split_call_args(sql: str, open_paren: int) -> tuple[list[str], int]:
 
 
 def _contains_marker(text: str) -> bool:
-    """Whether ``text`` holds a ``geolens_buffer`` token at a code position."""
+    """Whether ``text`` holds a ``geolens_buffer`` token at a code position.
+
+    Tracks ``previous`` exactly as ``expand_buffer_markers`` does, so the two
+    agree on what counts as a marker. They disagreeing is how a string could be
+    expanded at the top level and rejected as nesting inside an argument.
+    """
     i = 0
+    previous = ""
     while i < len(text):
-        past = _skip_non_code(text, i)
+        past = _skip_comment(text, i)
         if past is not None:
+            i = past  # a comment is transparent; `previous` carries across it
+            continue
+        past = _skip_quoted(text, i)
+        if past is not None:
+            previous = text[past - 1]
             i = past
             continue
-        if _marker_starts_at(text, i):
+        if _marker_starts_at(text, i, previous):
             return True
+        if not text[i].isspace():
+            previous = text[i]
         i += 1
     return False
 
@@ -351,8 +374,13 @@ def _checked_distance(raw: str) -> float:
     The bounds are that function's: greater than zero, at most
     ``MAX_BUFFER_METERS``. A zero-metre buffer is refused rather than rendered
     empty, which is what the analysis surface does with the same number.
+
+    Comments are dropped first, for the reason ``_without_comments`` gives:
+    ``geolens_buffer(s.geom_4326, 500 /* metres */)`` is a correct call, and
+    refusing it would leave half of the failure class this change removes
+    (fix(#1589 review r2)).
     """
-    text = raw.strip()
+    text = _without_comments(raw).strip()
     if not _DISTANCE.match(text):
         raise _fail(f"{_MARKER}()'s distance must be a plain number of metres")
     distance = float(text)
@@ -382,12 +410,22 @@ def expand_buffer_markers(sql: str) -> str:
     consumed = 0
     markers = 0
     i = 0
+    # The last character that was neither whitespace nor part of a comment.
+    # Only the qualifier rule reads it; see _marker_starts_at.
+    previous = ""
     while i < len(sql):
-        past = _skip_non_code(sql, i)
+        past = _skip_comment(sql, i)
         if past is not None:
+            i = past  # a comment is transparent; `previous` carries across it
+            continue
+        past = _skip_quoted(sql, i)
+        if past is not None:
+            previous = sql[past - 1]
             i = past
             continue
-        if not _marker_starts_at(sql, i):
+        if not _marker_starts_at(sql, i, previous):
+            if not sql[i].isspace():
+                previous = sql[i]
             i += 1
             continue
 
@@ -396,6 +434,7 @@ def expand_buffer_markers(sql: str) -> str:
         # model meant is not this module's job.
         after = _next_code_char(sql, i + len(_MARKER))
         if after is None or sql[after] != "(":
+            previous = _MARKER[-1]
             i += len(_MARKER)
             continue
 
@@ -415,6 +454,7 @@ def expand_buffer_markers(sql: str) -> str:
         pieces.append(sql[consumed:i])
         pieces.append(render_geodesic_buffer(geom, distance))
         consumed = end
+        previous = ")"
         i = end
 
     if not pieces:

--- a/backend/app/processing/ai/buffer_marker.py
+++ b/backend/app/processing/ai/buffer_marker.py
@@ -328,6 +328,80 @@ def _without_comments(text: str) -> str:
     return "".join(kept)
 
 
+def _single_expression(text: str) -> exp.Expression | None:
+    """The one expression ``text`` parses to, or None when it is not one.
+
+    None covers three cases the caller treats alike: sqlglot cannot parse it,
+    it is more than one statement, or it is a bare statement rather than an
+    expression. A parenthesised ``(SELECT …)`` is an ``exp.Subquery`` and so
+    an expression, which is the shape the prompt teaches for a scalar input.
+    """
+    try:
+        parsed = [stmt for stmt in sqlglot.parse(text, dialect="postgres") if stmt]
+    except Exception:  # broad: any sqlglot failure is a refusal
+        return None
+    if len(parsed) != 1:
+        return None
+    root = parsed[0]
+    if isinstance(root, exp.Query) and not isinstance(root, exp.Subquery):
+        return None
+    return root
+
+
+def _matching_paren(text: str, opening: int) -> int | None:
+    """Index of the ``)`` closing the ``(`` at ``opening``; None if unbalanced.
+
+    Scans code positions only, so a ``)`` inside a string literal does not
+    close anything.
+    """
+    depth = 0
+    i = opening
+    while i < len(text):
+        past = _skip_non_code(text, i)
+        if past is not None:
+            i = past
+            continue
+        if text[i] == "(":
+            depth += 1
+        elif text[i] == ")":
+            depth -= 1
+            if depth == 0:
+                return i
+        i += 1
+    return None
+
+
+def _without_redundant_parens(text: str) -> str:
+    """``text`` with wrapping parentheses removed, one layer at a time.
+
+    fix(#1589 review r2): ``geolens_buffer((s.geom_4326), 500)`` is a correct
+    call, and the parentheses are the model's formatting rather than anything
+    it was asked for. But ``_is_bounded_geometry_source`` in the validator
+    recognises a bare column or a scalar subquery and nothing else, so the
+    rendered ``(s.geom_4326)`` was not granted the exemption and the buffer
+    came back "disallowed spatial function". Harmless formatting, recreating
+    exactly the refusal this change exists to remove.
+
+    Two conditions stop the peel, and both matter:
+
+    - the opening parenthesis must be closed by the LAST character, or
+      ``(a) + (b)`` would lose the parentheses that group it, and
+      ``(s.geom_4326)::geometry`` would lose a cast's operand;
+    - the inside must still be an expression afterwards, or ``((SELECT …))``
+      would peel twice and leave a bare ``SELECT`` where the renderer needs a
+      scalar. It peels once, to the ``(SELECT …)`` the validator accepts.
+    """
+    while text.startswith("("):
+        close = _matching_paren(text, 0)
+        if close is None or text[close + 1 :].strip():
+            break
+        inner = text[1:close].strip()
+        if not inner or _single_expression(inner) is None:
+            break
+        text = inner
+    return text
+
+
 def _checked_geometry(raw: str) -> str:
     """The geometry argument, checked for SYNTAX and nothing else.
 
@@ -338,8 +412,10 @@ def _checked_geometry(raw: str) -> str:
     to a stored column — belongs to ``_is_bounded_geometry_source`` and the
     function allowlist, in one place, for the reasons #1002 recorded.
 
-    Comments are dropped rather than passed through; ``_without_comments`` has
-    the why.
+    Comments are dropped and redundant wrapping parentheses peeled rather than
+    passed through; ``_without_comments`` and ``_without_redundant_parens``
+    have the why. Both are formatting the model chose, both are
+    semantics-preserving to remove, and both otherwise cost it the exemption.
     """
     geom = _without_comments(raw).strip()
     if not geom:
@@ -350,17 +426,11 @@ def _checked_geometry(raw: str) -> str:
         # geometry, and a buffer is not one. The prompt says the same ("a
         # nested buffer ... is refused"). Refusing here rather than rendering
         # ~6 KB that cannot pass is the whole benefit; the specific reason
-        # reaches the server log, not the model (see _fail).
+        # reaches the server log, not the model (see _fail). Checked BEFORE the
+        # peel so a parenthesised nested marker is refused, not unwrapped.
         raise _fail(f"{_MARKER}() cannot be nested inside another {_MARKER}()")
-    try:
-        parsed = [stmt for stmt in sqlglot.parse(geom, dialect="postgres") if stmt]
-    except Exception as exc:  # broad: any sqlglot failure is a refusal
-        raise _fail(
-            f"{_MARKER}()'s geometry argument is not a valid expression"
-        ) from exc
-    if len(parsed) != 1 or (
-        isinstance(parsed[0], exp.Query) and not isinstance(parsed[0], exp.Subquery)
-    ):
+    geom = _without_redundant_parens(geom)
+    if _single_expression(geom) is None:
         raise _fail(f"{_MARKER}()'s geometry argument is not a single expression")
     return geom
 

--- a/backend/app/processing/ai/sql_generator.py
+++ b/backend/app/processing/ai/sql_generator.py
@@ -195,11 +195,13 @@ Respond with ONLY the SQL query (or an -- ERROR comment if the query cannot be g
 # in four places and inherited neither fix.
 #
 # fix(#935) embedded ``render_geodesic_buffer``'s rendered output here at
-# import time and told the model to copy it. fix(#1589) took that back out:
-# the expression is 3 088 characters, and the light model reproduced it
-# correctly about half the time — six of nine nightly eval runs failed on a
-# dropped parenthesis or a paraphrase back to the bare form. The prompt now
-# teaches a marker, ``geolens_buffer(<geom>, <metres>)``, and
+# import time, twice, and told the model to copy it: a 3 017-character
+# ``<GEOM>``/``<METERS>`` template plus a 3 073-character worked example, so
+# 6 090 of the prompt's 16 786 characters were rendered buffer. fix(#1589)
+# took both back out — the light model reproduced them correctly about half
+# the time, and six of nine nightly eval runs failed on a dropped parenthesis
+# or a paraphrase back to the bare form. The prompt is 11 595 characters now.
+# It teaches a marker, ``geolens_buffer(<geom>, <metres>)``, and
 # ``buffer_marker.expand_buffer_markers`` renders the real expression at the
 # tail of ``generate_sql`` before anything else sees the SQL.
 #

--- a/backend/app/processing/ai/sql_generator.py
+++ b/backend/app/processing/ai/sql_generator.py
@@ -14,9 +14,10 @@ import uuid as _uuid
 import structlog
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.platform.analysis_sql import render_geodesic_buffer
+from app.platform.analysis_sql import MAX_BUFFER_METERS
 from app.platform.cache import tenant_cache_key
 from app.platform.extensions import get_ai_provider
+from app.processing.ai.buffer_marker import expand_buffer_markers
 from app.processing.ai.llm_loop import noop_tool_executor
 from app.processing.ai.schemas import ChatMapLayer
 from app.processing.ai.token_usage import record_token_usage
@@ -191,21 +192,25 @@ Respond with ONLY the SQL query (or an -- ERROR comment if the query cannot be g
 # error 1/cos(latitude)) and produces corrupt geometry for buffers crossing
 # the antimeridian. The real analysis path fixed both (#883, #900, #902) in
 # ``render_geodesic_buffer``; the prompt previously restated the SQL as prose
-# in four places and inherited neither fix. Rendering the expression from the
-# same generator at import time removes the drift class by construction —
-# ``tests/test_ai_sql_prompt_935.py`` pins the wiring.
+# in four places and inherited neither fix.
 #
-# ``99999`` is a placeholder distance chosen because it cannot collide with
-# any other literal in the rendered expression; ``render_geometry_expr`` (not
-# ``render_geodesic_buffer``) owns distance validation, so the placeholder
-# render is safe.
-_GEODESIC_BUFFER_TEMPLATE = render_geodesic_buffer("<GEOM>", 99999).replace(
-    "99999", "<METERS>"
-)
-_GEODESIC_BUFFER_DENVER_EXAMPLE = render_geodesic_buffer(
-    "(SELECT geom_4326 FROM data.us_state_capitals WHERE name = 'Denver')",
-    50000,
-)
+# fix(#935) embedded ``render_geodesic_buffer``'s rendered output here at
+# import time and told the model to copy it. fix(#1589) took that back out:
+# the expression is 3 088 characters, and the light model reproduced it
+# correctly about half the time — six of nine nightly eval runs failed on a
+# dropped parenthesis or a paraphrase back to the bare form. The prompt now
+# teaches a marker, ``geolens_buffer(<geom>, <metres>)``, and
+# ``buffer_marker.expand_buffer_markers`` renders the real expression at the
+# tail of ``generate_sql`` before anything else sees the SQL.
+#
+# The anti-drift property #935 bought survives the change and is in fact
+# stronger: the prompt no longer states the expression at all, so there is
+# nothing left to drift. ``tests/test_ai_sql_prompt_935.py`` pins that the
+# expression is gone, that the marker is taught, and that the prompt's worked
+# example still expands into something the sandbox admits. The one import from
+# ``analysis_sql`` that remains is ``MAX_BUFFER_METERS``, so the distance
+# ceiling the prompt quotes is the one the expander enforces.
+_MAX_BUFFER_METERS_TEXT = f"{MAX_BUFFER_METERS:.0f}"
 
 SQL_SYSTEM_PROMPT = f"""\
 You are a PostgreSQL/PostGIS SQL expert. Generate a single SELECT query to answer the user's question using the database schema provided in the user message.
@@ -228,6 +233,7 @@ ST_AsGeoJSON(geom) -> text               -- Convert geometry to GeoJSON string
 ST_Transform(geom, srid) -> geometry     -- Reproject geometry to target SRID
 ST_X(point) -> float                     -- X coordinate (longitude) of a point
 ST_Y(point) -> float                     -- Y coordinate (latitude) of a point
+geolens_buffer(geom, meters) -> geometry -- Buffer in METERS; see Metric Buffers below
 
 ## Text Search Functions (requires pg_trgm extension)
 
@@ -258,7 +264,7 @@ Vector columns are queried with these operators, NOT with similarity() or ILIKE
 
 For distance in meters:  ST_Distance(a.geom_4326::geography, b.geom_4326::geography)
 For area in sq meters:   ST_Area(a.geom_4326::geography)
-For buffer in meters:    use the Metric Buffers expression below — NEVER a bare geography-cast buffer
+For buffer in meters:    geolens_buffer(s.geom_4326, meters) — NEVER a bare geography-cast buffer
 
 Without ::geography, distance/area use DEGREES (not meters)!
 
@@ -266,13 +272,15 @@ Without ::geography, distance/area use DEGREES (not meters)!
 
 For "within X meters of" questions, prefer ST_DWithin(a.geom_4326::geography, b.geom_4326::geography, meters) — it needs no buffer geometry and uses the spatial index.
 
-When the buffer GEOMETRY itself is needed, a bare ST_Buffer(geom::geography, meters)::geometry silently degrades: PostGIS projects the whole input into one planar SRID, which falls back to world Mercator for inputs spanning 45 degrees of longitude or more (radius error 1/cos(latitude)), and a buffer crossing the antimeridian comes back as corrupt geometry. Use this expression instead, copied VERBATIM with <GEOM> replaced by the geometry expression and <METERS> replaced by the distance in meters:
+When the buffer GEOMETRY itself is needed, a bare ST_Buffer(geom::geography, meters)::geometry silently degrades: PostGIS projects the whole input into one planar SRID, which falls back to world Mercator for inputs spanning 45 degrees of longitude or more (radius error 1/cos(latitude)), and a buffer crossing the antimeridian comes back as corrupt geometry. Write this instead:
 
-{_GEODESIC_BUFFER_TEMPLATE}
+geolens_buffer(<GEOM>, <METERS>)
 
-It is long but mechanical: it slices wide inputs into per-projection bands, splits antimeridian-crossing output at +/-180, and dissolves the parts. Do not abbreviate it, do not re-derive it, and do not substitute the bare ST_Buffer form.
+GeoLens replaces every geolens_buffer(...) call with the correct PostGIS expression before the query runs — one that slices wide inputs into per-projection bands, splits antimeridian-crossing output at +/-180, and dissolves the parts. Write the short call and nothing else: do not expand it yourself, and do not fall back to a bare ST_Buffer for a distance in meters.
 
-<GEOM> must be the managed geom_4326 column, and it must be QUALIFIED: a reference like s.geom_4326, or a subquery selecting one like (SELECT geom_4326 FROM data.t WHERE name = 'X'). A bare geom_4326 passed straight to the expression is refused. A reprojection, a nested buffer, a constructed geometry, or a dataset's original geom column in another CRS is refused, because the expression's cost scales with its input's extent and only geom_4326 is bounded. Buffer geom_4326, then transform the result if you need another CRS.
+<GEOM> must be the managed geom_4326 column, and it must be QUALIFIED: a reference like s.geom_4326, or a subquery selecting one like (SELECT geom_4326 FROM data.t WHERE name = 'X'). A bare geom_4326 passed straight to the call is refused, even when the query reads one table. So give that table an alias and use it: write FROM data.stations s ... geolens_buffer(s.geom_4326, 10000), never FROM data.stations ... geolens_buffer(geom_4326, 10000). A reprojection, a nested buffer, a constructed geometry, or a dataset's original geom column in another CRS is refused, because the expression's cost scales with its input's extent and only geom_4326 is bounded. Buffer geom_4326, then transform the result if you need another CRS.
+
+<METERS> must be a plain number greater than 0 and at most {_MAX_BUFFER_METERS_TEXT} — not an expression, not a column, not a cast. Convert other units yourself (5 miles is 8046.72). geolens_buffer is a GeoLens call, so it takes no other arguments and cannot be nested inside itself.
 
 ## Unit Conversions (apply in SQL, not after)
 
@@ -334,12 +342,17 @@ SELECT SUM(ST_Area(p.geom_4326::geography) / 4046.8564224) AS total_acres
 FROM data.parcels p
 WHERE p.zone_type = 'agricultural';
 
--- Buffer + intersect (metric buffer geometry, using the Metric Buffers expression):
+-- Metric buffer geometry per row (the alias is what makes s.geom_4326 qualified):
+SELECT s.name, ST_AsGeoJSON(geolens_buffer(s.geom_4326, 10000)) AS geometry
+FROM data.stations s
+LIMIT 1000;
+
+-- Buffer + intersect (metric buffer geometry, using geolens_buffer):
 SELECT p.name AS park_name
 FROM data.national_parks p
 WHERE ST_Intersects(
   p.geom_4326,
-  {_GEODESIC_BUFFER_DENVER_EXAMPLE}
+  geolens_buffer((SELECT geom_4326 FROM data.us_state_capitals WHERE name = 'Denver'), 50000)
 );
 
 -- Proximity by coordinates (within 5 miles of a point):
@@ -385,7 +398,7 @@ ORDER BY distance
 LIMIT 10;
 
 -- Common Mistakes to Avoid:
--- WRONG: ST_Buffer(geom_4326::geography, 1000)::geometry → wrong radius for wide inputs, corrupt across the antimeridian; use the Metric Buffers expression
+-- WRONG: ST_Buffer(p.geom_4326::geography, 1000)::geometry → wrong radius for wide inputs, corrupt across the antimeridian; use geolens_buffer(p.geom_4326, 1000)
 -- WRONG: ST_Distance(a.geom_4326, b.geom_4326) → returns DEGREES, not meters
 -- CORRECT: ST_Distance(a.geom_4326::geography, b.geom_4326::geography) → meters
 -- WRONG: WHERE column = NULL → always false; use WHERE column IS NULL
@@ -399,7 +412,7 @@ LIMIT 10;
 - Always use the `data.` schema prefix for table names (e.g., `data.cities`, not just `cities`).
 - The geometry column is always `geom_4326` (SRID 4326).
 - When querying multiple tables, always qualify column names with table alias to avoid ambiguity.
-- Use ::geography casts for distance, buffer, and area operations to get results in meters.
+- Use ::geography casts for distance and area operations to get results in meters; for a buffer in meters use geolens_buffer.
 - Always convert area/distance to human-friendly units (acres, miles, etc.) in the SQL using the conversion factors above.
 - For proximity filters ("within X miles/km of Y"), prefer ST_DWithin over ST_Distance < threshold — ST_DWithin uses the spatial index.
 - For ad-hoc coordinate queries, create points with: ST_SetSRID(ST_MakePoint(longitude, latitude), 4326)::geography
@@ -504,6 +517,14 @@ async def generate_sql(
 
     # Strip leaked special tokens from local LLMs (e.g., <|im_start|>, <|im_end|>)
     sql = re.sub(r"<\|[^|]+\|>", "", sql).strip()
+
+    # fix(#1589): the prompt asks for geolens_buffer(<geom>, <metres>); the
+    # canonical expression is rendered here, once, for every NL consumer. This
+    # is the last point at which the text is still the model's, which is what
+    # makes the marker a private protocol between the prompt and the server
+    # rather than a SQL dialect — the raw /api/query/ endpoint takes SQL a
+    # person wrote and never reaches this function.
+    sql = expand_buffer_markers(sql)
 
     logger.info(
         "SQL generated",

--- a/backend/tests/evals/test_sql_generation_evals.py
+++ b/backend/tests/evals/test_sql_generation_evals.py
@@ -556,8 +556,8 @@ async def test_seam_crossing_buffer_uses_the_geodesic_expression(
     client, test_db_session, pacific_dataset
 ):
     """fix(#935): a metric-buffer question over stations ~5.5 km from ±180
-    must reproduce the prompt's geodesic buffer expression, and the executed
-    output must stay coherent at the seam.
+    must produce the geodesic buffer expression, and the executed output must
+    stay coherent at the seam.
 
     SQL predicate: the distinctive machinery of render_geodesic_buffer
     (span-gated CASE + dissolve) is present. Result assertion: every output
@@ -565,6 +565,12 @@ async def test_seam_crossing_buffer_uses_the_geodesic_expression(
     bare ``ST_Buffer(::geography)`` is a single component ~359.9 degrees
     wide, which is exactly what drew a band across the map and fit-bounds'd
     the chat overlay to the whole world (#935's user-visible symptom).
+
+    fix(#1589): the model no longer types that expression — it writes
+    ``geolens_buffer(...)`` and ``generate_sql`` expands the marker before
+    returning. The predicates are unchanged and now read the expansion, which
+    is what actually runs; the marker itself must be gone by then, or
+    something downstream is looking at SQL nobody expanded.
     """
     sql, result = await _ask(
         test_db_session,
@@ -572,6 +578,7 @@ async def test_seam_crossing_buffer_uses_the_geodesic_expression(
         "Return each station's name and a 10 kilometer buffer around it "
         "as GeoJSON geometry.",
     )
+    assert "geolens_buffer" not in sql.lower(), f"marker left unexpanded:\n{sql}"
     assert "ST_UnaryUnion" in sql, f"geodesic buffer expression not used:\n{sql}"
     assert re.search(r"ST_XMax\(\w+\.g\)\s*-\s*ST_XMin\(\w+\.g\)", sql), (
         f"span-gated buffer CASE missing:\n{sql}"
@@ -593,13 +600,16 @@ async def test_wide_multipart_buffer_stays_component_narrow(
     across the seam, so its buffer trips the >= 6° span gate — the branch the
     per-point question cannot reach. Every output component must stay narrow
     and inside ±180; the unfixed whole-input projection produced either a
-    world-spanning component or geometry escaping the range."""
+    world-spanning component or geometry escaping the range.
+
+    fix(#1589): asserted on the expanded SQL, as above."""
     sql, result = await _ask(
         test_db_session,
         pacific_dataset,
         "Buffer the Fiji Basin Network region by 10 kilometers and return "
         "its name and the buffer as GeoJSON geometry.",
     )
+    assert "geolens_buffer" not in sql.lower(), f"marker left unexpanded:\n{sql}"
     assert "ST_UnaryUnion" in sql, f"geodesic buffer expression not used:\n{sql}"
     widths, lons = _geojson_component_stats(result)
     assert widths, f"no GeoJSON geometry in result columns {result.columns}\nSQL: {sql}"

--- a/backend/tests/test_ai_buffer_marker_1589.py
+++ b/backend/tests/test_ai_buffer_marker_1589.py
@@ -288,6 +288,82 @@ def test_a_comment_that_looks_like_one_inside_a_literal_is_kept():
 
 
 # ---------------------------------------------------------------------------
+# Redundant parentheses (fix(#1589) review r2)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "geom",
+    [
+        pytest.param("(s.geom_4326)", id="one-layer"),
+        pytest.param("((s.geom_4326))", id="two-layers"),
+        pytest.param("(  s.geom_4326  )", id="padded"),
+        pytest.param("( (s.geom_4326) )", id="padded-two-layers"),
+        pytest.param("(s.geom_4326 /* the stop */)", id="with-a-comment"),
+    ],
+)
+def test_wrapping_parentheses_are_peeled_off_the_geometry(geom):
+    """The model's formatting must not cost it the exemption.
+
+    ``_is_bounded_geometry_source`` recognises a bare column or a scalar
+    subquery, so a rendered ``(s.geom_4326)`` got no exemption and the buffer
+    came back "disallowed spatial function" — the refusal this whole change
+    exists to remove, brought back by a pair of parentheses.
+    """
+    expanded = expand_buffer_markers(_wrap(f"geolens_buffer({geom}, 500)"))
+    assert expanded == _wrap(render_geodesic_buffer("s.geom_4326", 500.0))
+    assert validate_sql(expanded).tables == {("data", "stations")}
+
+
+def test_a_doubly_wrapped_subquery_peels_to_the_form_the_validator_accepts():
+    """Exactly one layer comes off ``((SELECT …))``.
+
+    Peeling both would leave a bare ``SELECT`` where the renderer fences a
+    scalar, so the stop condition is that the inside must still be an
+    expression. ``(SELECT …)`` is the shape the prompt teaches and the
+    validator admits, and this asserts it lands there rather than merely
+    parsing.
+    """
+    inner = "(SELECT geom_4326 FROM data.us_state_capitals WHERE name = 'Denver')"
+    expanded = expand_buffer_markers(
+        "SELECT p.name FROM data.national_parks p "
+        f"WHERE ST_Intersects(p.geom_4326, geolens_buffer(({inner}), 50000)) LIMIT 100"
+    )
+    assert expanded == (
+        "SELECT p.name FROM data.national_parks p "
+        f"WHERE ST_Intersects(p.geom_4326, {render_geodesic_buffer(inner, 50000.0)}) "
+        "LIMIT 100"
+    )
+    assert validate_sql(expanded).tables == {
+        ("data", "national_parks"),
+        ("data", "us_state_capitals"),
+    }
+
+
+@pytest.mark.parametrize(
+    "geom",
+    [
+        pytest.param("(s.geom_4326)::geometry", id="cast-operand"),
+        pytest.param("(s.x) + (s.y)", id="two-groups"),
+        pytest.param("(s.geom_4326) IS NOT NULL", id="trailing-predicate"),
+    ],
+)
+def test_parentheses_that_are_not_a_wrapper_are_left_alone(geom):
+    """The counterfactual for the peel: the first ``(`` here is not closed by
+    the last character, so removing it would change what the expression means.
+    The argument reaches the renderer exactly as written."""
+    expanded = expand_buffer_markers(_wrap(f"geolens_buffer({geom}, 500)"))
+    assert expanded == _wrap(render_geodesic_buffer(geom, 500.0))
+
+
+def test_parentheses_around_a_nested_marker_do_not_unwrap_it():
+    """The nesting check runs before the peel, so a parenthesised inner marker
+    is still refused rather than quietly unwrapped into one."""
+    err = _refusal(_wrap("geolens_buffer((geolens_buffer(s.geom_4326, 10)), 20)"))
+    assert "nested" in str(err).lower()
+
+
+# ---------------------------------------------------------------------------
 # Malformed markers
 # ---------------------------------------------------------------------------
 

--- a/backend/tests/test_ai_buffer_marker_1589.py
+++ b/backend/tests/test_ai_buffer_marker_1589.py
@@ -1,0 +1,527 @@
+"""fix(#1589): the NL->SQL prompt asks for a marker; the server expands it.
+
+Before this, the prompt embedded ``render_geodesic_buffer``'s rendered output
+(3 088 characters) and told the model to reproduce it character for character.
+The light model managed that about half the time — the nightly buffer evals
+failed on six of nine runs between 08-12 and 08-18, every failure a sandbox
+refusal of a dropped parenthesis or a paraphrase back to the bare
+``ST_Buffer(::geography)`` form, never a wrong answer that ran.
+
+So the model now writes ``geolens_buffer(<geom>, <metres>)`` and
+``app.processing.ai.buffer_marker`` substitutes the canonical render before
+anything sees the SQL. The shape can no longer be wrong, because the model no
+longer writes it.
+
+What these tests hold down:
+
+- the scanner reads the arguments the way PostgreSQL would — balanced parens,
+  string literals, comments — and never by regex;
+- a malformed marker fails as ``invalid_query`` rather than being passed
+  through to produce a confusing sandbox error later;
+- expansion happens on MODEL output only. The raw ``POST /api/query/``
+  endpoint takes user-written SQL and must keep refusing ``geolens_buffer``
+  as the unknown function it is;
+- the geometry argument stays fully under the sandbox's authority. The
+  expander decides syntax, never policy — #1002 is the record of what
+  happens when two layers both try to decide whether a buffer's argument is
+  safe.
+"""
+
+import pytest
+import sqlglot
+
+from app.platform.analysis_sql import MAX_BUFFER_METERS, render_geodesic_buffer
+from app.platform.sandbox import SandboxError
+from app.platform.sandbox.validator import validate_sql
+from app.processing.ai.buffer_marker import (
+    MAX_BUFFER_MARKERS,
+    expand_buffer_markers,
+)
+
+
+def _wrap(expr: str, table: str = "data.stations s") -> str:
+    return f"SELECT ST_AsGeoJSON({expr}) AS geometry FROM {table} LIMIT 100"
+
+
+# ---------------------------------------------------------------------------
+# The happy path: what the model is now asked to write
+# ---------------------------------------------------------------------------
+
+
+def test_a_simple_marker_becomes_the_canonical_render():
+    sql = _wrap("geolens_buffer(s.geom_4326, 500)")
+    assert expand_buffer_markers(sql) == _wrap(
+        render_geodesic_buffer("s.geom_4326", 500.0)
+    )
+
+
+def test_the_prompts_worked_example_expands_and_the_sandbox_admits_it():
+    """The Denver example the prompt teaches, end to end.
+
+    This is the counterfactual for every refusal test below: the machinery
+    that rejects a hostile argument has to let the taught shape through, or
+    the rejections prove nothing.
+    """
+    denver = "(SELECT geom_4326 FROM data.us_state_capitals WHERE name = 'Denver')"
+    expanded = expand_buffer_markers(
+        "SELECT p.name AS park_name\n"
+        "FROM data.national_parks p\n"
+        f"WHERE ST_Intersects(p.geom_4326, geolens_buffer({denver}, 50000))\n"
+        "LIMIT 100"
+    )
+    assert "geolens_buffer" not in expanded
+    result = validate_sql(expanded)
+    assert result.tables == {
+        ("data", "national_parks"),
+        ("data", "us_state_capitals"),
+    }
+
+
+def test_a_nested_call_in_the_geometry_argument_survives_intact():
+    geom = "ST_Transform(ST_SetSRID(ST_MakePoint(-105.0, 39.7), 4326), 4326)"
+    expanded = expand_buffer_markers(_wrap(f"geolens_buffer({geom}, 1000)"))
+    assert expanded == _wrap(render_geodesic_buffer(geom, 1000.0))
+
+
+def test_a_string_literal_holding_parens_and_commas_does_not_split_the_arguments():
+    """The argument split cannot be a regex: this literal contains both the
+    separator and the terminator the scanner is looking for."""
+    geom = "(SELECT geom_4326 FROM data.parks WHERE name = 'Elm (North), Ward 2')"
+    expanded = expand_buffer_markers(_wrap(f"geolens_buffer({geom}, 250)"))
+    assert expanded == _wrap(render_geodesic_buffer(geom, 250.0))
+
+
+def test_a_doubled_quote_inside_a_literal_does_not_end_it():
+    geom = "(SELECT geom_4326 FROM data.parks WHERE name = 'O''Hare, gate (3)')"
+    expanded = expand_buffer_markers(_wrap(f"geolens_buffer({geom}, 250)"))
+    assert expanded == _wrap(render_geodesic_buffer(geom, 250.0))
+
+
+def test_every_marker_in_a_statement_is_expanded():
+    sql = (
+        "SELECT ST_Intersects("
+        "geolens_buffer(a.geom_4326, 100), geolens_buffer(b.geom_4326, 200))\n"
+        "FROM data.a a, data.b b"
+    )
+    expanded = expand_buffer_markers(sql)
+    assert render_geodesic_buffer("a.geom_4326", 100.0) in expanded
+    assert render_geodesic_buffer("b.geom_4326", 200.0) in expanded
+    assert "geolens_buffer" not in expanded
+
+
+def test_the_marker_name_and_its_spacing_are_read_loosely():
+    """Case and whitespace are the model's freedom; the call is not."""
+    expanded = expand_buffer_markers(
+        _wrap("GeoLens_Buffer\n  (  s.geom_4326 ,  500  )")
+    )
+    assert expanded == _wrap(render_geodesic_buffer("s.geom_4326", 500.0))
+
+
+def test_sql_without_a_marker_is_returned_unchanged():
+    sql = "SELECT s.name, ST_Area(s.geom_4326::geography) FROM data.stations s"
+    assert expand_buffer_markers(sql) is sql
+
+
+def test_an_error_comment_from_the_model_passes_through():
+    sql = "-- ERROR: Cannot answer this question with the available data."
+    assert expand_buffer_markers(sql) is sql
+
+
+# ---------------------------------------------------------------------------
+# Where the marker is NOT a call
+# ---------------------------------------------------------------------------
+
+
+def test_a_marker_inside_a_string_literal_is_not_a_call():
+    sql = "SELECT 'geolens_buffer(s.geom_4326, 500)' AS note FROM data.stations s"
+    assert expand_buffer_markers(sql) is sql
+
+
+def test_a_marker_inside_a_line_comment_is_not_a_call():
+    sql = (
+        "SELECT s.name FROM data.stations s\n"
+        "-- geolens_buffer(s.geom_4326, 500) would go here"
+    )
+    assert expand_buffer_markers(sql) is sql
+
+
+def test_a_marker_inside_a_block_comment_is_not_a_call():
+    sql = "SELECT s.name /* geolens_buffer(s.geom_4326, 500 */ FROM data.stations s"
+    assert expand_buffer_markers(sql) is sql
+
+
+def test_a_longer_identifier_that_merely_starts_with_the_marker_is_not_a_call():
+    sql = "SELECT geolens_buffer_x(s.geom_4326, 500) FROM data.stations s"
+    assert expand_buffer_markers(sql) is sql
+
+
+def test_a_qualified_name_ending_in_the_marker_is_not_a_call():
+    """``public.geolens_buffer(...)`` names some other schema's function, and
+    substituting our expression for it would answer a different question."""
+    sql = "SELECT public.geolens_buffer(s.geom_4326, 500) FROM data.stations s"
+    assert expand_buffer_markers(sql) is sql
+
+
+def test_a_comment_between_the_name_and_its_parenthesis_still_reads_as_a_call():
+    expanded = expand_buffer_markers(
+        _wrap("geolens_buffer /* metric */ (s.geom_4326, 500)")
+    )
+    assert expanded == _wrap(render_geodesic_buffer("s.geom_4326", 500.0))
+
+
+# ---------------------------------------------------------------------------
+# Malformed markers
+# ---------------------------------------------------------------------------
+
+
+def _refusal(sql: str) -> SandboxError:
+    with pytest.raises(SandboxError) as excinfo:
+        expand_buffer_markers(sql)
+    assert excinfo.value.category == "invalid_query"
+    return excinfo.value
+
+
+@pytest.mark.parametrize(
+    "call",
+    [
+        pytest.param("geolens_buffer(s.geom_4326)", id="one-argument"),
+        pytest.param("geolens_buffer(s.geom_4326, 100, 8)", id="three-arguments"),
+        pytest.param("geolens_buffer()", id="no-arguments"),
+        pytest.param("geolens_buffer(, 100)", id="empty-geometry"),
+    ],
+)
+def test_wrong_arity_is_refused(call):
+    _refusal(_wrap(call))
+
+
+def test_an_unterminated_marker_is_refused():
+    _refusal("SELECT ST_AsGeoJSON(geolens_buffer(s.geom_4326, 500 FROM data.stations s")
+
+
+def test_an_unterminated_string_literal_in_the_argument_is_refused():
+    _refusal("SELECT geolens_buffer((SELECT geom_4326 FROM data.t WHERE n = 'x), 500)")
+
+
+@pytest.mark.parametrize(
+    "distance",
+    [
+        pytest.param("", id="empty"),
+        pytest.param("0", id="zero"),
+        pytest.param("-100", id="negative"),
+        pytest.param("1e400", id="overflows-to-inf"),
+        pytest.param("'500'", id="quoted"),
+        pytest.param("500 + 1", id="expression"),
+        pytest.param("s.radius", id="column"),
+        pytest.param("NaN", id="nan"),
+        pytest.param("Infinity", id="infinity"),
+        pytest.param("500::numeric", id="cast"),
+        pytest.param("0x1F", id="hex"),
+        pytest.param("1_000", id="underscore-separated"),
+        pytest.param(f"{MAX_BUFFER_METERS + 1:g}", id="over-the-cap"),
+    ],
+)
+def test_a_distance_that_is_not_a_plain_in_range_number_is_refused(distance):
+    _refusal(_wrap(f"geolens_buffer(s.geom_4326, {distance})"))
+
+
+@pytest.mark.parametrize(
+    ("distance", "expected"),
+    [
+        ("1", 1.0),
+        ("1500.5", 1500.5),
+        ("1e4", 10000.0),
+        ("1E4", 10000.0),
+        (".5", 0.5),
+        ("100000", MAX_BUFFER_METERS),
+        ("100000.0", MAX_BUFFER_METERS),
+    ],
+)
+def test_an_in_range_numeric_literal_is_accepted_however_it_is_spelled(
+    distance, expected
+):
+    expanded = expand_buffer_markers(_wrap(f"geolens_buffer(s.geom_4326, {distance})"))
+    assert expanded == _wrap(render_geodesic_buffer("s.geom_4326", expected))
+
+
+def test_a_geometry_argument_that_is_not_one_expression_is_refused():
+    """Syntax only. Whether the expression is an ACCEPTABLE geometry is the
+    sandbox's call, and deliberately not re-decided here."""
+    _refusal(_wrap("geolens_buffer(SELECT geom_4326 FROM data.t, 500)"))
+    _refusal(_wrap("geolens_buffer(s.geom_4326 OFFSET 0, 500)"))
+
+
+# ---------------------------------------------------------------------------
+# Nesting and volume
+# ---------------------------------------------------------------------------
+
+
+def test_a_nested_marker_is_refused_rather_than_expanded_inside_out():
+    """Decision, recorded here and in the module: reject.
+
+    An inner buffer is not a stored geometry, so ``_is_bounded_geometry_source``
+    in the validator refuses the outer one no matter what we render — the
+    prompt says as much ("a nested buffer ... is refused"). Expanding it
+    anyway would trade a sentence the model can act on for a sandbox error
+    about a spatial function it never wrote.
+    """
+    err = _refusal(_wrap("geolens_buffer(geolens_buffer(s.geom_4326, 10), 20)"))
+    assert "nested" in str(err).lower()
+
+
+def test_the_marker_count_is_capped():
+    calls = ", ".join(
+        f"geolens_buffer(s.geom_4326, {i + 1}00)" for i in range(MAX_BUFFER_MARKERS)
+    )
+    at_cap = f"SELECT {calls} FROM data.stations s"
+    assert "geolens_buffer" not in expand_buffer_markers(at_cap)
+
+    over = f"SELECT {calls}, geolens_buffer(s.geom_4326, 900) FROM data.stations s"
+    _refusal(over)
+
+
+def test_the_marker_cap_matches_the_validators_verification_budget():
+    """One over the validator's budget is one the sandbox would refuse anyway.
+
+    ``_MAX_BUFFER_MATCH_ATTEMPTS`` bounds how many buffer-shaped subtrees the
+    validator will re-render and verify; past it no exemption is granted. So
+    expanding a ninth marker can only produce SQL that is rejected after
+    ~25 KB of rendering. Keeping the two numbers equal is the point, not a
+    coincidence — this fails if either moves alone.
+    """
+    from app.platform.sandbox.validator import _MAX_BUFFER_MATCH_ATTEMPTS
+
+    assert MAX_BUFFER_MARKERS == _MAX_BUFFER_MATCH_ATTEMPTS
+
+
+# ---------------------------------------------------------------------------
+# The geometry argument keeps every check the sandbox applies
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "geom",
+    [
+        pytest.param("pg_sleep(5)", id="pg_sleep"),
+        pytest.param("pg_read_file('/etc/passwd')", id="pg_read_file"),
+        pytest.param("lo_import('/etc/passwd')", id="lo_import"),
+        pytest.param("dblink('host=evil', 'SELECT 1')", id="dblink"),
+        pytest.param("ST_AsEWKB(s.geom_4326) || 'x'", id="concat"),
+        pytest.param(
+            "(SELECT pg_sleep(5) FROM data.other)", id="subquery-hiding-a-call"
+        ),
+        pytest.param("ST_Transform(s.geom_4326, 3857)", id="reprojection"),
+        pytest.param(
+            "ST_Buffer(ST_SetSRID(ST_MakePoint(0, 0), 4326), 1000000000)",
+            id="planar-buffer-in-degrees",
+        ),
+    ],
+)
+def test_expansion_grants_the_geometry_argument_nothing(geom):
+    """The exemption covers the scaffold the renderer produced, never the
+    argument. A marker is therefore not a way in: whatever the model puts in
+    the geometry slot is validated as ordinary SQL, exactly as it would be if
+    the model had written the whole expression itself."""
+    expanded = expand_buffer_markers(_wrap(f"geolens_buffer({geom}, 100)"))
+    with pytest.raises(SandboxError) as excinfo:
+        validate_sql(expanded)
+    assert excinfo.value.category == "invalid_query"
+
+
+def test_a_comment_cannot_smuggle_sql_through_the_argument_split():
+    """A comment that carries the separator, the terminator and a payload.
+
+    Two things have to hold. Nothing inside the comment may become SQL — the
+    scanner reads it as a comment, so ``pg_sleep`` stays text and ``data.t``
+    never becomes a table. And the statement is refused anyway: the comment
+    rides into the rendered scaffold, where it perturbs the re-render
+    ``_matches_canonical_buffer`` compares against, so no exemption is granted
+    and the buffer's own functions fall back under the allowlist. That is the
+    fail-closed direction, and it is the same outcome a model would have got
+    writing the expression by hand with a comment in it.
+    """
+    smuggle = "s.geom_4326 /*, 1) AS g, pg_sleep(9) FROM data.t --*/"
+    expanded = expand_buffer_markers(_wrap(f"geolens_buffer({smuggle}, 100)"))
+
+    stmt = sqlglot.parse_one(expanded, dialect="postgres")
+    called = {fn.name.lower() for fn in stmt.find_all(sqlglot.exp.Anonymous)}
+    assert "pg_sleep" not in called
+    assert not [tbl for tbl in stmt.find_all(sqlglot.exp.Table) if tbl.name == "t"]
+
+    with pytest.raises(SandboxError) as excinfo:
+        validate_sql(expanded)
+    assert excinfo.value.category == "invalid_query"
+
+
+def test_a_benign_marker_in_the_same_shape_validates():
+    """The counterfactual for the refusals above: same statement, same
+    expansion, an ordinary column in the geometry slot."""
+    result = validate_sql(
+        expand_buffer_markers(_wrap("geolens_buffer(s.geom_4326, 500)"))
+    )
+    assert result.tables == {("data", "stations")}
+
+
+def test_a_cast_around_the_call_does_not_break_the_exemption():
+    """``geolens_buffer(...)::geometry`` is a shape the model may reach for,
+    and the exemption is matched on the subquery inside the cast, so it still
+    lands."""
+    result = validate_sql(
+        expand_buffer_markers(
+            "SELECT geolens_buffer(s.geom_4326, 500)::geometry AS g "
+            "FROM data.stations s LIMIT 10"
+        )
+    )
+    assert result.tables == {("data", "stations")}
+
+
+def test_the_expansion_is_what_the_validator_recognises_as_canonical():
+    """Not merely 'the statement validates' — the buffer's own machinery is
+    admitted through the fix(#1001) exemption, which is only granted to an
+    exact re-render."""
+    from app.platform.sandbox.validator import _canonical_buffer_exempt_ids
+
+    expanded = expand_buffer_markers(_wrap("geolens_buffer(s.geom_4326, 500)"))
+    stmt = sqlglot.parse_one(expanded, dialect="postgres")
+    assert _canonical_buffer_exempt_ids(stmt), (
+        "the expansion was not recognised as the canonical buffer, so the "
+        "sandbox is admitting it for some other reason"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Placement: model output expands, user-written SQL does not
+# ---------------------------------------------------------------------------
+
+
+async def test_generate_sql_expands_before_it_returns(monkeypatch):
+    """The marker never leaves ``generate_sql``.
+
+    Every NL consumer goes through this one function (``chat_actions``'s
+    ``query_data`` is the only production caller, the evals are the other),
+    so expanding at its tail is what makes the marker a private protocol
+    between the prompt and the server rather than a new SQL dialect.
+    """
+    from app.processing.ai import sql_generator as sg
+    from app.processing.ai.llm_loop import ToolLoopResult
+
+    class _Setting:
+        def __init__(self, value):
+            self._value = value
+
+        async def get(self, _db):
+            return self._value
+
+    class _FakeProvider:
+        async def resolve_runtime_config(self, _db):
+            return {"base_url": None}
+
+        async def complete(self, **_kw):
+            return ToolLoopResult(
+                text=(
+                    "```sql\n"
+                    "SELECT ST_AsGeoJSON(geolens_buffer(s.geom_4326, 500)) AS geometry\n"
+                    "FROM data.stations s LIMIT 100;\n"
+                    "```"
+                )
+            )
+
+    monkeypatch.setattr(sg, "LLM_PROVIDER", _Setting("anthropic"))
+    monkeypatch.setattr(sg, "LLM_MODEL_LIGHT", _Setting("test-model"))
+    monkeypatch.setattr(sg, "get_ai_provider", lambda _name: _FakeProvider())
+
+    sql = await sg.generate_sql(None, "buffer the stations by 500 m", "-- ddl")
+
+    assert "geolens_buffer" not in sql
+    assert sql == (
+        f"SELECT ST_AsGeoJSON({render_geodesic_buffer('s.geom_4326', 500.0)}) "
+        "AS geometry\nFROM data.stations s LIMIT 100"
+    )
+
+
+async def test_the_raw_query_endpoint_does_not_expand_a_marker(
+    client, admin_auth_header, test_db_session
+):
+    """``POST /api/query/`` takes SQL a person wrote, so the marker has no
+    meaning there and must stay the unknown function it is.
+
+    This is the counterfactual for "model-only": if expansion ever moved down
+    into the sandbox, this request would start succeeding.
+    """
+    import uuid as _uuid
+
+    from sqlalchemy import text as _text
+
+    from tests.factories import create_dataset
+
+    me = (await client.get("/auth/me/", headers=admin_auth_header)).json()["id"]
+    tbl = f"m1589_{_uuid.uuid4().hex[:10]}"
+    await test_db_session.execute(
+        _text(f"CREATE TABLE data.{tbl} (gid int, geom_4326 geometry(Point, 4326))")
+    )
+    await test_db_session.execute(
+        _text(
+            f"INSERT INTO data.{tbl} VALUES "
+            "(1, ST_SetSRID(ST_MakePoint(-73.9, 40.7), 4326))"
+        )
+    )
+    await test_db_session.commit()
+    await create_dataset(test_db_session, created_by=_uuid.UUID(me), table_name=tbl)
+
+    resp = await client.post(
+        "/query/",
+        json={
+            "sql": (
+                f"SELECT ST_AsGeoJSON(geolens_buffer(t.geom_4326, 500)) "
+                f"FROM data.{tbl} t"
+            ),
+            "restrict_tables": [tbl],
+        },
+        headers=admin_auth_header,
+    )
+    assert resp.status_code == 422
+    assert resp.json()["detail"] == "Query uses a disallowed function"
+
+    # And the same statement without the marker runs, so the refusal above is
+    # about the marker and not about the fixture.
+    ok = await client.post(
+        "/query/",
+        json={
+            "sql": f"SELECT ST_AsGeoJSON(t.geom_4326) FROM data.{tbl} t",
+            "restrict_tables": [tbl],
+        },
+        headers=admin_auth_header,
+    )
+    assert ok.status_code == 200, ok.text
+
+
+def test_expansion_has_exactly_one_call_site():
+    """A closed list, not a convention.
+
+    The property "user-written SQL is never expanded" is a statement about
+    which modules call the expander, so it is checked that way. Adding the
+    call to ``query_router.py`` — or to the sandbox — fails here.
+    """
+    import ast
+    from pathlib import Path
+
+    app_root = Path(__file__).resolve().parents[1] / "app"
+    callers: set[str] = set()
+    for candidate in sorted(app_root.rglob("*.py")):
+        rel = candidate.relative_to(app_root.parent).as_posix()
+        if rel == "app/processing/ai/buffer_marker.py":
+            continue
+        tree = ast.parse(candidate.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            named = (
+                isinstance(node, ast.ImportFrom)
+                and any(a.name == "expand_buffer_markers" for a in node.names)
+            ) or (isinstance(node, ast.Name) and node.id == "expand_buffer_markers")
+            if named or (
+                isinstance(node, ast.Attribute) and node.attr == "expand_buffer_markers"
+            ):
+                callers.add(rel)
+
+    assert callers == {"app/processing/ai/sql_generator.py"}, (
+        "the buffer-marker expander reached a module outside the NL->SQL "
+        f"generation path: {sorted(callers)}"
+    )

--- a/backend/tests/test_ai_buffer_marker_1589.py
+++ b/backend/tests/test_ai_buffer_marker_1589.py
@@ -158,11 +158,68 @@ def test_a_longer_identifier_that_merely_starts_with_the_marker_is_not_a_call():
     assert expand_buffer_markers(sql) is sql
 
 
-def test_a_qualified_name_ending_in_the_marker_is_not_a_call():
+@pytest.mark.parametrize(
+    "qualified",
+    [
+        pytest.param("public.geolens_buffer", id="adjacent"),
+        pytest.param("public. geolens_buffer", id="space-after-the-dot"),
+        pytest.param("public./**/geolens_buffer", id="comment-after-the-dot"),
+        pytest.param("public. /* schema */ geolens_buffer", id="comment-and-spaces"),
+        pytest.param("public.\n  geolens_buffer", id="newline-after-the-dot"),
+    ],
+)
+def test_a_qualified_name_ending_in_the_marker_is_not_a_call(qualified):
     """``public.geolens_buffer(...)`` names some other schema's function, and
-    substituting our expression for it would answer a different question."""
-    sql = "SELECT public.geolens_buffer(s.geom_4326, 500) FROM data.stations s"
+    substituting our expression for it would answer a different question.
+
+    fix(#1589 review r2): the rule used to read the character immediately
+    before the name, so anything between the dot and the name defeated it —
+    a comment (the scan had already skipped it and saw ``/``) or even a plain
+    space. All of these are one qualified name to PostgreSQL.
+    """
+    sql = f"SELECT {qualified}(s.geom_4326, 500) FROM data.stations s"
     assert expand_buffer_markers(sql) is sql
+
+
+@pytest.mark.parametrize(
+    "prefix",
+    [
+        pytest.param("/* metric */ ", id="comment"),
+        pytest.param("-- metric\n", id="line-comment"),
+    ],
+)
+def test_a_comment_before_an_unqualified_marker_still_reads_as_a_call(prefix):
+    """The counterfactual for the qualifier rule: a comment before the name is
+    not a qualifier, and must not switch expansion off."""
+    expanded = expand_buffer_markers(
+        f"SELECT ST_AsGeoJSON({prefix}geolens_buffer(s.geom_4326, 500)) AS geometry "
+        "FROM data.stations s LIMIT 100"
+    )
+    assert render_geodesic_buffer("s.geom_4326", 500.0) in expanded
+    assert "geolens_buffer" not in expanded
+
+
+def test_the_nested_check_agrees_with_the_top_level_scan_on_qualified_names():
+    """A qualified name is not our marker in either place.
+
+    Before fix(#1589 review r2) the two disagreed for
+    ``public./**/geolens_buffer``: the top-level scan expanded it, while the
+    same string inside a geometry argument was rejected as nesting. Whichever
+    answer is right, one of those was wrong.
+    """
+    inner = "public./**/geolens_buffer(s.geom_4326, 10)"
+
+    # Top level: not our marker, so the SQL comes back untouched.
+    top = f"SELECT {inner} FROM data.stations s"
+    assert expand_buffer_markers(top) is top
+
+    # Same string in the geometry slot: also not our marker, so it is NOT
+    # rejected as nesting. It is an ordinary expression the sandbox will refuse
+    # on its own terms, and the buffer around it renders normally.
+    expanded = expand_buffer_markers(_wrap(f"geolens_buffer({inner}, 500)"))
+    assert expanded == _wrap(
+        render_geodesic_buffer("public. geolens_buffer(s.geom_4326, 10)", 500.0)
+    )
 
 
 def test_a_comment_between_the_name_and_its_parenthesis_still_reads_as_a_call():
@@ -204,6 +261,22 @@ def test_a_comment_inside_the_call_does_not_ride_into_the_expression(geom):
     assert "/*" not in expanded and "--" not in expanded
     result = validate_sql(expanded)
     assert result.tables
+
+
+@pytest.mark.parametrize(
+    "distance",
+    [
+        pytest.param("500 /* metres */", id="block-comment-after"),
+        pytest.param("/* metres */ 500", id="block-comment-before"),
+        pytest.param("500 -- metres\n", id="line-comment"),
+    ],
+)
+def test_a_comment_around_the_distance_does_not_refuse_the_call(distance):
+    """fix(#1589 review r2): the distance argument gets the same treatment as
+    the geometry one. Leaving it out would have kept half the failure class:
+    a correct call, refused with a message nobody sees."""
+    expanded = expand_buffer_markers(_wrap(f"geolens_buffer(s.geom_4326, {distance})"))
+    assert expanded == _wrap(render_geodesic_buffer("s.geom_4326", 500.0))
 
 
 def test_a_comment_that_looks_like_one_inside_a_literal_is_kept():

--- a/backend/tests/test_ai_buffer_marker_1589.py
+++ b/backend/tests/test_ai_buffer_marker_1589.py
@@ -1,8 +1,10 @@
 """fix(#1589): the NL->SQL prompt asks for a marker; the server expands it.
 
 Before this, the prompt embedded ``render_geodesic_buffer``'s rendered output
-(3 088 characters) and told the model to reproduce it character for character.
-The light model managed that about half the time — the nightly buffer evals
+twice — a 3 017-character template and a 3 073-character worked example, 6 090
+of the prompt's 16 786 characters — and told the model to reproduce it
+character for character. The light model managed that about half the time. The
+nightly buffer evals
 failed on six of nine runs between 08-12 and 08-18, every failure a sandbox
 refusal of a dropped parenthesis or a paraphrase back to the bare
 ``ST_Buffer(::geography)`` form, never a wrong answer that ran.
@@ -37,6 +39,7 @@ from app.processing.ai.buffer_marker import (
     MAX_BUFFER_MARKERS,
     expand_buffer_markers,
 )
+from app.processing.ai.schemas import ChatMapLayer
 
 
 def _wrap(expr: str, table: str = "data.stations s") -> str:
@@ -170,6 +173,48 @@ def test_a_comment_between_the_name_and_its_parenthesis_still_reads_as_a_call():
 
 
 # ---------------------------------------------------------------------------
+# Comments inside the call (fix(#1589) review r1)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "geom",
+    [
+        pytest.param("s.geom_4326 /* the stop */", id="block-comment-after"),
+        pytest.param("/* the stop */ s.geom_4326", id="block-comment-before"),
+        pytest.param("s.geom_4326 -- the stop\n", id="line-comment"),
+        pytest.param(
+            "(SELECT geom_4326 /* managed */ FROM data.parks WHERE gid = 1)",
+            id="comment-inside-a-subquery",
+        ),
+    ],
+)
+def test_a_comment_inside_the_call_does_not_ride_into_the_expression(geom):
+    """The scanner skips comments to SPLIT the arguments; it must also drop
+    them from the slice it hands to the renderer.
+
+    Passing one through breaks the query in a way the model cannot see. A
+    block comment perturbs the text ``_matches_canonical_buffer`` re-renders,
+    so the exemption is refused and the scaffold's own functions are rejected.
+    A line comment comments out the rest of the rendered expression. Both are
+    the failure class this change exists to remove, so both have to survive
+    validation now, not merely fail closed.
+    """
+    expanded = expand_buffer_markers(_wrap(f"geolens_buffer({geom}, 500)"))
+    assert "/*" not in expanded and "--" not in expanded
+    result = validate_sql(expanded)
+    assert result.tables
+
+
+def test_a_comment_that_looks_like_one_inside_a_literal_is_kept():
+    """The counterfactual for the stripper: ``--`` and ``/*`` inside a string
+    are data. Removing them would change which rows the query matches."""
+    geom = "(SELECT geom_4326 FROM data.parks WHERE code = 'A--B/*C*/')"
+    expanded = expand_buffer_markers(_wrap(f"geolens_buffer({geom}, 500)"))
+    assert expanded == _wrap(render_geodesic_buffer(geom, 500.0))
+
+
+# ---------------------------------------------------------------------------
 # Malformed markers
 # ---------------------------------------------------------------------------
 
@@ -187,11 +232,25 @@ def _refusal(sql: str) -> SandboxError:
         pytest.param("geolens_buffer(s.geom_4326)", id="one-argument"),
         pytest.param("geolens_buffer(s.geom_4326, 100, 8)", id="three-arguments"),
         pytest.param("geolens_buffer()", id="no-arguments"),
-        pytest.param("geolens_buffer(, 100)", id="empty-geometry"),
     ],
 )
 def test_wrong_arity_is_refused(call):
     _refusal(_wrap(call))
+
+
+@pytest.mark.parametrize(
+    "call",
+    [
+        pytest.param("geolens_buffer(, 100)", id="nothing"),
+        pytest.param("geolens_buffer(   , 100)", id="whitespace"),
+        pytest.param("geolens_buffer(/* gone */, 100)", id="only-a-comment"),
+    ],
+)
+def test_an_empty_geometry_argument_is_refused(call):
+    """Two arguments, so this is not an arity failure; the geometry slot is
+    the one that is empty, and the message has to say so."""
+    err = _refusal(_wrap(call))
+    assert "needs a geometry expression" in str(err)
 
 
 def test_an_unterminated_marker_is_refused():
@@ -260,9 +319,14 @@ def test_a_nested_marker_is_refused_rather_than_expanded_inside_out():
 
     An inner buffer is not a stored geometry, so ``_is_bounded_geometry_source``
     in the validator refuses the outer one no matter what we render — the
-    prompt says as much ("a nested buffer ... is refused"). Expanding it
-    anyway would trade a sentence the model can act on for a sandbox error
-    about a spatial function it never wrote.
+    prompt says as much ("a nested buffer ... is refused"). Refusing here
+    rather than rendering ~6 KB that cannot pass is the benefit.
+
+    The message asserted below is DEVELOPER-facing, and that is the whole of
+    its audience: ``_execute_chat_tool`` replaces every ``invalid_query``
+    message with the generic ERROR_MESSAGES line, so the model and the user
+    see that instead. What this pins is the reason reaching the log line in
+    ``_fail`` and pytest, which is where a malformed marker gets diagnosed.
     """
     err = _refusal(_wrap("geolens_buffer(geolens_buffer(s.geom_4326, 10), 20)"))
     assert "nested" in str(err).lower()
@@ -330,14 +394,17 @@ def test_expansion_grants_the_geometry_argument_nothing(geom):
 def test_a_comment_cannot_smuggle_sql_through_the_argument_split():
     """A comment that carries the separator, the terminator and a payload.
 
-    Two things have to hold. Nothing inside the comment may become SQL — the
-    scanner reads it as a comment, so ``pg_sleep`` stays text and ``data.t``
-    never becomes a table. And the statement is refused anyway: the comment
-    rides into the rendered scaffold, where it perturbs the re-render
-    ``_matches_canonical_buffer`` compares against, so no exemption is granted
-    and the buffer's own functions fall back under the allowlist. That is the
-    fail-closed direction, and it is the same outcome a model would have got
-    writing the expression by hand with a comment in it.
+    The scanner reads it as a comment when it splits the arguments, so neither
+    the ``,`` nor the ``)`` inside it moves the split, and ``_without_comments``
+    then drops it before anything is rendered. So ``pg_sleep`` never becomes a
+    call and ``data.t`` never becomes a table.
+
+    What is left is ``s.geom_4326``, and the statement VALIDATES. That is the
+    right outcome rather than a lucky one: the attempt failed as an attempt,
+    and the query that remains is the ordinary buffer the model asked for.
+    Before fix(#1589 review r1) this was refused instead, which looked like
+    security and was really the comment breaking the canonical re-render — the
+    same collateral damage a plain ``/* the stop */`` took.
     """
     smuggle = "s.geom_4326 /*, 1) AS g, pg_sleep(9) FROM data.t --*/"
     expanded = expand_buffer_markers(_wrap(f"geolens_buffer({smuggle}, 100)"))
@@ -347,9 +414,8 @@ def test_a_comment_cannot_smuggle_sql_through_the_argument_split():
     assert "pg_sleep" not in called
     assert not [tbl for tbl in stmt.find_all(sqlglot.exp.Table) if tbl.name == "t"]
 
-    with pytest.raises(SandboxError) as excinfo:
-        validate_sql(expanded)
-    assert excinfo.value.category == "invalid_query"
+    assert expanded == _wrap(render_geodesic_buffer("s.geom_4326", 100.0))
+    assert validate_sql(expanded).tables == {("data", "stations")}
 
 
 def test_a_benign_marker_in_the_same_shape_validates():
@@ -492,6 +558,49 @@ async def test_the_raw_query_endpoint_does_not_expand_a_marker(
         headers=admin_auth_header,
     )
     assert ok.status_code == 200, ok.text
+
+
+def test_the_chat_path_rewrites_that_follow_expansion_keep_the_buffer_valid():
+    """fix(#1589 review r1): the two rewrites ``query_data`` applies AFTER
+    ``generate_sql`` returns, run over the expanded 3 KB scaffold.
+
+    ``ensure_geometry_selected`` parses the statement with sqlglot and prints
+    it back, and the truncation-recovery COUNT wraps it in another SELECT.
+    Both are full round-trips of the rendered buffer, and
+    ``_matches_canonical_buffer`` compares by re-render, so a sqlglot upgrade
+    that changed how any scaffold node prints would break metric buffers in
+    production while every eval stayed green — the evals call
+    ``validate_and_execute`` on ``generate_sql``'s output directly and never
+    see either rewrite. No DB needed to pin it.
+    """
+    from app.processing.ai.chat_geojson import ensure_geometry_selected
+
+    layers = [
+        ChatMapLayer(
+            id="layer-1",
+            name="Stations",
+            dataset_id="11111111-1111-1111-1111-111111111111",
+            dataset_table_name="stations",
+            geometry_type="Point",
+        )
+    ]
+    # Attribute-only projection, which is the shape that makes
+    # ensure_geometry_selected actually append a column.
+    expanded = expand_buffer_markers(
+        "SELECT s.name FROM data.stations s "
+        "WHERE ST_Intersects(s.geom_4326, geolens_buffer(s.geom_4326, 500)) "
+        "LIMIT 100"
+    )
+    with_geometry = ensure_geometry_selected(expanded, layers)
+    assert with_geometry != expanded, (
+        "the fixture no longer exercises the append, so this test proves "
+        "nothing about the rewrite"
+    )
+    assert validate_sql(with_geometry).tables == {("data", "stations")}
+
+    # chat_actions builds this one when the row cap truncated the result.
+    counted = f"SELECT COUNT(*) AS n FROM ({with_geometry}) AS _geolens_total"
+    assert validate_sql(counted).tables == {("data", "stations")}
 
 
 def test_expansion_has_exactly_one_call_site():

--- a/backend/tests/test_ai_sql_prompt_935.py
+++ b/backend/tests/test_ai_sql_prompt_935.py
@@ -1,19 +1,29 @@
-"""fix(#935): the NL->SQL prompt and analysis_sql must agree on the buffer shape.
+"""fix(#935) / fix(#1589): what the NL->SQL prompt teaches about metric buffers.
 
-The prompt used to hand-write ``ST_Buffer(geom::geography, N)::geometry`` in
-four places, so it inherited neither the antimeridian split (#883) nor the
-per-projection pass (#891/#902) applied to the real analysis path — twice.
-The prompt now embeds ``render_geodesic_buffer``'s own output at import time,
-which removes the drift class by construction; these tests pin the wiring so
-a rewrite of the prompt cannot quietly reintroduce a hand-written copy.
+#935: the prompt used to hand-write ``ST_Buffer(geom::geography, N)::geometry``
+in four places, so it inherited neither the antimeridian split (#883) nor the
+per-projection pass (#891/#902) applied to the real analysis path — twice. The
+fix embedded ``render_geodesic_buffer``'s own output at import time, which
+removed the drift class by construction.
+
+#1589: it also asked the model to reproduce 3 088 characters exactly, and the
+light model could not. Six of nine nightly eval runs failed on a dropped
+parenthesis or a paraphrase back to the bare geography-cast form. The prompt
+now teaches a short marker, ``geolens_buffer(<geom>, <metres>)``, and
+``app.processing.ai.buffer_marker`` renders the real expression server-side.
+
+So the property has moved rather than gone away. The prompt must no longer
+carry the expression at all, and the expansion of what it DOES teach must be
+exactly what the sandbox admits — which is still ``render_geodesic_buffer``'s
+output, still compared by re-render in ``_matches_canonical_buffer``.
 """
 
-from app.platform.analysis_sql import render_geodesic_buffer
+import re
+
+from app.platform.analysis_sql import MAX_BUFFER_METERS, render_geodesic_buffer
+from app.platform.sandbox.validator import validate_sql
+from app.processing.ai.buffer_marker import expand_buffer_markers
 from app.processing.ai.sql_generator import SQL_SYSTEM_PROMPT
-
-
-def _expected_template() -> str:
-    return render_geodesic_buffer("<GEOM>", 99999).replace("99999", "<METERS>")
 
 
 def _is_negative_teaching(line: str) -> bool:
@@ -28,39 +38,31 @@ def _is_negative_teaching(line: str) -> bool:
     )
 
 
-def test_prompt_embeds_the_generated_buffer_template():
-    """The canonical <GEOM>/<METERS> template in the Metric Buffers section is
-    render_geodesic_buffer's output, freshly rendered — if analysis_sql
-    changes shape and the prompt module stops re-rendering it, this fails."""
-    assert _expected_template() in SQL_SYSTEM_PROMPT
+def test_prompt_teaches_the_marker():
+    """The one thing the model is asked to write for a metric buffer."""
+    assert "geolens_buffer(" in SQL_SYSTEM_PROMPT
+    assert "## Metric Buffers" in SQL_SYSTEM_PROMPT
 
 
-def test_prompt_embeds_a_generated_worked_example():
-    """The Buffer + intersect example is a real rendered expression, not a
-    hand-typed restatement."""
-    denver = render_geodesic_buffer(
-        "(SELECT geom_4326 FROM data.us_state_capitals WHERE name = 'Denver')",
-        50000,
-    )
-    assert denver in SQL_SYSTEM_PROMPT
+def test_prompt_no_longer_carries_the_rendered_expression():
+    """fix(#1589): the 3 KB embed is gone, and nothing may quietly restore it.
+
+    Checked by the scaffold's own fingerprints rather than by length: the
+    renderer's internal alias and its dissolve are in every render it produces
+    and in nothing a person would write by hand, so either one appearing in the
+    prompt means the expression came back.
+    """
+    assert render_geodesic_buffer("<GEOM>", 99999) not in SQL_SYSTEM_PROMPT
+    assert "ST_UnaryUnion" not in SQL_SYSTEM_PROMPT
+    assert "_pb" not in SQL_SYSTEM_PROMPT
+    assert "ST_DumpSegments" not in SQL_SYSTEM_PROMPT
 
 
-def test_every_buffer_in_the_prompt_is_generated_or_marked_wrong():
-    """No ST_Buffer in the prompt teaches a form render_geodesic_buffer would
-    not produce. Every occurrence must come from a rendered embed or sit on an
-    explicit '-- WRONG' line; a fifth hand-written copy fails here."""
-    embeds = [
-        _expected_template(),
-        render_geodesic_buffer(
-            "(SELECT geom_4326 FROM data.us_state_capitals WHERE name = 'Denver')",
-            50000,
-        ),
-    ]
-    remainder = SQL_SYSTEM_PROMPT
-    for embed in embeds:
-        assert embed in remainder
-        remainder = remainder.replace(embed, "")
-    for line in remainder.splitlines():
+def test_every_buffer_in_the_prompt_is_marked_wrong():
+    """No ST_Buffer in the prompt teaches a form the model should emit. Every
+    occurrence must sit on an explicit '-- WRONG' line or in the prose that
+    warns against it."""
+    for line in SQL_SYSTEM_PROMPT.splitlines():
         if "ST_Buffer(" not in line:
             continue
         assert _is_negative_teaching(line), (
@@ -68,9 +70,75 @@ def test_every_buffer_in_the_prompt_is_generated_or_marked_wrong():
         )
 
 
+def test_no_bare_geography_buffer_taught_positively():
+    """The bare geography-cast buffer appears only as a negative example."""
+    for line in SQL_SYSTEM_PROMPT.splitlines():
+        if "::geography," in line and "ST_Buffer(" in line:
+            assert _is_negative_teaching(line), line
+
+
+def test_function_reference_line_declares_degrees():
+    """sql_generator.py's ST_Buffer reference line must state the
+    planar/degrees semantics explicitly so it stops contradicting the Metric
+    Buffers section."""
+    assert "DEGREES on geom_4326" in SQL_SYSTEM_PROMPT
+
+
+def test_prompt_states_the_bounded_input_rule():
+    """fix(#1001): the sandbox admits the rendered buffer only around a stored
+    geometry, because the expression's cost scales with its input's extent.
+
+    The model has to be told, or it emits a shape that is silently refused —
+    the same prompt-vs-validator disagreement this whole chain is about. The
+    marker changed who writes the expression, not which inputs it accepts.
+    """
+    assert "must be the managed geom_4326 column" in SQL_SYSTEM_PROMPT
+    # fix(#1001 codex r4): the scaffold interposes its own scope, so a bare
+    # top-level column is undecidable and refused. The prompt has to say so.
+    assert "it must be QUALIFIED" in SQL_SYSTEM_PROMPT
+    assert "s.geom_4326" in SQL_SYSTEM_PROMPT
+    assert "A reprojection, a nested buffer, a constructed geometry" in (
+        SQL_SYSTEM_PROMPT
+    )
+    # fix(#1001 codex r3): a dataset's original projected geom column is the
+    # non-obvious one, so the prompt has to name it.
+    assert "original geom column in another CRS" in SQL_SYSTEM_PROMPT
+
+
+def test_prompt_states_the_distance_rule():
+    """fix(#1589): the expander takes a plain number and caps it, so a model
+    writing `500 * 2` or `200000` gets a refusal. Say so up front."""
+    assert f"{MAX_BUFFER_METERS:.0f}" in SQL_SYSTEM_PROMPT
+
+
+def test_the_worked_example_expands_and_the_sandbox_admits_it():
+    """The prompt's Buffer + intersect example, taken from the prompt itself
+    and run through the real expansion and the real validator.
+
+    Pinning the example by its text alone would pass for an example that no
+    longer works; this fails if the marker syntax, the expander, or the
+    sandbox's canonical-buffer match drift apart.
+    """
+    match = re.search(
+        r"^SELECT p\.name AS park_name$.*?;$",
+        SQL_SYSTEM_PROMPT,
+        re.MULTILINE | re.DOTALL,
+    )
+    assert match, "the Buffer + intersect example is no longer in the prompt"
+    example = match.group(0).rstrip(";")
+    assert "geolens_buffer(" in example
+
+    expanded = expand_buffer_markers(example)
+    assert "geolens_buffer" not in expanded
+    result = validate_sql(expanded)
+    assert result.tables == {
+        ("data", "national_parks"),
+        ("data", "us_state_capitals"),
+    }
+
+
 def test_rendered_buffer_expression_validates():
-    """fix(#1001): the prompt mandates render_geodesic_buffer's output, so the
-    sandbox has to admit what the model is taught to emit.
+    """fix(#1001): the sandbox has to admit what the expander produces.
 
     This test spent one release inverted. #935 codex r1 admitted the buffer's
     functions and bounded them with per-call cost guards; #990 then rebuilt the
@@ -85,15 +153,13 @@ def test_rendered_buffer_expression_validates():
 
     #1001 admits it a different way: nothing is allowlisted per call, and a
     subtree is exempted only when it is exactly what the renderer emits around
-    its own input. So this asserts admission again.
+    its own input. fix(#1589) moved the rendering from the model to the server
+    and left that rule untouched, which is why this still reads the same.
     """
-    from app.platform.sandbox.validator import validate_sql
-
     denver = render_geodesic_buffer(
         "(SELECT geom_4326 FROM data.us_state_capitals WHERE name = 'Denver')",
         50000,
     )
-    # The prompt's worked example, as the model would emit it.
     result = validate_sql(
         "SELECT p.name AS park_name\n"
         "FROM data.national_parks p\n"
@@ -114,48 +180,3 @@ def test_rendered_buffer_expression_validates():
         "FROM data.stations s\nLIMIT 100"
     )
     assert result.tables == {("data", "stations")}
-
-
-def test_function_reference_line_declares_degrees():
-    """sql_generator.py:194's old form taught a unitless buffer; the reference
-    line must state the planar/degrees semantics explicitly so it stops
-    contradicting the Metric Buffers section."""
-    assert "DEGREES on geom_4326" in SQL_SYSTEM_PROMPT
-
-
-def test_no_bare_geography_buffer_taught_positively():
-    """The three original cheat-sheet/example sites are gone: outside the
-    rendered embeds, the bare geography-cast buffer appears only as a negative
-    (WRONG) example."""
-    remainder = SQL_SYSTEM_PROMPT
-    for embed in (
-        _expected_template(),
-        render_geodesic_buffer(
-            "(SELECT geom_4326 FROM data.us_state_capitals WHERE name = 'Denver')",
-            50000,
-        ),
-    ):
-        remainder = remainder.replace(embed, "")
-    for line in remainder.splitlines():
-        if "::geography," in line and "ST_Buffer(" in line:
-            assert _is_negative_teaching(line), line
-
-
-def test_prompt_states_the_bounded_input_rule():
-    """fix(#1001): the sandbox admits the rendered buffer only around a stored
-    geometry, because the expression's cost scales with its input's extent.
-
-    The model has to be told, or it emits a shape that is silently refused —
-    the same prompt-vs-validator disagreement this whole chain is about.
-    """
-    assert "<GEOM> must be the managed geom_4326 column" in SQL_SYSTEM_PROMPT
-    # fix(#1001 codex r4): the scaffold interposes its own scope, so a bare
-    # top-level column is undecidable and refused. The prompt has to say so.
-    assert "it must be QUALIFIED" in SQL_SYSTEM_PROMPT
-    assert "s.geom_4326" in SQL_SYSTEM_PROMPT
-    assert "A reprojection, a nested buffer, a constructed geometry" in (
-        SQL_SYSTEM_PROMPT
-    )
-    # fix(#1001 codex r3): a dataset's original projected geom column is the
-    # non-obvious one, so the prompt has to name it.
-    assert "original geom column in another CRS" in SQL_SYSTEM_PROMPT

--- a/backend/tests/test_ai_sql_prompt_935.py
+++ b/backend/tests/test_ai_sql_prompt_935.py
@@ -6,8 +6,9 @@ per-projection pass (#891/#902) applied to the real analysis path — twice. The
 fix embedded ``render_geodesic_buffer``'s own output at import time, which
 removed the drift class by construction.
 
-#1589: it also asked the model to reproduce 3 088 characters exactly, and the
-light model could not. Six of nine nightly eval runs failed on a dropped
+#1589: it also asked the model to reproduce 6 090 characters of rendered buffer
+exactly (a 3 017-character template plus a 3 073-character worked example), and
+the light model could not. Six of nine nightly eval runs failed on a dropped
 parenthesis or a paraphrase back to the bare geography-cast form. The prompt
 now teaches a short marker, ``geolens_buffer(<geom>, <metres>)``, and
 ``app.processing.ai.buffer_marker`` renders the real expression server-side.

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1454,7 +1454,7 @@ def test_analysis_sql_facade_guard_sees_every_bypass_shape() -> None:
     }
     assert not rejected, f"the guard rejected legitimate façade usage: {rejected}"
 
-    # The seven real consumers, checked as themselves rather than as snippets:
+    # The eight real consumers, checked as themselves rather than as snippets:
     # each must still reference the façade (so this is not vacuous) and none
     # may trip the guard.
     for rel in _ANALYSIS_SQL_CALLERS:

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -902,15 +902,21 @@ _ANALYSIS_SQL_FAMILIES = frozenset(
 # when nothing new binds, so this is a ceiling rather than a cost.
 _BINDING_REBIND_ROUNDS = 3
 
-# The seven modules that legitimately consume the façade. Named so the
+# The eight modules that legitimately consume the façade. Named so the
 # both-directions test can prove the guard still LETS THEM THROUGH — a refusal
 # assertion cannot notice that a correct import started being rejected.
+#
+# fix(#1589): buffer_marker.py joins them. It renders the geodesic buffer the
+# NL->SQL prompt used to embed, which is why sql_generator.py is still on the
+# list too — it keeps MAX_BUFFER_METERS, so the distance ceiling the prompt
+# quotes is the one the expander enforces.
 _ANALYSIS_SQL_CALLERS = (
     "app/modules/catalog/datasets/api/router_analysis.py",
     "app/modules/catalog/datasets/domain/schemas.py",
     "app/modules/catalog/datasets/domain/service_analysis.py",
     "app/platform/extensions/defaults_processing_port.py",
     "app/platform/sandbox/validator.py",
+    "app/processing/ai/buffer_marker.py",
     "app/processing/ai/sql_generator.py",
     "app/processing/analysis/tasks.py",
 )

--- a/backend/tests/test_sec025_sandbox_allowlist.py
+++ b/backend/tests/test_sec025_sandbox_allowlist.py
@@ -770,10 +770,15 @@ def _unlisted_names_in_canonical_buffer() -> set[str]:
 
 
 class TestCanonicalGeodesicBufferAdmitted:
-    """fix(#1001): the NL->SQL prompt mandates render_geodesic_buffer's output
-    verbatim, and the fail-closed allowlist refused it — every buffer question
-    in the surface was dead. The functions it needs are admitted only inside a
-    subtree that re-renders to exactly the same AST, never per call."""
+    """fix(#1001): every metric buffer on the NL->SQL surface is
+    render_geodesic_buffer's output, and the fail-closed allowlist refused it —
+    every buffer question in the surface was dead. The functions it needs are
+    admitted only inside a subtree that re-renders to exactly the same AST,
+    never per call.
+
+    fix(#1589): the model no longer types that output. It writes a
+    geolens_buffer() marker and processing/ai/buffer_marker.py expands it
+    before validation, so what arrives here is unchanged and so is this."""
 
     def test_admits_the_rendered_buffer(self):
         _assert_allows(


### PR DESCRIPTION
The NL→SQL prompt embedded `render_geodesic_buffer`'s rendered output twice, a
3 017-character `<GEOM>`/`<METERS>` template and a 3 073-character worked
example, so 6 090 of the prompt's 16 786 characters were banding,
seam-splitting and dissolve machinery the model was asked to reproduce
exactly. The light model managed that about half the time. Six of
the nine nightly `AI Evals` runs between 08-12 and 08-18 failed on the two
buffer evals, and every failure was the sandbox refusing the SQL rather than a
wrong answer that ran. A dropped parenthesis came back as `invalid_query`. A
paraphrase to the bare `ST_Buffer(::geography)` form stopped matching the
canonical-shape exemption in `_matches_canonical_buffer`, so it came back as
"disallowed spatial function". For a user that meant a metric-buffer question
in chat failed roughly every other time, with no repair pass behind it.

The prompt now teaches a marker. The model writes
`geolens_buffer(<geom>, <metres>)`, and `generate_sql` renders the real
expression before returning. The shape can no longer be wrong, because the
model no longer writes it.

## What changed

`backend/app/processing/ai/buffer_marker.py` is new. It scans model SQL for the
marker and substitutes `render_geodesic_buffer`'s output. `sql_generator.py`
calls it at the tail of `generate_sql`, next to the code-fence and
special-token stripping, and its prompt drops both embeds for a one-line call
plus the rules the expander enforces, 16 786 characters down to 11 595.

`tests/test_ai_sql_prompt_935.py` still pins that the prompt and `analysis_sql`
agree about buffers, but from the other side now. The expression must be
absent, the marker must be taught, and the prompt's own worked example is
pulled out of the prompt text, expanded, and run through `validate_sql`, so an
example that stopped working would fail rather than pass on its wording.

## The expander reads syntax, not policy

It finds the two arguments by balanced-parenthesis scanning that skips string
literals, dollar quotes and comments the way PostgreSQL does, checks the
distance is a plain number in range, and checks the geometry argument parses as
one expression. Whether that expression is an acceptable buffer *input*
(bounded, allowlisted, resolvable to a stored column) stays exactly one
decision, made in the sandbox. #1002 is three rounds of evidence for what
happens when two layers both try to answer that question.

So the marker grants nothing. The expansion is the same text the model was
previously asked to type, which means `_matches_canonical_buffer` still
re-renders the template around the extracted input and compares ASTs, and the
geometry argument is still validated as ordinary SQL. `pg_sleep(g)`,
`ST_Transform(g, 3857)`, a subquery hiding a call and a planar buffer in
degrees are all refused after expansion. The tests carry the benign
counterfactual next to them so the refusals mean something.

Comments inside the call are dropped rather than passed through, which review
round 1 caught. The scanner already skipped them to split the arguments, but
the slice it returned still carried them into the renderer, and both forms then
broke the query the model could not see: a block comment perturbs the text
`_matches_canonical_buffer` compares against, so the exemption is refused, and
a line comment comments out the rest of the rendered expression. Both failed
closed, and both were the failure class this PR exists to remove. PostgreSQL
treats a comment as whitespace, so dropping it is semantics-preserving; a
comment sitting inside a string literal is data and is kept, with a test for
that.

Distance is the one value this module does bound. `render_geodesic_buffer`
interpolates the number straight into SQL text and does not check it;
`render_buffer_expr` is the caller that does, and it is not on this path. So
the expander takes a decimal literal only (no sign, no cast, no arithmetic, and
no `_` separators, which `float()` would otherwise accept) and applies the
analysis surface's own bounds: above 0, at most `MAX_BUFFER_METERS`.

## Nesting, volume, placement

A nested marker is refused rather than expanded inside out. A buffer is not a
stored geometry, so the validator would refuse the outer one however it was
rendered. Refusing early trades a sandbox error about spatial functions the
model never wrote for a sentence about what it actually did.

Eight markers per statement, which is the validator's
`_MAX_BUFFER_MATCH_ATTEMPTS` rather than a round number. Past that count no
exemption is granted, so a ninth expansion could only produce another 3 KB of
SQL that is then refused. A test asserts the two constants stay equal.

Expansion runs on model output only. `generate_sql` is the single production
path that turns model text into SQL (`chat_actions._handle_query_data` is its
one caller, the evals are the other), and the call sits at its tail. The raw
`POST /api/query/` endpoint takes SQL a person wrote and never reaches it, so
`geolens_buffer` stays the unknown function it is there. Two tests hold that
down: one sends a marker to the endpoint and asserts the 422, and one walks
every module under `backend/app/` and asserts the expander has one call site.

## One prompt fix that is not about transcription

The first eval run on the new prompt still failed `wide_multipart` once, and
the marker had expanded correctly. The model had written a bare, unqualified
`geom_4326`, which #1001's bounded-input rule refuses because the rendered
scaffold interposes its own scope. The prompt already said the reference must
be qualified. It did not say what to do when the query reads one table with no
alias. It does now, and there is a worked single-table example. Six consecutive
buffer-eval runs after that change, then 16/16 on the full evals directory.

No repair loop in this PR. Nothing in those runs needed one.

## Verification

`tests/test_ai_buffer_marker_1589.py` (68 tests) and
`tests/test_ai_sql_prompt_935.py` (9) were written before the implementation.
Both files failed at import until the module existed.

- `cd backend && uv run ruff check . && uv run ruff format --check .`
- The two marker files: 77 passed.
- `tests/test_layering.py` and `tests/test_sec025_sandbox_allowlist.py`: 215
  passed. `buffer_marker.py` joins `_ANALYSIS_SQL_CALLERS`. No LOC cap moved;
  `validator.py` is still 1871 lines exactly.
- `-k "sql_generator or sandbox or buffer or chat_geojson"`: 436 passed, 3
  skipped.
- Full backend suite, `uv run pytest -n 4 -q`: 9518 passed, 100 skipped in
  1311.81s. Run on the first revision; the second revision's changes are
  covered by the selections above plus CI.
- The `make ai-evals` command replayed from this worktree against the dev DB:
  16 passed, including both buffer evals. Per-eval table in a comment below.
  The prompt string is byte-identical between revisions (still 11 595
  characters), so that result still stands.

The first commit's message repeats the wrong "3 088 characters" figure. It is
corrected everywhere it can be without rewriting a pushed commit: here, in the
source comments, and in the test docstrings.

Refs #1589.
