### PR TITLE
fix(settings): reject falsy non-string public URL values instead of clearing them

### DIFF
--- a/backend/app/modules/settings/schemas.py
+++ b/backend/app/modules/settings/schemas.py
@@ -453,8 +453,14 @@ def validate_public_app_url(v: Any) -> str:
     does nothing. The ``/api`` clause is checked explicitly first only to keep
     its specific message; ``canonical_host_error`` supplies one for a host.
     """
-    if not v or (isinstance(v, str) and not v.strip()):
+    # `v is None`, not `not v`: JSON null is a legitimate clear (matching
+    # validate_privacy_url below), but a falsy non-string -- False, 0, [], {}
+    # -- is a type error, not a clear. `not v` caught those too and
+    # returned "" before the isinstance check below ever ran.
+    if v is None or (isinstance(v, str) and not v.strip()):
         return ""
+    if not isinstance(v, str):
+        raise ValueError("Value must be a string")
     normalized = _normalize_absolute_url(v)
     if is_api_base_path(urlsplit(normalized).path):
         raise ValueError("public_app_url must point to the app, not the /api base")
@@ -469,8 +475,11 @@ def validate_public_app_url(v: Any) -> str:
 
 
 def validate_public_api_url(v: Any) -> str:
-    if not v or (isinstance(v, str) and not v.strip()):
+    # `v is None`, not `not v`: see validate_public_app_url above.
+    if v is None or (isinstance(v, str) and not v.strip()):
         return ""
+    if not isinstance(v, str):
+        raise ValueError("Value must be a string")
     return _normalize_absolute_url(v)
 
 

--- a/backend/tests/test_settings_router.py
+++ b/backend/tests/test_settings_router.py
@@ -1072,15 +1072,19 @@ async def test_put_public_url_null_and_empty_still_clear(
 ):
     """JSON null and an empty/whitespace string remain legitimate clears,
     distinct from the falsy non-strings rejected above."""
-    resp = await client.put(
-        "/settings/",
-        json={"settings": {key: explicit_value}},
-        headers=admin_auth_header,
-    )
-    assert resp.status_code == 200
-    assert _general_tab_values(resp.json())[key] == explicit_value
-
     for clearing_value in (None, "", "   "):
+        # Re-set the explicit value before every clear, so each clearing
+        # value is tested against a value that is actually set; otherwise
+        # the second and third iterations would pass against an
+        # already-cleared key no matter what they did.
+        resp = await client.put(
+            "/settings/",
+            json={"settings": {key: explicit_value}},
+            headers=admin_auth_header,
+        )
+        assert resp.status_code == 200
+        assert _general_tab_values(resp.json())[key] == explicit_value
+
         resp = await client.put(
             "/settings/",
             json={"settings": {key: clearing_value}},

--- a/backend/tests/test_settings_router.py
+++ b/backend/tests/test_settings_router.py
@@ -1028,3 +1028,66 @@ async def test_a_url_free_request_still_resolves_the_committed_endpoint(
         {"model": _NEW_MODEL, "dimensions": None, "base_url": _APPROVED_URL}
     ]
     assert await EMBEDDING_DIMS.get_uncached(test_db_session) == _APPROVED_WIDTH
+
+
+# ---------------------------------------------------------------------------
+# public_app_url / public_api_url falsy-clear validation (#1592 follow-up)
+# ---------------------------------------------------------------------------
+
+
+def _general_tab_values(payload: dict) -> dict[str, object]:
+    return {item["key"]: item["value"] for item in payload["tabs"]["general"]}
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("key", ["public_app_url", "public_api_url"])
+@pytest.mark.parametrize("value", [False, 0, [], {}])
+async def test_put_public_url_rejects_falsy_non_strings(
+    client: AsyncClient, admin_auth_header: dict, key: str, value
+):
+    """A falsy non-string value (False, 0, [], {}) is a type error, not a
+    clear -- only JSON null and an empty/whitespace string clear a public
+    URL. `if not v` caught these too and cleared silently instead of
+    422ing, since every one of them is falsy in Python (the same bug as
+    privacy_url, fixed for that key in #1592).
+    """
+    resp = await client.put(
+        "/settings/",
+        json={"settings": {key: value}},
+        headers=admin_auth_header,
+    )
+    assert resp.status_code == 422
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    "key,explicit_value",
+    [
+        ("public_app_url", "https://maps.example.com"),
+        ("public_api_url", "https://maps.example.com/api"),
+    ],
+)
+async def test_put_public_url_null_and_empty_still_clear(
+    client: AsyncClient, admin_auth_header: dict, key: str, explicit_value: str
+):
+    """JSON null and an empty/whitespace string remain legitimate clears,
+    distinct from the falsy non-strings rejected above."""
+    resp = await client.put(
+        "/settings/",
+        json={"settings": {key: explicit_value}},
+        headers=admin_auth_header,
+    )
+    assert resp.status_code == 200
+    assert _general_tab_values(resp.json())[key] == explicit_value
+
+    for clearing_value in (None, "", "   "):
+        resp = await client.put(
+            "/settings/",
+            json={"settings": {key: clearing_value}},
+            headers=admin_auth_header,
+        )
+        assert resp.status_code == 200
+        # Once cleared, the resolved value falls back to a request/env-derived
+        # default -- it must simply stop being the explicit value we set,
+        # which proves the clear took effect rather than silently no-oping.
+        assert _general_tab_values(resp.json())[key] != explicit_value


### PR DESCRIPTION
`validate_public_app_url` and `validate_public_api_url` opened with `if not v or (isinstance(v, str) and not v.strip()): return ""`. `not v` is true for any falsy value, not just an empty string, so a JSON `false`, `0`, `[]`, or `{}` sent for either key silently cleared the configured URL instead of failing validation. #1592 fixed the same bug for `privacy_url`; this applies the identical shape to the other two URL validators: `v is None` clears, a non-string falls through to a 422, and everything else keeps its existing normalization.

Refs #1592

## Verification

- Red-first: reverted the schema change, ran the new tests, and confirmed all 8 falsy-rejection cases failed with 200 instead of 422 (the null/empty-clear cases already passed, since that path was never broken). Reapplied the fix and reran; all 10 pass.
- `cd backend && uv run ruff check . && uv run ruff format --check .`
- `tests/test_settings_router.py tests/test_public_app_url_shape_contract_1548.py tests/test_branding_settings.py`: 126 passed
- `tests/test_layering.py`: 47 passed, no cap changes needed
- `make openapi-check`: no diff (validator-only change, no schema shape change)
- Checked the frontend admin form (`SettingsGeneralTab.tsx` / `useSettingsForm.ts`): both fields are plain text inputs, so `e.target.value` is always a string, sent unmodified through `handleSave` and `updateMutation.mutate`. Nothing there relied on the old falsy-clear behavior.
