### PR TITLE
fix(cors): answer anonymous cross-origin catalog search with the public wildcard policy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -389,7 +389,10 @@ FRONTEND_PORT=8080
 
 # --- CORS ---
 # [OPTIONAL] Comma-separated list of allowed origins for cross-origin API requests
-# Leave empty for same-origin only (no CORS headers sent).
+# Leave empty for same-origin only. The anonymous read surface -- standards
+# discovery (/, /conformance, /collections, /stac, the DCAT exports) and
+# catalog search (/search/datasets, /search/facets) -- still answers any
+# browser origin with a credential-free wildcard, with or without this set.
 # Required when the frontend is served from a different domain than the API.
 # Type: string (comma-separated URLs) | Default: "" (same-origin only)
 # Example: https://app.example.com,https://other.example.com

--- a/backend/app/api/main.py
+++ b/backend/app/api/main.py
@@ -122,8 +122,9 @@ async def seed_roles() -> None:
 
 def _warn_if_cors_unset(settings_obj, log) -> None:
     """SEC-08 / M-72: warn loudly when CORS_ALLOWED_ORIGINS is unset in
-    production. Anonymous standards reads remain browser-accessible, while
-    credentialed application routes require an explicit origin allowlist.
+    production. Anonymous standards and catalog search reads remain
+    browser-accessible, while credentialed application routes require an
+    explicit origin allowlist.
 
     Gated on is_production so dev/test runs don't get the warning. SEC-005:
     previously gated on log_json (the de-facto production indicator); now uses
@@ -134,7 +135,8 @@ def _warn_if_cors_unset(settings_obj, log) -> None:
             "cors_allowed_origins_unset",
             message=(
                 "CORS_ALLOWED_ORIGINS is empty in production. "
-                "Anonymous standards reads allow any browser origin, but "
+                "Anonymous standards and catalog search reads allow any "
+                "browser origin, but "
                 "credentialed application CORS is disabled. Set "
                 "CORS_ALLOWED_ORIGINS=<comma-separated origins> to enable it."
             ),
@@ -1176,11 +1178,11 @@ def _add_trailing_slash_aliases(target_app: FastAPI) -> None:
 def _register_standards_head_routes(target_app: FastAPI) -> None:
     """fix(#1470): serve HEAD wherever the CORS preflight says we do.
 
-    ``DynamicCORSMiddleware._set_public_standards_cors_headers`` answers a
-    preflight on the anonymous standards surface with
+    ``DynamicCORSMiddleware._set_public_cors_headers`` answers a preflight on
+    the anonymous standards surface with
     ``Access-Control-Allow-Methods: GET, HEAD, POST, OPTIONS``, and
-    ``_is_anonymous_standards_request`` accepts ``HEAD`` as a requested
-    method — but FastAPI's ``APIRoute`` does not add HEAD alongside GET the
+    ``_anonymous_public_methods`` accepts ``HEAD`` as a requested method for
+    that surface — but FastAPI's ``APIRoute`` does not add HEAD alongside GET the
     way starlette's plain ``Route`` does, so every one of these routes
     answered ``405 allow: GET``. A browser client that trusts the preflight
     was told HEAD was fine and then refused. HEAD-probing a landing page or a
@@ -1190,6 +1192,11 @@ def _register_standards_head_routes(target_app: FastAPI) -> None:
     Both surfaces read the same ``standards_api_path`` classifier, so the set
     that answers HEAD and the set advertised as answering it cannot drift —
     which is the actual bug, not the missing routes.
+
+    fix(#1596) gave the anonymous wildcard a second surface, the catalog search
+    routes, which this pass does not cover. That does not reopen the drift: the
+    middleware advertises ``GET, OPTIONS`` there, matching the GET-only routes,
+    rather than being extended to promise a HEAD nothing registers.
 
     Runs after ``_add_trailing_slash_aliases`` so the no-slash aliases are
     covered too. Registering a route rather than adding to

--- a/backend/app/api/middleware/cors.py
+++ b/backend/app/api/middleware/cors.py
@@ -202,12 +202,13 @@ class DynamicCORSMiddleware(BaseHTTPMiddleware):
         credential exclusion and the safelisted-header check are what make a
         wildcard safe, and a new surface must not be able to opt out of them.
         """
-        standards_path = cls._standards_path(request)
+        request_path = cls._request_path(request)
+        standards_path = standards_api_path(request_path)
         if standards_path is not None:
             allow_methods = _STANDARDS_PUBLIC_METHODS
             permitted = {"GET", "HEAD"}
             stac_search = standards_path.rstrip("/") == "/stac/search"
-        elif cls._request_path(request) in _PUBLIC_SEARCH_PATHS:
+        elif request_path in _PUBLIC_SEARCH_PATHS:
             allow_methods = _SEARCH_PUBLIC_METHODS
             permitted = {"GET"}
             stac_search = False

--- a/backend/app/api/middleware/cors.py
+++ b/backend/app/api/middleware/cors.py
@@ -164,6 +164,7 @@ class DynamicCORSMiddleware(BaseHTTPMiddleware):
         response.headers["Access-Control-Expose-Headers"] = (
             "X-Total-Count, Link, Content-Crs, Content-Language, "
             "ETag, Content-Range, Accept-Ranges, Content-Disposition, "
+            "Retry-After, "
             "X-GeoLens-Source-Dataset-Count, X-GeoLens-Serialized-Dataset-Count, "
             "X-GeoLens-Excluded-Dataset-Count, "
             "X-GeoLens-Metadata-Fallback-Dataset-Count, "
@@ -260,12 +261,16 @@ class DynamicCORSMiddleware(BaseHTTPMiddleware):
         """Answer an anonymous public request with the credential-free policy.
 
         The Expose-Headers list is shared across both public surfaces. It
-        already covers everything the search routes set that a browser would
-        otherwise hide: ``standard_response_headers`` sets ``Vary``,
-        ``Content-Language`` and ``Link``, and ``Link`` — which carries the
-        next/prev pagination hrefs — is the only one of those that is not
-        CORS-safelisted. Search sets no count or rate-limit response header, so
-        nothing new is exposed anonymously by fix(#1596).
+        covers everything the search routes set that a browser would otherwise
+        hide: ``standard_response_headers`` sets ``Vary``, ``Content-Language``
+        and ``Link``, and ``Link`` — which carries the next/prev pagination
+        hrefs — is the only one of those that is not CORS-safelisted. Search
+        sets no count header. It does rate-limit (the per-IP semantic-search
+        limit on ``/search/datasets`` and the global limiter), and
+        ``_rate_limit_handler`` in ``api/main.py`` puts ``Retry-After`` on that
+        429; ``Retry-After`` is not safelisted, so it is listed here and on the
+        credentialed policy too, or a cross-origin caller sees the 429 and
+        cannot read the retry window (codex on #1601).
 
         No ``Vary: Origin`` here, and none on the credentialed policy either:
         the shipped ``frontend/nginx.conf`` serves ``location /api/`` with
@@ -280,7 +285,7 @@ class DynamicCORSMiddleware(BaseHTTPMiddleware):
         if requested_headers:
             response.headers["Access-Control-Allow-Headers"] = requested_headers
         response.headers["Access-Control-Expose-Headers"] = (
-            "Link, Content-Crs, Content-Language, "
+            "Link, Content-Crs, Content-Language, Retry-After, "
             "X-GeoLens-Source-Dataset-Count, X-GeoLens-Serialized-Dataset-Count, "
             "X-GeoLens-Excluded-Dataset-Count, "
             "X-GeoLens-Metadata-Fallback-Dataset-Count, "

--- a/backend/app/api/middleware/cors.py
+++ b/backend/app/api/middleware/cors.py
@@ -13,6 +13,38 @@ from app.standards.ogc.utils import standards_api_path
 _origins_cache: tuple[float, set[str]] = (0.0, set())
 _ORIGINS_CACHE_TTL = 30  # seconds — matches PersistentConfig cache TTL
 
+# fix(#1596): native catalog routes that carry the same anonymous, read-only
+# contract as the standards surface and so earn the same wildcard answer.
+#
+# Enumerated here rather than by widening ``standards_api_path``: that
+# classifier is shared with the error and OpenAPI contracts, and adding
+# ``/search`` to it would move these routes onto the OGC error shape as a side
+# effect of a CORS fix. Enumerated rather than matched by prefix because
+# ``/search/saved`` sits under the same router and requires an authenticated
+# user — a prefix over ``/search`` would hand it the wildcard too.
+#
+# Both handlers run ``apply_visibility_filter`` and treat an anonymous caller
+# as having no roles, so a wildcard response returns exactly the public
+# catalog. ``tests/test_search_cors_1596.py`` holds each listed path to a
+# GET-only route with no authenticated-user dependency.
+#
+# A tuple rather than a set because tests parametrize over it: string hashing
+# is salted per process, so a set's iteration order differs between xdist
+# workers and collection no longer matches across them.
+_PUBLIC_SEARCH_PATHS: tuple[str, ...] = (
+    "/search/datasets",
+    "/search/datasets/",
+    "/search/facets",
+    "/search/facets/",
+)
+
+# What each public surface actually answers. Search is registered GET-only, and
+# the derived-HEAD pass in ``api/main.py`` is keyed on ``standards_api_path``,
+# so HEAD and POST 405 here — fix(#1470) is the record of what happens when a
+# preflight promises a method the route refuses.
+_STANDARDS_PUBLIC_METHODS = "GET, HEAD, POST, OPTIONS"
+_SEARCH_PUBLIC_METHODS = "GET, OPTIONS"
+
 
 class DynamicCORSMiddleware(BaseHTTPMiddleware):
     """CORS middleware that dynamically resolves allowed origins from PersistentConfig.
@@ -32,18 +64,20 @@ class DynamicCORSMiddleware(BaseHTTPMiddleware):
         allowed = await self._is_origin_allowed(origin)
 
         if not allowed:
-            # Standards discovery and read/search routes are intentionally
-            # usable by anonymous browser clients on a default deployment.  A
-            # wildcard response is safe here because credential-bearing
-            # requests are excluded and Access-Control-Allow-Credentials is not
-            # emitted. Native application routes retain the explicit-origin,
+            # Standards discovery and the anonymous catalog search routes are
+            # intentionally usable by anonymous browser clients on a default
+            # deployment.  A wildcard response is safe here because
+            # credential-bearing requests are excluded and
+            # Access-Control-Allow-Credentials is not emitted. Every other
+            # native application route retains the explicit-origin,
             # credentialed policy below.
-            if self._is_anonymous_standards_request(request):
+            allow_methods = self._anonymous_public_methods(request)
+            if allow_methods is not None:
                 if request.method == "OPTIONS":
                     response = Response(status_code=status.HTTP_200_OK)
                 else:
                     response = await call_next(request)
-                self._set_public_standards_cors_headers(response, request)
+                self._set_public_cors_headers(response, request, allow_methods)
                 return response
 
             # Origin not permitted -- pass through without CORS headers.
@@ -138,25 +172,55 @@ class DynamicCORSMiddleware(BaseHTTPMiddleware):
         response.headers["Access-Control-Max-Age"] = "3600"
 
     @staticmethod
-    def _standards_path(request: Request) -> str | None:
-        return standards_api_path(
-            request.scope.get("path", request.url.path),
-            root_path=request.scope.get("root_path", ""),
-        )
+    def _request_path(request: Request) -> str:
+        """The request path with any ASGI ``root_path`` prefix removed."""
+        path = request.scope.get("path", request.url.path)
+        root_path = request.scope.get("root_path", "").rstrip("/")
+        if root_path and path.startswith(root_path):
+            path = path[len(root_path) :] or "/"
+        return path
 
     @classmethod
-    def _is_anonymous_standards_request(cls, request: Request) -> bool:
-        path = cls._standards_path(request)
-        if path is None:
-            return False
+    def _standards_path(cls, request: Request) -> str | None:
+        return standards_api_path(cls._request_path(request))
+
+    @classmethod
+    def _anonymous_public_methods(cls, request: Request) -> str | None:
+        """Return the ``Allow-Methods`` value for an anonymous wildcard answer.
+
+        ``None`` means the request does not qualify and falls through to the
+        explicit-origin policy (or to no CORS headers at all).
+
+        The two public surfaces answer different method sets, so the value is
+        resolved per surface rather than fixed: standards routes serve GET,
+        HEAD and a POST on ``/stac/search``; the search routes in
+        ``_PUBLIC_SEARCH_PATHS`` serve GET only. Advertising more than the
+        route answers is fix(#1470) — a browser was told HEAD was allowed and
+        then got a 405.
+
+        Everything after the surface check is shared, and deliberately so: the
+        credential exclusion and the safelisted-header check are what make a
+        wildcard safe, and a new surface must not be able to opt out of them.
+        """
+        standards_path = cls._standards_path(request)
+        if standards_path is not None:
+            allow_methods = _STANDARDS_PUBLIC_METHODS
+            permitted = {"GET", "HEAD"}
+            stac_search = standards_path.rstrip("/") == "/stac/search"
+        elif cls._request_path(request) in _PUBLIC_SEARCH_PATHS:
+            allow_methods = _SEARCH_PUBLIC_METHODS
+            permitted = {"GET"}
+            stac_search = False
+        else:
+            return None
 
         requested_method = request.headers.get(
             "access-control-request-method", request.method
         ).upper()
-        if requested_method not in {"GET", "HEAD"} and not (
-            requested_method == "POST" and path.rstrip("/") == "/stac/search"
+        if requested_method not in permitted and not (
+            requested_method == "POST" and stac_search
         ):
-            return False
+            return None
 
         # Never grant wildcard browser access to a request that can carry an
         # application identity.  This covers actual requests and preflights.
@@ -167,9 +231,9 @@ class DynamicCORSMiddleware(BaseHTTPMiddleware):
             "x-embed-token",
         }
         if any(request.headers.get(header) for header in credential_headers):
-            return False
+            return None
         if "api_key" in request.query_params or "embed_token" in request.query_params:
-            return False
+            return None
 
         requested_headers = {
             value.strip().lower()
@@ -184,14 +248,33 @@ class DynamicCORSMiddleware(BaseHTTPMiddleware):
             "content-language",
             "content-type",
         }
-        return requested_headers <= allowed_headers
+        if not requested_headers <= allowed_headers:
+            return None
+        return allow_methods
 
     @staticmethod
-    def _set_public_standards_cors_headers(
-        response: Response, request: Request
+    def _set_public_cors_headers(
+        response: Response, request: Request, allow_methods: str
     ) -> None:
+        """Answer an anonymous public request with the credential-free policy.
+
+        The Expose-Headers list is shared across both public surfaces. It
+        already covers everything the search routes set that a browser would
+        otherwise hide: ``standard_response_headers`` sets ``Vary``,
+        ``Content-Language`` and ``Link``, and ``Link`` — which carries the
+        next/prev pagination hrefs — is the only one of those that is not
+        CORS-safelisted. Search sets no count or rate-limit response header, so
+        nothing new is exposed anonymously by fix(#1596).
+
+        No ``Vary: Origin`` here, and none on the credentialed policy either:
+        the shipped ``frontend/nginx.conf`` serves ``location /api/`` with
+        ``proxy_cache off``, and a browser fails closed on a cached policy that
+        does not match its own origin. An operator fronting the API with their
+        own caching CDN would want it; that is a property of both policies and
+        not something fix(#1596) changed.
+        """
         response.headers["Access-Control-Allow-Origin"] = "*"
-        response.headers["Access-Control-Allow-Methods"] = "GET, HEAD, POST, OPTIONS"
+        response.headers["Access-Control-Allow-Methods"] = allow_methods
         requested_headers = request.headers.get("access-control-request-headers")
         if requested_headers:
             response.headers["Access-Control-Allow-Headers"] = requested_headers

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -2402,7 +2402,15 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # once per horizon instead of every five minutes. Two lines of docstring say
     # why the two passes on this line differ; the guard itself lives beside the
     # function it guards, in staging.py. Cap 1626 -> 1628, exact.
-    "backend/app/api/main.py": 1628,
+    # fix(#1596): +7 of comment, no code. The anonymous CORS wildcard now has a
+    # second surface (catalog search), which the derived-HEAD pass keyed on
+    # standards_api_path does not cover. Five lines in that function's docstring
+    # say the omission is deliberate and why it does not reopen #1470 — the
+    # middleware advertises GET, OPTIONS there, so nothing promises a HEAD no
+    # route registers. The other two widen the production CORS warning, which
+    # told an operator only standards reads were open to any browser origin.
+    # Cap 1628 -> 1635, exact.
+    "backend/app/api/main.py": 1635,
     # fix(#1005): +4 — MapSummaryResponse gains thumbnail_updated_at, the
     # thumbnail cache version split out of updated_at. Ratchet stays exact.
     # fix(#910): +1 on top of that, the fillColorSaved entry in the authoritative

--- a/backend/tests/test_ogc_discovery.py
+++ b/backend/tests/test_ogc_discovery.py
@@ -213,7 +213,7 @@ async def test_anonymous_standards_cors_default_is_read_only(client, monkeypatch
 async def test_head_is_served_wherever_the_preflight_advertises_it(client, monkeypatch):
     """fix(#1470): the preflight said HEAD was allowed; the route said 405.
 
-    ``_set_public_standards_cors_headers`` answers a standards preflight with
+    ``_set_public_cors_headers`` answers a standards preflight with
     ``GET, HEAD, POST, OPTIONS``, so a browser client that trusts it sent HEAD
     and got ``405 allow: GET``. Both surfaces are now derived from
     ``standards_api_path``.

--- a/backend/tests/test_phase_273_startup_warnings.py
+++ b/backend/tests/test_phase_273_startup_warnings.py
@@ -32,7 +32,8 @@ def test_cors_warning_fires_in_production_with_empty_cors():
         "cors_allowed_origins_unset",
         message=(
             "CORS_ALLOWED_ORIGINS is empty in production. "
-            "Anonymous standards reads allow any browser origin, but "
+            "Anonymous standards and catalog search reads allow any "
+            "browser origin, but "
             "credentialed application CORS is disabled. Set "
             "CORS_ALLOWED_ORIGINS=<comma-separated origins> to enable it."
         ),

--- a/backend/tests/test_search_cors_1596.py
+++ b/backend/tests/test_search_cors_1596.py
@@ -1,0 +1,313 @@
+"""fix(#1596): the anonymous wildcard has to cover catalog search too.
+
+``DynamicCORSMiddleware`` answers an origin outside ``CORS_ALLOWED_ORIGINS``
+with a credential-free wildcard policy, but only for paths
+``standards_api_path()`` classifies. ``GET /search/datasets/`` is the native
+route behind the same query engine as ``/collections/datasets/items``, it is
+anonymous-readable by design, and a browser page on another origin got no CORS
+headers at all — so the OGC Records alias worked cross-origin and the native
+search did not.
+
+The classifier stays where it is. It is shared with the error and OpenAPI
+contracts, and widening it would move ``/search`` onto the OGC error shape as a
+side effect. The middleware carries its own explicit list instead.
+
+Two properties these tests exist to hold:
+
+- the widening is narrow. ``/search/saved/`` sits under the same router prefix
+  and requires an authenticated user; a native route like ``/datasets/`` is not
+  public at all. Neither may pick up the wildcard.
+- the preflight tells the truth. #1470 was a preflight advertising ``HEAD`` on
+  routes that answered ``405``. Search answers ``GET`` and nothing else, so its
+  ``Access-Control-Allow-Methods`` says ``GET, OPTIONS`` and a preflight asking
+  for ``HEAD`` or ``POST`` is refused rather than promised.
+"""
+
+from fastapi.routing import APIRoute, iter_route_contexts
+import pytest
+from starlette.requests import Request
+
+from app.api.main import app
+from app.api.middleware.cors import _PUBLIC_SEARCH_PATHS, DynamicCORSMiddleware
+from app.modules.auth.dependencies import (
+    get_current_active_user,
+    get_current_user,
+)
+
+_FOREIGN_ORIGIN = "https://cors-1596.example.org"
+_ALLOWED_ORIGIN = "https://allowed-1596.example.com"
+
+
+@pytest.fixture
+def deny_all_origins(monkeypatch):
+    """Force every origin outside the allow-list.
+
+    Stubbed rather than written through settings for the reason
+    ``test_ogc_discovery.py`` spells out: a real lookup populates
+    ``cors._origins_cache``, a module global with a 30s TTL and no write
+    invalidation, and under ``pytest -n 4`` that cache outlives the test.
+    """
+
+    async def _deny(_self, _origin):
+        return False
+
+    monkeypatch.setattr(
+        "app.api.middleware.cors.DynamicCORSMiddleware._is_origin_allowed",
+        _deny,
+    )
+
+
+@pytest.fixture
+def allow_one_origin(monkeypatch):
+    async def _allow(_self, origin):
+        return origin == _ALLOWED_ORIGIN
+
+    monkeypatch.setattr(
+        "app.api.middleware.cors.DynamicCORSMiddleware._is_origin_allowed",
+        _allow,
+    )
+
+
+async def test_anonymous_search_is_readable_from_a_foreign_origin(
+    client, deny_all_origins
+):
+    """The reported case: a browser page elsewhere calls catalog search."""
+    response = await client.get(
+        "/search/datasets/?q=subway", headers={"Origin": _FOREIGN_ORIGIN}
+    )
+    assert response.status_code == 200
+    assert response.headers["access-control-allow-origin"] == "*"
+    assert "access-control-allow-credentials" not in response.headers
+
+
+@pytest.mark.parametrize("path", _PUBLIC_SEARCH_PATHS)
+async def test_every_listed_search_path_answers_the_wildcard(
+    client, deny_all_origins, path
+):
+    response = await client.get(path, headers={"Origin": _FOREIGN_ORIGIN})
+    assert response.status_code == 200, path
+    assert response.headers["access-control-allow-origin"] == "*", path
+    assert "access-control-allow-credentials" not in response.headers, path
+
+
+async def test_search_preflight_is_answered(client, deny_all_origins):
+    preflight = await client.options(
+        "/search/datasets/",
+        headers={
+            "Origin": _FOREIGN_ORIGIN,
+            "Access-Control-Request-Method": "GET",
+            "Access-Control-Request-Headers": "Accept",
+        },
+    )
+    assert preflight.status_code == 200
+    assert preflight.headers["access-control-allow-origin"] == "*"
+    assert "access-control-allow-credentials" not in preflight.headers
+    assert preflight.headers["access-control-allow-headers"] == "Accept"
+
+
+async def test_search_preflight_advertises_only_what_the_route_answers(
+    client, deny_all_origins
+):
+    """fix(#1470) again, on the new surface: no promise the route will refuse.
+
+    Search is registered ``GET``-only. FastAPI's ``APIRoute`` does not add HEAD
+    alongside GET the way starlette's plain ``Route`` does, and the derived-HEAD
+    pass in ``api/main.py`` is keyed on ``standards_api_path``, so HEAD and POST
+    both 405 here. The preflight has to say so instead of inviting them.
+    """
+    preflight = await client.options(
+        "/search/datasets/",
+        headers={
+            "Origin": _FOREIGN_ORIGIN,
+            "Access-Control-Request-Method": "GET",
+        },
+    )
+    methods = {
+        method.strip()
+        for method in preflight.headers["access-control-allow-methods"].split(",")
+    }
+    assert methods == {"GET", "OPTIONS"}
+
+    for refused in ("HEAD", "POST"):
+        # What the route does with it...
+        direct = await client.request(refused, "/search/datasets/")
+        assert direct.status_code == 405, refused
+        # ...is what the preflight has to predict.
+        preflight = await client.options(
+            "/search/datasets/",
+            headers={
+                "Origin": _FOREIGN_ORIGIN,
+                "Access-Control-Request-Method": refused,
+            },
+        )
+        assert "access-control-allow-origin" not in preflight.headers, refused
+
+
+async def test_search_exposes_the_headers_it_sets(client, deny_all_origins):
+    """``Link`` is unreadable to JavaScript unless it is named here.
+
+    ``standard_response_headers`` sets ``Vary``, ``Content-Language`` and
+    ``Link`` on the search response. ``Content-Language`` is CORS-safelisted;
+    ``Link`` carries the next/prev pagination hrefs and is not, so a client
+    paginating cross-origin needs it exposed.
+    """
+    response = await client.get(
+        "/search/datasets/?q=subway", headers={"Origin": _FOREIGN_ORIGIN}
+    )
+    exposed = {
+        header.strip().lower()
+        for header in response.headers["access-control-expose-headers"].split(",")
+    }
+    assert "link" in exposed
+    assert "content-language" in exposed
+
+
+@pytest.mark.parametrize(
+    "credential",
+    [
+        {"Authorization": "Bearer not-a-real-token"},
+        {"X-Api-Key": "not-a-real-key"},
+        {"Cookie": "session=not-a-real-session"},
+    ],
+)
+async def test_a_credential_bearing_search_gets_no_wildcard(
+    client, deny_all_origins, credential
+):
+    response = await client.get(
+        "/search/datasets/?q=subway",
+        headers={"Origin": _FOREIGN_ORIGIN, **credential},
+    )
+    assert "access-control-allow-origin" not in response.headers
+
+
+async def test_a_query_string_credential_gets_no_wildcard(client, deny_all_origins):
+    response = await client.get(
+        "/search/datasets/?q=subway&api_key=not-a-real-key",
+        headers={"Origin": _FOREIGN_ORIGIN},
+    )
+    assert "access-control-allow-origin" not in response.headers
+
+
+@pytest.mark.parametrize("path", ["/datasets/", "/search/saved/", "/maps/"])
+async def test_the_widening_stops_at_the_listed_paths(client, deny_all_origins, path):
+    """The counterfactual. ``/search/saved/`` shares the router prefix and is
+    authenticated, so a prefix match over ``/search`` would have taken it."""
+    response = await client.get(path, headers={"Origin": _FOREIGN_ORIGIN})
+    assert "access-control-allow-origin" not in response.headers, path
+
+
+async def test_an_allowed_origin_keeps_the_credentialed_policy(
+    client, allow_one_origin
+):
+    response = await client.get(
+        "/search/datasets/?q=subway", headers={"Origin": _ALLOWED_ORIGIN}
+    )
+    assert response.status_code == 200
+    assert response.headers["access-control-allow-origin"] == _ALLOWED_ORIGIN
+    assert response.headers["access-control-allow-credentials"] == "true"
+
+
+async def test_an_allowed_origin_keeps_the_credentialed_policy_with_a_token(
+    client, allow_one_origin, admin_auth_header
+):
+    """An allow-listed origin is unaffected by the credential exclusion."""
+    response = await client.get(
+        "/search/datasets/?q=subway",
+        headers={"Origin": _ALLOWED_ORIGIN, **admin_auth_header},
+    )
+    assert response.status_code == 200
+    assert response.headers["access-control-allow-origin"] == _ALLOWED_ORIGIN
+    assert response.headers["access-control-allow-credentials"] == "true"
+
+
+# --- path normalization ---
+
+
+def _scope(path: str, *, root_path: str = "") -> Request:
+    return Request(
+        {
+            "type": "http",
+            "method": "GET",
+            "path": path,
+            "root_path": root_path,
+            "query_string": b"",
+            "headers": [],
+        }
+    )
+
+
+@pytest.mark.parametrize(
+    "root_path,raw,expected",
+    [
+        ("", "/search/datasets/", "/search/datasets/"),
+        ("/api", "/api/search/datasets/", "/search/datasets/"),
+        ("/api/", "/api/search/datasets/", "/search/datasets/"),
+        ("/api", "/api", "/"),
+    ],
+)
+def test_root_path_is_stripped_before_the_list_is_read(root_path, raw, expected):
+    """The list holds app-relative paths, so a mounted deployment has to match.
+
+    Whether ``/api`` is stripped by the proxy or carried as an ASGI
+    ``root_path`` is the operator's choice, and the reported URL
+    (``/api/search/datasets/``) is the mounted form.
+    """
+    request = _scope(raw, root_path=root_path)
+    assert DynamicCORSMiddleware._request_path(request) == expected
+
+
+def test_a_mounted_deployment_still_earns_the_wildcard():
+    request = _scope("/api/search/datasets/", root_path="/api")
+    assert DynamicCORSMiddleware._anonymous_public_methods(request) == "GET, OPTIONS"
+
+
+def test_a_mounted_standards_path_keeps_its_own_method_set():
+    """The two surfaces are resolved separately and must not swap policies."""
+    request = _scope("/api/collections", root_path="/api")
+    assert (
+        DynamicCORSMiddleware._anonymous_public_methods(request)
+        == "GET, HEAD, POST, OPTIONS"
+    )
+
+
+# --- structural guard on the list itself ---
+
+
+def _dependency_calls(dependant) -> set:
+    calls = {dependant.call}
+    for child in dependant.dependencies:
+        calls |= _dependency_calls(child)
+    return calls
+
+
+def _routes_for_path(path: str) -> list:
+    return [
+        ctx.route
+        for ctx in iter_route_contexts(app.routes)
+        if isinstance(ctx.route, APIRoute) and ctx.path == path
+    ]
+
+
+@pytest.mark.parametrize("path", _PUBLIC_SEARCH_PATHS)
+def test_listed_paths_are_get_only_and_anonymous(path):
+    """A path earns the wildcard only by being a real, GET-only, open route.
+
+    Fails toward reporting: an entry that matches nothing in the route table is
+    a failure, not a silent pass, so a typo or a route rename cannot leave a
+    dead string in the list looking healthy.
+    """
+    routes = _routes_for_path(path)
+    assert routes, f"{path} is in _PUBLIC_SEARCH_PATHS but matches no route"
+
+    for route in routes:
+        assert route.methods <= {"GET", "HEAD", "OPTIONS"}, (
+            f"{path} answers {sorted(route.methods)}; the wildcard is read-only"
+        )
+        requires_auth = _dependency_calls(route.dependant) & {
+            get_current_active_user,
+            get_current_user,
+        }
+        assert not requires_auth, (
+            f"{path} requires an authenticated user via "
+            f"{[dep.__name__ for dep in requires_auth]}"
+        )

--- a/backend/tests/test_search_cors_1596.py
+++ b/backend/tests/test_search_cors_1596.py
@@ -15,8 +15,9 @@ side effect. The middleware carries its own explicit list instead.
 Two properties these tests exist to hold:
 
 - the widening is narrow. ``/search/saved/`` sits under the same router prefix
-  and requires an authenticated user; a native route like ``/datasets/`` is not
-  public at all. Neither may pick up the wildcard.
+  and requires an authenticated user, and ``/maps/`` answers a stranger with a
+  200 and still stays outside the wildcard. The list is an allow-list, not
+  "whatever an anonymous caller happens to be able to read".
 - the preflight tells the truth. #1470 was a preflight advertising ``HEAD`` on
   routes that answered ``405``. Search answers ``GET`` and nothing else, so its
   ``Access-Control-Allow-Methods`` says ``GET, OPTIONS`` and a preflight asking

--- a/backend/tests/test_search_cors_1596.py
+++ b/backend/tests/test_search_cors_1596.py
@@ -188,11 +188,24 @@ async def test_a_query_string_credential_gets_no_wildcard(client, deny_all_origi
     assert "access-control-allow-origin" not in response.headers
 
 
-@pytest.mark.parametrize("path", ["/datasets/", "/search/saved/", "/maps/"])
-async def test_the_widening_stops_at_the_listed_paths(client, deny_all_origins, path):
-    """The counterfactual. ``/search/saved/`` shares the router prefix and is
-    authenticated, so a prefix match over ``/search`` would have taken it."""
+@pytest.mark.parametrize(
+    "path,expected_status",
+    [
+        # Shares the router prefix with the listed paths and is authenticated,
+        # so a prefix match over ``/search`` would have swept it in.
+        ("/search/saved/", 401),
+        ("/datasets/", 401),
+        # The sharp one: anonymous-readable, 200 to a stranger, and still no
+        # wildcard. The list is an allow-list, not "whatever anonymous can read".
+        ("/maps/", 200),
+    ],
+)
+async def test_the_widening_stops_at_the_listed_paths(
+    client, deny_all_origins, path, expected_status
+):
     response = await client.get(path, headers={"Origin": _FOREIGN_ORIGIN})
+    # Pinned so a rename cannot turn this into a 404 that passes for free.
+    assert response.status_code == expected_status, path
     assert "access-control-allow-origin" not in response.headers, path
 
 

--- a/backend/tests/test_search_cors_1596.py
+++ b/backend/tests/test_search_cors_1596.py
@@ -163,6 +163,72 @@ async def test_search_exposes_the_headers_it_sets(client, deny_all_origins):
     assert "content-language" in exposed
 
 
+@pytest.fixture
+def one_search_per_minute(monkeypatch):
+    """Arm the limiter and drop the semantic-search limit to 1/minute.
+
+    ``_semantic_search_rate_limit`` reads ``get_cached_semantic_search_rate_limit``
+    at request time, so patching the router's reference is enough. The limiter
+    is off under test by default; switch it on and reset its storage so the
+    count starts at zero for this test and leaves nothing behind.
+    """
+    from app.platform.ratelimit import limiter
+
+    monkeypatch.setattr(
+        "app.modules.catalog.search.router.get_cached_semantic_search_rate_limit",
+        lambda: 1,
+    )
+    original_enabled = limiter.enabled
+    limiter.enabled = True
+    limiter._storage.reset()
+    try:
+        yield
+    finally:
+        limiter.enabled = original_enabled
+        limiter._storage.reset()
+
+
+@pytest.mark.parametrize(
+    "policy_fixture, origin, expected_allow_origin",
+    [
+        ("deny_all_origins", _FOREIGN_ORIGIN, "*"),
+        ("allow_one_origin", _ALLOWED_ORIGIN, _ALLOWED_ORIGIN),
+    ],
+    ids=["wildcard", "credentialed"],
+)
+async def test_a_429_exposes_its_retry_window(
+    client,
+    request,
+    one_search_per_minute,
+    policy_fixture,
+    origin,
+    expected_allow_origin,
+):
+    """A rate-limited search is still a CORS response, and its ``Retry-After``
+    has to be readable.
+
+    ``_rate_limit_handler`` (api/main.py) sets ``Retry-After`` on every 429.
+    The header is not CORS-safelisted, so unless it is named in
+    ``Access-Control-Expose-Headers`` a cross-origin caller sees the 429 and
+    cannot read how long to back off (codex on #1601). Both policies are
+    checked: the anonymous wildcard this fix added, and the credentialed one
+    that already served an allowed origin.
+    """
+    request.getfixturevalue(policy_fixture)
+    headers = {"Origin": origin}
+    first = await client.get("/search/datasets/?q=subway", headers=headers)
+    assert first.status_code == 200, first.text
+    limited = await client.get("/search/datasets/?q=subway", headers=headers)
+    assert limited.status_code == 429, limited.text
+    assert limited.headers["access-control-allow-origin"] == expected_allow_origin
+    assert "retry-after" in limited.headers, dict(limited.headers)
+    exposed = {
+        header.strip().lower()
+        for header in limited.headers["access-control-expose-headers"].split(",")
+    }
+    assert "retry-after" in exposed, sorted(exposed)
+
+
 @pytest.mark.parametrize(
     "credential",
     [


### PR DESCRIPTION
Closes #1596

`DynamicCORSMiddleware` answers an origin outside `CORS_ALLOWED_ORIGINS` with a credential-free wildcard, but only on paths `standards_api_path()` classifies. `GET /search/datasets/` is the native route behind the same query engine as `/collections/datasets/items`, and it got no CORS headers at all, so a browser page on another origin could call the OGC Records alias but not the native search. The comment in the middleware already claimed "read/search routes" were covered.

## What changed

The middleware carries its own explicit list of native catalog paths that earn the wildcard:

```
/search/datasets, /search/datasets/, /search/facets, /search/facets/
```

`standards_api_path` is untouched. It is shared with the error and OpenAPI contracts, so widening it would have moved `/search` onto the OGC error shape as a side effect of a CORS fix. The paths are enumerated rather than matched as a `/search` prefix because `/search/saved` sits under the same router and requires an authenticated user.

Both handlers take `get_optional_user`, treat an anonymous caller as having no roles, and run `apply_visibility_filter`, so a wildcard response returns exactly the public catalog. `/search/facets/` is in the list because a search UI reads facet counts alongside results under the same anonymous contract.

`Access-Control-Allow-Methods` is now resolved per surface instead of being one fixed string. Standards routes keep `GET, HEAD, POST, OPTIONS`; search gets `GET, OPTIONS`. Search is registered GET-only and the derived-HEAD pass in `api/main.py` is keyed on `standards_api_path`, so HEAD and POST both 405 there. Advertising a method the route refuses is what #1470 was, so a preflight asking for either is declined instead of answered.

## Invariants kept

- no `Access-Control-Allow-Credentials` on the wildcard;
- only for an origin that is *not* allow-listed. An allow-listed origin still gets the explicit-origin credentialed policy on the search route;
- credential-bearing requests excluded on the same terms as the standards surface: `Authorization`, `Cookie`, `X-Api-Key`, `X-Embed-Token`, and the `api_key`/`embed_token` query parameters. That check and the safelisted-request-header check are shared by both surfaces, so a new surface cannot opt out of them;
- Expose-Headers unchanged. `standard_response_headers` sets `Vary`, `Content-Language` and `Link` on the search response. `Link` carries the pagination hrefs and is the only one of those that is not CORS-safelisted, and it was already listed. Search sets no count or rate-limit response header, so nothing new is readable anonymously.

## Also

The production `cors_allowed_origins_unset` warning and the `.env.example` note both told an operator that only standards reads were open to any browser origin. Both name catalog search now.

`_MODULE_LOC_CAPS["backend/app/api/main.py"]` goes 1628 to 1635, all comment. Five lines record why the derived-HEAD pass deliberately does not cover the new surface; two are the widened warning.

## Verification

Red first. The eight wildcard assertions failed before the middleware change, with the counterfactual tests already passing:

```
8 failed, 13 passed
FAILED test_anonymous_search_is_readable_from_a_foreign_origin
FAILED test_every_listed_search_path_answers_the_wildcard[/search/datasets/]  (x4 paths)
FAILED test_search_preflight_is_answered
FAILED test_search_preflight_advertises_only_what_the_route_answers
FAILED test_search_exposes_the_headers_it_sets
```

Then, against the dev Postgres:

- `pytest tests/test_search_cors_1596.py`: 27 passed
- `pytest tests/test_search_cors_1596.py tests/test_ogc_discovery.py tests/test_persistent_config.py tests/test_search.py tests/test_search_facets.py tests/test_saved_searches.py tests/test_cors_range_headers_1540.py tests/test_phase_273_startup_warnings.py tests/test_layering.py tests/test_rule1_structural.py -n 4`: 228 passed
- `pytest tests/test_layering.py tests/test_rule1_structural.py tests/test_rule2_structural.py`: 150 passed
- `ruff check .` and `ruff format --check .`: clean
- `python scripts/dump_openapi.py --check`: no drift, since no route was added
- `pre-commit run --files <changed>`: all hooks pass

`test_search_cors_1596.py` also holds the list itself. Every entry has to resolve to a real route whose methods are a subset of `{GET, HEAD, OPTIONS}` and whose dependency tree does not reach `get_current_user` or `get_current_active_user`. An entry matching nothing in the route table fails rather than passing quietly, so a rename cannot leave a dead string looking healthy.

The list is a tuple rather than a frozenset for a reason worth writing down: the tests parametrize over it, string hashing is salted per process, and a set's iteration order differs between xdist workers, which broke collection under `-n 4` before I changed it.

## One thing I did not change

Neither policy emits `Vary: Origin`, which predates this PR. The shipped `frontend/nginx.conf` serves `location /api/` with `proxy_cache off`, and a browser fails closed on a cached policy that does not match its own origin, so nothing leaks. An operator fronting the API with their own caching CDN would still want it. It applies to both policies and to every standards route, so it belongs in its own change rather than riding along here. There is a note on `_set_public_cors_headers` recording that.
