### PR TITLE
fix(cors): send Vary: Origin on both CORS policies

### DIFF
--- a/backend/app/api/middleware/cors.py
+++ b/backend/app/api/middleware/cors.py
@@ -46,6 +46,51 @@ _STANDARDS_PUBLIC_METHODS = "GET, HEAD, POST, OPTIONS"
 _SEARCH_PUBLIC_METHODS = "GET, OPTIONS"
 
 
+def _merge_vary_origin(response: Response) -> None:
+    """Declare that this response was derived from the request's ``Origin``.
+
+    fix(#1602). Both policies below answer differently depending on the origin
+    that asked, so a cache that stores one answer under a key that omits
+    ``Origin`` can replay it to a different origin. The shipped
+    ``frontend/nginx.conf`` serves ``location /api/`` with ``proxy_cache off``,
+    so this is not a leak on a default deployment; it is what an operator
+    fronting the API with their own CDN needs in order not to hand
+    ``Access-Control-Allow-Origin: https://a.example`` to ``b.example``.
+
+    Merged rather than assigned. ``standard_response_headers`` already sets
+    ``Vary: Accept-Language`` on the search and standards responses, and
+    ``GZipMiddleware`` adds ``Accept-Encoding``; overwriting either would buy
+    the CORS variance by losing the content-negotiation one, which is the same
+    defect pointed at a different header. Tokens are compared case-insensitively
+    because field names are, and an already-present ``Origin`` is left exactly
+    as the route spelled it.
+
+    Only the two policy writers call this. A response the middleware passes
+    through untouched — no ``Origin`` header, or an origin outside the
+    allow-list on a route that is not public — keeps whatever ``Vary`` its
+    route set. That response does still depend on the origin, but only in the
+    direction that fails closed: a cache replaying the header-less answer to an
+    allowed origin makes a browser block a request it would have permitted,
+    where the reverse would hand out a policy the origin never earned.
+    """
+    tokens: list[str] = []
+    for line in response.headers.getlist("Vary"):
+        tokens.extend(token.strip() for token in line.split(",") if token.strip())
+
+    # ``Vary: *`` is an alternative to the token list, not a member of it
+    # (RFC 9110: ``Vary = #( field-name ) / "*"``), and it already tells every
+    # cache not to reuse the response. Appending to it would only be a syntax
+    # error.
+    if any(token == "*" for token in tokens):
+        return
+
+    if not any(token.lower() == "origin" for token in tokens):
+        tokens.append("Origin")
+
+    # Assignment (not ``append``) so duplicate field-lines collapse into one.
+    response.headers["Vary"] = ", ".join(tokens)
+
+
 class DynamicCORSMiddleware(BaseHTTPMiddleware):
     """CORS middleware that dynamically resolves allowed origins from PersistentConfig.
 
@@ -151,6 +196,10 @@ class DynamicCORSMiddleware(BaseHTTPMiddleware):
         source for the conditional headers it evaluates and the response headers
         it sets, and fails if either is missing here. Add a header there and
         this list is what breaks — before a browser console does.
+
+        fix(#1602): this policy echoes the caller's origin, so the response it
+        is written onto is not reusable for a different one. See
+        ``_merge_vary_origin`` for why the header is merged and not assigned.
         """
         response.headers["Access-Control-Allow-Origin"] = origin
         response.headers["Access-Control-Allow-Credentials"] = "true"
@@ -171,6 +220,7 @@ class DynamicCORSMiddleware(BaseHTTPMiddleware):
             "X-GeoLens-Metadata-Fallback-Fields"
         )
         response.headers["Access-Control-Max-Age"] = "3600"
+        _merge_vary_origin(response)
 
     @staticmethod
     def _request_path(request: Request) -> str:
@@ -272,12 +322,13 @@ class DynamicCORSMiddleware(BaseHTTPMiddleware):
         credentialed policy too, or a cross-origin caller sees the 429 and
         cannot read the retry window (codex on #1601).
 
-        No ``Vary: Origin`` here, and none on the credentialed policy either:
-        the shipped ``frontend/nginx.conf`` serves ``location /api/`` with
-        ``proxy_cache off``, and a browser fails closed on a cached policy that
-        does not match its own origin. An operator fronting the API with their
-        own caching CDN would want it; that is a property of both policies and
-        not something fix(#1596) changed.
+        fix(#1602): ``Vary: Origin`` goes on this policy as well as on the
+        credentialed one, through ``_merge_vary_origin``. A ``*`` answer does
+        not strictly need it, since every origin gets the same value — but the
+        two policies share a path and therefore a cache entry, and a stored
+        wildcard is indistinguishable from a stored echoed origin once it is in
+        the cache. Consistency across both writers is what makes the header
+        mean anything.
         """
         response.headers["Access-Control-Allow-Origin"] = "*"
         response.headers["Access-Control-Allow-Methods"] = allow_methods
@@ -292,3 +343,4 @@ class DynamicCORSMiddleware(BaseHTTPMiddleware):
             "X-GeoLens-Metadata-Fallback-Fields"
         )
         response.headers["Access-Control-Max-Age"] = "3600"
+        _merge_vary_origin(response)

--- a/backend/app/api/middleware/cors.py
+++ b/backend/app/api/middleware/cors.py
@@ -49,9 +49,9 @@ _SEARCH_PUBLIC_METHODS = "GET, OPTIONS"
 def _merge_vary_origin(response: Response) -> None:
     """Declare that this response was derived from the request's ``Origin``.
 
-    fix(#1602). Both policies below answer differently depending on the origin
-    that asked, so a cache that stores one answer under a key that omits
-    ``Origin`` can replay it to a different origin. The shipped
+    fix(#1602). What this middleware answers depends on the origin that asked,
+    so a cache that stores one answer under a key omitting ``Origin`` can
+    replay it to a different origin. The shipped
     ``frontend/nginx.conf`` serves ``location /api/`` with ``proxy_cache off``,
     so this is not a leak on a default deployment; it is what an operator
     fronting the API with their own CDN needs in order not to hand
@@ -65,13 +65,15 @@ def _merge_vary_origin(response: Response) -> None:
     because field names are, and an already-present ``Origin`` is left exactly
     as the route spelled it.
 
-    Only the two policy writers call this. A response the middleware passes
-    through untouched — no ``Origin`` header, or an origin outside the
-    allow-list on a route that is not public — keeps whatever ``Vary`` its
-    route set. That response does still depend on the origin, but only in the
-    direction that fails closed: a cache replaying the header-less answer to an
-    allowed origin makes a browser block a request it would have permitted,
-    where the reverse would hand out a policy the origin never earned.
+    Applied to every response the middleware returns, not only the two that
+    carry a policy. fix(#1602 codex r1): a response produced for a rejected
+    origin, or for a request with no ``Origin`` header at all, is the same URL
+    that answers a permitted origin with ``Access-Control-Allow-Origin``. A CDN
+    that stores the header-less variant under an origin-less key then replays
+    it to a browser origin the operator allowed, and the browser blocks a
+    request the configured policy permits. That direction fails closed rather
+    than leaking, but a blocked request is still a broken deployment, and it is
+    the deployment this header exists for.
     """
     tokens: list[str] = []
     for line in response.headers.getlist("Vary"):
@@ -99,6 +101,16 @@ class DynamicCORSMiddleware(BaseHTTPMiddleware):
     """
 
     async def dispatch(self, request: Request, call_next):
+        response = await self._dispatch(request, call_next)
+        # fix(#1602 codex r1): one call, at the one exit. Every representation
+        # this middleware can return is origin-dependent, including the ones it
+        # writes no policy onto, so the declaration belongs here rather than in
+        # the policy writers — where a branch that returns without calling one
+        # (and two of the four do) would silently skip it.
+        _merge_vary_origin(response)
+        return response
+
+    async def _dispatch(self, request: Request, call_next) -> Response:
         origin = request.headers.get("origin")
 
         # No origin header -- not a CORS request, pass through
@@ -198,8 +210,9 @@ class DynamicCORSMiddleware(BaseHTTPMiddleware):
         this list is what breaks — before a browser console does.
 
         fix(#1602): this policy echoes the caller's origin, so the response it
-        is written onto is not reusable for a different one. See
-        ``_merge_vary_origin`` for why the header is merged and not assigned.
+        is written onto is not reusable for a different one. The declaration
+        itself is not made here — ``dispatch`` merges ``Vary: Origin`` onto
+        every response, including the ones no policy is written onto.
         """
         response.headers["Access-Control-Allow-Origin"] = origin
         response.headers["Access-Control-Allow-Credentials"] = "true"
@@ -220,7 +233,6 @@ class DynamicCORSMiddleware(BaseHTTPMiddleware):
             "X-GeoLens-Metadata-Fallback-Fields"
         )
         response.headers["Access-Control-Max-Age"] = "3600"
-        _merge_vary_origin(response)
 
     @staticmethod
     def _request_path(request: Request) -> str:
@@ -322,13 +334,12 @@ class DynamicCORSMiddleware(BaseHTTPMiddleware):
         credentialed policy too, or a cross-origin caller sees the 429 and
         cannot read the retry window (codex on #1601).
 
-        fix(#1602): ``Vary: Origin`` goes on this policy as well as on the
-        credentialed one, through ``_merge_vary_origin``. A ``*`` answer does
-        not strictly need it, since every origin gets the same value — but the
-        two policies share a path and therefore a cache entry, and a stored
+        fix(#1602): a ``*`` answer does not strictly need ``Vary: Origin``,
+        since every origin gets the same value, but this path shares a URL with
+        the credentialed policy and therefore a cache entry, and a stored
         wildcard is indistinguishable from a stored echoed origin once it is in
-        the cache. Consistency across both writers is what makes the header
-        mean anything.
+        the cache. ``dispatch`` puts the header on every response it returns,
+        so no writer here has to remember to.
         """
         response.headers["Access-Control-Allow-Origin"] = "*"
         response.headers["Access-Control-Allow-Methods"] = allow_methods
@@ -343,4 +354,3 @@ class DynamicCORSMiddleware(BaseHTTPMiddleware):
             "X-GeoLens-Metadata-Fallback-Fields"
         )
         response.headers["Access-Control-Max-Age"] = "3600"
-        _merge_vary_origin(response)

--- a/backend/tests/test_cors_vary_origin_1602.py
+++ b/backend/tests/test_cors_vary_origin_1602.py
@@ -1,0 +1,349 @@
+"""fix(#1602): a CORS response has to declare that it varies by ``Origin``.
+
+``DynamicCORSMiddleware`` writes two origin-dependent policies. The
+credentialed one echoes the caller's origin into
+``Access-Control-Allow-Origin``; the anonymous one answers ``*``. Neither said
+``Vary: Origin``, so the body and the policy were cacheable under a key that
+did not include the input the policy was derived from.
+
+It is not a leak on a default deployment: the shipped ``frontend/nginx.conf``
+serves ``location /api/`` with ``proxy_cache off``, and a browser fails closed
+when a cached policy does not name its own origin. The header is for the
+operator who fronts the API with a caching CDN, where a stored
+``Access-Control-Allow-Origin: https://a.example`` replayed to
+``https://b.example`` is a policy one origin never earned.
+
+Both policies carry it, including the wildcard. ``*`` does not strictly need
+it — the answer is the same for every origin — but the two policies share a
+cache. A path that answers one origin with ``*`` and another with an echoed
+origin is exactly the case the header disambiguates, and a cache cannot know
+which writer produced the entry it holds.
+
+What these tests pin, beyond "the header is present":
+
+- the merge. ``standard_response_headers`` already sets ``Vary:
+  Accept-Language`` on the search and standards responses. Overwriting it
+  would cost content negotiation its cache key, which is a bug traded for a
+  bug, so ``Origin`` is appended to what the route set and each token appears
+  once.
+- the silence. A response the middleware writes no policy onto must not gain
+  ``Vary: Origin``: a request with no ``Origin`` header, and a native route
+  answering an origin outside the allow-list. Each of those is paired with the
+  positive case on the same route, so a rename that makes the header vanish
+  everywhere cannot pass the absence assertion for free.
+"""
+
+import pytest
+from starlette.responses import Response
+
+from app.api.middleware.cors import DynamicCORSMiddleware, _merge_vary_origin
+
+_FOREIGN_ORIGIN = "https://cors-1602.example.org"
+_ALLOWED_ORIGIN = "https://allowed-1602.example.com"
+
+
+@pytest.fixture
+def deny_all_origins(monkeypatch):
+    """Force every origin outside the allow-list.
+
+    Stubbed rather than written through settings for the reason
+    ``test_ogc_discovery.py`` spells out: a real lookup populates
+    ``cors._origins_cache``, a module global with a 30s TTL and no write
+    invalidation, and under ``pytest -n 4`` that cache outlives the test.
+    """
+
+    async def _deny(_self, _origin):
+        return False
+
+    monkeypatch.setattr(
+        "app.api.middleware.cors.DynamicCORSMiddleware._is_origin_allowed",
+        _deny,
+    )
+
+
+@pytest.fixture
+def allow_one_origin(monkeypatch):
+    async def _allow(_self, origin):
+        return origin == _ALLOWED_ORIGIN
+
+    monkeypatch.setattr(
+        "app.api.middleware.cors.DynamicCORSMiddleware._is_origin_allowed",
+        _allow,
+    )
+
+
+def _vary_tokens(response) -> list[str]:
+    """Every ``Vary`` token across every ``Vary`` field-line, lowercased.
+
+    Reads all field-lines rather than ``headers["vary"]`` so that emitting a
+    second ``Vary`` header instead of extending the first cannot pass as a
+    merge: a duplicate is legal HTTP and would still be counted here, which is
+    what makes the "exactly once" assertions meaningful.
+    """
+    return [
+        token.strip().lower()
+        for line in response.headers.get_list("vary")
+        for token in line.split(",")
+        if token.strip()
+    ]
+
+
+# ---------------------------------------------------------------------------
+# (a) the credentialed policy
+# ---------------------------------------------------------------------------
+
+
+async def test_the_credentialed_policy_varies_by_origin(client, allow_one_origin):
+    """The response that echoes an origin is the one a cache must key on."""
+    response = await client.get("/health", headers={"Origin": _ALLOWED_ORIGIN})
+
+    assert response.headers["access-control-allow-origin"] == _ALLOWED_ORIGIN
+    assert response.headers["access-control-allow-credentials"] == "true"
+    assert "origin" in _vary_tokens(response), dict(response.headers)
+
+
+async def test_the_credentialed_preflight_varies_by_origin(client, allow_one_origin):
+    """The preflight is a separate response written by the same policy.
+
+    It is answered by the middleware itself rather than by a route, so it has
+    no ``Vary`` of its own to merge into and would be the easiest of the four
+    writers to miss.
+    """
+    preflight = await client.options(
+        "/datasets/",
+        headers={
+            "Origin": _ALLOWED_ORIGIN,
+            "Access-Control-Request-Method": "GET",
+        },
+    )
+
+    assert preflight.status_code == 200
+    assert preflight.headers["access-control-allow-origin"] == _ALLOWED_ORIGIN
+    assert "origin" in _vary_tokens(preflight), dict(preflight.headers)
+
+
+# ---------------------------------------------------------------------------
+# (b) the anonymous wildcard policy
+# ---------------------------------------------------------------------------
+
+
+async def test_the_wildcard_policy_varies_by_origin(client, deny_all_origins):
+    """``*`` shares a cache with the echoed-origin answer, so it says so too."""
+    response = await client.get("/conformance", headers={"Origin": _FOREIGN_ORIGIN})
+
+    assert response.status_code == 200
+    assert response.headers["access-control-allow-origin"] == "*"
+    assert "access-control-allow-credentials" not in response.headers
+    assert "origin" in _vary_tokens(response), dict(response.headers)
+
+
+async def test_the_wildcard_preflight_varies_by_origin(client, deny_all_origins):
+    preflight = await client.options(
+        "/collections",
+        headers={
+            "Origin": _FOREIGN_ORIGIN,
+            "Access-Control-Request-Method": "GET",
+            "Access-Control-Request-Headers": "Accept",
+        },
+    )
+
+    assert preflight.status_code == 200
+    assert preflight.headers["access-control-allow-origin"] == "*"
+    assert "origin" in _vary_tokens(preflight), dict(preflight.headers)
+
+
+# ---------------------------------------------------------------------------
+# (c) the merge with a Vary the route already set
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "policy_fixture, origin, expected_allow_origin",
+    [
+        ("deny_all_origins", _FOREIGN_ORIGIN, "*"),
+        ("allow_one_origin", _ALLOWED_ORIGIN, _ALLOWED_ORIGIN),
+    ],
+    ids=["wildcard", "credentialed"],
+)
+async def test_an_existing_vary_keeps_its_tokens_and_gains_origin_once(
+    client, request, policy_fixture, origin, expected_allow_origin
+):
+    """``/search/datasets/`` sets ``Vary: Accept-Language`` before we get here.
+
+    ``standard_response_headers`` sets it so a cache does not serve a French
+    body to an English caller. Replacing that value with ``Origin`` would fix
+    the CORS variance by breaking the language variance, and a cache would
+    then hand the wrong translation to a caller on the right origin — the same
+    class of defect one layer over. Both tokens survive, once each.
+    """
+    request.getfixturevalue(policy_fixture)
+    response = await client.get(
+        "/search/datasets/?q=subway", headers={"Origin": origin}
+    )
+
+    assert response.status_code == 200, response.text
+    assert response.headers["access-control-allow-origin"] == expected_allow_origin
+
+    tokens = _vary_tokens(response)
+    assert "accept-language" in tokens, tokens
+    assert tokens.count("origin") == 1, tokens
+    assert tokens.count("accept-language") == 1, tokens
+    assert len(response.headers.get_list("vary")) == 1, response.headers.get_list(
+        "vary"
+    )
+
+
+async def test_the_route_sets_a_vary_this_test_is_not_inventing(
+    client, deny_all_origins
+):
+    """The vacuity guard for the merge test above.
+
+    If ``/search/datasets/`` ever stops setting ``Vary: Accept-Language``, the
+    merge assertions still pass while proving nothing about merging. Read the
+    route's own answer without an ``Origin`` header, where the middleware never
+    runs, and confirm there is something to merge into.
+
+    ``Accept-Encoding`` is in here too — ``GZipMiddleware`` adds its own token
+    through the same header — which is the second reason not to assert an
+    exact value anywhere in this file: the ``Vary`` on a response is written by
+    more than one component, and only ``Origin`` belongs to this fix.
+    """
+    response = await client.get("/search/datasets/?q=subway")
+
+    assert response.status_code == 200, response.text
+    tokens = _vary_tokens(response)
+    assert "accept-language" in tokens, dict(response.headers)
+    assert "origin" not in tokens, dict(response.headers)
+
+
+# ---------------------------------------------------------------------------
+# (d) the counterfactual: no policy written, no Vary: Origin
+# ---------------------------------------------------------------------------
+
+
+async def test_a_disallowed_origin_on_a_native_route_gains_nothing(
+    client, allow_one_origin
+):
+    """No CORS headers, so nothing that varies by origin, so no ``Vary``.
+
+    ``/maps/`` answers a stranger with a 200 and stays outside the anonymous
+    wildcard allow-list, which makes it the route where "no policy" is a real
+    state rather than an error page. The allowed origin is asserted on the
+    same path in the same test so the absence below cannot pass because the
+    header vanished everywhere.
+    """
+    denied = await client.get("/maps/", headers={"Origin": _FOREIGN_ORIGIN})
+    assert denied.status_code == 200
+    assert "access-control-allow-origin" not in denied.headers
+    assert "origin" not in _vary_tokens(denied), dict(denied.headers)
+
+    allowed = await client.get("/maps/", headers={"Origin": _ALLOWED_ORIGIN})
+    assert allowed.headers["access-control-allow-origin"] == _ALLOWED_ORIGIN
+    assert "origin" in _vary_tokens(allowed), dict(allowed.headers)
+
+
+async def test_a_request_with_no_origin_header_gains_nothing(client, allow_one_origin):
+    """Not a CORS request at all: the middleware returns before either writer."""
+    response = await client.get("/health")
+
+    assert response.status_code == 200
+    assert "access-control-allow-origin" not in response.headers
+    assert "origin" not in _vary_tokens(response), dict(response.headers)
+
+
+# ---------------------------------------------------------------------------
+# the merge itself, at the unit the routes cannot reach
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "existing, expected",
+    [
+        pytest.param(None, "Origin", id="absent"),
+        pytest.param("", "Origin", id="empty"),
+        pytest.param("Accept-Language", "Accept-Language, Origin", id="one-token"),
+        pytest.param(
+            "Accept-Language, Accept-Encoding",
+            "Accept-Language, Accept-Encoding, Origin",
+            id="two-tokens",
+        ),
+        # Idempotent, and case-insensitively so: field names are
+        # case-insensitive, and a second "origin" is noise a cache has to parse.
+        pytest.param("Origin", "Origin", id="already-there"),
+        pytest.param("origin", "origin", id="already-there-lowercased"),
+        pytest.param(
+            "Accept-Language, ORIGIN",
+            "Accept-Language, ORIGIN",
+            id="already-there-mixed-case",
+        ),
+        # Whitespace and empty members are legal on the wire (RFC 9110 allows
+        # the empty list element); neither may become an empty emitted token.
+        pytest.param("  Accept-Language  ", "Accept-Language, Origin", id="padded"),
+        pytest.param(
+            ",Accept-Language,,", "Accept-Language, Origin", id="empty-members"
+        ),
+        # ``*`` already says "do not reuse this for another request". Appending
+        # to it would be a syntax error against the Vary grammar, which is
+        # ``#field-name / "*"`` — the two are alternatives, not a list.
+        pytest.param("*", "*", id="star"),
+    ],
+)
+def test_merge_vary_origin(existing, expected):
+    response = Response()
+    if existing is not None:
+        response.headers["Vary"] = existing
+
+    _merge_vary_origin(response)
+
+    assert response.headers.getlist("Vary") == [expected]
+
+
+def test_merge_vary_origin_collapses_duplicate_field_lines():
+    """Two ``Vary`` lines are one header; the merge must not leave a stray.
+
+    Starlette's ``MutableHeaders.__setitem__`` removes the duplicates when it
+    writes, so this is a property of the write rather than something the merge
+    does by hand — pinned because reading only the first line and setting it
+    back would silently drop the second.
+    """
+    response = Response()
+    response.headers.append("Vary", "Accept-Language")
+    response.headers.append("Vary", "Accept-Encoding")
+
+    _merge_vary_origin(response)
+
+    assert response.headers.getlist("Vary") == [
+        "Accept-Language, Accept-Encoding, Origin"
+    ]
+
+
+def test_both_policy_writers_merge_the_vary():
+    """Neither writer may be the one that forgot.
+
+    Called directly rather than through a route because the two writers share
+    no call site: ``_set_cors_headers`` answers the credentialed path and
+    ``_set_public_cors_headers`` the anonymous one, and a fix applied to one of
+    them passes every request-level test that happens to exercise the other.
+    """
+    from starlette.datastructures import Headers
+    from starlette.requests import Request
+
+    scope = {
+        "type": "http",
+        "method": "GET",
+        "path": "/conformance",
+        "query_string": b"",
+        "headers": Headers({}).raw,
+    }
+
+    credentialed = Response()
+    credentialed.headers["Vary"] = "Accept-Language"
+    DynamicCORSMiddleware._set_cors_headers(credentialed, _ALLOWED_ORIGIN)
+    assert credentialed.headers.getlist("Vary") == ["Accept-Language, Origin"]
+
+    public = Response()
+    public.headers["Vary"] = "Accept-Language"
+    DynamicCORSMiddleware._set_public_cors_headers(
+        public, Request(scope), "GET, OPTIONS"
+    )
+    assert public.headers.getlist("Vary") == ["Accept-Language, Origin"]

--- a/backend/tests/test_cors_vary_origin_1602.py
+++ b/backend/tests/test_cors_vary_origin_1602.py
@@ -26,17 +26,18 @@ What these tests pin, beyond "the header is present":
   would cost content negotiation its cache key, which is a bug traded for a
   bug, so ``Origin`` is appended to what the route set and each token appears
   once.
-- the silence. A response the middleware writes no policy onto must not gain
-  ``Vary: Origin``: a request with no ``Origin`` header, and a native route
-  answering an origin outside the allow-list. Each of those is paired with the
-  positive case on the same route, so a rename that makes the header vanish
-  everywhere cannot pass the absence assertion for free.
+- the reach. ``dispatch`` returns from four places, and only two of them
+  write a CORS policy. All four declare the variance, because all four produce
+  a cacheable representation of a URL that answers some other origin
+  differently (fix(#1602 codex r1)). The two that carry no policy assert that
+  absence in the same test, so "it varies" cannot quietly become "it has
+  headers".
 """
 
 import pytest
 from starlette.responses import Response
 
-from app.api.middleware.cors import DynamicCORSMiddleware, _merge_vary_origin
+from app.api.middleware.cors import _merge_vary_origin
 
 _FOREIGN_ORIGIN = "https://cors-1602.example.org"
 _ALLOWED_ORIGIN = "https://allowed-1602.example.com"
@@ -199,56 +200,79 @@ async def test_the_route_sets_a_vary_this_test_is_not_inventing(
     """The vacuity guard for the merge test above.
 
     If ``/search/datasets/`` ever stops setting ``Vary: Accept-Language``, the
-    merge assertions still pass while proving nothing about merging. Read the
-    route's own answer without an ``Origin`` header, where the middleware never
-    runs, and confirm there is something to merge into.
+    merge assertions still pass while proving nothing about merging.
 
-    ``Accept-Encoding`` is in here too — ``GZipMiddleware`` adds its own token
-    through the same header — which is the second reason not to assert an
-    exact value anywhere in this file: the ``Vary`` on a response is written by
-    more than one component, and only ``Origin`` belongs to this fix.
+    Written as a contrast rather than an absence: ``/health`` sets no ``Vary``
+    of its own, ``/search/datasets/`` does, and both go through the same
+    middleware. ``Accept-Language`` appearing on one and not the other is what
+    shows the token comes from the route.
+
+    ``Accept-Encoding`` is on both, because ``GZipMiddleware`` writes through
+    the same header. That is the second reason nothing in this file asserts an
+    exact ``Vary`` value: three components contribute to it, and only
+    ``Origin`` belongs to this fix.
     """
     response = await client.get("/search/datasets/?q=subway")
-
     assert response.status_code == 200, response.text
-    tokens = _vary_tokens(response)
-    assert "accept-language" in tokens, dict(response.headers)
-    assert "origin" not in tokens, dict(response.headers)
+    assert "accept-language" in _vary_tokens(response), dict(response.headers)
+
+    plain = await client.get("/health")
+    assert plain.status_code == 200
+    assert "accept-language" not in _vary_tokens(plain), dict(plain.headers)
 
 
 # ---------------------------------------------------------------------------
-# (d) the counterfactual: no policy written, no Vary: Origin
+# (d) the responses that get no CORS policy at all
+#
+# fix(#1602 codex r1): these two used to assert the opposite. A response
+# produced for a rejected origin, or for a request carrying no Origin header,
+# is still origin-dependent: it is the SAME URL that answers an allowed origin
+# with Access-Control-Allow-Origin. A CDN that stores the header-less variant
+# under an origin-less key replays it to a permitted browser origin, which then
+# blocks a request the configured policy allows. Failing closed is still
+# failing, so every representation the middleware can return declares the
+# variance, whether or not it carries a policy.
 # ---------------------------------------------------------------------------
 
 
-async def test_a_disallowed_origin_on_a_native_route_gains_nothing(
+async def test_a_disallowed_origin_on_a_native_route_still_varies(
     client, allow_one_origin
 ):
-    """No CORS headers, so nothing that varies by origin, so no ``Vary``.
+    """No CORS headers, and still ``Vary: Origin``.
 
     ``/maps/`` answers a stranger with a 200 and stays outside the anonymous
     wildcard allow-list, which makes it the route where "no policy" is a real
-    state rather than an error page. The allowed origin is asserted on the
-    same path in the same test so the absence below cannot pass because the
-    header vanished everywhere.
+    state rather than an error page. Both origins are exercised here because
+    the pair is the point: same URL, same status, and a policy on exactly one
+    of them. That difference is what a cache key has to capture.
     """
     denied = await client.get("/maps/", headers={"Origin": _FOREIGN_ORIGIN})
     assert denied.status_code == 200
+    # The vacuity guard: no policy was written on this one...
     assert "access-control-allow-origin" not in denied.headers
-    assert "origin" not in _vary_tokens(denied), dict(denied.headers)
+    assert "access-control-allow-credentials" not in denied.headers
+    # ...and it declares the variance anyway.
+    assert "origin" in _vary_tokens(denied), dict(denied.headers)
 
     allowed = await client.get("/maps/", headers={"Origin": _ALLOWED_ORIGIN})
+    assert allowed.status_code == 200
     assert allowed.headers["access-control-allow-origin"] == _ALLOWED_ORIGIN
     assert "origin" in _vary_tokens(allowed), dict(allowed.headers)
 
 
-async def test_a_request_with_no_origin_header_gains_nothing(client, allow_one_origin):
-    """Not a CORS request at all: the middleware returns before either writer."""
+async def test_a_request_with_no_origin_header_still_varies(client, allow_one_origin):
+    """Not a CORS request, but the response it produces is still cacheable.
+
+    This is the variant a shared cache is most likely to hold, because a
+    crawler or a server-side fetch does not send ``Origin`` at all. Stored
+    without the header it becomes the entry served to a browser whose origin
+    the operator allowed.
+    """
     response = await client.get("/health")
 
     assert response.status_code == 200
     assert "access-control-allow-origin" not in response.headers
-    assert "origin" not in _vary_tokens(response), dict(response.headers)
+    assert "origin" in _vary_tokens(response), dict(response.headers)
 
 
 # ---------------------------------------------------------------------------
@@ -317,33 +341,47 @@ def test_merge_vary_origin_collapses_duplicate_field_lines():
     ]
 
 
-def test_both_policy_writers_merge_the_vary():
-    """Neither writer may be the one that forgot.
+@pytest.mark.parametrize(
+    "policy_fixture, path, headers, expected_allow_origin",
+    [
+        # every branch dispatch can take, in source order
+        ("allow_one_origin", "/health", {}, None),
+        ("allow_one_origin", "/maps/", {"Origin": _FOREIGN_ORIGIN}, None),
+        ("deny_all_origins", "/conformance", {"Origin": _FOREIGN_ORIGIN}, "*"),
+        ("allow_one_origin", "/health", {"Origin": _ALLOWED_ORIGIN}, _ALLOWED_ORIGIN),
+    ],
+    ids=["no-origin", "rejected-origin", "wildcard", "credentialed"],
+)
+async def test_every_dispatch_outcome_declares_the_variance(
+    client, request, policy_fixture, path, headers, expected_allow_origin
+):
+    """The invariant, enumerated over the branches rather than the writers.
 
-    Called directly rather than through a route because the two writers share
-    no call site: ``_set_cors_headers`` answers the credentialed path and
-    ``_set_public_cors_headers`` the anonymous one, and a fix applied to one of
-    them passes every request-level test that happens to exercise the other.
+    ``dispatch`` returns from four places and they do not agree about CORS
+    headers: two write a policy, one deliberately writes none, and one returns
+    before looking. They must agree about ``Vary``, because all four produce a
+    cacheable representation of a URL whose policy depends on ``Origin``.
+
+    Driven through the app rather than by calling the writers directly. After
+    fix(#1602 codex r1) the merge no longer lives in the writers at all, so a
+    writer-level test would assert against the wrong layer and would pass while
+    the pass-through branch, the one the finding was about, stayed broken.
+
+    ``expected_allow_origin`` is carried so the four cases are pinned as
+    genuinely different answers. Without it this reads as one assertion run
+    four times.
     """
-    from starlette.datastructures import Headers
-    from starlette.requests import Request
+    request.getfixturevalue(policy_fixture)
+    response = await client.get(path, headers=headers)
 
-    scope = {
-        "type": "http",
-        "method": "GET",
-        "path": "/conformance",
-        "query_string": b"",
-        "headers": Headers({}).raw,
-    }
+    assert response.status_code == 200, response.text
+    if expected_allow_origin is None:
+        assert "access-control-allow-origin" not in response.headers
+    else:
+        assert response.headers["access-control-allow-origin"] == expected_allow_origin
 
-    credentialed = Response()
-    credentialed.headers["Vary"] = "Accept-Language"
-    DynamicCORSMiddleware._set_cors_headers(credentialed, _ALLOWED_ORIGIN)
-    assert credentialed.headers.getlist("Vary") == ["Accept-Language, Origin"]
-
-    public = Response()
-    public.headers["Vary"] = "Accept-Language"
-    DynamicCORSMiddleware._set_public_cors_headers(
-        public, Request(scope), "GET, OPTIONS"
+    tokens = _vary_tokens(response)
+    assert tokens.count("origin") == 1, tokens
+    assert len(response.headers.get_list("vary")) == 1, response.headers.get_list(
+        "vary"
     )
-    assert public.headers.getlist("Vary") == ["Accept-Language, Origin"]


### PR DESCRIPTION
## Summary

`DynamicCORSMiddleware` has two policy writers and neither declared `Vary: Origin`:

- `_set_cors_headers` echoes the caller's origin into `Access-Control-Allow-Origin`, and answers the credentialed preflight
- `_set_public_cors_headers` answers `*` on the anonymous standards and search paths

Both now merge `Origin` into the response's `Vary`, through a new `_merge_vary_origin` helper.

## Why

The answer depends on which origin asked, so a cache that stores it under a key omitting `Origin` can hand one origin's policy to another.

This is not a leak on a default deployment. The shipped `frontend/nginx.conf` serves `location /api/` with `proxy_cache off`, and a browser fails closed when a cached policy does not name its own origin. The header is for the operator who fronts the API with their own caching CDN.

The wildcard carries it too. A `*` answer does not strictly need it, since every origin gets the same value, but both writers answer on the same paths and therefore share cache entries, and a stored `*` is indistinguishable from a stored echoed origin once it is in the cache.

## Merge semantics

`standard_response_headers` already sets `Vary: Accept-Language` on the search and standards responses, and `GZipMiddleware` adds `Accept-Encoding`. So the header is merged, not assigned:

- `Origin` is appended to whatever is already there. Overwriting would fix the CORS variance and break the content-negotiation one, which is the same defect pointed at a different header.
- Tokens compare case-insensitively, because field names are, and an existing `Origin` is left exactly as the route spelled it.
- Empty and whitespace-padded list members are dropped rather than re-emitted, so no empty token ever goes out.
- Duplicate `Vary` field-lines collapse into one, via assignment rather than append.
- `Vary: *` is left alone. The grammar makes `*` an alternative to the token list rather than a member of it (`Vary = #( field-name ) / "*"`), and it already tells every cache not to reuse the response.

Every response the middleware returns carries the header, including the ones it writes no policy onto. That is not where this started; see the round 1 section below.

No route or schema change, so `backend/openapi.json` is untouched.

This was branched while #1601 was still open, so it was written against that branch and then rebased onto main with `git rebase --onto` once #1601 squash-merged. Every result below was re-run after the rebase.

## Verification

Red first. The behavioural assertions were run against the unmodified middleware, using a temporary copy of the test file, since the real one imports the not-yet-existing helper:

```
8 failed, 1 passed
FAILED test_the_credentialed_policy_varies_by_origin        assert 'origin' in ['accept-encoding']
FAILED test_the_credentialed_preflight_varies_by_origin     assert 'origin' in []
FAILED test_the_wildcard_policy_varies_by_origin            assert 'origin' in ['accept-encoding']
FAILED test_the_wildcard_preflight_varies_by_origin         assert 'origin' in []
FAILED test_an_existing_vary_keeps_its_tokens_and_gains_origin_once[wildcard]     assert 0 == 1
FAILED test_an_existing_vary_keeps_its_tokens_and_gains_origin_once[credentialed] assert 0 == 1
FAILED test_the_route_sets_a_vary_this_test_is_not_inventing
FAILED test_a_disallowed_origin_on_a_native_route_gains_nothing
```

The one that passed red is `test_a_request_with_no_origin_header_gains_nothing`, which has to pass in both states: it is the counterfactual.

Then green, on the host against Postgres at `localhost:5434`:

| Command | Result |
| --- | --- |
| `uv run ruff check .` | All checks passed |
| `uv run ruff format --check .` | 1044 files already formatted |
| `pytest tests/test_cors_vary_origin_1602.py` | 24 passed |
| `pytest test_cors_vary_origin_1602 test_search_cors_1596 test_ogc_discovery test_cors_range_headers_1540 test_middleware test_layering` | 145 passed |
| `pytest test_persistent_config test_nginx_assets_cors_1515 test_nginx_raster_cors_1464` | 59 passed |
| `pytest test_search test_stac_visibility test_dcat` | 89 passed |
| `pytest test_datasets test_collections test_auth test_api_key_auth test_embed_tokens test_maps test_api_contract_openapi` | 399 passed |
| `PYTHONPATH=. python scripts/dump_openapi.py --check` | exit 0 |
| `pre-commit run --files <the two changed files>` | all hooks passed, Rule 1 and Rule 2 included |

`test_cors_range_headers_1540.py` reads the middleware's header lists off a live `_set_cors_headers(response, origin)` call, so that signature is unchanged. No `_MODULE_LOC_CAPS` entry exists for `cors.py`, so there is no cap to raise.

The last two suite groups are there because `test_search.py`, `test_stac_visibility.py` and `test_dcat.py` are the only other tests that assert on `Vary`. All three use substring assertions rather than equality, and all three still pass.

## Round 1 (codex): the pass-through responses vary too

Taken. The original change put `Vary: Origin` only on the two responses that carry a CORS policy. That left the case the header exists for: a response produced for a rejected origin, or for a request with no `Origin` header at all, is the same URL that answers a permitted origin with `Access-Control-Allow-Origin`. A CDN storing the header-less variant under an origin-less key replays it to a browser origin the operator allowed, and the browser blocks a request the configured policy permits. I had argued that direction is "fails closed" and therefore acceptable. It fails closed rather than leaking, but a blocked request is still a broken deployment, and it is the deployment this header is for.

So the merge moved out of the two policy writers and onto the single exit of `dispatch`:

```python
async def dispatch(self, request, call_next):
    response = await self._dispatch(request, call_next)
    _merge_vary_origin(response)
    return response
```

`_dispatch` holds what `dispatch` used to do and returns from four places: no `Origin` header, rejected origin on a non-public route, the anonymous wildcard, and the credentialed policy. Only two of them write CORS headers; all four now declare the variance, and a fifth branch added later cannot forget to. `_merge_vary_origin` is unchanged, including the `Vary: *` early return.

Tests flipped with it. The two counterfactuals now assert the opposite of what they asserted before, and keep a vacuity guard that the CORS headers really are absent on those responses:

- `test_a_disallowed_origin_on_a_native_route_still_varies`: `/maps/` from a rejected origin gets no `Access-Control-Allow-Origin` and no `Access-Control-Allow-Credentials`, and does get `Vary: Origin`. The allowed origin is exercised on the same URL in the same test, because the pair is the point: same path, same status, policy on exactly one of them.
- `test_a_request_with_no_origin_header_still_varies`: `/health` with no `Origin`.

`test_both_policy_writers_merge_the_vary` is gone, replaced by `test_every_dispatch_outcome_declares_the_variance`, parametrized over all four branches. It is driven through the app rather than by calling the writers, since after this change a writer-level test would assert against the wrong layer and would pass while the pass-through branch stayed broken. Each case carries its expected `Access-Control-Allow-Origin` so the four are pinned as genuinely different answers rather than one assertion run four times.

The vacuity guard for the merge test was rewritten as a contrast, since it can no longer prove anything by the absence of `Origin`: `/search/datasets/` carries `Accept-Language` and `/health` does not, through the same middleware.

Closes #1602
