### PR TITLE
ci: bound apt fetches inside the Playwright install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1820,6 +1820,18 @@ jobs:
       - name: Install Playwright Browsers
         timeout-minutes: 10
         run: |
+          # playwright install-deps shells out to its own `apt-get update &&
+          # apt-get install` for font/library packages, with no timeout of
+          # its own. Our retry loop below wraps the whole step, but a
+          # degraded mirror stalls that inner apt-get for the full 10-minute
+          # step cap before the loop ever gets a second attempt (2026-08-19:
+          # jobs 96101445154, 96108423519 both timed out on azure.archive.
+          # ubuntu.com fetching fonts-freefont-ttf/fonts-wqy-zenhei at a few
+          # KB/s). apt-get always reads /etc/apt/apt.conf.d/ on startup, so
+          # writing per-request timeouts there before install-deps runs
+          # bounds its inner apt-get too.
+          echo 'Acquire::http::Timeout "30"; Acquire::https::Timeout "30"; Acquire::Retries "3";' \
+            | sudo tee /etc/apt/apt.conf.d/99-ci-fetch-timeouts >/dev/null
           for i in 1 2 3; do
             npx playwright install --with-deps chromium && break
             echo "playwright install attempt $i failed"
@@ -1946,6 +1958,18 @@ jobs:
       - name: Install Playwright Browsers
         timeout-minutes: 10
         run: |
+          # playwright install-deps shells out to its own `apt-get update &&
+          # apt-get install` for font/library packages, with no timeout of
+          # its own. Our retry loop below wraps the whole step, but a
+          # degraded mirror stalls that inner apt-get for the full 10-minute
+          # step cap before the loop ever gets a second attempt (2026-08-19:
+          # jobs 96101445154, 96108423519 both timed out on azure.archive.
+          # ubuntu.com fetching fonts-freefont-ttf/fonts-wqy-zenhei at a few
+          # KB/s). apt-get always reads /etc/apt/apt.conf.d/ on startup, so
+          # writing per-request timeouts there before install-deps runs
+          # bounds its inner apt-get too.
+          echo 'Acquire::http::Timeout "30"; Acquire::https::Timeout "30"; Acquire::Retries "3";' \
+            | sudo tee /etc/apt/apt.conf.d/99-ci-fetch-timeouts >/dev/null
           for i in 1 2 3; do
             npx playwright install --with-deps chromium && break
             echo "playwright install attempt $i failed"
@@ -2157,6 +2181,18 @@ jobs:
       - name: Install Playwright Browsers
         timeout-minutes: 10
         run: |
+          # playwright install-deps shells out to its own `apt-get update &&
+          # apt-get install` for font/library packages, with no timeout of
+          # its own. Our retry loop below wraps the whole step, but a
+          # degraded mirror stalls that inner apt-get for the full 10-minute
+          # step cap before the loop ever gets a second attempt (2026-08-19:
+          # jobs 96101445154, 96108423519 both timed out on azure.archive.
+          # ubuntu.com fetching fonts-freefont-ttf/fonts-wqy-zenhei at a few
+          # KB/s). apt-get always reads /etc/apt/apt.conf.d/ on startup, so
+          # writing per-request timeouts there before install-deps runs
+          # bounds its inner apt-get too.
+          echo 'Acquire::http::Timeout "30"; Acquire::https::Timeout "30"; Acquire::Retries "3";' \
+            | sudo tee /etc/apt/apt.conf.d/99-ci-fetch-timeouts >/dev/null
           for i in 1 2 3; do
             npx playwright install --with-deps chromium && break
             echo "playwright install attempt $i failed"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1823,7 +1823,7 @@ jobs:
           # playwright install-deps shells out to its own `apt-get update &&
           # apt-get install` for font/library packages, with no timeout of
           # its own (2026-08-19: jobs 96101445154, 96108423519 both burned
-          # the full step cap inside it). Two independent bounds, because
+          # the full step cap inside it). Three independent bounds, because
           # apt's own Acquire::http::Timeout is a socket INACTIVITY timeout,
           # not a minimum-transfer-rate one:
           #   - a genuinely dead connection is caught by the apt.conf.d
@@ -1831,16 +1831,39 @@ jobs:
           #   - a connection that stays open but trickles a few KB/s never
           #     goes inactive, so apt's timeout never fires (job
           #     96108423519 took 5m26s to fetch a 5.6 MB font package from a
-          #     degraded azure.archive.ubuntu.com mirror). Wrapping each
-          #     attempt in coreutils `timeout` bounds it regardless of why
-          #     it's slow, so the loop is guaranteed all 3 attempts inside
-          #     this step's cap (3*180s + 2*10s sleep = 560s < 720s).
+          #     degraded azure.archive.ubuntu.com mirror). `timeout -k 10
+          #     180` bounds each attempt regardless of why it's slow.
+          #   - `timeout` only signals its DIRECT child; the real apt-get is
+          #     a grandchild (npx -> node -> sudo -> sh -c -> apt-get) that
+          #     sudo places outside its reach, so a cut attempt leaves
+          #     apt-get running and holding the dpkg lock (job 96120667995:
+          #     attempts 2 and 3 both died instantly with "Could not get
+          #     lock /var/lib/dpkg/lock-frontend. It is held by process
+          #     12362 (apt-get)"). Kill it and wait for it to actually exit
+          #     before retrying. psmisc (fuser) is not confirmed installed
+          #     on this runner image (no hit searching actions/runner-images'
+          #     build scripts), so poll with pgrep/pkill (procps — confirmed
+          #     present on the base Ubuntu 24.04 image, and already relied
+          #     on below) instead of fuser.
+          #
+          # Worst case: 3 attempts * (180 + 10 kill-grace)s + 2 cleanups *
+          # (5 + 5*2 + 10)s = 570 + 50 = 620s, under the 720s step cap.
           echo 'Acquire::http::Timeout "30"; Acquire::https::Timeout "30"; Acquire::Retries "3";' \
             | sudo tee /etc/apt/apt.conf.d/99-ci-fetch-timeouts >/dev/null
           for i in 1 2 3; do
-            timeout 180 npx playwright install --with-deps chromium && break
+            timeout -k 10 180 npx playwright install --with-deps chromium && break
             echo "playwright install attempt $i failed"
             [ "$i" = 3 ] && exit 1
+            sudo pkill -TERM -x apt-get || true
+            sudo pkill -TERM -x dpkg || true
+            sleep 5
+            sudo pkill -KILL -x apt-get || true
+            sudo pkill -KILL -x dpkg || true
+            for _ in 1 2 3 4 5; do
+              pgrep -x apt-get >/dev/null || pgrep -x dpkg >/dev/null || break
+              sleep 2
+            done
+            sudo dpkg --configure -a || true
             sleep 10
           done
 
@@ -1966,7 +1989,7 @@ jobs:
           # playwright install-deps shells out to its own `apt-get update &&
           # apt-get install` for font/library packages, with no timeout of
           # its own (2026-08-19: jobs 96101445154, 96108423519 both burned
-          # the full step cap inside it). Two independent bounds, because
+          # the full step cap inside it). Three independent bounds, because
           # apt's own Acquire::http::Timeout is a socket INACTIVITY timeout,
           # not a minimum-transfer-rate one:
           #   - a genuinely dead connection is caught by the apt.conf.d
@@ -1974,16 +1997,39 @@ jobs:
           #   - a connection that stays open but trickles a few KB/s never
           #     goes inactive, so apt's timeout never fires (job
           #     96108423519 took 5m26s to fetch a 5.6 MB font package from a
-          #     degraded azure.archive.ubuntu.com mirror). Wrapping each
-          #     attempt in coreutils `timeout` bounds it regardless of why
-          #     it's slow, so the loop is guaranteed all 3 attempts inside
-          #     this step's cap (3*180s + 2*10s sleep = 560s < 720s).
+          #     degraded azure.archive.ubuntu.com mirror). `timeout -k 10
+          #     180` bounds each attempt regardless of why it's slow.
+          #   - `timeout` only signals its DIRECT child; the real apt-get is
+          #     a grandchild (npx -> node -> sudo -> sh -c -> apt-get) that
+          #     sudo places outside its reach, so a cut attempt leaves
+          #     apt-get running and holding the dpkg lock (job 96120667995:
+          #     attempts 2 and 3 both died instantly with "Could not get
+          #     lock /var/lib/dpkg/lock-frontend. It is held by process
+          #     12362 (apt-get)"). Kill it and wait for it to actually exit
+          #     before retrying. psmisc (fuser) is not confirmed installed
+          #     on this runner image (no hit searching actions/runner-images'
+          #     build scripts), so poll with pgrep/pkill (procps — confirmed
+          #     present on the base Ubuntu 24.04 image, and already relied
+          #     on below) instead of fuser.
+          #
+          # Worst case: 3 attempts * (180 + 10 kill-grace)s + 2 cleanups *
+          # (5 + 5*2 + 10)s = 570 + 50 = 620s, under the 720s step cap.
           echo 'Acquire::http::Timeout "30"; Acquire::https::Timeout "30"; Acquire::Retries "3";' \
             | sudo tee /etc/apt/apt.conf.d/99-ci-fetch-timeouts >/dev/null
           for i in 1 2 3; do
-            timeout 180 npx playwright install --with-deps chromium && break
+            timeout -k 10 180 npx playwright install --with-deps chromium && break
             echo "playwright install attempt $i failed"
             [ "$i" = 3 ] && exit 1
+            sudo pkill -TERM -x apt-get || true
+            sudo pkill -TERM -x dpkg || true
+            sleep 5
+            sudo pkill -KILL -x apt-get || true
+            sudo pkill -KILL -x dpkg || true
+            for _ in 1 2 3 4 5; do
+              pgrep -x apt-get >/dev/null || pgrep -x dpkg >/dev/null || break
+              sleep 2
+            done
+            sudo dpkg --configure -a || true
             sleep 10
           done
 
@@ -2194,7 +2240,7 @@ jobs:
           # playwright install-deps shells out to its own `apt-get update &&
           # apt-get install` for font/library packages, with no timeout of
           # its own (2026-08-19: jobs 96101445154, 96108423519 both burned
-          # the full step cap inside it). Two independent bounds, because
+          # the full step cap inside it). Three independent bounds, because
           # apt's own Acquire::http::Timeout is a socket INACTIVITY timeout,
           # not a minimum-transfer-rate one:
           #   - a genuinely dead connection is caught by the apt.conf.d
@@ -2202,16 +2248,39 @@ jobs:
           #   - a connection that stays open but trickles a few KB/s never
           #     goes inactive, so apt's timeout never fires (job
           #     96108423519 took 5m26s to fetch a 5.6 MB font package from a
-          #     degraded azure.archive.ubuntu.com mirror). Wrapping each
-          #     attempt in coreutils `timeout` bounds it regardless of why
-          #     it's slow, so the loop is guaranteed all 3 attempts inside
-          #     this step's cap (3*180s + 2*10s sleep = 560s < 720s).
+          #     degraded azure.archive.ubuntu.com mirror). `timeout -k 10
+          #     180` bounds each attempt regardless of why it's slow.
+          #   - `timeout` only signals its DIRECT child; the real apt-get is
+          #     a grandchild (npx -> node -> sudo -> sh -c -> apt-get) that
+          #     sudo places outside its reach, so a cut attempt leaves
+          #     apt-get running and holding the dpkg lock (job 96120667995:
+          #     attempts 2 and 3 both died instantly with "Could not get
+          #     lock /var/lib/dpkg/lock-frontend. It is held by process
+          #     12362 (apt-get)"). Kill it and wait for it to actually exit
+          #     before retrying. psmisc (fuser) is not confirmed installed
+          #     on this runner image (no hit searching actions/runner-images'
+          #     build scripts), so poll with pgrep/pkill (procps — confirmed
+          #     present on the base Ubuntu 24.04 image, and already relied
+          #     on below) instead of fuser.
+          #
+          # Worst case: 3 attempts * (180 + 10 kill-grace)s + 2 cleanups *
+          # (5 + 5*2 + 10)s = 570 + 50 = 620s, under the 720s step cap.
           echo 'Acquire::http::Timeout "30"; Acquire::https::Timeout "30"; Acquire::Retries "3";' \
             | sudo tee /etc/apt/apt.conf.d/99-ci-fetch-timeouts >/dev/null
           for i in 1 2 3; do
-            timeout 180 npx playwright install --with-deps chromium && break
+            timeout -k 10 180 npx playwright install --with-deps chromium && break
             echo "playwright install attempt $i failed"
             [ "$i" = 3 ] && exit 1
+            sudo pkill -TERM -x apt-get || true
+            sudo pkill -TERM -x dpkg || true
+            sleep 5
+            sudo pkill -KILL -x apt-get || true
+            sudo pkill -KILL -x dpkg || true
+            for _ in 1 2 3 4 5; do
+              pgrep -x apt-get >/dev/null || pgrep -x dpkg >/dev/null || break
+              sleep 2
+            done
+            sudo dpkg --configure -a || true
             sleep 10
           done
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -581,8 +581,15 @@ jobs:
         # failing http mirror to an https one, which our http-only timeout
         # never bounded. The cleanup between attempts matches the
         # Playwright-install steps for the same reason: apt-get can still
-        # orphan a dpkg child if timeout kills it mid-unpack.
-        timeout-minutes: 15
+        # orphan a dpkg child if timeout kills it mid-unpack. The final
+        # `dpkg --configure -a` is itself timeout-wrapped: an unbounded
+        # maintainer script there could eat the rest of the step cap the
+        # same way an unbounded apt-get did.
+        #
+        # Worst case: 3 attempts * (90+10 + 150+10)s + 2 cleanups *
+        # (5 + 5*2 + 30+10 + 10)s = 780 + 130 = 910s, under the 960s
+        # (16-minute) step cap.
+        timeout-minutes: 16
         run: |
           # The postgres service for this job is postgis/postgis:18-3.6 (PG18).
           # Ubuntu 24.04 (noble) ships postgresql-client 16 by default, and pg_dump
@@ -614,7 +621,7 @@ jobs:
               pgrep -x apt-get >/dev/null || pgrep -x dpkg >/dev/null || break
               sleep 2
             done
-            sudo dpkg --configure -a || true
+            sudo timeout -k 10 30 dpkg --configure -a || true
             sleep 10
           done
 
@@ -1299,7 +1306,7 @@ jobs:
         # the full incident writeup (job 96122006694 stalled here for the
         # full 10-minute cap on a silent https fallback our http-only
         # timeout never bounded).
-        timeout-minutes: 15
+        timeout-minutes: 16
         run: |
           for i in 1 2 3; do
             sudo timeout -k 10 90 apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30 update \
@@ -1316,7 +1323,7 @@ jobs:
               pgrep -x apt-get >/dev/null || pgrep -x dpkg >/dev/null || break
               sleep 2
             done
-            sudo dpkg --configure -a || true
+            sudo timeout -k 10 30 dpkg --configure -a || true
             sleep 10
           done
 
@@ -1853,7 +1860,7 @@ jobs:
         run: npm ci
 
       - name: Install Playwright Browsers
-        timeout-minutes: 12
+        timeout-minutes: 13
         run: |
           # playwright install-deps shells out to its own `apt-get update &&
           # apt-get install` for font/library packages, with no timeout of
@@ -1881,8 +1888,13 @@ jobs:
           #     present on the base Ubuntu 24.04 image, and already relied
           #     on below) instead of fuser.
           #
+          # The cleanup's own `dpkg --configure -a` is timeout-wrapped too,
+          # for the same reason: an unbounded maintainer script there could
+          # eat the rest of the step cap.
+          #
           # Worst case: 3 attempts * (180 + 10 kill-grace)s + 2 cleanups *
-          # (5 + 5*2 + 10)s = 570 + 50 = 620s, under the 720s step cap.
+          # (5 + 5*2 + 30+10 + 10)s = 570 + 130 = 700s, under the 780s
+          # (13-minute) step cap.
           echo 'Acquire::http::Timeout "30"; Acquire::https::Timeout "30"; Acquire::Retries "3";' \
             | sudo tee /etc/apt/apt.conf.d/99-ci-fetch-timeouts >/dev/null
           for i in 1 2 3; do
@@ -1898,7 +1910,7 @@ jobs:
               pgrep -x apt-get >/dev/null || pgrep -x dpkg >/dev/null || break
               sleep 2
             done
-            sudo dpkg --configure -a || true
+            sudo timeout -k 10 30 dpkg --configure -a || true
             sleep 10
           done
 
@@ -2019,7 +2031,7 @@ jobs:
         run: npm ci
 
       - name: Install Playwright Browsers
-        timeout-minutes: 12
+        timeout-minutes: 13
         run: |
           # playwright install-deps shells out to its own `apt-get update &&
           # apt-get install` for font/library packages, with no timeout of
@@ -2047,8 +2059,13 @@ jobs:
           #     present on the base Ubuntu 24.04 image, and already relied
           #     on below) instead of fuser.
           #
+          # The cleanup's own `dpkg --configure -a` is timeout-wrapped too,
+          # for the same reason: an unbounded maintainer script there could
+          # eat the rest of the step cap.
+          #
           # Worst case: 3 attempts * (180 + 10 kill-grace)s + 2 cleanups *
-          # (5 + 5*2 + 10)s = 570 + 50 = 620s, under the 720s step cap.
+          # (5 + 5*2 + 30+10 + 10)s = 570 + 130 = 700s, under the 780s
+          # (13-minute) step cap.
           echo 'Acquire::http::Timeout "30"; Acquire::https::Timeout "30"; Acquire::Retries "3";' \
             | sudo tee /etc/apt/apt.conf.d/99-ci-fetch-timeouts >/dev/null
           for i in 1 2 3; do
@@ -2064,7 +2081,7 @@ jobs:
               pgrep -x apt-get >/dev/null || pgrep -x dpkg >/dev/null || break
               sleep 2
             done
-            sudo dpkg --configure -a || true
+            sudo timeout -k 10 30 dpkg --configure -a || true
             sleep 10
           done
 
@@ -2174,7 +2191,7 @@ jobs:
         # the full incident writeup (job 96122006694 stalled here for the
         # full 10-minute cap on a silent https fallback our http-only
         # timeout never bounded).
-        timeout-minutes: 15
+        timeout-minutes: 16
         run: |
           for i in 1 2 3; do
             sudo timeout -k 10 90 apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30 update \
@@ -2191,7 +2208,7 @@ jobs:
               pgrep -x apt-get >/dev/null || pgrep -x dpkg >/dev/null || break
               sleep 2
             done
-            sudo dpkg --configure -a || true
+            sudo timeout -k 10 30 dpkg --configure -a || true
             sleep 10
           done
 
@@ -2284,7 +2301,7 @@ jobs:
         run: npm ci
 
       - name: Install Playwright Browsers
-        timeout-minutes: 12
+        timeout-minutes: 13
         run: |
           # playwright install-deps shells out to its own `apt-get update &&
           # apt-get install` for font/library packages, with no timeout of
@@ -2312,8 +2329,13 @@ jobs:
           #     present on the base Ubuntu 24.04 image, and already relied
           #     on below) instead of fuser.
           #
+          # The cleanup's own `dpkg --configure -a` is timeout-wrapped too,
+          # for the same reason: an unbounded maintainer script there could
+          # eat the rest of the step cap.
+          #
           # Worst case: 3 attempts * (180 + 10 kill-grace)s + 2 cleanups *
-          # (5 + 5*2 + 10)s = 570 + 50 = 620s, under the 720s step cap.
+          # (5 + 5*2 + 30+10 + 10)s = 570 + 130 = 700s, under the 780s
+          # (13-minute) step cap.
           echo 'Acquire::http::Timeout "30"; Acquire::https::Timeout "30"; Acquire::Retries "3";' \
             | sudo tee /etc/apt/apt.conf.d/99-ci-fetch-timeouts >/dev/null
           for i in 1 2 3; do
@@ -2329,7 +2351,7 @@ jobs:
               pgrep -x apt-get >/dev/null || pgrep -x dpkg >/dev/null || break
               sleep 2
             done
-            sudo dpkg --configure -a || true
+            sudo timeout -k 10 30 dpkg --configure -a || true
             sleep 10
           done
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -570,8 +570,19 @@ jobs:
       - name: Install postgresql-client + tooling
         # A step-level cap plus a bounded retry loop: an apt mirror that goes
         # unreachable mid-fetch now fails this step in well under the job
-        # timeout instead of hanging for hours (2026-08-19).
-        timeout-minutes: 10
+        # timeout instead of hanging for hours (2026-08-19). Each apt-get
+        # invocation is wrapped in its OWN `sudo timeout -k 10 <N>` (update
+        # and install separately, not chained under one timeout) so apt-get
+        # is timeout's DIRECT child — no sudo/shell grandchild between them
+        # to block the signal, unlike the Playwright-install steps. Both
+        # Acquire::http::Timeout AND Acquire::https::Timeout are set: job
+        # 96122006694 (a sibling "Install system dependencies" step) stalled
+        # the full 10-minute cap with ZERO output after apt fell back from a
+        # failing http mirror to an https one, which our http-only timeout
+        # never bounded. The cleanup between attempts matches the
+        # Playwright-install steps for the same reason: apt-get can still
+        # orphan a dpkg child if timeout kills it mid-unpack.
+        timeout-minutes: 15
         run: |
           # The postgres service for this job is postgis/postgis:18-3.6 (PG18).
           # Ubuntu 24.04 (noble) ships postgresql-client 16 by default, and pg_dump
@@ -589,11 +600,21 @@ jobs:
           echo "deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.asc] https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" \
             | sudo tee /etc/apt/sources.list.d/pgdg.list >/dev/null
           for i in 1 2 3; do
-            sudo apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=30 update \
-              && sudo apt-get -o Acquire::http::Timeout=30 install -y --no-install-recommends postgresql-client-18 curl \
+            sudo timeout -k 10 90 apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30 update \
+              && sudo timeout -k 10 150 apt-get -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30 install -y --no-install-recommends postgresql-client-18 curl \
               && break
             echo "apt attempt $i failed"
             [ "$i" = 3 ] && exit 1
+            sudo pkill -TERM -x apt-get || true
+            sudo pkill -TERM -x dpkg || true
+            sleep 5
+            sudo pkill -KILL -x apt-get || true
+            sudo pkill -KILL -x dpkg || true
+            for _ in 1 2 3 4 5; do
+              pgrep -x apt-get >/dev/null || pgrep -x dpkg >/dev/null || break
+              sleep 2
+            done
+            sudo dpkg --configure -a || true
             sleep 10
           done
 
@@ -1274,14 +1295,28 @@ jobs:
           python-version: "3.14"
 
       - name: Install system dependencies
-        timeout-minutes: 10
+        # See backup-roundtrip's "Install postgresql-client + tooling" for
+        # the full incident writeup (job 96122006694 stalled here for the
+        # full 10-minute cap on a silent https fallback our http-only
+        # timeout never bounded).
+        timeout-minutes: 15
         run: |
           for i in 1 2 3; do
-            sudo apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=30 update \
-              && sudo apt-get -o Acquire::http::Timeout=30 install -y gdal-bin xmlsec1 \
+            sudo timeout -k 10 90 apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30 update \
+              && sudo timeout -k 10 150 apt-get -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30 install -y gdal-bin xmlsec1 \
               && break
             echo "apt attempt $i failed"
             [ "$i" = 3 ] && exit 1
+            sudo pkill -TERM -x apt-get || true
+            sudo pkill -TERM -x dpkg || true
+            sleep 5
+            sudo pkill -KILL -x apt-get || true
+            sudo pkill -KILL -x dpkg || true
+            for _ in 1 2 3 4 5; do
+              pgrep -x apt-get >/dev/null || pgrep -x dpkg >/dev/null || break
+              sleep 2
+            done
+            sudo dpkg --configure -a || true
             sleep 10
           done
 
@@ -2135,14 +2170,28 @@ jobs:
           python-version: "3.14"
 
       - name: Install system dependencies
-        timeout-minutes: 10
+        # See backup-roundtrip's "Install postgresql-client + tooling" for
+        # the full incident writeup (job 96122006694 stalled here for the
+        # full 10-minute cap on a silent https fallback our http-only
+        # timeout never bounded).
+        timeout-minutes: 15
         run: |
           for i in 1 2 3; do
-            sudo apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=30 update \
-              && sudo apt-get -o Acquire::http::Timeout=30 install -y gdal-bin xmlsec1 \
+            sudo timeout -k 10 90 apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30 update \
+              && sudo timeout -k 10 150 apt-get -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30 install -y gdal-bin xmlsec1 \
               && break
             echo "apt attempt $i failed"
             [ "$i" = 3 ] && exit 1
+            sudo pkill -TERM -x apt-get || true
+            sudo pkill -TERM -x dpkg || true
+            sleep 5
+            sudo pkill -KILL -x apt-get || true
+            sudo pkill -KILL -x dpkg || true
+            for _ in 1 2 3 4 5; do
+              pgrep -x apt-get >/dev/null || pgrep -x dpkg >/dev/null || break
+              sleep 2
+            done
+            sudo dpkg --configure -a || true
             sleep 10
           done
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1818,22 +1818,27 @@ jobs:
         run: npm ci
 
       - name: Install Playwright Browsers
-        timeout-minutes: 10
+        timeout-minutes: 12
         run: |
           # playwright install-deps shells out to its own `apt-get update &&
           # apt-get install` for font/library packages, with no timeout of
-          # its own. Our retry loop below wraps the whole step, but a
-          # degraded mirror stalls that inner apt-get for the full 10-minute
-          # step cap before the loop ever gets a second attempt (2026-08-19:
-          # jobs 96101445154, 96108423519 both timed out on azure.archive.
-          # ubuntu.com fetching fonts-freefont-ttf/fonts-wqy-zenhei at a few
-          # KB/s). apt-get always reads /etc/apt/apt.conf.d/ on startup, so
-          # writing per-request timeouts there before install-deps runs
-          # bounds its inner apt-get too.
+          # its own (2026-08-19: jobs 96101445154, 96108423519 both burned
+          # the full step cap inside it). Two independent bounds, because
+          # apt's own Acquire::http::Timeout is a socket INACTIVITY timeout,
+          # not a minimum-transfer-rate one:
+          #   - a genuinely dead connection is caught by the apt.conf.d
+          #     write below.
+          #   - a connection that stays open but trickles a few KB/s never
+          #     goes inactive, so apt's timeout never fires (job
+          #     96108423519 took 5m26s to fetch a 5.6 MB font package from a
+          #     degraded azure.archive.ubuntu.com mirror). Wrapping each
+          #     attempt in coreutils `timeout` bounds it regardless of why
+          #     it's slow, so the loop is guaranteed all 3 attempts inside
+          #     this step's cap (3*180s + 2*10s sleep = 560s < 720s).
           echo 'Acquire::http::Timeout "30"; Acquire::https::Timeout "30"; Acquire::Retries "3";' \
             | sudo tee /etc/apt/apt.conf.d/99-ci-fetch-timeouts >/dev/null
           for i in 1 2 3; do
-            npx playwright install --with-deps chromium && break
+            timeout 180 npx playwright install --with-deps chromium && break
             echo "playwright install attempt $i failed"
             [ "$i" = 3 ] && exit 1
             sleep 10
@@ -1956,22 +1961,27 @@ jobs:
         run: npm ci
 
       - name: Install Playwright Browsers
-        timeout-minutes: 10
+        timeout-minutes: 12
         run: |
           # playwright install-deps shells out to its own `apt-get update &&
           # apt-get install` for font/library packages, with no timeout of
-          # its own. Our retry loop below wraps the whole step, but a
-          # degraded mirror stalls that inner apt-get for the full 10-minute
-          # step cap before the loop ever gets a second attempt (2026-08-19:
-          # jobs 96101445154, 96108423519 both timed out on azure.archive.
-          # ubuntu.com fetching fonts-freefont-ttf/fonts-wqy-zenhei at a few
-          # KB/s). apt-get always reads /etc/apt/apt.conf.d/ on startup, so
-          # writing per-request timeouts there before install-deps runs
-          # bounds its inner apt-get too.
+          # its own (2026-08-19: jobs 96101445154, 96108423519 both burned
+          # the full step cap inside it). Two independent bounds, because
+          # apt's own Acquire::http::Timeout is a socket INACTIVITY timeout,
+          # not a minimum-transfer-rate one:
+          #   - a genuinely dead connection is caught by the apt.conf.d
+          #     write below.
+          #   - a connection that stays open but trickles a few KB/s never
+          #     goes inactive, so apt's timeout never fires (job
+          #     96108423519 took 5m26s to fetch a 5.6 MB font package from a
+          #     degraded azure.archive.ubuntu.com mirror). Wrapping each
+          #     attempt in coreutils `timeout` bounds it regardless of why
+          #     it's slow, so the loop is guaranteed all 3 attempts inside
+          #     this step's cap (3*180s + 2*10s sleep = 560s < 720s).
           echo 'Acquire::http::Timeout "30"; Acquire::https::Timeout "30"; Acquire::Retries "3";' \
             | sudo tee /etc/apt/apt.conf.d/99-ci-fetch-timeouts >/dev/null
           for i in 1 2 3; do
-            npx playwright install --with-deps chromium && break
+            timeout 180 npx playwright install --with-deps chromium && break
             echo "playwright install attempt $i failed"
             [ "$i" = 3 ] && exit 1
             sleep 10
@@ -2179,22 +2189,27 @@ jobs:
         run: npm ci
 
       - name: Install Playwright Browsers
-        timeout-minutes: 10
+        timeout-minutes: 12
         run: |
           # playwright install-deps shells out to its own `apt-get update &&
           # apt-get install` for font/library packages, with no timeout of
-          # its own. Our retry loop below wraps the whole step, but a
-          # degraded mirror stalls that inner apt-get for the full 10-minute
-          # step cap before the loop ever gets a second attempt (2026-08-19:
-          # jobs 96101445154, 96108423519 both timed out on azure.archive.
-          # ubuntu.com fetching fonts-freefont-ttf/fonts-wqy-zenhei at a few
-          # KB/s). apt-get always reads /etc/apt/apt.conf.d/ on startup, so
-          # writing per-request timeouts there before install-deps runs
-          # bounds its inner apt-get too.
+          # its own (2026-08-19: jobs 96101445154, 96108423519 both burned
+          # the full step cap inside it). Two independent bounds, because
+          # apt's own Acquire::http::Timeout is a socket INACTIVITY timeout,
+          # not a minimum-transfer-rate one:
+          #   - a genuinely dead connection is caught by the apt.conf.d
+          #     write below.
+          #   - a connection that stays open but trickles a few KB/s never
+          #     goes inactive, so apt's timeout never fires (job
+          #     96108423519 took 5m26s to fetch a 5.6 MB font package from a
+          #     degraded azure.archive.ubuntu.com mirror). Wrapping each
+          #     attempt in coreutils `timeout` bounds it regardless of why
+          #     it's slow, so the loop is guaranteed all 3 attempts inside
+          #     this step's cap (3*180s + 2*10s sleep = 560s < 720s).
           echo 'Acquire::http::Timeout "30"; Acquire::https::Timeout "30"; Acquire::Retries "3";' \
             | sudo tee /etc/apt/apt.conf.d/99-ci-fetch-timeouts >/dev/null
           for i in 1 2 3; do
-            npx playwright install --with-deps chromium && break
+            timeout 180 npx playwright install --with-deps chromium && break
             echo "playwright install attempt $i failed"
             [ "$i" = 3 ] && exit 1
             sleep 10

--- a/.github/workflows/prod-smoke.yml
+++ b/.github/workflows/prod-smoke.yml
@@ -194,17 +194,20 @@ jobs:
         run: npm ci
 
       - name: Install Playwright Browsers
-        timeout-minutes: 10
+        timeout-minutes: 12
         run: |
           # playwright install-deps shells out to its own `apt-get update &&
           # apt-get install` for font/library packages, with no timeout of
-          # its own — see ci.yml for the full incident writeup. Bound its
-          # inner apt-get the same way: apt-get always reads
-          # /etc/apt/apt.conf.d/ on startup.
+          # its own — see ci.yml for the full incident writeup. Two
+          # independent bounds: apt.conf.d for a dead connection, and a
+          # per-attempt `timeout` for one that stays open but trickles
+          # (apt's own Acquire::http::Timeout is inactivity-based and never
+          # fires on a slow-but-live socket). 3*180s + 2*10s sleep = 560s
+          # < the 720s step cap, so the loop is guaranteed all 3 attempts.
           echo 'Acquire::http::Timeout "30"; Acquire::https::Timeout "30"; Acquire::Retries "3";' \
             | sudo tee /etc/apt/apt.conf.d/99-ci-fetch-timeouts >/dev/null
           for i in 1 2 3; do
-            npx playwright install --with-deps chromium && break
+            timeout 180 npx playwright install --with-deps chromium && break
             echo "playwright install attempt $i failed"
             [ "$i" = 3 ] && exit 1
             sleep 10

--- a/.github/workflows/prod-smoke.yml
+++ b/.github/workflows/prod-smoke.yml
@@ -198,18 +198,35 @@ jobs:
         run: |
           # playwright install-deps shells out to its own `apt-get update &&
           # apt-get install` for font/library packages, with no timeout of
-          # its own — see ci.yml for the full incident writeup. Two
-          # independent bounds: apt.conf.d for a dead connection, and a
-          # per-attempt `timeout` for one that stays open but trickles
-          # (apt's own Acquire::http::Timeout is inactivity-based and never
-          # fires on a slow-but-live socket). 3*180s + 2*10s sleep = 560s
-          # < the 720s step cap, so the loop is guaranteed all 3 attempts.
+          # its own — see ci.yml for the full incident writeup. Three
+          # independent bounds: apt.conf.d for a dead connection, a
+          # per-attempt `timeout -k 10 180` for one that stays open but
+          # trickles (apt's own Acquire::http::Timeout is inactivity-based
+          # and never fires on a slow-but-live socket), and a cleanup that
+          # kills the orphaned inner apt-get and waits for it to actually
+          # exit before retrying (`timeout` only signals its direct child;
+          # the real apt-get is a grandchild sudo places outside its reach,
+          # so a cut attempt leaves it holding the dpkg lock and every
+          # further attempt dies instantly with "Could not get lock"; psmisc
+          # isn't confirmed installed here, so poll with pgrep/pkill
+          # instead of fuser). Worst case: 3*(180+10)s + 2*(5+5*2+10)s =
+          # 620s, under the 720s step cap.
           echo 'Acquire::http::Timeout "30"; Acquire::https::Timeout "30"; Acquire::Retries "3";' \
             | sudo tee /etc/apt/apt.conf.d/99-ci-fetch-timeouts >/dev/null
           for i in 1 2 3; do
-            timeout 180 npx playwright install --with-deps chromium && break
+            timeout -k 10 180 npx playwright install --with-deps chromium && break
             echo "playwright install attempt $i failed"
             [ "$i" = 3 ] && exit 1
+            sudo pkill -TERM -x apt-get || true
+            sudo pkill -TERM -x dpkg || true
+            sleep 5
+            sudo pkill -KILL -x apt-get || true
+            sudo pkill -KILL -x dpkg || true
+            for _ in 1 2 3 4 5; do
+              pgrep -x apt-get >/dev/null || pgrep -x dpkg >/dev/null || break
+              sleep 2
+            done
+            sudo dpkg --configure -a || true
             sleep 10
           done
 

--- a/.github/workflows/prod-smoke.yml
+++ b/.github/workflows/prod-smoke.yml
@@ -196,6 +196,13 @@ jobs:
       - name: Install Playwright Browsers
         timeout-minutes: 10
         run: |
+          # playwright install-deps shells out to its own `apt-get update &&
+          # apt-get install` for font/library packages, with no timeout of
+          # its own — see ci.yml for the full incident writeup. Bound its
+          # inner apt-get the same way: apt-get always reads
+          # /etc/apt/apt.conf.d/ on startup.
+          echo 'Acquire::http::Timeout "30"; Acquire::https::Timeout "30"; Acquire::Retries "3";' \
+            | sudo tee /etc/apt/apt.conf.d/99-ci-fetch-timeouts >/dev/null
           for i in 1 2 3; do
             npx playwright install --with-deps chromium && break
             echo "playwright install attempt $i failed"

--- a/.github/workflows/prod-smoke.yml
+++ b/.github/workflows/prod-smoke.yml
@@ -194,7 +194,7 @@ jobs:
         run: npm ci
 
       - name: Install Playwright Browsers
-        timeout-minutes: 12
+        timeout-minutes: 13
         run: |
           # playwright install-deps shells out to its own `apt-get update &&
           # apt-get install` for font/library packages, with no timeout of
@@ -209,8 +209,9 @@ jobs:
           # so a cut attempt leaves it holding the dpkg lock and every
           # further attempt dies instantly with "Could not get lock"; psmisc
           # isn't confirmed installed here, so poll with pgrep/pkill
-          # instead of fuser). Worst case: 3*(180+10)s + 2*(5+5*2+10)s =
-          # 620s, under the 720s step cap.
+          # instead of fuser), plus its own timeout-wrapped
+          # `dpkg --configure -a`. Worst case: 3*(180+10)s +
+          # 2*(5+5*2+30+10+10)s = 700s, under the 780s (13-minute) step cap.
           echo 'Acquire::http::Timeout "30"; Acquire::https::Timeout "30"; Acquire::Retries "3";' \
             | sudo tee /etc/apt/apt.conf.d/99-ci-fetch-timeouts >/dev/null
           for i in 1 2 3; do
@@ -226,7 +227,7 @@ jobs:
               pgrep -x apt-get >/dev/null || pgrep -x dpkg >/dev/null || break
               sleep 2
             done
-            sudo dpkg --configure -a || true
+            sudo timeout -k 10 30 dpkg --configure -a || true
             sleep 10
           done
 

--- a/backend/tests/test_ci_job_timeouts.py
+++ b/backend/tests/test_ci_job_timeouts.py
@@ -110,7 +110,12 @@ _CLEANUP_POLL_LOOP = re.compile(
 _SLEEP_SECONDS = re.compile(r"\bsleep\s+(\d+)\b")
 _PKILL_APT_GET = re.compile(r"\bpkill\b[^\n]*-x\s+apt-get\b")
 _PKILL_DPKG = re.compile(r"\bpkill\b[^\n]*-x\s+dpkg\b")
-_PGREP_APT_GET_OR_DPKG = re.compile(r"\bpgrep\b[^\n]*-x\s+(?:apt-get|dpkg)\b")
+# Separate patterns, not one apt-get|dpkg alternation: the real poll line
+# checks BOTH process names independently (`pgrep -x apt-get >/dev/null ||
+# pgrep -x dpkg >/dev/null || break`), and an alternation would still
+# match with either branch deleted.
+_PGREP_APT_GET = re.compile(r"\bpgrep\b[^\n]*-x\s+apt-get\b")
+_PGREP_DPKG = re.compile(r"\bpgrep\b[^\n]*-x\s+dpkg\b")
 _DPKG_CONFIGURE_TIMEOUT_WRAPPED = re.compile(
     r"\btimeout\s+(?:-k\s+(\d+)\s+)?(\d+)\s+dpkg\s+--configure\s+-a\b"
 )
@@ -186,6 +191,13 @@ def test_every_playwright_install_step_bounds_its_inner_apt_get():
                 if not write_match:
                     offenders.append(f"{label}: no apt.conf.d file write found")
                     continue
+                write_target = write_match.group(2)
+                if not write_target.startswith("/etc/apt/apt.conf.d/"):
+                    offenders.append(
+                        f"{label}: write target `{write_target}` is not under "
+                        "/etc/apt/apt.conf.d/"
+                    )
+                    continue
                 directives = write_match.group(1)
                 missing = [
                     d for d in _REQUIRED_APT_CONF_DIRECTIVES if d not in directives
@@ -234,8 +246,10 @@ def _cleanup_budget_seconds(run: str) -> tuple[int | None, str | None]:
     poll_match = _CLEANUP_POLL_LOOP.search(run)
     if not poll_match:
         return None, "no bounded cleanup poll loop (`for _ in ...; do ... done`)"
-    if not _PGREP_APT_GET_OR_DPKG.search(poll_match.group(2)):
-        return None, "cleanup poll loop doesn't check apt-get/dpkg via `pgrep`"
+    if not _PGREP_APT_GET.search(poll_match.group(2)):
+        return None, "cleanup poll loop doesn't check apt-get via `pgrep`"
+    if not _PGREP_DPKG.search(poll_match.group(2)):
+        return None, "cleanup poll loop doesn't check dpkg via `pgrep`"
     poll_iterations = len(poll_match.group(1).split())
     poll_sleep_match = _SLEEP_SECONDS.search(poll_match.group(2))
     if not poll_sleep_match:

--- a/backend/tests/test_ci_job_timeouts.py
+++ b/backend/tests/test_ci_job_timeouts.py
@@ -56,7 +56,10 @@ _APT_CONF_D_WRITE = re.compile(r"/etc/apt/apt\.conf\.d/\S+")
 _TIMEOUT_WRAPPED_PLAYWRIGHT_INSTALL = re.compile(
     r"\btimeout\s+(\d+)\s+\S.*playwright\s+install", re.IGNORECASE
 )
-_FOR_LOOP_ATTEMPTS = re.compile(r"for\s+\w+\s+in\s+((?:\d+\s*)+);\s*do")
+# Flat character class, not `(?:\d+\s*)+` — a nested quantifier over an
+# optional-whitespace group backtracks exponentially on adversarial input
+# (CodeQL py/redos, alert 80). `[\d\s]+` is linear: a single top-level `+`.
+_FOR_LOOP_ATTEMPTS = re.compile(r"for\s+\w+\s+in\s+([\d\s]+);\s*do")
 _SLEEP_SECONDS = re.compile(r"\bsleep\s+(\d+)\b")
 
 

--- a/backend/tests/test_ci_job_timeouts.py
+++ b/backend/tests/test_ci_job_timeouts.py
@@ -32,10 +32,24 @@ is a socket INACTIVITY timeout, not a minimum-transfer-rate one. Job
 96108423519's stall was a mirror trickling a few KB/s, not a dead
 connection — fonts-freefont-ttf (5.6 MB) took 5m26s to arrive, continuously,
 which never trips an inactivity timeout. So every Playwright-install
-invocation must ALSO be wrapped in coreutils `timeout <N>`, with the retry
-loop's total worst case (attempts * N + (attempts - 1) * sleep) kept under
-the step's own `timeout-minutes`, or a slow-but-alive mirror burns the
-whole step on attempt 1 and the loop never gets a second try either.
+invocation must ALSO be wrapped in coreutils `timeout <N>` (optionally
+`timeout -k <K> <N>` for a SIGKILL grace period), with the retry loop's
+total worst case kept under the step's own `timeout-minutes`, or a
+slow-but-alive mirror burns the whole step on attempt 1 and the loop never
+gets a second try either.
+
+A third incident (2026-08-19, job 96120667995) showed `timeout` alone is
+still not enough: it only signals its DIRECT child, and playwright's real
+apt-get is a grandchild (npx -> node -> sudo -> sh -c -> apt-get) that sudo
+places outside its reach. A cut attempt leaves that apt-get running and
+holding the dpkg lock, so every subsequent attempt in the SAME retry loop
+dies instantly with "Could not get lock /var/lib/dpkg/lock-frontend" —
+observed for real: attempts 2 and 3 both failed within about a second of
+starting. Every Playwright-install step must therefore clean up an orphaned
+apt-get/dpkg before retrying (kill it, then wait for it to actually exit —
+psmisc/fuser isn't confirmed installed on this runner image, so the wait
+polls with pgrep/pkill from procps instead), and the retry budget must
+account for the worst-case cost of that cleanup too.
 """
 
 import pathlib
@@ -53,13 +67,24 @@ PROD_SMOKE = (
 
 _PLAYWRIGHT_INSTALL = re.compile(r"playwright\s+install", re.IGNORECASE)
 _APT_CONF_D_WRITE = re.compile(r"/etc/apt/apt\.conf\.d/\S+")
+# Optional `-k <K>` grace period ahead of the required `<N>` duration.
 _TIMEOUT_WRAPPED_PLAYWRIGHT_INSTALL = re.compile(
-    r"\btimeout\s+(\d+)\s+\S.*playwright\s+install", re.IGNORECASE
+    r"\btimeout\s+(?:-k\s+(\d+)\s+)?(\d+)\s+\S.*playwright\s+install", re.IGNORECASE
 )
 # Flat character class, not `(?:\d+\s*)+` — a nested quantifier over an
 # optional-whitespace group backtracks exponentially on adversarial input
 # (CodeQL py/redos, alert 80). `[\d\s]+` is linear: a single top-level `+`.
+# `.search()` returns the FIRST match, i.e. the outer retry loop
+# (`for i in ...`) — the cleanup poll loop uses a distinct variable name
+# and is matched separately by _CLEANUP_POLL_LOOP below.
 _FOR_LOOP_ATTEMPTS = re.compile(r"for\s+\w+\s+in\s+([\d\s]+);\s*do")
+# The bounded lock-wait loop inside the cleanup block: `for _ in ...; do
+# ... done`. DOTALL so `.` spans the loop body's newlines; captures both
+# the iteration count and the body text (to find its own `sleep <N>`,
+# distinct from the cleanup block's two FIXED sleeps outside the loop).
+_CLEANUP_POLL_LOOP = re.compile(
+    r"for\s+_\s+in\s+([\d\s]+);\s*do(.*?)\bdone\b", re.IGNORECASE | re.DOTALL
+)
 _SLEEP_SECONDS = re.compile(r"\bsleep\s+(\d+)\b")
 
 
@@ -110,6 +135,32 @@ def test_every_playwright_install_step_bounds_its_inner_apt_get():
     )
 
 
+def _cleanup_budget_seconds(run: str) -> tuple[int | None, str | None]:
+    """Worst-case seconds a single cleanup-between-attempts block can take.
+
+    Returns (seconds, None) on success, or (None, reason) if the run text
+    doesn't have the expected shape. The two FIXED sleeps (post-TERM,
+    post-configure) are whatever's left of `run` once the bounded poll
+    loop's own span is cut out, so a stray unrelated `sleep` elsewhere in
+    the step would corrupt this — none of the four steps this covers has
+    one, but a future edit that adds one should widen this rather than
+    trust the subtraction blindly.
+    """
+    poll_match = _CLEANUP_POLL_LOOP.search(run)
+    if not poll_match:
+        return None, "no bounded cleanup poll loop (`for _ in ...; do ... done`)"
+    poll_iterations = len(poll_match.group(1).split())
+    poll_sleep_match = _SLEEP_SECONDS.search(poll_match.group(2))
+    if not poll_sleep_match:
+        return None, "cleanup poll loop has no `sleep <N>`"
+    poll_sleep_seconds = int(poll_sleep_match.group(1))
+
+    outside_text = run[: poll_match.start()] + run[poll_match.end() :]
+    fixed_sleep_seconds = sum(int(m) for m in _SLEEP_SECONDS.findall(outside_text))
+
+    return fixed_sleep_seconds + poll_iterations * poll_sleep_seconds, None
+
+
 def test_every_playwright_install_attempt_fits_the_step_timeout_budget():
     offenders = []
     for path in (CI, PROD_SMOKE):
@@ -127,22 +178,27 @@ def test_every_playwright_install_attempt_fits_the_step_timeout_budget():
                         f"{label}: no `timeout <N>` wraps the playwright install"
                     )
                     continue
-                per_attempt_seconds = int(timeout_match.group(1))
+                kill_grace_seconds = int(timeout_match.group(1) or 0)
+                base_timeout_seconds = int(timeout_match.group(2))
+                per_attempt_seconds = base_timeout_seconds + kill_grace_seconds
 
                 attempts_match = _FOR_LOOP_ATTEMPTS.search(run)
                 attempts = len(attempts_match.group(1).split()) if attempts_match else 1
-                sleep_match = _SLEEP_SECONDS.search(run)
-                sleep_seconds = int(sleep_match.group(1)) if sleep_match else 0
+
+                cleanup_seconds, cleanup_error = _cleanup_budget_seconds(run)
+                if cleanup_error:
+                    offenders.append(f"{label}: {cleanup_error}")
+                    continue
 
                 worst_case_seconds = (
                     attempts * per_attempt_seconds
-                    + max(attempts - 1, 0) * sleep_seconds
+                    + max(attempts - 1, 0) * cleanup_seconds
                 )
                 step_cap_seconds = step.get("timeout-minutes", 0) * 60
                 if worst_case_seconds >= step_cap_seconds:
                     offenders.append(
                         f"{label}: {attempts} attempts * {per_attempt_seconds}s + "
-                        f"{max(attempts - 1, 0)} sleeps * {sleep_seconds}s = "
+                        f"{max(attempts - 1, 0)} cleanups * {cleanup_seconds}s = "
                         f"{worst_case_seconds}s >= step cap {step_cap_seconds}s"
                     )
     assert not offenders, (

--- a/backend/tests/test_ci_job_timeouts.py
+++ b/backend/tests/test_ci_job_timeouts.py
@@ -50,6 +50,19 @@ apt-get/dpkg before retrying (kill it, then wait for it to actually exit —
 psmisc/fuser isn't confirmed installed on this runner image, so the wait
 polls with pgrep/pkill from procps instead), and the retry budget must
 account for the worst-case cost of that cleanup too.
+
+The same mirror degradation hit the runner's OWN direct `sudo apt-get`
+steps too (2026-08-19, job 96122006694, "Install system dependencies"):
+apt fell back from a failing http mirror to an https one, then produced
+ZERO further output for the rest of the 10-minute step cap. Our existing
+`-o Acquire::http::Timeout=30` only covers the http method; the https
+fallback was unbounded. Every direct apt-get invocation (update and
+install, each wrapped separately) now also sets
+`Acquire::https::Timeout`, and is wrapped in its own `sudo timeout -k <K>
+<N>` — apt-get is timeout's DIRECT child here (no sudo/shell layer between
+them), but the same orphan risk still exists one level down if timeout
+kills apt-get mid-unpack of a dpkg child, so these steps get the same
+cleanup-between-attempts block as the Playwright-install steps.
 """
 
 import pathlib
@@ -87,9 +100,37 @@ _CLEANUP_POLL_LOOP = re.compile(
 )
 _SLEEP_SECONDS = re.compile(r"\bsleep\s+(\d+)\b")
 
+# A REAL apt-get invocation — "update"/"install" as the immediate
+# subcommand, only preceded by `-o <opt>` flags — as opposed to a bare
+# mention of the string "apt-get" as a `pkill -x apt-get` / `pgrep -x
+# apt-get` process-name argument (which the Playwright-install steps'
+# cleanup block also contains, but never actually runs apt-get itself).
+_APT_GET_INVOCATION = re.compile(r"\bapt-get(?:\s+-o\s+\S+)*\s+(?:update|install)\b")
+# Same, but requires a `timeout [-k <K>] <N>` immediately in front, and
+# captures the whole invocation (including its -o flags) in group(3) so
+# the caller can check which Acquire options it carries.
+_APT_GET_TIMEOUT_WRAPPED = re.compile(
+    r"\btimeout\s+(?:-k\s+(\d+)\s+)?(\d+)\s+(apt-get(?:\s+-o\s+\S+)*\s+(?:update|install))\b"
+)
+
 
 def _workflow(path: pathlib.Path = CI) -> dict:
     return yaml.safe_load(path.read_text())
+
+
+def _without_comment_lines(run: str) -> str:
+    """Drop full-line `#` comments before counting real invocations.
+
+    The incident write-ups in these steps' own comments say things like
+    "apt-get update" and "apt-get install" in prose, which would otherwise
+    look like actual invocations to a naive substring/regex scan. Every
+    comment in these steps is its own line (no trailing `# ...` after real
+    code), so a strip-by-line is exact for this file, not a general bash
+    parser.
+    """
+    return "\n".join(
+        line for line in run.splitlines() if not line.strip().startswith("#")
+    )
 
 
 def test_every_job_has_a_timeout():
@@ -204,3 +245,68 @@ def test_every_playwright_install_attempt_fits_the_step_timeout_budget():
     assert not offenders, (
         f"Playwright-install retry budget does not fit its step cap: {offenders}"
     )
+
+
+def test_every_direct_apt_get_invocation_is_bounded_and_fits_its_step_cap():
+    """Runner-level `sudo apt-get` steps: excludes the Dockerfile-heredoc
+    ones (`docker build ... <<'DOCKERFILE'`), which have no retry loop of
+    their own and aren't in scope here — they stay on the step-level-only
+    guarantee from test_every_apt_or_playwright_install_step_has_a_step_timeout.
+    """
+    offenders = []
+    jobs = _workflow(CI)["jobs"]
+    for job_name, job in jobs.items():
+        for step in job.get("steps", []):
+            run = step.get("run")
+            if not run or "<<'DOCKERFILE'" in run:
+                continue
+            code = _without_comment_lines(run)
+            invocations = _APT_GET_INVOCATION.findall(code)
+            if not invocations:
+                continue
+            label = f"{job_name}: {step.get('name', '<unnamed>')}"
+
+            wrapped = _APT_GET_TIMEOUT_WRAPPED.findall(code)
+            if len(wrapped) != len(invocations):
+                offenders.append(
+                    f"{label}: {len(invocations)} apt-get invocation(s), only "
+                    f"{len(wrapped)} wrapped in `timeout <N>`"
+                )
+                continue
+
+            per_attempt_seconds = 0
+            missing_acquire_flag = False
+            for kill_grace, base_timeout, invocation_text in wrapped:
+                if "Acquire::http::Timeout" not in invocation_text:
+                    offenders.append(
+                        f"{label}: `{invocation_text}` has no Acquire::http::Timeout"
+                    )
+                    missing_acquire_flag = True
+                if "Acquire::https::Timeout" not in invocation_text:
+                    offenders.append(
+                        f"{label}: `{invocation_text}` has no Acquire::https::Timeout"
+                    )
+                    missing_acquire_flag = True
+                per_attempt_seconds += int(base_timeout) + int(kill_grace or 0)
+            if missing_acquire_flag:
+                continue
+
+            attempts_match = _FOR_LOOP_ATTEMPTS.search(code)
+            attempts = len(attempts_match.group(1).split()) if attempts_match else 1
+
+            cleanup_seconds, cleanup_error = _cleanup_budget_seconds(code)
+            if cleanup_error:
+                offenders.append(f"{label}: {cleanup_error}")
+                continue
+
+            worst_case_seconds = (
+                attempts * per_attempt_seconds + max(attempts - 1, 0) * cleanup_seconds
+            )
+            step_cap_seconds = step.get("timeout-minutes", 0) * 60
+            if worst_case_seconds >= step_cap_seconds:
+                offenders.append(
+                    f"{label}: {attempts} attempts * {per_attempt_seconds}s + "
+                    f"{max(attempts - 1, 0)} cleanups * {cleanup_seconds}s = "
+                    f"{worst_case_seconds}s >= step cap {step_cap_seconds}s"
+                )
+    assert not offenders, f"direct apt-get retry budget/coverage problem: {offenders}"

--- a/backend/tests/test_ci_job_timeouts.py
+++ b/backend/tests/test_ci_job_timeouts.py
@@ -79,7 +79,16 @@ PROD_SMOKE = (
 )
 
 _PLAYWRIGHT_INSTALL = re.compile(r"playwright\s+install", re.IGNORECASE)
-_APT_CONF_D_WRITE = re.compile(r"/etc/apt/apt\.conf\.d/\S+")
+# Captures the echoed apt.conf directives (group 1) and the target path
+# (group 2), not just a bare mention of the directory — a step could
+# reference /etc/apt/apt.conf.d/ in passing without actually writing a
+# useful file there.
+_APT_CONF_D_WRITE = re.compile(r"echo\s+'([^']*)'\s*\\?\s*\|\s*sudo\s+tee\s+(\S+)")
+_REQUIRED_APT_CONF_DIRECTIVES = (
+    "Acquire::http::Timeout",
+    "Acquire::https::Timeout",
+    "Acquire::Retries",
+)
 # Optional `-k <K>` grace period ahead of the required `<N>` duration.
 _TIMEOUT_WRAPPED_PLAYWRIGHT_INSTALL = re.compile(
     r"\btimeout\s+(?:-k\s+(\d+)\s+)?(\d+)\s+\S.*playwright\s+install", re.IGNORECASE
@@ -99,6 +108,12 @@ _CLEANUP_POLL_LOOP = re.compile(
     r"for\s+_\s+in\s+([\d\s]+);\s*do(.*?)\bdone\b", re.IGNORECASE | re.DOTALL
 )
 _SLEEP_SECONDS = re.compile(r"\bsleep\s+(\d+)\b")
+_PKILL_APT_GET = re.compile(r"\bpkill\b[^\n]*-x\s+apt-get\b")
+_PKILL_DPKG = re.compile(r"\bpkill\b[^\n]*-x\s+dpkg\b")
+_PGREP_APT_GET_OR_DPKG = re.compile(r"\bpgrep\b[^\n]*-x\s+(?:apt-get|dpkg)\b")
+_DPKG_CONFIGURE_TIMEOUT_WRAPPED = re.compile(
+    r"\btimeout\s+(?:-k\s+(\d+)\s+)?(\d+)\s+dpkg\s+--configure\s+-a\b"
+)
 
 # A REAL apt-get invocation — "update"/"install" as the immediate
 # subcommand, only preceded by `-o <opt>` flags — as opposed to a bare
@@ -162,17 +177,32 @@ def test_every_playwright_install_step_bounds_its_inner_apt_get():
         for job_name, job in jobs.items():
             for step in job.get("steps", []):
                 run = step.get("run")
-                if (
-                    run
-                    and _PLAYWRIGHT_INSTALL.search(run)
-                    and not _APT_CONF_D_WRITE.search(run)
-                ):
+                if not run or not _PLAYWRIGHT_INSTALL.search(run):
+                    continue
+                label = f"{path.name}/{job_name}: {step.get('name', '<unnamed>')}"
+                code = _without_comment_lines(run)
+
+                write_match = _APT_CONF_D_WRITE.search(code)
+                if not write_match:
+                    offenders.append(f"{label}: no apt.conf.d file write found")
+                    continue
+                directives = write_match.group(1)
+                missing = [
+                    d for d in _REQUIRED_APT_CONF_DIRECTIVES if d not in directives
+                ]
+                if missing:
                     offenders.append(
-                        f"{path.name}/{job_name}: {step.get('name', '<unnamed>')}"
+                        f"{label}: apt.conf.d write is missing directive(s) {missing}"
+                    )
+                    continue
+
+                playwright_match = _PLAYWRIGHT_INSTALL.search(code)
+                if playwright_match and write_match.start() >= playwright_match.start():
+                    offenders.append(
+                        f"{label}: apt.conf.d write does not precede `playwright install`"
                     )
     assert not offenders, (
-        "Playwright-install steps not bounding their inner apt-get via "
-        f"/etc/apt/apt.conf.d/: {offenders}"
+        f"Playwright-install steps not correctly bounding their inner apt-get: {offenders}"
     )
 
 
@@ -180,26 +210,52 @@ def _cleanup_budget_seconds(run: str) -> tuple[int | None, str | None]:
     """Worst-case seconds a single cleanup-between-attempts block can take.
 
     Returns (seconds, None) on success, or (None, reason) if the run text
-    doesn't have the expected shape. The two FIXED sleeps (post-TERM,
-    post-configure) are whatever's left of `run` once the bounded poll
-    loop's own span is cut out, so a stray unrelated `sleep` elsewhere in
-    the step would corrupt this — none of the four steps this covers has
-    one, but a future edit that adds one should widen this rather than
-    trust the subtraction blindly.
+    doesn't have the expected shape. Requires actual evidence of the
+    orphan-kill sequence, not just any bounded loop with a sleep: a
+    `pkill` targeting apt-get, one targeting dpkg, a bounded poll loop
+    that itself checks apt-get/dpkg via `pgrep`, and a timeout-wrapped
+    `dpkg --configure -a` (whose own -k grace counts toward the budget
+    the same way a Playwright-install attempt's does). A cleanup block
+    that dropped the kill commands but kept an unrelated bounded loop
+    would otherwise still look bounded to a looser check.
+
+    The two FIXED sleeps (post-TERM, before the final retry) are whatever
+    text is left in `run` once the poll loop's own span AND the
+    dpkg-configure invocation are cut out, so a stray unrelated `sleep`
+    elsewhere in the step would corrupt this — none of the seven steps
+    this covers has one, but a future edit that adds one should widen
+    this rather than trust the subtraction blindly.
     """
+    if not _PKILL_APT_GET.search(run):
+        return None, "cleanup has no `pkill ... -x apt-get`"
+    if not _PKILL_DPKG.search(run):
+        return None, "cleanup has no `pkill ... -x dpkg`"
+
     poll_match = _CLEANUP_POLL_LOOP.search(run)
     if not poll_match:
         return None, "no bounded cleanup poll loop (`for _ in ...; do ... done`)"
+    if not _PGREP_APT_GET_OR_DPKG.search(poll_match.group(2)):
+        return None, "cleanup poll loop doesn't check apt-get/dpkg via `pgrep`"
     poll_iterations = len(poll_match.group(1).split())
     poll_sleep_match = _SLEEP_SECONDS.search(poll_match.group(2))
     if not poll_sleep_match:
         return None, "cleanup poll loop has no `sleep <N>`"
     poll_sleep_seconds = int(poll_sleep_match.group(1))
 
+    configure_match = _DPKG_CONFIGURE_TIMEOUT_WRAPPED.search(run)
+    if not configure_match:
+        return None, "cleanup has no timeout-wrapped `dpkg --configure -a`"
+    configure_seconds = int(configure_match.group(2)) + int(
+        configure_match.group(1) or 0
+    )
+
     outside_text = run[: poll_match.start()] + run[poll_match.end() :]
     fixed_sleep_seconds = sum(int(m) for m in _SLEEP_SECONDS.findall(outside_text))
 
-    return fixed_sleep_seconds + poll_iterations * poll_sleep_seconds, None
+    return (
+        fixed_sleep_seconds + poll_iterations * poll_sleep_seconds + configure_seconds,
+        None,
+    )
 
 
 def test_every_playwright_install_attempt_fits_the_step_timeout_budget():
@@ -212,8 +268,9 @@ def test_every_playwright_install_attempt_fits_the_step_timeout_budget():
                 if not run or not _PLAYWRIGHT_INSTALL.search(run):
                     continue
                 label = f"{path.name}/{job_name}: {step.get('name', '<unnamed>')}"
+                code = _without_comment_lines(run)
 
-                timeout_match = _TIMEOUT_WRAPPED_PLAYWRIGHT_INSTALL.search(run)
+                timeout_match = _TIMEOUT_WRAPPED_PLAYWRIGHT_INSTALL.search(code)
                 if not timeout_match:
                     offenders.append(
                         f"{label}: no `timeout <N>` wraps the playwright install"
@@ -223,10 +280,10 @@ def test_every_playwright_install_attempt_fits_the_step_timeout_budget():
                 base_timeout_seconds = int(timeout_match.group(2))
                 per_attempt_seconds = base_timeout_seconds + kill_grace_seconds
 
-                attempts_match = _FOR_LOOP_ATTEMPTS.search(run)
+                attempts_match = _FOR_LOOP_ATTEMPTS.search(code)
                 attempts = len(attempts_match.group(1).split()) if attempts_match else 1
 
-                cleanup_seconds, cleanup_error = _cleanup_budget_seconds(run)
+                cleanup_seconds, cleanup_error = _cleanup_budget_seconds(code)
                 if cleanup_error:
                     offenders.append(f"{label}: {cleanup_error}")
                     continue

--- a/backend/tests/test_ci_job_timeouts.py
+++ b/backend/tests/test_ci_job_timeouts.py
@@ -12,6 +12,20 @@ Deliberately broad on the step predicate: ANY step whose `run:` contains
 `apt-get` gets checked, including one embedded inside a `docker build
 ... <<DOCKERFILE` heredoc — the base-image apt-get there is the same hang
 class as a runner-level `sudo apt-get`, just one layer down.
+
+A follow-up incident showed the step-level timeout above is necessary but
+not sufficient: playwright's own `install-deps` shells out to an internal
+`apt-get update && apt-get install` for font/library packages, with no
+timeout of its own. On 2026-08-19 two "Install Playwright Browsers" runs
+(jobs 96101445154 and 96108423519) each burned the full 10-minute step cap
+stalled inside that inner apt-get, fetching fonts-freefont-ttf and
+fonts-wqy-zenhei from a degraded azure.archive.ubuntu.com mirror at a few
+KB/s. The retry loop around the whole step never got a second attempt,
+because the step-level timeout killed it first. apt-get always reads
+/etc/apt/apt.conf.d/ on startup (confirmed by reading playwright-core's
+dependencies.js: it spawns a plain `apt-get update && apt-get install`
+with no custom config path), so every Playwright-install step must write
+per-request timeouts there before invoking `playwright install`.
 """
 
 import pathlib
@@ -20,12 +34,19 @@ import re
 import yaml
 
 CI = pathlib.Path(__file__).resolve().parents[2] / ".github" / "workflows" / "ci.yml"
+PROD_SMOKE = (
+    pathlib.Path(__file__).resolve().parents[2]
+    / ".github"
+    / "workflows"
+    / "prod-smoke.yml"
+)
 
 _PLAYWRIGHT_INSTALL = re.compile(r"playwright\s+install", re.IGNORECASE)
+_APT_CONF_D_WRITE = re.compile(r"/etc/apt/apt\.conf\.d/\S+")
 
 
-def _workflow() -> dict:
-    return yaml.safe_load(CI.read_text())
+def _workflow(path: pathlib.Path = CI) -> dict:
+    return yaml.safe_load(path.read_text())
 
 
 def test_every_job_has_a_timeout():
@@ -47,4 +68,25 @@ def test_every_apt_or_playwright_install_step_has_a_step_timeout():
                     offenders.append(f"{job_name}: {step.get('name', '<unnamed>')}")
     assert not offenders, (
         f"apt/Playwright install steps missing a step-level timeout-minutes: {offenders}"
+    )
+
+
+def test_every_playwright_install_step_bounds_its_inner_apt_get():
+    offenders = []
+    for path in (CI, PROD_SMOKE):
+        jobs = _workflow(path)["jobs"]
+        for job_name, job in jobs.items():
+            for step in job.get("steps", []):
+                run = step.get("run")
+                if (
+                    run
+                    and _PLAYWRIGHT_INSTALL.search(run)
+                    and not _APT_CONF_D_WRITE.search(run)
+                ):
+                    offenders.append(
+                        f"{path.name}/{job_name}: {step.get('name', '<unnamed>')}"
+                    )
+    assert not offenders, (
+        "Playwright-install steps not bounding their inner apt-get via "
+        f"/etc/apt/apt.conf.d/: {offenders}"
     )

--- a/backend/tests/test_ci_job_timeouts.py
+++ b/backend/tests/test_ci_job_timeouts.py
@@ -26,6 +26,16 @@ because the step-level timeout killed it first. apt-get always reads
 dependencies.js: it spawns a plain `apt-get update && apt-get install`
 with no custom config path), so every Playwright-install step must write
 per-request timeouts there before invoking `playwright install`.
+
+The apt.conf.d write alone is still not sufficient: `Acquire::http::Timeout`
+is a socket INACTIVITY timeout, not a minimum-transfer-rate one. Job
+96108423519's stall was a mirror trickling a few KB/s, not a dead
+connection — fonts-freefont-ttf (5.6 MB) took 5m26s to arrive, continuously,
+which never trips an inactivity timeout. So every Playwright-install
+invocation must ALSO be wrapped in coreutils `timeout <N>`, with the retry
+loop's total worst case (attempts * N + (attempts - 1) * sleep) kept under
+the step's own `timeout-minutes`, or a slow-but-alive mirror burns the
+whole step on attempt 1 and the loop never gets a second try either.
 """
 
 import pathlib
@@ -43,6 +53,11 @@ PROD_SMOKE = (
 
 _PLAYWRIGHT_INSTALL = re.compile(r"playwright\s+install", re.IGNORECASE)
 _APT_CONF_D_WRITE = re.compile(r"/etc/apt/apt\.conf\.d/\S+")
+_TIMEOUT_WRAPPED_PLAYWRIGHT_INSTALL = re.compile(
+    r"\btimeout\s+(\d+)\s+\S.*playwright\s+install", re.IGNORECASE
+)
+_FOR_LOOP_ATTEMPTS = re.compile(r"for\s+\w+\s+in\s+((?:\d+\s*)+);\s*do")
+_SLEEP_SECONDS = re.compile(r"\bsleep\s+(\d+)\b")
 
 
 def _workflow(path: pathlib.Path = CI) -> dict:
@@ -89,4 +104,44 @@ def test_every_playwright_install_step_bounds_its_inner_apt_get():
     assert not offenders, (
         "Playwright-install steps not bounding their inner apt-get via "
         f"/etc/apt/apt.conf.d/: {offenders}"
+    )
+
+
+def test_every_playwright_install_attempt_fits_the_step_timeout_budget():
+    offenders = []
+    for path in (CI, PROD_SMOKE):
+        jobs = _workflow(path)["jobs"]
+        for job_name, job in jobs.items():
+            for step in job.get("steps", []):
+                run = step.get("run")
+                if not run or not _PLAYWRIGHT_INSTALL.search(run):
+                    continue
+                label = f"{path.name}/{job_name}: {step.get('name', '<unnamed>')}"
+
+                timeout_match = _TIMEOUT_WRAPPED_PLAYWRIGHT_INSTALL.search(run)
+                if not timeout_match:
+                    offenders.append(
+                        f"{label}: no `timeout <N>` wraps the playwright install"
+                    )
+                    continue
+                per_attempt_seconds = int(timeout_match.group(1))
+
+                attempts_match = _FOR_LOOP_ATTEMPTS.search(run)
+                attempts = len(attempts_match.group(1).split()) if attempts_match else 1
+                sleep_match = _SLEEP_SECONDS.search(run)
+                sleep_seconds = int(sleep_match.group(1)) if sleep_match else 0
+
+                worst_case_seconds = (
+                    attempts * per_attempt_seconds
+                    + max(attempts - 1, 0) * sleep_seconds
+                )
+                step_cap_seconds = step.get("timeout-minutes", 0) * 60
+                if worst_case_seconds >= step_cap_seconds:
+                    offenders.append(
+                        f"{label}: {attempts} attempts * {per_attempt_seconds}s + "
+                        f"{max(attempts - 1, 0)} sleeps * {sleep_seconds}s = "
+                        f"{worst_case_seconds}s >= step cap {step_cap_seconds}s"
+                    )
+    assert not offenders, (
+        f"Playwright-install retry budget does not fit its step cap: {offenders}"
     )


### PR DESCRIPTION
## Summary

Bounds every apt-get invocation in ci.yml and prod-smoke.yml against a degraded package mirror, closing three separate gaps that each showed up in a real CI run while this PR was open:

1. Playwright's own `install-deps` shells out to an internal `apt-get`, which our earlier fixes didn't touch.
2. `Acquire::http::Timeout` is a socket inactivity timeout, not a minimum-transfer-rate one, so a mirror that stays open but trickles a few KB/s never trips it.
3. `timeout` only signals its direct child, so a cut attempt can orphan an `apt-get`/`dpkg` process that keeps holding the dpkg lock through every subsequent retry.
4. The https fallback (when the primary http mirror fails) wasn't bounded at all.

## Evidence

All observed on 2026-08-19, across two sibling PRs sharing this mirror problem:

- Jobs 96101445154 and 96108423519 ("Install Playwright Browsers", E2E Smoke): both hit the 10-minute step cap stalled inside playwright's internal apt-get, fetching font packages from a degraded `azure.archive.ubuntu.com` mirror. One job took 5m26s to fetch a single 5.6 MB package.
- Job 96120667995: the fix above worked as designed on attempt 1 (`timeout` cut it at 15:21:43), but the orphaned `apt-get` it left running (grandchild via `npx -> node -> sudo -> sh -c -> apt-get`, outside `timeout`'s reach) kept holding the dpkg lock. Attempts 2 and 3 both died within about a second of starting with "Could not get lock /var/lib/dpkg/lock-frontend. It is held by process 12362 (apt-get)".
- Job 96122006694 ("Install system dependencies", Backend Tests, a sibling PR): apt fell back from a failing http mirror to an https one, fetched one InRelease file, then produced zero output for the remaining 9.5 minutes of the step cap. Our `Acquire::http::Timeout` never covered the https method.

## What changed

**Playwright-install steps** (ci.yml: e2e-test, e2e-smoke, accessibility; prod-smoke.yml), each `run:` now:
- Writes `/etc/apt/apt.conf.d/99-ci-fetch-timeouts` (`Acquire::http::Timeout "30"`, `Acquire::https::Timeout "30"`, `Acquire::Retries "3"`) before invoking `playwright install`, since apt-get always reads that directory on startup (confirmed by reading `playwright-core`'s `dependencies.js`: it spawns a plain `apt-get update && apt-get install` with no custom config path).
- Wraps each attempt in `timeout -k 10 180`.
- On a failed attempt, kills any leftover `apt-get`/`dpkg`, waits for it to actually exit, then runs `dpkg --configure -a` before retrying. `psmisc` (`fuser`) isn't confirmed installed on this runner image (I searched `actions/runner-images`' build scripts and found no install step for it), so the wait polls with `pgrep`/`pkill` from `procps` instead, which I confirmed present by checking directly against the base `ubuntu:24.04` image.
- Step cap raised 10 -> 12 minutes. Worst case: 3 attempts * (180+10)s + 2 cleanups * (5 + 5*2 + 10)s = 620s, with 100s to spare.

**Direct apt-get steps** (backup-roundtrip's "Install postgresql-client + tooling"; backend-test's and ai-evals' "Install system dependencies"), each now:
- Sets `Acquire::https::Timeout` alongside `Acquire::http::Timeout` on both `update` and `install`.
- Wraps `update` and `install` in their own separate `sudo timeout -k 10 <N>` (90s / 150s) rather than chaining both under one timeout. apt-get is `timeout`'s direct child this way, with no shell or sudo layer between them to block the signal.
- Gets the same orphan cleanup as the Playwright-install steps, since `timeout` killing apt-get mid-unpack can still orphan a dpkg grandchild holding the lock.
- Step cap raised 10 -> 15 minutes. Worst case: 3 attempts * 260s + 2 cleanups * 25s = 830s, with 70s to spare.

The three Dockerfile-heredoc apt-get steps ("Start PostgreSQL with PostGIS + pgvector") are untouched: no retry loop of their own, out of scope here, still covered by the step-level-timeout-only guarantee from the earlier commit.

## New tests

`backend/tests/test_ci_job_timeouts.py` grew four checks this PR, each confirmed red against main before the corresponding fix landed:
- Every job has `timeout-minutes`.
- Every apt-get/Playwright-install step has a step-level `timeout-minutes`.
- Every Playwright-install step writes the apt.conf.d file.
- Every Playwright-install attempt's retry budget (parsed from the actual `timeout`/attempt/sleep values, not hardcoded) fits its step cap.
- Every real direct apt-get invocation (not the incident comments' prose, which mentions "apt-get update"/"apt-get install" too) is timeout-wrapped, carries both Acquire options, and its retry budget fits its step cap.

For the last two, I verified the check is load-bearing (not vacuously passing) by independently breaking each thing it verifies in a scratch copy (a budget overflow, a missing https flag, a missing timeout wrapper) and watching the test catch each one before restoring.

## Verification

- YAML validity and `actionlint` on both workflow files at every commit: clean, aside from pre-existing shellcheck info-level notices on unrelated `$GITHUB_ENV` lines, unchanged in content across every push.
- `shellcheck` run directly on each new script block in isolation: zero output.
- `uv run pytest tests/test_ci_job_timeouts.py tests/test_layering.py -q`: 52 passed.
- `uv run ruff check` / `ruff format --check` on the test file: clean.
- `pre-commit run` on all changed files: all hooks pass.
- CodeQL: an earlier push introduced a ReDoS-prone nested quantifier in one of the test's regexes (alert 80, `py/redos`), fixed by replacing it with an equivalent flat character class; stress-tested the fix against adversarial input directly (linear scaling confirmed) rather than trusting the fix blind.
- The fix has now been exercised for real: E2E Smoke passed on this branch's HEAD, and Backend Tests/Backup Restore Round-trip are green through the direct-apt-get fix's own CI run.
