### PR TITLE
chore(release): v1.14.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and releases use semantic versioning.
 
 ## [Unreleased]
 
-## [1.14.1] - 2026-08-19
+## [1.14.1] - 2026-08-20
 
 ### Added
 
@@ -40,7 +40,16 @@ and releases use semantic versioning.
   authenticated saved-search routes are unchanged. Both CORS policies also
   expose `Retry-After` on a 429 and send `Vary: Origin`, so a cross-origin
   caller can read the retry window and a caching proxy in front of the API
-  keys its entries by origin (#1596, #1602).
+  keys its entries by origin. The shipped nginx ignores that header on its
+  raster-tile cache, whose CORS value is a static wildcard for every caller,
+  so tiles stay one cache entry per tile instead of one per embedding site
+  (#1596, #1602, #1605).
+- **A force reseed no longer breaks the demo links the examples gallery
+  depends on.** `scripts/seed-showcase.py` now pins the four externally
+  linked showcase maps and the meteorites dataset: `--force` repairs the
+  Sentinel map in place and keeps every pinned row's UUID and share links,
+  `--prune`/`--prune-userdata` hard-keep them, and a new `--force-pinned`
+  says exactly what it destroys before an operator uses it (#1607).
 - **Default extension ports match their Protocol signatures.** Four default
   port methods and two default AI-provider stream methods had drifted from the
   parameter names their Protocols declare, so a keyword caller or an overlay

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and releases use semantic versioning.
 
 ## [Unreleased]
 
+## [1.14.1] - 2026-08-19
+
+### Added
+
+- **The login privacy-policy link is now a per-instance setting.** Every
+  self-hosted login and register page linked to getgeolens.com's privacy
+  policy, which describes our data practices rather than the operator's. The
+  link now comes from a `privacy_url` setting on the General tab (or the
+  `PRIVACY_URL` environment variable) and stays hidden until one is set, so an
+  instance never shows another operator's policy to its users by default
+  (#1592).
+
 ### Fixed
 
 - **Metric-buffer questions in chat stop failing at the sandbox.** Asking for a
@@ -15,6 +27,29 @@ and releases use semantic versioning.
   roughly every other such question came back as a refused query rather than an
   answer. The assistant now writes a short call and the server renders the
   expression itself, so the shape can no longer be wrong (#1589).
+- **A bare `/api` no longer redirects to `http://<host>:8080/api/`.** The
+  shipped nginx answered the slash redirect with an absolute `Location` built
+  from the container port and plain http, which behind a TLS edge sent clients
+  to an unreachable address. It now emits a relative `Location: /api/` (#1597).
+- **Anonymous catalog search answers cross-origin browser requests.** The
+  read-only `/search/datasets` and `/search/facets` routes sent no
+  `Access-Control-Allow-Origin` to an origin outside the allow-list while the
+  OGC Records and STAC routes did, so a static page could query the standards
+  surface but not native search. They now get the same credential-free
+  wildcard, with a preflight that advertises only the `GET` they answer; the
+  authenticated saved-search routes are unchanged. Both CORS policies also
+  expose `Retry-After` on a 429 and send `Vary: Origin`, so a cross-origin
+  caller can read the retry window and a caching proxy in front of the API
+  keys its entries by origin (#1596, #1602).
+- **Default extension ports match their Protocol signatures.** Four default
+  port methods and two default AI-provider stream methods had drifted from the
+  parameter names their Protocols declare, so a keyword caller or an overlay
+  forwarding by name hit a `TypeError` against the default. The signatures are
+  now pinned by a structural test (#1590).
+- **A falsy non-string sent for `public_app_url` or `public_api_url` is
+  rejected instead of clearing the value.** JSON `false`, `0`, `[]` or `{}`
+  silently cleared the configured URL; only `null` and an empty string clear it
+  now, and anything else is a 422.
 
 ## [1.14.0] - 2026-08-18
 
@@ -2367,7 +2402,8 @@ regression-covered fixes:
 - Initial public release of the GeoLens catalog, API, map builder, CLI, SDKs,
   Docker development stack, and public documentation entrypoints.
 
-[Unreleased]: https://github.com/geolens-io/geolens/compare/v1.14.0...HEAD
+[Unreleased]: https://github.com/geolens-io/geolens/compare/v1.14.1...HEAD
+[1.14.1]: https://github.com/geolens-io/geolens/compare/v1.14.0...v1.14.1
 [1.14.0]: https://github.com/geolens-io/geolens/compare/v1.13.1...v1.14.0
 [1.13.1]: https://github.com/geolens-io/geolens/compare/v1.13.0...v1.13.1
 [1.13.0]: https://github.com/geolens-io/geolens/compare/v1.12.0...v1.13.0

--- a/backend/app/api/main.py
+++ b/backend/app/api/main.py
@@ -746,7 +746,7 @@ _is_production = settings.is_production
 # no metadata to read. We fall back to the current published line so import never
 # crashes. Keep this fallback in lockstep with backend/pyproject.toml — it is one
 # of the sites `make bump` rewrites.
-_FALLBACK_APP_VERSION = "1.14.0"
+_FALLBACK_APP_VERSION = "1.14.1"
 
 
 def _resolve_app_version() -> str:

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -18506,7 +18506,7 @@
     "summary": "PostGIS-native geospatial data catalog with OGC API Features and Records support",
     "termsOfService": "https://github.com/geolens-io/geolens/blob/main/LICENSE",
     "title": "GeoLens API",
-    "version": "1.14.0"
+    "version": "1.14.1"
   },
   "openapi": "3.1.0",
   "paths": {

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geolens-backend"
-version = "1.14.0"
+version = "1.14.1"
 description = "PostGIS-native GIS data catalog"
 # Docker image (Dockerfile) ships python:3.14-slim (see the Dockerfile FROM for
 # the exact patch pin) as the project's tested runtime.

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -838,7 +838,7 @@ wheels = [
 
 [[package]]
 name = "geolens-backend"
-version = "1.14.0"
+version = "1.14.1"
 source = { virtual = "." }
 dependencies = [
     { name = "alembic" },

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "geolens-cli"
-version = "1.14.0"
+version = "1.14.1"
 description = "Apache-2.0 command-line interface for the GeoLens API. Login, scan, publish, and export STAC against any GeoLens instance."
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/docs-contract.json
+++ b/docs-contract.json
@@ -1,6 +1,6 @@
 {
   "_comment": "Canonical cross-surface facts for the GeoLens README, marketing site (getgeolens.com/src), and docs site (getgeolens.com/docs). Validated against scripts/install.sh + backend/pyproject.toml by scripts/check_docs_contract.py (geolens CI). The getgeolens.com repo vendors a copy and enforces the same `forbidden` list in its own CI. See docs-internal/DOC-CONSISTENCY-STRATEGY for the full design. Edit a fact ONCE here (and in its canonical source) — the gates make every surface follow.",
-  "version": "1.14.0",
+  "version": "1.14.1",
   "install": {
     "oneLiner": "curl -fsSL https://getgeolens.com/install.sh | sh",
     "sourceBuild": "bash scripts/install.sh",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "1.14.0",
+  "version": "1.14.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "1.14.0",
+      "version": "1.14.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.14.0",
+  "version": "1.14.1",
   "type": "module",
   "license": "Apache-2.0",
   "author": "Carto Concepts, LLC",

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "geolens-mcp"
-version = "1.14.0"
+version = "1.14.1"
 description = "Apache-2.0 read-only Model Context Protocol (MCP) server for GeoLens. Lets coding agents discover datasets, inspect schemas, and ask spatial questions against any GeoLens instance."
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/mcp/uv.lock
+++ b/mcp/uv.lock
@@ -225,7 +225,7 @@ wheels = [
 
 [[package]]
 name = "geolens"
-version = "1.14.0"
+version = "1.14.1"
 source = { editable = "../sdks/python" }
 dependencies = [
     { name = "attrs" },
@@ -244,7 +244,7 @@ requires-dist = [
 
 [[package]]
 name = "geolens-mcp"
-version = "1.14.0"
+version = "1.14.1"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "geolens",
-  "version": "1.14.0",
+  "version": "1.14.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "geolens",
-      "version": "1.14.0",
+      "version": "1.14.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@axe-core/playwright": "^4.13.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geolens",
-  "version": "1.14.0",
+  "version": "1.14.1",
   "private": true,
   "license": "Apache-2.0",
   "author": "Carto Concepts, LLC",

--- a/sdks/python/.openapi-python-client.yaml
+++ b/sdks/python/.openapi-python-client.yaml
@@ -4,7 +4,7 @@ project_name_override: geolens
 package_name_override: geolens
 # Rewritten on every `make sdks` run by scripts/sync_sdk_versions.py to match
 # backend/openapi.json info.version. Do not edit by hand.
-package_version_override: 1.14.0
+package_version_override: 1.14.1
 
 # Cleaner enum output (matches our pydantic v2 backend's enum emission).
 literal_enums: true

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "geolens"
-version = "1.14.0"
+version = "1.14.1"
 description = "Auto-generated Python SDK for the GeoLens API. Typed clients with Bearer + API-key auth helpers."
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/sdks/typescript/package-lock.json
+++ b/sdks/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@geolens/sdk",
-  "version": "1.14.0",
+  "version": "1.14.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@geolens/sdk",
-      "version": "1.14.0",
+      "version": "1.14.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@hey-api/client-fetch": "0.13.1"

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geolens/sdk",
-  "version": "1.14.0",
+  "version": "1.14.1",
   "description": "Auto-generated TypeScript SDK for the GeoLens API. Typed clients with Bearer + API-key auth helpers.",
   "license": "Apache-2.0",
   "author": "Carto Concepts, LLC",


### PR DESCRIPTION
Cuts v1.14.1. Folds the `[Unreleased]` notes into a dated `## [1.14.1] - 2026-08-20` section (the merge-queue run and the tag land past midnight UTC), adds the compare link, and moves every version site to 1.14.1 with `make bump VERSION=1.14.1` (19 sites: backend, CLI, MCP, both SDKs, root and frontend package files, `openapi.json` info.version, `docs-contract.json`, the five lockfiles). No behaviour changes.

What is in the release: the per-instance privacy-policy link (#1592), the server-side `geolens_buffer` marker for metric-buffer chat questions (#1594 for #1589), the relative `/api` slash redirect in the shipped nginx (#1598 for #1597), anonymous CORS for catalog search with `Retry-After` exposed and `Vary: Origin` on both policies (#1601, #1603), the raster-tile cache guard against per-origin fragmentation (#1610 for #1605), default extension ports pinned to their Protocol signatures (#1593 for #1590), the public URL falsy-clear fix (#1599), and the seed-showcase pinning of the externally linked demo maps (#1613 for #1607). CI-only, not in the notes: the release-to-site dispatch (#1591) and the job timeouts with bounded, retried installs (#1600, #1604), the examples release dispatch (#1612 for #1609), and the four-locale README refresh (#1611 for #1608). The full text is in the CHANGELOG diff.

Verification on the branch:

```
make version-check          # OK: all 19 version sites agree on 1.14.1
make openapi-check          # clean
make sdks-check             # clean on the committed tree
```

Verification on main at f5e37d382 (the tree this tags apart from the late folds), before opening this PR: every local gate green (`openapi-check`, `sdks-check`, `cli-test`, `alembic-check`, `version-check`, MCP tests, frontend build/lint/typecheck/i18n/tests, `e2e:smoke` 7/7); the export route answers a strong ETag on 200 and the same ETag on 206, a cold `ogrinfo` open of a never-built GeoPackage export over `/vsicurl/` succeeds and the warm open is all 206s off one artifact; the geolens-examples Python, OGC and MCP scripts pass against the local stack. Release-specific acceptance: anonymous cross-origin `GET /api/search/datasets/` and `/facets/` answer `Access-Control-Allow-Origin: *` with `Retry-After` in the exposed list, `/search/saved/` and a credential-bearing request get no wildcard, the preflight advertises `GET, OPTIONS` and refuses `HEAD`; `PUT /settings/` with `false`/`0`/`[]`/`{}` for `public_app_url` is a 422 and `null` clears; the public branding payload carries `privacy_url`. Browser QA: the login page renders the privacy block only while `privacy_url` is set, search, the admin General tab fields, and a map with tiles. The nginx redirect cannot be exercised on the Vite dev stack; it was reproduced on nginx 1.27 directly and is checked again on the demo after deploy.

After merge: tag `v1.14.1`, docs sync, demo deploy with `PRIVACY_URL`, examples `verify.yml` against the demo and client pins to 1.14.1.

https://claude.ai/code/session_01UM7M9D4sWb23hzNeCHQnyB