### PR TITLE
docs(readme): describe the current geolens-examples contents in all four locales

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -106,7 +106,7 @@ PostGIS und pgvector teilen sich eine Datenbank. Bei aktivierter semantischer Su
 
 Direkt aus QGIS verbinden: **Layer > Add WFS / OGC API Features**, Ziel `http://localhost:8080/api/`.
 
-Dieselben Endpunkte aus einer Kartenbibliothek: [geolens-examples](https://github.com/geolens-io/geolens-examples) enthält Ein-Datei-Seiten für MapLibre, Leaflet, OpenLayers und das ArcGIS SDK, dazu beide GeoLens-SDKs, eine eingebettete gespeicherte Karte, eine Python/GeoPandas-Analyse und eine MCP-Konfiguration. Jedes Beispiel läuft gegen die öffentliche Demo, und die CI führt sie wöchentlich erneut dagegen aus. Was Sie kopieren, hat also diese Woche funktioniert. [Galerie ansehen](https://geolens-io.github.io/geolens-examples/).
+Dieselben Endpunkte aus den Werkzeugen, die Sie ohnehin nutzen: [geolens-examples](https://github.com/geolens-io/geolens-examples) enthält Ein-Datei-Seiten für MapLibre, Leaflet, OpenLayers und das ArcGIS JavaScript SDK, Anleitungen für QGIS und DuckDB, beide GeoLens-SDKs, eine semantische Katalogsuche, einen STAC-Browser, eine eingebettete gespeicherte Karte, eine Python/GeoPandas-Analyse, ein Katalog-als-Code-Manifest für die CLI und eine MCP-Konfiguration. Die rein lesenden Beispiele laufen direkt gegen die öffentliche Demo, und die CI führt sie dort bei jedem Push und einmal wöchentlich erneut aus. Was Sie kopieren, hat also diese Woche funktioniert. [Galerie ansehen](https://geolens-io.github.io/geolens-examples/).
 
 ## Funktionen
 
@@ -354,7 +354,7 @@ API und Worker exportieren sofort Prometheus-Metriken (HTTP-Rate/Latenz/Fehler, 
 | [CLI & Manifeste](https://docs.getgeolens.com/guides/cli/) | Dateien veröffentlichen und Kataloge mit `geolens` verwalten |
 | [API-Referenz](https://docs.getgeolens.com/guides/api/) | Automatisch erzeugte Referenz; interaktive Swagger UI unter `/api/docs` zur Laufzeit |
 | [Manifestbeispiele](examples/manifests/) | Anpassbare `geolens.yaml`-Vorlagen: public-cog (entferntes COG), url-source, s3-source, publication-states |
-| [Client-Beispiele](https://github.com/geolens-io/geolens-examples) | Lauffähige Browser-, SDK-, Embed-, Python- und MCP-Beispiele, in der CI gegen die öffentliche Demo geprüft ([Galerie](https://geolens-io.github.io/geolens-examples/)) |
+| [Client-Beispiele](https://github.com/geolens-io/geolens-examples) | Lauffähige Browser-, QGIS-, DuckDB-, SDK-, CLI-, Embed-, Python- und MCP-Beispiele, in der CI gegen die öffentliche Demo geprüft ([Galerie](https://geolens-io.github.io/geolens-examples/)) |
 
 ## Community
 

--- a/README.de.md
+++ b/README.de.md
@@ -354,7 +354,7 @@ API und Worker exportieren sofort Prometheus-Metriken (HTTP-Rate/Latenz/Fehler, 
 | [CLI & Manifeste](https://docs.getgeolens.com/guides/cli/) | Dateien veröffentlichen und Kataloge mit `geolens` verwalten |
 | [API-Referenz](https://docs.getgeolens.com/guides/api/) | Automatisch erzeugte Referenz; interaktive Swagger UI unter `/api/docs` zur Laufzeit |
 | [Manifestbeispiele](examples/manifests/) | Anpassbare `geolens.yaml`-Vorlagen: public-cog (entferntes COG), url-source, s3-source, publication-states |
-| [Client-Beispiele](https://github.com/geolens-io/geolens-examples) | Lauffähige Browser-, QGIS-, DuckDB-, SDK-, CLI-, Embed-, Python- und MCP-Beispiele, in der CI gegen die öffentliche Demo geprüft ([Galerie](https://geolens-io.github.io/geolens-examples/)) |
+| [Client-Beispiele](https://github.com/geolens-io/geolens-examples) | Lauffähige Browser-, QGIS-, DuckDB-, SDK-, CLI-, Embed-, Python- und MCP-Beispiele; die rein lesenden werden in der CI gegen die öffentliche Demo geprüft ([Galerie](https://geolens-io.github.io/geolens-examples/)) |
 
 ## Community
 

--- a/README.es.md
+++ b/README.es.md
@@ -355,7 +355,7 @@ La API y el worker exportan métricas Prometheus de serie (tasa/latencia/errores
 | [CLI y manifiestos](https://docs.getgeolens.com/guides/cli/) | Publica archivos y gestiona catálogos con la CLI `geolens` |
 | [Referencia de la API](https://docs.getgeolens.com/guides/api/) | Referencia generada en docs.getgeolens.com; Swagger UI interactiva en `/api/docs` durante la ejecución |
 | [Ejemplos de manifiestos](examples/manifests/) | Plantillas `geolens.yaml` adaptables: public-cog (COG remoto), url-source, s3-source, publication-states |
-| [Ejemplos de clientes](https://github.com/geolens-io/geolens-examples) | Ejemplos ejecutables de navegador, QGIS, DuckDB, SDK, CLI, incrustación, Python y MCP, verificados en CI contra la demo pública ([galería](https://geolens-io.github.io/geolens-examples/)) |
+| [Ejemplos de clientes](https://github.com/geolens-io/geolens-examples) | Ejemplos ejecutables de navegador, QGIS, DuckDB, SDK, CLI, incrustación, Python y MCP; los de solo lectura se verifican en CI contra la demo pública ([galería](https://geolens-io.github.io/geolens-examples/)) |
 
 ## Comunidad
 

--- a/README.es.md
+++ b/README.es.md
@@ -107,7 +107,7 @@ PostGIS y pgvector comparten una única base de datos, de modo que, con la búsq
 
 Conecta directamente desde QGIS: **Capa > Añadir WFS / OGC API Features** y apunta a `http://localhost:8080/api/`.
 
-Los mismos endpoints desde una biblioteca de mapas: [geolens-examples](https://github.com/geolens-io/geolens-examples) reúne páginas de un solo archivo para MapLibre, Leaflet, OpenLayers y el SDK de ArcGIS, además de ambos SDK de GeoLens, un mapa guardado incrustado, un análisis en Python/GeoPandas y una configuración de MCP. Cada ejemplo se ejecuta contra la demo pública y CI los vuelve a ejecutar todos cada semana, así que lo que copias es código que funcionaba esta semana. [Explora la galería](https://geolens-io.github.io/geolens-examples/).
+Los mismos endpoints desde las herramientas que ya usas: [geolens-examples](https://github.com/geolens-io/geolens-examples) reúne páginas de un solo archivo para MapLibre, Leaflet, OpenLayers y el SDK de ArcGIS para JavaScript, guías de QGIS y DuckDB, ambos SDK de GeoLens, una búsqueda semántica del catálogo, un explorador STAC, un mapa guardado incrustado, un análisis en Python/GeoPandas, un manifiesto de catálogo como código para la CLI y una configuración de MCP. Los ejemplos de solo lectura se ejecutan directamente contra la demo pública y CI los vuelve a ejecutar allí en cada push y una vez por semana, así que lo que copias es código que funcionaba esta semana. [Explora la galería](https://geolens-io.github.io/geolens-examples/).
 
 ## Funciones
 
@@ -355,7 +355,7 @@ La API y el worker exportan métricas Prometheus de serie (tasa/latencia/errores
 | [CLI y manifiestos](https://docs.getgeolens.com/guides/cli/) | Publica archivos y gestiona catálogos con la CLI `geolens` |
 | [Referencia de la API](https://docs.getgeolens.com/guides/api/) | Referencia generada en docs.getgeolens.com; Swagger UI interactiva en `/api/docs` durante la ejecución |
 | [Ejemplos de manifiestos](examples/manifests/) | Plantillas `geolens.yaml` adaptables: public-cog (COG remoto), url-source, s3-source, publication-states |
-| [Ejemplos de clientes](https://github.com/geolens-io/geolens-examples) | Ejemplos ejecutables de navegador, SDK, incrustación, Python y MCP, verificados en CI contra la demo pública ([galería](https://geolens-io.github.io/geolens-examples/)) |
+| [Ejemplos de clientes](https://github.com/geolens-io/geolens-examples) | Ejemplos ejecutables de navegador, QGIS, DuckDB, SDK, CLI, incrustación, Python y MCP, verificados en CI contra la demo pública ([galería](https://geolens-io.github.io/geolens-examples/)) |
 
 ## Comunidad
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -106,7 +106,7 @@ PostGIS et pgvector partagent une base de données. Lorsque la recherche sémant
 
 Connectez-vous directement depuis QGIS : **Couche > Ajouter une couche WFS / OGC API Features** et indiquez `http://localhost:8080/api/`.
 
-Les mêmes points de terminaison depuis une bibliothèque cartographique : [geolens-examples](https://github.com/geolens-io/geolens-examples) rassemble des pages d’un seul fichier pour MapLibre, Leaflet, OpenLayers et le SDK ArcGIS, ainsi que les deux SDK GeoLens, une carte enregistrée intégrée, une analyse Python/GeoPandas et une configuration MCP. Chaque exemple s’exécute sur la démo publique, et la CI les rejoue tous chaque semaine : ce que vous copiez est donc du code qui fonctionnait cette semaine. [Parcourir la galerie](https://geolens-io.github.io/geolens-examples/).
+Les mêmes points de terminaison depuis les outils que vous utilisez déjà : [geolens-examples](https://github.com/geolens-io/geolens-examples) rassemble des pages d’un seul fichier pour MapLibre, Leaflet, OpenLayers et le SDK JavaScript ArcGIS, des guides QGIS et DuckDB, les deux SDK GeoLens, une recherche sémantique dans le catalogue, un navigateur STAC, une carte enregistrée intégrée, une analyse Python/GeoPandas, un manifeste de catalogue pour la CLI et une configuration MCP. Les exemples en lecture seule s’exécutent directement sur la démo publique, et la CI les y rejoue à chaque push et une fois par semaine : ce que vous copiez est donc du code qui fonctionnait cette semaine. [Parcourir la galerie](https://geolens-io.github.io/geolens-examples/).
 
 ## Fonctionnalités
 
@@ -354,7 +354,7 @@ L’API et le worker exportent nativement des métriques Prometheus (taux/latenc
 | [CLI et manifestes](https://docs.getgeolens.com/guides/cli/) | Publication de fichiers et gestion des catalogues avec la CLI `geolens` |
 | [Référence API](https://docs.getgeolens.com/guides/api/) | Référence générée sur docs.getgeolens.com ; Swagger UI interactive sur `/api/docs` à l’exécution |
 | [Exemples de manifestes](examples/manifests/) | Modèles `geolens.yaml` : public-cog (COG distant), url-source, s3-source, publication-states |
-| [Exemples clients](https://github.com/geolens-io/geolens-examples) | Exemples exécutables navigateur, SDK, intégration, Python et MCP, vérifiés par la CI sur la démo publique ([galerie](https://geolens-io.github.io/geolens-examples/)) |
+| [Exemples clients](https://github.com/geolens-io/geolens-examples) | Exemples exécutables navigateur, QGIS, DuckDB, SDK, CLI, intégration, Python et MCP, vérifiés par la CI sur la démo publique ([galerie](https://geolens-io.github.io/geolens-examples/)) |
 
 ## Communauté
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -354,7 +354,7 @@ L’API et le worker exportent nativement des métriques Prometheus (taux/latenc
 | [CLI et manifestes](https://docs.getgeolens.com/guides/cli/) | Publication de fichiers et gestion des catalogues avec la CLI `geolens` |
 | [Référence API](https://docs.getgeolens.com/guides/api/) | Référence générée sur docs.getgeolens.com ; Swagger UI interactive sur `/api/docs` à l’exécution |
 | [Exemples de manifestes](examples/manifests/) | Modèles `geolens.yaml` : public-cog (COG distant), url-source, s3-source, publication-states |
-| [Exemples clients](https://github.com/geolens-io/geolens-examples) | Exemples exécutables navigateur, QGIS, DuckDB, SDK, CLI, intégration, Python et MCP, vérifiés par la CI sur la démo publique ([galerie](https://geolens-io.github.io/geolens-examples/)) |
+| [Exemples clients](https://github.com/geolens-io/geolens-examples) | Exemples exécutables navigateur, QGIS, DuckDB, SDK, CLI, intégration, Python et MCP ; ceux en lecture seule sont vérifiés par la CI sur la démo publique ([galerie](https://geolens-io.github.io/geolens-examples/)) |
 
 ## Communauté
 

--- a/README.md
+++ b/README.md
@@ -417,7 +417,7 @@ see [RUNBOOK.md §4](RUNBOOK.md#4-monitoring) for the setup steps.
 | [CLI & Manifests](https://docs.getgeolens.com/guides/cli/) | Publish files and manage catalogs with the `geolens` CLI |
 | [API Reference](https://docs.getgeolens.com/guides/api/) | Auto-generated reference at docs.getgeolens.com; interactive Swagger UI at `/api/docs` when running |
 | [Manifest examples](examples/manifests/) | Template `geolens.yaml` manifests to adapt: public-cog (remote COG), url-source, s3-source, publication-states |
-| [Client examples](https://github.com/geolens-io/geolens-examples) | Runnable browser, QGIS, DuckDB, SDK, CLI, embed, Python, and MCP examples, verified against the live demo in CI ([gallery](https://geolens-io.github.io/geolens-examples/)) |
+| [Client examples](https://github.com/geolens-io/geolens-examples) | Runnable browser, QGIS, DuckDB, SDK, CLI, embed, Python, and MCP examples; the read-only ones are verified against the live demo in CI ([gallery](https://geolens-io.github.io/geolens-examples/)) |
 
 ## Community
 

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ PostGIS and pgvector share one database, so with semantic search enabled you can
 
 Connect directly from QGIS: **Layer > Add WFS / OGC API Features** and point at `http://localhost:8080/api/`.
 
-The same endpoints from a map library: [geolens-examples](https://github.com/geolens-io/geolens-examples) holds single-file MapLibre, Leaflet, OpenLayers, and ArcGIS SDK pages, plus both GeoLens SDKs, a saved-map embed, a Python/GeoPandas analysis, and an MCP setup. Each one runs against the live demo, and CI re-runs them all against it weekly, so what you copy is code that worked this week. [Browse the gallery](https://geolens-io.github.io/geolens-examples/).
+The same endpoints from the tools you already use: [geolens-examples](https://github.com/geolens-io/geolens-examples) holds single-file MapLibre, Leaflet, OpenLayers and ArcGIS JS pages, QGIS and DuckDB walkthroughs, both GeoLens SDKs, a semantic catalog search, a STAC browser, a saved-map embed, a Python/GeoPandas analysis, a catalog-as-code manifest for the CLI, and an MCP setup. The read-only ones run against the live demo, and CI replays them there on every push and once a week, so what you copy is code that worked this week. [Browse the gallery](https://geolens-io.github.io/geolens-examples/).
 
 ## Features
 
@@ -417,7 +417,7 @@ see [RUNBOOK.md §4](RUNBOOK.md#4-monitoring) for the setup steps.
 | [CLI & Manifests](https://docs.getgeolens.com/guides/cli/) | Publish files and manage catalogs with the `geolens` CLI |
 | [API Reference](https://docs.getgeolens.com/guides/api/) | Auto-generated reference at docs.getgeolens.com; interactive Swagger UI at `/api/docs` when running |
 | [Manifest examples](examples/manifests/) | Template `geolens.yaml` manifests to adapt: public-cog (remote COG), url-source, s3-source, publication-states |
-| [Client examples](https://github.com/geolens-io/geolens-examples) | Runnable browser, SDK, embed, Python, and MCP examples, verified against the live demo in CI ([gallery](https://geolens-io.github.io/geolens-examples/)) |
+| [Client examples](https://github.com/geolens-io/geolens-examples) | Runnable browser, QGIS, DuckDB, SDK, CLI, embed, Python, and MCP examples, verified against the live demo in CI ([gallery](https://geolens-io.github.io/geolens-examples/)) |
 
 ## Community
 


### PR DESCRIPTION
The geolens-examples paragraph and the "Client examples" table row still described the repo as it stood before it grew a QGIS project, a DuckDB script, a semantic catalog search page, a STAC browser and a catalog-as-code manifest for the CLI.

Both sites now list what the Examples table in that repo's README actually holds today, checked against the live file rather than against the issue text. All four locales change at the same two places and nowhere else.

The English paragraph also drops the blanket claim that each example runs against the live demo. The CLI example publishes to a catalog, so it needs your own instance and a credential.

Verified: `pre-commit run --files` on the four READMEs (exit 0), `node scripts/check-readme-locales.mjs` (locale coverage OK), and both URLs in the changed lines return 200.

Closes #1608
