### PR TITLE
ci(release): dispatch geolens-release to geolens-examples too

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,6 +196,12 @@ jobs:
               # must run on PRs that touch it — otherwise CI-config changes ship
               # unvalidated by the very tests they configure.
               - '.github/workflows/ci.yml'
+              # fix(#1609): test_release_dispatch_targets_1609.py reads
+              # release.yml by literal path and asserts both downstream
+              # dispatches (the site and geolens-examples) stay wired and
+              # independent. Without this, a release.yml-only PR skips the
+              # only suite that would notice one of them going away.
+              - '.github/workflows/release.yml'
             frontend:
               - 'frontend/**'
               - 'backend/openapi.json'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -175,7 +175,12 @@ jobs:
       # CI-1 (see geolens-io/getgeolens.com#108): the site repo listens for
       # this dispatch to run release-drift immediately and to open its
       # docs-contract sync PR (getgeolens.com#108, release-sync.yml).
-      - name: Notify the site of the release
+      # #1609: geolens-examples listens for the same event. It pins every
+      # published client (geolens, @geolens/sdk, geolens-mcp, geolens-cli)
+      # to one version across a dozen files, and otherwise hears about a
+      # release only from a weekly ci/check-pins.py line that warns and
+      # passes. On this event it opens a "bump the pins and re-sweep" issue.
+      - name: Notify the site and the examples repo of the release
         # Only GA tags (no `-` suffix) dispatch — same shape as the
         # IS_PRERELEASE case pattern in "Create release" above. A prerelease
         # never becomes the "latest" release the site's install one-liner and
@@ -191,57 +196,92 @@ jobs:
         # this" behavior visible instead of silent.
         if: ${{ !contains(env.TAG, '-') }}
         env:
-          # Two different tokens for two different targets: reading THIS
-          # repo's latest release needs only the default GITHUB_TOKEN;
-          # dispatching to getgeolens.com needs a PAT scoped there
-          # (SITE_DISPATCH_TOKEN has no read access here, and the default
-          # token has no access there). Fine-grained PAT, Contents:
-          # read/write on geolens-io/getgeolens.com; absent = skipped with
-          # a ::notice::.
+          # Three tokens for three jobs: reading THIS repo's latest release
+          # needs only the default GITHUB_TOKEN, and each dispatch target
+          # needs a PAT scoped to that target (neither dispatch token has
+          # read access here, and the default token has access to neither
+          # target). Fine-grained PATs, Contents: read/write on
+          # geolens-io/getgeolens.com and on geolens-io/geolens-examples
+          # respectively; absent = skipped with a ::notice::.
+          #
+          # EXAMPLES_DISPATCH_TOKEN falls back to SITE_DISPATCH_TOKEN, so one
+          # PAT scoped to both targets is enough and two separate ones also
+          # work. Only the fallback direction exists: a token scoped to the
+          # examples repo must never be tried against the site, because a
+          # dispatch that 404s is indistinguishable here from a site outage.
           DEFAULT_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SITE_DISPATCH_TOKEN: ${{ secrets.SITE_DISPATCH_TOKEN }}
+          EXAMPLES_DISPATCH_TOKEN: ${{ secrets.EXAMPLES_DISPATCH_TOKEN }}
         # The release is already published by this point in the job. A failed
-        # dispatch must never fail the release on the site repo's account —
+        # dispatch must never fail the release on a downstream repo's account —
         # worst case, the site's own nightly release-drift check catches the
-        # gap and the manual sync step still exists as a fallback.
+        # gap, the examples repo's weekly pin check warns, and the manual sync
+        # step still exists as a fallback for both.
         continue-on-error: true
         timeout-minutes: 5
         run: |
           # A small heading so these lines read as their own section in the
           # job summary rather than trailing off the "Generate release
-          # notes" step's own ### warning block above them.
+          # notes" step's own ### warning block above them. Written once
+          # however many targets report, so two dispatches produce one
+          # section with two rows rather than two one-row sections.
+          heading_written=
           summary() {
-            { echo "### Site dispatch"; echo "- $1"; } >> "$GITHUB_STEP_SUMMARY"
+            if [ -z "$heading_written" ]; then
+              echo "### Release dispatches" >> "$GITHUB_STEP_SUMMARY"
+              heading_written=1
+            fi
+            echo "- $1" >> "$GITHUB_STEP_SUMMARY"
           }
 
           # prod-smoke.yml runs tag smokes in parallel and this workflow has
           # no concurrency group, so an older tag's smoke can finish after a
           # newer one's (or a re-run replays an old tag's smoke) and reach
           # this step after a newer release already published. Dispatching
-          # then would tell the site to sync backwards. Only the actual
-          # latest release may dispatch.
+          # then would tell the downstream repos to sync backwards. Only the
+          # actual latest release may dispatch.
           if ! LATEST="$(GH_TOKEN="$DEFAULT_TOKEN" gh api "repos/${GITHUB_REPOSITORY}/releases/latest" --jq .tag_name)"; then
-            echo "::warning title=Site dispatch failed::Could not read the latest release for ${TAG}, so the site dispatch did not run."
+            echo "::warning title=Release dispatch failed::Could not read the latest release for ${TAG}, so no release dispatch ran."
             summary "FAILED for ${TAG} (could not read the latest release)"
             exit 1
           fi
           if [ "$LATEST" != "$TAG" ]; then
-            echo "::notice title=Not the latest release::Skipping the site dispatch for ${TAG} — the latest published release is ${LATEST}. A newer tag's smoke likely finished first, or this is a re-run of an older tag."
+            echo "::notice title=Not the latest release::Skipping the release dispatches for ${TAG} — the latest published release is ${LATEST}. A newer tag's smoke likely finished first, or this is a re-run of an older tag."
             summary "skipped, ${TAG} is not the latest release (${LATEST} is)"
             exit 0
           fi
 
+          # Each target is reported on its own and NEITHER short-circuits the
+          # other: a site outage must not cost the examples repo its release
+          # notification, and vice versa. So the failures below set a flag and
+          # the step exits on it once, at the end, after both have been tried.
+          failed=0
+
           if [ -z "$SITE_DISPATCH_TOKEN" ]; then
             echo "::notice title=Site not notified::SITE_DISPATCH_TOKEN is not configured, so ${TAG} was not dispatched to getgeolens.com. Add it as a fine-grained PAT with Contents: read/write on geolens-io/getgeolens.com to enable this."
-            summary "skipped (no SITE_DISPATCH_TOKEN)"
-            exit 0
-          fi
-
-          if ! GH_TOKEN="$SITE_DISPATCH_TOKEN" gh api repos/geolens-io/getgeolens.com/dispatches \
+            summary "site: skipped (no SITE_DISPATCH_TOKEN)"
+          elif GH_TOKEN="$SITE_DISPATCH_TOKEN" gh api repos/geolens-io/getgeolens.com/dispatches \
             -f event_type=geolens-release \
             -f "client_payload[version]=${TAG}"; then
+            summary "site: notified getgeolens.com of ${TAG}"
+          else
             echo "::warning title=Site dispatch failed::Could not notify geolens-io/getgeolens.com of release ${TAG}. The GeoLens release itself published fine; the site will pick up the contract sync on its next scheduled release-drift check instead."
-            summary "FAILED for ${TAG} (see the warning above)"
-            exit 1
+            summary "site: FAILED for ${TAG} (see the warning above)"
+            failed=1
           fi
-          summary "notified getgeolens.com of ${TAG}"
+
+          EXAMPLES_TOKEN="${EXAMPLES_DISPATCH_TOKEN:-$SITE_DISPATCH_TOKEN}"
+          if [ -z "$EXAMPLES_TOKEN" ]; then
+            echo "::notice title=Examples repo not notified::Neither EXAMPLES_DISPATCH_TOKEN nor SITE_DISPATCH_TOKEN is configured, so ${TAG} was not dispatched to geolens-examples. Add either as a fine-grained PAT with Contents: read/write on geolens-io/geolens-examples to enable this."
+            summary "examples: skipped (no EXAMPLES_DISPATCH_TOKEN or SITE_DISPATCH_TOKEN)"
+          elif GH_TOKEN="$EXAMPLES_TOKEN" gh api repos/geolens-io/geolens-examples/dispatches \
+            -f event_type=geolens-release \
+            -f "client_payload[version]=${TAG}"; then
+            summary "examples: notified geolens-examples of ${TAG}"
+          else
+            echo "::warning title=Examples dispatch failed::Could not notify geolens-io/geolens-examples of release ${TAG}. The GeoLens release itself published fine; the examples repo's weekly ci/check-pins.py run will still warn that the demo has moved past its pins."
+            summary "examples: FAILED for ${TAG} (see the warning above)"
+            failed=1
+          fi
+
+          exit "$failed"

--- a/backend/tests/test_release_dispatch_targets_1609.py
+++ b/backend/tests/test_release_dispatch_targets_1609.py
@@ -1,0 +1,234 @@
+"""#1609: a GA release must notify BOTH downstream repos, not just the site.
+
+``.github/workflows/release.yml`` sends a ``geolens-release`` repository
+dispatch so downstream repos can react to a release the moment it publishes.
+``geolens-io/getgeolens.com`` has listened for it since getgeolens.com#108;
+``geolens-io/geolens-examples`` pins every published client (``geolens``,
+``@geolens/sdk``, ``geolens-mcp``, ``geolens-cli``) to one version across a
+dozen files, and before #1609 learned about a release only from a weekly
+``ci/check-pins.py`` log line that warns and passes.
+
+Both dispatches live in ONE step, which is what makes this worth a test. The
+failure mode is not "the examples dispatch was never written" — it is a later
+edit quietly re-coupling the two targets, so a site outage takes the examples
+notification down with it (or the reverse). Hence the assertions below cover
+the shape as much as the endpoints: two independent token names with a
+documented fallback, and the step still marked ``continue-on-error`` and
+still gated to GA tags.
+
+Reads the workflow off disk and parses it as YAML. No database, no network.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+from typing import Any
+
+import yaml
+
+REPO_ROOT = pathlib.Path(__file__).parent.parent.parent
+RELEASE_YML = REPO_ROOT / ".github" / "workflows" / "release.yml"
+CI_YML = REPO_ROOT / ".github" / "workflows" / "ci.yml"
+
+STEP_NAME_MARKER = "Notify the site"
+
+SITE_DISPATCH_API = "repos/geolens-io/getgeolens.com/dispatches"
+EXAMPLES_DISPATCH_API = "repos/geolens-io/geolens-examples/dispatches"
+
+
+def _dispatch_step() -> dict[str, Any]:
+    """The single step in release.yml that sends the release dispatches.
+
+    Matched on a prefix of its name rather than the whole string, so renaming
+    it to cover a new target does not silently stop this test from finding it
+    (an assertion that cannot locate its subject passes vacuously).
+    """
+    workflow: dict[str, Any] = yaml.safe_load(RELEASE_YML.read_text(encoding="utf-8"))
+
+    matches = [
+        step
+        for job in workflow.get("jobs", {}).values()
+        for step in job.get("steps", [])
+        if STEP_NAME_MARKER in str(step.get("name", ""))
+    ]
+    assert len(matches) == 1, (
+        f"Expected exactly one step in {RELEASE_YML.name} whose name contains "
+        f"{STEP_NAME_MARKER!r}; found {len(matches)}: "
+        f"{[step.get('name') for step in matches]}"
+    )
+    return matches[0]
+
+
+def _run_text() -> str:
+    return str(_dispatch_step().get("run", ""))
+
+
+class TestBothDispatchTargets:
+    """Both downstream repos get the same event from the same step."""
+
+    def test_site_is_dispatched(self):
+        assert SITE_DISPATCH_API in _run_text(), (
+            f"The release step no longer dispatches to {SITE_DISPATCH_API}. "
+            "getgeolens.com's release-sync.yml (getgeolens.com#108) is driven "
+            "by this call."
+        )
+
+    def test_examples_repo_is_dispatched(self):
+        assert EXAMPLES_DISPATCH_API in _run_text(), (
+            f"The release step does not dispatch to {EXAMPLES_DISPATCH_API}. "
+            "#1609: geolens-examples pins every client to one version and has "
+            "no other prompt to bump them."
+        )
+
+    def test_both_targets_get_the_geolens_release_event(self):
+        """One ``event_type=geolens-release`` per target, not one shared call."""
+        run = _run_text()
+        events = re.findall(r"event_type=geolens-release", run)
+        assert len(events) == 2, (
+            "Expected exactly two `event_type=geolens-release` dispatches (the "
+            f"site and the examples repo); found {len(events)}."
+        )
+
+    def test_both_targets_get_the_tag_as_the_payload_version(self):
+        run = _run_text()
+        payloads = re.findall(r"client_payload\[version\]=\$\{TAG\}", run)
+        assert len(payloads) == 2, (
+            "Both dispatches must carry the released tag as "
+            "`client_payload[version]=${TAG}`; found "
+            f"{len(payloads)} occurrence(s)."
+        )
+
+
+class TestDispatchTokens:
+    """Two token names, with the examples target falling back to the site's."""
+
+    def test_both_token_names_are_wired_into_the_step_env(self):
+        env = _dispatch_step().get("env", {})
+        for name in ("SITE_DISPATCH_TOKEN", "EXAMPLES_DISPATCH_TOKEN"):
+            assert name in env, (
+                f"{name} is not in the dispatch step's env, so the secret never "
+                f"reaches the run script. env keys: {sorted(env)}"
+            )
+            assert f"secrets.{name}" in str(env[name]), (
+                f"{name} must be read from `secrets.{name}`; got {env[name]!r}."
+            )
+
+    def test_examples_token_falls_back_to_the_site_token(self):
+        """One PAT scoped to both repos must be enough to wire this up.
+
+        Asserted as the fallback expression rather than as "the examples
+        dispatch succeeds", because the alternative — requiring a second
+        secret — is a silently skipped dispatch, not a red build.
+        """
+        assert "${EXAMPLES_DISPATCH_TOKEN:-$SITE_DISPATCH_TOKEN}" in _run_text(), (
+            "The examples dispatch must fall back to SITE_DISPATCH_TOKEN when "
+            "EXAMPLES_DISPATCH_TOKEN is unset, so a single PAT scoped to both "
+            "target repos works without a second secret."
+        )
+
+    def test_each_target_reports_its_own_missing_token(self):
+        """A missing secret is a visible ::notice::, per target, never a skip."""
+        run = _run_text()
+        notices = re.findall(r"::notice title=[^:]*not notified::", run)
+        assert len(notices) == 2, (
+            "Each target needs its own ::notice:: for the no-token case, so a "
+            "PAT that is scoped to only one of them is legible in the run log; "
+            f"found {len(notices)}."
+        )
+
+
+class TestFailureIsolation:
+    """Neither target's result may mask the other's."""
+
+    def test_the_step_never_fails_the_release(self):
+        step = _dispatch_step()
+        assert step.get("continue-on-error") is True, (
+            "The dispatch step must stay `continue-on-error: true`. The release "
+            "is already published by the time it runs; a downstream repo being "
+            "unreachable must never turn a shipped release red."
+        )
+
+    def test_a_failure_flag_is_collected_rather_than_exited_on(self):
+        """The site dispatch must not `exit 1` before the examples one runs.
+
+        The whole point of #1609 is that the examples repo hears about every
+        release. An early exit on the site's failure would make that
+        conditional on the site being reachable.
+        """
+        run = _run_text()
+        site_at = run.index(SITE_DISPATCH_API)
+        examples_at = run.index(EXAMPLES_DISPATCH_API)
+        assert site_at < examples_at, (
+            "Expected the site dispatch before the examples dispatch in the run script."
+        )
+        between = run[site_at:examples_at]
+        assert "exit 1" not in between, (
+            "There is an `exit 1` between the two dispatches: a site failure "
+            "would abort the step before the examples repo is notified. "
+            "Collect a failure flag and exit non-zero after both have run."
+        )
+        assert re.search(r"^\s*exit \"?\$\{?failed\}?\"?\s*$", run, re.MULTILINE), (
+            "The run script must end by exiting on the collected failure flag, "
+            "so a failed dispatch is still reported (under continue-on-error) "
+            "rather than swallowed."
+        )
+
+    def test_each_target_has_its_own_failure_warning(self):
+        run = _run_text()
+        warnings = re.findall(r"::warning title=[^:]*dispatch failed::", run)
+        assert len(warnings) >= 2, (
+            "Each target needs its own ::warning:: on failure, or one repo's "
+            f"outage reads as the other's; found {len(warnings)}."
+        )
+
+
+class TestUnchangedGuards:
+    """#1609 must not loosen what already gated this step."""
+
+    def test_only_ga_tags_dispatch(self):
+        condition = str(_dispatch_step().get("if", ""))
+        assert "!contains(env.TAG, '-')" in condition, (
+            "The GA-only guard is gone. A prerelease never becomes the `latest` "
+            f"release downstream repos follow. Current if: {condition!r}"
+        )
+
+    def test_only_the_latest_release_dispatches(self):
+        """The stale-tag guard: an older tag's smoke must not sync backwards."""
+        run = _run_text()
+        assert "releases/latest" in run and '"$LATEST" != "$TAG"' in run, (
+            "The latest-release guard is gone. prod-smoke.yml runs tag smokes "
+            "in parallel with no concurrency group, so an older tag can reach "
+            "this step after a newer release published."
+        )
+
+    def test_the_step_caps_its_own_runtime(self):
+        assert _dispatch_step().get("timeout-minutes") == 5, (
+            "The dispatch step must keep its own timeout-minutes; two network "
+            "calls to two repos are two chances to hang."
+        )
+
+
+class TestBackendFilterCoversThisWorkflow:
+    """This file is only a gate on PRs that actually run the backend suite."""
+
+    def test_release_yml_triggers_backend_tests(self):
+        """A release.yml-only PR must run Backend Tests.
+
+        Same class as fix(#561), fix(#1088) and fix(#1517) in ci.yml: a backend
+        test that reads a file by literal path is dead weight unless changing
+        that file turns the suite on.
+        """
+        ci: dict[str, Any] = yaml.safe_load(CI_YML.read_text(encoding="utf-8"))
+        filter_step = next(
+            step
+            for step in ci["jobs"]["changes"]["steps"]
+            if "dorny/paths-filter" in str(step.get("uses", ""))
+        )
+        filters: dict[str, list[str]] = yaml.safe_load(filter_step["with"]["filters"])
+        backend_globs = filters.get("backend", [])
+        assert ".github/workflows/release.yml" in backend_globs, (
+            "'.github/workflows/release.yml' is not in ci.yml's backend "
+            "paths-filter, so a PR editing only that workflow skips the suite "
+            "holding this file's assertions. Backend globs: {}".format(backend_globs)
+        )


### PR DESCRIPTION
`.github/workflows/release.yml` dispatches `geolens-release` to `geolens-io/getgeolens.com` when a GA tag publishes. The same step now also dispatches it to `geolens-io/geolens-examples`, carrying the same `client_payload[version]`.

## Why

`geolens-examples` pins `geolens`, `@geolens/sdk`, `geolens-mcp` and `geolens-cli` to one version across sixteen files, and replays every example against the demo, which is redeployed from the release. Its only signal that a release had happened was `ci/check-pins.py` on the weekly schedule printing `WARNING: the demo runs X, this repo pins Y` and exiting 0. A warning that passes is a task nobody is assigned.

## Tokens

`EXAMPLES_DISPATCH_TOKEN` when it is set, `SITE_DISPATCH_TOKEN` otherwise. So one fine-grained PAT with Contents: read/write on both target repos is enough, and two separate secrets work just as well.

The fallback runs one way only. An examples-scoped token is never tried against the site, because a dispatch that 404s on a scope problem is indistinguishable, from inside this step, from the site being down.

Neither secret is required. With neither configured the step logs two `::notice::` lines and passes. That case stays inside the run script rather than in the step's `if:` on purpose: a skipped step is a grey row nobody reads, which is how a missing token would go unnoticed indefinitely. This file already learned that once, in #1530.

## Failure isolation

The two dispatches cannot mask each other. A failure sets a flag instead of exiting, both targets are attempted on every run, and the step exits non-zero once at the end. `continue-on-error: true` stays, so a downstream repo being unreachable never turns an already-published release red.

Each target gets its own `::notice::` for a missing token, its own `::warning::` on failure, and its own row in the job summary. The heading is now "Release dispatches" and is written once however many rows follow, rather than repeating above each line.

The GA-only `if:` and the latest-release guard are untouched.

## Tests

`backend/tests/test_release_dispatch_targets_1609.py` parses the workflow and asserts both dispatch URLs, one `event_type=geolens-release` and one `client_payload[version]=${TAG}` per target, both token env names, the fallback expression, that no `exit 1` sits between the two dispatches, `continue-on-error: true`, `timeout-minutes`, and both guards.

It pins the shape rather than only the new endpoint, because the regression worth catching is a later edit re-coupling the two targets, not the examples dispatch never having been written in the first place.

Red first, against `main`'s `release.yml`:

```
8 failed, 6 passed in 9.91s
```

The 6 that passed are the site-dispatch and unchanged-guard assertions, which already held. Green on this branch: `14 passed`.

`.github/workflows/release.yml` is also added to `ci.yml`'s `backend` paths-filter. Without it a release.yml-only PR skips Backend Tests, and the test file above becomes a gate that cannot run on the change it exists to catch. Same class as fix(#561), fix(#1088) and fix(#1517) already in that filter.

## Behaviour, not just shape

The structural test asserts the script's text. To check it actually behaves, the step's `run:` was extracted and executed under `bash -e -o pipefail` against a stubbed `gh`:

| scenario | site | examples | exit |
| --- | --- | --- | --- |
| both tokens, both succeed | dispatched | dispatched | 0 |
| site dispatch fails | warning | still dispatched | 1 |
| examples dispatch fails | dispatched | warning | 1 |
| both fail | warning | warning | 1 |
| only `SITE_DISPATCH_TOKEN` set | dispatched | dispatched via fallback | 0 |
| only `EXAMPLES_DISPATCH_TOKEN` set | notice, skipped | dispatched | 0 |
| neither token set | notice, skipped | notice, skipped | 0 |
| tag is not the latest release | not attempted | not attempted | 0 |

Row two is the one that matters: before this change a site failure `exit 1`d out of the step, so the examples repo would never have been told.

The job summary comes out as one `### Release dispatches` section with one row per target in every case.

## Verification

- `actionlint .github/workflows/release.yml`: one SC2016 info at line 66, byte-identical to the finding on `main` (the new step adds none)
- `actionlint .github/workflows/ci.yml`: 8 findings, the same 8 as on `main`
- `pre-commit run --files .github/workflows/release.yml .github/workflows/ci.yml backend/tests/test_release_dispatch_targets_1609.py`: all hooks pass
- `uv run pytest tests/test_release_dispatch_targets_1609.py tests/test_ci_alembic_filter_paths.py tests/test_layering.py -q`: 70 passed
- `uv run ruff check` and `ruff format --check` on the new test: clean

Not verified: the dispatch itself, which only fires on a real GA tag. The `EXAMPLES_DISPATCH_TOKEN` secret does not exist yet, so until it is added (or `SITE_DISPATCH_TOKEN` is rescoped to cover both repos) the examples half logs its `::notice::` and skips.

## Receiver

geolens-io/geolens-examples#34 adds the workflow that listens for this event and opens the pin-bump issue. That side is inert until this one lands.

Closes #1609
