### PR TITLE
fix(seed): pin the showcase maps and the meteorites dataset the examples load

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,6 +156,12 @@ jobs:
               # script would otherwise skip Backend Tests and never run the
               # assertion that says whether it still works.
               - 'scripts/fix_sdk_optional_body.py'
+              # fix(#1607): test_seed_showcase_pins_1607.py imports this seeder
+              # and walks its AST to prove every builder routes its map-exists
+              # check through _keep_existing_map, so the maps geolens-examples
+              # links by UUID survive --force. A seeder-only PR that skipped
+              # Backend Tests would drop the pin with the gate showing green.
+              - 'scripts/seed-showcase.py'
               - '.gitignore'
               # Frontend files that backend parity/drift tests read by literal
               # path (fe-sdk type drift, basemap/capability/paint-key drift,

--- a/backend/tests/test_seed_showcase_pins_1607.py
+++ b/backend/tests/test_seed_showcase_pins_1607.py
@@ -416,3 +416,153 @@ def test_prune_keeps_a_pinned_name_that_also_appears_in_a_retired_list(monkeypat
 
     assert api.deleted_maps == ["m-retired"]
     assert api.deleted_datasets == [retired_dataset]
+
+
+# --- the Sentinel in-place repair (#1607 review r2) ---------------------------
+
+
+class _LayerApi:
+    """Just the surface _replace_map_layers touches, with a call log."""
+
+    def __init__(self, layers):
+        self._layers = list(layers)
+        self.deleted = []
+        self.added = []
+        self.deleted_maps = []
+
+    def get_map(self, map_id):
+        return {"id": map_id, "layers": self._layers}
+
+    def delete_layer(self, map_id, layer_id):
+        self.deleted.append(layer_id)
+
+    def add_layer(self, map_id, body):
+        self.added.append(body)
+
+    def delete_map(self, map_id):  # pragma: no cover - must never be called
+        self.deleted_maps.append(map_id)
+
+
+def test_replace_map_layers_swaps_the_stack_and_keeps_the_row():
+    api = _LayerApi([{"id": "l-old-1"}, {"id": "l-old-2"}])
+    fresh = [
+        {"dataset_id": "d1", "sort_order": 0},
+        {"dataset_id": "d2", "sort_order": 1},
+    ]
+
+    added = seeder._replace_map_layers(api, "m-pinned", fresh)
+
+    assert added == 2
+    assert api.deleted == ["l-old-1", "l-old-2"]
+    assert api.added == fresh
+    # The whole point: the map row is never touched, so its uuid and its share
+    # tokens survive the repair.
+    assert api.deleted_maps == []
+
+
+def test_replace_map_layers_handles_a_map_whose_layers_already_cascaded():
+    """Deleting the scene datasets takes their layers with them.
+
+    MapLayer.dataset_id is ON DELETE CASCADE, so by the time the repair gets
+    here the stack is usually already empty. The delete pass exists for the
+    layers that did NOT cascade - a scene kept because another map shares it.
+    """
+    api = _LayerApi([])
+    assert seeder._replace_map_layers(api, "m-pinned", [{"dataset_id": "d1"}]) == 1
+    assert api.deleted == []
+    assert api.added == [{"dataset_id": "d1"}]
+
+
+def test_sentinel2_does_not_return_on_a_pinned_keep():
+    """The pinned keep must not short-circuit the repair.
+
+    Every other builder returns straight out of the `_keep_existing_map` block.
+    build_sentinel2 has to fall through it, or `--only sentinel2 --force` -- the
+    documented repair for instances seeded before item_href -- is reachable
+    only via --force-pinned, which mints the new uuid the examples must not get.
+    """
+    body = _function_node(SOURCE, "build_sentinel2")
+    guard = next(
+        node
+        for node in ast.walk(body)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "_keep_existing_map"
+        and any(
+            isinstance(a, ast.Call)
+            and isinstance(a.func, ast.Name)
+            and a.func.id == "_map_exists"
+            for a in node.args
+        )
+    )
+    # The decision is bound to a name rather than used as a bare `if` test:
+    # the repair path needs it again further down to pick reuse over create.
+    assert isinstance(guard, ast.Call)
+    bindings = [
+        n
+        for n in ast.walk(body)
+        if isinstance(n, ast.Assign)
+        and any(
+            isinstance(t, ast.Name) and t.id == "keep_pinned_row" for t in n.targets
+        )
+    ]
+    assert bindings, "build_sentinel2 must keep the pin decision, not return on it"
+
+    # And it must reuse the row: a create_map call guarded by that decision,
+    # plus the in-place rebind.
+    called = {
+        n.func.id
+        for n in ast.walk(body)
+        if isinstance(n, ast.Call) and isinstance(n.func, ast.Name)
+    }
+    assert "_replace_map_layers" in called
+
+
+def test_only_sentinel2_replaces_layers_in_place():
+    """No other builder rebinds a stack; they create their maps outright."""
+    users = {
+        node.name
+        for node in ast.walk(ast.parse(SOURCE))
+        if isinstance(node, ast.FunctionDef)
+        and any(
+            isinstance(c, ast.Call)
+            and isinstance(c.func, ast.Name)
+            and c.func.id == "_replace_map_layers"
+            for c in ast.walk(node)
+        )
+    }
+    assert users == {"build_sentinel2"}
+
+
+# --- the outcome main() reports (#1607 review r2) -----------------------------
+
+
+def test_a_pinned_keep_returns_a_distinct_marker():
+    assert seeder._announce_kept_map(PINNED, force=True) == "(pinned)"
+    assert seeder._announce_kept_map(PINNED, force=False) == "(skipped)"
+
+
+def test_the_pinned_outcome_line_does_not_tell_you_to_use_force():
+    """--force is what already ran and declined; saying "use --force" is wrong."""
+    line = seeder._builder_outcome_line("sentinel2", "(pinned)")
+    assert line is not None
+    assert "--force-pinned" in line
+    assert "use --force to recreate" not in line
+
+
+def test_the_ordinary_skip_line_is_unchanged():
+    line = seeder._builder_outcome_line("manhattan", "(skipped)")
+    assert line == "  manhattan: already exists, skipped (use --force to recreate)"
+
+
+def test_a_falsy_result_still_reports_as_skipped():
+    assert seeder._builder_outcome_line("embed", None) is not None
+    assert seeder._builder_outcome_line("embed", "") is not None
+
+
+def test_a_map_id_reports_nothing_and_counts_as_built():
+    assert seeder._builder_outcome_line("manhattan", "dcae16bd-40bd") is None
+    # The two builders that return a sentinel of their own must keep counting
+    # as built, exactly as they did before the marker was added.
+    assert seeder._builder_outcome_line("catalog", "(catalog)") is None
+    assert seeder._builder_outcome_line("collections", "(none)") is None

--- a/backend/tests/test_seed_showcase_pins_1607.py
+++ b/backend/tests/test_seed_showcase_pins_1607.py
@@ -350,3 +350,67 @@ def test_force_pinned_without_force_is_refused():
     result = _run("--force-pinned", "--password", "unused")
     assert result.returncode == 2
     assert "--force-pinned is only meaningful with --force" in result.stderr
+
+
+# --- --prune ------------------------------------------------------------------
+
+
+class _PruneApi:
+    """Records what prune() would delete instead of deleting it."""
+
+    def __init__(self, maps, datasets):
+        self._maps = maps
+        self._datasets = datasets
+        self.deleted_maps = []
+        self.deleted_datasets = []
+
+    def list_maps(self):
+        return self._maps
+
+    def list_own_datasets(self):
+        return self._datasets
+
+    def collections_by_name(self):
+        return {}
+
+    def delete_map(self, map_id):
+        self.deleted_maps.append(map_id)
+
+    def delete_dataset(self, dataset_id, title):
+        self.deleted_datasets.append(title)
+
+
+def test_prune_keeps_a_pinned_name_that_also_appears_in_a_retired_list(monkeypatch):
+    """The two lists are meant to be disjoint; prune must not rely on that.
+
+    RETIRED_* is a plain list of names a future edit could collide with, and
+    prune deletes by name. So the collision is forced here rather than waiting
+    for someone to make it for real.
+    """
+    retired_map = "World Airports"
+    retired_dataset = "World Rivers - Casing"
+    assert retired_map in seeder.RETIRED_MAPS
+    assert retired_dataset in seeder.RETIRED_DATASETS
+
+    monkeypatch.setattr(seeder, "RETIRED_MAPS", [retired_map, PINNED])
+    monkeypatch.setattr(
+        seeder,
+        "RETIRED_DATASETS",
+        [retired_dataset, "Meteorite Landings (Meteoritical Society)"],
+    )
+    monkeypatch.setattr(seeder, "RETIRED_COLLECTIONS", [])
+
+    api = _PruneApi(
+        {retired_map: "m-retired", PINNED: "m-pinned"},
+        [
+            {"id": "d-retired", "title": retired_dataset},
+            {
+                "id": "d-pinned",
+                "title": "Meteorite Landings (Meteoritical Society)",
+            },
+        ],
+    )
+    seeder.prune(api)
+
+    assert api.deleted_maps == ["m-retired"]
+    assert api.deleted_datasets == [retired_dataset]

--- a/backend/tests/test_seed_showcase_pins_1607.py
+++ b/backend/tests/test_seed_showcase_pins_1607.py
@@ -1,0 +1,352 @@
+"""fix(#1607): the showcase content geolens-examples addresses by id stays put.
+
+The examples repo hardcodes demo fixtures: `ci/fixtures.json` names the
+meteorites dataset (viewport paging, the vector-tile handoff, a search phrase)
+and the Restless Earth share token, and the gallery in `index.html` deep-links
+three showcase maps by UUID. None of that is visible from inside this repo -
+the only signal today is the examples' own preflight going red after the fact.
+
+So the seeder pins them, and these tests hold the pin in place:
+
+* the pin tuples still name what the examples load;
+* `_keep_existing_map` decides the same way for every builder;
+* EVERY builder's exists-check goes through that one function, so a builder
+  added later cannot re-invent the bare `not force and _map_exists(...)` shape
+  and quietly drop a pinned map's uuid on the floor;
+* `--prune-userdata`'s classifier hard-keeps a pinned map whoever owns it.
+
+Pure static analysis plus one fake-API unit - no database, no HTTP, no docker.
+"""
+
+from __future__ import annotations
+
+import ast
+import importlib.util
+import subprocess
+import sys
+
+import pytest
+
+from tests.repo_paths import repo_root
+
+SCRIPT_PATH = repo_root(__file__) / "scripts" / "seed-showcase.py"
+
+
+def _load_seeder():
+    """Import scripts/seed-showcase.py as a module without running main().
+
+    The filename is not an identifier (hyphen), so the plain `from scripts.X
+    import ...` other seeder tests use is unavailable here. main() is guarded
+    by __main__, so exec_module only evaluates constants and defs.
+    """
+    spec = importlib.util.spec_from_file_location("seed_showcase_1607", SCRIPT_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+seeder = _load_seeder()
+SOURCE = SCRIPT_PATH.read_text(encoding="utf-8")
+
+
+# --- the pin lists themselves -------------------------------------------------
+
+
+def test_pinned_dataset_titles_name_every_externally_referenced_dataset():
+    assert seeder.PINNED_DATASET_TITLES == (
+        "NYC Subway Lines (MTA)",
+        "NYC Subway Stations (MTA)",
+        "swissALTI3D Matterhorn DEM (2m mosaic)",
+        # geolens-examples ci/fixtures.json -> fixtures.meteorites
+        "Meteorite Landings (Meteoritical Society)",
+    )
+
+
+def test_pinned_map_names_are_the_four_the_examples_address_by_id():
+    assert seeder.PINNED_MAP_NAMES == (
+        # /m/NDuwpSJc3yx4Exic5Na48xO-8bpjWiaIofJefpjqfbU (embed/iframe.html)
+        "Restless Earth",
+        # the three the gallery deep-links by UUID from index.html
+        "Manhattan - A Century of Skyline",
+        "The Matterhorn in 3D",
+        "New York From Orbit - Sentinel-2, by Reference",
+    )
+
+
+def test_a_pinned_name_is_never_also_a_retired_one():
+    """--prune deletes RETIRED_* by exact name; the two sets must not overlap."""
+    assert set(seeder.PINNED_MAP_NAMES).isdisjoint(seeder.RETIRED_MAPS)
+    pinned_titles = set(seeder.PINNED_DATASET_TITLES) | set(
+        seeder.PINNED_FOREIGN_DATASET_TITLES
+    )
+    assert pinned_titles.isdisjoint(seeder.RETIRED_DATASETS)
+
+
+def test_a_pinned_map_is_never_reported_as_a_stray():
+    assert set(seeder.PINNED_MAP_NAMES) <= seeder._showcase_map_names()
+
+
+def test_the_pin_comment_points_at_the_examples_manifest():
+    """Point 3 of #1607: the comment has to name the file to diff against."""
+    assert "ci/fixtures.json" in SOURCE
+    assert "index.html" in SOURCE
+
+
+# --- the decision -------------------------------------------------------------
+
+PINNED = "Restless Earth"
+UNPINNED = "Hurricane Alley"
+
+
+@pytest.mark.parametrize(
+    ("name", "exists", "force", "force_pinned", "expected"),
+    [
+        # Nothing there: build it, pinned or not.
+        (PINNED, False, False, False, False),
+        (PINNED, False, True, False, False),
+        (PINNED, False, True, True, False),
+        (UNPINNED, False, False, False, False),
+        # No --force: the long-standing skip, unchanged.
+        (PINNED, True, False, False, True),
+        (UNPINNED, True, False, False, True),
+        # --force: recreate, EXCEPT a pinned name.
+        (UNPINNED, True, True, False, False),
+        (PINNED, True, True, False, True),
+        # --force-pinned lifts the pin, and only the pin.
+        (PINNED, True, True, True, False),
+        (UNPINNED, True, True, True, False),
+    ],
+)
+def test_keep_existing_map_truth_table(name, exists, force, force_pinned, expected):
+    assert seeder._keep_existing_map(name, exists, force, force_pinned) is expected
+
+
+def test_force_pinned_alone_does_not_lift_the_pin_without_force():
+    """--force-pinned is a modifier: with no --force there is nothing to lift."""
+    assert seeder._keep_existing_map(PINNED, True, False, True) is True
+
+
+def test_the_kept_message_names_the_override_flag(capsys):
+    seeder._announce_kept_map(PINNED, force=True)
+    out = capsys.readouterr().out
+    assert "[pinned]" in out
+    assert "--force-pinned" in out
+
+    seeder._announce_kept_map(PINNED, force=False)
+    assert "[skip]" in capsys.readouterr().out
+
+
+# --- the structural guard -----------------------------------------------------
+
+
+def _unguarded_map_exists_calls(source: str) -> list[int]:
+    """Line numbers of `_map_exists(...)` calls not wrapped by the pin helper.
+
+    AST rather than grep so a mention in a comment or docstring cannot pass
+    for a call site, and so `def _map_exists(` is not mistaken for one.
+    """
+    tree = ast.parse(source)
+
+    def _is_call_to(node: ast.AST, fname: str) -> bool:
+        return (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == fname
+        )
+
+    guarded: set[int] = set()
+    for node in ast.walk(tree):
+        if _is_call_to(node, "_keep_existing_map"):
+            for arg in [*node.args, *(kw.value for kw in node.keywords)]:
+                guarded.add(id(arg))
+
+    return sorted(
+        node.lineno
+        for node in ast.walk(tree)
+        if _is_call_to(node, "_map_exists") and id(node) not in guarded
+    )
+
+
+def _guarded_map_exists_count(source: str) -> int:
+    tree = ast.parse(source)
+    total = sum(
+        1
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "_map_exists"
+    )
+    return total - len(_unguarded_map_exists_calls(source))
+
+
+def test_every_builder_checks_existence_through_the_pin_helper():
+    """A builder that spells the check itself cannot honour the pin."""
+    unguarded = _unguarded_map_exists_calls(SOURCE)
+    assert unguarded == [], (
+        f"seed-showcase.py lines {unguarded} call _map_exists() outside "
+        "_keep_existing_map(); route the check through the helper so the "
+        "pinned maps in PINNED_MAP_NAMES survive --force (see #1607)"
+    )
+
+
+def test_the_guard_is_not_vacuous():
+    """An empty list above must mean 'all routed', not 'no call sites left'.
+
+    One per builder that owns a map: restless, manhattan, hurricanes,
+    hurricane-exposure, meteorites, matterhorn, sentinel2, embed.
+    """
+    assert _guarded_map_exists_count(SOURCE) >= 8
+
+
+def test_the_guard_catches_the_old_bare_shape():
+    """Counterfactual: the shape every builder used before #1607 is flagged."""
+    before = """
+def build_something(api, force=False):
+    name = "Restless Earth"
+    if not force and _map_exists(api, name):
+        print("skip")
+        return "(skipped)"
+"""
+    assert _unguarded_map_exists_calls(before) == [4]
+    assert _guarded_map_exists_count(before) == 0
+
+
+def test_the_guard_accepts_the_new_shape():
+    after = """
+def build_something(api, force=False, force_pinned=False):
+    name = "Restless Earth"
+    if _keep_existing_map(name, _map_exists(api, name), force, force_pinned):
+        _announce_kept_map(name, force)
+        return "(skipped)"
+"""
+    assert _unguarded_map_exists_calls(after) == []
+    assert _guarded_map_exists_count(after) == 1
+
+
+def _function_node(source: str, name: str) -> ast.FunctionDef:
+    for node in ast.walk(ast.parse(source)):
+        if isinstance(node, ast.FunctionDef) and node.name == name:
+            return node
+    raise AssertionError(f"{name} not found in seed-showcase.py")
+
+
+def test_the_force_delete_path_rechecks_the_pin():
+    """build_sentinel2's --force branch deletes map rows by id.
+
+    Its early return already covers the pinned name, but the delete loop is
+    where the uuid the gallery links actually dies, so the decision is
+    re-asked there: one call for the early return, one at the delete.
+    """
+    body = _function_node(SOURCE, "build_sentinel2")
+    calls = [
+        node
+        for node in ast.walk(body)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "_keep_existing_map"
+    ]
+    assert len(calls) >= 2
+
+
+# --- --prune-userdata ---------------------------------------------------------
+
+
+class _FakeApi:
+    """Just the surface _classify_userdata reads."""
+
+    username = "admin"
+    user_id = "u-admin"
+
+    def __init__(self, maps, datasets):
+        self._maps = maps
+        self._datasets = datasets
+
+    def list_all_maps(self):
+        return self._maps
+
+    def list_all_datasets(self):
+        return self._datasets
+
+
+def _classify(maps, datasets):
+    api = _FakeApi(maps, datasets)
+    known = seeder._showcase_map_names()
+    titles = seeder._showcase_dataset_titles()
+    return seeder._classify_userdata(
+        api,
+        known,
+        lambda title: (
+            title in titles or title.startswith(seeder._SHOWCASE_TITLE_PREFIXES)
+        ),
+    )
+
+
+def test_prune_userdata_hard_keeps_a_pinned_map_whoever_owns_it():
+    buckets = _classify(
+        [
+            {"id": "m1", "name": PINNED, "created_by_username": "admin"},
+            {
+                "id": "m2",
+                "name": "Manhattan - A Century of Skyline",
+                "created_by_username": "visitor",
+            },
+            {"id": "m3", "name": "A visitor's map", "created_by_username": "visitor"},
+        ],
+        [],
+    )
+    assert [m["id"] for m in buckets["pinned_maps"]] == ["m1"]
+    assert [m["id"] for m in buckets["pinned_map_impostors"]] == ["m2"]
+    # The delete set is the only bucket that matters for safety.
+    assert [m["id"] for m in buckets["foreign_maps"]] == ["m3"]
+
+
+def test_prune_userdata_keeps_the_meteorites_dataset():
+    buckets = _classify(
+        [],
+        [
+            {
+                "id": "d1",
+                "title": "Meteorite Landings (Meteoritical Society)",
+                "created_by": "u-admin",
+            },
+            {"id": "d2", "title": "A visitor's upload", "created_by": "u-visitor"},
+        ],
+    )
+    assert [d["id"] for d in buckets["pinned"]] == ["d1"]
+    assert [d["id"] for d in buckets["foreign_datasets"]] == ["d2"]
+
+
+def test_the_prune_report_labels_pinned_maps_as_pinned(capsys):
+    seeder._report_pinned_maps(
+        [{"name": PINNED}],
+        [{"name": "The Matterhorn in 3D", "created_by_username": "visitor"}],
+    )
+    out = capsys.readouterr().out
+    assert "externally pinned maps, hard-kept: 1" in out
+    assert PINNED in out
+    assert "visitor" in out
+
+
+# --- the CLI ------------------------------------------------------------------
+
+
+def _run(*args) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT_PATH), *args],
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+
+
+def test_help_lists_the_override_flag():
+    result = _run("--help")
+    assert result.returncode == 0
+    assert "--force-pinned" in result.stdout
+
+
+def test_force_pinned_without_force_is_refused():
+    """Refused before login, so this never touches a server."""
+    result = _run("--force-pinned", "--password", "unused")
+    assert result.returncode == 2
+    assert "--force-pinned is only meaningful with --force" in result.stderr

--- a/backend/tests/test_seed_showcase_pins_1607.py
+++ b/backend/tests/test_seed_showcase_pins_1607.py
@@ -13,7 +13,9 @@ So the seeder pins them, and these tests hold the pin in place:
 * EVERY builder's exists-check goes through that one function, so a builder
   added later cannot re-invent the bare `not force and _map_exists(...)` shape
   and quietly drop a pinned map's uuid on the floor;
-* `--prune-userdata`'s classifier hard-keeps a pinned map whoever owns it.
+* `--prune-userdata`'s classifier hard-keeps a pinned map whoever owns it;
+* `--prune` refuses to delete a pinned name even if one is added to a RETIRED_*
+  list, which the tests force rather than wait for.
 
 Pure static analysis plus one fake-API unit - no database, no HTTP, no docker.
 """

--- a/backend/tests/test_seed_showcase_pins_1607.py
+++ b/backend/tests/test_seed_showcase_pins_1607.py
@@ -493,6 +493,92 @@ def test_replace_map_layers_handles_a_map_whose_layers_already_cascaded():
     assert api.added == [{"dataset_id": "d1"}]
 
 
+# --- every retained duplicate is rebound (#1607 review r4) --------------------
+
+
+class _MultiRowApi:
+    """A fake holding several same-named rows, each with its own layer stack."""
+
+    def __init__(self, rows):
+        self._rows = {rid: list(layers) for rid, layers in rows.items()}
+        self.added = {rid: [] for rid in rows}
+        self.deleted_layers = {rid: [] for rid in rows}
+        self.views = {}
+        self.deleted_maps = []
+
+    def get_map(self, map_id):
+        return {"id": map_id, "layers": self._rows[map_id]}
+
+    def delete_layer(self, map_id, layer_id):
+        self.deleted_layers[map_id].append(layer_id)
+
+    def add_layer(self, map_id, body):
+        self.added[map_id].append(body)
+
+    def set_view(self, map_id, **fields):
+        self.views[map_id] = fields
+
+    def visibility_check(self, map_id):
+        return {"has_non_public": False}
+
+    def delete_map(self, map_id):  # pragma: no cover - must never be called
+        self.deleted_maps.append(map_id)
+
+
+@pytest.mark.parametrize(
+    ("newest", "retained", "expected"),
+    [
+        # The ordinary case: one row, resolved and retained, rebound once.
+        ("m-new", ["m-new"], ["m-new"]),
+        # Duplicates an older --force stacked up: all of them, primary first.
+        ("m-new", ["m-new", "m-old"], ["m-new", "m-old"]),
+        ("m-new", ["m-old", "m-new"], ["m-new", "m-old"]),
+        # The row vanished during the STAC window: nothing to rebind, and the
+        # builder falls through to create_map.
+        (None, [], []),
+        # --force-pinned deleted them all; the fresh row is not retained.
+        (None, [], []),
+        # Retained but no longer resolvable by name (renamed underneath us):
+        # still rebound, because it still holds the uuid.
+        (None, ["m-old"], ["m-old"]),
+    ],
+)
+def test_rows_to_rebind(newest, retained, expected):
+    assert seeder._rows_to_rebind(newest, retained) == expected
+
+
+def test_every_retained_duplicate_is_rebound_and_none_is_deleted():
+    """The r4 hole: the scene delete cascades EVERY retained row's layers away.
+
+    Rebinding only the primary would leave the other rows holding their uuids
+    with no layers at all - an empty map behind a link the examples may use,
+    which is worse than the stale map the pin exists to avoid.
+    """
+    api = _MultiRowApi({"m-new": [{"id": "l-new-1"}], "m-old": [{"id": "l-old-1"}]})
+    layers = [{"dataset_id": "d1", "sort_order": 0}, {"dataset_id": "d2"}]
+
+    primary = seeder._rebind_pinned_rows(
+        api, ["m-new", "m-old"], "New York From Orbit", layers, {"visibility": "public"}
+    )
+
+    assert primary == "m-new"
+    for row in ("m-new", "m-old"):
+        assert api.added[row] == layers, f"{row} did not get the fresh stack"
+        assert api.deleted_layers[row], f"{row} kept its old layers"
+        assert api.views[row] == {"visibility": "public"}, f"{row} missed set_view"
+    assert api.deleted_maps == []
+
+
+def test_rebinding_reports_each_duplicate(capsys):
+    api = _MultiRowApi({"m-new": [], "m-old": []})
+    seeder._rebind_pinned_rows(api, ["m-new", "m-old"], "n", [], {})
+    out = capsys.readouterr().out
+    # The primary's line is the builder's "-> map"; only the extras announce
+    # themselves here, or a single-row repair would print a confusing echo.
+    assert "also rebound duplicate row m-old" in out
+    assert "m-new" not in out
+
+
 def test_sentinel2_does_not_return_on_a_pinned_keep():
     """The pinned keep must not short-circuit the repair.
 
@@ -528,30 +614,39 @@ def test_sentinel2_does_not_return_on_a_pinned_keep():
     ]
     assert bindings, "build_sentinel2 must keep the pin decision, not return on it"
 
-    # And it must reuse the row: a create_map call guarded by that decision,
-    # plus the in-place rebind.
+    # And it must reuse the rows: the retained-row list feeds the rebind.
     called = {
         n.func.id
         for n in ast.walk(body)
         if isinstance(n, ast.Call) and isinstance(n.func, ast.Name)
     }
-    assert "_replace_map_layers" in called
+    assert "_rows_to_rebind" in called
+    assert "_rebind_pinned_rows" in called
 
 
-def test_only_sentinel2_replaces_layers_in_place():
-    """No other builder rebinds a stack; they create their maps outright."""
-    users = {
+def _callers_of(fname: str) -> set[str]:
+    return {
         node.name
         for node in ast.walk(ast.parse(SOURCE))
         if isinstance(node, ast.FunctionDef)
         and any(
             isinstance(c, ast.Call)
             and isinstance(c.func, ast.Name)
-            and c.func.id == "_replace_map_layers"
+            and c.func.id == fname
             for c in ast.walk(node)
         )
     }
-    assert users == {"build_sentinel2"}
+
+
+def test_only_sentinel2_replaces_layers_in_place():
+    """No other builder rebinds a stack; they create their maps outright.
+
+    The rebind goes through _rebind_pinned_rows so that EVERY retained row is
+    rebound, not just the primary - a builder reaching _replace_map_layers
+    directly would be back to rebinding one row (fix(#1607 review r4)).
+    """
+    assert _callers_of("_replace_map_layers") == {"_rebind_pinned_rows"}
+    assert _callers_of("_rebind_pinned_rows") == {"build_sentinel2"}
 
 
 # --- the outcome main() reports (#1607 review r2) -----------------------------

--- a/backend/tests/test_seed_showcase_pins_1607.py
+++ b/backend/tests/test_seed_showcase_pins_1607.py
@@ -347,6 +347,26 @@ def test_help_lists_the_override_flag():
     assert "--force-pinned" in result.stdout
 
 
+def test_help_names_the_sentinel_exception_under_force_pinned():
+    """--force-pinned does not cost the same on all four pinned maps.
+
+    For Restless Earth, Manhattan and the Matterhorn the builder creates a
+    fresh row and the old one survives with its id. build_sentinel2 runs its
+    stale-map loop first, which deletes every row under the name AND their
+    share links, so there the override really does destroy the uuid the
+    examples link. An operator reads the help, not the source, so the help has
+    to carry the exception (fix(#1607 review r3)).
+    """
+    result = _run("--help")
+    assert result.returncode == 0
+    # argparse hard-wraps to the terminal width; compare on normalised text.
+    text = " ".join(result.stdout.split())
+    assert "--force-pinned" in text
+    assert "New York From Orbit" in text
+    assert "deletes the existing row(s) and their share links" in text
+    assert "For the other three" in text
+
+
 def test_force_pinned_without_force_is_refused():
     """Refused before login, so this never touches a server."""
     result = _run("--force-pinned", "--password", "unused")

--- a/scripts/seed-showcase.py
+++ b/scripts/seed-showcase.py
@@ -81,11 +81,11 @@ Upgrading an existing instance: run with --prune to delete the retired
 first-generation showcase maps/datasets (see RETIRED_* below), then seed.
 --force rebuilds a showcase map that already exists - except the four in
 PINNED_MAP_NAMES, whose ids and share token the geolens-examples repo links.
---force-pinned lifts that pin, and only that: the builder then does what --force
-does for any other map, which is to create a FRESH row beside the existing one.
-The old row keeps its id and share links until someone removes it, so an
-operator who uses the flag has to move the examples' references onto the new ids
-or keep the old row.
+--force-pinned lifts that pin. What it then costs differs by map: New York From
+Orbit (Sentinel-2) has its existing row and share links DELETED before the
+rebuild, so that uuid is gone; the other three get a fresh row beside the old
+one, which keeps its id and share links until someone removes it. Either way the
+examples' references have to be moved onto the new ids.
 
 Requires: pip install httpx
 
@@ -1864,13 +1864,16 @@ def _keep_existing_map(
         exists, force, pinned, override -> False  --force-pinned
 
     False on that last line means only that this function stops holding the
-    builder back. It is NOT "replace the pinned row": the builder goes on to do
-    what --force does for any other map, which for every builder but
-    build_sentinel2 is create_map() beside the existing row. After
-    --force --force-pinned the old map is therefore still there, still holding
-    the uuid and the share token geolens-examples links, while the name now
-    resolves to the fresh row. Moving those references onto the new ids, or
-    deleting the old row, is the operator's job - nothing here does it.
+    builder back, and what the builder does with that freedom is not uniform.
+    For every builder but build_sentinel2 it is create_map() beside the
+    existing row, so after --force --force-pinned the old map is still there,
+    still holding the uuid and the share token geolens-examples links, while
+    the name resolves to the fresh row; moving those references onto the new
+    ids, or deleting the old row, is the operator's job. build_sentinel2 is the
+    exception in BOTH directions: this same False sends it through the
+    stale-map loop, which deletes every row under the name - and their share
+    links - before rebuilding, so there --force-pinned really does destroy the
+    externally referenced uuid.
 
     True is likewise not the whole story for one caller. Six of the seven
     builders that own a pinned-eligible map treat True as "return, do nothing",
@@ -1906,7 +1909,10 @@ def _announce_kept_map(name: str, force: bool, note: str = "") -> str:
     nothing happen will otherwise go delete the map by hand, which is the exact
     outcome the pin exists to prevent. It also has to say what the flag really
     does, because "recreate" would be a promise this seeder does not keep - the
-    builder builds a fresh row and leaves this one standing.
+    builder builds a fresh row and leaves this one standing. That is true of
+    every builder that reaches this line: build_sentinel2, whose --force-pinned
+    path does delete the row, never prints it under force (it repairs instead
+    of returning), so the sentence cannot be read against the wrong map.
     """
     if force:
         print(
@@ -4645,7 +4651,9 @@ def build_sentinel2(api: Api, force: bool = False, force_pinned: bool = False) -
         print(
             f"  [pinned] {name} will be REPAIRED in place: its scenes are "
             "re-imported and its layers rebound, and the map keeps its id and "
-            "share links (--force-pinned builds a fresh row instead)"
+            "share links (--force-pinned would DELETE this row and its share "
+            "links first, then rebuild - this map is the one pinned map where "
+            "the override destroys the id rather than leaving it behind)"
         )
     print("\n[sentinel2] New York From Orbit (COGs by reference)")
     # Query the STAC API DIRECTLY (the backend /services/stac/search proxy 502s
@@ -4900,7 +4908,10 @@ def build_sentinel2(api: Api, force: bool = False, force_pinned: bool = False) -
             # the examples gallery links, so the decision is asked here rather
             # than inherited from a caller 250 lines up. Under a pinned repair
             # the row is kept and rebound below; --force-pinned is what turns
-            # this back into a delete-and-recreate.
+            # this back into a delete-and-recreate, and this delete is why the
+            # --force-pinned help singles this map out: for the other three
+            # pinned maps the override leaves the old row standing, and here it
+            # does not (fix(#1607 review r3)).
             if _keep_existing_map(name, True, force, force_pinned):
                 print(f"  [pinned] keeping map {map_id} - rebound in place below")
                 continue
@@ -6216,11 +6227,14 @@ def main() -> int:
         "--force-pinned",
         action="store_true",
         help="with --force, stop keeping the externally pinned maps "
-        "(PINNED_MAP_NAMES). This lifts the pin and nothing more: the builder "
-        "then does what --force does for any other map and creates a FRESH row "
-        "beside the existing one, which keeps its UUID and share links until "
-        "you delete it. Move the geolens-examples references "
-        "(ci/fixtures.json, index.html) onto the new ids, or keep the old row",
+        "(PINNED_MAP_NAMES). What that costs is NOT the same for all four. For "
+        "'New York From Orbit' (Sentinel-2) it deletes the existing row(s) and "
+        "their share links first and then recreates, so the externally "
+        "referenced UUID is destroyed. For the other three the builder creates "
+        "a fresh row beside the existing one, which keeps its UUID and share "
+        "links until you delete it by hand. Either way, move the "
+        "geolens-examples references (ci/fixtures.json, index.html) onto the "
+        "new ids",
     )
     ap.add_argument(
         "--prune",

--- a/scripts/seed-showcase.py
+++ b/scripts/seed-showcase.py
@@ -4969,6 +4969,16 @@ def build_sentinel2(api: Api, force: bool = False, force_pinned: bool = False) -
     # STAC search and import sit in between, and a row that disappeared in that
     # window has no id left to preserve, so falling through to create_map is
     # the honest outcome rather than a KeyError.
+    #
+    # "Share links survive" is exact, and worth being exact about: the map row,
+    # its uuid, its public /maps/{id} URL and any embed-token ROW are all still
+    # there afterwards (verified on a dev instance: same id, same created_at,
+    # same token id and hint). What a re-import cannot preserve is an embed
+    # token's SCOPE - scoped_dataset_ids is a snapshot of the map's layers at
+    # mint time (see build_embed_demo), so it still names the scenes this run
+    # deleted and authorizes nothing. Re-mint the token if one is in use. Under
+    # --force-pinned the token would not survive at all, so this is the better
+    # end of a trade, not a clean one.
     map_id = api.list_maps().get(name) if keep_pinned_row else None
     if map_id:
         print(f"  [pinned] reusing map {map_id} (its id and share links survive)")

--- a/scripts/seed-showcase.py
+++ b/scripts/seed-showcase.py
@@ -1871,6 +1871,18 @@ def _keep_existing_map(
     the uuid and the share token geolens-examples links, while the name now
     resolves to the fresh row. Moving those references onto the new ids, or
     deleting the old row, is the operator's job - nothing here does it.
+
+    True is likewise not the whole story for one caller. Six of the seven
+    builders that own a pinned-eligible map treat True as "return, do nothing",
+    which is right for them: their layers point at datasets this seeder can
+    refresh in place, so there is no repair a rebuild would perform that a
+    plain re-run does not. build_sentinel2 is different - its layers point at
+    scenes imported BY REFERENCE, and `--only sentinel2 --force` is the
+    documented repair for an instance seeded before item_href was sent. So it
+    reads this True as "keep the ROW", not "do nothing": it runs the whole
+    force path and rebinds the existing map's layers in place
+    (_replace_map_layers), which is the only shape that repairs the scenes
+    without minting the new uuid --force-pinned would (fix(#1607 review r2)).
     """
     if not exists:
         return False
@@ -1879,8 +1891,15 @@ def _keep_existing_map(
     return name in PINNED_MAP_NAMES and not force_pinned
 
 
-def _announce_kept_map(name: str, force: bool, note: str = "") -> None:
+def _announce_kept_map(name: str, force: bool, note: str = "") -> str:
     """The one line a builder prints when _keep_existing_map said keep.
+
+    Returns the marker the builder returns, so the sentence printed here and
+    the outcome main() reports cannot drift apart: a pinned keep is "(pinned)"
+    and an ordinary skip is "(skipped)". They read the same to a builder and
+    differently to the operator, which is the point - "use --force to recreate"
+    is the opposite of what --force does to a pinned map
+    (fix(#1607 review r2)).
 
     Separate from the decision so that stays pure. The force case has to name
     the flag that lifts the pin: an operator who typed --force and watched
@@ -1896,8 +1915,9 @@ def _announce_kept_map(name: str, force: bool, note: str = "") -> None:
             "builds a FRESH map beside this one; this row keeps its id and "
             "share links until you move those references or delete it"
         )
-    else:
-        print(f"  [skip] {name} already exists{note}")
+        return "(pinned)"
+    print(f"  [skip] {name} already exists{note}")
+    return "(skipped)"
 
 
 def _rename_map_if_needed(api: Api, name: str, legacy: str) -> None:
@@ -1913,6 +1933,31 @@ def _rename_map_if_needed(api: Api, name: str, legacy: str) -> None:
     if legacy in maps and name not in maps:
         api.set_view(maps[legacy], name=name)
         print(f"  renamed map {legacy!r} -> {name!r}")
+
+
+def _replace_map_layers(api: Api, map_id: str, layers: list[dict]) -> int:
+    """Swap a map's whole layer stack, leaving the map ROW alone.
+
+    fix(#1607 review r2). This is what lets build_sentinel2 repair a pinned map
+    under plain --force: a layer points at a dataset id, the scene re-import
+    mints new ids, and the map's uuid and share tokens have to survive because
+    geolens-examples addresses them. Delete-then-add is the only shape that
+    rebinds the stack without a new map row.
+
+    Deleting the scene datasets already cascades their layers away
+    (MapLayer.dataset_id is ON DELETE CASCADE), so the delete pass here is not
+    usually the one doing the work - it is what catches the layers that did NOT
+    cascade, i.e. the ones whose scene was deliberately kept because another
+    map shares it. Skipping the pass would leave those beside the fresh stack
+    as duplicates.
+
+    Returns the number of layers added.
+    """
+    for layer in api.get_map(map_id).get("layers", []):
+        api.delete_layer(map_id, layer["id"])
+    for body in layers:
+        api.add_layer(map_id, body)
+    return len(layers)
 
 
 def _find_under_either_title(
@@ -2765,8 +2810,7 @@ def build_restless_earth(
     quakes_ds, heat_ds = ensure_quake_datasets(api, by_title)
 
     if _keep_existing_map(name, _map_exists(api, name), force, force_pinned):
-        _announce_kept_map(name, force, " (quake bindings brought current)")
-        return "(skipped)"
+        return _announce_kept_map(name, force, " (quake bindings brought current)")
 
     # --- plate boundaries ------------------------------------------------------
     plates_title = "Tectonic Plate Boundaries (PB2002)"
@@ -3357,8 +3401,7 @@ def build_manhattan(api: Api, force: bool = False, force_pinned: bool = False) -
     """
     name = "Manhattan - A Century of Skyline"
     if _keep_existing_map(name, _map_exists(api, name), force, force_pinned):
-        _announce_kept_map(name, force)
-        return "(skipped)"
+        return _announce_kept_map(name, force)
     print("\n[manhattan] Manhattan (3D by height, colored by era, + subway)")
     by_title = api.datasets_by_title()
 
@@ -3715,8 +3758,7 @@ def build_hurricanes(api: Api, force: bool = False, force_pinned: bool = False) 
     # builds a duplicate next to it.
     _rename_map_if_needed(api, name, HURRICANE_MAP_LEGACY)
     if _keep_existing_map(name, _map_exists(api, name), force, force_pinned):
-        _announce_kept_map(name, force)
-        return "(skipped)"
+        return _announce_kept_map(name, force)
     print("\n[hurricanes] Hurricane Alley (HURDAT2 majors since 1950)")
     by_title = api.datasets_by_title()
 
@@ -4123,8 +4165,7 @@ def build_hurricane_exposure(
     """
     name = EXPOSURE_MAP
     if _keep_existing_map(name, _map_exists(api, name), force, force_pinned):
-        _announce_kept_map(name, force)
-        return "(skipped)"
+        return _announce_kept_map(name, force)
     print("\n[hurricane-exposure] buffer -> intersect -> dissolve (HURDAT2 majors)")
     by_title = api.datasets_by_title()
     chain = _build_exposure_chain(api, by_title, force=force)
@@ -4217,8 +4258,7 @@ def build_meteorites(api: Api, force: bool = False, force_pinned: bool = False) 
             )
 
     if _keep_existing_map(name, _map_exists(api, name), force, force_pinned):
-        _announce_kept_map(name, force)
-        return "(skipped)"
+        return _announce_kept_map(name, force)
 
     met_ds = _get_or_ingest(
         api,
@@ -4336,8 +4376,7 @@ def build_matterhorn(api: Api, force: bool = False, force_pinned: bool = False) 
     (white-cased, the classic Swiss-map convention) and labeled peaks."""
     name = "The Matterhorn in 3D"
     if _keep_existing_map(name, _map_exists(api, name), force, force_pinned):
-        _announce_kept_map(name, force)
-        return "(skipped)"
+        return _announce_kept_map(name, force)
     print("\n[matterhorn] The Matterhorn (3D terrain via regional VRT mosaic)")
     by_title = api.datasets_by_title()
     vrt_title = "swissALTI3D Matterhorn DEM (2m mosaic)"
@@ -4584,11 +4623,30 @@ def build_matterhorn(api: Api, force: bool = False, force_pinned: bool = False) 
 def build_sentinel2(api: Api, force: bool = False, force_pinned: bool = False) -> str:
     """The by-reference hero: recent low-cloud Sentinel-2 true color over NYC,
     streamed straight from the AWS open-data COGs - zero download at seed
-    time; Titiler needs S3 egress at VIEW time."""
+    time; Titiler needs S3 egress at VIEW time.
+
+    Alone among the builders this one does NOT return early on a pinned keep.
+    `--only sentinel2 --force` is the documented repair for an instance seeded
+    before item_href was sent, and this map is pinned, so an early return would
+    leave that repair reachable only through --force-pinned - the one flag that
+    mints the new uuid the examples must not get. Instead the pin is honoured
+    by REUSING the row: the force preflight, the scene deletion and the STAC
+    import all run exactly as they do without a pin, and only create_map is
+    skipped, in favour of rebinding the existing map's layers in place
+    (fix(#1607 review r2))."""
     name = "New York From Orbit - Sentinel-2, by Reference"
-    if _keep_existing_map(name, _map_exists(api, name), force, force_pinned):
-        _announce_kept_map(name, force)
-        return "(skipped)"
+    keep_pinned_row = _keep_existing_map(
+        name, _map_exists(api, name), force, force_pinned
+    )
+    if keep_pinned_row and not force:
+        # The ordinary already-built skip; nothing to repair.
+        return _announce_kept_map(name, force)
+    if keep_pinned_row:
+        print(
+            f"  [pinned] {name} will be REPAIRED in place: its scenes are "
+            "re-imported and its layers rebound, and the map keeps its id and "
+            "share links (--force-pinned builds a fresh row instead)"
+        )
     print("\n[sentinel2] New York From Orbit (COGs by reference)")
     # Query the STAC API DIRECTLY (the backend /services/stac/search proxy 502s
     # on the SSRF IP-pin against Element84's CloudFront edge). Collection-1
@@ -4690,12 +4748,24 @@ def build_sentinel2(api: Api, force: bool = False, force_pinned: bool = False) -
                 "listing cannot see other users' private maps, so the "
                 "shared-scene protection would be blind"
             )
-        # fix(#1493 review): --force must RECREATE, not duplicate - the import
+        # fix(#1493 review): --force must REBUILD, not duplicate - the import
         # endpoint dedupes on source_url and returns status="skipped" WITHOUT
         # updating origin_ref, so a rerun over existing scenes could never
-        # record fresh bindings. Deleting first is what makes
+        # record fresh bindings. Deleting the SCENES first is what makes
         # `--only sentinel2 --force` the supported repair for instances seeded
-        # before item_href was sent. Three deliberate shapes here:
+        # before item_href was sent.
+        #
+        # fix(#1607 review r2): the map ROW is a separate question from the
+        # scenes, and since the name is pinned the two now part company. The
+        # scene deletion and re-import below are what the repair actually is,
+        # and they run unchanged; the map row is kept and rebound in place
+        # (see _replace_map_layers at the end of this function), so the uuid
+        # and share token geolens-examples links survive the repair. Only
+        # --force-pinned goes back to deleting the row. Deleting a scene
+        # cascades its layers away (MapLayer.dataset_id is ON DELETE CASCADE),
+        # so the kept row is left layer-less in between rather than dangling.
+        #
+        # Three deliberate shapes here:
         #
         # * Runs AFTER the catalog search succeeded (round 3): a flaky
         #   Element84 must fail this builder BEFORE it destroys a working
@@ -4826,16 +4896,13 @@ def build_sentinel2(api: Api, force: bool = False, force_pinned: bool = False) -
         if doomed:
             print(f"  [force] deleted {len(doomed)} attached scene datasets")
         for map_id in stale_maps:
-            # fix(#1607): re-checked at the irreversible step rather than
-            # trusting the early return 250 lines up. This name IS pinned, so
-            # the return already covers it - but this loop is the line that
-            # actually destroys the uuid the examples gallery links, and a
-            # guard on the decision belongs where the damage is done.
+            # fix(#1607): this loop is the line that actually destroys the uuid
+            # the examples gallery links, so the decision is asked here rather
+            # than inherited from a caller 250 lines up. Under a pinned repair
+            # the row is kept and rebound below; --force-pinned is what turns
+            # this back into a delete-and-recreate.
             if _keep_existing_map(name, True, force, force_pinned):
-                print(
-                    f"  [pinned] kept existing map {map_id} "
-                    "(--force-pinned to delete it)"
-                )
+                print(f"  [pinned] keeping map {map_id} - rebound in place below")
                 continue
             api.delete_map(map_id)
             print(f"  [force] deleted existing map {map_id}")
@@ -4877,27 +4944,44 @@ def build_sentinel2(api: Api, force: bool = False, force_pinned: bool = False) -
             "STAC import resolved no dataset_ids (skipped items not found by "
             "title); remove the existing Sentinel-2 datasets and retry"
         )
-    map_id = api.create_map(
-        name,
-        "Recent low-cloud Sentinel-2 true-color scenes over New York, "
-        "streamed BY REFERENCE from the AWS Earth Search open-data archive - "
-        "no file was downloaded to build this map; Titiler reads the "
-        "cloud-optimized GeoTIFFs straight from S3, newest scene on top. "
-        "ESA Copernicus / Element84 Earth Search.",
-    )
-    for i, (ds_id, day) in enumerate(scenes):
-        api.add_layer(
-            map_id,
-            {
-                "dataset_id": ds_id,
-                "sort_order": i,  # newest first = on top (results are date-desc)
-                "opacity": 1.0,
-                "display_name": f"Sentinel-2 - {day}",
-                "layer_type": "raster_geolens",
-                # true color = NO render_mode, no paint (default RGB path).
-                "style_config": {"builder": {}},
-            },
+    layers = [
+        {
+            "dataset_id": ds_id,
+            "sort_order": i,  # newest first = on top (results are date-desc)
+            "opacity": 1.0,
+            "display_name": f"Sentinel-2 - {day}",
+            "layer_type": "raster_geolens",
+            # true color = NO render_mode, no paint (default RGB path).
+            "style_config": {"builder": {}},
+        }
+        for i, (ds_id, day) in enumerate(scenes)
+    ]
+    # fix(#1607 review r2): under a pinned repair the row the examples link is
+    # reused instead of created. Resolved through list_maps(), which is what
+    # every other pass in this seeder already targets (the globe projection,
+    # the styling pass and the prune classifier all read it) - repairing a
+    # different row would leave the seeder disagreeing with itself. Where an
+    # older --force left duplicates under this name, list_maps() picks the
+    # newest-created one; if the gallery links an older duplicate, that is a
+    # by-hand reconciliation this seeder cannot make for you.
+    #
+    # Re-resolved HERE rather than carried down from the check at the top: the
+    # STAC search and import sit in between, and a row that disappeared in that
+    # window has no id left to preserve, so falling through to create_map is
+    # the honest outcome rather than a KeyError.
+    map_id = api.list_maps().get(name) if keep_pinned_row else None
+    if map_id:
+        print(f"  [pinned] reusing map {map_id} (its id and share links survive)")
+    else:
+        map_id = api.create_map(
+            name,
+            "Recent low-cloud Sentinel-2 true-color scenes over New York, "
+            "streamed BY REFERENCE from the AWS Earth Search open-data archive - "
+            "no file was downloaded to build this map; Titiler reads the "
+            "cloud-optimized GeoTIFFs straight from S3, newest scene on top. "
+            "ESA Copernicus / Element84 Earth Search.",
         )
+    _replace_map_layers(api, map_id, layers)
     api.set_view(
         map_id,
         visibility="public",
@@ -4939,8 +5023,7 @@ def build_embed_demo(api: Api, force: bool = False, force_pinned: bool = False) 
     stays PRIVATE and the X-Embed-Token header grants scoped tile access."""
     name = "Private Embed Demo"
     if _keep_existing_map(name, _map_exists(api, name), force, force_pinned):
-        _announce_kept_map(name, force)
-        return "(skipped)"
+        return _announce_kept_map(name, force)
     print("\n[embed] private-dataset embed-token demo")
     priv_ds = api.ingest_geojson(
         "vip_sites_private.geojson",
@@ -6045,6 +6128,29 @@ def run_maintenance_mode(api: Api, args) -> int | None:
     return None
 
 
+def _builder_outcome_line(bname: str, result: str | None) -> str | None:
+    """What main() prints for a builder that produced no NEW map, or None.
+
+    None means "this result is a map id, record it as built". Split out of
+    main() so the wording is testable and so the pinned case cannot drift back
+    to the generic line, which tells the operator to do the one thing that
+    would break the examples: "use --force to recreate" is exactly what --force
+    declines to do to a pinned map (fix(#1607 review r2)).
+
+    A falsy result keeps the generic line it has always had - a builder that
+    returned nothing built nothing.
+    """
+    if result == "(pinned)":
+        return (
+            f"  {bname}: kept as-is - externally pinned (PINNED_MAP_NAMES), so "
+            "--force left its id and share links alone; --force-pinned builds "
+            "a fresh row beside it"
+        )
+    if not result or result == "(skipped)":
+        return f"  {bname}: already exists, skipped (use --force to recreate)"
+    return None
+
+
 def main() -> int:
     ap = argparse.ArgumentParser(description="Seed GeoLens showcase maps.")
     ap.add_argument(
@@ -6212,10 +6318,11 @@ def main() -> int:
                 print(e.response.text[:500], file=sys.stderr)
             failed[bname] = str(e)
             continue
-        if result and result != "(skipped)":
+        outcome = _builder_outcome_line(bname, result)
+        if outcome is None:
             built[bname] = result
         else:
-            print(f"  {bname}: already exists, skipped (use --force to recreate)")
+            print(outcome)
 
     # Backfill license + keywords on whatever showcase datasets now exist (the
     # ingest flow leaves them "proprietary" with no keywords). Best-effort and

--- a/scripts/seed-showcase.py
+++ b/scripts/seed-showcase.py
@@ -81,7 +81,11 @@ Upgrading an existing instance: run with --prune to delete the retired
 first-generation showcase maps/datasets (see RETIRED_* below), then seed.
 --force rebuilds a showcase map that already exists - except the four in
 PINNED_MAP_NAMES, whose ids and share token the geolens-examples repo links.
---force-pinned rebuilds those too, and then those links have to be updated.
+--force-pinned lifts that pin, and only that: the builder then does what --force
+does for any other map, which is to create a FRESH row beside the existing one.
+The old row keeps its id and share links until someone removes it, so an
+operator who uses the flag has to move the examples' references onto the new ids
+or keep the old row.
 
 Requires: pip install httpx
 
@@ -560,13 +564,22 @@ PINNED_FOREIGN_DATASET_TITLES = ("MNMAP_PLUTO",)
 #   The Matterhorn in 3D              /maps/1c5e021a-8ede-4ebe-a06c-92322208de45
 #   New York From Orbit               /maps/1c4207ab-b1c0-4309-9924-c1ea355003a3
 #
-# Recreating one mints a fresh uuid and leaves its share tokens behind, so every
-# link above 404s while a working map sits next to them under the same name -
-# and nothing inside this repo can see that. So: --force KEEPS a pinned map that
-# already exists (_keep_existing_map), --prune and --prune-userdata hard-keep it,
-# and no path that keeps a map re-mints or revokes its share/embed tokens.
-# --force-pinned lifts the pin for an operator who means it and will re-publish
-# the links afterwards.
+# Building one of these again mints a fresh uuid and leaves the share tokens on
+# the row they were minted against, so every link above keeps resolving to the
+# OLD map while the seeder's later passes work on the new one - and nothing
+# inside this repo can see that. So: --force KEEPS a pinned map that already
+# exists (_keep_existing_map), --prune and --prune-userdata hard-keep it, and no
+# path that keeps a map re-mints or revokes its share/embed tokens.
+#
+# --force-pinned lifts the pin, and only that. It does not replace the pinned
+# row: the builder then behaves exactly as --force does for any other map, which
+# for every builder except build_sentinel2 means create_map() beside the row that
+# is already there (build_sentinel2 deletes the stale rows under the same name
+# first, so there the old row and its links do go). The surviving row keeps the
+# uuid and the share token the links above use until someone prunes or deletes
+# it by hand. An operator who uses the flag therefore has to move the references
+# in geolens-examples (ci/fixtures.json, index.html) onto the new ids, or keep
+# the old row and let the new one sit beside it.
 PINNED_MAP_NAMES = (
     "Restless Earth",
     "Manhattan - A Century of Skyline",
@@ -1849,6 +1862,15 @@ def _keep_existing_map(
                                                   addressed from outside this
                                                   repo (PINNED_MAP_NAMES)
         exists, force, pinned, override -> False  --force-pinned
+
+    False on that last line means only that this function stops holding the
+    builder back. It is NOT "replace the pinned row": the builder goes on to do
+    what --force does for any other map, which for every builder but
+    build_sentinel2 is create_map() beside the existing row. After
+    --force --force-pinned the old map is therefore still there, still holding
+    the uuid and the share token geolens-examples links, while the name now
+    resolves to the fresh row. Moving those references onto the new ids, or
+    deleting the old row, is the operator's job - nothing here does it.
     """
     if not exists:
         return False
@@ -1863,12 +1885,16 @@ def _announce_kept_map(name: str, force: bool, note: str = "") -> None:
     Separate from the decision so that stays pure. The force case has to name
     the flag that lifts the pin: an operator who typed --force and watched
     nothing happen will otherwise go delete the map by hand, which is the exact
-    outcome the pin exists to prevent.
+    outcome the pin exists to prevent. It also has to say what the flag really
+    does, because "recreate" would be a promise this seeder does not keep - the
+    builder builds a fresh row and leaves this one standing.
     """
     if force:
         print(
-            f"  [pinned] {name} kept as-is: the examples address this map by id "
-            "(see PINNED_MAP_NAMES) - pass --force-pinned to recreate it anyway"
+            f"  [pinned] {name} kept as-is: geolens-examples addresses this map "
+            "by id (see PINNED_MAP_NAMES). --force-pinned lifts the pin, which "
+            "builds a FRESH map beside this one; this row keeps its id and "
+            "share links until you move those references or delete it"
         )
     else:
         print(f"  [skip] {name} already exists{note}")
@@ -6073,9 +6099,12 @@ def main() -> int:
     ap.add_argument(
         "--force-pinned",
         action="store_true",
-        help="with --force, re-create the externally pinned maps too "
-        "(PINNED_MAP_NAMES). They get new UUIDs and lose their share tokens, so "
-        "the geolens-examples links must be updated after this",
+        help="with --force, stop keeping the externally pinned maps "
+        "(PINNED_MAP_NAMES). This lifts the pin and nothing more: the builder "
+        "then does what --force does for any other map and creates a FRESH row "
+        "beside the existing one, which keeps its UUID and share links until "
+        "you delete it. Move the geolens-examples references "
+        "(ci/fixtures.json, index.html) onto the new ids, or keep the old row",
     )
     ap.add_argument(
         "--prune",

--- a/scripts/seed-showcase.py
+++ b/scripts/seed-showcase.py
@@ -1966,6 +1966,49 @@ def _replace_map_layers(api: Api, map_id: str, layers: list[dict]) -> int:
     return len(layers)
 
 
+def _rows_to_rebind(newest: str | None, retained: list[str]) -> list[str]:
+    """Every map row a pinned repair has to rebind, primary first, deduped.
+
+    fix(#1607 review r4). `retained` is every same-named row the force path
+    kept instead of deleting; `newest` is the one list_maps() resolves, which
+    is what the seeder's other passes target and therefore the primary. They
+    overlap in the ordinary case and must not be rebound twice.
+
+    Older duplicates exist because --force used to stack a second map beside
+    the first rather than replacing it. They are not cosmetic here: the scene
+    deletion cascades EVERY retained row's layers away at once, so a row left
+    unrebound keeps its uuid and becomes an EMPTY map. Guessing which
+    duplicate the examples link is not possible from inside this repo, and it
+    does not have to be - the loop that kept them already knows all their ids,
+    so all of them get the fresh stack.
+    """
+    rows: list[str] = []
+    for row_id in ([newest] if newest else []) + retained:
+        if row_id not in rows:
+            rows.append(row_id)
+    return rows
+
+
+def _rebind_pinned_rows(
+    api: Api, rows: list[str], name: str, layers: list[dict], view: dict
+) -> str:
+    """Give every row in `rows` the same fresh layer stack and view.
+
+    fix(#1607 review r4). Returns the primary (rows[0]) - the id the builder
+    reports and the rest of the seeder resolves. Rebinding is deliberately not
+    conditional on a row being a duplicate: an empty map and a stale map fail
+    the same way for whoever follows the link, and the work is one small
+    request per row.
+    """
+    for index, row_id in enumerate(rows):
+        _replace_map_layers(api, row_id, layers)
+        api.set_view(row_id, **view)
+        warn_if_hidden_layers(api, row_id, name)
+        if index:
+            print(f"  [pinned] also rebound duplicate row {row_id}")
+    return rows[0]
+
+
 def _find_under_either_title(
     by_title: dict, title: str, legacy: str | None
 ) -> tuple[str | None, bool]:
@@ -4743,6 +4786,10 @@ def build_sentinel2(api: Api, force: bool = False, force_pinned: bool = False) -
     # titles are NOT unique (see datasets_by_title) and the newest same-titled
     # row is not necessarily the row holding the asset (round 8).
     resolved_by_href: dict[str, str] = {}
+    # Same-named rows the loop below kept instead of deleting. Every one of
+    # them loses its layers to the scene cascade, so every one is rebound
+    # (fix(#1607 review r4)).
+    retained_rows: list[str] = []
     if force:
         # fix(#1493 review round 8): the shared-scene and conflict scans
         # below must see EVERY map and dataset. --username can select a
@@ -4913,6 +4960,7 @@ def build_sentinel2(api: Api, force: bool = False, force_pinned: bool = False) -
             # pinned maps the override leaves the old row standing, and here it
             # does not (fix(#1607 review r3)).
             if _keep_existing_map(name, True, force, force_pinned):
+                retained_rows.append(map_id)
                 print(f"  [pinned] keeping map {map_id} - rebound in place below")
                 continue
             api.delete_map(map_id)
@@ -4990,31 +5038,41 @@ def build_sentinel2(api: Api, force: bool = False, force_pinned: bool = False) -
     # deleted and authorizes nothing. Re-mint the token if one is in use. Under
     # --force-pinned the token would not survive at all, so this is the better
     # end of a trade, not a clean one.
-    map_id = api.list_maps().get(name) if keep_pinned_row else None
-    if map_id:
-        print(f"  [pinned] reusing map {map_id} (its id and share links survive)")
-    else:
-        map_id = api.create_map(
-            name,
-            "Recent low-cloud Sentinel-2 true-color scenes over New York, "
-            "streamed BY REFERENCE from the AWS Earth Search open-data archive - "
-            "no file was downloaded to build this map; Titiler reads the "
-            "cloud-optimized GeoTIFFs straight from S3, newest scene on top. "
-            "ESA Copernicus / Element84 Earth Search.",
-        )
-    _replace_map_layers(api, map_id, layers)
-    api.set_view(
-        map_id,
-        visibility="public",
-        center_lng=-73.97,
-        center_lat=40.72,
-        zoom=10.2,
-        pitch=0,
-        bearing=0,
-        basemap_style="openfreemap-positron",
-        show_basemap_labels=True,
+    rows = _rows_to_rebind(
+        api.list_maps().get(name) if keep_pinned_row else None, retained_rows
     )
-    warn_if_hidden_layers(api, map_id, name)
+    if rows:
+        print(
+            f"  [pinned] reusing {len(rows)} existing row(s) "
+            f"(ids and share links survive): {', '.join(rows)}"
+        )
+    else:
+        rows = [
+            api.create_map(
+                name,
+                "Recent low-cloud Sentinel-2 true-color scenes over New York, "
+                "streamed BY REFERENCE from the AWS Earth Search open-data "
+                "archive - no file was downloaded to build this map; Titiler "
+                "reads the cloud-optimized GeoTIFFs straight from S3, newest "
+                "scene on top. ESA Copernicus / Element84 Earth Search.",
+            )
+        ]
+    map_id = _rebind_pinned_rows(
+        api,
+        rows,
+        name,
+        layers,
+        {
+            "visibility": "public",
+            "center_lng": -73.97,
+            "center_lat": 40.72,
+            "zoom": 10.2,
+            "pitch": 0,
+            "bearing": 0,
+            "basemap_style": "openfreemap-positron",
+            "show_basemap_labels": True,
+        },
+    )
     print(f"  -> map {map_id}  ({len(scenes)} scenes)")
     return map_id
 

--- a/scripts/seed-showcase.py
+++ b/scripts/seed-showcase.py
@@ -79,6 +79,9 @@ Maintenance:
 
 Upgrading an existing instance: run with --prune to delete the retired
 first-generation showcase maps/datasets (see RETIRED_* below), then seed.
+--force rebuilds a showcase map that already exists - except the four in
+PINNED_MAP_NAMES, whose ids and share token the geolens-examples repo links.
+--force-pinned rebuilds those too, and then those links have to be updated.
 
 Requires: pip install httpx
 
@@ -504,15 +507,33 @@ QUAKE_HEATMAP_WEIGHT = [
 ]
 
 # --- externally pinned content -------------------------------------------------
-# These three are referenced from OUTSIDE this repo by UUID or by the table name
-# their title derives (the subway lines dataset backs `data.nyc_subway_lines_mta`).
+# These four are referenced from OUTSIDE this repo by UUID or by the table name
+# their title derives (the subway lines dataset backs `data.nyc_subway_lines_mta`,
+# the meteorites dataset backs `data.meteorite_landings_meteoritical_society`).
 # A metadata PATCH is safe; a retitle, delete or re-ingest is NOT - it breaks the
 # external reference silently. --prune-userdata hard-keeps them regardless of
 # owner, and nothing here may be added to RETIRED_DATASETS.
+#
+# What the DATASET pin does not cover: --force still ingests a fresh copy under
+# a NEW id (_get_or_ingest), because re-ingest is what --force means everywhere
+# in this file. Only the map pin below overrides --force. So a forced re-seed of
+# one of these titles needs the examples' fixtures.json updated with the new
+# collection id afterwards - the pin keeps a prune from taking it, not you.
+#
+# fix(#1607): before editing any list in this section, or re-ingesting a showcase
+# dataset, diff it against geolens-examples `ci/fixtures.json` and the map UUIDs
+# in that repo's `index.html`. Those are the list of what the examples actually
+# load; this section only mirrors it, and the examples' own preflight
+# (`ci/check-fixtures.mjs`) going red is the only signal today that it drifted.
 PINNED_DATASET_TITLES = (
     "NYC Subway Lines (MTA)",  # title derives data.nyc_subway_lines_mta - NEVER rename
     "NYC Subway Stations (MTA)",
     "swissALTI3D Matterhorn DEM (2m mosaic)",
+    # fix(#1607): maplibre/features-viewport.html opens on this one and pages it
+    # by viewport, the vector-tile handoff reads its MVT by table name, and
+    # search/catalog.html's fixture expects "space rocks that fell to earth" to
+    # find it - a re-ingest under a new id breaks all three at once.
+    "Meteorite Landings (Meteoritical Society)",
 )
 
 # Pinned titles the seeder did NOT create and expects a VISITOR to own.
@@ -528,6 +549,30 @@ PINNED_DATASET_TITLES = (
 # over-keeping a squatter is the accepted cost (deleting the real one breaks
 # the walkthrough; keeping a fake one frees nothing).
 PINNED_FOREIGN_DATASET_TITLES = ("MNMAP_PLUTO",)
+
+# fix(#1607): maps the examples address by an id THIS seeder minted, so the row
+# itself has to survive - a map of the same name built beside it is not the same
+# map. geolens-examples deep-links three from its gallery and embeds the fourth
+# by share token:
+#
+#   Restless Earth                    /m/NDuwpSJc3yx4Exic5Na48xO-8bpjWiaIofJefpjqfbU
+#   Manhattan - A Century of Skyline  /maps/dcae16bd-40bd-494e-bf2f-cfb378735257
+#   The Matterhorn in 3D              /maps/1c5e021a-8ede-4ebe-a06c-92322208de45
+#   New York From Orbit               /maps/1c4207ab-b1c0-4309-9924-c1ea355003a3
+#
+# Recreating one mints a fresh uuid and leaves its share tokens behind, so every
+# link above 404s while a working map sits next to them under the same name -
+# and nothing inside this repo can see that. So: --force KEEPS a pinned map that
+# already exists (_keep_existing_map), --prune and --prune-userdata hard-keep it,
+# and no path that keeps a map re-mints or revokes its share/embed tokens.
+# --force-pinned lifts the pin for an operator who means it and will re-publish
+# the links afterwards.
+PINNED_MAP_NAMES = (
+    "Restless Earth",
+    "Manhattan - A Century of Skyline",
+    "The Matterhorn in 3D",
+    "New York From Orbit - Sentinel-2, by Reference",
+)
 
 # --- globe projection ---------------------------------------------------------
 # The showcase maps whose story is GLOBAL, where Mercator actively misleads:
@@ -1787,6 +1832,48 @@ def _map_exists(api: Api, name: str) -> bool:
     return name in api.list_maps()
 
 
+def _keep_existing_map(
+    name: str, exists: bool, force: bool, force_pinned: bool
+) -> bool:
+    """Whether a builder must leave the map row that is already there alone.
+
+    fix(#1607). Pure - no API call, no printing - so the whole truth table is
+    testable, and ONE function rather than a condition spelled out in each
+    builder, so a builder added later cannot quietly grow its own rule and drop
+    a pinned map's uuid on the floor:
+
+        not exists                      -> False  build it
+        exists, no force                -> True   the long-standing skip
+        exists, force, not pinned       -> False  --force means recreate
+        exists, force, pinned           -> True   its id/share token are
+                                                  addressed from outside this
+                                                  repo (PINNED_MAP_NAMES)
+        exists, force, pinned, override -> False  --force-pinned
+    """
+    if not exists:
+        return False
+    if not force:
+        return True
+    return name in PINNED_MAP_NAMES and not force_pinned
+
+
+def _announce_kept_map(name: str, force: bool, note: str = "") -> None:
+    """The one line a builder prints when _keep_existing_map said keep.
+
+    Separate from the decision so that stays pure. The force case has to name
+    the flag that lifts the pin: an operator who typed --force and watched
+    nothing happen will otherwise go delete the map by hand, which is the exact
+    outcome the pin exists to prevent.
+    """
+    if force:
+        print(
+            f"  [pinned] {name} kept as-is: the examples address this map by id "
+            "(see PINNED_MAP_NAMES) - pass --force-pinned to recreate it anyway"
+        )
+    else:
+        print(f"  [skip] {name} already exists{note}")
+
+
 def _rename_map_if_needed(api: Api, name: str, legacy: str) -> None:
     """Migrate a map that was created under an older name.
 
@@ -1855,7 +1942,9 @@ def ensure_quake_datasets(api: Api, by_title: dict) -> tuple[str, str]:
     "re-ingest instead of reusing", but there is nothing to re-download from a
     service binding, and creating a second pair would orphan the datasets the
     Restless Earth map's layers point at. A stale binding is fixed by
-    converting, which this already does on every run.
+    converting, which this already does on every run. fix(#1607): the map row
+    is pinned for the same shape of reason - the examples embed it by share
+    token, and a token belongs to a map id.
 
     Returns (circles_dataset_id, heatmap_dataset_id).
     """
@@ -1946,11 +2035,22 @@ def prune(api: Api) -> None:
     print("\n[prune] removing retired first-generation showcase content")
     maps = api.list_maps()
     for name in RETIRED_MAPS:
-        if name in maps:
-            api.delete_map(maps[name])
-            print(f"  - map: {name}")
+        if name not in maps:
+            continue
+        # fix(#1607): the retired and pinned lists are meant to be disjoint -
+        # both pin tuples say so in words - but this is a delete keyed on a
+        # name, so it checks instead of trusting the comment. Same below for
+        # the titles.
+        if name in PINNED_MAP_NAMES:
+            print(f"  = kept, externally pinned (map): {name}")
+            continue
+        api.delete_map(maps[name])
+        print(f"  - map: {name}")
     for d in api.list_own_datasets():
         if d["title"] in RETIRED_DATASETS:
+            if d["title"] in PINNED_DATASET_TITLES + PINNED_FOREIGN_DATASET_TITLES:
+                print(f"  = kept, externally pinned (dataset): {d['title']}")
+                continue
             try:
                 api.delete_dataset(d["id"], d["title"])
                 print(f"  - dataset: {d['title']}")
@@ -2197,7 +2297,7 @@ _SHOWCASE_TITLE_PREFIXES = ("swissALTI3D 2m ", "Sentinel-2 TCI ")
 
 def _showcase_map_names() -> set[str]:
     """Every map name this seeder creates or has created."""
-    return {
+    names = {
         "Restless Earth",
         "Manhattan - A Century of Skyline",
         HURRICANE_MAP,
@@ -2208,6 +2308,10 @@ def _showcase_map_names() -> set[str]:
         "New York From Orbit - Sentinel-2, by Reference",
         "Private Embed Demo",
     } | set(RETIRED_MAPS)
+    # fix(#1607): the pinned names are folded in separately, so one of them can
+    # never read as a stray if the literals above are ever edited apart from
+    # PINNED_MAP_NAMES.
+    return names | set(PINNED_MAP_NAMES)
 
 
 def _classify_userdata(api: Api, known_maps: set, recognised) -> dict:
@@ -2218,12 +2322,24 @@ def _classify_userdata(api: Api, known_maps: set, recognised) -> dict:
     between two of these buckets is the difference between deleting a
     visitor's upload and deleting the operator's.
 
-    Ownership decides, with one override: the externally pinned datasets are
-    pulled out FIRST and land in their own bucket whoever owns them, so no
-    later branch can reach them.
+    Ownership decides, with one override: the externally pinned maps and
+    datasets are pulled out FIRST and land in their own buckets whoever owns
+    them, so no later branch can reach them.
     """
     foreign_maps, stray_maps, ownerless_maps = [], [], []
+    pinned_maps, pinned_map_impostors = [], []
     for m in api.list_all_maps():
+        if m.get("name") in PINNED_MAP_NAMES:
+            # fix(#1607): first, whoever owns it, for the same reason as the
+            # pinned datasets below - the examples address these by the uuid
+            # this seeder minted, and one of them by share token, so the ROW
+            # has to survive. A name is no more proof of identity than a title
+            # is, so a copy under another account is kept as well and reported
+            # apart, rather than hiding among the real four.
+            if m.get("created_by_username") == api.username:
+                pinned_maps.append(m)
+            else:
+                pinned_map_impostors.append(m)
         # A NULL owner is not evidence of anything. Both Map.created_by and
         # Record.created_by are ON DELETE SET NULL, so deleting a user strips
         # ownership from everything they made and leaves it looking exactly
@@ -2231,7 +2347,7 @@ def _classify_userdata(api: Api, known_maps: set, recognised) -> dict:
         # signal would destroy an operator's own work the moment their account
         # was removed, which is the one outcome this command must never
         # produce. Reported and kept, for a person to decide.
-        if m.get("created_by_username") is None:
+        elif m.get("created_by_username") is None:
             ownerless_maps.append(m)
         elif m.get("created_by_username") != api.username:
             foreign_maps.append(m)
@@ -2277,12 +2393,36 @@ def _classify_userdata(api: Api, known_maps: set, recognised) -> dict:
         "foreign_maps": foreign_maps,
         "stray_maps": stray_maps,
         "ownerless_maps": ownerless_maps,
+        "pinned_maps": pinned_maps,
+        "pinned_map_impostors": pinned_map_impostors,
         "foreign_datasets": foreign_datasets,
         "stray_datasets": stray_datasets,
         "ownerless_datasets": ownerless_datasets,
         "pinned": pinned,
         "pinned_impostors": pinned_impostors,
     }
+
+
+def _report_pinned_maps(pinned_maps: list, impostors: list) -> None:
+    """The pinned-map half of the prune report (fix(#1607)).
+
+    Its own function so prune_userdata does not grow two more loops for a rule
+    _classify_userdata has already applied. Owner is printed for the impostors
+    only: for the real four it is always the seeder, and saying so on every
+    line would bury the one row that needs a person.
+    """
+    print(f"\n  externally pinned maps, hard-kept: {len(pinned_maps)}")
+    for m in pinned_maps:
+        print(f"    = {m.get('name')!r}")
+    if impostors:
+        print(
+            f"\n  !! kept, but NOT the seeder's: {len(impostors)} map(s) carry a "
+            "pinned name while belonging to another account. The examples link "
+            "the seeder's ids, so keeping these frees nothing - review by hand:"
+        )
+        for m in impostors:
+            owner = m.get("created_by_username") or "?"
+            print(f"    ? {m.get('name')!r}  (owner: {owner})")
 
 
 def prune_userdata(api: Api, execute: bool = False) -> int:
@@ -2301,6 +2441,9 @@ def prune_userdata(api: Api, execute: bool = False) -> int:
       and KEPT. The live demo carries hand-uploaded datasets that predate this
       script, and deleting one because this file has never heard of it is
       exactly the accident this split prevents.
+    * Pinned MAPS are hard-kept whoever owns them: PINNED_MAP_NAMES, which the
+      examples repo deep-links by uuid and embeds by share token. Deleting one
+      breaks a published page in a way nothing in this repo can see.
     * Pinned datasets are hard-kept whoever owns them: PINNED_DATASET_TITLES
       (referenced from outside this repo by id or by the table name their title
       derives) and PINNED_FOREIGN_DATASET_TITLES (visitor-uploaded content that
@@ -2329,6 +2472,8 @@ def prune_userdata(api: Api, execute: bool = False) -> int:
     stray_datasets = buckets["stray_datasets"]
     pinned_hits = buckets["pinned"]
     pinned_impostors = buckets["pinned_impostors"]
+    pinned_maps = buckets["pinned_maps"]
+    pinned_map_impostors = buckets["pinned_map_impostors"]
     ownerless_maps = buckets["ownerless_maps"]
     ownerless_datasets = buckets["ownerless_datasets"]
 
@@ -2370,6 +2515,8 @@ def prune_userdata(api: Api, execute: bool = False) -> int:
         "title",
         "created_by",
     )
+
+    _report_pinned_maps(pinned_maps, pinned_map_impostors)
 
     # Ownership is still worth SHOWING for the expected-foreign pins: they are
     # trusted, but a cleanup audit that never mentions a kept dataset belongs
@@ -2413,7 +2560,8 @@ def prune_userdata(api: Api, execute: bool = False) -> int:
         print(
             f"\n  SUMMARY (dry run): would delete {len(foreign_maps)} maps and "
             f"{len(foreign_datasets)} datasets; would keep {len(stray_maps)} "
-            f"admin-owned maps, {len(stray_datasets)} admin-owned strays and "
+            f"admin-owned maps, {len(stray_datasets)} admin-owned strays, "
+            f"{len(pinned_maps) + len(pinned_map_impostors)} pinned maps and "
             f"{len(pinned_hits) + len(pinned_impostors)} pinned-title datasets "
             f"({len(pinned_foreign)} expected visitor-owned, "
             f"{len(pinned_ownerless)} ownerless, "
@@ -2446,7 +2594,8 @@ def prune_userdata(api: Api, execute: bool = False) -> int:
         f"\n  SUMMARY: deleted {deleted_maps}/{len(foreign_maps)} maps and "
         f"{deleted_datasets}/{len(foreign_datasets)} datasets; kept "
         f"{len(stray_maps)} admin-owned maps, {len(stray_datasets)} admin-owned "
-        f"strays, {len(pinned_hits) + len(pinned_impostors)} pinned-title "
+        f"strays, {len(pinned_maps) + len(pinned_map_impostors)} pinned maps, "
+        f"{len(pinned_hits) + len(pinned_impostors)} pinned-title "
         f"datasets ({len(pinned_foreign)} expected visitor-owned, "
         f"{len(pinned_ownerless)} ownerless, "
         f"{len(pinned_impostors)} impostors) and "
@@ -2459,7 +2608,7 @@ def prune_userdata(api: Api, execute: bool = False) -> int:
 # --- showcase builders -----------------------------------------------------------
 
 
-def build_catalog(api: Api, force: bool = False) -> str:
+def build_catalog(api: Api, force: bool = False, force_pinned: bool = False) -> str:
     """Catalog-only datasets - no maps. These exist to fuel the AI demos:
 
     * World Countries: rich numeric/categorical columns for AI add_layer /
@@ -2553,7 +2702,7 @@ def build_catalog(api: Api, force: bool = False) -> str:
 
 
 def build_restless_earth(
-    api: Api, force: bool = False, with_oceans: bool = True
+    api: Api, force: bool = False, with_oceans: bool = True, force_pinned: bool = False
 ) -> str:
     """The world hero: quakes + eruptions + plate boundaries + exposed cities,
     on the actual relief of the planet.
@@ -2589,8 +2738,8 @@ def build_restless_earth(
     # to run a normal seed, and that seed would take the early return.
     quakes_ds, heat_ds = ensure_quake_datasets(api, by_title)
 
-    if not force and _map_exists(api, name):
-        print(f"  [skip] {name} map already exists (quake bindings brought current)")
+    if _keep_existing_map(name, _map_exists(api, name), force, force_pinned):
+        _announce_kept_map(name, force, " (quake bindings brought current)")
         return "(skipped)"
 
     # --- plate boundaries ------------------------------------------------------
@@ -3168,7 +3317,7 @@ def build_restless_earth(
     return map_id
 
 
-def build_manhattan(api: Api, force: bool = False) -> str:
+def build_manhattan(api: Api, force: bool = False, force_pinned: bool = False) -> str:
     """The city hero: 3D extrusion at TRUE surveyed height, colored by
     construction ERA (height carries the form, color carries the story), over
     the subway in official MTA route colors with ADA-coded stations.
@@ -3181,8 +3330,8 @@ def build_manhattan(api: Api, force: bool = False) -> str:
       numeric breaks (1900 -> "1.9K"), so year breaks are unreadable there.
     """
     name = "Manhattan - A Century of Skyline"
-    if not force and _map_exists(api, name):
-        print(f"  [skip] {name} already exists")
+    if _keep_existing_map(name, _map_exists(api, name), force, force_pinned):
+        _announce_kept_map(name, force)
         return "(skipped)"
     print("\n[manhattan] Manhattan (3D by height, colored by era, + subway)")
     by_title = api.datasets_by_title()
@@ -3526,7 +3675,7 @@ def build_manhattan(api: Api, force: bool = False) -> str:
     return map_id
 
 
-def build_hurricanes(api: Api, force: bool = False) -> str:
+def build_hurricanes(api: Api, force: bool = False, force_pinned: bool = False) -> str:
     """The line-story hero: every major Atlantic hurricane since 1950 from
     NOAA HURDAT2, drawn as per-6-hour segments so each track changes color and
     width as the storm intensifies and decays.
@@ -3539,8 +3688,8 @@ def build_hurricanes(api: Api, force: bool = False) -> str:
     # Migrate before the exists-check, or the check misses the renamed map and
     # builds a duplicate next to it.
     _rename_map_if_needed(api, name, HURRICANE_MAP_LEGACY)
-    if not force and _map_exists(api, name):
-        print(f"  [skip] {name} already exists")
+    if _keep_existing_map(name, _map_exists(api, name), force, force_pinned):
+        _announce_kept_map(name, force)
         return "(skipped)"
     print("\n[hurricanes] Hurricane Alley (HURDAT2 majors since 1950)")
     by_title = api.datasets_by_title()
@@ -3925,7 +4074,9 @@ def _exposure_layer_body(exposure_ds: str) -> dict:
     }
 
 
-def build_hurricane_exposure(api: Api, force: bool = False) -> str:
+def build_hurricane_exposure(
+    api: Api, force: bool = False, force_pinned: bool = False
+) -> str:
     """The analysis hero: the only showcase map that is a computed RESULT.
 
     Three real operations, each one a provenance-tracked derived dataset:
@@ -3945,8 +4096,8 @@ def build_hurricane_exposure(api: Api, force: bool = False) -> str:
     the layer it came from. That is the thing on display.
     """
     name = EXPOSURE_MAP
-    if not force and _map_exists(api, name):
-        print(f"  [skip] {name} already exists")
+    if _keep_existing_map(name, _map_exists(api, name), force, force_pinned):
+        _announce_kept_map(name, force)
         return "(skipped)"
     print("\n[hurricane-exposure] buffer -> intersect -> dissolve (HURDAT2 majors)")
     by_title = api.datasets_by_title()
@@ -4004,7 +4155,7 @@ def build_hurricane_exposure(api: Api, force: bool = False) -> str:
     return map_id
 
 
-def build_meteorites(api: Api, force: bool = False) -> str:
+def build_meteorites(api: Api, force: bool = False, force_pinned: bool = False) -> str:
     """The cluster hero: all ~32k located meteorite landings.
 
     Above 5,000 points the viewer switches from client GeoJSON clustering to
@@ -4039,8 +4190,8 @@ def build_meteorites(api: Api, force: bool = False) -> str:
                 by_title[met_title], "meteorite_landings.geojson", meteorites_bytes()
             )
 
-    if not force and _map_exists(api, name):
-        print(f"  [skip] {name} already exists")
+    if _keep_existing_map(name, _map_exists(api, name), force, force_pinned):
+        _announce_kept_map(name, force)
         return "(skipped)"
 
     met_ds = _get_or_ingest(
@@ -4153,13 +4304,13 @@ def build_meteorites(api: Api, force: bool = False) -> str:
     return map_id
 
 
-def build_matterhorn(api: Api, force: bool = False) -> str:
+def build_matterhorn(api: Api, force: bool = False, force_pinned: bool = False) -> str:
     """The terrain hero: 3D mesh + hillshade + hypsometric tint from a VRT
     mosaic of swissALTI3D 2m lidar COGs, with dashed alpine climbing routes
     (white-cased, the classic Swiss-map convention) and labeled peaks."""
     name = "The Matterhorn in 3D"
-    if not force and _map_exists(api, name):
-        print(f"  [skip] {name} already exists")
+    if _keep_existing_map(name, _map_exists(api, name), force, force_pinned):
+        _announce_kept_map(name, force)
         return "(skipped)"
     print("\n[matterhorn] The Matterhorn (3D terrain via regional VRT mosaic)")
     by_title = api.datasets_by_title()
@@ -4404,13 +4555,13 @@ def build_matterhorn(api: Api, force: bool = False) -> str:
     return map_id
 
 
-def build_sentinel2(api: Api, force: bool = False) -> str:
+def build_sentinel2(api: Api, force: bool = False, force_pinned: bool = False) -> str:
     """The by-reference hero: recent low-cloud Sentinel-2 true color over NYC,
     streamed straight from the AWS open-data COGs - zero download at seed
     time; Titiler needs S3 egress at VIEW time."""
     name = "New York From Orbit - Sentinel-2, by Reference"
-    if not force and _map_exists(api, name):
-        print(f"  [skip] {name} already exists")
+    if _keep_existing_map(name, _map_exists(api, name), force, force_pinned):
+        _announce_kept_map(name, force)
         return "(skipped)"
     print("\n[sentinel2] New York From Orbit (COGs by reference)")
     # Query the STAC API DIRECTLY (the backend /services/stac/search proxy 502s
@@ -4649,6 +4800,17 @@ def build_sentinel2(api: Api, force: bool = False) -> str:
         if doomed:
             print(f"  [force] deleted {len(doomed)} attached scene datasets")
         for map_id in stale_maps:
+            # fix(#1607): re-checked at the irreversible step rather than
+            # trusting the early return 250 lines up. This name IS pinned, so
+            # the return already covers it - but this loop is the line that
+            # actually destroys the uuid the examples gallery links, and a
+            # guard on the decision belongs where the damage is done.
+            if _keep_existing_map(name, True, force, force_pinned):
+                print(
+                    f"  [pinned] kept existing map {map_id} "
+                    "(--force-pinned to delete it)"
+                )
+                continue
             api.delete_map(map_id)
             print(f"  [force] deleted existing map {map_id}")
     print(f"  importing {len(items)} TCI COGs by reference (no download)...")
@@ -4745,13 +4907,13 @@ PRIVATE_VIP_FC = {
 }
 
 
-def build_embed_demo(api: Api, force: bool = False) -> str:
+def build_embed_demo(api: Api, force: bool = False, force_pinned: bool = False) -> str:
     """Private-dataset embed-token capability demo. A PUBLIC share URL is
     impossible with a private dataset (publishing the map 400s), so the map
     stays PRIVATE and the X-Embed-Token header grants scoped tile access."""
     name = "Private Embed Demo"
-    if not force and _map_exists(api, name):
-        print("  [skip] Private Embed Demo already exists")
+    if _keep_existing_map(name, _map_exists(api, name), force, force_pinned):
+        _announce_kept_map(name, force)
         return "(skipped)"
     print("\n[embed] private-dataset embed-token demo")
     priv_ds = api.ingest_geojson(
@@ -4850,7 +5012,7 @@ COLLECTIONS = {
 }
 
 
-def build_collections(api: Api, force: bool = False) -> str:
+def build_collections(api: Api, force: bool = False, force_pinned: bool = False) -> str:
     """Two themed collections. Collection.name is UNIQUE -> reuse on re-runs;
     membership top-up is idempotent.
 
@@ -5905,7 +6067,15 @@ def main() -> int:
     ap.add_argument(
         "--force",
         action="store_true",
-        help="re-create showcase maps/datasets even if they already exist",
+        help="re-create showcase maps/datasets even if they already exist "
+        "(the externally pinned maps are kept - see --force-pinned)",
+    )
+    ap.add_argument(
+        "--force-pinned",
+        action="store_true",
+        help="with --force, re-create the externally pinned maps too "
+        "(PINNED_MAP_NAMES). They get new UUIDs and lose their share tokens, so "
+        "the geolens-examples links must be updated after this",
     )
     ap.add_argument(
         "--prune",
@@ -5943,6 +6113,10 @@ def main() -> int:
         # would be fine today and a trap the moment anything else grows a
         # dry-run pair.
         ap.error("--execute is only meaningful with --prune-userdata")
+    if args.force_pinned and not args.force:
+        # Same shape as --execute: a modifier, not a mode. On its own it reads
+        # like "force the pinned maps" and would do nothing whatsoever.
+        ap.error("--force-pinned is only meaningful with --force")
 
     print(f"Logging in to {args.base_url} as {args.username}...")
     api = Api.login(args.base_url, args.username, args.password)
@@ -5956,8 +6130,8 @@ def main() -> int:
 
     fns = {
         "catalog": build_catalog,
-        "restless": lambda a, force=False: build_restless_earth(
-            a, force=force, with_oceans=not args.no_oceans
+        "restless": lambda a, force=False, force_pinned=False: build_restless_earth(
+            a, force=force, with_oceans=not args.no_oceans, force_pinned=force_pinned
         ),
         "manhattan": build_manhattan,
         "hurricanes": build_hurricanes,
@@ -5994,7 +6168,10 @@ def main() -> int:
         # buildings table mid-replace): isolate each builder, report at end.
         # httpx.TimeoutException is NOT builtins.TimeoutError - catch both.
         try:
-            result = fn(api, force=args.force)
+            # Every builder takes the same (api, force, force_pinned) so the
+            # pinned-map rule cannot be forgotten by a builder added later; the
+            # two with no map of their own ignore force_pinned (fix(#1607)).
+            result = fn(api, force=args.force, force_pinned=args.force_pinned)
         except (
             httpx.HTTPStatusError,
             httpx.TimeoutException,


### PR DESCRIPTION
## What this fixes

`geolens-examples` hardcodes demo content this seeder owns, and none of it was pinned here.

Its `ci/fixtures.json` names the meteorite landings dataset: `maplibre/features-viewport.html` opens on it and pages it by viewport, the vector-tile handoff reads `data.meteorite_landings_meteoritical_society`, and `search/catalog.html` expects the phrase "space rocks that fell to earth" to find it. The same file records the Restless Earth share token that `embed/iframe.html` puts in an iframe. The gallery in `index.html` deep-links three more showcase maps by UUID.

A `--prune-userdata` run or a `--force` re-seed could take any of it, and the only signal was the examples' own preflight (`ci/check-fixtures.mjs`) going red afterwards.

## Behaviour change

`--force` no longer recreates a pinned map. If the map already exists and its name is in the new `PINNED_MAP_NAMES`, the builder takes the same early return the non-force path takes and prints a `[pinned]` line naming the override flag, so the row keeps its UUID and its share tokens. `--prune` and `--prune-userdata` hard-keep those maps too, and the prune report lists them under "externally pinned maps, hard-kept". No path that keeps a map re-mints or revokes a token on it.

The decision lives in one pure function:

```python
def _keep_existing_map(name: str, exists: bool, force: bool, force_pinned: bool) -> bool:
```

Every builder calls it, and `backend/tests/test_seed_showcase_pins_1607.py` walks the script's AST and fails if any `_map_exists()` call sits outside a `_keep_existing_map()` call. A builder added later cannot re-invent the bare `not force and _map_exists(...)` shape without tripping that test. `build_sentinel2` re-asks the same function inside its `[force] deleted existing map` loop, which is where the UUID would actually die.

## The override

`--force-pinned` lifts the pin, and only that. It is a modifier, so it errors out without `--force`, the same way `--execute` errors out without `--prune-userdata`.

It is worth being exact about what lifting the pin does, and about the fact that it does not cost the same on all four maps. For Restless Earth, Manhattan and the Matterhorn, "recreate" would be a promise this seeder does not keep. Returning `False` from `_keep_existing_map` stops the function holding the builder back; the builder then does what `--force` does for any other map, which for every builder except `build_sentinel2` is `create_map()` beside the row that is already there. So after `--force --force-pinned` the old map is still standing with the UUID and the share token the examples link attached to it, while the name resolves to the fresh row. `build_sentinel2` is the exception: its force branch deletes the stale rows under the same name first.

`build_sentinel2` is the exception in both directions: the same lifted pin sends it through its stale-map loop, which deletes every row under the name **and their share links** before rebuilding. So on the one pinned map with a documented `--force` repair, the override really does destroy the externally referenced UUID. The `--force-pinned` help splits those two cases and names the map, and there is a test asserting the rendered `--help` (not the source string) carries it.

That is the pre-existing `--force` behaviour for every non-Sentinel map and this PR does not change it. What it does change is the words: the flag's help, the `[pinned]` print, the `PINNED_MAP_NAMES` comment and the `_keep_existing_map` docstring all now say a fresh row is built beside the old one, that the old row keeps its id and share links until someone removes it, and that the operator has to move the `geolens-examples` references (`ci/fixtures.json`, `index.html`) onto the new ids or keep the old row.

## The Sentinel repair

`--only sentinel2 --force` is the documented repair for instances seeded before `item_href` was sent, so the pin cannot simply stop that builder: an early return would leave the repair reachable only through `--force-pinned`, the one flag that mints the new UUID the examples must not get.

`build_sentinel2` therefore does not return on a pinned keep. It runs the force preflight, the attached-scene deletion and the STAC import exactly as before, then reuses the existing row instead of calling `create_map`, rebinding the layers through a new helper:

```python
def _replace_map_layers(api: Api, map_id: str, layers: list[dict]) -> int:
```

so the map keeps its id and its share links while its scenes are re-imported. Deleting a scene already cascades its layers away (`MapLayer.dataset_id` is `ON DELETE CASCADE`, checked in `backend/app/modules/catalog/maps/models.py`), so the delete pass in that helper is what catches the layers that did *not* cascade: the ones whose scene was kept because another map shares it.

Every retained row is rebound, not just the resolved one. The scene deletion cascades the layers off all same-named rows at once, so where an older `--force` stacked duplicates, rebinding only the primary would leave the others holding their UUIDs with no layers: an empty map behind a link the examples may use, which is worse than the stale map the pin exists to prevent. The stale-map loop already enumerates those ids, so it records what it keeps and `_rows_to_rebind()` puts the resolved row first and dedups; `_rebind_pinned_rows()` gives each the fresh stack and view. No guessing which duplicate is the externally linked one, which is not answerable from inside this repo. The resolved row is the primary because it is what the globe projection, the styling pass and the prune classifier all already target, so the repair cannot disagree with the rest of the file. It is re-resolved *after* the import rather than carried across it, so a row that disappeared in that window falls through to `create_map` instead of raising.

The stale-map loop stays pin-aware, and `--force-pinned` keeps today's delete-and-recreate. Every other builder keeps the early return: their layers point at datasets this seeder refreshes in place, so there is no repair a rebuild would perform that a plain re-run does not. The `_keep_existing_map` docstring says which caller reads a `True` as "keep the row" rather than "do nothing".

### Exercised for real

Run against a disposable local dev instance seeded with the showcase (never the demo): `--only sentinel2 --force`, exit 0.

```
  [pinned] New York From Orbit - Sentinel-2, by Reference will be REPAIRED in place: ...
  newest low-cloud scene: 2026-08-19 (sentinel-2-c1-l2a)
  [force] deleted 4 attached scene datasets
  [pinned] keeping map b852a1d8-bcb9-44de-b344-02db7bef3466 - rebound in place below
  importing 4 TCI COGs by reference (no download)...
  [pinned] reusing map b852a1d8-bcb9-44de-b344-02db7bef3466 (its id and share links survive)
  -> map b852a1d8-bcb9-44de-b344-02db7bef3466  (4 scenes)
```

Before/after diff, all passing: map id unchanged; `created_at` unchanged (`2026-08-02T10:51:25Z`, so it is the same row, not a rebuild); one row named "New York From Orbit" before and after, so no duplicate; all four layer ids replaced with zero overlap; layer count equals the fresh scene count; layers bound to the new scene datasets, each resolving HTTP 200; `visibility: public` unchanged; the embed-token row survived with the same id and hint. Anonymous `GET /api/maps/{id}` returns 200 with 4 layers, which is what the gallery deep-link does, `visibility_check` reports no non-public datasets, and a raster tile from a rebound layer serves a 191 KB PNG.

A second run with a same-named duplicate planted and bound to the same scenes confirmed the multi-row path: both rows survived, both came out with the identical fresh four-scene stack, every layer's dataset resolving 200. The planted duplicate was deleted afterwards. Before that fix the older row would have been left with zero layers.

One thing the run measured that "share links survive" does not cover: an embed token's `scoped_dataset_ids` is a snapshot of the map's layers at mint time, so after the re-import it still names the deleted scenes and authorizes nothing. The token has to be re-minted. That is inherent to re-importing scenes rather than a consequence of this change, and under `--force-pinned` there would be no token left to re-mint; it is now written down where the reuse happens.

## The reported outcome

A pinned builder used to return `"(skipped)"`, so `main()` printed "use --force to recreate" one line after the `[pinned]` line said `--force` had declined to. The keep now returns a distinct `"(pinned)"` marker, chosen by the same helper that prints the line so the two cannot drift, and `_builder_outcome_line()` picks the wording. A falsy result keeps the generic line it always had, and `build_catalog`/`build_collections`, which return sentinels of their own, still count as built.

## Also

`Meteorite Landings (Meteoritical Society)` joins `PINNED_DATASET_TITLES`. The comment above the pin lists now carries the third point from the issue: before editing them, or re-ingesting a showcase dataset, diff against the examples' `ci/fixtures.json` and the map UUIDs in its `index.html`. It also states plainly what the dataset pin does not cover: `--force` still ingests a fresh copy under a new id, because re-ingest is what `--force` means everywhere else in the file. Only the map pin overrides `--force`.

## CI

`scripts/seed-showcase.py` is added to the `backend` paths-filter in `ci.yml`. The new test reads the seeder by literal path, and `test_ci_alembic_filter_paths.py` requires that: without the entry a seeder-only PR skips Backend Tests, so the test written to catch a dropped pin sits skipped while the required job reports green. That is the #1027 failure mode the guard exists for, and it caught this PR on the first run.

## Schema, API, config

No schema, API, or config surface. One script, one test, one paths-filter line.

## Verification

Written red first. Against the pre-change script the new file was 25 failed, 2 passed (the two passing ones are the AST checker's own counterfactuals, which are independent of the script and pass in both states). After the change, 28 passed.

The `--prune` guard has its own red: run against the pre-change script, `test_prune_keeps_a_pinned_name_that_also_appears_in_a_retired_list` printed `- map: Restless Earth` and `- dataset: Meteorite Landings (Meteoritical Society)` and failed.

```
cd backend && uv run ruff check ../scripts/seed-showcase.py .    # scripts/ carries 5 pre-existing C901s, unchanged
cd backend && uv run ruff format --check .                        # clean
cd backend && uv run pytest tests/test_seed_showcase_pins_1607.py \
    tests/test_seed_tiles.py tests/test_seed_admin_concurrency.py \
    tests/test_layering.py -q                                     # 103 passed
pre-commit run --files scripts/seed-showcase.py \
    backend/tests/test_seed_showcase_pins_1607.py                 # all hooks pass
```

Against a local dev stack carrying the same showcase content, `--prune-userdata` (dry run, no `--execute`):

```
  externally pinned maps, hard-kept: 5
    = 'The Matterhorn in 3D'
    = 'The Matterhorn in 3D'
    = 'New York From Orbit - Sentinel-2, by Reference'
    = 'Manhattan - A Century of Skyline'
    = 'Restless Earth'

  externally pinned, hard-kept: 4
    = 'swissALTI3D Matterhorn DEM (2m mosaic)'
    = 'Meteorite Landings (Meteoritical Society)'
    = 'NYC Subway Stations (MTA)'
    = 'NYC Subway Lines (MTA)'
```

Five rather than four because that instance carries two rows named "The Matterhorn in 3D"; the prune classifier reads every row, unlike `list_maps()`, which collapses a name.

There is no dry-run flag on the builder path, so nothing forced was run locally. The decision was checked read-only instead, calling `_map_exists` and `_keep_existing_map` against the live map list:

```
map name                                           exists  --force  --force --force-pinned
Restless Earth                                     True    KEEP     recreate
Manhattan - A Century of Skyline                   True    KEEP     recreate
The Matterhorn in 3D                               True    KEEP     recreate
New York From Orbit - Sentinel-2, by Reference     True    KEEP     recreate
Hurricane Alley - Major Atlantic Storms Since 1950 True    recreate recreate
Everything That Fell From the Sky                  True    recreate recreate
```

`recreate` in that last column means only "the pin no longer keeps this row"; see the override section above for what the builder then does.

Nothing was run against the public demo.

Closes #1607
