### PR TITLE
fix(config): accept ambient AWS credentials for S3 storage

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -474,6 +474,18 @@ class Settings(BaseSettings):
     s3_allow_http: bool = False
     s3_addressing_style: Literal["auto", "path", "virtual"] = "auto"
 
+    # Ambient AWS credential markers, injected by the runtime rather than by an
+    # operator: EKS IRSA / Pod Identity set AWS_ROLE_ARN +
+    # AWS_WEB_IDENTITY_TOKEN_FILE, and the ECS/EKS container credential
+    # providers set one of the AWS_CONTAINER_CREDENTIALS_* pair. Modelled as
+    # fields rather than read through os.environ, matching CONF-03/CONF-04.
+    # Read only by has_ambient_aws_credentials below; boto3 and GDAL resolve
+    # the actual credentials from these themselves.
+    aws_role_arn: str | None = None
+    aws_web_identity_token_file: str | None = None
+    aws_container_credentials_full_uri: str | None = None
+    aws_container_credentials_relative_uri: str | None = None
+
     # Azure Blob Storage (STOR-01 / Phase 1210)
     azure_storage_container: str | None = None
     azure_storage_connection_string: SecretStr | None = (
@@ -1027,18 +1039,54 @@ class Settings(BaseSettings):
             )
         return self
 
+    @property
+    def has_ambient_aws_credentials(self) -> bool:
+        """True when the runtime supplies AWS credentials the SDKs resolve alone.
+
+        Covers EKS IRSA / Pod Identity (web-identity token) and the ECS/EKS
+        container credential providers. EC2 instance profiles are deliberately
+        NOT probed: detecting one needs an IMDS round trip during settings
+        construction, and a node role broad enough to reach the bucket is not a
+        posture to boot silently into — set the keys, or use IRSA.
+        """
+        return bool(
+            (self.aws_role_arn and self.aws_web_identity_token_file)
+            or self.aws_container_credentials_full_uri
+            or self.aws_container_credentials_relative_uri
+        )
+
     @model_validator(mode="after")
     def validate_provider_settings(self) -> "Settings":
         if self.storage_provider == "s3":
             missing: list[str] = []
             if not self.s3_bucket:
                 missing.append("S3_BUCKET")
-            if not self.s3_access_key_id:
+            # A static key pair is one of two supported credential sources. The
+            # other is ambient (IRSA / Pod Identity / container credentials),
+            # which S3StorageProvider and derive_gdal_s3_env already support:
+            # both omit the explicit key arguments when unset, leaving boto3 and
+            # GDAL to resolve the role themselves. Requiring the pair here was
+            # the ONLY thing forcing long-lived IAM user keys into a Kubernetes
+            # Secret on EKS.
+            #
+            # A HALF-configured pair stays an error under either source: it is
+            # always a mistake, and boto3 fails it far less legibly at runtime.
+            if not self.s3_access_key_id and not self.s3_secret_access_key:
+                if not self.has_ambient_aws_credentials:
+                    missing.append("S3_ACCESS_KEY_ID")
+                    missing.append("S3_SECRET_ACCESS_KEY")
+            elif not self.s3_access_key_id:
                 missing.append("S3_ACCESS_KEY_ID")
-            if not self.s3_secret_access_key:
+            elif not self.s3_secret_access_key:
                 missing.append("S3_SECRET_ACCESS_KEY")
             if missing:
-                raise ValueError("STORAGE_PROVIDER=s3 requires: " + ", ".join(missing))
+                raise ValueError(
+                    "STORAGE_PROVIDER=s3 requires: "
+                    + ", ".join(missing)
+                    + " (or ambient AWS credentials: on EKS, annotate the "
+                    "ServiceAccount with eks.amazonaws.com/role-arn and leave "
+                    "both keys unset)"
+                )
         elif self.storage_provider == "azure":
             if not self.azure_storage_container:
                 raise ValueError(

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -16,6 +16,19 @@ BASE_ENV = {
     "geolens_admin_password": "adminpass",
 }
 
+# Pinned off for every _make_settings() call: these are read from the ambient
+# environment, so a developer or runner that happens to export them (anything
+# running inside EKS or ECS) would otherwise satisfy the s3 credential
+# requirement and flip the expectations in TestConditionalValidation. Kept out
+# of BASE_ENV because that dict is also replayed through monkeypatch.setenv,
+# which takes str values only.
+_AMBIENT_AWS_OFF = {
+    "aws_role_arn": None,
+    "aws_web_identity_token_file": None,
+    "aws_container_credentials_full_uri": None,
+    "aws_container_credentials_relative_uri": None,
+}
+
 
 def _make_settings(**overrides):
     """Create a fresh Settings instance with given env overrides.
@@ -25,7 +38,7 @@ def _make_settings(**overrides):
     an independent Settings instance — the module-level ``settings`` singleton
     in ``app.config`` is never touched.
     """
-    env = {**BASE_ENV, **overrides}
+    env = {**BASE_ENV, **_AMBIENT_AWS_OFF, **overrides}
     return Settings(**env)
 
 
@@ -487,6 +500,59 @@ class TestConditionalValidation:
             s3_secret_access_key="secret",
         )
         assert s.storage_provider == "s3"
+
+    def test_s3_ambient_irsa_credentials_allow_missing_keys(self):
+        """EKS IRSA: the runtime injects a web-identity token, boto3 and GDAL
+        resolve the role themselves, and no static key pair should be needed."""
+        s = _make_settings(
+            storage_provider="s3",
+            s3_bucket="my-bucket",
+            aws_role_arn="arn:aws:iam::123456789012:role/geolens",
+            aws_web_identity_token_file=(
+                "/var/run/secrets/eks.amazonaws.com/serviceaccount/token"
+            ),
+        )
+        assert s.storage_provider == "s3"
+        assert s.has_ambient_aws_credentials is True
+        assert s.s3_access_key_id is None
+
+    def test_s3_ambient_container_credentials_allow_missing_keys(self):
+        s = _make_settings(
+            storage_provider="s3",
+            s3_bucket="my-bucket",
+            aws_container_credentials_full_uri="http://169.254.170.23/v1/creds",
+        )
+        assert s.has_ambient_aws_credentials is True
+
+    def test_s3_role_arn_without_token_file_is_not_ambient(self):
+        """Both halves of the web-identity pair are required — a lone
+        AWS_ROLE_ARN resolves no credentials, so it must not unlock the keys."""
+        with pytest.raises(Exception) as exc_info:
+            _make_settings(
+                storage_provider="s3",
+                s3_bucket="my-bucket",
+                aws_role_arn="arn:aws:iam::123456789012:role/geolens",
+            )
+        assert "S3_ACCESS_KEY_ID" in str(exc_info.value)
+
+    def test_s3_half_configured_key_pair_raises_even_with_ambient(self):
+        """A half-set static pair is always a mistake; ambient must not mask it."""
+        with pytest.raises(Exception) as exc_info:
+            _make_settings(
+                storage_provider="s3",
+                s3_bucket="my-bucket",
+                s3_access_key_id="key",
+                aws_role_arn="arn:aws:iam::123456789012:role/geolens",
+                aws_web_identity_token_file="/var/run/secrets/token",
+            )
+        err = str(exc_info.value)
+        assert "S3_SECRET_ACCESS_KEY" in err
+        assert "S3_ACCESS_KEY_ID" not in err
+
+    def test_s3_missing_keys_error_points_at_the_ambient_option(self):
+        with pytest.raises(Exception) as exc_info:
+            _make_settings(storage_provider="s3", s3_bucket="my-bucket")
+        assert "eks.amazonaws.com/role-arn" in str(exc_info.value)
 
     def test_ssl_verify_full_without_cert_raises(self):
         with pytest.raises(Exception) as exc_info:

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -2950,7 +2950,18 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # deliberately stricter than a browser, so a future "browser accepts,
     # we reject" report is read against that list first. Cap 1307 -> 1375,
     # exact.
-    "backend/app/core/config.py": 1375,
+    #
+    # Ambient AWS credentials: four runtime-injected marker fields
+    # (AWS_ROLE_ARN / AWS_WEB_IDENTITY_TOKEN_FILE and the two
+    # AWS_CONTAINER_CREDENTIALS_* forms), the has_ambient_aws_credentials
+    # property that reads them, and the rework of the s3 branch of
+    # validate_provider_settings to accept EITHER a complete static key pair or
+    # an ambient source while still rejecting a half-configured pair. Bought
+    # keyless S3 on EKS (IRSA): the storage layer and derive_gdal_s3_env
+    # already omitted unset keys, so this validator was the only thing forcing
+    # long-lived IAM user keys into a Kubernetes Secret. Cap 1375 -> 1423,
+    # exact.
+    "backend/app/core/config.py": 1423,
     # fix(#1543): first entry — crossed _RATCHET_INCLUSION_LOC on the change
     # that gave PersistentConfig a batch eviction. The code is small
     # (apply_side_effects_batch, plus splitting the process-local half of

--- a/scripts/check_env_doc_drift.py
+++ b/scripts/check_env_doc_drift.py
@@ -43,6 +43,17 @@ SETTINGS_DOC_ALLOWLIST: frozenset[str] = frozenset(
         "POSTGRES_DB_TEST",
         # Shared-volume invariant: Compose pins this to /app/staging.
         "UPLOAD_STAGING_DIR",
+        # Injected by the runtime, never set by a host operator: EKS IRSA and
+        # Pod Identity write the web-identity pair into the pod, and the
+        # ECS/EKS container credential providers write the other two. The
+        # Settings fields exist only so has_ambient_aws_credentials can read
+        # them the documented way instead of through os.environ. Putting them
+        # in .env.example would invite operators to set by hand what a platform
+        # is supposed to supply, and a hand-set AWS_ROLE_ARN resolves nothing.
+        "AWS_ROLE_ARN",
+        "AWS_WEB_IDENTITY_TOKEN_FILE",
+        "AWS_CONTAINER_CREDENTIALS_FULL_URI",
+        "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI",
     }
 )
 


### PR DESCRIPTION
## What

`STORAGE_PROVIDER=s3` required `S3_ACCESS_KEY_ID` and `S3_SECRET_ACCESS_KEY` at boot, so a Kubernetes deployment had to keep long-lived IAM user keys in a Secret. This accepts an ambient credential source (EKS IRSA / Pod Identity, ECS/EKS container credentials) in their place.

## Why this is a validator-only change

Nothing below `validate_provider_settings` needed the keys:

- `S3StorageProvider` (`platform/storage/s3.py:94-97`) passes `aws_access_key_id` / `aws_secret_access_key` to boto3 **only if set**.
- `derive_gdal_s3_env` guards every `AWS_*` key the same way, and its docstring already anticipates "ambient AWS credentials".

## Verified on real infrastructure

Run on an EKS 1.33 cluster against a real S3 bucket, with the ServiceAccount annotated for IRSA:

| probe | result |
| --- | --- |
| boto3 in the api pod, no explicit credentials | resolved `assumed-role/…/botocore-session-…`, listed the bucket, read an object |
| GDAL/rasterio in the titiler pod, `AWS_ACCESS_KEY_ID` unset | opened `/vsis3/<bucket>/rasters/…/source.cog.tif` |
| booting with s3 and no static keys (before this change) | `FATAL: STORAGE_PROVIDER=s3 requires: S3_ACCESS_KEY_ID, S3_SECRET_ACCESS_KEY` |
| control: with keys | boots |

After the change, with the patched settings deployed and **no credential anywhere in the cluster**, the whole path worked end to end: vector ingest, raster ingest, tile rendering, export. The app logs the source itself — `credential_source=assume-role-with-web-identity`.

## Design notes

- Modelled as four settings fields rather than raw `os.environ` reads, per the CONF-03/CONF-04 convention already in this file.
- A **half-configured** key pair stays an error under either source — that is always a mistake, and boto3 fails it far less legibly at runtime.
- A lone `AWS_ROLE_ARN` does not count as ambient: without the token file it resolves nothing.
- EC2 instance profiles are deliberately **not** probed. That needs an IMDS round trip during settings construction, and a node role broad enough to reach the bucket is not a posture to boot into silently.
- `_make_settings` in the tests pins the four fields off, so the suite cannot flip behaviour when it happens to run inside EKS or ECS.

## Verification

```
backend: pytest tests/test_config.py tests/test_gdal_env.py   209 passed
backend: pytest tests/test_layering.py                         47 passed
ruff check / ruff format --check                               clean
```

Counterfactual: reverting `config.py` alone fails 3 of the 5 new tests (the other 2 are negative guards, correct in both versions).

`_MODULE_LOC_CAPS` for `core/config.py` moves 1375 → 1423 with the rationale recorded inline, per AGENTS.md.

## Companion change

The Helm chart side is geolens-deployments — `storage.s3AmbientCredentials` plus a ServiceAccount to hang the role on. That chart value requires this fix to be released before it does anything.
