### PR TITLE
fix(config): give ogr2ogr the CA path under verify-full

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -1341,7 +1341,13 @@ class Settings(BaseSettings):
                 parts.append(f"password={libpq_value(unquote(parsed.password))}")
             if self.database_ssl_mode != "disable":
                 parts.append(f"sslmode={self.database_ssl_mode}")
-            if self.database_ssl_ca_cert:
+            # verify-full ONLY. libpq treats sslmode=require as verify-ca as
+            # soon as a root CA file is present, so emitting this under
+            # `require` would make ogr2ogr and Procrastinate verify the server
+            # certificate while database_connect_args explicitly disables that
+            # check for the API — the same divergence between clients this
+            # property exists to remove (codex review on #1617).
+            if self.database_ssl_mode == "verify-full" and self.database_ssl_ca_cert:
                 parts.append(f"sslrootcert={libpq_value(self.database_ssl_ca_cert)}")
             # BUG-002: the non-override branch sets
             # options='-c search_path=<schema>,public' so procrastinate's
@@ -1408,7 +1414,13 @@ class Settings(BaseSettings):
             # always emitted this pair together; this is the sibling that did
             # not. Emitted whenever a CA is configured: libpq ignores it under
             # the modes that do not verify.
-            if self.database_ssl_ca_cert:
+            # verify-full ONLY. libpq treats sslmode=require as verify-ca as
+            # soon as a root CA file is present, so emitting this under
+            # `require` would make ogr2ogr and Procrastinate verify the server
+            # certificate while database_connect_args explicitly disables that
+            # check for the API — the same divergence between clients this
+            # property exists to remove (codex review on #1617).
+            if self.database_ssl_mode == "verify-full" and self.database_ssl_ca_cert:
                 parts.append(f"sslrootcert={libpq_value(self.database_ssl_ca_cert)}")
             return " ".join(parts)
         return (

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -1368,6 +1368,19 @@ class Settings(BaseSettings):
                 parts.append(f"password={parsed.password}")
             if self.database_ssl_mode not in ("disable", "prefer"):
                 parts.append(f"sslmode={self.database_ssl_mode}")
+            # ogr2ogr reaches PostGIS through libpq, which resolves the CA from
+            # the DSN or from its own ~/.postgresql/root.crt — it cannot see
+            # DATABASE_SSL_CA_CERT, which only reaches asyncpg as an SSLContext.
+            # Without this, sslmode=verify-full above sends libpq looking for a
+            # root.crt that is not in the image, and EVERY vector ingest fails
+            # ("root certificate file ... does not exist") while the api, the
+            # worker's own queue connection and raster ingest all stay healthy,
+            # because those paths never shell out. procrastinate_conninfo has
+            # always emitted this pair together; this is the sibling that did
+            # not. Emitted whenever a CA is configured: libpq ignores it under
+            # the modes that do not verify.
+            if self.database_ssl_ca_cert:
+                parts.append(f"sslrootcert={self.database_ssl_ca_cert}")
             return " ".join(parts)
         return (
             f"PG:host={self.postgres_host} "

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -21,6 +21,27 @@ def reveal(secret: SecretStr | None) -> str | None:
     return secret.get_secret_value() if secret is not None else None
 
 
+def libpq_value(value: object) -> str:
+    """Render one value for a libpq keyword/value connection string.
+
+    libpq splits `keyword=value` pairs on whitespace, so a value containing a
+    space — a CA path under a directory with one, a generated password — ends
+    the pair early and produces a malformed DSN. The documented escape is to
+    single-quote the value and backslash-escape any single quote or backslash
+    inside it.
+
+    Quoting is applied only when the value actually needs it. GDAL parses the
+    remainder of a `PG:` string itself before handing it to libpq, so leaving
+    ordinary values bare keeps the emitted DSN byte-identical to what every
+    existing deployment already passes through that driver.
+    """
+    text = str(value)
+    if text and not re.search(r"""[\s'\\]""", text):
+        return text
+    escaped = text.replace("\\", "\\\\").replace("'", "\\'")
+    return f"'{escaped}'"
+
+
 def validate_privacy_url_shape(v: str) -> str:
     r"""PRIV-1: shape check for the login/register privacy-policy link.
 
@@ -1292,7 +1313,7 @@ class Settings(BaseSettings):
     @property
     def procrastinate_conninfo(self) -> str:
         if self.database_url_override:
-            from urllib.parse import parse_qs, urlparse
+            from urllib.parse import parse_qs, unquote, urlparse
 
             raw = self.database_url_override
             for prefix in ("postgresql+asyncpg://", "postgresql+psycopg://"):
@@ -1305,19 +1326,19 @@ class Settings(BaseSettings):
             parts = []
             host = parsed.hostname or parse_qs(parsed.query).get("host", [None])[0]
             if host:
-                parts.append(f"host={host}")
+                parts.append(f"host={libpq_value(host)}")
             if parsed.port:
                 parts.append(f"port={parsed.port}")
             if parsed.path and parsed.path != "/":
-                parts.append(f"dbname={parsed.path.lstrip('/')}")
+                parts.append(f"dbname={libpq_value(unquote(parsed.path.lstrip('/')))}")
             if parsed.username:
-                parts.append(f"user={parsed.username}")
+                parts.append(f"user={libpq_value(unquote(parsed.username))}")
             if parsed.password:
-                parts.append(f"password={parsed.password}")
+                parts.append(f"password={libpq_value(unquote(parsed.password))}")
             if self.database_ssl_mode != "disable":
                 parts.append(f"sslmode={self.database_ssl_mode}")
             if self.database_ssl_ca_cert:
-                parts.append(f"sslrootcert={self.database_ssl_ca_cert}")
+                parts.append(f"sslrootcert={libpq_value(self.database_ssl_ca_cert)}")
             # BUG-002: the non-override branch sets
             # options='-c search_path=<schema>,public' so procrastinate's
             # unqualified objects resolve in the catalog schema. The override
@@ -1344,7 +1365,7 @@ class Settings(BaseSettings):
     @property
     def ogr_connection_string(self) -> str:
         if self.database_url_override:
-            from urllib.parse import parse_qs, urlparse
+            from urllib.parse import parse_qs, unquote, urlparse
 
             raw = self.database_url_override
             for prefix in ("postgresql+asyncpg://", "postgresql+psycopg://"):
@@ -1357,15 +1378,15 @@ class Settings(BaseSettings):
             parts = ["PG:"]
             host = parsed.hostname or parse_qs(parsed.query).get("host", [None])[0]
             if host:
-                parts.append(f"host={host}")
+                parts.append(f"host={libpq_value(host)}")
             if parsed.port:
                 parts.append(f"port={parsed.port}")
             if parsed.path and parsed.path != "/":
-                parts.append(f"dbname={parsed.path.lstrip('/')}")
+                parts.append(f"dbname={libpq_value(unquote(parsed.path.lstrip('/')))}")
             if parsed.username:
-                parts.append(f"user={parsed.username}")
+                parts.append(f"user={libpq_value(unquote(parsed.username))}")
             if parsed.password:
-                parts.append(f"password={parsed.password}")
+                parts.append(f"password={libpq_value(unquote(parsed.password))}")
             if self.database_ssl_mode not in ("disable", "prefer"):
                 parts.append(f"sslmode={self.database_ssl_mode}")
             # ogr2ogr reaches PostGIS through libpq, which resolves the CA from
@@ -1380,7 +1401,7 @@ class Settings(BaseSettings):
             # not. Emitted whenever a CA is configured: libpq ignores it under
             # the modes that do not verify.
             if self.database_ssl_ca_cert:
-                parts.append(f"sslrootcert={self.database_ssl_ca_cert}")
+                parts.append(f"sslrootcert={libpq_value(self.database_ssl_ca_cert)}")
             return " ".join(parts)
         return (
             f"PG:host={self.postgres_host} "

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -21,6 +21,23 @@ def reveal(secret: SecretStr | None) -> str | None:
     return secret.get_secret_value() if secret is not None else None
 
 
+def libpq_ssl_parts(mode: str, ca_cert: str | None) -> list[str]:
+    """Return the libpq TLS keyword/value pairs for one connection string.
+
+    Shared so the override and component-field branches of both DSN builders
+    cannot drift: a deployment that configures PostgreSQL through POSTGRES_HOST
+    rather than DATABASE_URL_OVERRIDE gets the same TLS posture. `disable` and
+    `prefer` emit nothing because libpq already defaults to prefer, and the CA
+    is emitted only for verify-full (see ogr_connection_string).
+    """
+    parts: list[str] = []
+    if mode not in ("disable", "prefer"):
+        parts.append(f"sslmode={mode}")
+    if mode == "verify-full" and ca_cert:
+        parts.append(f"sslrootcert={libpq_value(ca_cert)}")
+    return parts
+
+
 def libpq_value(value: object) -> str:
     """Render one value for a libpq keyword/value connection string.
 
@@ -1365,12 +1382,16 @@ class Settings(BaseSettings):
             )
             parts.append(f"options='{combined_options}'")
             return " ".join(parts)
-        return (
-            f"host={self.postgres_host} port={self.postgres_port} "
-            f"dbname={self.postgres_db} user={self.postgres_user} "
-            f"password={self.postgres_password.get_secret_value()} "
-            f"options='-c search_path={self.procrastinate_schema},public'"
-        )
+        parts = [
+            f"host={libpq_value(self.postgres_host)}",
+            f"port={self.postgres_port}",
+            f"dbname={libpq_value(self.postgres_db)}",
+            f"user={libpq_value(self.postgres_user)}",
+            f"password={libpq_value(self.postgres_password.get_secret_value())}",
+        ]
+        parts += libpq_ssl_parts(self.database_ssl_mode, self.database_ssl_ca_cert)
+        parts.append(f"options='-c search_path={self.procrastinate_schema},public'")
+        return " ".join(parts)
 
     @property
     def ogr_connection_string(self) -> str:
@@ -1423,13 +1444,16 @@ class Settings(BaseSettings):
             if self.database_ssl_mode == "verify-full" and self.database_ssl_ca_cert:
                 parts.append(f"sslrootcert={libpq_value(self.database_ssl_ca_cert)}")
             return " ".join(parts)
-        return (
-            f"PG:host={self.postgres_host} "
-            f"port={self.postgres_port} "
-            f"dbname={self.postgres_db} "
-            f"user={self.postgres_user} "
-            f"password={self.postgres_password.get_secret_value()}"
-        )
+        parts = [
+            "PG:",
+            f"host={libpq_value(self.postgres_host)}",
+            f"port={self.postgres_port}",
+            f"dbname={libpq_value(self.postgres_db)}",
+            f"user={libpq_value(self.postgres_user)}",
+            f"password={libpq_value(self.postgres_password.get_secret_value())}",
+        ]
+        parts += libpq_ssl_parts(self.database_ssl_mode, self.database_ssl_ca_cert)
+        return " ".join(parts)
 
     model_config = SettingsConfigDict(
         env_file=str(_PROJECT_ROOT_ENV),

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -1330,7 +1330,11 @@ class Settings(BaseSettings):
             if parsed.port:
                 parts.append(f"port={parsed.port}")
             if parsed.path and parsed.path != "/":
-                parts.append(f"dbname={libpq_value(unquote(parsed.path.lstrip('/')))}")
+                parts.append(f"dbname={libpq_value(parsed.path.lstrip('/'))}")
+            # unquote on the credentials ONLY: SQLAlchemy decodes username and
+            # password but leaves the database name percent-encoded, so decoding
+            # dbname here would make these two clients target a DIFFERENT
+            # database than the API (codex review on #1617).
             if parsed.username:
                 parts.append(f"user={libpq_value(unquote(parsed.username))}")
             if parsed.password:
@@ -1382,7 +1386,11 @@ class Settings(BaseSettings):
             if parsed.port:
                 parts.append(f"port={parsed.port}")
             if parsed.path and parsed.path != "/":
-                parts.append(f"dbname={libpq_value(unquote(parsed.path.lstrip('/')))}")
+                parts.append(f"dbname={libpq_value(parsed.path.lstrip('/'))}")
+            # unquote on the credentials ONLY: SQLAlchemy decodes username and
+            # password but leaves the database name percent-encoded, so decoding
+            # dbname here would make these two clients target a DIFFERENT
+            # database than the API (codex review on #1617).
             if parsed.username:
                 parts.append(f"user={libpq_value(unquote(parsed.username))}")
             if parsed.password:

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -1215,3 +1215,36 @@ class TestRootCaOnlyUnderVerifyFull:
         )
         for dsn in (s.ogr_connection_string, s.procrastinate_conninfo):
             assert "sslrootcert=/etc/ssl/rds/ca.pem" in dsn
+
+
+class TestComponentFieldDsnCarriesTls:
+    """codex review on #1617: a deployment configured through POSTGRES_HOST
+    rather than DATABASE_URL_OVERRIDE took a branch that emitted no sslmode and
+    no sslrootcert at all, so ogr2ogr and Procrastinate connected under libpq's
+    default while the API honoured DATABASE_SSL_MODE — the same divergence in a
+    branch the original fix did not touch."""
+
+    def test_verify_full_reaches_both_component_field_builders(self):
+        s = _make_settings(
+            database_ssl_mode="verify-full",
+            database_ssl_ca_cert="/etc/ssl/rds/ca.pem",
+        )
+        for dsn in (s.ogr_connection_string, s.procrastinate_conninfo):
+            assert "sslmode=verify-full" in dsn
+            assert "sslrootcert=/etc/ssl/rds/ca.pem" in dsn
+
+    def test_prefer_emits_nothing_since_libpq_already_defaults_to_it(self):
+        s = _make_settings(database_ssl_mode="prefer")
+        for dsn in (s.ogr_connection_string, s.procrastinate_conninfo):
+            assert "sslmode" not in dsn
+
+    def test_component_field_values_are_libpq_quoted(self):
+        s = _make_settings(postgres_password="pass word")
+        for dsn in (s.ogr_connection_string, s.procrastinate_conninfo):
+            assert "password='pass word'" in dsn
+
+    def test_procrastinate_keeps_its_search_path(self):
+        s = _make_settings(
+            database_ssl_mode="verify-full", database_ssl_ca_cert="/c.pem"
+        )
+        assert "options='-c search_path=catalog,public'" in s.procrastinate_conninfo

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -1189,3 +1189,29 @@ class TestLibpqValueQuoting:
         for dsn in (s.ogr_connection_string, s.procrastinate_conninfo):
             assert "dbname=my%20db" in dsn
             assert "dbname='my db'" not in dsn
+
+
+class TestRootCaOnlyUnderVerifyFull:
+    """codex review on #1617: libpq treats sslmode=require as verify-ca once a
+    root CA file is present. Emitting sslrootcert under `require` would make
+    ogr2ogr and Procrastinate verify the certificate while the API's
+    database_connect_args explicitly disables that check for `require` — the
+    exact client divergence this pair of properties exists to remove."""
+
+    def test_require_does_not_emit_the_root_ca(self):
+        s = _make_settings(
+            database_url_override="postgresql://u:p@host/db",
+            database_ssl_mode="require",
+            database_ssl_ca_cert="/etc/ssl/rds/ca.pem",
+        )
+        for dsn in (s.ogr_connection_string, s.procrastinate_conninfo):
+            assert "sslrootcert" not in dsn
+
+    def test_verify_full_still_emits_it(self):
+        s = _make_settings(
+            database_url_override="postgresql://u:p@host/db",
+            database_ssl_mode="verify-full",
+            database_ssl_ca_cert="/etc/ssl/rds/ca.pem",
+        )
+        for dsn in (s.ogr_connection_string, s.procrastinate_conninfo):
+            assert "sslrootcert=/etc/ssl/rds/ca.pem" in dsn

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -1132,3 +1132,49 @@ class TestPendingJobTimeoutBounds:
         """The original gt=0 intent survives inside the higher floor."""
         with pytest.raises(Exception):
             _make_settings(pending_job_timeout_seconds=0)
+
+
+class TestLibpqValueQuoting:
+    """codex review on #1617: an unescaped value with whitespace ends the
+    keyword/value pair early and produces a malformed libpq DSN. Applied to
+    every interpolated value in both builders, not only the reported one."""
+
+    def test_ordinary_values_stay_bare(self):
+        # Byte-identical to what deployments already pass to GDAL's PG driver.
+        assert config_module.libpq_value("/etc/ssl/rds/ca.pem") == "/etc/ssl/rds/ca.pem"
+        assert config_module.libpq_value("geolens") == "geolens"
+
+    def test_value_with_space_is_quoted(self):
+        assert config_module.libpq_value("/etc/company certs/ca.pem") == (
+            "'/etc/company certs/ca.pem'"
+        )
+
+    def test_quotes_and_backslashes_are_escaped(self):
+        assert config_module.libpq_value("pa'ss\\word") == "'pa\\'ss\\\\word'"
+
+    def test_empty_value_is_quoted(self):
+        assert config_module.libpq_value("") == "''"
+
+    def test_ca_path_with_space_survives_into_both_builders(self):
+        s = _make_settings(
+            database_url_override="postgresql://u:p@host/db",
+            database_ssl_mode="verify-full",
+            database_ssl_ca_cert="/etc/company certs/ca.pem",
+        )
+        for dsn in (s.ogr_connection_string, s.procrastinate_conninfo):
+            assert "sslrootcert='/etc/company certs/ca.pem'" in dsn
+
+    def test_percent_encoded_credentials_are_decoded_like_sqlalchemy(self):
+        """Found while testing the quoting above. urlparse does NOT decode, so
+        these two builders were sending the literal `pass%20word` as the
+        password while the API path — which hands the DSN to SQLAlchemy, which
+        does decode — authenticated correctly. Any password needing
+        percent-encoding (a `@` is the common one) therefore worked for the API
+        and failed for vector ingest and the job queue."""
+        s = _make_settings(
+            database_url_override="postgresql://u%40corp:p%40ss%20word@host/my%20db",
+        )
+        for dsn in (s.ogr_connection_string, s.procrastinate_conninfo):
+            assert "user=u@corp" in dsn
+            assert "password='p@ss word'" in dsn
+            assert "dbname='my db'" in dsn

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -1177,4 +1177,15 @@ class TestLibpqValueQuoting:
         for dsn in (s.ogr_connection_string, s.procrastinate_conninfo):
             assert "user=u@corp" in dsn
             assert "password='p@ss word'" in dsn
-            assert "dbname='my db'" in dsn
+
+    def test_database_name_is_NOT_decoded_because_sqlalchemy_does_not(self):
+        """codex review on #1617: SQLAlchemy decodes username and password but
+        leaves the database name percent-encoded — `make_url(...).database` on
+        `/my%20db` returns `my%20db`. Decoding it here would point ogr2ogr and
+        Procrastinate at a different database than the API, so a healthy API
+        could sit alongside every queued job and vector ingest writing
+        somewhere else. Whatever the API uses, these two must use."""
+        s = _make_settings(database_url_override="postgresql://u:p@host/my%20db")
+        for dsn in (s.ogr_connection_string, s.procrastinate_conninfo):
+            assert "dbname=my%20db" in dsn
+            assert "dbname='my db'" not in dsn

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -419,6 +419,39 @@ class TestOgrConnectionString:
         )
         assert "sslmode=require" in s.ogr_connection_string
 
+    def test_override_includes_ca_cert_for_verify_full(self):
+        """Measured on EKS against RDS with rds.force_ssl=1: sslmode=verify-full
+        without sslrootcert sent libpq to ~/.postgresql/root.crt, which the
+        image does not ship, and every vector ingest died in ogr2ogr with
+        "root certificate file ... does not exist" while the api stayed
+        healthy — asyncpg gets the CA as an SSLContext and never consults it."""
+        s = _make_settings(
+            database_url_override="postgresql://u:p@host/db",
+            database_ssl_mode="verify-full",
+            database_ssl_ca_cert="/etc/ssl/rds/ca.pem",
+        )
+        ogr = s.ogr_connection_string
+        assert "sslmode=verify-full" in ogr
+        assert "sslrootcert=/etc/ssl/rds/ca.pem" in ogr
+
+    def test_ca_cert_matches_the_procrastinate_sibling(self):
+        """The two libpq DSN builders must not drift apart again."""
+        s = _make_settings(
+            database_url_override="postgresql://u:p@host/db",
+            database_ssl_mode="verify-full",
+            database_ssl_ca_cert="/etc/ssl/rds/ca.pem",
+        )
+        for token in ("sslmode=verify-full", "sslrootcert=/etc/ssl/rds/ca.pem"):
+            assert token in s.ogr_connection_string
+            assert token in s.procrastinate_conninfo
+
+    def test_no_ca_cert_emits_no_sslrootcert(self):
+        s = _make_settings(
+            database_url_override="postgresql://u:p@host/db",
+            database_ssl_mode="require",
+        )
+        assert "sslrootcert" not in s.ogr_connection_string
+
     def test_override_omits_sslmode_for_prefer(self):
         s = _make_settings(
             database_url_override="postgresql://u:p@host/db",

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -2978,7 +2978,8 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # authenticated fine — fixed with unquote() on user/password/dbname.
     # Cap 1375 -> 1409, exact.
             # Cap 1375 -> 1417, exact.
-        "backend/app/core/config.py": 1465,
+            # Cap 1375 -> 1429, exact.
+        "backend/app/core/config.py": 1477,
     # fix(#1543): first entry — crossed _RATCHET_INCLUSION_LOC on the change
     # that gave PersistentConfig a batch eviction. The code is small
     # (apply_side_effects_batch, plus splitting the process-local half of

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -2961,13 +2961,12 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # already omitted unset keys, so this validator was the only thing forcing
     # long-lived IAM user keys into a Kubernetes Secret. Cap 1375 -> 1423,
     # exact.
-        # ogr_connection_string now emits sslrootcert alongside sslmode, matching
+    # ogr_connection_string now emits sslrootcert alongside sslmode, matching
     # the procrastinate_conninfo sibling it had drifted from. Bought working
     # vector ingest against a managed database under DATABASE_SSL_MODE=
     # verify-full: ogr2ogr goes through libpq, which cannot see the CA that
     # only ever reached asyncpg as an SSLContext. Most of the growth is the
-    # comment recording that asymmetry. Cap 1375 -> 1388, exact.
-            # comment recording that asymmetry.
+    # comment recording that asymmetry.
     #
     # codex review on #1617 then added libpq_value(), which quotes and escapes
     # every interpolated value in BOTH DSN builders — an unescaped path or
@@ -2975,11 +2974,9 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # yields a malformed DSN. Testing that turned up a second defect in the
     # same two functions: urlparse does not percent-decode, so they sent the
     # literal `pass%20word` while the API path (SQLAlchemy, which decodes)
-    # authenticated fine — fixed with unquote() on user/password/dbname.
-    # Cap 1375 -> 1409, exact.
-            # Cap 1375 -> 1417, exact.
-            # Cap 1375 -> 1429, exact.
-        "backend/app/core/config.py": 1477,
+    # authenticated fine — fixed with unquote() on user/password.
+    # Cap 1423 -> 1501, exact.
+    "backend/app/core/config.py": 1501,
     # fix(#1543): first entry — crossed _RATCHET_INCLUSION_LOC on the change
     # that gave PersistentConfig a batch eviction. The code is small
     # (apply_side_effects_batch, plus splitting the process-local half of

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -2977,7 +2977,8 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # literal `pass%20word` while the API path (SQLAlchemy, which decodes)
     # authenticated fine — fixed with unquote() on user/password/dbname.
     # Cap 1375 -> 1409, exact.
-        "backend/app/core/config.py": 1457,
+            # Cap 1375 -> 1417, exact.
+        "backend/app/core/config.py": 1465,
     # fix(#1543): first entry — crossed _RATCHET_INCLUSION_LOC on the change
     # that gave PersistentConfig a batch eviction. The code is small
     # (apply_side_effects_batch, plus splitting the process-local half of

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -2967,7 +2967,17 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # verify-full: ogr2ogr goes through libpq, which cannot see the CA that
     # only ever reached asyncpg as an SSLContext. Most of the growth is the
     # comment recording that asymmetry. Cap 1375 -> 1388, exact.
-        "backend/app/core/config.py": 1436,
+            # comment recording that asymmetry.
+    #
+    # codex review on #1617 then added libpq_value(), which quotes and escapes
+    # every interpolated value in BOTH DSN builders — an unescaped path or
+    # password containing whitespace ends the keyword/value pair early and
+    # yields a malformed DSN. Testing that turned up a second defect in the
+    # same two functions: urlparse does not percent-decode, so they sent the
+    # literal `pass%20word` while the API path (SQLAlchemy, which decodes)
+    # authenticated fine — fixed with unquote() on user/password/dbname.
+    # Cap 1375 -> 1409, exact.
+        "backend/app/core/config.py": 1457,
     # fix(#1543): first entry — crossed _RATCHET_INCLUSION_LOC on the change
     # that gave PersistentConfig a batch eviction. The code is small
     # (apply_side_effects_batch, plus splitting the process-local half of

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -2961,7 +2961,13 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # already omitted unset keys, so this validator was the only thing forcing
     # long-lived IAM user keys into a Kubernetes Secret. Cap 1375 -> 1423,
     # exact.
-    "backend/app/core/config.py": 1423,
+        # ogr_connection_string now emits sslrootcert alongside sslmode, matching
+    # the procrastinate_conninfo sibling it had drifted from. Bought working
+    # vector ingest against a managed database under DATABASE_SSL_MODE=
+    # verify-full: ogr2ogr goes through libpq, which cannot see the CA that
+    # only ever reached asyncpg as an SSLContext. Most of the growth is the
+    # comment recording that asymmetry. Cap 1375 -> 1388, exact.
+        "backend/app/core/config.py": 1436,
     # fix(#1543): first entry — crossed _RATCHET_INCLUSION_LOC on the change
     # that gave PersistentConfig a batch eviction. The code is small
     # (apply_side_effects_batch, plus splitting the process-local half of


### PR DESCRIPTION
## What

`ogr_connection_string` emitted `sslmode` but never `sslrootcert`. Its sibling `procrastinate_conninfo` has always emitted both.

## The failure

`ogr2ogr` reaches PostGIS through **libpq**, which takes its CA from the DSN or from its own `~/.postgresql/root.crt`. It cannot see `DATABASE_SSL_CA_CERT` — that value only ever reaches asyncpg, as an `SSLContext`. So with `DATABASE_SSL_MODE=verify-full` against a managed database, libpq went looking for a root.crt the image does not ship:

```
ogr2ogr failed (exit 1): ERROR 1: PQconnectdb failed.
connection to server at "…rds.amazonaws.com", port 5432 failed:
root certificate file "/home/appuser/.postgresql/root.crt" does not exist
```

**Every vector ingest failed**, per job, while `/health`, the worker's own queue connection and raster ingest all stayed green — none of those shell out. Nothing in the catalog or any health check surfaces it; the datasets simply never appear.

Found on EKS against RDS PostgreSQL 18, where `rds.force_ssl=1` is the default on the `default.postgres18` parameter group, so `verify-full` is the natural mode to reach for.

## Verified

Same cluster, same database, same code path:

- before: 4 failed ingest jobs, each with the root.crt error
- after: both vector ingests succeeded; the worker's DSN now reads `… sslmode=verify-full sslrootcert=/etc/ssl/rds/rds-ca.pem`

## Tests

Four tests, including one that pins the two libpq DSN builders against each other so they cannot drift apart again. Reverting `config.py` alone fails the two positive ones.

```
backend: pytest tests/test_config.py    199 passed
backend: pytest tests/test_layering.py   47 passed
```

`_MODULE_LOC_CAPS` moves 1375 → 1388, rationale inline.

## Related, not fixed here

`database_url_sync` (psycopg; Alembic offline and helper scripts) passes the override DSN through verbatim and adds neither `sslmode` nor `sslrootcert`, so those callers connect under libpq's default regardless of `DATABASE_SSL_MODE`. Alembic's normal path is unaffected — `env.py` uses the async `database_url` with `database_connect_args`, which was confirmed to connect under verify-full during the same run. Left alone rather than changing connection behaviour for scripts in a fix PR.
