### PR TITLE
docs(runbook): cover managed-database restore on Kubernetes

### DIFF
--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -1204,18 +1204,24 @@ What changes:
     --query '{Versions: Versions[].[Key,VersionId,IsLatest,LastModified],
               DeleteMarkers: DeleteMarkers[].[Key,VersionId,IsLatest]}'
 
-  # A deletion: remove the delete marker and the previous version is current again.
-  aws s3api delete-object --bucket <bucket> --key "<key>" \
-    --version-id <delete-marker-version-id>
-
-  # An overwrite: copy the version that was current at $POINT back over the key.
+  # PROMOTE the version that was current at $POINT, whatever happened since.
+  # Copying it back writes a NEW current version, which supersedes a delete
+  # marker and an overwrite alike:
   aws s3api copy-object --bucket <bucket> --key "<key>" \
     --copy-source "<bucket>/<key>?versionId=<version-id-current-at-POINT>"
   ```
 
   Pick the version whose `LastModified` is the newest at or before `$POINT`, so
-  the object matches the database you restored — a newer one belongs to writes
-  the restore discarded. Then re-request a tile: it should stop returning 500.
+  the object matches the database you restored — anything newer belongs to
+  writes the restore discarded.
+
+  Promote rather than just deleting the delete marker. Removing a marker makes
+  the *immediately preceding* version current, which is the right one only if
+  nothing else happened in between; after an overwrite followed by a delete it
+  hands back the overwrite, silently pairing the recovered catalog with the
+  wrong bytes. Copying the chosen version is correct in every case.
+
+  Then re-request a tile: it should stop returning 500.
 
   A lifecycle rule to expire noncurrent versions keeps the cost bounded, but
   **it must outlast the database recovery window, or it silently re-creates the

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -150,7 +150,9 @@ deleted into a dated archive prefix you can restore from:
 ```bash
 rclone sync :s3:<bucket> :s3:<backup-bucket>/current \
   --backup-dir ":s3:<backup-bucket>/archive/$(date -u +%F)"
-``` Uploaded raster datasets are the ones that
+```
+
+Uploaded raster datasets are the ones that
 depend on it: a managed COG exists only in the bucket, so a database restore
 brings the catalog row back while every tile fails. By-reference imports (STAC,
 public COGs) keep serving from the upstream URL instead. See
@@ -1128,10 +1130,15 @@ What changes:
   # cannot tell instances apart (the incident-state database is at the same
   # migration revision), so check identity by TIME: the restored instance has
   # no rows newer than the recovery point, while the incident-state one does.
-  # From a debug pod:
+  # From a debug pod (both tables live in the catalog schema):
   #   psql 'host=<restored-endpoint> ...' \
-  #     -c 'select version_num from alembic_version' \
-  #     -c 'select max(created_at) from ingest_jobs'   # must be <= $POINT
+  #     -c 'select version_num from catalog.alembic_version' \
+  #     -c 'select max(created_at) from catalog.ingest_jobs'  # must be <= $POINT
+  # If nothing was written after $POINT the data cannot tell the two instances
+  # apart — anchor identity on the endpoint itself: the host you install must
+  # be exactly what the restore produced,
+  #   aws rds describe-db-instances --db-instance-identifier <restored-id> \
+  #     --query 'DBInstances[0].Endpoint.Address' --output text
   #
   # Pin the chart you are already running. Without --version, helm takes the
   # newest one in the repo and the recovery quietly becomes an app upgrade

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -1058,7 +1058,10 @@ What changes:
   # (MIGRATION_DATABASE_URL_OVERRIDE is a Compose-only variable — docker-compose.yml
   # maps it into the migrate service. Nothing in the chart or the application
   # reads it, so it is not part of this path.)
-  sed -i.bak 's/<old-endpoint>/<restored-endpoint>/g' values.yaml   # or your secret source
+  # No -i.bak: that would leave values.yaml.bak holding the OLD DSN, password
+  # and all, sitting in plaintext next to the file you are careful about.
+  sed 's/<old-endpoint>/<restored-endpoint>/g' values.yaml > values.yaml.tmp \
+    && mv values.yaml.tmp values.yaml      # or your secret source
 
   # Pin the chart you are already running. Without --version, helm takes the
   # newest one in the repo and the recovery quietly becomes an app upgrade

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -1131,7 +1131,10 @@ What changes:
      (`argocd app sync <app>`, `flux reconcile hr <name> -n <ns>`). Nothing
      lands while it is suspended — and because the manifest now says zero, this
      does not bring the writers back.
-  3. Verify the endpoint, as below, with the database still quiet.
+  3. Verify the endpoint, as below, with the database still quiet — and if the
+     incident touched object storage, do the
+     [object-version repair](#restoring-an-object-version) now, while the
+     writers are still down.
   4. Commit the original replica counts, let that reconcile, and wait for both
      rollouts to finish (`kubectl -n <ns> rollout status deploy/<release>-api`
      and the worker equivalent) — a reconciled manifest says nothing about the
@@ -1204,7 +1207,8 @@ What changes:
   # Where objects are namespaced per tenant, the managed layout is
   # tenants/<tenant-id>/rasters/<dataset-id>/ — use that prefix instead.
   PREFIX=rasters/<dataset-id>/     # from the catalog row you restored
-  # Repeat for originals/<dataset-id>/ — the archived source upload lives there.
+  # Repeat for originals/<dataset-id>/ — the archived source upload lives
+  # there — and, for vector datasets, vectors/<dataset-id>/ (the quicklook).
   POINT=2026-08-20T23:45:08Z       # the same timestamp you restored the DB to
 
   # What versions exist, and what is on top right now:

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -1048,7 +1048,8 @@ What changes:
   | | recovered by a database-only restore? |
   |---|---|
   | Vector datasets | **Yes, fully.** Features live in PostGIS. A lost object costs the original upload file and the quicklook thumbnail, not the data. |
-  | Raster datasets | **No.** The COG lives only in object storage. The catalog row comes back reading `published`, and every tile request then fails with a 500. Nothing in the catalog marks it broken. |
+  | Raster datasets, uploaded | **No.** A managed COG — anything ingested through GeoLens, plus VRT artifacts — lives only in your bucket. The catalog row comes back reading `published`, and every tile request then fails with a 500. Nothing in the catalog marks it broken. |
+  | Raster datasets, by reference | **Yes**, as far as GeoLens is concerned. STAC and public-COG imports keep the upstream asset URL (`storage_backend="remote"`) and are served from it, so a restore recovers a working pointer — provided the upstream asset still exists, which is somebody else's retention policy, not yours. |
 
   So protect the bucket *before* you need it — this is the step that has no
   GeoLens-side equivalent:
@@ -1075,6 +1076,12 @@ What changes:
   is only as good as the shorter half.
 
   ```bash
+  # WARNING: put-bucket-lifecycle-configuration REPLACES the bucket's entire
+  # lifecycle configuration — including the abort-incomplete-multipart rule
+  # recommended in § 1. Fetch what is there and merge, never post this rule
+  # alone to a bucket that already has any:
+  #   aws s3api get-bucket-lifecycle-configuration --bucket <bucket>
+  #
   # 35-day PITR + a week of detection headroom.
   aws s3api put-bucket-lifecycle-configuration --bucket <bucket> \
     --lifecycle-configuration '{"Rules":[{"ID":"noncurrent-42d","Status":"Enabled",

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -135,6 +135,14 @@ If your deployment offloads objects to an external S3/R2/GCS bucket, that bucket
 lifecycle policy is responsible for its own backup; GeoLens does not back up
 external object stores.
 
+Concretely, that means enabling **object versioning** on the bucket — it is the
+only thing that makes an accidental delete or overwrite recoverable, and no
+database backup substitutes for it. Raster datasets are the ones that depend on
+it: their COGs exist only in the bucket, so a database restore brings the
+catalog row back while every tile fails. See
+[On Kubernetes](#on-kubernetes-the-community-helm-chart) for the measured
+breakdown of what a database-only restore does and does not recover.
+
 ### Abandoned multipart uploads (bucket hygiene)
 
 A client that starts a presigned multipart upload and walks away — never
@@ -1006,6 +1014,59 @@ Update `.env` to point `POSTGRES_HOST`, `POSTGRES_USER`, `POSTGRES_PASSWORD`, an
 docker compose up -d api worker frontend
 docker compose ps    # confirm api and worker are healthy
 ```
+
+### On Kubernetes (the community Helm chart)
+
+Steps 2 and 3 above are Compose-shaped and do not apply. A chart deployment has
+no `backup` container, no `backup_data` volume, and no Compose project — the
+chart ships **no backup workload at all**, so the database backups are entirely
+your provider's, and object storage is entirely your bucket's.
+
+What changes:
+
+- **Step 1 is the same** and is the whole database recovery. Restoring an RDS
+  instance to a point in time produces a **new endpoint**, so the recovery ends
+  with re-pointing the release rather than editing `.env`:
+
+  ```bash
+  helm upgrade geolens geolens/geolens -n <ns> -f values.yaml \
+    --set secrets.databaseUrlOverride='postgresql+asyncpg://<user>:<pw>@<restored-endpoint>:5432/<db>'
+  ```
+
+  Prefer a pre-created Secret (`secrets.existingSecret`) so the DSN never
+  reaches a shell history. Point-in-time restore is not instant in either
+  sense: the restorable window trails real time by several minutes, and
+  provisioning the restored instance takes ~10-15 minutes. Both are on top of
+  the time it takes to notice the incident.
+
+- **Step 2 has no equivalent, and that is the part that bites.** With
+  `storage.backend=s3` there is no `upload_staging` volume to archive; objects
+  live in the bucket, which no GeoLens backup ever touched (see the
+  [Scope caveat](#scope-caveat)). Restoring only the database recovers your
+  catalog **asymmetrically**:
+
+  | | recovered by a database-only restore? |
+  |---|---|
+  | Vector datasets | **Yes, fully.** Features live in PostGIS. A lost object costs the original upload file and the quicklook thumbnail, not the data. |
+  | Raster datasets | **No.** The COG lives only in object storage. The catalog row comes back reading `published`, and every tile request then fails with a 500. Nothing in the catalog marks it broken. |
+
+  So protect the bucket *before* you need it — this is the step that has no
+  GeoLens-side equivalent:
+
+  ```bash
+  aws s3api put-bucket-versioning --bucket <bucket> \
+    --versioning-configuration Status=Enabled
+  ```
+
+  Versioning is what makes an accidental delete or overwrite recoverable at
+  all; add cross-region replication if the bucket itself is in scope for your
+  DR plan. A lifecycle rule to expire noncurrent versions keeps the cost
+  bounded. Verified by drill: with versioning off, deleting a raster's objects
+  left a published dataset whose tiles returned 500, and nothing could bring
+  them back.
+
+- **Step 3** becomes `kubectl -n <ns> get pods` plus a probe through the edge,
+  e.g. `curl -sf https://<host>/api/health`.
 
 ### Optional: point-in-time recovery (PITR) with WAL archiving
 

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -1027,6 +1027,9 @@ your provider's, and object storage is entirely your bucket's.
 
 ```bash
 kubectl -n <ns> scale deploy/<release>-api deploy/<release>-worker --replicas=0
+# scale returns immediately; the pods are still draining and still writing.
+kubectl -n <ns> wait --for=delete pod \
+  -l app.kubernetes.io/instance=<release> --timeout=180s
 ```
 
 Provisioning a restored instance takes ten minutes or more. Every write
@@ -1069,23 +1072,25 @@ What changes:
   # (MIGRATION_DATABASE_URL_OVERRIDE is a Compose-only variable — docker-compose.yml
   # maps it into the migrate service. Nothing in the chart or the application
   # reads it, so it is not part of this path.)
-  # Plain values file. If the DSN lives in SOPS, a SealedSecret or an
-  # ExternalSecret, do NOT edit the ciphertext — go through that tool
-  # (`sops values.enc.yaml`, re-seal, or edit the upstream secret store),
-  # or the next reconciliation overwrites what you just changed.
+  # Start from what the release is ACTUALLY running, not from a values file
+  # that may be one of several, or missing --set overrides given at install
+  # time. `helm get values` returns the complete user-supplied set.
   #
-  # No -i.bak, and the mode is carried over: a backup would leave the OLD DSN
-  # in plaintext beside the file, and a bare `mv` would replace a 0600 file
-  # with whatever your umask produces.
-  cp -p values.yaml values.yaml.tmp
-  sed 's/<old-endpoint>/<restored-endpoint>/g' values.yaml > values.yaml.tmp \
-    && mv values.yaml.tmp values.yaml
+  # If the DSN lives in SOPS, a SealedSecret or an ExternalSecret, do NOT edit
+  # the ciphertext — go through that tool (`sops values.enc.yaml`, re-seal, or
+  # edit the upstream secret store) or the next reconciliation overwrites it.
+  umask 077     # this file holds the DSN
+  helm get values <release> -n <ns> -o yaml > deployed-values.yaml
+  sed 's/<old-endpoint>/<restored-endpoint>/g' deployed-values.yaml > tmp \
+    && mv tmp deployed-values.yaml
+  grep -c '<restored-endpoint>' deployed-values.yaml    # expect >= 1
 
   # Pin the chart you are already running. Without --version, helm takes the
   # newest one in the repo and the recovery quietly becomes an app upgrade
   # too — new images and a migration hook, during an incident.
   CHART=$(helm list -n <ns> -o json | jq -r '.[] | select(.name=="<release>") | .chart | sub("^geolens-"; "")')
-  helm upgrade <release> geolens/geolens -n <ns> -f values.yaml --version "$CHART"
+  helm upgrade <release> geolens/geolens -n <ns> \
+    -f deployed-values.yaml --version "$CHART"
   ```
 
   With a chart-managed Secret, that `helm upgrade` is the whole cutover. If the

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -1191,7 +1191,12 @@ What changes:
      `flux resume hr <name> -n <ns>` — resuming reconciles, while
      `flux reconcile` alone refuses as long as `.spec.suspend` is set — or,
      for Argo CD, a one-shot `argocd app sync <app>` (a manual sync works
-     while auto-sync is off; re-enable the sync policy at the end). Nothing
+     while auto-sync is off; re-enable the sync policy at the end). When a
+     Flux Kustomization delivers the HelmRelease manifest, reconcile that
+     first (`flux reconcile kustomization <name> -n <ns>`) so the live
+     HelmRelease already carries the committed zeros — resuming before the
+     Kustomization has applied them reconciles the old spec and brings the
+     writers back. Nothing
      lands while it is suspended — and because the manifest now says zero, this
      does not bring the writers back.
   3. Verify the endpoint, as below, with the database still quiet — and if the
@@ -1259,6 +1264,15 @@ What changes:
   left a published dataset whose tiles returned 500, and nothing could bring
   them back.
 
+  On **Azure Blob storage** — the application's other supported object store —
+  none of the `aws s3api` commands apply. The equivalents are Azure-native:
+  enable **blob versioning** and soft delete on the container, and promote a
+  prior version by copying it over the current blob (`az storage blob copy
+  start` with a version-id source). The selection logic below is identical:
+  per key, the newest version at or before the recovery point, with the
+  restored catalog arbitrating soft-deleted blobs the way it arbitrates
+  delete markers.
+
   <a id="restoring-an-object-version"></a>
   **Enabling it is protection for next time, not a recovery.** If versioning was
   already on when the incident happened, the objects are still there but not
@@ -1279,14 +1293,18 @@ What changes:
   #   vectors/<dataset-id>/      vector quicklooks
   #   maps/thumbnails/ maps/og-images/ maps/icons/   map assets
   #   staging/                   in-flight uploads. Promote the keys from
-  #                                SELECT file_path FROM catalog.ingest_jobs
+  #                                SELECT tenant_id, file_path
+  #                                FROM catalog.ingest_jobs
   #                                WHERE file_path LIKE 'staging/%'
   #                                  AND status IN ('pending','running','failed')
   #                                UNION
-  #                                SELECT user_metadata->>'s3_key'
+  #                                SELECT tenant_id, user_metadata->>'s3_key'
   #                                FROM catalog.ingest_jobs
   #                                WHERE user_metadata->>'s3_key' LIKE 'staging/%'
   #                                  AND status IN ('pending','running','failed');
+  #                              The rows are LOGICAL keys — where tenant_id is
+  #                              set, the object lives at
+  #                              tenants/<tenant_id>/<key>.
   #                              (a presigned upload keeps its key in
   #                              user_metadata until the completion call sets
   #                              file_path) before the worker returns — retry
@@ -1342,8 +1360,9 @@ What changes:
   match the one you copied from — compare `ContentLength` against the `Size`
   the listing above showed for the version you selected. `ETag` only
   corroborates when the source version's ETag carries no multipart `-N`
-  suffix: a single-request copy of a multipart-uploaded version (managed COGs
-  usually are) legitimately changes it. The
+  suffix **and** the object is not SSE-KMS/SSE-C encrypted: a single-request
+  copy of a multipart-uploaded version (managed COGs usually are) legitimately
+  changes it, and encrypted objects' ETags are not content digests at all. The
   end-to-end check comes after the replicas return — re-request a tile, and it
   should stop returning 500.
 

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -1194,8 +1194,8 @@ What changes:
   your database recovery point:
 
   ```bash
-  # Single-tenant. In multi-tenant mode the managed layout is namespaced —
-  # tenants/<tenant-id>/rasters/<dataset-id>/ — so use that prefix instead.
+  # Where objects are namespaced per tenant, the managed layout is
+  # tenants/<tenant-id>/rasters/<dataset-id>/ — use that prefix instead.
   PREFIX=rasters/<dataset-id>/     # from the catalog row you restored
   POINT=2026-08-20T23:45:08Z       # the same timestamp you restored the DB to
 

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -1211,9 +1211,12 @@ What changes:
     --copy-source "<bucket>/<key>?versionId=<version-id-current-at-POINT>"
   ```
 
-  Pick the version whose `LastModified` is the newest at or before `$POINT`, so
-  the object matches the database you restored — anything newer belongs to
-  writes the restore discarded.
+  Pick the newest entry at or before `$POINT` — **counting delete markers as
+  entries**. If that entry is a delete marker, the object was already deleted at
+  the recovery point and there is nothing to promote: the restored catalog
+  should not reference it, and putting bytes back would resurrect data the
+  restore deliberately dropped. Otherwise promote that version; anything newer
+  belongs to writes the restore discarded.
 
   Promote rather than just deleting the delete marker. Removing a marker makes
   the *immediately preceding* version current, which is the right one only if

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -1034,6 +1034,12 @@ kubectl -n <ns> wait --for=delete pod --timeout=180s \
   -l 'app.kubernetes.io/instance=<release>,app.kubernetes.io/component in (api,worker)'
 ```
 
+Under Argo CD or Flux, a `kubectl scale` is drift the controller undoes on its
+next sync — the writers come back mid-restore. Suspend the sync first
+(`argocd app set <app> --sync-policy none`, or `flux suspend hr <name>`), or set
+the replica counts to zero in the source repository, and reverse whichever you
+chose at the end.
+
 Provisioning a restored instance takes ten minutes or more. Every write
 accepted in that window — and any accepted after the point in time you are
 restoring to — lands only on the incident-state database and is discarded when

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -1184,9 +1184,11 @@ What changes:
      schema-plus-recency check as the manual path, from a debug pod —
      because the resumed sync immediately runs the migration hook against
      whatever the Secret now says, and a wrong-but-reachable host would
-     receive the migration. Then resume the
-     sync you suspended at the start, or force one reconcile
-     (`argocd app sync <app>`, `flux reconcile hr <name> -n <ns>`). Nothing
+     receive the migration. Then resume what you suspended:
+     `flux resume hr <name> -n <ns>` — resuming reconciles, while
+     `flux reconcile` alone refuses as long as `.spec.suspend` is set — or,
+     for Argo CD, a one-shot `argocd app sync <app>` (a manual sync works
+     while auto-sync is off; re-enable the sync policy at the end). Nothing
      lands while it is suspended — and because the manifest now says zero, this
      does not bring the writers back.
   3. Verify the endpoint, as below, with the database still quiet — and if the
@@ -1274,11 +1276,18 @@ What changes:
   #   vectors/<dataset-id>/      vector quicklooks
   #   maps/thumbnails/ maps/og-images/ maps/icons/   map assets
   #   staging/                   in-flight uploads. Promote the keys from
-  #                                SELECT file_path FROM ingest_jobs WHERE
-  #                                file_path LIKE 'staging/%' AND status IN
-  #                                ('pending','running','failed');
-  #                              before the worker returns — retry requires
-  #                              the staged object to exist
+  #                                SELECT file_path FROM catalog.ingest_jobs
+  #                                WHERE file_path LIKE 'staging/%'
+  #                                  AND status IN ('pending','running','failed')
+  #                                UNION
+  #                                SELECT user_metadata->>'s3_key'
+  #                                FROM catalog.ingest_jobs
+  #                                WHERE user_metadata->>'s3_key' LIKE 'staging/%'
+  #                                  AND status IN ('pending','running','failed');
+  #                              (a presigned upload keeps its key in
+  #                              user_metadata until the completion call sets
+  #                              file_path) before the worker returns — retry
+  #                              requires the staged object to exist
   POINT=2026-08-20T23:45:08Z       # the same timestamp you restored the DB to
 
   # What versions exist, and what is on top right now:

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -1060,10 +1060,26 @@ What changes:
 
   Versioning is what makes an accidental delete or overwrite recoverable at
   all; add cross-region replication if the bucket itself is in scope for your
-  DR plan. A lifecycle rule to expire noncurrent versions keeps the cost
-  bounded. Verified by drill: with versioning off, deleting a raster's objects
+  DR plan. Verified by drill: with versioning off, deleting a raster's objects
   left a published dataset whose tiles returned 500, and nothing could bring
   them back.
+
+  A lifecycle rule to expire noncurrent versions keeps the cost bounded, but
+  **it must outlast the database recovery window, or it silently re-creates the
+  same failure.** The two retentions have to be read together: restoring the
+  database to a point 20 days back while noncurrent versions expire after 7
+  leaves exactly the rasters that were deleted or overwritten in between
+  pointing at versions AWS has already collected. Set the noncurrent expiry to
+  at least your PITR window plus however long an incident realistically takes
+  to notice and act on, and revisit it whenever either number moves — the pair
+  is only as good as the shorter half.
+
+  ```bash
+  # 35-day PITR + a week of detection headroom.
+  aws s3api put-bucket-lifecycle-configuration --bucket <bucket> \
+    --lifecycle-configuration '{"Rules":[{"ID":"noncurrent-42d","Status":"Enabled",
+      "Filter":{},"NoncurrentVersionExpiration":{"NoncurrentDays":42}}]}'
+  ```
 
 - **Step 3** becomes `kubectl -n <ns> get pods` plus a probe through the edge,
   e.g. `curl -sf https://<host>/api/health`.

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -1132,7 +1132,10 @@ What changes:
      lands while it is suspended — and because the manifest now says zero, this
      does not bring the writers back.
   3. Verify the endpoint, as below, with the database still quiet.
-  4. Commit the original replica counts and let that reconcile.
+  4. Commit the original replica counts, let that reconcile, and wait for both
+     rollouts to finish (`kubectl -n <ns> rollout status deploy/<release>-api`
+     and the worker equivalent) — a reconciled manifest says nothing about the
+     pods actually becoming ready.
 
   Verify the endpoint before letting traffic back in — connect with `psql` from
   a debug pod, or check that the restored data is present. **If the incident

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -1181,6 +1181,35 @@ What changes:
   left a published dataset whose tiles returned 500, and nothing could bring
   them back.
 
+  **Enabling it is protection for next time, not a recovery.** If versioning was
+  already on when the incident happened, the objects are still there but not
+  *current* — a delete left a delete marker on top, an overwrite left the wrong
+  version current — so the restored catalog still points at something
+  unusable. Roll each affected prefix back to the version that was current at
+  your database recovery point:
+
+  ```bash
+  PREFIX=rasters/<dataset-id>/     # from the catalog row you restored
+  POINT=2026-08-20T23:45:08Z       # the same timestamp you restored the DB to
+
+  # What versions exist, and what is on top right now:
+  aws s3api list-object-versions --bucket <bucket> --prefix "$PREFIX" \
+    --query '{Versions: Versions[].[Key,VersionId,IsLatest,LastModified],
+              DeleteMarkers: DeleteMarkers[].[Key,VersionId,IsLatest]}'
+
+  # A deletion: remove the delete marker and the previous version is current again.
+  aws s3api delete-object --bucket <bucket> --key "<key>" \
+    --version-id <delete-marker-version-id>
+
+  # An overwrite: copy the version that was current at $POINT back over the key.
+  aws s3api copy-object --bucket <bucket> --key "<key>" \
+    --copy-source "<bucket>/<key>?versionId=<version-id-current-at-POINT>"
+  ```
+
+  Pick the version whose `LastModified` is the newest at or before `$POINT`, so
+  the object matches the database you restored — a newer one belongs to writes
+  the restore discarded. Then re-request a tile: it should stop returning 500.
+
   A lifecycle rule to expire noncurrent versions keeps the cost bounded, but
   **it must outlast the database recovery window, or it silently re-creates the
   same failure.** The two retentions have to be read together: restoring the

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -1197,6 +1197,7 @@ What changes:
   # Where objects are namespaced per tenant, the managed layout is
   # tenants/<tenant-id>/rasters/<dataset-id>/ — use that prefix instead.
   PREFIX=rasters/<dataset-id>/     # from the catalog row you restored
+  # Repeat for originals/<dataset-id>/ — the archived source upload lives there.
   POINT=2026-08-20T23:45:08Z       # the same timestamp you restored the DB to
 
   # What versions exist, and what is on top right now:

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -1028,8 +1028,10 @@ your provider's, and object storage is entirely your bucket's.
 ```bash
 kubectl -n <ns> scale deploy/<release>-api deploy/<release>-worker --replicas=0
 # scale returns immediately; the pods are still draining and still writing.
-kubectl -n <ns> wait --for=delete pod \
-  -l app.kubernetes.io/instance=<release> --timeout=180s
+# Wait only on the two you scaled — the release's frontend and titiler pods
+# stay up, so an instance-wide selector would just time out.
+kubectl -n <ns> wait --for=delete pod --timeout=180s \
+  -l 'app.kubernetes.io/instance=<release>,app.kubernetes.io/component in (api,worker)'
 ```
 
 Provisioning a restored instance takes ten minutes or more. Every write
@@ -1089,16 +1091,26 @@ What changes:
   # newest one in the repo and the recovery quietly becomes an app upgrade
   # too — new images and a migration hook, during an incident.
   CHART=$(helm list -n <ns> -o json | jq -r '.[] | select(.name=="<release>") | .chart | sub("^geolens-"; "")')
+  # Keep the writers down through the upgrade: deployed-values.yaml carries the
+  # ORIGINAL replica counts, so a plain upgrade would bring pods straight back
+  # up against an endpoint nobody has verified yet.
   helm upgrade <release> geolens/geolens -n <ns> \
-    -f deployed-values.yaml --version "$CHART"
+    -f deployed-values.yaml --version "$CHART" \
+    --set api.replicas=0 --set worker.replicas=0
   ```
 
   With a chart-managed Secret, that `helm upgrade` is the whole cutover. If the
   Secret is operator-managed, update its source, re-apply it, and only then:
 
+  Verify the endpoint before letting traffic back in — connect with `psql` from
+  a debug pod, or check that the restored data is present. Then restore the
+  replica counts that `deployed-values.yaml` already records:
+
   ```bash
-  kubectl -n <ns> scale deploy/<release>-api --replicas=<n>
-  kubectl -n <ns> scale deploy/<release>-worker --replicas=<n>
+  helm upgrade <release> geolens/geolens -n <ns> \
+    -f deployed-values.yaml --version "$CHART"
+  kubectl -n <ns> rollout status deploy/<release>-api --timeout=300s
+  rm -f deployed-values.yaml     # it holds the DSN
   ```
 
   A `TILE_DATABASE_URL_OVERRIDE` left pointing at the old endpoint is the

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -1028,16 +1028,34 @@ What changes:
   instance to a point in time produces a **new endpoint**, so the recovery ends
   with re-pointing the release rather than editing `.env`:
 
+  **Repoint every DSN, not just the runtime one.** Take the DSN you already
+  have and replace only its host — do not retype it. Passwords are
+  percent-encoded in a URI (see `.env.example`), so re-typing one containing
+  `#`, `?`, `@`, `/` or `:` produces a URL the API rejects at boot instead of
+  connecting to the restored instance:
+
   ```bash
-  helm upgrade geolens geolens/geolens -n <ns> -f values.yaml \
-    --set secrets.databaseUrlOverride='postgresql+asyncpg://<user>:<pw>@<restored-endpoint>:5432/<db>'
+  # In the Secret (preferred — keeps the DSN out of shell history):
+  #   DATABASE_URL_OVERRIDE       runtime
+  #   TILE_DATABASE_URL_OVERRIDE  vector-tile pool, when you have set one
+  # Swap the host in place rather than rebuilding the URI:
+  OLD=<old-endpoint>; NEW=<restored-endpoint>
+  kubectl -n <ns> get secret <release>-secrets -o json \
+    | jq --arg o "$OLD" --arg n "$NEW" '.data |= with_entries(
+        select(.key | test("DATABASE_URL")) |= (.value |= (@base64d | sub($o; $n) | @base64)))' \
+    | kubectl apply -f -
+  kubectl -n <ns> rollout restart deploy/<release>-api deploy/<release>-worker
   ```
 
-  Prefer a pre-created Secret (`secrets.existingSecret`) so the DSN never
-  reaches a shell history. Point-in-time restore is not instant in either
-  sense: the restorable window trails real time by several minutes, and
-  provisioning the restored instance takes ~10-15 minutes. Both are on top of
-  the time it takes to notice the incident.
+  A `TILE_DATABASE_URL_OVERRIDE` left pointing at the old endpoint is the
+  quiet one: the API reads the restored database while vector tiles keep
+  serving from the incident-state instance, until that endpoint is deleted and
+  they start failing instead.
+
+  Point-in-time restore is not instant in either sense: the restorable window
+  trails real time by several minutes, and provisioning the restored instance
+  takes ~10-15 minutes. Both are on top of the time it takes to notice the
+  incident.
 
 - **Step 2 has no equivalent, and that is the part that bites.** With
   `storage.backend=s3` there is no `upload_staging` volume to archive; objects

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -1049,9 +1049,15 @@ What changes:
   database. Swap the host in place rather than retyping the URI:
 
   ```bash
-  # Keys to update — both, if you set the second:
-  #   DATABASE_URL_OVERRIDE       runtime
-  #   TILE_DATABASE_URL_OVERRIDE  vector-tile pool
+  # Update EVERY key holding a DSN, not just the obvious one. On the chart
+  # that is DATABASE_URL_OVERRIDE and, if you set it, TILE_DATABASE_URL_OVERRIDE
+  # — plus any DSN you pass through migrate.extraEnv or your own Secret. The
+  # replacement below is a global host swap precisely so a key you forgot is
+  # still caught; grep the result before applying it.
+  #
+  # (MIGRATION_DATABASE_URL_OVERRIDE is a Compose-only variable — docker-compose.yml
+  # maps it into the migrate service. Nothing in the chart or the application
+  # reads it, so it is not part of this path.)
   sed -i.bak 's/<old-endpoint>/<restored-endpoint>/g' values.yaml   # or your secret source
 
   # Pin the chart you are already running. Without --version, helm takes the

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -1110,11 +1110,16 @@ What changes:
   # Secret, and the grep below returns 0. Update that Secret's source and
   # re-apply it FIRST; the helm upgrade alone changes nothing, and the pods
   # would come back on the old endpoint. Controller-managed sources
-  # (ExternalSecret, SealedSecret) reconcile asynchronously, so before the
-  # upgrade — whose migration hook reads this live Secret — confirm the target
-  # Secret actually carries the restored endpoint:
-  #   kubectl -n <ns> get secret <name> \
-  #     -o jsonpath='{.data.DATABASE_URL_OVERRIDE}' | base64 -d
+  # (ExternalSecret, SealedSecret) reconcile asynchronously — an ExternalSecret
+  # can be told to refresh now:
+  #   kubectl -n <ns> annotate externalsecret <name> force-sync=$(date +%s) --overwrite
+  # — so before the upgrade, whose migration hook reads this live Secret,
+  # confirm the target Secret carries the restored endpoint in EVERY DSN key
+  # it holds (TILE_DATABASE_URL_OVERRIDE and friends too, if you set them),
+  # not just the obvious one:
+  #   kubectl -n <ns> get secret <name> -o json | jq -r \
+  #     '.data | to_entries[] | select(.key | test("DATABASE_URL"))
+  #      | "\(.key) \(.value | @base64d)"'
   grep -c '<restored-endpoint>' deployed-values.yaml    # 0 => the DSN is in the Secret
 
   # Before invoking the upgrade at all, prove the restored endpoint is the
@@ -1127,7 +1132,9 @@ What changes:
   # Pin the chart you are already running. Without --version, helm takes the
   # newest one in the repo and the recovery quietly becomes an app upgrade
   # too — new images and a migration hook, during an incident.
-  CHART=$(helm list -n <ns> -o json | jq -r '.[] | select(.name=="<release>") | .chart | sub("^geolens-"; "")')
+  # (-a: a release left in a pending/failed state by an interrupted operation
+  # would otherwise not be listed, and CHART would come out empty.)
+  CHART=$(helm list -a -n <ns> -o json | jq -r '.[] | select(.name=="<release>") | .chart | sub("^geolens-"; "")')
   # Keep the writers down through the upgrade: deployed-values.yaml carries the
   # ORIGINAL replica counts, so a plain upgrade would bring pods straight back
   # up against an endpoint nobody has verified yet.
@@ -1161,7 +1168,12 @@ What changes:
      on it would deadlock. Apply that one committed resource first
      (`argocd app sync <app> --resource bitnami.com/SealedSecret:<ns>/<name>`,
      or `kubectl apply` of the same manifest you committed), let the controller
-     unseal it, and confirm the target Secret before going on. Then resume the
+     unseal it, and confirm the target Secret before going on. Before any
+     reconcile, also validate the restored endpoint itself — the same
+     `psql ... alembic_version` check as the manual path, from a debug pod —
+     because the resumed sync immediately runs the migration hook against
+     whatever the Secret now says, and a wrong-but-reachable host would
+     receive the migration. Then resume the
      sync you suspended at the start, or force one reconcile
      (`argocd app sync <app>`, `flux reconcile hr <name> -n <ns>`). Nothing
      lands while it is suspended — and because the manifest now says zero, this
@@ -1180,8 +1192,9 @@ What changes:
   touched object storage, do that repair now too**, while the writers are still
   down — see [object versions](#restoring-an-object-version) below. Restarting
   the api first means serving 500s from rasters you are about to fix, and
-  re-ingesting or re-uploading against a half-restored bucket. Then restore the
-  replica counts that `deployed-values.yaml` already records:
+  re-ingesting or re-uploading against a half-restored bucket. Then, on the
+  manual path, restore the replica counts that `deployed-values.yaml` already
+  records (under GitOps this is step 4 above, not a `helm` command):
 
   ```bash
   helm upgrade <release> geolens/geolens -n <ns> \
@@ -1249,10 +1262,12 @@ What changes:
   #   originals/<dataset-id>/    archived source uploads
   #   vectors/<dataset-id>/      vector quicklooks
   #   maps/thumbnails/ maps/og-images/ maps/icons/   map assets
-  #   staging/                   in-flight uploads: promote the file_path keys
-  #                              of nonterminal AND retryable failed ingest
-  #                              jobs before the worker returns — retry
-  #                              requires the staged object to exist
+  #   staging/                   in-flight uploads. Promote the keys from
+  #                                SELECT file_path FROM ingest_jobs WHERE
+  #                                file_path LIKE 'staging/%' AND status IN
+  #                                ('pending','running','failed');
+  #                              before the worker returns — retry requires
+  #                              the staged object to exist
   POINT=2026-08-20T23:45:08Z       # the same timestamp you restored the DB to
 
   # What versions exist, and what is on top right now:
@@ -1299,9 +1314,12 @@ What changes:
   ```
 
   While the writers are still down, confirm the promotion at the store:
-  `aws s3api head-object --bucket <bucket> --key "<key>"` should report the
-  promoted bytes as the current version. The end-to-end check comes after the
-  replicas return — re-request a tile, and it should stop returning 500.
+  `aws s3api head-object --bucket <bucket> --key "<key>"` shows what is
+  current now. The promoted copy is a **new** version, so its id will not
+  match the one you copied from — compare `ContentLength` (and, for a
+  single-part `copy-object`, `ETag`) against the version you selected. The
+  end-to-end check comes after the replicas return — re-request a tile, and it
+  should stop returning 500.
 
   A lifecycle rule to expire noncurrent versions keeps the cost bounded, but
   **it must outlast the database recovery window, or it silently re-creates the

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -1118,8 +1118,9 @@ What changes:
   yours to run** — the controller holds the values and will revert anything you
   apply directly. Make the same three changes (endpoint, pinned chart version,
   replicas at zero) in the Application or HelmRelease manifest, commit, and let
-  a sync apply them; then resume the sync you suspended earlier and commit the
-  replica counts back. The ordering and the reasoning are identical — only the
+  a sync apply them. Verify the endpoint the same way as below, while the
+  writers are still down; only then resume the sync you suspended earlier and
+  commit the replica counts back. The ordering and the reasoning are identical — only the
   thing you edit changes.
 
   Verify the endpoint before letting traffic back in — connect with `psql` from
@@ -1130,6 +1131,7 @@ What changes:
   helm upgrade <release> geolens/geolens -n <ns> \
     -f deployed-values.yaml --version "$CHART"
   kubectl -n <ns> rollout status deploy/<release>-api --timeout=300s
+  kubectl -n <ns> rollout status deploy/<release>-worker --timeout=300s
   rm -f deployed-values.yaml     # it holds the DSN
   ```
 

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -1176,6 +1176,9 @@ What changes:
   GeoLens-side equivalent:
 
   ```bash
+  # Non-AWS endpoint (self-hosted MinIO or similar): add
+  # --endpoint-url <S3_ENDPOINT> to every aws command in this section,
+  # or the commands silently target AWS instead of your object store.
   aws s3api put-bucket-versioning --bucket <bucket> \
     --versioning-configuration Status=Enabled
   ```
@@ -1208,7 +1211,10 @@ What changes:
 
   # PROMOTE the version that was current at $POINT, whatever happened since.
   # Copying it back writes a NEW current version, which supersedes a delete
-  # marker and an overwrite alike:
+  # marker and an overwrite alike.
+  # URL-encode <key> inside --copy-source: originals/ keys keep the uploaded
+  # filename, which can carry spaces or reserved characters. The destination
+  # --key stays literal.
   aws s3api copy-object --bucket <bucket> --key "<key>" \
     --copy-source "<bucket>/<key>?versionId=<version-id-current-at-POINT>"
   ```

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -1132,7 +1132,11 @@ What changes:
      ExternalSecret) when it is `secrets.existingSecret`-backed. Reconciling
      the manifest alone would apply the replica and version changes while
      leaving the live Secret on the incident-state database.
-  2. Resume the sync you suspended at the start, or force one reconcile
+  2. With a provider-backed Secret (ExternalSecret, SealedSecret), first wait
+     until the target Secret decodes to the restored endpoint (the
+     `kubectl get secret ... | base64 -d` check above) — provider refresh is
+     asynchronous, and the sync's migration hook reads the live Secret. Then
+     resume the sync you suspended at the start, or force one reconcile
      (`argocd app sync <app>`, `flux reconcile hr <name> -n <ns>`). Nothing
      lands while it is suspended — and because the manifest now says zero, this
      does not bring the writers back.

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -1116,12 +1116,18 @@ What changes:
 
   **If Argo CD or Flux owns the release, the `helm` commands above are not
   yours to run** — the controller holds the values and will revert anything you
-  apply directly. Make the same three changes (endpoint, pinned chart version,
-  replicas at zero) in the Application or HelmRelease manifest, commit, and let
-  a sync apply them. Verify the endpoint the same way as below, while the
-  writers are still down; only then resume the sync you suspended earlier and
-  commit the replica counts back. The ordering and the reasoning are identical — only the
-  thing you edit changes.
+  apply directly. The ordering and the reasoning are identical; only the thing
+  you edit changes:
+
+  1. Commit the same three changes to the Application or HelmRelease manifest:
+     the restored endpoint, the chart version pinned to what is deployed, and
+     both replica counts at zero.
+  2. Resume the sync you suspended at the start, or force one reconcile
+     (`argocd app sync <app>`, `flux reconcile hr <name> -n <ns>`). Nothing
+     lands while it is suspended — and because the manifest now says zero, this
+     does not bring the writers back.
+  3. Verify the endpoint, as below, with the database still quiet.
+  4. Commit the original replica counts and let that reconcile.
 
   Verify the endpoint before letting traffic back in — connect with `psql` from
   a debug pod, or check that the restored data is present. Then restore the

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -1124,10 +1124,14 @@ What changes:
 
   # Before invoking the upgrade at all, prove the restored endpoint is the
   # database you intend — the pre-upgrade migration hook will run against it,
-  # and a wrong-but-reachable host would receive the migration. From a debug
-  # pod:
+  # and a wrong-but-reachable host would receive the migration. Schema alone
+  # cannot tell instances apart (the incident-state database is at the same
+  # migration revision), so check identity by TIME: the restored instance has
+  # no rows newer than the recovery point, while the incident-state one does.
+  # From a debug pod:
   #   psql 'host=<restored-endpoint> ...' \
-  #     -c 'select version_num from alembic_version'
+  #     -c 'select version_num from alembic_version' \
+  #     -c 'select max(created_at) from ingest_jobs'   # must be <= $POINT
   #
   # Pin the chart you are already running. Without --version, helm takes the
   # newest one in the repo and the recovery quietly becomes an app upgrade
@@ -1166,11 +1170,11 @@ What changes:
      suspended sync, so the wait works as-is. A **SealedSecret that is itself
      deployed by the suspended app cannot land while sync is paused** — waiting
      on it would deadlock. Apply that one committed resource first
-     (`argocd app sync <app> --resource bitnami.com/SealedSecret:<ns>/<name>`,
+     (`argocd app sync <app> --resource bitnami.com:SealedSecret:<ns>/<name>`,
      or `kubectl apply` of the same manifest you committed), let the controller
      unseal it, and confirm the target Secret before going on. Before any
-     reconcile, also validate the restored endpoint itself — the same
-     `psql ... alembic_version` check as the manual path, from a debug pod —
+     reconcile, also validate the restored endpoint itself — the same psql
+     schema-plus-recency check as the manual path, from a debug pod —
      because the resumed sync immediately runs the migration hook against
      whatever the Secret now says, and a wrong-but-reachable host would
      receive the migration. Then resume the

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -1034,17 +1034,34 @@ What changes:
   `#`, `?`, `@`, `/` or `:` produces a URL the API rejects at boot instead of
   connecting to the restored instance:
 
+  **Stop the workloads first.** A rolling restart would leave pods on the
+  incident-state database running alongside pods on the restored one, splitting
+  requests and queued jobs across two diverging databases:
+
   ```bash
-  # In the Secret (preferred — keeps the DSN out of shell history):
+  kubectl -n <ns> scale deploy/<release>-api deploy/<release>-worker --replicas=0
+  ```
+
+  Then change the endpoint **in whatever your deployment renders from** — the
+  values file, the SOPS/sealed secret, the ExternalSecret. Patching only the
+  live Secret is temporary: the next `helm upgrade` or GitOps reconciliation
+  re-renders it and silently points the workloads back at the incident-state
+  database. Swap the host in place rather than retyping the URI:
+
+  ```bash
+  # Keys to update — both, if you set the second:
   #   DATABASE_URL_OVERRIDE       runtime
-  #   TILE_DATABASE_URL_OVERRIDE  vector-tile pool, when you have set one
-  # Swap the host in place rather than rebuilding the URI:
-  OLD=<old-endpoint>; NEW=<restored-endpoint>
-  kubectl -n <ns> get secret <release>-secrets -o json \
-    | jq --arg o "$OLD" --arg n "$NEW" '.data |= with_entries(
-        select(.key | test("DATABASE_URL")) |= (.value |= (@base64d | sub($o; $n) | @base64)))' \
-    | kubectl apply -f -
-  kubectl -n <ns> rollout restart deploy/<release>-api deploy/<release>-worker
+  #   TILE_DATABASE_URL_OVERRIDE  vector-tile pool
+  sed -i.bak 's/<old-endpoint>/<restored-endpoint>/g' values.yaml   # or your secret source
+  helm upgrade <release> geolens/geolens -n <ns> -f values.yaml
+  ```
+
+  With a chart-managed Secret, that `helm upgrade` is the whole cutover. If the
+  Secret is operator-managed, update its source, re-apply it, and only then:
+
+  ```bash
+  kubectl -n <ns> scale deploy/<release>-api --replicas=<n>
+  kubectl -n <ns> scale deploy/<release>-worker --replicas=<n>
   ```
 
   A `TILE_DATABASE_URL_OVERRIDE` left pointing at the old endpoint is the

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -1221,6 +1221,16 @@ What changes:
   hands back the overwrite, silently pairing the recovered catalog with the
   wrong bytes. Copying the chosen version is correct in every case.
 
+  `copy-object` is a single-part copy and fails above **5 GB**, which COGs
+  reach easily. For those, round-trip the version instead — `aws s3 cp`
+  multiparts automatically on the way back up:
+
+  ```bash
+  aws s3api get-object --bucket <bucket> --key "<key>" \
+    --version-id <version-id-current-at-POINT> /tmp/restore.tif
+  aws s3 cp /tmp/restore.tif "s3://<bucket>/<key>"
+  ```
+
   Then re-request a tile: it should stop returning 500.
 
   A lifecycle rule to expire noncurrent versions keeps the cost bounded, but

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -1205,7 +1205,8 @@ What changes:
 
   ```bash
   # Where objects are namespaced per tenant, every prefix below sits under
-  # tenants/<tenant-id>/.
+  # tenants/<tenant-id>/ — except maps/icons/, which is written at the bucket
+  # root in every mode.
   PREFIX=rasters/<dataset-id>/     # from the catalog row you restored
   # Repeat for every prefix the restored database still references — the
   # managed layout, in full:

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -1134,7 +1134,11 @@ What changes:
   4. Commit the original replica counts and let that reconcile.
 
   Verify the endpoint before letting traffic back in — connect with `psql` from
-  a debug pod, or check that the restored data is present. Then restore the
+  a debug pod, or check that the restored data is present. **If the incident
+  touched object storage, do that repair now too**, while the writers are still
+  down — see [object versions](#restoring-an-object-version) below. Restarting
+  the api first means serving 500s from rasters you are about to fix, and
+  re-ingesting or re-uploading against a half-restored bucket. Then restore the
   replica counts that `deployed-values.yaml` already records:
 
   ```bash
@@ -1181,6 +1185,7 @@ What changes:
   left a published dataset whose tiles returned 500, and nothing could bring
   them back.
 
+  <a id="restoring-an-object-version"></a>
   **Enabling it is protection for next time, not a recovery.** If versioning was
   already on when the incident happened, the objects are still there but not
   *current* — a delete left a delete marker on top, an overwrite left the wrong
@@ -1189,6 +1194,8 @@ What changes:
   your database recovery point:
 
   ```bash
+  # Single-tenant. In multi-tenant mode the managed layout is namespaced —
+  # tenants/<tenant-id>/rasters/<dataset-id>/ — so use that prefix instead.
   PREFIX=rasters/<dataset-id>/     # from the catalog row you restored
   POINT=2026-08-20T23:45:08Z       # the same timestamp you restored the DB to
 

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -1052,7 +1052,10 @@ kubectl -n <ns> wait --for=delete pod --timeout=180s \
 
 Under Argo CD or Flux, a `kubectl scale` is drift the controller undoes on its
 next sync — the writers come back mid-restore. Suspend the sync first
-(`argocd app set <app> --sync-policy none`, or `flux suspend hr <name> -n <ns>` —
+(`argocd app set <app> --sync-policy none`, then
+`argocd app terminate-op <app>` — the policy change stops *future* syncs but
+not one already running, which would still reapply the replica counts; or
+`flux suspend hr <name> -n <ns>` —
 it defaults to `flux-system`, not the release namespace), or set
 the replica counts to zero in the source repository, and reverse whichever you
 chose at the end.
@@ -1336,9 +1339,11 @@ What changes:
   While the writers are still down, confirm the promotion at the store:
   `aws s3api head-object --bucket <bucket> --key "<key>"` shows what is
   current now. The promoted copy is a **new** version, so its id will not
-  match the one you copied from — compare `ContentLength` (and, for a
-  single-part `copy-object`, `ETag`) against the `Size` and `ETag` the listing
-  above showed for the version you selected. The
+  match the one you copied from — compare `ContentLength` against the `Size`
+  the listing above showed for the version you selected. `ETag` only
+  corroborates when the source version's ETag carries no multipart `-N`
+  suffix: a single-request copy of a multipart-uploaded version (managed COGs
+  usually are) legitimately changes it. The
   end-to-end check comes after the replicas return — re-request a tile, and it
   should stop returning 500.
 

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -1053,7 +1053,12 @@ What changes:
   #   DATABASE_URL_OVERRIDE       runtime
   #   TILE_DATABASE_URL_OVERRIDE  vector-tile pool
   sed -i.bak 's/<old-endpoint>/<restored-endpoint>/g' values.yaml   # or your secret source
-  helm upgrade <release> geolens/geolens -n <ns> -f values.yaml
+
+  # Pin the chart you are already running. Without --version, helm takes the
+  # newest one in the repo and the recovery quietly becomes an app upgrade
+  # too — new images and a migration hook, during an incident.
+  CHART=$(helm list -n <ns> -o json | jq -r '.[] | select(.name=="<release>") | .chart | sub("^geolens-"; "")')
+  helm upgrade <release> geolens/geolens -n <ns> -f values.yaml --version "$CHART"
   ```
 
   With a chart-managed Secret, that `helm upgrade` is the whole cutover. If the

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -137,9 +137,10 @@ external object stores.
 
 Concretely, that means enabling **object versioning** on the bucket — it is the
 only thing that makes an accidental delete or overwrite recoverable, and no
-database backup substitutes for it. Raster datasets are the ones that depend on
-it: their COGs exist only in the bucket, so a database restore brings the
-catalog row back while every tile fails. See
+database backup substitutes for it. Uploaded raster datasets are the ones that
+depend on it: a managed COG exists only in the bucket, so a database restore
+brings the catalog row back while every tile fails. By-reference imports (STAC,
+public COGs) keep serving from the upstream URL instead. See
 [On Kubernetes](#on-kubernetes-the-community-helm-chart) for the measured
 breakdown of what a database-only restore does and does not recover.
 
@@ -1203,7 +1204,7 @@ What changes:
   # What versions exist, and what is on top right now:
   aws s3api list-object-versions --bucket <bucket> --prefix "$PREFIX" \
     --query '{Versions: Versions[].[Key,VersionId,IsLatest,LastModified],
-              DeleteMarkers: DeleteMarkers[].[Key,VersionId,IsLatest]}'
+              DeleteMarkers: DeleteMarkers[].[Key,VersionId,IsLatest,LastModified]}'
 
   # PROMOTE the version that was current at $POINT, whatever happened since.
   # Copying it back writes a NEW current version, which supersedes a delete

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -1245,7 +1245,10 @@ What changes:
   aws s3 cp /tmp/restore.tif "s3://<bucket>/<key>"
   ```
 
-  Then re-request a tile: it should stop returning 500.
+  While the writers are still down, confirm the promotion at the store:
+  `aws s3api head-object --bucket <bucket> --key "<key>"` should report the
+  promoted bytes as the current version. The end-to-end check comes after the
+  replicas return — re-request a tile, and it should stop returning 500.
 
   A lifecycle rule to expire noncurrent versions keeps the cost bounded, but
   **it must outlast the database recovery window, or it silently re-creates the

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -1036,7 +1036,8 @@ kubectl -n <ns> wait --for=delete pod --timeout=180s \
 
 Under Argo CD or Flux, a `kubectl scale` is drift the controller undoes on its
 next sync — the writers come back mid-restore. Suspend the sync first
-(`argocd app set <app> --sync-policy none`, or `flux suspend hr <name>`), or set
+(`argocd app set <app> --sync-policy none`, or `flux suspend hr <name> -n <ns>` —
+it defaults to `flux-system`, not the release namespace), or set
 the replica counts to zero in the source repository, and reverse whichever you
 chose at the end.
 

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -1022,6 +1022,20 @@ no `backup` container, no `backup_data` volume, and no Compose project — the
 chart ships **no backup workload at all**, so the database backups are entirely
 your provider's, and object storage is entirely your bucket's.
 
+**Before anything else, stop the writers.** Scale the workloads to zero
+*before* you initiate the restore, not at cutover:
+
+```bash
+kubectl -n <ns> scale deploy/<release>-api deploy/<release>-worker --replicas=0
+```
+
+Provisioning a restored instance takes ten minutes or more. Every write
+accepted in that window — and any accepted after the point in time you are
+restoring to — lands only on the incident-state database and is discarded when
+you cut over. Quiescing first bounds the loss to what happened before you
+noticed; quiescing at cutover silently extends it by the length of the
+recovery. Keep them at zero until the new endpoint is verified.
+
 What changes:
 
 - **Step 1 is the same** and is the whole database recovery. Restoring an RDS
@@ -1034,15 +1048,12 @@ What changes:
   `#`, `?`, `@`, `/` or `:` produces a URL the API rejects at boot instead of
   connecting to the restored instance:
 
-  **Stop the workloads first.** A rolling restart would leave pods on the
-  incident-state database running alongside pods on the restored one, splitting
-  requests and queued jobs across two diverging databases:
+  The workloads are already at zero from the step above — keep them there.
+  Bringing them back before the endpoint changes would put pods on the
+  incident-state database alongside pods on the restored one, splitting
+  requests and queued jobs across two diverging databases.
 
-  ```bash
-  kubectl -n <ns> scale deploy/<release>-api deploy/<release>-worker --replicas=0
-  ```
-
-  Then change the endpoint **in whatever your deployment renders from** — the
+  Change the endpoint **in whatever your deployment renders from** — the
   values file, the SOPS/sealed secret, the ExternalSecret. Patching only the
   live Secret is temporary: the next `helm upgrade` or GitOps reconciliation
   re-renders it and silently points the workloads back at the incident-state

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -1219,8 +1219,10 @@ What changes:
     --copy-source "<bucket>/<key>?versionId=<version-id-current-at-POINT>"
   ```
 
-  Pick the newest entry at or before `$POINT`, **counting delete markers as
-  entries**. A real version there is the one to promote; anything newer belongs
+  The listing interleaves every key under the prefix — a COG travels with its
+  VRT artifacts and quicklook — so make this selection **per key**, for each
+  key the restored catalog references. Pick that key's newest entry at or
+  before `$POINT`, **counting delete markers as entries**. A real version there is the one to promote; anything newer belongs
   to writes the restore discarded. A delete marker there needs the restored
   catalog to arbitrate — deletion removes the objects *before* the database
   row, so a restore can land in that gap with the row back and a marker on top

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -1212,12 +1212,15 @@ What changes:
     --copy-source "<bucket>/<key>?versionId=<version-id-current-at-POINT>"
   ```
 
-  Pick the newest entry at or before `$POINT` — **counting delete markers as
-  entries**. If that entry is a delete marker, the object was already deleted at
-  the recovery point and there is nothing to promote: the restored catalog
-  should not reference it, and putting bytes back would resurrect data the
-  restore deliberately dropped. Otherwise promote that version; anything newer
-  belongs to writes the restore discarded.
+  Pick the newest entry at or before `$POINT`, **counting delete markers as
+  entries**. A real version there is the one to promote; anything newer belongs
+  to writes the restore discarded. A delete marker there needs the restored
+  catalog to arbitrate — deletion removes the objects *before* the database
+  row, so a restore can land in that gap with the row back and a marker on top
+  of its objects. If the restored catalog references the key, promote the
+  newest real version older than the marker: the bytes belong with the row. If
+  it does not, there is nothing to promote, and putting bytes back would
+  resurrect data the restore deliberately dropped.
 
   Promote rather than just deleting the delete marker. Removing a marker makes
   the *immediately preceding* version current, which is the right one only if

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -1204,11 +1204,18 @@ What changes:
   your database recovery point:
 
   ```bash
-  # Where objects are namespaced per tenant, the managed layout is
-  # tenants/<tenant-id>/rasters/<dataset-id>/ — use that prefix instead.
+  # Where objects are namespaced per tenant, every prefix below sits under
+  # tenants/<tenant-id>/.
   PREFIX=rasters/<dataset-id>/     # from the catalog row you restored
-  # Repeat for originals/<dataset-id>/ — the archived source upload lives
-  # there — and, for vector datasets, vectors/<dataset-id>/ (the quicklook).
+  # Repeat for every prefix the restored database still references — the
+  # managed layout, in full:
+  #   rasters/<dataset-id>/      managed COGs and VRT artifacts
+  #   originals/<dataset-id>/    archived source uploads
+  #   vectors/<dataset-id>/      vector quicklooks
+  #   maps/thumbnails/ maps/og-images/ maps/icons/   map assets
+  #   staging/                   in-flight uploads: promote the file_path keys
+  #                              of nonterminal ingest jobs before the worker
+  #                              returns, or their retry refuses to run
   POINT=2026-08-20T23:45:08Z       # the same timestamp you restored the DB to
 
   # What versions exist, and what is on top right now:

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -1121,10 +1121,11 @@ What changes:
   # — so before the upgrade, whose migration hook reads this live Secret,
   # confirm the target Secret carries the restored endpoint in EVERY DSN key
   # it holds (TILE_DATABASE_URL_OVERRIDE and friends too, if you set them),
-  # not just the obvious one:
+  # not just the obvious one. Print only the key and the host part — the full
+  # DSN carries the password, and scrollback outlives the incident:
   #   kubectl -n <ns> get secret <name> -o json | jq -r \
   #     '.data | to_entries[] | select(.key | test("DATABASE_URL"))
-  #      | "\(.key) \(.value | @base64d)"'
+  #      | "\(.key) \(.value | @base64d | sub("^.*@"; ""))"'
   grep -c '<restored-endpoint>' deployed-values.yaml    # 0 => the DSN is in the Secret
 
   # Before invoking the upgrade at all, prove the restored endpoint is the
@@ -1203,7 +1204,10 @@ What changes:
      incident touched object storage, do the
      [object-version repair](#restoring-an-object-version) now, while the
      writers are still down.
-  4. Commit the original replica counts, let that reconcile, and wait for both
+  4. Commit the original replica counts and reconcile them — on Argo CD
+     auto-sync is still off at this point, so re-enable the sync policy or run
+     the one-shot `argocd app sync` again; on Flux the resumed HelmRelease
+     picks the commit up. Then wait for both
      rollouts to finish (`kubectl -n <ns> rollout status deploy/<release>-api`
      and the worker equivalent) — a reconciled manifest says nothing about the
      pods actually becoming ready.

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -141,8 +141,16 @@ database backup substitutes for it. Versioning is an S3 (and GCS) capability;
 **Cloudflare R2 does not implement it** — the bucket-versioning calls are
 outside R2's S3 compatibility surface, and the
 [version-promotion procedure](#restoring-an-object-version) below does not
-apply there. On R2 the equivalent protection is a scheduled copy to a second
-bucket (for example an `rclone sync` job), which is what you restore from. Uploaded raster datasets are the ones that
+apply there. On R2 the equivalent protection is a scheduled job that
+*preserves* replaced and deleted objects instead of mirroring their removal —
+a plain `rclone sync` would propagate the very deletion you need to survive at
+its next run. Use the backup-dir form, which moves anything overwritten or
+deleted into a dated archive prefix you can restore from:
+
+```bash
+rclone sync :s3:<bucket> :s3:<backup-bucket>/current \
+  --backup-dir ":s3:<backup-bucket>/archive/$(date -u +%F)"
+``` Uploaded raster datasets are the ones that
 depend on it: a managed COG exists only in the bucket, so a database restore
 brings the catalog row back while every tile fails. By-reference imports (STAC,
 public COGs) keep serving from the upstream URL instead. See

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -1058,10 +1058,17 @@ What changes:
   # (MIGRATION_DATABASE_URL_OVERRIDE is a Compose-only variable — docker-compose.yml
   # maps it into the migrate service. Nothing in the chart or the application
   # reads it, so it is not part of this path.)
-  # No -i.bak: that would leave values.yaml.bak holding the OLD DSN, password
-  # and all, sitting in plaintext next to the file you are careful about.
+  # Plain values file. If the DSN lives in SOPS, a SealedSecret or an
+  # ExternalSecret, do NOT edit the ciphertext — go through that tool
+  # (`sops values.enc.yaml`, re-seal, or edit the upstream secret store),
+  # or the next reconciliation overwrites what you just changed.
+  #
+  # No -i.bak, and the mode is carried over: a backup would leave the OLD DSN
+  # in plaintext beside the file, and a bare `mv` would replace a 0600 file
+  # with whatever your umask produces.
+  cp -p values.yaml values.yaml.tmp
   sed 's/<old-endpoint>/<restored-endpoint>/g' values.yaml > values.yaml.tmp \
-    && mv values.yaml.tmp values.yaml      # or your secret source
+    && mv values.yaml.tmp values.yaml
 
   # Pin the chart you are already running. Without --version, helm takes the
   # newest one in the repo and the recovery quietly becomes an app upgrade

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -1096,7 +1096,12 @@ What changes:
   # With secrets.existingSecret the DSN is NOT in the values — it is in your
   # Secret, and the grep below returns 0. Update that Secret's source and
   # re-apply it FIRST; the helm upgrade alone changes nothing, and the pods
-  # would come back on the old endpoint.
+  # would come back on the old endpoint. Controller-managed sources
+  # (ExternalSecret, SealedSecret) reconcile asynchronously, so before the
+  # upgrade — whose migration hook reads this live Secret — confirm the target
+  # Secret actually carries the restored endpoint:
+  #   kubectl -n <ns> get secret <name> \
+  #     -o jsonpath='{.data.DATABASE_URL_OVERRIDE}' | base64 -d
   grep -c '<restored-endpoint>' deployed-values.yaml    # 0 => the DSN is in the Secret
 
   # Pin the chart you are already running. Without --version, helm takes the
@@ -1215,8 +1220,9 @@ What changes:
   #   vectors/<dataset-id>/      vector quicklooks
   #   maps/thumbnails/ maps/og-images/ maps/icons/   map assets
   #   staging/                   in-flight uploads: promote the file_path keys
-  #                              of nonterminal ingest jobs before the worker
-  #                              returns, or their retry refuses to run
+  #                              of nonterminal AND retryable failed ingest
+  #                              jobs before the worker returns — retry
+  #                              requires the staged object to exist
   POINT=2026-08-20T23:45:08Z       # the same timestamp you restored the DB to
 
   # What versions exist, and what is on top right now:

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -1091,7 +1091,11 @@ What changes:
   helm get values <release> -n <ns> -o yaml > deployed-values.yaml
   sed 's/<old-endpoint>/<restored-endpoint>/g' deployed-values.yaml > tmp \
     && mv tmp deployed-values.yaml
-  grep -c '<restored-endpoint>' deployed-values.yaml    # expect >= 1
+  # With secrets.existingSecret the DSN is NOT in the values — it is in your
+  # Secret, and the grep below returns 0. Update that Secret's source and
+  # re-apply it FIRST; the helm upgrade alone changes nothing, and the pods
+  # would come back on the old endpoint.
+  grep -c '<restored-endpoint>' deployed-values.yaml    # 0 => the DSN is in the Secret
 
   # Pin the chart you are already running. Without --version, helm takes the
   # newest one in the repo and the recovery quietly becomes an app upgrade
@@ -1105,8 +1109,9 @@ What changes:
     --set api.replicas=0 --set worker.replicas=0
   ```
 
-  With a chart-managed Secret, that `helm upgrade` is the whole cutover. If the
-  Secret is operator-managed, update its source, re-apply it, and only then:
+  With a chart-managed Secret, that `helm upgrade` is the whole cutover. With
+  `secrets.existingSecret`, the Secret you updated above is, and the upgrade
+  only re-renders the workloads around it.
 
   Verify the endpoint before letting traffic back in — connect with `psql` from
   a debug pod, or check that the restored data is present. Then restore the

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -1119,9 +1119,13 @@ What changes:
   apply directly. The ordering and the reasoning are identical; only the thing
   you edit changes:
 
-  1. Commit the same three changes to the Application or HelmRelease manifest:
-     the restored endpoint, the chart version pinned to what is deployed, and
-     both replica counts at zero.
+  1. Commit the chart version pinned to what is deployed, and both replica
+     counts at zero, to the Application or HelmRelease manifest. The restored
+     **endpoint** goes wherever the DSN actually lives — the same manifest for
+     inline values, but the external provider (and a refresh of the
+     ExternalSecret) when it is `secrets.existingSecret`-backed. Reconciling
+     the manifest alone would apply the replica and version changes while
+     leaving the live Secret on the incident-state database.
   2. Resume the sync you suspended at the start, or force one reconcile
      (`argocd app sync <app>`, `flux reconcile hr <name> -n <ns>`). Nothing
      lands while it is suspended — and because the manifest now says zero, this

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -1283,7 +1283,7 @@ What changes:
 
   # What versions exist, and what is on top right now:
   aws s3api list-object-versions --bucket <bucket> --prefix "$PREFIX" \
-    --query '{Versions: Versions[].[Key,VersionId,IsLatest,LastModified],
+    --query '{Versions: Versions[].[Key,VersionId,IsLatest,LastModified,Size,ETag],
               DeleteMarkers: DeleteMarkers[].[Key,VersionId,IsLatest,LastModified]}'
 
   # PROMOTE the version that was current at $POINT, whatever happened since.
@@ -1328,7 +1328,8 @@ What changes:
   `aws s3api head-object --bucket <bucket> --key "<key>"` shows what is
   current now. The promoted copy is a **new** version, so its id will not
   match the one you copied from — compare `ContentLength` (and, for a
-  single-part `copy-object`, `ETag`) against the version you selected. The
+  single-part `copy-object`, `ETag`) against the `Size` and `ETag` the listing
+  above showed for the version you selected. The
   end-to-end check comes after the replicas return — re-request a tile, and it
   should stop returning 500.
 

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -1114,6 +1114,14 @@ What changes:
   `secrets.existingSecret`, the Secret you updated above is, and the upgrade
   only re-renders the workloads around it.
 
+  **If Argo CD or Flux owns the release, the `helm` commands above are not
+  yours to run** — the controller holds the values and will revert anything you
+  apply directly. Make the same three changes (endpoint, pinned chart version,
+  replicas at zero) in the Application or HelmRelease manifest, commit, and let
+  a sync apply them; then resume the sync you suspended earlier and commit the
+  replica counts back. The ordering and the reasoning are identical — only the
+  thing you edit changes.
+
   Verify the endpoint before letting traffic back in — connect with `psql` from
   a debug pod, or check that the restored data is present. Then restore the
   replica counts that `deployed-values.yaml` already records:

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -1117,6 +1117,13 @@ What changes:
   #     -o jsonpath='{.data.DATABASE_URL_OVERRIDE}' | base64 -d
   grep -c '<restored-endpoint>' deployed-values.yaml    # 0 => the DSN is in the Secret
 
+  # Before invoking the upgrade at all, prove the restored endpoint is the
+  # database you intend — the pre-upgrade migration hook will run against it,
+  # and a wrong-but-reachable host would receive the migration. From a debug
+  # pod:
+  #   psql 'host=<restored-endpoint> ...' \
+  #     -c 'select version_num from alembic_version'
+  #
   # Pin the chart you are already running. Without --version, helm takes the
   # newest one in the repo and the recovery quietly becomes an app upgrade
   # too — new images and a migration hook, during an incident.
@@ -1145,11 +1152,17 @@ What changes:
      ExternalSecret) when it is `secrets.existingSecret`-backed. Reconciling
      the manifest alone would apply the replica and version changes while
      leaving the live Secret on the incident-state database.
-  2. With a provider-backed Secret (ExternalSecret, SealedSecret), first wait
-     until the target Secret decodes to the restored endpoint (the
-     `kubectl get secret ... | base64 -d` check above) — provider refresh is
-     asynchronous, and the sync's migration hook reads the live Secret. Then
-     resume the sync you suspended at the start, or force one reconcile
+  2. With a provider-backed Secret, first wait until the target Secret decodes
+     to the restored endpoint (the `kubectl get secret ... | base64 -d` check
+     above) — provider refresh is asynchronous, and the sync's migration hook
+     reads the live Secret. An ExternalSecret reconciles independently of the
+     suspended sync, so the wait works as-is. A **SealedSecret that is itself
+     deployed by the suspended app cannot land while sync is paused** — waiting
+     on it would deadlock. Apply that one committed resource first
+     (`argocd app sync <app> --resource bitnami.com/SealedSecret:<ns>/<name>`,
+     or `kubectl apply` of the same manifest you committed), let the controller
+     unseal it, and confirm the target Secret before going on. Then resume the
+     sync you suspended at the start, or force one reconcile
      (`argocd app sync <app>`, `flux reconcile hr <name> -n <ns>`). Nothing
      lands while it is suspended — and because the manifest now says zero, this
      does not bring the writers back.

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -137,7 +137,12 @@ external object stores.
 
 Concretely, that means enabling **object versioning** on the bucket — it is the
 only thing that makes an accidental delete or overwrite recoverable, and no
-database backup substitutes for it. Uploaded raster datasets are the ones that
+database backup substitutes for it. Versioning is an S3 (and GCS) capability;
+**Cloudflare R2 does not implement it** — the bucket-versioning calls are
+outside R2's S3 compatibility surface, and the
+[version-promotion procedure](#restoring-an-object-version) below does not
+apply there. On R2 the equivalent protection is a scheduled copy to a second
+bucket (for example an `rclone sync` job), which is what you restore from. Uploaded raster datasets are the ones that
 depend on it: a managed COG exists only in the bucket, so a database restore
 brings the catalog row back while every tile fails. By-reference imports (STAC,
 public COGs) keep serving from the upstream URL instead. See
@@ -1237,9 +1242,9 @@ What changes:
   # PROMOTE the version that was current at $POINT, whatever happened since.
   # Copying it back writes a NEW current version, which supersedes a delete
   # marker and an overwrite alike.
-  # URL-encode <key> inside --copy-source: originals/ keys keep the uploaded
-  # filename, which can carry spaces or reserved characters. The destination
-  # --key stays literal.
+  # URL-encode <key> — and the versionId value — inside --copy-source:
+  # originals/ keys keep the uploaded filename, which can carry spaces or
+  # reserved characters. The destination --key stays literal.
   aws s3api copy-object --bucket <bucket> --key "<key>" \
     --copy-source "<bucket>/<key>?versionId=<version-id-current-at-POINT>"
   ```


### PR DESCRIPTION
## What

RUNBOOK §3 ("Restore — managed / external Postgres mode") told an operator with an external database to recover object storage with `docker run -v <project>_backup_data …` and then bring the stack up with `docker compose up -d`. On the community Helm chart none of that exists: no backup container, no `backup_data` volume, no Compose project — and with `storage.backend=s3`, no `upload_staging` volume to archive either.

## What was executed

The procedure was run against real infrastructure (EKS, RDS PostgreSQL 18, S3), not reasoned about:

- **Step 1 works and is the whole database recovery.** A dataset was deleted at 23:45:59Z and recovered by restoring to 23:45:08Z; a direct query confirmed the restored instance held all three records while the live one held two. Two timings are now written down because both eat into an RTO: the restorable window trailed real time by ~5 minutes, and provisioning the restored instance took ~11 more.
- A point-in-time restore produces a **new endpoint**, so the recovery ends by re-pointing the release — `helm upgrade --set secrets.databaseUrlOverride=…`, not by editing `.env`.
- **Step 2 has no Kubernetes equivalent, and that is where the real exposure is.**

## The finding worth reading

A database-only restore recovers an S3-backed catalog **asymmetrically**, measured on the recovered data:

| | recovered? |
| --- | --- |
| Vector datasets | **Yes, fully.** Features live in PostGIS — `features` and `export` both returned 200 with the object gone. The loss costs the original upload and the quicklook. |
| Raster datasets | **No.** The COG exists only in the bucket. Deleting it left tiles returning **500** while the catalog row still read `record_status: published`, `source_health: unknown`. |

The bucket had no versioning, no lifecycle and no replication, so the objects were simply gone. §1's "Scope caveat" was already honest that GeoLens does not back up external object stores; it now names the defense (`put-bucket-versioning`) instead of gesturing at "that bucket's lifecycle policy", and §3 says what a database-only restore does and does not bring back.

## Scope

Documentation only. No behaviour change.
