### PR TITLE
chore(release): v1.14.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,44 @@ and releases use semantic versioning.
 
 ## [Unreleased]
 
+## [1.14.2] - 2026-08-21
+
+### Added
+
+- **S3 storage works without static keys.** With `STORAGE_PROVIDER=s3`, boot
+  validation demanded `S3_ACCESS_KEY_ID`/`S3_SECRET_ACCESS_KEY` even when the
+  environment carried ambient AWS credentials, so keyless setups — EKS with
+  IRSA or Pod Identity, ECS task roles — could not start at all. The validator
+  now accepts an ambient credential source (a web-identity role or a container
+  credentials URI) in place of the static pair, while a half-configured pair
+  is still rejected. The storage layer and GDAL already resolved the SDK
+  default chain; the validator was the only thing in the way (#1616).
+
+### Fixed
+
+- **Vector ingest works against a TLS-verified database.** Under
+  `DATABASE_SSL_MODE=verify-full`, the CA certificate reached asyncpg as an
+  SSLContext but never reached ogr2ogr, whose libpq connection string carried
+  no `sslrootcert` — so every vector ingest failed certificate verification
+  while the rest of the app connected fine. The ogr2ogr and Procrastinate
+  connection strings now carry the same TLS parameters as the API path, values
+  are quoted and escaped per libpq rules, and percent-encoded credentials are
+  decoded to match what SQLAlchemy sends (#1617).
+- **The operator runbook covers managed-database and object-storage restore on
+  Kubernetes.** The backup/restore runbook assumed the Docker Compose stack;
+  restoring a chart deployment — RDS point-in-time restore, the Secret
+  cutover, GitOps-owned releases, S3 object-version promotion, and the full
+  managed-storage prefix layout — is now drilled and documented, including the
+  recovery asymmetry table for what a database-only restore does and does not
+  bring back (#1618).
+
+### Security
+
+- **CI dependency audit unblocked.** pip 26.1.2 — a transitive dependency of
+  the audit tooling, not of GeoLens itself — matched the newly published
+  PYSEC-2026-3721 advisory and failed every strict audit run; bumped to
+  26.2.1 (#1619).
+
 ## [1.14.1] - 2026-08-20
 
 ### Added
@@ -2411,7 +2449,8 @@ regression-covered fixes:
 - Initial public release of the GeoLens catalog, API, map builder, CLI, SDKs,
   Docker development stack, and public documentation entrypoints.
 
-[Unreleased]: https://github.com/geolens-io/geolens/compare/v1.14.1...HEAD
+[Unreleased]: https://github.com/geolens-io/geolens/compare/v1.14.2...HEAD
+[1.14.2]: https://github.com/geolens-io/geolens/compare/v1.14.1...v1.14.2
 [1.14.1]: https://github.com/geolens-io/geolens/compare/v1.14.0...v1.14.1
 [1.14.0]: https://github.com/geolens-io/geolens/compare/v1.13.1...v1.14.0
 [1.13.1]: https://github.com/geolens-io/geolens/compare/v1.13.0...v1.13.1

--- a/backend/app/api/main.py
+++ b/backend/app/api/main.py
@@ -746,7 +746,7 @@ _is_production = settings.is_production
 # no metadata to read. We fall back to the current published line so import never
 # crashes. Keep this fallback in lockstep with backend/pyproject.toml — it is one
 # of the sites `make bump` rewrites.
-_FALLBACK_APP_VERSION = "1.14.1"
+_FALLBACK_APP_VERSION = "1.14.2"
 
 
 def _resolve_app_version() -> str:

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -18506,7 +18506,7 @@
     "summary": "PostGIS-native geospatial data catalog with OGC API Features and Records support",
     "termsOfService": "https://github.com/geolens-io/geolens/blob/main/LICENSE",
     "title": "GeoLens API",
-    "version": "1.14.1"
+    "version": "1.14.2"
   },
   "openapi": "3.1.0",
   "paths": {

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geolens-backend"
-version = "1.14.1"
+version = "1.14.2"
 description = "PostGIS-native GIS data catalog"
 # Docker image (Dockerfile) ships python:3.14-slim (see the Dockerfile FROM for
 # the exact patch pin) as the project's tested runtime.

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -838,7 +838,7 @@ wheels = [
 
 [[package]]
 name = "geolens-backend"
-version = "1.14.1"
+version = "1.14.2"
 source = { virtual = "." }
 dependencies = [
     { name = "alembic" },

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "geolens-cli"
-version = "1.14.1"
+version = "1.14.2"
 description = "Apache-2.0 command-line interface for the GeoLens API. Login, scan, publish, and export STAC against any GeoLens instance."
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/docs-contract.json
+++ b/docs-contract.json
@@ -1,6 +1,6 @@
 {
   "_comment": "Canonical cross-surface facts for the GeoLens README, marketing site (getgeolens.com/src), and docs site (getgeolens.com/docs). Validated against scripts/install.sh + backend/pyproject.toml by scripts/check_docs_contract.py (geolens CI). The getgeolens.com repo vendors a copy and enforces the same `forbidden` list in its own CI. See docs-internal/DOC-CONSISTENCY-STRATEGY for the full design. Edit a fact ONCE here (and in its canonical source) — the gates make every surface follow.",
-  "version": "1.14.1",
+  "version": "1.14.2",
   "install": {
     "oneLiner": "curl -fsSL https://getgeolens.com/install.sh | sh",
     "sourceBuild": "bash scripts/install.sh",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "1.14.1",
+  "version": "1.14.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "1.14.1",
+      "version": "1.14.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.14.1",
+  "version": "1.14.2",
   "type": "module",
   "license": "Apache-2.0",
   "author": "Carto Concepts, LLC",

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "geolens-mcp"
-version = "1.14.1"
+version = "1.14.2"
 description = "Apache-2.0 read-only Model Context Protocol (MCP) server for GeoLens. Lets coding agents discover datasets, inspect schemas, and ask spatial questions against any GeoLens instance."
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/mcp/uv.lock
+++ b/mcp/uv.lock
@@ -225,7 +225,7 @@ wheels = [
 
 [[package]]
 name = "geolens"
-version = "1.14.1"
+version = "1.14.2"
 source = { editable = "../sdks/python" }
 dependencies = [
     { name = "attrs" },
@@ -244,7 +244,7 @@ requires-dist = [
 
 [[package]]
 name = "geolens-mcp"
-version = "1.14.1"
+version = "1.14.2"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "geolens",
-  "version": "1.14.1",
+  "version": "1.14.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "geolens",
-      "version": "1.14.1",
+      "version": "1.14.2",
       "license": "Apache-2.0",
       "devDependencies": {
         "@axe-core/playwright": "^4.13.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geolens",
-  "version": "1.14.1",
+  "version": "1.14.2",
   "private": true,
   "license": "Apache-2.0",
   "author": "Carto Concepts, LLC",

--- a/sdks/python/.openapi-python-client.yaml
+++ b/sdks/python/.openapi-python-client.yaml
@@ -4,7 +4,7 @@ project_name_override: geolens
 package_name_override: geolens
 # Rewritten on every `make sdks` run by scripts/sync_sdk_versions.py to match
 # backend/openapi.json info.version. Do not edit by hand.
-package_version_override: 1.14.1
+package_version_override: 1.14.2
 
 # Cleaner enum output (matches our pydantic v2 backend's enum emission).
 literal_enums: true

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "geolens"
-version = "1.14.1"
+version = "1.14.2"
 description = "Auto-generated Python SDK for the GeoLens API. Typed clients with Bearer + API-key auth helpers."
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/sdks/typescript/package-lock.json
+++ b/sdks/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@geolens/sdk",
-  "version": "1.14.1",
+  "version": "1.14.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@geolens/sdk",
-      "version": "1.14.1",
+      "version": "1.14.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@hey-api/client-fetch": "0.13.1"

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geolens/sdk",
-  "version": "1.14.1",
+  "version": "1.14.2",
   "description": "Auto-generated TypeScript SDK for the GeoLens API. Typed clients with Bearer + API-key auth helpers.",
   "license": "Apache-2.0",
   "author": "Carto Concepts, LLC",


### PR DESCRIPTION
Cuts v1.14.2, the cloud-deployment patch from the EKS chart-validation wave.

Contents since v1.14.1: ambient AWS credentials for S3 storage (#1616), ogr2ogr TLS under verify-full (#1617), the Kubernetes backup/restore runbook (#1618), the pip 26.2.1 audit unblock (#1619), and the CodeQL suppression pack (#1615).

Mechanics: `make bump VERSION=1.14.2` (19 sites, `make version-check` green), CHANGELOG folded with a fresh empty Unreleased above it.

Verification: full local smoke on merged main earlier today — 12 gates plus e2e:smoke and the export-semantics battery, all green.