### PR TITLE
chore(mcp): add glama.json so the Glama listing can be claimed

### DIFF
--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": ["ishiland"]
+}


### PR DESCRIPTION
Adds the maintainers manifest Glama requires at the repo root before an org-owned server listing can be claimed. The geolens-mcp listing (glama.ai/mcp/servers/geolens-io/geolens) is a prerequisite for the awesome-mcp-servers entry, whose bot requires a Glama score badge.

No runtime impact; single static JSON file.