### PR TITLE
feat(mcp): publish the MCP server to the official registry on release

### DIFF
--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -7,6 +7,14 @@
 #   - workflow_dispatch → same gate; for ad-hoc / re-publish, run from a tag ref:
 #     `gh workflow run publish-mcp.yml --ref vX.Y.Z`
 #
+# Recovering a half-finished release (fix(#1623)): PyPI refuses a re-upload of a
+# version it already has, so once `uv publish` succeeds there is no way back
+# through the PyPI half — `force_publish` overrides the pre-flight gate but
+# `uv publish` still fails on the duplicate. If the registry half is what broke,
+# re-run with `registry_only=true`, which skips build and PyPI entirely and
+# publishes only mcp/server.json:
+#   `gh workflow run publish-mcp.yml --ref vX.Y.Z -f registry_only=true`
+#
 # One-time cold-start credentials required before the first publish:
 #   1. PyPI Trusted Publishing configured for `geolens-mcp` at https://pypi.org/manage/account/publishing/
 #      (pending publisher; environment left BLANK — see the gate-job note below)
@@ -26,6 +34,11 @@ on:
         default: false
       force_publish:
         description: 'Override pre-flight gate (allow re-publishing over an existing version). Only set true after confirming the existing version is intentionally being re-published.'
+        required: false
+        type: boolean
+        default: false
+      registry_only:
+        description: 'Skip build and PyPI; publish only the MCP Registry entry. Use to retry the registry half after PyPI already published this version.'
         required: false
         type: boolean
         default: false
@@ -67,8 +80,12 @@ jobs:
         with:
           python-version: "3.14"
 
-      - name: Assert tag matches package version (tag push only)
-        if: ${{ github.event_name == 'push' }}
+      # Any tag ref, not just a tag push: a `registry_only` retry is dispatched
+      # manually, and running it from the wrong tag would claim a version that is
+      # not the one on PyPI. `make version-check` keeps server.json equal to this
+      # pyproject on every merged commit, so asserting one covers both.
+      - name: Assert tag matches package version (tag refs only)
+        if: ${{ github.ref_type == 'tag' }}
         working-directory: mcp
         run: |
           TAG="${GITHUB_REF_NAME#v}"
@@ -85,15 +102,17 @@ jobs:
           echo "tag v${TAG} matches mcp version ${PKG}"
 
       - name: Build wheel + sdist
+        if: ${{ !inputs.registry_only }}
         working-directory: mcp
         run: uv build
 
       - name: List built artifacts
+        if: ${{ !inputs.registry_only }}
         working-directory: mcp
         run: ls -la dist/
 
       - name: Pre-flight version gate (geolens-mcp on PyPI)
-        if: ${{ !inputs.dry_run }}
+        if: ${{ !inputs.dry_run && !inputs.registry_only }}
         working-directory: mcp
         run: |
           set -e
@@ -133,7 +152,7 @@ jobs:
           fi
 
       - name: Publish to PyPI
-        if: ${{ !inputs.dry_run }}
+        if: ${{ !inputs.dry_run && !inputs.registry_only }}
         working-directory: mcp
         run: uv publish --trusted-publishing automatic
 
@@ -143,14 +162,33 @@ jobs:
       # mcp/README.md, so the version named in server.json has to be live on PyPI
       # first. `login github-oidc` needs the workflow-level `id-token: write` and
       # no secret — the registry grants `io.github.<repo owner>/*`, which covers
-      # this server's name. A failure here leaves PyPI published; re-run the
-      # workflow from the tag with dry_run=false to retry just this half.
+      # this server's name. If this half fails after PyPI succeeded, re-run with
+      # `registry_only=true` (see the header) — the PyPI half cannot be replayed.
+      #
+      # The binary is pinned by release tag AND by the sha256 the release's own
+      # checksums.txt published for that asset, rather than tracking `latest`
+      # (fix(#1623)): this step runs in a job holding `id-token: write`, so a
+      # swapped or compromised publisher build could mint OIDC tokens for this
+      # workflow's identity. A moved `latest` also silently changes what an
+      # old-tag re-run executes. Upgrading is a reviewed edit: bump the version,
+      # re-read the checksum from that release's registry_<version>_checksums.txt.
       - name: Install mcp-publisher
         if: ${{ !inputs.dry_run }}
+        env:
+          MCP_PUBLISHER_VERSION: '1.8.1'
+          # sha256 of mcp-publisher_linux_amd64.tar.gz, from the v1.8.1 release's
+          # registry_1.8.1_checksums.txt. Runners are ubuntu-latest (linux/amd64),
+          # so the asset is named outright rather than derived from uname.
+          MCP_PUBLISHER_SHA256: 'a06c9096dcb9727c13555b6be26c7effa707b01f06a4c561ba7a3635443cf2cc'
         run: |
-          curl -fsSL "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" \
-            | tar xz mcp-publisher
+          set -euo pipefail
+          ASSET="mcp-publisher_linux_amd64.tar.gz"
+          curl -fsSL --retry 3 -o "$ASSET" \
+            "https://github.com/modelcontextprotocol/registry/releases/download/v${MCP_PUBLISHER_VERSION}/${ASSET}"
+          echo "${MCP_PUBLISHER_SHA256}  ${ASSET}" | sha256sum --check --strict -
+          tar xzf "$ASSET" mcp-publisher
           sudo mv mcp-publisher /usr/local/bin/
+          rm -f "$ASSET"
           mcp-publisher --help > /dev/null
 
       - name: Publish to the MCP Registry

--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -4,8 +4,8 @@
 # Triggers:
 #   - push a `v*.*.*` tag → publish job queues behind the `publish` environment
 #     and pauses for required-reviewer approval (one click) before publishing.
-#   - workflow_dispatch → same gate; for ad-hoc / re-publish, run from a tag ref:
-#     `gh workflow run publish-mcp.yml --ref vX.Y.Z`
+#   - workflow_dispatch → same gate; run from a tag ref, which any non-dry run
+#     now enforces: `gh workflow run publish-mcp.yml --ref vX.Y.Z`
 #
 # Recovering a half-finished release (fix(#1623)): PyPI refuses a re-upload of a
 # version it already has, so once `uv publish` succeeds there is no way back
@@ -80,14 +80,22 @@ jobs:
         with:
           python-version: "3.14"
 
-      # Any tag ref, not just a tag push: a `registry_only` retry is dispatched
-      # manually, and running it from the wrong tag would claim a version that is
-      # not the one on PyPI. `make version-check` keeps server.json equal to this
-      # pyproject on every merged commit, so asserting one covers both.
-      - name: Assert tag matches package version (tag refs only)
-        if: ${{ github.ref_type == 'tag' }}
+      # Every publishing run must come from a tag ref, and this is a hard failure
+      # rather than a skipped check (fix(#1623)): a manual dispatch defaults to the
+      # branch selected in the Actions UI, and the repo sits at the last released
+      # version between bumps, so a branch run would happily publish that branch's
+      # current server.json as metadata for an already-released PyPI artifact.
+      # `make version-check` keeps server.json equal to this pyproject on every
+      # merged commit, so asserting the tag against one of them covers both. Dry
+      # runs are exempt — they only build.
+      - name: Require a tag ref, and assert it matches the package version
+        if: ${{ !inputs.dry_run }}
         working-directory: mcp
         run: |
+          if [ "${GITHUB_REF_TYPE}" != "tag" ]; then
+            echo "::error::publishing requires a tag ref; got ${GITHUB_REF_TYPE} '${GITHUB_REF_NAME}'. Re-run with --ref vX.Y.Z"
+            exit 1
+          fi
           TAG="${GITHUB_REF_NAME#v}"
           PKG=$(python - <<'PY'
           import tomllib

--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -1,4 +1,5 @@
-# Publish workflow for the GeoLens MCP server (PyPI `geolens-mcp`).
+# Publish workflow for the GeoLens MCP server (PyPI `geolens-mcp`, then the
+# MCP Registry entry `io.github.geolens-io/geolens` described by mcp/server.json).
 #
 # Triggers:
 #   - push a `v*.*.*` tag → publish job queues behind the `publish` environment
@@ -135,3 +136,26 @@ jobs:
         if: ${{ !inputs.dry_run }}
         working-directory: mcp
         run: uv publish --trusted-publishing automatic
+
+      # MCP Registry (registry.modelcontextprotocol.io). This runs AFTER the PyPI
+      # publish on purpose: the registry verifies ownership by fetching the
+      # published package description and looking for the `mcp-name:` marker in
+      # mcp/README.md, so the version named in server.json has to be live on PyPI
+      # first. `login github-oidc` needs the workflow-level `id-token: write` and
+      # no secret — the registry grants `io.github.<repo owner>/*`, which covers
+      # this server's name. A failure here leaves PyPI published; re-run the
+      # workflow from the tag with dry_run=false to retry just this half.
+      - name: Install mcp-publisher
+        if: ${{ !inputs.dry_run }}
+        run: |
+          curl -fsSL "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" \
+            | tar xz mcp-publisher
+          sudo mv mcp-publisher /usr/local/bin/
+          mcp-publisher --help > /dev/null
+
+      - name: Publish to the MCP Registry
+        if: ${{ !inputs.dry_run }}
+        working-directory: mcp
+        run: |
+          mcp-publisher login github-oidc
+          mcp-publisher publish

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -64,3 +64,9 @@ Cursor / Codex / any client that reads an `mcpServers` block:
 cd mcp
 uv run --extra dev python -m pytest -v
 ```
+
+<!-- mcp-name: io.github.geolens-io/geolens -->
+<!-- The marker above is how the MCP Registry proves ownership of the PyPI package: it
+     looks for `mcp-name: <server name>` in the published package description, which is
+     this file. Keep it byte-identical to `name` in server.json, and keep it alone on its
+     line — the token has to be followed by whitespace or the comment close to match. -->

--- a/mcp/server.json
+++ b/mcp/server.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.geolens-io/geolens",
+  "title": "GeoLens",
+  "description": "Read-only access to a self-hosted GeoLens spatial catalog: datasets, features, maps, sandboxed SQL.",
+  "version": "1.14.2",
+  "websiteUrl": "https://docs.getgeolens.com/",
+  "repository": {
+    "url": "https://github.com/geolens-io/geolens",
+    "source": "github",
+    "subfolder": "mcp"
+  },
+  "packages": [
+    {
+      "registryType": "pypi",
+      "identifier": "geolens-mcp",
+      "version": "1.14.2",
+      "transport": {
+        "type": "stdio"
+      },
+      "environmentVariables": [
+        {
+          "name": "GEOLENS_INSTANCE",
+          "description": "Base URL of the GeoLens instance, e.g. https://geolens.example.com (the /api suffix is appended automatically).",
+          "format": "string",
+          "isRequired": true
+        },
+        {
+          "name": "GEOLENS_API_KEY",
+          "description": "API key, sent as X-Api-Key. Omit for public-only access.",
+          "format": "string",
+          "isSecret": true
+        },
+        {
+          "name": "GEOLENS_TOKEN",
+          "description": "JWT bearer token, used only when GEOLENS_API_KEY is unset.",
+          "format": "string",
+          "isSecret": true
+        }
+      ]
+    }
+  ]
+}

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -14,6 +14,11 @@
   - package.json                           (root .version — private/unpublished)
   - cli/pyproject.toml                     ([project] version)
   - mcp/pyproject.toml                     ([project] version)
+  - mcp/server.json                        (.version and packages[].version — the
+                                           MCP Registry manifest. The registry
+                                           rejects a publish whose package version
+                                           is not the one live on PyPI, so both
+                                           fields move with the release)
   - sdks/python/pyproject.toml             ([project] version)
   - sdks/python/.openapi-python-client.yaml (package_version_override)
   - sdks/typescript/package.json           (.version)
@@ -69,6 +74,7 @@ FRONTEND_PACKAGE = REPO_ROOT / "frontend" / "package.json"
 ROOT_PACKAGE = REPO_ROOT / "package.json"
 CLI_PYPROJECT = REPO_ROOT / "cli" / "pyproject.toml"
 MCP_PYPROJECT = REPO_ROOT / "mcp" / "pyproject.toml"
+MCP_SERVER_JSON = REPO_ROOT / "mcp" / "server.json"
 PY_SDK_PYPROJECT = REPO_ROOT / "sdks" / "python" / "pyproject.toml"
 PY_SDK_GEN_CONFIG = REPO_ROOT / "sdks" / "python" / ".openapi-python-client.yaml"
 TS_SDK_PACKAGE = REPO_ROOT / "sdks" / "typescript" / "package.json"
@@ -123,6 +129,26 @@ def _bump_package_json(path: Path, version: str) -> None:
         new_text += "\n"
     path.write_text(new_text)
     print(f"  {_rel(path)} -> {version}")
+
+
+def _bump_server_json(path: Path, version: str) -> None:
+    # The MCP Registry manifest records the version twice: once for the server
+    # release and once for the PyPI package it points at. A missing `packages`
+    # list means the file was restructured, so fail rather than stamp half of it.
+    text = path.read_text()
+    had_trailing_newline = text.endswith("\n")
+    data = json.loads(text)
+    packages = data.get("packages")
+    if not packages:
+        sys.exit(f"ERROR: expected at least one entry under 'packages' in {_rel(path)}, found none.")
+    data["version"] = version
+    for package in packages:
+        package["version"] = version
+    new_text = json.dumps(data, indent=2)
+    if had_trailing_newline:
+        new_text += "\n"
+    path.write_text(new_text)
+    print(f"  {_rel(path)} (.version + packages[].version) -> {version}")
 
 
 def _bump_openapi(path: Path, version: str) -> None:
@@ -244,6 +270,7 @@ def main(argv: list[str]) -> int:
     _bump_package_json(ROOT_PACKAGE, version)
     _bump_project_version(CLI_PYPROJECT, version)
     _bump_project_version(MCP_PYPROJECT, version)
+    _bump_server_json(MCP_SERVER_JSON, version)
     _bump_project_version(PY_SDK_PYPROJECT, version)
     _bump_yaml_override(PY_SDK_GEN_CONFIG, version)
     _bump_package_json(TS_SDK_PACKAGE, version)

--- a/scripts/check_version_coherence.py
+++ b/scripts/check_version_coherence.py
@@ -23,6 +23,8 @@ Sites checked:
   - package.json                            (root) .version
   - cli/pyproject.toml                      [project].version
   - mcp/pyproject.toml                      [project].version
+  - mcp/server.json                         .version + packages[].version (the
+                                            MCP Registry manifest)
   - sdks/python/pyproject.toml              [project].version
   - sdks/python/.openapi-python-client.yaml package_version_override
   - sdks/typescript/package.json            .version
@@ -65,6 +67,7 @@ FRONTEND_PACKAGE = REPO_ROOT / "frontend" / "package.json"
 ROOT_PACKAGE = REPO_ROOT / "package.json"
 CLI_PYPROJECT = REPO_ROOT / "cli" / "pyproject.toml"
 MCP_PYPROJECT = REPO_ROOT / "mcp" / "pyproject.toml"
+MCP_SERVER_JSON = REPO_ROOT / "mcp" / "server.json"
 PY_SDK_PYPROJECT = REPO_ROOT / "sdks" / "python" / "pyproject.toml"
 PY_SDK_GEN_CONFIG = REPO_ROOT / "sdks" / "python" / ".openapi-python-client.yaml"
 TS_SDK_PACKAGE = REPO_ROOT / "sdks" / "typescript" / "package.json"
@@ -96,6 +99,18 @@ def _pyproject_version(path: Path) -> str:
 
 def _package_json_version(path: Path) -> str:
     return json.loads(path.read_text())["version"]
+
+
+def _server_json_versions(path: Path) -> list[tuple[str, str]]:
+    """(label, version) for the server release and every package it declares."""
+    data = json.loads(path.read_text())
+    found = [(".version", data["version"])]
+    packages = data.get("packages")
+    if not packages:
+        sys.exit(f"ERROR: no 'packages' entries in {_rel(path)}.")
+    for package in packages:
+        found.append((f"packages['{package['identifier']}'].version", package["version"]))
+    return found
 
 
 def _openapi_version(path: Path) -> str:
@@ -187,6 +202,8 @@ def main() -> int:
     sites[f"{_rel(MCP_PYPROJECT)} ([project].version)"] = _pyproject_version(
         MCP_PYPROJECT
     )
+    for label, found in _server_json_versions(MCP_SERVER_JSON):
+        sites[f"{_rel(MCP_SERVER_JSON)} ({label})"] = found
     sites[f"{_rel(PY_SDK_PYPROJECT)} ([project].version)"] = _pyproject_version(
         PY_SDK_PYPROJECT
     )


### PR DESCRIPTION
## What

Puts `geolens-mcp` on the [MCP Registry](https://registry.modelcontextprotocol.io/) automatically, starting with the next release.

The registry matters more than it did a month ago: `modelcontextprotocol/servers` has dropped its community list, and its README now points readers at the registry instead. We were not in it.

## How

- `mcp/server.json` — the registry manifest (name `io.github.geolens-io/geolens`, the PyPI package, stdio transport, the three `GEOLENS_*` env vars). Validated locally against the `2025-12-11` schema.
- `mcp/README.md` — the `mcp-name:` ownership marker. The registry fetches the published PyPI description and looks for that token, so it has to ride in the package README. Confirmed present in a locally built wheel's `METADATA`.
- `.github/workflows/publish-mcp.yml` — an `mcp-publisher` step after the PyPI upload. Auth is GitHub OIDC (`login github-oidc`), which needs no secret: the registry grants `io.github.<repo owner>/*` from the workflow's OIDC claims, and the workflow already requests `id-token: write` for PyPI trusted publishing. It sits in the existing publish job, so it stays behind the same required-reviewer gate.

## Version contract

`server.json` records the version twice (server release + PyPI package), and the registry rejects a publish whose package version is not live on PyPI. Both fields are therefore wired into the version contract rather than hand-edited: `bump_version.py` stamps them, `check_version_coherence.py` verifies them. `make version-check` now reports 21 sites, up from 19.

## Verification

```
make version-check                       # OK: all 21 version sites agree on 1.14.2
jsonschema validate mcp/server.json      # VALID against the 2025-12-11 schema
bump 1.99.0 -> back to 1.14.2            # both server.json fields move and restore
uv build && grep METADATA                # mcp-name marker present in the wheel
```

No schema, API, or config impact. The first registry entry appears when the next `v*.*.*` tag publishes, since the marker must be live on PyPI for the version being claimed.