### PR TITLE
fix(ui): render object-valued feature properties as JSON in the popup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and releases use semantic versioning.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Object-valued feature properties render as JSON in the map popup.** A
+  feature property holding an object or array (a JSON column, a nested
+  attribute) rendered as the literal text `[object Object]` when clicked,
+  while the accessible data panel already rendered the same value as JSON
+  text. Both components now call one shared formatter, so an object or array
+  property renders the same way in either place (#1627).
+
 ## [1.14.2] - 2026-08-21
 
 ### Added

--- a/frontend/src/components/map/FeaturePopup.tsx
+++ b/frontend/src/components/map/FeaturePopup.tsx
@@ -7,6 +7,7 @@ import { ChevronLeft, ChevronRight, Copy, Check, X } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { truncateGraphemes } from '@/lib/text';
 import { splitTextWithUrls, classifyUrl } from '@/lib/popup-rich-text';
+import { formatFeaturePropertyValue } from '@/lib/feature-property-value';
 
 export interface FeatureInfo {
   properties: Record<string, unknown>;
@@ -106,17 +107,13 @@ export function FeaturePopup({
   const feature = features[activeIndex] ?? features[0];
 
   const formatValue = useCallback(
-    (value: unknown): string => {
-      if (value === null || value === undefined) return '--';
-      if (typeof value === 'boolean')
-        return value ? t('featurePopup.booleanTrue') : t('featurePopup.booleanFalse');
-      if (typeof value === 'number') {
-        return Number.isInteger(value)
-          ? value.toLocaleString(i18n.language)
-          : value.toLocaleString(i18n.language, { maximumFractionDigits: 4 });
-      }
-      return String(value);
-    },
+    (value: unknown): string =>
+      formatFeaturePropertyValue(
+        value,
+        i18n.language,
+        t('featurePopup.booleanTrue'),
+        t('featurePopup.booleanFalse'),
+      ) ?? '--',
     [t],
   );
 

--- a/frontend/src/components/map/__tests__/FeaturePopup.test.tsx
+++ b/frontend/src/components/map/__tests__/FeaturePopup.test.tsx
@@ -247,6 +247,18 @@ describe('FeaturePopup', () => {
     expect(cells[3]).toHaveTextContent('1');
   });
 
+  it('fix(#1627): renders an object-valued property as its JSON text, not [object Object]', () => {
+    const features: FeatureInfo[] = [
+      makeFeature({
+        properties: { metadata: { source: 'survey', accuracy: 5 } },
+        visibleFields: ['metadata'],
+      }),
+    ];
+    render(<FeaturePopup longitude={0} latitude={0} features={features} onClose={vi.fn()} />);
+    expect(screen.getByText('{"source":"survey","accuracy":5}')).toBeInTheDocument();
+    expect(screen.queryByText('[object Object]')).not.toBeInTheDocument();
+  });
+
   it('clamps activeIndex when features.length shrinks below the active page', () => {
     const features: FeatureInfo[] = [
       makeFeature({ properties: { name: 'A' } }),

--- a/frontend/src/components/viewer/AccessibleMapDataPanel.tsx
+++ b/frontend/src/components/viewer/AccessibleMapDataPanel.tsx
@@ -12,6 +12,7 @@ import {
 } from '@/components/ui/sheet';
 import type { SharedLayerResponse } from '@/types/api';
 import { createViewerLayerEntries } from '@/components/viewer/layer-identity';
+import { formatFeaturePropertyValue } from '@/lib/feature-property-value';
 import type { AccessibleMapFeatureResult } from './accessible-map-data';
 
 interface AccessibleMapDataPanelProps {
@@ -36,15 +37,7 @@ function formatValue(
   booleanTrue: string,
   booleanFalse: string,
 ): string {
-  if (value === null || value === undefined) return '—';
-  if (typeof value === 'boolean') return value ? booleanTrue : booleanFalse;
-  if (typeof value === 'number') {
-    return Number.isInteger(value)
-      ? value.toLocaleString(locale)
-      : value.toLocaleString(locale, { maximumFractionDigits: 5 });
-  }
-  if (typeof value === 'object') return JSON.stringify(value) ?? '—';
-  return String(value);
+  return formatFeaturePropertyValue(value, locale, booleanTrue, booleanFalse) ?? '—';
 }
 
 export function AccessibleMapDataPanel({

--- a/frontend/src/components/viewer/AccessibleMapDataPanel.tsx
+++ b/frontend/src/components/viewer/AccessibleMapDataPanel.tsx
@@ -37,7 +37,10 @@ function formatValue(
   booleanTrue: string,
   booleanFalse: string,
 ): string {
-  return formatFeaturePropertyValue(value, locale, booleanTrue, booleanFalse) ?? '—';
+  // 5 fraction digits (not the shared default of 4): this panel is the
+  // accessible surface for raw feature coordinates, so it keeps its
+  // original, more precise formatting.
+  return formatFeaturePropertyValue(value, locale, booleanTrue, booleanFalse, 5) ?? '—';
 }
 
 export function AccessibleMapDataPanel({

--- a/frontend/src/lib/__tests__/feature-property-value.test.ts
+++ b/frontend/src/lib/__tests__/feature-property-value.test.ts
@@ -12,9 +12,17 @@ describe('formatFeaturePropertyValue', () => {
     expect(formatFeaturePropertyValue(false, 'en', 'Yes', 'No')).toBe('No');
   });
 
-  it('formats integers without decimals and floats to 4 fraction digits', () => {
+  it('formats integers without decimals and floats to 4 fraction digits by default', () => {
     expect(formatFeaturePropertyValue(1234, 'en', 'True', 'False')).toBe('1,234');
     expect(formatFeaturePropertyValue(1.23456789, 'en', 'True', 'False')).toBe('1.2346');
+  });
+
+  it('fix(#1629 codex): a caller-supplied maxFractionDigits overrides the 4-digit default', () => {
+    // The data panel renders raw feature coordinates and needs 5 digits;
+    // the popup relies on the default. Both must be reachable through the
+    // same shared function.
+    expect(formatFeaturePropertyValue(1.234567, 'en', 'True', 'False', 5)).toBe('1.23457');
+    expect(formatFeaturePropertyValue(1.234567, 'en', 'True', 'False')).toBe('1.2346');
   });
 
   it('fix(#1627): renders a plain object as its JSON text, not [object Object]', () => {

--- a/frontend/src/lib/__tests__/feature-property-value.test.ts
+++ b/frontend/src/lib/__tests__/feature-property-value.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import { formatFeaturePropertyValue } from '../feature-property-value';
+
+describe('formatFeaturePropertyValue', () => {
+  it('returns null for null/undefined so callers can render their own empty text', () => {
+    expect(formatFeaturePropertyValue(null, 'en', 'True', 'False')).toBeNull();
+    expect(formatFeaturePropertyValue(undefined, 'en', 'True', 'False')).toBeNull();
+  });
+
+  it('renders booleans using the caller-supplied, locale-aware labels', () => {
+    expect(formatFeaturePropertyValue(true, 'en', 'Yes', 'No')).toBe('Yes');
+    expect(formatFeaturePropertyValue(false, 'en', 'Yes', 'No')).toBe('No');
+  });
+
+  it('formats integers without decimals and floats to 4 fraction digits', () => {
+    expect(formatFeaturePropertyValue(1234, 'en', 'True', 'False')).toBe('1,234');
+    expect(formatFeaturePropertyValue(1.23456789, 'en', 'True', 'False')).toBe('1.2346');
+  });
+
+  it('fix(#1627): renders a plain object as its JSON text, not [object Object]', () => {
+    const result = formatFeaturePropertyValue({ a: 1, b: 'two' }, 'en', 'True', 'False');
+    expect(result).toBe('{"a":1,"b":"two"}');
+    expect(result).not.toContain('[object Object]');
+  });
+
+  it('fix(#1627): renders a nested array as its JSON text', () => {
+    const result = formatFeaturePropertyValue([1, { x: 'y' }, [2, 3]], 'en', 'True', 'False');
+    expect(result).toBe('[1,{"x":"y"},[2,3]]');
+  });
+
+  it('falls back to String(value) when the object is circular', () => {
+    const circular: Record<string, unknown> = { name: 'loop' };
+    circular.self = circular;
+    const result = formatFeaturePropertyValue(circular, 'en', 'True', 'False');
+    expect(result).toBe(String(circular));
+    expect(result).not.toBeNull();
+  });
+
+  it('renders plain strings unchanged via String()', () => {
+    expect(formatFeaturePropertyValue('hello', 'en', 'True', 'False')).toBe('hello');
+  });
+});

--- a/frontend/src/lib/feature-property-value.ts
+++ b/frontend/src/lib/feature-property-value.ts
@@ -17,13 +17,19 @@ export function formatFeaturePropertyValue(
   locale: string,
   booleanTrue: string,
   booleanFalse: string,
+  // fix(#1629 codex P2): the data panel formatted non-integer numbers to 5
+  // fraction digits (it renders raw feature coordinates on the accessibility
+  // surface); collapsing both callers onto the popup's 4-digit default
+  // silently dropped a digit of precision there. Each caller now states its
+  // own precision explicitly instead of inheriting the popup's.
+  maxFractionDigits = 4,
 ): string | null {
   if (value === null || value === undefined) return null;
   if (typeof value === 'boolean') return value ? booleanTrue : booleanFalse;
   if (typeof value === 'number') {
     return Number.isInteger(value)
       ? value.toLocaleString(locale)
-      : value.toLocaleString(locale, { maximumFractionDigits: 4 });
+      : value.toLocaleString(locale, { maximumFractionDigits: maxFractionDigits });
   }
   if (typeof value === 'object') {
     // Circular structures throw in JSON.stringify; fall back to String()

--- a/frontend/src/lib/feature-property-value.ts
+++ b/frontend/src/lib/feature-property-value.ts
@@ -1,0 +1,38 @@
+/**
+ * Shared value formatter for feature/record properties, used by the map
+ * popup (`FeaturePopup`) and the accessible data panel (`AccessibleMapDataPanel`)
+ * so the same property value renders the same way in both places.
+ *
+ * fix(#1627): the two components had drifted apart — the popup had no
+ * object/array branch and fell through to `String(value)`, which rendered
+ * `[object Object]` for an object-valued property. The data panel already
+ * `JSON.stringify`d objects. Centralizing avoids a third copy drifting too.
+ *
+ * `null`/`undefined` return `null` — callers render their own existing empty
+ * text (the popup uses "--", the panel uses "—") rather than sharing one
+ * placeholder string.
+ */
+export function formatFeaturePropertyValue(
+  value: unknown,
+  locale: string,
+  booleanTrue: string,
+  booleanFalse: string,
+): string | null {
+  if (value === null || value === undefined) return null;
+  if (typeof value === 'boolean') return value ? booleanTrue : booleanFalse;
+  if (typeof value === 'number') {
+    return Number.isInteger(value)
+      ? value.toLocaleString(locale)
+      : value.toLocaleString(locale, { maximumFractionDigits: 4 });
+  }
+  if (typeof value === 'object') {
+    // Circular structures throw in JSON.stringify; fall back to String()
+    // rather than letting the popup/panel crash on a pathological value.
+    try {
+      return JSON.stringify(value) ?? String(value);
+    } catch {
+      return String(value);
+    }
+  }
+  return String(value);
+}


### PR DESCRIPTION
## What changed

`FeaturePopup`'s `formatValue` had no branch for objects or arrays and fell through to `String(value)`, so a JSON-valued feature property (a JSON column, a nested attribute) rendered as the literal text `[object Object]` in the map's click popup. `AccessibleMapDataPanel` already handled the same case with `JSON.stringify`, so the same property looked different depending on which UI showed it.

Extracted one shared formatter, `formatFeaturePropertyValue`, into `frontend/src/lib/feature-property-value.ts` and made both components call it:

- `null`/`undefined` return `null` from the shared function; each caller still renders its own existing empty text (`--` in the popup, `—` in the data panel).
- Booleans and numbers keep locale-aware formatting. The popup passed its translated `true`/`false` strings and locale into the shared function instead of formatting inline. Numeric precision differed between the two (4 vs. 5 fraction digits) with no test pinning either value, so the shared function uses the popup's 4-digit precision.
- Objects and arrays render as `JSON.stringify(value)`, guarded with try/catch so a circular structure falls back to `String(value)` instead of throwing.
- Everything else falls back to `String(value)`, matching both components' prior behavior.

## Schema/API/config impact

None. Frontend-only.

## Verification

- `npm ci`
- `npm run lint`: clean
- `npm run typecheck`: clean
- `npx vitest run src/lib/__tests__/feature-property-value.test.ts src/components/map/__tests__/FeaturePopup.test.tsx src/components/viewer/__tests__/AccessibleMapDataPanel.test.tsx`: 28 passed
- `npm run test:i18n`: passed (no new `t()` keys, reused existing `featurePopup.booleanTrue`/`booleanFalse` and `viewer.data.booleanTrue`/`booleanFalse`)
- `npm run build`: succeeded
- Counterfactual: reverted the `FeaturePopup.tsx` change via a patch file, re-ran the new `fix(#1627)` render test, and confirmed it failed (`getByText` couldn't find the JSON text because the unpatched code rendered `[object Object]`). Reapplied the patch and reran the full suite green.

Closes #1627
