### PR TITLE
docs(maps): record uploaded icons as a deployment-global asset and pin it

### DIFF
--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -1287,15 +1287,20 @@ What changes:
 
   ```bash
   # Where objects are namespaced per tenant, every prefix below sits under
-  # tenants/<tenant-id>/ — except maps/icons/, which is written at the bucket
-  # root in every mode.
+  # tenants/<tenant-id>/. maps/icons/ is the deliberate exception and is
+  # written at the bucket root in every mode: the icon catalog
+  # (catalog.map_icon_assets) has no tenant_id and no RLS policy, so one set
+  # of icons serves every tenant and one copy of the bytes has to be readable
+  # from every tenant's request. Back it up once, restore it once (#1621).
   PREFIX=rasters/<dataset-id>/     # from the catalog row you restored
   # Repeat for every prefix the restored database still references — the
   # managed layout, in full:
   #   rasters/<dataset-id>/      managed COGs and VRT artifacts
   #   originals/<dataset-id>/    archived source uploads
   #   vectors/<dataset-id>/      vector quicklooks
-  #   maps/thumbnails/ maps/og-images/ maps/icons/   map assets
+  #   maps/thumbnails/ maps/og-images/   per-map images
+  #   maps/icons/                bucket-root icon catalog, never under
+  #                                tenants/ (see the note above)
   #   staging/                   in-flight uploads. Promote the keys from
   #                                SELECT tenant_id, file_path
   #                                FROM catalog.ingest_jobs

--- a/backend/app/modules/catalog/maps/sprites.py
+++ b/backend/app/modules/catalog/maps/sprites.py
@@ -309,6 +309,23 @@ async def create_icon_asset(
     icon_id = uuid.uuid4()
     extension = SUPPORTED_MEDIA_TYPES[media_type]
     slug = f"{base_slug}-{str(icon_id)[:8]}"
+    # fix(#1621): this key is DELIBERATELY global. It stays outside the
+    # tenants/<id>/ prefix that maps/thumbnails/ and maps/og-images/ resolve
+    # into through resolve_current_storage_key, because the bytes have to
+    # follow the rows and the rows are fleet-wide: catalog.map_icon_assets
+    # carries no tenant_id, has no RLS policy, appears in no tenant-adoption
+    # SQL, and its slug uniqueness is deployment-global (models.py). Every
+    # tenant's anonymous sprite request loads that one catalog, and the sheet
+    # cache is process-global to match.
+    #
+    # Resolving this key per tenant writes an icon under the uploader's prefix
+    # that no other tenant can read, so the next cold sprite build for any
+    # other tenant raises FileNotFoundError and 500s an unauthenticated route.
+    # Making icons per-tenant means moving the ROWS first: tenant_id, an RLS
+    # policy, per-tenant slug uniqueness, and a per-tenant sheet cache. Until
+    # that happens the bytes belong at the bucket root, and
+    # test_map_sprites.py::test_icon_storage_keys_stay_global_under_tenant_context
+    # fails if anyone reroutes them.
     storage_key = f"maps/icons/{icon_id}{extension}"
     # Persist the sanitized form so the bytes on disk match what validation
     # accepted (SEC-09). For PNG this is the original bytes unchanged.

--- a/backend/tests/test_map_sprites.py
+++ b/backend/tests/test_map_sprites.py
@@ -1,6 +1,7 @@
 """Tests for map sprite and icon helper behavior."""
 
 import asyncio
+from contextlib import contextmanager
 from io import BytesIO
 import struct
 import threading
@@ -11,6 +12,8 @@ from PIL import Image
 from httpx import AsyncClient
 import pytest
 
+from app.core.config import settings
+from app.core.db.tenant_session import current_tenant_var
 from app.modules.catalog.maps import sprites
 from app.modules.catalog.maps.models import MapIconAsset
 from app.modules.catalog.maps.sprites import (
@@ -629,3 +632,67 @@ async def test_icon_upload_route_rejects_oversized_dimensions(
 
     assert resp.status_code == 400
     assert "dimensions" in resp.json()["detail"]
+
+
+# fix(#1621): the icon catalog is deployment-global, so the icon BYTES have to
+# be too. catalog.map_icon_assets carries no tenant_id and no RLS policy, and
+# every tenant's anonymous sprite request loads the same rows, so routing the
+# keys through resolve_current_storage_key (the way maps/thumbnails/ and
+# maps/og-images/ are routed) would write each icon under its uploader's prefix
+# where no other tenant could read it. The next cold sprite build for any other
+# tenant would then raise FileNotFoundError and 500 an unauthenticated route.
+# These pin the global key so that change fails here instead of in production.
+TENANT_ICONS = "00000000-0000-0000-0000-000000001621"
+
+
+@contextmanager
+def _tenant_mode(monkeypatch, mode: str, tenant_id: str | None):
+    monkeypatch.setattr(settings, "geolens_tenancy_mode", mode)
+    token = current_tenant_var.set(tenant_id)
+    try:
+        yield
+    finally:
+        current_tenant_var.reset(token)
+
+
+@pytest.mark.anyio
+async def test_icon_storage_keys_stay_global_under_tenant_context(monkeypatch):
+    """Upload, single read, and sheet build all use the unprefixed key.
+
+    Staging the bytes at the global key and nowhere else is what makes the read
+    assertions bite: a tenant-resolved lookup would ask FakeStorage for
+    tenants/<id>/maps/icons/... and raise instead of returning the icon.
+    """
+    storage = FakeStorage()
+    monkeypatch.setattr("app.modules.catalog.maps.sprites.get_storage", lambda: storage)
+    session = FakeSession()
+
+    with _tenant_mode(monkeypatch, "multi_tenant", TENANT_ICONS):
+        asset = await create_icon_asset(
+            session,
+            filename="Bus.svg",
+            content_type="image/svg+xml",
+            content=b"<svg></svg>",
+            created_by=uuid.uuid4(),
+        )
+
+        assert asset.storage_key == f"maps/icons/{asset.id}.svg"
+        assert list(storage.objects) == [asset.storage_key]
+
+        content, media_type = await get_icon_content(session, str(asset.id))
+        assert b"<svg" in content
+        assert media_type == "image/svg+xml"
+
+        png = await build_sprite_png(session)
+        assert png.startswith(b"\x89PNG\r\n\x1a\n")
+
+
+def test_map_icon_assets_has_no_tenant_column():
+    """The schema fact the global storage key depends on.
+
+    If a tenant_id column ever lands on this table, the icon catalog stops
+    being fleet-wide and the storage keys can (and should) move under
+    tenants/<id>/ with it. Revisit the comment in create_icon_asset and the
+    RUNBOOK prefix inventory at the same time.
+    """
+    assert "tenant_id" not in MapIconAsset.__table__.columns


### PR DESCRIPTION
Issue #1621 reported that `maps/icons/` sits at the bucket root while `maps/thumbnails/` and `maps/og-images/` resolve through `resolve_current_storage_key` into `tenants/<id>/`, and proposed routing icons the same way. This branch did that first. It was wrong, and codex caught it as a P1 before merge.

## Why icons stay global

The bytes have to follow the rows, and the rows are fleet-wide. Asked of the database rather than inferred from the migration files:

- `catalog.map_icon_assets` has no `tenant_id`. The catalog tables that do: `audit_logs`, `collections`, `dataset_refresh_runs`, `datasets`, `detached_relations`, `embed_tokens`, `ingest_jobs`, `maps`, `oauth_accounts`, `records`, `retired_table_names`, `users`.
- Its `pg_policy` count is 0. Its siblings each carry `tenant_isolation_*` with `(tenant_id = current_setting('app.current_tenant')::uuid)`.
- It appears in no tenant-adoption SQL and in no migration since the baseline, and `backend/tests/test_dormant_tenancy_schema.py` leaves it out of `_SHARED_TABLES`.
- The model declares a deployment-global `uq_map_icon_assets_slug`, and `_sprite_png_cache` / `_sprite_index_cache` in `sprites.py` are process-global.

So one icon catalog serves the whole deployment. Resolving the key per tenant writes each icon under its uploader's prefix, where nobody else can read it: tenant A uploads, tenant B's anonymous `GET /maps/sprites/geolens.png` loads the same global rows, looks under `tenants/B/`, misses, and `_load_icon_payloads` re-raises `FileNotFoundError` into a 500 on an unauthenticated route. The process-global sheet cache makes it depend on which tenant renders first. `GET /maps/icons/<id>/asset` fails the same way.

Issue #1621 offered this as its own option 2, and the schema settles it.

## What changed

Nothing at runtime. The keys are byte-identical to what shipped in 1.14.2, so there is no CHANGELOG entry.

- `create_icon_asset` carries the reason the key is global, and points at the test that fails if anyone reroutes it.
- `test_icon_storage_keys_stay_global_under_tenant_context` runs the upload, the single-asset read, and the sheet build under `multi_tenant` with a tenant in context, and fails if any of the three picks up a prefix.
- `test_map_icon_assets_has_no_tenant_column` pins the schema fact underneath all of it, so the day a `tenant_id` lands on the table someone is told to revisit the storage key with it.
- RUNBOOK.md keeps the `maps/icons/` call-out but states it as a decision with its reason, and the prefix inventory no longer lists icons on the same line as the tenant-prefixed map assets.

## What real per-tenant icons would need

Recorded here rather than as a follow-up issue, so it stays findable from #1621 when this closes it. Multi-tenant is enterprise-only and nothing is asking for per-tenant icon catalogs today, so none of this is scheduled:

- a `tenant_id` column on `catalog.map_icon_assets`, nullable like its siblings
- a `tenant_isolation_map_icon_assets` RLS policy, and the table added to tenant adoption
- per-tenant slug uniqueness, replacing the deployment-global `uq_map_icon_assets_slug`
- a per-tenant sprite sheet cache, since `_sprite_png_cache` and `_sprite_index_cache` are keyed by catalog signature alone
- an object migration moving the existing `maps/icons/` bytes under each tenant's prefix, with a read fallback covering the cutover window

The rows have to move before the bytes do. Doing the storage half alone is exactly the bug this PR backed out of.

## Impact

No schema change, no API change (`make openapi-check` clean), no config change, no behavior change.

## Verification

```
tests/test_map_sprites.py + test_tenant_staging_storage_keys.py
  + test_phase_275_api_style.py + test_rule1_structural.py   -> 51 passed
tests/test_layering.py                                        -> 47 passed
cd backend && uv run ruff check .                             -> All checks passed!
cd backend && uv run ruff format --check .                    -> 1048 files already formatted
dump_openapi.py --check                                       -> exit 0, snapshot unchanged
```

The schema claims above were read from the running Postgres on :5434, not from the migration files.

### Counterfactuals

| mutation | result |
| --- | --- |
| route write + both reads through `resolve_current_storage_key` | fails, naming `tenants/<id>/maps/icons/<uuid>.svg` |
| route only the single-asset read | fails on the missing prefixed key |
| route only the sprite-sheet gather | fails on the missing prefixed key |
| add a `tenant_id` column to `MapIconAsset` | `test_map_icon_assets_has_no_tenant_column` fails |

The two read counterfactuals are run separately because the write assertion fires first and would otherwise mask them.

RUNBOOK.md fence count is 128 before and after, unchanged.

Closes #1621
