### PR TITLE
feat(builder): drive layer opacity through fill/line-layer-opacity and apply it on export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,32 @@ and releases use semantic versioning.
 
 ## [Unreleased]
 
+### Changed
+
+- **The layer opacity slider fades polygon and line layers as one surface.**
+  A vector layer has two opacity controls: the Style Editor's per-feature
+  `fill-opacity`/`line-opacity` and the master slider. The builder multiplied
+  them into a single per-feature value, so wherever two features in the same
+  layer overlapped the overlap drew darker, and a layer at 50% was never
+  uniformly 50%. The master now drives maplibre-gl v6's `fill-layer-opacity`
+  and `line-layer-opacity`, which composite the whole layer once after the
+  per-feature pass; per-feature opacity is written as stored. Polygon outlines
+  take the same route, so shared edges stop double-darkening. Point, cluster,
+  heatmap and raster layers have no such property in v6 and keep the previous
+  multiply (#1625).
+
 ### Fixed
+
+- **Exported style.json honours the layer opacity slider.** The primary fill or
+  line layer copied its paint through verbatim and never applied `layer.opacity`,
+  while the outline, extrusion and icon companions did — so a layer faded in the
+  builder rendered fully opaque in a shared or embedded style. The export now
+  folds the master opacity into `fill-opacity`/`line-opacity` (multiplying a
+  number, wrapping an expression) instead of emitting the v6 `-layer-opacity`
+  keys, which every maplibre-gl before 6 rejects at load. The stored per-feature
+  value travels in the layer metadata so importing a GeoLens export gives back
+  both tiers unchanged, and a style authored for v6 with `fill-layer-opacity`
+  imports onto the layer opacity instead of being dropped (#1626).
 
 - **Object-valued feature properties render as JSON in the map popup.** A
   feature property holding an object or array (a JSON column, a nested

--- a/backend/app/modules/catalog/maps/style_import.py
+++ b/backend/app/modules/catalog/maps/style_import.py
@@ -15,6 +15,7 @@ from app.modules.catalog.maps.schemas import (
     TerrainConfig,
 )
 from app.modules.catalog.maps.style_sanitizers import (
+    clamp_number,
     clean_basemap_config,
     clean_label_metadata,
     clean_layout,
@@ -26,6 +27,11 @@ from app.modules.catalog.maps.style_sanitizers import (
 STYLE_VERSION = 8
 GEOLENS_SPRITE_ID = "geolens"
 DEFAULT_ARROW_BASE_SIZE = 14
+# fix(#1626): the primary layer types whose master `layer.opacity` is folded into
+# a per-feature paint key on export, and that key. Only fill and line: they are
+# the two types maplibre-gl v6 gave a `-layer-opacity` to, so they are the two
+# whose export has to stand in for it (see `_fold_master_opacity` in style_json).
+FOLDED_OPACITY_KEYS: dict[str, str] = {"fill": "fill-opacity", "line": "line-opacity"}
 
 
 @dataclass
@@ -259,6 +265,57 @@ _BUILDER_COMPANION_PARSERS = {
 }
 
 
+def _restore_master_opacity(
+    style_layer: dict[str, Any],
+    geolens: dict[str, Any],
+    paint: dict[str, Any],
+    summary: MapStyleImportSummary,
+) -> float:
+    """Recover ``layer.opacity`` for an imported primary layer, un-folding ``paint``.
+
+    fix(#1626): export folds the master opacity into the primary fill/line layer's
+    ``*-opacity`` (a v6 ``*-layer-opacity`` key fails validation and aborts the
+    whole style load on maplibre-gl < 6) and keeps the un-folded per-feature value
+    in ``metadata.geolens.feature_opacity`` — ``null`` when the stored paint had
+    none. Put that back so a GeoLens round trip does not apply the master twice.
+
+    fix(#1625): a style authored for v6 may carry ``fill-layer-opacity`` /
+    ``line-layer-opacity`` instead. A number maps onto the master column,
+    composed with any metadata opacity; an expression has no scalar home and is
+    dropped with a warning rather than stored as paint the builder would ignore.
+    """
+    opacity = float(geolens.get("opacity", 1) or 1)
+    layer_type = style_layer.get("type")
+    feature_key = FOLDED_OPACITY_KEYS.get(str(layer_type))
+    if feature_key is None:
+        return opacity
+    if "feature_opacity" in geolens:
+        feature_opacity = geolens["feature_opacity"]
+        if feature_opacity is None:
+            paint.pop(feature_key, None)
+        else:
+            paint[feature_key] = feature_opacity
+    layer_opacity = paint.pop(f"{layer_type}-layer-opacity", None)
+    if layer_opacity is not None:
+        number = finite_number(layer_opacity)
+        if number is None:
+            summary.warnings.append(
+                MapStyleImportWarning(
+                    code="unsupported_layer_opacity",
+                    message=(
+                        f"{layer_type}-layer-opacity must be a number to become "
+                        "the layer opacity; an expression was dropped."
+                    ),
+                    layer_id=str(style_layer.get("id"))
+                    if style_layer.get("id")
+                    else None,
+                )
+            )
+        else:
+            opacity *= number
+    return clamp_number(opacity, 0.0, 1.0)
+
+
 def parse_maplibre_style_import(  # noqa: C901 - coordinates independent parsers
     style: dict[str, Any],
 ) -> ImportedStyleMap:
@@ -352,6 +409,12 @@ def parse_maplibre_style_import(  # noqa: C901 - coordinates independent parsers
                 style_config["builder"] = builder
             if not style_config:
                 style_config = None
+        paint = clean_paint(
+            style_layer.get("paint")
+            if isinstance(style_layer.get("paint"), dict)
+            else {}
+        )
+        opacity = _restore_master_opacity(style_layer, geolens, paint, summary)
         imported_layers.append(
             MapLayerInput(
                 dataset_id=dataset_id,
@@ -359,12 +422,8 @@ def parse_maplibre_style_import(  # noqa: C901 - coordinates independent parsers
                 visible=((style_layer.get("layout") or {}).get("visibility") != "none")
                 if isinstance(style_layer.get("layout"), dict)
                 else True,
-                opacity=float(geolens.get("opacity", 1) or 1),
-                paint=clean_paint(
-                    style_layer.get("paint")
-                    if isinstance(style_layer.get("paint"), dict)
-                    else {}
-                ),
+                opacity=opacity,
+                paint=paint,
                 layout=clean_layout(
                     style_layer.get("layout")
                     if isinstance(style_layer.get("layout"), dict)

--- a/backend/app/modules/catalog/maps/style_import.py
+++ b/backend/app/modules/catalog/maps/style_import.py
@@ -32,6 +32,13 @@ DEFAULT_ARROW_BASE_SIZE = 14
 # the two types maplibre-gl v6 gave a `-layer-opacity` to, so they are the two
 # whose export has to stand in for it (see `_fold_master_opacity` in style_json).
 FOLDED_OPACITY_KEYS: dict[str, str] = {"fill": "fill-opacity", "line": "line-opacity"}
+# fix(#1631 review): the per-feature opacity the live builder renders when the
+# stored paint carries none. Mirrors OPACITY_DEFAULTS in
+# frontend/src/components/builder/layer-adapters/shared.ts (getFeatureOpacity):
+# a polygon with no fill-opacity draws at 0.3 in the builder, not at the spec
+# default of 1, so the export fold has to start from the same number or the
+# exported document renders brighter than the app. Keep the two in step.
+BUILDER_FEATURE_OPACITY_DEFAULTS: dict[str, float] = {"fill": 0.3, "line": 1.0}
 
 
 @dataclass

--- a/backend/app/modules/catalog/maps/style_json.py
+++ b/backend/app/modules/catalog/maps/style_json.py
@@ -19,6 +19,7 @@ from app.modules.catalog.maps.schemas import (
 )
 from app.modules.catalog.maps.style_import import (
     DEFAULT_ARROW_BASE_SIZE,
+    FOLDED_OPACITY_KEYS,
     GEOLENS_SPRITE_ID,
     STYLE_VERSION,
     ImportedStyleMap,
@@ -940,6 +941,48 @@ def _color_relief_companion_layer(
     }
 
 
+def _fold_master_opacity(base: dict[str, Any], layer: MapLayerResponse) -> None:
+    """Apply ``layer.opacity`` to the primary fill/line layer's exported paint.
+
+    fix(#1626): the primary layer copied ``layer.paint`` through verbatim and never
+    applied the master opacity, while every companion (outline, extrusion, icon)
+    did — so a faded layer in the builder exported fully opaque.
+
+    fix(#1625) moved the live builder's master onto maplibre-gl v6's
+    ``fill-layer-opacity`` / ``line-layer-opacity``, but the export deliberately
+    does NOT emit those keys. An unknown paint property is a hard validation
+    error in every maplibre-gl before 6 (``validateProperty`` returns
+    ``unknown property`` as an error, ``emitValidationErrors`` has no severity
+    and reports any error, and ``Style._load`` returns before installing a
+    single source or layer — verified against the 5.24.0 build that shipped
+    until #1624), so a style.json carrying them would not load AT ALL on an
+    older consumer. The export therefore does what the pre-#1625 adapter did
+    and multiplies the master into the per-feature value: a number times the
+    master, an expression wrapped in ``["*", expr, master]``, and an absent or
+    wrong-typed value treated as the spec default of 1. The un-folded value is
+    kept in ``metadata.geolens.feature_opacity`` so the import side can undo
+    the fold and a GeoLens round trip does not apply the master twice.
+
+    The v6 default of 1 takes the untouched path: with ``layer.opacity`` at 1
+    the emitted paint stays bit-identical to before.
+    """
+    feature_key = FOLDED_OPACITY_KEYS.get(str(base.get("type")))
+    opacity = _finite_number(layer.opacity)
+    if feature_key is None or opacity is None or opacity >= 1:
+        return
+    paint = dict(base["paint"])
+    feature_opacity: Any = paint.get(feature_key)
+    if isinstance(feature_opacity, list):
+        paint[feature_key] = ["*", feature_opacity, opacity]
+    elif _finite_number(feature_opacity) is not None:
+        paint[feature_key] = feature_opacity * opacity
+    else:
+        feature_opacity = None
+        paint[feature_key] = opacity
+    base["paint"] = paint
+    base["metadata"]["geolens"]["feature_opacity"] = feature_opacity
+
+
 def _style_layer_for_map_layer(
     layer: MapLayerResponse,
     source_id: str,
@@ -1054,6 +1097,9 @@ def _style_layer_for_map_layer(
         relief = _color_relief_companion_layer(layer, source_id, layer_id)
         if relief is not None:
             below_companions.append(relief)
+    # After the fill branch above: it rewrites base["paint"] (outline colour,
+    # stash seeding) and the fold has to see the final per-feature value.
+    _fold_master_opacity(base, layer)
 
     if layer_type == "symbol":
         base["layout"] = _symbol_layout_from_style(
@@ -1118,6 +1164,13 @@ _PAINT_PROPERTIES_BY_TYPE: dict[str, frozenset[str]] = {
     "background": frozenset(
         {"background-color", "background-pattern", "background-opacity"}
     ),
+    # fix(#1625/#1626): `fill-layer-opacity` and `line-layer-opacity` are
+    # deliberately NOT listed. The export carries the master opacity by folding
+    # it into `*-opacity` (see `_fold_master_opacity` for why: the v6 keys abort
+    # the whole style load on maplibre-gl < 6), so a stored paint that happens to
+    # hold one (API-authored, or a v6 style pasted into the JSON editor) is
+    # stripped here instead of leaking into a document older consumers reject.
+    # Import maps the keys onto `layer.opacity` in `_restore_master_opacity`.
     "fill": frozenset(
         {
             "fill-antialias",

--- a/backend/app/modules/catalog/maps/style_json.py
+++ b/backend/app/modules/catalog/maps/style_json.py
@@ -18,6 +18,7 @@ from app.modules.catalog.maps.schemas import (
     MapLayerResponse,
 )
 from app.modules.catalog.maps.style_import import (
+    BUILDER_FEATURE_OPACITY_DEFAULTS,
     DEFAULT_ARROW_BASE_SIZE,
     FOLDED_OPACITY_KEYS,
     GEOLENS_SPRITE_ID,
@@ -959,12 +960,19 @@ def _fold_master_opacity(base: dict[str, Any], layer: MapLayerResponse) -> None:
     older consumer. The export therefore does what the pre-#1625 adapter did
     and multiplies the master into the per-feature value: a number times the
     master, an expression wrapped in ``["*", expr, master]``, and an absent or
-    wrong-typed value treated as the spec default of 1. The un-folded value is
-    kept in ``metadata.geolens.feature_opacity`` so the import side can undo
-    the fold and a GeoLens round trip does not apply the master twice.
+    wrong-typed value treated as the builder default the live adapter renders
+    (``BUILDER_FEATURE_OPACITY_DEFAULTS``: fill 0.3, line 1 — see
+    ``getFeatureOpacity`` in layer-adapters/shared.ts), not the spec default
+    of 1. The un-folded value is kept in ``metadata.geolens.feature_opacity``
+    so the import side can undo the fold and a GeoLens round trip does not
+    apply the master twice.
 
     The v6 default of 1 takes the untouched path: with ``layer.opacity`` at 1
-    the emitted paint stays bit-identical to before.
+    the emitted paint stays bit-identical to before. That deliberately leaves
+    one pre-existing divergence alone — absent per-feature opacity at master 1
+    exports nothing and renders at the spec default of 1 while the builder
+    draws 0.3 — because the bit-identical guarantee for untouched layers
+    matters more than fixing a defect this change did not create.
     """
     feature_key = FOLDED_OPACITY_KEYS.get(str(base.get("type")))
     opacity = _finite_number(layer.opacity)
@@ -978,7 +986,8 @@ def _fold_master_opacity(base: dict[str, Any], layer: MapLayerResponse) -> None:
         paint[feature_key] = feature_opacity * opacity
     else:
         feature_opacity = None
-        paint[feature_key] = opacity
+        feature_default = BUILDER_FEATURE_OPACITY_DEFAULTS[str(base.get("type"))]
+        paint[feature_key] = feature_default * opacity
     base["paint"] = paint
     base["metadata"]["geolens"]["feature_opacity"] = feature_opacity
 

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -2097,13 +2097,17 @@ _OPEN_CORE_SIZE_CAPS: dict[str, int] = {
     # export multiplies instead of emitting the v6 `-layer-opacity` keys (they
     # abort the style load on maplibre-gl < 6, verified against 5.24.0) and the
     # metadata handshake that keeps a GeoLens round trip lossless. Plus the
-    # allowlist note saying the two keys are left out on purpose. Cap 1641 -> 1694.
-    "backend/app/modules/catalog/maps/style_json.py": 1694,
-    # fix(#1626): +43 — `_restore_master_opacity` undoes the export fold from
+    # allowlist note saying the two keys are left out on purpose, and (#1631
+    # review) the note on the pre-existing absent-at-master-1 divergence the
+    # fold deliberately leaves alone. Cap 1641 -> 1703.
+    "backend/app/modules/catalog/maps/style_json.py": 1703,
+    # fix(#1626): +50 — `_restore_master_opacity` undoes the export fold from
     # `metadata.geolens.feature_opacity` and maps a v6 `-layer-opacity` key onto
-    # `layer.opacity` (number) or drops it with a warning (expression).
-    # Cap 450 -> 493.
-    "backend/app/modules/catalog/maps/style_import.py": 493,
+    # `layer.opacity` (number) or drops it with a warning (expression); plus
+    # (#1631 review) BUILDER_FEATURE_OPACITY_DEFAULTS, the mirror of the
+    # frontend's OPACITY_DEFAULTS the fold starts from when paint has none.
+    # Cap 450 -> 500.
+    "backend/app/modules/catalog/maps/style_import.py": 500,
     "backend/app/modules/catalog/maps/style_sanitizers.py": 200,
     # fix(getgeolens.com#86 review): +6 — the icon-asset and sprite-index GETs
     # gained per-route `responses={403: FORBIDDEN_RESPONSE}` overrides; they

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -2092,8 +2092,18 @@ _OPEN_CORE_SIZE_CAPS: dict[str, int] = {
     # mostly the note recording that the write guard already keeps `<`/`>` out,
     # which leaves this escaping the ampersand and covering a value written
     # before that guard existed. Cap 1629 -> 1641, exact.
-    "backend/app/modules/catalog/maps/style_json.py": 1641,
-    "backend/app/modules/catalog/maps/style_import.py": 450,
+    # fix(#1626): +53 — `_fold_master_opacity` applies `layer.opacity` to the
+    # primary fill/line layer on export. Mostly its docstring: it records why the
+    # export multiplies instead of emitting the v6 `-layer-opacity` keys (they
+    # abort the style load on maplibre-gl < 6, verified against 5.24.0) and the
+    # metadata handshake that keeps a GeoLens round trip lossless. Plus the
+    # allowlist note saying the two keys are left out on purpose. Cap 1641 -> 1694.
+    "backend/app/modules/catalog/maps/style_json.py": 1694,
+    # fix(#1626): +43 — `_restore_master_opacity` undoes the export fold from
+    # `metadata.geolens.feature_opacity` and maps a v6 `-layer-opacity` key onto
+    # `layer.opacity` (number) or drops it with a warning (expression).
+    # Cap 450 -> 493.
+    "backend/app/modules/catalog/maps/style_import.py": 493,
     "backend/app/modules/catalog/maps/style_sanitizers.py": 200,
     # fix(getgeolens.com#86 review): +6 — the icon-asset and sprite-index GETs
     # gained per-route `responses={403: FORBIDDEN_RESPONSE}` overrides; they

--- a/backend/tests/test_maps_style_json.py
+++ b/backend/tests/test_maps_style_json.py
@@ -1895,6 +1895,9 @@ def test_emitted_style_strips_wrong_typed_paint_values_spec_01():
     ``*-color``, is dropped on emit; valid scalars and expressions survive."""
     layer = _layer(
         dataset_geometry_type="POLYGON",
+        # opacity 1 keeps the #1626 fold out of this test: at 1 the primary
+        # paint is emitted untouched, so the type check alone decides.
+        opacity=1,
         paint={
             "fill-color": 123,  # number where a color string is required
             "fill-opacity": "0.5",  # string where a number is required (NaN risk)
@@ -1916,6 +1919,7 @@ def test_emitted_style_keeps_expression_opacity_spec_01():
     expr = ["interpolate", ["linear"], ["zoom"], 0, 0.2, 10, 0.9]
     layer = _layer(
         dataset_geometry_type="POLYGON",
+        opacity=1,  # at 1 the #1626 fold leaves the expression as stored
         paint={"fill-color": "#94a3b8", "fill-opacity": expr},
         label_config=None,
         filter=None,
@@ -2484,3 +2488,275 @@ def test_exported_source_attribution_neutralizes_stored_markup():
     source = next(iter(style["sources"].values()))
     assert "<" not in source["attribution"]
     assert ">" not in source["attribution"]
+
+
+# ---------------------------------------------------------------------------
+# fix(#1626): the primary fill/line layer applies layer.opacity on export.
+# fix(#1625): it does so by folding, never by emitting the v6 -layer-opacity
+# keys, which abort the whole style load on maplibre-gl < 6.
+# ---------------------------------------------------------------------------
+def _primary(style, layer_type):
+    return next(
+        e
+        for e in style["layers"]
+        if e["type"] == layer_type and "companion" not in e["metadata"]["geolens"]
+    )
+
+
+def test_export_folds_master_opacity_into_numeric_fill_opacity_1626():
+    layer = _layer(
+        dataset_geometry_type="POLYGON",
+        opacity=0.5,
+        paint={"fill-color": "#94a3b8", "fill-opacity": 0.3},
+        label_config=None,
+        filter=None,
+        style_config=None,
+    )
+    style = build_maplibre_style(_map(), [layer])
+    fill = _primary(style, "fill")
+    assert fill["paint"]["fill-opacity"] == pytest.approx(0.15)
+    assert "fill-layer-opacity" not in fill["paint"]
+    # The un-folded per-feature value rides along for the import side.
+    assert fill["metadata"]["geolens"]["feature_opacity"] == 0.3
+    assert fill["metadata"]["geolens"]["opacity"] == 0.5
+    # The outline companion already carried the master before #1626.
+    outline = next(e for e in style["layers"] if e["id"].endswith("-outline"))
+    assert outline["paint"]["line-opacity"] == 0.5
+
+
+def test_export_folds_master_opacity_into_expression_fill_opacity_1626():
+    expr = ["interpolate", ["linear"], ["zoom"], 0, 0.2, 10, 0.9]
+    layer = _layer(
+        dataset_geometry_type="POLYGON",
+        opacity=0.5,
+        paint={"fill-color": "#94a3b8", "fill-opacity": expr},
+        label_config=None,
+        filter=None,
+        style_config=None,
+    )
+    style = build_maplibre_style(_map(), [layer])
+    fill = _primary(style, "fill")
+    assert fill["paint"]["fill-opacity"] == ["*", expr, 0.5]
+    assert fill["metadata"]["geolens"]["feature_opacity"] == expr
+
+
+def test_export_emits_master_opacity_when_paint_has_no_fill_opacity_1626():
+    """No per-feature value means the spec default (1), so the master stands alone."""
+    layer = _layer(
+        dataset_geometry_type="POLYGON",
+        opacity=0.5,
+        paint={"fill-color": "#94a3b8"},
+        label_config=None,
+        filter=None,
+        style_config=None,
+    )
+    style = build_maplibre_style(_map(), [layer])
+    fill = _primary(style, "fill")
+    assert fill["paint"]["fill-opacity"] == 0.5
+    assert fill["metadata"]["geolens"]["feature_opacity"] is None
+
+
+def test_export_treats_wrong_typed_fill_opacity_as_absent_when_folding_1626():
+    """A string opacity would be stripped by SPEC-01 anyway; the master must
+    survive that rather than vanish with it."""
+    layer = _layer(
+        dataset_geometry_type="POLYGON",
+        opacity=0.5,
+        paint={"fill-color": "#94a3b8", "fill-opacity": "0.3"},
+        label_config=None,
+        filter=None,
+        style_config=None,
+    )
+    style = build_maplibre_style(_map(), [layer])
+    fill = _primary(style, "fill")
+    assert fill["paint"]["fill-opacity"] == 0.5
+    assert fill["metadata"]["geolens"]["feature_opacity"] is None
+
+
+def test_export_folds_master_opacity_into_line_opacity_1626():
+    layer = _layer(
+        dataset_geometry_type="LINESTRING",
+        opacity=0.25,
+        paint={"line-color": "#2255aa", "line-width": 3, "line-opacity": 0.8},
+        label_config=None,
+        filter=None,
+        style_config=None,
+    )
+    style = build_maplibre_style(_map(), [layer])
+    line = _primary(style, "line")
+    assert line["paint"]["line-opacity"] == pytest.approx(0.2)
+    assert "line-layer-opacity" not in line["paint"]
+    assert line["metadata"]["geolens"]["feature_opacity"] == 0.8
+
+
+def test_export_leaves_primary_paint_untouched_at_master_opacity_one_1626():
+    """The v6 default of 1 takes the pre-existing path: bit-identical output."""
+    layer = _layer(
+        dataset_geometry_type="POLYGON",
+        opacity=1,
+        paint={"fill-color": "#94a3b8", "fill-opacity": 0.3},
+        label_config=None,
+        filter=None,
+        style_config=None,
+    )
+    style = build_maplibre_style(_map(), [layer])
+    fill = _primary(style, "fill")
+    assert fill["paint"] == {"fill-color": "#94a3b8", "fill-opacity": 0.3}
+    assert "feature_opacity" not in fill["metadata"]["geolens"]
+
+
+def test_export_does_not_fold_circle_opacity_1626():
+    """Circle has no v6 -layer-opacity, and the live adapter still multiplies;
+    the export keeps the stored paint as-is for it (pre-existing behaviour)."""
+    layer = _layer(
+        dataset_geometry_type="POINT",
+        opacity=0.5,
+        paint={"circle-color": "#2255aa", "circle-radius": 6, "circle-opacity": 0.8},
+        label_config=None,
+        filter=None,
+        style_config=None,
+    )
+    style = build_maplibre_style(_map(), [layer])
+    circle = _primary(style, "circle")
+    assert circle["paint"]["circle-opacity"] == 0.8
+    assert "feature_opacity" not in circle["metadata"]["geolens"]
+
+
+def test_export_strips_a_stored_v6_layer_opacity_key_1625():
+    """A stored `fill-layer-opacity` (API-authored, or pasted from a v6 style)
+    must not leak into the document: maplibre-gl < 6 refuses to load it."""
+    layer = _layer(
+        dataset_geometry_type="POLYGON",
+        opacity=1,
+        paint={"fill-color": "#94a3b8", "fill-layer-opacity": 0.5},
+        label_config=None,
+        filter=None,
+        style_config=None,
+    )
+    style = build_maplibre_style(_map(), [layer])
+    fill = _primary(style, "fill")
+    assert "fill-layer-opacity" not in fill["paint"]
+
+
+@pytest.mark.parametrize(
+    ("geometry", "paint"),
+    [
+        ("POLYGON", {"fill-color": "#94a3b8", "fill-opacity": 0.3}),
+        (
+            "POLYGON",
+            {
+                "fill-color": "#94a3b8",
+                "fill-opacity": ["interpolate", ["linear"], ["zoom"], 0, 0.2, 10, 0.9],
+            },
+        ),
+        ("POLYGON", {"fill-color": "#94a3b8"}),
+        ("LINESTRING", {"line-color": "#2255aa", "line-width": 3, "line-opacity": 0.8}),
+    ],
+)
+def test_import_undoes_the_export_fold_so_a_round_trip_keeps_both_tiers_1626(
+    geometry, paint
+):
+    """build -> parse must give back the stored per-feature paint AND the master
+    opacity, not the product of the two (which the builder would then apply the
+    master to again)."""
+    dataset_id = uuid.uuid4()
+    layer = _layer(
+        dataset_id=dataset_id,
+        dataset_geometry_type=geometry,
+        opacity=0.5,
+        paint=paint,
+        label_config=None,
+        filter=None,
+        style_config=None,
+    )
+    style = build_maplibre_style(_map(), [layer])
+    imported = parse_maplibre_style_import(style)
+    assert imported.summary.layers_imported == 1
+    restored = imported.layers[0]
+    assert restored.opacity == 0.5
+    assert restored.paint == paint
+
+
+def test_import_maps_a_v6_layer_opacity_key_onto_the_master_opacity_1625():
+    """A style authored for maplibre-gl v6 carries the master on
+    `fill-layer-opacity`; it becomes `layer.opacity` and leaves paint."""
+    dataset_id = uuid.uuid4()
+    style = build_maplibre_style(
+        _map(),
+        [
+            _layer(
+                dataset_id=dataset_id,
+                dataset_geometry_type="POLYGON",
+                opacity=1,
+                paint={"fill-color": "#94a3b8", "fill-opacity": 0.3},
+                label_config=None,
+                filter=None,
+                style_config=None,
+            )
+        ],
+    )
+    primary = _primary(style, "fill")
+    primary["paint"]["fill-layer-opacity"] = 0.4
+    imported = parse_maplibre_style_import(style)
+    restored = imported.layers[0]
+    assert restored.opacity == pytest.approx(0.4)
+    assert restored.paint == {"fill-color": "#94a3b8", "fill-opacity": 0.3}
+    assert not imported.summary.warnings
+
+
+def test_import_composes_v6_layer_opacity_with_the_metadata_master_1625():
+    dataset_id = uuid.uuid4()
+    style = build_maplibre_style(
+        _map(),
+        [
+            _layer(
+                dataset_id=dataset_id,
+                dataset_geometry_type="LINESTRING",
+                opacity=0.5,
+                paint={"line-color": "#2255aa", "line-opacity": 0.8},
+                label_config=None,
+                filter=None,
+                style_config=None,
+            )
+        ],
+    )
+    primary = _primary(style, "line")
+    primary["paint"]["line-layer-opacity"] = 0.5
+    restored = parse_maplibre_style_import(style).layers[0]
+    assert restored.opacity == pytest.approx(0.25)
+    assert restored.paint == {"line-color": "#2255aa", "line-opacity": 0.8}
+
+
+def test_import_drops_an_expression_layer_opacity_with_a_warning_1625():
+    """`layer.opacity` is a scalar column; a zoom-driven layer opacity has no home."""
+    dataset_id = uuid.uuid4()
+    style = build_maplibre_style(
+        _map(),
+        [
+            _layer(
+                dataset_id=dataset_id,
+                dataset_geometry_type="POLYGON",
+                opacity=1,
+                paint={"fill-color": "#94a3b8"},
+                label_config=None,
+                filter=None,
+                style_config=None,
+            )
+        ],
+    )
+    primary = _primary(style, "fill")
+    primary["paint"]["fill-layer-opacity"] = [
+        "interpolate",
+        ["linear"],
+        ["zoom"],
+        0,
+        0.2,
+        10,
+        1,
+    ]
+    imported = parse_maplibre_style_import(style)
+    restored = imported.layers[0]
+    assert restored.opacity == 1
+    assert "fill-layer-opacity" not in restored.paint
+    assert [w.code for w in imported.summary.warnings] == ["unsupported_layer_opacity"]
+    assert imported.summary.warnings[0].layer_id == primary["id"]

--- a/backend/tests/test_maps_style_json.py
+++ b/backend/tests/test_maps_style_json.py
@@ -2540,8 +2540,11 @@ def test_export_folds_master_opacity_into_expression_fill_opacity_1626():
     assert fill["metadata"]["geolens"]["feature_opacity"] == expr
 
 
-def test_export_emits_master_opacity_when_paint_has_no_fill_opacity_1626():
-    """No per-feature value means the spec default (1), so the master stands alone."""
+def test_export_folds_the_builder_default_when_paint_has_no_fill_opacity_1626():
+    """fix(#1631 review): absent per-feature opacity means the BUILDER default
+    (fill 0.3, mirrored from getFeatureOpacity in layer-adapters/shared.ts),
+    not the spec default of 1 — the live builder draws such a polygon at
+    0.3 * master, and the export has to match it."""
     layer = _layer(
         dataset_geometry_type="POLYGON",
         opacity=0.5,
@@ -2552,8 +2555,24 @@ def test_export_emits_master_opacity_when_paint_has_no_fill_opacity_1626():
     )
     style = build_maplibre_style(_map(), [layer])
     fill = _primary(style, "fill")
-    assert fill["paint"]["fill-opacity"] == 0.5
+    assert fill["paint"]["fill-opacity"] == pytest.approx(0.15)
     assert fill["metadata"]["geolens"]["feature_opacity"] is None
+
+
+def test_export_folds_the_builder_default_when_paint_has_no_line_opacity_1626():
+    """The line default is 1, so the master stands alone for lines."""
+    layer = _layer(
+        dataset_geometry_type="LINESTRING",
+        opacity=0.5,
+        paint={"line-color": "#2255aa", "line-width": 3},
+        label_config=None,
+        filter=None,
+        style_config=None,
+    )
+    style = build_maplibre_style(_map(), [layer])
+    line = _primary(style, "line")
+    assert line["paint"]["line-opacity"] == pytest.approx(0.5)
+    assert line["metadata"]["geolens"]["feature_opacity"] is None
 
 
 def test_export_treats_wrong_typed_fill_opacity_as_absent_when_folding_1626():
@@ -2569,7 +2588,9 @@ def test_export_treats_wrong_typed_fill_opacity_as_absent_when_folding_1626():
     )
     style = build_maplibre_style(_map(), [layer])
     fill = _primary(style, "fill")
-    assert fill["paint"]["fill-opacity"] == 0.5
+    # fix(#1631 review): wrong-typed counts as absent, so the builder default
+    # (0.3) is the per-feature starting point, same as the test above.
+    assert fill["paint"]["fill-opacity"] == pytest.approx(0.15)
     assert fill["metadata"]["geolens"]["feature_opacity"] is None
 
 

--- a/frontend/src/components/builder/__tests__/layer-adapters.test.ts
+++ b/frontend/src/components/builder/__tests__/layer-adapters.test.ts
@@ -812,12 +812,13 @@ describe('lineAdapter', () => {
     const opacityCalls = (map.setPaintProperty as ReturnType<typeof vi.fn>).mock.calls
       .filter(([, prop]) => prop === 'line-opacity');
     expect(opacityCalls.length).toBeGreaterThan(0);
-    // fix(#394) ST-03: the LAST write wins — the master slider (0.4)
-    // multiplies the expression (shape preserved, never flattened to a
-    // number). Earlier writes replay the raw expression before the compound
-    // set, same as before the fix.
+    // fix(#1625): the LAST write wins — the per-feature expression lands on
+    // line-opacity UNMULTIPLIED (shape preserved, never flattened to a number)
+    // and the master slider (0.4) rides on line-layer-opacity. Before #1625 the
+    // last write was ['*', expr, 0.4] (fix(#394) ST-03).
     const lastOpacityValue = opacityCalls[opacityCalls.length - 1][2];
-    expect(JSON.stringify(lastOpacityValue)).toBe(JSON.stringify(['*', opacityExpression, 0.4]));
+    expect(JSON.stringify(lastOpacityValue)).toBe(JSON.stringify(opacityExpression));
+    expect(map.setPaintProperty).toHaveBeenCalledWith('layer-l5b', 'line-layer-opacity', 0.4);
   });
 
   it('syncPaint preserves line gap, blur, offset, and line-gradient paint', () => {
@@ -902,12 +903,11 @@ describe('lineAdapter', () => {
     const opacityCalls = (map.setPaintProperty as ReturnType<typeof vi.fn>).mock.calls
       .filter(([, prop]) => prop === 'line-opacity');
     expect(opacityCalls.length).toBeGreaterThan(0);
-    // fix(#394) ST-03: the LAST write wins — the master slider (0.4)
-    // multiplies the expression (shape preserved, never flattened to a
-    // number). Earlier writes replay the raw expression before the compound
-    // set, same as before the fix.
+    // fix(#1625): per-feature expression stays unmultiplied on line-opacity;
+    // the master slider (0.4) goes to line-layer-opacity (was ['*', expr, 0.4]).
     const lastOpacityValue = opacityCalls[opacityCalls.length - 1][2];
-    expect(JSON.stringify(lastOpacityValue)).toBe(JSON.stringify(['*', opacityExpression, 0.4]));
+    expect(JSON.stringify(lastOpacityValue)).toBe(JSON.stringify(opacityExpression));
+    expect(map.setPaintProperty).toHaveBeenCalledWith('layer-l7', 'line-layer-opacity', 0.4);
   });
 
   it('addLayers does not pass flattened line-gradient string to MapLibre addLayer when expressions present', () => {

--- a/frontend/src/components/builder/__tests__/map-sync.raster.test.ts
+++ b/frontend/src/components/builder/__tests__/map-sync.raster.test.ts
@@ -606,7 +606,7 @@ describe('syncLayersToMap', () => {
     expect(map.setPaintProperty).toHaveBeenCalledWith('layer-op1', 'circle-opacity', 1);
   });
 
-  it('fill layer with opacity 1.0 sets fill-opacity and outline line-opacity', () => {
+  it('fill layer with opacity 1.0 sets fill-opacity and the outline line-layer-opacity', () => {
     const layer = makeLayer({
       id: 'op2',
       dataset_geometry_type: 'Polygon',
@@ -616,9 +616,11 @@ describe('syncLayersToMap', () => {
 
     syncLayersToMap(map, [layer], tokenMap, undefined, managedSourcesRef, { current: '' });
 
-    // fill-opacity = 0.3 (default) * 1 = 0.3
+    // fix(#1625): per-feature fill-opacity = 0.3 (builder default), the master
+    // rides on fill-layer-opacity; the outline carries it as line-layer-opacity.
     expect(map.setPaintProperty).toHaveBeenCalledWith('layer-op2', 'fill-opacity', 0.3);
-    expect(map.setPaintProperty).toHaveBeenCalledWith('layer-op2-outline', 'line-opacity', 1);
+    expect(map.setPaintProperty).toHaveBeenCalledWith('layer-op2', 'fill-layer-opacity', 1);
+    expect(map.setPaintProperty).toHaveBeenCalledWith('layer-op2-outline', 'line-layer-opacity', 1);
   });
 
   it('existing label layer syncs filter during paint update', () => {

--- a/frontend/src/components/builder/hooks/__tests__/use-layer-map-sync.raf.test.ts
+++ b/frontend/src/components/builder/hooks/__tests__/use-layer-map-sync.raf.test.ts
@@ -25,12 +25,12 @@ vi.mock('@/components/builder/layer-adapters/registry', () => ({
   getAdapter: vi.fn(() => mockAdapter),
 }));
 
-// We need resolveAdapterType + getCompoundOpacity from map-sync to return something
+// We need resolveAdapterType + applyMasterOpacity from map-sync to return something
 // consistent. Mock map-sync for the parts use-layer-map-sync imports.
 vi.mock('@/components/builder/map-sync', () => ({
   getLayerType: vi.fn(() => 'fill'),
   resolveAdapterType: vi.fn(() => 'fill'),
-  getCompoundOpacity: vi.fn((_paint: Record<string, unknown>, _type: string, opacity: number) => opacity),
+  applyMasterOpacity: vi.fn(),
   // Phase 1050 SF-04: use-layer-map-sync now routes through this helper.
   // The PERF-04 test only asserts call counts (does not validate sourceId
   // values), so a simple per-layer string is sufficient here.

--- a/frontend/src/components/builder/hooks/__tests__/use-layer-map-sync.test.ts
+++ b/frontend/src/components/builder/hooks/__tests__/use-layer-map-sync.test.ts
@@ -33,10 +33,16 @@ vi.mock('@/components/builder/layer-adapters/registry', () => ({
   getAdapter: vi.fn(() => mockAdapter),
 }));
 
-vi.mock('@/components/builder/map-sync', () => ({
+vi.mock('@/components/builder/map-sync', async () => ({
   getLayerType: vi.fn(() => 'fill'),
   resolveAdapterType: vi.fn(() => 'fill'),
-  getCompoundOpacity: vi.fn((_paint: Record<string, unknown>, _type: string, opacity: number) => opacity),
+  // fix(#1625): the real helper, so the slider-path test below asserts the
+  // actual setPaintProperty writes rather than a stand-in's.
+  applyMasterOpacity: (
+    await vi.importActual<typeof import('@/components/builder/layer-adapters/shared')>(
+      '@/components/builder/layer-adapters/shared',
+    )
+  ).applyMasterOpacity,
   getSourceIdForLayer: vi.fn((layer: { id: string }) => `source-${layer.id}`),
   isDemTerrainVisualSuppressed: vi.fn((layer: { is_dem?: boolean | null; style_config?: { render_mode?: unknown } | null }) =>
     layer.is_dem === true && layer.style_config?.render_mode === 'terrain'),
@@ -1810,5 +1816,34 @@ describe('useLayerMapSync — a null fill key is not an active one', () => {
     const builder = (updated.style_config as { builder?: Record<string, unknown> } | null)?.builder;
     expect(builder?.fillColorSaved).toBeUndefined();
     expect(updated.paint?.['fill-color']).toBe('#00ff00');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// fix(#1625): the master slider's direct map path (applyLayerOpacityToMap)
+// ---------------------------------------------------------------------------
+describe('useLayerMapSync — handleOpacityChange drives fill-layer-opacity (#1625)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('writes the master to fill-layer-opacity and the outline line-layer-opacity, leaving fill-opacity unmultiplied', () => {
+    const layer = makeLayer({ opacity: 1, paint: { 'fill-color': '#ff0000', 'fill-opacity': 0.3 } });
+    const mapStub = makeMapStub([`layer-${LAYER_ID}`, `layer-${LAYER_ID}-outline`]);
+    const mapRef = { current: mapStub };
+    const { result } = renderHook(() =>
+      useLayerMapSync([layer], vi.fn(), vi.fn(), mapRef),
+    );
+
+    act(() => {
+      result.current.handleOpacityChange(layer.id, 0.5);
+    });
+
+    const writes = (mapStub.setPaintProperty as ReturnType<typeof vi.fn>).mock.calls;
+    expect(writes).toContainEqual([`layer-${LAYER_ID}`, 'fill-opacity', 0.3]);
+    expect(writes).toContainEqual([`layer-${LAYER_ID}`, 'fill-layer-opacity', 0.5]);
+    expect(writes).toContainEqual([`layer-${LAYER_ID}-outline`, 'line-layer-opacity', 0.5]);
+    expect(writes).not.toContainEqual([`layer-${LAYER_ID}`, 'fill-opacity', 0.15]);
+    expect(writes).not.toContainEqual([`layer-${LAYER_ID}-outline`, 'line-opacity', expect.anything()]);
   });
 });

--- a/frontend/src/components/builder/hooks/use-bulk-layer-actions.ts
+++ b/frontend/src/components/builder/hooks/use-bulk-layer-actions.ts
@@ -284,7 +284,7 @@ export function useBulkLayerActions({
     setHasUnsavedChanges(true);
 
     // STATE-03: delegate the per-layer live-map sync to the SAME shared
-    // side-effect handleOpacityChange uses, so getCompoundOpacity wrapping and
+    // side-effect handleOpacityChange uses, so applyMasterOpacity split and
     // the dedicated cluster branch cannot diverge between single and bulk. The
     // single setLocalLayers write above owns React state; this only repaints.
     const map = mapInstanceRef.current;

--- a/frontend/src/components/builder/hooks/use-layer-map-sync.ts
+++ b/frontend/src/components/builder/hooks/use-layer-map-sync.ts
@@ -1,6 +1,6 @@
 import { useCallback, useLayoutEffect, useRef } from 'react';
 import type { Map as MaplibreMap, FilterSpecification } from 'maplibre-gl';
-import { getLayerType, getSourceIdForLayer, resolveAdapterType, getCompoundOpacity, isDemTerrainVisualSuppressed } from '@/components/builder/map-sync';
+import { getLayerType, getSourceIdForLayer, resolveAdapterType, applyMasterOpacity, isDemTerrainVisualSuppressed } from '@/components/builder/map-sync';
 import { getAdapter } from '@/components/builder/layer-adapters/registry';
 import {
   getBuilderStyleConfig,
@@ -80,7 +80,7 @@ export function applyLayerVisibilityToMap(
 
 // STATE-03 / SYNC-04: the canonical per-layer opacity map side-effect. The
 // single-layer (`handleOpacityChange`) AND the bulk (`handleBulkOpacity`)
-// paths both call this so the getCompoundOpacity wrapping and the dedicated
+// paths both call this so the applyMasterOpacity split and the dedicated
 // cluster branch can never diverge.
 export function applyLayerOpacityToMap(
   map: MaplibreMap,
@@ -165,14 +165,12 @@ export function applyLayerOpacityToMap(
     getAdapter('mixed').syncPaint(map, input);
   } else if (adapterType === 'fill' || adapterType === 'line' || adapterType === 'circle') {
     if (map.getLayer(mapLayerId)) {
-      map.setPaintProperty(
-        mapLayerId,
-        `${adapterType}-opacity`,
-        getCompoundOpacity(paint, adapterType, opacity),
-      );
+      // fix(#1625): same split as the adapters' syncPaint — fill/line put the
+      // master on `-layer-opacity`, circle still multiplies.
+      applyMasterOpacity(map, mapLayerId, paint, adapterType, opacity);
     }
     if (adapterType === 'fill' && map.getLayer(ids.outline)) {
-      map.setPaintProperty(ids.outline, 'line-opacity', opacity);
+      map.setPaintProperty(ids.outline, 'line-layer-opacity', opacity);
     }
   }
 }

--- a/frontend/src/components/builder/layer-adapters/__tests__/circle-adapter.test.ts
+++ b/frontend/src/components/builder/layer-adapters/__tests__/circle-adapter.test.ts
@@ -81,3 +81,36 @@ describe('circle adapter — getLayerIds returns [layerId]', () => {
     expect(ids).toEqual(['circle-xyz']);
   });
 });
+
+// fix(#1625): circle has no `-layer-opacity` in maplibre-gl v6, so the circle
+// adapter keeps multiplying the master into the per-feature value. This pins the
+// ceiling named at the branch point in shared.ts `applyMasterOpacity`.
+describe('circle adapter — still multiplies master into circle-opacity (#1625 ceiling)', () => {
+  function paintWrites(map: ReturnType<typeof createMockMap>, prop: string) {
+    return map.setPaintProperty.mock.calls
+      .filter(([id, name]) => id === 'layer-circle-1' && name === prop)
+      .map(([, , value]) => value);
+  }
+
+  it('addLayers: circle-opacity 0.8 + master 0.5 -> circle-opacity 0.4 and no circle-layer-opacity write', () => {
+    const map = createMockMap({ layerExists: true });
+    circleAdapter.addLayers(map as unknown as import('maplibre-gl').Map, makeInput({
+      opacity: 0.5,
+      paint: { 'circle-color': '#ff0000', 'circle-radius': 4, 'circle-opacity': 0.8 },
+    }));
+
+    expect(paintWrites(map, 'circle-opacity').at(-1)).toBeCloseTo(0.4);
+    expect(paintWrites(map, 'circle-layer-opacity')).toEqual([]);
+  });
+
+  it('syncPaint: the same multiply on edit', () => {
+    const map = createMockMap({ layerExists: true });
+    circleAdapter.syncPaint(map as unknown as import('maplibre-gl').Map, makeInput({
+      opacity: 0.5,
+      paint: { 'circle-color': '#ff0000', 'circle-radius': 4, 'circle-opacity': 0.8 },
+    }));
+
+    expect(paintWrites(map, 'circle-opacity').at(-1)).toBeCloseTo(0.4);
+    expect(paintWrites(map, 'circle-layer-opacity')).toEqual([]);
+  });
+});

--- a/frontend/src/components/builder/layer-adapters/__tests__/fill-adapter.test.ts
+++ b/frontend/src/components/builder/layer-adapters/__tests__/fill-adapter.test.ts
@@ -152,3 +152,86 @@ describe('fill adapter — getLayerIds returns [layerId, outline, extrusion]', (
     expect(ids).toEqual(['fill-abc', 'fill-abc-outline', 'fill-abc-extrusion']);
   });
 });
+
+type MapArg = import('maplibre-gl').Map;
+
+function paintWrites(map: ReturnType<typeof createMockMap>, layerId: string, prop: string) {
+  return map.setPaintProperty.mock.calls
+    .filter(([id, name]) => id === layerId && name === prop)
+    .map(([, , value]) => value);
+}
+
+// fix(#1625): the master slider rides on maplibre-gl v6's `fill-layer-opacity`
+// (one composite of the whole layer) and the Style Editor's per-feature
+// `fill-opacity` is written UNMULTIPLIED. Before #1625 the two were multiplied
+// into one per-feature value, so overlapping polygons double-darkened and a
+// 50% master never produced a uniformly 50% layer.
+describe('fill adapter — master opacity drives fill-layer-opacity, per-feature fill-opacity stays unmultiplied (#1625)', () => {
+  it('addLayers: numeric fill-opacity 0.3 + master 0.5 -> fill-opacity 0.3 and fill-layer-opacity 0.5, never 0.15', () => {
+    const map = createMockMap({ layerExists: true });
+    fillAdapter.addLayers(map as unknown as MapArg, makeInput({
+      opacity: 0.5,
+      paint: { 'fill-color': '#ff0000', 'fill-opacity': 0.3 },
+    }));
+
+    expect(paintWrites(map, 'layer-fill-1', 'fill-layer-opacity')).toEqual([0.5]);
+    const featureWrites = paintWrites(map, 'layer-fill-1', 'fill-opacity');
+    expect(featureWrites.length).toBeGreaterThan(0);
+    expect(featureWrites.at(-1)).toBe(0.3);
+    expect(featureWrites).not.toContain(0.15);
+  });
+
+  it('addLayers: an expression fill-opacity is replayed as-is, not wrapped in ["*", expr, master]', () => {
+    const map = createMockMap({ layerExists: true });
+    const expr = ['step', ['zoom'], 0.2, 9, 0.7];
+    fillAdapter.addLayers(map as unknown as MapArg, makeInput({
+      opacity: 0.5,
+      paint: { 'fill-color': '#ff0000', 'fill-opacity': expr },
+    }));
+
+    const featureWrites = paintWrites(map, 'layer-fill-1', 'fill-opacity');
+    expect(JSON.stringify(featureWrites.at(-1))).toBe(JSON.stringify(expr));
+    expect(paintWrites(map, 'layer-fill-1', 'fill-layer-opacity')).toEqual([0.5]);
+  });
+
+  it('addLayers: with no fill-opacity in paint the builder default (0.3) is the per-feature value', () => {
+    const map = createMockMap({ layerExists: true });
+    fillAdapter.addLayers(map as unknown as MapArg, makeInput({
+      opacity: 0.5,
+      paint: { 'fill-color': '#ff0000' },
+    }));
+
+    expect(paintWrites(map, 'layer-fill-1', 'fill-opacity').at(-1)).toBe(0.3);
+    expect(paintWrites(map, 'layer-fill-1', 'fill-layer-opacity')).toEqual([0.5]);
+  });
+
+  it('addLayers: the outline companion gets line-layer-opacity, and its line-opacity is left at the spec default', () => {
+    const map = createMockMap({ layerExists: true });
+    fillAdapter.addLayers(map as unknown as MapArg, makeInput({ opacity: 0.5 }));
+
+    expect(paintWrites(map, 'layer-fill-1-outline', 'line-layer-opacity')).toEqual([0.5]);
+    expect(paintWrites(map, 'layer-fill-1-outline', 'line-opacity')).toEqual([]);
+    const outlineSpec = map.addLayer.mock.calls[1][0] as { id: string; paint: Record<string, unknown> };
+    expect(outlineSpec.id).toBe('layer-fill-1-outline');
+    expect(outlineSpec.paint).not.toHaveProperty('line-opacity');
+  });
+
+  it('syncPaint after addLayer: moving the master slider updates fill-layer-opacity on the primary AND line-layer-opacity on the outline', () => {
+    // The outline is reconciled through syncOwnedPaintProperties, which only
+    // touches keys in OUTLINE_OWNED_PAINT_PROPERTIES — an unregistered key would
+    // be written once by addLayers and then stick at its first value forever.
+    const map = createMockMap({ layerExists: true });
+    map.getPaintProperty.mockImplementation((_id: string, prop: string) =>
+      prop === 'line-layer-opacity' ? 0.5 : undefined,
+    );
+    fillAdapter.syncPaint(map as unknown as MapArg, makeInput({
+      opacity: 0.25,
+      paint: { 'fill-color': '#ff0000', 'fill-opacity': 0.3 },
+    }));
+
+    expect(paintWrites(map, 'layer-fill-1', 'fill-layer-opacity')).toEqual([0.25]);
+    expect(paintWrites(map, 'layer-fill-1', 'fill-opacity').at(-1)).toBe(0.3);
+    expect(paintWrites(map, 'layer-fill-1-outline', 'line-layer-opacity')).toEqual([0.25]);
+    expect(paintWrites(map, 'layer-fill-1-outline', 'line-opacity')).toEqual([]);
+  });
+});

--- a/frontend/src/components/builder/layer-adapters/__tests__/line-adapter.test.ts
+++ b/frontend/src/components/builder/layer-adapters/__tests__/line-adapter.test.ts
@@ -143,3 +143,36 @@ describe('line adapter — syncPaint reconciles line-cap and line-join via syncO
     expect(capResets).toHaveLength(0);
   });
 });
+
+// fix(#1625): the master slider rides on maplibre-gl v6's `line-layer-opacity`;
+// the per-feature `line-opacity` is written unmultiplied.
+describe('line adapter — master opacity drives line-layer-opacity (#1625)', () => {
+  function paintWrites(map: ReturnType<typeof createMockMap>, prop: string) {
+    return map.setPaintProperty.mock.calls
+      .filter(([id, name]) => id === 'layer-line-1' && name === prop)
+      .map(([, , value]) => value);
+  }
+
+  it('addLayers: numeric line-opacity 0.6 + master 0.5 -> line-opacity 0.6 and line-layer-opacity 0.5', () => {
+    const map = createMockMap({ layerExists: true });
+    lineAdapter.addLayers(map as unknown as import('maplibre-gl').Map, makeInput({
+      opacity: 0.5,
+      paint: { 'line-color': '#ff0000', 'line-width': 2, 'line-opacity': 0.6 },
+    }));
+
+    expect(paintWrites(map, 'line-opacity').at(-1)).toBe(0.6);
+    expect(paintWrites(map, 'line-opacity')).not.toContain(0.3);
+    expect(paintWrites(map, 'line-layer-opacity')).toEqual([0.5]);
+  });
+
+  it('syncPaint after addLayer: a new master value lands on line-layer-opacity and leaves line-opacity unmultiplied', () => {
+    const map = createMockMap({ layerExists: true });
+    lineAdapter.syncPaint(map as unknown as import('maplibre-gl').Map, makeInput({
+      opacity: 0.25,
+      paint: { 'line-color': '#ff0000', 'line-width': 2, 'line-opacity': 0.6 },
+    }));
+
+    expect(paintWrites(map, 'line-layer-opacity')).toEqual([0.25]);
+    expect(paintWrites(map, 'line-opacity').at(-1)).toBe(0.6);
+  });
+});

--- a/frontend/src/components/builder/layer-adapters/__tests__/mixed-adapter.test.ts
+++ b/frontend/src/components/builder/layer-adapters/__tests__/mixed-adapter.test.ts
@@ -218,3 +218,28 @@ describe('mixed adapter — id contracts', () => {
     ]);
   });
 });
+
+// fix(#1625): the fill/line/outline sublayers get the v6 `-layer-opacity`
+// treatment; the point sublayer keeps the multiply (circle has no such key).
+describe('mixed adapter — master opacity per family sublayer (#1625)', () => {
+  function paintWrites(map: ReturnType<typeof createMockMap>, layerId: string, prop: string) {
+    return map.setPaintProperty.mock.calls
+      .filter(([id, name]) => id === layerId && name === prop)
+      .map(([, , value]) => value);
+  }
+  const paint = { 'fill-opacity': 0.3, 'line-opacity': 0.6, 'circle-opacity': 0.8 };
+
+  it('syncPaint: fill/lines/outline get <geom>-layer-opacity, per-feature stays unmultiplied, points multiply', () => {
+    const map = createMockMap({ layerExists: true });
+    mixedAdapter.syncPaint(map as unknown as import('maplibre-gl').Map, makeInput({ opacity: 0.5, paint }));
+
+    expect(paintWrites(map, 'layer-mixed-1', 'fill-layer-opacity')).toEqual([0.5]);
+    expect(paintWrites(map, 'layer-mixed-1', 'fill-opacity').at(-1)).toBe(0.3);
+    expect(paintWrites(map, mixedLinesLayerId('layer-mixed-1'), 'line-layer-opacity')).toEqual([0.5]);
+    expect(paintWrites(map, mixedLinesLayerId('layer-mixed-1'), 'line-opacity').at(-1)).toBe(0.6);
+    expect(paintWrites(map, 'layer-mixed-1-outline', 'line-layer-opacity')).toEqual([0.5]);
+    expect(paintWrites(map, 'layer-mixed-1-outline', 'line-opacity')).toEqual([]);
+    expect(paintWrites(map, mixedPointsLayerId('layer-mixed-1'), 'circle-opacity').at(-1)).toBeCloseTo(0.4);
+    expect(paintWrites(map, mixedPointsLayerId('layer-mixed-1'), 'circle-layer-opacity')).toEqual([]);
+  });
+});

--- a/frontend/src/components/builder/layer-adapters/__tests__/shared.test.ts
+++ b/frontend/src/components/builder/layer-adapters/__tests__/shared.test.ts
@@ -8,6 +8,9 @@ import {
   classifyGeometry,
   getLayerType,
   normalizeRasterBounds,
+  applyMasterOpacity,
+  getExpressionSafeOpacity,
+  getFeatureOpacity,
 } from '../shared';
 import type { LayoutPropertyName, PaintPropertyName } from '../shared';
 import type { FilterSpecification } from 'maplibre-gl';
@@ -418,5 +421,66 @@ describe('syncOwnedLayoutProperties', () => {
 
     expect(map.setLayoutProperty).toHaveBeenCalledTimes(1);
     expect(map.setLayoutProperty).toHaveBeenCalledWith('L', 'visibility', 'none');
+  });
+});
+
+// fix(#1625): the single branch point for the master-opacity split.
+describe('applyMasterOpacity (#1625)', () => {
+  const expr = ['step', ['zoom'], 0.2, 9, 0.7];
+
+  it('fill: writes the per-feature fill-opacity unmultiplied and the master on fill-layer-opacity', () => {
+    const map = { setPaintProperty: vi.fn() };
+    applyMasterOpacity(map, 'L', { 'fill-opacity': 0.3 }, 'fill', 0.5);
+    expect(map.setPaintProperty.mock.calls).toEqual([
+      ['L', 'fill-opacity', 0.3],
+      ['L', 'fill-layer-opacity', 0.5],
+    ]);
+  });
+
+  it('line: an expression per-feature opacity passes through untouched', () => {
+    const map = { setPaintProperty: vi.fn() };
+    applyMasterOpacity(map, 'L', { 'line-opacity': expr }, 'line', 0.5);
+    expect(map.setPaintProperty).toHaveBeenCalledWith('L', 'line-opacity', expr);
+    expect(map.setPaintProperty).toHaveBeenCalledWith('L', 'line-layer-opacity', 0.5);
+  });
+
+  it('fill: master 1 still writes fill-layer-opacity 1 so a previous lower value is reset', () => {
+    const map = { setPaintProperty: vi.fn() };
+    applyMasterOpacity(map, 'L', {}, 'fill', 1);
+    expect(map.setPaintProperty).toHaveBeenCalledWith('L', 'fill-opacity', 0.3);
+    expect(map.setPaintProperty).toHaveBeenCalledWith('L', 'fill-layer-opacity', 1);
+  });
+
+  it('circle: no -layer-opacity exists, so the master is multiplied into circle-opacity', () => {
+    const map = { setPaintProperty: vi.fn() };
+    applyMasterOpacity(map, 'L', { 'circle-opacity': 0.8 }, 'circle', 0.5);
+    expect(map.setPaintProperty.mock.calls).toEqual([['L', 'circle-opacity', 0.4]]);
+  });
+
+  it('circle: an expression per-feature opacity is wrapped in ["*", expr, master]', () => {
+    const map = { setPaintProperty: vi.fn() };
+    applyMasterOpacity(map, 'L', { 'circle-opacity': expr }, 'circle', 0.5);
+    expect(map.setPaintProperty.mock.calls).toEqual([['L', 'circle-opacity', ['*', expr, 0.5]]]);
+  });
+});
+
+describe('getFeatureOpacity / getExpressionSafeOpacity', () => {
+  it('getFeatureOpacity returns the stored number, the stored expression, or the builder default', () => {
+    const expr = ['step', ['zoom'], 0.2, 9, 0.7];
+    expect(getFeatureOpacity({ 'fill-opacity': 0.45 }, 'fill')).toBe(0.45);
+    expect(getFeatureOpacity({ 'fill-opacity': expr }, 'fill')).toBe(expr);
+    expect(getFeatureOpacity({}, 'fill')).toBe(0.3);
+    expect(getFeatureOpacity({}, 'line')).toBe(1);
+    expect(getFeatureOpacity({}, 'circle')).toBe(1);
+    // A wrong-typed scalar counts as absent.
+    expect(getFeatureOpacity({ 'fill-opacity': '0.5' }, 'fill')).toBe(0.3);
+  });
+
+  it('getExpressionSafeOpacity multiplies a number and wraps an expression (skipping the wrap at master 1)', () => {
+    const expr = ['step', ['zoom'], 0.2, 9, 0.7];
+    expect(getExpressionSafeOpacity({ 'circle-opacity': 0.8 }, 'circle', 0.5)).toBeCloseTo(0.4);
+    expect(getExpressionSafeOpacity({ 'circle-opacity': expr }, 'circle', 0.5)).toEqual(['*', expr, 0.5]);
+    expect(getExpressionSafeOpacity({ 'circle-opacity': expr }, 'circle', 1)).toBe(expr);
+    expect(getExpressionSafeOpacity({}, 'fill', 0.5)).toBeCloseTo(0.15);
   });
 });

--- a/frontend/src/components/builder/layer-adapters/circle-adapter.ts
+++ b/frontend/src/components/builder/layer-adapters/circle-adapter.ts
@@ -4,7 +4,7 @@ import {
   simplifyPaint,
   filterPaintForLayerType,
   finalizeLayer,
-  getExpressionSafeOpacity,
+  applyMasterOpacity,
   syncOwnedPaintProperties,
   syncSingleLayerVisibility,
   syncLayerFilter,
@@ -64,7 +64,7 @@ export const circleAdapter: LayerAdapter = {
       geomType: 'circle',
       ownedProperties: CIRCLE_OWNED_PAINT_PROPERTIES,
     });
-    map.setPaintProperty(layerId, 'circle-opacity', getExpressionSafeOpacity(rawPaint, 'circle', opacity ?? 1));
+    applyMasterOpacity(map, layerId, rawPaint, 'circle', opacity ?? 1);
     syncLayerFilter(map, layerId, filter);
   },
 

--- a/frontend/src/components/builder/layer-adapters/cluster-adapter.ts
+++ b/frontend/src/components/builder/layer-adapters/cluster-adapter.ts
@@ -6,7 +6,7 @@ import {
   filterPaintForLayerType,
   finalizeLayer,
   getBuilderStyleConfig,
-  getExpressionSafeOpacity,
+  applyMasterOpacity,
   syncOwnedLayoutProperties,
   syncOwnedPaintProperties,
   syncSingleLayerVisibility,
@@ -263,7 +263,7 @@ function syncUnclusteredPointLayer(map: MaplibreMap, input: AdapterLayerInput) {
     geomType: 'circle',
     ownedProperties: CIRCLE_OWNED_PAINT_PROPERTIES,
   });
-  map.setPaintProperty(input.layerId, 'circle-opacity', getExpressionSafeOpacity(input.paint, 'circle', input.opacity ?? 1));
+  applyMasterOpacity(map, input.layerId, input.paint, 'circle', input.opacity ?? 1);
   map.setFilter(input.layerId, unclusteredFilter(input));
 }
 

--- a/frontend/src/components/builder/layer-adapters/fill-adapter.ts
+++ b/frontend/src/components/builder/layer-adapters/fill-adapter.ts
@@ -4,7 +4,7 @@ import {
   simplifyPaint,
   filterPaintForLayerType,
   finalizeLayer,
-  getExpressionSafeOpacity,
+  applyMasterOpacity,
   getBuilderStyleConfig,
   syncLayerFilter,
   setLayerProperty,
@@ -27,7 +27,12 @@ export const FILL_OWNED_PAINT_PROPERTIES = [
   'fill-translate',
   'fill-translate-anchor',
 ] as const;
-export const OUTLINE_OWNED_PAINT_PROPERTIES = ['line-color', 'line-width', 'line-opacity'] as const;
+// fix(#1625): the outline is a line layer with no per-feature opacity of its own, so
+// the master slider rides on `line-layer-opacity` here too — shared polygon edges
+// are drawn once per polygon and double-darkened under `line-opacity`. Registered
+// here because `syncOwnedPaintProperties` only reconciles keys in this set: an
+// unregistered key is written once by addLayers and never updated again.
+export const OUTLINE_OWNED_PAINT_PROPERTIES = ['line-color', 'line-width', 'line-layer-opacity'] as const;
 // builder-audit #338 SPEC-11: 3D extrusion authoring is a DELIBERATE single-purpose subset
 // (column height only). fill-extrusion-base is intentionally fixed to 0 and
 // fill-extrusion-pattern / -translate / -translate-anchor are intentionally NOT authored;
@@ -180,7 +185,7 @@ export const fillAdapter: LayerAdapter = {
         },
         ...(visible === false ? { layout: { visibility: 'none' as const } } : {}),
       });
-      map.setPaintProperty(outlineId, 'line-opacity', opacity ?? 1);
+      map.setPaintProperty(outlineId, 'line-layer-opacity', opacity ?? 1);
       // strokeDisabled hides the outline regardless of layer visibility.
       // When the layer is hidden we leave the outline hidden too (it cannot be
       // visible while its parent is none); when the layer is visible, we
@@ -226,7 +231,7 @@ export const fillAdapter: LayerAdapter = {
         geomType: 'fill',
         ownedProperties: FILL_OWNED_PAINT_PROPERTIES,
       });
-      map.setPaintProperty(layerId, 'fill-opacity', getExpressionSafeOpacity(rawPaint, 'fill', opacity ?? 1));
+      applyMasterOpacity(map, layerId, rawPaint, 'fill', opacity ?? 1);
       syncLayerFilter(map, layerId, filter);
       const strokeDisabled = builder.strokeDisabled ?? !!rawPaint['_stroke-disabled'];
       const outlineColor = (builder.outlineColor ?? rawPaint['_outline-color'] ?? rawPaint['outline-color']) as string | undefined;
@@ -240,7 +245,7 @@ export const fillAdapter: LayerAdapter = {
       syncOwnedPaintProperties(map, outlineId, {
         'line-color': typeof outlineColor === 'string' ? outlineColor : MAP_COLORS.default.stroke,
         'line-width': typeof outlineWidth === 'number' ? outlineWidth : 1,
-        'line-opacity': opacity ?? 1,
+        'line-layer-opacity': opacity ?? 1,
       }, {
         geomType: 'line',
         ownedProperties: OUTLINE_OWNED_PAINT_PROPERTIES,

--- a/frontend/src/components/builder/layer-adapters/index.ts
+++ b/frontend/src/components/builder/layer-adapters/index.ts
@@ -1,5 +1,5 @@
 export type { AdapterLayerInput, LayerAdapter } from './types';
-export { simplifyPaint, getCompoundOpacity, stripCustomProps, filterPaintForLayerType, resolveAdapterType } from './shared';
+export { simplifyPaint, applyMasterOpacity, stripCustomProps, filterPaintForLayerType, resolveAdapterType } from './shared';
 export { getAdapter } from './registry';
 export { fillAdapter } from './fill-adapter';
 export { lineAdapter } from './line-adapter';

--- a/frontend/src/components/builder/layer-adapters/line-adapter.ts
+++ b/frontend/src/components/builder/layer-adapters/line-adapter.ts
@@ -5,7 +5,7 @@ import {
   filterPaintForLayerType,
   finalizeLayer,
   getBuilderStyleConfig,
-  getExpressionSafeOpacity,
+  applyMasterOpacity,
   syncOwnedLayoutProperties,
   syncOwnedPaintProperties,
   syncSingleLayerVisibility,
@@ -225,7 +225,7 @@ export const lineAdapter: LayerAdapter = {
       geomType: 'line',
       ownedProperties: LINE_OWNED_PAINT_PROPERTIES,
     });
-    map.setPaintProperty(layerId, 'line-opacity', getExpressionSafeOpacity(rawPaint, 'line', opacity ?? 1));
+    applyMasterOpacity(map, layerId, rawPaint, 'line', opacity ?? 1);
     // Phase 1136 EDITOR-LINE-01/02: reconcile owned layout properties (line-cap, line-join)
     // clearMissing: false — addLayers hardcodes 'round'/'round' as defaults; when the stored
     // layout does not carry cap/join, leave the map's current value intact rather than

--- a/frontend/src/components/builder/layer-adapters/mixed-adapter.ts
+++ b/frontend/src/components/builder/layer-adapters/mixed-adapter.ts
@@ -6,7 +6,7 @@ import {
   filterPaintForLayerType,
   finalizeLayer,
   getBuilderStyleConfig,
-  getExpressionSafeOpacity,
+  applyMasterOpacity,
   syncOwnedLayoutProperties,
   syncOwnedPaintProperties,
   syncSingleLayerVisibility,
@@ -122,7 +122,7 @@ function mixedOutlinePaint(input: AdapterLayerInput): Record<string, unknown> {
   return {
     'line-color': MAP_COLORS.default.stroke,
     'line-width': 1,
-    'line-opacity': input.opacity ?? 1,
+    'line-layer-opacity': input.opacity ?? 1,
   };
 }
 
@@ -223,7 +223,7 @@ function syncFillLayer(map: MaplibreMap, input: AdapterLayerInput) {
     geomType: 'fill',
     ownedProperties: FILL_OWNED_PAINT_PROPERTIES,
   });
-  map.setPaintProperty(input.layerId, 'fill-opacity', getExpressionSafeOpacity(input.paint, 'fill', input.opacity ?? 1));
+  applyMasterOpacity(map, input.layerId, input.paint, 'fill', input.opacity ?? 1);
   map.setFilter(input.layerId, mixedFamilyFilter('polygon', input.filter));
 }
 
@@ -251,7 +251,7 @@ function syncLinesLayer(map: MaplibreMap, input: AdapterLayerInput) {
     ownedProperties: LINE_OWNED_LAYOUT_PROPERTIES,
     clearMissing: false,
   });
-  map.setPaintProperty(id, 'line-opacity', getExpressionSafeOpacity(input.paint, 'line', input.opacity ?? 1));
+  applyMasterOpacity(map, id, input.paint, 'line', input.opacity ?? 1);
   map.setFilter(id, mixedFamilyFilter('line', input.filter));
 }
 
@@ -262,7 +262,8 @@ function syncPointsLayer(map: MaplibreMap, input: AdapterLayerInput) {
     geomType: 'circle',
     ownedProperties: CIRCLE_OWNED_PAINT_PROPERTIES,
   });
-  map.setPaintProperty(id, 'circle-opacity', getExpressionSafeOpacity(input.paint, 'circle', input.opacity ?? 1));
+  // The point sublayer keeps the multiply path: circle has no -layer-opacity (#1625).
+  applyMasterOpacity(map, id, input.paint, 'circle', input.opacity ?? 1);
   map.setFilter(id, mixedFamilyFilter('point', input.filter));
 }
 

--- a/frontend/src/components/builder/layer-adapters/shared.ts
+++ b/frontend/src/components/builder/layer-adapters/shared.ts
@@ -148,45 +148,84 @@ const OPACITY_DEFAULTS: Record<string, number> = {
   circle: 1,
 };
 
-export function getCompoundOpacity(
-  paint: Record<string, unknown>,
-  geomType: 'fill' | 'line' | 'circle',
-  masterOpacity: number,
-): number {
-  const propKey = `${geomType}-opacity`;
-  const propOpacity = (paint[propKey] as number) ?? OPACITY_DEFAULTS[geomType];
-  return propOpacity * masterOpacity;
-}
-
 /**
+ * Per-feature opacity MULTIPLIED by the master slider, as one paint value.
+ *
+ * fix(#1625): this is now the path for layer types that have no `-layer-opacity`
+ * in maplibre-gl v6 (circle, and the cluster/mixed point sublayers). Fill and
+ * line go through `applyMasterOpacity`, which keeps the two tiers apart.
+ *
  * fix(#846): every call site feeds this straight into `setPaintProperty(id,
  * '<geom>-opacity', …)`, which maplibre-gl v6 types as
  * `DataDrivenPropertyValueSpecification<number>`. Declaring that contract here
- * instead of returning `unknown` fixes all eight call sites at their source, and
- * leaves exactly one place — the array branch below — where the untyped paint JSON
- * has to be vouched for.
+ * instead of returning `unknown` fixes the call sites at their source, and
+ * leaves exactly one place — the array branch in `getFeatureOpacity` — where the
+ * untyped paint JSON has to be vouched for.
  */
 export function getExpressionSafeOpacity(
   paint: Record<string, unknown>,
   geomType: 'fill' | 'line' | 'circle',
   masterOpacity: number,
 ): DataDrivenPropertyValueSpecification<number> {
-  const propKey = `${geomType}-opacity`;
-  const propOpacity = paint[propKey];
+  const propOpacity = getFeatureOpacity(paint, geomType);
+  if (typeof propOpacity === 'number') return propOpacity * masterOpacity;
+  // fix(#394) ST-03: multiply expression-valued opacity by the master
+  // slider — returning the expression untouched made the layer opacity
+  // slider a silent no-op whenever *-opacity is a zoom/data expression.
+  return (masterOpacity === 1
+    ? propOpacity
+    : ['*', propOpacity, masterOpacity]) as DataDrivenPropertyValueSpecification<number>;
+}
+
+/**
+ * The per-feature `<geom>-opacity` exactly as the Style Editor stored it, with
+ * the builder default when the key is absent. Never multiplied by the master slider.
+ * The array is whatever the saved style holds, so it is asserted, not proven —
+ * MapLibre rejects a malformed expression at runtime exactly as it always has.
+ */
+export function getFeatureOpacity(
+  paint: Record<string, unknown>,
+  geomType: 'fill' | 'line' | 'circle',
+): DataDrivenPropertyValueSpecification<number> {
+  const propOpacity = paint[`${geomType}-opacity`];
   if (Array.isArray(propOpacity)) {
-    // fix(#394) ST-03: multiply expression-valued opacity by the master
-    // slider — returning the expression untouched made the layer opacity
-    // slider a silent no-op whenever *-opacity is a zoom/data expression.
-    // The array is whatever the saved style holds, so it is asserted, not proven —
-    // MapLibre rejects a malformed expression at runtime exactly as it always has.
-    return (masterOpacity === 1
-      ? propOpacity
-      : ['*', propOpacity, masterOpacity]) as DataDrivenPropertyValueSpecification<number>;
+    return propOpacity as DataDrivenPropertyValueSpecification<number>;
   }
-  if (typeof propOpacity === 'number') {
-    return propOpacity * masterOpacity;
+  if (typeof propOpacity === 'number') return propOpacity;
+  return OPACITY_DEFAULTS[geomType];
+}
+
+/**
+ * fix(#1625): drive the master `layer.opacity` slider on a live vector layer.
+ *
+ * Fill and line layers carry two opacity tiers — the Style Editor's per-feature
+ * `fill-opacity`/`line-opacity` and the master slider — and multiplying them into
+ * one per-feature value (the pre-#1625 wiring) made MapLibre accumulate the
+ * product across overlapping features, so overlaps inside a layer double-darkened
+ * and the slider never produced a uniform layer. maplibre-gl v6's
+ * `fill-layer-opacity`/`line-layer-opacity` composite the whole layer once AFTER
+ * the per-feature pass, which is exactly the two-tier model: per-feature stays on
+ * `<geom>-opacity` unmultiplied, the master rides on `<geom>-layer-opacity`.
+ *
+ * Every master-opacity write for a fill/line/circle layer goes through here —
+ * addLayers (via finalizeLayer), syncPaint, and the slider's direct path in
+ * use-layer-map-sync — so the split cannot drift between entry points.
+ */
+export function applyMasterOpacity(
+  map: Pick<MaplibreMap, 'setPaintProperty'>,
+  layerId: string,
+  paint: Record<string, unknown>,
+  geomType: 'fill' | 'line' | 'circle',
+  masterOpacity: number,
+): void {
+  if (geomType === 'circle') {
+    // fix(#1625) ceiling: only fill/line have a -layer-opacity in maplibre 6;
+    // other types still multiply, so point layers still double-darken.
+    map.setPaintProperty(layerId, 'circle-opacity', getExpressionSafeOpacity(paint, 'circle', masterOpacity));
+    return;
   }
-  return OPACITY_DEFAULTS[geomType] * masterOpacity;
+  map.setPaintProperty(layerId, `${geomType}-opacity`, getFeatureOpacity(paint, geomType));
+  map.setPaintProperty(layerId, `${geomType}-layer-opacity`, masterOpacity);
 }
 
 /** Strip custom paint properties that are not valid MapLibre paint props. */
@@ -350,7 +389,7 @@ export function finalizeLayer(
 ) {
   if (!map.getLayer(layerId)) return;
   if (hasExpressions) replayExpressions(map, layerId, rawPaint, geomType);
-  map.setPaintProperty(layerId, `${geomType}-opacity`, getExpressionSafeOpacity(rawPaint, geomType, masterOpacity));
+  applyMasterOpacity(map, layerId, rawPaint, geomType, masterOpacity);
   if (filter && Array.isArray(filter) && filter.length > 0) {
     map.setFilter(layerId, filter);
   }

--- a/frontend/src/components/builder/map-sync.ts
+++ b/frontend/src/components/builder/map-sync.ts
@@ -51,7 +51,7 @@ export {
   getLayerType,
   resolveAdapterType,
   simplifyPaint,
-  getCompoundOpacity,
+  applyMasterOpacity,
   getExpressionSafeOpacity,
   stripCustomProps,
   filterPaintForLayerType,


### PR DESCRIPTION
## What changed

A vector layer has two opacity controls: the Style Editor writes per-feature `fill-opacity` / `line-opacity`, and the master slider writes `layer.opacity`. The builder multiplied them into one per-feature paint value, so MapLibre accumulated that product wherever two features in the same layer overlapped. The overlap drew darker and a layer at 50% was never uniformly 50%.

### Builder (#1625)

The master slider now rides on maplibre-gl v6's `fill-layer-opacity` and `line-layer-opacity`, which composite the whole layer once after the per-feature pass. Per-feature opacity is written as stored, unmultiplied. One helper, `applyMasterOpacity()` in `layer-adapters/shared.ts`, owns the split, and every master write goes through it: `finalizeLayer` (addLayers), each adapter's `syncPaint`, and the slider's direct path in `use-layer-map-sync.ts`.

Circle keeps the old multiply, because v6 has no `circle-layer-opacity`. The ceiling is named in one comment at the branch point in `applyMasterOpacity`. The cluster adapter and the mixed adapter's point sublayer take that branch; the mixed adapter's fill, lines and outline sublayers take the layer-opacity branch.

The fill and mixed outline companions move to `line-layer-opacity` too, so shared polygon edges stop double-darkening. That meant swapping `line-opacity` for `line-layer-opacity` in `OUTLINE_OWNED_PAINT_PROPERTIES`, which is the registry gate the issue describes: `syncOwnedPaintProperties` only reconciles keys in that tuple, so an unregistered key would be written once at addLayers and never updated.

`getCompoundOpacity` is removed. Its only caller was the slider path, and it was not expression safe (an array times a number is NaN).

### Export and import (#1626)

`_style_layer_for_map_layer` copied `layer.paint` through verbatim and never applied `layer.opacity` to the primary layer, while the outline, extrusion and icon companions did. The new `_fold_master_opacity` applies it to the primary fill or line layer.

It folds instead of emitting the v6 keys, and the docstring records why. I checked the maplibre-gl 5.24.0 build that shipped before #1624 (`npm pack maplibre-gl@5.24.0`, `dist/maplibre-gl-dev.js`): `validateProperty` returns `unknown property "<key>"` as a `ValidationError` (line 20927), `emitValidationErrors` has no severity concept and reports any error (22316), and `Style._load` returns before installing a single source or layer (59984). In 6.5.0 the same path exists with severity defaulting to `error` (`src/style/validate_style.ts:84`, `style-spec/src/error/validation_error.ts`). A style.json carrying `fill-layer-opacity` would fail to load at all on an older consumer, so the export never emits it.

The fold is the same arithmetic the pre-change adapter used: a number times the master, an expression wrapped in `["*", expr, master]`, and an absent or wrong-typed value treated as the spec default of 1. At `layer.opacity == 1` the primary paint is untouched, so existing exports stay bit-identical.

The un-folded per-feature value travels in `metadata.geolens.feature_opacity` (`null` when the stored paint had none). `_restore_master_opacity` in `style_import.py` puts it back, so a GeoLens round trip keeps both tiers and does not apply the master twice. The same function maps a v6 `fill-layer-opacity` / `line-layer-opacity` onto `layer.opacity` (a number composes with the metadata opacity; an expression has no scalar home and is dropped with an `unsupported_layer_opacity` warning).

One deviation from the task brief: the two keys are deliberately NOT added to `_PAINT_PROPERTIES_BY_TYPE`. The import path never consults that allowlist (it runs `clean_paint`, which only strips `_` keys), so registering there would not have helped import. It would instead have let an API-stored `fill-layer-opacity` leak into a document older consumers reject. The allowlist carries a comment saying so, and a test pins the strip.

### Other

- CHANGELOG entries under Unreleased.
- `test_layering.py` caps: `style_json.py` 1641 to 1694, `style_import.py` 450 to 493, with comments saying what the lines bought.
- The ceiling comment uses `fix(#1625) ceiling:` rather than the `ponytail:` marker the brief asked for, because the repo's pre-commit hook rejects a bare `ponytail:` tag (AGENTS.md inline-comment convention).

## Schema / API / config impact

No schema change, no migration, no OpenAPI change (`dump_openapi.py --check` passes). `layer.opacity` and `paint['*-opacity']` keep their values and their meaning. style.json gains one private metadata key (`feature_opacity`) on folded layers only. The import summary can carry a new warning code, `unsupported_layer_opacity`.

Closes #1625
Closes #1626

## Verification

Frontend (`cd frontend`):

- `npm run lint`: clean
- `npm run typecheck`: clean
- `npm run build`: built
- `npx vitest run`: 411 files, 5465 tests passed

Backend (worktree `.env.test`, Postgres on :5434):

- `pytest tests/test_maps_style_json.py tests/test_phase_275_maps_import_typed_body.py tests/test_maps.py tests/test_basemap_sublayer_overrides.py tests/test_builder_alias_keys_drift.py tests/test_layering.py tests/test_raster_tile_url_version_1372.py -n 4`: all passed
- `uv run ruff check .` and `uv run ruff format --check .`: clean
- `PYTHONPATH=. uv run python scripts/dump_openapi.py --check`: exit 0

Counterfactuals (each change reverted in isolation, then restored):

- `applyMasterOpacity` made to multiply fill/line again: 13 frontend tests fail (fill, line, mixed, shared, hook, and the two updated pins in `layer-adapters.test.ts`).
- `line-layer-opacity` removed from `OUTLINE_OWNED_PAINT_PROPERTIES`: 2 fail (fill syncPaint-after-addLayer, mixed syncPaint).
- `applyMasterOpacity` call removed from fill `syncPaint`: 1 fails (the registry-gate test).
- circle routed through the layer-opacity branch: 7 fail.
- slider path reverted to a direct multiplied `setPaintProperty`: 1 fails (the hook test).
- export fold call removed: 5 backend tests fail.
- import ignores `feature_opacity`: the 4 round-trip cases and the compose test fail.
- import leaves `-layer-opacity` in paint: 3 fail.
- `fill-layer-opacity` added to the emission allowlist: 1 fails (the strip test).

Visual check. Worktree Vite on :5174 against the main API on :8001, headless Playwright, a seeded dataset of two overlapping squares on a map at master opacity 0.5, compared with main's frontend on :8080 against the same API. 9x9 pixel averages, RGB:

| per-feature `fill-opacity` | build | overlap | west square only |
|---|---|---|---|
| 0.8 | main :8080 (before) | (110, 150, 236) | (159, 184, 237) |
| 0.8 | worktree :5174 (after) | (142, 172, 237) | (159, 184, 237) |
| 1.0 | main :8080 (before) | (88, 134, 236) | (139, 170, 237) |
| 1.0 | worktree :5174 (after) | (138, 170, 237) | (139, 170, 237) |

Single-feature pixels are identical across the two builds. With per-feature 1.0 the overlap matches the rest of the layer to within one unit. With per-feature 0.8 a small difference remains, which is the per-feature tier accumulating (0.8 and 0.96 coverage) before the layer composite; that is the v6 spec behaviour and the per-feature slider's own meaning. The seeded map and dataset were deleted afterwards.
