### PR TITLE
fix(dataset): keep an inline cell edit alive across re-renders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,17 @@ and releases use semantic versioning.
   text. Both components now call one shared formatter, so an object or array
   property renders the same way in either place (#1627).
 
+- **Editing an attribute cell no longer loses what you typed.** The dataset
+  Data tab rebuilt its column definitions on every render, and because
+  TanStack Table renders a column's `cell` function as a React component type,
+  that rebuild remounted every cell instead of re-rendering it. An open cell
+  editor was reset to the stored value, so a save started from a re-render —
+  the map above finishing its load, a background query settling — wrote
+  nothing and showed nothing: no update, no rejection message, the editor just
+  closed. Column definitions are now stable, so an in-progress edit survives
+  unrelated renders, and a value the backend or the type check rejects stays
+  in the box to be corrected (#1628).
+
 ## [1.14.2] - 2026-08-21
 
 ### Added

--- a/e2e/feature-editing.spec.ts
+++ b/e2e/feature-editing.spec.ts
@@ -138,6 +138,12 @@ test.describe('Feature editing round-trips', () => {
     const input = page.locator('tbody input');
     await expect(input).toBeVisible();
     await input.fill(nextValue);
+    // fix(#1628): assert the editor is actually holding the new value before
+    // committing. When a re-render used to remount the cell it silently reset
+    // the input to the stored value, and Enter then took the unchanged-value
+    // branch — no PATCH, no toast. The failure surfaced 10s later as "Cell
+    // updated never appeared", which named the wrong thing.
+    await expect(input).toHaveValue(nextValue);
     await input.press('Enter');
     await expect(page.getByText('Cell updated').first()).toBeVisible({
       timeout: 10_000,
@@ -175,6 +181,9 @@ test.describe('Feature editing round-trips', () => {
     await cell.click();
     const input = page.locator('tbody input');
     await input.fill('not-a-number');
+    // fix(#1628): same precondition as editCell — a reset editor would make
+    // Enter a no-op cancel and the rejection message would never be reached.
+    await expect(input).toHaveValue('not-a-number');
     await input.press('Enter');
     await expect(page.getByText(/not a valid/i).first()).toBeVisible({
       timeout: 10_000,

--- a/frontend/src/components/dataset/AttributeTable.tsx
+++ b/frontend/src/components/dataset/AttributeTable.tsx
@@ -103,10 +103,16 @@ function InlineCellEditor({
   const [value, setValue] = useState(initialValue);
   const errorId = useId();
 
+  // fix(#1628): keyed on isSaving, not []. The saving branch below swaps the
+  // input out for a spinner, and a save that fails leaves the editor open —
+  // before #1628 the editor was remounted wholesale on every render, so this
+  // effect happened to re-run and put the caret back. It no longer remounts,
+  // so re-focus explicitly when the input comes back.
   useEffect(() => {
+    if (isSaving) return;
     inputRef.current?.focus();
     inputRef.current?.select();
-  }, []);
+  }, [isSaving]);
 
   // fix(#458 E-35): an unchanged value is a cancel, not a save — blur used to
   // commit a no-op PATCH that bumped updated_at, rolled the tile version, and
@@ -167,8 +173,6 @@ export function AttributeTable({ datasetId, canEdit = false, compact = false }: 
   const [cursorHistory, setCursorHistory] = useState<number[]>([0]);
   const [editingCell, setEditingCell] = useState<EditingCell | null>(null);
   const [editError, setEditError] = useState<string | null>(null);
-  const editingCellRef = useRef<EditingCell | null>(null);
-  editingCellRef.current = editingCell;
   // Scroll container ref used by the row virtualizer (PERF-07).
   const parentRef = useRef<HTMLDivElement>(null);
   const [columnFilters, setColumnFilters] = useState<Record<string, string>>({});
@@ -246,6 +250,38 @@ export function AttributeTable({ datasetId, canEdit = false, compact = false }: 
     }
   }, [datasetId, updateFeature, t]);
 
+  // fix(#1628): everything the cell renderer needs that changes from render to
+  // render, read through one ref so `columns` below never has to list it.
+  //
+  // TanStack's `<table.FlexRender cell={cell} />` renders `columnDef.cell` as
+  // the React component TYPE (`React.createElement(def.cell, ctx)`), so a new
+  // `columns` array is a new element type at every cell position and React
+  // unmounts and remounts the whole cell subtree instead of re-rendering it.
+  // That resets InlineCellEditor's `value` state back to the stored cell value.
+  // `columns` used to depend on `handleCellSave`, whose own dep list carries
+  // the object react-query's useMutation returns — and that is rebuilt on
+  // EVERY render (`return { ...result, mutate, mutateAsync: result.mutate }`,
+  // react-query 5.101 useMutation.ts). So any re-render at all, from anywhere
+  // in the page, silently threw away what the user had typed into an open
+  // cell editor. Enter then hit commit()'s value === initialValue branch: no
+  // PATCH, no validation message, editor just closes. That is the #1628 e2e
+  // flake, and the same reset also defeated the "keep the editor open so the
+  // value can be corrected" behaviour of E-03/E-21 for real users.
+  //
+  // Reading state from a ref during render is the pattern this component
+  // already used for `editingCell`: the ref is written in this render pass,
+  // before FlexRender renders the cells that read it.
+  const cellRenderState = {
+    editingCell,
+    editError,
+    isSaving: updateFeature.isPending,
+    canEdit,
+    compact,
+    onSave: handleCellSave,
+  };
+  const cellRenderRef = useRef(cellRenderState);
+  cellRenderRef.current = cellRenderState;
+
   const handleNextPage = useCallback(() => {
     if (data?.next_cursor != null) {
       setCursorHistory((prev) => [...prev, data.next_cursor!]);
@@ -268,9 +304,16 @@ export function AttributeTable({ datasetId, canEdit = false, compact = false }: 
       accessorKey: col.name,
       header: `${col.name} (${col.type})`,
       cell: (info) => {
+        const {
+          editingCell: currentEdit,
+          editError: cellError,
+          isSaving,
+          canEdit: cellsEditable,
+          compact: isCompact,
+          onSave,
+        } = cellRenderRef.current;
         const rowData = info.row.original;
         const gid = rowData.gid as number;
-        const currentEdit = editingCellRef.current;
         const isEditing =
           currentEdit?.rowGid === gid && currentEdit?.column === col.name;
 
@@ -284,21 +327,21 @@ export function AttributeTable({ datasetId, canEdit = false, compact = false }: 
                 defaultValue: 'Edit {{column}} for feature {{gid}}',
               })}
               colType={col.type}
-              error={editError}
-              onSave={(val) => handleCellSave(gid, col.name, col.type, val)}
+              error={cellError}
+              onSave={(val) => onSave(gid, col.name, col.type, val)}
               onCancel={() => {
                 setEditError(null);
                 setEditingCell(null);
               }}
-              isSaving={updateFeature.isPending}
-              compact={compact}
+              isSaving={isSaving}
+              compact={isCompact}
             />
           );
         }
 
         const cellValue = String(info.getValue() ?? '');
 
-        if (canEdit && !NON_EDITABLE_COLUMNS.has(col.name)) {
+        if (cellsEditable && !NON_EDITABLE_COLUMNS.has(col.name)) {
           return (
             <button
               type="button"
@@ -327,7 +370,13 @@ export function AttributeTable({ datasetId, canEdit = false, compact = false }: 
         return cellValue;
       },
     }));
-  }, [data?.columns, canEdit, compact, handleCellSave, updateFeature.isPending, editError, t]);
+    // fix(#1628): the column list and `t` ONLY. Every other input the renderer
+    // needs comes from cellRenderRef, because adding any of them back here
+    // remounts every cell — and with it any open editor — whenever they change.
+    // `t` is safe to keep: react-i18next caches its useSyncExternalStore
+    // snapshot and only hands back a new `t` on a language change, which is a
+    // legitimate reason to rebuild the columns.
+  }, [data?.columns, t]);
 
   const table = useTable(
     {

--- a/frontend/src/components/dataset/__tests__/AttributeTable.cell-editor.test.tsx
+++ b/frontend/src/components/dataset/__tests__/AttributeTable.cell-editor.test.tsx
@@ -90,4 +90,30 @@ describe('fix(#1628): inline cell editor survives an unrelated re-render', () =>
     expect(afterRerender).toBe(editor);
     expect(afterRerender).toHaveValue('250');
   });
+
+  // fix(#458 E-03/E-39) says a rejected value stays in the box to be
+  // corrected. Setting editError re-rendered AttributeTable, which rebuilt
+  // `columns`, which remounted the editor — so the rejected text was replaced
+  // by the old value and only the message survived.
+  it('keeps a rejected value in the editor and marks the field invalid', async () => {
+    const user = userEvent.setup();
+    render(<AttributeTable datasetId="ds-1628" canEdit />);
+
+    await user.click(screen.getByRole('button', { name: '100' }));
+
+    const editor = screen.getByRole('textbox', { name: 'Edit population for feature 1' });
+    await user.clear(editor);
+    await user.type(editor, 'not-a-number');
+    await user.keyboard('{Enter}');
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      'Not a valid integer value',
+    );
+    const afterReject = screen.getByRole('textbox', {
+      name: 'Edit population for feature 1',
+    });
+    expect(afterReject).toBe(editor);
+    expect(afterReject).toHaveValue('not-a-number');
+    expect(afterReject).toHaveAttribute('aria-invalid', 'true');
+  });
 });

--- a/frontend/src/components/dataset/__tests__/AttributeTable.cell-editor.test.tsx
+++ b/frontend/src/components/dataset/__tests__/AttributeTable.cell-editor.test.tsx
@@ -1,0 +1,93 @@
+/**
+ * fix(#1628): an in-progress inline cell edit must survive an unrelated
+ * re-render of AttributeTable.
+ *
+ * TanStack's `<table.FlexRender cell={cell} />` renders `columnDef.cell` as the
+ * React component TYPE, so rebuilding the `columns` array gives every cell a
+ * new element type and React remounts the cell subtree instead of re-rendering
+ * it — wiping InlineCellEditor's `value` state back to the stored cell value.
+ * `columns` used to list `handleCellSave`, whose dep list carries the object
+ * react-query's `useMutation` returns, and that object is rebuilt on every
+ * render. So any re-render at all discarded what the user had typed, and the
+ * following Enter took commit()'s `value === initialValue` branch: no PATCH,
+ * no validation message, editor silently closed. That is the intermittent
+ * failure e2e/feature-editing.spec.ts kept hitting.
+ *
+ * `useUpdateFeature` is deliberately NOT mocked here — the real react-query
+ * `useMutation` identity churn is the trigger under test, and a hand-stubbed
+ * hook returning one frozen object would make this pass against the bug.
+ *
+ * `useVirtualizer` IS mocked: jsdom computes no layout, so the real
+ * virtualizer's measured viewport is 0px tall and it renders no body rows at
+ * all (see the note at the top of AttributeTable.test.tsx). The stub windows
+ * nothing and hands back every row, which is what this suite needs to reach a
+ * body cell.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import userEvent from '@testing-library/user-event';
+import { render, screen } from '@/test/test-utils';
+import { AttributeTable } from '@/components/dataset/AttributeTable';
+import { useDatasetRows } from '@/components/dataset/hooks/use-dataset';
+
+vi.mock('@/components/dataset/hooks/use-dataset', () => ({
+  useDatasetRows: vi.fn(),
+}));
+// Pass the debounced value straight through, as AttributeTable.test.tsx does.
+vi.mock('@/hooks/use-debounce', () => ({
+  useDebouncedValue: (value: unknown) => value,
+}));
+vi.mock('@tanstack/react-virtual', () => ({
+  useVirtualizer: ({ count, estimateSize }: { count: number; estimateSize: () => number }) => ({
+    getVirtualItems: () =>
+      Array.from({ length: count }, (_, index) => ({
+        index,
+        key: index,
+        start: index * estimateSize(),
+        size: estimateSize(),
+      })),
+    getTotalSize: () => count * estimateSize(),
+    measure: () => {},
+  }),
+}));
+
+const ROWS_RESPONSE = {
+  columns: [{ name: 'population', type: 'integer' }],
+  rows: [{ gid: 1, population: 100 }],
+  next_cursor: null,
+  approximate_total: 1,
+};
+
+describe('fix(#1628): inline cell editor survives an unrelated re-render', () => {
+  beforeEach(() => {
+    vi.mocked(useDatasetRows).mockReturnValue({
+      data: ROWS_RESPONSE,
+      isLoading: false,
+      isFetching: false,
+      isError: false,
+    } as unknown as ReturnType<typeof useDatasetRows>);
+  });
+
+  it('keeps the typed value, and the same input element, across a re-render', async () => {
+    const user = userEvent.setup();
+    const { rerender } = render(<AttributeTable datasetId="ds-1628" canEdit />);
+
+    await user.click(screen.getByRole('button', { name: '100' }));
+
+    const editor = screen.getByRole('textbox', { name: 'Edit population for feature 1' });
+    await user.clear(editor);
+    await user.type(editor, '250');
+    expect(editor).toHaveValue('250');
+
+    // Any render of AttributeTable at all — a sibling query settling, the map
+    // above finishing its load, a parent state change.
+    rerender(<AttributeTable datasetId="ds-1628" canEdit />);
+
+    const afterRerender = screen.getByRole('textbox', {
+      name: 'Edit population for feature 1',
+    });
+    // Identity: a remount is the mechanism, so pin the element itself, not
+    // just the symptom.
+    expect(afterRerender).toBe(editor);
+    expect(afterRerender).toHaveValue('250');
+  });
+});


### PR DESCRIPTION
## What

`e2e/feature-editing.spec.ts` failed about one run in five. The reading in #1628, a race between dataset creation and the Data tab rendering the seeded rows, turns out to be wrong. The seeded cell always rendered. Every failure I captured happened after `input.press('Enter')`, at the assertion for either the "Cell updated" toast or the rejection message, with the table still showing the original value and no editor open.

## Root cause

`AttributeTable` rebuilt its `columns` array on every render, and TanStack Table renders `columnDef.cell` as the React component *type* (`FlexRender` calls `React.createElement(def.cell, ctx)`). A new `columns` array is a new element type at every cell position, so React unmounts and remounts the cell subtree instead of re-rendering it, and `InlineCellEditor`'s `value` state goes back to the stored cell value.

The rebuild was unconditional. `columns` listed `handleCellSave`, which in turn lists `updateFeature`, the object react-query's `useMutation` returns. That object is rebuilt on every render (`return { ...result, mutate, mutateAsync: result.mutate }`, react-query 5.101 `useMutation.ts`).

So any render at all between opening a cell editor and pressing Enter discarded what had been typed. Enter then compared the restored value against `initialValue`, took `commit()`'s unchanged-value branch, and closed the editor. No PATCH, no validation message, nothing to assert on. The window between the click and Enter is roughly 100 ms, which is why this was load-sensitive rather than deterministic.

I measured it with a requestAnimationFrame probe injected into the page that stamped every ancestor of the editor input. At the failure the `<td>` kept its identity and only the `<input>` was replaced, with the value back at `100`:

```
1174 ms  val='not-a-number'  input#1  < td#2 < tr#3 < tbody#4 ...
1242 ms  val='100'           input#18 < td#2 < tr#3 < tbody#4 ...
```

No request landed in that window, so the trigger was a plain client-side render.

Real users hit this too. The same reset defeats the "keep the editor open so the value can be corrected" behaviour of #458 E-03 and E-21: a value the type check or the backend rejected was silently replaced by the old one.

## Change

- `columns` now depends on the column list and `t` only. Everything else the renderer needs (`editingCell`, `editError`, `isSaving`, `canEdit`, `compact`, the save handler) is read from one ref during render, which extends the pattern the component already used for `editingCell`.
- `InlineCellEditor`'s focus effect is keyed on `isSaving`. The saving branch swaps the input for a spinner, and the accidental remount is what used to put the caret back afterwards.
- The e2e spec asserts the editor holds the new value before pressing Enter. That is diagnostics, not a fix: it caught the reset in 2 of the 5 reverted-control failures, and the other 3 slipped through in the gap between that assertion and the keypress. The spec is still in no smoke subset.
- New vitest suite `AttributeTable.cell-editor.test.tsx`. It does not mock `useUpdateFeature` on purpose: the real react-query identity churn is the trigger under test, and a stub returning one frozen object would pass against the bug.

## Schema / API / config impact

None. Frontend plus the e2e spec.

Closes #1628

## Verification

Backend untouched, so no backend gates.

| command | result |
|---|---|
| `cd frontend && npm run typecheck` | pass |
| `cd frontend && npm run lint` | pass |
| `cd frontend && npm run build` | pass |
| `cd frontend && npx vitest run` | 412 files, 5448 tests, all pass |

E2E was `npx playwright test e2e/feature-editing.spec.ts --project=chromium`, one full spec run per row. Worktree frontend code needs the host-Vite recipe from AGENTS.md, so the branch rows went through Vite on `:5175` with `API_PROXY_TARGET=http://localhost:8001`. The baseline row ran against the shared `:8080` stack, which serves `main`.

| condition | stack | runs | runs with failures |
|---|---|---|---|
| `main`, before the fix | `:8080` (main checkout) | 8 | 4 |
| with the fix | `:5175` (this branch) | 15 | 0 |
| fix reverted, spec kept | `:5175` (this branch) | 10 | 5 |

The failures covered all three tests named in the issue, in the same shape every time: the assertion after Enter, with the table still showing the seeded value. The reverted control failed at a higher rate than the one-in-five reported in the issue because the machine was running three other agents at the time. The reverted block ran between the two with-fix blocks (5 with, 10 reverted, 10 with) on the same stack within the same hour, so the two rows are comparable.

Unit counterfactual: with `AttributeTable.tsx` reverted (patch file, not a stash) the new vitest case fails on both assertions, `expected <input> to be <input>` for element identity and `expected the element to have value 250, received 100` for the typed value.
