### PR TITLE
test(auth): derive the grace-window race tolerance from the stall it discriminates

### DIFF
--- a/backend/tests/test_auth_refresh_cookies_1302.py
+++ b/backend/tests/test_auth_refresh_cookies_1302.py
@@ -737,12 +737,27 @@ class TestGraceWindowCannotRatchetOpen:
         ).scalar_one()
         # Retired to about one grace window measured from the START, NOT to the
         # original multi-day lifetime and not to a cutoff the queued caller
-        # pushed out by its own stall. The tolerance sits well under the stall,
-        # so a ratchet is unambiguous.
+        # pushed out by its own stall.
+        #
+        # The two outcomes this assertion separates:
+        #   no ratchet — overshoot is the winner's pre-lock latency: request
+        #     routing and scheduling jitter, milliseconds on an idle machine
+        #     but over a second on a loaded CI runner;
+        #   ratchet    — the queued caller waited out the winner's stall
+        #     before writing, so its cutoff overshoots by AT LEAST
+        #     stall_seconds (2.5s) plus its own latency.
+        # The discriminating signal is therefore stall_seconds, and the
+        # tolerance must be derived from it, sitting far enough below it to
+        # keep a ratchet unambiguous and far enough above observed scheduling
+        # jitter not to fire on load. A literal 1s failed exactly that way: a
+        # merge-group run under full xdist load measured 1.01s of legitimate
+        # winner latency and ejected an unrelated PR from the merge queue.
         overshoot = (row - started_at).total_seconds() - grace
-        assert overshoot <= 1, (
+        tolerance = stall_seconds * 0.6  # 1.5s: >= 1s below the ratchet floor
+        assert overshoot <= tolerance, (
             f"retirement cutoff was extended {overshoot:.2f}s beyond the "
-            f"{grace}s grace window measured from the start of the race"
+            f"{grace}s grace window measured from the start of the race "
+            f"(tolerance {tolerance:.2f}s, ratchet floor {stall_seconds:.2f}s)"
         )
 
 


### PR DESCRIPTION
The grace-window ratchet test failed a merge-group run today with `overshoot 1.01 <= 1` and ejected an unrelated frontend PR (#1632's queue entry, run 32662068306). The 1s tolerance was the problem, not the property.

The test injects a 2.5s stall into `create_access_token` so a ratcheted cutoff is unmistakable: the queued caller waits out the winner's stall before writing, so a real ratchet overshoots by at least the stall. Legitimate overshoot is only the winner's pre-lock latency, which is milliseconds on an idle machine and crossed 1s under full xdist load on a CI runner. A literal 1s therefore measured scheduling jitter, not the signal.

The tolerance is now derived from the stall (`stall_seconds * 0.6` = 1.5s), keeping at least a second of separation from the ratchet floor in both directions. The assertion message states both numbers.

Verification (worktree, host Postgres at :5434):
- `uv run pytest tests/test_auth_refresh_cookies_1302.py::TestGraceWindowCannotRatchetOpen -q` — 1 passed.
- Counterfactual: replacing the no-extend guard in `AuthService` (`if current.expires_at > grace_cutoff:`) with `if True:` makes the test FAIL at the new tolerance, then the file was restored. The guard's failure mode is still caught.
- `ruff check` / `ruff format --check` via pre-commit on commit — clean. Test-only change, no product code touched.
