### PR TITLE
fix(raster): skip PREDICTOR for sub-byte NBITS sources in COG conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and releases use semantic versioning.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Low-bit-depth rasters (NBITS < 8) no longer fail COG conversion.**
+  LULC and palette rasters commonly pack 1/2/4-bit samples into a rasterio
+  `uint8` container, via GDAL's `IMAGE_STRUCTURE` `NBITS` tag, which lives
+  at the band level rather than the dataset level. The COG converter picked
+  a `PREDICTOR` from the dtype string alone, so it handed `gdal_translate` a
+  `PREDICTOR=2` the tool hard-refuses on anything outside 8/16/32/64-bit
+  samples, failing the whole conversion step and the ingest job with it.
+  This is what broke `Peshawar_City_LULC_2050.tif` on the demo.
+  `convert_to_cog` now checks each band's actual bit width before deciding
+  whether a predictor creation option is safe to pass.
+
 ## [1.15.0] - 2026-08-23
 
 ### Added

--- a/backend/app/processing/raster/cog.py
+++ b/backend/app/processing/raster/cog.py
@@ -529,10 +529,54 @@ def _predictor_for_dtype(dtype: str, compression: str = "DEFLATE") -> str | None
 
     Predictors only work for DEFLATE, ZSTD, and LZW.
     Returns None for JPEG, WEBP, LERC (no predictor applicable).
+
+    A rasterio dtype string alone is not the whole story: see
+    ``_predictor_supported`` for the sample-width check ``convert_to_cog``
+    layers on top of this before it lets a predictor onto the argv.
     """
     if compression.upper() not in ("DEFLATE", "ZSTD", "LZW"):
         return None
     return "3" if _is_float_dtype(dtype) else "2"
+
+
+def _predictor_supported(file_path: str) -> bool:
+    """Whether every band's actual sample width supports a GDAL PREDICTOR.
+
+    A rasterio dtype like ``uint8`` does not say how many bits a sample
+    occupies: GDAL's ``IMAGE_STRUCTURE`` ``NBITS`` tag sub-byte-packs 1/2/4-bit
+    samples (common for LULC/palette rasters) or non-standard widths (e.g.
+    12/14-bit sensor data) into a wider dtype container. gdal_translate's
+    ``PREDICTOR=2``/``PREDICTOR=3`` creation options hard-refuse anything
+    outside {8, 16, 32, 64} bits -- ``ERROR 1: ... PREDICTOR=2 is only
+    supported with 8/16/32/64 bit samples`` -- which fails the whole COG
+    conversion (observed in production on an NBITS=4 LULC raster).
+
+    The tag lives at the BAND level, not the dataset level: calling
+    ``src.tags(ns="IMAGE_STRUCTURE")`` with no band index returns only
+    ``INTERLEAVE`` for a packed source and never sees ``NBITS`` at all, so
+    every band is probed individually via
+    ``src.tags(band, ns="IMAGE_STRUCTURE")``. A source that declares no
+    NBITS on any band is trusted at its rasterio dtype, which is always one
+    of 8/16/32/64; this only disables the predictor when a band explicitly
+    declares a narrower one.
+
+    Fails closed: a probe that cannot complete (unreadable file, unexpected
+    tag value) reports "not supported" rather than risk reproducing the
+    gdal_translate failure this exists to prevent -- the cost of a wrong
+    False here is a slightly larger COG, the cost of a wrong True is a
+    failed ingest job.
+    """
+    import rasterio
+
+    try:
+        with rasterio.open(file_path) as src:
+            for band in range(1, src.count + 1):
+                raw = src.tags(band, ns="IMAGE_STRUCTURE").get("NBITS")
+                if raw is not None and int(raw) not in (8, 16, 32, 64):
+                    return False
+    except Exception:  # broad: best-effort probe -- fail closed (see docstring)
+        return False
+    return True
 
 
 def convert_to_cog(
@@ -555,6 +599,11 @@ def convert_to_cog(
     reaches ``gdaladdo`` and nothing else: it decides how overviews are
     built, never what the base band contains.
 
+    ``dtype`` alone is not enough to pick a PREDICTOR: see
+    ``_predictor_supported`` for why a low-bit-depth source (NBITS < 8, e.g.
+    LULC/palette rasters) must skip it or gdal_translate refuses to run at
+    all.
+
     Raises RuntimeError on failure.
     """
     # fix(#1291): overviews are built from the SOURCE grid, which is also the
@@ -566,6 +615,8 @@ def convert_to_cog(
     )
     try:
         predictor = _predictor_for_dtype(dtype, compression)
+        if predictor is not None and not _predictor_supported(tmp_path):
+            predictor = None
         # KNOWN-03 (Phase 1071): apply the raster-pipeline GDAL safety clamps
         # on top of GDAL_CACHEMAX=200.
         env = gdal_safe_env(extras={"GDAL_CACHEMAX": "200"})

--- a/backend/tests/test_cog_subprocess_env.py
+++ b/backend/tests/test_cog_subprocess_env.py
@@ -424,3 +424,133 @@ class TestGdalFailureTempCleanup:
         assert list(work_dir.iterdir()) == [], (
             "a temp file leaked from the CRS-assignment path after run_gdal raised"
         )
+
+
+# ---------------------------------------------------------------------------
+# Low-bit-depth predictor guard: production failure on
+# Peshawar_City_LULC_2050.tif (2026-08-21 demo ingest)
+# ---------------------------------------------------------------------------
+#
+# A rasterio dtype string like "uint8" does not say how many bits a sample
+# occupies. GDAL's IMAGE_STRUCTURE NBITS tag sub-byte-packs 1/2/4-bit samples
+# (common for LULC/palette rasters) into that same uint8 container, and
+# gdal_translate hard-refuses PREDICTOR=2/3 on anything outside 8/16/32/64
+# bits:
+#
+#   ERROR 1: source.cog.tif: PREDICTOR=2 is only supported with 8/16/32/64
+#   bit samples.
+#
+# which failed the whole COG conversion step (and the ingest job with it).
+# These tests write REAL on-disk GeoTIFFs via rasterio's `nbits` creation
+# option -- the GDAL CLI is not guaranteed on the test host, but rasterio's
+# own driver bindings always are -- and let ``convert_to_cog`` run its real
+# rasterio-based NBITS probe against them. Only the GDAL CLI subprocesses
+# are mocked (via ``_capture_subprocess_runs``), so the fixture and the
+# per-band tag detection are both genuine.
+
+
+def _write_nbits_fixture(
+    path: str, *, nbits: int | None, width: int = 4, height: int = 4
+) -> None:
+    """A minimal on-disk uint8 GeoTIFF, optionally sub-byte-packed via NBITS.
+
+    ``nbits=None`` writes a plain uint8 band with no NBITS tag at all (the
+    common case: rasterio dtype and true sample width agree). ``nbits=1/2/4``
+    reproduces the LULC/palette shape that broke production: rasterio still
+    reports the band as ``uint8``, but GDAL's IMAGE_STRUCTURE tag (band-level,
+    not dataset-level -- ``src.tags(ns=...)`` with no band index returns only
+    INTERLEAVE) declares the true, narrower packing.
+    """
+    import numpy as np
+    import rasterio
+    from rasterio.transform import from_origin
+
+    kwargs = {} if nbits is None else {"nbits": nbits}
+    with rasterio.open(
+        path,
+        "w",
+        driver="GTiff",
+        width=width,
+        height=height,
+        count=1,
+        dtype="uint8",
+        crs="EPSG:4326",
+        transform=from_origin(0, height, 1, 1),
+        **kwargs,
+    ) as dst:
+        dst.write(np.zeros((height, width), dtype="uint8"), 1)
+
+
+def _gdal_translate_argv(captured):
+    calls = [(cmd, env) for cmd, env in captured if cmd and cmd[0] == "gdal_translate"]
+    assert calls, f"gdal_translate was not invoked; ran {[c[0] for c in captured]}"
+    return calls[0][0]
+
+
+class TestPredictorLowBitDepth:
+    """convert_to_cog must not hand gdal_translate a PREDICTOR it will refuse."""
+
+    def test_nbits4_source_drops_the_predictor(self, tmp_path, monkeypatch):
+        """NBITS=4 (e.g. an LULC classification raster) is the exact shape that
+        broke Peshawar_City_LULC_2050.tif in production."""
+        from app.processing.raster import cog as cog_module
+
+        src = tmp_path / "src.tif"
+        _write_nbits_fixture(str(src), nbits=4)
+
+        with _capture_subprocess_runs(monkeypatch) as captured:
+            cog_module.convert_to_cog(str(src), str(tmp_path / "out.tif"), "uint8")
+
+        cmd = _gdal_translate_argv(captured)
+        assert not any(arg.startswith("PREDICTOR=") for arg in cmd), (
+            f"NBITS=4 source must not receive any PREDICTOR -- gdal_translate "
+            f"hard-refuses PREDICTOR=2 on sub-byte samples; argv: {cmd}"
+        )
+
+    def test_nbits1_source_drops_the_predictor(self, tmp_path, monkeypatch):
+        """NBITS=1 (a binary mask/palette raster) is the other end of the same
+        failure class."""
+        from app.processing.raster import cog as cog_module
+
+        src = tmp_path / "src.tif"
+        _write_nbits_fixture(str(src), nbits=1)
+
+        with _capture_subprocess_runs(monkeypatch) as captured:
+            cog_module.convert_to_cog(str(src), str(tmp_path / "out.tif"), "uint8")
+
+        cmd = _gdal_translate_argv(captured)
+        assert not any(arg.startswith("PREDICTOR=") for arg in cmd), (
+            f"NBITS=1 source must not receive any PREDICTOR; argv: {cmd}"
+        )
+
+    def test_ordinary_uint8_source_keeps_the_predictor(self, tmp_path, monkeypatch):
+        """Counterpoint: a genuine 8-bit source (no NBITS tag at all) must keep
+        PREDICTOR=2 -- the fix must not turn the predictor off across the
+        board, only for the sources that actually can't take it."""
+        from app.processing.raster import cog as cog_module
+
+        src = tmp_path / "src.tif"
+        _write_nbits_fixture(str(src), nbits=None)
+
+        with _capture_subprocess_runs(monkeypatch) as captured:
+            cog_module.convert_to_cog(str(src), str(tmp_path / "out.tif"), "uint8")
+
+        cmd = _gdal_translate_argv(captured)
+        assert "PREDICTOR=2" in cmd, (
+            f"an ordinary uint8 source should still get PREDICTOR=2; argv: {cmd}"
+        )
+
+    def test_predictor_supported_reads_band_level_tag_not_dataset_level(self, tmp_path):
+        """Direct pin on the probe itself: NBITS lives under
+        ``src.tags(band, ns="IMAGE_STRUCTURE")``, not
+        ``src.tags(ns="IMAGE_STRUCTURE")`` (which only ever reports
+        INTERLEAVE for a packed source and would silently miss the tag)."""
+        from app.processing.raster import cog as cog_module
+
+        packed = tmp_path / "packed.tif"
+        plain = tmp_path / "plain.tif"
+        _write_nbits_fixture(str(packed), nbits=4)
+        _write_nbits_fixture(str(plain), nbits=None)
+
+        assert cog_module._predictor_supported(str(packed)) is False
+        assert cog_module._predictor_supported(str(plain)) is True

--- a/backend/tests/test_rule2_structural.py
+++ b/backend/tests/test_rule2_structural.py
@@ -351,6 +351,12 @@ RASTERIO_OPEN_ALLOWLIST: dict[tuple[str, str], tuple[int, str]] = {
         "local staged/temp path only; probes for internal overviews before "
         "spawning the (safe-env) gdaladdo subprocess",
     ),
+    ("processing/raster/cog.py", "_predictor_supported"): (
+        1,
+        "local staged/temp path only; probes per-band IMAGE_STRUCTURE NBITS "
+        "before letting convert_to_cog put PREDICTOR=<n> on the gdal_translate "
+        "argv",
+    ),
     ("processing/raster/quicklook.py", "generate_quicklook"): (
         1,
         "opens the locally produced COG output, never a source URL",


### PR DESCRIPTION
## What

Fixes a production ingest failure on the demo (2026-08-21, `Peshawar_City_LULC_2050.tif`):

```
gdal_translate failed: ERROR 1: source.cog.tif: PREDICTOR=2 is only supported with 8/16/32/64 bit samples.
```

`_predictor_for_dtype` in `backend/app/processing/raster/cog.py` picked `PREDICTOR=2`/`3` from the rasterio dtype string alone. That's not enough: GDAL's `IMAGE_STRUCTURE` `NBITS` tag sub-byte-packs 1/2/4-bit samples (LULC/palette rasters, common) or non-standard widths (12/14-bit sensor data) into a wider dtype container, so a source that reads as plain `uint8` in rasterio can still be a 4-bit raster underneath. `gdal_translate` hard-refuses `PREDICTOR=2`/`3` on anything outside 8/16/32/64 bits, which failed the whole `cog_convert` step (and the ingest job with it).

The `NBITS` tag lives at the **band level**, not the dataset level: `src.tags(ns="IMAGE_STRUCTURE")` with no band index returns only `INTERLEAVE` for a packed source and silently misses it.

## Why this shape

`convert_to_cog` now checks each band's actual bit width (`_predictor_supported`, a new helper next to `_predictor_for_dtype`) and drops the predictor when any band declares NBITS outside `{8, 16, 32, 64}`. A source with no NBITS tag is trusted at its rasterio dtype (unchanged behavior).

I checked whether `prepare_with_overviews`'s `gdaladdo` call needed the same treatment. It doesn't pass `PREDICTOR`/`PREDICTOR_OVERVIEW` at all (only `COMPRESS_OVERVIEW`), so it's unaffected by this bug.

The probe fails closed: if it can't determine bit width (unreadable file, unexpected tag value), it reports "not supported" rather than risk reproducing the exact failure this fixes. Worst case is a slightly larger COG, not a failed ingest.

## Changes

- `backend/app/processing/raster/cog.py`: new `_predictor_supported(file_path)` helper; `convert_to_cog` calls it before putting `-co PREDICTOR=<n>` on the `gdal_translate` argv.
- `backend/tests/test_rule2_structural.py`: new `RASTERIO_OPEN_ALLOWLIST` entry for the new `rasterio.open` call in `_predictor_supported` (local staged/temp path only, same trust class as the sibling entries already in this file).
- `backend/tests/test_cog_subprocess_env.py`: new `TestPredictorLowBitDepth` class. It builds real NBITS=1/NBITS=4 GeoTIFF fixtures with rasterio's `nbits` creation option (no GDAL CLI dependency, since the CLI isn't guaranteed on the test host) and runs them through `convert_to_cog` with only the GDAL subprocess layer mocked, so the fixture and the per-band tag detection are both genuine.
- `CHANGELOG.md`: `[Unreleased] > Fixed` entry.

No schema/API/config impact.

## Verification

```
cd backend && uv run ruff check . && uv run ruff format --check .
uv run pytest tests/test_cog_subprocess_env.py -v          # 15 passed
uv run pytest tests/test_rule2_structural.py -q             # 98 passed
uv run pytest tests/test_layering.py -q                     # 47 passed
uv run pytest tests/test_raster_replace_1221.py tests/test_vrt_rewrite.py \
  tests/test_cog_band_unit_capture.py tests/test_crs_wkt2_backfill_1376.py \
  tests/test_raster_antimeridian_887.py -q                  # 277 passed
```

Also reproduced the underlying GDAL behavior directly on the host GDAL 3.13.0 to confirm the error text and that dropping `PREDICTOR` alone fixes the conversion:

```
$ gdal_translate -of GTiff -co COMPRESS=DEFLATE -co PREDICTOR=2 -co TILED=YES nbits4.tif out.tif
ERROR 1: out.tif: PREDICTOR=2 is only supported with 8/16/32/64 bit samples. ...

$ gdal_translate -of GTiff -co COMPRESS=DEFLATE -co TILED=YES nbits4.tif out.tif
... done.
```

### Counterfactual

Committed the fix, then `git checkout HEAD~1 -- backend/app/processing/raster/cog.py backend/tests/test_rule2_structural.py` to put the pre-fix source back while keeping the new tests, and re-ran the new tests:

```
FAILED tests/test_cog_subprocess_env.py::TestPredictorLowBitDepth::test_nbits4_source_drops_the_predictor
FAILED tests/test_cog_subprocess_env.py::TestPredictorLowBitDepth::test_nbits1_source_drops_the_predictor
FAILED tests/test_cog_subprocess_env.py::TestPredictorLowBitDepth::test_predictor_supported_reads_band_level_tag_not_dataset_level
3 failed, 1 passed, 11 deselected
```

(the 4th test, "ordinary uint8 source keeps the predictor", correctly passed both before and after: it pins pre-existing behavior, not the fix). Then restored the fix with `git checkout HEAD -- ...` and the full suite passed again (160/160 across the three focused files).
