### PR TITLE
ops(demo): retain container logs and bridge Prometheus alerts to Azure Monitor

### DIFF
--- a/infra/demo/logging-override.yml
+++ b/infra/demo/logging-override.yml
@@ -1,0 +1,98 @@
+# ==============================================================================
+# Demo-VM log retention override — NOT part of the shipped root compose.
+# ==============================================================================
+# Root docker-compose.prod.yml (and docker-compose.yml) leave every service on
+# Docker's default `json-file` log driver with no explicit `log-opts`. On a
+# fresh host that means the daemon's own default applies, which most self-host
+# installs never touch — switching the SHIPPED compose to journald by default
+# would silently break any non-systemd host (bare Docker on a distro without
+# journald, a Docker-in-a-VM appliance, etc.), so that default stays put. This
+# file is an opt-in override, demo-only.
+#
+# The problem it fixes: `docker logs` output is tied to the CONTAINER's log
+# file, not the image or the compose project. `docker compose up -d --build`
+# (or any command that recreates a container — a new image tag, a changed
+# `environment:` block, `--force-recreate`) allocates a fresh container ID and
+# a fresh, EMPTY log file; the old container's log file is deleted with it.
+# The 2026-08-23 v1.15.0 redeploy did exactly that and took a week of api/
+# nginx history with it mid-incident-review. journald instead retains log
+# entries by CONTAINER_NAME/CONTAINER_TAG independent of container churn, so
+# history survives recreation (bounded by journald's own retention policy on
+# the host, e.g. SystemMaxUse in journald.conf).
+#
+# Activate on the VM via COMPOSE_FILE in /opt/geolens/.env so a bare
+# `docker compose ...` (no -f flags) picks it up automatically:
+#   COMPOSE_FILE=docker-compose.prod.yml:logging-override.yml
+# (compose reads COMPOSE_FILE as a `:`-joined list, applied in order — the
+# override merges on top of the base file exactly as -f/-f would.)
+#
+# `docker logs <container>` keeps working unmodified: Docker's journald log
+# driver still backs the `docker logs`/`docker compose logs` API, it just also
+# persists into the systemd journal outside the container's lifecycle.
+#
+# Querying history directly via journald (survives `docker compose up -d`
+# recreating the container, unlike `docker logs`):
+#   journalctl CONTAINER_NAME=geolens-api-1 --since "2026-08-23 00:00:00"
+#   journalctl CONTAINER_NAME=geolens-frontend-1 --since "-1 week"
+# CONTAINER_NAME is always populated by the journald driver regardless of the
+# `tag` option below; `tag` additionally sets SYSLOG_IDENTIFIER for tools that
+# key off that field instead.
+#
+# IMPORTANT: only override services that exist in docker-compose.prod.yml — a
+# service name here that ISN'T in the base file creates a NEW service instead
+# of overriding an existing one. Verify after any edit:
+#   docker compose -f docker-compose.prod.yml -f infra/demo/logging-override.yml config --quiet
+# and confirm the merged `docker compose config --services` list is unchanged
+# from the base file's.
+# ==============================================================================
+services:
+  db:
+    logging:
+      driver: journald
+      options:
+        tag: "{{.Name}}"
+  migrate:
+    logging:
+      driver: journald
+      options:
+        tag: "{{.Name}}"
+  api:
+    logging:
+      driver: journald
+      options:
+        tag: "{{.Name}}"
+  worker:
+    logging:
+      driver: journald
+      options:
+        tag: "{{.Name}}"
+  titiler:
+    logging:
+      driver: journald
+      options:
+        tag: "{{.Name}}"
+  frontend:
+    logging:
+      driver: journald
+      options:
+        tag: "{{.Name}}"
+  backup:
+    logging:
+      driver: journald
+      options:
+        tag: "{{.Name}}"
+  minio:
+    logging:
+      driver: journald
+      options:
+        tag: "{{.Name}}"
+  minio-setup:
+    logging:
+      driver: journald
+      options:
+        tag: "{{.Name}}"
+  valkey:
+    logging:
+      driver: journald
+      options:
+        tag: "{{.Name}}"

--- a/infra/demo/monitoring/README.md
+++ b/infra/demo/monitoring/README.md
@@ -1,0 +1,108 @@
+# Demo VM: log retention + alert delivery
+
+Install notes for two ops gaps found during the 2026-08-23 v1.15.0 redeploy audit:
+container logs were lost on container re-creation, and Prometheus `ALERTS` were
+never wired to a notification channel.
+
+**Why this file, and not `infra/demo/README.md`:** the top-level demo README
+carries the VM's public IP, admin-credential pointer, and other operational
+narrative and is explicitly marked "do not commit to the public repo" (it is
+not tracked in git — only `infra/monitoring/*`, the generic self-host reference
+config, is). The two scripts below and this note contain no VM-identifying
+secrets — subscription id is read from IMDS at runtime, nothing is hardcoded
+beyond the already-public demo resource *names* (`rg-geolens-demo`,
+`geolens-demo`, `ag-geolens-demo-ops` — not credentials) — so they're tracked
+here rather than folded into the private file. If you also want this content
+merged into the top-level README, that edit has to happen by hand on the VM
+operator's own checkout; nothing in this PR touches that file.
+
+## Part 1 — Log retention survives container re-creation
+
+`infra/demo/logging-override.yml` switches every service in the root
+`docker-compose.prod.yml` from the default `json-file` driver (tied to the
+container, deleted on re-creation) to `journald` (tied to the host, survives
+`docker compose up -d --build` / `--force-recreate` / any image bump).
+
+Install on the VM:
+
+```bash
+# 1. Copy the override alongside docker-compose.prod.yml.
+scp infra/demo/logging-override.yml azureuser@<vm>:/opt/geolens/logging-override.yml
+
+# 2. Point bare `docker compose` at both files (add to /opt/geolens/.env):
+echo 'COMPOSE_FILE=docker-compose.prod.yml:logging-override.yml' >> /opt/geolens/.env
+
+# 3. Recreate the stack so the new log driver takes effect (log driver is
+#    set at container-create time, not live-reloadable):
+cd /opt/geolens && docker compose up -d
+
+# 4. Verify.
+docker inspect --format '{{.HostConfig.LogConfig.Type}}' geolens-api-1   # -> journald
+docker logs geolens-api-1 --tail 20                                      # still works
+journalctl CONTAINER_NAME=geolens-api-1 --since "-1 hour"                # survives recreation
+```
+
+Re-run `docker compose -f docker-compose.prod.yml -f infra/demo/logging-override.yml
+config --quiet` after editing either compose file — an override entry that
+doesn't match an existing base-file service name creates a *new* service
+instead of overriding one, and `--quiet` only tells you the YAML parsed, not
+that the service set is unchanged (diff `config --services` for that).
+
+## Part 2 — Prometheus alerts reach the on-call inbox
+
+`infra/demo/monitoring/prom-alert-bridge.sh` polls the VM's local Prometheus
+(`:9090/api/v1/alerts`) every 5 minutes, counts alerts with `state=="firing"`,
+and pushes the count as an Azure Monitor custom metric
+(`geolens/prometheus` / `alerts_firing`) on the VM's own resource, using the
+VM's system-assigned managed identity via IMDS — no stored credential on the
+box. `prom-guard.sh` (same directory) is a separate, older path: local-log +
+optional dead-man's-switch ping. This bridge is additive, not a replacement.
+
+Install on the VM:
+
+```bash
+# 1. Ship the script + cron file (matches how the monitoring stack itself
+#    deploys to /opt/geolens-monitoring — see docker-compose.monitoring.yml).
+scp infra/demo/monitoring/prom-alert-bridge.sh azureuser@<vm>:/opt/geolens-monitoring/prom-alert-bridge.sh
+ssh azureuser@<vm> 'sudo chmod +x /opt/geolens-monitoring/prom-alert-bridge.sh'
+scp infra/demo/monitoring/prom-alert-bridge.cron azureuser@<vm>:/tmp/prom-alert-bridge.cron
+ssh azureuser@<vm> 'sudo install -o root -g root -m 0644 /tmp/prom-alert-bridge.cron /etc/cron.d/geolens-prom-bridge'
+
+# 2. Smoke-test manually before waiting on cron.
+ssh azureuser@<vm> 'sudo /opt/geolens-monitoring/prom-alert-bridge.sh && tail -3 /var/log/geolens-prom-bridge.log'
+```
+
+### Azure side — already provisioned, nothing to run here
+
+- **No role assignment needed.** Validated live: an IMDS token for
+  `https://monitoring.azure.com/` scoped to the VM's own managed identity is
+  sufficient to POST a custom metric against that same VM's resource ID — a
+  VM may emit metrics about itself without `Monitoring Metrics Publisher`.
+  (Earlier drafts of this doc assumed that role assignment was required; it
+  is not, and the credential available to provision this couldn't grant one
+  anyway.)
+- **Metric alert rule already exists**: `geolens-demo-prom-alerts` — average
+  of `alerts_firing` (namespace `geolens/prometheus`) `> 0` over a 15-minute
+  window, evaluated every 5 minutes, action group `ag-geolens-demo-ops`
+  (the existing email channel already used by `geolens-demo-disk-90`). A
+  zero-value sample has already been seeded so "no data" reads as "bridge is
+  down", not "steady state".
+
+Read-only checks (no state change):
+
+```bash
+az monitor metrics alert show -g rg-geolens-demo -n geolens-demo-prom-alerts -o table
+az monitor metrics list -g rg-geolens-demo --resource geolens-demo \
+  --resource-type Microsoft.Compute/virtualMachines \
+  --namespace geolens/prometheus --metric alerts_firing --interval PT5M
+```
+
+## Redeploy checklist note
+
+Neither `logging-override.yml` nor the `prom-alert-bridge.*` files are picked
+up by an image/release redeploy — they're demo-VM ops files, not shipped
+product artifacts. They sync to the VM the same way `infra/demo/monitoring/
+alerts.yml` already does relative to the tracked `infra/monitoring/alerts.yml`:
+by hand, on demand. After merging a change to any of the three files here,
+re-run the copy steps above on the VM — a `git pull` on the VM checkout alone
+does not restart the cron job or recreate the containers.

--- a/infra/demo/monitoring/prom-alert-bridge.cron
+++ b/infra/demo/monitoring/prom-alert-bridge.cron
@@ -1,0 +1,17 @@
+# /etc/cron.d/geolens-prom-bridge — install as root:owned, mode 0644, at
+# /etc/cron.d/geolens-prom-bridge on the demo VM.
+#
+# /etc/cron.d/ format differs from a user crontab: it carries an explicit
+# user field (5th column) between the schedule and the command, and cron
+# reads it without a `crontab -e`/`crontab -l` step — dropping this file in
+# place is the whole install.
+#
+#   install -o root -g root -m 0644 infra/demo/monitoring/prom-alert-bridge.cron \
+#     /etc/cron.d/geolens-prom-bridge
+#
+# PATH is set explicitly because /etc/cron.d entries run with a minimal
+# environment — no inherited login PATH, so bare `curl`/`python3` would
+# otherwise fail to resolve.
+PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+*/5 * * * * root /opt/geolens-monitoring/prom-alert-bridge.sh >/dev/null 2>&1

--- a/infra/demo/monitoring/prom-alert-bridge.sh
+++ b/infra/demo/monitoring/prom-alert-bridge.sh
@@ -1,0 +1,142 @@
+#!/bin/bash
+# Demo-VM Prometheus -> Azure Monitor alert bridge — cron every 5 min.
+#
+# prom-guard.sh (this dir) already logs firing alerts locally and can ping an
+# optional dead-man's-switch URL. This script is a DIFFERENT delivery path:
+# it turns "firing alert count" into an Azure Monitor custom metric on the VM
+# resource, so the VM's existing action group (ag-geolens-demo-ops, email —
+# already wired to the geolens-demo-disk-90 disk alert) can also fire on
+# Prometheus alerts without the VM needing its own SMTP/webhook credentials.
+#
+# jq is NOT guaranteed on the VM; python3 IS. All JSON handling below goes
+# through python3 instead.
+#
+# Auth: the VM's system-assigned managed identity requests a token from IMDS
+# scoped to https://monitoring.azure.com/ and POSTs the metric as itself
+# against its own resource ID — no stored credential, no extra role
+# assignment needed (validated live: a VM's managed identity may emit custom
+# metrics against itself without Monitoring Metrics Publisher).
+set -u
+
+LOG=${LOG:-/var/log/geolens-prom-bridge.log}
+PROMETHEUS_URL=${PROMETHEUS_URL:-http://127.0.0.1:9090/api/v1/alerts}
+
+# Azure resource coordinates. Overridable so this script isn't tied to one VM;
+# defaults match the current demo (rg-geolens-demo / geolens-demo / centralus).
+SUBSCRIPTION_ID_URL=${SUBSCRIPTION_ID_URL:-"http://169.254.169.254/metadata/instance/compute/subscriptionId?api-version=2021-02-01&format=text"}
+IMDS_TOKEN_URL=${IMDS_TOKEN_URL:-"http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01&resource=https%3A%2F%2Fmonitoring.azure.com%2F"}
+RESOURCE_GROUP=${RESOURCE_GROUP:-rg-geolens-demo}
+VM_NAME=${VM_NAME:-geolens-demo}
+REGION=${REGION:-centralus}
+METRIC_NAMESPACE=${METRIC_NAMESPACE:-geolens/prometheus}
+METRIC_NAME=${METRIC_NAME:-alerts_firing}
+# Set to point the POST at a local mock for a dry run; empty derives the real
+# per-VM endpoint below from RESOURCE_GROUP/VM_NAME/REGION.
+METRICS_URL_OVERRIDE=${METRICS_URL_OVERRIDE:-}
+
+ts() { date -u +%Y-%m-%dT%H:%M:%SZ; }
+
+# --- 1. Count firing alerts -------------------------------------------------
+ALERTS_JSON=$(curl -fsS --max-time 10 "$PROMETHEUS_URL" 2>>"$LOG") || {
+    echo "$(ts) ERROR prometheus unreachable at $PROMETHEUS_URL" >>"$LOG"
+    exit 0
+}
+
+# Prints "<count>\t<comma-joined alertnames>" on success, "ERROR\t<msg>" on
+# failure — read as a single tab-delimited line to avoid multi-line parsing.
+PARSED=$(printf '%s' "$ALERTS_JSON" | python3 -c '
+import json, sys
+try:
+    data = json.load(sys.stdin)
+    alerts = [a for a in data.get("data", {}).get("alerts", []) if a.get("state") == "firing"]
+    names = ",".join(a.get("labels", {}).get("alertname", "unknown") for a in alerts)
+    print(f"{len(alerts)}\t{names}")
+except Exception as exc:
+    print(f"ERROR\t{exc}")
+')
+IFS=$'\t' read -r COUNT NAMES <<<"$PARSED"
+
+if [ "$COUNT" = "ERROR" ] || ! [[ "$COUNT" =~ ^[0-9]+$ ]]; then
+    echo "$(ts) ERROR could not parse prometheus alerts response: ${NAMES:-unknown}" >>"$LOG"
+    exit 0
+fi
+
+# --- 2. Managed-identity token + subscription id (IMDS) ---------------------
+TOKEN_RESPONSE=$(curl -fsS --max-time 10 --noproxy '*' -H "Metadata:true" "$IMDS_TOKEN_URL" 2>>"$LOG") || {
+    echo "$(ts) ERROR IMDS token request failed (count=$COUNT firing=${NAMES:-none})" >>"$LOG"
+    exit 0
+}
+TOKEN=$(printf '%s' "$TOKEN_RESPONSE" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("access_token",""))' 2>>"$LOG")
+if [ -z "$TOKEN" ]; then
+    echo "$(ts) ERROR IMDS token response missing access_token (count=$COUNT firing=${NAMES:-none})" >>"$LOG"
+    exit 0
+fi
+
+SUBSCRIPTION_ID=$(curl -fsS --max-time 10 --noproxy '*' -H "Metadata:true" "$SUBSCRIPTION_ID_URL" 2>>"$LOG") || {
+    echo "$(ts) ERROR IMDS subscriptionId request failed (count=$COUNT firing=${NAMES:-none})" >>"$LOG"
+    exit 0
+}
+if [ -z "$SUBSCRIPTION_ID" ]; then
+    echo "$(ts) ERROR IMDS subscriptionId response empty (count=$COUNT firing=${NAMES:-none})" >>"$LOG"
+    exit 0
+fi
+
+# --- 3. POST the custom metric -----------------------------------------------
+# ALWAYS runs, even at count=0 — a zero-valued series is what lets the alert
+# rule's "no data" state mean "bridge is down/silent" instead of overloading
+# it to also mean "all quiet". min/max/sum all equal count, count=1 (a single
+# sample per 5-minute run) — this is the exact body shape validated live
+# against the metrics endpoint below.
+RESOURCE_ID="/subscriptions/${SUBSCRIPTION_ID}/resourceGroups/${RESOURCE_GROUP}/providers/Microsoft.Compute/virtualMachines/${VM_NAME}"
+METRICS_URL="${METRICS_URL_OVERRIDE:-https://${REGION}.monitoring.azure.com${RESOURCE_ID}/metrics}"
+
+POST_RESULT=$(COUNT="$COUNT" TOKEN="$TOKEN" METRICS_URL="$METRICS_URL" \
+    METRIC_NAME="$METRIC_NAME" METRIC_NAMESPACE="$METRIC_NAMESPACE" python3 - <<'PYEOF'
+import json
+import os
+import urllib.error
+import urllib.request
+from datetime import datetime, timezone
+
+count = int(os.environ["COUNT"])
+body = {
+    "time": datetime.now(timezone.utc).replace(tzinfo=None).isoformat(timespec="milliseconds"),
+    "data": {
+        "baseData": {
+            "metric": os.environ["METRIC_NAME"],
+            "namespace": os.environ["METRIC_NAMESPACE"],
+            "dimNames": [],
+            "series": [
+                {"dimValues": [], "min": count, "max": count, "sum": count, "count": 1}
+            ],
+        }
+    },
+}
+payload = json.dumps(body).encode("utf-8")
+req = urllib.request.Request(
+    os.environ["METRICS_URL"],
+    data=payload,
+    method="POST",
+    headers={
+        "Authorization": "Bearer " + os.environ["TOKEN"],
+        "Content-Type": "application/json",
+    },
+)
+try:
+    with urllib.request.urlopen(req, timeout=10) as resp:
+        print(f"OK\t{resp.status}\t")
+except urllib.error.HTTPError as exc:
+    detail = exc.read().decode("utf-8", "replace")[:300].replace("\n", " ").replace("\t", " ")
+    print(f"ERROR\t{exc.code}\t{detail}")
+except Exception as exc:
+    print(f"ERROR\t-\t{exc}")
+PYEOF
+)
+IFS=$'\t' read -r STATUS CODE DETAIL <<<"$POST_RESULT"
+
+if [ "$STATUS" = "OK" ]; then
+    echo "$(ts) OK count=$COUNT firing=${NAMES:-none} metric_post=$CODE" >>"$LOG"
+else
+    echo "$(ts) ERROR count=$COUNT firing=${NAMES:-none} metric_post_failed status=$CODE detail=$DETAIL" >>"$LOG"
+fi
+exit 0


### PR DESCRIPTION
## What / why

Two ops gaps on the demo VM found during the v1.15.0 redeploy audit:

1. **Logs die on container re-creation.** `docker logs` is tied to the
   container's `json-file` log, which is deleted when the container is
   re-created (any `docker compose up -d`/`--build`/image bump). Today's
   redeploy destroyed a week of api/nginx history mid-incident-review.
2. **Prometheus alerts fire into the void.** Prometheus records `ALERTS` but
   nothing was ever notified — despite the VM already having a working
   channel (Azure Monitor action group `ag-geolens-demo-ops`, email, used by
   the disk alert `geolens-demo-disk-90`) and a system-assigned managed
   identity that can use it.

This PR is repo-side artifacts only; the orchestrator applies them to the VM.

### Part 1 — `infra/demo/logging-override.yml`

Opt-in compose override, **not** a change to the shipped root
`docker-compose.prod.yml` (a journald default would silently break any
non-systemd self-host). Sets `logging: {driver: journald, options: {tag:
"{{.Name}}"}}` for every service in the base file. Activated on the VM via
`COMPOSE_FILE=docker-compose.prod.yml:logging-override.yml` in
`/opt/geolens/.env`, so a bare `docker compose` picks it up. `docker logs`
keeps working; history now also survives re-creation via
`journalctl CONTAINER_NAME=geolens-api-1 --since ...`.

### Part 2 — `infra/demo/monitoring/prom-alert-bridge.sh` (+ `.cron`)

Cron job, every 5 minutes: GETs `http://127.0.0.1:9090/api/v1/alerts`, counts
`state=="firing"` alerts (python3 — jq isn't guaranteed on the VM), fetches an
IMDS token scoped to `https://monitoring.azure.com/` plus the subscription id
(also via IMDS), and POSTs the count as an Azure Monitor custom metric
(`geolens/prometheus` / `alerts_firing`) against the VM's own resource ID.
Always POSTs, even at count=0 — a zero series is what lets the alert rule's
"no data" state mean "bridge is down" instead of double-duty as "all quiet".
Logs one line per run to `/var/log/geolens-prom-bridge.log`; any HTTP failure
logs and exits 0 (cron stays noise-free).

`infra/demo/monitoring/README.md` documents install steps for both parts, the
already-provisioned Azure side (see mid-review update below), and a redeploy
note: neither of these syncs to the VM automatically on release — same
manual-copy convention as `infra/demo/monitoring/alerts.yml` relative to the
tracked `infra/monitoring/alerts.yml`.

**Mid-review update incorporated:** the orchestrator validated the exact
request shape live against the real endpoint and reported that no
`Monitoring Metrics Publisher` role assignment is needed (a VM's managed
identity may emit metrics against itself), and that the metric alert rule
(`geolens-demo-prom-alerts`, avg `alerts_firing` > 0 over 15m, eval 5m, action
group `ag-geolens-demo-ops`) already exists. The script and README reflect
that — no role-assignment step, alert rule documented as existing rather than
as a command to run.

### A repo-structure note worth flagging

`infra/demo/` has never been tracked in this repo (`git log --all -- infra/demo`
is empty) — it's local-only content excluded via `.git/info/exclude`, and its
top-level `README.md` (untracked, not touched by this PR) is explicitly
marked "Private: do not commit to the public repo" (it carries the VM's
public IP and an admin-credential pointer). Only `infra/monitoring/*` (the
generic, VM-agnostic reference config) was previously tracked. The four files
in this PR contain no VM-identifying secrets (subscription id comes from IMDS
at runtime; nothing hardcoded beyond the already-public resource *names*), so
I force-added them (`git add -f`, per the local exclude) rather than folding
them into the private README. Flagging this so it's a deliberate call, not a
missed one — happy to fold `infra/demo/monitoring/README.md` differently if
preferred.

## Verification

```
docker compose -f docker-compose.prod.yml -f infra/demo/logging-override.yml config --quiet
# exit 0, no errors (only expected "variable is not set" warnings for
# POSTGRES_*/JWT_SECRET_KEY/etc — no .env in this environment)

# merged services == base services, both profiles:
diff <(docker compose -f docker-compose.prod.yml config --services | sort) \
     <(docker compose -f docker-compose.prod.yml -f infra/demo/logging-override.yml config --services | sort)
# -> identical (7 core services)
diff <(docker compose --profile cloud-dev -f docker-compose.prod.yml config --services | sort) \
     <(docker compose --profile cloud-dev -f docker-compose.prod.yml -f infra/demo/logging-override.yml config --services | sort)
# -> identical (10 services incl. minio/minio-setup/valkey)

# confirmed every service in the merged config actually carries the
# journald logging block (parsed the rendered YAML)

shellcheck infra/demo/monitoring/prom-alert-bridge.sh   # clean, no findings
bash -n infra/demo/monitoring/prom-alert-bridge.sh      # syntax OK
```

Functional dry run against a local mock Prometheus + IMDS + Azure Monitor
endpoint (script's URLs are env-overridable for exactly this):
- 0 firing alerts -> logs `OK count=0 firing=none metric_post=200`, posts a
  zero-valued series.
- 2 firing + 1 pending -> logs `OK count=2
  firing=HostDiskUsageHigh,ContainerMemoryNearLimit metric_post=200` (pending
  correctly excluded); posted body:
  `{"time":"...","data":{"baseData":{"metric":"alerts_firing","namespace":"geolens/prometheus","dimNames":[],"series":[{"dimValues":[],"min":2,"max":2,"sum":2,"count":1}]}}}`
  — matches the shape validated live by the orchestrator against the real
  endpoint.
- Prometheus unreachable -> logs the curl error, exits 0.
- Metric POST unreachable -> logs the failure detail, exits 0.

This is new-file/new-capability work rather than a fix to existing broken
logic, so the counterfactual is that none of this exists on `main` today:
there is no `logging-override.yml` to merge (services stay on `json-file`),
and no `prom-alert-bridge.sh` to run at all.

No CHANGELOG entry — checked precedent on the only tracked `infra/` history
(`a26f3cdf6` shipping the original monitoring config, `1fbd72f06` splitting an
alert rule): neither touched `CHANGELOG.md`.
