### PR TITLE
fix(jobs): settle abandoned presigned uploads as cancelled, not failed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,12 @@ and releases use semantic versioning.
   the status poll, and a worker's startup recovery. Only that class moves.
   Every other never-queued job keeps reporting `failed` — including a service
   or URL import whose dispatch never landed, because retry is offered on failed
-  jobs and taking that away would cost a recoverable job its recovery. No
-  schema change: `cancelled` was already a permitted job status (#1556).
+  jobs and taking that away would cost a recoverable job its recovery. The
+  cleanup pass counts cancellations apart from failures, so an operator reading
+  a sweep's audit entry sees what it actually did, and the import view stops
+  polling a job once it settles cancelled instead of asking for its status
+  every two seconds for the life of the tab. No schema change: `cancelled` was
+  already a permitted job status (#1556).
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and releases use semantic versioning.
 
 ## [Unreleased]
 
+### Changed
+
+- **An upload that was never started is now `cancelled`, not `failed`.** Ask
+  for a presigned upload URL and walk away, and the job row sat `pending` until
+  the stale sweep marked it failed with "pending too long (never queued)" — a
+  state that reads, in the admin jobs list and in the failed-jobs count beside
+  it, exactly like an ingest that broke. Nothing was ever attempted for those
+  rows, so they now settle `cancelled` with "Abandoned: upload was never
+  completed", at all three places that can settle them: the background sweep,
+  the status poll, and a worker's startup recovery. Only that class moves.
+  Every other never-queued job keeps reporting `failed` — including a service
+  or URL import whose dispatch never landed, because retry is offered on failed
+  jobs and taking that away would cost a recoverable job its recovery. No
+  schema change: `cancelled` was already a permitted job status (#1556).
+
 ### Fixed
 
 - **Low-bit-depth rasters (NBITS < 8) no longer fail COG conversion.**

--- a/backend/app/platform/jobs/router.py
+++ b/backend/app/platform/jobs/router.py
@@ -38,6 +38,7 @@ from app.platform.jobs.schemas import (
 )
 from app.platform.jobs.staging_reconcile import reconcile_orphaned_staging_objects
 from app.platform.jobs.sweep import (
+    ABANDONED_UPLOAD_MESSAGE,  # noqa: F401 -- re-exported, see __all__
     JOB_TIMEOUT_SECONDS,
     audit_settled_embedding_backfill,
     STALE_PENDING_BOUND_MESSAGE,
@@ -50,8 +51,10 @@ from app.platform.jobs.sweep import (
     fail_stale_jobs,
     post_expiry_sweep_after_seconds,  # noqa: F401 -- re-exported, see __all__
     publish_refresh_reconciliation,
+    is_abandoned_presigned_upload,  # noqa: F401 -- re-exported, see __all__
     stale_pending_clauses,
     stale_pending_cutoff_seconds,
+    stale_pending_unbound_values,
     sweep_stale_vrt_assets,  # noqa: F401 -- re-exported, see __all__
 )
 from app.platform.storage.titiler_url import resolve_current_storage_key
@@ -386,6 +389,16 @@ async def get_job_status(
                 completion_bound=completion_bound
             ):
                 continue
+            # fix(#1556): the unbound half takes the shared ACTION, which
+            # settles a never-bound presigned upload as `cancelled`. The bound
+            # half keeps writing `failed` outright — a completion that bound
+            # bytes and then stalled IS a failure — and this is the same split
+            # the background sweep and the worker's startup recovery apply.
+            values = (
+                {"status": "failed", "error_message": message, "completed_at": now}
+                if completion_bound
+                else stale_pending_unbound_values(now, message=message)
+            )
             result = await db.execute(
                 update(IngestJob)
                 .where(
@@ -393,11 +406,7 @@ async def get_job_status(
                     IngestJob.attempt_id == job.attempt_id,
                     *stale_pending_clauses(now, completion_bound=completion_bound),
                 )
-                .values(
-                    status="failed",
-                    error_message=message,
-                    completed_at=now,
-                )
+                .values(**values)
             )
             if result.rowcount:
                 await audit_settled_embedding_backfill(
@@ -777,6 +786,7 @@ async def retry_job(
 
 
 __all__ = [
+    "ABANDONED_UPLOAD_MESSAGE",
     "JOB_TIMEOUT_SECONDS",
     "STALE_PENDING_BOUND_MESSAGE",
     "STALE_PENDING_UNBOUND_MESSAGE",
@@ -789,9 +799,11 @@ __all__ = [
     "audit_settled_embedding_backfill",
     "fail_stale_jobs",
     "get_retry_capability",
+    "is_abandoned_presigned_upload",
     "post_expiry_sweep_after_seconds",
     "router",
     "stale_pending_clauses",
     "stale_pending_cutoff_seconds",
+    "stale_pending_unbound_values",
     "sweep_stale_vrt_assets",
 ]

--- a/backend/app/platform/jobs/sweep.py
+++ b/backend/app/platform/jobs/sweep.py
@@ -19,7 +19,7 @@ from pathlib import Path
 from typing import Literal, overload
 
 import structlog
-from sqlalchemy import and_, delete, func, not_, or_, select, text, update
+from sqlalchemy import and_, case, delete, func, not_, or_, select, text, update
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -133,6 +133,85 @@ def stale_pending_clauses(now: datetime, *, completion_bound: bool) -> tuple:
         completion_key if completion_bound else not_(completion_key),
         no_live_procrastinate_job(),
     )
+
+
+# fix(#1556): the terminal state for a presigned upload nobody ever bound bytes
+# to. `failed` claims an ingest was attempted and broke; for a visitor who
+# presigned an upload and walked away, nothing was ever attempted, and on the
+# public demo those rows are indistinguishable from real ingest failures in the
+# admin jobs list and the failed-jobs badge that counts it. `cancelled` is
+# already in the `ingest_jobs` status CHECK constraint, in the admin `JobStatus`
+# literal and in openapi.json, so this needs no migration and changes no
+# published contract.
+ABANDONED_UPLOAD_MESSAGE = "Abandoned: upload was never completed"
+
+
+def is_abandoned_presigned_upload(
+    file_path: str | None, user_metadata: dict | None
+) -> bool:
+    """Python twin of ``abandoned_presigned_upload``, over one loaded row.
+
+    Only the worker's startup recovery needs it: that site mirrors the UPDATE
+    onto the returned ORM instances, and a plain ``job.status = "failed"``
+    there would write the in-memory object back over the status the database
+    just computed. Kept beside the SQL so the two are read as one rule.
+    """
+    return not file_path and bool((user_metadata or {}).get("presigned"))
+
+
+def abandoned_presigned_upload():
+    """Predicate: a presigned upload whose bytes were never bound.
+
+    Deliberately narrower than "falsy ``file_path``". The unbound half of the
+    pending sweep also reaps rows that DID have work attempted for them, and
+    each of those must keep reporting `failed`:
+
+    - a service/URL import (``source_url`` set, ``file_path`` empty) whose
+      defer never landed. ``/jobs/{id}/retry`` requires status `failed`, and
+      ``_retry_capability`` offers exactly that row, so cancelling it would
+      take a recoverable job's only recovery path away — the same 1h-to-
+      recoverable-becomes-unrecoverable trap #1235 avoided for absolute paths.
+    - an analysis run or an admin embedding backfill, both of which carry
+      ``file_path=""`` by construction. A dispatch that never landed is a real
+      failure of something the user asked for, and #1550's audit trail settles
+      the backfill `never_started` in the same transaction as the row.
+
+    The ``presigned`` marker is what both presign doors stamp
+    (``processing/ingest/router.py`` and ``datasets/api/router_reupload.py``)
+    at the moment they hand a client a URL, so it names the one class where an
+    empty ``file_path`` means "the client never came back". A completion binds
+    ``staging/{job}/frozen/...`` and is therefore the BOUND half's business,
+    never this one.
+    """
+    return and_(
+        func.coalesce(IngestJob.file_path, "") == "",
+        func.coalesce(IngestJob.user_metadata["presigned"].astext, "false") == "true",
+    )
+
+
+def stale_pending_unbound_values(now: datetime, *, message: str) -> dict:
+    """Every column the unbound half of the pending sweep writes.
+
+    The companion to ``stale_pending_clauses``, for the same reason it exists:
+    three sites flip an unbound pending row terminal — the background sweep,
+    `get_job_status` (the one that actually fires, polled every 2s) and the
+    worker's startup recovery — and a split expressed in the ACTION at one of
+    them, with the other two still writing `failed`, would make the same
+    abandoned upload report two different terminal states depending on which
+    actor reached it first. Returning the whole mapping rather than just the
+    status means a caller cannot take the split without also taking the
+    message.
+
+    ``message`` is the caller's own unbound wording (the poll path interpolates
+    the elapsed seconds); it survives untouched for every row that is not an
+    abandoned upload, so nothing about the existing failure reporting moves.
+    """
+    abandoned = abandoned_presigned_upload()
+    return {
+        "status": case((abandoned, "cancelled"), else_="failed"),
+        "error_message": case((abandoned, ABANDONED_UPLOAD_MESSAGE), else_=message),
+        "completed_at": now,
+    }
 
 
 def no_live_procrastinate_job():
@@ -1144,9 +1223,7 @@ async def fail_stale_jobs(
         update(IngestJob)
         .where(*stale_pending_clauses(now, completion_bound=False))
         .values(
-            status="failed",
-            error_message=STALE_PENDING_UNBOUND_MESSAGE,
-            completed_at=now,
+            **stale_pending_unbound_values(now, message=STALE_PENDING_UNBOUND_MESSAGE)
         )
         .returning(IngestJob.id, IngestJob.user_metadata, IngestJob.created_by)
     )

--- a/backend/app/platform/jobs/sweep.py
+++ b/backend/app/platform/jobs/sweep.py
@@ -258,6 +258,16 @@ class StaleCleanupOutcome:
     storage_objects_reaped: int
     staged_paths_skipped: int
     staged_cleanup_failures: int
+    # fix(#1556 review, codex P2): pending rows the sweep settled `cancelled`
+    # rather than `failed` — abandoned presigned uploads. Counted apart from
+    # `pending_failed` because that number is read as a failure count by the
+    # admin cleanup response, its audit event and the sweeper's log line, and
+    # folding abandonments back into it would undo the split at exactly the
+    # surfaces the split exists for.
+    #
+    # Last, with a default, only because a dataclass cannot put a defaulted
+    # field before undefaulted ones; it belongs beside `pending_failed`.
+    pending_cancelled: int = 0
     _staged_paths: tuple[str, ...] = field(default=(), repr=False, compare=False)
     # fix(#1202 review r5): presigned staging keys of the purged rows. Kept
     # separate from _staged_paths because they need no survivor query — a
@@ -282,14 +292,26 @@ class StaleCleanupOutcome:
 
     @property
     def total_cleaned(self) -> int:
-        """Legacy count: ingest jobs transitioned from active to failed."""
+        """Legacy count: ingest jobs transitioned from active to failed.
+
+        fix(#1556 review): still literally that, which is why cancellations
+        are absent. Its published identity is `pending_failed + running_failed`
+        and a caller reading "cleaned" as "failed" is reading it correctly.
+        """
         return self.pending_failed + self.running_failed
 
     @property
     def total_affected(self) -> int:
-        """Rows and staged objects mutated by the cleanup pass."""
+        """Rows and staged objects mutated by the cleanup pass.
+
+        fix(#1556 review): cancellations DO belong here. This one counts work
+        done, not failures, so leaving them out would under-report the rows the
+        pass actually mutated — a number that hides work is worse than one that
+        does not break down.
+        """
         return (
             self.total_cleaned
+            + self.pending_cancelled
             + self.vrt_assets_recovered
             + self.vrt_generations_failed
             + self.terminal_jobs_purged
@@ -298,9 +320,21 @@ class StaleCleanupOutcome:
         )
 
     def as_dict(self) -> dict[str, int]:
-        """Return the stable API and audit detail shape."""
+        """Return the stable API and audit detail shape.
+
+        fix(#1556 review): `pending_cancelled` reaches the audit event (a JSONB
+        `details` blob with no schema) and the multi-tenant fleet totals, which
+        is where an operator reconstructs what a pass did. It deliberately does
+        NOT reach the HTTP response: `StaleCleanupResponse` is a published
+        model, generated into both SDKs and `api.generated.ts`, and pydantic's
+        default `extra="ignore"` drops the key on the way out. Surfacing it
+        there is a contract change with a regen attached, and it is not needed
+        to fix the misreport — `pending_failed` no longer counts abandonments
+        on any of the three surfaces.
+        """
         return {
             "pending_failed": self.pending_failed,
+            "pending_cancelled": self.pending_cancelled,
             "running_failed": self.running_failed,
             "total_cleaned": self.total_cleaned,
             "vrt_assets_recovered": self.vrt_assets_recovered,
@@ -1219,16 +1253,35 @@ async def fail_stale_jobs(
     # presign endpoints, and analysis jobs carry "" too (see
     # `_retry_capability`). An IS NULL guard would match nothing and leave the
     # race exactly as it was, while looking fixed.
-    pending_result = await db.execute(
+    unbound_result = await db.execute(
         update(IngestJob)
         .where(*stale_pending_clauses(now, completion_bound=False))
         .values(
             **stale_pending_unbound_values(now, message=STALE_PENDING_UNBOUND_MESSAGE)
         )
-        .returning(IngestJob.id, IngestJob.user_metadata, IngestJob.created_by)
+        # fix(#1556 review, codex P2): RETURNING carries the status the CASE
+        # actually chose. Postgres returns the NEW row, so this is what the
+        # database wrote — the alternative, re-deriving the predicate in
+        # Python to classify the rows, is a second copy of the rule that can
+        # disagree with the one that ran.
+        .returning(
+            IngestJob.id,
+            IngestJob.user_metadata,
+            IngestJob.created_by,
+            IngestJob.status,
+        )
     )
-    pending_rows = list(pending_result.all())
-    pending_job_ids = [row[0] for row in pending_rows]
+    unbound_rows = list(unbound_result.all())
+    # Positional, like every other row read in this function: a mocked session
+    # hands back plain tuples, and attribute access would work against the
+    # database while raising in the unit suites that drive this with doubles.
+    pending_cancelled = sum(1 for row in unbound_rows if row[3] == "cancelled")
+    # Back to the three columns every consumer below expects; the audit loop
+    # still visits cancelled rows, which is a no-op for them by construction
+    # (an embedding backfill carries no `presigned` marker, so it is never in
+    # the cancelled class).
+    pending_rows = [(row[0], row[1], row[2]) for row in unbound_rows]
+    pending_job_ids = [row[0] for row in unbound_rows]
 
     # fix(#1234): the other half. A row that DID bind bytes but never committed
     # its status is now exempt from the 1h clause, and the retention purge only
@@ -1471,7 +1524,8 @@ async def fail_stale_jobs(
             deleted_paths -= set(survivors.scalars())
         staged_paths_considered = len(deleted_paths)
     outcome = StaleCleanupOutcome(
-        pending_failed=len(pending_job_ids),
+        pending_failed=len(pending_job_ids) - pending_cancelled,
+        pending_cancelled=pending_cancelled,
         running_failed=len(running_job_ids),
         vrt_assets_recovered=vrt_assets_recovered,
         vrt_generations_failed=vrt_generations_failed,

--- a/backend/app/platform/jobs/worker.py
+++ b/backend/app/platform/jobs/worker.py
@@ -159,28 +159,41 @@ async def _recover_stale_jobs_for_current_scope() -> None:
         # bound/unbound split (#1234, so it could fail a completion mid-commit
         # every time a worker booted).
         from app.platform.jobs.router import (
+            ABANDONED_UPLOAD_MESSAGE,
             STALE_PENDING_UNBOUND_MESSAGE,
+            is_abandoned_presigned_upload,
             stale_pending_clauses,
+            stale_pending_unbound_values,
         )
 
         orphaned_result = await session.execute(
             update(IngestJob)
             .where(*stale_pending_clauses(now, completion_bound=False))
             .values(
-                status="failed",
-                error_message=STALE_PENDING_UNBOUND_MESSAGE,
-                completed_at=now,
+                **stale_pending_unbound_values(
+                    now, message=STALE_PENDING_UNBOUND_MESSAGE
+                )
             )
             .returning(IngestJob)
         )
         orphaned_jobs = list(orphaned_result.scalars())
         for job in orphaned_jobs:
-            job.status = "failed"
-            job.error_message = STALE_PENDING_UNBOUND_MESSAGE
+            # fix(#1556): the mirror has to reproduce the CASE the database
+            # just evaluated, not a constant. These assignments exist to keep
+            # lightweight session doubles representative (see the running half
+            # above), but they are writes to a persistent instance either way —
+            # a flat `job.status = "failed"` here would mark the object dirty
+            # and push `failed` back over the `cancelled` the UPDATE wrote.
+            abandoned = is_abandoned_presigned_upload(job.file_path, job.user_metadata)
+            job.status = "cancelled" if abandoned else "failed"
+            job.error_message = (
+                ABANDONED_UPLOAD_MESSAGE if abandoned else STALE_PENDING_UNBOUND_MESSAGE
+            )
             job.completed_at = now
             log.warning(
                 "Recovered orphaned pending job",
                 job_id=str(job.id),
+                status=job.status,
             )
             # fix(#1556): the other half, same reason. A backfill whose
             # dispatch never landed is `pending` with no queue row, which is

--- a/backend/app/processing/ingest/presigned.py
+++ b/backend/app/processing/ingest/presigned.py
@@ -294,20 +294,27 @@ def require_completable_presigned_job(job: "IngestJob", *, restart_hint: str) ->
        whatever now sits at the staging key, which the client's unexpired PUT
        URL controls.
 
-    2. status `failed` — the job is terminal and no task will ever run for it.
-       Without this a client could re-PUT after a content refusal and complete
-       again: the endpoint 200s and binds a frozen object, but the row stays
-       failed, so preview and commit then reject it with "Job already
-       processed". The 200 is a lie, the client's recovery path is dead, and
-       the frozen object is unowned — no task tail fires for a job nothing was
-       deferred for, and the post-expiry sweep only covers the client's key.
+    2. a TERMINAL status — the job is settled and no task will ever run for
+       it. Without this a client could re-PUT after a content refusal and
+       complete again: the endpoint 200s and binds a frozen object, but the
+       row stays terminal, so preview and commit then reject it with "Job
+       already processed". The 200 is a lie, the client's recovery path is
+       dead, and the frozen object is unowned — no task tail fires for a job
+       nothing was deferred for, and the post-expiry sweep only covers the
+       client's key.
 
     The two doors reach state 2 by different routes, which is why this guard
     belongs to both: the reupload door stamps `failed` itself before a content
     422 (its direct sibling does, and a provenance test asserts that trail),
-    while an abandoned presigned upload is marked failed by the stale-pending
-    reaper after an hour — the same hour the PUT URL stays valid, so the
-    windows overlap.
+    while an abandoned presigned upload is settled by the stale-pending reaper
+    after an hour — the same hour the PUT URL stays valid, so the windows
+    overlap.
+
+    fix(#1556): that reaper now settles the abandoned-upload class `cancelled`
+    rather than `failed`, so "terminal" here is BOTH statuses. Reading only
+    `failed` would have reopened this hole for the exact rows the sentence
+    above is about — the class that reaches state 2 without any door stamping
+    it — while every test covering the door-stamped route kept passing.
 
     REJECT rather than resurrect. Reviving a failed job would re-open the
     client-writable-state-re-entering class this endpoint spent ten rounds
@@ -322,6 +329,13 @@ def require_completable_presigned_job(job: "IngestJob", *, restart_hint: str) ->
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=f"This job has already failed and cannot be completed. {restart_hint}",
+        )
+    if job.status == "cancelled":
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=(
+                f"This upload was abandoned and has been cancelled. {restart_hint}"
+            ),
         )
 
 

--- a/backend/tests/test_jobs_router.py
+++ b/backend/tests/test_jobs_router.py
@@ -1103,7 +1103,15 @@ class TestCleanupStaleJobs:
             audit for audit in audits if audit["details"].get("outcome") == "completed"
         )
         operation_id = completed["details"]["operation_id"]
-        assert completed["details"] == {
+        details = dict(completed["details"])
+        # fix(#1556): the audit detail carries one count the published response
+        # model does not. `pending_cancelled` reaches this JSONB blob (and the
+        # multi-tenant fleet totals) so an operator can see that a pass settled
+        # abandoned uploads rather than failing anything; StaleCleanupResponse
+        # has no such field and pydantic drops it on the way out. Popped here so
+        # the exact-shape assertion below still refuses any OTHER new key.
+        assert isinstance(details.pop("pending_cancelled"), int)
+        assert details == {
             "operation_id": operation_id,
             "outcome": "completed",
             **{key: data[key] for key in expected_counts},

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -2862,7 +2862,16 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # is also unbound, and `/jobs/{id}/retry` only offers a `failed` row, so
     # the broader rule would take a recoverable job's recovery away.
     # Cap 1522 -> 1599, exact.
-    "backend/app/platform/jobs/sweep.py": 1599,
+    # fix(#1556 review, codex P2): +54 — the unbound UPDATE returns the status
+    # its CASE chose, so `pending_failed` can stop counting the rows that were
+    # cancelled. Without it the admin cleanup response, its audit event and the
+    # sweeper's log line all still reported an abandoned upload as a failure,
+    # which is the whole thing the split exists to stop. The lines are the new
+    # field plus the docstrings recording why `total_cleaned` excludes
+    # cancellations while `total_affected` includes them, and why the count
+    # reaches the audit event but not the published response model.
+    # Cap 1599 -> 1653, exact.
+    "backend/app/platform/jobs/sweep.py": 1653,
     # fix(second-opinion review on #1236 review r3): first entry — crossed
     # _RATCHET_INCLUSION_LOC while adding the belt-and-suspenders
     # `le=5120` bound on `presigned_multipart_threshold_mb` (the router-side

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -2852,7 +2852,17 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # `terminal_backfill_audit_exists`: one operation gets one terminal entry,
     # whoever writes it first, because three actors can legitimately close the
     # same run and two of them disagreeing is the defect.
-    "backend/app/platform/jobs/sweep.py": 1522,
+    # fix(#1556): +77 — the unbound half of the pending sweep gained an ACTION
+    # helper (`stale_pending_unbound_values`) to sit beside the existing clause
+    # helper, so a presigned upload nobody ever bound bytes to settles
+    # `cancelled` at all three sites that can reach it instead of `failed` at
+    # whichever one got there first. Most of the lines are the two predicate
+    # docstrings recording why the class is "presigned marker AND empty
+    # file_path" and not "falsy file_path": a service import with a source_url
+    # is also unbound, and `/jobs/{id}/retry` only offers a `failed` row, so
+    # the broader rule would take a recoverable job's recovery away.
+    # Cap 1522 -> 1599, exact.
+    "backend/app/platform/jobs/sweep.py": 1599,
     # fix(second-opinion review on #1236 review r3): first entry — crossed
     # _RATCHET_INCLUSION_LOC while adding the belt-and-suspenders
     # `le=5120` bound on `presigned_multipart_threshold_mb` (the router-side

--- a/backend/tests/test_stale_pending_reaper.py
+++ b/backend/tests/test_stale_pending_reaper.py
@@ -658,6 +658,43 @@ class TestAbandonedUploadsAreCancelled:
         assert dispatched.status == "failed"
         assert "never queued" in (dispatched.error_message or "")
 
+    async def test_the_outcome_counts_cancellations_apart_from_failures(
+        self, test_db_session
+    ) -> None:
+        """fix(#1556 review, codex P2): settling the row was only half of it.
+
+        `pending_failed` is read as a failure count by the admin cleanup
+        response, by its `job.cleanup_stale` audit event and by the sweeper's
+        log line. Leaving abandoned uploads inside it undoes the split at
+        exactly the surfaces the split exists for — the row would say
+        `cancelled` while the pass that wrote it still reported a failure.
+        """
+        from app.platform.jobs.router import fail_stale_jobs
+
+        # The test database is shared across every test on this xdist worker
+        # (see conftest's isolation note), so drain whatever is already stale
+        # before counting. Without this the assertions below measure other
+        # tests' leftovers.
+        await fail_stale_jobs(test_db_session)
+
+        await _make_pending_job(test_db_session, age_seconds=7200, file_path="")
+        await _make_pending_job(
+            test_db_session, age_seconds=7200, file_path="", presigned=False
+        )
+
+        outcome = await fail_stale_jobs(test_db_session, detailed=True)
+
+        assert outcome.pending_cancelled == 1
+        assert outcome.pending_failed == 1, (
+            "the abandoned upload is still being counted as a failure"
+        )
+        assert outcome.total_cleaned == outcome.pending_failed + outcome.running_failed
+        # Work done, not failures: a pass that cancelled a row mutated it.
+        assert outcome.total_affected >= outcome.total_cleaned + 1
+        detail = outcome.as_dict()
+        assert detail["pending_cancelled"] == 1
+        assert detail["pending_failed"] == 1
+
     async def test_a_cancelled_job_cannot_be_completed(self) -> None:
         """The completion door reads the sweep's terminal state.
 
@@ -696,6 +733,48 @@ class TestAbandonedUploadsAreCancelled:
         from app.platform.jobs.router import is_abandoned_presigned_upload
 
         assert is_abandoned_presigned_upload(file_path, user_metadata) is abandoned
+
+
+def test_the_published_cleanup_response_drops_the_new_count_without_raising() -> None:
+    """fix(#1556 review, codex P2): the boundary, pinned deliberately.
+
+    `pending_cancelled` reaches the audit event's `details` (a JSONB blob with
+    no schema) and the multi-tenant fleet totals. It stops at
+    `StaleCleanupResponse`, which is published in openapi.json and generated
+    into both SDKs and `api.generated.ts` — adding a field there is a contract
+    change with a regen attached, and it is a decision to take on its own
+    rather than a side effect of this one.
+
+    The endpoint builds that model with `StaleCleanupResponse(**details)`, so
+    the half that MUST hold is that the extra key is ignored rather than
+    refused: an `extra="forbid"` added later (six sibling models in that file
+    have it) would turn every cleanup call into a 500.
+    """
+    from app.platform.jobs.schemas import StaleCleanupResponse
+    from app.platform.jobs.sweep import StaleCleanupOutcome
+
+    outcome = StaleCleanupOutcome(
+        pending_failed=1,
+        running_failed=0,
+        vrt_assets_recovered=0,
+        vrt_generations_failed=0,
+        terminal_jobs_purged=0,
+        staged_paths_considered=0,
+        local_files_reaped=0,
+        storage_objects_reaped=0,
+        staged_paths_skipped=0,
+        staged_cleanup_failures=0,
+        pending_cancelled=2,
+    )
+    details = outcome.as_dict()
+    assert details["pending_cancelled"] == 2
+    assert details["pending_failed"] == 1
+    assert details["total_cleaned"] == 1, "cancellations must not inflate the failures"
+    assert details["total_affected"] == 3, "cancellations are work the pass did"
+
+    response = StaleCleanupResponse(**details)
+    assert response.pending_failed == 1
+    assert not hasattr(response, "pending_cancelled")
 
 
 def test_every_unbound_pending_site_uses_the_shared_action() -> None:

--- a/backend/tests/test_stale_pending_reaper.py
+++ b/backend/tests/test_stale_pending_reaper.py
@@ -185,8 +185,20 @@ class TestStatusPollDoesNotReapQueuedJobs:
         assert "without being processed" in (job.error_message or "")
 
 
-async def _make_pending_job(session, *, age_seconds: int, file_path: str):
-    """A pending job aged past a cutoff, with file_path as given."""
+async def _make_pending_job(
+    session,
+    *,
+    age_seconds: int,
+    file_path: str,
+    presigned: bool = True,
+    source_url: str | None = None,
+):
+    """A pending job aged past a cutoff, with file_path as given.
+
+    fix(#1556): `presigned` is now a parameter because it discriminates two
+    classes that both reach the unbound half. Default True keeps every existing
+    caller describing the presigned upload it already described.
+    """
     from datetime import datetime, timedelta, timezone
 
     from sqlalchemy import select, update
@@ -202,7 +214,8 @@ async def _make_pending_job(session, *, age_seconds: int, file_path: str):
         created_by=admin.id,
         status="pending",
         file_path=file_path,
-        user_metadata={"presigned": True},
+        source_url=source_url,
+        user_metadata={"presigned": True} if presigned else {},
     )
     session.add(job)
     await session.commit()
@@ -226,7 +239,9 @@ class TestBoundPendingSweep:
     """
 
     @staticmethod
-    async def _make_job(session, *, age_seconds: int, file_path: str):
+    async def _make_job(
+        session, *, age_seconds: int, file_path: str, presigned: bool = True
+    ):
         from datetime import datetime, timedelta, timezone
 
         from sqlalchemy import select, update
@@ -242,7 +257,7 @@ class TestBoundPendingSweep:
             created_by=admin.id,
             status="pending",
             file_path=file_path,
-            user_metadata={"presigned": True},
+            user_metadata={"presigned": True} if presigned else {},
         )
         session.add(job)
         await session.commit()
@@ -276,11 +291,35 @@ class TestBoundPendingSweep:
             "bytes — the completion that set file_path was still committing"
         )
 
-    async def test_an_unbound_job_still_fails_at_1h(self, test_db_session) -> None:
-        """The policy itself is deliberate and stays."""
+    async def test_an_unbound_job_is_still_settled_at_1h(self, test_db_session) -> None:
+        """The policy itself is deliberate and stays.
+
+        fix(#1556): the TERMINAL STATE moved for this row and only this row —
+        a presigned upload with nothing bound is an abandonment, not a failed
+        ingest. The 1h clause, the class it selects and the sites that apply it
+        are all untouched; see TestAbandonedUploadsAreCancelled for the split.
+        """
         from app.platform.jobs.router import fail_stale_jobs
 
         job = await self._make_job(test_db_session, age_seconds=7200, file_path="")
+
+        await fail_stale_jobs(test_db_session)
+
+        await test_db_session.refresh(job)
+        assert job.status == "cancelled"
+        assert "Abandoned" in (job.error_message or "")
+
+    async def test_an_unbound_non_presigned_job_still_fails_at_1h(
+        self, test_db_session
+    ) -> None:
+        """The other side of the same fork: an analysis run or an embedding
+        backfill also carries `file_path=""`, and a dispatch that never landed
+        is a real failure of something the user asked for."""
+        from app.platform.jobs.router import fail_stale_jobs
+
+        job = await self._make_job(
+            test_db_session, age_seconds=7200, file_path="", presigned=False
+        )
 
         await fail_stale_jobs(test_db_session)
 
@@ -402,11 +441,32 @@ class TestPollingPathHonoursTheSameGuard:
             "completion that set file_path was still committing"
         )
 
-    async def test_a_poll_still_fails_an_unbound_pending_job(
+    async def test_a_poll_still_settles_an_unbound_pending_job(
         self, client, admin_auth_header, test_db_session
     ) -> None:
-        """The 1h abandonment policy is deliberate and stays on this path too."""
+        """The 1h abandonment policy is deliberate and stays on this path too.
+
+        fix(#1556): terminal state only — this row is a presigned upload with
+        nothing bound, so the poll settles it `cancelled` exactly as the
+        background sweep does. The non-presigned twin below keeps `failed`.
+        """
         job = await _make_pending_job(test_db_session, age_seconds=7200, file_path="")
+
+        resp = await self._poll(client, admin_auth_header, job.id)
+
+        assert resp.status_code == 200, resp.text
+        await test_db_session.refresh(job)
+        assert job.status == "cancelled"
+        assert "Abandoned" in (job.error_message or "")
+
+    async def test_a_poll_still_fails_an_unbound_non_presigned_job(
+        self, client, admin_auth_header, test_db_session
+    ) -> None:
+        """The poll keeps its own elapsed-seconds wording for everything that
+        is not an abandoned upload."""
+        job = await _make_pending_job(
+            test_db_session, age_seconds=7200, file_path="", presigned=False
+        )
 
         resp = await self._poll(client, admin_auth_header, job.id)
 
@@ -454,6 +514,210 @@ class TestPollingPathHonoursTheSameGuard:
         await test_db_session.refresh(job)
         assert job.status == "failed"
         assert "completed but never committed" in (job.error_message or "")
+
+
+class TestAbandonedUploadsAreCancelled:
+    """fix(#1556): a presigned upload nobody ever bound bytes to is not a
+    failed ingest.
+
+    On the public demo two rows (uls.csv, 2026-08-18) sat in the admin jobs
+    list as `failed` with "Stale: pending too long (never queued)" — a visitor
+    asked for a presigned URL and walked away. Nothing was ever attempted, so
+    they were indistinguishable from real ingest failures in the failed-jobs
+    badge and in operator triage.
+
+    `cancelled` is already in the `ingest_jobs` status CHECK constraint, in the
+    admin `JobStatus` literal and in openapi.json, so this is a state change
+    and not a schema or contract change.
+    """
+
+    async def test_the_sweep_cancels_an_abandoned_upload(self, test_db_session) -> None:
+        from app.platform.jobs.router import fail_stale_jobs
+
+        job = await _make_pending_job(test_db_session, age_seconds=7200, file_path="")
+
+        await fail_stale_jobs(test_db_session)
+
+        await test_db_session.refresh(job)
+        assert job.status == "cancelled"
+        assert job.error_message == "Abandoned: upload was never completed"
+        assert job.completed_at is not None
+
+    async def test_a_service_import_awaiting_retry_still_fails(
+        self, test_db_session
+    ) -> None:
+        """The reason the class is not "falsy file_path".
+
+        A service/URL import that was never queued is unbound too, and it IS
+        recoverable — but `/jobs/{id}/retry` and `_retry_capability` both
+        require status `failed`, so cancelling it would take its only recovery
+        path away.
+        """
+        from app.platform.jobs.router import fail_stale_jobs, get_retry_capability
+
+        job = await _make_pending_job(
+            test_db_session,
+            age_seconds=7200,
+            file_path="",
+            presigned=False,
+            source_url="https://example.test/roads.geojson",
+        )
+
+        await fail_stale_jobs(test_db_session)
+
+        await test_db_session.refresh(job)
+        assert job.status == "failed"
+        assert "never queued" in (job.error_message or "")
+        can_retry, reason = await get_retry_capability(job)
+        assert can_retry, f"the retry path was lost: {reason}"
+
+    async def test_a_direct_upload_with_a_real_file_still_fails(
+        self, test_db_session
+    ) -> None:
+        """#1235's absolute-path class, unchanged: a real file exists and
+        retry matters, so the row must stay `failed`."""
+        from app.platform.jobs.router import fail_stale_jobs
+
+        job = await _make_pending_job(
+            test_db_session, age_seconds=7200, file_path="/tmp/fake.geojson"
+        )
+
+        await fail_stale_jobs(test_db_session)
+
+        await test_db_session.refresh(job)
+        assert job.status == "failed"
+        assert "never queued" in (job.error_message or "")
+
+    async def test_the_bound_half_is_untouched(self, test_db_session) -> None:
+        """The 24h backstop keeps writing `failed` with its own message: a
+        completion that bound bytes and then stalled IS a failure."""
+        from app.platform.jobs.router import fail_stale_jobs
+
+        job = await _make_pending_job(
+            test_db_session,
+            age_seconds=90000,
+            file_path="staging/x/frozen/roads.geojson",
+        )
+
+        await fail_stale_jobs(test_db_session)
+
+        await test_db_session.refresh(job)
+        assert job.status == "failed"
+        assert "completed but never committed" in (job.error_message or "")
+
+    async def test_the_running_lease_sweep_is_untouched(self, test_db_session) -> None:
+        """The stale-RUNNING path shares the function, not the values."""
+        from datetime import datetime, timedelta, timezone
+
+        from sqlalchemy import update
+
+        from app.platform.jobs.models import IngestJob
+        from app.platform.jobs.router import fail_stale_jobs
+
+        job = await _make_pending_job(test_db_session, age_seconds=7200, file_path="")
+        await test_db_session.execute(
+            update(IngestJob)
+            .where(IngestJob.id == job.id)
+            .values(
+                status="running",
+                started_at=datetime.now(timezone.utc) - timedelta(seconds=7200),
+            )
+        )
+        await test_db_session.commit()
+
+        await fail_stale_jobs(test_db_session)
+
+        await test_db_session.refresh(job)
+        assert job.status == "failed"
+        assert "running for over" in (job.error_message or "")
+
+    async def test_the_worker_startup_recovery_cancels_it_too(
+        self, test_db_session
+    ) -> None:
+        """The third site. It settles the same rows with the same clauses, and
+        it is the pass that actually reaches a row after a hard restart."""
+        from app.platform.jobs.worker import recover_stale_jobs
+
+        abandoned = await _make_pending_job(
+            test_db_session, age_seconds=7200, file_path=""
+        )
+        dispatched = await _make_pending_job(
+            test_db_session, age_seconds=7200, file_path="", presigned=False
+        )
+
+        await recover_stale_jobs()
+
+        test_db_session.expire_all()
+        await test_db_session.refresh(abandoned)
+        await test_db_session.refresh(dispatched)
+        assert abandoned.status == "cancelled", (
+            "the worker's startup recovery still reports an abandoned upload "
+            "as a failed ingest"
+        )
+        assert abandoned.error_message == "Abandoned: upload was never completed"
+        assert dispatched.status == "failed"
+        assert "never queued" in (dispatched.error_message or "")
+
+    async def test_a_cancelled_job_cannot_be_completed(self) -> None:
+        """The completion door reads the sweep's terminal state.
+
+        `require_completable_presigned_job` refuses a settled job precisely
+        because the PUT URL outlives the 1h clause, so a client can still
+        re-PUT and complete. Reading only `failed` would have reopened that
+        hole for the one class that reaches it without any door stamping it.
+        """
+        from app.processing.ingest.presigned import require_completable_presigned_job
+
+        job = SimpleNamespace(file_path="", status="cancelled")
+        with pytest.raises(HTTPException) as exc:
+            require_completable_presigned_job(job, restart_hint="Start again.")
+        assert exc.value.status_code == 400
+        assert "cancelled" in exc.value.detail.lower()
+
+    @pytest.mark.parametrize(
+        "file_path,user_metadata,abandoned",
+        [
+            ("", {"presigned": True}, True),
+            (None, {"presigned": True}, True),
+            ("", {}, False),
+            ("", None, False),
+            ("", {"analysis": True}, False),
+            ("", {"embedding_backfill": {}}, False),
+            ("/tmp/fake.geojson", {"presigned": True}, False),
+            ("staging/x/frozen/roads.geojson", {"presigned": True}, False),
+        ],
+    )
+    def test_the_python_twin_agrees_with_the_sql_predicate(
+        self, file_path, user_metadata, abandoned
+    ) -> None:
+        """The worker mirrors the UPDATE onto ORM instances, so the two
+        expressions of one rule must not drift. Enumerated over every shape a
+        pending row can carry, not just the reported one."""
+        from app.platform.jobs.router import is_abandoned_presigned_upload
+
+        assert is_abandoned_presigned_upload(file_path, user_metadata) is abandoned
+
+
+def test_every_unbound_pending_site_uses_the_shared_action() -> None:
+    """fix(#1556): the census again, for the ACTION this time.
+
+    The clause helper stopped a fifth site from reconstructing the predicates.
+    The same argument applies to what a site WRITES: three of them settle an
+    unbound pending row, and a split applied at one while the others keep
+    writing `failed` makes the same abandoned upload report two different
+    terminal states depending on which actor reached it first.
+    """
+    import inspect
+
+    from app.platform.jobs import router as jobs_router
+    from app.platform.jobs import sweep as jobs_sweep
+    from app.platform.jobs import worker as jobs_worker
+
+    for module in (jobs_router, jobs_sweep, jobs_worker):
+        assert "stale_pending_unbound_values" in inspect.getsource(module), (
+            f"{module.__name__} settles unbound pending rows without the "
+            "shared action helper"
+        )
 
 
 def test_every_pending_fail_site_uses_the_shared_clauses() -> None:
@@ -677,15 +941,16 @@ class TestThePollPathSkipsUpdatesItCannotMatch:
             "routine poll, and the frontend polls this route every 2s"
         )
 
-    async def test_a_genuinely_stale_job_is_still_failed(
+    async def test_a_genuinely_stale_job_is_still_settled(
         self, test_db_session: AsyncSession
     ) -> None:
         """The skip must not become the guard: past the cutoff the UPDATE runs
-        and the row is failed exactly as before."""
+        and the row goes terminal exactly as before (fix(#1556): `cancelled`
+        for this presigned-and-unbound row)."""
         job = await _make_pending_job(test_db_session, age_seconds=7200, file_path="")
 
         statements = await self._poll_recording_statements(test_db_session, job)
 
         assert self._updates(statements), "the stale job was never updated"
         await test_db_session.refresh(job)
-        assert job.status == "failed"
+        assert job.status == "cancelled"

--- a/backend/tests/test_vrt_stale_sweep_gap002.py
+++ b/backend/tests/test_vrt_stale_sweep_gap002.py
@@ -138,7 +138,9 @@ def _make_mock_db_for_fail_stale(
 
     execute() side effects (in order):
       1. stale UNBOUND pending IngestJobs (1h) → all() returns
-         (id, user_metadata, created_by) triples
+         (id, user_metadata, created_by, status) — fix(#1556 review) widened
+         this one RETURNING so the sweep can count the rows its CASE settled
+         `cancelled` apart from the ones it failed
       2. stale BOUND pending IngestJobs (24h, fix(#1234)) → empty here
       3. stale running IngestJobs → all() returns the same triples
       3. stale VrtGeneration UPDATE → all() returns (id, vrt_dataset_id) pairs
@@ -160,14 +162,16 @@ def _make_mock_db_for_fail_stale(
       6. optional surviving-path SELECT when a deleted row had a file_path
     """
     results = []
-    for returned_ids in [
-        stale_jobs_pending or [],
-        # fix(#1234): the pending sweep is two clauses now — unbound rows at
-        # 1h, then rows that bound bytes but never committed at 24h. These
-        # fixtures exercise the first, so the second returns nothing.
-        [],
-        stale_jobs_running or [],
-    ]:
+    for index, returned_ids in enumerate(
+        [
+            stale_jobs_pending or [],
+            # fix(#1234): the pending sweep is two clauses now — unbound rows at
+            # 1h, then rows that bound bytes but never committed at 24h. These
+            # fixtures exercise the first, so the second returns nothing.
+            [],
+            stale_jobs_running or [],
+        ]
+    ):
         mock_result = MagicMock()
         mock_result.scalars.return_value = returned_ids
         # fix(#1550 review): the three job sweeps RETURN (id, user_metadata,
@@ -176,7 +180,19 @@ def _make_mock_db_for_fail_stale(
         # run's own metadata to write a correlated entry. These fixtures carry
         # no backfill marker, so the audit emission is a no-op for them; the
         # shape still has to match or the counts read zero.
-        mock_result.all.return_value = [(job_id, None, None) for job_id in returned_ids]
+        #
+        # fix(#1556 review): the UNBOUND half (index 0) carries a fourth column,
+        # the status its CASE chose. These fixtures describe rows with no
+        # `presigned` marker, so the status the database would have written is
+        # `failed` — which is what keeps `pending_failed` reading 1 below.
+        if index == 0:
+            mock_result.all.return_value = [
+                (job_id, None, None, "failed") for job_id in returned_ids
+            ]
+        else:
+            mock_result.all.return_value = [
+                (job_id, None, None) for job_id in returned_ids
+            ]
         results.append(mock_result)
 
     # feat(#1267): RETURNING widened to (id, vrt_dataset_id) — the storage

--- a/frontend/src/components/import/hooks/__tests__/use-ingest.test.ts
+++ b/frontend/src/components/import/hooks/__tests__/use-ingest.test.ts
@@ -1,4 +1,4 @@
-import { renderHook, waitFor } from '@/test/test-utils';
+import { act, renderHook, waitFor } from '@/test/test-utils';
 import { vi } from 'vitest';
 import { useRef } from 'react';
 import { useQueryClient, type QueryClient } from '@tanstack/react-query';
@@ -26,6 +26,7 @@ import {
   useDiscoverTables,
   useUploadConfig,
   useCreateVrt,
+  isTerminalJobStatus,
 } from '@/components/import/hooks/use-ingest';
 import { queryKeys } from '@/lib/query-keys';
 import { useAuthStore } from '@/stores/auth-store';
@@ -120,6 +121,75 @@ describe('useJobStatus', () => {
     const { result } = renderHook(() => useJobStatus('bad-id'));
 
     await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+
+  /**
+   * fix(#1556): the poll's terminal check is a DENYLIST, so a terminal status
+   * missing from it does not merely mis-render — it polls /jobs/{id} every 2s
+   * for the life of the tab. An abandoned presigned upload now settles
+   * 'cancelled', which was the missing one.
+   */
+  it('stops polling once a job settles cancelled', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    try {
+      mockGetJobStatus.mockResolvedValue({ job_id: 'j-c', status: 'cancelled' } as never);
+
+      const { result } = renderHook(() => useJobStatus('j-c'));
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0);
+      });
+      expect(result.current.isSuccess).toBe(true);
+      expect(mockGetJobStatus).toHaveBeenCalledTimes(1);
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(10_000);
+      });
+      expect(mockGetJobStatus).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('keeps polling a job that is still running', async () => {
+    // The control for the test above: without it, a hook that never polls at
+    // all would satisfy the cancelled case for the wrong reason.
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    try {
+      mockGetJobStatus.mockResolvedValue({ job_id: 'j-r', status: 'running' } as never);
+
+      renderHook(() => useJobStatus('j-r'));
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0);
+      });
+      expect(mockGetJobStatus).toHaveBeenCalledTimes(1);
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(10_000);
+      });
+      expect(mockGetJobStatus.mock.calls.length).toBeGreaterThan(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
+describe('isTerminalJobStatus', () => {
+  // Enumerated over the whole JobStatusResponse status enum rather than the
+  // one status that was reported, because the failure mode is "a status is
+  // missing from the denylist" and only enumeration can see that.
+  it.each(['complete', 'failed', 'fanned_out', 'cancelled'])(
+    'treats %s as terminal',
+    (status) => {
+      expect(isTerminalJobStatus(status)).toBe(true);
+    },
+  );
+
+  it.each(['pending', 'running'])('keeps %s pollable', (status) => {
+    expect(isTerminalJobStatus(status)).toBe(false);
+  });
+
+  it('treats an absent status as pollable', () => {
+    expect(isTerminalJobStatus(undefined)).toBe(false);
   });
 });
 

--- a/frontend/src/components/import/hooks/use-ingest.ts
+++ b/frontend/src/components/import/hooks/use-ingest.ts
@@ -12,6 +12,29 @@ export function useUploadFile() {
   });
 }
 
+/**
+ * Job statuses a job never transitions out of, so polling must stop.
+ *
+ * 'fanned_out' is terminal because the parent never transitions again; its
+ * children (with their own job IDs) carry forward progress. See SMOKE-v1013-F1.
+ *
+ * fix(#1556): 'cancelled' joined the set, and the set became a named function
+ * rather than an inline condition. This is a DENYLIST — anything missing from
+ * it polls /jobs/{id} every 2s for the life of the tab — so it has to be
+ * exhaustive over the status enum, and the one place that decides is easier to
+ * keep exhaustive than a condition inside a query option. An abandoned
+ * presigned upload now settles 'cancelled' instead of 'failed', which is
+ * exactly the status that was missing.
+ */
+export function isTerminalJobStatus(status: string | undefined): boolean {
+  return (
+    status === 'complete' ||
+    status === 'failed' ||
+    status === 'fanned_out' ||
+    status === 'cancelled'
+  );
+}
+
 export function useJobStatus(jobId: string | null) {
   // fix(#762): AnalysisJobWatcher mounts in RootLayout with a persist-backed
   // job id, so without this gate a stale tracked job made an anonymous
@@ -24,13 +47,7 @@ export function useJobStatus(jobId: string | null) {
     queryFn: () => getJobStatus(jobId!),
     enabled: !!jobId && hasToken,
     staleTime: 2000,
-    refetchInterval: (query) => {
-      const status = query.state.data?.status;
-      // 'fanned_out' is terminal — the parent never transitions again; children
-      // (with their own job IDs) carry forward progress. See SMOKE-v1013-F1.
-      if (status === 'complete' || status === 'failed' || status === 'fanned_out') return false;
-      return 2000;
-    },
+    refetchInterval: (query) => (isTerminalJobStatus(query.state.data?.status) ? false : 2000),
   });
 }
 


### PR DESCRIPTION
## What

An abandoned presigned upload — a visitor asks for an upload URL and walks away, so the job row is created, nothing is ever uploaded, and it is never queued — now settles as `cancelled` with `"Abandoned: upload was never completed"` instead of `failed` with `"Stale: pending too long (never queued)"`.

Two such rows (uls.csv, 2026-08-18) showed up on the public demo as `failed`, indistinguishable from real ingest failures in the admin jobs list and in the failed-jobs badge counted beside it.

## Why this class and no other

The split is deliberately narrower than "falsy `file_path`", which the unbound half of the sweep also reaps for rows that DID have work attempted:

- **a service/URL import** (`source_url` set, `file_path` empty) whose defer never landed. `/jobs/{id}/retry` and `_retry_capability` both require status `failed`, so cancelling it would take a recoverable job's only recovery path away — the same 1h-to-recoverable-becomes-unrecoverable trap #1235 avoided for absolute paths. Pinned by `test_a_service_import_awaiting_retry_still_fails`, which asserts `get_retry_capability` still answers yes.
- **an analysis run or an admin embedding backfill**, both of which carry `file_path=""` by construction. A dispatch that never landed is a real failure of something the user asked for, and #1550's audit trail settles the backfill `never_started` alongside the row.

The discriminator is the `presigned` marker both presign doors stamp (`processing/ingest/router.py`, `datasets/api/router_reupload.py`) at the moment they hand a client a URL, AND an empty `file_path`. A completion binds `staging/{job}/frozen/...` and is the BOUND half's business, untouched here.

## Where the change lives

In the ACTION, never the clause set. `stale_pending_unbound_values()` is the companion to `stale_pending_clauses()`, for the same reason that helper exists — and it is applied at all three sites that can settle an unbound pending row:

1. `fail_stale_jobs` in `platform/jobs/sweep.py` (background lifespan sweeper + admin cleanup endpoint)
2. `get_job_status` in `platform/jobs/router.py` — the one that actually fires, polled every 2s
3. `_recover_stale_jobs_for_current_scope` in `platform/jobs/worker.py` (startup recovery)

The fourth site in the #1235 census is the sweep's BOUND half, which cannot reach this class: its clause requires the `staging/` prefix. It keeps writing `failed` with `STALE_PENDING_BOUND_MESSAGE` verbatim.

The worker site also mirrors the UPDATE onto the returned ORM instances. A flat `job.status = "failed"` there would mark the persistent object dirty and push `failed` back over the `cancelled` the database just computed, so it now reproduces the CASE via `is_abandoned_presigned_upload()` — a Python twin kept beside the SQL, with a parametrized test enumerating every row shape to pin that the two agree.

## One companion change outside the sweep

`require_completable_presigned_job` (`processing/ingest/presigned.py`) refuses a completion on a settled job, and its docstring names this exact class as the reason: the PUT URL stays valid for the same hour the sweep acts in, so a client can re-PUT and complete into an unowned frozen object while the row stays terminal. It read `status == "failed"` only. Reading only `failed` after this change would have reopened that hole for precisely the rows the docstring is about — the class that reaches a terminal status without any door stamping it — while every test covering the door-stamped route kept passing. It now refuses both terminal statuses, with the `failed` message and behaviour unchanged.

## Verified consequences

- **Failure metrics / alerts.** `geolens_jobs_failed_total` (and therefore `GeoLensJobFailures` in `infra/monitoring/alerts.yml`, plus the Grafana panel at `grafana-dashboard.json:415`) is derived from `catalog.procrastinate_jobs`, not `ingest_jobs` — `grep -c ingest_jobs infra/monitoring/*` is 0 across all three files. An abandoned upload has no procrastinate row at all (that IS the `no_live_procrastinate_job()` predicate), so it never counted there and this changes nothing for those series. The surfaces that do improve are `ingest_jobs`-backed and operator-facing: the admin jobs list (`GET /admin/jobs?status=failed`) and the sidebar failed-jobs alert badge, which is `useFailedJobCount` → `listAdminJobs({ status: 'failed' })`.
- **Frontend.** No changes, and none needed. `cancelled` is an existing status: `JobList.tsx` renders `job.status` through `jobStatusColors[...] ?? 'bg-muted text-muted-foreground border-border'`, so it shows a neutral badge rather than a destructive one; `JobProgress.tsx:75` already has `case 'cancelled': return t('jobProgress.status.cancelled')`; `SaveChatPreviewDialog.tsx:107` already treats `cancelled` alongside `failed`. The admin status-filter dropdown does not offer `cancelled` (it also does not offer `fanned_out`), which is a pre-existing gap and out of scope here — the rows are reachable by dropping the filter, and the URL param passes through.
- **API / SDK / OpenAPI.** No contract change. `cancelled` is already in the `ingest_jobs` status CHECK constraint, in `admin/schemas.py::JobStatus`, and in `backend/openapi.json` (two enums). `GET /admin/jobs`'s `status` is an unconstrained `str` query param, so `status=cancelled` already filtered. `make openapi-check` (run with env sourced) exits 0 with no diff, so no regen is required.
- **Paths that must not change.** The stale-RUNNING lease sweep and the bound/completion 24h backstop share the function, not the values, and both are pinned by tests. Staging lifecycle is unaffected: `_sweep_expired_presigned_staging` selects on `status NOT IN ('pending','running')`, so `cancelled` behaves exactly as `failed` did; the retention purge's survivor query keys on `file_path`, which this class does not have; and `staging_reconcile._owner_still_manages()` keeps shielding the row through its unfinalized `s3_key` half.

## Related

#1556 is the follow-up home for job-lifecycle and audit-trail edges after #1550, and this change follows its principle that the durable trail and the job row must agree about one operation. Of the edges it lists, none are affected: the audit-trail work is scoped to embedding backfills, and those carry `file_path=""` without the `presigned` marker, so they stay `failed` and keep settling `never_started` in the same transaction — the change is a no-op for every row an audit trail exists for. The candidate it lists about *other job types sharing `platform/jobs/router.py` inheriting the sweeper's semantics* is the one this touches, and it is addressed the way that entry asks: the split is expressed once, in a shared helper, applied at every site that can reach the class.

## Verification

```
cd backend && uv run ruff check . && uv run ruff format --check .
uv run pytest tests/test_stale_pending_reaper.py -q                 # 52 passed
uv run pytest tests/test_layering.py -q                             # 47 passed
uv run pytest tests/test_worker.py tests/test_jobs_router.py \
  tests/test_ingest_job_attempt_fencing.py tests/test_tenant_job_recovery.py -q   # 71 passed
uv run pytest tests/test_presigned_content_validation_1202.py \
  tests/test_reupload_completion_contract_1207.py \
  tests/test_presigned_staging_reap_1202.py tests/test_reupload.py -q             # 110 passed
uv run pytest tests/test_embedding_backfill_queue_1542.py \
  tests/test_refresh_gate_1269.py tests/test_refresh_observability_1268.py -q     # 61 passed
uv run pytest tests/test_alert_rules.py -q                          # 17 passed
PYTHONPATH=. uv run python scripts/dump_openapi.py --check          # exit 0, no drift
```

**Counterfactual.** With the commit in place, `git checkout HEAD~1 -- backend/app/` (tests kept, source reverted) and re-running `tests/test_stale_pending_reaper.py` gives **15 failed, 37 passed** — every site-level test (`test_the_sweep_cancels_an_abandoned_upload`, `test_a_poll_still_settles_an_unbound_pending_job`, `test_the_worker_startup_recovery_cancels_it_too`), the completion-door test, the Python/SQL twin table and the action census all fail, with `assert 'failed' == 'cancelled'`. The negative controls (`test_a_service_import_awaiting_retry_still_fails`, `test_a_direct_upload_with_a_real_file_still_fails`, `test_the_bound_half_is_untouched`, `test_the_running_lease_sweep_is_untouched`, `test_an_unbound_non_presigned_job_still_fails_at_1h`) pass against both revisions, which is the point of them. Restored with `git checkout HEAD -- backend/app/`; 99 passed.

## Schema / config impact

None. No migration — `cancelled` was already permitted by `chk_ingest_jobs_status`. No new settings, no env vars, no OpenAPI or SDK regen. `backend/tests/test_layering.py` raises the `sweep.py` LOC cap 1522 → 1599 in the same commit, with the reason recorded inline.

---

## Review round 1 (afe80e6a8)

Both codex P2s were real and are fixed.

**1 — cancellations were still counted as failures.** Settling the row was half the job: the unbound UPDATE returned every row it touched into `pending_rows`, whose length became `pending_failed`, so the admin cleanup response, the `job.cleanup_stale` audit event and the sweeper's log line all still reported an abandoned upload as a failure while the row said `cancelled`.

The unbound RETURNING now carries the status its CASE chose — what the database actually wrote, rather than a second copy of the rule re-derived in Python. `pending_failed` counts only failures; a new `pending_cancelled` counts the rest. `total_cleaned` keeps its published identity (`pending_failed + running_failed`) and its documented meaning (transitioned to failed); `total_affected` gains the cancellations, because that one counts work done and a number that hides work is worse than one that does not break down.

`pending_cancelled` reaches the audit event's JSONB `details` and the multi-tenant fleet totals. It deliberately stops at `StaleCleanupResponse`: that model is published in `openapi.json` and generated into both SDKs and `api.generated.ts`, so adding a field is a contract change with a regen attached, it is not needed to fix the misreport, and it is a call to make on its own rather than as a side effect here. `test_the_published_cleanup_response_drops_the_new_count_without_raising` pins that boundary — including that the extra key is *ignored* rather than refused, since an `extra="forbid"` added later (six sibling models in that file have one) would turn every cleanup call into a 500. **If you would rather surface it in the API, say so and I will add the field and regen.**

`test_vrt_stale_sweep_gap002`'s mocked-session fixture mirrors the real RETURNING shape by design, so it widened with it; the sweep reads rows positionally (a mocked session hands back plain tuples, where attribute access works against the database and raises in the unit suites).

**2 — a cancelled job polled forever.** `useJobStatus`'s poll gate was a denylist of terminal statuses, so a job settling `cancelled` asked `/jobs/{id}` for its status every two seconds for the life of the tab. It is now a named `isTerminalJobStatus` covering the whole status enum. Checked the sibling poll sites while there: `use-dataset.ts:276` and `DatasetPage.tsx:171` gate on *active* statuses (an allowlist), so they already stop for any status they do not know; `BulkTrackingList`'s `isTerminal` is a display gate where `cancelled` behaves exactly as `failed` does today.

### Verification (round 1)

```
cd backend && uv run ruff check . && uv run ruff format --check .
uv run pytest tests/test_stale_pending_reaper.py tests/test_layering.py \
  tests/test_jobs_router.py tests/test_vrt_stale_sweep_gap002.py tests/test_worker.py \
  tests/test_ingest.py tests/test_tenant_job_recovery.py \
  tests/test_embedding_backfill_queue_1542.py -q          # 277 passed
PYTHONPATH=. uv run python scripts/dump_openapi.py --check # exit 0, still no drift
cd frontend && npm run lint && npm run typecheck           # clean
npx vitest run src/components/import src/components/analysis/__tests__/AnalysisJobWatcher.test.tsx \
  src/components/dataset/__tests__/ReuploadDialog.test.tsx # 163 passed (15 files)
```

**Counterfactuals**, both targeted at the exact line rather than the whole file, so the failure is the arithmetic and not a missing symbol:

- backend — restore the commit, then `pending_failed=len(pending_job_ids) - pending_cancelled` → `pending_failed=len(pending_job_ids)`: `test_the_outcome_counts_cancellations_apart_from_failures` fails with `AssertionError: the abandoned upload is still being counted as a failure / assert 2 == 1`; 53 others pass.
- frontend — drop only `status === 'cancelled'` from `isTerminalJobStatus`: exactly 2 fail (`stops polling once a job settles cancelled` and the enumerated `treats cancelled as terminal`), 20 pass — including the `keeps polling a job that is still running` control, which is what stops the poll test from passing for the wrong reason.

The LOC cap for `sweep.py` moves again in the same commit: 1599 → 1653, exact.
