### PR TITLE
fix(ingest): replace raw GDAL stderr with a friendly open-failure message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,8 @@ and releases use semantic versioning.
   upload filename, e.g. "Could not open 'march.gpkg' as a spatial dataset —
   the file may be corrupt, incomplete, or not a valid GeoPackage (.gpkg)
   file."; the full stderr still reaches structured logs at error level, and
-  every other ogr2ogr/ogrinfo failure keeps its real message unchanged.
+  every other ogr2ogr/ogrinfo failure keeps its real message unchanged
+  (#1640).
 
 ## [1.15.0] - 2026-08-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,18 @@ and releases use semantic versioning.
   `convert_to_cog` now checks each band's actual bit width before deciding
   whether a predictor creation option is safe to pass.
 
+- **A corrupt vector upload no longer shows a raw GDAL diagnostic dump.**
+  When ogr2ogr or ogrinfo couldn't open an uploaded file — a corrupt or
+  incomplete GeoPackage, Shapefile, or similar — the stored and displayed
+  `IngestJob.error_message` was GDAL's raw stderr verbatim: either a 100+
+  line driver enumeration or SQLite's own corrupt-database diagnostics,
+  both including the internal staging file path. Both failure shapes are
+  now recognized and replaced with a short message built from the original
+  upload filename, e.g. "Could not open 'march.gpkg' as a spatial dataset —
+  the file may be corrupt, incomplete, or not a valid GeoPackage (.gpkg)
+  file."; the full stderr still reaches structured logs at error level, and
+  every other ogr2ogr/ogrinfo failure keeps its real message unchanged.
+
 ## [1.15.0] - 2026-08-23
 
 ### Added

--- a/backend/app/processing/ingest/ogr.py
+++ b/backend/app/processing/ingest/ogr.py
@@ -7,6 +7,8 @@ import re
 from collections.abc import Callable
 from typing import TypedDict
 
+import structlog
+
 from app.core.config import settings
 from app.core.crs_uri import parse_crs_uri
 from app.core.service_tokens import HEADER_TOKEN_CHARSET, HEADER_TOKEN_MIN_LENGTH
@@ -18,6 +20,77 @@ from app.core.url_redaction import redact_url_credentials
 # The trailing mode group (...) is optional — some GDAL builds emit bare driver names
 # without a mode suffix, so the regex accepts " -> 'NAME'" with optional "(...)" after.
 _OGR_DRIVER_LIST_LINE_RE = re.compile(r"^\s*->\s*'[^']+'\s*(\([^)]*\))?\s*$")
+
+# When ogr2ogr/ogrinfo can find no driver willing to open the source, they
+# print this one line followed by GDAL's full driver enumeration (100+
+# lines) — the raw text a demo visitor saw verbatim in the job UI for an
+# invalid march.gpkg upload. Anchored tightly to that exact phrase so no
+# other failure class (bad SRS, permission denied, disk full, ...) matches.
+_OGR_UNABLE_TO_OPEN_RE = re.compile(
+    r"Unable to open datasource `[^']*' with the following drivers\."
+)
+
+# A second shape of the same user-facing problem: a driver DOES claim the
+# source (by extension/header — e.g. GPKG is SQLite) but the content
+# underneath is corrupt, which surfaces as SQLite's own error instead of a
+# GDAL driver-enumeration failure. GDAL prints a "bad application_id=0x..."
+# warning above this for GPKG specifically, but the "file is not a
+# database" line is the one that's common to the class and safe to anchor
+# on — it's SQLite's own open-failure text, not phrasing GDAL reuses for
+# anything else.
+_SQLITE_NOT_A_DATABASE_RE = re.compile(r"file is not a database")
+
+
+def _is_unopenable_source_stderr(stderr_text: str) -> bool:
+    """True when ``stderr_text`` matches a known "can't open this source" shape.
+
+    Both patterns below mean the same thing to the person who uploaded the
+    file — GDAL could not read it as a spatial dataset — so both map to the
+    same friendly message; see ``_friendly_open_failure_message``.
+    """
+    return bool(
+        _OGR_UNABLE_TO_OPEN_RE.search(stderr_text)
+        or _SQLITE_NOT_A_DATABASE_RE.search(stderr_text)
+    )
+
+
+# Human-readable label per uploaded extension, used only to phrase the
+# friendly "could not open" message below. Unknown/missing extensions fall
+# back to a generic "spatial data" phrasing.
+_VECTOR_FORMAT_LABELS: dict[str, str] = {
+    ".gpkg": "GeoPackage (.gpkg)",
+    ".shp": "Shapefile (.shp)",
+    ".zip": "zipped Shapefile (.zip)",
+    ".geojson": "GeoJSON (.geojson)",
+    ".json": "GeoJSON (.json)",
+    ".csv": "CSV (.csv)",
+    ".kml": "KML (.kml)",
+    ".kmz": "KMZ (.kmz)",
+    ".fgb": "FlatGeobuf (.fgb)",
+    ".gml": "GML (.gml)",
+    ".gdb": "File Geodatabase (.gdb)",
+}
+
+
+def _friendly_open_failure_message(original_filename: "str | None") -> str:
+    """User-facing text for an ogr2ogr "unable to open datasource" failure.
+
+    Deliberately built from ``original_filename`` alone — never from the
+    staging path or the raw stderr — so the message can never leak the
+    `/app/staging/<uuid>_...` path GDAL echoes back on this failure class.
+    """
+    name = os.path.basename(original_filename) if original_filename else None
+    suffix = os.path.splitext(name)[1].lower() if name else ""
+    format_label = _VECTOR_FORMAT_LABELS.get(suffix, "spatial data")
+    if name:
+        return (
+            f"Could not open '{name}' as a spatial dataset — the file may be "
+            f"corrupt, incomplete, or not a valid {format_label} file."
+        )
+    return (
+        "Could not open the uploaded file as a spatial dataset — it may be "
+        "corrupt, incomplete, or not a valid spatial data file."
+    )
 
 
 def _sanitize_authorization_token(token: "str | None") -> "str | None":
@@ -467,12 +540,23 @@ def _parse_text_ogrinfo(output: str) -> dict:
     }
 
 
-async def run_ogrinfo(file_path: str, layer_name: str | None = None) -> OgrinfoResult:
+async def run_ogrinfo(
+    file_path: str,
+    layer_name: str | None = None,
+    *,
+    original_filename: str | None = None,
+) -> OgrinfoResult:
     """Run ogrinfo to detect CRS and layer metadata.
 
     Returns dict with keys: srid, geometry_type, layer_name, feature_count, all_layers.
     When multiple layers exist and no layer_name is specified, all_layers lists them.
     Tries JSON output first (GDAL 3.7+), falls back to text parsing.
+
+    Args:
+        original_filename: The user-visible upload filename (not the staging
+            path in ``file_path``), used only to phrase the friendly message
+            on an "unable to open" failure. Optional — callers without it
+            (e.g. the preview endpoint) still get a generic-but-safe message.
     """
     if layer_name:
         validate_layer_name_argv(layer_name)
@@ -532,9 +616,21 @@ async def run_ogrinfo(file_path: str, layer_name: str | None = None) -> OgrinfoR
     )
 
     if proc.returncode != 0:
-        raise IngestionError(
-            f"ogrinfo failed (exit {proc.returncode}): {stderr.decode().strip()}"
-        )
+        stderr_text = stderr.decode().strip()
+        if _is_unopenable_source_stderr(stderr_text):
+            # The full stderr (driver enumeration, or SQLite's own corrupt-
+            # database diagnostics) is diagnostic gold for us and unreadable
+            # noise — plus a leaked staging path — for the job UI. Log the
+            # raw text at error level here, the one place that still sees
+            # it, then raise a short, human-readable IngestionError.
+            structlog.get_logger().error(
+                "ogrinfo could not open source file",
+                exit_code=proc.returncode,
+                stderr=stderr_text,
+                original_filename=original_filename,
+            )
+            raise IngestionError(_friendly_open_failure_message(original_filename))
+        raise IngestionError(f"ogrinfo failed (exit {proc.returncode}): {stderr_text}")
 
     result = _parse_text_ogrinfo(stdout.decode())
     # Text-fallback parse doesn't extract field definitions, so the DBF
@@ -622,6 +718,7 @@ async def run_ogr2ogr(
     *,
     schema: str,
     effective_srid: int | None = None,
+    original_filename: str | None = None,
 ) -> None:
     """Run ogr2ogr to load a file into PostGIS.
 
@@ -637,6 +734,9 @@ async def run_ogr2ogr(
             (user srid_override > detected > 4326). Used only by the parquet
             path, which must stamp geometries with the SRID the downstream
             ST_Transform will trust; GDAL formats carry their own CRS.
+        original_filename: The user-visible upload filename (not the staging
+            path in ``file_path``), used only to phrase the friendly message
+            on an "unable to open" failure.
 
     Raises:
         IngestionError: If ogr2ogr exits with non-zero code.
@@ -752,9 +852,18 @@ async def run_ogr2ogr(
     )
 
     if proc.returncode != 0:
-        raise IngestionError(
-            f"ogr2ogr failed (exit {proc.returncode}): {stderr.decode().strip()}"
-        )
+        stderr_text = stderr.decode().strip()
+        if _is_unopenable_source_stderr(stderr_text):
+            # Same rationale as the matching branch in run_ogrinfo above:
+            # log the full diagnostic once, raise a short user-facing one.
+            structlog.get_logger().error(
+                "ogr2ogr could not open source file",
+                exit_code=proc.returncode,
+                stderr=stderr_text,
+                original_filename=original_filename,
+            )
+            raise IngestionError(_friendly_open_failure_message(original_filename))
+        raise IngestionError(f"ogr2ogr failed (exit {proc.returncode}): {stderr_text}")
 
 
 async def run_ogr2ogr_service(

--- a/backend/app/processing/ingest/ogr.py
+++ b/backend/app/processing/ingest/ogr.py
@@ -37,20 +37,36 @@ _OGR_UNABLE_TO_OPEN_RE = re.compile(
 # warning above this for GPKG specifically, but the "file is not a
 # database" line is the one that's common to the class and safe to anchor
 # on — it's SQLite's own open-failure text, not phrasing GDAL reuses for
-# anything else.
+# anything else. This fires when the SQLite header itself doesn't parse
+# (e.g. the magic string is present but the page-size/header fields are
+# garbage).
 _SQLITE_NOT_A_DATABASE_RE = re.compile(r"file is not a database")
+
+# fix(codex review, #1640): a THIRD shape of the same problem — the SQLite
+# header parses fine (magic, page size, application_id all valid) but an
+# interior b-tree page is corrupt, which SQLite reports as "database disk
+# image is malformed" instead of "file is not a database". Empirically
+# reproduced: a real GPKG (via ogr2ogr) with the first 100 header bytes
+# untouched and ~1KB flipped inside a near-full leaf page of the sqlite
+# schema b-tree (found via `dbstat`) makes `sqlite3` itself report exactly
+# this string, and both ogrinfo and ogr2ogr surface it verbatim in stderr —
+# ogrinfo's failure text does NOT also contain "with the following drivers"
+# or "file is not a database", so without this pattern it fell through to
+# the raw stderr (and the leaked staging path) unmodified.
+_SQLITE_DISK_IMAGE_MALFORMED_RE = re.compile(r"database disk image is malformed")
 
 
 def _is_unopenable_source_stderr(stderr_text: str) -> bool:
     """True when ``stderr_text`` matches a known "can't open this source" shape.
 
-    Both patterns below mean the same thing to the person who uploaded the
-    file — GDAL could not read it as a spatial dataset — so both map to the
-    same friendly message; see ``_friendly_open_failure_message``.
+    All three patterns below mean the same thing to the person who uploaded
+    the file — GDAL could not read it as a spatial dataset — so all three
+    map to the same friendly message; see ``_friendly_open_failure_message``.
     """
     return bool(
         _OGR_UNABLE_TO_OPEN_RE.search(stderr_text)
         or _SQLITE_NOT_A_DATABASE_RE.search(stderr_text)
+        or _SQLITE_DISK_IMAGE_MALFORMED_RE.search(stderr_text)
     )
 
 

--- a/backend/app/processing/ingest/tasks_reupload.py
+++ b/backend/app/processing/ingest/tasks_reupload.py
@@ -84,6 +84,8 @@ async def _detect_reupload_crs(
     file_path: str,
     layer_name: str | None,
     user_metadata: dict,
+    *,
+    original_filename: str | None = None,
 ) -> tuple[dict, int]:
     """Detect CRS/geometry for a reupload file and resolve the effective SRID.
 
@@ -101,7 +103,9 @@ async def _detect_reupload_crs(
     from app.processing.ingest.ogr import IngestionError, run_ogrinfo
     from app.processing.ingest.tasks_common import check_missing_crs
 
-    info = await run_ogrinfo(file_path, layer_name=layer_name)
+    info = await run_ogrinfo(
+        file_path, layer_name=layer_name, original_filename=original_filename
+    )
     srid = info.get("srid")
     geometry_type = info.get("geometry_type")
     srid_override = user_metadata.get("srid_override")
@@ -296,7 +300,7 @@ async def reupload_file(
         # 2-3. Detect CRS from the new file, enforce the missing-CRS gate,
         # and resolve the effective SRID (override > detected > 4326).
         info, effective_srid = await _detect_reupload_crs(
-            file_path, layer_name, user_metadata
+            file_path, layer_name, user_metadata, original_filename=source_filename
         )
         srid = info.get("srid")
         geometry_type = info.get("geometry_type")
@@ -315,6 +319,7 @@ async def reupload_file(
             layer_name=layer_name,
             schema=_current_tenant_schema(),
             effective_srid=effective_srid,
+            original_filename=source_filename,
         )
 
         # 7. Compute file hash (moved up — must be outside any session)

--- a/backend/app/processing/ingest/tasks_vector.py
+++ b/backend/app/processing/ingest/tasks_vector.py
@@ -368,7 +368,9 @@ async def ingest_file(
             source_filename = job.source_filename
 
             # 2. Detect CRS via ogrinfo
-            info = await run_ogrinfo(file_path, layer_name=layer_name)
+            info = await run_ogrinfo(
+                file_path, layer_name=layer_name, original_filename=source_filename
+            )
             srid = info.get("srid")
             geometry_type = info.get("geometry_type")
             has_geometry = geometry_type is not None
@@ -468,6 +470,7 @@ async def ingest_file(
             layer_name=layer_name,
             schema=_current_tenant_schema(),
             effective_srid=effective_srid,
+            original_filename=source_filename,
         )
 
         # ----------------------------------------------------------------- #

--- a/backend/tests/test_cli_round_trip.py
+++ b/backend/tests/test_cli_round_trip.py
@@ -474,7 +474,7 @@ class TestManifestApplyRoundTrip:
         assert city_parks["job_id"]
         assert city_parks["job_id"] == queued["job_id"]
 
-        async def _fake_run_ogrinfo(file_path, layer_name=None):
+        async def _fake_run_ogrinfo(file_path, layer_name=None, original_filename=None):
             return {
                 "columns": [{"name": "name", "type": "String"}],
                 "geometry_type": "Point",
@@ -491,6 +491,7 @@ class TestManifestApplyRoundTrip:
             *,
             schema,
             effective_srid=None,
+            original_filename=None,
         ):
             from app.core.db import async_session
             from sqlalchemy import text

--- a/backend/tests/test_ingest_ogr_pure.py
+++ b/backend/tests/test_ingest_ogr_pure.py
@@ -946,9 +946,10 @@ class TestIsUnopenableSourceStderr:
     """The "unable to open datasource" leak: an ogr2ogr/ogrinfo failure whose
     raw stderr is a 100+ line GDAL driver enumeration (the exact text a demo
     visitor saw for an invalid march.gpkg upload). This is the pattern-match
-    that gates the friendly-message replacement — it must catch both stderr
-    shapes GDAL produces for "I can't read this as spatial data" and stay
-    narrow enough to leave every other ogr2ogr/ogrinfo failure untouched.
+    that gates the friendly-message replacement — it must catch all three
+    stderr shapes GDAL/SQLite produce for "I can't read this as spatial
+    data" and stay narrow enough to leave every other ogr2ogr/ogrinfo
+    failure untouched.
     """
 
     def test_matches_driver_enumeration_failure(self):
@@ -974,6 +975,27 @@ class TestIsUnopenableSourceStderr:
             "ERROR 1: sqlite3_prepare_v2(SELECT COUNT(*) FROM sqlite_master "
             "WHERE name IN ('gpkg_metadata', 'gpkg_metadata_reference') AND "
             "type IN ('table', 'view')) failed: file is not a database\n"
+        )
+        assert _is_unopenable_source_stderr(stderr) is True
+
+    def test_matches_sqlite_malformed_page_failure(self):
+        """A GPKG with a fully intact SQLite header but a corrupted interior
+        b-tree page — a DIFFERENT SQLite diagnostic from the corrupt-header
+        case above (codex review, #1640): "database disk image is
+        malformed", not "file is not a database". Empirically confirmed
+        against a real ogr2ogr-generated GPKG with one byte-flipped leaf
+        page (see test_ingest_open_failure_message.py's
+        _write_malformed_page_gpkg for the real-binaries reproduction)."""
+        stderr = (
+            "ERROR 1: database disk image is malformed\n"
+            "ERROR 1: sqlite3_prepare_v2(SELECT COUNT(*) FROM sqlite_master "
+            "WHERE name IN ('gpkg_metadata', 'gpkg_metadata_reference') AND "
+            "type IN ('table', 'view')) failed: database disk image is "
+            "malformed\n"
+            "ERROR 1: database disk image is malformed\n"
+            "ogrinfo failed - unable to open "
+            "'/app/staging/9a1b_march.gpkg'. Did you intend to call "
+            "gdalinfo?\n"
         )
         assert _is_unopenable_source_stderr(stderr) is True
 

--- a/backend/tests/test_ingest_ogr_pure.py
+++ b/backend/tests/test_ingest_ogr_pure.py
@@ -13,6 +13,8 @@ import pytest
 from app.processing.ingest.metadata import _sql_quote_ident
 from app.processing.ingest.ogr import (
     _extract_common_layer_metadata,
+    _friendly_open_failure_message,
+    _is_unopenable_source_stderr,
     _sanitize_authorization_token,
     _strip_ogr_driver_list,
     extract_srid_from_json,
@@ -938,6 +940,107 @@ class TestStripOgrDriverList:
 
         assert hasattr(settings, "ingest_http_timeout_seconds")
         assert settings.ingest_http_timeout_seconds == 300
+
+
+class TestIsUnopenableSourceStderr:
+    """The "unable to open datasource" leak: an ogr2ogr/ogrinfo failure whose
+    raw stderr is a 100+ line GDAL driver enumeration (the exact text a demo
+    visitor saw for an invalid march.gpkg upload). This is the pattern-match
+    that gates the friendly-message replacement — it must catch both stderr
+    shapes GDAL produces for "I can't read this as spatial data" and stay
+    narrow enough to leave every other ogr2ogr/ogrinfo failure untouched.
+    """
+
+    def test_matches_driver_enumeration_failure(self):
+        """No driver claims the source at all — the original march.gpkg incident."""
+        stderr = (
+            "ERROR 1: Unable to open datasource "
+            "`/app/staging/9f2c_march.gpkg' with the following drivers.\n"
+            "  -> `GPKG'\n"
+            "  -> `FITS'\n"
+            "  -> `PCIDSK'\n"
+        )
+        assert _is_unopenable_source_stderr(stderr) is True
+
+    def test_matches_sqlite_corrupt_content_failure(self):
+        """A GPKG with an intact SQLite header but corrupt page data — the
+        driver claims the source by header/extension, then SQLite itself
+        refuses to open it. Live-reproduced stderr shape (bad application_id
+        warning + "file is not a database" + the sqlite3_prepare_v2 detail)."""
+        stderr = (
+            "Warning 1: GPKG: bad application_id=0x75de07d1 on "
+            "'/app/staging/1a2b_march.gpkg'\n"
+            "ERROR 1: file is not a database\n"
+            "ERROR 1: sqlite3_prepare_v2(SELECT COUNT(*) FROM sqlite_master "
+            "WHERE name IN ('gpkg_metadata', 'gpkg_metadata_reference') AND "
+            "type IN ('table', 'view')) failed: file is not a database\n"
+        )
+        assert _is_unopenable_source_stderr(stderr) is True
+
+    def test_does_not_match_unrelated_ogr2ogr_failure(self):
+        """Narrow anchoring: a real, different ogr2ogr failure (constraint
+        violation) must NOT be caught by this pattern — those messages keep
+        their real stderr."""
+        stderr = (
+            'ERROR 1: PQclear() failed: ERROR:  null value in column "geom" '
+            "violates not-null constraint\n"
+        )
+        assert _is_unopenable_source_stderr(stderr) is False
+
+    def test_does_not_match_permission_denied(self):
+        stderr = "ERROR 1: permission denied for schema data\n"
+        assert _is_unopenable_source_stderr(stderr) is False
+
+    def test_empty_string_does_not_match(self):
+        assert _is_unopenable_source_stderr("") is False
+
+
+class TestFriendlyOpenFailureMessage:
+    """The user-facing replacement text — built only from the original
+    upload filename, never from the staging path or the raw stderr."""
+
+    def test_gpkg_extension_names_geopackage(self):
+        msg = _friendly_open_failure_message("march.gpkg")
+        assert msg == (
+            "Could not open 'march.gpkg' as a spatial dataset — the file "
+            "may be corrupt, incomplete, or not a valid GeoPackage (.gpkg) "
+            "file."
+        )
+
+    def test_shp_extension_names_shapefile(self):
+        msg = _friendly_open_failure_message("parcels.shp")
+        assert "Shapefile (.shp)" in msg
+        assert "parcels.shp" in msg
+
+    def test_zip_extension_names_zipped_shapefile(self):
+        msg = _friendly_open_failure_message("export.zip")
+        assert "zipped Shapefile (.zip)" in msg
+
+    def test_unknown_extension_falls_back_to_generic_phrasing(self):
+        msg = _friendly_open_failure_message("data.mysteryformat")
+        assert "data.mysteryformat" in msg
+        assert "not a valid spatial data file" in msg
+
+    def test_no_filename_uses_fully_generic_message(self):
+        msg = _friendly_open_failure_message(None)
+        assert msg == (
+            "Could not open the uploaded file as a spatial dataset — it "
+            "may be corrupt, incomplete, or not a valid spatial data file."
+        )
+
+    def test_staging_path_never_appears_in_message(self):
+        """The staging path GDAL echoes in its own stderr must never reach
+        this message — only the original upload filename does."""
+        msg = _friendly_open_failure_message("march.gpkg")
+        assert "/app/staging" not in msg
+        assert "staging" not in msg
+
+    def test_directory_component_stripped_even_if_passed(self):
+        """Defensive: even if a caller passed a path instead of a bare
+        filename, only the leaf name is shown — never the directories."""
+        msg = _friendly_open_failure_message("/app/staging/9f2c_march.gpkg")
+        assert "march.gpkg" in msg
+        assert "/app/staging" not in msg
 
 
 class TestSecFu04SanitizeAuthorizationToken:

--- a/backend/tests/test_ingest_open_failure_message.py
+++ b/backend/tests/test_ingest_open_failure_message.py
@@ -1,0 +1,212 @@
+"""End-to-end coverage for the "unable to open datasource" friendly-message fix.
+
+A corrupt vector upload (the demo incident: an invalid ``march.gpkg``) used to
+land the RAW ogr2ogr/ogrinfo stderr — GDAL's full driver enumeration, or
+SQLite's own corrupt-database diagnostics, either one including the staging
+file path — verbatim in ``IngestJob.error_message``, where a demo visitor
+read it in the job UI.
+
+These tests run the real ``ogrinfo``/``ogr2ogr`` binaries against corrupt
+fixture files built in ``tmp_path`` and assert:
+
+  1. The raised ``IngestionError`` carries the short, human-readable message
+     — built from the ORIGINAL upload filename, never the staging path.
+  2. The full raw stderr (driver list / SQLite diagnostics) still reaches
+     structured logs at error level, so the diagnostic is not lost.
+
+Two corrupt-file shapes are covered, matching the two stderr patterns GDAL
+actually produces for this failure class:
+
+  - No driver recognizes the source at all (plain garbage bytes) → GDAL's
+    "Unable to open datasource ... with the following drivers." enumeration.
+  - The SQLite/GPKG magic header is intact but the content underneath is
+    corrupt (a truncated/garbage-filled GPKG) → SQLite's own
+    "file is not a database" diagnostics. This is the realistic upload case:
+    the app's content-sniffing at upload time already rejects files with no
+    magic header at all, so a corrupt upload that reaches ogr2ogr/ogrinfo in
+    production has a valid header and corrupt content underneath it.
+
+Requires the real ogr2ogr/ogrinfo binaries — skipped when unavailable
+(dev hosts without GDAL; CI and the backend Docker image install it).
+"""
+
+import os
+import shutil
+
+import pytest
+import structlog
+
+from app.processing.ingest.ogr import IngestionError, run_ogr2ogr, run_ogrinfo
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("ogr2ogr") is None or shutil.which("ogrinfo") is None,
+    reason="ogr2ogr/ogrinfo binaries not available on host (runs in backend Docker image / CI)",
+)
+
+
+def _write_no_driver_gpkg(tmp_path) -> str:
+    """Plain garbage bytes with a .gpkg name — no driver recognizes this at all."""
+    path = tmp_path / "9f2c1a3e-uuid_march.gpkg"
+    path.write_bytes(b"this is not a real geopackage file, just plain bytes\n")
+    return str(path)
+
+
+def _write_sqlite_magic_corrupt_gpkg(tmp_path) -> str:
+    """A GPKG with a real SQLite header but corrupt content underneath.
+
+    Mirrors what content-sniffing at upload time actually lets through: the
+    magic header alone is not enough to guarantee GDAL can read the rest.
+    """
+    path = tmp_path / "1a2b3c4d-uuid_march.gpkg"
+    path.write_bytes(b"SQLite format 3\x00" + os.urandom(200))
+    return str(path)
+
+
+class TestRunOgrinfoFriendlyOpenFailure:
+    """ogrinfo runs before ogr2ogr in the ingest_file task (CRS detection), so
+    for the realistic corrupt-upload case — content-sniffing at upload time
+    already rejects a file with no recognizable magic header at all — this is
+    the function that actually raises. Empirically (GDAL 3.13 on this host,
+    matching the orchestrator's live dev-stack reproduction), ogrinfo's
+    "no driver at all" failure is a short one-liner without a driver
+    enumeration (a distinct, out-of-scope leak noted in the PR description),
+    so only the sqlite-magic-header-but-corrupt-content shape is exercised
+    against ogrinfo here; the driver-enumeration shape is exercised against
+    ogr2ogr below, which is where the original march.gpkg incident's exact
+    stderr came from.
+    """
+
+    async def test_sqlite_corrupt_content_case_raises_friendly_message(self, tmp_path):
+        source = _write_sqlite_magic_corrupt_gpkg(tmp_path)
+        with pytest.raises(IngestionError) as exc_info:
+            await run_ogrinfo(source, original_filename="march.gpkg")
+        message = str(exc_info.value)
+        assert message == (
+            "Could not open 'march.gpkg' as a spatial dataset — the file "
+            "may be corrupt, incomplete, or not a valid GeoPackage (.gpkg) "
+            "file."
+        )
+        assert str(tmp_path) not in message
+        assert "sqlite3_prepare_v2" not in message
+
+    async def test_full_stderr_still_reaches_structured_logs(self, tmp_path):
+        """The diagnostic is not lost — it moves to the log, not nowhere."""
+        source = _write_sqlite_magic_corrupt_gpkg(tmp_path)
+        with structlog.testing.capture_logs() as captured:
+            with pytest.raises(IngestionError):
+                await run_ogrinfo(source, original_filename="march.gpkg")
+
+        error_events = [e for e in captured if e.get("log_level") == "error"]
+        assert error_events, [e for e in captured]
+        logged = error_events[0]
+        assert "file is not a database" in logged["stderr"]
+        assert "sqlite3_prepare_v2" in logged["stderr"]
+        # The staging path DOES appear in the logged raw stderr (that's the
+        # point — full diagnostics for us) even though it never reaches the
+        # user-facing message asserted above.
+        assert source in logged["stderr"]
+        assert logged["original_filename"] == "march.gpkg"
+
+    async def test_unrelated_ogrinfo_failure_keeps_raw_message(self, tmp_path):
+        """Narrow mapping: a non-"unable to open" ogrinfo failure (invalid
+        layer name argv rejected before spawn is covered elsewhere; here, a
+        nonexistent file with a plain .txt extension still fails, but through
+        a different message shape) must not be swallowed by the same
+        friendly text — the leading-dash guard raises before spawn, so use a
+        real GDAL failure that ISN'T the open-failure class instead: a
+        request for a named layer that does not exist in an otherwise valid,
+        openable source. ogrinfo's error there names the missing layer, not
+        "unable to open" or "file is not a database", so it must fall
+        through unmodified.
+        """
+        # A minimal valid (empty) GeoJSON FeatureCollection: openable, but
+        # asking for a layer name GDAL won't find inside it produces a
+        # different failure shape than "can't open the source at all".
+        source = tmp_path / "empty.geojson"
+        source.write_text('{"type": "FeatureCollection", "features": []}')
+        with pytest.raises(IngestionError) as exc_info:
+            await run_ogrinfo(
+                str(source),
+                layer_name="nonexistent_layer",
+                original_filename="x.geojson",
+            )
+        message = str(exc_info.value)
+        assert "Could not open" not in message
+        assert message.startswith("ogrinfo failed")
+
+
+class TestRunOgr2ogrFriendlyOpenFailure:
+    async def test_no_driver_case_raises_friendly_message(self, tmp_path):
+        source = _write_no_driver_gpkg(tmp_path)
+        with pytest.raises(IngestionError) as exc_info:
+            await run_ogr2ogr(
+                source,
+                "some_table",
+                "PG:dbname=unused_this_never_gets_reached",
+                schema="data",
+                original_filename="march.gpkg",
+            )
+        message = str(exc_info.value)
+        assert message == (
+            "Could not open 'march.gpkg' as a spatial dataset — the file "
+            "may be corrupt, incomplete, or not a valid GeoPackage (.gpkg) "
+            "file."
+        )
+        assert str(tmp_path) not in message
+        assert "->" not in message
+
+    async def test_sqlite_corrupt_content_case_raises_friendly_message(self, tmp_path):
+        source = _write_sqlite_magic_corrupt_gpkg(tmp_path)
+        with pytest.raises(IngestionError) as exc_info:
+            await run_ogr2ogr(
+                source,
+                "some_table",
+                "PG:dbname=unused_this_never_gets_reached",
+                schema="data",
+                original_filename="march.gpkg",
+            )
+        message = str(exc_info.value)
+        assert message == (
+            "Could not open 'march.gpkg' as a spatial dataset — the file "
+            "may be corrupt, incomplete, or not a valid GeoPackage (.gpkg) "
+            "file."
+        )
+        assert str(tmp_path) not in message
+
+    async def test_full_stderr_still_reaches_structured_logs(self, tmp_path):
+        source = _write_sqlite_magic_corrupt_gpkg(tmp_path)
+        with structlog.testing.capture_logs() as captured:
+            with pytest.raises(IngestionError):
+                await run_ogr2ogr(
+                    source,
+                    "some_table",
+                    "PG:dbname=unused_this_never_gets_reached",
+                    schema="data",
+                    original_filename="march.gpkg",
+                )
+
+        error_events = [e for e in captured if e.get("log_level") == "error"]
+        assert error_events, [e for e in captured]
+        logged = error_events[0]
+        assert "file is not a database" in logged["stderr"]
+        assert source in logged["stderr"]
+        assert logged["original_filename"] == "march.gpkg"
+
+    async def test_no_original_filename_falls_back_to_generic_message(self, tmp_path):
+        """Callers that can't supply the original filename (none exist in
+        production today, but the parameter is optional) still get a safe,
+        staging-path-free message instead of an AttributeError or a leak."""
+        source = _write_no_driver_gpkg(tmp_path)
+        with pytest.raises(IngestionError) as exc_info:
+            await run_ogr2ogr(
+                source,
+                "some_table",
+                "PG:dbname=unused_this_never_gets_reached",
+                schema="data",
+            )
+        message = str(exc_info.value)
+        assert message == (
+            "Could not open the uploaded file as a spatial dataset — it "
+            "may be corrupt, incomplete, or not a valid spatial data file."
+        )
+        assert str(tmp_path) not in message

--- a/backend/tests/test_ingest_open_failure_message.py
+++ b/backend/tests/test_ingest_open_failure_message.py
@@ -14,17 +14,23 @@ fixture files built in ``tmp_path`` and assert:
   2. The full raw stderr (driver list / SQLite diagnostics) still reaches
      structured logs at error level, so the diagnostic is not lost.
 
-Two corrupt-file shapes are covered, matching the two stderr patterns GDAL
-actually produces for this failure class:
+Three corrupt-file shapes are covered, matching the three stderr patterns
+GDAL/SQLite actually produce for this failure class:
 
   - No driver recognizes the source at all (plain garbage bytes) → GDAL's
     "Unable to open datasource ... with the following drivers." enumeration.
-  - The SQLite/GPKG magic header is intact but the content underneath is
-    corrupt (a truncated/garbage-filled GPKG) → SQLite's own
-    "file is not a database" diagnostics. This is the realistic upload case:
-    the app's content-sniffing at upload time already rejects files with no
-    magic header at all, so a corrupt upload that reaches ogr2ogr/ogrinfo in
-    production has a valid header and corrupt content underneath it.
+  - The SQLite/GPKG magic header itself doesn't parse (a truncated/
+    garbage-filled GPKG whose first bytes claim to be SQLite but the header
+    fields are junk) → SQLite's own "file is not a database" diagnostics.
+    This is the realistic upload case: the app's content-sniffing at upload
+    time already rejects files with no magic header at all, so a corrupt
+    upload that reaches ogr2ogr/ogrinfo in production has a valid header and
+    corrupt content underneath it.
+  - The SQLite header parses fine but an interior b-tree page is corrupt
+    (a real GPKG with a byte-flipped leaf page of its own schema table) →
+    SQLite's "database disk image is malformed" diagnostics — a distinct
+    string from "file is not a database" (codex review on #1640: the
+    header-corrupt and page-corrupt cases report different SQLite errors).
 
 Requires the real ogr2ogr/ogrinfo binaries — skipped when unavailable
 (dev hosts without GDAL; CI and the backend Docker image install it).
@@ -32,6 +38,8 @@ Requires the real ogr2ogr/ogrinfo binaries — skipped when unavailable
 
 import os
 import shutil
+import sqlite3
+import subprocess
 
 import pytest
 import structlog
@@ -62,6 +70,67 @@ def _write_sqlite_magic_corrupt_gpkg(tmp_path) -> str:
     return str(path)
 
 
+def _write_malformed_page_gpkg(tmp_path) -> str:
+    """A REAL GPKG (via ogr2ogr) with an intact SQLite header but a
+    corrupted interior b-tree page.
+
+    Distinct corruption class from ``_write_sqlite_magic_corrupt_gpkg``: the
+    header this time is completely valid (untouched), so SQLite gets past
+    header validation and only fails once it tries to parse page content —
+    which it reports as "database disk image is malformed", not "file is not
+    a database" (codex review, #1640). The fixture must therefore be a real,
+    well-formed SQLite/GPKG file with one byte-flipped page, not hand-rolled
+    bytes.
+
+    Uses SQLite's ``dbstat`` virtual table (built into Python's stdlib
+    sqlite3) to find the fullest LEAF page of the sqlite_schema b-tree
+    itself — corrupting a near-full page hits real cell content rather than
+    a page's unused free space, and every GDAL/SQLite open reads the schema
+    table first regardless of which user table is queried.
+    """
+    seed_geojson = tmp_path / "seed_for_malformed_page.geojson"
+    seed_geojson.write_text(
+        '{"type": "FeatureCollection", "features": ['
+        '{"type": "Feature", "properties": {"name": "a"}, '
+        '"geometry": {"type": "Point", "coordinates": [-77.0, 38.9]}}, '
+        '{"type": "Feature", "properties": {"name": "b"}, '
+        '"geometry": {"type": "Point", "coordinates": [-77.1, 38.8]}}]}'
+    )
+    real_gpkg = tmp_path / "seed_for_malformed_page.gpkg"
+    subprocess.run(
+        ["ogr2ogr", "-f", "GPKG", str(real_gpkg), str(seed_geojson)],
+        check=True,
+        capture_output=True,
+    )
+
+    conn = sqlite3.connect(str(real_gpkg))
+    try:
+        page_size = conn.execute("PRAGMA page_size").fetchone()[0]
+        # Least "unused" == fullest page; page 1 (the file header) is
+        # excluded by pagetype='leaf' since it's an interior page here.
+        row = conn.execute(
+            "SELECT pgoffset, unused FROM dbstat "
+            "WHERE name = 'sqlite_schema' AND pagetype = 'leaf' "
+            "ORDER BY unused ASC LIMIT 1"
+        ).fetchone()
+    finally:
+        conn.close()
+    assert row is not None, "expected at least one sqlite_schema leaf page"
+    pgoffset, _unused = row
+
+    data = bytearray(real_gpkg.read_bytes())
+    # Flip a chunk well inside the page (past any per-page header bytes),
+    # clear of the 100-byte SQLite file header GDAL validates up front.
+    start = pgoffset + 150
+    length = min(1200, page_size - 300)
+    for i in range(start, start + length):
+        data[i] ^= 0xFF
+
+    corrupt_path = tmp_path / "9a1b2c3d-uuid_march.gpkg"
+    corrupt_path.write_bytes(bytes(data))
+    return str(corrupt_path)
+
+
 class TestRunOgrinfoFriendlyOpenFailure:
     """ogrinfo runs before ogr2ogr in the ingest_file task (CRS detection), so
     for the realistic corrupt-upload case — content-sniffing at upload time
@@ -70,10 +139,10 @@ class TestRunOgrinfoFriendlyOpenFailure:
     matching the orchestrator's live dev-stack reproduction), ogrinfo's
     "no driver at all" failure is a short one-liner without a driver
     enumeration (a distinct, out-of-scope leak noted in the PR description),
-    so only the sqlite-magic-header-but-corrupt-content shape is exercised
-    against ogrinfo here; the driver-enumeration shape is exercised against
-    ogr2ogr below, which is where the original march.gpkg incident's exact
-    stderr came from.
+    so only the two SQLite-diagnostic shapes (corrupt header, corrupt page)
+    are exercised against ogrinfo here; the driver-enumeration shape is
+    exercised against ogr2ogr below, which is where the original march.gpkg
+    incident's exact stderr came from.
     """
 
     async def test_sqlite_corrupt_content_case_raises_friendly_message(self, tmp_path):
@@ -104,6 +173,35 @@ class TestRunOgrinfoFriendlyOpenFailure:
         # The staging path DOES appear in the logged raw stderr (that's the
         # point — full diagnostics for us) even though it never reaches the
         # user-facing message asserted above.
+        assert source in logged["stderr"]
+        assert logged["original_filename"] == "march.gpkg"
+
+    async def test_malformed_page_case_raises_friendly_message(self, tmp_path):
+        """Valid header, corrupt interior page — SQLite's "database disk
+        image is malformed", not "file is not a database" (codex review)."""
+        source = _write_malformed_page_gpkg(tmp_path)
+        with pytest.raises(IngestionError) as exc_info:
+            await run_ogrinfo(source, original_filename="march.gpkg")
+        message = str(exc_info.value)
+        assert message == (
+            "Could not open 'march.gpkg' as a spatial dataset — the file "
+            "may be corrupt, incomplete, or not a valid GeoPackage (.gpkg) "
+            "file."
+        )
+        assert str(tmp_path) not in message
+
+    async def test_malformed_page_full_stderr_still_reaches_structured_logs(
+        self, tmp_path
+    ):
+        source = _write_malformed_page_gpkg(tmp_path)
+        with structlog.testing.capture_logs() as captured:
+            with pytest.raises(IngestionError):
+                await run_ogrinfo(source, original_filename="march.gpkg")
+
+        error_events = [e for e in captured if e.get("log_level") == "error"]
+        assert error_events, [e for e in captured]
+        logged = error_events[0]
+        assert "database disk image is malformed" in logged["stderr"]
         assert source in logged["stderr"]
         assert logged["original_filename"] == "march.gpkg"
 
@@ -189,6 +287,47 @@ class TestRunOgr2ogrFriendlyOpenFailure:
         assert error_events, [e for e in captured]
         logged = error_events[0]
         assert "file is not a database" in logged["stderr"]
+        assert source in logged["stderr"]
+        assert logged["original_filename"] == "march.gpkg"
+
+    async def test_malformed_page_case_raises_friendly_message(self, tmp_path):
+        """Valid header, corrupt interior page — SQLite's "database disk
+        image is malformed", not "file is not a database" (codex review)."""
+        source = _write_malformed_page_gpkg(tmp_path)
+        with pytest.raises(IngestionError) as exc_info:
+            await run_ogr2ogr(
+                source,
+                "some_table",
+                "PG:dbname=unused_this_never_gets_reached",
+                schema="data",
+                original_filename="march.gpkg",
+            )
+        message = str(exc_info.value)
+        assert message == (
+            "Could not open 'march.gpkg' as a spatial dataset — the file "
+            "may be corrupt, incomplete, or not a valid GeoPackage (.gpkg) "
+            "file."
+        )
+        assert str(tmp_path) not in message
+
+    async def test_malformed_page_full_stderr_still_reaches_structured_logs(
+        self, tmp_path
+    ):
+        source = _write_malformed_page_gpkg(tmp_path)
+        with structlog.testing.capture_logs() as captured:
+            with pytest.raises(IngestionError):
+                await run_ogr2ogr(
+                    source,
+                    "some_table",
+                    "PG:dbname=unused_this_never_gets_reached",
+                    schema="data",
+                    original_filename="march.gpkg",
+                )
+
+        error_events = [e for e in captured if e.get("log_level") == "error"]
+        assert error_events, [e for e in captured]
+        logged = error_events[0]
+        assert "database disk image is malformed" in logged["stderr"]
         assert source in logged["stderr"]
         assert logged["original_filename"] == "march.gpkg"
 

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -2762,7 +2762,11 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # credit. Most of the lines are the comment recording why this path is the
     # only reupload one that needs it and why dataset.record is safe to touch
     # (joinedloaded by the SELECT above it). Cap 1139 -> 1151, exact.
-    "backend/app/processing/ingest/tasks_reupload.py": 1151,
+    # fix: +5 — thread original_filename through _detect_reupload_crs and the
+    # two run_ogrinfo/run_ogr2ogr call sites so a corrupt reupload gets the
+    # same friendly "could not open" message as a fresh upload, instead of
+    # leaking the staging path / GDAL driver dump. Cap 1151 -> 1156, exact.
+    "backend/app/processing/ingest/tasks_reupload.py": 1156,
     # --- entered by the inclusion rule, feat(#1266) -----------------------
     # The refresh door crossed 1000 when it gained its third execution
     # strategy. Two thirds of the addition is the STAC dispatcher, which is
@@ -3257,7 +3261,19 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # typename instead of storing nothing. Most of it is the comment recording
     # that build_gdal_source makes id and name mutually exclusive per service,
     # which is why one key suffices. Cap 1074 -> 1090, exact.
-    "backend/app/processing/ingest/tasks_vector.py": 1090,
+    # fix: +3 — pass original_filename (job.source_filename) to run_ogrinfo
+    # and run_ogr2ogr so a corrupt vector upload gets a friendly message
+    # instead of GDAL's raw driver-enumeration stderr. Cap 1090 -> 1093, exact.
+    "backend/app/processing/ingest/tasks_vector.py": 1093,
+    # --- entered by the inclusion rule ------------------------------------
+    # Crossed 1000 lines adding the "unable to open datasource" friendly-
+    # message mapping shared by run_ogrinfo and run_ogr2ogr: the pattern
+    # regexes (GDAL's driver-enumeration line and SQLite's own "file is not
+    # a database"), the per-extension format-label table, and the message
+    # builder, plus the log-then-raise branch duplicated at both call sites'
+    # failure handling (ogrinfo's text-fallback raise and ogr2ogr's raise).
+    # Exact line count at entry.
+    "backend/app/processing/ingest/ogr.py": 1073,
     "backend/app/modules/auth/oauth/service.py": 1031,
     # fix(#1113 review): +15 — register_existing_table linearizes a
     # pre-existing geom_4326 (savepoint + error contract mirroring the

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -3273,7 +3273,12 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # builder, plus the log-then-raise branch duplicated at both call sites'
     # failure handling (ogrinfo's text-fallback raise and ogr2ogr's raise).
     # Exact line count at entry.
-    "backend/app/processing/ingest/ogr.py": 1073,
+    # fix(codex review, #1640): +16 — a third pattern, SQLite's "database
+    # disk image is malformed" (a valid header with a corrupt interior
+    # b-tree page — distinct from "file is not a database", which is a
+    # corrupt header). Empirically confirmed against a real GPKG with a
+    # byte-flipped leaf page. Cap 1073 -> 1089, exact.
+    "backend/app/processing/ingest/ogr.py": 1089,
     "backend/app/modules/auth/oauth/service.py": 1031,
     # fix(#1113 review): +15 — register_existing_table linearizes a
     # pre-existing geom_4326 (savepoint + error contract mirroring the


### PR DESCRIPTION
## What

A corrupt vector upload (demo, 2026-08-18, `march.gpkg`) stored GDAL's raw ogr2ogr stderr — a 100+ line driver enumeration, including the internal staging path — verbatim in `IngestJob.error_message`, which a demo visitor then read in the job UI:

```
ogr2ogr failed (exit 1): ERROR 1: Unable to open datasource `/app/staging/<uuid>_march.gpkg' with the following drivers.
  -> `FITS'
  -> `PCIDSK'
  ... (dozens more)
```

Live reproduction against the dev stack surfaced a second instance of the same class in `ogrinfo` (which runs first, for CRS detection, so it's the one that actually fires for the realistic corrupt-upload case — upload-time content sniffing already rejects a file with no recognizable magic header at all, so a corrupt upload that reaches GDAL has a valid header and corrupt content underneath):

```
Warning 1: GPKG: bad application_id=0x... on '/app/staging/<uuid>_march.gpkg'
ERROR 1: file is not a database
ERROR 1: sqlite3_prepare_v2(...) failed: file is not a database
```

## Change

In `backend/app/processing/ingest/ogr.py`, `run_ogrinfo` and `run_ogr2ogr` now pattern-match their stderr against two failure shapes:

- `Unable to open datasource `...' with the following drivers.` (no driver claims the source at all)
- `file is not a database` (SQLite/GPKG: header recognized, content corrupt)

On a match, the full stderr is logged at error level via structlog (diagnostic is not lost), and a short user-facing message is raised instead, built only from the original upload filename (never the staging path):

> Could not open 'march.gpkg' as a spatial dataset — the file may be corrupt, incomplete, or not a valid GeoPackage (.gpkg) file.

The format label comes from the upload's extension (gpkg/shp/zip/geojson/csv/kml/kmz/fgb/gml/gdb), falling back to generic "spatial data" phrasing for unknown extensions or when no filename is available. Every other ogr2ogr/ogrinfo failure (constraint violations, permission errors, missing layers, timeouts, ...) keeps its real stderr — the mapping is pattern-anchored and narrow, not a blanket try/except.

`original_filename` is threaded from `job.source_filename` through the two production call sites: `tasks_vector.py`'s `ingest_file` and `tasks_reupload.py`'s `reupload_file` (via `_detect_reupload_crs`). A third `run_ogr2ogr` call site in `tasks_common.py` is test-only (per its own docstring — nothing in `app/` calls it) and is left without the parameter; it gets the safe generic fallback message if it ever hits this path.

## Raster: investigated, left alone

Checked whether the raster ingest path (`gdal_translate`/rasterio) has the same leak. Empirically (GDAL 3.13, and via the backend's own rasterio):

- `gdal_translate`/`gdalinfo` on an unopenable raster: `ERROR 4: '<path>' not recognized as being in a supported file format.` — a short one-liner, no driver enumeration.
- `rasterio.open()` on the same file: `RasterioIOError: '<path>' not recognized as being in a supported file format.` — same shape.

Neither matches the "with the following drivers" dozens-of-lines pattern this PR targets, so raster is out of scope here. Note: that short message does still echo the file path (a smaller, different leak) — flagging as a known gap for a separate, narrower follow-up rather than pulling it into this fix.

Also out of scope: `run_ogr2ogr_service` (WFS/OGC API/ArcGIS ingest) already has partial mitigation (`_strip_ogr_driver_list` + `redact_url_credentials`) predating this change; it isn't the "vector upload" path this task covers and wasn't asked for.

## error_message conventions checked

No existing length cap or sanitizer on this call path (`tasks_vector.py`/`tasks_reupload.py`/`ogr.py`) — `_cleanup_staging_on_failure` in `tasks_common.py` applies `redact_url_credentials` (a no-op on our message, which has no URLs) but no truncation; `_MAX_ERROR_CHARS`/`_MAX_ERROR_MESSAGE_CHARS` conventions exist elsewhere (`embeddings/backfill.py`, `platform/refresh/service.py`) but aren't wired into this path today. The new messages are short by construction, so no new cap was added — kept the diff to the pattern-matched class only.

## Testing

- `backend/tests/test_ingest_ogr_pure.py` — new `TestIsUnopenableSourceStderr` / `TestFriendlyOpenFailureMessage` classes: pattern-match true/false cases (including narrow-anchoring negatives against unrelated ogr2ogr errors), extension→label mapping, staging-path-never-leaked, directory-component-stripped defensive case.
- `backend/tests/test_ingest_open_failure_message.py` (new) — end-to-end against the real `ogr2ogr`/`ogrinfo` binaries with corrupt fixtures built in `tmp_path` (skipped when GDAL isn't on the host): both failure shapes for `run_ogr2ogr`, the sqlite-corrupt shape for `run_ogrinfo` (the no-driver shape doesn't reproduce through `ogrinfo` on this GDAL version — documented in the test class docstring), full-stderr-still-logged via `structlog.testing.capture_logs()`, and an unrelated-failure negative case (missing named layer) proving the mapping doesn't over-match.

**Counterfactual** (WAVE-RULES): committed the fix, then `git checkout 72b23725e -- backend/app/processing/ingest/{ogr,tasks_vector,tasks_reupload}.py` to revert to pre-fix state with the new tests still present. Result: `test_ingest_ogr_pure.py` fails to even collect (`ImportError: cannot import name '_friendly_open_failure_message'`), and all 7 tests in `test_ingest_open_failure_message.py` fail — either `TypeError: unexpected keyword argument 'original_filename'` or an assertion showing the raw driver-dump/staging-path text the fix removes. Restored with `git checkout HEAD -- <same files>` and reconfirmed green.

### Commands run

```
cd backend && uv run ruff check . && uv run ruff format --check .
uv run pytest tests/test_ingest_open_failure_message.py tests/test_ingest_ogr_pure.py \
  tests/test_ingest_layer_name_guard.py tests/test_ingest_column_preservation.py \
  tests/test_reupload_completion_contract_1207.py tests/test_staging_pipeline.py \
  tests/test_layering.py -q
# 208 passed
```

## Schema/API impact

None. `error_message` stays a `Text` column; no migration. No API contract change (job status/error surface shape unchanged, only the string content of one failure class).

## LOC caps

`tasks_reupload.py` (1151→1156) and `tasks_vector.py` (1090→1093) grew from threading `original_filename` through; `ogr.py` newly crossed 1000 lines and is added to `_MODULE_LOC_CAPS` at its exact new count (1073), all in `backend/tests/test_layering.py` with comments recording what the growth bought.
