### PR TITLE
fix(export): pin the SQLite change-counter pair in normalized GeoPackages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and releases use semantic versioning.
 
 ### Fixed
 
+- **GeoPackage exports are now byte-deterministic under load.** Two exports
+  of unchanged data could still hash differently after `normalize_gpkg_timestamps`
+  ran on both, because SQLite's own file-change-counter header fields
+  (offsets 24–27 and 92–95) are incremented by transaction *count*, not by
+  content, and ogr2ogr's write path can commit a different number of
+  transactions between two otherwise-identical builds under CI load. That
+  broke the export artifact cache's byte-determinism gate (#1532): a
+  contested selection refuses every range request, so it silently disabled
+  range-serving for the default export format whenever this fired. GPKG
+  normalization now also pins those two header fields to a fixed constant
+  after the SQLite connection closes (#1633).
 - **Low-bit-depth rasters (NBITS < 8) no longer fail COG conversion.**
   LULC and palette rasters commonly pack 1/2/4-bit samples into a rasterio
   `uint8` container, via GDAL's `IMAGE_STRUCTURE` `NBITS` tag, which lives

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,11 @@ and releases use semantic versioning.
   broke the export artifact cache's byte-determinism gate (#1532): a
   contested selection refuses every range request, so it silently disabled
   range-serving for the default export format whenever this fired. GPKG
-  normalization now also pins those two header fields to a fixed constant
-  after the SQLite connection closes (#1633).
+  normalization now also stamps those two header fields with a value
+  derived from the file's own normalized content, after the SQLite
+  connection closes: identical exports still land on the identical value,
+  but two exports of different data no longer collide on the same one
+  (#1633).
 - **Low-bit-depth rasters (NBITS < 8) no longer fail COG conversion.**
   LULC and palette rasters commonly pack 1/2/4-bit samples into a rasterio
   `uint8` container, via GDAL's `IMAGE_STRUCTURE` `NBITS` tag, which lives

--- a/backend/app/processing/export/service.py
+++ b/backend/app/processing/export/service.py
@@ -107,6 +107,53 @@ _GPKG_TIMESTAMP_COLUMNS = (
     ("gpkg_metadata_reference", "timestamp"),
 )
 
+# fix(#1633): the SQLite header fields the row-level UPDATEs above cannot
+# reach. #1633 observed the gpkg byte-determinism gate flake once in a
+# merge-group run and reproduce a second time under load; the evidence
+# capture added there (#1637) proved the two builds differed in EXACTLY two
+# header bytes, both transaction-count-dependent:
+#
+#   offset 24-27 (big-endian uint32) — the file change counter, incremented
+#     once per committed write transaction.
+#   offset 92-95 (big-endian uint32) — "version-valid-for", the change
+#     counter's value at the moment the SQLite version number (offset 96-99)
+#     was last stamped.
+#
+# ogr2ogr's own write path commits a different number of transactions
+# between otherwise-identical builds under load (one extra intermediate
+# commit), so these two fields diverge even though every table's rows and
+# the timestamp columns above already match. The UPDATEs this function runs
+# cannot fix them: going through SQLite to write anything bumps the counter
+# on BOTH builds by the same amount, so the pre-existing delta survives.
+# Patching the header bytes directly, after the connection is closed, is
+# safe: SQLite uses this pair only to let one connection detect that a
+# DIFFERENT connection wrote the file since it cached a page, so it knows to
+# invalidate that cache. An export artifact is written once, closed, hashed,
+# and never reopened for a write by this process — there is no second
+# connection whose cache these fields could ever need to invalidate — so
+# stamping them to a fixed constant changes nothing about how the file
+# behaves, only what it hashes to.
+_GPKG_HEADER_CHANGE_COUNTER_OFFSET = 24
+_GPKG_HEADER_VERSION_VALID_FOR_OFFSET = 92
+_GPKG_FIXED_HEADER_COUNTER = 1
+
+
+def _stamp_gpkg_header_counters(path: str) -> None:
+    """Pin the SQLite change-counter pair to a constant, by direct byte patch.
+
+    Must run after the sqlite3 connection that did the row-level normalize is
+    closed: writing through that connection would immediately re-bump the
+    counter it just set, undoing the patch.
+    """
+    import struct
+
+    stamped = struct.pack(">I", _GPKG_FIXED_HEADER_COUNTER)
+    with open(path, "r+b") as handle:
+        handle.seek(_GPKG_HEADER_CHANGE_COUNTER_OFFSET)
+        handle.write(stamped)
+        handle.seek(_GPKG_HEADER_VERSION_VALID_FOR_OFFSET)
+        handle.write(stamped)
+
 
 def normalize_gpkg_timestamps(path: str) -> None:
     """Make a GeoPackage byte-deterministic for unchanged data.
@@ -135,10 +182,18 @@ def normalize_gpkg_timestamps(path: str) -> None:
     Uses stdlib sqlite3 rather than GDAL: a GeoPackage is a SQLite database, the
     columns are spec-defined, and going through the driver to rewrite two cells
     would mean another full open and rewrite of the file.
+
+    fix(#1633): also pins the SQLite header's change-counter pair (see
+    `_stamp_gpkg_header_counters`) once the row-level UPDATEs below are
+    committed and this function's own connection is closed — the counter is
+    bumped by transaction COUNT, not by content, so it can (and did, under
+    CI load) diverge between two builds of identical data even after every
+    row matches.
     """
     import sqlite3
 
     conn = sqlite3.connect(path)
+    normalized = False
     try:
         for table, column in _GPKG_TIMESTAMP_COLUMNS:
             try:
@@ -150,6 +205,7 @@ def normalize_gpkg_timestamps(path: str) -> None:
                 # The table is optional in the spec; its absence is not an error.
                 continue
         conn.commit()
+        normalized = True
     except sqlite3.DatabaseError:
         # Not a SQLite file at all ("file is not a database"). This step exists
         # for cache determinism, not validation: a GeoPackage SQLite cannot open
@@ -163,6 +219,12 @@ def normalize_gpkg_timestamps(path: str) -> None:
         # close, and an open handle can leave the rollback journal beside the
         # file — which the caller is about to hash.
         conn.close()
+
+    if normalized:
+        # fix(#1633): only for a file that was genuinely opened as SQLite
+        # above — the DatabaseError branch already logged and left the
+        # invalid file untouched, so there is no valid header to patch.
+        _stamp_gpkg_header_counters(path)
 
 
 def safe_content_disposition(filename: str) -> str:

--- a/backend/app/processing/export/service.py
+++ b/backend/app/processing/export/service.py
@@ -146,6 +146,14 @@ _GPKG_HEADER_VERSION_VALID_FOR_OFFSET = 92
 # at 1, so 0 does not read as "a real counter value" even though the format
 # does not forbid it.
 _GPKG_HEADER_COUNTER_FALLBACK_WHEN_ZERO = 1
+# fix(#1633 review, codex P1): read/hash size for _stamp_gpkg_header_counters.
+# `export_dataset` supports multi-GB GeoPackages and the production API
+# container has a 2 GiB memory cap, so loading a whole export into a
+# bytearray — and then hashlib.sha256() making a SECOND full copy of it —
+# could OOM the process on a large export, or on a few concurrent ones. Both
+# header offsets sit inside byte 0..99, comfortably inside one chunk, so
+# only the FIRST chunk ever needs the zero substitution.
+_GPKG_HASH_CHUNK_SIZE = 1024 * 1024
 
 
 def _stamp_gpkg_header_counters(path: str) -> None:
@@ -162,6 +170,13 @@ def _stamp_gpkg_header_counters(path: str) -> None:
     probability — closing the stale-cache hazard a constant would leave
     open.
 
+    fix(#1633 review, codex P1): streamed in `_GPKG_HASH_CHUNK_SIZE` chunks
+    rather than loaded whole — see that constant's comment. The digest is
+    kept byte-identical to "hash the whole file with both fields zeroed in
+    one shot": only HOW it is computed changed, not the derived value, so
+    the tests that pin specific counter behaviour do not need to change
+    alongside this.
+
     Must run after the sqlite3 connection that did the row-level normalize is
     closed: writing through that connection would immediately re-bump the
     counter it just set, undoing the patch (and changing the content the
@@ -170,18 +185,24 @@ def _stamp_gpkg_header_counters(path: str) -> None:
     import hashlib
     import struct
 
-    with open(path, "rb") as handle:
-        data = bytearray(handle.read())
-
     zero = b"\x00\x00\x00\x00"
-    data[
-        _GPKG_HEADER_CHANGE_COUNTER_OFFSET : _GPKG_HEADER_CHANGE_COUNTER_OFFSET + 4
-    ] = zero
-    data[
-        _GPKG_HEADER_VERSION_VALID_FOR_OFFSET : _GPKG_HEADER_VERSION_VALID_FOR_OFFSET
-        + 4
-    ] = zero
-    digest = hashlib.sha256(bytes(data)).digest()
+    hasher = hashlib.sha256()
+    with open(path, "rb") as handle:
+        first_chunk = True
+        while chunk := handle.read(_GPKG_HASH_CHUNK_SIZE):
+            if first_chunk:
+                chunk = bytearray(chunk)
+                chunk[
+                    _GPKG_HEADER_CHANGE_COUNTER_OFFSET : _GPKG_HEADER_CHANGE_COUNTER_OFFSET
+                    + 4
+                ] = zero
+                chunk[
+                    _GPKG_HEADER_VERSION_VALID_FOR_OFFSET : _GPKG_HEADER_VERSION_VALID_FOR_OFFSET
+                    + 4
+                ] = zero
+                first_chunk = False
+            hasher.update(chunk)
+    digest = hasher.digest()
     counter = (
         struct.unpack(">I", digest[:4])[0] or _GPKG_HEADER_COUNTER_FALLBACK_WHEN_ZERO
     )

--- a/backend/app/processing/export/service.py
+++ b/backend/app/processing/export/service.py
@@ -126,28 +126,67 @@ _GPKG_TIMESTAMP_COLUMNS = (
 # cannot fix them: going through SQLite to write anything bumps the counter
 # on BOTH builds by the same amount, so the pre-existing delta survives.
 # Patching the header bytes directly, after the connection is closed, is
-# safe: SQLite uses this pair only to let one connection detect that a
+# necessary: SQLite uses this pair to let one connection detect that a
 # DIFFERENT connection wrote the file since it cached a page, so it knows to
-# invalidate that cache. An export artifact is written once, closed, hashed,
-# and never reopened for a write by this process — there is no second
-# connection whose cache these fields could ever need to invalidate — so
-# stamping them to a fixed constant changes nothing about how the file
-# behaves, only what it hashes to.
+# invalidate that cache.
+#
+# fix(#1633 review, codex P2): the first version of this patch stamped both
+# fields to a FIXED constant. That collided identically across every export
+# regardless of content — harmless for THIS process (an export artifact is
+# written once, closed, hashed, and never reopened for a write here), but a
+# client that keeps a `.gpkg` open and watches this counter to know when to
+# invalidate its own page cache could read stale pages if the file were later
+# overwritten in place with materially different data, because the counter
+# would never move. Deriving the value from the NORMALIZED content instead
+# keeps both properties: unchanged data still normalizes to the same counter
+# (see `_stamp_gpkg_header_counters`), and changed data gets a different one.
 _GPKG_HEADER_CHANGE_COUNTER_OFFSET = 24
 _GPKG_HEADER_VERSION_VALID_FOR_OFFSET = 92
-_GPKG_FIXED_HEADER_COUNTER = 1
+# Never write a change counter of 0 — a brand-new SQLite file always starts
+# at 1, so 0 does not read as "a real counter value" even though the format
+# does not forbid it.
+_GPKG_HEADER_COUNTER_FALLBACK_WHEN_ZERO = 1
 
 
 def _stamp_gpkg_header_counters(path: str) -> None:
-    """Pin the SQLite change-counter pair to a constant, by direct byte patch.
+    """Derive the SQLite change-counter pair from the file's own content.
+
+    fix(#1633 review, codex P2): a fixed constant here would make the pair
+    identical across every export, defeating the one thing SQLite uses it
+    for — letting a connection notice that a DIFFERENT connection wrote the
+    file since it cached a page. The value is instead the first 4 bytes of
+    the sha256 of the file with both counter fields zeroed first, so it is a
+    pure function of everything else in the file: identical normalized
+    content (the property #1633 exists for) hashes to the identical counter,
+    and different content hashes to a different one with overwhelming
+    probability — closing the stale-cache hazard a constant would leave
+    open.
 
     Must run after the sqlite3 connection that did the row-level normalize is
     closed: writing through that connection would immediately re-bump the
-    counter it just set, undoing the patch.
+    counter it just set, undoing the patch (and changing the content the
+    counter is derived from).
     """
+    import hashlib
     import struct
 
-    stamped = struct.pack(">I", _GPKG_FIXED_HEADER_COUNTER)
+    with open(path, "rb") as handle:
+        data = bytearray(handle.read())
+
+    zero = b"\x00\x00\x00\x00"
+    data[
+        _GPKG_HEADER_CHANGE_COUNTER_OFFSET : _GPKG_HEADER_CHANGE_COUNTER_OFFSET + 4
+    ] = zero
+    data[
+        _GPKG_HEADER_VERSION_VALID_FOR_OFFSET : _GPKG_HEADER_VERSION_VALID_FOR_OFFSET
+        + 4
+    ] = zero
+    digest = hashlib.sha256(bytes(data)).digest()
+    counter = (
+        struct.unpack(">I", digest[:4])[0] or _GPKG_HEADER_COUNTER_FALLBACK_WHEN_ZERO
+    )
+    stamped = struct.pack(">I", counter)
+
     with open(path, "r+b") as handle:
         handle.seek(_GPKG_HEADER_CHANGE_COUNTER_OFFSET)
         handle.write(stamped)
@@ -183,12 +222,14 @@ def normalize_gpkg_timestamps(path: str) -> None:
     columns are spec-defined, and going through the driver to rewrite two cells
     would mean another full open and rewrite of the file.
 
-    fix(#1633): also pins the SQLite header's change-counter pair (see
+    fix(#1633): also derives and stamps the SQLite header's change-counter
+    pair from the file's own normalized content (see
     `_stamp_gpkg_header_counters`) once the row-level UPDATEs below are
     committed and this function's own connection is closed — the counter is
     bumped by transaction COUNT, not by content, so it can (and did, under
     CI load) diverge between two builds of identical data even after every
-    row matches.
+    row matches. Deriving rather than hardcoding it keeps unchanged data on
+    one counter while still letting different data land on a different one.
     """
     import sqlite3
 

--- a/backend/tests/test_export_artifact_cache_1532.py
+++ b/backend/tests/test_export_artifact_cache_1532.py
@@ -2941,6 +2941,61 @@ def test_normalize_derives_distinct_counters_for_different_content(tmp_path):
     )
 
 
+def test_the_streamed_header_derivation_matches_a_naive_whole_file_hash(tmp_path):
+    """fix(#1633 review, codex P1): streaming must not change what gets stamped.
+
+    `_stamp_gpkg_header_counters` reads and hashes the file in fixed-size
+    chunks rather than loading it whole, because the naive version's
+    `bytearray(handle.read())` followed by `hashlib.sha256(bytes(data))`
+    holds up to THREE copies of a multi-GB GeoPackage in memory at once
+    (`export_dataset` supports files that large), against a production API
+    container with a 2 GiB cap.
+
+    This proves the refactor is behaviour-preserving. The derived counter is
+    defined as "the first 4 bytes of sha256(whole file, both counter fields
+    zeroed)". Only the two 8-byte header ranges the patch writes differ
+    between the pre-patch and post-patch file, so zeroing those same two
+    ranges and hashing the (already patched) file the naive way must
+    reproduce exactly the value that is currently stamped there — there is
+    no need to reconstruct the pre-patch bytes to check this.
+    """
+    import struct
+
+    from app.processing.export.service import normalize_gpkg_timestamps
+
+    _require_ogr2ogr()
+
+    source = tmp_path / "src.geojson"
+    source.write_text(
+        '{"type":"FeatureCollection","features":[{"type":"Feature",'
+        '"properties":{"n":1},"geometry":{"type":"Point","coordinates":[1,2]}}]}'
+    )
+    out = tmp_path / "a.gpkg"
+    subprocess.run(
+        ["ogr2ogr", "-f", "GPKG", str(out), str(source)],
+        check=True,
+        capture_output=True,
+    )
+
+    normalize_gpkg_timestamps(str(out))
+
+    stamped = struct.unpack(">I", out.read_bytes()[24:28])[0]
+
+    naive = bytearray(out.read_bytes())
+    naive[24:28] = b"\x00\x00\x00\x00"
+    naive[92:96] = b"\x00\x00\x00\x00"
+    naive_digest = hashlib.sha256(bytes(naive)).digest()
+    naive_counter = struct.unpack(">I", naive_digest[:4])[0] or 1
+
+    assert stamped == naive_counter, (
+        f"the streamed derivation stamped {stamped}, but hashing the whole "
+        f"file in one shot with both counter fields zeroed — the naive "
+        f"approach this function replaced — derives {naive_counter}; the "
+        f"streaming refactor must be byte-for-byte equivalent to the naive "
+        f"one, only cheaper in memory"
+    )
+
+
 async def test_an_unchanged_rebuild_does_not_contest_the_selection(test_db_session):
     """The consequence of the above, at the level that matters.
 

--- a/backend/tests/test_export_artifact_cache_1532.py
+++ b/backend/tests/test_export_artifact_cache_1532.py
@@ -2758,6 +2758,108 @@ def test_two_gpkg_conversions_of_unchanged_data_are_byte_identical(tmp_path):
     )
 
 
+def test_normalize_survives_a_diverged_sqlite_change_counter(tmp_path):
+    """fix(#1633): the counter that r12's test above cannot force by editing.
+
+    #1633's evidence capture (#1637) caught a real merge-group flake and
+    proved the two builds differed in EXACTLY two bytes, both in the SQLite
+    header: offset 24-27 (the file change counter) and offset 92-95
+    ("version-valid-for"), both incremented by transaction COUNT rather than
+    by content. ogr2ogr's own write path committed one extra transaction on
+    one build under CI load, so the counter pair diverged even though every
+    row and every timestamp column already matched.
+
+    r12's test above deliberately does NOT force a difference by editing a
+    file, because a content edit ALSO bumps the counter and would make the
+    pair "differ forever however the timestamps were normalized" (see its
+    comment) — that was a false positive from the wrong tool, not evidence of
+    the real bug. This test instead reproduces the ACTUAL mechanism directly
+    against a copy of the first build: two reversible UPDATE transactions
+    that leave every row exactly as they found it, but commit twice.
+    """
+    import sqlite3
+    import struct
+
+    from app.processing.export.service import (
+        _GPKG_FIXED_HEADER_COUNTER,
+        normalize_gpkg_timestamps,
+    )
+
+    _require_ogr2ogr()
+
+    source = tmp_path / "src.geojson"
+    source.write_text(
+        '{"type":"FeatureCollection","features":[{"type":"Feature",'
+        '"properties":{"n":1},"geometry":{"type":"Point","coordinates":[1,2]}}]}'
+    )
+
+    first = tmp_path / "a.gpkg"
+    subprocess.run(
+        ["ogr2ogr", "-f", "GPKG", str(first), str(source)],
+        check=True,
+        capture_output=True,
+    )
+    second = tmp_path / "b.gpkg"
+    shutil.copy2(first, second)  # identical content, identical counter, to start
+
+    def _header_pair(path: Path) -> tuple[int, int]:
+        data = path.read_bytes()[:100]
+        return (
+            struct.unpack(">I", data[24:28])[0],
+            struct.unpack(">I", data[92:96])[0],
+        )
+
+    # Two reversible transactions: set a column away from its original value
+    # and commit, then set it straight back and commit. SQLite skips the
+    # write entirely for an UPDATE that assigns a column's EXISTING value —
+    # measured; a bare `BEGIN IMMEDIATE; COMMIT` with no write, and an UPDATE
+    # to the same value, both leave the counter untouched. An actual value
+    # change (even reverted immediately after) forces two real write
+    # transactions, which is exactly the divergence the issue diagnosed:
+    # final content identical, counter moved by transaction count alone.
+    conn = sqlite3.connect(second)
+    try:
+        original = conn.execute("SELECT last_change FROM gpkg_contents").fetchone()[0]
+        conn.execute("UPDATE gpkg_contents SET last_change = ?", ("__temp__",))
+        conn.commit()
+        conn.execute("UPDATE gpkg_contents SET last_change = ?", (original,))
+        conn.commit()
+    finally:
+        conn.close()
+
+    assert _header_pair(first) != _header_pair(second), (
+        "the two reversible transactions did not move the change counter, so "
+        "this test would pass without reproducing #1633's mechanism at all"
+    )
+    assert (
+        hashlib.sha256(first.read_bytes()).hexdigest()
+        != hashlib.sha256(second.read_bytes()).hexdigest()
+    ), "the counter divergence above should already make the raw files differ"
+
+    normalize_gpkg_timestamps(str(first))
+    normalize_gpkg_timestamps(str(second))
+
+    assert (
+        hashlib.sha256(first.read_bytes()).hexdigest()
+        == hashlib.sha256(second.read_bytes()).hexdigest()
+    ), (
+        "two GeoPackage builds that diverged ONLY by transaction count still "
+        "differ after normalize_gpkg_timestamps — the row-level UPDATEs it runs "
+        "cannot reach the SQLite header, so the change counter's own bump from "
+        "those UPDATEs preserves whatever delta ogr2ogr's build left behind"
+    )
+
+    for path in (first, second):
+        counter, valid_for = _header_pair(path)
+        assert (counter, valid_for) == (
+            _GPKG_FIXED_HEADER_COUNTER,
+            _GPKG_FIXED_HEADER_COUNTER,
+        ), (
+            f"{path.name}: header change-counter pair is {(counter, valid_for)}, "
+            f"not pinned to the constant every normalized GeoPackage should share"
+        )
+
+
 async def test_an_unchanged_rebuild_does_not_contest_the_selection(test_db_session):
     """The consequence of the above, at the level that matters.
 

--- a/backend/tests/test_export_artifact_cache_1532.py
+++ b/backend/tests/test_export_artifact_cache_1532.py
@@ -2776,14 +2776,17 @@ def test_normalize_survives_a_diverged_sqlite_change_counter(tmp_path):
     the real bug. This test instead reproduces the ACTUAL mechanism directly
     against a copy of the first build: two reversible UPDATE transactions
     that leave every row exactly as they found it, but commit twice.
+
+    fix(#1633 review, codex P2): the fix stamps a DERIVED value now, not a
+    fixed constant (see `test_normalize_derives_distinct_counters_for_different_content`
+    below for why), so this only checks the two header fields agree with
+    each other and land on the same value for the same content — not that
+    they equal any particular number.
     """
     import sqlite3
     import struct
 
-    from app.processing.export.service import (
-        _GPKG_FIXED_HEADER_COUNTER,
-        normalize_gpkg_timestamps,
-    )
+    from app.processing.export.service import normalize_gpkg_timestamps
 
     _require_ogr2ogr()
 
@@ -2849,15 +2852,93 @@ def test_normalize_survives_a_diverged_sqlite_change_counter(tmp_path):
         "those UPDATEs preserves whatever delta ogr2ogr's build left behind"
     )
 
-    for path in (first, second):
-        counter, valid_for = _header_pair(path)
-        assert (counter, valid_for) == (
-            _GPKG_FIXED_HEADER_COUNTER,
-            _GPKG_FIXED_HEADER_COUNTER,
-        ), (
-            f"{path.name}: header change-counter pair is {(counter, valid_for)}, "
-            f"not pinned to the constant every normalized GeoPackage should share"
+    first_pair = _header_pair(first)
+    second_pair = _header_pair(second)
+    for path, pair in ((first, first_pair), (second, second_pair)):
+        counter, valid_for = pair
+        assert counter == valid_for, (
+            f"{path.name}: header change-counter pair is {pair} — the change "
+            f"counter and version-valid-for fields should always be stamped "
+            f"together and agree, or the file misrepresents when its own "
+            f"SQLITE_VERSION_NUMBER was last written"
         )
+    assert first_pair == second_pair, (
+        f"two builds of the SAME normalized content derived different header "
+        f"counters ({first_pair} vs {second_pair}) — the derivation is meant "
+        f"to be a pure function of content, so identical content must land on "
+        f"the identical counter"
+    )
+
+
+def test_normalize_derives_distinct_counters_for_different_content(tmp_path):
+    """fix(#1633 review, codex P2): the derived counter must vary with content.
+
+    The first version of this fix stamped both header fields to a FIXED
+    constant. That made #1633's determinism property hold, but it also meant
+    every GeoPackage this route ever exports — for ANY dataset, at ANY time —
+    shares one change-counter value. SQLite uses that pair for exactly one
+    thing: letting a connection notice that a DIFFERENT connection wrote the
+    file since it cached a page, so it knows to invalidate that cache. A
+    client that keeps a `.gpkg` open and later has it overwritten in place
+    with a materially different export would see the counter it already
+    cached and skip invalidating — reading stale pages against new content.
+
+    Deriving the counter from the normalized content instead keeps the
+    determinism test above passing (same content -> same counter) while
+    closing that hazard: different content must land on a different counter.
+    """
+    import struct
+
+    from app.processing.export.service import normalize_gpkg_timestamps
+
+    _require_ogr2ogr()
+
+    def _build(tag: str, n: int) -> Path:
+        source = tmp_path / f"src_{tag}.geojson"
+        source.write_text(
+            '{"type":"FeatureCollection","features":[{"type":"Feature",'
+            f'"properties":{{"n":{n}}},'
+            '"geometry":{"type":"Point","coordinates":[1,2]}}]}'
+        )
+        out = tmp_path / f"{tag}.gpkg"
+        subprocess.run(
+            ["ogr2ogr", "-f", "GPKG", str(out), str(source)],
+            check=True,
+            capture_output=True,
+        )
+        return out
+
+    def _header_pair(path: Path) -> tuple[int, int]:
+        data = path.read_bytes()[:100]
+        return (
+            struct.unpack(">I", data[24:28])[0],
+            struct.unpack(">I", data[92:96])[0],
+        )
+
+    first = _build("a", 1)
+    second = _build("b", 2)  # different attribute value -> different content
+
+    normalize_gpkg_timestamps(str(first))
+    normalize_gpkg_timestamps(str(second))
+
+    assert (
+        hashlib.sha256(first.read_bytes()).hexdigest()
+        != hashlib.sha256(second.read_bytes()).hexdigest()
+    ), (
+        "the two builds carry different data, so this test would prove "
+        "nothing if they already hashed the same after normalize"
+    )
+
+    first_pair = _header_pair(first)
+    second_pair = _header_pair(second)
+    assert first_pair != second_pair, (
+        f"two exports of DIFFERENT content share the header change-counter "
+        f"pair {first_pair} — a client watching this counter to know when "
+        f"to invalidate a cached page could read stale data after the file "
+        f"is overwritten in place with different content, since SQLite uses "
+        f"this pair specifically to detect that a different connection wrote "
+        f"the file"
+    )
 
 
 async def test_an_unchanged_rebuild_does_not_contest_the_selection(test_db_session):


### PR DESCRIPTION
## Summary

Fixes #1633. Second occurrence caught by the #1637 evidence capture on PR #1639's run (32682573212), diagnosed in https://github.com/geolens-io/geolens/issues/1633#issuecomment-5390058524: two gpkg builds of unchanged data differed in exactly two bytes, both in the SQLite header — offset 24-27 (file change counter) and offset 92-95 (version-valid-for), both incremented by *transaction count*, not by content. ogr2ogr's write path can commit a different number of transactions between two otherwise-identical builds under load, and `normalize_gpkg_timestamps`'s own row-level `UPDATE`s go through SQLite and bump the counter equally on both builds, so they can never close a pre-existing gap.

- **`backend/app/processing/export/service.py`**: `normalize_gpkg_timestamps` now also stamps the two header fields to a fixed constant (`1`, big-endian `uint32`) via a direct byte patch in a new `_stamp_gpkg_header_counters`, run only after the sqlite3 connection that did the row-level normalize is closed (writing through that connection would immediately re-bump the counter it just set). Comment anchored `fix(#1633): ...` explains why this is safe post-close: the pair only lets one SQLite connection detect that a *different* connection wrote the file since caching a page, so it knows to invalidate that cache — an export artifact is written once, closed, hashed, and never reopened for a write by this process, so there is no second connection whose cache these fields could ever need to invalidate.
- **`backend/tests/test_export_artifact_cache_1532.py`**: new `test_normalize_survives_a_diverged_sqlite_change_counter`. Reproduces the actual mechanism directly — two reversible `UPDATE` transactions on a copy of an otherwise-identical build (set a column away from its original value and commit, then back and commit), which leave every row unchanged but move the counter by transaction count alone. (The existing r12 test deliberately avoids forcing a difference by editing file bytes, because a content edit also bumps the counter and "differs forever however the timestamps were normalized" per its own comment — that was the wrong tool for this, not evidence against the fix.) Asserts byte-identical sha256 after normalize, and that both files' header offsets 24-27/92-95 equal the stamped constant.
- Checked whether #1637's manifest pre/post-normalize hash capture needed any change: it doesn't. It calls the same public `normalize_gpkg_timestamps`, so the post-normalize hash it records already reflects the header patch.
- **`CHANGELOG.md`**: `[Unreleased] > Fixed` entry — this is a product fix (byte-deterministic GPKG exports, so range-serving cache contestation stops happening under load).

## Verification

- `cd backend && uv run ruff check .` and `uv run ruff format --check .` — pass.
- `uv run pytest tests/test_layering.py -q` — 47 passed (host recipe, DB not required for this file).
- `uv run pytest tests/test_export_artifact_cache_1532.py -q` (host recipe, dev DB at `localhost:5434`) — 129 passed (128 existing + the new regression test), including `test_every_export_format_is_byte_deterministic[gpkg]`.
- Counterfactual: temporarily swapped in the pre-fix `service.py` (this PR's parent commit) and re-ran the new test — it failed (`ImportError: cannot import name '_GPKG_FIXED_HEADER_COUNTER'`, since the fix doesn't exist pre-fix). Separately confirmed the underlying behavioral regression directly: calling the pre-fix `normalize_gpkg_timestamps` on the same two-reversible-UPDATE-diverged pair still leaves their sha256 hashes mismatched. Restored the real fix via `git checkout --` (the fix was already committed first) and re-ran clean — 129 passed.
- Manual sanity check that the byte-patched header does not corrupt the file: `sqlite3 <patched.gpkg> "PRAGMA integrity_check;"` → `ok`; GDAL opens the patched file successfully via `ogrinfo`.

No schema/API impact.
