### PR TITLE
chore(release): v1.15.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and releases use semantic versioning.
 
 ## [Unreleased]
 
+## [1.15.1] - 2026-08-24
+
 ### Changed
 
 - **An upload that was never started is now `cancelled`, not `failed`.** Ask
@@ -2576,7 +2578,8 @@ regression-covered fixes:
 - Initial public release of the GeoLens catalog, API, map builder, CLI, SDKs,
   Docker development stack, and public documentation entrypoints.
 
-[Unreleased]: https://github.com/geolens-io/geolens/compare/v1.15.0...HEAD
+[Unreleased]: https://github.com/geolens-io/geolens/compare/v1.15.1...HEAD
+[1.15.1]: https://github.com/geolens-io/geolens/compare/v1.15.0...v1.15.1
 [1.15.0]: https://github.com/geolens-io/geolens/compare/v1.14.2...v1.15.0
 [1.14.2]: https://github.com/geolens-io/geolens/compare/v1.14.1...v1.14.2
 [1.14.1]: https://github.com/geolens-io/geolens/compare/v1.14.0...v1.14.1

--- a/backend/app/api/main.py
+++ b/backend/app/api/main.py
@@ -746,7 +746,7 @@ _is_production = settings.is_production
 # no metadata to read. We fall back to the current published line so import never
 # crashes. Keep this fallback in lockstep with backend/pyproject.toml — it is one
 # of the sites `make bump` rewrites.
-_FALLBACK_APP_VERSION = "1.15.0"
+_FALLBACK_APP_VERSION = "1.15.1"
 
 
 def _resolve_app_version() -> str:

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -18506,7 +18506,7 @@
     "summary": "PostGIS-native geospatial data catalog with OGC API Features and Records support",
     "termsOfService": "https://github.com/geolens-io/geolens/blob/main/LICENSE",
     "title": "GeoLens API",
-    "version": "1.15.0"
+    "version": "1.15.1"
   },
   "openapi": "3.1.0",
   "paths": {

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geolens-backend"
-version = "1.15.0"
+version = "1.15.1"
 description = "PostGIS-native GIS data catalog"
 # Docker image (Dockerfile) ships python:3.14-slim (see the Dockerfile FROM for
 # the exact patch pin) as the project's tested runtime.

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -838,7 +838,7 @@ wheels = [
 
 [[package]]
 name = "geolens-backend"
-version = "1.15.0"
+version = "1.15.1"
 source = { virtual = "." }
 dependencies = [
     { name = "alembic" },

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "geolens-cli"
-version = "1.15.0"
+version = "1.15.1"
 description = "Apache-2.0 command-line interface for the GeoLens API. Login, scan, publish, and export STAC against any GeoLens instance."
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/docs-contract.json
+++ b/docs-contract.json
@@ -1,6 +1,6 @@
 {
   "_comment": "Canonical cross-surface facts for the GeoLens README, marketing site (getgeolens.com/src), and docs site (getgeolens.com/docs). Validated against scripts/install.sh + backend/pyproject.toml by scripts/check_docs_contract.py (geolens CI). The getgeolens.com repo vendors a copy and enforces the same `forbidden` list in its own CI. See docs-internal/DOC-CONSISTENCY-STRATEGY for the full design. Edit a fact ONCE here (and in its canonical source) — the gates make every surface follow.",
-  "version": "1.15.0",
+  "version": "1.15.1",
   "install": {
     "oneLiner": "curl -fsSL https://getgeolens.com/install.sh | sh",
     "sourceBuild": "bash scripts/install.sh",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "1.15.0",
+  "version": "1.15.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "1.15.0",
+      "version": "1.15.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.15.0",
+  "version": "1.15.1",
   "type": "module",
   "license": "Apache-2.0",
   "author": "Carto Concepts, LLC",

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "geolens-mcp"
-version = "1.15.0"
+version = "1.15.1"
 description = "Apache-2.0 read-only Model Context Protocol (MCP) server for GeoLens. Lets coding agents discover datasets, inspect schemas, and ask spatial questions against any GeoLens instance."
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/mcp/server.json
+++ b/mcp/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.geolens-io/geolens",
   "title": "GeoLens",
   "description": "Read-only access to a self-hosted GeoLens spatial catalog: datasets, features, maps, sandboxed SQL.",
-  "version": "1.15.0",
+  "version": "1.15.1",
   "websiteUrl": "https://docs.getgeolens.com/",
   "repository": {
     "url": "https://github.com/geolens-io/geolens",
@@ -14,7 +14,7 @@
     {
       "registryType": "pypi",
       "identifier": "geolens-mcp",
-      "version": "1.15.0",
+      "version": "1.15.1",
       "transport": {
         "type": "stdio"
       },

--- a/mcp/uv.lock
+++ b/mcp/uv.lock
@@ -225,7 +225,7 @@ wheels = [
 
 [[package]]
 name = "geolens"
-version = "1.15.0"
+version = "1.15.1"
 source = { editable = "../sdks/python" }
 dependencies = [
     { name = "attrs" },
@@ -244,7 +244,7 @@ requires-dist = [
 
 [[package]]
 name = "geolens-mcp"
-version = "1.15.0"
+version = "1.15.1"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "geolens",
-  "version": "1.15.0",
+  "version": "1.15.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "geolens",
-      "version": "1.15.0",
+      "version": "1.15.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@axe-core/playwright": "^4.13.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geolens",
-  "version": "1.15.0",
+  "version": "1.15.1",
   "private": true,
   "license": "Apache-2.0",
   "author": "Carto Concepts, LLC",

--- a/sdks/python/.openapi-python-client.yaml
+++ b/sdks/python/.openapi-python-client.yaml
@@ -4,7 +4,7 @@ project_name_override: geolens
 package_name_override: geolens
 # Rewritten on every `make sdks` run by scripts/sync_sdk_versions.py to match
 # backend/openapi.json info.version. Do not edit by hand.
-package_version_override: 1.15.0
+package_version_override: 1.15.1
 
 # Cleaner enum output (matches our pydantic v2 backend's enum emission).
 literal_enums: true

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "geolens"
-version = "1.15.0"
+version = "1.15.1"
 description = "Auto-generated Python SDK for the GeoLens API. Typed clients with Bearer + API-key auth helpers."
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/sdks/typescript/package-lock.json
+++ b/sdks/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@geolens/sdk",
-  "version": "1.15.0",
+  "version": "1.15.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@geolens/sdk",
-      "version": "1.15.0",
+      "version": "1.15.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@hey-api/client-fetch": "0.13.1"

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geolens/sdk",
-  "version": "1.15.0",
+  "version": "1.15.1",
   "description": "Auto-generated TypeScript SDK for the GeoLens API. Typed clients with Bearer + API-key auth helpers.",
   "license": "Apache-2.0",
   "author": "Carto Concepts, LLC",


### PR DESCRIPTION
Patch release: stamps every version site at 1.15.1 and cuts the `## [1.15.1]` changelog section for the four fixes merged since v1.15.0:

- #1636 — low-bit-depth (NBITS < 8) rasters no longer fail COG conversion
- #1640 — corrupt vector uploads get a friendly error instead of raw GDAL stderr
- #1639 — abandoned presigned uploads settle `cancelled`, counted apart from failures
- #1641 — GeoPackage exports byte-deterministic under load (closes the #1633 flake class)

No API surface changes: `backend/openapi.json` is untouched since v1.15.0, so no SDK regen and no docs contract sync.

Verification: `make version-check` — OK, all 21 sites agree on 1.15.1 (changelog section present, comparison links updated).
