### PR TITLE
feat(import): capture upload-path failures and add a report CTA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and releases use semantic versioning.
 
 ## [Unreleased]
 
+### Added
+
+- **A failed upload now leaves a trace, and a way to report it.** UploadForm
+  calls the presign, PUT, direct-upload POST, and preview/detection endpoints
+  directly from a plain try/catch instead of through a TanStack mutation, so
+  none of their failures ever reached the shared problem-reporter tap in
+  main.tsx: a broken CSV just showed an error with nothing recorded anywhere a
+  user could report. Each of those calls now reports its own failure into the
+  same buffer (status, error text, and filename only, never the file body or a
+  presigned URL's signature), and a failed file's row now carries a "Report
+  this problem" action that opens the reporter pre-scoped to Import /
+  Ingestion. Also fixed: the error text on the first, or only, staged file in
+  a batch was invisible, because its row started expanded by state even
+  though upload-failed rows have no expand panel to show.
+
 ## [1.15.1] - 2026-08-24
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,17 +10,20 @@ and releases use semantic versioning.
 ### Added
 
 - **A failed upload now leaves a trace, and a way to report it.** UploadForm
-  calls the presign, PUT, direct-upload POST, and preview/detection endpoints
-  directly from a plain try/catch instead of through a TanStack mutation, so
-  none of their failures ever reached the shared problem-reporter tap in
-  main.tsx: a broken CSV just showed an error with nothing recorded anywhere a
-  user could report. Each of those calls now reports its own failure into the
-  same buffer (status, error text, and filename only, never the file body or a
-  presigned URL's signature), and a failed file's row now carries a "Report
-  this problem" action that opens the reporter pre-scoped to Import /
-  Ingestion. Also fixed: the error text on the first, or only, staged file in
-  a batch was invisible, because its row started expanded by state even
-  though upload-failed rows have no expand panel to show.
+  calls the presign, PUT, direct-upload POST, preview/detection, commit, and
+  commit-fan-out endpoints directly from a plain try/catch instead of through
+  a TanStack mutation, so none of their failures ever reached the shared
+  problem-reporter tap in main.tsx: a broken CSV just showed an error with
+  nothing recorded anywhere a user could report. Each of those calls now
+  reports its own failure into the same buffer (status, error text, and
+  filename only, never the file body or a presigned URL's signature),
+  including a 2xx response with a malformed JSON body and a preview rejection
+  that isn't an `ApiError`, both of which used to fall through the reporting
+  entirely. A failed file's row now also carries a "Report this problem"
+  action that opens the reporter pre-scoped to Import / Ingestion. Also
+  fixed: the error text on the first, or only, staged file in a batch was
+  invisible, because its row started expanded by state even though
+  upload-failed rows have no expand panel to show.
 
 ## [1.15.1] - 2026-08-24
 

--- a/frontend/src/api/__tests__/ingest-report-capture.test.ts
+++ b/frontend/src/api/__tests__/ingest-report-capture.test.ts
@@ -25,6 +25,14 @@
  *     (xhrUpload's final JSON.parse, outside the status-based reporting)
  * (j) a non-ApiError preview rejection (apiFetch's own response.json()
  *     parse failure isn't an ApiError, so the old `instanceof` guard skipped it)
+ *
+ * codex round 3 on #1660: commitFanOut can return HTTP 200 with
+ * results[].status === 'failed' for one or more layers — not a transport
+ * failure, so reportNetworkError doesn't apply, but UploadForm still maps
+ * that to a commit-failed row (showing the report CTA) with nothing about
+ * WHICH layer failed or WHY ever written to the buffer:
+ * (k) a mixed 200 (some layers failed) writes one entry per failed layer
+ * (l) an all-success 200 writes nothing
  */
 import { clearReportEntries, getReportEntries } from '@/lib/report';
 import { commitImport, previewFile, uploadFile, uploadPresigned } from '@/api/ingest';
@@ -285,5 +293,73 @@ describe('upload-path report capture', () => {
     // No HTTP error status exists for this failure — reported as status 0,
     // the same convention xhrUpload's network-layer catch uses.
     expect(entries[0].message).toContain('/ingest/preview');
+  });
+
+  it('(k) a mixed 200 from commitFanOut writes one entry per failed layer', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () =>
+        jsonResponse(200, {
+          fan_out_id: 'job-1',
+          results: [
+            { layer_name: 'roads', new_job_id: 'j2', dataset_id: null, status: 'queued', error: null },
+            {
+              layer_name: 'parcels',
+              new_job_id: null,
+              dataset_id: null,
+              status: 'failed',
+              error: 'Dispatch failed: queue unavailable',
+            },
+            {
+              layer_name: 'rivers',
+              new_job_id: null,
+              dataset_id: null,
+              status: 'failed',
+              error: 'Dispatch failed: queue unavailable',
+            },
+          ],
+        }),
+      ),
+    );
+
+    const response = await commitFanOut('job-1', [
+      { layer_name: 'roads' },
+      { layer_name: 'parcels' },
+      { layer_name: 'rivers' },
+    ]);
+    expect(response.results).toHaveLength(3);
+
+    const entries = getReportEntries();
+    // Two failed layers, byte-identical error text — still two entries, not
+    // one deduped row, because each message names its own layer.
+    expect(entries).toHaveLength(2);
+    for (const entry of entries) {
+      expect(entry.source).toBe('network');
+      expect(entry.severity).toBe('error');
+      expect(entry.detail).toContain('Dispatch failed: queue unavailable');
+    }
+    expect(entries.some((e) => e.message.includes('parcels'))).toBe(true);
+    expect(entries.some((e) => e.message.includes('rivers'))).toBe(true);
+    // The queued layer wrote nothing.
+    expect(entries.some((e) => e.message.includes('roads'))).toBe(false);
+  });
+
+  it('(l) an all-success 200 from commitFanOut writes nothing', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () =>
+        jsonResponse(200, {
+          fan_out_id: 'job-1',
+          results: [
+            { layer_name: 'roads', new_job_id: 'j2', dataset_id: null, status: 'queued', error: null },
+            { layer_name: 'parcels', new_job_id: 'j3', dataset_id: null, status: 'queued', error: null },
+          ],
+        }),
+      ),
+    );
+
+    await commitFanOut('job-1', [{ layer_name: 'roads' }, { layer_name: 'parcels' }]);
+
+    expect(getReportEntries()).toHaveLength(0);
   });
 });

--- a/frontend/src/api/__tests__/ingest-report-capture.test.ts
+++ b/frontend/src/api/__tests__/ingest-report-capture.test.ts
@@ -1,0 +1,190 @@
+/**
+ * The upload path bypasses TanStack entirely: UploadForm calls uploadFile /
+ * uploadPresigned / previewFile directly from a plain try/catch (per-file
+ * progress needs granular state a shared mutation can't give it), so none of
+ * these failures ever reached the shared MutationCache.onError tap that feeds
+ * the problem-reporter buffer in main.tsx. A file could fail to stage or
+ * detect with nothing recorded anywhere a user could report.
+ *
+ * Tests that each failure class now lands a redacted entry in the report
+ * buffer via the existing reportNetworkError tap — metadata only (status,
+ * error text, filename), never the file body or a presigned URL's signature:
+ * (a) direct-POST upload failure (uploadFile / xhrUpload)
+ * (b) presign-request failure (uploadPresigned, step 1)
+ * (c) single-part presigned PUT failure (uploadPresigned, step 2)
+ * (d) multipart presigned PUT failure (uploadPresigned → uploadChunks)
+ * (e) preview/detection failure (previewFile)
+ * (f) a redaction-worthy error detail is scrubbed the same as any other entry
+ */
+import { clearReportEntries, getReportEntries } from '@/lib/report';
+import { previewFile, uploadFile, uploadPresigned } from '@/api/ingest';
+
+function jsonResponse(status: number, body: unknown): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(body),
+  } as Response;
+}
+
+class FakeXHR {
+  static respond: { status: number; body: string } = { status: 500, body: '{}' };
+  status = 0;
+  responseText = '';
+  upload = { onprogress: null as unknown };
+  onload: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+  open() {}
+  setRequestHeader() {}
+  send() {
+    this.status = FakeXHR.respond.status;
+    this.responseText = FakeXHR.respond.body;
+    queueMicrotask(() => this.onload?.());
+  }
+}
+
+describe('upload-path report capture', () => {
+  beforeEach(() => {
+    clearReportEntries();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('(a) captures a direct-POST upload failure with filename, never the file body', async () => {
+    vi.stubGlobal('XMLHttpRequest', FakeXHR);
+    FakeXHR.respond = { status: 500, body: JSON.stringify({ detail: 'Unsupported file type' }) };
+
+    const secretRow = 'ROW-CONTENT-471,parcel,42.0,-71.0';
+    await expect(
+      uploadFile(new File([secretRow], 'parcels.csv', { type: 'text/csv' })),
+    ).rejects.toMatchObject({ status: 500 });
+
+    const entries = getReportEntries();
+    expect(entries).toHaveLength(1);
+    expect(entries[0].source).toBe('network');
+    expect(entries[0].severity).toBe('error'); // 5xx
+    expect(entries[0].message).toContain('500');
+    expect(entries[0].message).toContain('parcels.csv');
+    // Metadata only — the uploaded row content must never reach the buffer.
+    expect(entries[0].message).not.toContain(secretRow);
+    expect(entries[0].detail ?? '').not.toContain(secretRow);
+  });
+
+  it('(b) captures a presign-request failure (step 1 of uploadPresigned)', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => jsonResponse(422, { detail: 'File size exceeds the configured limit' })),
+    );
+
+    await expect(
+      uploadPresigned(new File(['x'], 'big-parcels.gpkg')),
+    ).rejects.toBeTruthy();
+
+    const entries = getReportEntries();
+    expect(entries).toHaveLength(1);
+    expect(entries[0].source).toBe('network');
+    expect(entries[0].message).toContain('422');
+    expect(entries[0].message).toContain('presigned:request');
+    expect(entries[0].message).toContain('big-parcels.gpkg');
+  });
+
+  it('(c) captures a single-part presigned PUT failure without leaking the signed URL', async () => {
+    const signedUrl = 'https://storage.example.com/bucket/key?X-Amz-Signature=SECRETSIG&X-Amz-Credential=AKIDEXAMPLE';
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = typeof input === 'string' ? input : input.toString();
+        if (url === signedUrl) {
+          return { ok: false, status: 403 } as Response;
+        }
+        return jsonResponse(200, {
+          job_id: 'job-1',
+          urls: [signedUrl],
+          s3_key: 'k',
+          upload_id: null,
+          part_size: null,
+        });
+      }),
+    );
+
+    await expect(uploadPresigned(new File(['x'], 'parcels.gpkg'))).rejects.toBeTruthy();
+
+    const entries = getReportEntries();
+    expect(entries).toHaveLength(1);
+    expect(entries[0].source).toBe('network');
+    expect(entries[0].message).toContain('403');
+    expect(entries[0].message).toContain('presigned:put');
+    expect(entries[0].message).toContain('parcels.gpkg');
+    // The presigned URL carries a time-limited access signature — never log it.
+    expect(entries[0].message).not.toContain('SECRETSIG');
+    expect(entries[0].message).not.toContain('X-Amz-Signature');
+  });
+
+  it('(d) captures a multipart presigned PUT failure with the failing part number', async () => {
+    const part1 = 'https://storage.example.com/bucket/key?partNumber=1&X-Amz-Signature=SIG1';
+    const part2 = 'https://storage.example.com/bucket/key?partNumber=2&X-Amz-Signature=SIG2';
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = typeof input === 'string' ? input : input.toString();
+        if (url === part1) return { ok: true, status: 200, headers: new Headers({ ETag: 'e1' }) } as Response;
+        // Non-retriable status — fails immediately, no backoff delay to wait out.
+        if (url === part2) return { ok: false, status: 403, headers: new Headers() } as Response;
+        return jsonResponse(200, {
+          job_id: 'job-2',
+          urls: [part1, part2],
+          s3_key: 'k',
+          upload_id: 'multipart-1',
+          part_size: 5,
+        });
+      }),
+    );
+
+    await expect(
+      uploadPresigned(new File(['aaaaaaaaaa'], 'big.tif')),
+    ).rejects.toBeTruthy();
+
+    const entries = getReportEntries();
+    expect(entries).toHaveLength(1);
+    expect(entries[0].source).toBe('network');
+    expect(entries[0].message).toContain('403');
+    expect(entries[0].message).toContain('part 2/2');
+    expect(entries[0].message).toContain('big.tif');
+    expect(entries[0].message).not.toContain('SIG2');
+  });
+
+  it('(e) captures a preview/detection failure, dropping the job id from the reported path', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => jsonResponse(422, { detail: 'Could not determine a coordinate reference system' })),
+    );
+
+    await expect(previewFile('job-abc-123')).rejects.toBeTruthy();
+
+    const entries = getReportEntries();
+    expect(entries).toHaveLength(1);
+    expect(entries[0].source).toBe('network');
+    expect(entries[0].message).toContain('422');
+    expect(entries[0].message).toContain('/ingest/preview');
+    // The job id is a parameter, not a namespace — dropped like reportQueryKey
+    // drops ids in main.tsx.
+    expect(entries[0].message).not.toContain('job-abc-123');
+  });
+
+  it('(f) redacts a credential in the captured error detail', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () =>
+        jsonResponse(400, { detail: 'Rejected: api_key=SUPERSECRET123 is not permitted in uploads' }),
+      ),
+    );
+
+    await expect(previewFile('job-1')).rejects.toBeTruthy();
+
+    const entries = getReportEntries();
+    expect(entries).toHaveLength(1);
+    expect(entries[0].detail ?? '').not.toContain('SUPERSECRET123');
+  });
+});

--- a/frontend/src/api/__tests__/ingest-report-capture.test.ts
+++ b/frontend/src/api/__tests__/ingest-report-capture.test.ts
@@ -15,9 +15,20 @@
  * (d) multipart presigned PUT failure (uploadPresigned → uploadChunks)
  * (e) preview/detection failure (previewFile)
  * (f) a redaction-worthy error detail is scrubbed the same as any other entry
+ *
+ * codex on #1660 found the same gap class at three more sites — a failure
+ * path that flips a staged file's row to 'upload-failed'/'commit-failed'
+ * (and so shows the report CTA) without writing a buffer entry:
+ * (g) commitImport failure (no capture existed here at all, unlike (a)/(e))
+ * (h) commitFanOut failure (same — a different API module, same gap)
+ * (i) a 2xx response with a malformed JSON body on the direct-POST upload
+ *     (xhrUpload's final JSON.parse, outside the status-based reporting)
+ * (j) a non-ApiError preview rejection (apiFetch's own response.json()
+ *     parse failure isn't an ApiError, so the old `instanceof` guard skipped it)
  */
 import { clearReportEntries, getReportEntries } from '@/lib/report';
-import { previewFile, uploadFile, uploadPresigned } from '@/api/ingest';
+import { commitImport, previewFile, uploadFile, uploadPresigned } from '@/api/ingest';
+import { commitFanOut } from '@/api/datasets';
 
 function jsonResponse(status: number, body: unknown): Response {
   return {
@@ -186,5 +197,93 @@ describe('upload-path report capture', () => {
     const entries = getReportEntries();
     expect(entries).toHaveLength(1);
     expect(entries[0].detail ?? '').not.toContain('SUPERSECRET123');
+  });
+
+  it('(g) captures a commitImport failure (a class codex found uncaptured entirely)', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => jsonResponse(500, { detail: 'Dispatch failed' })),
+    );
+
+    await expect(
+      commitImport('job-1', { title: 'Parcels' }),
+    ).rejects.toBeTruthy();
+
+    const entries = getReportEntries();
+    expect(entries).toHaveLength(1);
+    expect(entries[0].source).toBe('network');
+    expect(entries[0].message).toContain('500');
+    expect(entries[0].message).toContain('/ingest/commit');
+    expect(entries[0].message).not.toContain('job-1');
+  });
+
+  it('(h) captures a commitFanOut failure (same gap, different API module)', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => jsonResponse(502, { detail: 'Bad gateway' })),
+    );
+
+    await expect(
+      commitFanOut('job-1', [{ layer_name: 'a' }, { layer_name: 'b' }]),
+    ).rejects.toBeTruthy();
+
+    const entries = getReportEntries();
+    expect(entries).toHaveLength(1);
+    expect(entries[0].source).toBe('network');
+    expect(entries[0].message).toContain('502');
+    expect(entries[0].message).toContain('/ingest/commit-fan-out');
+  });
+
+  it('(i) captures a malformed-JSON 2xx body on the direct-POST upload', async () => {
+    class MalformedJsonXHR {
+      status = 0;
+      responseText = '';
+      upload = { onprogress: null as unknown };
+      onload: (() => void) | null = null;
+      onerror: (() => void) | null = null;
+      open() {}
+      setRequestHeader() {}
+      send() {
+        this.status = 200;
+        // Truncated body — valid HTTP 200, invalid JSON. The old code's
+        // status-based branch (`res.status < 200 || res.status >= 300`)
+        // never runs for a 2xx, so JSON.parse threw completely uncaptured.
+        this.responseText = '{"job_id": "job-1"';
+        queueMicrotask(() => this.onload?.());
+      }
+    }
+    vi.stubGlobal('XMLHttpRequest', MalformedJsonXHR);
+
+    await expect(
+      uploadFile(new File(['x'], 'parcels.csv')),
+    ).rejects.toBeTruthy();
+
+    const entries = getReportEntries();
+    expect(entries).toHaveLength(1);
+    expect(entries[0].source).toBe('network');
+    expect(entries[0].message).toContain('200');
+    expect(entries[0].message).toContain('parcels.csv');
+  });
+
+  it('(j) captures a non-ApiError preview rejection (malformed 2xx JSON)', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({
+        ok: true,
+        status: 200,
+        // apiFetch calls response.json() directly; a malformed body throws a
+        // raw SyntaxError here, never an ApiError.
+        json: () => Promise.reject(new SyntaxError('Unexpected end of JSON input')),
+      }) as unknown as Response),
+    );
+
+    await expect(previewFile('job-1')).rejects.toBeInstanceOf(SyntaxError);
+
+    const entries = getReportEntries();
+    expect(entries).toHaveLength(1);
+    expect(entries[0].source).toBe('network');
+    // No HTTP error status exists for this failure — reported as status 0,
+    // the same convention xhrUpload's network-layer catch uses.
+    expect(entries[0].message).toContain('/ingest/preview');
   });
 });

--- a/frontend/src/api/_presignedUpload.ts
+++ b/frontend/src/api/_presignedUpload.ts
@@ -1,4 +1,5 @@
 import i18n from '@/i18n/i18n';
+import { reportNetworkError } from '@/lib/report';
 
 /**
  * Shared chunked-PUT helper for presigned S3 multipart uploads.
@@ -79,6 +80,13 @@ export async function uploadChunks(
 ): Promise<string[]> {
   const { signal, maxRetries = DEFAULT_MAX_RETRIES } = options;
   const etags: string[] = [];
+  // Metadata only for the report buffer: filename (only known when the
+  // caller passed a File, not a bare Blob) and the part index — never the
+  // presigned URL itself (bearer-equivalent; unlike an Authorization header
+  // it can't be scrubbed by key name) or the chunk body.
+  const filename = file instanceof File ? file.name : undefined;
+  const partLabel = (i: number) =>
+    `presigned:put (part ${i + 1}/${urls.length})${filename ? ` — ${filename}` : ''}`;
 
   for (let i = 0; i < urls.length; i++) {
     const start = i * partSize;
@@ -99,6 +107,7 @@ export async function uploadChunks(
           break;
         }
         if (!isRetriableStatus(resp.status) || attempt >= maxRetries) {
+          reportNetworkError({ status: resp.status, url: partLabel(i) });
           throw new UploadHttpError(
             i18n.t('common:errors.storageUploadPartFailed', {
               part: i + 1,
@@ -107,12 +116,15 @@ export async function uploadChunks(
           );
         }
       } catch (err) {
-        // A caller-initiated abort is terminal, not a retriable failure.
+        // A caller-initiated abort is terminal, not a retriable failure — and
+        // not a problem to report.
         if (err instanceof DOMException && err.name === 'AbortError') throw err;
-        // A non-retriable HTTP status threw above; re-throw once retries are out.
+        // A non-retriable HTTP status threw (and was already reported) above;
+        // re-throw once retries are out.
         if (err instanceof UploadHttpError) throw err;
         // Otherwise it is a network-layer error (TypeError) — retriable.
         if (attempt >= maxRetries) {
+          reportNetworkError({ status: 0, url: partLabel(i) });
           throw new Error(
             i18n.t('common:errors.storageUploadPartRetriesFailed', {
               part: i + 1,

--- a/frontend/src/api/datasets.ts
+++ b/frontend/src/api/datasets.ts
@@ -1,8 +1,9 @@
 import { API_BASE } from '@/lib/constants';
 import { translateApiErrorDetail } from '@/lib/error-map';
 import i18n from '@/i18n/i18n';
-import { apiFetch, authenticatedRawFetch } from './client';
+import { apiFetch, authenticatedRawFetch, ApiError } from './client';
 import { uploadChunks } from './_presignedUpload';
+import { reportNetworkError } from '@/lib/report';
 import type {
   CreateDatasetRequest,
   DatasetResponse,
@@ -480,8 +481,27 @@ export async function commitFanOut(
   jobId: string,
   layers: { layer_name: string; title?: string }[],
 ): Promise<FanOutCommitResponse> {
-  return apiFetch<FanOutCommitResponse>(`/ingest/commit-fan-out/${jobId}`, {
-    method: 'POST',
-    body: JSON.stringify({ layers }),
-  });
+  // codex on #1660: commitFanOut is a direct apiFetch call reached from
+  // UploadForm's handleIngestAllLayers, not a TanStack mutation — a
+  // network/HTTP-level failure here (as opposed to a 200 response naming
+  // per-layer failures, which the results modal already shows) set every
+  // layer's row to 'commit-failed' with nothing written to the report
+  // buffer at all.
+  try {
+    return await apiFetch<FanOutCommitResponse>(`/ingest/commit-fan-out/${jobId}`, {
+      method: 'POST',
+      body: JSON.stringify({ layers }),
+    });
+  } catch (err) {
+    if (err instanceof ApiError) {
+      reportNetworkError({ status: err.status, url: '/ingest/commit-fan-out', detail: err.body ?? err.message });
+    } else {
+      reportNetworkError({
+        status: 0,
+        url: '/ingest/commit-fan-out',
+        detail: err instanceof Error ? err.message : undefined,
+      });
+    }
+    throw err;
+  }
 }

--- a/frontend/src/api/datasets.ts
+++ b/frontend/src/api/datasets.ts
@@ -3,7 +3,7 @@ import { translateApiErrorDetail } from '@/lib/error-map';
 import i18n from '@/i18n/i18n';
 import { apiFetch, authenticatedRawFetch, ApiError } from './client';
 import { uploadChunks } from './_presignedUpload';
-import { reportNetworkError } from '@/lib/report';
+import { pushReportEntry, reportNetworkError } from '@/lib/report';
 import type {
   CreateDatasetRequest,
   DatasetResponse,
@@ -483,15 +483,36 @@ export async function commitFanOut(
 ): Promise<FanOutCommitResponse> {
   // codex on #1660: commitFanOut is a direct apiFetch call reached from
   // UploadForm's handleIngestAllLayers, not a TanStack mutation — a
-  // network/HTTP-level failure here (as opposed to a 200 response naming
-  // per-layer failures, which the results modal already shows) set every
-  // layer's row to 'commit-failed' with nothing written to the report
-  // buffer at all.
+  // network/HTTP-level failure here set every layer's row to 'commit-failed'
+  // with nothing written to the report buffer at all. codex round 3 found
+  // the same is true of a 200 response naming per-layer failures — see
+  // below, where that case gets its own capture.
   try {
-    return await apiFetch<FanOutCommitResponse>(`/ingest/commit-fan-out/${jobId}`, {
+    const response = await apiFetch<FanOutCommitResponse>(`/ingest/commit-fan-out/${jobId}`, {
       method: 'POST',
       body: JSON.stringify({ layers }),
     });
+    // codex round 3 on #1660: a 200 response here can still carry per-layer
+    // failures (results[].status === 'failed') — not a transport/HTTP
+    // failure, so reportNetworkError doesn't apply, but UploadForm still
+    // maps these to a commit-failed row that shows the report CTA. Without
+    // this, a filed report carried nothing about which layer failed or why:
+    // the results modal shows the USER, but the buffer is what a filed
+    // REPORT carries. One entry per failed layer, not one merged summary,
+    // so two layers failing with byte-identical error text don't collapse
+    // into a single count via the buffer's own dedup, which compares
+    // message text alone.
+    for (const result of response.results) {
+      if (result.status === 'failed') {
+        pushReportEntry({
+          severity: 'error',
+          source: 'network',
+          message: `Layer import failed: ${result.layer_name}`,
+          detail: result.error ?? undefined,
+        });
+      }
+    }
+    return response;
   } catch (err) {
     if (err instanceof ApiError) {
       reportNetworkError({ status: err.status, url: '/ingest/commit-fan-out', detail: err.body ?? err.message });

--- a/frontend/src/api/ingest.ts
+++ b/frontend/src/api/ingest.ts
@@ -117,7 +117,21 @@ async function xhrUpload<T>(
     throw new ApiError(translateApiErrorDetail(detail, res.status), res.status, detail);
   }
 
-  return JSON.parse(res.body) as T;
+  // codex on #1660: a 2xx response whose body isn't valid JSON (empty,
+  // truncated, an HTML error page from an intermediary proxy) previously
+  // threw a raw SyntaxError here, outside every reporting branch above —
+  // the status-based `if (res.status < 200 || res.status >= 300)` block
+  // never runs for a 2xx, so this failure had no capture path at all.
+  try {
+    return JSON.parse(res.body) as T;
+  } catch (err) {
+    reportNetworkError({
+      status: res.status,
+      url: reportUrl,
+      detail: err instanceof Error ? `Malformed response body: ${err.message}` : undefined,
+    });
+    throw err;
+  }
 }
 
 export async function uploadFile(
@@ -162,9 +176,13 @@ export async function previewFile(jobId: string, layerName?: string): Promise<Fi
     // to the report buffer the same way uploadFile was. Drop the job id from
     // the reported path — same reasoning as reportQueryKey in main.tsx: an id
     // isn't reliably distinguishable from a secret by shape.
-    if (err instanceof ApiError) {
-      reportNetworkError({ status: err.status, url: '/ingest/preview', detail: err.body ?? err.message });
-    }
+    //
+    // codex on #1660: gating this on `instanceof ApiError` skipped a real
+    // failure class — apiFetch's own `response.json()` throws a raw
+    // SyntaxError (not ApiError) on a malformed 2xx body, and that error type
+    // silently fell through this guard uncaptured. reportApiCallFailure
+    // handles every error shape uniformly.
+    reportApiCallFailure('/ingest/preview', err);
     throw err;
   }
 }
@@ -173,10 +191,20 @@ export async function commitImport(
   jobId: string,
   request: CommitImportRequest,
 ): Promise<CommitImportResponse> {
-  return apiFetch<CommitImportResponse>(`/ingest/commit/${jobId}`, {
-    method: 'POST',
-    body: JSON.stringify(request),
-  });
+  // codex on #1660: commitImport is a direct apiFetch call reached from
+  // UploadForm's handleCommitSingle/handleCommitAll, neither of which is a
+  // TanStack mutation — a commit failure set the row to 'commit-failed' with
+  // nothing written to the report buffer at all (a different gap from the
+  // upload/preview one: no capture attempt existed here previously).
+  try {
+    return await apiFetch<CommitImportResponse>(`/ingest/commit/${jobId}`, {
+      method: 'POST',
+      body: JSON.stringify(request),
+    });
+  } catch (err) {
+    reportApiCallFailure('/ingest/commit', err);
+    throw err;
+  }
 }
 
 export async function retryJob(jobId: string): Promise<UploadResponse> {
@@ -243,16 +271,27 @@ export async function completePresignedUpload(
   });
 }
 
+/**
+ * Metadata-only report for any apiFetch-driven failure: an ApiError (a real
+ * HTTP error status) or anything else apiFetch can throw uncaught — notably
+ * a raw SyntaxError from `response.json()` on a malformed 2xx body, which the
+ * previous `instanceof ApiError` gates in this file silently swallowed
+ * (codex on #1660). `label` is a short static description, never a raw URL
+ * with an id or a presigned query string in it.
+ */
+function reportApiCallFailure(label: string, err: unknown): void {
+  if (err instanceof ApiError) {
+    reportNetworkError({ status: err.status, url: label, detail: err.body ?? err.message });
+  } else {
+    reportNetworkError({ status: 0, url: label, detail: err instanceof Error ? err.message : undefined });
+  }
+}
+
 // Metadata-only report for a step in the presigned-upload handshake
 // (request → PUT → complete). `stage` is a short static label, never the
 // presigned URL itself, which carries a time-limited access signature.
 function reportPresignFailure(stage: string, filename: string, err: unknown): void {
-  const url = `presigned:${stage} (${filename})`;
-  if (err instanceof ApiError) {
-    reportNetworkError({ status: err.status, url, detail: err.body ?? err.message });
-  } else {
-    reportNetworkError({ status: 0, url, detail: err instanceof Error ? err.message : undefined });
-  }
+  reportApiCallFailure(`presigned:${stage} (${filename})`, err);
 }
 
 /**

--- a/frontend/src/api/ingest.ts
+++ b/frontend/src/api/ingest.ts
@@ -4,6 +4,7 @@ import { API_BASE } from '@/lib/constants';
 import { translateApiErrorDetail } from '@/lib/error-map';
 import i18n from '@/i18n/i18n';
 import { useAuthStore } from '@/stores/auth-store';
+import { reportNetworkError } from '@/lib/report';
 import type {
   UploadResponse,
   JobStatusResponse,
@@ -42,6 +43,15 @@ async function xhrUpload<T>(
     await tryRefresh();
   }
 
+  // A direct-POST upload (uploadFile) previously bypassed the problem
+  // reporter entirely: it's called from a plain try/catch in UploadForm, not
+  // a TanStack mutation, so the shared MutationCache.onError tap in main.tsx
+  // never sees it. Report here instead — metadata only (status, error text,
+  // filename), never the multipart file body.
+  const uploadedFile = formData.get('file');
+  const filename = uploadedFile instanceof File ? uploadedFile.name : undefined;
+  const reportUrl = filename ? `${path} (${filename})` : path;
+
   const attempt = (): Promise<{ status: number; body: string }> =>
     new Promise((resolve, reject) => {
       const xhr = new XMLHttpRequest();
@@ -59,7 +69,13 @@ async function xhrUpload<T>(
       xhr.send(formData);
     });
 
-  let res = await attempt();
+  let res: { status: number; body: string };
+  try {
+    res = await attempt();
+  } catch (err) {
+    reportNetworkError({ status: 0, url: reportUrl, detail: err instanceof Error ? err.message : undefined });
+    throw err;
+  }
   // fix(#1446): capture the dead session BEFORE refreshing, matching
   // authenticatedRawFetch — every concurrent failure then keys the
   // notification latch on the same value.
@@ -67,7 +83,12 @@ async function xhrUpload<T>(
   if (res.status === 401) {
     deadSessionKey = useAuthStore.getState().token;
     if (await tryRefresh()) {
-      res = await attempt();
+      try {
+        res = await attempt();
+      } catch (err) {
+        reportNetworkError({ status: 0, url: reportUrl, detail: err instanceof Error ? err.message : undefined });
+        throw err;
+      }
     }
   }
 
@@ -79,6 +100,7 @@ async function xhrUpload<T>(
     } catch {
       // Non-JSON failures use the localized status category below.
     }
+    reportNetworkError({ status: res.status, url: reportUrl, detail });
     // fix(#1446): route terminal auth failure through the shared path instead
     // of clearing the store directly. Since the refresh credential became an
     // httpOnly cookie, a store-only logout leaves it and its server-side row
@@ -130,9 +152,21 @@ export async function previewFile(jobId: string, layerName?: string): Promise<Fi
   const url = layerName
     ? `/ingest/preview/${jobId}?layer_name=${encodeURIComponent(layerName)}`
     : `/ingest/preview/${jobId}`;
-  return apiFetch<FilePreviewResponse>(url, {
-    method: 'POST',
-  });
+  try {
+    return await apiFetch<FilePreviewResponse>(url, {
+      method: 'POST',
+    });
+  } catch (err) {
+    // Detection/preview also runs outside any TanStack mutation (UploadForm
+    // calls it directly to keep per-file state granular), so it was invisible
+    // to the report buffer the same way uploadFile was. Drop the job id from
+    // the reported path — same reasoning as reportQueryKey in main.tsx: an id
+    // isn't reliably distinguishable from a secret by shape.
+    if (err instanceof ApiError) {
+      reportNetworkError({ status: err.status, url: '/ingest/preview', detail: err.body ?? err.message });
+    }
+    throw err;
+  }
 }
 
 export async function commitImport(
@@ -209,42 +243,85 @@ export async function completePresignedUpload(
   });
 }
 
+// Metadata-only report for a step in the presigned-upload handshake
+// (request → PUT → complete). `stage` is a short static label, never the
+// presigned URL itself, which carries a time-limited access signature.
+function reportPresignFailure(stage: string, filename: string, err: unknown): void {
+  const url = `presigned:${stage} (${filename})`;
+  if (err instanceof ApiError) {
+    reportNetworkError({ status: err.status, url, detail: err.body ?? err.message });
+  } else {
+    reportNetworkError({ status: 0, url, detail: err instanceof Error ? err.message : undefined });
+  }
+}
+
 /**
  * Upload a file via presigned URL flow:
  * 1. Request presigned URL(s) from backend
  * 2. PUT file directly to S3
  * 3. Notify backend of completion
  * Returns the same UploadResponse as the regular upload endpoint.
+ *
+ * This whole flow runs outside any TanStack mutation (UploadForm calls it
+ * directly to keep per-file state granular), so none of its failures ever
+ * reached the shared MutationCache.onError tap in main.tsx — a job could be
+ * staged on the backend by step 1 and then abandoned by a step-2/3 failure
+ * with nothing recorded anywhere the user could report. Each step below
+ * reports its own failure through the existing reportNetworkError tap.
  */
 export async function uploadPresigned(
   file: File,
   onProgress?: UploadProgress,
 ): Promise<UploadResponse> {
-  const { job_id, urls, upload_id, part_size } = await requestPresignedUpload(
-    file.name,
-    file.size,
-    file.type || undefined,
-  );
+  let job_id: string, urls: string[], upload_id: string | null | undefined, part_size: number | null | undefined;
+  try {
+    ({ job_id, urls, upload_id, part_size } = await requestPresignedUpload(
+      file.name,
+      file.size,
+      file.type || undefined,
+    ));
+  } catch (err) {
+    reportPresignFailure('request', file.name, err);
+    throw err;
+  }
 
   if (urls.length === 1 && !upload_id) {
     // Simple PUT upload. Single-PUT is only used for small files, so progress
     // is a coarse 0→1 instead of an extra XHR-with-progress path.
     onProgress?.(0);
-    const resp = await fetch(urls[0], { method: 'PUT', body: file });
+    let resp: Response;
+    try {
+      resp = await fetch(urls[0], { method: 'PUT', body: file });
+    } catch (err) {
+      reportPresignFailure('put', file.name, err);
+      throw err;
+    }
     if (!resp.ok) {
+      reportNetworkError({ status: resp.status, url: `presigned:put (${file.name})` });
       throw new Error(
         i18n.t('common:errors.storageUploadFailed', { status: resp.status }),
       );
     }
     onProgress?.(1);
-    return completePresignedUpload(job_id);
+    try {
+      return await completePresignedUpload(job_id);
+    } catch (err) {
+      reportPresignFailure('complete', file.name, err);
+      throw err;
+    }
   }
 
-  // Multipart upload — progress reported per completed chunk.
+  // Multipart upload — progress reported per completed chunk. uploadChunks
+  // reports its own per-part failures.
   const etags = await uploadChunks(urls, file, part_size!, onProgress);
   const completedParts = etags.map((etag, i) => ({ etag, part_number: i + 1 }));
 
-  return completePresignedUpload(job_id, completedParts);
+  try {
+    return await completePresignedUpload(job_id, completedParts);
+  } catch (err) {
+    reportPresignFailure('complete', file.name, err);
+    throw err;
+  }
 }
 
 export async function createVrt(request: VrtCreateRequest): Promise<VrtCreateResponse> {

--- a/frontend/src/components/import/BulkReviewList.tsx
+++ b/frontend/src/components/import/BulkReviewList.tsx
@@ -1,7 +1,7 @@
 import { useState, useMemo } from 'react';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { useTranslation } from 'react-i18next';
-import { Layers, X, ChevronDown, ChevronRight } from 'lucide-react';
+import { Layers, X, ChevronDown, ChevronRight, LifeBuoy } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -12,7 +12,33 @@ import { StatusPill } from './StatusPill';
 import { isRasterPreview, isFilePreview, fileExt, kindFromEntry } from './utils';
 import { getGeometryTypeLabel } from '@/i18n/labels';
 import { formatNumber } from '@/lib/format';
+import { useReportDialog } from '@/lib/report';
 import type { FileEntry, CommitImportRequest, FilePreviewResponse } from '@/types/api';
+
+/* ── Report CTA (upload/commit failure rows) ─────────── */
+
+/**
+ * Inline nudge on a failed staged file toward the in-app problem reporter.
+ * The import route already maps to the "Import / Ingestion" area
+ * (mapAreaFromPath in build-issue.ts), so opening the wizard from here
+ * pre-seeds it without any wizard changes.
+ */
+function ReportProblemButton() {
+  const { t } = useTranslation('import');
+  const openReport = useReportDialog((s) => s.openReport);
+
+  return (
+    <Button
+      type="button"
+      variant="outline"
+      size="xs"
+      onClick={openReport}
+    >
+      <LifeBuoy className="size-3" />
+      {t('upload.reportProblem')}
+    </Button>
+  );
+}
 
 /* ── Detection panel (expanded row) ──────────────────── */
 
@@ -400,14 +426,25 @@ export function BulkReviewList({
                   )}
 
                   {entry.status === 'commit-failed' && entry.error && (
-                    <p className="mt-2 text-sm text-destructive">{entry.error}</p>
+                    <div className="mt-2 space-y-1.5">
+                      <p className="text-sm text-destructive">{entry.error}</p>
+                      <ReportProblemButton />
+                    </div>
                   )}
                 </div>
               )}
 
-              {/* Non-expanded error */}
-              {!isExpanded && entry.status === 'upload-failed' && entry.error && (
-                <p className="px-4 pb-3 text-sm text-destructive">{entry.error}</p>
+              {/* Non-expanded error. Guarded on `canExpand` (always false for
+                  upload-failed), not just `isExpanded`: `expandedId` seeds
+                  from entries[0], so when the FIRST — or sole — staged file
+                  fails upload, isExpanded is true for it despite canExpand
+                  being false, and `!isExpanded` alone hid the error and this
+                  CTA for exactly the single-file-upload-fails case. */}
+              {!(isExpanded && canExpand) && entry.status === 'upload-failed' && entry.error && (
+                <div className="space-y-1.5 px-4 pb-3">
+                  <p className="text-sm text-destructive">{entry.error}</p>
+                  <ReportProblemButton />
+                </div>
               )}
             </div>
           );

--- a/frontend/src/components/import/__tests__/BulkReviewList.reportCta.test.tsx
+++ b/frontend/src/components/import/__tests__/BulkReviewList.reportCta.test.tsx
@@ -1,0 +1,222 @@
+/**
+ * "Report this problem" CTA on failed staged files.
+ *
+ * The import UI showed a failure state with no path to the in-app problem
+ * reporter, so a stuck uploader had no nudge toward filing a report. Tests:
+ * (a) renders on the sole/first entry's upload-failed error (regression for
+ *     the isExpanded/canExpand bug that hid the error entirely — see below)
+ * (b) renders on a non-first upload-failed entry too
+ * (c) renders inside the expanded panel for a commit-failed entry
+ * (d) does NOT render for a healthy 'preview' entry
+ * (e) clicking it opens the report wizard via useReportDialog().openReport
+ */
+import { render, screen } from '@/test/test-utils';
+import userEvent from '@testing-library/user-event';
+import { BulkReviewList } from '../BulkReviewList';
+import type { FileEntry, CommitImportRequest } from '@/types/api';
+
+// ---------------------------------------------------------------------------
+// Module mocks
+// ---------------------------------------------------------------------------
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, opts?: Record<string, unknown>) => {
+      if (key === 'upload.reportProblem') return 'Report this problem';
+      if (typeof opts?.defaultValue === 'string') return opts.defaultValue;
+      return key;
+    },
+  }),
+}));
+
+vi.mock('@/i18n/labels', () => ({
+  getGeometryTypeLabel: (_t: unknown, type: string) => type,
+}));
+
+vi.mock('@/lib/format', () => ({
+  formatNumber: (n: number) => String(n),
+}));
+
+vi.mock('../ImportMetadataForm', () => ({
+  ImportMetadataForm: () => <div data-testid="import-metadata-form" />,
+}));
+
+vi.mock('../TypeTag', () => ({
+  TypeTag: () => <div data-testid="type-tag" />,
+  kindFromExtension: () => 'table',
+}));
+
+vi.mock('../StatusPill', () => ({
+  StatusPill: () => <div data-testid="status-pill" />,
+}));
+
+const mockOpenReport = vi.fn();
+vi.mock('@/lib/report', () => ({
+  useReportDialog: (selector: (s: { openReport: () => void }) => unknown) =>
+    selector({ openReport: mockOpenReport }),
+}));
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function makeEntry(overrides: Partial<FileEntry>): FileEntry {
+  return {
+    id: 'entry-1',
+    file: null,
+    fileName: 'parcels.csv',
+    status: 'preview',
+    jobId: 'job-1',
+    previewData: null,
+    error: null,
+    submittedTitle: null,
+    submittedVisibility: null,
+    submittedKind: null,
+    ...overrides,
+  };
+}
+
+const noopCommitSingle = (_entryId: string, _request: CommitImportRequest) => {};
+const noopCommitAll = () => {};
+const noopRemove = (_entryId: string) => {};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('BulkReviewList — "Report this problem" CTA', () => {
+  beforeEach(() => {
+    mockOpenReport.mockClear();
+  });
+
+  it('(a) renders for the sole/first entry\'s upload-failed error', () => {
+    const entry = makeEntry({
+      id: 'entry-1',
+      status: 'upload-failed',
+      error: 'Upload failed: HTTP 500',
+    });
+
+    render(
+      <BulkReviewList
+        entries={[entry]}
+        onCommitSingle={noopCommitSingle}
+        onCommitAll={noopCommitAll}
+        onRemove={noopRemove}
+        isCommitting={false}
+      />,
+    );
+
+    // Regression: expandedId seeds from entries[0], so isExpanded is true for
+    // the first entry even though upload-failed is never expandable
+    // (canExpand === false) — a guard on isExpanded alone hid this error.
+    expect(screen.getByText('Upload failed: HTTP 500')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Report this problem/ })).toBeInTheDocument();
+  });
+
+  it('(b) renders for a non-first upload-failed entry', () => {
+    const entries = [
+      makeEntry({ id: 'entry-ok', status: 'preview', previewData: null }),
+      makeEntry({ id: 'entry-bad', status: 'upload-failed', error: 'Upload failed: HTTP 500' }),
+    ];
+
+    render(
+      <BulkReviewList
+        entries={entries}
+        onCommitSingle={noopCommitSingle}
+        onCommitAll={noopCommitAll}
+        onRemove={noopRemove}
+        isCommitting={false}
+      />,
+    );
+
+    expect(screen.getByText('Upload failed: HTTP 500')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Report this problem/ })).toBeInTheDocument();
+  });
+
+  it('(c) renders inside the expanded panel for a commit-failed entry', () => {
+    const entry = makeEntry({
+      id: 'entry-1',
+      status: 'commit-failed',
+      error: 'Failed to start import',
+      previewData: {
+        job_id: 'job-1',
+        source_filename: 'parcels.csv',
+        columns: [],
+        geometry_type: 'Point',
+        crs: 4326,
+        layer_name: 'only',
+        layers: [{ name: 'only', feature_count: 5, field_count: 2 }],
+        sample_rows: [],
+        feature_count: 5,
+        detected_geometry_columns: null,
+      },
+    });
+
+    render(
+      <BulkReviewList
+        entries={[entry]}
+        onCommitSingle={noopCommitSingle}
+        onCommitAll={noopCommitAll}
+        onRemove={noopRemove}
+        isCommitting={false}
+      />,
+    );
+
+    expect(screen.getByText('Failed to start import')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Report this problem/ })).toBeInTheDocument();
+  });
+
+  it('(d) does NOT render for a healthy preview entry', () => {
+    const entry = makeEntry({
+      id: 'entry-1',
+      status: 'preview',
+      previewData: {
+        job_id: 'job-1',
+        source_filename: 'parcels.csv',
+        columns: [],
+        geometry_type: 'Point',
+        crs: 4326,
+        layer_name: 'only',
+        layers: [{ name: 'only', feature_count: 5, field_count: 2 }],
+        sample_rows: [],
+        feature_count: 5,
+        detected_geometry_columns: null,
+      },
+    });
+
+    render(
+      <BulkReviewList
+        entries={[entry]}
+        onCommitSingle={noopCommitSingle}
+        onCommitAll={noopCommitAll}
+        onRemove={noopRemove}
+        isCommitting={false}
+      />,
+    );
+
+    expect(screen.queryByRole('button', { name: /Report this problem/ })).not.toBeInTheDocument();
+  });
+
+  it('(e) clicking it opens the report wizard', async () => {
+    const user = userEvent.setup();
+    const entry = makeEntry({
+      id: 'entry-1',
+      status: 'upload-failed',
+      error: 'Upload failed: HTTP 500',
+    });
+
+    render(
+      <BulkReviewList
+        entries={[entry]}
+        onCommitSingle={noopCommitSingle}
+        onCommitAll={noopCommitAll}
+        onRemove={noopRemove}
+        isCommitting={false}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: /Report this problem/ }));
+
+    expect(mockOpenReport).toHaveBeenCalledOnce();
+  });
+});

--- a/frontend/src/i18n/locales/de/import.json
+++ b/frontend/src/i18n/locales/de/import.json
@@ -74,7 +74,8 @@
     "multiLayerRetryClose": "Schließen (erneut auf 'Alle Ebenen importieren' klicken)",
     "quotaShort": "Übersprungen – Datensatzlimit erreicht",
     "quotaBannerTitle": "Datensatzlimit erreicht",
-    "quotaBannerHint": "Löschen Sie vorhandene Datensätze, um Platz zu schaffen, oder bitten Sie einen Administrator, das Limit zu erhöhen."
+    "quotaBannerHint": "Löschen Sie vorhandene Datensätze, um Platz zu schaffen, oder bitten Sie einen Administrator, das Limit zu erhöhen.",
+    "reportProblem": "Dieses Problem melden"
   },
   "warnings": {
     "bannerTitle": "Import mit Warnungen abgeschlossen",

--- a/frontend/src/i18n/locales/en/import.json
+++ b/frontend/src/i18n/locales/en/import.json
@@ -74,7 +74,8 @@
     "multiLayerRetryClose": "Close (retry by re-clicking Ingest all layers)",
     "quotaShort": "Skipped — dataset limit reached",
     "quotaBannerTitle": "Dataset limit reached",
-    "quotaBannerHint": "Delete existing datasets to free space, or ask an administrator to raise the limit."
+    "quotaBannerHint": "Delete existing datasets to free space, or ask an administrator to raise the limit.",
+    "reportProblem": "Report this problem"
   },
   "warnings": {
     "bannerTitle": "Import completed with warnings",

--- a/frontend/src/i18n/locales/es/import.json
+++ b/frontend/src/i18n/locales/es/import.json
@@ -74,7 +74,8 @@
     "multiLayerRetryClose": "Cerrar (volver a hacer clic en 'Ingerir todas las capas')",
     "quotaShort": "Omitido: límite de conjuntos de datos alcanzado",
     "quotaBannerTitle": "Límite de conjuntos de datos alcanzado",
-    "quotaBannerHint": "Elimina conjuntos de datos existentes para liberar espacio o pide a un administrador que aumente el límite."
+    "quotaBannerHint": "Elimina conjuntos de datos existentes para liberar espacio o pide a un administrador que aumente el límite.",
+    "reportProblem": "Informar de este problema"
   },
   "warnings": {
     "bannerTitle": "Importación completada con advertencias",

--- a/frontend/src/i18n/locales/fr/import.json
+++ b/frontend/src/i18n/locales/fr/import.json
@@ -74,7 +74,8 @@
     "multiLayerRetryClose": "Fermer (recliquer sur 'Ingérer toutes les couches')",
     "quotaShort": "Ignoré — limite de jeux de données atteinte",
     "quotaBannerTitle": "Limite de jeux de données atteinte",
-    "quotaBannerHint": "Supprimez des jeux de données existants pour libérer de l'espace, ou demandez à un administrateur d'augmenter la limite."
+    "quotaBannerHint": "Supprimez des jeux de données existants pour libérer de l'espace, ou demandez à un administrateur d'augmenter la limite.",
+    "reportProblem": "Signaler ce problème"
   },
   "warnings": {
     "bannerTitle": "Importation terminée avec des avertissements",


### PR DESCRIPTION
## What / why

A visitor's CSV upload failed client-side twice in one minute on the public
demo and gave up. The server recorded two abandoned presigned jobs with zero
diagnostic, and no report was filed. Two suspected holes, confirmed by
investigation:

**1. The upload path bypassed the report buffer entirely, not just the XHR
progress path.** `UploadForm.processFiles` calls `uploadFile` /
`uploadPresigned` / `previewFile` directly from a plain `try/catch`
(`frontend/src/components/import/UploadForm.tsx:186-212`), not through a
`useMutation`. The shared `MutationCache.onError` tap that feeds the report
buffer only fires for TanStack-driven calls (`frontend/src/main.tsx:60-70`),
so every failure in the upload/preview flow was invisible to it, regardless
of whether the failing call used XHR, `fetch`, or `apiFetch`:

- `uploadFile` -> `xhrUpload` (`frontend/src/api/ingest.ts`): XHR network
  error and non-2xx status both just threw; neither was reported.
- `uploadPresigned` (`frontend/src/api/ingest.ts`): the presign request
  (`apiFetch`), the single-part S3 PUT (raw `fetch`), and the multipart PUT
  loop (`uploadChunks` in `frontend/src/api/_presignedUpload.ts`, shared with
  `datasets.ts`'s reupload flow) all threw with nothing reported.
- `previewFile` (`frontend/src/api/ingest.ts`): `apiFetch`-based, same gap.

**2. No nudge toward the reporter on a failure row.** `BulkReviewList`
rendered `entry.error` for `upload-failed` and `commit-failed` rows with no
path to the wizard.

While adding the CTA, found a third, load-bearing bug: `BulkReviewList`
seeds `expandedId` from `entries[0]`, so `isExpanded` is `true` for the
first entry even when its status (`upload-failed`) is never expandable
(`canExpand` is `false` for that status). The old guard was `!isExpanded`
alone, so for the sole/first staged file in a batch, the exact demo
scenario, one CSV, neither the expanded panel nor the non-expanded error
block rendered. The error text, and now the CTA, was invisible for exactly
the case this PR is meant to fix. Fixed the guard to `!(isExpanded &&
canExpand)`.

## What changed

- `frontend/src/api/ingest.ts`: `xhrUpload` (direct-POST upload),
  `uploadPresigned` (presign request, single-part PUT, complete), and
  `previewFile` now call `reportNetworkError` on failure.
- `frontend/src/api/_presignedUpload.ts`: `uploadChunks` reports its own
  per-part failures (both the non-retriable/exhausted-retries HTTP case and
  the network-layer case), skipping `AbortError`. This is shared with
  `datasets.ts`'s `reuploadPresigned`, so the dataset re-upload flow picks up
  the same coverage as a side effect.
- `frontend/src/components/import/BulkReviewList.tsx`: adds a "Report this
  problem" CTA (`Button variant="outline" size="xs"`, `LifeBuoy` icon) on the
  `upload-failed` and `commit-failed` error rows, calling
  `useReportDialog().openReport()`. No wizard changes: the import route
  already maps to the "Import / Ingestion" area via `mapAreaFromPath` in
  `build-issue.ts`, so opening from here pre-seeds it. Also fixes the
  `isExpanded`/`canExpand` visibility bug above.
- Redaction: everything routes through the existing `reportNetworkError` /
  `pushReportEntry`, so capture-time `redact()` applies unchanged, no
  parallel path. Only metadata is captured (status, error text, filename);
  the multipart file body and the presigned S3 URLs (which carry a
  time-limited access signature) are never logged. The presigned-PUT taps
  use synthetic labels (`presigned:put (part N/M) - filename`) instead of
  the real signed URL, on the same reasoning `reportQueryKey` in `main.tsx`
  already uses for dropping ids from reported paths.
- `CHANGELOG.md`: `[Unreleased] > Added`.
- i18n: `upload.reportProblem` added to all four locales
  (en/es/fr/de import.json).

## Schema / API impact

None. Frontend-only.

## Tests

New:
- `frontend/src/api/__tests__/ingest-report-capture.test.ts` (6 cases):
  direct-POST failure (asserts filename in the entry, uploaded row content
  never appears), presign-request failure, single-part PUT failure (asserts
  the signed URL's signature never appears), multipart PUT failure (asserts
  the failing part number), preview/detection failure (asserts the job id is
  dropped from the reported path), and a redaction sanity check on the
  captured detail.
- `frontend/src/components/import/__tests__/BulkReviewList.reportCta.test.tsx`
  (5 cases): CTA on the sole/first upload-failed entry (the visibility-bug
  regression case), on a non-first upload-failed entry, inside the expanded
  commit-failed panel, absent on a healthy entry, and that clicking it calls
  `openReport`.

Counterfactual (WAVE-RULES): committed the change, then `git checkout
<base>~1 -- <the three touched source files>` (not the test files) and
re-ran both new test files. 10 of 11 assertions failed against the
pre-change code (the 11th is a negative "CTA absent on a healthy entry"
assertion, correct either way, a guard against false positives, not a
regression detector). Restored via `git checkout HEAD -- <files>`; full
suite green again.

Commands actually run:
\`\`\`
cd frontend
npm run typecheck
npm run lint
npm run test:i18n
npx vitest run                       # full suite: 415 files / 5496 tests
npx vitest run src/api/__tests__/ingest-report-capture.test.ts \\
  src/components/import/__tests__/BulkReviewList.reportCta.test.tsx \\
  src/lib/report src/api/_presignedUpload.test.ts \\
  src/api/__tests__/presigned-upload.test.ts src/components/import
\`\`\`

No backend changes were needed for this slice.

---

## Update: codex round 1

Codex flagged 3 inline P2s, all the same finding class: a failure path that
flips a row to `upload-failed`/`commit-failed` (and so shows the CTA)
without writing a buffer entry.

1. `commitImport`/`commitFanOut` are direct `apiFetch` calls, no TanStack, no
   `reportNetworkError` at all.
2. `xhrUpload`'s final `JSON.parse(res.body)` on `/ingest/upload` runs
   outside the status-based reporting block, so a 2xx response with a
   malformed body threw uncaptured.
3. `previewFile`'s `instanceof ApiError` guard skipped a real failure class:
   `apiFetch`'s own `response.json()` throws a raw `SyntaxError`, not an
   `ApiError`, on a malformed 2xx body.

**Enumeration.** Every setter of `status: 'upload-failed'` or
`status: 'commit-failed'` in `UploadForm.tsx`:

| Line | Status set | Underlying call |
|---|---|---|
| `UploadForm.tsx:205` | `upload-failed` | `uploadFile` / `uploadPresigned` / `previewFile` (one `try/catch` covers all three) |
| `UploadForm.tsx:293` | `commit-failed` | `commitImport` (`handleCommitSingle`) |
| `UploadForm.tsx:332` | `commit-failed` | `commitImport` (`handleCommitAll`) |
| `UploadForm.tsx:412` | `commit-failed` | `commitFanOut` throwing (`handleIngestAllLayers`, all-layers-rejected branch) |
| `UploadForm.tsx:417` | `commit-failed` | `commitFanOut` returning a 200 with some layers `'failed'` — **not** a network/HTTP error, so out of scope for `reportNetworkError`; those per-layer errors are already shown in the results modal, not silently lost |

`handleSheetChange`'s `previewFile` failure doesn't set either status (stays
`'preview'` with just `entry.error`), so it's outside this enumeration, and
its network-layer failure is still captured because `previewFile` itself
reports before rethrowing.

**Shape chosen: capture stays at the API-function choke point (one report
call per `api/*.ts` function), not moved into `UploadForm.tsx`'s
status-setting catches.** `uploadFile`/`uploadPresigned`/`previewFile` are
also called from `SaveChatPreviewDialog.tsx`, and `uploadChunks` is also
called from `datasets.ts`'s `reuploadPresigned` (used by
`ReuploadDialog.tsx`) — moving capture into `UploadForm.tsx` alone would
have dropped coverage for those other callers back to zero. Fixed the
*class* by:

- Adding capture to `commitImport` and `commitFanOut`, which had none before
  (finding 1) — a different gap from the others: no reporting attempt
  existed at all, not just a type-guard miss.
- Wrapping `xhrUpload`'s final `JSON.parse` in its own try/catch (finding 2).
- Replacing the `instanceof ApiError` gate in `previewFile` with a shared
  `reportApiCallFailure(label, err)` helper that reports an `ApiError` (real
  status) or anything else uniformly (status `0`), so a `SyntaxError` from a
  malformed JSON body is no longer silently dropped (finding 3) — and
  reusing that same helper in `commitImport` and (a small local duplicate,
  matching the existing `ingest.ts`/`datasets.ts` duplication convention
  already documented in `_presignedUpload.ts`) `commitFanOut` closes finding
  1 with the same fix, not a one-off.

No double-reporting: each of these functions has exactly one `try/catch`
around its own `apiFetch`/`fetch` call, so a given failure is reported once,
at the layer that already owns the HTTP-level try/catch, regardless of
which UI surface called it.

New tests (appended to
`frontend/src/api/__tests__/ingest-report-capture.test.ts`):
`(g)` `commitImport` failure, `(h)` `commitFanOut` failure, `(i)` malformed
2xx JSON body on the direct-POST upload, `(j)` non-`ApiError` preview
rejection.

Counterfactual: committed, `git checkout HEAD~1 -- frontend/src/api/ingest.ts
frontend/src/api/datasets.ts`, reran the test file — exactly `(g)`-`(j)` fail
(4 of 4 new cases; the original 6 from the first commit are unaffected).
Restored with `git checkout HEAD -- <files>`; full suite green (415 files /
5500 tests), lint and typecheck clean.


---

## Update: codex round 3

One new P2 (thread on `datasets.ts:494`), and it correctly overturns part of
my round-1 exclusion: when `commitFanOut` returns HTTP 200 with
`results[].status === 'failed'` for one or more layers, `UploadForm` still
maps that to a `commit-failed` row, which shows the report CTA. My earlier
rationale ("those per-layer errors are already shown in the results modal,
so they're not silently lost") covers what the *user* sees, not what a
*filed report* carries. The buffer held nothing about which layer failed or
why.

Fix: at the choke point (`commitFanOut` in `datasets.ts`, consistent with
the round-1 shape decision), after a successful (200) response, push one
`pushReportEntry` call per failed layer (message: `Layer import failed:
{layer_name}`, detail: the layer's own error text) — not
`reportNetworkError`, since there's no HTTP failure here. One entry per
layer rather than one merged summary, so two layers failing with
byte-identical error text stay distinguishable instead of collapsing into a
single count via the buffer's own message-based dedup. Redaction applies
automatically (`pushReportEntry` always redacts); metadata only, same as
every other tap in this PR.

New tests: `(k)` a mixed 200 (2 of 3 layers failed) writes one entry per
failed layer, verifies the queued layer wrote nothing, and verifies the two
failed layers stay as two distinct entries despite identical error text;
`(l)` an all-success 200 writes nothing.

Counterfactual: committed, `git checkout HEAD~1 -- frontend/src/api/datasets.ts`,
reran the test file — exactly `(k)` fails (`(l)` is a negative guard, passes
either way, same pattern as the earlier rounds). Restored; full focused
suite green (307 tests across `src/api`, `src/components/import`,
`src/lib/report`), lint and typecheck clean.

Head sha: `e8cf63363806d17f54c153b1c18cb9cacd93cb87`.
