### PR TITLE
feat(ui): linkify https URLs in the admin site banner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,14 +6,6 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and releases use semantic versioning.
 
 ## [Unreleased]
-### Changed
-
-- **`https://` links in the site banner are clickable.** The admin-configured
-  announcement banner rendered its text as plain escaped text, so a URL in it
-  could only be retyped. Matched `https://` URLs now render as anchors
-  (new tab, `rel="noopener noreferrer"`); everything else stays escaped text,
-  so banner content still cannot inject markup.
-
 ### Added
 
 - **A failed upload now leaves a trace, and a way to report it.** UploadForm
@@ -41,6 +33,11 @@ and releases use semantic versioning.
   traffic browses anonymously, so a visitor who hit a broken map had no way to
   say so. The gate is removed; the button still appears only after an error is
   captured.
+- **`https://` links in the site banner are clickable.** The admin-configured
+  announcement banner rendered its text as plain escaped text, so a URL in it
+  could only be retyped. Matched `https://` URLs now render as anchors
+  (new tab, `rel="noopener noreferrer"`); everything else stays escaped text,
+  so banner content still cannot inject markup.
 
 ## [1.15.1] - 2026-08-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and releases use semantic versioning.
 
 ## [Unreleased]
+### Changed
+
+- **`https://` links in the site banner are clickable.** The admin-configured
+  announcement banner rendered its text as plain escaped text, so a URL in it
+  could only be retyped. Matched `https://` URLs now render as anchors
+  (new tab, `rel="noopener noreferrer"`); everything else stays escaped text,
+  so banner content still cannot inject markup.
 
 ### Added
 

--- a/frontend/src/components/layout/SiteBanner.tsx
+++ b/frontend/src/components/layout/SiteBanner.tsx
@@ -43,7 +43,15 @@ const DISMISS_KEY = 'gl-site-banner-dismissed';
 const URL_RE = /https:\/\/[^\s<>"\u201C\u201D\u2018\u2019\u00AB\u00BB\u2013\u2014]+/gi;
 const TRAIL_RE = /[.,;:!?)\]\u2026\u3002\u3001]+$/;
 
+// fix(#1662 review): the linkifier runs per visitor render on admin-entered
+// text with no schema length limit. Rather than proving every scan linear on
+// adversarial input, cap the work: a banner longer than this renders as plain
+// text (an announcement banner past 2,000 characters is broken UX regardless),
+// which bounds worst-case cost to a constant.
+const LINKIFY_MAX_LENGTH = 2000;
+
 function renderBannerText(text: string) {
+  if (text.length > LINKIFY_MAX_LENGTH) return [text];
   const parts: Array<string | { url: string; trail: string }> = [];
   let last = 0;
   for (const m of text.matchAll(URL_RE)) {

--- a/frontend/src/components/layout/SiteBanner.tsx
+++ b/frontend/src/components/layout/SiteBanner.tsx
@@ -70,10 +70,15 @@ function renderBannerText(text: string) {
     // The regex may stop early inside <…> (excluded characters like dashes are
     // allowed there), so the verbatim span runs to the closing bracket itself.
     if (m.index! > 0 && text[m.index! - 1] === '<') {
-      const close = text.indexOf('>', m.index!);
-      const span = close === -1 ? '' : text.slice(m.index!, close);
-      if (close !== -1 && !/\s/.test(span)) {
-        parts.push({ url: span, trail: '' });
+      // fix(#1662 review): bound the '>' search to the current whitespace-free
+      // token — an unclosed '<' must not scan the whole remaining text, or
+      // repeated unclosed spans would make the render quadratic.
+      const ws = text.slice(m.index!).search(/\s/);
+      const tokenEnd = ws === -1 ? text.length : m.index! + ws;
+      const closeInToken = text.slice(m.index!, tokenEnd).indexOf('>');
+      if (closeInToken !== -1) {
+        const close = m.index! + closeInToken;
+        parts.push({ url: text.slice(m.index!, close), trail: '' });
         last = close;
         continue;
       }

--- a/frontend/src/components/layout/SiteBanner.tsx
+++ b/frontend/src/components/layout/SiteBanner.tsx
@@ -33,8 +33,11 @@ const DISMISS_KEY = 'gl-site-banner-dismissed';
 // clickable. The text itself stays React-escaped; only the matched URL
 // becomes an anchor, so an admin cannot inject markup through the banner.
 // Trailing sentence punctuation stays outside the link.
+// Apostrophes are legitimate URL characters (/O'Reilly), so ' is NOT an
+// excluded body character; a single quote only acts as a delimiter when it
+// wraps the URL ('https://…'), handled by the paired-wrapper check below.
 const URL_RE =
-  /(https:\/\/[^\s<>"'\u201C\u201D\u2018\u2019\u00AB\u00BB]+?)([.,;:!?)\]\u2026\u3002\u3001]*)(?=[\s<>"'\u201C\u201D\u2018\u2019\u00AB\u00BB]|$)/g;
+  /(https:\/\/[^\s<>"\u201C\u201D\u2018\u2019\u00AB\u00BB]+?)([.,;:!?)\]\u2026\u3002\u3001]*)(?=[\s<>"\u201C\u201D\u2018\u2019\u00AB\u00BB]|$)/g;
 
 function renderBannerText(text: string) {
   const parts: Array<string | { url: string; trail: string }> = [];
@@ -43,6 +46,13 @@ function renderBannerText(text: string) {
     if (m.index! > last) parts.push(text.slice(last, m.index));
     let url = m[1];
     let trail = m[2];
+    // fix(#1662 review): 'https://…' wrapped in single quotes — the opening
+    // quote sits just before the match, so a trailing apostrophe is the
+    // closing wrapper, not part of the URL. Unpaired apostrophes stay in.
+    if (m.index! > 0 && text[m.index! - 1] === "'" && url.endsWith("'")) {
+      url = url.slice(0, -1);
+      trail = "'" + trail;
+    }
     // fix(#1662 review): a URL that legitimately ends in ')' or ']' — e.g. a
     // Wikipedia path like /Function_(mathematics) — should keep as many
     // closing brackets as it has unmatched opening ones of the same kind;

--- a/frontend/src/components/layout/SiteBanner.tsx
+++ b/frontend/src/components/layout/SiteBanner.tsx
@@ -33,7 +33,8 @@ const DISMISS_KEY = 'gl-site-banner-dismissed';
 // clickable. The text itself stays React-escaped; only the matched URL
 // becomes an anchor, so an admin cannot inject markup through the banner.
 // Trailing sentence punctuation stays outside the link.
-const URL_RE = /(https:\/\/[^\s<>"']+?)([.,;:!?)\]]*)(?=[\s<>"']|$)/g;
+const URL_RE =
+  /(https:\/\/[^\s<>"'\u201C\u201D\u2018\u2019\u00AB\u00BB]+?)([.,;:!?)\]\u2026\u3002\u3001]*)(?=[\s<>"'\u201C\u201D\u2018\u2019\u00AB\u00BB]|$)/g;
 
 function renderBannerText(text: string) {
   const parts: Array<string | { url: string; trail: string }> = [];

--- a/frontend/src/components/layout/SiteBanner.tsx
+++ b/frontend/src/components/layout/SiteBanner.tsx
@@ -29,7 +29,7 @@ const COLOR_CLASSES: Record<string, string> = {
 
 const DISMISS_KEY = 'gl-site-banner-dismissed';
 
-// feat(#123-followup): make https:// URLs in admin-entered banner text
+// feat(#1662): make https:// URLs in admin-entered banner text
 // clickable. The text itself stays React-escaped; only the matched URL
 // becomes an anchor, so an admin cannot inject markup through the banner.
 // Trailing sentence punctuation stays outside the link.
@@ -40,7 +40,23 @@ function renderBannerText(text: string) {
   let last = 0;
   for (const m of text.matchAll(URL_RE)) {
     if (m.index! > last) parts.push(text.slice(last, m.index));
-    parts.push({ url: m[1], trail: m[2] });
+    let url = m[1];
+    let trail = m[2];
+    // fix(#1662 review): a URL that legitimately ends in ')' — e.g. a
+    // Wikipedia path like /Function_(mathematics) — should keep as many
+    // closing parens as it has unmatched opening ones; only the excess is
+    // sentence punctuation.
+    let unmatched = 0;
+    for (const ch of url) {
+      if (ch === '(') unmatched += 1;
+      else if (ch === ')' && unmatched > 0) unmatched -= 1;
+    }
+    while (unmatched > 0 && trail.startsWith(')')) {
+      url += ')';
+      trail = trail.slice(1);
+      unmatched -= 1;
+    }
+    parts.push({ url, trail });
     last = m.index! + m[0].length;
   }
   if (last < text.length) parts.push(text.slice(last));

--- a/frontend/src/components/layout/SiteBanner.tsx
+++ b/frontend/src/components/layout/SiteBanner.tsx
@@ -47,6 +47,10 @@ function renderBannerText(text: string) {
   const parts: Array<string | { url: string; trail: string }> = [];
   let last = 0;
   for (const m of text.matchAll(URL_RE)) {
+    // fix(#1662 review): a verbatim <…> span advances `last` past characters
+    // matchAll has not seen; a scheme inside the consumed span must not
+    // produce a second, overlapping link.
+    if (m.index! < last) continue;
     // fix(#1662 review): only linkify at a token boundary — an https:// embedded
     // inside another token (nothttps://…, or a URL nested in another URL's
     // path) is not a link of its own.

--- a/frontend/src/components/layout/SiteBanner.tsx
+++ b/frontend/src/components/layout/SiteBanner.tsx
@@ -29,6 +29,40 @@ const COLOR_CLASSES: Record<string, string> = {
 
 const DISMISS_KEY = 'gl-site-banner-dismissed';
 
+// feat(#123-followup): make https:// URLs in admin-entered banner text
+// clickable. The text itself stays React-escaped; only the matched URL
+// becomes an anchor, so an admin cannot inject markup through the banner.
+// Trailing sentence punctuation stays outside the link.
+const URL_RE = /(https:\/\/[^\s<>"']+?)([.,;:!?)]*)(?=\s|$)/g;
+
+function renderBannerText(text: string) {
+  const parts: Array<string | { url: string; trail: string }> = [];
+  let last = 0;
+  for (const m of text.matchAll(URL_RE)) {
+    if (m.index! > last) parts.push(text.slice(last, m.index));
+    parts.push({ url: m[1], trail: m[2] });
+    last = m.index! + m[0].length;
+  }
+  if (last < text.length) parts.push(text.slice(last));
+  return parts.map((p, i) =>
+    typeof p === 'string' ? (
+      p
+    ) : (
+      <span key={i}>
+        <a
+          href={p.url}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="underline underline-offset-2 hover:opacity-80"
+        >
+          {p.url}
+        </a>
+        {p.trail}
+      </span>
+    ),
+  );
+}
+
 function getDismissed(): string | null {
   try {
     return sessionStorage.getItem(DISMISS_KEY);
@@ -66,7 +100,7 @@ export function SiteBanner() {
       aria-live="polite"
       className={`relative border-b px-8 py-1.5 text-center text-sm ${colorClass}`}
     >
-      {text}
+      {renderBannerText(text)}
       <button
         type="button"
         onClick={handleDismiss}

--- a/frontend/src/components/layout/SiteBanner.tsx
+++ b/frontend/src/components/layout/SiteBanner.tsx
@@ -33,7 +33,7 @@ const DISMISS_KEY = 'gl-site-banner-dismissed';
 // clickable. The text itself stays React-escaped; only the matched URL
 // becomes an anchor, so an admin cannot inject markup through the banner.
 // Trailing sentence punctuation stays outside the link.
-const URL_RE = /(https:\/\/[^\s<>"']+?)([.,;:!?)]*)(?=\s|$)/g;
+const URL_RE = /(https:\/\/[^\s<>"']+?)([.,;:!?)]*)(?=[\s<>"']|$)/g;
 
 function renderBannerText(text: string) {
   const parts: Array<string | { url: string; trail: string }> = [];

--- a/frontend/src/components/layout/SiteBanner.tsx
+++ b/frontend/src/components/layout/SiteBanner.tsx
@@ -37,7 +37,7 @@ const DISMISS_KEY = 'gl-site-banner-dismissed';
 // excluded body character; a single quote only acts as a delimiter when it
 // wraps the URL ('https://…'), handled by the paired-wrapper check below.
 const URL_RE =
-  /(https:\/\/[^\s<>"\u201C\u201D\u2018\u2019\u00AB\u00BB]+?)([.,;:!?)\]\u2026\u3002\u3001]*)(?=[\s<>"\u201C\u201D\u2018\u2019\u00AB\u00BB]|$)/g;
+  /(https:\/\/[^\s<>"\u201C\u201D\u2018\u2019\u00AB\u00BB]+?)([.,;:!?)\]\u2026\u3002\u3001]*)(?=[\s<>"\u201C\u201D\u2018\u2019\u00AB\u00BB]|$)/gi;
 
 function renderBannerText(text: string) {
   const parts: Array<string | { url: string; trail: string }> = [];
@@ -46,6 +46,18 @@ function renderBannerText(text: string) {
     if (m.index! > last) parts.push(text.slice(last, m.index));
     let url = m[1];
     let trail = m[2];
+    // fix(#1662 review): <https://…> is RFC 3986's own URL delimiting. Inside
+    // angle brackets the URL is taken VERBATIM — trailing punctuation like
+    // /wiki/Yahoo! stays in the href, and no wrapper/balance heuristics run.
+    // This is also the documented escape hatch: an admin who needs an exact
+    // URL that the heuristics would trim can always write <URL>.
+    const angleDelimited =
+      m.index! > 0 && text[m.index! - 1] === '<' && text[m.index! + m[0].length] === '>';
+    if (angleDelimited) {
+      parts.push({ url: url + trail, trail: '' });
+      last = m.index! + m[0].length;
+      continue;
+    }
     // fix(#1662 review): 'https://…' wrapped in single quotes — the opening
     // quote sits just before the match, so a trailing apostrophe is the
     // closing wrapper, not part of the URL. Unpaired apostrophes stay in.

--- a/frontend/src/components/layout/SiteBanner.tsx
+++ b/frontend/src/components/layout/SiteBanner.tsx
@@ -47,6 +47,12 @@ function renderBannerText(text: string) {
   const parts: Array<string | { url: string; trail: string }> = [];
   let last = 0;
   for (const m of text.matchAll(URL_RE)) {
+    // fix(#1662 review): only linkify at a token boundary — an https:// embedded
+    // inside another token (nothttps://…, or a URL nested in another URL's
+    // path) is not a link of its own.
+    if (m.index! > 0 && !/[\s<>"'()[\]\u201C\u201D\u2018\u2019\u00AB\u00BB]/.test(text[m.index! - 1])) {
+      continue;
+    }
     if (m.index! > last) parts.push(text.slice(last, m.index));
     const matched = m[0];
     const trailMatch = TRAIL_RE.exec(matched);

--- a/frontend/src/components/layout/SiteBanner.tsx
+++ b/frontend/src/components/layout/SiteBanner.tsx
@@ -40,7 +40,7 @@ const DISMISS_KEY = 'gl-site-banner-dismissed';
 // split — the earlier lazy-body + punctuation-group pair let the engine retry
 // every split point on adversarial runs (quadratic). The trail is peeled in
 // plain code below instead, which is linear by construction.
-const URL_RE = /https:\/\/[^\s<>"\u201C\u201D\u2018\u2019\u00AB\u00BB]+/gi;
+const URL_RE = /https:\/\/[^\s<>"\u201C\u201D\u2018\u2019\u00AB\u00BB\u2013\u2014]+/gi;
 const TRAIL_RE = /[.,;:!?)\]\u2026\u3002\u3001]+$/;
 
 function renderBannerText(text: string) {
@@ -63,12 +63,16 @@ function renderBannerText(text: string) {
     // /wiki/Yahoo! stays in the href, and no wrapper/balance heuristics run.
     // This is also the documented escape hatch: an admin who needs an exact
     // URL that the heuristics would trim can always write <URL>.
-    const angleDelimited =
-      m.index! > 0 && text[m.index! - 1] === '<' && text[m.index! + m[0].length] === '>';
-    if (angleDelimited) {
-      parts.push({ url: matched, trail: '' });
-      last = m.index! + m[0].length;
-      continue;
+    // The regex may stop early inside <…> (excluded characters like dashes are
+    // allowed there), so the verbatim span runs to the closing bracket itself.
+    if (m.index! > 0 && text[m.index! - 1] === '<') {
+      const close = text.indexOf('>', m.index!);
+      const span = close === -1 ? '' : text.slice(m.index!, close);
+      if (close !== -1 && !/\s/.test(span)) {
+        parts.push({ url: span, trail: '' });
+        last = close;
+        continue;
+      }
     }
     // fix(#1662 review): 'https://…' wrapped in single quotes — the opening
     // quote sits just before the match, so a trailing apostrophe is the

--- a/frontend/src/components/layout/SiteBanner.tsx
+++ b/frontend/src/components/layout/SiteBanner.tsx
@@ -33,7 +33,7 @@ const DISMISS_KEY = 'gl-site-banner-dismissed';
 // clickable. The text itself stays React-escaped; only the matched URL
 // becomes an anchor, so an admin cannot inject markup through the banner.
 // Trailing sentence punctuation stays outside the link.
-const URL_RE = /(https:\/\/[^\s<>"']+?)([.,;:!?)]*)(?=[\s<>"']|$)/g;
+const URL_RE = /(https:\/\/[^\s<>"']+?)([.,;:!?)\]]*)(?=[\s<>"']|$)/g;
 
 function renderBannerText(text: string) {
   const parts: Array<string | { url: string; trail: string }> = [];
@@ -42,19 +42,25 @@ function renderBannerText(text: string) {
     if (m.index! > last) parts.push(text.slice(last, m.index));
     let url = m[1];
     let trail = m[2];
-    // fix(#1662 review): a URL that legitimately ends in ')' — e.g. a
+    // fix(#1662 review): a URL that legitimately ends in ')' or ']' — e.g. a
     // Wikipedia path like /Function_(mathematics) — should keep as many
-    // closing parens as it has unmatched opening ones; only the excess is
-    // sentence punctuation.
-    let unmatched = 0;
-    for (const ch of url) {
-      if (ch === '(') unmatched += 1;
-      else if (ch === ')' && unmatched > 0) unmatched -= 1;
-    }
-    while (unmatched > 0 && trail.startsWith(')')) {
-      url += ')';
-      trail = trail.slice(1);
-      unmatched -= 1;
+    // closing brackets as it has unmatched opening ones of the same kind;
+    // only the excess is sentence punctuation or a wrapping delimiter.
+    for (const [openCh, closeCh] of [
+      ['(', ')'],
+      ['[', ']'],
+    ] as const) {
+      let unmatched = 0;
+      for (const ch of url) {
+        if (ch === openCh) unmatched += 1;
+        else if (ch === closeCh && unmatched > 0) unmatched -= 1;
+      }
+      while (unmatched > 0 && trail.includes(closeCh)) {
+        const j = trail.indexOf(closeCh);
+        url += trail.slice(0, j + 1);
+        trail = trail.slice(j + 1);
+        unmatched -= 1;
+      }
     }
     parts.push({ url, trail });
     last = m.index! + m[0].length;

--- a/frontend/src/components/layout/SiteBanner.tsx
+++ b/frontend/src/components/layout/SiteBanner.tsx
@@ -36,16 +36,22 @@ const DISMISS_KEY = 'gl-site-banner-dismissed';
 // Apostrophes are legitimate URL characters (/O'Reilly), so ' is NOT an
 // excluded body character; a single quote only acts as a delimiter when it
 // wraps the URL ('https://…'), handled by the paired-wrapper check below.
-const URL_RE =
-  /(https:\/\/[^\s<>"\u201C\u201D\u2018\u2019\u00AB\u00BB]+?)([.,;:!?)\]\u2026\u3002\u3001]*)(?=[\s<>"\u201C\u201D\u2018\u2019\u00AB\u00BB]|$)/gi;
+// fix(#1662 review): a single greedy group with no trailing-group/lookahead
+// split — the earlier lazy-body + punctuation-group pair let the engine retry
+// every split point on adversarial runs (quadratic). The trail is peeled in
+// plain code below instead, which is linear by construction.
+const URL_RE = /https:\/\/[^\s<>"\u201C\u201D\u2018\u2019\u00AB\u00BB]+/gi;
+const TRAIL_RE = /[.,;:!?)\]\u2026\u3002\u3001]+$/;
 
 function renderBannerText(text: string) {
   const parts: Array<string | { url: string; trail: string }> = [];
   let last = 0;
   for (const m of text.matchAll(URL_RE)) {
     if (m.index! > last) parts.push(text.slice(last, m.index));
-    let url = m[1];
-    let trail = m[2];
+    const matched = m[0];
+    const trailMatch = TRAIL_RE.exec(matched);
+    let url = trailMatch ? matched.slice(0, trailMatch.index) : matched;
+    let trail = trailMatch ? trailMatch[0] : '';
     // fix(#1662 review): <https://…> is RFC 3986's own URL delimiting. Inside
     // angle brackets the URL is taken VERBATIM — trailing punctuation like
     // /wiki/Yahoo! stays in the href, and no wrapper/balance heuristics run.
@@ -54,7 +60,7 @@ function renderBannerText(text: string) {
     const angleDelimited =
       m.index! > 0 && text[m.index! - 1] === '<' && text[m.index! + m[0].length] === '>';
     if (angleDelimited) {
-      parts.push({ url: url + trail, trail: '' });
+      parts.push({ url: matched, trail: '' });
       last = m.index! + m[0].length;
       continue;
     }

--- a/frontend/src/components/layout/SiteBanner.tsx
+++ b/frontend/src/components/layout/SiteBanner.tsx
@@ -50,7 +50,7 @@ function renderBannerText(text: string) {
     // fix(#1662 review): only linkify at a token boundary — an https:// embedded
     // inside another token (nothttps://…, or a URL nested in another URL's
     // path) is not a link of its own.
-    if (m.index! > 0 && !/[\s<>"'()[\]\u201C\u201D\u2018\u2019\u00AB\u00BB]/.test(text[m.index! - 1])) {
+    if (m.index! > 0 && !/[\s<>"'()[\]\u201C\u201D\u2018\u2019\u00AB\u00BB\u2013\u2014]/.test(text[m.index! - 1])) {
       continue;
     }
     if (m.index! > last) parts.push(text.slice(last, m.index));

--- a/frontend/src/components/layout/__tests__/SiteBanner.test.tsx
+++ b/frontend/src/components/layout/__tests__/SiteBanner.test.tsx
@@ -151,4 +151,13 @@ describe('SiteBanner', () => {
     expect(links[0]).toHaveAttribute('href', 'https://ok.example/docs');
     expect(links[1]).toHaveAttribute('href', 'https://ok.example/more');
   });
+
+  it("L) apostrophes inside a URL survive; a single-quote wrapper is shed", () => {
+    renderBanner({
+      banner_text: "See https://ok.example/O'Reilly and 'https://ok.example/wrapped'",
+    });
+    const links = screen.getAllByRole('link');
+    expect(links[0]).toHaveAttribute('href', "https://ok.example/O'Reilly");
+    expect(links[1]).toHaveAttribute('href', 'https://ok.example/wrapped');
+  });
 });

--- a/frontend/src/components/layout/__tests__/SiteBanner.test.tsx
+++ b/frontend/src/components/layout/__tests__/SiteBanner.test.tsx
@@ -160,4 +160,13 @@ describe('SiteBanner', () => {
     expect(links[0]).toHaveAttribute('href', "https://ok.example/O'Reilly");
     expect(links[1]).toHaveAttribute('href', 'https://ok.example/wrapped');
   });
+
+  it('M) uppercase scheme matches; angle-delimited URLs are taken verbatim', () => {
+    renderBanner({
+      banner_text: 'Go to HTTPS://ok.example/up or <https://en.wikipedia.org/wiki/Yahoo!>',
+    });
+    const links = screen.getAllByRole('link');
+    expect(links[0]).toHaveAttribute('href', 'HTTPS://ok.example/up');
+    expect(links[1]).toHaveAttribute('href', 'https://en.wikipedia.org/wiki/Yahoo!');
+  });
 });

--- a/frontend/src/components/layout/__tests__/SiteBanner.test.tsx
+++ b/frontend/src/components/layout/__tests__/SiteBanner.test.tsx
@@ -186,5 +186,11 @@ describe('SiteBanner', () => {
     const links = screen.getAllByRole('link');
     expect(links[0]).toHaveAttribute('href', 'https://ok.example/a');
     expect(links[1]).toHaveAttribute('href', 'https://ok.example/b\u2013c');
+    // a dash is also a valid LEFT boundary: Maintenance\u2014https://… linkifies
+  });
+
+  it('P) a URL immediately after an em dash still linkifies', () => {
+    renderBanner({ banner_text: 'Maintenance\u2014https://ok.example/status tonight' });
+    expect(screen.getByRole('link')).toHaveAttribute('href', 'https://ok.example/status');
   });
 });

--- a/frontend/src/components/layout/__tests__/SiteBanner.test.tsx
+++ b/frontend/src/components/layout/__tests__/SiteBanner.test.tsx
@@ -133,4 +133,13 @@ describe('SiteBanner', () => {
     expect(links[0]).toHaveAttribute('href', 'https://ok.example/docs');
     expect(links[1]).toHaveAttribute('href', 'https://ok.example/alt');
   });
+
+  it('J) a bracket-wrapped URL sheds the wrapper; balanced brackets in the path survive', () => {
+    renderBanner({
+      banner_text: 'Docs: [https://ok.example/plain] and https://ok.example/item[3]',
+    });
+    const links = screen.getAllByRole('link');
+    expect(links[0]).toHaveAttribute('href', 'https://ok.example/plain');
+    expect(links[1]).toHaveAttribute('href', 'https://ok.example/item[3]');
+  });
 });

--- a/frontend/src/components/layout/__tests__/SiteBanner.test.tsx
+++ b/frontend/src/components/layout/__tests__/SiteBanner.test.tsx
@@ -169,4 +169,13 @@ describe('SiteBanner', () => {
     expect(links[0]).toHaveAttribute('href', 'HTTPS://ok.example/up');
     expect(links[1]).toHaveAttribute('href', 'https://en.wikipedia.org/wiki/Yahoo!');
   });
+
+  it('N) an https:// embedded inside another token does not linkify', () => {
+    renderBanner({
+      banner_text: 'nothttps://ok.example/a and http://proxy.example/https://ok.example/b stay plain, https://ok.example/c links',
+    });
+    const links = screen.getAllByRole('link');
+    expect(links).toHaveLength(1);
+    expect(links[0]).toHaveAttribute('href', 'https://ok.example/c');
+  });
 });

--- a/frontend/src/components/layout/__tests__/SiteBanner.test.tsx
+++ b/frontend/src/components/layout/__tests__/SiteBanner.test.tsx
@@ -178,4 +178,13 @@ describe('SiteBanner', () => {
     expect(links).toHaveLength(1);
     expect(links[0]).toHaveAttribute('href', 'https://ok.example/c');
   });
+
+  it('O) an em or en dash ends the URL; <URL> keeps one verbatim', () => {
+    renderBanner({
+      banner_text: 'See https://ok.example/a\u2014tonight and <https://ok.example/b\u2013c>',
+    });
+    const links = screen.getAllByRole('link');
+    expect(links[0]).toHaveAttribute('href', 'https://ok.example/a');
+    expect(links[1]).toHaveAttribute('href', 'https://ok.example/b\u2013c');
+  });
 });

--- a/frontend/src/components/layout/__tests__/SiteBanner.test.tsx
+++ b/frontend/src/components/layout/__tests__/SiteBanner.test.tsx
@@ -213,4 +213,11 @@ describe('SiteBanner', () => {
     expect(links[0]).toHaveAttribute('href', 'https://ok.example/open');
     expect(links[1]).toHaveAttribute('href', 'https://ok.example/next');
   });
+
+  it('S) a banner over the linkify length cap renders as plain text', () => {
+    const long = '<https://a.example/x\u2014'.repeat(200) + ' https://ok.example/tail';
+    renderBanner({ banner_text: long });
+    expect(screen.queryByRole('link')).toBeNull();
+    expect(screen.getByRole('status')).toHaveTextContent('https://ok.example/tail');
+  });
 });

--- a/frontend/src/components/layout/__tests__/SiteBanner.test.tsx
+++ b/frontend/src/components/layout/__tests__/SiteBanner.test.tsx
@@ -88,4 +88,29 @@ describe('SiteBanner', () => {
     renderBanner({ banner_text: 'New announcement' });
     expect(screen.getByRole('status')).toBeInTheDocument();
   });
+
+  it('F) https:// URLs in banner text render as anchors; the rest stays text', () => {
+    renderBanner({
+      banner_text: 'Release notes at https://buttondown.com/geolens. Enjoy!',
+    });
+    const link = screen.getByRole('link', { name: 'https://buttondown.com/geolens' });
+    expect(link).toHaveAttribute('href', 'https://buttondown.com/geolens');
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+    expect(link).toHaveAttribute('target', '_blank');
+    // trailing period stays outside the anchor; surrounding prose is plain text
+    expect(link.textContent).toBe('https://buttondown.com/geolens');
+    expect(screen.getByRole('status')).toHaveTextContent(
+      'Release notes at https://buttondown.com/geolens. Enjoy!',
+    );
+  });
+
+  it('G) markup in banner text is escaped, not rendered; http:// is not linkified', () => {
+    renderBanner({
+      banner_text: '<b>bold?</b> see http://plain.example and https://ok.example/x',
+    });
+    // the literal tag text is visible (escaped), no <b> element materializes
+    expect(screen.getByRole('status')).toHaveTextContent('<b>bold?</b>');
+    expect(screen.getAllByRole('link')).toHaveLength(1);
+    expect(screen.getByRole('link')).toHaveAttribute('href', 'https://ok.example/x');
+  });
 });

--- a/frontend/src/components/layout/__tests__/SiteBanner.test.tsx
+++ b/frontend/src/components/layout/__tests__/SiteBanner.test.tsx
@@ -113,4 +113,14 @@ describe('SiteBanner', () => {
     expect(screen.getAllByRole('link')).toHaveLength(1);
     expect(screen.getByRole('link')).toHaveAttribute('href', 'https://ok.example/x');
   });
+
+  it('H) a URL with balanced parens keeps its closing paren; excess stays punctuation', () => {
+    renderBanner({
+      banner_text: 'See https://en.wikipedia.org/wiki/Function_(mathematics). Also (https://ok.example/y).',
+    });
+    const links = screen.getAllByRole('link');
+    expect(links[0]).toHaveAttribute('href', 'https://en.wikipedia.org/wiki/Function_(mathematics)');
+    // parenthesized plain URL: the closing paren has no unmatched opener inside the URL
+    expect(links[1]).toHaveAttribute('href', 'https://ok.example/y');
+  });
 });

--- a/frontend/src/components/layout/__tests__/SiteBanner.test.tsx
+++ b/frontend/src/components/layout/__tests__/SiteBanner.test.tsx
@@ -142,4 +142,13 @@ describe('SiteBanner', () => {
     expect(links[0]).toHaveAttribute('href', 'https://ok.example/plain');
     expect(links[1]).toHaveAttribute('href', 'https://ok.example/item[3]');
   });
+
+  it('K) typographic punctuation stays out of the href', () => {
+    renderBanner({
+      banner_text: 'Read \u201Chttps://ok.example/docs\u201D or https://ok.example/more\u2026',
+    });
+    const links = screen.getAllByRole('link');
+    expect(links[0]).toHaveAttribute('href', 'https://ok.example/docs');
+    expect(links[1]).toHaveAttribute('href', 'https://ok.example/more');
+  });
 });

--- a/frontend/src/components/layout/__tests__/SiteBanner.test.tsx
+++ b/frontend/src/components/layout/__tests__/SiteBanner.test.tsx
@@ -193,4 +193,14 @@ describe('SiteBanner', () => {
     renderBanner({ banner_text: 'Maintenance\u2014https://ok.example/status tonight' });
     expect(screen.getByRole('link')).toHaveAttribute('href', 'https://ok.example/status');
   });
+
+  it('Q) a scheme inside a consumed <…> span does not produce a second link', () => {
+    renderBanner({
+      banner_text: 'See <https://a.example/x\u2014https://b.example/y> now',
+    });
+    const links = screen.getAllByRole('link');
+    expect(links).toHaveLength(1);
+    expect(links[0]).toHaveAttribute('href', 'https://a.example/x\u2014https://b.example/y');
+    expect(screen.getByRole('status')).toHaveTextContent('now');
+  });
 });

--- a/frontend/src/components/layout/__tests__/SiteBanner.test.tsx
+++ b/frontend/src/components/layout/__tests__/SiteBanner.test.tsx
@@ -203,4 +203,14 @@ describe('SiteBanner', () => {
     expect(links[0]).toHaveAttribute('href', 'https://a.example/x\u2014https://b.example/y');
     expect(screen.getByRole('status')).toHaveTextContent('now');
   });
+
+  it('R) an unclosed < falls back to normal linkify without scanning ahead', () => {
+    renderBanner({
+      banner_text: '<https://ok.example/open and later https://ok.example/next',
+    });
+    const links = screen.getAllByRole('link');
+    expect(links).toHaveLength(2);
+    expect(links[0]).toHaveAttribute('href', 'https://ok.example/open');
+    expect(links[1]).toHaveAttribute('href', 'https://ok.example/next');
+  });
 });

--- a/frontend/src/components/layout/__tests__/SiteBanner.test.tsx
+++ b/frontend/src/components/layout/__tests__/SiteBanner.test.tsx
@@ -123,4 +123,14 @@ describe('SiteBanner', () => {
     // parenthesized plain URL: the closing paren has no unmatched opener inside the URL
     expect(links[1]).toHaveAttribute('href', 'https://ok.example/y');
   });
+
+  it('I) URLs wrapped in quotes or angle brackets still linkify', () => {
+    renderBanner({
+      banner_text: 'Read "https://ok.example/docs" or <https://ok.example/alt>',
+    });
+    const links = screen.getAllByRole('link');
+    expect(links).toHaveLength(2);
+    expect(links[0]).toHaveAttribute('href', 'https://ok.example/docs');
+    expect(links[1]).toHaveAttribute('href', 'https://ok.example/alt');
+  });
 });


### PR DESCRIPTION
The admin announcement banner (SiteBanner.tsx) rendered banner_text as plain escaped text, so a URL in it displayed but couldn't be clicked. Matched https:// URLs now render as anchors (target=_blank, rel=noopener noreferrer, trailing sentence punctuation kept outside the link); all other text remains React-escaped, so the banner still can't carry injected markup. No new setting, no API/schema change.

Verification: SiteBanner suite 7/7 (2 new cases: linkify + escaping/no-http), eslint clean, typecheck clean. Counterfactual: with the component change reverted and tests kept, exactly the 2 new tests fail.