### PR TITLE
feat(report): surface the problem reporter to anonymous visitors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,14 @@ and releases use semantic versioning.
 
 ### Changed
 
+- **Anonymous visitors can report problems too.** The in-app problem reporter
+  (error-triggered floating button + wizard) was gated to signed-in users, but
+  error capture already runs for everyone and the report itself is a prefilled
+  GitHub issue that needs no GeoLens session. On a public instance most
+  traffic browses anonymously, so a visitor who hit a broken map had no way to
+  say so. The gate is removed; the button still appears only after an error is
+  captured.
+
 - **An upload that was never started is now `cancelled`, not `failed`.** Ask
   for a presigned upload URL and walk away, and the job row sat `pending` until
   the stale sweep marked it failed with "pending too long (never queued)" — a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,8 +25,6 @@ and releases use semantic versioning.
   invisible, because its row started expanded by state even though
   upload-failed rows have no expand panel to show.
 
-## [1.15.1] - 2026-08-24
-
 ### Changed
 
 - **Anonymous visitors can report problems too.** The in-app problem reporter
@@ -36,6 +34,10 @@ and releases use semantic versioning.
   traffic browses anonymously, so a visitor who hit a broken map had no way to
   say so. The gate is removed; the button still appears only after an error is
   captured.
+
+## [1.15.1] - 2026-08-24
+
+### Changed
 
 - **An upload that was never started is now `cancelled`, not `failed`.** Ask
   for a presigned upload URL and walk away, and the job row sat `pending` until

--- a/frontend/src/components/report/ReportProblemHost.tsx
+++ b/frontend/src/components/report/ReportProblemHost.tsx
@@ -1,6 +1,5 @@
 import { useTranslation } from 'react-i18next';
 import { LifeBuoy } from 'lucide-react';
-import { useAuthStore } from '@/stores/auth-store';
 import { countDistinctFailures, useReportDialog, useReportEntries } from '@/lib/report';
 import { cn } from '@/lib/utils';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
@@ -13,17 +12,19 @@ import { ReportProblemWizard } from './ReportProblemWizard';
  *   - a floating button that appears ONLY once errors are captured, surfacing a
  *     count badge so a user notices a problem the moment it happens.
  *
- * Gated to authenticated users. Capture runs app-wide via initReportCapture()
- * (main.tsx); this only owns the affordance + wizard.
+ * Available to everyone, signed in or not. Capture runs app-wide via
+ * initReportCapture() (main.tsx); this only owns the affordance + wizard.
+ * Anonymous visitors matter here: on a public instance most traffic browses
+ * without an account, the floating button only appears once an error is
+ * captured, and the wizard's output is a prefilled GitHub issue — nothing
+ * about it needs a GeoLens session. (Originally auth-gated; relaxed so an
+ * anonymous visitor who hits a broken map can still tell someone.)
  */
 export function ReportProblemHost() {
-  const token = useAuthStore((s) => s.token);
   const entries = useReportEntries();
   const { t } = useTranslation('report');
   const open = useReportDialog((s) => s.open);
   const setOpen = useReportDialog((s) => s.setOpen);
-
-  if (!token) return null;
 
   // fix(#908): distinct failures, not rows — one unrecovered map error writes
   // both a `maplibre` row and a `console` row, and the badge used to read "2".

--- a/frontend/src/components/report/__tests__/ReportProblemHost.test.tsx
+++ b/frontend/src/components/report/__tests__/ReportProblemHost.test.tsx
@@ -15,9 +15,15 @@ beforeEach(() => {
 });
 
 describe('ReportProblemHost', () => {
-  it('renders nothing for unauthenticated users', () => {
+  it('shows no floating button for an anonymous visitor with no errors', () => {
     render(<ReportProblemHost />);
     expect(screen.queryByRole('button', { name: /report a problem/i })).toBeNull();
+  });
+
+  it('surfaces the floating button to an anonymous visitor once an error is captured', async () => {
+    render(<ReportProblemHost />);
+    pushReportEntry({ severity: 'error', source: 'console', message: 'anon-visible failure' });
+    expect(await screen.findByRole('button', { name: /report a problem/i })).toBeInTheDocument();
   });
 
   it('shows no floating button when authenticated and idle (no errors)', () => {

--- a/frontend/src/lib/__tests__/auth-cache-reset.test.ts
+++ b/frontend/src/lib/__tests__/auth-cache-reset.test.ts
@@ -1,6 +1,7 @@
 import { QueryClient } from '@tanstack/react-query';
 import { wireAuthCacheReset } from '../auth-cache-reset';
 import { useAuthStore } from '@/stores/auth-store';
+import { getReportEntries, pushReportEntry } from '@/lib/report';
 import type { UserResponse } from '@/types/api';
 
 // fix(#430 codex r6): identity changes evict the whole query cache; token
@@ -39,6 +40,27 @@ describe('wireAuthCacheReset', () => {
       seed(qc);
       useAuthStore.setState({ token: null, user: null });
       expect(qc.getQueryData(['search', 'maps', 'matterhorn'])).toBeUndefined();
+    } finally {
+      unsubscribe();
+    }
+  });
+
+  it('clears the problem-report capture buffer when identity changes, not on refresh', () => {
+    const qc = new QueryClient();
+    const unsubscribe = wireAuthCacheReset(qc);
+    try {
+      useAuthStore.setState({ token: 't1', user: { id: 'user-1' } as UserResponse });
+      pushReportEntry({ severity: 'error', source: 'console', message: 'user-1 residue' });
+      expect(getReportEntries()).toHaveLength(1);
+
+      // Token refresh (same identity): buffer kept.
+      useAuthStore.setState({ token: 't2' });
+      expect(getReportEntries()).toHaveLength(1);
+
+      // Logout: buffer cleared — an anonymous tab must not inherit the
+      // previous user's captured entries (fix(#1663 review P1)).
+      useAuthStore.setState({ token: null, user: null });
+      expect(getReportEntries()).toHaveLength(0);
     } finally {
       unsubscribe();
     }

--- a/frontend/src/lib/auth-cache-reset.ts
+++ b/frontend/src/lib/auth-cache-reset.ts
@@ -1,5 +1,6 @@
 import type { QueryClient } from '@tanstack/react-query';
 import { useAuthStore } from '@/stores/auth-store';
+import { clearReportEntries } from '@/lib/report';
 
 /**
  * fix(#430 codex r6): user-scoped queries (dataset search, map search, map
@@ -23,5 +24,12 @@ export function wireAuthCacheReset(queryClient: QueryClient): () => void {
     // is error-prone (a missed key leaks the prior user's data); revisit only if
     // the refetch burst is measured to matter.
     queryClient.clear();
+    // fix(#1663 review P1): the problem reporter's in-memory capture buffer is
+    // the same kind of identity-scoped residue. With the reporter visible to
+    // anonymous visitors, a logout that leaves the buffer populated would show
+    // the previous user's captured entries (and attach them to a report) in
+    // the now-anonymous tab. Same choke point, same rule: identity changed,
+    // drop everything captured under the old one.
+    clearReportEntries();
   });
 }


### PR DESCRIPTION
ReportProblemHost returned null without an auth token, so anonymous visitors — most of a public instance's traffic — never saw the error-triggered floating button even though capture runs app-wide and the wizard's output (a prefilled GitHub issue URL) requires no GeoLens session. The gate is removed; behavior is otherwise unchanged (button only appears once a distinct failure is captured; the user-menu entry point remains signed-in-only because anonymous visitors have no user menu).

Verification: report suite 12/12 (host tests rewritten: anon+idle shows nothing, anon+error surfaces the button), eslint + typecheck clean. Counterfactual: with the component reverted and tests kept, exactly the new anon-error test fails (1 failed / 6 passed).