### PR TITLE
fix(ingest): translate raster open-failure into a friendly message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,21 @@ and releases use semantic versioning.
   say so. The gate is removed; the button still appears only after an error is
   captured.
 
+### Fixed
+
+- **A raster open-failure error no longer echoes the internal staging path.**
+  Deferred from #1640, which fixed the vector side: when a corrupt or
+  unopenable raster upload reached `rasterio.open`, `IngestJob.error_message`
+  carried GDAL's raw one-liner verbatim — `'<path>' not recognized as being
+  in a supported file format.` — leaking the internal
+  `/app/staging/<uuid>_...` path instead of the original upload filename.
+  That shape is now pattern-matched and replaced with a short message built
+  from the upload's original filename (e.g. `Could not open 'survey.tif' as
+  a raster dataset — the file may be corrupt, incomplete, or not a valid
+  GeoTIFF (.tif) file.`); the full rasterio message still reaches structured
+  logs at error level, and every other rasterio/GDAL failure keeps its real
+  message unchanged.
+
 ## [1.15.1] - 2026-08-24
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,15 +40,17 @@ and releases use semantic versioning.
 - **A raster open-failure error no longer echoes the internal staging path.**
   Deferred from #1640, which fixed the vector side: when a corrupt or
   unopenable raster upload reached `rasterio.open`, `IngestJob.error_message`
-  carried GDAL's raw one-liner verbatim — `'<path>' not recognized as being
-  in a supported file format.` — leaking the internal
+  carried the raw rasterio message verbatim — e.g. `'<path>' not recognized
+  as being in a supported file format.` — leaking the internal
   `/app/staging/<uuid>_...` path instead of the original upload filename.
-  That shape is now pattern-matched and replaced with a short message built
-  from the upload's original filename (e.g. `Could not open 'survey.tif' as
-  a raster dataset — the file may be corrupt, incomplete, or not a valid
-  GeoTIFF (.tif) file.`); the full rasterio message still reaches structured
-  logs at error level, and every other rasterio/GDAL failure keeps its real
-  message unchanged.
+  Any `RasterioIOError` raised by that open call (unrecognized format,
+  corrupt/truncated IFD, missing file, ...) is now replaced with a short
+  message built from the upload's original filename instead (e.g. `Could not
+  open 'survey.tif' as a raster dataset — the file may be corrupt,
+  incomplete, or not a valid GeoTIFF (.tif) file.`); the full rasterio
+  message still reaches structured logs at error level, and a failure raised
+  by anything other than the open call itself keeps its real message
+  unchanged.
 
 ## [1.15.1] - 2026-08-24
 

--- a/backend/app/processing/ingest/tasks_raster.py
+++ b/backend/app/processing/ingest/tasks_raster.py
@@ -39,6 +39,7 @@ from app.processing.ingest.tasks_raster_common import (
     _reject_raw_vrt_job,
     _resolve_managed_raster_storage_keys,
     create_raster_dataset,
+    extract_source_raster_metadata,
 )
 from app.processing.ingest.tasks_common import (
     _bind_task_log_context,
@@ -245,7 +246,14 @@ async def ingest_raster(
         # 5. Extract metadata from the SOURCE. Only two things come from this
         # read now (fix(#1290 review)): whether a CRS assignment is needed, and
         # `original_srid`. Everything the catalog stores describes the COG.
-        source_meta = await asyncio.to_thread(extract_raster_metadata, file_path)
+        # fix(#1661): extract_source_raster_metadata (not extract_raster_metadata
+        # directly) so an unopenable upload raises a friendly message built from
+        # `source_filename` instead of leaking the staging path in `file_path`.
+        source_meta = await asyncio.to_thread(
+            extract_source_raster_metadata,
+            file_path,
+            original_filename=source_filename,
+        )
 
         # Read GDAL options from user_metadata (set at commit time)
         assign_crs = um.get("srid_override")

--- a/backend/app/processing/ingest/tasks_raster_common.py
+++ b/backend/app/processing/ingest/tasks_raster_common.py
@@ -12,6 +12,8 @@ module, which is the kind of reach-across that makes a later split harder than
 it needs to be. They have one home now.
 """
 
+import os
+import re
 import uuid
 from datetime import datetime, timezone
 from typing import Any
@@ -19,8 +21,87 @@ from typing import Any
 import structlog
 
 from app.platform.dataset_origin import set_dataset_origin
-from app.processing.raster.cog import check_cog_compliance
+from app.processing.raster.cog import check_cog_compliance, extract_raster_metadata
 from app.platform.storage.titiler_url import resolve_current_storage_key
+
+
+# fix(#1661): mirrors ogr.py's vector-side #1640 fix. GDAL/rasterio print this
+# exact one-liner when NO driver recognizes the source at all — no driver
+# enumeration (unlike the vector "Unable to open datasource ... with the
+# following drivers." case), but it still echoes the internal staging path
+# (``'/app/staging/<uuid>_...' not recognized...``) verbatim. Anchored to the
+# literal GDAL phrasing so no other rasterio.open failure (permission denied,
+# disk full, unsupported band count, ...) matches.
+_RASTER_NOT_RECOGNIZED_RE = re.compile(
+    r"not recognized as being in a supported file format\."
+)
+
+# Human-readable label per uploaded extension, used only to phrase the
+# friendly "could not open" message below.
+_RASTER_FORMAT_LABELS: dict[str, str] = {
+    ".tif": "GeoTIFF (.tif)",
+    ".tiff": "GeoTIFF (.tiff)",
+    ".vrt": "VRT (.vrt)",
+}
+
+
+def _is_unopenable_raster_stderr(message: str) -> bool:
+    """True when a rasterio error message matches GDAL's "no driver" shape."""
+    return bool(_RASTER_NOT_RECOGNIZED_RE.search(message))
+
+
+def _friendly_raster_open_failure_message(original_filename: "str | None") -> str:
+    """User-facing text for a rasterio "not recognized" open failure.
+
+    Deliberately built from ``original_filename`` alone — never from the
+    staging path or the raw rasterio message — so the message can never leak
+    the `/app/staging/<uuid>_...` path GDAL echoes back on this failure class.
+    """
+    name = os.path.basename(original_filename) if original_filename else None
+    suffix = os.path.splitext(name)[1].lower() if name else ""
+    format_label = _RASTER_FORMAT_LABELS.get(suffix, "raster")
+    if name:
+        return (
+            f"Could not open '{name}' as a raster dataset — the file may be "
+            f"corrupt, incomplete, or not a valid {format_label} file."
+        )
+    return (
+        "Could not open the uploaded file as a raster dataset — it may be "
+        "corrupt, incomplete, or not a valid raster file."
+    )
+
+
+def extract_source_raster_metadata(
+    file_path: str, *, original_filename: "str | None" = None
+) -> dict:
+    """``extract_raster_metadata``, translating an unrecognized-format failure.
+
+    fix(#1661): both raster ingest tails (``ingest_raster``, the replace tail)
+    call this on the freshly-staged SOURCE upload, where ``rasterio.open``
+    raising the "not recognized as being in a supported file format" shape
+    used to land the raw message — including the internal staging path — in
+    ``IngestJob.error_message`` verbatim. The full rasterio message still
+    reaches structured logs at error level here, the one place that sees it;
+    every other rasterio/GDAL failure (corrupt-but-recognized TIFF, permission
+    error, ...) keeps its real message unchanged. Callers reading their own
+    just-produced COG (no upload filename to leak) don't need this wrapper.
+    """
+    import rasterio
+
+    try:
+        return extract_raster_metadata(file_path)
+    except rasterio.errors.RasterioIOError as exc:
+        message = str(exc)
+        if not _is_unopenable_raster_stderr(message):
+            raise
+        structlog.get_logger().error(
+            "rasterio could not open raster source",
+            error=message,
+            original_filename=original_filename,
+        )
+        raise ValueError(
+            _friendly_raster_open_failure_message(original_filename)
+        ) from exc
 
 
 def _is_manifest_vrt_job(job: Any) -> bool:

--- a/backend/app/processing/ingest/tasks_raster_common.py
+++ b/backend/app/processing/ingest/tasks_raster_common.py
@@ -13,7 +13,6 @@ it needs to be. They have one home now.
 """
 
 import os
-import re
 import uuid
 from datetime import datetime, timezone
 from typing import Any
@@ -25,17 +24,6 @@ from app.processing.raster.cog import check_cog_compliance, extract_raster_metad
 from app.platform.storage.titiler_url import resolve_current_storage_key
 
 
-# fix(#1661): mirrors ogr.py's vector-side #1640 fix. GDAL/rasterio print this
-# exact one-liner when NO driver recognizes the source at all — no driver
-# enumeration (unlike the vector "Unable to open datasource ... with the
-# following drivers." case), but it still echoes the internal staging path
-# (``'/app/staging/<uuid>_...' not recognized...``) verbatim. Anchored to the
-# literal GDAL phrasing so no other rasterio.open failure (permission denied,
-# disk full, unsupported band count, ...) matches.
-_RASTER_NOT_RECOGNIZED_RE = re.compile(
-    r"not recognized as being in a supported file format\."
-)
-
 # Human-readable label per uploaded extension, used only to phrase the
 # friendly "could not open" message below.
 _RASTER_FORMAT_LABELS: dict[str, str] = {
@@ -45,17 +33,15 @@ _RASTER_FORMAT_LABELS: dict[str, str] = {
 }
 
 
-def _is_unopenable_raster_stderr(message: str) -> bool:
-    """True when a rasterio error message matches GDAL's "no driver" shape."""
-    return bool(_RASTER_NOT_RECOGNIZED_RE.search(message))
-
-
 def _friendly_raster_open_failure_message(original_filename: "str | None") -> str:
-    """User-facing text for a rasterio "not recognized" open failure.
+    """User-facing text for a raster source ``rasterio.open`` open-time failure.
 
     Deliberately built from ``original_filename`` alone — never from the
     staging path or the raw rasterio message — so the message can never leak
-    the `/app/staging/<uuid>_...` path GDAL echoes back on this failure class.
+    the `/app/staging/<uuid>_...` path rasterio/GDAL echo back on any
+    open-time failure (unrecognized format, corrupt/truncated IFD, missing
+    file, permission error — all read, from the person who uploaded the
+    file, as the same thing: "GeoLens could not open this as a raster").
     """
     name = os.path.basename(original_filename) if original_filename else None
     suffix = os.path.splitext(name)[1].lower() if name else ""
@@ -74,17 +60,27 @@ def _friendly_raster_open_failure_message(original_filename: "str | None") -> st
 def extract_source_raster_metadata(
     file_path: str, *, original_filename: "str | None" = None
 ) -> dict:
-    """``extract_raster_metadata``, translating an unrecognized-format failure.
+    """``extract_raster_metadata``, translating an open-time rasterio failure.
 
     fix(#1661): both raster ingest tails (``ingest_raster``, the replace tail)
-    call this on the freshly-staged SOURCE upload, where ``rasterio.open``
-    raising the "not recognized as being in a supported file format" shape
-    used to land the raw message — including the internal staging path — in
-    ``IngestJob.error_message`` verbatim. The full rasterio message still
-    reaches structured logs at error level here, the one place that sees it;
-    every other rasterio/GDAL failure (corrupt-but-recognized TIFF, permission
-    error, ...) keeps its real message unchanged. Callers reading their own
-    just-produced COG (no upload filename to leak) don't need this wrapper.
+    call this on the freshly-staged SOURCE upload. ``extract_raster_metadata``
+    opens that file with a single ``rasterio.open`` call and reads everything
+    else off the resulting dataset, so ANY ``RasterioIOError`` it raises is by
+    definition "rasterio could not open this file" — the class GDAL raises
+    for an unrecognized format, a corrupt/truncated IFD, a missing file, or a
+    permission error alike (codex review on #1661 round 1: a narrower pattern
+    match on just the "not recognized as being in a supported file format"
+    text missed the corrupt-IFD shape, which ALSO quotes the staging path and
+    is equally production-reachable — a .tif with a valid magic header but a
+    corrupt IFD passes upload-time content-sniffing same as any other .tif).
+    That used to land the raw rasterio message — including the internal
+    staging path — in ``IngestJob.error_message`` verbatim. The full rasterio
+    message still reaches structured logs at error level here, the one place
+    that sees it; a failure raised by anything OTHER than the open call
+    itself (e.g. malformed EXIF/tag parsing further down in
+    ``extract_raster_metadata``) is not a ``RasterioIOError`` and keeps its
+    real message unchanged. Callers reading their own just-produced COG (no
+    upload filename to leak) don't need this wrapper.
     """
     import rasterio
 
@@ -92,8 +88,6 @@ def extract_source_raster_metadata(
         return extract_raster_metadata(file_path)
     except rasterio.errors.RasterioIOError as exc:
         message = str(exc)
-        if not _is_unopenable_raster_stderr(message):
-            raise
         structlog.get_logger().error(
             "rasterio could not open raster source",
             error=message,

--- a/backend/app/processing/ingest/tasks_raster_replace.py
+++ b/backend/app/processing/ingest/tasks_raster_replace.py
@@ -72,6 +72,7 @@ from app.processing.ingest.tasks_raster_common import (
     _cleanup_orphaned_storage_keys,
     _enforce_strict_cog,
     _resolve_managed_raster_storage_keys,
+    extract_source_raster_metadata,
 )
 from app.processing.ingest.tasks_raster_swap import (
     _prior_asset_keys_to_reap,
@@ -395,7 +396,14 @@ async def reupload_raster(
         # conversion needs a CRS assignment. Nothing here is persisted —
         # fix(#1290 review) moved every stored field onto the converted COG's
         # own metadata, which is the file the dataset will actually serve.
-        source_meta = await asyncio.to_thread(extract_raster_metadata, file_path)
+        # fix(#1661): extract_source_raster_metadata (not extract_raster_metadata
+        # directly) so an unopenable upload raises a friendly message built from
+        # `source_filename` instead of leaking the staging path in `file_path`.
+        source_meta = await asyncio.to_thread(
+            extract_source_raster_metadata,
+            file_path,
+            original_filename=source_filename,
+        )
 
         user_compression = um.get("compression") or "DEFLATE"
         user_resampling = um.get("resampling") or None

--- a/backend/tests/test_ingest_raster_open_failure_message.py
+++ b/backend/tests/test_ingest_raster_open_failure_message.py
@@ -1,0 +1,185 @@
+"""Coverage for the raster-side "unable to open source" friendly-message fix.
+
+Deferred from #1640 (which fixed the VECTOR side): for a corrupt/unopenable
+uploaded raster, ``rasterio.open`` (via ``extract_raster_metadata``) raises
+``RasterioIOError`` with GDAL's one-liner ``'<path>' not recognized as being
+in a supported file format.`` — no driver enumeration (far less noisy than
+the vector case), but it still echoes the internal ``/app/staging/<uuid>_...``
+path instead of the original upload filename, and that raw message used to
+land verbatim in ``IngestJob.error_message``.
+
+Mirrors ``test_ingest_ogr_pure.py`` (pure pattern/message-builder unit tests)
+and ``test_ingest_open_failure_message.py`` (real-binaries end-to-end
+coverage) for the vector fix. The raster class has only ONE known stderr
+shape (empirically confirmed: plain unrecognized bytes, GDAL never gets far
+enough to enumerate drivers for a genuinely-unrecognized raster the way it
+does for a claimed-but-corrupt vector source), so there is only one pattern
+here rather than three.
+"""
+
+import os
+
+import pytest
+import structlog
+
+from app.processing.ingest.tasks_raster_common import (
+    _friendly_raster_open_failure_message,
+    _is_unopenable_raster_stderr,
+    extract_source_raster_metadata,
+)
+
+
+class TestIsUnopenableRasterStderr:
+    def test_matches_not_recognized_message(self):
+        """Empirically reproduced (GDAL/rasterio on this host): plain
+        unrecognized bytes given a .tif name produce exactly this
+        RasterioIOError text, quoting the path GDAL was asked to open."""
+        stderr = "'/app/staging/9f2c1a3e-uuid_survey.tif' not recognized as being in a supported file format."
+        assert _is_unopenable_raster_stderr(stderr) is True
+
+    def test_matches_message_without_quoted_path(self):
+        """The pattern anchors on the trailing phrase only, not the quoting —
+        some rasterio/GDAL builds omit the leading quoted path entirely."""
+        stderr = "not recognized as being in a supported file format."
+        assert _is_unopenable_raster_stderr(stderr) is True
+
+    def test_does_not_match_unrelated_rasterio_failure(self):
+        """Narrow anchoring: a real, different rasterio/GDAL failure (a TIFF
+        whose magic header is intact but whose IFD is corrupt) must NOT be
+        caught by this pattern — that message keeps its real stderr."""
+        stderr = "survey.tif: TIFFReadDirectory:Failed to read directory at offset 1907891221"
+        assert _is_unopenable_raster_stderr(stderr) is False
+
+    def test_does_not_match_permission_denied(self):
+        stderr = "Permission denied"
+        assert _is_unopenable_raster_stderr(stderr) is False
+
+    def test_empty_string_does_not_match(self):
+        assert _is_unopenable_raster_stderr("") is False
+
+
+class TestFriendlyRasterOpenFailureMessage:
+    """The user-facing replacement text — built only from the original
+    upload filename, never from the staging path or the raw rasterio
+    message."""
+
+    def test_tif_extension_names_geotiff(self):
+        msg = _friendly_raster_open_failure_message("survey.tif")
+        assert msg == (
+            "Could not open 'survey.tif' as a raster dataset — the file may "
+            "be corrupt, incomplete, or not a valid GeoTIFF (.tif) file."
+        )
+
+    def test_tiff_extension_names_geotiff(self):
+        msg = _friendly_raster_open_failure_message("survey.tiff")
+        assert "GeoTIFF (.tiff)" in msg
+        assert "survey.tiff" in msg
+
+    def test_unknown_extension_falls_back_to_generic_phrasing(self):
+        msg = _friendly_raster_open_failure_message("data.mysteryformat")
+        assert "data.mysteryformat" in msg
+        assert "not a valid raster file" in msg
+
+    def test_no_filename_uses_fully_generic_message(self):
+        msg = _friendly_raster_open_failure_message(None)
+        assert msg == (
+            "Could not open the uploaded file as a raster dataset — it may "
+            "be corrupt, incomplete, or not a valid raster file."
+        )
+
+    def test_staging_path_never_appears_in_message(self):
+        """The staging path GDAL echoes in its own rasterio message must
+        never reach this message — only the original upload filename does."""
+        msg = _friendly_raster_open_failure_message("survey.tif")
+        assert "/app/staging" not in msg
+        assert "staging" not in msg
+
+    def test_directory_component_stripped_even_if_passed(self):
+        """Defensive: even if a caller passed a path instead of a bare
+        filename, only the leaf name is shown — never the directories."""
+        msg = _friendly_raster_open_failure_message("/app/staging/9f2c_survey.tif")
+        assert "survey.tif" in msg
+        assert "/app/staging" not in msg
+
+
+class TestExtractSourceRasterMetadataFriendlyOpenFailure:
+    """Real-binaries coverage against the actual rasterio/GDAL install.
+
+    Plain garbage bytes with a ``.tif`` name reproduce GDAL's "no driver
+    recognizes this at all" shape (confirmed live on this host: a valid TIFF
+    magic prefix instead makes the GTiff driver claim the source and fail
+    with a DIFFERENT, more specific error — "TIFFReadDirectory:Failed to
+    read directory..." — which is exactly the unrelated-failure case
+    ``test_does_not_match_unrelated_rasterio_failure`` above pins). The
+    upload-time content-sniffer (``validate_file_content``) would reject
+    magic-less bytes before they ever reach this function in production —
+    same as the vector fix's "no driver at all" fixture — but that gate is a
+    separate, already-tested layer; this test exercises
+    ``extract_source_raster_metadata`` directly, the one place that
+    translates whatever rasterio raises.
+    """
+
+    def _write_unrecognized_raster(self, tmp_path) -> str:
+        path = tmp_path / "9f2c1a3e-uuid_survey.tif"
+        path.write_bytes(os.urandom(500))
+        return str(path)
+
+    def test_unrecognized_source_raises_friendly_message(self, tmp_path):
+        source = self._write_unrecognized_raster(tmp_path)
+        with pytest.raises(ValueError) as exc_info:
+            extract_source_raster_metadata(source, original_filename="survey.tif")
+        message = str(exc_info.value)
+        assert message == (
+            "Could not open 'survey.tif' as a raster dataset — the file may "
+            "be corrupt, incomplete, or not a valid GeoTIFF (.tif) file."
+        )
+        assert str(tmp_path) not in message
+        assert source not in message
+
+    def test_full_message_still_reaches_structured_logs(self, tmp_path):
+        """The diagnostic is not lost — it moves to the log, not nowhere."""
+        source = self._write_unrecognized_raster(tmp_path)
+        with structlog.testing.capture_logs() as captured:
+            with pytest.raises(ValueError):
+                extract_source_raster_metadata(source, original_filename="survey.tif")
+
+        error_events = [e for e in captured if e.get("log_level") == "error"]
+        assert error_events, [e for e in captured]
+        logged = error_events[0]
+        assert "not recognized as being in a supported file format" in logged["error"]
+        # The staging path DOES appear in the logged raw message (that's the
+        # point — full diagnostics for us) even though it never reaches the
+        # user-facing message asserted above.
+        assert source in logged["error"]
+        assert logged["original_filename"] == "survey.tif"
+
+    def test_no_original_filename_uses_generic_message(self, tmp_path):
+        source = self._write_unrecognized_raster(tmp_path)
+        with pytest.raises(ValueError) as exc_info:
+            extract_source_raster_metadata(source, original_filename=None)
+        message = str(exc_info.value)
+        assert message == (
+            "Could not open the uploaded file as a raster dataset — it may "
+            "be corrupt, incomplete, or not a valid raster file."
+        )
+        assert source not in message
+
+    def test_unrelated_rasterio_failure_keeps_real_message(self, tmp_path):
+        """A TIFF with a valid magic header but a corrupt IFD is a
+        DIFFERENT rasterio failure shape from the "not recognized" class —
+        it must propagate the real rasterio message unchanged, not the
+        friendly one, so a genuinely different problem doesn't get
+        misdiagnosed as "wrong format"."""
+        path = tmp_path / "9f2c1a3e-uuid_survey.tif"
+        # Valid little-endian TIFF magic ("II*\x00") followed by garbage —
+        # the GTiff driver claims the source by magic, then fails reading
+        # the IFD, which is a distinct rasterio error from the
+        # "not recognized" class this fix targets.
+        path.write_bytes(b"II*\x00" + os.urandom(500))
+        source = str(path)
+
+        with pytest.raises(Exception) as exc_info:
+            extract_source_raster_metadata(source, original_filename="survey.tif")
+        message = str(exc_info.value)
+        assert "Could not open" not in message
+        assert "raster dataset" not in message

--- a/backend/tests/test_ingest_raster_open_failure_message.py
+++ b/backend/tests/test_ingest_raster_open_failure_message.py
@@ -2,19 +2,22 @@
 
 Deferred from #1640 (which fixed the VECTOR side): for a corrupt/unopenable
 uploaded raster, ``rasterio.open`` (via ``extract_raster_metadata``) raises
-``RasterioIOError`` with GDAL's one-liner ``'<path>' not recognized as being
-in a supported file format.`` — no driver enumeration (far less noisy than
-the vector case), but it still echoes the internal ``/app/staging/<uuid>_...``
-path instead of the original upload filename, and that raw message used to
-land verbatim in ``IngestJob.error_message``.
+``RasterioIOError``, and its message — whatever shape it takes — used to land
+verbatim in ``IngestJob.error_message``, echoing the internal
+``/app/staging/<uuid>_...`` path instead of the original upload filename.
 
-Mirrors ``test_ingest_ogr_pure.py`` (pure pattern/message-builder unit tests)
-and ``test_ingest_open_failure_message.py`` (real-binaries end-to-end
-coverage) for the vector fix. The raster class has only ONE known stderr
-shape (empirically confirmed: plain unrecognized bytes, GDAL never gets far
-enough to enumerate drivers for a genuinely-unrecognized raster the way it
-does for a claimed-but-corrupt vector source), so there is only one pattern
-here rather than three.
+Mirrors ``test_ingest_ogr_pure.py`` (pure message-builder unit tests) and
+``test_ingest_open_failure_message.py`` (real-binaries end-to-end coverage)
+for the vector fix. Unlike the vector side, the raster boundary is NOT a
+pattern match on specific stderr text: ``extract_raster_metadata`` opens the
+source with exactly one ``rasterio.open`` call and reads everything else off
+the resulting dataset, so ANY ``RasterioIOError`` it raises is by definition
+an open-time "could not read this file" failure (codex review on #1661
+round 1: an earlier version of this fix pattern-matched only the "not
+recognized as being in a supported file format" text and missed a real,
+production-reachable shape — a .tif with a valid TIFF magic header but a
+corrupt/truncated IFD, which passes upload-time content-sniffing the same as
+any other .tif and ALSO quotes the staging path in its rasterio message).
 """
 
 import os
@@ -24,38 +27,8 @@ import structlog
 
 from app.processing.ingest.tasks_raster_common import (
     _friendly_raster_open_failure_message,
-    _is_unopenable_raster_stderr,
     extract_source_raster_metadata,
 )
-
-
-class TestIsUnopenableRasterStderr:
-    def test_matches_not_recognized_message(self):
-        """Empirically reproduced (GDAL/rasterio on this host): plain
-        unrecognized bytes given a .tif name produce exactly this
-        RasterioIOError text, quoting the path GDAL was asked to open."""
-        stderr = "'/app/staging/9f2c1a3e-uuid_survey.tif' not recognized as being in a supported file format."
-        assert _is_unopenable_raster_stderr(stderr) is True
-
-    def test_matches_message_without_quoted_path(self):
-        """The pattern anchors on the trailing phrase only, not the quoting —
-        some rasterio/GDAL builds omit the leading quoted path entirely."""
-        stderr = "not recognized as being in a supported file format."
-        assert _is_unopenable_raster_stderr(stderr) is True
-
-    def test_does_not_match_unrelated_rasterio_failure(self):
-        """Narrow anchoring: a real, different rasterio/GDAL failure (a TIFF
-        whose magic header is intact but whose IFD is corrupt) must NOT be
-        caught by this pattern — that message keeps its real stderr."""
-        stderr = "survey.tif: TIFFReadDirectory:Failed to read directory at offset 1907891221"
-        assert _is_unopenable_raster_stderr(stderr) is False
-
-    def test_does_not_match_permission_denied(self):
-        stderr = "Permission denied"
-        assert _is_unopenable_raster_stderr(stderr) is False
-
-    def test_empty_string_does_not_match(self):
-        assert _is_unopenable_raster_stderr("") is False
 
 
 class TestFriendlyRasterOpenFailureMessage:
@@ -105,27 +78,54 @@ class TestFriendlyRasterOpenFailureMessage:
 class TestExtractSourceRasterMetadataFriendlyOpenFailure:
     """Real-binaries coverage against the actual rasterio/GDAL install.
 
-    Plain garbage bytes with a ``.tif`` name reproduce GDAL's "no driver
-    recognizes this at all" shape (confirmed live on this host: a valid TIFF
-    magic prefix instead makes the GTiff driver claim the source and fail
-    with a DIFFERENT, more specific error — "TIFFReadDirectory:Failed to
-    read directory..." — which is exactly the unrelated-failure case
-    ``test_does_not_match_unrelated_rasterio_failure`` above pins). The
-    upload-time content-sniffer (``validate_file_content``) would reject
-    magic-less bytes before they ever reach this function in production —
-    same as the vector fix's "no driver at all" fixture — but that gate is a
-    separate, already-tested layer; this test exercises
-    ``extract_source_raster_metadata`` directly, the one place that
-    translates whatever rasterio raises.
+    Two DIFFERENT corrupt-file shapes both reach ``rasterio.open`` and both
+    raise ``RasterioIOError`` — confirmed live on this host (rasterio 1.5.1):
+    plain garbage bytes with a ``.tif`` name ("no driver recognizes this at
+    all") and a valid TIFF magic header followed by garbage ("the GTiff
+    driver claims the source by magic, then fails reading the IFD" —
+    ``TIFFReadDirectory:Failed to read directory...``). Both get the friendly
+    message, because both are open-time failures at this call site; a
+    narrower fix that pattern-matched only the first shape's exact text
+    missed the second, which is equally production-reachable (a corrupt-IFD
+    .tif passes upload-time content-sniffing the same as any other .tif) and
+    equally leaks the staging path.
     """
 
     def _write_unrecognized_raster(self, tmp_path) -> str:
+        """Plain garbage bytes with a .tif name — no driver recognizes this
+        at all."""
         path = tmp_path / "9f2c1a3e-uuid_survey.tif"
         path.write_bytes(os.urandom(500))
         return str(path)
 
+    def _write_corrupt_ifd_raster(self, tmp_path) -> str:
+        """Valid little-endian TIFF magic ("II*\\x00") followed by garbage —
+        the GTiff driver claims the source by magic, then fails reading the
+        IFD. A DIFFERENT rasterio failure shape from the "no driver" case
+        above, and the one the round-1 fix's narrower pattern match missed."""
+        path = tmp_path / "9f2c1a3e-uuid_survey.tif"
+        path.write_bytes(b"II*\x00" + os.urandom(500))
+        return str(path)
+
     def test_unrecognized_source_raises_friendly_message(self, tmp_path):
         source = self._write_unrecognized_raster(tmp_path)
+        with pytest.raises(ValueError) as exc_info:
+            extract_source_raster_metadata(source, original_filename="survey.tif")
+        message = str(exc_info.value)
+        assert message == (
+            "Could not open 'survey.tif' as a raster dataset — the file may "
+            "be corrupt, incomplete, or not a valid GeoTIFF (.tif) file."
+        )
+        assert str(tmp_path) not in message
+        assert source not in message
+
+    def test_corrupt_ifd_source_raises_friendly_message(self, tmp_path):
+        """codex review, #1661 round 1: a valid TIFF magic header with a
+        corrupt IFD is a distinct RasterioIOError shape from the "no driver"
+        case, but it is STILL an open-time failure at this call site — and
+        its rasterio message ALSO quotes the staging path — so it gets the
+        same friendly translation, not the raw message."""
+        source = self._write_corrupt_ifd_raster(tmp_path)
         with pytest.raises(ValueError) as exc_info:
             extract_source_raster_metadata(source, original_filename="survey.tif")
         message = str(exc_info.value)
@@ -153,6 +153,22 @@ class TestExtractSourceRasterMetadataFriendlyOpenFailure:
         assert source in logged["error"]
         assert logged["original_filename"] == "survey.tif"
 
+    def test_corrupt_ifd_message_also_reaches_structured_logs(self, tmp_path):
+        source = self._write_corrupt_ifd_raster(tmp_path)
+        with structlog.testing.capture_logs() as captured:
+            with pytest.raises(ValueError):
+                extract_source_raster_metadata(source, original_filename="survey.tif")
+
+        error_events = [e for e in captured if e.get("log_level") == "error"]
+        assert error_events, [e for e in captured]
+        logged = error_events[0]
+        assert "TIFFReadDirectory" in logged["error"]
+        # This shape's rasterio message quotes only the basename, not the
+        # full staging path (unlike the "not recognized" shape above) — the
+        # point stands either way: the full diagnostic reaches the log.
+        assert os.path.basename(source) in logged["error"]
+        assert logged["original_filename"] == "survey.tif"
+
     def test_no_original_filename_uses_generic_message(self, tmp_path):
         source = self._write_unrecognized_raster(tmp_path)
         with pytest.raises(ValueError) as exc_info:
@@ -164,22 +180,28 @@ class TestExtractSourceRasterMetadataFriendlyOpenFailure:
         )
         assert source not in message
 
-    def test_unrelated_rasterio_failure_keeps_real_message(self, tmp_path):
-        """A TIFF with a valid magic header but a corrupt IFD is a
-        DIFFERENT rasterio failure shape from the "not recognized" class —
-        it must propagate the real rasterio message unchanged, not the
-        friendly one, so a genuinely different problem doesn't get
-        misdiagnosed as "wrong format"."""
-        path = tmp_path / "9f2c1a3e-uuid_survey.tif"
-        # Valid little-endian TIFF magic ("II*\x00") followed by garbage —
-        # the GTiff driver claims the source by magic, then fails reading
-        # the IFD, which is a distinct rasterio error from the
-        # "not recognized" class this fix targets.
-        path.write_bytes(b"II*\x00" + os.urandom(500))
-        source = str(path)
+    def test_post_open_failure_keeps_real_message(self, tmp_path, monkeypatch):
+        """The boundary is "the open call itself", not "anything
+        ``extract_raster_metadata`` can raise". A failure from something
+        OTHER than ``rasterio.open`` — e.g. a non-``RasterioIOError`` raised
+        while parsing metadata off an already-opened dataset — must keep its
+        real message, not get relabeled as an open failure. Simulated via
+        monkeypatch (a real post-open, non-open-time rasterio failure isn't
+        cheaply reproducible with fixture bytes) so this pins the boundary
+        decision itself rather than any one rasterio internal."""
+        source = self._write_unrecognized_raster(tmp_path)
 
-        with pytest.raises(Exception) as exc_info:
+        def _raise_unrelated(_file_path):
+            raise ValueError("malformed TIFFTAG_DATETIME tag: not a date")
+
+        monkeypatch.setattr(
+            "app.processing.ingest.tasks_raster_common.extract_raster_metadata",
+            _raise_unrelated,
+        )
+
+        with pytest.raises(ValueError) as exc_info:
             extract_source_raster_metadata(source, original_filename="survey.tif")
         message = str(exc_info.value)
+        assert message == "malformed TIFFTAG_DATETIME tag: not a date"
         assert "Could not open" not in message
         assert "raster dataset" not in message


### PR DESCRIPTION
Fixes #1661.

## What

Deferred from #1640, which fixed the vector side (ogr2ogr/ogrinfo). This does the same for raster: when a corrupt or unopenable raster upload reaches `rasterio.open` (via `extract_raster_metadata`), the raised `RasterioIOError` carries GDAL's one-liner:

```
'<path>' not recognized as being in a supported file format.
```

That message used to land verbatim in `IngestJob.error_message`, leaking the internal `/app/staging/<uuid>_...` path instead of the original upload filename.

## Fix

Adds `extract_source_raster_metadata` to `backend/app/processing/ingest/tasks_raster_common.py`:

- `_is_unopenable_raster_stderr` pattern-matches the "not recognized as being in a supported file format" shape (anchored tightly — no other rasterio/GDAL failure, e.g. a TIFF with an intact magic header but a corrupt IFD, matches it).
- On a match, the full rasterio message is logged at error level (`structlog`), and a short message built from the ORIGINAL upload filename is raised instead — never the staging path.
- Every other rasterio/GDAL failure keeps its real message unchanged.

Both raster ingest tails that read a freshly-staged source now call the wrapper instead of `extract_raster_metadata` directly:
- `tasks_raster.py` (`ingest_raster`, step 5 — source metadata extraction)
- `tasks_raster_replace.py` (replace tail's source read)

Reads of an already-converted COG (`tasks_raster.py` step 6, `tasks_raster_replace.py`'s `_read_cog_metadata`) are untouched — no upload filename to leak there.

### Before / after

Before:
```
'/app/staging/9f2c1a3e-uuid_survey.tif' not recognized as being in a supported file format.
```

After:
```
Could not open 'survey.tif' as a raster dataset — the file may be corrupt, incomplete, or not a valid GeoTIFF (.tif) file.
```

## Verification

Empirically confirmed the exact rasterio message on this host before writing the pattern/tests: plain unrecognized bytes with a `.tif` name reproduce the "not recognized" `RasterioIOError` verbatim; a valid TIFF magic header + corrupt IFD instead produces a *different* message (`TIFFReadDirectory:Failed to read directory...`), which is pinned as a negative case so it's never misdiagnosed as "wrong format".

```
cd backend && uv run ruff check . && uv run ruff format --check .
cd backend && set -a && source ../.env.test && set +a && uv run pytest tests/test_ingest_raster_open_failure_message.py tests/test_layering.py tests/test_raster_ingest.py tests/test_raster_replace_1221.py -q
# 199 passed
```

Counterfactual: committed the fix, then `git checkout HEAD~1 -- <changed files>` to restore the pre-fix code and re-ran the new test file — it fails collection with `ImportError: cannot import name '_friendly_raster_open_failure_message'`, confirming the tests exercise the new code path. Restored the fix afterward (`git diff HEAD` is empty).

CHANGELOG entry added under `[Unreleased] > Fixed`.

No schema/API/config impacts.
