### PR TITLE
docs(changelog): correct the CatalogPort migration note in 1.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -371,11 +371,13 @@ and releases use semantic versioning.
   vectors anchors on the one search would use (#1546, #1578, #1580, #1583).
 
   Overlay authors: `EXTENSION_API_VERSION` is now 9, bumped twice in this
-  release. `CatalogPort` gained a required
-  `resolve_embedding_config_fingerprint`, `generate_embedding` takes the
-  resolved configuration as a pin, `get_record_embedding` returns the row's
-  model and fingerprint alongside the vector, `get_embedding_distances` takes
-  that pair, and `get_nearest_record_ids` takes the anchor's pair.
+  release. `CatalogPort` gained a required `resolve_embedding_config`,
+  `generate_embedding` takes the resolved configuration as a pin,
+  `get_record_embedding` returns the row's model and fingerprint alongside the
+  vector, `get_embedding_distances` takes that pair as two required keyword-only
+  arguments, and `get_nearest_record_ids` takes the caller's already-read
+  anchor — the vector and that pair together, in one required `anchor` keyword —
+  instead of reading one for itself.
 - **A force embedding regenerate no longer deletes before it can finish.**
   It used to commit `DELETE` of every embedding before generating anything,
   so any abort after that point left the catalog with no vectors. Old rows


### PR DESCRIPTION
Closes #1667.

The 1.14.0 **"Overlay authors:"** paragraph is the migration instruction for anyone implementing `CatalogPort` against `EXTENSION_API_VERSION = 9`. Two things in it were wrong.

## 1. The method name

It named `resolve_embedding_config_fingerprint`. That name belongs to a module-level helper at `backend/app/processing/embeddings/helpers.py:244`. The Protocol member is `resolve_embedding_config` (`backend/app/core/catalog_port.py:237`).

An overlay author following the note implements the wrong thing and leaves the actual required member unimplemented.

Grepped the tree: `CHANGELOG.md:375` was the only wrong occurrence — every other hit is a legitimate reference to the real helper.

## 2. The `get_nearest_record_ids` clause

It read *"`get_nearest_record_ids` takes the anchor's pair"*, immediately after the clause describing `get_embedding_distances`. That method genuinely takes the pair as two required keyword-only arguments, so reading the parallel gives the wrong shape — `get_nearest_record_ids` takes the caller's already-read anchor as a **single** required `anchor` keyword carrying the vector and the pair together:

```python
async def get_nearest_record_ids(
    self, session, record_id, *,
    anchor: tuple[list[float], str, str | None],
    limit: int = 5, max_distance: float = 0.7,
) -> list[uuid.UUID]: ...
```

## Source of truth

Both corrections are taken from `core/catalog_port.py` and the rationale block in `platform/extensions/version.py`, which had them right all along — only the changelog carried the helper's name.

## Verification

Every method the corrected paragraph names resolves on the Protocol, with signatures matching the new wording:

```
OK  resolve_embedding_config(self, session) -> tuple[...] | None
OK  generate_embedding(self, text, session, *, pinned=None) -> list[float]
OK  get_record_embedding(self, session, record_id) -> tuple[list[float], str, str | None] | None
OK  get_embedding_distances(self, session, embedding, record_ids, *, model_name, config_fingerprint)
OK  get_nearest_record_ids(self, session, record_id, *, anchor, limit=5, max_distance=0.7)
```

## Deliberately not added

A gate asserting that every identifier named in an "Overlay authors:" paragraph resolves on the port would catch this class, but it needs a heuristic to tell port members from the other backticked names in those paragraphs, and a wrong heuristic in a gate costs more than the paragraph it guards. Happy to add one if you'd rather have it.

Docs-only. The docs-side copy of this error was already corrected in geolens-io/getgeolens.com#138; this is the upstream.

https://claude.ai/code/session_01BXUUv3x71zWaLKEvoL4cTY