### PR TITLE
feat(release): draft the Buttondown release-notes email automatically

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -180,7 +180,16 @@ jobs:
       # to one version across a dozen files, and otherwise hears about a
       # release only from a weekly ci/check-pins.py line that warns and
       # passes. On this event it opens a "bump the pins and re-sweep" issue.
-      - name: Notify the site and the examples repo of the release
+      #
+      # The third target is the Buttondown newsletter. It lives here rather
+      # than in its own step so it inherits this one's latest-release guard
+      # and reporting: a stale tag must not draft a newsletter for a version
+      # that is no longer current, and that check is subtle enough that a
+      # second copy of it would drift. The runbook's step 11 recorded the
+      # reason it kept being missed — "nothing triggers it and nothing checks
+      # it" — which is both halves of what this step already does for the
+      # other two.
+      - name: Notify downstream targets of the release
         # Only GA tags (no `-` suffix) dispatch — same shape as the
         # IS_PRERELEASE case pattern in "Create release" above. A prerelease
         # never becomes the "latest" release the site's install one-liner and
@@ -212,6 +221,9 @@ jobs:
           DEFAULT_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SITE_DISPATCH_TOKEN: ${{ secrets.SITE_DISPATCH_TOKEN }}
           EXAMPLES_DISPATCH_TOKEN: ${{ secrets.EXAMPLES_DISPATCH_TOKEN }}
+          # Buttondown API key (Buttondown -> Settings -> Programming). Absent
+          # = skipped with a ::notice::, like the dispatch tokens above.
+          BUTTONDOWN_API_KEY: ${{ secrets.BUTTONDOWN_API_KEY }}
         # The release is already published by this point in the job. A failed
         # dispatch must never fail the release on a downstream repo's account —
         # worst case, the site's own nightly release-drift check catches the
@@ -282,6 +294,58 @@ jobs:
             echo "::warning title=Examples dispatch failed::Could not notify geolens-io/geolens-examples of release ${TAG}. The GeoLens release itself published fine; the examples repo's weekly ci/check-pins.py run will still warn that the demo has moved past its pins."
             summary "examples: FAILED for ${TAG} (see the warning above)"
             failed=1
+          fi
+
+          # Draft the release-notes newsletter. DRAFT on purpose: this removes
+          # the "remember it exists" problem, which is the one that actually
+          # bit, without putting unreviewed copy in front of subscribers.
+          if [ -z "$BUTTONDOWN_API_KEY" ]; then
+            echo "::notice title=Newsletter not drafted::BUTTONDOWN_API_KEY is not configured, so no release-notes email was drafted for ${TAG}. Add it as a repository secret (Buttondown -> Settings -> Programming) to enable this."
+            summary "newsletter: skipped (no BUTTONDOWN_API_KEY)"
+          else
+            SUBJECT="GeoLens ${TAG}"
+            # A re-run of this workflow must not leave a second draft. The API's
+            # `subject` filter is a CONTAINS match, so compare exactly rather
+            # than trusting that a match is THE match.
+            EXISTING=$(curl -sS --max-time 30 -G "https://api.buttondown.com/v1/emails" \
+              --data-urlencode "subject=${SUBJECT}" \
+              -H "Authorization: Token ${BUTTONDOWN_API_KEY}" 2>/dev/null \
+              | jq -r --arg s "$SUBJECT" '[.results[]? | select(.subject == $s)] | length' 2>/dev/null || true)
+            # An unreadable check falls through to creating one. A duplicate
+            # DRAFT is cheap and visible; a missing newsletter is the failure
+            # this whole target exists to prevent.
+            if [ "${EXISTING:-0}" != "0" ] && [ -n "${EXISTING}" ]; then
+              echo "::notice title=Newsletter already drafted::A Buttondown email titled \"${SUBJECT}\" already exists, so this run did not create another."
+              summary "newsletter: already drafted for ${TAG}"
+            else
+              # release-notes.md is the curated CHANGELOG section this job
+              # already built for the GitHub Release body.
+              {
+                cat release-notes.md
+                printf '\n[Release notes on GitHub](https://github.com/%s/releases/tag/%s)\n' "${GITHUB_REPOSITORY}" "${TAG}"
+              } > newsletter.md
+              # --rawfile, not string interpolation: the body is arbitrary
+              # markdown with quotes, backticks and newlines in it.
+              jq -n --arg subject "$SUBJECT" --rawfile body newsletter.md \
+                '{subject: $subject, body: $body, status: "draft"}' > newsletter.json
+              CODE=$(curl -sS --max-time 30 -o newsletter-response.json -w '%{http_code}' \
+                -X POST "https://api.buttondown.com/v1/emails" \
+                -H "Authorization: Token ${BUTTONDOWN_API_KEY}" \
+                -H "Content-Type: application/json" \
+                --data-binary @newsletter.json || echo 000)
+              case "$CODE" in
+                2*)
+                  summary "newsletter: drafted \"${SUBJECT}\" in Buttondown — review and send"
+                  ;;
+                *)
+                  # Never echo the response wholesale; it echoes the request.
+                  DETAIL=$(jq -r '.detail // .error // empty' newsletter-response.json 2>/dev/null | head -c 200)
+                  echo "::warning title=Newsletter draft failed::Could not draft the Buttondown release-notes email for ${TAG} (HTTP ${CODE}). ${DETAIL} The release itself published fine; draft it by hand per the release runbook."
+                  summary "newsletter: FAILED for ${TAG} (HTTP ${CODE})"
+                  failed=1
+                  ;;
+              esac
+            fi
           fi
 
           exit "$failed"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -339,7 +339,18 @@ jobs:
                   ;;
                 *)
                   # Never echo the response wholesale; it echoes the request.
-                  DETAIL=$(jq -r '.detail // .error // empty' newsletter-response.json 2>/dev/null | head -c 200)
+                  #
+                  # `|| true` because this must not become the thing that stops
+                  # the failure being REPORTED. A transport failure leaves no
+                  # response file at all (curl -o writes nothing), and a proxy
+                  # can return a non-JSON error body; either way jq exits
+                  # non-zero. This step runs under GitHub's default `bash -e`,
+                  # where the pipeline's status is `head`'s and that is
+                  # survivable — but adding `shell: bash` anywhere above turns
+                  # on `pipefail` and the step would then die here, before the
+                  # warning, the summary line and `failed=1`. Not a dependency
+                  # to leave implicit (#1673 codex P2).
+                  DETAIL=$(jq -r '.detail // .error // empty' newsletter-response.json 2>/dev/null | head -c 200 || true)
                   echo "::warning title=Newsletter draft failed::Could not draft the Buttondown release-notes email for ${TAG} (HTTP ${CODE}). ${DETAIL} The release itself published fine; draft it by hand per the release runbook."
                   summary "newsletter: FAILED for ${TAG} (HTTP ${CODE})"
                   failed=1

--- a/backend/tests/test_release_dispatch_targets_1609.py
+++ b/backend/tests/test_release_dispatch_targets_1609.py
@@ -31,7 +31,9 @@ REPO_ROOT = pathlib.Path(__file__).parent.parent.parent
 RELEASE_YML = REPO_ROOT / ".github" / "workflows" / "release.yml"
 CI_YML = REPO_ROOT / ".github" / "workflows" / "ci.yml"
 
-STEP_NAME_MARKER = "Notify the site"
+# fix(#1673): tracks the step name, which changed when the Buttondown
+# newsletter joined the site and examples dispatches as a third target.
+STEP_NAME_MARKER = "Notify downstream"
 
 SITE_DISPATCH_API = "repos/geolens-io/getgeolens.com/dispatches"
 EXAMPLES_DISPATCH_API = "repos/geolens-io/geolens-examples/dispatches"
@@ -40,9 +42,13 @@ EXAMPLES_DISPATCH_API = "repos/geolens-io/geolens-examples/dispatches"
 def _dispatch_step() -> dict[str, Any]:
     """The single step in release.yml that sends the release dispatches.
 
-    Matched on a prefix of its name rather than the whole string, so renaming
-    it to cover a new target does not silently stop this test from finding it
-    (an assertion that cannot locate its subject passes vacuously).
+    Matched on a prefix of its name rather than the whole string. That is not
+    rename-proof — fix(#1673) renamed the step past the old ``"Notify the
+    site"`` marker and this had to move with it — but the ``== 1`` assertion
+    below is what makes that safe: a marker that no longer matches fails
+    loudly here instead of letting every assertion in this file pass
+    vacuously against a step it could not find. Renaming the step means
+    updating this marker in the same commit.
     """
     workflow: dict[str, Any] = yaml.safe_load(RELEASE_YML.read_text(encoding="utf-8"))
 


### PR DESCRIPTION
The release-notes newsletter was the one release step nothing triggered and nothing checked. The runbook said so in as many words:

> **11. Send the Buttondown release-notes email**
> Manual, every release... Nothing triggers it and nothing checks it, which is why it was missed for both v1.15.0 and v1.15.1.

Being written down did not make it happen.

## What this does

The Release workflow now POSTs the curated release notes to Buttondown as a **draft** on every GA tag.

Draft rather than sent, on purpose: what failed was *remembering the email existed*, not writing it. This removes that step without putting unreviewed copy in front of subscribers. You get a `newsletter:` line in the run summary, open Buttondown, read it, send it.

## Why it rides in the existing step

It goes inside "Notify downstream targets of the release" (renamed from "...the site and the examples repo") rather than a new step, so it inherits that step's guards instead of copying them:

- **The latest-release check.** `prod-smoke.yml` runs tag smokes in parallel and this workflow has no concurrency group, so an older tag's smoke can land after a newer release published. That must not draft a newsletter for a version that is no longer current — and the check is subtle enough that a second copy would drift from the first.
- **The GA-only `if:`**, so prereleases never draft one.
- **`continue-on-error` plus a per-target step-summary line.** A missing `BUTTONDOWN_API_KEY` logs a `::notice::` and reports `newsletter: skipped (no BUTTONDOWN_API_KEY)` rather than showing as a bare grey skipped step — the lesson this file already learned for `SITE_DISPATCH_TOKEN` in #1530.

## Details worth knowing

**Body.** `release-notes.md` — the same curated CHANGELOG section used for the GitHub Release body — plus a link back to the release. Built with `jq --rawfile`, not string interpolation, because it is arbitrary markdown full of quotes, backticks and dollar signs.

**Re-runs don't duplicate.** It queries for an existing email first. That filter is a **contains** match, so the comparison is exact — otherwise `GeoLens v1.15.1` would match a future `GeoLens v1.15.11`. If the check itself is unreadable it falls through to creating one: a duplicate draft is cheap and visible, a missing newsletter is the failure being fixed.

## Verification

Exercised against a stubbed API across all five paths:

```
no BUTTONDOWN_API_KEY  -> ::notice:: + "newsletter: skipped (no BUTTONDOWN_API_KEY)"
none existing          -> "newsletter: drafted \"GeoLens v9.9.9\" ... review and send"
already drafted        -> ::notice:: + "newsletter: already drafted for v9.9.9"
existence check fails  -> falls through and drafts (intended)
create fails (400)     -> ::warning:: with the API's detail + failed=1
```

The contains-vs-exact edge is covered: an API response of `GeoLens v9.9.90` and `Re: GeoLens v9.9.9 follow-up` correctly does **not** count as already-drafted.

The payload validates against Buttondown's published `EmailInput` schema — which sets `additionalProperties: false`, so an unknown field would 422:

```
unknown fields sent : none
required missing    : none
status value valid  : True
```

And the markdown survives the round trip intact:

```
body: '### Added\n- **A thing** with `backticks`, "quotes" and a $dollar.\n\n[Release notes on GitHub](...)\n'
```

## Before this helps

Set the `BUTTONDOWN_API_KEY` repository secret (Buttondown → Settings → Programming). Until then the step skips and says so in the summary; nothing else changes.

## Considered and rejected

A Buttondown **External Feed** pointed at `releases.atom` would have been zero repo code, and the feed does carry the full curated notes. Rejected because it moves the mechanism outside the repo, where its own breakage would be silent — which is the same class of failure as the manual step it replaces, and the thing #1530 taught this file to avoid. It also can't filter out prereleases.

The private release runbook's step 11 is updated separately (it is gitignored).

https://claude.ai/code/session_01BXUUv3x71zWaLKEvoL4cTY