### PR TITLE
test(ogc): pin the QGIS >=3.44 CQL2 push-down conformance set

### DIFF
--- a/backend/tests/test_ogc_discovery.py
+++ b/backend/tests/test_ogc_discovery.py
@@ -345,6 +345,55 @@ async def test_conformance_f_json_accepted(client):
     assert response.status_code == 200
 
 
+# fix(#1674 codex): qgis/QGIS#62156 (merged 2025-06-05, first released in QGIS
+# 3.44) fixed the OAPIF provider's server-capability detection to recognize
+# the FINAL-SPEC conformance class name `cql2/1.0/conf/basic-spatial-functions`
+# -- QGIS<3.44 only recognized the deprecated draft name
+# `cql2/{0.0,1.0}/conf/basic-spatial-operators`. QgsOapifProvider::init() sets
+# two independent capability flags from the classes below (verified against
+# the merged patch, src/providers/wfs/oapif/qgsoapifprovider.cpp):
+#
+#   mServerSupportsFilterCql2Text (base gate for ANY filter push-down; ALL
+#   four required):
+#     cql2/{0.0,1.0}/conf/basic-cql2
+#     ogcapi-features-3/{0.0,1.0}/conf/filter
+#     ogcapi-features-3/{0.0,1.0}/conf/features-filter
+#     cql2/{0.0,1.0}/conf/cql2-text
+#
+#   mServerSupportsBasicSpatialFunctions (gates S_INTERSECTS/BBOX()/POINT()
+#   push-down specifically -- the class this PR fixed recognition of):
+#     cql2/1.0/conf/basic-spatial-functions
+#
+# The CQL2 spec (opengeospatial/ogcapi-features, cql2/standard/requirements/
+# basic-spatial-functions/REQ_spatial-functions.adoc) mandates only
+# S_INTERSECTS for this class, which is exactly what GeoLens's filter
+# validator (standards/ogc/filtering.py) supports -- advertising it is
+# honest. GeoLens serves the 1.0 URI for every class below; this pins that
+# set so a future conformance-list edit cannot silently drop QGIS push-down.
+_QGIS_3_44_CQL2_PUSHDOWN_CLASSES = [
+    "http://www.opengis.net/spec/cql2/1.0/conf/basic-cql2",
+    "http://www.opengis.net/spec/ogcapi-features-3/1.0/conf/filter",
+    "http://www.opengis.net/spec/ogcapi-features-3/1.0/conf/features-filter",
+    "http://www.opengis.net/spec/cql2/1.0/conf/cql2-text",
+    "http://www.opengis.net/spec/cql2/1.0/conf/basic-spatial-functions",
+]
+
+
+async def test_conformance_pins_qgis_344_cql2_pushdown_classes(client):
+    """GET /conformance advertises every class QGIS>=3.44 needs before it
+    pushes CQL2 filters (including spatial S_INTERSECTS) down to this server.
+
+    A regression here never 500s or 400s anywhere: QGIS just falls back to
+    client-side filtering, which is silent until someone notices a large
+    layer got slow. See qgis/QGIS#62156 for the exact detection logic.
+    """
+    response = await client.get("/conformance")
+    assert response.status_code == 200
+    conforms_to = response.json()["conformsTo"]
+    for cls in _QGIS_3_44_CQL2_PUSHDOWN_CLASSES:
+        assert cls in conforms_to, f"Missing QGIS CQL2 push-down class: {cls}"
+
+
 async def test_conformance_f_unsupported_returns_400(client):
     """GET /conformance?f=xml returns 400."""
     response = await client.get("/conformance", params={"f": "xml"})

--- a/backend/tests/test_ogc_features_filter.py
+++ b/backend/tests/test_ogc_features_filter.py
@@ -939,20 +939,24 @@ async def test_qgis_344_request_sequence_end_to_end(
     landing = await client.get("/")
     assert landing.status_code == 200
     landing_links = landing.json()["links"]
-    # fix(#1680 codex r5): deriving the expected origin from the landing
-    # page's OWN self href was circular -- a uniformly misconfigured
-    # PUBLIC_API_URL would make every advertised link agree with itself and
-    # this replay would still pass. The client's base_url is the one origin
-    # a real client (QGIS) actually used to reach the server; validate every
-    # advertised link -- self included -- against THAT instead.
-    base_url = urlparse(str(client.base_url))
-    origin = f"{base_url.scheme}://{base_url.netloc}"
+    # The expected origin is the landing page's OWN self href, not
+    # client.base_url ("http://test" for this ASGI-transport fixture).
+    # fix(#1680 codex r5) tried comparing against client.base_url instead,
+    # reasoning that self-href-derivation was circular; that broke in CI
+    # (build_url()'s PUBLIC_API_URL resolution legitimately returned
+    # "http://localhost:8000" there, independent of the dummy transport
+    # host) because GeoLens's public API URL is BY DESIGN allowed to differ
+    # from the literal address a client connected on -- that's the entire
+    # point of PUBLIC_API_URL/PUBLIC_BASE_URL (reverse proxy / custom
+    # domain support; see app/core/public_urls.py). What actually matters,
+    # and IS a real regression to catch, is every advertised link agreeing
+    # with every OTHER advertised link -- a client that starts at the
+    # landing page has no ground truth beyond what the landing page itself
+    # says, so self-consistency across the whole discovery chain is the
+    # right invariant, not agreement with this test harness's placeholder
+    # transport address.
     self_href = next(link["href"] for link in landing_links if link["rel"] == "self")
-    # Origin-only check (fix(#1680 codex r5) doesn't need this link's exact
-    # path -- PUBLIC_API_URL legitimately carries a mount prefix, e.g. "/api"
-    # behind a reverse proxy -- just that it resolves under the same origin
-    # a real client used to reach the server at all.
-    _same_origin_path(self_href, origin)
+    origin = f"{urlparse(self_href).scheme}://{urlparse(self_href).netloc}"
 
     conformance_href = next(
         link["href"] for link in landing_links if link["rel"] == "conformance"

--- a/backend/tests/test_ogc_features_filter.py
+++ b/backend/tests/test_ogc_features_filter.py
@@ -906,26 +906,53 @@ async def test_filter_still_rejected_without_value_types(
 # before it reaches a real QGIS session.
 
 
+def _same_origin_path(href: str, expected_origin: str) -> str:
+    """Path+query of ``href`` iff it shares ``expected_origin``.
+
+    fix(#1680 codex r3): urlparse(href).path alone discards scheme/host, so a
+    PUBLIC_API_URL that resolved a *different* origin on one leg would still
+    resolve locally via ASGITransport and pass every suffix assertion -- a
+    real client (QGIS) would instead be pointed off-server and fail to
+    connect. Asserting the origin before discarding it makes that class of
+    bug fail loudly here instead of shipping silently.
+    """
+    parsed = urlparse(href)
+    origin = f"{parsed.scheme}://{parsed.netloc}"
+    assert origin == expected_origin, (
+        f"advertised link {href!r} has origin {origin!r}, expected "
+        f"{expected_origin!r} -- a real client could not follow it"
+    )
+    path = parsed.path
+    return f"{path}?{parsed.query}" if parsed.query else path
+
+
 @pytest.mark.anyio
 async def test_qgis_344_request_sequence_end_to_end(
     client: AsyncClient, filter_dataset: Dataset
 ):
-    # 1. Landing page: QGIS follows rel=conformance from here. Fetch the next
-    # leg via the *discovered* href's path (fix(#1680 codex r1): a hard-coded
-    # "/conformance" request would still land on the right route even if
-    # PUBLIC_API_URL produced a wrong scheme/host/prefix, silently defeating
-    # the whole point of replaying advertised links).
+    # 1. Landing page: QGIS follows rel=data (collections) and rel=conformance
+    # from here. Every subsequent leg is fetched via its *discovered* href,
+    # validated to share the landing page's own origin (fix(#1680 codex
+    # r1-r3): a hard-coded path would still land on the right local route even
+    # if an advertised link pointed somewhere QGIS could never actually reach,
+    # silently defeating the whole point of replaying advertised links).
     landing = await client.get("/")
     assert landing.status_code == 200
+    landing_links = landing.json()["links"]
+    self_href = next(link["href"] for link in landing_links if link["rel"] == "self")
+    origin = f"{urlparse(self_href).scheme}://{urlparse(self_href).netloc}"
+
     conformance_href = next(
-        link["href"] for link in landing.json()["links"] if link["rel"] == "conformance"
+        link["href"] for link in landing_links if link["rel"] == "conformance"
     )
     assert conformance_href.endswith("/conformance")
+    data_href = next(link["href"] for link in landing_links if link["rel"] == "data")
+    assert data_href.endswith("/collections")
 
     # 2. Conformance: gates mServerSupportsFilterCql2Text (base push-down) AND
     # mServerSupportsBasicSpatialFunctions (spatial predicate push-down), per
     # qgis/QGIS#62156 (see test_ogc_discovery.py for the full URI-by-URI pin).
-    conformance = await client.get(urlparse(conformance_href).path)
+    conformance = await client.get(_same_origin_path(conformance_href, origin))
     assert conformance.status_code == 200
     conforms_to = set(conformance.json()["conformsTo"])
     required = {
@@ -937,9 +964,14 @@ async def test_qgis_344_request_sequence_end_to_end(
     }
     assert required <= conforms_to
 
-    # 3. Collection metadata: QGIS resolves the queryables AND items links
-    # from here -- neither is a path the client is allowed to assume.
-    collection = await client.get(f"/collections/{filter_dataset.id}")
+    # 3. Collection metadata, reached via the landing page's rel=data
+    # (collections) link -- the dataset id itself is the one thing a real
+    # QGIS user supplies (by picking it from the browsable collections list,
+    # which this single-dataset fixture can't exercise meaningfully; the
+    # origin+path validation above and below is what actually matters here).
+    collection = await client.get(
+        f"{_same_origin_path(data_href, origin)}/{filter_dataset.id}"
+    )
     assert collection.status_code == 200
     collection_links = collection.json()["links"]
     queryables_href = next(
@@ -954,8 +986,8 @@ async def test_qgis_344_request_sequence_end_to_end(
     assert items_href.endswith(f"/collections/{filter_dataset.id}/items")
 
     # 4. Queryables: QGIS builds its field list + geometry queryable from
-    # this -- again via the discovered href's path, not a re-typed one.
-    queryables = await client.get(urlparse(queryables_href).path)
+    # this -- again via the discovered href, not a re-typed path.
+    queryables = await client.get(_same_origin_path(queryables_href, origin))
     assert queryables.status_code == 200
     props = queryables.json()["properties"]
     assert "geometry" in props
@@ -963,11 +995,10 @@ async def test_qgis_344_request_sequence_end_to_end(
 
     # 5. Items with a pushed-down spatial predicate, exactly as QGIS's
     # QgsOapifCql2TextExpressionCompiler emits it for a map-canvas-extent
-    # request (S_INTERSECTS + a BBOX() literal), cql2-text encoded. fix(#1680
-    # codex r2): issued against the discovered items_href's path, not a
-    # re-typed one -- same rationale as the conformance/queryables legs above.
+    # request (S_INTERSECTS + a BBOX() literal), cql2-text encoded. Issued
+    # against the discovered items_href, not a re-typed path.
     items = await client.get(
-        urlparse(items_href).path,
+        _same_origin_path(items_href, origin),
         params={
             "filter": f"S_INTERSECTS(geometry,BBOX({','.join(str(v) for v in BBOX_12)}))",
             "filter-lang": "cql2-text",

--- a/backend/tests/test_ogc_features_filter.py
+++ b/backend/tests/test_ogc_features_filter.py
@@ -956,7 +956,20 @@ async def test_qgis_344_request_sequence_end_to_end(
     # right invariant, not agreement with this test harness's placeholder
     # transport address.
     self_href = next(link["href"] for link in landing_links if link["rel"] == "self")
-    origin = f"{urlparse(self_href).scheme}://{urlparse(self_href).netloc}"
+    self_parsed = urlparse(self_href)
+    # fix(#1680 codex r7): normalize_public_url() (app/core/public_urls.py)
+    # accepts any nonempty string verbatim -- it strips whitespace and a
+    # trailing slash but never validates scheme or host. A misconfigured
+    # PUBLIC_API_URL of "https://" (no host) or "ftp://catalog.example"
+    # would make every generated link agree with that same broken origin,
+    # passing self-consistency while no real client could dereference any
+    # of it. Require a real HTTP(S) origin before trusting it as the
+    # baseline every other link gets checked against.
+    assert self_parsed.scheme in ("http", "https"), (
+        f"landing page self href {self_href!r} has a non-HTTP(S) scheme"
+    )
+    assert self_parsed.netloc, f"landing page self href {self_href!r} has no host"
+    origin = f"{self_parsed.scheme}://{self_parsed.netloc}"
 
     conformance_href = next(
         link["href"] for link in landing_links if link["rel"] == "conformance"

--- a/backend/tests/test_ogc_features_filter.py
+++ b/backend/tests/test_ogc_features_filter.py
@@ -964,14 +964,44 @@ async def test_qgis_344_request_sequence_end_to_end(
     }
     assert required <= conforms_to
 
-    # 3. Collection metadata, reached via the landing page's rel=data
-    # (collections) link -- the dataset id itself is the one thing a real
-    # QGIS user supplies (by picking it from the browsable collections list,
-    # which this single-dataset fixture can't exercise meaningfully; the
-    # origin+path validation above and below is what actually matters here).
-    collection = await client.get(
-        f"{_same_origin_path(data_href, origin)}/{filter_dataset.id}"
+    # 3. Collections list, reached via the landing page's rel=data link (the
+    # ONE hand-known value left is *which* collection id to pick, matching
+    # how a QGIS user browses the list and clicks a layer -- every href that
+    # gets followed, including paging, comes from a response, never from
+    # re-deriving it from the id). Other tests in this shared-DB file leave
+    # their fixture datasets' catalog rows behind (only the backing table is
+    # dropped), so the target collection is not guaranteed to be on page one
+    # -- follow rel=next like a real client paging a large catalog would.
+    target_id = str(filter_dataset.id)
+    collections_href = data_href
+    collection_entry = None
+    for _ in range(50):  # generous bound; a real catalog would still terminate
+        collections = await client.get(_same_origin_path(collections_href, origin))
+        assert collections.status_code == 200
+        payload = collections.json()
+        collection_entry = next(
+            (e for e in payload["collections"] if e["id"] == target_id), None
+        )
+        if collection_entry is not None:
+            break
+        next_href = next(
+            (link["href"] for link in payload["links"] if link["rel"] == "next"),
+            None,
+        )
+        assert next_href is not None, (
+            f"collection {target_id} not found in /collections and no "
+            "rel=next page remains"
+        )
+        collections_href = next_href
+    assert collection_entry is not None
+    collection_self_href = next(
+        link["href"] for link in collection_entry["links"] if link["rel"] == "self"
     )
+    assert collection_self_href.endswith(f"/collections/{filter_dataset.id}")
+
+    # 4. Collection metadata, reached via the collections-list entry's own
+    # rel=self link discovered above.
+    collection = await client.get(_same_origin_path(collection_self_href, origin))
     assert collection.status_code == 200
     collection_links = collection.json()["links"]
     queryables_href = next(
@@ -985,7 +1015,7 @@ async def test_qgis_344_request_sequence_end_to_end(
     )
     assert items_href.endswith(f"/collections/{filter_dataset.id}/items")
 
-    # 4. Queryables: QGIS builds its field list + geometry queryable from
+    # 5. Queryables: QGIS builds its field list + geometry queryable from
     # this -- again via the discovered href, not a re-typed path.
     queryables = await client.get(_same_origin_path(queryables_href, origin))
     assert queryables.status_code == 200
@@ -993,7 +1023,7 @@ async def test_qgis_344_request_sequence_end_to_end(
     assert "geometry" in props
     assert "name" in props
 
-    # 5. Items with a pushed-down spatial predicate, exactly as QGIS's
+    # 6. Items with a pushed-down spatial predicate, exactly as QGIS's
     # QgsOapifCql2TextExpressionCompiler emits it for a map-canvas-extent
     # request (S_INTERSECTS + a BBOX() literal), cql2-text encoded. Issued
     # against the discovered items_href, not a re-typed path.

--- a/backend/tests/test_ogc_features_filter.py
+++ b/backend/tests/test_ogc_features_filter.py
@@ -939,8 +939,20 @@ async def test_qgis_344_request_sequence_end_to_end(
     landing = await client.get("/")
     assert landing.status_code == 200
     landing_links = landing.json()["links"]
+    # fix(#1680 codex r5): deriving the expected origin from the landing
+    # page's OWN self href was circular -- a uniformly misconfigured
+    # PUBLIC_API_URL would make every advertised link agree with itself and
+    # this replay would still pass. The client's base_url is the one origin
+    # a real client (QGIS) actually used to reach the server; validate every
+    # advertised link -- self included -- against THAT instead.
+    base_url = urlparse(str(client.base_url))
+    origin = f"{base_url.scheme}://{base_url.netloc}"
     self_href = next(link["href"] for link in landing_links if link["rel"] == "self")
-    origin = f"{urlparse(self_href).scheme}://{urlparse(self_href).netloc}"
+    # Origin-only check (fix(#1680 codex r5) doesn't need this link's exact
+    # path -- PUBLIC_API_URL legitimately carries a mount prefix, e.g. "/api"
+    # behind a reverse proxy -- just that it resolves under the same origin
+    # a real client used to reach the server at all.
+    _same_origin_path(self_href, origin)
 
     conformance_href = next(
         link["href"] for link in landing_links if link["rel"] == "conformance"

--- a/backend/tests/test_ogc_features_filter.py
+++ b/backend/tests/test_ogc_features_filter.py
@@ -887,3 +887,80 @@ async def test_filter_still_rejected_without_value_types(
         params={"filter": "S_DWITHIN(geometry, POINT(0 0), 10, 'meters')"},
     )
     assert resp.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# QGIS >=3.44 client-shaped integration replay (qgis/QGIS#62156)
+# ---------------------------------------------------------------------------
+#
+# QGIS's OAPIF provider issues this exact sequence before it ever emits a
+# filter=: landing page -> /conformance (capability detection, gating
+# mServerSupportsFilterCql2Text + mServerSupportsBasicSpatialFunctions) ->
+# /collections/{id} (find the rel=queryables link, only fetched at all when
+# the conformance check passed) -> /collections/{id}/queryables (build the
+# field list) -> /collections/{id}/items?filter=...&filter-lang=cql2-text
+# once a QgsFeatureRequest carries a spatial predicate QGIS's
+# QgsOapifCql2TextExpressionCompiler can push down. Replaying the whole
+# sequence catches a break in any leg -- not just the CQL2 compiler itself --
+# before it reaches a real QGIS session.
+
+
+@pytest.mark.anyio
+async def test_qgis_344_request_sequence_end_to_end(
+    client: AsyncClient, filter_dataset: Dataset
+):
+    # 1. Landing page: QGIS follows rel=conformance from here.
+    landing = await client.get("/")
+    assert landing.status_code == 200
+    conformance_href = next(
+        link["href"] for link in landing.json()["links"] if link["rel"] == "conformance"
+    )
+    assert conformance_href.endswith("/conformance")
+
+    # 2. Conformance: gates mServerSupportsFilterCql2Text (base push-down) AND
+    # mServerSupportsBasicSpatialFunctions (spatial predicate push-down), per
+    # qgis/QGIS#62156 (see test_ogc_discovery.py for the full URI-by-URI pin).
+    conformance = await client.get("/conformance")
+    assert conformance.status_code == 200
+    conforms_to = set(conformance.json()["conformsTo"])
+    required = {
+        "http://www.opengis.net/spec/cql2/1.0/conf/basic-cql2",
+        "http://www.opengis.net/spec/ogcapi-features-3/1.0/conf/filter",
+        "http://www.opengis.net/spec/ogcapi-features-3/1.0/conf/features-filter",
+        "http://www.opengis.net/spec/cql2/1.0/conf/cql2-text",
+        "http://www.opengis.net/spec/cql2/1.0/conf/basic-spatial-functions",
+    }
+    assert required <= conforms_to
+
+    # 3. Collection metadata: QGIS resolves the queryables link from here.
+    collection = await client.get(f"/collections/{filter_dataset.id}")
+    assert collection.status_code == 200
+    queryables_href = next(
+        link["href"]
+        for link in collection.json()["links"]
+        if link["rel"] == "http://www.opengis.net/def/rel/ogc/1.0/queryables"
+    )
+    assert queryables_href.endswith(f"/collections/{filter_dataset.id}/queryables")
+
+    # 4. Queryables: QGIS builds its field list + geometry queryable from this.
+    queryables = await client.get(f"/collections/{filter_dataset.id}/queryables")
+    assert queryables.status_code == 200
+    props = queryables.json()["properties"]
+    assert "geometry" in props
+    assert "name" in props
+
+    # 5. Items with a pushed-down spatial predicate, exactly as QGIS's
+    # QgsOapifCql2TextExpressionCompiler emits it for a map-canvas-extent
+    # request (S_INTERSECTS + a BBOX() literal), cql2-text encoded.
+    items = await client.get(
+        f"/collections/{filter_dataset.id}/items",
+        params={
+            "filter": f"S_INTERSECTS(geometry,BBOX({','.join(str(v) for v in BBOX_12)}))",
+            "filter-lang": "cql2-text",
+        },
+    )
+    assert items.status_code == 200, items.text
+    body = items.json()
+    assert body["numberMatched"] == 2
+    names = {f["properties"]["name"] for f in body["features"]}
+    assert names == {"Alpha", "Beta"}

--- a/backend/tests/test_ogc_features_filter.py
+++ b/backend/tests/test_ogc_features_filter.py
@@ -20,6 +20,7 @@ unadvertised until it worked:
 import json
 import uuid
 from datetime import datetime
+from urllib.parse import urlparse
 
 import pytest
 from httpx import AsyncClient
@@ -909,7 +910,11 @@ async def test_filter_still_rejected_without_value_types(
 async def test_qgis_344_request_sequence_end_to_end(
     client: AsyncClient, filter_dataset: Dataset
 ):
-    # 1. Landing page: QGIS follows rel=conformance from here.
+    # 1. Landing page: QGIS follows rel=conformance from here. Fetch the next
+    # leg via the *discovered* href's path (fix(#1680 codex r1): a hard-coded
+    # "/conformance" request would still land on the right route even if
+    # PUBLIC_API_URL produced a wrong scheme/host/prefix, silently defeating
+    # the whole point of replaying advertised links).
     landing = await client.get("/")
     assert landing.status_code == 200
     conformance_href = next(
@@ -920,7 +925,7 @@ async def test_qgis_344_request_sequence_end_to_end(
     # 2. Conformance: gates mServerSupportsFilterCql2Text (base push-down) AND
     # mServerSupportsBasicSpatialFunctions (spatial predicate push-down), per
     # qgis/QGIS#62156 (see test_ogc_discovery.py for the full URI-by-URI pin).
-    conformance = await client.get("/conformance")
+    conformance = await client.get(urlparse(conformance_href).path)
     assert conformance.status_code == 200
     conforms_to = set(conformance.json()["conformsTo"])
     required = {
@@ -942,8 +947,9 @@ async def test_qgis_344_request_sequence_end_to_end(
     )
     assert queryables_href.endswith(f"/collections/{filter_dataset.id}/queryables")
 
-    # 4. Queryables: QGIS builds its field list + geometry queryable from this.
-    queryables = await client.get(f"/collections/{filter_dataset.id}/queryables")
+    # 4. Queryables: QGIS builds its field list + geometry queryable from
+    # this -- again via the discovered href's path, not a re-typed one.
+    queryables = await client.get(urlparse(queryables_href).path)
     assert queryables.status_code == 200
     props = queryables.json()["properties"]
     assert "geometry" in props

--- a/backend/tests/test_ogc_features_filter.py
+++ b/backend/tests/test_ogc_features_filter.py
@@ -937,15 +937,21 @@ async def test_qgis_344_request_sequence_end_to_end(
     }
     assert required <= conforms_to
 
-    # 3. Collection metadata: QGIS resolves the queryables link from here.
+    # 3. Collection metadata: QGIS resolves the queryables AND items links
+    # from here -- neither is a path the client is allowed to assume.
     collection = await client.get(f"/collections/{filter_dataset.id}")
     assert collection.status_code == 200
+    collection_links = collection.json()["links"]
     queryables_href = next(
         link["href"]
-        for link in collection.json()["links"]
+        for link in collection_links
         if link["rel"] == "http://www.opengis.net/def/rel/ogc/1.0/queryables"
     )
     assert queryables_href.endswith(f"/collections/{filter_dataset.id}/queryables")
+    items_href = next(
+        link["href"] for link in collection_links if link["rel"] == "items"
+    )
+    assert items_href.endswith(f"/collections/{filter_dataset.id}/items")
 
     # 4. Queryables: QGIS builds its field list + geometry queryable from
     # this -- again via the discovered href's path, not a re-typed one.
@@ -957,9 +963,11 @@ async def test_qgis_344_request_sequence_end_to_end(
 
     # 5. Items with a pushed-down spatial predicate, exactly as QGIS's
     # QgsOapifCql2TextExpressionCompiler emits it for a map-canvas-extent
-    # request (S_INTERSECTS + a BBOX() literal), cql2-text encoded.
+    # request (S_INTERSECTS + a BBOX() literal), cql2-text encoded. fix(#1680
+    # codex r2): issued against the discovered items_href's path, not a
+    # re-typed one -- same rationale as the conformance/queryables legs above.
     items = await client.get(
-        f"/collections/{filter_dataset.id}/items",
+        urlparse(items_href).path,
         params={
             "filter": f"S_INTERSECTS(geometry,BBOX({','.join(str(v) for v in BBOX_12)}))",
             "filter-lang": "cql2-text",


### PR DESCRIPTION
## Summary

Verified GeoLens's OGC API Features conformance advertisement against the exact QGIS >=3.44 requirement, before touching any code. Ground truth came from the merged fix itself: qgis/QGIS#62156 (merged 2025-06-05, first released in QGIS 3.44) patched `QgsOapifProvider::init()` (`src/providers/wfs/oapif/qgsoapifprovider.cpp`) to recognize the final-spec conformance class name `cql2/1.0/conf/basic-spatial-functions`, where it previously only recognized the deprecated draft name `cql2/{0.0,1.0}/conf/basic-spatial-operators`.

Reading that function directly shows two independent capability flags gate whether QGIS pushes a CQL2 filter server-side at all:

- `mServerSupportsFilterCql2Text` (base gate for ANY push-down) requires ALL of: `cql2/{0.0,1.0}/conf/basic-cql2`, `ogcapi-features-3/{0.0,1.0}/conf/filter`, `ogcapi-features-3/{0.0,1.0}/conf/features-filter`, `cql2/{0.0,1.0}/conf/cql2-text`.
- `mServerSupportsBasicSpatialFunctions` (gates spatial `S_INTERSECTS`/`BBOX()`/`POINT()` push-down specifically — what #62156 fixed) requires `cql2/1.0/conf/basic-spatial-functions` (or the deprecated `basic-spatial-operators` name).

Cross-checked against the CQL2 spec itself (`opengeospatial/ogcapi-features`, `cql2/standard/requirements/basic-spatial-functions/REQ_spatial-functions.adoc`): the `basic-spatial-functions` requirement class mandates only `S_INTERSECTS`, which matches what `backend/app/standards/ogc/filtering.py` implements (GeoLens actually supports the whole spatial-comparison family, a superset, and explicitly rejects `S_DWITHIN`/`S_BEYOND`, which belong to a different, unadvertised class).

**Result: GeoLens's current conformance list (`backend/app/standards/ogc/router.py`, from #1674/#1614) already advertises every one of the 5 required 1.0 URIs.** Both QGIS capability flags already evaluate `true`. No conformance-list change is honest to make, so this PR is test-only.

## Changes

- `backend/tests/test_ogc_discovery.py`: `test_conformance_pins_qgis_344_cql2_pushdown_classes` — pins the exact 5-URI set, cites qgis/QGIS#62156 and documents the two-flag detection logic in a comment.
- `backend/tests/test_ogc_features_filter.py`: `test_qgis_344_request_sequence_end_to_end` — replays the actual QGIS request sequence (landing → conformance → collection → queryables → items with a pushed-down `S_INTERSECTS(...)` filter, `filter-lang=cql2-text`) against the test app and asserts the conformance set plus correct filtered results.

Both tests guard against a future conformance-list edit silently breaking QGIS filter push-down — a regression here produces no error anywhere; QGIS just falls back to slow client-side filtering.

## Verification

```
cd backend && set -a && source ../.env.test && set +a && uv run pytest tests/test_ogc_features_filter.py tests/test_ogc_discovery.py -v   # 90 passed
uv run pytest tests/test_layering.py -q   # 47 passed
uv run ruff check .
uv run ruff format --check .
```

No product code changed, so `backend/openapi.json` and generated SDKs are unaffected.

https://claude.ai/code/session_01BXUUv3x71zWaLKEvoL4cTY