### PR TITLE
feat(export): add FlatGeobuf export format

### DIFF
--- a/backend/alembic/versions/0054_backfill_flatgeobuf_distributions.py
+++ b/backend/alembic/versions/0054_backfill_flatgeobuf_distributions.py
@@ -1,0 +1,83 @@
+"""Backfill FlatGeobuf download distributions for existing spatial datasets.
+
+fix(#1681 codex review): _DISTRIBUTION_TEMPLATES now generates a FlatGeobuf
+download distribution at dataset creation (records/service.py), but those rows
+are materialized — existing spatial datasets created before this deploy would
+never advertise the fgb download in DCAT feeds until an unrelated geometry-mode
+flip happened to run reconcile. This backfills one row per spatial dataset that
+lacks it, so DCAT distributions match what a fresh ingest produces. Mirrors
+0013_backfill_geoparquet_distributions.py, the precedent for adding a format to
+this materialized list.
+
+Idempotent: the NOT EXISTS guard (plus ON CONFLICT DO NOTHING against
+uq_record_distribution) makes re-running a no-op. Downgrade removes only the
+auto-generated fgb download rows.
+
+Non-spatial datasets are excluded (geometry_type IS NULL) — FlatGeobuf
+requires geometry, matching generate_distributions' spatial-only filter.
+
+fix(#1681 codex review round 2): the NOT EXISTS guard reads only
+auto_generated rows, matching generate_distributions' own existence probe
+(fix(#1370) there) — a user-authored download/fgb row must not suppress the
+platform's own export row; the intended end state is both rows coexisting.
+Narrowing the guard reopens the case that broad check was incidentally
+absorbing: a user's row at the exact guessable URL this INSERT targets
+(`/datasets/{id}/export?format=fgb`) collides on uq_record_distribution, so
+the INSERT carries `ON CONFLICT DO NOTHING` — the same resolution
+`reconcile_distributions` uses for the identical collision at runtime (see
+`TestATemplateUrlCollisionDoesNotRaise` in
+test_distribution_reconcile_1314.py).
+
+Revises 0053_source_format_fgb (#1682, merged concurrently) rather than a
+core revision authored alongside this one: that PR's own migration already
+covers letting 'fgb' through chk_datasets_source_format, so this file is
+scoped to the (unrelated) DCAT distribution gap only.
+
+Revision ID: 0054_backfill_flatgeobuf_distributions
+Revises: 0053_source_format_fgb
+Create Date: 2026-08-26
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = "0054_backfill_flatgeobuf_distributions"
+down_revision: Union[str, None] = "0053_source_format_fgb"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        INSERT INTO catalog.record_distributions
+            (record_id, distribution_type, format, url, title, protocol,
+             media_type, is_primary, auto_generated)
+        SELECT d.record_id, 'download', 'fgb',
+               '/datasets/' || d.id::text || '/export?format=fgb',
+               'FlatGeobuf Download', 'HTTP',
+               'application/vnd.flatgeobuf', false, true
+        FROM catalog.datasets d
+        WHERE d.geometry_type IS NOT NULL
+          AND NOT EXISTS (
+              SELECT 1 FROM catalog.record_distributions rd
+              WHERE rd.record_id = d.record_id
+                AND rd.distribution_type = 'download'
+                AND rd.format = 'fgb'
+                AND rd.auto_generated = true
+          )
+        ON CONFLICT ON CONSTRAINT uq_record_distribution DO NOTHING
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        """
+        DELETE FROM catalog.record_distributions
+        WHERE distribution_type = 'download'
+          AND format = 'fgb'
+          AND auto_generated = true
+        """
+    )

--- a/backend/app/modules/catalog/records/service.py
+++ b/backend/app/modules/catalog/records/service.py
@@ -613,6 +613,15 @@ _DISTRIBUTION_TEMPLATES = [
         False,
     ),
     (
+        "download",
+        "fgb",
+        "/datasets/{dataset_id}/export?format=fgb",
+        "FlatGeobuf Download",
+        "HTTP",
+        "application/vnd.flatgeobuf",
+        False,
+    ),
+    (
         "ogc_features",
         "geojson",
         "/collections/{dataset_id}/items",
@@ -692,8 +701,9 @@ async def generate_distributions(
 ) -> list[RecordDistribution]:
     """Generate standard distribution records for a dataset.
 
-    For spatial datasets (geometry_type is not None): creates 7 distribution rows
-    (5 download formats incl. GeoParquet + OGC features + vector tiles).
+    For spatial datasets (geometry_type is not None): creates 8 distribution rows
+    (6 download formats incl. GeoParquet and FlatGeobuf + OGC features + vector
+    tiles).
     For non-spatial datasets (geometry_type is None): creates only csv download
     + OGC features (2 rows).
 

--- a/backend/app/modules/catalog/search/service_records.py
+++ b/backend/app/modules/catalog/search/service_records.py
@@ -40,6 +40,7 @@ _FORMAT_MEDIA = {
     "shp": "application/x-shapefile",
     "csv": "text/csv",
     "parquet": "application/vnd.apache.parquet",
+    "fgb": "application/vnd.flatgeobuf",
 }
 
 _RASTER_FORMAT_MEDIA = {

--- a/backend/app/processing/export/ogr.py
+++ b/backend/app/processing/export/ogr.py
@@ -49,6 +49,19 @@ FORMAT_MAP: dict[str, dict[str, str]] = {
         "ext": ".csv",
         "media": "text/csv",
     },
+    # FlatGeobuf has no IANA registration. `application/vnd.flatgeobuf` is the
+    # vendor-prefixed type the format's own maintainers proposed
+    # (flatgeobuf/flatgeobuf#112) after an OGC standardization attempt stalled,
+    # and it is the same vendor-prefix pattern this table already uses for
+    # GeoParquet (PARQUET_MEDIA_TYPE below) for the identical reason. It is a
+    # single file like GeoJSON/GPKG/CSV, not multi-file like Shapefile, so it
+    # must NOT be added to the `format_key == "shp"` zip special-casing in
+    # service.py.
+    "fgb": {
+        "driver": "FlatGeobuf",
+        "ext": ".fgb",
+        "media": "application/vnd.flatgeobuf",
+    },
 }
 
 

--- a/backend/app/processing/export/router.py
+++ b/backend/app/processing/export/router.py
@@ -328,9 +328,9 @@ async def export_dataset_endpoint(
 ) -> Response:
     """Export a dataset as a downloadable file.
 
-    Supports GeoPackage, GeoJSON, Shapefile (zipped), CSV, and GeoParquet
-    formats. Optional CRS reprojection, spatial filtering, and attribute
-    filtering. GeoParquet is always emitted in EPSG:4326 (OGC:CRS84).
+    Supports GeoPackage, GeoJSON, Shapefile (zipped), CSV, GeoParquet, and
+    FlatGeobuf formats. Optional CRS reprojection, spatial filtering, and
+    attribute filtering. GeoParquet is always emitted in EPSG:4326 (OGC:CRS84).
     """
     port = get_processing_port()
     data_schema = tenant_data_schema(current_tenant_var.get())
@@ -436,6 +436,7 @@ async def export_dataset_endpoint(
         "geojson",
         "shp",
         "parquet",
+        "fgb",
     ):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,

--- a/backend/app/processing/export/schemas.py
+++ b/backend/app/processing/export/schemas.py
@@ -9,3 +9,4 @@ class ExportFormat(StrEnum):
     shp = "shp"
     csv = "csv"
     parquet = "parquet"
+    fgb = "fgb"

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -7398,7 +7398,8 @@
           "geojson",
           "shp",
           "csv",
-          "parquet"
+          "parquet",
+          "fgb"
         ],
         "title": "ExportFormat",
         "type": "string"
@@ -34072,7 +34073,7 @@
     },
     "/datasets/{dataset_id}/export": {
       "get": {
-        "description": "Export a dataset as a downloadable file.\n\nSupports GeoPackage, GeoJSON, Shapefile (zipped), CSV, and GeoParquet\nformats. Optional CRS reprojection, spatial filtering, and attribute\nfiltering. GeoParquet is always emitted in EPSG:4326 (OGC:CRS84).",
+        "description": "Export a dataset as a downloadable file.\n\nSupports GeoPackage, GeoJSON, Shapefile (zipped), CSV, GeoParquet, and\nFlatGeobuf formats. Optional CRS reprojection, spatial filtering, and\nattribute filtering. GeoParquet is always emitted in EPSG:4326 (OGC:CRS84).",
         "operationId": "export_dataset_endpoint_datasets__dataset_id__export_get",
         "parameters": [
           {

--- a/backend/tests/test_dataset_source_state.py
+++ b/backend/tests/test_dataset_source_state.py
@@ -1800,6 +1800,7 @@ class TestReuploadReconcilesDistributions:
             ("download", "shp"),
             ("download", "parquet"),
             ("download", "csv"),
+            ("download", "fgb"),
             ("ogc_features", "geojson"),
             ("vector_tiles", "pbf"),
         }

--- a/backend/tests/test_distribution_reconcile_1314.py
+++ b/backend/tests/test_distribution_reconcile_1314.py
@@ -53,6 +53,7 @@ _SPATIAL_PAIRS = {
     ("download", "shp"),
     ("download", "parquet"),
     ("download", "csv"),
+    ("download", "fgb"),
     ("ogc_features", "geojson"),
     ("vector_tiles", "pbf"),
 }

--- a/backend/tests/test_export.py
+++ b/backend/tests/test_export.py
@@ -520,6 +520,40 @@ class TestExportFormats:
         assert resp.status_code == 200
         assert "text/csv" in resp.headers["content-type"]
 
+    @pytest.mark.anyio
+    async def test_export_format_fgb(
+        self, client: AsyncClient, admin_auth_header: dict, test_db_session
+    ):
+        """Request with format=fgb returns 200 with the FlatGeobuf Content-Type."""
+        admin_id = await get_user_id(test_db_session, "admin")
+        ds = await _create_dataset(test_db_session, created_by=admin_id, name="FgbDS")
+        resp = await client.get(
+            f"/datasets/{ds.id}/export",
+            params={"format": "fgb"},
+            headers=admin_auth_header,
+        )
+        assert resp.status_code == 200
+        assert "vnd.flatgeobuf" in resp.headers["content-type"]
+
+    @pytest.mark.anyio
+    async def test_export_non_spatial_dataset_fgb_returns_400(
+        self, client: AsyncClient, admin_auth_header: dict, test_db_session
+    ):
+        """FlatGeobuf is a spatial-only format, like gpkg/geojson/shp/parquet."""
+        admin_id = await get_user_id(test_db_session, "admin")
+        ds = await _create_dataset(
+            test_db_session,
+            created_by=admin_id,
+            name="NonSpatialFgbDS",
+            geometry_type=None,
+        )
+        resp = await client.get(
+            f"/datasets/{ds.id}/export",
+            params={"format": "fgb"},
+            headers=admin_auth_header,
+        )
+        assert resp.status_code == 400
+
 
 # ---------------------------------------------------------------------------
 # Audit tests

--- a/backend/tests/test_flatgeobuf_distribution_backfill_1681.py
+++ b/backend/tests/test_flatgeobuf_distribution_backfill_1681.py
@@ -1,0 +1,345 @@
+"""Migration 0054's backfill of the FlatGeobuf download distribution (#1681).
+
+``_DISTRIBUTION_TEMPLATES`` (records/service.py) now generates an ``fgb``
+download row at dataset creation, mirroring 0013's GeoParquet precedent —
+but that table is only consulted by ``generate_distributions()``, so a
+spatial dataset that existed before this migration's deploy never gets the
+row until an unrelated geometry-mode flip happens to run reconcile. This
+covers the migration that closes that gap for datasets already in the
+database.
+
+The round trip is real — ``alembic downgrade`` to 0054's own predecessor
+(0054's downgrade deletes exactly the auto-generated ``fgb`` download rows,
+which is also what a dataset created via ``generate_distributions`` already
+holds) followed by ``alembic upgrade head`` re-runs the backfill over rows
+this test committed first, through the same alembic.ini/env.py stack CI
+uses.
+
+Run with: cd backend && set -a && source ../.env.test && set +a &&
+          uv run pytest tests/test_flatgeobuf_distribution_backfill_1681.py -x -q
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from app.modules.catalog.records.service import create_distribution
+from tests.alembic_helpers import (
+    enterprise_migrations_present,
+    fresh_query as _fresh_query,
+    run_alembic as _run_alembic,
+)
+from tests.factories import create_dataset, get_user_id
+
+pytestmark = pytest.mark.anyio
+
+
+_SKIP_UNDER_OVERLAY = pytest.mark.skipif(
+    enterprise_migrations_present(),
+    reason=(
+        "OSS migration round trip; multi-head under the enterprise overlay — "
+        "runs in the no-overlay Pytest Parallel Isolation job instead."
+    ),
+)
+
+
+def _migration_0054():
+    """The migration module this file is about, loaded for its own constants.
+
+    Copying the down_revision out by hand would let the two drift silently.
+    """
+    import importlib.util
+    from pathlib import Path
+
+    path = (
+        Path(__file__).resolve().parents[1]
+        / "alembic"
+        / "versions"
+        / "0054_backfill_flatgeobuf_distributions.py"
+    )
+    spec = importlib.util.spec_from_file_location("migration_0054", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _revision_below_0054() -> str:
+    """The revision 0054 sits on, read from 0054's own ``down_revision``.
+
+    fix(#1383 precedent): a bare ``downgrade -1`` reverts whatever the
+    CURRENT head is, so it silently steps over 0054 the moment a later
+    migration lands on top. Naming the target keeps this test about its own
+    migration whatever else is stacked above it.
+    """
+    return _migration_0054().down_revision
+
+
+@_SKIP_UNDER_OVERLAY
+class TestFlatgeobufDistributionBackfill:
+    async def test_a_spatial_dataset_missing_the_row_is_backfilled(
+        self, test_db_session
+    ) -> None:
+        """The case the migration exists for.
+
+        ``tests.factories.create_dataset`` inserts the Record/Dataset pair
+        directly — no ``generate_distributions`` call — so this dataset
+        starts with zero distribution rows, exactly the shape of a dataset
+        that predates the fgb template entry entirely.
+        """
+        admin_id = await get_user_id(test_db_session, "admin")
+        dataset = await create_dataset(
+            test_db_session,
+            created_by=admin_id,
+            name=f"fgb backfill spatial {uuid.uuid4().hex[:8]}",
+            geometry_type="MultiPolygon",
+        )
+        await test_db_session.commit()
+
+        try:
+            target = _revision_below_0054()
+            down = _run_alembic("downgrade", target)
+            assert down.returncode == 0, (
+                f"alembic downgrade {target} failed (rc={down.returncode}):\n"
+                f"stdout: {down.stdout}\nstderr: {down.stderr}"
+            )
+            up = _run_alembic("upgrade", "head")
+            assert up.returncode == 0, (
+                f"alembic upgrade head failed (rc={up.returncode}):\n"
+                f"stdout: {up.stdout}\nstderr: {up.stderr}"
+            )
+
+            rows = await _fresh_query(
+                "SELECT format, url, title, protocol, media_type, is_primary, "
+                "auto_generated FROM catalog.record_distributions "
+                "WHERE record_id = :record_id AND distribution_type = 'download' "
+                "AND format = 'fgb'",
+                {"record_id": dataset.record_id},
+            )
+            assert len(rows) == 1, (
+                f"expected exactly one backfilled fgb row, got {len(rows)}"
+            )
+            row = rows[0]
+            assert row.url == f"/datasets/{dataset.id}/export?format=fgb"
+            assert row.media_type == "application/vnd.flatgeobuf"
+            assert row.auto_generated is True
+            assert row.is_primary is False
+        finally:
+            await _fresh_query(
+                "DELETE FROM catalog.record_distributions WHERE record_id = :r",
+                {"r": dataset.record_id},
+            )
+            await _fresh_query(
+                "DELETE FROM catalog.datasets WHERE id = :d", {"d": dataset.id}
+            )
+            await _fresh_query(
+                "DELETE FROM catalog.records WHERE id = :r",
+                {"r": dataset.record_id},
+            )
+
+    async def test_a_non_spatial_dataset_is_left_alone(self, test_db_session) -> None:
+        """The predicate excludes geometry_type IS NULL, like generate_distributions."""
+        admin_id = await get_user_id(test_db_session, "admin")
+        dataset = await create_dataset(
+            test_db_session,
+            created_by=admin_id,
+            name=f"fgb backfill nonspatial {uuid.uuid4().hex[:8]}",
+            geometry_type=None,
+        )
+        await test_db_session.commit()
+
+        try:
+            target = _revision_below_0054()
+            down = _run_alembic("downgrade", target)
+            assert down.returncode == 0
+            up = _run_alembic("upgrade", "head")
+            assert up.returncode == 0
+
+            rows = await _fresh_query(
+                "SELECT id FROM catalog.record_distributions "
+                "WHERE record_id = :record_id AND distribution_type = 'download' "
+                "AND format = 'fgb'",
+                {"record_id": dataset.record_id},
+            )
+            assert len(rows) == 0, (
+                "a non-spatial dataset must never get an fgb download row"
+            )
+        finally:
+            await _fresh_query(
+                "DELETE FROM catalog.record_distributions WHERE record_id = :r",
+                {"r": dataset.record_id},
+            )
+            await _fresh_query(
+                "DELETE FROM catalog.datasets WHERE id = :d", {"d": dataset.id}
+            )
+            await _fresh_query(
+                "DELETE FROM catalog.records WHERE id = :r",
+                {"r": dataset.record_id},
+            )
+
+    async def test_rerunning_the_backfill_is_a_no_op(self, test_db_session) -> None:
+        """Idempotent: NOT EXISTS plus the unique constraint make a second run inert."""
+        admin_id = await get_user_id(test_db_session, "admin")
+        dataset = await create_dataset(
+            test_db_session,
+            created_by=admin_id,
+            name=f"fgb backfill idempotent {uuid.uuid4().hex[:8]}",
+            geometry_type="MultiPolygon",
+        )
+        await test_db_session.commit()
+
+        try:
+            target = _revision_below_0054()
+            assert _run_alembic("downgrade", target).returncode == 0
+            assert _run_alembic("upgrade", "head").returncode == 0
+            assert _run_alembic("upgrade", "head").returncode == 0
+
+            rows = await _fresh_query(
+                "SELECT id FROM catalog.record_distributions "
+                "WHERE record_id = :record_id AND distribution_type = 'download' "
+                "AND format = 'fgb'",
+                {"record_id": dataset.record_id},
+            )
+            assert len(rows) == 1, (
+                "running the backfill twice must not duplicate the row"
+            )
+        finally:
+            await _fresh_query(
+                "DELETE FROM catalog.record_distributions WHERE record_id = :r",
+                {"r": dataset.record_id},
+            )
+            await _fresh_query(
+                "DELETE FROM catalog.datasets WHERE id = :d", {"d": dataset.id}
+            )
+            await _fresh_query(
+                "DELETE FROM catalog.records WHERE id = :r",
+                {"r": dataset.record_id},
+            )
+
+    async def test_a_users_own_fgb_row_does_not_suppress_the_platform_row(
+        self, test_db_session
+    ) -> None:
+        """codex review round 2: the NOT EXISTS guard must read auto_generated only.
+
+        ``generate_distributions`` deliberately probes only auto-generated
+        rows (fix(#1370)) so a user's own download/fgb entry at some other URL
+        never blocks the platform's own export row — both are meant to
+        coexist. A migration that checked ANY row would leave this dataset
+        permanently missing the platform row after an upgrade.
+        """
+        admin_id = await get_user_id(test_db_session, "admin")
+        dataset = await create_dataset(
+            test_db_session,
+            created_by=admin_id,
+            name=f"fgb backfill user-row {uuid.uuid4().hex[:8]}",
+            geometry_type="MultiPolygon",
+        )
+        await create_distribution(
+            test_db_session,
+            dataset.record_id,
+            distribution_type="download",
+            format="fgb",
+            url="https://example.org/mine.fgb",
+        )
+        await test_db_session.commit()
+
+        try:
+            target = _revision_below_0054()
+            assert _run_alembic("downgrade", target).returncode == 0
+            up = _run_alembic("upgrade", "head")
+            assert up.returncode == 0, (
+                f"alembic upgrade head failed (rc={up.returncode}):\n"
+                f"stdout: {up.stdout}\nstderr: {up.stderr}"
+            )
+
+            rows = await _fresh_query(
+                "SELECT url, auto_generated FROM catalog.record_distributions "
+                "WHERE record_id = :record_id AND distribution_type = 'download' "
+                "AND format = 'fgb'",
+                {"record_id": dataset.record_id},
+            )
+            by_url = {row.url: row.auto_generated for row in rows}
+            assert by_url.get("https://example.org/mine.fgb") is False, (
+                "the user's own row must survive untouched"
+            )
+            assert by_url.get(f"/datasets/{dataset.id}/export?format=fgb") is True, (
+                "the platform row must still be backfilled alongside it"
+            )
+            assert len(rows) == 2
+        finally:
+            await _fresh_query(
+                "DELETE FROM catalog.record_distributions WHERE record_id = :r",
+                {"r": dataset.record_id},
+            )
+            await _fresh_query(
+                "DELETE FROM catalog.datasets WHERE id = :d", {"d": dataset.id}
+            )
+            await _fresh_query(
+                "DELETE FROM catalog.records WHERE id = :r",
+                {"r": dataset.record_id},
+            )
+
+    async def test_a_user_row_at_the_template_url_does_not_raise(
+        self, test_db_session
+    ) -> None:
+        """The collision the narrowed guard reopens (codex review round 2).
+
+        A user row at the exact guessable URL the INSERT targets collides on
+        ``uq_record_distribution`` once the existence check no longer treats
+        it as "the pair is taken". ``ON CONFLICT DO NOTHING`` resolves it the
+        same way ``reconcile_distributions`` does at runtime (see
+        ``TestATemplateUrlCollisionDoesNotRaise`` in
+        test_distribution_reconcile_1314.py) — the migration must not raise,
+        and must not leave two rows fighting over one URL.
+        """
+        admin_id = await get_user_id(test_db_session, "admin")
+        dataset = await create_dataset(
+            test_db_session,
+            created_by=admin_id,
+            name=f"fgb backfill url-collision {uuid.uuid4().hex[:8]}",
+            geometry_type="MultiPolygon",
+        )
+        await create_distribution(
+            test_db_session,
+            dataset.record_id,
+            distribution_type="download",
+            format="fgb",
+            url=f"/datasets/{dataset.id}/export?format=fgb",
+        )
+        await test_db_session.commit()
+
+        try:
+            target = _revision_below_0054()
+            assert _run_alembic("downgrade", target).returncode == 0
+            up = _run_alembic("upgrade", "head")
+            assert up.returncode == 0, (
+                f"alembic upgrade head failed (rc={up.returncode}):\n"
+                f"stdout: {up.stdout}\nstderr: {up.stderr}"
+            )
+
+            rows = await _fresh_query(
+                "SELECT url, auto_generated FROM catalog.record_distributions "
+                "WHERE record_id = :record_id AND distribution_type = 'download' "
+                "AND format = 'fgb'",
+                {"record_id": dataset.record_id},
+            )
+            assert len(rows) == 1, (
+                f"expected the user's row to be the only survivor, got {rows}"
+            )
+            assert rows[0].auto_generated is False, (
+                "the user's row at the template URL must not be overwritten"
+            )
+        finally:
+            await _fresh_query(
+                "DELETE FROM catalog.record_distributions WHERE record_id = :r",
+                {"r": dataset.record_id},
+            )
+            await _fresh_query(
+                "DELETE FROM catalog.datasets WHERE id = :d", {"d": dataset.id}
+            )
+            await _fresh_query(
+                "DELETE FROM catalog.records WHERE id = :r",
+                {"r": dataset.record_id},
+            )

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1675,7 +1675,9 @@ def test_decomposed_service_modules_stay_within_size_budgets() -> None:
         # exposes the storage layout). One is_publishable_url guard plus the
         # comment saying why this profile drops the row instead of replacing it
         # — build_assets already advertises raster access here. Cap 519 -> 524.
-        "backend/app/modules/catalog/search/service_records.py": 524,
+        # feat(#1681): +1 — FlatGeobuf joined _FORMAT_MEDIA alongside every
+        # other export format. Cap 524 -> 525, exact.
+        "backend/app/modules/catalog/search/service_records.py": 525,
         # fix(#448): +~40 LOC — query-embedding hot-path deadline (asyncio.wait_for
         # wrapper) + the gated/approximated vector-only match COUNT in
         # _run_rrf_merge (perf audit 2026-07-10 §2d). Cap 350 → 390
@@ -3886,7 +3888,11 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # worth more than the six lines. Cap at the exact size; the module is
     # otherwise a stable set of CRUD helpers over the record's related tables
     # and is not where new domains should land.
-    "backend/app/modules/catalog/records/service.py": 1007,
+    # feat(#1681): +10 — the FlatGeobuf export format joined
+    # `_DISTRIBUTION_TEMPLATES` (a download row, matching every other export
+    # format already in that table) plus a docstring update to the row count
+    # it now generates.
+    "backend/app/modules/catalog/records/service.py": 1017,
     # fix(#1528): crossed the inclusion threshold, and this is the file the
     # inclusion rule's own comment named as one of the two "routers-by-role the
     # glob's filename match cannot see ... watched by nothing until they cross

--- a/backend/tests/test_ogc_record_properties.py
+++ b/backend/tests/test_ogc_record_properties.py
@@ -99,12 +99,13 @@ async def test_record_has_formats_list(client: AsyncClient, test_db_session):
     assert "formats" in props
     formats = props["formats"]
     assert isinstance(formats, list)
-    assert len(formats) == 5
+    assert len(formats) == 6
     assert "application/geopackage+sqlite3" in formats
     assert "application/geo+json" in formats
     assert "application/x-shapefile" in formats
     assert "text/csv" in formats
     assert "application/vnd.apache.parquet" in formats
+    assert "application/vnd.flatgeobuf" in formats
 
 
 # ---------------------------------------------------------------------------
@@ -509,7 +510,7 @@ async def test_vector_record_formats_includes_shapefile(
     props = resp.json()["properties"]
     formats = props["formats"]
     assert "application/x-shapefile" in formats
-    assert len(formats) == 5
+    assert len(formats) == 6
 
 
 @pytest.mark.anyio

--- a/backend/tests/test_postgis_refresh_1265.py
+++ b/backend/tests/test_postgis_refresh_1265.py
@@ -1187,6 +1187,7 @@ class TestPostgisRefreshExecution:
             ("download", "shp"),
             ("download", "parquet"),
             ("download", "csv"),
+            ("download", "fgb"),
             ("ogc_features", "geojson"),
             ("vector_tiles", "pbf"),
         }

--- a/backend/tests/test_records_related.py
+++ b/backend/tests/test_records_related.py
@@ -738,7 +738,7 @@ class TestDistributions:
         admin_auth_header: dict,
         test_db_session: AsyncSession,
     ):
-        """Dataset created via service gets 6 auto-generated distributions."""
+        """Dataset created via service gets 8 auto-generated distributions."""
         admin_id = await get_user_id(test_db_session, "admin")
         ds = await _create_dataset_with_distributions(
             test_db_session, created_by=admin_id
@@ -748,7 +748,7 @@ class TestDistributions:
         )
         assert resp.status_code == 200
         data = resp.json()
-        assert data["total"] == 7
+        assert data["total"] == 8
 
         # All auto_generated
         for d in data["distributions"]:
@@ -1048,7 +1048,7 @@ class TestDistributions:
             geometry_type="MultiPolygon",
         )
         await test_db_session.commit()
-        assert len(created1) == 7
+        assert len(created1) == 8
 
         # Second generation (idempotent)
         created2 = await generate_distributions(
@@ -1061,11 +1061,11 @@ class TestDistributions:
         await test_db_session.commit()
         assert len(created2) == 0  # No new rows
 
-        # Still only 7 total
+        # Still only 8 total
         resp = await client.get(
             f"/records/{ds.record_id}/distributions/", headers=admin_auth_header
         )
-        assert resp.json()["total"] == 7
+        assert resp.json()["total"] == 8
 
     async def test_distribution_lifecycle_modes(
         self,
@@ -1093,11 +1093,11 @@ class TestDistributions:
         assert manual_resp.status_code == 201
         manual_id = manual_resp.json()["id"]
 
-        # Total: 7 system + 1 manual = 8
+        # Total: 8 system + 1 manual = 9
         list_resp = await client.get(
             f"/records/{ds.record_id}/distributions/", headers=admin_auth_header
         )
-        assert list_resp.json()["total"] == 8
+        assert list_resp.json()["total"] == 9
 
         # System distributions are immutable
         auto_dist = next(
@@ -1223,7 +1223,7 @@ class TestCascadeDelete:
         pre_result = await test_db_session.execute(
             select(RecordDistribution).where(RecordDistribution.record_id == record_id)
         )
-        assert len(pre_result.all()) == 7
+        assert len(pre_result.all()) == 8
 
         await client.request(
             "DELETE",
@@ -1322,7 +1322,7 @@ class TestMigrationData:
             )
         )
         download_dists = result.scalars().all()
-        assert len(download_dists) == 5
+        assert len(download_dists) == 6
 
         for d in download_dists:
             assert dataset_id_str in d.url, (

--- a/frontend/src/components/dataset/ExportButton.tsx
+++ b/frontend/src/components/dataset/ExportButton.tsx
@@ -25,6 +25,7 @@ const EXPORT_FORMATS = [
   { value: 'shp', labelKey: 'export.shp', ext: 'zip' },
   { value: 'csv', labelKey: 'export.csv', ext: 'csv' },
   { value: 'parquet', labelKey: 'export.parquet', ext: 'parquet' },
+  { value: 'fgb', labelKey: 'export.fgb', ext: 'fgb' },
 ] as const;
 
 const CSV_ONLY = EXPORT_FORMATS.filter((f) => f.value === 'csv');

--- a/frontend/src/components/dataset/__tests__/ExportButton.test.tsx
+++ b/frontend/src/components/dataset/__tests__/ExportButton.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from '@/test/test-utils';
 import userEvent from '@testing-library/user-event';
 import { ExportButton } from '../ExportButton';
+import { downloadExport } from '@/api/datasets';
 
 vi.mock('@/api/datasets', () => ({
   downloadExport: vi.fn(),
@@ -17,16 +18,23 @@ beforeAll(() => {
 });
 
 describe('ExportButton', () => {
-  it('renders all 5 format options by default', async () => {
+  it('renders all 6 format options by default', async () => {
     const user = userEvent.setup();
     render(<ExportButton datasetId="ds-1" datasetName="test" />);
 
     await user.click(screen.getByRole('combobox'));
     const options = await screen.findAllByRole('option');
-    expect(options).toHaveLength(5);
+    expect(options).toHaveLength(6);
     const labels = options.map((o) => o.textContent);
     expect(labels).toEqual(
-      expect.arrayContaining(['GeoPackage', 'GeoJSON', 'Shapefile', 'CSV', 'GeoParquet']),
+      expect.arrayContaining([
+        'GeoPackage',
+        'GeoJSON',
+        'Shapefile',
+        'CSV',
+        'GeoParquet',
+        'FlatGeobuf',
+      ]),
     );
   });
 
@@ -51,6 +59,17 @@ describe('ExportButton', () => {
     // Path separator -> _, single quote doubled -> valid DuckDB string literal
     // that matches the browser-saved filename.
     expect(screen.getByText(/Bob''s Roads_2026\.parquet/)).toBeInTheDocument();
+  });
+
+  it('downloads FlatGeobuf with a .fgb extension', async () => {
+    const user = userEvent.setup();
+    render(<ExportButton datasetId="ds-1" datasetName="rivers" />);
+
+    await user.click(screen.getByRole('combobox'));
+    await user.click(await screen.findByRole('option', { name: 'FlatGeobuf' }));
+    await user.click(screen.getByRole('button', { name: /export/i }));
+
+    expect(downloadExport).toHaveBeenCalledWith('ds-1', 'fgb', 'rivers.fgb');
   });
 
   it('limits table datasets to CSV export', async () => {

--- a/frontend/src/i18n/locales/de/dataset.json
+++ b/frontend/src/i18n/locales/de/dataset.json
@@ -194,6 +194,7 @@
     "shp": "Shapefile",
     "csv": "CSV",
     "parquet": "GeoParquet",
+    "fgb": "FlatGeobuf",
     "duckdbHint": "Mit DuckDB abfragen",
     "button": "Exportieren",
     "failed": "Export fehlgeschlagen",

--- a/frontend/src/i18n/locales/en/dataset.json
+++ b/frontend/src/i18n/locales/en/dataset.json
@@ -194,6 +194,7 @@
     "shp": "Shapefile",
     "csv": "CSV",
     "parquet": "GeoParquet",
+    "fgb": "FlatGeobuf",
     "duckdbHint": "Query with DuckDB",
     "button": "Export",
     "failed": "Export failed",

--- a/frontend/src/i18n/locales/es/dataset.json
+++ b/frontend/src/i18n/locales/es/dataset.json
@@ -194,6 +194,7 @@
     "shp": "Shapefile",
     "csv": "CSV",
     "parquet": "GeoParquet",
+    "fgb": "FlatGeobuf",
     "duckdbHint": "Consultar con DuckDB",
     "button": "Exportar",
     "failed": "Exportación fallida",

--- a/frontend/src/i18n/locales/fr/dataset.json
+++ b/frontend/src/i18n/locales/fr/dataset.json
@@ -194,6 +194,7 @@
     "shp": "Shapefile",
     "csv": "CSV",
     "parquet": "GeoParquet",
+    "fgb": "FlatGeobuf",
     "duckdbHint": "Interroger avec DuckDB",
     "button": "Exporter",
     "failed": "Échec de l'exportation",

--- a/frontend/src/types/api.generated.ts
+++ b/frontend/src/types/api.generated.ts
@@ -2098,9 +2098,9 @@ export interface paths {
          * Export Dataset Endpoint
          * @description Export a dataset as a downloadable file.
          *
-         *     Supports GeoPackage, GeoJSON, Shapefile (zipped), CSV, and GeoParquet
-         *     formats. Optional CRS reprojection, spatial filtering, and attribute
-         *     filtering. GeoParquet is always emitted in EPSG:4326 (OGC:CRS84).
+         *     Supports GeoPackage, GeoJSON, Shapefile (zipped), CSV, GeoParquet, and
+         *     FlatGeobuf formats. Optional CRS reprojection, spatial filtering, and
+         *     attribute filtering. GeoParquet is always emitted in EPSG:4326 (OGC:CRS84).
          */
         get: operations["export_dataset_endpoint_datasets__dataset_id__export_get"];
         put?: never;
@@ -8383,7 +8383,7 @@ export interface components {
          * ExportFormat
          * @enum {string}
          */
-        ExportFormat: "gpkg" | "geojson" | "shp" | "csv" | "parquet";
+        ExportFormat: "gpkg" | "geojson" | "shp" | "csv" | "parquet" | "fgb";
         /**
          * FacetCountResponse
          * @description Multi-group facet counts for the search sidebar.

--- a/sdks/python/geolens/api/datasets/export_dataset_endpoint_datasets_dataset_id_export_get.py
+++ b/sdks/python/geolens/api/datasets/export_dataset_endpoint_datasets_dataset_id_export_get.py
@@ -147,9 +147,9 @@ def sync_detailed(
 
      Export a dataset as a downloadable file.
 
-    Supports GeoPackage, GeoJSON, Shapefile (zipped), CSV, and GeoParquet
-    formats. Optional CRS reprojection, spatial filtering, and attribute
-    filtering. GeoParquet is always emitted in EPSG:4326 (OGC:CRS84).
+    Supports GeoPackage, GeoJSON, Shapefile (zipped), CSV, GeoParquet, and
+    FlatGeobuf formats. Optional CRS reprojection, spatial filtering, and
+    attribute filtering. GeoParquet is always emitted in EPSG:4326 (OGC:CRS84).
 
     Args:
         dataset_id (UUID):
@@ -194,9 +194,9 @@ def sync(
 
      Export a dataset as a downloadable file.
 
-    Supports GeoPackage, GeoJSON, Shapefile (zipped), CSV, and GeoParquet
-    formats. Optional CRS reprojection, spatial filtering, and attribute
-    filtering. GeoParquet is always emitted in EPSG:4326 (OGC:CRS84).
+    Supports GeoPackage, GeoJSON, Shapefile (zipped), CSV, GeoParquet, and
+    FlatGeobuf formats. Optional CRS reprojection, spatial filtering, and
+    attribute filtering. GeoParquet is always emitted in EPSG:4326 (OGC:CRS84).
 
     Args:
         dataset_id (UUID):
@@ -236,9 +236,9 @@ async def asyncio_detailed(
 
      Export a dataset as a downloadable file.
 
-    Supports GeoPackage, GeoJSON, Shapefile (zipped), CSV, and GeoParquet
-    formats. Optional CRS reprojection, spatial filtering, and attribute
-    filtering. GeoParquet is always emitted in EPSG:4326 (OGC:CRS84).
+    Supports GeoPackage, GeoJSON, Shapefile (zipped), CSV, GeoParquet, and
+    FlatGeobuf formats. Optional CRS reprojection, spatial filtering, and
+    attribute filtering. GeoParquet is always emitted in EPSG:4326 (OGC:CRS84).
 
     Args:
         dataset_id (UUID):
@@ -281,9 +281,9 @@ async def asyncio(
 
      Export a dataset as a downloadable file.
 
-    Supports GeoPackage, GeoJSON, Shapefile (zipped), CSV, and GeoParquet
-    formats. Optional CRS reprojection, spatial filtering, and attribute
-    filtering. GeoParquet is always emitted in EPSG:4326 (OGC:CRS84).
+    Supports GeoPackage, GeoJSON, Shapefile (zipped), CSV, GeoParquet, and
+    FlatGeobuf formats. Optional CRS reprojection, spatial filtering, and
+    attribute filtering. GeoParquet is always emitted in EPSG:4326 (OGC:CRS84).
 
     Args:
         dataset_id (UUID):

--- a/sdks/python/geolens/models/export_format.py
+++ b/sdks/python/geolens/models/export_format.py
@@ -1,9 +1,10 @@
 from typing import Literal, cast
 
-ExportFormat = Literal["csv", "geojson", "gpkg", "parquet", "shp"]
+ExportFormat = Literal["csv", "fgb", "geojson", "gpkg", "parquet", "shp"]
 
 EXPORT_FORMAT_VALUES: set[ExportFormat] = {
     "csv",
+    "fgb",
     "geojson",
     "gpkg",
     "parquet",

--- a/sdks/typescript/src/client/sdk.gen.ts
+++ b/sdks/typescript/src/client/sdk.gen.ts
@@ -2201,9 +2201,9 @@ export const downloadCogDatasetsDatasetIdDownloadCogGet = <ThrowOnError extends 
  *
  * Export a dataset as a downloadable file.
  *
- * Supports GeoPackage, GeoJSON, Shapefile (zipped), CSV, and GeoParquet
- * formats. Optional CRS reprojection, spatial filtering, and attribute
- * filtering. GeoParquet is always emitted in EPSG:4326 (OGC:CRS84).
+ * Supports GeoPackage, GeoJSON, Shapefile (zipped), CSV, GeoParquet, and
+ * FlatGeobuf formats. Optional CRS reprojection, spatial filtering, and
+ * attribute filtering. GeoParquet is always emitted in EPSG:4326 (OGC:CRS84).
  */
 export const exportDatasetEndpointDatasetsDatasetIdExportGet = <ThrowOnError extends boolean = false>(options: Options<ExportDatasetEndpointDatasetsDatasetIdExportGetData, ThrowOnError>): RequestResult<ExportDatasetEndpointDatasetsDatasetIdExportGetResponses, ExportDatasetEndpointDatasetsDatasetIdExportGetErrors, ThrowOnError> => (options.client ?? client).get<ExportDatasetEndpointDatasetsDatasetIdExportGetResponses, ExportDatasetEndpointDatasetsDatasetIdExportGetErrors, ThrowOnError>({
     security: [

--- a/sdks/typescript/src/client/types.gen.ts
+++ b/sdks/typescript/src/client/types.gen.ts
@@ -4323,7 +4323,7 @@ export type EnterpriseTabsResponse = {
 /**
  * ExportFormat
  */
-export type ExportFormat = 'gpkg' | 'geojson' | 'shp' | 'csv' | 'parquet';
+export type ExportFormat = 'gpkg' | 'geojson' | 'shp' | 'csv' | 'parquet' | 'fgb';
 
 /**
  * FacetCountResponse


### PR DESCRIPTION
## Summary

Adds `fgb` (FlatGeobuf) to the dataset export endpoint's format list, alongside the existing GeoPackage, GeoJSON, Shapefile, CSV, and GeoParquet options.

- `ExportFormat` gains `fgb`; `FORMAT_MAP` gains a `fgb` entry (driver `FlatGeobuf`, ext `.fgb`).
- FlatGeobuf is a single-file format, like GeoJSON/GPKG/CSV — it deliberately does **not** go through the `format_key == "shp"` zip special-casing in `export/service.py`.
- Geometry-required gate in the router (`?format=fgb` on a non-spatial dataset returns 400, same as gpkg/geojson/shp/parquet) and the endpoint docstring both updated.
- Frontend: `ExportButton`'s format picker gains a FlatGeobuf option; `export.fgb` i18n key added to all four locales (en/es/fr/de) since it's user-visible.
- `fgb` also joins the catalog discovery surfaces every other export format is already in: a download row in `generate_distributions`' DCAT template table (`catalog/records/service.py::_DISTRIBUTION_TEMPLATES`), the STAC/OGC asset media-type map (`catalog/search/service_records.py::_FORMAT_MEDIA`), and a new migration (`0054_backfill_flatgeobuf_distributions`) that backfills the row onto spatial datasets created before this deploy.

**Media type**: `application/vnd.flatgeobuf`. FlatGeobuf has no IANA registration; this is the vendor-prefixed type the format's own maintainers proposed after an OGC standardization attempt stalled ([flatgeobuf/flatgeobuf#112](https://github.com/flatgeobuf/flatgeobuf/discussions/112)), and it mirrors the pattern this codebase already uses for GeoParquet (`application/vnd.apache.parquet`), which also has no IANA registration.

**Concurrent-work note**: #1682 landed while this PR was in review and independently enabled `.fgb` uploads/ingest (allowlist default, magic-byte content validation, compose/env defaults, CLI `scan`). This PR is rebased on top of it and does not duplicate any of that — it is scoped to the export side only. The backfill migration here revises `0053_source_format_fgb` (#1682's migration) rather than a core revision authored alongside it. A follow-up (#1683) tracks extending the manifest-apply door to the four tier-1 formats #1682 added, deliberately deferred as its own contract-affecting change.

## Verification

Empirically confirmed byte-determinism (two builds of the same source hash identically) via the real `ogr2ogr -f FlatGeobuf` writer before relying on it — `_DETERMINISM_FORMATS` in `test_export_artifact_cache_1532.py` is derived from `FORMAT_MAP`, so `fgb` was automatically picked up by `test_every_export_format_is_byte_deterministic` with no test-file changes needed.

```
cd backend && set -a && source ../.env.test && set +a && uv run pytest tests/test_layering.py -q
uv run pytest tests/test_export.py tests/test_export_access.py tests/test_export_hardening.py tests/test_export_head_1513.py -q
uv run pytest tests/test_export_artifact_cache_1532.py -q
uv run pytest tests/test_distribution_reconcile_1314.py tests/test_dataset_source_state.py tests/test_postgis_refresh_1265.py tests/test_records_related.py -q
uv run pytest tests/test_ogc_record_properties.py tests/test_flatgeobuf_distribution_backfill_1681.py -q
uv run pytest tests/test_sdks_round_trip.py -q
uv run ruff check . && uv run ruff format --check .

cd frontend && npm run typecheck && npm run lint && npm run test:i18n
npx vitest run src/components/dataset/__tests__/ExportButton.test.tsx

make openapi-check
make sdks-check
```

Migration round-trip (`0054`'s upgrade/downgrade) verified against a from-scratch bootstrapped Postgres DB with `alembic upgrade head` + `alembic check` (exit 0, no drift) — `make alembic-check` itself can't run against a worktree's migrations since the api container's bind mount is main-checkout-relative.

All pass locally. CI green.

## API/contract impact

`ExportFormat` enum gains `fgb`. Regenerated and committed: `backend/openapi.json`, both SDKs (`sdks/python`, `sdks/typescript`), and `frontend/src/types/api.generated.ts`.

https://claude.ai/code/session_01BXUUv3x71zWaLKEvoL4cTY