### PR TITLE
fix(compose): apply uvicorn worker recycling only when a supervisor exists

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -274,7 +274,11 @@ GEOLENS_ADMIN_PASSWORD=
 # disables recycling only for direct image runs; docker-compose.prod.yml maps
 # an unset or empty value to its own default of 10000, so disabling it there
 # means editing the compose value.
-# Type: integer (minimum 1) or empty | Default: 10000 (prod compose)
+# fix(#1687): recycling only takes effect with UVICORN_WORKERS >= 2. A single
+# worker has no supervisor to respawn it — the process would exit and the
+# container restart would surface as a short public outage every N requests —
+# so the prod compose omits the flag entirely when UVICORN_WORKERS=1.
+# Type: integer (minimum 1) or empty | Default: 10000 (prod compose, workers >= 2 only)
 # UVICORN_MAX_REQUESTS=10000
 
 # fix(#1240, #651): prometheus_client multiprocess mode for the api service.

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -262,13 +262,19 @@ services:
     # UVICORN_MAX_REQUESTS requests and the uvicorn supervisor respawns it, so
     # slow memory growth can't ride one worker into the cgroup OOM killer.
     # Unset/empty disables; the value must be a positive integer.
+    # fix(#1687): the supervisor only exists when --workers >= 2. With
+    # UVICORN_WORKERS=1 uvicorn serves in-process, so hitting the limit exits
+    # the WHOLE process and the container restart policy turns each recycle
+    # into a short public outage (observed on the demo VM as unexplained
+    # twice-daily api restarts at ~10k background requests). The flag is
+    # therefore applied only when a supervisor is present to absorb it.
     command: >
       sh -c "uv run --no-dev uvicorn app.api.main:app
       --host 0.0.0.0 --port 8000
       --workers $${UVICORN_WORKERS:-2}
       --timeout-keep-alive $${UVICORN_TIMEOUT_KEEP_ALIVE:-5}
       --timeout-graceful-shutdown $${UVICORN_TIMEOUT_GRACEFUL_SHUTDOWN:-30}
-      $${UVICORN_MAX_REQUESTS:+--limit-max-requests $${UVICORN_MAX_REQUESTS}}
+      $$(if [ \"$${UVICORN_WORKERS:-2}\" -gt 1 ] && [ -n \"$${UVICORN_MAX_REQUESTS}\" ]; then printf %s \"--limit-max-requests $${UVICORN_MAX_REQUESTS}\"; fi)
       --proxy-headers --forwarded-allow-ips='*'"
     user: "0:0"
     init: true


### PR DESCRIPTION
Diagnosed live on the demo VM: the api container restarted cleanly (exit 0, graceful shutdown, no OOM, no errors) roughly every 12–14 hours since at least Aug 18 — the restart that day was recorded as unexplained and got the disk-guard's watch mode added. Cause: `docker-compose.prod.yml` defaults `UVICORN_MAX_REQUESTS=10000`, and uvicorn's `--limit-max-requests` is only a rolling recycle when the multiprocess supervisor exists (`--workers >= 2`). The demo runs the documented single-worker D2s tuning, where hitting the limit exits the whole process; the container restart policy masks it as a ~17s public outage. Demo math confirmed it: ~12 background requests/min (Prometheus scrape + healthcheck) ≈ 10k in ~13h, matching the observed cadence exactly.

## Change

- `docker-compose.prod.yml`: the api command appends `--limit-max-requests` only when `UVICORN_WORKERS > 1` and the value is non-empty. Default (workers 2) behavior is unchanged.
- `.env.example`: documents that recycling requires a supervisor.
- Verified: `docker compose -f docker-compose.prod.yml config` parses; the shell conditional simulated for workers=1 (flag omitted), workers=2 (flag present), empty value (omitted).
- Demo VM already mitigated operationally (effectively-infinite override in its .env, api healthy through the edge); this change makes the fix structural for every single-worker install.

No app code, schema, or contract changes.

https://claude.ai/code/session_01BXUUv3x71zWaLKEvoL4cTY