### PR TITLE
feat(ingest): lease service tokens at the import and reupload-commit doors

### DIFF
--- a/backend/app/modules/catalog/datasets/api/router_reupload.py
+++ b/backend/app/modules/catalog/datasets/api/router_reupload.py
@@ -46,6 +46,11 @@ from app.platform.jobs.defer_guard import (
     make_ingest_job_failed_rollback,
 )
 from app.platform.jobs.models import IngestJob
+from app.platform.refresh.credentials import (
+    CredentialStoreUnavailable,
+    discard_service_credential,
+    resolve_dispatch_credential,
+)
 from app.platform.refresh.service import (
     DatasetBusyError,
     create_pending_run,
@@ -590,6 +595,7 @@ async def _dispatch_reupload_task(
     record_type: str,
     user_id: uuid.UUID,
     token: str | None,
+    credential_ref: str | None,
     is_service_refresh: bool,
     rollback,
 ) -> None:
@@ -604,6 +610,11 @@ async def _dispatch_reupload_task(
 
     Extracted from ``reupload_commit`` when the raster branch (#1221) pushed
     that handler past the McCabe gate.
+
+    feat(#1676): ``token`` and ``credential_ref`` are the two shapes a service
+    credential can arrive in, and exactly one of them is ever set — the caller
+    gets the pair from ``resolve_dispatch_credential``. Both are forwarded
+    verbatim; deciding between them is the worker's job, not this one's.
     """
     if is_service_refresh:
         source_url = job.source_url
@@ -618,6 +629,7 @@ async def _dispatch_reupload_task(
                 source_layer=job.source_layer or "",
                 user_id=str(user_id),
                 token=token,
+                credential_ref=credential_ref,
             )
 
         await defer_with_orphan_guard(_defer_service, rollback=rollback, db=db)
@@ -780,6 +792,38 @@ async def reupload_commit(
             },
         ) from exc
 
+    # feat(#1676): staged before the commit, exactly as the refresh door
+    # stages its own, so a configured-but-unreachable store rolls the whole
+    # request back — no committed job, no reserved run, nothing for the sweep
+    # to unwind — rather than leaving a dispatch that can never authenticate.
+    # The reverse order strands the credential instead, which is why the TTL
+    # exists and why nothing depends on the discard below actually running.
+    #
+    # An install with NO store configured takes the third branch and keeps the
+    # durable argument this door has always sent. Refusing there would break
+    # protected re-upload on every stock install, which is the trade #1220
+    # declined; see platform/refresh/credentials for the full contract.
+    credential_ref: str | None = None
+    token: str | None = request.token
+    if is_service_refresh:
+        try:
+            token, credential_ref = await resolve_dispatch_credential(
+                request.token, door="reupload_commit"
+            )
+        except CredentialStoreUnavailable as exc:
+            await db.rollback()
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail={
+                    "code": "credential_store_unavailable",
+                    "message": (
+                        "Could not stage the service credential for this "
+                        "re-upload. Check that the credential store is "
+                        "reachable and try again."
+                    ),
+                },
+            ) from exc
+
     await db.commit()
 
     # Each defer_async path is wrapped in the shared orphan guard
@@ -790,7 +834,7 @@ async def reupload_commit(
     # outcome is already known here, and an hour of `pending` for a dispatch
     # that provably failed is the silent-failure shape this table exists to
     # remove.
-    rollback = make_refresh_run_failed_rollback(
+    inner_rollback = make_refresh_run_failed_rollback(
         make_ingest_job_failed_rollback(
             job, message_prefix="Failed to queue reupload task"
         ),
@@ -798,13 +842,19 @@ async def reupload_commit(
         ingest_job_id=job.id,
     )
 
+    async def rollback(defer_exc: BaseException) -> None:
+        await inner_rollback(defer_exc)
+        # The worker will never come for it, and the run is already terminal.
+        await discard_service_credential(credential_ref)
+
     await _dispatch_reupload_task(
         db,
         job=job,
         dataset_id=dataset_id,
         record_type=dataset.record.record_type,
         user_id=user.id,
-        token=request.token,
+        token=token,
+        credential_ref=credential_ref,
         is_service_refresh=is_service_refresh,
         rollback=rollback,
     )

--- a/backend/app/platform/refresh/credentials.py
+++ b/backend/app/platform/refresh/credentials.py
@@ -41,10 +41,39 @@ there is no store. The refresh endpoint refuses a token-bearing request up
 front in that case, which is a clear error at the door instead of a confusing
 failure an hour later in a worker.
 
-Deliberately NOT wired into the existing re-upload commit door, which still
-passes its token as a task argument. Doing both would have made a protected
-re-upload stop working on every install without Valkey — a live regression
-traded for a latent one. See the #1220 PR body for the disposition.
+### Three doors, one mechanism, three states
+
+#1220 wired the refresh door only. The first-import and re-upload-commit
+doors kept passing their token as a task argument, because refusing a
+credentialed request without Valkey would have stopped protected imports
+working on every stock install — a live regression traded for a latent one.
+
+feat(#1676) closes the gap without paying that regression, by keying the
+decision on what the install HAS rather than on which door the request came
+through:
+
+- **state 1, store configured and reachable** — stash, dispatch the
+  reference, claim once in the worker. Nothing durable, at every door.
+- **state 2, store configured but the stash fails** — 503
+  ``credential_store_unavailable``, identical at every door. An operator who
+  opted into a store is told it is broken rather than silently downgraded to
+  the durable argument they thought they had stopped using.
+- **state 3, no store configured at all** — the token rides in the task
+  argument, as it always has at the two pre-existing doors. The refresh door
+  refuses here instead, and keeps refusing: token-bearing refresh has never
+  worked without a store, so nothing regresses by leaving it that way.
+
+State 3 is the one asymmetry and it is deliberate. The alternative — one
+uniform refusal — reads tidier and breaks protected import on the default
+install, which is the trade #1220 already declined once.
+
+:func:`resolve_dispatch_credential` decides all three for the two doors that
+can reach state 3, so neither of them can drift from the other or from this
+text. The refresh door does not call it: it answers state 3 with an explicit
+refusal in its own handler, before it writes anything, and then reaches
+states 1 and 2 through :func:`stash_service_credential` — which is the only
+other call this helper makes. Two spellings of the same two calls, because
+the third state genuinely differs there.
 """
 
 from __future__ import annotations
@@ -104,8 +133,8 @@ class CredentialStoreUnavailable(RuntimeError):
     """No shared credential store is configured.
 
     Raised at the API door, before anything is written, so the caller gets a
-    503 naming the missing configuration rather than a refresh that dispatches
-    and then fails in a worker for reasons nothing surfaces.
+    503 naming the missing configuration rather than a dispatch that fails in
+    a worker an hour later for reasons nothing surfaces.
     """
 
 
@@ -114,9 +143,11 @@ class CredentialExpiredError(RuntimeError):
 
     Both cases are the same fact from the worker's side — there is no
     credential to fetch — and both are permanent for this attempt, because a
-    single-use secret is gone the moment it is read. The worker turns this
-    into the ``credential_expired`` run error code so the history row says
-    "supply a token and try again" rather than blaming the origin.
+    single-use secret is gone the moment it is read. The refresh worker turns
+    this into the ``credential_expired`` run error code so the history row
+    says "supply a token and try again" rather than blaming the origin; the
+    import worker has no run row and carries the same sentence as its
+    ``error_message``.
     """
 
 
@@ -176,12 +207,12 @@ class RedisCredentialBackend:
                 "refresh_credential_store_write_failed", error_type=type(exc).__name__
             )
             raise CredentialStoreUnavailable(
-                "The credential store could not be reached, so this refresh "
+                "The credential store could not be reached, so this request "
                 "cannot be started with a token."
             ) from exc
         if not stored:
             raise CredentialStoreUnavailable(
-                "Could not stash the service credential for this refresh."
+                "Could not stash the service credential for this request."
             )
 
     async def take(self, key: str) -> str | None:
@@ -192,7 +223,7 @@ class RedisCredentialBackend:
                 "refresh_credential_store_read_failed", error_type=type(exc).__name__
             )
             raise CredentialStoreUnavailable(
-                "The credential store could not be reached, so this refresh "
+                "The credential store could not be reached, so this job "
                 "could not retrieve its token."
             ) from exc
 
@@ -245,9 +276,9 @@ def get_credential_backend() -> CredentialBackend:
         return _backend
     if not settings.redis_url:
         raise CredentialStoreUnavailable(
-            "Refreshing a protected service requires a shared credential "
-            "store. Set REDIS_URL to a Valkey/Redis instance reachable by "
-            "both the API and the worker."
+            "Handing a service token to the worker requires a shared "
+            "credential store. Set REDIS_URL to a Valkey/Redis instance "
+            "reachable by both the API and the worker."
         )
     _backend = RedisCredentialBackend(settings.redis_url)
     _backend_url = settings.redis_url
@@ -305,7 +336,7 @@ async def claim_service_credential(ref: str) -> str:
     """
     if not _REF_PATTERN.match(ref or ""):
         raise CredentialExpiredError(
-            "The service credential for this refresh is no longer available."
+            "The service credential for this job is no longer available."
         )
     try:
         secret = await get_credential_backend().take(_KEY_PREFIX + ref)
@@ -317,15 +348,83 @@ async def claim_service_credential(ref: str) -> str:
         # key. Log the class, surface the fixed sentence.
         logger.warning("refresh_credential_claim_failed", error_type=type(exc).__name__)
         raise CredentialStoreUnavailable(
-            "The credential store could not be reached, so this refresh could "
+            "The credential store could not be reached, so this job could "
             "not retrieve its token."
         ) from exc
     if secret is None:
         raise CredentialExpiredError(
-            "The service credential for this refresh was already used or has "
-            "expired. Start the refresh again with a fresh token."
+            "The service credential for this job was already used or has "
+            "expired. Start again with a fresh token."
         )
     return secret
+
+
+async def resolve_worker_credential(
+    token: str | None, credential_ref: str | None
+) -> str | None:
+    """The credential this attempt will fetch with, redeeming a ref if given.
+
+    feat(#1220), shared with the import door by feat(#1676). Called inside the
+    task's handled region and after the attempt check, so a single-use
+    credential is only ever consumed for an attempt that is actually going to
+    run. A ref that names nothing raises :class:`CredentialExpiredError` —
+    deliberately NOT a fall-through to an unauthenticated fetch, which would
+    reach the origin, collect a 401, and report a protected service as broken.
+
+    The ref wins over a directly-passed token when both are somehow set: the
+    door that sends a ref is the door that promised nothing durable, and
+    honouring the durable value instead would quietly undo that promise. In
+    practice the pair is mutually exclusive by construction — see
+    :func:`resolve_dispatch_credential`, which is the only thing that fills
+    either — so this is the tie-break for a rolling deploy, not a routine
+    branch.
+
+    Lives here rather than in either task module because both
+    ``reupload_service`` and ``ingest_service`` need it and neither may import
+    the other: ``tasks_reupload`` already reaches into ``tasks_vector`` at
+    call time, so a top-level edge back would close a cycle.
+    """
+    if credential_ref:
+        return await claim_service_credential(credential_ref)
+    return token
+
+
+async def resolve_dispatch_credential(
+    token: str | None, *, door: str
+) -> tuple[str | None, str | None]:
+    """Decide how *token* reaches the worker. Returns ``(token, ref)``.
+
+    feat(#1676). The single decision point for the three states in this
+    module's docstring, so the three doors cannot answer it three ways:
+
+    - no token at all           -> ``(None, None)``; nothing to protect.
+    - store configured          -> ``(None, ref)``; the secret is stashed and
+                                   only the reference is returned, so nothing
+                                   durable can carry it. A store that is
+                                   configured but unreachable raises
+                                   :class:`CredentialStoreUnavailable` from
+                                   the stash, which every caller turns into
+                                   the same 503.
+    - no store configured       -> ``(token, None)``; the pre-existing durable
+                                   argument, unchanged.
+
+    Exactly one element of the pair is ever set, which is what lets
+    :func:`resolve_worker_credential` treat "both" as an impossibility rather
+    than a case.
+
+    The fallback is logged rather than silent. It is the one branch where the
+    stored shape of a request differs from what the UI copy leads with, and an
+    operator asking "is this install actually leasing?" should be able to
+    answer it from logs instead of from settings archaeology. The log line
+    carries the DOOR, never the token and never the reference — a reference is
+    harmless after its claim but not before it, and log sinks outlive TTLs.
+    """
+    if not token:
+        return None, None
+    if not credential_store_available():
+        logger.info("service_credential_durable_fallback", door=door)
+        return token, None
+    return None, await stash_service_credential(token)
 
 
 async def discard_service_credential(ref: str | None) -> None:
@@ -392,15 +491,36 @@ async def discard_service_credential(ref: str | None) -> None:
 #
 # Correlated on `args->>'job_id'`, the correlation every task in this codebase
 # passes and the one both refresh sweeps already use.
+#
+# feat(#1676): the run join is a LEFT join, and the run-liveness stop has a
+# fallback. The INNER join was correct while only the refresh door leased,
+# because that door writes a `dataset_refresh_runs` row on the way in — and so
+# does the re-upload commit door, which is why that one inherits renewal for
+# free. The FIRST-IMPORT door writes no run at all. Left as an inner join it
+# would have matched nothing for an import, silently dropping renewal for the
+# one door with no run row: a protected import queued behind a long ingest
+# would have expired at the TTL and failed `credential_expired` where today it
+# simply waits. That is a regression the lease itself would have introduced,
+# and no test of the refresh path could have seen it.
+#
+# The fallback stop is `ingest_jobs.status`, which is the same question the
+# run's status answers on the other branch — is this dispatch still going to
+# be worked? — asked of the row that exists for a run-less job. It keeps the
+# self-terminating property intact for the same reason the run branch has it:
+# `EXPIRE` cannot resurrect, so once the worker's GETDEL has removed the key
+# every later renewal is a no-op regardless of what any status column says.
 _RENEWABLE_CREDENTIALS_SQL = text(
     """
     SELECT DISTINCT pj.args->>'credential_ref' AS credential_ref
     FROM catalog.procrastinate_jobs pj
     JOIN catalog.ingest_jobs j ON pj.args->>'job_id' = j.id::text
-    JOIN catalog.dataset_refresh_runs r ON r.ingest_job_id = j.id
+    LEFT JOIN catalog.dataset_refresh_runs r ON r.ingest_job_id = j.id
     WHERE pj.status IN ('todo', 'doing')
       AND pj.args->>'credential_ref' IS NOT NULL
-      AND r.status IN ('pending', 'running')
+      AND (
+          r.status IN ('pending', 'running')
+          OR (r.id IS NULL AND j.status IN ('pending', 'running'))
+      )
       AND (
           CAST(:tenant_id AS uuid) IS NULL
           OR j.tenant_id = CAST(:tenant_id AS uuid)
@@ -416,6 +536,14 @@ async def renew_queued_refresh_credentials(
 
     Returns how many were renewed. Driven by the API's existing stale-job
     sweeper, once per :data:`CREDENTIAL_RENEWAL_INTERVAL_SECONDS`.
+
+    feat(#1676): the ``refresh`` in the name is historical. Since the import
+    and re-upload-commit doors lease too, this covers every leased dispatch —
+    see the query's own note on why a run-less import needed the join
+    widened. The name is kept because it is the spelling
+    ``test_service_refresh_1220`` and the lifespan structural assertions
+    already pin, and renaming it would churn a dozen call sites to say the
+    same thing the docstring says.
 
     This is what makes a short TTL correct rather than optimistic: the
     credential's lifetime becomes the real queue wait instead of a number

--- a/backend/app/processing/ingest/service.py
+++ b/backend/app/processing/ingest/service.py
@@ -1187,6 +1187,31 @@ async def queue_ingest_job(
                 source_layer=job.source_layer or "",
                 user_id=user_id,
                 token=token,
+                # fix(#1689 codex r1) — ROLLING-DEPLOY SKEW, accepted, and
+                # accepted the way #1220 accepted the identical question at
+                # the refresh door (router_refresh.py carries the long form).
+                # A worker from the previous generation takes `credential_ref`
+                # through `**kwargs` and discards it, fetches unauthenticated,
+                # collects the origin's 401, and fails the job blaming the
+                # origin.
+                #
+                # The gate that would close it is a task name old workers do
+                # not register, and it is the WORSE option for the reason
+                # #1220 wrote down: Procrastinate marks its OWN job failed on
+                # TaskNotFound, but nothing then writes the ingest_jobs row,
+                # so it sits `pending` in the user's job list until the
+                # stale-job sweep. A hang reads worse than a failure you can
+                # retry, and the retry succeeds because by then the window has
+                # closed.
+                #
+                # The window is narrower here than at the refresh door. A
+                # storeless install dispatches no reference at all (state 3),
+                # so the default deployment has no skew; only an install with
+                # REDIS_URL set, mid-rollout, on a token-bearing import is
+                # exposed, and single-node compose deploys never overlap
+                # generations. Nothing is stranded either: the old worker
+                # fails the job, `ingest_jobs.status` leaves ('pending',
+                # 'running'), renewal stops, and the credential dies by TTL.
                 credential_ref=credential_ref,
             )
 

--- a/backend/app/processing/ingest/service.py
+++ b/backend/app/processing/ingest/service.py
@@ -1125,10 +1125,17 @@ async def queue_ingest_job(
 
     Raises ``HTTPException 400`` when the job has no file_path and no
     source_url so the route handler surfaces a clear error.
-    Raises ``HTTPException 503`` when Procrastinate is unreachable.
+    Raises ``HTTPException 503`` when Procrastinate is unreachable, or when a
+    configured credential store cannot be reached to stage a service token
+    (feat(#1676) — see ``resolve_dispatch_credential``).
     """
     import os
 
+    from app.platform.refresh.credentials import (
+        CredentialStoreUnavailable,
+        discard_service_credential,
+        resolve_dispatch_credential,
+    )
     from app.processing.ingest.constants import PRIORITY_QUEUE_THRESHOLD_BYTES
     from app.processing.ingest.tasks import ingest_file, ingest_raster, ingest_service
 
@@ -1137,6 +1144,39 @@ async def queue_ingest_job(
         # a local so mypy preserves the ``str`` narrowing inside the
         # nested closure (the attribute access reverts to ``str | None``).
         source_url = job.source_url
+        job_failed = make_ingest_job_failed_rollback(job)
+
+        # feat(#1676): the import door's half of the lease. On an install with
+        # a shared credential store this returns (None, ref) and the secret
+        # never becomes a task argument; without one it returns the token
+        # unchanged, which is what this door has always dispatched. The whole
+        # decision — including which of those two an install gets — is
+        # resolve_dispatch_credential's, so this door cannot drift from the
+        # re-upload one.
+        credential_ref: str | None = None
+        try:
+            token, credential_ref = await resolve_dispatch_credential(
+                token, door="import"
+            )
+        except CredentialStoreUnavailable as exc:
+            # The job row is already committed by the time this runs
+            # (commit_import commits before dispatching), so a bare raise
+            # would strand it pending until the stale sweep. Finalize it the
+            # way the orphan guard would have, then answer with the 503 the
+            # refresh door gives for the same condition.
+            await job_failed(exc)
+            await db.commit()
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail={
+                    "code": "credential_store_unavailable",
+                    "message": (
+                        "Could not stage the service credential for this "
+                        "import. Check that the credential store is "
+                        "reachable and try again."
+                    ),
+                },
+            ) from exc
 
         async def _defer_service() -> None:
             await defer_async_with_tenant(
@@ -1147,11 +1187,19 @@ async def queue_ingest_job(
                 source_layer=job.source_layer or "",
                 user_id=user_id,
                 token=token,
+                credential_ref=credential_ref,
             )
+
+        async def _rollback_service(defer_exc: BaseException) -> None:
+            await job_failed(defer_exc)
+            # The worker will never come for it. Best-effort; the TTL is the
+            # real guarantee, and this only shortens a window we already know
+            # nothing will use.
+            await discard_service_credential(credential_ref)
 
         await defer_with_orphan_guard(
             _defer_service,
-            rollback=make_ingest_job_failed_rollback(job),
+            rollback=_rollback_service,
             db=db,
         )
         return

--- a/backend/app/processing/ingest/tasks_reupload.py
+++ b/backend/app/processing/ingest/tasks_reupload.py
@@ -26,7 +26,7 @@ from app.platform.jobs.models import owned_presigned_staging_key
 from app.platform.refresh.credentials import (
     CredentialExpiredError,
     CredentialStoreUnavailable,
-    claim_service_credential,
+    resolve_worker_credential,
 )
 from app.platform.refresh.service import (
     claim_run_for_job,
@@ -671,21 +671,14 @@ async def _resolve_service_token(
 ) -> str | None:
     """The credential this attempt will fetch with, redeeming a ref if given.
 
-    feat(#1220). Called inside the task's handled region and after the attempt
-    check, so a single-use credential is only ever consumed for an attempt
-    that is actually going to run. A ref that names nothing raises
-    ``CredentialExpiredError``, which the task's failure handler records as
-    ``credential_expired`` — deliberately NOT a fall-through to an
-    unauthenticated fetch, which would reach the origin, collect a 401, and
-    report a protected service as broken.
-
-    The ref wins over a directly-passed token when both are somehow set: the
-    door that sends a ref is the door that promised nothing durable, and
-    honouring the durable value instead would quietly undo that promise.
+    feat(#1220). fix(#1676) moved the body to
+    ``platform.refresh.credentials.resolve_worker_credential`` so
+    ``ingest_service`` redeems the same way without either task module
+    importing the other. The rules and the reasoning live there; this stays as
+    the name this task and its tests already reach for, and as the anchor for
+    the ``credential_expired`` mapping above.
     """
-    if credential_ref:
-        return await claim_service_credential(credential_ref)
-    return token
+    return await resolve_worker_credential(token, credential_ref)
 
 
 async def _fetch_service_layer_with_paging_guard(
@@ -798,14 +791,16 @@ async def reupload_service(
 ) -> None:
     """Background task: replace dataset data from a remote service source.
 
-    Two doors dispatch this task and they hand over a credential differently.
-    The re-upload commit door passes ``token`` directly, which is a durable
-    task argument; the one-request refresh door (#1220) passes
-    ``credential_ref``, a single-use reference redeemed once here for a secret
-    that never touched a committed row. Both are optional and at most one is
-    ever set — the reference wins if both somehow are, because the door that
-    sends one is the door that promised nothing durable. Neither is required:
-    a public service needs no credential at all.
+    Two doors dispatch this task, and since feat(#1676) they hand a credential
+    over the same way: ``credential_ref``, a single-use reference redeemed
+    once here for a secret that never touched a committed row — the
+    one-request refresh door since #1220, the re-upload commit door since
+    #1676. ``token`` is the surviving durable argument, and after #1676 only
+    an install with no shared credential store configured at all still
+    produces one (state 3 in ``platform/refresh/credentials``). Both are
+    optional and at most one is ever set — the reference wins if both somehow
+    are, because the door that sends one is the door that promised nothing
+    durable. Neither is required: a public service needs no credential at all.
 
     Session lifecycle (gh #100 followup): the AsyncSession is split into two
     short-lived blocks so it is NOT held open across ``run_ogr2ogr_service``

--- a/backend/app/processing/ingest/tasks_vector.py
+++ b/backend/app/processing/ingest/tasks_vector.py
@@ -10,6 +10,7 @@ import structlog
 from sqlalchemy import text
 
 from app.core.db.tenant_session import tenant_task
+from app.core.url_redaction import scrub_secret_from_exception
 from app.platform.dataset_origin import service_layer_identity
 from app.platform.jobs.heartbeat import (
     attempt_scoped_staging_table,
@@ -746,9 +747,18 @@ async def ingest_service(
     user_id: str,
     attempt_id: str | None = None,
     token: str | None = None,
+    credential_ref: str | None = None,
     **kwargs,
 ) -> None:
     """Background task: import a remote service layer via ogr2ogr.
+
+    feat(#1676): the import door hands its service credential over the same
+    one-use channel the refresh door has used since #1220. ``credential_ref``
+    is a reference redeemed exactly once below; ``token`` is the durable task
+    argument, which after #1676 only an install with no shared credential
+    store configured still produces. At most one is ever set — see
+    ``resolve_worker_credential`` for the tie-break and
+    ``resolve_dispatch_credential`` for which state produces which.
 
     Full pipeline:
     1. Update job status to running
@@ -773,6 +783,7 @@ async def ingest_service(
     from app.processing.ingest.ogr import build_pg_conn_str, run_ogr2ogr_service
     from app.processing.ingest.service import generate_table_name
     from app.platform.jobs.models import IngestJob
+    from app.platform.refresh.credentials import resolve_worker_credential
 
     # IA-P0-03 defense-in-depth: revalidate source_url at fetch time.
     # The route-level check at commit_import covers the preview→commit
@@ -847,6 +858,20 @@ async def ingest_service(
                     "collision_warning": collision_warning,
                 }
                 await session.commit()
+
+        # feat(#1676): redeem the one-use credential, AFTER phase 1 rather
+        # than before it. Two reasons, and the second is the load-bearing one:
+        # a single-use secret must only be spent on an attempt that is really
+        # going to run, and phase 1 is where `claim_job_attempt_and_start_
+        # heartbeat` decides that (it returns None for a superseded attempt,
+        # and this task returns without ever touching the credential). The
+        # second: the failure write at the bottom of this task is fenced on
+        # `status == 'running'`, and phase 1 is what sets that — claiming
+        # before it would leave a `credential_expired` failure unrecorded and
+        # the job pending until the stale sweep. Placed outside the phase-1
+        # session so the store round trip does not run with a DB session held
+        # open.
+        token = await resolve_worker_credential(token, credential_ref)
 
         # ----------------------------------------------------------------- #
         # ogr2ogr subprocess — NO session open. Holding a session open
@@ -1049,6 +1074,13 @@ async def ingest_service(
             )
 
     except Exception as exc:  # broad: PostGIS/DB ingest can fail at any step; mark job failed and re-raise
+        # feat(#1676): this task now HOLDS the claimed secret as a value, so it
+        # gets the same exact-value scrub `reupload_service` does. The pattern
+        # layers (run_ogr2ogr_service, redact_url_credentials) cover the token
+        # nobody holds by matching URL shapes; this covers the one this attempt
+        # holds, in whatever shape an origin echoes it back. Mutated in place
+        # so the class survives for the bare re-raise the queue records.
+        scrub_secret_from_exception(exc, token)
         structlog.get_logger().exception(
             "Ingest task failed",
             job_id=job_id,

--- a/backend/tests/test_import_token_lease_1676.py
+++ b/backend/tests/test_import_token_lease_1676.py
@@ -1,0 +1,869 @@
+"""feat(#1676): the import and re-upload-commit doors lease their token too.
+
+#1220 gave the refresh door a one-use Valkey handoff so a service credential
+never lands in ``catalog.procrastinate_jobs.args``. The other two doors kept
+dispatching the raw token, while the import UI promised the opposite. These
+tests pin the three states those doors now have, at both ends of the handoff:
+
+- **state 1** store configured -> a reference travels, the secret does not,
+  and the worker spends the reference exactly once;
+- **state 2** store configured but unreachable -> 503 at the door, nothing
+  dispatched, and no half-written state left for a sweep to unwind;
+- **state 3** no store configured -> the durable argument this door has
+  always sent, which is the whole reason these two doors do not simply refuse.
+
+State 3 has a test of its own for each door because it is the branch a
+tidy-up would delete: it looks like an oversight and is the only thing
+keeping protected import working on a stock install, where ``REDIS_URL`` is
+unset and the ``valkey`` service is behind the ``cloud-dev`` profile.
+
+The last class covers the renewal query, which had to be widened for the
+first-import door — the one leasing door that writes no ``dataset_refresh_
+runs`` row and so matched nothing under the old inner join.
+"""
+
+from __future__ import annotations
+
+import uuid
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+import structlog
+from httpx import AsyncClient
+from sqlalchemy import select, text
+
+from app.platform.jobs.models import IngestJob
+from app.platform.refresh import credentials as creds
+from app.platform.refresh.models import DatasetRefreshRun
+
+from tests.factories import create_dataset, get_user_id
+
+# The fake store and its fixture are #1220's; reusing them keeps the two
+# suites answering to one model of what a credential backend does, the way
+# test_refresh_pagination_1675 reuses test_refresh_gate_1269's harness.
+from tests.test_service_refresh_1220 import (  # noqa: F401
+    _FakeCredentialBackend,
+    credential_backend,
+)
+
+pytestmark = pytest.mark.anyio
+
+_SERVICE_URL = "https://example.arcgis.test/rest/services/Parcels/FeatureServer/0"
+
+
+class _DownBackend:
+    """Configured, reachable by settings, unreachable in fact.
+
+    The distinction this class exists for: ``credential_store_available()``
+    reads the SETTING, so an outage gets past every door's availability check
+    and surfaces at the stash. State 2 is what happens then.
+    """
+
+    async def put(self, key, value, ttl_seconds):
+        raise creds.CredentialStoreUnavailable("valkey is away")
+
+    async def take(self, key):
+        raise creds.CredentialStoreUnavailable("valkey is away")
+
+    async def renew(self, key, ttl_seconds):
+        return False
+
+
+@pytest.fixture
+def no_credential_store(monkeypatch):
+    """The stock install: no backend installed, no REDIS_URL set."""
+    from app.core.config import settings
+
+    creds.set_credential_backend(None)
+    monkeypatch.setattr(settings, "redis_url", None, raising=False)
+    yield
+    creds.set_credential_backend(None)
+
+
+@pytest.fixture
+def down_credential_store():
+    backend = _DownBackend()
+    creds.set_credential_backend(backend)
+    try:
+        yield backend
+    finally:
+        creds.set_credential_backend(None)
+
+
+async def _service_import_job(session, *, created_by: uuid.UUID) -> IngestJob:
+    """A pending first-import job bound to a remote service layer."""
+    job = IngestJob(
+        source_filename="Parcels",
+        source_url=_SERVICE_URL,
+        source_layer="0",
+        created_by=created_by,
+        status="pending",
+        user_metadata={"service_type": "ArcGIS:FeatureServer", "layer_id": 0},
+    )
+    session.add(job)
+    await session.commit()
+    await session.refresh(job)
+    return job
+
+
+async def _service_reupload_job(
+    session, *, dataset_id: uuid.UUID, created_by: uuid.UUID
+) -> IngestJob:
+    job = IngestJob(
+        dataset_id=dataset_id,
+        source_filename="Parcels",
+        source_url=_SERVICE_URL,
+        source_layer="roads",
+        created_by=created_by,
+        status="pending",
+        user_metadata={
+            "reupload": True,
+            "dataset_id": str(dataset_id),
+            "service_type": "WFS 2.0.0",
+            "layer_id": None,
+            "source_type": "service_url",
+        },
+    )
+    session.add(job)
+    await session.commit()
+    await session.refresh(job)
+    return job
+
+
+@asynccontextmanager
+async def _import_harness(defer_side_effect=None):
+    """Patch the SSRF probe and the deferred task; yield the task mock.
+
+    ``task.defer_async.call_args.kwargs`` IS what becomes
+    ``procrastinate_jobs.args`` — Procrastinate serializes those kwargs
+    verbatim into the column — so inspecting the call is equivalent to
+    querying a row this harness never lets reach the real queue. The same
+    equivalence #1220's dispatch harness documents and relies on.
+
+    ``validate_url_for_ssrf`` is patched in its DEFINING module: both
+    ``commit_import`` and the worker re-import it lazily, so a patch on the
+    router's namespace would be rebound away on the next call.
+    """
+    task = MagicMock()
+    task.defer_async = AsyncMock(return_value=None, side_effect=defer_side_effect)
+    with (
+        patch("app.platform.security.validate_url_for_ssrf", new=AsyncMock()),
+        patch("app.processing.ingest.tasks.ingest_service", task),
+    ):
+        yield task
+
+
+@asynccontextmanager
+async def _reupload_harness(defer_side_effect=None):
+    task = MagicMock()
+    task.defer_async = AsyncMock(return_value=None, side_effect=defer_side_effect)
+    file_task = MagicMock()
+    file_task.defer_async = AsyncMock(return_value=None)
+    port = MagicMock()
+    port.reupload_service_task.return_value = task
+    port.reupload_file_task.return_value = file_task
+    port.priority_queue_threshold_bytes = 10_000_000
+    with patch(
+        "app.modules.catalog.datasets.api.router_reupload.get_catalog_port",
+        return_value=port,
+    ):
+        yield task
+
+
+async def _reload(session, job_id: uuid.UUID) -> IngestJob:
+    """Re-read a row the request transaction wrote, through the same session.
+
+    ``populate_existing`` rather than ``expire_all``: the handler and this
+    session share an identity map, so without it the already-loaded instance
+    is returned unchanged and every assertion below reads the pre-request
+    values. ``expire_all`` fixes that and breaks something else — it expires
+    EVERY loaded object, so the next plain attribute read on any of them
+    (``dataset.id``, two lines later) becomes lazy IO in a sync context and
+    raises ``MissingGreenlet``.
+    """
+    return (
+        await session.execute(
+            select(IngestJob)
+            .where(IngestJob.id == job_id)
+            .execution_options(populate_existing=True)
+        )
+    ).scalar_one()
+
+
+# ---------------------------------------------------------------------------
+# Door 1 — first import (POST /ingest/commit/{job_id})
+# ---------------------------------------------------------------------------
+
+
+class TestImportDoor:
+    async def test_a_token_reaches_the_worker_as_a_reference_only(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session,
+        credential_backend,  # noqa: F811
+    ) -> None:
+        """The sentinel is the token STRING, in every durable surface.
+
+        Asserting a ``token`` key is absent passes just as happily when the
+        value moved to another key, which is the exact shape of the bug this
+        lease exists to prevent — so the assertion is on the value.
+        """
+        secret = "tok-" + uuid.uuid4().hex
+        admin_id = await get_user_id(test_db_session, "admin")
+        job = await _service_import_job(test_db_session, created_by=admin_id)
+
+        with structlog.testing.capture_logs() as captured:
+            async with _import_harness() as task:
+                resp = await client.post(
+                    f"/ingest/commit/{job.id}",
+                    json={"title": "Parcels", "token": secret},
+                    headers=admin_auth_header,
+                )
+
+        assert resp.status_code == 202, resp.text
+        kwargs = task.defer_async.call_args.kwargs
+        assert kwargs["credential_ref"]
+        assert kwargs["token"] is None
+        assert secret not in str(kwargs)
+
+        reloaded = await _reload(test_db_session, job.id)
+        assert secret not in str(reloaded.user_metadata)
+        assert reloaded.user_metadata["service_auth_required"] is True
+        assert secret not in str(captured)
+
+        # And the secret really is retrievable by the reference, once.
+        assert await creds.claim_service_credential(kwargs["credential_ref"]) == secret
+
+    async def test_without_a_store_the_import_still_runs_on_the_durable_argument(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session,
+        no_credential_store,
+    ) -> None:
+        """State 3, pinned deliberately rather than left as an accident.
+
+        A stock install has no ``REDIS_URL``. Refusing here — which is what
+        the refresh door does, and what a later tidy-up would "fix" this into
+        — would stop protected imports working on every one of them. The log
+        line is asserted with the branch so an operator can answer "is this
+        install leasing?" from logs rather than from settings archaeology,
+        and so that deleting the branch cannot pass this test quietly.
+        """
+        secret = "tok-" + uuid.uuid4().hex
+        admin_id = await get_user_id(test_db_session, "admin")
+        job = await _service_import_job(test_db_session, created_by=admin_id)
+
+        with structlog.testing.capture_logs() as captured:
+            async with _import_harness() as task:
+                resp = await client.post(
+                    f"/ingest/commit/{job.id}",
+                    json={"title": "Parcels", "token": secret},
+                    headers=admin_auth_header,
+                )
+
+        assert resp.status_code == 202, resp.text
+        kwargs = task.defer_async.call_args.kwargs
+        assert kwargs["token"] == secret
+        assert kwargs["credential_ref"] is None
+
+        fallbacks = [
+            entry
+            for entry in captured
+            if entry.get("event") == "service_credential_durable_fallback"
+        ]
+        assert len(fallbacks) == 1, captured
+        assert fallbacks[0]["door"] == "import"
+        # The line names the door, never the secret and never a reference.
+        assert secret not in str(fallbacks[0])
+
+    async def test_a_store_that_is_down_returns_503_and_finalizes_the_job(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session,
+        down_credential_store,
+    ) -> None:
+        """State 2, and the half this door has to do for itself.
+
+        ``commit_import`` commits the job BEFORE dispatching, so unlike the
+        two doors that stage before their own commit this one cannot answer
+        an unreachable store by rolling back. A bare raise would leave the row
+        `pending`, holding against the stale sweep for an hour, for a dispatch
+        that provably never happened.
+        """
+        admin_id = await get_user_id(test_db_session, "admin")
+        job = await _service_import_job(test_db_session, created_by=admin_id)
+
+        async with _import_harness() as task:
+            resp = await client.post(
+                f"/ingest/commit/{job.id}",
+                json={"title": "Parcels", "token": "never-stashed"},
+                headers=admin_auth_header,
+            )
+
+        assert resp.status_code == 503, resp.text
+        assert resp.json()["detail"]["code"] == "credential_store_unavailable"
+        task.defer_async.assert_not_awaited()
+
+        reloaded = await _reload(test_db_session, job.id)
+        assert reloaded.status == "failed"
+        assert reloaded.completed_at is not None
+
+    async def test_a_public_import_is_untouched_by_any_of_this(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session,
+        down_credential_store,
+    ) -> None:
+        """No token, no credential, no store involvement — even a broken one.
+
+        The counterfactual for the two tests above: if the 503 were keyed on
+        the store rather than on the request carrying a secret, this would
+        fail, and every unauthenticated service import on an install with a
+        sick Valkey would fail with it.
+        """
+        admin_id = await get_user_id(test_db_session, "admin")
+        job = await _service_import_job(test_db_session, created_by=admin_id)
+
+        async with _import_harness() as task:
+            resp = await client.post(
+                f"/ingest/commit/{job.id}",
+                json={"title": "Parcels"},
+                headers=admin_auth_header,
+            )
+
+        assert resp.status_code == 202, resp.text
+        kwargs = task.defer_async.call_args.kwargs
+        assert kwargs["token"] is None
+        assert kwargs["credential_ref"] is None
+
+    async def test_a_queue_outage_discards_the_credential_it_stashed(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session,
+        credential_backend,  # noqa: F811
+    ) -> None:
+        """The dispatch failed, so nothing will ever claim it.
+
+        The TTL is the real guarantee; this only shortens a window we already
+        know is dead. Asserting it directly because "best-effort" is exactly
+        the kind of call that gets dropped in a refactor without a test
+        noticing.
+        """
+        secret = "tok-" + uuid.uuid4().hex
+        admin_id = await get_user_id(test_db_session, "admin")
+        job = await _service_import_job(test_db_session, created_by=admin_id)
+
+        async with _import_harness(
+            defer_side_effect=RuntimeError("queue unavailable")
+        ) as task:
+            resp = await client.post(
+                f"/ingest/commit/{job.id}",
+                json={"title": "Parcels", "token": secret},
+                headers=admin_auth_header,
+            )
+
+        assert resp.status_code == 503, resp.text
+        ref = task.defer_async.call_args.kwargs["credential_ref"]
+        with pytest.raises(creds.CredentialExpiredError):
+            await creds.claim_service_credential(ref)
+
+        reloaded = await _reload(test_db_session, job.id)
+        assert reloaded.status == "failed"
+
+
+# ---------------------------------------------------------------------------
+# Door 2 — re-upload commit (POST /datasets/{id}/reupload/{job_id}/commit)
+# ---------------------------------------------------------------------------
+
+
+class TestReuploadCommitDoor:
+    async def _dataset(self, session, *, created_by: uuid.UUID):
+        return await create_dataset(
+            session,
+            created_by=created_by,
+            name="Service Reupload Dataset",
+            visibility="public",
+            feature_count=100,
+            source_filename="original.geojson",
+            source_url="https://old.example.test/source",
+        )
+
+    async def _run_for(self, session, dataset_id: uuid.UUID):
+        return (
+            await session.execute(
+                select(DatasetRefreshRun)
+                .where(DatasetRefreshRun.dataset_id == dataset_id)
+                .execution_options(populate_existing=True)
+            )
+        ).scalar_one_or_none()
+
+    async def test_a_token_reaches_the_worker_as_a_reference_only(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session,
+        credential_backend,  # noqa: F811
+    ) -> None:
+        secret = "tok-" + uuid.uuid4().hex
+        admin_id = await get_user_id(test_db_session, "admin")
+        dataset = await self._dataset(test_db_session, created_by=admin_id)
+        job = await _service_reupload_job(
+            test_db_session, dataset_id=dataset.id, created_by=admin_id
+        )
+
+        with structlog.testing.capture_logs() as captured:
+            async with _reupload_harness() as task:
+                resp = await client.post(
+                    f"/datasets/{dataset.id}/reupload/{job.id}/commit",
+                    json={"token": secret},
+                    headers=admin_auth_header,
+                )
+
+        assert resp.status_code == 202, resp.text
+        kwargs = task.defer_async.call_args.kwargs
+        assert kwargs["credential_ref"]
+        assert kwargs["token"] is None
+        assert secret not in str(kwargs)
+
+        reloaded = await _reload(test_db_session, job.id)
+        assert secret not in str(reloaded.user_metadata)
+        assert reloaded.user_metadata["service_auth_required"] is True
+
+        run = await self._run_for(test_db_session, dataset.id)
+        assert run is not None
+        assert secret not in str((run.error_message, run.error_code, run.origin_kind))
+        assert secret not in str(captured)
+
+        assert await creds.claim_service_credential(kwargs["credential_ref"]) == secret
+
+    async def test_without_a_store_the_reupload_still_runs_on_the_durable_argument(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session,
+        no_credential_store,
+    ) -> None:
+        """State 3 at the second door. Same reason, same shape, own test.
+
+        Both doors are pinned separately on purpose: one of them silently
+        losing the fallback is exactly the half-migration this change exists
+        to finish, and a shared test would let either half regress alone.
+        """
+        secret = "tok-" + uuid.uuid4().hex
+        admin_id = await get_user_id(test_db_session, "admin")
+        dataset = await self._dataset(test_db_session, created_by=admin_id)
+        job = await _service_reupload_job(
+            test_db_session, dataset_id=dataset.id, created_by=admin_id
+        )
+
+        with structlog.testing.capture_logs() as captured:
+            async with _reupload_harness() as task:
+                resp = await client.post(
+                    f"/datasets/{dataset.id}/reupload/{job.id}/commit",
+                    json={"token": secret},
+                    headers=admin_auth_header,
+                )
+
+        assert resp.status_code == 202, resp.text
+        kwargs = task.defer_async.call_args.kwargs
+        assert kwargs["token"] == secret
+        assert kwargs["credential_ref"] is None
+
+        fallbacks = [
+            entry
+            for entry in captured
+            if entry.get("event") == "service_credential_durable_fallback"
+        ]
+        assert len(fallbacks) == 1, captured
+        assert fallbacks[0]["door"] == "reupload_commit"
+        assert secret not in str(fallbacks[0])
+
+    async def test_a_store_that_is_down_returns_503_and_rolls_the_request_back(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session,
+        down_credential_store,
+    ) -> None:
+        """State 2, staged before the commit so the rollback is total.
+
+        The reserved run is the part that matters: leaving one behind would
+        hold the dataset against the admission index and answer the retry —
+        the one the operator makes once Valkey is back — with `dataset_busy`.
+        """
+        admin_id = await get_user_id(test_db_session, "admin")
+        dataset = await self._dataset(test_db_session, created_by=admin_id)
+        job = await _service_reupload_job(
+            test_db_session, dataset_id=dataset.id, created_by=admin_id
+        )
+
+        async with _reupload_harness() as task:
+            resp = await client.post(
+                f"/datasets/{dataset.id}/reupload/{job.id}/commit",
+                json={"token": "never-stashed"},
+                headers=admin_auth_header,
+            )
+
+        assert resp.status_code == 503, resp.text
+        assert resp.json()["detail"]["code"] == "credential_store_unavailable"
+        task.defer_async.assert_not_awaited()
+        assert await self._run_for(test_db_session, dataset.id) is None
+        assert (await _reload(test_db_session, job.id)).status == "pending"
+
+    async def test_a_public_reupload_is_untouched_by_a_broken_store(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session,
+        down_credential_store,
+    ) -> None:
+        admin_id = await get_user_id(test_db_session, "admin")
+        dataset = await self._dataset(test_db_session, created_by=admin_id)
+        job = await _service_reupload_job(
+            test_db_session, dataset_id=dataset.id, created_by=admin_id
+        )
+
+        async with _reupload_harness() as task:
+            resp = await client.post(
+                f"/datasets/{dataset.id}/reupload/{job.id}/commit",
+                json={},
+                headers=admin_auth_header,
+            )
+
+        assert resp.status_code == 202, resp.text
+        kwargs = task.defer_async.call_args.kwargs
+        assert kwargs["token"] is None
+        assert kwargs["credential_ref"] is None
+
+
+# ---------------------------------------------------------------------------
+# Redemption — the worker end of the import door's handoff
+# ---------------------------------------------------------------------------
+
+
+class TestImportWorkerRedemption:
+    """``ingest_service`` spends the reference, and spends it once.
+
+    Driven through the real task entry point with only the outbound ogr2ogr
+    boundary faked, so the claim's PLACEMENT is under test and not just the
+    helper it calls.
+    """
+
+    async def _drive(
+        self, session, monkeypatch, *, credential_ref, token=None, error_text="stop"
+    ):
+        from app.processing.ingest import tasks_vector
+        from app.processing.ingest.ogr import IngestionError
+
+        admin_id = await get_user_id(session, "admin")
+        job = await _service_import_job(session, created_by=admin_id)
+
+        seen: dict = {}
+
+        class _FakeProcessingPort:
+            def build_gdal_source(self, *args, **kwargs):
+                return "FAKE_GDAL_SOURCE", "0"
+
+        async def _fallback(import_fn, source_layer, **kwargs):
+            seen["token"] = kwargs.get("token")
+            raise IngestionError(error_text)
+
+        monkeypatch.setattr("app.platform.security.validate_url_for_ssrf", AsyncMock())
+        monkeypatch.setattr(
+            "app.platform.extensions.get_processing_port", lambda: _FakeProcessingPort()
+        )
+        monkeypatch.setattr(
+            "app.processing.ingest.ogr.build_pg_conn_str", lambda: "PG:"
+        )
+        monkeypatch.setattr(
+            tasks_vector, "_run_service_import_with_wfs_fallback", _fallback
+        )
+
+        with pytest.raises(IngestionError):
+            await tasks_vector.ingest_service.func(
+                job_id=str(job.id),
+                attempt_id=str(job.attempt_id),
+                source_url=_SERVICE_URL,
+                source_layer="0",
+                user_id=str(admin_id),
+                token=token,
+                credential_ref=credential_ref,
+            )
+        return job, seen
+
+    async def test_the_reference_is_redeemed_for_the_fetch_and_spent(
+        self,
+        test_db_session,
+        monkeypatch,
+        credential_backend,  # noqa: F811
+    ) -> None:
+        secret = "tok-" + uuid.uuid4().hex
+        ref = await creds.stash_service_credential(secret)
+
+        _job, seen = await self._drive(test_db_session, monkeypatch, credential_ref=ref)
+
+        assert seen["token"] == secret
+        # Single-use: the same dispatch retried cannot fetch again. #1220's
+        # Decision 3 — a credential is request-scoped, so a run that outlives
+        # its credential must ask a human rather than retry unauthenticated
+        # and report the origin's 401 as the fault.
+        with pytest.raises(creds.CredentialExpiredError):
+            await creds.claim_service_credential(ref)
+
+    async def test_a_spent_reference_fails_the_job_rather_than_fetching_bare(
+        self,
+        test_db_session,
+        monkeypatch,
+        credential_backend,  # noqa: F811
+    ) -> None:
+        """The claim is placed AFTER phase 1 for this reason.
+
+        Phase 1 is what writes ``status='running'``, and the failure write at
+        the bottom of the task is fenced on it. Claim before phase 1 and a
+        spent credential leaves the job `pending` with nothing recorded — the
+        silent-hang shape, not a failure anyone can read.
+        """
+        from app.processing.ingest import tasks_vector
+
+        ref = await creds.stash_service_credential("already-spent")
+        assert await creds.claim_service_credential(ref) == "already-spent"
+
+        admin_id = await get_user_id(test_db_session, "admin")
+        job = await _service_import_job(test_db_session, created_by=admin_id)
+
+        called = {"fetch": False}
+
+        class _FakeProcessingPort:
+            def build_gdal_source(self, *args, **kwargs):
+                return "FAKE_GDAL_SOURCE", "0"
+
+        async def _fallback(import_fn, source_layer, **kwargs):
+            called["fetch"] = True
+
+        monkeypatch.setattr("app.platform.security.validate_url_for_ssrf", AsyncMock())
+        monkeypatch.setattr(
+            "app.platform.extensions.get_processing_port", lambda: _FakeProcessingPort()
+        )
+        monkeypatch.setattr(
+            "app.processing.ingest.ogr.build_pg_conn_str", lambda: "PG:"
+        )
+        monkeypatch.setattr(
+            tasks_vector, "_run_service_import_with_wfs_fallback", _fallback
+        )
+
+        with pytest.raises(creds.CredentialExpiredError):
+            await tasks_vector.ingest_service.func(
+                job_id=str(job.id),
+                attempt_id=str(job.attempt_id),
+                source_url=_SERVICE_URL,
+                source_layer="0",
+                user_id=str(admin_id),
+                credential_ref=ref,
+            )
+
+        # Never reached the origin: a fall-through would have collected a 401
+        # and reported a working service as broken.
+        assert called["fetch"] is False
+        reloaded = await _reload(test_db_session, job.id)
+        assert reloaded.status == "failed"
+        assert "already used or has expired" in (reloaded.error_message or "")
+
+    async def test_an_unreachable_store_is_an_outage_not_an_expiry(
+        self, down_credential_store
+    ) -> None:
+        """Two answers, and only one of them is about the credential.
+
+        A store that ANSWERS "no such key" is evidence the secret was claimed
+        or expired. A store that cannot be reached is evidence of an outage
+        and nothing else. Reporting the second as the first sends the reader
+        to re-issue a token that was never the problem — the #1277 finding,
+        pinned here for the door that inherited the mechanism.
+        """
+        with pytest.raises(creds.CredentialStoreUnavailable):
+            await creds.resolve_worker_credential(None, "a" * 24)
+
+    async def test_the_claimed_secret_is_scrubbed_out_of_the_failure(
+        self,
+        test_db_session,
+        monkeypatch,
+        credential_backend,  # noqa: F811
+    ) -> None:
+        """The exact-value layer, which only a holder of the value can do.
+
+        ``run_ogr2ogr_service`` and ``redact_url_credentials`` already scrub
+        by URL SHAPE, which covers a token nobody holds. This task now holds
+        one, so an origin that echoes it back in some other shape is covered
+        too — and ``error_message`` is a durable column, which is the whole
+        point of the lease.
+        """
+        secret = "tok-" + uuid.uuid4().hex
+        ref = await creds.stash_service_credential(secret)
+
+        job, _seen = await self._drive(
+            test_db_session,
+            monkeypatch,
+            credential_ref=ref,
+            error_text=f"origin rejected token={secret}",
+        )
+
+        reloaded = await _reload(test_db_session, job.id)
+        assert reloaded.status == "failed"
+        assert secret not in (reloaded.error_message or "")
+
+
+# ---------------------------------------------------------------------------
+# Renewal — the query the run-less import door forced open
+# ---------------------------------------------------------------------------
+
+
+class TestRenewalCoversEveryLeasingDoor:
+    """The regression the lease itself would have introduced.
+
+    ``_RENEWABLE_CREDENTIALS_SQL`` inner-joined ``dataset_refresh_runs``,
+    which every #1220 dispatch has and which the re-upload commit door writes
+    too (``create_pending_run``). The first-import door writes none. Left as
+    an inner join, an import's credential would have been renewed zero times
+    and expired at the TTL — so a protected import queued behind a long
+    ingest would fail ``credential_expired`` where today it simply waits.
+
+    No refresh-path test could have caught that, and no import-path test
+    catches a refresh-path regression from widening the join, so both live
+    here and both directions are asserted in one pass.
+    """
+
+    async def _procrastinate_row(self, session, *, job_id, ref, pj_status="todo"):
+        # Procrastinate's insert trigger writes procrastinate_events through
+        # unqualified names, so the schema has to be on the search_path for a
+        # hand-written INSERT the way it is for the library's own.
+        await session.execute(text("SET LOCAL search_path TO catalog, public"))
+        await session.execute(
+            text(
+                "INSERT INTO catalog.procrastinate_jobs "
+                "(queue_name, task_name, args, status) "
+                "VALUES ('ingest', 'ingest_service', "
+                "jsonb_build_object('job_id', CAST(:job_id AS text), "
+                "'credential_ref', CAST(:ref AS text)), "
+                "CAST(:pj_status AS catalog.procrastinate_job_status))"
+            ),
+            {"job_id": str(job_id), "ref": ref, "pj_status": pj_status},
+        )
+
+    async def _import_dispatch(self, session, *, ref, job_status="pending"):
+        """A leased first import: an ingest job with NO refresh run."""
+        admin_id = await get_user_id(session, "admin")
+        job = await _service_import_job(session, created_by=admin_id)
+        job.status = job_status
+        await self._procrastinate_row(session, job_id=job.id, ref=ref)
+        await session.commit()
+        return job
+
+    async def _refresh_dispatch(self, session, *, ref, run_status="pending"):
+        """A leased refresh: the #1220 shape, ingest job plus a run row."""
+        from app.platform.refresh.service import create_pending_run
+
+        admin_id = await get_user_id(session, "admin")
+        dataset = await create_dataset(
+            session,
+            created_by=admin_id,
+            name=f"Renewal {uuid.uuid4().hex[:8]}",
+            visibility="public",
+            source_url=_SERVICE_URL,
+        )
+        job = IngestJob(
+            dataset_id=dataset.id,
+            source_url=_SERVICE_URL,
+            source_layer="0",
+            created_by=admin_id,
+            status="pending",
+            user_metadata={"reupload": True, "dataset_id": str(dataset.id)},
+        )
+        session.add(job)
+        await session.commit()
+        await session.refresh(job)
+        run = await create_pending_run(
+            session,
+            dataset_id=dataset.id,
+            origin_kind="service",
+            trigger="api",
+            triggered_by=admin_id,
+            ingest_job_id=job.id,
+            feature_count_before=dataset.feature_count,
+        )
+        run.status = run_status
+        await self._procrastinate_row(session, job_id=job.id, ref=ref)
+        await session.commit()
+        return job
+
+    async def test_one_pass_renews_both_shapes(
+        self,
+        client: AsyncClient,
+        test_db_session,
+        credential_backend,  # noqa: F811
+    ) -> None:
+        """A run-bearing refresh and a run-less import, renewed together.
+
+        The refresh half is the regression guard on the LEFT JOIN: a
+        generalization that quietly stopped matching #1220's own shape would
+        be the worse bug, and it would look like a passing import test.
+        """
+        import_ref = await creds.stash_service_credential("import-waiting")
+        refresh_ref = await creds.stash_service_credential("refresh-waiting")
+        await self._import_dispatch(test_db_session, ref=import_ref)
+        await self._refresh_dispatch(test_db_session, ref=refresh_ref)
+
+        assert await creds.renew_queued_refresh_credentials(test_db_session) == 2
+
+        # Renewal must not consume: both are still claimable afterwards.
+        assert await creds.claim_service_credential(import_ref) == "import-waiting"
+        assert await creds.claim_service_credential(refresh_ref) == "refresh-waiting"
+
+    async def test_a_terminal_row_of_either_shape_is_not_renewed(
+        self,
+        client: AsyncClient,
+        test_db_session,
+        credential_backend,  # noqa: F811
+    ) -> None:
+        """Both stops still stop. Widening the join must not widen the life.
+
+        The import branch's stop is ``ingest_jobs.status`` because there is no
+        run to ask; the refresh branch's is the run's, unchanged. A pass that
+        renewed either of these would be durable storage wearing a TTL.
+        """
+        import_ref = await creds.stash_service_credential("import-is-over")
+        refresh_ref = await creds.stash_service_credential("refresh-is-over")
+        await self._import_dispatch(
+            test_db_session, ref=import_ref, job_status="failed"
+        )
+        await self._refresh_dispatch(
+            test_db_session, ref=refresh_ref, run_status="failed"
+        )
+
+        assert await creds.renew_queued_refresh_credentials(test_db_session) == 0
+
+    async def test_a_live_import_job_with_a_terminal_run_defers_to_the_run(
+        self,
+        client: AsyncClient,
+        test_db_session,
+        credential_backend,  # noqa: F811
+    ) -> None:
+        """The fallback is a fallback, not a second opinion.
+
+        When a run row EXISTS it owns the liveness question, exactly as it did
+        before the join was widened — the ingest job's own status must not
+        resurrect a credential the run has already finished with. The row here
+        has both: a terminal run and a job still marked running.
+        """
+        ref = await creds.stash_service_credential("run-said-no")
+        job = await self._refresh_dispatch(
+            test_db_session, ref=ref, run_status="succeeded"
+        )
+        job.status = "running"
+        await test_db_session.commit()
+
+        assert await creds.renew_queued_refresh_credentials(test_db_session) == 0

--- a/backend/tests/test_import_token_lease_1676.py
+++ b/backend/tests/test_import_token_lease_1676.py
@@ -370,6 +370,10 @@ class TestImportDoor:
 
         assert resp.status_code == 503, resp.text
         ref = task.defer_async.call_args.kwargs["credential_ref"]
+        # Asserted before the claim: claim_service_credential(None) raises the
+        # same CredentialExpiredError from its shape guard, so without this the
+        # test passes just as happily on a door that leased nothing at all.
+        assert ref
         with pytest.raises(creds.CredentialExpiredError):
             await creds.claim_service_credential(ref)
 

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -2839,7 +2839,14 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # derivation moved to the shared ingest/source_format.py (one import line),
     # and the DBF-truncation guard gained the comment recording that it is
     # keyed on the derived format, not the .zip suffix. Cap 1245 -> 1247, exact.
-    "backend/app/processing/ingest/tasks_reupload.py": 1247,
+    # feat(#1676): -5 — `_resolve_service_token`'s body moved out to
+    # platform/refresh/credentials.resolve_worker_credential so `ingest_service`
+    # can redeem the same way. Neither task module may import the other
+    # (tasks_reupload already reaches into tasks_vector at call time, so a
+    # top-level edge back would close a cycle), which is what put the shared
+    # copy in platform/. Ratchet DOWN in the same commit, per the no-headroom
+    # rule. Cap 1247 -> 1242, exact.
+    "backend/app/processing/ingest/tasks_reupload.py": 1242,
     # --- entered by the inclusion rule, feat(#1266) -----------------------
     # The refresh door crossed 1000 when it gained its third execution
     # strategy. Two thirds of the addition is the STAC dispatcher, which is
@@ -3281,7 +3288,17 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # dropped its nine-entry literal for settings.allowed_extensions_list, so
     # the two upload doors cannot answer differently. Ratchet DOWN in the same
     # commit, per the no-headroom rule. Cap 1151 -> 1144, exact.
-    "backend/app/modules/catalog/datasets/api/router_reupload.py": 1144,
+    # feat(#1676): +50 — the re-upload commit door leases its service token
+    # through the same one-use Valkey handoff the refresh door has used since
+    # #1220, instead of dispatching it as a durable task argument. Most of the
+    # lines are the staging block and its 503, placed before the commit for the
+    # reason the refresh door places its own there (a store failure rolls the
+    # whole request back rather than stranding a dispatch that can never
+    # authenticate), plus the comment recording why a storeless install falls
+    # back here and is refused at the refresh door. The rest is the discard
+    # wrapper on the defer rollback and the extra dispatch argument.
+    # Cap 1144 -> 1194, exact.
+    "backend/app/modules/catalog/datasets/api/router_reupload.py": 1194,
     # fix(#1218 review): +5 — VRT assembly stamps last_refreshed_at like every
     # other creation path, so a post-migration VRT does not report null while
     # a backfilled one carries a timestamp, with a note on why it is a Python
@@ -3367,7 +3384,16 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # warning is Shapefile-only and a File Geodatabase now arrives in a .zip
     # too. The derivation itself moved out to ingest/source_format.py, shared
     # with the reupload path. Cap 1083 -> 1085, exact.
-    "backend/app/processing/ingest/tasks_vector.py": 1085,
+    # feat(#1676): +32 — `ingest_service` accepts a `credential_ref` and
+    # redeems it once. Nearly all of it is two comments: why the claim sits
+    # AFTER phase 1 (the failure write below is fenced on `status == 'running'`,
+    # which phase 1 is what sets, so claiming earlier would leave a
+    # `credential_expired` failure unrecorded and the job pending until the
+    # stale sweep), and why the failure handler now scrubs the claimed secret
+    # by exact value the way `reupload_service` does — this task holds the
+    # value now, and the pattern layers only match tokens shaped like URLs.
+    # Cap 1085 -> 1117, exact.
+    "backend/app/processing/ingest/tasks_vector.py": 1117,
     # --- entered by the inclusion rule ------------------------------------
     # Crossed 1000 lines adding the "unable to open datasource" friendly-
     # message mapping shared by run_ogrinfo and run_ogr2ogr: the pattern
@@ -3456,7 +3482,15 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # analysis materialize path handing over one it just CTAS'd, and delete now
     # drops only the second; the caller is the only place that knows which.
     # Cap 1199 -> 1211, exact.
-    "backend/app/processing/ingest/service.py": 1211,
+    # feat(#1676): +48 — `queue_ingest_job`'s service branch leases the token
+    # rather than dispatching it. The 503 branch is the bulk: unlike the two
+    # doors that stage before their commit, this runs after `commit_import` has
+    # already committed the job, so an unreachable store has to finalize the
+    # job row itself before raising or it strands a pending row until the stale
+    # sweep. The rest is the discard on the defer rollback and the comment
+    # saying the state-1/state-3 choice is not this door's to make.
+    # Cap 1211 -> 1259, exact.
+    "backend/app/processing/ingest/service.py": 1259,
     # --- entered by the inclusion rule, feat(#765) -------------------------
     # First time this module crosses 1000. main sat at 994, six lines under the
     # gate, so it was going to fire on whoever added next; it fired here.

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -3490,7 +3490,16 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # sweep. The rest is the discard on the defer rollback and the comment
     # saying the state-1/state-3 choice is not this door's to make.
     # Cap 1211 -> 1259, exact.
-    "backend/app/processing/ingest/service.py": 1259,
+    # fix(#1689 codex r1): +25 — the rolling-deploy skew note. A worker from
+    # the previous generation takes `credential_ref` through `**kwargs` and
+    # discards it, and the review asked for a versioned task name to gate that.
+    # The comment records why the gate is the worse option (Procrastinate fails
+    # its own job on TaskNotFound but nothing writes the ingest_jobs row, so the
+    # user sees a hang instead of a retryable failure) and why the window is
+    # narrower here than at the refresh door, where #1220 accepted the same
+    # trade. Written down so the next review lands on the decision rather than
+    # re-deriving it. Cap 1259 -> 1284, exact.
+    "backend/app/processing/ingest/service.py": 1284,
     # --- entered by the inclusion rule, feat(#765) -------------------------
     # First time this module crosses 1000. main sat at 994, six lines under the
     # gate, so it was going to fire on whoever added next; it fired here.


### PR DESCRIPTION
Closes #1676

## The gap

Since #1220 the refresh door has handed its service token to the worker through a one-use Valkey lease. The API stashes the secret under a random reference with a short TTL, only the reference reaches `catalog.procrastinate_jobs.args`, and the worker consumes it with `GETDEL`. The first-import and reupload-commit doors still put the raw token into those durable task args, so a failed or queued job held plaintext until the retention purge, while the import UI told the user that tokens are "used for this import and are never stored".

#1678 fixed the copy half. This is the mechanism half.

## What changed

Both doors take the same channel now. Which of the three states a request lands in is keyed on what the install has, not on which door the request came through.

| install state | first import | reupload commit | refresh (#1220, unchanged) |
| --- | --- | --- | --- |
| store configured and reachable | stash, `credential_ref` in the args, `GETDEL` in the worker | same | same |
| store configured, the stash fails | 503 `credential_store_unavailable`, job finalized `failed` | 503 `credential_store_unavailable`, whole request rolled back | 503 `credential_store_unavailable`, whole request rolled back |
| no store configured (`REDIS_URL` unset, which is the default) | durable `token` arg as before, logged | durable `token` arg as before, logged | 503 at the door, unchanged |

State 3 is the one asymmetry, and it is why #1220 stopped where it did. `REDIS_URL` is unset by default and the `valkey` service sits behind the `cloud-dev` compose profile, so refusing there would stop protected imports working on every stock install. That trades a latent problem for a live one. The refresh door keeps refusing at state 3, because token-bearing refresh has never worked without a store and nothing regresses by leaving it alone.

The state-3 branch logs `service_credential_durable_fallback` with the door name (never the token, never the reference), so an operator can answer "is this install actually leasing?" from logs rather than from settings archaeology.

`resolve_dispatch_credential` makes that decision in one place. The worker-side redeem moved out to `resolve_worker_credential` so `ingest_service` and `reupload_service` share one copy without importing each other: `tasks_reupload` already reaches into `tasks_vector` at call time, so a top-level edge back would close a cycle.

## Two things the lease needed on the way in

The renewal query would have skipped imports entirely. `_RENEWABLE_CREDENTIALS_SQL` inner-joined `dataset_refresh_runs`. The reupload-commit door writes one of those rows via `create_pending_run`, so it inherits renewal for free. The first-import door writes none, and left as an inner join its credential would have been renewed zero times and then expired at the 900s TTL. A protected import queued behind a long ingest would fail `credential_expired` where today it simply waits. The join is `LEFT` now, with `ingest_jobs.status` as the liveness stop when there is no run. `EXPIRE` still cannot resurrect a claimed key, so the self-terminating property is unchanged.

`ingest_service` claims after phase 1, not before it. Its failure write is fenced on `status = 'running'`, and phase 1 is what sets that, so an earlier claim would leave a `credential_expired` failure unrecorded and the job `pending` until the stale sweep. That is a silent hang rather than a readable failure. The task also scrubs the claimed secret out of exceptions by exact value now, the way `reupload_service` does, because it holds the value; the existing pattern layers only match tokens shaped like a URL.

## Security rationale

ADR-002 invariant 4 says a service credential never lands in a committed row. Two of the three doors were violating it. On any install with a shared credential store they no longer do: the only thing reaching a durable surface is a random reference that means nothing once claimed or expired, and the worker's `GETDEL` makes a second claim impossible. On an install with no store the exposure is exactly what it was before this PR, and it stays bounded, because the worker deletes successful jobs (`delete_jobs="successful"`) so plaintext survives only in failed or pending rows.

## UI copy

No locale changes. #1678's wording, "Service tokens are used for this import and are never stored with the dataset", is accurate in every state after this change and understates it on a leased install. The token has never gone into `user_metadata` (both doors strip it and persist only `service_auth_required`), so "never stored with the dataset" was already literally true. What was untrue was the broader reading, and that is what the lease closes. An unconditional "never stored" of the kind the refresh panel uses would still be wrong for state 3, so the hedged sentence stays.

## Schema, API, config

No migration. No OpenAPI change (`make openapi-check` is clean), so no SDK or `api.generated.ts` regeneration.

## Verification

```
cd backend && uv run pytest tests/test_import_token_lease_1676.py -v     # 16 passed

cd backend && uv run pytest tests/test_service_refresh_1220.py tests/test_credential_renewal_tenancy_1277.py \
    tests/test_reupload_service.py tests/test_ingest.py tests/test_reupload.py \
    tests/test_dataset_refresh_runs.py tests/test_ingest_progress.py \
    tests/test_commit_revalidates_source_url.py -q                       # 261 passed

cd backend && uv run pytest tests/test_rule1_structural.py tests/test_rule2_structural.py \
    tests/test_defer_orphan_guard.py tests/test_jobs_router.py tests/test_refresh_gate_1269.py \
    tests/test_refresh_pagination_1675.py tests/test_sdks_round_trip.py \
    tests/test_manifest_apply_service.py tests/test_ingest_job_attempt_fencing.py -q

cd backend && uv run pytest tests/test_layering.py -q
cd backend && uv run ruff check . && uv run ruff format --check .
make openapi-check
```

Counterfactuals, run against the new tests, because a lease test that passes without the lease is worth nothing:

- restore the inner join in `_RENEWABLE_CREDENTIALS_SQL`, and `test_one_pass_renews_both_shapes` fails on `assert 1 == 2`;
- make `resolve_dispatch_credential` always return the durable token, and the state-1 and state-2 tests at both doors fail (4 of 16).

https://claude.ai/code/session_01BXUUv3x71zWaLKEvoL4cTY
