### PR TITLE
fix(compose): bound every prod container's json-file log

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -146,6 +146,16 @@ x-hardened-base: &hardened-base
     - SETUID
   read_only: true
 
+# fix(#1690): bound every container's json-file log — with no options the
+# default driver grows without limit for the life of the container (observed
+# on the demo VM: a four-week-old container already held a 36M log). 50m x 3
+# keeps ~150M of recent log per service, enough for incident forensics.
+x-bounded-logs: &bounded-logs
+  driver: json-file
+  options:
+    max-size: "50m"
+    max-file: "3"
+
 # Registry + owner for the published images. Override REGISTRY/IMAGE_OWNER only
 # for a fork or a mirror; defaults point at the canonical GHCR namespace.
 x-image-base: &image-registry ${REGISTRY:-ghcr.io}/${IMAGE_OWNER:-geolens-io}
@@ -155,6 +165,7 @@ x-image-base: &image-registry ${REGISTRY:-ghcr.io}/${IMAGE_OWNER:-geolens-io}
 # ==============================================================================
 services:
   db:
+    logging: *bounded-logs
     # PostGIS 17 + pgvector, built locally from ./db — a thin layer on the
     # OFFICIAL postgis/postgis image (the source maintainer) plus the pgvector
     # apt package. No single upstream image bundles both PostGIS and pgvector,
@@ -214,6 +225,7 @@ services:
       - SETUID
 
   migrate:
+    logging: *bounded-logs
     # One-shot alembic upgrade, runs from the baked api image (alembic/ +
     # alembic.ini are COPYed into /app — Dockerfile backend-base).
     image: ${REGISTRY:-ghcr.io}/${IMAGE_OWNER:-geolens-io}/geolens-api:${GEOLENS_VERSION:-latest}
@@ -248,6 +260,7 @@ services:
         condition: service_healthy
 
   api:
+    logging: *bounded-logs
     image: ${REGISTRY:-ghcr.io}/${IMAGE_OWNER:-geolens-io}/geolens-api:${GEOLENS_VERSION:-latest}
     # GAP-003: override the baked image CMD to add --proxy-headers so uvicorn
     # populates request.client from X-Forwarded-For / X-Real-IP sent by the
@@ -341,6 +354,7 @@ services:
         condition: service_completed_successfully
 
   worker:
+    logging: *bounded-logs
     # The worker is the SAME image as api — identical backend-base; the published
     # geolens-worker image differs only in its baked ENTRYPOINT/CMD/HEALTHCHECK.
     # Run it from the PUBLIC geolens-api image with those three overridden (the
@@ -407,6 +421,7 @@ services:
         condition: service_completed_successfully
 
   titiler:
+    logging: *bounded-logs
     # Third-party image — identical to docker-compose.yml.
     # 2.2.1 per the 2026-08 reassessment (#1190); see the note there.
     image: ghcr.io/developmentseed/titiler:2.2.1
@@ -519,6 +534,7 @@ services:
         condition: service_healthy
 
   frontend:
+    logging: *bounded-logs
     # Published nginx image: serves the built SPA on :8080 and proxies /api ->
     # api:8000 and /raster-tiles/* -> the api raster proxy internally (see
     # frontend/nginx.conf). No build, no bind-mounts, no Vite.
@@ -570,6 +586,7 @@ services:
         condition: service_healthy
 
   backup:
+    logging: *bounded-logs
     # Backup runs by default — no --profile flag needed (BKP-01).
     # Pulls the published multi-arch geolens-backup image from GHCR;
     # no local build required on the operator host.

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -150,6 +150,13 @@ x-hardened-base: &hardened-base
 # default driver grows without limit for the life of the container (observed
 # on the demo VM: a four-week-old container already held a 36M log). 50m x 3
 # keeps ~150M of recent log per service, enough for incident forensics.
+# The driver is pinned deliberately: a stock install (daemon default
+# json-file, no options) is the audience this protects, and omitting the
+# driver would fail container create wherever the daemon default is not
+# json-file, because the options below are json-file-specific. Operators who
+# centralize logs at the daemon level (journald/fluentd/awslogs) should
+# override `logging:` per service in a compose override file with their
+# driver; that override replaces this block wholesale.
 x-bounded-logs: &bounded-logs
   driver: json-file
   options:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -670,6 +670,7 @@ services:
 
   # --- cloud-dev profile: local S3 + cache (identical to docker-compose.yml) ---
   minio:
+    logging: *bounded-logs
     image: quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z@sha256:14cea493d9a34af32f524e538b8346cf79f3321eff8e708c1e2960462bd8936e
     profiles: ["cloud-dev"]
     # INST-01 + Codex P1 (true fail-closed, parse-safe) — mirrors the
@@ -726,6 +727,7 @@ services:
       start_period: 5s
 
   minio-setup:
+    logging: *bounded-logs
     image: quay.io/minio/mc:RELEASE.2025-08-13T08-35-41Z@sha256:a7fe349ef4bd8521fb8497f55c6042871b2ae640607cf99d9bede5e9bdf11727
     profiles: ["cloud-dev"]
     # BUG-015 (Phase 1184): same fix as docker-compose.yml — mounted script
@@ -747,6 +749,7 @@ services:
     entrypoint: ["/bin/sh", "/usr/local/bin/minio-setup.sh"]
 
   valkey:
+    logging: *bounded-logs
     image: valkey/valkey:8.1.7-alpine
     profiles: ["cloud-dev"]
     security_opt:


### PR DESCRIPTION
From the demo VM audit: `docker inspect` shows `{json-file map[]}` for the prod services — no rotation options, so container logs grow without limit for the container's lifetime (a four-week-old monitoring container on the demo already held a 36M log; app containers only look small because recreates have been resetting them).

Adds an `x-bounded-logs` anchor (json-file, max-size 50m, max-file 3) applied to all seven services in `docker-compose.prod.yml`. ~150M ceiling of recent log per service, enough for incident forensics.

Verified: `docker compose -f docker-compose.prod.yml config` parses and renders the logging block on all seven services.

Deployment note: existing deployments pick this up on the next container recreate (`up -d` after pulling the compose change recreates due to config drift); a plain restart is not enough.

No app code, schema, or contract changes.

https://claude.ai/code/session_01BXUUv3x71zWaLKEvoL4cTY