### PR TITLE
fix(catalog): allow anonymous COG download for public+published rasters

### DIFF
--- a/backend/app/modules/catalog/datasets/api/router_export.py
+++ b/backend/app/modules/catalog/datasets/api/router_export.py
@@ -60,7 +60,7 @@ from app.core.dependencies import get_db
 from app.core.db.tenant_session import current_tenant_var
 from app.core.tenancy import is_multi_tenant
 from app.core.public_urls import get_public_urls
-from app.platform.extensions import get_catalog_port
+from app.platform.extensions import get_catalog_port, get_permission_extension
 from app.platform.http.ranges import (
     RANGE_UNSATISFIABLE,
     if_match_passes,
@@ -778,9 +778,23 @@ async def _resolve_download_user(
     downstream consumer (``download_cog``) is responsible for enforcing
     public visibility when user is None.
 
-    401 is reserved for: no auth signal at all (no header AND no token),
-    invalid token bytes, wrong typ, wrong scope, expired token, or a
-    sub-bearing token whose user no longer exists / is inactive.
+    No auth signal at all (no header AND no ``?token=``) also returns
+    ``None`` rather than raising 401: mirrors ``get_optional_user``, which is
+    what ``/datasets/{id}/export`` (``processing/export/router.py``) depends
+    on directly. Before this, a plain anonymous GET here — no Authorization
+    header, no minted token — hit the unconditional 401 below regardless of
+    the dataset's visibility, so a public+published raster's COG could not be
+    opened directly in QGIS/GDAL the way its tiles and vector export already
+    can; only a caller that first minted a download token could get through.
+    ``download_cog`` runs the same ``check_dataset_access_or_anonymous`` +
+    public-visibility gate the export route runs, so this closes that
+    asymmetry without loosening anything: a private/restricted/unpublished
+    dataset still denies (404, to hide existence) once ``download_cog``
+    applies that gate.
+
+    401 is reserved for an auth signal that is actually invalid: bad token
+    bytes, wrong typ, wrong scope, expired token, or a sub-bearing token
+    whose user no longer exists / is inactive.
     """
     if user is not None:
         return user
@@ -853,18 +867,27 @@ async def _resolve_download_user(
                 found = result.scalar_one_or_none()
                 if found and found.is_active and found.status == "active":
                     return found
-            # Sub-bearing token whose user disappeared or is inactive — 401
-            # (fall through to the unconditional 401 below).
+            # Sub-bearing token whose user disappeared or is inactive — 401.
+            # This IS an invalid auth signal (a token was presented and its
+            # sub claim does not resolve to a usable user), unlike the
+            # no-token case below, so it stays a hard 401 rather than falling
+            # through to anonymous.
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Authentication required",
+            )
         else:
             # KNOWN-01: no-sub anonymous download token. Token is valid
             # (typ/scope/exp all passed); return None and let download_cog
             # enforce public-visibility as defense-in-depth.
             return None
 
-    raise HTTPException(
-        status_code=status.HTTP_401_UNAUTHORIZED,
-        detail="Authentication required",
-    )
+    # No Authorization header, no API key, no ?token= at all: no auth signal
+    # to reject. Return None so download_cog's own
+    # check_dataset_access_or_anonymous + public-visibility gate decides
+    # access, the same way the export route's get_optional_user dependency
+    # lets export_dataset_endpoint decide.
+    return None
 
 
 # fix(#1528): HEAD alongside GET. FastAPI's APIRoute does not add it the way
@@ -917,6 +940,16 @@ async def download_cog(
     # docstring moves openapi.json and churns both SDKs and the CLI for prose
     # about an operation the schema does not carry, so it lives on the branch
     # itself instead.
+    #
+    # Same reasoning for what follows: `user` may ALSO be None for a plain
+    # anonymous request with no auth signal at all (no header, no ?token=),
+    # not only for the KNOWN-01 no-sub token case the docstring above
+    # describes — see `_resolve_download_user`. That case is new
+    # (fix(anon-raster-download)): a public+published raster's COG used to
+    # 401 an anonymous caller unconditionally before reaching this function,
+    # which the docstring never had to mention because it never happened.
+    # It's a comment rather than a docstring addition for the same
+    # openapi.json/SDK/CLI churn reason.
     from slugify import slugify
 
     from app.modules.auth.permissions import get_effective_permissions
@@ -930,13 +963,15 @@ async def download_cog(
         )
 
     # 2. Visibility + permission check (branches on authenticated vs anonymous).
+    # Mirrors export_dataset_endpoint's gate (processing/export/router.py)
+    # exactly: anonymous covers both a plain unauthenticated GET (no header,
+    # no ?token=) and a mint-issued no-sub token, since _resolve_download_user
+    # returns None for both.
     if user is None:
-        # Anonymous download via mint-issued no-sub token. The mint endpoint at
-        # POST /auth/download-token/{id} already enforced
-        # check_dataset_access_or_anonymous(); the token's typ/scope/exp checks
-        # in _resolve_download_user are the auth gate. Still require public
-        # visibility here as defense-in-depth (a tampered/replayed token
-        # cannot grant access to a private dataset).
+        # Anonymous download: enforce public+published gate via the anon-aware
+        # helper (raises 404 to hide existence on denial), then a
+        # defense-in-depth guard requiring public visibility — a tampered or
+        # replayed download token cannot grant access to a private dataset.
         await check_dataset_access_or_anonymous(db, dataset, dataset_id, user)
         if dataset.record.visibility != "public":
             raise HTTPException(
@@ -944,11 +979,24 @@ async def download_cog(
                 detail="Anonymous download requires public dataset",
             )
     else:
-        # Authenticated path: full RBAC visibility check + export permission.
+        # Authenticated path: full RBAC visibility check + export capability.
         await check_dataset_access(db, dataset, dataset_id, user)
         user_roles = await get_user_roles(db, user)
         matrix = await get_effective_permissions(db)
-        if not any(matrix.get(role, {}).get("export", False) for role in user_roles):
+        # Route through the permission extension point (same call
+        # export_dataset_endpoint makes) rather than inlining the per-role
+        # matrix check, so a deployment that registers a custom
+        # PermissionExtension applies its policy here too.
+        # DefaultPermissionExtension.check_permission reduces to the same
+        # any(matrix...) check, so OSS behavior is unchanged.
+        granted = await get_permission_extension().check_permission(
+            db,
+            user,
+            "export",
+            user_roles=user_roles,
+            permission_matrix=matrix,
+        )
+        if not granted:
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,
                 detail="Missing permission: export",

--- a/backend/app/modules/catalog/datasets/api/router_export.py
+++ b/backend/app/modules/catalog/datasets/api/router_export.py
@@ -800,8 +800,18 @@ async def _resolve_download_user(
         return user
 
     # Fallback: download-scoped JWT in ?token= query param (browser <a href> downloads)
+    #
+    # fix(#1693 codex r1): check presence (`is not None`), not truthiness. A
+    # URL with a bare `?token=` (empty value) is a PRESENT-but-malformed
+    # credential — jwt.decode("") raises DecodeError ("Not enough segments"),
+    # a PyJWTError caught below and turned into 401 — not an ABSENT one. The
+    # `if qt:` this replaces treated "" the same as "no ?token= at all" and
+    # fell all the way through to the anonymous return None below it, which
+    # would hide a client's broken token propagation behind a silent
+    # anonymous success on a public dataset instead of the 401 that every
+    # other malformed-token case in this block raises.
     qt = request.query_params.get("token")
-    if qt:
+    if qt is not None:
         # WR-04 (Phase 1071 review): no audience claim is verified here because
         # the mint endpoint (auth/router.py) does not emit an `aud` claim in
         # download-token payloads. If a future change adds `aud` to minted tokens
@@ -945,9 +955,9 @@ async def download_cog(
     # anonymous request with no auth signal at all (no header, no ?token=),
     # not only for the KNOWN-01 no-sub token case the docstring above
     # describes — see `_resolve_download_user`. That case is new
-    # (fix(anon-raster-download)): a public+published raster's COG used to
-    # 401 an anonymous caller unconditionally before reaching this function,
-    # which the docstring never had to mention because it never happened.
+    # (fix(#1693): a public+published raster's COG used to 401 an anonymous
+    # caller unconditionally before reaching this function, which the
+    # docstring never had to mention because it never happened).
     # It's a comment rather than a docstring addition for the same
     # openapi.json/SDK/CLI churn reason.
     from slugify import slugify

--- a/backend/tests/test_cog_download_access.py
+++ b/backend/tests/test_cog_download_access.py
@@ -1,0 +1,212 @@
+"""Regression tests for the anonymous-access asymmetry between
+``/datasets/{id}/export`` (vector) and ``/datasets/{id}/download/cog``
+(raster).
+
+Before this fix, ``download_cog``'s own visibility gate
+(``check_dataset_access_or_anonymous`` + a public-visibility
+defense-in-depth check) was correct and already matched
+``/export``'s — but a plain anonymous GET (no Authorization header, no
+minted ``?token=``) never reached it: the ``_resolve_download_user``
+dependency unconditionally raised 401 first. That meant a public+published
+raster's tiles rendered anonymously while its COG could only be downloaded
+after a separate authenticated or token-minting round trip, breaking the
+"download this and open it in QGIS" flow for exactly the showcase rasters.
+
+Mirrors ``test_export_access.py``'s EXP-01/EXP-02 matrix for the COG route:
+  - anon + public+published -> 200
+  - anon + public-unpublished (record_status="internal") -> {401,403,404}
+  - anon + private -> {401,403,404} (404 specifically: existence hiding)
+  - anon + restricted -> {401,403,404}
+  - non-owner authenticated (viewer, not the admin owner) + private ->
+    {401,403,404}
+
+Requirements:
+  - Docker database must be running (docker compose up db)
+  - Alembic migrations must be applied
+  - Run with: set -a && source ../.env.test && set +a
+               uv run pytest tests/test_cog_download_access.py -v
+"""
+
+from httpx import AsyncClient
+
+from app.platform.storage import get_storage
+
+from tests.factories import create_raster_dataset, get_user_id
+
+_COG_BYTES = b"GEOLENS-TEST-COG-BYTES" * 64
+
+
+async def _raster_dataset_with_bytes(session, *, visibility, record_status, created_by):
+    """A raster Dataset + RasterAsset with real bytes in local storage.
+
+    Mirrors ``test_cog_head_ranges_1528.py``'s ``_raster_dataset`` fixture:
+    the conftest points the storage singleton at a ``LocalStorageProvider``
+    rooted in the per-test staging dir, so ``get_storage().put`` writes real
+    bytes a 200 response actually streams back.
+    """
+    dataset = await create_raster_dataset(
+        session,
+        created_by=created_by,
+        name=f"CogDownloadAccess {visibility}/{record_status}",
+        visibility=visibility,
+        record_status=record_status,
+        create_raster_asset=True,
+    )
+    # create_raster_dataset doesn't return the RasterAsset row directly, so
+    # look up the asset_uri it stamped and write real bytes for it.
+    from sqlalchemy import select
+
+    from app.processing.raster.models import RasterAsset
+
+    result = await session.execute(
+        select(RasterAsset).where(RasterAsset.dataset_id == dataset.id)
+    )
+    raster_asset = result.scalar_one()
+    await get_storage().put(raster_asset.asset_uri, _COG_BYTES)
+    return dataset
+
+
+# ---------------------------------------------------------------------------
+# Positive guard
+# ---------------------------------------------------------------------------
+
+
+async def test_anon_cog_download_public_published_allowed(
+    client: AsyncClient,
+    test_db_session,
+):
+    """Anonymous GET (no header, no ?token=) of a public+published raster's
+    COG must return 200 and stream the stored bytes back — the exact case
+    the reported asymmetry broke.
+    """
+    admin_id = await get_user_id(test_db_session, "admin")
+    ds = await _raster_dataset_with_bytes(
+        test_db_session,
+        visibility="public",
+        record_status="published",
+        created_by=admin_id,
+    )
+
+    resp = await client.get(f"/datasets/{ds.id}/download/cog")
+
+    assert resp.status_code == 200, (
+        f"Expected 200 for anon download of public+published raster COG, "
+        f"got {resp.status_code}: {resp.text}"
+    )
+    assert resp.content == _COG_BYTES
+    assert resp.headers.get("content-type") == "image/tiff"
+
+
+# ---------------------------------------------------------------------------
+# Deny matrix
+# ---------------------------------------------------------------------------
+
+
+async def test_anon_cog_download_public_unpublished_denied(
+    client: AsyncClient,
+    test_db_session,
+):
+    """Anonymous download of a public but unpublished (internal) raster must
+    be denied — status in {401, 403, 404}.
+    """
+    admin_id = await get_user_id(test_db_session, "admin")
+    ds = await create_raster_dataset(
+        test_db_session,
+        created_by=admin_id,
+        name="CogDownloadPublicUnpublishedDenied",
+        visibility="public",
+        record_status="internal",  # unpublished
+        create_raster_asset=True,
+    )
+
+    resp = await client.get(f"/datasets/{ds.id}/download/cog")
+
+    assert resp.status_code in {401, 403, 404}, (
+        f"Expected denial (401/403/404) for anon download of public+unpublished "
+        f"raster, got {resp.status_code}: {resp.text}"
+    )
+
+
+async def test_anon_cog_download_private_denied(
+    client: AsyncClient,
+    test_db_session,
+):
+    """Anonymous download of a private+published raster must be denied with
+    404 specifically — check_dataset_access_or_anonymous hides existence for
+    anon callers on non-public datasets, so this must not leak a 401/403 that
+    confirms the dataset exists.
+    """
+    admin_id = await get_user_id(test_db_session, "admin")
+    ds = await create_raster_dataset(
+        test_db_session,
+        created_by=admin_id,
+        name="CogDownloadPrivateDenied",
+        visibility="private",
+        record_status="published",
+        create_raster_asset=True,
+    )
+
+    resp = await client.get(f"/datasets/{ds.id}/download/cog")
+
+    assert resp.status_code == 404, (
+        f"Expected 404 (existence-hiding) for anon download of private raster, "
+        f"got {resp.status_code}: {resp.text}"
+    )
+
+
+async def test_anon_cog_download_restricted_denied(
+    client: AsyncClient,
+    test_db_session,
+):
+    """Anonymous download of a restricted+published raster must be denied —
+    status in {401, 403, 404}.
+    """
+    admin_id = await get_user_id(test_db_session, "admin")
+    ds = await create_raster_dataset(
+        test_db_session,
+        created_by=admin_id,
+        name="CogDownloadRestrictedDenied",
+        visibility="restricted",
+        record_status="published",
+        create_raster_asset=True,
+    )
+
+    resp = await client.get(f"/datasets/{ds.id}/download/cog")
+
+    assert resp.status_code in {401, 403, 404}, (
+        f"Expected denial (401/403/404) for anon download of restricted raster, "
+        f"got {resp.status_code}: {resp.text}"
+    )
+
+
+async def test_non_owner_cog_download_private_denied(
+    client: AsyncClient,
+    test_db_session,
+    viewer_auth_header: dict,
+):
+    """Authenticated non-owner (viewer) download of a private raster must be
+    denied — status in {401, 403, 404}, per the existing authenticated-branch
+    policy (check_dataset_access raises 404 for non-owner denials).
+
+    The dataset is owned by admin; the viewer is a distinct user who is
+    neither the owner nor an admin.
+    """
+    admin_id = await get_user_id(test_db_session, "admin")
+    ds = await create_raster_dataset(
+        test_db_session,
+        created_by=admin_id,
+        name="CogDownloadNonOwnerPrivateDenied",
+        visibility="private",
+        record_status="published",
+        create_raster_asset=True,
+    )
+
+    resp = await client.get(
+        f"/datasets/{ds.id}/download/cog",
+        headers=viewer_auth_header,
+    )
+
+    assert resp.status_code in {401, 403, 404}, (
+        f"Expected denial (401/403/404) for non-owner (viewer) download of "
+        f"private raster, got {resp.status_code}: {resp.text}"
+    )

--- a/backend/tests/test_cog_download_access.py
+++ b/backend/tests/test_cog_download_access.py
@@ -97,6 +97,33 @@ async def test_anon_cog_download_public_published_allowed(
     assert resp.headers.get("content-type") == "image/tiff"
 
 
+async def test_anon_cog_download_with_empty_token_param_is_401(
+    client: AsyncClient,
+    test_db_session,
+):
+    """fix(#1693 codex r1): a bare ``?token=`` (empty value) must 401, not
+    fall through to the anonymous branch as if no token were supplied at
+    all — even for a public+published raster where the anonymous branch
+    would otherwise return 200. An empty value is a PRESENT, malformed
+    credential, not an ABSENT one.
+    """
+    admin_id = await get_user_id(test_db_session, "admin")
+    ds = await _raster_dataset_with_bytes(
+        test_db_session,
+        visibility="public",
+        record_status="published",
+        created_by=admin_id,
+    )
+
+    resp = await client.get(f"/datasets/{ds.id}/download/cog?token=")
+
+    assert resp.status_code == 401, (
+        f"Expected 401 for an empty ?token= on a public+published raster "
+        f"(a malformed credential must not be treated as no credential), "
+        f"got {resp.status_code}: {resp.text}"
+    )
+
+
 # ---------------------------------------------------------------------------
 # Deny matrix
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_dcat.py
+++ b/backend/tests/test_dcat.py
@@ -1047,7 +1047,7 @@ async def test_dcat_raster_does_not_advertise_the_cog_download_url(
 ):
     """DCAT does not advertise ``/download/cog`` as a raster distribution URL.
 
-    fix(anon-raster-download): a public+published raster (this fixture's
+    fix(#1693): a public+published raster (this fixture's
     shape) is now directly downloadable by an anonymous caller with no
     minted token, matching ``/export``'s anonymous-access contract. But a
     private/restricted/unpublished raster still is not, and DCAT's feed has

--- a/backend/tests/test_dcat.py
+++ b/backend/tests/test_dcat.py
@@ -1039,18 +1039,22 @@ async def test_dcat_raster_advertises_the_tile_template(
 
 @pytest.mark.anyio
 @pytest.mark.parametrize("record_type", ["raster_dataset", "vrt_dataset"])
-async def test_dcat_raster_does_not_advertise_the_token_gated_cog_download(
+async def test_dcat_raster_does_not_advertise_the_cog_download_url(
     client: AsyncClient,
     admin_auth_header: dict,
     test_db_session,
     record_type: str,
 ):
-    """``/download/cog`` 401s an anonymous caller, and this feed serves those.
+    """DCAT does not advertise ``/download/cog`` as a raster distribution URL.
 
-    Reaching it needs a download-scoped token minted by a separate POST to
-    ``/auth/download-token/{id}``, which no generic DCAT client will make, so
-    advertising it — as ``downloadURL`` in two of the three profiles — would
-    publish a link that fails for the feed's audience.
+    fix(anon-raster-download): a public+published raster (this fixture's
+    shape) is now directly downloadable by an anonymous caller with no
+    minted token, matching ``/export``'s anonymous-access contract. But a
+    private/restricted/unpublished raster still is not, and DCAT's feed has
+    no per-caller way to express that distinction in a single accessURL —
+    advertising the download link unconditionally would still publish one
+    that 404s for a generic DCAT client crawling a catalog that also lists
+    non-public datasets.
     """
     session = test_db_session
     admin_id = await get_user_id(session, "admin")

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -4051,7 +4051,19 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # the export download can evaluate the same preconditions against the same
     # kind of strong ETag. Everything seven review rounds settled travelled with
     # them; only the home changed. Cap 1686 -> 1490, exact.
-    "backend/app/modules/catalog/datasets/api/router_export.py": 1490,
+    # fix(anon-raster-download): +48. _resolve_download_user's no-auth-signal
+    # case now returns None instead of an unconditional 401 (mirroring
+    # get_optional_user, what /export's dependency already does), so
+    # download_cog's existing check_dataset_access_or_anonymous +
+    # public-visibility gate — previously unreachable for a plain anonymous
+    # GET — actually runs. download_cog's authenticated branch also now
+    # routes its capability check through get_permission_extension() instead
+    # of inlining the matrix lookup, matching export_dataset_endpoint. The
+    # docstring (published OpenAPI description) is left untouched to avoid
+    # openapi.json/SDK/CLI churn; the new None case is explained in a plain
+    # comment instead, same as the file already does for the HEAD/GET
+    # docstring split above it. Cap 1490 -> 1538, exact.
+    "backend/app/modules/catalog/datasets/api/router_export.py": 1538,
     # fix(#1532 review r29): first entry — crossed _RATCHET_INCLUSION_LOC. The
     # export artifact cache: everything is in the key (stamp, size, digest,
     # nonce), freshness and reclamation read one publication bound that is a

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -4051,7 +4051,7 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # the export download can evaluate the same preconditions against the same
     # kind of strong ETag. Everything seven review rounds settled travelled with
     # them; only the home changed. Cap 1686 -> 1490, exact.
-    # fix(anon-raster-download): +48. _resolve_download_user's no-auth-signal
+    # fix(#1693): +48. _resolve_download_user's no-auth-signal
     # case now returns None instead of an unconditional 401 (mirroring
     # get_optional_user, what /export's dependency already does), so
     # download_cog's existing check_dataset_access_or_anonymous +
@@ -4062,8 +4062,12 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # docstring (published OpenAPI description) is left untouched to avoid
     # openapi.json/SDK/CLI churn; the new None case is explained in a plain
     # comment instead, same as the file already does for the HEAD/GET
-    # docstring split above it. Cap 1490 -> 1538, exact.
-    "backend/app/modules/catalog/datasets/api/router_export.py": 1538,
+    # docstring split above it. fix(#1693 codex r1): +10 more —
+    # `if qt:` -> `if qt is not None:` so a present-but-empty ?token= 401s
+    # through the existing PyJWTError path instead of falling through to the
+    # new anonymous return None as if no token were supplied. Cap
+    # 1490 -> 1548, exact.
+    "backend/app/modules/catalog/datasets/api/router_export.py": 1548,
     # fix(#1532 review r29): first entry — crossed _RATCHET_INCLUSION_LOC. The
     # export artifact cache: everything is in the key (stamp, size, digest,
     # nonce), freshness and reclamation read one publication bound that is a


### PR DESCRIPTION
## The asymmetry

`GET /datasets/{id}/export` (vector) lets an anonymous caller download a public+published dataset outright. `GET /datasets/{id}/download/cog` (raster) 401'd every anonymous caller unconditionally — even for a public+published raster whose tiles already render anonymously — unless the caller first minted a download-scoped token via `POST /auth/download-token/{id}`. That broke "download this raster and open it in QGIS" for exactly the datasets meant to be showcased.

The route's *own* access gate (`check_dataset_access_or_anonymous` + a public-visibility defense-in-depth check) was already correct and already matched the export route's — the bug was one level up, in the `_resolve_download_user` dependency: when there was no Authorization header AND no `?token=`, it raised 401 unconditionally, before that gate ever ran.

## The fix

`backend/app/modules/catalog/datasets/api/router_export.py`:

- `_resolve_download_user`: the "no auth signal at all" case now `return None` (mirroring `get_optional_user`, which is what `/export`'s dependency uses directly) instead of raising 401. `download_cog`'s existing anonymous branch — `check_dataset_access_or_anonymous(...)` then a `visibility != "public"` 403 — now actually runs for a plain anonymous GET, exactly mirroring `processing/export/router.py`'s `export_dataset_endpoint` anonymous branch. An auth signal that's actually invalid (bad token bytes, wrong `typ`/`scope`, expired, unresolvable `sub`) still 401s explicitly — that branch's implicit fall-through was made an explicit `raise` so it isn't accidentally swept into the new `return None`.
- `download_cog`'s **authenticated** branch previously inlined the per-role matrix check (`any(matrix.get(role, {}).get("export", False) for role in user_roles)`), while the export route routes the same check through `get_permission_extension().check_permission(...)`. That's a real difference: a deployment registering a custom `PermissionExtension` would get its policy applied on `/export` but bypassed on `/download/cog`. Mirrored it — `download_cog` now calls the same extension point. `DefaultPermissionExtension.check_permission` reduces to the identical matrix check, so OSS behavior is unchanged.

## Sibling-route audit

`router_export.py` (the module holding `download_cog`) registers exactly one download-shaped route pair (`HEAD`+`GET` sharing the `download_cog` handler); its other routes are DCAT/DCAT-US/GeoDCAT-AP JSON-LD feeds, not asset downloads. `_resolve_download_user` is used by no other handler in the backend (`grep -rn resolve_download_user backend/app`). No sibling instance of this asymmetry found.

`backend/tests/test_dcat.py`'s `test_dcat_raster_does_not_advertise_the_cog_download_url` (renamed from `..._token_gated_cog_download`) had a now-stale docstring premise ("`/download/cog` 401s an anonymous caller") for its public+published fixture — updated the docstring; the assertion itself (DCAT never advertises a `/download/cog` URL) is unrelated to auth and still holds.

## Tests

New `backend/tests/test_cog_download_access.py`, mirroring `test_export_access.py`'s matrix for the COG route:
- anon + public+published → 200, streams the real stored bytes, `image/tiff`
- anon + public+unpublished (`record_status=internal`) → denied (401/403/404)
- anon + private → **404** specifically (existence hiding, not 401/403)
- anon + restricted → denied (401/403/404)
- authenticated non-owner (viewer) + private → denied (401/403/404)

## Contract

No OpenAPI surface change. The route's published docstring (its OpenAPI description) is untouched on purpose — the new anonymous-access behavior is explained in a plain source comment instead, following the pattern the file already uses for its HEAD/GET docstring split, specifically to avoid churning `openapi.json`/SDKs/CLI for prose. `make openapi-check` passes clean (no diff), confirmed by running `scripts/dump_openapi.py --check` before and after.

`backend/tests/test_layering.py`'s `_MODULE_LOC_CAPS` ratchet for `router_export.py` raised 1490 → 1538 (exact), with a comment describing what the lines bought.

## Verification

```
cd backend && set -a && source ../.env.test && set +a && uv run pytest \
  tests/test_cog_download_access.py tests/test_export_access.py \
  tests/test_rule1_structural.py tests/test_layering.py -q
# 67 passed

cd backend && set -a && source ../.env.test && set +a && uv run pytest \
  tests/test_cog_head_ranges_1528.py tests/test_download_token.py \
  tests/test_phase_273_download_token.py tests/test_phase_273_cog_redirect_revalidate.py \
  tests/test_dcat.py tests/test_cors_range_headers_1540.py tests/test_cog_s3_head_wire_1540.py \
  tests/test_cog_vsicurl_1528.py tests/test_api_key_scope_875.py tests/test_alert_rules.py -q
# 203 passed, 4 skipped (pre-existing, unrelated)

cd backend && uv run ruff check . && uv run ruff format --check .
cd backend && PYTHONPATH=. uv run python scripts/dump_openapi.py --check
```

https://claude.ai/code/session_01BXUUv3x71zWaLKEvoL4cTY