### PR TITLE
feat(ingest): accept tier-1 vector formats in the manifest door

### DIFF
--- a/backend/app/processing/ingest/manifest_schemas.py
+++ b/backend/app/processing/ingest/manifest_schemas.py
@@ -63,9 +63,27 @@ ManifestBbox = Annotated[
     Field(min_length=4, max_length=4, description="WGS84 bbox hint."),
 ]
 
+# fix(#1683): the upload/reupload doors accept four more tier-1 vector
+# formats as of #1682 (FlatGeobuf, KML, KMZ, and a zipped File Geodatabase),
+# but that PR deliberately deferred extending the manifest door to them —
+# an earlier fgb-only version of this allowlist was dropped from #1681 for
+# being asymmetric with the other three. `.zip` already covers a zipped
+# File Geodatabase (the shapefile-vs-fgdb disambiguation happens downstream
+# in `source_format.py`, keyed off content, not the manifest schema).
 MANIFEST_SOURCE_EXTENSIONS: dict[str, frozenset[str]] = {
     "vector": frozenset(
-        {".zip", ".gpkg", ".geojson", ".json", ".csv", ".xlsx", ".xls"}
+        {
+            ".zip",
+            ".gpkg",
+            ".geojson",
+            ".json",
+            ".csv",
+            ".xlsx",
+            ".xls",
+            ".fgb",
+            ".kml",
+            ".kmz",
+        }
     ),
     "raster_cog": frozenset({".tif", ".tiff"}),
 }
@@ -95,7 +113,8 @@ class ManifestSource(_ManifestBaseModel):
     type: Literal["vector", "raster_cog"] = Field(
         description=(
             "Source modality. Vector sources require zip, gpkg, geojson, json, "
-            "csv, xlsx, or xls; raster_cog sources require tif or tiff."
+            "csv, xlsx, xls, fgb, kml, or kmz; raster_cog sources require tif "
+            "or tiff."
         )
     )
     uri: ManifestSourceUri

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -8947,7 +8947,7 @@
         "additionalProperties": false,
         "properties": {
           "type": {
-            "description": "Source modality. Vector sources require zip, gpkg, geojson, json, csv, xlsx, or xls; raster_cog sources require tif or tiff.",
+            "description": "Source modality. Vector sources require zip, gpkg, geojson, json, csv, xlsx, xls, fgb, kml, or kmz; raster_cog sources require tif or tiff.",
             "enum": [
               "vector",
               "raster_cog"

--- a/backend/tests/test_manifest_apply_api.py
+++ b/backend/tests/test_manifest_apply_api.py
@@ -86,11 +86,33 @@ class TestManifestApplySchemas:
         assert "vrt" in str(exc.value)
 
     @pytest.mark.parametrize(
+        "extension",
+        [".fgb", ".kml", ".kmz", ".zip"],
+    )
+    def test_accepts_tier1_vector_extensions(self, extension: str):
+        """fix(#1683): manifest sources now accept the same four tier-1
+        vector formats the upload/reupload doors accepted as of #1682
+        (FlatGeobuf, KML, KMZ, and a zipped File Geodatabase — the last one
+        already matched the pre-existing `.zip` entry)."""
+        payload = valid_manifest_payload()
+        payload["datasets"][0]["sources"][0]["uri"] = f"./data/roads{extension}"
+        del payload["datasets"][0]["sources"][0]["format"]
+
+        request = ManifestApplyRequest.model_validate(payload)
+
+        assert request.datasets[0].sources[0].uri == f"./data/roads{extension}"
+
+    @pytest.mark.parametrize(
         ("source_type", "uri", "expected"),
         [
             ("vector", "./rasters/tile.tif", "requires one of"),
             ("raster_cog", "./data/roads.geojson", "requires one of"),
             ("raster_cog", "./rasters/mosaic.vrt", "Standalone VRT"),
+            # fix(#1683): the new tier-1 vector formats are vector-only —
+            # keep the mismatch check symmetric with the pre-existing ones.
+            ("raster_cog", "./data/roads.fgb", "requires one of"),
+            ("raster_cog", "./data/roads.kml", "requires one of"),
+            ("raster_cog", "./data/roads.kmz", "requires one of"),
         ],
     )
     def test_rejects_source_type_extension_mismatch(

--- a/backend/tests/test_manifest_apply_service.py
+++ b/backend/tests/test_manifest_apply_service.py
@@ -232,6 +232,45 @@ class TestManifestApplyHelpers:
         assert derive_source_filename(remote) == "tile-001.tif"
         assert derive_source_extension(remote) == ".tif"
 
+    @pytest.mark.parametrize(
+        ("uri", "expected_filename", "expected_extension"),
+        [
+            ("./data/trails.fgb", "trails.fgb", ".fgb"),
+            ("./data/poi.kml", "poi.kml", ".kml"),
+            ("./data/poi.kmz", "poi.kmz", ".kmz"),
+            ("./data/parcels.zip", "parcels.zip", ".zip"),
+        ],
+    )
+    def test_source_filename_and_extension_derivation_tier1_formats(
+        self, uri: str, expected_filename: str, expected_extension: str
+    ):
+        """fix(#1683): FlatGeobuf, KML, KMZ, and zipped-FileGDB manifest
+        sources derive the same filename/extension as any other vector
+        source — the tier-1 upload formats added in #1682."""
+        source = ManifestSource(type="vector", uri=uri)
+
+        assert derive_source_filename(source) == expected_filename
+        assert derive_source_extension(source) == expected_extension
+
+    @pytest.mark.anyio
+    @pytest.mark.parametrize(
+        "uri",
+        ["./data/trails.fgb", "./data/poi.kml", "./data/poi.kmz"],
+    )
+    async def test_classify_manifest_source_accepts_tier1_vector_formats(
+        self, uri: str
+    ):
+        """fix(#1683): these formats used to be rejected by
+        `MANIFEST_SOURCE_EXTENSIONS` before ever reaching ingest, even
+        though the upload door has accepted the identical bytes since
+        #1682."""
+        source = ManifestSource(type="vector", uri=uri)
+
+        prepared = await classify_manifest_source(source)
+
+        assert prepared.kind == "local"
+        assert prepared.extension == Path(uri).suffix.lower()
+
     async def test_manifest_job_metadata_redacts_remote_credentials(self):
         dataset = _request(
             _manifest_dataset(

--- a/cli/geolens_cli/manifest/fixtures/valid/vector-fgb.yaml
+++ b/cli/geolens_cli/manifest/fixtures/valid/vector-fgb.yaml
@@ -1,0 +1,22 @@
+manifest_version: "1"
+catalog:
+  title: Trail network catalog
+  organization: Parks Department
+datasets:
+  - key: trails
+    title: Trail centerlines
+    description: FlatGeobuf export of the trail network.
+    sources:
+      - type: vector
+        uri: ./data/trails.fgb
+        format: flatgeobuf
+    metadata:
+      tags:
+        - recreation
+        - trails
+      organization: Parks Department
+      crs: EPSG:4326
+      license: CC-BY-4.0
+      attribution: Parks Department
+    publication:
+      intent: draft

--- a/cli/geolens_cli/manifest/fixtures/valid/vector-kml.yaml
+++ b/cli/geolens_cli/manifest/fixtures/valid/vector-kml.yaml
@@ -1,0 +1,21 @@
+manifest_version: "1"
+catalog:
+  title: Points of interest catalog
+  organization: Tourism Board
+datasets:
+  - key: poi
+    title: Points of interest
+    description: KML export of tourism points of interest.
+    sources:
+      - type: vector
+        uri: ./data/poi.kml
+        format: kml
+    metadata:
+      tags:
+        - tourism
+      organization: Tourism Board
+      crs: EPSG:4326
+      license: CC-BY-4.0
+      attribution: Tourism Board
+    publication:
+      intent: ready

--- a/cli/geolens_cli/manifest/fixtures/valid/vector-kmz.yaml
+++ b/cli/geolens_cli/manifest/fixtures/valid/vector-kmz.yaml
@@ -1,0 +1,21 @@
+manifest_version: "1"
+catalog:
+  title: Points of interest catalog
+  organization: Tourism Board
+datasets:
+  - key: poi-archive
+    title: Points of interest (archive)
+    description: KMZ export of tourism points of interest.
+    sources:
+      - type: vector
+        uri: https://data.example.com/poi-archive.kmz
+        format: kmz
+    metadata:
+      tags:
+        - tourism
+      organization: Tourism Board
+      crs: EPSG:4326
+      license: CC-BY-4.0
+      attribution: Tourism Board
+    publication:
+      intent: published

--- a/cli/geolens_cli/manifest/schemas/geolens-manifest-v1.schema.json
+++ b/cli/geolens_cli/manifest/schemas/geolens-manifest-v1.schema.json
@@ -122,7 +122,7 @@
           "then": {
             "properties": {
               "uri": {
-                "pattern": "(?i)\\.(?:zip|gpkg|geojson|json|csv|xlsx|xls)(?:[?#].*)?$"
+                "pattern": "(?i)\\.(?:zip|gpkg|geojson|json|csv|xlsx|xls|fgb|kml|kmz)(?:[?#].*)?$"
               }
             }
           }
@@ -145,7 +145,7 @@
         "type": {
           "type": "string",
           "enum": ["vector", "raster_cog"],
-          "description": "Source modality. Vector sources require zip, gpkg, geojson, json, csv, xlsx, or xls; raster_cog sources require tif or tiff."
+          "description": "Source modality. Vector sources require zip, gpkg, geojson, json, csv, xlsx, xls, fgb, kml, or kmz; raster_cog sources require tif or tiff."
         },
         "uri": {
           "type": "string",

--- a/cli/tests/test_manifest_schema.py
+++ b/cli/tests/test_manifest_schema.py
@@ -83,6 +83,9 @@ def test_valid_manifest_fixtures_pass() -> None:
         "raster-cog-storage.yaml",
         "vector-relative.yaml",
         "vector-url.yaml",
+        "vector-fgb.yaml",
+        "vector-kml.yaml",
+        "vector-kmz.yaml",
     }
     for path in valid_fixtures:
         assert validate_manifest(load_manifest(path)) == [], path.name
@@ -170,6 +173,12 @@ def test_manifest_v1_dataset_batch_is_bounded() -> None:
         ("vector", "./rasters/tile.tif"),
         ("raster_cog", "./data/roads.geojson"),
         ("raster_cog", "./rasters/mosaic.vrt"),
+        # fix(#1683): the tier-1 formats added to the vector allowlist are
+        # still vector-only — asserting the mismatch keeps the manifest
+        # door symmetric with the pre-existing formats above.
+        ("raster_cog", "./data/trails.fgb"),
+        ("raster_cog", "./data/poi.kml"),
+        ("raster_cog", "./data/poi.kmz"),
     ],
 )
 def test_manifest_source_type_requires_matching_extension(
@@ -179,6 +188,26 @@ def test_manifest_source_type_requires_matching_extension(
     document["datasets"][0]["sources"][0].update({"type": source_type, "uri": uri})
 
     assert ("$.datasets[0].sources[0].uri", "pattern") in _error_pairs(document)
+
+
+@pytest.mark.parametrize(
+    "uri",
+    [
+        "./data/trails.fgb",
+        "./data/poi.kml",
+        "https://data.example.com/poi-archive.kmz",
+        "./data/parcels.zip",
+    ],
+)
+def test_manifest_accepts_tier1_vector_extensions(uri: str) -> None:
+    """fix(#1683): the manifest door now accepts the same four tier-1
+    vector formats the upload/reupload doors accepted as of #1682
+    (FlatGeobuf, KML, KMZ, and a zipped File Geodatabase — the last one
+    already matched `.zip`)."""
+    document = _minimal_manifest()
+    document["datasets"][0]["sources"][0]["uri"] = uri
+
+    assert validate_manifest(document) == []
 
 
 def test_unknown_top_level_fields_are_rejected() -> None:

--- a/frontend/src/types/api.generated.ts
+++ b/frontend/src/types/api.generated.ts
@@ -9076,7 +9076,7 @@ export interface components {
         ManifestSource: {
             /**
              * Type
-             * @description Source modality. Vector sources require zip, gpkg, geojson, json, csv, xlsx, or xls; raster_cog sources require tif or tiff.
+             * @description Source modality. Vector sources require zip, gpkg, geojson, json, csv, xlsx, xls, fgb, kml, or kmz; raster_cog sources require tif or tiff.
              * @enum {string}
              */
             type: "vector" | "raster_cog";

--- a/sdks/python/geolens/models/manifest_source.py
+++ b/sdks/python/geolens/models/manifest_source.py
@@ -19,8 +19,8 @@ T = TypeVar("T", bound="ManifestSource")
 class ManifestSource:
     """
     Attributes:
-        type_ (ManifestSourceType): Source modality. Vector sources require zip, gpkg, geojson, json, csv, xlsx, or xls;
-            raster_cog sources require tif or tiff.
+        type_ (ManifestSourceType): Source modality. Vector sources require zip, gpkg, geojson, json, csv, xlsx, xls,
+            fgb, kml, or kmz; raster_cog sources require tif or tiff.
         uri (str): Relative path (no `..` traversal), HTTP(S) URL, or storage URI.
         title (None | str | Unset):
         description (None | str | Unset):

--- a/sdks/typescript/src/client/types.gen.ts
+++ b/sdks/typescript/src/client/types.gen.ts
@@ -5264,7 +5264,7 @@ export type ManifestSource = {
     /**
      * Type
      *
-     * Source modality. Vector sources require zip, gpkg, geojson, json, csv, xlsx, or xls; raster_cog sources require tif or tiff.
+     * Source modality. Vector sources require zip, gpkg, geojson, json, csv, xlsx, xls, fgb, kml, or kmz; raster_cog sources require tif or tiff.
      */
     type: 'vector' | 'raster_cog';
     /**


### PR DESCRIPTION
## What

Extends the CLI manifest ("`geolens apply`") door to accept the same four tier-1 vector formats the upload/reupload doors accepted as of #1682 — FlatGeobuf (`.fgb`), KML (`.kml`), KMZ (`.kmz`), and a zipped File Geodatabase. #1682 deliberately deferred this ("Extending the manifest door to these formats is a separate, contract-affecting change") because an fgb-only version was dropped from #1681 for creating an asymmetric door. This PR does all four together.

Closes #1683

## Scope decision: the zip question

`cli/geolens_cli/scan.py` already carries a documented exclusion (D-15): it has never classified any `.zip`, including a zipped shapefile. A prior codex finding on #1682 proposed adding gdb-zip-only scan support and was rebutted as asymmetric with zipped shapefiles.

Investigating current `main`, `scan.py` already mirrors `.fgb`/`.kml`/`.kmz` as single-file vector primaries (its own docstring: *"FlatGeobuf, KML, and KMZ were mirrored that way; a zipped File Geodatabase was not, because it arrives as .zip."*) — that mirroring shipped as part of #1682's client-side work, since it touches no server contract. So the "keep all zips out of scan" choice was already made and is unchanged here; there is nothing to alter in `scan.py` for this issue. This PR only extends the **manifest** door (`MANIFEST_SOURCE_EXTENSIONS`, the packaged JSON Schema), where `.zip` was already an accepted vector extension for shapefile bundles — a zipped File Geodatabase reaches the manifest door by that same existing `.zip` entry, disambiguated downstream from a shapefile bundle by content (`zip_contains_filegdb` in `source_format.py`), exactly as it is on the upload door. No new zip-handling code was needed or added.

## Symmetry table

| Format | `scan` behavior (unchanged) | Manifest door (this PR) | `source_format` stored |
|---|---|---|---|
| `.fgb` | classified as `flatgeobuf` (already mirrored in #1682) | now accepted (`MANIFEST_SOURCE_EXTENSIONS["vector"]`) | `fgb` |
| `.kml` | classified as `kml` (already mirrored in #1682) | now accepted | `kml` |
| `.kmz` | classified as `kmz` (already mirrored in #1682) | now accepted | `kml` (KMZ normalizes to `kml`, same as upload) |
| zipped `.gdb` | excluded (D-15, `.zip` never classified by scan) | already accepted (`.zip` was already in the allowlist) | `fgdb` (content-sniffed from the zip's central directory, same as upload) |

## How

- `backend/app/processing/ingest/manifest_schemas.py`: `MANIFEST_SOURCE_EXTENSIONS["vector"]` gains `.fgb`, `.kml`, `.kmz`; the `ManifestSource.type` field description is updated to match.
- `cli/geolens_cli/manifest/schemas/geolens-manifest-v1.schema.json`: the vector source `uri` pattern and the `type` field's `description` are updated identically, keeping the packaged offline schema in sync with the backend allowlist (mirrors how `.parquet`/`.xlsx`/`.xls` were added previously).
- No changes were needed in `manifest_sources.py`/`manifest_service.py`: `source_format` derivation (including the fgdb-vs-shapefile zip disambiguation and the kmz→kml normalization) already lives in one shared place (`source_format.py`) that both the upload and manifest-created ingest/reupload jobs run through — extending the allowlist is enough for the identical downstream behavior to apply.
- No changes were needed in `cli/geolens_cli/scan.py` or `publish.py`: both already carry fgb/kml/kmz support from #1682, and the zip exclusion in `scan.py` is deliberately out of scope per the precedent above.

## Contract impact

`ManifestSource.type`'s Pydantic field `description` reaches the public OpenAPI contract (it's the only place the manifest allowlist surfaces there, per #1682's own note). Regenerated and committed:

- `backend/openapi.json`
- `sdks/python/geolens/models/manifest_source.py`
- `sdks/typescript/src/client/types.gen.ts`
- `frontend/src/types/api.generated.ts` (the fourth regen artifact — caught by CI's `Frontend Lint & Typecheck` job, which runs `generate-api-types.mjs` and diffs the result; missed in the first push, fixed in a follow-up commit)

Diff in all four is the description string only ("...csv, xlsx, or xls..." → "...csv, xlsx, xls, fgb, kml, or kmz..."). `make sdks-check`, the SDK round-trip test, and `npm run types:check` all pass clean against the committed regen.

## Tests

- `backend/tests/test_manifest_apply_api.py`: new parametrized accept test for `.fgb`/`.kml`/`.kmz`/`.zip` vector sources; extended the existing type/extension-mismatch parametrize with the three new formats under `raster_cog`.
- `backend/tests/test_manifest_apply_service.py`: extended filename/extension derivation coverage and added `classify_manifest_source` acceptance coverage for the three new extensions.
- `cli/tests/test_manifest_schema.py`: extended the extension-mismatch parametrize, added an accept-extensions test, and three new valid fixtures (`vector-fgb.yaml`, `vector-kml.yaml`, `vector-kmz.yaml`) exercised by the existing fixture-driven test.
- No new `backend/tests/test_manifest_apply_roundtrip.py` fixtures: extension acceptance is gated entirely at the schema/service layer before staging or job creation, and roundtrip coverage of that shared code path already exists for the pre-existing formats.

## Verification

```bash
# CLI + backend manifest contract tests, layering, openapi, and SDK drift — all green
POSTGRES_HOST=localhost POSTGRES_PORT=5434 POSTGRES_USER=geolens POSTGRES_PASSWORD=geolens \
POSTGRES_DB=geolens JWT_SECRET_KEY=test-secret-key-for-ci-padding-32chars \
GEOLENS_ADMIN_USERNAME=admin GEOLENS_ADMIN_PASSWORD=geolens-ci-admin-password DB_PORT=5434 \
make manifest-contract-check

cd backend && uv run ruff check . && uv run ruff format --check .
cd backend && uv run pytest tests/test_layering.py -q
make cli-test
```

https://claude.ai/code/session_01BXUUv3x71zWaLKEvoL4cTY

