### PR TITLE
chore(release): prepare v1.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,25 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and releases use semantic versioning.
 
 ## [Unreleased]
+
+## [1.16.0] - 2026-08-27
+
 ### Added
+
+
+- **Server-side CQL2 filtering on feature collections.** OGC API Features
+  clients can now send `filter=` (with `filter-lang=cql2-text` or
+  `cql2-json`) on `/collections/{id}/items` and the server evaluates it in
+  SQL, ANDed with `bbox` and the property-filter extension. Until now a
+  spec-driven client had to download every feature and filter locally. Each
+  collection also gains a `/queryables` endpoint derived from the live
+  database schema, published with `additionalProperties: false`, so the
+  advertised property set always matches what filter validation accepts.
+  The conformance document now declares Part 3 queryables/filter plus CQL2
+  advanced comparison and basic spatial functions, which is exactly the set
+  QGIS 3.44+ checks before pushing its filter expressions to the server
+  instead of filtering client-side; a regression test pins that set so it
+  cannot silently regress (#1674, #1680).
 
 - **Four more upload formats: FlatGeobuf, KML, KMZ, and zipped File
   Geodatabase.** The GDAL build in the worker has read these all along — they
@@ -21,6 +39,36 @@ and releases use semantic versioning.
   verified directly (puremagic has no signature for it), a KMZ goes through
   the same zip-bomb checks as any other archive, and a `.kml` must at least
   open an XML tag.
+
+- **PMTiles export.** Any vector dataset can be exported as a single
+  PMTiles archive of MVT tiles and hosted from a static file server or
+  object store, with no tile server involved. The tile pyramid's depth
+  adapts to the dataset's extent (a citywide dataset gets street-level
+  zoom 14, a global one stops at zoom 8) so archives stay a sensible size.
+  The format appears everywhere other exports do: the export menu, DCAT
+  distributions, and STAC/OGC assets, with existing datasets backfilled
+  (#1686).
+
+- **FlatGeobuf export.** The export menu, DCAT distributions, and STAC/OGC
+  assets gain `fgb` alongside GeoPackage, GeoJSON, Shapefile, CSV, and
+  GeoParquet, with a backfill for existing spatial datasets. Served as
+  `application/vnd.flatgeobuf`, the vendor type the format's maintainers
+  proposed (#1681).
+
+- **PMTiles basemaps.** A basemap URL can now be a PMTiles archive, either
+  `pmtiles://https://...` or a bare `https://....pmtiles`, such as a
+  protomaps world build or a GeoLens PMTiles export. The admin settings
+  form probes the archive header before saving and rejects a vector
+  archive that has no style to render it with. Together with PMTiles
+  export this closes the offline loop: export a dataset, drop the file
+  behind any static host, and point a basemap at it, no tile server and
+  no API key (#1688).
+
+- **The CLI manifest accepts the new vector formats.** `geolens apply`
+  manifests can now declare FlatGeobuf, KML, KMZ, and zipped File
+  Geodatabase sources, the same four formats the upload doors accepted in
+  this release, so scripted and version-controlled ingest is not weaker
+  than the browser path (#1694).
 
 - **A failed upload now leaves a trace, and a way to report it.** UploadForm
   calls the presign, PUT, direct-upload POST, preview/detection, commit, and
@@ -52,6 +100,29 @@ and releases use semantic versioning.
   could only be retyped. Matched `https://` URLs now render as anchors
   (new tab, `rel="noopener noreferrer"`); everything else stays escaped text,
   so banner content still cannot inject markup.
+
+
+- **Multi-layer files say what they contain.** A File Geodatabase or
+  GeoPackage holds layers, not sheets; the import review now uses the
+  right word for each container, shows an "N layers" badge, and "Import
+  all" respects the layer selection instead of ignoring it (#1685).
+
+### Security
+
+
+- **Service tokens are leased, not stored, at every import door.** The
+  refresh door has handed ArcGIS service tokens to the worker through a
+  one-use Valkey lease since 1.13; the first-import and reupload doors
+  still wrote the raw token into durable job-queue arguments, where a
+  failed or queued job held it in plaintext until the retention purge,
+  while the import UI promised tokens are "never stored". All three doors
+  now behave the same way, keyed on what the install has: with a
+  credential store configured the token is stashed under a one-use
+  reference the worker consumes; if the stash fails the request is
+  refused with a 503 rather than silently downgraded; and an install with
+  no store configured keeps the previous durable-argument behavior, now
+  logged. This also fixes a latent bug where an import with no run rows
+  would lose its lease after 900 seconds (#1689).
 
 ### Fixed
 
@@ -101,6 +172,57 @@ and releases use semantic versioning.
   message still reaches structured logs at error level, and a failure raised
   by anything other than the open call itself keeps its real message
   unchanged.
+
+
+- **Refreshing a large ArcGIS layer pages like importing one.** Refresh
+  performed a single unpaged fetch and trusted the server's paging
+  metadata, exactly what the import path's guarded loop exists to
+  distrust (servers that misreport pagination support, sparse object IDs,
+  transfer limits). A short result could then swap in cleanly as a
+  silently truncated dataset. Refresh now runs the same guarded
+  `resultOffset` loop as import, and a connectivity probe failure now
+  stamps `last_checked_at` so a failing source is visibly stale rather
+  than frozen at its last success (#1678).
+
+- **Exported map styles import back.** `GET /maps/{id}/style.json` emits
+  `sprite` in MapLibre's array form, but import only accepted a string,
+  so a style document GeoLens itself produced failed re-import with a
+  422. Import accepts both forms now, a test pins the full
+  export-import round trip, and the export operation's previously empty
+  response schema now names the MapLibre Style Specification and the one
+  guarantee beyond it (#1679).
+
+- **A broken migration overlay now fails the migration run.** When an
+  installed edition overlay's migration provider failed to load,
+  `alembic upgrade heads` logged an error, skipped that overlay's entire
+  revision chain, and exited 0, so a deployment pipeline gating on the
+  exit code reported a partial schema as a successful migration. Both
+  failure classes now raise; a Community install without overlays is
+  unaffected (#1668).
+
+- **Single-worker installs no longer restart on a request quota.**
+  uvicorn's `--limit-max-requests` is a rolling worker recycle only when
+  the multiprocess supervisor exists; with `UVICORN_WORKERS=1` (the
+  documented small-VM tuning) hitting the limit exited the whole process,
+  which surfaced as a clean unexplained container restart and a ~17
+  second outage roughly every 13 hours under ordinary monitoring
+  traffic. The flag is now applied only when there are at least two
+  workers (#1687).
+
+- **Container logs are bounded.** The production compose file pinned no
+  log rotation, so a long-lived container's json-file log grew without
+  limit. Every service now caps logs at three 50 MB files. Existing
+  deployments pick this up on the next `docker compose up -d` after
+  pulling the change; a plain restart is not enough (#1690).
+
+- **Anonymous downloads work for public rasters, not just vectors.** A
+  public, published vector dataset could be exported anonymously, but the
+  COG download for an equally public raster answered 401 unless the
+  caller first minted a download token, which broke "open this raster in
+  QGIS" for exactly the datasets meant to be showcased. The route's
+  access checks were already correct; the dependency above them refused
+  anonymous requests before those checks ran. Anonymous requests now
+  reach the same public-visibility gate the vector path uses (#1693).
 
 ## [1.15.1] - 2026-08-24
 
@@ -2675,7 +2797,8 @@ regression-covered fixes:
 - Initial public release of the GeoLens catalog, API, map builder, CLI, SDKs,
   Docker development stack, and public documentation entrypoints.
 
-[Unreleased]: https://github.com/geolens-io/geolens/compare/v1.15.1...HEAD
+[Unreleased]: https://github.com/geolens-io/geolens/compare/v1.16.0...HEAD
+[1.16.0]: https://github.com/geolens-io/geolens/compare/v1.15.1...v1.16.0
 [1.15.1]: https://github.com/geolens-io/geolens/compare/v1.15.0...v1.15.1
 [1.15.0]: https://github.com/geolens-io/geolens/compare/v1.14.2...v1.15.0
 [1.14.2]: https://github.com/geolens-io/geolens/compare/v1.14.1...v1.14.2

--- a/backend/app/api/main.py
+++ b/backend/app/api/main.py
@@ -747,7 +747,7 @@ _is_production = settings.is_production
 # no metadata to read. We fall back to the current published line so import never
 # crashes. Keep this fallback in lockstep with backend/pyproject.toml — it is one
 # of the sites `make bump` rewrites.
-_FALLBACK_APP_VERSION = "1.15.1"
+_FALLBACK_APP_VERSION = "1.16.0"
 
 
 def _resolve_app_version() -> str:

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -18483,7 +18483,7 @@
     "summary": "PostGIS-native geospatial data catalog with OGC API Features and Records support",
     "termsOfService": "https://github.com/geolens-io/geolens/blob/main/LICENSE",
     "title": "GeoLens API",
-    "version": "1.15.1"
+    "version": "1.16.0"
   },
   "openapi": "3.1.0",
   "paths": {

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geolens-backend"
-version = "1.15.1"
+version = "1.16.0"
 description = "PostGIS-native GIS data catalog"
 # Docker image (Dockerfile) ships python:3.14-slim (see the Dockerfile FROM for
 # the exact patch pin) as the project's tested runtime.

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -838,7 +838,7 @@ wheels = [
 
 [[package]]
 name = "geolens-backend"
-version = "1.15.1"
+version = "1.16.0"
 source = { virtual = "." }
 dependencies = [
     { name = "alembic" },

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "geolens-cli"
-version = "1.15.1"
+version = "1.16.0"
 description = "Apache-2.0 command-line interface for the GeoLens API. Login, scan, publish, and export STAC against any GeoLens instance."
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/docs-contract.json
+++ b/docs-contract.json
@@ -1,6 +1,6 @@
 {
   "_comment": "Canonical cross-surface facts for the GeoLens README, marketing site (getgeolens.com/src), and docs site (getgeolens.com/docs). Validated against scripts/install.sh + backend/pyproject.toml by scripts/check_docs_contract.py (geolens CI). The getgeolens.com repo vendors a copy and enforces the same `forbidden` list in its own CI. See docs-internal/DOC-CONSISTENCY-STRATEGY for the full design. Edit a fact ONCE here (and in its canonical source) — the gates make every surface follow.",
-  "version": "1.15.1",
+  "version": "1.16.0",
   "install": {
     "oneLiner": "curl -fsSL https://getgeolens.com/install.sh | sh",
     "sourceBuild": "bash scripts/install.sh",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "1.15.1",
+  "version": "1.16.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "1.15.1",
+      "version": "1.16.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.15.1",
+  "version": "1.16.0",
   "type": "module",
   "license": "Apache-2.0",
   "author": "Carto Concepts, LLC",

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "geolens-mcp"
-version = "1.15.1"
+version = "1.16.0"
 description = "Apache-2.0 read-only Model Context Protocol (MCP) server for GeoLens. Lets coding agents discover datasets, inspect schemas, and ask spatial questions against any GeoLens instance."
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/mcp/server.json
+++ b/mcp/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.geolens-io/geolens",
   "title": "GeoLens",
   "description": "Read-only access to a self-hosted GeoLens spatial catalog: datasets, features, maps, sandboxed SQL.",
-  "version": "1.15.1",
+  "version": "1.16.0",
   "websiteUrl": "https://docs.getgeolens.com/",
   "repository": {
     "url": "https://github.com/geolens-io/geolens",
@@ -14,7 +14,7 @@
     {
       "registryType": "pypi",
       "identifier": "geolens-mcp",
-      "version": "1.15.1",
+      "version": "1.16.0",
       "transport": {
         "type": "stdio"
       },

--- a/mcp/uv.lock
+++ b/mcp/uv.lock
@@ -225,7 +225,7 @@ wheels = [
 
 [[package]]
 name = "geolens"
-version = "1.15.1"
+version = "1.16.0"
 source = { editable = "../sdks/python" }
 dependencies = [
     { name = "attrs" },
@@ -244,7 +244,7 @@ requires-dist = [
 
 [[package]]
 name = "geolens-mcp"
-version = "1.15.1"
+version = "1.16.0"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "geolens",
-  "version": "1.15.1",
+  "version": "1.16.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "geolens",
-      "version": "1.15.1",
+      "version": "1.16.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@axe-core/playwright": "^4.13.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geolens",
-  "version": "1.15.1",
+  "version": "1.16.0",
   "private": true,
   "license": "Apache-2.0",
   "author": "Carto Concepts, LLC",

--- a/sdks/python/.openapi-python-client.yaml
+++ b/sdks/python/.openapi-python-client.yaml
@@ -4,7 +4,7 @@ project_name_override: geolens
 package_name_override: geolens
 # Rewritten on every `make sdks` run by scripts/sync_sdk_versions.py to match
 # backend/openapi.json info.version. Do not edit by hand.
-package_version_override: 1.15.1
+package_version_override: 1.16.0
 
 # Cleaner enum output (matches our pydantic v2 backend's enum emission).
 literal_enums: true

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "geolens"
-version = "1.15.1"
+version = "1.16.0"
 description = "Auto-generated Python SDK for the GeoLens API. Typed clients with Bearer + API-key auth helpers."
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/sdks/typescript/package-lock.json
+++ b/sdks/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@geolens/sdk",
-  "version": "1.15.1",
+  "version": "1.16.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@geolens/sdk",
-      "version": "1.15.1",
+      "version": "1.16.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@hey-api/client-fetch": "0.13.1"

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geolens/sdk",
-  "version": "1.15.1",
+  "version": "1.16.0",
   "description": "Auto-generated TypeScript SDK for the GeoLens API. Typed clients with Bearer + API-key auth helpers.",
   "license": "Apache-2.0",
   "author": "Carto Concepts, LLC",


### PR DESCRIPTION
## What

Release preparation for v1.16.0:

- `make bump VERSION=1.16.0` — all 21 version sites stamped (verified with `make version-check`).
- CHANGELOG: cut the `## [1.16.0] - 2026-08-27` section covering everything since v1.15.1 — server-side CQL2 filtering (#1674, #1680), the four tier-1 upload formats (#1682), FlatGeobuf (#1681) and PMTiles (#1686) exports, PMTiles basemaps (#1688), the manifest-door catch-up (#1694), multi-layer import vocabulary (#1685), the import-door token lease under a new Security heading (#1689), and the fixes: ArcGIS refresh paging (#1678), style.json round-trip (#1679), overlay migration provider (#1668), uvicorn single-worker recycling (#1687), bounded container logs (#1690), and anonymous COG downloads (#1693). Comparison links updated.
- Empty `## [Unreleased]` section left for the next cycle.

No code changes beyond version stamps.

## Verification

- `make version-check` — OK: all 21 version sites agree on 1.16.0, section heading present.
- Pre-commit hooks all pass.

After merge: tag `v1.16.0` on the merge commit; the tag workflows publish the Release, PyPI/npm packages, GHCR images, and draft the Buttondown release notes.

https://claude.ai/code/session_01BXUUv3x71zWaLKEvoL4cTY