### PR TITLE
fix(map): stop the tile transformRequest from mangling pmtiles:// URLs

### DIFF
--- a/frontend/src/lib/__tests__/tile-utils.test.ts
+++ b/frontend/src/lib/__tests__/tile-utils.test.ts
@@ -271,6 +271,29 @@ describe('buildTileTransformRequest', () => {
     });
   });
 
+  // fix(#1688 follow-up): transformRequest runs before MapLibre's protocol
+  // dispatch, so a pmtiles:// URL must pass through byte-identical or the
+  // registered protocol handler never sees it.
+  it('passes pmtiles:// URLs through unchanged with no headers', () => {
+    useAuthStore.setState({ token: 'tok-123' });
+    const transform = buildTileTransformRequest();
+    const url = 'pmtiles://https://tiles.example.com/world.pmtiles';
+    expect(transform(url)).toEqual({ url });
+  });
+
+  it('passes pmtiles:// URLs through unchanged on the embed surface (no X-Embed-Token)', () => {
+    const transform = buildTileTransformRequest({ embedToken: 'embed-tok' });
+    const url = 'pmtiles://https://tiles.example.com/world.pmtiles';
+    expect(transform(url)).toEqual({ url });
+  });
+
+  it('leaves protocol-relative URLs alone rather than double-slashing the origin', () => {
+    const transform = buildTileTransformRequest();
+    expect(transform('//tiles.example.com/1/2/3.png')).toEqual({
+      url: '//tiles.example.com/1/2/3.png',
+    });
+  });
+
   it('attaches the Bearer header to first-party raster tiles when signed in (#819 regression class)', () => {
     useAuthStore.setState({ token: 'jwt-abc' });
     const transform = buildTileTransformRequest();

--- a/frontend/src/lib/tile-utils.ts
+++ b/frontend/src/lib/tile-utils.ts
@@ -76,7 +76,13 @@ export function buildTileTransformRequest(
   options: TileTransformRequestOptions = {},
 ): (url: string) => { url: string; headers?: Record<string, string> } {
   return (url: string) => {
-    const absUrl = url.startsWith('http') ? url : `${window.location.origin}${url}`;
+    // fix(#1688 follow-up): absolutify ONLY site-relative paths. The old
+    // `startsWith('http')` predicate origin-prefixed every other scheme, and
+    // transformRequest runs BEFORE MapLibre's custom-protocol dispatch, so a
+    // `pmtiles://…` basemap source became `http://<origin>pmtiles://…` and
+    // never reached the registered pmtiles protocol handler.
+    const absUrl =
+      url.startsWith('/') && !url.startsWith('//') ? `${window.location.origin}${url}` : url;
     const tileConfig = options.getTileConfig?.() ?? null;
     const headers: Record<string, string> = {};
     if (options.embedToken && !isThirdPartyTileUrl(url, tileConfig)) {


### PR DESCRIPTION
## The bug (release-blocking for v1.16.0's PMTiles basemaps)

`buildTileTransformRequest` (`frontend/src/lib/tile-utils.ts`) absolutified every URL that did not start with `http`:

```ts
const absUrl = url.startsWith('http') ? url : `${window.location.origin}${url}`;
```

MapLibre runs `transformRequest` **before** its custom-protocol dispatch, so a `pmtiles://https://…` basemap source (#1688) became `http://<origin>pmtiles://https://…`, never reached the protocol handler registered in `maplibre-worker.ts`, and failed with `TypeError: Failed to construct 'Request': Failed to parse URL`. Since #835 every map surface (Builder, Viewer, Dataset, public viewer) wires this transform in `onLoad`, so **every PMTiles basemap failed to render everywhere**. #1688's validator, admin form probe, and unit tests all passed because none of them exercise the transformRequest pipeline.

## The fix

Absolutify only site-relative paths (single leading `/`); scheme-carrying (`pmtiles://`, `https://`) and protocol-relative (`//host/…`) URLs pass through untouched. `isThirdPartyTileUrl` already classifies a `pmtiles:` URL as third-party (opaque origin), so neither `Authorization` nor `X-Embed-Token` attaches to archive requests — a regression test pins that for the embed surface.

## Verification

- Found and confirmed by live browser smoke against the dev stack (Playwright): before the fix, swapping a builder basemap to a raster PMTiles archive logged the mangled-URL error and rendered nothing; after, the archive is range-read directly (206s) and renders, with attribution.
- `npx vitest run src/lib/__tests__ src/components/viewer/__tests__ src/components/builder/__tests__` — 162 files, 2916 tests, all pass.
- `npm run typecheck` and `npm run lint` clean.

https://claude.ai/code/session_01BXUUv3x71zWaLKEvoL4cTY