### PR TITLE
feat(release): put a subscribe form on the newsletter's archive page

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -343,6 +343,10 @@ jobs:
               {
                 cat release-notes.md
                 printf '\n[Release notes on GitHub](https://github.com/%s/releases/tag/%s)\n' "${GITHUB_REPOSITORY}" "${TAG}"
+                # Buttondown renders this only on the web/archive page, never
+                # in the copies subscribers receive; it also clears the
+                # "consider adding a subscribe form" pre-send warning.
+                printf '\n{{ subscribe_form }}\n'
               } > newsletter.md
               # Curated notes are safe to send unreviewed; commit-subject
               # fallback notes (the '> **Note**' banner above) are not — those


### PR DESCRIPTION
The v1.16.0 send surfaced two things about the automated release-notes email. The mangled-markdown one turned out to be Buttondown's Fancy Mode editor rewriting the body on open (fixed operationally: the account editor is now pinned to Markdown mode, and the runbook documents the trap). This PR fixes the other: the dashboard's one pre-send warning, a missing subscribe form.

Appends Buttondown's `{{ subscribe_form }}` template tag to the auto-drafted newsletter body. The tag renders an embedded subscribe form on the email's public archive page only — Buttondown strips it from the copies subscribers receive — and the archive page is exactly where the demo banner and shared links send curious readers.

No behavior change for the scheduled-send logic in #1697; the tag is part of the body text, appended after the release-notes link.

Verification: the tag is plain `{{ }}`, not `${{ }}`, so Actions expression expansion does not touch it; `newsletter.md` feeds `jq --rawfile` unchanged. The v1.16.0 archive page (https://buttondown.com/geolens/archive/geolens-v1160/) now carries the same tag, added by hand, and renders the form.

https://claude.ai/code/session_01BXUUv3x71zWaLKEvoL4cTY