### PR TITLE
docs(readme): replace the aged Early-release note with an API-stability statement

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -122,7 +122,7 @@ Für jedes Beispiel gibt es eine vollständige Anleitung in der [Dokumentation](
 - **Vektor:** Shapefile, GeoPackage, GeoJSON, GeoParquet, FlatGeobuf, KML/KMZ, gezippte File Geodatabase, CSV, XLSX
 - **Raster:** GeoTIFF und Cloud-Optimized GeoTIFF (COG) mit automatischer Konvertierung
 - **Mosaike:** VRT-basierte Rastermosaike aus mehreren Quelldateien
-- **Export:** GeoJSON, Shapefile, GeoPackage, CSV, GeoParquet und FlatGeobuf mit CRS-Reprojektion; PMTiles als eigenständiges Kachelarchiv für statische Hosts mit Unterstützung für Range-Anfragen
+- **Export:** GeoJSON, Shapefile, GeoPackage, CSV und FlatGeobuf mit CRS-Reprojektion; GeoParquet (immer EPSG:4326); PMTiles als eigenständiges Kachelarchiv für statische Hosts mit Unterstützung für Range-Anfragen
 - **Quellstatus:** Herkunft, Zeitstempel der letzten Aktualisierung und Prüfung, rhythmusbasierte Quellenaktualität und bedarfsgesteuerte Zustandsprüfungen für Service- und STAC-Quellen
 - Herkunftsverfolgung und Metadatenbearbeitung
 

--- a/README.de.md
+++ b/README.de.md
@@ -30,9 +30,13 @@ curl -fsSL https://getgeolens.com/install.sh | sh
 </p>
 
 > [!NOTE]
-> **Frühe Version.** GeoLens wird aktiv entwickelt und gepflegt und wurde erst
-> kürzlich als Open Source veröffentlicht. Die selbst gehostete Distribution ist
-> jung und manche Funktionen und APIs können sich noch ändern. [Erstellen Sie ein Issue](https://github.com/geolens-io/geolens/issues), wenn Probleme auftreten.
+> **API-Stabilität.** Die Standardschnittstellen (OGC API Features/Records,
+> STAC und die Kachel-Endpunkte) folgen ihren Spezifikationen und sind eine
+> sichere Basis für Integrationen. GeoLens’ eigene REST-API kann sich zwischen
+> Minor-Versionen noch ändern: Vertragsänderungen stehen im
+> [CHANGELOG](CHANGELOG.md), und inkompatible Änderungen halten die alte Form
+> mindestens eine weitere Minor-Version funktionsfähig. Probleme?
+> [Erstellen Sie ein Issue](https://github.com/geolens-io/geolens/issues).
 
 ## Dokumentation
 
@@ -66,8 +70,8 @@ GeoLens ersetzt diesen Ablauf:
 
 - **Ein Geodaten-Hub:** Laden Sie Dateien hoch, erstellen Sie Datensätze, registrieren Sie Tabellen, die bereits in GeoLens’ Datenbank liegen, importieren Sie Snapshots von Feature-Diensten oder referenzieren Sie entfernte STAC-Assets – anschließend durchsuchen Sie alles gemeinsam und zeigen es in der Vorschau an
 - **Quellstatus statt Rätselraten:** Sehen Sie, wie jeder Datensatz in den Katalog gelangt ist, wann er zuletzt aktualisiert oder geprüft wurde, ob seine letzte Aktualisierung gemessen am angegebenen Rhythmus aktuell, fällig, überfällig oder unbekannt ist und ob eine entfernte Service- oder STAC-Quelle noch erreichbar ist
-- **Funktioniert mit Ihren Werkzeugen:** OGC API Features/Records, STAC API 1.0 und direkte Kachel-URLs für QGIS, ArcGIS und MapLibre
-- **Kein Lock-in:** Ihr Katalog und die von GeoLens verwalteten Kopien bleiben auf der Infrastruktur, die Sie kontrollieren, und verlassen sie über offene Formate. Vektordatensätze werden als GeoPackage, GeoJSON, Shapefile, CSV oder GeoParquet exportiert; Raster werden als Cloud-optimiertes GeoTIFF (COG) heruntergeladen; und jeder OGC-API-Client liest den Katalog direkt
+- **Funktioniert mit Ihren Werkzeugen:** OGC API Features/Records mit serverseitiger CQL2-Filterung, STAC API 1.0 und direkte Kachel-URLs für QGIS, ArcGIS und MapLibre
+- **Kein Lock-in:** Ihr Katalog und die von GeoLens verwalteten Kopien bleiben auf der Infrastruktur, die Sie kontrollieren, und verlassen sie über offene Formate. Vektordatensätze werden als GeoPackage, GeoJSON, Shapefile, CSV, GeoParquet, FlatGeobuf oder PMTiles exportiert; Raster werden als Cloud-optimiertes GeoTIFF (COG) heruntergeladen; und jeder OGC-API-Client liest den Katalog direkt
 - **Semantische und räumliche Suche:** sofort einsatzbereiter unscharfer Abgleich mit pg_trgm; mit Embedding-Anbieter und aktivierter semantischer Suche werden Datensätze nach Bedeutung geordnet (pgvector)
 - **Integrierter Karteneditor:** mehrschichtige Karten zusammenstellen, gestalten und über öffentlichen Link oder einbettbares iframe teilen
 - **KI-Unterstützung (optional):** mit Karten chatten, Beschreibungen automatisch erzeugen und in natürlicher Sprache suchen. Verwenden Sie einen OpenAI-kompatiblen Endpunkt oder Anthropic-Schlüssel – oder verzichten Sie vollständig darauf
@@ -115,10 +119,10 @@ Für jedes Beispiel gibt es eine vollständige Anleitung in der [Dokumentation](
 ### Datenimport und -export
 
 - **Fünf Quellmodi:** Hochgeladene und Erstellte Daten werden lokal verwaltet; Tabelle registrieren stellt eine vorhandene Tabelle in GeoLens’ eigener PostGIS-Datenbank direkt bereit; Service-Importe sind einmalige lokale Kopien; STAC-Datensätze behalten eine Live-Referenz auf das entfernte Asset
-- **Vektor:** Shapefile, GeoPackage, GeoJSON, GeoParquet, CSV, XLSX
+- **Vektor:** Shapefile, GeoPackage, GeoJSON, GeoParquet, FlatGeobuf, KML/KMZ, gezippte File Geodatabase, CSV, XLSX
 - **Raster:** GeoTIFF und Cloud-Optimized GeoTIFF (COG) mit automatischer Konvertierung
 - **Mosaike:** VRT-basierte Rastermosaike aus mehreren Quelldateien
-- **Export:** GeoJSON, Shapefile, GeoPackage, CSV, mit CRS-Reprojektion
+- **Export:** GeoJSON, Shapefile, GeoPackage, CSV, GeoParquet und FlatGeobuf mit CRS-Reprojektion; PMTiles als eigenständiges Kachelarchiv für statische Hosts mit Unterstützung für Range-Anfragen
 - **Quellstatus:** Herkunft, Zeitstempel der letzten Aktualisierung und Prüfung, rhythmusbasierte Quellenaktualität und bedarfsgesteuerte Zustandsprüfungen für Service- und STAC-Quellen
 - Herkunftsverfolgung und Metadatenbearbeitung
 
@@ -131,10 +135,11 @@ Für jedes Beispiel gibt es eine vollständige Anleitung in der [Dokumentation](
 
 ### Standards und Interoperabilität
 
-- OGC API - Features und OGC API - Records; STAC API 1.0-Katalogendpunkt; JSON-LD-Kataloge nach DCAT 3, DCAT-US 3.0 und GeoDCAT-AP
+- OGC API - Features (mit serverseitiger CQL2-Filterung und `/queryables` je Collection) und OGC API - Records; STAC API 1.0-Katalogendpunkt; JSON-LD-Kataloge nach DCAT 3, DCAT-US 3.0 und GeoDCAT-AP
 - Direkte Kachel-URLs und benutzerspezifische API-Schlüssel für QGIS, ArcGIS, MapLibre und jeden OGC-Client
 - Vektorkacheln lassen unter Zoomstufe 10 Attributspalten weg, damit Kacheln klein bleiben; fügen Sie `cols=<column>,<column>` an die URL an, um bestimmte Spalten bei jeder Zoomstufe einzuschließen (Namen werden mit den Datensatzspalten abgeglichen, unbekannte verworfen)
 - JWT + OAuth 2.0/OIDC, RBAC mit datensatzbezogenen Berechtigungen
+- Oberfläche auf Englisch, Spanisch, Französisch und Deutsch
 
 <details>
 <summary>Sicherheit</summary>
@@ -145,7 +150,6 @@ Für jedes Beispiel gibt es eine vollständige Anleitung in der [Dokumentation](
 - Rollenbasierte Zugriffskontrolle (RBAC) mit datensatzbezogenen Berechtigungen
 - Selbstregistrierung ist standardmäßig deaktiviert; wird sie mit SMTP-Prüfung aktiviert, erfolgt der Versand für neue und bereits vorhandene Anmeldungen einheitlich
 - Auditprotokollierung aller administrativen Aktionen
-- Internationalisierung: Englisch, Spanisch, Französisch, Deutsch
 
 </details>
 
@@ -223,7 +227,7 @@ docker compose ps
 
 Beim ersten Start **lädt** die Einzeileninstallation vorgefertigte Images und ist nach etwa einer Minute bereit (nur die kleine PostGIS- + pgvector-Datenbankschicht wird lokal gebaut). Klonen und `bash scripts/install.sh` **baut** alle Images aus dem Quellcode: beim ersten Mal 5–10 Minuten (GDAL + Postgres-Erweiterungen + Frontend-Bundle); weitere Starts benötigen in beiden Fällen etwa 60 Sekunden. Sind 5434/8001/8080 belegt, ändern Sie `DB_PORT`, `API_PORT` oder `FRONTEND_PORT` in `.env`. Hinweise zu Portkonflikten, blockierten Starts, Speichermangel und Migrationswarnungen enthält die [Fehlerbehebungsanleitung](https://docs.getgeolens.com/guides/quickstart/install/#troubleshooting).
 
-Für die Produktion siehe [Installationsanleitung](https://docs.getgeolens.com/guides/quickstart/install/). Ein von der Community gepflegtes [Helm-Chart](https://github.com/geolens-io/geolens-deployments) liegt im separaten Repository [`geolens-deployments`](https://github.com/geolens-io/geolens-deployments).
+Für die Produktion siehe [Installationsanleitung](https://docs.getgeolens.com/guides/quickstart/install/). Ein Helm-Chart liegt im separaten Repository [`geolens-deployments`](https://github.com/geolens-io/geolens-deployments).
 
 ### Installer überprüfen
 
@@ -314,7 +318,7 @@ flowchart TB
 
 | Komponente | Technologie |
 |-----------|-----------|
-| Frontend | React 19, Vite, MapLibre GL v5, TanStack Query, Tailwind CSS |
+| Frontend | React 19, Vite, MapLibre GL v6, TanStack Query, Tailwind CSS |
 | Backend-API | FastAPI (Python), GDAL/ogr2ogr, Procrastinate (Aufgabenwarteschlange) |
 | Rasterkacheln | Titiler (COG-Kachelserver) |
 | Objektspeicher | MinIO (S3-kompatibel, lokale Entwicklung) oder beliebiger S3-Anbieter |
@@ -352,7 +356,7 @@ API und Worker exportieren sofort Prometheus-Metriken (HTTP-Rate/Latenz/Fehler, 
 | [Administrationsanleitung](https://docs.getgeolens.com/guides/admin/) | Benutzer, Datensätze und Systemzustand verwalten |
 | [Selbsthosting auf AWS, GCP oder DigitalOcean](https://docs.getgeolens.com/guides/quickstart/cloud-deployment/) | Anleitungen für verwaltete Datenbank, Objektspeicher und Cache |
 | [CLI & Manifeste](https://docs.getgeolens.com/guides/cli/) | Dateien veröffentlichen und Kataloge mit `geolens` verwalten |
-| [API-Referenz](https://docs.getgeolens.com/guides/api/) | Automatisch erzeugte Referenz; interaktive Swagger UI unter `/api/docs` zur Laufzeit |
+| [API-Referenz](https://docs.getgeolens.com/guides/api/) | Automatisch erzeugte Referenz; im Entwicklungsmodus dient die Instanz zusätzlich Swagger UI unter `/api/docs` (in Produktion deaktiviert) |
 | [Manifestbeispiele](examples/manifests/) | Anpassbare `geolens.yaml`-Vorlagen: public-cog (entferntes COG), url-source, s3-source, publication-states |
 | [Client-Beispiele](https://github.com/geolens-io/geolens-examples) | Lauffähige Browser-, QGIS-, DuckDB-, SDK-, CLI-, Embed-, Python- und MCP-Beispiele; die rein lesenden werden in der CI gegen die öffentliche Demo geprüft ([Galerie](https://geolens-io.github.io/geolens-examples/)) |
 
@@ -367,7 +371,7 @@ API und Worker exportieren sofort Prometheus-Metriken (HTTP-Rate/Latenz/Fehler, 
 - Einzelne PostgreSQL-Instanz ohne integrierte Hochverfügbarkeit oder Clusterbildung.
 - GeoLens ist für eine Organisation pro selbst gehosteter Bereitstellung ausgelegt.
 - Geländedarstellung setzt DEM-Einheiten in Metern voraus; andere vertikale Einheiten können überhöht erscheinen.
-- Die selbst gehostete Distribution ist jung; manche Funktionen und APIs können sich noch ändern (siehe Hinweis zur frühen Version).
+- GeoLens’ eigene REST-API kann sich zwischen Minor-Versionen noch ändern (siehe Hinweis zur API-Stabilität oben).
 
 ## Lizenz
 

--- a/README.es.md
+++ b/README.es.md
@@ -122,7 +122,7 @@ Cada ejemplo anterior tiene una guía completa en la [documentación](https://do
 - **Vector:** Shapefile, GeoPackage, GeoJSON, GeoParquet, FlatGeobuf, KML/KMZ, File Geodatabase comprimida (zip), CSV, XLSX
 - **Ráster:** GeoTIFF y Cloud-Optimized GeoTIFF (COG) con conversión automática
 - **Mosaicos:** mosaicos ráster basados en VRT a partir de varios archivos fuente
-- **Exportación:** GeoJSON, Shapefile, GeoPackage, CSV, GeoParquet y FlatGeobuf, con reproyección del CRS; PMTiles como archivo de teselas autocontenido para hosts estáticos que admitan solicitudes de rango
+- **Exportación:** GeoJSON, Shapefile, GeoPackage, CSV y FlatGeobuf, con reproyección del CRS; GeoParquet (siempre en EPSG:4326); PMTiles como archivo de teselas autocontenido para hosts estáticos que admitan solicitudes de rango
 - **Estado de la fuente:** origen, marcas de tiempo de última actualización y comprobación, vigencia basada en la frecuencia y comprobaciones de salud bajo demanda para orígenes de tipo Servicio y STAC
 - Seguimiento de procedencia y edición de metadatos
 

--- a/README.es.md
+++ b/README.es.md
@@ -30,10 +30,13 @@ curl -fsSL https://getgeolens.com/install.sh | sh
 </p>
 
 > [!NOTE]
-> **Versión inicial.** GeoLens se desarrolla y mantiene activamente y se ha publicado
-> recientemente como código abierto. La distribución autohospedada es joven y
-> algunas funciones y APIs aún pueden cambiar.
-> [Abre una incidencia](https://github.com/geolens-io/geolens/issues) si encuentras algún problema.
+> **Estabilidad de la API.** Las superficies estándar (OGC API Features/Records,
+> STAC y los endpoints de teselas) siguen sus especificaciones y son seguras
+> para construir sobre ellas. La API REST propia de GeoLens aún puede cambiar
+> entre versiones menores: los cambios de contrato se listan en el
+> [CHANGELOG](CHANGELOG.md) y los cambios incompatibles mantienen la forma
+> anterior funcionando al menos una versión menor más. ¿Encuentras algún
+> problema? [Abre una incidencia](https://github.com/geolens-io/geolens/issues).
 
 ## Documentación
 
@@ -67,8 +70,8 @@ GeoLens sustituye ese flujo de trabajo:
 
 - **Un solo centro de datos:** sube archivos, crea datasets, registra tablas que ya estén en la base de datos de GeoLens, importa instantáneas de servicios de entidades o referencia recursos STAC remotos; después consulta y previsualiza todo en conjunto
 - **Estado de la fuente, sin conjeturas:** consulta cómo llegó cada dataset al catálogo, cuándo se actualizó o comprobó por última vez, si su última actualización está al día, pendiente, atrasada o es desconocida respecto a la frecuencia declarada, y si el origen remoto de tipo Servicio o STAC sigue accesible
-- **Funciona con tus herramientas:** OGC API Features/Records, STAC API 1.0 y URLs directas de teselas para QGIS, ArcGIS y MapLibre
-- **Sin dependencia de proveedor:** tu catálogo y las copias que administra GeoLens permanecen en la infraestructura que controlas y salen mediante formatos abiertos. Los datasets vectoriales se exportan a GeoPackage, GeoJSON, Shapefile, CSV o GeoParquet; los ráster se descargan como GeoTIFF optimizado para la nube (COG); y cualquier cliente OGC API lee el catálogo directamente
+- **Funciona con tus herramientas:** OGC API Features/Records con filtrado CQL2 en el servidor, STAC API 1.0 y URLs directas de teselas para QGIS, ArcGIS y MapLibre
+- **Sin dependencia de proveedor:** tu catálogo y las copias que administra GeoLens permanecen en la infraestructura que controlas y salen mediante formatos abiertos. Los datasets vectoriales se exportan a GeoPackage, GeoJSON, Shapefile, CSV, GeoParquet, FlatGeobuf o PMTiles; los ráster se descargan como GeoTIFF optimizado para la nube (COG); y cualquier cliente OGC API lee el catálogo directamente
 - **Búsqueda semántica y espacial:** coincidencia difusa con pg_trgm desde el primer momento; añade un proveedor de embeddings y activa la búsqueda semántica para clasificar conjuntos de datos por significado (pgvector)
 - **Constructor de mapas integrado:** compón mapas multicapa, aplica estilos y compártelos mediante un enlace público o un iframe incrustable
 - **Asistencia de IA (opcional):** conversa con tus mapas, genera descripciones automáticamente y busca con lenguaje natural. Aporta un endpoint compatible con OpenAI o una clave de Anthropic, o prescinde por completo de esta función
@@ -116,10 +119,10 @@ Cada ejemplo anterior tiene una guía completa en la [documentación](https://do
 ### Ingesta y exportación de datos
 
 - **Cinco modos de fuente:** los datos Subidos y Creados se administran localmente; Registrar tabla sirve en el sitio una tabla existente de la propia base de datos PostGIS de GeoLens; las importaciones de Servicios son copias locales puntuales; los datasets STAC mantienen una referencia activa al recurso remoto
-- **Vector:** Shapefile, GeoPackage, GeoJSON, GeoParquet, CSV, XLSX
+- **Vector:** Shapefile, GeoPackage, GeoJSON, GeoParquet, FlatGeobuf, KML/KMZ, File Geodatabase comprimida (zip), CSV, XLSX
 - **Ráster:** GeoTIFF y Cloud-Optimized GeoTIFF (COG) con conversión automática
 - **Mosaicos:** mosaicos ráster basados en VRT a partir de varios archivos fuente
-- **Exportación:** GeoJSON, Shapefile, GeoPackage y CSV, con reproyección del CRS
+- **Exportación:** GeoJSON, Shapefile, GeoPackage, CSV, GeoParquet y FlatGeobuf, con reproyección del CRS; PMTiles como archivo de teselas autocontenido para hosts estáticos que admitan solicitudes de rango
 - **Estado de la fuente:** origen, marcas de tiempo de última actualización y comprobación, vigencia basada en la frecuencia y comprobaciones de salud bajo demanda para orígenes de tipo Servicio y STAC
 - Seguimiento de procedencia y edición de metadatos
 
@@ -132,10 +135,11 @@ Cada ejemplo anterior tiene una guía completa en la [documentación](https://do
 
 ### Estándares e interoperabilidad
 
-- OGC API - Features y OGC API - Records; endpoint de catálogo STAC API 1.0; catálogos JSON-LD DCAT 3, DCAT-US 3.0 y GeoDCAT-AP
+- OGC API - Features (con filtrado CQL2 en el servidor y `/queryables` por colección) y OGC API - Records; endpoint de catálogo STAC API 1.0; catálogos JSON-LD DCAT 3, DCAT-US 3.0 y GeoDCAT-AP
 - URLs directas de teselas y claves de API por usuario para QGIS, ArcGIS, MapLibre y cualquier cliente OGC
 - Las teselas vectoriales omiten columnas de atributos por debajo del zoom 10 para mantener pequeñas las teselas de zoom bajo; añade el parámetro de consulta `cols=<column>,<column>` a una URL de tesela para incluir columnas concretas en todos los niveles de zoom (los nombres se validan contra las columnas del conjunto y se descartan los desconocidos)
 - JWT + OAuth 2.0/OIDC y RBAC con permisos por conjunto de datos
+- Interfaz en inglés, español, francés y alemán
 
 <details>
 <summary>Seguridad</summary>
@@ -146,7 +150,6 @@ Cada ejemplo anterior tiene una guía completa en la [documentación](https://do
 - Control de acceso basado en roles (RBAC) con permisos por conjunto de datos
 - El registro de autoservicio está desactivado por defecto; cuando se activa con verificación SMTP, la entrega del correo de registro es uniforme para solicitudes nuevas y coincidentes
 - Registro de auditoría para todas las acciones administrativas
-- Internacionalización: inglés, español, francés y alemán
 
 </details>
 
@@ -224,7 +227,7 @@ docker compose ps
 
 Notas del primer arranque: la instalación en una línea **descarga** imágenes precompiladas y tarda alrededor de un minuto (solo se compila localmente la pequeña capa de base de datos PostGIS + pgvector). Clonar y ejecutar `bash scripts/install.sh` **compila** cada imagen desde el código fuente: 5-10 minutos la primera vez (GDAL + extensiones de Postgres + bundle del frontend); los arranques posteriores se estabilizan en unos 60 segundos en ambos casos. Si los puertos 5434/8001/8080 están ocupados, cambia `DB_PORT`, `API_PORT` o `FRONTEND_PORT` en `.env`. Para conflictos de puertos, arranques bloqueados, falta de memoria y advertencias de migración, consulta la [guía de resolución de problemas](https://docs.getgeolens.com/guides/quickstart/install/#troubleshooting).
 
-Para despliegues de producción, consulta la [guía de instalación](https://docs.getgeolens.com/guides/quickstart/install/). Hay un [chart de Helm](https://github.com/geolens-io/geolens-deployments) mantenido por la comunidad en el repositorio independiente [`geolens-deployments`](https://github.com/geolens-io/geolens-deployments).
+Para despliegues de producción, consulta la [guía de instalación](https://docs.getgeolens.com/guides/quickstart/install/). Un chart de Helm vive en el repositorio independiente [`geolens-deployments`](https://github.com/geolens-io/geolens-deployments).
 
 ### Verificar el instalador
 
@@ -315,7 +318,7 @@ flowchart TB
 
 | Componente | Tecnología |
 |-----------|-----------|
-| Frontend | React 19, Vite, MapLibre GL v5, TanStack Query, Tailwind CSS |
+| Frontend | React 19, Vite, MapLibre GL v6, TanStack Query, Tailwind CSS |
 | API backend | FastAPI (Python), GDAL/ogr2ogr, Procrastinate (cola de tareas) |
 | Teselas ráster | Titiler (servidor de teselas COG) |
 | Almacenamiento de objetos | MinIO (compatible con S3, desarrollo local) o cualquier proveedor S3 |
@@ -353,7 +356,7 @@ La API y el worker exportan métricas Prometheus de serie (tasa/latencia/errores
 | [Guía de administración](https://docs.getgeolens.com/guides/admin/) | Gestión de usuarios, conjuntos de datos y estado del sistema |
 | [Autohospedaje en AWS, GCP o DigitalOcean](https://docs.getgeolens.com/guides/quickstart/cloud-deployment/) | Guías para bases de datos, almacenamiento de objetos y caché administrados |
 | [CLI y manifiestos](https://docs.getgeolens.com/guides/cli/) | Publica archivos y gestiona catálogos con la CLI `geolens` |
-| [Referencia de la API](https://docs.getgeolens.com/guides/api/) | Referencia generada en docs.getgeolens.com; Swagger UI interactiva en `/api/docs` durante la ejecución |
+| [Referencia de la API](https://docs.getgeolens.com/guides/api/) | Referencia generada en docs.getgeolens.com; en modo de desarrollo la instancia también sirve Swagger UI en `/api/docs` (deshabilitada en producción) |
 | [Ejemplos de manifiestos](examples/manifests/) | Plantillas `geolens.yaml` adaptables: public-cog (COG remoto), url-source, s3-source, publication-states |
 | [Ejemplos de clientes](https://github.com/geolens-io/geolens-examples) | Ejemplos ejecutables de navegador, QGIS, DuckDB, SDK, CLI, incrustación, Python y MCP; los de solo lectura se verifican en CI contra la demo pública ([galería](https://geolens-io.github.io/geolens-examples/)) |
 
@@ -368,7 +371,7 @@ La API y el worker exportan métricas Prometheus de serie (tasa/latencia/errores
 - Una única instancia PostgreSQL, sin alta disponibilidad ni agrupación integradas.
 - GeoLens está diseñado para una organización por despliegue autohospedado.
 - La representación del terreno presupone que las unidades del DEM son metros; los conjuntos con otras unidades verticales pueden aparecer exagerados.
-- La distribución autohospedada es joven y algunas funciones y APIs aún pueden cambiar (consulta la nota de versión inicial anterior).
+- La API REST propia de GeoLens aún puede cambiar entre versiones menores (consulta la nota de estabilidad de la API anterior).
 
 ## Licencia
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -30,9 +30,13 @@ curl -fsSL https://getgeolens.com/install.sh | sh
 </p>
 
 > [!NOTE]
-> **Version initiale.** GeoLens est activement développé et maintenu, et vient
-> d’être publié en open source. La distribution auto-hébergée est jeune et
-> certaines fonctions et APIs peuvent encore évoluer. [Ouvrez un ticket](https://github.com/geolens-io/geolens/issues) en cas de difficulté.
+> **Stabilité de l’API.** Les surfaces standard (OGC API Features/Records,
+> STAC et les points de terminaison de tuiles) suivent leurs spécifications et
+> sont sûres pour vos intégrations. L’API REST propre à GeoLens peut encore
+> changer entre versions mineures : les changements de contrat sont listés dans
+> le [CHANGELOG](CHANGELOG.md), et les changements incompatibles conservent
+> l’ancienne forme fonctionnelle pendant au moins une version mineure
+> supplémentaire. Une difficulté ? [Ouvrez un ticket](https://github.com/geolens-io/geolens/issues).
 
 ## Documentation
 
@@ -66,8 +70,8 @@ GeoLens remplace ce processus :
 
 - **Une plateforme de données unique :** chargez des fichiers, créez des jeux de données, enregistrez des tables déjà présentes dans la base GeoLens, importez des instantanés de services d’entités ou référencez des ressources STAC distantes, puis recherchez et prévisualisez le tout au même endroit
 - **L’état des sources, sans conjectures :** voyez comment chaque jeu est arrivé dans le catalogue, quand il a été actualisé ou vérifié pour la dernière fois, si cette actualisation est récente, à effectuer, en retard ou indéterminée par rapport à la fréquence déclarée, et si une origine Service ou STAC distante reste accessible
-- **Compatible avec vos outils :** OGC API Features/Records, STAC API 1.0 et URLs directes de tuiles pour QGIS, ArcGIS et MapLibre
-- **Sans verrouillage :** votre catalogue et les copies gérées par GeoLens restent sur l’infrastructure que vous contrôlez et en sortent via des formats ouverts. Les jeux de données vectoriels s’exportent en GeoPackage, GeoJSON, Shapefile, CSV ou GeoParquet ; les rasters se téléchargent en GeoTIFF optimisé pour le cloud (COG) ; et n’importe quel client OGC API lit le catalogue directement
+- **Compatible avec vos outils :** OGC API Features/Records avec filtrage CQL2 côté serveur, STAC API 1.0 et URLs directes de tuiles pour QGIS, ArcGIS et MapLibre
+- **Sans verrouillage :** votre catalogue et les copies gérées par GeoLens restent sur l’infrastructure que vous contrôlez et en sortent via des formats ouverts. Les jeux de données vectoriels s’exportent en GeoPackage, GeoJSON, Shapefile, CSV, GeoParquet, FlatGeobuf ou PMTiles ; les rasters se téléchargent en GeoTIFF optimisé pour le cloud (COG) ; et n’importe quel client OGC API lit le catalogue directement
 - **Recherche sémantique et spatiale :** correspondance approximative pg_trgm prête à l’emploi ; ajoutez un fournisseur d’embeddings et activez la recherche sémantique pour classer les jeux de données par sens (pgvector)
 - **Générateur de cartes intégré :** composez des cartes multicouches, stylisez-les et partagez-les par lien public ou iframe intégrable
 - **Assistance IA (facultative) :** dialogue avec les cartes, génération automatique de descriptions et recherche en langage naturel. Utilisez un point de terminaison compatible OpenAI ou une clé Anthropic, ou ignorez entièrement cette fonction
@@ -115,10 +119,10 @@ Chaque exemple ci-dessus dispose d’un guide complet dans la [documentation](ht
 ### Ingestion et exportation des données
 
 - **Cinq modes de source :** les données Chargées et Créées sont gérées localement ; Enregistrer une table expose sur place une table existante de la base PostGIS de GeoLens ; les importations de Services sont des copies locales ponctuelles ; les jeux STAC conservent une référence active vers la ressource distante
-- **Vecteur :** Shapefile, GeoPackage, GeoJSON, GeoParquet, CSV, XLSX
+- **Vecteur :** Shapefile, GeoPackage, GeoJSON, GeoParquet, FlatGeobuf, KML/KMZ, File Geodatabase zippée, CSV, XLSX
 - **Raster :** GeoTIFF et Cloud-Optimized GeoTIFF (COG) avec conversion automatique
 - **Mosaïques :** mosaïques raster basées sur VRT à partir de plusieurs fichiers sources
-- **Exportation :** GeoJSON, Shapefile, GeoPackage, CSV, avec reprojection du CRS
+- **Exportation :** GeoJSON, Shapefile, GeoPackage, CSV, GeoParquet et FlatGeobuf, avec reprojection du CRS ; PMTiles pour une archive de tuiles autonome, servie par un hébergement statique acceptant les requêtes de plage (range)
 - **État de la source :** origine, horodatages de dernière actualisation et de dernière vérification, fraîcheur fondée sur la fréquence, et contrôles d’état à la demande pour les origines Service et STAC
 - Suivi de provenance et édition des métadonnées
 
@@ -131,10 +135,11 @@ Chaque exemple ci-dessus dispose d’un guide complet dans la [documentation](ht
 
 ### Normes et interopérabilité
 
-- OGC API - Features et OGC API - Records ; point de terminaison de catalogue STAC API 1.0 ; catalogues JSON-LD DCAT 3, DCAT-US 3.0 et GeoDCAT-AP
+- OGC API - Features (avec filtrage CQL2 côté serveur et `/queryables` par collection) et OGC API - Records ; point de terminaison de catalogue STAC API 1.0 ; catalogues JSON-LD DCAT 3, DCAT-US 3.0 et GeoDCAT-AP
 - URLs directes de tuiles et clés d’API par utilisateur pour QGIS, ArcGIS, MapLibre et tout client OGC
 - Les tuiles vectorielles omettent les colonnes d’attributs en dessous du zoom 10 afin de limiter leur taille ; ajoutez le paramètre `cols=<column>,<column>` à leur URL pour inclure certaines colonnes à chaque zoom (les noms sont validés par rapport aux colonnes du jeu et les noms inconnus sont ignorés)
 - JWT + OAuth 2.0/OIDC, RBAC avec permissions par jeu de données
+- Interface en anglais, espagnol, français et allemand
 
 <details>
 <summary>Sécurité</summary>
@@ -145,7 +150,6 @@ Chaque exemple ci-dessus dispose d’un guide complet dans la [documentation](ht
 - Contrôle d’accès par rôles (RBAC) avec permissions par jeu de données
 - L’inscription en libre-service est désactivée par défaut ; lorsqu’elle est activée avec vérification SMTP, l’envoi du courriel d’inscription est uniforme pour les demandes nouvelles ou déjà existantes
 - Journal d’audit de toutes les actions administratives
-- Internationalisation : anglais, espagnol, français, allemand
 
 </details>
 
@@ -223,7 +227,7 @@ docker compose ps
 
 Au premier démarrage, l’installation en une ligne **télécharge** les images précompilées et prend environ une minute (seule la petite couche PostGIS + pgvector est construite localement). Cloner puis exécuter `bash scripts/install.sh` **construit** toutes les images depuis les sources : 5 à 10 minutes la première fois (GDAL + extensions Postgres + bundle frontend) ; les démarrages suivants prennent environ 60 secondes dans les deux cas. Si les ports 5434/8001/8080 sont occupés, modifiez `DB_PORT`, `API_PORT` ou `FRONTEND_PORT` dans `.env`. Pour les conflits de ports, blocages, manques de mémoire et avertissements de migration, consultez le [guide de dépannage](https://docs.getgeolens.com/guides/quickstart/install/#troubleshooting).
 
-Pour un déploiement en production, consultez le [guide d’installation](https://docs.getgeolens.com/guides/quickstart/install/). Un [chart Helm](https://github.com/geolens-io/geolens-deployments) maintenu par la communauté se trouve dans le dépôt distinct [`geolens-deployments`](https://github.com/geolens-io/geolens-deployments).
+Pour un déploiement en production, consultez le [guide d’installation](https://docs.getgeolens.com/guides/quickstart/install/). Un chart Helm se trouve dans le dépôt distinct [`geolens-deployments`](https://github.com/geolens-io/geolens-deployments).
 
 ### Vérifier l’installateur
 
@@ -314,7 +318,7 @@ flowchart TB
 
 | Composant | Technologie |
 |-----------|-----------|
-| Frontend | React 19, Vite, MapLibre GL v5, TanStack Query, Tailwind CSS |
+| Frontend | React 19, Vite, MapLibre GL v6, TanStack Query, Tailwind CSS |
 | API backend | FastAPI (Python), GDAL/ogr2ogr, Procrastinate (file de tâches) |
 | Tuiles raster | Titiler (serveur de tuiles COG) |
 | Stockage objet | MinIO (compatible S3, développement local) ou tout fournisseur S3 |
@@ -352,7 +356,7 @@ L’API et le worker exportent nativement des métriques Prometheus (taux/latenc
 | [Guide d’administration](https://docs.getgeolens.com/guides/admin/) | Gestion des utilisateurs, jeux de données et santé du système |
 | [Auto-hébergement sur AWS, GCP ou DigitalOcean](https://docs.getgeolens.com/guides/quickstart/cloud-deployment/) | Guides de déploiement de base, stockage objet et cache gérés |
 | [CLI et manifestes](https://docs.getgeolens.com/guides/cli/) | Publication de fichiers et gestion des catalogues avec la CLI `geolens` |
-| [Référence API](https://docs.getgeolens.com/guides/api/) | Référence générée sur docs.getgeolens.com ; Swagger UI interactive sur `/api/docs` à l’exécution |
+| [Référence API](https://docs.getgeolens.com/guides/api/) | Référence générée sur docs.getgeolens.com ; en mode développement l’instance sert aussi Swagger UI sur `/api/docs` (désactivée en production) |
 | [Exemples de manifestes](examples/manifests/) | Modèles `geolens.yaml` : public-cog (COG distant), url-source, s3-source, publication-states |
 | [Exemples clients](https://github.com/geolens-io/geolens-examples) | Exemples exécutables navigateur, QGIS, DuckDB, SDK, CLI, intégration, Python et MCP ; ceux en lecture seule sont vérifiés par la CI sur la démo publique ([galerie](https://geolens-io.github.io/geolens-examples/)) |
 
@@ -367,7 +371,7 @@ L’API et le worker exportent nativement des métriques Prometheus (taux/latenc
 - Une instance PostgreSQL unique, sans haute disponibilité ni clustering intégrés.
 - GeoLens est conçu pour une organisation par déploiement auto-hébergé.
 - Le rendu du terrain suppose que les unités du DEM sont des mètres ; d’autres unités verticales peuvent produire un relief exagéré.
-- La distribution auto-hébergée est jeune et certaines fonctions et APIs peuvent encore évoluer (voir la note de version initiale ci-dessus).
+- L’API REST propre à GeoLens peut encore changer entre versions mineures (voir la note de stabilité de l’API ci-dessus).
 
 ## Licence
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -122,7 +122,7 @@ Chaque exemple ci-dessus dispose d’un guide complet dans la [documentation](ht
 - **Vecteur :** Shapefile, GeoPackage, GeoJSON, GeoParquet, FlatGeobuf, KML/KMZ, File Geodatabase zippée, CSV, XLSX
 - **Raster :** GeoTIFF et Cloud-Optimized GeoTIFF (COG) avec conversion automatique
 - **Mosaïques :** mosaïques raster basées sur VRT à partir de plusieurs fichiers sources
-- **Exportation :** GeoJSON, Shapefile, GeoPackage, CSV, GeoParquet et FlatGeobuf, avec reprojection du CRS ; PMTiles pour une archive de tuiles autonome, servie par un hébergement statique acceptant les requêtes de plage (range)
+- **Exportation :** GeoJSON, Shapefile, GeoPackage, CSV et FlatGeobuf, avec reprojection du CRS ; GeoParquet (toujours en EPSG:4326) ; PMTiles pour une archive de tuiles autonome, servie par un hébergement statique acceptant les requêtes de plage (range)
 - **État de la source :** origine, horodatages de dernière actualisation et de dernière vérification, fraîcheur fondée sur la fréquence, et contrôles d’état à la demande pour les origines Service et STAC
 - Suivi de provenance et édition des métadonnées
 

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Each example above has a full guide in the [docs](https://docs.getgeolens.com/gu
 - **Vector:** Shapefile, GeoPackage, GeoJSON, GeoParquet, FlatGeobuf, KML/KMZ, zipped File Geodatabase, CSV, XLSX
 - **Raster:** GeoTIFF and Cloud-Optimized GeoTIFF (COG) with automatic conversion
 - **Mosaics:** VRT-based raster mosaics from multiple source files
-- **Export:** GeoJSON, Shapefile, GeoPackage, CSV, GeoParquet, and FlatGeobuf with CRS reprojection; PMTiles as a self-contained tile archive for static hosts that support range requests
+- **Export:** GeoJSON, Shapefile, GeoPackage, CSV, and FlatGeobuf with CRS reprojection; GeoParquet (always EPSG:4326); PMTiles as a self-contained tile archive for static hosts that support range requests
 - **Source state:** origin and last-refreshed/last-checked timestamps, cadence-based source freshness, and on-demand health checks for Service and STAC origins
 - Provenance tracking and metadata editing
 

--- a/README.md
+++ b/README.md
@@ -30,10 +30,12 @@ curl -fsSL https://getgeolens.com/install.sh | sh
 </p>
 
 > [!NOTE]
-> **Early release.** GeoLens is actively developed and maintained, and newly
-> open-sourced. The self-hosted distribution is young and some features and APIs
-> may still change. Please
-> [open an issue](https://github.com/geolens-io/geolens/issues) if you hit a rough edge.
+> **API stability.** The standards surfaces (OGC API Features/Records, STAC,
+> and the tile endpoints) track their specifications and are safe to build
+> against. GeoLens's own REST API can still change between minor releases:
+> contract changes are listed in the [CHANGELOG](CHANGELOG.md), and breaking
+> ones keep the old form working for at least one more minor release. Hit a
+> rough edge? [Open an issue](https://github.com/geolens-io/geolens/issues).
 
 ## Documentation
 
@@ -67,8 +69,8 @@ GeoLens replaces that workflow:
 
 - **One data hub:** upload files, create datasets, register tables already in GeoLens's database, import feature-service snapshots, or reference remote STAC assets — then search and preview them together
 - **Source state, not guesswork:** see how each dataset entered the catalog, when it was last refreshed or checked, how its last refresh compares with its declared cadence (fresh, due, overdue, or unknown), and whether a remote Service or STAC origin is still reachable
-- **Works with your tools:** OGC API Features/Records, STAC API 1.0, direct tile URLs for QGIS, ArcGIS, and MapLibre
-- **No lock-in:** your catalog and the copies GeoLens manages stay on infrastructure you control and leave through open formats. Vector datasets export to GeoPackage, GeoJSON, Shapefile, CSV, or GeoParquet; rasters download as Cloud-Optimized GeoTIFF; and any OGC API client reads the catalog directly
+- **Works with your tools:** OGC API Features/Records with server-side CQL2 filtering, STAC API 1.0, direct tile URLs for QGIS, ArcGIS, and MapLibre
+- **No lock-in:** your catalog and the copies GeoLens manages stay on infrastructure you control and leave through open formats. Vector datasets export to GeoPackage, GeoJSON, Shapefile, CSV, GeoParquet, FlatGeobuf, or PMTiles; rasters download as Cloud-Optimized GeoTIFF; and any OGC API client reads the catalog directly
 - **Semantic and spatial search:** pg_trgm fuzzy matching out of the box; add an embedding provider and enable semantic search to rank datasets by meaning (pgvector)
 - **Built-in map builder:** compose multi-layer maps, style them, and share via public link or embeddable iframe
 - **AI-assisted (optional):** chat with your maps, auto-generate descriptions, search by natural language. Bring an OpenAI-compatible endpoint or Anthropic key, or skip it entirely
@@ -124,7 +126,7 @@ Each example above has a full guide in the [docs](https://docs.getgeolens.com/gu
 - **Vector:** Shapefile, GeoPackage, GeoJSON, GeoParquet, FlatGeobuf, KML/KMZ, zipped File Geodatabase, CSV, XLSX
 - **Raster:** GeoTIFF and Cloud-Optimized GeoTIFF (COG) with automatic conversion
 - **Mosaics:** VRT-based raster mosaics from multiple source files
-- **Export:** GeoJSON, Shapefile, GeoPackage, CSV, with CRS reprojection
+- **Export:** GeoJSON, Shapefile, GeoPackage, CSV, GeoParquet, and FlatGeobuf with CRS reprojection; PMTiles as a self-contained tile archive for static hosts that support range requests
 - **Source state:** origin and last-refreshed/last-checked timestamps, cadence-based source freshness, and on-demand health checks for Service and STAC origins
 - Provenance tracking and metadata editing
 
@@ -137,10 +139,11 @@ Each example above has a full guide in the [docs](https://docs.getgeolens.com/gu
 
 ### Standards and interop
 
-- OGC API - Features and OGC API - Records; STAC API 1.0 catalog endpoint
+- OGC API - Features (with server-side CQL2 filtering and per-collection `/queryables`) and OGC API - Records; STAC API 1.0 catalog endpoint; JSON-LD catalogs for DCAT 3, DCAT-US 3.0, and GeoDCAT-AP
 - Direct tile URLs and per-user API keys for QGIS, ArcGIS, MapLibre, and any OGC client
 - Vector tiles omit attribute columns below zoom 10 to keep low-zoom tiles small; add the `cols=<column>,<column>` query parameter to a tile URL to opt specific columns in at every zoom (names are validated against the dataset's columns, unknown names are dropped)
 - JWT + OAuth 2.0/OIDC, RBAC with per-dataset permissions
+- Interface in English, Spanish, French, and German
 
 <details>
 <summary>Security</summary>
@@ -152,7 +155,6 @@ Each example above has a full guide in the [docs](https://docs.getgeolens.com/gu
 - Self-serve registration is off by default; when enabled with SMTP verification,
   registration email delivery is uniform for new and colliding submissions
 - Audit logging for all administrative actions
-- Internationalization: English, Spanish, French, German
 
 </details>
 
@@ -253,7 +255,7 @@ already taken, change `DB_PORT`, `API_PORT`,
 or `FRONTEND_PORT` in `.env`. For port conflicts, stuck startups, out-of-memory,
 and migration warnings, see the [Troubleshooting guide](https://docs.getgeolens.com/guides/quickstart/install/#troubleshooting).
 
-For production deployment, see the [Install Guide](https://docs.getgeolens.com/guides/quickstart/install/). A community-maintained Kubernetes [Helm chart](https://github.com/geolens-io/geolens-deployments) lives in the separate [`geolens-deployments`](https://github.com/geolens-io/geolens-deployments) repo.
+For production deployment, see the [Install Guide](https://docs.getgeolens.com/guides/quickstart/install/). A Kubernetes Helm chart lives in the separate [`geolens-deployments`](https://github.com/geolens-io/geolens-deployments) repo.
 
 ### Verify the installer
 
@@ -359,7 +361,7 @@ flowchart TB
 
 | Component | Technology |
 |-----------|-----------|
-| Frontend | React 19, Vite, MapLibre GL v5, TanStack Query, Tailwind CSS |
+| Frontend | React 19, Vite, MapLibre GL v6, TanStack Query, Tailwind CSS |
 | Backend API | FastAPI (Python), GDAL/ogr2ogr, Procrastinate (task queue) |
 | Raster Tiles | Titiler (COG tile server) |
 | Object Storage | MinIO (S3-compatible, local dev) or any S3 provider |
@@ -415,7 +417,7 @@ see [RUNBOOK.md §4](RUNBOOK.md#4-monitoring) for the setup steps.
 | [Admin Guide](https://docs.getgeolens.com/guides/admin/) | User management, datasets, system health |
 | [Self-host on AWS, GCP, or DigitalOcean](https://docs.getgeolens.com/guides/quickstart/cloud-deployment/) | Managed database, object storage, and cache deployment guides |
 | [CLI & Manifests](https://docs.getgeolens.com/guides/cli/) | Publish files and manage catalogs with the `geolens` CLI |
-| [API Reference](https://docs.getgeolens.com/guides/api/) | Auto-generated reference at docs.getgeolens.com; interactive Swagger UI at `/api/docs` when running |
+| [API Reference](https://docs.getgeolens.com/guides/api/) | Auto-generated reference at docs.getgeolens.com; development-mode stacks also serve Swagger UI at `/api/docs` (disabled in production) |
 | [Manifest examples](examples/manifests/) | Template `geolens.yaml` manifests to adapt: public-cog (remote COG), url-source, s3-source, publication-states |
 | [Client examples](https://github.com/geolens-io/geolens-examples) | Runnable browser, QGIS, DuckDB, SDK, CLI, embed, Python, and MCP examples; the read-only ones are verified against the live demo in CI ([gallery](https://geolens-io.github.io/geolens-examples/)) |
 
@@ -430,7 +432,7 @@ see [RUNBOOK.md §4](RUNBOOK.md#4-monitoring) for the setup steps.
 - Single PostgreSQL instance, with no built-in high availability or clustering.
 - GeoLens is designed for one organization per self-hosted deployment.
 - Terrain rendering assumes DEM units are in meters; datasets in other vertical units may render exaggerated.
-- The self-hosted distribution is young and some features and APIs may still change (see the Early release note above).
+- GeoLens's own REST API may still change between minor releases (see the API stability note above).
 
 ## License
 


### PR DESCRIPTION
A completeness/correctness audit of the README against 1.16.0, folded into the Early-release-note retirement the roadmap called for ("replace with a concrete API-stability statement, don't delete silently"). All four locales updated in the same pass, per the convention #1611 set.

**The note.** The standards surfaces (OGC/STAC/tiles) are declared safe to build against; GeoLens's own REST API may change between minor releases, with contract changes listed in the CHANGELOG and breaking ones keeping the old form working for at least one more minor release — the practice #1670 established and #1671 will follow.

**Drift fixed alongside it (verified against the code):**
- Export lists gain GeoParquet/FlatGeobuf/PMTiles to match `ExportFormat` (PMTiles qualified as needing a range-capable static host, per the docs-site review consensus).
- The translated vector-format lists get the 1.16 additions (FlatGeobuf, KML/KMZ, zipped File Geodatabase) they never received.
- Server-side CQL2 filtering (the 1.16 headline) added to the Why and Standards bullets; the English standards bullet also regains the DCAT 3 / DCAT-US 3.0 / GeoDCAT-AP catalogs the translations still list (`backend/app/standards/dcat/`).
- MapLibre GL v5 → v6 in the architecture table (frontend pins ^6.5.0).
- The API-reference row no longer promises Swagger UI "when running": `docs_url=None` in production (backend/app/api/main.py:768).
- "Community-maintained" dropped from the first-party Helm chart line.
- The i18n line moved out of the Security details block to the interop list.

Verified correct and left alone: Python versions (3.14 bundled / 3.13 floor / CLI 3.11+ / SDK 3.10+), PG18 + PG13/pgvector-0.5 floors, ports, install and login flows, the search page-0 behavior note, and the QGIS connect URL.

https://claude.ai/code/session_01BXUUv3x71zWaLKEvoL4cTY