### PR TITLE
fix(nginx): send CORS headers on the export and COG download routes

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -315,6 +315,53 @@ server {
         # and a route that does not serve ranges should keep compressing.
         location ~ ^/api/datasets/[^/]+/(export|download/cog)/?$ {
             gzip off;
+
+            # fix(#1698): these routes carried no CORS headers at all, so a
+            # browser page on another origin could not consume a public export:
+            # the pmtiles protocol's ranged reads died on a preflight the api
+            # answers with 405, and the whole-file-fetch fallback died on the
+            # missing allow-origin. The api's anonymous wildcard covers only
+            # the standards/search paths, never these proxied byte routes.
+            #
+            # STATIC "*", same constraints as the raster-tiles block (#1464):
+            # auth is bearer-token/api-key (never cookies, so no
+            # Allow-Credentials is involved), authz is enforced server-side
+            # regardless of origin, and a reflected $http_origin would be
+            # replayed to other origins by any cache in front.
+            if ($request_method = OPTIONS) {
+                # Preflight, forced by the Range request header (pmtiles,
+                # DuckDB-WASM httpfs) or by Authorization. add_header in an
+                # if-block inherits nothing from outer scopes, so this is the
+                # complete header set for the 204.
+                add_header Access-Control-Allow-Origin "*" always;
+                add_header Access-Control-Allow-Methods "GET" always;
+                add_header Access-Control-Allow-Headers "Range, Authorization" always;
+                # Matches the api's own preflight lifetime. A pmtiles client
+                # issues many ranged reads against one URL; without this the
+                # browser re-preflights every few seconds.
+                add_header Access-Control-Max-Age "3600" always;
+                return 204;
+            }
+
+            # proxy_hide_header, because add_header APPENDS: for an origin
+            # listed in CORS_ALLOWED_ORIGINS the api echoes that origin on
+            # this route, and a response carrying two allow-origin values is
+            # rejected by browsers outright. Declaring proxy_hide_header at
+            # this level disables inheritance of the outer block's
+            # `proxy_hide_header X-Frame-Options` (A3), so that one is
+            # restated alongside.
+            proxy_hide_header Access-Control-Allow-Origin;
+            proxy_hide_header X-Frame-Options;
+            add_header Access-Control-Allow-Origin "*" always;
+            # Range clients need the range/validator response headers: a
+            # header not named here is invisible to cross-origin JavaScript.
+            add_header Access-Control-Expose-Headers "Content-Range, Accept-Ranges, Content-Length, ETag, Content-Disposition" always;
+            # add_header disables inheritance of the server-scope security
+            # set — restate it (same rule /assets/ and `location /` follow).
+            add_header X-Frame-Options "SAMEORIGIN" always;
+            add_header X-Content-Type-Options "nosniff" always;
+            add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+
             set $upstream_api ${API_UPSTREAM};
             rewrite ^/api/(.*) /$1 break;
             proxy_pass $upstream_api;

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -405,9 +405,24 @@ server {
             return 204;
         }
         # A genuinely unsupported method (POST/PUT/... to a byte route):
-        # re-emit the api's refusal. The intercepted body is gone; the status
-        # and the Allow set are what matter. add_header here disables the
-        # server-scope security set, so it is restated.
+        # re-emit the api's refusal. The intercepted body is gone, but the
+        # intercepted response's headers survive as $upstream_http_*, so the
+        # api's CORS policy is re-emitted rather than dropped (#1701 r2: a
+        # configured origin's POST used to come back as a bare 405 the
+        # browser reports as an opaque CORS failure instead of the api's
+        # refusal). The map hands back the middleware's explicit-origin echo
+        # when there is one and the wildcard otherwise; credentials and
+        # expose-headers come straight from the intercepted response, and
+        # add_header skips a header whose value is empty, so an anonymous
+        # refusal carries only the wildcard. Vary passes through for the
+        # same cache-keying reason as the main location. Allow stays
+        # hardcoded: the api's 405 advertises its own GET/HEAD router, but
+        # OPTIONS is answered at this edge, so the api's value would
+        # under-advertise the route's real surface.
+        add_header Access-Control-Allow-Origin $geolens_export_acao always;
+        add_header Access-Control-Allow-Credentials $upstream_http_access_control_allow_credentials always;
+        add_header Access-Control-Expose-Headers $upstream_http_access_control_expose_headers always;
+        add_header Vary $upstream_http_vary always;
         add_header Allow "GET, HEAD, OPTIONS" always;
         add_header X-Frame-Options "SAMEORIGIN" always;
         add_header X-Content-Type-Options "nosniff" always;

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -36,6 +36,19 @@ log_format geolens_safe '$remote_addr - $remote_user [$time_local] '
                         '"$request_method $geolens_safe_log_path $server_protocol" '
                         '$status $body_bytes_sent "$http_user_agent"';
 
+# fix(#1698, #1701 review): allow-origin for the dataset export/COG byte
+# routes. The api echoes an explicit origin (plus Allow-Credentials) when the
+# caller's Origin is listed in CORS_ALLOWED_ORIGINS; re-emitting exactly that
+# value keeps credentialed configured-origin fetches working — browsers reject
+# a wildcard whenever the request's credentials mode is include. When the api
+# declared no policy (anonymous, or an unlisted origin), fall back to the
+# static wildcard: auth on these routes is bearer-token/api-key and authz is
+# enforced server-side regardless of origin.
+map $upstream_http_access_control_allow_origin $geolens_export_acao {
+    ""      "*";
+    default $upstream_http_access_control_allow_origin;
+}
+
 # fix(#581): trusted-proxy trust boundary, rendered by the entrypoint from
 # TRUSTED_PROXY_CIDRS. Unset (the default), this is only an identity map
 # defining $geolens_fwd_proto = $scheme — byte-equivalent to the previous
@@ -323,36 +336,36 @@ server {
             # missing allow-origin. The api's anonymous wildcard covers only
             # the standards/search paths, never these proxied byte routes.
             #
-            # STATIC "*", same constraints as the raster-tiles block (#1464):
-            # auth is bearer-token/api-key (never cookies, so no
-            # Allow-Credentials is involved), authz is enforced server-side
-            # regardless of origin, and a reflected $http_origin would be
-            # replayed to other origins by any cache in front.
-            if ($request_method = OPTIONS) {
-                # Preflight, forced by the Range request header (pmtiles,
-                # DuckDB-WASM httpfs) or by Authorization. add_header in an
-                # if-block inherits nothing from outer scopes, so this is the
-                # complete header set for the 204.
-                add_header Access-Control-Allow-Origin "*" always;
-                add_header Access-Control-Allow-Methods "GET" always;
-                add_header Access-Control-Allow-Headers "Range, Authorization" always;
-                # Matches the api's own preflight lifetime. A pmtiles client
-                # issues many ranged reads against one URL; without this the
-                # browser re-preflights every few seconds.
-                add_header Access-Control-Max-Age "3600" always;
-                return 204;
-            }
+            # Split responsibility with the api (#1701 review): the api's
+            # DynamicCORSMiddleware still answers whenever it has a policy —
+            # an origin listed in CORS_ALLOWED_ORIGINS gets the credentialed
+            # explicit-origin answer, preflight included — and the edge fills
+            # only the gap the api refuses: the anonymous wildcard. That keeps
+            # the api's method/header allow-lists authoritative instead of
+            # mirroring them here and drifting. An anonymous preflight falls
+            # through the middleware to a router that registers GET/HEAD only,
+            # so it 405s; convert exactly that refusal into the wildcard
+            # answer. A configured origin's preflight is answered 200 by the
+            # middleware and passes through untouched. Only 405 is listed, so
+            # every other upstream status (401, 404, 416, ...) still reaches
+            # the client as the api wrote it.
+            proxy_intercept_errors on;
+            error_page 405 = @export_cors_preflight;
 
-            # proxy_hide_header, because add_header APPENDS: for an origin
-            # listed in CORS_ALLOWED_ORIGINS the api echoes that origin on
-            # this route, and a response carrying two allow-origin values is
-            # rejected by browsers outright. Declaring proxy_hide_header at
-            # this level disables inheritance of the outer block's
-            # `proxy_hide_header X-Frame-Options` (A3), so that one is
-            # restated alongside.
+            # proxy_hide_header, because add_header APPENDS and a response
+            # carrying two allow-origin values is rejected by browsers
+            # outright. The map at the top of this file re-emits the api's
+            # explicit-origin answer when there is one (a credentialed
+            # configured-origin fetch needs that exact origin, never "*") and
+            # falls back to the static wildcard when the api declared no
+            # policy. The api sends Vary: Origin on every response (#1602) and
+            # that passes through here, so caches in front key correctly.
+            # Declaring proxy_hide_header at this level disables inheritance
+            # of the outer block's `proxy_hide_header X-Frame-Options` (A3),
+            # so that one is restated alongside.
             proxy_hide_header Access-Control-Allow-Origin;
             proxy_hide_header X-Frame-Options;
-            add_header Access-Control-Allow-Origin "*" always;
+            add_header Access-Control-Allow-Origin $geolens_export_acao always;
             # Range clients need the range/validator response headers: a
             # header not named here is invisible to cross-origin JavaScript.
             add_header Access-Control-Expose-Headers "Content-Range, Accept-Ranges, Content-Length, ETag, Content-Disposition" always;
@@ -366,6 +379,40 @@ server {
             rewrite ^/api/(.*) /$1 break;
             proxy_pass $upstream_api;
         }
+    }
+
+    # fix(#1698, #1701 review): anonymous CORS preflight for the export/COG
+    # byte routes. Reached ONLY via error_page from the export location above,
+    # when the api answered 405 — i.e. the middleware recognized no origin and
+    # the request fell through to a GET/HEAD router. A configured origin's
+    # preflight never lands here; the middleware answers it upstream with the
+    # credentialed policy.
+    location @export_cors_preflight {
+        if ($request_method = OPTIONS) {
+            # The anonymous wildcard answer. add_header in an if-block
+            # inherits nothing, so this is the complete set for the 204.
+            # The allow list mirrors what these routes consume: Range plus
+            # the conditional headers #1528 gave the COG download, and the
+            # two token auth headers — a header-authenticated request is not
+            # credentialed in the CORS sense, so it works under a wildcard.
+            add_header Access-Control-Allow-Origin "*" always;
+            add_header Access-Control-Allow-Methods "GET, HEAD, OPTIONS" always;
+            add_header Access-Control-Allow-Headers "Range, If-Range, If-None-Match, If-Match, Authorization, X-Api-Key" always;
+            # Matches the api's own preflight lifetime. A pmtiles client
+            # issues many ranged reads against one URL; without this the
+            # browser re-preflights every few seconds.
+            add_header Access-Control-Max-Age "3600" always;
+            return 204;
+        }
+        # A genuinely unsupported method (POST/PUT/... to a byte route):
+        # re-emit the api's refusal. The intercepted body is gone; the status
+        # and the Allow set are what matter. add_header here disables the
+        # server-scope security set, so it is restated.
+        add_header Allow "GET, HEAD, OPTIONS" always;
+        add_header X-Frame-Options "SAMEORIGIN" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+        return 405;
     }
 
     # SEC-S08 (Phase 1062-05): per-token embed framing relies on the FastAPI


### PR DESCRIPTION
Closes #1698.

`/api/datasets/{id}/export` and `/download/cog` sent no CORS headers, so a browser page on another origin could not consume a public export at all. The pmtiles protocol's ranged reads were blocked twice: the `Range` header forces a preflight the route answered with 405, and the response carried no allow-origin. The whole-file `ArrayBuffer` fallback was blocked by the missing allow-origin alone. The api's anonymous CORS wildcard covers only the standards and search paths, never these proxied byte routes.

### Design (after the codex round)

The api's `DynamicCORSMiddleware` stays authoritative wherever it has a policy; nginx fills only the gap the api refuses.

- **Response allow-origin**: an http-scope map re-emits the api's explicit-origin answer when there is one (an origin listed in `CORS_ALLOWED_ORIGINS` gets its echo back, paired with the api's `Allow-Credentials: true`, which credentialed fetches require, since browsers reject a wildcard whenever the request's credentials mode is include). When the api declared no policy, the map falls back to a static `*`. The upstream copy is hidden first (`proxy_hide_header`), because `add_header` appends and two allow-origin values are browser-fatal. `Access-Control-Expose-Headers: Content-Range, Accept-Ranges, Content-Length, ETag, Content-Disposition` is added so range clients (pmtiles, DuckDB-WASM httpfs) can read the range and validator headers.
- **Preflight**: OPTIONS proxies upstream. A configured origin's preflight is answered by the middleware with its full credentialed policy and passes through untouched, so the api's method and header allow-lists never need mirroring into nginx. An anonymous preflight falls through the middleware to a GET/HEAD router and 405s; `proxy_intercept_errors` + `error_page 405` convert exactly that refusal into a 204 with `Allow-Origin: *`, `Allow-Methods: GET, HEAD, OPTIONS`, `Allow-Headers: Range, If-Range, If-None-Match, If-Match, Authorization, X-Api-Key`, and `Max-Age: 3600` (the api's own preflight lifetime; pmtiles issues many ranged reads against one URL). Only 405 is listed, so every other upstream status still reaches the client as the api wrote it.
- Declaring `proxy_hide_header` in the nested block stops inheritance of the outer `proxy_hide_header X-Frame-Options` (the A3 dedupe), so that one is restated, as is the server-scope security header set that any `add_header` stops inheriting.

### Why a wildcard for the anonymous case

The issue proposed the anonymous-only treatment the standards paths get, and after the review round that is essentially what shipped, in nginx rather than the api: explicit origin for configured origins, wildcard otherwise. The wildcard is safe here because auth is a bearer token or api key, never cookies (a header-authenticated request is not "credentialed" in the CORS sense, and both auth headers are in the anonymous preflight allow list), authorization is enforced server-side regardless of origin (a private dataset answers 401/404 no matter who asks), and the value is static, since a reflected `$http_origin` would be replayed to other origins by any cache in front (the demo runs behind Cloudflare). The api already sends `Vary: Origin` on every response, and it passes through, so caches key the configured-origin echoes correctly.

### Verification

Dev stack proxies through Vite, not nginx, so this was tested against the real image: built from this branch with `docker build --target frontend`, run standalone on a spare port. `nginx -t` passes (the duplicate-wasm warning is pre-existing base-image mime.types overlap). Two upstreams were used: the real API for the anonymous paths, and a stub reproducing `DynamicCORSMiddleware`'s configured-origin behavior (echo + `Allow-Credentials: true`, OPTIONS answered 200 before routing) for the configured-origin paths, since setting `CORS_ALLOWED_ORIGINS` on the shared dev API was off-limits.

Anonymous origin, real API upstream:

```
$ curl -sS -i -H 'Origin: https://geolens-io.github.io' \
    'http://127.0.0.1:8093/api/datasets/00000000-.../export?format=pmtiles'
HTTP/1.1 404 Not Found                  (dummy id; 404 proves the `always` flag)
Access-Control-Allow-Origin: *
Access-Control-Expose-Headers: Content-Range, Accept-Ranges, Content-Length, ETag, Content-Disposition
X-Frame-Options: SAMEORIGIN
X-Content-Type-Options: nosniff
Referrer-Policy: strict-origin-when-cross-origin

$ curl -sS -i -X OPTIONS -H 'Origin: https://geolens-io.github.io' \
    -H 'Access-Control-Request-Method: GET' -H 'Access-Control-Request-Headers: Range' \
    'http://127.0.0.1:8093/api/datasets/00000000-.../export?format=pmtiles'
HTTP/1.1 204 No Content                 (FastAPI's 405 intercepted at the edge)
Access-Control-Allow-Origin: *
Access-Control-Allow-Methods: GET, HEAD, OPTIONS
Access-Control-Allow-Headers: Range, If-Range, If-None-Match, If-Match, Authorization, X-Api-Key
Access-Control-Max-Age: 3600
```

Configured origin, stub upstream:

```
$ curl -sS -i -H 'Origin: https://app.example.com' '.../export?format=pmtiles'
HTTP/1.1 200 OK
Access-Control-Allow-Credentials: true
Access-Control-Allow-Origin: https://app.example.com     (exactly one, the api's echo)
Access-Control-Expose-Headers: Content-Range, Accept-Ranges, Content-Length, ETag, Content-Disposition

$ curl -sS -i -X OPTIONS -H 'Origin: https://app.example.com' \
    -H 'Access-Control-Request-Method: GET' -H 'Access-Control-Request-Headers: Range' \
    '.../export?format=pmtiles'
HTTP/1.1 200 OK                          (middleware's answer, passed through untouched)
Access-Control-Allow-Credentials: true
Access-Control-Allow-Headers: Authorization, Content-Type, Accept, X-Api-Key, X-Embed-Token, X-Config-Preview-Token, Range, If-Range, If-None-Match, If-Match
Access-Control-Allow-Methods: GET, HEAD, POST, PUT, PATCH, DELETE, OPTIONS
Access-Control-Allow-Origin: https://app.example.com
```

`/download/cog` answers identically (same block). Controls: `GET /api/health` with an Origin gains no access-control headers, `OPTIONS /api/health` still passes through to the upstream 405 (no interception outside the export block), a POST to the export path re-emits 405 with `Allow: GET, HEAD, OPTIONS`, and exactly one `X-Frame-Options` appears on export responses, confirming the restated hide keeps the A3 dedupe intact.

Config impact: none. nginx-only change, no backend, schema, or API surface change.

https://claude.ai/code/session_01BXUUv3x71zWaLKEvoL4cTY
