### PR TITLE
fix(builder): derive export attribution priority from MapLibre's live used flags

### DIFF
--- a/frontend/src/lib/__tests__/map-image-attribution.test.ts
+++ b/frontend/src/lib/__tests__/map-image-attribution.test.ts
@@ -455,6 +455,74 @@ describe('readRenderedAttribution', () => {
     expect(readRenderedAttribution(sourcesMap('   ', '\n\t'))).toEqual([]);
   });
 
+  /* feat(#1553 candidate 4): <object>, <embed>, <iframe> and <video> render
+   * perfectly visibly in the on-screen control — MapLibre's sanitizer strips
+   * only <script>, on* handlers and javascript:/data: URLs — and none of them
+   * derives DOM text. They take the same treatment as an unnamed <img>:
+   * accessible alternatives first, then the host-derived placeholder. */
+
+  it('names an unnamed object logo by its host, like an image', () => {
+    expect(
+      readRenderedAttribution(sourcesMap('<object data="https://assets.acme.com/logo.svg"></object>')),
+    ).toEqual(['(image credit: assets.acme.com)']);
+  });
+
+  it('names embed, iframe and video credits the same way', () => {
+    expect(
+      readRenderedAttribution(
+        sourcesMap(
+          '<embed src="https://a.example.com/logo.svg">',
+          '<iframe src="https://b.example.com/badge"></iframe>',
+          '<video poster="https://c.example.com/still.jpg"></video>',
+        ),
+      ),
+    ).toEqual([
+      '(image credit: a.example.com)',
+      '(image credit: b.example.com)',
+      '(image credit: c.example.com)',
+    ]);
+  });
+
+  it('lets an embed\'s accessible alternative outrank its host placeholder', () => {
+    // The generic-element rule already reads aria-label/title on these; the
+    // placeholder is only for an embed nothing names.
+    expect(
+      readRenderedAttribution(
+        sourcesMap('<object data="https://assets.acme.com/logo.svg" aria-label="© Acme 2026"></object>'),
+      ),
+    ).toEqual(['© Acme 2026']);
+  });
+
+  it('lets object fallback content, which is DOM text, win over the placeholder', () => {
+    expect(
+      readRenderedAttribution(
+        sourcesMap('<object data="https://assets.acme.com/logo.svg">© Acme Provider</object>'),
+      ),
+    ).toEqual(['© Acme Provider']);
+  });
+
+  it('keeps text around an unnamed embed rather than replacing or dropping it', () => {
+    // The inline mirror of the <img> rule: the embed is on screen beside the
+    // text, so the derivation says so.
+    expect(
+      readRenderedAttribution(
+        sourcesMap('© Provider <embed src="https://cdn.acme.com/logo.svg">'),
+      ),
+    ).toEqual(['© Provider (image credit: cdn.acme.com)']);
+  });
+
+  it('falls back to the bare placeholder for an embed with no usable URL', () => {
+    // data: URIs are what MapLibre's sanitizer strips anyway, so a host is
+    // never derived from one.
+    expect(
+      readRenderedAttribution(sourcesMap('<object data="data:image/svg+xml,<svg/>"></object>')),
+    ).toEqual(['(image credit)']);
+    // <video> tries src first, then poster.
+    expect(
+      readRenderedAttribution(sourcesMap('<video src="blob:whatever"></video>')),
+    ).toEqual(['(image credit)']);
+  });
+
   /* fix(#1541 codex P1): "no `used` gating — over-crediting is the safe
    * direction" was true while the band could grow without limit. Once the
    * outputs gained a capacity limit and a prefix fit, an unused credit stopped
@@ -621,6 +689,147 @@ describe('readRenderedAttribution', () => {
     expect(credits).toEqual(['© Shown', '© Also Shown']);
   });
 
+  it('counts a filter-excluded source as shown, exactly as the control does', () => {
+    // feat(#1553 candidate 2), settled by parity rather than by evaluation:
+    // MapLibre sets `used` from `!layer.isHidden(zoom)` alone (verified in the
+    // 6.5.0 source), so a layer whose filter matches no feature still puts its
+    // source's credit in the on-screen control. Matching the control means
+    // counting it shown here too; evaluating filters ourselves would OPEN a
+    // divergence, not close one.
+    const credits = readRenderedAttribution({
+      ...mapWithControl(null),
+      getStyle: () => ({
+        sources: {
+          filtered: { attribution: '© Filtered But Credited' },
+          plain: { attribution: '© Plain' },
+        },
+        layers: [
+          { id: 'l0', source: 'filtered', layout: {}, filter: ['==', ['get', 'kind'], 'nothing-has-this'] },
+          { id: 'l1', source: 'plain', layout: {} },
+        ],
+      }),
+    });
+    expect(credits).toEqual(['© Filtered But Credited', '© Plain']);
+  });
+
+  /* feat(#1553 candidate 1): the priority set reads MapLibre's OWN live
+   * `used`/`usedForTerrain` flags — the exact state the on-screen control
+   * renders from (`map.style.tileManagers` in 6.5.0) — whenever the map
+   * exposes them, so the partition cannot drift from the control. The modeled
+   * signals below survive only as the fallback for a partial map, or for the
+   * next time MapLibre renames the internal collection (it already went
+   * `sourceCaches` → `tileManagers` once). */
+
+  function liveFlagMap(
+    sources: Record<string, string>,
+    managers: Record<string, { used?: boolean; usedForTerrain?: boolean }> | 'absent',
+    layers?: { source: string; hidden?: boolean }[],
+  ) {
+    const layerDefs: { source: string; hidden?: boolean }[] =
+      layers ?? Object.keys(sources).map((source) => ({ source }));
+    return {
+      ...mapWithControl(null),
+      getStyle: () => ({
+        sources: Object.fromEntries(
+          Object.entries(sources).map(([id, attribution]) => [id, { attribution }]),
+        ),
+        layers: layerDefs.map(({ source, hidden }, i) => ({
+          id: `layer-${i}`,
+          source,
+          layout: hidden ? { visibility: 'none' } : {},
+        })),
+      }),
+      ...(managers === 'absent' ? {} : { style: { tileManagers: managers } }),
+    };
+  }
+
+  it('reads the live used flags in preference to the modeled signals', () => {
+    // Both layers are visible and in range, so the model would call both
+    // shown. MapLibre itself says one is unused — its judgement wins, and the
+    // unused credit is ordered back, never dropped.
+    const credits = readRenderedAttribution(
+      liveFlagMap(
+        { idle: '© Live-Unused Provider', busy: '© Live-Used Provider' },
+        { idle: { used: false }, busy: { used: true } },
+      ),
+    );
+    expect(credits).toEqual(['© Live-Used Provider', '© Live-Unused Provider']);
+  });
+
+  it('counts a live usedForTerrain source as shown, as the control does', () => {
+    // Terrain through the flag itself, with no layer reference and no
+    // getTerrain on the mock: exactly what the control reads.
+    const credits = readRenderedAttribution(
+      liveFlagMap(
+        { dem: '© swisstopo swissALTI3D', hiddenSrc: '© Hidden Provider' },
+        { dem: { usedForTerrain: true }, hiddenSrc: { used: false } },
+        [{ source: 'hiddenSrc' }],
+      ),
+    );
+    expect(credits).toEqual(['© swisstopo swissALTI3D', '© Hidden Provider']);
+  });
+
+  it('lets a live used flag overrule a hidden layer', () => {
+    // Live REPLACES the model rather than intersecting with it: whatever made
+    // MapLibre count the source used (another layer, terrain, a state the
+    // model cannot see), the control credits it, so the image leads with it.
+    const credits = readRenderedAttribution(
+      liveFlagMap(
+        { contested: '© Contested Provider', plain: '© Plain Provider' },
+        { contested: { used: true }, plain: { used: false } },
+        [{ source: 'contested', hidden: true }, { source: 'plain' }],
+      ),
+    );
+    expect(credits).toEqual(['© Contested Provider', '© Plain Provider']);
+  });
+
+  it('falls back to the modeled signals when the live collection is absent', () => {
+    // No `style` at all (every partial mock the builder suites pass) …
+    const modelOnly = readRenderedAttribution(
+      liveFlagMap({ a: '© Shown', b: '© Hidden' }, 'absent', [
+        { source: 'a' },
+        { source: 'b', hidden: true },
+      ]),
+    );
+    expect(modelOnly).toEqual(['© Shown', '© Hidden']);
+    // … and a style whose collection is missing or reshaped (the rename risk:
+    // `sourceCaches` → `tileManagers` has already happened once).
+    for (const style of [{}, { tileManagers: null }, { tileManagers: 'renamed-away' }]) {
+      const credits = readRenderedAttribution({
+        ...liveFlagMap({ a: '© Shown', b: '© Hidden' }, 'absent', [
+          { source: 'a' },
+          { source: 'b', hidden: true },
+        ]),
+        style,
+      });
+      expect(credits, `style shape: ${JSON.stringify(style)}`).toEqual(['© Shown', '© Hidden']);
+    }
+  });
+
+  it('treats an empty live collection as a live answer, not a fallback', () => {
+    // Sources are declared but none is instantiated, so the control shows
+    // nothing. Everything goes to the hidden group in style order — still
+    // credited while there is room, per the ordering-not-filtering rule. The
+    // model would instead have promoted `visible` ahead of `declared-first`.
+    const credits = readRenderedAttribution(
+      liveFlagMap(
+        { hiddenByLayer: '© Declared First', visible: '© Visible By Layer' },
+        {},
+        [{ source: 'hiddenByLayer', hidden: true }, { source: 'visible' }],
+      ),
+    );
+    expect(credits).toEqual(['© Declared First', '© Visible By Layer']);
+  });
+
+  it('ignores a manager entry that is not an object', () => {
+    const credits = readRenderedAttribution({
+      ...mapWithControl(null),
+      getStyle: () => ({ sources: { a: { attribution: '© Provider' } } }),
+      style: { tileManagers: { a: null } },
+    });
+    expect(credits).toEqual(['© Provider']);
+  });
+
   /* fix(#1541 codex P2 round 8): MapLibre's AttributionControl drops an entry
    * another entry contains whole, so `© Acme` beside `© Acme — CC BY 4.0`
    * showed once on screen and twice in the image. Asymmetric failure: source
@@ -663,6 +872,21 @@ describe('readRenderedAttribution', () => {
     // Strictly-longer containment, so equal strings cannot suppress each
     // other; the exact dedupe owns that case and keeps one.
     expect(readRenderedAttribution(sourcesMap('© Same', '© Same'))).toEqual(['© Same']);
+  });
+
+  it('collapses raw-distinct credits whose rendered text is identical', () => {
+    // chore(#1553 candidate 3): the one DELIBERATE divergence from the
+    // control's dedupe, which compares raw HTML and renders `© OSM | © OSM`
+    // for two anchors differing only in href. Text is what the image renders,
+    // so text-identical credits are visual duplicates here and keep one line.
+    expect(
+      readRenderedAttribution(
+        sourcesMap(
+          '<a href="https://www.openstreetmap.org/copyright">© OSM</a>',
+          '<a href="https://osm.org/copyright">© OSM</a>',
+        ),
+      ),
+    ).toEqual(['© OSM']);
   });
 
   it('suppresses a chain of containments down to the fullest statement', () => {

--- a/frontend/src/lib/map-image-attribution.ts
+++ b/frontend/src/lib/map-image-attribution.ts
@@ -64,6 +64,12 @@ export interface AttributionMapLike {
   /** The current zoom, against which a layer's zoom range is judged. Also
    *  public, also only used to order; see `shownSourceIds`. */
   getZoom?: () => number | undefined;
+  /** feat(#1553): MapLibre's live style object, reached ONLY to read the same
+   *  `used`/`usedForTerrain` flags the on-screen AttributionControl renders
+   *  from. Typed `unknown` because the shape is internal and has been renamed
+   *  under us once already; `liveUsedSourceIds` reads it defensively and the
+   *  modeled approximation stays as the fallback. */
+  style?: unknown;
 }
 
 function attributionFont(fontPx: number): string {
@@ -142,24 +148,52 @@ function textAlternative(el: Element): string | null {
   return null;
 }
 
-/** A name for an image that offers no alternative at all. Its host, where it
+/** Replaced elements that, like an image, display external content identified
+ *  only by a URL, mapped to the attribute carrying that URL.
+ *
+ *  feat(#1553 candidate 4): MapLibre's control sanitizer strips only <script>,
+ *  `on*` handlers and javascript:/data: URLs, so every one of these renders
+ *  perfectly visibly in the on-screen control — and none of them derives DOM
+ *  text, so a provider crediting itself with `<object data="logo.svg">` used to
+ *  contribute nothing inline and reach the image only through the source-level
+ *  floor, or not at all when text stood beside it. They now take the same
+ *  treatment as an unnamed <img>: the accessible alternatives first (the
+ *  generic-element rule already checks those), then the host-derived
+ *  placeholder. <img> keeps its own branch because `alt=""` is a decorative
+ *  opt-out these elements do not have. Elements that embed nothing external
+ *  (an empty <span>, a bare <canvas>) are deliberately absent: markup with no
+ *  URL names nothing, and the source-level floor still counts a credit made
+ *  only of them. */
+const EMBED_URL_ATTRS: Record<string, readonly string[]> = {
+  OBJECT: ['data'],
+  EMBED: ['src'],
+  IFRAME: ['src'],
+  VIDEO: ['src', 'poster'],
+};
+
+/** A name for an embed that offers no alternative at all. Its host, where it
  *  has one: that is the only provider-identifying text such a credit carries,
  *  and it also keeps two distinct unnamed logos from deduping into one. Two
  *  hostless ones (a data: URI) still collapse — they are indistinguishable in
  *  text, which is the residual of a credit that ships no words. */
-function unnamedImageCredit(el: Element): string {
-  const src = el.getAttribute('src');
-  if (src) {
+function unnamedEmbedCredit(el: Element, urlAttrs: readonly string[]): string {
+  for (const attr of urlAttrs) {
+    const src = el.getAttribute(attr);
+    if (!src) continue;
     try {
       const url = new URL(src, window.location.href);
       if (url.protocol === 'http:' || url.protocol === 'https:') {
         return i18n.t('builder:export.imageCreditFrom', { host: url.hostname });
       }
     } catch {
-      // Unparseable src: fall through to the bare placeholder.
+      // Unparseable URL: try the next attribute, then the bare placeholder.
     }
   }
   return i18n.t('builder:export.imageCredit');
+}
+
+function unnamedImageCredit(el: Element): string {
+  return unnamedEmbedCredit(el, ['src']);
 }
 
 /** Walk `node`, collecting text and text alternatives with break sentinels at
@@ -192,8 +226,18 @@ function collectCreditText(node: Node): string {
   for (const child of Array.from(el.childNodes)) inner += collectCreditText(child);
   // An element that contributes no text of its own falls back to its own
   // alternative. Checked AFTER the children so a labelled wrapper around real
-  // text does not credit the same provider twice.
-  if (!inner.split(BREAK).join('').trim()) inner = textAlternative(el) ?? inner;
+  // text does not credit the same provider twice — and so <object>/<iframe>
+  // fallback content, which IS DOM text, wins over the placeholder.
+  if (!inner.split(BREAK).join('').trim()) {
+    const alternative = textAlternative(el);
+    const urlAttrs = EMBED_URL_ATTRS[tag];
+    if (alternative) inner = alternative;
+    // feat(#1553 candidate 4): an unnamed URL-bearing embed is displaying
+    // something we cannot name, exactly like an unnamed <img>. Placeholder,
+    // not silence — mirroring the image rule keeps the two forms a provider
+    // actually ships (img and object/embed logos) from diverging.
+    else if (urlAttrs) inner = unnamedEmbedCredit(el, urlAttrs);
+  }
   return BLOCK_CREDIT_TAGS.has(tag) ? `${BREAK}${inner}${BREAK}` : inner;
 }
 
@@ -337,17 +381,21 @@ function dedupe(entries: string[]): string[] {
  * running), so the reader sees credits the screen does not.
  *
  * Ordering rather than filtering, deliberately: a source hidden at capture time
- * can still be part of what the map is OF, and `used` is a live-render concept
- * a headless export cannot always reproduce. Everything is still credited when
+ * can still be part of what the map is OF. Everything is still credited when
  * there is room — the over-crediting property is intact — and what the marker
  * elides first is now the hidden sources, which is the correct thing to lose.
+ * The on-screen control filters (an unused source's credit simply is not
+ * there), so a bounded export with room to spare renders a SUPERSET of the
+ * control's line. That is the one deliberate, decided divergence (#1541
+ * review) and it errs in the licensing-safe direction.
  *
- * `shownSourceIds` is an explicit approximation of `used`/`usedForTerrain` from
- * public signals — layer visibility, layer zoom range, terrain — with the gaps
- * it does not model named in its own comment rather than left to be discovered.
- * Every one of them errs toward calling a source shown, which costs nothing:
- * the answer only ORDERS the list, so a source it gets wrong is mis-sorted,
- * never dropped.
+ * feat(#1553): `shownSourceIds` now reads MapLibre's live `used` /
+ * `usedForTerrain` flags — the control's own input — whenever the map exposes
+ * them, and falls back to the documented approximation (layer visibility, zoom
+ * range, terrain) only when it does not. See its comment for the two tiers and
+ * their gaps. Every gap errs toward calling a source shown, which costs
+ * nothing: the answer only ORDERS the list, so a source it gets wrong is
+ * mis-sorted, never dropped.
  *
  * One cost of preferring (1), accepted:
  *
@@ -388,6 +436,21 @@ interface AttributionStyle {
  * this list is ordered shown-first and by style order within that, which is
  * load-bearing (see `readRenderedAttribution`).
  *
+ * chore(#1553 candidate 3): re-verified line-by-line against the installed
+ * maplibre-gl 6.5.0 (`_updateAttributions`): exact-duplicate skip at
+ * collection, whitespace-only filter, length sort, then drop any entry a
+ * LATER — post-sort, longer — entry `includes`. Two rules line up exactly:
+ * strictly-longer containment (after the sort and the exact dedupe, an
+ * equal-length distinct entry can never contain another) and the ` | ` join.
+ * One divergence is deliberate and stays: the control compares RAW HTML
+ * strings, this module compares DERIVED TEXT. Text is what the image renders,
+ * so two anchors differing only in `href` — which the control shows twice —
+ * are indistinguishable visual duplicates here and collapse to one; and
+ * raw-level containment that normalization breaks (`©  Acme` beside
+ * `© Acme Data`) still suppresses at the text level. Both directions only ever
+ * REMOVE a line whose text another line carries whole, so no credit text is
+ * lost either way.
+ *
  * STRICTLY longer, and WITHIN ONE PRIORITY GROUP ONLY. Strictly longer so two
  * equal strings cannot suppress each other into nothing — `dedupe` owns that
  * case. Within one group because a hidden credit suppressing a shown one would
@@ -405,20 +468,36 @@ function suppressContainedCredits(entries: string[]): string[] {
 }
 
 /**
- * Source ids that are rendering. AN APPROXIMATION OF MAPLIBRE'S `used` /
- * `usedForTerrain`, computed from public signals, and stated as one so the next
- * gap in it is a known limit rather than a bug report.
+ * Source ids that are rendering, in TWO TIERS: MapLibre's own live
+ * `used`/`usedForTerrain` flags where they are reachable (feat(#1553)), and
+ * the modeled approximation of them where they are not.
  *
- * The live flags are NOT reachable as public API. They live on the internal
- * per-source cache reached through `map.style`, and the collection holding them
- * is `Style.tileManagers` in maplibre-gl 5.24 where it was `sourceCaches`
- * before — an internal name that has already been renamed once under us. So
- * this recomputes them from what `getStyle()`, `getZoom()` and `getTerrain()`
- * expose.
+ * TIER 1 — the live flags (`liveUsedSourceIds`). The on-screen
+ * AttributionControl renders exactly the sources for which
+ * `map.style.tileManagers[id].used || .usedForTerrain` holds (maplibre-gl
+ * 6.5.0, src/ui/control/attribution_control.ts `_updateAttributions`), and
+ * `map.style` IS reachable from the live Map instance both capture paths
+ * already hold — the export is canvas-composited, not headless. Reading the
+ * control's own input removes the approximation class of drift outright: the
+ * partition cannot disagree with the control, including when MapLibre next
+ * changes what counts as used. The one residual is timing — the flags are
+ * recomputed per rendered frame, and both captures run inside a render
+ * callback, so they are at most one frame old, strictly fresher than a model.
  *
- * WHAT IT MODELS, which is MapLibre's own definition of the flag — "at least
- * one of its layers becomes visible in style sense (inside the layer's zoom
- * range and with layout.visibility set to 'visible')", and in the source
+ * The collection is internal, though, typed on `Style` but not API, and it has
+ * been renamed once already — `sourceCaches` until maplibre-gl 5.24,
+ * `tileManagers` since. So it is read defensively: an unreachable collection
+ * (absent, renamed again, not an object) falls back to tier 2 rather than
+ * degrading to an everything-hidden answer, which is why null and an empty
+ * live collection are distinguished.
+ *
+ * TIER 2 — the approximation, kept as the fallback for a partial map (the
+ * builder suites' mocks) and for the next rename. It recomputes the flag from
+ * what `getStyle()`, `getZoom()` and `getTerrain()` expose.
+ *
+ * WHAT TIER 2 MODELS, which is MapLibre's own definition of the flag — "at
+ * least one of its layers becomes visible in style sense (inside the layer's
+ * zoom range and with layout.visibility set to 'visible')", and in the source
  * `!layer.isHidden(zoom) && layer.source && tileManagers[layer.source].used =
  * true`, where `isHidden` is `zoom < minzoom || zoom >= maxzoom || visibility
  * === 'none'`:
@@ -435,23 +514,52 @@ function suppressContainedCredits(entries: string[]): string[] {
  *     that only `usedForTerrain` counts, so layer references alone put a credit
  *     for plainly visible 3D relief in the hidden group.
  *
- * WHAT IT DOES NOT MODEL. Neither does `used` — these make a source render
- * nothing while MapLibre still counts it used, so reading the live flag would
- * not close them either:
+ * WHAT NEITHER TIER MODELS — and neither does the CONTROL, verified against
+ * the 6.5.0 source: `used` is set from `!layer.isHidden(zoom)` alone, so these
+ * make a source render nothing while the on-screen control still credits it:
  *
- *   - a layer `filter` that matches no feature
+ *   - a layer `filter` that matches no feature (#1553 candidate 2: the control
+ *     counts such a source used and shows its credit, so PARITY with the
+ *     control means counting it shown here too — evaluating filters ourselves
+ *     would open a divergence, not close one)
  *   - zero opacity, or paint that renders invisibly
  *   - tiles that are empty, absent, or outside the viewport
  *
- * And two that are ours alone:
+ * And two that are tier 2's alone:
  *
  *   - anything not in the serialized style, since `getStyle()` is the input
  *   - timing: MapLibre recomputes per frame, this reads once at capture
  *
- * Every one of those errs toward calling a source SHOWN, which is the safe way
- * to be wrong: the answer only ORDERS the credit list, so a source it misjudges
- * is mis-sorted, never dropped.
+ * Every gap errs toward calling a source SHOWN, which is the safe way to be
+ * wrong: the answer only ORDERS the credit list, so a source it misjudges is
+ * mis-sorted, never dropped.
  */
+interface LiveTileManagerLike {
+  used?: unknown;
+  usedForTerrain?: unknown;
+}
+
+/**
+ * feat(#1553): the ids MapLibre itself counts used, read from the live flags
+ * the on-screen control renders from, or null when the internal collection is
+ * not reachable. The truthiness test mirrors the control's own
+ * (`tileManager.used || tileManager.usedForTerrain`).
+ */
+function liveUsedSourceIds(map: AttributionMapLike): Set<string> | null {
+  const style = map.style as
+    | { tileManagers?: Record<string, LiveTileManagerLike | null | undefined> | null }
+    | null
+    | undefined;
+  const managers = style?.tileManagers;
+  if (!managers || typeof managers !== 'object') return null;
+  const used = new Set<string>();
+  for (const id of Object.keys(managers)) {
+    const manager = managers[id];
+    if (manager && (manager.used || manager.usedForTerrain)) used.add(id);
+  }
+  return used;
+}
+
 function layerHiddenAtZoom(
   layer: { minzoom?: unknown; maxzoom?: unknown },
   zoom: number | undefined,
@@ -469,6 +577,12 @@ function shownSourceIds(
   map: AttributionMapLike,
   style: AttributionStyle | null | undefined,
 ): Set<string> {
+  // feat(#1553): the live flags first — this is the state the on-screen
+  // control renders from, so the partition cannot drift from it. The model
+  // below is the fallback for a map that does not expose them.
+  const live = liveUsedSourceIds(map);
+  if (live) return live;
+
   const shown = new Set<string>();
   const terrainSource = map.getTerrain?.()?.source;
   if (typeof terrainSource === 'string') shown.add(terrainSource);


### PR DESCRIPTION
Advances #1553 (the rolling follow-up home; leaves it open).

The export/thumbnail/OG attribution priority set was a model of MapLibre's `used`/`usedForTerrain` state. This PR reads the live state where it is reachable and settles the rest of the issue's candidate list against the installed maplibre-gl 6.5.0 source.

## Candidate 1: derive priority from the live `used`/`usedForTerrain` state. Done.

The premise held. The "headless" export path is not actually headless: both capture paths (`doCapture` and `handleExportPNG` in `use-builder-save.ts`) hold the live builder `Map`, and the state the on-screen control renders from is reachable through it. In 6.5.0, `_updateAttributions` shows exactly the sources for which `map.style.tileManagers[id].used || .usedForTerrain` holds.

`shownSourceIds` now reads those flags first (`liveUsedSourceIds`), so the shown/hidden partition cannot drift from the control, including when MapLibre next changes what counts as used. Both captures run inside a render callback and the flags are recomputed per rendered frame, so they are at most one frame old. That is fresher than any model can be.

The approximation is demoted rather than deleted. `Style.tileManagers` is internal (typed, but not API) and has been renamed once already: it was `sourceCaches` until 5.24. The read is defensive. A collection that is absent, renamed again, or reshaped returns null, and the modeled tier (visibility, zoom range, terrain) answers exactly as before, instead of degrading to an everything-hidden answer. A reachable but empty collection is a live answer and is distinguished from an unreachable one. On a real map the live tier is what runs, so the approximation class of drift is gone from every real capture; removing the fallback outright would trade that for a silent regression on the next upstream rename, which is why the issue's "remove the approximation class" lands as "demote it to the degradation tier".

Ordering-not-filtering is unchanged: an unused source's credit is still rendered when there is room and elided first when there is not (the #1541-review decision). The control filters, so a bounded output with room to spare remains a deliberate superset of the control's line, which errs in the direction licensing wants.

## Candidate 2: layer `filter` expressions. Resolved by parity, with no filter evaluation.

Verified in the 6.5.0 source: `used` is set from `!layer.isHidden(zoom)` alone (`Style.update`), and `isHidden` is zoom range plus `layout.visibility`. Filters play no part. A source whose every feature is filtered out still shows its credit in the on-screen control, so parity with the control means counting it shown here too. The issue guessed this class "falls out for free if candidate 1 works", and it does, in an unexpected way: the control itself over-credits this class, and now the image does too, identically, by construction. Evaluating filters ourselves would open a divergence rather than close one. A test pins the semantics and the module comment records the finding.

## Candidate 3: dedupe/suppression alignment with current v6. Verified; one divergence documented and pinned.

`_updateAttributions` in 6.5.0 does: exact-duplicate skip at collection, whitespace-only filter, length sort, then drop any entry a later (post-sort, longer) entry `includes`. Comparing line by line:

- Strictly-longer containment suppression matches. After the sort and the exact dedupe, an equal-length distinct entry can never contain another, so our `dedupe` plus strictly-longer rule produce the same survivor set. Existing tests already cover this, including order-independence.
- The ` | ` join matches.
- The length sort is deliberately not mirrored: the shown-first order is load-bearing for elision (documented since #1541).
- One divergence is deliberate, and is now documented in the module and pinned by a test: the control compares raw HTML while this module compares derived text. Two anchors differing only in `href` render `© OSM | © OSM` on screen and collapse to one line in the image. Text is what the image renders, and both directions of the difference only ever remove a line whose text another line carries whole.

## Candidate 4: other embedded markup forms. Done.

MapLibre's control sanitizer (`DOM.sanitize`) strips only `<script>`, `on*` handlers, and `javascript:`/`data:` URLs, so `<object>`, `<embed>`, `<iframe>`, and `<video>` all render visibly in the control while deriving no DOM text. They now take the same treatment as an unnamed `<img>`: accessible alternatives first (the generic-element rule already read `aria-label`/`title` on them), object/iframe fallback content next (which is DOM text), then the host-derived `(image credit: host)` placeholder. `data:`/`blob:` URLs fall through to the bare placeholder as before. `<img>` keeps its own branch because `alt=""` is a decorative opt-out these elements do not have. Elements that embed nothing external (an empty `<span>`, a bare `<canvas>`) deliberately stay out of the new map; the source-level floor still counts a credit made only of them. No new i18n keys, since the two existing placeholder keys are reused.

## Remaining in #1553

- The rename fragility of `Style.tileManagers` itself. The live read degrades to the modeled tier on the next upstream rename, and nothing here can detect the rename beyond falling back. Re-verifying against new maplibre-gl majors is the standing task.
- The raw-HTML vs derived-text comparison basis, documented as deliberate; revisit only if MapLibre changes its own dedupe.
- Suppression across priority groups stays intentionally off (a hidden superstring must not displace shown text into the elision marker).

## Diff shape

Two files: `frontend/src/lib/map-image-attribution.ts` and its test file. No hook changes; `AttributionMapLike` gained an optional `style?: unknown` that the live `Map` both call sites already pass satisfies structurally. No backend contact, no i18n changes.

## Verification

- `cd frontend && npm ci && npm run lint && npm run typecheck`: clean.
- `npx vitest run src/lib/__tests__/map-image-attribution.test.ts`: 108 tests, 15 of them new (live-flag preference, live overruling a hidden layer, usedForTerrain via the flag, fallback on absent/renamed/reshaped collections, empty-collection-is-an-answer, filter parity, raw-distinct/text-identical dedupe, and the object/embed/iframe/video derivation set).
- `npx vitest run src/components/builder/hooks/__tests__/use-builder-save.test.ts`: 90 tests; the unchanged mocks exercise the fallback tier.
- `npm run test:coverage`: full suite green.

https://claude.ai/code/session_01BXUUv3x71zWaLKEvoL4cTY
