### PR TITLE
feat(stac): preserve origin assets on by-reference imports so generic clients can render items

### DIFF
--- a/backend/app/modules/catalog/sources/adapters/stac.py
+++ b/backend/app/modules/catalog/sources/adapters/stac.py
@@ -54,6 +54,28 @@ def projection_epsg(properties: dict[str, Any]) -> int | None:
 # keys were tracked; the refresh then falls back to matching on the href.
 MAX_ASSET_KEY_CHARS = 255
 
+# feat(#1692): the longest asset media type GeoLens will carry — the width of
+# ``DatasetAsset.media_type`` (String(100)), where an imported item's declared
+# type is persisted so the STAC items GeoLens serves can re-advertise it.
+# Same capture-side bound and for the same reason as MAX_ASSET_KEY_CHARS
+# above: search surfacing a type the import model would reject turns one
+# unusual item into a 422 for the whole batch. Registered media types are
+# nowhere near this long; an item whose type is longer simply imports
+# without one.
+MAX_ASSET_MEDIA_TYPE_CHARS = 100
+
+
+def storable_media_type(media_type: str | None) -> str | None:
+    """The asset's declared media type if it fits the column, else None.
+
+    feat(#1692): applied at capture (search) and again where the refresh
+    reads a re-fetched item, so every writer of ``DatasetAsset.media_type``
+    carries the same bound the column enforces.
+    """
+    if not isinstance(media_type, str) or len(media_type) > MAX_ASSET_MEDIA_TYPE_CHARS:
+        return None
+    return media_type
+
 
 def storable_asset_key(key: str | None) -> str | None:
     """The asset key if it is short enough to carry, else None.
@@ -372,7 +394,12 @@ async def search_stac_items(
                 "gsd": props.get("gsd"),
                 "cloud_cover": props.get("eo:cloud_cover"),
                 "data_asset_href": data_asset.get("href") if data_asset else None,
-                "data_asset_type": data_asset.get("type") if data_asset else None,
+                # feat(#1692): bounded at capture like the key below, so the
+                # echoed value always fits the import model and the
+                # DatasetAsset.media_type column it is persisted into.
+                "data_asset_type": storable_media_type(
+                    data_asset.get("type") if data_asset else None
+                ),
                 # feat(#1266): the durable half of the asset's identity. The
                 # href is what moves; this is what still names the same asset
                 # afterwards, so a refresh can follow the move instead of

--- a/backend/app/modules/catalog/sources/stac_resolve_asset_gate.py
+++ b/backend/app/modules/catalog/sources/stac_resolve_asset_gate.py
@@ -22,6 +22,7 @@ from app.modules.catalog.sources.adapters.stac import (
     self_link_href,
     storable_asset_key,
     storable_href,
+    storable_media_type,
 )
 from app.modules.catalog.sources.cog_info import fetch_cog_info, reconcile_epsg
 from app.modules.catalog.sources.origin_probe import (
@@ -355,6 +356,10 @@ async def _resolve_from_item(
         # simply not carried, and the asset is still resolved — identity was
         # already settled above, and the href match will find it again.
         asset_key=storable_asset_key(key),
+        # feat(#1692): from the same document as the href — the refresh
+        # writes it onto the served `dataset_assets` row, so what GeoLens
+        # re-advertises is what the publisher currently declares.
+        asset_media_type=storable_media_type(describing["assets"][key].get("type")),
         asset_metadata=metadata,
         # fix(#1334 review): reconciled here, once, where both facts are in
         # hand — `reconcile_epsg({}, declared_epsg)` for an unmoved asset

--- a/backend/app/modules/catalog/sources/stac_resolve_taxonomy.py
+++ b/backend/app/modules/catalog/sources/stac_resolve_taxonomy.py
@@ -57,6 +57,13 @@ class StacResolution:
     collection_id: str | None = None
     asset_href: str | None = None
     asset_key: str | None = None
+    # feat(#1692): the bound asset's declared media type, read from the same
+    # document the href came from. It repairs the served `dataset_assets`
+    # row's media_type on every successful refresh — the import echoes the
+    # value search captured, and a dataset imported before either existed
+    # learns it the first time it refreshes. Bounded by storable_media_type
+    # at the gate, so it always fits the column it is written into.
+    asset_media_type: str | None = None
     # fix(#1266 review round 5): the moved object's OWN structural metadata.
     # A moved asset is not the same asset — a re-tiled scene can change its
     # band count, dtype, nodata and the statistics every rescale is computed

--- a/backend/app/modules/catalog/sources/stac_router.py
+++ b/backend/app/modules/catalog/sources/stac_router.py
@@ -32,6 +32,7 @@ from app.platform.dataset_origin import set_dataset_origin
 from app.platform.extensions import get_catalog_port
 from app.modules.catalog.sources.adapters.stac import (
     MAX_ASSET_KEY_CHARS,
+    MAX_ASSET_MEDIA_TYPE_CHARS,
     connect_stac_api,
     list_stac_collections,
     search_stac_items,
@@ -241,6 +242,17 @@ class StacImportItem(BaseModel):
         default=None,
         max_length=MAX_ASSET_KEY_CHARS,
         description="The asset key on the item, echoed from search results.",
+    )
+    # feat(#1692): the asset's declared media type, echoed from search so the
+    # persisted origin asset can re-advertise it to generic STAC clients.
+    # Optional for the same reason the two echoes above are — an older client
+    # (or an item that declares no type) still imports, and the first refresh
+    # repairs the value from the live item document. Search bounds it at
+    # capture (storable_media_type), so an echo always fits.
+    data_asset_type: str | None = Field(
+        default=None,
+        max_length=MAX_ASSET_MEDIA_TYPE_CHARS,
+        description="Media type of the data asset, echoed from search results.",
     )
     bbox: list[float] | None = Field(default=None, description="Item bounding box.")
     epsg: int | None = Field(default=None, description="EPSG code.")
@@ -670,6 +682,29 @@ async def stac_import(
                     **pixel_geometry,
                 )
                 db.add(raster_asset)
+
+                # feat(#1692): persist the origin item's primary data asset
+                # as a `dataset_assets` row, so the STAC items GeoLens serves
+                # carry the source COG href alongside the internal
+                # `raster_tiles` template. The tiles template renders only in
+                # GeoLens's own frontend; this row is what lets a generic
+                # STAC client (stac-browser, the QGIS STAC plugin, rio-viz)
+                # actually read pixels from an item we re-publish. Roled
+                # `data` — the tiles asset is the `visual` one — and served
+                # verbatim by resolve_asset_url's absolute-http(s)
+                # pass-through, since the href is already public in the
+                # origin catalog. The STAC refresh task upserts this same row
+                # (`_upsert_origin_data_asset`), which is what backfills
+                # datasets imported before it existed.
+                db.add(
+                    get_catalog_port().dataset_asset_orm_class()(
+                        dataset_id=dataset.id,
+                        key="data",
+                        href=item.data_asset_href,
+                        media_type=item.data_asset_type,
+                        roles=["data"],
+                    )
+                )
 
                 for kw in item.keywords:
                     db.add(

--- a/backend/app/platform/assets/urls.py
+++ b/backend/app/platform/assets/urls.py
@@ -1,6 +1,7 @@
 """Asset URL resolution with security-aware routing.
 
 Rules:
+  - Absolute http(s) hrefs (by-reference origin assets, #1692): passed through
   - Published thumbnails: public URL (no auth, cacheable)
   - S3 + published data assets: presigned URL (time-limited)
   - Local storage: no unauthenticated proxy URL emitted (GAP-031)
@@ -50,6 +51,19 @@ def resolve_asset_url(
         (e.g. local-storage paths that would collide with the SPA /assets/
         nginx location — GAP-031).
     """
+    # feat(#1692): a by-reference origin asset (STAC import) stores the
+    # publisher's absolute http(s) URL as its href. That URL is already
+    # public in the origin catalog — it is not managed storage, so neither
+    # the presign branch nor the GAP-031 proxy refusal below applies, and
+    # both would mishandle it (the presign path would strip it into a
+    # nonsense storage key; the refusal would drop the one asset a generic
+    # STAC client can actually read). Checked FIRST and passed through
+    # untouched. Managed ingest writes storage-relative keys or s3:// URIs
+    # (see _build_dataset_asset_rows), so only origin pass-through rows
+    # match this shape.
+    if href.startswith(("http://", "https://")):
+        return href
+
     # S3 + published data assets: signed URL (always safe — signed by provider)
     is_published = record_status == "published"
     if is_published and storage_backend == "s3" and storage_provider is not None:

--- a/backend/app/processing/ingest/tasks_stac_refresh.py
+++ b/backend/app/processing/ingest/tasks_stac_refresh.py
@@ -405,6 +405,61 @@ async def _repoint_remote_asset(
     )
 
 
+async def _upsert_origin_data_asset(
+    session: Any,
+    dataset_uuid: uuid.UUID,
+    *,
+    href: str,
+    media_type: str | None,
+) -> None:
+    """Make the served ``dataset_assets`` row describe the resolved asset.
+
+    feat(#1692). The STAC import persists the origin item's primary data
+    asset as a ``dataset_assets`` row keyed ``data``, which is what puts a
+    readable COG href on the STAC items GeoLens serves (the ``raster_tiles``
+    template renders only in GeoLens's own frontend). This is the refresh's
+    half of that contract, and it runs on EVERY successful resolution, moved
+    or not — an upsert against an unchanged answer is a no-op, and against a
+    dataset imported before the row existed it IS the backfill: one refresh
+    and the dataset serves the asset every generic client needs.
+
+    ON CONFLICT against ``uq_dataset_assets_key``, the same statement shape
+    the raster-replace tail uses (``_upsert_stac_and_distribution_rows``) —
+    and that tail is also why this write is safe against a replaced dataset:
+    a #1290 replace flips ``source_format`` off ``stac``, so the binding
+    guard in phase 3 discards this task's answer before it could overwrite
+    the replacement's managed row.
+
+    Lives inside the success block on purpose (invariant 10): a refresh that
+    resolved nothing repairs nothing.
+    """
+    from sqlalchemy.dialects.postgresql import insert as pg_insert
+
+    from app.processing.raster.models import DatasetAsset
+
+    stmt = pg_insert(DatasetAsset).values(
+        dataset_id=dataset_uuid,
+        key="data",
+        href=href,
+        media_type=media_type,
+        roles=["data"],
+    )
+    await session.execute(
+        stmt.on_conflict_do_update(
+            constraint="uq_dataset_assets_key",
+            # href, media_type and roles describe the resolved asset and move
+            # with it; size_bytes is deliberately absent — this task measures
+            # nothing, and listing it would overwrite a stored value with
+            # NULL.
+            set_={
+                "href": stmt.excluded.href,
+                "media_type": stmt.excluded.media_type,
+                "roles": stmt.excluded.roles,
+            },
+        )
+    )
+
+
 @task_app.task(queue="ingest", retry=0)
 @tenant_task
 async def refresh_stac(
@@ -624,6 +679,17 @@ async def refresh_stac(
                 # still carrying the OLD version keeps the pre-refresh href
                 # until that entry expires (60s), bounded and self-healing.
                 dataset.bump_tile_cache_version()
+
+            # feat(#1692): unconditional on purpose — not gated on `moved` or
+            # `rebound`. For an unchanged answer it rewrites the row with the
+            # values it already has; for a dataset imported before the row
+            # existed it is the backfill. See _upsert_origin_data_asset.
+            await _upsert_origin_data_asset(
+                session,
+                dataset_uuid,
+                href=resolution.asset_href,
+                media_type=resolution.asset_media_type,
+            )
 
             # AFTER the rebind, never before: `set_dataset_origin` clears the
             # probe state on every write, because a binding write is the

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -15949,6 +15949,19 @@
             "description": "The asset key on the item, echoed from search results.",
             "title": "Data Asset Key"
           },
+          "data_asset_type": {
+            "anyOf": [
+              {
+                "maxLength": 100,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Media type of the data asset, echoed from search results.",
+            "title": "Data Asset Type"
+          },
           "bbox": {
             "anyOf": [
               {

--- a/backend/tests/test_gap031_asset_url_no_proxy.py
+++ b/backend/tests/test_gap031_asset_url_no_proxy.py
@@ -114,3 +114,84 @@ class TestGap031NoProxyUrl:
 def _no_assets_path(url: str | None) -> bool:
     """Return True when the URL does not contain '/assets/'."""
     return url is None or "/assets/" not in url
+
+
+class TestRemoteHrefPassThrough:
+    """feat(#1692): a by-reference origin href is served verbatim.
+
+    A STAC import persists the publisher's absolute http(s) COG URL as a
+    ``dataset_assets`` href. That URL is already public in the origin
+    catalog — it is not managed storage, so neither the presign branch nor
+    the GAP-031 refusal applies, on any backend and at any record status.
+    """
+
+    def test_https_href_passes_through_on_local_storage(self):
+        href = "https://cogs.example.com/scenes/scene-1.tif"
+        assert (
+            resolve_asset_url(
+                href,
+                storage_backend="local",
+                record_status="published",
+                roles=["data"],
+                public_api_url=PUBLIC_API_URL,
+            )
+            == href
+        )
+
+    def test_https_href_is_not_presigned_on_s3_storage(self):
+        """The presign branch must never mangle a remote URL into a storage
+        key — the pass-through is checked first."""
+        from unittest.mock import MagicMock
+
+        mock_provider = MagicMock()
+        href = "https://cogs.example.com/scenes/scene-1.tif"
+        result = resolve_asset_url(
+            href,
+            storage_backend="s3",
+            record_status="published",
+            roles=["data"],
+            public_api_url=PUBLIC_API_URL,
+            storage_provider=mock_provider,
+        )
+        assert result == href
+        mock_provider.generate_presigned_get_url.assert_not_called()
+
+    def test_https_href_survives_a_non_published_status(self):
+        """Status gates protect GeoLens-held bytes; a third-party public URL
+        holds none. The item endpoint's visibility filter is what gates who
+        sees the record at all."""
+        href = "http://cogs.example.com/scenes/scene-1.tif"
+        assert (
+            resolve_asset_url(
+                href,
+                storage_backend="local",
+                record_status="draft",
+                roles=["data"],
+                public_api_url=PUBLIC_API_URL,
+            )
+            == href
+        )
+
+    def test_storage_relative_keys_still_take_the_managed_paths(self):
+        """The pass-through matches only absolute http(s) hrefs — an s3://
+        URI or a storage-relative key behaves exactly as before."""
+        assert (
+            resolve_asset_url(
+                "uploads/a.tif",
+                storage_backend="local",
+                record_status="published",
+                roles=["data"],
+                public_api_url=PUBLIC_API_URL,
+            )
+            is None
+        )
+        assert (
+            resolve_asset_url(
+                "s3://bucket/uploads/a.tif",
+                storage_backend="local",
+                record_status="published",
+                roles=["data"],
+                public_api_url=PUBLIC_API_URL,
+            )
+            is None
+        )

--- a/backend/tests/test_stac_import.py
+++ b/backend/tests/test_stac_import.py
@@ -474,6 +474,137 @@ class TestStacImport:
         assert detail.json()["last_checked_at"] is None
         assert detail.json()["source_health"] == "unknown"
 
+    async def test_import_persists_the_origin_asset_for_generic_clients(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session,
+        mock_stac_ssrf,
+    ):
+        """feat(#1692): the served STAC item carries a readable COG href.
+
+        Before this, a by-reference import stored no ``dataset_assets`` row,
+        so the item GeoLens re-published exposed exactly one asset — the
+        internal ``raster_tiles`` XYZ template, which renders only in
+        GeoLens's own frontend. A generic STAC client (stac-browser, the
+        QGIS STAC plugin) could discover the item but had no pixel data to
+        read. The import now persists the origin item's primary data asset,
+        and the item endpoint serves it verbatim beside the tiles template,
+        roled ``data`` against the template's ``visual``.
+        """
+        from sqlalchemy import select
+
+        from app.processing.raster.models import DatasetAsset
+
+        cog_href = f"https://example.com/data/origin-{uuid.uuid4().hex[:8]}.tif"
+        cog_type = "image/tiff; application=geotiff; profile=cloud-optimized"
+        resp = await client.post(
+            "/services/stac/import",
+            json={
+                "url": "https://stac.example.com/v1",
+                "items": [
+                    {
+                        "id": f"origin-asset-{uuid.uuid4().hex[:8]}",
+                        "collection": "dem-collection",
+                        "title": "Origin Asset Import",
+                        "data_asset_href": cog_href,
+                        "data_asset_type": cog_type,
+                        "data_asset_key": "data",
+                        "bbox": [-1, -1, 1, 1],
+                        "keywords": [],
+                    }
+                ],
+                "visibility": "private",
+            },
+            headers=admin_auth_header,
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["created"] == 1
+        dataset_id = resp.json()["results"][0]["dataset_id"]
+
+        # The stored row: the origin COG, roled as the data asset.
+        row = (
+            await test_db_session.execute(
+                select(DatasetAsset).where(
+                    DatasetAsset.dataset_id == uuid.UUID(dataset_id),
+                    DatasetAsset.key == "data",
+                )
+            )
+        ).scalar_one()
+        assert row.href == cog_href
+        assert row.media_type == cog_type
+        assert row.roles == ["data"]
+
+        # The served item, read the way a generic client reads it. The
+        # remote href passes through resolve_asset_url untouched — it is
+        # not managed storage, so neither presigning nor the GAP-031 proxy
+        # refusal applies — and it sits BESIDE the tiles template, each
+        # roled as what it is.
+        item = await client.get(f"/stac/items/{dataset_id}", headers=admin_auth_header)
+        assert item.status_code == 200, item.text
+        assets = item.json()["assets"]
+        assert assets["data"]["href"] == cog_href
+        assert assets["data"]["type"] == cog_type
+        assert assets["data"]["roles"] == ["data"]
+        assert assets["raster_tiles"]["roles"] == ["visual"]
+
+        # And the dataset detail's stac_assets mirror — the surface the
+        # issue observed as null on a by-reference Sentinel-2 dataset.
+        detail = await client.get(f"/datasets/{dataset_id}", headers=admin_auth_header)
+        assert detail.status_code == 200
+        assert detail.json()["stac_assets"]["data"]["href"] == cog_href
+
+    async def test_import_without_a_declared_type_still_persists_the_href(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session,
+        mock_stac_ssrf,
+    ):
+        """feat(#1692): the type echo is optional, like the other echoes.
+
+        An older client — or an item whose asset declares no ``type`` —
+        still imports, and still gets the pass-through asset; the row simply
+        carries no media type until the first refresh reads one off the live
+        item document.
+        """
+        from sqlalchemy import select
+
+        from app.processing.raster.models import DatasetAsset
+
+        cog_href = f"https://example.com/data/untyped-{uuid.uuid4().hex[:8]}.tif"
+        resp = await client.post(
+            "/services/stac/import",
+            json={
+                "url": "https://stac.example.com/v1",
+                "items": [
+                    {
+                        "id": f"untyped-{uuid.uuid4().hex[:8]}",
+                        "title": "Untyped Origin Asset",
+                        "data_asset_href": cog_href,
+                        "keywords": [],
+                    }
+                ],
+                "visibility": "private",
+            },
+            headers=admin_auth_header,
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["created"] == 1
+        dataset_id = resp.json()["results"][0]["dataset_id"]
+
+        row = (
+            await test_db_session.execute(
+                select(DatasetAsset).where(
+                    DatasetAsset.dataset_id == uuid.UUID(dataset_id),
+                    DatasetAsset.key == "data",
+                )
+            )
+        ).scalar_one()
+        assert row.href == cog_href
+        assert row.media_type is None
+        assert row.roles == ["data"]
+
     async def test_import_with_cog_info_stamps_the_contact(
         self,
         client: AsyncClient,

--- a/backend/tests/test_stac_refresh_1266.py
+++ b/backend/tests/test_stac_refresh_1266.py
@@ -48,7 +48,7 @@ from app.platform.jobs.models import IngestJob
 from app.platform.refresh.models import DatasetRefreshRun
 from app.processing.ingest import tasks_stac_refresh
 from app.processing.ingest.tasks_stac_refresh import refresh_stac
-from app.processing.raster.models import RasterAsset
+from app.processing.raster.models import DatasetAsset, RasterAsset
 from tests.factories import create_dataset as _create_dataset, get_user_id
 
 pytestmark = pytest.mark.anyio
@@ -394,6 +394,20 @@ async def _run_for(dataset_id: uuid.UUID) -> DatasetRefreshRun | None:
                 )
             )
         ).scalar_one_or_none()
+
+
+async def _origin_asset_rows(dataset_id: uuid.UUID) -> list[DatasetAsset]:
+    """Every served ``dataset_assets`` row for the dataset (feat #1692)."""
+    async with _fresh_session() as session:
+        return list(
+            (
+                await session.execute(
+                    select(DatasetAsset).where(DatasetAsset.dataset_id == dataset_id)
+                )
+            )
+            .scalars()
+            .all()
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -2875,6 +2889,120 @@ class TestWorker:
         assert finished.claimed_at is not None
         # No data moved, so there is no new version of it to point at.
         assert finished.dataset_version_id is None
+
+
+class TestOriginAssetRepair:
+    """feat(#1692): the refresh repairs the served origin asset.
+
+    The import persists the origin item's primary data asset as a
+    ``dataset_assets`` row, which is what puts a COG href a generic STAC
+    client can read on the items GeoLens serves. The refresh upserts that
+    same row on every success — for a dataset imported before the row
+    existed, that upsert IS the backfill.
+    """
+
+    async def test_a_refresh_backfills_the_served_origin_asset(
+        self, client, admin_auth_header, test_db_session, stac_transport
+    ) -> None:
+        """A pre-#1692 dataset gains the row from an UNCHANGED answer.
+
+        ``_stac_dataset`` writes no ``dataset_assets`` row — the exact shape
+        every by-reference dataset had before the import started persisting
+        one — so a refresh that moved nothing must still create it, or the
+        backfill story only covers datasets whose asset happens to move.
+        """
+        install, _ = stac_transport
+        install({_ITEM: (200, _item_doc()), _ASSET: (206, None)})
+        admin_id = await get_user_id(test_db_session, "admin")
+        dataset = await _stac_dataset(test_db_session, created_by=admin_id)
+        assert await _origin_asset_rows(dataset.id) == []
+
+        payload = await _dispatch(client, admin_auth_header, dataset.id)
+        await _execute(test_db_session, payload)
+
+        rows = await _origin_asset_rows(dataset.id)
+        assert len(rows) == 1
+        assert rows[0].key == "data"
+        assert rows[0].href == _ASSET
+        # From the item document's asset entry, not invented locally.
+        assert rows[0].media_type == "image/tiff"
+        assert rows[0].roles == ["data"]
+
+        # Idempotent: a second refresh rewrites the row it already wrote.
+        payload = await _dispatch(client, admin_auth_header, dataset.id)
+        await _execute(test_db_session, payload)
+        rows = await _origin_asset_rows(dataset.id)
+        assert len(rows) == 1
+        assert rows[0].href == _ASSET
+
+    async def test_a_moved_asset_moves_the_served_row_with_it(
+        self, client, admin_auth_header, test_db_session, stac_transport
+    ) -> None:
+        """The row the import wrote follows the publisher's move — href AND
+        media type, both read from the live item document."""
+        install, _ = stac_transport
+        install(
+            {
+                _ITEM: (
+                    200,
+                    _item_doc(
+                        assets={
+                            "data": {
+                                "href": _MOVED_ASSET,
+                                "roles": ["data"],
+                                "type": (
+                                    "image/tiff; application=geotiff; "
+                                    "profile=cloud-optimized"
+                                ),
+                            }
+                        }
+                    ),
+                ),
+                _MOVED_ASSET: (206, None),
+            }
+        )
+        admin_id = await get_user_id(test_db_session, "admin")
+        dataset = await _stac_dataset(test_db_session, created_by=admin_id)
+        # The row as the import writes it, pointing at the pre-move href.
+        test_db_session.add(
+            DatasetAsset(
+                dataset_id=dataset.id,
+                key="data",
+                href=_ASSET,
+                media_type="image/tiff",
+                roles=["data"],
+            )
+        )
+        await test_db_session.commit()
+
+        payload = await _dispatch(client, admin_auth_header, dataset.id)
+        await _execute(test_db_session, payload)
+
+        rows = await _origin_asset_rows(dataset.id)
+        assert len(rows) == 1
+        assert rows[0].href == _MOVED_ASSET
+        assert rows[0].media_type == (
+            "image/tiff; application=geotiff; profile=cloud-optimized"
+        )
+        assert rows[0].roles == ["data"]
+
+    async def test_a_failed_refresh_repairs_no_asset_row(
+        self, client, admin_auth_header, test_db_session, stac_transport
+    ) -> None:
+        """Invariant 10 extends to the served row: a refresh that resolved
+        nothing backfills nothing."""
+        install, _ = stac_transport
+        # Everything 404s: the item is gone and the search finds nothing.
+        install({})
+        admin_id = await get_user_id(test_db_session, "admin")
+        dataset = await _stac_dataset(test_db_session, created_by=admin_id)
+
+        payload = await _dispatch(client, admin_auth_header, dataset.id)
+        with pytest.raises(Exception):
+            await _execute(test_db_session, payload)
+
+        assert (await _run_for(dataset.id)).status == "failed"
+        assert await _origin_asset_rows(dataset.id) == []
 
 
 # ---------------------------------------------------------------------------

--- a/frontend/src/components/import/StacImportForm.tsx
+++ b/frontend/src/components/import/StacImportForm.tsx
@@ -163,6 +163,9 @@ export function StacImportForm() {
         // same asset afterwards, so a refresh follows the move instead of
         // re-running the priority list and possibly binding another band.
         data_asset_key: i.data_asset_key,
+        // feat(#1692): echo the asset's declared media type so the persisted
+        // origin asset re-advertises it on the STAC items GeoLens serves.
+        data_asset_type: i.data_asset_type,
         // feat(#1222): echo the item's own href back so the dataset's origin
         // can point at the item, not only its asset. The health probe needs
         // both to tell "the file is gone" from "the publisher withdrew it".

--- a/frontend/src/types/api.generated.ts
+++ b/frontend/src/types/api.generated.ts
@@ -12188,6 +12188,11 @@ export interface components {
              */
             data_asset_key?: string | null;
             /**
+             * Data Asset Type
+             * @description Media type of the data asset, echoed from search results.
+             */
+            data_asset_type?: string | null;
+            /**
              * Bbox
              * @description Item bounding box.
              */

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -2047,6 +2047,7 @@ export interface StacImportItem {
   title: string;
   data_asset_href: string;
   data_asset_key: string | null;
+  data_asset_type: string | null;
   item_href: string | null;
   bbox: number[] | null;
   epsg: number | null;

--- a/sdks/python/geolens/models/stac_import_item.py
+++ b/sdks/python/geolens/models/stac_import_item.py
@@ -24,6 +24,7 @@ class StacImportItem:
         collection (None | str | Unset): Parent collection ID.
         item_href (None | str | Unset): The item's own canonical URL, echoed from search results.
         data_asset_key (None | str | Unset): The asset key on the item, echoed from search results.
+        data_asset_type (None | str | Unset): Media type of the data asset, echoed from search results.
         bbox (list[float] | None | Unset): Item bounding box.
         epsg (int | None | Unset): EPSG code.
         datetime_start (None | str | Unset): Temporal start.
@@ -37,6 +38,7 @@ class StacImportItem:
     collection: None | str | Unset = UNSET
     item_href: None | str | Unset = UNSET
     data_asset_key: None | str | Unset = UNSET
+    data_asset_type: None | str | Unset = UNSET
     bbox: list[float] | None | Unset = UNSET
     epsg: int | None | Unset = UNSET
     datetime_start: None | str | Unset = UNSET
@@ -68,6 +70,12 @@ class StacImportItem:
             data_asset_key = UNSET
         else:
             data_asset_key = self.data_asset_key
+
+        data_asset_type: None | str | Unset
+        if isinstance(self.data_asset_type, Unset):
+            data_asset_type = UNSET
+        else:
+            data_asset_type = self.data_asset_type
 
         bbox: list[float] | None | Unset
         if isinstance(self.bbox, Unset):
@@ -115,6 +123,8 @@ class StacImportItem:
             field_dict["item_href"] = item_href
         if data_asset_key is not UNSET:
             field_dict["data_asset_key"] = data_asset_key
+        if data_asset_type is not UNSET:
+            field_dict["data_asset_type"] = data_asset_type
         if bbox is not UNSET:
             field_dict["bbox"] = bbox
         if epsg is not UNSET:
@@ -163,6 +173,15 @@ class StacImportItem:
             return cast(None | str | Unset, data)
 
         data_asset_key = _parse_data_asset_key(d.pop("data_asset_key", UNSET))
+
+        def _parse_data_asset_type(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        data_asset_type = _parse_data_asset_type(d.pop("data_asset_type", UNSET))
 
         def _parse_bbox(data: object) -> list[float] | None | Unset:
             if data is None:
@@ -217,6 +236,7 @@ class StacImportItem:
             collection=collection,
             item_href=item_href,
             data_asset_key=data_asset_key,
+            data_asset_type=data_asset_type,
             bbox=bbox,
             epsg=epsg,
             datetime_start=datetime_start,

--- a/sdks/typescript/src/client/types.gen.ts
+++ b/sdks/typescript/src/client/types.gen.ts
@@ -9446,6 +9446,12 @@ export type StacImportItem = {
      */
     data_asset_key?: string | null;
     /**
+     * Data Asset Type
+     *
+     * Media type of the data asset, echoed from search results.
+     */
+    data_asset_type?: string | null;
+    /**
      * Bbox
      *
      * Item bounding box.


### PR DESCRIPTION
Closes #1692.

## What changed

A by-reference STAC import stored no `dataset_assets` row, so the STAC items GeoLens serves exposed exactly one asset — the internal `raster_tiles` XYZ template, which renders only in GeoLens's own frontend. Generic STAC clients (stac-browser, the QGIS STAC plugin, rio-viz) could discover our items but had no COG href to read.

- **Import** (`sources/stac_router.py`): persists the origin item's primary data asset as a `dataset_assets` row keyed `data` — href, declared media type, roles `["data"]`. No migration: the table, its `data` key and its CHECK constraint already existed.
- **Serving** (`platform/assets/urls.py`): `resolve_asset_url` passes an absolute http(s) href through untouched. It is already public in the origin catalog, so it is neither managed storage to presign (the presign branch would have mangled it into a storage key) nor a GAP-031 proxy path to refuse. Managed ingest writes storage-relative keys or `s3://` URIs, so only origin pass-through rows match. The served item now carries `assets.data` (roles `["data"]`, remote COG href) beside `assets.raster_tiles` (roles `["visual"]`), and the same row surfaces in the dataset detail's `stac_assets` and search enrichment.
- **Refresh = backfill** (`tasks_stac_refresh.py`): the refresh task upserts the same row on every successful resolution (`ON CONFLICT uq_dataset_assets_key`, the raster-replace tail's statement shape), from the re-fetched item document. A dataset imported before the row existed gains it on its first refresh; an unchanged answer rewrites the row it already wrote. `StacResolution` gains `asset_media_type`, read from the same document as the href and bounded by the same capture-side rule as the asset key (`storable_media_type`, sized to the `media_type` column).
- **Item self link**: needs no new storage — `origin_ref.item_href` has persisted it since #1222 (the demo dataset in the issue predates that), and `origin_uri` stays the asset href ADR-002 keys the duplicate-source guard on.

## SSRF

No new outbound request. The refresh-time re-fetch was already going through the Rule 2 safe client in `sources/stac_resolve*`; this change only reads one more field off the document it already had. Re-publishing an already-public remote href adds no SSRF surface, and the asset-gate's `_ASSET_BLOCKED` refusal still stops a policy-blocked href before anything is persisted.

## API impact

`StacImportItem` gains optional `data_asset_type` (echoed from search like `item_href`/`data_asset_key`; older clients still import, and the first refresh repairs the missing type from the live item). Regenerated: `backend/openapi.json`, both SDKs, `frontend/src/types/api.generated.ts`, plus the hand-typed mirror in `api.ts`. Additive only. Lane 1 (#1691) may also touch `openapi.json`; later-merging branch rebases.

## Verification

- `pytest tests/test_stac_import.py tests/test_stac_refresh_1266.py tests/test_gap031_asset_url_no_proxy.py tests/test_modality_assets.py tests/test_raster_dataset_assets_bug041.py tests/test_asset_url_security.py tests/test_stac_serializer.py tests/test_stac_record_output.py tests/test_stac_api.py tests/test_stac_asset_model.py tests/test_stac_visibility.py tests/test_stac_integration.py` — 325 passed, including the new tests:
  - import persists the row and the served `/stac/items/{id}` payload carries `data` (remote COG href + declared type, roles `["data"]`) beside `raster_tiles` (`["visual"]`)
  - a refresh against an unchanged item backfills the missing row idempotently; a moved asset moves the row's href and media type with it; a failed refresh repairs nothing (invariant 10)
  - `resolve_asset_url` pass-through: verbatim on local and s3 (never presigned), storage-relative keys and `s3://` URIs unchanged
- `pytest tests/test_layering.py tests/test_sdks_round_trip.py tests/test_rule1_structural.py tests/test_rule2_structural.py` — pass
- `make openapi-check`, `make sdks-check` — pass; `ruff check .`, `ruff format --check .` — clean
- `cd frontend && npm run typecheck && npm run lint && npx vitest run src/components/import/__tests__` — clean, 83 passed

https://claude.ai/code/session_01BXUUv3x71zWaLKEvoL4cTY