### PR TITLE
feat(settings): restrict public visibility to admins behind an instance flag

### DIFF
--- a/backend/app/core/persistent_config.py
+++ b/backend/app/core/persistent_config.py
@@ -563,6 +563,19 @@ ENABLE_DATASET_EDITING = PersistentConfig[bool](
     label="Enable Dataset Editing",
 )
 
+# feat(#1691): when ON, only admins may set `visibility: public` on datasets and
+# maps. Default OFF so private self-hosted installs keep current behavior. The
+# server-side gate is `check_public_visibility_allowed` in
+# `modules/catalog/authorization.py`; existing public content is untouched
+# (the gate fires only on a mutation that REQUESTS public).
+RESTRICT_PUBLIC_VISIBILITY = PersistentConfig[bool](
+    key="restrict_public_visibility",
+    type_=bool,
+    env_default=False,
+    tab="general",
+    label="Restrict Public Visibility to Admins",
+)
+
 # FRONT-01 (Phase 1223): landing-first flag.  Default OFF so existing
 # self-hosters see no change.  When ON, the frontend root guard redirects
 # unauthenticated visitors from "/" to "/login" (the marketing landing page)

--- a/backend/app/modules/catalog/authorization.py
+++ b/backend/app/modules/catalog/authorization.py
@@ -536,3 +536,50 @@ async def require_dataset_editing_enabled(db: AsyncSession) -> None:
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Dataset editing is disabled by the administrator.",
         )
+
+
+async def check_public_visibility_allowed(
+    db: AsyncSession,
+    user: Identity,
+    visibility: str | None,
+    *,
+    user_roles: set[str] | None = None,
+) -> set[str] | None:
+    """Enforce the `restrict_public_visibility` instance setting (#1691).
+
+    The ONE shared gate for every mutation that accepts a `visibility` value:
+    dataset metadata PATCH, ingest commit/fan-out/register/bulk-register/VRT
+    create, STAC import, manifest apply, and map update. When the setting is
+    ON, a non-admin requesting `public` gets a 403; every other visibility
+    value passes through untouched. Existing public content is unaffected —
+    the gate fires only on a mutation that REQUESTS public.
+
+    Pass ``user_roles`` when the caller already resolved them (e.g. after
+    ``check_dataset_write_access``) to avoid a second lookup. Returns the
+    resolved roles when a lookup happened (or the caller-provided set), so
+    callers can reuse them downstream; returns ``None`` untouched when the
+    fast paths made a role lookup unnecessary.
+    """
+    if visibility != "public":
+        return user_roles
+
+    # Local import mirrors the other persistent_config call sites in this
+    # module (require_dataset_editing_enabled) and avoids any import cycle.
+    from app.core.persistent_config import RESTRICT_PUBLIC_VISIBILITY
+
+    if not await RESTRICT_PUBLIC_VISIBILITY.get(db):
+        return user_roles
+
+    if user_roles is None:
+        user_roles = await get_user_roles(db, user)
+    if "admin" in user_roles:
+        return user_roles
+
+    raise HTTPException(
+        status_code=status.HTTP_403_FORBIDDEN,
+        detail=(
+            "Public visibility is restricted to administrators on this "
+            "instance. Choose a narrower visibility or ask an admin to "
+            "make this content public."
+        ),
+    )

--- a/backend/app/modules/catalog/datasets/api/router.py
+++ b/backend/app/modules/catalog/datasets/api/router.py
@@ -27,6 +27,7 @@ from app.modules.catalog.authorization import (
     can_view_dataset_provenance,
     check_dataset_access_or_anonymous,
     check_dataset_write_access,
+    check_public_visibility_allowed,
     get_user_roles,
     visible_lineage_summary,
 )
@@ -332,6 +333,11 @@ async def update_dataset_metadata(
             detail="Dataset not found",
         )
     user_roles = await check_dataset_write_access(db, dataset, dataset_id, user)
+    # feat(#1691): a non-admin may not move a dataset TO public when the
+    # restrict_public_visibility instance setting is on.
+    await check_public_visibility_allowed(
+        db, user, meta.visibility, user_roles=user_roles
+    )
 
     # fix(#458 E-48): capture the pre-update value so a PATCH that echoes the
     # same tile_columns doesn't roll the tile version / purge the tile cache.

--- a/backend/app/modules/catalog/maps/router.py
+++ b/backend/app/modules/catalog/maps/router.py
@@ -28,7 +28,10 @@ from app.modules.auth.dependencies import (
     get_optional_user,
     require_permission,
 )
-from app.modules.catalog.authorization import get_user_roles
+from app.modules.catalog.authorization import (
+    check_public_visibility_allowed,
+    get_user_roles,
+)
 from app.core.dependencies import get_db
 from app.modules.catalog.maps.schemas import (
     BulkDeleteLayersRequest,
@@ -460,6 +463,12 @@ async def update_map_endpoint(
             # embed tokens, which previously survived (only the share token was
             # flipped) and kept serving tiles for a now-private map until expiry.
             await revoke_embed_tokens_by_map(db, map_id)
+
+    # feat(#1691): a non-admin may not move a map TO public when the
+    # restrict_public_visibility instance setting is on. MapVisibility is a
+    # str Enum, so the gate's == "public" comparison works on it directly;
+    # None (visibility untouched) passes through.
+    await check_public_visibility_allowed(db, user, body.visibility)
 
     # Hard block: prevent publishing maps with non-public datasets
     if body.visibility == MapVisibility.public:

--- a/backend/app/modules/catalog/sources/stac_router.py
+++ b/backend/app/modules/catalog/sources/stac_router.py
@@ -22,6 +22,7 @@ from app.core.url_redaction import has_url_credentials, redact_url_credentials
 from app.modules.audit.service import AuditEvent, audit_emit
 from app.core.identity import Identity
 from app.modules.auth.dependencies import require_permission
+from app.modules.catalog.authorization import check_public_visibility_allowed
 from app.modules.catalog.datasets.domain.models import (
     Dataset,
     Record,
@@ -441,6 +442,10 @@ async def stac_import(
     remote COG asset URL. Titiler serves the tiles directly from the
     remote source — no file download required.
     """
+    # feat(#1691): a non-admin may not create public datasets when the
+    # restrict_public_visibility instance setting is on.
+    await check_public_visibility_allowed(db, user, request.visibility)
+
     results: list[StacImportResult] = []
     safe_url = redact_url_credentials(request.url)
     created = 0

--- a/backend/app/modules/settings/router_public.py
+++ b/backend/app/modules/settings/router_public.py
@@ -17,6 +17,7 @@ from app.core.persistent_config import (
     MAP_DEFAULTS,
     PRIVACY_URL,
     REQUIRE_METADATA_FOR_PUBLISH,
+    RESTRICT_PUBLIC_VISIBILITY,
     get_cached_basemap_proxy_rate_limit,
 )
 from app.platform.ratelimit import limiter
@@ -70,6 +71,7 @@ async def get_feature_flags(
     return FeatureFlagsResponse(
         enable_dataset_editing=await ENABLE_DATASET_EDITING.get(db),
         require_metadata_for_publish=await REQUIRE_METADATA_FOR_PUBLISH.get(db),
+        restrict_public_visibility=await RESTRICT_PUBLIC_VISIBILITY.get(db),
     )
 
 

--- a/backend/app/modules/settings/schemas.py
+++ b/backend/app/modules/settings/schemas.py
@@ -188,6 +188,9 @@ class FeatureFlagsResponse(BaseModel):
 
     enable_dataset_editing: bool = False
     require_metadata_for_publish: bool = False
+    # feat(#1691): when true, only admins may set `visibility: public`; the
+    # frontend uses it to hide/disable the Public option for non-admins.
+    restrict_public_visibility: bool = False
 
 
 class SettingsAllResponse(BaseModel):

--- a/backend/app/processing/ingest/manifest_service.py
+++ b/backend/app/processing/ingest/manifest_service.py
@@ -40,6 +40,7 @@ from app.processing.ingest.manifest_sources import (
     classify_manifest_source,
     manifest_dataset_fingerprint,
     manifest_job_metadata,
+    publication_to_catalog_fields,
     validate_publication_intent,
 )
 from app.processing.ingest.service import queue_ingest_job, validate_file_extension
@@ -483,6 +484,18 @@ async def _classify_dataset(
     # before any staging, download, or queue work — and before the dry_run
     # early return, which is the branch operators use to validate a manifest.
     validate_publication_intent(dataset.publication)
+    # feat(#1691): the publication intent maps to a catalog visibility
+    # (publication_to_catalog_fields); an intent resolving to public goes
+    # through the same admin gate as every API mutation that accepts a
+    # visibility. Raises 403 for a non-admin when the
+    # restrict_public_visibility instance setting is on — surfaced as this
+    # entry's error by apply_manifest's per-entry isolation, and checked
+    # before staging so dry_run reports it too. Local import: processing/
+    # must not import app.modules.catalog.* at module level (PROCESS-02/04).
+    from app.modules.catalog.authorization import check_public_visibility_allowed
+
+    intent_visibility, _ = publication_to_catalog_fields(dataset.publication)
+    await check_public_visibility_allowed(db, user, intent_visibility)
     prepared = await classify_manifest_source(dataset.sources[0])
     await _validate_prepared_source(db, prepared)
     await _authorize_prepared_source(db, prepared, user)

--- a/backend/app/processing/ingest/router.py
+++ b/backend/app/processing/ingest/router.py
@@ -902,6 +902,14 @@ async def commit_import(
     # layer_name, which reaches the worker's ogr2ogr argv (see layer_guard).
     validate_commit_layer_name(job, getattr(commit, "layer_name", None))
 
+    # feat(#1691): a non-admin may not commit a public dataset when the
+    # restrict_public_visibility instance setting is on. Local import:
+    # processing/ must not import app.modules.catalog.* at module level
+    # (PROCESS-02/04 layering invariant).
+    from app.modules.catalog.authorization import check_public_visibility_allowed
+
+    await check_public_visibility_allowed(db, user, commit.visibility)
+
     # Extract token only for service commits (ServiceCommitRequest is the
     # only subclass with a token field). AUTH-04: never persisted.
     token = getattr(commit, "token", None)
@@ -980,6 +988,15 @@ async def commit_fan_out(
             detail=f"Job already processed (status='{job.status}')",
         )
 
+    # feat(#1691): fan-out jobs inherit the parent job's user_metadata, so a
+    # visibility seeded there (defense-in-depth — the request schema itself
+    # has no visibility field) goes through the same admin gate as a commit.
+    from app.modules.catalog.authorization import check_public_visibility_allowed
+
+    await check_public_visibility_allowed(
+        db, user, (job.user_metadata or {}).get("visibility")
+    )
+
     # Validate all requested layer_names appear in the job's all_layers preview.
     # fix(#823): normalisation extracted to layer_guard.known_layer_names,
     # shared with the single-layer commit endpoint's new validation.
@@ -1036,6 +1053,12 @@ async def register_table(
     Verifies the table exists, extracts metadata, and creates a
     catalog entry.
     """
+    # feat(#1691): a non-admin may not register a public dataset when the
+    # restrict_public_visibility instance setting is on.
+    from app.modules.catalog.authorization import check_public_visibility_allowed
+
+    await check_public_visibility_allowed(db, user, request.visibility)
+
     try:
         dataset = await register_existing_table(db, request, user)
         await db.commit()
@@ -1109,6 +1132,14 @@ async def bulk_register_tables(
     """
     from app.core.db import async_session
 
+    # feat(#1691): gate ONCE for the whole batch — any item requesting public
+    # visibility puts the request through the shared admin check before any
+    # table is registered (403, not a per-item error, so nothing partial runs).
+    from app.modules.catalog.authorization import check_public_visibility_allowed
+
+    if any(item.visibility == "public" for item in request.tables):
+        await check_public_visibility_allowed(db, user, "public")
+
     async def _register_one(
         table_req: BulkRegisterItem,
     ) -> BulkRegisterResult:
@@ -1158,6 +1189,12 @@ async def create_vrt(
     Returns a job_id for polling. Validation + queuing logic lives in
     ``ingest.service.create_vrt_job`` (K5 extraction).
     """
+    # feat(#1691): a non-admin may not create a public VRT dataset when the
+    # restrict_public_visibility instance setting is on.
+    from app.modules.catalog.authorization import check_public_visibility_allowed
+
+    await check_public_visibility_allowed(db, user, request.visibility)
+
     from app.processing.ingest.service import create_vrt_job
 
     job = await create_vrt_job(db, request, user)

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -7661,6 +7661,11 @@
             "default": false,
             "title": "Require Metadata For Publish",
             "type": "boolean"
+          },
+          "restrict_public_visibility": {
+            "default": false,
+            "title": "Restrict Public Visibility",
+            "type": "boolean"
           }
         },
         "title": "FeatureFlagsResponse",

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -2167,7 +2167,10 @@ _OPEN_CORE_SIZE_CAPS: dict[str, int] = {
     # against the shape rule and drops (+ logs) an unsafe one instead of
     # serving it as a login-page <a href>; a stored value can predate the
     # check or bypass PersistentConfig.set()'s validation entirely.
-    "backend/app/modules/settings/router_public.py": 175,
+    # feat(#1691): +2 — restrict_public_visibility rides the public
+    # feature-flags bundle so the UI can hide the Public option for
+    # non-admins. Cap 175 -> 177.
+    "backend/app/modules/settings/router_public.py": 177,
 }
 
 
@@ -2628,7 +2631,11 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # instead of an eight-entry literal that had drifted two formats behind.
     # Most of the growth is the docstring recording why a narrower fallback is
     # not a safer one. Cap 1543 -> 1547, exact.
-    "backend/app/processing/ingest/router.py": 1547,
+    # feat(#1691): +37 — the check_public_visibility_allowed gate at the five
+    # visibility-writing handlers (commit, fan-out, register, bulk register,
+    # VRT create), each a local import (PROCESS-02/04) plus one call and the
+    # comment saying which surface it closes. Cap 1547 -> 1584, exact.
+    "backend/app/processing/ingest/router.py": 1584,
     # fix(#888): +25 — the `mercator_clip` StagingResult field and the
     # `_append_mercator_clip_warning` emitter that keeps the three ingest call
     # sites a single statement each (`reupload_file` is already at the C901
@@ -3115,7 +3122,10 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # PRIV-1: +11 — a PRIVACY_URL PersistentConfig on the "general" tab (not
     # "branding", which ENTERPRISE_ONLY_TABS gates) for the login/register
     # privacy-policy link. Cap 1018 -> 1029, exact.
-    "backend/app/core/persistent_config.py": 1029,
+    # feat(#1691): +13 — the RESTRICT_PUBLIC_VISIBILITY flag (admins-only
+    # `visibility: public`) plus the comment pointing at its shared gate in
+    # catalog/authorization.py. Cap 1029 -> 1042, exact.
+    "backend/app/core/persistent_config.py": 1042,
     # fix(#1533): first entry — crossed _RATCHET_INCLUSION_LOC on the change
     # that made the run notice the embedding column moving under it. Two
     # guards, both small: _live_column_dims (one pg_attribute read, shared with
@@ -3756,7 +3766,10 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # `responses={403: FORBIDDEN_RESPONSE}` overrides; get_map_history_endpoint
     # keeps the router's write-flavored default since it genuinely requires
     # edit_metadata + ownership. Cap 1425 -> 1460, exact.
-    "backend/app/modules/catalog/maps/router.py": 1460,
+    # feat(#1691): +9 — the check_public_visibility_allowed gate on the map
+    # update route (a non-admin may not move a map TO public when
+    # restrict_public_visibility is on). Cap 1460 -> 1469, exact.
+    "backend/app/modules/catalog/maps/router.py": 1469,
     # fix(#474): thread negotiated languages through catalog search, cache keys,
     # and OGC record serialization; fix(#475) adds Records array-query handling,
     # including collection IDs, plus response-header and documented 400 parity.

--- a/backend/tests/test_public_visibility_gate.py
+++ b/backend/tests/test_public_visibility_gate.py
@@ -1,0 +1,345 @@
+"""Behavioral tests for the `restrict_public_visibility` setting (feat #1691).
+
+When the instance setting is ON, only admins may set `visibility: public`;
+non-admin requests get a 403 from the ONE shared gate
+(`check_public_visibility_allowed` in catalog/authorization.py). Default OFF
+preserves current behavior, and existing public content is untouched — the
+gate fires only on a mutation that REQUESTS public.
+
+Structural coverage (every visibility-writing route calls the gate) lives in
+test_visibility_gate_structural.py; this file proves the gate's runtime
+behavior on representative surfaces: dataset metadata PATCH, map update, and
+the ingest register/bulk-register/VRT-create + STAC-import request-time
+checks (which fire before any work happens).
+"""
+
+import uuid
+
+import pytest
+from httpx import AsyncClient
+
+from .conftest import _create_test_user
+from tests.factories import create_dataset, create_map_via_api
+
+
+@pytest.fixture
+def _restrict_public_visibility(monkeypatch):
+    """Flip the restrict_public_visibility flag ON for one test.
+
+    Mirrors conftest's `_enable_dataset_editing` stub pattern: the gate
+    re-imports `RESTRICT_PUBLIC_VISIBILITY` from the module on each call, so
+    replacing the module attribute is picked up and the gate's real
+    role-resolution branch still runs.
+    """
+    import app.core.persistent_config as pc
+
+    import app.modules.settings.router_public as rp
+
+    class _AlwaysOn:
+        async def get(self, _db):
+            return True
+
+    stub = _AlwaysOn()
+    monkeypatch.setattr(pc, "RESTRICT_PUBLIC_VISIBILITY", stub)
+    # router_public binds the name at import time (module-level `from` import),
+    # so its feature-flags endpoint needs the module-local binding patched too.
+    monkeypatch.setattr(rp, "RESTRICT_PUBLIC_VISIBILITY", stub)
+
+
+# ---------------------------------------------------------------------------
+# Dataset metadata PATCH
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_default_off_editor_can_publish_public(
+    client: AsyncClient, admin_auth_header: dict, test_db_session
+):
+    """With the setting at its default (OFF) nothing changes for editors."""
+    editor_headers, editor_id = await _create_test_user(
+        client, admin_auth_header, "editor"
+    )
+    ds = await create_dataset(
+        test_db_session,
+        created_by=uuid.UUID(editor_id),
+        name="editor goes public",
+        visibility="private",
+    )
+    resp = await client.patch(
+        f"/datasets/{ds.id}", json={"visibility": "public"}, headers=editor_headers
+    )
+    assert resp.status_code == 200
+    assert resp.json()["visibility"] == "public"
+
+
+@pytest.mark.anyio
+async def test_restricted_editor_public_patch_403(
+    client: AsyncClient,
+    admin_auth_header: dict,
+    test_db_session,
+    _restrict_public_visibility,
+):
+    editor_headers, editor_id = await _create_test_user(
+        client, admin_auth_header, "editor"
+    )
+    ds = await create_dataset(
+        test_db_session,
+        created_by=uuid.UUID(editor_id),
+        name="editor blocked from public",
+        visibility="private",
+    )
+    resp = await client.patch(
+        f"/datasets/{ds.id}", json={"visibility": "public"}, headers=editor_headers
+    )
+    assert resp.status_code == 403
+    assert "restricted to administrators" in resp.json()["detail"]
+
+
+@pytest.mark.anyio
+async def test_restricted_editor_internal_patch_ok(
+    client: AsyncClient,
+    admin_auth_header: dict,
+    test_db_session,
+    _restrict_public_visibility,
+):
+    """Only `public` is gated — non-admins keep every narrower visibility."""
+    editor_headers, editor_id = await _create_test_user(
+        client, admin_auth_header, "editor"
+    )
+    ds = await create_dataset(
+        test_db_session,
+        created_by=uuid.UUID(editor_id),
+        name="internal stays available",
+        visibility="private",
+    )
+    resp = await client.patch(
+        f"/datasets/{ds.id}", json={"visibility": "internal"}, headers=editor_headers
+    )
+    assert resp.status_code == 200
+    assert resp.json()["visibility"] == "internal"
+
+
+@pytest.mark.anyio
+async def test_restricted_admin_public_patch_ok(
+    client: AsyncClient,
+    admin_auth_header: dict,
+    test_db_session,
+    _restrict_public_visibility,
+):
+    ds = await create_dataset(
+        test_db_session,
+        created_by=None,
+        name="admin publishes",
+        visibility="private",
+    )
+    resp = await client.patch(
+        f"/datasets/{ds.id}", json={"visibility": "public"}, headers=admin_auth_header
+    )
+    assert resp.status_code == 200
+    assert resp.json()["visibility"] == "public"
+
+
+@pytest.mark.anyio
+async def test_restricted_existing_public_content_untouched(
+    client: AsyncClient,
+    admin_auth_header: dict,
+    test_db_session,
+    _restrict_public_visibility,
+):
+    """A non-admin can still edit OTHER metadata on an already-public dataset
+    (no visibility in the body), and the dataset stays public — enabling the
+    setting never retroactively narrows anything."""
+    editor_headers, editor_id = await _create_test_user(
+        client, admin_auth_header, "editor"
+    )
+    ds = await create_dataset(
+        test_db_session,
+        created_by=uuid.UUID(editor_id),
+        name="already public",
+        visibility="public",
+    )
+    resp = await client.patch(
+        f"/datasets/{ds.id}", json={"summary": "still editable"}, headers=editor_headers
+    )
+    assert resp.status_code == 200
+    assert resp.json()["visibility"] == "public"
+
+
+# ---------------------------------------------------------------------------
+# Map update
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_restricted_editor_map_public_403(
+    client: AsyncClient, admin_auth_header: dict, _restrict_public_visibility
+):
+    editor_headers, _ = await _create_test_user(client, admin_auth_header, "editor")
+    map_obj = await create_map_via_api(client, editor_headers)
+    resp = await client.put(
+        f"/maps/{map_obj['id']}", json={"visibility": "public"}, headers=editor_headers
+    )
+    assert resp.status_code == 403
+    assert "restricted to administrators" in resp.json()["detail"]
+
+
+@pytest.mark.anyio
+async def test_restricted_editor_map_internal_ok(
+    client: AsyncClient, admin_auth_header: dict, _restrict_public_visibility
+):
+    editor_headers, _ = await _create_test_user(client, admin_auth_header, "editor")
+    map_obj = await create_map_via_api(client, editor_headers)
+    resp = await client.put(
+        f"/maps/{map_obj['id']}",
+        json={"visibility": "internal"},
+        headers=editor_headers,
+    )
+    assert resp.status_code == 200
+    assert resp.json()["visibility"] == "internal"
+
+
+@pytest.mark.anyio
+async def test_restricted_admin_map_public_ok(
+    client: AsyncClient, admin_auth_header: dict, _restrict_public_visibility
+):
+    map_obj = await create_map_via_api(client, admin_auth_header)
+    resp = await client.put(
+        f"/maps/{map_obj['id']}",
+        json={"visibility": "public"},
+        headers=admin_auth_header,
+    )
+    assert resp.status_code == 200
+    assert resp.json()["visibility"] == "public"
+
+
+# ---------------------------------------------------------------------------
+# Ingest surfaces — the gate fires at request time, before any work
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_restricted_editor_register_public_403(
+    client: AsyncClient, admin_auth_header: dict, _restrict_public_visibility
+):
+    """The register gate runs before the table is even looked up, so the
+    table does not need to exist for the 403 to prove the surface."""
+    editor_headers, _ = await _create_test_user(client, admin_auth_header, "editor")
+    resp = await client.post(
+        "/ingest/register/",
+        json={
+            "table_name": "no_such_table_1691",
+            "title": "Blocked register",
+            "visibility": "public",
+        },
+        headers=editor_headers,
+    )
+    assert resp.status_code == 403
+    assert "restricted to administrators" in resp.json()["detail"]
+
+
+@pytest.mark.anyio
+async def test_restricted_editor_bulk_register_public_403(
+    client: AsyncClient, admin_auth_header: dict, _restrict_public_visibility
+):
+    """One public item rejects the whole batch up front (403, nothing partial)."""
+    editor_headers, _ = await _create_test_user(client, admin_auth_header, "editor")
+    resp = await client.post(
+        "/ingest/register/bulk/",
+        json={
+            "tables": [
+                {
+                    "table_name": "t_private_1691",
+                    "title": "Private item",
+                    "visibility": "private",
+                },
+                {
+                    "table_name": "t_public_1691",
+                    "title": "Public item",
+                    "visibility": "public",
+                },
+            ]
+        },
+        headers=editor_headers,
+    )
+    assert resp.status_code == 403
+
+
+@pytest.mark.anyio
+async def test_restricted_editor_vrt_create_public_403(
+    client: AsyncClient, admin_auth_header: dict, _restrict_public_visibility
+):
+    editor_headers, _ = await _create_test_user(client, admin_auth_header, "editor")
+    resp = await client.post(
+        "/ingest/vrt/create",
+        json={
+            "title": "blocked vrt",
+            "source_dataset_ids": [str(uuid.uuid4())],
+            "vrt_type": "mosaic",
+            "resolution_strategy": "finest",
+            "visibility": "public",
+        },
+        headers=editor_headers,
+    )
+    assert resp.status_code == 403
+
+
+@pytest.mark.anyio
+async def test_restricted_editor_stac_import_public_403(
+    client: AsyncClient, admin_auth_header: dict, _restrict_public_visibility
+):
+    editor_headers, _ = await _create_test_user(client, admin_auth_header, "editor")
+    resp = await client.post(
+        "/services/stac/import",
+        json={
+            "url": "https://stac.example.com/api",
+            "visibility": "public",
+            "items": [
+                {
+                    "id": "item-1691",
+                    "title": "Blocked import",
+                    "data_asset_href": "https://stac.example.com/cog.tif",
+                }
+            ],
+        },
+        headers=editor_headers,
+    )
+    assert resp.status_code == 403
+
+
+@pytest.mark.anyio
+async def test_restricted_admin_register_public_passes_gate(
+    client: AsyncClient, admin_auth_header: dict, _restrict_public_visibility
+):
+    """Admin passes the gate; the request then fails on the missing table
+    with a 400 (NOT the gate's 403), proving the gate is role-sensitive."""
+    resp = await client.post(
+        "/ingest/register/",
+        json={
+            "table_name": "no_such_table_1691_admin",
+            "title": "Admin register",
+            "visibility": "public",
+        },
+        headers=admin_auth_header,
+    )
+    assert resp.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# Feature flag exposure
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_feature_flags_expose_restrict_public_visibility(
+    client: AsyncClient, _restrict_public_visibility
+):
+    resp = await client.get("/settings/feature-flags/")
+    assert resp.status_code == 200
+    assert resp.json()["restrict_public_visibility"] is True
+
+
+@pytest.mark.anyio
+async def test_feature_flags_default_off(client: AsyncClient):
+    resp = await client.get("/settings/feature-flags/")
+    assert resp.status_code == 200
+    assert resp.json()["restrict_public_visibility"] is False

--- a/backend/tests/test_visibility_gate_structural.py
+++ b/backend/tests/test_visibility_gate_structural.py
@@ -1,0 +1,267 @@
+"""Structural guard for the admins-only-public gate (feat #1691).
+
+The `restrict_public_visibility` instance setting caps non-admin content at
+non-public visibility. Its enforcement contract is: EVERY mutation route whose
+request body accepts a `visibility` value routes through the ONE shared gate,
+`check_public_visibility_allowed` in `app/modules/catalog/authorization.py` —
+never a per-handler copy of the check.
+
+Same spirit as test_rule1_structural.py, deliberately smaller machinery:
+
+- Walk the real (flattened) FastAPI route table.
+- For each POST/PUT/PATCH route, recurse through the request-body model tree
+  (nested models, lists, unions) looking for a field literally named
+  ``visibility``. Response models never enter ``dependant.body_params``, so
+  read-side ``visibility`` fields (DatasetResponse, MapResponse, tile meta)
+  cannot false-positive here, and query params (the records router's
+  ``audience_visibility`` counterfactual, the maps list filter) are reads by
+  construction and also invisible to this walk.
+- Assert the handler's own source CALLS the gate, or the handler appears in
+  ``_DELEGATED_GATES`` naming the exact helper that carries the call for it
+  (integrity-checked below, so delegation cannot go stale).
+
+Known limits (accepted):
+
+- Source-level detection: a call site inside dead code would still credit the
+  handler. The behavioral 403 is covered by test_public_visibility_gate.py.
+- The manifest-apply body carries no ``visibility`` field — its publication
+  *intent* maps to one in ``publication_to_catalog_fields``. The walk cannot
+  see that by field name, so the route is pinned explicitly
+  (test_manifest_apply_routes_through_the_gate) rather than discovered.
+- The ingest fan-out body also carries no ``visibility`` field; the cloned
+  jobs inherit the parent job's user_metadata, so the handler gates that
+  inherited value as defense-in-depth. Pinned explicitly for the same reason
+  (test_fan_out_gates_inherited_visibility).
+"""
+
+from __future__ import annotations
+
+import inspect
+import re
+import textwrap
+import typing
+from functools import lru_cache
+from typing import Any
+
+import pytest
+
+_GATE_NAME = "check_public_visibility_allowed"
+_MUTATION_METHODS = {"POST", "PUT", "PATCH"}
+
+# Handlers whose gate call lives in a helper instead of the handler body.
+# Value: (module path, function name) whose source must contain the call.
+_DELEGATED_GATES: dict[str, tuple[str, str]] = {}
+
+# Mutation routes whose body accepts `visibility` but which are deliberately
+# NOT gated, each with a written justification. Kept empty on purpose: every
+# discovered surface is currently gated. Asserted exact in both directions.
+_ALLOWLIST: dict[str, str] = {}
+
+
+def _unwrap(fn: Any) -> Any:
+    seen: set[int] = set()
+    while hasattr(fn, "__wrapped__") and id(fn) not in seen:
+        seen.add(id(fn))
+        fn = fn.__wrapped__
+    return fn
+
+
+def _source_of(fn: Any) -> str:
+    try:
+        return textwrap.dedent(inspect.getsource(fn))
+    except (OSError, TypeError):
+        return ""
+
+
+def _calls_gate(source: str) -> bool:
+    """True when the source contains a CALL of the gate (not a bare mention)."""
+    return re.search(rf"\b{_GATE_NAME}\s*\(", source) is not None
+
+
+def _model_tree_has_visibility(annotation: Any, seen: set[int]) -> bool:
+    """Recurse an annotation's model tree for a field named ``visibility``."""
+    if annotation is None or id(annotation) in seen:
+        return False
+    seen.add(id(annotation))
+
+    from pydantic import BaseModel
+
+    if inspect.isclass(annotation) and issubclass(annotation, BaseModel):
+        for name, field in annotation.model_fields.items():
+            if name == "visibility":
+                return True
+            if _model_tree_has_visibility(field.annotation, seen):
+                return True
+        return False
+
+    for arg in typing.get_args(annotation):
+        if _model_tree_has_visibility(arg, seen):
+            return True
+    return False
+
+
+class _FlaggedRoute(typing.NamedTuple):
+    key: str
+    path: str
+    methods: tuple[str, ...]
+    gated: bool
+
+
+@lru_cache(maxsize=1)
+def _flagged_routes() -> tuple[_FlaggedRoute, ...]:
+    """Every unique mutation handler whose body tree carries `visibility`."""
+    from fastapi.routing import APIRoute, iter_route_contexts
+
+    from app.api.main import app
+
+    flagged: dict[str, _FlaggedRoute] = {}
+    for ctx in iter_route_contexts(app.routes):
+        route = ctx.route
+        if not isinstance(route, APIRoute):
+            continue
+        if not (_MUTATION_METHODS & set(route.methods or ())):
+            continue
+        has_visibility = any(
+            _model_tree_has_visibility(param.field_info.annotation, set())
+            for param in route.dependant.body_params
+        )
+        if not has_visibility:
+            continue
+        fn = _unwrap(route.endpoint)
+        key = f"{fn.__module__}.{fn.__qualname__}"
+        if key in flagged:
+            continue  # dual-shape slash aliases register the endpoint twice
+        gated = _calls_gate(_source_of(fn))
+        if not gated and key in _DELEGATED_GATES:
+            mod_path, helper_name = _DELEGATED_GATES[key]
+            module = __import__(mod_path, fromlist=[helper_name])
+            gated = _calls_gate(_source_of(getattr(module, helper_name)))
+        flagged[key] = _FlaggedRoute(
+            key=key,
+            path=ctx.path or route.path,
+            methods=tuple(sorted(route.methods or ())),
+            gated=gated,
+        )
+    return tuple(flagged.values())
+
+
+@pytest.mark.architecture
+def test_detection_is_alive() -> None:
+    """The body-tree walk must still find the known visibility surfaces.
+
+    If pydantic renames ``model_fields`` or the schemas move, every assertion
+    below could pass vacuously (nothing flagged, nothing required). Pin a
+    floor and two anchors that AGENTS.md-level refactors are least likely to
+    touch silently.
+    """
+    flagged = _flagged_routes()
+    assert len(flagged) >= 6, (
+        f"only {len(flagged)} mutation routes with a body-level `visibility` "
+        "field were discovered (expected >= 6: dataset PATCH, map PUT, ingest "
+        "commit/register/bulk-register/VRT-create, STAC import). The "
+        "detection walk is broken — fix it before trusting this module."
+    )
+    keys = {r.key for r in flagged}
+    for anchor_suffix in ("update_dataset_metadata", "commit_import"):
+        assert any(k.endswith(anchor_suffix) for k in keys), (
+            f"anchor handler *.{anchor_suffix} no longer flagged — either its "
+            "schema lost the visibility field or detection broke."
+        )
+
+
+@pytest.mark.architecture
+def test_every_visibility_mutation_routes_through_the_gate() -> None:
+    """feat(#1691): each discovered surface calls the ONE shared gate."""
+    offenders = [
+        f"  {r.key} [{','.join(r.methods)} {r.path}]"
+        for r in _flagged_routes()
+        if not r.gated and r.key not in _ALLOWLIST
+    ]
+    if offenders:
+        pytest.fail(
+            "Mutation route(s) accept a `visibility` value without calling "
+            f"{_GATE_NAME} (app/modules/catalog/authorization.py). Gate them "
+            "through that ONE shared check — do not hand-roll an admin "
+            "check — or add a justified _ALLOWLIST entry:\n" + "\n".join(offenders)
+        )
+
+
+@pytest.mark.architecture
+def test_allowlist_and_delegations_are_current() -> None:
+    """Stale exemption entries are silent licences to regress — both lists
+    must reference handlers that still exist and still need the entry."""
+    flagged = {r.key: r for r in _flagged_routes()}
+    stale = [key for key in _ALLOWLIST if key not in flagged]
+    stale += [
+        key
+        for key in _DELEGATED_GATES
+        if key not in flagged or _calls_gate(_source_of_key(key))
+    ]
+    assert not stale, (
+        "_ALLOWLIST/_DELEGATED_GATES entries no longer match a flagged "
+        f"handler (or the handler now gates directly): {stale}. Delete them."
+    )
+
+
+def _source_of_key(key: str) -> str:
+    mod_path, _, qualname = key.rpartition(".")
+    module = __import__(mod_path, fromlist=[qualname])
+    return _source_of(getattr(module, qualname, None))
+
+
+@pytest.mark.architecture
+def test_manifest_apply_routes_through_the_gate() -> None:
+    """The manifest body has no `visibility` field — its publication intent
+    maps to one. Pin that the apply path's classification step calls the
+    gate, and that the route itself still exists (so this pin cannot outlive
+    the surface it covers)."""
+    from fastapi.routing import APIRoute, iter_route_contexts
+
+    from app.api.main import app
+    from app.processing.ingest import manifest_service
+
+    manifest_routes = [
+        ctx.path
+        for ctx in iter_route_contexts(app.routes)
+        if isinstance(ctx.route, APIRoute)
+        and "POST" in (ctx.route.methods or ())
+        and (ctx.path or ctx.route.path).endswith("/ingest/manifest/apply")
+    ]
+    assert manifest_routes, "manifest apply route disappeared — update this pin"
+    assert _calls_gate(_source_of(manifest_service._classify_dataset)), (
+        "manifest_service._classify_dataset no longer calls "
+        f"{_GATE_NAME}; a manifest with intent 'published' would create "
+        "public datasets past the restrict_public_visibility setting."
+    )
+
+
+@pytest.mark.architecture
+def test_fan_out_gates_inherited_visibility() -> None:
+    """FanOutCommitRequest has no visibility field, but the cloned jobs
+    inherit the parent job's user_metadata — the handler must gate that
+    inherited value (defense-in-depth, feat #1691)."""
+    from app.processing.ingest import router as ingest_router
+
+    assert _calls_gate(_source_of(ingest_router.commit_fan_out)), (
+        f"commit_fan_out no longer calls {_GATE_NAME} on the parent job's "
+        "inherited user_metadata visibility."
+    )
+
+
+@pytest.mark.architecture
+def test_gate_integrity() -> None:
+    """The shared gate must still read the setting, resolve roles, and fail
+    closed with a 403 — a hollowed-out gate satisfies every check above."""
+    from app.modules.catalog import authorization
+
+    source = _source_of(authorization.check_public_visibility_allowed)
+    for needle, why in (
+        ("RESTRICT_PUBLIC_VISIBILITY", "reads the instance setting"),
+        ("get_user_roles", "resolves the caller's roles"),
+        ('"admin"', "checks admin membership"),
+        ("HTTP_403_FORBIDDEN", "fails closed with a 403"),
+    ):
+        assert needle in source, (
+            f"{_GATE_NAME} no longer {why} ({needle!r} missing) — the "
+            "structural credit every handler gets from calling it is void."
+        )

--- a/frontend/src/api/__tests__/hand-typed-mirror-drift.test.ts
+++ b/frontend/src/api/__tests__/hand-typed-mirror-drift.test.ts
@@ -66,7 +66,7 @@ const MIRRORS: MirrorShape[] = [
   {
     schema: 'FeatureFlagsResponse',
     source: 'settings.ts FeatureFlags',
-    required: ['enable_dataset_editing', 'require_metadata_for_publish'],
+    required: ['enable_dataset_editing', 'require_metadata_for_publish', 'restrict_public_visibility'],
     optional: [],
   },
   {

--- a/frontend/src/api/settings.ts
+++ b/frontend/src/api/settings.ts
@@ -65,6 +65,8 @@ export async function getEnabledPlugins(): Promise<string[] | null> {
 export interface FeatureFlags {
   enable_dataset_editing: boolean;
   require_metadata_for_publish: boolean;
+  // feat(#1691): when true, only admins may set `visibility: public`.
+  restrict_public_visibility: boolean;
 }
 
 export async function getFeatureFlags(): Promise<FeatureFlags> {

--- a/frontend/src/components/admin/settings/SettingsGeneralTab.tsx
+++ b/frontend/src/components/admin/settings/SettingsGeneralTab.tsx
@@ -22,6 +22,7 @@ interface TabProps {
 const FIELDS = [
   { key: 'require_metadata_for_publish', defaultValue: false },
   { key: 'enable_dataset_editing', defaultValue: false },
+  { key: 'restrict_public_visibility', defaultValue: false },
   { key: 'banner_enabled', defaultValue: false },
   { key: 'banner_text', defaultValue: '' },
   { key: 'banner_color', defaultValue: 'warning' },
@@ -66,6 +67,22 @@ export function SettingsGeneralTab({ settings, envOnly, onSave, onReset, isSavin
           id="enable-dataset-editing-toggle"
           checked={values.enable_dataset_editing as boolean}
           onCheckedChange={setters.enable_dataset_editing}
+          disabled={envOnly}
+        />
+      </div>
+
+      <div className="flex items-center justify-between max-w-md">
+        <div className="space-y-0.5">
+          <div className="flex items-center gap-2">
+            <Label htmlFor="restrict-public-visibility-toggle">{t('settings.general.restrictPublicVisibility')}</Label>
+            <SettingSourceBadge source={findSetting(settings, 'restrict_public_visibility')?.source ?? 'default'} settingKey="restrict_public_visibility" onReset={onReset} />
+          </div>
+          <p className="text-sm text-muted-foreground">{t('settings.general.restrictPublicVisibilityDescription')}</p>
+        </div>
+        <Switch
+          id="restrict-public-visibility-toggle"
+          checked={values.restrict_public_visibility as boolean}
+          onCheckedChange={setters.restrict_public_visibility}
           disabled={envOnly}
         />
       </div>

--- a/frontend/src/components/builder/SharePanel.tsx
+++ b/frontend/src/components/builder/SharePanel.tsx
@@ -22,7 +22,7 @@ import {
 import { formatDate } from '@/lib/format';
 import { cn } from '@/lib/utils';
 import { useEdition } from '@/hooks/use-edition';
-import { useTileConfig } from '@/hooks/use-settings';
+import { useCanSetPublicVisibility, useTileConfig } from '@/hooks/use-settings';
 import {
   Dialog,
   DialogContent,
@@ -946,6 +946,10 @@ export function ShareDialog({
   const { t } = useTranslation('builder');
   const { isEnterprise } = useEdition();
   const publishMap = usePublishMap();
+  // feat(#1691): the restrict_public_visibility instance setting caps
+  // non-admins at non-public; the server enforces it with a 403, this only
+  // disables the Public choice.
+  const canSetPublic = useCanSetPublicVisibility();
 
   // fix(#1548 review r3/r4/r5): three origins live here, and the question that
   // picks between them is WHO OPENS THE URL — not whether it is "a share".
@@ -1234,6 +1238,9 @@ export function ShareDialog({
               {VISIBILITY_OPTIONS.map((opt) => {
                 const Icon = opt.icon;
                 const isActive = visibility === opt.value;
+                // feat(#1691): a non-admin cannot move a map TO public while
+                // the instance restricts public visibility to admins.
+                const publicBlocked = opt.value === 'public' && !canSetPublic;
                 return (
                   <button
                     key={opt.value}
@@ -1245,14 +1252,19 @@ export function ShareDialog({
                       isActive
                         ? 'ring-2 ring-ring border-primary bg-primary/5'
                         : 'border-border hover:border-muted-foreground/30 hover:bg-accent/50',
+                      publicBlocked && 'cursor-not-allowed opacity-60',
                     )}
                     onClick={() => handleVisibilitySelect(opt.value)}
-                    disabled={publishMap.isPending}
+                    disabled={publishMap.isPending || publicBlocked}
                   >
                     <Icon className={cn('h-4 w-4 mt-0.5 shrink-0', opt.iconClass)} />
                     <div className="min-w-0">
                       <p className="text-sm font-semibold">{t(opt.titleKey)}</p>
-                      <p className="text-xs text-muted-foreground">{t(opt.descKey)}</p>
+                      <p className="text-xs text-muted-foreground">
+                        {publicBlocked
+                          ? t('common:visibilityPublicAdminOnly')
+                          : t(opt.descKey)}
+                      </p>
                     </div>
                   </button>
                 );

--- a/frontend/src/components/builder/__tests__/SharePanel.test.tsx
+++ b/frontend/src/components/builder/__tests__/SharePanel.test.tsx
@@ -12,7 +12,7 @@ import {
   useUpdateEmbedToken,
 } from '@/components/builder/hooks/use-embed-tokens';
 import { useEdition } from '@/hooks/use-edition';
-import { useTileConfig } from '@/hooks/use-settings';
+import { useCanSetPublicVisibility, useTileConfig } from '@/hooks/use-settings';
 import {
   useCreateShareToken,
   useMapShareToken,
@@ -46,6 +46,7 @@ vi.mock('@/hooks/use-maps', () => ({
 // tests that care drive a DIFFERENT hostname, which is the whole point.
 vi.mock('@/hooks/use-settings', () => ({
   useTileConfig: vi.fn(),
+  useCanSetPublicVisibility: vi.fn(),
 }));
 
 vi.mock('@/components/builder/hooks/use-embed-tokens', () => ({
@@ -56,6 +57,7 @@ vi.mock('@/components/builder/hooks/use-embed-tokens', () => ({
 }));
 
 const mockedUseTileConfig = vi.mocked(useTileConfig);
+const mockedUseCanSetPublicVisibility = vi.mocked(useCanSetPublicVisibility);
 const mockedUseEdition = vi.mocked(useEdition);
 const mockedCheckMapVisibility = vi.mocked(checkMapVisibility);
 const mockedUsePublishMap = vi.mocked(usePublishMap);
@@ -99,6 +101,7 @@ function setup({
   layers,
   publishMapFn = vi.fn().mockResolvedValue({}),
   publicAppUrl = window.location.origin,
+  canSetPublic = true,
   forceActiveEmbedToken = false,
   lockOriginsAfterCreate = null,
 }: {
@@ -121,6 +124,9 @@ function setup({
   publishMapFn?: (...args: any[]) => any;
   /** The deployment's configured PUBLIC_APP_URL. null = unconfigured. */
   publicAppUrl?: string | null;
+  /** feat(#1691): useCanSetPublicVisibility() — false when the instance
+   *  restricts public visibility to admins and the user is not one. */
+  canSetPublic?: boolean;
   /** Return an active embed token even when the share link is created at
    *  runtime — the domain-locked branch needs both. */
   forceActiveEmbedToken?: boolean;
@@ -148,6 +154,8 @@ function setup({
       is_active: true,
     };
   });
+
+  mockedUseCanSetPublicVisibility.mockReturnValue(canSetPublic);
 
   mockedUseTileConfig.mockReturnValue({
     data: {
@@ -1271,6 +1279,21 @@ describe('fix(#778) public-boundary visibility confirmation', () => {
     });
     expect(publishMapFn).toHaveBeenCalledWith({ id: 'map-1', visibility: 'internal' });
     expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument();
+  });
+
+  // feat(#1691): the restrict_public_visibility instance setting caps
+  // non-admins at non-public. The server enforces it with a 403; the panel
+  // disables the choice and swaps its description for the admin-only note.
+  it('disables the Public choice when the instance restricts public to admins', () => {
+    setup({ visibility: 'private', hasShareToken: false, canSetPublic: false });
+
+    const publicRadio = screen.getByRole('radio', {
+      name: /only administrators can make content public/i,
+    });
+    expect(publicRadio).toBeDisabled();
+    // The other choices stay usable.
+    expect(screen.getByRole('radio', { name: /only you/i })).toBeEnabled();
+    expect(screen.getByRole('radio', { name: /all team members/i })).toBeEnabled();
   });
 });
 

--- a/frontend/src/components/dataset/__tests__/AccessTab.test.tsx
+++ b/frontend/src/components/dataset/__tests__/AccessTab.test.tsx
@@ -4,7 +4,7 @@ import {
   useSetPrimaryDistribution,
 } from '@/components/dataset/hooks/use-records';
 import { useUpdateDataset } from '@/components/dataset/hooks/use-dataset';
-import { useTileConfig } from '@/hooks/use-settings';
+import { useCanSetPublicVisibility, useTileConfig } from '@/hooks/use-settings';
 import { listKeywords } from '@/api/records';
 import { toast } from 'sonner';
 import { AccessTab } from '../tabs/AccessTab';
@@ -26,6 +26,7 @@ vi.mock('@/api/records', () => ({
 
 vi.mock('@/hooks/use-settings', () => ({
   useTileConfig: vi.fn(),
+  useCanSetPublicVisibility: vi.fn(),
 }));
 
 vi.mock('@/components/dataset/hooks/use-dataset', () => ({
@@ -39,6 +40,7 @@ vi.mock('sonner', () => ({
 const mockUseDistributions = vi.mocked(useDistributions);
 const mockUseSetPrimaryDistribution = vi.mocked(useSetPrimaryDistribution);
 const mockUseTileConfig = vi.mocked(useTileConfig);
+const mockUseCanSetPublic = vi.mocked(useCanSetPublicVisibility);
 const mockUseUpdateDataset = vi.mocked(useUpdateDataset);
 const mockListKeywords = vi.mocked(listKeywords);
 const mutate = vi.fn();
@@ -93,6 +95,7 @@ function makeDataset(overrides: Partial<DatasetResponse> = {}): DatasetResponse 
 
 describe('AccessTab', () => {
   beforeEach(() => {
+    mockUseCanSetPublic.mockReturnValue(true);
     mockUseDistributions.mockReturnValue({
       data: {
         distributions: [
@@ -229,6 +232,38 @@ describe('AccessTab', () => {
       openVisibilitySelect();
 
       expect(screen.queryByRole('option', { name: 'Restricted' })).not.toBeInTheDocument();
+    });
+
+    // feat(#1691): the restrict_public_visibility instance setting caps
+    // non-admins at non-public. The server enforces it with a 403; this
+    // control disables the Public move and explains why.
+    it('disables the Public move when the instance restricts public to admins', async () => {
+      mockUseCanSetPublic.mockReturnValue(false);
+      render(<AccessTab dataset={makeDataset({ visibility: 'private' })} canEdit />);
+
+      expect(
+        screen.getByText('Only administrators can make content public on this instance.'),
+      ).toBeInTheDocument();
+
+      openVisibilitySelect();
+      const publicOption = screen.getByRole('option', { name: 'Public' });
+      expect(publicOption).toHaveAttribute('aria-disabled', 'true');
+
+      fireEvent.click(publicOption);
+      expect(mutate).not.toHaveBeenCalled();
+    });
+
+    it('keeps the Public move and hides the admin-only note when allowed', () => {
+      render(<AccessTab dataset={makeDataset({ visibility: 'private' })} canEdit />);
+
+      expect(
+        screen.queryByText('Only administrators can make content public on this instance.'),
+      ).not.toBeInTheDocument();
+
+      openVisibilitySelect();
+      expect(
+        screen.getByRole('option', { name: 'Public' }),
+      ).not.toHaveAttribute('aria-disabled', 'true');
     });
 
     // fix(#930): `internal` joined the ladder once its permission branches

--- a/frontend/src/components/dataset/tabs/AccessTab.tsx
+++ b/frontend/src/components/dataset/tabs/AccessTab.tsx
@@ -5,6 +5,7 @@ import { Copy, Check } from 'lucide-react';
 import { toast } from 'sonner';
 import { useDatasetAccessEndpoints } from '@/components/dataset/hooks/use-dataset-access';
 import { useUpdateDataset } from '@/components/dataset/hooks/use-dataset';
+import { useCanSetPublicVisibility } from '@/hooks/use-settings';
 import { listKeywords } from '@/api/records';
 import type { DatasetResponse, DatasetVisibility } from '@/types/api';
 import {
@@ -254,6 +255,10 @@ export function AccessTab({ dataset, canEdit = false }: AccessTabProps) {
   const { t } = useTranslation('dataset');
   const { endpoints, publicApiBaseUrl } = useDatasetAccessEndpoints(dataset);
   const updateDataset = useUpdateDataset();
+  // feat(#1691): the restrict_public_visibility instance setting caps
+  // non-admins at non-public; the server enforces it with a 403, this only
+  // disables the affordance.
+  const canSetPublic = useCanSetPublicVisibility();
   const isLegacyVisibility = !SELECTABLE_VISIBILITIES.includes(
     dataset.visibility as (typeof SELECTABLE_VISIBILITIES)[number],
   );
@@ -425,7 +430,11 @@ export function AccessTab({ dataset, canEdit = false }: AccessTabProps) {
                     </SelectItem>
                   )}
                   {SELECTABLE_VISIBILITIES.map((value) => (
-                    <SelectItem key={value} value={value}>
+                    <SelectItem
+                      key={value}
+                      value={value}
+                      disabled={value === 'public' && !canSetPublic}
+                    >
                       {getVisibilityLabel(t, value)}
                     </SelectItem>
                   ))}
@@ -446,6 +455,11 @@ export function AccessTab({ dataset, canEdit = false }: AccessTabProps) {
           <p className="text-xs text-muted-foreground mt-2">
             {t('metadataEdit.visibilityHelp')}
           </p>
+          {canEdit && !canSetPublic && (
+            <p className="text-xs text-muted-foreground mt-1">
+              {t('common:visibilityPublicAdminOnly')}
+            </p>
+          )}
         </CardContent>
       </Card>
 

--- a/frontend/src/components/import/ImportMetadataForm.tsx
+++ b/frontend/src/components/import/ImportMetadataForm.tsx
@@ -1,6 +1,7 @@
 import { useRef, useMemo, useState } from 'react';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { useTranslation } from 'react-i18next';
+import { useCanSetPublicVisibility } from '@/hooks/use-settings';
 import { Loader2 } from 'lucide-react';
 import type { CommitImportRequest, RasterPreviewResponse } from '@/types/api';
 import { Button } from '@/components/ui/button';
@@ -61,6 +62,12 @@ export function ImportMetadataForm({
   detectedGeometryColumns,
 }: ImportMetadataFormProps) {
   const { t } = useTranslation('import');
+  // feat(#1691): hide the Public option when the restrict_public_visibility
+  // instance setting caps non-admins at non-public (server enforces via 403).
+  const canSetPublic = useCanSetPublicVisibility();
+  const visibilityOptions = canSetPublic
+    ? VISIBILITY_OPTIONS
+    : VISIBILITY_OPTIONS.filter((opt) => opt.value !== 'public');
   const [name, setName] = useState(stripExtension(defaultName));
   const [description, setDescription] = useState('');
   const [visibility, setVisibility] = useState('private');
@@ -196,7 +203,7 @@ export function ImportMetadataForm({
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>
-                {VISIBILITY_OPTIONS.map((opt) => (
+                {visibilityOptions.map((opt) => (
                   <SelectItem key={opt.value} value={opt.value}>
                     {t(opt.labelKey)}
                   </SelectItem>

--- a/frontend/src/components/import/RegisterForm.tsx
+++ b/frontend/src/components/import/RegisterForm.tsx
@@ -3,6 +3,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { useNavigate, Link } from 'react-router';
 import { useQueryClient } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
+import { useCanSetPublicVisibility } from '@/hooks/use-settings';
 import { useDiscoverTables, useBulkRegister, useDatasetCountHint } from '@/components/import/hooks/use-ingest';
 import { queryKeys } from '@/lib/query-keys';
 import type { BulkRegisterResult, DiscoveredTable } from '@/types/api';
@@ -262,6 +263,9 @@ function TableDetail({
   isPending: boolean;
 }) {
   const { t } = useTranslation('import');
+  // feat(#1691): hide the Public option when the restrict_public_visibility
+  // instance setting caps non-admins at non-public (server enforces via 403).
+  const canSetPublic = useCanSetPublicVisibility();
 
   return (
     <>
@@ -302,7 +306,9 @@ function TableDetail({
           </SelectTrigger>
           <SelectContent>
             <SelectItem value="private">{t('register.visibilityPrivate')}</SelectItem>
-            <SelectItem value="public">{t('register.visibilityPublic')}</SelectItem>
+            {canSetPublic && (
+              <SelectItem value="public">{t('register.visibilityPublic')}</SelectItem>
+            )}
           </SelectContent>
         </Select>
         <Button onClick={onRegister} disabled={isPending}>

--- a/frontend/src/hooks/use-settings.ts
+++ b/frontend/src/hooks/use-settings.ts
@@ -1,5 +1,6 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { queryKeys } from '@/lib/query-keys';
+import { useAuthStore } from '@/stores/auth-store';
 import { formatMutationError } from '@/lib/error-map';
 import { toast } from 'sonner';
 import i18n from '@/i18n/i18n';
@@ -66,6 +67,20 @@ export function useFeatureFlags() {
     staleTime: 60_000,
     gcTime: 30 * 60_000,
   });
+}
+
+/**
+ * feat(#1691): whether the current user may set `visibility: public`.
+ *
+ * False only when the `restrict_public_visibility` instance setting is on
+ * AND the user is not an admin. The server enforces the rule with a 403 at
+ * every visibility-writing mutation — this hook only drives UI affordances
+ * (hiding/disabling the Public option).
+ */
+export function useCanSetPublicVisibility(): boolean {
+  const { data: featureFlags } = useFeatureFlags();
+  const isAdmin = useAuthStore((s) => s.isAdmin());
+  return isAdmin || !(featureFlags?.restrict_public_visibility ?? false);
 }
 
 // --- Unified admin hooks ---

--- a/frontend/src/i18n/locales/de/admin.json
+++ b/frontend/src/i18n/locales/de/admin.json
@@ -460,6 +460,8 @@
       "requireMetadataDescription": "Wenn aktiviert, müssen Datensätze vollständige Metadaten haben, bevor sie veröffentlicht werden können.",
       "enableDatasetEditing": "Datensatzbearbeitung aktivieren",
       "enableDatasetEditingDescription": "Geometrie-Zeichnung und Attributbearbeitung auf Datensatz-Detailseiten erlauben. Wenn deaktiviert, sind Datensätze schreibgeschützt.",
+      "restrictPublicVisibility": "Öffentliche Sichtbarkeit auf Administratoren beschränken",
+      "restrictPublicVisibilityDescription": "Wenn aktiviert, können nur Administratoren Datensätze und Karten auf öffentlich stellen. Nicht-Administratoren behalten alle engeren Sichtbarkeitsstufen.",
       "bannerEnabled": "Site-Banner aktivieren",
       "bannerEnabledDescription": "Das Ankündigungsbanner allen Besuchern anzeigen. Der Banner-Text unten muss ebenfalls gesetzt sein.",
       "bannerText": "Site-Banner-Text",

--- a/frontend/src/i18n/locales/de/common.json
+++ b/frontend/src/i18n/locales/de/common.json
@@ -637,5 +637,6 @@
   "copied": "Kopiert",
   "mapViewerGate": {
     "accessCheckFailed": "Ihr Zugriff auf diese Karte konnte nicht geprüft werden. Versuchen Sie es erneut."
-  }
+  },
+  "visibilityPublicAdminOnly": "Nur Administratoren können Inhalte auf dieser Instanz öffentlich machen."
 }

--- a/frontend/src/i18n/locales/en/admin.json
+++ b/frontend/src/i18n/locales/en/admin.json
@@ -508,6 +508,8 @@
       "requireMetadataDescription": "When enabled, datasets must have complete metadata (title, summary, contacts, keywords, license, spatial extent, CRS, lineage) before they can be published.",
       "enableDatasetEditing": "Enable Dataset Editing",
       "enableDatasetEditingDescription": "Allow geometry drawing and attribute editing on dataset detail pages. When disabled, datasets are read-only.",
+      "restrictPublicVisibility": "Restrict Public Visibility to Admins",
+      "restrictPublicVisibilityDescription": "When enabled, only administrators can set datasets and maps to public visibility. Non-admin users keep every narrower visibility level.",
       "bannerEnabled": "Enable Site Banner",
       "bannerEnabledDescription": "Show the announcement banner to all visitors. The banner text below must also be set.",
       "bannerText": "Site Banner Text",

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -637,5 +637,6 @@
   "copied": "Copied",
   "mapViewerGate": {
     "accessCheckFailed": "We could not check your access to this map. Try again."
-  }
+  },
+  "visibilityPublicAdminOnly": "Only administrators can make content public on this instance."
 }

--- a/frontend/src/i18n/locales/es/admin.json
+++ b/frontend/src/i18n/locales/es/admin.json
@@ -460,6 +460,8 @@
       "requireMetadataDescription": "Cuando está habilitado, los conjuntos de datos deben tener metadatos completos antes de poder publicarse.",
       "enableDatasetEditing": "Habilitar edición de conjuntos de datos",
       "enableDatasetEditingDescription": "Permitir dibujo de geometría y edición de atributos en las páginas de detalle de conjuntos de datos. Cuando está deshabilitado, los conjuntos de datos son de solo lectura.",
+      "restrictPublicVisibility": "Restringir la visibilidad pública a administradores",
+      "restrictPublicVisibilityDescription": "Cuando está activado, solo los administradores pueden hacer públicos los conjuntos de datos y los mapas. Los usuarios sin permisos de administrador conservan todos los niveles de visibilidad más restringidos.",
       "bannerEnabled": "Activar banner del sitio",
       "bannerEnabledDescription": "Mostrar el banner de aviso a todos los visitantes. El texto del banner de abajo también debe estar configurado.",
       "bannerText": "Texto del banner del sitio",

--- a/frontend/src/i18n/locales/es/common.json
+++ b/frontend/src/i18n/locales/es/common.json
@@ -637,5 +637,6 @@
   "copied": "Copiado",
   "mapViewerGate": {
     "accessCheckFailed": "No pudimos comprobar tu acceso a este mapa. Inténtalo de nuevo."
-  }
+  },
+  "visibilityPublicAdminOnly": "Solo los administradores pueden hacer público el contenido en esta instancia."
 }

--- a/frontend/src/i18n/locales/fr/admin.json
+++ b/frontend/src/i18n/locales/fr/admin.json
@@ -460,6 +460,8 @@
       "requireMetadataDescription": "Lorsque activé, les jeux de données doivent avoir des métadonnées complètes avant de pouvoir être publiés.",
       "enableDatasetEditing": "Activer l'édition des jeux de données",
       "enableDatasetEditingDescription": "Autoriser le dessin de géométrie et l'édition des attributs sur les pages de détail des jeux de données. Lorsque désactivé, les jeux de données sont en lecture seule.",
+      "restrictPublicVisibility": "Réserver la visibilité publique aux administrateurs",
+      "restrictPublicVisibilityDescription": "Lorsque cette option est activée, seuls les administrateurs peuvent rendre publics les jeux de données et les cartes. Les utilisateurs non administrateurs conservent tous les niveaux de visibilité plus restreints.",
       "bannerEnabled": "Activer la bannière du site",
       "bannerEnabledDescription": "Afficher la bannière d'annonce à tous les visiteurs. Le texte de la bannière ci-dessous doit également être renseigné.",
       "bannerText": "Texte de la bannière du site",

--- a/frontend/src/i18n/locales/fr/common.json
+++ b/frontend/src/i18n/locales/fr/common.json
@@ -637,5 +637,6 @@
   "copied": "Copié",
   "mapViewerGate": {
     "accessCheckFailed": "Impossible de vérifier votre accès à cette carte. Réessayez."
-  }
+  },
+  "visibilityPublicAdminOnly": "Seuls les administrateurs peuvent rendre le contenu public sur cette instance."
 }

--- a/frontend/src/types/api.generated.ts
+++ b/frontend/src/types/api.generated.ts
@@ -8538,6 +8538,11 @@ export interface components {
              * @default false
              */
             require_metadata_for_publish: boolean;
+            /**
+             * Restrict Public Visibility
+             * @default false
+             */
+            restrict_public_visibility: boolean;
         };
         /**
          * FeatureReplace

--- a/sdks/python/geolens/models/feature_flags_response.py
+++ b/sdks/python/geolens/models/feature_flags_response.py
@@ -19,16 +19,20 @@ class FeatureFlagsResponse:
     Attributes:
         enable_dataset_editing (bool | Unset):  Default: False.
         require_metadata_for_publish (bool | Unset):  Default: False.
+        restrict_public_visibility (bool | Unset):  Default: False.
     """
 
     enable_dataset_editing: bool | Unset = False
     require_metadata_for_publish: bool | Unset = False
+    restrict_public_visibility: bool | Unset = False
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
         enable_dataset_editing = self.enable_dataset_editing
 
         require_metadata_for_publish = self.require_metadata_for_publish
+
+        restrict_public_visibility = self.restrict_public_visibility
 
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
@@ -37,6 +41,8 @@ class FeatureFlagsResponse:
             field_dict["enable_dataset_editing"] = enable_dataset_editing
         if require_metadata_for_publish is not UNSET:
             field_dict["require_metadata_for_publish"] = require_metadata_for_publish
+        if restrict_public_visibility is not UNSET:
+            field_dict["restrict_public_visibility"] = restrict_public_visibility
 
         return field_dict
 
@@ -47,9 +53,12 @@ class FeatureFlagsResponse:
 
         require_metadata_for_publish = d.pop("require_metadata_for_publish", UNSET)
 
+        restrict_public_visibility = d.pop("restrict_public_visibility", UNSET)
+
         feature_flags_response = cls(
             enable_dataset_editing=enable_dataset_editing,
             require_metadata_for_publish=require_metadata_for_publish,
+            restrict_public_visibility=restrict_public_visibility,
         )
 
         feature_flags_response.additional_properties = d

--- a/sdks/typescript/src/client/types.gen.ts
+++ b/sdks/typescript/src/client/types.gen.ts
@@ -4508,6 +4508,10 @@ export type FeatureFlagsResponse = {
      * Require Metadata For Publish
      */
     require_metadata_for_publish?: boolean;
+    /**
+     * Restrict Public Visibility
+     */
+    restrict_public_visibility?: boolean;
 };
 
 /**


### PR DESCRIPTION
Implements #1691: an instance setting (default OFF) that restricts the `public` visibility level to admins. Built for open instances like the demo, where any signed-in visitor can currently mark junk content public and pollute every visitor's search facets.

## What changed

**Setting.** `RESTRICT_PUBLIC_VISIBILITY` (`restrict_public_visibility`, bool, default `false`) joins the persistent-config registry on the General tab. No migration — it rides the existing `app_settings` KV surface like every other flag.

**One shared gate.** `check_public_visibility_allowed(db, user, visibility, *, user_roles=None)` in `backend/app/modules/catalog/authorization.py`. When the setting is ON and a non-admin requests `public`, it raises 403 with a clear message; every other value passes through. Existing public content is untouched — the gate fires only on a mutation that requests public, so enabling the setting never retroactively narrows anything.

**Enforcement points** (enumerated, all through the one gate):

| Surface | Route |
|---|---|
| Dataset metadata PATCH | `PATCH /datasets/{id}` |
| Map update | `PUT /maps/{id}` |
| STAC import | `POST /services/stac/import` |
| Ingest commit | `POST /ingest/commit/{job_id}` |
| Ingest fan-out | `POST /ingest/commit-fan-out/{job_id}` (gates the parent job's inherited `user_metadata.visibility` — defense-in-depth; the request body itself has no visibility field) |
| Table register | `POST /ingest/register/` |
| Bulk register | `POST /ingest/register/bulk/` (one public item 403s the whole batch before anything runs) |
| VRT create | `POST /ingest/vrt/create` |
| Manifest apply (CLI `geolens apply`) | `POST /ingest/manifest/apply` — publication intent `published` maps to `public`; gated in `_classify_dataset` before staging, so it surfaces as that entry's error and dry runs report it too |

Surfaces confirmed to need **no** gate: collections (no visibility field at all), records router (reads only — `audience_visibility` is a counterfactual query param), map create (`MapCreate` has no visibility; maps are born private), map sharing routes (require an already-public map; they never write visibility).

**Structural test.** `backend/tests/test_visibility_gate_structural.py` walks the flattened FastAPI route table, recurses each POST/PUT/PATCH body-model tree for a field named `visibility`, and asserts every discovered handler calls the gate (7 discovered, all gated). The manifest and fan-out paths — whose bodies carry no `visibility` field — are pinned explicitly, and a gate-integrity test keeps the shared check from being hollowed out. `backend/tests/test_public_visibility_gate.py` covers the runtime matrix (editor 403 / admin 200 / internal ok / already-public untouched / default-off unchanged / feature-flag exposure).

**Frontend.** The flag rides the public `GET /settings/feature-flags/` bundle. A new `useCanSetPublicVisibility()` hook (feature flag + `isAdmin`) drives the affordances: the dataset Access tab disables the Public move with an explanatory note, the map SharePanel disables the Public choice and swaps its description, and the import/register pickers hide the Public option. The admin Settings → General tab gains the toggle. New `t()` keys are in all four locales (en/es/fr/de).

## API / config impact

- `FeatureFlagsResponse` gains `restrict_public_visibility` (default `false`) — additive. `backend/openapi.json`, both SDKs, and `frontend/src/types/api.generated.ts` regenerated.
- New settings key `restrict_public_visibility` (General tab). Default OFF: zero behavior change for existing installs until an admin enables it.
- Visibility-writing mutations can now return 403 (`"Public visibility is restricted to administrators…"`) when the setting is enabled — for non-admins requesting `public` only.

## Verification

```
cd backend && uv run pytest tests/test_public_visibility_gate.py tests/test_visibility_gate_structural.py -v   # 21 passed
cd backend && uv run pytest tests/test_layering.py tests/test_rule1_structural.py -q                            # 53 passed
cd backend && uv run pytest tests/test_manifest_apply_api.py tests/test_manifest_apply_service.py \
  tests/test_manifest_apply_roundtrip.py tests/test_manifest_apply_vrt.py tests/test_stac_import.py \
  tests/test_settings_router.py tests/test_settings_admin.py tests/test_api_contract_openapi.py \
  tests/test_sdks_round_trip.py -q -n 4                                                                         # 202 passed, 1 skipped
cd backend && uv run pytest tests/test_dataset_metadata_idor.py tests/test_maps.py tests/test_vrt_schema_171.py \
  tests/test_ingest.py tests/test_ingest_fan_out.py -q -n 4                                                     # 254 passed
cd backend && uv run ruff check . && uv run ruff format --check .                                               # clean
make openapi-check && make sdks-check                                                                            # clean
make public-surface-check && make deployed-surface-check                                                         # clean
cd frontend && npm run lint && npm run typecheck && npm run test:i18n                                            # clean
cd frontend && npx vitest run src/components/dataset/__tests__/AccessTab.test.tsx \
  src/components/builder/__tests__/SharePanel.test.tsx src/api/__tests__/hand-typed-mirror-drift.test.ts \
  src/components/import/__tests__/ src/components/admin/settings/__tests__/                                      # 246 passed
pre-commit run --from-ref main --to-ref HEAD                                                                     # all hooks pass
```

Closes #1691

https://claude.ai/code/session_01BXUUv3x71zWaLKEvoL4cTY
