### PR TITLE
chore(release): prepare v1.16.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,53 @@ and releases use semantic versioning.
 
 ## [Unreleased]
 
+## [1.16.1] - 2026-08-28
+
+### Added
+
+- **Instance setting to restrict public visibility to admins.** A new
+  `restrict_public_visibility` setting (default off, General tab): when
+  enabled, non-admin users can still create and edit content, but any request
+  to mark a dataset, map, or import `public` is refused with a clear 403.
+  Enforcement runs server-side through one shared gate at every
+  visibility-writing surface — dataset metadata, map save, STAC import,
+  ingest commit and fan-out, register, VRT create, and manifest apply — and a
+  structural test walks the route table so a new visibility-accepting handler
+  cannot ship ungated. The UI hides or disables the Public option for
+  non-admins with a note. Existing public content is untouched. Built for
+  open-SSO instances such as the public demo, where anonymous-facing search
+  facets otherwise accumulate whatever visitors mark public (#1691, #1704).
+
+- **STAC items now advertise their origin assets.** A dataset imported by
+  reference from a remote STAC catalog stores the source item's data asset
+  (the COG href) and serves it on GeoLens's own STAC items beside the tile
+  asset, clearly roled `data` vs `visual`, so generic clients — stac-browser,
+  the QGIS STAC plugin, rio-viz — can actually read pixels from items GeoLens
+  republishes. A successful refresh repairs existing by-reference datasets
+  idempotently, which doubles as the backfill (#1692, #1703).
+
+### Fixed
+
+- **Browsers can consume public exports cross-origin.** The export and COG
+  download routes now answer CORS preflights and carry Access-Control
+  headers: anonymous requests get the wildcard treatment with the range and
+  conditional request headers allowed and `Content-Range`, `Accept-Ranges`,
+  `Content-Length`, `ETag`, and `Content-Disposition` exposed, while origins
+  listed in `CORS_ALLOWED_ORIGINS` keep the API middleware's explicit-origin
+  credentialed policy untouched — the API stays authoritative and the edge
+  only fills the anonymous gap. A browser page on another origin can now
+  point the pmtiles protocol or DuckDB-WASM straight at a live export URL
+  (#1698, #1701).
+
+- **Exported map images derive attribution from MapLibre's live state.** The
+  credit band in saved thumbnails and share images now reads the renderer's
+  own used/usedForTerrain flags rather than approximating them from
+  visibility and zoom, falling back to the previous model when those
+  internals are unreachable. Deduplication and joining now match the
+  on-screen control, and embedded object/embed/iframe/video markup in
+  attribution HTML gets the same accessible-text treatment as images
+  (#1553, #1702).
+
 ## [1.16.0] - 2026-08-27
 
 ### Added
@@ -2797,7 +2844,8 @@ regression-covered fixes:
 - Initial public release of the GeoLens catalog, API, map builder, CLI, SDKs,
   Docker development stack, and public documentation entrypoints.
 
-[Unreleased]: https://github.com/geolens-io/geolens/compare/v1.16.0...HEAD
+[Unreleased]: https://github.com/geolens-io/geolens/compare/v1.16.1...HEAD
+[1.16.1]: https://github.com/geolens-io/geolens/compare/v1.16.0...v1.16.1
 [1.16.0]: https://github.com/geolens-io/geolens/compare/v1.15.1...v1.16.0
 [1.15.1]: https://github.com/geolens-io/geolens/compare/v1.15.0...v1.15.1
 [1.15.0]: https://github.com/geolens-io/geolens/compare/v1.14.2...v1.15.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,15 @@ and releases use semantic versioning.
 
 ### Fixed
 
+- **PMTiles basemaps render again.** The shared tile request transform
+  absolutified every URL that did not start with `http`, and MapLibre runs
+  `transformRequest` before its custom-protocol dispatch, so a `pmtiles://`
+  basemap source became `http://<origin>pmtiles://...` and never reached the
+  protocol handler — every PMTiles basemap added in 1.16.0 failed to render
+  with a "Failed to construct Request" error. Only site-relative paths are
+  absolutified now; scheme-carrying and protocol-relative URLs pass through
+  untouched (#1696).
+
 - **Browsers can consume public exports cross-origin.** The export and COG
   download routes now answer CORS preflights and carry Access-Control
   headers: anonymous requests get the wildcard treatment with the range and

--- a/backend/app/api/main.py
+++ b/backend/app/api/main.py
@@ -747,7 +747,7 @@ _is_production = settings.is_production
 # no metadata to read. We fall back to the current published line so import never
 # crashes. Keep this fallback in lockstep with backend/pyproject.toml — it is one
 # of the sites `make bump` rewrites.
-_FALLBACK_APP_VERSION = "1.16.0"
+_FALLBACK_APP_VERSION = "1.16.1"
 
 
 def _resolve_app_version() -> str:

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -18501,7 +18501,7 @@
     "summary": "PostGIS-native geospatial data catalog with OGC API Features and Records support",
     "termsOfService": "https://github.com/geolens-io/geolens/blob/main/LICENSE",
     "title": "GeoLens API",
-    "version": "1.16.0"
+    "version": "1.16.1"
   },
   "openapi": "3.1.0",
   "paths": {

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geolens-backend"
-version = "1.16.0"
+version = "1.16.1"
 description = "PostGIS-native GIS data catalog"
 # Docker image (Dockerfile) ships python:3.14-slim (see the Dockerfile FROM for
 # the exact patch pin) as the project's tested runtime.

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -838,7 +838,7 @@ wheels = [
 
 [[package]]
 name = "geolens-backend"
-version = "1.16.0"
+version = "1.16.1"
 source = { virtual = "." }
 dependencies = [
     { name = "alembic" },

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "geolens-cli"
-version = "1.16.0"
+version = "1.16.1"
 description = "Apache-2.0 command-line interface for the GeoLens API. Login, scan, publish, and export STAC against any GeoLens instance."
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/docs-contract.json
+++ b/docs-contract.json
@@ -1,6 +1,6 @@
 {
   "_comment": "Canonical cross-surface facts for the GeoLens README, marketing site (getgeolens.com/src), and docs site (getgeolens.com/docs). Validated against scripts/install.sh + backend/pyproject.toml by scripts/check_docs_contract.py (geolens CI). The getgeolens.com repo vendors a copy and enforces the same `forbidden` list in its own CI. See docs-internal/DOC-CONSISTENCY-STRATEGY for the full design. Edit a fact ONCE here (and in its canonical source) — the gates make every surface follow.",
-  "version": "1.16.0",
+  "version": "1.16.1",
   "install": {
     "oneLiner": "curl -fsSL https://getgeolens.com/install.sh | sh",
     "sourceBuild": "bash scripts/install.sh",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "1.16.0",
+  "version": "1.16.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "1.16.0",
+      "version": "1.16.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.16.0",
+  "version": "1.16.1",
   "type": "module",
   "license": "Apache-2.0",
   "author": "Carto Concepts, LLC",

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "geolens-mcp"
-version = "1.16.0"
+version = "1.16.1"
 description = "Apache-2.0 read-only Model Context Protocol (MCP) server for GeoLens. Lets coding agents discover datasets, inspect schemas, and ask spatial questions against any GeoLens instance."
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/mcp/server.json
+++ b/mcp/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.geolens-io/geolens",
   "title": "GeoLens",
   "description": "Read-only access to a self-hosted GeoLens spatial catalog: datasets, features, maps, sandboxed SQL.",
-  "version": "1.16.0",
+  "version": "1.16.1",
   "websiteUrl": "https://docs.getgeolens.com/",
   "repository": {
     "url": "https://github.com/geolens-io/geolens",
@@ -14,7 +14,7 @@
     {
       "registryType": "pypi",
       "identifier": "geolens-mcp",
-      "version": "1.16.0",
+      "version": "1.16.1",
       "transport": {
         "type": "stdio"
       },

--- a/mcp/uv.lock
+++ b/mcp/uv.lock
@@ -225,7 +225,7 @@ wheels = [
 
 [[package]]
 name = "geolens"
-version = "1.16.0"
+version = "1.16.1"
 source = { editable = "../sdks/python" }
 dependencies = [
     { name = "attrs" },
@@ -244,7 +244,7 @@ requires-dist = [
 
 [[package]]
 name = "geolens-mcp"
-version = "1.16.0"
+version = "1.16.1"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "geolens",
-  "version": "1.16.0",
+  "version": "1.16.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "geolens",
-      "version": "1.16.0",
+      "version": "1.16.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@axe-core/playwright": "^4.13.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geolens",
-  "version": "1.16.0",
+  "version": "1.16.1",
   "private": true,
   "license": "Apache-2.0",
   "author": "Carto Concepts, LLC",

--- a/sdks/python/.openapi-python-client.yaml
+++ b/sdks/python/.openapi-python-client.yaml
@@ -4,7 +4,7 @@ project_name_override: geolens
 package_name_override: geolens
 # Rewritten on every `make sdks` run by scripts/sync_sdk_versions.py to match
 # backend/openapi.json info.version. Do not edit by hand.
-package_version_override: 1.16.0
+package_version_override: 1.16.1
 
 # Cleaner enum output (matches our pydantic v2 backend's enum emission).
 literal_enums: true

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "geolens"
-version = "1.16.0"
+version = "1.16.1"
 description = "Auto-generated Python SDK for the GeoLens API. Typed clients with Bearer + API-key auth helpers."
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/sdks/typescript/package-lock.json
+++ b/sdks/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@geolens/sdk",
-  "version": "1.16.0",
+  "version": "1.16.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@geolens/sdk",
-      "version": "1.16.0",
+      "version": "1.16.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@hey-api/client-fetch": "0.13.1"

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geolens/sdk",
-  "version": "1.16.0",
+  "version": "1.16.1",
   "description": "Auto-generated TypeScript SDK for the GeoLens API. Typed clients with Bearer + API-key auth helpers.",
   "license": "Apache-2.0",
   "author": "Carto Concepts, LLC",


### PR DESCRIPTION
Version bump 1.16.0 → 1.16.1 across all 21 version sites (`make bump`), plus the CHANGELOG section for the release.

Contents of v1.16.1:

- #1704 — `restrict_public_visibility` instance setting (#1691): one shared server-side gate across all nine visibility-writing surfaces, structural test, UI treatment for non-admins.
- #1701 — CORS on the export/COG byte routes (#1698): anonymous wildcard with preflight + exposed range headers at the edge; configured origins keep the middleware's credentialed policy.
- #1703 — STAC origin assets (#1692): by-reference imports persist and re-serve the source COG asset; refresh doubles as the idempotent backfill.
- #1702 — export attribution parity (#1553): credit band driven by MapLibre's live used/usedForTerrain state with fallback, dedupe aligned with the on-screen control.

Verification: `make version-check` — all 21 sites agree on 1.16.1, changelog section present. No schema or API changes beyond the version stamps; the four feature PRs above carried their own gates.

https://claude.ai/code/session_01BXUUv3x71zWaLKEvoL4cTY