### PR TITLE
fix(ci): trigger published-package verification off the release workflow

### DIFF
--- a/.github/workflows/verify-published.yml
+++ b/.github/workflows/verify-published.yml
@@ -369,14 +369,26 @@ jobs:
                 echo "::warning::could not resolve a semver tag for commit ${SHA}; falling back to VERIFY_VERSION=latest, which under-verifies a prerelease"
               else
                 # Resolve deterministically via the releases API instead of
-                # guessing from tag semantics. The hollow-run check above
-                # already proved this run's "Create GitHub Release" job
-                # succeeded, so by construction it just created or updated
-                # exactly ONE release among these matched tags — that
-                # release is the newest one by created_at. This handles
-                # RC->GA promotion (the GA release is newest) AND an
-                # rc-recut (rc.2's release is newest) with no assumption
-                # about which case produced the ambiguity.
+                # guessing from tag semantics: look up each matched tag's
+                # release and take the one with the newest created_at. In
+                # the ordinary case that IS the release this run's own
+                # trigger chain just created or updated — true for both an
+                # RC->GA promotion (GA release is newest) and an rc-recut
+                # (rc.2's release is newest) — with no assumption about
+                # which case produced the ambiguity.
+                #
+                # One exotic case where it picks a DIFFERENT matched tag:
+                # a manual rerun of an OLDER tag's Release run, on a commit
+                # that has since gained a newer released sibling. `gh
+                # release edit` (release.yml's rerun-onto-an-existing-
+                # release path) never changes created_at, so the older
+                # tag's release stays older and the newer sibling still
+                # wins here. That's fine, not a miss: the older tag already
+                # got its own correct verification cycle when IT was the
+                # newest match, and re-checking one specific superseded tag
+                # on demand is what manual `workflow_dispatch -f
+                # version=vX.Y.Z` is for (it bypasses this resolution
+                # entirely) — not a job for the automatic trigger path.
                 #
                 # Looked up per-candidate (releases/tags/{tag}) rather than
                 # listing+filtering the full releases collection: there are
@@ -401,7 +413,7 @@ jobs:
                 done <<< "${MATCHES}"
                 if [ -n "${NEWEST_TAG}" ]; then
                   TAG="${NEWEST_TAG}"
-                  echo "::notice::commit ${SHA} matches ${MATCH_COUNT} semver tags ($(printf '%s' "${MATCHES}" | tr '\n' ' ')); resolved via the releases API to the newest-created release: ${TAG} (created ${NEWEST_CREATED})"
+                  echo "::notice::commit ${SHA} matches ${MATCH_COUNT} semver tags ($(printf '%s' "${MATCHES}" | tr '\n' ' ')); resolved to the newest release among the matched tags: ${TAG} (created ${NEWEST_CREATED})"
                   echo "resolved_version=${TAG}" >> "$GITHUB_OUTPUT"
                 else
                   echo "::warning::commit ${SHA} matches ${MATCH_COUNT} semver tags ($(printf '%s' "${MATCHES}" | tr '\n' ' ')) but none has a GitHub Release yet (unexpected — the release job just succeeded); falling back to VERIFY_VERSION=latest"
@@ -535,14 +547,26 @@ jobs:
                 echo "::warning::could not resolve a semver tag for commit ${SHA}; falling back to VERIFY_VERSION=latest, which under-verifies a prerelease"
               else
                 # Resolve deterministically via the releases API instead of
-                # guessing from tag semantics. The hollow-run check above
-                # already proved this run's "Create GitHub Release" job
-                # succeeded, so by construction it just created or updated
-                # exactly ONE release among these matched tags — that
-                # release is the newest one by created_at. This handles
-                # RC->GA promotion (the GA release is newest) AND an
-                # rc-recut (rc.2's release is newest) with no assumption
-                # about which case produced the ambiguity.
+                # guessing from tag semantics: look up each matched tag's
+                # release and take the one with the newest created_at. In
+                # the ordinary case that IS the release this run's own
+                # trigger chain just created or updated — true for both an
+                # RC->GA promotion (GA release is newest) and an rc-recut
+                # (rc.2's release is newest) — with no assumption about
+                # which case produced the ambiguity.
+                #
+                # One exotic case where it picks a DIFFERENT matched tag:
+                # a manual rerun of an OLDER tag's Release run, on a commit
+                # that has since gained a newer released sibling. `gh
+                # release edit` (release.yml's rerun-onto-an-existing-
+                # release path) never changes created_at, so the older
+                # tag's release stays older and the newer sibling still
+                # wins here. That's fine, not a miss: the older tag already
+                # got its own correct verification cycle when IT was the
+                # newest match, and re-checking one specific superseded tag
+                # on demand is what manual `workflow_dispatch -f
+                # version=vX.Y.Z` is for (it bypasses this resolution
+                # entirely) — not a job for the automatic trigger path.
                 #
                 # Looked up per-candidate (releases/tags/{tag}) rather than
                 # listing+filtering the full releases collection: there are
@@ -567,7 +591,7 @@ jobs:
                 done <<< "${MATCHES}"
                 if [ -n "${NEWEST_TAG}" ]; then
                   TAG="${NEWEST_TAG}"
-                  echo "::notice::commit ${SHA} matches ${MATCH_COUNT} semver tags ($(printf '%s' "${MATCHES}" | tr '\n' ' ')); resolved via the releases API to the newest-created release: ${TAG} (created ${NEWEST_CREATED})"
+                  echo "::notice::commit ${SHA} matches ${MATCH_COUNT} semver tags ($(printf '%s' "${MATCHES}" | tr '\n' ' ')); resolved to the newest release among the matched tags: ${TAG} (created ${NEWEST_CREATED})"
                   echo "resolved_version=${TAG}" >> "$GITHUB_OUTPUT"
                 else
                   echo "::warning::commit ${SHA} matches ${MATCH_COUNT} semver tags ($(printf '%s' "${MATCHES}" | tr '\n' ' ')) but none has a GitHub Release yet (unexpected — the release job just succeeded); falling back to VERIFY_VERSION=latest"

--- a/.github/workflows/verify-published.yml
+++ b/.github/workflows/verify-published.yml
@@ -343,13 +343,35 @@ jobs:
               # release.yml's own "Assert semver-shaped tag" step is: a
               # 4-digit GSD milestone tag could in principle share a commit
               # with a real release.
-              TAG=$(gh api "repos/${REPOSITORY}/tags" --paginate \
+              MATCHES=$(gh api "repos/${REPOSITORY}/tags" --paginate \
                 --jq ".[] | select(.commit.sha == \"${SHA}\") | .name" \
-                | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$' | head -1) || true
-              if [ -n "${TAG}" ]; then
+                | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$') || true
+              MATCH_COUNT=$(printf '%s\n' "${MATCHES}" | grep -c . || true)
+              # A commit can carry MORE THAN ONE semver tag: promoting an
+              # unchanged release candidate straight to GA (no new commit)
+              # tags the SAME sha as both `v1.17.0-rc.1` and `v1.17.0`, and
+              # `head -1` on the raw match list would arbitrarily pick
+              # whichever the tags API happened to list first — silently
+              # verifying the wrong one instead of failing loudly. Only
+              # trust the resolution when it's unambiguous (exactly one
+              # match); 0 or >1 falls back to VERIFY_VERSION=latest, same as
+              # a failed resolution already did. That fallback is exactly
+              # right for the >1 case specifically: the only realistic way
+              # to get here is an RC->GA promotion, and this Release-
+              # triggered run fires immediately after `gh release create`
+              # made the GA the newest release, so 'latest' resolves to
+              # precisely the release that was just promoted, by
+              # construction — no guessing needed. The earlier RC-only
+              # verify (back when this commit had just the one prerelease
+              # tag) already resolved and checked the RC correctly, so nothing
+              # is lost by falling back here.
+              if [ "${MATCH_COUNT}" -eq 1 ]; then
+                TAG="${MATCHES}"
                 echo "resolved_version=${TAG}" >> "$GITHUB_OUTPUT"
-              else
+              elif [ "${MATCH_COUNT}" -eq 0 ]; then
                 echo "::warning::could not resolve a semver tag for commit ${SHA}; falling back to VERIFY_VERSION=latest, which under-verifies a prerelease"
+              else
+                echo "::notice::commit ${SHA} matches ${MATCH_COUNT} semver tags ($(printf '%s' "${MATCHES}" | tr '\n' ' ')); ambiguous (expected from an RC promoted unchanged to GA) — falling back to VERIFY_VERSION=latest, which resolves to the GA release this run just created"
               fi
               echo "hollow=false" >> "$GITHUB_OUTPUT"
             else
@@ -453,13 +475,35 @@ jobs:
               # release.yml's own "Assert semver-shaped tag" step is: a
               # 4-digit GSD milestone tag could in principle share a commit
               # with a real release.
-              TAG=$(gh api "repos/${REPOSITORY}/tags" --paginate \
+              MATCHES=$(gh api "repos/${REPOSITORY}/tags" --paginate \
                 --jq ".[] | select(.commit.sha == \"${SHA}\") | .name" \
-                | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$' | head -1) || true
-              if [ -n "${TAG}" ]; then
+                | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$') || true
+              MATCH_COUNT=$(printf '%s\n' "${MATCHES}" | grep -c . || true)
+              # A commit can carry MORE THAN ONE semver tag: promoting an
+              # unchanged release candidate straight to GA (no new commit)
+              # tags the SAME sha as both `v1.17.0-rc.1` and `v1.17.0`, and
+              # `head -1` on the raw match list would arbitrarily pick
+              # whichever the tags API happened to list first — silently
+              # verifying the wrong one instead of failing loudly. Only
+              # trust the resolution when it's unambiguous (exactly one
+              # match); 0 or >1 falls back to VERIFY_VERSION=latest, same as
+              # a failed resolution already did. That fallback is exactly
+              # right for the >1 case specifically: the only realistic way
+              # to get here is an RC->GA promotion, and this Release-
+              # triggered run fires immediately after `gh release create`
+              # made the GA the newest release, so 'latest' resolves to
+              # precisely the release that was just promoted, by
+              # construction — no guessing needed. The earlier RC-only
+              # verify (back when this commit had just the one prerelease
+              # tag) already resolved and checked the RC correctly, so nothing
+              # is lost by falling back here.
+              if [ "${MATCH_COUNT}" -eq 1 ]; then
+                TAG="${MATCHES}"
                 echo "resolved_version=${TAG}" >> "$GITHUB_OUTPUT"
-              else
+              elif [ "${MATCH_COUNT}" -eq 0 ]; then
                 echo "::warning::could not resolve a semver tag for commit ${SHA}; falling back to VERIFY_VERSION=latest, which under-verifies a prerelease"
+              else
+                echo "::notice::commit ${SHA} matches ${MATCH_COUNT} semver tags ($(printf '%s' "${MATCHES}" | tr '\n' ' ')); ambiguous (expected from an RC promoted unchanged to GA) — falling back to VERIFY_VERSION=latest, which resolves to the GA release this run just created"
               fi
               echo "hollow=false" >> "$GITHUB_OUTPUT"
             else

--- a/.github/workflows/verify-published.yml
+++ b/.github/workflows/verify-published.yml
@@ -399,19 +399,37 @@ jobs:
                 # the true global newest.
                 NEWEST_TAG=""
                 NEWEST_CREATED=""
+                LOOKUP_FAILED=""
                 while IFS= read -r CANDIDATE; do
                   [ -z "${CANDIDATE}" ] && continue
-                  # `|| continue` (not `|| true`): a lookup failure for one
-                  # candidate — e.g. its release hasn't propagated yet —
-                  # skips that candidate under bash -e instead of aborting
-                  # the whole loop.
-                  CREATED=$(gh api "repos/${REPOSITORY}/releases/tags/${CANDIDATE}" --jq '.created_at' 2>/dev/null) || continue
+                  # A candidate whose lookup fails is FLAGGED, never
+                  # silently skipped: selecting the newest among only the
+                  # tags that happened to resolve, while one candidate's
+                  # real status is unknown, is exactly the partial-data
+                  # selection this whole resolution exists to avoid (a
+                  # transient failure on the true-newest candidate would
+                  # verify its OLDER sibling green instead of falling back
+                  # loudly). One immediate retry first, since a transient
+                  # API hiccup shouldn't discard an otherwise-resolvable
+                  # selection over a single blip.
+                  if ! CREATED=$(gh api "repos/${REPOSITORY}/releases/tags/${CANDIDATE}" --jq '.created_at' 2>/dev/null); then
+                    if ! CREATED=$(gh api "repos/${REPOSITORY}/releases/tags/${CANDIDATE}" --jq '.created_at' 2>/dev/null); then
+                      LOOKUP_FAILED="${LOOKUP_FAILED}${LOOKUP_FAILED:+ }${CANDIDATE}"
+                      continue
+                    fi
+                  fi
                   if [ -z "${NEWEST_CREATED}" ] || [ "${CREATED}" \> "${NEWEST_CREATED}" ]; then
                     NEWEST_CREATED="${CREATED}"
                     NEWEST_TAG="${CANDIDATE}"
                   fi
                 done <<< "${MATCHES}"
-                if [ -n "${NEWEST_TAG}" ]; then
+                if [ -n "${LOOKUP_FAILED}" ]; then
+                  # Discard the partial selection entirely rather than
+                  # trusting NEWEST_TAG computed from incomplete data —
+                  # even if it's set, one candidate's real created_at was
+                  # never confirmed, so the "newest" claim can't be trusted.
+                  echo "::warning::could not confirm every matched tag's release for commit ${SHA} (lookup failed twice for: ${LOOKUP_FAILED}); refusing to select from a partial result — falling back to VERIFY_VERSION=latest"
+                elif [ -n "${NEWEST_TAG}" ]; then
                   TAG="${NEWEST_TAG}"
                   echo "::notice::commit ${SHA} matches ${MATCH_COUNT} semver tags ($(printf '%s' "${MATCHES}" | tr '\n' ' ')); resolved to the newest release among the matched tags: ${TAG} (created ${NEWEST_CREATED})"
                   echo "resolved_version=${TAG}" >> "$GITHUB_OUTPUT"
@@ -577,19 +595,37 @@ jobs:
                 # the true global newest.
                 NEWEST_TAG=""
                 NEWEST_CREATED=""
+                LOOKUP_FAILED=""
                 while IFS= read -r CANDIDATE; do
                   [ -z "${CANDIDATE}" ] && continue
-                  # `|| continue` (not `|| true`): a lookup failure for one
-                  # candidate — e.g. its release hasn't propagated yet —
-                  # skips that candidate under bash -e instead of aborting
-                  # the whole loop.
-                  CREATED=$(gh api "repos/${REPOSITORY}/releases/tags/${CANDIDATE}" --jq '.created_at' 2>/dev/null) || continue
+                  # A candidate whose lookup fails is FLAGGED, never
+                  # silently skipped: selecting the newest among only the
+                  # tags that happened to resolve, while one candidate's
+                  # real status is unknown, is exactly the partial-data
+                  # selection this whole resolution exists to avoid (a
+                  # transient failure on the true-newest candidate would
+                  # verify its OLDER sibling green instead of falling back
+                  # loudly). One immediate retry first, since a transient
+                  # API hiccup shouldn't discard an otherwise-resolvable
+                  # selection over a single blip.
+                  if ! CREATED=$(gh api "repos/${REPOSITORY}/releases/tags/${CANDIDATE}" --jq '.created_at' 2>/dev/null); then
+                    if ! CREATED=$(gh api "repos/${REPOSITORY}/releases/tags/${CANDIDATE}" --jq '.created_at' 2>/dev/null); then
+                      LOOKUP_FAILED="${LOOKUP_FAILED}${LOOKUP_FAILED:+ }${CANDIDATE}"
+                      continue
+                    fi
+                  fi
                   if [ -z "${NEWEST_CREATED}" ] || [ "${CREATED}" \> "${NEWEST_CREATED}" ]; then
                     NEWEST_CREATED="${CREATED}"
                     NEWEST_TAG="${CANDIDATE}"
                   fi
                 done <<< "${MATCHES}"
-                if [ -n "${NEWEST_TAG}" ]; then
+                if [ -n "${LOOKUP_FAILED}" ]; then
+                  # Discard the partial selection entirely rather than
+                  # trusting NEWEST_TAG computed from incomplete data —
+                  # even if it's set, one candidate's real created_at was
+                  # never confirmed, so the "newest" claim can't be trusted.
+                  echo "::warning::could not confirm every matched tag's release for commit ${SHA} (lookup failed twice for: ${LOOKUP_FAILED}); refusing to select from a partial result — falling back to VERIFY_VERSION=latest"
+                elif [ -n "${NEWEST_TAG}" ]; then
                   TAG="${NEWEST_TAG}"
                   echo "::notice::commit ${SHA} matches ${MATCH_COUNT} semver tags ($(printf '%s' "${MATCHES}" | tr '\n' ' ')); resolved to the newest release among the matched tags: ${TAG} (created ${NEWEST_CREATED})"
                   echo "resolved_version=${TAG}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/verify-published.yml
+++ b/.github/workflows/verify-published.yml
@@ -98,12 +98,12 @@ on:
   # the publishes wait on a human approval click, Release waits on the
   # ~40-minute Prod Compose Smoke — so the concurrency group below queues
   # duplicate triggers for the same version behind the in-flight verify
-  # (never cancelling it). A Release-triggered run lands in its own
-  # `verify-published-main` group (see VERIFY_VERSION below) and runs
-  # independently of the per-version group; that's fine. Each job's `if:`
-  # (in `jobs:` below) additionally restricts it to the one trigger source
-  # that can actually satisfy it, so a publish-triggered run only exercises
-  # the two package-registry jobs and a Release-triggered run only exercises
+  # (never cancelling it). A Release-triggered run gets its own per-commit
+  # group (see the concurrency block below), separate from the per-tag group
+  # publish-triggered runs use. Each job's `if:` (in `jobs:` below)
+  # additionally restricts it to the one trigger source that can actually
+  # satisfy it, so a publish-triggered run only exercises the two
+  # package-registry jobs and a Release-triggered run only exercises
   # "Verify GHCR images"/"Verify GitHub Release" — neither pair ever polls
   # for an artifact its own trigger hasn't produced.
   workflow_run:
@@ -130,14 +130,32 @@ permissions:
 # A run triggered by Release's completion reports its OWN head_branch as the
 # default branch ("main"), not the tag — that's how GitHub represents any
 # workflow_run-triggered run, since the triggered workflow's file is always
-# read from the default branch. Such a run lands in a fixed
-# `verify-published-main` group instead of the tag's group; VERIFY_VERSION
-# below falls back to 'latest' for it. `latest` is only a LAST-RESORT
-# fallback for the two Release-gated jobs though — each resolves the exact
-# tag itself from head_sha (see their guard step) precisely because 'latest'
-# would silently under-verify a prerelease. See that step's comment.
+# read from the default branch. Grouping those runs by head_branch alone (as
+# an earlier version of this file did) would put EVERY release's
+# Release-triggered run in one shared `verify-published-main` group — and
+# because GitHub keeps only the newest PENDING run per group, an overlapping
+# Release completion for a DIFFERENT tag (including a hollow one from a
+# failed/manual smoke, which the guard step below makes harmless to run but
+# which still occupies a concurrency slot) could evict a still-pending
+# verification for an unrelated release, leaving its GHCR/Release checks
+# never run. So a Release-triggered run's group key instead uses
+# `github.event.workflow_run.head_sha` — proven elsewhere in this file to be
+# the exact tagged commit even on a Release-triggered run, unlike
+# head_branch — giving each release (or each distinct commit a hollow run
+# happens to be about) its own group: duplicate Release completions for the
+# SAME tag still dedupe/queue together as intended, and completions for
+# DIFFERENT tags can no longer evict one another. Publish-triggered runs are
+# untouched: `github.event.workflow.name == 'Release'` is false for them, so
+# the `&&` short-circuits to that same falsy value and the `||` chain falls
+# through to head_branch exactly as before — the three publishes for one tag
+# still land in one `verify-published-vX.Y.Z` group. VERIFY_VERSION below
+# still falls back to 'latest' for a Release-triggered run needing it, but
+# that's only a LAST-RESORT fallback for the two Release-gated jobs: each
+# resolves the exact tag itself from head_sha (see their guard step)
+# precisely because 'latest' would silently under-verify a prerelease. See
+# that step's comment.
 concurrency:
-  group: verify-published-${{ inputs.version || github.event.workflow_run.head_branch || github.run_id }}
+  group: verify-published-${{ inputs.version || (github.event.workflow.name == 'Release' && github.event.workflow_run.head_sha) || github.event.workflow_run.head_branch || github.run_id }}
   cancel-in-progress: false
 
 env:

--- a/.github/workflows/verify-published.yml
+++ b/.github/workflows/verify-published.yml
@@ -15,10 +15,23 @@
 # landed while the ~40-minute compose-boot-and-E2E smoke was still running:
 # both checks burned their full 5-minute retry window twice in a row and went
 # red roughly 2 minutes before Release actually finished, needing a manual
-# rerun every time. Triggering off "Release" too closes this by construction —
-# Release only fires after Prod Compose Smoke has already pulled the GHCR
-# images and the release job has already created the release, so a
-# Release-triggered run of this workflow can never lose that race.
+# rerun every time.
+#
+# Adding "Release" as a trigger alone would only add a green run alongside the
+# still-guaranteed-red publish-triggered ones — the approval click routinely
+# lands well inside the ~40-minute smoke, so those two jobs would still poll
+# for an artifact their own trigger can never produce. Each job's `if:` (see
+# `jobs:` below) fixes that by also restricting it to the one trigger source
+# that can actually satisfy it: a publish-triggered auto-run skips "Verify
+# GHCR images"/"Verify GitHub Release" entirely, and a Release-triggered
+# auto-run skips the two package-registry jobs. Release only fires after Prod
+# Compose Smoke has already pulled the GHCR images and the release job has
+# already created the release; the three publishes are the only source of the
+# PyPI/npm packages the other two jobs check. So the failure mode is
+# structurally impossible in both directions — including a slow publish
+# approval that lands AFTER Release, since the eventual publish-triggered run
+# still verifies the registries once they exist, same as always. Manual
+# dispatch is unaffected and still runs all four jobs.
 #
 # Manual usage:
 #   gh workflow run verify-published.yml -f version=vX.Y.Z
@@ -47,9 +60,12 @@ on:
   # duplicate triggers for the same version behind the in-flight verify
   # (never cancelling it). A Release-triggered run lands in its own
   # `verify-published-main` group (see VERIFY_VERSION below) and runs
-  # independently of the per-version group; that's fine; it exists
-  # specifically to catch the GHCR/Release checks a publish-triggered run can
-  # miss while Prod Compose Smoke is still boot-testing the tag.
+  # independently of the per-version group; that's fine. Each job's `if:`
+  # (in `jobs:` below) additionally restricts it to the one trigger source
+  # that can actually satisfy it, so a publish-triggered run only exercises
+  # the two package-registry jobs and a Release-triggered run only exercises
+  # "Verify GHCR images"/"Verify GitHub Release" — neither pair ever polls
+  # for an artifact its own trigger hasn't produced.
   workflow_run:
     workflows: ["Publish SDKs", "Publish CLI", "Publish MCP Server", "Release"]
     types: [completed]
@@ -95,8 +111,21 @@ env:
 
 jobs:
   verify-python:
-    # Manual dispatch always runs; an auto-trigger only runs if the publish succeeded.
-    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
+    # Manual dispatch always runs. An auto-trigger runs only for a successful
+    # PUBLISH completion (Publish SDKs/CLI/MCP) — never for Release — since
+    # only the publishes produce the PyPI package this job verifies; a
+    # Release-triggered run couldn't tell us anything new here.
+    #
+    # Uses github.event.workflow.name (the triggering run's static Workflow
+    # resource, i.e. the workflow's `name:`) rather than
+    # github.event.workflow_run.name: GitHub repoints the latter to the run's
+    # `run-name`/display title once the run has completed
+    # (actions/runner#4141), so it stops equalling the workflow's declared
+    # name the moment anyone adds a `run-name:` to one of these four upstream
+    # workflows. None of them set one today, but `workflow.name` is immune to
+    # that regardless, so prefer it here rather than relying on it staying
+    # that way.
+    if: ${{ github.event_name != 'workflow_run' || (github.event.workflow_run.conclusion == 'success' && github.event.workflow.name != 'Release') }}
     name: Verify Python packages on python:3.13-slim
     runs-on: ubuntu-latest
     steps:
@@ -144,7 +173,10 @@ jobs:
           done
 
   verify-typescript:
-    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
+    # Same routing as verify-python — npm is populated by the publishes, not
+    # by Release. See verify-python's comment for the github.event.workflow.name
+    # (vs .workflow_run.name) rationale.
+    if: ${{ github.event_name != 'workflow_run' || (github.event.workflow_run.conclusion == 'success' && github.event.workflow.name != 'Release') }}
     name: Verify TypeScript package on node:22-slim
     runs-on: ubuntu-latest
     steps:
@@ -183,7 +215,12 @@ jobs:
           done
 
   verify-ghcr:
-    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
+    # Mirror image of verify-python: this job only exists to confirm an
+    # artifact that ONLY a completed Release guarantees is pullable, so an
+    # auto-trigger runs only for a successful Release completion — never for
+    # a publish, which says nothing about whether the images have landed. See
+    # verify-python's comment for the github.event.workflow.name rationale.
+    if: ${{ github.event_name != 'workflow_run' || (github.event.workflow_run.conclusion == 'success' && github.event.workflow.name == 'Release') }}
     name: Verify GHCR images
     runs-on: ubuntu-latest
     steps:
@@ -222,7 +259,9 @@ jobs:
           done
 
   verify-github-release:
-    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
+    # Same routing as verify-ghcr — Release-only (or manual dispatch); see
+    # verify-python's comment for the github.event.workflow.name rationale.
+    if: ${{ github.event_name != 'workflow_run' || (github.event.workflow_run.conclusion == 'success' && github.event.workflow.name == 'Release') }}
     name: Verify GitHub Release
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/verify-published.yml
+++ b/.github/workflows/verify-published.yml
@@ -7,71 +7,39 @@
 # downstream user gets. Each check polls with a bounded retry to absorb
 # registry/CDN propagation lag.
 #
-# The "Verify GitHub Release" and "Verify GHCR images" jobs used to race the
-# Release workflow: this workflow triggered only off the package publishes
-# (Publish SDKs/CLI/MCP), which pause for a human approval click and finish on
-# their own schedule, independent of the "Prod Compose Smoke" -> "Release"
-# chain that actually creates the GitHub Release. On v1.16.0 the approvals
-# landed while the ~40-minute compose-boot-and-E2E smoke was still running:
-# both checks burned their full 5-minute retry window twice in a row and went
-# red roughly 2 minutes before Release actually finished, needing a manual
-# rerun every time.
+# fix(#1707): each job's `if:` (see `jobs:` below) restricts it to the one
+# trigger source that can satisfy it — a publish-triggered run only checks
+# PyPI/npm, a Release-triggered run only checks GHCR/GitHub Release — so
+# neither pair polls for an artifact its own trigger can't produce. Release
+# only fires after Prod Compose Smoke has pulled the GHCR images and the
+# release job has created the release; the publishes are the only source of
+# the PyPI/npm packages the other two jobs check.
 #
-# Adding "Release" as a trigger alone would only add a green run alongside the
-# still-guaranteed-red publish-triggered ones — the approval click routinely
-# lands well inside the ~40-minute smoke, so those two jobs would still poll
-# for an artifact their own trigger can never produce. Each job's `if:` (see
-# `jobs:` below) fixes that by also restricting it to the one trigger source
-# that can actually satisfy it: a publish-triggered auto-run skips "Verify
-# GHCR images"/"Verify GitHub Release" entirely, and a Release-triggered
-# auto-run skips the two package-registry jobs. Release only fires after Prod
-# Compose Smoke has already pulled the GHCR images and the release job has
-# already created the release; the three publishes are the only source of the
-# PyPI/npm packages the other two jobs check. So the failure mode is
-# structurally impossible in both directions — including a slow publish
-# approval that lands AFTER Release, since the eventual publish-triggered run
-# still verifies the registries once they exist, same as always. Manual
-# dispatch is unaffected and still runs all four jobs.
-#
-# One more wrinkle: "Release" firing is necessary but not sufficient proof
-# that a release exists. release.yml's own workflow_run trigger listens on
-# `types: [completed]`, which fires on FAILURE too, and it gates the actual
-# release-creation job only at the JOB level
+# fix(#1707): "Release" firing is not sufficient proof a release exists.
+# release.yml's workflow_run trigger fires on FAILURE too (`types:
+# [completed]`), and gates the release-creation job only at the JOB level
 # (`conclusion == 'success' && startsWith(head_branch, 'v')`) — a run whose
-# sole job SKIPPED (a failed Prod Compose Smoke, or a manual smoke of
-# `latest`/a branch) still CONCLUDES 'success' as a *workflow*, because an
-# all-skipped run is reported as successful. Left unguarded, that hollow
-# Release run would still trigger this workflow, VERIFY_VERSION would still
-# resolve to 'latest', and "Verify GHCR images"/"Verify GitHub Release" would
-# pass against the PREVIOUS release — a misleading green sitting right after
-# a failed or irrelevant smoke. Each of those two jobs' first step guards
-# against this by querying the triggering run's own jobs and confirming
-# "Create GitHub Release" actually concluded success; on a hollow run it logs
-# an `::notice::` and skips the real check WITHOUT failing the job — the
-# smoke failure is already the loud red signal, and this workflow going red
-# too would only be noise.
+# sole job SKIPPED (failed Prod Compose Smoke, or a manual smoke of
+# `latest`/a branch) still CONCLUDES 'success' as a workflow. Each of
+# verify-ghcr/verify-github-release's guard step confirms "Create GitHub
+# Release" actually succeeded before trusting the trigger; on a hollow run it
+# logs an `::notice::` and skips the real check without failing the job.
 #
-# (Considered switching Release's trigger to `release: types: [published]`
-# instead of workflow_run, which would sidestep the hollow-run problem
-# entirely and hand us the real tag via github.event.release.tag_name instead
-# of 'latest'. Ruled out: release.yml creates/edits the release using the
-# default `secrets.GITHUB_TOKEN` in every `gh release`/`gh api` call, and
-# GitHub does not fire downstream workflow triggers off events created by the
-# default GITHUB_TOKEN — that's the trigger-loop guard, and it would make a
-# `release: published` trigger here simply never fire. Revisit if release.yml
-# ever switches that step to a PAT or GitHub App token.)
+# fix(#1707): considered `release: types: [published]` instead of
+# workflow_run, which would avoid the hollow-run problem and give the real
+# tag via github.event.release.tag_name directly. Ruled out: release.yml
+# creates/edits releases with the default `secrets.GITHUB_TOKEN`, and GitHub
+# does not fire workflow triggers off events created by that token, so this
+# trigger would never fire here. Revisit if release.yml switches that step
+# to a PAT or GitHub App token.
 #
-# A related trap the naive fallback would have hit: 'latest' only ever means
-# the newest GA. publish.yml never re-tags GHCR `:latest` for a `-rc`/
-# prerelease suffix, and GitHub's own "latest release" concept explicitly
-# skips prereleases too — so a Release-triggered run for a *prerelease* tag
-# (this pipeline supports them end to end: Prod Compose Smoke, Release, and
-# publish.yml's tag matching all explicitly handle `-rc`/prerelease suffixes)
-# would otherwise silently re-verify the PREVIOUS GA instead of what was just
-# published, passing green without checking anything new. The same guard
-# step that checks for a hollow run also resolves the exact tag from
-# head_sha (reliable even though head_branch isn't — see above) and hands it
-# to the real check in place of 'latest'.
+# fix(#1707): 'latest' only ever means the newest GA — publish.yml never
+# re-tags GHCR `:latest` for a `-rc`/prerelease suffix, and GitHub's own
+# "latest release" concept skips prereleases too. A Release-triggered run
+# for a prerelease tag (this pipeline supports them end to end) would
+# otherwise silently re-verify the previous GA. The guard step resolves the
+# exact tag from head_sha (reliable even though head_branch isn't — see
+# below) instead of relying on VERIFY_VERSION=latest.
 #
 # Manual usage:
 #   gh workflow run verify-published.yml -f version=vX.Y.Z
@@ -127,38 +95,23 @@ permissions:
 # Verifying two different versions concurrently is fine — the group is
 # per-version.
 #
-# A run triggered by Release's completion reports its OWN head_branch as the
-# default branch ("main"), not the tag — that's how GitHub represents any
-# workflow_run-triggered run, since the triggered workflow's file is always
-# read from the default branch. Grouping those runs by head_branch alone (as
-# an earlier version of this file did) would put EVERY release's
-# Release-triggered run in one shared `verify-published-main` group — and
-# because GitHub keeps only the newest PENDING run per group, an overlapping
-# Release completion for a DIFFERENT tag (including a hollow one from a
-# failed/manual smoke, which the guard step below makes harmless to run but
-# which still occupies a concurrency slot) could evict a still-pending
-# verification for an unrelated release, leaving its GHCR/Release checks
-# never run. So a Release-triggered run's group key instead uses
-# `github.event.workflow_run.head_sha` — proven elsewhere in this file to be
-# the exact tagged commit even on a Release-triggered run, unlike
-# head_branch — giving each release (or each distinct commit a hollow run
-# happens to be about) its own group: duplicate Release completions for the
-# SAME tag still dedupe/queue together as intended, and completions for
-# DIFFERENT tags can no longer evict one another. Publish-triggered runs are
-# untouched: `github.event.workflow.name == 'Release'` is false for them, so
-# the `&&` short-circuits to that same falsy value and the `||` chain falls
-# through to head_branch exactly as before — the three publishes for one tag
-# still land in one `verify-published-vX.Y.Z` group. VERIFY_VERSION below
-# still falls back to 'latest' for a Release-triggered run needing it, but
-# that's only a LAST-RESORT fallback for the two Release-gated jobs: each
-# resolves the exact tag itself from head_sha (see their guard step)
-# precisely because 'latest' would silently under-verify a prerelease. See
-# that step's comment.
+# fix(#1707): a run triggered by Release's completion reports its OWN
+# head_branch as the default branch ("main"), not the tag. Keying the group
+# on head_branch would put every Release-triggered run in one shared group,
+# where an overlapping completion for a DIFFERENT tag (including a hollow
+# one) could evict a still-pending verification for an unrelated release.
+# The group instead uses `github.event.workflow_run.head_sha` for a
+# Release-triggered run — the exact tagged commit even though head_branch
+# isn't (see the guard step's comment) — giving each release its own group:
+# same-tag duplicates still dedupe, different tags can't evict each other.
+# Publish-triggered runs are untouched: the `&&` is false for them, so the
+# `||` chain falls through to head_branch exactly as before.
 concurrency:
   group: verify-published-${{ inputs.version || (github.event.workflow.name == 'Release' && github.event.workflow_run.head_sha) || github.event.workflow_run.head_branch || github.run_id }}
   cancel-in-progress: false
 
 env:
+  # fix(#1707): resolution ladder for VERIFY_VERSION.
   # Manual dispatch → the version input. workflow_run after a tag-triggered
   # publish (Publish SDKs/CLI/MCP) → head_branch is the tag (e.g. v1.2.4),
   # used only when it looks like a version tag — exact for both a GA and a
@@ -180,6 +133,7 @@ env:
 
 jobs:
   verify-python:
+    # fix(#1707): routing rule for this job.
     # Manual dispatch always runs. An auto-trigger runs only for a successful
     # PUBLISH completion (Publish SDKs/CLI/MCP) — never for Release — since
     # only the publishes produce the PyPI package this job verifies; a
@@ -304,67 +258,48 @@ jobs:
           SHA: ${{ github.event.workflow_run.head_sha }}
           REPOSITORY: ${{ github.repository }}
         run: |
-          # See the "hollow Release run" note at the top of this file. A
-          # workflow_run trigger only tells us Release CONCLUDED success as a
-          # workflow — not that its "Create GitHub Release" job actually ran,
-          # since an all-skipped run also concludes success. Confirm the real
-          # job ran before trusting anything about this trigger.
+          # fix(#1707): a workflow_run trigger only tells us Release CONCLUDED
+          # success as a workflow — not that its "Create GitHub Release" job
+          # actually ran, since an all-skipped run also concludes success.
+          # Confirm the real job ran before trusting anything about this
+          # trigger.
           #
-          # The `gh api` call is wrapped in an `if` (rather than a bare
-          # `CONCLUSION=$(...)` assignment) so a transient API error can't
-          # kill this step under `bash -e` — that would turn a network blip
-          # into a NEW red check, the opposite of this guard's job. It gets
-          # one immediate retry (the `||` below); if BOTH attempts fail,
-          # this now fails CLOSED into a loud skip (hollow=true + a
-          # distinct ::warning::), not a proceed-with-latest fallback. That
-          # fallback used to be described as "this workflow's behavior
-          # before this guard existed" — that reference point no longer
-          # applies; the guard IS the behavior now, and proceeding against
-          # unconfirmed data (VERIFY_VERSION=latest, with no idea whether
-          # the real release is a GA or a prerelease) is exactly the
-          # fail-open-on-unconfirmed-data class this file already fixed
-          # once, in the tag-resolution loop below.
+          # fix(#1707): the `gh api` call is wrapped in `if` (not a bare
+          # assignment) so a transient error can't kill this step under
+          # `bash -e`. One immediate retry (the `||` below); if both attempts
+          # fail, fail CLOSED into a loud skip (hollow=true + a distinct
+          # ::warning::) rather than proceeding against unconfirmed
+          # VERIFY_VERSION=latest.
           if CONCLUSION=$(gh api "repos/${REPOSITORY}/actions/runs/${RUN_ID}/jobs" \
               --jq '.jobs[] | select(.name == "Create GitHub Release") | .conclusion' 2>&1) \
             || CONCLUSION=$(gh api "repos/${REPOSITORY}/actions/runs/${RUN_ID}/jobs" \
               --jq '.jobs[] | select(.name == "Create GitHub Release") | .conclusion' 2>&1); then
             if [ "${CONCLUSION}" = "success" ]; then
-              # Resolve the exact tag this run released rather than trusting
-              # VERIFY_VERSION=latest: `latest` only ever tracks the newest
-              # GA release/image — publish.yml never re-tags GHCR :latest for
-              # a `-rc`/prerelease suffix (its `type=raw,value=latest` gate),
-              # and GitHub's own "latest release" concept explicitly skips
-              # prereleases. Left as 'latest', a Release-triggered run for a
-              # *prerelease* tag would silently pass by re-verifying the
-              # PREVIOUS GA instead of what this run just published.
-              # head_sha is reliable here even though head_branch isn't (see
-              # the header note) — it's the exact tagged commit, inherited
-              # through the workflow_run chain (Prod Compose Smoke -> Release
-              # -> here); only head_branch gets reset to the default branch.
-              # This is not a theory: the v1.14.1 Release run (created
-              # 2026-08-20T00:24:04Z) reports head_sha 1eb456346..., exactly
-              # `git rev-parse v1.14.1` — even though main's actual tip at
-              # that instant had already moved one commit past it, to
-              # 1e4a3ef4e... (#1615). If head_sha tracked the default
-              # branch's current tip the way head_branch does, this run
-              # would report 1e4a3ef4e; it reports the older tag commit
-              # instead. Filtered to semver-shaped names for the same reason
+              # fix(#1707): resolve the exact tag from head_sha rather than
+              # trusting VERIFY_VERSION=latest — publish.yml never advances
+              # GHCR :latest for a `-rc` suffix and GitHub's "latest release"
+              # skips prereleases, so a prerelease-triggered run would
+              # otherwise re-verify the previous GA.
+              #
+              # fix(#1707): head_sha is reliable here even though head_branch
+              # isn't — head_branch resets to the default branch on any
+              # workflow_run-triggered run, but head_sha is inherited through
+              # the trigger chain. Confirmed against the v1.14.1 Release run
+              # (created 2026-08-20T00:24:04Z): its head_sha (1eb456346...)
+              # is exactly `git rev-parse v1.14.1`, even though main's tip at
+              # that instant had already advanced past it to 1e4a3ef4e...
+              # (#1615). Filtered to semver-shaped names for the same reason
               # release.yml's own "Assert semver-shaped tag" step is: a
-              # 4-digit GSD milestone tag could in principle share a commit
-              # with a real release.
-              # One rule, applied at every query in this branch:
-              # resolution CONFIRMED (a query succeeded and found exactly
-              # what's needed) -> use it. Resolution confirmed ABSENT
-              # (queries succeeded, legitimately zero/no-candidate result)
-              # -> VERIFY_VERSION=latest, the pre-existing best-effort
-              # fallback. Resolution UNCONFIRMED (any query failed even
-              # after one retry) -> the loud skip (hollow=true), never
-              # 'latest' and never a guess from partial data. The tags
-              # query below is retried and its OWN success/failure is
-              # tracked separately from "found zero matches", so an API
-              # failure can no longer masquerade as a legitimately-empty
-              # result and flow into the latest fallback the way `|| true`
-              # on the raw pipeline used to let it.
+              # 4-digit GSD milestone tag could share a commit with a real
+              # release.
+              # fix(#1707): resolution follows one rule everywhere in this
+              # branch — CONFIRMED (query succeeded, found what's needed) ->
+              # use it; ABSENT (query succeeded, legitimately empty) ->
+              # VERIFY_VERSION=latest; UNCONFIRMED (query failed even after
+              # one retry) -> the loud skip, never a guess from partial data.
+              # The tags query's own success/failure is tracked separately
+              # from "found zero matches" so a failed request can't
+              # masquerade as an empty result.
               UNCONFIRMED=false
               if ! RAW_TAGS=$(gh api "repos/${REPOSITORY}/tags" --paginate \
                   --jq ".[] | select(.commit.sha == \"${SHA}\") | .name" 2>&1); then
@@ -377,111 +312,68 @@ jobs:
               if [ "${UNCONFIRMED}" != true ]; then
                 MATCHES=$(printf '%s\n' "${RAW_TAGS}" | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$') || true
                 MATCH_COUNT=$(printf '%s\n' "${MATCHES}" | grep -c . || true)
-                # A commit can carry MORE THAN ONE semver tag: promoting an
-                # unchanged release candidate straight to GA (no new commit)
-                # tags the SAME sha as both `v1.17.0-rc.1` and `v1.17.0`, and
-                # `head -1` on the raw match list would arbitrarily pick
-                # whichever the tags API happened to list first — silently
-                # verifying the wrong one instead of failing loudly. Only
-                # trust the resolution outright when it's unambiguous
-                # (exactly one match). 0 matches is a CONFIRMED-ABSENT
-                # result (the tags query above already succeeded), so it
-                # falls back to VERIFY_VERSION=latest, the pre-existing
-                # best-effort semantics. More than one match is resolved
-                # deterministically below rather than assumed to be an
-                # RC->GA promotion — that assumption doesn't hold for every
-                # ambiguous case: re-cutting `v1.17.0-rc.1` as
-                # `v1.17.0-rc.2` on an unchanged commit also lands here, and
-                # 'latest' would then silently verify the PREVIOUS GA (a
-                # prerelease never advances 'latest').
+                # fix(#1707): a commit can carry more than one semver tag (an RC
+                # promoted unchanged to GA, or one prerelease re-cut as
+                # another, both tag the same commit). Trust the resolution
+                # outright only when unambiguous (exactly one match); 0
+                # matches is CONFIRMED-ABSENT (falls back to latest); more
+                # than one is resolved deterministically below, not assumed
+                # to be any one specific scenario.
                 if [ "${MATCH_COUNT}" -eq 1 ]; then
                   TAG="${MATCHES}"
                   echo "resolved_version=${TAG}" >> "$GITHUB_OUTPUT"
                 elif [ "${MATCH_COUNT}" -eq 0 ]; then
                   echo "::warning::could not resolve a semver tag for commit ${SHA}; falling back to VERIFY_VERSION=latest, which under-verifies a prerelease"
                 else
-                  # Resolve deterministically via the releases API instead of
-                  # guessing from tag semantics: look up each matched tag's
-                  # release and take the one with the newest published_at.
+                  # fix(#1707): tie-break by published_at, not created_at. For a
+                  # release created against an already-tagged commit (exactly
+                  # this ambiguous case), GitHub sets created_at to the
+                  # target COMMIT's date, not the publish moment — confirmed
+                  # against this repo's own releases (v1.16.1, v1.16.0,
+                  # v1.15.1: created_at == tag commit date, published_at ==
+                  # the real gh-release-create moment). Two tags on one
+                  # commit would carry identical created_at, so that
+                  # comparison was never actually deterministic. published_at
+                  # is set once, at the true publish moment.
                   #
-                  # NOT created_at, which an earlier version of this branch
-                  # used: for a release created against an EXISTING tagged
-                  # commit (exactly this ambiguous case — the whole point is
-                  # that both matched tags share one commit), GitHub sets
-                  # created_at to the target COMMIT's date, not the moment
-                  # `gh release create` ran. This repo's own data proves it:
-                  # v1.16.1's release created_at (2026-08-28T18:07:09Z)
-                  # equals its tag commit's date exactly, while published_at
-                  # (18:48:48Z) is the real gh-release-create moment — same
-                  # pattern confirmed on v1.16.0 and v1.15.1. Two tags on the
-                  # SAME commit therefore carry IDENTICAL created_at values,
-                  # the strict `>` comparison below never fires for the
-                  # second one, and the loop silently kept whichever tag the
-                  # tags API happened to list first — not deterministic at
-                  # all for exactly the case this branch exists to handle.
-                  # published_at does not have this problem: it is set once,
-                  # at the actual publish moment, and differs between two
-                  # releases of the same commit exactly when one was
-                  # published later than the other.
+                  # fix(#1707): a manual rerun of an OLDER tag's Release run,
+                  # on a commit that has since gained a newer released
+                  # sibling, resolves to the newer sibling — `gh release
+                  # edit` (release.yml's rerun-onto-an-existing-release path)
+                  # changes neither timestamp. Not a miss: the older tag
+                  # already got its own correct verification cycle when it
+                  # was the newest match; re-checking one specific superseded
+                  # tag on demand is `workflow_dispatch -f version=vX.Y.Z`,
+                  # which bypasses this resolution.
                   #
-                  # In the ordinary case the newest-published release IS the
-                  # release this run's own trigger chain just created or
-                  # updated — true for both an RC->GA promotion (GA release
-                  # is newest) and an rc-recut (rc.2's release is newest) —
-                  # with no assumption about which case produced the
-                  # ambiguity.
-                  #
-                  # One exotic case where it picks a DIFFERENT matched tag:
-                  # a manual rerun of an OLDER tag's Release run, on a commit
-                  # that has since gained a newer released sibling. `gh
-                  # release edit` (release.yml's rerun-onto-an-existing-
-                  # release path) changes neither created_at nor
-                  # published_at, so the older tag's release stays older and
-                  # the newer sibling still wins here — this analysis
-                  # transfers unchanged from the created_at version. That's
-                  # fine, not a miss: the older tag already got its own
-                  # correct verification cycle when IT was the newest match,
-                  # and re-checking one specific superseded tag on demand is
-                  # what manual `workflow_dispatch -f version=vX.Y.Z` is for
-                  # (it bypasses this resolution entirely) — not a job for
-                  # the automatic trigger path.
-                  #
-                  # Looked up per-candidate (releases/tags/{tag}) rather than
-                  # listing+filtering the full releases collection: there are
-                  # only ever a couple of matched tags here, and
-                  # `gh api --paginate` applies --jq PER PAGE, so an aggregate
-                  # sort/max over the whole paginated list would silently
-                  # pick the wrong answer across a page boundary instead of
-                  # the true global newest.
+                  # fix(#1707): looked up per-candidate (releases/tags/{tag})
+                  # rather than listing+filtering the full releases
+                  # collection — gh api --paginate applies --jq PER PAGE, so
+                  # an aggregate sort/max over a paginated list would pick
+                  # the wrong answer across a page boundary.
                   NEWEST_TAG=""
                   NEWEST_PUBLISHED=""
                   LOOKUP_FAILED=""
                   while IFS= read -r CANDIDATE; do
                     [ -z "${CANDIDATE}" ] && continue
-                    # A candidate whose lookup fails is FLAGGED, never
-                    # silently skipped: selecting the newest among only the
-                    # tags that happened to resolve, while one candidate's
-                    # real status is unknown, is exactly the partial-data
-                    # selection this whole resolution exists to avoid (a
-                    # transient failure on the true-newest candidate would
-                    # verify its OLDER sibling green instead of falling back
-                    # loudly). One immediate retry first, since a transient
-                    # API hiccup shouldn't discard an otherwise-resolvable
-                    # selection over a single blip.
+                    # fix(#1707): a candidate whose lookup fails is flagged, never
+                    # silently skipped — selecting the newest among only the
+                    # tags that resolved, while one candidate's real status
+                    # is unknown, is the partial-data selection this
+                    # resolution exists to avoid. One immediate retry first
+                    # for a single transient blip.
                     if ! PUBLISHED=$(gh api "repos/${REPOSITORY}/releases/tags/${CANDIDATE}" --jq '.published_at' 2>/dev/null); then
                       if ! PUBLISHED=$(gh api "repos/${REPOSITORY}/releases/tags/${CANDIDATE}" --jq '.published_at' 2>/dev/null); then
                         LOOKUP_FAILED="${LOOKUP_FAILED}${LOOKUP_FAILED:+ }${CANDIDATE}"
                         continue
                       fi
                     fi
-                    # A draft release has published_at=null (gh api prints
-                    # the literal string "null"); this pipeline never
-                    # creates drafts, so a null here means this candidate is
-                    # confirmed NOT to be the release this trigger chain
-                    # just published. Exclude it from the newest comparison
-                    # without treating the whole resolution as UNCONFIRMED —
-                    # the query itself succeeded, it just isn't a
-                    # candidate.
+                    # fix(#1707): a draft release has published_at=null (gh api
+                    # prints the literal string "null"); this pipeline never
+                    # creates drafts, so null means this candidate is
+                    # confirmed not to be the published release. Excluded
+                    # from the comparison without marking the whole
+                    # resolution UNCONFIRMED — the query itself succeeded.
                     if [ "${PUBLISHED}" = "null" ] || [ -z "${PUBLISHED}" ]; then
                       continue
                     fi
@@ -491,14 +383,10 @@ jobs:
                     fi
                   done <<< "${MATCHES}"
                   if [ -n "${LOOKUP_FAILED}" ]; then
-                    # UNCONFIRMED, not ABSENT: at least one candidate's real
+                    # fix(#1707): UNCONFIRMED, not ABSENT — one candidate's real
                     # published_at was never confirmed, so any "newest"
-                    # claim can't be trusted. Skip loudly (same as the
-                    # tags-query and outer-guard-query failure paths)
-                    # instead of falling back to 'latest' the way this
-                    # branch used to — that was the same
-                    # fail-open-on-unconfirmed-data class already fixed for
-                    # the other two queries in this file.
+                    # claim can't be trusted. Skip loudly rather than
+                    # falling back to latest.
                     echo "::warning::could not confirm every matched tag's release for commit ${SHA} (lookup failed twice for: ${LOOKUP_FAILED}); skipping verification rather than proceeding against an unconfirmed VERIFY_VERSION=latest. Re-verify explicitly once the API is healthy: gh workflow run verify-published.yml -f version=vX.Y.Z"
                     UNCONFIRMED=true
                   elif [ -n "${NEWEST_TAG}" ]; then
@@ -577,67 +465,48 @@ jobs:
           SHA: ${{ github.event.workflow_run.head_sha }}
           REPOSITORY: ${{ github.repository }}
         run: |
-          # See the "hollow Release run" note at the top of this file. A
-          # workflow_run trigger only tells us Release CONCLUDED success as a
-          # workflow — not that its "Create GitHub Release" job actually ran,
-          # since an all-skipped run also concludes success. Confirm the real
-          # job ran before trusting anything about this trigger.
+          # fix(#1707): a workflow_run trigger only tells us Release CONCLUDED
+          # success as a workflow — not that its "Create GitHub Release" job
+          # actually ran, since an all-skipped run also concludes success.
+          # Confirm the real job ran before trusting anything about this
+          # trigger.
           #
-          # The `gh api` call is wrapped in an `if` (rather than a bare
-          # `CONCLUSION=$(...)` assignment) so a transient API error can't
-          # kill this step under `bash -e` — that would turn a network blip
-          # into a NEW red check, the opposite of this guard's job. It gets
-          # one immediate retry (the `||` below); if BOTH attempts fail,
-          # this now fails CLOSED into a loud skip (hollow=true + a
-          # distinct ::warning::), not a proceed-with-latest fallback. That
-          # fallback used to be described as "this workflow's behavior
-          # before this guard existed" — that reference point no longer
-          # applies; the guard IS the behavior now, and proceeding against
-          # unconfirmed data (VERIFY_VERSION=latest, with no idea whether
-          # the real release is a GA or a prerelease) is exactly the
-          # fail-open-on-unconfirmed-data class this file already fixed
-          # once, in the tag-resolution loop below.
+          # fix(#1707): the `gh api` call is wrapped in `if` (not a bare
+          # assignment) so a transient error can't kill this step under
+          # `bash -e`. One immediate retry (the `||` below); if both attempts
+          # fail, fail CLOSED into a loud skip (hollow=true + a distinct
+          # ::warning::) rather than proceeding against unconfirmed
+          # VERIFY_VERSION=latest.
           if CONCLUSION=$(gh api "repos/${REPOSITORY}/actions/runs/${RUN_ID}/jobs" \
               --jq '.jobs[] | select(.name == "Create GitHub Release") | .conclusion' 2>&1) \
             || CONCLUSION=$(gh api "repos/${REPOSITORY}/actions/runs/${RUN_ID}/jobs" \
               --jq '.jobs[] | select(.name == "Create GitHub Release") | .conclusion' 2>&1); then
             if [ "${CONCLUSION}" = "success" ]; then
-              # Resolve the exact tag this run released rather than trusting
-              # VERIFY_VERSION=latest: `latest` only ever tracks the newest
-              # GA release/image — publish.yml never re-tags GHCR :latest for
-              # a `-rc`/prerelease suffix (its `type=raw,value=latest` gate),
-              # and GitHub's own "latest release" concept explicitly skips
-              # prereleases. Left as 'latest', a Release-triggered run for a
-              # *prerelease* tag would silently pass by re-verifying the
-              # PREVIOUS GA instead of what this run just published.
-              # head_sha is reliable here even though head_branch isn't (see
-              # the header note) — it's the exact tagged commit, inherited
-              # through the workflow_run chain (Prod Compose Smoke -> Release
-              # -> here); only head_branch gets reset to the default branch.
-              # This is not a theory: the v1.14.1 Release run (created
-              # 2026-08-20T00:24:04Z) reports head_sha 1eb456346..., exactly
-              # `git rev-parse v1.14.1` — even though main's actual tip at
-              # that instant had already moved one commit past it, to
-              # 1e4a3ef4e... (#1615). If head_sha tracked the default
-              # branch's current tip the way head_branch does, this run
-              # would report 1e4a3ef4e; it reports the older tag commit
-              # instead. Filtered to semver-shaped names for the same reason
+              # fix(#1707): resolve the exact tag from head_sha rather than
+              # trusting VERIFY_VERSION=latest — publish.yml never advances
+              # GHCR :latest for a `-rc` suffix and GitHub's "latest release"
+              # skips prereleases, so a prerelease-triggered run would
+              # otherwise re-verify the previous GA.
+              #
+              # fix(#1707): head_sha is reliable here even though head_branch
+              # isn't — head_branch resets to the default branch on any
+              # workflow_run-triggered run, but head_sha is inherited through
+              # the trigger chain. Confirmed against the v1.14.1 Release run
+              # (created 2026-08-20T00:24:04Z): its head_sha (1eb456346...)
+              # is exactly `git rev-parse v1.14.1`, even though main's tip at
+              # that instant had already advanced past it to 1e4a3ef4e...
+              # (#1615). Filtered to semver-shaped names for the same reason
               # release.yml's own "Assert semver-shaped tag" step is: a
-              # 4-digit GSD milestone tag could in principle share a commit
-              # with a real release.
-              # One rule, applied at every query in this branch:
-              # resolution CONFIRMED (a query succeeded and found exactly
-              # what's needed) -> use it. Resolution confirmed ABSENT
-              # (queries succeeded, legitimately zero/no-candidate result)
-              # -> VERIFY_VERSION=latest, the pre-existing best-effort
-              # fallback. Resolution UNCONFIRMED (any query failed even
-              # after one retry) -> the loud skip (hollow=true), never
-              # 'latest' and never a guess from partial data. The tags
-              # query below is retried and its OWN success/failure is
-              # tracked separately from "found zero matches", so an API
-              # failure can no longer masquerade as a legitimately-empty
-              # result and flow into the latest fallback the way `|| true`
-              # on the raw pipeline used to let it.
+              # 4-digit GSD milestone tag could share a commit with a real
+              # release.
+              # fix(#1707): resolution follows one rule everywhere in this
+              # branch — CONFIRMED (query succeeded, found what's needed) ->
+              # use it; ABSENT (query succeeded, legitimately empty) ->
+              # VERIFY_VERSION=latest; UNCONFIRMED (query failed even after
+              # one retry) -> the loud skip, never a guess from partial data.
+              # The tags query's own success/failure is tracked separately
+              # from "found zero matches" so a failed request can't
+              # masquerade as an empty result.
               UNCONFIRMED=false
               if ! RAW_TAGS=$(gh api "repos/${REPOSITORY}/tags" --paginate \
                   --jq ".[] | select(.commit.sha == \"${SHA}\") | .name" 2>&1); then
@@ -650,111 +519,68 @@ jobs:
               if [ "${UNCONFIRMED}" != true ]; then
                 MATCHES=$(printf '%s\n' "${RAW_TAGS}" | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$') || true
                 MATCH_COUNT=$(printf '%s\n' "${MATCHES}" | grep -c . || true)
-                # A commit can carry MORE THAN ONE semver tag: promoting an
-                # unchanged release candidate straight to GA (no new commit)
-                # tags the SAME sha as both `v1.17.0-rc.1` and `v1.17.0`, and
-                # `head -1` on the raw match list would arbitrarily pick
-                # whichever the tags API happened to list first — silently
-                # verifying the wrong one instead of failing loudly. Only
-                # trust the resolution outright when it's unambiguous
-                # (exactly one match). 0 matches is a CONFIRMED-ABSENT
-                # result (the tags query above already succeeded), so it
-                # falls back to VERIFY_VERSION=latest, the pre-existing
-                # best-effort semantics. More than one match is resolved
-                # deterministically below rather than assumed to be an
-                # RC->GA promotion — that assumption doesn't hold for every
-                # ambiguous case: re-cutting `v1.17.0-rc.1` as
-                # `v1.17.0-rc.2` on an unchanged commit also lands here, and
-                # 'latest' would then silently verify the PREVIOUS GA (a
-                # prerelease never advances 'latest').
+                # fix(#1707): a commit can carry more than one semver tag (an RC
+                # promoted unchanged to GA, or one prerelease re-cut as
+                # another, both tag the same commit). Trust the resolution
+                # outright only when unambiguous (exactly one match); 0
+                # matches is CONFIRMED-ABSENT (falls back to latest); more
+                # than one is resolved deterministically below, not assumed
+                # to be any one specific scenario.
                 if [ "${MATCH_COUNT}" -eq 1 ]; then
                   TAG="${MATCHES}"
                   echo "resolved_version=${TAG}" >> "$GITHUB_OUTPUT"
                 elif [ "${MATCH_COUNT}" -eq 0 ]; then
                   echo "::warning::could not resolve a semver tag for commit ${SHA}; falling back to VERIFY_VERSION=latest, which under-verifies a prerelease"
                 else
-                  # Resolve deterministically via the releases API instead of
-                  # guessing from tag semantics: look up each matched tag's
-                  # release and take the one with the newest published_at.
+                  # fix(#1707): tie-break by published_at, not created_at. For a
+                  # release created against an already-tagged commit (exactly
+                  # this ambiguous case), GitHub sets created_at to the
+                  # target COMMIT's date, not the publish moment — confirmed
+                  # against this repo's own releases (v1.16.1, v1.16.0,
+                  # v1.15.1: created_at == tag commit date, published_at ==
+                  # the real gh-release-create moment). Two tags on one
+                  # commit would carry identical created_at, so that
+                  # comparison was never actually deterministic. published_at
+                  # is set once, at the true publish moment.
                   #
-                  # NOT created_at, which an earlier version of this branch
-                  # used: for a release created against an EXISTING tagged
-                  # commit (exactly this ambiguous case — the whole point is
-                  # that both matched tags share one commit), GitHub sets
-                  # created_at to the target COMMIT's date, not the moment
-                  # `gh release create` ran. This repo's own data proves it:
-                  # v1.16.1's release created_at (2026-08-28T18:07:09Z)
-                  # equals its tag commit's date exactly, while published_at
-                  # (18:48:48Z) is the real gh-release-create moment — same
-                  # pattern confirmed on v1.16.0 and v1.15.1. Two tags on the
-                  # SAME commit therefore carry IDENTICAL created_at values,
-                  # the strict `>` comparison below never fires for the
-                  # second one, and the loop silently kept whichever tag the
-                  # tags API happened to list first — not deterministic at
-                  # all for exactly the case this branch exists to handle.
-                  # published_at does not have this problem: it is set once,
-                  # at the actual publish moment, and differs between two
-                  # releases of the same commit exactly when one was
-                  # published later than the other.
+                  # fix(#1707): a manual rerun of an OLDER tag's Release run,
+                  # on a commit that has since gained a newer released
+                  # sibling, resolves to the newer sibling — `gh release
+                  # edit` (release.yml's rerun-onto-an-existing-release path)
+                  # changes neither timestamp. Not a miss: the older tag
+                  # already got its own correct verification cycle when it
+                  # was the newest match; re-checking one specific superseded
+                  # tag on demand is `workflow_dispatch -f version=vX.Y.Z`,
+                  # which bypasses this resolution.
                   #
-                  # In the ordinary case the newest-published release IS the
-                  # release this run's own trigger chain just created or
-                  # updated — true for both an RC->GA promotion (GA release
-                  # is newest) and an rc-recut (rc.2's release is newest) —
-                  # with no assumption about which case produced the
-                  # ambiguity.
-                  #
-                  # One exotic case where it picks a DIFFERENT matched tag:
-                  # a manual rerun of an OLDER tag's Release run, on a commit
-                  # that has since gained a newer released sibling. `gh
-                  # release edit` (release.yml's rerun-onto-an-existing-
-                  # release path) changes neither created_at nor
-                  # published_at, so the older tag's release stays older and
-                  # the newer sibling still wins here — this analysis
-                  # transfers unchanged from the created_at version. That's
-                  # fine, not a miss: the older tag already got its own
-                  # correct verification cycle when IT was the newest match,
-                  # and re-checking one specific superseded tag on demand is
-                  # what manual `workflow_dispatch -f version=vX.Y.Z` is for
-                  # (it bypasses this resolution entirely) — not a job for
-                  # the automatic trigger path.
-                  #
-                  # Looked up per-candidate (releases/tags/{tag}) rather than
-                  # listing+filtering the full releases collection: there are
-                  # only ever a couple of matched tags here, and
-                  # `gh api --paginate` applies --jq PER PAGE, so an aggregate
-                  # sort/max over the whole paginated list would silently
-                  # pick the wrong answer across a page boundary instead of
-                  # the true global newest.
+                  # fix(#1707): looked up per-candidate (releases/tags/{tag})
+                  # rather than listing+filtering the full releases
+                  # collection — gh api --paginate applies --jq PER PAGE, so
+                  # an aggregate sort/max over a paginated list would pick
+                  # the wrong answer across a page boundary.
                   NEWEST_TAG=""
                   NEWEST_PUBLISHED=""
                   LOOKUP_FAILED=""
                   while IFS= read -r CANDIDATE; do
                     [ -z "${CANDIDATE}" ] && continue
-                    # A candidate whose lookup fails is FLAGGED, never
-                    # silently skipped: selecting the newest among only the
-                    # tags that happened to resolve, while one candidate's
-                    # real status is unknown, is exactly the partial-data
-                    # selection this whole resolution exists to avoid (a
-                    # transient failure on the true-newest candidate would
-                    # verify its OLDER sibling green instead of falling back
-                    # loudly). One immediate retry first, since a transient
-                    # API hiccup shouldn't discard an otherwise-resolvable
-                    # selection over a single blip.
+                    # fix(#1707): a candidate whose lookup fails is flagged, never
+                    # silently skipped — selecting the newest among only the
+                    # tags that resolved, while one candidate's real status
+                    # is unknown, is the partial-data selection this
+                    # resolution exists to avoid. One immediate retry first
+                    # for a single transient blip.
                     if ! PUBLISHED=$(gh api "repos/${REPOSITORY}/releases/tags/${CANDIDATE}" --jq '.published_at' 2>/dev/null); then
                       if ! PUBLISHED=$(gh api "repos/${REPOSITORY}/releases/tags/${CANDIDATE}" --jq '.published_at' 2>/dev/null); then
                         LOOKUP_FAILED="${LOOKUP_FAILED}${LOOKUP_FAILED:+ }${CANDIDATE}"
                         continue
                       fi
                     fi
-                    # A draft release has published_at=null (gh api prints
-                    # the literal string "null"); this pipeline never
-                    # creates drafts, so a null here means this candidate is
-                    # confirmed NOT to be the release this trigger chain
-                    # just published. Exclude it from the newest comparison
-                    # without treating the whole resolution as UNCONFIRMED —
-                    # the query itself succeeded, it just isn't a
-                    # candidate.
+                    # fix(#1707): a draft release has published_at=null (gh api
+                    # prints the literal string "null"); this pipeline never
+                    # creates drafts, so null means this candidate is
+                    # confirmed not to be the published release. Excluded
+                    # from the comparison without marking the whole
+                    # resolution UNCONFIRMED — the query itself succeeded.
                     if [ "${PUBLISHED}" = "null" ] || [ -z "${PUBLISHED}" ]; then
                       continue
                     fi
@@ -764,14 +590,10 @@ jobs:
                     fi
                   done <<< "${MATCHES}"
                   if [ -n "${LOOKUP_FAILED}" ]; then
-                    # UNCONFIRMED, not ABSENT: at least one candidate's real
+                    # fix(#1707): UNCONFIRMED, not ABSENT — one candidate's real
                     # published_at was never confirmed, so any "newest"
-                    # claim can't be trusted. Skip loudly (same as the
-                    # tags-query and outer-guard-query failure paths)
-                    # instead of falling back to 'latest' the way this
-                    # branch used to — that was the same
-                    # fail-open-on-unconfirmed-data class already fixed for
-                    # the other two queries in this file.
+                    # claim can't be trusted. Skip loudly rather than
+                    # falling back to latest.
                     echo "::warning::could not confirm every matched tag's release for commit ${SHA} (lookup failed twice for: ${LOOKUP_FAILED}); skipping verification rather than proceeding against an unconfirmed VERIFY_VERSION=latest. Re-verify explicitly once the API is healthy: gh workflow run verify-published.yml -f version=vX.Y.Z"
                     UNCONFIRMED=true
                   elif [ -n "${NEWEST_TAG}" ]; then

--- a/.github/workflows/verify-published.yml
+++ b/.github/workflows/verify-published.yml
@@ -1,10 +1,24 @@
 # Clean-machine smoke verification of published GeoLens packages.
 #
-# Runs automatically after the gated SDK/CLI publishes complete (workflow_run,
-# below), and can be run manually any time. Jobs run inside fresh Docker images
-# (python:3.13-slim, node:22-slim) — no repo context, no runner pollution; mimics
-# what a downstream user gets. Each check polls with a bounded retry to absorb
+# Runs automatically after the gated SDK/CLI publishes complete AND after the
+# Release workflow creates the GitHub Release (workflow_run, below), and can be
+# run manually any time. Jobs run inside fresh Docker images (python:3.13-slim,
+# node:22-slim) — no repo context, no runner pollution; mimics what a
+# downstream user gets. Each check polls with a bounded retry to absorb
 # registry/CDN propagation lag.
+#
+# The "Verify GitHub Release" and "Verify GHCR images" jobs used to race the
+# Release workflow: this workflow triggered only off the package publishes
+# (Publish SDKs/CLI/MCP), which pause for a human approval click and finish on
+# their own schedule, independent of the "Prod Compose Smoke" -> "Release"
+# chain that actually creates the GitHub Release. On v1.16.0 the approvals
+# landed while the ~40-minute compose-boot-and-E2E smoke was still running:
+# both checks burned their full 5-minute retry window twice in a row and went
+# red roughly 2 minutes before Release actually finished, needing a manual
+# rerun every time. Triggering off "Release" too closes this by construction —
+# Release only fires after Prod Compose Smoke has already pulled the GHCR
+# images and the release job has already created the release, so a
+# Release-triggered run of this workflow can never lose that race.
 #
 # Manual usage:
 #   gh workflow run verify-published.yml -f version=vX.Y.Z
@@ -13,7 +27,8 @@
 # This intentionally does NOT trigger on `push: tags`. On a tag push the GHCR
 # images are still building and the PyPI/npm publishes are still waiting on the
 # `publish` environment's approval gate, so a tag-triggered run would always
-# race/expire. Triggering after the publishes finish is the correct ordering.
+# race/expire. Triggering after the publishes finish (or after Release
+# finishes) is the correct ordering.
 # See docs.getgeolens.com for the release runbook.
 name: Verify Published Packages
 
@@ -25,11 +40,18 @@ on:
         required: false
         type: string
         default: 'latest'
-  # Auto-run after a gated publish completes. The publish workflows finish at
-  # different times; the concurrency group below queues duplicate triggers for
-  # the same version behind the in-flight verify (never cancelling it).
+  # Auto-run after a gated publish completes, and after Release creates the
+  # GitHub Release. These four upstream workflows finish at different times —
+  # the publishes wait on a human approval click, Release waits on the
+  # ~40-minute Prod Compose Smoke — so the concurrency group below queues
+  # duplicate triggers for the same version behind the in-flight verify
+  # (never cancelling it). A Release-triggered run lands in its own
+  # `verify-published-main` group (see VERIFY_VERSION below) and runs
+  # independently of the per-version group; that's fine; it exists
+  # specifically to catch the GHCR/Release checks a publish-triggered run can
+  # miss while Prod Compose Smoke is still boot-testing the tag.
   workflow_run:
-    workflows: ["Publish SDKs", "Publish CLI", "Publish MCP Server"]
+    workflows: ["Publish SDKs", "Publish CLI", "Publish MCP Server", "Release"]
     types: [completed]
 
 permissions:
@@ -44,14 +66,27 @@ permissions:
 # newest pending run per group), so an in-flight verify always finishes.
 # Verifying two different versions concurrently is fine — the group is
 # per-version.
+#
+# A run triggered by Release's completion reports its OWN head_branch as the
+# default branch ("main"), not the tag — that's how GitHub represents any
+# workflow_run-triggered run, since the triggered workflow's file is always
+# read from the default branch. Such a run lands in a fixed
+# `verify-published-main` group instead of the tag's group; VERIFY_VERSION
+# below falls back to 'latest' for it, which is correct because Release has,
+# by construction, just finished creating the newest release.
 concurrency:
   group: verify-published-${{ inputs.version || github.event.workflow_run.head_branch || github.run_id }}
   cancel-in-progress: false
 
 env:
-  # Manual dispatch → the version input. workflow_run after a tag publish →
-  # head_branch is the tag (e.g. v1.2.4), used only when it looks like a version
-  # tag; a non-tag publish (e.g. dispatched from a branch) falls back to 'latest'.
+  # Manual dispatch → the version input. workflow_run after a tag-triggered
+  # publish (Publish SDKs/CLI/MCP) → head_branch is the tag (e.g. v1.2.4),
+  # used only when it looks like a version tag. workflow_run after Release
+  # always falls through to 'latest' below: Release is itself
+  # workflow_run-triggered, so its own head_branch is reported as the default
+  # branch ("main"), never the tag — and 'latest' is right anyway, since
+  # Release only fires once it has already created the newest release. A
+  # non-tag publish (e.g. dispatched from a branch) also falls back to 'latest'.
   VERIFY_VERSION: ${{ inputs.version || (startsWith(github.event.workflow_run.head_branch, 'v') && github.event.workflow_run.head_branch) || 'latest' }}
   # Bounded retry to absorb registry/CDN propagation lag after a publish.
   # 20 × 15s ≈ 5 min ceiling per check.

--- a/.github/workflows/verify-published.yml
+++ b/.github/workflows/verify-published.yml
@@ -311,10 +311,20 @@ jobs:
               # *prerelease* tag would silently pass by re-verifying the
               # PREVIOUS GA instead of what this run just published.
               # head_sha is reliable here even though head_branch isn't (see
-              # the header note) — it's the exact tagged commit. Filtered to
-              # semver-shaped names for the same reason release.yml's own
-              # "Assert semver-shaped tag" step is: a 4-digit GSD milestone
-              # tag could in principle share a commit with a real release.
+              # the header note) — it's the exact tagged commit, inherited
+              # through the workflow_run chain (Prod Compose Smoke -> Release
+              # -> here); only head_branch gets reset to the default branch.
+              # This is not a theory: the v1.14.1 Release run (created
+              # 2026-08-20T00:24:04Z) reports head_sha 1eb456346..., exactly
+              # `git rev-parse v1.14.1` — even though main's actual tip at
+              # that instant had already moved one commit past it, to
+              # 1e4a3ef4e... (#1615). If head_sha tracked the default
+              # branch's current tip the way head_branch does, this run
+              # would report 1e4a3ef4e; it reports the older tag commit
+              # instead. Filtered to semver-shaped names for the same reason
+              # release.yml's own "Assert semver-shaped tag" step is: a
+              # 4-digit GSD milestone tag could in principle share a commit
+              # with a real release.
               TAG=$(gh api "repos/${REPOSITORY}/tags" --paginate \
                 --jq ".[] | select(.commit.sha == \"${SHA}\") | .name" \
                 | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$' | head -1) || true
@@ -411,10 +421,20 @@ jobs:
               # *prerelease* tag would silently pass by re-verifying the
               # PREVIOUS GA instead of what this run just published.
               # head_sha is reliable here even though head_branch isn't (see
-              # the header note) — it's the exact tagged commit. Filtered to
-              # semver-shaped names for the same reason release.yml's own
-              # "Assert semver-shaped tag" step is: a 4-digit GSD milestone
-              # tag could in principle share a commit with a real release.
+              # the header note) — it's the exact tagged commit, inherited
+              # through the workflow_run chain (Prod Compose Smoke -> Release
+              # -> here); only head_branch gets reset to the default branch.
+              # This is not a theory: the v1.14.1 Release run (created
+              # 2026-08-20T00:24:04Z) reports head_sha 1eb456346..., exactly
+              # `git rev-parse v1.14.1` — even though main's actual tip at
+              # that instant had already moved one commit past it, to
+              # 1e4a3ef4e... (#1615). If head_sha tracked the default
+              # branch's current tip the way head_branch does, this run
+              # would report 1e4a3ef4e; it reports the older tag commit
+              # instead. Filtered to semver-shaped names for the same reason
+              # release.yml's own "Assert semver-shaped tag" step is: a
+              # 4-digit GSD milestone tag could in principle share a commit
+              # with a real release.
               TAG=$(gh api "repos/${REPOSITORY}/tags" --paginate \
                 --jq ".[] | select(.commit.sha == \"${SHA}\") | .name" \
                 | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$' | head -1) || true

--- a/.github/workflows/verify-published.yml
+++ b/.github/workflows/verify-published.yml
@@ -353,25 +353,59 @@ jobs:
               # `head -1` on the raw match list would arbitrarily pick
               # whichever the tags API happened to list first — silently
               # verifying the wrong one instead of failing loudly. Only
-              # trust the resolution when it's unambiguous (exactly one
-              # match); 0 or >1 falls back to VERIFY_VERSION=latest, same as
-              # a failed resolution already did. That fallback is exactly
-              # right for the >1 case specifically: the only realistic way
-              # to get here is an RC->GA promotion, and this Release-
-              # triggered run fires immediately after `gh release create`
-              # made the GA the newest release, so 'latest' resolves to
-              # precisely the release that was just promoted, by
-              # construction — no guessing needed. The earlier RC-only
-              # verify (back when this commit had just the one prerelease
-              # tag) already resolved and checked the RC correctly, so nothing
-              # is lost by falling back here.
+              # trust the resolution outright when it's unambiguous
+              # (exactly one match). 0 matches falls back to
+              # VERIFY_VERSION=latest, same as a failed resolution always
+              # did. More than one match is resolved deterministically
+              # below rather than assumed to be an RC->GA promotion — that
+              # assumption doesn't hold for every ambiguous case: re-cutting
+              # `v1.17.0-rc.1` as `v1.17.0-rc.2` on an unchanged commit also
+              # lands here, and 'latest' would then silently verify the
+              # PREVIOUS GA (a prerelease never advances 'latest').
               if [ "${MATCH_COUNT}" -eq 1 ]; then
                 TAG="${MATCHES}"
                 echo "resolved_version=${TAG}" >> "$GITHUB_OUTPUT"
               elif [ "${MATCH_COUNT}" -eq 0 ]; then
                 echo "::warning::could not resolve a semver tag for commit ${SHA}; falling back to VERIFY_VERSION=latest, which under-verifies a prerelease"
               else
-                echo "::notice::commit ${SHA} matches ${MATCH_COUNT} semver tags ($(printf '%s' "${MATCHES}" | tr '\n' ' ')); ambiguous (expected from an RC promoted unchanged to GA) — falling back to VERIFY_VERSION=latest, which resolves to the GA release this run just created"
+                # Resolve deterministically via the releases API instead of
+                # guessing from tag semantics. The hollow-run check above
+                # already proved this run's "Create GitHub Release" job
+                # succeeded, so by construction it just created or updated
+                # exactly ONE release among these matched tags — that
+                # release is the newest one by created_at. This handles
+                # RC->GA promotion (the GA release is newest) AND an
+                # rc-recut (rc.2's release is newest) with no assumption
+                # about which case produced the ambiguity.
+                #
+                # Looked up per-candidate (releases/tags/{tag}) rather than
+                # listing+filtering the full releases collection: there are
+                # only ever a couple of matched tags here, and
+                # `gh api --paginate` applies --jq PER PAGE, so an aggregate
+                # sort/max over the whole paginated list would silently
+                # pick the wrong answer across a page boundary instead of
+                # the true global newest.
+                NEWEST_TAG=""
+                NEWEST_CREATED=""
+                while IFS= read -r CANDIDATE; do
+                  [ -z "${CANDIDATE}" ] && continue
+                  # `|| continue` (not `|| true`): a lookup failure for one
+                  # candidate — e.g. its release hasn't propagated yet —
+                  # skips that candidate under bash -e instead of aborting
+                  # the whole loop.
+                  CREATED=$(gh api "repos/${REPOSITORY}/releases/tags/${CANDIDATE}" --jq '.created_at' 2>/dev/null) || continue
+                  if [ -z "${NEWEST_CREATED}" ] || [ "${CREATED}" \> "${NEWEST_CREATED}" ]; then
+                    NEWEST_CREATED="${CREATED}"
+                    NEWEST_TAG="${CANDIDATE}"
+                  fi
+                done <<< "${MATCHES}"
+                if [ -n "${NEWEST_TAG}" ]; then
+                  TAG="${NEWEST_TAG}"
+                  echo "::notice::commit ${SHA} matches ${MATCH_COUNT} semver tags ($(printf '%s' "${MATCHES}" | tr '\n' ' ')); resolved via the releases API to the newest-created release: ${TAG} (created ${NEWEST_CREATED})"
+                  echo "resolved_version=${TAG}" >> "$GITHUB_OUTPUT"
+                else
+                  echo "::warning::commit ${SHA} matches ${MATCH_COUNT} semver tags ($(printf '%s' "${MATCHES}" | tr '\n' ' ')) but none has a GitHub Release yet (unexpected — the release job just succeeded); falling back to VERIFY_VERSION=latest"
+                fi
               fi
               echo "hollow=false" >> "$GITHUB_OUTPUT"
             else
@@ -485,25 +519,59 @@ jobs:
               # `head -1` on the raw match list would arbitrarily pick
               # whichever the tags API happened to list first — silently
               # verifying the wrong one instead of failing loudly. Only
-              # trust the resolution when it's unambiguous (exactly one
-              # match); 0 or >1 falls back to VERIFY_VERSION=latest, same as
-              # a failed resolution already did. That fallback is exactly
-              # right for the >1 case specifically: the only realistic way
-              # to get here is an RC->GA promotion, and this Release-
-              # triggered run fires immediately after `gh release create`
-              # made the GA the newest release, so 'latest' resolves to
-              # precisely the release that was just promoted, by
-              # construction — no guessing needed. The earlier RC-only
-              # verify (back when this commit had just the one prerelease
-              # tag) already resolved and checked the RC correctly, so nothing
-              # is lost by falling back here.
+              # trust the resolution outright when it's unambiguous
+              # (exactly one match). 0 matches falls back to
+              # VERIFY_VERSION=latest, same as a failed resolution always
+              # did. More than one match is resolved deterministically
+              # below rather than assumed to be an RC->GA promotion — that
+              # assumption doesn't hold for every ambiguous case: re-cutting
+              # `v1.17.0-rc.1` as `v1.17.0-rc.2` on an unchanged commit also
+              # lands here, and 'latest' would then silently verify the
+              # PREVIOUS GA (a prerelease never advances 'latest').
               if [ "${MATCH_COUNT}" -eq 1 ]; then
                 TAG="${MATCHES}"
                 echo "resolved_version=${TAG}" >> "$GITHUB_OUTPUT"
               elif [ "${MATCH_COUNT}" -eq 0 ]; then
                 echo "::warning::could not resolve a semver tag for commit ${SHA}; falling back to VERIFY_VERSION=latest, which under-verifies a prerelease"
               else
-                echo "::notice::commit ${SHA} matches ${MATCH_COUNT} semver tags ($(printf '%s' "${MATCHES}" | tr '\n' ' ')); ambiguous (expected from an RC promoted unchanged to GA) — falling back to VERIFY_VERSION=latest, which resolves to the GA release this run just created"
+                # Resolve deterministically via the releases API instead of
+                # guessing from tag semantics. The hollow-run check above
+                # already proved this run's "Create GitHub Release" job
+                # succeeded, so by construction it just created or updated
+                # exactly ONE release among these matched tags — that
+                # release is the newest one by created_at. This handles
+                # RC->GA promotion (the GA release is newest) AND an
+                # rc-recut (rc.2's release is newest) with no assumption
+                # about which case produced the ambiguity.
+                #
+                # Looked up per-candidate (releases/tags/{tag}) rather than
+                # listing+filtering the full releases collection: there are
+                # only ever a couple of matched tags here, and
+                # `gh api --paginate` applies --jq PER PAGE, so an aggregate
+                # sort/max over the whole paginated list would silently
+                # pick the wrong answer across a page boundary instead of
+                # the true global newest.
+                NEWEST_TAG=""
+                NEWEST_CREATED=""
+                while IFS= read -r CANDIDATE; do
+                  [ -z "${CANDIDATE}" ] && continue
+                  # `|| continue` (not `|| true`): a lookup failure for one
+                  # candidate — e.g. its release hasn't propagated yet —
+                  # skips that candidate under bash -e instead of aborting
+                  # the whole loop.
+                  CREATED=$(gh api "repos/${REPOSITORY}/releases/tags/${CANDIDATE}" --jq '.created_at' 2>/dev/null) || continue
+                  if [ -z "${NEWEST_CREATED}" ] || [ "${CREATED}" \> "${NEWEST_CREATED}" ]; then
+                    NEWEST_CREATED="${CREATED}"
+                    NEWEST_TAG="${CANDIDATE}"
+                  fi
+                done <<< "${MATCHES}"
+                if [ -n "${NEWEST_TAG}" ]; then
+                  TAG="${NEWEST_TAG}"
+                  echo "::notice::commit ${SHA} matches ${MATCH_COUNT} semver tags ($(printf '%s' "${MATCHES}" | tr '\n' ' ')); resolved via the releases API to the newest-created release: ${TAG} (created ${NEWEST_CREATED})"
+                  echo "resolved_version=${TAG}" >> "$GITHUB_OUTPUT"
+                else
+                  echo "::warning::commit ${SHA} matches ${MATCH_COUNT} semver tags ($(printf '%s' "${MATCHES}" | tr '\n' ' ')) but none has a GitHub Release yet (unexpected — the release job just succeeded); falling back to VERIFY_VERSION=latest"
+                fi
               fi
               echo "hollow=false" >> "$GITHUB_OUTPUT"
             else

--- a/.github/workflows/verify-published.yml
+++ b/.github/workflows/verify-published.yml
@@ -33,6 +33,46 @@
 # still verifies the registries once they exist, same as always. Manual
 # dispatch is unaffected and still runs all four jobs.
 #
+# One more wrinkle: "Release" firing is necessary but not sufficient proof
+# that a release exists. release.yml's own workflow_run trigger listens on
+# `types: [completed]`, which fires on FAILURE too, and it gates the actual
+# release-creation job only at the JOB level
+# (`conclusion == 'success' && startsWith(head_branch, 'v')`) — a run whose
+# sole job SKIPPED (a failed Prod Compose Smoke, or a manual smoke of
+# `latest`/a branch) still CONCLUDES 'success' as a *workflow*, because an
+# all-skipped run is reported as successful. Left unguarded, that hollow
+# Release run would still trigger this workflow, VERIFY_VERSION would still
+# resolve to 'latest', and "Verify GHCR images"/"Verify GitHub Release" would
+# pass against the PREVIOUS release — a misleading green sitting right after
+# a failed or irrelevant smoke. Each of those two jobs' first step guards
+# against this by querying the triggering run's own jobs and confirming
+# "Create GitHub Release" actually concluded success; on a hollow run it logs
+# an `::notice::` and skips the real check WITHOUT failing the job — the
+# smoke failure is already the loud red signal, and this workflow going red
+# too would only be noise.
+#
+# (Considered switching Release's trigger to `release: types: [published]`
+# instead of workflow_run, which would sidestep the hollow-run problem
+# entirely and hand us the real tag via github.event.release.tag_name instead
+# of 'latest'. Ruled out: release.yml creates/edits the release using the
+# default `secrets.GITHUB_TOKEN` in every `gh release`/`gh api` call, and
+# GitHub does not fire downstream workflow triggers off events created by the
+# default GITHUB_TOKEN — that's the trigger-loop guard, and it would make a
+# `release: published` trigger here simply never fire. Revisit if release.yml
+# ever switches that step to a PAT or GitHub App token.)
+#
+# A related trap the naive fallback would have hit: 'latest' only ever means
+# the newest GA. publish.yml never re-tags GHCR `:latest` for a `-rc`/
+# prerelease suffix, and GitHub's own "latest release" concept explicitly
+# skips prereleases too — so a Release-triggered run for a *prerelease* tag
+# (this pipeline supports them end to end: Prod Compose Smoke, Release, and
+# publish.yml's tag matching all explicitly handle `-rc`/prerelease suffixes)
+# would otherwise silently re-verify the PREVIOUS GA instead of what was just
+# published, passing green without checking anything new. The same guard
+# step that checks for a hollow run also resolves the exact tag from
+# head_sha (reliable even though head_branch isn't — see above) and hands it
+# to the real check in place of 'latest'.
+#
 # Manual usage:
 #   gh workflow run verify-published.yml -f version=vX.Y.Z
 # Omit version (or pass 'latest') to verify whatever each registry calls latest.
@@ -72,6 +112,10 @@ on:
 
 permissions:
   contents: read
+  # Lets the hollow-Release guard in verify-ghcr/verify-github-release list
+  # the triggering Release run's jobs (GET .../actions/runs/{id}/jobs) to
+  # confirm "Create GitHub Release" actually ran and succeeded.
+  actions: read
 
 # Collapse the publish-completion triggers (and any manual run) for the same
 # version into the same group. cancel-in-progress stays FALSE (fix #829): with
@@ -88,8 +132,10 @@ permissions:
 # workflow_run-triggered run, since the triggered workflow's file is always
 # read from the default branch. Such a run lands in a fixed
 # `verify-published-main` group instead of the tag's group; VERIFY_VERSION
-# below falls back to 'latest' for it, which is correct because Release has,
-# by construction, just finished creating the newest release.
+# below falls back to 'latest' for it. `latest` is only a LAST-RESORT
+# fallback for the two Release-gated jobs though — each resolves the exact
+# tag itself from head_sha (see their guard step) precisely because 'latest'
+# would silently under-verify a prerelease. See that step's comment.
 concurrency:
   group: verify-published-${{ inputs.version || github.event.workflow_run.head_branch || github.run_id }}
   cancel-in-progress: false
@@ -97,12 +143,17 @@ concurrency:
 env:
   # Manual dispatch → the version input. workflow_run after a tag-triggered
   # publish (Publish SDKs/CLI/MCP) → head_branch is the tag (e.g. v1.2.4),
-  # used only when it looks like a version tag. workflow_run after Release
-  # always falls through to 'latest' below: Release is itself
-  # workflow_run-triggered, so its own head_branch is reported as the default
-  # branch ("main"), never the tag — and 'latest' is right anyway, since
-  # Release only fires once it has already created the newest release. A
-  # non-tag publish (e.g. dispatched from a branch) also falls back to 'latest'.
+  # used only when it looks like a version tag — exact for both a GA and a
+  # prerelease tag, since Publish SDKs/CLI/MCP are themselves `push: tags`
+  # triggered. workflow_run after Release always falls through to 'latest'
+  # below: Release is itself workflow_run-triggered, so its own head_branch
+  # is reported as the default branch ("main"), never the tag. verify-ghcr
+  # and verify-github-release don't actually rely on that 'latest' fallback
+  # in practice — their guard step resolves the exact tag from head_sha and
+  # overrides it — but VERIFY_VERSION still needs a sane default here for
+  # workflow_dispatch and for the (defensive, expected-rare) case where that
+  # resolution itself fails. A non-tag publish (e.g. dispatched from a
+  # branch) also falls back to 'latest'.
   VERIFY_VERSION: ${{ inputs.version || (startsWith(github.event.workflow_run.head_branch, 'v') && github.event.workflow_run.head_branch) || 'latest' }}
   # Bounded retry to absorb registry/CDN propagation lag after a publish.
   # 20 × 15s ≈ 5 min ceiling per check.
@@ -219,14 +270,73 @@ jobs:
     # artifact that ONLY a completed Release guarantees is pullable, so an
     # auto-trigger runs only for a successful Release completion — never for
     # a publish, which says nothing about whether the images have landed. See
-    # verify-python's comment for the github.event.workflow.name rationale.
+    # verify-python's comment for the github.event.workflow.name rationale,
+    # and the "hollow Release run" note at the top of this file for why the
+    # guard step below exists.
     if: ${{ github.event_name != 'workflow_run' || (github.event.workflow_run.conclusion == 'success' && github.event.workflow.name == 'Release') }}
     name: Verify GHCR images
     runs-on: ubuntu-latest
     steps:
-      - name: docker pull published GHCR images
+      - name: Guard against a hollow Release run
+        id: release_guard
+        if: ${{ github.event_name == 'workflow_run' }}
         env:
-          VERSION: ${{ env.VERIFY_VERSION }}
+          GH_TOKEN: ${{ github.token }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+          SHA: ${{ github.event.workflow_run.head_sha }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          # See the "hollow Release run" note at the top of this file. A
+          # workflow_run trigger only tells us Release CONCLUDED success as a
+          # workflow — not that its "Create GitHub Release" job actually ran,
+          # since an all-skipped run also concludes success. Confirm the real
+          # job ran before trusting anything about this trigger.
+          #
+          # The `gh api` call is wrapped in an `if` (rather than a bare
+          # `CONCLUSION=$(...)` assignment) so a transient API error can't
+          # kill this step under `bash -e` — that would turn a network blip
+          # into a NEW red check, the opposite of this guard's job. On a
+          # query failure this falls through to "not hollow" (run the real
+          # check below), which is exactly this workflow's behavior before
+          # this guard existed, not a new failure mode.
+          if CONCLUSION=$(gh api "repos/${REPOSITORY}/actions/runs/${RUN_ID}/jobs" \
+            --jq '.jobs[] | select(.name == "Create GitHub Release") | .conclusion' 2>&1); then
+            if [ "${CONCLUSION}" = "success" ]; then
+              # Resolve the exact tag this run released rather than trusting
+              # VERIFY_VERSION=latest: `latest` only ever tracks the newest
+              # GA release/image — publish.yml never re-tags GHCR :latest for
+              # a `-rc`/prerelease suffix (its `type=raw,value=latest` gate),
+              # and GitHub's own "latest release" concept explicitly skips
+              # prereleases. Left as 'latest', a Release-triggered run for a
+              # *prerelease* tag would silently pass by re-verifying the
+              # PREVIOUS GA instead of what this run just published.
+              # head_sha is reliable here even though head_branch isn't (see
+              # the header note) — it's the exact tagged commit. Filtered to
+              # semver-shaped names for the same reason release.yml's own
+              # "Assert semver-shaped tag" step is: a 4-digit GSD milestone
+              # tag could in principle share a commit with a real release.
+              TAG=$(gh api "repos/${REPOSITORY}/tags" --paginate \
+                --jq ".[] | select(.commit.sha == \"${SHA}\") | .name" \
+                | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$' | head -1) || true
+              if [ -n "${TAG}" ]; then
+                echo "resolved_version=${TAG}" >> "$GITHUB_OUTPUT"
+              else
+                echo "::warning::could not resolve a semver tag for commit ${SHA}; falling back to VERIFY_VERSION=latest, which under-verifies a prerelease"
+              fi
+              echo "hollow=false" >> "$GITHUB_OUTPUT"
+            else
+              echo "::notice::triggering Release run created no release; nothing to verify (Create GitHub Release job conclusion: '${CONCLUSION:-absent}')"
+              echo "hollow=true" >> "$GITHUB_OUTPUT"
+            fi
+          else
+            echo "::warning::could not query the triggering Release run's jobs (gh api failed: ${CONCLUSION}); proceeding with verification as if not hollow"
+            echo "hollow=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: docker pull published GHCR images
+        if: ${{ steps.release_guard.outputs.hollow != 'true' }}
+        env:
+          VERSION: ${{ steps.release_guard.outputs.resolved_version || env.VERIFY_VERSION }}
           OWNER: ${{ github.repository_owner }}
         run: |
           if [ "${VERSION}" = "latest" ]; then
@@ -260,15 +370,74 @@ jobs:
 
   verify-github-release:
     # Same routing as verify-ghcr — Release-only (or manual dispatch); see
-    # verify-python's comment for the github.event.workflow.name rationale.
+    # verify-python's comment for the github.event.workflow.name rationale,
+    # and the "hollow Release run" note at the top of this file for why the
+    # guard step below exists.
     if: ${{ github.event_name != 'workflow_run' || (github.event.workflow_run.conclusion == 'success' && github.event.workflow.name == 'Release') }}
     name: Verify GitHub Release
     runs-on: ubuntu-latest
     steps:
-      - name: Check release exists
+      - name: Guard against a hollow Release run
+        id: release_guard
+        if: ${{ github.event_name == 'workflow_run' }}
         env:
           GH_TOKEN: ${{ github.token }}
-          VERSION: ${{ env.VERIFY_VERSION }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+          SHA: ${{ github.event.workflow_run.head_sha }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          # See the "hollow Release run" note at the top of this file. A
+          # workflow_run trigger only tells us Release CONCLUDED success as a
+          # workflow — not that its "Create GitHub Release" job actually ran,
+          # since an all-skipped run also concludes success. Confirm the real
+          # job ran before trusting anything about this trigger.
+          #
+          # The `gh api` call is wrapped in an `if` (rather than a bare
+          # `CONCLUSION=$(...)` assignment) so a transient API error can't
+          # kill this step under `bash -e` — that would turn a network blip
+          # into a NEW red check, the opposite of this guard's job. On a
+          # query failure this falls through to "not hollow" (run the real
+          # check below), which is exactly this workflow's behavior before
+          # this guard existed, not a new failure mode.
+          if CONCLUSION=$(gh api "repos/${REPOSITORY}/actions/runs/${RUN_ID}/jobs" \
+            --jq '.jobs[] | select(.name == "Create GitHub Release") | .conclusion' 2>&1); then
+            if [ "${CONCLUSION}" = "success" ]; then
+              # Resolve the exact tag this run released rather than trusting
+              # VERIFY_VERSION=latest: `latest` only ever tracks the newest
+              # GA release/image — publish.yml never re-tags GHCR :latest for
+              # a `-rc`/prerelease suffix (its `type=raw,value=latest` gate),
+              # and GitHub's own "latest release" concept explicitly skips
+              # prereleases. Left as 'latest', a Release-triggered run for a
+              # *prerelease* tag would silently pass by re-verifying the
+              # PREVIOUS GA instead of what this run just published.
+              # head_sha is reliable here even though head_branch isn't (see
+              # the header note) — it's the exact tagged commit. Filtered to
+              # semver-shaped names for the same reason release.yml's own
+              # "Assert semver-shaped tag" step is: a 4-digit GSD milestone
+              # tag could in principle share a commit with a real release.
+              TAG=$(gh api "repos/${REPOSITORY}/tags" --paginate \
+                --jq ".[] | select(.commit.sha == \"${SHA}\") | .name" \
+                | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$' | head -1) || true
+              if [ -n "${TAG}" ]; then
+                echo "resolved_version=${TAG}" >> "$GITHUB_OUTPUT"
+              else
+                echo "::warning::could not resolve a semver tag for commit ${SHA}; falling back to VERIFY_VERSION=latest, which under-verifies a prerelease"
+              fi
+              echo "hollow=false" >> "$GITHUB_OUTPUT"
+            else
+              echo "::notice::triggering Release run created no release; nothing to verify (Create GitHub Release job conclusion: '${CONCLUSION:-absent}')"
+              echo "hollow=true" >> "$GITHUB_OUTPUT"
+            fi
+          else
+            echo "::warning::could not query the triggering Release run's jobs (gh api failed: ${CONCLUSION}); proceeding with verification as if not hollow"
+            echo "hollow=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Check release exists
+        if: ${{ steps.release_guard.outputs.hollow != 'true' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ steps.release_guard.outputs.resolved_version || env.VERIFY_VERSION }}
           REPOSITORY: ${{ github.repository }}
         run: |
           if [ "${VERSION}" = "latest" ]; then

--- a/.github/workflows/verify-published.yml
+++ b/.github/workflows/verify-published.yml
@@ -362,8 +362,30 @@ jobs:
                     # is unknown, is the partial-data selection this
                     # resolution exists to avoid. One immediate retry first
                     # for a single transient blip.
-                    if ! PUBLISHED=$(gh api "repos/${REPOSITORY}/releases/tags/${CANDIDATE}" --jq '.published_at' 2>/dev/null); then
-                      if ! PUBLISHED=$(gh api "repos/${REPOSITORY}/releases/tags/${CANDIDATE}" --jq '.published_at' 2>/dev/null); then
+                    #
+                    # fix(#1707): HTTP 404 is a definitive CONFIRMED-ABSENT
+                    # answer for that one candidate, not an unconfirmed one —
+                    # the guard already proved THIS run's release job
+                    # succeeded, so a 404 on a sibling tag just means that
+                    # sibling has no release, exactly like a draft's
+                    # published_at=null below. No retry needed, and it must
+                    # not count toward LOOKUP_FAILED: otherwise a merely
+                    # unlucky OLDER sibling (e.g. one whose own smoke failed,
+                    # so it was never released) can mask a genuinely
+                    # verifiable newer one. Matched conservatively on gh's
+                    # literal `(HTTP 404)` error suffix; anything that
+                    # doesn't match falls through to the transient-failure
+                    # retry below, and an unclassifiable failure still ends
+                    # up UNCONFIRMED — 404 is the one carve-out, fail-closed
+                    # stays the default for everything else.
+                    if ! PUBLISHED=$(gh api "repos/${REPOSITORY}/releases/tags/${CANDIDATE}" --jq '.published_at' 2>&1); then
+                      case "${PUBLISHED}" in
+                        *"(HTTP 404)"*) continue ;;
+                      esac
+                      if ! PUBLISHED=$(gh api "repos/${REPOSITORY}/releases/tags/${CANDIDATE}" --jq '.published_at' 2>&1); then
+                        case "${PUBLISHED}" in
+                          *"(HTTP 404)"*) continue ;;
+                        esac
                         LOOKUP_FAILED="${LOOKUP_FAILED}${LOOKUP_FAILED:+ }${CANDIDATE}"
                         continue
                       fi
@@ -569,8 +591,30 @@ jobs:
                     # is unknown, is the partial-data selection this
                     # resolution exists to avoid. One immediate retry first
                     # for a single transient blip.
-                    if ! PUBLISHED=$(gh api "repos/${REPOSITORY}/releases/tags/${CANDIDATE}" --jq '.published_at' 2>/dev/null); then
-                      if ! PUBLISHED=$(gh api "repos/${REPOSITORY}/releases/tags/${CANDIDATE}" --jq '.published_at' 2>/dev/null); then
+                    #
+                    # fix(#1707): HTTP 404 is a definitive CONFIRMED-ABSENT
+                    # answer for that one candidate, not an unconfirmed one —
+                    # the guard already proved THIS run's release job
+                    # succeeded, so a 404 on a sibling tag just means that
+                    # sibling has no release, exactly like a draft's
+                    # published_at=null below. No retry needed, and it must
+                    # not count toward LOOKUP_FAILED: otherwise a merely
+                    # unlucky OLDER sibling (e.g. one whose own smoke failed,
+                    # so it was never released) can mask a genuinely
+                    # verifiable newer one. Matched conservatively on gh's
+                    # literal `(HTTP 404)` error suffix; anything that
+                    # doesn't match falls through to the transient-failure
+                    # retry below, and an unclassifiable failure still ends
+                    # up UNCONFIRMED — 404 is the one carve-out, fail-closed
+                    # stays the default for everything else.
+                    if ! PUBLISHED=$(gh api "repos/${REPOSITORY}/releases/tags/${CANDIDATE}" --jq '.published_at' 2>&1); then
+                      case "${PUBLISHED}" in
+                        *"(HTTP 404)"*) continue ;;
+                      esac
+                      if ! PUBLISHED=$(gh api "repos/${REPOSITORY}/releases/tags/${CANDIDATE}" --jq '.published_at' 2>&1); then
+                        case "${PUBLISHED}" in
+                          *"(HTTP 404)"*) continue ;;
+                        esac
                         LOOKUP_FAILED="${LOOKUP_FAILED}${LOOKUP_FAILED:+ }${CANDIDATE}"
                         continue
                       fi

--- a/.github/workflows/verify-published.yml
+++ b/.github/workflows/verify-published.yml
@@ -313,12 +313,21 @@ jobs:
           # The `gh api` call is wrapped in an `if` (rather than a bare
           # `CONCLUSION=$(...)` assignment) so a transient API error can't
           # kill this step under `bash -e` — that would turn a network blip
-          # into a NEW red check, the opposite of this guard's job. On a
-          # query failure this falls through to "not hollow" (run the real
-          # check below), which is exactly this workflow's behavior before
-          # this guard existed, not a new failure mode.
+          # into a NEW red check, the opposite of this guard's job. It gets
+          # one immediate retry (the `||` below); if BOTH attempts fail,
+          # this now fails CLOSED into a loud skip (hollow=true + a
+          # distinct ::warning::), not a proceed-with-latest fallback. That
+          # fallback used to be described as "this workflow's behavior
+          # before this guard existed" — that reference point no longer
+          # applies; the guard IS the behavior now, and proceeding against
+          # unconfirmed data (VERIFY_VERSION=latest, with no idea whether
+          # the real release is a GA or a prerelease) is exactly the
+          # fail-open-on-unconfirmed-data class this file already fixed
+          # once, in the tag-resolution loop below.
           if CONCLUSION=$(gh api "repos/${REPOSITORY}/actions/runs/${RUN_ID}/jobs" \
-            --jq '.jobs[] | select(.name == "Create GitHub Release") | .conclusion' 2>&1); then
+              --jq '.jobs[] | select(.name == "Create GitHub Release") | .conclusion' 2>&1) \
+            || CONCLUSION=$(gh api "repos/${REPOSITORY}/actions/runs/${RUN_ID}/jobs" \
+              --jq '.jobs[] | select(.name == "Create GitHub Release") | .conclusion' 2>&1); then
             if [ "${CONCLUSION}" = "success" ]; then
               # Resolve the exact tag this run released rather than trusting
               # VERIFY_VERSION=latest: `latest` only ever tracks the newest
@@ -443,8 +452,8 @@ jobs:
               echo "hollow=true" >> "$GITHUB_OUTPUT"
             fi
           else
-            echo "::warning::could not query the triggering Release run's jobs (gh api failed: ${CONCLUSION}); proceeding with verification as if not hollow"
-            echo "hollow=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::could not confirm whether the triggering Release run (id ${RUN_ID}) actually created a release, after 2 attempts (gh api failed: ${CONCLUSION}); skipping verification rather than proceeding against an unconfirmed VERIFY_VERSION=latest. Re-verify explicitly once the API is healthy: gh workflow run verify-published.yml -f version=vX.Y.Z"
+            echo "hollow=true" >> "$GITHUB_OUTPUT"
           fi
 
       - name: docker pull published GHCR images
@@ -509,12 +518,21 @@ jobs:
           # The `gh api` call is wrapped in an `if` (rather than a bare
           # `CONCLUSION=$(...)` assignment) so a transient API error can't
           # kill this step under `bash -e` — that would turn a network blip
-          # into a NEW red check, the opposite of this guard's job. On a
-          # query failure this falls through to "not hollow" (run the real
-          # check below), which is exactly this workflow's behavior before
-          # this guard existed, not a new failure mode.
+          # into a NEW red check, the opposite of this guard's job. It gets
+          # one immediate retry (the `||` below); if BOTH attempts fail,
+          # this now fails CLOSED into a loud skip (hollow=true + a
+          # distinct ::warning::), not a proceed-with-latest fallback. That
+          # fallback used to be described as "this workflow's behavior
+          # before this guard existed" — that reference point no longer
+          # applies; the guard IS the behavior now, and proceeding against
+          # unconfirmed data (VERIFY_VERSION=latest, with no idea whether
+          # the real release is a GA or a prerelease) is exactly the
+          # fail-open-on-unconfirmed-data class this file already fixed
+          # once, in the tag-resolution loop below.
           if CONCLUSION=$(gh api "repos/${REPOSITORY}/actions/runs/${RUN_ID}/jobs" \
-            --jq '.jobs[] | select(.name == "Create GitHub Release") | .conclusion' 2>&1); then
+              --jq '.jobs[] | select(.name == "Create GitHub Release") | .conclusion' 2>&1) \
+            || CONCLUSION=$(gh api "repos/${REPOSITORY}/actions/runs/${RUN_ID}/jobs" \
+              --jq '.jobs[] | select(.name == "Create GitHub Release") | .conclusion' 2>&1); then
             if [ "${CONCLUSION}" = "success" ]; then
               # Resolve the exact tag this run released rather than trusting
               # VERIFY_VERSION=latest: `latest` only ever tracks the newest
@@ -639,8 +657,8 @@ jobs:
               echo "hollow=true" >> "$GITHUB_OUTPUT"
             fi
           else
-            echo "::warning::could not query the triggering Release run's jobs (gh api failed: ${CONCLUSION}); proceeding with verification as if not hollow"
-            echo "hollow=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::could not confirm whether the triggering Release run (id ${RUN_ID}) actually created a release, after 2 attempts (gh api failed: ${CONCLUSION}); skipping verification rather than proceeding against an unconfirmed VERIFY_VERSION=latest. Re-verify explicitly once the API is healthy: gh workflow run verify-published.yml -f version=vX.Y.Z"
+            echo "hollow=true" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Check release exists

--- a/.github/workflows/verify-published.yml
+++ b/.github/workflows/verify-published.yml
@@ -352,101 +352,133 @@ jobs:
               # release.yml's own "Assert semver-shaped tag" step is: a
               # 4-digit GSD milestone tag could in principle share a commit
               # with a real release.
-              MATCHES=$(gh api "repos/${REPOSITORY}/tags" --paginate \
-                --jq ".[] | select(.commit.sha == \"${SHA}\") | .name" \
-                | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$') || true
-              MATCH_COUNT=$(printf '%s\n' "${MATCHES}" | grep -c . || true)
-              # A commit can carry MORE THAN ONE semver tag: promoting an
-              # unchanged release candidate straight to GA (no new commit)
-              # tags the SAME sha as both `v1.17.0-rc.1` and `v1.17.0`, and
-              # `head -1` on the raw match list would arbitrarily pick
-              # whichever the tags API happened to list first — silently
-              # verifying the wrong one instead of failing loudly. Only
-              # trust the resolution outright when it's unambiguous
-              # (exactly one match). 0 matches falls back to
-              # VERIFY_VERSION=latest, same as a failed resolution always
-              # did. More than one match is resolved deterministically
-              # below rather than assumed to be an RC->GA promotion — that
-              # assumption doesn't hold for every ambiguous case: re-cutting
-              # `v1.17.0-rc.1` as `v1.17.0-rc.2` on an unchanged commit also
-              # lands here, and 'latest' would then silently verify the
-              # PREVIOUS GA (a prerelease never advances 'latest').
-              if [ "${MATCH_COUNT}" -eq 1 ]; then
-                TAG="${MATCHES}"
-                echo "resolved_version=${TAG}" >> "$GITHUB_OUTPUT"
-              elif [ "${MATCH_COUNT}" -eq 0 ]; then
-                echo "::warning::could not resolve a semver tag for commit ${SHA}; falling back to VERIFY_VERSION=latest, which under-verifies a prerelease"
-              else
-                # Resolve deterministically via the releases API instead of
-                # guessing from tag semantics: look up each matched tag's
-                # release and take the one with the newest created_at. In
-                # the ordinary case that IS the release this run's own
-                # trigger chain just created or updated — true for both an
-                # RC->GA promotion (GA release is newest) and an rc-recut
-                # (rc.2's release is newest) — with no assumption about
-                # which case produced the ambiguity.
-                #
-                # One exotic case where it picks a DIFFERENT matched tag:
-                # a manual rerun of an OLDER tag's Release run, on a commit
-                # that has since gained a newer released sibling. `gh
-                # release edit` (release.yml's rerun-onto-an-existing-
-                # release path) never changes created_at, so the older
-                # tag's release stays older and the newer sibling still
-                # wins here. That's fine, not a miss: the older tag already
-                # got its own correct verification cycle when IT was the
-                # newest match, and re-checking one specific superseded tag
-                # on demand is what manual `workflow_dispatch -f
-                # version=vX.Y.Z` is for (it bypasses this resolution
-                # entirely) — not a job for the automatic trigger path.
-                #
-                # Looked up per-candidate (releases/tags/{tag}) rather than
-                # listing+filtering the full releases collection: there are
-                # only ever a couple of matched tags here, and
-                # `gh api --paginate` applies --jq PER PAGE, so an aggregate
-                # sort/max over the whole paginated list would silently
-                # pick the wrong answer across a page boundary instead of
-                # the true global newest.
-                NEWEST_TAG=""
-                NEWEST_CREATED=""
-                LOOKUP_FAILED=""
-                while IFS= read -r CANDIDATE; do
-                  [ -z "${CANDIDATE}" ] && continue
-                  # A candidate whose lookup fails is FLAGGED, never
-                  # silently skipped: selecting the newest among only the
-                  # tags that happened to resolve, while one candidate's
-                  # real status is unknown, is exactly the partial-data
-                  # selection this whole resolution exists to avoid (a
-                  # transient failure on the true-newest candidate would
-                  # verify its OLDER sibling green instead of falling back
-                  # loudly). One immediate retry first, since a transient
-                  # API hiccup shouldn't discard an otherwise-resolvable
-                  # selection over a single blip.
-                  if ! CREATED=$(gh api "repos/${REPOSITORY}/releases/tags/${CANDIDATE}" --jq '.created_at' 2>/dev/null); then
-                    if ! CREATED=$(gh api "repos/${REPOSITORY}/releases/tags/${CANDIDATE}" --jq '.created_at' 2>/dev/null); then
-                      LOOKUP_FAILED="${LOOKUP_FAILED}${LOOKUP_FAILED:+ }${CANDIDATE}"
-                      continue
-                    fi
-                  fi
-                  if [ -z "${NEWEST_CREATED}" ] || [ "${CREATED}" \> "${NEWEST_CREATED}" ]; then
-                    NEWEST_CREATED="${CREATED}"
-                    NEWEST_TAG="${CANDIDATE}"
-                  fi
-                done <<< "${MATCHES}"
-                if [ -n "${LOOKUP_FAILED}" ]; then
-                  # Discard the partial selection entirely rather than
-                  # trusting NEWEST_TAG computed from incomplete data —
-                  # even if it's set, one candidate's real created_at was
-                  # never confirmed, so the "newest" claim can't be trusted.
-                  echo "::warning::could not confirm every matched tag's release for commit ${SHA} (lookup failed twice for: ${LOOKUP_FAILED}); refusing to select from a partial result — falling back to VERIFY_VERSION=latest"
-                elif [ -n "${NEWEST_TAG}" ]; then
-                  TAG="${NEWEST_TAG}"
-                  echo "::notice::commit ${SHA} matches ${MATCH_COUNT} semver tags ($(printf '%s' "${MATCHES}" | tr '\n' ' ')); resolved to the newest release among the matched tags: ${TAG} (created ${NEWEST_CREATED})"
-                  echo "resolved_version=${TAG}" >> "$GITHUB_OUTPUT"
-                else
-                  echo "::warning::commit ${SHA} matches ${MATCH_COUNT} semver tags ($(printf '%s' "${MATCHES}" | tr '\n' ' ')) but none has a GitHub Release yet (unexpected — the release job just succeeded); falling back to VERIFY_VERSION=latest"
+              # One rule, applied at every query in this branch:
+              # resolution CONFIRMED (a query succeeded and found exactly
+              # what's needed) -> use it. Resolution confirmed ABSENT
+              # (queries succeeded, legitimately zero/no-candidate result)
+              # -> VERIFY_VERSION=latest, the pre-existing best-effort
+              # fallback. Resolution UNCONFIRMED (any query failed even
+              # after one retry) -> the loud skip (hollow=true), never
+              # 'latest' and never a guess from partial data. The tags
+              # query below is retried and its OWN success/failure is
+              # tracked separately from "found zero matches", so an API
+              # failure can no longer masquerade as a legitimately-empty
+              # result and flow into the latest fallback the way `|| true`
+              # on the raw pipeline used to let it.
+              UNCONFIRMED=false
+              if ! RAW_TAGS=$(gh api "repos/${REPOSITORY}/tags" --paginate \
+                  --jq ".[] | select(.commit.sha == \"${SHA}\") | .name" 2>&1); then
+                if ! RAW_TAGS=$(gh api "repos/${REPOSITORY}/tags" --paginate \
+                    --jq ".[] | select(.commit.sha == \"${SHA}\") | .name" 2>&1); then
+                  echo "::warning::could not query tags for commit ${SHA} after 2 attempts (gh api failed: ${RAW_TAGS}); skipping verification rather than proceeding against an unconfirmed VERIFY_VERSION=latest. Re-verify explicitly once the API is healthy: gh workflow run verify-published.yml -f version=vX.Y.Z"
+                  UNCONFIRMED=true
                 fi
               fi
-              echo "hollow=false" >> "$GITHUB_OUTPUT"
+              if [ "${UNCONFIRMED}" != true ]; then
+                MATCHES=$(printf '%s\n' "${RAW_TAGS}" | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$') || true
+                MATCH_COUNT=$(printf '%s\n' "${MATCHES}" | grep -c . || true)
+                # A commit can carry MORE THAN ONE semver tag: promoting an
+                # unchanged release candidate straight to GA (no new commit)
+                # tags the SAME sha as both `v1.17.0-rc.1` and `v1.17.0`, and
+                # `head -1` on the raw match list would arbitrarily pick
+                # whichever the tags API happened to list first — silently
+                # verifying the wrong one instead of failing loudly. Only
+                # trust the resolution outright when it's unambiguous
+                # (exactly one match). 0 matches is a CONFIRMED-ABSENT
+                # result (the tags query above already succeeded), so it
+                # falls back to VERIFY_VERSION=latest, the pre-existing
+                # best-effort semantics. More than one match is resolved
+                # deterministically below rather than assumed to be an
+                # RC->GA promotion — that assumption doesn't hold for every
+                # ambiguous case: re-cutting `v1.17.0-rc.1` as
+                # `v1.17.0-rc.2` on an unchanged commit also lands here, and
+                # 'latest' would then silently verify the PREVIOUS GA (a
+                # prerelease never advances 'latest').
+                if [ "${MATCH_COUNT}" -eq 1 ]; then
+                  TAG="${MATCHES}"
+                  echo "resolved_version=${TAG}" >> "$GITHUB_OUTPUT"
+                elif [ "${MATCH_COUNT}" -eq 0 ]; then
+                  echo "::warning::could not resolve a semver tag for commit ${SHA}; falling back to VERIFY_VERSION=latest, which under-verifies a prerelease"
+                else
+                  # Resolve deterministically via the releases API instead of
+                  # guessing from tag semantics: look up each matched tag's
+                  # release and take the one with the newest created_at. In
+                  # the ordinary case that IS the release this run's own
+                  # trigger chain just created or updated — true for both an
+                  # RC->GA promotion (GA release is newest) and an rc-recut
+                  # (rc.2's release is newest) — with no assumption about
+                  # which case produced the ambiguity.
+                  #
+                  # One exotic case where it picks a DIFFERENT matched tag:
+                  # a manual rerun of an OLDER tag's Release run, on a commit
+                  # that has since gained a newer released sibling. `gh
+                  # release edit` (release.yml's rerun-onto-an-existing-
+                  # release path) never changes created_at, so the older
+                  # tag's release stays older and the newer sibling still
+                  # wins here. That's fine, not a miss: the older tag already
+                  # got its own correct verification cycle when IT was the
+                  # newest match, and re-checking one specific superseded tag
+                  # on demand is what manual `workflow_dispatch -f
+                  # version=vX.Y.Z` is for (it bypasses this resolution
+                  # entirely) — not a job for the automatic trigger path.
+                  #
+                  # Looked up per-candidate (releases/tags/{tag}) rather than
+                  # listing+filtering the full releases collection: there are
+                  # only ever a couple of matched tags here, and
+                  # `gh api --paginate` applies --jq PER PAGE, so an aggregate
+                  # sort/max over the whole paginated list would silently
+                  # pick the wrong answer across a page boundary instead of
+                  # the true global newest.
+                  NEWEST_TAG=""
+                  NEWEST_CREATED=""
+                  LOOKUP_FAILED=""
+                  while IFS= read -r CANDIDATE; do
+                    [ -z "${CANDIDATE}" ] && continue
+                    # A candidate whose lookup fails is FLAGGED, never
+                    # silently skipped: selecting the newest among only the
+                    # tags that happened to resolve, while one candidate's
+                    # real status is unknown, is exactly the partial-data
+                    # selection this whole resolution exists to avoid (a
+                    # transient failure on the true-newest candidate would
+                    # verify its OLDER sibling green instead of falling back
+                    # loudly). One immediate retry first, since a transient
+                    # API hiccup shouldn't discard an otherwise-resolvable
+                    # selection over a single blip.
+                    if ! CREATED=$(gh api "repos/${REPOSITORY}/releases/tags/${CANDIDATE}" --jq '.created_at' 2>/dev/null); then
+                      if ! CREATED=$(gh api "repos/${REPOSITORY}/releases/tags/${CANDIDATE}" --jq '.created_at' 2>/dev/null); then
+                        LOOKUP_FAILED="${LOOKUP_FAILED}${LOOKUP_FAILED:+ }${CANDIDATE}"
+                        continue
+                      fi
+                    fi
+                    if [ -z "${NEWEST_CREATED}" ] || [ "${CREATED}" \> "${NEWEST_CREATED}" ]; then
+                      NEWEST_CREATED="${CREATED}"
+                      NEWEST_TAG="${CANDIDATE}"
+                    fi
+                  done <<< "${MATCHES}"
+                  if [ -n "${LOOKUP_FAILED}" ]; then
+                    # UNCONFIRMED, not ABSENT: at least one candidate's real
+                    # created_at was never confirmed, so any "newest" claim
+                    # can't be trusted. Skip loudly (same as the tags-query
+                    # and outer-guard-query failure paths) instead of
+                    # falling back to 'latest' the way this branch used to —
+                    # that was the same fail-open-on-unconfirmed-data class
+                    # already fixed for the other two queries in this file.
+                    echo "::warning::could not confirm every matched tag's release for commit ${SHA} (lookup failed twice for: ${LOOKUP_FAILED}); skipping verification rather than proceeding against an unconfirmed VERIFY_VERSION=latest. Re-verify explicitly once the API is healthy: gh workflow run verify-published.yml -f version=vX.Y.Z"
+                    UNCONFIRMED=true
+                  elif [ -n "${NEWEST_TAG}" ]; then
+                    TAG="${NEWEST_TAG}"
+                    echo "::notice::commit ${SHA} matches ${MATCH_COUNT} semver tags ($(printf '%s' "${MATCHES}" | tr '\n' ' ')); resolved to the newest release among the matched tags: ${TAG} (created ${NEWEST_CREATED})"
+                    echo "resolved_version=${TAG}" >> "$GITHUB_OUTPUT"
+                  else
+                    echo "::warning::commit ${SHA} matches ${MATCH_COUNT} semver tags ($(printf '%s' "${MATCHES}" | tr '\n' ' ')) but none has a GitHub Release yet (unexpected — the release job just succeeded); falling back to VERIFY_VERSION=latest"
+                  fi
+                fi
+              fi
+              if [ "${UNCONFIRMED}" = true ]; then
+                echo "hollow=true" >> "$GITHUB_OUTPUT"
+              else
+                echo "hollow=false" >> "$GITHUB_OUTPUT"
+              fi
             else
               echo "::notice::triggering Release run created no release; nothing to verify (Create GitHub Release job conclusion: '${CONCLUSION:-absent}')"
               echo "hollow=true" >> "$GITHUB_OUTPUT"
@@ -557,101 +589,133 @@ jobs:
               # release.yml's own "Assert semver-shaped tag" step is: a
               # 4-digit GSD milestone tag could in principle share a commit
               # with a real release.
-              MATCHES=$(gh api "repos/${REPOSITORY}/tags" --paginate \
-                --jq ".[] | select(.commit.sha == \"${SHA}\") | .name" \
-                | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$') || true
-              MATCH_COUNT=$(printf '%s\n' "${MATCHES}" | grep -c . || true)
-              # A commit can carry MORE THAN ONE semver tag: promoting an
-              # unchanged release candidate straight to GA (no new commit)
-              # tags the SAME sha as both `v1.17.0-rc.1` and `v1.17.0`, and
-              # `head -1` on the raw match list would arbitrarily pick
-              # whichever the tags API happened to list first — silently
-              # verifying the wrong one instead of failing loudly. Only
-              # trust the resolution outright when it's unambiguous
-              # (exactly one match). 0 matches falls back to
-              # VERIFY_VERSION=latest, same as a failed resolution always
-              # did. More than one match is resolved deterministically
-              # below rather than assumed to be an RC->GA promotion — that
-              # assumption doesn't hold for every ambiguous case: re-cutting
-              # `v1.17.0-rc.1` as `v1.17.0-rc.2` on an unchanged commit also
-              # lands here, and 'latest' would then silently verify the
-              # PREVIOUS GA (a prerelease never advances 'latest').
-              if [ "${MATCH_COUNT}" -eq 1 ]; then
-                TAG="${MATCHES}"
-                echo "resolved_version=${TAG}" >> "$GITHUB_OUTPUT"
-              elif [ "${MATCH_COUNT}" -eq 0 ]; then
-                echo "::warning::could not resolve a semver tag for commit ${SHA}; falling back to VERIFY_VERSION=latest, which under-verifies a prerelease"
-              else
-                # Resolve deterministically via the releases API instead of
-                # guessing from tag semantics: look up each matched tag's
-                # release and take the one with the newest created_at. In
-                # the ordinary case that IS the release this run's own
-                # trigger chain just created or updated — true for both an
-                # RC->GA promotion (GA release is newest) and an rc-recut
-                # (rc.2's release is newest) — with no assumption about
-                # which case produced the ambiguity.
-                #
-                # One exotic case where it picks a DIFFERENT matched tag:
-                # a manual rerun of an OLDER tag's Release run, on a commit
-                # that has since gained a newer released sibling. `gh
-                # release edit` (release.yml's rerun-onto-an-existing-
-                # release path) never changes created_at, so the older
-                # tag's release stays older and the newer sibling still
-                # wins here. That's fine, not a miss: the older tag already
-                # got its own correct verification cycle when IT was the
-                # newest match, and re-checking one specific superseded tag
-                # on demand is what manual `workflow_dispatch -f
-                # version=vX.Y.Z` is for (it bypasses this resolution
-                # entirely) — not a job for the automatic trigger path.
-                #
-                # Looked up per-candidate (releases/tags/{tag}) rather than
-                # listing+filtering the full releases collection: there are
-                # only ever a couple of matched tags here, and
-                # `gh api --paginate` applies --jq PER PAGE, so an aggregate
-                # sort/max over the whole paginated list would silently
-                # pick the wrong answer across a page boundary instead of
-                # the true global newest.
-                NEWEST_TAG=""
-                NEWEST_CREATED=""
-                LOOKUP_FAILED=""
-                while IFS= read -r CANDIDATE; do
-                  [ -z "${CANDIDATE}" ] && continue
-                  # A candidate whose lookup fails is FLAGGED, never
-                  # silently skipped: selecting the newest among only the
-                  # tags that happened to resolve, while one candidate's
-                  # real status is unknown, is exactly the partial-data
-                  # selection this whole resolution exists to avoid (a
-                  # transient failure on the true-newest candidate would
-                  # verify its OLDER sibling green instead of falling back
-                  # loudly). One immediate retry first, since a transient
-                  # API hiccup shouldn't discard an otherwise-resolvable
-                  # selection over a single blip.
-                  if ! CREATED=$(gh api "repos/${REPOSITORY}/releases/tags/${CANDIDATE}" --jq '.created_at' 2>/dev/null); then
-                    if ! CREATED=$(gh api "repos/${REPOSITORY}/releases/tags/${CANDIDATE}" --jq '.created_at' 2>/dev/null); then
-                      LOOKUP_FAILED="${LOOKUP_FAILED}${LOOKUP_FAILED:+ }${CANDIDATE}"
-                      continue
-                    fi
-                  fi
-                  if [ -z "${NEWEST_CREATED}" ] || [ "${CREATED}" \> "${NEWEST_CREATED}" ]; then
-                    NEWEST_CREATED="${CREATED}"
-                    NEWEST_TAG="${CANDIDATE}"
-                  fi
-                done <<< "${MATCHES}"
-                if [ -n "${LOOKUP_FAILED}" ]; then
-                  # Discard the partial selection entirely rather than
-                  # trusting NEWEST_TAG computed from incomplete data —
-                  # even if it's set, one candidate's real created_at was
-                  # never confirmed, so the "newest" claim can't be trusted.
-                  echo "::warning::could not confirm every matched tag's release for commit ${SHA} (lookup failed twice for: ${LOOKUP_FAILED}); refusing to select from a partial result — falling back to VERIFY_VERSION=latest"
-                elif [ -n "${NEWEST_TAG}" ]; then
-                  TAG="${NEWEST_TAG}"
-                  echo "::notice::commit ${SHA} matches ${MATCH_COUNT} semver tags ($(printf '%s' "${MATCHES}" | tr '\n' ' ')); resolved to the newest release among the matched tags: ${TAG} (created ${NEWEST_CREATED})"
-                  echo "resolved_version=${TAG}" >> "$GITHUB_OUTPUT"
-                else
-                  echo "::warning::commit ${SHA} matches ${MATCH_COUNT} semver tags ($(printf '%s' "${MATCHES}" | tr '\n' ' ')) but none has a GitHub Release yet (unexpected — the release job just succeeded); falling back to VERIFY_VERSION=latest"
+              # One rule, applied at every query in this branch:
+              # resolution CONFIRMED (a query succeeded and found exactly
+              # what's needed) -> use it. Resolution confirmed ABSENT
+              # (queries succeeded, legitimately zero/no-candidate result)
+              # -> VERIFY_VERSION=latest, the pre-existing best-effort
+              # fallback. Resolution UNCONFIRMED (any query failed even
+              # after one retry) -> the loud skip (hollow=true), never
+              # 'latest' and never a guess from partial data. The tags
+              # query below is retried and its OWN success/failure is
+              # tracked separately from "found zero matches", so an API
+              # failure can no longer masquerade as a legitimately-empty
+              # result and flow into the latest fallback the way `|| true`
+              # on the raw pipeline used to let it.
+              UNCONFIRMED=false
+              if ! RAW_TAGS=$(gh api "repos/${REPOSITORY}/tags" --paginate \
+                  --jq ".[] | select(.commit.sha == \"${SHA}\") | .name" 2>&1); then
+                if ! RAW_TAGS=$(gh api "repos/${REPOSITORY}/tags" --paginate \
+                    --jq ".[] | select(.commit.sha == \"${SHA}\") | .name" 2>&1); then
+                  echo "::warning::could not query tags for commit ${SHA} after 2 attempts (gh api failed: ${RAW_TAGS}); skipping verification rather than proceeding against an unconfirmed VERIFY_VERSION=latest. Re-verify explicitly once the API is healthy: gh workflow run verify-published.yml -f version=vX.Y.Z"
+                  UNCONFIRMED=true
                 fi
               fi
-              echo "hollow=false" >> "$GITHUB_OUTPUT"
+              if [ "${UNCONFIRMED}" != true ]; then
+                MATCHES=$(printf '%s\n' "${RAW_TAGS}" | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$') || true
+                MATCH_COUNT=$(printf '%s\n' "${MATCHES}" | grep -c . || true)
+                # A commit can carry MORE THAN ONE semver tag: promoting an
+                # unchanged release candidate straight to GA (no new commit)
+                # tags the SAME sha as both `v1.17.0-rc.1` and `v1.17.0`, and
+                # `head -1` on the raw match list would arbitrarily pick
+                # whichever the tags API happened to list first — silently
+                # verifying the wrong one instead of failing loudly. Only
+                # trust the resolution outright when it's unambiguous
+                # (exactly one match). 0 matches is a CONFIRMED-ABSENT
+                # result (the tags query above already succeeded), so it
+                # falls back to VERIFY_VERSION=latest, the pre-existing
+                # best-effort semantics. More than one match is resolved
+                # deterministically below rather than assumed to be an
+                # RC->GA promotion — that assumption doesn't hold for every
+                # ambiguous case: re-cutting `v1.17.0-rc.1` as
+                # `v1.17.0-rc.2` on an unchanged commit also lands here, and
+                # 'latest' would then silently verify the PREVIOUS GA (a
+                # prerelease never advances 'latest').
+                if [ "${MATCH_COUNT}" -eq 1 ]; then
+                  TAG="${MATCHES}"
+                  echo "resolved_version=${TAG}" >> "$GITHUB_OUTPUT"
+                elif [ "${MATCH_COUNT}" -eq 0 ]; then
+                  echo "::warning::could not resolve a semver tag for commit ${SHA}; falling back to VERIFY_VERSION=latest, which under-verifies a prerelease"
+                else
+                  # Resolve deterministically via the releases API instead of
+                  # guessing from tag semantics: look up each matched tag's
+                  # release and take the one with the newest created_at. In
+                  # the ordinary case that IS the release this run's own
+                  # trigger chain just created or updated — true for both an
+                  # RC->GA promotion (GA release is newest) and an rc-recut
+                  # (rc.2's release is newest) — with no assumption about
+                  # which case produced the ambiguity.
+                  #
+                  # One exotic case where it picks a DIFFERENT matched tag:
+                  # a manual rerun of an OLDER tag's Release run, on a commit
+                  # that has since gained a newer released sibling. `gh
+                  # release edit` (release.yml's rerun-onto-an-existing-
+                  # release path) never changes created_at, so the older
+                  # tag's release stays older and the newer sibling still
+                  # wins here. That's fine, not a miss: the older tag already
+                  # got its own correct verification cycle when IT was the
+                  # newest match, and re-checking one specific superseded tag
+                  # on demand is what manual `workflow_dispatch -f
+                  # version=vX.Y.Z` is for (it bypasses this resolution
+                  # entirely) — not a job for the automatic trigger path.
+                  #
+                  # Looked up per-candidate (releases/tags/{tag}) rather than
+                  # listing+filtering the full releases collection: there are
+                  # only ever a couple of matched tags here, and
+                  # `gh api --paginate` applies --jq PER PAGE, so an aggregate
+                  # sort/max over the whole paginated list would silently
+                  # pick the wrong answer across a page boundary instead of
+                  # the true global newest.
+                  NEWEST_TAG=""
+                  NEWEST_CREATED=""
+                  LOOKUP_FAILED=""
+                  while IFS= read -r CANDIDATE; do
+                    [ -z "${CANDIDATE}" ] && continue
+                    # A candidate whose lookup fails is FLAGGED, never
+                    # silently skipped: selecting the newest among only the
+                    # tags that happened to resolve, while one candidate's
+                    # real status is unknown, is exactly the partial-data
+                    # selection this whole resolution exists to avoid (a
+                    # transient failure on the true-newest candidate would
+                    # verify its OLDER sibling green instead of falling back
+                    # loudly). One immediate retry first, since a transient
+                    # API hiccup shouldn't discard an otherwise-resolvable
+                    # selection over a single blip.
+                    if ! CREATED=$(gh api "repos/${REPOSITORY}/releases/tags/${CANDIDATE}" --jq '.created_at' 2>/dev/null); then
+                      if ! CREATED=$(gh api "repos/${REPOSITORY}/releases/tags/${CANDIDATE}" --jq '.created_at' 2>/dev/null); then
+                        LOOKUP_FAILED="${LOOKUP_FAILED}${LOOKUP_FAILED:+ }${CANDIDATE}"
+                        continue
+                      fi
+                    fi
+                    if [ -z "${NEWEST_CREATED}" ] || [ "${CREATED}" \> "${NEWEST_CREATED}" ]; then
+                      NEWEST_CREATED="${CREATED}"
+                      NEWEST_TAG="${CANDIDATE}"
+                    fi
+                  done <<< "${MATCHES}"
+                  if [ -n "${LOOKUP_FAILED}" ]; then
+                    # UNCONFIRMED, not ABSENT: at least one candidate's real
+                    # created_at was never confirmed, so any "newest" claim
+                    # can't be trusted. Skip loudly (same as the tags-query
+                    # and outer-guard-query failure paths) instead of
+                    # falling back to 'latest' the way this branch used to —
+                    # that was the same fail-open-on-unconfirmed-data class
+                    # already fixed for the other two queries in this file.
+                    echo "::warning::could not confirm every matched tag's release for commit ${SHA} (lookup failed twice for: ${LOOKUP_FAILED}); skipping verification rather than proceeding against an unconfirmed VERIFY_VERSION=latest. Re-verify explicitly once the API is healthy: gh workflow run verify-published.yml -f version=vX.Y.Z"
+                    UNCONFIRMED=true
+                  elif [ -n "${NEWEST_TAG}" ]; then
+                    TAG="${NEWEST_TAG}"
+                    echo "::notice::commit ${SHA} matches ${MATCH_COUNT} semver tags ($(printf '%s' "${MATCHES}" | tr '\n' ' ')); resolved to the newest release among the matched tags: ${TAG} (created ${NEWEST_CREATED})"
+                    echo "resolved_version=${TAG}" >> "$GITHUB_OUTPUT"
+                  else
+                    echo "::warning::commit ${SHA} matches ${MATCH_COUNT} semver tags ($(printf '%s' "${MATCHES}" | tr '\n' ' ')) but none has a GitHub Release yet (unexpected — the release job just succeeded); falling back to VERIFY_VERSION=latest"
+                  fi
+                fi
+              fi
+              if [ "${UNCONFIRMED}" = true ]; then
+                echo "hollow=true" >> "$GITHUB_OUTPUT"
+              else
+                echo "hollow=false" >> "$GITHUB_OUTPUT"
+              fi
             else
               echo "::notice::triggering Release run created no release; nothing to verify (Create GitHub Release job conclusion: '${CONCLUSION:-absent}')"
               echo "hollow=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/verify-published.yml
+++ b/.github/workflows/verify-published.yml
@@ -402,25 +402,49 @@ jobs:
                 else
                   # Resolve deterministically via the releases API instead of
                   # guessing from tag semantics: look up each matched tag's
-                  # release and take the one with the newest created_at. In
-                  # the ordinary case that IS the release this run's own
-                  # trigger chain just created or updated — true for both an
-                  # RC->GA promotion (GA release is newest) and an rc-recut
-                  # (rc.2's release is newest) — with no assumption about
-                  # which case produced the ambiguity.
+                  # release and take the one with the newest published_at.
+                  #
+                  # NOT created_at, which an earlier version of this branch
+                  # used: for a release created against an EXISTING tagged
+                  # commit (exactly this ambiguous case — the whole point is
+                  # that both matched tags share one commit), GitHub sets
+                  # created_at to the target COMMIT's date, not the moment
+                  # `gh release create` ran. This repo's own data proves it:
+                  # v1.16.1's release created_at (2026-08-28T18:07:09Z)
+                  # equals its tag commit's date exactly, while published_at
+                  # (18:48:48Z) is the real gh-release-create moment — same
+                  # pattern confirmed on v1.16.0 and v1.15.1. Two tags on the
+                  # SAME commit therefore carry IDENTICAL created_at values,
+                  # the strict `>` comparison below never fires for the
+                  # second one, and the loop silently kept whichever tag the
+                  # tags API happened to list first — not deterministic at
+                  # all for exactly the case this branch exists to handle.
+                  # published_at does not have this problem: it is set once,
+                  # at the actual publish moment, and differs between two
+                  # releases of the same commit exactly when one was
+                  # published later than the other.
+                  #
+                  # In the ordinary case the newest-published release IS the
+                  # release this run's own trigger chain just created or
+                  # updated — true for both an RC->GA promotion (GA release
+                  # is newest) and an rc-recut (rc.2's release is newest) —
+                  # with no assumption about which case produced the
+                  # ambiguity.
                   #
                   # One exotic case where it picks a DIFFERENT matched tag:
                   # a manual rerun of an OLDER tag's Release run, on a commit
                   # that has since gained a newer released sibling. `gh
                   # release edit` (release.yml's rerun-onto-an-existing-
-                  # release path) never changes created_at, so the older
-                  # tag's release stays older and the newer sibling still
-                  # wins here. That's fine, not a miss: the older tag already
-                  # got its own correct verification cycle when IT was the
-                  # newest match, and re-checking one specific superseded tag
-                  # on demand is what manual `workflow_dispatch -f
-                  # version=vX.Y.Z` is for (it bypasses this resolution
-                  # entirely) — not a job for the automatic trigger path.
+                  # release path) changes neither created_at nor
+                  # published_at, so the older tag's release stays older and
+                  # the newer sibling still wins here — this analysis
+                  # transfers unchanged from the created_at version. That's
+                  # fine, not a miss: the older tag already got its own
+                  # correct verification cycle when IT was the newest match,
+                  # and re-checking one specific superseded tag on demand is
+                  # what manual `workflow_dispatch -f version=vX.Y.Z` is for
+                  # (it bypasses this resolution entirely) — not a job for
+                  # the automatic trigger path.
                   #
                   # Looked up per-candidate (releases/tags/{tag}) rather than
                   # listing+filtering the full releases collection: there are
@@ -430,7 +454,7 @@ jobs:
                   # pick the wrong answer across a page boundary instead of
                   # the true global newest.
                   NEWEST_TAG=""
-                  NEWEST_CREATED=""
+                  NEWEST_PUBLISHED=""
                   LOOKUP_FAILED=""
                   while IFS= read -r CANDIDATE; do
                     [ -z "${CANDIDATE}" ] && continue
@@ -444,33 +468,45 @@ jobs:
                     # loudly). One immediate retry first, since a transient
                     # API hiccup shouldn't discard an otherwise-resolvable
                     # selection over a single blip.
-                    if ! CREATED=$(gh api "repos/${REPOSITORY}/releases/tags/${CANDIDATE}" --jq '.created_at' 2>/dev/null); then
-                      if ! CREATED=$(gh api "repos/${REPOSITORY}/releases/tags/${CANDIDATE}" --jq '.created_at' 2>/dev/null); then
+                    if ! PUBLISHED=$(gh api "repos/${REPOSITORY}/releases/tags/${CANDIDATE}" --jq '.published_at' 2>/dev/null); then
+                      if ! PUBLISHED=$(gh api "repos/${REPOSITORY}/releases/tags/${CANDIDATE}" --jq '.published_at' 2>/dev/null); then
                         LOOKUP_FAILED="${LOOKUP_FAILED}${LOOKUP_FAILED:+ }${CANDIDATE}"
                         continue
                       fi
                     fi
-                    if [ -z "${NEWEST_CREATED}" ] || [ "${CREATED}" \> "${NEWEST_CREATED}" ]; then
-                      NEWEST_CREATED="${CREATED}"
+                    # A draft release has published_at=null (gh api prints
+                    # the literal string "null"); this pipeline never
+                    # creates drafts, so a null here means this candidate is
+                    # confirmed NOT to be the release this trigger chain
+                    # just published. Exclude it from the newest comparison
+                    # without treating the whole resolution as UNCONFIRMED —
+                    # the query itself succeeded, it just isn't a
+                    # candidate.
+                    if [ "${PUBLISHED}" = "null" ] || [ -z "${PUBLISHED}" ]; then
+                      continue
+                    fi
+                    if [ -z "${NEWEST_PUBLISHED}" ] || [ "${PUBLISHED}" \> "${NEWEST_PUBLISHED}" ]; then
+                      NEWEST_PUBLISHED="${PUBLISHED}"
                       NEWEST_TAG="${CANDIDATE}"
                     fi
                   done <<< "${MATCHES}"
                   if [ -n "${LOOKUP_FAILED}" ]; then
                     # UNCONFIRMED, not ABSENT: at least one candidate's real
-                    # created_at was never confirmed, so any "newest" claim
-                    # can't be trusted. Skip loudly (same as the tags-query
-                    # and outer-guard-query failure paths) instead of
-                    # falling back to 'latest' the way this branch used to —
-                    # that was the same fail-open-on-unconfirmed-data class
-                    # already fixed for the other two queries in this file.
+                    # published_at was never confirmed, so any "newest"
+                    # claim can't be trusted. Skip loudly (same as the
+                    # tags-query and outer-guard-query failure paths)
+                    # instead of falling back to 'latest' the way this
+                    # branch used to — that was the same
+                    # fail-open-on-unconfirmed-data class already fixed for
+                    # the other two queries in this file.
                     echo "::warning::could not confirm every matched tag's release for commit ${SHA} (lookup failed twice for: ${LOOKUP_FAILED}); skipping verification rather than proceeding against an unconfirmed VERIFY_VERSION=latest. Re-verify explicitly once the API is healthy: gh workflow run verify-published.yml -f version=vX.Y.Z"
                     UNCONFIRMED=true
                   elif [ -n "${NEWEST_TAG}" ]; then
                     TAG="${NEWEST_TAG}"
-                    echo "::notice::commit ${SHA} matches ${MATCH_COUNT} semver tags ($(printf '%s' "${MATCHES}" | tr '\n' ' ')); resolved to the newest release among the matched tags: ${TAG} (created ${NEWEST_CREATED})"
+                    echo "::notice::commit ${SHA} matches ${MATCH_COUNT} semver tags ($(printf '%s' "${MATCHES}" | tr '\n' ' ')); resolved to the most-recently-published release among the matched tags: ${TAG} (published ${NEWEST_PUBLISHED})"
                     echo "resolved_version=${TAG}" >> "$GITHUB_OUTPUT"
                   else
-                    echo "::warning::commit ${SHA} matches ${MATCH_COUNT} semver tags ($(printf '%s' "${MATCHES}" | tr '\n' ' ')) but none has a GitHub Release yet (unexpected — the release job just succeeded); falling back to VERIFY_VERSION=latest"
+                    echo "::warning::commit ${SHA} matches ${MATCH_COUNT} semver tags ($(printf '%s' "${MATCHES}" | tr '\n' ' ')) but none has a published GitHub Release yet (unexpected — the release job just succeeded); falling back to VERIFY_VERSION=latest"
                   fi
                 fi
               fi
@@ -639,25 +675,49 @@ jobs:
                 else
                   # Resolve deterministically via the releases API instead of
                   # guessing from tag semantics: look up each matched tag's
-                  # release and take the one with the newest created_at. In
-                  # the ordinary case that IS the release this run's own
-                  # trigger chain just created or updated — true for both an
-                  # RC->GA promotion (GA release is newest) and an rc-recut
-                  # (rc.2's release is newest) — with no assumption about
-                  # which case produced the ambiguity.
+                  # release and take the one with the newest published_at.
+                  #
+                  # NOT created_at, which an earlier version of this branch
+                  # used: for a release created against an EXISTING tagged
+                  # commit (exactly this ambiguous case — the whole point is
+                  # that both matched tags share one commit), GitHub sets
+                  # created_at to the target COMMIT's date, not the moment
+                  # `gh release create` ran. This repo's own data proves it:
+                  # v1.16.1's release created_at (2026-08-28T18:07:09Z)
+                  # equals its tag commit's date exactly, while published_at
+                  # (18:48:48Z) is the real gh-release-create moment — same
+                  # pattern confirmed on v1.16.0 and v1.15.1. Two tags on the
+                  # SAME commit therefore carry IDENTICAL created_at values,
+                  # the strict `>` comparison below never fires for the
+                  # second one, and the loop silently kept whichever tag the
+                  # tags API happened to list first — not deterministic at
+                  # all for exactly the case this branch exists to handle.
+                  # published_at does not have this problem: it is set once,
+                  # at the actual publish moment, and differs between two
+                  # releases of the same commit exactly when one was
+                  # published later than the other.
+                  #
+                  # In the ordinary case the newest-published release IS the
+                  # release this run's own trigger chain just created or
+                  # updated — true for both an RC->GA promotion (GA release
+                  # is newest) and an rc-recut (rc.2's release is newest) —
+                  # with no assumption about which case produced the
+                  # ambiguity.
                   #
                   # One exotic case where it picks a DIFFERENT matched tag:
                   # a manual rerun of an OLDER tag's Release run, on a commit
                   # that has since gained a newer released sibling. `gh
                   # release edit` (release.yml's rerun-onto-an-existing-
-                  # release path) never changes created_at, so the older
-                  # tag's release stays older and the newer sibling still
-                  # wins here. That's fine, not a miss: the older tag already
-                  # got its own correct verification cycle when IT was the
-                  # newest match, and re-checking one specific superseded tag
-                  # on demand is what manual `workflow_dispatch -f
-                  # version=vX.Y.Z` is for (it bypasses this resolution
-                  # entirely) — not a job for the automatic trigger path.
+                  # release path) changes neither created_at nor
+                  # published_at, so the older tag's release stays older and
+                  # the newer sibling still wins here — this analysis
+                  # transfers unchanged from the created_at version. That's
+                  # fine, not a miss: the older tag already got its own
+                  # correct verification cycle when IT was the newest match,
+                  # and re-checking one specific superseded tag on demand is
+                  # what manual `workflow_dispatch -f version=vX.Y.Z` is for
+                  # (it bypasses this resolution entirely) — not a job for
+                  # the automatic trigger path.
                   #
                   # Looked up per-candidate (releases/tags/{tag}) rather than
                   # listing+filtering the full releases collection: there are
@@ -667,7 +727,7 @@ jobs:
                   # pick the wrong answer across a page boundary instead of
                   # the true global newest.
                   NEWEST_TAG=""
-                  NEWEST_CREATED=""
+                  NEWEST_PUBLISHED=""
                   LOOKUP_FAILED=""
                   while IFS= read -r CANDIDATE; do
                     [ -z "${CANDIDATE}" ] && continue
@@ -681,33 +741,45 @@ jobs:
                     # loudly). One immediate retry first, since a transient
                     # API hiccup shouldn't discard an otherwise-resolvable
                     # selection over a single blip.
-                    if ! CREATED=$(gh api "repos/${REPOSITORY}/releases/tags/${CANDIDATE}" --jq '.created_at' 2>/dev/null); then
-                      if ! CREATED=$(gh api "repos/${REPOSITORY}/releases/tags/${CANDIDATE}" --jq '.created_at' 2>/dev/null); then
+                    if ! PUBLISHED=$(gh api "repos/${REPOSITORY}/releases/tags/${CANDIDATE}" --jq '.published_at' 2>/dev/null); then
+                      if ! PUBLISHED=$(gh api "repos/${REPOSITORY}/releases/tags/${CANDIDATE}" --jq '.published_at' 2>/dev/null); then
                         LOOKUP_FAILED="${LOOKUP_FAILED}${LOOKUP_FAILED:+ }${CANDIDATE}"
                         continue
                       fi
                     fi
-                    if [ -z "${NEWEST_CREATED}" ] || [ "${CREATED}" \> "${NEWEST_CREATED}" ]; then
-                      NEWEST_CREATED="${CREATED}"
+                    # A draft release has published_at=null (gh api prints
+                    # the literal string "null"); this pipeline never
+                    # creates drafts, so a null here means this candidate is
+                    # confirmed NOT to be the release this trigger chain
+                    # just published. Exclude it from the newest comparison
+                    # without treating the whole resolution as UNCONFIRMED —
+                    # the query itself succeeded, it just isn't a
+                    # candidate.
+                    if [ "${PUBLISHED}" = "null" ] || [ -z "${PUBLISHED}" ]; then
+                      continue
+                    fi
+                    if [ -z "${NEWEST_PUBLISHED}" ] || [ "${PUBLISHED}" \> "${NEWEST_PUBLISHED}" ]; then
+                      NEWEST_PUBLISHED="${PUBLISHED}"
                       NEWEST_TAG="${CANDIDATE}"
                     fi
                   done <<< "${MATCHES}"
                   if [ -n "${LOOKUP_FAILED}" ]; then
                     # UNCONFIRMED, not ABSENT: at least one candidate's real
-                    # created_at was never confirmed, so any "newest" claim
-                    # can't be trusted. Skip loudly (same as the tags-query
-                    # and outer-guard-query failure paths) instead of
-                    # falling back to 'latest' the way this branch used to —
-                    # that was the same fail-open-on-unconfirmed-data class
-                    # already fixed for the other two queries in this file.
+                    # published_at was never confirmed, so any "newest"
+                    # claim can't be trusted. Skip loudly (same as the
+                    # tags-query and outer-guard-query failure paths)
+                    # instead of falling back to 'latest' the way this
+                    # branch used to — that was the same
+                    # fail-open-on-unconfirmed-data class already fixed for
+                    # the other two queries in this file.
                     echo "::warning::could not confirm every matched tag's release for commit ${SHA} (lookup failed twice for: ${LOOKUP_FAILED}); skipping verification rather than proceeding against an unconfirmed VERIFY_VERSION=latest. Re-verify explicitly once the API is healthy: gh workflow run verify-published.yml -f version=vX.Y.Z"
                     UNCONFIRMED=true
                   elif [ -n "${NEWEST_TAG}" ]; then
                     TAG="${NEWEST_TAG}"
-                    echo "::notice::commit ${SHA} matches ${MATCH_COUNT} semver tags ($(printf '%s' "${MATCHES}" | tr '\n' ' ')); resolved to the newest release among the matched tags: ${TAG} (created ${NEWEST_CREATED})"
+                    echo "::notice::commit ${SHA} matches ${MATCH_COUNT} semver tags ($(printf '%s' "${MATCHES}" | tr '\n' ' ')); resolved to the most-recently-published release among the matched tags: ${TAG} (published ${NEWEST_PUBLISHED})"
                     echo "resolved_version=${TAG}" >> "$GITHUB_OUTPUT"
                   else
-                    echo "::warning::commit ${SHA} matches ${MATCH_COUNT} semver tags ($(printf '%s' "${MATCHES}" | tr '\n' ' ')) but none has a GitHub Release yet (unexpected — the release job just succeeded); falling back to VERIFY_VERSION=latest"
+                    echo "::warning::commit ${SHA} matches ${MATCH_COUNT} semver tags ($(printf '%s' "${MATCHES}" | tr '\n' ' ')) but none has a published GitHub Release yet (unexpected — the release job just succeeded); falling back to VERIFY_VERSION=latest"
                   fi
                 fi
               fi


### PR DESCRIPTION
## What

`verify-published.yml` triggers off `workflow_run` for `Publish SDKs`, `Publish CLI`, `Publish MCP Server` completing. Its `Verify GitHub Release` and `Verify GHCR images` jobs poll `gh release view` / `docker pull ghcr.io/...` for up to 5 minutes (20 attempts × 15s) before giving up. That polling window races the *actual* release-creation path, which runs on a separate, much slower schedule: `push: tags` → `Prod Compose Smoke` (pulls the just-built GHCR images, boots the full prod compose stack, runs the Playwright audit suite, 40-minute timeout) → on success, `Release` (`workflow_run`) creates the GitHub Release.

The SDK/CLI/MCP publishes are gated behind a required-reviewer approval click on the `publish` environment, so their completion time has no relationship to how long `Prod Compose Smoke` takes. When the approval lands early (the normal case — see below), this workflow starts polling for a release that won't exist for many more minutes, exhausts its retry window, and goes red — needing a manual rerun that then passes trivially because the release has since appeared.

## Measured gap (v1.16.0)

Pulled directly from `gh run view` / `gh release view` on `geolens-io/geolens`, not simulated:

- `19:16:52` / `19:17:04` — two `workflow_run` triggers fire off the Publish CLI/MCP/SDK completions (run ids `33107676929`, `33107693181`; a third duplicate was queue-cancelled by the concurrency group).
- `19:16:56`–`19:21:49` — first run's `Verify GitHub Release` job polls 20×15s and fails: `release v1.16.0 not found after 20 attempts (~300s)`. Its `Verify GHCR images` job fails the same way in the same window.
- `19:22:03`–`19:26:55` — second run, queued behind the first by the concurrency group, retries the same checks and fails again (`Verify GitHub Release` still not found; `Verify GHCR images` passes this time, propagation had caught up).
- `19:28:55`–`19:29:15` — `Release` workflow run `33108636684` actually runs and creates the release. `gh release view v1.16.0` confirms `publishedAt: 2026-08-27T19:29:08Z`.
- `20:32:17` — manual `workflow_dispatch` rerun succeeds in 41s, over an hour later, because the release has long since existed.

The second automatic attempt gave up **~2m13s before** the release was actually created, and the whole automatic-retry budget (~10 minutes across the two queued runs) undershot the real, `Prod Compose Smoke`-bounded gap of **~12m16s**. That gap is bounded by `Prod Compose Smoke`'s 40-minute timeout, not a small constant — which is why this needed job routing, not a longer sleep (below). Same 2-failure signature confirmed on the v1.15.0 and v1.15.1 release runs too.

## Fix (commits on this branch, in order)

1. **`21df255`** — added `"Release"` to the `workflow_run.workflows` trigger list. Necessary but not sufficient on its own (see below).
2. **`f6b9119`** — routed each job to the one trigger that can actually satisfy it: `verify-python`/`verify-typescript` (PyPI/npm) run only for a successful publish completion; `verify-ghcr`/`verify-github-release` run only for a successful `Release` completion. Manual dispatch still runs all four.
3. **`5402cf8`** — two automated-review findings (both confirmed real): a *hollow* `Release` run (smoke failed, or a manual smoke of a branch/`latest`) still concludes `'success'` as a workflow and was passing this workflow's routing check with nothing actually released; and a *prerelease* `Release` run was falling back to `VERIFY_VERSION=latest`, which silently re-verifies the previous GA instead of the prerelease just published. Fixed both with a guard step that confirms the release job ran and resolves the exact tag from `head_sha`.
4. **`b97fbaa`** — comment-only: cites the concrete v1.14.1 run-history data point (below) that falsifies a follow-up review claim that `head_sha` isn't trustworthy here, so a future reader doesn't have to re-derive it.
5. **`9d26f83`** — a third automated-review finding (confirmed real): every Release-triggered run landed in one shared `verify-published-main` concurrency group (since `head_branch` resets to the default branch on any `workflow_run`-triggered run), so an overlapping completion for a *different* tag — including a hollow one — could evict a still-pending verification for an unrelated release. Fixed by keying the group on `head_sha` for a Release-triggered run instead.
6. **`4a94115`** — a fourth automated-review finding (confirmed real): the `head_sha` → tag lookup could match *more than one* semver tag (a prerelease promoted unchanged to GA shares one commit with two tags), and the old `head -1` selection picked an arbitrary one of them. Fixed by only trusting an unambiguous (exactly one) match; 0 or >1 both fell back to `VERIFY_VERSION=latest` at this point (superseded by commit 7 for the >1 case).
7. **`3e07ff8`** — a fifth automated-review finding (confirmed real): commit 6's `latest` fallback for the >1-match case assumed the ambiguity was always an RC→GA promotion, but re-cutting one prerelease as another (`rc.1` → `rc.2` on an unchanged commit) also produces >1 matches, and `latest` never advances for a prerelease — so that case would silently verify the previous GA. Fixed by resolving the >1-match case deterministically via the releases API instead of falling back to `latest` at all: look up each matched tag's release and take the one with the newest `created_at`.
8. **`b78620c`** — comment/echo text only, no logic change: two review findings in the same round (below, round 6) were rebutted, but both surfaced phrasing in commit 7's comments/notice that overclaimed ("that release is the newest one by `created_at`" stated as always true of the tag this run touched). Reworded to describe what the code computes and to name the one exotic case (a manual rerun of an older tag's `Release` run) where it correctly picks a different matched tag.
9. **`1901c48`** — a sixth automated-review finding (confirmed real, and a genuine gap in commit 7's own new lines, not a repeat): a per-candidate release lookup that failed was silently dropped (`|| continue`) and the newest-by-`created_at` selection proceeded from whichever candidates DID resolve — so a lookup hiccup on the true-newest candidate (e.g. an `rc.2` recut whose lookup blipped) could select and verify its older sibling green instead. Fixed by tracking failed lookups (one retry each) and discarding the ENTIRE selection — not just the failed candidate — if any lookup never resolves, falling back to `latest` with a warning naming the unconfirmed tag(s).
10. **`58ccae2`** — a seventh automated-review finding (confirmed real, same class as commit 9 applied one branch up): when the guard's OWN `gh api .../jobs` query failed, the fallback set `hollow=false` with no `resolved_version`, so the real check proceeded against unconfirmed `VERIFY_VERSION=latest` — silently verifying the previous GA on a prerelease-triggered run. Fixed with the same two-part pattern: one immediate retry of the query, and on persistent failure, fail CLOSED into the same skip a confirmed hollow run uses (`hollow=true`) rather than proceeding on unconfirmed data or going red on API flakiness.
11. **`ae0df3d`** — an eighth automated-review finding (confirmed real): two remaining inconsistencies in the same family — the tags query discarded its own exit status via `|| true` (an API failure was indistinguishable from a legitimately-empty result and both flowed into `latest`), and commit 9's per-candidate-lookup-failure branch still warned-and-fell-back-to-`latest` instead of skipping like commit 10's jobs-query-failure branch. Unified to one rule everywhere in this resolution: CONFIRMED (query succeeded, found what's needed) → use it; ABSENT (query succeeded, legitimately zero/no candidate) → `latest`, the pre-existing best-effort semantics; UNCONFIRMED (any query failed after one retry) → the loud skip, never `latest`, never a guess from partial data. This closes the fail-open-on-unconfirmed-data family across every query in the file.
12. **`02606ea`** — a ninth automated-review finding (confirmed real, and a factual error in commit 7's original design that commits 9 and 11 both built retry/skip logic on top of): the >1-match tie-breaker sorted by a matched tag's release `created_at` and took the newest — but for a release created against an already-tagged commit (exactly the ambiguous case, since both matched tags share one commit), GitHub sets `created_at` to the target COMMIT's date, not the actual publish moment. Two tags on the same commit therefore always carried IDENTICAL `created_at`, the strict `>` never fired for the second one, and the "newest" pick was really just whichever tag the tags API happened to list first. Verified against this repo's real releases (v1.16.1/v1.16.0/v1.15.1: `created_at` == tag commit date in all three, `published_at` == the real `gh release create` moment) before fixing. Switched the tie-breaker to `published_at`, which is set once at the true publish moment; added defensive handling for a draft release's `published_at: null` (excluded as confirmed-not-a-candidate, not treated as UNCONFIRMED, since this pipeline never leaves a draft in practice).
13. **`17a4e0e`** — a tenth automated-review finding (confirmed real, a documentation/convention issue rather than a behavioral one): every explanatory comment this PR added referenced its own review history in relative terms ("used to be described as", "an earlier version of this branch", round numbers) instead of AGENTS.md's inline review-comment convention (a stable, lookup-able reference). Swept every review-derived comment in the file to `fix(#1707): <context>`, keeping the technical constraint each one records and dropping the narrative. Verified comment-only: diffing the file with comments/blank lines stripped showed the executable logic unchanged.
14. **`830551e`** — an eleventh automated-review finding (confirmed real): the per-candidate release lookup treated an HTTP 404 (a legitimate "this tag has no release" answer — e.g. an older sibling tag whose own smoke run failed) the same as a transient API failure, so it counted toward `LOOKUP_FAILED` and discarded the whole selection, skipping verification of a genuinely new sibling release. Fixed by classifying gh's literal `(HTTP 404)` error suffix as CONFIRMED-ABSENT for that one candidate — excluded from the comparison like a draft release, no retry needed — while any other failure still falls through to the existing retry-then-UNCONFIRMED path unchanged.

### Why commit 1 alone wasn't enough

Adding `Release` as a fourth trigger source is necessary but not sufficient: every release still produces a `workflow_run` trigger from the publishes finishing, and that trigger's approval click routinely lands well inside the ~40-minute `Prod Compose Smoke` window. Without job routing, that publish-triggered run would still execute `Verify GHCR images`/`Verify GitHub Release`, still poll for artifacts that can't exist yet, and still go red.

### Why commit 2's routing closes the timing race in both directions

- **Publish-triggered run**: only runs `verify-python`/`verify-typescript`. Those check PyPI/npm, which the publish itself just populated.
- **Release-triggered run**: only runs `verify-ghcr`/`verify-github-release`. `Release` fires strictly after `Prod Compose Smoke` has already pulled the GHCR images and the release job has already run `gh release create`/`edit`.
- **A slow publish approval that lands *after* Release** is covered too: the Release-triggered run doesn't check PyPI/npm at all, and the eventual publish-triggered run (whenever the approval lands) still verifies the registries once they exist.
- **Manual dispatch** is untouched by the routing and still runs all four jobs.

### Field choice: `github.event.workflow.name` vs `github.event.workflow_run.name`

Used `github.event.workflow.name` — the triggering run's static **Workflow** resource (the `name:` declared at the top of the workflow YAML) — rather than `github.event.workflow_run.name` (a field on the **WorkflowRun** object). None of the four upstream workflows declare `run-name:` today, but `github.event.workflow_run.name` is documented and confirmed (via [actions/runner#4141](https://github.com/actions/runner/issues/4141)) to get **repointed to the run's `run-name`/display title once the run has completed** — exactly the `types: [completed]` case this workflow triggers on. `github.event.workflow.name` is a property of the workflow *definition*, immune to `run-name` regardless of whether one gets added later.

## Review history — fourteen automated-review findings across twelve rounds, all resolved (eleven fixed, three rebutted)

**Round 1, P2 — hollow Release run** ([thread](https://github.com/geolens-io/geolens/pull/1707#discussion_r3884373059), fixed in `5402cf8`): `release.yml`'s `if: conclusion == 'success' && startsWith(head_branch, 'v')` gate is job-level only. `types: [completed]` fires on failure too, so a run whose sole job skips (failed smoke, or a manual smoke of a branch/`latest`) still concludes `'success'` as a *workflow* — an all-skipped run is reported as successful. Left unguarded, that hollow run would trigger `verify-ghcr`/`verify-github-release`, `VERIFY_VERSION` would resolve to `'latest'`, and both would pass against the **previous** release.

**Round 1, P1 — prerelease Release run** ([thread](https://github.com/geolens-io/geolens/pull/1707#discussion_r3884334376), fixed in `5402cf8`): even for a genuine, successful `Release` run, `'latest'` is wrong for a `-rc`/prerelease tag. `publish.yml`'s GHCR `:latest` tag is explicitly gated to GA-only (`!contains(github.ref_name, '-')`), and GitHub's own "latest release" concept skips prereleases too. A Release-triggered run for a supported prerelease tag would pass by silently re-verifying the previous GA instead of what was just published.

**Round 2, P1 — "head_sha isn't trustworthy on a Release-triggered run"** ([thread](https://github.com/geolens-io/geolens/pull/1707#discussion_r3884451513), rebutted, no code change): claimed `head_sha` on a `workflow_run`-triggered run is the default-branch tip, not the tagged commit, so the tag-resolution guard from round 1 would normally find nothing. Falsified by this repo's own run history: checked all 22 `workflow_run`-triggered runs (every `release.yml` run + every `workflow_run`-triggered `verify-published.yml` run), comparing each run's `headSha` against `git rev-list -1 --first-parent --before=<createdAt> origin/main` (main's actual tip at that instant) — `headSha` matched the tag commit in 22/22. The discriminating case: the v1.14.1 `Release` run (`databaseId 32317158772`, created `2026-08-20T00:24:04Z`) reports `head_sha = 1eb45634640de33cf61dcd46e34c6c3d0cdb5dbd` (`git rev-parse v1.14.1`), even though `main`'s actual tip at that instant had already advanced one commit past it, to `1e4a3ef4ef5391f72187c232c35650c909de129b` (`#1615`, confirmed via `git merge-base --is-ancestor`). If `head_sha` tracked the default branch's current tip, this run would report `1e4a3ef4e`; it reports the older tag commit instead. Only `head_branch` resets to the default branch on a `workflow_run`-triggered run — `head_sha` is inherited through the trigger chain. Cited this data point inline in `b97fbaa` so it doesn't need re-deriving.

**Round 3, P2 — concurrency group lets releases evict each other** ([thread](https://github.com/geolens-io/geolens/pull/1707#discussion_r3884486309), fixed in `9d26f83`): correct finding. Every Release-triggered run's `head_branch` is `main`, so before this fix they all shared one `verify-published-main` concurrency group. Since GitHub keeps only the newest pending run per group, an overlapping `Release` completion for a *different* tag — including a hollow one — could evict a still-pending verification for an unrelated release, and that release's GHCR/GitHub-Release checks would simply never run. Fixed by keying the group on `head_sha` (proven trustworthy in round 2) specifically for a Release-triggered run; see the concurrency section below.

**Round 4, P1 — ambiguous tag when a GA and a prerelease share a commit** ([thread](https://github.com/geolens-io/geolens/pull/1707#discussion_r3884800907), fixed in `4a94115`, superseded by round 5): correct finding, and unlike round 2's this one held up. Promoting an unchanged `v1.17.0-rc.1` commit straight to `v1.17.0` tags the SAME sha twice; `GET /repos/{owner}/{repo}/tags` lists both refs independently (no dedup by commit), and the guard's `head -1` over the matches would silently pick whichever the API happened to order first — potentially verifying the RC's artifacts while reporting the GA check green. Fixed by counting matches: exactly 1 → use it; 0 or >1 → fall back to `VERIFY_VERSION=latest`, reasoning that `latest` resolves correctly for the >1 case because it's an RC→GA promotion and this run only fires after `gh release create` made the GA the newest release.

**Round 5, P2 — the round-4 fallback assumed every ambiguity is an RC→GA promotion** ([thread](https://github.com/geolens-io/geolens/pull/1707#discussion_r3884832847), fixed in `3e07ff8`): correct finding — that assumption doesn't hold. Re-cutting `v1.17.0-rc.1` as `v1.17.0-rc.2` on an unchanged commit also produces >1 matches, and a prerelease never advances `latest`, so `latest` would silently verify the previous GA instead of either RC. Closed the class deterministically instead of adding another heuristic: in the >1-match branch, look up each matched tag's GitHub Release via `gh api repos/OWNER/REPO/releases/tags/{tag}` and take whichever has the newest `created_at`. The hollow-run guard earlier in the same step already proved the triggering Release run's "Create GitHub Release" job succeeded, so by construction it just created or updated exactly one release among the matched tags — the newest one by `created_at` IS that release, whether the ambiguity is a GA promotion or a prerelease recut, with no assumption about which case produced it. `latest` remains only for the never-expected case where none of the matched tags has a release yet (the hollow-run guard already ruled this out in practice).

**Round 6, P2 — "resolve the triggering tag instead of newest-created release"** ([thread](https://github.com/geolens-io/geolens/pull/1707#discussion_r3884861453), rebutted, no code change): scenario is a manual rerun of an OLDER tag's `Release` run on a commit that has since gained a newer released sibling tag. Premise checked and accepted: `release.yml` lines 145-149 do take the `gh release edit` path when a release already exists, and an edit never bumps `created_at`, so the resolution does pick the newer sibling, not the tag the rerun was actually about. Conclusion rebutted on three points: (1) the rerun's own tag was already verified in its own original cycle, when it was the newest match; (2) the pick is still a real, live release of the same commit — not hollow, just not the specific superseded sibling; (3) re-verifying one specific superseded tag on demand is exactly what the documented manual `gh workflow run verify-published.yml -f version=vX.Y.Z` is for — it bypasses this entire resolution (the guard step doesn't even run for `workflow_dispatch`). Prompted the wording fix in `b78620c` above.

**Round 6, P2 — "key concurrency by run ID"** ([thread](https://github.com/geolens-io/geolens/pull/1707#discussion_r3884861458), rebutted, no code change): argued the sha-keyed concurrency group isn't release-unique, since round 5 explicitly handles multiple tags on one sha. Rebutted: the scenario needs three `Release` completions for tags on ONE commit to overlap within a verify run's few-minute window, but each is downstream of its own tag's ~40-minute `Prod Compose Smoke` chain with tag pushes serialized one at a time — not schedulable here. Even a two-way same-commit overlap isn't a coverage loss: both candidates resolve against the identical match set post-round-5, so whichever survives the eviction gives the same correct answer — evicting a same-commit duplicate is the concurrency group's intended dedup behavior, not a miss. Keying by run ID would just add redundant CI runs for a coverage gain that doesn't exist.

**Round 7, P2 — a failed candidate lookup let the ambiguity resolution select from partial data** ([thread](https://github.com/geolens-io/geolens/pull/1707#discussion_r3884887496), fixed in `1901c48`): correct finding, and a genuine gap in round 5's own new lines rather than a repeat of the capped family — the `|| continue` on a failed `releases/tags/{tag}` lookup silently dropped that candidate and let the newest-by-`created_at` selection proceed from the remaining ones, so a lookup hiccup on the true-newest candidate could select and verify an older sibling green. Fixed by tracking failed lookups (with one immediate retry each) and discarding the entire selection — not just the failed candidate — if any lookup never resolves, falling back to `VERIFY_VERSION=latest` with a warning naming the unconfirmed tag(s). The 1-match and 0-match paths are untouched.

**Round 8, P2 — the round-7 principle applied to the guard's own query, not just the tag loop** ([thread](https://github.com/geolens-io/geolens/pull/1707#discussion_r3884911572), fixed in `58ccae2`): correct finding, same fail-open-on-unconfirmed-data class as round 7, in a branch written earlier (round 1) rather than a repeat of an already-fixed one. The outer `gh api .../jobs` query failing set `hollow=false` with no `resolved_version`, so the real check proceeded against unconfirmed `VERIFY_VERSION=latest` on a prerelease-triggered run — verifying the previous GA and reporting green. Fixed with the same two established patterns: one immediate retry of the query (`CMD1 || CMD2` inside the `if` condition, avoiding duplicating the branching logic below it), and on persistent failure, fail CLOSED into the same skip a confirmed hollow run uses (`hollow=true`, with a distinct `::warning::` naming the run id and pointing at the manual `-f version=vX.Y.Z` dispatch) rather than proceeding on unconfirmed data or going red on API flakiness. (This entry originally claimed the family was closed here — round 9 found that claim premature; corrected below.)

**Round 9, P2 — two remaining inconsistencies in the same family, unified to one rule** ([thread](https://github.com/geolens-io/geolens/pull/1707#discussion_r3884936335), fixed in `ae0df3d`): correct finding. The tags query still discarded its own exit status via `|| true` on the full `... | grep -E '...' || true` pipeline, so an API failure was indistinguishable from a legitimately-empty result and both flowed into `latest`; and commit 9's (round 7's) per-candidate-lookup-failure branch warned-and-fell-back-to-`latest` instead of skipping the way commit 10's (round 8's) jobs-query-failure branch did — two different answers to the same "a query failed" question in the same file. Unified to a single rule applied at every query in this resolution: **CONFIRMED** (query succeeded, found what's needed) → use it; **ABSENT** (query succeeded, legitimately zero/no candidate) → `latest`, unchanged pre-existing best-effort semantics; **UNCONFIRMED** (any query failed even after one retry) → the loud skip, never `latest`, never a guess from partial data. The tags query now captures its own `gh api` exit status directly (before the semver-regex filter runs) instead of relying on the filtered pipeline's exit code, and the per-candidate-lookup-failure branch now sets the same skip flag the jobs-query-failure branch already used.

**Round 10, P1 — the round-5 "newest release" tie-breaker was never actually deterministic** ([thread](https://github.com/geolens-io/geolens/pull/1707#discussion_r3884967745), fixed in `02606ea`): a factual error, not a design gap — and the most consequential finding of this family, since rounds 7 and 9 both built retry/skip logic on top of a comparison that couldn't do its one job. GitHub sets a release's `created_at` to its target COMMIT's date when the release is created against an already-tagged commit — exactly this branch's ambiguous case, since both matched tags share one commit by definition. Verified empirically against this repo's own releases before fixing: v1.16.1's release `created_at` (`2026-08-28T18:07:09Z`) equals its tag commit's date exactly, not the `18:48:48Z` moment `gh release create` actually ran (that's `published_at`); same pattern on v1.16.0 and v1.15.1. So two tags on one commit always carried identical `created_at`, the strict `>` comparison never fired for the second candidate, and the "newest" pick was really just whichever tag the tags API happened to return first — not deterministic at all for the RC→GA and RC-recut cases this branch exists to handle. Fixed by switching the tie-breaker to `published_at` (set once, at the true publish moment) and handling a draft release's `published_at: null` defensively (excluded as confirmed-not-a-candidate, not treated as UNCONFIRMED — this pipeline never leaves a draft in practice, but the check costs nothing). The round-6 rerun rebuttal transfers unchanged: `gh release edit` touches neither timestamp.

**Round 11, P1 — review-derived comments must anchor to a stable reference, not narrate review history** ([thread](https://github.com/geolens-io/geolens/pull/1707#discussion_r3884994658), fixed in `17a4e0e`): correct, and specific to this repo's own AGENTS.md convention. Every comment this PR added leaned on relative narration ("used to be described as", "an earlier version of this branch", round numbers) instead of a stable, lookup-able reference. Swept every review-derived comment in the file in one pass to `fix(#1707): <context>`, keeping the technical constraint each one records and dropping the narrative — verified comment-only via a stripped-comments diff against the previous commit.

**Round 12, P2 — a 404 on an unreleased sibling tag was misclassified as UNCONFIRMED** ([thread](https://github.com/geolens-io/geolens/pull/1707#discussion_r3885041062), fixed in `830551e`): correct, and a realistic sequence — an older prerelease tag's own smoke fails (no release ever gets created for it), the same commit is re-cut as a new prerelease that DOES release successfully, and the resulting ambiguous-tag verify's per-candidate lookup on the older tag 404s. That 404 was indistinguishable from a transport/auth failure, so it counted toward `LOOKUP_FAILED` and discarded the whole selection — skipping verification of the genuinely new release. Verified the exact `gh api` error format empirically (raw JSON body to stdout, `gh: Not Found (HTTP 404)` to stderr, exit 1) and ran the fix live against a real release and a deliberately nonexistent tag before committing. Fixed by capturing stderr and matching gh's literal `(HTTP 404)` error suffix as CONFIRMED-ABSENT for that one candidate — excluded from the comparison like a draft release, no retry needed, and not counted toward `LOOKUP_FAILED`. Anything that doesn't match the literal 404 pattern (a different error, a future `gh` format change, a genuine transient failure) still falls through to the existing retry-then-UNCONFIRMED path — an unclassifiable failure fails closed, 404 is the one carve-out.

### The fix: a guard step in both `verify-ghcr` and `verify-github-release`

A new first step, `Guard against a hollow Release run` (`id: release_guard`, `if: github.event_name == 'workflow_run'`), does two things when the job is Release-triggered:

1. **Hollow check** — calls `gh api repos/${{ github.repository }}/actions/runs/${{ github.event.workflow_run.id }}/jobs` (one immediate retry: `CMD1 || CMD2` inside the `if` condition) and checks whether the `"Create GitHub Release"` job concluded `success`.
2. **Tag resolution** — on a non-hollow run, resolves the exact released tag from `github.event.workflow_run.head_sha`.

Both steps follow one rule throughout: **CONFIRMED** (a query succeeded and found exactly what's needed) → use the result. **ABSENT** (queries succeeded, legitimately zero or no usable candidate) → `VERIFY_VERSION=latest`, the pre-existing best-effort semantics, unchanged. **UNCONFIRMED** (any query failed even after one retry) → the loud skip (`hollow=true` + a `::warning::` naming the manual `-f version=vX.Y.Z` dispatch), never `latest`, never a guess from partial data. Full truth table:

| Query | Outcome | Class | Result |
|---|---|---|---|
| Guard's jobs-list query | fails twice | UNCONFIRMED | `hollow=true`, warn, points to manual dispatch |
| Guard's jobs-list query | succeeds, job != success | CONFIRMED (no release) | `hollow=true`, notice: nothing to verify |
| Guard's jobs-list query | succeeds, job == success | CONFIRMED | proceed to tag resolution |
| Tags query (`gh api .../tags --paginate`, filtered to `^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$` — mirroring `release.yml`'s own "Assert semver-shaped tag" regex) | fails twice | UNCONFIRMED | `hollow=true`, warn, points to manual dispatch |
| Tags query | succeeds, 0 semver matches | CONFIRMED-ABSENT | `hollow=false`, `VERSION=latest`, warn |
| Tags query | succeeds, 1 semver match | CONFIRMED | `hollow=false`, `VERSION=`that tag, no extra API call |
| Tags query | succeeds, >1 matches, ≥1 candidate resolves to a non-null `published_at` (others may 404 — no release — or be a draft) | CONFIRMED | `hollow=false`, `VERSION=`most-recently-`published_at` tag among the resolved candidates, notice |
| Tags query | succeeds, >1 matches, every candidate is CONFIRMED-ABSENT (404 and/or `published_at: null`; no genuine failures) | CONFIRMED, no usable candidate | `hollow=false`, `VERSION=latest`, warn |
| Tags query | succeeds, >1 matches, any per-candidate lookup fails for a reason OTHER than HTTP 404 (twice) | UNCONFIRMED | `hollow=true`, warn, points to manual dispatch |

Tie-broken by `published_at`, not `created_at` — round 10 found that `created_at` reflects the target COMMIT's date for a release created against an already-tagged commit (exactly this branch's case), so two tags sharing one commit always carried identical `created_at` and the old comparison wasn't actually deterministic. `published_at` is set once, at the true publish moment, and a `null` (draft) is excluded from the comparison as a confirmed non-candidate rather than folded into the UNCONFIRMED path.

Round 12 added a second CONFIRMED-ABSENT source alongside the draft case: an HTTP 404 on `releases/tags/{tag}` (a sibling tag that legitimately has no release — e.g. its own smoke run failed) is classified the same way, matched conservatively on gh's literal `(HTTP 404)` error suffix. Before round 12, ANY per-candidate lookup failure — a genuine 404 included — was folded into `LOOKUP_FAILED` and forced UNCONFIRMED, which could discard a perfectly resolvable selection over an older sibling's unrelated, expected absence. Only a non-404 failure reaches `LOOKUP_FAILED` now.

Both real-check steps use `VERSION: ${{ steps.release_guard.outputs.resolved_version || env.VERIFY_VERSION }}`. Every UNCONFIRMED outcome resolves to the same skip; no path lets unconfirmed data reach a verification target.

**Reliability of the guard itself**: the `gh api` job-list call is wrapped in an `if CONCLUSION=$(...) || CONCLUSION=$(...); then ... else ...` (not a bare assignment), so a transient API error can't crash the step under `bash -e`'s implicit exit-on-error, and a single blip doesn't matter thanks to the built-in retry. On persistent failure it fails CLOSED (see above) rather than falling through to "not hollow" — that fallback used to be described as reproducing "this workflow's pre-guard behavior for that edge case," but that reference point stopped applying once the guard itself became the only behavior there is; proceeding on unconfirmed data was itself a bug (round 8), not a safe default.

**Permissions**: added `actions: read` to the workflow's top-level `permissions:` block — needed for the jobs-list API call. `contents: read` was already present.

### Alternative considered and ruled out: `release: types: [published]`

Before writing the guard, checked whether `release.yml` creates the release with the default `GITHUB_TOKEN` or a PAT/app token, since a PAT would make `release: types: [published]` a strictly better trigger — no hollow-run ambiguity, and `github.event.release.tag_name` gives the exact tag directly. Checked every `gh release`/`gh api` call in `release.yml`'s "Generate release notes", "Create release", "Upload install script", and "Generate + upload SHA256SUMS" steps: all four use `GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}` — the default token, not a PAT (the PATs in that file — `SITE_DISPATCH_TOKEN`, `EXAMPLES_DISPATCH_TOKEN` — are only for the unrelated downstream dispatch step). GitHub does not fire workflow triggers off events created by the default `GITHUB_TOKEN`, so `release: types: [published]` would simply never fire here. Documented this as a comment in the workflow file.

## Event chain — all three orderings for the next tag push

**1. Normal case — approval lands before Prod Compose Smoke finishes** (this is what happened on v1.16.0, v1.15.1, v1.15.0):
```
push vX.Y.Z tag
 ├─→ Publish Images    (no gate)
 ├─→ Publish CLI/MCP/SDKs (approval click, ~minutes)
 │     └─→ workflow_run(success, workflow.name != "Release")
 │           └─→ Verify Published Packages [group verify-published-vX.Y.Z]:
 │                 verify-python + verify-typescript RUN
 │                 verify-ghcr + verify-github-release SKIP (if: false)
 └─→ Prod Compose Smoke (pulls GHCR images, boots stack, E2E, ≤40min)
       └─→ workflow_run(success) ─→ Release (creates the GitHub Release)
             └─→ workflow_run(success, workflow.name == "Release")
                   └─→ Verify Published Packages [group verify-published-<tag's head_sha>]:
                         verify-python + verify-typescript SKIP
                         verify-ghcr + verify-github-release RUN:
                           guard confirms "Create GitHub Release" succeeded (not hollow),
                           resolves the exact tag from head_sha, verifies THAT tag — pass
```
No run ever polls for something its own trigger hasn't produced, the Release-triggered run verifies the exact tag rather than "whatever latest happens to mean," and it does so in a concurrency group scoped to that one commit — a different tag's Release completion can't evict it. All-green, no manual rerun.

**2. Approval lands after Release finishes** (slow reviewer, or a fast Prod Compose Smoke):
```
push vX.Y.Z tag
 ├─→ Prod Compose Smoke → Release (finishes first)
 │     └─→ workflow_run(success, workflow.name == "Release")
 │           └─→ Verify Published Packages [group verify-published-<tag's head_sha>]:
 │                 verify-ghcr + verify-github-release RUN, guard confirms real release, resolves tag, passes
 │                 verify-python + verify-typescript SKIP
 └─→ Publish CLI/MCP/SDKs (approval finally clicked, arbitrarily later)
       └─→ workflow_run(success, workflow.name != "Release")
             └─→ Verify Published Packages [group verify-published-vX.Y.Z]:
                   verify-python + verify-typescript RUN (packages exist by now) and pass
                   verify-ghcr + verify-github-release SKIP
```

**3. Prod Compose Smoke fails, or is manually smoked for `latest`/a branch:**
```
push vX.Y.Z tag
 ├─→ Publish CLI/MCP/SDKs → workflow_run(success) → verify-python/verify-typescript RUN as in case 1
 └─→ Prod Compose Smoke FAILS (types: [completed] still fires on failure)
       └─→ Release workflow_run TRIGGERS, but its "Create GitHub Release" job's own
           `if: conclusion == 'success' && startsWith(head_branch, 'v')` SKIPS it.
           A run with its only job skipped still CONCLUDES 'success' as a workflow — a hollow success,
           whose head_sha is whatever commit that smoke attempt was actually about.
             └─→ workflow_run(success, workflow.name == "Release") still fires verify-published,
                 in its OWN group keyed off that commit's head_sha — separate from any other tag's group,
                 so it cannot evict a different release's pending verification
                   └─→ verify-ghcr + verify-github-release RUN, but their guard step queries the
                       Release run's jobs, finds "Create GitHub Release" did NOT succeed, logs
                       `::notice::triggering Release run created no release; nothing to verify`,
                       and skips the real check — job concludes green, nothing was silently
                       re-checked against the previous release.
```
This is correct, not a gap: `Prod Compose Smoke` failing is itself a loud, red, top-level check on the tag. A second red check here would just be noise on top of it, and the guard's `::notice::` makes it clear in the log that nothing was actually verified.

**The real proof is the next release tag** — this PR is reviewed by reasoning and line-by-line diff only, per the task; there's no way to fire a live tag from this branch to prove it end-to-end ahead of time.

## `if:` and concurrency — everything touched, exact before/after

All `if:` conditions below have **no explicit status-check function** (`success()`/`failure()`/`always()`/`cancelled()`), so GitHub implicitly ANDs a `success()` onto each at evaluation time. That implicit AND is a no-op for the four job-level conditions (none of those jobs declare `needs:`, so job-level `success()` has no prior job in this workflow that could have failed). The two step-level conditions (`release_guard`'s own `if:`, and the real-check steps' `if: steps.release_guard.outputs.hollow != 'true'`) are evaluated within an already-running job and reference a step output, not a job dependency — the implicit `success()` there just means "no earlier step in this job failed," which up to that point is trivially true. No `always()` was introduced anywhere.

**`verify-python`** and **`verify-typescript`** (job-level, identical, since commit 2):
```
if: ${{ github.event_name != 'workflow_run' || (github.event.workflow_run.conclusion == 'success' && github.event.workflow.name != 'Release') }}
```

**`verify-ghcr`** and **`verify-github-release`** (job-level, identical, since commit 2):
```
if: ${{ github.event_name != 'workflow_run' || (github.event.workflow_run.conclusion == 'success' && github.event.workflow.name == 'Release') }}
```

**`Guard against a hollow Release run` step**, since commit 3, added to both `verify-ghcr` and `verify-github-release`:
```
if: ${{ github.event_name == 'workflow_run' }}
```
Only runs when there's an upstream run to interrogate (skips on manual dispatch, where there's no `github.event.workflow_run.id`).

**The real-check step in both jobs**, since commit 3 (`docker pull published GHCR images` / `Check release exists`):
```
if: ${{ steps.release_guard.outputs.hollow != 'true' }}
```
On manual dispatch the guard step didn't run, so this output is empty (`'' != 'true'` → true → runs). On a genuine Release trigger it's `'false'` → runs. On a hollow Release trigger it's `'true'` → skipped, job still concludes green.

**Concurrency group**, changed in commit 5:
```
# before
group: verify-published-${{ inputs.version || github.event.workflow_run.head_branch || github.run_id }}
# after
group: verify-published-${{ inputs.version || (github.event.workflow.name == 'Release' && github.event.workflow_run.head_sha) || github.event.workflow_run.head_branch || github.run_id }}
```
`cancel-in-progress: false` is unchanged — it's a workflow-level setting independent of the group key. Not an `if:`, but same operator family and worth being explicit about the short-circuit behavior: GitHub Actions `&&`/`||` are JS-style logical operators that return an operand, not a coerced boolean. For a Release-triggered run, `workflow.name == 'Release'` is `true` (truthy), so `&&` yields `head_sha`; a non-empty sha string is truthy, so the `||` chain stops there. For a publish-triggered run, the equality is `false` (falsy), so `&&` yields that same `false`; falsy, so `||` falls through to `head_branch` exactly as before — the three publishes for one tag still land together in one `verify-published-vX.Y.Z` group and dedupe/queue as intended. `inputs.version` (manual dispatch, always non-empty thanks to its `default: 'latest'`) still short-circuits the whole chain first, unaffected.

## Verification

Reasoning + line-by-line diff review only (per task scope) — no live tag push from this branch. Ran locally after each commit:
- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/verify-published.yml'))"` — parses.
- `actionlint .github/workflows/verify-published.yml` — only the same pre-existing shellcheck SC2086 note present on unmodified `main` (line-shifted by each commit's additions, confirmed via `git stash`/`actionlint` on the unmodified file before commit 1; no new findings after any subsequent commit).
- Confirmed via `WebFetch`/`WebSearch` against GitHub's docs and [actions/runner#4141](https://github.com/actions/runner/issues/4141) that `workflow_run.name` gets repointed to `run-name`/`display_title` on `completed` events.
- Confirmed via `gh api`/`gh run list`/`git rev-parse`/`git rev-list`/`git merge-base` on this repo's real history: none of the four upstream workflows set `run-name`; every `workflow_run`-triggered run's `head_sha` (22/22, including the v1.14.1 discriminating case above) is the tag commit, never the default branch's current tip; every release-creating `gh` call in `release.yml` uses `secrets.GITHUB_TOKEN`, validating the `release: published`-trigger rejection.
- Confirmed the round-4 premise before fixing it: the GitHub tags API lists every tag ref independently with no dedup by commit sha, so two semver tags on one commit really do both come back from `gh api repos/OWNER/REPO/tags`, and the prior `head -1` had no ordering guarantee to lean on.
- Round 5: verified the counterexample to round 4's assumption is a real, distinct scenario (prerelease-to-prerelease recut, not RC→GA), and that GitHub's releases-by-tag endpoint (`releases/tags/{tag}`) plus a per-candidate lookup (not a paginated list+aggregate, which `gh api --paginate` would apply `--jq` to per page rather than globally) resolves it deterministically without a `latest` fallback.
- Round 6: verified the `release.yml` premise directly (lines 145-149 do take the `gh release edit` path, which doesn't bump `created_at`) before rebutting the conclusion; verified the concurrency-collision premise against this pipeline's actual serialization (one tag push at a time, each behind its own ~40-minute smoke chain) before rebutting it as unschedulable.
- Round 7: confirmed the gap was real by re-reading round 5's own loop rather than assuming a repeat finding — the `|| continue` on a failed lookup does let selection proceed from partial data, exactly as described.
- Round 8: confirmed the same fail-open pattern existed one branch up, in the guard's own outer query (written in round 1, before the round-7 pattern existed to compare it against) — read the actual `else` branch rather than assuming the round-7 fix had already covered every `gh api` call in this file.
- Round 9: built the full CONFIRMED/ABSENT/UNCONFIRMED truth table for every query in this resolution (see the guard description above) and verified by construction — not just for the two outcomes the finding named — that every UNCONFIRMED row lands on the same skip and no row lets partial or failed-query data reach `VERSION`; also confirmed one branch (">1 matches, all lookups succeed, none has a release") was unreachable given the `created_at` loop's own logic at the time, not merely untested. (Round 10's switch to `published_at` reopened that branch as a genuinely reachable — if practically unreachable — draft-release case; see the guard description's truth-table footnote.)
- Round 10: did not take GitHub's documented `created_at` semantics on faith — pulled `created_at`/`published_at` for v1.16.1, v1.16.0, and v1.15.1 directly via `gh api repos/.../releases/tags/{tag}` and compared each `created_at` against `git log -1 --format=%cI <tag>` before concluding the tie-breaker was actually broken, not just theoretically fragile.
- Round 11: diffed the file with comments and blank lines stripped, before and after the sweep, and confirmed byte-for-byte identical executable logic — the round-11 fix touched only comments.
- Round 12: confirmed `gh api`'s actual 404 error shape empirically (`gh: Not Found (HTTP 404)` to stderr, raw JSON body to stdout, exit 1) via a live call against a nonexistent tag, then ran the fixed classification logic against both a real release and a nonexistent tag before committing, rather than trusting the pattern match would work from reasoning alone.
- All fourteen automated-review findings on this PR replied to individually, each referencing the sha that fixed it (or, for the three rebuttals, the evidence that resolved it).

https://claude.ai/code/session_01EH2GqED7gqVwFJ2T2fneDu







