### PR TITLE
chore(release): prepare v1.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2891,7 +2891,8 @@ regression-covered fixes:
 - Initial public release of the GeoLens catalog, API, map builder, CLI, SDKs,
   Docker development stack, and public documentation entrypoints.
 
-[Unreleased]: https://github.com/geolens-io/geolens/compare/v1.16.1...HEAD
+[Unreleased]: https://github.com/geolens-io/geolens/compare/v1.17.0...HEAD
+[1.17.0]: https://github.com/geolens-io/geolens/compare/v1.16.1...v1.17.0
 [1.16.1]: https://github.com/geolens-io/geolens/compare/v1.16.0...v1.16.1
 [1.16.0]: https://github.com/geolens-io/geolens/compare/v1.15.1...v1.16.0
 [1.15.1]: https://github.com/geolens-io/geolens/compare/v1.15.0...v1.15.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,44 @@ and releases use semantic versioning.
 
 ## [Unreleased]
 
+## [1.17.0] - 2026-08-30
+
+### Added
+
+- **Cancel a running import or refresh.** Imports and dataset refreshes can now
+  be cancelled while they are pending or in flight, from the refresh history on
+  a dataset's source panel and from the admin job list. A cancelled run stops
+  before anything reaches the live table: the finalize path is fenced on the
+  job's attempt, so a worker that finishes after the cancel commits rolls its
+  swap back rather than publishing data the user already walked away from.
+  Existing data and version history are left untouched, and the cancel lands in
+  the audit log. Asking twice is harmless. The job's owner can cancel, so can an
+  admin, and so can the dataset's own owner, which means a stuck job can always
+  be cleared by someone with a stake in the dataset (#1677, #1709).
+
+- **Import a dataset from a file URL.** A new File URL tab on the import page
+  takes an HTTP(S) link to a data file, fetches it server-side, and hands it to
+  the same preview and commit pipeline an upload uses, layer picker and raster
+  branch included. Plenty of public data is published as a stable link rather
+  than a file you keep on disk. The URL goes through the same SSRF checks as
+  every other outbound fetch and is re-checked on each redirect hop. The size cap
+  is enforced per chunk as the body streams, so an origin that lies about its
+  length, or simply never stops sending, cannot get past it. Once staged, the
+  file faces the same extension, content-sniff and quota checks as a direct
+  upload (#1705, #1708).
+
+### Fixed
+
+- **Published-package verification no longer races the release it verifies.**
+  The workflow triggered off the SDK, CLI and MCP publishes, then polled five
+  minutes for a GitHub Release and GHCR images that land much later: the release
+  waits for the prod compose smoke to boot the published images and run the audit
+  suite. On 1.16.0 the automatic attempts gave up more than two minutes before
+  the release existed, so every release needed a manual rerun that then passed
+  trivially. Each check now runs off the trigger that can actually satisfy it,
+  and resolves the exact tag under test instead of falling back to `latest`
+  (#1707).
+
 ## [1.16.1] - 2026-08-28
 
 ### Added

--- a/backend/app/api/main.py
+++ b/backend/app/api/main.py
@@ -747,7 +747,7 @@ _is_production = settings.is_production
 # no metadata to read. We fall back to the current published line so import never
 # crashes. Keep this fallback in lockstep with backend/pyproject.toml — it is one
 # of the sites `make bump` rewrites.
-_FALLBACK_APP_VERSION = "1.16.1"
+_FALLBACK_APP_VERSION = "1.17.0"
 
 
 def _resolve_app_version() -> str:

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -18571,7 +18571,7 @@
     "summary": "PostGIS-native geospatial data catalog with OGC API Features and Records support",
     "termsOfService": "https://github.com/geolens-io/geolens/blob/main/LICENSE",
     "title": "GeoLens API",
-    "version": "1.16.1"
+    "version": "1.17.0"
   },
   "openapi": "3.1.0",
   "paths": {

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geolens-backend"
-version = "1.16.1"
+version = "1.17.0"
 description = "PostGIS-native GIS data catalog"
 # Docker image (Dockerfile) ships python:3.14-slim (see the Dockerfile FROM for
 # the exact patch pin) as the project's tested runtime.

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -838,7 +838,7 @@ wheels = [
 
 [[package]]
 name = "geolens-backend"
-version = "1.16.1"
+version = "1.17.0"
 source = { virtual = "." }
 dependencies = [
     { name = "alembic" },

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "geolens-cli"
-version = "1.16.1"
+version = "1.17.0"
 description = "Apache-2.0 command-line interface for the GeoLens API. Login, scan, publish, and export STAC against any GeoLens instance."
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/docs-contract.json
+++ b/docs-contract.json
@@ -1,6 +1,6 @@
 {
   "_comment": "Canonical cross-surface facts for the GeoLens README, marketing site (getgeolens.com/src), and docs site (getgeolens.com/docs). Validated against scripts/install.sh + backend/pyproject.toml by scripts/check_docs_contract.py (geolens CI). The getgeolens.com repo vendors a copy and enforces the same `forbidden` list in its own CI. See docs-internal/DOC-CONSISTENCY-STRATEGY for the full design. Edit a fact ONCE here (and in its canonical source) — the gates make every surface follow.",
-  "version": "1.16.1",
+  "version": "1.17.0",
   "install": {
     "oneLiner": "curl -fsSL https://getgeolens.com/install.sh | sh",
     "sourceBuild": "bash scripts/install.sh",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "1.16.1",
+  "version": "1.17.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "1.16.1",
+      "version": "1.17.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.16.1",
+  "version": "1.17.0",
   "type": "module",
   "license": "Apache-2.0",
   "author": "Carto Concepts, LLC",

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "geolens-mcp"
-version = "1.16.1"
+version = "1.17.0"
 description = "Apache-2.0 read-only Model Context Protocol (MCP) server for GeoLens. Lets coding agents discover datasets, inspect schemas, and ask spatial questions against any GeoLens instance."
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/mcp/server.json
+++ b/mcp/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.geolens-io/geolens",
   "title": "GeoLens",
   "description": "Read-only access to a self-hosted GeoLens spatial catalog: datasets, features, maps, sandboxed SQL.",
-  "version": "1.16.1",
+  "version": "1.17.0",
   "websiteUrl": "https://docs.getgeolens.com/",
   "repository": {
     "url": "https://github.com/geolens-io/geolens",
@@ -14,7 +14,7 @@
     {
       "registryType": "pypi",
       "identifier": "geolens-mcp",
-      "version": "1.16.1",
+      "version": "1.17.0",
       "transport": {
         "type": "stdio"
       },

--- a/mcp/uv.lock
+++ b/mcp/uv.lock
@@ -225,7 +225,7 @@ wheels = [
 
 [[package]]
 name = "geolens"
-version = "1.16.1"
+version = "1.17.0"
 source = { editable = "../sdks/python" }
 dependencies = [
     { name = "attrs" },
@@ -244,7 +244,7 @@ requires-dist = [
 
 [[package]]
 name = "geolens-mcp"
-version = "1.16.1"
+version = "1.17.0"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "geolens",
-  "version": "1.16.1",
+  "version": "1.17.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "geolens",
-      "version": "1.16.1",
+      "version": "1.17.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@axe-core/playwright": "^4.13.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geolens",
-  "version": "1.16.1",
+  "version": "1.17.0",
   "private": true,
   "license": "Apache-2.0",
   "author": "Carto Concepts, LLC",

--- a/sdks/python/.openapi-python-client.yaml
+++ b/sdks/python/.openapi-python-client.yaml
@@ -4,7 +4,7 @@ project_name_override: geolens
 package_name_override: geolens
 # Rewritten on every `make sdks` run by scripts/sync_sdk_versions.py to match
 # backend/openapi.json info.version. Do not edit by hand.
-package_version_override: 1.16.1
+package_version_override: 1.17.0
 
 # Cleaner enum output (matches our pydantic v2 backend's enum emission).
 literal_enums: true

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "geolens"
-version = "1.16.1"
+version = "1.17.0"
 description = "Auto-generated Python SDK for the GeoLens API. Typed clients with Bearer + API-key auth helpers."
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/sdks/typescript/package-lock.json
+++ b/sdks/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@geolens/sdk",
-  "version": "1.16.1",
+  "version": "1.17.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@geolens/sdk",
-      "version": "1.16.1",
+      "version": "1.17.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@hey-api/client-fetch": "0.13.1"

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geolens/sdk",
-  "version": "1.16.1",
+  "version": "1.17.0",
   "description": "Auto-generated TypeScript SDK for the GeoLens API. Typed clients with Bearer + API-key auth helpers.",
   "license": "Apache-2.0",
   "author": "Carto Concepts, LLC",


### PR DESCRIPTION
Cuts 1.17.0 from the three commits since v1.16.1.

## What changed

- `make bump VERSION=1.17.0` rewrote all 21 version sites. No hand-edited version strings.
- CHANGELOG entry covering the two features and the CI fix.

## What's in the release

| PR | |
|---|---|
| #1709 | `feat(jobs)` cancel import and refresh runs (#1677) |
| #1708 | `feat(ingest)` import a dataset from an HTTP file URL (#1705) |
| #1707 | `fix(ci)` trigger published-package verification off the release workflow |

Two features, so a minor bump.

## Impact

- **No migration.** #1709 reuses `status='cancelled'`, already in the jobs CHECK constraint; #1708 reuses `IngestJob` as-is.
- **API surface already shipped** in the feature PRs (`POST /jobs/{job_id}/cancel`, `POST /ingest/upload/url`). `backend/openapi.json` and both SDKs carry only the version field change here.
- No config or env changes.

## Verification

- `make version-check` — OK, all 21 sites agree on 1.17.0, CHANGELOG section present
- `make openapi-check` — pass
- `make sdks-check` — pass (post-commit; it diffs the committed tree, so an uncommitted bump reads as drift)
- pre-commit full hook set — pass

Merged main was smoke-tested before this PR: the cancel flow and a real GeoParquet URL import both ran end to end on the local stack, and all 7 public showcase maps were verified rendering on the demo.

https://claude.ai/code/session_01485UjhPsbiLYZqWB8yWYCz
