### PR TITLE
fix(ingest): refuse registration when geometry is not named geom (#1737)

### DIFF
--- a/backend/app/processing/ingest/service.py
+++ b/backend/app/processing/ingest/service.py
@@ -741,6 +741,32 @@ async def register_existing_table(
     has_geom = "geom" in geom_cols
     has_4326 = "geom_4326" in geom_cols
 
+    # fix(#1737): a spatial table whose geometry lives under any other name
+    # used to register SILENTLY as a non-spatial attribute table -- the branch
+    # below is gated on `has_geom`, and extract_metadata reports srid/
+    # geometry_type/extent as None for a column it does not recognize. The
+    # non-spatial registration path is deliberate (#1359), so the two cases
+    # have to be told apart here rather than by widening that path: a table
+    # with NO geometry column anywhere is still a legitimate attribute table.
+    # `ogr2ogr -f PostgreSQL` names its column `wkb_geometry` by default, so
+    # the most ordinary way to land a table in the data schema hit this.
+    if not has_geom:
+        other_geom = await session.execute(
+            text(
+                "SELECT f_geometry_column FROM geometry_columns "
+                "WHERE f_table_schema = :schema AND f_table_name = :table_name "
+                "LIMIT 1"
+            ).bindparams(schema=_schema, table_name=table_name)
+        )
+        found = other_geom.scalar_one_or_none()
+        if found is not None:
+            raise ValueError(
+                f"Table '{table_name}' stores geometry in a column named "
+                f"'{found}'. GeoLens reads geometry from a column named "
+                "'geom'. Rename the column, or re-export the table with "
+                "`-lco GEOMETRY_NAME=geom`."
+            )
+
     from app.processing.ingest.tasks_common import (
         _current_tenant_role,
     )

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -218,6 +218,7 @@ _TENANCY_GLOBAL_STATE_MODULES = {
     #     concurrently with each other or the group above (pg_shdepend contention).
     "test_analysis_materialize",  # register_existing_table → grant_reader_access
     "test_registered_delete_detach_1452",  # same: registers real tables
+    "test_register_geom_column_name_1737",  # same: its accept-case registers
     "test_embed_tokens",
     "test_features_crud",
     "test_features_geojson_z",

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -3753,7 +3753,12 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # unreachable, and dead compensation code reads as a live invariant.
     # Replaced by the smaller claim/restore pair, restore being the fenced
     # CR-02 retry contract. Cap 1417 -> 1376, exact.
-    "backend/app/processing/ingest/service.py": 1376,
+    # fix(#1737): +26 for the geometry-column-name probe in
+    # register_existing_table. A spatial table whose geometry is not named
+    # `geom` used to register silently as a non-spatial attribute table; the
+    # probe tells that case apart from the deliberate no-geometry path (#1359)
+    # and refuses with the offending column name. Cap 1376 -> 1402, exact.
+    "backend/app/processing/ingest/service.py": 1402,
     # --- entered by the inclusion rule, feat(#765) -------------------------
     # First time this module crosses 1000. main sat at 994, six lines under the
     # gate, so it was going to fire on whoever added next; it fired here.

--- a/backend/tests/test_register_geom_column_name_1737.py
+++ b/backend/tests/test_register_geom_column_name_1737.py
@@ -1,0 +1,126 @@
+"""fix(#1737): a spatial table whose geometry column is not named `geom`
+must be refused at registration, not catalogued as a non-spatial table.
+
+``register_existing_table`` decides "is this spatial?" by looking for the
+exact names ``geom``/``geom_4326``. Anything else left ``has_geom`` false,
+skipped the whole ``add_4326_column`` branch, and let registration finish:
+``extract_metadata`` reports srid, geometry_type and extent as None for a
+column it does not recognize, so the dataset was created as an attribute
+table with no error anywhere. Discovery does not filter these out either
+(its ``geometry_columns`` join is a LEFT JOIN pinned to ``f_geometry_column
+= 'geom'``), so the table looks legitimately non-spatial in the picker.
+
+``ogr2ogr -f PostgreSQL`` names its geometry column ``wkb_geometry`` by
+default, which made the most ordinary way of landing a table in the data
+schema produce a dataset that renders nothing.
+
+The non-spatial registration path is deliberate (#1359), so the fix has to
+separate "geometry under another name" from "no geometry at all" rather
+than tightening registration for every table. Both halves are pinned here.
+"""
+
+import uuid as _uuid
+from types import SimpleNamespace
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from tests.factories import get_user_id
+
+
+@pytest.mark.anyio
+async def test_register_refuses_geometry_column_under_another_name(
+    test_db_session: AsyncSession,
+):
+    """The ogr2ogr default (`wkb_geometry`) is refused, and named."""
+    from app.processing.ingest.schemas import RegisterRequest
+    from app.processing.ingest.service import register_existing_table
+
+    admin_id = await get_user_id(test_db_session, "admin")
+    table_name = f"tbl_wkbgeom_{_uuid.uuid4().hex[:10]}"
+
+    await test_db_session.execute(
+        text(
+            f'CREATE TABLE data."{table_name}" '
+            f"(gid serial PRIMARY KEY, name text, "
+            f"wkb_geometry geometry(Point, 4326))"
+        )
+    )
+    await test_db_session.execute(
+        text(
+            f'INSERT INTO data."{table_name}" (name, wkb_geometry) '  # noqa: S608
+            f"VALUES ('a', ST_SetSRID(ST_MakePoint(-73.9, 40.7), 4326))"
+        )
+    )
+    await test_db_session.commit()
+
+    try:
+        with pytest.raises(ValueError) as excinfo:
+            await register_existing_table(
+                test_db_session,
+                RegisterRequest(table_name=table_name, title="Wkb Geometry"),
+                SimpleNamespace(id=admin_id),
+            )
+
+        message = str(excinfo.value)
+        # The offending column has to be IN the message: "rename it" with no
+        # name sends the operator back to psql to work out which column.
+        assert "wkb_geometry" in message
+        assert "geom" in message
+    finally:
+        await test_db_session.rollback()
+        await test_db_session.execute(
+            text(f'DROP TABLE IF EXISTS data."{table_name}" CASCADE')
+        )
+        await test_db_session.commit()
+
+
+@pytest.mark.anyio
+async def test_register_still_accepts_a_table_with_no_geometry(
+    test_db_session: AsyncSession,
+):
+    """The #1359 attribute-table path is the boundary the refusal must not cross.
+
+    A table with no geometry column anywhere has no ``geometry_columns`` row,
+    so the new probe finds nothing and registration proceeds exactly as it
+    did. Pinned next to the refusal because the two answers come from one
+    branch, and a probe that matched too widely would turn every non-spatial
+    registration into an error.
+    """
+    from app.processing.ingest.schemas import RegisterRequest
+    from app.processing.ingest.service import register_existing_table
+
+    admin_id = await get_user_id(test_db_session, "admin")
+    table_name = f"tbl_noge_{_uuid.uuid4().hex[:10]}"
+
+    await test_db_session.execute(
+        text(
+            f'CREATE TABLE data."{table_name}" '
+            f"(gid serial PRIMARY KEY, code text, population integer)"
+        )
+    )
+    await test_db_session.execute(
+        text(
+            f'INSERT INTO data."{table_name}" (code, population) '  # noqa: S608
+            f"VALUES ('a', 1)"
+        )
+    )
+    await test_db_session.commit()
+
+    try:
+        dataset = await register_existing_table(
+            test_db_session,
+            RegisterRequest(table_name=table_name, title="No Geometry"),
+            SimpleNamespace(id=admin_id),
+        )
+        await test_db_session.commit()
+
+        assert dataset.geometry_type is None
+        assert dataset.feature_count == 1
+    finally:
+        await test_db_session.rollback()
+        await test_db_session.execute(
+            text(f'DROP TABLE IF EXISTS data."{table_name}" CASCADE')
+        )
+        await test_db_session.commit()


### PR DESCRIPTION
Closes #1737.

`register_existing_table` decided "is this spatial?" by looking for the exact
column names `geom`/`geom_4326`. A table whose geometry lived under any other
name left `has_geom` false, skipped the `add_4326_column` branch, and still
registered: `extract_metadata` reports srid, geometry_type and extent as None
for a column it does not recognize, so the dataset was catalogued as an
attribute table with no error anywhere.

Discovery hid it too. Its `geometry_columns` join is a LEFT JOIN pinned to
`f_geometry_column = 'geom'`, so the table appears in the picker looking
legitimately non-spatial.

`ogr2ogr -f PostgreSQL` names its geometry column `wkb_geometry` by default,
which made the most ordinary way of landing a table in the data schema produce
a dataset that rendered nothing and explained nothing.

## Change

When neither name is present, probe `geometry_columns` for a geometry column
under some other name and refuse with the one that was found:

> Table 'facilities' stores geometry in a column named 'wkb_geometry'. GeoLens
> reads geometry from a column named 'geom'. Rename the column, or re-export
> the table with `-lco GEOMETRY_NAME=geom`.

The deliberate non-spatial path from #1359 is untouched: a table with no
geometry column anywhere has no `geometry_columns` row, the probe finds
nothing, and registration proceeds as before. Both halves are pinned in
`backend/tests/test_register_geom_column_name_1737.py`.

## Verification

```
uv run pytest tests/test_register_geom_column_name_1737.py \
  tests/test_service_column_info_1359.py::test_register_non_spatial_table_populates_column_info -q
3 passed

uv run pytest tests/test_layering.py -q
47 passed

uv run ruff check / ruff format --check    clean
```

Counterfactual: with the new branch replaced by `if False:`, the refusal test
fails and the no-geometry test still passes, so the guard is what the first
test is measuring and it is not propping up the second.

## Notes

No schema change, no API change, no new dependency. `service.py`'s cap in
`test_layering.py` goes 1376 -> 1402 for the probe, commented in place.
