### PR TITLE
fix(auth): stop the login page promising a password reset nobody can do (#1715)

### DIFF
--- a/frontend/src/i18n/locales/de/auth.json
+++ b/frontend/src/i18n/locales/de/auth.json
@@ -84,7 +84,7 @@
   "configLoadError": "Registrierungseinstellungen konnten nicht geladen werden. Bitte erneut versuchen.",
   "hidePassword": "Passwort ausblenden",
   "showPassword": "Passwort anzeigen",
-  "supportHint": "Brauchen Sie Zugang oder eine Passwortzurücksetzung? Wenden Sie sich an einen GeoLens-Administrator.",
+  "supportHint": "Brauchen Sie Zugang? Wenden Sie sich an einen GeoLens-Administrator.",
   "consentNote": "Mit der Anmeldung stimmen Sie unserer",
   "privacyPolicy": "Datenschutzrichtlinie",
   "consentNoteSuffix": " zu.",

--- a/frontend/src/i18n/locales/en/auth.json
+++ b/frontend/src/i18n/locales/en/auth.json
@@ -84,7 +84,7 @@
   "configLoadError": "Unable to load registration settings. Please try again.",
   "hidePassword": "Hide password",
   "showPassword": "Show password",
-  "supportHint": "Need access or a password reset? Contact a GeoLens administrator.",
+  "supportHint": "Need access? Contact a GeoLens administrator.",
   "consentNote": "By signing in you agree to our",
   "privacyPolicy": "Privacy Policy",
   "consentNoteSuffix": ".",

--- a/frontend/src/i18n/locales/es/auth.json
+++ b/frontend/src/i18n/locales/es/auth.json
@@ -84,7 +84,7 @@
   "configLoadError": "No se pudieron cargar los ajustes de registro. Inténtalo de nuevo.",
   "hidePassword": "Ocultar contraseña",
   "showPassword": "Mostrar contraseña",
-  "supportHint": "Necesitas acceso o restablecimiento de contraseña? Contacta a un administrador de GeoLens.",
+  "supportHint": "¿Necesitas acceso? Contacta a un administrador de GeoLens.",
   "consentNote": "Al iniciar sesión, acepta nuestra",
   "privacyPolicy": "Política de privacidad",
   "consentNoteSuffix": ".",

--- a/frontend/src/i18n/locales/fr/auth.json
+++ b/frontend/src/i18n/locales/fr/auth.json
@@ -84,7 +84,7 @@
   "configLoadError": "Impossible de charger les paramètres d'inscription. Veuillez réessayer.",
   "hidePassword": "Masquer le mot de passe",
   "showPassword": "Afficher le mot de passe",
-  "supportHint": "Besoin d'accès ou de réinitialisation du mot de passe ? Contactez un administrateur GeoLens.",
+  "supportHint": "Besoin d'accès ? Contactez un administrateur GeoLens.",
   "consentNote": "En vous connectant, vous acceptez notre",
   "privacyPolicy": "Politique de confidentialité",
   "consentNoteSuffix": ".",


### PR DESCRIPTION
Partial mitigation for #1715. **Does not close it.**

The login page tells a locked-out user:

> Need access or a password reset? Contact a GeoLens administrator.

An administrator cannot do the second half. `UserUpdate` has no password
field, `POST /auth/change-password/` requires the current password, and there
is no forgot-password, reset-token or invite flow. The workarounds all cost
something: `delete_user` is a hard delete, so the user's datasets survive as
ownerless rows while their `UserRole` and `ApiKey` records are dropped.

This removes the promise, in all four locales. Asking an administrator is
still the right first step for access, and a login page is not the place to
document operator-level recovery.

I am deliberately not building the reset flow here. That spans `UserUpdate`,
an admin UI control, session and API-key invalidation semantics, and four
locales, on an auth path. #1715 stays open for it. Fixing the copy is the
part that costs nothing to get right today.

Also adds the opening `¿` the Spanish string was missing.

## Verification

```
npm run test:i18n     4 passed   (locale parity; no keys added or removed)
npm run lint          clean
npm run typecheck     clean
```

No key changes, so nothing to translate beyond the four edited strings, and
no risk to the parity gate.
