### PR TITLE
fix(import): keep a visited tab mounted so a switch cannot strand its job (#1712)

### DIFF
--- a/frontend/src/pages/ImportPage.tsx
+++ b/frontend/src/pages/ImportPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Upload, Link, Database, Globe, Satellite } from 'lucide-react';
 import { PageHeader } from '@/components/layout/PageHeader';
@@ -31,6 +31,50 @@ export function ImportPage() {
   const [uploadPhase, setUploadPhase] = useState<BatchPhase>('idle');
   useDocumentTitle(t('common:pageTitle.import'));
 
+  // fix(#1712): a tab is mounted on first visit and never unmounted again.
+  //
+  // These panels used to render as `activeTab === x && <Form />`, so switching
+  // tabs mid-import UNMOUNTED the running form. The request kept going, since
+  // the server does not stop working when a client goes away, and its response
+  // landed in dead component state: the job became unreachable from the UI and
+  // its staged bytes sat there until the stale-pending sweep took them.
+  //
+  // Aborting on unmount is not a fix, for the same reason #1708 gives for the
+  // URL tab: the abort strands the identical server-side state and throws away
+  // the id needed to find it. Not unmounting is the direct answer, and it costs
+  // one Set: an in-flight XHR's progress callbacks keep writing to live state
+  // because the component they belong to is still there.
+  //
+  // Mount-on-FIRST-VISIT rather than mount-everything, because these forms do
+  // real work when they mount -- RegisterForm lists unregistered tables -- and
+  // rendering all five up front would fire that for tabs nobody opened.
+  //
+  // This closes tab switching, which is what #1712 reports. It does NOT survive
+  // leaving the Import route entirely; only a module-scoped session outside
+  // React does that, which is what #1708 built for the URL tab. #1712 stays
+  // open for the batch version of that work.
+  const [visited, setVisited] = useState<ReadonlySet<Tab>>(() => new Set<Tab>(['upload']));
+
+  const selectTab = useCallback((value: Tab) => {
+    setActiveTab(value);
+    setVisited((prev) => (prev.has(value) ? prev : new Set(prev).add(value)));
+  }, []);
+
+  const panelFor = (value: Tab) => {
+    switch (value) {
+      case 'upload':
+        return <UploadForm onPhaseChange={setUploadPhase} />;
+      case 'url':
+        return <UrlImportForm />;
+      case 'register':
+        return <RegisterForm />;
+      case 'service':
+        return <ServiceUrlForm />;
+      case 'stac':
+        return <StacImportForm />;
+    }
+  };
+
   return (
     <PageShell>
       <PageHeader
@@ -51,7 +95,7 @@ export function ImportPage() {
             <button
               key={value}
               type="button"
-              onClick={() => setActiveTab(value)}
+              onClick={() => selectTab(value)}
               aria-current={activeTab === value ? 'page' : undefined}
               className={cn(
                 'inline-flex items-center gap-2 border-b-2 px-4 pb-3 pt-3 text-sm font-medium transition-colors',
@@ -76,13 +120,15 @@ export function ImportPage() {
       {/* Two-column layout */}
       <div className="grid grid-cols-1 gap-6 pb-12 xl:grid-cols-[1fr_320px]">
         <div className="min-w-0">
-          <AppErrorBoundary>
-            {activeTab === 'upload' && <UploadForm onPhaseChange={setUploadPhase} />}
-            {activeTab === 'url' && <UrlImportForm />}
-            {activeTab === 'register' && <RegisterForm />}
-            {activeTab === 'service' && <ServiceUrlForm />}
-            {activeTab === 'stac' && <StacImportForm />}
-          </AppErrorBoundary>
+          {MODE_TABS.filter(({ value }) => visited.has(value)).map(({ value }) => (
+            // `hidden` rather than unmounting: it takes the panel out of the
+            // a11y tree and the tab order while leaving the component alive.
+            // One boundary PER panel, because a shared one would let a hidden
+            // tab's error blank the tab the user is actually looking at.
+            <div key={value} hidden={activeTab !== value}>
+              <AppErrorBoundary>{panelFor(value)}</AppErrorBoundary>
+            </div>
+          ))}
         </div>
         <WorkflowRail
           mode={activeTab}

--- a/frontend/src/pages/__tests__/ImportPage.keep-mounted.test.tsx
+++ b/frontend/src/pages/__tests__/ImportPage.keep-mounted.test.tsx
@@ -18,10 +18,10 @@ import { ImportPage } from '../ImportPage';
 
 const mounts: Record<string, number> = {};
 
-function trackMount(name: string) {
+function useTrackMount(name: string) {
   useEffect(() => {
     mounts[name] = (mounts[name] ?? 0) + 1;
-  }, []);
+  }, [name]);
 }
 
 vi.mock('react-i18next', () => ({
@@ -47,7 +47,7 @@ vi.mock('@/hooks/use-document-title', () => ({ useDocumentTitle: vi.fn() }));
 // that an unmount would have destroyed.
 vi.mock('@/components/import/UploadForm', () => ({
   UploadForm: () => {
-    trackMount('upload');
+    useTrackMount('upload');
     const [value, setValue] = useState('');
     return (
       <input
@@ -61,28 +61,28 @@ vi.mock('@/components/import/UploadForm', () => ({
 
 vi.mock('@/components/import/UrlImportForm', () => ({
   UrlImportForm: () => {
-    trackMount('url');
+    useTrackMount('url');
     return <div>URL workflow</div>;
   },
 }));
 
 vi.mock('@/components/import/RegisterForm', () => ({
   RegisterForm: () => {
-    trackMount('register');
+    useTrackMount('register');
     return <div>Register workflow</div>;
   },
 }));
 
 vi.mock('@/components/import/ServiceUrlForm', () => ({
   ServiceUrlForm: () => {
-    trackMount('service');
+    useTrackMount('service');
     return <div>Service workflow</div>;
   },
 }));
 
 vi.mock('@/components/import/StacImportForm', () => ({
   StacImportForm: () => {
-    trackMount('stac');
+    useTrackMount('stac');
     return <div>STAC workflow</div>;
   },
 }));

--- a/frontend/src/pages/__tests__/ImportPage.keep-mounted.test.tsx
+++ b/frontend/src/pages/__tests__/ImportPage.keep-mounted.test.tsx
@@ -1,0 +1,139 @@
+/**
+ * fix(#1712): switching Import tabs must not unmount a form that is working.
+ *
+ * The panels used to render as `activeTab === x && <Form />`, so a tab switch
+ * mid-import unmounted the running form. The request carried on, because the
+ * server does not stop when a client goes away, and the response landed in
+ * dead component state: an unreachable job plus its staged bytes.
+ *
+ * These pin the two halves of the fix that can regress independently. A panel
+ * stays mounted once visited (so in-flight work keeps a live component to
+ * report into), and a panel nobody has opened is not mounted at all (so the
+ * forms that do real work on mount, RegisterForm lists unregistered tables,
+ * still only do it when asked).
+ */
+import { fireEvent, render, screen } from '@/test/test-utils';
+import { useEffect, useState } from 'react';
+import { ImportPage } from '../ImportPage';
+
+const mounts: Record<string, number> = {};
+
+function trackMount(name: string) {
+  useEffect(() => {
+    mounts[name] = (mounts[name] ?? 0) + 1;
+  }, []);
+}
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: { defaultValue?: string }) => {
+      if (options?.defaultValue) return options.defaultValue;
+      const labels: Record<string, string> = {
+        'tabs.label': 'Import sources',
+        'tabs.upload': 'Upload',
+        'tabs.url': 'From URL',
+        'tabs.register': 'Register table',
+        'tabs.service': 'Service URL',
+        'tabs.stac': 'STAC',
+      };
+      return labels[key] ?? key;
+    },
+  }),
+}));
+
+vi.mock('@/hooks/use-document-title', () => ({ useDocumentTitle: vi.fn() }));
+
+// Stands in for a form carrying in-flight work: the typed value is the state
+// that an unmount would have destroyed.
+vi.mock('@/components/import/UploadForm', () => ({
+  UploadForm: () => {
+    trackMount('upload');
+    const [value, setValue] = useState('');
+    return (
+      <input
+        aria-label="Upload workflow"
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+      />
+    );
+  },
+}));
+
+vi.mock('@/components/import/UrlImportForm', () => ({
+  UrlImportForm: () => {
+    trackMount('url');
+    return <div>URL workflow</div>;
+  },
+}));
+
+vi.mock('@/components/import/RegisterForm', () => ({
+  RegisterForm: () => {
+    trackMount('register');
+    return <div>Register workflow</div>;
+  },
+}));
+
+vi.mock('@/components/import/ServiceUrlForm', () => ({
+  ServiceUrlForm: () => {
+    trackMount('service');
+    return <div>Service workflow</div>;
+  },
+}));
+
+vi.mock('@/components/import/StacImportForm', () => ({
+  StacImportForm: () => {
+    trackMount('stac');
+    return <div>STAC workflow</div>;
+  },
+}));
+
+vi.mock('@/components/import/WorkflowRail', () => ({
+  WorkflowRail: ({ mode }: { mode: string }) => <aside data-mode={mode}>Workflow rail</aside>,
+}));
+
+describe('ImportPage panel lifecycle', () => {
+  beforeEach(() => {
+    for (const key of Object.keys(mounts)) delete mounts[key];
+  });
+
+  it('keeps a visited panel mounted, with its state, across a tab switch', () => {
+    render(<ImportPage />);
+
+    const upload = screen.getByLabelText('Upload workflow');
+    fireEvent.change(upload, { target: { value: 'import in progress' } });
+    expect(mounts.upload).toBe(1);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Service URL' }));
+    expect(screen.getByText('Service workflow')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Upload' }));
+
+    // One mount, not two: the panel was hidden, never torn down. If it had
+    // remounted the value would be back to '' and the counter would read 2.
+    expect(mounts.upload).toBe(1);
+    expect(screen.getByLabelText('Upload workflow')).toHaveValue('import in progress');
+  });
+
+  it('does not mount a panel the user has never opened', () => {
+    render(<ImportPage />);
+
+    expect(mounts.upload).toBe(1);
+    expect(mounts.register).toBeUndefined();
+    expect(mounts.stac).toBeUndefined();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Register table' }));
+
+    expect(mounts.register).toBe(1);
+    expect(mounts.stac).toBeUndefined();
+  });
+
+  it('hides the inactive panel from the accessibility tree', () => {
+    render(<ImportPage />);
+    fireEvent.click(screen.getByRole('button', { name: 'Service URL' }));
+
+    // Still in the DOM, which is the entire point, but `hidden` keeps it out
+    // of the a11y tree and out of the tab order.
+    expect(screen.getByLabelText('Upload workflow')).toBeInTheDocument();
+    expect(screen.queryByRole('textbox', { name: 'Upload workflow' })).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Partial fix for #1712. **Does not close it** — see the scope note below.

## The change

The Import panels rendered as `activeTab === x && <Form />`, so a tab switch
mid-import unmounted the running form. The request carried on, because the
server does not stop when a client disconnects, and its response landed in
dead component state: an unreachable job plus staged bytes waiting on the
stale-pending sweep.

A tab is now mounted on first visit and never unmounted. An in-flight XHR's
progress callbacks keep writing into live state because the component is
still there, so the whole class of bug goes away without touching any form's
internals.

Two details the change forces:

- Inactive panels use `hidden`, which keeps them out of the a11y tree and the
  tab order while leaving them alive.
- The error boundary moves inside the loop, one per panel. A single shared
  boundary would let a hidden tab's error blank the tab the user is looking at,
  which is a blast radius the old one-panel-at-a-time render did not have.

Mount-on-first-visit rather than mounting all five: these forms do real work
when they mount, and `RegisterForm` would list unregistered tables for a tab
nobody opened.

## Why not the module-session port the issue describes

The issue prescribes porting #1708's out-of-React session to the remaining
tabs. That is the right long-term shape and it covers strictly more, including
navigating away from the Import route entirely. It is also a much larger piece
of work than it sounds: `UploadForm` is 548 lines tracking a *batch* of
entries with per-entry progress callbacks writing into component state, and
the single-job URL version took ~25 review rounds to get the lifecycle right.

Not what I would land on the highest-traffic import path days before a
release. This closes the reported failure, tab switching, for Upload, Register,
Service and STAC in one file and ~20 lines, and it cannot regress any form's
internals because it does not touch them.

**#1712 stays open** for the batch session work and for route-navigation
survival.

## Verification

```
npx vitest run src/pages/__tests__/ src/components/import/
  39 files, 235 passed

npm run lint       clean
npm run typecheck  clean
```

New `ImportPage.keep-mounted.test.tsx` pins three properties. Counterfactual
against the old conditional render: "keeps a visited panel mounted" and "hides
the inactive panel from the a11y tree" both fail, so they measure this change;
"does not mount a panel the user has never opened" passes either way, which is
correct, since it guards behaviour this preserves rather than introduces.

The existing `ImportPage.layout.test.tsx` passes unmodified.
