### PR TITLE
docs(cli): drop the cron blessing that contradicts ADR-002 A9

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -50,6 +50,11 @@ thing standing between a truncated or reshaped source and live data. Nothing in
 the API stops you calling this from a scheduler, but until completeness
 verification ships, you are the check.
 
+`--wait` reports the job's terminal status, not what changed in the data. Drift
+is recorded on the dataset: read `schema_drift_status` from `GET /datasets/{id}`,
+or open the dataset's Source panel in the web app. Neither `geolens refresh` nor
+`geolens status` surfaces it today.
+
 Protected services can receive a transient credential with `--token`. Use bare
 `--token` to open a hidden-input prompt, which keeps the value out of terminal
 output and shell history. Supplying a token value directly is supported for

--- a/cli/README.md
+++ b/cli/README.md
@@ -40,8 +40,15 @@ source whose data changed independently.
 the dataset from the origin binding stored by GeoLens, without accepting a URL,
 layer, or client-selected trigger. Add `--wait` to poll the refresh job to a
 terminal state without an implicit deadline; pass `--timeout` when automation
-needs a finite bound. This is the supported command for scheduled cron or CI
-refresh jobs; use `apply` when the declared source configuration itself changes.
+needs a finite bound. Use `apply` when the declared source configuration itself
+changes.
+
+Unattended refresh is not supported yet. GeoLens does not verify that a
+re-pulled source is complete, and schema drift is reported but does not block
+the swap, so the person who triggers a refresh and reads the result is the only
+thing standing between a truncated or reshaped source and live data. Nothing in
+the API stops you calling this from a scheduler, but until completeness
+verification ships, you are the check.
 
 Protected services can receive a transient credential with `--token`. Use bare
 `--token` to open a hidden-input prompt, which keeps the value out of terminal


### PR DESCRIPTION
`cli/README.md` called `geolens refresh` "the supported command for scheduled
cron or CI refresh jobs". ADR-002 §A9 decided the opposite and named this exact
surface:

> no GeoLens surface publishes a cron or automation recipe. That covers #1227's
> CLI docs, #1229's positioning copy, and the docs site alike. Where automation
> copy is unavoidable, it states that unattended refresh is unsupported until
> verification ships.

The README line landed after that decision, so the README is the side that is
wrong. No ADR change needed.

## What changed

Gate 1 still stands, so this does not pretend the API is closed. `--wait` and
`--timeout` exist for automation and stay documented as such. What goes is the
word "supported", replaced by the statement §A9 asks for.

Invariant 9 is why it matters:

> The invariant's protection survives v1 only because **every refresh is
> human-triggered and human-reviewable**. The human is the schema gate. That is
> a real safeguard and it is also the entire safeguard.

There is no completeness verification and drift does not block the swap, so a
reader who wires this into cron on the strength of that sentence has removed
the only thing standing between a truncated source and their live data.

## Sweep

Checked the other public surfaces for the same shape. What is left is fine and
untouched:

- `RUNBOOK.md`, `.github/ARCHITECTURE.md` — the backup service's own schedule.
- Generated SDK docstrings — the ops-only stale-job cleanup endpoint.
- `EDITIONS.md:17` — names scheduled refresh as a paid capability, which is the
  gate-4 edition boundary rather than an automation recipe.
