### PR TITLE
fix(compose): run the cloud-dev valkey service as the valkey user

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -759,6 +759,8 @@ services:
     logging: *bounded-logs
     image: valkey/valkey:8.1.7-alpine
     profiles: ["cloud-dev"]
+    # fix(#1746): cap_drop ALL removes CAP_SETUID, so the entrypoint's setpriv fails; a non-root user skips setpriv.
+    user: "valkey"
     security_opt:
       - no-new-privileges:true
     cap_drop:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -901,6 +901,8 @@ services:
     # 8.x line tip; cloud-dev profile only.
     image: valkey/valkey:8.1.7-alpine
     profiles: ["cloud-dev"]
+    # fix(#1746): cap_drop ALL removes CAP_SETUID, so the entrypoint's setpriv fails; a non-root user skips setpriv.
+    user: "valkey"
     # D04 (docker-audit-20260604): drop caps + block privilege gain (opt-in dev cache).
     security_opt:
       - no-new-privileges:true


### PR DESCRIPTION
The `cloud-dev` valkey service never starts on main. Both compose files give it `cap_drop: [ALL]`, and the image entrypoint runs `setpriv` to drop from root to the valkey user. Without CAP_SETUID that call dies with "setresuid failed: Operation not permitted" and the container exits 127. Because the credential store cannot come up, every self-hosted install runs without `REDIS_URL`, which is what leaves raw service tokens in failed job rows (finding 2, separate PR).

This adds `user: "valkey"` to the valkey block in `docker-compose.yml` and `docker-compose.prod.yml`. The entrypoint skips `setpriv` when it is already non-root, so the hardening stays as it was. Nothing else in either file changes.

Closes finding 10 of #1746.

Verification, run from the branch on a throwaway compose project:

```
docker compose -p gl1746valkey --profile cloud-dev up -d --no-deps --wait valkey
docker compose -p gl1746valkey logs valkey | tail -5
docker compose -p gl1746valkey --profile cloud-dev down -v
docker compose -f docker-compose.prod.yml --profile cloud-dev config --services
```

The container reports healthy and logs "Ready to accept connections tcp". `backend/tests/test_phase_272_compose.py` checks the valkey healthcheck and port binding only, so no test changed.

Config impact: the cloud-dev valkey container now runs as the image's `valkey` user instead of starting as root and dropping privileges. `cap_drop: [ALL]` is unchanged.

https://claude.ai/code/session_01SFCMH3VJ5pFfM9Rer7KHZq
