### PR TITLE
fix(logging): redact service tokens from stdlib log messages

### DIFF
--- a/backend/app/core/logging_config.py
+++ b/backend/app/core/logging_config.py
@@ -191,6 +191,27 @@ def _redact_url_match(match: re.Match[str]) -> str:
     return redacted
 
 
+# fix(#1746 codex r11): catches a credential-bearing query independent of
+# whether URL_LIKE_RE matched the URL it belongs to. A base URL containing
+# an apostrophe (or any other character URL_LIKE_RE's `[^\s"'<>]+` class
+# excludes) in its PATH -- accepted by validators that only reject
+# whitespace/control characters, and kept literal by httpx -- makes
+# URL_LIKE_RE stop before the query ever starts, so `_redact_url_match()`
+# above never runs on it and a trailing `?token=...` survives untouched.
+# This scans for any `?`-led run of non-whitespace ANYWHERE in the text,
+# independent of what precedes the `?`, and applies the same
+# query-has-credentials check `_redact_url_match()` uses.
+_QUERY_TAIL_RE = re.compile(r"\?[^\s]*")
+
+
+def _redact_query_tail_match(match: re.Match[str]) -> str:
+    """Redact one `?`-led run of non-whitespace if its tail carries a credential."""
+    tail = match.group(0)[1:]
+    if query_has_credentials(tail) or query_has_credentials(tail.replace("#", "&")):
+        return "?<redacted>"
+    return match.group(0)
+
+
 def _scrub_text(value: str) -> str:
     """Redact URL credentials and rendered token values in free text.
 
@@ -206,8 +227,17 @@ def _scrub_text(value: str) -> str:
     applied to `event` -- an exception's own message can carry a credential
     just as easily as a log line can, e.g. `httpx.HTTPStatusError`'s message
     quotes the failing request URL verbatim, `?token=...` included.
+
+    fix(#1746 codex r11): the `_QUERY_TAIL_RE` pass runs independently of the
+    `URL_LIKE_RE` one above it, deliberately -- see its own comment for why
+    the URL match alone is not reliable enough to gate a query redaction on.
+    A trailing quote or bracket swallowed along with a credential-bearing
+    query tail is acceptable in a log line; a bare `?` with no credential
+    after it, or one already redacted by the pass above, is left alone
+    either way.
     """
     value = URL_LIKE_RE.sub(_redact_url_match, value)
+    value = _QUERY_TAIL_RE.sub(_redact_query_tail_match, value)
     return _redact_token_value_repr(value)
 
 

--- a/backend/app/core/logging_config.py
+++ b/backend/app/core/logging_config.py
@@ -25,11 +25,13 @@ fix(#1746): `_redact_sensitive_fields` is KEY-based, so it never looks inside
 the `event` message string itself. That leaves two leak paths open: httpx
 (and its httpcore transport) log the full outgoing request URL at INFO for
 every call, including a `?token=...` query string on the ArcGIS path; and
-Procrastinate's worker logs a dict-repr of `task_kwargs`
-(`Starting job x[1](({'token': '...'})`), which puts a credential-store token
-inside the message text rather than a keyed field. Both are stdlib records,
-and `shared_processors` doubles as the `ProcessorFormatter`'s
-`foreign_pre_chain`, so this chain already runs for them.
+Procrastinate's worker logs `task_kwargs` rendered by `Job.call_string`
+(`procrastinate/jobs.py`: `", ".join(f"{key}={value!r}" ...)`), e.g.
+`Starting job ingest_service[1270](token='...', credential_ref=None)`, which
+puts a credential-store token inside the message text as a bare keyword
+argument rather than a keyed field. Both are stdlib records, and
+`shared_processors` doubles as the `ProcessorFormatter`'s `foreign_pre_chain`,
+so this chain already runs for them.
 """
 
 import logging
@@ -67,24 +69,36 @@ _SENSITIVE_FIELDS: frozenset[str] = frozenset(
 # most; this only exists so a caller-supplied cyclic structure terminates.
 _MAX_REDACT_DEPTH = 8
 
-# fix(#1746): catches a dict-repr rendering of task_kwargs, e.g.
-# `{'token': 'abc', 'credential_ref': None}`. A Python dict repr always
-# quotes a key and its value with the same quote character, but the two
-# named groups (rather than one shared backreference) still let this match
-# either style without assuming which one produced the string.
-_TOKEN_DICT_REPR_RE = re.compile(
-    r"(?P<kq>['\"])token(?P=kq)\s*:\s*(?P<vq>['\"]).*?(?P=vq)"
+# fix(#1746): catches a token value rendered either as a Python dict repr
+# (`{'token': 'abc', ...}`) or as `key=value!r` keyword arguments — the shape
+# `Job.call_string` actually produces, e.g.
+# `ingest_service[1270](token='abc', credential_ref=None)`. `\btoken\b`
+# excludes `credential_ref=` and `token_hint=`: a word boundary never falls
+# between "n" and "_", so a name that merely CONTAINS "token" as a sub-word
+# never matches either branch.
+_TOKEN_VALUE_RE = re.compile(
+    r"""
+    (?:
+        (?P<dq>['\"])token(?P=dq)\s*:\s*(?P<dv>['\"]).*?(?P=dv)
+      |
+        \btoken\b\s*=\s*(?P<kv>['\"]).*?(?P=kv)
+    )
+    """,
+    re.VERBOSE,
 )
 
 
-def _redact_token_dict_repr(value: str) -> str:
-    """Redact a `'token': '...'` (or double-quoted) pair inside free text."""
-    return _TOKEN_DICT_REPR_RE.sub(
-        lambda m: (
-            f"{m.group('kq')}token{m.group('kq')}: {m.group('vq')}[REDACTED]{m.group('vq')}"
-        ),
-        value,
-    )
+def _redact_token_value_repr(value: str) -> str:
+    """Redact a `'token': '...'` (dict-repr) or `token='...'` (kwarg) pair."""
+
+    def _sub(match: re.Match[str]) -> str:
+        if match.group("dq") is not None:
+            quote, value_quote = match.group("dq"), match.group("dv")
+            return f"{quote}token{quote}: {value_quote}[REDACTED]{value_quote}"
+        value_quote = match.group("kv")
+        return f"token={value_quote}[REDACTED]{value_quote}"
+
+    return _TOKEN_VALUE_RE.sub(_sub, value)
 
 
 def _redact_sensitive_fields(
@@ -102,16 +116,16 @@ def _redact_sensitive_fields(
     fix(#1746): the key-based loop above only ever sees STRUCTURED fields, so
     it cannot catch a secret embedded in the rendered MESSAGE STRING itself —
     which is exactly how it reaches the log for a raw stdlib record (httpx's
-    request-URL line, Procrastinate's dict-repr of task_kwargs). `event` is
-    the one field every record has by this point, so it is scrubbed here by
-    pattern and by shape rather than by key.
+    request-URL line, Procrastinate's keyword-rendered task_kwargs). `event`
+    is the one field every record has by this point, so it is scrubbed here
+    by pattern and by shape rather than by key.
     """
     for key in list(event_dict.keys()):
         if key.lower() in _SENSITIVE_FIELDS:
             event_dict[key] = "[REDACTED]"
     event = event_dict.get("event")
     if isinstance(event, str):
-        event_dict["event"] = _redact_token_dict_repr(redact_url_credentials(event))
+        event_dict["event"] = _redact_token_value_repr(redact_url_credentials(event))
     return event_dict
 
 

--- a/backend/app/core/logging_config.py
+++ b/backend/app/core/logging_config.py
@@ -33,15 +33,26 @@ argument rather than a keyed field. Both are stdlib records, and
 `shared_processors` doubles as the `ProcessorFormatter`'s `foreign_pre_chain`,
 so this chain already runs for them.
 
-fix(#1746 codex r2): `redact_url_credentials()` is built for a URL (or a
-GDAL-style URL-shaped string): its `_URLSPLIT_STRIPS` step deletes `\t`,
-`\r`, `\n` unconditionally, on the assumption the caller already knows the
-string is URL-shaped (see that module's own docstring). An arbitrary log
-`event` is not that — a plain multi-line or tab-delimited message with no
-credential in it at all came back with every `\n`/`\t` silently removed.
-`has_url_credentials()` is the read-only counterpart with none of that side
-effect, so it gates the call: only a string that actually carries a
-credential-shaped URL is worth the stripping `redact_url_credentials` does.
+fix(#1746 codex r2, replaced r5): `redact_url_credentials()` is built for a
+string already known to be URL-shaped: its `_URLSPLIT_STRIPS` step deletes
+`\t`, `\r`, `\n` unconditionally on that assumption, which is wrong for an
+arbitrary log `event`. Round 2 gated the call on `has_url_credentials(event)`
+to avoid that, but `has_url_credentials()` parses the WHOLE event as one URL
+— a message like `HTTP Request: GET https://user:SECRET@example.com/path
+"HTTP/1.1 200 OK"` does not parse as a URL on its own (the sentence around it
+breaks `urlsplit`), so the gate returned False and the userinfo credential
+was emitted verbatim.
+
+`url_redaction.URL_LIKE_RE` already exists to find just the URL-shaped
+SUBSTRING inside free text (it is what `redact_url_credentials()` itself
+falls back to for non-URL input), so this instead matches every URL-shaped
+substring and redacts each one individually. That both finds the real
+credential (per-URL matching sees the userinfo the whole-event parse missed)
+and keeps the earlier fix intact: `URL_LIKE_RE`'s own character class
+excludes whitespace, so a matched substring can never contain `\t`/`\r`/`\n`
+in the first place — `redact_url_credentials()`'s unconditional strip has
+nothing to strip inside a match, and every character outside a match is
+untouched.
 """
 
 import logging
@@ -51,7 +62,7 @@ from typing import Any
 
 import structlog
 
-from app.core.url_redaction import has_url_credentials, redact_url_credentials
+from app.core.url_redaction import URL_LIKE_RE, redact_url_credentials
 
 # SEC-03: case-insensitive denylist of field names that contain sensitive
 # values. Comparison is done in lower-case after stripping common
@@ -154,11 +165,13 @@ def _redact_sensitive_fields(
             event_dict[key] = "[REDACTED]"
     event = event_dict.get("event")
     if isinstance(event, str):
-        # fix(#1746 codex r2): only feed a credential-bearing string through
-        # redact_url_credentials() -- see the module docstring for why an
-        # unconditional call corrupts every other event.
-        if has_url_credentials(event):
-            event = redact_url_credentials(event)
+        # fix(#1746 codex r5): redact credentials PER URL-SHAPED SUBSTRING,
+        # not the whole event -- see the module docstring for why a
+        # whole-event gate missed a userinfo credential, and why matching on
+        # URL_LIKE_RE first is still whitespace-safe.
+        event = URL_LIKE_RE.sub(
+            lambda match: redact_url_credentials(match.group(0)), event
+        )
         event_dict["event"] = _redact_token_value_repr(event)
     return event_dict
 

--- a/backend/app/core/logging_config.py
+++ b/backend/app/core/logging_config.py
@@ -173,6 +173,26 @@ def _redact_url_match(match: re.Match[str]) -> str:
     return redacted
 
 
+def _scrub_text(value: str) -> str:
+    """Redact URL credentials and rendered token values in free text.
+
+    fix(#1746 codex r5): redact credentials PER URL-SHAPED SUBSTRING, not the
+    whole string -- see the module docstring for why a whole-string gate
+    missed a userinfo credential, and why matching on URL_LIKE_RE first is
+    still whitespace-safe. fix(#1746 codex r6): `_redact_url_match()`
+    escalates to the whole query when a partial parse would leave part of
+    the credential behind -- see its own docstring.
+
+    fix(#1746 codex r9): factored out of `_redact_sensitive_fields` so the
+    exact same scrub applies to a rendered `exception` string as already
+    applied to `event` -- an exception's own message can carry a credential
+    just as easily as a log line can, e.g. `httpx.HTTPStatusError`'s message
+    quotes the failing request URL verbatim, `?token=...` included.
+    """
+    value = URL_LIKE_RE.sub(_redact_url_match, value)
+    return _redact_token_value_repr(value)
+
+
 def _redact_sensitive_fields(
     _logger: Any, _method_name: str, event_dict: MutableMapping[str, Any]
 ) -> MutableMapping[str, Any]:
@@ -191,21 +211,25 @@ def _redact_sensitive_fields(
     request-URL line, Procrastinate's keyword-rendered task_kwargs). `event`
     is the one field every record has by this point, so it is scrubbed here
     by pattern and by shape rather than by key.
+
+    fix(#1746 codex r9): `exception` gets the identical scrub, when present
+    and already a string. `format_exc_info` now runs BEFORE this processor
+    (see `setup_logging`) precisely so `exception` exists as a plain string
+    by the time this runs, instead of being rendered afterward and reaching
+    JSON/production logs unscrubbed. `exc_info` itself (the raw tuple/bool,
+    present only when `format_exc_info` did NOT run first -- dev mode) is
+    never touched: it is not text, and dev's rich-based renderer is the one
+    that turns it into text, after this processor.
     """
     for key in list(event_dict.keys()):
         if key.lower() in _SENSITIVE_FIELDS:
             event_dict[key] = "[REDACTED]"
     event = event_dict.get("event")
     if isinstance(event, str):
-        # fix(#1746 codex r5): redact credentials PER URL-SHAPED SUBSTRING,
-        # not the whole event -- see the module docstring for why a
-        # whole-event gate missed a userinfo credential, and why matching on
-        # URL_LIKE_RE first is still whitespace-safe. fix(#1746 codex r6):
-        # _redact_url_match() escalates to the whole query when a partial
-        # parse would leave part of the credential behind -- see its own
-        # docstring.
-        event = URL_LIKE_RE.sub(_redact_url_match, event)
-        event_dict["event"] = _redact_token_value_repr(event)
+        event_dict["event"] = _scrub_text(event)
+    exception = event_dict.get("exception")
+    if isinstance(exception, str):
+        event_dict["exception"] = _scrub_text(exception)
     return event_dict
 
 
@@ -306,12 +330,6 @@ def setup_logging(
         structlog.stdlib.PositionalArgumentsFormatter(),
         structlog.stdlib.ExtraAdder(),
         structlog.processors.TimeStamper(fmt="iso", utc=True),
-        # SEC-03: redact sensitive fields BEFORE rendering / stack-info.
-        # Placed after TimeStamper (so the redactor runs on the final
-        # field set) and before StackInfoRenderer (which doesn't add
-        # user-supplied values).
-        _redact_sensitive_fields,
-        structlog.processors.StackInfoRenderer(),
     ]
 
     # fix(#1485): resolve `exc_info` into a plain `exception` string inside the
@@ -319,8 +337,28 @@ def setup_logging(
     # pretty-print. This chain is also the ProcessorFormatter's
     # `foreign_pre_chain` below, so it covers stdlib records (uvicorn.error and
     # friends) as well as structlog's own.
+    #
+    # fix(#1746 codex r9): moved BEFORE `_redact_sensitive_fields` (it used to
+    # run last, after `StackInfoRenderer`). An exception's own message can
+    # carry a credential -- `httpx.HTTPStatusError` quotes the failing
+    # request URL verbatim -- and the redactor can only scrub a field that
+    # already exists when it runs. Left conditional on `json_logs or
+    # production`: dev's rich-based renderer is NOT tolerant of a
+    # pre-rendered `exception` field (see the `plain_traceback` comment
+    # below -- it warns and stops rendering prettily), so a pre-rendered
+    # `exception` string is unconditionally worse there, not just untested.
     if json_logs or production:
         shared_processors.append(structlog.processors.format_exc_info)
+
+    shared_processors += [
+        # SEC-03: redact sensitive fields BEFORE rendering / stack-info.
+        # Placed after TimeStamper (so the redactor runs on the final field
+        # set, including a `format_exc_info`-rendered `exception` string
+        # when one exists) and before StackInfoRenderer (which doesn't add
+        # user-supplied values).
+        _redact_sensitive_fields,
+        structlog.processors.StackInfoRenderer(),
+    ]
 
     structlog.configure(
         processors=shared_processors

--- a/backend/app/core/logging_config.py
+++ b/backend/app/core/logging_config.py
@@ -87,7 +87,7 @@ _MAX_REDACT_DEPTH = 8
 # between "n" and "_", so a name that merely CONTAINS "token" as a sub-word
 # never matches either branch.
 #
-# fix(#1746 codex r3): the value body is `(?:\\.|.)*?`, not a bare `.*?`.
+# fix(#1746 codex r3): the value body is `(?:\\.|[^\\])*?`, not a bare `.*?`.
 # `repr()` of a string containing BOTH quote styles picks one as the
 # delimiter and ESCAPES that character where it occurs in the value (and
 # always escapes a literal backslash), e.g. `repr("pre'SECRET\"post")` is
@@ -95,12 +95,22 @@ _MAX_REDACT_DEPTH = 8
 # instead of the real closing quote, leaving the rest of the token in the
 # log. `\\.` consumes an escape (backslash + whatever follows it) as one
 # unit before the closing-quote alternative gets a chance to match it.
+#
+# fix(#1746 codex r4): the non-escape alternative excludes the backslash
+# (`[^\\]`, not `.`) so the two alternatives never overlap. `.` also
+# matches `\\`, so a run of N backslashes with no closing quote had N ways
+# to split into `\\.` pairs versus lone `.` characters, and the engine tried
+# all of them before giving up -- exponential backtracking on malformed
+# third-party text (36 backslashes took over three seconds), synchronously,
+# on every log record. Excluding the backslash from the second alternative
+# leaves exactly one way to consume each character, so an unterminated match
+# fails in time linear in the input length instead.
 _TOKEN_VALUE_RE = re.compile(
     r"""
     (?:
-        (?P<dq>['\"])token(?P=dq)\s*:\s*(?P<dv>['\"])(?:\\.|.)*?(?P=dv)
+        (?P<dq>['\"])token(?P=dq)\s*:\s*(?P<dv>['\"])(?:\\.|[^\\])*?(?P=dv)
       |
-        \btoken\b\s*=\s*(?P<kv>['\"])(?:\\.|.)*?(?P=kv)
+        \btoken\b\s*=\s*(?P<kv>['\"])(?:\\.|[^\\])*?(?P=kv)
     )
     """,
     re.VERBOSE,

--- a/backend/app/core/logging_config.py
+++ b/backend/app/core/logging_config.py
@@ -62,7 +62,11 @@ from typing import Any
 
 import structlog
 
-from app.core.url_redaction import URL_LIKE_RE, redact_url_credentials
+from app.core.url_redaction import (
+    URL_LIKE_RE,
+    query_has_credentials,
+    redact_url_credentials,
+)
 
 # SEC-03: case-insensitive denylist of field names that contain sensitive
 # values. Comparison is done in lower-case after stripping common
@@ -141,6 +145,34 @@ def _redact_token_value_repr(value: str) -> str:
     return _TOKEN_VALUE_RE.sub(_sub, value)
 
 
+def _redact_url_match(match: re.Match[str]) -> str:
+    """Redact one `URL_LIKE_RE` match, escalating to the whole query if needed.
+
+    fix(#1746 codex r6): `redact_url_credentials()` only replaces KNOWN
+    credential query-parameter VALUES, via `urlsplit`/`parse_qsl`. A token
+    value containing an unescaped `#` or `&` (the validators only reject
+    whitespace/control characters) breaks that: `urlsplit` reads a `#` as
+    the start of a fragment, which query redaction never looks at, and
+    `parse_qsl` reads an `&` as a new parameter -- a bare name with no
+    value, which matches no known-sensitive key. Either way, part of the
+    secret survives in the "redacted" output. This is a log line, so once
+    the ORIGINAL query is known to carry a credential at all, dropping the
+    whole query is cheaper than trusting a partial parse. Checked on the
+    raw query and, since `#` is not a `parse_qsl` delimiter, again with `#`
+    treated as `&` so a credential split across the fragment boundary is
+    still caught.
+    """
+    url = match.group(0)
+    redacted = redact_url_credentials(url)
+    _, _, query = url.partition("?")
+    if query and (
+        query_has_credentials(query) or query_has_credentials(query.replace("#", "&"))
+    ):
+        head, _, _ = redacted.partition("?")
+        redacted = f"{head}?<redacted>"
+    return redacted
+
+
 def _redact_sensitive_fields(
     _logger: Any, _method_name: str, event_dict: MutableMapping[str, Any]
 ) -> MutableMapping[str, Any]:
@@ -168,10 +200,11 @@ def _redact_sensitive_fields(
         # fix(#1746 codex r5): redact credentials PER URL-SHAPED SUBSTRING,
         # not the whole event -- see the module docstring for why a
         # whole-event gate missed a userinfo credential, and why matching on
-        # URL_LIKE_RE first is still whitespace-safe.
-        event = URL_LIKE_RE.sub(
-            lambda match: redact_url_credentials(match.group(0)), event
-        )
+        # URL_LIKE_RE first is still whitespace-safe. fix(#1746 codex r6):
+        # _redact_url_match() escalates to the whole query when a partial
+        # parse would leave part of the credential behind -- see its own
+        # docstring.
+        event = URL_LIKE_RE.sub(_redact_url_match, event)
         event_dict["event"] = _redact_token_value_repr(event)
     return event_dict
 

--- a/backend/app/core/logging_config.py
+++ b/backend/app/core/logging_config.py
@@ -6,7 +6,8 @@ structlog chain so JWT / API-key / password values are replaced with
 accidentally logs `logger.info("attempt", token=jwt)`, the token is
 redacted at the structlog layer.
 
-fix(#1485): exception rendering is never handed to rich in production.
+fix(#1485): exception rendering is never handed to rich, in production OR
+dev (as of #1746 codex r10 -- see that fix note below for why dev joined).
 `structlog.dev.ConsoleRenderer` defaults its `exception_formatter` to
 `RichTracebackFormatter(show_locals=True)` whenever rich is importable, and
 rich is in the backend's transitive dependency set. Rendering per-frame
@@ -53,6 +54,23 @@ excludes whitespace, so a matched substring can never contain `\t`/`\r`/`\n`
 in the first place — `redact_url_credentials()`'s unconditional strip has
 nothing to strip inside a match, and every character outside a match is
 untouched.
+
+fix(#1746 codex r10): round 9 only closed this for `json_logs or production`,
+because `format_exc_info` stayed conditional on that and dev's renderer used
+a rich-based formatter incompatible with a pre-rendered `exception` field
+anyway. That left dev exactly as exposed as before: an unhandled exception
+in a local API or worker run still printed a raw, unscrubbed traceback, and
+rich's own locals rendering would print a secret held in a local variable
+even if the message text were somehow already clean. `format_exc_info` now
+runs UNCONDITIONALLY, and dev's `ConsoleRenderer` now takes the same
+`plain_traceback` formatter production does — not a softer version of the
+same idea, but the only formatter that is even compatible with a
+pre-rendered `exception` field (a non-plain one meeting one warns and stops
+rendering prettily; see the `plain_traceback` comment in `setup_logging`).
+Locals are where a secret variable itself would leak regardless of any
+string scrub, so removing rich from dev closes that path too, not only the
+one the string scrub covers. Dev keeps every other `ConsoleRenderer` default
+(colours included) — only the exception formatter changed.
 """
 
 import logging
@@ -267,20 +285,6 @@ def redact_nested(value: Any, _depth: int = 0) -> Any:
     return value
 
 
-def _dev_exception_formatter() -> structlog.types.ExceptionRenderer:
-    """The console exception formatter for non-production deployments.
-
-    Keeps rich's syntax-highlighted frames, which are the reason the pretty
-    renderer is worth having, and drops only the per-frame locals tables — the
-    part whose cost is unbounded (see the module docstring). Deployments
-    without rich installed keep whatever structlog picked for them.
-    """
-    formatter = structlog.dev.default_exception_formatter
-    if isinstance(formatter, structlog.dev.RichTracebackFormatter):
-        return structlog.dev.RichTracebackFormatter(show_locals=False)
-    return formatter
-
-
 def apply_http_logger_levels(root_level: int | str) -> None:
     """Keep httpx/httpcore at least as quiet as WARNING, never quieter than root.
 
@@ -318,10 +322,14 @@ def setup_logging(
 ) -> None:
     """Configure structlog + stdlib logging with shared processor chain.
 
-    `production` selects the exception-rendering posture rather than the log
-    format: when set, tracebacks are formatted by the stdlib `traceback`
-    module and rich is never reached, at a cost that does not depend on the
-    size of any frame's local variables.
+    fix(#1746 codex r10): `production` no longer selects the
+    exception-rendering posture -- dev and production now render exceptions
+    identically (plain, scrubbed, no rich), because `format_exc_info` runs
+    unconditionally and the redactor needs the SAME `exception` string to
+    scrub regardless of console mode. `production` is still threaded through
+    from `settings.is_production` at both call sites, in case a future
+    difference needs it again; today it affects nothing inside this
+    function.
     """
     shared_processors: list[structlog.types.Processor] = [
         structlog.contextvars.merge_contextvars,
@@ -342,13 +350,15 @@ def setup_logging(
     # run last, after `StackInfoRenderer`). An exception's own message can
     # carry a credential -- `httpx.HTTPStatusError` quotes the failing
     # request URL verbatim -- and the redactor can only scrub a field that
-    # already exists when it runs. Left conditional on `json_logs or
-    # production`: dev's rich-based renderer is NOT tolerant of a
-    # pre-rendered `exception` field (see the `plain_traceback` comment
-    # below -- it warns and stops rendering prettily), so a pre-rendered
-    # `exception` string is unconditionally worse there, not just untested.
-    if json_logs or production:
-        shared_processors.append(structlog.processors.format_exc_info)
+    # already exists when it runs.
+    #
+    # fix(#1746 codex r10): now UNCONDITIONAL. Gating this on `json_logs or
+    # production` left dev exactly as exposed as before -- an unhandled
+    # exception in a local run still printed a raw, unscrubbed traceback.
+    # dev's `ConsoleRenderer` below now uses `plain_traceback`
+    # unconditionally too, so there is no longer a renderer left that this
+    # would be incompatible with.
+    shared_processors.append(structlog.processors.format_exc_info)
 
     shared_processors += [
         # SEC-03: redact sensitive fields BEFORE rendering / stack-info.
@@ -371,18 +381,18 @@ def setup_logging(
     log_renderer: structlog.types.Processor
     if json_logs:
         log_renderer = structlog.processors.JSONRenderer()
-    elif production:
+    else:
         # `plain_traceback` is the second half of the #1485 fix, not a
         # redundant one: ConsoleRenderer warns on every exception when a
         # non-plain formatter meets an already-rendered `exception` field
         # ("Remove `format_exc_info` from your processor chain..."), and it
         # still owns any exc_info that reaches it by another route.
+        #
+        # fix(#1746 codex r10): dev and production share this construction
+        # now -- see the module docstring and this function's docstring for
+        # why `production` no longer needs to pick between them.
         log_renderer = structlog.dev.ConsoleRenderer(
             exception_formatter=structlog.dev.plain_traceback
-        )
-    else:
-        log_renderer = structlog.dev.ConsoleRenderer(
-            exception_formatter=_dev_exception_formatter()
         )
 
     formatter = structlog.stdlib.ProcessorFormatter(

--- a/backend/app/core/logging_config.py
+++ b/backend/app/core/logging_config.py
@@ -86,12 +86,21 @@ _MAX_REDACT_DEPTH = 8
 # excludes `credential_ref=` and `token_hint=`: a word boundary never falls
 # between "n" and "_", so a name that merely CONTAINS "token" as a sub-word
 # never matches either branch.
+#
+# fix(#1746 codex r3): the value body is `(?:\\.|.)*?`, not a bare `.*?`.
+# `repr()` of a string containing BOTH quote styles picks one as the
+# delimiter and ESCAPES that character where it occurs in the value (and
+# always escapes a literal backslash), e.g. `repr("pre'SECRET\"post")` is
+# `'pre\'SECRET"post'`. A bare lazy `.*?` stops at that escaped delimiter
+# instead of the real closing quote, leaving the rest of the token in the
+# log. `\\.` consumes an escape (backslash + whatever follows it) as one
+# unit before the closing-quote alternative gets a chance to match it.
 _TOKEN_VALUE_RE = re.compile(
     r"""
     (?:
-        (?P<dq>['\"])token(?P=dq)\s*:\s*(?P<dv>['\"]).*?(?P=dv)
+        (?P<dq>['\"])token(?P=dq)\s*:\s*(?P<dv>['\"])(?:\\.|.)*?(?P=dv)
       |
-        \btoken\b\s*=\s*(?P<kv>['\"]).*?(?P=kv)
+        \btoken\b\s*=\s*(?P<kv>['\"])(?:\\.|.)*?(?P=kv)
     )
     """,
     re.VERBOSE,

--- a/backend/app/core/logging_config.py
+++ b/backend/app/core/logging_config.py
@@ -20,13 +20,26 @@ path. With `--workers 1` that is the whole API.
 bound it: they truncate containers and `str` values, not the `repr()` of an
 arbitrary object, which is exactly what a SQLAlchemy session or model
 instance produces.
+
+fix(#1746): `_redact_sensitive_fields` is KEY-based, so it never looks inside
+the `event` message string itself. That leaves two leak paths open: httpx
+(and its httpcore transport) log the full outgoing request URL at INFO for
+every call, including a `?token=...` query string on the ArcGIS path; and
+Procrastinate's worker logs a dict-repr of `task_kwargs`
+(`Starting job x[1](({'token': '...'})`), which puts a credential-store token
+inside the message text rather than a keyed field. Both are stdlib records,
+and `shared_processors` doubles as the `ProcessorFormatter`'s
+`foreign_pre_chain`, so this chain already runs for them.
 """
 
 import logging
+import re
 from collections.abc import Mapping, MutableMapping
 from typing import Any
 
 import structlog
+
+from app.core.url_redaction import redact_url_credentials
 
 # SEC-03: case-insensitive denylist of field names that contain sensitive
 # values. Comparison is done in lower-case after stripping common
@@ -54,6 +67,25 @@ _SENSITIVE_FIELDS: frozenset[str] = frozenset(
 # most; this only exists so a caller-supplied cyclic structure terminates.
 _MAX_REDACT_DEPTH = 8
 
+# fix(#1746): catches a dict-repr rendering of task_kwargs, e.g.
+# `{'token': 'abc', 'credential_ref': None}`. A Python dict repr always
+# quotes a key and its value with the same quote character, but the two
+# named groups (rather than one shared backreference) still let this match
+# either style without assuming which one produced the string.
+_TOKEN_DICT_REPR_RE = re.compile(
+    r"(?P<kq>['\"])token(?P=kq)\s*:\s*(?P<vq>['\"]).*?(?P=vq)"
+)
+
+
+def _redact_token_dict_repr(value: str) -> str:
+    """Redact a `'token': '...'` (or double-quoted) pair inside free text."""
+    return _TOKEN_DICT_REPR_RE.sub(
+        lambda m: (
+            f"{m.group('kq')}token{m.group('kq')}: {m.group('vq')}[REDACTED]{m.group('vq')}"
+        ),
+        value,
+    )
+
 
 def _redact_sensitive_fields(
     _logger: Any, _method_name: str, event_dict: MutableMapping[str, Any]
@@ -66,10 +98,20 @@ def _redact_sensitive_fields(
     deliberate trade-off: structlog idiomatic usage logs flat key/value
     pairs; recursing would amplify the redactor's CPU cost on every log
     line.
+
+    fix(#1746): the key-based loop above only ever sees STRUCTURED fields, so
+    it cannot catch a secret embedded in the rendered MESSAGE STRING itself —
+    which is exactly how it reaches the log for a raw stdlib record (httpx's
+    request-URL line, Procrastinate's dict-repr of task_kwargs). `event` is
+    the one field every record has by this point, so it is scrubbed here by
+    pattern and by shape rather than by key.
     """
     for key in list(event_dict.keys()):
         if key.lower() in _SENSITIVE_FIELDS:
             event_dict[key] = "[REDACTED]"
+    event = event_dict.get("event")
+    if isinstance(event, str):
+        event_dict["event"] = _redact_token_dict_repr(redact_url_credentials(event))
     return event_dict
 
 
@@ -201,3 +243,14 @@ def setup_logging(
 
     logging.getLogger("uvicorn.access").handlers.clear()
     logging.getLogger("uvicorn.access").propagate = False
+
+    # fix(#1746): httpx (and its httpcore transport) logs the full request
+    # URL at INFO on every call, including a `?token=...` query string on the
+    # ArcGIS path — with or without a credential store. Root defaults to
+    # INFO (see core/config.py), so that line reached every deployment's logs
+    # by default, twice per refresh on the credential-store path. WARNING
+    # keeps connection failures visible while dropping the routine per-request
+    # echo; the `event`-string scrub above is the backstop for whatever still
+    # gets through at WARNING or above.
+    for _log in ("httpx", "httpcore"):
+        logging.getLogger(_log).setLevel(logging.WARNING)

--- a/backend/app/core/logging_config.py
+++ b/backend/app/core/logging_config.py
@@ -257,6 +257,38 @@ def _dev_exception_formatter() -> structlog.types.ExceptionRenderer:
     return formatter
 
 
+def apply_http_logger_levels(root_level: int | str) -> None:
+    """Keep httpx/httpcore at least as quiet as WARNING, never quieter than root.
+
+    fix(#1746): httpx (and its httpcore transport) logs the full request URL
+    at INFO on every call, including a `?token=...` query string on the
+    ArcGIS path — with or without a credential store. Root defaults to INFO
+    (see core/config.py), so that line reached every deployment's logs by
+    default, twice per refresh on the credential-store path. WARNING keeps
+    connection failures visible while dropping the routine per-request echo;
+    the `event`-string scrub in `_redact_sensitive_fields` is the backstop
+    for whatever still gets through at WARNING or above.
+
+    fix(#1746 codex r8): a FIXED WARNING silently reverses itself the moment
+    root is raised past it. `Logger.isEnabledFor` uses the LOGGER'S OWN
+    explicit level once one is set and never re-derives it from root, so
+    `LOG_LEVEL=ERROR`/`CRITICAL` at boot, or a runtime change to either via
+    the persistent-config log-level setter, left httpx sitting at WARNING —
+    MORE verbose than the deployment asked for. Deriving from whichever
+    level is stricter makes WARNING a floor rather than a fixed point:
+    quieter than WARNING (ERROR, CRITICAL), httpx follows root; noisier
+    (INFO or below), httpx stays at WARNING. Accepts the string form too,
+    since both call sites (this module's own `setup_logging` and
+    `persistent_config.py`'s runtime setter) hold the level as a string
+    right before calling this.
+    """
+    if isinstance(root_level, str):
+        root_level = logging.getLevelName(root_level.upper())
+    level = max(logging.WARNING, root_level)
+    for _log in ("httpx", "httpcore"):
+        logging.getLogger(_log).setLevel(level)
+
+
 def setup_logging(
     json_logs: bool = False, log_level: str = "INFO", *, production: bool = False
 ) -> None:
@@ -338,13 +370,4 @@ def setup_logging(
     logging.getLogger("uvicorn.access").handlers.clear()
     logging.getLogger("uvicorn.access").propagate = False
 
-    # fix(#1746): httpx (and its httpcore transport) logs the full request
-    # URL at INFO on every call, including a `?token=...` query string on the
-    # ArcGIS path — with or without a credential store. Root defaults to
-    # INFO (see core/config.py), so that line reached every deployment's logs
-    # by default, twice per refresh on the credential-store path. WARNING
-    # keeps connection failures visible while dropping the routine per-request
-    # echo; the `event`-string scrub above is the backstop for whatever still
-    # gets through at WARNING or above.
-    for _log in ("httpx", "httpcore"):
-        logging.getLogger(_log).setLevel(logging.WARNING)
+    apply_http_logger_levels(log_level.upper())

--- a/backend/app/core/logging_config.py
+++ b/backend/app/core/logging_config.py
@@ -32,6 +32,16 @@ puts a credential-store token inside the message text as a bare keyword
 argument rather than a keyed field. Both are stdlib records, and
 `shared_processors` doubles as the `ProcessorFormatter`'s `foreign_pre_chain`,
 so this chain already runs for them.
+
+fix(#1746 codex r2): `redact_url_credentials()` is built for a URL (or a
+GDAL-style URL-shaped string): its `_URLSPLIT_STRIPS` step deletes `\t`,
+`\r`, `\n` unconditionally, on the assumption the caller already knows the
+string is URL-shaped (see that module's own docstring). An arbitrary log
+`event` is not that — a plain multi-line or tab-delimited message with no
+credential in it at all came back with every `\n`/`\t` silently removed.
+`has_url_credentials()` is the read-only counterpart with none of that side
+effect, so it gates the call: only a string that actually carries a
+credential-shaped URL is worth the stripping `redact_url_credentials` does.
 """
 
 import logging
@@ -41,7 +51,7 @@ from typing import Any
 
 import structlog
 
-from app.core.url_redaction import redact_url_credentials
+from app.core.url_redaction import has_url_credentials, redact_url_credentials
 
 # SEC-03: case-insensitive denylist of field names that contain sensitive
 # values. Comparison is done in lower-case after stripping common
@@ -125,7 +135,12 @@ def _redact_sensitive_fields(
             event_dict[key] = "[REDACTED]"
     event = event_dict.get("event")
     if isinstance(event, str):
-        event_dict["event"] = _redact_token_value_repr(redact_url_credentials(event))
+        # fix(#1746 codex r2): only feed a credential-bearing string through
+        # redact_url_credentials() -- see the module docstring for why an
+        # unconditional call corrupts every other event.
+        if has_url_credentials(event):
+            event = redact_url_credentials(event)
+        event_dict["event"] = _redact_token_value_repr(event)
     return event_dict
 
 

--- a/backend/app/core/persistent_config.py
+++ b/backend/app/core/persistent_config.py
@@ -23,6 +23,7 @@ from app.platform.cache import get_cache
 from app.platform.cache.provider import CacheProvider
 from app.platform.audit import AuditEvent, audit_emit
 from app.core.config import settings
+from app.core.logging_config import apply_http_logger_levels
 from app.core.public_urls import (
     PUBLIC_URL_KEYS,
     _is_env_only,
@@ -438,6 +439,10 @@ class _LogLevelConfig(PersistentConfig[str]):
 
     def _on_change(self, value: str) -> None:
         logging.getLogger().setLevel(value.upper())
+        # fix(#1746 codex r8): keep httpx/httpcore's WARNING floor correct
+        # after a runtime log-level change too -- see
+        # apply_http_logger_levels() in logging_config.py.
+        apply_http_logger_levels(value.upper())
 
 
 # ---------------------------------------------------------------------------

--- a/backend/app/modules/catalog/sources/adapters/arcgis.py
+++ b/backend/app/modules/catalog/sources/adapters/arcgis.py
@@ -2,7 +2,7 @@
 
 import asyncio
 import re
-from urllib.parse import urlparse
+from urllib.parse import quote, urlparse
 
 import httpx
 import structlog
@@ -133,7 +133,13 @@ async def probe_arcgis_service(
     or None if not an ArcGIS service.
     """
     try:
-        query = f"{base_url}?f=json" + (f"&token={token}" if token else "")
+        # fix(#1746 codex r7): percent-encode the token before concatenating it
+        # into the URL -- a URL-reserved character in a raw token (', #, &)
+        # can change what the request means and, in a log line, end the
+        # URL_LIKE_RE match early enough to escape the redactor entirely.
+        query = f"{base_url}?f=json" + (
+            f"&token={quote(token, safe='')}" if token else ""
+        )
         response = await client.get(query)
         response.raise_for_status()
     except (httpx.HTTPStatusError, httpx.TransportError) as exc:
@@ -227,9 +233,11 @@ async def enrich_arcgis_feature_counts(
             layer_id = layer.get("id")
             if layer_id is None:
                 return {**layer, "feature_count": None}
+            # fix(#1746 codex r7): same percent-encoding as probe_arcgis_service
+            # above -- see its comment.
             url = (
                 f"{base_url}/{layer_id}/query?where=1%3D1&returnCountOnly=true&f=json"
-            ) + (f"&token={token}" if token else "")
+            ) + (f"&token={quote(token, safe='')}" if token else "")
             try:
                 resp = await client.get(url)
                 resp.raise_for_status()

--- a/backend/tests/_logging_state.py
+++ b/backend/tests/_logging_state.py
@@ -1,11 +1,18 @@
 """Save and restore everything ``setup_logging()`` mutates.
 
 fix(#1064 codex r2): ``setup_logging()`` does not only touch the root logger.
-Reading ``app/core/logging_config.py:103-112`` line by line, it clears root's
+Reading ``app/core/logging_config.py:283-304`` line by line, it clears root's
 handlers, then clears handlers and rewrites ``propagate`` on ``uvicorn``,
 ``uvicorn.error`` and ``uvicorn.access``. A teardown that restores only root
 leaves those three changed — measured, a caller's ``uvicorn.access`` goes in
 with ``propagate=True`` and comes back out with ``propagate=False``.
+
+fix(#1746 codex r5): the same function also sets ``httpx``/``httpcore`` to
+``WARNING`` (finding 1/13's fix), and that level survived every restore here
+until now for exactly the reason the paragraph above warns about: it was not
+on this list. A caller doing ``configured_logging()`` around a direct
+``setup_logging()`` call left both loggers pinned at ``WARNING`` for the rest
+of the worker.
 
 Two earlier rounds of this same mistake are why the list is derived from the
 source rather than from memory. The first restored root but not the structlog
@@ -31,9 +38,16 @@ import structlog
 
 from app.core.logging_config import setup_logging
 
-# Every logger setup_logging() reaches, from logging_config.py:103-112.
+# Every logger setup_logging() reaches, from logging_config.py:283-304.
 # "" is the root logger.
-_MUTATED_LOGGERS = ("", "uvicorn", "uvicorn.error", "uvicorn.access")
+_MUTATED_LOGGERS = (
+    "",
+    "uvicorn",
+    "uvicorn.error",
+    "uvicorn.access",
+    "httpx",
+    "httpcore",
+)
 
 
 @contextlib.contextmanager

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -490,10 +490,21 @@ def _install_stdout_safe_structlog_baseline():
 _install_stdout_safe_structlog_baseline()
 
 
-# Every logger setup_logging() reaches, read off app/core/logging_config.py:102-112.
+# Every logger setup_logging() reaches, read off app/core/logging_config.py:283-304.
 # "" is the root logger. tests/_logging_state.py keeps the same list for the
 # per-test helper; both are derived from that source, not from each other.
-_LOGGING_MUTATED_LOGGERS = ("", "uvicorn", "uvicorn.error", "uvicorn.access")
+#
+# fix(#1746 codex r5): httpx/httpcore (set to WARNING there) were missing
+# from this list, so this guard could not undo a direct setup_logging() call
+# that left them pinned at WARNING for the rest of the worker.
+_LOGGING_MUTATED_LOGGERS = (
+    "",
+    "uvicorn",
+    "uvicorn.error",
+    "uvicorn.access",
+    "httpx",
+    "httpcore",
+)
 
 
 def _is_pytest_owned_handler(handler: logging.Handler) -> bool:

--- a/backend/tests/test_1746_stdlib_log_redaction.py
+++ b/backend/tests/test_1746_stdlib_log_redaction.py
@@ -32,6 +32,7 @@ import pytest
 from procrastinate.jobs import Job
 
 from app.core.logging_config import _redact_token_value_repr
+from app.core.url_redaction import has_url_credentials
 from tests._logging_state import configured_logging
 
 _TOKEN = "SECRETTOKEN123"
@@ -164,6 +165,43 @@ def test_procrastinate_worker_task_kwargs_token_is_redacted():
     assert _TOKEN not in lines[0]
     assert "credential_ref=None" in lines[0]
     assert "dataset_id='abc'" in lines[0]
+
+
+def test_event_without_a_credential_url_is_never_mangled():
+    """Codex round 2 P2: `redact_url_credentials()` must be gated, not blanket.
+
+    That helper's `_URLSPLIT_STRIPS` step deletes `\t`/`\r`/`\n`
+    unconditionally -- correct for a string already known to be URL-shaped,
+    wrong for an arbitrary log `event`. `_redact_sensitive_fields` now calls
+    it only when `has_url_credentials()` says the string actually carries a
+    credential-shaped URL, so a plain multi-line / tab-delimited message with
+    no credential in it survives byte-for-byte.
+    """
+    message = "first line\nsecond\tline"
+    assert not has_url_credentials(message)  # pin the premise: nothing to redact
+
+    lines = _emit_through_real_pipeline("procrastinate.worker", logging.INFO, message)
+
+    assert len(lines) == 1
+    assert message in lines[0]
+
+
+def test_multiline_event_with_a_credential_url_still_gets_the_token_scrubbed():
+    """A credential URL embedded in a multi-line message is still caught.
+
+    Flattening the message is accepted here -- it DOES carry a credential, so
+    running it through `redact_url_credentials()` is the right call. Only the
+    no-credential case above is required to come back untouched.
+    """
+    message = f'retrying request\nHTTP Request: GET {_ARCGIS_URL} "HTTP/1.1 200 OK"'
+    assert has_url_credentials(message)  # pin the premise before redacting it
+
+    lines = _emit_through_real_pipeline(
+        "procrastinate.worker", logging.WARNING, message
+    )
+
+    assert len(lines) == 1
+    assert _TOKEN not in lines[0]
 
 
 def test_redact_token_value_repr_also_handles_a_dict_repr_shape():

--- a/backend/tests/test_1746_stdlib_log_redaction.py
+++ b/backend/tests/test_1746_stdlib_log_redaction.py
@@ -26,6 +26,7 @@ loggers, and (as of fix #1746 codex r5) ``httpx``/``httpcore`` (see
 the autouse fixture below for why it needs to.
 """
 
+import json
 import logging
 import time
 
@@ -448,3 +449,68 @@ def test_redact_token_value_repr_stays_linear_on_unterminated_input():
 
     assert elapsed < 1.0, f"took {elapsed:.3f}s -- no longer linear"
     assert redacted == message  # no closing quote: nothing to redact, unchanged
+
+
+def _emit_exception_through_real_pipeline(exc: Exception) -> tuple[str, dict]:
+    """Raise/catch *exc*, log it with `exc_info=True` through the real
+    JSON/production pipeline, and return (captured line, parsed JSON dict).
+
+    Uses the same capturing-handler approach as `_emit_through_real_pipeline`
+    above, but with `exc_info=True` so `format_exc_info` actually renders an
+    `exception` field, and `json_logs=True` so the captured line is parseable
+    JSON rather than an ANSI-colored console line.
+    """
+    with configured_logging(json_logs=True, log_level="INFO", production=True):
+        root = logging.getLogger()
+        capture = _ListHandler()
+        capture.setFormatter(root.handlers[0].formatter)
+        root.addHandler(capture)
+        try:
+            try:
+                raise exc
+            except type(exc):
+                logging.getLogger("test.exception_scrub").error("boom", exc_info=True)
+        finally:
+            root.removeHandler(capture)
+    assert len(capture.lines) == 1
+    return capture.lines[0], json.loads(capture.lines[0])
+
+
+def test_exception_field_url_credential_is_scrubbed():
+    """Codex round 9 P1: `format_exc_info` ran AFTER the redactor.
+
+    `_redact_sensitive_fields` only ever saw `event`; `format_exc_info` was
+    appended to the chain AFTER it (only when `json_logs or production`), so
+    the `exception` string it renders -- which can itself quote a credential,
+    e.g. `httpx.HTTPStatusError`'s message quoting the failing request URL --
+    was created after redaction and reached JSON/production logs verbatim.
+    `format_exc_info` now runs before `_redact_sensitive_fields`, so
+    `exception` exists as a plain string in time to be scrubbed the same way
+    `event` always was.
+    """
+    exc = ValueError(f"request failed: {_ARCGIS_URL}")
+    assert _TOKEN in str(exc)  # pin the premise before redacting it
+
+    line, data = _emit_exception_through_real_pipeline(exc)
+
+    assert _TOKEN not in line
+    assert "ValueError" in data["exception"]
+    assert "?<redacted>" in data["exception"]
+
+
+def test_exception_field_keyword_form_token_is_scrubbed():
+    """Same fix, the keyword-rendered token shape (finding 13's shape).
+
+    An exception raised while handling a credential-store token can just as
+    easily quote it back in a `key=value!r` shape as Procrastinate's worker
+    does -- the same `_scrub_text()` now applied to `event` and `exception`
+    catches both shapes either way.
+    """
+    exc = ValueError(f"job failed with kwargs token='{_TOKEN}'")
+    assert _TOKEN in str(exc)  # pin the premise before redacting it
+
+    line, data = _emit_exception_through_real_pipeline(exc)
+
+    assert _TOKEN not in line
+    assert "ValueError" in data["exception"]
+    assert "token='[REDACTED]'" in data["exception"]

--- a/backend/tests/test_1746_stdlib_log_redaction.py
+++ b/backend/tests/test_1746_stdlib_log_redaction.py
@@ -18,12 +18,12 @@ handler onto a logger that structlog's stdlib bridge does not use the same
 way), so these tests attach an explicit ``logging.Handler`` to the stdlib
 root logger instead and read back what it actually received.
 
-``tests/_logging_state.configured_logging()`` only saves and restores the
-loggers ``setup_logging()`` is documented to mutate — root and the three
-uvicorn loggers (see ``_logging_state.py``'s own docstring). httpx/httpcore
-are outside that list, so this file restores their levels itself; otherwise
-the first test below would leak a WARNING level into every later test in the
-same worker.
+``tests/_logging_state.configured_logging()`` saves and restores every
+logger ``setup_logging()`` is documented to mutate — root, the three uvicorn
+loggers, and (as of fix #1746 codex r5) ``httpx``/``httpcore`` (see
+``_logging_state.py``'s own docstring). ``setup_logging()`` never touches
+``.disabled`` though, so this file still restores that one flag itself; see
+the autouse fixture below for why it needs to.
 """
 
 import logging
@@ -33,7 +33,7 @@ import pytest
 from procrastinate.jobs import Job
 
 from app.core.logging_config import _redact_token_value_repr
-from app.core.url_redaction import has_url_credentials
+from app.core.url_redaction import URL_LIKE_RE
 from tests._logging_state import configured_logging
 
 _TOKEN = "SECRETTOKEN123"
@@ -52,33 +52,32 @@ class _ListHandler(logging.Handler):
 
 
 @pytest.fixture(autouse=True)
-def _restore_httpx_logger_state():
-    """Undo this file's own level change, and alembic's `fileConfig()`.
+def _restore_httpx_logger_disabled_flag():
+    """Undo alembic's `fileConfig()` disabling the "httpx" logger.
 
-    `configured_logging()` only tracks the loggers `setup_logging()` is
-    documented to mutate (see `_logging_state.py`'s own docstring), so it
-    never restores httpx/httpcore's level -- without this, running this file
-    would leave both pinned at WARNING for whatever test runs next on the
-    same xdist worker.
+    `_logging_state._MUTATED_LOGGERS` and `conftest._LOGGING_MUTATED_LOGGERS`
+    now include "httpx"/"httpcore" (fix #1746 codex r5), so `level` -- what
+    this fixture used to also save and restore -- is covered by
+    `configured_logging()` and the autouse guard already. `.disabled` is not:
+    neither snapshot reads or writes it, because `setup_logging()` itself
+    never touches it, so it was never in scope for either.
 
-    Separately: `alembic/env.py` calls `logging.config.fileConfig()` to run
-    migrations, and that defaults to `disable_existing_loggers=True`, which
-    disables every *already-registered* logger not named in alembic.ini's
-    `[loggers]` section. By the time that runs, collection has already
-    imported plenty of other test modules that import httpx, so the "httpx"
-    logger object already exists and gets silently `.disabled = True` for
-    the rest of the session -- independent of level, and independent of this
-    file's own fix. Restoring the `disabled` flag too keeps this file
-    exercising the real `setup_logging()` level change instead of that
-    unrelated fixture's side effect.
+    `alembic/env.py` calls `logging.config.fileConfig()` to run migrations,
+    and that defaults to `disable_existing_loggers=True`, which disables
+    every *already-registered* logger not named in alembic.ini's `[loggers]`
+    section. By the time that runs, collection has already imported plenty
+    of other test modules that import httpx, so the "httpx" logger object
+    already exists and gets silently `.disabled = True` for the rest of the
+    session -- independent of this file's own fix, and independent of
+    `setup_logging()` entirely. Restoring the flag here keeps this file
+    exercising the real fix instead of that unrelated side effect.
     """
     loggers = [logging.getLogger(name) for name in ("httpx", "httpcore")]
-    saved = [(lg.level, lg.disabled) for lg in loggers]
+    saved = [lg.disabled for lg in loggers]
     for lg in loggers:
         lg.disabled = False
     yield
-    for lg, (level, disabled) in zip(loggers, saved):
-        lg.setLevel(level)
+    for lg, disabled in zip(loggers, saved):
         lg.disabled = disabled
 
 
@@ -132,6 +131,28 @@ def test_httpx_warning_request_line_is_delivered_but_redacted():
     assert _TOKEN not in lines[0]
     assert "token=" in lines[0]  # the field survives; only the value is scrubbed
     assert "HTTP Request: GET" in lines[0]
+
+
+def test_httpx_warning_userinfo_credential_is_redacted():
+    """Codex round 5 P1: a userinfo credential the whole-event gate missed.
+
+    `has_url_credentials()` (round 2's gate, since replaced) parses the
+    WHOLE event as one URL, and a sentence like `HTTP Request: GET
+    https://user:SECRET@host/path "HTTP/1.1 200 OK"` does not parse as a URL
+    on its own -- the surrounding prose breaks `urlsplit`, so the gate
+    returned False and the credential went out untouched. Round 5 matches
+    `URL_LIKE_RE` first and redacts each matched URL individually, which
+    finds the userinfo the whole-event parse missed.
+    """
+    secret_url = f"https://user:{_TOKEN}@example.com/path"
+    message = f'HTTP Request: GET {secret_url} "HTTP/1.1 200 OK"'
+    assert f"user:{_TOKEN}@" in message  # pin the premise before redacting it
+
+    lines = _emit_through_real_pipeline("httpx", logging.WARNING, message)
+
+    assert len(lines) == 1
+    assert _TOKEN not in lines[0]
+    assert "redacted@" in lines[0]
 
 
 def test_procrastinate_worker_task_kwargs_token_is_redacted():
@@ -206,17 +227,19 @@ def test_procrastinate_worker_token_with_escaped_quotes_is_redacted():
 
 
 def test_event_without_a_credential_url_is_never_mangled():
-    """Codex round 2 P2: `redact_url_credentials()` must be gated, not blanket.
+    """Codex round 2 P2, mechanism updated in round 5.
 
-    That helper's `_URLSPLIT_STRIPS` step deletes `\t`/`\r`/`\n`
-    unconditionally -- correct for a string already known to be URL-shaped,
-    wrong for an arbitrary log `event`. `_redact_sensitive_fields` now calls
-    it only when `has_url_credentials()` says the string actually carries a
-    credential-shaped URL, so a plain multi-line / tab-delimited message with
-    no credential in it survives byte-for-byte.
+    `redact_url_credentials()`'s `_URLSPLIT_STRIPS` step deletes
+    `\t`/`\r`/`\n` unconditionally -- correct for a string already known to
+    be URL-shaped, wrong for an arbitrary log `event`. Round 2 gated the
+    whole-event call on `has_url_credentials()`; round 5 replaced that with
+    matching `URL_LIKE_RE` and redacting each match, which keeps this
+    property for a different reason: a message with no URL-shaped substring
+    at all has nothing for `URL_LIKE_RE` to match, so it is never handed to
+    `redact_url_credentials()` in the first place and survives byte-for-byte.
     """
     message = "first line\nsecond\tline"
-    assert not has_url_credentials(message)  # pin the premise: nothing to redact
+    assert URL_LIKE_RE.search(message) is None  # pin the premise: no URL at all
 
     lines = _emit_through_real_pipeline("procrastinate.worker", logging.INFO, message)
 
@@ -227,12 +250,17 @@ def test_event_without_a_credential_url_is_never_mangled():
 def test_multiline_event_with_a_credential_url_still_gets_the_token_scrubbed():
     """A credential URL embedded in a multi-line message is still caught.
 
-    Flattening the message is accepted here -- it DOES carry a credential, so
-    running it through `redact_url_credentials()` is the right call. Only the
-    no-credential case above is required to come back untouched.
+    Round 2 accepted flattening the WHOLE message here, because the old
+    whole-event gate could only call `redact_url_credentials()` on
+    everything or nothing. Round 5's per-`URL_LIKE_RE`-match redaction
+    removes that trade-off entirely: `URL_LIKE_RE`'s character class already
+    excludes whitespace, so the matched URL substring can never contain the
+    leading `\n`, and text outside the match is never touched at all. Both
+    the token and the newline are asserted now -- neither has to be given up
+    for the other.
     """
     message = f'retrying request\nHTTP Request: GET {_ARCGIS_URL} "HTTP/1.1 200 OK"'
-    assert has_url_credentials(message)  # pin the premise before redacting it
+    assert URL_LIKE_RE.search(message) is not None  # pin the premise: a URL is there
 
     lines = _emit_through_real_pipeline(
         "procrastinate.worker", logging.WARNING, message
@@ -240,6 +268,7 @@ def test_multiline_event_with_a_credential_url_still_gets_the_token_scrubbed():
 
     assert len(lines) == 1
     assert _TOKEN not in lines[0]
+    assert "retrying request\n" in lines[0]
 
 
 def test_redact_token_value_repr_also_handles_a_dict_repr_shape():

--- a/backend/tests/test_1746_stdlib_log_redaction.py
+++ b/backend/tests/test_1746_stdlib_log_redaction.py
@@ -1,0 +1,147 @@
+"""fix(#1746): stdlib log records must not leak service tokens (findings 1, 13).
+
+httpx (and its httpcore transport) logs the full outgoing request URL at INFO
+for every call, e.g. ``HTTP Request: GET <url>?f=json&token=<value> "HTTP/1.1
+200 OK"``. That line reaches every deployment's logs by default, because root
+defaults to INFO (``app.core.config``), and it fires twice per refresh on the
+credential-store path (finding 13). Procrastinate's worker separately logs a
+dict-repr of ``task_kwargs`` (``Starting job x[1]({'token': '...'})``), which
+puts a token inside the MESSAGE STRING rather than a keyed field, so the
+existing key-based ``_redact_sensitive_fields`` processor cannot see it
+either way.
+
+pytest's ``caplog`` sees zero structlog records in this repo (it hooks a
+handler onto a logger that structlog's stdlib bridge does not use the same
+way), so these tests attach an explicit ``logging.Handler`` to the stdlib
+root logger instead and read back what it actually received.
+
+``tests/_logging_state.configured_logging()`` only saves and restores the
+loggers ``setup_logging()`` is documented to mutate — root and the three
+uvicorn loggers (see ``_logging_state.py``'s own docstring). httpx/httpcore
+are outside that list, so this file restores their levels itself; otherwise
+the first test below would leak a WARNING level into every later test in the
+same worker.
+"""
+
+import logging
+
+import pytest
+
+from tests._logging_state import configured_logging
+
+_TOKEN = "SECRETTOKEN123"
+_ARCGIS_URL = f"https://services6.arcgis.com/x/FeatureServer/0?f=json&token={_TOKEN}"
+
+
+class _ListHandler(logging.Handler):
+    """Captures the fully rendered line for every record it receives."""
+
+    def __init__(self) -> None:
+        super().__init__(level=logging.DEBUG)
+        self.lines: list[str] = []
+
+    def emit(self, record: logging.LogRecord) -> None:
+        self.lines.append(self.format(record))
+
+
+@pytest.fixture(autouse=True)
+def _restore_httpx_logger_state():
+    """Undo this file's own level change, and alembic's `fileConfig()`.
+
+    `configured_logging()` only tracks the loggers `setup_logging()` is
+    documented to mutate (see `_logging_state.py`'s own docstring), so it
+    never restores httpx/httpcore's level -- without this, running this file
+    would leave both pinned at WARNING for whatever test runs next on the
+    same xdist worker.
+
+    Separately: `alembic/env.py` calls `logging.config.fileConfig()` to run
+    migrations, and that defaults to `disable_existing_loggers=True`, which
+    disables every *already-registered* logger not named in alembic.ini's
+    `[loggers]` section. By the time that runs, collection has already
+    imported plenty of other test modules that import httpx, so the "httpx"
+    logger object already exists and gets silently `.disabled = True` for
+    the rest of the session -- independent of level, and independent of this
+    file's own fix. Restoring the `disabled` flag too keeps this file
+    exercising the real `setup_logging()` level change instead of that
+    unrelated fixture's side effect.
+    """
+    loggers = [logging.getLogger(name) for name in ("httpx", "httpcore")]
+    saved = [(lg.level, lg.disabled) for lg in loggers]
+    for lg in loggers:
+        lg.disabled = False
+    yield
+    for lg, (level, disabled) in zip(loggers, saved):
+        lg.setLevel(level)
+        lg.disabled = disabled
+
+
+def _emit_through_real_pipeline(
+    logger_name: str, level: int, message: str
+) -> list[str]:
+    """Run `setup_logging()` for real and capture what reaches the root logger.
+
+    The capturing handler is given the SAME formatter `setup_logging()`
+    installed (a `structlog.stdlib.ProcessorFormatter` whose
+    `foreign_pre_chain` includes `_redact_sensitive_fields`), so redaction is
+    exercised exactly as it runs in production rather than by calling the
+    processor function directly.
+    """
+    with configured_logging(json_logs=False, log_level="INFO", production=True):
+        root = logging.getLogger()
+        capture = _ListHandler()
+        capture.setFormatter(root.handlers[0].formatter)
+        root.addHandler(capture)
+        try:
+            logging.getLogger(logger_name).log(level, message)
+        finally:
+            root.removeHandler(capture)
+    return capture.lines
+
+
+def test_httpx_info_request_line_never_reaches_the_handler():
+    """Finding 1: the routine per-request INFO line is silenced outright.
+
+    httpx's own message is exactly this shape (`%s`-style args pre-merged by
+    `record.getMessage()` before the record ever reaches our chain).
+    """
+    message = f'HTTP Request: GET {_ARCGIS_URL} "HTTP/1.1 200 OK"'
+    lines = _emit_through_real_pipeline("httpx", logging.INFO, message)
+
+    assert lines == []
+    assert _TOKEN not in "".join(lines)
+
+
+def test_httpx_warning_request_line_is_delivered_but_redacted():
+    """A WARNING-or-above httpx record still reaches logs, minus the token.
+
+    Silencing httpx to WARNING (finding 1's primary fix) must not become the
+    only defense — an httpx warning (e.g. a retry log) carries the same URL
+    shape, so the event-string scrub is the backstop this test pins.
+    """
+    message = f'HTTP Request: GET {_ARCGIS_URL} "HTTP/1.1 200 OK"'
+    lines = _emit_through_real_pipeline("httpx", logging.WARNING, message)
+
+    assert len(lines) == 1
+    assert _TOKEN not in lines[0]
+    assert "token=" in lines[0]  # the field survives; only the value is scrubbed
+    assert "HTTP Request: GET" in lines[0]
+
+
+def test_procrastinate_worker_dict_repr_token_is_redacted():
+    """Finding 13: a credential-store token survives inside a dict repr.
+
+    Procrastinate's worker renders `task_kwargs` with Python's dict repr
+    (`Job.call_string`), so the token sits inside free text next to a
+    `credential_ref` field that must stay visible for operators debugging a
+    stuck job.
+    """
+    message = (
+        "Starting job "
+        f"ingest_service[1270]({{'token': '{_TOKEN}', 'credential_ref': None}})"
+    )
+    lines = _emit_through_real_pipeline("procrastinate.worker", logging.INFO, message)
+
+    assert len(lines) == 1
+    assert _TOKEN not in lines[0]
+    assert "credential_ref" in lines[0]
+    assert "None" in lines[0]

--- a/backend/tests/test_1746_stdlib_log_redaction.py
+++ b/backend/tests/test_1746_stdlib_log_redaction.py
@@ -33,12 +33,16 @@ import time
 import pytest
 from procrastinate.jobs import Job
 
-from app.core.logging_config import _redact_token_value_repr
+from app.core.logging_config import _redact_token_value_repr, _scrub_text
 from app.core.url_redaction import URL_LIKE_RE
 from tests._logging_state import configured_logging
 
 _TOKEN = "SECRETTOKEN123"
 _ARCGIS_URL = f"https://services6.arcgis.com/x/FeatureServer/0?f=json&token={_TOKEN}"
+# fix(#1746 codex r11): an apostrophe in the URL PATH (not the token) stops
+# URL_LIKE_RE's match before the query ever starts -- see _QUERY_TAIL_RE's
+# comment in logging_config.py.
+_APOSTROPHE_URL = f"https://example.com/it'works/FeatureServer/0?f=json&token={_TOKEN}"
 
 
 class _ListHandler(logging.Handler):
@@ -556,3 +560,61 @@ def test_dev_console_exception_is_scrubbed_and_has_no_locals():
     assert "ValueError" in out
     assert "?<redacted>" in out
     assert _TOKEN not in out
+
+
+def test_httpx_warning_apostrophe_in_url_path_still_redacts_the_query():
+    """Codex round 11 P1: URL_LIKE_RE's own match can hide the query from it.
+
+    `URL_LIKE_RE`'s character class excludes `'`/`"`/`<`/`>` and whitespace,
+    so a base URL with an apostrophe in its PATH -- accepted by validators
+    that only reject whitespace/control characters, and kept literal by
+    httpx -- makes the match stop BEFORE the query ever starts.
+    `_redact_url_match()` then never runs on the real query at all, and
+    `?token=...` survives untouched even though the token itself is
+    perfectly well-formed. `_QUERY_TAIL_RE` in `_scrub_text()` finds the
+    query independently of whether `URL_LIKE_RE` matched through it.
+    """
+    message = f'HTTP Request: GET {_APOSTROPHE_URL} "HTTP/1.1 200 OK"'
+    assert _TOKEN in message  # pin the premise before redacting it
+
+    lines = _emit_through_real_pipeline("httpx", logging.WARNING, message)
+
+    assert len(lines) == 1
+    assert _TOKEN not in lines[0]
+    assert "?<redacted>" in lines[0]
+    assert '"HTTP/1.1 200 OK"' in lines[0]
+
+
+def test_exception_field_apostrophe_in_url_path_still_redacts_the_query():
+    """Same gap, in a rendered exception message through the JSON pipeline.
+
+    `_scrub_text()` is shared between `event` and `exception`, so the fix
+    above covers both without a second implementation.
+    """
+    exc = ValueError(f"request failed: {_APOSTROPHE_URL}")
+    assert _TOKEN in str(exc)  # pin the premise before redacting it
+
+    line, data = _emit_exception_through_real_pipeline(exc)
+
+    assert _TOKEN not in line
+    assert "ValueError" in data["exception"]
+    assert "?<redacted>" in data["exception"]
+
+
+def test_scrub_text_leaves_a_non_credential_query_unchanged():
+    """The new `_QUERY_TAIL_RE` pass must not fire on an ordinary query.
+
+    `where=1%3D1` carries no credential-shaped parameter, so nothing here
+    should trip `query_has_credentials()` either directly or with `#`
+    treated as `&`.
+    """
+    text = "GET https://host/path?f=json&where=1%3D1 done"
+
+    assert _scrub_text(text) == text
+
+
+def test_scrub_text_leaves_a_bare_question_mark_in_prose_unchanged():
+    """A `?` with nothing credential-shaped after it is just punctuation."""
+    text = "are we done? yes, all set"
+
+    assert _scrub_text(text) == text

--- a/backend/tests/test_1746_stdlib_log_redaction.py
+++ b/backend/tests/test_1746_stdlib_log_redaction.py
@@ -223,6 +223,31 @@ def test_httpx_warning_query_without_a_credential_is_left_intact():
     assert plain_url in lines[0]
 
 
+def test_httpx_warning_percent_encoded_reserved_chars_are_fully_redacted():
+    """Codex round 7: the OTHER half of the fix.
+
+    Once the ArcGIS adapter percent-encodes a token before concatenating it
+    into a URL (`adapters/arcgis.py`, `quote(token, safe="")`), the raw
+    `'`/`#`/`&` a token could otherwise contain never reaches the log line
+    at all. This pins that the existing whole-query redaction already
+    covers the encoded form end-to-end: a percent-encoded token no longer
+    ends the `URL_LIKE_RE` match early, so the match runs to the end of the
+    URL and `query_has_credentials()` still sees the `token=` key.
+    """
+    secret_url = (
+        "https://services6.arcgis.com/x/FeatureServer/0"
+        "?f=json&token=AA%27%23%26ULTRASECRET"
+    )
+    message = f'HTTP Request: GET {secret_url} "HTTP/1.1 200 OK"'
+    assert "ULTRASECRET" in message  # pin the premise before redacting it
+
+    lines = _emit_through_real_pipeline("httpx", logging.WARNING, message)
+
+    assert len(lines) == 1
+    assert "ULTRASECRET" not in lines[0]
+    assert "?<redacted>" in lines[0]
+
+
 def test_procrastinate_worker_task_kwargs_token_is_redacted():
     """Finding 13: a credential-store token survives inside `Job.call_string`.
 

--- a/backend/tests/test_1746_stdlib_log_redaction.py
+++ b/backend/tests/test_1746_stdlib_log_redaction.py
@@ -398,6 +398,29 @@ def test_redact_token_value_repr_handles_a_dict_repr_escaped_quote():
     assert "'credential_ref': None" in redacted
 
 
+@pytest.mark.parametrize(
+    ("log_level", "expected_httpx_level"),
+    [
+        ("ERROR", logging.ERROR),
+        ("INFO", logging.WARNING),
+        ("DEBUG", logging.WARNING),
+    ],
+)
+def test_setup_logging_derives_httpx_floor_from_root(log_level, expected_httpx_level):
+    """Codex round 8 P2: httpx's WARNING floor must track root, not override it.
+
+    A FIXED WARNING silently reverses itself the moment root is raised past
+    it: `LOG_LEVEL=ERROR` at boot (`app.core.config`) previously left httpx
+    sitting AT WARNING -- more verbose than the deployment asked for.
+    `apply_http_logger_levels()` makes WARNING a floor rather than a fixed
+    point: root stricter than WARNING (ERROR here) raises httpx to match;
+    root laxer than WARNING (INFO, DEBUG) leaves httpx pinned at WARNING.
+    """
+    with configured_logging(json_logs=False, log_level=log_level, production=True):
+        assert logging.getLogger("httpx").level == expected_httpx_level
+        assert logging.getLogger("httpcore").level == expected_httpx_level
+
+
 def test_redact_token_value_repr_stays_linear_on_unterminated_input():
     """Codex round 4 P2: the two value-body alternatives must not overlap.
 

--- a/backend/tests/test_1746_stdlib_log_redaction.py
+++ b/backend/tests/test_1746_stdlib_log_redaction.py
@@ -4,11 +4,14 @@ httpx (and its httpcore transport) logs the full outgoing request URL at INFO
 for every call, e.g. ``HTTP Request: GET <url>?f=json&token=<value> "HTTP/1.1
 200 OK"``. That line reaches every deployment's logs by default, because root
 defaults to INFO (``app.core.config``), and it fires twice per refresh on the
-credential-store path (finding 13). Procrastinate's worker separately logs a
-dict-repr of ``task_kwargs`` (``Starting job x[1]({'token': '...'})``), which
-puts a token inside the MESSAGE STRING rather than a keyed field, so the
-existing key-based ``_redact_sensitive_fields`` processor cannot see it
-either way.
+credential-store path (finding 13). Procrastinate's worker separately logs
+``task_kwargs`` rendered by ``Job.call_string`` (pinned procrastinate 3.9.0,
+``procrastinate/jobs.py``): ``", ".join(f"{key}={value!r}" ...)`` — a bare
+keyword-argument rendering, e.g.
+``Starting job ingest_service[1270](token='...', credential_ref=None)``, NOT
+a dict repr. That puts a token inside the MESSAGE STRING rather than a keyed
+field, so the existing key-based ``_redact_sensitive_fields`` processor
+cannot see it either way.
 
 pytest's ``caplog`` sees zero structlog records in this repo (it hooks a
 handler onto a logger that structlog's stdlib bridge does not use the same
@@ -26,7 +29,9 @@ same worker.
 import logging
 
 import pytest
+from procrastinate.jobs import Job
 
+from app.core.logging_config import _redact_token_value_repr
 from tests._logging_state import configured_logging
 
 _TOKEN = "SECRETTOKEN123"
@@ -127,21 +132,52 @@ def test_httpx_warning_request_line_is_delivered_but_redacted():
     assert "HTTP Request: GET" in lines[0]
 
 
-def test_procrastinate_worker_dict_repr_token_is_redacted():
-    """Finding 13: a credential-store token survives inside a dict repr.
+def test_procrastinate_worker_task_kwargs_token_is_redacted():
+    """Finding 13: a credential-store token survives inside `Job.call_string`.
 
-    Procrastinate's worker renders `task_kwargs` with Python's dict repr
-    (`Job.call_string`), so the token sits inside free text next to a
-    `credential_ref` field that must stay visible for operators debugging a
-    stuck job.
+    Built from a REAL `procrastinate.jobs.Job`, mirroring
+    `procrastinate/worker.py:285`'s `f"Starting job {job.call_string}"`
+    exactly, so this test breaks if Procrastinate ever changes how it
+    renders `task_kwargs` rather than silently staying green against a
+    hand-typed guess. `call_string` renders each kwarg as `key=value!r` —
+    NOT a dict repr — so the token sits next to a `credential_ref` field
+    that must stay visible for operators debugging a stuck job.
     """
-    message = (
-        "Starting job "
-        f"ingest_service[1270]({{'token': '{_TOKEN}', 'credential_ref': None}})"
+    job = Job(
+        id=1270,
+        queue="default",
+        lock=None,
+        queueing_lock=None,
+        task_name="ingest_service",
+        task_kwargs={
+            "token": _TOKEN,
+            "credential_ref": None,
+            "dataset_id": "abc",
+        },
     )
+    message = f"Starting job {job.call_string}"
+    assert f"token='{_TOKEN}'" in message  # pin the premise before redacting it
+
     lines = _emit_through_real_pipeline("procrastinate.worker", logging.INFO, message)
 
     assert len(lines) == 1
     assert _TOKEN not in lines[0]
-    assert "credential_ref" in lines[0]
-    assert "None" in lines[0]
+    assert "credential_ref=None" in lines[0]
+    assert "dataset_id='abc'" in lines[0]
+
+
+def test_redact_token_value_repr_also_handles_a_dict_repr_shape():
+    """The dict-repr shape (`{'token': '...'}`) is a separate, real shape.
+
+    Not how Procrastinate renders `task_kwargs` (see the test above), but a
+    shape other code logs a raw dict as (`%r` on a plain dict, or a
+    debug-only `logger.info(str(payload))`), so it stays covered directly on
+    the helper rather than only through one caller's rendering choice.
+    """
+    text = f"payload: {{'token': '{_TOKEN}', 'credential_ref': None}}"
+
+    redacted = _redact_token_value_repr(text)
+
+    assert _TOKEN not in redacted
+    assert "'token': '[REDACTED]'" in redacted
+    assert "'credential_ref': None" in redacted

--- a/backend/tests/test_1746_stdlib_log_redaction.py
+++ b/backend/tests/test_1746_stdlib_log_redaction.py
@@ -123,14 +123,22 @@ def test_httpx_warning_request_line_is_delivered_but_redacted():
     Silencing httpx to WARNING (finding 1's primary fix) must not become the
     only defense — an httpx warning (e.g. a retry log) carries the same URL
     shape, so the event-string scrub is the backstop this test pins.
+
+    fix(#1746 codex r6): the query is now redacted WHOLE (`?<redacted>`)
+    whenever it carries any credential, not just the token's value -- see
+    `_redact_url_match()` for why a partial parse is not trustworthy enough
+    to leave the rest of the query in place. `"token="` itself no longer
+    survives here; the host and path do.
     """
     message = f'HTTP Request: GET {_ARCGIS_URL} "HTTP/1.1 200 OK"'
     lines = _emit_through_real_pipeline("httpx", logging.WARNING, message)
 
     assert len(lines) == 1
     assert _TOKEN not in lines[0]
-    assert "token=" in lines[0]  # the field survives; only the value is scrubbed
+    assert "?<redacted>" in lines[0]
+    assert "services6.arcgis.com/x/FeatureServer/0" in lines[0]
     assert "HTTP Request: GET" in lines[0]
+    assert '"HTTP/1.1 200 OK"' in lines[0]
 
 
 def test_httpx_warning_userinfo_credential_is_redacted():
@@ -153,6 +161,66 @@ def test_httpx_warning_userinfo_credential_is_redacted():
     assert len(lines) == 1
     assert _TOKEN not in lines[0]
     assert "redacted@" in lines[0]
+
+
+def test_httpx_warning_query_credential_with_hash_is_fully_redacted():
+    """Codex round 6 P1: an un-escaped `#` in a token value breaks the parse.
+
+    The token/source validators only reject whitespace/control characters,
+    so a value containing `#` is reachable. `urlsplit` reads `#` as the
+    start of a URL fragment, which query redaction never inspects, so
+    `redact_url_credentials()` alone left everything after the `#` -- the
+    bulk of the secret -- untouched. `_redact_url_match()` now escalates to
+    redacting the whole query once the ORIGINAL query is known to carry a
+    credential, so the host and path stay legible but the query does not.
+    """
+    secret_url = (
+        f"https://services6.arcgis.com/x/FeatureServer/0?f=json&token=#{_TOKEN}"
+    )
+    message = f'HTTP Request: GET {secret_url} "HTTP/1.1 200 OK"'
+    assert _TOKEN in message  # pin the premise before redacting it
+
+    lines = _emit_through_real_pipeline("httpx", logging.WARNING, message)
+
+    assert len(lines) == 1
+    assert _TOKEN not in lines[0]
+    assert "services6.arcgis.com/x/FeatureServer/0" in lines[0]
+    assert '"HTTP/1.1 200 OK"' in lines[0]
+
+
+def test_httpx_warning_query_credential_with_ampersand_is_fully_redacted():
+    """Codex round 6 P1: an un-escaped `&` in a token value breaks the parse.
+
+    `parse_qsl` reads an un-escaped `&` inside a token value as the START of
+    a NEW query parameter -- a bare name with no `=`, which matches no
+    known-sensitive key, so the tail of the secret survived as an
+    unredacted "parameter". Same escalation as the `#` case above.
+    """
+    secret_url = f"https://services6.arcgis.com/x/FeatureServer/0?token=abc&{_TOKEN}"
+    message = f'HTTP Request: GET {secret_url} "HTTP/1.1 200 OK"'
+    assert _TOKEN in message  # pin the premise before redacting it
+
+    lines = _emit_through_real_pipeline("httpx", logging.WARNING, message)
+
+    assert len(lines) == 1
+    assert _TOKEN not in lines[0]
+    assert "services6.arcgis.com/x/FeatureServer/0" in lines[0]
+    assert '"HTTP/1.1 200 OK"' in lines[0]
+
+
+def test_httpx_warning_query_without_a_credential_is_left_intact():
+    """The round 6 escalation must not fire for a query with no credential.
+
+    `where=1%3D1` is a plain (non-credential) query parameter; nothing here
+    should trip `query_has_credentials()`, so the query survives whole.
+    """
+    plain_url = "https://services6.arcgis.com/x/FeatureServer/0?f=json&where=1%3D1"
+    message = f'HTTP Request: GET {plain_url} "HTTP/1.1 200 OK"'
+
+    lines = _emit_through_real_pipeline("httpx", logging.WARNING, message)
+
+    assert len(lines) == 1
+    assert plain_url in lines[0]
 
 
 def test_procrastinate_worker_task_kwargs_token_is_redacted():

--- a/backend/tests/test_1746_stdlib_log_redaction.py
+++ b/backend/tests/test_1746_stdlib_log_redaction.py
@@ -167,6 +167,43 @@ def test_procrastinate_worker_task_kwargs_token_is_redacted():
     assert "dataset_id='abc'" in lines[0]
 
 
+def test_procrastinate_worker_token_with_escaped_quotes_is_redacted():
+    """Codex round 3 P1: a token containing both quote styles survives `repr()`.
+
+    `repr()` of a string with BOTH a single and a double quote in it picks
+    one quote character as the delimiter and ESCAPES that character where it
+    recurs in the value (and always escapes a literal backslash), e.g.
+    `repr("pre'SECRET\"post")` is `'pre\'SECRET"post'`. A lazy `.*?` value
+    match stops at that escaped delimiter instead of the real closing quote,
+    leaving the rest of the token in the log. ArcGIS tokens only pass a weak
+    validator, so a value shaped like this is reachable. Built from a REAL
+    `Job.call_string`, with a backslash in the value as well, so both escape
+    forms `_TOKEN_VALUE_RE` has to consume are exercised together.
+    """
+    tricky_token = "pre'" + _TOKEN + '"post\\end'
+    job = Job(
+        id=1270,
+        queue="default",
+        lock=None,
+        queueing_lock=None,
+        task_name="ingest_service",
+        task_kwargs={
+            "token": tricky_token,
+            "credential_ref": None,
+            "dataset_id": "abc",
+        },
+    )
+    message = f"Starting job {job.call_string}"
+    assert _TOKEN in message  # pin the premise before redacting it
+
+    lines = _emit_through_real_pipeline("procrastinate.worker", logging.INFO, message)
+
+    assert len(lines) == 1
+    assert _TOKEN not in lines[0]
+    assert "credential_ref=None" in lines[0]
+    assert "dataset_id='abc'" in lines[0]
+
+
 def test_event_without_a_credential_url_is_never_mangled():
     """Codex round 2 P2: `redact_url_credentials()` must be gated, not blanket.
 
@@ -213,6 +250,23 @@ def test_redact_token_value_repr_also_handles_a_dict_repr_shape():
     the helper rather than only through one caller's rendering choice.
     """
     text = f"payload: {{'token': '{_TOKEN}', 'credential_ref': None}}"
+
+    redacted = _redact_token_value_repr(text)
+
+    assert _TOKEN not in redacted
+    assert "'token': '[REDACTED]'" in redacted
+    assert "'credential_ref': None" in redacted
+
+
+def test_redact_token_value_repr_handles_a_dict_repr_escaped_quote():
+    """The dict-repr branch needs the same escape-consuming fix as the keyword one.
+
+    `repr()` of a token with both quote styles in it escapes the delimiter
+    quote inside the value, so a bare lazy `.*?` would stop early here too.
+    """
+    tricky_token = "pre'" + _TOKEN + '"post\\end'
+    text = f"payload: {{'token': {tricky_token!r}, 'credential_ref': None}}"
+    assert _TOKEN in text  # pin the premise before redacting it
 
     redacted = _redact_token_value_repr(text)
 

--- a/backend/tests/test_1746_stdlib_log_redaction.py
+++ b/backend/tests/test_1746_stdlib_log_redaction.py
@@ -27,6 +27,7 @@ same worker.
 """
 
 import logging
+import time
 
 import pytest
 from procrastinate.jobs import Job
@@ -273,3 +274,32 @@ def test_redact_token_value_repr_handles_a_dict_repr_escaped_quote():
     assert _TOKEN not in redacted
     assert "'token': '[REDACTED]'" in redacted
     assert "'credential_ref': None" in redacted
+
+
+def test_redact_token_value_repr_stays_linear_on_unterminated_input():
+    """Codex round 4 P2: the two value-body alternatives must not overlap.
+
+    `(?:\\.|.)*?` let `.` also match a backslash, so an unterminated
+    `token='` followed by N backslashes had N different ways to split into
+    `\\.` pairs versus lone `.` characters -- and the regex engine tried all
+    of them before concluding there is no closing quote, which is
+    exponential in N. That ran synchronously on every log record, so
+    malformed third-party error text (no code here has to intend it) could
+    stall the whole process. `[^\\]` in place of the second `.` makes the
+    two alternatives partition the input instead of overlapping it: for any
+    given position there is exactly one alternative that can consume it, so
+    an unterminated match now fails in time linear in the input length.
+
+    200 backslashes is comfortably past the ~34 where the old pattern's
+    runtime was already visible in a manual timing check; a generous 1
+    second bound is asserted so this fails loudly (not by hanging) if the
+    linear property regresses.
+    """
+    message = "token='" + "\\" * 200
+
+    start = time.perf_counter()
+    redacted = _redact_token_value_repr(message)
+    elapsed = time.perf_counter() - start
+
+    assert elapsed < 1.0, f"took {elapsed:.3f}s -- no longer linear"
+    assert redacted == message  # no closing quote: nothing to redact, unchanged

--- a/backend/tests/test_1746_stdlib_log_redaction.py
+++ b/backend/tests/test_1746_stdlib_log_redaction.py
@@ -514,3 +514,45 @@ def test_exception_field_keyword_form_token_is_scrubbed():
     assert _TOKEN not in line
     assert "ValueError" in data["exception"]
     assert "token='[REDACTED]'" in data["exception"]
+
+
+def _raise_with_secret_local() -> None:
+    secret = _TOKEN  # noqa: F841 -- deliberately unused; must never leak via locals rendering
+    raise ValueError(f"request failed: {_ARCGIS_URL}")
+
+
+def test_dev_console_exception_is_scrubbed_and_has_no_locals():
+    """Codex round 10 P1: dev console mode leaked a token two different ways.
+
+    Round 9 only fixed the JSON/production path: `format_exc_info` stayed
+    conditional on `json_logs or production`, so in pure dev mode `exc_info`
+    was still a raw tuple when `_redact_sensitive_fields` ran -- nothing to
+    scrub yet -- and only got rendered afterward, by the console renderer,
+    unscrubbed. Rich's own locals rendering was a SECOND, independent leak on
+    top of that: even a scrubbed message would not have stopped a `secret`
+    local variable from appearing verbatim, since `RichTracebackFormatter`
+    prints every frame local's `repr()` regardless of what the message says.
+    Both are closed now: `format_exc_info` runs unconditionally (so
+    `exception` exists, scrubbed, before ANY renderer runs), and dev's
+    renderer is `plain_traceback`, which never touches locals at all.
+    """
+    with configured_logging(json_logs=False, production=False, log_level="INFO"):
+        root = logging.getLogger()
+        capture = _ListHandler()
+        capture.setFormatter(root.handlers[0].formatter)
+        root.addHandler(capture)
+        try:
+            try:
+                _raise_with_secret_local()
+            except ValueError:
+                logging.getLogger("test.dev_exception_scrub").error(
+                    "boom", exc_info=True
+                )
+        finally:
+            root.removeHandler(capture)
+
+    assert len(capture.lines) == 1
+    out = capture.lines[0]
+    assert "ValueError" in out
+    assert "?<redacted>" in out
+    assert _TOKEN not in out

--- a/backend/tests/test_arcgis_auth.py
+++ b/backend/tests/test_arcgis_auth.py
@@ -7,6 +7,7 @@ import pytest
 
 from app.modules.catalog.sources.adapters.arcgis import (
     ArcGISTokenError,
+    enrich_arcgis_feature_counts,
     fetch_arcgis_pagination_info,
     probe_arcgis_service,
 )
@@ -47,6 +48,61 @@ async def test_arcgis_probe_no_bearer_header():
     kwargs = call_args[1] if call_args[1] else {}
     headers = kwargs.get("headers", {})
     assert "Authorization" not in headers
+
+
+@pytest.mark.asyncio
+async def test_arcgis_probe_encodes_url_reserved_characters_in_token():
+    """fix(#1746 codex r7): a token with URL-reserved characters must be encoded.
+
+    probe_arcgis_service() concatenates the token into the query string by
+    hand (unlike the sibling call sites that pass it through httpx's
+    ``params=``, which encodes automatically). The token validators only
+    reject whitespace/control characters, so ``'``, ``#``, and ``&`` all
+    pass through and were kept literal here -- a raw ``#`` truncates the
+    URL at a fragment boundary and a raw ``&`` starts a bogus new query
+    parameter, either of which leaks the tail of the token into the actual
+    request AND lets it escape the log redactor's URL match.
+    """
+    mock_client = AsyncMock(spec=httpx.AsyncClient)
+    mock_response = _make_mock_response({"layers": []})
+    mock_client.get.return_value = mock_response
+
+    await probe_arcgis_service(
+        "https://services.arcgis.com/svc/FeatureServer",
+        mock_client,
+        token="AA'#&ULTRASECRET",
+    )
+
+    url_called = mock_client.get.call_args[0][0]
+    assert "token=AA%27%23%26ULTRASECRET" in url_called
+    assert "'" not in url_called
+    assert "#" not in url_called
+    assert "&ULTRA" not in url_called
+
+
+@pytest.mark.asyncio
+async def test_enrich_arcgis_feature_counts_encodes_url_reserved_characters_in_token():
+    """fix(#1746 codex r7): the second raw string-concatenation site.
+
+    Same issue and same fix as the probe above, in
+    ``enrich_arcgis_feature_counts()``'s per-layer count query.
+    """
+    mock_client = AsyncMock(spec=httpx.AsyncClient)
+    mock_response = _make_mock_response({"count": 5})
+    mock_client.get.return_value = mock_response
+
+    await enrich_arcgis_feature_counts(
+        "https://services.arcgis.com/svc/FeatureServer",
+        [{"id": 0, "name": "layer0"}],
+        mock_client,
+        token="AA'#&ULTRASECRET",
+    )
+
+    url_called = mock_client.get.call_args[0][0]
+    assert "token=AA%27%23%26ULTRASECRET" in url_called
+    assert "'" not in url_called
+    assert "#" not in url_called
+    assert "&ULTRA" not in url_called
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_exception_log_rendering.py
+++ b/backend/tests/test_exception_log_rendering.py
@@ -143,20 +143,23 @@ def test_production_resolves_exc_info_before_the_renderer(json_logs: bool) -> No
         assert structlog.processors.format_exc_info in foreign_chain
 
 
-def test_development_console_renderer_does_not_render_locals() -> None:
-    """Dev keeps rich's highlighted frames but not the unbounded part.
+def test_development_console_renderer_uses_plain_traceback_too() -> None:
+    """fix(#1746 codex r10): dev no longer keeps rich at all, locals-off or not.
 
-    Turning locals off is what makes the render cost independent of local
-    size; no setting bounds an arbitrary object's `repr()`.
+    Superseded by a stronger fix, not merely a stricter test: round 10
+    retired dev's rich-with-locals-off compromise (the previous version of
+    this test) entirely. `format_exc_info` now runs unconditionally, so an
+    `exception` field is always pre-rendered before any renderer sees it --
+    and a non-plain formatter meeting a pre-rendered `exception` field is
+    the exact case the `plain_traceback` comment in `setup_logging` warns
+    about, not merely a perf compromise. Dev and production now build this
+    renderer identically.
     """
     with configured_logging(json_logs=False, production=False):
         renderer = _current_formatter().processors[-1]
-        exception_formatter = renderer.exception_formatter
 
-        if isinstance(exception_formatter, structlog.dev.RichTracebackFormatter):
-            assert exception_formatter.show_locals is False
-        else:
-            assert exception_formatter is structlog.dev.plain_traceback
+        assert isinstance(renderer, structlog.dev.ConsoleRenderer)
+        assert renderer.exception_formatter is structlog.dev.plain_traceback
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -3338,7 +3338,11 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # feat(#1691): +13 — the RESTRICT_PUBLIC_VISIBILITY flag (admins-only
     # `visibility: public`) plus the comment pointing at its shared gate in
     # catalog/authorization.py. Cap 1029 -> 1042, exact.
-    "backend/app/core/persistent_config.py": 1042,
+    # fix(#1746 codex r8): +5 — the runtime log-level setter now also calls
+    # apply_http_logger_levels() (logging_config.py) after raising root's
+    # level, so httpx/httpcore's WARNING floor tracks a LOG_LEVEL change made
+    # through the admin settings UI, not just one made at boot.
+    "backend/app/core/persistent_config.py": 1047,
     # fix(#1533): first entry — crossed _RATCHET_INCLUSION_LOC on the change
     # that made the run notice the embedding column moving under it. Two
     # guards, both small: _live_column_dims (one pg_attribute read, shared with

--- a/backend/tests/test_persistent_config.py
+++ b/backend/tests/test_persistent_config.py
@@ -341,6 +341,42 @@ async def test_log_level_side_effect(client: AsyncClient):
 
 
 @pytest.mark.anyio
+async def test_log_level_side_effect_raises_httpx_floor_too(client: AsyncClient):
+    """fix(#1746 codex r8): a runtime LOG_LEVEL change must raise httpx's floor.
+
+    `apply_http_logger_levels()` keeps httpx/httpcore at least WARNING, but
+    that floor has to track root upward too: a LOG_LEVEL=CRITICAL change made
+    through the admin settings UI at runtime (not just LOG_LEVEL set at boot)
+    must not leave httpx sitting at WARNING -- MORE verbose than the
+    deployment just asked for. The round 5/6 test guards already restore
+    httpx/httpcore's level around every test, so no manual cleanup is needed
+    for those two here; only root's own level is restored, matching the
+    sibling test above.
+    """
+    import logging
+
+    from app.core.persistent_config import LOG_LEVEL
+
+    from app.core.dependencies import get_db
+    from app.api.main import app
+
+    original_level = logging.getLogger().level
+    try:
+        async for db in app.dependency_overrides[get_db]():
+            await LOG_LEVEL.set(db, "CRITICAL")
+            assert logging.getLogger().level == logging.CRITICAL
+            assert logging.getLogger("httpx").level == logging.CRITICAL
+            assert logging.getLogger("httpcore").level == logging.CRITICAL
+
+            # Dropping back below WARNING restores the WARNING floor.
+            await LOG_LEVEL.set(db, "INFO")
+            assert logging.getLogger("httpx").level == logging.WARNING
+            assert logging.getLogger("httpcore").level == logging.WARNING
+    finally:
+        logging.getLogger().setLevel(original_level)
+
+
+@pytest.mark.anyio
 async def test_sync_rate_limit_accessor(client: AsyncClient):
     """Sync rate limit accessor returns cached value or default."""
     from app.core.persistent_config import LOGIN_RATE_LIMIT, get_cached_login_rate_limit


### PR DESCRIPTION
Two stdlib log lines carried a service token in plaintext at INFO in both the api and the worker. httpx logs the full request URL for every call (`HTTP Request: GET ...?f=json&token=...`), which is the ArcGIS adapter's normal path with or without a credential store. Procrastinate's worker logs `Starting job ingest_service[1270](token='...', ...)` and the matching "ended with status" line. The structlog redactor in `logging_config.py` was key based, so it never looked at the rendered message string, and root defaults to INFO.

What this PR does now, after twelve review rounds that each found a distinct render path or character class:

The `httpx` and `httpcore` loggers get `max(WARNING, root)` from a small `apply_http_logger_levels` helper, called from `setup_logging` and from the runtime log-level setter in `persistent_config.py`, so `LOG_LEVEL=ERROR` at boot or at runtime still applies to them.

`_redact_sensitive_fields` now scrubs text as well as keys. A `_scrub_text` helper runs three passes over the `event` string and, when present, the rendered `exception` string: `redact_url_credentials` per `URL_LIKE_RE` match (userinfo and query parameters, leaving newlines and tabs outside URLs intact); any `?`-led run whose tail carries a credential parameter is replaced with `?<redacted>` independently of the URL match, so a `#`, `&`, quote or apostrophe anywhere in the URL cannot hide the suffix; and Procrastinate's keyword form `token='...'` and the dict form `'token': '...'` are redacted with a linear-time pattern that consumes Python string escapes. `credential_ref` stays visible.

`format_exc_info` now runs unconditionally before the redactor, and the dev console renderer uses the same `plain_traceback` formatter production already used, so tracebacks are scrubbed before any renderer sees them and frame locals are never printed. The `production` flag no longer changes anything inside `setup_logging`; the docstrings say so.

The two ArcGIS adapter sites that concatenated the raw token into a URL (`adapters/arcgis.py`, the probe and the feature-count fetch) now percent-encode it; the other four already went through httpx params.

The test-side restoration lists in `tests/_logging_state.py` and `tests/conftest.py` include `httpx` and `httpcore`.

Closes findings 1 and 13 of #1746. Both were confirmed on the direct-token path and on the credential-store path.

Verification, from `backend/` with `.env.test` sourced:

```
uv run ruff check . && uv run ruff format --check .
uv run pytest tests/test_1746_stdlib_log_redaction.py -v
uv run pytest tests/test_phase_273_log_redaction.py tests/test_logging_conftest_guard.py tests/test_exception_log_rendering.py tests/test_notification_channels.py tests/test_sec025_sandbox_allowlist.py tests/test_persistent_config.py tests/test_arcgis_auth.py -q
uv run pytest tests/test_layering.py -q
```

The 24 new tests run through the real pipeline in JSON, production and dev modes and cover: the httpx INFO line never reaching the handler; WARNING lines delivered with the query redacted (well-formed, `#`, `&`, percent-encoded, apostrophe in the path); userinfo in prose; a real `Job.call_string` with a token holding both quote styles and a backslash; a credential-free multi-line event arriving byte for byte; an unterminated `token='` followed by 200 backslashes returning immediately; exceptions carrying a credential URL or a keyword token in JSON and dev modes, with a secret in a frame local; and level derivation at boot and through the runtime setting. As a positive control, the original three tests fail against main's `logging_config.py`.

`persistent_config.py`'s cap in `_MODULE_LOC_CAPS` is raised by the five lines the runtime hook needed. No schema, API or config impact. One thing noticed and left in #1755: `alembic/env.py` calls `fileConfig()` with `disable_existing_loggers=True`, which silently disables already imported third-party loggers for the rest of a test session.

https://claude.ai/code/session_01SFCMH3VJ5pFfM9Rer7KHZq
