### PR TITLE
fix(ingest): keep GDAL header tempfiles in staging and carry the ArcGIS feature count into preview

### DIFF
--- a/backend/app/api/main.py
+++ b/backend/app/api/main.py
@@ -46,6 +46,7 @@ from app.core.runtime.staging import (
     ensure_staging_ready,
     sweep_orphaned_exports,
     sweep_orphaned_write_scratch_occasionally,
+    sweep_stale_gdal_header_files,
 )
 from app.platform.extensions.bootstrap import (
     assert_enterprise_ports_resolved,
@@ -301,6 +302,15 @@ def _sweep_orphaned_exports_periodic(exports_dir: Path) -> tuple[int, int]:
     )
     if scratch:
         logger.info("orphaned_write_scratch_swept", removed=scratch)
+    # fix(#1746): reclaim GDAL bearer-header tempfiles a SIGKILL/OOM left
+    # behind (see sweep_stale_gdal_header_files docstring). Rides this same
+    # periodic cadence; the default 1-hour age matches EXPORTS_SWEEP_AGE_SECONDS
+    # (boot-time), not the wider periodic export threshold, since a header file
+    # is only ever alive for a single ogr2ogr subprocess run, not an
+    # in-flight multi-hour export.
+    gdal_headers = sweep_stale_gdal_header_files(Path(settings.upload_staging_dir))
+    if gdal_headers:
+        logger.info("stale_gdal_header_files_swept", removed=gdal_headers)
     return sweep_orphaned_exports(
         exports_dir, age_threshold_seconds=EXPORTS_PERIODIC_SWEEP_AGE_SECONDS
     )
@@ -398,6 +408,9 @@ async def lifespan(app: FastAPI):
     # truncate an export a surviving sibling was still writing or streaming. Share
     # the worker's age-aware sweeper instead.
     sweep_orphaned_exports(exports_dir)
+    # fix(#1746): reclaim GDAL bearer-header tempfiles orphaned by a crash
+    # before this boot (see sweep_stale_gdal_header_files docstring).
+    sweep_stale_gdal_header_files(staging_root)
 
     await init_tile_pool()
     await task_app.open_async()

--- a/backend/app/core/runtime/staging.py
+++ b/backend/app/core/runtime/staging.py
@@ -225,6 +225,56 @@ def sweep_orphaned_exports(
     return (deleted_count, skipped_count)
 
 
+# fix(#1746): the GDAL bearer-header tempfile ogr.py writes for a WFS/OGC API
+# preview/ingest (GDAL_HTTP_HEADER_FILE, 0600) is unlinked in a `finally`
+# block, but a SIGKILL/OOM on the ogr2ogr subprocess skips it, leaking the
+# token-bearing file. Matched by exact prefix/suffix (mirrors
+# `tempfile.mkstemp(prefix="gdal_auth_", suffix=".hdr", ...)` in ogr.py).
+_GDAL_AUTH_HEADER_PREFIX = "gdal_auth_"
+_GDAL_AUTH_HEADER_SUFFIX = ".hdr"
+
+
+def sweep_stale_gdal_header_files(
+    staging_dir: Path, max_age_seconds: int = 3600
+) -> int:
+    """Reclaim orphaned GDAL bearer-header tempfiles under ``staging_dir``.
+
+    Only direct children of ``staging_dir`` named ``gdal_auth_*.hdr`` are
+    considered — never recurse, since the staging volume also holds
+    originals, COGs, exports, and VRTs this sweeper has no business
+    touching. A file younger than ``max_age_seconds`` is left alone (still
+    in use by a running ogr2ogr subprocess).
+
+    Never raises: a file that disappears between listing and stat/unlink
+    (a race with the process that owns it, or with another sweep pass) is
+    silently skipped, not an error.
+
+    Returns the number of files removed.
+    """
+    staging_dir = Path(staging_dir)
+    if not staging_dir.is_dir():
+        return 0
+    cutoff = time.time() - max_age_seconds
+    removed = 0
+    for entry in staging_dir.iterdir():
+        name = entry.name
+        if not (
+            name.startswith(_GDAL_AUTH_HEADER_PREFIX)
+            and name.endswith(_GDAL_AUTH_HEADER_SUFFIX)
+        ):
+            continue
+        try:
+            if not entry.is_file():
+                continue
+            if entry.stat().st_mtime >= cutoff:
+                continue
+            entry.unlink(missing_ok=True)
+            removed += 1
+        except OSError:
+            continue
+    return removed
+
+
 class StagingRuntimeError(RuntimeError):
     """Raised when a staging directory cannot be created or written to."""
 

--- a/backend/app/modules/catalog/sources/adapters/arcgis.py
+++ b/backend/app/modules/catalog/sources/adapters/arcgis.py
@@ -415,11 +415,28 @@ async def fetch_arcgis_layer_preview(
             exc,
         )
 
+    # fix(#1746): the preview previously always returned feature_count=None;
+    # reuse the existing returnCountOnly=true helper (same safe client, one
+    # extra request) so the preview matches the count the probe already shows.
+    # A count failure degrades to None rather than failing the whole preview.
+    feature_count: int | None = None
+    try:
+        feature_count = await fetch_arcgis_feature_count(
+            base, safe_layer_id, client, token=token
+        )
+    except (httpx.HTTPError, ValueError, ArcGISTokenError) as exc:
+        logger.debug(
+            "ArcGIS feature-count fetch failed for %s/%s: %s",
+            base,
+            safe_layer_id,
+            exc,
+        )
+
     return {
         "srid": srid,
         "geometry_type": geometry_type,
         "layer_name": layer_name,
-        "feature_count": None,
+        "feature_count": feature_count,
         "columns": columns,
         "sample_rows": sample_rows,
     }

--- a/backend/app/platform/jobs/worker.py
+++ b/backend/app/platform/jobs/worker.py
@@ -23,6 +23,7 @@ from app.core.runtime.staging import (
     ensure_staging_ready,
     redirect_tempfile_to_staging,
     sweep_orphaned_exports,
+    sweep_stale_gdal_header_files,
 )
 
 # Redirect stdlib tempfile to the staging volume BEFORE any task module is
@@ -537,6 +538,13 @@ async def main() -> None:
     # boot during the export's stream phase.
     exports_dir = Path(settings.upload_staging_dir) / "exports"
     sweep_orphaned_exports(exports_dir)
+
+    # fix(#1746): reclaim GDAL bearer-header tempfiles a SIGKILL/OOM left
+    # behind on a previous ogr2ogr run (see sweep_stale_gdal_header_files
+    # docstring). The worker has no periodic sweep loop, unlike the API, so
+    # boot-time is the only hook here — matches how sweep_orphaned_exports
+    # itself is only swept at worker boot, not on a cadence.
+    sweep_stale_gdal_header_files(Path(settings.upload_staging_dir))
 
     # 2. WORK-01: shared bootstrap — load extensions (overlay), check enterprise
     # overlay requested, init edition, init storage + S3 health probe, init cache.

--- a/backend/app/processing/ingest/ogr.py
+++ b/backend/app/processing/ingest/ogr.py
@@ -1039,7 +1039,14 @@ async def run_ogr2ogr_service(
             # set explicitly for clarity).
             import tempfile
 
-            fd, header_file_path = tempfile.mkstemp(prefix="gdal_auth_", suffix=".hdr")
+            # fix(#1746): mkstemp had no dir=, so it landed in the system
+            # tempdir, not the staging volume the comment above claims — a
+            # SIGKILL/OOM before the finally block below then leaks the
+            # bearer-header tempfile outside anything a sweep can reach.
+            os.makedirs(settings.upload_staging_dir, exist_ok=True)
+            fd, header_file_path = tempfile.mkstemp(
+                prefix="gdal_auth_", suffix=".hdr", dir=settings.upload_staging_dir
+            )
             try:
                 os.write(fd, f"Authorization: Bearer {safe_token}\n".encode("ascii"))
             finally:

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -2468,7 +2468,11 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # route registers. The other two widen the production CORS warning, which
     # told an operator only standards reads were open to any browser origin.
     # Cap 1628 -> 1635, exact.
-    "backend/app/api/main.py": 1757,
+    # fix(#1746): +13 — the boot-time and periodic sweeps now also call
+    # sweep_stale_gdal_header_files, reclaiming the GDAL bearer-header
+    # tempfile ogr.py's finally block misses on a SIGKILL/OOM. Cap 1757 ->
+    # 1770, exact.
+    "backend/app/api/main.py": 1770,
     # fix(#1005): +4 — MapSummaryResponse gains thumbnail_updated_at, the
     # thumbnail cache version split out of updated_at. Ratchet stays exact.
     # fix(#910): +1 on top of that, the fillColorSaved entry in the authoritative
@@ -3646,7 +3650,11 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # b-tree page — distinct from "file is not a database", which is a
     # corrupt header). Empirically confirmed against a real GPKG with a
     # byte-flipped leaf page. Cap 1073 -> 1089, exact.
-    "backend/app/processing/ingest/ogr.py": 1089,
+    # fix(#1746): +7 — the GDAL bearer-header tempfile now pins dir=
+    # settings.upload_staging_dir (plus an os.makedirs and a comment
+    # explaining why) so it lands on the staging volume the stale-file
+    # sweep can reach, instead of the system tempdir. Cap 1089 -> 1096, exact.
+    "backend/app/processing/ingest/ogr.py": 1096,
     "backend/app/modules/auth/oauth/service.py": 1031,
     # fix(#1113 review): +15 — register_existing_table linearizes a
     # pre-existing geom_4326 (savepoint + error contract mirroring the

--- a/backend/tests/test_ogr_subprocess_env.py
+++ b/backend/tests/test_ogr_subprocess_env.py
@@ -12,7 +12,18 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from app.core.config import settings
 from app.processing.ingest.ogr import run_ogr2ogr_service
+
+
+@pytest.fixture(autouse=True)
+def _staging_dir(tmp_path, monkeypatch):
+    """fix(#1746): the header-file mkstemp now os.makedirs + writes under
+    settings.upload_staging_dir (previously it used the system tempdir
+    unconditionally), so tests must point that setting at a writable
+    per-test directory rather than the container-only default (/app/staging).
+    """
+    monkeypatch.setattr(settings, "upload_staging_dir", str(tmp_path))
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_preview_token_sec021.py
+++ b/backend/tests/test_preview_token_sec021.py
@@ -154,10 +154,14 @@ async def test_preview_timeout_raises_not_empty(monkeypatch):
 
 @pytest.mark.anyio
 async def test_fetch_arcgis_layer_preview_maps_fields_crs_and_attributes():
-    """fetch_arcgis_layer_preview reads ?f=json metadata + a bounded sample.
+    """fetch_arcgis_layer_preview reads ?f=json metadata + a bounded sample
+    + a returnCountOnly=true feature count.
 
-    Verifies ESRI field types map to OGR names, CRS prefers latestWkid, and
-    the sample query reads ``attributes`` (ArcGIS) not ``properties``.
+    Verifies ESRI field types map to OGR names, CRS prefers latestWkid, the
+    sample query reads ``attributes`` (ArcGIS) not ``properties``, and the
+    preview now carries the layer's feature count (fix(#1746): the preview
+    used to always report feature_count=None even though the probe already
+    showed a real count for the same layer).
     """
     from unittest.mock import AsyncMock, MagicMock
 
@@ -180,6 +184,7 @@ async def test_fetch_arcgis_layer_preview_maps_fields_crs_and_attributes():
             {"attributes": {"OBJECTID": 2, "owner": "Jones", "value": 200.0}},
         ]
     }
+    count = {"count": 9567}
 
     meta_resp = MagicMock()
     meta_resp.raise_for_status = MagicMock()
@@ -187,9 +192,12 @@ async def test_fetch_arcgis_layer_preview_maps_fields_crs_and_attributes():
     sample_resp = MagicMock()
     sample_resp.raise_for_status = MagicMock()
     sample_resp.json = MagicMock(return_value=sample)
+    count_resp = MagicMock()
+    count_resp.raise_for_status = MagicMock()
+    count_resp.json = MagicMock(return_value=count)
 
     client = MagicMock()
-    client.get = AsyncMock(side_effect=[meta_resp, sample_resp])
+    client.get = AsyncMock(side_effect=[meta_resp, sample_resp, count_resp])
 
     result = await fetch_arcgis_layer_preview(
         "https://services.arcgis.com/x/rest/services/Parcels/FeatureServer",
@@ -200,9 +208,49 @@ async def test_fetch_arcgis_layer_preview_maps_fields_crs_and_attributes():
     assert result["srid"] == 3857  # latestWkid wins over wkid
     assert result["geometry_type"] == "Polygon"
     assert result["layer_name"] == "Parcels"
-    assert result["feature_count"] is None
+    assert result["feature_count"] == 9567
     # Geometry field is skipped; OID→Integer64, String→String, Double→Real.
     cols = {c["name"]: c["type"] for c in result["columns"]}
     assert cols == {"OBJECTID": "Integer64", "owner": "String", "value": "Real"}
     assert len(result["sample_rows"]) == 2
     assert result["sample_rows"][0]["owner"] == "Smith"
+
+
+@pytest.mark.anyio
+async def test_fetch_arcgis_layer_preview_count_failure_degrades_to_none():
+    """fix(#1746): a returnCountOnly=true failure must degrade feature_count
+    to None, not fail the whole preview."""
+    from unittest.mock import AsyncMock, MagicMock
+
+    import httpx
+
+    from app.modules.catalog.sources.adapters.arcgis import fetch_arcgis_layer_preview
+
+    meta = {
+        "name": "Parcels",
+        "geometryType": "esriGeometryPolygon",
+        "extent": {"spatialReference": {"wkid": 3857}},
+        "fields": [{"name": "OBJECTID", "type": "esriFieldTypeOID"}],
+    }
+    sample = {"features": []}
+
+    meta_resp = MagicMock()
+    meta_resp.raise_for_status = MagicMock()
+    meta_resp.json = MagicMock(return_value=meta)
+    sample_resp = MagicMock()
+    sample_resp.raise_for_status = MagicMock()
+    sample_resp.json = MagicMock(return_value=sample)
+
+    client = MagicMock()
+    client.get = AsyncMock(
+        side_effect=[meta_resp, sample_resp, httpx.TransportError("connection reset")]
+    )
+
+    result = await fetch_arcgis_layer_preview(
+        "https://services.arcgis.com/x/rest/services/Parcels/FeatureServer",
+        0,
+        client,
+    )
+
+    assert result["feature_count"] is None
+    assert result["layer_name"] == "Parcels"

--- a/backend/tests/test_staging_runtime.py
+++ b/backend/tests/test_staging_runtime.py
@@ -1,3 +1,5 @@
+import os
+import time
 from pathlib import Path
 
 import pytest
@@ -105,3 +107,45 @@ async def test_export_dataset_creates_temp_dir_after_staging_guard_passes(
     assert output.parent.name  # uuid-like directory created by export service
     assert filename == "Roads_2024.gpkg"
     assert media_type == "application/geopackage+sqlite3"
+
+
+def test_sweep_stale_gdal_header_files_removes_only_old_matching_files(
+    tmp_path: Path,
+) -> None:
+    """fix(#1746): only ``gdal_auth_*.hdr`` files older than ``max_age_seconds``
+    are removed. A fresh header file (still owned by a running ogr2ogr
+    subprocess) and a non-matching old file both survive.
+    """
+    from app.core.runtime.staging import sweep_stale_gdal_header_files
+
+    fresh_header = tmp_path / "gdal_auth_abc123.hdr"
+    fresh_header.write_text("Authorization: Bearer x\n", encoding="utf-8")
+
+    stale_header = tmp_path / "gdal_auth_def456.hdr"
+    stale_header.write_text("Authorization: Bearer y\n", encoding="utf-8")
+
+    other_old_file = tmp_path / "some_other_file.tmp"
+    other_old_file.write_text("unrelated", encoding="utf-8")
+
+    now = time.time()
+    # fresh_header stays at "now" (just written, well within the window).
+    os.utime(stale_header, (now - 2 * 3600, now - 2 * 3600))  # 2 hours old
+    os.utime(other_old_file, (now - 2 * 3600, now - 2 * 3600))  # 2 hours old
+
+    removed = sweep_stale_gdal_header_files(tmp_path, max_age_seconds=3600)
+
+    assert removed == 1
+    assert fresh_header.exists(), "a fresh header file must survive"
+    assert not stale_header.exists(), "a 2-hour-old header file must be swept"
+    assert other_old_file.exists(), (
+        "a non-matching old file must survive — the sweep only ever touches "
+        "gdal_auth_*.hdr"
+    )
+
+
+def test_sweep_stale_gdal_header_files_missing_dir_is_a_noop(tmp_path: Path) -> None:
+    """A staging dir that does not exist yet (fresh boot) must not raise."""
+    from app.core.runtime.staging import sweep_stale_gdal_header_files
+
+    missing = tmp_path / "does-not-exist"
+    assert sweep_stale_gdal_header_files(missing) == 0


### PR DESCRIPTION
Two contained fixes from the ArcGIS authenticated-import test.

Preview dropped the feature count. Probe reports `feature_count` per layer (9,567 on the test layer) but the ArcGIS preview hardcoded `None`. `fetch_arcgis_layer_preview` in `adapters/arcgis.py` now calls the existing `fetch_arcgis_feature_count` helper (same safe client, one `returnCountOnly=true` request) and degrades to `None` if that request fails. The preview response schema already had the field, so `openapi.json` and the SDKs are unchanged.

GDAL bearer header files were written with `mkstemp` and no `dir=`. In a deployed process this was mostly latent, because `main.py` and `worker.py` both call `redirect_tempfile_to_staging` at boot, but a direct call or a future refactor lands the file in the system tempdir, and a SIGKILL or OOM between write and the `finally` unlink leaves it behind either way. `run_ogr2ogr_service` in `ogr.py` now passes `dir=settings.upload_staging_dir`, and a new `sweep_stale_gdal_header_files` in `core/runtime/staging.py` unlinks `gdal_auth_*.hdr` files older than an hour. It runs at the three places `sweep_orphaned_exports` already runs: API boot, the API's periodic sweeper, and worker boot. The matching `preview.py` line is in the lane D PR, which edits the same block for the strict token check.

Closes finding 7 and the `ogr.py` half of 16 of #1746.

Verification, from `backend/` with `.env.test` sourced:

```
uv run ruff check . && uv run ruff format --check .
uv run pytest tests/test_staging_runtime.py tests/test_preview_token_sec021.py tests/test_ogr_subprocess_env.py tests/test_rule2_structural.py tests/test_layering.py -q
make openapi-check
```

`test_ogr_subprocess_env.py` calls `run_ogr2ogr_service` directly and bypasses the client fixture that points `upload_staging_dir` at a tmp dir, so it gained an autouse fixture doing the same. `ogr.py` and `api/main.py` caps in `_MODULE_LOC_CAPS` are raised to the measured line counts.

No schema or API change. No config impact.

https://claude.ai/code/session_01SFCMH3VJ5pFfM9Rer7KHZq
