### PR TITLE
fix(refresh): refuse token-less refresh of auth-required sources and detect ArcGIS auth envelopes in the health probe

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -673,6 +673,11 @@ FRONTEND_PORT=8080
 # after a re-upload or PostGIS refresh — the API keeps serving pre-swap tiles
 # until they expire (TILE_CACHE_TTL). The worker says so at boot. Set this if
 # you re-upload datasets and cannot wait out the TTL.
+# Also required to REFRESH a token-protected service (ArcGIS org-only layers,
+# WFS/OGC API behind auth): the token is staged in the shared credential store
+# so it can reach the worker without being written to a job row. Without this,
+# POST /datasets/{id}/refresh with a token answers 503
+# credential_store_unavailable.
 # Type: string | No default
 # Example: redis://redis:6379/0
 # REDIS_URL=

--- a/backend/app/modules/catalog/datasets/api/router_health.py
+++ b/backend/app/modules/catalog/datasets/api/router_health.py
@@ -195,7 +195,10 @@ def _service_probe_target(dataset: Dataset) -> str:
     status-code probe reads them as healthy. fix(#1746) parses exactly one of
     those envelopes: codes 498 and 499, the auth refusals, which
     :func:`probe_arcgis_origin` reports as ``inaccessible`` /
-    ``auth_required``. A DROPPED LAYER is still not detected — parsing the
+    ``auth_required``. fix(#1746 codex r6): it asks the ``/query`` operation
+    rather than the layer document, because that is what the worker reads and
+    a service can serve one publicly while gating the other. A DROPPED LAYER
+    is still not detected — parsing the
     rest of the per-service error space is the connector-completeness
     contract, which ADR-002 leaves out of v1, so ``missing`` on a service
     origin still means the HTTP resource itself is gone, not that a layer was

--- a/backend/app/modules/catalog/datasets/api/router_health.py
+++ b/backend/app/modules/catalog/datasets/api/router_health.py
@@ -62,6 +62,7 @@ from app.modules.catalog.sources.origin_probe import (
     ITEM_WITHDRAWN,
     MISSING,
     OriginProbeResult,
+    probe_arcgis_service,
     probe_remote_uri,
 )
 from app.observability.metrics.refresh import (
@@ -189,13 +190,16 @@ async def _probe_stac_targets(
 def _service_probe_target(dataset: Dataset) -> str:
     """The URL a service probe contacts. Reachability is all it can claim.
 
-    Reachability is genuinely all this can claim. ArcGIS FeatureServer in
-    particular answers a request for a layer that no longer exists with HTTP
-    200 and an error envelope in the body, so a status-code probe reads that
-    as healthy. Parsing per-service error bodies to do better is the
-    connector-completeness contract, which ADR-002 leaves out of v1; until
-    then ``missing`` on a service origin means the HTTP resource itself is
-    gone, not that a layer was dropped from a service that still answers.
+    Reachability is nearly all this can claim. ArcGIS FeatureServer answers
+    several conditions with HTTP 200 and an error envelope in the body, so a
+    status-code probe reads them as healthy. fix(#1746) parses exactly one of
+    those envelopes: codes 498 and 499, the auth refusals, which
+    :func:`probe_arcgis_service` reports as ``inaccessible`` /
+    ``auth_required``. A DROPPED LAYER is still not detected — parsing the
+    rest of the per-service error space is the connector-completeness
+    contract, which ADR-002 leaves out of v1, so ``missing`` on a service
+    origin still means the HTTP resource itself is gone, not that a layer was
+    dropped from a service that still answers.
 
     fix(#1271 review): the probe target depends on the service type. Ingest
     stores ``origin_uri`` as ``<base>/<layer identity>`` for provenance, and
@@ -281,9 +285,14 @@ async def check_source_health(
     if origin == "stac":
         asset_uri, item_href = await _stac_probe_targets(db, dataset)
         service_target = None
+        service_type = None
     else:
         asset_uri = item_href = None
         service_target = _service_probe_target(dataset)
+        # fix(#1746): read while the session is still live — the ORM instance
+        # is dead after the rollback below, and the probe branch needs to know
+        # whether this origin speaks ArcGIS error envelopes.
+        service_type = (dataset.origin_ref or {}).get("service_type")
 
     # ...then release the pooled connection BEFORE the outbound wait
     # (fix #1271 review). The probe can take 10s against a slow origin, and
@@ -302,6 +311,10 @@ async def check_source_health(
     probe_started = time.perf_counter()
     if origin == "stac":
         result = await _probe_stac_targets(asset_uri, item_href)
+    elif service_type == "arcgis_featureserver":
+        # fix(#1746): ArcGIS answers an auth refusal with HTTP 200 and an
+        # error envelope, which a status-code probe reads as healthy.
+        result = await probe_arcgis_service(service_target)
     else:
         result = await probe_remote_uri(service_target)
     origin_probe_duration_seconds.labels(

--- a/backend/app/modules/catalog/datasets/api/router_health.py
+++ b/backend/app/modules/catalog/datasets/api/router_health.py
@@ -194,7 +194,7 @@ def _service_probe_target(dataset: Dataset) -> str:
     several conditions with HTTP 200 and an error envelope in the body, so a
     status-code probe reads them as healthy. fix(#1746) parses exactly one of
     those envelopes: codes 498 and 499, the auth refusals, which
-    :func:`probe_arcgis_service` reports as ``inaccessible`` /
+    :func:`probe_arcgis_origin` reports as ``inaccessible`` /
     ``auth_required``. A DROPPED LAYER is still not detected — parsing the
     rest of the per-service error space is the connector-completeness
     contract, which ADR-002 leaves out of v1, so ``missing`` on a service

--- a/backend/app/modules/catalog/datasets/api/router_health.py
+++ b/backend/app/modules/catalog/datasets/api/router_health.py
@@ -57,13 +57,13 @@ from app.modules.catalog.authorization import check_dataset_write_access
 from app.modules.catalog.datasets.domain.models import Dataset
 from app.modules.catalog.datasets.domain.schemas import SourceHealthResponse
 from app.modules.catalog.datasets.domain.service import get_dataset
-from app.modules.catalog.sources.adapters.wfs import build_capabilities_url
 from app.modules.catalog.sources.origin_probe import (
     ITEM_WITHDRAWN,
     MISSING,
     OriginProbeResult,
-    probe_arcgis_service,
     probe_remote_uri,
+    probe_service_origin,
+    service_probe_target,
 )
 from app.observability.metrics.refresh import (
     origin_probe_duration_seconds,
@@ -201,35 +201,16 @@ def _service_probe_target(dataset: Dataset) -> str:
     origin still means the HTTP resource itself is gone, not that a layer was
     dropped from a service that still answers.
 
-    fix(#1271 review): the probe target depends on the service type. Ingest
-    stores ``origin_uri`` as ``<base>/<layer identity>`` for provenance, and
-    only ArcGIS's flavor of that (``<base>/<numeric id>``) is a real HTTP
-    resource — WFS and OGC API address layers through a typename or collection
-    parameter, so their enriched URI is a non-endpoint and probing it records
-    whatever the server's 404 fallback happens to say about a URL nobody
-    serves. For those two the canonical service base in ``origin_ref.url`` is
-    the thing whose reachability the answer claims to describe — and for WFS
-    the base alone is not enough either: many servers 4xx a request without
-    ``service=WFS&request=GetCapabilities``, so the probe asks the same
-    question the import adapter asks, via the same URL builder. An OGC API
-    base is a plain JSON landing page and needs no parameters.
+    The per-service target rule lives in
+    :func:`~app.modules.catalog.sources.origin_probe.service_probe_target`,
+    which the refresh door reads too (fix #1746). This wrapper is only the
+    HTTP vocabulary around it: a row with nothing safe to probe answers 409
+    rather than reporting a health state.
     """
-    ref = dataset.origin_ref or {}
-    service_type = ref.get("service_type")
-    if service_type in ("wfs", "ogcapi_features"):
-        # No fallback to origin_uri here: migration 0036's legacy branch
-        # deliberately leaves ``url`` unset when the base is not derivable
-        # (the enriched URI cannot be split without the layer name that went
-        # missing), so the only value on hand is the non-endpoint. Probing
-        # it would persist a false result; refusing keeps "nothing safe to
-        # probe" distinguishable from a health state, same as every other
-        # pointerless row.
-        target = ref.get("url")
-        if target and service_type == "wfs":
-            target = build_capabilities_url(target)
-    else:
-        target = dataset.origin_uri or ref.get("url")
+    target = service_probe_target(dataset.origin_ref, dataset.origin_uri)
     if not target:
+        # "Nothing safe to probe" stays distinguishable from a health state,
+        # the same way every other pointerless row is answered.
         raise _origin_pointer_missing("service")
     return target
 
@@ -311,12 +292,12 @@ async def check_source_health(
     probe_started = time.perf_counter()
     if origin == "stac":
         result = await _probe_stac_targets(asset_uri, item_href)
-    elif service_type == "arcgis_featureserver":
-        # fix(#1746): ArcGIS answers an auth refusal with HTTP 200 and an
-        # error envelope, which a status-code probe reads as healthy.
-        result = await probe_arcgis_service(service_target)
     else:
-        result = await probe_remote_uri(service_target)
+        # fix(#1746): ArcGIS answers an auth refusal with HTTP 200 and an
+        # error envelope, which a status-code probe reads as healthy, so the
+        # probe is chosen by service type. The refresh door chooses the same
+        # way, through the same helper.
+        result = await probe_service_origin(service_target, service_type)
     origin_probe_duration_seconds.labels(
         origin_kind=origin, health=result.health
     ).observe(time.perf_counter() - probe_started)

--- a/backend/app/modules/catalog/datasets/api/router_refresh.py
+++ b/backend/app/modules/catalog/datasets/api/router_refresh.py
@@ -60,6 +60,11 @@ from app.modules.catalog.datasets.domain.schemas import (
 from app.modules.catalog.datasets.domain.service import get_dataset
 from app.platform.security import SSRFError, validate_url_for_ssrf
 from app.modules.catalog.sources.stac_resolve import states_verifiable_identity
+from app.modules.catalog.sources.origin_probe import (
+    AUTH_CHALLENGE_DETAILS,
+    probe_service_origin,
+    service_probe_target,
+)
 from app.platform.dataset_origin import classify_origin, service_auth_required
 from app.platform.extensions import get_catalog_port
 from app.platform.jobs.defer_guard import (
@@ -221,37 +226,69 @@ def _resolve_service_origin(dataset) -> _ServiceOrigin:
     )
 
 
-def _require_service_token_if_marked(dataset, token: str | None) -> None:
-    """Refuse a credential-less refresh of an origin that needed one.
+async def _require_service_token_if_marked(dataset, token: str | None) -> None:
+    """Refuse a credential-less refresh only when the origin still demands one.
 
-    fix(#1746): the origin asked for a credential the last time it answered,
-    and the refresh body carries none. Dispatching anyway is a 202 followed
-    ~0.5s later by a worker failure whose message is the only place the real
-    cause appears. Refuse at the door instead, naming the field that fixes it.
+    fix(#1746): dispatching a token-less refresh of a protected origin is a
+    202 followed ~0.5s later by a worker failure whose message is the only
+    place the real cause appears. Refusing at the door instead, naming the
+    field that fixes it, is the whole point.
 
-    Absent means "not known to need auth", which is where every dataset
-    imported before this marker existed sits — they refresh exactly as before.
-    The marker clears on the next successful token-less pull, and since this
-    door refuses those, the re-upload dialog (preview + commit with no token)
-    is the way to prove a service went public again. Say that here so a later
-    reader does not read the 422 as a permanent trap.
+    fix(#1746 codex r1): but the marker alone is not that fact. The worker
+    cannot observe a challenge, so ``auth_required`` records only that the
+    last SUCCESSFUL pull was MADE with a token — a user who imported a public
+    service while holding a token gets a marked dataset, and refusing on the
+    marker alone would lock them out of every token-less refresh until they
+    went through the re-upload dialog. So the marker is the gate, not the
+    verdict: it is cheap, it is written where the credential is known, and
+    reaching it costs one token-less probe that asks the origin whether it
+    still demands a credential.
 
-    A function rather than three lines in the handler because ``refresh_
-    dataset`` sits one branch under ruff's C901 ceiling, and the repo's answer
-    to that has been extraction (see ``router_analysis`` and ``router_export``)
-    rather than another per-file exemption.
+    Only an auth challenge refuses. Every other probe outcome — healthy,
+    missing, timed out, unreachable, blocked — falls through and lets the
+    refresh proceed exactly as it did before this existed. Failing open is
+    deliberate: a probe is one request against a third party, and turning its
+    bad day into a refusal would be a worse bug than the one this closes. The
+    worker is still there, and its auth-failure copy now names the token
+    field.
+
+    A false marker therefore costs one probe per refresh and never a refusal,
+    and it does not persist: a successful token-less pull rebuilds the ref
+    without the key, so the next refresh does not probe at all.
+
+    A function rather than inline lines because ``refresh_dataset`` sits one
+    branch under ruff's C901 ceiling, and the repo's answer to that has been
+    extraction (see ``router_analysis`` and ``router_export``) rather than
+    another per-file exemption.
     """
     if token or not service_auth_required(dataset.origin_ref):
+        return
+    ref = dataset.origin_ref or {}
+    target = service_probe_target(ref, dataset.origin_uri)
+    if not target:
+        # Nothing safe to contact, so there is nothing to ask. The health
+        # endpoint answers 409 here; a refresh has no verdict to persist and
+        # simply lets the worker try.
+        return
+    try:
+        result = await probe_service_origin(target, ref.get("service_type"))
+    except Exception:  # broad: this guard must never 500 a refresh bound for 202
+        # Both probes already swallow every transport failure into a verdict,
+        # so this is the belt to those braces. Anything that still escapes is
+        # a bug in the probe, and the honest response to it is to let the
+        # refresh proceed the way it did before this guard existed.
+        return
+    if result.detail not in AUTH_CHALLENGE_DETAILS:
         return
     raise HTTPException(
         status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
         detail={
             "code": "service_token_required",
             "message": (
-                "This dataset's source required a service token the last "
-                "time it was imported or refreshed. Send the token again "
-                "in the request body's `token` field; tokens are "
-                "request-only and are never stored between runs."
+                "This dataset's source is asking for a service token, and it "
+                "needed one the last time it was imported or refreshed. Send "
+                "the token again in the request body's `token` field; tokens "
+                "are request-only and are never stored between runs."
             ),
         },
     )
@@ -834,14 +871,6 @@ async def refresh_dataset(
     # again below, after the reservation exists. See the ordering note there.
     candidate = _resolve_service_origin(dataset)
 
-    # fix(#1746): placed after the postgis and stac early returns so it can
-    # never fire for a non-service origin, and before the reservation so a
-    # doomed request never burns a run row or holds the dataset against the
-    # admission index. It needs no network and no database, so refusing ahead
-    # of the SSRF check also saves a DNS resolution on a request that cannot
-    # succeed.
-    _require_service_token_if_marked(dataset, body.token)
-
     # Rule 2: the URL is ours, but "ours" is not a safety property — it was a
     # client's when ingest stored it, and DNS moves. Revalidating at dispatch
     # matches what the preview door does with a fresh URL; the worker
@@ -859,6 +888,14 @@ async def refresh_dataset(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=f"This dataset's stored source URL is not reachable: {exc}",
         ) from exc
+
+    # fix(#1746): placed after the postgis and stac early returns so it can
+    # never fire for a non-service origin, and after the SSRF block because it
+    # FETCHES the stored URL — fix(#1746 codex r1) turned this from a marker
+    # read into a token-less probe, so the target has to be validated before
+    # it is contacted. Still before `create_pending_run`: a refusal here must
+    # not burn a run row or hold the dataset against the admission index.
+    await _require_service_token_if_marked(dataset, body.token)
 
     # Refuse a credentialed refresh we cannot carry out, before writing
     # anything. Without a shared store the secret cannot reach the worker at

--- a/backend/app/modules/catalog/datasets/api/router_refresh.py
+++ b/backend/app/modules/catalog/datasets/api/router_refresh.py
@@ -62,7 +62,7 @@ from app.platform.security import SSRFError, validate_url_for_ssrf
 from app.modules.catalog.sources.stac_resolve import states_verifiable_identity
 from app.modules.catalog.sources.origin_probe import (
     AUTH_CHALLENGE_DETAILS,
-    probe_service_origin,
+    probe_arcgis_origin,
     service_probe_target,
 )
 from app.platform.dataset_origin import classify_origin, service_auth_required
@@ -226,35 +226,80 @@ def _resolve_service_origin(dataset) -> _ServiceOrigin:
     )
 
 
-async def _require_service_token_if_marked(dataset, token: str | None) -> None:
-    """Refuse a credential-less refresh only when the origin still demands one.
+def _service_token_required() -> HTTPException:
+    """The one 422 both refusal paths raise, so the wording cannot fork."""
+    return HTTPException(
+        status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+        detail={
+            "code": "service_token_required",
+            "message": (
+                "This dataset's source needed a service token the last time "
+                "it was imported or refreshed, and this request carries "
+                "none. Send the token again in the request body's `token` "
+                "field; tokens are request-only and are never stored between "
+                "runs. If the source is public now, re-import it through the "
+                "re-upload dialog without a token to clear the requirement."
+            ),
+        },
+    )
+
+
+async def _require_service_token_if_marked(db, dataset, dataset_id, token):
+    """Handle a token-less refresh of an origin whose last pull used a token.
+
+    Returns the dataset to carry forward — the same instance, or a re-read one
+    when this had to release the session (see the rollback note below).
+
+    CALLER CONTRACT: on the ArcGIS probe path this rolls back, which expires
+    EVERY ORM instance in the session, not just the dataset. Anything the
+    caller loaded earlier and still needs — the injected ``user`` included,
+    since ``Identity`` is a Protocol the concrete ``User`` ORM satisfies —
+    must be re-read or captured into a local before the call.
 
     fix(#1746): dispatching a token-less refresh of a protected origin is a
     202 followed ~0.5s later by a worker failure whose message is the only
     place the real cause appears. Refusing at the door instead, naming the
     field that fixes it, is the whole point.
 
-    fix(#1746 codex r1): but the marker alone is not that fact. The worker
-    cannot observe a challenge, so ``auth_required`` records only that the
-    last SUCCESSFUL pull was MADE with a token — a user who imported a public
-    service while holding a token gets a marked dataset, and refusing on the
-    marker alone would lock them out of every token-less refresh until they
-    went through the re-upload dialog. So the marker is the gate, not the
-    verdict: it is cheap, it is written where the credential is known, and
-    reaching it costs one token-less probe that asks the origin whether it
-    still demands a credential.
+    fix(#1746 codex r1): the marker alone is not that fact. The worker cannot
+    observe a challenge, so ``auth_required`` records only that the last
+    SUCCESSFUL pull was MADE with a token — a user who imported a public
+    service while holding a token gets a marked dataset. So the marker is a
+    gate, and where it is possible to ask the origin, the door asks.
 
-    Only an auth challenge refuses. Every other probe outcome — healthy,
-    missing, timed out, unreachable, blocked — falls through and lets the
-    refresh proceed exactly as it did before this existed. Failing open is
-    deliberate: a probe is one request against a third party, and turning its
-    bad day into a refusal would be a worse bug than the one this closes. The
-    worker is still there, and its auth-failure copy now names the token
-    field.
+    fix(#1746 codex r2): "where it is possible" is the whole of this function,
+    and it is not every service.
 
-    A false marker therefore costs one probe per refresh and never a refusal,
-    and it does not persist: a successful token-less pull rebuilds the ref
-    without the key, so the next refresh does not probe at all.
+    ArcGIS is asked. Its probe target IS the resource the worker reads: the
+    layer's ``?f=json``, which answers 499 "Token Required" for an org-only
+    layer and 498 for a token it rejected. A healthy answer there is real
+    evidence the token-less refresh will work, so a false marker costs one
+    probe and never a refusal.
+
+    WFS and OGC API Features are refused outright, with no probe. Their probe
+    target is the capabilities document or the landing page, which is a
+    DIFFERENT resource from the one the worker fetches — a public
+    GetCapabilities in front of a protected GetFeature is an ordinary
+    deployment, so a healthy answer there would be evidence of nothing while
+    reading as permission to proceed. Probing the feature endpoint anonymously
+    instead is not on the table: composing a correct GetFeature or /items
+    request means reproducing the worker's whole URL-building path, and a
+    wrong one would answer 400 and be read as "not an auth problem". A
+    refusal that names the field is honest; a probe that cannot see the
+    protected resource is not.
+
+    The escape hatch is the same for both, and the message says so: a
+    successful token-less pull rebuilds the ref without the key, and the
+    re-upload dialog (preview + commit with no token) is the door that still
+    allows one. So a marked WFS dataset that genuinely went public is two
+    clicks from clearing its marker, not stuck.
+
+    Only an auth challenge refuses on the ArcGIS path. Every other probe
+    outcome — healthy, missing, timed out, unreachable, blocked — falls
+    through and lets the refresh proceed exactly as it did before this
+    existed. Failing open is deliberate: a probe is one request against a
+    third party, and turning its bad day into a refusal would be worse than
+    the bug this closes.
 
     A function rather than inline lines because ``refresh_dataset`` sits one
     branch under ruff's C901 ceiling, and the repo's answer to that has been
@@ -262,36 +307,54 @@ async def _require_service_token_if_marked(dataset, token: str | None) -> None:
     another per-file exemption.
     """
     if token or not service_auth_required(dataset.origin_ref):
-        return
+        return dataset
     ref = dataset.origin_ref or {}
+    if ref.get("service_type") != "arcgis_featureserver":
+        # No probe, and no session released: this path touches no network.
+        raise _service_token_required()
     target = service_probe_target(ref, dataset.origin_uri)
     if not target:
         # Nothing safe to contact, so there is nothing to ask. The health
         # endpoint answers 409 here; a refresh has no verdict to persist and
         # simply lets the worker try.
-        return
+        return dataset
+
+    # fix(#1746 codex r2): release the pooled connection BEFORE the outbound
+    # wait, exactly as `check_source_health` does and for the same reason. The
+    # probe can hold its full deadline against a slow origin, and a session
+    # held across it pins one of the pool's connections for the duration —
+    # enough concurrent marked refreshes would starve every other
+    # database-backed request. Nothing has been written yet (the job row and
+    # the reservation both come later), so this rolls back a read-only
+    # transaction and costs nothing.
+    #
+    # Everything the probe needs is already in locals; the ORM instance is
+    # dead across the await, and touching an expired attribute there would
+    # raise on an async lazy load rather than quietly re-query. Hence the
+    # re-read below, whose result is what the caller carries forward.
+    await db.rollback()
     try:
-        result = await probe_service_origin(target, ref.get("service_type"))
+        result = await probe_arcgis_origin(target)
     except Exception:  # broad: this guard must never 500 a refresh bound for 202
-        # Both probes already swallow every transport failure into a verdict,
-        # so this is the belt to those braces. Anything that still escapes is
-        # a bug in the probe, and the honest response to it is to let the
+        # `probe_arcgis_origin` already swallows every transport failure into
+        # a verdict, so this is the belt to those braces. Anything that still
+        # escapes is a bug in the probe, and the honest response is to let the
         # refresh proceed the way it did before this guard existed.
-        return
-    if result.detail not in AUTH_CHALLENGE_DETAILS:
-        return
-    raise HTTPException(
-        status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
-        detail={
-            "code": "service_token_required",
-            "message": (
-                "This dataset's source is asking for a service token, and it "
-                "needed one the last time it was imported or refreshed. Send "
-                "the token again in the request body's `token` field; tokens "
-                "are request-only and are never stored between runs."
-            ),
-        },
-    )
+        result = None
+
+    # Re-read on BOTH outcomes, so the post-condition is flat: when this
+    # returns or raises, the session is live again and no expired instance is
+    # left for a later line to touch. Write access was gated on this same
+    # dataset id before the probe; this read only re-materializes it.
+    reloaded = await get_dataset(db, dataset_id)
+    if reloaded is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Dataset not found",
+        )
+    if result is not None and result.detail in AUTH_CHALLENGE_DETAILS:
+        raise _service_token_required()
+    return reloaded
 
 
 @dataclass(frozen=True)
@@ -890,12 +953,31 @@ async def refresh_dataset(
         ) from exc
 
     # fix(#1746): placed after the postgis and stac early returns so it can
-    # never fire for a non-service origin, and after the SSRF block because it
-    # FETCHES the stored URL — fix(#1746 codex r1) turned this from a marker
-    # read into a token-less probe, so the target has to be validated before
-    # it is contacted. Still before `create_pending_run`: a refusal here must
-    # not burn a run row or hold the dataset against the admission index.
-    await _require_service_token_if_marked(dataset, body.token)
+    # never fire for a non-service origin, and after the SSRF block because
+    # its ArcGIS branch FETCHES the stored URL — fix(#1746 codex r1) turned
+    # this from a marker read into a token-less probe, so the target has to be
+    # validated before it is contacted. Still before `create_pending_run`: a
+    # refusal here must not burn a run row or hold the dataset against the
+    # admission index.
+    #
+    # fix(#1746 codex r2): it returns the dataset because its probe path
+    # releases the session across the outbound wait, and what comes back is a
+    # re-read instance. Rebinding the name here is what keeps the reads below
+    # (`dataset.feature_count`, the post-reservation `db.refresh`) off an
+    # expired one. `candidate` is deliberately NOT recomputed: it is the
+    # pre-check binding, and a rebind during the probe window is exactly what
+    # the `origin != candidate` check after the reservation answers with 409.
+    #
+    # `user` needs the same treatment and cannot get it, because it is not
+    # this function's to re-read: `Identity` is a Protocol the concrete `User`
+    # ORM satisfies, so the injected instance lives in THIS session and the
+    # rollback expires it too. Reading `user.id` afterwards is a sync lazy
+    # load inside a coroutine, which raises MissingGreenlet rather than
+    # re-querying. It is one already-loaded UUID, so it is captured here.
+    user_id = user.id
+    dataset = await _require_service_token_if_marked(
+        db, dataset, dataset_id, body.token
+    )
 
     # Refuse a credentialed refresh we cannot carry out, before writing
     # anything. Without a shared store the secret cannot reach the worker at
@@ -958,7 +1040,7 @@ async def refresh_dataset(
     # ------------------------------------------------------------------ #
     job = IngestJob(
         dataset_id=dataset_id,
-        created_by=user.id,
+        created_by=user_id,
         status="pending",
         # Enough to be a well-formed re-upload job; the source binding is
         # filled in below, from the read that happens after the reservation.
@@ -976,7 +1058,7 @@ async def refresh_dataset(
             dataset_id=dataset_id,
             origin_kind="service",
             trigger="api",
-            triggered_by=user.id,
+            triggered_by=user_id,
             ingest_job_id=job.id,
             feature_count_before=dataset.feature_count,
         )
@@ -1152,7 +1234,7 @@ async def refresh_dataset(
             dataset_id=str(dataset_id),
             source_url=origin.base_url,
             source_layer=origin.layer_name,
-            user_id=str(user.id),
+            user_id=str(user_id),
             # The REFERENCE, never the secret. Task arguments are durable rows
             # in PostgreSQL and a failed job keeps them until retention runs;
             # this value means nothing once claimed or expired.

--- a/backend/app/modules/catalog/datasets/api/router_refresh.py
+++ b/backend/app/modules/catalog/datasets/api/router_refresh.py
@@ -244,6 +244,55 @@ def _service_token_required() -> HTTPException:
     )
 
 
+async def _recheck_service_token_after_reservation(
+    db, dataset, token, *, marked_before: bool
+) -> None:
+    """Catch a marker that APPEARED while the refresh was being reserved.
+
+    fix(#1746 codex r3): a narrow race the pre-reservation guard cannot close.
+    A token-less refresh reads an UNMARKED dataset and passes; an
+    authenticated re-upload of the same origin commits inside the reservation
+    window and marks it; and the dispatch goes out token-less into exactly the
+    worker failure the guard exists to prevent.
+
+    The post-reservation binding check cannot see it. ``_ServiceOrigin`` is the
+    binding the WORKER is handed — base url, layer identity, service type — and
+    its equality answers "did the source move". The marker is not part of that:
+    the source did not move, its auth state did, and folding the marker into
+    that dataclass would both mis-describe it and answer with
+    ``origin_changed``, whose copy tells the caller to "check the new source"
+    when the fix is to send a token. So the decision is re-applied here instead,
+    through the same predicate and the same message the door already uses —
+    one source of truth for what the refusal means, in two places that have to
+    ask at two different times.
+
+    No probe, deliberately. A marker that APPEARED inside the reservation
+    window is not the ambiguous case the pre-reservation probe exists for: it
+    was written by the swap of an authenticated pull that just succeeded
+    against this exact origin, seconds ago. That is the strongest evidence the
+    origin wants a credential that this door will ever hold, and re-asking
+    over the network could only weaken it.
+
+    A TRANSITION, not a second opinion. ``marked_before`` is what the
+    pre-check saw, and a marker that was already there has already been
+    adjudicated: the pre-reservation guard probed the ArcGIS layer and let this
+    request through, or refused a WFS outright so it never reached here.
+    Re-deciding on the marker alone would overturn a healthy probe with no new
+    evidence, which is the regression the ArcGIS pass-through tests caught the
+    moment this was written as an unconditional recheck.
+
+    A function rather than three lines in the handler for the reason every
+    other extraction here has: ``refresh_dataset`` sits one branch under ruff's
+    C901 ceiling.
+    """
+    if token or marked_before or not service_auth_required(dataset.origin_ref):
+        return
+    # Release the reservation the way every other post-reservation refusal
+    # does, so a refused request leaves no run row holding the dataset.
+    await db.rollback()
+    raise _service_token_required()
+
+
 async def _require_service_token_if_marked(db, dataset, dataset_id, token):
     """Handle a token-less refresh of an origin whose last pull used a token.
 
@@ -975,6 +1024,11 @@ async def refresh_dataset(
     # load inside a coroutine, which raises MissingGreenlet rather than
     # re-querying. It is one already-loaded UUID, so it is captured here.
     user_id = user.id
+    # fix(#1746 codex r3): what the PRE-CHECK saw, so the recheck after the
+    # reservation can tell a marker that appeared in the window from one the
+    # guard below has already adjudicated. Read before the guard, because its
+    # ArcGIS path re-reads the row.
+    marked_before = service_auth_required(dataset.origin_ref)
     dataset = await _require_service_token_if_marked(
         db, dataset, dataset_id, body.token
     )
@@ -1104,6 +1158,14 @@ async def refresh_dataset(
                 ),
             },
         )
+
+    # fix(#1746 codex r3): the binding can be identical and the answer still
+    # different. An authenticated re-upload that landed inside the reservation
+    # window marks the dataset without moving its origin, so the check above
+    # passes and only this one notices.
+    await _recheck_service_token_after_reservation(
+        db, dataset, body.token, marked_before=marked_before
+    )
 
     # fix(#1277 review): read after the reservation too, for the same reason
     # the binding is. An unchanged binding does NOT mean unchanged dispatch

--- a/backend/app/modules/catalog/datasets/api/router_refresh.py
+++ b/backend/app/modules/catalog/datasets/api/router_refresh.py
@@ -60,7 +60,7 @@ from app.modules.catalog.datasets.domain.schemas import (
 from app.modules.catalog.datasets.domain.service import get_dataset
 from app.platform.security import SSRFError, validate_url_for_ssrf
 from app.modules.catalog.sources.stac_resolve import states_verifiable_identity
-from app.platform.dataset_origin import classify_origin
+from app.platform.dataset_origin import classify_origin, service_auth_required
 from app.platform.extensions import get_catalog_port
 from app.platform.jobs.defer_guard import (
     defer_with_orphan_guard,
@@ -218,6 +218,42 @@ def _resolve_service_origin(dataset) -> _ServiceOrigin:
         base_url=base_url,
         layer_id=layer_identity,
         layer_name=str(layer_identity),
+    )
+
+
+def _require_service_token_if_marked(dataset, token: str | None) -> None:
+    """Refuse a credential-less refresh of an origin that needed one.
+
+    fix(#1746): the origin asked for a credential the last time it answered,
+    and the refresh body carries none. Dispatching anyway is a 202 followed
+    ~0.5s later by a worker failure whose message is the only place the real
+    cause appears. Refuse at the door instead, naming the field that fixes it.
+
+    Absent means "not known to need auth", which is where every dataset
+    imported before this marker existed sits — they refresh exactly as before.
+    The marker clears on the next successful token-less pull, and since this
+    door refuses those, the re-upload dialog (preview + commit with no token)
+    is the way to prove a service went public again. Say that here so a later
+    reader does not read the 422 as a permanent trap.
+
+    A function rather than three lines in the handler because ``refresh_
+    dataset`` sits one branch under ruff's C901 ceiling, and the repo's answer
+    to that has been extraction (see ``router_analysis`` and ``router_export``)
+    rather than another per-file exemption.
+    """
+    if token or not service_auth_required(dataset.origin_ref):
+        return
+    raise HTTPException(
+        status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+        detail={
+            "code": "service_token_required",
+            "message": (
+                "This dataset's source required a service token the last "
+                "time it was imported or refreshed. Send the token again "
+                "in the request body's `token` field; tokens are "
+                "request-only and are never stored between runs."
+            ),
+        },
     )
 
 
@@ -797,6 +833,14 @@ async def refresh_dataset(
     # reservation window. The binding the worker is actually handed is read
     # again below, after the reservation exists. See the ordering note there.
     candidate = _resolve_service_origin(dataset)
+
+    # fix(#1746): placed after the postgis and stac early returns so it can
+    # never fire for a non-service origin, and before the reservation so a
+    # doomed request never burns a run row or holds the dataset against the
+    # admission index. It needs no network and no database, so refusing ahead
+    # of the SSRF check also saves a DNS resolution on a request that cannot
+    # succeed.
+    _require_service_token_if_marked(dataset, body.token)
 
     # Rule 2: the URL is ours, but "ours" is not a safety property — it was a
     # client's when ingest stored it, and DNS moves. Revalidating at dispatch

--- a/backend/app/modules/catalog/sources/adapters/arcgis.py
+++ b/backend/app/modules/catalog/sources/adapters/arcgis.py
@@ -2,7 +2,7 @@
 
 import asyncio
 import re
-from urllib.parse import quote, urlparse
+from urllib.parse import quote, urlencode, urlparse
 
 import httpx
 import structlog
@@ -258,6 +258,39 @@ async def enrich_arcgis_feature_counts(
     return list(enriched)
 
 
+def build_arcgis_count_query_url(layer_url: str, token: str | None = None) -> str:
+    """The bounded count query for one FeatureServer layer.
+
+    ``<layer>/query?where=1=1&returnCountOnly=true&f=json`` — the smallest
+    request that exercises the QUERY operation, which is the operation
+    ``build_gdal_source`` composes and the worker actually reads. It returns a
+    single integer no matter how large the layer is, so it is safe to issue
+    against anything.
+
+    fix(#1746 codex r6): extracted so the health probe can ask the same
+    question this function asks. A deployment that serves layer METADATA
+    publicly while gating ``/query`` is ordinary, and a probe of the layer
+    document would call it healthy and then fail in the worker. One builder,
+    so the probe and the count fetcher cannot drift into probing one endpoint
+    and depending on another.
+    """
+    # A stored origin_uri is provenance, not a curated endpoint: it can carry
+    # a query string, a fragment, or an already-appended /query. Strip all
+    # three before composing, the same way `normalize_arcgis_url` does, so the
+    # result is an endpoint rather than `.../0?f=html/query?...`.
+    clean = urlparse(layer_url)._replace(query="", fragment="").geturl().rstrip("/")
+    if clean.lower().endswith("/query"):
+        clean = clean[: -len("/query")].rstrip("/")
+    params: dict[str, str] = {
+        "where": "1=1",
+        "returnCountOnly": "true",
+        "f": "json",
+    }
+    if token:
+        params["token"] = token
+    return f"{clean}/query?{urlencode(params)}"
+
+
 async def fetch_arcgis_feature_count(
     base_url: str,
     layer_id: int | str,
@@ -267,15 +300,10 @@ async def fetch_arcgis_feature_count(
     """Fetch a layer feature count from ArcGIS REST query metadata."""
     base = base_url.rstrip("/")
     safe_layer_id = str(layer_id).strip("/")
-    params: dict[str, str] = {
-        "where": "1=1",
-        "returnCountOnly": "true",
-        "f": "json",
-    }
-    if token:
-        params["token"] = token
 
-    resp = await client.get(f"{base}/{safe_layer_id}/query", params=params)
+    resp = await client.get(
+        build_arcgis_count_query_url(f"{base}/{safe_layer_id}", token)
+    )
     resp.raise_for_status()
     data = resp.json()
     if "error" in data:

--- a/backend/app/modules/catalog/sources/origin_probe.py
+++ b/backend/app/modules/catalog/sources/origin_probe.py
@@ -135,6 +135,13 @@ class OriginProbeResult:
     # SSRF refusal did contact the first hop, but under-stamping a contact
     # is recoverable while fabricating one is not.
     contacted: bool = True
+    # fix(#1746 codex post-rebase): the body came back sub-400 but exceeded
+    # `max_bytes`, so it was never parsed. Deliberately NOT a detail code: the
+    # persisted vocabulary is a wire contract every consumer enumerates, and
+    # this is an internal fact one caller needs to interpret its own silence.
+    # The verdict stays `inaccessible`/`unexpected_status` for everyone who
+    # does not ask.
+    oversized: bool = False
 
     @property
     def ok(self) -> bool:
@@ -269,6 +276,10 @@ async def probe_arcgis_origin(
     and answers with layer metadata. Two functions with one name in one
     package is a trap, and it got closer once this module started importing
     from ``adapters/`` for the WFS URL builder.
+
+    Reads the body, so it inherits ``fetch_json_document``'s size cap, and an
+    oversized sub-400 answer is resolved in the origin's favour — see the
+    comment at that branch.
     """
     try:
         target = str(httpx.URL(uri).copy_set_param("f", "json"))
@@ -277,6 +288,16 @@ async def probe_arcgis_origin(
         # out of a handler that has already released its DB session.
         target = uri
     result, body, _final_url = await fetch_json_document(target, timeout=timeout)
+    if result.oversized:
+        # fix(#1746 codex post-rebase): the origin answered sub-400 with a
+        # body too big to parse. An ArcGIS auth envelope is a few hundred
+        # bytes, so whatever this is, it is not one — a real layer document
+        # with a long field list or a coded-value domain is exactly what runs
+        # past the cap. Calling a layer that answered 200 `inaccessible`
+        # because it answered at LENGTH is the false negative that mirrors the
+        # false positive this probe exists to close. The size limit stays
+        # where STAC needs it; only the reading of a hit limit changes.
+        return OriginProbeResult(HEALTHY)
     if not result.ok:
         return result
     error = body.get("error") if isinstance(body, dict) else None
@@ -340,9 +361,17 @@ async def probe_service_origin(
 
 
 # "The origin answered, and what it said is not something GeoLens can act
-# on." One verdict for both shapes of that, because they are one fact to the
+# on." One VERDICT for both shapes of that, because they are one fact to the
 # person reading it and neither is a transport failure.
-_OVERSIZED_OR_UNREADABLE = OriginProbeResult(INACCESSIBLE, UNEXPECTED_STATUS)
+#
+# fix(#1746 codex post-rebase): two constants rather than one, because they
+# are no longer one fact to every CALLER. "Too big to parse" and "not JSON"
+# say different things about whether an ArcGIS auth envelope could have been
+# in there, and only the size case can be ruled out by arithmetic. The
+# health value and the detail code are identical, so nothing persisted or
+# served changes.
+_UNREADABLE_DOCUMENT = OriginProbeResult(INACCESSIBLE, UNEXPECTED_STATUS)
+_OVERSIZED_DOCUMENT = OriginProbeResult(INACCESSIBLE, UNEXPECTED_STATUS, oversized=True)
 
 
 async def fetch_json_document(
@@ -420,7 +449,7 @@ async def fetch_json_document(
                                 # Stop reading rather than stop the request:
                                 # leaving the context manager closes the
                                 # response, so nothing keeps arriving.
-                                return _OVERSIZED_OR_UNREADABLE, None, final_url
+                                return _OVERSIZED_DOCUMENT, None, final_url
     except (
         Exception
     ) as exc:  # broad: every transport failure means "could not determine"
@@ -441,7 +470,7 @@ async def fetch_json_document(
         # JSON is not a transport failure, and classifying it as one would
         # report `network_error` for an origin that answered perfectly well
         # with an HTML error page.
-        return _OVERSIZED_OR_UNREADABLE, None, final_url
+        return _UNREADABLE_DOCUMENT, None, final_url
 
 
 async def remote_asset_exists(asset_uri: str) -> bool:

--- a/backend/app/modules/catalog/sources/origin_probe.py
+++ b/backend/app/modules/catalog/sources/origin_probe.py
@@ -53,6 +53,7 @@ from typing import Any
 
 import httpx
 
+from app.modules.catalog.sources.adapters.wfs import build_capabilities_url
 from app.platform.security import (
     SSRFError,
     SSRFResolutionError,
@@ -105,6 +106,12 @@ DETAIL_CODES: frozenset[str] = frozenset(
         AUTH_REQUIRED,
     }
 )
+
+# fix(#1746): the two ways an origin can say "you need a credential I do not
+# hold" — ArcGIS's error envelope inside a 200, and a plain 401/403 from
+# everything else. They are one fact to a caller deciding whether to ask for a
+# token, so the set is named once here rather than spelled out at each reader.
+AUTH_CHALLENGE_DETAILS: frozenset[str] = frozenset({UNAUTHORIZED, AUTH_REQUIRED})
 
 # "The origin answered and the resource is gone." 404 and 410 only.
 _GONE_STATUSES = frozenset({404, 410})
@@ -250,7 +257,15 @@ _ARCGIS_AUTH_ERROR_CODES = frozenset({498, 499})
 async def probe_arcgis_service(
     uri: str, *, timeout: float = PROBE_TIMEOUT_SECONDS
 ) -> OriginProbeResult:
-    """Probe an ArcGIS FeatureServer layer and read its error envelope."""
+    """Probe an ArcGIS FeatureServer layer and read its error envelope.
+
+    NOT the namesake in ``sources/adapters/arcgis.py``. That one is the
+    import-time detector — it takes a client and a token, asks whether a URL
+    is a FeatureServer at all, and answers with layer metadata. This one asks
+    the much smaller question this module exists for, about a pointer GeoLens
+    already stored: does it still answer, and is it asking us to authenticate.
+    Do not import the two into the same namespace.
+    """
     try:
         target = str(httpx.URL(uri).copy_set_param("f", "json"))
     except (httpx.InvalidURL, ValueError):
@@ -266,6 +281,58 @@ async def probe_arcgis_service(
         # read, and the closed vocabulary is what keeps it leak-proof.
         return OriginProbeResult(INACCESSIBLE, AUTH_REQUIRED)
     return result
+
+
+def service_probe_target(origin_ref: Any, origin_uri: str | None) -> str | None:
+    """The URL a probe of a service origin should contact, or ``None``.
+
+    fix(#1271 review): the target depends on the service type. Ingest stores
+    ``origin_uri`` as ``<base>/<layer identity>`` for provenance, and only
+    ArcGIS's flavor of that (``<base>/<numeric id>``) is a real HTTP resource
+    — WFS and OGC API address layers through a typename or collection
+    parameter, so their enriched URI is a non-endpoint and probing it records
+    whatever the server's 404 fallback happens to say about a URL nobody
+    serves. For those two the canonical service base in ``origin_ref.url`` is
+    the thing whose reachability the answer describes, and for WFS the base
+    alone is not enough either: many servers 4xx a request without
+    ``service=WFS&request=GetCapabilities``, so the probe asks the same
+    question the import adapter asks, through the same URL builder. An OGC API
+    base is a plain JSON landing page and needs no parameters.
+
+    No fallback to ``origin_uri`` on the WFS and OGC API branches: migration
+    0036's legacy branch deliberately leaves ``url`` unset when the base is
+    not derivable, so the only value on hand is the non-endpoint, and probing
+    it would produce a false verdict. ``None`` means "nothing safe to probe",
+    which each caller answers in its own vocabulary.
+
+    fix(#1746): lifted out of ``router_health`` so the refresh door can decide
+    what to contact the same way the health endpoint does. It takes the two
+    stored columns rather than a ``Dataset`` so this module keeps its
+    independence from the catalog ORM.
+    """
+    ref = origin_ref if isinstance(origin_ref, dict) else {}
+    service_type = ref.get("service_type")
+    if service_type in ("wfs", "ogcapi_features"):
+        target = ref.get("url")
+        if target and service_type == "wfs":
+            target = build_capabilities_url(target)
+    else:
+        target = origin_uri or ref.get("url")
+    return target or None
+
+
+async def probe_service_origin(
+    target: str, service_type: str | None, *, timeout: float = PROBE_TIMEOUT_SECONDS
+) -> OriginProbeResult:
+    """Probe a service origin with the probe its service type needs.
+
+    fix(#1746): one place decides which probe answers for which service, so
+    the health endpoint and the refresh door cannot drift into disagreeing
+    about whether an ArcGIS 200 was healthy.
+    """
+    if service_type == "arcgis_featureserver":
+        return await probe_arcgis_service(target, timeout=timeout)
+    return await probe_remote_uri(target, timeout=timeout)
 
 
 # "The origin answered, and what it said is not something GeoLens can act

--- a/backend/app/modules/catalog/sources/origin_probe.py
+++ b/backend/app/modules/catalog/sources/origin_probe.py
@@ -86,6 +86,11 @@ UNEXPECTED_STATUS = "unexpected_status"  # any other >= 400
 TIMEOUT = "timeout"
 NETWORK_ERROR = "network_error"  # connect failure, DNS, TLS, bad redirect chain
 BLOCKED_BY_POLICY = "blocked_by_policy"  # SSRF validation refused the target
+# fix(#1746): the origin wants a credential we do not hold. Separate from
+# UNAUTHORIZED, whose shipped copy says the source "now requires" access —
+# that misdescribes a service which has been org-only since the day it was
+# imported, which is the common case for an ArcGIS 499.
+AUTH_REQUIRED = "auth_required"
 
 DETAIL_CODES: frozenset[str] = frozenset(
     {
@@ -97,6 +102,7 @@ DETAIL_CODES: frozenset[str] = frozenset(
         TIMEOUT,
         NETWORK_ERROR,
         BLOCKED_BY_POLICY,
+        AUTH_REQUIRED,
     }
 )
 
@@ -232,6 +238,34 @@ async def probe_remote_uri(
         return OriginProbeResult(INACCESSIBLE, detail, contacted=contacted)
 
     return _status_result(status_code)
+
+
+# ArcGIS reports auth refusals as an error envelope inside an HTTP 200 body:
+# 499 "Token Required" for an org-only service, 498 for a token it rejected.
+# A status-code probe reads both as healthy, which is the false positive this
+# closes (#1746 finding 12).
+_ARCGIS_AUTH_ERROR_CODES = frozenset({498, 499})
+
+
+async def probe_arcgis_service(
+    uri: str, *, timeout: float = PROBE_TIMEOUT_SECONDS
+) -> OriginProbeResult:
+    """Probe an ArcGIS FeatureServer layer and read its error envelope."""
+    try:
+        target = str(httpx.URL(uri).copy_set_param("f", "json"))
+    except (httpx.InvalidURL, ValueError):
+        # Let the fetch classify a malformed stored URL, rather than raising
+        # out of a handler that has already released its DB session.
+        target = uri
+    result, body, _final_url = await fetch_json_document(target, timeout=timeout)
+    if not result.ok:
+        return result
+    error = body.get("error") if isinstance(body, dict) else None
+    if isinstance(error, dict) and error.get("code") in _ARCGIS_AUTH_ERROR_CODES:
+        # No provider text: `source_health_detail` is served on every dataset
+        # read, and the closed vocabulary is what keeps it leak-proof.
+        return OriginProbeResult(INACCESSIBLE, AUTH_REQUIRED)
+    return result
 
 
 # "The origin answered, and what it said is not something GeoLens can act

--- a/backend/app/modules/catalog/sources/origin_probe.py
+++ b/backend/app/modules/catalog/sources/origin_probe.py
@@ -254,17 +254,21 @@ async def probe_remote_uri(
 _ARCGIS_AUTH_ERROR_CODES = frozenset({498, 499})
 
 
-async def probe_arcgis_service(
+async def probe_arcgis_origin(
     uri: str, *, timeout: float = PROBE_TIMEOUT_SECONDS
 ) -> OriginProbeResult:
     """Probe an ArcGIS FeatureServer layer and read its error envelope.
 
-    NOT the namesake in ``sources/adapters/arcgis.py``. That one is the
-    import-time detector — it takes a client and a token, asks whether a URL
-    is a FeatureServer at all, and answers with layer metadata. This one asks
-    the much smaller question this module exists for, about a pointer GeoLens
-    already stored: does it still answer, and is it asking us to authenticate.
-    Do not import the two into the same namespace.
+    Named for the question it asks, like its siblings ``probe_remote_uri`` and
+    ``probe_service_origin``: this is about an ORIGIN, a pointer GeoLens
+    already stored. Does it still answer, and is it asking us to authenticate.
+
+    Deliberately not ``probe_arcgis_service``, which is taken in this package
+    by the import-time DETECTOR in ``sources/adapters/arcgis.py`` — that one
+    takes a client and a token, asks whether a URL is a FeatureServer at all,
+    and answers with layer metadata. Two functions with one name in one
+    package is a trap, and it got closer once this module started importing
+    from ``adapters/`` for the WFS URL builder.
     """
     try:
         target = str(httpx.URL(uri).copy_set_param("f", "json"))
@@ -331,7 +335,7 @@ async def probe_service_origin(
     about whether an ArcGIS 200 was healthy.
     """
     if service_type == "arcgis_featureserver":
-        return await probe_arcgis_service(target, timeout=timeout)
+        return await probe_arcgis_origin(target, timeout=timeout)
     return await probe_remote_uri(target, timeout=timeout)
 
 

--- a/backend/app/modules/catalog/sources/origin_probe.py
+++ b/backend/app/modules/catalog/sources/origin_probe.py
@@ -53,6 +53,9 @@ from typing import Any
 
 import httpx
 
+from app.modules.catalog.sources.adapters.arcgis import (
+    build_arcgis_count_query_url,
+)
 from app.modules.catalog.sources.adapters.wfs import build_capabilities_url
 from app.platform.security import (
     SSRFError,
@@ -280,10 +283,18 @@ async def probe_arcgis_origin(
     Reads the body, so it inherits ``fetch_json_document``'s size cap, and an
     oversized sub-400 answer is resolved in the origin's favour — see the
     comment at that branch.
+
+    fix(#1746 codex r6): probes ``<layer>/query``, not the layer document.
+    ``build_gdal_source`` composes ``<layer>/query?...`` and that is what the
+    worker fetches, while a deployment that serves layer METADATA publicly and
+    gates the query operation is ordinary. Probing the document would clear
+    such a service and hand it to the worker to fail on. ``uri`` is still the
+    stored layer pointer, because that is what both callers hold; the query
+    URL is composed from it by the one builder the count fetcher also uses.
     """
     try:
-        target = str(httpx.URL(uri).copy_set_param("f", "json"))
-    except (httpx.InvalidURL, ValueError):
+        target = build_arcgis_count_query_url(uri)
+    except (ValueError, AttributeError):
         # Let the fetch classify a malformed stored URL, rather than raising
         # out of a handler that has already released its DB session.
         target = uri
@@ -291,12 +302,12 @@ async def probe_arcgis_origin(
     if result.oversized:
         # fix(#1746 codex post-rebase): the origin answered sub-400 with a
         # body too big to parse. An ArcGIS auth envelope is a few hundred
-        # bytes, so whatever this is, it is not one — a real layer document
-        # with a long field list or a coded-value domain is exactly what runs
-        # past the cap. Calling a layer that answered 200 `inaccessible`
-        # because it answered at LENGTH is the false negative that mirrors the
-        # false positive this probe exists to close. The size limit stays
-        # where STAC needs it; only the reading of a hit limit changes.
+        # bytes and a returnCountOnly answer is smaller still, so whatever
+        # this is, it is not a refusal. Calling an origin that answered 200
+        # `inaccessible` because it answered at LENGTH is the false negative
+        # that mirrors the false positive this probe exists to close. The
+        # size limit stays where STAC needs it; only the reading of a hit
+        # limit changes.
         return OriginProbeResult(HEALTHY)
     if not result.ok:
         return result
@@ -313,8 +324,10 @@ def service_probe_target(origin_ref: Any, origin_uri: str | None) -> str | None:
 
     fix(#1271 review): the target depends on the service type. Ingest stores
     ``origin_uri`` as ``<base>/<layer identity>`` for provenance, and only
-    ArcGIS's flavor of that (``<base>/<numeric id>``) is a real HTTP resource
-    — WFS and OGC API address layers through a typename or collection
+    ArcGIS's flavor of that (``<base>/<numeric id>``) addresses a real HTTP
+    resource — the layer, from which :func:`probe_arcgis_origin` composes the
+    ``/query`` the worker actually reads (fix #1746 codex r6).
+    WFS and OGC API address layers through a typename or collection
     parameter, so their enriched URI is a non-endpoint and probing it records
     whatever the server's 404 fallback happens to say about a URL nobody
     serves. For those two the canonical service base in ``origin_ref.url`` is

--- a/backend/app/platform/dataset_origin.py
+++ b/backend/app/platform/dataset_origin.py
@@ -117,7 +117,15 @@ ORIGIN_REF_KEYS: dict[str, frozenset[str]] = {
     # must never have to strip a layer back out of the url. Note this is why
     # `url` is not the same value as `datasets.origin_uri`, which deliberately
     # keeps the enriched form ingest composed, as provenance.
-    "service": frozenset({"service_type", "url", "layer_id"}),
+    #
+    # `auth_required` (fix #1746) records that the last SUCCESSFUL pull of this
+    # origin needed a service token. It is `True` or absent, never `False`, so
+    # an unauthenticated pull stores the exact ref shape it stored before the
+    # key existed and no backfill is owed — the same absent-means-no convention
+    # `managed` uses on the postgis kind. The worker writes it at the service
+    # swap, from the credential it actually used; a request door only knows a
+    # token was offered. Never the token itself: this is a boolean.
+    "service": frozenset({"service_type", "url", "layer_id", "auth_required"}),
     # `asset_href` is additive to ADR-002's declared stac shape, and the two
     # href keys are NOT interchangeable: `asset_href` is the COG the tiler
     # reads, `item_href` is the STAC item document that publishes it. A 200 on
@@ -269,6 +277,18 @@ def geolens_owns_table(
     # `is True`, not truthiness: a stored "yes" or 1 is not a claim this
     # function is willing to drop a table on.
     return origin_ref.get("managed") is True
+
+
+def service_auth_required(origin_ref: Any) -> bool:
+    """Whether the last successful pull of this service origin used a token.
+
+    fix(#1746): `is True`, not truthiness, for the same reason
+    ``geolens_owns_table`` spells it that way — this decides whether a request
+    is refused, and a stored 1 or "yes" is not a claim worth refusing on.
+    """
+    if not isinstance(origin_ref, dict):
+        return False
+    return origin_ref.get("auth_required") is True
 
 
 def service_layer_identity(

--- a/backend/app/platform/dataset_origin.py
+++ b/backend/app/platform/dataset_origin.py
@@ -119,12 +119,19 @@ ORIGIN_REF_KEYS: dict[str, frozenset[str]] = {
     # keeps the enriched form ingest composed, as provenance.
     #
     # `auth_required` (fix #1746) records that the last SUCCESSFUL pull of this
-    # origin needed a service token. It is `True` or absent, never `False`, so
-    # an unauthenticated pull stores the exact ref shape it stored before the
-    # key existed and no backfill is owed — the same absent-means-no convention
-    # `managed` uses on the postgis kind. The worker writes it at the service
-    # swap, from the credential it actually used; a request door only knows a
-    # token was offered. Never the token itself: this is a boolean.
+    # origin was MADE with a service token. Read the claim narrowly: the worker
+    # writes it at the swap from the credential it actually used, and a
+    # successful fetch never shows it a challenge, so this is NOT "the origin
+    # demanded one" (fix #1746 codex r1). A public service imported while the
+    # user happened to hold a token is marked too, which is why the refresh
+    # door treats the key as a gate — one token-less probe before it refuses —
+    # rather than as a verdict.
+    #
+    # `True` or absent, never `False`, so an unauthenticated pull stores the
+    # exact ref shape it stored before the key existed, no backfill is owed —
+    # the same absent-means-no convention `managed` uses on the postgis kind —
+    # and a later token-less success clears it. Never the token itself: this is
+    # a boolean.
     "service": frozenset({"service_type", "url", "layer_id", "auth_required"}),
     # `asset_href` is additive to ADR-002's declared stac shape, and the two
     # href keys are NOT interchangeable: `asset_href` is the COG the tiler
@@ -282,9 +289,14 @@ def geolens_owns_table(
 def service_auth_required(origin_ref: Any) -> bool:
     """Whether the last successful pull of this service origin used a token.
 
+    Exactly that, and no more: a token was USED, not demanded. Nothing on the
+    worker's success path observes a challenge, so no caller may read this as
+    "the origin requires authentication" — the refresh door asks the origin
+    that question itself before acting (fix #1746 codex r1).
+
     fix(#1746): `is True`, not truthiness, for the same reason
-    ``geolens_owns_table`` spells it that way — this decides whether a request
-    is refused, and a stored 1 or "yes" is not a claim worth refusing on.
+    ``geolens_owns_table`` spells it that way — this gates an outbound request
+    and a refusal, and a stored 1 or "yes" is not a claim worth acting on.
     """
     if not isinstance(origin_ref, dict):
         return False

--- a/backend/app/processing/ingest/tasks_reupload.py
+++ b/backend/app/processing/ingest/tasks_reupload.py
@@ -1144,7 +1144,12 @@ async def reupload_service(
                         layer_id=layer_id,
                         layer_name=source_layer_value,
                     ),
-                    # fix(#1746): the origin needed a credential to answer.
+                    # fix(#1746): the last successful pull of this origin was
+                    # MADE with a token. Not "the origin demanded one" — the
+                    # worker never sees a challenge on the happy path. See the
+                    # matching comment in tasks_vector.ingest_service; the
+                    # refresh door turns this gate into a verdict by probing.
+                    #
                     # True or absent, never False — build_origin_ref drops
                     # None, so an unauthenticated pull stores the ref shape it
                     # stored before this key existed, and no backfill is owed.

--- a/backend/app/processing/ingest/tasks_reupload.py
+++ b/backend/app/processing/ingest/tasks_reupload.py
@@ -848,11 +848,6 @@ async def reupload_service(
     port = get_processing_port()
     Dataset = port.get_dataset_orm_class()
 
-    auth_error_message = (
-        "Remote service authentication failed. Retry commit with a service token; "
-        "tokens are request-only and are not persisted for retries."
-    )
-
     # fix(#1271 review): tracks whether the outbound fetch was reached, so the
     # failure handler can date the contact. A failure before this point never
     # touched the origin and must not claim it did.
@@ -941,6 +936,10 @@ async def reupload_service(
             source_layer_value = job.source_layer or source_layer
             source_filename = job.source_filename
             reupload_oid_field = um.get("object_id_field") or None
+            # fix(#1746): which door dispatched this run, so the auth-failure
+            # copy can name the call the operator actually made. router_refresh
+            # writes "refresh" into user_metadata; reupload_commit does not.
+            is_refresh = bool(um.get("refresh"))
 
             if not source_url_value:
                 raise IngestionError(
@@ -1018,7 +1017,25 @@ async def reupload_service(
                 _run_service_import,
                 source_layer_value,
                 token=token,
-                auth_error_message=auth_error_message,
+                # fix(#1746): the old copy said "Retry commit", which names a
+                # door neither caller came through — this task serves the
+                # refresh endpoint and the re-upload commit, never a first
+                # import (ingest_service passes no auth_error_message at all).
+                # Two literals rather than one f-string over a noun: the
+                # message reaches record_refresh_failure through
+                # redact_run_error, and a composed string is one more thing a
+                # redactor has to be right about.
+                auth_error_message=(
+                    "Remote service authentication failed. Retry the refresh "
+                    "with a service token in the request body's `token` "
+                    "field; tokens are request-only and are not stored "
+                    "between runs."
+                    if is_refresh
+                    else "Remote service authentication failed. Retry the "
+                    "re-upload with a service token in the commit request's "
+                    "`token` field; tokens are request-only and are not "
+                    "stored between runs."
+                ),
             )
         except ValueError as exc:
             raise IngestionError(str(exc)) from exc
@@ -1127,6 +1144,16 @@ async def reupload_service(
                         layer_id=layer_id,
                         layer_name=source_layer_value,
                     ),
+                    # fix(#1746): the origin needed a credential to answer.
+                    # True or absent, never False — build_origin_ref drops
+                    # None, so an unauthenticated pull stores the ref shape it
+                    # stored before this key existed, and no backfill is owed.
+                    # Written on the SUCCESS path only: a failed authenticated
+                    # attempt tells you nothing new, and a successful
+                    # token-less pull clearing the key is how a service that
+                    # went public gets un-marked. The value is a boolean; the
+                    # token itself is never stored on the dataset.
+                    "auth_required": True if token else None,
                 },
             )
             # Captured pre-commit: the ORM attribute may be expired after commit.

--- a/backend/app/processing/ingest/tasks_vector.py
+++ b/backend/app/processing/ingest/tasks_vector.py
@@ -1069,13 +1069,22 @@ async def ingest_service(
                             layer_id=layer_id,
                             layer_name=source_layer,
                         ),
-                        # fix(#1746): the origin needed a credential to answer.
+                        # fix(#1746): the last successful pull of this origin
+                        # was MADE with a token. Not "the origin demanded one":
+                        # the worker never sees a challenge on the happy path,
+                        # so this cannot be that claim, and a public service
+                        # imported while holding a token is marked too.
+                        #
+                        # fix(#1746 codex r1): which is why the refresh door
+                        # treats the marker as a GATE and not a verdict — it
+                        # runs one token-less probe before refusing, so a false
+                        # marker costs a probe and never a refusal.
+                        #
                         # True or absent, never False — build_origin_ref drops
                         # None, so an unauthenticated pull stores the ref shape
-                        # it stored before this key existed, and no backfill is
-                        # owed. This is the resolved worker credential, so the
-                        # marker means the fetch really did use one; the value
-                        # is a boolean and the token itself is never stored.
+                        # it stored before this key existed, no backfill is
+                        # owed, and a later token-less success clears it. The
+                        # value is a boolean; the token itself is never stored.
                         "auth_required": True if token else None,
                     },
                 )

--- a/backend/app/processing/ingest/tasks_vector.py
+++ b/backend/app/processing/ingest/tasks_vector.py
@@ -1069,6 +1069,14 @@ async def ingest_service(
                             layer_id=layer_id,
                             layer_name=source_layer,
                         ),
+                        # fix(#1746): the origin needed a credential to answer.
+                        # True or absent, never False — build_origin_ref drops
+                        # None, so an unauthenticated pull stores the ref shape
+                        # it stored before this key existed, and no backfill is
+                        # owed. This is the resolved worker credential, so the
+                        # marker means the fetch really did use one; the value
+                        # is a boolean and the token itself is never stored.
+                        "auth_required": True if token else None,
                     },
                 )
             )

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -5757,7 +5757,7 @@
                 "type": "null"
               }
             ],
-            "description": "Why the origin is not healthy, as one of a fixed set of GeoLens codes: blocked_by_policy, item_withdrawn, network_error, not_found, server_error, timeout, unauthorized, unexpected_status. Null when healthy or never probed. Never provider text, a URL, or a response body \u2014 nothing the origin sent is stored here.",
+            "description": "Why the origin is not healthy, as one of a fixed set of GeoLens codes: auth_required, blocked_by_policy, item_withdrawn, network_error, not_found, server_error, timeout, unauthorized, unexpected_status. Null when healthy or never probed. Never provider text, a URL, or a response body \u2014 nothing the origin sent is stored here.",
             "title": "Source Health Detail"
           },
           "schema_drift_status": {
@@ -15468,7 +15468,7 @@
                 "type": "null"
               }
             ],
-            "description": "Why the origin is not healthy, as one of a fixed set of GeoLens codes: blocked_by_policy, item_withdrawn, network_error, not_found, server_error, timeout, unauthorized, unexpected_status. Null when healthy or never probed. Never provider text, a URL, or a response body \u2014 nothing the origin sent is stored here.",
+            "description": "Why the origin is not healthy, as one of a fixed set of GeoLens codes: auth_required, blocked_by_policy, item_withdrawn, network_error, not_found, server_error, timeout, unauthorized, unexpected_status. Null when healthy or never probed. Never provider text, a URL, or a response body \u2014 nothing the origin sent is stored here.",
             "title": "Source Health Detail"
           },
           "last_checked_at": {

--- a/backend/tests/test_dataset_source_state.py
+++ b/backend/tests/test_dataset_source_state.py
@@ -53,6 +53,7 @@ from app.platform.dataset_origin import (
     build_origin_ref,
     classify_origin,
     project_unknown,
+    service_auth_required,
     service_layer_identity,
     set_dataset_origin,
     set_postgis_origin,
@@ -2584,9 +2585,45 @@ class TestServiceLayerIdentity:
 
     def test_a_second_name_key_is_still_refused(self) -> None:
         """Unification means one key; the allowlist must not have grown."""
+        # fix(#1746): `auth_required` joined the set. It is not a second layer
+        # key — it says the last successful pull needed a service token — so
+        # the "one key addresses the layer" rule this test guards is intact.
         assert ORIGIN_REF_KEYS["service"] == frozenset(
-            {"service_type", "url", "layer_id"}
+            {"service_type", "url", "layer_id", "auth_required"}
         )
         for key in ("layer_name", "source_layer", "typename", "collection_id"):
             with pytest.raises(ValueError, match="rejects key"):
                 build_origin_ref("service", **{key: "topp:parcels"})
+
+    def test_auth_required_is_true_or_absent_never_false(self) -> None:
+        """fix(#1746): a token-less pull stores the pre-marker ref shape."""
+        ref = build_origin_ref(
+            "service",
+            service_type="arcgis_featureserver",
+            url="https://example.test/FeatureServer",
+            layer_id="3",
+            auth_required=None,
+        )
+        assert ref is not None
+        assert "auth_required" not in ref
+        assert not service_auth_required(ref)
+
+        marked = build_origin_ref(
+            "service",
+            service_type="arcgis_featureserver",
+            url="https://example.test/FeatureServer",
+            layer_id="3",
+            auth_required=True,
+        )
+        assert marked is not None
+        assert marked["auth_required"] is True
+        assert service_auth_required(marked)
+
+    def test_service_auth_required_reads_only_a_real_true(self) -> None:
+        """A stored 1 or "yes" is not a claim worth refusing a request on."""
+        assert not service_auth_required(None)
+        assert not service_auth_required("auth_required")
+        assert not service_auth_required({})
+        assert not service_auth_required({"auth_required": 1})
+        assert not service_auth_required({"auth_required": "yes"})
+        assert not service_auth_required({"auth_required": False})

--- a/backend/tests/test_ingest.py
+++ b/backend/tests/test_ingest.py
@@ -1643,3 +1643,180 @@ class TestCommitImportDispatch:
         assert "title" in body["detail"]  # e.g. "body.title: Field required"
         assert "Field required" in body["detail"] or "required" in body["detail"]
         assert mock_ingest_task.await_count == 0
+
+
+# ---------------------------------------------------------------------------
+# fix(#1746): the auth_required marker on a first service import
+# ---------------------------------------------------------------------------
+
+
+class TestServiceImportAuthRequiredMarker:
+    """A token-bearing first import records that the origin wanted one.
+
+    The marker is what lets the refresh door refuse a credential-less refresh
+    of an org-only service instead of answering 202 and failing in the worker
+    half a second later. It is written HERE, at the swap, from the credential
+    the fetch actually used — a request door only ever knows a token was
+    offered, which is a different claim.
+    """
+
+    @pytest.mark.anyio
+    @pytest.mark.parametrize(
+        "worker_token",
+        ["service-token", None],
+        ids=["with_token", "without_token"],
+    )
+    async def test_the_swap_marks_only_a_token_bearing_import(
+        self,
+        client: AsyncClient,  # points app.core.db.async_session at the test DB
+        test_db_session,
+        monkeypatch,
+        worker_token: str | None,
+    ) -> None:
+        from sqlalchemy import text
+
+        import app.core.db as db_module
+        from app.modules.catalog.datasets.domain.models import Dataset
+        from app.processing.ingest import tasks_vector
+        from app.platform.jobs.heartbeat import attempt_scoped_staging_table
+        from tests.factories import get_user_id
+
+        admin_id = await get_user_id(test_db_session, "admin")
+        table_name = f"tbl_svc_{uuid.uuid4().hex[:8]}"
+
+        job = IngestJob(
+            source_filename="Roads",
+            source_url="https://services.example.com/svc/FeatureServer",
+            source_layer="0",
+            created_by=admin_id,
+            status="pending",
+            user_metadata={
+                "title": f"Roads {uuid.uuid4().hex[:6]}",
+                "visibility": "private",
+                "service_type": "ArcGIS FeatureServer",
+                "layer_id": "0",
+                "geometry_type": None,
+            },
+        )
+        test_db_session.add(job)
+        await test_db_session.commit()
+        await test_db_session.refresh(job)
+        attempt_id = job.attempt_id
+        assert attempt_id is not None
+
+        staging = attempt_scoped_staging_table(table_name, attempt_id)
+
+        async def _fake_generate_table_name(*_args, **_kwargs):
+            return table_name, None
+
+        async def _fake_import(_import_fn, _source_layer, **_kwargs) -> None:
+            """Stands in for the whole fetch: just land the staging table."""
+            async with db_module.async_session() as session:
+                await session.execute(text(f'DROP TABLE IF EXISTS data."{staging}"'))
+                await session.execute(
+                    text(
+                        f'CREATE TABLE data."{staging}" '
+                        "(gid serial PRIMARY KEY, name text)"
+                    )
+                )
+                await session.commit()
+
+        async def _noop(*_args, **_kwargs) -> None:
+            return None
+
+        monkeypatch.setattr("app.platform.security.validate_url_for_ssrf", AsyncMock())
+        monkeypatch.setattr(
+            "app.processing.ingest.service.generate_table_name",
+            _fake_generate_table_name,
+        )
+        monkeypatch.setattr(
+            "app.processing.ingest.ogr.build_pg_conn_str", lambda: "PG:"
+        )
+        monkeypatch.setattr(
+            tasks_vector, "_run_service_import_with_wfs_fallback", _fake_import
+        )
+        monkeypatch.setattr(tasks_vector, "_emit_billing_event", _noop)
+
+        with (
+            patch(
+                "app.processing.ingest.metadata.ensure_geom_column",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+            patch(
+                "app.processing.ingest.metadata.clip_to_mercator_bounds",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "app.processing.ingest.metadata.add_4326_column",
+                new_callable=AsyncMock,
+            ),
+            # Mocked so this never touches cluster-global role grants, which
+            # would force the module into the tenancy serialization group for
+            # one assertion about a JSONB key.
+            patch(
+                "app.processing.ingest.metadata.grant_reader_access",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "app.processing.ingest.metadata.extract_metadata",
+                new_callable=AsyncMock,
+                return_value={
+                    "srid": 4326,
+                    "geometry_type": "POINT",
+                    "feature_count": 3,
+                    "extent_wkt": "POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))",
+                    "column_info": [],
+                },
+            ),
+            patch(
+                "app.processing.ingest.metadata.get_sample_values",
+                new_callable=AsyncMock,
+                return_value={},
+            ),
+            patch(
+                "app.processing.ingest.metadata.refresh_attribute_metadata",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "app.processing.ingest.metadata.compute_quality_score",
+                new_callable=AsyncMock,
+                return_value={"overall": 90},
+            ),
+        ):
+            try:
+                await tasks_vector.ingest_service.func(
+                    job_id=str(job.id),
+                    attempt_id=str(attempt_id),
+                    source_url="https://services.example.com/svc/FeatureServer",
+                    source_layer="0",
+                    user_id=str(admin_id),
+                    token=worker_token,
+                )
+
+                dataset = (
+                    await test_db_session.execute(
+                        select(Dataset).where(Dataset.table_name == table_name)
+                    )
+                ).scalar_one()
+
+                origin_ref = dataset.origin_ref or {}
+                if worker_token is None:
+                    # Absent, not False: an unauthenticated pull stores the
+                    # exact ref shape it stored before the key existed, which
+                    # is why no backfill is owed for existing rows.
+                    assert "auth_required" not in origin_ref
+                else:
+                    assert origin_ref["auth_required"] is True
+                # A boolean, never the credential, anywhere on the row.
+                assert "service-token" not in str(origin_ref)
+                assert "service-token" not in str(dataset.origin_uri)
+            finally:
+                async with db_module.async_session() as session:
+                    await session.execute(
+                        text(f'DROP TABLE IF EXISTS data."{table_name}" CASCADE')
+                    )
+                    await session.execute(
+                        text(f'DROP TABLE IF EXISTS data."{staging}" CASCADE')
+                    )
+                    await session.commit()

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -3120,7 +3120,16 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # exhaust the pool. Most of the addition is the docstring stating which
     # services can be asked and why, plus the caller contract for the
     # rollback. Cap 1200 -> 1282, exact.
-    "backend/app/modules/catalog/datasets/api/router_refresh.py": 1282,
+    # fix(#1746 codex r3): +62 — the marker is re-checked after the
+    # reservation. A token-less refresh could read an unmarked dataset, pass
+    # the guard, and have an authenticated re-upload of the same origin mark it
+    # inside the reservation window; the binding comparison there cannot see
+    # that, because `_ServiceOrigin` is the worker's binding and the origin did
+    # not move. Detects the TRANSITION rather than re-deciding, so a healthy
+    # ArcGIS probe is not overturned with no new evidence. Most of the addition
+    # is the docstring saying why it is not folded into the binding check and
+    # why it does not probe. Cap 1282 -> 1344, exact.
+    "backend/app/modules/catalog/datasets/api/router_refresh.py": 1344,
     # fix(#1335): stac_resolve.py's 1040 lines were split along their natural
     # seams — verdict taxonomy, identity checks, the asset gate (SSRF + COG
     # probe), and the by-search fallback each moved into a sibling module,

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -3060,7 +3060,14 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # way a task can learn its own queue-row id) and the
     # `purge_token_on_failure` wrapper, plus the comment saying what the
     # context is for. Cap 1242 -> 1251, exact.
-    "backend/app/processing/ingest/tasks_reupload.py": 1251,
+    # fix(#1746): +27 — the auth_required marker on the service swap's
+    # origin_ref (True or absent, never False, so a token-less pull stores the
+    # pre-marker ref shape and no backfill is owed), plus door-aware
+    # auth-failure copy. The old string said "Retry commit", which names a
+    # door neither caller came through: this task serves the refresh endpoint
+    # and the re-upload commit, and never a first import. Cap 1251 -> 1278,
+    # exact.
+    "backend/app/processing/ingest/tasks_reupload.py": 1278,
     # --- entered by the inclusion rule, feat(#1266) -----------------------
     # The refresh door crossed 1000 when it gained its third execution
     # strategy. Two thirds of the addition is the STAC dispatcher, which is
@@ -3083,7 +3090,15 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # business: an unverified first answer would be both adopted and recorded
     # as durable truth, and a caller who learns that immediately can act on
     # it, where one who learns it from a failed run cannot. Cap 1091 -> 1119.
-    "backend/app/modules/catalog/datasets/api/router_refresh.py": 1119,
+    # fix(#1746): +44 — the service_token_required 422, refusing a
+    # credential-less refresh of an origin whose last successful pull needed a
+    # token, before the SSRF resolve and before the run reservation. Extracted
+    # into its own helper rather than three lines in the handler, because
+    # refresh_dataset sits one branch under ruff's C901 ceiling and the repo's
+    # answer to that is extraction. Most of the addition is the docstring
+    # saying why the marker is not a permanent trap: the re-upload dialog with
+    # no token is the path that clears it. Cap 1119 -> 1163, exact.
+    "backend/app/modules/catalog/datasets/api/router_refresh.py": 1163,
     # fix(#1335): stac_resolve.py's 1040 lines were split along their natural
     # seams — verdict taxonomy, identity checks, the asset gate (SSRF + COG
     # probe), and the by-search fallback each moved into a sibling module,
@@ -3690,7 +3705,12 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # way a task can learn its own queue-row id) and the
     # `purge_token_on_failure` wrapper, plus the comment saying what the
     # context is for. Cap 1117 -> 1126, exact.
-    "backend/app/processing/ingest/tasks_vector.py": 1126,
+    # fix(#1746): +8 — the auth_required marker on a first service import's
+    # origin_ref, so a token-bearing import is refusable at the refresh door.
+    # One key and the comment saying why the value is True-or-None: absent
+    # means "not known to need auth", which is where every dataset imported
+    # before the marker sits. Cap 1126 -> 1134, exact.
+    "backend/app/processing/ingest/tasks_vector.py": 1134,
     # --- entered by the inclusion rule ------------------------------------
     # Crossed 1000 lines adding the "unable to open datasource" friendly-
     # message mapping shared by run_ogrinfo and run_ogr2ogr: the pattern

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -3067,7 +3067,10 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # door neither caller came through: this task serves the refresh endpoint
     # and the re-upload commit, and never a first import. Cap 1251 -> 1278,
     # exact.
-    "backend/app/processing/ingest/tasks_reupload.py": 1278,
+    # fix(#1746 codex r1): +5 — the marker comment now states the claim
+    # narrowly ("the last successful pull was MADE with a token"), because the
+    # worker never sees a challenge on the happy path. Cap 1278 -> 1283, exact.
+    "backend/app/processing/ingest/tasks_reupload.py": 1283,
     # --- entered by the inclusion rule, feat(#1266) -----------------------
     # The refresh door crossed 1000 when it gained its third execution
     # strategy. Two thirds of the addition is the STAC dispatcher, which is
@@ -3098,7 +3101,15 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # answer to that is extraction. Most of the addition is the docstring
     # saying why the marker is not a permanent trap: the re-upload dialog with
     # no token is the path that clears it. Cap 1119 -> 1163, exact.
-    "backend/app/modules/catalog/datasets/api/router_refresh.py": 1163,
+    # fix(#1746 codex r1): +37 — the marker records that a token was USED, not
+    # that the origin demanded one, so refusing on it alone locks a user who
+    # imported a public service while holding a token out of every token-less
+    # refresh. The guard now runs ONE token-less probe (through the health
+    # endpoint's own target and probe helpers, both lifted into origin_probe)
+    # and refuses only on an auth challenge; every other outcome falls through
+    # to the worker. Most of the addition is the docstring saying why it fails
+    # open. Cap 1163 -> 1200, exact.
+    "backend/app/modules/catalog/datasets/api/router_refresh.py": 1200,
     # fix(#1335): stac_resolve.py's 1040 lines were split along their natural
     # seams — verdict taxonomy, identity checks, the asset gate (SSRF + COG
     # probe), and the by-search fallback each moved into a sibling module,
@@ -3710,7 +3721,10 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # One key and the comment saying why the value is True-or-None: absent
     # means "not known to need auth", which is where every dataset imported
     # before the marker sits. Cap 1126 -> 1134, exact.
-    "backend/app/processing/ingest/tasks_vector.py": 1134,
+    # fix(#1746 codex r1): +9 — same narrowing of the marker comment, plus the
+    # note that the refresh door treats the key as a gate and not a verdict.
+    # Cap 1134 -> 1143, exact.
+    "backend/app/processing/ingest/tasks_vector.py": 1143,
     # --- entered by the inclusion rule ------------------------------------
     # Crossed 1000 lines adding the "unable to open datasource" friendly-
     # message mapping shared by run_ogrinfo and run_ogr2ogr: the pattern

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -3109,7 +3109,18 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # and refuses only on an auth challenge; every other outcome falls through
     # to the worker. Most of the addition is the docstring saying why it fails
     # open. Cap 1163 -> 1200, exact.
-    "backend/app/modules/catalog/datasets/api/router_refresh.py": 1200,
+    # fix(#1746 codex r2): +82 — two corrections to the r1 guard. It probes
+    # only ArcGIS, whose target IS the layer the worker reads; WFS and OGC API
+    # are refused outright, because their probe target is GetCapabilities or
+    # the landing page and a public one of those in front of a protected
+    # GetFeature is an ordinary deployment, so a healthy answer would be
+    # evidence of nothing. And the probe path now releases the session across
+    # the outbound wait and re-reads after it, the way check_source_health
+    # does, so concurrent marked refreshes against a slow origin cannot
+    # exhaust the pool. Most of the addition is the docstring stating which
+    # services can be asked and why, plus the caller contract for the
+    # rollback. Cap 1200 -> 1282, exact.
+    "backend/app/modules/catalog/datasets/api/router_refresh.py": 1282,
     # fix(#1335): stac_resolve.py's 1040 lines were split along their natural
     # seams — verdict taxonomy, identity checks, the asset gate (SSRF + COG
     # probe), and the by-search fallback each moved into a sibling module,

--- a/backend/tests/test_reupload_service.py
+++ b/backend/tests/test_reupload_service.py
@@ -49,6 +49,7 @@ async def _create_service_reupload_job(
     source_url: str = "https://example.com/wfs",
     source_layer: str = "roads",
     source_filename: str = "Roads Layer",
+    refresh: bool = False,
 ) -> IngestJob:
     job = IngestJob(
         dataset_id=dataset_id,
@@ -63,6 +64,10 @@ async def _create_service_reupload_job(
             "service_type": "WFS 2.0.0",
             "layer_id": None,
             "source_type": "service_url",
+            # fix(#1746): router_refresh stamps this; reupload_commit does
+            # not. It is the only thing separating the two doors inside a
+            # task that serves both.
+            **({"refresh": True} if refresh else {}),
         },
     )
     session.add(job)
@@ -136,10 +141,16 @@ class TestServiceReuploadCommitDispatch:
 
 
 class TestServiceReuploadWorker:
+    @pytest.mark.parametrize(
+        "worker_token",
+        ["runtime-token", None],
+        ids=["with_token", "without_token"],
+    )
     async def test_reupload_service_preserves_identity_and_increments_version(
         self,
         client: AsyncClient,  # ensures app.database.async_session points to test DB
         test_db_session,
+        worker_token: str | None,
     ):
         admin_id = await get_user_id(test_db_session, "admin")
         dataset = await _create_dataset(test_db_session, created_by=admin_id)
@@ -289,7 +300,7 @@ class TestServiceReuploadWorker:
                 source_url=job.source_url or "",
                 source_layer=job.source_layer or "",
                 user_id=str(admin_id),
-                token="runtime-token",
+                token=worker_token,
             )
 
         await test_db_session.refresh(dataset)
@@ -301,6 +312,19 @@ class TestServiceReuploadWorker:
         assert dataset.source_url == "https://services.example.com/wfs"
         assert dataset.source_format == "wfs"
         assert dataset.source_filename == "roads_wfs"
+
+        # fix(#1746): the swap records that the pull needed a credential, as a
+        # boolean. True or ABSENT, never False — a token-less success stores
+        # the ref shape it stored before the key existed, which is also how a
+        # service that went public gets un-marked. The token itself is never
+        # written to the dataset row, in any form.
+        origin_ref = dataset.origin_ref or {}
+        if worker_token is None:
+            assert "auth_required" not in origin_ref
+        else:
+            assert origin_ref["auth_required"] is True
+        assert "runtime-token" not in str(origin_ref)
+        assert "runtime-token" not in str(dataset.origin_uri)
 
         table_exists = await test_db_session.execute(
             text(
@@ -347,11 +371,28 @@ class TestServiceReuploadWorker:
         mock_quality_score.assert_awaited_once()
         mock_invalidate_catalog.assert_awaited_once_with()
 
+    @pytest.mark.parametrize(
+        ("refresh", "expected"),
+        [
+            (False, "Retry the re-upload with a service token"),
+            (True, "Retry the refresh with a service token"),
+        ],
+        ids=["reupload_commit", "refresh"],
+    )
     async def test_reupload_service_without_token_returns_retry_guidance_on_auth_failure(
         self,
         client: AsyncClient,  # ensures app.database.async_session points to test DB
         test_db_session,
+        refresh: bool,
+        expected: str,
     ):
+        """fix(#1746): the copy names the door the operator actually used.
+
+        One task serves the refresh endpoint and the re-upload commit, and the
+        old string said "Retry commit" on both — advice about a door half the
+        callers never came through. It also names the request field that fixes
+        it, since a token is request-only and there is nothing to un-expire.
+        """
         admin_id = await get_user_id(test_db_session, "admin")
         dataset = await _create_dataset(test_db_session, created_by=admin_id)
         job = await _create_service_reupload_job(
@@ -360,6 +401,7 @@ class TestServiceReuploadWorker:
             created_by=admin_id,
             source_url="https://protected.example.com/wfs",
             source_layer="roads",
+            refresh=refresh,
         )
 
         with (
@@ -385,9 +427,7 @@ class TestServiceReuploadWorker:
                 "ogr2ogr failed (exit 1): HTTP error code : 401 Unauthorized"
             )
 
-            with pytest.raises(
-                IngestionError, match="Retry commit with a service token"
-            ):
+            with pytest.raises(IngestionError, match=expected):
                 await reupload_service(
                     job_id=str(job.id),
                     attempt_id=str(job.attempt_id),
@@ -400,4 +440,7 @@ class TestServiceReuploadWorker:
 
         await test_db_session.refresh(job)
         assert job.status == "failed"
-        assert "Retry commit with a service token" in (job.error_message or "")
+        assert expected in (job.error_message or "")
+        assert "`token` field" in (job.error_message or "")
+        # The door that was NOT used is never named.
+        assert "Retry commit with a service token" not in (job.error_message or "")

--- a/backend/tests/test_service_refresh_1220.py
+++ b/backend/tests/test_service_refresh_1220.py
@@ -37,6 +37,15 @@ from sqlalchemy import select
 
 from app.modules.catalog.datasets.api import router_refresh
 from app.modules.catalog.datasets.domain.schemas import DatasetRefreshRequest
+from app.modules.catalog.sources.origin_probe import (
+    AUTH_REQUIRED,
+    HEALTHY,
+    INACCESSIBLE,
+    MISSING,
+    NOT_FOUND,
+    UNAUTHORIZED,
+    OriginProbeResult,
+)
 from app.platform.dataset_origin import set_dataset_origin
 from app.platform.jobs.models import IngestJob
 from app.platform.refresh import credentials as creds
@@ -165,6 +174,24 @@ async def _service_dataset(
     await session.commit()
     await session.refresh(dataset)
     return dataset
+
+
+@asynccontextmanager
+async def _probe_harness(*, result=None, raises=None):
+    """Patch the refresh door's token-less probe; yield the mock.
+
+    fix(#1746 codex r1): the door no longer refuses on the stored marker
+    alone, it asks the origin. Tests need to state the origin's answer, and to
+    assert that the probe did NOT happen on the paths that must not pay for
+    one.
+    """
+    probe = AsyncMock()
+    if raises is not None:
+        probe.side_effect = raises
+    else:
+        probe.return_value = result or OriginProbeResult(HEALTHY)
+    with patch.object(router_refresh, "probe_service_origin", probe):
+        yield probe
 
 
 async def _run_for(session, dataset_id: uuid.UUID) -> DatasetRefreshRun | None:
@@ -389,13 +416,30 @@ class TestAuthRequiredRefusal:
 
     Before this, a credential-less refresh of an org-only service answered
     202 and then failed ~0.5s later in the worker, where the only statement
-    of the real cause was a job error message nobody was watching. The
-    dataset carries a boolean marker (never a token) saying its last
-    successful pull needed a credential, and the door reads it.
+    of the real cause was a job error message nobody was watching.
+
+    fix(#1746 codex r1): the stored marker says the last successful pull was
+    MADE with a token, which is not the same claim as "the origin demands
+    one" — a public service imported while the user held a token is marked
+    too. So the marker is a gate and the door asks the origin itself. Only an
+    auth challenge refuses; every other probe outcome falls through to the
+    worker, exactly as before this existed.
     """
 
-    async def test_a_marked_dataset_without_a_token_is_refused(
-        self, client: AsyncClient, admin_auth_header: dict, test_db_session
+    _CHALLENGES = [
+        OriginProbeResult(INACCESSIBLE, AUTH_REQUIRED),  # ArcGIS 498/499
+        OriginProbeResult(INACCESSIBLE, UNAUTHORIZED),  # a plain 401/403
+    ]
+
+    @pytest.mark.parametrize(
+        "challenge", _CHALLENGES, ids=["arcgis_envelope", "http_401"]
+    )
+    async def test_a_marked_dataset_is_refused_when_the_origin_challenges(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session,
+        challenge,
     ) -> None:
         admin_id = await get_user_id(test_db_session, "admin")
         dataset = await _service_dataset(
@@ -403,9 +447,10 @@ class TestAuthRequiredRefusal:
         )
 
         async with _dispatch_harness() as task:
-            resp = await client.post(
-                f"/datasets/{dataset.id}/refresh", headers=admin_auth_header
-            )
+            async with _probe_harness(result=challenge) as probe:
+                resp = await client.post(
+                    f"/datasets/{dataset.id}/refresh", headers=admin_auth_header
+                )
 
         assert resp.status_code == 422, resp.text
         detail = resp.json()["detail"]
@@ -415,10 +460,93 @@ class TestAuthRequiredRefusal:
         assert "`token` field" in detail["message"]
         assert "request-only" in detail["message"]
 
+        # The probe went to the canonical service target for this service
+        # type, token-less, and ran exactly once.
+        probe.assert_awaited_once()
+        target, service_type = probe.await_args.args
+        assert target == f"{_WFS_BASE}?service=WFS&request=GetCapabilities"
+        assert service_type == "wfs"
+
         # Refused before the reservation: no run row, nothing deferred, and
         # so nothing holding the dataset against the admission index.
         assert await _run_for(test_db_session, dataset.id) is None
         task.defer_async.assert_not_awaited()
+
+    async def test_a_healthy_probe_lets_the_refresh_through(
+        self, client: AsyncClient, admin_auth_header: dict, test_db_session
+    ) -> None:
+        """The false-marker case, which is the whole reason for the probe.
+
+        A public service imported while the user held a token carries the
+        marker. Refusing on it alone would lock them out of every token-less
+        refresh until they went through the re-upload dialog.
+        """
+        admin_id = await get_user_id(test_db_session, "admin")
+        dataset = await _service_dataset(
+            test_db_session, created_by=admin_id, auth_required=True
+        )
+
+        async with _dispatch_harness() as task:
+            async with _probe_harness(result=OriginProbeResult(HEALTHY)) as probe:
+                resp = await client.post(
+                    f"/datasets/{dataset.id}/refresh", headers=admin_auth_header
+                )
+
+        assert resp.status_code == 202, resp.text
+        probe.assert_awaited_once()
+        task.defer_async.assert_awaited_once()
+        assert await _run_for(test_db_session, dataset.id) is not None
+
+    @pytest.mark.parametrize(
+        "outcome",
+        [
+            OriginProbeResult(INACCESSIBLE, "timeout"),
+            OriginProbeResult(INACCESSIBLE, "network_error"),
+            OriginProbeResult(INACCESSIBLE, "blocked_by_policy"),
+            OriginProbeResult(MISSING, NOT_FOUND),
+        ],
+        ids=["timeout", "unreachable", "blocked", "missing"],
+    )
+    async def test_a_non_challenge_probe_outcome_fails_open(
+        self, client: AsyncClient, admin_auth_header: dict, test_db_session, outcome
+    ) -> None:
+        """Only an auth challenge refuses.
+
+        A probe is one request against a third party. Turning its bad day into
+        a refusal would be a worse bug than the one this closes, and the
+        worker is still there with copy that names the token field.
+        """
+        admin_id = await get_user_id(test_db_session, "admin")
+        dataset = await _service_dataset(
+            test_db_session, created_by=admin_id, auth_required=True
+        )
+
+        async with _dispatch_harness() as task:
+            async with _probe_harness(result=outcome):
+                resp = await client.post(
+                    f"/datasets/{dataset.id}/refresh", headers=admin_auth_header
+                )
+
+        assert resp.status_code == 202, resp.text
+        task.defer_async.assert_awaited_once()
+
+    async def test_a_probe_that_raises_fails_open(
+        self, client: AsyncClient, admin_auth_header: dict, test_db_session
+    ) -> None:
+        """The guard cannot be the thing that 500s a request bound for 202."""
+        admin_id = await get_user_id(test_db_session, "admin")
+        dataset = await _service_dataset(
+            test_db_session, created_by=admin_id, auth_required=True
+        )
+
+        async with _dispatch_harness() as task:
+            async with _probe_harness(raises=RuntimeError("origin exploded")):
+                resp = await client.post(
+                    f"/datasets/{dataset.id}/refresh", headers=admin_auth_header
+                )
+
+        assert resp.status_code == 202, resp.text
+        task.defer_async.assert_awaited_once()
 
     async def test_the_refusal_never_echoes_a_credential(
         self, client: AsyncClient, admin_auth_header: dict, test_db_session
@@ -430,11 +558,14 @@ class TestAuthRequiredRefusal:
         )
 
         async with _dispatch_harness():
-            resp = await client.post(
-                f"/datasets/{dataset.id}/refresh",
-                headers=admin_auth_header,
-                json={"token": None},
-            )
+            async with _probe_harness(
+                result=OriginProbeResult(INACCESSIBLE, AUTH_REQUIRED)
+            ):
+                resp = await client.post(
+                    f"/datasets/{dataset.id}/refresh",
+                    headers=admin_auth_header,
+                    json={"token": None},
+                )
 
         assert resp.status_code == 422, resp.text
         # Structural rather than "this particular secret is absent": the
@@ -457,13 +588,16 @@ class TestAuthRequiredRefusal:
         )
 
         async with _dispatch_harness() as task:
-            resp = await client.post(
-                f"/datasets/{dataset.id}/refresh",
-                headers=admin_auth_header,
-                json={"token": "tok-" + uuid.uuid4().hex},
-            )
+            async with _probe_harness() as probe:
+                resp = await client.post(
+                    f"/datasets/{dataset.id}/refresh",
+                    headers=admin_auth_header,
+                    json={"token": "tok-" + uuid.uuid4().hex},
+                )
 
         assert resp.status_code == 202, resp.text
+        # A token was sent, so there is nothing to ask the origin.
+        probe.assert_not_awaited()
         task.defer_async.assert_awaited_once()
         assert await _run_for(test_db_session, dataset.id) is not None
 
@@ -480,11 +614,15 @@ class TestAuthRequiredRefusal:
         assert "auth_required" not in (dataset.origin_ref or {})
 
         async with _dispatch_harness() as task:
-            resp = await client.post(
-                f"/datasets/{dataset.id}/refresh", headers=admin_auth_header
-            )
+            async with _probe_harness() as probe:
+                resp = await client.post(
+                    f"/datasets/{dataset.id}/refresh", headers=admin_auth_header
+                )
 
         assert resp.status_code == 202, resp.text
+        # The marker is the gate: an unmarked dataset pays for no probe at
+        # all, so the common refresh costs exactly what it always did.
+        probe.assert_not_awaited()
         task.defer_async.assert_awaited_once()
 
     async def test_a_stored_false_is_not_a_reason_to_refuse(
@@ -497,11 +635,13 @@ class TestAuthRequiredRefusal:
         await test_db_session.commit()
 
         async with _dispatch_harness():
-            resp = await client.post(
-                f"/datasets/{dataset.id}/refresh", headers=admin_auth_header
-            )
+            async with _probe_harness() as probe:
+                resp = await client.post(
+                    f"/datasets/{dataset.id}/refresh", headers=admin_auth_header
+                )
 
         assert resp.status_code == 202, resp.text
+        probe.assert_not_awaited()
 
     @pytest.mark.parametrize(
         ("source_format", "record_type"),
@@ -537,9 +677,12 @@ class TestAuthRequiredRefusal:
         await test_db_session.commit()
 
         async with _dispatch_harness():
-            resp = await client.post(
-                f"/datasets/{dataset.id}/refresh", headers=admin_auth_header
-            )
+            async with _probe_harness(
+                result=OriginProbeResult(INACCESSIBLE, AUTH_REQUIRED)
+            ):
+                resp = await client.post(
+                    f"/datasets/{dataset.id}/refresh", headers=admin_auth_header
+                )
 
         body = resp.json()
         detail = body.get("detail")

--- a/backend/tests/test_service_refresh_1220.py
+++ b/backend/tests/test_service_refresh_1220.py
@@ -34,6 +34,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from httpx import AsyncClient
 from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.modules.catalog.datasets.api import router_refresh
 from app.modules.catalog.datasets.domain.schemas import DatasetRefreshRequest
@@ -58,6 +59,9 @@ pytestmark = pytest.mark.anyio
 
 _ARCGIS_BASE = "https://services.example.com/arcgis/rest/services/Parcels/FeatureServer"
 _WFS_BASE = "https://services.example.com/geoserver/wfs"
+# fix(#1746 codex r2): the third service type the marker gate has to
+# answer for, and the second that cannot be probed.
+_OGCAPI_BASE = "https://services.example.com/ogcapi"
 
 
 # ---------------------------------------------------------------------------
@@ -184,13 +188,17 @@ async def _probe_harness(*, result=None, raises=None):
     alone, it asks the origin. Tests need to state the origin's answer, and to
     assert that the probe did NOT happen on the paths that must not pay for
     one.
+
+    fix(#1746 codex r2): only the ArcGIS path probes, so this patches the
+    ArcGIS origin probe by name. A WFS or OGC API dataset that reaches the
+    probe at all is the bug this harness now also catches.
     """
     probe = AsyncMock()
     if raises is not None:
         probe.side_effect = raises
     else:
         probe.return_value = result or OriginProbeResult(HEALTHY)
-    with patch.object(router_refresh, "probe_service_origin", probe):
+    with patch.object(router_refresh, "probe_arcgis_origin", probe):
         yield probe
 
 
@@ -421,9 +429,14 @@ class TestAuthRequiredRefusal:
     fix(#1746 codex r1): the stored marker says the last successful pull was
     MADE with a token, which is not the same claim as "the origin demands
     one" — a public service imported while the user held a token is marked
-    too. So the marker is a gate and the door asks the origin itself. Only an
-    auth challenge refuses; every other probe outcome falls through to the
-    worker, exactly as before this existed.
+    too. So the marker is a gate.
+
+    fix(#1746 codex r2): and the gate resolves differently per service,
+    because only ArcGIS can be asked. Its probe target is the layer the
+    worker actually reads. A WFS or OGC API probe would hit GetCapabilities
+    or the landing page, which says nothing about whether GetFeature or
+    /items is protected, so those are refused outright rather than cleared by
+    evidence that is not evidence.
     """
 
     _CHALLENGES = [
@@ -431,10 +444,25 @@ class TestAuthRequiredRefusal:
         OriginProbeResult(INACCESSIBLE, UNAUTHORIZED),  # a plain 401/403
     ]
 
+    @staticmethod
+    async def _marked_arcgis(session, *, created_by):
+        return await _service_dataset(
+            session,
+            created_by=created_by,
+            source_format="arcgis_featureserver",
+            base_url=_ARCGIS_BASE,
+            layer_id="0",
+            auth_required=True,
+        )
+
+    # ---------------------------------------------------------------- #
+    # ArcGIS: the probe target IS the resource the worker reads
+    # ---------------------------------------------------------------- #
+
     @pytest.mark.parametrize(
         "challenge", _CHALLENGES, ids=["arcgis_envelope", "http_401"]
     )
-    async def test_a_marked_dataset_is_refused_when_the_origin_challenges(
+    async def test_a_marked_arcgis_is_refused_when_the_layer_challenges(
         self,
         client: AsyncClient,
         admin_auth_header: dict,
@@ -442,9 +470,7 @@ class TestAuthRequiredRefusal:
         challenge,
     ) -> None:
         admin_id = await get_user_id(test_db_session, "admin")
-        dataset = await _service_dataset(
-            test_db_session, created_by=admin_id, auth_required=True
-        )
+        dataset = await self._marked_arcgis(test_db_session, created_by=admin_id)
 
         async with _dispatch_harness() as task:
             async with _probe_harness(result=challenge) as probe:
@@ -455,24 +481,24 @@ class TestAuthRequiredRefusal:
         assert resp.status_code == 422, resp.text
         detail = resp.json()["detail"]
         assert detail["code"] == "service_token_required"
-        # The message names the field that fixes it, and says why there is
-        # nothing on the server to un-expire.
+        # The message names the field that fixes it, and the door that clears
+        # the marker when the source really did go public.
         assert "`token` field" in detail["message"]
         assert "request-only" in detail["message"]
+        assert "re-upload" in detail["message"]
 
-        # The probe went to the canonical service target for this service
-        # type, token-less, and ran exactly once.
+        # The probe went to the LAYER, once — the same resource the worker
+        # fetches, which is what makes its answer worth acting on.
         probe.assert_awaited_once()
-        target, service_type = probe.await_args.args
-        assert target == f"{_WFS_BASE}?service=WFS&request=GetCapabilities"
-        assert service_type == "wfs"
+        (target,) = probe.await_args.args
+        assert target == f"{_ARCGIS_BASE}/0"
 
         # Refused before the reservation: no run row, nothing deferred, and
         # so nothing holding the dataset against the admission index.
         assert await _run_for(test_db_session, dataset.id) is None
         task.defer_async.assert_not_awaited()
 
-    async def test_a_healthy_probe_lets_the_refresh_through(
+    async def test_a_healthy_layer_lets_the_refresh_through(
         self, client: AsyncClient, admin_auth_header: dict, test_db_session
     ) -> None:
         """The false-marker case, which is the whole reason for the probe.
@@ -482,9 +508,7 @@ class TestAuthRequiredRefusal:
         refresh until they went through the re-upload dialog.
         """
         admin_id = await get_user_id(test_db_session, "admin")
-        dataset = await _service_dataset(
-            test_db_session, created_by=admin_id, auth_required=True
-        )
+        dataset = await self._marked_arcgis(test_db_session, created_by=admin_id)
 
         async with _dispatch_harness() as task:
             async with _probe_harness(result=OriginProbeResult(HEALTHY)) as probe:
@@ -517,9 +541,7 @@ class TestAuthRequiredRefusal:
         worker is still there with copy that names the token field.
         """
         admin_id = await get_user_id(test_db_session, "admin")
-        dataset = await _service_dataset(
-            test_db_session, created_by=admin_id, auth_required=True
-        )
+        dataset = await self._marked_arcgis(test_db_session, created_by=admin_id)
 
         async with _dispatch_harness() as task:
             async with _probe_harness(result=outcome):
@@ -535,9 +557,7 @@ class TestAuthRequiredRefusal:
     ) -> None:
         """The guard cannot be the thing that 500s a request bound for 202."""
         admin_id = await get_user_id(test_db_session, "admin")
-        dataset = await _service_dataset(
-            test_db_session, created_by=admin_id, auth_required=True
-        )
+        dataset = await self._marked_arcgis(test_db_session, created_by=admin_id)
 
         async with _dispatch_harness() as task:
             async with _probe_harness(raises=RuntimeError("origin exploded")):
@@ -553,9 +573,7 @@ class TestAuthRequiredRefusal:
     ) -> None:
         """A token is request-only; nothing about it is ever reflected back."""
         admin_id = await get_user_id(test_db_session, "admin")
-        dataset = await _service_dataset(
-            test_db_session, created_by=admin_id, auth_required=True
-        )
+        dataset = await self._marked_arcgis(test_db_session, created_by=admin_id)
 
         async with _dispatch_harness():
             async with _probe_harness(
@@ -573,6 +591,170 @@ class TestAuthRequiredRefusal:
         assert "auth_required" not in resp.text
         await test_db_session.refresh(dataset)
         assert "token" not in str(dataset.origin_ref)
+
+    # ---------------------------------------------------------------- #
+    # WFS and OGC API: nothing reachable can answer the question
+    # ---------------------------------------------------------------- #
+
+    @pytest.mark.parametrize(
+        ("source_format", "base_url", "layer_id"),
+        [
+            ("wfs", _WFS_BASE, "topp:parcels"),
+            ("ogcapi_features", _OGCAPI_BASE, "parcels"),
+        ],
+        ids=["wfs", "ogcapi_features"],
+    )
+    async def test_a_marked_header_auth_service_is_refused_without_probing(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session,
+        source_format: str,
+        base_url: str,
+        layer_id: str,
+    ) -> None:
+        """fix(#1746 codex r2): a probe here could only ask the wrong question.
+
+        ``service_probe_target`` deliberately aims a WFS at GetCapabilities
+        and an OGC API at its landing page, because those are the documents
+        whose reachability describes the service. Neither is the resource the
+        worker fetches, and a public capabilities document in front of a
+        protected GetFeature is an ordinary deployment — so a healthy answer
+        would be evidence of nothing while reading as permission to proceed.
+        """
+        admin_id = await get_user_id(test_db_session, "admin")
+        dataset = await _service_dataset(
+            test_db_session,
+            created_by=admin_id,
+            source_format=source_format,
+            base_url=base_url,
+            layer_id=layer_id,
+            auth_required=True,
+        )
+
+        async with _dispatch_harness() as task:
+            async with _probe_harness() as probe:
+                resp = await client.post(
+                    f"/datasets/{dataset.id}/refresh", headers=admin_auth_header
+                )
+
+        assert resp.status_code == 422, resp.text
+        assert resp.json()["detail"]["code"] == "service_token_required"
+        # Not asked, because nothing it could reach would answer.
+        probe.assert_not_awaited()
+        assert await _run_for(test_db_session, dataset.id) is None
+        task.defer_async.assert_not_awaited()
+
+    async def test_the_header_auth_refusal_names_the_way_out(
+        self, client: AsyncClient, admin_auth_header: dict, test_db_session
+    ) -> None:
+        """The refusal must not read as a permanent trap.
+
+        A marked WFS that genuinely went public cannot clear itself through
+        this door, so the message has to name the one that still allows a
+        token-less pull.
+        """
+        admin_id = await get_user_id(test_db_session, "admin")
+        dataset = await _service_dataset(
+            test_db_session, created_by=admin_id, auth_required=True
+        )
+
+        async with _dispatch_harness():
+            async with _probe_harness():
+                resp = await client.post(
+                    f"/datasets/{dataset.id}/refresh", headers=admin_auth_header
+                )
+
+        message = resp.json()["detail"]["message"]
+        assert "re-upload" in message
+        assert "without a token" in message
+
+    # ---------------------------------------------------------------- #
+    # Session handling across the probe
+    # ---------------------------------------------------------------- #
+
+    async def test_the_session_is_released_across_the_probe_and_re_read_after(
+        self, client: AsyncClient, admin_auth_header: dict, test_db_session
+    ) -> None:
+        """fix(#1746 codex r2): the pool must not be held across the wait.
+
+        The probe can hold its full deadline against a slow origin, and a
+        session held across it pins one of the pool's connections — enough
+        concurrent marked refreshes would starve every other database-backed
+        request. ``check_source_health`` already releases; so does this.
+
+        The re-read afterwards is the other half. Rolling back expires the ORM
+        instance, and the lines below the guard read it
+        (``dataset.feature_count`` at the reservation, then a ``db.refresh``),
+        where an async lazy load raises rather than quietly re-querying.
+        """
+        admin_id = await get_user_id(test_db_session, "admin")
+        dataset = await self._marked_arcgis(test_db_session, created_by=admin_id)
+
+        calls: list[str] = []
+        real_get_dataset = router_refresh.get_dataset
+
+        async def _tracking_get_dataset(db, ds_id, *args, **kwargs):
+            calls.append("get_dataset")
+            return await real_get_dataset(db, ds_id, *args, **kwargs)
+
+        async def _probe(_target):
+            calls.append("probe")
+            return OriginProbeResult(HEALTHY)
+
+        real_rollback = AsyncSession.rollback
+
+        async def _tracking_rollback(self):
+            calls.append("rollback")
+            return await real_rollback(self)
+
+        with (
+            patch.object(router_refresh, "get_dataset", _tracking_get_dataset),
+            patch.object(router_refresh, "probe_arcgis_origin", _probe),
+            patch.object(AsyncSession, "rollback", _tracking_rollback),
+        ):
+            async with _dispatch_harness():
+                resp = await client.post(
+                    f"/datasets/{dataset.id}/refresh", headers=admin_auth_header
+                )
+
+        assert resp.status_code == 202, resp.text
+        # The door's own first read, then release, then the outbound wait,
+        # then the read that re-materializes what the rest of the handler
+        # touches. The ORDER is the property under test; what the request does
+        # after those four is not this test's business.
+        assert calls[:4] == ["get_dataset", "rollback", "probe", "get_dataset"], calls
+
+    async def test_the_header_auth_refusal_releases_nothing(
+        self, client: AsyncClient, admin_auth_header: dict, test_db_session
+    ) -> None:
+        """No network, no rollback. The refusal is a pure read of the marker."""
+        admin_id = await get_user_id(test_db_session, "admin")
+        dataset = await _service_dataset(
+            test_db_session, created_by=admin_id, auth_required=True
+        )
+
+        rolled_back: list[bool] = []
+        real_rollback = AsyncSession.rollback
+
+        async def _tracking_rollback(self):
+            rolled_back.append(True)
+            return await real_rollback(self)
+
+        with patch.object(AsyncSession, "rollback", _tracking_rollback):
+            async with _dispatch_harness():
+                async with _probe_harness() as probe:
+                    resp = await client.post(
+                        f"/datasets/{dataset.id}/refresh", headers=admin_auth_header
+                    )
+
+        assert resp.status_code == 422, resp.text
+        probe.assert_not_awaited()
+        assert rolled_back == []
+
+    # ---------------------------------------------------------------- #
+    # The paths that must cost nothing at all
+    # ---------------------------------------------------------------- #
 
     async def test_a_marked_dataset_with_a_token_still_dispatches(
         self,

--- a/backend/tests/test_service_refresh_1220.py
+++ b/backend/tests/test_service_refresh_1220.py
@@ -35,6 +35,7 @@ import pytest
 from httpx import AsyncClient
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm.attributes import set_committed_value
 
 from app.modules.catalog.datasets.api import router_refresh
 from app.modules.catalog.datasets.domain.schemas import DatasetRefreshRequest
@@ -751,6 +752,112 @@ class TestAuthRequiredRefusal:
         assert resp.status_code == 422, resp.text
         probe.assert_not_awaited()
         assert rolled_back == []
+
+    # ---------------------------------------------------------------- #
+    # The reservation window
+    # ---------------------------------------------------------------- #
+
+    @staticmethod
+    @asynccontextmanager
+    async def _marked_inside_the_reservation_window():
+        """Make the post-reservation re-read see a marker the pre-check did not.
+
+        The real race is an authenticated re-upload of the same origin
+        committing its swap between the door's first read and the read after
+        the reservation. Reproducing that with two racing sessions would be a
+        stopwatch test; setting the committed value on the door's own re-read
+        is the same observation without the flake. ``set_committed_value``
+        rather than plain assignment, so the instance is not left dirty and no
+        later flush can write the simulation back to the row.
+        """
+        real_refresh = AsyncSession.refresh
+        marked = {"done": False}
+
+        async def _refresh(self, instance, attribute_names=None, **kwargs):
+            await real_refresh(self, instance, attribute_names, **kwargs)
+            if marked["done"] or not attribute_names:
+                return
+            if "origin_ref" not in attribute_names:
+                return
+            marked["done"] = True
+            set_committed_value(
+                instance,
+                "origin_ref",
+                {**(instance.origin_ref or {}), "auth_required": True},
+            )
+
+        with patch.object(AsyncSession, "refresh", _refresh):
+            yield
+
+    async def test_a_marker_that_lands_during_the_reservation_is_caught(
+        self, client: AsyncClient, admin_auth_header: dict, test_db_session
+    ) -> None:
+        """fix(#1746 codex r3): the binding check cannot see this one.
+
+        An authenticated re-upload commits its swap while this refresh is
+        reserving. The origin did not move, so ``origin != candidate`` passes,
+        and without the recheck the dispatch goes out token-less into the
+        worker failure the whole guard exists to prevent.
+        """
+        admin_id = await get_user_id(test_db_session, "admin")
+        dataset = await _service_dataset(test_db_session, created_by=admin_id)
+        assert "auth_required" not in (dataset.origin_ref or {})
+
+        async with _dispatch_harness() as task:
+            async with _probe_harness() as probe:
+                async with self._marked_inside_the_reservation_window():
+                    resp = await client.post(
+                        f"/datasets/{dataset.id}/refresh", headers=admin_auth_header
+                    )
+
+        assert resp.status_code == 422, resp.text
+        assert resp.json()["detail"]["code"] == "service_token_required"
+        # Unmarked at the pre-check, so the pre-reservation guard had nothing
+        # to ask about and correctly did not.
+        probe.assert_not_awaited()
+        # The point: the token-less dispatch never left the door.
+        task.defer_async.assert_not_awaited()
+        # And the refusal released the dataset rather than leaving a run row
+        # holding the admission index against the retry that follows.
+        assert await _run_for(test_db_session, dataset.id) is None
+        jobs = (
+            (
+                await test_db_session.execute(
+                    select(IngestJob).where(IngestJob.dataset_id == dataset.id)
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert jobs == []
+
+    async def test_a_marker_landing_during_the_reservation_is_fine_with_a_token(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session,
+        credential_backend,
+    ) -> None:
+        """The recheck asks for a credential; it does not lock the dataset.
+
+        Same race, same window, but this caller sent the thing the marker is
+        asking for, so there is nothing to refuse.
+        """
+        admin_id = await get_user_id(test_db_session, "admin")
+        dataset = await _service_dataset(test_db_session, created_by=admin_id)
+
+        async with _dispatch_harness() as task:
+            async with _probe_harness():
+                async with self._marked_inside_the_reservation_window():
+                    resp = await client.post(
+                        f"/datasets/{dataset.id}/refresh",
+                        headers=admin_auth_header,
+                        json={"token": "tok-" + uuid.uuid4().hex},
+                    )
+
+        assert resp.status_code == 202, resp.text
+        task.defer_async.assert_awaited_once()
+        assert await _run_for(test_db_session, dataset.id) is not None
 
     # ---------------------------------------------------------------- #
     # The paths that must cost nothing at all

--- a/backend/tests/test_service_refresh_1220.py
+++ b/backend/tests/test_service_refresh_1220.py
@@ -132,6 +132,7 @@ async def _service_dataset(
     base_url: str = _WFS_BASE,
     layer_id: str | int = "topp:parcels",
     visibility: str = "public",
+    auth_required: bool = False,
 ):
     """A dataset bound to a service origin the way ingest binds one.
 
@@ -157,6 +158,9 @@ async def _service_dataset(
         service_type=source_format,
         url=base_url,
         layer_id=str(layer_id),
+        # fix(#1746): True or None, never False — the worker writes it this
+        # way at the swap and the key is simply absent for a public origin.
+        auth_required=True if auth_required else None,
     )
     await session.commit()
     await session.refresh(dataset)
@@ -378,6 +382,169 @@ class TestRefreshDispatch:
 # ---------------------------------------------------------------------------
 # Refusals
 # ---------------------------------------------------------------------------
+
+
+class TestAuthRequiredRefusal:
+    """fix(#1746) finding 3: the door refuses what the worker cannot do.
+
+    Before this, a credential-less refresh of an org-only service answered
+    202 and then failed ~0.5s later in the worker, where the only statement
+    of the real cause was a job error message nobody was watching. The
+    dataset carries a boolean marker (never a token) saying its last
+    successful pull needed a credential, and the door reads it.
+    """
+
+    async def test_a_marked_dataset_without_a_token_is_refused(
+        self, client: AsyncClient, admin_auth_header: dict, test_db_session
+    ) -> None:
+        admin_id = await get_user_id(test_db_session, "admin")
+        dataset = await _service_dataset(
+            test_db_session, created_by=admin_id, auth_required=True
+        )
+
+        async with _dispatch_harness() as task:
+            resp = await client.post(
+                f"/datasets/{dataset.id}/refresh", headers=admin_auth_header
+            )
+
+        assert resp.status_code == 422, resp.text
+        detail = resp.json()["detail"]
+        assert detail["code"] == "service_token_required"
+        # The message names the field that fixes it, and says why there is
+        # nothing on the server to un-expire.
+        assert "`token` field" in detail["message"]
+        assert "request-only" in detail["message"]
+
+        # Refused before the reservation: no run row, nothing deferred, and
+        # so nothing holding the dataset against the admission index.
+        assert await _run_for(test_db_session, dataset.id) is None
+        task.defer_async.assert_not_awaited()
+
+    async def test_the_refusal_never_echoes_a_credential(
+        self, client: AsyncClient, admin_auth_header: dict, test_db_session
+    ) -> None:
+        """A token is request-only; nothing about it is ever reflected back."""
+        admin_id = await get_user_id(test_db_session, "admin")
+        dataset = await _service_dataset(
+            test_db_session, created_by=admin_id, auth_required=True
+        )
+
+        async with _dispatch_harness():
+            resp = await client.post(
+                f"/datasets/{dataset.id}/refresh",
+                headers=admin_auth_header,
+                json={"token": None},
+            )
+
+        assert resp.status_code == 422, resp.text
+        # Structural rather than "this particular secret is absent": the
+        # refusal is composed from literals and reads one boolean.
+        assert "auth_required" not in resp.text
+        await test_db_session.refresh(dataset)
+        assert "token" not in str(dataset.origin_ref)
+
+    async def test_a_marked_dataset_with_a_token_still_dispatches(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session,
+        credential_backend,
+    ) -> None:
+        """The marker is a prompt for a credential, not a lock on the dataset."""
+        admin_id = await get_user_id(test_db_session, "admin")
+        dataset = await _service_dataset(
+            test_db_session, created_by=admin_id, auth_required=True
+        )
+
+        async with _dispatch_harness() as task:
+            resp = await client.post(
+                f"/datasets/{dataset.id}/refresh",
+                headers=admin_auth_header,
+                json={"token": "tok-" + uuid.uuid4().hex},
+            )
+
+        assert resp.status_code == 202, resp.text
+        task.defer_async.assert_awaited_once()
+        assert await _run_for(test_db_session, dataset.id) is not None
+
+    async def test_an_unmarked_dataset_without_a_token_still_dispatches(
+        self, client: AsyncClient, admin_auth_header: dict, test_db_session
+    ) -> None:
+        """No backfill is owed: an absent key means "not known to need auth".
+
+        Every dataset imported before the marker existed sits here, and each
+        one keeps refreshing exactly the way it did.
+        """
+        admin_id = await get_user_id(test_db_session, "admin")
+        dataset = await _service_dataset(test_db_session, created_by=admin_id)
+        assert "auth_required" not in (dataset.origin_ref or {})
+
+        async with _dispatch_harness() as task:
+            resp = await client.post(
+                f"/datasets/{dataset.id}/refresh", headers=admin_auth_header
+            )
+
+        assert resp.status_code == 202, resp.text
+        task.defer_async.assert_awaited_once()
+
+    async def test_a_stored_false_is_not_a_reason_to_refuse(
+        self, client: AsyncClient, admin_auth_header: dict, test_db_session
+    ) -> None:
+        """``is True``, not truthiness — the same rule ``managed`` reads by."""
+        admin_id = await get_user_id(test_db_session, "admin")
+        dataset = await _service_dataset(test_db_session, created_by=admin_id)
+        dataset.origin_ref = {**(dataset.origin_ref or {}), "auth_required": False}
+        await test_db_session.commit()
+
+        async with _dispatch_harness():
+            resp = await client.post(
+                f"/datasets/{dataset.id}/refresh", headers=admin_auth_header
+            )
+
+        assert resp.status_code == 202, resp.text
+
+    @pytest.mark.parametrize(
+        ("source_format", "record_type"),
+        [
+            (None, "vector_dataset"),  # registered postgis table
+            ("stac", "vector_dataset"),
+            ("geojson", "vector_dataset"),  # upload
+            ("wfs", "vrt_dataset"),  # originless record type
+        ],
+        ids=["postgis", "stac", "upload", "vrt"],
+    )
+    async def test_a_non_service_origin_can_never_reach_the_refusal(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session,
+        source_format: str | None,
+        record_type: str,
+    ) -> None:
+        """The placement claim, stated as behaviour.
+
+        The check sits after the postgis and stac early returns and after
+        ``_resolve_service_origin``, so a stray ``auth_required`` on a row of
+        any other kind is inert. The allowlist would never write one there;
+        the JSONB column would happily store one.
+        """
+        admin_id = await get_user_id(test_db_session, "admin")
+        dataset = await _create_dataset(
+            test_db_session, created_by=admin_id, source_format=source_format
+        )
+        dataset.record.record_type = record_type
+        dataset.origin_ref = {"auth_required": True}
+        await test_db_session.commit()
+
+        async with _dispatch_harness():
+            resp = await client.post(
+                f"/datasets/{dataset.id}/refresh", headers=admin_auth_header
+            )
+
+        body = resp.json()
+        detail = body.get("detail")
+        code = detail.get("code") if isinstance(detail, dict) else None
+        assert code != "service_token_required", resp.text
 
 
 class TestRefreshRefusals:

--- a/backend/tests/test_source_health_1222.py
+++ b/backend/tests/test_source_health_1222.py
@@ -892,23 +892,77 @@ class TestArcgisAuthEnvelope:
         assert result.detail == AUTH_REQUIRED
         assert result.ok is False
 
-    async def test_a_normal_layer_document_stays_healthy(self, probe_transport) -> None:
+    async def test_a_public_layer_document_does_not_clear_a_gated_query(
+        self, probe_transport
+    ) -> None:
+        """fix(#1746 codex r6): the exact deployment the old target missed.
+
+        Serving layer metadata anonymously while requiring a token to run a
+        query is an ordinary ArcGIS configuration. The old probe read the
+        document, saw a healthy 200, and dispatched a refresh that the worker
+        could only fail — the metadata endpoint is not the one it reads.
+        """
         install, recorded = probe_transport
-        install(_json_body({"id": 0, "name": "roads", "type": "Feature Layer"}))
+
+        def _public_metadata_gated_query(request: httpx.Request) -> httpx.Response:
+            if request.url.path.endswith("/query"):
+                return httpx.Response(
+                    200, json={"error": {"code": 499, "message": "Token Required"}}
+                )
+            return httpx.Response(200, json={"id": 0, "name": "roads"})
+
+        install(_public_metadata_gated_query)
+        result = await probe_arcgis_origin(self._LAYER_URI)
+
+        assert result.health == INACCESSIBLE
+        assert result.detail == AUTH_REQUIRED
+        # And it never asked the endpoint that would have lied to it.
+        assert [r.url.path.endswith("/query") for r in recorded] == [True]
+
+    async def test_a_healthy_count_answer_probes_the_query_operation(
+        self, probe_transport
+    ) -> None:
+        """fix(#1746 codex r6): the probe asks what the WORKER asks.
+
+        ``build_gdal_source`` composes ``<layer>/query?...`` and that is what
+        ogr2ogr fetches. A service that serves the layer DOCUMENT publicly and
+        gates ``/query`` is an ordinary deployment, and probing the document
+        would clear it and hand it to the worker to fail on.
+        """
+        install, recorded = probe_transport
+        install(_json_body({"count": 4127}))
         result = await probe_arcgis_origin(self._LAYER_URI)
         assert result.health == HEALTHY
         assert result.detail is None
         assert len(recorded) == 1
+        assert recorded[0].url.path.endswith("/query")
+        assert recorded[0].url.params["returnCountOnly"] == "true"
+        assert recorded[0].url.params["where"] == "1=1"
         assert recorded[0].url.params["f"] == "json"
+        # Token-less by construction: the door only probes when the request
+        # carried no token, and the health endpoint never has one.
+        assert "token" not in recorded[0].url.params
 
-    async def test_a_url_that_already_carries_f_is_not_doubled(
-        self, probe_transport
+    @pytest.mark.parametrize(
+        "stored",
+        ["?f=html", "/", "/query", "#frag"],
+        ids=["query_string", "trailing_slash", "already_query", "fragment"],
+    )
+    async def test_a_stored_pointer_is_normalized_before_the_query_is_composed(
+        self, probe_transport, stored: str
     ) -> None:
-        """``copy_set_param`` replaces rather than appends."""
+        """``origin_uri`` is provenance, not a curated endpoint.
+
+        It can arrive with a query string, a fragment, a trailing slash, or an
+        already-appended ``/query``. Every one of those has to compose to the
+        same endpoint rather than to ``.../0?f=html/query?...``.
+        """
         install, recorded = probe_transport
-        install(_json_body({"id": 0, "name": "roads"}))
-        await probe_arcgis_origin(f"{self._LAYER_URI}?f=html")
+        install(_json_body({"count": 1}))
+        await probe_arcgis_origin(f"{self._LAYER_URI}{stored}")
+        assert str(recorded[0].url).startswith(f"{self._LAYER_URI}/query?")
         assert recorded[0].url.params.get_list("f") == ["json"]
+        assert recorded[0].url.params["returnCountOnly"] == "true"
 
     async def test_a_non_auth_envelope_is_left_alone(self, probe_transport) -> None:
         """Only 498 and 499 are read.
@@ -918,7 +972,7 @@ class TestArcgisAuthEnvelope:
         would report ``missing`` for services that still answer.
         """
         install, _ = probe_transport
-        install(_json_body({"error": {"code": 400, "message": "Invalid layer"}}))
+        install(_json_body({"error": {"code": 400, "message": "Invalid where"}}))
         result = await probe_arcgis_origin(self._LAYER_URI)
         assert result.health == HEALTHY
 
@@ -948,13 +1002,14 @@ class TestArcgisAuthEnvelope:
         assert result.health == INACCESSIBLE
         assert result.detail == UNEXPECTED_STATUS
 
-    def _oversized_layer_document(self) -> dict:
-        """A VALID layer document that runs past ``MAX_DOCUMENT_BYTES``.
+    def _oversized_document(self) -> dict:
+        """A VALID ArcGIS document that runs past ``MAX_DOCUMENT_BYTES``.
 
-        Not a contrived blob. A FeatureServer layer with a long field list and
-        coded-value domains on those fields is exactly the shape that gets
-        there, which is why the size cap and the envelope check collide at
-        all.
+        Shaped as a layer with a long field list and coded-value domains,
+        because that is the real thing that gets there. The probe asks
+        ``/query`` now (fix #1746 codex r6), whose answer is a single count
+        and could never be this big — which is exactly why an oversized body
+        cannot be an auth envelope either, and is read as reachable.
         """
         return {
             "id": 0,
@@ -993,7 +1048,7 @@ class TestArcgisAuthEnvelope:
         cannot be one. That is the whole argument, and it is arithmetic rather
         than a guess.
         """
-        payload = self._oversized_layer_document()
+        payload = self._oversized_document()
         # Positive control on the fixture: if this stops exceeding the cap,
         # the test below would pass while exercising nothing.
         assert len(json.dumps(payload).encode()) > MAX_DOCUMENT_BYTES
@@ -1018,7 +1073,7 @@ class TestArcgisAuthEnvelope:
         in the origin's favour.
         """
         install, _ = probe_transport
-        install(_json_body(self._oversized_layer_document()))
+        install(_json_body(self._oversized_document()))
         result, body, _url = await fetch_json_document(_ITEM)
 
         assert result.health == INACCESSIBLE
@@ -1055,7 +1110,7 @@ class TestArcgisAuthEnvelope:
         self, client, admin_auth_header, test_db_session, probe_transport
     ) -> None:
         install, _ = probe_transport
-        install(_json_body(self._oversized_layer_document()))
+        install(_json_body(self._oversized_document()))
         admin_id = await get_user_id(test_db_session, "admin")
         dataset = await _service_dataset(test_db_session, created_by=admin_id)
 
@@ -1101,9 +1156,11 @@ class TestServiceOriginProbe:
         self, client, admin_auth_header, test_db_session, probe_transport
     ) -> None:
         install, recorded = probe_transport
-        # fix(#1746): the ArcGIS branch now reads the body, so the double has
-        # to answer with a real layer document rather than an empty 200.
-        install(_json_body({"id": 0, "name": "roads", "type": "Feature Layer"}))
+        # fix(#1746): the ArcGIS branch reads the body, so the double has to
+        # answer with a real document rather than an empty 200. fix(#1746
+        # codex r6): and the thing asked is the count query, so that is what
+        # comes back.
+        install(_json_body({"count": 4127}))
         admin_id = await get_user_id(test_db_session, "admin")
         dataset = await _service_dataset(test_db_session, created_by=admin_id)
 
@@ -1113,12 +1170,15 @@ class TestServiceOriginProbe:
         assert resp.status_code == 200, resp.text
         assert resp.json()["origin"] == "service"
         assert resp.json()["source_health"] == HEALTHY
-        # Bounded: the layer endpoint, once. For ArcGIS the enriched
-        # origin_uri IS the layer resource, so it is the sharper probe target.
-        # fix(#1746): asked as `?f=json` rather than a ranged GET, because the
-        # error envelope only exists in the JSON representation.
+        # Bounded: one request, to the operation the worker depends on. The
+        # enriched origin_uri identifies the layer; the probe composes the
+        # `/query` from it. Asked as JSON rather than as a ranged GET, because
+        # the error envelope only exists in the JSON representation.
         assert len(recorded) == 1
-        assert str(recorded[0].url) == "https://origin.test/FeatureServer/0?f=json"
+        assert (
+            str(recorded[0].url) == "https://origin.test/FeatureServer/0/query"
+            "?where=1%3D1&returnCountOnly=true&f=json"
+        )
         assert "Range" not in recorded[0].headers
 
     async def test_mid_probe_rebind_discards_the_stale_verdict(

--- a/backend/tests/test_source_health_1222.py
+++ b/backend/tests/test_source_health_1222.py
@@ -43,6 +43,7 @@ from httpx import AsyncClient
 
 from app.modules.catalog.sources.adapters.stac import self_link_href
 from app.modules.catalog.sources.origin_probe import (
+    AUTH_REQUIRED,
     BLOCKED_BY_POLICY,
     DETAIL_CODES,
     HEALTHY,
@@ -55,6 +56,7 @@ from app.modules.catalog.sources.origin_probe import (
     TIMEOUT,
     UNAUTHORIZED,
     UNEXPECTED_STATUS,
+    probe_arcgis_service,
     probe_remote_uri,
     remote_asset_exists,
 )
@@ -100,6 +102,20 @@ def _status_map(mapping: dict[str, int], default: int = 200):
 
     def _handler(request: httpx.Request) -> httpx.Response:
         return httpx.Response(mapping.get(str(request.url), default))
+
+    return _handler
+
+
+def _json_body(payload, status: int = 200):
+    """fix(#1746): handler answering every URL with one JSON document.
+
+    The ArcGIS branch reads the body, so ``_status_map``'s empty response is
+    not a usable double for it — an empty body parses as neither an error
+    envelope nor a layer document.
+    """
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(status, json=payload)
 
     return _handler
 
@@ -846,12 +862,122 @@ class TestStacOriginProbe:
         assert resp.json()["source_health_detail"] == NOT_FOUND
 
 
+class TestArcgisAuthEnvelope:
+    """fix(#1746) finding 12: ArcGIS puts an auth refusal inside an HTTP 200.
+
+    A status-code probe reads 499 "Token Required" as healthy, so an org-only
+    layer that GeoLens can no longer read reports as fine. The health VALUE
+    stays ``inaccessible`` — the column's CHECK constraint pins three values
+    and a fourth would cost a migration — and the new information rides on
+    the detail code, which is a code and not a sentence for the same reason
+    every other one is.
+    """
+
+    _LAYER_URI = "https://origin.test/FeatureServer/0"
+
+    async def test_the_new_code_is_in_the_closed_vocabulary(self) -> None:
+        assert AUTH_REQUIRED in DETAIL_CODES
+
+    @pytest.mark.parametrize("code", [498, 499])
+    async def test_an_auth_envelope_inside_a_200_is_inaccessible(
+        self, probe_transport, code: int
+    ) -> None:
+        install, _ = probe_transport
+        install(_json_body({"error": {"code": code, "message": "Token Required"}}))
+        result = await probe_arcgis_service(self._LAYER_URI)
+        assert result.health == INACCESSIBLE
+        assert result.detail == AUTH_REQUIRED
+        assert result.ok is False
+
+    async def test_a_normal_layer_document_stays_healthy(self, probe_transport) -> None:
+        install, recorded = probe_transport
+        install(_json_body({"id": 0, "name": "roads", "type": "Feature Layer"}))
+        result = await probe_arcgis_service(self._LAYER_URI)
+        assert result.health == HEALTHY
+        assert result.detail is None
+        assert len(recorded) == 1
+        assert recorded[0].url.params["f"] == "json"
+
+    async def test_a_url_that_already_carries_f_is_not_doubled(
+        self, probe_transport
+    ) -> None:
+        """``copy_set_param`` replaces rather than appends."""
+        install, recorded = probe_transport
+        install(_json_body({"id": 0, "name": "roads"}))
+        await probe_arcgis_service(f"{self._LAYER_URI}?f=html")
+        assert recorded[0].url.params.get_list("f") == ["json"]
+
+    async def test_a_non_auth_envelope_is_left_alone(self, probe_transport) -> None:
+        """Only 498 and 499 are read.
+
+        Parsing the rest of the ArcGIS error space is the connector-
+        completeness contract ADR-002 leaves out of v1, and guessing at it
+        would report ``missing`` for services that still answer.
+        """
+        install, _ = probe_transport
+        install(_json_body({"error": {"code": 400, "message": "Invalid layer"}}))
+        result = await probe_arcgis_service(self._LAYER_URI)
+        assert result.health == HEALTHY
+
+    async def test_a_transport_verdict_still_wins(self, probe_transport) -> None:
+        """A 404 is still ``missing``; the envelope check runs after the status."""
+        install, _ = probe_transport
+        install(_status_map({}, default=404))
+        result = await probe_arcgis_service(self._LAYER_URI)
+        assert result.health == MISSING
+        assert result.detail == NOT_FOUND
+
+    async def test_a_non_json_body_is_no_longer_called_healthy(
+        self, probe_transport
+    ) -> None:
+        """The accepted behavior change, pinned.
+
+        A FeatureServer answering ``?f=json`` with HTML is broken, and the
+        honest verdict is the new one rather than the ranged GET's ``healthy``.
+        """
+        install, _ = probe_transport
+
+        def _html(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, text="<html>login</html>")
+
+        install(_html)
+        result = await probe_arcgis_service(self._LAYER_URI)
+        assert result.health == INACCESSIBLE
+        assert result.detail == UNEXPECTED_STATUS
+
+    async def test_end_to_end_persists_auth_required_and_leaks_nothing(
+        self, client, admin_auth_header, test_db_session, probe_transport
+    ) -> None:
+        install, _ = probe_transport
+        install(_json_body({"error": {"code": 499, "message": "Token Required"}}))
+        admin_id = await get_user_id(test_db_session, "admin")
+        dataset = await _service_dataset(test_db_session, created_by=admin_id)
+
+        resp = await client.post(
+            f"/datasets/{dataset.id}/source-health/", headers=admin_auth_header
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["origin"] == "service"
+        assert body["source_health"] == INACCESSIBLE
+        assert body["source_health_detail"] == AUTH_REQUIRED
+        # The closed vocabulary is the leak guarantee: no provider text.
+        assert "Token Required" not in resp.text
+
+        await test_db_session.refresh(dataset)
+        assert dataset.source_health == INACCESSIBLE
+        assert dataset.source_health_detail in DETAIL_CODES
+        assert dataset.source_health_detail == AUTH_REQUIRED
+
+
 class TestServiceOriginProbe:
     async def test_reachable_service_endpoint_is_healthy(
         self, client, admin_auth_header, test_db_session, probe_transport
     ) -> None:
         install, recorded = probe_transport
-        install(_status_map({}, default=200))
+        # fix(#1746): the ArcGIS branch now reads the body, so the double has
+        # to answer with a real layer document rather than an empty 200.
+        install(_json_body({"id": 0, "name": "roads", "type": "Feature Layer"}))
         admin_id = await get_user_id(test_db_session, "admin")
         dataset = await _service_dataset(test_db_session, created_by=admin_id)
 
@@ -861,11 +987,13 @@ class TestServiceOriginProbe:
         assert resp.status_code == 200, resp.text
         assert resp.json()["origin"] == "service"
         assert resp.json()["source_health"] == HEALTHY
-        # Bounded: the layer endpoint, once, ranged. For ArcGIS the enriched
+        # Bounded: the layer endpoint, once. For ArcGIS the enriched
         # origin_uri IS the layer resource, so it is the sharper probe target.
+        # fix(#1746): asked as `?f=json` rather than a ranged GET, because the
+        # error envelope only exists in the JSON representation.
         assert len(recorded) == 1
-        assert str(recorded[0].url) == "https://origin.test/FeatureServer/0"
-        assert recorded[0].headers["Range"] == "bytes=0-0"
+        assert str(recorded[0].url) == "https://origin.test/FeatureServer/0?f=json"
+        assert "Range" not in recorded[0].headers
 
     async def test_mid_probe_rebind_discards_the_stale_verdict(
         self, client, admin_auth_header, test_db_session, monkeypatch
@@ -888,6 +1016,12 @@ class TestServiceOriginProbe:
 
         monkeypatch.setattr(
             router_health, "probe_remote_uri", rebind_then_report_healthy
+        )
+        # fix(#1746): the default fixture dataset is ArcGIS, which now routes
+        # to the envelope probe. Both names are patched so this test keeps
+        # asserting the rebind property rather than which probe ran.
+        monkeypatch.setattr(
+            router_health, "probe_arcgis_service", rebind_then_report_healthy
         )
 
         resp = await client.post(
@@ -931,6 +1065,9 @@ class TestServiceOriginProbe:
             str(recorded[0].url)
             == "https://origin.test/wfs?service=WFS&request=GetCapabilities"
         )
+        # fix(#1746): still the ranged GET. Only the ArcGIS branch moved to a
+        # body-reading fetch; a WFS origin has no error envelope to read.
+        assert recorded[0].headers["Range"] == "bytes=0-0"
 
     async def test_legacy_wfs_row_without_a_base_url_refuses_to_probe(
         self, client, admin_auth_header, test_db_session, probe_transport

--- a/backend/tests/test_source_health_1222.py
+++ b/backend/tests/test_source_health_1222.py
@@ -1009,19 +1009,16 @@ class TestServiceOriginProbe:
         admin_id = await get_user_id(test_db_session, "admin")
         dataset = await _service_dataset(test_db_session, created_by=admin_id)
 
-        async def rebind_then_report_healthy(_uri) -> OriginProbeResult:
+        async def rebind_then_report_healthy(*_args, **_kwargs) -> OriginProbeResult:
             set_dataset_origin(dataset, "upload", filename="roads.gpkg")
             await test_db_session.commit()
             return OriginProbeResult(HEALTHY, None)
 
+        # fix(#1746): every service origin now goes through the one helper
+        # that picks a probe by service type, so this patches that rather than
+        # a specific probe and keeps asserting the rebind property.
         monkeypatch.setattr(
-            router_health, "probe_remote_uri", rebind_then_report_healthy
-        )
-        # fix(#1746): the default fixture dataset is ArcGIS, which now routes
-        # to the envelope probe. Both names are patched so this test keeps
-        # asserting the rebind property rather than which probe ran.
-        monkeypatch.setattr(
-            router_health, "probe_arcgis_service", rebind_then_report_healthy
+            router_health, "probe_service_origin", rebind_then_report_healthy
         )
 
         resp = await client.post(

--- a/backend/tests/test_source_health_1222.py
+++ b/backend/tests/test_source_health_1222.py
@@ -34,6 +34,7 @@ Six properties this suite exists to hold:
 from __future__ import annotations
 
 import asyncio
+import json
 import uuid
 from datetime import datetime, timedelta, timezone
 
@@ -49,6 +50,7 @@ from app.modules.catalog.sources.origin_probe import (
     HEALTHY,
     INACCESSIBLE,
     ITEM_WITHDRAWN,
+    MAX_DOCUMENT_BYTES,
     MISSING,
     NETWORK_ERROR,
     NOT_FOUND,
@@ -56,6 +58,7 @@ from app.modules.catalog.sources.origin_probe import (
     TIMEOUT,
     UNAUTHORIZED,
     UNEXPECTED_STATUS,
+    fetch_json_document,
     probe_arcgis_origin,
     probe_remote_uri,
     remote_asset_exists,
@@ -944,6 +947,129 @@ class TestArcgisAuthEnvelope:
         result = await probe_arcgis_origin(self._LAYER_URI)
         assert result.health == INACCESSIBLE
         assert result.detail == UNEXPECTED_STATUS
+
+    def _oversized_layer_document(self) -> dict:
+        """A VALID layer document that runs past ``MAX_DOCUMENT_BYTES``.
+
+        Not a contrived blob. A FeatureServer layer with a long field list and
+        coded-value domains on those fields is exactly the shape that gets
+        there, which is why the size cap and the envelope check collide at
+        all.
+        """
+        return {
+            "id": 0,
+            "name": "roads",
+            "type": "Feature Layer",
+            "fields": [
+                {
+                    "name": f"field_{i}",
+                    "alias": f"Field number {i}",
+                    "type": "esriFieldTypeString",
+                    "domain": {
+                        "type": "codedValue",
+                        "name": f"domain_{i}",
+                        "codedValues": [
+                            {"name": f"coded value number {j}", "code": j}
+                            for j in range(60)
+                        ],
+                    },
+                }
+                for i in range(1200)
+            ],
+        }
+
+    async def test_a_body_too_large_to_parse_is_reachable_not_inaccessible(
+        self, probe_transport
+    ) -> None:
+        """fix(#1746 codex post-rebase): the false negative that mirrors the bug.
+
+        ``fetch_json_document`` stops reading at ``MAX_DOCUMENT_BYTES``, a cap
+        sized for STAC item documents. A real ArcGIS layer with a long field
+        list runs past it, and before this the probe reported that layer
+        ``inaccessible`` — a healthy HTTP 200 called unreachable because it
+        answered at length.
+
+        An auth envelope is a few hundred bytes, so a body too big to parse
+        cannot be one. That is the whole argument, and it is arithmetic rather
+        than a guess.
+        """
+        payload = self._oversized_layer_document()
+        # Positive control on the fixture: if this stops exceeding the cap,
+        # the test below would pass while exercising nothing.
+        assert len(json.dumps(payload).encode()) > MAX_DOCUMENT_BYTES
+
+        install, recorded = probe_transport
+        install(_json_body(payload))
+        result = await probe_arcgis_origin(self._LAYER_URI)
+
+        assert result.health == HEALTHY
+        assert result.detail is None
+        assert result.ok is True
+        assert len(recorded) == 1
+
+    async def test_the_size_cap_still_stands_for_everyone_else(
+        self, probe_transport
+    ) -> None:
+        """The limit is not raised, only read differently by one caller.
+
+        STAC re-resolution needs the body it asked for, so an oversized item
+        document is still a verdict it cannot act on. Only the ArcGIS probe,
+        which reads the body for one specific small thing, resolves a hit cap
+        in the origin's favour.
+        """
+        install, _ = probe_transport
+        install(_json_body(self._oversized_layer_document()))
+        result, body, _url = await fetch_json_document(_ITEM)
+
+        assert result.health == INACCESSIBLE
+        assert result.detail == UNEXPECTED_STATUS
+        assert body is None
+        # The internal signal the ArcGIS probe reads. Not a detail code: the
+        # persisted vocabulary is a wire contract, and this is not on it.
+        assert result.oversized is True
+        assert result.detail in DETAIL_CODES
+
+    async def test_an_unreadable_body_is_not_confused_with_an_oversized_one(
+        self, probe_transport
+    ) -> None:
+        """Same verdict, different fact, and the ArcGIS probe needs the split.
+
+        A short HTML error page is still ``inaccessible`` for ArcGIS: it fits
+        inside the cap, so it COULD have carried an envelope and did not.
+        """
+        install, _ = probe_transport
+
+        def _html(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, text="<html>login</html>")
+
+        install(_html)
+        result, _body, _url = await fetch_json_document(_ITEM)
+        assert result.oversized is False
+
+        install(_html)
+        arcgis = await probe_arcgis_origin(self._LAYER_URI)
+        assert arcgis.health == INACCESSIBLE
+        assert arcgis.detail == UNEXPECTED_STATUS
+
+    async def test_end_to_end_an_oversized_layer_reports_healthy(
+        self, client, admin_auth_header, test_db_session, probe_transport
+    ) -> None:
+        install, _ = probe_transport
+        install(_json_body(self._oversized_layer_document()))
+        admin_id = await get_user_id(test_db_session, "admin")
+        dataset = await _service_dataset(test_db_session, created_by=admin_id)
+
+        resp = await client.post(
+            f"/datasets/{dataset.id}/source-health/", headers=admin_auth_header
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["source_health"] == HEALTHY
+        assert body["source_health_detail"] is None
+
+        await test_db_session.refresh(dataset)
+        assert dataset.source_health == HEALTHY
+        assert dataset.source_health_detail is None
 
     async def test_end_to_end_persists_auth_required_and_leaks_nothing(
         self, client, admin_auth_header, test_db_session, probe_transport

--- a/backend/tests/test_source_health_1222.py
+++ b/backend/tests/test_source_health_1222.py
@@ -56,7 +56,7 @@ from app.modules.catalog.sources.origin_probe import (
     TIMEOUT,
     UNAUTHORIZED,
     UNEXPECTED_STATUS,
-    probe_arcgis_service,
+    probe_arcgis_origin,
     probe_remote_uri,
     remote_asset_exists,
 )
@@ -884,7 +884,7 @@ class TestArcgisAuthEnvelope:
     ) -> None:
         install, _ = probe_transport
         install(_json_body({"error": {"code": code, "message": "Token Required"}}))
-        result = await probe_arcgis_service(self._LAYER_URI)
+        result = await probe_arcgis_origin(self._LAYER_URI)
         assert result.health == INACCESSIBLE
         assert result.detail == AUTH_REQUIRED
         assert result.ok is False
@@ -892,7 +892,7 @@ class TestArcgisAuthEnvelope:
     async def test_a_normal_layer_document_stays_healthy(self, probe_transport) -> None:
         install, recorded = probe_transport
         install(_json_body({"id": 0, "name": "roads", "type": "Feature Layer"}))
-        result = await probe_arcgis_service(self._LAYER_URI)
+        result = await probe_arcgis_origin(self._LAYER_URI)
         assert result.health == HEALTHY
         assert result.detail is None
         assert len(recorded) == 1
@@ -904,7 +904,7 @@ class TestArcgisAuthEnvelope:
         """``copy_set_param`` replaces rather than appends."""
         install, recorded = probe_transport
         install(_json_body({"id": 0, "name": "roads"}))
-        await probe_arcgis_service(f"{self._LAYER_URI}?f=html")
+        await probe_arcgis_origin(f"{self._LAYER_URI}?f=html")
         assert recorded[0].url.params.get_list("f") == ["json"]
 
     async def test_a_non_auth_envelope_is_left_alone(self, probe_transport) -> None:
@@ -916,14 +916,14 @@ class TestArcgisAuthEnvelope:
         """
         install, _ = probe_transport
         install(_json_body({"error": {"code": 400, "message": "Invalid layer"}}))
-        result = await probe_arcgis_service(self._LAYER_URI)
+        result = await probe_arcgis_origin(self._LAYER_URI)
         assert result.health == HEALTHY
 
     async def test_a_transport_verdict_still_wins(self, probe_transport) -> None:
         """A 404 is still ``missing``; the envelope check runs after the status."""
         install, _ = probe_transport
         install(_status_map({}, default=404))
-        result = await probe_arcgis_service(self._LAYER_URI)
+        result = await probe_arcgis_origin(self._LAYER_URI)
         assert result.health == MISSING
         assert result.detail == NOT_FOUND
 
@@ -941,7 +941,7 @@ class TestArcgisAuthEnvelope:
             return httpx.Response(200, text="<html>login</html>")
 
         install(_html)
-        result = await probe_arcgis_service(self._LAYER_URI)
+        result = await probe_arcgis_origin(self._LAYER_URI)
         assert result.health == INACCESSIBLE
         assert result.detail == UNEXPECTED_STATUS
 

--- a/frontend/src/components/dataset/SourcePanel.tsx
+++ b/frontend/src/components/dataset/SourcePanel.tsx
@@ -67,7 +67,10 @@ type HealthDetail =
   | 'unexpected_status'
   | 'timeout'
   | 'network_error'
-  | 'blocked_by_policy';
+  | 'blocked_by_policy'
+  // fix(#1746): separate from 'unauthorized', whose copy says the source "now
+  // requires" access — wrong for a service that has been org-only all along.
+  | 'auth_required';
 
 const HEALTH_DETAILS = new Set<HealthDetail>([
   'not_found',
@@ -78,6 +81,7 @@ const HEALTH_DETAILS = new Set<HealthDetail>([
   'timeout',
   'network_error',
   'blocked_by_policy',
+  'auth_required',
 ]);
 
 const healthClasses: Record<SourceHealth, string> = {

--- a/frontend/src/components/dataset/__tests__/SourcePanel.test.tsx
+++ b/frontend/src/components/dataset/__tests__/SourcePanel.test.tsx
@@ -468,6 +468,26 @@ describe('SourcePanel', () => {
     expect(container.innerHTML).not.toContain('Bearer hidden');
   });
 
+  // fix(#1746): the panel renders null for a detail code it does not know, so
+  // a backend code with no entry here is invisible rather than obviously
+  // broken. This is the assertion that notices.
+  it('renders the auth_required detail rather than nothing', () => {
+    render(
+      <SourcePanel
+        dataset={makeDataset({
+          origin: 'service',
+          source_format: 'arcgis_featureserver',
+          source_health: 'inaccessible',
+          source_health_detail: 'auth_required',
+        })}
+      />,
+    );
+
+    expect(screen.getByText('The source requires a service token GeoLens does not have.')).toBeInTheDocument();
+    // Distinct from 'unauthorized', whose copy claims the source CHANGED.
+    expect(screen.queryByText('The source now requires access GeoLens does not have.')).not.toBeInTheDocument();
+  });
+
   it('suppresses an origin_ref whose discriminator does not match the dataset origin', () => {
     const { container } = render(
       <SourcePanel

--- a/frontend/src/i18n/locales/de/dataset.json
+++ b/frontend/src/i18n/locales/de/dataset.json
@@ -808,7 +808,8 @@
       "unexpected_status": "Die Quelle hat eine unerwartete Antwort zurückgegeben.",
       "timeout": "Die Quelle hat nicht rechtzeitig geantwortet.",
       "network_error": "GeoLens konnte die Quelle nicht erreichen.",
-      "blocked_by_policy": "Die GeoLens-Sicherheitsrichtlinie hat diese Quelle blockiert."
+      "blocked_by_policy": "Die GeoLens-Sicherheitsrichtlinie hat diese Quelle blockiert.",
+      "auth_required": "Die Quelle erfordert ein Dienst-Token, das GeoLens nicht besitzt."
     },
     "history": {
       "title": "Quellverlauf",

--- a/frontend/src/i18n/locales/en/dataset.json
+++ b/frontend/src/i18n/locales/en/dataset.json
@@ -759,7 +759,8 @@
       "unexpected_status": "The source returned an unexpected response.",
       "timeout": "The source did not respond in time.",
       "network_error": "GeoLens could not reach the source.",
-      "blocked_by_policy": "GeoLens security policy blocked this source."
+      "blocked_by_policy": "GeoLens security policy blocked this source.",
+      "auth_required": "The source requires a service token GeoLens does not have."
     },
     "history": {
       "title": "Source history",

--- a/frontend/src/i18n/locales/es/dataset.json
+++ b/frontend/src/i18n/locales/es/dataset.json
@@ -808,7 +808,8 @@
       "unexpected_status": "La fuente devolvió una respuesta inesperada.",
       "timeout": "La fuente no respondió a tiempo.",
       "network_error": "GeoLens no pudo conectar con la fuente.",
-      "blocked_by_policy": "La política de seguridad de GeoLens bloqueó esta fuente."
+      "blocked_by_policy": "La política de seguridad de GeoLens bloqueó esta fuente.",
+      "auth_required": "La fuente requiere un token de servicio que GeoLens no tiene."
     },
     "history": {
       "title": "Historial de la fuente",

--- a/frontend/src/i18n/locales/fr/dataset.json
+++ b/frontend/src/i18n/locales/fr/dataset.json
@@ -808,7 +808,8 @@
       "unexpected_status": "La source a renvoyé une réponse inattendue.",
       "timeout": "La source n’a pas répondu à temps.",
       "network_error": "GeoLens n’a pas pu joindre la source.",
-      "blocked_by_policy": "La politique de sécurité de GeoLens a bloqué cette source."
+      "blocked_by_policy": "La politique de sécurité de GeoLens a bloqué cette source.",
+      "auth_required": "La source exige un jeton de service dont GeoLens ne dispose pas."
     },
     "history": {
       "title": "Historique de la source",

--- a/frontend/src/types/api.generated.ts
+++ b/frontend/src/types/api.generated.ts
@@ -7772,7 +7772,7 @@ export interface components {
             source_health: string;
             /**
              * Source Health Detail
-             * @description Why the origin is not healthy, as one of a fixed set of GeoLens codes: blocked_by_policy, item_withdrawn, network_error, not_found, server_error, timeout, unauthorized, unexpected_status. Null when healthy or never probed. Never provider text, a URL, or a response body — nothing the origin sent is stored here.
+             * @description Why the origin is not healthy, as one of a fixed set of GeoLens codes: auth_required, blocked_by_policy, item_withdrawn, network_error, not_found, server_error, timeout, unauthorized, unexpected_status. Null when healthy or never probed. Never provider text, a URL, or a response body — nothing the origin sent is stored here.
              */
             source_health_detail?: string | null;
             /**
@@ -11992,7 +11992,7 @@ export interface components {
             source_health: "healthy" | "missing" | "inaccessible";
             /**
              * Source Health Detail
-             * @description Why the origin is not healthy, as one of a fixed set of GeoLens codes: blocked_by_policy, item_withdrawn, network_error, not_found, server_error, timeout, unauthorized, unexpected_status. Null when healthy or never probed. Never provider text, a URL, or a response body — nothing the origin sent is stored here.
+             * @description Why the origin is not healthy, as one of a fixed set of GeoLens codes: auth_required, blocked_by_policy, item_withdrawn, network_error, not_found, server_error, timeout, unauthorized, unexpected_status. Null when healthy or never probed. Never provider text, a URL, or a response body — nothing the origin sent is stored here.
              */
             source_health_detail?: string | null;
             /**

--- a/sdks/python/geolens/models/dataset_response.py
+++ b/sdks/python/geolens/models/dataset_response.py
@@ -87,9 +87,9 @@ class DatasetResponse:
         source_health (str | Unset): healthy, missing, inaccessible, or unknown. 'unknown' means never probed, or an
             origin kind with nothing to probe. Default: 'unknown'.
         source_health_detail (None | str | Unset): Why the origin is not healthy, as one of a fixed set of GeoLens
-            codes: blocked_by_policy, item_withdrawn, network_error, not_found, server_error, timeout, unauthorized,
-            unexpected_status. Null when healthy or never probed. Never provider text, a URL, or a response body — nothing
-            the origin sent is stored here.
+            codes: auth_required, blocked_by_policy, item_withdrawn, network_error, not_found, server_error, timeout,
+            unauthorized, unexpected_status. Null when healthy or never probed. Never provider text, a URL, or a response
+            body — nothing the origin sent is stored here.
         schema_drift_status (str | Unset): none, drifted, or unknown. Set at refresh commit from the schema diff;
             'unknown' until a refresh has run. Default: 'unknown'.
         source_freshness (str | Unset): fresh, due, overdue, or unknown, computed from last_refreshed_at against the

--- a/sdks/python/geolens/models/source_health_response.py
+++ b/sdks/python/geolens/models/source_health_response.py
@@ -44,9 +44,9 @@ class SourceHealthResponse:
                 missing — the origin answered authoritatively that it is gone (404/410). inaccessible — GeoLens could not
                 determine either way, which includes 401/403: access was lost, the data may be intact.
             source_health_detail (None | str | Unset): Why the origin is not healthy, as one of a fixed set of GeoLens
-                codes: blocked_by_policy, item_withdrawn, network_error, not_found, server_error, timeout, unauthorized,
-                unexpected_status. Null when healthy or never probed. Never provider text, a URL, or a response body — nothing
-                the origin sent is stored here.
+                codes: auth_required, blocked_by_policy, item_withdrawn, network_error, not_found, server_error, timeout,
+                unauthorized, unexpected_status. Null when healthy or never probed. Never provider text, a URL, or a response
+                body — nothing the origin sent is stored here.
             last_checked_at (datetime.datetime | None | Unset): When GeoLens last contacted this origin, success or failure.
     """
 

--- a/sdks/typescript/src/client/types.gen.ts
+++ b/sdks/typescript/src/client/types.gen.ts
@@ -3403,7 +3403,7 @@ export type DatasetResponse = {
     /**
      * Source Health Detail
      *
-     * Why the origin is not healthy, as one of a fixed set of GeoLens codes: blocked_by_policy, item_withdrawn, network_error, not_found, server_error, timeout, unauthorized, unexpected_status. Null when healthy or never probed. Never provider text, a URL, or a response body — nothing the origin sent is stored here.
+     * Why the origin is not healthy, as one of a fixed set of GeoLens codes: auth_required, blocked_by_policy, item_withdrawn, network_error, not_found, server_error, timeout, unauthorized, unexpected_status. Null when healthy or never probed. Never provider text, a URL, or a response body — nothing the origin sent is stored here.
      */
     source_health_detail?: string | null;
     /**
@@ -9107,7 +9107,7 @@ export type SourceHealthResponse = {
     /**
      * Source Health Detail
      *
-     * Why the origin is not healthy, as one of a fixed set of GeoLens codes: blocked_by_policy, item_withdrawn, network_error, not_found, server_error, timeout, unauthorized, unexpected_status. Null when healthy or never probed. Never provider text, a URL, or a response body — nothing the origin sent is stored here.
+     * Why the origin is not healthy, as one of a fixed set of GeoLens codes: auth_required, blocked_by_policy, item_withdrawn, network_error, not_found, server_error, timeout, unauthorized, unexpected_status. Null when healthy or never probed. Never provider text, a URL, or a response body — nothing the origin sent is stored here.
      */
     source_health_detail?: string | null;
     /**


### PR DESCRIPTION
Two findings from the ArcGIS authenticated-import test, both about what happens after a protected service is imported.

Refresh dead end. A dataset imported with a service token carried no record of that on its row; only the job's `user_metadata` had `service_auth_required`. So a credential-less refresh was accepted with 202, failed half a second later in the worker, and the run's error was import-door copy ("Retry commit with a service token"). On a default install a refresh with a token returned 503 `credential_store_unavailable` with nothing saying why.

The marker is a new optional key on `origin_ref` for the `service` kind: `auth_required: true`, or absent. `origin_ref` is JSONB gated only by the Python allowlist `ORIGIN_REF_KEYS`, so there is no Alembic migration and no backfill. Absent means "not known to need auth", which is where every existing dataset sits, and they refresh exactly as before. The worker writes it at the two successful-swap sites (`ingest_service` and `reupload_service`) from the resolved token, never at the request doors. It records that the last successful pull was made with a token. The worker cannot see a challenge, so a user who imported a public service while holding a token gets a marked dataset too. That is why the marker is a gate, not a verdict, and it clears on the next successful token-less pull, which the re-upload dialog without a token still allows.

The refresh door treats a token-less refresh of a marked dataset by service type. For ArcGIS it asks the origin first: one token-less request to `<layer>/query?where=1=1&returnCountOnly=true&f=json`, the same operation the worker's `build_gdal_source` composes, through the same URL builder the count fetcher uses (`build_arcgis_count_query_url`). Only an auth challenge (a 499 or 498 envelope, or a real 401/403) refuses with 422 `service_token_required`, naming the `token` field. Every other outcome, including unreachable, timed out or oversized, falls open and the refresh proceeds as it did before this existed. A public service that happened to be imported with a token costs one probe and never a refusal. The session is rolled back before the outbound wait and the dataset re-read after it, as `check_source_health` already does, so a slow origin does not pin a pooled connection. WFS and OGC API Features are refused outright with no probe: their probe target is the capabilities document or landing page, which is a different resource from the one the worker fetches, and a public GetCapabilities in front of a protected GetFeature is an ordinary deployment. The message tells the caller how to clear the marker.

A second, transition-only check runs after the run is reserved. If the dataset was unmarked at the door and became marked inside the reservation window (an authenticated re-upload of the same origin committed meanwhile), the refresh rolls back its reservation and refuses with the same 422. A marker that was already there has been adjudicated by the door, so it is not re-decided.

The worker's auth-failure copy now says refresh or re-upload based on the `refresh` flag the refresh door already stamps, and names the `token` field. `.env.example` says next to `REDIS_URL` that refreshing a protected service needs the credential store.

Health probe false positive. `POST /datasets/{id}/source-health/` reported `healthy` for an org-only ArcGIS service because the 499 "Token Required" envelope rides on HTTP 200. `probe_arcgis_origin` in `origin_probe.py` fetches the same count query through the existing safe client and maps envelope codes 498 and 499 to health `inaccessible` with a new detail code `auth_required`. An oversized sub-400 answer is read as reachable rather than inaccessible, since an auth envelope is a few hundred bytes. The health value stays inside the three the database check constraint allows, so no migration there either. `service_probe_target` and `probe_service_origin` are lifted out of `router_health.py` into `origin_probe.py` so the health endpoint and the refresh door pick the same target and the same probe for a service type. `SourcePanel.tsx` renders the new detail code in all four locales.

Closes findings 3 and 12 of #1746.

Verification, from `backend/` with `.env.test` sourced:

```
uv run ruff check . && uv run ruff format --check .
uv run pytest tests/test_service_refresh_1220.py tests/test_source_health_1222.py tests/test_dataset_source_state.py tests/test_reupload_service.py tests/test_ingest.py -q
uv run pytest tests/test_rule1_structural.py tests/test_rule2_structural.py tests/test_sdks_round_trip.py tests/test_layering.py -q
make openapi-check && make sdks-check
```

and from `frontend/`: `npm run typecheck && npm run lint && npx vitest run src/components/dataset/__tests__/SourcePanel.test.tsx && npm run test:i18n`.

Tests cover: the marker written only on success and only when a token was used (both tasks, parametrized); a marked ArcGIS dataset passing through on a healthy, unreachable or oversized probe and refused on a 499 envelope, 498, 401 and 403; a marked WFS dataset refused without any request; the token absent from the 422 body; the post-reservation recheck refusing only on a transition and releasing the run row; the worker copy choosing refresh vs re-upload; the health probe on a 200 body with `{"error":{"code":499}}`, a 498, and an oversized 200; the probe target being `/query` with the count parameters; the `ORIGIN_REF_KEYS` allowlist pin.

Schema and API impact: no Alembic migration. `origin_ref` gains an optional `auth_required` key. The refresh door adds 422 `service_token_required`. Source health gains detail code `auth_required`, so `backend/openapi.json`, both SDKs and `frontend/src/types/api.generated.ts` are regenerated (the hand-typed mirror needed no change). Config: `.env.example` comment only. LOC caps for `router_refresh.py`, `tasks_reupload.py` and `tasks_vector.py` are re-measured after the rebase across #1752 and #1753.

Left for #1755: `SourceRefreshAction.tsx` renders `service_token_required` as a generic error rather than offering the token field inline; the `unauthorized` detail copy still reads wrong for a service that was always private; `enrich_arcgis_feature_counts` is a third copy of the count query; and the `_require_service_token_if_marked` docstring still says the ArcGIS probe reads `?f=json` where it now reads `/query`.

https://claude.ai/code/session_01SFCMH3VJ5pFfM9Rer7KHZq
