### PR TITLE
feat(auth): add the credential policy for basic and header-key service auth

### DIFF
--- a/backend/app/core/service_tokens.py
+++ b/backend/app/core/service_tokens.py
@@ -121,13 +121,15 @@ HEADER_NAME_CHARSET: frozenset[str] = frozenset(
     string.ascii_letters + string.digits + "!#$%&'*+-.^_`|~"
 )
 
-# Names GeoLens sets itself on outbound requests. Accepting one would let a
-# caller overwrite the request's own framing rather than add a credential to
-# it, and ``authorization`` in particular would collide with the header the
-# bearer and basic branches compose. Compared case-insensitively, because HTTP
-# field names are case-insensitive and a reviewer will try ``AUTHORIZATION``.
+# Header names a caller may not send a credential under. Compared
+# case-insensitively, because HTTP field names are case-insensitive and a
+# reviewer will try ``AUTHORIZATION``. Two groups, for two different reasons.
 RESERVED_HEADER_NAMES: frozenset[str] = frozenset(
     {
+        # GeoLens sets these itself on outbound requests. Accepting one would
+        # let a caller overwrite what the request says about itself rather
+        # than add a credential to it, and ``authorization`` in particular
+        # would collide with the header the bearer and basic branches compose.
         "authorization",
         "x-esri-authorization",
         "accept",
@@ -135,10 +137,35 @@ RESERVED_HEADER_NAMES: frozenset[str] = frozenset(
         "content-length",
         "host",
         "cookie",
+        "set-cookie",
         "user-agent",
         "referer",
+        # These change how the request is framed, routed or terminated rather
+        # than what it carries, so none of them is ever the header a service
+        # key travels in. ``transfer-encoding: chunked`` is honoured both by
+        # httpx and by the libcurl header file GDAL reads, so it re-frames the
+        # request body from under the caller. ``proxy-authorization`` and
+        # ``proxy-connection`` are read by a configured forward proxy, which
+        # is a different party than the service being addressed. The rest are
+        # the RFC 9110 hop-by-hop names, plus ``expect``, which can stall a
+        # request waiting for a 100-continue that never comes.
+        "transfer-encoding",
+        "connection",
+        "proxy-authorization",
+        "proxy-connection",
+        "keep-alive",
+        "te",
+        "trailer",
+        "upgrade",
+        "expect",
     }
 )
+
+# HTTP/2 and HTTP/3 pseudo-headers are protocol framing rather than fields, and
+# the set is open-ended (:authority, :method, :path, :scheme, :status), so this
+# is a prefix rule rather than another list of names. The charset above already
+# refuses a colon; this exists so the caller is told which rule they hit.
+PSEUDO_HEADER_PREFIX = ":"
 
 # Every message below describes the policy and never the input, on the same
 # reasoning as HEADER_TOKEN_POLICY: these reach a 422 body, a log line and a
@@ -164,9 +191,10 @@ HEADER_NAME_POLICY = (
 )
 
 RESERVED_HEADER_NAME_POLICY = (
-    "That header name is one GeoLens sets on every request of its own, so a "
-    "credential cannot be sent under it. Use the header name the service "
-    "documents for its API key."
+    "A credential cannot be sent under that header name: GeoLens either sets "
+    "it on every request of its own, or it controls how the request is framed "
+    "and routed rather than what the request carries. Use the header name the "
+    "service documents for its API key."
 )
 
 CREDENTIAL_METHOD_POLICY = (
@@ -239,6 +267,10 @@ def header_name_rejection_reason(name: str | None) -> str | None:
     """Why *name* is unusable as the header a credential is sent under."""
     if not name:
         return HEADER_NAME_POLICY
+    # Before the charset rule, which would also refuse a pseudo-header but
+    # would tell the caller the colon was a typo rather than the point.
+    if name.startswith(PSEUDO_HEADER_PREFIX):
+        return RESERVED_HEADER_NAME_POLICY
     if any(character not in HEADER_NAME_CHARSET for character in name):
         return HEADER_NAME_POLICY
     if name.lower() in RESERVED_HEADER_NAMES:

--- a/backend/app/core/service_tokens.py
+++ b/backend/app/core/service_tokens.py
@@ -23,7 +23,10 @@ GDAL invocation. Neither may import the other, and both may import here.
 
 from __future__ import annotations
 
+import base64
 import string
+from dataclasses import dataclass
+from enum import StrEnum
 
 # The services whose credential travels as an Authorization header. ArcGIS is
 # deliberately absent: its token is a query parameter, urlencoded into the
@@ -77,3 +80,250 @@ def header_token_rejection_reason(token: str | None) -> str | None:
 def requires_header_token_policy(source_format: str | None) -> bool:
     """Whether *source_format*'s credential travels as an Authorization header."""
     return source_format in HEADER_AUTH_SERVICE_FORMATS
+
+
+# ---------------------------------------------------------------------------
+# fix(#1746): username-and-password and named API-key credentials for the two
+# header-auth service formats.
+#
+# A bearer token is one shape of service credential; a username and password
+# and a named API key are two more, and all three end up in the same two
+# places: one ASCII line in a 0600 GDAL header file, and one key in a probe
+# adapter's header dict. The rules below judge the INPUTS a caller typed, and
+# ``build_credential_header`` composes the header afterwards.
+#
+# That order is the whole point of the split. A composed Basic line contains a
+# space and a colon, so ``HEADER_TOKEN_CHARSET`` would reject the very line it
+# exists to protect, at the door or, worse, in the worker after the single-use
+# credential was already spent. So the charset above is untouched and keeps
+# judging exactly one thing, a bare bearer token, and the encoded output of a
+# validated username and password is safe by construction rather than by a
+# second charset check: standard base64 emits ``+`` or ``/`` only when the byte
+# at an offset congruent to 2 mod 3 is ``>``, ``?`` or ``~``, which is why the
+# same password passes or fails depending on the length of the username.
+# ---------------------------------------------------------------------------
+
+# Printable ASCII with no whitespace, which is 0x21 through 0x7E. Non-ASCII is
+# rejected deliberately rather than by omission: both header-file writers
+# encode the line with ``.encode("ascii")``, so an accented letter in an API
+# key would raise UnicodeEncodeError inside the worker, after the single-use
+# credential has been claimed. RFC 7617 makes UTF-8 the default charset for
+# basic authentication and this is narrower than that on purpose; the failure
+# it prevents is unrecoverable without re-entering the credential.
+CREDENTIAL_INPUT_CHARSET: frozenset[str] = frozenset(
+    character for character in string.printable if not character.isspace()
+)
+
+# RFC 7230 tchar, which is what an HTTP field name may contain. A colon and a
+# space are both absent from it, so a name carrying either cannot smuggle a
+# second header line or a value into the file.
+HEADER_NAME_CHARSET: frozenset[str] = frozenset(
+    string.ascii_letters + string.digits + "!#$%&'*+-.^_`|~"
+)
+
+# Names GeoLens sets itself on outbound requests. Accepting one would let a
+# caller overwrite the request's own framing rather than add a credential to
+# it, and ``authorization`` in particular would collide with the header the
+# bearer and basic branches compose. Compared case-insensitively, because HTTP
+# field names are case-insensitive and a reviewer will try ``AUTHORIZATION``.
+RESERVED_HEADER_NAMES: frozenset[str] = frozenset(
+    {
+        "authorization",
+        "x-esri-authorization",
+        "accept",
+        "content-type",
+        "content-length",
+        "host",
+        "cookie",
+        "user-agent",
+        "referer",
+    }
+)
+
+# Every message below describes the policy and never the input, on the same
+# reasoning as HEADER_TOKEN_POLICY: these reach a 422 body, a log line and a
+# job row. None of them may contain a brace, so none can grow an interpolation
+# later without failing the pin in tests/test_service_refresh_1220.py.
+CREDENTIAL_INPUT_POLICY = (
+    "A username, password or header value must not be empty, and may use "
+    "only printable ASCII characters with no spaces and no line breaks. "
+    "Accented letters and other characters outside ASCII cannot be written "
+    "into the credential header this service needs."
+)
+
+BASIC_USERNAME_POLICY = (
+    "A username used with a password must not contain a colon, because the "
+    "colon is what separates the username from the password in the encoded "
+    "credential."
+)
+
+HEADER_NAME_POLICY = (
+    "A header name must not be empty, and may use only letters, digits and "
+    "the characters ! # $ % & ' * + - . ^ _ ` | ~ . Spaces, colons and "
+    "anything outside that set are not valid in an HTTP header name."
+)
+
+RESERVED_HEADER_NAME_POLICY = (
+    "That header name is one GeoLens sets on every request of its own, so a "
+    "credential cannot be sent under it. Use the header name the service "
+    "documents for its API key."
+)
+
+CREDENTIAL_METHOD_POLICY = (
+    "Unrecognized authentication method. The supported methods are none, "
+    "bearer, basic and header."
+)
+
+
+class CredentialMethod(StrEnum):
+    """How a caller says a service credential should be presented.
+
+    The values are the wire literals, so a request schema can validate against
+    them directly and pass the string straight through. ``HEADER_KEY`` spells
+    its value ``header`` because that is the name the taxonomy gives the user,
+    an API key in a header; the member name says which of the header branches
+    it is, since bearer and basic also produce one.
+    """
+
+    NONE = "none"
+    BEARER = "bearer"
+    BASIC = "basic"
+    HEADER_KEY = "header"
+
+
+@dataclass(frozen=True, slots=True)
+class ServiceCredential:
+    """What a caller supplied for one remote service, before validation.
+
+    Carries ``service_format`` because that, and not the method, is what
+    decides whether a credential may become a header at all. An ArcGIS token
+    is percent-encoded into a URL query, so a header composed for it would put
+    an Authorization line inside a query string; see
+    ``build_credential_header``.
+
+    A frozen dataclass rather than a pydantic model so both layers can hold
+    one: ``core/`` may not import ``app.modules.*`` and neither may
+    ``processing/``, but both may import here. A request schema converts into
+    this at the door, and a caller that already holds the values, such as a
+    refresh service invoked in process rather than over HTTP, constructs one
+    directly.
+    """
+
+    method: CredentialMethod | str = CredentialMethod.NONE
+    service_format: str | None = None
+    token: str | None = None
+    username: str | None = None
+    password: str | None = None
+    header_name: str | None = None
+    header_value: str | None = None
+
+
+def credential_input_rejection_reason(value: str | None) -> str | None:
+    """Why *value* is unusable as a username, password or header value.
+
+    Returns a description of the POLICY, never a description of the value.
+
+    ``None`` is a rejection here, unlike in ``header_token_rejection_reason``
+    where it means that no token was supplied and none is required. This
+    function only ever judges a field the chosen method requires, so a missing
+    one is a rejection rather than an absence.
+    """
+    if not value:
+        return CREDENTIAL_INPUT_POLICY
+    if any(character not in CREDENTIAL_INPUT_CHARSET for character in value):
+        return CREDENTIAL_INPUT_POLICY
+    return None
+
+
+def header_name_rejection_reason(name: str | None) -> str | None:
+    """Why *name* is unusable as the header a credential is sent under."""
+    if not name:
+        return HEADER_NAME_POLICY
+    if any(character not in HEADER_NAME_CHARSET for character in name):
+        return HEADER_NAME_POLICY
+    if name.lower() in RESERVED_HEADER_NAMES:
+        return RESERVED_HEADER_NAME_POLICY
+    return None
+
+
+def build_credential_header(
+    auth: ServiceCredential | None,
+) -> tuple[str, str] | None:
+    """The one producer of a credential header, as a name and value pair.
+
+    Returns ``None`` when no header should be sent at all: no credential, or a
+    service format whose credential does not travel as a header. That second
+    case is the ArcGIS invariant, and it is expressed as an allowlist of the
+    formats in ``HEADER_AUTH_SERVICE_FORMATS`` rather than as a denylist of
+    ArcGIS, so a format nobody thought about degrades to no header rather than
+    to a smuggled one. The cost is that a caller which does not set
+    ``service_format`` gets no header, and the resulting failure is a 401 from
+    the origin, which is loud, rather than an Authorization line inside a URL
+    query, which is not.
+
+    Raises ``ValueError`` when the inputs for the chosen method are unusable.
+    The message is the policy and never the value, because it becomes a 422
+    body as well as a log line.
+
+    A pair rather than a finished string because two transports consume it: the
+    GDAL header file wants a line, from ``credential_header_line``, and the
+    probe adapters want a dict key. Returning only a string would put a second
+    parser in each adapter, which is what the single-producer rule exists to
+    prevent.
+    """
+    if auth is None:
+        return None
+    if not requires_header_token_policy(auth.service_format):
+        return None
+
+    method = auth.method
+    if method == CredentialMethod.NONE:
+        return None
+
+    if method == CredentialMethod.BEARER:
+        reason = header_token_rejection_reason(auth.token)
+        if auth.token is None or reason is not None:
+            raise ValueError(reason or HEADER_TOKEN_POLICY)
+        return ("Authorization", f"Bearer {auth.token}")
+
+    if method == CredentialMethod.BASIC:
+        username = auth.username
+        password = auth.password
+        if username is None or password is None:
+            raise ValueError(CREDENTIAL_INPUT_POLICY)
+        for supplied in (username, password):
+            reason = credential_input_rejection_reason(supplied)
+            if reason is not None:
+                raise ValueError(reason)
+        # RFC 7617: a user-id containing a colon is invalid, and accepting one
+        # would move the split point rather than fail, so the origin would
+        # authenticate a different user than the one that was typed.
+        if ":" in username:
+            raise ValueError(BASIC_USERNAME_POLICY)
+        encoded = base64.b64encode(f"{username}:{password}".encode("ascii"))
+        return ("Authorization", f"Basic {encoded.decode('ascii')}")
+
+    if method == CredentialMethod.HEADER_KEY:
+        name = auth.header_name
+        value = auth.header_value
+        reason = header_name_rejection_reason(name)
+        if name is None or reason is not None:
+            raise ValueError(reason or HEADER_NAME_POLICY)
+        reason = credential_input_rejection_reason(value)
+        if value is None or reason is not None:
+            raise ValueError(reason or CREDENTIAL_INPUT_POLICY)
+        return (name, value)
+
+    raise ValueError(CREDENTIAL_METHOD_POLICY)
+
+
+def credential_header_line(pair: tuple[str, str]) -> str:
+    """One header line, with no trailing newline.
+
+    The pair comes from ``build_credential_header`` and is not re-judged here:
+    a second validator standing beside the first is how the two disagreeing
+    policies this module exists to merge came about in the first place. The
+    writers add their own newline, so this returns exactly one line.
+    """
+    name, value = pair
+    return f"{name}: {value}"

--- a/backend/app/platform/security.py
+++ b/backend/app/platform/security.py
@@ -128,6 +128,67 @@ async def validate_url_for_ssrf(url: str) -> None:
             raise SSRFError("URLs targeting private/internal networks are not allowed")
 
 
+# HYG-03 (Phase 1070, v1014 IN-01): include HTTP 305 (Use Proxy) for
+# completeness even though RFC 7231 deprecated it and httpx does not follow
+# 305 redirects by default. Cheap defense-in-depth.
+_REDIRECT_STATUSES = frozenset({301, 302, 303, 305, 307, 308})
+
+# Ports the scheme already implies, so `https://host` and `https://host:443`
+# read as one origin rather than two.
+_DEFAULT_PORTS = {"http": 80, "https": 443}
+
+# Header names that ARE a credential whatever the caller declared. httpx drops
+# `Authorization` itself when a redirect crosses origins, so that one needs
+# nothing here; this one it would forward.
+_ALWAYS_CREDENTIAL_HEADERS = frozenset({"x-esri-authorization"})
+
+# Describes the policy and never the header value, on the same reasoning as the
+# messages in core/service_tokens.py: this reaches an API response body, a log
+# line and a job row.
+CROSS_ORIGIN_CREDENTIAL_POLICY = (
+    "Refusing to send a credential header to a different origin after a "
+    "redirect. Point the source at the address that answers directly, or ask "
+    "the service operator why it redirects a credentialed request elsewhere."
+)
+
+
+def _origin(url: httpx.URL) -> tuple[str, str, int | None]:
+    """Scheme, host and port, with the scheme's default port filled in."""
+    scheme = (url.scheme or "").lower()
+    return (scheme, (url.host or "").lower(), url.port or _DEFAULT_PORTS.get(scheme))
+
+
+def _refuse_cross_origin_credential(
+    response: httpx.Response, watched: frozenset[str]
+) -> None:
+    """Keep a credential on the origin it was given to.
+
+    fix(#1746): httpx strips `Authorization` when a redirect changes origin and
+    forwards every other header unchanged, so an API key sent under a name of
+    the service's choosing -- `X-API-Key`, Ordnance Survey's `key`, Azure's
+    `Ocp-Apim-Subscription-Key` -- is handed to whatever origin a 302 names.
+    The SSRF revalidation beside this does not close it: the redirect target
+    can be an entirely ordinary public host that simply is not the service the
+    user gave a credential to.
+
+    Called from the response hook, which httpx runs BEFORE it follows the
+    redirect, so raising here means the second request is never issued.
+    """
+    if response.status_code not in _REDIRECT_STATUSES:
+        return
+    location = response.headers.get("Location")
+    if not location:
+        return
+    request = response.request
+    # httpx.Headers membership is case-insensitive, which is the point: the
+    # caller may declare `X-API-Key` and the request may spell it `x-api-key`.
+    if not any(name in request.headers for name in watched):
+        return
+    if _origin(httpx.URL(response.url).join(location)) == _origin(request.url):
+        return
+    raise SSRFError(CROSS_ORIGIN_CREDENTIAL_POLICY)
+
+
 async def _revalidate_redirect(response: httpx.Response) -> None:
     """httpx response hook: re-validate the Location target on every redirect hop.
 
@@ -138,11 +199,14 @@ async def _revalidate_redirect(response: httpx.Response) -> None:
 
     Raising SSRFError from a response hook aborts further redirect-following
     and propagates the exception to the awaiting caller.
+
+    fix(#1746): also refuses a hop that would carry a credential header to a
+    different origin. That check runs first because it needs no DNS lookup, and
+    because its message names the actual problem: the Location can be a public
+    host this validator is perfectly happy with.
     """
-    # HYG-03 (Phase 1070, v1014 IN-01): include HTTP 305 (Use Proxy) for
-    # completeness even though RFC 7231 deprecated it and httpx does not
-    # follow 305 redirects by default. Cheap defense-in-depth.
-    if response.status_code not in (301, 302, 303, 305, 307, 308):
+    _refuse_cross_origin_credential(response, _ALWAYS_CREDENTIAL_HEADERS)
+    if response.status_code not in _REDIRECT_STATUSES:
         return
     location = response.headers.get("Location")
     if not location:
@@ -150,6 +214,26 @@ async def _revalidate_redirect(response: httpx.Response) -> None:
     # Resolve relative redirects against the original response URL.
     target = str(httpx.URL(response.url).join(location))
     await validate_url_for_ssrf(target)
+
+
+def _redirect_hook(credential_header: str | None):
+    """The response hook one client installs, for the header it declared.
+
+    A closure rather than another parameter on ``_revalidate_redirect``,
+    because that function is named in AGENTS.md Rule 2 and is called directly
+    by several tests, so it stays a plain single-argument coroutine that
+    already covers the always-credential names on its own.
+    """
+    if not credential_header:
+        return _revalidate_redirect
+
+    watched = _ALWAYS_CREDENTIAL_HEADERS | {credential_header.lower()}
+
+    async def _hook(response: httpx.Response) -> None:
+        _refuse_cross_origin_credential(response, watched)
+        await _revalidate_redirect(response)
+
+    return _hook
 
 
 class _SSRFGuardTransport(httpx.AsyncHTTPTransport):
@@ -203,6 +287,7 @@ def make_safe_transport() -> httpx.AsyncBaseTransport:
 
 def make_safe_client(
     timeout: float | httpx.Timeout = PROBE_TIMEOUT,
+    credential_header: str | None = None,
 ) -> httpx.AsyncClient:
     """Construct an httpx.AsyncClient with SSRF IP-pinning and per-hop revalidation.
 
@@ -215,11 +300,20 @@ def make_safe_client(
     DNS-rebinding answer between submission-time validation and connect cannot
     reach an internal IP. The response hook _revalidate_redirect additionally
     re-validates each 3xx Location, and the transport re-pins each redirect hop.
+
+    fix(#1746): pass ``credential_header`` when the request carries a service
+    credential under a name the service chose. httpx drops ``Authorization``
+    across a cross-origin redirect and forwards everything else, so without
+    this an API key follows a 302 to whatever origin it names. The refusal
+    lands on the hop, before the second request is issued.
+    ``X-Esri-Authorization`` is refused whether or not it was declared, since
+    that name is a credential by definition. A caller that passes nothing gets
+    exactly today's behaviour.
     """
     return httpx.AsyncClient(
         timeout=timeout,
         follow_redirects=True,
         max_redirects=5,
-        event_hooks={"response": [_revalidate_redirect]},
+        event_hooks={"response": [_redirect_hook(credential_header)]},
         transport=make_safe_transport(),
     )

--- a/backend/tests/test_credential_policy.py
+++ b/backend/tests/test_credential_policy.py
@@ -101,14 +101,18 @@ class TestCredentialInputRejection:
 
 
 class TestHeaderNameRejection:
-    """RFC 7230 token characters, and none of the names GeoLens sets itself."""
+    """RFC 7230 token characters, and no name that is spoken for."""
 
     @pytest.mark.parametrize(
         "name",
         [
+            # The five header names the surveyed providers actually use. A
+            # field hardcoded to X-API-Key would serve exactly one of them.
             "X-API-Key",
             "key",
             "Ocp-Apim-Subscription-Key",
+            "maxar-api-key",
+            "authkey",
             "apikey",
             "X-Api-Key123",
             "!#$%&'*+-.^_`|~",
@@ -140,20 +144,38 @@ class TestHeaderNameRejection:
     def test_charset_rejections(self, name: str | None, why: str) -> None:
         assert header_name_rejection_reason(name) == HEADER_NAME_POLICY, why
 
-    def test_the_denylist_is_the_nine_names_geolens_sets(self) -> None:
-        assert RESERVED_HEADER_NAMES == frozenset(
-            {
-                "authorization",
-                "x-esri-authorization",
-                "accept",
-                "content-type",
-                "content-length",
-                "host",
-                "cookie",
-                "user-agent",
-                "referer",
-            }
-        )
+    def test_the_denylist_is_the_two_groups_and_nothing_else(self) -> None:
+        """Names GeoLens sets, and names that change the transport.
+
+        fix(#1756 codex round 7): the second group was missing, so a caller
+        could send ``Transfer-Encoding: chunked`` as their API key header and
+        re-frame the request body, or ``Proxy-Authorization``, which a
+        configured forward proxy reads rather than the service.
+        """
+        geolens_sets = {
+            "authorization",
+            "x-esri-authorization",
+            "accept",
+            "content-type",
+            "content-length",
+            "host",
+            "cookie",
+            "set-cookie",
+            "user-agent",
+            "referer",
+        }
+        changes_the_transport = {
+            "transfer-encoding",
+            "connection",
+            "proxy-authorization",
+            "proxy-connection",
+            "keep-alive",
+            "te",
+            "trailer",
+            "upgrade",
+            "expect",
+        }
+        assert RESERVED_HEADER_NAMES == frozenset(geolens_sets | changes_the_transport)
 
     @pytest.mark.parametrize("reserved", sorted(RESERVED_HEADER_NAMES))
     @pytest.mark.parametrize("case", ["lower", "upper", "title", "mixed"])
@@ -180,6 +202,45 @@ class TestHeaderNameRejection:
         for an invalid character that is not there.
         """
         assert header_name_rejection_reason("AUTHORIZATION") != HEADER_NAME_POLICY
+
+    @pytest.mark.parametrize(
+        "name", [":authority", ":method", ":Path", ":SCHEME", ":status"]
+    )
+    def test_pseudo_headers_are_refused_as_reserved(self, name: str) -> None:
+        """fix(#1756 codex round 7): protocol framing, not a header field.
+
+        The charset rule would refuse these anyway, for the colon. The reason
+        matters: a caller told their colon is an invalid character will try
+        again without it, and a caller told the name is spoken for will not.
+        """
+        assert header_name_rejection_reason(name) == RESERVED_HEADER_NAME_POLICY
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "Transfer-Encoding",
+            "Connection",
+            "TE",
+            "Trailer",
+            "Upgrade",
+            "Proxy-Authorization",
+            "Proxy-Connection",
+            "Keep-Alive",
+            "Expect",
+            "Set-Cookie",
+        ],
+    )
+    def test_transport_headers_are_refused(self, name: str) -> None:
+        """fix(#1756 codex round 7): these reframe the request, not its body.
+
+        ``Transfer-Encoding: chunked`` is honoured by httpx and by the libcurl
+        header file GDAL reads, and ``Proxy-Authorization`` is read by a
+        configured forward proxy rather than by the service being addressed.
+        Tried in the casing a user would actually type.
+        """
+        assert header_name_rejection_reason(name) == RESERVED_HEADER_NAME_POLICY
+        assert header_name_rejection_reason(name.upper()) == RESERVED_HEADER_NAME_POLICY
+        assert header_name_rejection_reason(name.lower()) == RESERVED_HEADER_NAME_POLICY
 
 
 class TestBuildCredentialHeaderProducesTheHeader:
@@ -418,6 +479,24 @@ class TestBuildCredentialHeaderRejections:
                     method=CredentialMethod.HEADER_KEY,
                     service_format="wfs",
                     header_name="Authorization",
+                    header_value="k1234567",
+                ),
+                RESERVED_HEADER_NAME_POLICY,
+            ),
+            (
+                ServiceCredential(
+                    method=CredentialMethod.HEADER_KEY,
+                    service_format="wfs",
+                    header_name="Transfer-Encoding",
+                    header_value="chunked",
+                ),
+                RESERVED_HEADER_NAME_POLICY,
+            ),
+            (
+                ServiceCredential(
+                    method=CredentialMethod.HEADER_KEY,
+                    service_format="wfs",
+                    header_name=":authority",
                     header_value="k1234567",
                 ),
                 RESERVED_HEADER_NAME_POLICY,

--- a/backend/tests/test_credential_policy.py
+++ b/backend/tests/test_credential_policy.py
@@ -1,0 +1,634 @@
+"""fix(#1746): the credential policy for basic and header-key service auth.
+
+Covers the four additions to ``app/core/service_tokens.py`` and the two
+invariants they carry. The first is that the composed credential is never
+judged by ``HEADER_TOKEN_CHARSET``: the inputs are validated and the encoding
+happens afterwards, so a base64 blob containing ``+`` or ``/`` is safe by
+construction rather than by a second charset check. The second is that
+``build_credential_header`` returns None for ArcGIS whatever the method,
+because an ArcGIS token is percent-encoded into a URL query and a header
+composed for it would put an Authorization line inside a query string.
+"""
+
+from __future__ import annotations
+
+import base64
+import string
+
+import pytest
+
+from app.core import service_tokens
+from app.core.service_tokens import (
+    BASIC_USERNAME_POLICY,
+    CREDENTIAL_INPUT_POLICY,
+    CREDENTIAL_METHOD_POLICY,
+    HEADER_NAME_POLICY,
+    HEADER_TOKEN_CHARSET,
+    HEADER_TOKEN_MIN_LENGTH,
+    HEADER_TOKEN_POLICY,
+    RESERVED_HEADER_NAME_POLICY,
+    RESERVED_HEADER_NAMES,
+    CredentialMethod,
+    ServiceCredential,
+    build_credential_header,
+    credential_header_line,
+    credential_input_rejection_reason,
+    header_name_rejection_reason,
+    header_token_rejection_reason,
+)
+
+# A bearer token that satisfies the existing base64url policy, used wherever a
+# test needs the bearer branch to succeed rather than to be the subject.
+GOOD_BEARER = "abc.DEF-ghi_012="
+
+# Formats whose credential travels as a header, and one that does not.
+HEADER_FORMATS = ("wfs", "ogcapi_features")
+ARCGIS_FORMAT = "arcgis_featureserver"
+
+
+class TestCredentialInputRejection:
+    """Usernames, passwords and header values: printable ASCII, no spaces."""
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "plain-value",
+            "a~b1234",
+            "abc?",
+            "x>y",
+            "punctuation!#$%&'*+,-./:;<=>?@[]^_`{|}~",
+            "".join(sorted(HEADER_TOKEN_CHARSET)),
+            "9" * 200,
+        ],
+    )
+    def test_printable_ascii_is_accepted(self, value: str) -> None:
+        assert credential_input_rejection_reason(value) is None
+
+    @pytest.mark.parametrize(
+        ("value", "why"),
+        [
+            (None, "absent"),
+            ("", "empty"),
+            ("has space", "inner space"),
+            (" leading", "leading space"),
+            ("trailing ", "trailing space"),
+            ("tab\there", "tab"),
+            ("carriage\rreturn", "CR"),
+            ("line\nfeed", "LF"),
+            ("crlf\r\n", "CRLF"),
+            ("vertical\x0btab", "vertical tab"),
+            ("form\x0cfeed", "form feed"),
+            ("nul\x00byte", "NUL"),
+            ("delete\x7fchar", "DEL is not printable"),
+            ("café-value", "non-ASCII letter"),
+            ("nbsp\u00a0here", "non-ASCII whitespace"),
+            ("emoji\U0001f600", "non-ASCII astral"),
+            ("你好", "non-Latin script"),
+        ],
+    )
+    def test_rejections(self, value: str | None, why: str) -> None:
+        assert credential_input_rejection_reason(value) == CREDENTIAL_INPUT_POLICY, why
+
+    def test_absent_is_a_rejection_unlike_the_bearer_rule(self) -> None:
+        """The two functions differ on None on purpose.
+
+        ``header_token_rejection_reason(None)`` means "no token supplied and
+        none required". This one only ever judges a field the chosen method
+        requires, so a missing one is a rejection.
+        """
+        assert header_token_rejection_reason(None) is None
+        assert credential_input_rejection_reason(None) == CREDENTIAL_INPUT_POLICY
+
+
+class TestHeaderNameRejection:
+    """RFC 7230 token characters, and none of the names GeoLens sets itself."""
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "X-API-Key",
+            "key",
+            "Ocp-Apim-Subscription-Key",
+            "apikey",
+            "X-Api-Key123",
+            "!#$%&'*+-.^_`|~",
+        ],
+    )
+    def test_token_characters_are_accepted(self, name: str) -> None:
+        assert header_name_rejection_reason(name) is None
+
+    @pytest.mark.parametrize(
+        ("name", "why"),
+        [
+            (None, "absent"),
+            ("", "empty"),
+            ("X-API:Key", "colon"),
+            ("X API Key", "space"),
+            ("X-API-Key\r", "CR"),
+            ("X-API-Key\n", "LF"),
+            ("X-API-Key\t", "tab"),
+            ("X-API=Key", "equals is not a token character"),
+            ("X-API,Key", "comma"),
+            ("X-API;Key", "semicolon"),
+            ("X-API@Key", "at sign"),
+            ("X-API(Key)", "parentheses"),
+            ('X-API"Key"', "quote"),
+            ("X-API/Key", "solidus"),
+            ("X-Küy", "non-ASCII"),
+        ],
+    )
+    def test_charset_rejections(self, name: str | None, why: str) -> None:
+        assert header_name_rejection_reason(name) == HEADER_NAME_POLICY, why
+
+    def test_the_denylist_is_the_nine_names_geolens_sets(self) -> None:
+        assert RESERVED_HEADER_NAMES == frozenset(
+            {
+                "authorization",
+                "x-esri-authorization",
+                "accept",
+                "content-type",
+                "content-length",
+                "host",
+                "cookie",
+                "user-agent",
+                "referer",
+            }
+        )
+
+    @pytest.mark.parametrize("reserved", sorted(RESERVED_HEADER_NAMES))
+    @pytest.mark.parametrize("case", ["lower", "upper", "title", "mixed"])
+    def test_reserved_names_are_refused_in_any_case(
+        self, reserved: str, case: str
+    ) -> None:
+        spellings = {
+            "lower": reserved,
+            "upper": reserved.upper(),
+            "title": reserved.title(),
+            "mixed": "".join(
+                character.upper() if index % 2 else character
+                for index, character in enumerate(reserved)
+            ),
+        }
+        assert (
+            header_name_rejection_reason(spellings[case]) == RESERVED_HEADER_NAME_POLICY
+        )
+
+    def test_a_reserved_name_is_refused_for_the_reserved_reason(self) -> None:
+        """Not merely refused: the message has to say which rule bit.
+
+        A charset message for ``AUTHORIZATION`` would send the user hunting
+        for an invalid character that is not there.
+        """
+        assert header_name_rejection_reason("AUTHORIZATION") != HEADER_NAME_POLICY
+
+
+class TestBuildCredentialHeaderProducesTheHeader:
+    @pytest.mark.parametrize("service_format", HEADER_FORMATS)
+    def test_bearer(self, service_format: str) -> None:
+        assert build_credential_header(
+            ServiceCredential(
+                method=CredentialMethod.BEARER,
+                service_format=service_format,
+                token=GOOD_BEARER,
+            )
+        ) == ("Authorization", f"Bearer {GOOD_BEARER}")
+
+    @pytest.mark.parametrize(
+        ("username", "secret", "expected"),
+        [
+            # The memo's two counterexamples. Both encode to something the
+            # bearer charset would refuse or accept by accident, and both must
+            # work, because the encoded form is never charset-checked.
+            ("wfs", "a~b1234", "d2ZzOmF+YjEyMzQ="),
+            ("admin", "abc?", "YWRtaW46YWJjPw=="),
+            # `>`, `?` and `~` at an offset congruent to 2 mod 3, which is the
+            # only way standard base64 emits `+` or `/`.
+            ("wfs", "a>bcdef", "d2ZzOmE+YmNkZWY="),
+            ("wfs", "a?bcdef", "d2ZzOmE/YmNkZWY="),
+        ],
+    )
+    def test_basic_encodes_server_side(
+        self, username: str, secret: str, expected: str
+    ) -> None:
+        assert build_credential_header(
+            ServiceCredential(
+                method=CredentialMethod.BASIC,
+                service_format="wfs",
+                username=username,
+                password=secret,
+            )
+        ) == ("Authorization", f"Basic {expected}")
+        assert base64.b64decode(expected).decode("ascii") == f"{username}:{secret}"
+
+    def test_the_encoded_form_is_never_charset_checked(self) -> None:
+        """The point of validating inputs and encoding afterwards.
+
+        ``d2ZzOmF+YjEyMzQ=`` carries a ``+`` and ``d2ZzOmE/YmNkZWY=`` a ``/``,
+        so both would be refused as bearer tokens. Whether they appear at all
+        depends on the length of the username, which is why the rule cannot
+        live on the encoded output.
+        """
+        for encoded in ("d2ZzOmF+YjEyMzQ=", "d2ZzOmE/YmNkZWY="):
+            assert header_token_rejection_reason(encoded) == HEADER_TOKEN_POLICY
+        # And the memo's second example encodes to something the charset would
+        # have accepted, which is exactly why the difference is unexplainable
+        # to a user and the check does not belong there.
+        assert header_token_rejection_reason("YWRtaW46YWJjPw==") is None
+
+    @pytest.mark.parametrize("service_format", HEADER_FORMATS)
+    def test_header_key_passes_the_pair_through(self, service_format: str) -> None:
+        assert build_credential_header(
+            ServiceCredential(
+                method=CredentialMethod.HEADER_KEY,
+                service_format=service_format,
+                header_name="Ocp-Apim-Subscription-Key",
+                header_value="ab~cd?ef",
+            )
+        ) == ("Ocp-Apim-Subscription-Key", "ab~cd?ef")
+
+    def test_the_method_enum_values_are_the_wire_literals(self) -> None:
+        """Pinned because the request schema validates against these strings."""
+        assert {member.value for member in CredentialMethod} == {
+            "none",
+            "bearer",
+            "basic",
+            "header",
+        }
+        assert CredentialMethod.HEADER_KEY.value == "header"
+
+
+class TestBuildCredentialHeaderReturnsNone:
+    @pytest.mark.parametrize(
+        "auth",
+        [
+            None,
+            ServiceCredential(),
+            ServiceCredential(method=CredentialMethod.NONE, service_format="wfs"),
+            ServiceCredential(method="none", service_format="ogcapi_features"),
+        ],
+        ids=["absent", "default", "explicit-none", "none-as-a-string"],
+    )
+    def test_no_credential(self, auth: ServiceCredential | None) -> None:
+        assert build_credential_header(auth) is None
+
+    @pytest.mark.parametrize("method", ["none", "bearer", "basic", "header", "oauth"])
+    def test_arcgis_never_gets_a_header_whatever_the_method(self, method: str) -> None:
+        """D9's invariant at the one place it can be tested in isolation.
+
+        Every field is populated, so nothing here returns None for want of an
+        input. An ArcGIS token is percent-encoded into a URL query, so a
+        header line composed for it would land inside a query string.
+        """
+        assert (
+            build_credential_header(
+                ServiceCredential(
+                    method=method,
+                    service_format=ARCGIS_FORMAT,
+                    token=GOOD_BEARER,
+                    username="wfs",
+                    password="a~b1234",
+                    header_name="X-API-Key",
+                    header_value="k1234567",
+                )
+            )
+            is None
+        )
+
+    @pytest.mark.parametrize(
+        "service_format", [None, "stac", "geojson", "shapefile", ""]
+    )
+    def test_a_format_whose_credential_is_not_a_header(
+        self, service_format: str | None
+    ) -> None:
+        """An allowlist, so an unconsidered format degrades to no header.
+
+        The resulting failure is a 401 from the origin, which is loud. The
+        denylist version of this rule fails the other way.
+        """
+        assert (
+            build_credential_header(
+                ServiceCredential(
+                    method=CredentialMethod.BEARER,
+                    service_format=service_format,
+                    token=GOOD_BEARER,
+                )
+            )
+            is None
+        )
+
+
+class TestBuildCredentialHeaderRejections:
+    @pytest.mark.parametrize(
+        ("auth", "expected"),
+        [
+            (
+                ServiceCredential(
+                    method=CredentialMethod.BEARER, service_format="wfs", token="short"
+                ),
+                HEADER_TOKEN_POLICY,
+            ),
+            (
+                ServiceCredential(
+                    method=CredentialMethod.BEARER,
+                    service_format="wfs",
+                    token="has+plus+chars",
+                ),
+                HEADER_TOKEN_POLICY,
+            ),
+            (
+                ServiceCredential(
+                    method=CredentialMethod.BEARER, service_format="wfs", token=None
+                ),
+                HEADER_TOKEN_POLICY,
+            ),
+            (
+                ServiceCredential(
+                    method=CredentialMethod.BASIC,
+                    service_format="wfs",
+                    username="wfs",
+                    password="carriage\rreturn",
+                ),
+                CREDENTIAL_INPUT_POLICY,
+            ),
+            (
+                ServiceCredential(
+                    method=CredentialMethod.BASIC,
+                    service_format="wfs",
+                    username="wfs",
+                    password="line\nfeed",
+                ),
+                CREDENTIAL_INPUT_POLICY,
+            ),
+            (
+                ServiceCredential(
+                    method=CredentialMethod.BASIC,
+                    service_format="wfs",
+                    username="café",
+                    password="a~b1234",
+                ),
+                CREDENTIAL_INPUT_POLICY,
+            ),
+            (
+                ServiceCredential(
+                    method=CredentialMethod.BASIC,
+                    service_format="wfs",
+                    username="wfs",
+                    password=None,
+                ),
+                CREDENTIAL_INPUT_POLICY,
+            ),
+            (
+                ServiceCredential(
+                    method=CredentialMethod.BASIC,
+                    service_format="wfs",
+                    username="wfs",
+                    password="",
+                ),
+                CREDENTIAL_INPUT_POLICY,
+            ),
+            (
+                ServiceCredential(
+                    method=CredentialMethod.BASIC,
+                    service_format="wfs",
+                    username="two:parts",
+                    password="a~b1234",
+                ),
+                BASIC_USERNAME_POLICY,
+            ),
+            (
+                ServiceCredential(
+                    method=CredentialMethod.HEADER_KEY,
+                    service_format="wfs",
+                    header_name="X-API:Key",
+                    header_value="k1234567",
+                ),
+                HEADER_NAME_POLICY,
+            ),
+            (
+                ServiceCredential(
+                    method=CredentialMethod.HEADER_KEY,
+                    service_format="wfs",
+                    header_name=None,
+                    header_value="k1234567",
+                ),
+                HEADER_NAME_POLICY,
+            ),
+            (
+                ServiceCredential(
+                    method=CredentialMethod.HEADER_KEY,
+                    service_format="wfs",
+                    header_name="Authorization",
+                    header_value="k1234567",
+                ),
+                RESERVED_HEADER_NAME_POLICY,
+            ),
+            (
+                ServiceCredential(
+                    method=CredentialMethod.HEADER_KEY,
+                    service_format="wfs",
+                    header_name="X-API-Key",
+                    header_value="kéy-value",
+                ),
+                CREDENTIAL_INPUT_POLICY,
+            ),
+            (
+                ServiceCredential(
+                    method=CredentialMethod.HEADER_KEY,
+                    service_format="wfs",
+                    header_name="X-API-Key",
+                    header_value=None,
+                ),
+                CREDENTIAL_INPUT_POLICY,
+            ),
+            (
+                ServiceCredential(method="oauth", service_format="wfs"),
+                CREDENTIAL_METHOD_POLICY,
+            ),
+            (
+                ServiceCredential(method="", service_format="wfs"),
+                CREDENTIAL_METHOD_POLICY,
+            ),
+        ],
+    )
+    def test_raises_the_policy(self, auth: ServiceCredential, expected: str) -> None:
+        with pytest.raises(ValueError) as raised:
+            build_credential_header(auth)
+        assert str(raised.value) == expected
+
+    @pytest.mark.parametrize(
+        "supplied",
+        [
+            "carriage\rreturn",
+            "line\nfeed",
+            "café-value",
+            "has space",
+        ],
+    )
+    def test_no_message_ever_echoes_the_input(self, supplied: str) -> None:
+        """The message reaches a 422 body, a log line and a job row.
+
+        Each value is tried in every position that can raise, so a branch that
+        grew an interpolation is caught wherever it is. The values are the
+        ones every branch refuses, which is what lets the count below be
+        exact.
+        """
+        candidates = [
+            ServiceCredential(
+                method=CredentialMethod.BASIC,
+                service_format="wfs",
+                username=supplied,
+                password="a~b1234",
+            ),
+            ServiceCredential(
+                method=CredentialMethod.BASIC,
+                service_format="wfs",
+                username="wfs",
+                password=supplied,
+            ),
+            ServiceCredential(
+                method=CredentialMethod.HEADER_KEY,
+                service_format="wfs",
+                header_name=supplied,
+                header_value="k1234567",
+            ),
+            ServiceCredential(
+                method=CredentialMethod.HEADER_KEY,
+                service_format="wfs",
+                header_name="X-API-Key",
+                header_value=supplied,
+            ),
+            ServiceCredential(
+                method=CredentialMethod.BEARER,
+                service_format="wfs",
+                token=supplied,
+            ),
+        ]
+        raised_count = 0
+        for auth in candidates:
+            try:
+                build_credential_header(auth)
+            except ValueError as exc:
+                raised_count += 1
+                assert supplied not in str(exc)
+        # Positive control: an assertion inside a `try` that never raises
+        # would pass while testing nothing.
+        assert raised_count == len(candidates)
+
+    def test_the_colon_rejection_does_not_echo_the_username(self) -> None:
+        """The one value a password may hold and a username may not."""
+        with pytest.raises(ValueError) as raised:
+            build_credential_header(
+                ServiceCredential(
+                    method=CredentialMethod.BASIC,
+                    service_format="wfs",
+                    username="two:parts",
+                    password="a~b1234",
+                )
+            )
+        assert "two:parts" not in str(raised.value)
+        # And a colon in the password is fine, since nothing has to split it.
+        assert build_credential_header(
+            ServiceCredential(
+                method=CredentialMethod.BASIC,
+                service_format="wfs",
+                username="wfs",
+                password="two:parts",
+            )
+        ) == ("Authorization", f"Basic {base64.b64encode(b'wfs:two:parts').decode()}")
+
+
+class TestPolicyConstants:
+    def test_no_policy_constant_can_interpolate(self) -> None:
+        """Mirrors the pin at tests/test_service_refresh_1220.py on
+        HEADER_TOKEN_POLICY, over every policy string in the module rather
+        than the one that existed when that test was written."""
+        policies = {
+            name: value
+            for name, value in vars(service_tokens).items()
+            if name.endswith("_POLICY") and isinstance(value, str)
+        }
+        # Positive control on the collection itself: five new constants plus
+        # the one that shipped before this lane.
+        assert len(policies) >= 6, sorted(policies)
+        for name, value in policies.items():
+            assert "{" not in value, name
+            assert "}" not in value, name
+            assert "%s" not in value, name
+
+    def test_every_policy_constant_is_reachable_from_a_rejection(self) -> None:
+        """A message nothing can produce is copy nobody proofreads."""
+        produced = {
+            credential_input_rejection_reason(""),
+            header_name_rejection_reason("bad name"),
+            header_name_rejection_reason("Cookie"),
+            header_token_rejection_reason("bad token"),
+        }
+        with pytest.raises(ValueError) as raised:
+            build_credential_header(
+                ServiceCredential(
+                    method=CredentialMethod.BASIC,
+                    service_format="wfs",
+                    username="two:parts",
+                    password="a~b1234",
+                )
+            )
+        produced.add(str(raised.value))
+        with pytest.raises(ValueError) as raised:
+            build_credential_header(
+                ServiceCredential(method="oauth", service_format="wfs")
+            )
+        produced.add(str(raised.value))
+        assert produced == {
+            CREDENTIAL_INPUT_POLICY,
+            HEADER_NAME_POLICY,
+            RESERVED_HEADER_NAME_POLICY,
+            HEADER_TOKEN_POLICY,
+            BASIC_USERNAME_POLICY,
+            CREDENTIAL_METHOD_POLICY,
+        }
+
+
+class TestTheExistingBearerPolicyIsUntouched:
+    """The standing constraint: HEADER_TOKEN_CHARSET is not widened."""
+
+    def test_charset_and_floor_are_unchanged(self) -> None:
+        assert HEADER_TOKEN_CHARSET == frozenset(
+            string.ascii_letters + string.digits + "._-="
+        )
+        assert HEADER_TOKEN_MIN_LENGTH == 8
+
+    def test_the_two_charsets_are_different_rules(self) -> None:
+        """A value the credential rule accepts and the bearer rule refuses.
+
+        If these two ever collapse into one, a basic password would have to
+        satisfy the base64url alphabet, which is the failure this split
+        exists to prevent.
+        """
+        assert credential_input_rejection_reason("a~b1234") is None
+        assert header_token_rejection_reason("a~b1234") == HEADER_TOKEN_POLICY
+        assert service_tokens.CREDENTIAL_INPUT_CHARSET > HEADER_TOKEN_CHARSET
+
+
+class TestCredentialHeaderLine:
+    def test_joins_with_a_colon_and_a_space(self) -> None:
+        assert credential_header_line(("X-API-Key", "k1234567")) == (
+            "X-API-Key: k1234567"
+        )
+
+    def test_is_exactly_one_line_with_no_trailing_newline(self) -> None:
+        """Both writers append their own newline."""
+        line = credential_header_line(("Authorization", "Basic d2ZzOmF+YjEyMzQ="))
+        assert line.splitlines() == [line]
+        assert not line.endswith("\n")
+
+    def test_round_trips_the_builder_output(self) -> None:
+        pair = build_credential_header(
+            ServiceCredential(
+                method=CredentialMethod.BASIC,
+                service_format="wfs",
+                username="wfs",
+                password="a~b1234",
+            )
+        )
+        assert pair is not None
+        assert credential_header_line(pair) == ("Authorization: Basic d2ZzOmF+YjEyMzQ=")

--- a/backend/tests/test_credential_producer_structural.py
+++ b/backend/tests/test_credential_producer_structural.py
@@ -1,39 +1,58 @@
 """One producer of a credential header, enforced structurally (fix(#1746)).
 
 In the shape of ``test_rule2_structural.py``: walk every module under
-``backend/app/`` as an AST and assert that the two transports which carry a
-service credential get their header from ``build_credential_header`` and
+``backend/app/`` as an AST and assert that the transports which carry a
+credential get their header from ``build_credential_header`` and
 ``credential_header_line`` in ``app/core/service_tokens.py`` rather than
 composing one of their own.
 
 Why a structural test rather than a code comment. The prefix is composed today
-in four separate places, and handing any of them a finished line without
-removing its own composition produces ``Authorization: Bearer Authorization:
-Basic <blob>``, a working-looking string that fails at the origin with a 401
-and reads in a log like a credential problem rather than a bug. Once the four
-are collapsed into the builder, nothing except this test stops a fifth
-appearing beside them.
+in four separate places on the service-credential path, and handing any of them
+a finished line without removing its own composition produces
+``Authorization: Bearer Authorization: Basic <blob>``, a working-looking string
+that fails at the origin with a 401 and reads in a log like a credential
+problem rather than a bug. Once the four are collapsed into the builder,
+nothing except this test stops a fifth appearing beside them.
 
-The two shapes it watches:
+The two shapes it watches, over the whole ``backend/app/`` tree:
 
 1. **Header-file writes.** Any write in a scope that calls
    ``gdal_header_dir()``. That directory exists for exactly one thing, the
    0600 ``GDAL_HTTP_HEADER_FILE``, so a write in a scope that located it is a
    credential line by construction.
-2. **Adapter header assignments.** Any ``headers[...] = ...`` under
-   ``modules/catalog/sources/adapters/``, and any dict literal there keyed by
-   a credential header name, which is the same composition wearing a literal.
+2. **Credential header writes.** Any ``headers[...] = ...`` keyed by a
+   credential header name, and any dict literal with such a key. The dict
+   literal is the same composition one line up, and leaving it out would make
+   the rule free to evade.
+
+   Under ``modules/catalog/sources/`` and ``processing/``, a header
+   assignment with a NON-constant key is judged too, because that is where a
+   service credential is actually handled and ``headers[key] = ...`` with
+   ``key = "Authorization"`` two lines above would otherwise walk straight
+   through. Elsewhere in the tree a computed key is left alone: response
+   headers are set that way all over the API (``response.headers[name] =
+   value``), and judging those would be noise, not coverage.
+
+   fix(#1756 codex round 1): this rule used to be scoped to
+   ``sources/adapters/``, which missed the composition in ``sources/router.py``
+   entirely. Scope now comes from the key, not from the directory.
+
+Provenance is deliberately narrow: a value counts as guarded only when
+``build_credential_header`` is in its chain. ``credential_header_line`` alone
+does not qualify, because it only concatenates whatever pair it is handed, so
+crediting it would let ``credential_header_line(("Authorization", whatever))``
+through the gate with no validation at all (fix(#1756 codex round 1)).
 
 Both allowlists are asserted EXACT in both directions and by count, so an
-entry whose site disappears fails loudly instead of going stale. The four
-entries below are the four compositions that exist today; lane B2b deletes
-them, and this test is what tells it when the last one is gone.
+entry whose site disappears fails loudly instead of going stale. Four of the
+five credential-header entries are the compositions lane B2b deletes; this
+test is what tells it when the last one is gone.
 
 WHAT THIS DOES NOT CLAIM, in the same spirit as the Rule-2 guard. It is a
 lexical rule, not dataflow. A line built in one function and written in
 another (no such shape exists today), a header dict assembled through
-``update()`` from a value computed elsewhere, and a credential reaching an
-adapter as a pre-built parameter are all outside what an AST rule can answer.
+``update()`` from a value computed elsewhere, and a credential reaching a
+request as a pre-built parameter are all outside what an AST rule can answer.
 The provenance check follows names bound to a builder call within the same
 scope and no further. False alarms are cheap and visible; a silent miss is the
 failure that matters, so anything the resolver cannot classify is reported.
@@ -47,22 +66,28 @@ from pathlib import Path
 
 APP_ROOT = Path(__file__).resolve().parent.parent / "app"
 
-# The single producer, and the joiner that turns its pair into a line.
-BUILDER_FUNCTIONS = frozenset({"build_credential_header", "credential_header_line"})
+# The single producer, and the joiner that turns its pair into a line. Only
+# the producer confers provenance; see the module docstring.
+CREDENTIAL_BUILDER = "build_credential_header"
+CREDENTIAL_JOINER = "credential_header_line"
 
 # The helper that locates the 0600 header-file directory. A scope that calls
 # it is writing a credential header or nothing at all.
 HEADER_DIR_HELPER = "gdal_header_dir"
 
-ADAPTER_PACKAGE = "modules/catalog/sources/adapters/"
+# Where a computed header key is judged as well as a literal one: the two
+# trees that handle a service credential.
+DYNAMIC_KEY_PACKAGES = ("modules/catalog/sources/", "processing/")
 
 # Write calls, by exact name. Substring matching would sweep in unrelated
 # helpers: `_tenant_writer_subprocess_env` contains "write".
 WRITE_CALL_NAMES = frozenset({"write", "writelines", "write_text", "write_bytes"})
 
-# Dict keys that name a credential header, compared case-insensitively
-# because HTTP field names are case-insensitive.
-CREDENTIAL_HEADER_KEYS = frozenset({"authorization", "x-esri-authorization"})
+# Header names that carry a credential, compared case-insensitively because
+# HTTP field names are case-insensitive.
+CREDENTIAL_HEADER_KEYS = frozenset(
+    {"authorization", "proxy-authorization", "x-esri-authorization"}
+)
 
 # Every allowlist entry is (module, scope) -> (exact count, justification).
 HEADER_FILE_WRITE_ALLOWLIST: dict[tuple[str, str], tuple[int, str]] = {
@@ -78,16 +103,30 @@ HEADER_FILE_WRITE_ALLOWLIST: dict[tuple[str, str], tuple[int, str]] = {
     ),
 }
 
-ADAPTER_HEADER_ALLOWLIST: dict[tuple[str, str], tuple[int, str]] = {
-    (f"{ADAPTER_PACKAGE}wfs.py", "probe_wfs"): (
+CREDENTIAL_HEADER_ALLOWLIST: dict[tuple[str, str], tuple[int, str]] = {
+    ("modules/catalog/sources/adapters/wfs.py", "probe_wfs"): (
         1,
         "fix(#1746 service-auth B2b removes this): composes the bearer header "
         "for the WFS GetCapabilities probe",
     ),
-    (f"{ADAPTER_PACKAGE}ogcapi.py", "probe_ogcapi"): (
+    ("modules/catalog/sources/adapters/ogcapi.py", "probe_ogcapi"): (
         1,
         "fix(#1746 service-auth B2b removes this): composes the bearer header "
         "for the OGC API Features landing-page probe",
+    ),
+    ("modules/catalog/sources/router.py", "_fetch_ogcapi_collection_srid"): (
+        1,
+        "fix(#1746 service-auth B2b removes this): composes the bearer header "
+        "for the collection CRS fallback fetch, which is the same service "
+        "credential the two probe adapters carry",
+    ),
+    ("modules/auth/oauth/service.py", "_resolve_github_identity"): (
+        1,
+        "not a service credential and not B2b's to move: this is the OAuth "
+        "access token for the provider's own userinfo call, and the builder "
+        "cannot produce it by design, since it composes a header only for the "
+        "formats in HEADER_AUTH_SERVICE_FORMATS. Listed so the rule can stay "
+        "tree-wide and catch the next hand-composed Authorization header",
     ),
 }
 
@@ -96,7 +135,7 @@ ADAPTER_HEADER_ALLOWLIST: dict[tuple[str, str], tuple[int, str]] = {
 # absence-claim rule exists for.
 MIN_APP_MODULES = 100
 MIN_HEADER_FILE_WRITE_SITES = 2
-MIN_ADAPTER_HEADER_SITES = 2
+MIN_CREDENTIAL_HEADER_SITES = 4
 
 _MODULE_SCOPE = "<module>"
 
@@ -146,18 +185,36 @@ def _scope_calls(scope: ast.AST, name: str) -> bool:
     )
 
 
-def _mentions_builder(expr: ast.AST, bound: frozenset[str]) -> bool:
-    """Whether *expr* calls the builder or reads a name bound to one."""
+def _from_builder(expr: ast.AST, bound: frozenset[str]) -> bool:
+    """Whether *expr*'s value came from ``build_credential_header``.
+
+    The joiner counts only when it is joining a builder pair. On its own it
+    concatenates any two strings, so crediting a bare
+    ``credential_header_line(("Authorization", value))`` would hand the gate a
+    way to pass an unvalidated credential.
+    """
     for node in ast.walk(expr):
-        if isinstance(node, ast.Call) and _call_name(node.func) in BUILDER_FUNCTIONS:
-            return True
+        if isinstance(node, ast.Call):
+            name = _call_name(node.func)
+            if name == CREDENTIAL_BUILDER:
+                return True
+            if (
+                name == CREDENTIAL_JOINER
+                and node.args
+                and _from_builder(node.args[0], bound)
+            ):
+                return True
         if isinstance(node, ast.Name) and node.id in bound:
             return True
     return False
 
 
 def _builder_bound_names(scope: ast.AST) -> frozenset[str]:
-    """Names bound to a builder call anywhere in *scope*.
+    """Names holding a value derived from the builder, anywhere in *scope*.
+
+    Iterated to a fixed point so a chain resolves whatever order the
+    assignments appear in: ``pair`` from the builder, then ``line`` from the
+    joiner applied to ``pair``.
 
     Deliberately flow-insensitive: a name assigned from the builder counts
     wherever it is used in that scope. Narrowing it would report violations
@@ -165,17 +222,21 @@ def _builder_bound_names(scope: ast.AST) -> frozenset[str]:
     not to referee assignment order.
     """
     bound: set[str] = set()
-    for node in ast.walk(scope):
-        if not isinstance(node, (ast.Assign, ast.AnnAssign, ast.NamedExpr)):
-            continue
-        value = node.value
-        if value is None or not _mentions_builder(value, frozenset()):
-            continue
-        targets = node.targets if isinstance(node, ast.Assign) else [node.target]
-        for target in targets:
-            for inner in ast.walk(target):
-                if isinstance(inner, ast.Name):
-                    bound.add(inner.id)
+    changed = True
+    while changed:
+        changed = False
+        for node in ast.walk(scope):
+            if not isinstance(node, (ast.Assign, ast.AnnAssign, ast.NamedExpr)):
+                continue
+            value = node.value
+            if value is None or not _from_builder(value, frozenset(bound)):
+                continue
+            targets = node.targets if isinstance(node, ast.Assign) else [node.target]
+            for target in targets:
+                for inner in ast.walk(target):
+                    if isinstance(inner, ast.Name) and inner.id not in bound:
+                        bound.add(inner.id)
+                        changed = True
     return frozenset(bound)
 
 
@@ -199,40 +260,52 @@ def _written_value(call: ast.Call) -> ast.expr | None:
     return call.args[index]
 
 
-def _is_header_subscript(target: ast.expr) -> bool:
+def _header_container_name(target: ast.expr) -> str | None:
     if not isinstance(target, ast.Subscript):
-        return False
+        return None
     container = target.value
-    name = None
     if isinstance(container, ast.Name):
         name = container.id
     elif isinstance(container, ast.Attribute):
         name = container.attr
-    return name is not None and "header" in name.lower()
+    else:
+        return None
+    return name if "header" in name.lower() else None
 
 
-def _credential_header_values(node: ast.AST) -> list[ast.expr]:
-    """Every value *node* puts into a header mapping.
+def _is_credential_key(key: ast.expr, allow_dynamic_key: bool) -> bool:
+    if isinstance(key, ast.Constant):
+        return (
+            isinstance(key.value, str) and key.value.lower() in CREDENTIAL_HEADER_KEYS
+        )
+    # A computed key cannot be read off the AST. In the two trees that handle
+    # a service credential that is a violation waiting to happen, so it is
+    # judged; everywhere else it is ordinary response-header plumbing.
+    return allow_dynamic_key
+
+
+def _credential_header_values(node: ast.AST, allow_dynamic_key: bool) -> list[ast.expr]:
+    """Every value *node* writes under a credential header name.
 
     Two shapes: a subscript assignment into a name that reads as a header
-    mapping, and a dict literal keyed by a credential header name. The second
-    is the first one wearing a literal, and leaving it out would let a
-    composition move one line up to evade the rule.
+    mapping, and a dict literal keyed by a credential header name.
     """
     if isinstance(node, (ast.Assign, ast.AnnAssign)):
+        if node.value is None:
+            return []
         targets = node.targets if isinstance(node, ast.Assign) else [node.target]
-        if node.value is not None and any(
-            _is_header_subscript(target) for target in targets
-        ):
-            return [node.value]
+        for target in targets:
+            if _header_container_name(target) is None:
+                continue
+            assert isinstance(target, ast.Subscript)
+            if _is_credential_key(target.slice, allow_dynamic_key):
+                return [node.value]
         return []
     if isinstance(node, ast.Dict):
         return [
             value
             for key, value in zip(node.keys, node.values, strict=True)
-            if isinstance(key, ast.Constant)
-            and isinstance(key.value, str)
-            and key.value.lower() in CREDENTIAL_HEADER_KEYS
+            if key is not None and _is_credential_key(key, allow_dynamic_key=False)
         ]
     return []
 
@@ -256,7 +329,7 @@ class _Scan:
 def _scan_module(rel: str, tree: ast.Module) -> _Scan:
     _annotate_parents(tree)
     scan = _Scan()
-    is_adapter = rel.startswith(ADAPTER_PACKAGE)
+    allow_dynamic_key = rel.startswith(DYNAMIC_KEY_PACKAGES)
     bound_cache: dict[int, frozenset[str]] = {}
     header_dir_cache: dict[int, bool] = {}
 
@@ -264,7 +337,7 @@ def _scan_module(rel: str, tree: ast.Module) -> _Scan:
         is_write = (
             isinstance(node, ast.Call) and _call_name(node.func) in WRITE_CALL_NAMES
         )
-        header_values = _credential_header_values(node) if is_adapter else []
+        header_values = _credential_header_values(node, allow_dynamic_key)
         if not is_write and not header_values:
             continue
 
@@ -283,12 +356,12 @@ def _scan_module(rel: str, tree: ast.Module) -> _Scan:
             if writes_a_header:
                 scan.write_sites += 1
                 value = _written_value(node)  # type: ignore[arg-type]
-                if value is None or not _mentions_builder(value, bound):
+                if value is None or not _from_builder(value, bound):
                     scan.unguarded_writes[site] += 1
 
         for value in header_values:
             scan.header_sites += 1
-            if not _mentions_builder(value, bound):
+            if not _from_builder(value, bound):
                 scan.unguarded_headers[site] += 1
 
     return scan
@@ -343,14 +416,14 @@ def test_header_file_writes_come_from_the_shared_builder() -> None:
     assert not failures, "\n".join(failures)
 
 
-def test_adapter_credential_headers_come_from_the_shared_builder() -> None:
+def test_credential_headers_come_from_the_shared_builder() -> None:
     scan = _scan_backend()
-    assert scan.header_sites >= MIN_ADAPTER_HEADER_SITES, (
-        "the walk found no adapter credential headers at all, so every "
-        "assertion about them is vacuous"
+    assert scan.header_sites >= MIN_CREDENTIAL_HEADER_SITES, (
+        "the walk found no credential headers at all, so every assertion "
+        "about them is vacuous"
     )
     failures = _allowlist_failures(
-        scan.unguarded_headers, ADAPTER_HEADER_ALLOWLIST, "probe adapter"
+        scan.unguarded_headers, CREDENTIAL_HEADER_ALLOWLIST, "credential header"
     )
     assert not failures, "\n".join(failures)
 
@@ -359,16 +432,23 @@ def test_the_walk_actually_covers_the_backend() -> None:
     """The positive control for the two allowlist assertions above."""
     modules = _app_modules()
     assert len(modules) >= MIN_APP_MODULES
-    assert any(rel.startswith(ADAPTER_PACKAGE) for rel, _ in modules)
     assert any(_scope_calls(tree, HEADER_DIR_HELPER) for _, tree in modules), (
         f"{HEADER_DIR_HELPER}() is called nowhere, so the header-file rule "
         "matches nothing"
     )
+    # The scan reaches outside the sources package, which is the gap codex
+    # round 1 found: the rule used to be scoped to sources/adapters/ and so
+    # never looked at sources/router.py or anything else.
+    scanned = {site[0] for site in _scan_backend().unguarded_headers}
+    assert "modules/catalog/sources/router.py" in scanned
+    assert any(not rel.startswith("modules/catalog/sources/") for rel in scanned)
 
 
-def _scan_synthetic(source: str) -> _Scan:
-    """Run the real predicates over a synthetic adapter module."""
-    return _scan_module(f"{ADAPTER_PACKAGE}synthetic.py", ast.parse(source))
+def _scan_synthetic(source: str, rel: str | None = None) -> _Scan:
+    """Run the real predicates over a synthetic module."""
+    return _scan_module(
+        rel or "modules/catalog/sources/synthetic.py", ast.parse(source)
+    )
 
 
 def test_guard_an_inline_composition_is_flagged() -> None:
@@ -381,7 +461,7 @@ def test_guard_an_inline_composition_is_flagged() -> None:
     )
     assert sum(scan.unguarded_writes.values()) == 1
     assert sum(scan.unguarded_headers.values()) == 2
-    assert set(scan.unguarded_writes) == {(f"{ADAPTER_PACKAGE}synthetic.py", "f")}
+    assert set(scan.unguarded_writes) == {("modules/catalog/sources/synthetic.py", "f")}
 
 
 def test_guard_a_builder_composition_is_clean() -> None:
@@ -398,6 +478,23 @@ def test_guard_a_builder_composition_is_clean() -> None:
     assert scan.header_sites == 2
     assert not scan.unguarded_writes
     assert not scan.unguarded_headers
+
+
+def test_guard_the_joiner_alone_confers_nothing() -> None:
+    """fix(#1756 codex round 1): the joiner only concatenates.
+
+    Crediting a bare ``credential_header_line(...)`` would let an
+    unvalidated value through under a builder-shaped name.
+    """
+    scan = _scan_synthetic(
+        "def f(token, fd):\n"
+        "    path = gdal_header_dir()\n"
+        '    line = credential_header_line(("Authorization", token))\n'
+        '    os.write(fd, f"{line}\\n".encode("ascii"))\n'
+        '    headers["Authorization"] = credential_header_line(("X", token))\n'
+    )
+    assert sum(scan.unguarded_writes.values()) == 1
+    assert sum(scan.unguarded_headers.values()) == 1
 
 
 def test_guard_a_second_write_beside_a_builder_one_is_flagged() -> None:
@@ -427,7 +524,7 @@ def test_guard_os_write_reads_the_second_argument() -> None:
 
 
 def test_guard_a_write_outside_the_header_directory_is_not_judged() -> None:
-    """The rule is scoped to the one directory, not to every write.
+    """The write rule is scoped to the one directory, not to every write.
 
     Without the ``gdal_header_dir()`` condition this test's module would be a
     violation, and so would every unrelated file write in the backend.
@@ -438,3 +535,42 @@ def test_guard_a_write_outside_the_header_directory_is_not_judged() -> None:
     )
     assert scan.write_sites == 0
     assert not scan.unguarded_writes
+
+
+def test_guard_a_computed_key_is_judged_on_the_credential_path_only() -> None:
+    """The anti-evasion half of the key rule, and its limit.
+
+    ``key = "Authorization"`` two lines above a ``headers[key] =`` would
+    otherwise be a free pass. Outside the two credential trees the same shape
+    is ordinary response-header plumbing (``response.headers[name] = value``
+    appears throughout the API) and is left alone.
+    """
+    source = (
+        "def f(token):\n"
+        '    key = "Authorization"\n'
+        '    headers[key] = f"Bearer {token}"\n'
+    )
+    on_path = _scan_synthetic(source, "modules/catalog/sources/synthetic.py")
+    assert sum(on_path.unguarded_headers.values()) == 1
+
+    in_processing = _scan_synthetic(source, "processing/ingest/synthetic.py")
+    assert sum(in_processing.unguarded_headers.values()) == 1
+
+    elsewhere = _scan_synthetic(source, "standards/ogc/synthetic.py")
+    assert elsewhere.header_sites == 0
+
+
+def test_guard_a_non_credential_header_is_not_judged() -> None:
+    """Response headers are not this test's business.
+
+    Judging every header assignment would flag the CORS, CSP and ETag writes
+    all over the API, which have nothing to do with a credential.
+    """
+    scan = _scan_synthetic(
+        "def f(response, etag):\n"
+        '    response.headers["ETag"] = etag\n'
+        '    response.headers["Cache-Control"] = "no-store"\n'
+        '    other = {"Accept": "application/json"}\n',
+        "processing/tiles/synthetic.py",
+    )
+    assert scan.header_sites == 0

--- a/backend/tests/test_credential_producer_structural.py
+++ b/backend/tests/test_credential_producer_structural.py
@@ -20,11 +20,14 @@ The two sinks it watches, over the whole ``backend/app/`` tree:
    That directory exists for exactly one thing, the 0600
    ``GDAL_HTTP_HEADER_FILE``, so a write in a scope that located it is a
    credential line by construction.
-2. **A header MAPPING.** A ``headers[...] = ...`` assignment or a dict literal
-   key. Which keys are judged depends on where the code lives:
+2. **A header MAPPING.** A subscript assignment or a dict literal key. Which
+   ones are judged:
 
-   - Tree-wide, the three credential header names (``authorization``,
-     ``proxy-authorization``, ``x-esri-authorization``), case-insensitively.
+   - Tree-wide, any key naming one of the three credential headers
+     (``authorization``, ``proxy-authorization``, ``x-esri-authorization``),
+     case-insensitively, whatever the mapping is called and wherever it goes.
+     That rule has no preconditions, which is why it is the one that catches a
+     composition in a module nobody thought about.
    - On the two credential paths (``modules/catalog/sources/`` and
      ``processing/``), EVERY key of a mapping that reaches an outbound HTTP
      request, minus a short list of headers that cannot carry a credential.
@@ -33,18 +36,21 @@ The two sinks it watches, over the whole ``backend/app/`` tree:
      ``Ocp-Apim-Subscription-Key``. A computed key there is judged too, since
      ``key = "Authorization"`` two lines above would otherwise walk through.
 
+   "Reaches an outbound request" means the dict literal, or the name it is
+   bound to, is passed as a ``headers=`` argument to a request call (``get``,
+   ``post``, ``stream``, ``request`` and the rest). That binding is the whole
+   test for whether a mapping is in scope; the mapping's own name is not
+   consulted, so ``request_options`` is watched exactly as closely as
+   ``headers`` (fix(#1756 codex round 4)). It is also what separates a
+   credential from response-header plumbing: everything under
+   ``processing/export/`` and ``processing/tiles/`` passes ``headers=`` to
+   ``Response``, ``StreamingResponse`` or ``HTTPException``, and none of it
+   leaves the process.
+
    fix(#1756 codex round 1): the mapping rule used to be scoped to
    ``sources/adapters/``, which missed the composition in ``sources/router.py``
    entirely. fix(#1756 codex round 3): and it read only the three credential
    names, so a hand-composed ``X-API-Key`` bypassed it.
-
-   "Reaches an outbound request" means the dict literal, or the name it is
-   bound to, is passed as a ``headers=`` argument to a request call (``get``,
-   ``post``, ``stream``, ``request`` and the rest). That is what separates a
-   credential from response-header plumbing: everything under
-   ``processing/export/`` and ``processing/tiles/`` passes ``headers=`` to
-   ``Response``, ``StreamingResponse`` or ``HTTPException``, and none of it can
-   carry a credential anywhere.
 
 **Provenance is a whole-expression rule, and it depends on the sink.**
 fix(#1756 codex round 2): it used to ask whether the written expression
@@ -63,10 +69,15 @@ Every expression is classified as one of four kinds, or as nothing:
 - NAME and VALUE: the two components of a PAIR, reached by ``<PAIR>[0]`` and
   ``<PAIR>[1]`` or by unpacking ``name, value = build_credential_header(...)``.
 
-The file sink accepts a LINE and nothing else. The mapping sink accepts a
-VALUE for the value, and a NAME or a string constant for the key. So a PAIR
-written whole into a mapping fails, and so does a LINE, which is the round-3
-finding.
+The file sink accepts a LINE and nothing else, so a PAIR or a bare component
+written to the header file fails. The mapping sink accepts a VALUE for the
+value and a NAME for the key, and nothing else: a PAIR written whole fails, a
+LINE fails, and so does a string-literal key (fix(#1756 codex round 4)). The
+key rule is the one that stops ``headers["Authorization"] = pair[1]``, where
+the pair may well be an ``X-API-Key`` pair and the credential would go out
+under the wrong name. It means a clean mapping write is spelled
+``headers[pair[0]] = pair[1]`` or ``headers[name] = value``, which is also the
+only spelling that cannot drift from the builder's own answer.
 
 A name resolves to its latest binding BEFORE the use site, so a later
 ``line = anything_else`` revokes it, and a parameter, loop target, ``with``
@@ -295,7 +306,11 @@ class _Outbound(NamedTuple):
 
 
 def _outbound_header_mappings(scope: ast.AST) -> _Outbound:
-    """Header mappings handed to an outbound request call in *scope*."""
+    """Header mappings handed to an outbound request call in *scope*.
+
+    This binding, and not what the mapping is called, is what puts a mapping
+    in scope for the every-key rule (fix(#1756 codex round 4)).
+    """
     names: set[str] = set()
     dicts: set[int] = set()
     for node in _iter_scope_nodes(scope):
@@ -562,17 +577,22 @@ def _written_value(call: ast.Call) -> ast.expr | None:
     return call.args[index]
 
 
-def _header_container_name(target: ast.expr) -> str | None:
+def _container_name(target: ast.expr) -> str | None:
+    """The name a subscript is written into, whatever it is called.
+
+    fix(#1756 codex round 4): this used to require "header" in the name, so a
+    request-bound ``request_options`` mapping was invisible. The
+    request binding decides scope now; this only reports the name so that
+    binding can be looked up.
+    """
     if not isinstance(target, ast.Subscript):
         return None
     container = target.value
     if isinstance(container, ast.Name):
-        name = container.id
-    elif isinstance(container, ast.Attribute):
-        name = container.attr
-    else:
-        return None
-    return name if "header" in name.lower() else None
+        return container.id
+    if isinstance(container, ast.Attribute):
+        return container.attr
+    return None
 
 
 def _key_is_judged(key: ast.expr, *, credential_path: bool, outbound: bool) -> bool:
@@ -604,14 +624,13 @@ def _header_writes(
             return []
         targets = node.targets if isinstance(node, ast.Assign) else [node.target]
         for target in targets:
-            container = _header_container_name(target)
-            if container is None:
+            if not isinstance(target, ast.Subscript):
                 continue
-            assert isinstance(target, ast.Subscript)
+            container = _container_name(target)
             if _key_is_judged(
                 target.slice,
                 credential_path=credential_path,
-                outbound=container in outbound.names,
+                outbound=container is not None and container in outbound.names,
             ):
                 return [_HeaderWrite(target.slice, node.value)]
         return []
@@ -631,18 +650,18 @@ def _header_writes(
 def _mapping_write_is_clean(
     write: _HeaderWrite, bindings: dict[str, list[_Binding]]
 ) -> bool:
-    """A header mapping takes the pair's VALUE component, never the line.
+    """A header mapping takes the pair's two components, and nothing else.
 
     fix(#1756 codex round 3): ``headers["Authorization"] =
     credential_header_line(pair)`` used to pass, and puts
     ``Authorization: Authorization: Basic ...`` on the wire.
+    fix(#1756 codex round 4): and a string-literal key used to pass, so an
+    ``X-API-Key`` credential could be sent under ``Authorization``. The key
+    has to be the builder's own answer for the two halves to agree.
     """
     if _expr_kind(write.value, bindings, _pos(write.value)) != _VALUE:
         return False
-    key = write.key
-    if isinstance(key, ast.Constant) and isinstance(key.value, str):
-        return True
-    return _expr_kind(key, bindings, _pos(key)) == _NAME
+    return _expr_kind(write.key, bindings, _pos(write.key)) == _NAME
 
 
 class _Scan:
@@ -795,6 +814,62 @@ def _scan_synthetic(source: str, rel: str | None = None) -> _Scan:
     )
 
 
+# ---------------------------------------------------------------------------
+# The blessed shapes. Every way lane B2b can write a credential, one test per
+# sink, so tightening this gate further has to break a test that says what the
+# implementation is allowed to look like.
+# ---------------------------------------------------------------------------
+
+
+def test_guard_every_blessed_file_write_shape_is_clean() -> None:
+    """The header-file sink: a LINE, however it is spelled."""
+    scan = _scan_synthetic(
+        "def f(auth, fd, handle, path):\n"
+        "    directory = gdal_header_dir()\n"
+        "    pair = build_credential_header(auth)\n"
+        "    line = credential_header_line(pair)\n"
+        '    os.write(fd, f"{line}\\n".encode("ascii"))\n'
+        '    os.write(fd, (line + "\\n").encode())\n'
+        "    os.write(fd, credential_header_line(build_credential_header(auth)))\n"
+        "    handle.write(line)\n"
+        "    handle.writelines(line)\n"
+        "    path.write_text(line)\n"
+        '    path.write_bytes(f"{line}\\n".encode("ascii"))\n'
+    )
+    assert scan.write_sites == 7
+    assert not scan.unguarded_writes
+
+
+def test_guard_every_blessed_mapping_shape_is_clean() -> None:
+    """The mapping sink: the pair's NAME as the key, its VALUE as the value.
+
+    Five spellings, which is every one B2b can reasonably reach for: subscript
+    from the pair, subscript from an unpacking, a dict literal bound to a name,
+    a dict literal inline in the request call, and a dict literal merged onto a
+    base. The container is deliberately not called "headers" in one of them.
+    """
+    scan = _scan_synthetic(
+        "def f(auth, client, url, base):\n"
+        "    pair = build_credential_header(auth)\n"
+        "    name, value = build_credential_header(auth)\n"
+        "    request_options = {}\n"
+        "    request_options[pair[0]] = pair[1]\n"
+        "    request_options[name] = value\n"
+        "    client.get(url, headers=request_options)\n"
+        "    bound = {pair[0]: pair[1]}\n"
+        "    client.post(url, headers=bound)\n"
+        "    client.get(url, headers={pair[0]: pair[1]})\n"
+        "    client.stream(url, headers={**base, name: value})\n"
+    )
+    assert scan.header_sites == 5
+    assert not scan.unguarded_headers
+
+
+# ---------------------------------------------------------------------------
+# The rejected shapes, one per way the gate could be walked around.
+# ---------------------------------------------------------------------------
+
+
 def test_guard_an_inline_composition_is_flagged() -> None:
     scan = _scan_synthetic(
         "def f(token, fd, client, url):\n"
@@ -806,38 +881,6 @@ def test_guard_an_inline_composition_is_flagged() -> None:
     assert sum(scan.unguarded_writes.values()) == 1
     assert sum(scan.unguarded_headers.values()) == 2
     assert set(scan.unguarded_writes) == {("modules/catalog/sources/synthetic.py", "f")}
-
-
-def test_guard_a_builder_composition_is_clean() -> None:
-    """The shapes B2b is expected to write, in both sinks."""
-    scan = _scan_synthetic(
-        "def f(auth, fd, client, url):\n"
-        "    path = gdal_header_dir()\n"
-        "    pair = build_credential_header(auth)\n"
-        "    line = credential_header_line(pair)\n"
-        '    os.write(fd, f"{line}\\n".encode("ascii"))\n'
-        "    headers[pair[0]] = pair[1]\n"
-        "    name, value = build_credential_header(auth)\n"
-        "    headers[name] = value\n"
-        "    client.get(url, headers=headers)\n"
-    )
-    assert scan.write_sites == 1
-    assert scan.header_sites == 2
-    assert not scan.unguarded_writes
-    assert not scan.unguarded_headers
-
-
-def test_guard_the_other_allowed_line_shapes_are_clean() -> None:
-    """Concatenation instead of an f-string, and an unencoded line."""
-    scan = _scan_synthetic(
-        "def f(auth, fd, handle):\n"
-        "    path = gdal_header_dir()\n"
-        "    line = credential_header_line(build_credential_header(auth))\n"
-        '    os.write(fd, (line + "\\n").encode())\n'
-        "    handle.write(line)\n"
-    )
-    assert scan.write_sites == 2
-    assert not scan.unguarded_writes
 
 
 def test_guard_the_joiner_alone_confers_nothing() -> None:
@@ -906,6 +949,40 @@ def test_guard_a_whole_pair_in_mapping_position_is_flagged() -> None:
     assert sum(scan.unguarded_headers.values()) == 2
 
 
+def test_guard_a_literal_key_beside_a_builder_value_is_flagged() -> None:
+    """fix(#1756 codex round 4): the two halves have to come from one answer.
+
+    ``headers["Authorization"] = pair[1]`` looks careful and sends an
+    ``X-API-Key`` credential under ``Authorization`` whenever the pair is a
+    header-key one. The key must be the builder's own name component.
+    """
+    scan = _scan_synthetic(
+        "def f(auth, client, url):\n"
+        "    pair = build_credential_header(auth)\n"
+        "    name, value = build_credential_header(auth)\n"
+        "    headers = {}\n"
+        '    headers["Authorization"] = pair[1]\n'
+        "    client.get(url, headers=headers)\n"
+        '    client.post(url, headers={"Authorization": value})\n'
+    )
+    assert scan.header_sites == 2
+    assert sum(scan.unguarded_headers.values()) == 2
+
+
+def test_guard_a_pair_or_component_in_file_position_is_flagged() -> None:
+    """The file wants a finished line, not the pair it was joined from."""
+    scan = _scan_synthetic(
+        "def f(auth, fd):\n"
+        "    directory = gdal_header_dir()\n"
+        "    pair = build_credential_header(auth)\n"
+        "    os.write(fd, pair)\n"
+        "    os.write(fd, pair[1])\n"
+        '    os.write(fd, f"{pair[0]}: {pair[1]}\\n".encode("ascii"))\n'
+    )
+    assert scan.write_sites == 3
+    assert sum(scan.unguarded_writes.values()) == 3
+
+
 def test_guard_concatenating_an_untrusted_name_is_flagged() -> None:
     """Only a trailing newline may be concatenated onto builder output."""
     scan = _scan_synthetic(
@@ -922,16 +999,20 @@ def test_guard_concatenating_an_untrusted_name_is_flagged() -> None:
 def test_guard_a_rebinding_after_the_builder_call_revokes_trust() -> None:
     """The latest binding before the use site is the one that counts."""
     scan = _scan_synthetic(
-        "def f(auth, fd, untrusted):\n"
+        "def f(auth, fd, untrusted, client, url):\n"
         "    path = gdal_header_dir()\n"
         "    line = credential_header_line(build_credential_header(auth))\n"
         "    pair = build_credential_header(auth)\n"
+        "    headers = {}\n"
         "    line = untrusted\n"
         "    pair = untrusted\n"
         '    os.write(fd, f"{line}\\n".encode("ascii"))\n'
-        '    headers["Authorization"] = pair[1]\n'
+        "    headers[pair[0]] = pair[1]\n"
+        "    client.get(url, headers=headers)\n"
     )
+    assert scan.write_sites == 1
     assert sum(scan.unguarded_writes.values()) == 1
+    assert scan.header_sites == 1
     assert sum(scan.unguarded_headers.values()) == 1
 
 
@@ -1016,20 +1097,54 @@ def test_guard_a_custom_api_key_header_is_judged_on_the_credential_paths() -> No
         '    headers = {"Accept": "application/json"}\n'
         '    headers["X-API-Key"] = raw\n'
         "    client.get(url, headers=headers)\n"
+        '    client.post(url, headers={"Ocp-Apim-Subscription-Key": raw})\n'
     )
     for rel in (
         "modules/catalog/sources/synthetic.py",
         "processing/ingest/synthetic.py",
     ):
         scan = _scan_synthetic(source, rel)
-        assert scan.header_sites == 1, rel
-        assert sum(scan.unguarded_headers.values()) == 1, rel
+        assert scan.header_sites == 2, rel
+        assert sum(scan.unguarded_headers.values()) == 2, rel
 
     # Outside the credential paths the same shape is not this rule's business:
     # the three credential names stay covered everywhere, a product header
     # does not.
     elsewhere = _scan_synthetic(source, "standards/ogc/synthetic.py")
     assert elsewhere.header_sites == 0
+
+
+def test_guard_a_mapping_not_called_headers_is_still_judged() -> None:
+    """fix(#1756 codex round 4): the request binding decides scope.
+
+    The name filter this replaced meant ``request_options["X-API-Key"] = raw``
+    was scanned nowhere at all, even though it reaches the wire.
+    """
+    scan = _scan_synthetic(
+        "def f(raw, client, url):\n"
+        "    request_options = {}\n"
+        '    request_options["X-API-Key"] = raw\n'
+        "    client.get(url, headers=request_options)\n"
+    )
+    assert scan.header_sites == 1
+    assert sum(scan.unguarded_headers.values()) == 1
+
+
+def test_guard_a_mapping_with_no_request_binding_keeps_the_name_rule() -> None:
+    """The fallback, so dropping the name filter loses nothing.
+
+    Without a request call in the scope there is no outbound signal, and the
+    three credential names are still judged; a custom key is not.
+    """
+    scan = _scan_synthetic(
+        "def f(raw, token):\n"
+        "    options = {}\n"
+        '    options["X-API-Key"] = raw\n'
+        '    options["Authorization"] = f"Bearer {token}"\n'
+        "    return options\n"
+    )
+    assert scan.header_sites == 1
+    assert sum(scan.unguarded_headers.values()) == 1
 
 
 def test_guard_a_non_credential_header_is_ignored_on_the_credential_paths() -> None:
@@ -1040,8 +1155,9 @@ def test_guard_a_non_credential_header_is_ignored_on_the_credential_paths() -> N
     """
     scan = _scan_synthetic(
         "def f(client, url):\n"
-        '    headers = {"Accept": "application/json", "Content-Type": "application/json"}\n'
+        '    headers = {"Accept": "application/json", "Content-Type": "text/xml"}\n'
         '    headers["Accept-Encoding"] = "gzip"\n'
+        '    headers["Range"] = "bytes=0-0"\n'
         "    client.get(url, headers=headers)\n"
     )
     assert scan.header_sites == 0
@@ -1097,7 +1213,7 @@ def test_guard_a_credential_name_is_judged_everywhere() -> None:
     """
     scan = _scan_synthetic(
         "def f(token):\n"
-        '    headers["X-Esri-Authorization"] = f"Bearer {token}"\n'
+        '    anything["X-Esri-Authorization"] = f"Bearer {token}"\n'
         '    return {"Authorization": f"Bearer {token}"}\n',
         "standards/ogc/synthetic.py",
     )

--- a/backend/tests/test_credential_producer_structural.py
+++ b/backend/tests/test_credential_producer_structural.py
@@ -14,66 +14,78 @@ that fails at the origin with a 401 and reads in a log like a credential
 problem rather than a bug. Once the four are collapsed into the builder,
 nothing except this test stops a fifth appearing beside them.
 
-The two shapes it watches, over the whole ``backend/app/`` tree:
+The two sinks it watches, over the whole ``backend/app/`` tree:
 
-1. **Header-file writes.** Any write in a scope that calls
-   ``gdal_header_dir()``. That directory exists for exactly one thing, the
-   0600 ``GDAL_HTTP_HEADER_FILE``, so a write in a scope that located it is a
+1. **The header FILE.** Any write in a scope that calls ``gdal_header_dir()``.
+   That directory exists for exactly one thing, the 0600
+   ``GDAL_HTTP_HEADER_FILE``, so a write in a scope that located it is a
    credential line by construction.
-2. **Credential header writes.** Any ``headers[...] = ...`` keyed by a
-   credential header name, and any dict literal with such a key. The dict
-   literal is the same composition one line up, and leaving it out would make
-   the rule free to evade.
+2. **A header MAPPING.** A ``headers[...] = ...`` assignment or a dict literal
+   key. Which keys are judged depends on where the code lives:
 
-   Under ``modules/catalog/sources/`` and ``processing/``, a header
-   assignment with a NON-constant key is judged too, because that is where a
-   service credential is actually handled and ``headers[key] = ...`` with
-   ``key = "Authorization"`` two lines above would otherwise walk straight
-   through. Elsewhere in the tree a computed key is left alone: response
-   headers are set that way all over the API (``response.headers[name] =
-   value``), and judging those would be noise, not coverage.
+   - Tree-wide, the three credential header names (``authorization``,
+     ``proxy-authorization``, ``x-esri-authorization``), case-insensitively.
+   - On the two credential paths (``modules/catalog/sources/`` and
+     ``processing/``), EVERY key of a mapping that reaches an outbound HTTP
+     request, minus a short list of headers that cannot carry a credential.
+     That covers the header-key method, whose whole point is a custom name:
+     ``X-API-Key``, Ordnance Survey's literal ``key``, Azure's
+     ``Ocp-Apim-Subscription-Key``. A computed key there is judged too, since
+     ``key = "Authorization"`` two lines above would otherwise walk through.
 
-   fix(#1756 codex round 1): this rule used to be scoped to
+   fix(#1756 codex round 1): the mapping rule used to be scoped to
    ``sources/adapters/``, which missed the composition in ``sources/router.py``
-   entirely. Scope now comes from the key, not from the directory.
+   entirely. fix(#1756 codex round 3): and it read only the three credential
+   names, so a hand-composed ``X-API-Key`` bypassed it.
 
-**Provenance is a whole-expression rule.** fix(#1756 codex round 2): it used
-to ask whether the written expression MENTIONED builder output anywhere, which
-passed ``f"Authorization: Bearer {line}"`` for a builder-derived ``line``, the
-exact double-prefix string this module exists to prevent. It now asks whether
-the whole expression is one of these projections of builder output, and
-nothing else is accepted:
+   "Reaches an outbound request" means the dict literal, or the name it is
+   bound to, is passed as a ``headers=`` argument to a request call (``get``,
+   ``post``, ``stream``, ``request`` and the rest). That is what separates a
+   credential from response-header plumbing: everything under
+   ``processing/export/`` and ``processing/tiles/`` passes ``headers=`` to
+   ``Response``, ``StreamingResponse`` or ``HTTPException``, and none of it can
+   carry a credential anywhere.
 
-- ``build_credential_header(...)`` itself.
-- a name whose latest binding BEFORE the use site is an allowed expression, so
-  a later ``line = anything_else`` revokes it, and a parameter, loop target or
-  ``with`` target carries no provenance at all.
-- ``credential_header_line(<allowed>)``, one positional argument. The joiner
-  on its own only concatenates the pair it is handed, so
-  ``credential_header_line(("Authorization", value))`` is not allowed.
-- ``<allowed> + "\\n"``, or an f-string whose single interpolation is
-  ``<allowed>`` with no conversion and no format spec, and whose only literal
-  part, if any, is a trailing newline.
-- ``.encode()`` or ``.encode("ascii")`` on an allowed expression.
-- ``<allowed pair>[0]`` and ``[1]``, and a name unpacked from an allowed pair,
-  for the header-dict case.
+**Provenance is a whole-expression rule, and it depends on the sink.**
+fix(#1756 codex round 2): it used to ask whether the written expression
+MENTIONED builder output anywhere, which passed
+``f"Authorization: Bearer {line}"`` for a builder-derived ``line``.
+fix(#1756 codex round 3): and it accepted a joined line in mapping position,
+which puts ``Authorization: Authorization: Basic ...`` on the wire.
 
-Any other operator, any extra literal text, a second interpolation, or a
-format spec fails. A credential that arrives as a parameter has no lexical
-provenance and is therefore reported: the fix is to compose it at the write
-site, not to widen this rule.
+Every expression is classified as one of four kinds, or as nothing:
+
+- PAIR: ``build_credential_header(...)``, or a name bound to a PAIR.
+- LINE: ``credential_header_line(<PAIR>)``; ``<LINE> + "\\n"``; an f-string
+  whose single interpolation is a LINE, with no conversion, no format spec and
+  no literal part but a trailing newline; ``.encode()`` or ``.encode("ascii")``
+  on a LINE; or a name bound to a LINE.
+- NAME and VALUE: the two components of a PAIR, reached by ``<PAIR>[0]`` and
+  ``<PAIR>[1]`` or by unpacking ``name, value = build_credential_header(...)``.
+
+The file sink accepts a LINE and nothing else. The mapping sink accepts a
+VALUE for the value, and a NAME or a string constant for the key. So a PAIR
+written whole into a mapping fails, and so does a LINE, which is the round-3
+finding.
+
+A name resolves to its latest binding BEFORE the use site, so a later
+``line = anything_else`` revokes it, and a parameter, loop target, ``with``
+target or import carries no provenance at all.
 
 Both allowlists are asserted EXACT in both directions and by count, so an
 entry whose site disappears fails loudly instead of going stale. Four of the
-five credential-header entries are the compositions lane B2b deletes; this
-test is what tells it when the last one is gone.
+five mapping entries are the compositions lane B2b deletes; this test is what
+tells it when the last one is gone.
 
 WHAT THIS DOES NOT CLAIM, in the same spirit as the Rule-2 guard. It is a
 lexical rule, not dataflow. A line built in one function and written in
-another, a header dict assembled through ``update()`` from a value computed
-elsewhere, and a binding made under one branch of an ``if`` and used under the
+another, a header mapping assembled through ``update()``, a mapping handed to
+a helper that makes the request rather than passed to the request call in the
+same scope, and a binding made under one branch of an ``if`` and used under the
 other are all outside what an AST rule can answer. Binding order is read from
 source position, which is the straight-line answer and not a control-flow one.
+The tree-wide credential-name rule has none of those preconditions, so the
+three names that matter most stay covered whatever the surrounding shape.
 False alarms are cheap and visible; a silent miss is the failure that matters,
 so anything the resolver cannot classify is reported.
 """
@@ -96,18 +108,56 @@ CREDENTIAL_JOINER = "credential_header_line"
 # it is writing a credential header or nothing at all.
 HEADER_DIR_HELPER = "gdal_header_dir"
 
-# Where a computed header key is judged as well as a literal one: the two
-# trees that handle a service credential.
-DYNAMIC_KEY_PACKAGES = ("modules/catalog/sources/", "processing/")
+# The two trees that handle a service credential, where every outbound header
+# key is judged rather than only the three credential names.
+CREDENTIAL_PACKAGES = ("modules/catalog/sources/", "processing/")
 
 # Write calls, by exact name. Substring matching would sweep in unrelated
 # helpers: `_tenant_writer_subprocess_env` contains "write".
 WRITE_CALL_NAMES = frozenset({"write", "writelines", "write_text", "write_bytes"})
 
+# Calls that SEND a request. A header mapping handed to one of these leaves
+# the process; one handed to Response/StreamingResponse/HTTPException does
+# not, and cannot carry a credential to a third party.
+OUTBOUND_REQUEST_CALLS = frozenset(
+    {
+        "get",
+        "post",
+        "put",
+        "patch",
+        "delete",
+        "head",
+        "options",
+        "request",
+        "stream",
+        "send",
+        "build_request",
+    }
+)
+
 # Header names that carry a credential, compared case-insensitively because
-# HTTP field names are case-insensitive.
+# HTTP field names are case-insensitive. Judged everywhere in the tree.
 CREDENTIAL_HEADER_KEYS = frozenset(
     {"authorization", "proxy-authorization", "x-esri-authorization"}
+)
+
+# Request headers that cannot carry a credential, so they are exempt from the
+# every-key rule on the credential paths. Deliberately short and explicit: a
+# long list would turn the rule back into the three-name one by attrition.
+NON_CREDENTIAL_HEADERS = frozenset(
+    {
+        "accept",
+        "accept-encoding",
+        "accept-language",
+        "cache-control",
+        "content-length",
+        "content-type",
+        "if-modified-since",
+        "if-none-match",
+        "range",
+        "user-agent",
+        "x-request-id",
+    }
 )
 
 # Every allowlist entry is (module, scope) -> (exact count, justification).
@@ -165,6 +215,13 @@ _NESTED_SCOPES = (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda, ast.ClassDe
 # binding made later in the body.
 _SCOPE_START = (-1, -1)
 
+# The four kinds an expression can carry. See the module docstring.
+_PAIR = "pair"
+_LINE = "line"
+_NAME = "name"
+_VALUE = "value"
+_COMPONENT_KINDS = {0: _NAME, 1: _VALUE}
+
 
 def _app_modules() -> list[tuple[str, ast.Module]]:
     modules = []
@@ -215,16 +272,8 @@ def _pos(node: ast.AST) -> tuple[int, int]:
     return (getattr(node, "lineno", 0), getattr(node, "col_offset", 0))
 
 
-class _Binding(NamedTuple):
-    """One binding of a name inside a scope.
-
-    ``value`` is None when the binding is something this rule cannot judge: a
-    parameter, a loop target, an import. Such a binding is RECORDED rather
-    than skipped, because it has to revoke an earlier builder binding.
-    """
-
-    pos: tuple[int, int]
-    value: ast.expr | None
+def _is_header_keyword(keyword: ast.keyword) -> bool:
+    return bool(keyword.arg) and "header" in keyword.arg.lower()
 
 
 def _iter_scope_nodes(scope: ast.AST):
@@ -236,6 +285,59 @@ def _iter_scope_nodes(scope: ast.AST):
         if isinstance(node, _NESTED_SCOPES):
             continue
         stack.extend(ast.iter_child_nodes(node))
+
+
+class _Outbound(NamedTuple):
+    """The header mappings in one scope that reach a request call."""
+
+    names: frozenset[str]
+    dicts: frozenset[int]
+
+
+def _outbound_header_mappings(scope: ast.AST) -> _Outbound:
+    """Header mappings handed to an outbound request call in *scope*."""
+    names: set[str] = set()
+    dicts: set[int] = set()
+    for node in _iter_scope_nodes(scope):
+        if not isinstance(node, ast.Call):
+            continue
+        if _call_name(node.func) not in OUTBOUND_REQUEST_CALLS:
+            continue
+        for keyword in node.keywords:
+            if not _is_header_keyword(keyword):
+                continue
+            if isinstance(keyword.value, ast.Dict):
+                dicts.add(id(keyword.value))
+            elif isinstance(keyword.value, ast.Name):
+                names.add(keyword.value.id)
+
+    # The literal a request-bound name was built from is the same mapping.
+    for node in _iter_scope_nodes(scope):
+        if not isinstance(node, (ast.Assign, ast.AnnAssign)):
+            continue
+        if not isinstance(node.value, ast.Dict):
+            continue
+        targets = node.targets if isinstance(node, ast.Assign) else [node.target]
+        for target in targets:
+            if isinstance(target, ast.Name) and target.id in names:
+                dicts.add(id(node.value))
+    return _Outbound(frozenset(names), frozenset(dicts))
+
+
+class _Binding(NamedTuple):
+    """One binding of a name inside a scope.
+
+    ``value`` is None when the binding is something this rule cannot judge: a
+    parameter, a loop target, an import. Such a binding is RECORDED rather
+    than skipped, because it has to revoke an earlier builder binding.
+    ``index`` is the position within a tuple target, so
+    ``name, value = build_credential_header(auth)`` gives each name the right
+    component kind.
+    """
+
+    pos: tuple[int, int]
+    value: ast.expr | None
+    index: int | None = None
 
 
 def _scope_arguments(scope: ast.AST) -> list[str]:
@@ -286,14 +388,14 @@ def _scope_bindings(scope: ast.AST) -> dict[str, list[_Binding]]:
     """Every name binding in *scope*, ordered by source position."""
     bindings: dict[str, list[_Binding]] = defaultdict(list)
 
-    def record(target: ast.expr, value: ast.expr | None) -> None:
+    def record(
+        target: ast.expr, value: ast.expr | None, index: int | None = None
+    ) -> None:
         if isinstance(target, ast.Name):
-            bindings[target.id].append(_Binding(_pos(target), value))
+            bindings[target.id].append(_Binding(_pos(target), value, index))
         elif isinstance(target, (ast.Tuple, ast.List)):
-            # A component of an allowed pair is allowed, which is what makes
-            # `name, value = build_credential_header(auth)` usable.
-            for element in target.elts:
-                record(element, value)
+            for position, element in enumerate(target.elts):
+                record(element, value, position)
         elif isinstance(target, ast.Starred):
             record(target.value, None)
 
@@ -329,10 +431,70 @@ def _is_newline_literal(expr: ast.expr) -> bool:
     return isinstance(expr, ast.Constant) and expr.value == "\n"
 
 
-def _is_line_fstring(
+def _call_kind(
+    expr: ast.Call, bindings: dict[str, list[_Binding]], limit: tuple[int, int]
+) -> str | None:
+    name = _call_name(expr.func)
+    if name == CREDENTIAL_BUILDER:
+        return _PAIR
+    if name == CREDENTIAL_JOINER:
+        if len(expr.args) != 1 or expr.keywords:
+            return None
+        argument = _expr_kind(expr.args[0], bindings, limit)
+        return _LINE if argument == _PAIR else None
+    if name != "encode":
+        return None
+    if not isinstance(expr.func, ast.Attribute) or expr.keywords:
+        return None
+    if len(expr.args) > 1:
+        return None
+    if expr.args and not (
+        isinstance(expr.args[0], ast.Constant) and expr.args[0].value == "ascii"
+    ):
+        return None
+    encoded = _expr_kind(expr.func.value, bindings, limit)
+    return _LINE if encoded == _LINE else None
+
+
+def _name_kind(
+    expr: ast.Name, bindings: dict[str, list[_Binding]], limit: tuple[int, int]
+) -> str | None:
+    binding = _binding_before(bindings, expr.id, limit)
+    if binding is None or binding.value is None:
+        return None
+    bound = _expr_kind(binding.value, bindings, binding.pos)
+    if binding.index is None:
+        return bound
+    if bound != _PAIR:
+        return None
+    return _COMPONENT_KINDS.get(binding.index)
+
+
+def _component_kind(
+    expr: ast.Subscript, bindings: dict[str, list[_Binding]], limit: tuple[int, int]
+) -> str | None:
+    index = expr.slice
+    if not isinstance(index, ast.Constant) or isinstance(index.value, bool):
+        return None
+    if index.value not in _COMPONENT_KINDS:
+        return None
+    if _expr_kind(expr.value, bindings, limit) != _PAIR:
+        return None
+    return _COMPONENT_KINDS[index.value]
+
+
+def _concat_kind(
+    expr: ast.BinOp, bindings: dict[str, list[_Binding]], limit: tuple[int, int]
+) -> str | None:
+    if not isinstance(expr.op, ast.Add) or not _is_newline_literal(expr.right):
+        return None
+    return _LINE if _expr_kind(expr.left, bindings, limit) == _LINE else None
+
+
+def _fstring_kind(
     expr: ast.JoinedStr, bindings: dict[str, list[_Binding]], limit: tuple[int, int]
-) -> bool:
-    """One interpolation of an allowed expression, plus a trailing newline."""
+) -> str | None:
+    """One interpolation of a LINE, plus at most a trailing newline."""
     interpolations = [
         value for value in expr.values if isinstance(value, ast.FormattedValue)
     ]
@@ -340,51 +502,26 @@ def _is_line_fstring(
         value for value in expr.values if not isinstance(value, ast.FormattedValue)
     ]
     if len(interpolations) != 1 or len(literals) > 1:
-        return False
+        return None
     if literals and not (
         literals[0] is expr.values[-1] and _is_newline_literal(literals[0])
     ):
-        return False
+        return None
     placeholder = interpolations[0]
     if placeholder.conversion != -1 or placeholder.format_spec is not None:
-        return False
-    return _is_builder_projection(placeholder.value, bindings, limit)
+        return None
+    inner = _expr_kind(placeholder.value, bindings, limit)
+    return _LINE if inner == _LINE else None
 
 
-def _is_pair_component(
-    expr: ast.Subscript, bindings: dict[str, list[_Binding]], limit: tuple[int, int]
-) -> bool:
-    index = expr.slice
-    if not isinstance(index, ast.Constant) or isinstance(index.value, bool):
-        return False
-    if index.value not in (0, 1):
-        return False
-    return _is_builder_projection(expr.value, bindings, limit)
-
-
-def _is_encode_call(
-    expr: ast.Call, bindings: dict[str, list[_Binding]], limit: tuple[int, int]
-) -> bool:
-    if not isinstance(expr.func, ast.Attribute) or expr.keywords:
-        return False
-    if len(expr.args) > 1:
-        return False
-    if expr.args and not (
-        isinstance(expr.args[0], ast.Constant) and expr.args[0].value == "ascii"
-    ):
-        return False
-    return _is_builder_projection(expr.func.value, bindings, limit)
-
-
-def _is_builder_projection(
+def _expr_kind(
     expr: ast.expr, bindings: dict[str, list[_Binding]], limit: tuple[int, int]
-) -> bool:
-    """Whether the WHOLE of *expr* is an allowed projection of builder output.
+) -> str | None:
+    """What the WHOLE of *expr* is, as one of the four kinds, or nothing.
 
-    The allowed shapes are enumerated in the module docstring. Anything else
-    is a violation, including an expression that merely CONTAINS builder
-    output: that was the round-2 hole, and ``f"Authorization: Bearer {line}"``
-    is exactly the string it let through.
+    An expression that merely CONTAINS builder output is nothing: that was the
+    round-2 hole, and ``f"Authorization: Bearer {line}"`` is exactly the string
+    it let through.
 
     Name resolution walks backwards: a name resolves to its latest binding
     before *limit*, and that binding's own value is then judged with the
@@ -393,34 +530,16 @@ def _is_builder_projection(
     of recursing forever.
     """
     if isinstance(expr, ast.Call):
-        name = _call_name(expr.func)
-        if name == CREDENTIAL_BUILDER:
-            return True
-        if name == CREDENTIAL_JOINER:
-            return (
-                len(expr.args) == 1
-                and not expr.keywords
-                and _is_builder_projection(expr.args[0], bindings, limit)
-            )
-        if name == "encode":
-            return _is_encode_call(expr, bindings, limit)
-        return False
+        return _call_kind(expr, bindings, limit)
     if isinstance(expr, ast.Name):
-        binding = _binding_before(bindings, expr.id, limit)
-        if binding is None or binding.value is None:
-            return False
-        return _is_builder_projection(binding.value, bindings, binding.pos)
-    if isinstance(expr, ast.BinOp):
-        return (
-            isinstance(expr.op, ast.Add)
-            and _is_newline_literal(expr.right)
-            and _is_builder_projection(expr.left, bindings, limit)
-        )
-    if isinstance(expr, ast.JoinedStr):
-        return _is_line_fstring(expr, bindings, limit)
+        return _name_kind(expr, bindings, limit)
     if isinstance(expr, ast.Subscript):
-        return _is_pair_component(expr, bindings, limit)
-    return False
+        return _component_kind(expr, bindings, limit)
+    if isinstance(expr, ast.BinOp):
+        return _concat_kind(expr, bindings, limit)
+    if isinstance(expr, ast.JoinedStr):
+        return _fstring_kind(expr, bindings, limit)
+    return None
 
 
 def _written_value(call: ast.Call) -> ast.expr | None:
@@ -456,41 +575,74 @@ def _header_container_name(target: ast.expr) -> str | None:
     return name if "header" in name.lower() else None
 
 
-def _is_credential_key(key: ast.expr, allow_dynamic_key: bool) -> bool:
+def _key_is_judged(key: ast.expr, *, credential_path: bool, outbound: bool) -> bool:
+    """Whether a header under *key* is this rule's business."""
     if isinstance(key, ast.Constant):
-        return (
-            isinstance(key.value, str) and key.value.lower() in CREDENTIAL_HEADER_KEYS
-        )
-    # A computed key cannot be read off the AST. In the two trees that handle
-    # a service credential that is a violation waiting to happen, so it is
-    # judged; everywhere else it is ordinary response-header plumbing.
-    return allow_dynamic_key
+        if not isinstance(key.value, str):
+            return False
+        lowered = key.value.lower()
+        if lowered in CREDENTIAL_HEADER_KEYS:
+            return True
+        return credential_path and outbound and lowered not in NON_CREDENTIAL_HEADERS
+    # A computed key cannot be read off the AST. On an outbound mapping in the
+    # two credential trees that is a violation waiting to happen; elsewhere it
+    # is ordinary response-header plumbing.
+    return credential_path and outbound
 
 
-def _credential_header_values(node: ast.AST, allow_dynamic_key: bool) -> list[ast.expr]:
-    """Every value *node* writes under a credential header name.
+class _HeaderWrite(NamedTuple):
+    key: ast.expr
+    value: ast.expr
 
-    Two shapes: a subscript assignment into a name that reads as a header
-    mapping, and a dict literal keyed by a credential header name.
-    """
+
+def _header_writes(
+    node: ast.AST, *, credential_path: bool, outbound: _Outbound
+) -> list[_HeaderWrite]:
+    """Every key and value *node* writes into a header mapping."""
     if isinstance(node, (ast.Assign, ast.AnnAssign)):
         if node.value is None:
             return []
         targets = node.targets if isinstance(node, ast.Assign) else [node.target]
         for target in targets:
-            if _header_container_name(target) is None:
+            container = _header_container_name(target)
+            if container is None:
                 continue
             assert isinstance(target, ast.Subscript)
-            if _is_credential_key(target.slice, allow_dynamic_key):
-                return [node.value]
+            if _key_is_judged(
+                target.slice,
+                credential_path=credential_path,
+                outbound=container in outbound.names,
+            ):
+                return [_HeaderWrite(target.slice, node.value)]
         return []
     if isinstance(node, ast.Dict):
+        reaches_a_request = id(node) in outbound.dicts
         return [
-            value
+            _HeaderWrite(key, value)
             for key, value in zip(node.keys, node.values, strict=True)
-            if key is not None and _is_credential_key(key, allow_dynamic_key=False)
+            if key is not None
+            and _key_is_judged(
+                key, credential_path=credential_path, outbound=reaches_a_request
+            )
         ]
     return []
+
+
+def _mapping_write_is_clean(
+    write: _HeaderWrite, bindings: dict[str, list[_Binding]]
+) -> bool:
+    """A header mapping takes the pair's VALUE component, never the line.
+
+    fix(#1756 codex round 3): ``headers["Authorization"] =
+    credential_header_line(pair)`` used to pass, and puts
+    ``Authorization: Authorization: Basic ...`` on the wire.
+    """
+    if _expr_kind(write.value, bindings, _pos(write.value)) != _VALUE:
+        return False
+    key = write.key
+    if isinstance(key, ast.Constant) and isinstance(key.value, str):
+        return True
+    return _expr_kind(key, bindings, _pos(key)) == _NAME
 
 
 class _Scan:
@@ -509,44 +661,51 @@ class _Scan:
         self.header_sites += other.header_sites
 
 
+class _ScopeFacts(NamedTuple):
+    bindings: dict[str, list[_Binding]]
+    outbound: _Outbound
+    writes_a_header_file: bool
+
+
+def _scope_facts(scope: ast.AST) -> _ScopeFacts:
+    return _ScopeFacts(
+        _scope_bindings(scope),
+        _outbound_header_mappings(scope),
+        _scope_calls(scope, HEADER_DIR_HELPER),
+    )
+
+
 def _scan_module(rel: str, tree: ast.Module) -> _Scan:
     _annotate_parents(tree)
     scan = _Scan()
-    allow_dynamic_key = rel.startswith(DYNAMIC_KEY_PACKAGES)
-    bindings_cache: dict[int, dict[str, list[_Binding]]] = {}
-    header_dir_cache: dict[int, bool] = {}
+    credential_path = rel.startswith(CREDENTIAL_PACKAGES)
+    facts_cache: dict[int, _ScopeFacts] = {}
 
     for node in ast.walk(tree):
         is_write = (
             isinstance(node, ast.Call) and _call_name(node.func) in WRITE_CALL_NAMES
         )
-        header_values = _credential_header_values(node, allow_dynamic_key)
-        if not is_write and not header_values:
+        if not is_write and not isinstance(node, (ast.Assign, ast.AnnAssign, ast.Dict)):
             continue
 
         scope = _enclosing_scope(node, tree)
-        bindings = bindings_cache.get(id(scope))
-        if bindings is None:
-            bindings = _scope_bindings(scope)
-            bindings_cache[id(scope)] = bindings
+        facts = facts_cache.get(id(scope))
+        if facts is None:
+            facts = _scope_facts(scope)
+            facts_cache[id(scope)] = facts
         site = (rel, _scope_name(scope))
 
-        if is_write:
-            writes_a_header = header_dir_cache.get(id(scope))
-            if writes_a_header is None:
-                writes_a_header = _scope_calls(scope, HEADER_DIR_HELPER)
-                header_dir_cache[id(scope)] = writes_a_header
-            if writes_a_header:
-                scan.write_sites += 1
-                value = _written_value(node)  # type: ignore[arg-type]
-                if value is None or not _is_builder_projection(
-                    value, bindings, _pos(value)
-                ):
-                    scan.unguarded_writes[site] += 1
+        if is_write and facts.writes_a_header_file:
+            scan.write_sites += 1
+            value = _written_value(node)  # type: ignore[arg-type]
+            if value is None or _expr_kind(value, facts.bindings, _pos(value)) != _LINE:
+                scan.unguarded_writes[site] += 1
 
-        for value in header_values:
+        for write in _header_writes(
+            node, credential_path=credential_path, outbound=facts.outbound
+        ):
             scan.header_sites += 1
-            if not _is_builder_projection(value, bindings, _pos(value)):
+            if not _mapping_write_is_clean(write, facts.bindings):
                 scan.unguarded_headers[site] += 1
 
     return scan
@@ -638,11 +797,11 @@ def _scan_synthetic(source: str, rel: str | None = None) -> _Scan:
 
 def test_guard_an_inline_composition_is_flagged() -> None:
     scan = _scan_synthetic(
-        "def f(token, fd):\n"
+        "def f(token, fd, client, url):\n"
         "    path = gdal_header_dir()\n"
         '    os.write(fd, f"Authorization: Bearer {token}\\n".encode("ascii"))\n'
         '    headers["Authorization"] = f"Bearer {token}"\n'
-        '    other = {"Authorization": f"Bearer {token}"}\n'
+        '    client.get(url, headers={"Authorization": f"Bearer {token}"})\n'
     )
     assert sum(scan.unguarded_writes.values()) == 1
     assert sum(scan.unguarded_headers.values()) == 2
@@ -650,14 +809,17 @@ def test_guard_an_inline_composition_is_flagged() -> None:
 
 
 def test_guard_a_builder_composition_is_clean() -> None:
+    """The shapes B2b is expected to write, in both sinks."""
     scan = _scan_synthetic(
-        "def f(auth, fd):\n"
+        "def f(auth, fd, client, url):\n"
         "    path = gdal_header_dir()\n"
         "    pair = build_credential_header(auth)\n"
         "    line = credential_header_line(pair)\n"
         '    os.write(fd, f"{line}\\n".encode("ascii"))\n'
         "    headers[pair[0]] = pair[1]\n"
-        '    other = {"Authorization": credential_header_line(pair)}\n'
+        "    name, value = build_credential_header(auth)\n"
+        "    headers[name] = value\n"
+        "    client.get(url, headers=headers)\n"
     )
     assert scan.write_sites == 1
     assert scan.header_sites == 2
@@ -665,25 +827,17 @@ def test_guard_a_builder_composition_is_clean() -> None:
     assert not scan.unguarded_headers
 
 
-def test_guard_the_other_allowed_projections_are_clean() -> None:
-    """The shapes B2b may reasonably write, spelled out.
-
-    Concatenation instead of an f-string, an unencoded line, and the pair
-    unpacked into two names.
-    """
+def test_guard_the_other_allowed_line_shapes_are_clean() -> None:
+    """Concatenation instead of an f-string, and an unencoded line."""
     scan = _scan_synthetic(
         "def f(auth, fd, handle):\n"
         "    path = gdal_header_dir()\n"
         "    line = credential_header_line(build_credential_header(auth))\n"
         '    os.write(fd, (line + "\\n").encode())\n'
         "    handle.write(line)\n"
-        "    name, value = build_credential_header(auth)\n"
-        "    headers[name] = value\n"
     )
     assert scan.write_sites == 2
-    assert scan.header_sites == 1
     assert not scan.unguarded_writes
-    assert not scan.unguarded_headers
 
 
 def test_guard_the_joiner_alone_confers_nothing() -> None:
@@ -721,6 +875,37 @@ def test_guard_a_double_prefix_around_a_builder_line_is_flagged() -> None:
     assert sum(scan.unguarded_headers.values()) == 1
 
 
+def test_guard_a_joined_line_in_mapping_position_is_flagged() -> None:
+    """fix(#1756 codex round 3): the wire header would carry the name twice.
+
+    ``credential_header_line`` output under a header key sends
+    ``Authorization: Authorization: Basic <blob>``. The mapping sink takes the
+    pair's VALUE component and nothing else.
+    """
+    scan = _scan_synthetic(
+        "def f(auth, client, url):\n"
+        "    pair = build_credential_header(auth)\n"
+        "    headers = {}\n"
+        "    headers[pair[0]] = credential_header_line(pair)\n"
+        "    client.get(url, headers=headers)\n"
+        "    other = credential_header_line(pair)\n"
+        '    client.get(url, headers={"Authorization": other})\n'
+    )
+    assert scan.header_sites == 2
+    assert sum(scan.unguarded_headers.values()) == 2
+
+
+def test_guard_a_whole_pair_in_mapping_position_is_flagged() -> None:
+    """A tuple under a header key is not a header value."""
+    scan = _scan_synthetic(
+        "def f(auth, client, url):\n"
+        "    pair = build_credential_header(auth)\n"
+        '    headers["Authorization"] = pair\n'
+        '    client.get(url, headers={"Authorization": build_credential_header(auth)})\n'
+    )
+    assert sum(scan.unguarded_headers.values()) == 2
+
+
 def test_guard_concatenating_an_untrusted_name_is_flagged() -> None:
     """Only a trailing newline may be concatenated onto builder output."""
     scan = _scan_synthetic(
@@ -740,9 +925,11 @@ def test_guard_a_rebinding_after_the_builder_call_revokes_trust() -> None:
         "def f(auth, fd, untrusted):\n"
         "    path = gdal_header_dir()\n"
         "    line = credential_header_line(build_credential_header(auth))\n"
+        "    pair = build_credential_header(auth)\n"
         "    line = untrusted\n"
+        "    pair = untrusted\n"
         '    os.write(fd, f"{line}\\n".encode("ascii"))\n'
-        '    headers["Authorization"] = line\n'
+        '    headers["Authorization"] = pair[1]\n'
     )
     assert sum(scan.unguarded_writes.values()) == 1
     assert sum(scan.unguarded_headers.values()) == 1
@@ -818,6 +1005,65 @@ def test_guard_a_write_outside_the_header_directory_is_not_judged() -> None:
     assert not scan.unguarded_writes
 
 
+def test_guard_a_custom_api_key_header_is_judged_on_the_credential_paths() -> None:
+    """fix(#1756 codex round 3): the header-key method's whole point.
+
+    A hand-composed ``X-API-Key`` is a credential in exactly the way an
+    ``Authorization`` header is, and the three-name rule could not see it.
+    """
+    source = (
+        "def f(raw, client, url):\n"
+        '    headers = {"Accept": "application/json"}\n'
+        '    headers["X-API-Key"] = raw\n'
+        "    client.get(url, headers=headers)\n"
+    )
+    for rel in (
+        "modules/catalog/sources/synthetic.py",
+        "processing/ingest/synthetic.py",
+    ):
+        scan = _scan_synthetic(source, rel)
+        assert scan.header_sites == 1, rel
+        assert sum(scan.unguarded_headers.values()) == 1, rel
+
+    # Outside the credential paths the same shape is not this rule's business:
+    # the three credential names stay covered everywhere, a product header
+    # does not.
+    elsewhere = _scan_synthetic(source, "standards/ogc/synthetic.py")
+    assert elsewhere.header_sites == 0
+
+
+def test_guard_a_non_credential_header_is_ignored_on_the_credential_paths() -> None:
+    """``Accept`` and friends cannot carry a credential.
+
+    The exemption list is what keeps the every-key rule from flagging the
+    ``Accept`` header every adapter sets.
+    """
+    scan = _scan_synthetic(
+        "def f(client, url):\n"
+        '    headers = {"Accept": "application/json", "Content-Type": "application/json"}\n'
+        '    headers["Accept-Encoding"] = "gzip"\n'
+        "    client.get(url, headers=headers)\n"
+    )
+    assert scan.header_sites == 0
+
+
+def test_guard_a_response_header_is_not_judged() -> None:
+    """Response headers are not this rule's business.
+
+    Everything under processing/export/ and processing/tiles/ passes
+    ``headers=`` to Response, StreamingResponse or HTTPException, and none of
+    it can carry a credential to a third party.
+    """
+    scan = _scan_synthetic(
+        "def f(etag, body):\n"
+        '    response.headers["ETag"] = etag\n'
+        '    response.headers["X-GeoLens-Cache-Status"] = "hit"\n'
+        '    return Response(body, headers={"X-GeoLens-Band-Count": "3"})\n',
+        "processing/tiles/synthetic.py",
+    )
+    assert scan.header_sites == 0
+
+
 def test_guard_a_computed_key_is_judged_on_the_credential_path_only() -> None:
     """The anti-evasion half of the key rule, and its limit.
 
@@ -827,9 +1073,11 @@ def test_guard_a_computed_key_is_judged_on_the_credential_path_only() -> None:
     appears throughout the API) and is left alone.
     """
     source = (
-        "def f(token):\n"
+        "def f(token, client, url):\n"
         '    key = "Authorization"\n'
+        "    headers = {}\n"
         '    headers[key] = f"Bearer {token}"\n'
+        "    client.get(url, headers=headers)\n"
     )
     on_path = _scan_synthetic(source, "modules/catalog/sources/synthetic.py")
     assert sum(on_path.unguarded_headers.values()) == 1
@@ -841,20 +1089,20 @@ def test_guard_a_computed_key_is_judged_on_the_credential_path_only() -> None:
     assert elsewhere.header_sites == 0
 
 
-def test_guard_a_non_credential_header_is_not_judged() -> None:
-    """Response headers are not this test's business.
+def test_guard_a_credential_name_is_judged_everywhere() -> None:
+    """The three names need no outbound signal and no credential path.
 
-    Judging every header assignment would flag the CORS, CSP and ETag writes
-    all over the API, which have nothing to do with a credential.
+    This is the half of the rule with no preconditions, which is why it is
+    the one that catches a composition in a module nobody thought about.
     """
     scan = _scan_synthetic(
-        "def f(response, etag):\n"
-        '    response.headers["ETag"] = etag\n'
-        '    response.headers["Cache-Control"] = "no-store"\n'
-        '    other = {"Accept": "application/json"}\n',
-        "processing/tiles/synthetic.py",
+        "def f(token):\n"
+        '    headers["X-Esri-Authorization"] = f"Bearer {token}"\n'
+        '    return {"Authorization": f"Bearer {token}"}\n',
+        "standards/ogc/synthetic.py",
     )
-    assert scan.header_sites == 0
+    assert scan.header_sites == 2
+    assert sum(scan.unguarded_headers.values()) == 2
 
 
 def test_guard_a_self_reference_terminates() -> None:

--- a/backend/tests/test_credential_producer_structural.py
+++ b/backend/tests/test_credential_producer_structural.py
@@ -1,0 +1,440 @@
+"""One producer of a credential header, enforced structurally (fix(#1746)).
+
+In the shape of ``test_rule2_structural.py``: walk every module under
+``backend/app/`` as an AST and assert that the two transports which carry a
+service credential get their header from ``build_credential_header`` and
+``credential_header_line`` in ``app/core/service_tokens.py`` rather than
+composing one of their own.
+
+Why a structural test rather than a code comment. The prefix is composed today
+in four separate places, and handing any of them a finished line without
+removing its own composition produces ``Authorization: Bearer Authorization:
+Basic <blob>``, a working-looking string that fails at the origin with a 401
+and reads in a log like a credential problem rather than a bug. Once the four
+are collapsed into the builder, nothing except this test stops a fifth
+appearing beside them.
+
+The two shapes it watches:
+
+1. **Header-file writes.** Any write in a scope that calls
+   ``gdal_header_dir()``. That directory exists for exactly one thing, the
+   0600 ``GDAL_HTTP_HEADER_FILE``, so a write in a scope that located it is a
+   credential line by construction.
+2. **Adapter header assignments.** Any ``headers[...] = ...`` under
+   ``modules/catalog/sources/adapters/``, and any dict literal there keyed by
+   a credential header name, which is the same composition wearing a literal.
+
+Both allowlists are asserted EXACT in both directions and by count, so an
+entry whose site disappears fails loudly instead of going stale. The four
+entries below are the four compositions that exist today; lane B2b deletes
+them, and this test is what tells it when the last one is gone.
+
+WHAT THIS DOES NOT CLAIM, in the same spirit as the Rule-2 guard. It is a
+lexical rule, not dataflow. A line built in one function and written in
+another (no such shape exists today), a header dict assembled through
+``update()`` from a value computed elsewhere, and a credential reaching an
+adapter as a pre-built parameter are all outside what an AST rule can answer.
+The provenance check follows names bound to a builder call within the same
+scope and no further. False alarms are cheap and visible; a silent miss is the
+failure that matters, so anything the resolver cannot classify is reported.
+"""
+
+from __future__ import annotations
+
+import ast
+from collections import Counter
+from pathlib import Path
+
+APP_ROOT = Path(__file__).resolve().parent.parent / "app"
+
+# The single producer, and the joiner that turns its pair into a line.
+BUILDER_FUNCTIONS = frozenset({"build_credential_header", "credential_header_line"})
+
+# The helper that locates the 0600 header-file directory. A scope that calls
+# it is writing a credential header or nothing at all.
+HEADER_DIR_HELPER = "gdal_header_dir"
+
+ADAPTER_PACKAGE = "modules/catalog/sources/adapters/"
+
+# Write calls, by exact name. Substring matching would sweep in unrelated
+# helpers: `_tenant_writer_subprocess_env` contains "write".
+WRITE_CALL_NAMES = frozenset({"write", "writelines", "write_text", "write_bytes"})
+
+# Dict keys that name a credential header, compared case-insensitively
+# because HTTP field names are case-insensitive.
+CREDENTIAL_HEADER_KEYS = frozenset({"authorization", "x-esri-authorization"})
+
+# Every allowlist entry is (module, scope) -> (exact count, justification).
+HEADER_FILE_WRITE_ALLOWLIST: dict[tuple[str, str], tuple[int, str]] = {
+    ("processing/ingest/ogr.py", "run_ogr2ogr_service"): (
+        1,
+        "fix(#1746 service-auth B2b removes this): composes "
+        "`Authorization: Bearer <token>` inline for the commit path",
+    ),
+    ("modules/catalog/sources/preview.py", "run_service_preview"): (
+        1,
+        "fix(#1746 service-auth B2b removes this): composes the same line "
+        "inline for the preview path",
+    ),
+}
+
+ADAPTER_HEADER_ALLOWLIST: dict[tuple[str, str], tuple[int, str]] = {
+    (f"{ADAPTER_PACKAGE}wfs.py", "probe_wfs"): (
+        1,
+        "fix(#1746 service-auth B2b removes this): composes the bearer header "
+        "for the WFS GetCapabilities probe",
+    ),
+    (f"{ADAPTER_PACKAGE}ogcapi.py", "probe_ogcapi"): (
+        1,
+        "fix(#1746 service-auth B2b removes this): composes the bearer header "
+        "for the OGC API Features landing-page probe",
+    ),
+}
+
+# Positive controls. A walker that silently matched nothing would satisfy
+# every allowlist assertion in this module, which is the failure mode the
+# absence-claim rule exists for.
+MIN_APP_MODULES = 100
+MIN_HEADER_FILE_WRITE_SITES = 2
+MIN_ADAPTER_HEADER_SITES = 2
+
+_MODULE_SCOPE = "<module>"
+
+
+def _app_modules() -> list[tuple[str, ast.Module]]:
+    modules = []
+    for path in sorted(APP_ROOT.rglob("*.py")):
+        rel = path.relative_to(APP_ROOT).as_posix()
+        modules.append((rel, ast.parse(path.read_text(encoding="utf-8"))))
+    return modules
+
+
+def _annotate_parents(tree: ast.Module) -> None:
+    for node in ast.walk(tree):
+        for child in ast.iter_child_nodes(node):
+            child._credential_parent = node  # type: ignore[attr-defined]
+
+
+def _enclosing_scope(node: ast.AST, tree: ast.Module) -> ast.AST:
+    current: ast.AST | None = node
+    while current is not None:
+        if isinstance(current, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            return current
+        current = getattr(current, "_credential_parent", None)
+    return tree
+
+
+def _scope_name(scope: ast.AST) -> str:
+    if isinstance(scope, (ast.FunctionDef, ast.AsyncFunctionDef)):
+        return scope.name
+    return _MODULE_SCOPE
+
+
+def _call_name(func: ast.expr) -> str | None:
+    """Dotted-tail name of a call target: ``a.b.c(...)`` -> ``c``."""
+    if isinstance(func, ast.Name):
+        return func.id
+    if isinstance(func, ast.Attribute):
+        return func.attr
+    return None
+
+
+def _scope_calls(scope: ast.AST, name: str) -> bool:
+    return any(
+        isinstance(node, ast.Call) and _call_name(node.func) == name
+        for node in ast.walk(scope)
+    )
+
+
+def _mentions_builder(expr: ast.AST, bound: frozenset[str]) -> bool:
+    """Whether *expr* calls the builder or reads a name bound to one."""
+    for node in ast.walk(expr):
+        if isinstance(node, ast.Call) and _call_name(node.func) in BUILDER_FUNCTIONS:
+            return True
+        if isinstance(node, ast.Name) and node.id in bound:
+            return True
+    return False
+
+
+def _builder_bound_names(scope: ast.AST) -> frozenset[str]:
+    """Names bound to a builder call anywhere in *scope*.
+
+    Deliberately flow-insensitive: a name assigned from the builder counts
+    wherever it is used in that scope. Narrowing it would report violations
+    for correct code, and this rule's job is to catch a hand-composed prefix,
+    not to referee assignment order.
+    """
+    bound: set[str] = set()
+    for node in ast.walk(scope):
+        if not isinstance(node, (ast.Assign, ast.AnnAssign, ast.NamedExpr)):
+            continue
+        value = node.value
+        if value is None or not _mentions_builder(value, frozenset()):
+            continue
+        targets = node.targets if isinstance(node, ast.Assign) else [node.target]
+        for target in targets:
+            for inner in ast.walk(target):
+                if isinstance(inner, ast.Name):
+                    bound.add(inner.id)
+    return frozenset(bound)
+
+
+def _written_value(call: ast.Call) -> ast.expr | None:
+    """The expression a write call puts into the file.
+
+    ``os.write(fd, data)`` carries it second; every other write shape carries
+    it first. Reading the wrong index would credit an ``os.write`` for its
+    file descriptor, which never comes from the builder.
+    """
+    func = call.func
+    is_os_write = (
+        isinstance(func, ast.Attribute)
+        and func.attr == "write"
+        and isinstance(func.value, ast.Name)
+        and func.value.id == "os"
+    )
+    index = 1 if is_os_write else 0
+    if len(call.args) <= index:
+        return None
+    return call.args[index]
+
+
+def _is_header_subscript(target: ast.expr) -> bool:
+    if not isinstance(target, ast.Subscript):
+        return False
+    container = target.value
+    name = None
+    if isinstance(container, ast.Name):
+        name = container.id
+    elif isinstance(container, ast.Attribute):
+        name = container.attr
+    return name is not None and "header" in name.lower()
+
+
+def _credential_header_values(node: ast.AST) -> list[ast.expr]:
+    """Every value *node* puts into a header mapping.
+
+    Two shapes: a subscript assignment into a name that reads as a header
+    mapping, and a dict literal keyed by a credential header name. The second
+    is the first one wearing a literal, and leaving it out would let a
+    composition move one line up to evade the rule.
+    """
+    if isinstance(node, (ast.Assign, ast.AnnAssign)):
+        targets = node.targets if isinstance(node, ast.Assign) else [node.target]
+        if node.value is not None and any(
+            _is_header_subscript(target) for target in targets
+        ):
+            return [node.value]
+        return []
+    if isinstance(node, ast.Dict):
+        return [
+            value
+            for key, value in zip(node.keys, node.values, strict=True)
+            if isinstance(key, ast.Constant)
+            and isinstance(key.value, str)
+            and key.value.lower() in CREDENTIAL_HEADER_KEYS
+        ]
+    return []
+
+
+class _Scan:
+    """What one pass over a module found."""
+
+    def __init__(self) -> None:
+        self.unguarded_writes: Counter[tuple[str, str]] = Counter()
+        self.unguarded_headers: Counter[tuple[str, str]] = Counter()
+        self.write_sites = 0
+        self.header_sites = 0
+
+    def absorb(self, other: _Scan) -> None:
+        self.unguarded_writes.update(other.unguarded_writes)
+        self.unguarded_headers.update(other.unguarded_headers)
+        self.write_sites += other.write_sites
+        self.header_sites += other.header_sites
+
+
+def _scan_module(rel: str, tree: ast.Module) -> _Scan:
+    _annotate_parents(tree)
+    scan = _Scan()
+    is_adapter = rel.startswith(ADAPTER_PACKAGE)
+    bound_cache: dict[int, frozenset[str]] = {}
+    header_dir_cache: dict[int, bool] = {}
+
+    for node in ast.walk(tree):
+        is_write = (
+            isinstance(node, ast.Call) and _call_name(node.func) in WRITE_CALL_NAMES
+        )
+        header_values = _credential_header_values(node) if is_adapter else []
+        if not is_write and not header_values:
+            continue
+
+        scope = _enclosing_scope(node, tree)
+        bound = bound_cache.get(id(scope))
+        if bound is None:
+            bound = _builder_bound_names(scope)
+            bound_cache[id(scope)] = bound
+        site = (rel, _scope_name(scope))
+
+        if is_write:
+            writes_a_header = header_dir_cache.get(id(scope))
+            if writes_a_header is None:
+                writes_a_header = _scope_calls(scope, HEADER_DIR_HELPER)
+                header_dir_cache[id(scope)] = writes_a_header
+            if writes_a_header:
+                scan.write_sites += 1
+                value = _written_value(node)  # type: ignore[arg-type]
+                if value is None or not _mentions_builder(value, bound):
+                    scan.unguarded_writes[site] += 1
+
+        for value in header_values:
+            scan.header_sites += 1
+            if not _mentions_builder(value, bound):
+                scan.unguarded_headers[site] += 1
+
+    return scan
+
+
+def _scan_backend() -> _Scan:
+    total = _Scan()
+    for rel, tree in _app_modules():
+        total.absorb(_scan_module(rel, tree))
+    return total
+
+
+def _allowlist_failures(
+    found: Counter[tuple[str, str]],
+    allowlist: dict[tuple[str, str], tuple[int, str]],
+    label: str,
+) -> list[str]:
+    failures: list[str] = []
+    for site, count in sorted(found.items()):
+        expected = allowlist.get(site)
+        if expected is None:
+            failures.append(
+                f"{label}: {site[0]}:{site[1]} composes a credential header "
+                f"itself ({count} site(s)). Use build_credential_header() and "
+                "credential_header_line() from app/core/service_tokens.py."
+            )
+        elif expected[0] != count:
+            failures.append(
+                f"{label}: {site[0]}:{site[1]} has {count} unguarded site(s), "
+                f"allowlisted for {expected[0]}."
+            )
+    for site, (expected_count, justification) in sorted(allowlist.items()):
+        if not justification.strip():
+            failures.append(f"{label}: {site[0]}:{site[1]} has a blank justification.")
+        if site not in found:
+            failures.append(
+                f"{label}: {site[0]}:{site[1]} is allowlisted for "
+                f"{expected_count} site(s) and has none left. Delete the entry."
+            )
+    return failures
+
+
+def test_header_file_writes_come_from_the_shared_builder() -> None:
+    scan = _scan_backend()
+    assert scan.write_sites >= MIN_HEADER_FILE_WRITE_SITES, (
+        "the walk found no header-file writes at all, so every assertion "
+        "about them is vacuous"
+    )
+    failures = _allowlist_failures(
+        scan.unguarded_writes, HEADER_FILE_WRITE_ALLOWLIST, "GDAL header file"
+    )
+    assert not failures, "\n".join(failures)
+
+
+def test_adapter_credential_headers_come_from_the_shared_builder() -> None:
+    scan = _scan_backend()
+    assert scan.header_sites >= MIN_ADAPTER_HEADER_SITES, (
+        "the walk found no adapter credential headers at all, so every "
+        "assertion about them is vacuous"
+    )
+    failures = _allowlist_failures(
+        scan.unguarded_headers, ADAPTER_HEADER_ALLOWLIST, "probe adapter"
+    )
+    assert not failures, "\n".join(failures)
+
+
+def test_the_walk_actually_covers_the_backend() -> None:
+    """The positive control for the two allowlist assertions above."""
+    modules = _app_modules()
+    assert len(modules) >= MIN_APP_MODULES
+    assert any(rel.startswith(ADAPTER_PACKAGE) for rel, _ in modules)
+    assert any(_scope_calls(tree, HEADER_DIR_HELPER) for _, tree in modules), (
+        f"{HEADER_DIR_HELPER}() is called nowhere, so the header-file rule "
+        "matches nothing"
+    )
+
+
+def _scan_synthetic(source: str) -> _Scan:
+    """Run the real predicates over a synthetic adapter module."""
+    return _scan_module(f"{ADAPTER_PACKAGE}synthetic.py", ast.parse(source))
+
+
+def test_guard_an_inline_composition_is_flagged() -> None:
+    scan = _scan_synthetic(
+        "def f(token, fd):\n"
+        "    path = gdal_header_dir()\n"
+        '    os.write(fd, f"Authorization: Bearer {token}\\n".encode("ascii"))\n'
+        '    headers["Authorization"] = f"Bearer {token}"\n'
+        '    other = {"Authorization": f"Bearer {token}"}\n'
+    )
+    assert sum(scan.unguarded_writes.values()) == 1
+    assert sum(scan.unguarded_headers.values()) == 2
+    assert set(scan.unguarded_writes) == {(f"{ADAPTER_PACKAGE}synthetic.py", "f")}
+
+
+def test_guard_a_builder_composition_is_clean() -> None:
+    scan = _scan_synthetic(
+        "def f(auth, fd):\n"
+        "    path = gdal_header_dir()\n"
+        "    pair = build_credential_header(auth)\n"
+        "    line = credential_header_line(pair)\n"
+        '    os.write(fd, f"{line}\\n".encode("ascii"))\n'
+        "    headers[pair[0]] = pair[1]\n"
+        '    other = {"Authorization": credential_header_line(pair)}\n'
+    )
+    assert scan.write_sites == 1
+    assert scan.header_sites == 2
+    assert not scan.unguarded_writes
+    assert not scan.unguarded_headers
+
+
+def test_guard_a_second_write_beside_a_builder_one_is_flagged() -> None:
+    """An added composition does not ride a clean scope's credit."""
+    scan = _scan_synthetic(
+        "def f(auth, token, fd, other_fd):\n"
+        "    path = gdal_header_dir()\n"
+        "    line = credential_header_line(build_credential_header(auth))\n"
+        '    os.write(fd, f"{line}\\n".encode("ascii"))\n'
+        '    os.write(other_fd, f"X-API-Key: {token}\\n".encode("ascii"))\n'
+    )
+    assert scan.write_sites == 2
+    assert sum(scan.unguarded_writes.values()) == 1
+
+
+def test_guard_os_write_reads_the_second_argument() -> None:
+    """``os.write(fd, data)`` and ``handle.write(data)`` differ by one index."""
+    scan = _scan_synthetic(
+        "def f(auth, fd):\n"
+        "    path = gdal_header_dir()\n"
+        "    line = credential_header_line(build_credential_header(auth))\n"
+        "    handle.write(line)\n"
+        "    os.write(fd, line)\n"
+    )
+    assert scan.write_sites == 2
+    assert not scan.unguarded_writes
+
+
+def test_guard_a_write_outside_the_header_directory_is_not_judged() -> None:
+    """The rule is scoped to the one directory, not to every write.
+
+    Without the ``gdal_header_dir()`` condition this test's module would be a
+    violation, and so would every unrelated file write in the backend.
+    """
+    scan = _scan_synthetic(
+        "def f(token, fd):\n"
+        '    os.write(fd, f"Authorization: Bearer {token}\\n".encode("ascii"))\n'
+    )
+    assert scan.write_sites == 0
+    assert not scan.unguarded_writes

--- a/backend/tests/test_credential_producer_structural.py
+++ b/backend/tests/test_credential_producer_structural.py
@@ -85,10 +85,14 @@ produces, so a clean mapping write is spelled ``headers[pair[0]] = pair[1]`` or
 Provenance also requires the call to BE the shared helper (fix(#1756 codex
 round 5)). A bare name counts only when the module imports it from
 ``app.core.service_tokens`` and nothing shadows it at the call site; an
-attribute call counts only when its base is that module. A local
-``def build_credential_header`` or an ``other.build_credential_header(...)``
-therefore confers nothing, which matters because the whole point of the rule is
-that one function validates the inputs.
+attribute call counts only when its base names that module AND that base is
+itself unshadowed (fix(#1756 codex round 6)), so an alias rebound by a
+parameter or an assignment buys nothing. A local
+``def build_credential_header`` and an ``other.build_credential_header(...)``
+therefore confer nothing either, which matters because the whole point of the
+rule is that one function validates the inputs. A plain ``import a.b.c`` binds
+the package ``a`` as a namespace and cannot point it at another value, so it is
+not read as a shadow; ``import x as a`` and ``from x import a`` are.
 
 A name resolves to its latest binding BEFORE the use site, so a later
 ``line = anything_else`` revokes it, and a parameter, loop target, ``with``
@@ -526,7 +530,19 @@ def _opaque_names(node: ast.AST, imports: _Imports) -> list[str]:
     if isinstance(node, (ast.Import, ast.ImportFrom)):
         if id(node) in imports.policy_imports:
             return []
-        return [alias.asname or alias.name.split(".")[0] for alias in node.names]
+        names = []
+        for alias in node.names:
+            if alias.asname:
+                names.append(alias.asname)
+            elif isinstance(node, ast.Import) and "." in alias.name:
+                # `import a.b.c` binds the package `a` as a namespace. It
+                # cannot point `a` at another value, so it is not a shadow of
+                # a fully qualified policy call (fix(#1756 codex round 6));
+                # `import x as a` and `from x import a` still are.
+                continue
+            else:
+                names.append(alias.name)
+        return names
     if isinstance(node, _NESTED_SCOPES) and not isinstance(node, ast.Lambda):
         return [node.name]
     return []
@@ -607,11 +623,18 @@ def _resolves_to_policy(
         base = _dotted_path(func.value)
         if base is None:
             return False
-        if base in ctx.imports.module_paths:
-            return True
         # `import app.core.service_tokens` binds the root package, so the call
         # is spelled out in full.
-        return base == POLICY_MODULE and POLICY_MODULE in ctx.imports.module_paths
+        known = base in ctx.imports.module_paths or (
+            base == POLICY_MODULE and POLICY_MODULE in ctx.imports.module_paths
+        )
+        if not known:
+            return False
+        # fix(#1756 codex round 6): the base needs the same shadow check the
+        # bare name gets. `from app.core import service_tokens as policy` plus
+        # a parameter called `policy` would otherwise make anything that
+        # object returns authoritative.
+        return not _is_shadowed(base.split(".")[0], ctx, limit)
     return False
 
 
@@ -1154,6 +1177,79 @@ def test_guard_a_lookalike_helper_confers_nothing() -> None:
         imported=False,
     )
     assert sum(unimported.unguarded_headers.values()) == 1
+
+
+def test_guard_a_shadowed_module_alias_confers_nothing() -> None:
+    """fix(#1756 codex round 6): the base needs the same check as the name.
+
+    ``from app.core import service_tokens as policy`` is authoritative right
+    up until something else in the scope is also called ``policy``, at which
+    point ``policy.build_credential_header(...)`` is whatever that object
+    returns. The blessed twin is the same module with nothing shadowing it.
+    """
+    alias_import = f"from {POLICY_PACKAGE} import {POLICY_MODULE_TAIL} as policy\n"
+    call = f"    pair = policy.{CREDENTIAL_BUILDER}(auth)\n"
+
+    unshadowed = _scan_synthetic(
+        alias_import
+        + "def f(auth, client, url):\n"
+        + call
+        + "    client.get(url, headers={pair[0]: pair[1]})\n",
+        imported=False,
+    )
+    assert unshadowed.header_sites == 1
+    assert not unshadowed.unguarded_headers
+
+    by_parameter = _scan_synthetic(
+        alias_import
+        + "def f(auth, policy, client, url):\n"
+        + call
+        + "    client.get(url, headers={pair[0]: pair[1]})\n",
+        imported=False,
+    )
+    assert by_parameter.header_sites == 1
+    assert sum(by_parameter.unguarded_headers.values()) == 1
+
+    by_assignment = _scan_synthetic(
+        alias_import + "def f(auth, impostor, client, url):\n"
+        "    policy = impostor\n"
+        + call
+        + "    client.get(url, headers={pair[0]: pair[1]})\n",
+        imported=False,
+    )
+    assert by_assignment.header_sites == 1
+    assert sum(by_assignment.unguarded_headers.values()) == 1
+
+    # The fully qualified spelling resolves through its root name, so that
+    # name is checked too.
+    shadowed_root = _scan_synthetic(
+        f"import {POLICY_MODULE}\n"
+        "def f(auth, app, client, url):\n"
+        f"    pair = {POLICY_MODULE}.{CREDENTIAL_BUILDER}(auth)\n"
+        "    client.get(url, headers={pair[0]: pair[1]})\n",
+        imported=False,
+    )
+    assert shadowed_root.header_sites == 1
+    assert sum(shadowed_root.unguarded_headers.values()) == 1
+
+
+def test_guard_a_namespace_import_is_not_read_as_a_shadow() -> None:
+    """``import app.core.config`` beside the policy import is not a rebinding.
+
+    The root name it binds is a package, and a package cannot be the impostor
+    the shadow check is looking for. Reading it as one would reject a
+    correctly written module.
+    """
+    scan = _scan_synthetic(
+        f"import {POLICY_MODULE}\n"
+        "import app.core.config\n"
+        "def f(auth, client, url):\n"
+        f"    pair = {POLICY_MODULE}.{CREDENTIAL_BUILDER}(auth)\n"
+        "    client.get(url, headers={pair[0]: pair[1]})\n",
+        imported=False,
+    )
+    assert scan.header_sites == 1
+    assert not scan.unguarded_headers
 
 
 def test_guard_rebinding_the_imported_helper_confers_nothing() -> None:

--- a/backend/tests/test_credential_producer_structural.py
+++ b/backend/tests/test_credential_producer_structural.py
@@ -59,9 +59,12 @@ MENTIONED builder output anywhere, which passed
 fix(#1756 codex round 3): and it accepted a joined line in mapping position,
 which puts ``Authorization: Authorization: Basic ...`` on the wire.
 
-Every expression is classified as one of four kinds, or as nothing:
+Every expression is classified as one of four kinds, or as nothing, and a
+classified expression also carries the identity of the builder call it came
+from:
 
-- PAIR: ``build_credential_header(...)``, or a name bound to a PAIR.
+- PAIR: a resolved ``build_credential_header(...)`` call, or a name bound to a
+  PAIR.
 - LINE: ``credential_header_line(<PAIR>)``; ``<LINE> + "\\n"``; an f-string
   whose single interpolation is a LINE, with no conversion, no format spec and
   no literal part but a trailing newline; ``.encode()`` or ``.encode("ascii")``
@@ -71,13 +74,21 @@ Every expression is classified as one of four kinds, or as nothing:
 
 The file sink accepts a LINE and nothing else, so a PAIR or a bare component
 written to the header file fails. The mapping sink accepts a VALUE for the
-value and a NAME for the key, and nothing else: a PAIR written whole fails, a
-LINE fails, and so does a string-literal key (fix(#1756 codex round 4)). The
-key rule is the one that stops ``headers["Authorization"] = pair[1]``, where
-the pair may well be an ``X-API-Key`` pair and the credential would go out
-under the wrong name. It means a clean mapping write is spelled
-``headers[pair[0]] = pair[1]`` or ``headers[name] = value``, which is also the
-only spelling that cannot drift from the builder's own answer.
+value and a NAME for the key, from the SAME builder call: a PAIR written whole
+fails, a LINE fails, a string-literal key fails (fix(#1756 codex round 4)), and
+so does a key and value taken from two different results
+(fix(#1756 codex round 5)). ``headers[first[0]] = second[1]`` sends one call's
+credential under another call's name, which is the same mismatch a literal key
+produces, so a clean mapping write is spelled ``headers[pair[0]] = pair[1]`` or
+``headers[name] = value``.
+
+Provenance also requires the call to BE the shared helper (fix(#1756 codex
+round 5)). A bare name counts only when the module imports it from
+``app.core.service_tokens`` and nothing shadows it at the call site; an
+attribute call counts only when its base is that module. A local
+``def build_credential_header`` or an ``other.build_credential_header(...)``
+therefore confers nothing, which matters because the whole point of the rule is
+that one function validates the inputs.
 
 A name resolves to its latest binding BEFORE the use site, so a later
 ``line = anything_else`` revokes it, and a parameter, loop target, ``with``
@@ -88,13 +99,32 @@ entry whose site disappears fails loudly instead of going stale. Four of the
 five mapping entries are the compositions lane B2b deletes; this test is what
 tells it when the last one is gone.
 
-WHAT THIS DOES NOT CLAIM, in the same spirit as the Rule-2 guard. It is a
-lexical rule, not dataflow. A line built in one function and written in
-another, a header mapping assembled through ``update()``, a mapping handed to
-a helper that makes the request rather than passed to the request call in the
-same scope, and a binding made under one branch of an ``if`` and used under the
-other are all outside what an AST rule can answer. Binding order is read from
-source position, which is the straight-line answer and not a control-flow one.
+**Known limits, which are deliberate and are not defects.** This gate is one
+layer beside the runtime validation inside ``build_credential_header`` itself,
+and that function is the actual enforcement: it validates the inputs, encodes
+Basic server side, and refuses a header for any format outside
+``HEADER_AUTH_SERVICE_FORMATS``. What this test adds is that no SECOND composer
+appears beside it. It is a lexical AST rule, so:
+
+- Provenance is intra-function. A pair or line returned by a helper, or
+  arriving as a parameter, has no lexical provenance and is REPORTED, not
+  trusted. That is the safe direction and it is why B2b composes at the write
+  site rather than passing a finished line around.
+- Only two containers are modelled: a dict literal and a subscript assignment.
+  A credential put into a request through ``dict(Authorization=...)``,
+  ``headers.setdefault(...)``, a list of pairs, or a mapping built by a
+  comprehension is not seen by the mapping rule at all. A dict literal inside
+  ``headers.update({...})`` IS seen, because it is still a dict literal. This
+  is a silent gap rather than a loud one, and closing it needs container
+  modelling this rule does not have.
+- Dynamic dispatch is not modelled. ``getattr(module, "build_credential_header")``,
+  a callable pulled from a registry, and a mapping reached through a computed
+  attribute chain all resolve to nothing, so a call site built that way is
+  reported rather than trusted, and a container reached that way is invisible.
+- Binding order is read from source position. A binding made under one branch
+  of an ``if`` and used under the other is judged as though the file ran top to
+  bottom.
+
 The tree-wide credential-name rule has none of those preconditions, so the
 three names that matter most stay covered whatever the surrounding shape.
 False alarms are cheap and visible; a silent miss is the failure that matters,
@@ -110,8 +140,10 @@ from typing import NamedTuple
 
 APP_ROOT = Path(__file__).resolve().parent.parent / "app"
 
-# The single producer, and the joiner that turns its pair into a line. Only
-# the producer confers provenance; see the module docstring.
+# The module that owns the policy, and the two functions this gate trusts.
+POLICY_MODULE = "app.core.service_tokens"
+POLICY_PACKAGE = "app.core"
+POLICY_MODULE_TAIL = "service_tokens"
 CREDENTIAL_BUILDER = "build_credential_header"
 CREDENTIAL_JOINER = "credential_header_line"
 
@@ -234,6 +266,19 @@ _VALUE = "value"
 _COMPONENT_KINDS = {0: _NAME, 1: _VALUE}
 
 
+class _Kind(NamedTuple):
+    """What an expression is, and which builder call it came from.
+
+    ``result`` is the id of the originating ``build_credential_header`` call
+    node. The mapping sink compares it across the key and the value, so a key
+    from one call and a value from another cannot be paired
+    (fix(#1756 codex round 5)).
+    """
+
+    kind: str
+    result: int
+
+
 def _app_modules() -> list[tuple[str, ast.Module]]:
     modules = []
     for path in sorted(APP_ROOT.rglob("*.py")):
@@ -272,6 +317,16 @@ def _call_name(func: ast.expr) -> str | None:
     return None
 
 
+def _dotted_path(expr: ast.expr) -> str | None:
+    """``app.core.service_tokens`` for an attribute chain of plain names."""
+    if isinstance(expr, ast.Name):
+        return expr.id
+    if isinstance(expr, ast.Attribute):
+        base = _dotted_path(expr.value)
+        return None if base is None else f"{base}.{expr.attr}"
+    return None
+
+
 def _scope_calls(scope: ast.AST, name: str) -> bool:
     return any(
         isinstance(node, ast.Call) and _call_name(node.func) == name
@@ -296,6 +351,78 @@ def _iter_scope_nodes(scope: ast.AST):
         if isinstance(node, _NESTED_SCOPES):
             continue
         stack.extend(ast.iter_child_nodes(node))
+
+
+class _Imports(NamedTuple):
+    """How this module reaches the policy functions, if it does at all.
+
+    fix(#1756 codex round 5): trusting any callable whose attribute tail spells
+    ``build_credential_header`` lets a local helper of the same name defeat the
+    gate, which matters because the point of the rule is that ONE function
+    validates the inputs.
+    """
+
+    builder_names: frozenset[str]
+    joiner_names: frozenset[str]
+    module_paths: frozenset[str]
+    # Import statements that bound one of the above, so the shadow check does
+    # not read the import itself as a rebinding.
+    policy_imports: frozenset[int]
+
+
+def _policy_import_names(node: ast.AST) -> dict[str, str] | None:
+    """What a policy import binds locally: local name -> what it points at.
+
+    The value is the function name, or ``POLICY_MODULE_TAIL`` for the module.
+    """
+    if isinstance(node, ast.ImportFrom):
+        if node.module == POLICY_MODULE and not node.level:
+            return {
+                alias.asname or alias.name: alias.name
+                for alias in node.names
+                if alias.name in (CREDENTIAL_BUILDER, CREDENTIAL_JOINER)
+            } or None
+        if node.module == POLICY_PACKAGE and not node.level:
+            return {
+                alias.asname or alias.name: POLICY_MODULE_TAIL
+                for alias in node.names
+                if alias.name == POLICY_MODULE_TAIL
+            } or None
+        return None
+    if isinstance(node, ast.Import):
+        bound = {}
+        for alias in node.names:
+            if alias.name != POLICY_MODULE:
+                continue
+            # `import a.b.c` binds `a`; `import a.b.c as x` binds `x`.
+            bound[alias.asname or POLICY_MODULE] = POLICY_MODULE_TAIL
+        return bound or None
+    return None
+
+
+def _module_imports(tree: ast.Module) -> _Imports:
+    builders: set[str] = set()
+    joiners: set[str] = set()
+    modules: set[str] = set()
+    statements: set[int] = set()
+    for node in ast.walk(tree):
+        bound = _policy_import_names(node)
+        if bound is None:
+            continue
+        statements.add(id(node))
+        for local, target in bound.items():
+            if target == CREDENTIAL_BUILDER:
+                builders.add(local)
+            elif target == CREDENTIAL_JOINER:
+                joiners.add(local)
+            else:
+                modules.add(local)
+    return _Imports(
+        frozenset(builders),
+        frozenset(joiners),
+        frozenset(modules),
+        frozenset(statements),
+    )
 
 
 class _Outbound(NamedTuple):
@@ -388,18 +515,24 @@ def _assignment_binding(
     return None
 
 
-def _opaque_names(node: ast.AST) -> list[str]:
-    """Names *node* binds to something this rule cannot judge."""
+def _opaque_names(node: ast.AST, imports: _Imports) -> list[str]:
+    """Names *node* binds to something this rule cannot judge.
+
+    A policy import is not one of them: it is how the trusted names arrive, so
+    recording it would read as a shadow of itself.
+    """
     if isinstance(node, ast.ExceptHandler) and node.name:
         return [node.name]
     if isinstance(node, (ast.Import, ast.ImportFrom)):
+        if id(node) in imports.policy_imports:
+            return []
         return [alias.asname or alias.name.split(".")[0] for alias in node.names]
     if isinstance(node, _NESTED_SCOPES) and not isinstance(node, ast.Lambda):
         return [node.name]
     return []
 
 
-def _scope_bindings(scope: ast.AST) -> dict[str, list[_Binding]]:
+def _scope_bindings(scope: ast.AST, imports: _Imports) -> dict[str, list[_Binding]]:
     """Every name binding in *scope*, ordered by source position."""
     bindings: dict[str, list[_Binding]] = defaultdict(list)
 
@@ -423,7 +556,7 @@ def _scope_bindings(scope: ast.AST) -> dict[str, list[_Binding]]:
             targets, value = assignment
             for target in targets:
                 record(target, value)
-        for name in _opaque_names(node):
+        for name in _opaque_names(node, imports):
             bindings[name].append(_Binding(_pos(node), None))
 
     for name in bindings:
@@ -442,23 +575,59 @@ def _binding_before(
     return latest
 
 
+class _Context(NamedTuple):
+    """Everything expression classification needs about where it stands."""
+
+    bindings: dict[str, list[_Binding]]
+    module_bindings: dict[str, list[_Binding]]
+    imports: _Imports
+
+
+def _is_shadowed(name: str, ctx: _Context, limit: tuple[int, int]) -> bool:
+    """Whether *name* is bound to anything other than the policy import."""
+    if _binding_before(ctx.bindings, name, limit) is not None:
+        return True
+    return bool(ctx.module_bindings.get(name))
+
+
+def _resolves_to_policy(
+    func: ast.expr, target: str, ctx: _Context, limit: tuple[int, int]
+) -> bool:
+    """Whether this call target IS the shared helper, not one that looks like it."""
+    if isinstance(func, ast.Name):
+        allowed = (
+            ctx.imports.builder_names
+            if target == CREDENTIAL_BUILDER
+            else ctx.imports.joiner_names
+        )
+        return func.id in allowed and not _is_shadowed(func.id, ctx, limit)
+    if isinstance(func, ast.Attribute):
+        if func.attr != target:
+            return False
+        base = _dotted_path(func.value)
+        if base is None:
+            return False
+        if base in ctx.imports.module_paths:
+            return True
+        # `import app.core.service_tokens` binds the root package, so the call
+        # is spelled out in full.
+        return base == POLICY_MODULE and POLICY_MODULE in ctx.imports.module_paths
+    return False
+
+
 def _is_newline_literal(expr: ast.expr) -> bool:
     return isinstance(expr, ast.Constant) and expr.value == "\n"
 
 
-def _call_kind(
-    expr: ast.Call, bindings: dict[str, list[_Binding]], limit: tuple[int, int]
-) -> str | None:
-    name = _call_name(expr.func)
-    if name == CREDENTIAL_BUILDER:
-        return _PAIR
-    if name == CREDENTIAL_JOINER:
-        if len(expr.args) != 1 or expr.keywords:
-            return None
-        argument = _expr_kind(expr.args[0], bindings, limit)
-        return _LINE if argument == _PAIR else None
-    if name != "encode":
-        return None
+def _line_from(inner: _Kind | None) -> _Kind | None:
+    return (
+        _Kind(_LINE, inner.result)
+        if inner is not None and inner.kind == _LINE
+        else None
+    )
+
+
+def _encode_kind(expr: ast.Call, ctx: _Context, limit: tuple[int, int]) -> _Kind | None:
     if not isinstance(expr.func, ast.Attribute) or expr.keywords:
         return None
     if len(expr.args) > 1:
@@ -467,48 +636,63 @@ def _call_kind(
         isinstance(expr.args[0], ast.Constant) and expr.args[0].value == "ascii"
     ):
         return None
-    encoded = _expr_kind(expr.func.value, bindings, limit)
-    return _LINE if encoded == _LINE else None
+    return _line_from(_expr_kind(expr.func.value, ctx, limit))
 
 
-def _name_kind(
-    expr: ast.Name, bindings: dict[str, list[_Binding]], limit: tuple[int, int]
-) -> str | None:
-    binding = _binding_before(bindings, expr.id, limit)
+def _call_kind(expr: ast.Call, ctx: _Context, limit: tuple[int, int]) -> _Kind | None:
+    if _resolves_to_policy(expr.func, CREDENTIAL_BUILDER, ctx, limit):
+        return _Kind(_PAIR, id(expr))
+    if _resolves_to_policy(expr.func, CREDENTIAL_JOINER, ctx, limit):
+        if len(expr.args) != 1 or expr.keywords:
+            return None
+        argument = _expr_kind(expr.args[0], ctx, limit)
+        if argument is None or argument.kind != _PAIR:
+            return None
+        return _Kind(_LINE, argument.result)
+    if _call_name(expr.func) == "encode":
+        return _encode_kind(expr, ctx, limit)
+    return None
+
+
+def _name_kind(expr: ast.Name, ctx: _Context, limit: tuple[int, int]) -> _Kind | None:
+    binding = _binding_before(ctx.bindings, expr.id, limit)
     if binding is None or binding.value is None:
         return None
-    bound = _expr_kind(binding.value, bindings, binding.pos)
+    bound = _expr_kind(binding.value, ctx, binding.pos)
+    if bound is None:
+        return None
     if binding.index is None:
         return bound
-    if bound != _PAIR:
+    if bound.kind != _PAIR or binding.index not in _COMPONENT_KINDS:
         return None
-    return _COMPONENT_KINDS.get(binding.index)
+    return _Kind(_COMPONENT_KINDS[binding.index], bound.result)
 
 
 def _component_kind(
-    expr: ast.Subscript, bindings: dict[str, list[_Binding]], limit: tuple[int, int]
-) -> str | None:
+    expr: ast.Subscript, ctx: _Context, limit: tuple[int, int]
+) -> _Kind | None:
     index = expr.slice
     if not isinstance(index, ast.Constant) or isinstance(index.value, bool):
         return None
     if index.value not in _COMPONENT_KINDS:
         return None
-    if _expr_kind(expr.value, bindings, limit) != _PAIR:
+    base = _expr_kind(expr.value, ctx, limit)
+    if base is None or base.kind != _PAIR:
         return None
-    return _COMPONENT_KINDS[index.value]
+    return _Kind(_COMPONENT_KINDS[index.value], base.result)
 
 
 def _concat_kind(
-    expr: ast.BinOp, bindings: dict[str, list[_Binding]], limit: tuple[int, int]
-) -> str | None:
+    expr: ast.BinOp, ctx: _Context, limit: tuple[int, int]
+) -> _Kind | None:
     if not isinstance(expr.op, ast.Add) or not _is_newline_literal(expr.right):
         return None
-    return _LINE if _expr_kind(expr.left, bindings, limit) == _LINE else None
+    return _line_from(_expr_kind(expr.left, ctx, limit))
 
 
 def _fstring_kind(
-    expr: ast.JoinedStr, bindings: dict[str, list[_Binding]], limit: tuple[int, int]
-) -> str | None:
+    expr: ast.JoinedStr, ctx: _Context, limit: tuple[int, int]
+) -> _Kind | None:
     """One interpolation of a LINE, plus at most a trailing newline."""
     interpolations = [
         value for value in expr.values if isinstance(value, ast.FormattedValue)
@@ -525,14 +709,11 @@ def _fstring_kind(
     placeholder = interpolations[0]
     if placeholder.conversion != -1 or placeholder.format_spec is not None:
         return None
-    inner = _expr_kind(placeholder.value, bindings, limit)
-    return _LINE if inner == _LINE else None
+    return _line_from(_expr_kind(placeholder.value, ctx, limit))
 
 
-def _expr_kind(
-    expr: ast.expr, bindings: dict[str, list[_Binding]], limit: tuple[int, int]
-) -> str | None:
-    """What the WHOLE of *expr* is, as one of the four kinds, or nothing.
+def _expr_kind(expr: ast.expr, ctx: _Context, limit: tuple[int, int]) -> _Kind | None:
+    """What the WHOLE of *expr* is, and which builder call produced it.
 
     An expression that merely CONTAINS builder output is nothing: that was the
     round-2 hole, and ``f"Authorization: Bearer {line}"`` is exactly the string
@@ -545,15 +726,15 @@ def _expr_kind(
     of recursing forever.
     """
     if isinstance(expr, ast.Call):
-        return _call_kind(expr, bindings, limit)
+        return _call_kind(expr, ctx, limit)
     if isinstance(expr, ast.Name):
-        return _name_kind(expr, bindings, limit)
+        return _name_kind(expr, ctx, limit)
     if isinstance(expr, ast.Subscript):
-        return _component_kind(expr, bindings, limit)
+        return _component_kind(expr, ctx, limit)
     if isinstance(expr, ast.BinOp):
-        return _concat_kind(expr, bindings, limit)
+        return _concat_kind(expr, ctx, limit)
     if isinstance(expr, ast.JoinedStr):
-        return _fstring_kind(expr, bindings, limit)
+        return _fstring_kind(expr, ctx, limit)
     return None
 
 
@@ -581,9 +762,9 @@ def _container_name(target: ast.expr) -> str | None:
     """The name a subscript is written into, whatever it is called.
 
     fix(#1756 codex round 4): this used to require "header" in the name, so a
-    request-bound ``request_options`` mapping was invisible. The
-    request binding decides scope now; this only reports the name so that
-    binding can be looked up.
+    request-bound ``request_options`` mapping was invisible. The request
+    binding decides scope now; this only reports the name so that binding can
+    be looked up.
     """
     if not isinstance(target, ast.Subscript):
         return None
@@ -647,21 +828,25 @@ def _header_writes(
     return []
 
 
-def _mapping_write_is_clean(
-    write: _HeaderWrite, bindings: dict[str, list[_Binding]]
-) -> bool:
-    """A header mapping takes the pair's two components, and nothing else.
+def _mapping_write_is_clean(write: _HeaderWrite, ctx: _Context) -> bool:
+    """A header mapping takes both halves of ONE builder result.
 
     fix(#1756 codex round 3): ``headers["Authorization"] =
     credential_header_line(pair)`` used to pass, and puts
     ``Authorization: Authorization: Basic ...`` on the wire.
     fix(#1756 codex round 4): and a string-literal key used to pass, so an
-    ``X-API-Key`` credential could be sent under ``Authorization``. The key
-    has to be the builder's own answer for the two halves to agree.
+    ``X-API-Key`` credential could be sent under ``Authorization``.
+    fix(#1756 codex round 5): and the key and value were classified
+    independently, so ``headers[first[0]] = second[1]`` paired one call's name
+    with another call's credential. The two halves have to be the same answer.
     """
-    if _expr_kind(write.value, bindings, _pos(write.value)) != _VALUE:
+    value = _expr_kind(write.value, ctx, _pos(write.value))
+    if value is None or value.kind != _VALUE:
         return False
-    return _expr_kind(write.key, bindings, _pos(write.key)) == _NAME
+    key = _expr_kind(write.key, ctx, _pos(write.key))
+    if key is None or key.kind != _NAME:
+        return False
+    return key.result == value.result
 
 
 class _Scan:
@@ -681,14 +866,21 @@ class _Scan:
 
 
 class _ScopeFacts(NamedTuple):
-    bindings: dict[str, list[_Binding]]
+    ctx: _Context
     outbound: _Outbound
     writes_a_header_file: bool
 
 
-def _scope_facts(scope: ast.AST) -> _ScopeFacts:
+def _scope_facts(
+    scope: ast.AST, imports: _Imports, module_bindings: dict[str, list[_Binding]]
+) -> _ScopeFacts:
+    bindings = (
+        module_bindings
+        if isinstance(scope, ast.Module)
+        else _scope_bindings(scope, imports)
+    )
     return _ScopeFacts(
-        _scope_bindings(scope),
+        _Context(bindings, module_bindings, imports),
         _outbound_header_mappings(scope),
         _scope_calls(scope, HEADER_DIR_HELPER),
     )
@@ -698,6 +890,8 @@ def _scan_module(rel: str, tree: ast.Module) -> _Scan:
     _annotate_parents(tree)
     scan = _Scan()
     credential_path = rel.startswith(CREDENTIAL_PACKAGES)
+    imports = _module_imports(tree)
+    module_bindings = _scope_bindings(tree, imports)
     facts_cache: dict[int, _ScopeFacts] = {}
 
     for node in ast.walk(tree):
@@ -710,21 +904,22 @@ def _scan_module(rel: str, tree: ast.Module) -> _Scan:
         scope = _enclosing_scope(node, tree)
         facts = facts_cache.get(id(scope))
         if facts is None:
-            facts = _scope_facts(scope)
+            facts = _scope_facts(scope, imports, module_bindings)
             facts_cache[id(scope)] = facts
         site = (rel, _scope_name(scope))
 
         if is_write and facts.writes_a_header_file:
             scan.write_sites += 1
             value = _written_value(node)  # type: ignore[arg-type]
-            if value is None or _expr_kind(value, facts.bindings, _pos(value)) != _LINE:
+            kind = None if value is None else _expr_kind(value, facts.ctx, _pos(value))
+            if kind is None or kind.kind != _LINE:
                 scan.unguarded_writes[site] += 1
 
         for write in _header_writes(
             node, credential_path=credential_path, outbound=facts.outbound
         ):
             scan.header_sites += 1
-            if not _mapping_write_is_clean(write, facts.bindings):
+            if not _mapping_write_is_clean(write, facts.ctx):
                 scan.unguarded_headers[site] += 1
 
     return scan
@@ -807,10 +1002,20 @@ def test_the_walk_actually_covers_the_backend() -> None:
     assert any(not rel.startswith("modules/catalog/sources/") for rel in scanned)
 
 
-def _scan_synthetic(source: str, rel: str | None = None) -> _Scan:
+# The import every synthetic module needs, because provenance now requires the
+# call to resolve to the real helper.
+_POLICY_IMPORT = (
+    f"from {POLICY_MODULE} import {CREDENTIAL_BUILDER}, {CREDENTIAL_JOINER}\n"
+)
+
+
+def _scan_synthetic(
+    source: str, rel: str | None = None, *, imported: bool = True
+) -> _Scan:
     """Run the real predicates over a synthetic module."""
+    prelude = _POLICY_IMPORT if imported else ""
     return _scan_module(
-        rel or "modules/catalog/sources/synthetic.py", ast.parse(source)
+        rel or "modules/catalog/sources/synthetic.py", ast.parse(prelude + source)
     )
 
 
@@ -841,7 +1046,7 @@ def test_guard_every_blessed_file_write_shape_is_clean() -> None:
 
 
 def test_guard_every_blessed_mapping_shape_is_clean() -> None:
-    """The mapping sink: the pair's NAME as the key, its VALUE as the value.
+    """The mapping sink: one result's NAME as the key, its VALUE as the value.
 
     Five spellings, which is every one B2b can reasonably reach for: subscript
     from the pair, subscript from an unpacking, a dict literal bound to a name,
@@ -865,6 +1070,39 @@ def test_guard_every_blessed_mapping_shape_is_clean() -> None:
     assert not scan.unguarded_headers
 
 
+def test_guard_the_policy_module_can_be_reached_three_ways() -> None:
+    """An alias, a module import, and the fully qualified path all resolve."""
+    aliased = _scan_synthetic(
+        f"from {POLICY_MODULE} import {CREDENTIAL_BUILDER} as make_header\n"
+        "def f(auth, client, url):\n"
+        "    pair = make_header(auth)\n"
+        "    client.get(url, headers={pair[0]: pair[1]})\n",
+        imported=False,
+    )
+    assert aliased.header_sites == 1
+    assert not aliased.unguarded_headers
+
+    qualified = _scan_synthetic(
+        f"from {POLICY_PACKAGE} import {POLICY_MODULE_TAIL}\n"
+        "def f(auth, client, url):\n"
+        f"    pair = {POLICY_MODULE_TAIL}.{CREDENTIAL_BUILDER}(auth)\n"
+        "    client.get(url, headers={pair[0]: pair[1]})\n",
+        imported=False,
+    )
+    assert qualified.header_sites == 1
+    assert not qualified.unguarded_headers
+
+    dotted = _scan_synthetic(
+        f"import {POLICY_MODULE}\n"
+        "def f(auth, client, url):\n"
+        f"    pair = {POLICY_MODULE}.{CREDENTIAL_BUILDER}(auth)\n"
+        "    client.get(url, headers={pair[0]: pair[1]})\n",
+        imported=False,
+    )
+    assert dotted.header_sites == 1
+    assert not dotted.unguarded_headers
+
+
 # ---------------------------------------------------------------------------
 # The rejected shapes, one per way the gate could be walked around.
 # ---------------------------------------------------------------------------
@@ -881,6 +1119,75 @@ def test_guard_an_inline_composition_is_flagged() -> None:
     assert sum(scan.unguarded_writes.values()) == 1
     assert sum(scan.unguarded_headers.values()) == 2
     assert set(scan.unguarded_writes) == {("modules/catalog/sources/synthetic.py", "f")}
+
+
+def test_guard_a_lookalike_helper_confers_nothing() -> None:
+    """fix(#1756 codex round 5): the call has to BE the shared function.
+
+    A same-named local helper, a same-named attribute on some other object,
+    and no import at all each validate nothing, so none of them may buy the
+    provenance that exists because one function validates the inputs.
+    """
+    shadowed = _scan_synthetic(
+        "def build_credential_header(auth):\n"
+        '    return ("Authorization", auth)\n'
+        "def f(auth, fd, client, url):\n"
+        "    directory = gdal_header_dir()\n"
+        "    pair = build_credential_header(auth)\n"
+        "    os.write(fd, credential_header_line(pair))\n"
+        "    client.get(url, headers={pair[0]: pair[1]})\n"
+    )
+    assert sum(shadowed.unguarded_writes.values()) == 1
+    assert sum(shadowed.unguarded_headers.values()) == 1
+
+    other_module = _scan_synthetic(
+        "def f(auth, other, client, url):\n"
+        f"    pair = other.{CREDENTIAL_BUILDER}(auth)\n"
+        "    client.get(url, headers={pair[0]: pair[1]})\n"
+    )
+    assert sum(other_module.unguarded_headers.values()) == 1
+
+    unimported = _scan_synthetic(
+        "def f(auth, client, url):\n"
+        "    pair = build_credential_header(auth)\n"
+        "    client.get(url, headers={pair[0]: pair[1]})\n",
+        imported=False,
+    )
+    assert sum(unimported.unguarded_headers.values()) == 1
+
+
+def test_guard_rebinding_the_imported_helper_confers_nothing() -> None:
+    """A local rebinding of the imported name is a shadow like any other."""
+    scan = _scan_synthetic(
+        "def f(auth, impostor, client, url):\n"
+        "    build_credential_header = impostor\n"
+        "    pair = build_credential_header(auth)\n"
+        "    client.get(url, headers={pair[0]: pair[1]})\n"
+    )
+    assert sum(scan.unguarded_headers.values()) == 1
+
+
+def test_guard_two_builder_results_cannot_be_mixed() -> None:
+    """fix(#1756 codex round 5): one call's name, another call's credential.
+
+    Both halves are genuine builder output and the pairing is still wrong: the
+    header goes out under a name that belongs to a different result.
+    """
+    scan = _scan_synthetic(
+        "def f(first_auth, second_auth, client, url):\n"
+        "    first = build_credential_header(first_auth)\n"
+        "    second = build_credential_header(second_auth)\n"
+        "    headers = {}\n"
+        "    headers[first[0]] = second[1]\n"
+        "    client.get(url, headers=headers)\n"
+        "    client.post(url, headers={first[0]: second[1]})\n"
+        "    client.put(url, headers={first[0]: first[1]})\n"
+    )
+    # The third site is the same shape from ONE result, so this fails if the
+    # result identity is doing the rejecting and passes vacuously if nothing
+    # resolves at all.
+    assert scan.header_sites == 3
+    assert sum(scan.unguarded_headers.values()) == 2
 
 
 def test_guard_the_joiner_alone_confers_nothing() -> None:

--- a/backend/tests/test_credential_producer_structural.py
+++ b/backend/tests/test_credential_producer_structural.py
@@ -121,6 +121,16 @@ appears beside it. It is a lexical AST rule, so:
   ``headers.update({...})`` IS seen, because it is still a dict literal. This
   is a silent gap rather than a loud one, and closing it needs container
   modelling this rule does not have.
+- A mapping is identified by the tail name it is reached through, so
+  ``headers`` and ``self.headers`` are one key and the write meets the request
+  argument (fix(#1756 codex round 7)). Two things stay unmodelled after that:
+  a mapping aliased through a second attribute or a longer chain
+  (``self.session.headers`` written to and ``client.session.headers`` passed,
+  or two different objects whose attribute happens to share a tail) is matched
+  on the tail alone and so is neither reliably joined nor reliably separated,
+  and a mapping that only ever exists as a call result
+  (``client.get(url, headers=self._auth_headers())``) has no name to key on and
+  is invisible.
 - Dynamic dispatch is not modelled. ``getattr(module, "build_credential_header")``,
   a callable pulled from a registry, and a mapping reached through a computed
   attribute chain all resolve to nothing, so a call site built that way is
@@ -454,10 +464,17 @@ def _outbound_header_mappings(scope: ast.AST) -> _Outbound:
                 continue
             if isinstance(keyword.value, ast.Dict):
                 dicts.add(id(keyword.value))
-            elif isinstance(keyword.value, ast.Name):
-                names.add(keyword.value.id)
+                continue
+            # fix(#1756 codex round 7): an attribute reaches the request the
+            # same way a plain name does, and it is reduced by the same
+            # function the write target is reduced by, so
+            # `self.request_options[...] = ...` and
+            # `headers=self.request_options` meet on one key.
+            reference = _mapping_reference(keyword.value)
+            if reference is not None:
+                names.add(reference)
 
-    # The literal a request-bound name was built from is the same mapping.
+    # The literal a request-bound mapping was built from is the same mapping.
     for node in _iter_scope_nodes(scope):
         if not isinstance(node, (ast.Assign, ast.AnnAssign)):
             continue
@@ -465,7 +482,7 @@ def _outbound_header_mappings(scope: ast.AST) -> _Outbound:
             continue
         targets = node.targets if isinstance(node, ast.Assign) else [node.target]
         for target in targets:
-            if isinstance(target, ast.Name) and target.id in names:
+            if _mapping_reference(target) in names:
                 dicts.add(id(node.value))
     return _Outbound(frozenset(names), frozenset(dicts))
 
@@ -781,6 +798,21 @@ def _written_value(call: ast.Call) -> ast.expr | None:
     return call.args[index]
 
 
+def _mapping_reference(expr: ast.expr) -> str | None:
+    """How a header mapping is referred to, reduced to one comparable name.
+
+    ``headers`` and ``self.headers`` both reduce to ``headers``, so the write
+    target and the ``headers=`` argument meet on the same key whichever way
+    each is spelled (fix(#1756 codex round 7)). Reducing to the tail is what
+    makes that work and is also its limit, stated in the module docstring.
+    """
+    if isinstance(expr, ast.Name):
+        return expr.id
+    if isinstance(expr, ast.Attribute):
+        return expr.attr
+    return None
+
+
 def _container_name(target: ast.expr) -> str | None:
     """The name a subscript is written into, whatever it is called.
 
@@ -791,12 +823,7 @@ def _container_name(target: ast.expr) -> str | None:
     """
     if not isinstance(target, ast.Subscript):
         return None
-    container = target.value
-    if isinstance(container, ast.Name):
-        return container.id
-    if isinstance(container, ast.Attribute):
-        return container.attr
-    return None
+    return _mapping_reference(target.value)
 
 
 def _key_is_judged(key: ast.expr, *, credential_path: bool, outbound: bool) -> bool:
@@ -1531,6 +1558,41 @@ def test_guard_a_mapping_not_called_headers_is_still_judged() -> None:
     )
     assert scan.header_sites == 1
     assert sum(scan.unguarded_headers.values()) == 1
+
+
+def test_guard_a_mapping_held_on_an_attribute_is_judged() -> None:
+    """fix(#1756 codex round 7): an attribute reaches the wire too.
+
+    ``self.request_options["X-API-Key"] = raw`` with
+    ``headers=self.request_options`` was scanned nowhere, because the write
+    target was reduced to a name and the request argument was not reduced at
+    all. Both sides go through one reducer now, so the two meet.
+    """
+    hand_composed = _scan_synthetic(
+        "def f(self, raw, client, url):\n"
+        '    self.request_options["X-API-Key"] = raw\n'
+        "    client.get(url, headers=self.request_options)\n"
+    )
+    assert hand_composed.header_sites == 1
+    assert sum(hand_composed.unguarded_headers.values()) == 1
+
+    from_the_builder = _scan_synthetic(
+        "def f(self, auth, client, url):\n"
+        "    pair = build_credential_header(auth)\n"
+        "    self.request_options[pair[0]] = pair[1]\n"
+        "    client.get(url, headers=self.request_options)\n"
+    )
+    assert from_the_builder.header_sites == 1
+    assert not from_the_builder.unguarded_headers
+
+    # And a dict literal bound to the attribute is the same mapping.
+    literal = _scan_synthetic(
+        "def f(self, raw, client, url):\n"
+        '    self.request_options = {"X-API-Key": raw}\n'
+        "    client.get(url, headers=self.request_options)\n"
+    )
+    assert literal.header_sites == 1
+    assert sum(literal.unguarded_headers.values()) == 1
 
 
 def test_guard_a_mapping_with_no_request_binding_keeps_the_name_rule() -> None:

--- a/backend/tests/test_credential_producer_structural.py
+++ b/backend/tests/test_credential_producer_structural.py
@@ -37,11 +37,31 @@ The two shapes it watches, over the whole ``backend/app/`` tree:
    ``sources/adapters/``, which missed the composition in ``sources/router.py``
    entirely. Scope now comes from the key, not from the directory.
 
-Provenance is deliberately narrow: a value counts as guarded only when
-``build_credential_header`` is in its chain. ``credential_header_line`` alone
-does not qualify, because it only concatenates whatever pair it is handed, so
-crediting it would let ``credential_header_line(("Authorization", whatever))``
-through the gate with no validation at all (fix(#1756 codex round 1)).
+**Provenance is a whole-expression rule.** fix(#1756 codex round 2): it used
+to ask whether the written expression MENTIONED builder output anywhere, which
+passed ``f"Authorization: Bearer {line}"`` for a builder-derived ``line``, the
+exact double-prefix string this module exists to prevent. It now asks whether
+the whole expression is one of these projections of builder output, and
+nothing else is accepted:
+
+- ``build_credential_header(...)`` itself.
+- a name whose latest binding BEFORE the use site is an allowed expression, so
+  a later ``line = anything_else`` revokes it, and a parameter, loop target or
+  ``with`` target carries no provenance at all.
+- ``credential_header_line(<allowed>)``, one positional argument. The joiner
+  on its own only concatenates the pair it is handed, so
+  ``credential_header_line(("Authorization", value))`` is not allowed.
+- ``<allowed> + "\\n"``, or an f-string whose single interpolation is
+  ``<allowed>`` with no conversion and no format spec, and whose only literal
+  part, if any, is a trailing newline.
+- ``.encode()`` or ``.encode("ascii")`` on an allowed expression.
+- ``<allowed pair>[0]`` and ``[1]``, and a name unpacked from an allowed pair,
+  for the header-dict case.
+
+Any other operator, any extra literal text, a second interpolation, or a
+format spec fails. A credential that arrives as a parameter has no lexical
+provenance and is therefore reported: the fix is to compose it at the write
+site, not to widen this rule.
 
 Both allowlists are asserted EXACT in both directions and by count, so an
 entry whose site disappears fails loudly instead of going stale. Four of the
@@ -50,19 +70,20 @@ test is what tells it when the last one is gone.
 
 WHAT THIS DOES NOT CLAIM, in the same spirit as the Rule-2 guard. It is a
 lexical rule, not dataflow. A line built in one function and written in
-another (no such shape exists today), a header dict assembled through
-``update()`` from a value computed elsewhere, and a credential reaching a
-request as a pre-built parameter are all outside what an AST rule can answer.
-The provenance check follows names bound to a builder call within the same
-scope and no further. False alarms are cheap and visible; a silent miss is the
-failure that matters, so anything the resolver cannot classify is reported.
+another, a header dict assembled through ``update()`` from a value computed
+elsewhere, and a binding made under one branch of an ``if`` and used under the
+other are all outside what an AST rule can answer. Binding order is read from
+source position, which is the straight-line answer and not a control-flow one.
+False alarms are cheap and visible; a silent miss is the failure that matters,
+so anything the resolver cannot classify is reported.
 """
 
 from __future__ import annotations
 
 import ast
-from collections import Counter
+from collections import Counter, defaultdict
 from pathlib import Path
+from typing import NamedTuple
 
 APP_ROOT = Path(__file__).resolve().parent.parent / "app"
 
@@ -138,6 +159,11 @@ MIN_HEADER_FILE_WRITE_SITES = 2
 MIN_CREDENTIAL_HEADER_SITES = 4
 
 _MODULE_SCOPE = "<module>"
+_NESTED_SCOPES = (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda, ast.ClassDef)
+
+# Before every statement in a scope, so a parameter never resolves to a
+# binding made later in the body.
+_SCOPE_START = (-1, -1)
 
 
 def _app_modules() -> list[tuple[str, ast.Module]]:
@@ -185,59 +211,216 @@ def _scope_calls(scope: ast.AST, name: str) -> bool:
     )
 
 
-def _from_builder(expr: ast.AST, bound: frozenset[str]) -> bool:
-    """Whether *expr*'s value came from ``build_credential_header``.
+def _pos(node: ast.AST) -> tuple[int, int]:
+    return (getattr(node, "lineno", 0), getattr(node, "col_offset", 0))
 
-    The joiner counts only when it is joining a builder pair. On its own it
-    concatenates any two strings, so crediting a bare
-    ``credential_header_line(("Authorization", value))`` would hand the gate a
-    way to pass an unvalidated credential.
+
+class _Binding(NamedTuple):
+    """One binding of a name inside a scope.
+
+    ``value`` is None when the binding is something this rule cannot judge: a
+    parameter, a loop target, an import. Such a binding is RECORDED rather
+    than skipped, because it has to revoke an earlier builder binding.
     """
-    for node in ast.walk(expr):
-        if isinstance(node, ast.Call):
-            name = _call_name(node.func)
-            if name == CREDENTIAL_BUILDER:
-                return True
-            if (
-                name == CREDENTIAL_JOINER
-                and node.args
-                and _from_builder(node.args[0], bound)
-            ):
-                return True
-        if isinstance(node, ast.Name) and node.id in bound:
-            return True
-    return False
+
+    pos: tuple[int, int]
+    value: ast.expr | None
 
 
-def _builder_bound_names(scope: ast.AST) -> frozenset[str]:
-    """Names holding a value derived from the builder, anywhere in *scope*.
+def _iter_scope_nodes(scope: ast.AST):
+    """Every node in *scope*, without descending into a nested callable."""
+    stack = list(ast.iter_child_nodes(scope))
+    while stack:
+        node = stack.pop()
+        yield node
+        if isinstance(node, _NESTED_SCOPES):
+            continue
+        stack.extend(ast.iter_child_nodes(node))
 
-    Iterated to a fixed point so a chain resolves whatever order the
-    assignments appear in: ``pair`` from the builder, then ``line`` from the
-    joiner applied to ``pair``.
 
-    Deliberately flow-insensitive: a name assigned from the builder counts
-    wherever it is used in that scope. Narrowing it would report violations
-    for correct code, and this rule's job is to catch a hand-composed prefix,
-    not to referee assignment order.
+def _scope_arguments(scope: ast.AST) -> list[str]:
+    args = getattr(scope, "args", None)
+    if not isinstance(args, ast.arguments):
+        return []
+    every = [*args.posonlyargs, *args.args, *args.kwonlyargs]
+    if args.vararg is not None:
+        every.append(args.vararg)
+    if args.kwarg is not None:
+        every.append(args.kwarg)
+    return [argument.arg for argument in every]
+
+
+def _assignment_binding(
+    node: ast.AST,
+) -> tuple[list[ast.expr], ast.expr | None] | None:
+    """Targets and bound value for a node that binds by assignment.
+
+    A None value means the binding is real but unjudgeable, which is what
+    makes a loop target or an augmented assignment revoke an earlier one.
     """
-    bound: set[str] = set()
-    changed = True
-    while changed:
-        changed = False
-        for node in ast.walk(scope):
-            if not isinstance(node, (ast.Assign, ast.AnnAssign, ast.NamedExpr)):
-                continue
-            value = node.value
-            if value is None or not _from_builder(value, frozenset(bound)):
-                continue
-            targets = node.targets if isinstance(node, ast.Assign) else [node.target]
+    if isinstance(node, ast.Assign):
+        return node.targets, node.value
+    if isinstance(node, (ast.AnnAssign, ast.NamedExpr)):
+        return [node.target], node.value
+    if isinstance(node, ast.AugAssign):
+        return [node.target], None
+    if isinstance(node, (ast.For, ast.AsyncFor, ast.comprehension)):
+        return [node.target], None
+    if isinstance(node, ast.withitem) and node.optional_vars is not None:
+        return [node.optional_vars], None
+    return None
+
+
+def _opaque_names(node: ast.AST) -> list[str]:
+    """Names *node* binds to something this rule cannot judge."""
+    if isinstance(node, ast.ExceptHandler) and node.name:
+        return [node.name]
+    if isinstance(node, (ast.Import, ast.ImportFrom)):
+        return [alias.asname or alias.name.split(".")[0] for alias in node.names]
+    if isinstance(node, _NESTED_SCOPES) and not isinstance(node, ast.Lambda):
+        return [node.name]
+    return []
+
+
+def _scope_bindings(scope: ast.AST) -> dict[str, list[_Binding]]:
+    """Every name binding in *scope*, ordered by source position."""
+    bindings: dict[str, list[_Binding]] = defaultdict(list)
+
+    def record(target: ast.expr, value: ast.expr | None) -> None:
+        if isinstance(target, ast.Name):
+            bindings[target.id].append(_Binding(_pos(target), value))
+        elif isinstance(target, (ast.Tuple, ast.List)):
+            # A component of an allowed pair is allowed, which is what makes
+            # `name, value = build_credential_header(auth)` usable.
+            for element in target.elts:
+                record(element, value)
+        elif isinstance(target, ast.Starred):
+            record(target.value, None)
+
+    for argument in _scope_arguments(scope):
+        bindings[argument].append(_Binding(_SCOPE_START, None))
+
+    for node in _iter_scope_nodes(scope):
+        assignment = _assignment_binding(node)
+        if assignment is not None:
+            targets, value = assignment
             for target in targets:
-                for inner in ast.walk(target):
-                    if isinstance(inner, ast.Name) and inner.id not in bound:
-                        bound.add(inner.id)
-                        changed = True
-    return frozenset(bound)
+                record(target, value)
+        for name in _opaque_names(node):
+            bindings[name].append(_Binding(_pos(node), None))
+
+    for name in bindings:
+        bindings[name].sort(key=lambda binding: binding.pos)
+    return dict(bindings)
+
+
+def _binding_before(
+    bindings: dict[str, list[_Binding]], name: str, limit: tuple[int, int]
+) -> _Binding | None:
+    """The latest binding of *name* that precedes *limit*."""
+    latest: _Binding | None = None
+    for binding in bindings.get(name, ()):
+        if binding.pos < limit:
+            latest = binding
+    return latest
+
+
+def _is_newline_literal(expr: ast.expr) -> bool:
+    return isinstance(expr, ast.Constant) and expr.value == "\n"
+
+
+def _is_line_fstring(
+    expr: ast.JoinedStr, bindings: dict[str, list[_Binding]], limit: tuple[int, int]
+) -> bool:
+    """One interpolation of an allowed expression, plus a trailing newline."""
+    interpolations = [
+        value for value in expr.values if isinstance(value, ast.FormattedValue)
+    ]
+    literals = [
+        value for value in expr.values if not isinstance(value, ast.FormattedValue)
+    ]
+    if len(interpolations) != 1 or len(literals) > 1:
+        return False
+    if literals and not (
+        literals[0] is expr.values[-1] and _is_newline_literal(literals[0])
+    ):
+        return False
+    placeholder = interpolations[0]
+    if placeholder.conversion != -1 or placeholder.format_spec is not None:
+        return False
+    return _is_builder_projection(placeholder.value, bindings, limit)
+
+
+def _is_pair_component(
+    expr: ast.Subscript, bindings: dict[str, list[_Binding]], limit: tuple[int, int]
+) -> bool:
+    index = expr.slice
+    if not isinstance(index, ast.Constant) or isinstance(index.value, bool):
+        return False
+    if index.value not in (0, 1):
+        return False
+    return _is_builder_projection(expr.value, bindings, limit)
+
+
+def _is_encode_call(
+    expr: ast.Call, bindings: dict[str, list[_Binding]], limit: tuple[int, int]
+) -> bool:
+    if not isinstance(expr.func, ast.Attribute) or expr.keywords:
+        return False
+    if len(expr.args) > 1:
+        return False
+    if expr.args and not (
+        isinstance(expr.args[0], ast.Constant) and expr.args[0].value == "ascii"
+    ):
+        return False
+    return _is_builder_projection(expr.func.value, bindings, limit)
+
+
+def _is_builder_projection(
+    expr: ast.expr, bindings: dict[str, list[_Binding]], limit: tuple[int, int]
+) -> bool:
+    """Whether the WHOLE of *expr* is an allowed projection of builder output.
+
+    The allowed shapes are enumerated in the module docstring. Anything else
+    is a violation, including an expression that merely CONTAINS builder
+    output: that was the round-2 hole, and ``f"Authorization: Bearer {line}"``
+    is exactly the string it let through.
+
+    Name resolution walks backwards: a name resolves to its latest binding
+    before *limit*, and that binding's own value is then judged with the
+    binding's position as the new limit. The limit therefore decreases on
+    every step, so a self-reference such as ``line = line`` terminates instead
+    of recursing forever.
+    """
+    if isinstance(expr, ast.Call):
+        name = _call_name(expr.func)
+        if name == CREDENTIAL_BUILDER:
+            return True
+        if name == CREDENTIAL_JOINER:
+            return (
+                len(expr.args) == 1
+                and not expr.keywords
+                and _is_builder_projection(expr.args[0], bindings, limit)
+            )
+        if name == "encode":
+            return _is_encode_call(expr, bindings, limit)
+        return False
+    if isinstance(expr, ast.Name):
+        binding = _binding_before(bindings, expr.id, limit)
+        if binding is None or binding.value is None:
+            return False
+        return _is_builder_projection(binding.value, bindings, binding.pos)
+    if isinstance(expr, ast.BinOp):
+        return (
+            isinstance(expr.op, ast.Add)
+            and _is_newline_literal(expr.right)
+            and _is_builder_projection(expr.left, bindings, limit)
+        )
+    if isinstance(expr, ast.JoinedStr):
+        return _is_line_fstring(expr, bindings, limit)
+    if isinstance(expr, ast.Subscript):
+        return _is_pair_component(expr, bindings, limit)
+    return False
 
 
 def _written_value(call: ast.Call) -> ast.expr | None:
@@ -330,7 +513,7 @@ def _scan_module(rel: str, tree: ast.Module) -> _Scan:
     _annotate_parents(tree)
     scan = _Scan()
     allow_dynamic_key = rel.startswith(DYNAMIC_KEY_PACKAGES)
-    bound_cache: dict[int, frozenset[str]] = {}
+    bindings_cache: dict[int, dict[str, list[_Binding]]] = {}
     header_dir_cache: dict[int, bool] = {}
 
     for node in ast.walk(tree):
@@ -342,10 +525,10 @@ def _scan_module(rel: str, tree: ast.Module) -> _Scan:
             continue
 
         scope = _enclosing_scope(node, tree)
-        bound = bound_cache.get(id(scope))
-        if bound is None:
-            bound = _builder_bound_names(scope)
-            bound_cache[id(scope)] = bound
+        bindings = bindings_cache.get(id(scope))
+        if bindings is None:
+            bindings = _scope_bindings(scope)
+            bindings_cache[id(scope)] = bindings
         site = (rel, _scope_name(scope))
 
         if is_write:
@@ -356,12 +539,14 @@ def _scan_module(rel: str, tree: ast.Module) -> _Scan:
             if writes_a_header:
                 scan.write_sites += 1
                 value = _written_value(node)  # type: ignore[arg-type]
-                if value is None or not _from_builder(value, bound):
+                if value is None or not _is_builder_projection(
+                    value, bindings, _pos(value)
+                ):
                     scan.unguarded_writes[site] += 1
 
         for value in header_values:
             scan.header_sites += 1
-            if not _from_builder(value, bound):
+            if not _is_builder_projection(value, bindings, _pos(value)):
                 scan.unguarded_headers[site] += 1
 
     return scan
@@ -480,6 +665,27 @@ def test_guard_a_builder_composition_is_clean() -> None:
     assert not scan.unguarded_headers
 
 
+def test_guard_the_other_allowed_projections_are_clean() -> None:
+    """The shapes B2b may reasonably write, spelled out.
+
+    Concatenation instead of an f-string, an unencoded line, and the pair
+    unpacked into two names.
+    """
+    scan = _scan_synthetic(
+        "def f(auth, fd, handle):\n"
+        "    path = gdal_header_dir()\n"
+        "    line = credential_header_line(build_credential_header(auth))\n"
+        '    os.write(fd, (line + "\\n").encode())\n'
+        "    handle.write(line)\n"
+        "    name, value = build_credential_header(auth)\n"
+        "    headers[name] = value\n"
+    )
+    assert scan.write_sites == 2
+    assert scan.header_sites == 1
+    assert not scan.unguarded_writes
+    assert not scan.unguarded_headers
+
+
 def test_guard_the_joiner_alone_confers_nothing() -> None:
     """fix(#1756 codex round 1): the joiner only concatenates.
 
@@ -495,6 +701,81 @@ def test_guard_the_joiner_alone_confers_nothing() -> None:
     )
     assert sum(scan.unguarded_writes.values()) == 1
     assert sum(scan.unguarded_headers.values()) == 1
+
+
+def test_guard_a_double_prefix_around_a_builder_line_is_flagged() -> None:
+    """fix(#1756 codex round 2): the case the module docstring promises.
+
+    ``line`` really did come from the builder, and the f-string still writes
+    ``Authorization: Bearer Authorization: Basic <blob>``. A rule that asks
+    whether the expression MENTIONS builder output passes this.
+    """
+    scan = _scan_synthetic(
+        "def f(auth, fd):\n"
+        "    path = gdal_header_dir()\n"
+        "    line = credential_header_line(build_credential_header(auth))\n"
+        '    os.write(fd, f"Authorization: Bearer {line}\\n".encode("ascii"))\n'
+        '    headers["Authorization"] = f"Bearer {line}"\n'
+    )
+    assert sum(scan.unguarded_writes.values()) == 1
+    assert sum(scan.unguarded_headers.values()) == 1
+
+
+def test_guard_concatenating_an_untrusted_name_is_flagged() -> None:
+    """Only a trailing newline may be concatenated onto builder output."""
+    scan = _scan_synthetic(
+        "def f(auth, fd, untrusted):\n"
+        "    path = gdal_header_dir()\n"
+        "    line = credential_header_line(build_credential_header(auth))\n"
+        '    os.write(fd, (line + untrusted).encode("ascii"))\n'
+        '    headers["Authorization"] = line + untrusted\n'
+    )
+    assert sum(scan.unguarded_writes.values()) == 1
+    assert sum(scan.unguarded_headers.values()) == 1
+
+
+def test_guard_a_rebinding_after_the_builder_call_revokes_trust() -> None:
+    """The latest binding before the use site is the one that counts."""
+    scan = _scan_synthetic(
+        "def f(auth, fd, untrusted):\n"
+        "    path = gdal_header_dir()\n"
+        "    line = credential_header_line(build_credential_header(auth))\n"
+        "    line = untrusted\n"
+        '    os.write(fd, f"{line}\\n".encode("ascii"))\n'
+        '    headers["Authorization"] = line\n'
+    )
+    assert sum(scan.unguarded_writes.values()) == 1
+    assert sum(scan.unguarded_headers.values()) == 1
+
+
+def test_guard_a_second_interpolation_or_a_format_spec_is_flagged() -> None:
+    """One interpolation, no conversion, no format spec, no extra literal."""
+    scan = _scan_synthetic(
+        "def f(auth, fd, extra):\n"
+        "    path = gdal_header_dir()\n"
+        "    line = credential_header_line(build_credential_header(auth))\n"
+        '    os.write(fd, f"{line}{extra}\\n".encode("ascii"))\n'
+        '    os.write(fd, f"{line:>40}\\n".encode("ascii"))\n'
+        '    os.write(fd, f"{line!r}\\n".encode("ascii"))\n'
+        '    os.write(fd, f"{line}\\n\\n".encode("ascii"))\n'
+    )
+    assert scan.write_sites == 4
+    assert sum(scan.unguarded_writes.values()) == 4
+
+
+def test_guard_a_parameter_carries_no_provenance() -> None:
+    """A stated limit, reported rather than passed.
+
+    A finished line arriving as an argument has no lexical provenance, so the
+    write is judged rather than trusted. Composing at the write site is the
+    fix; widening the rule is not.
+    """
+    scan = _scan_synthetic(
+        "def f(line, fd):\n"
+        "    path = gdal_header_dir()\n"
+        '    os.write(fd, f"{line}\\n".encode("ascii"))\n'
+    )
+    assert sum(scan.unguarded_writes.values()) == 1
 
 
 def test_guard_a_second_write_beside_a_builder_one_is_flagged() -> None:
@@ -513,7 +794,7 @@ def test_guard_a_second_write_beside_a_builder_one_is_flagged() -> None:
 def test_guard_os_write_reads_the_second_argument() -> None:
     """``os.write(fd, data)`` and ``handle.write(data)`` differ by one index."""
     scan = _scan_synthetic(
-        "def f(auth, fd):\n"
+        "def f(auth, fd, handle):\n"
         "    path = gdal_header_dir()\n"
         "    line = credential_header_line(build_credential_header(auth))\n"
         "    handle.write(line)\n"
@@ -574,3 +855,18 @@ def test_guard_a_non_credential_header_is_not_judged() -> None:
         "processing/tiles/synthetic.py",
     )
     assert scan.header_sites == 0
+
+
+def test_guard_a_self_reference_terminates() -> None:
+    """``line = line`` resolves to nothing rather than recursing forever.
+
+    The resolution limit strictly decreases on every name lookup, which is
+    what makes that true; this is the check on that reasoning.
+    """
+    scan = _scan_synthetic(
+        "def f(fd):\n"
+        "    path = gdal_header_dir()\n"
+        "    line = line\n"
+        '    os.write(fd, f"{line}\\n".encode("ascii"))\n'
+    )
+    assert sum(scan.unguarded_writes.values()) == 1

--- a/backend/tests/test_cross_origin_credential_1746.py
+++ b/backend/tests/test_cross_origin_credential_1746.py
@@ -1,0 +1,190 @@
+"""A credential header stays on the origin it was given to (fix(#1746)).
+
+httpx removes ``Authorization`` when a redirect changes origin and forwards
+every other header unchanged. The header-key auth method sends a credential
+under a name the service chose -- ``X-API-Key``, Ordnance Survey's ``key``,
+Azure's ``Ocp-Apim-Subscription-Key`` -- so without this check a 302 from a
+probed service hands that key to whatever origin the Location names.
+
+The per-hop SSRF revalidation next to this does not close it. That one asks
+whether the target is a private address; this one asks whether it is the same
+service. A redirect to an ordinary public host passes the first question and
+fails the second.
+
+These tests drive a real client from ``make_safe_client`` over a mock
+transport, because two of the claims are about what httpx itself does: that a
+response hook raising stops the follow before a second request goes out, and
+that httpx strips ``Authorization`` on its own. Asserted against a stub, both
+would break silently on an httpx bump.
+"""
+
+from unittest.mock import AsyncMock
+
+import httpx
+import pytest
+
+from app.platform import security
+from app.platform.security import SSRFError, make_safe_client
+
+CREDENTIAL = "k1234567"
+FIRST = "https://service.example/data"
+SAME_ORIGIN = "https://service.example/moved"
+DEFAULT_PORT = "https://service.example:443/moved"
+CROSS_ORIGIN = "https://elsewhere.example/collect"
+
+
+@pytest.fixture
+def transport(monkeypatch):
+    """Install a transport that answers one 302 to *location*, then 200.
+
+    Patches the transport factory rather than reaching into the client, so the
+    client under test is the one ``make_safe_client`` actually builds, and
+    patches the SSRF validator so following a redirect does not depend on DNS.
+    Passing None answers 200 immediately.
+    """
+
+    def install(location: str | None) -> list[httpx.Request]:
+        recorded: list[httpx.Request] = []
+
+        def handle(request: httpx.Request) -> httpx.Response:
+            recorded.append(request)
+            if location is not None and len(recorded) == 1:
+                return httpx.Response(302, headers={"Location": location})
+            return httpx.Response(200, text="ok")
+
+        monkeypatch.setattr(
+            security, "make_safe_transport", lambda: httpx.MockTransport(handle)
+        )
+        monkeypatch.setattr(security, "validate_url_for_ssrf", AsyncMock())
+        return recorded
+
+    return install
+
+
+def _assert_real_client(client: httpx.AsyncClient) -> None:
+    """Guard against a sibling module's leaked patch of httpx.AsyncClient.
+
+    ``test_ssrf_redirect.py`` records contamination at this layer as a known
+    hazard, so a client that is not a real one fails here saying so, rather
+    than further down looking like a policy bug.
+    """
+    assert isinstance(client, httpx.AsyncClient), (
+        "make_safe_client did not return a real httpx client, so this test is "
+        "measuring a leaked patch rather than the redirect policy"
+    )
+
+
+@pytest.mark.anyio
+async def test_cross_origin_redirect_carrying_the_credential_is_refused(transport):
+    """The finding: the key must not reach the origin the 302 names."""
+    recorded = transport(CROSS_ORIGIN)
+    async with make_safe_client(credential_header="X-API-Key") as client:
+        _assert_real_client(client)
+        with pytest.raises(SSRFError) as raised:
+            await client.get(FIRST, headers={"X-API-Key": CREDENTIAL})
+
+    assert security.CROSS_ORIGIN_CREDENTIAL_POLICY in str(raised.value)
+    assert CREDENTIAL not in str(raised.value)
+    # The hook runs before httpx follows, so the second request never happened.
+    assert len(recorded) == 1
+
+
+@pytest.mark.anyio
+async def test_the_declared_name_is_matched_case_insensitively(transport):
+    """HTTP field names are case-insensitive and callers spell them either way."""
+    recorded = transport(CROSS_ORIGIN)
+    async with make_safe_client(credential_header="X-API-Key") as client:
+        with pytest.raises(SSRFError):
+            await client.get(FIRST, headers={"x-api-key": CREDENTIAL})
+    assert len(recorded) == 1
+
+
+@pytest.mark.anyio
+async def test_same_origin_redirect_still_follows_with_the_credential(transport):
+    """A service moving its own path is the ordinary case and keeps working."""
+    recorded = transport(SAME_ORIGIN)
+    async with make_safe_client(credential_header="X-API-Key") as client:
+        response = await client.get(FIRST, headers={"X-API-Key": CREDENTIAL})
+
+    assert response.status_code == 200
+    assert len(recorded) == 2
+    assert recorded[1].headers.get("X-API-Key") == CREDENTIAL
+
+
+@pytest.mark.anyio
+async def test_the_scheme_default_port_is_the_same_origin(transport):
+    """``https://host`` and ``https://host:443`` are one origin, not two.
+
+    Comparing the port as httpx reports it would make this a refusal, and a
+    real service would break over a spelling difference.
+    """
+    recorded = transport(DEFAULT_PORT)
+    async with make_safe_client(credential_header="X-API-Key") as client:
+        response = await client.get(FIRST, headers={"X-API-Key": CREDENTIAL})
+
+    assert response.status_code == 200
+    assert len(recorded) == 2
+
+
+@pytest.mark.anyio
+async def test_cross_origin_redirect_without_the_credential_still_follows(transport):
+    """The refusal is about the credential, not about crossing origins."""
+    recorded = transport(CROSS_ORIGIN)
+    async with make_safe_client(credential_header="X-API-Key") as client:
+        response = await client.get(FIRST)
+
+    assert response.status_code == 200
+    assert len(recorded) == 2
+
+
+@pytest.mark.anyio
+async def test_a_caller_declaring_nothing_is_unchanged(transport):
+    """Every call site that exists today passes no credential_header."""
+    recorded = transport(CROSS_ORIGIN)
+    async with make_safe_client() as client:
+        response = await client.get(FIRST, headers={"X-API-Key": CREDENTIAL})
+
+    assert response.status_code == 200
+    assert len(recorded) == 2
+
+
+@pytest.mark.anyio
+async def test_x_esri_authorization_is_refused_without_being_declared(transport):
+    """That name is a credential by definition, so it needs no declaration."""
+    recorded = transport(CROSS_ORIGIN)
+    async with make_safe_client() as client:
+        with pytest.raises(SSRFError):
+            await client.get(FIRST, headers={"X-Esri-Authorization": CREDENTIAL})
+    assert len(recorded) == 1
+
+
+@pytest.mark.anyio
+async def test_httpx_still_strips_authorization_across_origins(transport):
+    """The pin. ``Authorization`` is handled by httpx, not by this module.
+
+    Nothing in GeoLens refuses a cross-origin redirect carrying
+    ``Authorization``, because httpx drops the header itself. If an httpx bump
+    ever stopped doing that, the bearer token would start following redirects
+    off-origin and nothing else in the tree would notice.
+    """
+    recorded = transport(CROSS_ORIGIN)
+    async with make_safe_client() as client:
+        response = await client.get(
+            FIRST, headers={"Authorization": f"Bearer {CREDENTIAL}"}
+        )
+
+    assert response.status_code == 200
+    assert len(recorded) == 2
+    assert recorded[0].headers.get("Authorization") == f"Bearer {CREDENTIAL}"
+    assert "authorization" not in recorded[1].headers
+
+
+@pytest.mark.anyio
+async def test_a_response_that_is_not_a_redirect_is_never_judged(transport):
+    """No hop, nothing to refuse."""
+    recorded = transport(None)
+    async with make_safe_client(credential_header="X-API-Key") as client:
+        response = await client.get(FIRST, headers={"X-API-Key": CREDENTIAL})
+
+    assert response.status_code == 200
+    assert len(recorded) == 1


### PR DESCRIPTION
Wave 2 lane B1 of the per-source service auth work (#1746). Pure additions to
`backend/app/core/service_tokens.py` plus two new test files. No call site
changes anywhere, so behaviour on every shipping path is unchanged; lane B2b
rewires the four doors, the worker validator and the two header-file writers.

## What this adds

`credential_input_rejection_reason(value)` judges a username, password or
header value: not empty, printable ASCII, no whitespace, no line breaks. It
returns a policy string or None, the same convention as
`header_token_rejection_reason`, and it never describes the value.

`header_name_rejection_reason(name)` restricts a header name to RFC 7230 token
characters and denies two groups, case-insensitively. The names GeoLens sets
itself: authorization, x-esri-authorization, accept, content-type,
content-length, host, cookie, set-cookie, user-agent, referer. And the names
that change how a request is framed, routed or terminated rather than what it
carries: transfer-encoding, connection, proxy-authorization, proxy-connection,
keep-alive, te, trailer, upgrade, expect. HTTP/2 pseudo-headers are refused by
a colon-prefix rule rather than a list, because the set is open ended. The
second group was added in codex round 7: without it the header-key method
accepted `Transfer-Encoding: chunked`, which httpx and the libcurl header file
GDAL reads both honour, and `Proxy-Authorization`, which a configured forward
proxy reads rather than the service being addressed.

`build_credential_header(auth)` is the single producer. It returns a
`(name, value)` pair, or None. Bearer gives `Authorization: Bearer <token>`
and is still judged by the existing `header_token_rejection_reason`, so
nothing about today's bearer guarantee weakens. Basic base64-encodes
`user:password` server side. A header API key passes the validated pair
through.

`credential_header_line(pair)` joins with `": "` and returns one line with no
trailing newline. The pair-plus-joiner shape is deliberate: the GDAL header
file wants a line and the probe adapters want a dict key, and a builder that
returned only a string would put a re-parser in each adapter.

Five policy constants, none of which contains a brace, so none can grow an
interpolation later without failing the pin that
`tests/test_service_refresh_1220.py` already puts on `HEADER_TOKEN_POLICY`.

## The `auth` object, for lane B2a

Lane B2a builds the request schema on this, so the shape is stated here rather
than left to be inferred:

```python
class CredentialMethod(StrEnum):
    NONE = "none"
    BEARER = "bearer"
    BASIC = "basic"
    HEADER_KEY = "header"

@dataclass(frozen=True, slots=True)
class ServiceCredential:
    method: CredentialMethod | str = CredentialMethod.NONE
    service_format: str | None = None
    token: str | None = None
    username: str | None = None
    password: str | None = None
    header_name: str | None = None
    header_value: str | None = None
```

Four choices in it worth knowing about.

The enum values are the wire literals from plan section 3.4, so a pydantic
`Literal` or an enum field validates against them directly and the string
passes through with no mapping. `HEADER_KEY` spells its value `header`,
matching 3.4; the member name says which of the header branches it is, since
bearer and basic also produce one.

`service_format` is on the object, which is the one field 3.4 does not name.
It has to be somewhere, because the ArcGIS invariant is a property of the
service and not of the method: an ArcGIS token is percent-encoded into a URL
query, so a header composed for it would land inside a query string. Putting
it on the object keeps `build_credential_header(auth)` single-argument and
gives the doors one value to pass around, which is what D2 asks for.

The rule is an allowlist, not an ArcGIS denylist: a header is produced only
when `requires_header_token_policy(service_format)` is true, meaning wfs or
ogcapi_features. A format nobody considered, or an unset one, degrades to no
header. That direction is deliberate. The failure is a 401 from the origin,
which is loud; the denylist version fails toward composing a header for a
transport that cannot carry one. It does mean B2b has to thread the format
through, and preview is the awkward one: it holds a composed GDAL source
string rather than a stored `source_format`, so the `WFS:`/`OAPIF:` prefix is
the selector there, as `test_service_refresh_1220.py` already records.

A frozen dataclass rather than a pydantic model, because `core/` may not
import `app.modules.*` and neither may `processing/`, while both may import
here. B2a converts its request model into one of these at the door; an overlay
that has resolved a stored credential constructs one directly and calls the
service function, which is the seam D2 asks Phase 1 to leave open.

## Non-ASCII is rejected at the door, deliberately

RFC 7617 makes UTF-8 the default charset for basic authentication, so a
reviewer who knows the RFC will read this restriction as a bug. It is not.
Both header-file writers encode with `.encode("ascii")`, so an accented letter
in an API key raises `UnicodeEncodeError` inside the worker, after `GETDEL`
has already claimed the single-use credential. That failure is unrecoverable
without re-entering the credential and its message points at an encoding bug
rather than at the field the user typed. Rejecting it at the door costs the
small set of users with a non-ASCII API key an error they can act on, and the
alternative is a spent credential and a confusing message.

`HEADER_TOKEN_CHARSET` is untouched and still judges exactly one thing, a bare
bearer token. The composed credential is never charset-checked, which is what
makes the base64 of a validated username and password safe by construction:
standard base64 emits `+` or `/` only when the byte at an offset congruent to
2 mod 3 is `>`, `?` or `~`, so the same password passes or fails depending on
the length of the username. `wfs:a~b1234` and `wfs:a?bcdef` are both tested.

One rule beyond the plan text: a username containing a colon is rejected
(RFC 7617 says a user-id containing one is invalid). Without it the colon
moves the split point rather than failing, so the origin would authenticate a
different user than the one that was typed. A colon in the password is fine
and is tested.

## Structural test

`backend/tests/test_credential_producer_structural.py` walks every module
under `backend/app/` as an AST, in the shape of `test_rule2_structural.py`,
and requires the value of

- any write in a scope that calls `gdal_header_dir()`, and
- any `headers[...] = ...` under `modules/catalog/sources/adapters/`, plus any
  dict literal there keyed by a credential header name,

to come from `build_credential_header` or `credential_header_line`. The dict
literal shape is included because it is the same composition one line up and
would otherwise be a free evasion.

The four sites that compose their own prefix today (`ogr.py:1059`,
`preview.py:197`, `adapters/wfs.py:115`, `adapters/ogcapi.py:56`) are
allowlisted by exact count with a `fix(#1746 service-auth B2b removes this)`
justification each. The allowlist is asserted in both directions, so B2b's
last deletion turns the test red with "Delete the entry" rather than leaving a
stale entry behind. None of those four files is touched here.

Limits stated in the module docstring: it is a lexical rule, not dataflow. A
line built in one function and written in another, a header dict assembled
through `update()`, and a credential arriving as a pre-built parameter are
outside what an AST rule can answer. Anything the resolver cannot classify is
reported rather than passed.

## Schema, API and config impact

None. No request or response schema changes, so no OpenAPI regeneration, no
SDK churn and no migration. No new setting, no new env var. Nothing is stored
and nothing is logged.

## Verification

Run from this worktree with a local `.env.test` and Postgres on 5434.

- `uv run pytest tests/test_credential_policy.py tests/test_credential_producer_structural.py -q`: 144 passed.
- `uv run pytest tests/test_layering.py -q`: 47 passed, in the same run as the two above (191 passed together). `service_tokens.py` is 329 lines against a 1000-line ratchet-inclusion threshold, so no cap is raised and none is added.
- `uv run pytest tests/test_service_refresh_1220.py tests/test_door_token_policy_1746.py -q`: 98 passed. Those are the two suites that pin `HEADER_TOKEN_POLICY`, the door helper names and the worker charset.
- `uv run ruff check .` and `uv run ruff format --check .`: clean over the whole backend.

Three counterfactuals, each applied to the tree, run, and reverted, because a
structural test that cannot fail is worth nothing:

- a fifth composition added to `adapters/stac.py` fails with "composes a credential header itself".
- the `adapters/wfs.py` site rewritten the way B2b will rewrite it fails with "is allowlisted for 1 site(s) and has none left. Delete the entry."
- a second `os.write` added inside `run_ogr2ogr_service` fails with "has 2 unguarded site(s), allowlisted for 1".

The tree is back to the committed state after all three; `git status` is clean.

No Playwright run. This lane is backend only, and a worktree Playwright run
would exercise the main checkout's API rather than this branch, so a green one
would be evidence about code this PR did not write.

## Noticed and left alone

`_validate_safe_token` in `sources/schemas.py` is the second, looser token
rule and is untouched here; #1755 item 3 already tracks consolidating the two.
The worker's `_sanitize_authorization_token` still names the offending
character in its message, which stays correct for the bearer case and is lane
B2b's to narrow when the same path starts judging an encoded password.

https://claude.ai/code/session_01SFCMH3VJ5pFfM9Rer7KHZq

