### PR TITLE
fix(dataset): reveal an inline credential prompt on a refused refresh

### DIFF
--- a/e2e/dataset-refresh-credentials.spec.ts
+++ b/e2e/dataset-refresh-credentials.spec.ts
@@ -1,0 +1,190 @@
+import { test, expect, type Page, type Route } from '@playwright/test';
+import { getAuthToken, getSearchSeed, type SearchSeed } from './helpers/catalog';
+
+const BASE_URL = process.env.E2E_BASE_URL ?? 'http://localhost:8080';
+
+/**
+ * Refresh-door inline credential prompt (#1755 item 4, service-auth plan
+ * section 3.7). Covers the 422 `service_token_required` refusal from
+ * `POST /datasets/{id}/refresh`: the dialog must stay open and reveal a
+ * credential prompt keyed to the token field, with different copy for an
+ * ArcGIS origin (full sign-in taxonomy) than for a WFS/OGC API Features
+ * origin (bearer token only, refused-outright copy).
+ *
+ * Everything network-side is mocked with `page.route`:
+ *   - `GET /api/datasets/{id}` is rewritten to report whichever service
+ *     `source_format` the test needs, on top of a real dataset's full
+ *     payload (so every other field the page renders stays valid).
+ *   - `POST /api/datasets/{id}/refresh` is fulfilled with the 422 this
+ *     lane's frontend change reacts to; lane A1's sign-in endpoint has not
+ *     merged yet, and the 422 itself does not depend on any dataset's real
+ *     `auth_required` marker, so nothing here needs the live backend to
+ *     agree the dataset is protected.
+ *   - `POST /api/services/arcgis/signin/` is fulfilled per lane A1's
+ *     contract (plan 3.2), which this lane builds against and mocks rather
+ *     than calling for real.
+ *
+ * Navigation to the dataset goes through the search typeahead (client-side
+ * routing), not a direct `page.goto('/datasets/{id}')` — a hard `goto` of a
+ * protected route drops the session under the worktree Vite recipe used to
+ * exercise this lane (`AGENTS.md`, "Working from a git worktree").
+ */
+
+const RAW_SERVICE_TOKEN_MESSAGE =
+  "This dataset's source needed a service token the last time it was imported or refreshed, and this request carries none. Send the token again in the request body's `token` field; tokens are request-only and are never stored between runs. If the source is public now, re-import it through the re-upload dialog without a token to clear the requirement.";
+
+let seed: SearchSeed;
+let baseDataset: Record<string, unknown>;
+
+test.beforeAll(async () => {
+  seed = await getSearchSeed();
+  // Node-side fetch with the bearer token pulled from the saved storage
+  // state, matching `helpers/catalog.ts` and `dataset-detail.spec.ts` — the
+  // auth token lives in localStorage, not a cookie, so the Playwright
+  // `request` fixture (cookie-based) can't carry it.
+  const res = await fetch(`${BASE_URL}/api/datasets/${seed.id}`, {
+    headers: { Authorization: `Bearer ${getAuthToken()}` },
+  });
+  expect(res.ok).toBe(true);
+  baseDataset = await res.json();
+});
+
+function mockDataset(page: Page, sourceFormat: 'wfs' | 'arcgis_featureserver') {
+  return page.route(`**/api/datasets/${seed.id}`, (route: Route) => {
+    if (route.request().method() !== 'GET') return route.continue();
+    return route.fulfill({
+      json: {
+        ...baseDataset,
+        source_format: sourceFormat,
+        origin: 'service',
+      },
+    });
+  });
+}
+
+/** Always answers the 422 this lane's frontend change reacts to. */
+function mockRefreshRefused(page: Page) {
+  return page.route(`**/api/datasets/${seed.id}/refresh`, (route: Route) => {
+    if (route.request().method() !== 'POST') return route.continue();
+    return route.fulfill({
+      status: 422,
+      json: {
+        detail: { code: 'service_token_required', message: RAW_SERVICE_TOKEN_MESSAGE },
+      },
+    });
+  });
+}
+
+async function openRefreshDialogAndSubmit(page: Page) {
+  await page.goto('/');
+  await page.waitForLoadState('networkidle');
+
+  // SPA-navigate to the dataset via the search typeahead, not a hard goto —
+  // see the file-level comment.
+  const searchInput = page.getByRole('combobox', { name: 'Search the catalog...' });
+  await searchInput.click();
+  await searchInput.fill(seed.query);
+  await expect(page.getByRole('option', { name: seed.title, exact: true })).toBeVisible({
+    timeout: 15_000,
+  });
+  await searchInput.press('ArrowDown');
+  await searchInput.press('Enter');
+  await expect(page).toHaveURL(new RegExp(`/datasets/${seed.id}$`));
+
+  await page.getByRole('tab', { name: 'Source' }).click();
+  await page.getByRole('button', { name: 'Refresh from source' }).click();
+  await page.getByRole('button', { name: 'Start refresh' }).click();
+}
+
+test.describe('Refresh-door credential prompt on service_token_required', () => {
+  test('WFS origin: dialog stays open, shows the outright-refusal copy, never the raw response text', async ({
+    page,
+  }) => {
+    await mockDataset(page, 'wfs');
+    await mockRefreshRefused(page);
+
+    await openRefreshDialogAndSubmit(page);
+
+    await expect(
+      page.getByText(
+        'This source refused the refresh outright because it needs a credential. Send the token again below.',
+      ),
+    ).toBeVisible();
+    await expect(
+      page.getByText(
+        'If the source is public now, re-import it through the Re-Upload dialog with no token to clear this requirement.',
+      ),
+    ).toBeVisible();
+    await expect(page.getByRole('dialog')).toBeVisible();
+    await expect(page.getByLabel('Authentication method')).toHaveCount(0);
+    await expect(page.locator('body')).not.toContainText(RAW_SERVICE_TOKEN_MESSAGE);
+  });
+
+  test('ArcGIS origin: dialog stays open and offers the sign-in taxonomy, distinct from the WFS copy', async ({
+    page,
+  }) => {
+    await mockDataset(page, 'arcgis_featureserver');
+    await mockRefreshRefused(page);
+
+    await openRefreshDialogAndSubmit(page);
+
+    await expect(page.getByLabel('Authentication method')).toBeVisible();
+    await expect(page.getByRole('dialog')).toBeVisible();
+    await expect(page.getByText(/refused the refresh outright/i)).toHaveCount(0);
+    await expect(page.locator('body')).not.toContainText(RAW_SERVICE_TOKEN_MESSAGE);
+  });
+
+  test('ArcGIS sign-in mints a token and the retry sends it in the refresh body', async ({ page }) => {
+    await mockDataset(page, 'arcgis_featureserver');
+
+    await page.route(`**/api/services/arcgis/signin/`, (route: Route) =>
+      route.fulfill({
+        json: { token: 'minted-e2e-token', expires_at: '2026-09-01T13:00:00Z' },
+      }),
+    );
+
+    let refreshCalls = 0;
+    let secondCallBody: unknown;
+    await page.route(`**/api/datasets/${seed.id}/refresh`, async (route: Route) => {
+      if (route.request().method() !== 'POST') return route.continue();
+      refreshCalls += 1;
+      if (refreshCalls === 1) {
+        return route.fulfill({
+          status: 422,
+          json: {
+            detail: { code: 'service_token_required', message: RAW_SERVICE_TOKEN_MESSAGE },
+          },
+        });
+      }
+      secondCallBody = route.request().postDataJSON();
+      return route.fulfill({
+        json: {
+          run_id: 'e2e-run-1',
+          job_id: 'e2e-job-1',
+          dataset_id: seed.id,
+          origin_kind: 'service',
+          trigger: 'api',
+          status: 'pending',
+          message: 'Refresh queued from the stored source',
+        },
+      });
+    });
+
+    await openRefreshDialogAndSubmit(page);
+
+    await page.getByLabel('Authentication method').selectOption('signin');
+    await page.getByLabel('Portal URL').fill('https://myorg.maps.arcgis.com');
+    await page.getByLabel('Username').fill('alice');
+    await page.getByLabel('Password').fill('hunter2');
+    await page.getByRole('button', { name: 'Sign in' }).click();
+
+    await expect(page.getByText('Signed in. The token below is ready to use.')).toBeVisible();
+    await expect(page.getByLabel('Password')).toHaveValue('');
+
+    await page.getByRole('button', { name: 'Start refresh' }).click();
+
+    await expect(page.getByRole('dialog')).toHaveCount(0);
+    expect(refreshCalls).toBe(2);
+    expect((secondCallBody as { token?: string } | undefined)?.token).toBe('minted-e2e-token');
+  });
+});

--- a/e2e/dataset-refresh-credentials.spec.ts
+++ b/e2e/dataset-refresh-credentials.spec.ts
@@ -187,7 +187,7 @@ test.describe('Refresh-door credential prompt on service_token_required', () => 
     await page.getByLabel('Password').fill('hunter2');
     await page.getByRole('button', { name: 'Sign in' }).click();
 
-    await expect(page.getByText('Signed in. The token below is ready to use.')).toBeVisible();
+    await expect(page.getByText('Signed in. The refresh will use this token.')).toBeVisible();
     await expect(page.getByLabel('Password')).toHaveValue('');
 
     await page.getByRole('button', { name: 'Start refresh' }).click();

--- a/e2e/dataset-refresh-credentials.spec.ts
+++ b/e2e/dataset-refresh-credentials.spec.ts
@@ -33,6 +33,15 @@ const BASE_URL = process.env.E2E_BASE_URL ?? 'http://localhost:8080';
 const RAW_SERVICE_TOKEN_MESSAGE =
   "This dataset's source needed a service token the last time it was imported or refreshed, and this request carries none. Send the token again in the request body's `token` field; tokens are request-only and are never stored between runs. If the source is public now, re-import it through the re-upload dialog without a token to clear the requirement.";
 
+// codex #1759 round 3: ArcgisCredentialBlock now schedules a clear for
+// `expires_at` minus a 30s safety margin (round 2), so a mocked `expires_at`
+// fixed to a literal date goes stale the moment that date is in the past --
+// the credential clears itself right after sign-in and the spec can never
+// observe "Signed in". Derived from the run's own clock instead, mirroring
+// the `FAR_FUTURE_EXPIRY` fix applied to the vitest suite for the same
+// reason.
+const FAR_FUTURE_EXPIRY = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+
 let seed: SearchSeed;
 let baseDataset: Record<string, unknown>;
 
@@ -139,7 +148,7 @@ test.describe('Refresh-door credential prompt on service_token_required', () => 
 
     await page.route(`**/api/services/arcgis/signin/`, (route: Route) =>
       route.fulfill({
-        json: { token: 'minted-e2e-token', expires_at: '2026-09-01T13:00:00Z' },
+        json: { token: 'minted-e2e-token', expires_at: FAR_FUTURE_EXPIRY },
       }),
     );
 

--- a/frontend/src/api/arcgis-signin.ts
+++ b/frontend/src/api/arcgis-signin.ts
@@ -1,13 +1,17 @@
 import { apiFetch } from './client';
 
 /**
- * Lane A1's contract (service-auth plan, section 3.2): `POST
- * /api/services/arcgis/signin/` (the sources router is mounted at prefix
- * `/services`; the trailing slash is canonical -- `redirect_slashes=False`
- * means the wrong one 404s rather than redirecting) exchanges a portal URL,
- * username and password for a short-lived ArcGIS token.
+ * Lane A1's endpoint (PR #1758, merged): `POST /api/services/arcgis/signin/`
+ * (the sources router is mounted at prefix `/services`; the trailing slash
+ * is canonical -- `redirect_slashes=False` means the wrong one 404s rather
+ * than redirecting) exchanges a portal URL, username and password for a
+ * short-lived ArcGIS token. Request and response shape confirmed against
+ * `backend/openapi.json`'s `ArcGISSignInRequest`/`ArcGISSignInResponse`
+ * schemas post-merge -- both are exactly `{portal_url, username, password}`
+ * in, `{token, expires_at}` out, unchanged from the pre-merge contract this
+ * client was built against.
  *
- * Lane A2 (PR #1757) already added an equivalent `arcgisSignin` to
+ * Lane A2 (PR #1757, not yet merged) adds an equivalent `arcgisSignin` to
  * `frontend/src/api/ingest.ts` with hand-typed request/response types in
  * `frontend/src/types/api.ts`. This file is a separate, local copy built
  * against the same contract rather than a pull of A2's branch -- collapse

--- a/frontend/src/api/arcgis-signin.ts
+++ b/frontend/src/api/arcgis-signin.ts
@@ -1,4 +1,5 @@
 import { apiFetch } from './client';
+import { ARCGIS_SIGNIN_TIMEOUT_MS } from './ingest';
 
 /**
  * Lane A1's endpoint (PR #1758, merged): `POST /api/services/arcgis/signin/`
@@ -11,12 +12,13 @@ import { apiFetch } from './client';
  * in, `{token, expires_at}` out, unchanged from the pre-merge contract this
  * client was built against.
  *
- * Lane A2 (PR #1757, not yet merged) adds an equivalent `arcgisSignin` to
+ * Lane A2 (PR #1757, merged) added an equivalent `arcgisSignin` to
  * `frontend/src/api/ingest.ts` with hand-typed request/response types in
- * `frontend/src/types/api.ts`. This file is a separate, local copy built
- * against the same contract rather than a pull of A2's branch -- collapse
- * onto A2's version in a follow-up once both lanes are on main (see the PR
- * body).
+ * `frontend/src/types/api.ts`. This file is still a separate, local copy of
+ * the request function itself -- collapsing the two into one shared client
+ * remains a follow-up -- but `ARCGIS_SIGNIN_TIMEOUT_MS` (below) is imported
+ * from there rather than redeclared, so the two calls can't drift onto two
+ * different numbers for the same backend bound.
  *
  * The password is sent once, in this request body, and nowhere else. This
  * function does not retry on failure; the caller must not add a retry loop
@@ -33,15 +35,6 @@ export interface ArcgisSignInResponse {
   token: string;
   expires_at: string;
 }
-
-// codex #1759 P2: apiFetch's default (REQUEST_TIMEOUT_MS, 30s in client.ts)
-// is shorter than this endpoint's own advertised worst case. arcgis_signin.py
-// bounds discovery at 20s and the mint POST at 25s
-// (_DISCOVERY_DEADLINE_SECONDS, _MINT_DEADLINE_SECONDS) and sums them to "the
-// 45 seconds the endpoint has always advertised" in its own comment -- a
-// slow but legitimate sign-in past 30s would otherwise abort client-side
-// with a spurious network error while the backend was still working.
-const ARCGIS_SIGNIN_TIMEOUT_MS = 45_000;
 
 export async function arcgisSignIn(
   request: ArcgisSignInRequest,

--- a/frontend/src/api/arcgis-signin.ts
+++ b/frontend/src/api/arcgis-signin.ts
@@ -1,0 +1,40 @@
+import { apiFetch } from './client';
+
+/**
+ * Lane A1's contract (service-auth plan, section 3.2): `POST
+ * /api/services/arcgis/signin/` (the sources router is mounted at prefix
+ * `/services`; the trailing slash is canonical -- `redirect_slashes=False`
+ * means the wrong one 404s rather than redirecting) exchanges a portal URL,
+ * username and password for a short-lived ArcGIS token.
+ *
+ * Lane A2 (PR #1757) already added an equivalent `arcgisSignin` to
+ * `frontend/src/api/ingest.ts` with hand-typed request/response types in
+ * `frontend/src/types/api.ts`. This file is a separate, local copy built
+ * against the same contract rather than a pull of A2's branch -- collapse
+ * onto A2's version in a follow-up once both lanes are on main (see the PR
+ * body).
+ *
+ * The password is sent once, in this request body, and nowhere else. This
+ * function does not retry on failure; the caller must not add a retry loop
+ * either, since ArcGIS locks an account after five failed sign-ins in
+ * fifteen minutes and a retry here would spend the user's own attempts.
+ */
+export interface ArcgisSignInRequest {
+  portal_url: string;
+  username: string;
+  password: string;
+}
+
+export interface ArcgisSignInResponse {
+  token: string;
+  expires_at: string;
+}
+
+export async function arcgisSignIn(
+  request: ArcgisSignInRequest,
+): Promise<ArcgisSignInResponse> {
+  return apiFetch<ArcgisSignInResponse>('/services/arcgis/signin/', {
+    method: 'POST',
+    body: JSON.stringify(request),
+  });
+}

--- a/frontend/src/api/arcgis-signin.ts
+++ b/frontend/src/api/arcgis-signin.ts
@@ -34,11 +34,21 @@ export interface ArcgisSignInResponse {
   expires_at: string;
 }
 
+// codex #1759 P2: apiFetch's default (REQUEST_TIMEOUT_MS, 30s in client.ts)
+// is shorter than this endpoint's own advertised worst case. arcgis_signin.py
+// bounds discovery at 20s and the mint POST at 25s
+// (_DISCOVERY_DEADLINE_SECONDS, _MINT_DEADLINE_SECONDS) and sums them to "the
+// 45 seconds the endpoint has always advertised" in its own comment -- a
+// slow but legitimate sign-in past 30s would otherwise abort client-side
+// with a spurious network error while the backend was still working.
+const ARCGIS_SIGNIN_TIMEOUT_MS = 45_000;
+
 export async function arcgisSignIn(
   request: ArcgisSignInRequest,
 ): Promise<ArcgisSignInResponse> {
   return apiFetch<ArcgisSignInResponse>('/services/arcgis/signin/', {
     method: 'POST',
     body: JSON.stringify(request),
+    timeoutMs: ARCGIS_SIGNIN_TIMEOUT_MS,
   });
 }

--- a/frontend/src/api/ingest.ts
+++ b/frontend/src/api/ingest.ts
@@ -284,7 +284,12 @@ export async function previewServiceLayer(
 // abort a valid slow sign-in in the browser while the backend keeps
 // processing, and counting, the attempt. 60s covers the 45s backend
 // bound with margin.
-const ARCGIS_SIGNIN_TIMEOUT_MS = 60_000;
+// codex #1759 post-#1757-merge dedupe: exported so lane A3's
+// independent arcgis-signin.ts client (frontend/src/components/dataset/
+// ArcgisCredentialBlock.tsx's refresh-door credential prompt) can share
+// this exact number rather than declare its own -- the backend bound
+// below is one fact and both callers need the same margin over it.
+export const ARCGIS_SIGNIN_TIMEOUT_MS = 60_000;
 
 // fix(service-auth wave, lane A2): mints a short-lived (60 min) ArcGIS token
 // from a username and password so the import wizard never has to hold that

--- a/frontend/src/components/dataset/ArcgisCredentialBlock.tsx
+++ b/frontend/src/components/dataset/ArcgisCredentialBlock.tsx
@@ -247,10 +247,9 @@ export const ArcgisCredentialBlock = forwardRef<ArcgisCredentialBlockHandle, Arc
       onTokenChange(result.token);
       expiresAtRef.current = result.expires_at;
       // `isSignedIn` is derived from `token` (now non-empty) and `method`
-      // (still 'signin' here) -- no separate flag to set.
-      // The password has finished its one job -- minting the token -- and
-      // must not linger in state any longer than that took.
-      setPassword('');
+      // (still 'signin' here) -- no separate flag to set. The password is
+      // cleared once, below, in the generation-matched `finally` -- not
+      // here, so success and failure clear it exactly the same way.
 
       // codex #1759 round 2: the refresh door only stages this credential
       // and queues the worker -- it does not use it synchronously -- so a
@@ -280,6 +279,23 @@ export const ArcgisCredentialBlock = forwardRef<ArcgisCredentialBlockHandle, Arc
       );
     } finally {
       if (generationRef.current === generation) {
+        // codex #1759 round 4 P2: cleared here, unconditionally on
+        // outcome, not only on a successful mint. A rejected sign-in or a
+        // timed-out request used to leave the password sitting in state
+        // and in the controlled input until the user edited it or closed
+        // the dialog -- contradicting this block's own request-scoped
+        // lifetime, and letting the same password be resent by a second
+        // click, which matters under ArcGIS's five-attempts lockout.
+        // Mirrors the sibling ServiceUrlForm.tsx flow's identical
+        // generation-gated clear in its own `finally`. Gated on
+        // generation, not unconditional, because an edit already made
+        // during this attempt (portal URL, username, or password) bumped
+        // the generation and may have put a NEW password in state for the
+        // next attempt -- clearing unconditionally here would wipe that
+        // out from under the user when this now-superseded request
+        // settles. The username is left alone; only the password is
+        // treated as too sensitive to linger.
+        setPassword('');
         setSignInPending(false);
       }
     }

--- a/frontend/src/components/dataset/ArcgisCredentialBlock.tsx
+++ b/frontend/src/components/dataset/ArcgisCredentialBlock.tsx
@@ -1,7 +1,6 @@
 import { forwardRef, useEffect, useImperativeHandle, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Loader2 } from 'lucide-react';
-import { ApiError } from '@/api/client';
 import { arcgisSignIn } from '@/api/arcgis-signin';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -40,86 +39,36 @@ export interface ArcgisCredentialBlockHandle {
   markExpired: () => void;
 }
 
-// codex round (post-#1758 merge): lane A1's merged endpoint
-// (arcgis_signin.py, signin_guard.py) ships four more caller-facing codes
-// than existed when this map was first written. Confirmed against
-// backend/openapi.json and the two source modules directly -- these are
-// the complete set of codes `_signin_refusal` can raise, plus `rate_limited`
-// (handled separately below by status, since it can also arrive with a
-// plain string `detail` from the route-level slowapi limiter rather than
-// this shape).
-const SIGNIN_ERROR_I18N_KEY: Record<string, string> = {
-  arcgis_signin_rejected: 'sourcePanel.refresh.credential.arcgis.errors.arcgisSigninRejected',
-  arcgis_sso_account: 'sourcePanel.refresh.credential.arcgis.errors.arcgisSsoAccount',
-  ssrf_refused: 'sourcePanel.refresh.credential.arcgis.errors.ssrfRefused',
-  network_error: 'sourcePanel.refresh.credential.arcgis.errors.networkError',
-  arcgis_portal_not_https: 'sourcePanel.refresh.credential.arcgis.errors.arcgisPortalNotHttps',
-  arcgis_portal_host_invalid: 'sourcePanel.refresh.credential.arcgis.errors.arcgisPortalHostInvalid',
-  arcgis_signin_in_progress: 'sourcePanel.refresh.credential.arcgis.errors.arcgisSigninInProgress',
-};
-
-// codex #1759 P2: `ArcGISSignInRequest` (backend/openapi.json) rejects
-// input -- a portal URL with no scheme, one carrying userinfo, an overlong
-// field -- before the route runs at all. FastAPI reports that as the
-// standard pydantic validation array, not one of this endpoint's own
-// `{code, message}` refusals, so `err.body` there is an array and
-// `(err.body as {code?}).code` above is always undefined. Falling through
-// to `networkError` for it is actively wrong: the request never reached
-// the network, and the real, actionable problem (which of portal_url,
-// username or password failed, and why) is silently dropped.
-//
-// `ApiError.message` is already the fix, not a new translation. `apiFetch`
-// (client.ts) always runs the raw `detail` through `translateApiErrorDetail`
-// (error-map.ts) before this component ever sees it, and that function's
-// array branch (`validationDescriptor`) turns a pydantic entry into a
-// translated, field-named sentence -- exactly the shape "anchored to the
-// field" calls for, since `ArcGISSignInRequest` only has those three
-// fields to name. Reused here rather than duplicated, for the same reason
-// the codes above use a lookup table instead of hand-writing each string
-// twice: one producer.
-function resolveSignInErrorMessage(err: unknown, t: (key: string) => string): string {
-  if (err instanceof ApiError) {
-    if (err.status === 429) {
-      return t('sourcePanel.refresh.credential.arcgis.errors.rateLimited');
-    }
-    const body = err.body;
-    if (body !== null && typeof body === 'object' && !Array.isArray(body)) {
-      const code = (body as { code?: string }).code;
-      if (code && SIGNIN_ERROR_I18N_KEY[code]) {
-        return t(SIGNIN_ERROR_I18N_KEY[code]);
-      }
-    }
-    if (body !== undefined) {
-      // A validation array, or any other detail shape this endpoint's own
-      // codes don't cover. Never the generic guess below: this has a body,
-      // so a response was received and it already carries better text.
-      return err.message;
-    }
-  }
-  // No detail payload reached the client at all: a genuine transport
-  // failure (offline, DNS, CORS, a timeout), the one case the generic copy
-  // is actually correct for.
-  return t('sourcePanel.refresh.credential.arcgis.errors.networkError');
-}
+// codex #1759, post-#1757-merge dedupe: this block used to carry its own
+// {code -> key} table and its own copy for all seven of this endpoint's
+// refusal shapes. Lane A2's error-map.ts (frontend/src/lib/error-map.ts)
+// now maps every one of them -- arcgis_signin_rejected, arcgis_sso_account,
+// ssrf_refused, arcgis_signin_in_progress, arcgis_portal_not_https and
+// arcgis_portal_host_invalid -- under `common:errors.*`, and deliberately
+// leaves a bare 429 unmapped there because the generic `errors.rateLimited`
+// fallback already covers it. apiFetch (client.ts) already runs this
+// error's `detail` through that exact map, via `translateApiErrorDetail`,
+// before this component ever sees it, so `ApiError.message` (an instance
+// of `Error`) IS that translated text -- reusing it, rather than a second
+// table repeating the same strings, is the fix: one string, one meaning,
+// so this flow and the import wizard's can never drift apart on wording.
+// This also covers a FastAPI/pydantic validation array for free (a
+// scheme-less portal URL, one carrying credentials, an overlong field --
+// `ArcGISSignInRequest` rejecting input before the route runs), since
+// `classifyApiError`'s array branch already turns that into a translated,
+// field-named message.
 
 /**
  * fix(#1755 item 4, plan 3.7/3.2): the refresh door's ArcGIS credential
- * prompt. Lane A2 (PR #1757, `feat/service-auth-a2-arcgis-signin-ui`) ships
- * the equivalent three-way method select for the import wizard
- * (`ServiceUrlForm.tsx`), plus an `arcgisSignin` client in
- * `api/ingest.ts` and hand-typed request/response types in `types/api.ts`.
- * Neither exists on main yet, so this is a minimal, independent copy built
- * against the same contract (plan 3.1's taxonomy, `POST
- * /api/services/arcgis/signin/`, confirmed against lane A1) rather than a
- * fork or an import of A2's branch. A2 also maps `arcgis_signin_rejected`,
- * `arcgis_sso_account`, `ssrf_refused` and `network_error` in
- * `lib/error-map.ts` against the `common` namespace (`translateApiErrorDetail`
- * always resolves there); this component keeps its own local copy under the
- * `dataset` namespace instead, resolved directly from the response code
- * rather than through that shared map, for the same reason -- no shared
- * component to import from yet. A2 and A3 should converge on one component
- * and one copy source in a follow-up once both are on main -- see the PR
- * body.
+ * prompt. Lane A2 (PR #1757, merged) ships the equivalent three-way method
+ * select for the import wizard (`ServiceUrlForm.tsx`), its own
+ * `arcgisSignin` client in `api/ingest.ts`, and hand-typed request/response
+ * types in `types/api.ts`. This component and that select are still two
+ * independent copies of the same taxonomy -- converging them into one
+ * shared component remains a follow-up -- but the error COPY is no longer
+ * duplicated: this component reuses A2's `common:errors.*` mapping in
+ * `lib/error-map.ts` via `ApiError.message` (see the comment above) rather
+ * than carrying a second `{code -> key}` table under its own namespace.
  *
  * None / Token / Sign in, per plan 3.1. Selecting a method discards the
  * other branch's fields rather than half-honouring them (plan 3.4's oneOf
@@ -305,7 +254,12 @@ export const ArcgisCredentialBlock = forwardRef<ArcgisCredentialBlockHandle, Arc
       if (generationRef.current !== generation) return;
       // No `isSignedIn` to clear: `token` was already cleared at the start
       // of this attempt, before the request, so it was already false.
-      setSignInError(resolveSignInErrorMessage(err, t));
+      // The error text rendered here is always this endpoint's own
+      // translated copy (see the module comment above) -- never the raw
+      // response body.
+      setSignInError(
+        err instanceof Error ? err.message : t('common:errors.couldNotReachService'),
+      );
     } finally {
       if (generationRef.current === generation) {
         setSignInPending(false);

--- a/frontend/src/components/dataset/ArcgisCredentialBlock.tsx
+++ b/frontend/src/components/dataset/ArcgisCredentialBlock.tsx
@@ -54,10 +54,26 @@ export function ArcgisCredentialBlock({ token, onTokenChange, disabled }: Arcgis
   const [signInPending, setSignInPending] = useState(false);
   const [signInError, setSignInError] = useState<string | null>(null);
   const [signedIn, setSignedIn] = useState(false);
-  // Bookkeeping only -- nothing renders the expiry, so a ref avoids an
-  // extra re-render on every mint/clear. Still explicitly cleared
-  // alongside `signedIn` and the token itself (codex #1759 round 1, P2).
+  // Bookkeeping only for the raw value; a ref avoids an extra re-render
+  // on every mint/clear. Still explicitly cleared alongside `signedIn` and
+  // the token itself (codex #1759 round 1, P2).
   const expiresAtRef = useRef<string | null>(null);
+  // codex #1759 round 2: distinct from `signInError` -- an expiry is not a
+  // rejected sign-in, it is a credential that WAS valid going stale while
+  // the dialog sat open. Drives the "Token expired" copy in place of
+  // "Signed in".
+  const [tokenExpired, setTokenExpired] = useState(false);
+  const expiryTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const clearExpiryTimer = () => {
+    if (expiryTimerRef.current !== null) {
+      clearTimeout(expiryTimerRef.current);
+      expiryTimerRef.current = null;
+    }
+  };
+
+  const isPastExpiry = () =>
+    expiresAtRef.current !== null && Date.now() >= new Date(expiresAtRef.current).getTime();
   // fix(codex #1759 round 1, P1/P2): a generation counter, not just a
   // boolean, so a stale attempt's response is dropped even when a NEWER
   // attempt is already in flight (not only on unmount). Bumped on unmount
@@ -71,8 +87,26 @@ export function ArcgisCredentialBlock({ token, onTokenChange, disabled }: Arcgis
   useEffect(() => {
     return () => {
       generationRef.current += 1;
+      clearExpiryTimer();
     };
   }, []);
+
+  // codex #1759 round 2, belt: the scheduled timer above is the primary
+  // mechanism, but re-verify on every render too (method switch, a field
+  // edit, the `disabled` prop flipping when "Start refresh" is clicked) in
+  // case the timer fires late -- background-tab throttling can delay a
+  // `setTimeout` well past its nominal delay. Deliberately has no
+  // dependency array so it runs after EVERY render, not only when
+  // `signedIn` changes -- that is the whole point of a render-triggered
+  // recheck. Self-heals by running the exact same clear the timer runs;
+  // does nothing once `signedIn` is already false, so this cannot loop.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  useEffect(() => {
+    if (signedIn && isPastExpiry()) {
+      clearMintedCredential();
+      setTokenExpired(true);
+    }
+  });
 
   // fix(codex #1759 round 1, P2): a minted token describes the fields it
   // was minted from. Once any of those fields changes, or a new attempt
@@ -82,6 +116,7 @@ export function ArcgisCredentialBlock({ token, onTokenChange, disabled }: Arcgis
   const clearMintedCredential = () => {
     setSignedIn(false);
     expiresAtRef.current = null;
+    clearExpiryTimer();
     onTokenChange('');
   };
 
@@ -89,6 +124,7 @@ export function ArcgisCredentialBlock({ token, onTokenChange, disabled }: Arcgis
     const next = value as ArcgisAuthMethod;
     setMethod(next);
     setSignInError(null);
+    setTokenExpired(false);
     clearMintedCredential();
     if (next !== 'signin') {
       setPortalUrl('');
@@ -99,16 +135,19 @@ export function ArcgisCredentialBlock({ token, onTokenChange, disabled }: Arcgis
 
   const handlePortalUrlChange = (value: string) => {
     setPortalUrl(value);
+    setTokenExpired(false);
     clearMintedCredential();
   };
 
   const handleUsernameChange = (value: string) => {
     setUsername(value);
+    setTokenExpired(false);
     clearMintedCredential();
   };
 
   const handlePasswordChange = (value: string) => {
     setPassword(value);
+    setTokenExpired(false);
     clearMintedCredential();
   };
 
@@ -121,6 +160,7 @@ export function ArcgisCredentialBlock({ token, onTokenChange, disabled }: Arcgis
     // submit (fix P2).
     const generation = (generationRef.current += 1);
     setSignInError(null);
+    setTokenExpired(false);
     clearMintedCredential();
     setSignInPending(true);
     try {
@@ -144,6 +184,24 @@ export function ArcgisCredentialBlock({ token, onTokenChange, disabled }: Arcgis
       // The password has finished its one job -- minting the token -- and
       // must not linger in state any longer than that took.
       setPassword('');
+
+      // codex #1759 round 2: the refresh door only stages this credential
+      // and queues the worker -- it does not use it synchronously -- so a
+      // dialog left open past the token's lifetime would otherwise submit
+      // one already-dead on the wire, and the failure would only surface
+      // later in the background. Schedule the clear for a safety margin
+      // BEFORE the real expiry, not at it, so a slow clock or a slightly
+      // stale local view of `expires_at` still clears before the origin
+      // itself would refuse the token.
+      clearExpiryTimer();
+      const expiresAtMs = new Date(result.expires_at).getTime();
+      const EXPIRY_SAFETY_MARGIN_MS = 30_000;
+      const delay = Math.max(0, expiresAtMs - Date.now() - EXPIRY_SAFETY_MARGIN_MS);
+      expiryTimerRef.current = setTimeout(() => {
+        if (generationRef.current !== generation) return;
+        clearMintedCredential();
+        setTokenExpired(true);
+      }, delay);
     } catch (err) {
       if (generationRef.current !== generation) return;
       setSignedIn(false);
@@ -271,6 +329,11 @@ export function ArcgisCredentialBlock({ token, onTokenChange, disabled }: Arcgis
           {signedIn && !signInError && (
             <p className="text-xs text-muted-foreground">
               {t('sourcePanel.refresh.credential.arcgis.signedIn')}
+            </p>
+          )}
+          {tokenExpired && !signInError && (
+            <p className="text-sm text-destructive">
+              {t('sourcePanel.refresh.credential.arcgis.tokenExpired')}
             </p>
           )}
           {signInError && <p className="text-sm text-destructive">{signInError}</p>}

--- a/frontend/src/components/dataset/ArcgisCredentialBlock.tsx
+++ b/frontend/src/components/dataset/ArcgisCredentialBlock.tsx
@@ -53,10 +53,9 @@ export function ArcgisCredentialBlock({ token, onTokenChange, disabled }: Arcgis
   const [password, setPassword] = useState('');
   const [signInPending, setSignInPending] = useState(false);
   const [signInError, setSignInError] = useState<string | null>(null);
-  const [signedIn, setSignedIn] = useState(false);
   // Bookkeeping only for the raw value; a ref avoids an extra re-render
-  // on every mint/clear. Still explicitly cleared alongside `signedIn` and
-  // the token itself (codex #1759 round 1, P2).
+  // on every mint/clear. Still explicitly cleared alongside the token
+  // itself (codex #1759 round 1, P2).
   const expiresAtRef = useRef<string | null>(null);
   // codex #1759 round 2: distinct from `signInError` -- an expiry is not a
   // rejected sign-in, it is a credential that WAS valid going stale while
@@ -74,6 +73,16 @@ export function ArcgisCredentialBlock({ token, onTokenChange, disabled }: Arcgis
 
   const isPastExpiry = () =>
     expiresAtRef.current !== null && Date.now() >= new Date(expiresAtRef.current).getTime();
+
+  // codex #1759 round 3, P2: derived from the parent's `token` prop rather
+  // than tracked in its own state. "Start refresh" (SourceRefreshAction)
+  // clears its `token` state before awaiting the refresh request, win or
+  // lose -- a separate `signedIn` boolean would go stale the moment that
+  // happens (a rejected refresh left this block still claiming "Signed in"
+  // while a retry silently submitted nothing). Deriving it means there is
+  // nothing here that CAN desynchronise from the token: whenever `token`
+  // clears, for any reason, this becomes false in the same render.
+  const isSignedIn = method === 'signin' && token.trim() !== '';
   // fix(codex #1759 round 1, P1/P2): a generation counter, not just a
   // boolean, so a stale attempt's response is dropped even when a NEWER
   // attempt is already in flight (not only on unmount). Bumped on unmount
@@ -97,12 +106,12 @@ export function ArcgisCredentialBlock({ token, onTokenChange, disabled }: Arcgis
   // case the timer fires late -- background-tab throttling can delay a
   // `setTimeout` well past its nominal delay. Deliberately has no
   // dependency array so it runs after EVERY render, not only when
-  // `signedIn` changes -- that is the whole point of a render-triggered
+  // `isSignedIn` changes -- that is the whole point of a render-triggered
   // recheck. Self-heals by running the exact same clear the timer runs;
-  // does nothing once `signedIn` is already false, so this cannot loop.
+  // does nothing once `isSignedIn` is already false, so this cannot loop.
   // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => {
-    if (signedIn && isPastExpiry()) {
+    if (isSignedIn && isPastExpiry()) {
       clearMintedCredential();
       setTokenExpired(true);
     }
@@ -114,7 +123,6 @@ export function ArcgisCredentialBlock({ token, onTokenChange, disabled }: Arcgis
   // would otherwise submit -- clear it immediately rather than leaving it
   // reachable until the next sign-in resolves (or fails).
   const clearMintedCredential = () => {
-    setSignedIn(false);
     expiresAtRef.current = null;
     clearExpiryTimer();
     onTokenChange('');
@@ -180,7 +188,8 @@ export function ArcgisCredentialBlock({ token, onTokenChange, disabled }: Arcgis
       if (generationRef.current !== generation) return;
       onTokenChange(result.token);
       expiresAtRef.current = result.expires_at;
-      setSignedIn(true);
+      // `isSignedIn` is derived from `token` (now non-empty) and `method`
+      // (still 'signin' here) -- no separate flag to set.
       // The password has finished its one job -- minting the token -- and
       // must not linger in state any longer than that took.
       setPassword('');
@@ -204,7 +213,8 @@ export function ArcgisCredentialBlock({ token, onTokenChange, disabled }: Arcgis
       }, delay);
     } catch (err) {
       if (generationRef.current !== generation) return;
-      setSignedIn(false);
+      // No `isSignedIn` to clear: `token` was already cleared at the start
+      // of this attempt, before the request, so it was already false.
       let key = 'sourcePanel.refresh.credential.arcgis.errors.networkError';
       if (err instanceof ApiError) {
         if (err.status === 429) {
@@ -326,7 +336,7 @@ export function ArcgisCredentialBlock({ token, onTokenChange, disabled }: Arcgis
             {signInPending && <Loader2 className="me-2 h-4 w-4 animate-spin" />}
             {t('sourcePanel.refresh.credential.arcgis.signInButton')}
           </Button>
-          {signedIn && !signInError && (
+          {isSignedIn && !signInError && (
             <p className="text-xs text-muted-foreground">
               {t('sourcePanel.refresh.credential.arcgis.signedIn')}
             </p>

--- a/frontend/src/components/dataset/ArcgisCredentialBlock.tsx
+++ b/frontend/src/components/dataset/ArcgisCredentialBlock.tsx
@@ -14,6 +14,18 @@ interface ArcgisCredentialBlockProps {
   disabled?: boolean;
 }
 
+// codex #1759 round 3 P2: the ONE margin shared by the scheduled timer
+// (handleSignIn, below) and this synchronous check -- mirrors lane A2's
+// identical fix in ServiceUrlForm.tsx (EXPIRY_MARGIN_MS, codex review
+// #1757 round 4 P2) for the same bug shape. The timer used to retire a
+// token 30 seconds before its real expiry while this check compared
+// against the raw `expires_at`, so a backgrounded tab resuming inside
+// that last 30 seconds passed the check and `handleConfirm` submitted a
+// credential this component had already decided to retire -- refresh
+// only queues the worker, so a token that thin can expire before the
+// worker ever uses it.
+const EXPIRY_SAFETY_MARGIN_MS = 30_000;
+
 // codex #1759 P2: a pure function, not a closure over `expiresAtRef`, so the
 // exact same check the render-triggered belt effect below uses is also
 // callable synchronously from SourceRefreshAction's handleConfirm (via the
@@ -22,9 +34,10 @@ interface ArcgisCredentialBlockProps {
 // expiry timer and this component's own re-renders, so the belt effect
 // never gets a chance to run before the user comes back and clicks "Start
 // refresh" -- `handleConfirm` captures `token` synchronously in the same
-// tick, ahead of any effect.
+// tick, ahead of any effect. Margined by EXPIRY_SAFETY_MARGIN_MS (above)
+// so this agrees with the timer on when a token counts as retired.
 export function isExpired(expiresAt: string | null, now: number): boolean {
-  return expiresAt !== null && now >= new Date(expiresAt).getTime();
+  return expiresAt !== null && now >= new Date(expiresAt).getTime() - EXPIRY_SAFETY_MARGIN_MS;
 }
 
 export interface ArcgisCredentialBlockHandle {
@@ -213,7 +226,13 @@ export const ArcgisCredentialBlock = forwardRef<ArcgisCredentialBlockHandle, Arc
     try {
       const result = await arcgisSignIn({
         portal_url: portalUrl.trim(),
-        username,
+        // codex #1759 round 3 P2: ArcGISSignInRequest does not strip
+        // whitespace and PortalSignIn.mint forwards the value unchanged,
+        // so a pasted username with leading/trailing whitespace would
+        // burn one of the ArcGIS account's limited sign-in attempts on a
+        // value that was never going to match. Mirrors the import
+        // wizard's identical `username.trim()` (ServiceUrlForm.tsx).
+        username: username.trim(),
         password,
       });
       // fix(codex #1759 round 1, P1): dropped when this attempt is stale --
@@ -243,7 +262,6 @@ export const ArcgisCredentialBlock = forwardRef<ArcgisCredentialBlockHandle, Arc
       // itself would refuse the token.
       clearExpiryTimer();
       const expiresAtMs = new Date(result.expires_at).getTime();
-      const EXPIRY_SAFETY_MARGIN_MS = 30_000;
       const delay = Math.max(0, expiresAtMs - Date.now() - EXPIRY_SAFETY_MARGIN_MS);
       expiryTimerRef.current = setTimeout(() => {
         if (generationRef.current !== generation) return;
@@ -268,7 +286,9 @@ export const ArcgisCredentialBlock = forwardRef<ArcgisCredentialBlockHandle, Arc
   };
 
   const fieldsDisabled = disabled || signInPending;
-  const canSignIn = !fieldsDisabled && portalUrl.trim() !== '' && username !== '' && password !== '';
+  // A whitespace-only username must never submit either -- it trims to
+  // '' and would otherwise still pass a bare `!== ''` check.
+  const canSignIn = !fieldsDisabled && portalUrl.trim() !== '' && username.trim() !== '' && password !== '';
 
   return (
     <div className="space-y-3 rounded-md border border-border p-3">

--- a/frontend/src/components/dataset/ArcgisCredentialBlock.tsx
+++ b/frontend/src/components/dataset/ArcgisCredentialBlock.tsx
@@ -15,11 +15,22 @@ interface ArcgisCredentialBlockProps {
   disabled?: boolean;
 }
 
+// codex round (post-#1758 merge): lane A1's merged endpoint
+// (arcgis_signin.py, signin_guard.py) ships four more caller-facing codes
+// than existed when this map was first written. Confirmed against
+// backend/openapi.json and the two source modules directly -- these are
+// the complete set of codes `_signin_refusal` can raise, plus `rate_limited`
+// (handled separately below by status, since it can also arrive with a
+// plain string `detail` from the route-level slowapi limiter rather than
+// this shape).
 const SIGNIN_ERROR_I18N_KEY: Record<string, string> = {
   arcgis_signin_rejected: 'sourcePanel.refresh.credential.arcgis.errors.arcgisSigninRejected',
   arcgis_sso_account: 'sourcePanel.refresh.credential.arcgis.errors.arcgisSsoAccount',
   ssrf_refused: 'sourcePanel.refresh.credential.arcgis.errors.ssrfRefused',
   network_error: 'sourcePanel.refresh.credential.arcgis.errors.networkError',
+  arcgis_portal_not_https: 'sourcePanel.refresh.credential.arcgis.errors.arcgisPortalNotHttps',
+  arcgis_portal_host_invalid: 'sourcePanel.refresh.credential.arcgis.errors.arcgisPortalHostInvalid',
+  arcgis_signin_in_progress: 'sourcePanel.refresh.credential.arcgis.errors.arcgisSigninInProgress',
 };
 
 /**

--- a/frontend/src/components/dataset/ArcgisCredentialBlock.tsx
+++ b/frontend/src/components/dataset/ArcgisCredentialBlock.tsx
@@ -1,0 +1,217 @@
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Loader2 } from 'lucide-react';
+import { ApiError } from '@/api/client';
+import { arcgisSignIn } from '@/api/arcgis-signin';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+
+type ArcgisAuthMethod = 'none' | 'token' | 'signin';
+
+interface ArcgisCredentialBlockProps {
+  token: string;
+  onTokenChange: (token: string) => void;
+  disabled?: boolean;
+}
+
+const SIGNIN_ERROR_I18N_KEY: Record<string, string> = {
+  arcgis_signin_rejected: 'sourcePanel.refresh.credential.arcgis.errors.arcgisSigninRejected',
+  arcgis_sso_account: 'sourcePanel.refresh.credential.arcgis.errors.arcgisSsoAccount',
+  ssrf_refused: 'sourcePanel.refresh.credential.arcgis.errors.ssrfRefused',
+  network_error: 'sourcePanel.refresh.credential.arcgis.errors.networkError',
+};
+
+/**
+ * fix(#1755 item 4, plan 3.7/3.2): the refresh door's ArcGIS credential
+ * prompt. Lane A2 (PR #1757, `feat/service-auth-a2-arcgis-signin-ui`) ships
+ * the equivalent three-way method select for the import wizard
+ * (`ServiceUrlForm.tsx`), plus an `arcgisSignin` client in
+ * `api/ingest.ts` and hand-typed request/response types in `types/api.ts`.
+ * Neither exists on main yet, so this is a minimal, independent copy built
+ * against the same contract (plan 3.1's taxonomy, `POST
+ * /api/services/arcgis/signin/`, confirmed against lane A1) rather than a
+ * fork or an import of A2's branch. A2 also maps `arcgis_signin_rejected`,
+ * `arcgis_sso_account`, `ssrf_refused` and `network_error` in
+ * `lib/error-map.ts` against the `common` namespace (`translateApiErrorDetail`
+ * always resolves there); this component keeps its own local copy under the
+ * `dataset` namespace instead, resolved directly from the response code
+ * rather than through that shared map, for the same reason -- no shared
+ * component to import from yet. A2 and A3 should converge on one component
+ * and one copy source in a follow-up once both are on main -- see the PR
+ * body.
+ *
+ * None / Token / Sign in, per plan 3.1. Selecting a method discards the
+ * other branch's fields rather than half-honouring them (plan 3.4's oneOf
+ * rule, applied here to component state rather than a request body).
+ */
+export function ArcgisCredentialBlock({ token, onTokenChange, disabled }: ArcgisCredentialBlockProps) {
+  const { t } = useTranslation('dataset');
+  const [method, setMethod] = useState<ArcgisAuthMethod>('none');
+  const [portalUrl, setPortalUrl] = useState('');
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [signInPending, setSignInPending] = useState(false);
+  const [signInError, setSignInError] = useState<string | null>(null);
+  const [signedIn, setSignedIn] = useState(false);
+
+  const handleMethodChange = (value: string) => {
+    const next = value as ArcgisAuthMethod;
+    setMethod(next);
+    setSignInError(null);
+    setSignedIn(false);
+    onTokenChange('');
+    if (next !== 'signin') {
+      setPortalUrl('');
+      setUsername('');
+      setPassword('');
+    }
+  };
+
+  const handleSignIn = async () => {
+    if (signInPending) return;
+    setSignInError(null);
+    setSignInPending(true);
+    try {
+      const result = await arcgisSignIn({
+        portal_url: portalUrl.trim(),
+        username,
+        password,
+      });
+      onTokenChange(result.token);
+      setSignedIn(true);
+      // The password has finished its one job -- minting the token -- and
+      // must not linger in state any longer than that took.
+      setPassword('');
+    } catch (err) {
+      setSignedIn(false);
+      let key = 'sourcePanel.refresh.credential.arcgis.errors.networkError';
+      if (err instanceof ApiError) {
+        if (err.status === 429) {
+          key = 'sourcePanel.refresh.credential.arcgis.errors.rateLimited';
+        } else {
+          const body = err.body as { code?: string } | undefined;
+          key = (body?.code && SIGNIN_ERROR_I18N_KEY[body.code]) || key;
+        }
+      }
+      // The error text rendered here is always this component's own copy,
+      // keyed off a stable code -- never the raw response body.
+      setSignInError(t(key));
+    } finally {
+      setSignInPending(false);
+    }
+  };
+
+  const fieldsDisabled = disabled || signInPending;
+  const canSignIn = !fieldsDisabled && portalUrl.trim() !== '' && username !== '' && password !== '';
+
+  return (
+    <div className="space-y-3 rounded-md border border-border p-3">
+      <div className="space-y-2">
+        <Label htmlFor="arcgis-credential-method">
+          {t('sourcePanel.refresh.credential.arcgis.methodLabel')}
+        </Label>
+        <select
+          id="arcgis-credential-method"
+          value={method}
+          onChange={(event) => handleMethodChange(event.target.value)}
+          disabled={fieldsDisabled}
+          className="w-full rounded-md border border-border bg-surface-0 px-3 py-2 text-sm disabled:opacity-60"
+        >
+          <option value="none">{t('sourcePanel.refresh.credential.arcgis.methodNone')}</option>
+          <option value="token">{t('sourcePanel.refresh.credential.arcgis.methodToken')}</option>
+          <option value="signin">{t('sourcePanel.refresh.credential.arcgis.methodSignIn')}</option>
+        </select>
+      </div>
+
+      {method === 'token' && (
+        <div className="space-y-2">
+          <Label htmlFor="arcgis-credential-token">
+            {t('sourcePanel.refresh.credential.arcgis.tokenLabel')}
+          </Label>
+          <Input
+            id="arcgis-credential-token"
+            type="password"
+            autoComplete="new-password"
+            data-1p-ignore
+            data-lpignore="true"
+            data-bwignore
+            value={token}
+            onChange={(event) => onTokenChange(event.target.value)}
+            placeholder={t('sourcePanel.refresh.credential.arcgis.tokenPlaceholder')}
+            disabled={fieldsDisabled}
+          />
+        </div>
+      )}
+
+      {method === 'signin' && (
+        <div className="space-y-3">
+          <div className="space-y-2">
+            <Label htmlFor="arcgis-credential-portal-url">
+              {t('sourcePanel.refresh.credential.arcgis.portalUrlLabel')}
+            </Label>
+            <Input
+              id="arcgis-credential-portal-url"
+              type="text"
+              autoComplete="url"
+              value={portalUrl}
+              onChange={(event) => setPortalUrl(event.target.value)}
+              placeholder={t('sourcePanel.refresh.credential.arcgis.portalUrlPlaceholder')}
+              disabled={fieldsDisabled}
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="arcgis-credential-username">
+              {t('sourcePanel.refresh.credential.arcgis.usernameLabel')}
+            </Label>
+            <Input
+              id="arcgis-credential-username"
+              type="text"
+              autoComplete="username"
+              value={username}
+              onChange={(event) => setUsername(event.target.value)}
+              disabled={fieldsDisabled}
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="arcgis-credential-password">
+              {t('sourcePanel.refresh.credential.arcgis.passwordLabel')}
+            </Label>
+            <Input
+              id="arcgis-credential-password"
+              type="password"
+              // fix(#1755 item 4, plan 3.2): a genuine third-party login, so a
+              // password manager offering to save it is not absurd -- but it
+              // would be saved against the GeoLens origin, which is
+              // misleading. Opt out the same way the request-only service
+              // token field does (#1750).
+              autoComplete="new-password"
+              data-1p-ignore
+              data-lpignore="true"
+              data-bwignore
+              value={password}
+              onChange={(event) => setPassword(event.target.value)}
+              disabled={fieldsDisabled}
+            />
+          </div>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={() => void handleSignIn()}
+            disabled={!canSignIn}
+          >
+            {signInPending && <Loader2 className="me-2 h-4 w-4 animate-spin" />}
+            {t('sourcePanel.refresh.credential.arcgis.signInButton')}
+          </Button>
+          {signedIn && !signInError && (
+            <p className="text-xs text-muted-foreground">
+              {t('sourcePanel.refresh.credential.arcgis.signedIn')}
+            </p>
+          )}
+          {signInError && <p className="text-sm text-destructive">{signInError}</p>}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/dataset/ArcgisCredentialBlock.tsx
+++ b/frontend/src/components/dataset/ArcgisCredentialBlock.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { forwardRef, useEffect, useImperativeHandle, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Loader2 } from 'lucide-react';
 import { ApiError } from '@/api/client';
@@ -13,6 +13,31 @@ interface ArcgisCredentialBlockProps {
   token: string;
   onTokenChange: (token: string) => void;
   disabled?: boolean;
+}
+
+// codex #1759 P2: a pure function, not a closure over `expiresAtRef`, so the
+// exact same check the render-triggered belt effect below uses is also
+// callable synchronously from SourceRefreshAction's handleConfirm (via the
+// imperative handle below) BEFORE it reads and submits `token`. That gap is
+// real: a background tab or a system sleep can suspend both the scheduled
+// expiry timer and this component's own re-renders, so the belt effect
+// never gets a chance to run before the user comes back and clicks "Start
+// refresh" -- `handleConfirm` captures `token` synchronously in the same
+// tick, ahead of any effect.
+export function isExpired(expiresAt: string | null, now: number): boolean {
+  return expiresAt !== null && now >= new Date(expiresAt).getTime();
+}
+
+export interface ArcgisCredentialBlockHandle {
+  /** The expiry the currently minted token carries, or null. Read this and
+   * call `isExpired` rather than trusting `token` alone to be current. */
+  getExpiresAt: () => string | null;
+  /** Transitions this block to its expired display state (clears the
+   * credential, swaps "Signed in" for "Token expired") without waiting for
+   * the timer or the belt effect. The caller is expected to have already
+   * established, via `isExpired(getExpiresAt(), Date.now())`, that this is
+   * warranted -- calling it unconditionally would clear a live token. */
+  markExpired: () => void;
 }
 
 // codex round (post-#1758 merge): lane A1's merged endpoint
@@ -32,6 +57,50 @@ const SIGNIN_ERROR_I18N_KEY: Record<string, string> = {
   arcgis_portal_host_invalid: 'sourcePanel.refresh.credential.arcgis.errors.arcgisPortalHostInvalid',
   arcgis_signin_in_progress: 'sourcePanel.refresh.credential.arcgis.errors.arcgisSigninInProgress',
 };
+
+// codex #1759 P2: `ArcGISSignInRequest` (backend/openapi.json) rejects
+// input -- a portal URL with no scheme, one carrying userinfo, an overlong
+// field -- before the route runs at all. FastAPI reports that as the
+// standard pydantic validation array, not one of this endpoint's own
+// `{code, message}` refusals, so `err.body` there is an array and
+// `(err.body as {code?}).code` above is always undefined. Falling through
+// to `networkError` for it is actively wrong: the request never reached
+// the network, and the real, actionable problem (which of portal_url,
+// username or password failed, and why) is silently dropped.
+//
+// `ApiError.message` is already the fix, not a new translation. `apiFetch`
+// (client.ts) always runs the raw `detail` through `translateApiErrorDetail`
+// (error-map.ts) before this component ever sees it, and that function's
+// array branch (`validationDescriptor`) turns a pydantic entry into a
+// translated, field-named sentence -- exactly the shape "anchored to the
+// field" calls for, since `ArcGISSignInRequest` only has those three
+// fields to name. Reused here rather than duplicated, for the same reason
+// the codes above use a lookup table instead of hand-writing each string
+// twice: one producer.
+function resolveSignInErrorMessage(err: unknown, t: (key: string) => string): string {
+  if (err instanceof ApiError) {
+    if (err.status === 429) {
+      return t('sourcePanel.refresh.credential.arcgis.errors.rateLimited');
+    }
+    const body = err.body;
+    if (body !== null && typeof body === 'object' && !Array.isArray(body)) {
+      const code = (body as { code?: string }).code;
+      if (code && SIGNIN_ERROR_I18N_KEY[code]) {
+        return t(SIGNIN_ERROR_I18N_KEY[code]);
+      }
+    }
+    if (body !== undefined) {
+      // A validation array, or any other detail shape this endpoint's own
+      // codes don't cover. Never the generic guess below: this has a body,
+      // so a response was received and it already carries better text.
+      return err.message;
+    }
+  }
+  // No detail payload reached the client at all: a genuine transport
+  // failure (offline, DNS, CORS, a timeout), the one case the generic copy
+  // is actually correct for.
+  return t('sourcePanel.refresh.credential.arcgis.errors.networkError');
+}
 
 /**
  * fix(#1755 item 4, plan 3.7/3.2): the refresh door's ArcGIS credential
@@ -56,7 +125,8 @@ const SIGNIN_ERROR_I18N_KEY: Record<string, string> = {
  * other branch's fields rather than half-honouring them (plan 3.4's oneOf
  * rule, applied here to component state rather than a request body).
  */
-export function ArcgisCredentialBlock({ token, onTokenChange, disabled }: ArcgisCredentialBlockProps) {
+export const ArcgisCredentialBlock = forwardRef<ArcgisCredentialBlockHandle, ArcgisCredentialBlockProps>(
+  function ArcgisCredentialBlock({ token, onTokenChange, disabled }, ref) {
   const { t } = useTranslation('dataset');
   const [method, setMethod] = useState<ArcgisAuthMethod>('none');
   const [portalUrl, setPortalUrl] = useState('');
@@ -81,9 +151,6 @@ export function ArcgisCredentialBlock({ token, onTokenChange, disabled }: Arcgis
       expiryTimerRef.current = null;
     }
   };
-
-  const isPastExpiry = () =>
-    expiresAtRef.current !== null && Date.now() >= new Date(expiresAtRef.current).getTime();
 
   // codex #1759 round 3, P2: derived from the parent's `token` prop rather
   // than tracked in its own state. "Start refresh" (SourceRefreshAction)
@@ -122,11 +189,23 @@ export function ArcgisCredentialBlock({ token, onTokenChange, disabled }: Arcgis
   // does nothing once `isSignedIn` is already false, so this cannot loop.
   // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => {
-    if (isSignedIn && isPastExpiry()) {
+    if (isSignedIn && isExpired(expiresAtRef.current, Date.now())) {
       clearMintedCredential();
       setTokenExpired(true);
     }
   });
+
+  // codex #1759 P2: exposes the synchronous pre-submit check documented on
+  // `ArcgisCredentialBlockHandle` above. `markExpired` reuses the exact
+  // clear-and-flip the timer and the belt effect both already perform, so
+  // there is still only one place that transition happens.
+  useImperativeHandle(ref, () => ({
+    getExpiresAt: () => expiresAtRef.current,
+    markExpired: () => {
+      clearMintedCredential();
+      setTokenExpired(true);
+    },
+  }));
 
   // fix(codex #1759 round 1, P2): a minted token describes the fields it
   // was minted from. Once any of those fields changes, or a new attempt
@@ -226,18 +305,7 @@ export function ArcgisCredentialBlock({ token, onTokenChange, disabled }: Arcgis
       if (generationRef.current !== generation) return;
       // No `isSignedIn` to clear: `token` was already cleared at the start
       // of this attempt, before the request, so it was already false.
-      let key = 'sourcePanel.refresh.credential.arcgis.errors.networkError';
-      if (err instanceof ApiError) {
-        if (err.status === 429) {
-          key = 'sourcePanel.refresh.credential.arcgis.errors.rateLimited';
-        } else {
-          const body = err.body as { code?: string } | undefined;
-          key = (body?.code && SIGNIN_ERROR_I18N_KEY[body.code]) || key;
-        }
-      }
-      // The error text rendered here is always this component's own copy,
-      // keyed off a stable code -- never the raw response body.
-      setSignInError(t(key));
+      setSignInError(resolveSignInErrorMessage(err, t));
     } finally {
       if (generationRef.current === generation) {
         setSignInPending(false);
@@ -362,4 +430,5 @@ export function ArcgisCredentialBlock({ token, onTokenChange, disabled }: Arcgis
       )}
     </div>
   );
-}
+  },
+);

--- a/frontend/src/components/dataset/ArcgisCredentialBlock.tsx
+++ b/frontend/src/components/dataset/ArcgisCredentialBlock.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Loader2 } from 'lucide-react';
 import { ApiError } from '@/api/client';
@@ -54,13 +54,42 @@ export function ArcgisCredentialBlock({ token, onTokenChange, disabled }: Arcgis
   const [signInPending, setSignInPending] = useState(false);
   const [signInError, setSignInError] = useState<string | null>(null);
   const [signedIn, setSignedIn] = useState(false);
+  // Bookkeeping only -- nothing renders the expiry, so a ref avoids an
+  // extra re-render on every mint/clear. Still explicitly cleared
+  // alongside `signedIn` and the token itself (codex #1759 round 1, P2).
+  const expiresAtRef = useRef<string | null>(null);
+  // fix(codex #1759 round 1, P1/P2): a generation counter, not just a
+  // boolean, so a stale attempt's response is dropped even when a NEWER
+  // attempt is already in flight (not only on unmount). Bumped on unmount
+  // (the dialog closing unmounts this block -- SourceRefreshAction renders
+  // it conditionally on `serviceTokenRequired`, which handleOpenChange
+  // resets on close) and at the start of every sign-in attempt. Mirrors
+  // the generation-counter pattern lane A2 applies in ServiceUrlForm.tsx,
+  // so the two blocks converge later.
+  const generationRef = useRef(0);
+
+  useEffect(() => {
+    return () => {
+      generationRef.current += 1;
+    };
+  }, []);
+
+  // fix(codex #1759 round 1, P2): a minted token describes the fields it
+  // was minted from. Once any of those fields changes, or a new attempt
+  // starts, that token no longer describes the account "Start refresh"
+  // would otherwise submit -- clear it immediately rather than leaving it
+  // reachable until the next sign-in resolves (or fails).
+  const clearMintedCredential = () => {
+    setSignedIn(false);
+    expiresAtRef.current = null;
+    onTokenChange('');
+  };
 
   const handleMethodChange = (value: string) => {
     const next = value as ArcgisAuthMethod;
     setMethod(next);
     setSignInError(null);
-    setSignedIn(false);
-    onTokenChange('');
+    clearMintedCredential();
     if (next !== 'signin') {
       setPortalUrl('');
       setUsername('');
@@ -68,9 +97,31 @@ export function ArcgisCredentialBlock({ token, onTokenChange, disabled }: Arcgis
     }
   };
 
+  const handlePortalUrlChange = (value: string) => {
+    setPortalUrl(value);
+    clearMintedCredential();
+  };
+
+  const handleUsernameChange = (value: string) => {
+    setUsername(value);
+    clearMintedCredential();
+  };
+
+  const handlePasswordChange = (value: string) => {
+    setPassword(value);
+    clearMintedCredential();
+  };
+
   const handleSignIn = async () => {
     if (signInPending) return;
+    // Start of every new attempt: bump the generation so a still-pending
+    // earlier attempt's response (fix P1, below) can never land after this
+    // one starts, and clear whatever an earlier attempt minted so a
+    // slow-failing retry can't leave it behind for "Start refresh" to
+    // submit (fix P2).
+    const generation = (generationRef.current += 1);
     setSignInError(null);
+    clearMintedCredential();
     setSignInPending(true);
     try {
       const result = await arcgisSignIn({
@@ -78,12 +129,23 @@ export function ArcgisCredentialBlock({ token, onTokenChange, disabled }: Arcgis
         username,
         password,
       });
+      // fix(codex #1759 round 1, P1): dropped when this attempt is stale --
+      // either this block unmounted (the dialog was cancelled/closed while
+      // the request was in flight; SourceRefreshAction renders this block
+      // conditionally and unmounts it on close) or a newer attempt already
+      // started. Calling `onTokenChange` here would call the STILL-MOUNTED
+      // parent's setter from an unmounted child's stale closure -- React
+      // allows that silently, so without this guard a token the user
+      // dismissed reappears the next time the dialog opens.
+      if (generationRef.current !== generation) return;
       onTokenChange(result.token);
+      expiresAtRef.current = result.expires_at;
       setSignedIn(true);
       // The password has finished its one job -- minting the token -- and
       // must not linger in state any longer than that took.
       setPassword('');
     } catch (err) {
+      if (generationRef.current !== generation) return;
       setSignedIn(false);
       let key = 'sourcePanel.refresh.credential.arcgis.errors.networkError';
       if (err instanceof ApiError) {
@@ -98,7 +160,9 @@ export function ArcgisCredentialBlock({ token, onTokenChange, disabled }: Arcgis
       // keyed off a stable code -- never the raw response body.
       setSignInError(t(key));
     } finally {
-      setSignInPending(false);
+      if (generationRef.current === generation) {
+        setSignInPending(false);
+      }
     }
   };
 
@@ -155,7 +219,7 @@ export function ArcgisCredentialBlock({ token, onTokenChange, disabled }: Arcgis
               type="text"
               autoComplete="url"
               value={portalUrl}
-              onChange={(event) => setPortalUrl(event.target.value)}
+              onChange={(event) => handlePortalUrlChange(event.target.value)}
               placeholder={t('sourcePanel.refresh.credential.arcgis.portalUrlPlaceholder')}
               disabled={fieldsDisabled}
             />
@@ -169,7 +233,7 @@ export function ArcgisCredentialBlock({ token, onTokenChange, disabled }: Arcgis
               type="text"
               autoComplete="username"
               value={username}
-              onChange={(event) => setUsername(event.target.value)}
+              onChange={(event) => handleUsernameChange(event.target.value)}
               disabled={fieldsDisabled}
             />
           </div>
@@ -190,7 +254,7 @@ export function ArcgisCredentialBlock({ token, onTokenChange, disabled }: Arcgis
               data-lpignore="true"
               data-bwignore
               value={password}
-              onChange={(event) => setPassword(event.target.value)}
+              onChange={(event) => handlePasswordChange(event.target.value)}
               disabled={fieldsDisabled}
             />
           </div>

--- a/frontend/src/components/dataset/SourceRefreshAction.tsx
+++ b/frontend/src/components/dataset/SourceRefreshAction.tsx
@@ -1,11 +1,15 @@
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Loader2, RefreshCw } from 'lucide-react';
 import { toast } from 'sonner';
 import { ApiError } from '@/api/client';
 import { useRefreshDataset } from '@/components/dataset/hooks/use-dataset';
 import { datasetOrigin } from '@/components/dataset/OriginBadge';
-import { ArcgisCredentialBlock } from '@/components/dataset/ArcgisCredentialBlock';
+import {
+  ArcgisCredentialBlock,
+  isExpired,
+  type ArcgisCredentialBlockHandle,
+} from '@/components/dataset/ArcgisCredentialBlock';
 import { useDrawingStore } from '@/stores/drawing-store';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -78,6 +82,11 @@ export function SourceRefreshAction({ dataset, watch }: SourceRefreshActionProps
   // the token field above, instead of rendering that refusal as a generic
   // inline error like every other refusal on this path.
   const [serviceTokenRequired, setServiceTokenRequired] = useState(false);
+  // codex #1759 P2: read synchronously in handleConfirm, below, before this
+  // component trusts `token` at submit time -- the belt effect inside
+  // ArcgisCredentialBlock cannot be relied on to have run first (see the
+  // comment on the check itself).
+  const credentialBlockRef = useRef<ArcgisCredentialBlockHandle>(null);
   const refreshMutation = useRefreshDataset();
   // fix(#1285 codex round 3): _dispatch_postgis_refresh() (router_refresh.py)
   // rejects ANY nonempty token with 422 credential_not_applicable — a
@@ -127,6 +136,23 @@ export function SourceRefreshAction({ dataset, watch }: SourceRefreshActionProps
 
   const handleConfirm = async () => {
     setError(null);
+    // codex #1759 P2: recheck expiry synchronously, right here, before
+    // `token` (below) is trusted. ArcgisCredentialBlock's own belt effect
+    // (a render-triggered recheck) and its scheduled expiry timer are both
+    // suspended by a backgrounded tab or a system sleep exactly like any
+    // other browser timer -- so if the user returns and clicks this button
+    // immediately, neither has necessarily run yet, and `token` can still
+    // hold a credential that is already dead. This uses the identical
+    // `isExpired` the belt effect and the timer both call.
+    if (
+      isArcgisOrigin &&
+      credentialBlockRef.current &&
+      isExpired(credentialBlockRef.current.getExpiresAt(), Date.now())
+    ) {
+      setToken('');
+      credentialBlockRef.current.markExpired();
+      return;
+    }
     const submittedToken = token.trim() || undefined;
     // Cleared before the request settles. Once handed to mutateAsync the
     // token lives only in the in-flight request body; this component never
@@ -198,6 +224,7 @@ export function SourceRefreshAction({ dataset, watch }: SourceRefreshActionProps
                   {t('sourcePanel.refresh.credential.requiredTitle')}
                 </p>
                 <ArcgisCredentialBlock
+                  ref={credentialBlockRef}
                   token={token}
                   onTokenChange={setToken}
                   disabled={refreshMutation.isPending}

--- a/frontend/src/components/dataset/SourceRefreshAction.tsx
+++ b/frontend/src/components/dataset/SourceRefreshAction.tsx
@@ -2,8 +2,10 @@ import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Loader2, RefreshCw } from 'lucide-react';
 import { toast } from 'sonner';
+import { ApiError } from '@/api/client';
 import { useRefreshDataset } from '@/components/dataset/hooks/use-dataset';
 import { datasetOrigin } from '@/components/dataset/OriginBadge';
+import { ArcgisCredentialBlock } from '@/components/dataset/ArcgisCredentialBlock';
 import { useDrawingStore } from '@/stores/drawing-store';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -71,6 +73,11 @@ export function SourceRefreshAction({ dataset, watch }: SourceRefreshActionProps
   const [open, setOpen] = useState(false);
   const [token, setToken] = useState('');
   const [error, setError] = useState<string | null>(null);
+  // fix(#1755 item 4, plan 3.7): set on a 422 `service_token_required`
+  // refusal so the dialog stays open and reveals a credential block keyed to
+  // the token field above, instead of rendering that refusal as a generic
+  // inline error like every other refusal on this path.
+  const [serviceTokenRequired, setServiceTokenRequired] = useState(false);
   const refreshMutation = useRefreshDataset();
   // fix(#1285 codex round 3): _dispatch_postgis_refresh() (router_refresh.py)
   // rejects ANY nonempty token with 422 credential_not_applicable — a
@@ -80,6 +87,12 @@ export function SourceRefreshAction({ dataset, watch }: SourceRefreshActionProps
   // same derivation DetailPanel uses for the REFRESHABLE_ORIGINS gate.
   const origin = dataset.origin ?? datasetOrigin(dataset);
   const supportsToken = origin === 'service';
+  // fix(#1755 item 4, plan 3.7): the two service families that can hit this
+  // refusal read differently -- ArcGIS was asked a probe question and lost,
+  // so it gets the full sign-in taxonomy; WFS and OGC API Features were
+  // refused outright with no probe, so they keep the plain token field and
+  // are told plainly that the refusal was unconditional.
+  const isArcgisOrigin = dataset.source_format === 'arcgis_featureserver';
   const { isBusy } = watch;
 
   // fix(#1285 codex round 6, widened on completion): DatasetMap stays
@@ -108,6 +121,7 @@ export function SourceRefreshAction({ dataset, watch }: SourceRefreshActionProps
       // confirm path does.
       setToken('');
       setError(null);
+      setServiceTokenRequired(false);
     }
   };
 
@@ -131,6 +145,19 @@ export function SourceRefreshAction({ dataset, watch }: SourceRefreshActionProps
       setOpen(false);
       toast.success(t('sourcePanel.refresh.toastAccepted', { runId: result.run_id }));
     } catch (err) {
+      // fix(#1755 item 4, plan 3.7): a 422 `service_token_required` gets its
+      // own inline credential block below rather than the generic error
+      // paragraph every other refusal renders. The 422 body carries only a
+      // stable code plus an English diagnostic sentence aimed at an API
+      // client, and that sentence must never reach the DOM here -- this
+      // component's own copy explains the refusal instead.
+      if (err instanceof ApiError && err.status === 422) {
+        const body = err.body as { code?: string } | undefined;
+        if (body?.code === 'service_token_required') {
+          setServiceTokenRequired(true);
+          return;
+        }
+      }
       setError(err instanceof Error ? err.message : t('sourcePanel.refresh.errors.unknown'));
     }
   };
@@ -165,8 +192,26 @@ export function SourceRefreshAction({ dataset, watch }: SourceRefreshActionProps
           </DialogHeader>
 
           <div className="space-y-4">
-            {supportsToken && (
+            {supportsToken && serviceTokenRequired && isArcgisOrigin && (
               <div className="space-y-2">
+                <p className="text-sm text-foreground">
+                  {t('sourcePanel.refresh.credential.requiredTitle')}
+                </p>
+                <ArcgisCredentialBlock
+                  token={token}
+                  onTokenChange={setToken}
+                  disabled={refreshMutation.isPending}
+                />
+              </div>
+            )}
+
+            {supportsToken && !(serviceTokenRequired && isArcgisOrigin) && (
+              <div className="space-y-2">
+                {serviceTokenRequired && (
+                  <p className="text-sm text-foreground">
+                    {t('sourcePanel.refresh.credential.wfs.intro')}
+                  </p>
+                )}
                 <Label htmlFor="source-refresh-token">{t('sourcePanel.refresh.tokenLabel')}</Label>
                 <Input
                   id="source-refresh-token"
@@ -185,6 +230,11 @@ export function SourceRefreshAction({ dataset, watch }: SourceRefreshActionProps
                   disabled={refreshMutation.isPending}
                 />
                 <p className="text-xs text-muted-foreground">{t('sourcePanel.refresh.tokenHint')}</p>
+                {serviceTokenRequired && (
+                  <p className="text-xs text-muted-foreground">
+                    {t('sourcePanel.refresh.credential.wfs.escapeHatch')}
+                  </p>
+                )}
               </div>
             )}
 

--- a/frontend/src/components/dataset/__tests__/SourceRefreshAction.test.tsx
+++ b/frontend/src/components/dataset/__tests__/SourceRefreshAction.test.tsx
@@ -3,6 +3,7 @@ import userEvent from '@testing-library/user-event';
 import { render } from '@/test/test-utils';
 import { useRefreshDataset } from '@/components/dataset/hooks/use-dataset';
 import { ApiError } from '@/api/client';
+import { translateApiErrorDetail } from '@/lib/error-map';
 import { arcgisSignIn } from '@/api/arcgis-signin';
 import { REFRESHABLE_ORIGINS, SourceRefreshAction } from '../SourceRefreshAction';
 import type { DatasetRefreshWatch } from '@/components/dataset/hooks/use-dataset';
@@ -449,6 +450,18 @@ describe('SourceRefreshAction', () => {
     });
   }
 
+  // codex #1759, post-#1757-merge dedupe: ArcgisCredentialBlock now renders
+  // `ApiError.message` directly rather than mapping `code` to its own copy
+  // (see the component's module comment). This mock has to match what the
+  // REAL apiFetch would have produced, so it runs the same detail through
+  // the same shared `translateApiErrorDetail` (error-map.ts) that A2's
+  // codes are mapped in -- not a hand-copied string that could silently
+  // drift from A2's actual wording the next time it changes.
+  function arcgisSigninError(code: string, status: number, rawMessage = 'raw diagnostic text, never rendered') {
+    const body = { code, message: rawMessage };
+    return new ApiError(translateApiErrorDetail(body, status), status, body);
+  }
+
   // codex #1759 round 2: the ArcGIS credential block now schedules a clear
   // for `expires_at` minus a safety margin, so any test that mints a token
   // without exercising expiry itself needs an `expires_at` safely in the
@@ -652,9 +665,7 @@ describe('SourceRefreshAction', () => {
 
     it('maps a rejected ArcGIS sign-in to this component\'s own copy, never the raw response, and never auto-retries', async () => {
       mutateAsync.mockRejectedValue(serviceTokenRequiredError());
-      mockArcgisSignIn.mockRejectedValue(
-        new ApiError('arcgis_signin_rejected', 400, { code: 'arcgis_signin_rejected', message: 'raw' }),
-      );
+      mockArcgisSignIn.mockRejectedValue(arcgisSigninError('arcgis_signin_rejected', 400, 'raw'));
       const user = userEvent.setup();
       render(
         <SourceRefreshAction
@@ -673,10 +684,9 @@ describe('SourceRefreshAction', () => {
       await user.click(screen.getByRole('button', { name: 'Sign in' }));
 
       expect(
-        await screen.findByText(
-          'ArcGIS did not accept that sign-in. Check the username and password, including capitalization. Too many failed attempts also lock an ArcGIS account temporarily.',
-        ),
+        await screen.findByText(translateApiErrorDetail({ code: 'arcgis_signin_rejected' }, 400)),
       ).toBeInTheDocument();
+      expect(screen.queryByText('raw')).not.toBeInTheDocument();
       // Exactly one attempt: nothing in this component retries a rejected
       // sign-in automatically (plan 3.2 -- a retry loop can lock the
       // customer's real ArcGIS account).
@@ -687,26 +697,12 @@ describe('SourceRefreshAction', () => {
     // signin_guard.py) ships three caller-facing codes beyond the four this
     // map originally covered. Confirmed against the merged source directly.
     it.each([
-      [
-        'arcgis_portal_not_https',
-        422,
-        'The portal URL must start with https. GeoLens will not send a password over an unencrypted connection.',
-      ],
-      [
-        'arcgis_portal_host_invalid',
-        422,
-        'That portal address is not a usable hostname. Check the URL, for example https://your-org.maps.arcgis.com.',
-      ],
-      [
-        'arcgis_signin_in_progress',
-        409,
-        'A sign-in to that ArcGIS account is already in progress. Wait for it to finish, then try again.',
-      ],
-    ])('maps the %s sign-in refusal to its own copy', async (code, status, expected) => {
+      ['arcgis_portal_not_https', 422],
+      ['arcgis_portal_host_invalid', 422],
+      ['arcgis_signin_in_progress', 409],
+    ])('maps the %s sign-in refusal to its own copy', async (code, status) => {
       mutateAsync.mockRejectedValue(serviceTokenRequiredError());
-      mockArcgisSignIn.mockRejectedValue(
-        new ApiError(code, status, { code, message: 'raw diagnostic text, never rendered' }),
-      );
+      mockArcgisSignIn.mockRejectedValue(arcgisSigninError(code, status));
       const user = userEvent.setup();
       render(
         <SourceRefreshAction
@@ -724,7 +720,9 @@ describe('SourceRefreshAction', () => {
       await user.type(screen.getByLabelText('Password'), 'hunter2');
       await user.click(screen.getByRole('button', { name: 'Sign in' }));
 
-      expect(await screen.findByText(expected)).toBeInTheDocument();
+      expect(
+        await screen.findByText(translateApiErrorDetail({ code }, status)),
+      ).toBeInTheDocument();
       expect(screen.queryByText('raw diagnostic text, never rendered')).not.toBeInTheDocument();
     });
 
@@ -857,9 +855,7 @@ describe('SourceRefreshAction', () => {
       mutateAsync.mockRejectedValue(serviceTokenRequiredError());
       mockArcgisSignIn
         .mockResolvedValueOnce({ token: 'first-token', expires_at: FAR_FUTURE_EXPIRY })
-        .mockRejectedValueOnce(
-          new ApiError('arcgis_signin_rejected', 400, { code: 'arcgis_signin_rejected', message: 'raw' }),
-        );
+        .mockRejectedValueOnce(arcgisSigninError('arcgis_signin_rejected', 400, 'raw'));
       const user = userEvent.setup();
       render(
         <SourceRefreshAction
@@ -885,9 +881,7 @@ describe('SourceRefreshAction', () => {
       await user.type(screen.getByLabelText('Password'), 'wrong-password');
       await user.click(screen.getByRole('button', { name: 'Sign in' }));
 
-      await screen.findByText(
-        'ArcGIS did not accept that sign-in. Check the username and password, including capitalization. Too many failed attempts also lock an ArcGIS account temporarily.',
-      );
+      await screen.findByText(translateApiErrorDetail({ code: 'arcgis_signin_rejected' }, 400));
 
       await user.click(screen.getByRole('button', { name: 'Start refresh' }));
 

--- a/frontend/src/components/dataset/__tests__/SourceRefreshAction.test.tsx
+++ b/frontend/src/components/dataset/__tests__/SourceRefreshAction.test.tsx
@@ -1,4 +1,4 @@
-import { screen, waitFor } from '@testing-library/react';
+import { act, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { render } from '@/test/test-utils';
 import { useRefreshDataset } from '@/components/dataset/hooks/use-dataset';
@@ -620,6 +620,137 @@ describe('SourceRefreshAction', () => {
       // sign-in automatically (plan 3.2 -- a retry loop can lock the
       // customer's real ArcGIS account).
       expect(mockArcgisSignIn).toHaveBeenCalledTimes(1);
+    });
+
+    // codex #1759 round 1, P1: a late arcgisSignIn response landing after
+    // the dialog (and this credential block, which SourceRefreshAction
+    // unmounts on close) is dismissed must not resurrect a token the user
+    // already dismissed.
+    it('drops a late ArcGIS sign-in response after the dialog is closed, leaving no token behind', async () => {
+      mutateAsync.mockRejectedValue(serviceTokenRequiredError());
+      let resolveSignIn!: (value: { token: string; expires_at: string }) => void;
+      mockArcgisSignIn.mockReturnValue(
+        new Promise((resolve) => {
+          resolveSignIn = resolve;
+        }),
+      );
+      const user = userEvent.setup();
+      render(
+        <SourceRefreshAction
+          dataset={makeDataset({ source_format: 'arcgis_featureserver' })}
+          watch={makeWatch()}
+        />,
+      );
+
+      await openDialog(user);
+      await user.click(screen.getByRole('button', { name: 'Start refresh' }));
+      const methodSelect = await screen.findByLabelText('Authentication method');
+      await user.selectOptions(methodSelect, 'signin');
+      await user.type(screen.getByLabelText('Portal URL'), 'https://myorg.maps.arcgis.com');
+      await user.type(screen.getByLabelText('Username'), 'alice');
+      await user.type(screen.getByLabelText('Password'), 'hunter2');
+      await user.click(screen.getByRole('button', { name: 'Sign in' }));
+
+      // Dismiss the dialog while the sign-in is still in flight. This
+      // unmounts ArcgisCredentialBlock (SourceRefreshAction renders it
+      // conditionally on `serviceTokenRequired`, which handleOpenChange
+      // resets to false on close).
+      await user.click(screen.getByRole('button', { name: 'Cancel' }));
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+
+      // The response lands after close.
+      await act(async () => {
+        resolveSignIn({ token: 'late-minted-token', expires_at: '2026-09-01T13:00:00Z' });
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      await openDialog(user);
+      expect(screen.getByLabelText('Access token (optional)')).toHaveValue('');
+    });
+
+    // codex #1759 round 1, P2: a token minted for one set of credentials
+    // must not survive editing those credentials or a rejected retry.
+    it('clears a previously minted token as soon as a sign-in field changes, before any new attempt', async () => {
+      mutateAsync.mockRejectedValue(serviceTokenRequiredError());
+      mockArcgisSignIn.mockResolvedValue({
+        token: 'first-token',
+        expires_at: '2026-09-01T13:00:00Z',
+      });
+      const user = userEvent.setup();
+      render(
+        <SourceRefreshAction
+          dataset={makeDataset({ source_format: 'arcgis_featureserver' })}
+          watch={makeWatch()}
+        />,
+      );
+
+      await openDialog(user);
+      await user.click(screen.getByRole('button', { name: 'Start refresh' }));
+      const methodSelect = await screen.findByLabelText('Authentication method');
+      await user.selectOptions(methodSelect, 'signin');
+      await user.type(screen.getByLabelText('Portal URL'), 'https://myorg.maps.arcgis.com');
+      await user.type(screen.getByLabelText('Username'), 'alice');
+      await user.type(screen.getByLabelText('Password'), 'hunter2');
+      await user.click(screen.getByRole('button', { name: 'Sign in' }));
+      await screen.findByText('Signed in. The token below is ready to use.');
+
+      // Edit a field but do NOT attempt sign-in again -- the field-change
+      // handler itself, not only the next attempt's start, must drop the
+      // token that no longer describes what's typed.
+      await user.type(screen.getByLabelText('Username'), 'x');
+      expect(
+        screen.queryByText('Signed in. The token below is ready to use.'),
+      ).not.toBeInTheDocument();
+
+      await user.click(screen.getByRole('button', { name: 'Start refresh' }));
+
+      await waitFor(() => {
+        expect(mutateAsync).toHaveBeenLastCalledWith({ datasetId: 'dataset-1', token: undefined });
+      });
+    });
+
+    it('clears a previously minted token once a sign-in field changes, so a rejected retry submits nothing', async () => {
+      mutateAsync.mockRejectedValue(serviceTokenRequiredError());
+      mockArcgisSignIn
+        .mockResolvedValueOnce({ token: 'first-token', expires_at: '2026-09-01T13:00:00Z' })
+        .mockRejectedValueOnce(
+          new ApiError('arcgis_signin_rejected', 400, { code: 'arcgis_signin_rejected', message: 'raw' }),
+        );
+      const user = userEvent.setup();
+      render(
+        <SourceRefreshAction
+          dataset={makeDataset({ source_format: 'arcgis_featureserver' })}
+          watch={makeWatch()}
+        />,
+      );
+
+      await openDialog(user);
+      await user.click(screen.getByRole('button', { name: 'Start refresh' }));
+      const methodSelect = await screen.findByLabelText('Authentication method');
+      await user.selectOptions(methodSelect, 'signin');
+      await user.type(screen.getByLabelText('Portal URL'), 'https://myorg.maps.arcgis.com');
+      await user.type(screen.getByLabelText('Username'), 'alice');
+      await user.type(screen.getByLabelText('Password'), 'hunter2');
+      await user.click(screen.getByRole('button', { name: 'Sign in' }));
+      await screen.findByText('Signed in. The token below is ready to use.');
+
+      // Editing a field after a successful mint invalidates that token --
+      // the fields no longer describe the account it was minted for.
+      await user.clear(screen.getByLabelText('Username'));
+      await user.type(screen.getByLabelText('Username'), 'bob');
+      await user.type(screen.getByLabelText('Password'), 'wrong-password');
+      await user.click(screen.getByRole('button', { name: 'Sign in' }));
+
+      await screen.findByText(
+        'ArcGIS did not accept that sign-in. Check the username and password, including capitalization. Too many failed attempts also lock an ArcGIS account temporarily.',
+      );
+
+      await user.click(screen.getByRole('button', { name: 'Start refresh' }));
+
+      await waitFor(() => {
+        expect(mutateAsync).toHaveBeenLastCalledWith({ datasetId: 'dataset-1', token: undefined });
+      });
     });
   });
 });

--- a/frontend/src/components/dataset/__tests__/SourceRefreshAction.test.tsx
+++ b/frontend/src/components/dataset/__tests__/SourceRefreshAction.test.tsx
@@ -592,7 +592,7 @@ describe('SourceRefreshAction', () => {
       await user.type(screen.getByLabelText('Password'), 'hunter2');
       await user.click(screen.getByRole('button', { name: 'Sign in' }));
 
-      await screen.findByText('Signed in. The token below is ready to use.');
+      await screen.findByText('Signed in. The refresh will use this token.');
       expect(mockArcgisSignIn).toHaveBeenCalledWith({
         portal_url: 'https://myorg.maps.arcgis.com',
         username: 'alice',
@@ -687,7 +687,7 @@ describe('SourceRefreshAction', () => {
       await user.type(screen.getByLabelText('Username'), 'alice');
       await user.type(screen.getByLabelText('Password'), 'hunter2');
       await user.click(screen.getByRole('button', { name: 'Sign in' }));
-      await screen.findByText('Signed in. The token below is ready to use.');
+      await screen.findByText('Signed in. The refresh will use this token.');
 
       // The refresh itself is refused (a transient 503 here; an invalid or
       // expired token on the origin's own side reads the same way to this
@@ -696,7 +696,7 @@ describe('SourceRefreshAction', () => {
 
       await waitFor(() => {
         expect(
-          screen.queryByText('Signed in. The token below is ready to use.'),
+          screen.queryByText('Signed in. The refresh will use this token.'),
         ).not.toBeInTheDocument();
       });
       // Still offering the sign-in method -- not reset to the taxonomy's
@@ -933,14 +933,14 @@ describe('SourceRefreshAction', () => {
       await user.type(screen.getByLabelText('Username'), 'alice');
       await user.type(screen.getByLabelText('Password'), 'hunter2');
       await user.click(screen.getByRole('button', { name: 'Sign in' }));
-      await screen.findByText('Signed in. The token below is ready to use.');
+      await screen.findByText('Signed in. The refresh will use this token.');
 
       // Edit a field but do NOT attempt sign-in again -- the field-change
       // handler itself, not only the next attempt's start, must drop the
       // token that no longer describes what's typed.
       await user.type(screen.getByLabelText('Username'), 'x');
       expect(
-        screen.queryByText('Signed in. The token below is ready to use.'),
+        screen.queryByText('Signed in. The refresh will use this token.'),
       ).not.toBeInTheDocument();
 
       await user.click(screen.getByRole('button', { name: 'Start refresh' }));
@@ -971,7 +971,7 @@ describe('SourceRefreshAction', () => {
       await user.type(screen.getByLabelText('Username'), 'alice');
       await user.type(screen.getByLabelText('Password'), 'hunter2');
       await user.click(screen.getByRole('button', { name: 'Sign in' }));
-      await screen.findByText('Signed in. The token below is ready to use.');
+      await screen.findByText('Signed in. The refresh will use this token.');
 
       // Editing a field after a successful mint invalidates that token --
       // the fields no longer describe the account it was minted for.
@@ -1008,7 +1008,7 @@ describe('SourceRefreshAction', () => {
         await user.type(screen.getByLabelText('Username'), 'alice');
         await user.type(screen.getByLabelText('Password'), 'hunter2');
         await user.click(screen.getByRole('button', { name: 'Sign in' }));
-        await screen.findByText('Signed in. The token below is ready to use.');
+        await screen.findByText('Signed in. The refresh will use this token.');
       }
 
       it('expires a minted token while the dialog stays open, clearing it and swapping the copy', async () => {
@@ -1036,7 +1036,7 @@ describe('SourceRefreshAction', () => {
         });
 
         expect(
-          screen.queryByText('Signed in. The token below is ready to use.'),
+          screen.queryByText('Signed in. The refresh will use this token.'),
         ).not.toBeInTheDocument();
         expect(
           await screen.findByText('The token expired. Sign in again to continue.'),

--- a/frontend/src/components/dataset/__tests__/SourceRefreshAction.test.tsx
+++ b/frontend/src/components/dataset/__tests__/SourceRefreshAction.test.tsx
@@ -739,6 +739,59 @@ describe('SourceRefreshAction', () => {
       expect(mockArcgisSignIn).toHaveBeenCalledTimes(1);
     });
 
+    // codex #1759 round 4 P2: a rejected sign-in used to leave the
+    // password sitting in state and in the controlled input until the
+    // user edited it or closed the dialog -- contradicting this block's
+    // own request-scoped credential lifetime, and letting a second click
+    // resend the very password ArcGIS just rejected, which matters under
+    // its five-attempts lockout. Counterfactual: without the fix, the
+    // password assertion below fails and the button stays enabled.
+    it('clears the password after a rejected sign-in, so a second click cannot resubmit it', async () => {
+      mutateAsync.mockRejectedValue(serviceTokenRequiredError());
+      mockArcgisSignIn.mockRejectedValue(arcgisSigninError('arcgis_signin_rejected', 400, 'raw'));
+      const user = userEvent.setup();
+      render(
+        <SourceRefreshAction
+          dataset={makeDataset({ source_format: 'arcgis_featureserver' })}
+          watch={makeWatch()}
+        />,
+      );
+
+      await openDialog(user);
+      await user.click(screen.getByRole('button', { name: 'Start refresh' }));
+      const methodSelect = await screen.findByLabelText('Authentication method');
+      await user.selectOptions(methodSelect, 'signin');
+      await user.type(screen.getByLabelText('Portal URL'), 'https://myorg.maps.arcgis.com');
+      await user.type(screen.getByLabelText('Username'), 'alice');
+      await user.type(screen.getByLabelText('Password'), 'wrong-password');
+      const signInButton = screen.getByRole('button', { name: 'Sign in' });
+      await user.click(signInButton);
+
+      await screen.findByText(translateApiErrorDetail({ code: 'arcgis_signin_rejected' }, 400));
+
+      // Password cleared the instant the rejected attempt settled.
+      expect(screen.getByLabelText('Password')).toHaveValue('');
+      // A second click with nothing re-typed cannot submit: the button
+      // requires a non-empty password, same as portal URL and username.
+      expect(signInButton).toBeDisabled();
+      expect(mockArcgisSignIn).toHaveBeenCalledTimes(1);
+
+      // Typing a genuinely new password is what it takes to try again --
+      // and that new value, not the rejected one, is what goes out.
+      await user.type(screen.getByLabelText('Password'), 'new-password');
+      expect(signInButton).not.toBeDisabled();
+      await user.click(signInButton);
+
+      await waitFor(() => {
+        expect(mockArcgisSignIn).toHaveBeenCalledTimes(2);
+      });
+      expect(mockArcgisSignIn).toHaveBeenLastCalledWith({
+        portal_url: 'https://myorg.maps.arcgis.com',
+        username: 'alice',
+        password: 'new-password',
+      });
+    });
+
     // Post-#1758-merge: the merged endpoint (arcgis_signin.py,
     // signin_guard.py) ships three caller-facing codes beyond the four this
     // map originally covered. Confirmed against the merged source directly.

--- a/frontend/src/components/dataset/__tests__/SourceRefreshAction.test.tsx
+++ b/frontend/src/components/dataset/__tests__/SourceRefreshAction.test.tsx
@@ -597,6 +597,59 @@ describe('SourceRefreshAction', () => {
       });
     });
 
+    // codex #1759 round 3, P2: "Start refresh" clears the parent's `token`
+    // state before awaiting the refresh request, win or lose. Before this
+    // fix, the credential block's own `signedIn` flag did not know that --
+    // a rejected refresh left it still claiming "Signed in" while the next
+    // retry silently submitted no token at all.
+    it('reverts to its own sign-in state, with no token, after a rejected refresh that follows a mint', async () => {
+      const remoteError = new ApiError('Remote service returned an error', 503);
+      mutateAsync
+        .mockRejectedValueOnce(serviceTokenRequiredError())
+        .mockRejectedValueOnce(remoteError)
+        .mockRejectedValue(remoteError);
+      mockArcgisSignIn.mockResolvedValue({
+        token: 'minted-token-xyz',
+        expires_at: FAR_FUTURE_EXPIRY,
+      });
+      const user = userEvent.setup();
+      render(
+        <SourceRefreshAction
+          dataset={makeDataset({ source_format: 'arcgis_featureserver' })}
+          watch={makeWatch()}
+        />,
+      );
+
+      await openDialog(user);
+      await user.click(screen.getByRole('button', { name: 'Start refresh' }));
+      const methodSelect = await screen.findByLabelText('Authentication method');
+      await user.selectOptions(methodSelect, 'signin');
+      await user.type(screen.getByLabelText('Portal URL'), 'https://myorg.maps.arcgis.com');
+      await user.type(screen.getByLabelText('Username'), 'alice');
+      await user.type(screen.getByLabelText('Password'), 'hunter2');
+      await user.click(screen.getByRole('button', { name: 'Sign in' }));
+      await screen.findByText('Signed in. The token below is ready to use.');
+
+      // The refresh itself is refused (a transient 503 here; an invalid or
+      // expired token on the origin's own side reads the same way to this
+      // dialog). The dialog stays open on any refusal.
+      await user.click(screen.getByRole('button', { name: 'Start refresh' }));
+
+      await waitFor(() => {
+        expect(
+          screen.queryByText('Signed in. The token below is ready to use.'),
+        ).not.toBeInTheDocument();
+      });
+      // Still offering the sign-in method -- not reset to the taxonomy's
+      // default -- but with nothing left to submit.
+      expect(screen.getByLabelText('Authentication method')).toHaveValue('signin');
+
+      await user.click(screen.getByRole('button', { name: 'Start refresh' }));
+      await waitFor(() => {
+        expect(mutateAsync).toHaveBeenLastCalledWith({ datasetId: 'dataset-1', token: undefined });
+      });
+    });
+
     it('maps a rejected ArcGIS sign-in to this component\'s own copy, never the raw response, and never auto-retries', async () => {
       mutateAsync.mockRejectedValue(serviceTokenRequiredError());
       mockArcgisSignIn.mockRejectedValue(

--- a/frontend/src/components/dataset/__tests__/SourceRefreshAction.test.tsx
+++ b/frontend/src/components/dataset/__tests__/SourceRefreshAction.test.tsx
@@ -449,6 +449,14 @@ describe('SourceRefreshAction', () => {
     });
   }
 
+  // codex #1759 round 2: the ArcGIS credential block now schedules a clear
+  // for `expires_at` minus a safety margin, so any test that mints a token
+  // without exercising expiry itself needs an `expires_at` safely in the
+  // future relative to whenever the suite actually runs -- a fixed literal
+  // date goes stale (and the timer fires almost immediately, wiping the
+  // "Signed in" state before an assertion ever sees it).
+  const FAR_FUTURE_EXPIRY = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+
   describe('service_token_required credential prompt', () => {
     it('keeps the dialog open on the 422 and never echoes the raw response text into the DOM', async () => {
       mutateAsync.mockRejectedValue(serviceTokenRequiredError());
@@ -551,7 +559,7 @@ describe('SourceRefreshAction', () => {
         });
       mockArcgisSignIn.mockResolvedValue({
         token: 'minted-token-xyz',
-        expires_at: '2026-09-01T13:00:00Z',
+        expires_at: FAR_FUTURE_EXPIRY,
       });
       const user = userEvent.setup();
       render(
@@ -660,7 +668,7 @@ describe('SourceRefreshAction', () => {
 
       // The response lands after close.
       await act(async () => {
-        resolveSignIn({ token: 'late-minted-token', expires_at: '2026-09-01T13:00:00Z' });
+        resolveSignIn({ token: 'late-minted-token', expires_at: FAR_FUTURE_EXPIRY });
         await Promise.resolve();
         await Promise.resolve();
       });
@@ -675,7 +683,7 @@ describe('SourceRefreshAction', () => {
       mutateAsync.mockRejectedValue(serviceTokenRequiredError());
       mockArcgisSignIn.mockResolvedValue({
         token: 'first-token',
-        expires_at: '2026-09-01T13:00:00Z',
+        expires_at: FAR_FUTURE_EXPIRY,
       });
       const user = userEvent.setup();
       render(
@@ -713,7 +721,7 @@ describe('SourceRefreshAction', () => {
     it('clears a previously minted token once a sign-in field changes, so a rejected retry submits nothing', async () => {
       mutateAsync.mockRejectedValue(serviceTokenRequiredError());
       mockArcgisSignIn
-        .mockResolvedValueOnce({ token: 'first-token', expires_at: '2026-09-01T13:00:00Z' })
+        .mockResolvedValueOnce({ token: 'first-token', expires_at: FAR_FUTURE_EXPIRY })
         .mockRejectedValueOnce(
           new ApiError('arcgis_signin_rejected', 400, { code: 'arcgis_signin_rejected', message: 'raw' }),
         );
@@ -750,6 +758,101 @@ describe('SourceRefreshAction', () => {
 
       await waitFor(() => {
         expect(mutateAsync).toHaveBeenLastCalledWith({ datasetId: 'dataset-1', token: undefined });
+      });
+    });
+
+    // codex #1759 round 2: the refresh door only stages a credential and
+    // queues the worker, so a dialog left open past the minted token's
+    // lifetime would otherwise submit one already dead on the wire, and
+    // the failure would only surface later in the background.
+    describe('ArcGIS token expiry', () => {
+      afterEach(() => {
+        vi.useRealTimers();
+      });
+
+      async function signInSuccessfully(user: ReturnType<typeof userEvent.setup>, expiresAt: string) {
+        mockArcgisSignIn.mockResolvedValue({ token: 'short-lived-token', expires_at: expiresAt });
+        await openDialog(user);
+        await user.click(screen.getByRole('button', { name: 'Start refresh' }));
+        const methodSelect = await screen.findByLabelText('Authentication method');
+        await user.selectOptions(methodSelect, 'signin');
+        await user.type(screen.getByLabelText('Portal URL'), 'https://myorg.maps.arcgis.com');
+        await user.type(screen.getByLabelText('Username'), 'alice');
+        await user.type(screen.getByLabelText('Password'), 'hunter2');
+        await user.click(screen.getByRole('button', { name: 'Sign in' }));
+        await screen.findByText('Signed in. The token below is ready to use.');
+      }
+
+      it('expires a minted token while the dialog stays open, clearing it and swapping the copy', async () => {
+        mutateAsync.mockRejectedValue(serviceTokenRequiredError());
+        // fix(#831 precedent, VerifyEmailPage.test.tsx): shouldAdvanceTime
+        // keeps the mocked arcgisSignIn promise progressing while fake
+        // timers also control the scheduled expiry; delay: null keeps
+        // userEvent synchronous under them.
+        vi.useFakeTimers({ shouldAdvanceTime: true });
+        const user = userEvent.setup({ delay: null });
+        render(
+          <SourceRefreshAction
+            dataset={makeDataset({ source_format: 'arcgis_featureserver' })}
+            watch={makeWatch()}
+          />,
+        );
+
+        await signInSuccessfully(user, new Date(Date.now() + 60_000).toISOString());
+
+        // Past expires_at minus the 30s safety margin, but before the raw
+        // expiry itself -- proves the margin, not just the raw timestamp,
+        // drives the clear.
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(31_000);
+        });
+
+        expect(
+          screen.queryByText('Signed in. The token below is ready to use.'),
+        ).not.toBeInTheDocument();
+        expect(
+          await screen.findByText('The token expired. Sign in again to continue.'),
+        ).toBeInTheDocument();
+
+        await user.click(screen.getByRole('button', { name: 'Start refresh' }));
+        await waitFor(() => {
+          expect(mutateAsync).toHaveBeenLastCalledWith({ datasetId: 'dataset-1', token: undefined });
+        });
+      });
+
+      it('clears the scheduled expiry timer when the dialog closes, so it never fires', async () => {
+        mutateAsync.mockRejectedValue(serviceTokenRequiredError());
+        vi.useFakeTimers({ shouldAdvanceTime: true });
+        const user = userEvent.setup({ delay: null });
+        const setTimeoutSpy = vi.spyOn(global, 'setTimeout');
+        const clearTimeoutSpy = vi.spyOn(global, 'clearTimeout');
+        render(
+          <SourceRefreshAction
+            dataset={makeDataset({ source_format: 'arcgis_featureserver' })}
+            watch={makeWatch()}
+          />,
+        );
+
+        // A long-lived token so the expiry timer's delay (minutes) is
+        // unambiguous against whatever short-delay timers userEvent/jsdom
+        // themselves schedule under fake timers.
+        await signInSuccessfully(user, new Date(Date.now() + 60 * 60 * 1000).toISOString());
+
+        const expiryTimerCallIndex = setTimeoutSpy.mock.calls.findIndex(
+          ([, delay]) => typeof delay === 'number' && delay > 10_000,
+        );
+        expect(expiryTimerCallIndex).toBeGreaterThanOrEqual(0);
+        const expiryTimerId = setTimeoutSpy.mock.results[expiryTimerCallIndex]?.value;
+
+        await user.click(screen.getByRole('button', { name: 'Cancel' }));
+        // Not just "cleared something" -- cleared THIS timer specifically.
+        expect(clearTimeoutSpy).toHaveBeenCalledWith(expiryTimerId);
+
+        // Advancing well past the original expiry raises nothing further --
+        // the block that owned the timer is gone.
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(2 * 60 * 60 * 1000);
+        });
       });
     });
   });

--- a/frontend/src/components/dataset/__tests__/SourceRefreshAction.test.tsx
+++ b/frontend/src/components/dataset/__tests__/SourceRefreshAction.test.tsx
@@ -728,6 +728,43 @@ describe('SourceRefreshAction', () => {
       expect(screen.queryByText('raw diagnostic text, never rendered')).not.toBeInTheDocument();
     });
 
+    // codex #1759 round 3, P2: ArcGISSignInRequest rejects input -- a
+    // scheme-less portal URL, one carrying credentials, an overlong field --
+    // before the route runs. That is a FastAPI/pydantic validation array in
+    // err.body, not this endpoint's {code, message} shape, so it has no
+    // `.code` and must not fall through to the generic "could not reach the
+    // portal" copy: the request never reached the network.
+    it('shows the client-translated validation message for input the endpoint rejects before the route runs', async () => {
+      mutateAsync.mockRejectedValue(serviceTokenRequiredError());
+      mockArcgisSignIn.mockRejectedValue(
+        new ApiError('portal_url: value is not a valid URL', 422, [
+          { loc: ['body', 'portal_url'], msg: 'value is not a valid URL', type: 'value_error' },
+        ]),
+      );
+      const user = userEvent.setup();
+      render(
+        <SourceRefreshAction
+          dataset={makeDataset({ source_format: 'arcgis_featureserver' })}
+          watch={makeWatch()}
+        />,
+      );
+
+      await openDialog(user);
+      await user.click(screen.getByRole('button', { name: 'Start refresh' }));
+      const methodSelect = await screen.findByLabelText('Authentication method');
+      await user.selectOptions(methodSelect, 'signin');
+      await user.type(screen.getByLabelText('Portal URL'), 'not-a-url');
+      await user.type(screen.getByLabelText('Username'), 'alice');
+      await user.type(screen.getByLabelText('Password'), 'hunter2');
+      await user.click(screen.getByRole('button', { name: 'Sign in' }));
+
+      expect(await screen.findByText('portal_url: value is not a valid URL')).toBeInTheDocument();
+      // Never the generic fallback: this never reached the network.
+      expect(
+        screen.queryByText('Could not reach the portal. Check the URL and try again.'),
+      ).not.toBeInTheDocument();
+    });
+
     // codex #1759 round 1, P1: a late arcgisSignIn response landing after
     // the dialog (and this credential block, which SourceRefreshAction
     // unmounts on close) is dismissed must not resurrect a token the user
@@ -951,6 +988,39 @@ describe('SourceRefreshAction', () => {
         await act(async () => {
           await vi.advanceTimersByTimeAsync(2 * 60 * 60 * 1000);
         });
+      });
+
+      // codex #1759 P2: the scheduled timer and the render-triggered belt
+      // effect are both suspended exactly like any other browser timer by a
+      // backgrounded tab or a system sleep. This proves the submit path
+      // catches an already-expired token on its own, without either of
+      // those ever getting a chance to run -- the clock is moved past
+      // expiry directly, and no fake timer is ever advanced.
+      it('recognizes an already-expired token synchronously at submit time, even if the scheduled timer never fires', async () => {
+        mutateAsync.mockRejectedValue(serviceTokenRequiredError());
+        vi.useFakeTimers({ shouldAdvanceTime: true });
+        const user = userEvent.setup({ delay: null });
+        render(
+          <SourceRefreshAction
+            dataset={makeDataset({ source_format: 'arcgis_featureserver' })}
+            watch={makeWatch()}
+          />,
+        );
+
+        await signInSuccessfully(user, new Date(Date.now() + 60_000).toISOString());
+
+        // Jump the clock past expiry. Deliberately NOT vi.advanceTimersByTimeAsync:
+        // the scheduled expiry timer must never fire in this test.
+        vi.setSystemTime(Date.now() + 61_000);
+
+        await user.click(screen.getByRole('button', { name: 'Start refresh' }));
+
+        // The original 422 dispatch is the only call mutateAsync ever sees --
+        // the stale token is never submitted.
+        expect(mutateAsync).toHaveBeenCalledTimes(1);
+        expect(
+          await screen.findByText('The token expired. Sign in again to continue.'),
+        ).toBeInTheDocument();
       });
     });
   });

--- a/frontend/src/components/dataset/__tests__/SourceRefreshAction.test.tsx
+++ b/frontend/src/components/dataset/__tests__/SourceRefreshAction.test.tsx
@@ -610,6 +610,52 @@ describe('SourceRefreshAction', () => {
       });
     });
 
+    // codex #1759 round 3 P2: ArcGISSignInRequest does not strip
+    // whitespace and PortalSignIn.mint forwards the value unchanged, so a
+    // pasted username with leading/trailing whitespace would burn one of
+    // the account's limited sign-in attempts on a value that could never
+    // match. A whitespace-only value must never submit at all.
+    it('trims the username before sending it, and refuses a whitespace-only one', async () => {
+      mutateAsync.mockRejectedValue(serviceTokenRequiredError());
+      mockArcgisSignIn.mockResolvedValue({ token: 'minted-token', expires_at: FAR_FUTURE_EXPIRY });
+      const user = userEvent.setup();
+      render(
+        <SourceRefreshAction
+          dataset={makeDataset({ source_format: 'arcgis_featureserver' })}
+          watch={makeWatch()}
+        />,
+      );
+
+      await openDialog(user);
+      await user.click(screen.getByRole('button', { name: 'Start refresh' }));
+      const methodSelect = await screen.findByLabelText('Authentication method');
+      await user.selectOptions(methodSelect, 'signin');
+      const usernameInput = screen.getByLabelText('Username');
+      const signInButton = screen.getByRole('button', { name: 'Sign in' });
+
+      await user.type(screen.getByLabelText('Portal URL'), 'https://myorg.maps.arcgis.com');
+      await user.type(screen.getByLabelText('Password'), 'hunter2');
+
+      await user.type(usernameInput, '   ');
+      expect(signInButton).toBeDisabled();
+
+      await user.clear(usernameInput);
+      await user.type(usernameInput, '  alice  ');
+      expect(signInButton).not.toBeDisabled();
+      await user.click(signInButton);
+
+      await waitFor(() => {
+        expect(mockArcgisSignIn).toHaveBeenCalledWith({
+          portal_url: 'https://myorg.maps.arcgis.com',
+          username: 'alice',
+          password: 'hunter2',
+        });
+      });
+      expect(mockArcgisSignIn).not.toHaveBeenCalledWith(
+        expect.objectContaining({ username: '  alice  ' }),
+      );
+    });
+
     // codex #1759 round 3, P2: "Start refresh" clears the parent's `token`
     // state before awaiting the refresh request, win or lose. Before this
     // fix, the credential block's own `signedIn` flag did not know that --
@@ -1011,6 +1057,39 @@ describe('SourceRefreshAction', () => {
 
         // The original 422 dispatch is the only call mutateAsync ever sees --
         // the stale token is never submitted.
+        expect(mutateAsync).toHaveBeenCalledTimes(1);
+        expect(
+          await screen.findByText('The token expired. Sign in again to continue.'),
+        ).toBeInTheDocument();
+      });
+
+      // codex #1759 round 3 P2: the synchronous guard used to compare
+      // against the raw expires_at, while the scheduled timer retires the
+      // token 30s early. A tab resuming inside that last 30-second window
+      // -- past the margin cutoff but before the real expiry -- used to
+      // pass the (unmargined) guard and let handleConfirm submit a
+      // credential this component had already decided was retired.
+      it('refuses a token still inside the 30s safety margin, not just past its real expiry', async () => {
+        mutateAsync.mockRejectedValue(serviceTokenRequiredError());
+        vi.useFakeTimers({ shouldAdvanceTime: true });
+        const user = userEvent.setup({ delay: null });
+        render(
+          <SourceRefreshAction
+            dataset={makeDataset({ source_format: 'arcgis_featureserver' })}
+            watch={makeWatch()}
+          />,
+        );
+
+        await signInSuccessfully(user, new Date(Date.now() + 60_000).toISOString());
+
+        // 35s elapsed: past the 30s-early margin cutoff (retires at 30s)
+        // but still short of the token's real expiry (60s). Deliberately
+        // NOT vi.advanceTimersByTimeAsync: the scheduled timer, set for
+        // ~30s from now, must never fire in this test either.
+        vi.setSystemTime(Date.now() + 35_000);
+
+        await user.click(screen.getByRole('button', { name: 'Start refresh' }));
+
         expect(mutateAsync).toHaveBeenCalledTimes(1);
         expect(
           await screen.findByText('The token expired. Sign in again to continue.'),

--- a/frontend/src/components/dataset/__tests__/SourceRefreshAction.test.tsx
+++ b/frontend/src/components/dataset/__tests__/SourceRefreshAction.test.tsx
@@ -683,6 +683,51 @@ describe('SourceRefreshAction', () => {
       expect(mockArcgisSignIn).toHaveBeenCalledTimes(1);
     });
 
+    // Post-#1758-merge: the merged endpoint (arcgis_signin.py,
+    // signin_guard.py) ships three caller-facing codes beyond the four this
+    // map originally covered. Confirmed against the merged source directly.
+    it.each([
+      [
+        'arcgis_portal_not_https',
+        422,
+        'The portal URL must start with https. GeoLens will not send a password over an unencrypted connection.',
+      ],
+      [
+        'arcgis_portal_host_invalid',
+        422,
+        'That portal address is not a usable hostname. Check the URL, for example https://your-org.maps.arcgis.com.',
+      ],
+      [
+        'arcgis_signin_in_progress',
+        409,
+        'A sign-in to that ArcGIS account is already in progress. Wait for it to finish, then try again.',
+      ],
+    ])('maps the %s sign-in refusal to its own copy', async (code, status, expected) => {
+      mutateAsync.mockRejectedValue(serviceTokenRequiredError());
+      mockArcgisSignIn.mockRejectedValue(
+        new ApiError(code, status, { code, message: 'raw diagnostic text, never rendered' }),
+      );
+      const user = userEvent.setup();
+      render(
+        <SourceRefreshAction
+          dataset={makeDataset({ source_format: 'arcgis_featureserver' })}
+          watch={makeWatch()}
+        />,
+      );
+
+      await openDialog(user);
+      await user.click(screen.getByRole('button', { name: 'Start refresh' }));
+      const methodSelect = await screen.findByLabelText('Authentication method');
+      await user.selectOptions(methodSelect, 'signin');
+      await user.type(screen.getByLabelText('Portal URL'), 'https://myorg.maps.arcgis.com');
+      await user.type(screen.getByLabelText('Username'), 'alice');
+      await user.type(screen.getByLabelText('Password'), 'hunter2');
+      await user.click(screen.getByRole('button', { name: 'Sign in' }));
+
+      expect(await screen.findByText(expected)).toBeInTheDocument();
+      expect(screen.queryByText('raw diagnostic text, never rendered')).not.toBeInTheDocument();
+    });
+
     // codex #1759 round 1, P1: a late arcgisSignIn response landing after
     // the dialog (and this credential block, which SourceRefreshAction
     // unmounts on close) is dismissed must not resurrect a token the user

--- a/frontend/src/components/dataset/__tests__/SourceRefreshAction.test.tsx
+++ b/frontend/src/components/dataset/__tests__/SourceRefreshAction.test.tsx
@@ -3,6 +3,7 @@ import userEvent from '@testing-library/user-event';
 import { render } from '@/test/test-utils';
 import { useRefreshDataset } from '@/components/dataset/hooks/use-dataset';
 import { ApiError } from '@/api/client';
+import { arcgisSignIn } from '@/api/arcgis-signin';
 import { REFRESHABLE_ORIGINS, SourceRefreshAction } from '../SourceRefreshAction';
 import type { DatasetRefreshWatch } from '@/components/dataset/hooks/use-dataset';
 import type { DatasetResponse } from '@/types/api';
@@ -14,6 +15,13 @@ import type { DatasetResponse } from '@/types/api';
 // useDatasetRefreshRuns no longer needs mocking here at all.
 vi.mock('@/components/dataset/hooks/use-dataset', () => ({
   useRefreshDataset: vi.fn(),
+}));
+
+// fix(#1755 item 4): lane A1's sign-in endpoint. Mocked here per the plan's
+// contract (portal_url/username/password in, token/expires_at out) since
+// this lane builds against that contract rather than a live backend.
+vi.mock('@/api/arcgis-signin', () => ({
+  arcgisSignIn: vi.fn(),
 }));
 
 vi.mock('sonner', () => ({
@@ -34,6 +42,7 @@ vi.mock('@/stores/drawing-store', () => ({
 }));
 
 const mockUseRefreshDataset = vi.mocked(useRefreshDataset);
+const mockArcgisSignIn = vi.mocked(arcgisSignIn);
 const mutateAsync = vi.fn();
 const trackDispatchedRun = vi.fn();
 
@@ -423,6 +432,194 @@ describe('SourceRefreshAction', () => {
 
     await waitFor(() => {
       expect(trackDispatchedRun).toHaveBeenCalledWith('run-slow');
+    });
+  });
+
+  // fix(#1755 item 4, plan 3.7): the refresh door's own 422 detail. The
+  // `message` field is a diagnostic sentence aimed at an API client, not UI
+  // copy -- it must never reach the DOM, and this suite pins that alongside
+  // the credential prompt it triggers instead.
+  const RAW_SERVICE_TOKEN_MESSAGE =
+    "This dataset's source needed a service token the last time it was imported or refreshed, and this request carries none. Send the token again in the request body's `token` field; tokens are request-only and are never stored between runs. If the source is public now, re-import it through the re-upload dialog without a token to clear the requirement.";
+
+  function serviceTokenRequiredError() {
+    return new ApiError('service_token_required', 422, {
+      code: 'service_token_required',
+      message: RAW_SERVICE_TOKEN_MESSAGE,
+    });
+  }
+
+  describe('service_token_required credential prompt', () => {
+    it('keeps the dialog open on the 422 and never echoes the raw response text into the DOM', async () => {
+      mutateAsync.mockRejectedValue(serviceTokenRequiredError());
+      const user = userEvent.setup();
+      render(<SourceRefreshAction dataset={makeDataset({ source_format: 'wfs' })} watch={makeWatch()} />);
+
+      await openDialog(user);
+      await user.click(screen.getByRole('button', { name: 'Start refresh' }));
+
+      await screen.findByText(
+        'This source refused the refresh outright because it needs a credential. Send the token again below.',
+      );
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+      expect(document.body.textContent).not.toContain(RAW_SERVICE_TOKEN_MESSAGE);
+    });
+
+    it('shows the ArcGIS sign-in taxonomy for an arcgis_featureserver origin, not the WFS escape hatch', async () => {
+      mutateAsync.mockRejectedValue(serviceTokenRequiredError());
+      const user = userEvent.setup();
+      render(
+        <SourceRefreshAction
+          dataset={makeDataset({ source_format: 'arcgis_featureserver' })}
+          watch={makeWatch()}
+        />,
+      );
+
+      await openDialog(user);
+      await user.click(screen.getByRole('button', { name: 'Start refresh' }));
+
+      expect(await screen.findByLabelText('Authentication method')).toBeInTheDocument();
+      expect(
+        screen.queryByText(/refused the refresh outright/i),
+      ).not.toBeInTheDocument();
+    });
+
+    it('shows the outright-refusal copy and the re-upload escape hatch for a WFS origin, not the ArcGIS select', async () => {
+      mutateAsync.mockRejectedValue(serviceTokenRequiredError());
+      const user = userEvent.setup();
+      render(<SourceRefreshAction dataset={makeDataset({ source_format: 'wfs' })} watch={makeWatch()} />);
+
+      await openDialog(user);
+      await user.click(screen.getByRole('button', { name: 'Start refresh' }));
+
+      expect(
+        await screen.findByText(
+          'This source refused the refresh outright because it needs a credential. Send the token again below.',
+        ),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText(
+          'If the source is public now, re-import it through the Re-Upload dialog with no token to clear this requirement.',
+        ),
+      ).toBeInTheDocument();
+      expect(screen.queryByLabelText('Authentication method')).not.toBeInTheDocument();
+    });
+
+    it('sends the freshly typed token on retry after a WFS refusal', async () => {
+      mutateAsync
+        .mockRejectedValueOnce(serviceTokenRequiredError())
+        .mockResolvedValueOnce({
+          run_id: 'run-7',
+          job_id: 'job-7',
+          dataset_id: 'dataset-1',
+          origin_kind: 'service',
+          trigger: 'api',
+          status: 'pending',
+          message: 'Refresh queued from the stored source',
+        });
+      const user = userEvent.setup();
+      render(<SourceRefreshAction dataset={makeDataset({ source_format: 'wfs' })} watch={makeWatch()} />);
+
+      await openDialog(user);
+      await user.click(screen.getByRole('button', { name: 'Start refresh' }));
+      await screen.findByText(
+        'This source refused the refresh outright because it needs a credential. Send the token again below.',
+      );
+
+      await user.type(screen.getByLabelText('Access token (optional)'), 'fresh-bearer-token');
+      await user.click(screen.getByRole('button', { name: 'Start refresh' }));
+
+      await waitFor(() => {
+        expect(mutateAsync).toHaveBeenLastCalledWith({
+          datasetId: 'dataset-1',
+          token: 'fresh-bearer-token',
+        });
+      });
+    });
+
+    it('mints an ArcGIS token via sign-in, clears the password once it lands, and sends the token on retry', async () => {
+      mutateAsync
+        .mockRejectedValueOnce(serviceTokenRequiredError())
+        .mockResolvedValueOnce({
+          run_id: 'run-9',
+          job_id: 'job-9',
+          dataset_id: 'dataset-1',
+          origin_kind: 'service',
+          trigger: 'api',
+          status: 'pending',
+          message: 'Refresh queued from the stored source',
+        });
+      mockArcgisSignIn.mockResolvedValue({
+        token: 'minted-token-xyz',
+        expires_at: '2026-09-01T13:00:00Z',
+      });
+      const user = userEvent.setup();
+      render(
+        <SourceRefreshAction
+          dataset={makeDataset({ source_format: 'arcgis_featureserver' })}
+          watch={makeWatch()}
+        />,
+      );
+
+      await openDialog(user);
+      await user.click(screen.getByRole('button', { name: 'Start refresh' }));
+      const methodSelect = await screen.findByLabelText('Authentication method');
+      await user.selectOptions(methodSelect, 'signin');
+
+      await user.type(screen.getByLabelText('Portal URL'), 'https://myorg.maps.arcgis.com');
+      await user.type(screen.getByLabelText('Username'), 'alice');
+      await user.type(screen.getByLabelText('Password'), 'hunter2');
+      await user.click(screen.getByRole('button', { name: 'Sign in' }));
+
+      await screen.findByText('Signed in. The token below is ready to use.');
+      expect(mockArcgisSignIn).toHaveBeenCalledWith({
+        portal_url: 'https://myorg.maps.arcgis.com',
+        username: 'alice',
+        password: 'hunter2',
+      });
+      expect(screen.getByLabelText('Password')).toHaveValue('');
+
+      await user.click(screen.getByRole('button', { name: 'Start refresh' }));
+
+      await waitFor(() => {
+        expect(mutateAsync).toHaveBeenLastCalledWith({
+          datasetId: 'dataset-1',
+          token: 'minted-token-xyz',
+        });
+      });
+    });
+
+    it('maps a rejected ArcGIS sign-in to this component\'s own copy, never the raw response, and never auto-retries', async () => {
+      mutateAsync.mockRejectedValue(serviceTokenRequiredError());
+      mockArcgisSignIn.mockRejectedValue(
+        new ApiError('arcgis_signin_rejected', 400, { code: 'arcgis_signin_rejected', message: 'raw' }),
+      );
+      const user = userEvent.setup();
+      render(
+        <SourceRefreshAction
+          dataset={makeDataset({ source_format: 'arcgis_featureserver' })}
+          watch={makeWatch()}
+        />,
+      );
+
+      await openDialog(user);
+      await user.click(screen.getByRole('button', { name: 'Start refresh' }));
+      const methodSelect = await screen.findByLabelText('Authentication method');
+      await user.selectOptions(methodSelect, 'signin');
+      await user.type(screen.getByLabelText('Portal URL'), 'https://myorg.maps.arcgis.com');
+      await user.type(screen.getByLabelText('Username'), 'alice');
+      await user.type(screen.getByLabelText('Password'), 'wrong-password');
+      await user.click(screen.getByRole('button', { name: 'Sign in' }));
+
+      expect(
+        await screen.findByText(
+          'ArcGIS did not accept that sign-in. Check the username and password, including capitalization. Too many failed attempts also lock an ArcGIS account temporarily.',
+        ),
+      ).toBeInTheDocument();
+      // Exactly one attempt: nothing in this component retries a rejected
+      // sign-in automatically (plan 3.2 -- a retry loop can lock the
+      // customer's real ArcGIS account).
+      expect(mockArcgisSignIn).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/frontend/src/i18n/locales/de/common.json
+++ b/frontend/src/i18n/locales/de/common.json
@@ -184,6 +184,7 @@
     "arcgisSigninInProgress": "Für dieses Konto läuft bereits eine andere Anmeldung. Versuchen Sie es gleich noch einmal.",
     "arcgisPortalNotHttps": "Dieses Portal oder der von ihm angegebene Token-Dienst verwendet kein HTTPS. GeoLens sendet kein Passwort über unverschlüsseltes HTTP; verwenden Sie eine https://-Portal-URL.",
     "arcgisPortalHostInvalid": "Diese Portaladresse ist kein verwendbarer Hostname. Überprüfen Sie die URL, zum Beispiel https://ihre-org.maps.arcgis.com.",
+    "refreshServiceTokenRequired": "Die Quelle dieses Datensatzes benötigt eine Dienst-Anmeldeinformation zur Aktualisierung. Geben Sie unten eine an, um fortzufahren.",
     "refreshSourceUrlBlocked": "Die gespeicherte Quell-URL dieses Datensatzes hat eine Sicherheitsprüfung nicht bestanden und kann nicht automatisch aktualisiert werden. Wenden Sie sich an einen Administrator.",
     "unknownLayers": "Diese Layer wurden in der hochgeladenen Datei nicht gefunden: {{layers}}.",
     "sourceValidationCrsMismatch": "Das Koordinatenreferenzsystem der Quelle {{source}} stimmt nicht mit den anderen Quellen überein.",

--- a/frontend/src/i18n/locales/de/dataset.json
+++ b/frontend/src/i18n/locales/de/dataset.json
@@ -854,6 +854,7 @@
           "passwordLabel": "Passwort",
           "signInButton": "Anmelden",
           "signedIn": "Angemeldet. Das Token unten ist einsatzbereit.",
+          "tokenExpired": "Das Token ist abgelaufen. Melden Sie sich erneut an, um fortzufahren.",
           "errors": {
             "arcgisSigninRejected": "ArcGIS hat diese Anmeldung nicht akzeptiert. Prüfen Sie Benutzername und Passwort, einschließlich Groß- und Kleinschreibung. Zu viele fehlgeschlagene Versuche sperren zudem vorübergehend ein ArcGIS-Konto.",
             "arcgisSsoAccount": "Dieses Konto meldet sich über den Identitätsanbieter Ihrer Organisation an oder hat Multi-Faktor-Authentifizierung aktiviert. Die Anmeldung mit Benutzername und Passwort funktioniert hier nicht. Fügen Sie stattdessen ein Token oder einen API-Schlüssel ein.",

--- a/frontend/src/i18n/locales/de/dataset.json
+++ b/frontend/src/i18n/locales/de/dataset.json
@@ -860,7 +860,10 @@
             "arcgisSsoAccount": "Dieses Konto meldet sich über den Identitätsanbieter Ihrer Organisation an oder hat Multi-Faktor-Authentifizierung aktiviert. Die Anmeldung mit Benutzername und Passwort funktioniert hier nicht. Fügen Sie stattdessen ein Token oder einen API-Schlüssel ein.",
             "ssrfRefused": "GeoLens kann von hier aus kein Portal unter einer privaten Netzwerkadresse erreichen.",
             "networkError": "Das Portal konnte nicht erreicht werden. Prüfen Sie die URL und versuchen Sie es erneut.",
-            "rateLimited": "Zu viele Anmeldeversuche. Warten Sie einige Minuten und versuchen Sie es erneut."
+            "rateLimited": "Zu viele Anmeldeversuche. Warten Sie einige Minuten und versuchen Sie es erneut.",
+            "arcgisPortalNotHttps": "Die Portal-URL muss mit https beginnen. GeoLens sendet kein Passwort über eine unverschlüsselte Verbindung.",
+            "arcgisPortalHostInvalid": "Diese Portaladresse ist kein gültiger Hostname. Prüfen Sie die URL, zum Beispiel https://your-org.maps.arcgis.com.",
+            "arcgisSigninInProgress": "Für dieses ArcGIS-Konto läuft bereits eine Anmeldung. Warten Sie, bis sie abgeschlossen ist, und versuchen Sie es erneut."
           }
         },
         "wfs": {

--- a/frontend/src/i18n/locales/de/dataset.json
+++ b/frontend/src/i18n/locales/de/dataset.json
@@ -830,7 +830,7 @@
       "dialogDescription": "Die Daten dieses Datensatzes werden erneut von der ursprünglichen Importquelle abgerufen. Der Datensatz liefert weiterhin seine aktuellen Daten, bis die neuen Daten bereit sind.",
       "tokenLabel": "Zugriffstoken (optional)",
       "tokenPlaceholder": "Nur für eine geschützte Quelle erforderlich",
-      "tokenHint": "Wird einmalig für diese Aktualisierung verwendet und nie gespeichert.",
+      "tokenHint": "Wird nur für diese Aktualisierung verwendet; nicht mit dem Datensatz gespeichert.",
       "confirm": "Aktualisierung starten",
       "cancel": "Abbrechen",
       "cancelling": "Wird abgebrochen...",
@@ -838,6 +838,34 @@
       "toastAccepted": "Aktualisierung gestartet (Lauf {{runId}}).",
       "errors": {
         "unknown": "Aktualisierung fehlgeschlagen. Versuchen Sie es erneut."
+      },
+      "credential": {
+        "requiredTitle": "Diese Quelle benötigt eine Anmeldeinformation zur Aktualisierung.",
+        "arcgis": {
+          "methodLabel": "Authentifizierungsmethode",
+          "methodNone": "Keine Authentifizierung",
+          "methodToken": "Token oder API-Schlüssel einfügen",
+          "methodSignIn": "Mit Benutzername und Passwort anmelden",
+          "tokenLabel": "Token oder API-Schlüssel",
+          "tokenPlaceholder": "ArcGIS-Token oder API-Schlüssel einfügen",
+          "portalUrlLabel": "Portal-URL",
+          "portalUrlPlaceholder": "https://www.arcgis.com",
+          "usernameLabel": "Benutzername",
+          "passwordLabel": "Passwort",
+          "signInButton": "Anmelden",
+          "signedIn": "Angemeldet. Das Token unten ist einsatzbereit.",
+          "errors": {
+            "arcgisSigninRejected": "ArcGIS hat diese Anmeldung nicht akzeptiert. Prüfen Sie Benutzername und Passwort, einschließlich Groß- und Kleinschreibung. Zu viele fehlgeschlagene Versuche sperren zudem vorübergehend ein ArcGIS-Konto.",
+            "arcgisSsoAccount": "Dieses Konto meldet sich über den Identitätsanbieter Ihrer Organisation an oder hat Multi-Faktor-Authentifizierung aktiviert. Die Anmeldung mit Benutzername und Passwort funktioniert hier nicht. Fügen Sie stattdessen ein Token oder einen API-Schlüssel ein.",
+            "ssrfRefused": "GeoLens kann von hier aus kein Portal unter einer privaten Netzwerkadresse erreichen.",
+            "networkError": "Das Portal konnte nicht erreicht werden. Prüfen Sie die URL und versuchen Sie es erneut.",
+            "rateLimited": "Zu viele Anmeldeversuche. Warten Sie einige Minuten und versuchen Sie es erneut."
+          }
+        },
+        "wfs": {
+          "intro": "Diese Quelle hat die Aktualisierung rundweg abgelehnt, da sie eine Anmeldeinformation benötigt. Senden Sie das Token unten erneut.",
+          "escapeHatch": "Falls die Quelle inzwischen öffentlich ist, importieren Sie sie über den Dialog Erneut hochladen ohne Token neu, um diese Anforderung aufzuheben."
+        }
       },
       "history": {
         "title": "Aktualisierungsverlauf",

--- a/frontend/src/i18n/locales/de/dataset.json
+++ b/frontend/src/i18n/locales/de/dataset.json
@@ -853,7 +853,7 @@
           "usernameLabel": "Benutzername",
           "passwordLabel": "Passwort",
           "signInButton": "Anmelden",
-          "signedIn": "Angemeldet. Das Token unten ist einsatzbereit.",
+          "signedIn": "Angemeldet. Die Aktualisierung verwendet dieses Token.",
           "tokenExpired": "Das Token ist abgelaufen. Melden Sie sich erneut an, um fortzufahren."
         },
         "wfs": {

--- a/frontend/src/i18n/locales/de/dataset.json
+++ b/frontend/src/i18n/locales/de/dataset.json
@@ -854,17 +854,7 @@
           "passwordLabel": "Passwort",
           "signInButton": "Anmelden",
           "signedIn": "Angemeldet. Das Token unten ist einsatzbereit.",
-          "tokenExpired": "Das Token ist abgelaufen. Melden Sie sich erneut an, um fortzufahren.",
-          "errors": {
-            "arcgisSigninRejected": "ArcGIS hat diese Anmeldung nicht akzeptiert. Prüfen Sie Benutzername und Passwort, einschließlich Groß- und Kleinschreibung. Zu viele fehlgeschlagene Versuche sperren zudem vorübergehend ein ArcGIS-Konto.",
-            "arcgisSsoAccount": "Dieses Konto meldet sich über den Identitätsanbieter Ihrer Organisation an oder hat Multi-Faktor-Authentifizierung aktiviert. Die Anmeldung mit Benutzername und Passwort funktioniert hier nicht. Fügen Sie stattdessen ein Token oder einen API-Schlüssel ein.",
-            "ssrfRefused": "GeoLens kann von hier aus kein Portal unter einer privaten Netzwerkadresse erreichen.",
-            "networkError": "Das Portal konnte nicht erreicht werden. Prüfen Sie die URL und versuchen Sie es erneut.",
-            "rateLimited": "Zu viele Anmeldeversuche. Warten Sie einige Minuten und versuchen Sie es erneut.",
-            "arcgisPortalNotHttps": "Die Portal-URL muss mit https beginnen. GeoLens sendet kein Passwort über eine unverschlüsselte Verbindung.",
-            "arcgisPortalHostInvalid": "Diese Portaladresse ist kein gültiger Hostname. Prüfen Sie die URL, zum Beispiel https://your-org.maps.arcgis.com.",
-            "arcgisSigninInProgress": "Für dieses ArcGIS-Konto läuft bereits eine Anmeldung. Warten Sie, bis sie abgeschlossen ist, und versuchen Sie es erneut."
-          }
+          "tokenExpired": "Das Token ist abgelaufen. Melden Sie sich erneut an, um fortzufahren."
         },
         "wfs": {
           "intro": "Diese Quelle hat die Aktualisierung rundweg abgelehnt, da sie eine Anmeldeinformation benötigt. Senden Sie das Token unten erneut.",

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -309,6 +309,7 @@
     "arcgisSigninInProgress": "Another sign-in for this account is already running. Try again in a moment.",
     "arcgisPortalNotHttps": "This portal, or the token service it points to, doesn't use HTTPS. GeoLens won't send a password over plain HTTP; use an https:// portal URL.",
     "arcgisPortalHostInvalid": "That portal address isn't a usable hostname. Check the URL, for example https://your-org.maps.arcgis.com.",
+    "refreshServiceTokenRequired": "This dataset's source needs a service credential to refresh. Provide one below to continue.",
     "refreshSourceUrlBlocked": "This dataset's stored source URL failed a safety check and can't be refreshed automatically. Contact an administrator.",
     "unknownLayers": "These layers were not found in the uploaded file: {{layers}}.",
     "sourceValidationCrsMismatch": "Source {{source}}'s coordinate reference system doesn't match the other sources.",

--- a/frontend/src/i18n/locales/en/dataset.json
+++ b/frontend/src/i18n/locales/en/dataset.json
@@ -781,7 +781,7 @@
       "dialogDescription": "Re-pull this dataset's data from where it was originally imported. The dataset keeps serving its current data until the new data is ready.",
       "tokenLabel": "Access token (optional)",
       "tokenPlaceholder": "Only needed for a protected source",
-      "tokenHint": "Used once for this refresh and never stored.",
+      "tokenHint": "Used for this refresh only; not stored with the dataset.",
       "confirm": "Start refresh",
       "cancel": "Cancel",
       "cancelling": "Cancelling...",
@@ -789,6 +789,34 @@
       "toastAccepted": "Refresh started (run {{runId}}).",
       "errors": {
         "unknown": "Refresh failed. Try again."
+      },
+      "credential": {
+        "requiredTitle": "This source needs a credential to refresh.",
+        "arcgis": {
+          "methodLabel": "Authentication method",
+          "methodNone": "No authentication",
+          "methodToken": "Paste a token or API key",
+          "methodSignIn": "Sign in with username and password",
+          "tokenLabel": "Token or API key",
+          "tokenPlaceholder": "Paste an ArcGIS token or API key",
+          "portalUrlLabel": "Portal URL",
+          "portalUrlPlaceholder": "https://www.arcgis.com",
+          "usernameLabel": "Username",
+          "passwordLabel": "Password",
+          "signInButton": "Sign in",
+          "signedIn": "Signed in. The token below is ready to use.",
+          "errors": {
+            "arcgisSigninRejected": "ArcGIS did not accept that sign-in. Check the username and password, including capitalization. Too many failed attempts also lock an ArcGIS account temporarily.",
+            "arcgisSsoAccount": "This account signs in through your organization's identity provider, or has multifactor authentication turned on. Username and password sign-in will not work here. Paste a token or API key instead.",
+            "ssrfRefused": "GeoLens cannot reach a portal on a private network address from here.",
+            "networkError": "Could not reach the portal. Check the URL and try again.",
+            "rateLimited": "Too many sign-in attempts. Wait a few minutes, then try again."
+          }
+        },
+        "wfs": {
+          "intro": "This source refused the refresh outright because it needs a credential. Send the token again below.",
+          "escapeHatch": "If the source is public now, re-import it through the Re-Upload dialog with no token to clear this requirement."
+        }
       },
       "history": {
         "title": "Refresh history",

--- a/frontend/src/i18n/locales/en/dataset.json
+++ b/frontend/src/i18n/locales/en/dataset.json
@@ -811,7 +811,10 @@
             "arcgisSsoAccount": "This account signs in through your organization's identity provider, or has multifactor authentication turned on. Username and password sign-in will not work here. Paste a token or API key instead.",
             "ssrfRefused": "GeoLens cannot reach a portal on a private network address from here.",
             "networkError": "Could not reach the portal. Check the URL and try again.",
-            "rateLimited": "Too many sign-in attempts. Wait a few minutes, then try again."
+            "rateLimited": "Too many sign-in attempts. Wait a few minutes, then try again.",
+            "arcgisPortalNotHttps": "The portal URL must start with https. GeoLens will not send a password over an unencrypted connection.",
+            "arcgisPortalHostInvalid": "That portal address is not a usable hostname. Check the URL, for example https://your-org.maps.arcgis.com.",
+            "arcgisSigninInProgress": "A sign-in to that ArcGIS account is already in progress. Wait for it to finish, then try again."
           }
         },
         "wfs": {

--- a/frontend/src/i18n/locales/en/dataset.json
+++ b/frontend/src/i18n/locales/en/dataset.json
@@ -805,17 +805,7 @@
           "passwordLabel": "Password",
           "signInButton": "Sign in",
           "signedIn": "Signed in. The token below is ready to use.",
-          "tokenExpired": "The token expired. Sign in again to continue.",
-          "errors": {
-            "arcgisSigninRejected": "ArcGIS did not accept that sign-in. Check the username and password, including capitalization. Too many failed attempts also lock an ArcGIS account temporarily.",
-            "arcgisSsoAccount": "This account signs in through your organization's identity provider, or has multifactor authentication turned on. Username and password sign-in will not work here. Paste a token or API key instead.",
-            "ssrfRefused": "GeoLens cannot reach a portal on a private network address from here.",
-            "networkError": "Could not reach the portal. Check the URL and try again.",
-            "rateLimited": "Too many sign-in attempts. Wait a few minutes, then try again.",
-            "arcgisPortalNotHttps": "The portal URL must start with https. GeoLens will not send a password over an unencrypted connection.",
-            "arcgisPortalHostInvalid": "That portal address is not a usable hostname. Check the URL, for example https://your-org.maps.arcgis.com.",
-            "arcgisSigninInProgress": "A sign-in to that ArcGIS account is already in progress. Wait for it to finish, then try again."
-          }
+          "tokenExpired": "The token expired. Sign in again to continue."
         },
         "wfs": {
           "intro": "This source refused the refresh outright because it needs a credential. Send the token again below.",

--- a/frontend/src/i18n/locales/en/dataset.json
+++ b/frontend/src/i18n/locales/en/dataset.json
@@ -804,7 +804,7 @@
           "usernameLabel": "Username",
           "passwordLabel": "Password",
           "signInButton": "Sign in",
-          "signedIn": "Signed in. The token below is ready to use.",
+          "signedIn": "Signed in. The refresh will use this token.",
           "tokenExpired": "The token expired. Sign in again to continue."
         },
         "wfs": {

--- a/frontend/src/i18n/locales/en/dataset.json
+++ b/frontend/src/i18n/locales/en/dataset.json
@@ -805,6 +805,7 @@
           "passwordLabel": "Password",
           "signInButton": "Sign in",
           "signedIn": "Signed in. The token below is ready to use.",
+          "tokenExpired": "The token expired. Sign in again to continue.",
           "errors": {
             "arcgisSigninRejected": "ArcGIS did not accept that sign-in. Check the username and password, including capitalization. Too many failed attempts also lock an ArcGIS account temporarily.",
             "arcgisSsoAccount": "This account signs in through your organization's identity provider, or has multifactor authentication turned on. Username and password sign-in will not work here. Paste a token or API key instead.",

--- a/frontend/src/i18n/locales/es/common.json
+++ b/frontend/src/i18n/locales/es/common.json
@@ -184,6 +184,7 @@
     "arcgisSigninInProgress": "Ya hay otro inicio de sesión en curso para esta cuenta. Vuelva a intentarlo en un momento.",
     "arcgisPortalNotHttps": "Este portal, o el servicio de tokens al que apunta, no usa HTTPS. GeoLens no enviará una contraseña por HTTP sin cifrar; use una URL de portal https://.",
     "arcgisPortalHostInvalid": "Esa dirección de portal no es un nombre de host utilizable. Verifique la URL, por ejemplo https://tu-org.maps.arcgis.com.",
+    "refreshServiceTokenRequired": "La fuente de este conjunto de datos necesita una credencial de servicio para actualizarse. Proporciona una a continuación para continuar.",
     "refreshSourceUrlBlocked": "La URL de origen almacenada de este conjunto de datos no superó una comprobación de seguridad y no se puede actualizar automáticamente. Contacta con un administrador.",
     "unknownLayers": "No se encontraron estas capas en el archivo subido: {{layers}}.",
     "sourceValidationCrsMismatch": "El sistema de referencia de coordenadas de la fuente {{source}} no coincide con las demás fuentes.",

--- a/frontend/src/i18n/locales/es/dataset.json
+++ b/frontend/src/i18n/locales/es/dataset.json
@@ -853,7 +853,7 @@
           "usernameLabel": "Usuario",
           "passwordLabel": "Contraseña",
           "signInButton": "Iniciar sesión",
-          "signedIn": "Sesión iniciada. El token de abajo ya está listo para usarse.",
+          "signedIn": "Sesión iniciada. La actualización usará este token.",
           "tokenExpired": "El token expiró. Inicia sesión de nuevo para continuar."
         },
         "wfs": {

--- a/frontend/src/i18n/locales/es/dataset.json
+++ b/frontend/src/i18n/locales/es/dataset.json
@@ -860,7 +860,10 @@
             "arcgisSsoAccount": "Esta cuenta inicia sesión mediante el proveedor de identidad de tu organización, o tiene activada la autenticación multifactor. El inicio de sesión con usuario y contraseña no funcionará aquí. Pega un token o clave de API en su lugar.",
             "ssrfRefused": "GeoLens no puede alcanzar un portal en una dirección de red privada desde aquí.",
             "networkError": "No se pudo contactar con el portal. Comprueba la URL e inténtalo de nuevo.",
-            "rateLimited": "Demasiados intentos de inicio de sesión. Espera unos minutos e inténtalo de nuevo."
+            "rateLimited": "Demasiados intentos de inicio de sesión. Espera unos minutos e inténtalo de nuevo.",
+            "arcgisPortalNotHttps": "La URL del portal debe empezar por https. GeoLens no enviará una contraseña por una conexión sin cifrar.",
+            "arcgisPortalHostInvalid": "Esa dirección de portal no es un nombre de host válido. Comprueba la URL, por ejemplo https://your-org.maps.arcgis.com.",
+            "arcgisSigninInProgress": "Ya hay un inicio de sesión en curso para esa cuenta de ArcGIS. Espera a que termine e inténtalo de nuevo."
           }
         },
         "wfs": {

--- a/frontend/src/i18n/locales/es/dataset.json
+++ b/frontend/src/i18n/locales/es/dataset.json
@@ -854,6 +854,7 @@
           "passwordLabel": "Contraseña",
           "signInButton": "Iniciar sesión",
           "signedIn": "Sesión iniciada. El token de abajo ya está listo para usarse.",
+          "tokenExpired": "El token expiró. Inicia sesión de nuevo para continuar.",
           "errors": {
             "arcgisSigninRejected": "ArcGIS no aceptó ese inicio de sesión. Comprueba el usuario y la contraseña, incluidas las mayúsculas. Demasiados intentos fallidos también bloquean temporalmente una cuenta de ArcGIS.",
             "arcgisSsoAccount": "Esta cuenta inicia sesión mediante el proveedor de identidad de tu organización, o tiene activada la autenticación multifactor. El inicio de sesión con usuario y contraseña no funcionará aquí. Pega un token o clave de API en su lugar.",

--- a/frontend/src/i18n/locales/es/dataset.json
+++ b/frontend/src/i18n/locales/es/dataset.json
@@ -830,7 +830,7 @@
       "dialogDescription": "Vuelve a extraer los datos de este conjunto desde donde se importaron originalmente. El conjunto de datos sigue sirviendo sus datos actuales hasta que los nuevos estén listos.",
       "tokenLabel": "Token de acceso (opcional)",
       "tokenPlaceholder": "Solo necesario para una fuente protegida",
-      "tokenHint": "Se usa una sola vez para esta actualización y nunca se almacena.",
+      "tokenHint": "Se usa solo para esta actualización; no se almacena con el conjunto de datos.",
       "confirm": "Iniciar actualización",
       "cancel": "Cancelar",
       "cancelling": "Cancelando...",
@@ -838,6 +838,34 @@
       "toastAccepted": "Actualización iniciada (ejecución {{runId}}).",
       "errors": {
         "unknown": "La actualización falló. Inténtalo de nuevo."
+      },
+      "credential": {
+        "requiredTitle": "Esta fuente necesita una credencial para actualizarse.",
+        "arcgis": {
+          "methodLabel": "Método de autenticación",
+          "methodNone": "Sin autenticación",
+          "methodToken": "Pegar un token o clave de API",
+          "methodSignIn": "Iniciar sesión con usuario y contraseña",
+          "tokenLabel": "Token o clave de API",
+          "tokenPlaceholder": "Pega un token o clave de API de ArcGIS",
+          "portalUrlLabel": "URL del portal",
+          "portalUrlPlaceholder": "https://www.arcgis.com",
+          "usernameLabel": "Usuario",
+          "passwordLabel": "Contraseña",
+          "signInButton": "Iniciar sesión",
+          "signedIn": "Sesión iniciada. El token de abajo ya está listo para usarse.",
+          "errors": {
+            "arcgisSigninRejected": "ArcGIS no aceptó ese inicio de sesión. Comprueba el usuario y la contraseña, incluidas las mayúsculas. Demasiados intentos fallidos también bloquean temporalmente una cuenta de ArcGIS.",
+            "arcgisSsoAccount": "Esta cuenta inicia sesión mediante el proveedor de identidad de tu organización, o tiene activada la autenticación multifactor. El inicio de sesión con usuario y contraseña no funcionará aquí. Pega un token o clave de API en su lugar.",
+            "ssrfRefused": "GeoLens no puede alcanzar un portal en una dirección de red privada desde aquí.",
+            "networkError": "No se pudo contactar con el portal. Comprueba la URL e inténtalo de nuevo.",
+            "rateLimited": "Demasiados intentos de inicio de sesión. Espera unos minutos e inténtalo de nuevo."
+          }
+        },
+        "wfs": {
+          "intro": "Esta fuente rechazó la actualización sin condiciones porque necesita una credencial. Vuelve a enviar el token abajo.",
+          "escapeHatch": "Si la fuente ya es pública, vuelve a importarla desde el cuadro de diálogo Volver a subir sin token para eliminar este requisito."
+        }
       },
       "history": {
         "title": "Historial de actualizaciones",

--- a/frontend/src/i18n/locales/es/dataset.json
+++ b/frontend/src/i18n/locales/es/dataset.json
@@ -854,17 +854,7 @@
           "passwordLabel": "Contraseña",
           "signInButton": "Iniciar sesión",
           "signedIn": "Sesión iniciada. El token de abajo ya está listo para usarse.",
-          "tokenExpired": "El token expiró. Inicia sesión de nuevo para continuar.",
-          "errors": {
-            "arcgisSigninRejected": "ArcGIS no aceptó ese inicio de sesión. Comprueba el usuario y la contraseña, incluidas las mayúsculas. Demasiados intentos fallidos también bloquean temporalmente una cuenta de ArcGIS.",
-            "arcgisSsoAccount": "Esta cuenta inicia sesión mediante el proveedor de identidad de tu organización, o tiene activada la autenticación multifactor. El inicio de sesión con usuario y contraseña no funcionará aquí. Pega un token o clave de API en su lugar.",
-            "ssrfRefused": "GeoLens no puede alcanzar un portal en una dirección de red privada desde aquí.",
-            "networkError": "No se pudo contactar con el portal. Comprueba la URL e inténtalo de nuevo.",
-            "rateLimited": "Demasiados intentos de inicio de sesión. Espera unos minutos e inténtalo de nuevo.",
-            "arcgisPortalNotHttps": "La URL del portal debe empezar por https. GeoLens no enviará una contraseña por una conexión sin cifrar.",
-            "arcgisPortalHostInvalid": "Esa dirección de portal no es un nombre de host válido. Comprueba la URL, por ejemplo https://your-org.maps.arcgis.com.",
-            "arcgisSigninInProgress": "Ya hay un inicio de sesión en curso para esa cuenta de ArcGIS. Espera a que termine e inténtalo de nuevo."
-          }
+          "tokenExpired": "El token expiró. Inicia sesión de nuevo para continuar."
         },
         "wfs": {
           "intro": "Esta fuente rechazó la actualización sin condiciones porque necesita una credencial. Vuelve a enviar el token abajo.",

--- a/frontend/src/i18n/locales/fr/common.json
+++ b/frontend/src/i18n/locales/fr/common.json
@@ -184,6 +184,7 @@
     "arcgisSigninInProgress": "Une autre connexion pour ce compte est déjà en cours. Réessayez dans un instant.",
     "arcgisPortalNotHttps": "Ce portail, ou le service de jetons qu'il indique, n'utilise pas HTTPS. GeoLens n'enverra pas de mot de passe en HTTP non chiffré ; utilisez une URL de portail en https://.",
     "arcgisPortalHostInvalid": "Cette adresse de portail n'est pas un nom d'hôte utilisable. Vérifiez l'URL, par exemple https://votre-org.maps.arcgis.com.",
+    "refreshServiceTokenRequired": "La source de ce jeu de données nécessite un identifiant de service pour être actualisée. Fournissez-en un ci-dessous pour continuer.",
     "refreshSourceUrlBlocked": "L'URL source enregistrée de ce jeu de données a échoué à un contrôle de sécurité et ne peut pas être actualisée automatiquement. Contactez un administrateur.",
     "unknownLayers": "Ces couches sont introuvables dans le fichier importé : {{layers}}.",
     "sourceValidationCrsMismatch": "Le système de référence de coordonnées de la source {{source}} ne correspond pas aux autres sources.",

--- a/frontend/src/i18n/locales/fr/dataset.json
+++ b/frontend/src/i18n/locales/fr/dataset.json
@@ -860,7 +860,10 @@
             "arcgisSsoAccount": "Ce compte se connecte via le fournisseur d'identité de votre organisation, ou a l'authentification multifacteur activée. La connexion par identifiant et mot de passe ne fonctionnera pas ici. Collez plutôt un jeton ou une clé API.",
             "ssrfRefused": "GeoLens ne peut pas atteindre un portail sur une adresse réseau privée depuis ici.",
             "networkError": "Impossible de joindre le portail. Vérifiez l'URL et réessayez.",
-            "rateLimited": "Trop de tentatives de connexion. Attendez quelques minutes, puis réessayez."
+            "rateLimited": "Trop de tentatives de connexion. Attendez quelques minutes, puis réessayez.",
+            "arcgisPortalNotHttps": "L'URL du portail doit commencer par https. GeoLens n'enverra pas de mot de passe sur une connexion non chiffrée.",
+            "arcgisPortalHostInvalid": "Cette adresse de portail n'est pas un nom d'hôte valide. Vérifiez l'URL, par exemple https://your-org.maps.arcgis.com.",
+            "arcgisSigninInProgress": "Une connexion à ce compte ArcGIS est déjà en cours. Attendez qu'elle se termine, puis réessayez."
           }
         },
         "wfs": {

--- a/frontend/src/i18n/locales/fr/dataset.json
+++ b/frontend/src/i18n/locales/fr/dataset.json
@@ -854,6 +854,7 @@
           "passwordLabel": "Mot de passe",
           "signInButton": "Se connecter",
           "signedIn": "Connecté. Le jeton ci-dessous est prêt à l'emploi.",
+          "tokenExpired": "Le jeton a expiré. Reconnectez-vous pour continuer.",
           "errors": {
             "arcgisSigninRejected": "ArcGIS n'a pas accepté cette connexion. Vérifiez l'identifiant et le mot de passe, y compris la casse. Trop de tentatives échouées verrouillent aussi temporairement un compte ArcGIS.",
             "arcgisSsoAccount": "Ce compte se connecte via le fournisseur d'identité de votre organisation, ou a l'authentification multifacteur activée. La connexion par identifiant et mot de passe ne fonctionnera pas ici. Collez plutôt un jeton ou une clé API.",

--- a/frontend/src/i18n/locales/fr/dataset.json
+++ b/frontend/src/i18n/locales/fr/dataset.json
@@ -853,7 +853,7 @@
           "usernameLabel": "Identifiant",
           "passwordLabel": "Mot de passe",
           "signInButton": "Se connecter",
-          "signedIn": "Connecté. Le jeton ci-dessous est prêt à l'emploi.",
+          "signedIn": "Connecté. L'actualisation utilisera ce jeton.",
           "tokenExpired": "Le jeton a expiré. Reconnectez-vous pour continuer."
         },
         "wfs": {

--- a/frontend/src/i18n/locales/fr/dataset.json
+++ b/frontend/src/i18n/locales/fr/dataset.json
@@ -830,7 +830,7 @@
       "dialogDescription": "Récupère à nouveau les données de ce jeu de données depuis son origine d'importation. Le jeu de données continue de servir ses données actuelles jusqu'à ce que les nouvelles soient prêtes.",
       "tokenLabel": "Jeton d'accès (facultatif)",
       "tokenPlaceholder": "Nécessaire uniquement pour une source protégée",
-      "tokenHint": "Utilisé une seule fois pour cette actualisation et jamais stocké.",
+      "tokenHint": "Utilisé uniquement pour cette actualisation ; non stocké avec le jeu de données.",
       "confirm": "Démarrer l'actualisation",
       "cancel": "Annuler",
       "cancelling": "Annulation...",
@@ -838,6 +838,34 @@
       "toastAccepted": "Actualisation démarrée (exécution {{runId}}).",
       "errors": {
         "unknown": "L'actualisation a échoué. Réessayez."
+      },
+      "credential": {
+        "requiredTitle": "Cette source nécessite un identifiant pour être actualisée.",
+        "arcgis": {
+          "methodLabel": "Méthode d'authentification",
+          "methodNone": "Aucune authentification",
+          "methodToken": "Coller un jeton ou une clé API",
+          "methodSignIn": "Se connecter avec un identifiant et un mot de passe",
+          "tokenLabel": "Jeton ou clé API",
+          "tokenPlaceholder": "Collez un jeton ou une clé API ArcGIS",
+          "portalUrlLabel": "URL du portail",
+          "portalUrlPlaceholder": "https://www.arcgis.com",
+          "usernameLabel": "Identifiant",
+          "passwordLabel": "Mot de passe",
+          "signInButton": "Se connecter",
+          "signedIn": "Connecté. Le jeton ci-dessous est prêt à l'emploi.",
+          "errors": {
+            "arcgisSigninRejected": "ArcGIS n'a pas accepté cette connexion. Vérifiez l'identifiant et le mot de passe, y compris la casse. Trop de tentatives échouées verrouillent aussi temporairement un compte ArcGIS.",
+            "arcgisSsoAccount": "Ce compte se connecte via le fournisseur d'identité de votre organisation, ou a l'authentification multifacteur activée. La connexion par identifiant et mot de passe ne fonctionnera pas ici. Collez plutôt un jeton ou une clé API.",
+            "ssrfRefused": "GeoLens ne peut pas atteindre un portail sur une adresse réseau privée depuis ici.",
+            "networkError": "Impossible de joindre le portail. Vérifiez l'URL et réessayez.",
+            "rateLimited": "Trop de tentatives de connexion. Attendez quelques minutes, puis réessayez."
+          }
+        },
+        "wfs": {
+          "intro": "Cette source a refusé l'actualisation sans condition car elle nécessite un identifiant. Renvoyez le jeton ci-dessous.",
+          "escapeHatch": "Si la source est désormais publique, réimportez-la depuis la fenêtre Recharger sans jeton pour lever cette exigence."
+        }
       },
       "history": {
         "title": "Historique des actualisations",

--- a/frontend/src/i18n/locales/fr/dataset.json
+++ b/frontend/src/i18n/locales/fr/dataset.json
@@ -854,17 +854,7 @@
           "passwordLabel": "Mot de passe",
           "signInButton": "Se connecter",
           "signedIn": "Connecté. Le jeton ci-dessous est prêt à l'emploi.",
-          "tokenExpired": "Le jeton a expiré. Reconnectez-vous pour continuer.",
-          "errors": {
-            "arcgisSigninRejected": "ArcGIS n'a pas accepté cette connexion. Vérifiez l'identifiant et le mot de passe, y compris la casse. Trop de tentatives échouées verrouillent aussi temporairement un compte ArcGIS.",
-            "arcgisSsoAccount": "Ce compte se connecte via le fournisseur d'identité de votre organisation, ou a l'authentification multifacteur activée. La connexion par identifiant et mot de passe ne fonctionnera pas ici. Collez plutôt un jeton ou une clé API.",
-            "ssrfRefused": "GeoLens ne peut pas atteindre un portail sur une adresse réseau privée depuis ici.",
-            "networkError": "Impossible de joindre le portail. Vérifiez l'URL et réessayez.",
-            "rateLimited": "Trop de tentatives de connexion. Attendez quelques minutes, puis réessayez.",
-            "arcgisPortalNotHttps": "L'URL du portail doit commencer par https. GeoLens n'enverra pas de mot de passe sur une connexion non chiffrée.",
-            "arcgisPortalHostInvalid": "Cette adresse de portail n'est pas un nom d'hôte valide. Vérifiez l'URL, par exemple https://your-org.maps.arcgis.com.",
-            "arcgisSigninInProgress": "Une connexion à ce compte ArcGIS est déjà en cours. Attendez qu'elle se termine, puis réessayez."
-          }
+          "tokenExpired": "Le jeton a expiré. Reconnectez-vous pour continuer."
         },
         "wfs": {
           "intro": "Cette source a refusé l'actualisation sans condition car elle nécessite un identifiant. Renvoyez le jeton ci-dessous.",

--- a/frontend/src/i18n/resources.test.ts
+++ b/frontend/src/i18n/resources.test.ts
@@ -87,6 +87,7 @@ const IDENTICAL_ACROSS_LOCALES = new Set([
   'dataset:schema.columnNamePlaceholder', // column_name
   'import:urlImport.placeholder', // https://data.source.coop/…/buildings.parquet
   'import:urlImport.filenamePlaceholder', // buildings.parquet
+  'dataset:sourcePanel.refresh.credential.arcgis.portalUrlPlaceholder', // https://www.arcgis.com
 ]);
 
 const translatedLngs = supportedLngs.filter((lng) => lng !== fallbackLng);

--- a/frontend/src/lib/error-map.ts
+++ b/frontend/src/lib/error-map.ts
@@ -503,6 +503,20 @@ export function classifyApiError(detail: unknown, status = 0): ApiErrorDescripto
         values: { layers: value.unknown_layers.map(String).join(', ') },
       };
     }
+
+    // --- Lane A3 (service-auth wave, #1755 item 4): appended as its own
+    // block, ahead of the generic string-message fallback below rather than
+    // interleaved with the codes above, so this merges cleanly onto lane
+    // A2's changes elsewhere in this function. `service_token_required`'s
+    // body carries an English diagnostic sentence aimed at an API client;
+    // `SourceRefreshAction.tsx` intercepts the code before this module ever
+    // sees it and renders its own inline credential prompt instead, but this
+    // entry keeps the mapping correct for any other caller of
+    // `classifyApiError` that reaches this code without that special case.
+    if (value.code === 'service_token_required') {
+      return { key: 'errors.refreshServiceTokenRequired' };
+    }
+
     if (typeof value.message === 'string') {
       return descriptorForMessage(value.message, status);
     }


### PR DESCRIPTION
What changed

POST /datasets/{id}/refresh already refuses a token-less refresh of a marked service origin with 422 service_token_required (#1754), but SourceRefreshAction rendered that refusal as a generic error and gave the user nothing to act on. It now keeps the dialog open on that specific code and reveals a credential prompt keyed to the token field.

For an ArcGIS origin (source_format arcgis_featureserver), the prompt is a None / Token / Sign in with username and password select. Sign in calls a new local arcgisSignIn client against POST /api/services/arcgis/signin/, built against lane A1's contract (portal_url, username, password in; token, expires_at out). The password clears from state as soon as the token lands.

For WFS and OGC API Features origins, the prompt keeps the existing bearer token field and adds copy explaining the refusal was unconditional (no probe, unlike ArcGIS) and that a token-less re-upload clears the marker. This matches plan section 3.7's requirement that the two families read differently.

This absorbs #1755 items 4 and 6. While the dataset.json file was open for item 6, I also softened the refresh dialog's token hint from "used once ... and never stored" to "used for this refresh only; not stored with the dataset" per #1755 item 12 (a crashed worker can leave a failed job's arguments readable until the sweep runs, so the unqualified promise isn't accurate).

lib/error-map.ts gets one new mapping, for service_token_required, added as its own block at the end of classifyApiError's object branch so it rebases cleanly onto lane A2's changes to the rest of that file. The component itself never renders the 422's raw message; it always renders its own copy.

Convergence note

Lane A2 (PR #1757) ships an equivalent three-way method select for the import wizard, plus an arcgisSignin client in api/ingest.ts and hand-typed types in types/api.ts. Neither existed on this branch when I started, so ArcgisCredentialBlock.tsx and api/arcgis-signin.ts are independent, minimal copies built against the same documented contract rather than a fork or an import of A2's branch. A2 also maps arcgis_signin_rejected, arcgis_sso_account, ssrf_refused and network_error in error-map.ts against the common namespace; this component resolves the same codes locally under the dataset namespace instead, since there was no shared component to route through yet. A2 and A3 should converge on one component and one copy source in a follow-up once both are on main.

Schema and API impact

None. No backend files changed, no request or response schema changed. The only new network call this lane adds (arcgisSignIn) is a client-side function calling an endpoint that lane A1 owns; it doesn't touch OpenAPI, SDKs, or generated types.

i18n

New t() keys added to all four locales (en/es/fr/de): sourcePanel.refresh.credential.* in dataset.json, and errors.refreshServiceTokenRequired in common.json. Also added dataset:sourcePanel.refresh.credential.arcgis.portalUrlPlaceholder to the IDENTICAL_ACROSS_LOCALES allowlist in resources.test.ts, since it's a literal URL example rather than translatable prose.

Verification run

cd frontend && npm run typecheck: pass
cd frontend && npm run lint: pass
cd frontend && npm run test:i18n: pass (4 tests)
cd frontend && npx vitest run src/components/dataset/__tests__/SourceRefreshAction.test.tsx: 24 passed, including the family-distinct copy, dialog-stays-open, retry-sends-token, and password-cleared-after-mint cases
Playwright: started Vite on :5174 with API_PROXY_TARGET=http://localhost:8001, then E2E_ALLOW_WORKTREE=1 E2E_BASE_URL=http://localhost:5174 npx playwright test e2e/dataset-refresh-credentials.spec.ts --project=chromium: 5 passed (auth setup, cleanup, and 3 spec tests). This exercises this worktree's frontend against main's API; it says nothing about backend code, since lane A1's endpoint doesn't exist on main yet and is mocked with page.route in the spec.

Left alone

The 422 body's field name (token vs a nested auth object) is unchanged in this lane; Basic and header API keys for WFS/OGC API Features are lane B2b/B4 scope per the plan, not this one.
The dialog does not remember which method worked across a retry, matching plan 3.7's explicit acceptance that dataset_origin.py's allowlist stays narrow in Phase 1.
