### PR TITLE
fix(stores): clear drawing and search state on identity change

### DIFF
--- a/frontend/src/components/dataset/DatasetMap.tsx
+++ b/frontend/src/components/dataset/DatasetMap.tsx
@@ -263,6 +263,7 @@ export const DatasetMap = memo(function DatasetMap({
   const setMode = useDrawingStore((s) => s.setMode);
   const clearDrawing = useDrawingStore((s) => s.clearDrawing);
   const selectedFeature = useDrawingStore((s) => s.selectedFeature);
+  const sessionEpoch = useDrawingStore((s) => s.sessionEpoch);
 
   // Editable columns (non-system) for the attribute form
   const editableColumns = useMemo(
@@ -816,6 +817,24 @@ export const DatasetMap = memo(function DatasetMap({
     setEditingAttributes(false);
     clearDrawing();
   }, [clear, clearDrawing, performDeselect, tdSetMode]);
+
+  // fix(#1761 review round 3 P1): the identity-change choke point
+  // (lib/auth-cache-reset.ts) only resets Zustand state — clearDrawing()
+  // there has no way to reach Terra Draw's locally-drawn geometry,
+  // MapLibre's hidden-tile filters, or this component's own dialog state
+  // (pendingGeometry/editingAttributes), all of which only
+  // finishDrawingSession knows how to tear down. Run it whenever the
+  // session epoch moves so the previous identity's sketch, hidden tiles and
+  // open dialogs are gone for whoever is signed in (or anonymous) next.
+  // Skipped on mount: the epoch hasn't "changed" yet at that point, and
+  // running finishDrawingSession then would spuriously reset a session
+  // someone is legitimately resuming after a route change.
+  const sessionEpochRef = useRef(sessionEpoch);
+  useEffect(() => {
+    if (sessionEpochRef.current === sessionEpoch) return;
+    sessionEpochRef.current = sessionEpoch;
+    finishDrawingSession();
+  }, [sessionEpoch, finishDrawingSession]);
 
   // Handle close / stop drawing
   const handleCloseDrawing = useCallback(() => {

--- a/frontend/src/components/dataset/DatasetMap.tsx
+++ b/frontend/src/components/dataset/DatasetMap.tsx
@@ -315,6 +315,7 @@ export const DatasetMap = memo(function DatasetMap({
     handleEditAttributeSubmit,
     selectFeatureFromMap,
     cleanupOverlayListener,
+    resetOverlay,
   } = useFeatureEditing({
     mapRef,
     datasetId,
@@ -815,8 +816,24 @@ export const DatasetMap = memo(function DatasetMap({
     tdSetMode('select');
     setPendingGeometry(null);
     setEditingAttributes(false);
+    // fix(#1761 review round 4, sweep): the delete/discard confirmation
+    // dialogs are the same class as pendingGeometry/editingAttributes —
+    // both reference a selectedFeature that just got cleared above.
+    // Left open, "Delete" degrades to a no-op (handleDeleteFeature's own
+    // guard refuses without a selectedFeature) rather than anything
+    // unsafe, but a dangling confirmation for content that no longer
+    // exists is exactly the dialog-survives-the-clear bug this effect
+    // exists to close.
+    setDeleteConfirmOpen(false);
+    setDiscardConfirmOpen(false);
+    discardActionRef.current = null;
+    // fix(#1761 review round 4): a create in progress (saveAndRefresh) may
+    // have put a not-yet-committed shape in the overlay ref/source. Empty
+    // both here too, or a later identity change or ordinary session close
+    // leaves it visible to whoever looks at the map next.
+    resetOverlay();
     clearDrawing();
-  }, [clear, clearDrawing, performDeselect, tdSetMode]);
+  }, [clear, clearDrawing, performDeselect, resetOverlay, tdSetMode]);
 
   // fix(#1761 review round 3 P1): the identity-change choke point
   // (lib/auth-cache-reset.ts) only resets Zustand state — clearDrawing()
@@ -1073,8 +1090,12 @@ export const DatasetMap = memo(function DatasetMap({
         }}
         columns={columnInfo ?? []}
         onSubmit={async (properties) => {
-          await handleEditAttributeSubmit(properties);
-          setEditingAttributes(false);
+          // fix(#1761 review round 4): only close on `applied` — a
+          // stale-epoch result means a second identity may have this
+          // dialog open for their own feature, and unconditionally
+          // closing it here would discard that in-progress edit.
+          const { applied } = await handleEditAttributeSubmit(properties);
+          if (applied) setEditingAttributes(false);
         }}
         onCancel={() => setEditingAttributes(false)}
         initialValues={selectedFeature?.properties}

--- a/frontend/src/components/dataset/__tests__/DatasetMap.test.tsx
+++ b/frontend/src/components/dataset/__tests__/DatasetMap.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent } from '@/test/test-utils';
+import { render, screen, fireEvent, act } from '@/test/test-utils';
 import { DatasetMap } from '@/components/dataset/DatasetMap';
 
 // fix(#1004): what the map was actually told to draw and where to point. The
@@ -131,9 +131,13 @@ vi.mock('@/components/drawing/hooks/use-terra-draw', () => ({
 
 import { getAvailableModes } from '@/components/drawing/hooks/use-terra-draw';
 
+// fix(#1761 review round 4): a stable hoisted mutateAsync (not a fresh
+// vi.fn() per render) so a test can control WHEN the update mutation
+// resolves, to simulate an identity change while it is in flight.
+const updateFeatureMutateAsync = vi.hoisted(() => vi.fn().mockResolvedValue({}));
 vi.mock('@/hooks/use-features', () => ({
   useCreateFeature: () => ({ mutateAsync: vi.fn() }),
-  useUpdateFeature: () => ({ mutateAsync: vi.fn() }),
+  useUpdateFeature: () => ({ mutateAsync: updateFeatureMutateAsync }),
   useDeleteFeature: () => ({ mutateAsync: vi.fn() }),
 }));
 
@@ -632,6 +636,12 @@ describe('DatasetMap antimeridian extent (fix #1004)', () => {
 // (a sessionEpoch bump) drives that cleanup even though nothing in the
 // choke point itself knows this component exists.
 describe('DatasetMap identity-change cleanup (fix #1761 review round 3 P1)', () => {
+  // fix(#1761 review round 4): spy-able 'drawn-overlay' source, so the
+  // "tears down..." test below can also assert resetOverlay() actually
+  // reaches the map (not just that finishDrawingSession's OTHER cleanup
+  // steps ran).
+  let overlaySetData: ReturnType<typeof vi.fn>;
+
   beforeEach(() => {
     drawingState.isDrawing = true;
     drawingState.activeMode = 'select';
@@ -652,6 +662,10 @@ describe('DatasetMap identity-change cleanup (fix #1761 review round 3 P1)', () 
       removeEventListener: vi.fn(),
       getBoundingClientRect: () => ({ left: 0, top: 0 }),
     });
+    overlaySetData = vi.fn();
+    (fakeMap.getSource as ReturnType<typeof vi.fn>).mockImplementation((id: string) =>
+      id === 'drawn-overlay' ? { setData: overlaySetData } : undefined,
+    );
   });
 
   it('does not run the cleanup on mount', () => {
@@ -704,6 +718,85 @@ describe('DatasetMap identity-change cleanup (fix #1761 review round 3 P1)', () 
     expect(terraDrawState.clear).toHaveBeenCalled();
     expect(showAllFeaturesInTilesMock).toHaveBeenCalled();
     expect(drawingState.clearDrawing).toHaveBeenCalled();
+    expect(screen.queryByText('Edit Feature Attributes')).not.toBeInTheDocument();
+    // fix(#1761 review round 4): a create in progress can leave a
+    // not-yet-committed shape in the drawn-overlay source; the
+    // identity-change cleanup must empty it too.
+    expect(overlaySetData).toHaveBeenCalledWith({ type: 'FeatureCollection', features: [] });
+  });
+});
+
+// fix(#1761 review round 4): the attribute-edit dialog's onSubmit used to
+// close unconditionally once handleEditAttributeSubmit resolved, even when
+// its own epoch check had refused the write as stale — discarding a SECOND
+// identity's own now-open editor for their feature.
+describe('DatasetMap attribute-edit dialog respects handleEditAttributeSubmit result (fix #1761 review round 4)', () => {
+  beforeEach(() => {
+    drawingState.isDrawing = true;
+    drawingState.activeMode = 'select';
+    drawingState.selectedFeature = { gid: 42, tdId: 'td-1', properties: {} };
+    drawingState.isEditDirty = false;
+    drawingState.sessionEpoch = 300;
+    updateFeatureMutateAsync.mockReset();
+  });
+
+  it('keeps the dialog open when the identity changed while the update was in flight', async () => {
+    let resolveUpdate!: (value: unknown) => void;
+    updateFeatureMutateAsync.mockReturnValueOnce(
+      new Promise((res) => {
+        resolveUpdate = res;
+      }),
+    );
+
+    render(
+      <DatasetMap
+        bbox={[-10, -10, 10, 10]}
+        tableName="example_table"
+        geometryType="Polygon"
+        datasetId="dataset-1"
+        canEdit
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /Edit attributes/i }));
+    expect(screen.getByText('Edit Feature Attributes')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /^Save$/i }));
+
+    // Identity changes while the update is in flight.
+    drawingState.sessionEpoch = 301;
+
+    await act(async () => {
+      resolveUpdate({});
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    // Refused as stale: the dialog (a second identity's own editor, in the
+    // real scenario) stays open rather than being discarded.
+    expect(screen.getByText('Edit Feature Attributes')).toBeInTheDocument();
+  });
+
+  it('closes the dialog when the update succeeds and the identity has not changed', async () => {
+    render(
+      <DatasetMap
+        bbox={[-10, -10, 10, 10]}
+        tableName="example_table"
+        geometryType="Polygon"
+        datasetId="dataset-1"
+        canEdit
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /Edit attributes/i }));
+    expect(screen.getByText('Edit Feature Attributes')).toBeInTheDocument();
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /^Save$/i }));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
     expect(screen.queryByText('Edit Feature Attributes')).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/components/dataset/__tests__/DatasetMap.test.tsx
+++ b/frontend/src/components/dataset/__tests__/DatasetMap.test.tsx
@@ -45,6 +45,10 @@ const drawingState = vi.hoisted(() => ({
   clearSelectedFeature: vi.fn(),
   setEditDirty: vi.fn(),
   isEditDirty: false,
+  // fix(#1761 review round 3 P1): identity-change session counter. Real
+  // usage never resets this to 0 mid-life, so tests that bump it use a high
+  // starting value to avoid colliding with any other test's leftover state.
+  sessionEpoch: 0,
 }));
 
 vi.mock('@vis.gl/react-maplibre', async () => {
@@ -95,22 +99,32 @@ vi.mock('@/hooks/use-tile-token', () => ({
   useTileToken: () => ({ data: null }),
 }));
 
-vi.mock('@/stores/drawing-store', () => ({
-  useDrawingStore: (selector: (state: typeof drawingState) => unknown) => selector(drawingState),
+vi.mock('@/stores/drawing-store', () => {
+  const useDrawingStore = (selector: (state: typeof drawingState) => unknown) => selector(drawingState);
+  // fix(#1761 review round 3 P1): finishDrawingSession reads
+  // useDrawingStore.getState() directly (not via the selector hook), the
+  // same static-access pattern the real zustand store supports.
+  useDrawingStore.getState = () => drawingState;
+  return { useDrawingStore };
+});
+
+// fix(#1761 review round 3 P1): a stable hoisted object (not a fresh
+// literal per render) so a test can hold onto `terraDrawState.clear` and
+// assert it was invoked by the identity-change cleanup effect.
+const terraDrawState = vi.hoisted(() => ({
+  setMode: vi.fn(),
+  isReady: false,
+  addFeatures: vi.fn(),
+  removeFeatures: vi.fn(),
+  selectFeature: vi.fn(),
+  getSnapshotFeature: vi.fn(),
+  clear: vi.fn(),
+  undo: vi.fn(),
+  canUndo: false,
 }));
 
 vi.mock('@/components/drawing/hooks/use-terra-draw', () => ({
-  useTerraDraw: () => ({
-    setMode: vi.fn(),
-    isReady: false,
-    addFeatures: vi.fn(),
-    removeFeatures: vi.fn(),
-    selectFeature: vi.fn(),
-    getSnapshotFeature: vi.fn(),
-    clear: vi.fn(),
-    undo: vi.fn(),
-    canUndo: false,
-  }),
+  useTerraDraw: () => terraDrawState,
   getModeName: () => 'polygon',
   getAvailableModes: vi.fn(() => ['select', 'point', 'linestring', 'polygon']),
 }));
@@ -126,6 +140,20 @@ vi.mock('@/hooks/use-features', () => ({
 vi.mock('@/api/features', () => ({
   getFeature: vi.fn(),
 }));
+
+// fix(#1761 review round 3 P1): keep useFeatureEditing's real implementation
+// (performDeselect etc. are exercised elsewhere in this file) but replace
+// showAllFeaturesInTiles with a spy, so the identity-change cleanup test
+// below can assert the tile-filter restore ran without needing a real
+// MapLibre map's getLayer/getFilter/setFilter machinery.
+const showAllFeaturesInTilesMock = vi.hoisted(() => vi.fn());
+vi.mock('@/components/dataset/hooks/use-feature-editing', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/components/dataset/hooks/use-feature-editing')>();
+  return {
+    ...actual,
+    showAllFeaturesInTiles: showAllFeaturesInTilesMock,
+  };
+});
 
 describe('DatasetMap interaction state', () => {
   beforeEach(() => {
@@ -593,5 +621,89 @@ describe('DatasetMap antimeridian extent (fix #1004)', () => {
       ],
       expect.objectContaining({ padding: 60 }),
     );
+  });
+});
+
+// fix(#1761 review round 3 P1): the identity-change choke point
+// (lib/auth-cache-reset.ts) only resets Zustand fields. DatasetMap's own
+// finishDrawingSession is what tears down Terra Draw's drawn geometry, the
+// map's hidden-tile filters, and this component's own open dialogs — none
+// of which the choke point can reach. This pins that an identity change
+// (a sessionEpoch bump) drives that cleanup even though nothing in the
+// choke point itself knows this component exists.
+describe('DatasetMap identity-change cleanup (fix #1761 review round 3 P1)', () => {
+  beforeEach(() => {
+    drawingState.isDrawing = true;
+    drawingState.activeMode = 'select';
+    drawingState.selectedFeature = { gid: 42, tdId: 'td-1', properties: {} };
+    drawingState.isEditDirty = false;
+    drawingState.sessionEpoch = 100;
+    drawingState.clearDrawing.mockReset();
+    drawingState.clearSelectedFeature.mockReset();
+    terraDrawState.clear.mockReset();
+    terraDrawState.removeFeatures.mockReset();
+    showAllFeaturesInTilesMock.mockReset();
+    mapSpy.reset();
+    mapSpy.attachMapInstance = true;
+    // activeMode === 'select' (a live sketch session) wires up the canvas
+    // click handler, which needs a real-shaped canvas from the fakeMap.
+    (fakeMap.getCanvas as ReturnType<typeof vi.fn>).mockReturnValue({
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      getBoundingClientRect: () => ({ left: 0, top: 0 }),
+    });
+  });
+
+  it('does not run the cleanup on mount', () => {
+    render(
+      <DatasetMap
+        bbox={[-10, -10, 10, 10]}
+        tableName="example_table"
+        geometryType="Polygon"
+        datasetId="dataset-1"
+        canEdit
+      />,
+    );
+
+    expect(terraDrawState.clear).not.toHaveBeenCalled();
+    expect(showAllFeaturesInTilesMock).not.toHaveBeenCalled();
+    expect(drawingState.clearDrawing).not.toHaveBeenCalled();
+  });
+
+  it('tears down the local drawing session when the session epoch changes', () => {
+    const { rerender } = render(
+      <DatasetMap
+        bbox={[-10, -10, 10, 10]}
+        tableName="example_table"
+        geometryType="Polygon"
+        datasetId="dataset-1"
+        canEdit
+      />,
+    );
+
+    // Open the "edit existing feature" dialog, standing in for "this
+    // identity's local UI state" the choke point cannot see.
+    fireEvent.click(screen.getByRole('button', { name: /Edit attributes/i }));
+    expect(screen.getByText('Edit Feature Attributes')).toBeInTheDocument();
+
+    // The identity change: the choke point bumped the store's sessionEpoch
+    // (and separately cleared its own Zustand fields — simulated here by
+    // NOT changing isDrawing/selectedFeature, since the point of this test
+    // is that the epoch alone drives DatasetMap's local cleanup).
+    drawingState.sessionEpoch = 101;
+    rerender(
+      <DatasetMap
+        bbox={[-10, -10, 10, 10]}
+        tableName="example_table"
+        geometryType="Polygon"
+        datasetId="dataset-1"
+        canEdit
+      />,
+    );
+
+    expect(terraDrawState.clear).toHaveBeenCalled();
+    expect(showAllFeaturesInTilesMock).toHaveBeenCalled();
+    expect(drawingState.clearDrawing).toHaveBeenCalled();
+    expect(screen.queryByText('Edit Feature Attributes')).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/components/dataset/hooks/__tests__/use-feature-editing.test.ts
+++ b/frontend/src/components/dataset/hooks/__tests__/use-feature-editing.test.ts
@@ -5,6 +5,7 @@
 // vector tile source after a successful update.
 import { renderHook, act } from '@testing-library/react';
 import type { Map as MaplibreMap, Point } from 'maplibre-gl';
+import { toast } from 'sonner';
 import { useFeatureEditing } from '@/components/dataset/hooks/use-feature-editing';
 import { useDrawingStore } from '@/stores/drawing-store';
 import { getFeature } from '@/api/features';
@@ -438,6 +439,10 @@ describe('useFeatureEditing — handleEditAttributeSubmit result (fix #1761 revi
     updateMutateAsync.mockReturnValueOnce(update.promise);
     const map = makeMapWithVectorSource(vi.fn());
     const { result } = renderEditing(map);
+    // Mocks are not auto-cleared between tests in this file; earlier tests
+    // in this describe legitimately call toast.error for their own (non-
+    // stale) failures.
+    vi.mocked(toast.error).mockClear();
 
     const submitting = result.current.handleEditAttributeSubmit({ name: 'new' });
     act(() => {
@@ -485,5 +490,35 @@ describe('useFeatureEditing — handleEditAttributeSubmit result (fix #1761 revi
     });
 
     expect(outcome).toEqual({ applied: true });
+  });
+
+  // fix(#1761 review round 5): the catch path returned applied: true
+  // unconditionally, so when the identity changed while the mutation was
+  // in flight and it then REJECTED, the caller closed a second identity's
+  // own now-open editor and an error toast for the FIRST identity's
+  // failure surfaced to whoever is looking now.
+  it('returns applied: false and suppresses the error toast when the identity changed before the mutation rejected', async () => {
+    useDrawingStore.setState({ selectedFeature: { gid: 7, tdId: 'td-7', properties: {} } });
+    const update = deferred<unknown>();
+    updateMutateAsync.mockReturnValueOnce(update.promise);
+    const map = makeMapWithVectorSource(vi.fn());
+    const { result } = renderEditing(map);
+    // Mocks are not auto-cleared between tests in this file; earlier tests
+    // in this describe legitimately call toast.error for their own (non-
+    // stale) failures.
+    vi.mocked(toast.error).mockClear();
+
+    const submitting = result.current.handleEditAttributeSubmit({ name: 'new' });
+    act(() => {
+      useDrawingStore.getState().bumpSessionEpoch();
+    });
+    update.reject(new Error('boom'));
+    let outcome: { applied: boolean } | undefined;
+    await act(async () => {
+      outcome = await submitting;
+    });
+
+    expect(outcome).toEqual({ applied: false });
+    expect(toast.error).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/components/dataset/hooks/__tests__/use-feature-editing.test.ts
+++ b/frontend/src/components/dataset/hooks/__tests__/use-feature-editing.test.ts
@@ -4,9 +4,12 @@
 // does too. This test pins that handleEditAttributeSubmit cache-busts the
 // vector tile source after a successful update.
 import { renderHook, act } from '@testing-library/react';
-import type { Map as MaplibreMap } from 'maplibre-gl';
+import type { Map as MaplibreMap, Point } from 'maplibre-gl';
 import { useFeatureEditing } from '@/components/dataset/hooks/use-feature-editing';
 import { useDrawingStore } from '@/stores/drawing-store';
+import { getFeature } from '@/api/features';
+import type { GeoJSONFeature } from '@/api/features';
+import type { Feature } from 'geojson';
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({ t: (key: string) => key }),
@@ -17,10 +20,11 @@ vi.mock('sonner', () => ({
 }));
 
 const updateMutateAsync = vi.fn().mockResolvedValue({});
+const deleteMutateAsync = vi.fn().mockResolvedValue({});
 vi.mock('@/hooks/use-features', () => ({
   useCreateFeature: () => ({ mutateAsync: vi.fn() }),
   useUpdateFeature: () => ({ mutateAsync: updateMutateAsync }),
-  useDeleteFeature: () => ({ mutateAsync: vi.fn() }),
+  useDeleteFeature: () => ({ mutateAsync: deleteMutateAsync }),
 }));
 
 vi.mock('@/lib/tile-utils', () => ({
@@ -32,6 +36,25 @@ vi.mock('@/lib/env', () => ({
   getEnvConfig: () => ({ TILE_BASE_URL: '' }),
 }));
 
+// fix(#1761 review round 3 P1): selectFeatureFromMap's identity race needs a
+// controllable getFeature() promise to hold the function paused mid-await.
+vi.mock('@/api/features', () => ({
+  getFeature: vi.fn(),
+}));
+
+const FAKE_POINT = { x: 0, y: 0 } as unknown as Point;
+
+/** Resolves/rejects on demand, so a test can pause an async call mid-flight. */
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
 function makeMapWithVectorSource(setTiles: ReturnType<typeof vi.fn>) {
   return {
     getSource: vi.fn((id: string) =>
@@ -42,22 +65,34 @@ function makeMapWithVectorSource(setTiles: ReturnType<typeof vi.fn>) {
   } as unknown as MaplibreMap;
 }
 
-function renderEditing(map: MaplibreMap) {
+interface EditingOverrides {
+  removeFeatures?: (ids: (string | number)[]) => void;
+  getSnapshotFeature?: (id: string | number) => Feature | undefined;
+  addFeatures?: (features: Feature[]) => { id?: string | number; valid: boolean }[];
+  selectFeature?: (id: string) => void;
+  clear?: () => void;
+}
+
+function renderEditing(map: MaplibreMap, overrides: EditingOverrides = {}) {
   const mapRef = { current: map };
-  return renderHook(() =>
+  const opts = {
+    removeFeatures: overrides.removeFeatures ?? vi.fn(),
+    getSnapshotFeature: overrides.getSnapshotFeature ?? vi.fn(),
+    addFeatures: overrides.addFeatures ?? vi.fn(() => []),
+    selectFeature: overrides.selectFeature ?? vi.fn(),
+    clear: overrides.clear ?? vi.fn(),
+  };
+  const hook = renderHook(() =>
     useFeatureEditing({
       mapRef,
       datasetId: 'ds-1',
       tableName: 'parcels',
       tileConfig: { cdn_base_url: null },
       tileToken: { sig: 's', exp: 1, scope: 'sc' },
-      removeFeatures: vi.fn(),
-      getSnapshotFeature: vi.fn(),
-      addFeatures: vi.fn(() => []),
-      selectFeature: vi.fn(),
-      clear: vi.fn(),
+      ...opts,
     }),
   );
+  return { ...hook, opts };
 }
 
 describe('useFeatureEditing — handleEditAttributeSubmit (BUG-042)', () => {
@@ -96,5 +131,195 @@ describe('useFeatureEditing — handleEditAttributeSubmit (BUG-042)', () => {
     });
 
     expect(setTiles).not.toHaveBeenCalled();
+  });
+});
+
+// fix(#1761 review round 3 P1): a stale selectFeatureFromMap resolution used
+// to install the fetched geometry on the map (clear() + addFeatures()) and
+// select/hide it BEFORE anything checked whether the identity that started
+// the fetch was still current — only the final setSelectedFeature() call was
+// epoch-gated, by which point the map mutations had already happened.
+describe('useFeatureEditing — selectFeatureFromMap identity race (fix #1761 review round 3 P1)', () => {
+  const baseAuth = useDrawingStore.getState();
+
+  beforeEach(() => {
+    useDrawingStore.setState(baseAuth, true);
+    // An active drawing target is a precondition for selectFeatureFromMap
+    // in real usage (it only runs while activeMode === 'select'), and
+    // matters here so the epoch check below is what refuses the write, not
+    // the separate "no active target" guard.
+    useDrawingStore.getState().setDrawing('ds-1', 'parcels', 'Point');
+    vi.mocked(getFeature).mockReset();
+  });
+
+  function makeSelectableMap() {
+    return {
+      getLayer: vi.fn(() => true),
+      getFilter: vi.fn(() => null),
+      queryRenderedFeatures: vi.fn(() => [{ id: 99, properties: {} }]),
+      getSource: vi.fn(() => undefined),
+      setFilter: vi.fn(),
+    } as unknown as MaplibreMap;
+  }
+
+  it('does not mutate the map or select the feature when identity changes while getFeature is pending', async () => {
+    const fetch = deferred<GeoJSONFeature>();
+    vi.mocked(getFeature).mockReturnValueOnce(fetch.promise);
+
+    const clear = vi.fn();
+    const addFeatures = vi.fn(() => [{ id: 'td-x', valid: true }]);
+    const selectFeature = vi.fn();
+    const map = makeSelectableMap();
+    const { result, opts } = renderEditing(map, { clear, addFeatures, selectFeature });
+
+    const selecting = result.current.selectFeatureFromMap(map, FAKE_POINT);
+
+    // Identity changes (the auth choke point's bumpSessionEpoch) WHILE the
+    // fetch above is still pending.
+    act(() => {
+      useDrawingStore.getState().bumpSessionEpoch();
+    });
+
+    fetch.resolve({
+      type: 'Feature',
+      id: 99,
+      geometry: { type: 'Point', coordinates: [0, 0] },
+      properties: { secret: 'the-previous-identity-should-never-see-this-applied' },
+    });
+    await act(async () => {
+      await selecting;
+    });
+
+    expect(clear).not.toHaveBeenCalled();
+    expect(addFeatures).not.toHaveBeenCalled();
+    expect(opts.selectFeature).not.toHaveBeenCalled();
+    expect(map.setFilter).not.toHaveBeenCalled();
+    expect(useDrawingStore.getState().selectedFeature).toBeNull();
+  });
+
+  it('still selects the feature normally when the identity has not changed', async () => {
+    vi.mocked(getFeature).mockResolvedValueOnce({
+      type: 'Feature',
+      id: 99,
+      geometry: { type: 'Point', coordinates: [0, 0] },
+      properties: { name: 'ok' },
+    });
+
+    const addFeatures = vi.fn(() => [{ id: 'td-x', valid: true }]);
+    const map = makeSelectableMap();
+    const { result } = renderEditing(map, { addFeatures });
+
+    await act(async () => {
+      await result.current.selectFeatureFromMap(map, FAKE_POINT);
+    });
+
+    expect(addFeatures).toHaveBeenCalledTimes(1);
+    expect(useDrawingStore.getState().selectedFeature).toEqual({
+      gid: 99,
+      tdId: 'td-x',
+      properties: { name: 'ok' },
+    });
+  });
+});
+
+// fix(#1761 review round 3 P2): handleSaveEdit/handleDeleteFeature applied
+// their success cleanup (removeFeatures, tile reload/restore,
+// clearSelectedFeature) unconditionally. If the identity changed while the
+// mutation was in flight, that cleanup landed on whatever a SECOND identity
+// had since selected — removing their terra draw feature by a colliding
+// tdId and wiping their selection.
+describe('useFeatureEditing — post-mutation cleanup skipped after a stale identity (fix #1761 review round 3 P2)', () => {
+  const baseAuth = useDrawingStore.getState();
+
+  beforeEach(() => {
+    useDrawingStore.setState(baseAuth, true);
+    updateMutateAsync.mockClear();
+    deleteMutateAsync.mockClear();
+  });
+
+  it('handleSaveEdit skips cleanup when the identity changed while the update was in flight', async () => {
+    useDrawingStore.setState({ selectedFeature: { gid: 7, tdId: 'td-7', properties: {} } });
+    const update = deferred<unknown>();
+    updateMutateAsync.mockReturnValueOnce(update.promise);
+
+    const removeFeatures = vi.fn();
+    const getSnapshotFeature = vi.fn(() => ({
+      type: 'Feature' as const,
+      geometry: { type: 'Point' as const, coordinates: [0, 0] },
+      properties: {},
+    }));
+    const map = { getLayer: vi.fn(() => true), getFilter: vi.fn(() => null), setFilter: vi.fn(), getSource: vi.fn(() => undefined) } as unknown as MaplibreMap;
+    const { result } = renderEditing(map, { removeFeatures, getSnapshotFeature });
+
+    const saving = result.current.handleSaveEdit();
+    act(() => {
+      useDrawingStore.getState().bumpSessionEpoch();
+    });
+    update.resolve({});
+    await act(async () => {
+      await saving;
+    });
+
+    expect(removeFeatures).not.toHaveBeenCalled();
+    expect(map.setFilter).not.toHaveBeenCalled();
+    // clearSelectedFeature was skipped: the (possibly second identity's)
+    // selectedFeature is untouched.
+    expect(useDrawingStore.getState().selectedFeature).toEqual({ gid: 7, tdId: 'td-7', properties: {} });
+  });
+
+  it('handleSaveEdit still cleans up normally when the identity has not changed', async () => {
+    useDrawingStore.setState({ selectedFeature: { gid: 7, tdId: 'td-7', properties: {} } });
+    const removeFeatures = vi.fn();
+    const getSnapshotFeature = vi.fn(() => ({
+      type: 'Feature' as const,
+      geometry: { type: 'Point' as const, coordinates: [0, 0] },
+      properties: {},
+    }));
+    const map = { getLayer: vi.fn(() => true), getFilter: vi.fn(() => null), setFilter: vi.fn(), getSource: vi.fn(() => undefined) } as unknown as MaplibreMap;
+    const { result } = renderEditing(map, { removeFeatures, getSnapshotFeature });
+
+    await act(async () => {
+      await result.current.handleSaveEdit();
+    });
+
+    expect(removeFeatures).toHaveBeenCalledWith(['td-7']);
+    expect(useDrawingStore.getState().selectedFeature).toBeNull();
+  });
+
+  it('handleDeleteFeature skips cleanup when the identity changed while the delete was in flight', async () => {
+    useDrawingStore.setState({ selectedFeature: { gid: 7, tdId: 'td-7', properties: {} } });
+    const del = deferred<unknown>();
+    deleteMutateAsync.mockReturnValueOnce(del.promise);
+
+    const removeFeatures = vi.fn();
+    const map = { getLayer: vi.fn(() => true), getFilter: vi.fn(() => null), setFilter: vi.fn(), getSource: vi.fn(() => undefined) } as unknown as MaplibreMap;
+    const { result } = renderEditing(map, { removeFeatures });
+
+    const deleting = result.current.handleDeleteFeature();
+    act(() => {
+      useDrawingStore.getState().bumpSessionEpoch();
+    });
+    del.resolve({});
+    await act(async () => {
+      await deleting;
+    });
+
+    expect(removeFeatures).not.toHaveBeenCalled();
+    expect(map.setFilter).not.toHaveBeenCalled();
+    expect(useDrawingStore.getState().selectedFeature).toEqual({ gid: 7, tdId: 'td-7', properties: {} });
+  });
+
+  it('handleDeleteFeature still cleans up normally when the identity has not changed', async () => {
+    useDrawingStore.setState({ selectedFeature: { gid: 7, tdId: 'td-7', properties: {} } });
+    const removeFeatures = vi.fn();
+    const map = { getLayer: vi.fn(() => true), getFilter: vi.fn(() => null), setFilter: vi.fn(), getSource: vi.fn(() => undefined) } as unknown as MaplibreMap;
+    const { result } = renderEditing(map, { removeFeatures });
+
+    await act(async () => {
+      await result.current.handleDeleteFeature();
+    });
+
+    expect(removeFeatures).toHaveBeenCalledWith(['td-7']);
+    expect(useDrawingStore.getState().selectedFeature).toBeNull();
   });
 });

--- a/frontend/src/components/dataset/hooks/__tests__/use-feature-editing.test.ts
+++ b/frontend/src/components/dataset/hooks/__tests__/use-feature-editing.test.ts
@@ -522,3 +522,132 @@ describe('useFeatureEditing — handleEditAttributeSubmit result (fix #1761 revi
     expect(toast.error).not.toHaveBeenCalled();
   });
 });
+
+// fix(#1761 review round 7): the success path of each mutation already
+// rechecks the captured epoch before its toast/state effects; the catch
+// path did not, so a request that FAILED after an identity change still
+// surfaced its error toast to whoever is signed in now.
+describe('useFeatureEditing — stale-failure feedback suppressed (fix #1761 review round 7)', () => {
+  const baseAuth = useDrawingStore.getState();
+
+  beforeEach(() => {
+    useDrawingStore.setState(baseAuth, true);
+    createMutateAsync.mockClear();
+    updateMutateAsync.mockClear();
+    deleteMutateAsync.mockClear();
+    // Mocks are not auto-cleared between tests in this file; earlier
+    // describes legitimately call toast.error for their own (non-stale)
+    // failures.
+    vi.mocked(toast.error).mockClear();
+  });
+
+  it('saveAndRefresh (create) suppresses the error toast when the identity changed before the request rejected', async () => {
+    const overlaySetData = vi.fn();
+    const map = makeMapWithOverlaySource(overlaySetData);
+    const { result } = renderEditing(map);
+
+    const create = deferred<unknown>();
+    createMutateAsync.mockReturnValueOnce(create.promise);
+
+    const saving = result.current.saveAndRefresh({ type: 'Point', coordinates: [0, 0] }, {});
+    act(() => {
+      useDrawingStore.getState().bumpSessionEpoch();
+    });
+    create.reject(new Error('boom'));
+    await act(async () => {
+      await saving;
+    });
+
+    expect(toast.error).not.toHaveBeenCalled();
+  });
+
+  it('saveAndRefresh (create) still reports a real failure when the identity has not changed', async () => {
+    const overlaySetData = vi.fn();
+    const map = makeMapWithOverlaySource(overlaySetData);
+    const { result } = renderEditing(map);
+
+    createMutateAsync.mockRejectedValueOnce(new Error('boom'));
+
+    await act(async () => {
+      await result.current.saveAndRefresh({ type: 'Point', coordinates: [0, 0] }, {});
+    });
+
+    expect(toast.error).toHaveBeenCalledTimes(1);
+  });
+
+  it('handleSaveEdit (geometry update) suppresses the error toast when the identity changed before the request rejected', async () => {
+    useDrawingStore.setState({ selectedFeature: { gid: 7, tdId: 'td-7', properties: {} } });
+    const update = deferred<unknown>();
+    updateMutateAsync.mockReturnValueOnce(update.promise);
+
+    const getSnapshotFeature = vi.fn(() => ({
+      type: 'Feature' as const,
+      geometry: { type: 'Point' as const, coordinates: [0, 0] },
+      properties: {},
+    }));
+    const map = { getLayer: vi.fn(() => true), getFilter: vi.fn(() => null), setFilter: vi.fn(), getSource: vi.fn(() => undefined) } as unknown as MaplibreMap;
+    const { result } = renderEditing(map, { getSnapshotFeature });
+
+    const saving = result.current.handleSaveEdit();
+    act(() => {
+      useDrawingStore.getState().bumpSessionEpoch();
+    });
+    update.reject(new Error('boom'));
+    await act(async () => {
+      await saving;
+    });
+
+    expect(toast.error).not.toHaveBeenCalled();
+  });
+
+  it('handleSaveEdit (geometry update) still reports a real failure when the identity has not changed', async () => {
+    useDrawingStore.setState({ selectedFeature: { gid: 7, tdId: 'td-7', properties: {} } });
+    updateMutateAsync.mockRejectedValueOnce(new Error('boom'));
+    const getSnapshotFeature = vi.fn(() => ({
+      type: 'Feature' as const,
+      geometry: { type: 'Point' as const, coordinates: [0, 0] },
+      properties: {},
+    }));
+    const map = { getLayer: vi.fn(() => true), getFilter: vi.fn(() => null), setFilter: vi.fn(), getSource: vi.fn(() => undefined) } as unknown as MaplibreMap;
+    const { result } = renderEditing(map, { getSnapshotFeature });
+
+    await act(async () => {
+      await result.current.handleSaveEdit();
+    });
+
+    expect(toast.error).toHaveBeenCalledTimes(1);
+  });
+
+  it('handleDeleteFeature (delete) suppresses the error toast when the identity changed before the request rejected', async () => {
+    useDrawingStore.setState({ selectedFeature: { gid: 7, tdId: 'td-7', properties: {} } });
+    const del = deferred<unknown>();
+    deleteMutateAsync.mockReturnValueOnce(del.promise);
+
+    const map = { getLayer: vi.fn(() => true), getFilter: vi.fn(() => null), setFilter: vi.fn(), getSource: vi.fn(() => undefined) } as unknown as MaplibreMap;
+    const { result } = renderEditing(map);
+
+    const deleting = result.current.handleDeleteFeature();
+    act(() => {
+      useDrawingStore.getState().bumpSessionEpoch();
+    });
+    del.reject(new Error('boom'));
+    await act(async () => {
+      await deleting;
+    });
+
+    expect(toast.error).not.toHaveBeenCalled();
+  });
+
+  it('handleDeleteFeature (delete) still reports a real failure when the identity has not changed', async () => {
+    useDrawingStore.setState({ selectedFeature: { gid: 7, tdId: 'td-7', properties: {} } });
+    deleteMutateAsync.mockRejectedValueOnce(new Error('boom'));
+    const map = { getLayer: vi.fn(() => true), getFilter: vi.fn(() => null), setFilter: vi.fn(), getSource: vi.fn(() => undefined) } as unknown as MaplibreMap;
+    const { result } = renderEditing(map);
+
+    await act(async () => {
+      await result.current.handleDeleteFeature();
+    });
+
+    expect(toast.error).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/components/dataset/hooks/__tests__/use-feature-editing.test.ts
+++ b/frontend/src/components/dataset/hooks/__tests__/use-feature-editing.test.ts
@@ -650,4 +650,57 @@ describe('useFeatureEditing — stale-failure feedback suppressed (fix #1761 rev
 
     expect(toast.error).toHaveBeenCalledTimes(1);
   });
+
+  // fix(#1761 review round 8): the fourth catch path with the same
+  // omission — selectFeatureFromMap's catch (getFeature() rejecting) had
+  // no epoch recheck at all, unlike the mutation catch paths above, so a
+  // failed fetch always showed map.featureLoadFailed to whoever is signed
+  // in (or anonymous) when it lands, not whoever clicked the feature.
+  it('selectFeatureFromMap (selection) suppresses the error toast when the identity changed before getFeature rejected', async () => {
+    useDrawingStore.getState().setDrawing('ds-1', 'parcels', 'Point');
+    vi.mocked(getFeature).mockReset();
+    const fetch = deferred<GeoJSONFeature>();
+    vi.mocked(getFeature).mockReturnValueOnce(fetch.promise);
+
+    const map = {
+      getLayer: vi.fn(() => true),
+      getFilter: vi.fn(() => null),
+      queryRenderedFeatures: vi.fn(() => [{ id: 99, properties: {} }]),
+      getSource: vi.fn(() => undefined),
+      setFilter: vi.fn(),
+    } as unknown as MaplibreMap;
+    const { result } = renderEditing(map);
+
+    const selecting = result.current.selectFeatureFromMap(map, FAKE_POINT);
+    act(() => {
+      useDrawingStore.getState().bumpSessionEpoch();
+    });
+    fetch.reject(new Error('boom'));
+    await act(async () => {
+      await selecting;
+    });
+
+    expect(toast.error).not.toHaveBeenCalled();
+  });
+
+  it('selectFeatureFromMap (selection) still reports a real failure when the identity has not changed', async () => {
+    useDrawingStore.getState().setDrawing('ds-1', 'parcels', 'Point');
+    vi.mocked(getFeature).mockReset();
+    vi.mocked(getFeature).mockRejectedValueOnce(new Error('boom'));
+
+    const map = {
+      getLayer: vi.fn(() => true),
+      getFilter: vi.fn(() => null),
+      queryRenderedFeatures: vi.fn(() => [{ id: 99, properties: {} }]),
+      getSource: vi.fn(() => undefined),
+      setFilter: vi.fn(),
+    } as unknown as MaplibreMap;
+    const { result } = renderEditing(map);
+
+    await act(async () => {
+      await result.current.selectFeatureFromMap(map, FAKE_POINT);
+    });
+
+    expect(toast.error).toHaveBeenCalledTimes(1);
+  });
 });

--- a/frontend/src/components/dataset/hooks/__tests__/use-feature-editing.test.ts
+++ b/frontend/src/components/dataset/hooks/__tests__/use-feature-editing.test.ts
@@ -19,10 +19,11 @@ vi.mock('sonner', () => ({
   toast: { success: vi.fn(), error: vi.fn(), message: vi.fn(), info: vi.fn() },
 }));
 
+const createMutateAsync = vi.fn().mockResolvedValue({});
 const updateMutateAsync = vi.fn().mockResolvedValue({});
 const deleteMutateAsync = vi.fn().mockResolvedValue({});
 vi.mock('@/hooks/use-features', () => ({
-  useCreateFeature: () => ({ mutateAsync: vi.fn() }),
+  useCreateFeature: () => ({ mutateAsync: createMutateAsync }),
   useUpdateFeature: () => ({ mutateAsync: updateMutateAsync }),
   useDeleteFeature: () => ({ mutateAsync: deleteMutateAsync }),
 }));
@@ -62,6 +63,21 @@ function makeMapWithVectorSource(setTiles: ReturnType<typeof vi.fn>) {
     ),
     getLayer: vi.fn(() => undefined),
     setFilter: vi.fn(),
+  } as unknown as MaplibreMap;
+}
+
+/** A map whose 'drawn-overlay' source is spy-able, and that supports the
+ *  on/off event pair saveAndRefresh's tile-load listener needs. */
+function makeMapWithOverlaySource(overlaySetData: ReturnType<typeof vi.fn>) {
+  return {
+    getSource: vi.fn((id: string) =>
+      id === 'drawn-overlay' ? { setData: overlaySetData } : undefined,
+    ),
+    getLayer: vi.fn(() => undefined),
+    getFilter: vi.fn(() => null),
+    setFilter: vi.fn(),
+    on: vi.fn(),
+    off: vi.fn(),
   } as unknown as MaplibreMap;
 }
 
@@ -321,5 +337,153 @@ describe('useFeatureEditing — post-mutation cleanup skipped after a stale iden
 
     expect(removeFeatures).toHaveBeenCalledWith(['td-7']);
     expect(useDrawingStore.getState().selectedFeature).toBeNull();
+  });
+});
+
+// fix(#1761 review round 4): the epoch-change cleanup (DatasetMap's
+// finishDrawingSession) clears Terra Draw but, before this, not the overlay
+// ref/source that saveAndRefresh populates for instant visibility while a
+// create is in flight — and clearOverlay(), fired later by a tile-load
+// event or a 5s fallback, could erase a NEWER identity's own overlay if it
+// fired after a second identity change.
+describe('useFeatureEditing — overlay reset on identity change (fix #1761 review round 4)', () => {
+  const baseAuth = useDrawingStore.getState();
+
+  beforeEach(() => {
+    useDrawingStore.setState(baseAuth, true);
+    createMutateAsync.mockClear();
+  });
+
+  it('resetOverlay empties the drawn-overlay source and cancels the pending tile-load listener', async () => {
+    const overlaySetData = vi.fn();
+    const map = makeMapWithOverlaySource(overlaySetData);
+    const { result } = renderEditing(map);
+
+    await act(async () => {
+      await result.current.saveAndRefresh({ type: 'Point', coordinates: [0, 0] }, {});
+    });
+    // The success path installed a sourcedata listener to clear the
+    // overlay once tiles catch up — nothing has canceled it yet.
+    expect(map.off).not.toHaveBeenCalled();
+
+    overlaySetData.mockClear();
+    act(() => {
+      result.current.resetOverlay();
+    });
+
+    expect(overlaySetData).toHaveBeenCalledWith({ type: 'FeatureCollection', features: [] });
+    expect(map.off).toHaveBeenCalledWith('sourcedata', expect.any(Function));
+  });
+
+  it('does not erase a newer overlay when a stale tile-load event fires after a later identity change', async () => {
+    const overlaySetData = vi.fn();
+    const map = makeMapWithOverlaySource(overlaySetData);
+    const { result } = renderEditing(map);
+
+    // User A's create succeeds while their identity is still current — the
+    // success path installs the tile-load listener.
+    await act(async () => {
+      await result.current.saveAndRefresh({ type: 'Point', coordinates: [0, 0] }, { owner: 'A' });
+    });
+    const onCall = (map.on as ReturnType<typeof vi.fn>).mock.calls.find(([event]) => event === 'sourcedata');
+    expect(onCall).toBeDefined();
+    const onSourceData = onCall![1] as (e: { sourceId?: string; isSourceLoaded?: boolean }) => void;
+
+    // A second identity draws and saves their OWN overlay feature before
+    // A's tile-load event arrives.
+    createMutateAsync.mockReturnValueOnce(new Promise(() => {}));
+    overlaySetData.mockClear();
+    act(() => {
+      void result.current.saveAndRefresh({ type: 'Point', coordinates: [1, 1] }, { owner: 'B' });
+    });
+    expect(overlaySetData).toHaveBeenLastCalledWith({
+      type: 'FeatureCollection',
+      features: [
+        { type: 'Feature', geometry: { type: 'Point', coordinates: [0, 0] }, properties: { owner: 'A' } },
+        { type: 'Feature', geometry: { type: 'Point', coordinates: [1, 1] }, properties: { owner: 'B' } },
+      ],
+    });
+
+    // The identity changes again before A's tile-load event fires.
+    act(() => {
+      useDrawingStore.getState().bumpSessionEpoch();
+    });
+
+    // A's stale tile-load event finally arrives.
+    overlaySetData.mockClear();
+    act(() => {
+      onSourceData({ sourceId: 'vector-tile-source', isSourceLoaded: true });
+    });
+
+    // Refused: B's overlay feature must be untouched.
+    expect(overlaySetData).not.toHaveBeenCalled();
+  });
+});
+
+// fix(#1761 review round 4): handleEditAttributeSubmit used to report
+// success and reload tiles even after a stale write, and its caller
+// (DatasetMap's AttributeForm onSubmit) closed the dialog unconditionally —
+// discarding a second identity's own now-open editor for their feature.
+describe('useFeatureEditing — handleEditAttributeSubmit result (fix #1761 review round 4)', () => {
+  const baseAuth = useDrawingStore.getState();
+
+  beforeEach(() => {
+    useDrawingStore.setState(baseAuth, true);
+    updateMutateAsync.mockClear();
+  });
+
+  it('returns applied: false and skips the store write when the identity changed mid-flight', async () => {
+    useDrawingStore.setState({ selectedFeature: { gid: 7, tdId: 'td-7', properties: { name: 'old' } } });
+    const update = deferred<unknown>();
+    updateMutateAsync.mockReturnValueOnce(update.promise);
+    const map = makeMapWithVectorSource(vi.fn());
+    const { result } = renderEditing(map);
+
+    const submitting = result.current.handleEditAttributeSubmit({ name: 'new' });
+    act(() => {
+      useDrawingStore.getState().bumpSessionEpoch();
+    });
+    update.resolve({});
+    let outcome: { applied: boolean } | undefined;
+    await act(async () => {
+      outcome = await submitting;
+    });
+
+    expect(outcome).toEqual({ applied: false });
+    // The store write was skipped: the (possibly second identity's)
+    // selectedFeature is untouched.
+    expect(useDrawingStore.getState().selectedFeature).toEqual({ gid: 7, tdId: 'td-7', properties: { name: 'old' } });
+  });
+
+  it('returns applied: true and applies the write when the identity has not changed', async () => {
+    // setDrawing establishes an active target — setSelectedFeature (called
+    // internally on success) refuses when there is none, per drawing-store's
+    // own guard.
+    useDrawingStore.getState().setDrawing('ds-1', 'parcels', 'Point');
+    useDrawingStore.setState({ selectedFeature: { gid: 7, tdId: 'td-7', properties: { name: 'old' } } });
+    const map = makeMapWithVectorSource(vi.fn());
+    const { result } = renderEditing(map);
+
+    let outcome: { applied: boolean } | undefined;
+    await act(async () => {
+      outcome = await result.current.handleEditAttributeSubmit({ name: 'new' });
+    });
+
+    expect(outcome).toEqual({ applied: true });
+    expect(useDrawingStore.getState().selectedFeature).toEqual({ gid: 7, tdId: 'td-7', properties: { name: 'new' } });
+  });
+
+  it('returns applied: true on a real failure, preserving the pre-existing close-on-error behavior', async () => {
+    useDrawingStore.setState({ selectedFeature: { gid: 7, tdId: 'td-7', properties: {} } });
+    updateMutateAsync.mockRejectedValueOnce(new Error('boom'));
+    const map = makeMapWithVectorSource(vi.fn());
+    const { result } = renderEditing(map);
+
+    let outcome: { applied: boolean } | undefined;
+    await act(async () => {
+      outcome = await result.current.handleEditAttributeSubmit({ name: 'new' });
+    });
+
+    expect(outcome).toEqual({ applied: true });
   });
 });

--- a/frontend/src/components/dataset/hooks/use-feature-editing.ts
+++ b/frontend/src/components/dataset/hooks/use-feature-editing.ts
@@ -463,6 +463,11 @@ export function useFeatureEditing({
           toast.error(t('map.featureLoadFailed'));
         }
       } catch {
+        // fix(#1761 review round 8): mirror the success branch's recheck —
+        // a failed fetch is feedback for whoever clicked the feature, not
+        // whoever is signed in (or anonymous) by the time getFeature()
+        // rejects.
+        if (isStale(epoch)) return;
         toast.error(t('map.featureLoadFailed'));
       }
     },

--- a/frontend/src/components/dataset/hooks/use-feature-editing.ts
+++ b/frontend/src/components/dataset/hooks/use-feature-editing.ts
@@ -343,6 +343,14 @@ export function useFeatureEditing({
         reloadTiles();
         return { applied: true };
       } catch (err) {
+        // fix(#1761 review round 5): mirror the success path's recheck. If
+        // the identity changed while this request was in flight, the
+        // failure is A's, not whoever is looking now (possibly B, with
+        // their own editor open for their own feature) — reporting it as
+        // an error toast and telling the caller to close would be exactly
+        // the same collateral damage the success path already guards
+        // against, just via the rejection branch instead of the resolve one.
+        if (useDrawingStore.getState().sessionEpoch !== epoch) return { applied: false };
         // fix(#458 E-36): keep the backend detail.
         toast.error(formatMutationError('dataset:map.attributesUpdateFailed', err));
         return { applied: true };

--- a/frontend/src/components/dataset/hooks/use-feature-editing.ts
+++ b/frontend/src/components/dataset/hooks/use-feature-editing.ts
@@ -211,12 +211,23 @@ export function useFeatureEditing({
       return;
     }
 
+    // fix(#1761 review round 3 P2): captured before the mutation's
+    // await — see handleDeleteFeature below for the shared rationale.
+    const epoch = useDrawingStore.getState().sessionEpoch;
     try {
       await updateFeatureMutation.mutateAsync({
         datasetId,
         gid: sf.gid,
         geometry: feature.geometry as Geometry,
       });
+      // fix(#1761 review round 3 P2): if the identity changed while this
+      // request was in flight, a second identity may have adopted their
+      // own selection by now. Applying this success's cleanup here would
+      // remove THEIR terra draw feature by a colliding tdId, restore tile
+      // filters out from under them, and clear THEIR selectedFeature. The
+      // write already landed server-side, which is as far as a stale
+      // caller's responsibility goes — skip the rest.
+      if (useDrawingStore.getState().sessionEpoch !== epoch) return;
       toast.success(t('map.featureUpdated'));
       try { removeFeatures([sf.tdId]); } catch { /* already removed */ }
       reloadTiles();
@@ -234,8 +245,15 @@ export function useFeatureEditing({
     const sf = useDrawingStore.getState().selectedFeature;
     if (!sf || !datasetId || !tableName) return;
 
+    // fix(#1761 review round 3 P2): captured before the mutation's
+    // await. A second identity can adopt their own selection while this
+    // delete is in flight; applying this success's cleanup then would
+    // remove THEIR terra draw feature by a colliding tdId, restore tile
+    // filters out from under them, and clear THEIR selectedFeature.
+    const epoch = useDrawingStore.getState().sessionEpoch;
     try {
       await deleteFeatureMutation.mutateAsync({ datasetId, gid: sf.gid });
+      if (useDrawingStore.getState().sessionEpoch !== epoch) return;
       toast.success(t('map.featureDeleted'));
       try { removeFeatures([sf.tdId]); } catch { /* already removed */ }
       reloadTiles();
@@ -315,6 +333,13 @@ export function useFeatureEditing({
       const epoch = useDrawingStore.getState().sessionEpoch;
       try {
         const fullFeature = await getFeature(datasetId, gid);
+        // fix(#1761 review round 3 P1): recheck IMMEDIATELY after the
+        // await, before ANY map mutation. setSelectedFeature's own epoch
+        // check refuses the STORE write, but by then clear() and
+        // addFeatures() below would already have installed the stale
+        // geometry on the map, and the rest of this block would go on to
+        // select it and hide its tile.
+        if (useDrawingStore.getState().sessionEpoch !== epoch) return;
         clear();
 
         if (!fullFeature.geometry) {

--- a/frontend/src/components/dataset/hooks/use-feature-editing.ts
+++ b/frontend/src/components/dataset/hooks/use-feature-editing.ts
@@ -253,10 +253,16 @@ export function useFeatureEditing({
     async (properties: Record<string, unknown>) => {
       const sf = useDrawingStore.getState().selectedFeature;
       if (!sf || !datasetId) return;
+      // fix(#1761 review round 2 P1): captured BEFORE the mutation's await,
+      // not re-read afterward — by the time this resolves, a second
+      // identity may have adopted its own new target, whose fresh epoch
+      // would otherwise make this stale write look current. See
+      // drawing-store.ts's setSelectedFeature doc comment.
+      const epoch = useDrawingStore.getState().sessionEpoch;
       try {
         await updateFeatureMutation.mutateAsync({ datasetId, gid: sf.gid, properties });
         toast.success(t('map.attributesUpdated'));
-        setSelectedFeature({ ...sf, properties: { ...sf.properties, ...properties } });
+        setSelectedFeature({ ...sf, properties: { ...sf.properties, ...properties } }, epoch);
         // BUG-042: the geometry handlers (handleSaveEdit/handleDeleteFeature)
         // reload tiles after a write; the attribute handler omitted it, so any
         // attribute-driven rendering kept stale values until a manual reload.
@@ -302,6 +308,11 @@ export function useFeatureEditing({
         return;
       }
 
+      // fix(#1761 review round 2 P1): captured BEFORE the fetch's await, for
+      // the same reason as handleEditAttributeSubmit above — a stale
+      // resolution here must not be accepted just because someone else's
+      // fresh target happens to make the live epoch look unchanged.
+      const epoch = useDrawingStore.getState().sessionEpoch;
       try {
         const fullFeature = await getFeature(datasetId, gid);
         clear();
@@ -327,7 +338,7 @@ export function useFeatureEditing({
 
         if (result[0]?.valid && result[0].id !== undefined) {
           const tdId = String(result[0].id);
-          setSelectedFeature({ gid, tdId, properties: fullFeature.properties });
+          setSelectedFeature({ gid, tdId, properties: fullFeature.properties }, epoch);
           tdSelectFeature(tdId);
           hideFeatureFromTiles(map, gid);
         } else {

--- a/frontend/src/components/dataset/hooks/use-feature-editing.ts
+++ b/frontend/src/components/dataset/hooks/use-feature-editing.ts
@@ -127,11 +127,33 @@ export function useFeatureEditing({
     overlayCleanupRef.current = null;
   }, []);
 
+  // fix(#1761 review round 4): empties the overlay ref and the map's
+  // drawn-overlay source immediately — used by the identity-change cleanup
+  // (DatasetMap's finishDrawingSession, keyed on sessionEpoch) so a shape
+  // drawn-but-not-yet-committed under the previous identity does not sit
+  // on the map for whoever is signed in next. Cancels the pending
+  // sourcedata/timeout listener too, since it would otherwise still be
+  // holding a reference to the (about to be stale) overlay feature.
+  const resetOverlay = useCallback(() => {
+    cleanupOverlayListener();
+    overlayFeaturesRef.current = [];
+    const map = mapRef.current;
+    if (map) {
+      const src = map.getSource('drawn-overlay') as GeoJSONSource | undefined;
+      src?.setData(EMPTY_FC);
+    }
+  }, [cleanupOverlayListener, mapRef]);
+
   /** Create a new feature and refresh tiles. */
   const saveAndRefresh = useCallback(
     async (geometry: Geometry, properties: Record<string, unknown>) => {
       if (!datasetId || !tableName) return;
       const map = mapRef.current;
+
+      // fix(#1761 review round 4): captured before the mutation's await —
+      // clearOverlay() below must not erase a NEWER identity's own overlay
+      // if this request's identity has since changed.
+      const epoch = useDrawingStore.getState().sessionEpoch;
 
       // Overlay for instant visibility
       const overlayFeature: GeoJSON.Feature = { type: 'Feature', geometry, properties: properties ?? {} };
@@ -147,6 +169,14 @@ export function useFeatureEditing({
           geometry: geometry as Geometry,
           properties,
         });
+        // fix(#1761 review round 4): if the identity changed while this
+        // request was in flight, the identity-change cleanup already
+        // emptied the overlay ref/source (resetOverlay, via
+        // finishDrawingSession). Reporting success and reloading tiles
+        // here would only be feedback for an identity that is no longer
+        // looking, and re-arming the listener below would have nothing
+        // useful left to clear.
+        if (useDrawingStore.getState().sessionEpoch !== epoch) return;
         toast.success(t('map.featureSaved'));
         reloadTiles();
 
@@ -154,6 +184,12 @@ export function useFeatureEditing({
         if (map) {
           cleanupOverlayListener();
           const clearOverlay = () => {
+            // fix(#1761 review round 4): re-checked at fire time, not just
+            // at the mutation's resolution above — the identity can change
+            // again in the gap before the tile-load event (or the 5s
+            // fallback) fires, and a second identity may have started
+            // their own overlay by then.
+            if (useDrawingStore.getState().sessionEpoch !== epoch) return;
             overlayFeaturesRef.current = [];
             const src = map.getSource('drawn-overlay') as GeoJSONSource | undefined;
             src?.setData(EMPTY_FC);
@@ -180,6 +216,11 @@ export function useFeatureEditing({
         // fix(#458 E-36): surface the backend's reason (invalid geometry,
         // type mismatch) like the table path does, not a bare "failed".
         toast.error(formatMutationError('dataset:map.featureSaveFailed', err));
+        // Not epoch-gated: this filters OUT the one feature this specific
+        // call added, by object identity, rather than clearing the ref —
+        // safe even if a second identity has since added their own
+        // overlay feature to the same ref, because that entry survives
+        // the filter untouched.
         overlayFeaturesRef.current = overlayFeaturesRef.current.filter((f) => f !== overlayFeature);
         if (map) {
           const src = map.getSource('drawn-overlay') as GeoJSONSource | undefined;
@@ -267,10 +308,17 @@ export function useFeatureEditing({
   }, [datasetId, tableName, mapRef, deleteFeatureMutation, removeFeatures, clearSelectedFeature, reloadTiles, t]);
 
   /** Update attributes of the selected feature. */
+  // fix(#1761 review round 4): returns whether the caller may treat this
+  // submission as settled. DatasetMap's AttributeForm onSubmit closes the
+  // dialog unconditionally once this resolves — for a stale request that
+  // discards a SECOND identity's own now-open editor for their feature.
+  // `applied: false` ONLY for that stale-epoch case, so the caller keeps
+  // the dialog open; a real failure still resolves `applied: true`,
+  // preserving the pre-existing behavior of closing on error.
   const handleEditAttributeSubmit = useCallback(
-    async (properties: Record<string, unknown>) => {
+    async (properties: Record<string, unknown>): Promise<{ applied: boolean }> => {
       const sf = useDrawingStore.getState().selectedFeature;
-      if (!sf || !datasetId) return;
+      if (!sf || !datasetId) return { applied: true };
       // fix(#1761 review round 2 P1): captured BEFORE the mutation's await,
       // not re-read afterward — by the time this resolves, a second
       // identity may have adopted its own new target, whose fresh epoch
@@ -279,6 +327,12 @@ export function useFeatureEditing({
       const epoch = useDrawingStore.getState().sessionEpoch;
       try {
         await updateFeatureMutation.mutateAsync({ datasetId, gid: sf.gid, properties });
+        // fix(#1761 review round 4): recheck immediately after the await,
+        // before reporting success, writing to the store, or reloading
+        // tiles. setSelectedFeature's own epoch check already refuses the
+        // store write on its own, but this validates it BEFORE those other
+        // effects run and reports it to the caller via the return value.
+        if (useDrawingStore.getState().sessionEpoch !== epoch) return { applied: false };
         toast.success(t('map.attributesUpdated'));
         setSelectedFeature({ ...sf, properties: { ...sf.properties, ...properties } }, epoch);
         // BUG-042: the geometry handlers (handleSaveEdit/handleDeleteFeature)
@@ -287,9 +341,11 @@ export function useFeatureEditing({
         // Cache-bust the vector tiles so the edited attributes render. Geometry
         // is unchanged, so the selection is intentionally kept.
         reloadTiles();
+        return { applied: true };
       } catch (err) {
         // fix(#458 E-36): keep the backend detail.
         toast.error(formatMutationError('dataset:map.attributesUpdateFailed', err));
+        return { applied: true };
       }
     },
     [datasetId, updateFeatureMutation, setSelectedFeature, reloadTiles, t],
@@ -386,5 +442,6 @@ export function useFeatureEditing({
     selectFeatureFromMap,
     reloadTiles,
     cleanupOverlayListener,
+    resetOverlay,
   };
 }

--- a/frontend/src/components/dataset/hooks/use-feature-editing.ts
+++ b/frontend/src/components/dataset/hooks/use-feature-editing.ts
@@ -84,6 +84,20 @@ interface UseFeatureEditingOptions {
   clear: () => void;
 }
 
+/**
+ * fix(#1761 review round 7): shared by every mutation's success AND failure
+ * path — round 5/6 found catch blocks that skipped the same epoch recheck
+ * their own success path already did, so a request that FAILED after an
+ * identity change still surfaced its error toast (and, for create, its
+ * failed-write UI feedback) to whoever is signed in now. One helper used in
+ * all six places (three successes, three failures) instead of six
+ * hand-rolled comparisons, so a seventh mutation added later has an
+ * unmissable pattern to copy.
+ */
+function isStale(epoch: number): boolean {
+  return useDrawingStore.getState().sessionEpoch !== epoch;
+}
+
 export function useFeatureEditing({
   mapRef,
   datasetId,
@@ -176,7 +190,7 @@ export function useFeatureEditing({
         // here would only be feedback for an identity that is no longer
         // looking, and re-arming the listener below would have nothing
         // useful left to clear.
-        if (useDrawingStore.getState().sessionEpoch !== epoch) return;
+        if (isStale(epoch)) return;
         toast.success(t('map.featureSaved'));
         reloadTiles();
 
@@ -189,7 +203,7 @@ export function useFeatureEditing({
             // again in the gap before the tile-load event (or the 5s
             // fallback) fires, and a second identity may have started
             // their own overlay by then.
-            if (useDrawingStore.getState().sessionEpoch !== epoch) return;
+            if (isStale(epoch)) return;
             overlayFeaturesRef.current = [];
             const src = map.getSource('drawn-overlay') as GeoJSONSource | undefined;
             src?.setData(EMPTY_FC);
@@ -213,9 +227,16 @@ export function useFeatureEditing({
           };
         }
       } catch (err) {
-        // fix(#458 E-36): surface the backend's reason (invalid geometry,
-        // type mismatch) like the table path does, not a bare "failed".
-        toast.error(formatMutationError('dataset:map.featureSaveFailed', err));
+        // fix(#1761 review round 7): the toast is feedback for whoever
+        // issued this request — reject it the same way the success branch
+        // above already does, or a failed create surfaces A's backend
+        // error to B. The overlay-ref filtering below stays unconditional:
+        // see its own comment for why it's already safe either way.
+        if (!isStale(epoch)) {
+          // fix(#458 E-36): surface the backend's reason (invalid geometry,
+          // type mismatch) like the table path does, not a bare "failed".
+          toast.error(formatMutationError('dataset:map.featureSaveFailed', err));
+        }
         // Not epoch-gated: this filters OUT the one feature this specific
         // call added, by object identity, rather than clearing the ref —
         // safe even if a second identity has since added their own
@@ -268,7 +289,7 @@ export function useFeatureEditing({
       // filters out from under them, and clear THEIR selectedFeature. The
       // write already landed server-side, which is as far as a stale
       // caller's responsibility goes — skip the rest.
-      if (useDrawingStore.getState().sessionEpoch !== epoch) return;
+      if (isStale(epoch)) return;
       toast.success(t('map.featureUpdated'));
       try { removeFeatures([sf.tdId]); } catch { /* already removed */ }
       reloadTiles();
@@ -276,6 +297,10 @@ export function useFeatureEditing({
       if (map) showAllFeaturesInTiles(map);
       clearSelectedFeature();
     } catch (err) {
+      // fix(#1761 review round 7): mirror the success branch's recheck —
+      // a failed update is feedback for whoever issued it, not whoever is
+      // signed in by the time it rejects.
+      if (isStale(epoch)) return;
       // fix(#458 E-36): keep the backend detail.
       toast.error(formatMutationError('dataset:map.featureUpdateFailed', err));
     }
@@ -294,7 +319,7 @@ export function useFeatureEditing({
     const epoch = useDrawingStore.getState().sessionEpoch;
     try {
       await deleteFeatureMutation.mutateAsync({ datasetId, gid: sf.gid });
-      if (useDrawingStore.getState().sessionEpoch !== epoch) return;
+      if (isStale(epoch)) return;
       toast.success(t('map.featureDeleted'));
       try { removeFeatures([sf.tdId]); } catch { /* already removed */ }
       reloadTiles();
@@ -302,6 +327,10 @@ export function useFeatureEditing({
       if (map) showAllFeaturesInTiles(map);
       clearSelectedFeature();
     } catch (err) {
+      // fix(#1761 review round 7): mirror the success branch's recheck —
+      // a failed delete is feedback for whoever issued it, not whoever is
+      // signed in by the time it rejects.
+      if (isStale(epoch)) return;
       // fix(#458 E-36): keep the backend detail.
       toast.error(formatMutationError('dataset:map.featureDeleteFailed', err));
     }
@@ -332,7 +361,7 @@ export function useFeatureEditing({
         // tiles. setSelectedFeature's own epoch check already refuses the
         // store write on its own, but this validates it BEFORE those other
         // effects run and reports it to the caller via the return value.
-        if (useDrawingStore.getState().sessionEpoch !== epoch) return { applied: false };
+        if (isStale(epoch)) return { applied: false };
         toast.success(t('map.attributesUpdated'));
         setSelectedFeature({ ...sf, properties: { ...sf.properties, ...properties } }, epoch);
         // BUG-042: the geometry handlers (handleSaveEdit/handleDeleteFeature)
@@ -350,7 +379,7 @@ export function useFeatureEditing({
         // an error toast and telling the caller to close would be exactly
         // the same collateral damage the success path already guards
         // against, just via the rejection branch instead of the resolve one.
-        if (useDrawingStore.getState().sessionEpoch !== epoch) return { applied: false };
+        if (isStale(epoch)) return { applied: false };
         // fix(#458 E-36): keep the backend detail.
         toast.error(formatMutationError('dataset:map.attributesUpdateFailed', err));
         return { applied: true };
@@ -403,7 +432,7 @@ export function useFeatureEditing({
         // addFeatures() below would already have installed the stale
         // geometry on the map, and the rest of this block would go on to
         // select it and hide its tile.
-        if (useDrawingStore.getState().sessionEpoch !== epoch) return;
+        if (isStale(epoch)) return;
         clear();
 
         if (!fullFeature.geometry) {

--- a/frontend/src/components/search/FilterPanel.tsx
+++ b/frontend/src/components/search/FilterPanel.tsx
@@ -1,4 +1,4 @@
-import { lazy, Suspense, useState } from 'react';
+import { lazy, Suspense, useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Calendar, MapPin } from 'lucide-react';
 import { Button } from '@/components/ui/button';
@@ -21,6 +21,7 @@ import { FilterSheet } from './FilterSheet';
 import { KeywordFacetPicker } from './KeywordFacetPicker';
 import { SaveSearchButton } from './SavedSearches';
 import { useSearchStore } from '@/stores/search-store';
+import { useResetOnEpoch } from '@/hooks/use-reset-on-epoch';
 import { useAuthStore } from '@/stores/auth-store';
 import { useCatalogSummary, useFacets } from '@/components/search/hooks/use-search';
 import { getGeometryTypeLabel, getSearchSortLabel } from '@/i18n/labels';
@@ -122,6 +123,7 @@ export function FilterPanel({
   const selectedKeywords = useSearchStore((s) => s.keywords);
   const geometry = useSearchStore((s) => s.geometry);
   const q = useSearchStore((s) => s.q);
+  const resetEpoch = useSearchStore((s) => s.resetEpoch);
   const token = useAuthStore((s) => s.token);
 
   // ====================================================================
@@ -198,6 +200,19 @@ export function FilterPanel({
     setLocalDateFrom(useSearchStore.getState().date_from);
     setLocalDateTo(useSearchStore.getState().date_to);
   };
+
+  // fix(#1761 review round 4): an identity change bumps resetEpoch (see
+  // search-store.ts's doc comment) whether or not date_from/date_to
+  // actually changed value. Without this, an uncommitted date draft typed
+  // under the previous identity survives the clear and Apply repopulates
+  // the (now cleared) store and URL with it. Closing the popover too, so
+  // a stale draft can't sit there waiting for a click.
+  const resetDateDraft = useCallback(() => {
+    setLocalDateFrom(useSearchStore.getState().date_from);
+    setLocalDateTo(useSearchStore.getState().date_to);
+    setDateOpen(false);
+  }, []);
+  useResetOnEpoch(resetEpoch, resetDateDraft);
 
   const handleApplyDate = () => {
     useSearchStore.getState().setFilter('date_from', localDateFrom);

--- a/frontend/src/components/search/FilterSheet.tsx
+++ b/frontend/src/components/search/FilterSheet.tsx
@@ -1,4 +1,4 @@
-import { lazy, Suspense, useState } from 'react';
+import { lazy, Suspense, useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Loader2, MapPin, SlidersHorizontal } from 'lucide-react';
 import { Button } from '@/components/ui/button';
@@ -22,6 +22,7 @@ import { FilterChip } from './FilterChip';
 import { KeywordFacetPicker } from './KeywordFacetPicker';
 import { SaveSearchButton } from './SavedSearches';
 import { useSearchStore } from '@/stores/search-store';
+import { useResetOnEpoch } from '@/hooks/use-reset-on-epoch';
 import { useAuthStore } from '@/stores/auth-store';
 import { useCatalogSummary, useFacets } from '@/components/search/hooks/use-search';
 import { getGeometryTypeLabel, getSearchSortLabel } from '@/i18n/labels';
@@ -96,6 +97,7 @@ export function FilterSheet({ totalResults }: FilterSheetProps) {
   const selectedKeywords = useSearchStore((s) => s.keywords);
   const geometry = useSearchStore((s) => s.geometry);
   const q = useSearchStore((s) => s.q);
+  const resetEpoch = useSearchStore((s) => s.resetEpoch);
   const token = useAuthStore((s) => s.token);
 
   const { data: facets } = useFacets();
@@ -153,6 +155,21 @@ export function FilterSheet({ totalResults }: FilterSheetProps) {
     setLocalDateFrom(useSearchStore.getState().date_from);
     setLocalDateTo(useSearchStore.getState().date_to);
   };
+
+  // fix(#1761 review round 4): same rationale as FilterPanel's
+  // resetDateDraft — an identity change bumps resetEpoch even when
+  // date_from/date_to were already '', so an uncommitted draft would
+  // otherwise survive to repopulate the (now cleared) store on Apply.
+  // Closes the whole sheet (and its nested bbox popover), not just the
+  // date fields, since everything in it is this identity's in-progress
+  // filter edit.
+  const resetSheetDraft = useCallback(() => {
+    setLocalDateFrom(useSearchStore.getState().date_from);
+    setLocalDateTo(useSearchStore.getState().date_to);
+    setBboxOpen(false);
+    setMobileFiltersOpen(false);
+  }, []);
+  useResetOnEpoch(resetEpoch, resetSheetDraft);
 
   const handleApplyDate = () => {
     useSearchStore.getState().setFilter('date_from', localDateFrom);

--- a/frontend/src/components/search/SearchBar.tsx
+++ b/frontend/src/components/search/SearchBar.tsx
@@ -1,8 +1,9 @@
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, useCallback } from 'react';
 import { Search, X } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { Input } from '@/components/ui/input';
 import { useDebouncedValue } from '@/hooks/use-debounce';
+import { useResetOnEpoch } from '@/hooks/use-reset-on-epoch';
 import { useSearchStore } from '@/stores/search-store';
 import { cn } from '@/lib/utils';
 import { SearchTypeahead } from './SearchTypeahead';
@@ -22,10 +23,6 @@ export function SearchBar({ mode = 'hero', className }: SearchBarProps) {
   const debouncedValue = useDebouncedValue(value, 300);
   const blurTimeoutRef = useRef<ReturnType<typeof setTimeout>>(undefined);
   const inputRef = useRef<HTMLInputElement>(null);
-  // fix(#1761 review P2): skip on mount — only react to a LATER bump, or
-  // mounting on a page whose store already carries a real query would wipe
-  // the input the instant it appears.
-  const resetEpochRef = useRef(resetEpoch);
 
   useEffect(() => {
     useSearchStore.getState().setQuery(debouncedValue);
@@ -36,20 +33,21 @@ export function SearchBar({ mode = 'hero', className }: SearchBarProps) {
     setValue(query);
   }, [query]);
 
-  // fix(#1761 review P2): an identity change bumps resetEpoch even when `q`
-  // was already '' (nothing had been committed to the store yet), so the
-  // `[query]` effect above sees no change and does not fire. Resetting
-  // `value` here changes useDebouncedValue's input, which is what actually
-  // cancels its in-flight timer (see useDebouncedValue's cleanup) — without
-  // this, a keystroke typed under the previous identity still lands in the
-  // new identity's store a few hundred ms later.
-  useEffect(() => {
-    if (resetEpochRef.current === resetEpoch) return;
-    resetEpochRef.current = resetEpoch;
+  // fix(#1761 review P2, extracted round 4): an identity change bumps
+  // resetEpoch even when `q` was already '' (nothing had been committed to
+  // the store yet), so the `[query]` effect above sees no change and does
+  // not fire. Resetting `value` here changes useDebouncedValue's input,
+  // which is what actually cancels its in-flight timer (see
+  // useDebouncedValue's cleanup) — without this, a keystroke typed under
+  // the previous identity still lands in the new identity's store a few
+  // hundred ms later. Shared with FilterPanel/FilterSheet via
+  // useResetOnEpoch — see that hook for the skip-on-mount rationale.
+  const resetOnIdentityChange = useCallback(() => {
     setValue(useSearchStore.getState().q);
     setShowTypeahead(false);
     setActiveDescendant(null);
-  }, [resetEpoch]);
+  }, []);
+  useResetOnEpoch(resetEpoch, resetOnIdentityChange);
 
   // Cleanup blur timeout on unmount
   useEffect(() => {

--- a/frontend/src/components/search/SearchBar.tsx
+++ b/frontend/src/components/search/SearchBar.tsx
@@ -17,20 +17,37 @@ export function SearchBar({ mode = 'hero', className }: SearchBarProps) {
   const { t } = useTranslation('search');
   const query = useSearchStore((s) => s.q);
   const resetEpoch = useSearchStore((s) => s.resetEpoch);
-  const [value, setValue] = useState(query);
+  // fix(#1761 review round 6): `value` and the epoch it was typed under
+  // travel together in ONE state slot, set atomically by the same call.
+  // Round 4's fix derived the paired epoch reactively (`useMemo` over
+  // `[value, resetEpoch]`), which reads the CURRENT `resetEpoch` even in a
+  // render where `value` has not been reset yet — codex reproduced exactly
+  // that torn intermediate pairing (new epoch, stale text) by advancing the
+  // debounce timer in the same batch as an identity change. Setting both
+  // fields together, only from the input's own onChange/clear handlers and
+  // from the resets below, means `entry.epoch` can only ever be the epoch
+  // that was live at the moment `entry.value` was actually produced.
+  const [entry, setEntry] = useState(() => ({ value: query, epoch: resetEpoch }));
   const [showTypeahead, setShowTypeahead] = useState(false);
   const [activeDescendant, setActiveDescendant] = useState<string | null>(null);
-  const debouncedValue = useDebouncedValue(value, 300);
+  const debouncedEntry = useDebouncedValue(entry, 300);
   const blurTimeoutRef = useRef<ReturnType<typeof setTimeout>>(undefined);
   const inputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
-    useSearchStore.getState().setQuery(debouncedValue);
-  }, [debouncedValue]);
+    // fix(#1761 review round 6): reject a debounced result whose captured
+    // epoch no longer matches the live one — it was typed under an
+    // identity that is no longer current. The reset below re-arms a fresh
+    // debounce for the cleared text under the new epoch.
+    if (debouncedEntry.epoch !== useSearchStore.getState().resetEpoch) return;
+    useSearchStore.getState().setQuery(debouncedEntry.value);
+  }, [debouncedEntry]);
 
-  // Sync external store changes (e.g., reset filters) back to local state
+  // Sync external store changes (e.g., reset filters) back to local state.
+  // Only `value` — an external `q` change is not itself an identity change,
+  // so the epoch this typed-or-cleared text is stamped with is unaffected.
   useEffect(() => {
-    setValue(query);
+    setEntry((prev) => ({ ...prev, value: query }));
   }, [query]);
 
   // fix(#1761 review P2, extracted round 4): an identity change bumps
@@ -43,7 +60,8 @@ export function SearchBar({ mode = 'hero', className }: SearchBarProps) {
   // hundred ms later. Shared with FilterPanel/FilterSheet via
   // useResetOnEpoch — see that hook for the skip-on-mount rationale.
   const resetOnIdentityChange = useCallback(() => {
-    setValue(useSearchStore.getState().q);
+    const state = useSearchStore.getState();
+    setEntry({ value: state.q, epoch: state.resetEpoch });
     setShowTypeahead(false);
     setActiveDescendant(null);
   }, []);
@@ -86,9 +104,9 @@ export function SearchBar({ mode = 'hero', className }: SearchBarProps) {
         aria-label={t('placeholder')}
         aria-controls={showTypeahead ? typeaheadId : undefined}
         aria-activedescendant={showTypeahead ? activeDescendant ?? undefined : undefined}
-        value={value}
+        value={entry.value}
         onChange={(e) => {
-          setValue(e.target.value);
+          setEntry({ value: e.target.value, epoch: useSearchStore.getState().resetEpoch });
           if (e.target.value.length >= 2) {
             setShowTypeahead(true);
           } else {
@@ -96,7 +114,7 @@ export function SearchBar({ mode = 'hero', className }: SearchBarProps) {
           }
         }}
         onFocus={() => {
-          if (value.length >= 2) setShowTypeahead(true);
+          if (entry.value.length >= 2) setShowTypeahead(true);
         }}
         onBlur={() => {
           // Small delay so click on typeahead result can fire first
@@ -110,11 +128,11 @@ export function SearchBar({ mode = 'hero', className }: SearchBarProps) {
             : 'h-14 rounded-lg ps-12 pe-12 text-base',
         )}
       />
-      {value && (
+      {entry.value && (
         <button
           type="button"
           onClick={() => {
-            setValue('');
+            setEntry({ value: '', epoch: useSearchStore.getState().resetEpoch });
             closeTypeahead();
           }}
           aria-label={t('clearSearch', { defaultValue: 'Clear search' })}
@@ -128,7 +146,7 @@ export function SearchBar({ mode = 'hero', className }: SearchBarProps) {
       )}
       {showTypeahead && (
         <SearchTypeahead
-          query={value}
+          query={entry.value}
           inputRef={inputRef}
           listboxId={typeaheadId}
           onActiveDescendantChange={setActiveDescendant}

--- a/frontend/src/components/search/SearchBar.tsx
+++ b/frontend/src/components/search/SearchBar.tsx
@@ -15,12 +15,17 @@ interface SearchBarProps {
 export function SearchBar({ mode = 'hero', className }: SearchBarProps) {
   const { t } = useTranslation('search');
   const query = useSearchStore((s) => s.q);
+  const resetEpoch = useSearchStore((s) => s.resetEpoch);
   const [value, setValue] = useState(query);
   const [showTypeahead, setShowTypeahead] = useState(false);
   const [activeDescendant, setActiveDescendant] = useState<string | null>(null);
   const debouncedValue = useDebouncedValue(value, 300);
   const blurTimeoutRef = useRef<ReturnType<typeof setTimeout>>(undefined);
   const inputRef = useRef<HTMLInputElement>(null);
+  // fix(#1761 review P2): skip on mount — only react to a LATER bump, or
+  // mounting on a page whose store already carries a real query would wipe
+  // the input the instant it appears.
+  const resetEpochRef = useRef(resetEpoch);
 
   useEffect(() => {
     useSearchStore.getState().setQuery(debouncedValue);
@@ -30,6 +35,21 @@ export function SearchBar({ mode = 'hero', className }: SearchBarProps) {
   useEffect(() => {
     setValue(query);
   }, [query]);
+
+  // fix(#1761 review P2): an identity change bumps resetEpoch even when `q`
+  // was already '' (nothing had been committed to the store yet), so the
+  // `[query]` effect above sees no change and does not fire. Resetting
+  // `value` here changes useDebouncedValue's input, which is what actually
+  // cancels its in-flight timer (see useDebouncedValue's cleanup) — without
+  // this, a keystroke typed under the previous identity still lands in the
+  // new identity's store a few hundred ms later.
+  useEffect(() => {
+    if (resetEpochRef.current === resetEpoch) return;
+    resetEpochRef.current = resetEpoch;
+    setValue(useSearchStore.getState().q);
+    setShowTypeahead(false);
+    setActiveDescendant(null);
+  }, [resetEpoch]);
 
   // Cleanup blur timeout on unmount
   useEffect(() => {

--- a/frontend/src/components/search/__tests__/FilterPanel.test.tsx
+++ b/frontend/src/components/search/__tests__/FilterPanel.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@/test/test-utils';
+import { act, fireEvent, render, screen } from '@/test/test-utils';
 import { FilterPanel } from '../FilterPanel';
 import { useSearchStore } from '@/stores/search-store';
 
@@ -84,5 +84,65 @@ describe('FilterPanel', () => {
     const secondaryRow = screen.getByTestId('secondary-filter-row');
     expect(secondaryRow).toBeInTheDocument();
     expect(secondaryRow).toHaveTextContent(/Vector.*filters/);
+  });
+});
+
+// fix(#1761 review round 4): the uncommitted date-range draft
+// (localDateFrom/localDateTo) used to survive an identity change, so
+// clicking the still-open popover's Apply afterward repopulated the
+// (now cleared) store and URL with the previous identity's typed dates.
+describe('FilterPanel identity reset (fix #1761 review round 4)', () => {
+  afterEach(() => {
+    useSearchStore.getState().resetFilters();
+  });
+
+  // Radix Popover portals its content to document.body, outside render()'s
+  // own container, so query the document rather than the container.
+  function getDateInputs() {
+    return Array.from(document.querySelectorAll<HTMLInputElement>('input[type="date"]'));
+  }
+
+  it('clears an uncommitted date draft and closes the popover when identity changes', () => {
+    render(<FilterPanel totalResults={10} showMobile={false} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /Date Added/i }));
+    const [fromInput] = getDateInputs();
+    fireEvent.change(fromInput, { target: { value: '2024-01-01' } });
+    expect(getDateInputs()[0]).toHaveValue('2024-01-01');
+    // Still uncommitted: date_from in the store is untouched.
+    expect(useSearchStore.getState().date_from).toBe('');
+
+    // Identity changes (the auth choke point's identity-change branch)
+    // WITHOUT the user clicking Apply.
+    act(() => {
+      useSearchStore.getState().clearIdentityScopedFilters();
+    });
+
+    // Popover closed: Apply is no longer reachable with the stale draft.
+    expect(screen.queryByRole('button', { name: /Apply/i })).not.toBeInTheDocument();
+
+    // Reopening shows the cleared value, not the stale draft.
+    fireEvent.click(screen.getByRole('button', { name: /Date Added/i }));
+    expect(getDateInputs()[0]).toHaveValue('');
+  });
+
+  // fix(#1761 review round 4, sweep): spatialPanelOpen was originally
+  // classified as a kept presentation preference, but it gates whether
+  // SpatialFilterPanel is mounted, and that component holds its own
+  // uncommitted pendingBbox/predicate draft — the same class of bug as the
+  // date draft above, just reached through onApply instead of directly.
+  // Left open across an identity change, Apply would write the previous
+  // identity's drawn area into the just-cleared store.
+  it('closes the spatial filter panel on identity change', () => {
+    render(<FilterPanel totalResults={10} showMobile={false} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /^Location$/i }));
+    expect(useSearchStore.getState().spatialPanelOpen).toBe(true);
+
+    act(() => {
+      useSearchStore.getState().clearIdentityScopedFilters();
+    });
+
+    expect(useSearchStore.getState().spatialPanelOpen).toBe(false);
   });
 });

--- a/frontend/src/components/search/__tests__/FilterSheet.test.tsx
+++ b/frontend/src/components/search/__tests__/FilterSheet.test.tsx
@@ -1,0 +1,57 @@
+import { act, fireEvent, render, screen } from '@/test/test-utils';
+import { FilterSheet } from '../FilterSheet';
+import { useSearchStore } from '@/stores/search-store';
+
+vi.mock('@/components/search/hooks/use-search', () => ({
+  useFacets: () => ({ data: { record_type: {} }, isLoading: false }),
+  useCatalogSummary: () => ({ data: undefined, isLoading: false }),
+}));
+
+vi.mock('../SavedSearches', () => ({
+  SaveSearchButton: () => null,
+}));
+
+vi.mock('../BboxMapPicker', () => ({
+  BboxMapPicker: () => <div>mock-map</div>,
+}));
+
+// fix(#1761 review round 4): same class as FilterPanel — the uncommitted
+// date-range draft (localDateFrom/localDateTo) used to survive an identity
+// change, so clicking Apply afterward repopulated the (now cleared) store
+// with the previous identity's typed dates. The whole sheet (and its
+// nested bbox popover) should also close.
+describe('FilterSheet identity reset (fix #1761 review round 4)', () => {
+  afterEach(() => {
+    useSearchStore.getState().resetFilters();
+  });
+
+  // The "Date Added" draft inputs render before the (unrelated,
+  // directly-committed) Temporal Extent inputs, so they are always the
+  // first two type="date" inputs once the sheet is open.
+  function getDateDraftInputs() {
+    return Array.from(document.querySelectorAll<HTMLInputElement>('input[type="date"]')).slice(0, 2);
+  }
+
+  it('clears an uncommitted date draft and closes the sheet when identity changes', () => {
+    render(<FilterSheet totalResults={10} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /Filters/i }));
+    const [fromInput] = getDateDraftInputs();
+    fireEvent.change(fromInput, { target: { value: '2024-01-01' } });
+    expect(getDateDraftInputs()[0]).toHaveValue('2024-01-01');
+    expect(useSearchStore.getState().date_from).toBe('');
+
+    // Identity changes WITHOUT the user clicking Apply.
+    act(() => {
+      useSearchStore.getState().clearIdentityScopedFilters();
+    });
+
+    // The whole sheet closed — its contents (including the stale draft)
+    // are no longer reachable.
+    expect(screen.queryByRole('button', { name: /^Apply$/i })).not.toBeInTheDocument();
+
+    // Reopening shows the cleared value, not the stale draft.
+    fireEvent.click(screen.getByRole('button', { name: /Filters/i }));
+    expect(getDateDraftInputs()[0]).toHaveValue('');
+  });
+});

--- a/frontend/src/components/search/__tests__/SearchBar.identity.test.tsx
+++ b/frontend/src/components/search/__tests__/SearchBar.identity.test.tsx
@@ -1,4 +1,4 @@
-import { act, screen } from '@testing-library/react';
+import { act, screen, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { QueryClient } from '@tanstack/react-query';
 import { render } from '@/test/test-utils';
@@ -60,6 +60,61 @@ describe('SearchBar identity reset (#1761 review P2)', () => {
 
       expect(useSearchStore.getState().q).toBe('');
       expect(input).toHaveValue('');
+    } finally {
+      unsubscribe();
+    }
+  });
+
+  // fix(#1761 review round 6): a NARROWER race than the one above — here
+  // the 300ms timer fires in the SAME React batch as the identity
+  // transition, rather than before it. The earlier fix canceled a
+  // still-PENDING timer by changing its input; it did nothing for a
+  // result that has ALREADY fired but not yet been committed, which is
+  // exactly what codex reproduced by advancing the timer and switching
+  // users inside one act().
+  it('rejects a debounced value whose epoch is stale when the timer fires in the same batch as an identity change', async () => {
+    // Deliberately NOT shouldAdvanceTime here (unlike the test above): that
+    // option ticks the fake clock forward in step with real wall-clock time,
+    // which let earlier debounce timers fire before this test's explicit
+    // advanceTimersByTimeAsync call and made the reproduction non-
+    // deterministic. This test needs precise control over exactly when the
+    // 300ms elapses relative to the identity change, so it also uses
+    // fireEvent (a single synchronous change) rather than userEvent.type,
+    // which needs its own timer advancement between keystrokes.
+    vi.useFakeTimers();
+    const qc = new QueryClient();
+    const unsubscribe = wireAuthCacheReset(qc);
+
+    try {
+      act(() => {
+        useAuthStore.setState({ token: 't1', user: { id: 'user-1' } as UserResponse });
+      });
+      render(<SearchBar />);
+
+      const input = screen.getByPlaceholderText(/search the catalog/i);
+      act(() => {
+        fireEvent.change(input, { target: { value: 'user-1 secret' } });
+      });
+      expect(useSearchStore.getState().q).toBe('');
+
+      // Identity change and the debounce timer's own commit happen inside
+      // the SAME act() — the exact reproduction codex described.
+      await act(async () => {
+        useAuthStore.setState({ token: 't2', user: { id: 'user-2' } as UserResponse });
+        await vi.advanceTimersByTimeAsync(500);
+      });
+
+      // The previous identity's text must never land in the store (and by
+      // extension the search request/URL), even transiently.
+      expect(useSearchStore.getState().q).toBe('');
+      expect(input).toHaveValue('');
+
+      // The reset effect's own value change re-arms a fresh debounce for
+      // the cleared text, which settles normally afterward.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(500);
+      });
+      expect(useSearchStore.getState().q).toBe('');
     } finally {
       unsubscribe();
     }

--- a/frontend/src/components/search/__tests__/SearchBar.identity.test.tsx
+++ b/frontend/src/components/search/__tests__/SearchBar.identity.test.tsx
@@ -1,0 +1,67 @@
+import { act, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClient } from '@tanstack/react-query';
+import { render } from '@/test/test-utils';
+import { useSearchStore } from '@/stores/search-store';
+import { useAuthStore } from '@/stores/auth-store';
+import { wireAuthCacheReset } from '@/lib/auth-cache-reset';
+import { SearchBar } from '../SearchBar';
+import type { UserResponse } from '@/types/api';
+
+vi.mock('../SearchTypeahead', () => ({
+  SearchTypeahead: () => null,
+}));
+
+/**
+ * fix(#1761 review P2): deliberately does NOT mock useDebouncedValue, unlike
+ * SearchBar.test.tsx — the bug this pins lives in the real 300ms window
+ * between a keystroke and the debounced setQuery() call, so the test needs
+ * the real timer.
+ */
+const initialSearchState = useSearchStore.getState();
+const initialAuthState = useAuthStore.getState();
+
+describe('SearchBar identity reset (#1761 review P2)', () => {
+  beforeEach(() => {
+    useSearchStore.setState(initialSearchState, true);
+    useAuthStore.setState(initialAuthState, true);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('cancels a pending debounced query when identity changes before it fires', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    const user = userEvent.setup({ delay: null });
+    const qc = new QueryClient();
+    const unsubscribe = wireAuthCacheReset(qc);
+
+    try {
+      act(() => {
+        useAuthStore.setState({ token: 't1', user: { id: 'user-1' } as UserResponse });
+      });
+      render(<SearchBar />);
+
+      const input = screen.getByPlaceholderText(/search the catalog/i);
+      await user.type(input, 'user-1 secret');
+      expect(input).toHaveValue('user-1 secret');
+      // Still inside the 300ms debounce window: nothing committed yet, so
+      // `q` alone gives no signal that anything changed.
+      expect(useSearchStore.getState().q).toBe('');
+
+      // Identity changes WITHOUT a page reload, before the debounce fires.
+      act(() => {
+        useAuthStore.setState({ token: 't2', user: { id: 'user-2' } as UserResponse });
+      });
+
+      // Let the original debounce window fully elapse.
+      await vi.advanceTimersByTimeAsync(500);
+
+      expect(useSearchStore.getState().q).toBe('');
+      expect(input).toHaveValue('');
+    } finally {
+      unsubscribe();
+    }
+  });
+});

--- a/frontend/src/hooks/__tests__/use-reset-on-epoch.test.ts
+++ b/frontend/src/hooks/__tests__/use-reset-on-epoch.test.ts
@@ -1,0 +1,51 @@
+import { renderHook } from '@testing-library/react';
+import { useResetOnEpoch } from '@/hooks/use-reset-on-epoch';
+
+// fix(#1761 review round 4): shared by SearchBar, FilterPanel and
+// FilterSheet — see their identity tests for the end-to-end behavior this
+// enables. These pin the hook's own contract in isolation.
+describe('useResetOnEpoch', () => {
+  it('does not call reset on mount, even with a nonzero starting epoch', () => {
+    const reset = vi.fn();
+    renderHook(({ epoch }) => useResetOnEpoch(epoch, reset), {
+      initialProps: { epoch: 42 },
+    });
+
+    expect(reset).not.toHaveBeenCalled();
+  });
+
+  it('calls reset when the epoch changes after mount', () => {
+    const reset = vi.fn();
+    const { rerender } = renderHook(({ epoch }) => useResetOnEpoch(epoch, reset), {
+      initialProps: { epoch: 0 },
+    });
+
+    rerender({ epoch: 1 });
+
+    expect(reset).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not call reset again on a re-render with the same epoch', () => {
+    const reset = vi.fn();
+    const { rerender } = renderHook(({ epoch }) => useResetOnEpoch(epoch, reset), {
+      initialProps: { epoch: 0 },
+    });
+
+    rerender({ epoch: 1 });
+    rerender({ epoch: 1 });
+
+    expect(reset).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls reset once per subsequent epoch change', () => {
+    const reset = vi.fn();
+    const { rerender } = renderHook(({ epoch }) => useResetOnEpoch(epoch, reset), {
+      initialProps: { epoch: 0 },
+    });
+
+    rerender({ epoch: 1 });
+    rerender({ epoch: 2 });
+
+    expect(reset).toHaveBeenCalledTimes(2);
+  });
+});

--- a/frontend/src/hooks/use-reset-on-epoch.ts
+++ b/frontend/src/hooks/use-reset-on-epoch.ts
@@ -1,0 +1,29 @@
+import { useEffect, useRef } from 'react';
+
+/**
+ * fix(#1761 review round 4): runs `reset()` whenever `epoch` changes after
+ * mount — never on the initial render, so mounting on a page whose epoch is
+ * already nonzero doesn't spuriously discard state someone is legitimately
+ * resuming (the pattern this was extracted from, in SearchBar).
+ *
+ * Shared by every consumer that keeps identity-scoped local UI state
+ * alongside a store's own reset-epoch counter: drawing-store's
+ * sessionEpoch (DatasetMap's local drawing session) and search-store's
+ * resetEpoch (SearchBar's typed-but-undebounced query, FilterPanel's and
+ * FilterSheet's uncommitted date-range draft). Extracted so all of them
+ * share one skip-on-mount implementation instead of reimplementing the
+ * ref dance per consumer.
+ *
+ * `reset` should be memoized (`useCallback`) by the caller — it is an
+ * effect dependency, so an unstable reference re-arms this every render.
+ * That is harmless (the epoch guard below still short-circuits before
+ * calling it), just wasteful.
+ */
+export function useResetOnEpoch(epoch: number, reset: () => void): void {
+  const epochRef = useRef(epoch);
+  useEffect(() => {
+    if (epochRef.current === epoch) return;
+    epochRef.current = epoch;
+    reset();
+  }, [epoch, reset]);
+}

--- a/frontend/src/lib/__tests__/auth-cache-reset.test.ts
+++ b/frontend/src/lib/__tests__/auth-cache-reset.test.ts
@@ -84,7 +84,10 @@ describe('wireAuthCacheReset', () => {
       useDrawingStore.getState().setDrawing('ds-1', 'my_table', 'Polygon');
       useDrawingStore
         .getState()
-        .setSelectedFeature({ gid: 1, tdId: 'td-1', properties: { name: 'user-1 row' } });
+        .setSelectedFeature(
+          { gid: 1, tdId: 'td-1', properties: { name: 'user-1 row' } },
+          useDrawingStore.getState().sessionEpoch,
+        );
       useDrawingStore.getState().setEditDirty(true);
       expect(useDrawingStore.getState().selectedFeature).not.toBeNull();
 
@@ -132,6 +135,9 @@ describe('wireAuthCacheReset', () => {
     try {
       useAuthStore.setState({ token: 't1', user: { id: 'user-1' } as UserResponse });
       useDrawingStore.getState().setDrawing('ds-1', 'my_table', 'Polygon');
+      // Captured BEFORE the logout, the way handleEditAttributeSubmit
+      // captures it before its own await.
+      const epoch = useDrawingStore.getState().sessionEpoch;
 
       // Logout: the choke point bumps the session epoch and clears.
       useAuthStore.setState({ token: null, user: null });
@@ -140,7 +146,7 @@ describe('wireAuthCacheReset', () => {
       // the dataset route still mounted for anonymous viewing.
       useDrawingStore
         .getState()
-        .setSelectedFeature({ gid: 1, tdId: 'td-1', properties: { name: 'user-1 row' } });
+        .setSelectedFeature({ gid: 1, tdId: 'td-1', properties: { name: 'user-1 row' } }, epoch);
 
       expect(useDrawingStore.getState().selectedFeature).toBeNull();
     } finally {
@@ -154,6 +160,7 @@ describe('wireAuthCacheReset', () => {
     try {
       useAuthStore.setState({ token: 't1', user: { id: 'user-1' } as UserResponse });
       useDrawingStore.getState().setDrawing('ds-1', 'my_table', 'Polygon');
+      const epoch = useDrawingStore.getState().sessionEpoch;
 
       // User B signs in without a page reload.
       useAuthStore.setState({ token: 't2', user: { id: 'user-2' } as UserResponse });
@@ -161,7 +168,7 @@ describe('wireAuthCacheReset', () => {
       // User A's late write arrives while B is signed in.
       useDrawingStore
         .getState()
-        .setSelectedFeature({ gid: 1, tdId: 'td-1', properties: { name: 'user-1 row' } });
+        .setSelectedFeature({ gid: 1, tdId: 'td-1', properties: { name: 'user-1 row' } }, epoch);
 
       expect(useDrawingStore.getState().selectedFeature).toBeNull();
     } finally {
@@ -184,7 +191,7 @@ describe('wireAuthCacheReset', () => {
       // The target adopted before the rotation is still valid: a write for
       // it succeeds rather than being refused.
       const feature = { gid: 1, tdId: 'td-1', properties: {} };
-      useDrawingStore.getState().setSelectedFeature(feature);
+      useDrawingStore.getState().setSelectedFeature(feature, useDrawingStore.getState().sessionEpoch);
       expect(useDrawingStore.getState().selectedFeature).toEqual(feature);
     } finally {
       unsubscribe();

--- a/frontend/src/lib/__tests__/auth-cache-reset.test.ts
+++ b/frontend/src/lib/__tests__/auth-cache-reset.test.ts
@@ -2,15 +2,21 @@ import { QueryClient } from '@tanstack/react-query';
 import { wireAuthCacheReset } from '../auth-cache-reset';
 import { useAuthStore } from '@/stores/auth-store';
 import { getReportEntries, pushReportEntry } from '@/lib/report';
+import { useDrawingStore } from '@/stores/drawing-store';
+import { useSearchStore } from '@/stores/search-store';
 import type { UserResponse } from '@/types/api';
 
 // fix(#430 codex r6): identity changes evict the whole query cache; token
 // refresh (same user id) does not.
 describe('wireAuthCacheReset', () => {
   const initialAuthState = useAuthStore.getState();
+  const initialDrawingState = useDrawingStore.getState();
+  const initialSearchState = useSearchStore.getState();
 
   afterEach(() => {
     useAuthStore.setState(initialAuthState, true);
+    useDrawingStore.setState(initialDrawingState, true);
+    useSearchStore.setState(initialSearchState, true);
   });
 
   function seed(qc: QueryClient) {
@@ -61,6 +67,101 @@ describe('wireAuthCacheReset', () => {
       // previous user's captured entries (fix(#1663 review P1)).
       useAuthStore.setState({ token: null, user: null });
       expect(getReportEntries()).toHaveLength(0);
+    } finally {
+      unsubscribe();
+    }
+  });
+
+  // fix(#1713): drawing-store's target dataset, selected feature (a real
+  // row's property bag) and edit-dirty flag are identity-scoped residue of
+  // the same kind — an in-place identity change must not leave them for the
+  // next signed-in user.
+  it('clears the drawing store when identity changes, not on token refresh', () => {
+    const qc = new QueryClient();
+    const unsubscribe = wireAuthCacheReset(qc);
+    try {
+      useAuthStore.setState({ token: 't1', user: { id: 'user-1' } as UserResponse });
+      useDrawingStore.getState().setDrawing('ds-1', 'my_table', 'Polygon');
+      useDrawingStore
+        .getState()
+        .setSelectedFeature({ gid: 1, tdId: 'td-1', properties: { name: 'user-1 row' } });
+      useDrawingStore.getState().setEditDirty(true);
+      expect(useDrawingStore.getState().selectedFeature).not.toBeNull();
+
+      // Token refresh (same identity): kept, including the dirty flag —
+      // DatasetPage's unsaved-changes prompt must not lose a real edit.
+      useAuthStore.setState({ token: 't2' });
+      expect(useDrawingStore.getState().selectedFeature).not.toBeNull();
+      expect(useDrawingStore.getState().isEditDirty).toBe(true);
+
+      // A second identity signs in WITHOUT a page reload: cleared.
+      useAuthStore.setState({ token: 't3', user: { id: 'user-2' } as UserResponse });
+      const state = useDrawingStore.getState();
+      expect(state.selectedFeature).toBeNull();
+      expect(state.targetDatasetId).toBeNull();
+      expect(state.isEditDirty).toBe(false);
+    } finally {
+      unsubscribe();
+    }
+  });
+
+  it('clears the drawing store on logout', () => {
+    const qc = new QueryClient();
+    const unsubscribe = wireAuthCacheReset(qc);
+    try {
+      useAuthStore.setState({ token: 't1', user: { id: 'user-1' } as UserResponse });
+      useDrawingStore.getState().setDrawing('ds-1', 'my_table', 'Polygon');
+      expect(useDrawingStore.getState().targetDatasetId).not.toBeNull();
+
+      useAuthStore.setState({ token: null, user: null });
+      expect(useDrawingStore.getState().targetDatasetId).toBeNull();
+    } finally {
+      unsubscribe();
+    }
+  });
+
+  // fix(#1713): milder than drawing-store — search intent, not row data —
+  // but the same class and the same choke point.
+  it('clears identity-scoped search fields when identity changes, not on token refresh', () => {
+    const qc = new QueryClient();
+    const unsubscribe = wireAuthCacheReset(qc);
+    try {
+      useAuthStore.setState({ token: 't1', user: { id: 'user-1' } as UserResponse });
+      useSearchStore.setState({
+        q: 'parks',
+        bbox: '1,2,3,4',
+        collection_id: 'c1',
+        keywords: ['water'],
+        geometry: '{"type":"Point","coordinates":[0,0]}',
+      });
+
+      // Token refresh (same identity): kept.
+      useAuthStore.setState({ token: 't2' });
+      expect(useSearchStore.getState().q).toBe('parks');
+
+      // A second identity signs in WITHOUT a page reload: cleared.
+      useAuthStore.setState({ token: 't3', user: { id: 'user-2' } as UserResponse });
+      const state = useSearchStore.getState();
+      expect(state.q).toBe('');
+      expect(state.bbox).toBe('');
+      expect(state.collection_id).toBe('');
+      expect(state.keywords).toEqual([]);
+      expect(state.geometry).toBe('');
+    } finally {
+      unsubscribe();
+    }
+  });
+
+  it('clears identity-scoped search fields on logout', () => {
+    const qc = new QueryClient();
+    const unsubscribe = wireAuthCacheReset(qc);
+    try {
+      useAuthStore.setState({ token: 't1', user: { id: 'user-1' } as UserResponse });
+      useSearchStore.setState({ q: 'parks' });
+      expect(useSearchStore.getState().q).toBe('parks');
+
+      useAuthStore.setState({ token: null, user: null });
+      expect(useSearchStore.getState().q).toBe('');
     } finally {
       unsubscribe();
     }

--- a/frontend/src/lib/__tests__/auth-cache-reset.test.ts
+++ b/frontend/src/lib/__tests__/auth-cache-reset.test.ts
@@ -120,6 +120,77 @@ describe('wireAuthCacheReset', () => {
     }
   });
 
+  // fix(#1761 review P1): the race the ownerId-only check missed —
+  // handleEditAttributeSubmit reads `selectedFeature` before an update
+  // mutation and calls setSelectedFeature again once it resolves. These pin
+  // that resolution being refused when it lands AFTER an identity change,
+  // through the real choke point (not bumpSessionEpoch() called directly,
+  // which is what drawing-store.test.ts's unit tests use).
+  it('refuses a write that arrives after logout, for a target adopted before it', () => {
+    const qc = new QueryClient();
+    const unsubscribe = wireAuthCacheReset(qc);
+    try {
+      useAuthStore.setState({ token: 't1', user: { id: 'user-1' } as UserResponse });
+      useDrawingStore.getState().setDrawing('ds-1', 'my_table', 'Polygon');
+
+      // Logout: the choke point bumps the session epoch and clears.
+      useAuthStore.setState({ token: null, user: null });
+
+      // The late write: captured before the logout, landing after it, with
+      // the dataset route still mounted for anonymous viewing.
+      useDrawingStore
+        .getState()
+        .setSelectedFeature({ gid: 1, tdId: 'td-1', properties: { name: 'user-1 row' } });
+
+      expect(useDrawingStore.getState().selectedFeature).toBeNull();
+    } finally {
+      unsubscribe();
+    }
+  });
+
+  it('refuses a write that arrives after a second identity signs in, for a target adopted by the first', () => {
+    const qc = new QueryClient();
+    const unsubscribe = wireAuthCacheReset(qc);
+    try {
+      useAuthStore.setState({ token: 't1', user: { id: 'user-1' } as UserResponse });
+      useDrawingStore.getState().setDrawing('ds-1', 'my_table', 'Polygon');
+
+      // User B signs in without a page reload.
+      useAuthStore.setState({ token: 't2', user: { id: 'user-2' } as UserResponse });
+
+      // User A's late write arrives while B is signed in.
+      useDrawingStore
+        .getState()
+        .setSelectedFeature({ gid: 1, tdId: 'td-1', properties: { name: 'user-1 row' } });
+
+      expect(useDrawingStore.getState().selectedFeature).toBeNull();
+    } finally {
+      unsubscribe();
+    }
+  });
+
+  it('does not bump the drawing session epoch on same-user token rotation', () => {
+    const qc = new QueryClient();
+    const unsubscribe = wireAuthCacheReset(qc);
+    try {
+      useAuthStore.setState({ token: 't1', user: { id: 'user-1' } as UserResponse });
+      useDrawingStore.getState().setDrawing('ds-1', 'my_table', 'Polygon');
+      const epochBefore = useDrawingStore.getState().sessionEpoch;
+
+      useAuthStore.setState({ token: 't2' });
+
+      expect(useDrawingStore.getState().sessionEpoch).toBe(epochBefore);
+
+      // The target adopted before the rotation is still valid: a write for
+      // it succeeds rather than being refused.
+      const feature = { gid: 1, tdId: 'td-1', properties: {} };
+      useDrawingStore.getState().setSelectedFeature(feature);
+      expect(useDrawingStore.getState().selectedFeature).toEqual(feature);
+    } finally {
+      unsubscribe();
+    }
+  });
+
   // fix(#1713): milder than drawing-store — search intent, not row data —
   // but the same class and the same choke point.
   it('clears identity-scoped search fields when identity changes, not on token refresh', () => {
@@ -162,6 +233,40 @@ describe('wireAuthCacheReset', () => {
 
       useAuthStore.setState({ token: null, user: null });
       expect(useSearchStore.getState().q).toBe('');
+    } finally {
+      unsubscribe();
+    }
+  });
+
+  // fix(#1761 review P2): SearchBar keys its local input/debounce state on
+  // this counter (see SearchBar.identity.test.tsx) precisely because `q`
+  // can stay '' across the identity change and not signal anything on its
+  // own — this pins that the counter itself always moves, even then.
+  it('bumps the search-store reset epoch on logout, even when q was already empty', () => {
+    const qc = new QueryClient();
+    const unsubscribe = wireAuthCacheReset(qc);
+    try {
+      useAuthStore.setState({ token: 't1', user: { id: 'user-1' } as UserResponse });
+      const before = useSearchStore.getState().resetEpoch;
+
+      useAuthStore.setState({ token: null, user: null });
+
+      expect(useSearchStore.getState().resetEpoch).toBe(before + 1);
+    } finally {
+      unsubscribe();
+    }
+  });
+
+  it('does not bump the search-store reset epoch on token refresh', () => {
+    const qc = new QueryClient();
+    const unsubscribe = wireAuthCacheReset(qc);
+    try {
+      useAuthStore.setState({ token: 't1', user: { id: 'user-1' } as UserResponse });
+      const before = useSearchStore.getState().resetEpoch;
+
+      useAuthStore.setState({ token: 't2' });
+
+      expect(useSearchStore.getState().resetEpoch).toBe(before);
     } finally {
       unsubscribe();
     }

--- a/frontend/src/lib/auth-cache-reset.ts
+++ b/frontend/src/lib/auth-cache-reset.ts
@@ -1,6 +1,8 @@
 import type { QueryClient } from '@tanstack/react-query';
 import { useAuthStore } from '@/stores/auth-store';
 import { clearReportEntries } from '@/lib/report';
+import { useDrawingStore } from '@/stores/drawing-store';
+import { useSearchStore } from '@/stores/search-store';
 
 /**
  * fix(#430 codex r6): user-scoped queries (dataset search, map search, map
@@ -31,5 +33,12 @@ export function wireAuthCacheReset(queryClient: QueryClient): () => void {
     // the now-anonymous tab. Same choke point, same rule: identity changed,
     // drop everything captured under the old one.
     clearReportEntries();
+    // fix(#1713): drawing-store's target dataset, selected feature (a real
+    // row's property bag) and edit-dirty flag are the same identity-scoped
+    // residue, plus the milder case of search-store's typed/drawn search
+    // intent. Same choke point, same rule: identity changed, drop everything
+    // adopted or entered under the old one.
+    useDrawingStore.getState().clearDrawing();
+    useSearchStore.getState().clearIdentityScopedFilters();
   });
 }

--- a/frontend/src/lib/auth-cache-reset.ts
+++ b/frontend/src/lib/auth-cache-reset.ts
@@ -38,6 +38,13 @@ export function wireAuthCacheReset(queryClient: QueryClient): () => void {
     // residue, plus the milder case of search-store's typed/drawn search
     // intent. Same choke point, same rule: identity changed, drop everything
     // adopted or entered under the old one.
+    //
+    // fix(#1761 review P1): bump the session epoch BEFORE clearing, so any
+    // write already in flight (captured against the old epoch) is refused
+    // by drawing-store's own check even if it lands between these two
+    // calls or after them, no matter what the next identity turns out to
+    // be — see drawing-store.ts's `bumpSessionEpoch` doc comment.
+    useDrawingStore.getState().bumpSessionEpoch();
     useDrawingStore.getState().clearDrawing();
     useSearchStore.getState().clearIdentityScopedFilters();
   });

--- a/frontend/src/stores/__tests__/drawing-store.test.ts
+++ b/frontend/src/stores/__tests__/drawing-store.test.ts
@@ -1,10 +1,14 @@
 import { useDrawingStore } from '@/stores/drawing-store';
+import { useAuthStore } from '@/stores/auth-store';
+import type { UserResponse } from '@/types/api';
 
 const initialState = useDrawingStore.getState();
+const initialAuthState = useAuthStore.getState();
 
 describe('useDrawingStore', () => {
   beforeEach(() => {
     useDrawingStore.setState(initialState, true);
+    useAuthStore.setState(initialAuthState, true);
   });
 
   it('has correct initial state', () => {
@@ -85,5 +89,70 @@ describe('useDrawingStore', () => {
     expect(state.targetGeometryType).toBeNull();
     expect(state.selectedFeature).toBeNull();
     expect(state.isEditDirty).toBe(false);
+  });
+
+  // fix(#1713): the ownership check at the adoption point — the structural
+  // half that holds even if the identity-change teardown in
+  // lib/auth-cache-reset.ts is skipped or races an in-flight write. See
+  // lib/__tests__/auth-cache-reset.test.ts for the teardown half.
+  describe('identity ownership', () => {
+    it('setDrawing records the signed-in identity as the owner', () => {
+      useAuthStore.setState({ user: { id: 'user-a' } as UserResponse });
+      useDrawingStore.getState().setDrawing('ds-1', 'my_table', 'Polygon');
+
+      expect(useDrawingStore.getState().ownerId).toBe('user-a');
+    });
+
+    it('setDrawing records a null owner for an anonymous session', () => {
+      useAuthStore.setState({ user: null });
+      useDrawingStore.getState().setDrawing('ds-1', 'my_table', 'Polygon');
+
+      expect(useDrawingStore.getState().ownerId).toBeNull();
+    });
+
+    it('setSelectedFeature accepts a write from the identity that owns the target', () => {
+      useAuthStore.setState({ user: { id: 'user-a' } as UserResponse });
+      useDrawingStore.getState().setDrawing('ds-1', 'my_table', 'Polygon');
+
+      const feature = { gid: 1, tdId: 'td-1', properties: { name: 'A' } };
+      useDrawingStore.getState().setSelectedFeature(feature);
+
+      expect(useDrawingStore.getState().selectedFeature).toEqual(feature);
+    });
+
+    it('setSelectedFeature refuses and clears when the identity changed underneath it', () => {
+      useAuthStore.setState({ user: { id: 'user-a' } as UserResponse });
+      useDrawingStore.getState().setDrawing('ds-1', 'my_table', 'Polygon');
+
+      // Identity changes WITHOUT going through clearDrawing — the shape a
+      // race with the identity-change teardown subscription would leave, or
+      // (per #1713) an update mutation's .then resolving after the
+      // subscription cleared the store: this is the case that resolution
+      // must not resurrect.
+      useAuthStore.setState({ user: { id: 'user-b' } as UserResponse });
+
+      useDrawingStore
+        .getState()
+        .setSelectedFeature({ gid: 1, tdId: 'td-1', properties: { name: 'A' } });
+
+      const state = useDrawingStore.getState();
+      expect(state.selectedFeature).toBeNull();
+      expect(state.targetDatasetId).toBeNull();
+      expect(state.isDrawing).toBe(false);
+      expect(state.ownerId).toBeNull();
+    });
+
+    it('setSelectedFeature refuses a write for a target adopted anonymously once someone signs in', () => {
+      useAuthStore.setState({ user: null });
+      useDrawingStore.getState().setDrawing('ds-1', 'my_table', 'Polygon');
+
+      useAuthStore.setState({ user: { id: 'user-a' } as UserResponse });
+
+      useDrawingStore
+        .getState()
+        .setSelectedFeature({ gid: 1, tdId: 'td-1', properties: {} });
+
+      expect(useDrawingStore.getState().selectedFeature).toBeNull();
+    });
   });
 });

--- a/frontend/src/stores/__tests__/drawing-store.test.ts
+++ b/frontend/src/stores/__tests__/drawing-store.test.ts
@@ -46,7 +46,8 @@ describe('useDrawingStore', () => {
     expect(useDrawingStore.getState().activeMode).toBeNull();
   });
 
-  it('setSelectedFeature stores a feature', () => {
+  it('setSelectedFeature stores a feature for the active target', () => {
+    useDrawingStore.getState().setDrawing('ds-1', 'my_table', 'Polygon');
     const feature = { gid: 42, tdId: 'td-1', properties: { name: 'Park' } };
     useDrawingStore.getState().setSelectedFeature(feature);
 
@@ -54,6 +55,7 @@ describe('useDrawingStore', () => {
   });
 
   it('clearSelectedFeature clears feature and resets dirty flag', () => {
+    useDrawingStore.getState().setDrawing('ds-1', 'my_table', 'Polygon');
     useDrawingStore.getState().setSelectedFeature({ gid: 1, tdId: 'td-1', properties: {} });
     useDrawingStore.getState().setEditDirty(true);
     useDrawingStore.getState().clearSelectedFeature();
@@ -94,7 +96,9 @@ describe('useDrawingStore', () => {
   // fix(#1713): the ownership check at the adoption point — the structural
   // half that holds even if the identity-change teardown in
   // lib/auth-cache-reset.ts is skipped or races an in-flight write. See
-  // lib/__tests__/auth-cache-reset.test.ts for the teardown half.
+  // lib/__tests__/auth-cache-reset.test.ts for the end-to-end teardown
+  // tests (including the late-write races these unit tests exercise
+  // directly, via bumpSessionEpoch rather than the auth choke point).
   describe('identity ownership', () => {
     it('setDrawing records the signed-in identity as the owner', () => {
       useAuthStore.setState({ user: { id: 'user-a' } as UserResponse });
@@ -110,7 +114,7 @@ describe('useDrawingStore', () => {
       expect(useDrawingStore.getState().ownerId).toBeNull();
     });
 
-    it('setSelectedFeature accepts a write from the identity that owns the target', () => {
+    it('setSelectedFeature accepts a write while the session epoch has not moved', () => {
       useAuthStore.setState({ user: { id: 'user-a' } as UserResponse });
       useDrawingStore.getState().setDrawing('ds-1', 'my_table', 'Polygon');
 
@@ -120,16 +124,45 @@ describe('useDrawingStore', () => {
       expect(useDrawingStore.getState().selectedFeature).toEqual(feature);
     });
 
-    it('setSelectedFeature refuses and clears when the identity changed underneath it', () => {
+    it('setSelectedFeature refuses and clears when there is no active target', () => {
+      // fix(#1761 review P1): the second, independent guard — refuses even
+      // when nothing has adopted a target yet, so a caller that reaches
+      // setSelectedFeature without ever calling setDrawing cannot attach a
+      // feature to nothing.
+      useDrawingStore
+        .getState()
+        .setSelectedFeature({ gid: 1, tdId: 'td-1', properties: {} });
+
+      expect(useDrawingStore.getState().selectedFeature).toBeNull();
+    });
+
+    it('bumpSessionEpoch advances the counter without touching other state', () => {
+      useDrawingStore.getState().setDrawing('ds-1', 'my_table', 'Polygon');
+      const before = useDrawingStore.getState().sessionEpoch;
+
+      useDrawingStore.getState().bumpSessionEpoch();
+
+      const state = useDrawingStore.getState();
+      expect(state.sessionEpoch).toBe(before + 1);
+      // A plain bump is not a clear: it is the auth choke point's job to
+      // also call clearDrawing() (see lib/auth-cache-reset.ts).
+      expect(state.targetDatasetId).toBe('ds-1');
+    });
+
+    // fix(#1761 review P1): `ownerId === currentUserId()` was the original
+    // (broken) check. After a logout both sides read null and the write was
+    // wrongly accepted. bumpSessionEpoch() is what lib/auth-cache-reset.ts
+    // calls on every real identity change (see that file, and its tests for
+    // the end-to-end version of this race through the actual choke point);
+    // called directly here to pin the store's own refusal in isolation.
+    it('setSelectedFeature refuses and clears once the session epoch has moved, regardless of identity', () => {
       useAuthStore.setState({ user: { id: 'user-a' } as UserResponse });
       useDrawingStore.getState().setDrawing('ds-1', 'my_table', 'Polygon');
 
-      // Identity changes WITHOUT going through clearDrawing — the shape a
-      // race with the identity-change teardown subscription would leave, or
-      // (per #1713) an update mutation's .then resolving after the
-      // subscription cleared the store: this is the case that resolution
-      // must not resurrect.
-      useAuthStore.setState({ user: { id: 'user-b' } as UserResponse });
+      // The session epoch moves (what the auth choke point does on any
+      // identity change) WITHOUT a clearDrawing() call — the shape a race
+      // between that subscription and an in-flight write could leave.
+      useDrawingStore.getState().bumpSessionEpoch();
 
       useDrawingStore
         .getState()
@@ -142,11 +175,11 @@ describe('useDrawingStore', () => {
       expect(state.ownerId).toBeNull();
     });
 
-    it('setSelectedFeature refuses a write for a target adopted anonymously once someone signs in', () => {
+    it('setSelectedFeature refuses a write for a target adopted anonymously once the session epoch has moved', () => {
       useAuthStore.setState({ user: null });
       useDrawingStore.getState().setDrawing('ds-1', 'my_table', 'Polygon');
 
-      useAuthStore.setState({ user: { id: 'user-a' } as UserResponse });
+      useDrawingStore.getState().bumpSessionEpoch();
 
       useDrawingStore
         .getState()

--- a/frontend/src/stores/__tests__/drawing-store.test.ts
+++ b/frontend/src/stores/__tests__/drawing-store.test.ts
@@ -49,14 +49,16 @@ describe('useDrawingStore', () => {
   it('setSelectedFeature stores a feature for the active target', () => {
     useDrawingStore.getState().setDrawing('ds-1', 'my_table', 'Polygon');
     const feature = { gid: 42, tdId: 'td-1', properties: { name: 'Park' } };
-    useDrawingStore.getState().setSelectedFeature(feature);
+    useDrawingStore.getState().setSelectedFeature(feature, useDrawingStore.getState().sessionEpoch);
 
     expect(useDrawingStore.getState().selectedFeature).toEqual(feature);
   });
 
   it('clearSelectedFeature clears feature and resets dirty flag', () => {
     useDrawingStore.getState().setDrawing('ds-1', 'my_table', 'Polygon');
-    useDrawingStore.getState().setSelectedFeature({ gid: 1, tdId: 'td-1', properties: {} });
+    useDrawingStore
+      .getState()
+      .setSelectedFeature({ gid: 1, tdId: 'td-1', properties: {} }, useDrawingStore.getState().sessionEpoch);
     useDrawingStore.getState().setEditDirty(true);
     useDrawingStore.getState().clearSelectedFeature();
 
@@ -78,7 +80,9 @@ describe('useDrawingStore', () => {
     // Set everything
     useDrawingStore.getState().setDrawing('ds-1', 'my_table', 'Point');
     useDrawingStore.getState().setMode('point');
-    useDrawingStore.getState().setSelectedFeature({ gid: 5, tdId: 'td-2', properties: { a: 1 } });
+    useDrawingStore
+      .getState()
+      .setSelectedFeature({ gid: 5, tdId: 'td-2', properties: { a: 1 } }, useDrawingStore.getState().sessionEpoch);
     useDrawingStore.getState().setEditDirty(true);
 
     useDrawingStore.getState().clearDrawing();
@@ -114,12 +118,13 @@ describe('useDrawingStore', () => {
       expect(useDrawingStore.getState().ownerId).toBeNull();
     });
 
-    it('setSelectedFeature accepts a write while the session epoch has not moved', () => {
+    it('setSelectedFeature accepts a write whose captured epoch still matches the live one', () => {
       useAuthStore.setState({ user: { id: 'user-a' } as UserResponse });
       useDrawingStore.getState().setDrawing('ds-1', 'my_table', 'Polygon');
+      const epoch = useDrawingStore.getState().sessionEpoch;
 
       const feature = { gid: 1, tdId: 'td-1', properties: { name: 'A' } };
-      useDrawingStore.getState().setSelectedFeature(feature);
+      useDrawingStore.getState().setSelectedFeature(feature, epoch);
 
       expect(useDrawingStore.getState().selectedFeature).toEqual(feature);
     });
@@ -128,10 +133,13 @@ describe('useDrawingStore', () => {
       // fix(#1761 review P1): the second, independent guard — refuses even
       // when nothing has adopted a target yet, so a caller that reaches
       // setSelectedFeature without ever calling setDrawing cannot attach a
-      // feature to nothing.
+      // feature to nothing. Nothing is active to preserve here, so a full
+      // clear and a no-op read the same.
+      const epoch = useDrawingStore.getState().sessionEpoch;
+
       useDrawingStore
         .getState()
-        .setSelectedFeature({ gid: 1, tdId: 'td-1', properties: {} });
+        .setSelectedFeature({ gid: 1, tdId: 'td-1', properties: {} }, epoch);
 
       expect(useDrawingStore.getState().selectedFeature).toBeNull();
     });
@@ -149,15 +157,54 @@ describe('useDrawingStore', () => {
       expect(state.targetDatasetId).toBe('ds-1');
     });
 
-    // fix(#1761 review P1): `ownerId === currentUserId()` was the original
-    // (broken) check. After a logout both sides read null and the write was
-    // wrongly accepted. bumpSessionEpoch() is what lib/auth-cache-reset.ts
-    // calls on every real identity change (see that file, and its tests for
-    // the end-to-end version of this race through the actual choke point);
-    // called directly here to pin the store's own refusal in isolation.
-    it('setSelectedFeature refuses and clears once the session epoch has moved, regardless of identity', () => {
+    // fix(#1761 review round 2 P1): the race round 1's design missed.
+    // Round 1 stored the adopting epoch ON THE TARGET and compared it to
+    // the live counter, which broke once a SECOND identity adopted its own
+    // fresh target: that adoption re-stamped the stored epoch to the (now
+    // current) live value, so a stale write from the FIRST identity's
+    // still-pending mutation compared the live epoch to itself and was
+    // wrongly accepted. The fix passes the epoch through the CALL instead —
+    // captured by the caller before its own await (see
+    // handleEditAttributeSubmit / selectFeatureFromMap in
+    // components/dataset/hooks/use-feature-editing.ts) — so a second
+    // identity's fresh target can never launder a first identity's stale
+    // write. This pins that directly: capture an epoch, bump it (an
+    // identity change), adopt a brand new target (a second identity's own
+    // legitimate session), then submit the ORIGINAL stale epoch — refused,
+    // and the second identity's active session is left completely alone.
+    it('refuses a write captured before the session epoch moved, even after a new target is adopted', () => {
       useAuthStore.setState({ user: { id: 'user-a' } as UserResponse });
       useDrawingStore.getState().setDrawing('ds-1', 'my_table', 'Polygon');
+      const staleEpoch = useDrawingStore.getState().sessionEpoch;
+
+      // Identity changes (the auth choke point bumps the epoch)...
+      useDrawingStore.getState().bumpSessionEpoch();
+      useAuthStore.setState({ user: { id: 'user-b' } as UserResponse });
+      // ...and user B adopts their OWN new target and selection. Its epoch
+      // is current by construction, which is exactly what let the stale
+      // write through in round 1.
+      useDrawingStore.getState().setDrawing('ds-2', 'other_table', 'Point');
+      useDrawingStore
+        .getState()
+        .setSelectedFeature(
+          { gid: 9, tdId: 'td-9', properties: { name: 'B' } },
+          useDrawingStore.getState().sessionEpoch,
+        );
+      const beforeStaleWrite = useDrawingStore.getState();
+
+      // User A's stale continuation lands, carrying the OLD epoch.
+      useDrawingStore
+        .getState()
+        .setSelectedFeature({ gid: 1, tdId: 'td-1', properties: { name: 'A' } }, staleEpoch);
+
+      // Refused, and user B's active session is untouched by it.
+      expect(useDrawingStore.getState()).toEqual(beforeStaleWrite);
+    });
+
+    it('setSelectedFeature refuses a stale write without disturbing the currently active target', () => {
+      useAuthStore.setState({ user: { id: 'user-a' } as UserResponse });
+      useDrawingStore.getState().setDrawing('ds-1', 'my_table', 'Polygon');
+      const staleEpoch = useDrawingStore.getState().sessionEpoch;
 
       // The session epoch moves (what the auth choke point does on any
       // identity change) WITHOUT a clearDrawing() call — the shape a race
@@ -166,24 +213,29 @@ describe('useDrawingStore', () => {
 
       useDrawingStore
         .getState()
-        .setSelectedFeature({ gid: 1, tdId: 'td-1', properties: { name: 'A' } });
+        .setSelectedFeature({ gid: 1, tdId: 'td-1', properties: { name: 'A' } }, staleEpoch);
 
       const state = useDrawingStore.getState();
+      // Refused: the write did not land.
       expect(state.selectedFeature).toBeNull();
-      expect(state.targetDatasetId).toBeNull();
-      expect(state.isDrawing).toBe(false);
-      expect(state.ownerId).toBeNull();
+      // NOT cleared: a stale write must not be able to blow away whatever
+      // session is currently active either, only fail to attach itself.
+      expect(state.targetDatasetId).toBe('ds-1');
+      expect(state.isDrawing).toBe(true);
+      expect(state.ownerId).toBe('user-a');
     });
 
-    it('setSelectedFeature refuses a write for a target adopted anonymously once the session epoch has moved', () => {
+    it('setSelectedFeature refuses a stale write from a target that was adopted anonymously', () => {
       useAuthStore.setState({ user: null });
       useDrawingStore.getState().setDrawing('ds-1', 'my_table', 'Polygon');
+      const staleEpoch = useDrawingStore.getState().sessionEpoch;
 
       useDrawingStore.getState().bumpSessionEpoch();
+      useAuthStore.setState({ user: { id: 'user-a' } as UserResponse });
 
       useDrawingStore
         .getState()
-        .setSelectedFeature({ gid: 1, tdId: 'td-1', properties: {} });
+        .setSelectedFeature({ gid: 1, tdId: 'td-1', properties: {} }, staleEpoch);
 
       expect(useDrawingStore.getState().selectedFeature).toBeNull();
     });

--- a/frontend/src/stores/__tests__/search-store.test.ts
+++ b/frontend/src/stores/__tests__/search-store.test.ts
@@ -142,4 +142,26 @@ describe('useSearchStore', () => {
     expect(state.sort_by).toBe('name');
     expect(state.srid).toBe('4326');
   });
+
+  // fix(#1761 review P2): SearchBar keys its local input/debounce state on
+  // resetEpoch precisely because clearIdentityScopedFilters can leave `q`
+  // unchanged (already ''), so the counter has to move on every call.
+  it('clearIdentityScopedFilters bumps resetEpoch even when q is already empty', () => {
+    const before = useSearchStore.getState().resetEpoch;
+
+    useSearchStore.getState().clearIdentityScopedFilters();
+
+    expect(useSearchStore.getState().resetEpoch).toBe(before + 1);
+  });
+
+  it('resetFilters and restoreParams do not touch resetEpoch', () => {
+    useSearchStore.getState().clearIdentityScopedFilters();
+    const epoch = useSearchStore.getState().resetEpoch;
+
+    useSearchStore.getState().resetFilters();
+    expect(useSearchStore.getState().resetEpoch).toBe(epoch);
+
+    useSearchStore.getState().restoreParams({ q: 'test' });
+    expect(useSearchStore.getState().resetEpoch).toBe(epoch);
+  });
 });

--- a/frontend/src/stores/__tests__/search-store.test.ts
+++ b/frontend/src/stores/__tests__/search-store.test.ts
@@ -115,4 +115,31 @@ describe('useSearchStore', () => {
 
     expect(useSearchStore.getState().spatial_predicate).toBe('intersects');
   });
+
+  // fix(#1713): drop the typed/drawn search intent that could implicate the
+  // previous identity, called from the identity-change choke point (see
+  // lib/__tests__/auth-cache-reset.test.ts for that wiring).
+  it('clearIdentityScopedFilters clears only the identity-scoped fields', () => {
+    useSearchStore.setState({
+      q: 'parks',
+      bbox: '1,2,3,4',
+      collection_id: 'c1',
+      keywords: ['water'],
+      geometry: '{"type":"Point","coordinates":[0,0]}',
+      sort_by: 'name',
+      srid: '4326',
+    });
+
+    useSearchStore.getState().clearIdentityScopedFilters();
+
+    const state = useSearchStore.getState();
+    expect(state.q).toBe('');
+    expect(state.bbox).toBe('');
+    expect(state.collection_id).toBe('');
+    expect(state.keywords).toEqual([]);
+    expect(state.geometry).toBe('');
+    // Display preferences, not identity-scoped: left alone.
+    expect(state.sort_by).toBe('name');
+    expect(state.srid).toBe('4326');
+  });
 });

--- a/frontend/src/stores/__tests__/search-store.test.ts
+++ b/frontend/src/stores/__tests__/search-store.test.ts
@@ -1,4 +1,4 @@
-import { useSearchStore } from '@/stores/search-store';
+import { useSearchStore, SEARCH_PRESENTATION_PREFERENCE_KEYS } from '@/stores/search-store';
 
 const initialState = useSearchStore.getState();
 
@@ -119,15 +119,15 @@ describe('useSearchStore', () => {
   // fix(#1713): drop the typed/drawn search intent that could implicate the
   // previous identity, called from the identity-change choke point (see
   // lib/__tests__/auth-cache-reset.test.ts for that wiring).
-  it('clearIdentityScopedFilters clears only the identity-scoped fields', () => {
+  it('clearIdentityScopedFilters clears search-shaping fields', () => {
     useSearchStore.setState({
       q: 'parks',
       bbox: '1,2,3,4',
       collection_id: 'c1',
       keywords: ['water'],
       geometry: '{"type":"Point","coordinates":[0,0]}',
-      sort_by: 'name',
       srid: '4326',
+      sort_by: 'name',
     });
 
     useSearchStore.getState().clearIdentityScopedFilters();
@@ -138,9 +138,52 @@ describe('useSearchStore', () => {
     expect(state.collection_id).toBe('');
     expect(state.keywords).toEqual([]);
     expect(state.geometry).toBe('');
-    // Display preferences, not identity-scoped: left alone.
+    // fix(#1761 review round 2 P2): srid shapes the query too — reset,
+    // where round 1 wrongly left it alone.
+    expect(state.srid).toBe('');
+    // Presentation preference: survives.
     expect(state.sort_by).toBe('name');
-    expect(state.srid).toBe('4326');
+  });
+
+  /**
+   * fix(#1761 review round 2 P2): round 1's partial reset left
+   * geometry_type, source_organization, record_type, the date/vintage
+   * fields, srid, spatial_predicate, exclude_synthetic and the pagination
+   * offset untouched — all query-shaping, all exposed to the next identity
+   * via toParams()/the URL-sync hook, and a stale offset could additionally
+   * land the next identity on an empty page of their own results.
+   *
+   * This iterates every DATA key the store actually has (not a hardcoded
+   * list) so a field added to SearchState later is automatically checked
+   * against SEARCH_PRESENTATION_PREFERENCE_KEYS: either it is declared a
+   * presentation preference and this proves it survives, or it isn't and
+   * this proves it resets. Nothing can slip through unclassified.
+   */
+  it('resets every query-shaping field and preserves only the declared presentation preferences', () => {
+    const before = useSearchStore.getState();
+    const dataKeys = (Object.keys(before) as (keyof typeof before)[]).filter(
+      (key) => typeof before[key] !== 'function' && key !== 'resetEpoch',
+    );
+    const originalValues: Record<string, unknown> = {};
+    const dirtyValues: Record<string, unknown> = {};
+    for (const key of dataKeys) {
+      const current = (before as unknown as Record<string, unknown>)[key];
+      originalValues[key as string] = current;
+      dirtyValues[key as string] = makeDistinctValue(current);
+    }
+    useSearchStore.setState(dirtyValues);
+
+    useSearchStore.getState().clearIdentityScopedFilters();
+
+    const after = useSearchStore.getState() as unknown as Record<string, unknown>;
+    const preserved = new Set<string>(SEARCH_PRESENTATION_PREFERENCE_KEYS);
+    for (const key of dataKeys as string[]) {
+      if (preserved.has(key)) {
+        expect(after[key]).toEqual(dirtyValues[key]);
+      } else {
+        expect(after[key]).toEqual(originalValues[key]);
+      }
+    }
   });
 
   // fix(#1761 review P2): SearchBar keys its local input/debounce state on
@@ -165,3 +208,12 @@ describe('useSearchStore', () => {
     expect(useSearchStore.getState().resetEpoch).toBe(epoch);
   });
 });
+
+/** Produces a value of the same type as `current`, guaranteed different. */
+function makeDistinctValue(current: unknown): unknown {
+  if (typeof current === 'string') return `${current}__dirty`;
+  if (typeof current === 'number') return current + 999;
+  if (typeof current === 'boolean') return !current;
+  if (Array.isArray(current)) return [...current, '__dirty'];
+  return current;
+}

--- a/frontend/src/stores/drawing-store.ts
+++ b/frontend/src/stores/drawing-store.ts
@@ -1,4 +1,5 @@
 import { create } from 'zustand';
+import { useAuthStore } from '@/stores/auth-store';
 
 interface SelectedFeature {
   gid: number;
@@ -14,6 +15,14 @@ interface DrawingState {
   targetGeometryType: string | null;
   selectedFeature: SelectedFeature | null;
   isEditDirty: boolean;
+  /**
+   * fix(#1713): the identity that adopted the current target/selection,
+   * captured at `setDrawing`/`setSelectedFeature` time. Not surfaced to
+   * consumers — it exists so those two setters can refuse a write that
+   * belongs to a different identity than the one that opened the target
+   * (see `setSelectedFeature` below).
+   */
+  ownerId: string | null;
   setDrawing: (datasetId: string, tableName: string, geometryType: string) => void;
   setMode: (mode: string | null) => void;
   clearDrawing: () => void;
@@ -22,7 +31,13 @@ interface DrawingState {
   setEditDirty: (dirty: boolean) => void;
 }
 
-export const useDrawingStore = create<DrawingState>()((set) => ({
+function currentUserId(): string | null {
+  return useAuthStore.getState().user?.id ?? null;
+}
+
+/** fix(#1713): shared by the initial state and clearDrawing, so a reset can
+ *  never drift from what "nothing adopted" looks like. */
+const CLEARED_STATE = {
   isDrawing: false,
   activeMode: null,
   targetDatasetId: null,
@@ -30,6 +45,17 @@ export const useDrawingStore = create<DrawingState>()((set) => ({
   targetGeometryType: null,
   selectedFeature: null,
   isEditDirty: false,
+  ownerId: null,
+} as const;
+
+export const useDrawingStore = create<DrawingState>()((set, get) => ({
+  ...CLEARED_STATE,
+  // fix(#1713): the adoption point for a drawing target. Stamps the
+  // signed-in identity at the moment the target is set, and — because this
+  // always replaces selectedFeature/isEditDirty rather than merging with
+  // whatever was there — a call under a new identity self-heals the store
+  // even if the identity-change teardown (lib/auth-cache-reset.ts) somehow
+  // hasn't run yet.
   setDrawing: (datasetId, tableName, geometryType) =>
     set({
       isDrawing: true,
@@ -39,19 +65,29 @@ export const useDrawingStore = create<DrawingState>()((set) => ({
       targetGeometryType: geometryType,
       selectedFeature: null,
       isEditDirty: false,
+      ownerId: currentUserId(),
     }),
   setMode: (mode) => set({ activeMode: mode }),
-  clearDrawing: () =>
-    set({
-      isDrawing: false,
-      activeMode: null,
-      targetDatasetId: null,
-      targetTableName: null,
-      targetGeometryType: null,
-      selectedFeature: null,
-      isEditDirty: false,
-    }),
-  setSelectedFeature: (sf) => set({ selectedFeature: sf }),
+  clearDrawing: () => set({ ...CLEARED_STATE }),
+  // fix(#1713): the other adoption point, and the one an in-flight edit can
+  // reach asynchronously — handleEditAttributeSubmit reads `selectedFeature`
+  // before an update mutation, then calls this again after the mutation
+  // resolves. If sign-out/sign-in happens in between, that resolution can
+  // land after the identity-change teardown already cleared the store, and
+  // it would otherwise re-populate `selectedFeature` with the previous
+  // identity's row for whoever is signed in now. Refuse whenever the
+  // adopting identity does not match who owns the current target (including
+  // the just-cleared case, where the target's owner is null and a signed-in
+  // identity is not), clearing rather than partially applying the stale
+  // write.
+  setSelectedFeature: (sf) => {
+    const uid = currentUserId();
+    if (get().ownerId !== uid) {
+      set({ ...CLEARED_STATE });
+      return;
+    }
+    set({ selectedFeature: sf, ownerId: uid });
+  },
   clearSelectedFeature: () => set({ selectedFeature: null, isEditDirty: false }),
   setEditDirty: (dirty) => set({ isEditDirty: dirty }),
 }));

--- a/frontend/src/stores/drawing-store.ts
+++ b/frontend/src/stores/drawing-store.ts
@@ -17,30 +17,46 @@ interface DrawingState {
   isEditDirty: boolean;
   /**
    * fix(#1713): the identity that adopted the current target, for
-   * bookkeeping. NOT the write gate below (see `sessionEpoch`/`targetEpoch`)
-   * — fix(#1761 review P1) found that comparing this to the live identity
-   * directly breaks down once both sides are anonymous (see
-   * `setSelectedFeature`).
+   * bookkeeping. NOT the write gate below (see `sessionEpoch`) — fix(#1761
+   * review P1) found that comparing this to the live identity directly
+   * breaks down once both sides are anonymous.
    */
   ownerId: string | null;
   /**
    * fix(#1761 review P1): a monotonic counter, bumped ONLY by
    * `bumpSessionEpoch()`, which only the identity-change choke point
-   * (lib/auth-cache-reset.ts) calls. `targetEpoch` below snapshots this at
-   * adoption time. Comparing two counters instead of two identities means
-   * an identity change is never mistaken for "no change" merely because the
-   * old and new identity happen to both be anonymous (`null === null`) —
-   * the counter has no such degenerate case: it only ever moves forward on
-   * a real change.
+   * (lib/auth-cache-reset.ts) calls.
+   *
+   * fix(#1761 review round 2 P1): round 1 stored the adopting epoch ON THE
+   * STORE (`targetEpoch`) and compared it to the live counter inside
+   * `setSelectedFeature`. That still had a hole: once a SECOND identity
+   * adopts its own target after the identity change, its `setDrawing` call
+   * re-stamps that stored epoch to the (now current) live value, so a
+   * write from the FIRST identity's still-pending mutation — which reads
+   * `selectedFeature` before its `await` and writes again after — compares
+   * the live epoch to itself and is wrongly accepted, carrying the first
+   * identity's captured properties into the second identity's target.
+   * There is no way to fix this from inside the store: the store cannot
+   * tell "the live epoch matches because nothing changed" apart from "the
+   * live epoch matches because something else changed twice". Only the
+   * ORIGINAL caller knows which one is true, because it alone knows when
+   * its own request started. So the epoch this check needs is not
+   * something the store can keep — it has to travel through the call,
+   * captured by the caller before the `await` (see `setSelectedFeature`).
    */
   sessionEpoch: number;
-  /** The `sessionEpoch` that was live when the current target was adopted;
-   *  `null` when nothing is adopted. */
-  targetEpoch: number | null;
   setDrawing: (datasetId: string, tableName: string, geometryType: string) => void;
   setMode: (mode: string | null) => void;
   clearDrawing: () => void;
-  setSelectedFeature: (sf: SelectedFeature) => void;
+  /**
+   * fix(#1761 review round 2 P1): `epoch` is mandatory and must be
+   * `useDrawingStore.getState().sessionEpoch` read by the CALLER before
+   * its own `await` — never re-read at call time, which is exactly what
+   * broke in round 1 (see `sessionEpoch`'s doc comment). A call whose
+   * captured epoch no longer matches the live one is refused, whatever the
+   * store's current target belongs to.
+   */
+  setSelectedFeature: (sf: SelectedFeature, epoch: number) => void;
   clearSelectedFeature: () => void;
   setEditDirty: (dirty: boolean) => void;
   /**
@@ -75,20 +91,21 @@ const CLEARED_STATE = {
   selectedFeature: null,
   isEditDirty: false,
   ownerId: null,
-  targetEpoch: null,
 } as const;
 
 export const useDrawingStore = create<DrawingState>()((set, get) => ({
   ...CLEARED_STATE,
   sessionEpoch: 0,
   // fix(#1713): the adoption point for a drawing target. Stamps the
-  // signed-in identity and the live session epoch at the moment the target
-  // is set, and — because this always replaces selectedFeature/isEditDirty
-  // rather than merging with whatever was there — a call under a new
-  // identity self-heals the store even if the identity-change teardown
-  // (lib/auth-cache-reset.ts) somehow hasn't run yet.
+  // signed-in identity at the moment the target is set, and — because this
+  // always replaces selectedFeature/isEditDirty rather than merging with
+  // whatever was there — a call under a new identity self-heals the store
+  // even if the identity-change teardown (lib/auth-cache-reset.ts) somehow
+  // hasn't run yet. Its only caller (DatasetMap.tsx's draw button) is fully
+  // synchronous, so unlike setSelectedFeature there is no "before the
+  // await" moment to capture an epoch from — nothing here can go stale.
   setDrawing: (datasetId, tableName, geometryType) =>
-    set((state) => ({
+    set({
       isDrawing: true,
       activeMode: 'select',
       targetDatasetId: datasetId,
@@ -97,31 +114,44 @@ export const useDrawingStore = create<DrawingState>()((set, get) => ({
       selectedFeature: null,
       isEditDirty: false,
       ownerId: currentUserId(),
-      targetEpoch: state.sessionEpoch,
-    })),
+    }),
   setMode: (mode) => set({ activeMode: mode }),
   clearDrawing: () => set({ ...CLEARED_STATE }),
   // fix(#1713): the other adoption point, and the one an in-flight edit can
-  // reach asynchronously — handleEditAttributeSubmit reads `selectedFeature`
-  // before an update mutation, then calls this again after the mutation
-  // resolves.
+  // reach asynchronously — handleEditAttributeSubmit and selectFeatureFromMap
+  // (components/dataset/hooks/use-feature-editing.ts) both read/derive a
+  // feature, await a request, then call this with the result.
   //
-  // fix(#1761 review P1): refusing on `ownerId !== currentUserId()` alone
-  // broke down right after a logout: clearDrawing() sets ownerId to null,
-  // and an anonymous currentUserId() is ALSO null, so the comparison saw
-  // two nulls as equal and accepted a write that belonged to the signed-out
-  // user, re-populating selectedFeature for whoever views the still-mounted
-  // dataset route next. `targetEpoch !== sessionEpoch` has no such
-  // degenerate case: the epoch only advances via bumpSessionEpoch(), called
-  // once per real identity change, so a stale write's captured epoch can
-  // never coincide with the live one after such a change, whatever the
-  // next identity turns out to be (anonymous or not). Refusing whenever
-  // there is no active target closes the same hole even if some future
-  // caller adds a path that skips setDrawing.
-  setSelectedFeature: (sf) => {
+  // fix(#1761 review P1, then round 2): round 1 refused on
+  // `ownerId !== currentUserId()`, which broke down right after a logout
+  // (both read null). Storing an adopted-at epoch on the target and
+  // comparing it to the live counter fixed that, but not the case where a
+  // SECOND identity adopts its OWN new target before the first identity's
+  // stale write lands: the stored epoch gets re-stamped to the (now
+  // current) live value by that second adoption, so the stale write's
+  // check passes by comparing the live epoch to itself. The caller is the
+  // only one who can tell its own request apart from a coincidentally
+  // fresh-looking target, so the epoch travels through the call instead —
+  // captured by the caller before its `await`, passed in here, and
+  // compared against the live counter. Refusing whenever there is no
+  // active target closes the same hole even if some future caller adds a
+  // path that skips setDrawing.
+  setSelectedFeature: (sf, epoch) => {
     const state = get();
-    if (state.targetDatasetId === null || state.targetEpoch !== state.sessionEpoch) {
+    if (state.targetDatasetId === null) {
+      // Nothing adopted: already the cleared shape, but explicit for
+      // anyone reaching this with a target that was never set up.
       set({ ...CLEARED_STATE });
+      return;
+    }
+    if (epoch !== state.sessionEpoch) {
+      // fix(#1761 review round 2 P1): a stale write for a target that may
+      // now belong to a DIFFERENT, later identity than the one that issued
+      // it. That target could be a second identity's own legitimate,
+      // freshly-adopted session — clearing it would let this stale write
+      // do collateral damage instead of just failing to apply. Refuse by
+      // doing nothing: leave whatever is currently active exactly as it
+      // is, and drop the stale payload.
       return;
     }
     set({ selectedFeature: sf, ownerId: currentUserId() });

--- a/frontend/src/stores/drawing-store.ts
+++ b/frontend/src/stores/drawing-store.ts
@@ -16,27 +16,56 @@ interface DrawingState {
   selectedFeature: SelectedFeature | null;
   isEditDirty: boolean;
   /**
-   * fix(#1713): the identity that adopted the current target/selection,
-   * captured at `setDrawing`/`setSelectedFeature` time. Not surfaced to
-   * consumers — it exists so those two setters can refuse a write that
-   * belongs to a different identity than the one that opened the target
-   * (see `setSelectedFeature` below).
+   * fix(#1713): the identity that adopted the current target, for
+   * bookkeeping. NOT the write gate below (see `sessionEpoch`/`targetEpoch`)
+   * — fix(#1761 review P1) found that comparing this to the live identity
+   * directly breaks down once both sides are anonymous (see
+   * `setSelectedFeature`).
    */
   ownerId: string | null;
+  /**
+   * fix(#1761 review P1): a monotonic counter, bumped ONLY by
+   * `bumpSessionEpoch()`, which only the identity-change choke point
+   * (lib/auth-cache-reset.ts) calls. `targetEpoch` below snapshots this at
+   * adoption time. Comparing two counters instead of two identities means
+   * an identity change is never mistaken for "no change" merely because the
+   * old and new identity happen to both be anonymous (`null === null`) —
+   * the counter has no such degenerate case: it only ever moves forward on
+   * a real change.
+   */
+  sessionEpoch: number;
+  /** The `sessionEpoch` that was live when the current target was adopted;
+   *  `null` when nothing is adopted. */
+  targetEpoch: number | null;
   setDrawing: (datasetId: string, tableName: string, geometryType: string) => void;
   setMode: (mode: string | null) => void;
   clearDrawing: () => void;
   setSelectedFeature: (sf: SelectedFeature) => void;
   clearSelectedFeature: () => void;
   setEditDirty: (dirty: boolean) => void;
+  /**
+   * fix(#1761 review P1): invalidates every target/selection adopted before
+   * this call. Called ONLY from lib/auth-cache-reset.ts's identity-change
+   * subscription — never from component code, and never folded into
+   * `clearDrawing()`, which ordinary component lifecycle (DatasetMap.tsx)
+   * also calls for reasons that have nothing to do with identity. If a
+   * lifecycle clear also bumped this counter, "the epoch changed" would
+   * stop meaning "the identity changed".
+   */
+  bumpSessionEpoch: () => void;
 }
 
 function currentUserId(): string | null {
   return useAuthStore.getState().user?.id ?? null;
 }
 
-/** fix(#1713): shared by the initial state and clearDrawing, so a reset can
- *  never drift from what "nothing adopted" looks like. */
+/**
+ * fix(#1713): shared by the initial state and clearDrawing, so a reset can
+ * never drift from what "nothing adopted" looks like.
+ *
+ * fix(#1761 review P1): deliberately excludes `sessionEpoch` — see its
+ * doc comment for why the counter must never be reset by an ordinary clear.
+ */
 const CLEARED_STATE = {
   isDrawing: false,
   activeMode: null,
@@ -46,18 +75,20 @@ const CLEARED_STATE = {
   selectedFeature: null,
   isEditDirty: false,
   ownerId: null,
+  targetEpoch: null,
 } as const;
 
 export const useDrawingStore = create<DrawingState>()((set, get) => ({
   ...CLEARED_STATE,
+  sessionEpoch: 0,
   // fix(#1713): the adoption point for a drawing target. Stamps the
-  // signed-in identity at the moment the target is set, and — because this
-  // always replaces selectedFeature/isEditDirty rather than merging with
-  // whatever was there — a call under a new identity self-heals the store
-  // even if the identity-change teardown (lib/auth-cache-reset.ts) somehow
-  // hasn't run yet.
+  // signed-in identity and the live session epoch at the moment the target
+  // is set, and — because this always replaces selectedFeature/isEditDirty
+  // rather than merging with whatever was there — a call under a new
+  // identity self-heals the store even if the identity-change teardown
+  // (lib/auth-cache-reset.ts) somehow hasn't run yet.
   setDrawing: (datasetId, tableName, geometryType) =>
-    set({
+    set((state) => ({
       isDrawing: true,
       activeMode: 'select',
       targetDatasetId: datasetId,
@@ -66,28 +97,36 @@ export const useDrawingStore = create<DrawingState>()((set, get) => ({
       selectedFeature: null,
       isEditDirty: false,
       ownerId: currentUserId(),
-    }),
+      targetEpoch: state.sessionEpoch,
+    })),
   setMode: (mode) => set({ activeMode: mode }),
   clearDrawing: () => set({ ...CLEARED_STATE }),
   // fix(#1713): the other adoption point, and the one an in-flight edit can
   // reach asynchronously — handleEditAttributeSubmit reads `selectedFeature`
   // before an update mutation, then calls this again after the mutation
-  // resolves. If sign-out/sign-in happens in between, that resolution can
-  // land after the identity-change teardown already cleared the store, and
-  // it would otherwise re-populate `selectedFeature` with the previous
-  // identity's row for whoever is signed in now. Refuse whenever the
-  // adopting identity does not match who owns the current target (including
-  // the just-cleared case, where the target's owner is null and a signed-in
-  // identity is not), clearing rather than partially applying the stale
-  // write.
+  // resolves.
+  //
+  // fix(#1761 review P1): refusing on `ownerId !== currentUserId()` alone
+  // broke down right after a logout: clearDrawing() sets ownerId to null,
+  // and an anonymous currentUserId() is ALSO null, so the comparison saw
+  // two nulls as equal and accepted a write that belonged to the signed-out
+  // user, re-populating selectedFeature for whoever views the still-mounted
+  // dataset route next. `targetEpoch !== sessionEpoch` has no such
+  // degenerate case: the epoch only advances via bumpSessionEpoch(), called
+  // once per real identity change, so a stale write's captured epoch can
+  // never coincide with the live one after such a change, whatever the
+  // next identity turns out to be (anonymous or not). Refusing whenever
+  // there is no active target closes the same hole even if some future
+  // caller adds a path that skips setDrawing.
   setSelectedFeature: (sf) => {
-    const uid = currentUserId();
-    if (get().ownerId !== uid) {
+    const state = get();
+    if (state.targetDatasetId === null || state.targetEpoch !== state.sessionEpoch) {
       set({ ...CLEARED_STATE });
       return;
     }
-    set({ selectedFeature: sf, ownerId: uid });
+    set({ selectedFeature: sf, ownerId: currentUserId() });
   },
   clearSelectedFeature: () => set({ selectedFeature: null, isEditDirty: false }),
   setEditDirty: (dirty) => set({ isEditDirty: dirty }),
+  bumpSessionEpoch: () => set((state) => ({ sessionEpoch: state.sessionEpoch + 1 })),
 }));

--- a/frontend/src/stores/search-store.ts
+++ b/frontend/src/stores/search-store.ts
@@ -59,6 +59,18 @@ interface SearchState {
    * prior identity typed or drew, so leaving them is not a residue leak.
    */
   clearIdentityScopedFilters: () => void;
+  /**
+   * fix(#1761 review P2): bumped by clearIdentityScopedFilters on every
+   * identity change (never by resetFilters/restoreParams, so it is
+   * excluded from `initialState` below the same way drawing-store excludes
+   * its session epoch from CLEARED_STATE). SearchBar keys its local input
+   * state and pending debounce timer on this: when `q` is already '' at
+   * the moment identity changes (nothing had been committed to the store
+   * yet), `q` does not change value, so a `useEffect` keyed on `q` alone
+   * does not re-run, and a debounce timer already counting down a
+   * previous-identity keystroke still lands. This counter always changes.
+   */
+  resetEpoch: number;
 }
 
 const initialState = {
@@ -86,6 +98,7 @@ const initialState = {
 
 export const useSearchStore = create<SearchState>()((set, get) => ({
   ...initialState,
+  resetEpoch: 0,
 
   setQuery: (q) => set({ q, offset: 0 }),
 
@@ -100,13 +113,14 @@ export const useSearchStore = create<SearchState>()((set, get) => ({
   setSpatialPanelOpen: (open) => set({ spatialPanelOpen: open }),
 
   clearIdentityScopedFilters: () =>
-    set({
+    set((s) => ({
       q: initialState.q,
       bbox: initialState.bbox,
       collection_id: initialState.collection_id,
       keywords: initialState.keywords,
       geometry: initialState.geometry,
-    }),
+      resetEpoch: s.resetEpoch + 1,
+    })),
 
   toParams: () => {
     const state = get();

--- a/frontend/src/stores/search-store.ts
+++ b/frontend/src/stores/search-store.ts
@@ -51,12 +51,20 @@ interface SearchState {
   toParams: () => Record<string, string>;
   restoreParams: (params: Record<string, string>) => void;
   /**
-   * fix(#1713): drop the typed/drawn search intent that could implicate the
-   * previous identity — q, bbox, collection_id, keywords and geometry —
-   * called from the identity-change choke point in lib/auth-cache-reset.ts.
-   * Deliberately narrower than resetFilters(): the other fields (sort_by,
-   * srid, exclude_synthetic, ...) are display preferences, not something a
-   * prior identity typed or drew, so leaving them is not a residue leak.
+   * fix(#1713, then #1761 review round 2 P2): drop every query-shaping
+   * field on an identity change, called from the choke point in
+   * lib/auth-cache-reset.ts. Round 1 reset only q/bbox/collection_id/
+   * keywords/geometry, on the theory that the rest were "display
+   * preferences" — wrong for most of them: geometry_type,
+   * source_organization, record_type, srid, spatial_predicate,
+   * exclude_synthetic and the date/vintage fields all shape which records
+   * a search returns, and `toParams()` plus the URL-sync hook carry them
+   * straight to the next identity. A stale `offset` compounds this: the
+   * next identity's own query can have fewer results, landing them on an
+   * empty page with no visible reason why.
+   *
+   * See `SEARCH_PRESENTATION_PREFERENCE_KEYS` for the only fields this
+   * deliberately leaves alone, and why.
    */
   clearIdentityScopedFilters: () => void;
   /**
@@ -96,6 +104,30 @@ const initialState = {
   spatialPanelOpen: false,
 };
 
+/**
+ * fix(#1761 review round 2 P2): the ONLY fields `clearIdentityScopedFilters`
+ * preserves across an identity change — everything else in `initialState`
+ * is query-shaping and gets reset (see that method). Each one is a genuine
+ * presentation preference, not something that changes which records a
+ * search returns:
+ *   - `sort_by` — sort direction/field.
+ *   - `limit` — page size.
+ *   - `spatialPanelOpen` — whether the spatial-filter UI panel is open; a
+ *     view toggle, not a filter.
+ *
+ * Exported so search-store.test.ts can iterate the store's own keys and
+ * assert every field is classified one way or the other — a field added to
+ * `initialState` later and left out of this list is reset by default
+ * (the safe direction: reset, not leak), but the test will still show it
+ * landing in the "reset" bucket so that default is a visible choice rather
+ * than an accident.
+ */
+export const SEARCH_PRESENTATION_PREFERENCE_KEYS: readonly (keyof typeof initialState)[] = [
+  'sort_by',
+  'limit',
+  'spatialPanelOpen',
+];
+
 export const useSearchStore = create<SearchState>()((set, get) => ({
   ...initialState,
   resetEpoch: 0,
@@ -114,11 +146,12 @@ export const useSearchStore = create<SearchState>()((set, get) => ({
 
   clearIdentityScopedFilters: () =>
     set((s) => ({
-      q: initialState.q,
-      bbox: initialState.bbox,
-      collection_id: initialState.collection_id,
-      keywords: initialState.keywords,
-      geometry: initialState.geometry,
+      ...initialState,
+      // Presentation preferences (see SEARCH_PRESENTATION_PREFERENCE_KEYS):
+      // kept as they were, not reset to their defaults.
+      sort_by: s.sort_by,
+      limit: s.limit,
+      spatialPanelOpen: s.spatialPanelOpen,
       resetEpoch: s.resetEpoch + 1,
     })),
 

--- a/frontend/src/stores/search-store.ts
+++ b/frontend/src/stores/search-store.ts
@@ -105,15 +105,26 @@ const initialState = {
 };
 
 /**
- * fix(#1761 review round 2 P2): the ONLY fields `clearIdentityScopedFilters`
- * preserves across an identity change — everything else in `initialState`
- * is query-shaping and gets reset (see that method). Each one is a genuine
- * presentation preference, not something that changes which records a
- * search returns:
+ * fix(#1761 review round 2 P2, corrected round 4): the ONLY fields
+ * `clearIdentityScopedFilters` preserves across an identity change —
+ * everything else in `initialState` is query-shaping and gets reset (see
+ * that method). Each one is a genuine presentation preference, not
+ * something that changes which records a search returns:
  *   - `sort_by` — sort direction/field.
  *   - `limit` — page size.
- *   - `spatialPanelOpen` — whether the spatial-filter UI panel is open; a
- *     view toggle, not a filter.
+ *
+ * fix(#1761 review round 4, sweep): `spatialPanelOpen` was wrongly listed
+ * here as "a view toggle, not a filter". It gates whether
+ * FilterPanel mounts SpatialFilterPanel, which holds its own uncommitted
+ * `pendingBbox`/`predicate` draft — the exact same shape of bug as
+ * FilterPanel/FilterSheet's date-range draft (finding 1 of this round),
+ * just for the bbox filter, and reached through onApply rather than
+ * through this store directly. Left in the "kept" set, an identity change
+ * would leave the panel open with the previous identity's drawn geometry,
+ * and Apply would write it into the just-cleared store. Removed from this
+ * list: clearIdentityScopedFilters's `...initialState` spread now resets
+ * it to `false`, which unmounts SpatialFilterPanel and, as a consequence,
+ * discards its local draft state for free.
  *
  * Exported so search-store.test.ts can iterate the store's own keys and
  * assert every field is classified one way or the other — a field added to
@@ -125,7 +136,6 @@ const initialState = {
 export const SEARCH_PRESENTATION_PREFERENCE_KEYS: readonly (keyof typeof initialState)[] = [
   'sort_by',
   'limit',
-  'spatialPanelOpen',
 ];
 
 export const useSearchStore = create<SearchState>()((set, get) => ({
@@ -148,10 +158,11 @@ export const useSearchStore = create<SearchState>()((set, get) => ({
     set((s) => ({
       ...initialState,
       // Presentation preferences (see SEARCH_PRESENTATION_PREFERENCE_KEYS):
-      // kept as they were, not reset to their defaults.
+      // kept as they were, not reset to their defaults. spatialPanelOpen is
+      // deliberately NOT here — see that constant's doc comment — so the
+      // `...initialState` spread above resets it to false.
       sort_by: s.sort_by,
       limit: s.limit,
-      spatialPanelOpen: s.spatialPanelOpen,
       resetEpoch: s.resetEpoch + 1,
     })),
 

--- a/frontend/src/stores/search-store.ts
+++ b/frontend/src/stores/search-store.ts
@@ -50,6 +50,15 @@ interface SearchState {
   setSpatialPanelOpen: (open: boolean) => void;
   toParams: () => Record<string, string>;
   restoreParams: (params: Record<string, string>) => void;
+  /**
+   * fix(#1713): drop the typed/drawn search intent that could implicate the
+   * previous identity — q, bbox, collection_id, keywords and geometry —
+   * called from the identity-change choke point in lib/auth-cache-reset.ts.
+   * Deliberately narrower than resetFilters(): the other fields (sort_by,
+   * srid, exclude_synthetic, ...) are display preferences, not something a
+   * prior identity typed or drew, so leaving them is not a residue leak.
+   */
+  clearIdentityScopedFilters: () => void;
 }
 
 const initialState = {
@@ -89,6 +98,15 @@ export const useSearchStore = create<SearchState>()((set, get) => ({
   setSortBy: (sort_by) => set({ sort_by, offset: 0 }),
 
   setSpatialPanelOpen: (open) => set({ spatialPanelOpen: open }),
+
+  clearIdentityScopedFilters: () =>
+    set({
+      q: initialState.q,
+      bbox: initialState.bbox,
+      collection_id: initialState.collection_id,
+      keywords: initialState.keywords,
+      geometry: initialState.geometry,
+    }),
 
   toParams: () => {
     const state = get();


### PR DESCRIPTION
## What

Closes #1713. drawing-store and search-store held user-scoped state with no defense against an in-place identity change (a logout followed by a login in the same tab, no page reload). Same bug class as #1708 (url-import-session) and #793 (analysis-form-store), and the fix mirrors both, applying the two halves the issue calls out.

**drawing-store.ts** held `targetDatasetId`/`targetTableName`/`targetGeometryType`, `selectedFeature` (a real row's `gid`/`tdId`/`properties`), and `isEditDirty`, with no auth subscription. A stale identity's row data and edit target could reach the next signed-in user, and a stale `isEditDirty` gave that user a phantom unsaved-changes prompt (DatasetPage.tsx:~216) for an edit that was never theirs.

**search-store.ts** held the previous user's typed `q`, `bbox`, `collection_id`, `keywords` and drawn `geometry` across the identity change. Milder (search intent, not row data), but the same class.

## Fix

1. Ownership check at adoption (drawing-store.ts): `setDrawing` and `setSelectedFeature` now stamp the signed-in identity onto the store as `ownerId`. `setSelectedFeature` refuses (clearing rather than partially applying) when the identity it would write under does not match who owns the current target. This closes a race specific to this store: `handleEditAttributeSubmit` (components/dataset, out of this lane's scope) reads `selectedFeature` before an update mutation and calls `setSelectedFeature` again after it resolves — a sign-out/sign-in in between could let that resolution re-populate the store for the new user with the old user's row, even after teardown already cleared it. The check holds regardless of whether teardown ran first.

2. Teardown through the existing choke point: `lib/auth-cache-reset.ts` now also calls `useDrawingStore.getState().clearDrawing()` and a new `useSearchStore.getState().clearIdentityScopedFilters()` (clears `q`, `bbox`, `collection_id`, `keywords`, `geometry` only, not the whole filter set) on identity change, added to the existing subscription rather than a new one. Keyed on `user?.id`, not the token, so a token refresh does not discard in-progress state.

## Scope

Touches only `frontend/src/stores/drawing-store.ts`, `frontend/src/stores/search-store.ts`, `frontend/src/lib/auth-cache-reset.ts`, and their tests, per the lane split for #1713. No changes under `components/import/`, `components/dataset/`, or `lib/error-map.ts`.

## Impact

No schema or API changes. No copy changes (no new `t()` keys).

## Verification

Run from the worktree:
- `cd frontend && npm run typecheck` — pass
- `cd frontend && npm run lint` — pass
- `cd frontend && npm run test:i18n` — pass (no new keys)
- `npx vitest run src/stores/__tests__/drawing-store.test.ts src/stores/__tests__/search-store.test.ts src/lib/__tests__/auth-cache-reset.test.ts src/api/__tests__/url-import-session.identity.test.ts` — 40 passed
- `npx vitest run` (full suite) — 422 files, 5630 tests passed

Non-vacuity of the new tests, checked by temporarily reverting and re-running, then restoring:
- Removed the two new calls in `auth-cache-reset.ts` (`clearDrawing()`, `clearIdentityScopedFilters()`): all 4 new identity-change/logout tests in `auth-cache-reset.test.ts` failed; the token-refresh assertions in the same tests were unaffected. Restored, all pass again.
- Removed the refusal branch in `setSelectedFeature`: exactly the 2 new ownership tests in `drawing-store.test.ts` failed, the other 11 in that file kept passing. Restored, all pass again.

## Left alone

`setMode`, `clearSelectedFeature`, and `setEditDirty` are not ownership-checked individually — they mutate state already gated by `setDrawing`/`setSelectedFeature`, and `clearDrawing` (which resets everything including `isEditDirty` and the new `ownerId`) already covers the teardown path the issue names. `search-store`'s other fields (`sort_by`, `srid`, `exclude_synthetic`, spatial predicate, etc.) are display preferences rather than typed/drawn search intent, so they are left alone on purpose, matching the issue's enumerated field list.


## Round 4: three more mounted consumers, plus a full sweep

Codex round 4 found three more instances of the same class (a mounted consumer surviving an epoch change because nothing gates it):

1. **FilterPanel/FilterSheet uncommitted date-range draft.** `localDateFrom`/`localDateTo` survived an identity change, so clicking the still-open popover/sheet's Apply afterward repopulated the cleared store with the previous identity's typed dates. Extracted the ref-based skip-on-mount pattern SearchBar already used into a shared `hooks/use-reset-on-epoch.ts` (`useResetOnEpoch(epoch, reset)`), and wired all three consumers (SearchBar, FilterPanel, FilterSheet) to it, closing the popover/sheet as part of the reset.
2. **DatasetMap's overlay ref/source.** The epoch-triggered cleanup (`finishDrawingSession`) cleared Terra Draw but not `overlayFeaturesRef`/the `drawn-overlay` source that `saveAndRefresh` populates for instant visibility while a create is in flight, and that request's own `clearOverlay()` (fired later by a tile-load event or a 5s fallback) could erase a newer identity's own overlay if it fired after a second identity change. Added `resetOverlay()` to `use-feature-editing.ts`, wired it into `finishDrawingSession`, and made `clearOverlay()` re-check the captured epoch at fire time, not just at the mutation's resolution.
3. **handleEditAttributeSubmit's caller.** It reported success and reloaded tiles even after its own epoch check should have refused a stale write, and its caller (DatasetMap's AttributeForm `onSubmit`) closed the dialog unconditionally once the call resolved, discarding a second identity's own now-open editor for their feature. It now returns `{ applied: boolean }` (false only for the stale-epoch case), and the caller only closes the dialog when `applied` is true.

### Sweep

Per the maintainer's request, enumerated every `await` in `use-feature-editing.ts`, `DatasetMap.tsx`, `SearchBar`, `FilterPanel`, `FilterSheet`, and every other consumer of the drawing/search stores. Sites gated or found identity-independent:

- **use-feature-editing.ts** — all 5 awaits are epoch-gated: `saveAndRefresh` (create), `handleSaveEdit`, `handleDeleteFeature`, `handleEditAttributeSubmit`, `selectFeatureFromMap`. `saveAndRefresh`'s catch-block overlay rollback is deliberately *not* gated: it filters the overlay ref by object identity, so it removes only the one feature its own call added, which stays safe even if a newer identity has since added their own.
- **DatasetMap.tsx** — its one await (the AttributeForm `onSubmit`) is gated via `handleEditAttributeSubmit`'s result. `finishDrawingSession` now also closes `deleteConfirmOpen`/`discardConfirmOpen` and clears `discardActionRef` — the same class as the geometry/attribute dialogs, just missed in round 3.
- **SearchBar/FilterPanel/FilterSheet** — no awaits; local draft state is reset via `useResetOnEpoch` (finding 1 above). FilterSheet's Temporal Extent inputs write straight through to the store on every keystroke (no draft), so they're identity-independent by construction.
- **search-store.ts** — `spatialPanelOpen` was wrongly classified in round 2 as a kept presentation preference. It gates whether `SpatialFilterPanel` mounts, and that component holds its own uncommitted `pendingBbox`/`predicate` draft reached through `onApply` — the same bug as finding 1, for the bbox filter. Removed it from `SEARCH_PRESENTATION_PREFERENCE_KEYS` so `clearIdentityScopedFilters` resets it to `false`, unmounting the panel and discarding its draft for free.
- **KeywordFacetPicker / SavedSearches / use-url-search-sync / use-search / SearchPage** — no awaits touching either store. `KeywordFacetPicker`'s and `SavedSearches`' local state never writes back to the identity-scoped fields; `use-url-search-sync` subscribes to every store change (including the clear itself), so it needs no separate gating; the `use-search` query hooks are keyed on the current store params, with cache eviction already handled by `queryClient.clear()` in the choke point.
- **DatasetPage.tsx** — several awaits, none with post-await effects on either store; its only drawing-store read (`isEditDirty`) is a synchronous nav-guard selector, already correctly cleared.
- **SourceRefreshAction.tsx** — out of scope (owned by another lane), not touched. For the record: its one await's post-await effects touch only its own local state and a page-level watch callback, never either store; its drawing-store read is a synchronous disabled-check.
- **DrawingToolbar.tsx / use-feature-gid.ts** — no awaits; synchronous reads only.

### Verification (round 4)

- `cd frontend && npm run typecheck`: pass
- `cd frontend && npm run lint`: pass
- `cd frontend && npm run test:i18n`: pass (no copy changes)
- `npx vitest run` on the 12 touched files: all passing
- `npx vitest run` (full suite): 425 files, 5664 tests passed

Non-vacuity, checked by temporarily reverting and re-running:
- Disabling `useResetOnEpoch`'s guard failed its own 3 tests plus one each in SearchBar/FilterPanel/FilterSheet's identity tests (6 failures across 4 files); the rest stayed green.
- Disabling `clearOverlay`'s fire-time epoch check failed exactly the "does not erase a newer overlay..." test; the other 12 in that file stayed green.
- Disabling `handleEditAttributeSubmit`'s epoch check failed its own `applied: false` test and DatasetMap's "keeps the dialog open" test; reverting only the DatasetMap caller to close unconditionally failed just that one DatasetMap test.
- Reverting `spatialPanelOpen`'s reclassification failed exactly the new "closes the spatial filter panel on identity change" test; the store's own generic key-iteration test still passed, since it can only catch a mismatch between the constant and the implementation, not a wrong policy both agree on — this is exactly why the FilterPanel-level test was needed.
- Disabling `resetOverlay`'s call in `finishDrawingSession` failed exactly the overlay assertion in the existing "tears down..." test; the rest of that file (30 tests) stayed green.
