### PR TITLE
fix(compose): mount the four repo files make test reads but never sees

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -308,6 +308,7 @@ services:
       - ./README.es.md:/app/README.es.md:ro
       - ./README.fr.md:/app/README.fr.md:ro
       - ./README.md:/app/README.md:ro
+      - ./RUNBOOK.md:/app/RUNBOOK.md:ro
       - ./SUPPORT.md:/app/SUPPORT.md:ro
       - ./backend/app:/app/app
       - ./backend/alembic:/app/alembic
@@ -316,11 +317,26 @@ services:
       - ./cli:/app/cli:ro
       - ./db:/app/db:ro
       - ./deployment:/app/deployment:ro
+      - ./docker-compose.prod.yml:/app/docker-compose.prod.yml:ro
       - ./docker-compose.yml:/app/docker-compose.yml:ro
       - ./e2e:/app/e2e:ro
       - ./examples:/app/examples:ro
       - ./frontend:/app/frontend:ro
+      - ./frontend/src/types/api.ts:/app/frontend/src/types/api.ts:ro
+      # fix(#1745): individual files/subdirs, never the whole ./scripts tree —
+      # backend/scripts/ is baked into /app/scripts by the image build
+      # (api-entrypoint.sh, worker-entrypoint.sh, dump_openapi.py live there),
+      # and a whole-directory mount of the repo-root scripts/ at the same
+      # /app/scripts path would shadow that baked content and break both
+      # entrypoints on next recreate. scripts/lib and scripts/tests have no
+      # same-named counterpart under backend/scripts, so those two are safe
+      # to mount as directories.
+      - ./scripts/flatten_openapi_defs.py:/app/scripts/flatten_openapi_defs.py:ro
+      - ./scripts/init-db.sh:/app/scripts/init-db.sh:ro
+      - ./scripts/lib:/app/scripts/lib:ro
+      - ./scripts/restore.sh:/app/scripts/restore.sh:ro
       - ./scripts/seed-showcase.py:/app/scripts/seed-showcase.py:ro
+      - ./scripts/tests:/app/scripts/tests:ro
       - ./sdks:/app/sdks:ro
       # GAP-022: SHARED-STAGING CONTRACT. The api, worker, and titiler services
       # all mount this one named volume at the FIXED path /app/staging and MUST


### PR DESCRIPTION
## What changed

Added four read-only mounts to the `api` service in `docker-compose.yml` so the seven test files named in #1745 can find the repo files they read: `./RUNBOOK.md`, `./docker-compose.prod.yml`, `./frontend/src/types/api.ts`, plus the specific root-level `scripts/` entries those tests actually touch.

The issue suggests `./scripts:/app/scripts:ro` as a single directory mount. I did not do that. `backend/scripts/` is what the Dockerfile bakes into `/app/scripts` at build time (`api-entrypoint.sh`, `worker-entrypoint.sh`, `dump_openapi.py`, `check_fe_type_drift.py`, and friends, confirmed with `docker exec geolens-api-1 ls /app/scripts`). Mounting the whole repo-root `scripts/` directory at that same path replaces that baked content outright. I reproduced it in a throwaway container: `/app/scripts/dump_openapi.py` disappeared, along with the entrypoint scripts. On a real `docker compose up --force-recreate`, `entrypoint: ["/app/scripts/api-entrypoint.sh"]` would no longer resolve, and the api and worker containers would fail to start.

Instead I mounted only the five root-level `scripts/` paths the two affected tests need: `flatten_openapi_defs.py`, `init-db.sh`, `restore.sh`, and the `lib/` and `tests/` subdirectories (mounted whole since neither has a same-named counterpart under `backend/scripts/`, so there's nothing to shadow). Verified `/app/scripts` afterward has both the baked entrypoint scripts and the new files side by side.

Left `./scripts` `:ro` throughout, per GAP-021 (same reasoning as the sibling `init-db.sh` mount on the `db` service). Did not touch `test_url_import_1705.py`'s chmod-as-root case; the issue calls that out as a separate decision.

Worker does not mount this file list at all (only `backend/app`, `backend/tests`, `upload_staging`), and nothing in the Makefile runs tests inside the worker container, so nothing changes there.

## Verification

`docker compose -f docker-compose.yml config` from the worktree resolves all four new mounts on `api` (confirmed via `--format yaml`, showing `source`/`target`/`read_only: true` for each). Also reran `docker compose config` against a verbatim `.env.example` copied to `.env`: exits 0, only the expected "variable not set" warnings (INST-01).

Built a throwaway container joining the live stack's `geolens_default` network (`docker run --rm --network geolens_default ... --entrypoint uv geolens-api:latest run pytest ...`), bind-mounting from this worktree at the same `/app/...` paths the compose file uses. That means the full `api` service volume list, not just the four new ones: with only the four new ones present, `repo_root()` can't locate `docker-compose.yml` at all, since none of the 25 mounts already on `main` are baked into the image, so testing whether the fix works needs the whole set. Env came from `docker exec geolens-api-1 env` (the running api container's real `POSTGRES_*`/`JWT_SECRET_KEY`/`GEOLENS_ADMIN_*`, since `.env.test`'s `POSTGRES_HOST=localhost:5434` is for host runs, not a container on the compose network), plus `UV_CACHE_DIR=/app/staging/uv-cache` and `UV_PROJECT_ENVIRONMENT=/app/staging/geolens-api-test-venv` as `make test` sets them. Did not touch the running stack: no `up`, `restart`, or `--force-recreate` against the `geolens` compose project.

Command run both before (original `docker-compose.yml` mount set, reconstructed from `git show HEAD~1:docker-compose.yml` into the same throwaway-container mount list) and after this change:

```
uv run pytest -o cache_dir=/app/staging/.pytest_cache --continue-on-collection-errors \
  tests/test_titiler_redirect_env.py tests/test_titiler_credentials.py \
  tests/test_titiler_gdal_security_env.py tests/test_runtime_db_role.py \
  tests/test_openapi_property_order.py tests/test_tenant_ownership_adoption.py \
  tests/test_upload_extension_defaults_agree.py tests/test_fe_sdk_type_drift.py -q
```

Before: `49 failed, 85 passed, 7 errors` (141 collected items plus the one file-level collection error).
After: `5 failed, 129 passed, 7 errors`. 44 tests move from failed to passing.

## What's still red, and why it's not this PR

The 7 errors are unchanged before and after. The 5 remaining failures are two separate, pre-existing bugs, neither caused by a missing mount:

1. Three `test_runtime_db_role.py` tests (`test_compose_scopes_managed_migrator_role_away_from_local_db`, `test_compose_infers_bundled_migrator_role_only_for_migrate`, `test_compose_passes_explicit_bundled_migration_owner_to_local_db`) shell out to the `docker` CLI via `subprocess.run(["docker", "compose", ...])`. The `docker` binary isn't installed in the `geolens-api` image, so this fails with `FileNotFoundError: docker` no matter what is mounted. Fixing it would mean either installing the docker CLI in the image or rewriting the test to parse the YAML directly, out of scope here.

2. Three test files (`test_openapi_property_order.py`, `test_tenant_ownership_adoption.py`, `test_fe_sdk_type_drift.py`) compute their repo root with a hardcoded parent count: `Path(__file__).resolve().parent.parent.parent` or `.parents[2]`, instead of the container-aware `repo_root()` helper in `backend/tests/repo_paths.py` that five sibling files already use correctly. That hardcoded count assumes the host's nesting (`repo_root/backend/tests/file.py`, two directories between the test file and repo root). In the container, `backend/tests` is mounted directly at `/app/tests` (one directory below `/app`), so the same three `.parent` hops overshoot to the filesystem root `/` instead of `/app`. No mount fixes this. `test_openapi_property_order.py` still errors at collection (now on `flatten_openapi_defs.py` instead of `dump_openapi.py`, since `dump_openapi.py` now resolves correctly through the already-correct `BACKEND_ROOT`), `test_tenant_ownership_adoption.py::test_runbook_documents_the_forward_only_recipe` looks for `/RUNBOOK.md`, and `test_fe_sdk_type_drift.py` looks for `/frontend/src/types/api.ts` and `/backend/scripts/check_fe_type_drift.py`. This looks like a real bug worth its own follow-up issue. Happy to file it, but fixing it means editing `backend/tests/*.py`, outside this lane's scope of `docker-compose.yml` only.

## Schema/API/config impact

None. Compose-only change, no schema, no API surface, no new env vars.

https://claude.ai/code/session_01SFCMH3VJ5pFfM9Rer7KHZq
