### PR TITLE
fix(release): write and verify the CHANGELOG compare links on bump

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -949,6 +949,15 @@ jobs:
       - name: Check the CHANGELOG gate tracks release.yml
         run: python scripts/tests/test-changelog-gate.py
 
+      # The reference-style compare links at the bottom of CHANGELOG.md are a
+      # separate block from the `## [version]` section above and used to be
+      # unenforced entirely: a release could ship with `[Unreleased]` still
+      # comparing from the previous tag and no link for the new version
+      # (v1.17.0, #1714). Pins the gate's link assertions and bump_version.py's
+      # mechanical write of both lines (fix(#1716)).
+      - name: Check the CHANGELOG compare links
+        run: python scripts/tests/test-changelog-links.py
+
   # ---------- docs contract ----------
   # Enforce docs-contract.json: validates the contract against install.sh +
   # pyproject (so it can't drift from the binaries) and scans the READMEs for

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -268,12 +268,14 @@ def _bump_package_lock(path: Path, version: str) -> None:
 _UNRELEASED_LINE_RE = re.compile(r"^\[Unreleased\]: .*$", re.MULTILINE)
 # A `## [<version>]` section heading, optionally followed by ` - <date>`.
 _CHANGELOG_HEADER_RE = re.compile(r"^## \[([^\]]+)\]")
+# Any reference-style link definition line, e.g. `[Unreleased]: https://...`.
+_LINK_LINE_RE = re.compile(r"^\[([^\]]+)\]: (\S+)$")
 
 
 def _changelog_prev_version(text: str, version: str) -> str | None:
     """The version whose `## [...]` section immediately follows `version`'s.
 
-    None if `version`'s section is the last one in the file — the initial
+    None if `version`'s section is the last one in the file - the initial
     release, with no preceding version to compare from.
     """
     found = False
@@ -291,36 +293,88 @@ def _changelog_prev_version(text: str, version: str) -> str | None:
     return None
 
 
-def _bump_changelog_links(path: Path, version: str) -> None:
-    """Repoint `[Unreleased]` and ensure `[X.Y.Z]:` compares from the right tag.
+def _changelog_link_lines(text: str) -> list[tuple[str, str, int]]:
+    """(label, url, 1-based line number) for every reference-style link
+    definition in `text`, in the order they appear.
+    """
+    result: list[tuple[str, str, int]] = []
+    for i, line in enumerate(text.splitlines(), start=1):
+        m = _LINK_LINE_RE.match(line)
+        if m:
+            result.append((m.group(1), m.group(2), i))
+    return result
 
-    The previous version is read from the CHANGELOG's own section structure
-    (the `## [...]` heading immediately below `## [version]`), not from the
-    current `[Unreleased]` link text — check_version_coherence.py verifies
-    the link against that same structural rule, so the two agree by
-    construction. Repairs whichever half is missing or wrong rather than
-    bailing out as soon as `[Unreleased]` already points at `version`: a
-    partial or hand-edited state — `[Unreleased]` repointed but the
-    `[X.Y.Z]:` link missing or stale — used to be left unrepaired
-    (fix(#1716 review)). A true no-op (both lines already correct) still
-    writes nothing.
+
+def _check_no_duplicate_changelog_labels(text: str, path: Path) -> None:
+    """Refuse to bump a CHANGELOG that defines the same link label twice.
+
+    Markdown resolves duplicate reference labels (compared
+    case-insensitively, matching CommonMark) to the FIRST definition, so a
+    stale duplicate later in the file renders invisibly while still leaving
+    it ambiguous which line this script is meant to edit.
+    check_version_coherence.py fails the same way for the same reason
+    (fix(#1716 review)).
+    """
+    first_seen: dict[str, int] = {}
+    for label, _url, line in _changelog_link_lines(text):
+        key = label.casefold()
+        if key in first_seen:
+            sys.exit(
+                f"ERROR: {_rel(path)} defines '[{label}]:' more than once "
+                f"(lines {first_seen[key]} and {line}). Remove or fix the "
+                f"duplicate before bumping."
+            )
+        first_seen[key] = line
+
+
+def _validate_changelog_links(path: Path, version: str) -> None:
+    """Every precondition `_bump_changelog_links` depends on, checked upfront.
+
+    main() calls this BEFORE any other version site is written, so a
+    CHANGELOG that can't be safely bumped - a duplicate reference label, no
+    `[Unreleased]:` line, or no `## [...]` section for `version` - aborts
+    the whole `make bump` with nothing touched, instead of leaving every
+    other site already bumped while only the CHANGELOG failed at the very
+    end (fix(#1716 review)).
     """
     text = path.read_text()
-
-    unreleased_m = _UNRELEASED_LINE_RE.search(text)
-    if not unreleased_m:
+    _check_no_duplicate_changelog_labels(text, path)
+    if not _UNRELEASED_LINE_RE.search(text):
         sys.exit(
             f"ERROR: no '[Unreleased]: ...' line in {_rel(path)}. Add the "
             f"reference-style link block before bumping."
         )
-
-    prev_version = _changelog_prev_version(text, version)
-    if prev_version is None:
+    if _changelog_prev_version(text, version) is None:
         sys.exit(
             f"ERROR: {_rel(path)} has no '## [...]' section below '## [{version}]' "
             f"to read the previous version from. Add the release's CHANGELOG "
             f"section (and the section for the version before it) before bumping."
         )
+
+
+def _bump_changelog_links(path: Path, version: str) -> None:
+    """Repoint `[Unreleased]` and ensure `[X.Y.Z]:` compares from the right tag.
+
+    The previous version is read from the CHANGELOG's own section structure
+    (the `## [...]` heading immediately below `## [version]`), not from the
+    current `[Unreleased]` link text - check_version_coherence.py verifies
+    the link against that same structural rule, so the two agree by
+    construction. Repairs whichever half is missing or wrong rather than
+    bailing out as soon as `[Unreleased]` already points at `version`: a
+    partial or hand-edited state - `[Unreleased]` repointed but the
+    `[X.Y.Z]:` link missing or stale - used to be left unrepaired
+    (fix(#1716 review)). A true no-op (both lines already correct) still
+    writes nothing.
+
+    Re-runs `_validate_changelog_links` so calling this directly (as the
+    tests do) is safe on its own, even though main() already validated
+    before writing anything else.
+    """
+    _validate_changelog_links(path, version)
+    text = path.read_text()
+
+    unreleased_m = _UNRELEASED_LINE_RE.search(text)
+    prev_version = _changelog_prev_version(text, version)
 
     expected_unreleased = f"[Unreleased]: {CHANGELOG_REPO_URL}/compare/v{version}...HEAD"
     expected_version_link = (
@@ -360,6 +414,12 @@ def main(argv: list[str]) -> int:
     version = argv[0].strip()
     if not SEMVER_RE.match(version):
         sys.exit(f"ERROR: version '{version}' is not X.Y.Z (plain semver, no suffixes).")
+
+    # Validate the CHANGELOG edit BEFORE touching any other version site, so
+    # a CHANGELOG that can't be safely bumped aborts with nothing written
+    # instead of leaving every other site already bumped while only the
+    # CHANGELOG failed, at the very end (fix(#1716 review)).
+    _validate_changelog_links(CHANGELOG, version)
 
     print(f"Bumping all version sites to {version}:")
     _bump_project_version(BACKEND_PYPROJECT, version)

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -25,6 +25,12 @@
   - docs-contract.json                     (.version — the cross-surface doc
                                            contract; check_docs_contract.py
                                            asserts it equals backend/pyproject)
+  - CHANGELOG.md                           (the reference-style compare links at
+                                           the bottom of the file: `[Unreleased]`
+                                           is repointed to compare/vX.Y.Z...HEAD
+                                           and a new `[X.Y.Z]:` link is inserted
+                                           comparing from the previous version,
+                                           fix(#1716))
 
 Every lockfile that embeds the package's own version is stamped too (fix(#877) —
 each of these had to be hand-stamped on past releases, and each was missed at
@@ -79,6 +85,8 @@ PY_SDK_PYPROJECT = REPO_ROOT / "sdks" / "python" / "pyproject.toml"
 PY_SDK_GEN_CONFIG = REPO_ROOT / "sdks" / "python" / ".openapi-python-client.yaml"
 TS_SDK_PACKAGE = REPO_ROOT / "sdks" / "typescript" / "package.json"
 DOCS_CONTRACT = REPO_ROOT / "docs-contract.json"
+CHANGELOG = REPO_ROOT / "CHANGELOG.md"
+CHANGELOG_REPO_URL = "https://github.com/geolens-io/geolens"
 
 # --- Lockfiles (fix(#877)) ---------------------------------------------------
 # A uv.lock records the version of every LOCAL package it resolves: the project
@@ -255,6 +263,48 @@ def _bump_package_lock(path: Path, version: str) -> None:
     print(f'  {_rel(path)} (.version + packages."".version) -> {version}')
 
 
+# The current `[Unreleased]` compare link. Its own from-tag IS the previous
+# version — reading it back means the bump needs no separate record of what
+# came before (fix(#1716)).
+_UNRELEASED_LINK_RE = re.compile(
+    rf"^\[Unreleased\]: {re.escape(CHANGELOG_REPO_URL)}/compare/"
+    rf"v(\d+\.\d+\.\d+)\.\.\.HEAD$",
+    re.MULTILINE,
+)
+
+
+def _bump_changelog_links(path: Path, version: str) -> None:
+    """Repoint `[Unreleased]` and insert the new `[X.Y.Z]:` compare link.
+
+    Idempotent: if `[Unreleased]` already compares from `version`, this bump
+    already ran for this version and nothing is written again — running the
+    script twice for the same version must not insert a second link.
+    """
+    text = path.read_text()
+    m = _UNRELEASED_LINK_RE.search(text)
+    if not m:
+        sys.exit(
+            f"ERROR: no '[Unreleased]: {CHANGELOG_REPO_URL}/compare/vPREV...HEAD'\n"
+            f"line in {_rel(path)}. Add the reference-style link block before bumping."
+        )
+    prev_version = m.group(1)
+    if prev_version == version:
+        print(f"  {_rel(path)} (compare links) already point at {version}, skipping.")
+        return
+    new_unreleased = f"[Unreleased]: {CHANGELOG_REPO_URL}/compare/v{version}...HEAD"
+    new_version_link = (
+        f"[{version}]: {CHANGELOG_REPO_URL}/compare/v{prev_version}...v{version}"
+    )
+    text = _UNRELEASED_LINK_RE.sub(
+        lambda _: f"{new_unreleased}\n{new_version_link}", text, count=1
+    )
+    path.write_text(text)
+    print(
+        f"  {_rel(path)} ([Unreleased] -> compare/v{version}...HEAD, "
+        f"+ [{version}] -> compare/v{prev_version}...v{version})"
+    )
+
+
 def main(argv: list[str]) -> int:
     if len(argv) != 1:
         sys.exit("Usage: bump_version.py X.Y.Z")
@@ -279,6 +329,7 @@ def main(argv: list[str]) -> int:
         _bump_uv_lock(lock, package_names, version)
     for lock in PACKAGE_LOCKS:
         _bump_package_lock(lock, version)
+    _bump_changelog_links(CHANGELOG, version)
     print(f"Done. Run `make version-check` to confirm coherence.")
     return 0
 

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -263,45 +263,94 @@ def _bump_package_lock(path: Path, version: str) -> None:
     print(f'  {_rel(path)} (.version + packages."".version) -> {version}')
 
 
-# The current `[Unreleased]` compare link. Its own from-tag IS the previous
-# version — reading it back means the bump needs no separate record of what
-# came before (fix(#1716)).
-_UNRELEASED_LINK_RE = re.compile(
-    rf"^\[Unreleased\]: {re.escape(CHANGELOG_REPO_URL)}/compare/"
-    rf"v(\d+\.\d+\.\d+)\.\.\.HEAD$",
-    re.MULTILINE,
-)
+# `[Unreleased]:` in whatever shape it currently reads, so a malformed line
+# gets repaired rather than silently ignored.
+_UNRELEASED_LINE_RE = re.compile(r"^\[Unreleased\]: .*$", re.MULTILINE)
+# A `## [<version>]` section heading, optionally followed by ` - <date>`.
+_CHANGELOG_HEADER_RE = re.compile(r"^## \[([^\]]+)\]")
+
+
+def _changelog_prev_version(text: str, version: str) -> str | None:
+    """The version whose `## [...]` section immediately follows `version`'s.
+
+    None if `version`'s section is the last one in the file — the initial
+    release, with no preceding version to compare from.
+    """
+    found = False
+    for line in text.splitlines():
+        m = _CHANGELOG_HEADER_RE.match(line)
+        if not m:
+            continue
+        label = m.group(1)
+        if found:
+            if label == "Unreleased":
+                continue
+            return label
+        if label == version:
+            found = True
+    return None
 
 
 def _bump_changelog_links(path: Path, version: str) -> None:
-    """Repoint `[Unreleased]` and insert the new `[X.Y.Z]:` compare link.
+    """Repoint `[Unreleased]` and ensure `[X.Y.Z]:` compares from the right tag.
 
-    Idempotent: if `[Unreleased]` already compares from `version`, this bump
-    already ran for this version and nothing is written again — running the
-    script twice for the same version must not insert a second link.
+    The previous version is read from the CHANGELOG's own section structure
+    (the `## [...]` heading immediately below `## [version]`), not from the
+    current `[Unreleased]` link text — check_version_coherence.py verifies
+    the link against that same structural rule, so the two agree by
+    construction. Repairs whichever half is missing or wrong rather than
+    bailing out as soon as `[Unreleased]` already points at `version`: a
+    partial or hand-edited state — `[Unreleased]` repointed but the
+    `[X.Y.Z]:` link missing or stale — used to be left unrepaired
+    (fix(#1716 review)). A true no-op (both lines already correct) still
+    writes nothing.
     """
     text = path.read_text()
-    m = _UNRELEASED_LINK_RE.search(text)
-    if not m:
+
+    unreleased_m = _UNRELEASED_LINE_RE.search(text)
+    if not unreleased_m:
         sys.exit(
-            f"ERROR: no '[Unreleased]: {CHANGELOG_REPO_URL}/compare/vPREV...HEAD'\n"
-            f"line in {_rel(path)}. Add the reference-style link block before bumping."
+            f"ERROR: no '[Unreleased]: ...' line in {_rel(path)}. Add the "
+            f"reference-style link block before bumping."
         )
-    prev_version = m.group(1)
-    if prev_version == version:
-        print(f"  {_rel(path)} (compare links) already point at {version}, skipping.")
-        return
-    new_unreleased = f"[Unreleased]: {CHANGELOG_REPO_URL}/compare/v{version}...HEAD"
-    new_version_link = (
+
+    prev_version = _changelog_prev_version(text, version)
+    if prev_version is None:
+        sys.exit(
+            f"ERROR: {_rel(path)} has no '## [...]' section below '## [{version}]' "
+            f"to read the previous version from. Add the release's CHANGELOG "
+            f"section (and the section for the version before it) before bumping."
+        )
+
+    expected_unreleased = f"[Unreleased]: {CHANGELOG_REPO_URL}/compare/v{version}...HEAD"
+    expected_version_link = (
         f"[{version}]: {CHANGELOG_REPO_URL}/compare/v{prev_version}...v{version}"
     )
-    text = _UNRELEASED_LINK_RE.sub(
-        lambda _: f"{new_unreleased}\n{new_version_link}", text, count=1
-    )
+
+    changed = False
+    if unreleased_m.group(0) != expected_unreleased:
+        text = text[: unreleased_m.start()] + expected_unreleased + text[unreleased_m.end() :]
+        changed = True
+
+    version_line_re = re.compile(rf"^\[{re.escape(version)}\]: .*$", re.MULTILINE)
+    version_m = version_line_re.search(text)
+    if version_m is None:
+        text = text.replace(
+            expected_unreleased, f"{expected_unreleased}\n{expected_version_link}", 1
+        )
+        changed = True
+    elif version_m.group(0) != expected_version_link:
+        text = text[: version_m.start()] + expected_version_link + text[version_m.end() :]
+        changed = True
+
+    if not changed:
+        print(f"  {_rel(path)} (compare links) already correct for {version}, skipping.")
+        return
+
     path.write_text(text)
     print(
         f"  {_rel(path)} ([Unreleased] -> compare/v{version}...HEAD, "
-        f"+ [{version}] -> compare/v{prev_version}...v{version})"
+        f"[{version}] -> compare/v{prev_version}...v{version})"
     )
 
 

--- a/scripts/check_version_coherence.py
+++ b/scripts/check_version_coherence.py
@@ -205,14 +205,61 @@ def _changelog_section(version: str) -> str | None:
     return "\n".join(out) if found else None
 
 
+def _changelog_link_lines() -> list[tuple[str, str, int]]:
+    """(label, url, 1-based line number) for every reference-style link
+    definition in CHANGELOG.md, in the order they appear.
+    """
+    result: list[tuple[str, str, int]] = []
+    for i, line in enumerate(CHANGELOG.read_text().splitlines(), start=1):
+        m = _LINK_DEF_RE.match(line)
+        if m:
+            result.append((m.group(1), m.group(2), i))
+    return result
+
+
 def _changelog_links() -> dict[str, str]:
     """Reference-style link definitions (`[label]: url`), keyed by label.
+
+    Markdown resolves multiple definitions of the same label (compared
+    case-insensitively) to the FIRST one - a later duplicate is dead text as
+    far as rendering goes. This mirrors that: the first occurrence of a
+    label wins, so `.get("Unreleased")` / `.get(canonical)` below see what a
+    reader of the rendered CHANGELOG would actually see, not whichever
+    duplicate happens to sort last. `_changelog_duplicate_labels()` is the
+    dedicated check for whether a duplicate exists at all, which is always
+    a CHANGELOG bug worth failing on regardless of which value would win.
 
     Returns an empty dict for a CHANGELOG with no link block at all, so a
     caller doing a plain `.get()` fails with the FAIL messages below instead
     of a traceback.
     """
-    return dict(_LINK_DEF_RE.findall(CHANGELOG.read_text()))
+    links: dict[str, str] = {}
+    seen_keys: set[str] = set()
+    for label, url, _line in _changelog_link_lines():
+        key = label.casefold()
+        if key in seen_keys:
+            continue
+        seen_keys.add(key)
+        links[label] = url
+    return links
+
+
+def _changelog_duplicate_labels() -> list[tuple[str, int, int]]:
+    """(label as first defined, first line, duplicate line) for every label
+    defined more than once, compared case-insensitively (matching how
+    Markdown resolves reference labels). A label appearing 3+ times reports
+    one entry per extra occurrence, each pointing back at the first line.
+    """
+    first_seen: dict[str, tuple[str, int]] = {}
+    duplicates: list[tuple[str, int, int]] = []
+    for label, _url, line in _changelog_link_lines():
+        key = label.casefold()
+        if key in first_seen:
+            orig_label, first_line = first_seen[key]
+            duplicates.append((orig_label, first_line, line))
+        else:
+            first_seen[key] = (label, line)
+    return duplicates
 
 
 # A `## [<version>]` section heading, optionally followed by ` - <date>`.
@@ -254,8 +301,18 @@ def _check_changelog_links(canonical: str) -> list[str]:
     block at all (an empty dict from `_changelog_links()`) fails both checks
     with a plain message here, not a traceback.
     """
-    links = _changelog_links()
     failures: list[str] = []
+
+    for label, first_line, dup_line in _changelog_duplicate_labels():
+        failures.append(
+            f"{_rel(CHANGELOG)} defines '[{label}]:' more than once (lines "
+            f"{first_line} and {dup_line}). Markdown resolves a duplicate "
+            f"reference label to the FIRST definition (case-insensitively), "
+            f"so the rendered CHANGELOG uses line {first_line} regardless of "
+            f"what line {dup_line} says. Remove or fix the duplicate."
+        )
+
+    links = _changelog_links()
 
     unreleased_url = links.get("Unreleased")
     if unreleased_url is None:

--- a/scripts/check_version_coherence.py
+++ b/scripts/check_version_coherence.py
@@ -215,14 +215,44 @@ def _changelog_links() -> dict[str, str]:
     return dict(_LINK_DEF_RE.findall(CHANGELOG.read_text()))
 
 
+# A `## [<version>]` section heading, optionally followed by ` - <date>`.
+_CHANGELOG_HEADER_RE = re.compile(r"^## \[([^\]]+)\]")
+
+
+def _changelog_prev_version(canonical: str) -> str | None:
+    """The version whose `## [...]` section immediately follows canonical's.
+
+    None if canonical's section is the last one in the file - the initial
+    release, with no preceding version to compare from. bump_version.py
+    derives the previous version the same way, so the two agree by
+    construction.
+    """
+    found = False
+    for line in CHANGELOG.read_text().splitlines():
+        m = _CHANGELOG_HEADER_RE.match(line)
+        if not m:
+            continue
+        label = m.group(1)
+        if found:
+            if label == "Unreleased":
+                continue
+            return label
+        if label == canonical:
+            found = True
+    return None
+
+
 def _check_changelog_links(canonical: str) -> list[str]:
     """FAIL messages for the CHANGELOG's reference-style compare links.
 
-    An empty list means both checks passed: a `[<canonical>]:` compare link
-    exists, and `[Unreleased]:` compares from `v<canonical>...HEAD` rather
-    than an older tag. A CHANGELOG with no link block at all (an empty dict
-    from `_changelog_links()`) fails both checks with a plain message here,
-    not a traceback.
+    An empty list means both checks passed: `[Unreleased]:` compares from
+    `v<canonical>...HEAD` rather than an older tag, and `[<canonical>]:`
+    compares from the version whose `## [...]` section immediately follows
+    canonical's in the file - not merely "some v...v<canonical> link", which
+    would let a stale or self-referential source (e.g.
+    `compare/v<canonical>...v<canonical>`) pass. A CHANGELOG with no link
+    block at all (an empty dict from `_changelog_links()`) fails both checks
+    with a plain message here, not a traceback.
     """
     links = _changelog_links()
     failures: list[str] = []
@@ -248,18 +278,37 @@ def _check_changelog_links(canonical: str) -> list[str]:
             )
 
     version_url = links.get(canonical)
+    prev_version = _changelog_prev_version(canonical)
+
     if version_url is None:
         failures.append(
             f"{_rel(CHANGELOG)} has no '[{canonical}]:' compare link definition. "
-            f"Add '[{canonical}]: {CHANGELOG_REPO_URL}/compare/vPREV...v{canonical}' "
-            f"to the link block (run `make bump VERSION={canonical}` to write it)."
+            f"Add '[{canonical}]: {CHANGELOG_REPO_URL}/compare/v{prev_version or 'PREV'}"
+            f"...v{canonical}' to the link block (run `make bump VERSION={canonical}` "
+            f"to write it)."
         )
-    else:
-        m = _COMPARE_LINK_RE.match(version_url)
-        if not m or m.group("to") != f"v{canonical}":
+    elif prev_version is None:
+        # canonical's section is the first (oldest) one in the file: there is
+        # no preceding '## [...]' section to derive a PREV tag from. Accept
+        # only the conventional initial-release link; anything else can't be
+        # verified against the repository's actual initial tag from the
+        # CHANGELOG alone, so report rather than silently pass.
+        initial_tag_url = f"{CHANGELOG_REPO_URL}/releases/tag/v{canonical}"
+        if version_url != initial_tag_url:
             failures.append(
-                f"{_rel(CHANGELOG)}'s '[{canonical}]:' link does not compare "
-                f"...v{canonical}. Got: {version_url!r}"
+                f"{_rel(CHANGELOG)}'s '[{canonical}]:' section is the first one in "
+                f"the file (no preceding '## [...]' section to compare from), so its "
+                f"link should be '{initial_tag_url}'. Got: {version_url!r}. If "
+                f"v{canonical} is not actually the repository's initial release, add "
+                f"the missing '## [...]' section for the version before it."
+            )
+    else:
+        expected = f"{CHANGELOG_REPO_URL}/compare/v{prev_version}...v{canonical}"
+        if version_url != expected:
+            failures.append(
+                f"{_rel(CHANGELOG)}'s '[{canonical}]:' link should compare "
+                f"v{prev_version}...v{canonical} (the next '## [...]' section below "
+                f"'## [{canonical}]' is '## [{prev_version}]'). Got: {version_url!r}"
             )
 
     return failures

--- a/scripts/check_version_coherence.py
+++ b/scripts/check_version_coherence.py
@@ -15,6 +15,15 @@ nothing — a fallback whose own filter drops every `docs(`/`chore(` subject, so
 release whose headline change landed as `chore(db): upgrade ... PostgreSQL 18`
 would publish notes that never mention it. Nothing else in CI reads CHANGELOG.md.
 
+Also asserts the reference-style link block at the bottom of CHANGELOG.md
+agrees with the canonical version (fix(#1716)): a `[<version>]:` compare link
+must exist for the canonical version, and `[Unreleased]:` must compare from
+`v<version>...HEAD`, not an older tag. Both edits used to be manual and
+unenforced, so a release could ship with an unlinked heading while
+`[Unreleased]` kept claiming every change in the release that just shipped
+(seen on v1.17.0, #1714). scripts/bump_version.py now writes both lines
+mechanically; this is the backstop.
+
 Sites checked:
   - backend/pyproject.toml                  [project].version (canonical)
   - backend/app/api/main.py                 _FALLBACK_APP_VERSION constant
@@ -72,6 +81,17 @@ PY_SDK_PYPROJECT = REPO_ROOT / "sdks" / "python" / "pyproject.toml"
 PY_SDK_GEN_CONFIG = REPO_ROOT / "sdks" / "python" / ".openapi-python-client.yaml"
 TS_SDK_PACKAGE = REPO_ROOT / "sdks" / "typescript" / "package.json"
 CHANGELOG = REPO_ROOT / "CHANGELOG.md"
+
+# The reference-style link block at the bottom of CHANGELOG.md, e.g.:
+#   [Unreleased]: https://github.com/geolens-io/geolens/compare/v1.17.0...HEAD
+#   [1.17.0]: https://github.com/geolens-io/geolens/compare/v1.16.1...v1.17.0
+# scripts/bump_version.py writes this same shape.
+CHANGELOG_REPO_URL = "https://github.com/geolens-io/geolens"
+_LINK_DEF_RE = re.compile(r"^\[([^\]]+)\]: (\S+)$", re.MULTILINE)
+_COMPARE_LINK_RE = re.compile(
+    rf"^{re.escape(CHANGELOG_REPO_URL)}/compare/"
+    rf"v(?P<from>\d+\.\d+\.\d+)\.\.\.(?P<to>v\d+\.\d+\.\d+|HEAD)$"
+)
 
 # Lockfiles that embed the package's own version (fix(#877)). A uv.lock records
 # it for every LOCAL package it resolves — the project itself plus any editable
@@ -185,6 +205,66 @@ def _changelog_section(version: str) -> str | None:
     return "\n".join(out) if found else None
 
 
+def _changelog_links() -> dict[str, str]:
+    """Reference-style link definitions (`[label]: url`), keyed by label.
+
+    Returns an empty dict for a CHANGELOG with no link block at all, so a
+    caller doing a plain `.get()` fails with the FAIL messages below instead
+    of a traceback.
+    """
+    return dict(_LINK_DEF_RE.findall(CHANGELOG.read_text()))
+
+
+def _check_changelog_links(canonical: str) -> list[str]:
+    """FAIL messages for the CHANGELOG's reference-style compare links.
+
+    An empty list means both checks passed: a `[<canonical>]:` compare link
+    exists, and `[Unreleased]:` compares from `v<canonical>...HEAD` rather
+    than an older tag. A CHANGELOG with no link block at all (an empty dict
+    from `_changelog_links()`) fails both checks with a plain message here,
+    not a traceback.
+    """
+    links = _changelog_links()
+    failures: list[str] = []
+
+    unreleased_url = links.get("Unreleased")
+    if unreleased_url is None:
+        failures.append(
+            f"{_rel(CHANGELOG)} has no '[Unreleased]:' compare link definition."
+        )
+    else:
+        m = _COMPARE_LINK_RE.match(unreleased_url)
+        if not m or m.group("to") != "HEAD":
+            failures.append(
+                f"{_rel(CHANGELOG)}'s '[Unreleased]:' link is not a "
+                f"'{CHANGELOG_REPO_URL}/compare/vX.Y.Z...HEAD' link. Got: {unreleased_url!r}"
+            )
+        elif m.group("from") != canonical:
+            failures.append(
+                f"{_rel(CHANGELOG)}'s '[Unreleased]:' link compares from "
+                f"v{m.group('from')}, not v{canonical} - it still claims every change "
+                f"since the last release as unreleased. Repoint it to "
+                f"'{CHANGELOG_REPO_URL}/compare/v{canonical}...HEAD'."
+            )
+
+    version_url = links.get(canonical)
+    if version_url is None:
+        failures.append(
+            f"{_rel(CHANGELOG)} has no '[{canonical}]:' compare link definition. "
+            f"Add '[{canonical}]: {CHANGELOG_REPO_URL}/compare/vPREV...v{canonical}' "
+            f"to the link block (run `make bump VERSION={canonical}` to write it)."
+        )
+    else:
+        m = _COMPARE_LINK_RE.match(version_url)
+        if not m or m.group("to") != f"v{canonical}":
+            failures.append(
+                f"{_rel(CHANGELOG)}'s '[{canonical}]:' link does not compare "
+                f"...v{canonical}. Got: {version_url!r}"
+            )
+
+    return failures
+
+
 def main() -> int:
     sites: dict[str, str] = {}
     sites[f"{_rel(BACKEND_PYPROJECT)} ([project].version)"] = _pyproject_version(
@@ -275,6 +355,23 @@ def main() -> int:
         lines = len([ln for ln in body.strip().splitlines() if ln.strip()])
         print(
             f"  [ok] {_rel(CHANGELOG)}: '## [{canonical}]' section present ({lines} lines)."
+        )
+
+    # fix(#1716): the reference-style compare links at the bottom of the file
+    # are not part of the `## [version]` section check above, and nothing else
+    # in CI reads them — a release can land with a correct header and section
+    # while `[Unreleased]` still compares from the previous tag and the new
+    # version has no link at all (v1.17.0, #1714). scripts/bump_version.py
+    # writes both lines mechanically; this asserts they landed.
+    link_failures = _check_changelog_links(canonical)
+    if link_failures:
+        failed = True
+        for msg in link_failures:
+            sys.stderr.write(f"FAIL: {msg}\n")
+    else:
+        print(
+            f"  [ok] {_rel(CHANGELOG)}: '[Unreleased]:' and '[{canonical}]:' "
+            f"compare links agree with {canonical}."
         )
 
     if failed:

--- a/scripts/tests/test-changelog-links.py
+++ b/scripts/tests/test-changelog-links.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+"""Regression test for the CHANGELOG compare-link block (fix(#1716)).
+
+`make bump` used to rewrite every version site except the reference-style
+compare links at the bottom of CHANGELOG.md, and `check_version_coherence.py`
+(the `make version-check` gate) never read them either. A release could ship
+with a correct `## [version]` header and section while `[Unreleased]` still
+compared from the previous tag and the new version had no link at all
+(v1.17.0, #1714). This pins both halves of the fix:
+
+  - scripts/check_version_coherence.py's `_check_changelog_links()`, which
+    `main()` now folds into the gate's pass/fail decision.
+  - scripts/bump_version.py's `_bump_changelog_links()`, which writes both
+    lines mechanically.
+
+Pure stdlib, no repo state: each case builds its own CHANGELOG in a tmpdir.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+import sys
+import tempfile
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+
+
+def _load(name: str, rel_path: str):
+    spec = importlib.util.spec_from_file_location(name, REPO_ROOT / rel_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+cvc = _load("cvc", "scripts/check_version_coherence.py")
+bv = _load("bv", "scripts/bump_version.py")
+
+PASS = FAIL = 0
+
+
+def ok(msg: str) -> None:
+    global PASS
+    PASS += 1
+    print(f"ok {PASS + FAIL} - {msg}")
+
+
+def bad(msg: str) -> None:
+    global FAIL
+    FAIL += 1
+    print(f"not ok {PASS + FAIL} - {msg}")
+
+
+def _write(text: str) -> pathlib.Path:
+    # `_rel()` in both modules does `path.relative_to(REPO_ROOT)` for its
+    # FAIL/print messages, so a tmp CHANGELOG needs REPO_ROOT repointed at its
+    # own tmpdir in both modules, not left at the real repo root.
+    d = pathlib.Path(tempfile.mkdtemp())
+    f = d / "CHANGELOG.md"
+    f.write_text(text)
+    cvc.REPO_ROOT = d
+    bv.REPO_ROOT = d
+    return f
+
+
+REPO = "https://github.com/geolens-io/geolens"
+
+# A realistic tail: two release sections plus their link block, in the exact
+# shape the real CHANGELOG.md uses (no blank lines between consecutive link
+# definitions).
+CORRECT = (
+    "## [Unreleased]\n\n"
+    "## [1.5.0] - 2026-07-26\n\n### Added\n- a thing\n\n"
+    "## [1.4.13]\n- old\n\n"
+    f"[Unreleased]: {REPO}/compare/v1.5.0...HEAD\n"
+    f"[1.5.0]: {REPO}/compare/v1.4.13...v1.5.0\n"
+    f"[1.4.13]: {REPO}/compare/v1.4.12...v1.4.13\n"
+)
+
+MISSING_VERSION_LINK = (
+    "## [Unreleased]\n\n## [1.5.0] - 2026-07-26\n\n### Added\n- a thing\n\n"
+    f"[Unreleased]: {REPO}/compare/v1.5.0...HEAD\n"
+    f"[1.4.13]: {REPO}/compare/v1.4.12...v1.4.13\n"
+)
+
+STALE_UNRELEASED = (
+    "## [Unreleased]\n\n## [1.5.0] - 2026-07-26\n\n### Added\n- a thing\n\n"
+    f"[Unreleased]: {REPO}/compare/v1.4.13...HEAD\n"
+    f"[1.5.0]: {REPO}/compare/v1.4.13...v1.5.0\n"
+    f"[1.4.13]: {REPO}/compare/v1.4.12...v1.4.13\n"
+)
+
+NO_LINK_BLOCK = "## [Unreleased]\n\n## [1.5.0] - 2026-07-26\n\n### Added\n- a thing\n"
+
+# --- 1. correct block passes -------------------------------------------------
+cvc.CHANGELOG = _write(CORRECT)
+failures = cvc._check_changelog_links("1.5.0")
+if failures == []:
+    ok("correct compare-link block reports no failures")
+else:
+    bad(f"correct block reported failures: {failures!r}")
+
+# --- 2. missing [X.Y.Z]: link fails ------------------------------------------
+cvc.CHANGELOG = _write(MISSING_VERSION_LINK)
+failures = cvc._check_changelog_links("1.5.0")
+if any("[1.5.0]:" in f and "no" in f for f in failures):
+    ok("a missing '[1.5.0]:' link definition is reported")
+else:
+    bad(f"missing version link was not reported: {failures!r}")
+if not any("Unreleased" in f for f in failures):
+    ok("the correct '[Unreleased]:' link is not also flagged")
+else:
+    bad(f"a correct '[Unreleased]:' link was wrongly flagged: {failures!r}")
+
+# --- 3. stale [Unreleased] fails ---------------------------------------------
+cvc.CHANGELOG = _write(STALE_UNRELEASED)
+failures = cvc._check_changelog_links("1.5.0")
+if any("Unreleased" in f and "v1.4.13" in f and "v1.5.0" in f for f in failures):
+    ok("an '[Unreleased]:' link still comparing from the previous tag is reported")
+else:
+    bad(f"stale '[Unreleased]:' link was not reported: {failures!r}")
+if len(failures) == 1:
+    ok("the correct '[1.5.0]:' link is not also flagged")
+else:
+    bad(
+        f"expected exactly 1 failure for a stale-Unreleased-only case, got: {failures!r}"
+    )
+
+# --- 4. no link block at all gives a clear error, not a traceback -----------
+cvc.CHANGELOG = _write(NO_LINK_BLOCK)
+try:
+    failures = cvc._check_changelog_links("1.5.0")
+except Exception as exc:  # noqa: BLE001 - the point is that nothing raises here
+    bad(f"a CHANGELOG with no link block raised {exc!r} instead of returning failures")
+else:
+    if len(failures) == 2 and all(isinstance(f, str) and f for f in failures):
+        ok("a CHANGELOG with no link block at all reports two clear failures")
+    else:
+        bad(f"expected 2 plain-string failures for no link block, got: {failures!r}")
+
+# --- 5. bump writes both lines ------------------------------------------------
+before = (
+    "## [Unreleased]\n\n## [1.4.13]\n- old\n\n"
+    f"[Unreleased]: {REPO}/compare/v1.4.13...HEAD\n"
+    f"[1.4.13]: {REPO}/compare/v1.4.12...v1.4.13\n"
+)
+bump_path = _write(before)
+bv._bump_changelog_links(bump_path, "1.5.0")
+after = bump_path.read_text()
+expected_unreleased = f"[Unreleased]: {REPO}/compare/v1.5.0...HEAD"
+expected_version = f"[1.5.0]: {REPO}/compare/v1.4.13...v1.5.0"
+if expected_unreleased in after and expected_version in after:
+    ok("bump writes both the repointed [Unreleased] and the new [1.5.0] link")
+else:
+    bad(f"bump did not write the expected lines. Got:\n{after}")
+if f"{expected_unreleased}\n{expected_version}\n" in after:
+    ok("bump preserves the block's ordering and blank-line shape")
+else:
+    bad(f"bump changed the block's shape. Got:\n{after}")
+if "[1.4.13]: " in after:
+    ok("bump leaves the older [1.4.13] link untouched")
+else:
+    bad(f"bump dropped an unrelated link. Got:\n{after}")
+
+# --- 6. bump is idempotent ----------------------------------------------------
+once = bump_path.read_text()
+bv._bump_changelog_links(bump_path, "1.5.0")
+twice = bump_path.read_text()
+if once == twice:
+    ok("running bump twice for the same version changes nothing further")
+else:
+    bad(
+        f"a second bump for the same version changed the file:\nfirst:\n{once}\nsecond:\n{twice}"
+    )
+if twice.count("[1.5.0]: ") == 1:
+    ok("running bump twice produces no second [1.5.0] link")
+else:
+    bad(f"expected exactly one '[1.5.0]: ' line, got {twice.count('[1.5.0]: ')}")
+
+# --- 7. bump against a CHANGELOG with no link block gives a clear error ------
+no_block_path = _write(NO_LINK_BLOCK)
+try:
+    bv._bump_changelog_links(no_block_path, "1.5.0")
+except SystemExit as exc:
+    if isinstance(exc.code, str) and exc.code.startswith("ERROR:"):
+        ok(
+            "bump against a CHANGELOG with no link block exits with a clear ERROR message"
+        )
+    else:
+        bad(f"bump's error path did not produce a clear message: {exc.code!r}")
+else:
+    bad("bump against a CHANGELOG with no link block did not raise SystemExit")
+
+print(f"1..{PASS + FAIL}")
+print(f"# {PASS} passed, {FAIL} failed")
+sys.exit(1 if FAIL else 0)

--- a/scripts/tests/test-changelog-links.py
+++ b/scripts/tests/test-changelog-links.py
@@ -9,9 +9,19 @@ compared from the previous tag and the new version had no link at all
 (v1.17.0, #1714). This pins both halves of the fix:
 
   - scripts/check_version_coherence.py's `_check_changelog_links()`, which
-    `main()` now folds into the gate's pass/fail decision.
+    `main()` now folds into the gate's pass/fail decision. It validates the
+    `[X.Y.Z]:` link's `from` tag against the version whose `## [...]` section
+    immediately follows `## [X.Y.Z]` in the file, not merely the link's
+    shape - a first pass of this check only checked the `to` tag, which let
+    `compare/vX.Y.Z...vX.Y.Z` (empty comparison) or an arbitrary wrong source
+    pass (review finding on #1765).
   - scripts/bump_version.py's `_bump_changelog_links()`, which writes both
-    lines mechanically.
+    lines mechanically, deriving the previous version the same structural
+    way so the two agree by construction. It repairs whichever half is
+    missing or wrong rather than skipping entirely once `[Unreleased]`
+    already points at the target version - a first pass returned early in
+    that case and left a partial hand-edit unrepaired (review finding on
+    #1765).
 
 Pure stdlib, no repo state: each case builds its own CHANGELOG in a tmpdir.
 """
@@ -67,7 +77,8 @@ REPO = "https://github.com/geolens-io/geolens"
 
 # A realistic tail: two release sections plus their link block, in the exact
 # shape the real CHANGELOG.md uses (no blank lines between consecutive link
-# definitions).
+# definitions). `## [1.4.13]` is a real section heading (not just a link
+# line) so `_changelog_prev_version("1.5.0")` can derive it structurally.
 CORRECT = (
     "## [Unreleased]\n\n"
     "## [1.5.0] - 2026-07-26\n\n### Added\n- a thing\n\n"
@@ -77,20 +88,61 @@ CORRECT = (
     f"[1.4.13]: {REPO}/compare/v1.4.12...v1.4.13\n"
 )
 
+# Same section structure as CORRECT (so PREV still derives to 1.4.13), just
+# missing the `[1.5.0]:` link definition.
 MISSING_VERSION_LINK = (
     "## [Unreleased]\n\n## [1.5.0] - 2026-07-26\n\n### Added\n- a thing\n\n"
+    "## [1.4.13]\n- old\n\n"
     f"[Unreleased]: {REPO}/compare/v1.5.0...HEAD\n"
     f"[1.4.13]: {REPO}/compare/v1.4.12...v1.4.13\n"
 )
 
+# Same section structure as CORRECT, `[Unreleased]` still pointing at the
+# previous tag instead of the canonical one.
 STALE_UNRELEASED = (
     "## [Unreleased]\n\n## [1.5.0] - 2026-07-26\n\n### Added\n- a thing\n\n"
+    "## [1.4.13]\n- old\n\n"
     f"[Unreleased]: {REPO}/compare/v1.4.13...HEAD\n"
     f"[1.5.0]: {REPO}/compare/v1.4.13...v1.5.0\n"
     f"[1.4.13]: {REPO}/compare/v1.4.12...v1.4.13\n"
 )
 
+# Same section structure as CORRECT, `[1.5.0]:` compares from an arbitrary
+# wrong tag instead of the one the CHANGELOG's own section order implies.
+WRONG_SOURCE = (
+    "## [Unreleased]\n\n## [1.5.0] - 2026-07-26\n\n### Added\n- a thing\n\n"
+    "## [1.4.13]\n- old\n\n"
+    f"[Unreleased]: {REPO}/compare/v1.5.0...HEAD\n"
+    f"[1.5.0]: {REPO}/compare/v1.0.0...v1.5.0\n"
+    f"[1.4.13]: {REPO}/compare/v1.4.12...v1.4.13\n"
+)
+
+# The exact bug pattern named in review: an empty self-comparison. Its `to`
+# tag is right, so a check that only validates `to` would pass this.
+EMPTY_COMPARISON = (
+    "## [Unreleased]\n\n## [1.5.0] - 2026-07-26\n\n### Added\n- a thing\n\n"
+    "## [1.4.13]\n- old\n\n"
+    f"[Unreleased]: {REPO}/compare/v1.5.0...HEAD\n"
+    f"[1.5.0]: {REPO}/compare/v1.5.0...v1.5.0\n"
+    f"[1.4.13]: {REPO}/compare/v1.4.12...v1.4.13\n"
+)
+
 NO_LINK_BLOCK = "## [Unreleased]\n\n## [1.5.0] - 2026-07-26\n\n### Added\n- a thing\n"
+
+# The initial release in the file: no preceding `## [...]` section exists to
+# derive a PREV tag from, so the conventional link is `releases/tag/vX.Y.Z`
+# rather than a compare link.
+FIRST_RELEASE_OK = (
+    "## [Unreleased]\n\n## [1.2.0] - 2026-05-01\n\n### Added\n- first\n\n"
+    f"[Unreleased]: {REPO}/compare/v1.2.0...HEAD\n"
+    f"[1.2.0]: {REPO}/releases/tag/v1.2.0\n"
+)
+
+FIRST_RELEASE_BAD = (
+    "## [Unreleased]\n\n## [1.2.0] - 2026-05-01\n\n### Added\n- first\n\n"
+    f"[Unreleased]: {REPO}/compare/v1.2.0...HEAD\n"
+    f"[1.2.0]: {REPO}/compare/v1.0.0...v1.2.0\n"
+)
 
 # --- 1. correct block passes -------------------------------------------------
 cvc.CHANGELOG = _write(CORRECT)
@@ -138,13 +190,60 @@ else:
     else:
         bad(f"expected 2 plain-string failures for no link block, got: {failures!r}")
 
-# --- 5. bump writes both lines ------------------------------------------------
-before = (
-    "## [Unreleased]\n\n## [1.4.13]\n- old\n\n"
+# --- 5. wrong source fails with a message naming both tags ------------------
+cvc.CHANGELOG = _write(WRONG_SOURCE)
+failures = cvc._check_changelog_links("1.5.0")
+if any("1.4.13" in f and "1.5.0" in f for f in failures):
+    ok("a '[1.5.0]:' link comparing from the wrong tag is reported, naming both tags")
+else:
+    bad(f"wrong-source version link was not reported: {failures!r}")
+if len(failures) == 1:
+    ok("the correct '[Unreleased]:' link is not also flagged for the wrong-source case")
+else:
+    bad(f"expected exactly 1 failure for a wrong-source-only case, got: {failures!r}")
+
+# --- 5b. the empty-comparison variant of the same bug also fails ------------
+cvc.CHANGELOG = _write(EMPTY_COMPARISON)
+failures = cvc._check_changelog_links("1.5.0")
+if any("1.4.13" in f and "1.5.0" in f for f in failures):
+    ok("a '[1.5.0]:' link comparing v1.5.0...v1.5.0 (empty range) is reported")
+else:
+    bad(f"empty-comparison version link was not reported: {failures!r}")
+
+# --- 6. correct source passes (explicit, beyond case 1) ---------------------
+cvc.CHANGELOG = _write(CORRECT)
+failures = cvc._check_changelog_links("1.5.0")
+if failures == []:
+    ok("a '[1.5.0]:' link comparing from the structurally-correct tag passes")
+else:
+    bad(f"correct-source block reported failures: {failures!r}")
+
+# --- 7. the first release in the file is accepted or clearly reported -------
+cvc.CHANGELOG = _write(FIRST_RELEASE_OK)
+failures = cvc._check_changelog_links("1.2.0")
+if failures == []:
+    ok("the initial release's 'releases/tag/vX.Y.Z' link passes with no PREV section")
+else:
+    bad(f"initial-release link wrongly reported failures: {failures!r}")
+
+cvc.CHANGELOG = _write(FIRST_RELEASE_BAD)
+failures = cvc._check_changelog_links("1.2.0")
+if any("first" in f.lower() for f in failures):
+    ok("an invalid link on the initial release gives a clear message")
+else:
+    bad(f"invalid initial-release link was not clearly reported: {failures!r}")
+
+# --- 8. bump writes both lines ------------------------------------------------
+# The realistic pre-bump state: the maintainer has already renamed the top
+# section from Unreleased to 1.5.0 (with a fresh empty Unreleased above it),
+# but the link block at the bottom is still the pre-bump one.
+PRE_BUMP = (
+    "## [Unreleased]\n\n## [1.5.0] - 2026-07-26\n\n### Added\n- a thing\n\n"
+    "## [1.4.13]\n- old\n\n"
     f"[Unreleased]: {REPO}/compare/v1.4.13...HEAD\n"
     f"[1.4.13]: {REPO}/compare/v1.4.12...v1.4.13\n"
 )
-bump_path = _write(before)
+bump_path = _write(PRE_BUMP)
 bv._bump_changelog_links(bump_path, "1.5.0")
 after = bump_path.read_text()
 expected_unreleased = f"[Unreleased]: {REPO}/compare/v1.5.0...HEAD"
@@ -162,7 +261,7 @@ if "[1.4.13]: " in after:
 else:
     bad(f"bump dropped an unrelated link. Got:\n{after}")
 
-# --- 6. bump is idempotent ----------------------------------------------------
+# --- 9. bump is idempotent ----------------------------------------------------
 once = bump_path.read_text()
 bv._bump_changelog_links(bump_path, "1.5.0")
 twice = bump_path.read_text()
@@ -177,7 +276,60 @@ if twice.count("[1.5.0]: ") == 1:
 else:
     bad(f"expected exactly one '[1.5.0]: ' line, got {twice.count('[1.5.0]: ')}")
 
-# --- 7. bump against a CHANGELOG with no link block gives a clear error ------
+# --- 10. partial state: [Unreleased] already repointed, [X.Y.Z]: missing ----
+# Review finding: the old idempotency check returned early as soon as
+# [Unreleased] pointed at the target, leaving this state unrepaired.
+partial_missing_path = _write(
+    "## [Unreleased]\n\n## [1.5.0] - 2026-07-26\n\n### Added\n- a thing\n\n"
+    "## [1.4.13]\n- old\n\n"
+    f"[Unreleased]: {REPO}/compare/v1.5.0...HEAD\n"
+    f"[1.4.13]: {REPO}/compare/v1.4.12...v1.4.13\n"
+)
+bv._bump_changelog_links(partial_missing_path, "1.5.0")
+repaired = partial_missing_path.read_text()
+if expected_version in repaired:
+    ok(
+        "bump adds the missing [1.5.0] link even though [Unreleased] already pointed at it"
+    )
+else:
+    bad(f"bump left a missing [1.5.0] link unrepaired. Got:\n{repaired}")
+if repaired.count(f"[Unreleased]: {REPO}/compare/") == 1:
+    ok("bump does not duplicate the [Unreleased] line while repairing")
+else:
+    bad(f"bump duplicated or dropped the [Unreleased] line. Got:\n{repaired}")
+
+# --- 11. partial state: [Unreleased] already repointed, [X.Y.Z]: wrong -----
+partial_wrong_path = _write(
+    "## [Unreleased]\n\n## [1.5.0] - 2026-07-26\n\n### Added\n- a thing\n\n"
+    "## [1.4.13]\n- old\n\n"
+    f"[Unreleased]: {REPO}/compare/v1.5.0...HEAD\n"
+    f"[1.5.0]: {REPO}/compare/v1.0.0...v1.5.0\n"
+    f"[1.4.13]: {REPO}/compare/v1.4.12...v1.4.13\n"
+)
+bv._bump_changelog_links(partial_wrong_path, "1.5.0")
+repaired = partial_wrong_path.read_text()
+if expected_version in repaired and f"{REPO}/compare/v1.0.0...v1.5.0" not in repaired:
+    ok(
+        "bump corrects a wrong [1.5.0] link even though [Unreleased] already pointed at it"
+    )
+else:
+    bad(f"bump left a wrong [1.5.0] link unrepaired. Got:\n{repaired}")
+if repaired.count("[1.5.0]: ") == 1:
+    ok("bump does not duplicate the [1.5.0] line while repairing it")
+else:
+    bad(f"bump duplicated the [1.5.0] line. Got:\n{repaired}")
+
+# --- 12. a true no-op writes nothing -----------------------------------------
+noop_path = _write(CORRECT)
+before_noop = noop_path.read_text()
+bv._bump_changelog_links(noop_path, "1.5.0")
+after_noop = noop_path.read_text()
+if before_noop == after_noop:
+    ok("bump against an already-correct block changes nothing")
+else:
+    bad(f"bump changed an already-correct block. Got:\n{after_noop}")
+
+# --- 13. bump against a CHANGELOG with no link block gives a clear error ----
 no_block_path = _write(NO_LINK_BLOCK)
 try:
     bv._bump_changelog_links(no_block_path, "1.5.0")
@@ -190,6 +342,36 @@ except SystemExit as exc:
         bad(f"bump's error path did not produce a clear message: {exc.code!r}")
 else:
     bad("bump against a CHANGELOG with no link block did not raise SystemExit")
+
+# --- 14. bump against a CHANGELOG with no section for the target version ---
+no_target_header_path = _write(
+    "## [Unreleased]\n\n## [1.4.13]\n- old\n\n"
+    f"[Unreleased]: {REPO}/compare/v1.4.13...HEAD\n"
+    f"[1.4.13]: {REPO}/compare/v1.4.12...v1.4.13\n"
+)
+try:
+    bv._bump_changelog_links(no_target_header_path, "1.5.0")
+except SystemExit as exc:
+    if isinstance(exc.code, str) and exc.code.startswith("ERROR:"):
+        ok("bump against a CHANGELOG with no '## [1.5.0]' section gives a clear error")
+    else:
+        bad(f"bump's missing-section error path was unclear: {exc.code!r}")
+else:
+    bad(
+        "bump against a CHANGELOG with no target-version section did not raise SystemExit"
+    )
+
+# --- 15. the bump writes the source from the same rule the gate checks -----
+# Integration: feed bump's own output back into the gate and confirm it
+# agrees, so the two can't silently drift apart from each other.
+agreement_path = _write(PRE_BUMP)
+bv._bump_changelog_links(agreement_path, "1.5.0")
+cvc.CHANGELOG = agreement_path
+failures = cvc._check_changelog_links("1.5.0")
+if failures == []:
+    ok("check_version_coherence.py accepts exactly what bump_version.py writes")
+else:
+    bad(f"the gate rejected bump's own output: {failures!r}")
 
 print(f"1..{PASS + FAIL}")
 print(f"# {PASS} passed, {FAIL} failed")

--- a/scripts/tests/test-changelog-links.py
+++ b/scripts/tests/test-changelog-links.py
@@ -23,12 +23,29 @@ compared from the previous tag and the new version had no link at all
     that case and left a partial hand-edit unrepaired (review finding on
     #1765).
 
+Two more review rounds on #1765 added:
+
+  - `_changelog_links()` in both scripts now resolves a duplicate reference
+    label (compared case-insensitively, matching CommonMark) to the FIRST
+    definition rather than whichever `dict()` happened to keep last, and a
+    dedicated check fails outright when a duplicate exists at all - a stale
+    first `[Unreleased]:` followed by a correct duplicate used to pass
+    silently while the rendered CHANGELOG still used the stale one.
+    bump_version.py refuses to bump a CHANGELOG with a duplicate label for
+    the same reason.
+  - `bump_version.py`'s `main()` now validates the CHANGELOG edit (via
+    `_validate_changelog_links()`) BEFORE writing any other version site,
+    so a CHANGELOG that can't be safely bumped aborts with nothing touched
+    instead of leaving every other site already bumped while only the
+    CHANGELOG failed, last.
+
 Pure stdlib, no repo state: each case builds its own CHANGELOG in a tmpdir.
 """
 
 from __future__ import annotations
 
 import importlib.util
+import json
 import pathlib
 import sys
 import tempfile
@@ -372,6 +389,291 @@ if failures == []:
     ok("check_version_coherence.py accepts exactly what bump_version.py writes")
 else:
     bad(f"the gate rejected bump's own output: {failures!r}")
+
+# --- 16. duplicate labels: stale first, correct duplicate second -----------
+# The exact bug named in review: a first (stale) [Unreleased] followed by a
+# correct duplicate. A dict()-of-findall keeps the LAST value (correct), so
+# it would wrongly pass; Markdown renders the FIRST (stale) one.
+DUPLICATE_STALE_FIRST = (
+    "## [Unreleased]\n\n## [1.5.0] - 2026-07-26\n\n### Added\n- a thing\n\n"
+    "## [1.4.13]\n- old\n\n"
+    f"[Unreleased]: {REPO}/compare/v1.4.13...HEAD\n"
+    f"[1.5.0]: {REPO}/compare/v1.4.13...v1.5.0\n"
+    f"[Unreleased]: {REPO}/compare/v1.5.0...HEAD\n"
+    f"[1.4.13]: {REPO}/compare/v1.4.12...v1.4.13\n"
+)
+cvc.CHANGELOG = _write(DUPLICATE_STALE_FIRST)
+failures = cvc._check_changelog_links("1.5.0")
+dup_failures = [f for f in failures if "more than once" in f]
+if len(dup_failures) == 1 and "Unreleased" in dup_failures[0]:
+    lines_in_file = DUPLICATE_STALE_FIRST.splitlines()
+    first_line = next(
+        i
+        for i, line in enumerate(lines_in_file, start=1)
+        if line.startswith("[Unreleased]:")
+    )
+    second_line = next(
+        i
+        for i, line in enumerate(lines_in_file, start=1)
+        if line.startswith("[Unreleased]:") and i != first_line
+    )
+    if str(first_line) in dup_failures[0] and str(second_line) in dup_failures[0]:
+        ok("a duplicate '[Unreleased]:' label is reported naming both line numbers")
+    else:
+        bad(
+            f"duplicate message missing line numbers {first_line}/{second_line}: {dup_failures[0]!r}"
+        )
+else:
+    bad(f"duplicate '[Unreleased]:' label was not reported: {failures!r}")
+# The resolved (first, stale) value must also fail the normal staleness
+# check - this is the actual bug: the gate must not silently prefer the
+# correct duplicate over the stale first definition.
+if any("compares from" in f and "v1.4.13" in f for f in failures):
+    ok(
+        "the FIRST (stale) definition is what the staleness check evaluates, not the duplicate"
+    )
+else:
+    bad(f"the gate used the duplicate's value instead of the first one: {failures!r}")
+
+# --- 17. duplicate labels: correct first, stale duplicate second -----------
+# Even when the first (winning) definition is correct, the duplicate itself
+# is still a CHANGELOG bug and must be reported.
+DUPLICATE_CORRECT_FIRST = (
+    "## [Unreleased]\n\n## [1.5.0] - 2026-07-26\n\n### Added\n- a thing\n\n"
+    "## [1.4.13]\n- old\n\n"
+    f"[Unreleased]: {REPO}/compare/v1.5.0...HEAD\n"
+    f"[1.5.0]: {REPO}/compare/v1.4.13...v1.5.0\n"
+    f"[Unreleased]: {REPO}/compare/v1.4.13...HEAD\n"
+    f"[1.4.13]: {REPO}/compare/v1.4.12...v1.4.13\n"
+)
+cvc.CHANGELOG = _write(DUPLICATE_CORRECT_FIRST)
+failures = cvc._check_changelog_links("1.5.0")
+if len(failures) == 1 and "more than once" in failures[0]:
+    ok("a duplicate label is reported even when the winning (first) value is correct")
+else:
+    bad(f"expected exactly 1 duplicate-label failure, got: {failures!r}")
+
+# --- 18. duplicate labels are compared case-insensitively -------------------
+DUPLICATE_CASE_INSENSITIVE = (
+    "## [Unreleased]\n\n## [1.5.0] - 2026-07-26\n\n### Added\n- a thing\n\n"
+    "## [1.4.13]\n- old\n\n"
+    f"[Unreleased]: {REPO}/compare/v1.5.0...HEAD\n"
+    f"[1.5.0]: {REPO}/compare/v1.4.13...v1.5.0\n"
+    f"[UNRELEASED]: {REPO}/compare/v1.5.0...HEAD\n"
+    f"[1.4.13]: {REPO}/compare/v1.4.12...v1.4.13\n"
+)
+cvc.CHANGELOG = _write(DUPLICATE_CASE_INSENSITIVE)
+failures = cvc._check_changelog_links("1.5.0")
+if any("more than once" in f for f in failures):
+    ok("'[Unreleased]:' and '[UNRELEASED]:' are detected as the same duplicated label")
+else:
+    bad(f"a case-only duplicate label was not detected: {failures!r}")
+
+# --- 19. bump refuses to run on a duplicate label ---------------------------
+for name, fixture in (
+    ("stale-first", DUPLICATE_STALE_FIRST),
+    ("correct-first", DUPLICATE_CORRECT_FIRST),
+    ("case-insensitive", DUPLICATE_CASE_INSENSITIVE),
+):
+    dup_path = _write(fixture)
+    try:
+        bv._bump_changelog_links(dup_path, "1.5.0")
+    except SystemExit as exc:
+        if (
+            isinstance(exc.code, str)
+            and exc.code.startswith("ERROR:")
+            and "once" in exc.code
+        ):
+            ok(f"bump refuses to run on a duplicate label ({name})")
+        else:
+            bad(f"bump's duplicate-label error path was unclear ({name}): {exc.code!r}")
+    else:
+        bad(f"bump did not refuse to run on a duplicate label ({name})")
+
+# --- 20. atomicity: a missing CHANGELOG section aborts main() with nothing --
+# --- touched, not just the CHANGELOG (review finding: the CHANGELOG edit
+# --- used to run LAST, after every manifest/lockfile write had already
+# --- happened).
+bv_main_module = bv  # alias for readability below
+
+
+def _write_full_repo_fixture(
+    root: pathlib.Path, version: str
+) -> dict[str, pathlib.Path]:
+    """Minimal, valid content for every non-CHANGELOG site main() rewrites."""
+
+    def write(rel: str, content: str) -> pathlib.Path:
+        p = root / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(content)
+        return p
+
+    paths: dict[str, pathlib.Path] = {}
+    paths["BACKEND_PYPROJECT"] = write(
+        "backend/pyproject.toml", f'[project]\nname = "x"\nversion = "{version}"\n'
+    )
+    paths["MAIN_PY"] = write(
+        "backend/app/api/main.py", f'_FALLBACK_APP_VERSION = "{version}"\n'
+    )
+    paths["OPENAPI_PATH"] = write(
+        "backend/openapi.json", json.dumps({"info": {"version": version}}) + "\n"
+    )
+    paths["FRONTEND_PACKAGE"] = write(
+        "frontend/package.json",
+        json.dumps({"name": "frontend", "version": version}) + "\n",
+    )
+    paths["ROOT_PACKAGE"] = write(
+        "package.json",
+        json.dumps({"name": "root", "version": version, "private": True}) + "\n",
+    )
+    paths["CLI_PYPROJECT"] = write(
+        "cli/pyproject.toml", f'[project]\nname = "cli"\nversion = "{version}"\n'
+    )
+    paths["MCP_PYPROJECT"] = write(
+        "mcp/pyproject.toml", f'[project]\nname = "mcp"\nversion = "{version}"\n'
+    )
+    paths["MCP_SERVER_JSON"] = write(
+        "mcp/server.json",
+        json.dumps(
+            {
+                "version": version,
+                "packages": [{"identifier": "geolens-mcp", "version": version}],
+            }
+        )
+        + "\n",
+    )
+    paths["PY_SDK_PYPROJECT"] = write(
+        "sdks/python/pyproject.toml",
+        f'[project]\nname = "sdk"\nversion = "{version}"\n',
+    )
+    paths["PY_SDK_GEN_CONFIG"] = write(
+        "sdks/python/.openapi-python-client.yaml",
+        f"package_version_override: {version}\n",
+    )
+    paths["TS_SDK_PACKAGE"] = write(
+        "sdks/typescript/package.json",
+        json.dumps({"name": "ts-sdk", "version": version}) + "\n",
+    )
+    paths["DOCS_CONTRACT"] = write(
+        "docs-contract.json",
+        json.dumps({"version": version, "_comment": "x"}, indent=2) + "\n",
+    )
+    paths["BACKEND_UV_LOCK"] = write(
+        "backend/uv.lock",
+        f'[[package]]\nname = "geolens-backend"\nversion = "{version}"\nsource = {{ editable = "." }}\n',
+    )
+    paths["MCP_UV_LOCK"] = write(
+        "mcp/uv.lock",
+        (
+            f'[[package]]\nname = "geolens-mcp"\nversion = "{version}"\n'
+            f'source = {{ editable = "." }}\n\n'
+            f'[[package]]\nname = "geolens"\nversion = "{version}"\n'
+            f'source = {{ editable = "../sdks/python" }}\n'
+        ),
+    )
+    lock_json = (
+        "{\n"
+        '  "name": "x",\n'
+        f'  "version": "{version}",\n'
+        '  "lockfileVersion": 3,\n'
+        '  "packages": {\n'
+        '    "": {\n'
+        '      "name": "x",\n'
+        f'      "version": "{version}"\n'
+        "    }\n"
+        "  }\n"
+        "}\n"
+    )
+    paths["ROOT_PACKAGE_LOCK"] = write("package-lock.json", lock_json)
+    paths["FRONTEND_PACKAGE_LOCK"] = write("frontend/package-lock.json", lock_json)
+    paths["TS_PACKAGE_LOCK"] = write("sdks/typescript/package-lock.json", lock_json)
+    return paths
+
+
+def _patch_bv_sites(root: pathlib.Path, changelog_path: pathlib.Path) -> None:
+    bv_main_module.REPO_ROOT = root
+    bv_main_module.BACKEND_PYPROJECT = root / "backend" / "pyproject.toml"
+    bv_main_module.MAIN_PY = root / "backend" / "app" / "api" / "main.py"
+    bv_main_module.OPENAPI_PATH = root / "backend" / "openapi.json"
+    bv_main_module.FRONTEND_PACKAGE = root / "frontend" / "package.json"
+    bv_main_module.ROOT_PACKAGE = root / "package.json"
+    bv_main_module.CLI_PYPROJECT = root / "cli" / "pyproject.toml"
+    bv_main_module.MCP_PYPROJECT = root / "mcp" / "pyproject.toml"
+    bv_main_module.MCP_SERVER_JSON = root / "mcp" / "server.json"
+    bv_main_module.PY_SDK_PYPROJECT = root / "sdks" / "python" / "pyproject.toml"
+    bv_main_module.PY_SDK_GEN_CONFIG = (
+        root / "sdks" / "python" / ".openapi-python-client.yaml"
+    )
+    bv_main_module.TS_SDK_PACKAGE = root / "sdks" / "typescript" / "package.json"
+    bv_main_module.DOCS_CONTRACT = root / "docs-contract.json"
+    bv_main_module.UV_LOCKS = (
+        (root / "backend" / "uv.lock", ("geolens-backend",)),
+        (root / "mcp" / "uv.lock", ("geolens-mcp", "geolens")),
+    )
+    bv_main_module.PACKAGE_LOCKS = (
+        root / "package-lock.json",
+        root / "frontend" / "package-lock.json",
+        root / "sdks" / "typescript" / "package-lock.json",
+    )
+    bv_main_module.CHANGELOG = changelog_path
+
+
+scratch_root = pathlib.Path(tempfile.mkdtemp())
+scratch_changelog = scratch_root / "CHANGELOG.md"
+# No '## [1.5.0]' section at all - main() must abort before writing anything.
+scratch_changelog.write_text(
+    "## [Unreleased]\n\n## [1.4.13]\n- old\n\n"
+    f"[Unreleased]: {REPO}/compare/v1.4.13...HEAD\n"
+    f"[1.4.13]: {REPO}/compare/v1.4.12...v1.4.13\n"
+)
+fixture_paths = _write_full_repo_fixture(scratch_root, "1.4.13")
+_patch_bv_sites(scratch_root, scratch_changelog)
+
+all_paths = list(fixture_paths.values()) + [scratch_changelog]
+before_snapshot = {p: p.read_bytes() for p in all_paths}
+
+try:
+    bv_main_module.main(["1.5.0"])
+except SystemExit:
+    pass
+else:
+    bad("main() did not abort for a CHANGELOG missing the target version's section")
+
+after_snapshot = {p: p.read_bytes() for p in all_paths}
+if before_snapshot == after_snapshot:
+    ok("a missing CHANGELOG section aborts main() with the scratch tree byte-identical")
+else:
+    changed = [str(p) for p in all_paths if before_snapshot[p] != after_snapshot[p]]
+    bad(f"main() modified sites despite the precondition failure: {changed}")
+
+# Sanity check the fixture itself: a VALID CHANGELOG must let main() succeed
+# and actually rewrite every site, so the byte-identical result above is
+# proof of the abort, not an artifact of a fixture that never gets touched.
+scratch_changelog.write_text(
+    "## [Unreleased]\n\n## [1.5.0] - 2026-07-26\n\n### Added\n- a thing\n\n"
+    "## [1.4.13]\n- old\n\n"
+    f"[Unreleased]: {REPO}/compare/v1.4.13...HEAD\n"
+    f"[1.4.13]: {REPO}/compare/v1.4.12...v1.4.13\n"
+)
+try:
+    rc = bv_main_module.main(["1.5.0"])
+except SystemExit as exc:
+    bad(f"main() raised SystemExit on a valid fixture: {exc.code!r}")
+else:
+    if rc == 0:
+        ok("the same fixture succeeds and returns 0 once the section exists")
+    else:
+        bad(f"main() returned {rc!r} instead of 0 on a valid fixture")
+after_success_snapshot = {p: p.read_bytes() for p in all_paths}
+if all(before_snapshot[p] != after_success_snapshot[p] for p in fixture_paths.values()):
+    ok("a successful run does rewrite every manifest and lockfile site")
+else:
+    unchanged = [
+        str(p)
+        for p in fixture_paths.values()
+        if before_snapshot[p] == after_success_snapshot[p]
+    ]
+    bad(f"a successful run left some sites unchanged: {unchanged}")
 
 print(f"1..{PASS + FAIL}")
 print(f"# {PASS} passed, {FAIL} failed")


### PR DESCRIPTION
## What

Closes #1716. `make bump VERSION=X.Y.Z` now writes the reference-style compare
links at the bottom of CHANGELOG.md, and `scripts/check_version_coherence.py`
(the `make version-check` gate) now verifies them.

Before this, `make bump` rewrote every version site except that link block,
and the gate never read it. A release could ship with a correct `## [version]`
heading and section while `[Unreleased]` still compared from the previous tag
and the new version had no link at all. That happened on v1.17.0 (#1714) and
was only caught by the automated reviewer reading the diff, not by a gate.

## Changes

- `scripts/bump_version.py`: new `_bump_changelog_links()` repoints
  `[Unreleased]` to `compare/vX.Y.Z...HEAD` and inserts a new `[X.Y.Z]:` link
  comparing from the previous version. The previous version is read back from
  the existing `[Unreleased]` line rather than tracked separately. Idempotent:
  running the bump twice for the same version writes nothing further.
- `scripts/check_version_coherence.py`: new `_check_changelog_links()` asserts
  a `[X.Y.Z]:` compare link exists for the canonical version and that
  `[Unreleased]` compares from `vX.Y.Z...HEAD`. Failure messages name the
  missing or stale line. A CHANGELOG with no link block at all fails with a
  plain message rather than a traceback. `main()` folds this into the
  existing pass/fail decision, so `make version-check` fails on either defect.
- `scripts/tests/test-changelog-links.py`: new test covering both halves
  (correct block passes, missing link fails, stale `[Unreleased]` fails, bump
  writes both lines, bump is idempotent, no link block gives a clear error).
  Wired into the `Version Coherence` CI job alongside the existing
  `test-changelog-gate.py`.

## Schema/API/config impact

None. Pure-stdlib script changes and a CI step addition.

## Verification

- `python3 scripts/tests/test-changelog-links.py` — 12 passed, 0 failed
- `python3 scripts/tests/test-changelog-gate.py` — 25 passed, 0 failed (unaffected by this change)
- `make version-check` — passes on the current tree; the live CHANGELOG's link
  block was already correct so no separate fix was needed there
- A dry run of `_bump_changelog_links` against a scratch copy of CHANGELOG.md
  (never `make bump` for real) confirmed the expected before/after: it
  repoints `[Unreleased]` to `compare/v1.18.0...HEAD` and inserts
  `[1.18.0]: compare/v1.17.0...v1.18.0`, and a second run for the same version
  changes nothing further.
- `cd backend && uv run ruff check` / `ruff format --check` against the
  touched files: no new issues introduced. One pre-existing `ruff format`
  finding in `bump_version.py` (an f-string with no placeholder on an
  unrelated line) predates this change and is left alone.

## Left alone

`ruff format --check` already fails on `scripts/bump_version.py` and
`scripts/check_version_coherence.py` on unmodified `main` (a handful of long
`sys.exit(...)` lines and one f-string without a placeholder). Confirmed via
`git show HEAD:<file>` before editing. Out of scope for this fix; not touched.
