### PR TITLE
fix(tests): container-aware repo root and docker-CLI skips

### DIFF
--- a/backend/tests/test_fe_sdk_type_drift.py
+++ b/backend/tests/test_fe_sdk_type_drift.py
@@ -29,15 +29,16 @@ from __future__ import annotations
 
 import json
 import re
-from pathlib import Path
 
 import pytest
+
+from tests.repo_paths import repo_root
 
 # ---------------------------------------------------------------------------
 # Shared helpers (mirrored from check_fe_type_drift to avoid circular deps)
 # ---------------------------------------------------------------------------
 
-_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+_REPO_ROOT = repo_root(__file__)
 _OPENAPI_JSON = _REPO_ROOT / "backend" / "openapi.json"
 _FE_TYPES = _REPO_ROOT / "frontend" / "src" / "types" / "api.ts"
 

--- a/backend/tests/test_openapi_property_order.py
+++ b/backend/tests/test_openapi_property_order.py
@@ -16,9 +16,10 @@ from pathlib import Path
 
 from app.api.main import app
 from app.modules.catalog.datasets.domain.schemas import AnalysisPreviewRequest
+from tests.repo_paths import repo_root
 
-BACKEND_ROOT = Path(__file__).resolve().parent.parent
-REPO_ROOT = BACKEND_ROOT.parent
+REPO_ROOT = repo_root(__file__)
+BACKEND_ROOT = REPO_ROOT / "backend"
 
 
 def _load_by_path(module_name: str, path: Path):

--- a/backend/tests/test_runtime_db_role.py
+++ b/backend/tests/test_runtime_db_role.py
@@ -3,6 +3,7 @@
 from pathlib import Path
 import json
 import os
+import shutil
 import subprocess
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock
@@ -16,6 +17,11 @@ from tests.repo_paths import repo_root
 ROOT = repo_root(__file__)
 ROLE_SCRIPT = ROOT / "scripts" / "lib" / "configure-runtime-db-role.sh"
 ROUNDTRIP_SCRIPT = ROOT / "scripts" / "tests" / "test-backup-restore-roundtrip.sh"
+
+requires_docker_cli = pytest.mark.skipif(
+    shutil.which("docker") is None,
+    reason="docker CLI is not installed in this image (fix(#1745))",
+)
 
 
 def _compose(filename: str) -> dict:
@@ -123,6 +129,7 @@ def test_compose_mounts_reconciler_read_only_and_scopes_the_password_to_db() -> 
             )
 
 
+@requires_docker_cli
 def test_compose_scopes_managed_migrator_role_away_from_local_db() -> None:
     for filename in ("docker-compose.yml", "docker-compose.prod.yml"):
         services = _render_compose(
@@ -155,6 +162,7 @@ def test_compose_scopes_managed_migrator_role_away_from_local_db() -> None:
         )
 
 
+@requires_docker_cli
 def test_compose_infers_bundled_migrator_role_only_for_migrate() -> None:
     for filename in ("docker-compose.yml", "docker-compose.prod.yml"):
         services = _render_compose(
@@ -175,6 +183,7 @@ def test_compose_infers_bundled_migrator_role_only_for_migrate() -> None:
         )
 
 
+@requires_docker_cli
 def test_compose_passes_explicit_bundled_migration_owner_to_local_db() -> None:
     for filename in ("docker-compose.yml", "docker-compose.prod.yml"):
         services = _render_compose(

--- a/backend/tests/test_tenant_ownership_adoption.py
+++ b/backend/tests/test_tenant_ownership_adoption.py
@@ -28,7 +28,6 @@ from __future__ import annotations
 
 import uuid
 from contextlib import asynccontextmanager
-from pathlib import Path
 
 import pytest
 import sqlalchemy as sa
@@ -65,10 +64,11 @@ from app.core.db.tenant_adoption_sql import (
     TILE,
 )
 from app.core.db.tenant_adoption_sql import WRITER as WRITER_GATEWAY
+from tests.repo_paths import repo_root
 
 pytestmark = pytest.mark.anyio
 
-ROOT = Path(__file__).resolve().parents[2]
+ROOT = repo_root(__file__)
 
 
 def _new_tenant() -> tuple[str, str, str, str]:


### PR DESCRIPTION
## What changed

Two of the three test-side residuals left open by #1762 (comment on #1745 after that PR merged).

1. `backend/tests/test_openapi_property_order.py`, `backend/tests/test_tenant_ownership_adoption.py` and `backend/tests/test_fe_sdk_type_drift.py` computed the repository root with a hardcoded parent-directory count (`Path(__file__).resolve().parent.parent` / `.parents[2]` / `.parent.parent.parent`). That assumes the host's nesting, two directories between the test file and the repo root. Inside the api container, `backend/tests` is bind-mounted directly at `/app/tests`, one directory below `/app`, so the same hop count overshoots to the filesystem root. Switched all three to the container-aware `repo_root()` helper from `tests/repo_paths.py` that five sibling test files already use.

2. `backend/tests/test_runtime_db_role.py` shells out to the `docker` CLI in three tests (`test_compose_scopes_managed_migrator_role_away_from_local_db`, `test_compose_infers_bundled_migrator_role_only_for_migrate`, `test_compose_passes_explicit_bundled_migration_owner_to_local_db`) to render `docker compose config` with overrides. The `geolens-api` image has no `docker` binary, so these always failed with `FileNotFoundError` in-container. Added a `shutil.which("docker") is None` skipif so they skip only where the binary is missing and still run on the host and in CI.

Left `test_url_import_1705.py`'s chmod-as-root case alone; the issue calls that out as a separate decision. The docker-CLI-in-image question (install it vs. keep skipping) stays open on #1745.

## Verification

Host, after `make env-test` in the worktree:

```
cd backend && set -a && source ../.env.test && set +a && uv run pytest -q \
  tests/test_openapi_property_order.py tests/test_tenant_ownership_adoption.py \
  tests/test_fe_sdk_type_drift.py tests/test_runtime_db_role.py
```

115 passed, 0 failed, 0 skipped (docker CLI is present on the host, so the three skipif-guarded tests run normally there).

Also reran the pre-fix files against the same host environment for comparison; they already pass on the host, since the bug is container-only (the hardcoded parent count happens to be correct for the host's nesting).

Container, throwaway, joining the live stack's `geolens_default` network with the `geolens-api:latest` image and the same volume list `docker-compose.yml`'s `api` service uses (per the recipe in #1762's PR body), bind-mounted from this worktree instead of the main checkout:

```
docker run --rm --user 0:0 --network geolens_default --env-file <dump of `docker exec geolens-api-1 env`> \
  -e UV_CACHE_DIR=/app/staging/uv-cache -e UV_PROJECT_ENVIRONMENT=/app/staging/geolens-api-test-venv \
  -e PROMETHEUS_MULTIPROC_DIR=/app/staging/prometheus-multiproc \
  <api service's full volume list, sourced from the worktree> \
  --entrypoint uv geolens-api:latest run pytest --continue-on-collection-errors -q \
  tests/test_openapi_property_order.py tests/test_tenant_ownership_adoption.py \
  tests/test_fe_sdk_type_drift.py tests/test_runtime_db_role.py
```

Before (pre-fix test files bind-mounted over the fixed tree, matching what #1745 reported): 5 failed, 101 passed, 7 errors.
After (this branch): 0 failed, 112 passed, 3 skipped, 0 errors.

The 3 skipped are the docker-CLI tests, correctly skipped only in the container where the binary is absent; they passed as part of the 115 on the host. No `docker compose up`, `restart`, or `--force-recreate` was run against the running `geolens` project; the throwaway container only joined its network read-only-mount-wise (aside from its own scratch `/app/staging`).

Ruff on the changed files: `uv run ruff check` and `uv run ruff format --check` both pass.

## Schema/API/config impact

None. Test-only change, no app code, no compose, no Dockerfile.
