### PR TITLE
fix(settings): password-manager attributes and unauthorized copy (#1755 items 5, 6)

### DIFF
--- a/frontend/src/components/admin/settings/SettingsAuthTab.tsx
+++ b/frontend/src/components/admin/settings/SettingsAuthTab.tsx
@@ -557,6 +557,12 @@ function OAuthProvidersSection({ envOnly }: { envOnly: boolean }) {
                 onChange={(e) => setForm((prev) => ({ ...prev, client_secret: e.target.value }))}
                 placeholder={editingProvider ? '********' : ''}
                 disabled={envOnly}
+                // fix(#1755): admin secret, not a login credential, so opt out
+                // of every password manager explicitly.
+                autoComplete="new-password"
+                data-1p-ignore
+                data-lpignore="true"
+                data-bwignore
               />
             </div>
 

--- a/frontend/src/components/admin/settings/SettingsMapTab.tsx
+++ b/frontend/src/components/admin/settings/SettingsMapTab.tsx
@@ -265,6 +265,12 @@ export function SettingsMapTab({ settings, envOnly, onSave, onReset, isSaving, s
                     className="h-7 text-xs max-w-xs"
                     placeholder={basemap.api_key ? '••••••••' : t('settings.basemaps.apiKeyPlaceholder', 'Enter API key')}
                     defaultValue={basemap.api_key ?? ''}
+                    // fix(#1755): admin secret, not a login credential, so opt
+                    // out of every password manager explicitly.
+                    autoComplete="new-password"
+                    data-1p-ignore
+                    data-lpignore="true"
+                    data-bwignore
                     onBlur={(e) => {
                       const val = e.target.value.trim();
                       if (val !== (basemap.api_key ?? '')) {
@@ -321,6 +327,12 @@ export function SettingsMapTab({ settings, envOnly, onSave, onReset, isSaving, s
                   placeholder={t('settings.basemaps.apiKeyPlaceholder', 'Optional — required if URL contains {api_key}')}
                   value={newApiKey}
                   onChange={(e) => setNewApiKey(e.target.value)}
+                  // fix(#1755): admin secret, not a login credential, so opt
+                  // out of every password manager explicitly.
+                  autoComplete="new-password"
+                  data-1p-ignore
+                  data-lpignore="true"
+                  data-bwignore
                 />
                 <p className="text-xs text-muted-foreground">{t('settings.basemaps.apiKeyHelp', 'Use {api_key} in the tile URL as a placeholder. The key is interpolated server-side.')}</p>
               </div>

--- a/frontend/src/components/admin/settings/__tests__/SettingsAuthTab.test.tsx
+++ b/frontend/src/components/admin/settings/__tests__/SettingsAuthTab.test.tsx
@@ -385,4 +385,23 @@ describe('SettingsAuthTab', () => {
       expectBothProviderCaches(invalidateQueries);
     });
   });
+
+  // fix(#1755): the OAuth client secret is an admin secret, not a login
+  // credential -- it needs the same password-manager opt-out attributes the
+  // service-token inputs gained in #1750.
+  describe('Client Secret field opts out of password managers', () => {
+    it('opts out the client secret field', async () => {
+      const user = userEvent.setup();
+      renderTab();
+
+      await user.click(screen.getByRole('button', { name: /add provider/i }));
+      const secretInput = await screen.findByLabelText('Client Secret');
+
+      expect(secretInput).toHaveAttribute('type', 'password');
+      expect(secretInput).toHaveAttribute('autocomplete', 'new-password');
+      expect(secretInput).toHaveAttribute('data-1p-ignore');
+      expect(secretInput).toHaveAttribute('data-lpignore', 'true');
+      expect(secretInput).toHaveAttribute('data-bwignore');
+    });
+  });
 });

--- a/frontend/src/components/admin/settings/__tests__/SettingsMapTab.test.tsx
+++ b/frontend/src/components/admin/settings/__tests__/SettingsMapTab.test.tsx
@@ -2,7 +2,7 @@ import { render, screen } from '@/test/test-utils';
 import userEvent from '@testing-library/user-event';
 import { PMTiles } from 'pmtiles';
 import { SettingsMapTab } from '../SettingsMapTab';
-import type { SettingItem } from '@/api/settings';
+import type { BasemapEntry, SettingItem } from '@/api/settings';
 
 /**
  * feat(pmtiles): `isValidTileUrl` in SettingsMapTab.tsx is the client-side
@@ -147,5 +147,47 @@ describe('SettingsMapTab custom basemap URL validation', () => {
 
     expect(screen.getByText('https://tiles.example.com/{z}/{x}/{y}.png')).toBeInTheDocument();
     expect(screen.queryByText(/must contain/i)).not.toBeInTheDocument();
+  });
+});
+
+// fix(#1755): the basemap API key fields are admin secrets, not login
+// credentials -- they need the same password-manager opt-out attributes the
+// service-token inputs gained in #1750.
+describe('SettingsMapTab API key fields opt out of password managers', () => {
+  function expectOptedOut(input: HTMLElement) {
+    expect(input).toHaveAttribute('autocomplete', 'new-password');
+    expect(input).toHaveAttribute('data-1p-ignore');
+    expect(input).toHaveAttribute('data-lpignore', 'true');
+    expect(input).toHaveAttribute('data-bwignore');
+  }
+
+  it('opts out the new-basemap API key field', () => {
+    renderMapTab();
+    expectOptedOut(screen.getByLabelText(/api key/i));
+  });
+
+  it('opts out the API key field on an existing custom basemap', () => {
+    const existingBasemap: BasemapEntry = {
+      id: 'custom-1',
+      label: 'Authenticated Basemap',
+      url: 'https://example.com/{api_key}/{z}/{x}/{y}.png',
+      enabled: true,
+      is_preset: false,
+      api_key: 'existing-secret',
+    };
+    const settings: SettingItem[] = [
+      { key: 'basemaps', value: [existingBasemap], source: 'overridden', label: 'basemaps' },
+    ];
+    render(
+      <SettingsMapTab
+        settings={settings}
+        envOnly={false}
+        onSave={vi.fn()}
+        onReset={vi.fn()}
+        isSaving={false}
+      />,
+    );
+
+    expectOptedOut(screen.getByPlaceholderText('••••••••'));
   });
 });

--- a/frontend/src/components/dataset/__tests__/SourcePanel.test.tsx
+++ b/frontend/src/components/dataset/__tests__/SourcePanel.test.tsx
@@ -461,7 +461,7 @@ describe('SourcePanel', () => {
     expect(screen.getByText('https://origin.test/FeatureServer')).toBeInTheDocument();
     expect(
       screen.getByText(
-        'The source refused the request because it requires credentials the dataset does not carry. Refresh with credentials to continue.',
+        'The source refused the request because it requires credentials this dataset does not carry.',
       ),
     ).toBeInTheDocument();
     expect(screen.getByText('Drift detected')).toBeInTheDocument();
@@ -492,7 +492,7 @@ describe('SourcePanel', () => {
     // service token: it covers any 401/403 from a general origin.
     expect(
       screen.queryByText(
-        'The source refused the request because it requires credentials the dataset does not carry. Refresh with credentials to continue.',
+        'The source refused the request because it requires credentials this dataset does not carry.',
       ),
     ).not.toBeInTheDocument();
   });

--- a/frontend/src/components/dataset/__tests__/SourcePanel.test.tsx
+++ b/frontend/src/components/dataset/__tests__/SourcePanel.test.tsx
@@ -459,7 +459,11 @@ describe('SourcePanel', () => {
     expect(screen.getByText('Owned copy')).toBeInTheDocument();
     expect(screen.getByText('arcgis_featureserver')).toBeInTheDocument();
     expect(screen.getByText('https://origin.test/FeatureServer')).toBeInTheDocument();
-    expect(screen.getByText('The source now requires access GeoLens does not have.')).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'The source refused the request because it requires credentials the dataset does not carry. Refresh with credentials to continue.',
+      ),
+    ).toBeInTheDocument();
     expect(screen.getByText('Drift detected')).toBeInTheDocument();
     expect(screen.getByText('Overdue')).toBeInTheDocument();
     expect(container.innerHTML).not.toContain('password');
@@ -484,8 +488,13 @@ describe('SourcePanel', () => {
     );
 
     expect(screen.getByText('The source requires a service token GeoLens does not have.')).toBeInTheDocument();
-    // Distinct from 'unauthorized', whose copy claims the source CHANGED.
-    expect(screen.queryByText('The source now requires access GeoLens does not have.')).not.toBeInTheDocument();
+    // Distinct from 'unauthorized', which is deliberately not specific to a
+    // service token: it covers any 401/403 from a general origin.
+    expect(
+      screen.queryByText(
+        'The source refused the request because it requires credentials the dataset does not carry. Refresh with credentials to continue.',
+      ),
+    ).not.toBeInTheDocument();
   });
 
   it('suppresses an origin_ref whose discriminator does not match the dataset origin', () => {

--- a/frontend/src/i18n/locales/de/dataset.json
+++ b/frontend/src/i18n/locales/de/dataset.json
@@ -803,7 +803,7 @@
     "healthDetail": {
       "not_found": "Die Quellressource wurde nicht gefunden.",
       "item_withdrawn": "Das STAC-Element wurde zurückgezogen.",
-      "unauthorized": "Die Quelle hat die Anfrage abgelehnt, weil sie Anmeldedaten erfordert, die der Datensatz nicht besitzt. Aktualisieren Sie mit Anmeldedaten, um fortzufahren.",
+      "unauthorized": "Die Quelle hat die Anfrage abgelehnt, weil sie Anmeldedaten erfordert, die dieser Datensatz nicht besitzt.",
       "server_error": "Die Quelle hat einen Serverfehler zurückgegeben.",
       "unexpected_status": "Die Quelle hat eine unerwartete Antwort zurückgegeben.",
       "timeout": "Die Quelle hat nicht rechtzeitig geantwortet.",

--- a/frontend/src/i18n/locales/de/dataset.json
+++ b/frontend/src/i18n/locales/de/dataset.json
@@ -803,7 +803,7 @@
     "healthDetail": {
       "not_found": "Die Quellressource wurde nicht gefunden.",
       "item_withdrawn": "Das STAC-Element wurde zurückgezogen.",
-      "unauthorized": "Die Quelle erfordert nun einen Zugriff, den GeoLens nicht besitzt.",
+      "unauthorized": "Die Quelle hat die Anfrage abgelehnt, weil sie Anmeldedaten erfordert, die der Datensatz nicht besitzt. Aktualisieren Sie mit Anmeldedaten, um fortzufahren.",
       "server_error": "Die Quelle hat einen Serverfehler zurückgegeben.",
       "unexpected_status": "Die Quelle hat eine unerwartete Antwort zurückgegeben.",
       "timeout": "Die Quelle hat nicht rechtzeitig geantwortet.",

--- a/frontend/src/i18n/locales/en/dataset.json
+++ b/frontend/src/i18n/locales/en/dataset.json
@@ -754,7 +754,7 @@
     "healthDetail": {
       "not_found": "The source resource was not found.",
       "item_withdrawn": "The STAC item was withdrawn.",
-      "unauthorized": "The source now requires access GeoLens does not have.",
+      "unauthorized": "The source refused the request because it requires credentials the dataset does not carry. Refresh with credentials to continue.",
       "server_error": "The source returned a server error.",
       "unexpected_status": "The source returned an unexpected response.",
       "timeout": "The source did not respond in time.",

--- a/frontend/src/i18n/locales/en/dataset.json
+++ b/frontend/src/i18n/locales/en/dataset.json
@@ -754,7 +754,7 @@
     "healthDetail": {
       "not_found": "The source resource was not found.",
       "item_withdrawn": "The STAC item was withdrawn.",
-      "unauthorized": "The source refused the request because it requires credentials the dataset does not carry. Refresh with credentials to continue.",
+      "unauthorized": "The source refused the request because it requires credentials this dataset does not carry.",
       "server_error": "The source returned a server error.",
       "unexpected_status": "The source returned an unexpected response.",
       "timeout": "The source did not respond in time.",

--- a/frontend/src/i18n/locales/es/dataset.json
+++ b/frontend/src/i18n/locales/es/dataset.json
@@ -803,7 +803,7 @@
     "healthDetail": {
       "not_found": "No se encontró el recurso de origen.",
       "item_withdrawn": "El elemento STAC fue retirado.",
-      "unauthorized": "La fuente rechazó la solicitud porque requiere credenciales que el conjunto de datos no tiene. Actualiza con credenciales para continuar.",
+      "unauthorized": "La fuente rechazó la solicitud porque requiere credenciales que este conjunto de datos no tiene.",
       "server_error": "La fuente devolvió un error del servidor.",
       "unexpected_status": "La fuente devolvió una respuesta inesperada.",
       "timeout": "La fuente no respondió a tiempo.",

--- a/frontend/src/i18n/locales/es/dataset.json
+++ b/frontend/src/i18n/locales/es/dataset.json
@@ -803,7 +803,7 @@
     "healthDetail": {
       "not_found": "No se encontró el recurso de origen.",
       "item_withdrawn": "El elemento STAC fue retirado.",
-      "unauthorized": "La fuente requiere ahora un acceso que GeoLens no tiene.",
+      "unauthorized": "La fuente rechazó la solicitud porque requiere credenciales que el conjunto de datos no tiene. Actualiza con credenciales para continuar.",
       "server_error": "La fuente devolvió un error del servidor.",
       "unexpected_status": "La fuente devolvió una respuesta inesperada.",
       "timeout": "La fuente no respondió a tiempo.",

--- a/frontend/src/i18n/locales/fr/dataset.json
+++ b/frontend/src/i18n/locales/fr/dataset.json
@@ -803,7 +803,7 @@
     "healthDetail": {
       "not_found": "La ressource source est introuvable.",
       "item_withdrawn": "L’élément STAC a été retiré.",
-      "unauthorized": "La source a refusé la requête car elle exige des identifiants que le jeu de données ne possède pas. Actualisez avec des identifiants pour continuer.",
+      "unauthorized": "La source a refusé la requête car elle exige des identifiants que ce jeu de données ne possède pas.",
       "server_error": "La source a renvoyé une erreur serveur.",
       "unexpected_status": "La source a renvoyé une réponse inattendue.",
       "timeout": "La source n’a pas répondu à temps.",

--- a/frontend/src/i18n/locales/fr/dataset.json
+++ b/frontend/src/i18n/locales/fr/dataset.json
@@ -803,7 +803,7 @@
     "healthDetail": {
       "not_found": "La ressource source est introuvable.",
       "item_withdrawn": "L’élément STAC a été retiré.",
-      "unauthorized": "La source exige désormais un accès dont GeoLens ne dispose pas.",
+      "unauthorized": "La source a refusé la requête car elle exige des identifiants que le jeu de données ne possède pas. Actualisez avec des identifiants pour continuer.",
       "server_error": "La source a renvoyé une erreur serveur.",
       "unexpected_status": "La source a renvoyé une réponse inattendue.",
       "timeout": "La source n’a pas répondu à temps.",


### PR DESCRIPTION
Addresses items 5 and 6 from #1755.

Item 5: SettingsMapTab's basemap API key inputs (the per-row edit field and the new-basemap field) and SettingsAuthTab's OAuth client secret input are `type="password"` fields for admin secrets, but did not have the autocomplete and password-manager opt-out attributes the service-token inputs gained in #1750. All three now carry `autoComplete="new-password"` plus `data-1p-ignore`, `data-lpignore="true"`, and `data-bwignore`, matching the exact set from #1750.

Item 6: the `unauthorized` source-health detail copy said the source "now requires access", which misdescribes a service that was always private (the common case for a general 401/403, distinct from the ArcGIS-specific `auth_required` code added in #1754). Rewritten in all four locales to state the refusal without implying a change: the source refused the request because it requires credentials the dataset does not carry, and to refresh with credentials to continue.

No schema, API, or config impact. Frontend only.

Verification, from `frontend/`:
- `npm run typecheck` - passed
- `npm run lint` - passed
- `npm run test:i18n` - passed (4 tests)
- `npx vitest run src/components/admin/settings/__tests__/SettingsMapTab.test.tsx src/components/admin/settings/__tests__/SettingsAuthTab.test.tsx src/components/dataset/__tests__/SourcePanel.test.tsx` - passed (45 tests)

Left alone: `backend/app/modules/catalog/sources/origin_probe.py` has a comment above `AUTH_REQUIRED` referencing the old `unauthorized` copy ("whose shipped copy says the source 'now requires' access"). That comment is now slightly stale since the copy changed, but it's backend and out of this lane's scope.
