### PR TITLE
chore(search): sunset the two pre-#1666 search compatibility forms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and releases use semantic versioning.
 
 ## [Unreleased]
 
+### Removed
+
+- **Two undocumented search compatibility forms are gone.** `?cql2_filter_lang=...`
+  (an alternate spelling of the published `filter-lang` parameter) and a JSON
+  `keywords` request body on `GET /search/datasets/` were kept working after
+  #1666 corrected the published OpenAPI contract, so a client generated from
+  the older contract would not silently break. Both were accepted but never
+  published, and the deprecation window has passed since #1666 shipped in
+  1.16.0. A client generated from a pre-1.16.0 contract must regenerate
+  against the current one. (#1671)
+
 ## [1.17.0] - 2026-08-30
 
 ### Added

--- a/backend/app/modules/catalog/search/router.py
+++ b/backend/app/modules/catalog/search/router.py
@@ -415,69 +415,29 @@ search_router = APIRouter(prefix="/search", tags=["Search"])
 _SUPPORTED_FILTER_LANGS = ("cql2-text", "cql2-json")
 
 
-_LEGACY_FILTER_LANG_PARAM = "cql2_filter_lang"
-
-
-async def _legacy_keywords_body(request: Request) -> list[str] | None:
-    """Read ``keywords`` from a JSON request body on a GET, for older clients.
-
-    compat(#1666 codex P2): the pre-fix contract declared ``keywords`` as an
-    ``application/json`` request BODY on a GET, so that is what SDKs generated
-    before this change send — the Python client's parameter was literally named
-    ``body``. Under the old ``Depends()`` binding FastAPI consumed it, and the
-    query-string form worked only because the handler read it separately. The
-    corrected query-parameter binding reads the opposite one, so an unchanged
-    client would silently receive UNFILTERED results, which is a worse failure
-    than an error.
-
-    Deliberately not republished: a request body on a GET is the defect being
-    fixed, is not reliably forwarded by proxies and CDNs, and should be sunset.
-    This honours what old clients send without offering it to new ones.
-
-    Anything that is not a JSON array of strings is ignored rather than
-    rejected. This runs on a normal search request, and the only job here is to
-    recognise the one shape the old generator emitted.
-    """
-    if not request.headers.get("content-type", "").startswith("application/json"):
-        return None
-    try:
-        body = await request.json()
-    except Exception:  # broad: any unreadable/!JSON body simply is not the legacy shape
-        return None
-    if isinstance(body, list) and body and all(isinstance(v, str) for v in body):
-        return body
-    return None
-
-
 def _resolve_filter_lang(
     params: SearchQueryParams, request: Request
 ) -> SearchQueryParams:
     """Resolve and validate ``filter-lang``, shared by both search handlers.
 
-    Reads the wire rather than the bound value, because the two handlers bind
-    this model differently and neither binding sees both accepted spellings.
+    Always reads the wire, never ``params.cql2_filter_lang``. Both routes need
+    that: ``collection_items`` binds ``params`` via a bare ``Depends()``, under
+    which pydantic's synthesized ``__init__`` cannot bind the hyphenated alias
+    ``filter-lang`` at all, so that route's ``params.cql2_filter_lang`` field
+    falls back to binding its own Python name instead -- meaning it still
+    reads a raw ``?cql2_filter_lang=...`` query parameter, the sunset spelling
+    #1671 removes (see the comment at that call site). Trusting the bound
+    field here would leave that spelling alive on this one route.
 
-    compat(#1666 codex P2): ``cql2_filter_lang`` is still honoured. It is the
-    field's Python name, and the pre-fix contract published it — so it is what
-    every SDK generated before this change sends, and under the old
-    ``Depends()`` binding it was the only spelling that actually bound. Ignoring
-    it now would leave an older client's ``cql2-json`` filter silently parsed as
-    ``cql2-text``: a wrong grammar or a rejected request, from a caller that
-    changed nothing. ``filter-lang`` wins when both are present, and only the
-    correct spelling is published.
-
-    The field stays a bare ``str`` deliberately — tightening it to a ``Literal``
-    would route the refusal through ``RequestValidationError``, which answers
-    422 on ``/search/datasets/``, and both handlers contract to 400 here.
+    The field stays a bare ``str`` deliberately: tightening it to a
+    ``Literal`` would route the refusal through ``RequestValidationError``,
+    which answers 422 on ``/search/datasets/``, and both handlers contract to
+    400 here.
 
     An explicitly empty ``?filter-lang=`` keeps its long-standing treatment as
-    "not supplied" rather than becoming a newly-rejected request; the raw read
-    this replaced skipped its check on any falsy value.
+    "not supplied" rather than becoming a newly-rejected request.
     """
-    supplied = request.query_params.get("filter-lang") or request.query_params.get(
-        _LEGACY_FILTER_LANG_PARAM
-    )
-    lang = supplied or params.cql2_filter_lang or "cql2-text"
+    lang = request.query_params.get("filter-lang") or "cql2-text"
     if lang not in _SUPPORTED_FILTER_LANGS:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
@@ -602,10 +562,6 @@ async def search_datasets_endpoint(
 ) -> OGCFeatureCollectionResponse:
     """Search datasets with text, spatial, and faceted filters."""
     params = _resolve_filter_lang(params, request)
-    if not params.keywords:
-        legacy_keywords = await _legacy_keywords_body(request)
-        if legacy_keywords:
-            params = params.model_copy(update={"keywords": legacy_keywords})
     result = await _handle_search(db, user, request, params)
     for name, value in standard_response_headers(
         list(result.links or []),
@@ -1212,13 +1168,10 @@ async def collection_items(
     # work on this route. (`filter` binds fine; its alias is a valid identifier.)
     raw_keywords = request.query_params.getlist("keywords")
     if raw_keywords:
-        # The PUBLISHED form wins. This route still binds the legacy GET body
-        # natively — it keeps `Depends()`, so FastAPI continues to populate
-        # `params.keywords` from it — and this used to be conditional on that
-        # being empty, which let the deprecated body override the query
-        # parameter. `_legacy_keywords_body` is therefore not needed here: the
-        # native binding already provides the compatibility the other route
-        # needs the shim for.
+        # The PUBLISHED form wins. This route still binds `Depends()`, so
+        # FastAPI continues to populate `params.keywords` from a GET body when
+        # one is sent; the query string form takes precedence when both are
+        # present.
         overrides["keywords"] = raw_keywords
 
     effective_params = params.model_copy(update=overrides) if overrides else params

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -4198,7 +4198,11 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # surface reports the composition being SERVED like every other one. Most
     # of the lines are the comment explaining why the generation's own count is
     # a fact about the attempt, not about the dataset. Cap 1455 -> 1468, exact.
-    "backend/app/modules/catalog/search/router.py": 1536,
+    # fix(#1671): the two pre-#1666 search compatibility shims are sunset --
+    # `_legacy_keywords_body`, the `_LEGACY_FILTER_LANG_PARAM` fallback, and
+    # the comments that only existed to explain them. Cap lowered
+    # 1536 -> 1489, exact.
+    "backend/app/modules/catalog/search/router.py": 1489,
     # fix(#474): negotiate localized STAC record text; fix(#475) adds the
     # unassigned Collection and matching HTTP Link navigation. fix(#506): keep
     # validated STAC item responses wire-compatible with serializer output.

--- a/backend/tests/test_ogc_cql2_filtering.py
+++ b/backend/tests/test_ogc_cql2_filtering.py
@@ -549,44 +549,38 @@ async def test_validation_failure_returns_the_declared_problem_body(
 
 
 # ---------------------------------------------------------------------------
-# compat(#1666 codex P2): the pre-fix contract published `filter-lang` under
-# the field's Python name, so every SDK generated before the fix sends
-# `cql2_filter_lang` — and under the old `Depends()` binding that was the only
-# spelling that actually bound. Both are accepted; only the correct one is
-# published.
+# filter-lang: only the published spelling, `filter-lang`, is read. #1671
+# removed the fallback that also read `cql2_filter_lang` -- the field's
+# Python name, which the pre-#1666 contract published and pre-1.16.0 SDKs
+# still send.
 # ---------------------------------------------------------------------------
 
 _JSON_FILTER = '{"op":"=","args":[{"property":"srid"},4326]}'
-_FILTER_LANG_SPELLINGS = ["filter-lang", "cql2_filter_lang"]
 
 
 @pytest.mark.anyio
 @pytest.mark.parametrize("path", ["/search/datasets/", "/collections/datasets/items"])
-@pytest.mark.parametrize("name", _FILTER_LANG_SPELLINGS)
-async def test_cql2_json_parses_under_either_filter_lang_spelling(
-    client: AsyncClient, path: str, name: str
-):
-    """A CQL2-JSON filter parses under both spellings.
+async def test_cql2_json_parses_under_filter_lang(client: AsyncClient, path: str):
+    """A CQL2-JSON filter parses under filter-lang=cql2-json.
 
     This is the discriminating case: a JSON filter string is not valid
-    cql2-text, so if the spelling were ignored the request would fail rather
+    cql2-text, so if filter-lang were ignored the request would fail rather
     than quietly return the wrong rows.
     """
     resp = await client.get(
-        path, params={"filter": _JSON_FILTER, name: "cql2-json", "limit": 1}
+        path, params={"filter": _JSON_FILTER, "filter-lang": "cql2-json", "limit": 1}
     )
-    assert resp.status_code == 200, f"?{name}=cql2-json -> {resp.text[:200]}"
+    assert resp.status_code == 200, resp.text[:200]
 
 
 @pytest.mark.anyio
 @pytest.mark.parametrize("path", ["/search/datasets/", "/collections/datasets/items"])
-@pytest.mark.parametrize("name", _FILTER_LANG_SPELLINGS)
-async def test_bogus_filter_lang_rejected_under_either_spelling(
-    client: AsyncClient, path: str, name: str
-):
-    """An unsupported value is a 400 whichever spelling carried it."""
-    resp = await client.get(path, params={"filter": "srid=4326", name: "bogus"})
-    assert resp.status_code == 400, f"?{name}=bogus -> {resp.status_code}"
+async def test_bogus_filter_lang_rejected(client: AsyncClient, path: str):
+    """An unsupported filter-lang value is a 400."""
+    resp = await client.get(
+        path, params={"filter": "srid=4326", "filter-lang": "bogus"}
+    )
+    assert resp.status_code == 400, resp.status_code
 
 
 @pytest.mark.anyio
@@ -611,16 +605,31 @@ async def test_published_filter_lang_wins_over_the_legacy_spelling(
 
 @pytest.mark.anyio
 @pytest.mark.parametrize("path", ["/search/datasets/", "/collections/datasets/items"])
-async def test_legacy_keywords_json_body_still_filters(
-    client: AsyncClient, test_db_session, path: str
-):
-    """compat(#1666 codex P2): an old SDK's GET-body keywords still filter.
+async def test_cql2_filter_lang_param_is_ignored(client: AsyncClient, path: str):
+    """#1671: the sunset `cql2_filter_lang` spelling now has no effect at all.
 
-    The pre-fix contract declared `keywords` as an `application/json` request
-    body on a GET — the generated Python client's parameter was named `body` —
-    and the old `Depends()` binding consumed it. The corrected query-parameter
-    binding reads the opposite one, so without this shim an unchanged client
-    would silently receive UNFILTERED results.
+    The pre-#1666 fallback that read this spelling has been removed. Sending
+    it alone, with no `filter-lang`, must behave exactly as if it were absent:
+    the request falls back to the cql2-text default, and the JSON filter does
+    not parse as cql2-text, so a 400 proves the value was never read.
+    """
+    resp = await client.get(
+        path, params={"filter": _JSON_FILTER, "cql2_filter_lang": "cql2-json"}
+    )
+    assert resp.status_code == 400, resp.text[:200]
+
+
+@pytest.mark.anyio
+async def test_json_keywords_body_does_not_filter_on_search(
+    client: AsyncClient, test_db_session
+):
+    """#1671: a JSON `keywords` body on GET /search/datasets/ has no effect.
+
+    The pre-#1666 contract declared `keywords` as a request body on this GET;
+    the shim that honoured it for pre-1.16.0 SDKs has been removed. A body
+    naming a keyword nothing else matches must not change the result set from
+    the unfiltered baseline -- the request behaves exactly as if no body were
+    sent.
     """
     session = test_db_session
     admin_id = await get_user_id(session, "admin")
@@ -628,69 +637,23 @@ async def test_legacy_keywords_json_body_still_filters(
     await create_dataset(
         session,
         created_by=admin_id,
-        name=f"legacy-body-{unique}",
-        description="legacy GET-body keywords fixture",
+        name=f"sunset-body-{unique}",
+        description="sunset GET-body keywords fixture",
         visibility="public",
-        keywords=[f"legacy{unique}"],
+        keywords=[f"sunset{unique}"],
     )
     await session.commit()
 
-    hit = await client.request("GET", path, json=[f"legacy{unique}"])
-    assert hit.status_code == 200, hit.text[:200]
-    assert hit.json()["numberMatched"] >= 1
+    baseline = await client.get("/search/datasets/", params={"limit": 100})
+    assert baseline.status_code == 200, baseline.text[:200]
 
-    miss = await client.request("GET", path, json=[f"absent{unique}"])
-    assert miss.status_code == 200, miss.text[:200]
-    assert miss.json()["numberMatched"] == 0, (
-        "the legacy GET body was ignored — an unchanged old SDK client would "
-        "silently get unfiltered results."
+    with_body = await client.request(
+        "GET", "/search/datasets/", params={"limit": 100}, json=[f"sunset{unique}"]
     )
-
-
-@pytest.mark.anyio
-@pytest.mark.parametrize("path", ["/search/datasets/", "/collections/datasets/items"])
-async def test_query_keywords_win_over_the_legacy_body(
-    client: AsyncClient, test_db_session, path: str
-):
-    """The published form decides when a client somehow sends both."""
-    session = test_db_session
-    admin_id = await get_user_id(session, "admin")
-    unique = uuid.uuid4().hex[:8]
-    await create_dataset(
-        session,
-        created_by=admin_id,
-        name=f"both-forms-{unique}",
-        description="query-wins fixture",
-        visibility="public",
-        keywords=[f"query{unique}"],
+    assert with_body.status_code == 200, with_body.text[:200]
+    assert with_body.json()["numberMatched"] == baseline.json()["numberMatched"], (
+        "a JSON keywords body changed the result set -- it should be ignored."
     )
-    await session.commit()
-
-    resp = await client.request(
-        "GET",
-        path,
-        params={"keywords": f"query{unique}", "limit": 100},
-        json=[f"absent{unique}"],
-    )
-    assert resp.status_code == 200, resp.text[:200]
-    assert resp.json()["numberMatched"] >= 1, (
-        "the legacy body overrode the query parameter."
-    )
-
-
-@pytest.mark.anyio
-async def test_non_keyword_json_body_is_ignored_on_search(client: AsyncClient):
-    """The shim recognises one shape and ignores anything else, without failing.
-
-    Scoped to `/search/datasets/` on purpose. `/collections/datasets/items`
-    keeps `Depends()`, so FastAPI still BINDS and VALIDATES the legacy body
-    there and answers 400 for a malformed one — pre-existing behaviour that
-    this PR removes from the published contract but cannot remove from the
-    runtime without the query-model form that route cannot use.
-    """
-    for payload in ({"not": "a list"}, [1, 2, 3], []):
-        resp = await client.request("GET", "/search/datasets/", json=payload)
-        assert resp.status_code == 200, f"{payload!r} -> {resp.status_code}"
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
Closes #1671.

Removes the two search compatibility forms #1670 kept alive for one release cycle after #1666 corrected the published OpenAPI contract: the `cql2_filter_lang` spelling of `filter-lang`, and a JSON `keywords` request body on `GET /search/datasets/`. #1666 shipped in 1.16.0 (2026-08-27); 1.16.1 and 1.17.0 have shipped since, so the deprecation window has passed. Both forms were accepted but never published, so no client generated from the current contract is affected.

Deleted `_legacy_keywords_body` and its call in `search_datasets_endpoint`, and the `_LEGACY_FILTER_LANG_PARAM` fallback and constant from `_resolve_filter_lang`, along with the comments that only existed to explain them.

Fixing this exposed a second gap in `_resolve_filter_lang`: `collection_items` binds its query model with a bare `Depends()`, under which pydantic's synthesized `__init__` cannot bind the hyphenated `filter-lang` alias at all, so it falls back to binding the field's own Python name, `cql2_filter_lang`, from the raw query string. That meant `?cql2_filter_lang=...` kept working on that one route through the native binding alone, independent of the explicit shim just removed. `_resolve_filter_lang` now reads only the published wire name (`filter-lang`) and never falls back to `params.cql2_filter_lang`, so the sunset spelling has no effect on either route.

Removed the compatibility tests #1671 named: `test_legacy_keywords_json_body_still_filters`, `test_query_keywords_win_over_the_legacy_body`, `test_non_keyword_json_body_is_ignored_on_search`, and the `cql2_filter_lang` parametrize cases (renamed the two surviving tests to `test_cql2_json_parses_under_filter_lang` and `test_bogus_filter_lang_rejected` now that only one spelling exists). `test_malformed_legacy_body_still_validates_on_collection_items` stays, as it pins a separate runtime/contract asymmetry unrelated to these shims. Added two tests pinning the sunset behavior: `test_cql2_filter_lang_param_is_ignored` and `test_json_keywords_body_does_not_filter_on_search`.

Schema/API impact: none. Both forms were never published, and `make openapi-check` confirms the snapshot is unchanged.

Lowered the `_MODULE_LOC_CAPS` entry for `search/router.py` from 1536 to 1489, its exact new `wc -l`.

Verification run from the worktree:
- `uv run pytest tests/test_ogc_cql2_filtering.py tests/test_layering.py -q` -> 77 passed
- `uv run ruff check .` -> all checks passed
- `uv run ruff format --check .` -> all files formatted
- `PYTHONPATH=. uv run python scripts/dump_openapi.py --check` -> passed, no diff (backend/openapi.json untouched)

Nothing left out.
