### PR TITLE
fix(jobs): settle abandoned uploads as cancelled, not failed

### DIFF
--- a/backend/app/modules/admin/router.py
+++ b/backend/app/modules/admin/router.py
@@ -1121,6 +1121,7 @@ async def trigger_backfill(
                 job, message_prefix="Failed to queue embedding backfill"
             ),
             db=db,
+            job=job,
         )
     except DeferFailed as dispatch_exc:
         # fix(#1550 review P2, round 1): the orphan guard has already marked the

--- a/backend/app/modules/catalog/datasets/api/router_analysis.py
+++ b/backend/app/modules/catalog/datasets/api/router_analysis.py
@@ -684,6 +684,6 @@ async def analysis_materialize_endpoint(
             **extra_kwargs,
         )
 
-    await defer_with_orphan_guard(_defer, rollback=rollback, db=db)
+    await defer_with_orphan_guard(_defer, rollback=rollback, db=db, job=job)
 
     return AnalysisMaterializeResponse(job_id=job.id, status="pending")

--- a/backend/app/modules/catalog/datasets/api/router_refresh.py
+++ b/backend/app/modules/catalog/datasets/api/router_refresh.py
@@ -604,7 +604,7 @@ async def _dispatch_postgis_refresh(
             dataset_id=str(dataset_id),
         )
 
-    await defer_with_orphan_guard(_defer_refresh, rollback=rollback, db=db)
+    await defer_with_orphan_guard(_defer_refresh, rollback=rollback, db=db, job=job)
 
     return DatasetRefreshResponse(
         run_id=run_id,
@@ -857,7 +857,7 @@ async def _dispatch_stac_refresh(
             dataset_id=str(dataset_id),
         )
 
-    await defer_with_orphan_guard(_defer_refresh, rollback=rollback, db=db)
+    await defer_with_orphan_guard(_defer_refresh, rollback=rollback, db=db, job=job)
 
     return DatasetRefreshResponse(
         run_id=run_id,
@@ -1340,7 +1340,7 @@ async def refresh_dataset(
             credential_ref=credential_ref,
         )
 
-    await defer_with_orphan_guard(_defer_refresh, rollback=_rollback, db=db)
+    await defer_with_orphan_guard(_defer_refresh, rollback=_rollback, db=db, job=job)
 
     return DatasetRefreshResponse(
         run_id=run_id,

--- a/backend/app/modules/catalog/datasets/api/router_reupload.py
+++ b/backend/app/modules/catalog/datasets/api/router_reupload.py
@@ -638,7 +638,7 @@ async def _dispatch_reupload_task(
                 credential_ref=credential_ref,
             )
 
-        await defer_with_orphan_guard(_defer_service, rollback=rollback, db=db)
+        await defer_with_orphan_guard(_defer_service, rollback=rollback, db=db, job=job)
         return
 
     if job.file_path is None:
@@ -669,7 +669,7 @@ async def _dispatch_reupload_task(
                 user_id=str(user_id),
             )
 
-        await defer_with_orphan_guard(_defer_raster, rollback=rollback, db=db)
+        await defer_with_orphan_guard(_defer_raster, rollback=rollback, db=db, job=job)
         return
 
     # Route small files to priority queue
@@ -698,7 +698,7 @@ async def _dispatch_reupload_task(
             user_id=str(user_id),
         )
 
-    await defer_with_orphan_guard(_defer_file, rollback=rollback, db=db)
+    await defer_with_orphan_guard(_defer_file, rollback=rollback, db=db, job=job)
 
 
 @router.post(

--- a/backend/app/modules/catalog/datasets/api/router_vrt.py
+++ b/backend/app/modules/catalog/datasets/api/router_vrt.py
@@ -532,7 +532,7 @@ async def regenerate_vrt_endpoint(
         previous_status=previous_status,
         previous_generation_id=previous_generation_id,
     )
-    await defer_with_orphan_guard(_defer, rollback=rollback, db=db)
+    await defer_with_orphan_guard(_defer, rollback=rollback, db=db, job=job)
 
     return VrtMutationResponse(
         job_id=job.id,

--- a/backend/app/platform/jobs/defer_guard.py
+++ b/backend/app/platform/jobs/defer_guard.py
@@ -41,7 +41,11 @@ from fastapi import HTTPException, status
 from sqlalchemy import update
 from sqlalchemy.ext.asyncio import AsyncSession, async_object_session
 
-from app.platform.jobs.models import IngestJob
+from app.platform.jobs.models import (
+    COMMIT_ATTEMPTED_METADATA_KEY,
+    IngestJob,
+    commit_attempted_marker,
+)
 
 if TYPE_CHECKING:
     # Typing-only edge: `platform/` must not import `processing/` at module
@@ -91,15 +95,55 @@ class DeferFailed(HTTPException):
         self.rolled_back = rolled_back
 
 
+async def stamp_commit_attempted(job: IngestJob, *, db: AsyncSession) -> None:
+    """Record durably, on the row, that a dispatch was attempted for it.
+
+    feat(#1744): the one write that lets the stale sweep tell an abandoned
+    upload from a broken one. ``POST /ingest/upload`` deliberately does not
+    queue anything, so a `pending` row with no Procrastinate job is the normal
+    state between upload and commit, and when the owner walks away at the
+    preview step that row looks exactly like a commit whose dispatch died. The
+    two are only indistinguishable because nothing on the row said whether a
+    dispatch was ever tried; this says it, and ``abandoned_upload`` in
+    ``jobs/sweep.py`` reads its absence.
+
+    Committed rather than left dirty on the session, because the states that
+    need it most are the ones where nothing later commits: ``get_db`` closes
+    without committing, and the two rows the marker has to survive for are a
+    defer whose rollback did not land and a dispatch whose queue row later
+    vanished with the ingest row still `pending`. The extra commit costs
+    nothing here, because every caller of the guard has just committed the row
+    it is about to dispatch, which the Phase 1060 close-gate fix made
+    mandatory so the worker can see the row before the task exists.
+
+    Idempotent: a second dispatch of the same row (``/jobs/{id}/retry``
+    re-queues through ``queue_ingest_job``) keeps the first timestamp and
+    issues no write. Written as an UPDATE keyed on the id rather than an ORM
+    mutation so it also lands for a caller holding a detached instance, and
+    mirrored onto the instance afterwards so in-memory reads agree with the
+    row.
+    """
+    metadata = dict(job.user_metadata or {})
+    if metadata.get(COMMIT_ATTEMPTED_METADATA_KEY):
+        return
+    metadata.update(commit_attempted_marker())
+    await db.execute(
+        update(IngestJob).where(IngestJob.id == job.id).values(user_metadata=metadata)
+    )
+    await db.commit()
+    job.user_metadata = metadata
+
+
 async def defer_with_orphan_guard(
     defer_call: DeferCallable,
     *,
     rollback: RollbackCallable,
     db: AsyncSession,
+    job: IngestJob,
 ) -> None:
     """Run a ``defer_async`` call with rollback-on-failure semantics.
 
-    On success: no-op wrapper around ``defer_call``.
+    On success: stamps ``job`` as dispatch-attempted, then ``defer_call``.
 
     On failure:
         1. Invoke ``rollback(defer_exc)`` to revert committed state.
@@ -111,17 +155,37 @@ async def defer_with_orphan_guard(
            the defer error, carrying ``rolled_back`` so a caller can tell
            "the state was reverted" from "the state is still out there".
 
+    feat(#1744): ``job`` is required, and it is required rather than optional
+    because this is the one place every ``IngestJob`` dispatch in the codebase
+    passes through. Nothing calls ``task.defer_async`` with a ``job_id``
+    outside a closure this guard runs, so stamping here reaches every door at
+    once and a new door cannot be written that skips it. Same "a caller cannot
+    express the operation without also taking the rule" shape that
+    ``stale_pending_clauses`` uses for the read side.
+    ``test_commit_attempted_marker_doors.py`` pins both halves.
+
+    The stamp is inside the try on purpose. It has to be on the row BEFORE the
+    task exists, and a stamp that does not land is a dispatch that must not
+    happen: without it a later sweep cannot tell this row from an upload nobody
+    ever committed, and would cancel a job whose only recovery path is
+    ``/jobs/{id}/retry`` (failed-only). Treating that as a dispatch failure
+    settles the row `failed` through the same rollback, which is the state a
+    caller can act on.
+
     Args:
         defer_call: 0-arg async closure that calls ``task.defer_async``.
         rollback: async closure that reverts committed state. Receives
             the defer exception for error-message embedding.
         db: session used to commit the rollback.
+        job: the ``IngestJob`` row this dispatch is for, stamped
+            dispatch-attempted before the defer runs.
 
     Raises:
         DeferFailed: always, when ``defer_call`` raises. Existing callers that
             catch ``HTTPException`` are unaffected; the 503 body is unchanged.
     """
     try:
+        await stamp_commit_attempted(job, db=db)
         await defer_call()
     except Exception as defer_exc:  # broad: defer_async can throw various job-runner errors; orphan-guard handles all
         rolled_back = False

--- a/backend/app/platform/jobs/defer_guard.py
+++ b/backend/app/platform/jobs/defer_guard.py
@@ -134,6 +134,31 @@ async def stamp_commit_attempted(job: IngestJob, *, db: AsyncSession) -> None:
     job.user_metadata = metadata
 
 
+async def _settle_after_failed_dispatch(
+    rollback: RollbackCallable, exc: BaseException, db: AsyncSession
+) -> bool:
+    """Run the caller's rollback closure and commit it. Returns whether it landed.
+
+    fix(#1774 review, codex P2): extracted so the two ways a dispatch can fail
+    (the marker write, then the defer itself) settle the row identically. A
+    second copy of this block is how one of them would end up not committing,
+    or not logging, or reporting a `rolled_back` the other does not.
+    """
+    try:
+        await rollback(exc)
+        await db.commit()
+        return True
+    except Exception:  # broad: rollback itself can fail with DB errors; log both, still surface 503 to client
+        # Rollback itself failed. Log the rollback error plus the dispatch
+        # context so operators can diagnose both. The caller still raises 503
+        # so the client retry flow stays consistent.
+        logger.exception(
+            "Orphan-guard rollback failed after defer error",
+            defer_error=str(exc),
+        )
+        return False
+
+
 async def defer_with_orphan_guard(
     defer_call: DeferCallable,
     *,
@@ -145,7 +170,7 @@ async def defer_with_orphan_guard(
 
     On success: stamps ``job`` as dispatch-attempted, then ``defer_call``.
 
-    On failure:
+    On failure of either step:
         1. Invoke ``rollback(defer_exc)`` to revert committed state.
         2. Commit the rollback on ``db``.
         3. If the rollback itself raises, log the rollback error plus
@@ -164,13 +189,17 @@ async def defer_with_orphan_guard(
     ``stale_pending_clauses`` uses for the read side.
     ``test_commit_attempted_marker_doors.py`` pins both halves.
 
-    The stamp is inside the try on purpose. It has to be on the row BEFORE the
-    task exists, and a stamp that does not land is a dispatch that must not
-    happen: without it a later sweep cannot tell this row from an upload nobody
-    ever committed, and would cancel a job whose only recovery path is
-    ``/jobs/{id}/retry`` (failed-only). Treating that as a dispatch failure
-    settles the row `failed` through the same rollback, which is the state a
-    caller can act on.
+    A failed stamp is treated as a failed dispatch. The marker has to be on
+    the row BEFORE the task exists, and without it a later sweep cannot tell
+    this row from an upload nobody ever committed, so it would cancel a job
+    whose only recovery path is ``/jobs/{id}/retry`` (failed-only). Settling
+    the row `failed` through the same rollback is the state a caller can act
+    on, and it keeps the row out of the sweep's pending class entirely.
+
+    fix(#1774 review, codex P2): the stamp gets its own try, because that
+    branch has to reset the session before it settles. A serialization failure
+    or deadlock on the marker write leaves the ``AsyncSession`` in a failed
+    transaction, and the settlement is itself a statement on that session.
 
     Args:
         defer_call: 0-arg async closure that calls ``task.defer_async``.
@@ -186,21 +215,34 @@ async def defer_with_orphan_guard(
     """
     try:
         await stamp_commit_attempted(job, db=db)
+    except Exception as stamp_exc:  # broad: a failed marker write is a failed dispatch
+        # fix(#1774 review, codex P2): reset the session BEFORE settling.
+        # A serialization failure or deadlock on the marker write leaves this
+        # AsyncSession in a failed transaction, and SQLAlchemy refuses every
+        # further statement on it until it is rolled back. Handing it straight
+        # to `settle_ingest_job_failed` would raise there too, and the job
+        # would stay `pending` with no marker, which is the one combination
+        # the stale sweep reads as an upload nobody committed. It would cancel
+        # a dispatch that was genuinely attempted and take away the retry this
+        # whole guard exists to preserve.
+        #
+        # Nothing is discarded by the reset: every caller commits the row
+        # before dispatching, so at this point the session holds only the
+        # marker write that just failed.
+        try:
+            await db.rollback()
+        except Exception:  # broad: a dead connection cannot be reset here
+            logger.exception(
+                "Orphan-guard could not reset the session after a failed "
+                "dispatch marker write"
+            )
+        rolled_back = await _settle_after_failed_dispatch(rollback, stamp_exc, db)
+        raise DeferFailed(rolled_back=rolled_back) from stamp_exc
+
+    try:
         await defer_call()
     except Exception as defer_exc:  # broad: defer_async can throw various job-runner errors; orphan-guard handles all
-        rolled_back = False
-        try:
-            await rollback(defer_exc)
-            await db.commit()
-            rolled_back = True
-        except Exception:  # broad: rollback itself can fail with DB errors; log both, still surface 503 to client
-            # Rollback itself failed — log the rollback error plus the
-            # defer context so operators can diagnose both. Still raise
-            # 503 so the client retry flow stays consistent.
-            logger.exception(
-                "Orphan-guard rollback failed after defer error",
-                defer_error=str(defer_exc),
-            )
+        rolled_back = await _settle_after_failed_dispatch(rollback, defer_exc, db)
         raise DeferFailed(rolled_back=rolled_back) from defer_exc
 
 

--- a/backend/app/platform/jobs/defer_guard.py
+++ b/backend/app/platform/jobs/defer_guard.py
@@ -38,8 +38,9 @@ from typing import TYPE_CHECKING, Any, Awaitable, Callable
 
 import structlog
 from fastapi import HTTPException, status
-from sqlalchemy import update
+from sqlalchemy import inspect as sa_inspect, update
 from sqlalchemy.ext.asyncio import AsyncSession, async_object_session
+from sqlalchemy.orm.attributes import set_committed_value
 
 from app.platform.jobs.models import (
     COMMIT_ATTEMPTED_METADATA_KEY,
@@ -134,6 +135,38 @@ async def stamp_commit_attempted(job: IngestJob, *, db: AsyncSession) -> None:
     job.user_metadata = metadata
 
 
+def _restore_settlement_identifiers(
+    job: IngestJob, identifiers: dict[str, Any] | None
+) -> None:
+    """Put the settlement's own identifiers back after a rollback expired them.
+
+    fix(#1774 review r2, codex P2): ``Session.rollback()`` expires every
+    instance that was in the failed transaction, and ``expire_on_commit=False``
+    does not change that. The next synchronous read of an expired column
+    attribute is a lazy load, and an ``AsyncSession`` has no greenlet to run
+    one, so SQLAlchemy raises ``MissingGreenlet`` instead of returning a value.
+    ``settle_ingest_job_failed`` reads ``job.id`` and ``job.attempt_id``
+    synchronously, and it is the one function every rollback closure in the
+    codebase funnels through, so without this the reset that makes the session
+    usable is also what stops the settlement from running.
+
+    Written from values snapshotted BEFORE the failed write, through
+    ``set_committed_value``, which marks an attribute loaded without a query
+    and without marking it dirty. A snapshot cannot fail; a reload is one more
+    statement on a connection that has just misbehaved. Only the two the shared
+    settlement reads are restored, so every other attribute stays expired and
+    reloads normally once the session is healthy.
+
+    A no-op when there is nothing to restore: ``identifiers`` is None if the
+    instance was already expired on the way in, and a non-mapped object (a test
+    double) was never expired to begin with.
+    """
+    if identifiers is None or sa_inspect(job, raiseerr=False) is None:
+        return
+    for key, value in identifiers.items():
+        set_committed_value(job, key, value)
+
+
 async def _settle_after_failed_dispatch(
     rollback: RollbackCallable, exc: BaseException, db: AsyncSession
 ) -> bool:
@@ -213,6 +246,20 @@ async def defer_with_orphan_guard(
         DeferFailed: always, when ``defer_call`` raises. Existing callers that
             catch ``HTTPException`` are unaffected; the 503 body is unchanged.
     """
+    # fix(#1774 review r2, codex P2): snapshotted BEFORE the write that can
+    # fail. A value in a local cannot be expired by the reset below, and these
+    # two are what the shared settlement reads. See
+    # `_restore_settlement_identifiers`. Guarded because reading them is itself
+    # an attribute access: an instance that arrived expired has nothing to
+    # snapshot, and the reload below is then the only route back.
+    try:
+        identifiers: dict[str, Any] | None = {
+            "id": job.id,
+            "attempt_id": job.attempt_id,
+        }
+    except Exception:  # broad: an already-expired instance has nothing to snapshot
+        identifiers = None
+
     try:
         await stamp_commit_attempted(job, db=db)
     except Exception as stamp_exc:  # broad: a failed marker write is a failed dispatch
@@ -234,6 +281,20 @@ async def defer_with_orphan_guard(
         except Exception:  # broad: a dead connection cannot be reset here
             logger.exception(
                 "Orphan-guard could not reset the session after a failed "
+                "dispatch marker write"
+            )
+        # fix(#1774 review r2, codex P2): the reset expires every instance it
+        # touched, so put the settlement's identifiers back before invoking a
+        # closure that reads them. The snapshot is the guarantee, because it
+        # needs no connection; the reload covers whatever a caller-supplied
+        # closure reads beyond those two, and is best-effort for the same
+        # reason the rollback above is.
+        _restore_settlement_identifiers(job, identifiers)
+        try:
+            await db.refresh(job)
+        except Exception:  # broad: best effort; the snapshot above is the guarantee
+            logger.exception(
+                "Orphan-guard could not reload the job after a failed "
                 "dispatch marker write"
             )
         rolled_back = await _settle_after_failed_dispatch(rollback, stamp_exc, db)

--- a/backend/app/platform/jobs/models.py
+++ b/backend/app/platform/jobs/models.py
@@ -1,5 +1,5 @@
 import uuid
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any
 
 from sqlalchemy import (
@@ -44,6 +44,29 @@ STATUSES_NEEDING_STAGED_INPUT = ("pending", "running", "failed")
 # default layer of a multi-layer file. Cross-reader markers live here beside
 # the others so the two sites cannot drift (#1249 r6 precedent).
 FAN_OUT_INTERRUPTED_METADATA_KEY = "fan_out_interrupted"
+
+# `user_metadata` key stamped by ``defer_with_orphan_guard`` at the moment a
+# dispatch is attempted for an ``IngestJob`` row, holding an ISO-8601 UTC
+# timestamp (fix(#1744)). Its ABSENCE is the load-bearing half: a pending,
+# never-queued row that carries no such stamp was never handed to the queue at
+# all, which is the abandoned upload the stale sweep settles `cancelled` rather
+# than `failed`. Read by the three sites that settle an unbound pending row
+# (the background sweep, the status poll and the worker's startup recovery),
+# written at exactly one, so it lives here beside the other cross-reader
+# markers.
+COMMIT_ATTEMPTED_METADATA_KEY = "commit_attempted_at"
+
+
+def commit_attempted_marker() -> dict[str, str]:
+    """The ``user_metadata`` fragment that records a dispatch attempt.
+
+    One producer of the value, because there are two writers: the guard stamps
+    it on an existing row, and ``create_fan_out_jobs`` puts it in the metadata
+    it commits for a new child. A second hand-rolled timestamp is how the two
+    would end up disagreeing about the format the predicate reads.
+    """
+    return {COMMIT_ATTEMPTED_METADATA_KEY: datetime.now(timezone.utc).isoformat()}
+
 
 # `user_metadata` key that marks an ``IngestJob`` row as an admin embedding
 # backfill run (fix(#1542)). The run itself imports nothing — the row exists so

--- a/backend/app/platform/jobs/router.py
+++ b/backend/app/platform/jobs/router.py
@@ -58,7 +58,7 @@ from app.platform.jobs.sweep import (
     fail_stale_jobs,
     post_expiry_sweep_after_seconds,  # noqa: F401 -- re-exported, see __all__
     publish_refresh_reconciliation,
-    is_abandoned_presigned_upload,  # noqa: F401 -- re-exported, see __all__
+    is_abandoned_upload,  # noqa: F401 -- re-exported, see __all__
     stale_pending_clauses,
     stale_pending_cutoff_seconds,
     stale_pending_unbound_values,
@@ -1248,7 +1248,7 @@ __all__ = [
     "audit_settled_embedding_backfill",
     "fail_stale_jobs",
     "get_retry_capability",
-    "is_abandoned_presigned_upload",
+    "is_abandoned_upload",
     "post_expiry_sweep_after_seconds",
     "router",
     "stale_pending_clauses",

--- a/backend/app/platform/jobs/sweep.py
+++ b/backend/app/platform/jobs/sweep.py
@@ -37,6 +37,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.config import MAX_PRESIGNED_URL_LIFETIME_SECONDS, settings
 from app.observability.metrics.refresh import refresh_sweep_reconciled_total
 from app.platform.jobs.models import (
+    COMMIT_ATTEMPTED_METADATA_KEY,
     EMBEDDING_BACKFILL_METADATA_KEY,
     FAN_OUT_INTERRUPTED_METADATA_KEY,
     STAGING_REAPED_FINAL_MARKER,
@@ -181,57 +182,84 @@ def stale_pending_clauses(now: datetime, *, completion_bound: bool) -> tuple:
     )
 
 
-# fix(#1556): the terminal state for a presigned upload nobody ever bound bytes
-# to. `failed` claims an ingest was attempted and broke; for a visitor who
-# presigned an upload and walked away, nothing was ever attempted, and on the
-# public demo those rows are indistinguishable from real ingest failures in the
-# admin jobs list and the failed-jobs badge that counts it. `cancelled` is
-# already in the `ingest_jobs` status CHECK constraint, in the admin `JobStatus`
-# literal and in openapi.json, so this needs no migration and changes no
-# published contract.
+# fix(#1556): the terminal state for an upload nobody ever committed. `failed`
+# claims an ingest was attempted and broke; for a visitor who staged an upload
+# and walked away, nothing was ever attempted, and on the public demo those
+# rows are indistinguishable from real ingest failures in the admin jobs list
+# and the failed-jobs badge that counts it. `cancelled` is already in the
+# `ingest_jobs` status CHECK constraint, in the admin `JobStatus` literal and
+# in openapi.json, so this needs no migration and changes no published
+# contract.
 ABANDONED_UPLOAD_MESSAGE = "Abandoned: upload was never completed"
 
 
-def is_abandoned_presigned_upload(
-    file_path: str | None, user_metadata: dict | None
-) -> bool:
-    """Python twin of ``abandoned_presigned_upload``, over one loaded row.
+def is_abandoned_upload(user_metadata: dict | None) -> bool:
+    """Python twin of ``abandoned_upload``, over one loaded row.
 
     Only the worker's startup recovery needs it: that site mirrors the UPDATE
     onto the returned ORM instances, and a plain ``job.status = "failed"``
     there would write the in-memory object back over the status the database
     just computed. Kept beside the SQL so the two are read as one rule.
     """
-    return not file_path and bool((user_metadata or {}).get("presigned"))
+    return not (user_metadata or {}).get(COMMIT_ATTEMPTED_METADATA_KEY)
 
 
-def abandoned_presigned_upload():
-    """Predicate: a presigned upload whose bytes were never bound.
+def abandoned_upload():
+    """Predicate: nothing was ever dispatched for this row.
 
-    Deliberately narrower than "falsy ``file_path``". The unbound half of the
-    pending sweep also reaps rows that DID have work attempted for them, and
-    each of those must keep reporting `failed`:
+    fix(#1744): asks the row whether a dispatch was attempted, instead of
+    guessing from its shape. ``defer_with_orphan_guard`` stamps
+    ``commit_attempted_at`` immediately before every ``defer_async`` in the
+    codebase and commits it, so an unbound pending row that carries no stamp
+    was never handed to the queue at all.
 
-    - a service/URL import (``source_url`` set, ``file_path`` empty) whose
-      defer never landed. ``/jobs/{id}/retry`` requires status `failed`, and
-      ``_retry_capability`` offers exactly that row, so cancelling it would
-      take a recoverable job's only recovery path away — the same 1h-to-
-      recoverable-becomes-unrecoverable trap #1235 avoided for absolute paths.
-    - an analysis run or an admin embedding backfill, both of which carry
-      ``file_path=""`` by construction. A dispatch that never landed is a real
-      failure of something the user asked for, and #1550's audit trail settles
-      the backfill `never_started` in the same transaction as the row.
+    This replaces the ``file_path`` empty AND ``presigned`` carve-out #1556
+    installed, and folds that class in rather than sitting beside it. The
+    carve-out was keyed to the presign doors because those were the only ones
+    that stamped anything, which left the door the demo actually uses
+    unprotected: a direct upload binds an ABSOLUTE staging path and stamps no
+    `presigned` marker, so four abandoned direct uploads over two weeks each
+    reported `failed` with "never queued" while the queue was working
+    correctly. The absolute-path carve-out the old docstring defended no
+    longer needs a branch of its own, because the shape of ``file_path`` was
+    never what the two classes differed by; a broken commit and an abandoned
+    upload can both carry the same absolute path, and only the stamp
+    distinguishes them.
 
-    The ``presigned`` marker is what both presign doors stamp
-    (``processing/ingest/router.py`` and ``datasets/api/router_reupload.py``)
-    at the moment they hand a client a URL, so it names the one class where an
-    empty ``file_path`` means "the client never came back". A completion binds
-    ``staging/{job}/frozen/...`` and is therefore the BOUND half's business,
-    never this one.
+    Everything the old predicate deliberately excluded stays excluded, and now
+    for a reason that holds at every door rather than at two of them. A
+    service/URL import, an analysis run and an admin embedding backfill all
+    reach the queue through the same guard, so a dispatch that never landed
+    for one of them carries the stamp and keeps reporting `failed`.
+    ``/jobs/{id}/retry`` requires status `failed` and ``_retry_capability``
+    offers exactly those rows, so this is what keeps a recoverable job's only
+    recovery path open (the 1h-to-recoverable-becomes-unrecoverable trap
+    #1235 avoided), and #1550's audit trail still settles the backfill
+    `never_started` in the same transaction as the row.
+
+    Rows created before the stamp existed carry no stamp, so a pending unbound
+    row that predates the deploy reclassifies as `cancelled`. That is the
+    right answer for the abandoned uploads it will mostly be (the demo audit
+    found four of those and zero broken commits) and the wrong one for a
+    genuinely broken commit; accepted rather than migrated, because a
+    migration would have to guess the same thing from the same missing fact.
+
+    Two residual gaps, recorded rather than papered over. A door commits its
+    row and then dispatches, so a process death in the gap between those two
+    leaves the row unstamped and it settles `cancelled` instead of `failed`.
+    That window is one statement wide, and it was unbounded before this change
+    for the same class. ``create_fan_out_jobs`` is the one door that closes it
+    outright, by putting the stamp in the metadata it commits: it runs inside
+    a worker task, and its child cannot be recreated by repeating a user
+    action, because the layer selection lived in the fan-out request body and
+    nowhere else. The second gap is storage-mode-shaped: in S3 mode a direct
+    upload binds ``staging/{job}/{name}``, which is the BOUND half's business,
+    so an abandoned S3 upload still settles `failed` after the 24h backstop
+    with the bound message. #1744's evidence and scope are the unbound half.
     """
-    return and_(
-        func.coalesce(IngestJob.file_path, "") == "",
-        func.coalesce(IngestJob.user_metadata["presigned"].astext, "false") == "true",
+    return (
+        func.coalesce(IngestJob.user_metadata[COMMIT_ATTEMPTED_METADATA_KEY].astext, "")
+        == ""
     )
 
 
@@ -252,7 +280,7 @@ def stale_pending_unbound_values(now: datetime, *, message: str) -> dict:
     the elapsed seconds); it survives untouched for every row that is not an
     abandoned upload, so nothing about the existing failure reporting moves.
     """
-    abandoned = abandoned_presigned_upload()
+    abandoned = abandoned_upload()
     return {
         "status": case((abandoned, "cancelled"), else_="failed"),
         "error_message": case((abandoned, ABANDONED_UPLOAD_MESSAGE), else_=message),
@@ -1357,9 +1385,11 @@ async def fail_stale_jobs(
     # database while raising in the unit suites that drive this with doubles.
     pending_cancelled = sum(1 for row in unbound_rows if row[3] == "cancelled")
     # Back to the three columns every consumer below expects; the audit loop
-    # still visits cancelled rows, which is a no-op for them by construction
-    # (an embedding backfill carries no `presigned` marker, so it is never in
-    # the cancelled class).
+    # still visits cancelled rows, and closing the trail is the right write for
+    # either terminal state. fix(#1744): a backfill reaches the queue through
+    # the same guard that stamps `commit_attempted_at`, so it is in the
+    # cancelled class only when the process died between its own commit and
+    # the dispatch, which is exactly the `never_started` the loop records.
     pending_rows = [(row[0], row[1], row[2]) for row in unbound_rows]
     pending_job_ids = [row[0] for row in unbound_rows]
 

--- a/backend/app/platform/jobs/worker.py
+++ b/backend/app/platform/jobs/worker.py
@@ -162,7 +162,7 @@ async def _recover_stale_jobs_for_current_scope() -> None:
         from app.platform.jobs.router import (
             ABANDONED_UPLOAD_MESSAGE,
             STALE_PENDING_UNBOUND_MESSAGE,
-            is_abandoned_presigned_upload,
+            is_abandoned_upload,
             stale_pending_clauses,
             stale_pending_unbound_values,
         )
@@ -185,7 +185,7 @@ async def _recover_stale_jobs_for_current_scope() -> None:
             # above), but they are writes to a persistent instance either way —
             # a flat `job.status = "failed"` here would mark the object dirty
             # and push `failed` back over the `cancelled` the UPDATE wrote.
-            abandoned = is_abandoned_presigned_upload(job.file_path, job.user_metadata)
+            abandoned = is_abandoned_upload(job.user_metadata)
             job.status = "cancelled" if abandoned else "failed"
             job.error_message = (
                 ABANDONED_UPLOAD_MESSAGE if abandoned else STALE_PENDING_UNBOUND_MESSAGE

--- a/backend/app/processing/ingest/manifest_service.py
+++ b/backend/app/processing/ingest/manifest_service.py
@@ -554,6 +554,7 @@ async def _queue_reupload_job(
         _defer_reupload,
         rollback=make_ingest_job_failed_rollback(job),
         db=db,
+        job=job,
     )
 
 

--- a/backend/app/processing/ingest/router.py
+++ b/backend/app/processing/ingest/router.py
@@ -2415,7 +2415,7 @@ async def add_vrt_source(
         previous_status=previous_status,
         previous_generation_id=previous_generation_id,
     )
-    await defer_with_orphan_guard(_defer, rollback=rollback, db=db)
+    await defer_with_orphan_guard(_defer, rollback=rollback, db=db, job=job)
 
     # fix(#1327): "queued", not "added". The catalog's source list still
     # describes the VRT being served; the addition becomes part of it when the
@@ -2574,7 +2574,7 @@ async def remove_vrt_source(
         previous_status=previous_status,
         previous_generation_id=previous_generation_id,
     )
-    await defer_with_orphan_guard(_defer, rollback=rollback, db=db)
+    await defer_with_orphan_guard(_defer, rollback=rollback, db=db, job=job)
 
     # fix(#1327): "queued", not "removed" — see the add endpoint's tail.
     return VrtMutationResponse(

--- a/backend/app/processing/ingest/service.py
+++ b/backend/app/processing/ingest/service.py
@@ -1137,6 +1137,24 @@ async def create_fan_out_jobs(
                 original_job_id=str(original_job.id),
                 error=str(exc),
             )
+        # fix(#1774 review, codex P2): reset the session before returning. The
+        # commit above carries this child's row AND its dispatch marker, and a
+        # transactional failure there leaves the session refusing every later
+        # statement. The caller loops over the remaining layers on this same
+        # session and then runs `restore_fan_out_parent_pending`, so without
+        # the reset one layer's deadlock fails every sibling and strands the
+        # parent `fanned_out` with no child importing. Nothing is discarded:
+        # a landed commit makes this a no-op, and a failed one had nothing to
+        # keep.
+        try:
+            await session.rollback()
+        except Exception:  # broad: a dead connection cannot be reset here
+            if logger:
+                logger.warning(
+                    "Fan-out layer session reset failed",
+                    layer_name=layer.layer_name,
+                    original_job_id=str(original_job.id),
+                )
         from app.processing.ingest.schemas import FanOutLayerResult
 
         return FanOutLayerResult(

--- a/backend/app/processing/ingest/service.py
+++ b/backend/app/processing/ingest/service.py
@@ -46,7 +46,7 @@ from app.platform.jobs.defer_guard import (
     defer_with_orphan_guard,
     make_ingest_job_failed_rollback,
 )
-from app.platform.jobs.models import IngestJob
+from app.platform.jobs.models import IngestJob, commit_attempted_marker
 from app.platform.storage.titiler_url import resolve_current_storage_key
 
 # Spool threshold for S3 uploads (PERF-001): SpooledTemporaryFile buffers this
@@ -978,6 +978,7 @@ async def create_vrt_job(
             job, message_prefix="Failed to queue VRT task"
         ),
         db=db,
+        job=job,
     )
 
     return job
@@ -1060,6 +1061,18 @@ async def create_fan_out_jobs(
                 # Clear dataset_id from parent metadata — each fan-out job
                 # creates its own dataset during _finalize_ingest.
                 "dataset_id": None,
+                # fix(#1744): stamped here rather than left to the guard
+                # below, so it rides the commit that makes the row visible.
+                # This runs inside a worker task; a process death in the gap
+                # between that commit and the dispatch would leave the row
+                # unstamped, which the stale sweep reads as an upload nobody
+                # committed and settles `cancelled`. That would take away the
+                # retry, and retry is the only way to re-run THIS layer: the
+                # layer selection lived in the fan-out request body and
+                # nowhere else (#1709 r8), so nothing can reconstruct it.
+                # Every other dispatch door creates its row inside the request
+                # that can simply be issued again.
+                **commit_attempted_marker(),
             },
         )
         session.add(new_job)
@@ -1097,6 +1110,7 @@ async def create_fan_out_jobs(
             _defer_fan_out_layer,
             rollback=make_ingest_job_failed_rollback(new_job),
             db=session,
+            job=new_job,
         )
 
         return FanOutLayerResult(
@@ -1407,6 +1421,7 @@ async def queue_ingest_job(
             _defer_service,
             rollback=_rollback_service,
             db=db,
+            job=job,
         )
         return
 
@@ -1432,6 +1447,7 @@ async def queue_ingest_job(
             _defer_raster,
             rollback=make_ingest_job_failed_rollback(job),
             db=db,
+            job=job,
         )
         return
 
@@ -1462,4 +1478,5 @@ async def queue_ingest_job(
         _defer_vector,
         rollback=make_ingest_job_failed_rollback(job),
         db=db,
+        job=job,
     )

--- a/backend/app/processing/ingest/service.py
+++ b/backend/app/processing/ingest/service.py
@@ -1146,14 +1146,27 @@ async def create_fan_out_jobs(
         # parent `fanned_out` with no child importing. Nothing is discarded:
         # a landed commit makes this a no-op, and a failed one had nothing to
         # keep.
+        #
+        # fix(#1774 review r2, codex P2): reload the parent in the same breath,
+        # because the reset expires it. The next layer reads
+        # `original_job.source_filename` and friends off this same instance,
+        # and `restore_fan_out_parent_pending` reads `job.id`, and a
+        # synchronous read of an expired attribute on an AsyncSession raises
+        # MissingGreenlet. Without the reload, the reset meant to let the
+        # siblings continue would instead turn one layer's failure into a 500.
+        # A reload rather than a snapshot here: the attributes read downstream
+        # are spread across two functions and the response, and one SELECT
+        # restores all of them.
+        parent_job_id = str(original_job.id)
         try:
             await session.rollback()
+            await session.refresh(original_job)
         except Exception:  # broad: a dead connection cannot be reset here
             if logger:
                 logger.warning(
                     "Fan-out layer session reset failed",
                     layer_name=layer.layer_name,
-                    original_job_id=str(original_job.id),
+                    original_job_id=parent_job_id,
                 )
         from app.processing.ingest.schemas import FanOutLayerResult
 

--- a/backend/tests/test_commit_attempted_marker_doors.py
+++ b/backend/tests/test_commit_attempted_marker_doors.py
@@ -1,0 +1,212 @@
+"""fix(#1744): every door that dispatches an ``IngestJob`` stamps the marker.
+
+``abandoned_upload`` in ``jobs/sweep.py`` reads the ABSENCE of
+``user_metadata["commit_attempted_at"]`` as "nothing was ever dispatched for
+this row", and settles it ``cancelled`` instead of ``failed``. That reading is
+only sound while every dispatch really does stamp it: a door that reached the
+queue without stamping would have its own genuine failures reported as
+abandoned uploads, and ``/jobs/{id}/retry`` accepts ``failed`` only, so the
+misreport would take the job's only recovery path away.
+
+The design answer was one choke point rather than a stamp per door. These tests
+pin that the choke point is still the only way through, in both directions:
+
+1. no ``defer_async_with_tenant(job_id=...)`` call reaches the queue outside a
+   function that goes through ``defer_with_orphan_guard``;
+2. every ``defer_with_orphan_guard`` call names the row it is dispatching;
+3. the guard stamps before it defers, and the stamp is committed.
+
+Source-walking, so it fails on a door that is added rather than on a door that
+happens to be exercised. The behavioural half lives in
+``test_stale_pending_reaper.py``.
+"""
+
+from __future__ import annotations
+
+import ast
+import pathlib
+
+import pytest
+
+BACKEND_ROOT = pathlib.Path(__file__).resolve().parents[1]
+APP_ROOT = BACKEND_ROOT / "app"
+
+GUARD = "defer_with_orphan_guard"
+DEFER = "defer_async_with_tenant"
+STAMP = "stamp_commit_attempted"
+
+
+def _called_name(node: ast.Call) -> str | None:
+    func = node.func
+    if isinstance(func, ast.Name):
+        return func.id
+    if isinstance(func, ast.Attribute):
+        return func.attr
+    return None
+
+
+def _parsed_modules() -> list[tuple[pathlib.Path, ast.Module]]:
+    return [
+        (path, ast.parse(path.read_text(encoding="utf-8")))
+        for path in sorted(APP_ROOT.rglob("*.py"))
+    ]
+
+
+def _parent_map(tree: ast.Module) -> dict[ast.AST, ast.AST]:
+    parents: dict[ast.AST, ast.AST] = {}
+    for node in ast.walk(tree):
+        for child in ast.iter_child_nodes(node):
+            parents[child] = node
+    return parents
+
+
+def _guard_calls() -> list[tuple[pathlib.Path, ast.Call]]:
+    found: list[tuple[pathlib.Path, ast.Call]] = []
+    for path, tree in _parsed_modules():
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Call) and _called_name(node) == GUARD:
+                found.append((path, node))
+    return found
+
+
+def test_no_ingest_job_dispatch_bypasses_the_guard() -> None:
+    """The choke point is the only route to the queue.
+
+    A ``job_id`` argument is what makes a deferred task an ``IngestJob``
+    dispatch: the worker loads that row and settles it. Every such call has to
+    sit inside a function that also runs the guard, because the guard is where
+    the marker is written and nowhere else writes it.
+
+    The two ``embed_record`` defers pass ``record_id`` and settle no ingest
+    row, so they are outside this rule by construction rather than by
+    exemption.
+    """
+    unguarded: list[str] = []
+    dispatch_count = 0
+
+    for path, tree in _parsed_modules():
+        parents = _parent_map(tree)
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call) or _called_name(node) != DEFER:
+                continue
+            if not any(kw.arg == "job_id" for kw in node.keywords):
+                continue
+            dispatch_count += 1
+            guarded = False
+            current: ast.AST = node
+            while current in parents:
+                current = parents[current]
+                if not isinstance(current, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                    continue
+                guarded = guarded or any(
+                    isinstance(sub, ast.Call) and _called_name(sub) == GUARD
+                    for sub in ast.walk(current)
+                )
+            if not guarded:
+                unguarded.append(f"{path}:{node.lineno}")
+
+    assert dispatch_count >= 17, (
+        "the walk found fewer ingest dispatches than the codebase has; the "
+        f"call shape this test recognizes has probably changed ({dispatch_count} found)"
+    )
+    assert not unguarded, (
+        "these sites dispatch an IngestJob without going through "
+        f"{GUARD}, so nothing stamps commit_attempted_at on the row and the "
+        "stale sweep will report their genuine failures as abandoned "
+        "uploads:\n" + "\n".join(unguarded)
+    )
+
+
+def test_every_guard_call_names_the_row_it_dispatches() -> None:
+    """``job=`` is required, and required is not the same as passed.
+
+    A missing keyword is a TypeError at runtime, which only shows up on a path
+    a test actually walks. This is the whole census, so a door added without it
+    fails here rather than in production on the one branch nobody exercised.
+    """
+    missing = [
+        f"{path}:{node.lineno}"
+        for path, node in _guard_calls()
+        if not any(kw.arg == "job" for kw in node.keywords)
+    ]
+    assert not missing, (
+        f"these {GUARD} calls do not name the IngestJob they dispatch:\n"
+        + "\n".join(missing)
+    )
+
+
+def test_the_guard_stamps_before_it_defers() -> None:
+    """Order is the whole point: the marker has to beat the task.
+
+    If the stamp ran after the defer, a worker could claim, run and settle the
+    row before the marker landed, and a crash in that window would leave a
+    dispatched row looking abandoned.
+    """
+    from app.platform.jobs import defer_guard
+
+    source = pathlib.Path(defer_guard.__file__).read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    guard_fn = next(
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+        and node.name == GUARD
+    )
+
+    stamp_lines = [
+        node.lineno
+        for node in ast.walk(guard_fn)
+        if isinstance(node, ast.Call) and _called_name(node) == STAMP
+    ]
+    defer_lines = [
+        node.lineno
+        for node in ast.walk(guard_fn)
+        if isinstance(node, ast.Call) and _called_name(node) == "defer_call"
+    ]
+
+    assert len(stamp_lines) == 1, f"expected one {STAMP} call in the guard"
+    assert defer_lines, "the guard no longer invokes its defer callable"
+    assert stamp_lines[0] < min(defer_lines), (
+        "the guard defers before it stamps, so a dispatched row can be read as "
+        "an abandoned upload"
+    )
+
+
+@pytest.mark.anyio
+async def test_the_stamp_is_committed_not_left_on_the_session() -> None:
+    """Durability, because the rows that need the marker never commit again.
+
+    ``get_db`` closes the session without committing, and the two shapes the
+    marker exists to catch are a defer whose rollback did not land and a
+    dispatch whose queue row later vanished. A stamp left dirty on the session
+    is gone in both.
+    """
+    import uuid
+    from types import SimpleNamespace
+
+    from app.platform.jobs.defer_guard import stamp_commit_attempted
+    from app.platform.jobs.models import COMMIT_ATTEMPTED_METADATA_KEY
+
+    executed: list[object] = []
+    commits: list[int] = []
+
+    class _Session:
+        async def execute(self, statement):
+            executed.append(statement)
+
+        async def commit(self):
+            commits.append(len(executed))
+
+    job = SimpleNamespace(id=uuid.uuid4(), user_metadata=None)
+    await stamp_commit_attempted(job, db=_Session())
+
+    assert len(executed) == 1, "the stamp did not write the row"
+    assert commits == [1], "the stamp was written but never committed"
+    assert job.user_metadata[COMMIT_ATTEMPTED_METADATA_KEY]
+
+    # Idempotent: a retry re-queues the same row, and the first attempt is the
+    # honest answer to "was a dispatch ever tried".
+    first = job.user_metadata[COMMIT_ATTEMPTED_METADATA_KEY]
+    await stamp_commit_attempted(job, db=_Session())
+    assert job.user_metadata[COMMIT_ATTEMPTED_METADATA_KEY] == first
+    assert len(executed) == 1, "the second dispatch rewrote a marker it should keep"

--- a/backend/tests/test_commit_attempted_marker_doors.py
+++ b/backend/tests/test_commit_attempted_marker_doors.py
@@ -27,7 +27,11 @@ import ast
 import pathlib
 
 import pytest
-from sqlalchemy.exc import OperationalError, PendingRollbackError
+from sqlalchemy.exc import (
+    MissingGreenlet,
+    OperationalError,
+    PendingRollbackError,
+)
 
 from app.platform.jobs.sweep import is_abandoned_upload
 
@@ -215,18 +219,70 @@ async def test_the_stamp_is_committed_not_left_on_the_session() -> None:
     assert len(executed) == 1, "the second dispatch rewrote a marker it should keep"
 
 
+class _ExpiringInstance:
+    """An ORM instance double that models what a rollback does to one.
+
+    `Session.rollback()` expires every instance that was in the failed
+    transaction, and `expire_on_commit=False` does not change that: the flag
+    only governs commit. The next SYNCHRONOUS read of an expired column
+    attribute is a lazy load, and an AsyncSession has no greenlet to run one,
+    so SQLAlchemy raises MissingGreenlet rather than returning a value. Setting
+    an attribute is unaffected, and so is a read of an attribute that has been
+    put back.
+
+    Verified against SQLAlchemy 2.0 and a real session before this double was
+    written; the double exists so the ordering can be asserted without a
+    deadlock to provoke.
+    """
+
+    def __init__(self, **attrs) -> None:
+        self.__dict__["_attrs"] = dict(attrs)
+        self.__dict__["_expired"] = set()
+
+    def _expire_all(self) -> None:
+        self.__dict__["_expired"] = set(self.__dict__["_attrs"])
+
+    def _reload(self) -> None:
+        self.__dict__["_expired"] = set()
+
+    def _restore(self, name: str) -> None:
+        self.__dict__["_expired"].discard(name)
+
+    def __getattr__(self, name: str):
+        attrs = self.__dict__["_attrs"]
+        if name in self.__dict__["_expired"]:
+            raise MissingGreenlet(
+                "greenlet_spawn has not been called; can't call await_only() "
+                "here. Was IO attempted in an unexpected place?"
+            )
+        try:
+            return attrs[name]
+        except KeyError as exc:
+            raise AttributeError(name) from exc
+
+    def __setattr__(self, name: str, value) -> None:
+        # A set on an expired attribute is legal and does not load.
+        self.__dict__["_attrs"][name] = value
+
+
 class _FailedTransactionSession:
     """A session that behaves like SQLAlchemy after a statement has failed.
 
     Once the marker commit raises, every later ``execute`` raises
-    ``PendingRollbackError`` until ``rollback`` is awaited. That is the real
-    constraint the fix is about: SQLAlchemy will not run another statement on
-    a session whose transaction failed, so the orphan settlement is only
+    ``PendingRollbackError`` until ``rollback`` is awaited. That is the first
+    constraint the fix is about: SQLAlchemy will not run another statement on a
+    session whose transaction failed, so the orphan settlement is only
     reachable after a reset.
+
+    The reset then expires every instance the session holds, which is the
+    second constraint: the settlement reads identifiers off one of those
+    instances, so a reset that is not followed by a restore or a reload trades
+    one failure for another.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, *instances: _ExpiringInstance) -> None:
         self.events: list[str] = []
+        self.instances = list(instances)
         self.broken = False
         self._commits = 0
 
@@ -253,6 +309,14 @@ class _FailedTransactionSession:
     async def rollback(self):
         self.events.append("rollback")
         self.broken = False
+        for instance in self.instances:
+            instance._expire_all()
+
+    async def refresh(self, instance):
+        self.events.append("refresh")
+        if self.broken:
+            raise PendingRollbackError("session must be rolled back first")
+        instance._reload()
 
 
 @pytest.mark.anyio
@@ -266,31 +330,45 @@ async def test_a_failed_marker_write_resets_the_session_before_settling() -> Non
     upload nobody committed. It would then cancel a dispatch that really was
     attempted and take away its retry.
 
-    So: reset first, settle second, and the row ends up `failed`, which keeps
-    it out of the sweep's pending class altogether.
+    fix(#1774 review r2, codex P2): and the reset alone is not enough, because
+    it expires the very instance the settlement reads. Reset, restore, settle,
+    in that order.
     """
     import uuid
-    from types import SimpleNamespace
 
     from app.platform.jobs.defer_guard import DeferFailed, defer_with_orphan_guard
 
-    session = _FailedTransactionSession()
-
     # Positive control: the double really does refuse work until it is reset,
-    # so the ordering assertion below cannot pass vacuously.
-    control = _FailedTransactionSession()
+    # and really does expire its instances when it is, so neither assertion
+    # below can pass vacuously.
+    control_job = _ExpiringInstance(id=uuid.uuid4(), attempt_id=uuid.uuid4())
+    control = _FailedTransactionSession(control_job)
     with pytest.raises(OperationalError):
         await control.commit()
     with pytest.raises(PendingRollbackError):
         await control.execute()
     await control.rollback()
     await control.execute()
+    with pytest.raises(MissingGreenlet):
+        control_job.id
+    await control.refresh(control_job)
+    assert control_job.id is not None
 
-    job = SimpleNamespace(id=uuid.uuid4(), user_metadata=None, status="pending")
+    job = _ExpiringInstance(
+        id=uuid.uuid4(),
+        attempt_id=uuid.uuid4(),
+        user_metadata=None,
+        status="pending",
+    )
+    session = _FailedTransactionSession(job)
+    settled_with: list[uuid.UUID] = []
 
     async def _settle(exc: BaseException) -> None:
-        # Stands in for `settle_ingest_job_failed`: a statement on the same
-        # session, which is what a failed transaction would reject.
+        # Stands in for `settle_ingest_job_failed`: it reads the identifiers
+        # off the instance synchronously and then issues a statement on the
+        # same session. Both are what a bare reset would have broken.
+        settled_with.append(job.id)
+        assert job.attempt_id is not None
         await session.execute()
         job.status = "failed"
 
@@ -306,11 +384,16 @@ async def test_a_failed_marker_write_resets_the_session_before_settling() -> Non
     )
     assert isinstance(exc_info.value.__cause__, OperationalError)
 
-    # execute+commit for the marker, then the reset, then the settlement.
-    assert session.events == ["execute", "commit", "rollback", "execute", "commit"]
-    assert session.events.index("rollback") < session.events.index(
-        "execute", session.events.index("rollback")
-    ), "the settlement ran on a session that had not been reset"
+    # execute+commit for the marker, the reset, the reload, then the settlement.
+    assert session.events == [
+        "execute",
+        "commit",
+        "rollback",
+        "refresh",
+        "execute",
+        "commit",
+    ]
+    assert len(settled_with) == 1, "the settlement never read the job"
 
     assert job.status == "failed", (
         "the job stayed pending, so the stale sweep would later read it as an "
@@ -326,15 +409,96 @@ async def test_a_failed_marker_write_resets_the_session_before_settling() -> Non
 
 
 @pytest.mark.anyio
+async def test_a_failed_marker_write_settles_the_real_row_without_a_reload(
+    test_db_session, monkeypatch
+) -> None:
+    """The whole recovery path, against a real session and a real row.
+
+    fix(#1774 review r2, codex P2): the snapshot is the guarantee and the
+    reload is the convenience, so the reload is disabled here. What is left is
+    a genuinely poisoned transaction, a genuinely expired `IngestJob`, and the
+    real `settle_ingest_job_failed` reading `job.id` and `job.attempt_id` off
+    it. The row has to come back `failed` from the database, because `failed`
+    is what keeps `/jobs/{id}/retry` reachable and keeps the row out of the
+    sweep's pending class.
+    """
+    from sqlalchemy import select, text, update
+
+    from app.platform.jobs import defer_guard
+    from app.platform.jobs.defer_guard import (
+        DeferFailed,
+        defer_with_orphan_guard,
+        make_ingest_job_failed_rollback,
+    )
+    from app.platform.jobs.models import IngestJob
+
+    job = IngestJob(source_filename="poisoned.geojson", status="pending", file_path="")
+    test_db_session.add(job)
+    await test_db_session.commit()
+    await test_db_session.refresh(job)
+    job_id = job.id
+
+    async def _poisoned_stamp(job_arg, *, db):
+        # A transaction that does real work and then fails, which is the shape
+        # of the marker UPDATE followed by a deadlocked commit.
+        await db.execute(
+            update(IngestJob).where(IngestJob.id == job_id).values(progress=1)
+        )
+        with pytest.raises(Exception):
+            await db.execute(text("SELECT 1/0"))
+        raise OperationalError(
+            "UPDATE catalog.ingest_jobs", None, Exception("deadlock detected")
+        )
+
+    async def _no_reload(*args, **kwargs):
+        raise OperationalError("SELECT ingest_jobs", None, Exception("gone"))
+
+    monkeypatch.setattr(defer_guard, "stamp_commit_attempted", _poisoned_stamp)
+    monkeypatch.setattr(test_db_session, "refresh", _no_reload)
+
+    async def _defer() -> None:  # pragma: no cover - never reached
+        raise AssertionError("the dispatch ran despite an unwritten marker")
+
+    with pytest.raises(DeferFailed) as exc_info:
+        await defer_with_orphan_guard(
+            _defer,
+            rollback=make_ingest_job_failed_rollback(job),
+            db=test_db_session,
+            job=job,
+        )
+
+    assert exc_info.value.status_code == 503
+    assert exc_info.value.rolled_back, (
+        "the settlement never landed, so the row is still pending with no "
+        "marker, which the sweep would later cancel as an abandoned upload"
+    )
+
+    monkeypatch.undo()
+    settled = (
+        await test_db_session.execute(select(IngestJob).where(IngestJob.id == job_id))
+    ).scalar_one()
+    assert settled.status == "failed"
+    assert "Failed to queue ingest task" in (settled.error_message or "")
+    assert is_abandoned_upload(settled.user_metadata), (
+        "the marker is expected NOT to have landed; if it did, this test is "
+        "no longer exercising the failure it was written for"
+    )
+
+    await test_db_session.execute(
+        IngestJob.__table__.delete().where(IngestJob.id == job_id)
+    )
+    await test_db_session.commit()
+
+
+@pytest.mark.anyio
 async def test_a_marker_write_that_succeeds_leaves_the_session_alone() -> None:
     """The counterweight: no reset on the path where nothing failed.
 
-    A rollback on the happy path would discard whatever the caller had staged
-    after its own commit, so the reset has to belong to the failure branch and
-    only to it.
+    A rollback on the happy path would expire every loaded instance and
+    discard whatever the caller had staged after its own commit, so the reset
+    has to belong to the failure branch and only to it.
     """
     import uuid
-    from types import SimpleNamespace
 
     from app.platform.jobs.defer_guard import defer_with_orphan_guard
 
@@ -342,8 +506,10 @@ async def test_a_marker_write_that_succeeds_leaves_the_session_alone() -> None:
         async def commit(self):
             self.events.append("commit")
 
-    session = _HealthySession()
-    job = SimpleNamespace(id=uuid.uuid4(), user_metadata=None, status="pending")
+    job = _ExpiringInstance(
+        id=uuid.uuid4(), attempt_id=uuid.uuid4(), user_metadata=None, status="pending"
+    )
+    session = _HealthySession(job)
     deferred: list[bool] = []
 
     async def _defer() -> None:
@@ -356,4 +522,102 @@ async def test_a_marker_write_that_succeeds_leaves_the_session_alone() -> None:
 
     assert deferred == [True]
     assert "rollback" not in session.events
+    assert "refresh" not in session.events
     assert session.events == ["execute", "commit"]
+
+
+@pytest.mark.anyio
+async def test_a_failed_fan_out_layer_leaves_the_parent_readable() -> None:
+    """fix(#1774 review r2, codex P2): the second stamping site, same hazard.
+
+    `create_fan_out_jobs` commits the child row and its dispatch marker
+    together, and its per-layer handler resets the session so the remaining
+    layers can still run. That reset expires the parent, which the next layer
+    reads (`source_filename`, `file_path`, `user_metadata`) and which
+    `restore_fan_out_parent_pending` reads (`id`). Without the reload, the
+    reset meant to save the siblings turns one layer's failure into a 500 and
+    strands the parent `fanned_out` with no child importing.
+    """
+    import uuid
+    from types import SimpleNamespace
+
+    from app.processing.ingest.service import create_fan_out_jobs
+
+    parent = _ExpiringInstance(
+        id=uuid.uuid4(),
+        source_filename="multi.gpkg",
+        file_path="/app/staging/multi.gpkg",
+        created_by=uuid.uuid4(),
+        user_metadata={"all_layers": ["buildings", "roads"], "file_type": "vector"},
+    )
+    session = _FailedTransactionSession(parent)
+    session.add = lambda obj: session.events.append("add")
+
+    async def _flush():
+        session.events.append("flush")
+
+    session.flush = _flush
+
+    result = await create_fan_out_jobs(
+        parent, SimpleNamespace(layer_name="buildings", title=None), session
+    )
+
+    assert result.status == "failed", "the commit was supposed to fail this layer"
+    assert "rollback" in session.events, "the session was left in a failed transaction"
+    assert session.events.index("refresh") == session.events.index("rollback") + 1, (
+        "the parent was not reloaded immediately after the reset"
+    )
+
+    # The point of the reload: the caller's next layer, and the parent restore
+    # after the loop, both read these off the same instance.
+    assert parent.source_filename == "multi.gpkg"
+    assert parent.id is not None
+    assert parent.user_metadata["file_type"] == "vector"
+
+
+@pytest.mark.anyio
+async def test_restoring_identifiers_needs_no_query_on_a_real_expired_row(
+    test_db_session,
+) -> None:
+    """The double's premise, checked against the real thing.
+
+    Everything above is asserted through a stand-in. This one provokes the
+    actual state: a transaction that does work and then fails, a rollback, and
+    a real `IngestJob` whose synchronous reads raise MissingGreenlet. It then
+    shows `_restore_settlement_identifiers` making exactly the two the
+    settlement needs readable again, with no statement issued.
+    """
+    from sqlalchemy import text, update
+
+    from app.platform.jobs.defer_guard import _restore_settlement_identifiers
+    from app.platform.jobs.models import IngestJob
+
+    job = IngestJob(source_filename="expiry.geojson", status="pending", file_path="")
+    test_db_session.add(job)
+    await test_db_session.commit()
+    await test_db_session.refresh(job)
+    identifiers = {"id": job.id, "attempt_id": job.attempt_id}
+
+    await test_db_session.execute(
+        update(IngestJob).where(IngestJob.id == identifiers["id"]).values(progress=1)
+    )
+    with pytest.raises(Exception):
+        await test_db_session.execute(text("SELECT 1/0"))
+    await test_db_session.rollback()
+
+    with pytest.raises(MissingGreenlet):
+        job.id
+
+    _restore_settlement_identifiers(job, identifiers)
+
+    assert job.id == identifiers["id"]
+    assert job.attempt_id == identifiers["attempt_id"]
+    # Untouched attributes stay expired, so the restore is precise rather than
+    # a wholesale un-expire that would hide a later missing read.
+    with pytest.raises(MissingGreenlet):
+        job.source_filename
+
+    await test_db_session.execute(
+        IngestJob.__table__.delete().where(IngestJob.id == identifiers["id"])
+    )
+    await test_db_session.commit()

--- a/backend/tests/test_commit_attempted_marker_doors.py
+++ b/backend/tests/test_commit_attempted_marker_doors.py
@@ -27,6 +27,9 @@ import ast
 import pathlib
 
 import pytest
+from sqlalchemy.exc import OperationalError, PendingRollbackError
+
+from app.platform.jobs.sweep import is_abandoned_upload
 
 BACKEND_ROOT = pathlib.Path(__file__).resolve().parents[1]
 APP_ROOT = BACKEND_ROOT / "app"
@@ -210,3 +213,147 @@ async def test_the_stamp_is_committed_not_left_on_the_session() -> None:
     await stamp_commit_attempted(job, db=_Session())
     assert job.user_metadata[COMMIT_ATTEMPTED_METADATA_KEY] == first
     assert len(executed) == 1, "the second dispatch rewrote a marker it should keep"
+
+
+class _FailedTransactionSession:
+    """A session that behaves like SQLAlchemy after a statement has failed.
+
+    Once the marker commit raises, every later ``execute`` raises
+    ``PendingRollbackError`` until ``rollback`` is awaited. That is the real
+    constraint the fix is about: SQLAlchemy will not run another statement on
+    a session whose transaction failed, so the orphan settlement is only
+    reachable after a reset.
+    """
+
+    def __init__(self) -> None:
+        self.events: list[str] = []
+        self.broken = False
+        self._commits = 0
+
+    async def execute(self, statement=None):
+        self.events.append("execute")
+        if self.broken:
+            raise PendingRollbackError(
+                "This Session's transaction has been rolled back due to a "
+                "previous exception during flush."
+            )
+        return None
+
+    async def commit(self):
+        self.events.append("commit")
+        self._commits += 1
+        if self._commits == 1:
+            self.broken = True
+            raise OperationalError(
+                "UPDATE catalog.ingest_jobs",
+                None,
+                Exception("deadlock detected"),
+            )
+
+    async def rollback(self):
+        self.events.append("rollback")
+        self.broken = False
+
+
+@pytest.mark.anyio
+async def test_a_failed_marker_write_resets_the_session_before_settling() -> None:
+    """fix(#1774 review, codex P2): the settlement needs a usable session.
+
+    A serialization failure or deadlock on the marker write leaves the session
+    in a failed transaction. Handing it straight to the rollback closure makes
+    `settle_ingest_job_failed` raise as well, and the job stays `pending` with
+    no marker, which is the exact combination the stale sweep reads as an
+    upload nobody committed. It would then cancel a dispatch that really was
+    attempted and take away its retry.
+
+    So: reset first, settle second, and the row ends up `failed`, which keeps
+    it out of the sweep's pending class altogether.
+    """
+    import uuid
+    from types import SimpleNamespace
+
+    from app.platform.jobs.defer_guard import DeferFailed, defer_with_orphan_guard
+
+    session = _FailedTransactionSession()
+
+    # Positive control: the double really does refuse work until it is reset,
+    # so the ordering assertion below cannot pass vacuously.
+    control = _FailedTransactionSession()
+    with pytest.raises(OperationalError):
+        await control.commit()
+    with pytest.raises(PendingRollbackError):
+        await control.execute()
+    await control.rollback()
+    await control.execute()
+
+    job = SimpleNamespace(id=uuid.uuid4(), user_metadata=None, status="pending")
+
+    async def _settle(exc: BaseException) -> None:
+        # Stands in for `settle_ingest_job_failed`: a statement on the same
+        # session, which is what a failed transaction would reject.
+        await session.execute()
+        job.status = "failed"
+
+    async def _defer() -> None:  # pragma: no cover - never reached
+        raise AssertionError("the dispatch ran despite an unwritten marker")
+
+    with pytest.raises(DeferFailed) as exc_info:
+        await defer_with_orphan_guard(_defer, rollback=_settle, db=session, job=job)
+
+    assert exc_info.value.status_code == 503
+    assert exc_info.value.rolled_back, (
+        "the orphan settlement did not land, so the row is still pending"
+    )
+    assert isinstance(exc_info.value.__cause__, OperationalError)
+
+    # execute+commit for the marker, then the reset, then the settlement.
+    assert session.events == ["execute", "commit", "rollback", "execute", "commit"]
+    assert session.events.index("rollback") < session.events.index(
+        "execute", session.events.index("rollback")
+    ), "the settlement ran on a session that had not been reset"
+
+    assert job.status == "failed", (
+        "the job stayed pending, so the stale sweep would later read it as an "
+        "abandoned upload and cancel it"
+    )
+    # The marker never landed, so `pending` is precisely the state that would
+    # have been misread. Being terminal is what keeps the row out of the
+    # sweep's pending class.
+    assert is_abandoned_upload(job.user_metadata), (
+        "the marker is expected NOT to have landed; if it did, this test is "
+        "no longer exercising the failure it was written for"
+    )
+
+
+@pytest.mark.anyio
+async def test_a_marker_write_that_succeeds_leaves_the_session_alone() -> None:
+    """The counterweight: no reset on the path where nothing failed.
+
+    A rollback on the happy path would discard whatever the caller had staged
+    after its own commit, so the reset has to belong to the failure branch and
+    only to it.
+    """
+    import uuid
+    from types import SimpleNamespace
+
+    from app.platform.jobs.defer_guard import defer_with_orphan_guard
+
+    class _HealthySession(_FailedTransactionSession):
+        async def commit(self):
+            self.events.append("commit")
+
+    session = _HealthySession()
+    job = SimpleNamespace(id=uuid.uuid4(), user_metadata=None, status="pending")
+    deferred: list[bool] = []
+
+    async def _defer() -> None:
+        deferred.append(True)
+
+    async def _rollback(exc: BaseException) -> None:  # pragma: no cover
+        raise AssertionError("rollback ran on a successful dispatch")
+
+    await defer_with_orphan_guard(_defer, rollback=_rollback, db=session, job=job)
+
+    assert deferred == [True]
+    assert "rollback" not in session.events
+    assert session.events == ["execute", "commit"]

--- a/backend/tests/test_defer_orphan_guard.py
+++ b/backend/tests/test_defer_orphan_guard.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 import asyncio
 import uuid
 from contextlib import asynccontextmanager
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -37,11 +38,28 @@ from fastapi import HTTPException
 # ---------------------------------------------------------------------------
 
 
+def _job():
+    """A row shaped enough for the #1744 dispatch stamp.
+
+    `stamp_commit_attempted` reads `user_metadata`, writes an UPDATE keyed on
+    `id` and mirrors the result back, so a plain namespace is representative;
+    a MagicMock is not, because its `user_metadata` is a Mock rather than a
+    mapping.
+    """
+    return SimpleNamespace(id=uuid.uuid4(), user_metadata=None)
+
+
 class TestDeferWithOrphanGuard:
     """Unit tests for the generic ``defer_with_orphan_guard`` helper."""
 
     def test_success_path_does_not_invoke_rollback(self):
-        """On a successful defer, rollback must not run and db.commit stays untouched."""
+        """On a successful defer, rollback must not run.
+
+        fix(#1744): the guard now commits once on this path, stamping
+        `commit_attempted_at` on the row before the task exists, so the count
+        is one rather than none. Any commit beyond that is the rollback's, and
+        the rollback did not run.
+        """
 
         async def _check():
             from app.platform.jobs.defer_guard import defer_with_orphan_guard
@@ -58,11 +76,13 @@ class TestDeferWithOrphanGuard:
             async def _rollback(exc: BaseException) -> None:
                 rollback_called.append(exc)
 
-            await defer_with_orphan_guard(_defer, rollback=_rollback, db=mock_db)
+            await defer_with_orphan_guard(
+                _defer, rollback=_rollback, db=mock_db, job=_job()
+            )
 
             assert defer_called == [True]
             assert rollback_called == []
-            mock_db.commit.assert_not_called()
+            mock_db.commit.assert_awaited_once()
 
         asyncio.run(_check())
 
@@ -84,7 +104,9 @@ class TestDeferWithOrphanGuard:
                 received_exc.append(exc)
 
             with pytest.raises(HTTPException) as exc_info:
-                await defer_with_orphan_guard(_defer, rollback=_rollback, db=mock_db)
+                await defer_with_orphan_guard(
+                    _defer, rollback=_rollback, db=mock_db, job=_job()
+                )
 
             assert exc_info.value.status_code == 503
             assert "retry" in str(exc_info.value.detail).lower()
@@ -92,8 +114,8 @@ class TestDeferWithOrphanGuard:
             assert len(received_exc) == 1
             assert isinstance(received_exc[0], RuntimeError)
             assert "procrastinate unreachable" in str(received_exc[0])
-            # Helper committed the rollback before raising
-            mock_db.commit.assert_awaited_once()
+            # Two commits: the #1744 dispatch stamp, then the rollback.
+            assert mock_db.commit.await_count == 2
 
         asyncio.run(_check())
 
@@ -113,7 +135,9 @@ class TestDeferWithOrphanGuard:
                 raise ValueError("rollback crashed")
 
             with pytest.raises(HTTPException) as exc_info:
-                await defer_with_orphan_guard(_defer, rollback=_rollback, db=mock_db)
+                await defer_with_orphan_guard(
+                    _defer, rollback=_rollback, db=mock_db, job=_job()
+                )
 
             # 503 is always raised — rollback failure is logged, not swallowed.
             assert exc_info.value.status_code == 503

--- a/backend/tests/test_embedding_backfill_queue_1542.py
+++ b/backend/tests/test_embedding_backfill_queue_1542.py
@@ -39,6 +39,7 @@ from app.platform.jobs.models import (
     ACTIVE_BACKFILL_INDEX_NAME,
     EMBEDDING_BACKFILL_METADATA_KEY,
     IngestJob,
+    commit_attempted_marker,
 )
 from app.processing.embeddings import backfill as backfill_module
 from app.processing.embeddings.models import RecordEmbedding
@@ -135,15 +136,21 @@ async def _stale_job(
         created_at=old,
         started_at=old if status == "running" else None,
         heartbeat_at=old if status == "running" else None,
+        # fix(#1744): both rows describe work that was dispatched and then
+        # orphaned, which is the class this sweep settles `failed`. Without
+        # the stamp the pending half reads them as uploads nobody committed
+        # and cancels them, and the non-vacuity assertions below would be
+        # measuring a different pass.
         user_metadata=(
             {
+                **commit_attempted_marker(),
                 EMBEDDING_BACKFILL_METADATA_KEY: {
                     "force": True,
                     "operation_id": f"sweep-pin-{uuid.uuid4().hex[:8]}",
-                }
+                },
             }
             if backfill
-            else {"file_type": "vector"}
+            else {"file_type": "vector", **commit_attempted_marker()}
         ),
     )
     session.add(job)

--- a/backend/tests/test_ingest.py
+++ b/backend/tests/test_ingest.py
@@ -17,7 +17,7 @@ from httpx import AsyncClient
 from sqlalchemy import select
 
 from app.modules.auth.models import User
-from app.platform.jobs.models import IngestJob
+from app.platform.jobs.models import IngestJob, commit_attempted_marker
 from tests.conftest import get_auth_header
 
 
@@ -414,6 +414,11 @@ class TestJobStatus:
             file_path="/tmp/fake.geojson",
             created_by=admin_user.id,
             status="pending",
+            # fix(#1744): a dispatch was attempted for this row and never
+            # landed, which is the class that keeps reporting `failed` so
+            # /jobs/{id}/retry stays reachable. Without the stamp the row is
+            # an upload nobody committed, and the poll cancels it.
+            user_metadata=commit_attempted_marker(),
         )
         test_db_session.add(job)
         await test_db_session.commit()
@@ -454,6 +459,10 @@ class TestJobCleanup:
             source_filename="stale.geojson",
             created_by=admin_user.id,
             status="pending",
+            # fix(#1744): see the poll test above. `pending_failed` is the
+            # count this asserts, and an unstamped row lands in
+            # `pending_cancelled` instead.
+            user_metadata=commit_attempted_marker(),
         )
         test_db_session.add(stale_job)
         await test_db_session.commit()

--- a/backend/tests/test_ingest_fan_out.py
+++ b/backend/tests/test_ingest_fan_out.py
@@ -39,7 +39,7 @@ from app.processing.ingest.service import _user_safe_error
 def mock_defer_guard():
     """Prevent Procrastinate task deferral in all fan-out tests."""
 
-    async def _noop(fn, rollback=None, db=None):
+    async def _noop(fn, rollback=None, db=None, job=None):
         # Do NOT call fn() — that would attempt ingest_file.defer_async
         # against a real Procrastinate queue.
         pass

--- a/backend/tests/test_job_cancel_fan_out.py
+++ b/backend/tests/test_job_cancel_fan_out.py
@@ -53,7 +53,7 @@ def mock_defer_guard():
     inside create_fan_out_jobs, so the source module is patched.
     """
 
-    async def _noop(fn, rollback=None, db=None):
+    async def _noop(fn, rollback=None, db=None, job=None):
         pass
 
     with patch(
@@ -268,7 +268,7 @@ class TestAllLayersFailed:
         without a re-upload — and a cancel afterwards works normally."""
         job = await _make_pending_parent(test_db_session, layers=["buildings"])
 
-        async def _raise(fn, rollback=None, db=None):
+        async def _raise(fn, rollback=None, db=None, job=None):
             raise RuntimeError("queue down")
 
         with patch(
@@ -541,6 +541,13 @@ class TestNeverQueuedChildRecovery:
                 "layer_name": "roads",
                 "title": "multi: roads",
                 "fan_out_parent_id": str(parent.id),
+                # fix(#1744): `create_fan_out_jobs` puts this in the metadata
+                # it commits for the child, precisely so a crash in the gap
+                # between that commit and the dispatch still leaves a row the
+                # stale sweep settles `failed` rather than `cancelled`. Retry
+                # is the only way to re-run THIS layer, so the child has to
+                # survive that window as a retryable row.
+                "commit_attempted_at": "2026-09-01T12:00:00+00:00",
             },
         )
         test_db_session.add(child)
@@ -559,7 +566,7 @@ class TestNeverQueuedChildRecovery:
         can_retry, reason = await get_retry_capability(child)
         assert can_retry is True, reason
 
-        async def _noop(fn, rollback=None, db=None):
+        async def _noop(fn, rollback=None, db=None, job=None):
             pass
 
         with patch(

--- a/backend/tests/test_job_cancel_reupload_commit.py
+++ b/backend/tests/test_job_cancel_reupload_commit.py
@@ -165,7 +165,7 @@ class TestCommitWinsThenCancel:
         transaction — no stranded reservation on this side either."""
         dataset, job = await _seed_committable_reupload(test_db_session)
 
-        async def _noop(fn, rollback=None, db=None):
+        async def _noop(fn, rollback=None, db=None, job=None):
             pass
 
         with patch(

--- a/backend/tests/test_jobs_router.py
+++ b/backend/tests/test_jobs_router.py
@@ -12,7 +12,7 @@ from sqlalchemy import text
 if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.platform.jobs.models import IngestJob
+from app.platform.jobs.models import IngestJob, commit_attempted_marker
 
 from tests.factories import get_user_id
 
@@ -309,6 +309,10 @@ class TestGetJobStatus:
             test_db_session,
             created_by=admin_id,
             status="pending",
+            # fix(#1744): the row this test is about is one whose dispatch was
+            # attempted and never landed. An unstamped pending row is an
+            # upload nobody committed, which the poll settles `cancelled`.
+            user_metadata=commit_attempted_marker(),
         )
         # Backdate created_at to 2 hours ago
         await test_db_session.execute(

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -3259,7 +3259,19 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # `fail_stale_jobs`, because that runs once per TENANT in hosted mode and
     # the queue table has no tenant column — the docstring carries that and
     # the why-no-index note. Cap 1792 -> 1827, exact.
-    "backend/app/platform/jobs/sweep.py": 1827,
+    # fix(#1744): +30. `abandoned_presigned_upload` became `abandoned_upload`,
+    # which asks the row whether a dispatch was ever attempted
+    # (`commit_attempted_at`) instead of inferring it from an empty
+    # `file_path` plus a `presigned` marker. Almost all of the lines are the
+    # docstring: why the shape-based carve-out missed the door the demo
+    # actually uses (a direct upload binds an absolute staging path and stamps
+    # no `presigned` marker, so four abandoned uploads reported `failed` with
+    # "never queued"), why the absolute-path class no longer needs a branch of
+    # its own, and why rows predating the stamp reclassify rather than get a
+    # migration, plus the two residual gaps it records (the one-statement
+    # window between a door's own commit and the stamp, and S3-mode direct
+    # uploads landing in the bound half). Cap 1827 -> 1857, exact.
+    "backend/app/platform/jobs/sweep.py": 1857,
     # fix(#1709 review r8 B): first entry — crossed the 1000-line inclusion
     # threshold at 1010 when refresh.cancelled attribution was corrected to
     # name the CANCELLING user (cancel_active_run_for_job and
@@ -3904,7 +3916,16 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # D2). Most of the lines are the docstring paragraph recording that, and
     # why an unsupported method is refused here rather than dispatched as an
     # anonymous fetch. Cap 1450 -> 1465, exact.
-    "backend/app/processing/ingest/service.py": 1465,
+    # fix(#1744): +17. One `job=` argument at each of this module's five
+    # `defer_with_orphan_guard` call sites, so the guard can stamp
+    # `commit_attempted_at` on the row before the task exists. The kwarg is
+    # required rather than optional precisely so a new dispatch site cannot be
+    # written past it, plus `create_fan_out_jobs` putting the same stamp in
+    # the metadata it commits for each child: that door runs inside a worker
+    # task and its child cannot be recreated by repeating a user action, so it
+    # is the one place the commit-to-dispatch window is worth closing
+    # outright. Cap 1465 -> 1482, exact.
+    "backend/app/processing/ingest/service.py": 1482,
     # --- entered by the inclusion rule, feat(#765) -------------------------
     # First time this module crosses 1000. main sat at 994, six lines under the
     # gate, so it was going to fire on whoever added next; it fired here.

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -3925,7 +3925,13 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # task and its child cannot be recreated by repeating a user action, so it
     # is the one place the commit-to-dispatch window is worth closing
     # outright. Cap 1465 -> 1482, exact.
-    "backend/app/processing/ingest/service.py": 1482,
+    # fix(#1774 review, codex P2): +18. `create_fan_out_jobs` resets the
+    # session in its per-layer failure handler. That commit now carries the
+    # child's dispatch marker as well as its row, and a transactional failure
+    # there left the session refusing every later statement, so one layer's
+    # deadlock failed every sibling and stranded the parent `fanned_out` with
+    # no child importing. Cap 1482 -> 1500, exact.
+    "backend/app/processing/ingest/service.py": 1500,
     # --- entered by the inclusion rule, feat(#765) -------------------------
     # First time this module crosses 1000. main sat at 994, six lines under the
     # gate, so it was going to fire on whoever added next; it fired here.

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -3931,7 +3931,13 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # there left the session refusing every later statement, so one layer's
     # deadlock failed every sibling and stranded the parent `fanned_out` with
     # no child importing. Cap 1482 -> 1500, exact.
-    "backend/app/processing/ingest/service.py": 1500,
+    # fix(#1774 review r2, codex P2): +13. That reset expires the parent, and
+    # both the next layer and `restore_fan_out_parent_pending` read attributes
+    # off the same instance, so a synchronous read would raise MissingGreenlet
+    # and turn one layer's failure into a 500. The parent is reloaded in the
+    # same breath, and the log line reads a snapshotted id rather than the
+    # instance it just expired. Cap 1500 -> 1513, exact.
+    "backend/app/processing/ingest/service.py": 1513,
     # --- entered by the inclusion rule, feat(#765) -------------------------
     # First time this module crosses 1000. main sat at 994, six lines under the
     # gate, so it was going to fire on whoever added next; it fired here.

--- a/backend/tests/test_stale_pending_reaper.py
+++ b/backend/tests/test_stale_pending_reaper.py
@@ -46,12 +46,37 @@ def _user(user_id: uuid.UUID) -> SimpleNamespace:
     return SimpleNamespace(id=user_id)
 
 
+def _dispatched_metadata() -> dict:
+    """The `user_metadata` a row carries once a dispatch has been attempted.
+
+    fix(#1744): `defer_with_orphan_guard` stamps `commit_attempted_at` before
+    every defer, so a row that reached the queue at all has this key. Its
+    absence is now what makes the sweep read a row as an abandoned upload, so
+    a fixture describing "the defer never landed" has to carry it or it
+    describes something else.
+    """
+    from app.platform.jobs.models import COMMIT_ATTEMPTED_METADATA_KEY
+
+    return {COMMIT_ATTEMPTED_METADATA_KEY: datetime.now(timezone.utc).isoformat()}
+
+
 async def _stale_pending_job(
-    session: AsyncSession, created_by: uuid.UUID | None = None
+    session: AsyncSession,
+    created_by: uuid.UUID | None = None,
+    *,
+    commit_attempted: bool = True,
 ) -> IngestJob:
-    """A pending job old enough for the reaper to consider it."""
+    """A pending job old enough for the reaper to consider it.
+
+    Dispatch-attempted by default: every test in this class is about the
+    live-queue predicate, and the row it reasons about is one whose task was
+    deferred (or whose defer died), not an upload nobody committed.
+    """
     job = IngestJob(
-        source_filename="reaper-test", status="pending", created_by=created_by
+        source_filename="reaper-test",
+        status="pending",
+        created_by=created_by,
+        user_metadata=_dispatched_metadata() if commit_attempted else {},
     )
     session.add(job)
     await session.flush()
@@ -192,12 +217,17 @@ async def _make_pending_job(
     file_path: str,
     presigned: bool = True,
     source_url: str | None = None,
+    commit_attempted: bool = False,
 ):
     """A pending job aged past a cutoff, with file_path as given.
 
     fix(#1556): `presigned` is now a parameter because it discriminates two
     classes that both reach the unbound half. Default True keeps every existing
     caller describing the presigned upload it already described.
+
+    fix(#1744): `commit_attempted` is what discriminates them now. Default
+    False, because the rows these fixtures describe are mostly ones nobody
+    dispatched; a caller that means "the defer never landed" passes True.
     """
     from datetime import datetime, timedelta, timezone
 
@@ -215,7 +245,10 @@ async def _make_pending_job(
         status="pending",
         file_path=file_path,
         source_url=source_url,
-        user_metadata={"presigned": True} if presigned else {},
+        user_metadata={
+            **({"presigned": True} if presigned else {}),
+            **(_dispatched_metadata() if commit_attempted else {}),
+        },
     )
     session.add(job)
     await session.commit()
@@ -240,7 +273,12 @@ class TestBoundPendingSweep:
 
     @staticmethod
     async def _make_job(
-        session, *, age_seconds: int, file_path: str, presigned: bool = True
+        session,
+        *,
+        age_seconds: int,
+        file_path: str,
+        presigned: bool = True,
+        commit_attempted: bool = False,
     ):
         from datetime import datetime, timedelta, timezone
 
@@ -257,7 +295,10 @@ class TestBoundPendingSweep:
             created_by=admin.id,
             status="pending",
             file_path=file_path,
-            user_metadata={"presigned": True} if presigned else {},
+            user_metadata={
+                **({"presigned": True} if presigned else {}),
+                **(_dispatched_metadata() if commit_attempted else {}),
+            },
         )
         session.add(job)
         await session.commit()
@@ -314,11 +355,19 @@ class TestBoundPendingSweep:
     ) -> None:
         """The other side of the same fork: an analysis run or an embedding
         backfill also carries `file_path=""`, and a dispatch that never landed
-        is a real failure of something the user asked for."""
+        is a real failure of something the user asked for.
+
+        fix(#1744): the row says so itself now. Both of those doors reach the
+        queue through the guard that stamps `commit_attempted_at`, so a defer
+        that died still leaves the stamp behind."""
         from app.platform.jobs.router import fail_stale_jobs
 
         job = await self._make_job(
-            test_db_session, age_seconds=7200, file_path="", presigned=False
+            test_db_session,
+            age_seconds=7200,
+            file_path="",
+            presigned=False,
+            commit_attempted=True,
         )
 
         await fail_stale_jobs(test_db_session)
@@ -334,7 +383,10 @@ class TestBoundPendingSweep:
         from app.platform.jobs.router import fail_stale_jobs
 
         job = await self._make_job(
-            test_db_session, age_seconds=7200, file_path="/tmp/fake.geojson"
+            test_db_session,
+            age_seconds=7200,
+            file_path="/tmp/fake.geojson",
+            commit_attempted=True,
         )
 
         await fail_stale_jobs(test_db_session)
@@ -465,7 +517,11 @@ class TestPollingPathHonoursTheSameGuard:
         """The poll keeps its own elapsed-seconds wording for everything that
         is not an abandoned upload."""
         job = await _make_pending_job(
-            test_db_session, age_seconds=7200, file_path="", presigned=False
+            test_db_session,
+            age_seconds=7200,
+            file_path="",
+            presigned=False,
+            commit_attempted=True,
         )
 
         resp = await self._poll(client, admin_auth_header, job.id)
@@ -488,7 +544,10 @@ class TestPollingPathHonoursTheSameGuard:
         24h-to-recoverable on a real path.
         """
         job = await _make_pending_job(
-            test_db_session, age_seconds=7200, file_path="/tmp/fake.geojson"
+            test_db_session,
+            age_seconds=7200,
+            file_path="/tmp/fake.geojson",
+            commit_attempted=True,
         )
 
         resp = await self._poll(client, admin_auth_header, job.id)
@@ -561,6 +620,7 @@ class TestAbandonedUploadsAreCancelled:
             file_path="",
             presigned=False,
             source_url="https://example.test/roads.geojson",
+            commit_attempted=True,
         )
 
         await fail_stale_jobs(test_db_session)
@@ -575,11 +635,18 @@ class TestAbandonedUploadsAreCancelled:
         self, test_db_session
     ) -> None:
         """#1235's absolute-path class, unchanged: a real file exists and
-        retry matters, so the row must stay `failed`."""
+        retry matters, so the row must stay `failed`.
+
+        fix(#1744): what keeps it failed is the stamp, not the path. The same
+        absolute path with no stamp is an upload nobody committed, which the
+        test below covers."""
         from app.platform.jobs.router import fail_stale_jobs
 
         job = await _make_pending_job(
-            test_db_session, age_seconds=7200, file_path="/tmp/fake.geojson"
+            test_db_session,
+            age_seconds=7200,
+            file_path="/tmp/fake.geojson",
+            commit_attempted=True,
         )
 
         await fail_stale_jobs(test_db_session)
@@ -642,7 +709,11 @@ class TestAbandonedUploadsAreCancelled:
             test_db_session, age_seconds=7200, file_path=""
         )
         dispatched = await _make_pending_job(
-            test_db_session, age_seconds=7200, file_path="", presigned=False
+            test_db_session,
+            age_seconds=7200,
+            file_path="",
+            presigned=False,
+            commit_attempted=True,
         )
 
         await recover_stale_jobs()
@@ -679,7 +750,11 @@ class TestAbandonedUploadsAreCancelled:
 
         await _make_pending_job(test_db_session, age_seconds=7200, file_path="")
         await _make_pending_job(
-            test_db_session, age_seconds=7200, file_path="", presigned=False
+            test_db_session,
+            age_seconds=7200,
+            file_path="",
+            presigned=False,
+            commit_attempted=True,
         )
 
         outcome = await fail_stale_jobs(test_db_session, detailed=True)
@@ -712,27 +787,38 @@ class TestAbandonedUploadsAreCancelled:
         assert "cancelled" in exc.value.detail.lower()
 
     @pytest.mark.parametrize(
-        "file_path,user_metadata,abandoned",
+        "user_metadata,abandoned",
         [
-            ("", {"presigned": True}, True),
-            (None, {"presigned": True}, True),
-            ("", {}, False),
-            ("", None, False),
-            ("", {"analysis": True}, False),
-            ("", {"embedding_backfill": {}}, False),
-            ("/tmp/fake.geojson", {"presigned": True}, False),
-            ("staging/x/frozen/roads.geojson", {"presigned": True}, False),
+            ({"presigned": True}, True),
+            ({}, True),
+            (None, True),
+            ({"analysis": True}, True),
+            ({"commit_attempted_at": "2026-09-01T12:00:00+00:00"}, False),
+            ({"presigned": True, "commit_attempted_at": "2026-09-01T12:00:00Z"}, False),
+            (
+                {"embedding_backfill": {}, "commit_attempted_at": "2026-09-01T12:00Z"},
+                False,
+            ),
+            ({"commit_attempted_at": ""}, True),
+            ({"commit_attempted_at": None}, True),
         ],
     )
     def test_the_python_twin_agrees_with_the_sql_predicate(
-        self, file_path, user_metadata, abandoned
+        self, user_metadata, abandoned
     ) -> None:
         """The worker mirrors the UPDATE onto ORM instances, so the two
         expressions of one rule must not drift. Enumerated over every shape a
-        pending row can carry, not just the reported one."""
-        from app.platform.jobs.router import is_abandoned_presigned_upload
+        pending row can carry, not just the reported one.
 
-        assert is_abandoned_presigned_upload(file_path, user_metadata) is abandoned
+        fix(#1744): the shapes that matter are now what the metadata says,
+        not what `file_path` looks like, so the empty and absent stamps are
+        enumerated alongside the present one. Both expressions coalesce a
+        missing or empty value to "no dispatch was attempted", which is the
+        conservative reading for a row that never got a real timestamp.
+        """
+        from app.platform.jobs.router import is_abandoned_upload
+
+        assert is_abandoned_upload(user_metadata) is abandoned
 
 
 def test_the_published_cleanup_response_drops_the_new_count_without_raising() -> None:
@@ -1033,3 +1119,158 @@ class TestThePollPathSkipsUpdatesItCannotMatch:
         assert self._updates(statements), "the stale job was never updated"
         await test_db_session.refresh(job)
         assert job.status == "cancelled"
+
+
+class TestAbandonedDirectUploadsAreCancelled:
+    """fix(#1744): the door #1556 did not reach.
+
+    `POST /ingest/upload` says it in its own docstring: it stages the file and
+    does NOT auto-queue, so a `pending` row with no Procrastinate job is the
+    normal state between upload and commit. When the owner walks away at the
+    preview step, the row settles at the pending timeout as `failed` with
+    "never queued", pointing at a queue that is working correctly.
+
+    #1556 fixed exactly this reasoning for the presign doors, but keyed the
+    carve-out to the `presigned` marker plus an empty `file_path`. A direct
+    upload binds an absolute staging path and stamps no such marker, so it
+    matched neither half: on the demo, four of six failed jobs were abandoned
+    direct uploads by three different users over two weeks, and zero were
+    broken commits.
+
+    The split is now the stamp `defer_with_orphan_guard` writes, so the two
+    classes are told apart by whether a dispatch was attempted rather than by
+    the shape of a path they can both carry.
+    """
+
+    async def test_the_sweep_cancels_an_abandoned_direct_upload(
+        self, test_db_session
+    ) -> None:
+        from app.platform.jobs.router import fail_stale_jobs
+
+        job = await _make_pending_job(
+            test_db_session,
+            age_seconds=7200,
+            file_path="/app/staging/abc_uls.csv",
+            presigned=False,
+        )
+
+        await fail_stale_jobs(test_db_session)
+
+        await test_db_session.refresh(job)
+        assert job.status == "cancelled", (
+            "an upload nobody ever committed is still reported as a failed "
+            "ingest, which is what inflates the admin failed-jobs badge"
+        )
+        assert job.error_message == "Abandoned: upload was never completed"
+        assert job.completed_at is not None
+
+    async def test_a_poll_cancels_an_abandoned_direct_upload(
+        self, client, admin_auth_header, test_db_session
+    ) -> None:
+        """The second site, and the one that usually gets there first: the
+        frontend polls this route every 2s for any job it is tracking."""
+        job = await _make_pending_job(
+            test_db_session,
+            age_seconds=7200,
+            file_path="/app/staging/abc_uls.csv",
+            presigned=False,
+        )
+
+        resp = await client.get(f"/jobs/{job.id}", headers=admin_auth_header)
+
+        assert resp.status_code == 200, resp.text
+        await test_db_session.refresh(job)
+        assert job.status == "cancelled"
+        assert job.error_message == "Abandoned: upload was never completed"
+
+    async def test_the_worker_startup_recovery_cancels_it_too(
+        self, test_db_session
+    ) -> None:
+        """The third site. After a hard restart it is the pass that reaches the
+        row, and once it has made the row terminal no later sweep looks at it
+        again."""
+        from app.platform.jobs.worker import recover_stale_jobs
+
+        job = await _make_pending_job(
+            test_db_session,
+            age_seconds=7200,
+            file_path="/app/staging/abc_uls.csv",
+            presigned=False,
+        )
+
+        await recover_stale_jobs()
+
+        test_db_session.expire_all()
+        await test_db_session.refresh(job)
+        assert job.status == "cancelled"
+        assert job.error_message == "Abandoned: upload was never completed"
+
+    @pytest.mark.parametrize("site", ["sweep", "poll", "recovery"])
+    async def test_a_dispatched_direct_upload_stays_failed_and_retryable(
+        self, client, admin_auth_header, test_db_session, tmp_path, site
+    ) -> None:
+        """The class the split exists to protect, at all three sites.
+
+        A commit whose dispatch died leaves the same absolute path on the same
+        `pending` row. It must keep reporting `failed`, because that is the
+        only status `/jobs/{id}/retry` accepts, and cancelling it would take a
+        recoverable job's only recovery path away (the trap #1235 avoided).
+
+        The staged file is real because `_retry_capability` reads it: a
+        `failed` status alone is not the retry affordance, it is half of it.
+        """
+        from app.platform.jobs.router import fail_stale_jobs, get_retry_capability
+        from app.platform.jobs.worker import recover_stale_jobs
+
+        staged = tmp_path / "abc_uls.csv"
+        staged.write_text("id,name\n1,a\n", encoding="utf-8")
+        job = await _make_pending_job(
+            test_db_session,
+            age_seconds=7200,
+            file_path=str(staged),
+            presigned=False,
+            commit_attempted=True,
+        )
+
+        if site == "sweep":
+            await fail_stale_jobs(test_db_session)
+        elif site == "poll":
+            resp = await client.get(f"/jobs/{job.id}", headers=admin_auth_header)
+            assert resp.status_code == 200, resp.text
+        else:
+            await recover_stale_jobs()
+            test_db_session.expire_all()
+
+        await test_db_session.refresh(job)
+        assert job.status == "failed", (
+            "a commit whose dispatch died was reported as an abandoned upload"
+        )
+        message = job.error_message or ""
+        assert "never queued" in message or "without being processed" in message
+        can_retry, reason = await get_retry_capability(job)
+        assert can_retry, f"the retry path was lost: {reason}"
+
+    async def test_the_stamp_survives_the_settlement_a_retry_reads(
+        self, test_db_session
+    ) -> None:
+        """`/jobs/{id}/retry` resets the row to `pending` and re-queues it
+        through the same guard, and neither it nor the sweep clears metadata.
+        If the stamp did not survive being settled, a retry whose dispatch also
+        died would come back as a cancellation on the second pass and lose the
+        retry affordance the first pass kept.
+        """
+        from app.platform.jobs.models import COMMIT_ATTEMPTED_METADATA_KEY
+        from app.platform.jobs.router import fail_stale_jobs
+
+        job = await _make_pending_job(
+            test_db_session,
+            age_seconds=7200,
+            file_path="/app/staging/abc_uls.csv",
+            presigned=False,
+            commit_attempted=True,
+        )
+
+        await fail_stale_jobs(test_db_session)
+        await test_db_session.refresh(job)
+        assert job.status == "failed"
+        assert (job.user_metadata or {}).get(COMMIT_ATTEMPTED_METADATA_KEY)

--- a/backend/tests/test_vrt_creation_173.py
+++ b/backend/tests/test_vrt_creation_173.py
@@ -660,9 +660,11 @@ class TestCreateVrtJob:
             assert stub_job.error_message is not None
             assert "procrastinate unreachable" in stub_job.error_message
             assert stub_job.completed_at is not None
-            # Two commits: one after create_ingest_job, one after flipping
-            # the job to failed. Verifies the failed state is durable.
-            assert mock_db.commit.await_count == 2
+            # Three commits: one after create_ingest_job, one for the #1744
+            # dispatch stamp the orphan guard writes before it defers, and one
+            # after flipping the job to failed. Verifies the failed state is
+            # durable.
+            assert mock_db.commit.await_count == 3
 
         asyncio.run(_check())
 

--- a/backend/tests/test_worker.py
+++ b/backend/tests/test_worker.py
@@ -6,6 +6,8 @@ from uuid import uuid4
 import pytest
 from httpx import ASGITransport, AsyncClient
 
+from app.platform.jobs.models import commit_attempted_marker
+
 # ---------------------------------------------------------------------------
 # Worker health app tests
 # ---------------------------------------------------------------------------
@@ -176,7 +178,14 @@ async def test_recover_stale_jobs_marks_orphaned_pending_as_failed():
     fake_job.status = "pending"
     fake_job.error_message = None
     fake_job.completed_at = None
-    fake_job.user_metadata = {"file_type": "vector"}  # see #1556 note above
+    # fix(#1744): a dispatch was attempted for this row and never landed, which
+    # is what keeps recovery reporting `failed` so /jobs/{id}/retry stays
+    # reachable. Without the stamp the double stands for an upload nobody
+    # committed, and recovery settles it `cancelled`.
+    fake_job.user_metadata = {
+        "file_type": "vector",  # see #1556 note above
+        **commit_attempted_marker(),
+    }
 
     # Two extra empty results for the GAP-002 VRT stale sweep.
     mock_session = _make_mock_session([], [fake_job], [], [], [])


### PR DESCRIPTION
Closes #1744.

## What changed

`POST /ingest/upload` stages a file and does not queue anything, so a `pending` row with no Procrastinate job is the normal state between upload and commit. When the owner walks away at the preview step, the pending sweep reaps that row as `failed` with "Stale: pending too long (never queued)". On the demo that put four abandoned direct uploads, from three users over two weeks, into the admin failed-jobs badge, with a message pointing at a queue that was working correctly.

#1556 fixed the same reasoning for the presign doors, but keyed the carve-out to an empty `file_path` plus a `presigned` marker. A direct upload binds an absolute staging path and stamps no marker, so it matched neither half.

The two states were only indistinguishable because the row carried no record of whether a dispatch had ever been attempted. Now it does:

- `defer_with_orphan_guard` stamps `user_metadata["commit_attempted_at"]` (ISO-8601 UTC) and commits it immediately before the defer.
- `abandoned_upload` in `jobs/sweep.py` reads its absence. Pending, unbound, aged, no live queue row, no stamp becomes `cancelled` with "Abandoned: upload was never completed". With the stamp it stays `failed` with the existing "never queued", so `/jobs/{id}/retry` remains reachable.
- `abandoned_presigned_upload` and its Python twin are gone. The new rule subsumes them: a presigned upload nobody bound bytes to was never dispatched either. The absolute-path carve-out the old docstring defended no longer needs a branch, because the shape of `file_path` was never what the two classes differed by.

All three settling sites still read the one predicate through `stale_pending_unbound_values`, untouched: the background sweep, the status poll and the worker's startup recovery.

## One stamping site, not one per door

`defer_with_orphan_guard` is the only route to the queue for an `IngestJob`: nothing calls `defer_async` with a `job_id` outside a closure the guard runs. The `job` argument is now required there, so a new dispatch site cannot be written past the stamp. The 17 call sites, one per dispatch branch:

| Module | Site |
| --- | --- |
| `processing/ingest/service.py` | `create_vrt_job` |
| `processing/ingest/service.py` | `create_fan_out_jobs` |
| `processing/ingest/service.py` | `queue_ingest_job`, service branch |
| `processing/ingest/service.py` | `queue_ingest_job`, raster branch |
| `processing/ingest/service.py` | `queue_ingest_job`, vector branch |
| `processing/ingest/router.py` | `add_vrt_source` |
| `processing/ingest/router.py` | `remove_vrt_source` |
| `processing/ingest/manifest_service.py` | `_queue_reupload_job` |
| `catalog/datasets/api/router_vrt.py` | `regenerate_vrt_endpoint` |
| `catalog/datasets/api/router_refresh.py` | `_dispatch_postgis_refresh` |
| `catalog/datasets/api/router_refresh.py` | `_dispatch_stac_refresh` |
| `catalog/datasets/api/router_refresh.py` | `refresh_dataset` |
| `catalog/datasets/api/router_reupload.py` | `_dispatch_reupload_task`, service branch |
| `catalog/datasets/api/router_reupload.py` | `_dispatch_reupload_task`, raster branch |
| `catalog/datasets/api/router_reupload.py` | `_dispatch_reupload_task`, file branch |
| `catalog/datasets/api/router_analysis.py` | `analysis_materialize_endpoint` |
| `modules/admin/router.py` | `trigger_backfill` |

`commit_import`, `/jobs/{id}/retry` and manifest apply reach the queue through `queue_ingest_job`, so they are covered by its three branches.

`tests/test_commit_attempted_marker_doors.py` walks the AST of `backend/app/` and pins this in both directions: no `defer_async_with_tenant(job_id=...)` call sits outside a function that runs the guard, every guard call names its row, the guard stamps before it defers, and the stamp commits.

## Accepted behaviour changes

Rows created before the stamp existed carry no stamp, so a pending unbound row that predates the deploy reclassifies as `cancelled`. That is the correct outcome for the abandoned uploads it will mostly be (the demo audit found four of those and zero broken commits) and the wrong one for a genuinely broken commit. Accepted rather than migrated: a migration would have to guess the same thing from the same missing fact.

## Noticed and recorded, not fixed here

- A door commits its row and then dispatches, so a process death in the one-statement gap between those leaves the row unstamped and it settles `cancelled` instead of `failed`. That window was unbounded before this change for the same class. `create_fan_out_jobs` closes it outright by putting the stamp in the metadata it commits, because it runs inside a worker task and its child cannot be recreated by repeating a user action: the layer selection lived in the fan-out request body and nowhere else (#1709 r8). Every other door creates its row inside a request the user can simply issue again.
- In S3 storage mode a direct upload binds `staging/{job}/{name}`, which is the BOUND half's business, so an abandoned S3 upload still settles `failed` after the 24h backstop with "Stale: upload completed but never committed". #1744's evidence and scope are the unbound half, and widening the bound half is a separate decision.

## Schema, API, config

None. `cancelled` is already in the `ingest_jobs` status CHECK constraint, in the admin `JobStatus` literal and in `openapi.json`. No migration, no new setting, nothing stored that was not stored before.

## Review round 1 (codex P2, session recovery)

A serialization failure or deadlock on the marker write leaves the `AsyncSession` in a failed transaction, and SQLAlchemy refuses every further statement on it until it is rolled back. The guard handed that session straight to the rollback closure, so `settle_ingest_job_failed` raised too and the job stayed `pending` with no marker: the exact combination the sweep reads as an abandoned upload. It would have cancelled a dispatch that really was attempted.

The stamp now has its own `try`. On failure the session is reset first, then the existing orphan settlement runs, then the usual `DeferFailed` goes out, so the caller's 503 path is unchanged. The settlement block is extracted into `_settle_after_failed_dispatch` so both failure points settle identically.

`create_fan_out_jobs` had the same ordering at its second stamping site: its per-layer commit now carries the child's marker as well as the row, and its exception handler returned without resetting the session, so one layer's transactional failure would fail every remaining layer and strand the parent `fanned_out` with no child importing. It resets too.

`test_a_failed_marker_write_resets_the_session_before_settling` drives a session double that refuses statements until rolled back (with a positive control proving the double is not vacuous) and asserts the reset precedes the settlement and the row ends `failed`. Counterfactual: deleting the `db.rollback()` makes that test fail with `PendingRollbackError`, verified locally.

## Review round 2 (codex P2 x2, rollback expiry)

`Session.rollback()` expires every instance that was in the failed transaction, and `expire_on_commit=False` does not change that: the flag only governs commit. The next synchronous read of an expired column attribute is a lazy load, and an `AsyncSession` has no greenlet to run one, so SQLAlchemy raises `MissingGreenlet`. Verified against SQLAlchemy 2.0.52 and a real session before writing either fix.

So the round 1 reset made the session usable and expired the state the settlement immediately needs. `settle_ingest_job_failed` reads `job.id` and `job.attempt_id` synchronously, and it is the one function every rollback closure in the codebase funnels through. The guard now snapshots those two before the marker write and puts them back after the reset through `set_committed_value`, which marks an attribute loaded with no query and without marking it dirty. A snapshot cannot fail; a reload is one more statement on a connection that has just misbehaved, so the snapshot is the guarantee and a best-effort `db.refresh(job)` covers whatever a caller-supplied closure reads beyond those two.

`create_fan_out_jobs` had the same problem from its own reset: the next layer reads `original_job.source_filename` and friends off that instance, and `restore_fan_out_parent_pending` reads `job.id`, so the reset meant to let the siblings continue would instead turn one layer's failure into a 500 and strand the parent `fanned_out`. It reloads the parent in the same breath. A reload rather than a snapshot there, because the attributes read downstream are spread across two functions and the response, and one SELECT restores all of them.

Tests: the session double now expires its instances on rollback and raises `MissingGreenlet` on a synchronous read until they are restored or reloaded, with a positive control proving the double is not vacuous. Three counterfactuals were run locally, each failing the intended test: dropping the restore and the reload together, dropping only the snapshot restore (caught by a DB-backed test that runs the real guard against a genuinely poisoned transaction with the reload disabled), and dropping the fan-out reload. A fourth test drives a real expired `IngestJob` and shows the restore making exactly the two identifiers readable again while everything else stays expired.

## Caps raised

- `backend/app/platform/jobs/sweep.py` 1827 to 1857. Almost all docstring: why the shape-based carve-out missed the door the demo uses, why the absolute-path class no longer needs its own branch, why pre-stamp rows reclassify rather than get a migration, and the two residual gaps above.
- `backend/app/processing/ingest/service.py` 1465 to 1482 to 1500 to 1513. One `job=` argument at each of five guard call sites, the fan-out child's early stamp and the comment saying why that door is the one worth closing, then the fan-out session reset from review round 1 and the parent reload from round 2.

## Verification

Run from the worktree with `.env.test` and Postgres on `localhost:5434`.

- `uv run pytest tests/test_commit_attempted_marker_doors.py tests/test_defer_orphan_guard.py tests/test_stale_pending_reaper.py tests/test_ingest_fan_out.py tests/test_job_cancel_fan_out.py tests/test_job_cancel_defer_rollback.py tests/test_job_cancel_reupload_commit.py tests/test_embedding_backfill_queue_1542.py tests/test_worker.py tests/test_jobs_router.py tests/test_vrt_creation_173.py tests/test_ingest.py -q -p no:randomly` -> 287 passed (review round 2; 284 at round 1)
- `uv run pytest tests/test_manifest_apply_api.py tests/test_manifest_apply_service.py tests/test_manifest_apply_roundtrip.py tests/test_refresh_gate_1269.py tests/test_service_refresh_1220.py tests/test_reupload.py tests/test_reupload_service.py tests/test_regenerate_vrt_integration.py tests/test_analysis_materialize.py tests/test_import_token_lease_1676.py tests/test_door_token_policy_1746.py tests/test_service_auth_contract_1746.py -q -p no:randomly` -> 389 passed (re-run at review round 2)
- `uv run pytest -q -p no:randomly -n 4` (full backend suite) -> 10668 passed, 100 skipped, 1 failed; the single failure was `test_module_loc_caps_have_no_headroom` against caps that had not yet been re-measured, and `uv run pytest tests/test_layering.py -q` is 47 passed after the raise above
- `uv run pytest tests/test_layering.py -q -p no:randomly` -> 47 passed
- `uv run ruff check .` and `uv run ruff format --check .` -> clean
- `PYTHONPATH=. uv run python scripts/dump_openapi.py --check` -> exit 0, no drift
