### PR TITLE
fix(settings): settings key spelling and ISO option CHECK drift

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,6 +202,14 @@ jobs:
               - 'frontend/src/lib/__tests__/public-urls.test.ts'
               - 'frontend/src/lib/normalize-style-config.ts'
               - 'frontend/vite.config.ts'
+              # fix(#1778): test_settings_key_drift.py reads these by
+              # literal path (the settings-key subset guard: frontend_keys
+              # is a subset of backend registry keys) and
+              # test_iso_option_drift.py reads iso-constants.ts (the ISO
+              # dropdown-option subset guard).
+              - 'frontend/src/api/settings.ts'
+              - 'frontend/src/components/admin/settings/Settings*Tab.tsx'
+              - 'frontend/src/lib/iso-constants.ts'
               # test_embed_framing_csp.py::test_e2e_sec_audit_s08_skips_when_no_share_token
               # reads this spec by literal path to pin the S08 test block; the
               # 'e2e' filter alone does not trigger Backend Tests.

--- a/backend/tests/test_iso_option_drift.py
+++ b/backend/tests/test_iso_option_drift.py
@@ -1,5 +1,6 @@
-"""Static-analysis test: the frontend ISO metadata dropdown option lists must
-be a subset of the records CHECK constraints they feed.
+"""DB-backed drift test: the frontend ISO metadata dropdown option lists must
+be a subset of the records CHECK constraints they feed, as those constraints
+are actually enforced by the migrated database.
 
 fix(#1778): the ISO metadata dropdowns offer four values the records CHECK
 constraint rejects, so picking them 500s the whole pending-edit batch.
@@ -15,34 +16,70 @@ constraint rejects, so picking them 500s the whole pending-edit batch.
   the server detail and shows a generic "Failed to save pending edits."
   toast naming no field.
 
-  Contract direction: frontend_options ⊆ constraint_values. The constraint
-  may accept values the frontend never offers (e.g. `public`/`internal` were
-  missing from the old SENSITIVITY_OPTIONS, which is a UX gap, not a 500) --
-  that is not what this guard checks.
+  Contract direction: frontend_options is a subset of constraint_values. The
+  constraint may accept values the frontend never offers (e.g.
+  `public`/`internal` were missing from the old SENSITIVITY_OPTIONS, which is
+  a UX gap, not a 500) -- that is not what this guard checks.
 
-  Fail-before is provable: add `'fortnightly'` back to
+fix(#1778): codex review (round 2 on the PR that added this file) found two
+gaps in the first version:
+
+1. The backend vocabulary was read off `Record.__table__` -- the ORM's
+   *declared* `CheckConstraint`, not what deployed PostgreSQL actually
+   enforces. Widening the ORM constraint while a migration is missing or
+   wrong would keep both subset tests green while the migrated database
+   still rejects the value. `test_check_constraint_parity.py` only compares
+   (table, name) pairs, not expressions, and Alembic autogenerate does not
+   detect CHECK-expression drift either -- nothing else closes this. Fixed
+   by reading `pg_get_constraintdef(oid)` from `pg_constraint` against the
+   migrated test database (the same `test_db_session` fixture
+   `test_check_constraint_parity.py` uses) and deriving the vocabulary from
+   that text instead of the ORM's.
+2. The frontend option regex was letter-only (`[A-Za-z]+`), so a value
+   containing an underscore, hyphen, or digit (e.g. `'as_needed'`) was
+   silently absent from the parsed set rather than caught as a real,
+   comparable value -- both the nonempty assertion and the subset checks
+   stayed green. Fixed by extracting the complete quoted contents
+   (`[^']+`), matching the pattern already used on the constraint side.
+
+  Fail-before is provable two ways: add `'fortnightly'` back to
   `UPDATE_FREQUENCY_OPTIONS` (or `'secret'`/`'topSecret'`/`'unclassified'`
-  back to `SENSITIVITY_OPTIONS`) in `iso-constants.ts` and this test fails,
-  naming the offending value.
+  back to `SENSITIVITY_OPTIONS`) in `iso-constants.ts`, or widen
+  `chk_records_update_frequency` on the ORM model without touching the
+  migration -- either fails a subset test, naming the offending value.
 """
 
 from __future__ import annotations
 
 import re
 
+import pytest
+from sqlalchemy import text
+
 from app.modules.catalog.datasets.domain.models import Record
 from tests.repo_paths import repo_root
+
+pytestmark = pytest.mark.anyio
 
 REPO_ROOT = repo_root(__file__)
 ISO_CONSTANTS_TS = REPO_ROOT / "frontend" / "src" / "lib" / "iso-constants.ts"
 
+# Matches the complete contents of a single-quoted string, whatever
+# characters it contains -- not a letter-only class. An ISO option or a
+# CHECK constraint's literal can contain digits or camelCase, and a typo can
+# contain an underscore or hyphen; all of those must be captured as a real
+# value to compare, never silently dropped.
+_QUOTED_VALUE_RE = re.compile(r"'([^']+)'")
 
-def _parse_frontend_option_list(const_name: str) -> set[str]:
-    """Parse a `export const <const_name> = [...] as const;` string array.
 
-    Static analysis only -- does not import or execute TypeScript.
+def _extract_option_array(const_name: str, source: str) -> set[str]:
+    """Parse `export const <const_name> = [...] as const;` out of `source`
+    and return the complete contents of every quoted string in the array.
+
+    Static analysis only -- does not import or execute TypeScript. Takes
+    `source` as text rather than reading the file directly so a test can
+    exercise the parser against a synthetic snippet.
     """
-    source = ISO_CONSTANTS_TS.read_text(encoding="utf-8")
     match = re.search(
         rf"export\s+const\s+{const_name}\s*=\s*\[(.*?)\]\s*as\s+const",
         source,
@@ -50,76 +87,165 @@ def _parse_frontend_option_list(const_name: str) -> set[str]:
     )
     assert match, (
         f"Could not find `export const {const_name} = [...] as const` in "
-        f"{ISO_CONSTANTS_TS}. The parser may be broken, or the constant was "
+        f"the given source. The parser may be broken, or the constant was "
         f"renamed or moved."
     )
-    body = match.group(1)
-    values = set(re.findall(r"'([A-Za-z]+)'", body))
+    values = set(_QUOTED_VALUE_RE.findall(match.group(1)))
     assert values, (
-        f"Parsed zero values from {const_name} in {ISO_CONSTANTS_TS}. "
-        f"The parser may have stopped matching -- check the regex against "
-        f"the current source."
+        f"Parsed zero values from {const_name}. The parser may have "
+        f"stopped matching -- check the regex against the current source."
     )
     return values
 
 
-def _parse_check_constraint_values(constraint_name: str) -> set[str]:
-    """Parse the quoted string literals out of a named CHECK constraint on
-    `Record.__table__`."""
-    constraint = next(
-        c for c in Record.__table__.constraints if c.name == constraint_name
+def _parse_frontend_option_list(const_name: str) -> set[str]:
+    """Parse a `export const <const_name> = [...] as const;` string array
+    out of the real `iso-constants.ts` file."""
+    source = ISO_CONSTANTS_TS.read_text(encoding="utf-8")
+    return _extract_option_array(const_name, source)
+
+
+async def _parse_migrated_check_constraint_values(
+    session, table_fullname: str, constraint_name: str
+) -> set[str]:
+    """Return the quoted string literals in a named CHECK constraint's
+    definition, read from the migrated test database rather than the ORM.
+
+    `pg_get_constraintdef` returns what PostgreSQL actually enforces (it
+    rewrites `IN (...)` to `= ANY (ARRAY[...])`, but the string literals
+    themselves survive verbatim), so this reflects a migration that failed
+    to land even when the ORM's `CheckConstraint` was already widened.
+    """
+    schema, table = table_fullname.split(".", 1)
+    result = await session.execute(
+        text(
+            """
+            SELECT pg_get_constraintdef(con.oid)
+            FROM pg_constraint con
+            JOIN pg_class rel ON rel.oid = con.conrelid
+            JOIN pg_namespace nsp ON nsp.oid = rel.relnamespace
+            WHERE con.contype = 'c'
+              AND nsp.nspname = :schema
+              AND rel.relname = :table
+              AND con.conname = :name
+            """
+        ),
+        {"schema": schema, "table": table, "name": constraint_name},
     )
-    values = set(re.findall(r"'([^']+)'", str(constraint.sqltext)))
+    row = result.first()
+    assert row is not None, (
+        f"No CHECK constraint named {constraint_name!r} found on "
+        f"{table_fullname} in the migrated test database. Either the "
+        f"migration is missing, or the table/constraint name changed -- "
+        f"see test_check_constraint_parity.py for the ORM<->DB name gate."
+    )
+    values = set(_QUOTED_VALUE_RE.findall(row[0]))
     assert values, (
-        f"Parsed zero values from {constraint_name}'s CHECK clause. "
-        f"The parser may be broken -- fix this test first."
+        f"Parsed zero values from {constraint_name}'s migrated CHECK "
+        f"definition ({row[0]!r}). The parser may be broken -- fix this "
+        f"test first."
     )
     return values
 
 
-def test_update_frequency_options_subset_of_check_constraint():
-    """UPDATE_FREQUENCY_OPTIONS must be a subset of chk_records_update_frequency.
+async def test_update_frequency_options_subset_of_check_constraint(test_db_session):
+    """UPDATE_FREQUENCY_OPTIONS must be a subset of the migrated
+    chk_records_update_frequency.
 
     An option outside the constraint's vocabulary passes frontend validation,
     reaches PATCH /datasets/{id}, and raises an unhandled CheckViolation that
     the global DBAPIError handler re-raises as a 500 (backend/app/api/main.py).
     """
     frontend = _parse_frontend_option_list("UPDATE_FREQUENCY_OPTIONS")
-    backend = _parse_check_constraint_values("chk_records_update_frequency")
+    backend = await _parse_migrated_check_constraint_values(
+        test_db_session, Record.__table__.fullname, "chk_records_update_frequency"
+    )
 
     only_in_frontend = frontend - backend
 
     assert not only_in_frontend, (
-        f"iso-constants.ts UPDATE_FREQUENCY_OPTIONS offers a value "
-        f"chk_records_update_frequency rejects (500 on save):\n"
+        f"iso-constants.ts UPDATE_FREQUENCY_OPTIONS offers a value the "
+        f"migrated chk_records_update_frequency rejects (500 on save):\n"
         f"  {sorted(only_in_frontend)}\n"
         f"\n"
         f"Fix: remove the value from UPDATE_FREQUENCY_OPTIONS in "
         f"frontend/src/lib/iso-constants.ts, or widen the CHECK constraint "
-        f"in backend/app/modules/catalog/datasets/domain/models.py (with a "
-        f"matching Alembic migration)."
+        f"in backend/app/modules/catalog/datasets/domain/models.py with a "
+        f"matching Alembic migration."
     )
 
 
-def test_sensitivity_options_subset_of_check_constraint():
-    """SENSITIVITY_OPTIONS must be a subset of chk_records_sensitivity.
+async def test_sensitivity_options_subset_of_check_constraint(test_db_session):
+    """SENSITIVITY_OPTIONS must be a subset of the migrated
+    chk_records_sensitivity.
 
     An option outside the constraint's vocabulary passes frontend validation,
     reaches PATCH /datasets/{id}, and raises an unhandled CheckViolation that
     the global DBAPIError handler re-raises as a 500 (backend/app/api/main.py).
     """
     frontend = _parse_frontend_option_list("SENSITIVITY_OPTIONS")
-    backend = _parse_check_constraint_values("chk_records_sensitivity")
+    backend = await _parse_migrated_check_constraint_values(
+        test_db_session, Record.__table__.fullname, "chk_records_sensitivity"
+    )
 
     only_in_frontend = frontend - backend
 
     assert not only_in_frontend, (
-        f"iso-constants.ts SENSITIVITY_OPTIONS offers a value "
+        f"iso-constants.ts SENSITIVITY_OPTIONS offers a value the migrated "
         f"chk_records_sensitivity rejects (500 on save):\n"
         f"  {sorted(only_in_frontend)}\n"
         f"\n"
         f"Fix: remove the value from SENSITIVITY_OPTIONS in "
         f"frontend/src/lib/iso-constants.ts, or widen the CHECK constraint "
-        f"in backend/app/modules/catalog/datasets/domain/models.py (with a "
-        f"matching Alembic migration)."
+        f"in backend/app/modules/catalog/datasets/domain/models.py with a "
+        f"matching Alembic migration."
+    )
+
+
+def test_extract_option_array_does_not_silently_drop_non_letter_values():
+    """Negative control for the old `[A-Za-z]+` class: a synthetic option
+    containing an underscore must be captured as a real value, not silently
+    erased from the parsed set.
+
+    `'as_needed'` is deliberately not `'asNeeded'` (the real, valid
+    UPDATE_FREQUENCY_OPTIONS/registry spelling) -- it stands in for the bug
+    class the letter-only regex missed: a typo'd or foreign value that
+    should show up as a violation, not vanish before the comparison runs.
+    """
+    synthetic_source = (
+        "export const FAKE_OPTIONS = [\n"
+        "  'continual',\n"
+        "  'as_needed',\n"
+        "  'unknown',\n"
+        "] as const;\n"
+    )
+
+    parsed = _extract_option_array("FAKE_OPTIONS", synthetic_source)
+
+    assert parsed == {"continual", "as_needed", "unknown"}, (
+        f"Expected the synthetic array's three literal values, underscore "
+        f"included, to all survive parsing; got {sorted(parsed)}"
+    )
+
+    # The real vocabulary spells this option 'asNeeded' (camelCase), so the
+    # synthetic 'as_needed' must land as a genuine, reportable mismatch
+    # against it -- not silently absent from `parsed` before this comparison
+    # ever runs.
+    real_update_frequency_vocabulary = {
+        "continual",
+        "daily",
+        "weekly",
+        "monthly",
+        "quarterly",
+        "biannually",
+        "annually",
+        "asNeeded",
+        "irregular",
+        "notPlanned",
+        "unknown",
+    }
+    only_in_synthetic = parsed - real_update_frequency_vocabulary
+    assert only_in_synthetic == {"as_needed"}, (
+        f"Expected 'as_needed' to be caught as the sole value outside the "
+        f"real vocabulary; got {sorted(only_in_synthetic)}"
     )

--- a/backend/tests/test_iso_option_drift.py
+++ b/backend/tests/test_iso_option_drift.py
@@ -1,9 +1,9 @@
 """Static-analysis test: the frontend ISO metadata dropdown option lists must
 be a subset of the records CHECK constraints they feed.
 
-Contract (codebase audit 2026-08-30 (8dc529f17), "The ISO metadata dropdowns
-offer four values the records CHECK constraint rejects, so picking them 500s
-the whole pending-edit batch"):
+fix(#1778): the ISO metadata dropdowns offer four values the records CHECK
+constraint rejects, so picking them 500s the whole pending-edit batch.
+
   `frontend/src/lib/iso-constants.ts` declares `UPDATE_FREQUENCY_OPTIONS` and
   `SENSITIVITY_OPTIONS`, rendered directly as `<SelectItem>` options in
   `SourceQualityTab.tsx`. Nothing validates a selection before it reaches

--- a/backend/tests/test_iso_option_drift.py
+++ b/backend/tests/test_iso_option_drift.py
@@ -1,0 +1,125 @@
+"""Static-analysis test: the frontend ISO metadata dropdown option lists must
+be a subset of the records CHECK constraints they feed.
+
+Contract (codebase audit 2026-08-30 (8dc529f17), "The ISO metadata dropdowns
+offer four values the records CHECK constraint rejects, so picking them 500s
+the whole pending-edit batch"):
+  `frontend/src/lib/iso-constants.ts` declares `UPDATE_FREQUENCY_OPTIONS` and
+  `SENSITIVITY_OPTIONS`, rendered directly as `<SelectItem>` options in
+  `SourceQualityTab.tsx`. Nothing validates a selection before it reaches
+  `PATCH /datasets/{id}` -- `_apply_simple_field_assignments` does a bare
+  `setattr(target, attr, value)`, and the only handler in the datasets PATCH
+  path catches `ValueError`, not `IntegrityError`. A value the CHECK
+  constraint rejects (`update_frequency`/`sensitivity_classification` on
+  `Record`) surfaces as an unfiltered 500, and `savePendingDrafts` discards
+  the server detail and shows a generic "Failed to save pending edits."
+  toast naming no field.
+
+  Contract direction: frontend_options ⊆ constraint_values. The constraint
+  may accept values the frontend never offers (e.g. `public`/`internal` were
+  missing from the old SENSITIVITY_OPTIONS, which is a UX gap, not a 500) --
+  that is not what this guard checks.
+
+  Fail-before is provable: add `'fortnightly'` back to
+  `UPDATE_FREQUENCY_OPTIONS` (or `'secret'`/`'topSecret'`/`'unclassified'`
+  back to `SENSITIVITY_OPTIONS`) in `iso-constants.ts` and this test fails,
+  naming the offending value.
+"""
+
+from __future__ import annotations
+
+import re
+
+from app.modules.catalog.datasets.domain.models import Record
+from tests.repo_paths import repo_root
+
+REPO_ROOT = repo_root(__file__)
+ISO_CONSTANTS_TS = REPO_ROOT / "frontend" / "src" / "lib" / "iso-constants.ts"
+
+
+def _parse_frontend_option_list(const_name: str) -> set[str]:
+    """Parse a `export const <const_name> = [...] as const;` string array.
+
+    Static analysis only -- does not import or execute TypeScript.
+    """
+    source = ISO_CONSTANTS_TS.read_text(encoding="utf-8")
+    match = re.search(
+        rf"export\s+const\s+{const_name}\s*=\s*\[(.*?)\]\s*as\s+const",
+        source,
+        re.DOTALL,
+    )
+    assert match, (
+        f"Could not find `export const {const_name} = [...] as const` in "
+        f"{ISO_CONSTANTS_TS}. The parser may be broken, or the constant was "
+        f"renamed or moved."
+    )
+    body = match.group(1)
+    values = set(re.findall(r"'([A-Za-z]+)'", body))
+    assert values, (
+        f"Parsed zero values from {const_name} in {ISO_CONSTANTS_TS}. "
+        f"The parser may have stopped matching -- check the regex against "
+        f"the current source."
+    )
+    return values
+
+
+def _parse_check_constraint_values(constraint_name: str) -> set[str]:
+    """Parse the quoted string literals out of a named CHECK constraint on
+    `Record.__table__`."""
+    constraint = next(
+        c for c in Record.__table__.constraints if c.name == constraint_name
+    )
+    values = set(re.findall(r"'([^']+)'", str(constraint.sqltext)))
+    assert values, (
+        f"Parsed zero values from {constraint_name}'s CHECK clause. "
+        f"The parser may be broken -- fix this test first."
+    )
+    return values
+
+
+def test_update_frequency_options_subset_of_check_constraint():
+    """UPDATE_FREQUENCY_OPTIONS must be a subset of chk_records_update_frequency.
+
+    An option outside the constraint's vocabulary passes frontend validation,
+    reaches PATCH /datasets/{id}, and raises an unhandled CheckViolation that
+    the global DBAPIError handler re-raises as a 500 (backend/app/api/main.py).
+    """
+    frontend = _parse_frontend_option_list("UPDATE_FREQUENCY_OPTIONS")
+    backend = _parse_check_constraint_values("chk_records_update_frequency")
+
+    only_in_frontend = frontend - backend
+
+    assert not only_in_frontend, (
+        f"iso-constants.ts UPDATE_FREQUENCY_OPTIONS offers a value "
+        f"chk_records_update_frequency rejects (500 on save):\n"
+        f"  {sorted(only_in_frontend)}\n"
+        f"\n"
+        f"Fix: remove the value from UPDATE_FREQUENCY_OPTIONS in "
+        f"frontend/src/lib/iso-constants.ts, or widen the CHECK constraint "
+        f"in backend/app/modules/catalog/datasets/domain/models.py (with a "
+        f"matching Alembic migration)."
+    )
+
+
+def test_sensitivity_options_subset_of_check_constraint():
+    """SENSITIVITY_OPTIONS must be a subset of chk_records_sensitivity.
+
+    An option outside the constraint's vocabulary passes frontend validation,
+    reaches PATCH /datasets/{id}, and raises an unhandled CheckViolation that
+    the global DBAPIError handler re-raises as a 500 (backend/app/api/main.py).
+    """
+    frontend = _parse_frontend_option_list("SENSITIVITY_OPTIONS")
+    backend = _parse_check_constraint_values("chk_records_sensitivity")
+
+    only_in_frontend = frontend - backend
+
+    assert not only_in_frontend, (
+        f"iso-constants.ts SENSITIVITY_OPTIONS offers a value "
+        f"chk_records_sensitivity rejects (500 on save):\n"
+        f"  {sorted(only_in_frontend)}\n"
+        f"\n"
+        f"Fix: remove the value from SENSITIVITY_OPTIONS in "
+        f"frontend/src/lib/iso-constants.ts, or widen the CHECK constraint "
+        f"in backend/app/modules/catalog/datasets/domain/models.py (with a "
+        f"matching Alembic migration)."
+    )

--- a/backend/tests/test_settings_key_drift.py
+++ b/backend/tests/test_settings_key_drift.py
@@ -1,26 +1,43 @@
 """Static-analysis test: every settings-key literal the admin frontend sends
 or reads must be a member of the backend PersistentConfig registry.
 
-Contract (codebase audit 2026-08-30 (8dc529f17), "The settings channel ...
-has no type, no OpenAPI enum, and no drift test"):
-  ``updateSettings`` (frontend/src/api/settings.ts) takes a bare
-  ``Record<string, unknown>`` and PUTs it to ``/settings/``. The registry map
-  built in ``settings/router.py`` (``{cfg.key: cfg for cfg in _registry}``)
-  does no key normalization, so a typo'd key either 400s on write
-  (``Unknown setting key: ...``) or silently falls back to a field's
-  hardcoded ``defaultValue`` on read (``useSettingsForm.ts``). That is exactly
-  how ``branding_show_badge`` (frontend) vs. ``branding.show_badge`` (backend
-  registry key) shipped in v1.17.0 — this repo already runs three sibling
-  static guards of the same shape for capabilities, basemap config, and
-  builder alias keys; this is the fourth.
+fix(#1778): the settings channel (46 registry keys against ~120 hand-written
+frontend literals) has no type, no OpenAPI enum, and no drift test.
+``updateSettings`` (frontend/src/api/settings.ts) takes a bare
+``Record<string, unknown>`` and PUTs it to ``/settings/``. The registry map
+built in ``settings/router.py`` (``{cfg.key: cfg for cfg in _registry}``)
+does no key normalization, so a typo'd key either 400s on write
+(``Unknown setting key: ...``) or silently falls back to a field's
+hardcoded ``defaultValue`` on read (``useSettingsForm.ts``). That is exactly
+how ``branding_show_badge`` (frontend) vs. ``branding.show_badge`` (backend
+registry key) shipped in v1.17.0 -- this repo already runs three sibling
+static guards of the same shape for capabilities, basemap config, and
+builder alias keys; this is the fourth.
 
-  Contract direction: frontend_keys ⊆ backend_registry_keys. The backend may
-  declare keys the frontend never surfaces (env-only or admin-API-only
-  settings); that is not a bug.
+Contract direction: frontend_keys is a subset of backend_registry_keys. The
+backend may declare keys the frontend never surfaces (env-only or
+admin-API-only settings); that is not a bug.
 
-  Fail-before is provable: rename ``'branding.show_badge'`` in
-  ``updateBranding`` (api/settings.ts) back to ``'branding_show_badge'`` and
-  this test fails, naming the offending key.
+Most tab components go through ``useSettingsForm`` (``key: '...'`` field
+defs, ``findSetting(settings, '...')`` reads, ``settingKey="..."`` reset
+wiring). ``SettingsPermissionsTab.tsx`` is the one tab that bypasses that
+hook entirely and talks to the settings item list, the save callback, and
+the reset callback directly: ``settings.find((s) => s.key ===
+'role_permissions')``, ``onSave({ role_permissions: matrix })``,
+``onReset('role_permissions')``. A first version of this test only
+recognized the ``useSettingsForm`` shapes, so a typo anywhere in that
+direct-access tab would have kept passing while still producing the same
+400-on-write / silent-default-on-read failure this guard exists to catch
+(fix(#1778): review round 1). The parser below also walks every
+``.find(...)``/``onSave(...)``/``onReset(...)`` call site and pulls out
+whatever key literal reaches it, rather than only the field-def shape, so
+a new hand-rolled access pattern is still covered.
+
+Fail-before is provable two ways: rename ``'branding.show_badge'`` in
+``updateBranding`` (api/settings.ts) back to ``'branding_show_badge'``, or
+change the ``onReset('role_permissions')`` argument in
+``SettingsPermissionsTab.tsx`` to a typo -- either fails this test, naming
+the offending key.
 """
 
 from __future__ import annotations
@@ -33,14 +50,45 @@ from tests.repo_paths import repo_root
 REPO_ROOT = repo_root(__file__)
 SETTINGS_TABS_DIR = REPO_ROOT / "frontend" / "src" / "components" / "admin" / "settings"
 API_SETTINGS_TS = REPO_ROOT / "frontend" / "src" / "api" / "settings.ts"
+PERMISSIONS_TAB_TSX = SETTINGS_TABS_DIR / "SettingsPermissionsTab.tsx"
 
+# useSettingsForm-mediated shapes: field defs, read-back lookups, reset wiring.
 _KEY_FIELD_RE = re.compile(r"key:\s*'([a-zA-Z0-9_.]+)'")
 _FIND_SETTING_RE = re.compile(r"findSetting\(settings,\s*'([a-zA-Z0-9_.]+)'\)")
 _SETTING_KEY_ATTR_RE = re.compile(r'settingKey="([a-zA-Z0-9_.]+)"')
+
+# Direct-access shapes (bypassing useSettingsForm): a raw `.find` read keyed
+# on `.key === '...'`, every key literal in an `onSave({ ... })` payload, and
+# the string argument to `onReset('...')`.
+_DIRECT_FIND_RE = re.compile(
+    r"\.find\(\s*\([^)]*\)\s*=>\s*[^)]*?\.key\s*===\s*'([a-zA-Z0-9_.]+)'"
+)
+_ON_SAVE_CALL_RE = re.compile(r"onSave\(\{(.*?)\}\)", re.DOTALL)
+_ON_SAVE_KEY_RE = re.compile(r"([a-zA-Z0-9_.]+)\s*:")
+_ON_RESET_CALL_RE = re.compile(r"onReset\('([a-zA-Z0-9_.]+)'\)")
+
+# frontend/src/api/settings.ts hand-built payload assignments (updateBranding
+# and any sibling that constructs a settings object without a field def).
 _PAYLOAD_DOT_ASSIGN_RE = re.compile(r"\bsettings\.([a-zA-Z0-9_]+)\s*=")
 _PAYLOAD_BRACKET_ASSIGN_RE = re.compile(
     r"""\bsettings\[['"]([a-zA-Z0-9_.]+)['"]\]\s*="""
 )
+
+
+def _parse_tab_source_keys(source: str) -> set[str]:
+    """Every settings-key literal reachable from one Settings*Tab.tsx source,
+    across both the useSettingsForm-mediated shapes and the direct
+    find/save/reset call sites a tab may use instead.
+    """
+    keys: set[str] = set()
+    keys |= set(_KEY_FIELD_RE.findall(source))
+    keys |= set(_FIND_SETTING_RE.findall(source))
+    keys |= set(_SETTING_KEY_ATTR_RE.findall(source))
+    keys |= set(_DIRECT_FIND_RE.findall(source))
+    keys |= set(_ON_RESET_CALL_RE.findall(source))
+    for on_save_body in _ON_SAVE_CALL_RE.findall(source):
+        keys |= set(_ON_SAVE_KEY_RE.findall(on_save_body))
+    return keys
 
 
 def _parse_frontend_setting_keys() -> set[str]:
@@ -48,11 +96,12 @@ def _parse_frontend_setting_keys() -> set[str]:
 
     Two sources, matching the two ways a key literal reaches the wire:
 
-    1. ``frontend/src/components/admin/settings/Settings*Tab.tsx`` — the
-       ``useSettingsForm`` field defs (``key: '...'``), the read-back lookups
-       (``findSetting(settings, '...')``), and the reset-badge wiring
-       (``settingKey="..."``).
-    2. ``frontend/src/api/settings.ts`` — the hand-built payload assignments
+    1. ``frontend/src/components/admin/settings/Settings*Tab.tsx`` -- both
+       the ``useSettingsForm`` shapes (field defs, ``findSetting`` reads,
+       ``settingKey`` reset wiring) and the direct-access shapes a tab may
+       use instead (``.find(... .key === '...')``, ``onSave({ ... })``,
+       ``onReset('...')``).
+    2. ``frontend/src/api/settings.ts`` -- the hand-built payload assignments
        in functions like ``updateBranding`` that construct a settings object
        without going through a ``useSettingsForm`` field def
        (``settings.foo = ...`` / ``settings['foo.bar'] = ...``).
@@ -67,10 +116,7 @@ def _parse_frontend_setting_keys() -> set[str]:
         f"The parser may be broken, or the tabs moved."
     )
     for path in tab_files:
-        source = path.read_text(encoding="utf-8")
-        keys |= set(_KEY_FIELD_RE.findall(source))
-        keys |= set(_FIND_SETTING_RE.findall(source))
-        keys |= set(_SETTING_KEY_ATTR_RE.findall(source))
+        keys |= _parse_tab_source_keys(path.read_text(encoding="utf-8"))
 
     api_source = API_SETTINGS_TS.read_text(encoding="utf-8")
     keys |= set(_PAYLOAD_DOT_ASSIGN_RE.findall(api_source))
@@ -87,14 +133,14 @@ def _parse_frontend_setting_keys() -> set[str]:
 def test_frontend_setting_keys_subset_of_backend_registry():
     """Frontend settings-key literals must be a subset of the backend registry.
 
-    Contract direction: frontend_keys ⊆ backend_registry_keys.
+    Contract direction: frontend_keys is a subset of backend_registry_keys.
 
     A key the frontend sends that the registry does not declare 400s on
     write (``Unknown setting key: ...``) and is silently invisible on read
-    (``findSetting`` returns undefined, the field renders its hardcoded
-    default). If a new registry key is added without a matching frontend
-    field, that is fine -- it is either env-only or intentionally
-    admin-API-only.
+    (``findSetting``/``.find`` returns undefined, the field renders its
+    hardcoded default or nothing at all). If a new registry key is added
+    without a matching frontend field, that is fine -- it is either
+    env-only or intentionally admin-API-only.
     """
     frontend_keys = _parse_frontend_setting_keys()
     backend_keys = {cfg.key for cfg in _registry}
@@ -113,4 +159,65 @@ def test_frontend_setting_keys_subset_of_backend_registry():
         f"frontend/src/components/admin/settings/ or frontend/src/api/settings.ts "
         f"to match the registry's key= value, or register the key in "
         f"backend/app/core/persistent_config.py."
+    )
+
+
+def test_parser_floor_and_permissions_tab_positive_control():
+    """Guard the parser itself, not just the drift it looks for.
+
+    Two properties, so a broken or narrowed parser fails loudly instead of
+    quietly passing an empty or shrunken subset check:
+
+    1. Positive control: ``SettingsPermissionsTab.tsx`` reaches
+       ``role_permissions`` only through the direct-access shapes
+       (``.find(... .key === 'role_permissions')``, ``onSave({
+       role_permissions: matrix })``, ``onReset('role_permissions')``) --
+       none of the ``useSettingsForm`` shapes appear in that file. If any of
+       the three direct-access regexes regresses, this key drops out and
+       the assertion below names it.
+    2. Floor: the combined frontend key count must not fall below the
+       current count. A regression that breaks one of the six extraction
+       regexes silently shrinks the set the subset check runs against,
+       which would make ``test_frontend_setting_keys_subset_of_backend_registry``
+       pass vacuously instead of catching real drift.
+    """
+    permissions_source = PERMISSIONS_TAB_TSX.read_text(encoding="utf-8")
+
+    direct_find_keys = set(_DIRECT_FIND_RE.findall(permissions_source))
+    on_reset_keys = set(_ON_RESET_CALL_RE.findall(permissions_source))
+    on_save_keys: set[str] = set()
+    for on_save_body in _ON_SAVE_CALL_RE.findall(permissions_source):
+        on_save_keys |= set(_ON_SAVE_KEY_RE.findall(on_save_body))
+
+    assert "role_permissions" in direct_find_keys, (
+        "Positive control failed: the direct-.find() regex no longer finds "
+        "'role_permissions' in SettingsPermissionsTab.tsx's "
+        "`settings.find((s) => s.key === 'role_permissions')` read."
+    )
+    assert "role_permissions" in on_save_keys, (
+        "Positive control failed: the onSave(...) regex no longer finds "
+        "'role_permissions' in SettingsPermissionsTab.tsx's "
+        "`onSave({ role_permissions: matrix })` call."
+    )
+    assert "role_permissions" in on_reset_keys, (
+        "Positive control failed: the onReset(...) regex no longer finds "
+        "'role_permissions' in SettingsPermissionsTab.tsx's "
+        "`onReset('role_permissions')` call."
+    )
+
+    # None of the useSettingsForm-mediated regexes should also fire on this
+    # file -- if one starts matching, the file changed shape and the "one
+    # tab bypasses useSettingsForm" premise in this test's docstring is
+    # stale and needs re-reading, not silently absorbing.
+    assert not _KEY_FIELD_RE.search(permissions_source)
+    assert not _FIND_SETTING_RE.search(permissions_source)
+    assert not _SETTING_KEY_ATTR_RE.search(permissions_source)
+
+    frontend_keys = _parse_frontend_setting_keys()
+    assert len(frontend_keys) >= 41, (
+        f"Frontend settings-key count dropped to {len(frontend_keys)} "
+        f"(expected at least 41). One of the extraction regexes likely "
+        f"stopped matching -- a shrunken set makes the subset-of-registry "
+        f"check pass vacuously instead of catching real drift.\n"
+        f"Keys found: {sorted(frontend_keys)}"
     )

--- a/backend/tests/test_settings_key_drift.py
+++ b/backend/tests/test_settings_key_drift.py
@@ -1,0 +1,116 @@
+"""Static-analysis test: every settings-key literal the admin frontend sends
+or reads must be a member of the backend PersistentConfig registry.
+
+Contract (codebase audit 2026-08-30 (8dc529f17), "The settings channel ...
+has no type, no OpenAPI enum, and no drift test"):
+  ``updateSettings`` (frontend/src/api/settings.ts) takes a bare
+  ``Record<string, unknown>`` and PUTs it to ``/settings/``. The registry map
+  built in ``settings/router.py`` (``{cfg.key: cfg for cfg in _registry}``)
+  does no key normalization, so a typo'd key either 400s on write
+  (``Unknown setting key: ...``) or silently falls back to a field's
+  hardcoded ``defaultValue`` on read (``useSettingsForm.ts``). That is exactly
+  how ``branding_show_badge`` (frontend) vs. ``branding.show_badge`` (backend
+  registry key) shipped in v1.17.0 — this repo already runs three sibling
+  static guards of the same shape for capabilities, basemap config, and
+  builder alias keys; this is the fourth.
+
+  Contract direction: frontend_keys ⊆ backend_registry_keys. The backend may
+  declare keys the frontend never surfaces (env-only or admin-API-only
+  settings); that is not a bug.
+
+  Fail-before is provable: rename ``'branding.show_badge'`` in
+  ``updateBranding`` (api/settings.ts) back to ``'branding_show_badge'`` and
+  this test fails, naming the offending key.
+"""
+
+from __future__ import annotations
+
+import re
+
+from app.core.persistent_config import _registry
+from tests.repo_paths import repo_root
+
+REPO_ROOT = repo_root(__file__)
+SETTINGS_TABS_DIR = REPO_ROOT / "frontend" / "src" / "components" / "admin" / "settings"
+API_SETTINGS_TS = REPO_ROOT / "frontend" / "src" / "api" / "settings.ts"
+
+_KEY_FIELD_RE = re.compile(r"key:\s*'([a-zA-Z0-9_.]+)'")
+_FIND_SETTING_RE = re.compile(r"findSetting\(settings,\s*'([a-zA-Z0-9_.]+)'\)")
+_SETTING_KEY_ATTR_RE = re.compile(r'settingKey="([a-zA-Z0-9_.]+)"')
+_PAYLOAD_DOT_ASSIGN_RE = re.compile(r"\bsettings\.([a-zA-Z0-9_]+)\s*=")
+_PAYLOAD_BRACKET_ASSIGN_RE = re.compile(
+    r"""\bsettings\[['"]([a-zA-Z0-9_.]+)['"]\]\s*="""
+)
+
+
+def _parse_frontend_setting_keys() -> set[str]:
+    """Parse every settings-key literal the admin frontend sends or reads.
+
+    Two sources, matching the two ways a key literal reaches the wire:
+
+    1. ``frontend/src/components/admin/settings/Settings*Tab.tsx`` — the
+       ``useSettingsForm`` field defs (``key: '...'``), the read-back lookups
+       (``findSetting(settings, '...')``), and the reset-badge wiring
+       (``settingKey="..."``).
+    2. ``frontend/src/api/settings.ts`` — the hand-built payload assignments
+       in functions like ``updateBranding`` that construct a settings object
+       without going through a ``useSettingsForm`` field def
+       (``settings.foo = ...`` / ``settings['foo.bar'] = ...``).
+
+    Static analysis only -- does not import or execute TypeScript.
+    """
+    keys: set[str] = set()
+
+    tab_files = sorted(SETTINGS_TABS_DIR.glob("Settings*Tab.tsx"))
+    assert tab_files, (
+        f"Found zero Settings*Tab.tsx files under {SETTINGS_TABS_DIR}. "
+        f"The parser may be broken, or the tabs moved."
+    )
+    for path in tab_files:
+        source = path.read_text(encoding="utf-8")
+        keys |= set(_KEY_FIELD_RE.findall(source))
+        keys |= set(_FIND_SETTING_RE.findall(source))
+        keys |= set(_SETTING_KEY_ATTR_RE.findall(source))
+
+    api_source = API_SETTINGS_TS.read_text(encoding="utf-8")
+    keys |= set(_PAYLOAD_DOT_ASSIGN_RE.findall(api_source))
+    keys |= set(_PAYLOAD_BRACKET_ASSIGN_RE.findall(api_source))
+
+    assert keys, (
+        "Parsed zero settings keys from the admin settings frontend. The "
+        "parser may have stopped matching -- check the regexes against the "
+        "current source."
+    )
+    return keys
+
+
+def test_frontend_setting_keys_subset_of_backend_registry():
+    """Frontend settings-key literals must be a subset of the backend registry.
+
+    Contract direction: frontend_keys ⊆ backend_registry_keys.
+
+    A key the frontend sends that the registry does not declare 400s on
+    write (``Unknown setting key: ...``) and is silently invisible on read
+    (``findSetting`` returns undefined, the field renders its hardcoded
+    default). If a new registry key is added without a matching frontend
+    field, that is fine -- it is either env-only or intentionally
+    admin-API-only.
+    """
+    frontend_keys = _parse_frontend_setting_keys()
+    backend_keys = {cfg.key for cfg in _registry}
+
+    only_in_frontend = frontend_keys - backend_keys
+
+    assert not only_in_frontend, (
+        f"Settings-key drift: the admin frontend references a key that "
+        f"backend/app/core/persistent_config.py does not register.\n"
+        f"\n"
+        f"Keys only in frontend (backend will 400 on write, silently fall "
+        f"back to defaultValue on read):\n"
+        f"  {sorted(only_in_frontend)}\n"
+        f"\n"
+        f"Fix: either correct the frontend key literal in "
+        f"frontend/src/components/admin/settings/ or frontend/src/api/settings.ts "
+        f"to match the registry's key= value, or register the key in "
+        f"backend/app/core/persistent_config.py."
+    )

--- a/frontend/src/api/__tests__/settings.contract.test.ts
+++ b/frontend/src/api/__tests__/settings.contract.test.ts
@@ -1,0 +1,44 @@
+/**
+ * codebase audit 2026-08-30 (8dc529f17): "The Appearance/branding toggle
+ * sends `branding_show_badge`; the registry key is `branding.show_badge`,
+ * so every save 400s".
+ *
+ * Pins the exact PUT body key `updateBranding` sends, so a future rename
+ * back to the underscore spelling fails here instead of shipping a dead
+ * Appearance toggle.
+ */
+import { updateBranding } from '@/api/settings';
+import { apiFetch } from '@/api/client';
+
+vi.mock('@/api/client', () => ({
+  apiFetch: vi.fn(() => Promise.resolve({ env_only: false, tabs: {} })),
+}));
+
+const mockApiFetch = vi.mocked(apiFetch);
+
+beforeEach(() => {
+  mockApiFetch.mockClear();
+});
+
+function calledUrl() {
+  return mockApiFetch.mock.calls[0]?.[0];
+}
+function calledInit() {
+  return mockApiFetch.mock.calls[0]?.[1];
+}
+
+describe('updateBranding request contract', () => {
+  it('PUTs the dotted registry key branding.show_badge, not branding_show_badge', async () => {
+    await updateBranding({ show_badge: true });
+    expect(calledUrl()).toBe('/settings/');
+    expect(calledInit()?.method).toBe('PUT');
+    expect(JSON.parse(calledInit()?.body as string)).toEqual({
+      settings: { 'branding.show_badge': true },
+    });
+  });
+
+  it('omits the key entirely when show_badge is undefined', async () => {
+    await updateBranding({});
+    expect(JSON.parse(calledInit()?.body as string)).toEqual({ settings: {} });
+  });
+});

--- a/frontend/src/api/__tests__/settings.contract.test.ts
+++ b/frontend/src/api/__tests__/settings.contract.test.ts
@@ -1,7 +1,6 @@
 /**
- * codebase audit 2026-08-30 (8dc529f17): "The Appearance/branding toggle
- * sends `branding_show_badge`; the registry key is `branding.show_badge`,
- * so every save 400s".
+ * fix(#1778): the Appearance/branding toggle sent `branding_show_badge`;
+ * the registry key is `branding.show_badge`, so every save 400s.
  *
  * Pins the exact PUT body key `updateBranding` sends, so a future rename
  * back to the underscore spelling fails here instead of shipping a dead

--- a/frontend/src/api/settings.ts
+++ b/frontend/src/api/settings.ts
@@ -180,7 +180,9 @@ export async function getBranding(): Promise<BrandingConfig> {
 
 export async function updateBranding(data: Partial<BrandingConfig>): Promise<void> {
   const settings: Record<string, unknown> = {};
-  if (data.show_badge !== undefined) settings.branding_show_badge = data.show_badge;
+  // The registry key is dotted (`branding.show_badge` in persistent_config.py),
+  // not `branding_show_badge` -- the underscore spelling 400s on every save.
+  if (data.show_badge !== undefined) settings['branding.show_badge'] = data.show_badge;
   await updateSettings(settings);
 }
 

--- a/frontend/src/i18n/locales/de/dataset.json
+++ b/frontend/src/i18n/locales/de/dataset.json
@@ -632,7 +632,6 @@
       "continual": "Fortlaufend",
       "daily": "Täglich",
       "weekly": "Wöchentlich",
-      "fortnightly": "Vierzehntägig",
       "monthly": "Monatlich",
       "quarterly": "Vierteljährlich",
       "biannually": "Halbjährlich",
@@ -643,11 +642,10 @@
       "unknown": "Unbekannt"
     },
     "sensitivityOptions": {
-      "unclassified": "Nicht klassifiziert",
-      "restricted": "Eingeschränkt",
+      "public": "Öffentlich",
+      "internal": "Intern",
       "confidential": "Vertraulich",
-      "secret": "Geheim",
-      "topSecret": "Streng geheim"
+      "restricted": "Eingeschränkt"
     },
     "themeCategories": {
       "farming": "Landwirtschaft",

--- a/frontend/src/i18n/locales/en/dataset.json
+++ b/frontend/src/i18n/locales/en/dataset.json
@@ -600,7 +600,6 @@
       "continual": "Continual",
       "daily": "Daily",
       "weekly": "Weekly",
-      "fortnightly": "Fortnightly",
       "monthly": "Monthly",
       "quarterly": "Quarterly",
       "biannually": "Biannually",
@@ -611,11 +610,10 @@
       "unknown": "Unknown"
     },
     "sensitivityOptions": {
-      "unclassified": "Unclassified",
-      "restricted": "Restricted",
+      "public": "Public",
+      "internal": "Internal",
       "confidential": "Confidential",
-      "secret": "Secret",
-      "topSecret": "Top secret"
+      "restricted": "Restricted"
     },
     "themeCategories": {
       "farming": "Farming",

--- a/frontend/src/i18n/locales/es/dataset.json
+++ b/frontend/src/i18n/locales/es/dataset.json
@@ -632,7 +632,6 @@
       "continual": "Continua",
       "daily": "Diaria",
       "weekly": "Semanal",
-      "fortnightly": "Quincenal",
       "monthly": "Mensual",
       "quarterly": "Trimestral",
       "biannually": "Semestral",
@@ -643,11 +642,10 @@
       "unknown": "Desconocida"
     },
     "sensitivityOptions": {
-      "unclassified": "Sin clasificar",
-      "restricted": "Restringida",
+      "public": "Público",
+      "internal": "Interno",
       "confidential": "Confidencial",
-      "secret": "Secreta",
-      "topSecret": "Alto secreto"
+      "restricted": "Restringida"
     },
     "themeCategories": {
       "farming": "Agricultura",

--- a/frontend/src/i18n/locales/fr/dataset.json
+++ b/frontend/src/i18n/locales/fr/dataset.json
@@ -632,7 +632,6 @@
       "continual": "Continue",
       "daily": "Quotidienne",
       "weekly": "Hebdomadaire",
-      "fortnightly": "Toutes les deux semaines",
       "monthly": "Mensuelle",
       "quarterly": "Trimestrielle",
       "biannually": "Semestrielle",
@@ -643,11 +642,10 @@
       "unknown": "Inconnue"
     },
     "sensitivityOptions": {
-      "unclassified": "Non classifié",
-      "restricted": "Restreinte",
+      "public": "Public",
+      "internal": "Interne",
       "confidential": "Confidentielle",
-      "secret": "Secrète",
-      "topSecret": "Très secret"
+      "restricted": "Restreinte"
     },
     "themeCategories": {
       "farming": "Agriculture",

--- a/frontend/src/lib/iso-constants.ts
+++ b/frontend/src/lib/iso-constants.ts
@@ -1,12 +1,17 @@
 /**
  * ISO 19115 constants shared across dataset detail components.
+ *
+ * Both option lists below must stay a subset of the records CHECK constraints
+ * they feed (chk_records_update_frequency / chk_records_sensitivity in
+ * backend/app/modules/catalog/datasets/domain/models.py) -- an option the
+ * constraint rejects 500s the whole pending-edit batch on save. See
+ * backend/tests/test_iso_option_drift.py.
  */
 
 export const UPDATE_FREQUENCY_OPTIONS = [
   'continual',
   'daily',
   'weekly',
-  'fortnightly',
   'monthly',
   'quarterly',
   'biannually',
@@ -18,11 +23,10 @@ export const UPDATE_FREQUENCY_OPTIONS = [
 ] as const;
 
 export const SENSITIVITY_OPTIONS = [
-  'unclassified',
-  'restricted',
+  'public',
+  'internal',
   'confidential',
-  'secret',
-  'topSecret',
+  'restricted',
 ] as const;
 
 export const THEME_CATEGORIES = [


### PR DESCRIPTION
Addresses two frontend/backend contract bugs from the codebase audit of 2026-08-30 (8dc529f17), tracked in #1778, and adds the drift tests that would have caught them.

## What changed

### Settings key spelling

`updateBranding` in `frontend/src/api/settings.ts` built its PUT payload as `branding_show_badge`. The persistent_config registry key is `branding.show_badge` (dotted). The PUT handler in `settings/router.py` does no key normalization, so every click of the Admin > Settings > Appearance "Show Powered by GeoLens Footer Label" toggle returned 400 "Unknown setting key: branding_show_badge", in both editions. Fixed to send the registry key as-is.

### ISO metadata option lists vs. records CHECK constraints

`frontend/src/lib/iso-constants.ts` offered `fortnightly` in `UPDATE_FREQUENCY_OPTIONS` and `unclassified`/`secret`/`topSecret` in `SENSITIVITY_OPTIONS`. None of those are accepted by `chk_records_update_frequency` / `chk_records_sensitivity` on `Record`. Nothing validates a PATCH before it reaches the database, and the datasets PATCH path has no `IntegrityError` handler, so picking one of these raised an unhandled CheckViolation that the global DBAPIError handler re-raises as a 500. `savePendingDrafts` then discards the server detail and shows a generic "Failed to save pending edits." toast that names no field, so the whole batch of staged metadata edits is lost with no indication which one caused it.

Replaced the four unstorable values with the two legal sensitivity values the UI never offered (`public`, `internal`) and added translations to all four locales (en/es/fr/de).

### Drift tests

Both bugs are the kind this repo already guards against for capabilities, basemap config, and builder alias keys, but nothing existed yet for settings keys or ISO option vocabularies. Added:

- `backend/tests/test_settings_key_drift.py`: parses every settings-key literal the admin frontend sends or reads and asserts the set is a subset of the `persistent_config` registry. Covers both the `useSettingsForm`-mediated shapes (`key: '...'` field defs, `findSetting` lookups, `settingKey` attrs) and the direct-access shapes the one tab that bypasses that hook uses instead (`settings.find((s) => s.key === '...')`, `onSave({ ... })` payload keys, `onReset('...')`), plus the hand-built payload assignments in `api/settings.ts`.
- `backend/tests/test_iso_option_drift.py`: parses `UPDATE_FREQUENCY_OPTIONS` / `SENSITIVITY_OPTIONS` out of `iso-constants.ts` and asserts each is a subset of the matching CHECK constraint's parsed values.
- `frontend/src/api/__tests__/settings.contract.test.ts`: pins the exact PUT body key `updateBranding` sends.

## Review round 1

A codex pass flagged that the first version of `test_settings_key_drift.py` only recognized the `useSettingsForm` shapes, so a typo in `SettingsPermissionsTab.tsx` (the one tab that reads/saves/resets `role_permissions` directly instead of through that hook) would have kept the test green while still producing the same 400-on-write / silent-default-on-read failure the guard exists to catch. Extended the parser to the three direct-access call shapes, added a positive control asserting the parser finds `role_permissions` in that tab through all three shapes, and added a floor on the total parsed key count so a regex regression that silently shrinks the frontend set fails loudly instead of letting the subset check pass vacuously.

Also switched the in-source comments citing this audit finding from the commit-hash label to the repository's `fix(#NNNN)` inline-comment convention (AGENTS.md), now pointing at #1778.

## Schema/API/config impact

None. No migration, no OpenAPI change, no new registry key. Both fixes make the frontend match a backend contract that already existed.

## Verification

Backend (host, Postgres at localhost:5434):
- `uv run pytest tests/test_settings_key_drift.py tests/test_iso_option_drift.py -v`: 4 passed
- `uv run pytest tests/test_branding_settings.py tests/test_capability_drift.py tests/test_basemap_config_drift.py tests/test_builder_alias_keys_drift.py tests/test_dataset_source_freshness.py tests/test_layering.py -q`: 161 passed
- `uv run ruff check` and `uv run ruff format --check` on the two test files: clean

Counterfactual runs (reverted, then restored, for each of the three guards):
- Reverting `updateBranding` back to `settings.branding_show_badge = data.show_badge` makes `test_frontend_setting_keys_subset_of_backend_registry` fail, naming `branding_show_badge`.
- Reverting `iso-constants.ts` back to include `fortnightly` and `unclassified`/`secret`/`topSecret` makes both `test_iso_option_drift.py` tests fail, naming the offending values.
- Typo'ing the `onReset` argument in `SettingsPermissionsTab.tsx` from `'role_permissions'` to `'role_permission'` makes both `test_frontend_setting_keys_subset_of_backend_registry` and the new `test_parser_floor_and_permissions_tab_positive_control` fail, naming `role_permission`.

All three restored to green afterward.

Frontend:
- `npm run typecheck`: clean
- `npm run lint`: clean
- `npm run test:i18n`: 4 passed
- `npx vitest run src/api/__tests__ src/components/dataset src/components/admin/settings src/hooks/__tests__/use-settings.test.ts`: 570 passed across 59 files

## Left alone

Two lower-severity findings from the same audit rows are not addressed here, since the brief scoped this lane to the branding-key spelling and the ISO-option CHECK mismatch:

- `updateBranding` accepts `Partial<BrandingConfig>` (including `privacy_url`), but only ever forwards `show_badge`. A caller passing `privacy_url` alone would PUT an empty settings object and get a silent no-op "Saved" toast. Today `SettingsAppearanceTab` is the only caller and only ever passes `show_badge`, so this is latent, not live.
- The two legal `sensitivity_classification` values the UI never offered (`public`, `internal`) now render correctly since they're valid `SelectItem` options, but no dedicated test exercises the read-only branch of `SourceQualityTab`, since no test file for that component exists yet.
