### PR TITLE
fix(cli): exit non-zero on a failed, cancelled, or timed-out publish --wait

### DIFF
--- a/cli/geolens_cli/main.py
+++ b/cli/geolens_cli/main.py
@@ -651,10 +651,9 @@ def publish(
     ``--wait`` (default), polls the job-status endpoint to resolve the
     dataset_id; ``--no-wait`` returns immediately with a job-search URL.
 
-    fix(audit 2026-08-30 finding 1): with ``--wait``, a job that fails, is
-    cancelled, or does not finish within the poll window exits non-zero and
-    prints a failure line instead of "Published:"; ``--json`` carries the
-    terminal status.
+    fix(#1778): with ``--wait``, a job that fails, is cancelled, or does not
+    finish within the poll window exits non-zero and prints a failure line
+    instead of "Published:"; ``--json`` carries the terminal status.
 
     Pitfall 6: commit is NOT idempotent. On a duplicate commit (job
     already processed), prints "already committed" and exits 1.
@@ -735,12 +734,12 @@ def publish(
         if wait:
             dataset_id = _publish.resolve_dataset_id(sdk.client, job_id)
             if dataset_id is None:
-                # fix(audit 2026-08-30 finding 1, 8dc529f17): resolve_dataset_id
-                # returns None for a failed/cancelled/fanned-out job AND for a
-                # poll that ran out AND for a non-200 response (a token that
-                # expired mid-poll included) — a caller that asked us to wait
-                # must not read any of those as success. Read the status back
-                # so each gets its own sentence and exit code, mirroring
+                # fix(#1778): resolve_dataset_id returns None for a
+                # failed/cancelled/fanned-out job AND for a poll that ran out
+                # AND for a non-200 response (a token that expired mid-poll
+                # included) — a caller that asked us to wait must not read
+                # any of those as success. Read the status back so each gets
+                # its own sentence and exit code, mirroring
                 # `analysis materialize --wait` (below, ~1150).
                 late_status, late_dataset_id = _analysis.job_snapshot(
                     sdk.client, job_id
@@ -782,17 +781,19 @@ def publish(
         # Stage 5 — fix(#569): apply --tags / --collection now that the
         # dataset id exists. Failures here are PARTIAL: the dataset was
         # created, so report honestly and exit non-zero below.
+        #
+        # fix(#1778): when dataset_id is still None here, wait was True (a
+        # bare --no-wait with tags/collection already exits EXIT_USAGE above)
+        # and publish_failure is already set, explaining why. Tags/collection
+        # were never attempted against a dataset that does not exist, so skip
+        # the block rather than append a second, contradictory "not applied"
+        # line under the terminal failure message.
         extras_failures: list[str] = []
-        if tags or collection:
-            if dataset_id is None:
-                extras_failures.append(
-                    "dataset id could not be resolved — tags/collection not applied"
-                )
-            else:
-                progress.add_task("Applying tags/collection...", total=None)
-                extras_failures = _publish.apply_publish_extras(
-                    sdk.client, dataset_id, tags, collection
-                )
+        if (tags or collection) and dataset_id is not None:
+            progress.add_task("Applying tags/collection...", total=None)
+            extras_failures = _publish.apply_publish_extras(
+                sdk.client, dataset_id, tags, collection
+            )
 
     dataset_url = _publish.construct_dataset_url(
         instance,
@@ -1397,8 +1398,8 @@ def analysis_materialize(
         timeout=_analysis.POLL_FOREVER if timeout is None else timeout,
     )
     if resolved is None:
-        # resolve_dataset_id returns None for a failed/cancelled/fanned-out
-        # job (fix(audit 2026-08-30 finding 2): "cancelled" was previously
+        # fix(#1778): resolve_dataset_id returns None for a
+        # failed/cancelled/fanned-out job ("cancelled" was previously
         # missing from its terminal set, so --wait polled a cancelled job
         # under POLL_FOREVER forever) AND for a poll that ran out, and a
         # script that asked us to wait must not read any of those as
@@ -1418,10 +1419,10 @@ def analysis_materialize(
                 f"GET /jobs/{job_id}."
             )
         elif status == "cancelled":
-            # fix(audit 2026-08-30 finding 2): reachable now that
-            # resolve_dataset_id treats cancelled as terminal — say so
-            # plainly instead of falling into the "still {status}" wording
-            # below, which would wrongly imply the job might still finish.
+            # fix(#1778): reachable now that resolve_dataset_id treats
+            # cancelled as terminal — say so plainly instead of falling into
+            # the "still {status}" wording below, which would wrongly imply
+            # the job might still finish.
             state.output.error(
                 f"Analysis job {job_id} was cancelled. Check GET /jobs/{job_id}."
             )

--- a/cli/geolens_cli/main.py
+++ b/cli/geolens_cli/main.py
@@ -772,17 +772,33 @@ def publish(
                 # treat this one-shot diagnostic read as unreadable rather
                 # than letting the network error abort the command outright
                 # — the original outcome is still worth reporting.
-                snapshot_client = sdk.client.with_timeout(
+                #
+                # fix(#1778, codex round 6): `client.with_timeout()` MUTATES
+                # the already-constructed httpx transport in place before
+                # returning an "evolved" wrapper (sdks/python/geolens/
+                # client.py) — the evolved wrapper is a decoy; sdk.client's
+                # OWN transport keeps the 5s bound for the rest of the
+                # command's lifetime. Stage 5 (extras) reuses sdk.client, so
+                # that mutation silently capped every tags/collection
+                # request at 5s too. get_httpx_client() is the SDK's own
+                # public escape hatch (OCCLI-06, used the same way by
+                # upload_file() above); save its timeout, bound it for this
+                # one read, and restore it unconditionally.
+                snapshot_transport = sdk.client.get_httpx_client()
+                original_timeout = snapshot_transport.timeout
+                snapshot_transport.timeout = (
                     _publish._SNAPSHOT_REQUEST_TIMEOUT_SECONDS
                 )
                 try:
                     late_status, late_dataset_id = _analysis.job_snapshot(
-                        snapshot_client, job_id
+                        sdk.client, job_id
                     )
                 except typer.Exit as exc:
                     if exc.exit_code != EXIT_NETWORK:
                         raise
                     late_status, late_dataset_id = None, None
+                finally:
+                    snapshot_transport.timeout = original_timeout
                 if late_dataset_id:
                     dataset_id = late_dataset_id
             if dataset_id is None:
@@ -1497,25 +1513,40 @@ def analysis_materialize(
             # read is skipped for "terminal" and "token_expired" for the
             # same reasons as there.
             #
-            # fix(#1778, codex round 5): use a FRESH, short-bound client
-            # rather than poll_client, which may be unbounded (the default
-            # --wait with no --timeout) or bound to a long caller-supplied
-            # --timeout — either way a stalled connection on this one-shot
-            # diagnostic read would hang the command past the outcome it
-            # already reached. If it ALSO times out, treat the read as
-            # unreadable rather than letting the network error abort the
-            # command — see publish()'s equivalent comment above.
-            snapshot_client = sdk.client.with_timeout(
-                _publish._SNAPSHOT_REQUEST_TIMEOUT_SECONDS
-            )
+            # fix(#1778, codex round 5): bind a short timeout for this
+            # one-shot diagnostic read rather than reusing poll_client
+            # as-is, which may be unbounded (the default --wait with no
+            # --timeout) or bound to a long caller-supplied --timeout —
+            # either way a stalled connection here would hang the command
+            # past the outcome it already reached. If it ALSO times out,
+            # treat the read as unreadable rather than letting the network
+            # error abort the command — see publish()'s equivalent comment.
+            #
+            # fix(#1778, codex round 6): `client.with_timeout()` MUTATES
+            # the already-constructed httpx transport in place before
+            # returning an "evolved" wrapper (sdks/python/geolens/
+            # client.py) — the evolved wrapper is a decoy. Bind sdk.client
+            # (not poll_client, so this can't alias whatever transport the
+            # explicit-timeout path above already constructed) via its own
+            # transport directly: get_httpx_client() is the SDK's public
+            # escape hatch (OCCLI-06); save its timeout, bound it for this
+            # one read, and restore it unconditionally — matching
+            # publish()'s fix, and cheap insurance against a future
+            # materialize change reusing sdk.client after this block the
+            # way publish()'s Stage 5 already does.
+            snapshot_transport = sdk.client.get_httpx_client()
+            original_timeout = snapshot_transport.timeout
+            snapshot_transport.timeout = _publish._SNAPSHOT_REQUEST_TIMEOUT_SECONDS
             try:
                 late_status, late_dataset_id = _analysis.job_snapshot(
-                    snapshot_client, job_id
+                    sdk.client, job_id
                 )
             except typer.Exit as exc:
                 if exc.exit_code != EXIT_NETWORK:
                     raise
                 late_status, late_dataset_id = None, None
+            finally:
+                snapshot_transport.timeout = original_timeout
             if late_dataset_id:
                 # The job finished between the poll's last look and this one
                 # (fix(#685 review)). Reporting a completed job as

--- a/cli/geolens_cli/main.py
+++ b/cli/geolens_cli/main.py
@@ -651,6 +651,11 @@ def publish(
     ``--wait`` (default), polls the job-status endpoint to resolve the
     dataset_id; ``--no-wait`` returns immediately with a job-search URL.
 
+    fix(audit 2026-08-30 finding 1): with ``--wait``, a job that fails, is
+    cancelled, or does not finish within the poll window exits non-zero and
+    prints a failure line instead of "Published:"; ``--json`` carries the
+    terminal status.
+
     Pitfall 6: commit is NOT idempotent. On a duplicate commit (job
     already processed), prints "already committed" and exits 1.
     """
@@ -725,8 +730,54 @@ def publish(
         # Stage 4 — Resolve dataset URL.
         progress.add_task("Resolving dataset...", total=None)
         dataset_id: Optional[str] = None
+        publish_status: Optional[str] = None
+        publish_failure: Optional[str] = None
         if wait:
             dataset_id = _publish.resolve_dataset_id(sdk.client, job_id)
+            if dataset_id is None:
+                # fix(audit 2026-08-30 finding 1, 8dc529f17): resolve_dataset_id
+                # returns None for a failed/cancelled/fanned-out job AND for a
+                # poll that ran out AND for a non-200 response (a token that
+                # expired mid-poll included) — a caller that asked us to wait
+                # must not read any of those as success. Read the status back
+                # so each gets its own sentence and exit code, mirroring
+                # `analysis materialize --wait` (below, ~1150).
+                late_status, late_dataset_id = _analysis.job_snapshot(
+                    sdk.client, job_id
+                )
+                if late_dataset_id:
+                    # The job finished between resolve_dataset_id's last look
+                    # and this one — report success, not a stale failure.
+                    dataset_id = late_dataset_id
+                elif late_status == "failed":
+                    publish_status = "failed"
+                    publish_failure = (
+                        f"Publish job {job_id} failed. Its error is on the "
+                        f"job record: GET /jobs/{job_id}."
+                    )
+                elif late_status == "cancelled":
+                    publish_status = "cancelled"
+                    publish_failure = (
+                        f"Publish job {job_id} was cancelled. "
+                        f"Check GET /jobs/{job_id}."
+                    )
+                elif late_status is None:
+                    # The status endpoint would not answer beyond the 401/403
+                    # that job_snapshot raises on directly — so the job's
+                    # fate is unknown.
+                    publish_status = None
+                    publish_failure = (
+                        f"Publish job {job_id} could not be read back, so "
+                        f"its outcome is unknown. Check GET /jobs/{job_id}."
+                    )
+                else:
+                    # The poll ran out while the job was still pending/running.
+                    publish_status = late_status
+                    publish_failure = (
+                        f"Publish job {job_id} was still {late_status} after "
+                        f"{int(_publish._DEFAULT_POLL_TIMEOUT_SECONDS)}s and "
+                        f"has not finished. Check GET /jobs/{job_id}."
+                    )
 
         # Stage 5 — fix(#569): apply --tags / --collection now that the
         # dataset id exists. Failures here are PARTIAL: the dataset was
@@ -749,11 +800,12 @@ def publish(
         job_id=str(job_id),
     )
 
+    commit_status = getattr(commit, "status", None)
     payload = {
         "dataset_url": dataset_url,
         "job_id": str(job_id),
         "dataset_id": str(dataset_id) if dataset_id else None,
-        "status": getattr(commit, "status", None),
+        "status": publish_status if publish_failure else commit_status,
     }
     if tags or collection:
         payload["extras_failures"] = extras_failures
@@ -761,10 +813,13 @@ def publish(
     if state.json_mode:
         state.output.json(payload)
     else:
-        state.output.success(f"Published: {dataset_url}")
+        if publish_failure:
+            state.output.error(publish_failure)
+        else:
+            state.output.success(f"Published: {dataset_url}")
         for failure in extras_failures:
             state.output.warn(f"Dataset created, but: {failure}")
-    if extras_failures:
+    if publish_failure or extras_failures:
         raise typer.Exit(EXIT_GENERIC)
 
 
@@ -1342,11 +1397,14 @@ def analysis_materialize(
         timeout=_analysis.POLL_FOREVER if timeout is None else timeout,
     )
     if resolved is None:
-        # resolve_dataset_id returns None for BOTH a failed job and a poll
-        # that ran out, and a script that asked us to wait must not read
-        # either as success. Read the status back so the two get different
-        # sentences; both still exit non-zero, because neither produced the
-        # dataset the caller waited for.
+        # resolve_dataset_id returns None for a failed/cancelled/fanned-out
+        # job (fix(audit 2026-08-30 finding 2): "cancelled" was previously
+        # missing from its terminal set, so --wait polled a cancelled job
+        # under POLL_FOREVER forever) AND for a poll that ran out, and a
+        # script that asked us to wait must not read any of those as
+        # success. Read the status back so each gets its own sentence; all
+        # still exit non-zero, because none produced the dataset the caller
+        # waited for.
         status, late_dataset_id = _analysis.job_snapshot(poll_client, job_id)
         if late_dataset_id:
             # The job finished between the poll's last look and this one, and
@@ -1358,6 +1416,14 @@ def analysis_materialize(
             state.output.error(
                 f"Analysis job {job_id} failed. Its error is on the job record: "
                 f"GET /jobs/{job_id}."
+            )
+        elif status == "cancelled":
+            # fix(audit 2026-08-30 finding 2): reachable now that
+            # resolve_dataset_id treats cancelled as terminal — say so
+            # plainly instead of falling into the "still {status}" wording
+            # below, which would wrongly imply the job might still finish.
+            state.output.error(
+                f"Analysis job {job_id} was cancelled. Check GET /jobs/{job_id}."
             )
         elif status is None:
             # The status endpoint would not answer (auth, 404, 5xx), so the

--- a/cli/geolens_cli/main.py
+++ b/cli/geolens_cli/main.py
@@ -741,6 +741,7 @@ def publish(
         if wait:
             outcome = _publish.resolve_dataset_id(sdk.client, job_id)
             dataset_id = outcome.dataset_id
+            late_status: Optional[str] = None
             if dataset_id is None and outcome.stopped_because in (
                 "timeout",
                 "poll_failed",
@@ -754,29 +755,42 @@ def publish(
                 # false "still running after 120s" timeout. This extra read
                 # is skipped for "terminal" (a terminal status cannot later
                 # gain a dataset_id) and "token_expired" (retrying the same
-                # dead token is pointless); where it does run, only its
-                # dataset_id is trusted — the job can genuinely finish
-                # between resolve_dataset_id's last look and now — and its
-                # own status is discarded rather than used for wording.
-                _, late_dataset_id = _analysis.job_snapshot(sdk.client, job_id)
+                # dead token is pointless).
+                late_status, late_dataset_id = _analysis.job_snapshot(
+                    sdk.client, job_id
+                )
                 if late_dataset_id:
                     dataset_id = late_dataset_id
             if dataset_id is None:
                 wait_outcome_known = True
-                publish_status = outcome.status
-                publish_stopped_because = outcome.stopped_because
-                reason = outcome.stopped_because
-                if reason == "terminal" and outcome.status == "failed":
+                # fix(#1778, codex round 4): the job can finish between
+                # resolve_dataset_id's last look and now (fix(#685 review)),
+                # but it can just as well have reached a DEFINITIVE terminal
+                # status by then — failed, cancelled, or fanned out. That is
+                # real information the original poll didn't have and must
+                # win over the stale timeout/poll_failed wording; only a
+                # pending/running (or unreadable) snapshot leaves the job's
+                # fate genuinely unresolved, so only THAT keeps the original
+                # outcome's wording.
+                if late_status in _publish._TERMINAL_NO_DATASET_STATUSES:
+                    effective_status = late_status
+                    reason = "terminal"
+                else:
+                    effective_status = outcome.status
+                    reason = outcome.stopped_because
+                publish_status = effective_status
+                publish_stopped_because = reason
+                if reason == "terminal" and effective_status == "failed":
                     publish_failure = (
                         f"Publish job {job_id} failed. Its error is on the "
                         f"job record: GET /jobs/{job_id}."
                     )
-                elif reason == "terminal" and outcome.status == "cancelled":
+                elif reason == "terminal" and effective_status == "cancelled":
                     publish_failure = (
                         f"Publish job {job_id} was cancelled. "
                         f"Check GET /jobs/{job_id}."
                     )
-                elif reason == "terminal" and outcome.status == "fanned_out":
+                elif reason == "terminal" and effective_status == "fanned_out":
                     # fanned_out is TERMINAL and a SUCCESS, not a timeout —
                     # the parent job of a multi-layer commit lands here the
                     # moment each layer's own import is queued
@@ -798,7 +812,7 @@ def publish(
                     # wording for yet.
                     publish_failure = (
                         f"Publish job {job_id} reached status "
-                        f"{outcome.status!r}, which will not produce a "
+                        f"{effective_status!r}, which will not produce a "
                         f"dataset. Check GET /jobs/{job_id}."
                     )
                 elif reason == "token_expired":
@@ -814,7 +828,7 @@ def publish(
                     )
                 else:  # "timeout"
                     publish_failure = (
-                        f"Publish job {job_id} was still {outcome.status} "
+                        f"Publish job {job_id} was still {effective_status} "
                         f"after {int(_publish._DEFAULT_POLL_TIMEOUT_SECONDS)}s "
                         f"and has not finished. Check GET /jobs/{job_id}."
                     )
@@ -1449,6 +1463,7 @@ def analysis_materialize(
     materialize_message: Optional[str] = None
     materialize_exit_code = EXIT_GENERIC
     if resolved is None:
+        late_status: Optional[str] = None
         if outcome.stopped_because in ("timeout", "poll_failed"):
             # fix(#1778, codex round 3): resolve_dataset_id now reports WHY
             # it stopped instead of collapsing every reason into None — see
@@ -1456,24 +1471,37 @@ def analysis_materialize(
             # (a transient poll failure followed by a lucky pending/running
             # re-read used to be reported as a false timeout). This extra
             # read is skipped for "terminal" and "token_expired" for the
-            # same reasons as there; where it does run, only its dataset_id
-            # is trusted.
-            _, late_dataset_id = _analysis.job_snapshot(poll_client, job_id)
+            # same reasons as there.
+            late_status, late_dataset_id = _analysis.job_snapshot(
+                poll_client, job_id
+            )
             if late_dataset_id:
                 # The job finished between the poll's last look and this one
                 # (fix(#685 review)). Reporting a completed job as
                 # unfinished would be the worst answer of the bunch.
                 resolved = late_dataset_id
         if resolved is None:
-            materialize_status = outcome.status
-            materialize_stopped_because = outcome.stopped_because
-            reason = outcome.stopped_because
-            if reason == "terminal" and outcome.status == "failed":
+            # fix(#1778, codex round 4): the job can just as well have
+            # reached a DEFINITIVE terminal status by the time of the
+            # follow-up read — failed, cancelled, or fanned out. That real
+            # information must win over the stale timeout/poll_failed
+            # wording; only a pending/running (or unreadable) snapshot
+            # leaves the job's fate genuinely unresolved, so only THAT
+            # keeps the original outcome's wording.
+            if late_status in _publish._TERMINAL_NO_DATASET_STATUSES:
+                effective_status = late_status
+                reason = "terminal"
+            else:
+                effective_status = outcome.status
+                reason = outcome.stopped_because
+            materialize_status = effective_status
+            materialize_stopped_because = reason
+            if reason == "terminal" and effective_status == "failed":
                 materialize_failure = (
                     f"Analysis job {job_id} failed. Its error is on the job "
                     f"record: GET /jobs/{job_id}."
                 )
-            elif reason == "terminal" and outcome.status == "cancelled":
+            elif reason == "terminal" and effective_status == "cancelled":
                 # fix(#1778): reachable now that resolve_dataset_id treats
                 # cancelled as terminal — say so plainly instead of falling
                 # into the "still {status}" wording below, which would
@@ -1482,7 +1510,7 @@ def analysis_materialize(
                     f"Analysis job {job_id} was cancelled. "
                     f"Check GET /jobs/{job_id}."
                 )
-            elif reason == "terminal" and outcome.status == "fanned_out":
+            elif reason == "terminal" and effective_status == "fanned_out":
                 # A fanned-out job is a SUCCESS whose children each carry
                 # their own dataset — see publish()'s equivalent branch.
                 # materialize jobs are never fanned out by the current
@@ -1496,8 +1524,8 @@ def analysis_materialize(
             elif reason == "terminal":
                 materialize_failure = (
                     f"Analysis job {job_id} reached status "
-                    f"{outcome.status!r}, which will not produce a dataset. "
-                    f"Check GET /jobs/{job_id}."
+                    f"{effective_status!r}, which will not produce a "
+                    f"dataset. Check GET /jobs/{job_id}."
                 )
             elif reason == "token_expired":
                 materialize_exit_code = EXIT_AUTH
@@ -1515,8 +1543,8 @@ def analysis_materialize(
                 # waits for a terminal state. Unfinished is not failed, and
                 # the wording says so (fix(#685 review)).
                 materialize_failure = (
-                    f"Analysis job {job_id} was still {outcome.status} after "
-                    f"{int(timeout or 0)}s and has not finished. "
+                    f"Analysis job {job_id} was still {effective_status} "
+                    f"after {int(timeout or 0)}s and has not finished. "
                     f"Check GET /jobs/{job_id}."
                 )
 

--- a/cli/geolens_cli/main.py
+++ b/cli/geolens_cli/main.py
@@ -733,51 +733,55 @@ def publish(
         progress.add_task("Resolving dataset...", total=None)
         dataset_id: Optional[str] = None
         publish_status: Optional[str] = None
+        publish_stopped_because: Optional[str] = None
         publish_failure: Optional[str] = None
         publish_message: Optional[str] = None
+        publish_exit_code = EXIT_GENERIC
         wait_outcome_known = False
         if wait:
-            dataset_id = _publish.resolve_dataset_id(sdk.client, job_id)
-            if dataset_id is None:
-                # fix(#1778): resolve_dataset_id returns None for a
-                # failed/cancelled/fanned-out job AND for a poll that ran out
-                # AND for a non-200 response (a token that expired mid-poll
-                # included) — a caller that asked us to wait must not read
-                # any of those as success. Read the status back so each gets
-                # its own sentence and exit code, mirroring
-                # `analysis materialize --wait` (below, ~1150).
-                late_status, late_dataset_id = _analysis.job_snapshot(
-                    sdk.client, job_id
-                )
+            outcome = _publish.resolve_dataset_id(sdk.client, job_id)
+            dataset_id = outcome.dataset_id
+            if dataset_id is None and outcome.stopped_because in (
+                "timeout",
+                "poll_failed",
+            ):
+                # fix(#1778, codex round 3): resolve_dataset_id now reports
+                # WHY it stopped (outcome.stopped_because) instead of
+                # collapsing every reason into None, so the wording below no
+                # longer has to be guessed from a second, possibly-
+                # contradictory read — a transient poll failure followed by a
+                # lucky pending/running re-read used to be reported as a
+                # false "still running after 120s" timeout. This extra read
+                # is skipped for "terminal" (a terminal status cannot later
+                # gain a dataset_id) and "token_expired" (retrying the same
+                # dead token is pointless); where it does run, only its
+                # dataset_id is trusted — the job can genuinely finish
+                # between resolve_dataset_id's last look and now — and its
+                # own status is discarded rather than used for wording.
+                _, late_dataset_id = _analysis.job_snapshot(sdk.client, job_id)
                 if late_dataset_id:
-                    # The job finished between resolve_dataset_id's last look
-                    # and this one — report success, not a stale failure.
                     dataset_id = late_dataset_id
-                elif late_status == "failed":
-                    wait_outcome_known = True
-                    publish_status = "failed"
+            if dataset_id is None:
+                wait_outcome_known = True
+                publish_status = outcome.status
+                publish_stopped_because = outcome.stopped_because
+                reason = outcome.stopped_because
+                if reason == "terminal" and outcome.status == "failed":
                     publish_failure = (
                         f"Publish job {job_id} failed. Its error is on the "
                         f"job record: GET /jobs/{job_id}."
                     )
-                elif late_status == "cancelled":
-                    wait_outcome_known = True
-                    publish_status = "cancelled"
+                elif reason == "terminal" and outcome.status == "cancelled":
                     publish_failure = (
                         f"Publish job {job_id} was cancelled. "
                         f"Check GET /jobs/{job_id}."
                     )
-                elif late_status == "fanned_out":
-                    # fix(#1778): fanned_out is TERMINAL and a SUCCESS, not a
-                    # timeout — the parent job of a multi-layer commit lands
-                    # here the moment each layer's own import is queued
+                elif reason == "terminal" and outcome.status == "fanned_out":
+                    # fanned_out is TERMINAL and a SUCCESS, not a timeout —
+                    # the parent job of a multi-layer commit lands here the
+                    # moment each layer's own import is queued
                     # (commit_fan_out, backend/app/processing/ingest/
                     # router.py), and never gets a dataset_id of its own.
-                    # Falling into the "still {status} ... has not finished"
-                    # wording below would be a false diagnosis: nothing timed
-                    # out and nothing failed, so exit 0.
-                    wait_outcome_known = True
-                    publish_status = "fanned_out"
                     publish_message = (
                         f"Publish job {job_id} fanned out into one import "
                         f"per layer; each layer is importing as its own "
@@ -789,24 +793,30 @@ def publish(
                             " --tags/--collection were not applied: there is "
                             "no single dataset id to apply them to."
                         )
-                elif late_status is None:
-                    # The status endpoint would not answer beyond the 401/403
-                    # that job_snapshot raises on directly — so the job's
-                    # fate is unknown.
-                    wait_outcome_known = True
-                    publish_status = None
+                elif reason == "terminal":
+                    # A future terminal status this CLI has no specific
+                    # wording for yet.
                     publish_failure = (
-                        f"Publish job {job_id} could not be read back, so "
-                        f"its outcome is unknown. Check GET /jobs/{job_id}."
+                        f"Publish job {job_id} reached status "
+                        f"{outcome.status!r}, which will not produce a "
+                        f"dataset. Check GET /jobs/{job_id}."
                     )
-                else:
-                    # The poll ran out while the job was still pending/running.
-                    wait_outcome_known = True
-                    publish_status = late_status
+                elif reason == "token_expired":
+                    publish_exit_code = EXIT_AUTH
                     publish_failure = (
-                        f"Publish job {job_id} was still {late_status} after "
-                        f"{int(_publish._DEFAULT_POLL_TIMEOUT_SECONDS)}s and "
-                        f"has not finished. Check GET /jobs/{job_id}."
+                        f"Authentication failed while reading job {job_id}'s "
+                        f"status. Run `geolens login` first."
+                    )
+                elif reason == "poll_failed":
+                    publish_failure = (
+                        f"Publish job {job_id}'s status could not be read "
+                        f"({outcome.detail}). Check GET /jobs/{job_id}."
+                    )
+                else:  # "timeout"
+                    publish_failure = (
+                        f"Publish job {job_id} was still {outcome.status} "
+                        f"after {int(_publish._DEFAULT_POLL_TIMEOUT_SECONDS)}s "
+                        f"and has not finished. Check GET /jobs/{job_id}."
                     )
 
         # Stage 5 — fix(#569): apply --tags / --collection now that the
@@ -839,6 +849,7 @@ def publish(
         "job_id": str(job_id),
         "dataset_id": str(dataset_id) if dataset_id else None,
         "status": publish_status if wait_outcome_known else commit_status,
+        "stopped_because": publish_stopped_because,
     }
     if tags or collection:
         payload["extras_failures"] = extras_failures
@@ -855,7 +866,7 @@ def publish(
         for failure in extras_failures:
             state.output.warn(f"Dataset created, but: {failure}")
     if publish_failure or extras_failures:
-        raise typer.Exit(EXIT_GENERIC)
+        raise typer.Exit(publish_exit_code if publish_failure else EXIT_GENERIC)
 
 
 @app.command()
@@ -1426,63 +1437,107 @@ def analysis_materialize(
     # A float rather than an httpx.Timeout because OCCLI-06 forbids importing
     # httpx here; httpx accepts either.
     poll_client = sdk.client if timeout is None else sdk.client.with_timeout(timeout)
-    resolved = _publish.resolve_dataset_id(
+    outcome = _publish.resolve_dataset_id(
         poll_client,
         job_id,
         timeout=_analysis.POLL_FOREVER if timeout is None else timeout,
     )
+    resolved = outcome.dataset_id
+    materialize_status: Optional[str] = None
+    materialize_stopped_because: Optional[str] = None
+    materialize_failure: Optional[str] = None
+    materialize_message: Optional[str] = None
+    materialize_exit_code = EXIT_GENERIC
     if resolved is None:
-        # fix(#1778): resolve_dataset_id returns None for a
-        # failed/cancelled/fanned-out job ("cancelled" was previously
-        # missing from its terminal set, so --wait polled a cancelled job
-        # under POLL_FOREVER forever) AND for a poll that ran out, and a
-        # script that asked us to wait must not read any of those as
-        # success. Read the status back so each gets its own sentence; all
-        # still exit non-zero, because none produced the dataset the caller
-        # waited for.
-        status, late_dataset_id = _analysis.job_snapshot(poll_client, job_id)
-        if late_dataset_id:
-            # The job finished between the poll's last look and this one, and
-            # the status response carries the id (fix(#685 review)). Reporting
-            # a completed job as unfinished would be the worst answer of the
-            # three.
-            resolved = late_dataset_id
-        elif status == "failed":
-            state.output.error(
-                f"Analysis job {job_id} failed. Its error is on the job record: "
-                f"GET /jobs/{job_id}."
-            )
-        elif status == "cancelled":
-            # fix(#1778): reachable now that resolve_dataset_id treats
-            # cancelled as terminal — say so plainly instead of falling into
-            # the "still {status}" wording below, which would wrongly imply
-            # the job might still finish.
-            state.output.error(
-                f"Analysis job {job_id} was cancelled. Check GET /jobs/{job_id}."
-            )
-        elif status is None:
-            # The status endpoint would not answer (auth, 404, 5xx), so the
-            # job's fate is unknown — do not assert a timeout it may not have
-            # hit (fix(#685 review)).
-            state.output.error(
-                f"Analysis job {job_id} could not be read back, so its outcome "
-                f"is unknown. Check GET /jobs/{job_id}."
-            )
-        else:
-            # Only reachable with an explicit --timeout: the default waits for
-            # a terminal state. Unfinished is not failed, and the wording says
-            # so (fix(#685 review)).
-            state.output.error(
-                f"Analysis job {job_id} was still {status} after {int(timeout or 0)}s "
-                f"and has not finished. Check GET /jobs/{job_id}."
-            )
+        if outcome.stopped_because in ("timeout", "poll_failed"):
+            # fix(#1778, codex round 3): resolve_dataset_id now reports WHY
+            # it stopped instead of collapsing every reason into None — see
+            # publish()'s equivalent comment above for the bug this fixes
+            # (a transient poll failure followed by a lucky pending/running
+            # re-read used to be reported as a false timeout). This extra
+            # read is skipped for "terminal" and "token_expired" for the
+            # same reasons as there; where it does run, only its dataset_id
+            # is trusted.
+            _, late_dataset_id = _analysis.job_snapshot(poll_client, job_id)
+            if late_dataset_id:
+                # The job finished between the poll's last look and this one
+                # (fix(#685 review)). Reporting a completed job as
+                # unfinished would be the worst answer of the bunch.
+                resolved = late_dataset_id
         if resolved is None:
-            raise typer.Exit(EXIT_GENERIC)
+            materialize_status = outcome.status
+            materialize_stopped_because = outcome.stopped_because
+            reason = outcome.stopped_because
+            if reason == "terminal" and outcome.status == "failed":
+                materialize_failure = (
+                    f"Analysis job {job_id} failed. Its error is on the job "
+                    f"record: GET /jobs/{job_id}."
+                )
+            elif reason == "terminal" and outcome.status == "cancelled":
+                # fix(#1778): reachable now that resolve_dataset_id treats
+                # cancelled as terminal — say so plainly instead of falling
+                # into the "still {status}" wording below, which would
+                # wrongly imply the job might still finish.
+                materialize_failure = (
+                    f"Analysis job {job_id} was cancelled. "
+                    f"Check GET /jobs/{job_id}."
+                )
+            elif reason == "terminal" and outcome.status == "fanned_out":
+                # A fanned-out job is a SUCCESS whose children each carry
+                # their own dataset — see publish()'s equivalent branch.
+                # materialize jobs are never fanned out by the current
+                # backend (fan-out is ingest-only), so this is defensive,
+                # not reachable today.
+                materialize_message = (
+                    f"Analysis job {job_id} fanned out into one import per "
+                    f"layer; check GET /jobs/{job_id} or the datasets list "
+                    f"for the resulting datasets."
+                )
+            elif reason == "terminal":
+                materialize_failure = (
+                    f"Analysis job {job_id} reached status "
+                    f"{outcome.status!r}, which will not produce a dataset. "
+                    f"Check GET /jobs/{job_id}."
+                )
+            elif reason == "token_expired":
+                materialize_exit_code = EXIT_AUTH
+                materialize_failure = (
+                    f"Authentication failed while reading job {job_id}'s "
+                    f"status. Run `geolens login` first."
+                )
+            elif reason == "poll_failed":
+                materialize_failure = (
+                    f"Analysis job {job_id}'s status could not be read "
+                    f"({outcome.detail}). Check GET /jobs/{job_id}."
+                )
+            else:
+                # Only reachable with an explicit --timeout: the default
+                # waits for a terminal state. Unfinished is not failed, and
+                # the wording says so (fix(#685 review)).
+                materialize_failure = (
+                    f"Analysis job {job_id} was still {outcome.status} after "
+                    f"{int(timeout or 0)}s and has not finished. "
+                    f"Check GET /jobs/{job_id}."
+                )
 
     url = _publish.construct_dataset_url(
         instance, dataset_id=resolved, job_id=job_id
     )
+    payload = {
+        "job_id": job_id,
+        "dataset_id": resolved,
+        "url": url,
+        "status": materialize_status,
+        "stopped_because": materialize_stopped_because,
+    }
     if state.output.json_mode:
-        state.output.json({"job_id": job_id, "dataset_id": resolved, "url": url})
-        return
-    state.output.success(url)
+        state.output.json(payload)
+    else:
+        if materialize_failure:
+            state.output.error(materialize_failure)
+        elif materialize_message:
+            state.output.success(materialize_message)
+        else:
+            state.output.success(url)
+    if materialize_failure:
+        raise typer.Exit(materialize_exit_code)

--- a/cli/geolens_cli/main.py
+++ b/cli/geolens_cli/main.py
@@ -29,7 +29,14 @@ from . import publish as _publish
 from . import refresh as _refresh
 from . import replace as _replace
 from . import scan as _scan
-from ._sdk_helpers import EXIT_AUTH, EXIT_GENERIC, EXIT_USAGE, call_sdk, unwrap
+from ._sdk_helpers import (
+    EXIT_AUTH,
+    EXIT_GENERIC,
+    EXIT_NETWORK,
+    EXIT_USAGE,
+    call_sdk,
+    unwrap,
+)
 
 app = typer.Typer(no_args_is_help=True, rich_markup_mode="rich", help="GeoLens CLI")
 export_app = typer.Typer(no_args_is_help=True, help="Export commands")
@@ -756,9 +763,26 @@ def publish(
                 # is skipped for "terminal" (a terminal status cannot later
                 # gain a dataset_id) and "token_expired" (retrying the same
                 # dead token is pointless).
-                late_status, late_dataset_id = _analysis.job_snapshot(
-                    sdk.client, job_id
+                #
+                # fix(#1778, codex round 5): sdk.client's generated transport
+                # defaults to timeout=None (unbounded), so a stalled
+                # connection on THIS read would hang the command forever
+                # instead of reporting the outcome the poll already reached.
+                # Bind it to a short, named bound; if that ALSO times out,
+                # treat this one-shot diagnostic read as unreadable rather
+                # than letting the network error abort the command outright
+                # — the original outcome is still worth reporting.
+                snapshot_client = sdk.client.with_timeout(
+                    _publish._SNAPSHOT_REQUEST_TIMEOUT_SECONDS
                 )
+                try:
+                    late_status, late_dataset_id = _analysis.job_snapshot(
+                        snapshot_client, job_id
+                    )
+                except typer.Exit as exc:
+                    if exc.exit_code != EXIT_NETWORK:
+                        raise
+                    late_status, late_dataset_id = None, None
                 if late_dataset_id:
                     dataset_id = late_dataset_id
             if dataset_id is None:
@@ -1472,9 +1496,26 @@ def analysis_materialize(
             # re-read used to be reported as a false timeout). This extra
             # read is skipped for "terminal" and "token_expired" for the
             # same reasons as there.
-            late_status, late_dataset_id = _analysis.job_snapshot(
-                poll_client, job_id
+            #
+            # fix(#1778, codex round 5): use a FRESH, short-bound client
+            # rather than poll_client, which may be unbounded (the default
+            # --wait with no --timeout) or bound to a long caller-supplied
+            # --timeout — either way a stalled connection on this one-shot
+            # diagnostic read would hang the command past the outcome it
+            # already reached. If it ALSO times out, treat the read as
+            # unreadable rather than letting the network error abort the
+            # command — see publish()'s equivalent comment above.
+            snapshot_client = sdk.client.with_timeout(
+                _publish._SNAPSHOT_REQUEST_TIMEOUT_SECONDS
             )
+            try:
+                late_status, late_dataset_id = _analysis.job_snapshot(
+                    snapshot_client, job_id
+                )
+            except typer.Exit as exc:
+                if exc.exit_code != EXIT_NETWORK:
+                    raise
+                late_status, late_dataset_id = None, None
             if late_dataset_id:
                 # The job finished between the poll's last look and this one
                 # (fix(#685 review)). Reporting a completed job as

--- a/cli/geolens_cli/main.py
+++ b/cli/geolens_cli/main.py
@@ -744,6 +744,7 @@ def publish(
         publish_failure: Optional[str] = None
         publish_message: Optional[str] = None
         publish_exit_code = EXIT_GENERIC
+        publish_extras_skipped: list[str] = []
         wait_outcome_known = False
         if wait:
             outcome = _publish.resolve_dataset_id(sdk.client, job_id)
@@ -842,10 +843,26 @@ def publish(
                         f"dataset. Check GET /jobs/{job_id} or the datasets "
                         f"list for progress."
                     )
-                    if tags or collection:
-                        publish_message += (
-                            " --tags/--collection were not applied: there is "
-                            "no single dataset id to apply them to."
+                    # fix(#1778, codex round 9): a note appended only to
+                    # publish_message was cosmetic — extras_failures stayed
+                    # empty, so Stage 5 below never ran and the command
+                    # exited 0 even though --tags/--collection were
+                    # requested and never applied. --json showed
+                    # extras_failures: [] too, telling automation nothing
+                    # was skipped. Recording the omission as an extras
+                    # failure instead routes it through the existing
+                    # extras-failure path: non-zero exit, and present in
+                    # the --json payload, same as any other partial
+                    # publish failure.
+                    if tags:
+                        publish_extras_skipped.append(
+                            "tags not applied: job fanned out into "
+                            "per-layer datasets"
+                        )
+                    if collection:
+                        publish_extras_skipped.append(
+                            "collection not applied: job fanned out into "
+                            "per-layer datasets"
                         )
                 elif reason == "terminal":
                     # A future terminal status this CLI has no specific
@@ -890,14 +907,18 @@ def publish(
         # and publish_failure or publish_message is already set, explaining
         # why. Tags/collection were never attempted against a dataset that
         # does not exist (or does not exist as a single id, for fanned_out),
-        # so skip the block rather than append a second, contradictory "not
-        # applied" line under the terminal message.
+        # so skip the API call — but fix(#1778, codex round 9):
+        # publish_extras_skipped still carries one entry per requested
+        # extra when fanned_out is the reason, so the omission still counts
+        # as an extras failure below instead of silently exiting 0.
         extras_failures: list[str] = []
         if (tags or collection) and dataset_id is not None:
             progress.add_task("Applying tags/collection...", total=None)
             extras_failures = _publish.apply_publish_extras(
                 sdk.client, dataset_id, tags, collection
             )
+        elif publish_extras_skipped:
+            extras_failures = publish_extras_skipped
 
     dataset_url = _publish.construct_dataset_url(
         instance,

--- a/cli/geolens_cli/main.py
+++ b/cli/geolens_cli/main.py
@@ -862,6 +862,14 @@ def publish(
                         f"status. Run `geolens login` first."
                     )
                 elif reason == "poll_failed":
+                    # fix(#1778, codex round 7): a poll_failed outcome
+                    # collapsed EVERY non-200 into the same generic exit
+                    # code, hiding a 5xx server outage from a script that
+                    # checks the exit code — match the same status matrix
+                    # unwrap() already uses elsewhere in this CLI.
+                    publish_exit_code = _publish.poll_failed_exit_code(
+                        outcome.http_status
+                    )
                     publish_failure = (
                         f"Publish job {job_id}'s status could not be read "
                         f"({outcome.detail}). Check GET /jobs/{job_id}."
@@ -1606,6 +1614,14 @@ def analysis_materialize(
                     f"status. Run `geolens login` first."
                 )
             elif reason == "poll_failed":
+                # fix(#1778, codex round 7): a poll_failed outcome collapsed
+                # EVERY non-200 into the same generic exit code, hiding a
+                # 5xx server outage from a script that checks the exit code
+                # — match the same status matrix unwrap() already uses
+                # elsewhere in this CLI.
+                materialize_exit_code = _publish.poll_failed_exit_code(
+                    outcome.http_status
+                )
                 materialize_failure = (
                     f"Analysis job {job_id}'s status could not be read "
                     f"({outcome.detail}). Check GET /jobs/{job_id}."

--- a/cli/geolens_cli/main.py
+++ b/cli/geolens_cli/main.py
@@ -653,7 +653,10 @@ def publish(
 
     fix(#1778): with ``--wait``, a job that fails, is cancelled, or does not
     finish within the poll window exits non-zero and prints a failure line
-    instead of "Published:"; ``--json`` carries the terminal status.
+    instead of "Published:"; ``--json`` carries the terminal status. A job
+    that fanned out into one import per layer is a success (exit 0), not a
+    failure — ``--json`` status is ``"fanned_out"`` and no single dataset id
+    is printed.
 
     Pitfall 6: commit is NOT idempotent. On a duplicate commit (job
     already processed), prints "already committed" and exits 1.
@@ -731,6 +734,8 @@ def publish(
         dataset_id: Optional[str] = None
         publish_status: Optional[str] = None
         publish_failure: Optional[str] = None
+        publish_message: Optional[str] = None
+        wait_outcome_known = False
         if wait:
             dataset_id = _publish.resolve_dataset_id(sdk.client, job_id)
             if dataset_id is None:
@@ -749,21 +754,46 @@ def publish(
                     # and this one — report success, not a stale failure.
                     dataset_id = late_dataset_id
                 elif late_status == "failed":
+                    wait_outcome_known = True
                     publish_status = "failed"
                     publish_failure = (
                         f"Publish job {job_id} failed. Its error is on the "
                         f"job record: GET /jobs/{job_id}."
                     )
                 elif late_status == "cancelled":
+                    wait_outcome_known = True
                     publish_status = "cancelled"
                     publish_failure = (
                         f"Publish job {job_id} was cancelled. "
                         f"Check GET /jobs/{job_id}."
                     )
+                elif late_status == "fanned_out":
+                    # fix(#1778): fanned_out is TERMINAL and a SUCCESS, not a
+                    # timeout — the parent job of a multi-layer commit lands
+                    # here the moment each layer's own import is queued
+                    # (commit_fan_out, backend/app/processing/ingest/
+                    # router.py), and never gets a dataset_id of its own.
+                    # Falling into the "still {status} ... has not finished"
+                    # wording below would be a false diagnosis: nothing timed
+                    # out and nothing failed, so exit 0.
+                    wait_outcome_known = True
+                    publish_status = "fanned_out"
+                    publish_message = (
+                        f"Publish job {job_id} fanned out into one import "
+                        f"per layer; each layer is importing as its own "
+                        f"dataset. Check GET /jobs/{job_id} or the datasets "
+                        f"list for progress."
+                    )
+                    if tags or collection:
+                        publish_message += (
+                            " --tags/--collection were not applied: there is "
+                            "no single dataset id to apply them to."
+                        )
                 elif late_status is None:
                     # The status endpoint would not answer beyond the 401/403
                     # that job_snapshot raises on directly — so the job's
                     # fate is unknown.
+                    wait_outcome_known = True
                     publish_status = None
                     publish_failure = (
                         f"Publish job {job_id} could not be read back, so "
@@ -771,6 +801,7 @@ def publish(
                     )
                 else:
                     # The poll ran out while the job was still pending/running.
+                    wait_outcome_known = True
                     publish_status = late_status
                     publish_failure = (
                         f"Publish job {job_id} was still {late_status} after "
@@ -784,10 +815,11 @@ def publish(
         #
         # fix(#1778): when dataset_id is still None here, wait was True (a
         # bare --no-wait with tags/collection already exits EXIT_USAGE above)
-        # and publish_failure is already set, explaining why. Tags/collection
-        # were never attempted against a dataset that does not exist, so skip
-        # the block rather than append a second, contradictory "not applied"
-        # line under the terminal failure message.
+        # and publish_failure or publish_message is already set, explaining
+        # why. Tags/collection were never attempted against a dataset that
+        # does not exist (or does not exist as a single id, for fanned_out),
+        # so skip the block rather than append a second, contradictory "not
+        # applied" line under the terminal message.
         extras_failures: list[str] = []
         if (tags or collection) and dataset_id is not None:
             progress.add_task("Applying tags/collection...", total=None)
@@ -806,7 +838,7 @@ def publish(
         "dataset_url": dataset_url,
         "job_id": str(job_id),
         "dataset_id": str(dataset_id) if dataset_id else None,
-        "status": publish_status if publish_failure else commit_status,
+        "status": publish_status if wait_outcome_known else commit_status,
     }
     if tags or collection:
         payload["extras_failures"] = extras_failures
@@ -816,6 +848,8 @@ def publish(
     else:
         if publish_failure:
             state.output.error(publish_failure)
+        elif publish_message:
+            state.output.success(publish_message)
         else:
             state.output.success(f"Published: {dataset_url}")
         for failure in extras_failures:

--- a/cli/geolens_cli/publish.py
+++ b/cli/geolens_cli/publish.py
@@ -42,7 +42,7 @@ from uuid import UUID
 
 import typer
 
-from ._sdk_helpers import EXIT_GENERIC, call_sdk
+from ._sdk_helpers import EXIT_GENERIC, EXIT_SERVER, call_sdk
 
 # ---------------------------------------------------------------------------
 # Status-code constants — verified by Plan 04 Task 0 Q4 spike.
@@ -271,13 +271,36 @@ class PollOutcome:
     - ``"token_expired"``: a job-status request came back 401/403.
     - ``"poll_failed"``: a job-status request failed some other way (a
       non-200/401/403 status, or a response body that could not be parsed)
-      — ``detail`` names the failure (an HTTP status or error text).
+      — ``detail`` names the failure (an HTTP status or error text), and
+      ``http_status`` carries the numeric status when the failure was a
+      real HTTP response (fix(#1778, codex round 7): a caller must be able
+      to tell a 5xx from a 404 to select the CLI's own EXIT_SERVER vs
+      EXIT_GENERIC per the matrix in ``_sdk_helpers.unwrap()`` — collapsing
+      every poll_failed into EXIT_GENERIC hid a server outage from scripts
+      that check the exit code). ``None`` when there was no real response
+      to classify (an invalid job id, or a 200 with an unparseable body).
     """
 
     dataset_id: Optional[str] = None
     status: Optional[str] = None
     stopped_because: Optional[str] = None
     detail: Optional[str] = None
+    http_status: Optional[int] = None
+
+
+def poll_failed_exit_code(http_status: Optional[int]) -> int:
+    """Exit code for a "poll_failed" PollOutcome (fix(#1778, codex round 7)).
+
+    Mirrors the status-to-exit-code matrix ``_sdk_helpers.unwrap()`` already
+    uses for every other SDK response in this CLI: 5xx maps to EXIT_SERVER,
+    anything else to EXIT_GENERIC. 401/403 never reach here — the poll
+    reports those as "token_expired", not "poll_failed" — and a missing
+    ``http_status`` (an invalid job id, or a 200 with an unparseable body)
+    has no server-error signal to preserve, so it falls back to generic.
+    """
+    if http_status is not None and 500 <= http_status <= 599:
+        return EXIT_SERVER
+    return EXIT_GENERIC
 
 
 def resolve_dataset_id(
@@ -332,11 +355,14 @@ def resolve_dataset_id(
         if code != JOB_STATUS_OK_STATUS:
             # Some other non-200 (server error, 404, ...) — give up rather
             # than spend the whole deadline retrying a status the caller
-            # should decide how to handle.
+            # should decide how to handle. http_status is carried so the
+            # caller can select EXIT_SERVER for a 5xx rather than the
+            # generic exit code (fix(#1778, codex round 7)).
             return PollOutcome(
                 status=last_status,
                 stopped_because="poll_failed",
                 detail=f"HTTP {code}",
+                http_status=code,
             )
         if isinstance(resp.parsed, ProblemDetail):
             return PollOutcome(

--- a/cli/geolens_cli/publish.py
+++ b/cli/geolens_cli/publish.py
@@ -80,6 +80,15 @@ _DUPLICATE_DETAIL_NEEDLE = "already processed"
 _DEFAULT_POLL_INTERVAL_SECONDS: float = 1.0
 _DEFAULT_POLL_TIMEOUT_SECONDS: float = 120.0
 
+#: fix(audit 2026-08-30 finding 2, 8dc529f17): job statuses that mean "this
+#: job will never produce a dataset_id through this endpoint". Previously
+#: only "failed" was terminal here, so --wait polled a cancelled job for the
+#: full timeout. "cancelled" matches refresh.wait_for_refresh's terminal set
+#: ({"failed", "cancelled"}); "fanned_out" is added too because the parent
+#: of a multi-layer commit is marked fanned_out and never gets its own
+#: dataset_id (commit_fan_out, backend/app/processing/ingest/router.py).
+_TERMINAL_NO_DATASET_STATUSES = frozenset({"failed", "cancelled", "fanned_out"})
+
 # ---------------------------------------------------------------------------
 # MIME map (RESEARCH Pattern 3 lines 317-325) — informational; the backend
 # re-validates content via puremagic. T-216-03 (file content-type spoofing)
@@ -236,8 +245,12 @@ def resolve_dataset_id(
     """Poll ``GET /jobs/{job_id}`` until the dataset_id materializes.
 
     Returns the dataset_id as a string when ingestion completes successfully,
-    or ``None`` on terminal failure / timeout (caller falls back to the
-    job-search URL form).
+    or ``None`` when the job lands on a status in
+    ``_TERMINAL_NO_DATASET_STATUSES`` or the poll times out (caller falls
+    back to the job-search URL form). A caller that must tell those outcomes
+    apart — e.g. to exit non-zero with the right message — should read the
+    job status back afterwards (see ``analysis.job_snapshot``, reused by both
+    ``publish --wait`` and ``analysis materialize --wait``).
 
     ``sleep`` and ``monotonic`` are injectable so tests can run with zero
     real-time delay.
@@ -277,8 +290,11 @@ def resolve_dataset_id(
         # Terminal success: dataset_id materialized.
         if dataset_id:
             return str(dataset_id)
-        # Terminal failure: the worker explicitly marked the job failed.
-        if status == "failed":
+        # Terminal failure: the worker will not produce a dataset_id on this
+        # job (fix(audit 2026-08-30 finding 2): "cancelled" and "fanned_out"
+        # were missing here, so --wait kept polling until timeout instead of
+        # stopping as soon as the job's fate was known).
+        if status in _TERMINAL_NO_DATASET_STATUSES:
             return None
         sleep(interval)
     return None  # timeout — fall back to job-search URL

--- a/cli/geolens_cli/publish.py
+++ b/cli/geolens_cli/publish.py
@@ -80,13 +80,13 @@ _DUPLICATE_DETAIL_NEEDLE = "already processed"
 _DEFAULT_POLL_INTERVAL_SECONDS: float = 1.0
 _DEFAULT_POLL_TIMEOUT_SECONDS: float = 120.0
 
-#: fix(audit 2026-08-30 finding 2, 8dc529f17): job statuses that mean "this
-#: job will never produce a dataset_id through this endpoint". Previously
-#: only "failed" was terminal here, so --wait polled a cancelled job for the
-#: full timeout. "cancelled" matches refresh.wait_for_refresh's terminal set
-#: ({"failed", "cancelled"}); "fanned_out" is added too because the parent
-#: of a multi-layer commit is marked fanned_out and never gets its own
-#: dataset_id (commit_fan_out, backend/app/processing/ingest/router.py).
+#: fix(#1778): job statuses that mean "this job will never produce a
+#: dataset_id through this endpoint". Previously only "failed" was terminal
+#: here, so --wait polled a cancelled job for the full timeout. "cancelled"
+#: matches refresh.wait_for_refresh's terminal set ({"failed", "cancelled"});
+#: "fanned_out" is added too because the parent of a multi-layer commit is
+#: marked fanned_out and never gets its own dataset_id (commit_fan_out,
+#: backend/app/processing/ingest/router.py).
 _TERMINAL_NO_DATASET_STATUSES = frozenset({"failed", "cancelled", "fanned_out"})
 
 # ---------------------------------------------------------------------------
@@ -290,10 +290,9 @@ def resolve_dataset_id(
         # Terminal success: dataset_id materialized.
         if dataset_id:
             return str(dataset_id)
-        # Terminal failure: the worker will not produce a dataset_id on this
-        # job (fix(audit 2026-08-30 finding 2): "cancelled" and "fanned_out"
-        # were missing here, so --wait kept polling until timeout instead of
-        # stopping as soon as the job's fate was known).
+        # fix(#1778): "cancelled" and "fanned_out" were missing from the
+        # terminal set, so --wait kept polling until timeout instead of
+        # stopping as soon as the job's fate was known.
         if status in _TERMINAL_NO_DATASET_STATUSES:
             return None
         sleep(interval)

--- a/cli/geolens_cli/publish.py
+++ b/cli/geolens_cli/publish.py
@@ -81,6 +81,17 @@ _DUPLICATE_DETAIL_NEEDLE = "already processed"
 _DEFAULT_POLL_INTERVAL_SECONDS: float = 1.0
 _DEFAULT_POLL_TIMEOUT_SECONDS: float = 120.0
 
+#: fix(#1778, codex round 5): bound for the ONE-SHOT follow-up read a
+#: caller makes after a "timeout" or "poll_failed" PollOutcome, to check
+#: for a dataset_id that resolved a moment too late (fix(#685 review)) or
+#: a status that has since gone terminal (fix(#1778) round 4). The SDK
+#: client's generated transport defaults to timeout=None — unbounded — so
+#: without this, a stalled connection on that read would hang the command
+#: forever instead of reporting the outcome it already has. A few seconds
+#: is enough for a status lookup; this is a diagnostic extra, not worth
+#: waiting long for.
+_SNAPSHOT_REQUEST_TIMEOUT_SECONDS: float = 5.0
+
 #: fix(#1778): job statuses that mean "this job will never produce a
 #: dataset_id through this endpoint". Previously only "failed" was terminal
 #: here, so --wait polled a cancelled job for the full timeout. "cancelled"

--- a/cli/geolens_cli/publish.py
+++ b/cli/geolens_cli/publish.py
@@ -33,6 +33,7 @@ from __future__ import annotations
 
 import mimetypes
 import time
+from dataclasses import dataclass
 from http import HTTPStatus
 from pathlib import Path
 from typing import Any, Optional
@@ -233,6 +234,41 @@ def _web_origin(instance: str) -> str:
 # ---------------------------------------------------------------------------
 
 
+@dataclass(frozen=True)
+class PollOutcome:
+    """Result of a ``resolve_dataset_id`` poll.
+
+    fix(#1778, codex round 3): the old ``Optional[str]`` return collapsed a
+    real 120s timeout, a terminal job status, a transient poll failure and
+    an expired token into the same bare ``None`` — a caller could only
+    guess which one happened by making a SECOND, independent request
+    (``analysis.job_snapshot``) and trusting ITS status, which can legally
+    disagree with what actually stopped the original poll (a transient 500
+    followed by a lucky ``pending`` re-read read as "still running after
+    120s", which was never true). This return type carries the real reason
+    instead, so callers never have to guess.
+
+    ``dataset_id`` is set only on success, in which case every other field
+    is None. Otherwise ``stopped_because`` explains why there is no
+    dataset_id:
+
+    - ``"terminal"``: the job reached a status in
+      ``_TERMINAL_NO_DATASET_STATUSES`` (failed/cancelled/fanned_out) —
+      ``status`` carries which one.
+    - ``"timeout"``: the deadline was reached while the job was still
+      pending/running — ``status`` carries the last status read.
+    - ``"token_expired"``: a job-status request came back 401/403.
+    - ``"poll_failed"``: a job-status request failed some other way (a
+      non-200/401/403 status, or a response body that could not be parsed)
+      — ``detail`` names the failure (an HTTP status or error text).
+    """
+
+    dataset_id: Optional[str] = None
+    status: Optional[str] = None
+    stopped_because: Optional[str] = None
+    detail: Optional[str] = None
+
+
 def resolve_dataset_id(
     client: Any,
     job_id: str | UUID,
@@ -241,16 +277,14 @@ def resolve_dataset_id(
     timeout: float = _DEFAULT_POLL_TIMEOUT_SECONDS,
     sleep: Any = time.sleep,
     monotonic: Any = time.monotonic,
-) -> Optional[str]:
+) -> PollOutcome:
     """Poll ``GET /jobs/{job_id}`` until the dataset_id materializes.
 
-    Returns the dataset_id as a string when ingestion completes successfully,
-    or ``None`` when the job lands on a status in
-    ``_TERMINAL_NO_DATASET_STATUSES`` or the poll times out (caller falls
-    back to the job-search URL form). A caller that must tell those outcomes
-    apart — e.g. to exit non-zero with the right message — should read the
-    job status back afterwards (see ``analysis.job_snapshot``, reused by both
-    ``publish --wait`` and ``analysis materialize --wait``).
+    Returns a ``PollOutcome`` — see its docstring for the full shape. A
+    caller that must tell a real timeout apart from a transient read
+    failure or an expired token no longer has to make a second request and
+    guess: ``stopped_because`` says which one happened, from THIS poll, not
+    a possibly-contradictory follow-up read.
 
     ``sleep`` and ``monotonic`` are injectable so tests can run with zero
     real-time delay.
@@ -264,10 +298,13 @@ def resolve_dataset_id(
         try:
             uuid_arg = UUID(str(job_id))
         except ValueError:
-            return None
+            return PollOutcome(
+                stopped_because="poll_failed", detail=f"invalid job id: {job_id!r}"
+            )
     else:
         uuid_arg = job_id
 
+    last_status: Optional[str] = None
     deadline = monotonic() + timeout
     while monotonic() < deadline:
         # BUG-034: route the poll through call_sdk so a network failure during
@@ -278,25 +315,38 @@ def resolve_dataset_id(
             job_id=uuid_arg,
             client=client,
         )
-        if int(resp.status_code) != JOB_STATUS_OK_STATUS:
-            # Non-200 (auth error, server error, 404) — give up and let the
-            # caller surface a fallback URL.
-            return None
+        code = int(resp.status_code)
+        if code in (401, 403):
+            return PollOutcome(status=last_status, stopped_because="token_expired")
+        if code != JOB_STATUS_OK_STATUS:
+            # Some other non-200 (server error, 404, ...) — give up rather
+            # than spend the whole deadline retrying a status the caller
+            # should decide how to handle.
+            return PollOutcome(
+                status=last_status,
+                stopped_because="poll_failed",
+                detail=f"HTTP {code}",
+            )
         if isinstance(resp.parsed, ProblemDetail):
-            return None
+            return PollOutcome(
+                status=last_status,
+                stopped_because="poll_failed",
+                detail=resp.parsed.detail or "unexpected response body",
+            )
         parsed = resp.parsed
         status = getattr(parsed, "status", None)
         dataset_id = getattr(parsed, "dataset_id", None)
+        last_status = status
         # Terminal success: dataset_id materialized.
         if dataset_id:
-            return str(dataset_id)
+            return PollOutcome(dataset_id=str(dataset_id), status=status)
         # fix(#1778): "cancelled" and "fanned_out" were missing from the
         # terminal set, so --wait kept polling until timeout instead of
         # stopping as soon as the job's fate was known.
         if status in _TERMINAL_NO_DATASET_STATUSES:
-            return None
+            return PollOutcome(status=status, stopped_because="terminal")
         sleep(interval)
-    return None  # timeout — fall back to job-search URL
+    return PollOutcome(status=last_status, stopped_because="timeout")
 
 
 # ---------------------------------------------------------------------------

--- a/cli/tests/test_analysis.py
+++ b/cli/tests/test_analysis.py
@@ -1029,6 +1029,66 @@ class TestAnalysisMaterializeCli:
         assert "still running" in result.output
         assert "has not finished" in result.output
 
+    def test_snapshot_read_does_not_leave_the_shared_client_mutated(
+        self, runner, tmp_xdg_home, mock_keyring, monkeypatch
+    ) -> None:
+        """fix(#1778, codex round 6): `with_timeout()` MUTATES the shared
+        transport's timeout in place before returning an "evolved" client
+        that is really a decoy (sdks/python/geolens/client.py). The shared
+        client's transport must be back to its ORIGINAL timeout once the
+        snapshot read completes, not left at the 5s snapshot bound — cheap
+        insurance against a future materialize change reusing sdk.client
+        after this point the way publish()'s Stage 5 already does.
+
+        No --timeout flag here deliberately: with one, the pre-existing
+        `poll_client = sdk.client.with_timeout(timeout)` construction
+        (unrelated to this fix) would ALSO mutate the shared transport,
+        which would make this test's assertion meaningless. The httpx
+        transport is force-constructed up front (.get_httpx_client())
+        because the pre-round-6 bug only mutates an ALREADY-CONSTRUCTED
+        one in place.
+        """
+        from geolens import GeolensClient
+
+        from geolens_cli import publish as _publish
+        from geolens_cli.main import app
+
+        instance = "https://x.example.com/api"
+        _seed_login(instance, mock_keyring)
+
+        real_sdk = GeolensClient(base_url=instance, bearer_token="tok-abc")
+        original_timeout = real_sdk.client.get_httpx_client().timeout
+        monkeypatch.setattr("geolens_cli.main.AppState.sdk", lambda self: real_sdk)
+
+        monkeypatch.setattr(
+            "geolens_cli.analysis.run_materialize", lambda c, d, r: _FakeJob()
+        )
+        monkeypatch.setattr(
+            "geolens_cli.publish.resolve_dataset_id",
+            lambda c, j, **kw: _publish.PollOutcome(
+                status="running", stopped_because="timeout"
+            ),
+        )
+        monkeypatch.setattr(
+            "geolens_cli.analysis.job_snapshot",
+            lambda c, j: ("complete", "ds-late"),
+        )
+
+        result = runner.invoke(
+            app,
+            [
+                "analysis",
+                "materialize",
+                "ds-1",
+                "--operation",
+                "centroid",
+                "--title",
+                "Centroids",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        assert real_sdk.client.get_httpx_client().timeout == original_timeout
+
     def test_the_default_wait_has_no_deadline(
         self, runner, tmp_xdg_home, mock_keyring, monkeypatch
     ) -> None:

--- a/cli/tests/test_analysis.py
+++ b/cli/tests/test_analysis.py
@@ -847,6 +847,132 @@ class TestAnalysisMaterializeCli:
         assert "fanned out" in result.output
         assert "has not finished" not in result.output
 
+    def test_timeout_then_failed_snapshot_reports_the_failure(
+        self, runner, tmp_xdg_home, mock_keyring, monkeypatch
+    ) -> None:
+        """fix(#1778, codex round 4): the poll timed out, but the follow-up
+        read shows the job has SINCE become failed — that definitive
+        answer must win over the stale "still running" wording, which the
+        previous implementation used to report."""
+        from geolens_cli import publish as _publish
+        from geolens_cli.main import app
+
+        _seed_login("https://x.example.com/api", mock_keyring)
+        monkeypatch.setattr(
+            "geolens_cli.analysis.run_materialize", lambda c, d, r: _FakeJob()
+        )
+        monkeypatch.setattr(
+            "geolens_cli.publish.resolve_dataset_id",
+            lambda c, j, **kw: _publish.PollOutcome(
+                status="running", stopped_because="timeout"
+            ),
+        )
+        monkeypatch.setattr(
+            "geolens_cli.analysis.job_snapshot", lambda c, j: ("failed", None)
+        )
+
+        result = runner.invoke(
+            app,
+            [
+                "analysis",
+                "materialize",
+                "ds-1",
+                "--operation",
+                "centroid",
+                "--title",
+                "Centroids",
+                "--timeout",
+                "30",
+            ],
+        )
+        assert result.exit_code == 1, result.output
+        assert "failed" in result.output
+        assert "job record" in result.output
+        assert "still running" not in result.output
+        assert "has not finished" not in result.output
+
+    def test_poll_failed_then_cancelled_snapshot_reports_cancellation(
+        self, runner, tmp_xdg_home, mock_keyring, monkeypatch
+    ) -> None:
+        """fix(#1778, codex round 4): the poll itself failed (a transient
+        500), but the follow-up read shows the job has SINCE been
+        cancelled — that definitive answer must win over the "status
+        could not be read" wording."""
+        from geolens_cli import publish as _publish
+        from geolens_cli.main import app
+
+        _seed_login("https://x.example.com/api", mock_keyring)
+        monkeypatch.setattr(
+            "geolens_cli.analysis.run_materialize", lambda c, d, r: _FakeJob()
+        )
+        monkeypatch.setattr(
+            "geolens_cli.publish.resolve_dataset_id",
+            lambda c, j, **kw: _publish.PollOutcome(
+                stopped_because="poll_failed", detail="HTTP 500"
+            ),
+        )
+        monkeypatch.setattr(
+            "geolens_cli.analysis.job_snapshot", lambda c, j: ("cancelled", None)
+        )
+
+        result = runner.invoke(
+            app,
+            [
+                "analysis",
+                "materialize",
+                "ds-1",
+                "--operation",
+                "centroid",
+                "--title",
+                "Centroids",
+            ],
+        )
+        assert result.exit_code == 1, result.output
+        assert "cancelled" in result.output
+        assert "could not be read" not in result.output
+
+    def test_timeout_then_running_snapshot_still_reports_the_timeout(
+        self, runner, tmp_xdg_home, mock_keyring, monkeypatch
+    ) -> None:
+        """fix(#1778, codex round 4): only a DEFINITIVE terminal snapshot
+        (failed/cancelled/fanned_out) overrides the original outcome — a
+        pending/running snapshot leaves the job's fate genuinely
+        unresolved, so the original timeout wording stands."""
+        from geolens_cli import publish as _publish
+        from geolens_cli.main import app
+
+        _seed_login("https://x.example.com/api", mock_keyring)
+        monkeypatch.setattr(
+            "geolens_cli.analysis.run_materialize", lambda c, d, r: _FakeJob()
+        )
+        monkeypatch.setattr(
+            "geolens_cli.publish.resolve_dataset_id",
+            lambda c, j, **kw: _publish.PollOutcome(
+                status="running", stopped_because="timeout"
+            ),
+        )
+        monkeypatch.setattr(
+            "geolens_cli.analysis.job_snapshot", lambda c, j: ("running", None)
+        )
+
+        result = runner.invoke(
+            app,
+            [
+                "analysis",
+                "materialize",
+                "ds-1",
+                "--operation",
+                "centroid",
+                "--title",
+                "Centroids",
+                "--timeout",
+                "30",
+            ],
+        )
+        assert result.exit_code == 1, result.output
+        assert "still running" in result.output
+        assert "has not finished" in result.output
+
     def test_the_default_wait_has_no_deadline(
         self, runner, tmp_xdg_home, mock_keyring, monkeypatch
     ) -> None:

--- a/cli/tests/test_analysis.py
+++ b/cli/tests/test_analysis.py
@@ -431,6 +431,7 @@ class TestAnalysisMaterializeCli:
     def test_wait_resolves_the_dataset_url(
         self, runner, tmp_xdg_home, mock_keyring, monkeypatch
     ) -> None:
+        from geolens_cli import publish as _publish
         from geolens_cli.main import app
 
         _seed_login("https://x.example.com/api", mock_keyring)
@@ -438,7 +439,8 @@ class TestAnalysisMaterializeCli:
             "geolens_cli.analysis.run_materialize", lambda c, d, r: _FakeJob()
         )
         monkeypatch.setattr(
-            "geolens_cli.publish.resolve_dataset_id", lambda c, j, **kw: "ds-new"
+            "geolens_cli.publish.resolve_dataset_id",
+            lambda c, j, **kw: _publish.PollOutcome(dataset_id="ds-new"),
         )
 
         result = runner.invoke(
@@ -473,8 +475,11 @@ class TestAnalysisMaterializeCli:
             return _FakeJob()
 
         monkeypatch.setattr("geolens_cli.analysis.run_materialize", _capture)
+        from geolens_cli import publish as _publish
+
         monkeypatch.setattr(
-            "geolens_cli.publish.resolve_dataset_id", lambda c, j, **kw: "ds-new"
+            "geolens_cli.publish.resolve_dataset_id",
+            lambda c, j, **kw: _publish.PollOutcome(dataset_id="ds-new"),
         )
 
         join = "0f0f0f0f-1111-4222-8333-444444444444"
@@ -563,9 +568,11 @@ class TestAnalysisMaterializeCli:
     def test_a_failed_job_exits_non_zero_and_says_so(
         self, runner, tmp_xdg_home, mock_keyring, monkeypatch
     ) -> None:
-        """fix(#685 review): resolve_dataset_id returns None for a FAILED job
-        as well as a timeout. Exiting 0 there would tell a script the analysis
-        succeeded."""
+        """fix(#685 review): resolve_dataset_id reports a terminal status for
+        a FAILED job as well as a timeout — see PollOutcome
+        (fix(#1778, codex round 3)). Exiting 0 there would tell a script the
+        analysis succeeded."""
+        from geolens_cli import publish as _publish
         from geolens_cli.main import app
 
         _seed_login("https://x.example.com/api", mock_keyring)
@@ -573,10 +580,10 @@ class TestAnalysisMaterializeCli:
             "geolens_cli.analysis.run_materialize", lambda c, d, r: _FakeJob()
         )
         monkeypatch.setattr(
-            "geolens_cli.publish.resolve_dataset_id", lambda c, j, **kw: None
-        )
-        monkeypatch.setattr(
-            "geolens_cli.analysis.job_snapshot", lambda c, j: ("failed", None)
+            "geolens_cli.publish.resolve_dataset_id",
+            lambda c, j, **kw: _publish.PollOutcome(
+                status="failed", stopped_because="terminal"
+            ),
         )
 
         result = runner.invoke(
@@ -603,6 +610,7 @@ class TestAnalysisMaterializeCli:
         so this status is reachable here. It must not fall into the
         "still {status}" wording, which would claim the job might still
         finish."""
+        from geolens_cli import publish as _publish
         from geolens_cli.main import app
 
         _seed_login("https://x.example.com/api", mock_keyring)
@@ -610,10 +618,10 @@ class TestAnalysisMaterializeCli:
             "geolens_cli.analysis.run_materialize", lambda c, d, r: _FakeJob()
         )
         monkeypatch.setattr(
-            "geolens_cli.publish.resolve_dataset_id", lambda c, j, **kw: None
-        )
-        monkeypatch.setattr(
-            "geolens_cli.analysis.job_snapshot", lambda c, j: ("cancelled", None)
+            "geolens_cli.publish.resolve_dataset_id",
+            lambda c, j, **kw: _publish.PollOutcome(
+                status="cancelled", stopped_because="terminal"
+            ),
         )
 
         result = runner.invoke(
@@ -638,6 +646,7 @@ class TestAnalysisMaterializeCli:
         """fix(#685 review): a materialize gets 300s of processing server-side
         and queues below uploads, so outliving the poll is not the same as
         failing. Still exit non-zero (no dataset), but do not call it failed."""
+        from geolens_cli import publish as _publish
         from geolens_cli.main import app
 
         _seed_login("https://x.example.com/api", mock_keyring)
@@ -645,7 +654,10 @@ class TestAnalysisMaterializeCli:
             "geolens_cli.analysis.run_materialize", lambda c, d, r: _FakeJob()
         )
         monkeypatch.setattr(
-            "geolens_cli.publish.resolve_dataset_id", lambda c, j, **kw: None
+            "geolens_cli.publish.resolve_dataset_id",
+            lambda c, j, **kw: _publish.PollOutcome(
+                status="running", stopped_because="timeout"
+            ),
         )
         monkeypatch.setattr(
             "geolens_cli.analysis.job_snapshot", lambda c, j: ("running", None)
@@ -676,6 +688,7 @@ class TestAnalysisMaterializeCli:
         """fix(#685 review): the job can finish between the poll's last look
         and the status re-read, and that response carries the dataset id.
         Reporting it as unfinished would be the worst of the three answers."""
+        from geolens_cli import publish as _publish
         from geolens_cli.main import app
 
         _seed_login("https://x.example.com/api", mock_keyring)
@@ -683,7 +696,10 @@ class TestAnalysisMaterializeCli:
             "geolens_cli.analysis.run_materialize", lambda c, d, r: _FakeJob()
         )
         monkeypatch.setattr(
-            "geolens_cli.publish.resolve_dataset_id", lambda c, j, **kw: None
+            "geolens_cli.publish.resolve_dataset_id",
+            lambda c, j, **kw: _publish.PollOutcome(
+                status="running", stopped_because="timeout"
+            ),
         )
         monkeypatch.setattr(
             "geolens_cli.analysis.job_snapshot",
@@ -710,9 +726,15 @@ class TestAnalysisMaterializeCli:
     def test_an_unreadable_status_is_not_reported_as_a_timeout(
         self, runner, tmp_xdg_home, mock_keyring, monkeypatch
     ) -> None:
-        """fix(#685 review): a 401/404/5xx on GET /jobs/{id} also yields None
-        from the poll. Claiming the job outlived the wait asserts something
-        that was never established."""
+        """fix(#1778, codex round 3): resolve_dataset_id's own poll failure
+        (a transient 500 here, mapped to stopped_because="poll_failed") must
+        not be reported as a timeout, even when a LATER, separate
+        job_snapshot() read happens to succeed and report "pending" — that
+        second read's status is discarded and used only to check for a
+        dataset_id (the fix(#685 review) case, preserved below). Claiming
+        the job outlived the wait, or was "still pending", asserts something
+        that was never established — the read failed, it did not run out."""
+        from geolens_cli import publish as _publish
         from geolens_cli.main import app
 
         _seed_login("https://x.example.com/api", mock_keyring)
@@ -720,10 +742,13 @@ class TestAnalysisMaterializeCli:
             "geolens_cli.analysis.run_materialize", lambda c, d, r: _FakeJob()
         )
         monkeypatch.setattr(
-            "geolens_cli.publish.resolve_dataset_id", lambda c, j, **kw: None
+            "geolens_cli.publish.resolve_dataset_id",
+            lambda c, j, **kw: _publish.PollOutcome(
+                stopped_because="poll_failed", detail="HTTP 500"
+            ),
         )
         monkeypatch.setattr(
-            "geolens_cli.analysis.job_snapshot", lambda c, j: (None, None)
+            "geolens_cli.analysis.job_snapshot", lambda c, j: ("pending", None)
         )
 
         result = runner.invoke(
@@ -739,7 +764,88 @@ class TestAnalysisMaterializeCli:
             ],
         )
         assert result.exit_code == 1, result.output
-        assert "outcome is unknown" in result.output
+        assert "could not be read" in result.output
+        assert "HTTP 500" in result.output
+        assert "still pending" not in result.output
+        assert "has not finished" not in result.output
+
+    def test_a_token_expired_mid_poll_exits_auth(
+        self, runner, tmp_xdg_home, mock_keyring, monkeypatch
+    ) -> None:
+        """fix(#1778, codex round 3): resolve_dataset_id detects a 401/403
+        itself (stopped_because == "token_expired"). No follow-up read is
+        attempted — retrying the same dead token is pointless — and the
+        command exits EXIT_AUTH directly, naming what went wrong."""
+        from geolens_cli import publish as _publish
+        from geolens_cli._sdk_helpers import EXIT_AUTH
+        from geolens_cli.main import app
+
+        _seed_login("https://x.example.com/api", mock_keyring)
+        monkeypatch.setattr(
+            "geolens_cli.analysis.run_materialize", lambda c, d, r: _FakeJob()
+        )
+        monkeypatch.setattr(
+            "geolens_cli.publish.resolve_dataset_id",
+            lambda c, j, **kw: _publish.PollOutcome(stopped_because="token_expired"),
+        )
+
+        def _must_not_read(*args, **kwargs):  # pragma: no cover - failure path
+            raise AssertionError("token_expired must not trigger a follow-up read")
+
+        monkeypatch.setattr("geolens_cli.analysis.job_snapshot", _must_not_read)
+
+        result = runner.invoke(
+            app,
+            [
+                "analysis",
+                "materialize",
+                "ds-1",
+                "--operation",
+                "centroid",
+                "--title",
+                "Centroids",
+            ],
+        )
+        assert result.exit_code == EXIT_AUTH, result.output
+        assert "Authentication failed" in result.output
+
+    def test_a_fanned_out_job_exits_zero_and_does_not_claim_a_timeout(
+        self, runner, tmp_xdg_home, mock_keyring, monkeypatch
+    ) -> None:
+        """A fanned-out job is a SUCCESS whose children each carry their own
+        dataset — see publish()'s equivalent branch (fix(#1778)). materialize
+        jobs are never fanned out by the current backend (fan-out is
+        ingest-only), so this is defensive coverage, not a reachable
+        production path today."""
+        from geolens_cli import publish as _publish
+        from geolens_cli.main import app
+
+        _seed_login("https://x.example.com/api", mock_keyring)
+        monkeypatch.setattr(
+            "geolens_cli.analysis.run_materialize", lambda c, d, r: _FakeJob()
+        )
+        monkeypatch.setattr(
+            "geolens_cli.publish.resolve_dataset_id",
+            lambda c, j, **kw: _publish.PollOutcome(
+                status="fanned_out", stopped_because="terminal"
+            ),
+        )
+
+        result = runner.invoke(
+            app,
+            [
+                "analysis",
+                "materialize",
+                "ds-1",
+                "--operation",
+                "centroid",
+                "--title",
+                "Centroids",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        assert "fanned out" in result.output
+        assert "has not finished" not in result.output
 
     def test_the_default_wait_has_no_deadline(
         self, runner, tmp_xdg_home, mock_keyring, monkeypatch
@@ -748,13 +854,14 @@ class TestAnalysisMaterializeCli:
         a job that is merely waiting in it, so any fixed deadline here would
         report a job the server is still going to finish as producing
         nothing."""
+        from geolens_cli import publish as _publish
         from geolens_cli.main import app
 
         seen: dict = {}
 
         def _capture(client, job_id, **kwargs):
             seen.update(kwargs)
-            return "ds-new"
+            return _publish.PollOutcome(dataset_id="ds-new")
 
         _seed_login("https://x.example.com/api", mock_keyring)
         monkeypatch.setattr(
@@ -780,13 +887,14 @@ class TestAnalysisMaterializeCli:
     def test_an_explicit_timeout_bounds_the_wait(
         self, runner, tmp_xdg_home, mock_keyring, monkeypatch
     ) -> None:
+        from geolens_cli import publish as _publish
         from geolens_cli.main import app
 
         seen: dict = {}
 
         def _capture(client, job_id, **kwargs):
             seen.update(kwargs)
-            return "ds-new"
+            return _publish.PollOutcome(dataset_id="ds-new")
 
         _seed_login("https://x.example.com/api", mock_keyring)
         monkeypatch.setattr(
@@ -817,6 +925,7 @@ class TestAnalysisMaterializeCli:
         """fix(#685 review): the poll deadline is only checked between
         iterations, and the SDK builds its httpx client with no request
         timeout at all, so a stalled response would outlive --timeout."""
+        from geolens_cli import publish as _publish
         from geolens_cli.main import app
 
         bounded: dict = {}
@@ -835,7 +944,8 @@ class TestAnalysisMaterializeCli:
             "geolens_cli.analysis.run_materialize", lambda c, d, r: _FakeJob()
         )
         monkeypatch.setattr(
-            "geolens_cli.publish.resolve_dataset_id", lambda c, j, **kw: "ds-new"
+            "geolens_cli.publish.resolve_dataset_id",
+            lambda c, j, **kw: _publish.PollOutcome(dataset_id="ds-new"),
         )
 
         result = runner.invoke(
@@ -926,6 +1036,7 @@ class TestAnalysisMaterializeCli:
     def test_json_mode_emits_the_job_and_dataset_ids(
         self, runner, tmp_xdg_home, mock_keyring, monkeypatch
     ) -> None:
+        from geolens_cli import publish as _publish
         from geolens_cli.main import app
 
         _seed_login("https://x.example.com/api", mock_keyring)
@@ -933,7 +1044,8 @@ class TestAnalysisMaterializeCli:
             "geolens_cli.analysis.run_materialize", lambda c, d, r: _FakeJob()
         )
         monkeypatch.setattr(
-            "geolens_cli.publish.resolve_dataset_id", lambda c, j, **kw: "ds-new"
+            "geolens_cli.publish.resolve_dataset_id",
+            lambda c, j, **kw: _publish.PollOutcome(dataset_id="ds-new"),
         )
 
         result = runner.invoke(
@@ -955,3 +1067,4 @@ class TestAnalysisMaterializeCli:
         payload = json.loads(result.output)
         assert payload["job_id"] == "job-1"
         assert payload["dataset_id"] == "ds-new"
+        assert payload["stopped_because"] is None

--- a/cli/tests/test_analysis.py
+++ b/cli/tests/test_analysis.py
@@ -973,6 +973,62 @@ class TestAnalysisMaterializeCli:
         assert "still running" in result.output
         assert "has not finished" in result.output
 
+    def test_snapshot_read_timeout_does_not_hang_and_reports_original_outcome(
+        self, runner, tmp_xdg_home, mock_keyring, monkeypatch
+    ) -> None:
+        """fix(#1778, codex round 5): sdk.client's generated transport
+        defaults to timeout=None (unbounded), so a stalled connection on
+        the follow-up diagnostic read could hang the command forever
+        instead of reporting the timeout it already reached. The read is
+        now bound (_SNAPSHOT_REQUEST_TIMEOUT_SECONDS); when it ALSO times
+        out, the command must not hang or crash — it falls back to the
+        original outcome. resolve_dataset_id is mocked directly (so this
+        test cannot itself hang on a real poll); the SDK call the real
+        job_snapshot() makes is mocked to raise httpx.TimeoutException,
+        standing in for the bound actually firing.
+        """
+        import httpx
+
+        from geolens_cli import publish as _publish
+        from geolens_cli.main import app
+
+        _seed_login("https://x.example.com/api", mock_keyring)
+        monkeypatch.setattr(
+            "geolens_cli.analysis.run_materialize", lambda c, d, r: _FakeJob()
+        )
+        monkeypatch.setattr(
+            "geolens_cli.publish.resolve_dataset_id",
+            lambda c, j, **kw: _publish.PollOutcome(
+                status="running", stopped_because="timeout"
+            ),
+        )
+
+        def boom(**kw):
+            raise httpx.TimeoutException("stalled")
+
+        monkeypatch.setattr(
+            "geolens.api.admin.get_job_status_jobs_job_id_get.sync_detailed",
+            boom,
+        )
+
+        result = runner.invoke(
+            app,
+            [
+                "analysis",
+                "materialize",
+                "ds-1",
+                "--operation",
+                "centroid",
+                "--title",
+                "Centroids",
+                "--timeout",
+                "30",
+            ],
+        )
+        assert result.exit_code == 1, result.output
+        assert "still running" in result.output
+        assert "has not finished" in result.output
+
     def test_the_default_wait_has_no_deadline(
         self, runner, tmp_xdg_home, mock_keyring, monkeypatch
     ) -> None:

--- a/cli/tests/test_analysis.py
+++ b/cli/tests/test_analysis.py
@@ -598,11 +598,11 @@ class TestAnalysisMaterializeCli:
     def test_a_cancelled_job_exits_non_zero_and_says_so(
         self, runner, tmp_xdg_home, mock_keyring, monkeypatch
     ) -> None:
-        """fix(audit 2026-08-30 finding 2): resolve_dataset_id now treats
-        cancelled as terminal (it previously polled a cancelled job forever
-        under POLL_FOREVER), so this status is reachable here. It must not
-        fall into the "still {status}" wording, which would claim the job
-        might still finish."""
+        """fix(#1778): resolve_dataset_id now treats cancelled as terminal
+        (it previously polled a cancelled job forever under POLL_FOREVER),
+        so this status is reachable here. It must not fall into the
+        "still {status}" wording, which would claim the job might still
+        finish."""
         from geolens_cli.main import app
 
         _seed_login("https://x.example.com/api", mock_keyring)

--- a/cli/tests/test_analysis.py
+++ b/cli/tests/test_analysis.py
@@ -769,6 +769,85 @@ class TestAnalysisMaterializeCli:
         assert "still pending" not in result.output
         assert "has not finished" not in result.output
 
+    def test_503_poll_exits_exit_server_with_poll_failed_wording(
+        self, runner, tmp_xdg_home, mock_keyring, monkeypatch
+    ) -> None:
+        """fix(#1778, codex round 7): a poll_failed outcome must select
+        EXIT_SERVER for a 5xx, matching the matrix `_sdk_helpers.unwrap()`
+        already uses — previously every poll_failed exited 1 regardless of
+        status, hiding a server outage from a script checking the exit
+        code. Drives the REAL resolve_dataset_id (only the underlying SDK
+        call is mocked) so the http_status classification is genuinely
+        exercised end to end, not asserted against a hand-built
+        PollOutcome."""
+        from unittest.mock import MagicMock
+
+        from geolens_cli._sdk_helpers import EXIT_SERVER
+        from geolens_cli.main import app
+
+        _seed_login("https://x.example.com/api", mock_keyring)
+        # A real UUID string: resolve_dataset_id coerces job_id to UUID
+        # before ever making a request, and the default _FakeJob "job-1"
+        # is not one, so the mocked SDK call below would never be reached.
+        monkeypatch.setattr(
+            "geolens_cli.analysis.run_materialize",
+            lambda c, d, r: _FakeJob(job_id="00000000-0000-0000-0000-000000000099"),
+        )
+        monkeypatch.setattr(
+            "geolens.api.admin.get_job_status_jobs_job_id_get.sync_detailed",
+            lambda **kw: MagicMock(status_code=503, parsed=None),
+        )
+
+        result = runner.invoke(
+            app,
+            [
+                "analysis",
+                "materialize",
+                "ds-1",
+                "--operation",
+                "centroid",
+                "--title",
+                "Centroids",
+            ],
+        )
+        assert result.exit_code == EXIT_SERVER, result.output
+        assert "could not be read" in result.output
+        assert "HTTP 503" in result.output
+
+    def test_404_poll_exits_generic_with_poll_failed_wording(
+        self, runner, tmp_xdg_home, mock_keyring, monkeypatch
+    ) -> None:
+        from unittest.mock import MagicMock
+
+        from geolens_cli._sdk_helpers import EXIT_GENERIC
+        from geolens_cli.main import app
+
+        _seed_login("https://x.example.com/api", mock_keyring)
+        monkeypatch.setattr(
+            "geolens_cli.analysis.run_materialize",
+            lambda c, d, r: _FakeJob(job_id="00000000-0000-0000-0000-000000000099"),
+        )
+        monkeypatch.setattr(
+            "geolens.api.admin.get_job_status_jobs_job_id_get.sync_detailed",
+            lambda **kw: MagicMock(status_code=404, parsed=None),
+        )
+
+        result = runner.invoke(
+            app,
+            [
+                "analysis",
+                "materialize",
+                "ds-1",
+                "--operation",
+                "centroid",
+                "--title",
+                "Centroids",
+            ],
+        )
+        assert result.exit_code == EXIT_GENERIC, result.output
+        assert "could not be read" in result.output
+        assert "HTTP 404" in result.output
+
     def test_a_token_expired_mid_poll_exits_auth(
         self, runner, tmp_xdg_home, mock_keyring, monkeypatch
     ) -> None:

--- a/cli/tests/test_analysis.py
+++ b/cli/tests/test_analysis.py
@@ -595,6 +595,43 @@ class TestAnalysisMaterializeCli:
         assert "failed" in result.output
         assert "job-1" in result.output
 
+    def test_a_cancelled_job_exits_non_zero_and_says_so(
+        self, runner, tmp_xdg_home, mock_keyring, monkeypatch
+    ) -> None:
+        """fix(audit 2026-08-30 finding 2): resolve_dataset_id now treats
+        cancelled as terminal (it previously polled a cancelled job forever
+        under POLL_FOREVER), so this status is reachable here. It must not
+        fall into the "still {status}" wording, which would claim the job
+        might still finish."""
+        from geolens_cli.main import app
+
+        _seed_login("https://x.example.com/api", mock_keyring)
+        monkeypatch.setattr(
+            "geolens_cli.analysis.run_materialize", lambda c, d, r: _FakeJob()
+        )
+        monkeypatch.setattr(
+            "geolens_cli.publish.resolve_dataset_id", lambda c, j, **kw: None
+        )
+        monkeypatch.setattr(
+            "geolens_cli.analysis.job_snapshot", lambda c, j: ("cancelled", None)
+        )
+
+        result = runner.invoke(
+            app,
+            [
+                "analysis",
+                "materialize",
+                "ds-1",
+                "--operation",
+                "centroid",
+                "--title",
+                "Centroids",
+            ],
+        )
+        assert result.exit_code == 1, result.output
+        assert "cancelled" in result.output
+        assert "has not finished" not in result.output
+
     def test_a_still_running_job_is_not_reported_as_failed(
         self, runner, tmp_xdg_home, mock_keyring, monkeypatch
     ) -> None:

--- a/cli/tests/test_publish_unit.py
+++ b/cli/tests/test_publish_unit.py
@@ -774,7 +774,7 @@ class TestPublishWaitTerminalOutcomes:
         sample_geojson,
         patch_sdk_for_publish,
     ) -> None:
-        """fix finding 2: cancelled was previously not terminal, so --wait
+        """fix(#1778): cancelled was previously not terminal, so --wait
         polled a cancelled job for the full 120s timeout and then reported
         success."""
         from geolens_cli.main import app
@@ -816,6 +816,91 @@ class TestPublishWaitTerminalOutcomes:
         payload = json.loads(result.output)
         assert payload["status"] == "cancelled"
         assert payload["dataset_id"] is None
+
+    def test_wait_job_fanned_out_exits_zero_and_does_not_claim_a_timeout(
+        self,
+        runner,
+        tmp_xdg_home,
+        mock_keyring,
+        monkeypatch,
+        sample_geojson,
+        patch_sdk_for_publish,
+    ) -> None:
+        """fix(#1778, codex round 2 P2): fanned_out is TERMINAL and a
+        SUCCESS — the parent job of a multi-layer commit lands here the
+        moment each layer's own import is queued, and it never gets a
+        dataset_id of its own. Reporting "still fanned_out ... has not
+        finished" would be a false diagnosis (nothing timed out), so this
+        exits 0 and says the job fanned out."""
+        from geolens_cli.main import app
+
+        _seed_login("https://x.example.com", mock_keyring)
+        patch_sdk_for_publish(
+            upload=_ok_upload(),
+            preview=_ok_preview(),
+            commit=_ok_commit(),
+            job_status=_ok_job_status(dataset_id=None, status="fanned_out"),
+        )
+
+        result = runner.invoke(app, ["publish", str(sample_geojson)])
+        assert result.exit_code == 0, result.output
+        assert "fanned out" in result.output
+        assert "has not finished" not in result.output
+        assert "still fanned_out" not in result.output
+
+    def test_wait_job_fanned_out_json_mode_carries_status(
+        self,
+        runner,
+        tmp_xdg_home,
+        mock_keyring,
+        monkeypatch,
+        sample_geojson,
+        patch_sdk_for_publish,
+    ) -> None:
+        from geolens_cli.main import app
+
+        _seed_login("https://x.example.com", mock_keyring)
+        patch_sdk_for_publish(
+            upload=_ok_upload(),
+            preview=_ok_preview(),
+            commit=_ok_commit(),
+            job_status=_ok_job_status(dataset_id=None, status="fanned_out"),
+        )
+
+        result = runner.invoke(app, ["--json", "publish", str(sample_geojson)])
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        assert payload["status"] == "fanned_out"
+        assert payload["dataset_id"] is None
+
+    def test_wait_job_fanned_out_with_tags_notes_they_were_not_applied(
+        self,
+        runner,
+        tmp_xdg_home,
+        mock_keyring,
+        monkeypatch,
+        sample_geojson,
+        patch_sdk_for_publish,
+    ) -> None:
+        """--tags/--collection cannot be applied to a fanned-out job: there
+        is no single dataset id, since every layer became its own dataset."""
+        from geolens_cli.main import app
+
+        _seed_login("https://x.example.com", mock_keyring)
+        patch_sdk_for_publish(
+            upload=_ok_upload(),
+            preview=_ok_preview(),
+            commit=_ok_commit(),
+            job_status=_ok_job_status(dataset_id=None, status="fanned_out"),
+        )
+
+        result = runner.invoke(
+            app, ["publish", str(sample_geojson), "--tags", "hydro"]
+        )
+        assert result.exit_code == 0, result.output
+        assert "fanned out" in result.output
+        assert "not applied" in result.output
+        assert "Dataset created" not in result.output
 
     def test_wait_poll_timed_out_exits_nonzero(
         self,

--- a/cli/tests/test_publish_unit.py
+++ b/cli/tests/test_publish_unit.py
@@ -1045,6 +1045,147 @@ class TestPublishWaitTerminalOutcomes:
         assert payload["stopped_because"] == "poll_failed"
         assert payload["dataset_id"] is None
 
+    def test_wait_poll_timeout_then_failed_snapshot_reports_the_failure(
+        self,
+        runner,
+        tmp_xdg_home,
+        mock_keyring,
+        monkeypatch,
+        sample_geojson,
+        patch_sdk_for_publish,
+    ) -> None:
+        """fix(#1778, codex round 4): the poll timed out, but the follow-up
+        read shows the job has SINCE become failed — that definitive
+        answer must win over the stale "still running after 120s"
+        wording, which the previous implementation used to report."""
+        from geolens_cli import publish as _publish
+        from geolens_cli.main import app
+
+        _seed_login("https://x.example.com", mock_keyring)
+        patch_sdk_for_publish(
+            upload=_ok_upload(), preview=_ok_preview(), commit=_ok_commit()
+        )
+        monkeypatch.setattr(
+            "geolens_cli.publish.resolve_dataset_id",
+            lambda c, j, **kw: _publish.PollOutcome(
+                status="running", stopped_because="timeout"
+            ),
+        )
+        monkeypatch.setattr(
+            "geolens_cli.analysis.job_snapshot", lambda c, j: ("failed", None)
+        )
+
+        result = runner.invoke(app, ["publish", str(sample_geojson)])
+        assert result.exit_code == 1, result.output
+        assert "Published:" not in result.output
+        assert "failed" in result.output
+        assert "job record" in result.output
+        assert "still running" not in result.output
+        assert "has not finished" not in result.output
+
+    def test_wait_poll_timeout_then_failed_snapshot_json_mode(
+        self,
+        runner,
+        tmp_xdg_home,
+        mock_keyring,
+        monkeypatch,
+        sample_geojson,
+        patch_sdk_for_publish,
+    ) -> None:
+        from geolens_cli import publish as _publish
+        from geolens_cli.main import app
+
+        _seed_login("https://x.example.com", mock_keyring)
+        patch_sdk_for_publish(
+            upload=_ok_upload(), preview=_ok_preview(), commit=_ok_commit()
+        )
+        monkeypatch.setattr(
+            "geolens_cli.publish.resolve_dataset_id",
+            lambda c, j, **kw: _publish.PollOutcome(
+                status="running", stopped_because="timeout"
+            ),
+        )
+        monkeypatch.setattr(
+            "geolens_cli.analysis.job_snapshot", lambda c, j: ("failed", None)
+        )
+
+        result = runner.invoke(app, ["--json", "publish", str(sample_geojson)])
+        assert result.exit_code == 1, result.output
+        payload = json.loads(result.output)
+        assert payload["status"] == "failed"
+        assert payload["stopped_because"] == "terminal"
+
+    def test_wait_poll_failed_then_cancelled_snapshot_reports_cancellation(
+        self,
+        runner,
+        tmp_xdg_home,
+        mock_keyring,
+        monkeypatch,
+        sample_geojson,
+        patch_sdk_for_publish,
+    ) -> None:
+        """fix(#1778, codex round 4): the poll itself failed (a transient
+        500), but the follow-up read shows the job has SINCE been
+        cancelled — that definitive answer must win over the "status
+        could not be read" wording."""
+        from geolens_cli import publish as _publish
+        from geolens_cli.main import app
+
+        _seed_login("https://x.example.com", mock_keyring)
+        patch_sdk_for_publish(
+            upload=_ok_upload(), preview=_ok_preview(), commit=_ok_commit()
+        )
+        monkeypatch.setattr(
+            "geolens_cli.publish.resolve_dataset_id",
+            lambda c, j, **kw: _publish.PollOutcome(
+                stopped_because="poll_failed", detail="HTTP 500"
+            ),
+        )
+        monkeypatch.setattr(
+            "geolens_cli.analysis.job_snapshot", lambda c, j: ("cancelled", None)
+        )
+
+        result = runner.invoke(app, ["publish", str(sample_geojson)])
+        assert result.exit_code == 1, result.output
+        assert "Published:" not in result.output
+        assert "cancelled" in result.output
+        assert "could not be read" not in result.output
+
+    def test_wait_poll_timeout_then_running_snapshot_still_reports_the_timeout(
+        self,
+        runner,
+        tmp_xdg_home,
+        mock_keyring,
+        monkeypatch,
+        sample_geojson,
+        patch_sdk_for_publish,
+    ) -> None:
+        """fix(#1778, codex round 4): only a DEFINITIVE terminal snapshot
+        (failed/cancelled/fanned_out) overrides the original outcome — a
+        pending/running snapshot leaves the job's fate genuinely
+        unresolved, so the original timeout wording stands."""
+        from geolens_cli import publish as _publish
+        from geolens_cli.main import app
+
+        _seed_login("https://x.example.com", mock_keyring)
+        patch_sdk_for_publish(
+            upload=_ok_upload(), preview=_ok_preview(), commit=_ok_commit()
+        )
+        monkeypatch.setattr(
+            "geolens_cli.publish.resolve_dataset_id",
+            lambda c, j, **kw: _publish.PollOutcome(
+                status="running", stopped_because="timeout"
+            ),
+        )
+        monkeypatch.setattr(
+            "geolens_cli.analysis.job_snapshot", lambda c, j: ("running", None)
+        )
+
+        result = runner.invoke(app, ["publish", str(sample_geojson)])
+        assert result.exit_code == 1, result.output
+        assert "still running" in result.output
+        assert "has not finished" in result.output
+
     def test_wait_token_expired_mid_poll_exits_auth(
         self,
         runner,

--- a/cli/tests/test_publish_unit.py
+++ b/cli/tests/test_publish_unit.py
@@ -675,6 +675,292 @@ class TestPublishCli:
 
 
 # ---------------------------------------------------------------------------
+# fix(audit 2026-08-30 finding 1, 8dc529f17) — `publish --wait` must not
+# report success (exit 0, "Published: ...") for a job that failed, was
+# cancelled, timed out, or could not be read back because the token expired
+# mid-poll. Mirrors analysis materialize --wait's job_snapshot fallback.
+# ---------------------------------------------------------------------------
+
+
+class TestPublishWaitTerminalOutcomes:
+    def test_wait_job_failed_exits_nonzero_and_does_not_print_published(
+        self,
+        runner,
+        tmp_xdg_home,
+        mock_keyring,
+        monkeypatch,
+        sample_geojson,
+        patch_sdk_for_publish,
+    ) -> None:
+        from geolens_cli.main import app
+
+        _seed_login("https://x.example.com", mock_keyring)
+        patch_sdk_for_publish(
+            upload=_ok_upload(),
+            preview=_ok_preview(),
+            commit=_ok_commit(),
+            job_status=_ok_job_status(dataset_id=None, status="failed"),
+        )
+
+        result = runner.invoke(app, ["publish", str(sample_geojson)])
+        assert result.exit_code == 1, result.output
+        assert "Published:" not in result.output
+        assert "failed" in result.output
+        assert "job record" in result.output
+
+    def test_wait_job_failed_json_mode_carries_status_and_null_dataset_id(
+        self,
+        runner,
+        tmp_xdg_home,
+        mock_keyring,
+        monkeypatch,
+        sample_geojson,
+        patch_sdk_for_publish,
+    ) -> None:
+        from geolens_cli.main import app
+
+        _seed_login("https://x.example.com", mock_keyring)
+        patch_sdk_for_publish(
+            upload=_ok_upload(),
+            preview=_ok_preview(),
+            commit=_ok_commit(),
+            job_status=_ok_job_status(dataset_id=None, status="failed"),
+        )
+
+        result = runner.invoke(app, ["--json", "publish", str(sample_geojson)])
+        assert result.exit_code == 1, result.output
+        payload = json.loads(result.output)
+        assert payload["status"] == "failed"
+        assert payload["dataset_id"] is None
+
+    def test_wait_job_cancelled_exits_nonzero_and_does_not_print_published(
+        self,
+        runner,
+        tmp_xdg_home,
+        mock_keyring,
+        monkeypatch,
+        sample_geojson,
+        patch_sdk_for_publish,
+    ) -> None:
+        """fix finding 2: cancelled was previously not terminal, so --wait
+        polled a cancelled job for the full 120s timeout and then reported
+        success."""
+        from geolens_cli.main import app
+
+        _seed_login("https://x.example.com", mock_keyring)
+        patch_sdk_for_publish(
+            upload=_ok_upload(),
+            preview=_ok_preview(),
+            commit=_ok_commit(),
+            job_status=_ok_job_status(dataset_id=None, status="cancelled"),
+        )
+
+        result = runner.invoke(app, ["publish", str(sample_geojson)])
+        assert result.exit_code == 1, result.output
+        assert "Published:" not in result.output
+        assert "cancelled" in result.output
+
+    def test_wait_job_cancelled_json_mode_carries_status(
+        self,
+        runner,
+        tmp_xdg_home,
+        mock_keyring,
+        monkeypatch,
+        sample_geojson,
+        patch_sdk_for_publish,
+    ) -> None:
+        from geolens_cli.main import app
+
+        _seed_login("https://x.example.com", mock_keyring)
+        patch_sdk_for_publish(
+            upload=_ok_upload(),
+            preview=_ok_preview(),
+            commit=_ok_commit(),
+            job_status=_ok_job_status(dataset_id=None, status="cancelled"),
+        )
+
+        result = runner.invoke(app, ["--json", "publish", str(sample_geojson)])
+        assert result.exit_code == 1, result.output
+        payload = json.loads(result.output)
+        assert payload["status"] == "cancelled"
+        assert payload["dataset_id"] is None
+
+    def test_wait_poll_timed_out_exits_nonzero(
+        self,
+        runner,
+        tmp_xdg_home,
+        mock_keyring,
+        monkeypatch,
+        sample_geojson,
+        patch_sdk_for_publish,
+    ) -> None:
+        """The 120s default poll gave up while the job was still running.
+
+        resolve_dataset_id and job_snapshot are monkeypatched directly (not
+        driven through a real 120s poll) so the test stays fast; this is the
+        same technique cli/tests/test_analysis.py uses for the sibling
+        materialize --wait timeout test.
+        """
+        from geolens_cli.main import app
+
+        _seed_login("https://x.example.com", mock_keyring)
+        patch_sdk_for_publish(
+            upload=_ok_upload(), preview=_ok_preview(), commit=_ok_commit()
+        )
+        monkeypatch.setattr(
+            "geolens_cli.publish.resolve_dataset_id", lambda c, j, **kw: None
+        )
+        monkeypatch.setattr(
+            "geolens_cli.analysis.job_snapshot", lambda c, j: ("running", None)
+        )
+
+        result = runner.invoke(app, ["publish", str(sample_geojson)])
+        assert result.exit_code == 1, result.output
+        assert "Published:" not in result.output
+        assert "still running" in result.output
+        assert "has not finished" in result.output
+
+    def test_wait_poll_timed_out_json_mode_carries_raw_status(
+        self,
+        runner,
+        tmp_xdg_home,
+        mock_keyring,
+        monkeypatch,
+        sample_geojson,
+        patch_sdk_for_publish,
+    ) -> None:
+        from geolens_cli.main import app
+
+        _seed_login("https://x.example.com", mock_keyring)
+        patch_sdk_for_publish(
+            upload=_ok_upload(), preview=_ok_preview(), commit=_ok_commit()
+        )
+        monkeypatch.setattr(
+            "geolens_cli.publish.resolve_dataset_id", lambda c, j, **kw: None
+        )
+        monkeypatch.setattr(
+            "geolens_cli.analysis.job_snapshot", lambda c, j: ("running", None)
+        )
+
+        result = runner.invoke(app, ["--json", "publish", str(sample_geojson)])
+        assert result.exit_code == 1, result.output
+        payload = json.loads(result.output)
+        assert payload["status"] == "running"
+        assert payload["dataset_id"] is None
+
+    def test_wait_token_expired_mid_poll_exits_auth(
+        self,
+        runner,
+        tmp_xdg_home,
+        mock_keyring,
+        monkeypatch,
+        sample_geojson,
+        patch_sdk_for_publish,
+    ) -> None:
+        """A token that expires mid-poll makes every job-status call 401.
+
+        resolve_dataset_id's poll treats a non-200 as "give up" (returns
+        None); the job_snapshot fallback then reads the SAME 401 and raises
+        EXIT_AUTH directly rather than reporting a generic failure, so the
+        exit code names what actually went wrong.
+        """
+        from geolens.models.problem_detail import ProblemDetail
+        from geolens_cli._sdk_helpers import EXIT_AUTH
+        from geolens_cli.main import app
+
+        _seed_login("https://x.example.com", mock_keyring)
+        expired = MagicMock(
+            status_code=HTTPStatus.UNAUTHORIZED,
+            parsed=ProblemDetail(
+                detail="Token expired",
+                status=401,
+                title="Unauthorized",
+                type_="about:blank",
+            ),
+        )
+        patch_sdk_for_publish(
+            upload=_ok_upload(),
+            preview=_ok_preview(),
+            commit=_ok_commit(),
+            job_status=expired,
+        )
+
+        result = runner.invoke(app, ["publish", str(sample_geojson)])
+        assert result.exit_code == EXIT_AUTH, result.output
+        assert "Authentication failed" in result.output
+
+    def test_wait_success_case_is_unchanged(
+        self,
+        runner,
+        tmp_xdg_home,
+        mock_keyring,
+        monkeypatch,
+        sample_geojson,
+        patch_sdk_for_publish,
+    ) -> None:
+        """Regression guard: a job that resolves normally still prints
+        "Published: ..." and exits 0 — the new failure branch must not fire
+        on the happy path."""
+        from geolens_cli.main import app
+
+        _seed_login("https://x.example.com", mock_keyring)
+        patch_sdk_for_publish(
+            upload=_ok_upload(),
+            preview=_ok_preview(),
+            commit=_ok_commit(),
+            job_status=_ok_job_status(
+                dataset_id="00000000-0000-0000-0000-000000000042", status="complete"
+            ),
+        )
+
+        result = runner.invoke(app, ["publish", str(sample_geojson)])
+        assert result.exit_code == 0, result.output
+        assert "Published:" in result.output
+        assert "00000000-0000-0000-0000-000000000042" in result.output
+
+
+class TestResolveDatasetIdTerminalStatuses:
+    """Unit-level: resolve_dataset_id stops polling as soon as the job status
+    is terminal, rather than sleeping and re-polling until timeout."""
+
+    def test_cancelled_stops_polling_immediately(self, monkeypatch) -> None:
+        from geolens_cli import publish as _publish
+
+        monkeypatch.setattr(
+            "geolens.api.admin.get_job_status_jobs_job_id_get.sync_detailed",
+            lambda **kw: _ok_job_status(dataset_id=None, status="cancelled"),
+        )
+        sleeps: list[float] = []
+
+        result = _publish.resolve_dataset_id(
+            MagicMock(),
+            "00000000-0000-0000-0000-000000000001",
+            sleep=sleeps.append,
+            monotonic=iter([0.0, 1.0, 2.0]).__next__,
+        )
+        assert result is None
+        assert sleeps == []
+
+    def test_fanned_out_stops_polling_immediately(self, monkeypatch) -> None:
+        from geolens_cli import publish as _publish
+
+        monkeypatch.setattr(
+            "geolens.api.admin.get_job_status_jobs_job_id_get.sync_detailed",
+            lambda **kw: _ok_job_status(dataset_id=None, status="fanned_out"),
+        )
+        sleeps: list[float] = []
+
+        result = _publish.resolve_dataset_id(
+            MagicMock(),
+            "00000000-0000-0000-0000-000000000001",
+            sleep=sleeps.append,
+            monotonic=iter([0.0, 1.0, 2.0]).__next__,
+        )
+        assert result is None
+        assert sleeps == []
+
+
+# ---------------------------------------------------------------------------
 # BUG-034 — network failures during upload / job-status poll map to EXIT_NETWORK
 # ---------------------------------------------------------------------------
 

--- a/cli/tests/test_publish_unit.py
+++ b/cli/tests/test_publish_unit.py
@@ -873,7 +873,7 @@ class TestPublishWaitTerminalOutcomes:
         assert payload["status"] == "fanned_out"
         assert payload["dataset_id"] is None
 
-    def test_wait_job_fanned_out_with_tags_notes_they_were_not_applied(
+    def test_wait_job_fanned_out_with_tags_records_an_extras_failure(
         self,
         runner,
         tmp_xdg_home,
@@ -882,8 +882,13 @@ class TestPublishWaitTerminalOutcomes:
         sample_geojson,
         patch_sdk_for_publish,
     ) -> None:
-        """--tags/--collection cannot be applied to a fanned-out job: there
-        is no single dataset id, since every layer became its own dataset."""
+        """fix(#1778, codex round 9): --tags/--collection cannot be applied
+        to a fanned-out job — there is no single dataset id, since every
+        layer became its own dataset. That omission must exit non-zero and
+        say so: recording only a note in the success message (the
+        pre-round-9 behavior) left extras_failures empty, so the command
+        exited 0 despite a requested operation never running."""
+        from geolens_cli._sdk_helpers import EXIT_GENERIC
         from geolens_cli.main import app
 
         _seed_login("https://x.example.com", mock_keyring)
@@ -897,10 +902,53 @@ class TestPublishWaitTerminalOutcomes:
         result = runner.invoke(
             app, ["publish", str(sample_geojson), "--tags", "hydro"]
         )
-        assert result.exit_code == 0, result.output
+        assert result.exit_code == EXIT_GENERIC, result.output
         assert "fanned out" in result.output
-        assert "not applied" in result.output
-        assert "Dataset created" not in result.output
+        assert "Dataset created, but" in result.output
+        assert "tags not applied" in result.output
+
+    def test_wait_job_fanned_out_with_extras_json_mode_carries_the_failures(
+        self,
+        runner,
+        tmp_xdg_home,
+        mock_keyring,
+        monkeypatch,
+        sample_geojson,
+        patch_sdk_for_publish,
+    ) -> None:
+        """One extras_failures entry per requested extra (fix(#1778, codex
+        round 9)): both --tags and --collection here, both skipped."""
+        from geolens_cli._sdk_helpers import EXIT_GENERIC
+        from geolens_cli.main import app
+
+        _seed_login("https://x.example.com", mock_keyring)
+        patch_sdk_for_publish(
+            upload=_ok_upload(),
+            preview=_ok_preview(),
+            commit=_ok_commit(),
+            job_status=_ok_job_status(dataset_id=None, status="fanned_out"),
+        )
+
+        result = runner.invoke(
+            app,
+            [
+                "--json",
+                "publish",
+                str(sample_geojson),
+                "--tags",
+                "hydro",
+                "--collection",
+                "terrain",
+            ],
+        )
+        assert result.exit_code == EXIT_GENERIC, result.output
+        payload = json.loads(result.output)
+        assert payload["status"] == "fanned_out"
+        assert len(payload["extras_failures"]) == 2
+        assert any("tags not applied" in f for f in payload["extras_failures"])
+        assert any(
+            "collection not applied" in f for f in payload["extras_failures"]
+        )
 
     def test_wait_poll_timed_out_exits_nonzero(
         self,

--- a/cli/tests/test_publish_unit.py
+++ b/cli/tests/test_publish_unit.py
@@ -1010,7 +1010,12 @@ class TestPublishWaitTerminalOutcomes:
         )
 
         result = runner.invoke(app, ["publish", str(sample_geojson)])
-        assert result.exit_code == 1, result.output
+        # fix(#1778, codex round 7): 500 is a 5xx, so this now maps to
+        # EXIT_SERVER rather than the old hard-coded EXIT_GENERIC — see
+        # TestPublishPollFailedExitCodes below for the dedicated coverage.
+        from geolens_cli._sdk_helpers import EXIT_SERVER
+
+        assert result.exit_code == EXIT_SERVER, result.output
         assert "Published:" not in result.output
         assert "could not be read" in result.output
         assert "HTTP 500" in result.output
@@ -1040,7 +1045,11 @@ class TestPublishWaitTerminalOutcomes:
         )
 
         result = runner.invoke(app, ["--json", "publish", str(sample_geojson)])
-        assert result.exit_code == 1, result.output
+        # fix(#1778, codex round 7): 500 is a 5xx, so this now maps to
+        # EXIT_SERVER rather than the old hard-coded EXIT_GENERIC.
+        from geolens_cli._sdk_helpers import EXIT_SERVER
+
+        assert result.exit_code == EXIT_SERVER, result.output
         payload = json.loads(result.output)
         assert payload["stopped_because"] == "poll_failed"
         assert payload["dataset_id"] is None
@@ -1415,6 +1424,69 @@ class TestPublishWaitTerminalOutcomes:
         assert "00000000-0000-0000-0000-000000000042" in result.output
 
 
+class TestPublishPollFailedExitCodes:
+    """fix(#1778, codex round 7): a poll_failed outcome must select the
+    CLI's established exit code for the HTTP status that caused it — a
+    5xx (server outage) is EXIT_SERVER, anything else is the pre-existing
+    EXIT_GENERIC — matching the matrix `_sdk_helpers.unwrap()` already
+    uses. Previously every poll_failed exited 1 regardless of status,
+    hiding a server outage from a script checking the exit code."""
+
+    def test_503_poll_exits_exit_server_with_poll_failed_wording(
+        self,
+        runner,
+        tmp_xdg_home,
+        mock_keyring,
+        monkeypatch,
+        sample_geojson,
+        patch_sdk_for_publish,
+    ) -> None:
+        from geolens_cli._sdk_helpers import EXIT_SERVER
+        from geolens_cli.main import app
+
+        _seed_login("https://x.example.com", mock_keyring)
+        patch_sdk_for_publish(
+            upload=_ok_upload(), preview=_ok_preview(), commit=_ok_commit()
+        )
+        monkeypatch.setattr(
+            "geolens.api.admin.get_job_status_jobs_job_id_get.sync_detailed",
+            lambda **kw: MagicMock(
+                status_code=HTTPStatus.SERVICE_UNAVAILABLE, parsed=None
+            ),
+        )
+
+        result = runner.invoke(app, ["publish", str(sample_geojson)])
+        assert result.exit_code == EXIT_SERVER, result.output
+        assert "could not be read" in result.output
+        assert "HTTP 503" in result.output
+
+    def test_404_poll_exits_generic_with_poll_failed_wording(
+        self,
+        runner,
+        tmp_xdg_home,
+        mock_keyring,
+        monkeypatch,
+        sample_geojson,
+        patch_sdk_for_publish,
+    ) -> None:
+        from geolens_cli._sdk_helpers import EXIT_GENERIC
+        from geolens_cli.main import app
+
+        _seed_login("https://x.example.com", mock_keyring)
+        patch_sdk_for_publish(
+            upload=_ok_upload(), preview=_ok_preview(), commit=_ok_commit()
+        )
+        monkeypatch.setattr(
+            "geolens.api.admin.get_job_status_jobs_job_id_get.sync_detailed",
+            lambda **kw: MagicMock(status_code=HTTPStatus.NOT_FOUND, parsed=None),
+        )
+
+        result = runner.invoke(app, ["publish", str(sample_geojson)])
+        assert result.exit_code == EXIT_GENERIC, result.output
+        assert "could not be read" in result.output
+        assert "HTTP 404" in result.output
+
+
 class TestResolveDatasetIdTerminalStatuses:
     """Unit-level: resolve_dataset_id stops polling as soon as the job status
     is terminal, rather than sleeping and re-polling until timeout, and
@@ -1518,6 +1590,18 @@ class TestResolveDatasetIdPollOutcomeShape:
         assert outcome.stopped_because == "poll_failed"
         assert outcome.detail == "HTTP 500"
         assert outcome.status == "running"
+        assert outcome.http_status == 500
+
+    def test_poll_failed_exit_code_maps_5xx_to_exit_server(self) -> None:
+        from geolens_cli import publish as _publish
+        from geolens_cli._sdk_helpers import EXIT_GENERIC, EXIT_SERVER
+
+        assert _publish.poll_failed_exit_code(500) == EXIT_SERVER
+        assert _publish.poll_failed_exit_code(503) == EXIT_SERVER
+        assert _publish.poll_failed_exit_code(599) == EXIT_SERVER
+        assert _publish.poll_failed_exit_code(404) == EXIT_GENERIC
+        assert _publish.poll_failed_exit_code(499) == EXIT_GENERIC
+        assert _publish.poll_failed_exit_code(None) == EXIT_GENERIC
 
     def test_token_expired_stops_polling_immediately(self, monkeypatch) -> None:
         from geolens_cli import publish as _publish

--- a/cli/tests/test_publish_unit.py
+++ b/cli/tests/test_publish_unit.py
@@ -1235,6 +1235,77 @@ class TestPublishWaitTerminalOutcomes:
         assert "still running" in result.output
         assert "has not finished" in result.output
 
+    def test_wait_snapshot_read_does_not_leak_its_timeout_into_stage_5(
+        self,
+        runner,
+        tmp_xdg_home,
+        mock_keyring,
+        monkeypatch,
+        sample_geojson,
+        patch_sdk_for_publish,
+    ) -> None:
+        """fix(#1778, codex round 6): `with_timeout()` MUTATES the shared
+        transport's timeout in place before returning an "evolved" client
+        that is really a decoy (sdks/python/geolens/client.py) — Stage 5
+        (--tags/--collection) reuses sdk.client, so binding the follow-up
+        snapshot read used to leave every metadata request capped at 5s
+        afterward too, reporting an otherwise-successful publish as a
+        partial failure. The shared transport's timeout must be back to
+        its ORIGINAL value by the time Stage 5 runs.
+
+        The httpx.Client is force-constructed before the command runs
+        (via ``.get_httpx_client()``) because the pre-round-6 bug only
+        mutates an ALREADY-CONSTRUCTED transport in place — a lazily
+        constructed one (the normal case, since every earlier stage is
+        mocked at the SDK-function level here) would not have exposed it.
+        """
+        import httpx
+        from geolens import GeolensClient
+
+        from geolens_cli import publish as _publish
+        from geolens_cli.main import app
+
+        instance = "https://x.example.com"
+        _seed_login(instance, mock_keyring)
+
+        real_sdk = GeolensClient(base_url=instance + "/api", bearer_token="tok-abc")
+        original_timeout = real_sdk.client.get_httpx_client().timeout
+        monkeypatch.setattr("geolens_cli.main.AppState.sdk", lambda self: real_sdk)
+
+        patch_sdk_for_publish(
+            upload=_ok_upload(),
+            preview=_ok_preview(),
+            commit=_ok_commit(),
+            job_status=_ok_job_status(
+                dataset_id="00000000-0000-0000-0000-000000000042", status="complete"
+            ),
+        )
+        monkeypatch.setattr(
+            "geolens_cli.publish.resolve_dataset_id",
+            lambda c, j, **kw: _publish.PollOutcome(
+                status="running", stopped_because="timeout"
+            ),
+        )
+
+        observed: dict = {}
+
+        def stage_5_extras(client, dataset_id, tags, collection):
+            observed["timeout"] = client.get_httpx_client().timeout
+            return []
+
+        monkeypatch.setattr(
+            "geolens_cli.publish.apply_publish_extras", stage_5_extras
+        )
+
+        result = runner.invoke(
+            app, ["publish", str(sample_geojson), "--tags", "hydro"]
+        )
+        assert result.exit_code == 0, result.output
+        assert observed["timeout"] == original_timeout
+        assert observed["timeout"] != httpx.Timeout(
+            _publish._SNAPSHOT_REQUEST_TIMEOUT_SECONDS
+        )
+
     def test_wait_token_expired_mid_poll_exits_auth(
         self,
         runner,

--- a/cli/tests/test_publish_unit.py
+++ b/cli/tests/test_publish_unit.py
@@ -918,6 +918,7 @@ class TestPublishWaitTerminalOutcomes:
         same technique cli/tests/test_analysis.py uses for the sibling
         materialize --wait timeout test.
         """
+        from geolens_cli import publish as _publish
         from geolens_cli.main import app
 
         _seed_login("https://x.example.com", mock_keyring)
@@ -925,7 +926,10 @@ class TestPublishWaitTerminalOutcomes:
             upload=_ok_upload(), preview=_ok_preview(), commit=_ok_commit()
         )
         monkeypatch.setattr(
-            "geolens_cli.publish.resolve_dataset_id", lambda c, j, **kw: None
+            "geolens_cli.publish.resolve_dataset_id",
+            lambda c, j, **kw: _publish.PollOutcome(
+                status="running", stopped_because="timeout"
+            ),
         )
         monkeypatch.setattr(
             "geolens_cli.analysis.job_snapshot", lambda c, j: ("running", None)
@@ -946,6 +950,7 @@ class TestPublishWaitTerminalOutcomes:
         sample_geojson,
         patch_sdk_for_publish,
     ) -> None:
+        from geolens_cli import publish as _publish
         from geolens_cli.main import app
 
         _seed_login("https://x.example.com", mock_keyring)
@@ -953,7 +958,10 @@ class TestPublishWaitTerminalOutcomes:
             upload=_ok_upload(), preview=_ok_preview(), commit=_ok_commit()
         )
         monkeypatch.setattr(
-            "geolens_cli.publish.resolve_dataset_id", lambda c, j, **kw: None
+            "geolens_cli.publish.resolve_dataset_id",
+            lambda c, j, **kw: _publish.PollOutcome(
+                status="running", stopped_because="timeout"
+            ),
         )
         monkeypatch.setattr(
             "geolens_cli.analysis.job_snapshot", lambda c, j: ("running", None)
@@ -963,6 +971,78 @@ class TestPublishWaitTerminalOutcomes:
         assert result.exit_code == 1, result.output
         payload = json.loads(result.output)
         assert payload["status"] == "running"
+        assert payload["stopped_because"] == "timeout"
+        assert payload["dataset_id"] is None
+
+    def test_wait_poll_failed_is_not_reported_as_a_timeout(
+        self,
+        runner,
+        tmp_xdg_home,
+        mock_keyring,
+        monkeypatch,
+        sample_geojson,
+        patch_sdk_for_publish,
+    ) -> None:
+        """fix(#1778, codex round 3): the bug this fix closes. A transient
+        poll failure (HTTP 500) followed by a job_snapshot() follow-up read
+        that happens to succeed and report "running" must NOT be reported
+        as a false "still running after 120s" timeout — nothing timed out;
+        one read failed, and the next one (a DIFFERENT request) recovered."""
+        from geolens_cli.main import app
+
+        _seed_login("https://x.example.com", mock_keyring)
+        patch_sdk_for_publish(
+            upload=_ok_upload(), preview=_ok_preview(), commit=_ok_commit()
+        )
+        calls = {"n": 0}
+
+        def flaky_then_running(**kw):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                return MagicMock(
+                    status_code=HTTPStatus.INTERNAL_SERVER_ERROR, parsed=None
+                )
+            return _ok_job_status(dataset_id=None, status="running")
+
+        monkeypatch.setattr(
+            "geolens.api.admin.get_job_status_jobs_job_id_get.sync_detailed",
+            flaky_then_running,
+        )
+
+        result = runner.invoke(app, ["publish", str(sample_geojson)])
+        assert result.exit_code == 1, result.output
+        assert "Published:" not in result.output
+        assert "could not be read" in result.output
+        assert "HTTP 500" in result.output
+        assert "still running" not in result.output
+        assert "has not finished" not in result.output
+
+    def test_wait_poll_failed_json_mode_carries_stopped_because(
+        self,
+        runner,
+        tmp_xdg_home,
+        mock_keyring,
+        monkeypatch,
+        sample_geojson,
+        patch_sdk_for_publish,
+    ) -> None:
+        from geolens_cli.main import app
+
+        _seed_login("https://x.example.com", mock_keyring)
+        patch_sdk_for_publish(
+            upload=_ok_upload(), preview=_ok_preview(), commit=_ok_commit()
+        )
+        monkeypatch.setattr(
+            "geolens.api.admin.get_job_status_jobs_job_id_get.sync_detailed",
+            lambda **kw: MagicMock(
+                status_code=HTTPStatus.INTERNAL_SERVER_ERROR, parsed=None
+            ),
+        )
+
+        result = runner.invoke(app, ["--json", "publish", str(sample_geojson)])
+        assert result.exit_code == 1, result.output
+        payload = json.loads(result.output)
+        assert payload["stopped_because"] == "poll_failed"
         assert payload["dataset_id"] is None
 
     def test_wait_token_expired_mid_poll_exits_auth(
@@ -976,10 +1056,12 @@ class TestPublishWaitTerminalOutcomes:
     ) -> None:
         """A token that expires mid-poll makes every job-status call 401.
 
-        resolve_dataset_id's poll treats a non-200 as "give up" (returns
-        None); the job_snapshot fallback then reads the SAME 401 and raises
-        EXIT_AUTH directly rather than reporting a generic failure, so the
-        exit code names what actually went wrong.
+        fix(#1778, codex round 3): resolve_dataset_id detects the 401/403
+        itself now (PollOutcome.stopped_because == "token_expired") instead
+        of returning a bare None for the caller to reinterpret via a second
+        job_snapshot() read; the command exits EXIT_AUTH directly off that,
+        naming what actually went wrong rather than reporting a generic
+        failure.
         """
         from geolens.models.problem_detail import ProblemDetail
         from geolens_cli._sdk_helpers import EXIT_AUTH
@@ -1005,6 +1087,42 @@ class TestPublishWaitTerminalOutcomes:
         result = runner.invoke(app, ["publish", str(sample_geojson)])
         assert result.exit_code == EXIT_AUTH, result.output
         assert "Authentication failed" in result.output
+
+    def test_wait_token_expired_json_mode_carries_stopped_because(
+        self,
+        runner,
+        tmp_xdg_home,
+        mock_keyring,
+        monkeypatch,
+        sample_geojson,
+        patch_sdk_for_publish,
+    ) -> None:
+        from geolens.models.problem_detail import ProblemDetail
+        from geolens_cli._sdk_helpers import EXIT_AUTH
+        from geolens_cli.main import app
+
+        _seed_login("https://x.example.com", mock_keyring)
+        expired = MagicMock(
+            status_code=HTTPStatus.UNAUTHORIZED,
+            parsed=ProblemDetail(
+                detail="Token expired",
+                status=401,
+                title="Unauthorized",
+                type_="about:blank",
+            ),
+        )
+        patch_sdk_for_publish(
+            upload=_ok_upload(),
+            preview=_ok_preview(),
+            commit=_ok_commit(),
+            job_status=expired,
+        )
+
+        result = runner.invoke(app, ["--json", "publish", str(sample_geojson)])
+        assert result.exit_code == EXIT_AUTH, result.output
+        payload = json.loads(result.output)
+        assert payload["stopped_because"] == "token_expired"
+        assert payload["dataset_id"] is None
 
     def test_wait_success_case_is_unchanged(
         self,
@@ -1038,7 +1156,9 @@ class TestPublishWaitTerminalOutcomes:
 
 class TestResolveDatasetIdTerminalStatuses:
     """Unit-level: resolve_dataset_id stops polling as soon as the job status
-    is terminal, rather than sleeping and re-polling until timeout."""
+    is terminal, rather than sleeping and re-polling until timeout, and
+    reports it via PollOutcome.stopped_because == "terminal"
+    (fix(#1778, codex round 3))."""
 
     def test_cancelled_stops_polling_immediately(self, monkeypatch) -> None:
         from geolens_cli import publish as _publish
@@ -1049,13 +1169,15 @@ class TestResolveDatasetIdTerminalStatuses:
         )
         sleeps: list[float] = []
 
-        result = _publish.resolve_dataset_id(
+        outcome = _publish.resolve_dataset_id(
             MagicMock(),
             "00000000-0000-0000-0000-000000000001",
             sleep=sleeps.append,
             monotonic=iter([0.0, 1.0, 2.0]).__next__,
         )
-        assert result is None
+        assert outcome.dataset_id is None
+        assert outcome.status == "cancelled"
+        assert outcome.stopped_because == "terminal"
         assert sleeps == []
 
     def test_fanned_out_stops_polling_immediately(self, monkeypatch) -> None:
@@ -1067,13 +1189,92 @@ class TestResolveDatasetIdTerminalStatuses:
         )
         sleeps: list[float] = []
 
-        result = _publish.resolve_dataset_id(
+        outcome = _publish.resolve_dataset_id(
             MagicMock(),
             "00000000-0000-0000-0000-000000000001",
             sleep=sleeps.append,
             monotonic=iter([0.0, 1.0, 2.0]).__next__,
         )
-        assert result is None
+        assert outcome.dataset_id is None
+        assert outcome.status == "fanned_out"
+        assert outcome.stopped_because == "terminal"
+        assert sleeps == []
+
+
+class TestResolveDatasetIdPollOutcomeShape:
+    """Unit-level: resolve_dataset_id's PollOutcome for the other three
+    stopped_because reasons — "timeout", "poll_failed", "token_expired" —
+    added in fix(#1778, codex round 3) so a caller never has to guess why
+    the poll gave up from a bare None."""
+
+    def test_timeout_preserves_the_last_known_status(self, monkeypatch) -> None:
+        """The deadline is reached while the job is still pending/running;
+        the last valid read's status is preserved, not discarded."""
+        from geolens_cli import publish as _publish
+
+        monkeypatch.setattr(
+            "geolens.api.admin.get_job_status_jobs_job_id_get.sync_detailed",
+            lambda **kw: _ok_job_status(dataset_id=None, status="running"),
+        )
+
+        outcome = _publish.resolve_dataset_id(
+            MagicMock(),
+            "00000000-0000-0000-0000-000000000001",
+            sleep=lambda *_: None,
+            monotonic=iter([0.0, 1.0, 200.0]).__next__,
+        )
+        assert outcome.dataset_id is None
+        assert outcome.status == "running"
+        assert outcome.stopped_because == "timeout"
+
+    def test_poll_failed_carries_the_http_status_and_last_known_status(
+        self, monkeypatch
+    ) -> None:
+        """A non-200/401/403 response (a transient 500 here) stops the poll
+        immediately with the HTTP status in ``detail``, and preserves
+        whatever status an EARLIER successful read saw."""
+        from geolens_cli import publish as _publish
+
+        responses = iter(
+            [
+                _ok_job_status(dataset_id=None, status="running"),
+                MagicMock(status_code=HTTPStatus.INTERNAL_SERVER_ERROR, parsed=None),
+            ]
+        )
+        monkeypatch.setattr(
+            "geolens.api.admin.get_job_status_jobs_job_id_get.sync_detailed",
+            lambda **kw: next(responses),
+        )
+        sleeps: list[float] = []
+
+        outcome = _publish.resolve_dataset_id(
+            MagicMock(),
+            "00000000-0000-0000-0000-000000000001",
+            sleep=sleeps.append,
+            monotonic=iter([0.0, 1.0, 2.0, 3.0]).__next__,
+        )
+        assert outcome.dataset_id is None
+        assert outcome.stopped_because == "poll_failed"
+        assert outcome.detail == "HTTP 500"
+        assert outcome.status == "running"
+
+    def test_token_expired_stops_polling_immediately(self, monkeypatch) -> None:
+        from geolens_cli import publish as _publish
+
+        monkeypatch.setattr(
+            "geolens.api.admin.get_job_status_jobs_job_id_get.sync_detailed",
+            lambda **kw: MagicMock(status_code=HTTPStatus.UNAUTHORIZED, parsed=None),
+        )
+        sleeps: list[float] = []
+
+        outcome = _publish.resolve_dataset_id(
+            MagicMock(),
+            "00000000-0000-0000-0000-000000000001",
+            sleep=sleeps.append,
+            monotonic=iter([0.0, 1.0, 2.0]).__next__,
+        )
+        assert outcome.dataset_id is None
+        assert outcome.stopped_because == "token_expired"
         assert sleeps == []
 
 

--- a/cli/tests/test_publish_unit.py
+++ b/cli/tests/test_publish_unit.py
@@ -1186,6 +1186,55 @@ class TestPublishWaitTerminalOutcomes:
         assert "still running" in result.output
         assert "has not finished" in result.output
 
+    def test_wait_snapshot_read_timeout_does_not_hang_and_reports_original_outcome(
+        self,
+        runner,
+        tmp_xdg_home,
+        mock_keyring,
+        monkeypatch,
+        sample_geojson,
+        patch_sdk_for_publish,
+    ) -> None:
+        """fix(#1778, codex round 5): sdk.client's generated transport
+        defaults to timeout=None (unbounded), so a stalled connection on
+        the follow-up diagnostic read could hang the command forever
+        instead of reporting the timeout it already reached. The read is
+        now bound (_SNAPSHOT_REQUEST_TIMEOUT_SECONDS); when it ALSO times
+        out, the command must not hang or crash — it falls back to the
+        original outcome. resolve_dataset_id is mocked directly (so this
+        test cannot itself hang on the real 120s poll); the SDK call the
+        real job_snapshot() makes is mocked to raise httpx.TimeoutException,
+        standing in for the bound actually firing.
+        """
+        import httpx
+
+        from geolens_cli import publish as _publish
+        from geolens_cli.main import app
+
+        _seed_login("https://x.example.com", mock_keyring)
+        patch_sdk_for_publish(
+            upload=_ok_upload(), preview=_ok_preview(), commit=_ok_commit()
+        )
+        monkeypatch.setattr(
+            "geolens_cli.publish.resolve_dataset_id",
+            lambda c, j, **kw: _publish.PollOutcome(
+                status="running", stopped_because="timeout"
+            ),
+        )
+
+        def boom(**kw):
+            raise httpx.TimeoutException("stalled")
+
+        monkeypatch.setattr(
+            "geolens.api.admin.get_job_status_jobs_job_id_get.sync_detailed",
+            boom,
+        )
+
+        result = runner.invoke(app, ["publish", str(sample_geojson)])
+        assert result.exit_code == 1, result.output
+        assert "still running" in result.output
+        assert "has not finished" in result.output
+
     def test_wait_token_expired_mid_poll_exits_auth(
         self,
         runner,

--- a/cli/tests/test_publish_unit.py
+++ b/cli/tests/test_publish_unit.py
@@ -675,10 +675,10 @@ class TestPublishCli:
 
 
 # ---------------------------------------------------------------------------
-# fix(audit 2026-08-30 finding 1, 8dc529f17) — `publish --wait` must not
-# report success (exit 0, "Published: ...") for a job that failed, was
-# cancelled, timed out, or could not be read back because the token expired
-# mid-poll. Mirrors analysis materialize --wait's job_snapshot fallback.
+# fix(#1778) — `publish --wait` must not report success (exit 0,
+# "Published: ...") for a job that failed, was cancelled, timed out, or
+# could not be read back because the token expired mid-poll. Mirrors
+# analysis materialize --wait's job_snapshot fallback.
 # ---------------------------------------------------------------------------
 
 
@@ -707,6 +707,38 @@ class TestPublishWaitTerminalOutcomes:
         assert "Published:" not in result.output
         assert "failed" in result.output
         assert "job record" in result.output
+
+    def test_wait_job_failed_with_tags_does_not_claim_a_dataset_was_created(
+        self,
+        runner,
+        tmp_xdg_home,
+        mock_keyring,
+        monkeypatch,
+        sample_geojson,
+        patch_sdk_for_publish,
+    ) -> None:
+        """fix(#1778, codex round 1 P2): a failed/cancelled/timed-out job
+        never resolves a dataset_id, so --tags/--collection are never
+        attempted against it. The output must carry only the terminal
+        failure line, not a "Dataset created, but: ... not applied" line
+        that contradicts it."""
+        from geolens_cli.main import app
+
+        _seed_login("https://x.example.com", mock_keyring)
+        patch_sdk_for_publish(
+            upload=_ok_upload(),
+            preview=_ok_preview(),
+            commit=_ok_commit(),
+            job_status=_ok_job_status(dataset_id=None, status="failed"),
+        )
+
+        result = runner.invoke(
+            app, ["publish", str(sample_geojson), "--tags", "hydro"]
+        )
+        assert result.exit_code == 1, result.output
+        assert "failed" in result.output
+        assert "Dataset created" not in result.output
+        assert "not applied" not in result.output
 
     def test_wait_job_failed_json_mode_carries_status_and_null_dataset_id(
         self,


### PR DESCRIPTION
Addresses two findings from the codebase audit 2026-08-30 (8dc529f17), audit "do first" item 7, tracked in #1778.

**Finding 1 — "`geolens publish --wait` exits 0 and prints 'Published:' when the ingest job FAILED".** Confirmed present on current main. `resolve_dataset_id` returns `None` for a failed job, a cancelled job, a timed-out poll, and a job-status read broken by an expired token (a non-200 response) alike, and the publish command read every one of those as success: exit 0, `Published: <job-search URL>`. Fixed by having the command read the job status back via `analysis.job_snapshot` (the same fallback `analysis materialize --wait` already uses) whenever `resolve_dataset_id` comes back empty, so each outcome gets its own message and a non-zero exit. `--json` mode now carries the resolved terminal status in the existing `status` field instead of the stale initial commit status.

**Finding 2 — "`resolve_dataset_id` treats `cancelled` as non-terminal".** Confirmed present. Only `"failed"` was in the terminal set, so `--wait` polled a cancelled job for the full 120s timeout (or forever, under `analysis materialize --wait`'s `POLL_FOREVER`). Added `"cancelled"` and `"fanned_out"` to `resolve_dataset_id`'s terminal set (`fanned_out` is the terminal status a multi-layer commit's parent job lands on and never gets its own dataset_id, per `commit_fan_out` in `backend/app/processing/ingest/router.py`). Since `analysis materialize --wait` polls through the same `resolve_dataset_id`, it gets the fix automatically; I also corrected its own `cancelled` status branch, which previously fell into the "still {status} ... has not finished" wording — wrong for a job that will never finish, not just hasn't yet.

`geolens replace --wait` (#1767) polls through `refresh.wait_for_refresh`, a separate poller that already treats `{"failed", "cancelled"}` as terminal, so it does not share `resolve_dataset_id` and needed no change; left untouched per the lane brief.

The third row in the register excerpt (`JobProgress.tsx`, no owner-facing cancel control) is frontend and out of scope for this lane.

No schema, API, or config impact. Nothing under `backend/app/` touched.

Codex round 1 findings addressed:
- P1: in-source comments cited the audit label (`fix(audit 2026-08-30 finding N, 8dc529f17)`) instead of a lookup-able PR/issue reference, against AGENTS.md's inline review-comment convention. Replaced every instance with `fix(#1778): <one line>`.
- P2: with `--tags`/`--collection`, a failed/cancelled/timed-out job left `dataset_id` unset, so the extras block still appended "dataset id could not be resolved — tags/collection not applied" to `extras_failures`, and the output showed both the terminal failure line and a "Dataset created, but: ..." line for a dataset that was never created. Tags/collection application is now skipped entirely when `dataset_id` did not resolve, since there is nothing to apply them to and the terminal failure message already explains why.

Codex round 2 findings addressed:
- P1: one in-source comment still used the bare `fix finding 2` form (the round 1 sweep grepped for the audit label and commit hash, not this bare pattern). Replaced with `fix(#1778)`.
- P2: `fanned_out` is explicitly terminal, but the new wait-outcome branching fell through to the generic "was still fanned_out after 120s and has not finished" wording, which is false — nothing timed out and nothing failed. A fanned-out parent job is a successful multi-layer import whose children each carry their own dataset, so `publish --wait` now exits 0 for it, prints that the job fanned out into per-layer imports, and points at `GET /jobs/{job_id}` and the datasets list (the API has no field listing the child job ids, so the CLI cannot enumerate them directly). `--json` carries status `"fanned_out"`. `--tags`/`--collection` are noted as not applied, since there is no single dataset id to apply them to.

Codex round 3 finding addressed:
- P2 (the only finding that round): `resolve_dataset_id` returning a bare `None` on a poll failure made every caller guess why by making a SECOND, independent request (`job_snapshot`) and trusting its status — which can legally disagree with what actually stopped the original poll. A transient 500 followed by a lucky `pending`/`running` re-read was reported as "still running after 120s", a false diagnosis reached after two requests with no timeout involved. `resolve_dataset_id` now returns a `PollOutcome` (`dataset_id`, last known `status`, and a `stopped_because` of `"terminal"`, `"timeout"`, `"token_expired"`, or `"poll_failed"` with the HTTP status or error text) instead of collapsing every reason into `None`. `publish` and `analysis materialize` branch on it directly: the "after Ns" wording is used only for a real timeout, a poll failure names the failure and points at `GET /jobs/{id}` (exits non-zero), an expired token exits `EXIT_AUTH` without a doomed retry, and terminal statuses keep their existing per-status messages. The follow-up read some of these branches still need for the "job actually finished a moment ago" race (`fix(#685 review)`) is now used only to check for a late dataset id, never trusted for wording, and is skipped for `"terminal"`/`"token_expired"` since neither can be resolved by asking again. `--json` now carries `stopped_because` on both commands. Rewrote every existing `resolve_dataset_id`-dependent test against the new shape and added one test per `stopped_because` reason (plus JSON variants) for both commands, including a regression test that reproduces the exact bug (a poll failure followed by a lucky `pending` re-read must not read as a timeout).

Codex round 4 finding addressed:
- P2 (the only finding that round): after a timeout or poll failure, the follow-up read was still only trusted for its dataset id - a job that had SINCE become failed or cancelled while the poll was stuck, or while one read failed, was still reported with the stale "still running" or "status could not be read" wording. Both commands now also check the follow-up read's status: `failed`, `cancelled`, or `fanned_out` wins outright and is reported exactly like a first-read terminal outcome (same messages, same exit codes, `stopped_because` becomes `"terminal"`); only `pending`/`running`/unreadable leaves the job's fate genuinely unresolved, so only those keep the original timeout/poll_failed wording. Added one test per command for each of the three named scenarios: timeout then a final failed snapshot, poll failure then a final cancelled snapshot, and timeout then a still-running snapshot (proving the override only fires on a definitive terminal status).

Codex round 5 finding addressed:
- P2 (the only finding that round): the follow-up snapshot read added in round 3 (used after a `timeout` or `poll_failed` outcome, and now also to check for a late terminal status per round 4) used `sdk.client` as-is, whose generated transport defaults to `timeout=None` - unbounded. A stalled connection on that one-shot diagnostic read could hang the command forever, even though the original poll had already reached a reportable outcome. Added a named constant, `_SNAPSHOT_REQUEST_TIMEOUT_SECONDS` (5s) in `publish.py`, and bind a fresh client to it for the follow-up read in both `publish` and `analysis materialize`. If that bounded read also times out, it is treated the same as any other unreadable follow-up: the command falls back to the original outcome's wording rather than hanging or aborting with a raw network error. Added one test per command simulating the bound firing (the mocked SDK call raises `httpx.TimeoutException`, the same technique the existing upload/poll network-error tests already use) and asserting the command exits promptly with the original outcome.

Codex round 6 finding addressed (a regression the round-5 fix introduced):
- P2 (the only finding that round): the generated SDK's `client.with_timeout()` mutates the already-constructed httpx transport's timeout in place before returning an "evolved" client - the evolved client is a decoy, since the caller's original client keeps the new timeout for the rest of its life (`sdks/python/geolens/client.py`). Binding the round-5 snapshot read via `sdk.client.with_timeout(5.0)` therefore left `sdk.client`'s own transport permanently capped at 5 seconds afterward. In `publish`, Stage 5 (`--tags`/`--collection`) reuses `sdk.client`, so a legitimately slower tag or collection request would have been reported as a partial publish failure even though publishing itself succeeded. Both commands now read the transport directly via `get_httpx_client()` (the SDK's own public escape hatch, already used by `upload_file()`), save its timeout, bind it to the snapshot bound for the one read, and restore it unconditionally in a `finally` block. `analysis materialize` gets the same fix for consistency, even though it has no post-snapshot use of `sdk.client` today. Added one test per command: each force-constructs the httpx transport up front (the bug only fires on an already-constructed one) and checks it is back to its original timeout afterward; the `publish` test also proves a Stage 5 call sees the unmutated client rather than the 5s bound.

Codex round 7 finding addressed (last round):
- P2 (the only finding that round): a `poll_failed` outcome collapsed every non-200 job-status response into the same `EXIT_GENERIC` (1), so a 503 read the same as a 404. This violates the exit-code matrix `_sdk_helpers.unwrap()` already establishes for the rest of the CLI, where a 5xx maps to `EXIT_SERVER` (5) so scripts can tell a server outage apart from other failures. `PollOutcome` now carries the HTTP status alongside its `detail` string when the `poll_failed` reason came from a real response. Added `poll_failed_exit_code()`, a small classifier mirroring `unwrap()`'s matrix (5xx to `EXIT_SERVER`, else `EXIT_GENERIC`; 401/403 never reach it, since those are reported as `"token_expired"` and already map to `EXIT_AUTH`). Both `publish` and `analysis materialize` call it instead of leaving their `poll_failed` branch on the default exit code. Updated the two existing tests that asserted the old hard-coded exit code for a mocked 500 (correctly `EXIT_SERVER` now) and added dedicated coverage for both commands: a 503 exits `EXIT_SERVER` with the poll-failed wording, a 404 exits `EXIT_GENERIC`, plus a unit test for the classifier itself.

Codex round 8/9 finding addressed (true final round):
- P2 (the only finding, kept in scope for r9 because it is exit-0-on-failure in the code this PR exists to fix): when `--tags`/`--collection` was requested and the job fanned out into per-layer datasets, the branch only appended a note to the human-readable success message. `extras_failures` stayed empty, so the existing extras-failure path (nonzero exit, `--json` `extras_failures` entries) never triggered - the command exited 0 despite a requested operation never running, and `--json` showed `extras_failures: []` with no indication anything was skipped. The fanned-out branch now records one `extras_failures` entry per requested extra that could not be applied (`"tags not applied: job fanned out into per-layer datasets"`, same for collection), so Stage 5 picks it up exactly like any other partial-publish failure: nonzero exit, present in the `--json` payload. `analysis materialize` has no `--tags`/`--collection` flags and no equivalent extras step, so it is unaffected and left untouched. Updated the one existing test this changes the behavior of, and added a `--json` test asserting one `extras_failures` entry per requested extra (tags and collection together) with the correct exit code.

Verification:
- `cd cli && uv run --extra dev python -m pytest -q` — 425 passed.
- Round-trip half of `make cli-test` (Postgres at localhost:5434): `tests/test_cli_round_trip.py` — 8 passed, 2 skipped. Both skips are the pre-existing publish/raster round-trip skip-on-runtime-exit-code guards documented inline in that file; the publish round-trip test uses `--no-wait`, which this change does not touch.

Left alone: `cli/README.md` documents `--wait` behavior for `replace`/`refresh`/`analysis materialize` but not `publish`; it does not document exit codes anywhere, so nothing there needed updating.





