### PR TITLE
fix(release): bind the smoked artifact to the tag ref across the release chain

### DIFF
--- a/.github/workflows/prod-smoke.yml
+++ b/.github/workflows/prod-smoke.yml
@@ -60,8 +60,13 @@ jobs:
       # "Assert semver-shaped tag" guard (keep the two in sync). A red run on a
       # junk tag is correct and cheap: release.yml fires only on this
       # workflow's SUCCESS, so nothing downstream advances.
+      #
+      # fix(#1778): gate on ref_type, not event_name. A workflow_dispatch run
+      # from a tag ref (`gh workflow run prod-smoke.yml --ref vX.Y.Z`) must be
+      # held to the same semver check as a tag push, or a re-smoke of a junk
+      # tag would skip straight past this and into the pull-retry loop below.
       - name: Assert semver release tag
-        if: github.event_name == 'push'
+        if: github.ref_type == 'tag'
         env:
           TAG: ${{ github.ref_name }}
         run: |
@@ -80,9 +85,17 @@ jobs:
           # the script body, where it would be evaluated as shell.
           INPUT_VERSION: ${{ github.event.inputs.version }}
         run: |
-          # On a tag push, github.ref_name is the tag (vX.Y.Z). On manual
-          # dispatch, use the input (default latest).
-          if [ "${{ github.event_name }}" = "push" ]; then
+          # fix(#1778): bind the smoked artifact to the ref, not the event.
+          # On ANY run from a tag ref — a tag push, or a workflow_dispatch
+          # re-run from that tag — github.ref_name IS the tag (vX.Y.Z), so
+          # ignore INPUT_VERSION and smoke that tag's own images. A dispatch
+          # defaults INPUT_VERSION to "latest", which is the PREVIOUS GA's
+          # images; using it here would let a re-smoke of a red tag pass by
+          # smoking a different artifact than the one release.yml is about to
+          # release (the tag it fires on is bound to THIS run's ref, not to
+          # VER). Only a dispatch from a branch (no tag to bind to) falls back
+          # to the input.
+          if [ "${{ github.ref_type }}" = "tag" ]; then
             VER="${{ github.ref_name }}"
           else
             VER="$INPUT_VERSION"

--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -66,10 +66,21 @@ jobs:
         with:
           python-version: "3.14"
 
-      - name: Assert tag matches package version (tag push only)
-        if: ${{ github.event_name == 'push' }}
+      # fix(#1778): every publishing run must come from a tag ref, and this is
+      # a hard failure rather than a skipped check, same as publish-mcp.yml's
+      # #1623 guard: a manual dispatch defaults to the branch selected in the
+      # Actions UI, and the repo sits at the last released version between
+      # bumps, so a branch run would happily publish that branch's current
+      # pyproject version as metadata for an already-released PyPI artifact.
+      # Dry runs are exempt — they only build.
+      - name: Require a tag ref, and assert it matches the package version
+        if: ${{ !inputs.dry_run }}
         working-directory: cli
         run: |
+          if [ "${GITHUB_REF_TYPE}" != "tag" ]; then
+            echo "::error::publishing requires a tag ref; got ${GITHUB_REF_TYPE} '${GITHUB_REF_NAME}'. Re-run with --ref vX.Y.Z"
+            exit 1
+          fi
           TAG="${GITHUB_REF_NAME#v}"
           PKG=$(python - <<'PY'
           import tomllib

--- a/.github/workflows/publish-sdks.yml
+++ b/.github/workflows/publish-sdks.yml
@@ -77,10 +77,21 @@ jobs:
         with:
           python-version: "3.14"
 
-      - name: Assert tag matches package version (tag push only)
-        if: ${{ github.event_name == 'push' }}
+      # fix(#1778): every publishing run must come from a tag ref, and this is
+      # a hard failure rather than a skipped check, same as publish-mcp.yml's
+      # #1623 guard: a manual dispatch defaults to the branch selected in the
+      # Actions UI, and the repo sits at the last released version between
+      # bumps, so a branch run would happily publish that branch's current
+      # pyproject version as metadata for an already-released PyPI artifact.
+      # Dry runs are exempt — they only build.
+      - name: Require a tag ref, and assert it matches the package version
+        if: ${{ !inputs.dry_run }}
         working-directory: sdks/python
         run: |
+          if [ "${GITHUB_REF_TYPE}" != "tag" ]; then
+            echo "::error::publishing requires a tag ref; got ${GITHUB_REF_TYPE} '${GITHUB_REF_NAME}'. Re-run with --ref vX.Y.Z"
+            exit 1
+          fi
           TAG="${GITHUB_REF_NAME#v}"
           PKG=$(python - <<'PY'
           import tomllib
@@ -169,9 +180,20 @@ jobs:
           cache: npm
           cache-dependency-path: sdks/typescript/package-lock.json
 
-      - name: Assert tag matches package version (tag push only)
-        if: ${{ github.event_name == 'push' }}
+      # fix(#1778): every publishing run must come from a tag ref, and this is
+      # a hard failure rather than a skipped check, same as publish-mcp.yml's
+      # #1623 guard: a manual dispatch defaults to the branch selected in the
+      # Actions UI, and the repo sits at the last released version between
+      # bumps, so a branch run would happily publish that branch's current
+      # package.json version as metadata for an already-released npm
+      # artifact. Dry runs are exempt — they only build.
+      - name: Require a tag ref, and assert it matches the package version
+        if: ${{ !inputs.dry_run }}
         run: |
+          if [ "${GITHUB_REF_TYPE}" != "tag" ]; then
+            echo "::error::publishing requires a tag ref; got ${GITHUB_REF_TYPE} '${GITHUB_REF_NAME}'. Re-run with --ref vX.Y.Z"
+            exit 1
+          fi
           TAG="${GITHUB_REF_NAME#v}"
           PKG=$(node -p "require('./sdks/typescript/package.json').version")
           if [ "${TAG}" != "${PKG}" ]; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,9 +23,12 @@ permissions:
 jobs:
   release:
     name: Create GitHub Release
-    # Only for a SUCCESSFUL smoke of a vX.Y.Z tag. A manual workflow_dispatch
-    # smoke of `latest` has head_branch == the default branch (not a tag), so it
-    # is skipped here.
+    # Only for a SUCCESSFUL smoke of a vX.Y.Z tag. fix(#1778): the job-level
+    # startsWith(head_branch, 'v') gate is necessary but not sufficient — a
+    # workflow_dispatch smoke run also has head_branch set to the dispatched
+    # ref's name, so `--ref v1.18.0` matches this check exactly like a real
+    # tag push does. The step-level event check below is what actually
+    # excludes a dispatch.
     if: >
       github.event.workflow_run.conclusion == 'success' &&
       startsWith(github.event.workflow_run.head_branch, 'v')
@@ -33,13 +36,25 @@ jobs:
     env:
       TAG: ${{ github.event.workflow_run.head_branch }}
     steps:
-      # The job-level startsWith(head_branch, 'v') gate also matches ordinary
-      # branch names like `video-fix` smoked via workflow_dispatch. Only a
-      # semver-shaped tag (optional prerelease suffix) may create or update a
-      # GitHub Release — anything else reaching this job is an anomaly, so
-      # fail loudly rather than releasing from it.
+      # fix(#1778): the job-level startsWith(head_branch, 'v') gate also
+      # matches ordinary branch names like `video-fix` smoked via
+      # workflow_dispatch, and it matches a workflow_dispatch smoke of a real
+      # tag ref too — head_branch carries the dispatched ref's name either
+      # way, so it cannot on its own tell "this tag was smoked by a tag push"
+      # from "this tag was smoked on demand, with whatever image version the
+      # dispatch input happened to carry". Require workflow_run.event ==
+      # 'push' as well: only a smoke that itself ran because of a tag push
+      # proves the artifact under test is bound to this tag (prod-smoke.yml's
+      # own ref-binding fix). Anything else reaching this job is an anomaly,
+      # so fail loudly rather than releasing from it.
       - name: Assert semver-shaped tag
+        env:
+          SMOKE_EVENT: ${{ github.event.workflow_run.event }}
         run: |
+          if [ "${SMOKE_EVENT}" != "push" ]; then
+            echo "::error::triggering smoke run was a '${SMOKE_EVENT}', not a tag push; refusing to release"
+            exit 1
+          fi
           if ! printf '%s' "${TAG}" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$'; then
             echo "::error::head_branch '${TAG}' is not a semver tag; refusing to release"
             exit 1
@@ -151,11 +166,13 @@ jobs:
             gh release create "${TAG}" \
               --title "${TAG}" \
               --notes-file release-notes.md \
+              --verify-tag \
               --prerelease
           else
             gh release create "${TAG}" \
               --title "${TAG}" \
-              --notes-file release-notes.md
+              --notes-file release-notes.md \
+              --verify-tag
           fi
 
       - name: Upload install script


### PR DESCRIPTION
codebase audit 2026-08-30 (8dc529f17), tracked in #1778: "A workflow_dispatch smoke of `latest` from a tag ref releases that tag, the smoke gate tests an entirely different artifact" and "publish-cli.yml and publish-sdks.yml have no tag-ref guard, a dispatch from a branch publishes to PyPI/npm with zero version assertion".

## What changed

`prod-smoke.yml` resolved the image version to smoke from a `workflow_dispatch` input that defaults to `latest` on any non-push run. A manual re-smoke of a red tag, which is the natural recovery gesture, therefore booted and tested the previous GA's images instead of the tag's own. `release.yml` then trusted that smoke's success for the tag on `head_branch` alone, with no check that the smoke run actually came from a tag push, so a dispatched smoke of a tag could pass and hand `release.yml` a success for a tag nothing had really tested: publishing a GitHub Release, dispatching to the sibling repos, and scheduling the newsletter.

`publish-cli.yml` and `publish-sdks.yml` (both jobs) only ran their tag-matches-version check `if: github.event_name == 'push'`. A `workflow_dispatch` from a branch published to PyPI/npm with no ref-type check and no version assertion at all. `publish-mcp.yml` already carries a hard tag-ref guard for this (fix(#1623)); these two workflows did not.

- `prod-smoke.yml`: the "Assert semver release tag" step and the "Resolve image tag to smoke" step now gate on `github.ref_type == 'tag'` instead of `github.event_name == 'push'`. On any run from a tag ref (push or dispatch) the semver check runs and `VER` is taken from `github.ref_name`, ignoring the `version` input. A dispatch from a branch still falls back to the input, unchanged.
- `release.yml`: the "Assert semver-shaped tag" step now also requires `github.event.workflow_run.event == 'push'`, so only a smoke that itself ran from a tag push can create or update a release. Fixed the stale comment that claimed a dispatch smoke of a tag could not reach this job; it can, since `head_branch` carries the dispatched ref's name either way. Added `--verify-tag` to both `gh release create` invocations.
- `publish-cli.yml` and both jobs of `publish-sdks.yml`: added the same "require a tag ref" guard `publish-mcp.yml` already carries (a hard failure, not a skip, on `GITHUB_REF_TYPE != tag`), and changed the tag-matches-version assertion from `if: github.event_name == 'push'` to `if: ${{ !inputs.dry_run }}` so a dispatched publish is checked too.

No behavior change on the normal push-tag path in any of the four files.

## Before and after

push-tag is unchanged everywhere; it is included for reference.

| Gate | push-tag | workflow_dispatch on a tag ref, before | workflow_dispatch on a tag ref, after | workflow_dispatch on a branch (e.g. main), before | workflow_dispatch on a branch, after |
|---|---|---|---|---|---|
| `prod-smoke.yml`, Assert semver release tag | runs, passes | skipped (`event_name != push`) | runs, passes (`ref_type == tag`) | skipped (`ref_type != tag`) | skipped (`ref_type != tag`), unchanged |
| `prod-smoke.yml`, image version smoked | `github.ref_name` (the tag) | `INPUT_VERSION`, defaults to `latest` (the previous GA's images) | `github.ref_name` (the tag itself); the input is ignored | `INPUT_VERSION` | `INPUT_VERSION`, unchanged (no tag to bind to) |
| `release.yml`, Assert semver-shaped tag | runs, passes | runs, passes (only checked that `head_branch` was semver-shaped, which a dispatched tag ref is) | fails: `workflow_run.event` is `workflow_dispatch`, not `push`; refuses to release | job-level `if` skips this job (`head_branch` does not start with `v` for a normal branch name) | skipped, unchanged |
| `publish-cli.yml` / `publish-sdks.yml`, tag-ref and version guard | runs, passes | skipped entirely (`event_name != push`); publish proceeds with zero check | runs; fails hard if the ref is not a tag, otherwise checks the tag against pyproject/package.json | skipped entirely; publish proceeds with zero check | runs; fails hard on `GITHUB_REF_TYPE != tag`, refusing to publish |
| `release.yml`, `gh release create` | `--verify-tag` added; the tag already exists on the remote at this point, so no behavior change | reached, passed pre-fix | not reached post-fix (the job now dies at the semver-shaped-tag step above) | not reached, before or after (job-level `if` skips) | not reached |

## Verification

- `actionlint` (installed via Homebrew, `brew list actionlint`, 1.7.12) on all four touched files, plus `publish-mcp.yml` and `verify-published.yml` for comparison. Result: one pre-existing shellcheck info-level finding each, in `release.yml` (SC2016, on an unrelated line, confirmed present on `main` before this branch's changes) and in `verify-published.yml` (SC2086, an untouched file). No new findings from this change.
- `python3 -c "import yaml, sys; [yaml.safe_load(open(f)) for f in sys.argv[1:]]"` on all four touched files: parses clean.
- `backend/tests/test_release_dispatch_targets_1609.py` (parses `release.yml`, matches its dispatch step by name): 14 passed.
- `backend/tests/test_ci_job_timeouts.py` (covers `prod-smoke.yml`'s job timeout): 5 passed.
- `backend/tests/test_layering.py`: 47 passed. This PR touches no files under `backend/app/`; ran it anyway per the lane's standing instruction.

Commands run from the worktree:
```
cd backend && set -a && source ../.env.test && set +a && uv run pytest tests/test_release_dispatch_targets_1609.py tests/test_ci_job_timeouts.py tests/test_layering.py -q
```

## Left alone

- `verify-published.yml`'s two duplicated `--jq '.jobs[] | select(.name == "Create GitHub Release") | .conclusion'` selectors (currently at lines 274 and 503) still pick the upstream `release.yml` job by display-name string, as the register excerpt cites. Out of scope for this lane. A rename of that job would still make both verify jobs report a hollow success with no red signal.
- The `dep-audit.yml` (pip-audit coverage gap for `cli/`, `mcp/`, `sdks/python/`) and `cli/pyproject.toml` (CI Python-version floor drift) rows in the register excerpt are explicitly out of scope for this lane.

## Already fixed on main

None. All five in-scope findings (the four numbered items in the brief, plus the verify-published.yml note) were verified present in the four touched files before this PR's changes.
