### PR TITLE
fix(features): write shapely's normalized geometry, not the client's raw dict

### DIFF
--- a/backend/app/modules/catalog/features/service.py
+++ b/backend/app/modules/catalog/features/service.py
@@ -2,14 +2,15 @@
 
 from __future__ import annotations
 
-import json
 import math
 import re
 from collections.abc import Sequence
 from typing import TYPE_CHECKING
 
+from shapely import to_geojson
 from shapely.errors import GEOSException
 from shapely.geometry import shape as shapely_shape
+from shapely.geometry.base import BaseGeometry
 from shapely.validation import explain_validity
 from sqlalchemy import func, text
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -506,7 +507,7 @@ async def effective_geometry_type(session: AsyncSession, dataset) -> str:
     return dataset.geometry_type
 
 
-def _validate_geometry_structure(geometry: dict) -> None:
+def _validate_geometry_structure(geometry: dict) -> BaseGeometry:
     """Reject degenerate or topologically invalid geometry before PostGIS.
 
     fix(#458 E-02): degenerate-but-schema-valid input (2-point polygon rings,
@@ -515,6 +516,14 @@ def _validate_geometry_structure(geometry: dict) -> None:
     raised GEOS TopologyException on bbox queries and tile renders — read-path
     500s that hit anonymous viewers of public datasets. Raises ValueError
     (routers map it to 400).
+
+    fix(#1778): return the shapely geometry itself rather than a bare None.
+    Shapely repairs some structurally-invalid input it accepts (an unclosed
+    polygon ring is auto-closed by `shape()`), but ST_GeomFromGeoJSON does not
+    repair the equivalent GeoJSON — it stores the ring open, which later
+    crashes any ST_Intersects bbox read with a GEOS "not closed" error.
+    Callers must write the returned, shapely-normalized geometry instead of
+    re-serializing the client's original dict.
     """
     try:
         geom = shapely_shape(geometry)
@@ -524,6 +533,7 @@ def _validate_geometry_structure(geometry: dict) -> None:
         raise ValueError("Invalid geometry: geometry is empty")
     if not geom.is_valid:
         raise ValueError(f"Invalid geometry: {explain_validity(geom)}")
+    return geom
 
 
 def _validate_geometry_type(geojson_type: str, dataset_geometry_type: str) -> None:
@@ -588,10 +598,10 @@ async def insert_feature(
     get_feature_by_id.
     """
     _validate_geometry_type(geometry.get("type", ""), dataset_geometry_type)
-    _validate_geometry_structure(geometry)
+    normalized_geom = _validate_geometry_structure(geometry)
     _reject_unknown_properties(properties, column_info)
 
-    geojson_str = json.dumps(geometry)
+    geojson_str = to_geojson(normalized_geom)
 
     geom_expr, geom_4326_expr = _geom_write_exprs(dataset_geometry_type, dataset_srid)
     cols = ["geom", "geom_4326"]
@@ -636,10 +646,10 @@ async def replace_feature(
     present in properties are set to NULL.
     """
     _validate_geometry_type(geometry.get("type", ""), dataset_geometry_type)
-    _validate_geometry_structure(geometry)
+    normalized_geom = _validate_geometry_structure(geometry)
     _reject_unknown_properties(properties, column_info)
 
-    geojson_str = json.dumps(geometry)
+    geojson_str = to_geojson(normalized_geom)
     geom_expr, geom_4326_expr = _geom_write_exprs(dataset_geometry_type, dataset_srid)
 
     sets = [
@@ -690,8 +700,8 @@ async def update_feature(
 
     if geometry is not None:
         _validate_geometry_type(geometry.get("type", ""), dataset_geometry_type)
-        _validate_geometry_structure(geometry)
-        geojson_str = json.dumps(geometry)
+        normalized_geom = _validate_geometry_structure(geometry)
+        geojson_str = to_geojson(normalized_geom)
         geom_expr, geom_4326_expr = _geom_write_exprs(
             dataset_geometry_type, dataset_srid
         )

--- a/backend/tests/test_features_crud.py
+++ b/backend/tests/test_features_crud.py
@@ -1513,6 +1513,21 @@ class TestGeometryValidity:
         "type": "Polygon",
         "coordinates": [[[0.0, 0.0], [1.0, 1.0], [0.0, 0.0]]],
     }
+    # fix(#1778): same rectangle as POLYGON_GEOJSON, minus the closing vertex.
+    # Shapely's shape() auto-closes this and reports it valid, so it must be
+    # ACCEPTED (not rejected) — the bug was that the raw, still-open dict was
+    # the thing written to PostGIS, which does not auto-close it.
+    UNCLOSED_RING = {
+        "type": "Polygon",
+        "coordinates": [
+            [
+                [-73.99, 40.74],
+                [-73.98, 40.74],
+                [-73.98, 40.75],
+                [-73.99, 40.75],
+            ]
+        ],
+    }
 
     async def test_self_intersecting_polygon_rejected(
         self,
@@ -1579,6 +1594,119 @@ class TestGeometryValidity:
             headers=admin_auth_header,
         )
         assert patch.status_code == 400, patch.text
+
+    async def test_closed_ring_round_trips_unchanged(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        polygon_layer: Dataset,
+    ):
+        """fix(#1778): already-valid input keeps producing byte-identical
+        GeoJSON. Writing shapely's normalized geometry instead of the raw
+        client dict must not change the response for input that was already
+        a closed ring.
+        """
+        resp = await client.post(
+            f"/datasets/{polygon_layer.id}/features/",
+            json={"geometry": POLYGON_GEOJSON, "properties": {"name": "valid"}},
+            headers=admin_auth_header,
+        )
+        assert resp.status_code == 201, resp.text
+        assert resp.json()["geometry"] == POLYGON_GEOJSON
+
+    async def test_insert_unclosed_ring_stored_closed_and_bbox_readable(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        polygon_layer: Dataset,
+    ):
+        """fix(#1778): an unclosed ring on create is stored closed, and a
+        subsequent bbox read over it returns 200 with the feature instead of
+        the pre-fix unhandled 500 (GEOS "not closed" from ST_Intersects).
+        """
+        resp = await client.post(
+            f"/datasets/{polygon_layer.id}/features/",
+            json={"geometry": self.UNCLOSED_RING, "properties": {"name": "unclosed"}},
+            headers=admin_auth_header,
+        )
+        assert resp.status_code == 201, resp.text
+        ring = resp.json()["geometry"]["coordinates"][0]
+        assert ring[0] == ring[-1], "stored ring must be closed"
+
+        bbox_resp = await client.get(
+            f"/datasets/{polygon_layer.id}/features/?bbox=-74.1,40.6,-73.9,40.8",
+            headers=admin_auth_header,
+        )
+        assert bbox_resp.status_code == 200, bbox_resp.text
+        names = {f["properties"]["name"] for f in bbox_resp.json()["features"]}
+        assert "unclosed" in names
+
+    async def test_replace_unclosed_ring_stored_closed_and_bbox_readable(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        polygon_layer: Dataset,
+    ):
+        """fix(#1778): same guard on PUT (full replace)."""
+        create = await client.post(
+            f"/datasets/{polygon_layer.id}/features/",
+            json={"geometry": POLYGON_GEOJSON, "properties": {"name": "orig"}},
+            headers=admin_auth_header,
+        )
+        assert create.status_code == 201, create.text
+        gid = create.json()["id"]
+
+        resp = await client.put(
+            f"/datasets/{polygon_layer.id}/features/{gid}",
+            json={
+                "geometry": self.UNCLOSED_RING,
+                "properties": {"name": "replaced"},
+            },
+            headers=admin_auth_header,
+        )
+        assert resp.status_code == 200, resp.text
+        ring = resp.json()["geometry"]["coordinates"][0]
+        assert ring[0] == ring[-1], "stored ring must be closed"
+
+        bbox_resp = await client.get(
+            f"/datasets/{polygon_layer.id}/features/?bbox=-74.1,40.6,-73.9,40.8",
+            headers=admin_auth_header,
+        )
+        assert bbox_resp.status_code == 200, bbox_resp.text
+        names = {f["properties"]["name"] for f in bbox_resp.json()["features"]}
+        assert "replaced" in names
+
+    async def test_patch_geometry_unclosed_ring_stored_closed_and_bbox_readable(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        polygon_layer: Dataset,
+    ):
+        """fix(#1778): same guard on PATCH (partial geometry update)."""
+        create = await client.post(
+            f"/datasets/{polygon_layer.id}/features/",
+            json={"geometry": POLYGON_GEOJSON, "properties": {"name": "orig"}},
+            headers=admin_auth_header,
+        )
+        assert create.status_code == 201, create.text
+        gid = create.json()["id"]
+
+        resp = await client.patch(
+            f"/datasets/{polygon_layer.id}/features/{gid}",
+            json={"geometry": self.UNCLOSED_RING},
+            headers=admin_auth_header,
+        )
+        assert resp.status_code == 200, resp.text
+        ring = resp.json()["geometry"]["coordinates"][0]
+        assert ring[0] == ring[-1], "stored ring must be closed"
+
+        bbox_resp = await client.get(
+            f"/datasets/{polygon_layer.id}/features/?bbox=-74.1,40.6,-73.9,40.8",
+            headers=admin_auth_header,
+        )
+        assert bbox_resp.status_code == 200, bbox_resp.text
+        names = {f["properties"]["name"] for f in bbox_resp.json()["features"]}
+        assert "orig" in names
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Codebase audit 2026-08-30 (8dc529f17), tracked in #1778. Finding: "An unclosed polygon ring passes both write validators and poisons every bbox read of the dataset with a 500".

## What changed

`insert_feature`, `replace_feature` and `update_feature` in `backend/app/modules/catalog/features/service.py` validated geometry with shapely (`_validate_geometry_structure`) but then serialized the client's original dict (`json.dumps(geometry)`) into `ST_GeomFromGeoJSON`. Shapely auto-closes an unclosed polygon ring and reports it valid, but `ST_GeomFromGeoJSON` does not repair the equivalent GeoJSON, so the row was stored with an open ring. Every later bbox read whose envelope touched that feature raised an unhandled 500 from `ST_Intersects` ("Points of LinearRing do not form a closed linestring"), reaching anonymous viewers of public datasets, while vector tiles kept rendering fine because the tile query tolerates invalid geometry.

`_validate_geometry_structure` now returns the shapely geometry it already builds, and all three write sites bind `shapely.to_geojson(normalized_geom)` instead of re-serializing the raw request dict. This closes the whole class of shapely-repairs-it/PostGIS-does-not divergences, not only ring closure.

## Schema/API impact

None. No request or response schema changed; `make openapi-check` passes with no diff. The response shape for already-valid input is unchanged (verified with a byte-equal round-trip test).

## Tests added

`TestGeometryValidity` in `backend/tests/test_features_crud.py`:
- `test_closed_ring_round_trips_unchanged`: an already-closed ring produces byte-identical response GeoJSON.
- `test_insert_unclosed_ring_stored_closed_and_bbox_readable`: POST with an unclosed ring is stored closed, and a subsequent bbox GET returns 200 with the feature.
- `test_replace_unclosed_ring_stored_closed_and_bbox_readable`: same guard on PUT.
- `test_patch_geometry_unclosed_ring_stored_closed_and_bbox_readable`: same guard on PATCH (partial geometry update).

## Verification run

- `uv run pytest tests/test_features_crud.py -q` — 44 passed
- `uv run pytest tests/test_feature_geometry_limits.py tests/test_features_geojson_z.py tests/test_ogc_features.py tests/test_ogc_features_filter.py -q` — 117 passed
- `uv run pytest tests/test_layering.py -q` — 47 passed (no cap changes needed; `features/service.py` is not in `_MODULE_LOC_CAPS` and stayed under any other size gate)
- `uv run ruff check .` and `uv run ruff format --check .` — pass
- `make openapi-check` — pass, no diff

Counterfactual: stashed the `service.py` fix, kept the new tests, and reran `tests/test_features_crud.py -k TestGeometryValidity`. The three unclosed-ring tests failed as expected: the write response showed the ring stored open (`ring[0] != ring[-1]`), and hitting the bbox endpoint directly against the unfixed code reproduced the exact audit-cited crash: `sqlalchemy.exc.InternalError ... IllegalArgumentException: Points of LinearRing do not form a closed linestring` from the `ST_Intersects` query. Restored the fix and reran; all 8 pass.

## Left alone

Two other rows in the same audit excerpt are context, not in this lane's scope, and are unaddressed:
- `schemas.py:12` `MAX_POSITION_DIMENSIONS = 4` advertises XYZM positions the service unconditionally rejects with a 400 (low severity, low effort) — still present on main.
- The `chat_geojson.py` empty-geometry/NaN-bbox finding is explicitly out of scope for this lane.

The register's third row (`TestGeometryValidity`'s fixtures never probed ring closure) is addressed as a side effect of the tests added here.