### PR TITLE
fix(export): release the pooled connection and bound the export by the edge

### DIFF
--- a/backend/app/api/middleware/logging.py
+++ b/backend/app/api/middleware/logging.py
@@ -31,7 +31,20 @@ class RequestLoggingMiddleware(BaseHTTPMiddleware):
         # ID without parsing client-supplied headers (RESILIENCE-9).
         request.state.request_id = request_id
 
-        start_time = time.perf_counter_ns()
+        # fix(#1778 codex r2): the moment the request entered the app, on the
+        # same clock a handler can compare against. A route that must answer
+        # inside the edge proxy's read timeout cannot start its own clock at
+        # its function body: FastAPI resolves that route's dependencies first,
+        # and one of those can block on a database pool checkout for as long
+        # as ``db_pool_timeout``. Stamped here, beside the request id and for
+        # the same reason, so the handler measures from where the proxy's own
+        # clock started rather than from where it got control.
+        #
+        # ``monotonic`` rather than ``perf_counter``: both are monotonic and
+        # both are ns-resolution here, and one read serves both the deadline
+        # below and the duration this middleware already logs.
+        started_at = time.monotonic()
+        request.state.started_at_monotonic = started_at
         response: Response | None = None
 
         try:
@@ -40,7 +53,7 @@ class RequestLoggingMiddleware(BaseHTTPMiddleware):
             structlog.stdlib.get_logger("api.error").exception("Unhandled exception")
             raise
         finally:
-            duration_ms = (time.perf_counter_ns() - start_time) / 1_000_000
+            duration_ms = (time.monotonic() - started_at) * 1000
             status_code = response.status_code if response is not None else 500
 
             access_logger.info(

--- a/backend/app/processing/export/ogr.py
+++ b/backend/app/processing/export/ogr.py
@@ -107,16 +107,23 @@ def export_subprocess_timeout_seconds(deadline: float | None) -> float:
 
     floored at ``EXPORT_BUDGET_FLOOR_SECONDS``.
 
-    ``deadline`` is a ``time.monotonic()`` stamp taken when the route was
-    entered, offset by ``EDGE_PROXY_READ_TIMEOUT_SECONDS``. ``None`` means the
-    caller is not serving a request (the direct-call tests, and any future
-    offline caller): the full edge window is assumed to start now, which is
-    the same arithmetic with an elapsed time of zero.
+    ``deadline`` is a ``time.monotonic()`` stamp taken when the request
+    entered the app (``RequestLoggingMiddleware``), offset by
+    ``EDGE_PROXY_READ_TIMEOUT_SECONDS``. ``None`` means the caller is not
+    serving a request (the direct-call tests, and any future offline caller):
+    the full edge window is assumed to start now, which is the same
+    arithmetic with an elapsed time of zero.
 
-    The interval before the route body runs (dependency resolution: auth, the
-    permission lookup, and any pool wait either incurs) sits outside this
-    clock and is the one residual it cannot see. Nothing inside the handler
-    can observe it, and the reserve above is what absorbs it.
+    Anchoring it at the middleware rather than at the route body is what puts
+    dependency resolution inside the clock. ``Depends(get_optional_user)``
+    runs before the body and can block on a pool checkout for as long as
+    ``db_pool_timeout``; a clock started in the body would not see that, and
+    an export that spent its whole calculated budget could still answer after
+    the proxy had given up. What remains outside is the handful of outer
+    middlewares that wrap the logging one (CORS, security headers, the
+    compression opt-out, the rate limiter, tenant context). None of them
+    touches the database, so the interval is header work, and the reserve
+    above absorbs it.
     """
     global _export_reserve_warned
 

--- a/backend/app/processing/export/ogr.py
+++ b/backend/app/processing/export/ogr.py
@@ -3,6 +3,7 @@
 import asyncio
 import math
 import os
+import time
 
 import structlog
 
@@ -32,103 +33,115 @@ class ExportError(Exception):
 # ---------------------------------------------------------------------------
 # fix(#1778): a synchronous export ran on a 3600s subprocess deadline behind a
 # 600s edge read timeout. This conversion runs inside the request, so the
-# deadline that governs it is the edge proxy's, not the worker's. The
-# module used to import the offline-ingest constant
-# ``OGR2OGR_FILE_TIMEOUT_SECONDS`` (3600s) and use it for both the subprocess
-# wall clock and the libpq ``statement_timeout``, six times the edge's own
-# read timeout: past 600s nginx severed the upstream read and answered 504
-# while this handler kept converting for up to another 50 minutes, holding a
-# pooled connection, an ogr2ogr child, a PostgreSQL backend and a multi-
-# gigabyte staging directory with nobody left to read the output.
+# deadline that governs it is the edge proxy's, not the worker's. The module
+# used to import the offline-ingest constant ``OGR2OGR_FILE_TIMEOUT_SECONDS``
+# (3600s) and use it for both the subprocess wall clock and the libpq
+# ``statement_timeout``, six times the edge's own read timeout: past 600s
+# nginx severed the upstream read and answered 504 while this handler kept
+# converting for up to another 50 minutes, holding a pooled connection, an
+# ogr2ogr child, a PostgreSQL backend and a multi-gigabyte staging directory
+# with nobody left to read the output.
 #
 # ``EDGE_PROXY_READ_TIMEOUT_SECONDS`` is imported rather than restated: the
 # URL importer derives its own synchronous budget from that constant, and
 # there is one edge read timeout (``proxy_read_timeout`` in frontend/
 # nginx.conf's ``location /api/``).
+#
+# fix(#1778 codex r1): measured against the request's own clock rather than
+# against an allowance for work that may or may not have happened. The route
+# stamps a monotonic deadline on entry and this module subtracts the time
+# actually consumed, so a fast pre-conversion phase hands its unused time to
+# the conversion and a slow one (an unindexed feature count, a parquet plan
+# over a wide table) takes it away. An allowance-based figure was wrong in
+# both directions: it killed a 430s conversion that would have fitted, and it
+# let a request whose pre-work overran run past the edge.
 
-# Every point where an export request checks a pooled connection out, each
-# able to wait up to ``settings.db_pool_timeout`` when the pool is exhausted:
+# Reserved out of the remaining time for what is still outstanding when the
+# subprocess starts, and only that:
 #
-#   1. The dependency and pre-conversion phase (get_optional_user, the
-#      access checks, the feature-count guard, the parquet plan) shares one
-#      checkout, which the route hands back immediately before this
-#      subprocess starts (see the rollback in export/router.py).
-#   2. The post-conversion audit row and its commit.
+#   - the format-specific finish inside ``export_dataset`` (the shapefile ZIP,
+#     the GeoPackage timestamp normalization),
+#   - hashing the built file and publishing it to object storage,
+#   - the audit row's commit.
 #
-# The GeoParquet branch takes a third for its own row stream, but it runs no
-# subprocess and is not bounded by this deadline.
-EXPORT_POOL_CHECKOUTS_PER_REQUEST = 2
-
-# Reserved, beyond the pool waits, for what the response still owes after
-# ogr2ogr exits and before the first byte reaches the client: the
-# format-specific finish inside export_dataset (the shapefile ZIP, the
-# GeoPackage timestamp normalization), hashing the built file, publishing it
-# to object storage, and the audit commit. Sized for a multi-gigabyte
-# artifact against same-network object storage (reading 5 GB to hash it plus
-# a ~1 Gbps push is well under two minutes).
-#
-# A reservation, not a measurement: those steps have no deadline of their
-# own, so a slow one can still overrun. The cost of overrunning is the
-# severed response this budget exists to make rare, not a corrupted export,
-# and the bound that matters is the one on the step that dominates.
+# Sized for a multi-gigabyte artifact against same-network object storage
+# (reading 5 GB to hash it plus a ~1 Gbps push is well under two minutes). A
+# reservation, not a measurement: those steps have no deadline of their own,
+# so a slow one can still overrun, and the cost of overrunning is the severed
+# response this budget exists to make rare rather than a corrupted export.
 EXPORT_POST_WORK_MARGIN_SECONDS = 120
 
-# A pathological pool timeout (DB_POOL_TIMEOUT=300 leaves 600 - 600 - 120 =
-# -120) must not yield a zero or negative deadline, and must not crash the
-# app at import over an operator setting. Clamp here instead and warn once,
-# so the operator sees a cause: at the floor every export times out promptly
-# instead of running past the proxy that is no longer listening.
-EXPORT_BUDGET_FLOOR_SECONDS = 1
 
-_export_budget_floor_warned = False
+def export_post_work_reserve_seconds() -> int:
+    """Everything the request still owes after the subprocess exits.
 
+    The margin above plus one ``db_pool_timeout``. That pool wait is the one
+    the elapsed clock cannot already contain: the audit row's checkout has not
+    happened yet when the conversion starts, and under an exhausted pool it
+    can block for the full timeout before the commit runs. Every earlier
+    checkout is behind us and is already priced into the elapsed time.
 
-def export_subprocess_timeout_seconds() -> int:
-    """Wall-clock ceiling for one in-request ogr2ogr export.
-
-        EDGE_PROXY
-          - EXPORT_POOL_CHECKOUTS_PER_REQUEST * db_pool_timeout
-          - EXPORT_POST_WORK_MARGIN,
-
-    clamped up to EXPORT_BUDGET_FLOOR_SECONDS.
-
-    Derived per call rather than fixed, for the reason
+    Derived from the live setting rather than fixed, for the reason
     ``url_fetch.stage_total_budget_seconds`` gives: ``db_pool_timeout`` is
     operator-settable, so a hardcoded figure silently breaks the arithmetic
     the moment it is raised, and a test that reads the live setting cannot
     catch that because CI only ever runs the default.
-
-    There is no separate upper ceiling. The URL importer needs one because
-    its preflight and fetch bounds assume a smaller number; nothing here
-    assumes one, and the post-work margin is what keeps a very small pool
-    timeout from pushing the response past the proxy.
     """
-    global _export_budget_floor_warned
+    return EXPORT_POST_WORK_MARGIN_SECONDS + settings.db_pool_timeout
 
-    pool_timeout = settings.db_pool_timeout
-    derived = (
-        EDGE_PROXY_READ_TIMEOUT_SECONDS
-        - (EXPORT_POOL_CHECKOUTS_PER_REQUEST * pool_timeout)
-        - EXPORT_POST_WORK_MARGIN_SECONDS
-    )
-    if derived < EXPORT_BUDGET_FLOOR_SECONDS:
-        if not _export_budget_floor_warned:
-            _export_budget_floor_warned = True
-            logger.warning(
-                "export_subprocess_budget_floored",
-                db_pool_timeout=pool_timeout,
-                edge_proxy_read_timeout=EDGE_PROXY_READ_TIMEOUT_SECONDS,
-                derived_budget=derived,
-                floor=EXPORT_BUDGET_FLOOR_SECONDS,
-                detail=(
-                    "DB_POOL_TIMEOUT leaves no room for a synchronous export "
-                    "inside the edge proxy's read timeout; exports will time "
-                    "out. Lower DB_POOL_TIMEOUT or raise the proxy's "
-                    "proxy_read_timeout."
-                ),
-            )
-        return EXPORT_BUDGET_FLOOR_SECONDS
-    return derived
+
+# A conversion cannot be given zero or negative time: that is not a deadline,
+# it is a crash or a child killed before it starts. When the pre-conversion
+# work has already eaten the whole window the request is going to fail either
+# way, and it fails through the ordinary timeout path with the ordinary error
+# rather than through an arithmetic edge case.
+EXPORT_BUDGET_FLOOR_SECONDS = 1
+
+_export_reserve_warned = False
+
+
+def export_subprocess_timeout_seconds(deadline: float | None) -> float:
+    """Seconds this conversion may run, measured from the request's clock.
+
+        deadline - time.monotonic() - export_post_work_reserve_seconds()
+
+    floored at ``EXPORT_BUDGET_FLOOR_SECONDS``.
+
+    ``deadline`` is a ``time.monotonic()`` stamp taken when the route was
+    entered, offset by ``EDGE_PROXY_READ_TIMEOUT_SECONDS``. ``None`` means the
+    caller is not serving a request (the direct-call tests, and any future
+    offline caller): the full edge window is assumed to start now, which is
+    the same arithmetic with an elapsed time of zero.
+
+    The interval before the route body runs (dependency resolution: auth, the
+    permission lookup, and any pool wait either incurs) sits outside this
+    clock and is the one residual it cannot see. Nothing inside the handler
+    can observe it, and the reserve above is what absorbs it.
+    """
+    global _export_reserve_warned
+
+    reserve = export_post_work_reserve_seconds()
+    if reserve >= EDGE_PROXY_READ_TIMEOUT_SECONDS and not _export_reserve_warned:
+        # A configuration problem rather than a slow request: no export can
+        # ever get time on this deployment. Said once, with the cause.
+        _export_reserve_warned = True
+        logger.warning(
+            "export_post_work_reserve_exceeds_edge_timeout",
+            db_pool_timeout=settings.db_pool_timeout,
+            edge_proxy_read_timeout=EDGE_PROXY_READ_TIMEOUT_SECONDS,
+            reserve=reserve,
+            detail=(
+                "DB_POOL_TIMEOUT leaves no room for a synchronous export "
+                "inside the edge proxy's read timeout; exports will time "
+                "out. Lower DB_POOL_TIMEOUT or raise the proxy's "
+                "proxy_read_timeout."
+            ),
+        )
+
+    if deadline is None:
+        deadline = time.monotonic() + EDGE_PROXY_READ_TIMEOUT_SECONDS
+    remaining = deadline - time.monotonic() - reserve
+    return max(remaining, float(EXPORT_BUDGET_FLOOR_SECONDS))
 
 
 # fix(#1532 review r9): the parquet media type lives HERE rather than in
@@ -279,6 +292,7 @@ async def run_ogr2ogr_export(
     where: str | None = None,
     format_key: str = "",
     pmtiles_maxzoom: int | None = None,
+    deadline: float | None = None,
 ) -> None:
     """Run ogr2ogr to export a PostGIS table to a file.
 
@@ -295,6 +309,10 @@ async def run_ogr2ogr_export(
             without geometry (the router drops it for non-spatial datasets).
         where: Optional SQL WHERE clause for attribute filtering.
         format_key: Format key from FORMAT_MAP for format-specific options.
+        deadline: ``time.monotonic()`` stamp by which the whole request must
+            be answered, from the route's entry. Bounds both this subprocess
+            and its server-side query. ``None`` for a caller outside a
+            request; see ``export_subprocess_timeout_seconds``.
 
     Raises:
         ExportError: If ogr2ogr exits with non-zero code.
@@ -373,9 +391,10 @@ async def run_ogr2ogr_export(
     # also cap the server-side query via libpq statement_timeout so the DB query
     # stops when the child is killed.
     #
-    # fix(#1778): the bound is the request's, derived from the edge proxy.
-    # See export_subprocess_timeout_seconds. Read once so the wall clock and
-    # the statement_timeout cannot disagree.
+    # fix(#1778): the bound is the request's, taken from what is left of the
+    # edge proxy's window at this moment. See export_subprocess_timeout_seconds.
+    # Read once, as late as possible (every earlier step has already spent its
+    # share), so the wall clock and the statement_timeout cannot disagree.
     #
     # The note that used to sit here also said `_communicate_with_timeout`
     # kills the child on a client disconnect. It does kill on cancellation,
@@ -384,12 +403,13 @@ async def run_ogr2ogr_export(
     # cycle disconnected and wakes `receive()`, and a GET handler never awaits
     # `receive()`. A departed client is therefore invisible here, and the
     # deadline below is what bounds the orphan.
-    export_timeout = export_subprocess_timeout_seconds()
+    export_timeout = export_subprocess_timeout_seconds(deadline)
     env = _tenant_reader_subprocess_env(
         schema,
         base_env={
             **os.environ,
-            "PGOPTIONS": f"-c statement_timeout={export_timeout * 1000}",
+            # Milliseconds, and libpq wants an integer.
+            "PGOPTIONS": f"-c statement_timeout={int(export_timeout * 1000)}",
         },
     )
     assert env is not None  # base_env is always returned in single-tenant mode

--- a/backend/app/processing/export/ogr.py
+++ b/backend/app/processing/export/ogr.py
@@ -4,21 +4,131 @@ import asyncio
 import math
 import os
 
+import structlog
+
+from app.core.config import settings
+
 # fix(#909): build_pg_conn_str is deliberately NOT imported at module scope.
 # The test fixture redirects app.processing.ingest.ogr.build_pg_conn_str at
 # the origin; a module-scope `from ... import` here snapshots the dev-DB
 # helper past that patch, which once sent a test's ogr2ogr export at the dev
 # database (#898). Late-bind at call scope (test_layering.py enforces this).
 from app.processing.ingest.ogr import (
-    OGR2OGR_FILE_TIMEOUT_SECONDS,
     IngestionError,
     _communicate_with_timeout,
     _tenant_reader_subprocess_env,
 )
+from app.processing.ingest.url_fetch import EDGE_PROXY_READ_TIMEOUT_SECONDS
+
+logger = structlog.get_logger(__name__)
 
 
 class ExportError(Exception):
     """Raised when an ogr2ogr export subprocess fails."""
+
+
+# ---------------------------------------------------------------------------
+# The in-request export deadline
+# ---------------------------------------------------------------------------
+# fix(#1778): a synchronous export ran on a 3600s subprocess deadline behind a
+# 600s edge read timeout. This conversion runs inside the request, so the
+# deadline that governs it is the edge proxy's, not the worker's. The
+# module used to import the offline-ingest constant
+# ``OGR2OGR_FILE_TIMEOUT_SECONDS`` (3600s) and use it for both the subprocess
+# wall clock and the libpq ``statement_timeout``, six times the edge's own
+# read timeout: past 600s nginx severed the upstream read and answered 504
+# while this handler kept converting for up to another 50 minutes, holding a
+# pooled connection, an ogr2ogr child, a PostgreSQL backend and a multi-
+# gigabyte staging directory with nobody left to read the output.
+#
+# ``EDGE_PROXY_READ_TIMEOUT_SECONDS`` is imported rather than restated: the
+# URL importer derives its own synchronous budget from that constant, and
+# there is one edge read timeout (``proxy_read_timeout`` in frontend/
+# nginx.conf's ``location /api/``).
+
+# Every point where an export request checks a pooled connection out, each
+# able to wait up to ``settings.db_pool_timeout`` when the pool is exhausted:
+#
+#   1. The dependency and pre-conversion phase (get_optional_user, the
+#      access checks, the feature-count guard, the parquet plan) shares one
+#      checkout, which the route hands back immediately before this
+#      subprocess starts (see the rollback in export/router.py).
+#   2. The post-conversion audit row and its commit.
+#
+# The GeoParquet branch takes a third for its own row stream, but it runs no
+# subprocess and is not bounded by this deadline.
+EXPORT_POOL_CHECKOUTS_PER_REQUEST = 2
+
+# Reserved, beyond the pool waits, for what the response still owes after
+# ogr2ogr exits and before the first byte reaches the client: the
+# format-specific finish inside export_dataset (the shapefile ZIP, the
+# GeoPackage timestamp normalization), hashing the built file, publishing it
+# to object storage, and the audit commit. Sized for a multi-gigabyte
+# artifact against same-network object storage (reading 5 GB to hash it plus
+# a ~1 Gbps push is well under two minutes).
+#
+# A reservation, not a measurement: those steps have no deadline of their
+# own, so a slow one can still overrun. The cost of overrunning is the
+# severed response this budget exists to make rare, not a corrupted export,
+# and the bound that matters is the one on the step that dominates.
+EXPORT_POST_WORK_MARGIN_SECONDS = 120
+
+# A pathological pool timeout (DB_POOL_TIMEOUT=300 leaves 600 - 600 - 120 =
+# -120) must not yield a zero or negative deadline, and must not crash the
+# app at import over an operator setting. Clamp here instead and warn once,
+# so the operator sees a cause: at the floor every export times out promptly
+# instead of running past the proxy that is no longer listening.
+EXPORT_BUDGET_FLOOR_SECONDS = 1
+
+_export_budget_floor_warned = False
+
+
+def export_subprocess_timeout_seconds() -> int:
+    """Wall-clock ceiling for one in-request ogr2ogr export.
+
+        EDGE_PROXY
+          - EXPORT_POOL_CHECKOUTS_PER_REQUEST * db_pool_timeout
+          - EXPORT_POST_WORK_MARGIN,
+
+    clamped up to EXPORT_BUDGET_FLOOR_SECONDS.
+
+    Derived per call rather than fixed, for the reason
+    ``url_fetch.stage_total_budget_seconds`` gives: ``db_pool_timeout`` is
+    operator-settable, so a hardcoded figure silently breaks the arithmetic
+    the moment it is raised, and a test that reads the live setting cannot
+    catch that because CI only ever runs the default.
+
+    There is no separate upper ceiling. The URL importer needs one because
+    its preflight and fetch bounds assume a smaller number; nothing here
+    assumes one, and the post-work margin is what keeps a very small pool
+    timeout from pushing the response past the proxy.
+    """
+    global _export_budget_floor_warned
+
+    pool_timeout = settings.db_pool_timeout
+    derived = (
+        EDGE_PROXY_READ_TIMEOUT_SECONDS
+        - (EXPORT_POOL_CHECKOUTS_PER_REQUEST * pool_timeout)
+        - EXPORT_POST_WORK_MARGIN_SECONDS
+    )
+    if derived < EXPORT_BUDGET_FLOOR_SECONDS:
+        if not _export_budget_floor_warned:
+            _export_budget_floor_warned = True
+            logger.warning(
+                "export_subprocess_budget_floored",
+                db_pool_timeout=pool_timeout,
+                edge_proxy_read_timeout=EDGE_PROXY_READ_TIMEOUT_SECONDS,
+                derived_budget=derived,
+                floor=EXPORT_BUDGET_FLOOR_SECONDS,
+                detail=(
+                    "DB_POOL_TIMEOUT leaves no room for a synchronous export "
+                    "inside the edge proxy's read timeout; exports will time "
+                    "out. Lower DB_POOL_TIMEOUT or raise the proxy's "
+                    "proxy_read_timeout."
+                ),
+            )
+        return EXPORT_BUDGET_FLOOR_SECONDS
+    return derived
 
 
 # fix(#1532 review r9): the parquet media type lives HERE rather than in
@@ -261,16 +371,25 @@ async def run_ogr2ogr_export(
     # fix(#430 BA-06): bound the export subprocess wall-clock with a kill-on-timeout
     # (mirrors the ingest path) so a slow/large table can't hold an API worker;
     # also cap the server-side query via libpq statement_timeout so the DB query
-    # stops when the child is killed. `_communicate_with_timeout` below kills the
-    # child on cancellation too (a client disconnect), not only on timeout — see
-    # its docstring for why that branch has to exist.
+    # stops when the child is killed.
+    #
+    # fix(#1778): the bound is the request's, derived from the edge proxy.
+    # See export_subprocess_timeout_seconds. Read once so the wall clock and
+    # the statement_timeout cannot disagree.
+    #
+    # The note that used to sit here also said `_communicate_with_timeout`
+    # kills the child on a client disconnect. It does kill on cancellation,
+    # and the ingest caller gets that from Procrastinate's shutdown, but
+    # nothing cancels THIS task: uvicorn's `connection_lost` only marks the
+    # cycle disconnected and wakes `receive()`, and a GET handler never awaits
+    # `receive()`. A departed client is therefore invisible here, and the
+    # deadline below is what bounds the orphan.
+    export_timeout = export_subprocess_timeout_seconds()
     env = _tenant_reader_subprocess_env(
         schema,
         base_env={
             **os.environ,
-            "PGOPTIONS": (
-                f"-c statement_timeout={OGR2OGR_FILE_TIMEOUT_SECONDS * 1000}"
-            ),
+            "PGOPTIONS": f"-c statement_timeout={export_timeout * 1000}",
         },
     )
     assert env is not None  # base_env is always returned in single-tenant mode
@@ -282,7 +401,7 @@ async def run_ogr2ogr_export(
     )
     try:
         stdout, stderr = await _communicate_with_timeout(
-            proc, OGR2OGR_FILE_TIMEOUT_SECONDS, tool_name="ogr2ogr export"
+            proc, export_timeout, tool_name="ogr2ogr export"
         )
     except IngestionError as exc:
         raise ExportError(str(exc)) from exc

--- a/backend/app/processing/export/router.py
+++ b/backend/app/processing/export/router.py
@@ -43,6 +43,7 @@ from app.processing.export.service import (
 )
 from app.processing.export.where_validator import canonical_where
 from app.processing.ingest.metadata import _qtable
+from app.processing.ingest.url_fetch import EDGE_PROXY_READ_TIMEOUT_SECONDS
 from app.standards.ogc.errors import (
     BAD_REQUEST_RESPONSE,
     FORBIDDEN_RESPONSE,
@@ -343,6 +344,18 @@ async def export_dataset_endpoint(
     filtering, and attribute filtering. GeoParquet is always emitted in
     EPSG:4326 (OGC:CRS84). PMTiles renders zooms 0..N where N is extent-budgeted (ceiling 14).
     """
+    # fix(#1778 codex r1): the request's own clock, stamped before anything
+    # else runs. Everything this handler does between here and the conversion
+    # spends part of the edge proxy's window, so the conversion's bound has to
+    # be what is LEFT of it rather than an allowance computed from scratch.
+    # An unindexed `_count_selected_features` scan, or a parquet plan over a
+    # wide table, can eat a minute here; a warm cold path costs milliseconds,
+    # and the conversion should get that time back.
+    #
+    # Monotonic, not wall clock: a clock step (NTP, a suspend) must not shorten
+    # or extend a running export.
+    request_deadline = time.monotonic() + EDGE_PROXY_READ_TIMEOUT_SECONDS
+
     port = get_processing_port()
     data_schema = tenant_data_schema(current_tenant_var.get())
     # 1. Fetch dataset
@@ -836,6 +849,7 @@ async def export_dataset_endpoint(
                 where=where,
                 column_info=dataset_columns,
                 pmtiles_maxzoom=pmtiles_maxzoom,
+                deadline=request_deadline,
             )
     except ValueError as e:
         raise HTTPException(

--- a/backend/app/processing/export/router.py
+++ b/backend/app/processing/export/router.py
@@ -344,17 +344,33 @@ async def export_dataset_endpoint(
     filtering, and attribute filtering. GeoParquet is always emitted in
     EPSG:4326 (OGC:CRS84). PMTiles renders zooms 0..N where N is extent-budgeted (ceiling 14).
     """
-    # fix(#1778 codex r1): the request's own clock, stamped before anything
-    # else runs. Everything this handler does between here and the conversion
-    # spends part of the edge proxy's window, so the conversion's bound has to
-    # be what is LEFT of it rather than an allowance computed from scratch.
-    # An unindexed `_count_selected_features` scan, or a parquet plan over a
-    # wide table, can eat a minute here; a warm cold path costs milliseconds,
-    # and the conversion should get that time back.
+    # fix(#1778 codex r1): the request's own clock. Everything this handler
+    # does between here and the conversion spends part of the edge proxy's
+    # window, so the conversion's bound has to be what is LEFT of it rather
+    # than an allowance computed from scratch. An unindexed
+    # `_count_selected_features` scan, or a parquet plan over a wide table,
+    # can eat a minute here; a warm cold path costs milliseconds, and the
+    # conversion should get that time back.
+    #
+    # fix(#1778 codex r2): read from where the REQUEST started, not from where
+    # this function did. FastAPI resolves `Depends(get_optional_user)` before
+    # the body runs, and that dependency's session checkout can block for up
+    # to `db_pool_timeout` under an exhausted pool. A clock started here would
+    # not see that wait, so an export that spent its whole calculated
+    # allowance could still land after nginx had given up, by the length of
+    # the wait. RequestLoggingMiddleware stamps the entry moment on the scope
+    # state for exactly this.
+    #
+    # The fallback is for a caller that reaches this handler with no such
+    # stamp (a direct unit call, a test app assembled without the middleware),
+    # where by construction nothing has been spent yet.
     #
     # Monotonic, not wall clock: a clock step (NTP, a suspend) must not shorten
     # or extend a running export.
-    request_deadline = time.monotonic() + EDGE_PROXY_READ_TIMEOUT_SECONDS
+    request_started = getattr(request.state, "started_at_monotonic", None)
+    if request_started is None:
+        request_started = time.monotonic()
+    request_deadline = request_started + EDGE_PROXY_READ_TIMEOUT_SECONDS
 
     port = get_processing_port()
     data_schema = tenant_data_schema(current_tenant_var.get())

--- a/backend/app/processing/export/router.py
+++ b/backend/app/processing/export/router.py
@@ -101,7 +101,7 @@ async def _emit_export_audit(
     db: AsyncSession,
     request: Request,
     *,
-    user: Identity | None,
+    user_id: uuid.UUID | None,
     dataset_id: uuid.UUID,
     format: ExportFormat,
     target_crs: str | None,
@@ -115,6 +115,12 @@ async def _emit_export_audit(
     same row. A cached read is still a download; only HEAD, which transfers
     nothing, stays out of the log.
 
+    fix(#1778): takes the id, not the ``Identity``. The conversion path calls
+    this after the session has been rolled back to release its pooled
+    connection, and the request's ``user`` is a live ORM instance on that
+    session, so reading ``user.id`` here would be an expired-attribute
+    refresh from a context with no greenlet.
+
     ``details.range`` distinguishes a tile-sized read from a full download when
     the log is read back. A range-probing client emits a row per read, which is
     a deliberate volume cost taken because the alternative is an audit blind
@@ -124,7 +130,7 @@ async def _emit_export_audit(
     await audit_emit(
         db,
         AuditEvent(
-            user_id=user.id if user is not None else None,
+            user_id=user_id,
             action="dataset.export",
             resource_type="dataset",
             resource_id=dataset_id,
@@ -390,6 +396,12 @@ async def export_dataset_endpoint(
                 detail="Missing permission: export",
             )
 
+    # fix(#1778): read once, here, while the session that loaded it is still in
+    # a transaction. `user` is the concrete User ORM instance on this request's
+    # session, and the release below expires it along with every other
+    # instance.
+    user_id = user.id if user is not None else None
+
     # 3. Parse bbox
     from app.modules.catalog.features.service import parse_bbox
 
@@ -577,7 +589,7 @@ async def export_dataset_endpoint(
         await _emit_export_audit(
             db,
             request,
-            user=user,
+            user_id=user_id,
             dataset_id=dataset_id,
             format=format,
             target_crs=target_crs,
@@ -687,6 +699,33 @@ async def export_dataset_endpoint(
                 detail=str(e),
             )
 
+    # 6d-b. fix(#1778): hand the pooled connection back before the conversion.
+    #
+    # `get_db` yields one session for the whole request and nothing released
+    # it, so the `port.get_dataset` above checked a connection out and this
+    # handler then kept it across ogr2ogr, the hash and the object-store
+    # upload. The API process has `db_pool_size` + `db_max_overflow`
+    # connections in total, and export is reachable anonymously for a
+    # public+published dataset, so a handful of concurrent exports could
+    # starve every other request in the process on `pool_timeout`. Same fix
+    # and same reasoning as fix(#1451 codex P1) in processing/tiles/router.py,
+    # which had already recognised the hazard for a query that holds the
+    # connection roughly a thousand times less long. Everything above is
+    # read-only, so the rollback discards nothing.
+    #
+    # Every value the rest of the handler needs is copied out FIRST. A
+    # rollback expires the ORM instances, so an attribute read afterwards
+    # would go back to the database from a context with no greenlet and raise
+    # MissingGreenlet; dropping the name makes that a NameError while the code
+    # is being written rather than a 500 in production.
+    dataset_title = dataset.record.title
+    dataset_table = dataset.table_name
+    dataset_columns = dataset.column_info
+    dataset_has_geometry = dataset.geometry_type is not None
+    dataset_extent = dataset.record.spatial_extent
+    del dataset
+    await db.rollback()
+
     # 6e. HEAD stops here — after every gate that decides the status, before
     # the conversion that decides the bytes. No audit event either: nothing was
     # exported, and a `dataset.export` row for a probe would misreport who
@@ -735,7 +774,7 @@ async def export_dataset_endpoint(
         return not_modified_response(None)
     if request.method == "HEAD":
         # Only the cold case reaches here; a hit returned above.
-        return _head_export_response(dataset.record.title, format)
+        return _head_export_response(dataset_title, format)
 
     # 7. Run export. GeoParquet goes through the pyarrow writer (the Debian GDAL
     # build has no Arrow driver); all other formats use the ogr2ogr path.
@@ -756,8 +795,8 @@ async def export_dataset_endpoint(
             assert parquet_plan is not None  # set by the parquet branch above
             file_path, filename, media_type = await export_parquet(
                 db,
-                dataset.table_name,
-                dataset.record.title,
+                dataset_table,
+                dataset_title,
                 schema=data_schema,
                 plan=parquet_plan,
             )
@@ -778,14 +817,13 @@ async def export_dataset_endpoint(
                 from geoalchemy2.shape import to_shape
 
                 bounds: tuple[float, float, float, float] | None = None
-                ext = dataset.record.spatial_extent
-                if ext is not None:
-                    bounds = to_shape(ext).bounds
+                if dataset_extent is not None:
+                    bounds = to_shape(dataset_extent).bounds
                 pmtiles_maxzoom = pmtiles_maxzoom_for_extent(bounds)
 
             file_path, filename, media_type = await export_dataset(
-                dataset.table_name,
-                dataset.record.title,
+                dataset_table,
+                dataset_title,
                 format,
                 schema=data_schema,
                 target_srs=target_crs,
@@ -794,9 +832,9 @@ async def export_dataset_endpoint(
                 # HAS geometry. csv is the one ogr format a non-spatial dataset
                 # can reach (gate 6 blocks the rest), and -spat was already a
                 # no-op there ("Cannot set spatial filter: no geometry field").
-                bbox=bbox_parsed if dataset.geometry_type is not None else None,
+                bbox=bbox_parsed if dataset_has_geometry else None,
                 where=where,
-                column_info=dataset.column_info,
+                column_info=dataset_columns,
                 pmtiles_maxzoom=pmtiles_maxzoom,
             )
     except ValueError as e:
@@ -852,6 +890,15 @@ async def export_dataset_endpoint(
     # a specific tag against no validator is refused rather than guessed — the
     # same call the shared helpers make for a COG row with no stored digest.
     try:
+        # fix(#1778): released again, for the same reason and in the same
+        # shape. The GeoParquet branch streams its rows through this session,
+        # so it checks a connection back out; without this the hash and the
+        # upload below would hold it exactly as the conversion used to. A
+        # no-op on the ogr2ogr branch, which opens no transaction of its own,
+        # and inside this try so a rollback that fails on a dead connection
+        # cleans the conversion directory up rather than stranding it. The
+        # audit row at the end re-acquires.
+        await db.rollback()
         try:
             digest, size = await artifact_cache.digest_and_size(file_path)
         except Exception:  # broad: an unhashable file still downloads
@@ -1013,7 +1060,7 @@ async def export_dataset_endpoint(
         await _emit_export_audit(
             db,
             request,
-            user=user,
+            user_id=user_id,
             dataset_id=dataset_id,
             format=format,
             target_crs=target_crs,

--- a/backend/app/processing/export/service.py
+++ b/backend/app/processing/export/service.py
@@ -443,6 +443,7 @@ async def export_dataset(
     where: str | None = None,
     column_info: list[dict] | None = None,
     pmtiles_maxzoom: int | None = None,
+    deadline: float | None = None,
 ) -> tuple[str, str, str]:
     """Export a dataset table to a file.
 
@@ -455,6 +456,9 @@ async def export_dataset(
         bbox: Optional bounding box [minx, miny, maxx, maxy] in WGS84.
         where: Optional SQL WHERE expression.
         column_info: Column metadata for where-clause validation.
+        deadline: ``time.monotonic()`` stamp by which the whole request must
+            be answered. Passed straight through to the ogr2ogr subprocess,
+            which reads what is left of it at spawn time (fix #1778).
 
     Returns:
         Tuple of (file_path, download_filename, media_type).
@@ -502,6 +506,7 @@ async def export_dataset(
                 where=where,
                 format_key=format_key,
                 pmtiles_maxzoom=pmtiles_maxzoom,
+                deadline=deadline,
             )
 
             # Zip all export.* files. fix(#435): DEFLATE of a multi-GB shapefile
@@ -529,6 +534,7 @@ async def export_dataset(
             # call is the one that must carry the extent-budgeted cap — the
             # shp branch above can never be pmtiles.
             pmtiles_maxzoom=pmtiles_maxzoom,
+            deadline=deadline,
         )
         if format_key == "gpkg":
             # fix(#1532 review r12): off the event loop, like every other

--- a/backend/tests/test_export.py
+++ b/backend/tests/test_export.py
@@ -90,6 +90,7 @@ def mock_export_service(monkeypatch):
         where=None,
         pmtiles_maxzoom=None,
         column_info=None,
+        deadline=None,
     ):
         # Replicate the real format validation
         if format_key not in FORMAT_MAP:

--- a/backend/tests/test_export_access.py
+++ b/backend/tests/test_export_access.py
@@ -56,6 +56,7 @@ def mock_export_service(monkeypatch):
         where=None,
         pmtiles_maxzoom=None,
         column_info=None,
+        deadline=None,
     ):
         if format_key not in FORMAT_MAP:
             raise ValueError(f"Unsupported export format: {format_key}")

--- a/backend/tests/test_export_antimeridian.py
+++ b/backend/tests/test_export_antimeridian.py
@@ -386,6 +386,7 @@ class TestNonSpatialBboxIsDropped:
             where=None,
             pmtiles_maxzoom=None,
             column_info=None,
+            deadline=None,
         ):
             seen["bbox"] = bbox
             path = tmp_path / f"{uuid.uuid4().hex}.out"

--- a/backend/tests/test_export_artifact_cache_1532.py
+++ b/backend/tests/test_export_artifact_cache_1532.py
@@ -91,6 +91,7 @@ class Conversions:
         where=None,
         pmtiles_maxzoom=None,
         column_info=None,
+        deadline=None,
     ):
         self.count += 1
         fmt = FORMAT_MAP[format_key]

--- a/backend/tests/test_export_hardening.py
+++ b/backend/tests/test_export_hardening.py
@@ -255,6 +255,7 @@ def mock_export_service_for_known05(monkeypatch):
         where=None,
         pmtiles_maxzoom=None,
         column_info=None,
+        deadline=None,
     ):
         if format_key not in FORMAT_MAP:
             raise ValueError(f"Unsupported export format: {format_key}")

--- a/backend/tests/test_export_head_1513.py
+++ b/backend/tests/test_export_head_1513.py
@@ -65,6 +65,7 @@ def mock_export_service(monkeypatch):
         where=None,
         pmtiles_maxzoom=None,
         column_info=None,
+        deadline=None,
     ):
         calls.append(format_key)
         # Derive names through the same helper the route uses for HEAD, so a

--- a/backend/tests/test_export_request_budget.py
+++ b/backend/tests/test_export_request_budget.py
@@ -8,6 +8,13 @@ Two findings from the codebase audit of 2026-08-30 (8dc529f17), tracked in
 - "Synchronous export runs on a 3600s subprocess deadline behind a 600s edge
   read timeout, and uvicorn never cancels the orphaned handler"
 
+The deadline tests drive the real clock rather than a fake one, by placing the
+deadline relative to ``time.monotonic()``: a deadline set 500s out IS a
+request that has already spent 100s of its 600s window, and no monkeypatching
+of a module the whole process shares is needed to say so. Comparisons are to
+the second, which is four orders of magnitude looser than the arithmetic under
+test.
+
 The pool test counts checkouts on the app's own engine rather than asserting
 on the session object, because the checkout is the resource the finding is
 about: a connection the handler is not using is still one the rest of the API
@@ -16,6 +23,7 @@ never observe a held connection fails instead of passing vacuously.
 """
 
 import asyncio
+import time
 import uuid
 
 import pytest
@@ -32,66 +40,117 @@ from app.processing.ingest.url_fetch import EDGE_PROXY_READ_TIMEOUT_SECONDS
 from tests.factories import create_dataset, get_user_id
 
 
+def _deadline_after(elapsed: float) -> float:
+    """The deadline a request would hold ``elapsed`` seconds into its window."""
+    return time.monotonic() + EDGE_PROXY_READ_TIMEOUT_SECONDS - elapsed
+
+
 # ---------------------------------------------------------------------------
 # The deadline
 # ---------------------------------------------------------------------------
 
 
 class TestExportSubprocessBudget:
-    def test_budget_is_derived_from_the_edge_read_timeout(self, monkeypatch):
-        """The number comes from the proxy in front, not from the worker."""
+    def test_budget_is_what_is_left_of_the_edge_window(self, monkeypatch):
+        """The number comes from the proxy in front, minus time already spent."""
         monkeypatch.setattr(settings, "db_pool_timeout", 30)
+        reserve = export_ogr.export_post_work_reserve_seconds()
 
-        assert export_ogr.export_subprocess_timeout_seconds() == (
-            EDGE_PROXY_READ_TIMEOUT_SECONDS
-            - export_ogr.EXPORT_POOL_CHECKOUTS_PER_REQUEST * 30
-            - export_ogr.EXPORT_POST_WORK_MARGIN_SECONDS
+        budget = export_ogr.export_subprocess_timeout_seconds(_deadline_after(100))
+
+        assert budget == pytest.approx(
+            EDGE_PROXY_READ_TIMEOUT_SECONDS - 100 - reserve, abs=1
         )
-        # Same claim, spelled out, so a change to the arithmetic above has to
-        # be argued rather than mirrored: 600 - 2*30 - 120.
-        assert export_ogr.export_subprocess_timeout_seconds() == 420
+        # Same claim, spelled out, so a change to the arithmetic has to be
+        # argued rather than mirrored: 600 - 100 - (120 + 30).
+        assert budget == pytest.approx(350, abs=1)
 
-    def test_budget_shrinks_as_the_pool_timeout_grows(self, monkeypatch):
-        """Raising DB_POOL_TIMEOUT must not push the response past the proxy.
+    def test_unspent_pre_work_time_goes_to_the_conversion(self, monkeypatch):
+        """The defect codex r1 named, in both directions.
 
-        The reason the budget is derived per call instead of stated once:
-        ``db_pool_timeout`` is operator-settable and CI only ever runs the
-        default, so a fixed figure would break silently in the field.
+        A fixed allowance for pool waits that did not happen killed a
+        conversion that would have fitted; the same allowance let a request
+        whose pre-work really did overrun run on past the edge. Elapsed time
+        is what separates the two cases, so the budget has to move with it.
         """
         monkeypatch.setattr(settings, "db_pool_timeout", 30)
-        at_default = export_ogr.export_subprocess_timeout_seconds()
+
+        quick = export_ogr.export_subprocess_timeout_seconds(_deadline_after(1))
+        slow = export_ogr.export_subprocess_timeout_seconds(_deadline_after(120))
+
+        assert quick - slow == pytest.approx(119, abs=1)
+
+    def test_no_request_clock_assumes_the_whole_window(self, monkeypatch):
+        """``None`` is the zero-elapsed case, not a special one."""
+        monkeypatch.setattr(settings, "db_pool_timeout", 30)
+
+        assert export_ogr.export_subprocess_timeout_seconds(None) == pytest.approx(
+            export_ogr.export_subprocess_timeout_seconds(_deadline_after(0)), abs=1
+        )
+
+    def test_budget_shrinks_as_the_pool_timeout_grows(self, monkeypatch):
+        """The audit commit's checkout has not happened yet, so it is reserved.
+
+        Derived per call rather than stated once: ``db_pool_timeout`` is
+        operator-settable and CI only ever runs the default, so a fixed figure
+        would break silently in the field.
+        """
+        monkeypatch.setattr(settings, "db_pool_timeout", 30)
+        at_default = export_ogr.export_subprocess_timeout_seconds(_deadline_after(0))
         monkeypatch.setattr(settings, "db_pool_timeout", 60)
-        at_double = export_ogr.export_subprocess_timeout_seconds()
+        at_double = export_ogr.export_subprocess_timeout_seconds(_deadline_after(0))
 
-        assert at_double < at_default
+        assert at_default - at_double == pytest.approx(30, abs=1)
 
-    @pytest.mark.parametrize("pool_timeout", [1, 5, 30, 60, 120])
-    def test_the_whole_request_fits_inside_the_edge_deadline(
-        self, monkeypatch, pool_timeout
+    @pytest.mark.parametrize("elapsed", [0, 1, 60, 300, 450])
+    @pytest.mark.parametrize("pool_timeout", [1, 5, 30, 60])
+    def test_the_rest_of_the_request_fits_inside_the_edge_deadline(
+        self, monkeypatch, elapsed, pool_timeout
     ):
         monkeypatch.setattr(settings, "db_pool_timeout", pool_timeout)
+        deadline = _deadline_after(elapsed)
+        reserve = export_ogr.export_post_work_reserve_seconds()
 
-        budget = export_ogr.export_subprocess_timeout_seconds()
-        worst_case = (
-            budget
-            + export_ogr.EXPORT_POOL_CHECKOUTS_PER_REQUEST * pool_timeout
-            + export_ogr.EXPORT_POST_WORK_MARGIN_SECONDS
-        )
-        assert worst_case <= EDGE_PROXY_READ_TIMEOUT_SECONDS
+        budget = export_ogr.export_subprocess_timeout_seconds(deadline)
 
-    def test_a_pathological_pool_timeout_floors_the_budget_and_warns(self, monkeypatch):
-        """DB_POOL_TIMEOUT=300 derives -120s. Clamp, do not crash or disable."""
-        monkeypatch.setattr(export_ogr, "_export_budget_floor_warned", False)
-        monkeypatch.setattr(settings, "db_pool_timeout", 300)
+        if budget > export_ogr.EXPORT_BUDGET_FLOOR_SECONDS:
+            finishes_at = time.monotonic() + budget + reserve
+            assert finishes_at <= deadline + 1
+        else:
+            # The floor is the one case that overruns on purpose, and it is
+            # reachable only when less than the reserve was left before the
+            # conversion could even start. Pinning that condition is what
+            # keeps the branch from swallowing a real arithmetic error.
+            assert deadline - time.monotonic() < reserve + 1
+
+    def test_pre_work_that_overran_the_deadline_yields_the_floor(self, monkeypatch):
+        """A negative remainder is not a deadline, it is a crash.
+
+        The request is lost either way; it is lost through the ordinary
+        timeout path with the ordinary error rather than through
+        ``asyncio.wait_for`` being handed a negative number.
+        """
+        monkeypatch.setattr(settings, "db_pool_timeout", 30)
+
+        for elapsed in (EDGE_PROXY_READ_TIMEOUT_SECONDS, 10_000):
+            budget = export_ogr.export_subprocess_timeout_seconds(
+                _deadline_after(elapsed)
+            )
+            assert budget == export_ogr.EXPORT_BUDGET_FLOOR_SECONDS
+            assert budget > 0
+
+    def test_a_pathological_pool_timeout_warns_once(self, monkeypatch):
+        """DB_POOL_TIMEOUT=500 reserves more than the edge window allows."""
+        monkeypatch.setattr(export_ogr, "_export_reserve_warned", False)
+        monkeypatch.setattr(settings, "db_pool_timeout", 500)
 
         assert (
-            export_ogr.export_subprocess_timeout_seconds()
+            export_ogr.export_subprocess_timeout_seconds(_deadline_after(0))
             == export_ogr.EXPORT_BUDGET_FLOOR_SECONDS
         )
-        assert export_ogr.EXPORT_BUDGET_FLOOR_SECONDS > 0
         # The operator gets a cause rather than a mysterious 502. Asserted via
         # the once-only flag: structlog records do not reach caplog.
-        assert export_ogr._export_budget_floor_warned is True
+        assert export_ogr._export_reserve_warned is True
 
     def test_the_worker_file_timeout_is_not_reachable_from_the_export_path(
         self, monkeypatch
@@ -106,12 +165,12 @@ class TestExportSubprocessBudget:
 
         assert not hasattr(export_ogr, "OGR2OGR_FILE_TIMEOUT_SECONDS")
         assert (
-            export_ogr.export_subprocess_timeout_seconds()
+            export_ogr.export_subprocess_timeout_seconds(_deadline_after(0))
             < OGR2OGR_FILE_TIMEOUT_SECONDS
         )
 
     @pytest.mark.anyio
-    async def test_derived_budget_bounds_both_the_child_and_the_query(
+    async def test_remaining_budget_bounds_both_the_child_and_the_query(
         self, monkeypatch, tmp_path
     ):
         """One read, so the wall clock and statement_timeout cannot disagree."""
@@ -134,12 +193,20 @@ class TestExportSubprocessBudget:
         monkeypatch.setattr(export_ogr, "_communicate_with_timeout", _communicate)
 
         await export_ogr.run_ogr2ogr_export(
-            "roads", str(tmp_path / "out.geojson"), "GeoJSON", schema="data"
+            "roads",
+            str(tmp_path / "out.geojson"),
+            "GeoJSON",
+            schema="data",
+            deadline=_deadline_after(100),
         )
 
-        budget = export_ogr.export_subprocess_timeout_seconds()
-        assert seen["timeout"] == budget
-        assert seen["env"]["PGOPTIONS"] == f"-c statement_timeout={budget * 1000}"
+        reserve = export_ogr.export_post_work_reserve_seconds()
+        expected = EDGE_PROXY_READ_TIMEOUT_SECONDS - 100 - reserve
+        assert seen["timeout"] == pytest.approx(expected, abs=1)
+        # libpq wants an integer number of milliseconds.
+        assert seen["env"]["PGOPTIONS"] == (
+            f"-c statement_timeout={int(seen['timeout'] * 1000)}"
+        )
 
     @pytest.mark.anyio
     async def test_the_deadline_terminates_the_child(self, monkeypatch, tmp_path):
@@ -166,7 +233,7 @@ class TestExportSubprocessBudget:
             export_ogr.asyncio, "create_subprocess_exec", _spawn_sleeper
         )
         monkeypatch.setattr(
-            export_ogr, "export_subprocess_timeout_seconds", lambda: 0.05
+            export_ogr, "export_subprocess_timeout_seconds", lambda deadline: 0.05
         )
 
         with pytest.raises(ExportError) as exc:
@@ -179,7 +246,7 @@ class TestExportSubprocessBudget:
 
 
 # ---------------------------------------------------------------------------
-# The pooled connection
+# The pooled connection, and the route's own clock
 # ---------------------------------------------------------------------------
 
 
@@ -235,6 +302,8 @@ class TestExportReleasesThePoolConnection:
         ):
             # Read from where ogr2ogr would be running.
             probes["at_conversion"] = live["n"]
+            probes["deadline"] = kwargs.get("deadline")
+            probes["observed_at"] = time.monotonic()
             out_dir = tmp_path / uuid.uuid4().hex
             out_dir.mkdir()
             path = out_dir / f"{dataset_name}.gpkg"
@@ -261,6 +330,14 @@ class TestExportReleasesThePoolConnection:
         # The finding: it holds none across the conversion, the hash and the
         # object-store upload.
         assert probes["at_conversion"] == baseline
+
+        # The route hands the conversion its own clock, stamped on entry, so
+        # the subprocess is bounded by what is left of the edge window rather
+        # than by a fresh allowance. A route that stopped passing it would
+        # silently fall back to assuming the whole window.
+        assert probes["deadline"] is not None
+        remaining = probes["deadline"] - probes["observed_at"]
+        assert 0 < remaining <= EDGE_PROXY_READ_TIMEOUT_SECONDS
 
         # And it re-acquires afterwards: the audit row is the proof that the
         # rolled-back session is still usable, not merely released.

--- a/backend/tests/test_export_request_budget.py
+++ b/backend/tests/test_export_request_budget.py
@@ -1,0 +1,279 @@
+"""What a synchronous export is allowed to hold, and for how long.
+
+Two findings from the codebase audit of 2026-08-30 (8dc529f17), tracked in
+#1778:
+
+- "The export handler holds an API DB-pool connection open for the entire
+  ogr2ogr conversion (up to 1 hour)"
+- "Synchronous export runs on a 3600s subprocess deadline behind a 600s edge
+  read timeout, and uvicorn never cancels the orphaned handler"
+
+The pool test counts checkouts on the app's own engine rather than asserting
+on the session object, because the checkout is the resource the finding is
+about: a connection the handler is not using is still one the rest of the API
+cannot have. It carries its own positive control, so a counter that could
+never observe a held connection fails instead of passing vacuously.
+"""
+
+import asyncio
+import uuid
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import event, select
+
+from app.core.config import settings
+from app.modules.audit.models import AuditLog
+from app.processing.export import ogr as export_ogr
+from app.processing.export.ogr import FORMAT_MAP, ExportError
+from app.processing.ingest.ogr import OGR2OGR_FILE_TIMEOUT_SECONDS
+from app.processing.ingest.url_fetch import EDGE_PROXY_READ_TIMEOUT_SECONDS
+
+from tests.factories import create_dataset, get_user_id
+
+
+# ---------------------------------------------------------------------------
+# The deadline
+# ---------------------------------------------------------------------------
+
+
+class TestExportSubprocessBudget:
+    def test_budget_is_derived_from_the_edge_read_timeout(self, monkeypatch):
+        """The number comes from the proxy in front, not from the worker."""
+        monkeypatch.setattr(settings, "db_pool_timeout", 30)
+
+        assert export_ogr.export_subprocess_timeout_seconds() == (
+            EDGE_PROXY_READ_TIMEOUT_SECONDS
+            - export_ogr.EXPORT_POOL_CHECKOUTS_PER_REQUEST * 30
+            - export_ogr.EXPORT_POST_WORK_MARGIN_SECONDS
+        )
+        # Same claim, spelled out, so a change to the arithmetic above has to
+        # be argued rather than mirrored: 600 - 2*30 - 120.
+        assert export_ogr.export_subprocess_timeout_seconds() == 420
+
+    def test_budget_shrinks_as_the_pool_timeout_grows(self, monkeypatch):
+        """Raising DB_POOL_TIMEOUT must not push the response past the proxy.
+
+        The reason the budget is derived per call instead of stated once:
+        ``db_pool_timeout`` is operator-settable and CI only ever runs the
+        default, so a fixed figure would break silently in the field.
+        """
+        monkeypatch.setattr(settings, "db_pool_timeout", 30)
+        at_default = export_ogr.export_subprocess_timeout_seconds()
+        monkeypatch.setattr(settings, "db_pool_timeout", 60)
+        at_double = export_ogr.export_subprocess_timeout_seconds()
+
+        assert at_double < at_default
+
+    @pytest.mark.parametrize("pool_timeout", [1, 5, 30, 60, 120])
+    def test_the_whole_request_fits_inside_the_edge_deadline(
+        self, monkeypatch, pool_timeout
+    ):
+        monkeypatch.setattr(settings, "db_pool_timeout", pool_timeout)
+
+        budget = export_ogr.export_subprocess_timeout_seconds()
+        worst_case = (
+            budget
+            + export_ogr.EXPORT_POOL_CHECKOUTS_PER_REQUEST * pool_timeout
+            + export_ogr.EXPORT_POST_WORK_MARGIN_SECONDS
+        )
+        assert worst_case <= EDGE_PROXY_READ_TIMEOUT_SECONDS
+
+    def test_a_pathological_pool_timeout_floors_the_budget_and_warns(self, monkeypatch):
+        """DB_POOL_TIMEOUT=300 derives -120s. Clamp, do not crash or disable."""
+        monkeypatch.setattr(export_ogr, "_export_budget_floor_warned", False)
+        monkeypatch.setattr(settings, "db_pool_timeout", 300)
+
+        assert (
+            export_ogr.export_subprocess_timeout_seconds()
+            == export_ogr.EXPORT_BUDGET_FLOOR_SECONDS
+        )
+        assert export_ogr.EXPORT_BUDGET_FLOOR_SECONDS > 0
+        # The operator gets a cause rather than a mysterious 502. Asserted via
+        # the once-only flag: structlog records do not reach caplog.
+        assert export_ogr._export_budget_floor_warned is True
+
+    def test_the_worker_file_timeout_is_not_reachable_from_the_export_path(
+        self, monkeypatch
+    ):
+        """The regression this replaces: importing the offline-ingest bound.
+
+        ``OGR2OGR_FILE_TIMEOUT_SECONDS`` is the Procrastinate worker's, where
+        an hour is reasonable because no proxy is waiting. Re-importing it
+        here would restore a deadline six times the edge's.
+        """
+        monkeypatch.setattr(settings, "db_pool_timeout", 30)
+
+        assert not hasattr(export_ogr, "OGR2OGR_FILE_TIMEOUT_SECONDS")
+        assert (
+            export_ogr.export_subprocess_timeout_seconds()
+            < OGR2OGR_FILE_TIMEOUT_SECONDS
+        )
+
+    @pytest.mark.anyio
+    async def test_derived_budget_bounds_both_the_child_and_the_query(
+        self, monkeypatch, tmp_path
+    ):
+        """One read, so the wall clock and statement_timeout cannot disagree."""
+        monkeypatch.setattr(settings, "db_pool_timeout", 30)
+        seen: dict = {}
+
+        async def _capture(*args, env=None, **kwargs):
+            seen["env"] = env or {}
+
+            class _Proc:
+                returncode = 0
+
+            return _Proc()
+
+        async def _communicate(proc, timeout, *, tool_name):
+            seen["timeout"] = timeout
+            return b"", b""
+
+        monkeypatch.setattr(export_ogr.asyncio, "create_subprocess_exec", _capture)
+        monkeypatch.setattr(export_ogr, "_communicate_with_timeout", _communicate)
+
+        await export_ogr.run_ogr2ogr_export(
+            "roads", str(tmp_path / "out.geojson"), "GeoJSON", schema="data"
+        )
+
+        budget = export_ogr.export_subprocess_timeout_seconds()
+        assert seen["timeout"] == budget
+        assert seen["env"]["PGOPTIONS"] == f"-c statement_timeout={budget * 1000}"
+
+    @pytest.mark.anyio
+    async def test_the_deadline_terminates_the_child(self, monkeypatch, tmp_path):
+        """A real subprocess, really reaped, on a deliberately tiny budget.
+
+        The deadline is only worth deriving if reaching it actually stops the
+        conversion; a timeout that raised while the child kept running would
+        leave exactly the orphan the finding is about.
+        """
+        real_exec = asyncio.create_subprocess_exec
+        spawned: dict = {}
+
+        async def _spawn_sleeper(*args, env=None, **kwargs):
+            proc = await real_exec(
+                "sleep",
+                "30",
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            spawned["proc"] = proc
+            return proc
+
+        monkeypatch.setattr(
+            export_ogr.asyncio, "create_subprocess_exec", _spawn_sleeper
+        )
+        monkeypatch.setattr(
+            export_ogr, "export_subprocess_timeout_seconds", lambda: 0.05
+        )
+
+        with pytest.raises(ExportError) as exc:
+            await export_ogr.run_ogr2ogr_export(
+                "roads", str(tmp_path / "out.geojson"), "GeoJSON", schema="data"
+            )
+
+        assert "timed out" in str(exc.value)
+        assert spawned["proc"].returncode is not None
+
+
+# ---------------------------------------------------------------------------
+# The pooled connection
+# ---------------------------------------------------------------------------
+
+
+class TestExportReleasesThePoolConnection:
+    @pytest.mark.anyio
+    async def test_nothing_is_checked_out_while_the_conversion_runs(
+        self,
+        client: AsyncClient,
+        test_db_session,
+        admin_auth_header: dict,
+        monkeypatch,
+        tmp_path,
+    ):
+        import app.core.db as db_module
+        from app.processing.export import artifact_cache
+
+        admin_id = await get_user_id(test_db_session, "admin")
+        dataset = await create_dataset(
+            test_db_session,
+            created_by=admin_id,
+            name="PoolReleaseExport",
+            visibility="public",
+        )
+
+        live = {"n": 0}
+
+        def _on_checkout(dbapi_connection, connection_record, connection_proxy):
+            live["n"] += 1
+
+        def _on_checkin(dbapi_connection, connection_record):
+            live["n"] -= 1
+
+        sync_engine = db_module.engine.sync_engine
+        event.listen(sync_engine, "checkout", _on_checkout)
+        event.listen(sync_engine, "checkin", _on_checkin)
+
+        probes: dict = {}
+        real_lookup = artifact_cache.lookup
+
+        async def _probing_lookup(*args, **kwargs):
+            # Read from inside the handler, after get_dataset and the access
+            # checks, before the release. The positive control.
+            #
+            # setdefault, not assignment: the publish path calls lookup a
+            # second time after the conversion, and that later call would
+            # otherwise overwrite the control with the released count and make
+            # this test pass for the wrong reason.
+            probes.setdefault("at_lookup", live["n"])
+            return await real_lookup(*args, **kwargs)
+
+        async def _fake_export(
+            table_name, dataset_name, format_key, *, schema, **kwargs
+        ):
+            # Read from where ogr2ogr would be running.
+            probes["at_conversion"] = live["n"]
+            out_dir = tmp_path / uuid.uuid4().hex
+            out_dir.mkdir()
+            path = out_dir / f"{dataset_name}.gpkg"
+            path.write_bytes(b"mock export data")
+            return str(path), path.name, FORMAT_MAP["gpkg"]["media"]
+
+        monkeypatch.setattr(artifact_cache, "lookup", _probing_lookup)
+        monkeypatch.setattr("app.processing.export.router.export_dataset", _fake_export)
+
+        try:
+            baseline = live["n"]
+            response = await client.get(
+                f"/datasets/{dataset.id}/export",
+                params={"format": "gpkg"},
+                headers=admin_auth_header,
+            )
+        finally:
+            event.remove(sync_engine, "checkout", _on_checkout)
+            event.remove(sync_engine, "checkin", _on_checkin)
+
+        assert response.status_code == 200
+        # Positive control: the counter CAN see the handler holding one.
+        assert probes["at_lookup"] == baseline + 1
+        # The finding: it holds none across the conversion, the hash and the
+        # object-store upload.
+        assert probes["at_conversion"] == baseline
+
+        # And it re-acquires afterwards: the audit row is the proof that the
+        # rolled-back session is still usable, not merely released.
+        rows = (
+            (
+                await test_db_session.execute(
+                    select(AuditLog).where(
+                        AuditLog.action == "dataset.export",
+                        AuditLog.resource_id == dataset.id,
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert len(rows) == 1

--- a/backend/tests/test_export_request_budget.py
+++ b/backend/tests/test_export_request_budget.py
@@ -15,6 +15,11 @@ of a module the whole process shares is needed to say so. Comparisons are to
 the second, which is four orders of magnitude looser than the arithmetic under
 test.
 
+Where that clock STARTS is pinned separately, by a deliberately slow auth
+dependency: the anchor has to be the moment the request entered the app, not
+the moment this route got control, and only an observable gap between the two
+can tell those apart.
+
 The pool test counts checkouts on the app's own engine rather than asserting
 on the session object, because the checkout is the resource the finding is
 about: a connection the handler is not using is still one the rest of the API
@@ -354,3 +359,78 @@ class TestExportReleasesThePoolConnection:
             .all()
         )
         assert len(rows) == 1
+
+
+# ---------------------------------------------------------------------------
+# Where the clock starts
+# ---------------------------------------------------------------------------
+
+
+class TestExportDeadlineAnchor:
+    @pytest.mark.anyio
+    async def test_the_deadline_covers_dependency_resolution(
+        self,
+        client: AsyncClient,
+        test_db_session,
+        monkeypatch,
+        tmp_path,
+    ):
+        """A slow dependency comes out of the conversion's budget, not on top.
+
+        ``Depends(get_optional_user)`` is resolved before the handler body
+        runs, and its session checkout can block for as long as
+        ``db_pool_timeout`` under an exhausted pool. A deadline stamped in the
+        body would not see that wait, so an export that spent its whole
+        calculated budget could still answer after nginx had given up, by the
+        length of the wait. The override below stands in for the contended
+        checkout: one second of dependency time has to leave one second less
+        for the conversion.
+        """
+        from app.api.main import app
+        from app.modules.auth.dependencies import get_optional_user
+
+        dependency_delay = 1.0
+
+        async def _slow_optional_user():
+            await asyncio.sleep(dependency_delay)
+            return None
+
+        admin_id = await get_user_id(test_db_session, "admin")
+        dataset = await create_dataset(
+            test_db_session,
+            created_by=admin_id,
+            name="DeadlineAnchorExport",
+            visibility="public",
+        )
+
+        probes: dict = {}
+
+        async def _fake_export(
+            table_name, dataset_name, format_key, *, schema, **kwargs
+        ):
+            probes["deadline"] = kwargs.get("deadline")
+            probes["observed_at"] = time.monotonic()
+            out_dir = tmp_path / uuid.uuid4().hex
+            out_dir.mkdir()
+            path = out_dir / f"{dataset_name}.gpkg"
+            path.write_bytes(b"mock export data")
+            return str(path), path.name, FORMAT_MAP["gpkg"]["media"]
+
+        monkeypatch.setitem(
+            app.dependency_overrides, get_optional_user, _slow_optional_user
+        )
+        monkeypatch.setattr("app.processing.export.router.export_dataset", _fake_export)
+
+        # Anonymous, so the slow override is the whole of the auth phase.
+        response = await client.get(
+            f"/datasets/{dataset.id}/export", params={"format": "gpkg"}
+        )
+
+        assert response.status_code == 200
+        remaining = probes["deadline"] - probes["observed_at"]
+        # Short by at least the dependency's wait. Stamped at the handler body
+        # instead, this would be very nearly the whole window.
+        assert remaining <= EDGE_PROXY_READ_TIMEOUT_SECONDS - dependency_delay
+        # And not anchored somewhere absurd: the rest of the request is
+        # milliseconds of local work.
+        assert remaining > EDGE_PROXY_READ_TIMEOUT_SECONDS - dependency_delay - 10

--- a/backend/tests/test_staging_runtime.py
+++ b/backend/tests/test_staging_runtime.py
@@ -85,6 +85,7 @@ async def test_export_dataset_creates_temp_dir_after_staging_guard_passes(
         where: str | None = None,
         format_key: str = "",
         pmtiles_maxzoom: int | None = None,
+        deadline: float | None = None,
     ) -> None:
         # Simulate successful export by creating the output file.
         Path(output_path).write_text("export-data", encoding="utf-8")


### PR DESCRIPTION
Two findings from the codebase audit 2026-08-30 (8dc529f17), tracked in #1778:

- "The export handler holds an API DB-pool connection open for the entire ogr2ogr conversion (up to 1 hour)"
- "Synchronous export runs on a 3600s subprocess deadline behind a 600s edge read timeout, and uvicorn never cancels the orphaned handler"

Both were still present on current main. Nothing under `backend/app/processing/export/` had changed since the audit commit, and the two pieces of evidence reproduce exactly: `rg 'db\.(commit|rollback|close)\(\)' backend/app/processing/export/router.py` returned only the two commits the audit named, and `export/ogr.py` still imported the worker's `OGR2OGR_FILE_TIMEOUT_SECONDS`.

## The pooled connection

`get_db` yields one session for the whole request. `port.get_dataset` checked a connection out and nothing released it, so the handler kept one of the API process's `db_pool_size + db_max_overflow` connections across ogr2ogr, the file hash and the object-store upload. Export is reachable anonymously for a public and published dataset, so a small number of concurrent exports could starve every other request in the process on `pool_timeout`.

The handler now copies the five values the rest of it needs (title, table name, column info, whether the dataset has geometry, the spatial extent) into locals, drops the `dataset` name so a later ORM read is a NameError rather than a MissingGreenlet at runtime, and rolls the session back before the conversion. It rolls back a second time before the hash and the upload, which matters for the GeoParquet branch: that one streams its rows through the same session, so it checks a connection back out. The audit row at the end re-acquires. This is the treatment `processing/tiles/router.py` already had from fix(#1451 codex P1) for a query that holds a connection roughly a thousand times less long.

`_emit_export_audit` now takes a `user_id` instead of the `Identity`. The request's `user` is the concrete `User` ORM instance on the session being rolled back, so reading `user.id` after the release raised MissingGreenlet. The id is read once, while the loading transaction is still open.

## The deadline

`export/ogr.py` imported the offline worker's `OGR2OGR_FILE_TIMEOUT_SECONDS` (3600s) and used it for both the subprocess wall clock and the libpq `statement_timeout` of a request-scoped conversion. The only `proxy_read_timeout` in `frontend/nginx.conf` is 600s, so past ten minutes nginx severed the upstream read and answered 504 while the handler kept converting for up to another fifty minutes.

The route now stamps `time.monotonic() + EDGE_PROXY_READ_TIMEOUT_SECONDS` on entry and threads that deadline through `export_dataset` to `run_ogr2ogr_export`, which reads what is left of it at spawn time. The bound is therefore the time actually remaining, not an allowance: a fast pre-conversion phase hands its unused time to the conversion, and a slow one (an unindexed `_count_selected_features` scan, a `plan_parquet_export` over a wide table) takes it away.

The only thing subtracted is what is still outstanding when the subprocess starts: a 120s margin for the format-specific finish inside `export_dataset` (the shapefile ZIP, the GeoPackage timestamp normalization), the file hash, the object-store upload and the audit commit, plus one `db_pool_timeout` for the audit row's checkout, which is the single pool wait the elapsed clock cannot already contain because it has not happened yet. Every earlier checkout is behind us and is already priced into elapsed time. `EDGE_PROXY_READ_TIMEOUT_SECONDS` comes from `processing/ingest/url_fetch.py`, the constant the URL importer already derives its own synchronous budget from, so there is one edge number rather than two.

The clock is monotonic so an NTP step or a suspend cannot lengthen or shorten a running export. A remainder at or below zero clamps to a one second floor: the request is lost either way, and it should fail through the ordinary timeout path with the ordinary error rather than by handing `asyncio.wait_for` a negative number. A pool timeout large enough that the reserve alone exceeds the edge window is a configuration problem rather than a slow request, and logs once with the cause.

The interval before the route body runs (dependency resolution: auth, the permission lookup, and any pool wait either incurs) sits outside this clock. Nothing inside the handler can observe it; the reserve is what absorbs it, and it is written down at the function rather than left implied.

The comment in `export/ogr.py` that said `_communicate_with_timeout` also kills the child on a client disconnect is corrected. It does kill on cancellation, and the ingest caller gets that from Procrastinate's shutdown, but nothing cancels this task: uvicorn's `connection_lost` only marks the cycle disconnected and wakes `receive()`, and a GET handler never awaits `receive()`.

## Client disconnect

Not addressed, deliberately. The brief allowed `request.is_disconnected()` at the poll points the handler already has, and there are none: the conversion is a single await, so polling would need a concurrent watchdog task plus a response status for a GET that declares none. The deadline is what bounds the orphan now, from an hour down to what remains of the window the client was going to give up on anyway.

## Schema, API and config impact

None. No request or response schema changed, no route signature changed, no new setting. `make openapi-check` is clean.

`export_dataset` and `run_ogr2ogr_export` each gained a keyword-only `deadline: float | None = None`. Seven test doubles that stand in for one of them with an explicit signature were updated to accept it; `None` keeps the direct-call tests and any future offline caller on the same arithmetic with an elapsed time of zero.

## Verification

Run from the worktree with `.env.test` sourced and Postgres on localhost:5434.

- `uv run pytest tests/test_export_request_budget.py tests/test_export.py tests/test_export_access.py tests/test_export_antimeridian.py tests/test_export_artifact_cache_1532.py tests/test_export_hardening.py tests/test_export_head_1513.py tests/test_export_parquet.py tests/test_export_parquet_writer.py tests/test_export_temp_cleanup.py tests/test_export_where_validator.py tests/test_tenant_ingest_export_routing.py tests/test_staging_runtime.py tests/test_layering.py tests/test_rule1_structural.py tests/test_rule2_structural.py tests/test_api_key_scope_875.py tests/test_ogr_communicate_cancellation.py tests/test_ogr_subprocess_env.py tests/test_worker_exports_sweep.py -q -p no:randomly`: 570 passed, 3 skipped
- `uv run ruff check .` and `uv run ruff format --check .`: clean
- `PYTHONPATH=. uv run python scripts/dump_openapi.py --check` (the body of `make openapi-check`, which needs the env the Makefile target does not source in a worktree): exit 0, no drift
- `pre-commit run --files` over the eleven changed files: all hooks pass
- After the codex round 1 rework, a focused re-run of `tests/test_export_request_budget.py tests/test_export_antimeridian.py tests/test_export_head_1513.py -q -p no:randomly`: 72 passed

## Caps

None raised, and none needed. Neither source file has an entry in `_MODULE_LOC_CAPS`: `export/router.py` is 1088 lines against the 1500 default in `test_router_orchestrator_modules_stay_within_loc_cap`, and `export/ogr.py` is 432, below the 1000-line `_RATCHET_INCLUSION_LOC` threshold that would pull it into the ratchet.

## Noticed and left alone

- The same false cancellation premise appears in two comments outside this lane's two files: `processing/export/service.py` ("BaseException, not Exception: a client disconnect cancels this task") and the `_communicate_with_timeout` docstring in `processing/ingest/ogr.py`. The ingest one is half true, since Procrastinate really does cancel worker jobs, and that file belongs to another active lane, so neither was touched.
- The GeoParquet branch has no wall-clock deadline of its own and never did; the 3600s constant only ever bounded the ogr2ogr subprocess. The request deadline is now available to give it one, but that is a behaviour change on a path this lane was not asked to bound.
- On a cache hit the handler holds its connection across two object-storage metadata reads before committing. That is milliseconds, and the response streams after the commit, so it is not the same hazard.
- The audit's KISS note about decomposing the 715-line handler is out of this lane's scope.
