### PR TITLE
fix(a11y): destructive contrast, dark-mode axe pass, bulk mid-commit guard

### DIFF
--- a/e2e/accessibility.spec.ts
+++ b/e2e/accessibility.spec.ts
@@ -146,238 +146,251 @@ test.describe('Accessibility - WCAG 2AA', () => {
     });
   });
 
-  test('public search page has no accessibility violations', async ({ page }) => {
-    await page.goto('/');
-    await page.waitForLoadState('networkidle');
+  // fix(#1778): every gating axe scan below runs in both color schemes.
+  // playwright.config.ts's `use` block sets no colorScheme, so Playwright
+  // defaults to light and the ThemeProvider's "system" default
+  // (main.tsx:106) resolves off that media query -- the dark palette was
+  // structurally unreachable to axe. beforeAll/afterAll above are shared
+  // across both passes so the fixture dataset/map/collection are seeded
+  // once, not once per scheme.
+  for (const colorScheme of ['light', 'dark'] as const) {
+    test.describe(`(${colorScheme} mode)`, () => {
+      test.use({ colorScheme });
 
-    const results = await new AxeBuilder({ page })
-      .withTags(wcagTags)
-      .analyze();
+      test('public search page has no accessibility violations', async ({ page }) => {
+        await page.goto('/');
+        await page.waitForLoadState('networkidle');
 
-    expect(results.violations, formatViolations(results.violations)).toEqual([]);
-  });
+        const results = await new AxeBuilder({ page })
+          .withTags(wcagTags)
+          .analyze();
 
-  test.describe('logged-out routes', () => {
-    test.use({ storageState: { cookies: [], origins: [] } });
-
-    test('login page has no accessibility violations', async ({ page }) => {
-      await page.goto('/login');
-      await page.waitForLoadState('networkidle');
-
-      const results = await new AxeBuilder({ page })
-        .withTags(wcagTags)
-        .analyze();
-
-      expect(results.violations, formatViolations(results.violations)).toEqual([]);
-    });
-
-    test('public saved-map output has no accessibility violations', async ({ page }) => {
-      await page.goto(`/m/${shareToken}`);
-      await expect(page.getByText(builderMapName)).toBeVisible({ timeout: 15_000 });
-      await page.getByRole('button', { name: 'Map data' }).click();
-      const dataDialog = page.getByRole('dialog', { name: 'Map data' });
-      await expect(dataDialog).toBeVisible();
-      await expect(dataDialog.getByText(datasetTitle).first()).toBeVisible();
-      await expect(
-        dataDialog.getByRole('region', { name: 'Map layer and feature data' }),
-      ).toBeVisible();
-      await expect(dataDialog.getByText('E2E Test Point', { exact: true })).toBeVisible({
-        timeout: 15_000,
-      });
-      await page.waitForLoadState('networkidle').catch(() => {
-        /* MapLibre/background tile requests may keep the page active. */
+        expect(results.violations, formatViolations(results.violations)).toEqual([]);
       });
 
-      const results = await new AxeBuilder({ page })
-        .withTags(wcagTags)
-        .exclude('.maplibregl-canvas')
-        .exclude('.maplibregl-control-container')
-        .exclude('.maplibregl-ctrl-attrib-inner')
-        .analyze();
+      test.describe('logged-out routes', () => {
+        test.use({ storageState: { cookies: [], origins: [] } });
 
-      expect(results.violations, formatViolations(results.violations)).toEqual([]);
-    });
-  });
+        test('login page has no accessibility violations', async ({ page }) => {
+          await page.goto('/login');
+          await page.waitForLoadState('networkidle');
 
-  test('dataset detail page has no accessibility violations', async ({ page }) => {
-    await page.goto(`/datasets/${datasetId}`);
-    await page.waitForLoadState('networkidle');
+          const results = await new AxeBuilder({ page })
+            .withTags(wcagTags)
+            .analyze();
 
-    // Wait for dataset detail to load
-    await expect(
-      page.getByRole('heading', { name: datasetTitle, exact: true }),
-    ).toBeVisible();
-    await page.waitForLoadState('networkidle');
+          expect(results.violations, formatViolations(results.violations)).toEqual([]);
+        });
 
-    // Exclude MapLibre canvas -- WebGL canvases cannot be inspected by axe
-    const results = await new AxeBuilder({ page })
-      .withTags(wcagTags)
-      .exclude('.maplibregl-map')
-      .analyze();
+        test('public saved-map output has no accessibility violations', async ({ page }) => {
+          await page.goto(`/m/${shareToken}`);
+          await expect(page.getByText(builderMapName)).toBeVisible({ timeout: 15_000 });
+          await page.getByRole('button', { name: 'Map data' }).click();
+          const dataDialog = page.getByRole('dialog', { name: 'Map data' });
+          await expect(dataDialog).toBeVisible();
+          await expect(dataDialog.getByText(datasetTitle).first()).toBeVisible();
+          await expect(
+            dataDialog.getByRole('region', { name: 'Map layer and feature data' }),
+          ).toBeVisible();
+          await expect(dataDialog.getByText('E2E Test Point', { exact: true })).toBeVisible({
+            timeout: 15_000,
+          });
+          await page.waitForLoadState('networkidle').catch(() => {
+            /* MapLibre/background tile requests may keep the page active. */
+          });
 
-    expect(results.violations, formatViolations(results.violations)).toEqual([]);
-  });
+          const results = await new AxeBuilder({ page })
+            .withTags(wcagTags)
+            .exclude('.maplibregl-canvas')
+            .exclude('.maplibregl-control-container')
+            .exclude('.maplibregl-ctrl-attrib-inner')
+            .analyze();
 
-  test('collection detail page has no accessibility violations', async ({ page }) => {
-    await page.goto(`/collections/${collectionId}`);
-    await expect(
-      page.getByRole('heading', { name: collectionName, exact: true }),
-    ).toBeVisible();
-    await page.waitForLoadState('networkidle');
+          expect(results.violations, formatViolations(results.violations)).toEqual([]);
+        });
+      });
 
-    const results = await new AxeBuilder({ page })
-      .withTags(wcagTags)
-      .analyze();
+      test('dataset detail page has no accessibility violations', async ({ page }) => {
+        await page.goto(`/datasets/${datasetId}`);
+        await page.waitForLoadState('networkidle');
 
-    expect(results.violations, formatViolations(results.violations)).toEqual([]);
-  });
+        // Wait for dataset detail to load
+        await expect(
+          page.getByRole('heading', { name: datasetTitle, exact: true }),
+        ).toBeVisible();
+        await page.waitForLoadState('networkidle');
 
-  test('maps listing page has no accessibility violations', async ({ page }) => {
-    await page.goto('/maps');
-    await page.waitForLoadState('networkidle');
+        // Exclude MapLibre canvas -- WebGL canvases cannot be inspected by axe
+        const results = await new AxeBuilder({ page })
+          .withTags(wcagTags)
+          .exclude('.maplibregl-map')
+          .analyze();
 
-    const results = await new AxeBuilder({ page })
-      .withTags(wcagTags)
-      .analyze();
+        expect(results.violations, formatViolations(results.violations)).toEqual([]);
+      });
 
-    expect(results.violations, formatViolations(results.violations)).toEqual([]);
-  });
+      test('collection detail page has no accessibility violations', async ({ page }) => {
+        await page.goto(`/collections/${collectionId}`);
+        await expect(
+          page.getByRole('heading', { name: collectionName, exact: true }),
+        ).toBeVisible();
+        await page.waitForLoadState('networkidle');
 
-  test('map builder page has no accessibility violations', async ({ page }) => {
-    await page.goto(`/maps/${builderMapId}`);
-    await page.waitForLoadState('networkidle');
+        const results = await new AxeBuilder({ page })
+          .withTags(wcagTags)
+          .analyze();
 
-    // Wait for builder sidebar to be present
-    await expect(
-      page.locator('input[type="text"]').first(),
-    ).toBeVisible({ timeout: 15_000 });
+        expect(results.violations, formatViolations(results.violations)).toEqual([]);
+      });
 
-    const results = await new AxeBuilder({ page })
-      .withTags(wcagTags)
-      .exclude('.maplibregl-canvas')
-      .exclude('.maplibregl-ctrl-attrib-inner')
-      .analyze();
+      test('maps listing page has no accessibility violations', async ({ page }) => {
+        await page.goto('/maps');
+        await page.waitForLoadState('networkidle');
 
-    expect(results.violations, formatViolations(results.violations)).toEqual([]);
-  });
+        const results = await new AxeBuilder({ page })
+          .withTags(wcagTags)
+          .analyze();
 
-  test('Add Dataset dialog has no accessibility violations', async ({ page }) => {
-    await page.goto(`/maps/${builderMapId}`);
-    await page.waitForLoadState('networkidle');
+        expect(results.violations, formatViolations(results.violations)).toEqual([]);
+      });
 
-    await expect(page.getByTestId('builder-sidebar')).toBeVisible({ timeout: 15_000 });
-    await page.getByRole('button', { name: /add data/i }).first().click();
+      test('map builder page has no accessibility violations', async ({ page }) => {
+        await page.goto(`/maps/${builderMapId}`);
+        await page.waitForLoadState('networkidle');
 
-    const dialog = page.getByRole('dialog', { name: /add dataset/i });
-    await expect(dialog).toBeVisible();
-    await expect(dialog.getByRole('radio', { name: 'All' })).toBeVisible();
+        // Wait for builder sidebar to be present
+        await expect(
+          page.locator('input[type="text"]').first(),
+        ).toBeVisible({ timeout: 15_000 });
 
-    const results = await new AxeBuilder({ page })
-      .withTags(wcagTags)
-      .include('[role="dialog"]')
-      .analyze();
+        const results = await new AxeBuilder({ page })
+          .withTags(wcagTags)
+          .exclude('.maplibregl-canvas')
+          .exclude('.maplibregl-ctrl-attrib-inner')
+          .analyze();
 
-    expect(results.violations, formatViolations(results.violations)).toEqual([]);
-  });
+        expect(results.violations, formatViolations(results.violations)).toEqual([]);
+      });
 
-  // fix(#806 item 2): the builder-page test above scans the builder with the editor
-  // closed, so neither the analysis panel nor any layer-editor tab was ever covered
-  // — including the live-region work #784/#782/#804 added. Both surfaces are reached
-  // by interaction rather than by URL, so they follow the Add Dataset dialog's shape
-  // and scope with .include() to keep them off what the page test already owns.
-  test('analysis panel has no accessibility violations', async ({ page }) => {
-    await page.goto(`/maps/${builderMapId}`);
-    await page.waitForLoadState('networkidle');
-    await expect(page.getByTestId('builder-sidebar')).toBeVisible({ timeout: 15_000 });
+      test('Add Dataset dialog has no accessibility violations', async ({ page }) => {
+        await page.goto(`/maps/${builderMapId}`);
+        await page.waitForLoadState('networkidle');
 
-    await page.getByRole('button', { name: 'Analysis', exact: true }).click();
-    await expect(page.getByTestId('analysis-panel')).toBeVisible({ timeout: 15_000 });
+        await expect(page.getByTestId('builder-sidebar')).toBeVisible({ timeout: 15_000 });
+        await page.getByRole('button', { name: /add data/i }).first().click();
 
-    // Scope to the rail panel, not the inner form: BuilderRail renders the panel
-    // title and close control as siblings of AnalysisPanel, and since the
-    // builder-page scan runs with the panel closed, that chrome would otherwise
-    // be covered nowhere.
-    const results = await new AxeBuilder({ page })
-      .withTags(wcagTags)
-      .include('[data-rail-panel]')
-      .analyze();
+        const dialog = page.getByRole('dialog', { name: /add dataset/i });
+        await expect(dialog).toBeVisible();
+        await expect(dialog.getByRole('radio', { name: 'All' })).toBeVisible();
 
-    expect(results.violations, formatViolations(results.violations)).toEqual([]);
-  });
+        const results = await new AxeBuilder({ page })
+          .withTags(wcagTags)
+          .include('[role="dialog"]')
+          .analyze();
 
-  // The seeded layer is vector, so LayerEditorPanel resolves all four tabs and one
-  // layer exposes the whole surface. Each tab renders its own panel body and only
-  // the active one is in the DOM, so every tab needs its own scan.
-  for (const tab of ['Style', 'Filter', 'Labels', 'Popup'] as const) {
-    test(`layer editor ${tab} tab has no accessibility violations`, async ({ page }) => {
-      await page.goto(`/maps/${builderMapId}`);
-      await page.waitForLoadState('networkidle');
-      await expect(page.getByTestId('builder-sidebar')).toBeVisible({ timeout: 15_000 });
+        expect(results.violations, formatViolations(results.violations)).toEqual([]);
+      });
 
-      await page
-        .locator('[id^="stack-row-"]:not([id="stack-row-basemap-group"])')
-        .first()
-        .click();
-      const editor = page.getByTestId('builder-layer-editor');
-      await expect(editor).toBeVisible({ timeout: 15_000 });
+      // fix(#806 item 2): the builder-page test above scans the builder with the editor
+      // closed, so neither the analysis panel nor any layer-editor tab was ever covered
+      // — including the live-region work #784/#782/#804 added. Both surfaces are reached
+      // by interaction rather than by URL, so they follow the Add Dataset dialog's shape
+      // and scope with .include() to keep them off what the page test already owns.
+      test('analysis panel has no accessibility violations', async ({ page }) => {
+        await page.goto(`/maps/${builderMapId}`);
+        await page.waitForLoadState('networkidle');
+        await expect(page.getByTestId('builder-sidebar')).toBeVisible({ timeout: 15_000 });
 
-      await editor.getByRole('tab', { name: tab }).click();
-      await expect(editor.getByRole('tab', { name: tab })).toHaveAttribute('aria-selected', 'true');
+        await page.getByRole('button', { name: 'Analysis', exact: true }).click();
+        await expect(page.getByTestId('analysis-panel')).toBeVisible({ timeout: 15_000 });
 
-      const results = await new AxeBuilder({ page })
-        .withTags(wcagTags)
-        .include('[data-testid="builder-layer-editor"]')
-        .analyze();
+        // Scope to the rail panel, not the inner form: BuilderRail renders the panel
+        // title and close control as siblings of AnalysisPanel, and since the
+        // builder-page scan runs with the panel closed, that chrome would otherwise
+        // be covered nowhere.
+        const results = await new AxeBuilder({ page })
+          .withTags(wcagTags)
+          .include('[data-rail-panel]')
+          .analyze();
 
-      expect(results.violations, formatViolations(results.violations)).toEqual([]);
+        expect(results.violations, formatViolations(results.violations)).toEqual([]);
+      });
+
+      // The seeded layer is vector, so LayerEditorPanel resolves all four tabs and one
+      // layer exposes the whole surface. Each tab renders its own panel body and only
+      // the active one is in the DOM, so every tab needs its own scan.
+      for (const tab of ['Style', 'Filter', 'Labels', 'Popup'] as const) {
+        test(`layer editor ${tab} tab has no accessibility violations`, async ({ page }) => {
+          await page.goto(`/maps/${builderMapId}`);
+          await page.waitForLoadState('networkidle');
+          await expect(page.getByTestId('builder-sidebar')).toBeVisible({ timeout: 15_000 });
+
+          await page
+            .locator('[id^="stack-row-"]:not([id="stack-row-basemap-group"])')
+            .first()
+            .click();
+          const editor = page.getByTestId('builder-layer-editor');
+          await expect(editor).toBeVisible({ timeout: 15_000 });
+
+          await editor.getByRole('tab', { name: tab }).click();
+          await expect(editor.getByRole('tab', { name: tab })).toHaveAttribute('aria-selected', 'true');
+
+          const results = await new AxeBuilder({ page })
+            .withTags(wcagTags)
+            .include('[data-testid="builder-layer-editor"]')
+            .analyze();
+
+          expect(results.violations, formatViolations(results.violations)).toEqual([]);
+        });
+      }
+
+      test('admin overview page has no accessibility violations', async ({ page }) => {
+        await page.goto('/admin');
+        await expect(
+          page.getByRole('heading', { level: 1 }),
+        ).toBeVisible();
+        await page.waitForLoadState('networkidle');
+
+        const results = await new AxeBuilder({ page })
+          .withTags(wcagTags)
+          .analyze();
+
+        expect(results.violations, formatViolations(results.violations)).toEqual([]);
+      });
+
+      // fix(#438): A11Y-12 — the audit found Import, Settings, and Collections
+      // uncovered. Same wcagTags contract as the routes above.
+      for (const { name, path } of [
+        { name: 'import', path: '/import' },
+        { name: 'settings', path: '/settings' },
+        { name: 'collections', path: '/collections' },
+      ]) {
+        test(`${name} page has no accessibility violations`, async ({ page }) => {
+          await page.goto(path);
+          await page.waitForLoadState('networkidle');
+
+          const results = await new AxeBuilder({ page })
+            .withTags(wcagTags)
+            .analyze();
+
+          expect(results.violations, formatViolations(results.violations)).toEqual([]);
+        });
+      }
+
+      test.describe('register (logged out)', () => {
+        test.use({ storageState: { cookies: [], origins: [] } });
+
+        test('register page has no accessibility violations', async ({ page }) => {
+          await page.goto('/register');
+          await page.waitForLoadState('networkidle');
+
+          const results = await new AxeBuilder({ page })
+            .withTags(wcagTags)
+            .analyze();
+
+          expect(results.violations, formatViolations(results.violations)).toEqual([]);
+        });
+      });
     });
   }
-
-  test('admin overview page has no accessibility violations', async ({ page }) => {
-    await page.goto('/admin');
-    await expect(
-      page.getByRole('heading', { level: 1 }),
-    ).toBeVisible();
-    await page.waitForLoadState('networkidle');
-
-    const results = await new AxeBuilder({ page })
-      .withTags(wcagTags)
-      .analyze();
-
-    expect(results.violations, formatViolations(results.violations)).toEqual([]);
-  });
-
-  // fix(#438): A11Y-12 — the audit found Import, Settings, and Collections
-  // uncovered. Same wcagTags contract as the routes above.
-  for (const { name, path } of [
-    { name: 'import', path: '/import' },
-    { name: 'settings', path: '/settings' },
-    { name: 'collections', path: '/collections' },
-  ]) {
-    test(`${name} page has no accessibility violations`, async ({ page }) => {
-      await page.goto(path);
-      await page.waitForLoadState('networkidle');
-
-      const results = await new AxeBuilder({ page })
-        .withTags(wcagTags)
-        .analyze();
-
-      expect(results.violations, formatViolations(results.violations)).toEqual([]);
-    });
-  }
-
-  test.describe('register (logged out)', () => {
-    test.use({ storageState: { cookies: [], origins: [] } });
-
-    test('register page has no accessibility violations', async ({ page }) => {
-      await page.goto('/register');
-      await page.waitForLoadState('networkidle');
-
-      const results = await new AxeBuilder({ page })
-        .withTags(wcagTags)
-        .analyze();
-
-      expect(results.violations, formatViolations(results.violations)).toEqual([]);
-    });
-  });
 });

--- a/frontend/src/components/import/BulkReviewList.tsx
+++ b/frontend/src/components/import/BulkReviewList.tsx
@@ -408,9 +408,14 @@ export function BulkReviewList({
                           {t(isSpreadsheetExt(ext) ? 'bulk.sheetLabel' : 'bulk.layerLabel')}
                         </Label>
                         {/* fix(#438): DS-08 — native <select> → themed ui/select. */}
+                        {/* fix(#1778): mirrors UrlImportForm.tsx's handleLayerChange
+                            guard (#1708 r24): the layer picker stayed live during a
+                            commit, so changing it re-enabled the commit button
+                            against a request that could not be recalled. */}
                         <Select
                           value={entry.previewData.layer_name}
                           onValueChange={(v) => onSheetChange?.(entry.id, v)}
+                          disabled={entry.status === 'committing'}
                         >
                           <SelectTrigger id={`sheet-${entry.id}`} className="w-full max-w-xs">
                             <SelectValue />

--- a/frontend/src/components/import/UploadForm.tsx
+++ b/frontend/src/components/import/UploadForm.tsx
@@ -354,6 +354,11 @@ export function UploadForm({ onPhaseChange }: UploadFormProps) {
   const handleSheetChange = async (entryId: string, layerName: string) => {
     const entry = entries.find((e) => e.id === entryId);
     if (!entry?.jobId) return;
+    // fix(#1778): mirrors UrlImportForm.tsx's handleLayerChange guard
+    // (#1708 r24): re-previewing mid-commit drove the entry back to
+    // 'preview' unconditionally, which re-enabled the commit button
+    // against a request already in flight for the same job.
+    if (entry.status === 'committing' || entry.status === 'tracking') return;
 
     updateEntry(entryId, { status: 'previewing' });
     try {

--- a/frontend/src/components/import/__tests__/BulkReviewList.midCommitGuard.test.tsx
+++ b/frontend/src/components/import/__tests__/BulkReviewList.midCommitGuard.test.tsx
@@ -1,0 +1,115 @@
+/**
+ * fix(#1778): "no layer change mid-commit" guard, bulk path.
+ *
+ * The #1708 r24 guard (UrlImportForm.tsx's handleLayerChange) was never
+ * applied to BulkReviewList's layer/sheet picker, so it stayed enabled while
+ * a commit was in flight -- changing it drove the entry back to 'preview',
+ * re-enabling the commit button against a request that was already running.
+ *
+ * This test pins the UI half of the fix: the layer/sheet <Select> is
+ * disabled once the entry's status is 'committing'.
+ */
+import { render, screen } from '@/test/test-utils';
+import { BulkReviewList } from '../BulkReviewList';
+import type { FileEntry, CommitImportRequest } from '@/types/api';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, opts?: Record<string, unknown>) => {
+      if (typeof opts?.defaultValue === 'string') return opts.defaultValue;
+      return key;
+    },
+  }),
+}));
+
+vi.mock('@/i18n/labels', () => ({
+  getGeometryTypeLabel: (_t: unknown, type: string) => type,
+}));
+
+vi.mock('@/lib/format', () => ({
+  formatNumber: (n: number) => String(n),
+}));
+
+vi.mock('../ImportMetadataForm', () => ({
+  ImportMetadataForm: () => <div data-testid="import-metadata-form" />,
+}));
+
+vi.mock('../TypeTag', () => ({
+  TypeTag: () => <div data-testid="type-tag" />,
+}));
+
+vi.mock('../StatusPill', () => ({
+  StatusPill: () => <div data-testid="status-pill" />,
+}));
+
+function makeMultiLayerEntry(overrides: Partial<FileEntry> = {}): FileEntry {
+  return {
+    id: 'entry-1',
+    file: null,
+    fileName: 'test.gpkg',
+    status: 'preview',
+    jobId: 'job-1',
+    previewData: {
+      job_id: 'job-1',
+      source_filename: 'test.gpkg',
+      columns: [],
+      geometry_type: 'Point',
+      crs: 4326,
+      layer_name: 'layer_a',
+      layers: [
+        { name: 'layer_a', feature_count: 10, field_count: 3 },
+        { name: 'layer_b', feature_count: 20, field_count: 5 },
+      ],
+      sample_rows: [],
+      feature_count: 10,
+      detected_geometry_columns: null,
+    },
+    error: null,
+    submittedTitle: null,
+    submittedVisibility: null,
+    submittedKind: null,
+    ...overrides,
+  };
+}
+
+const noopCommitSingle = (_entryId: string, _request: CommitImportRequest) => {};
+const noopCommitAll = () => {};
+const noopRemove = (_entryId: string) => {};
+
+describe('BulkReviewList — layer picker disabled mid-commit', () => {
+  it('leaves the layer/sheet Select enabled while the entry is in "preview"', () => {
+    const entry = makeMultiLayerEntry({ status: 'preview' });
+
+    render(
+      <BulkReviewList
+        entries={[entry]}
+        onCommitSingle={noopCommitSingle}
+        onCommitAll={noopCommitAll}
+        onRemove={noopRemove}
+        isCommitting={false}
+        onSheetChange={vi.fn()}
+      />,
+    );
+
+    const trigger = screen.getByLabelText('bulk.layerLabel');
+    expect(trigger).not.toBeDisabled();
+  });
+
+  it('disables the layer/sheet Select while the entry is "committing"', () => {
+    const entry = makeMultiLayerEntry({ status: 'committing' });
+
+    render(
+      <BulkReviewList
+        entries={[entry]}
+        onCommitSingle={noopCommitSingle}
+        onCommitAll={noopCommitAll}
+        onRemove={noopRemove}
+        isCommitting={true}
+        onSheetChange={vi.fn()}
+      />,
+    );
+
+    const trigger = screen.getByLabelText('bulk.layerLabel');
+    expect(trigger).toBeDisabled();
+  });
+});

--- a/frontend/src/components/import/__tests__/UploadForm.midCommitGuard.test.tsx
+++ b/frontend/src/components/import/__tests__/UploadForm.midCommitGuard.test.tsx
@@ -1,0 +1,166 @@
+/**
+ * fix(#1778): "no layer change mid-commit" guard, bulk path.
+ *
+ * The #1708 r24 guard (UrlImportForm.tsx's handleLayerChange) was never
+ * applied to UploadForm's handleSheetChange, so a mid-commit layer change
+ * drove the entry back to 'preview' unconditionally -- re-enabling the
+ * commit button against a request already in flight for the same job.
+ *
+ * This test pins the handler half: while an entry is 'committing',
+ * handleSheetChange must bail out before calling previewFile or touching
+ * the entry's status.
+ */
+import { render, screen, act } from '@/test/test-utils';
+import { UploadForm } from '../UploadForm';
+import type { FileEntry } from '@/types/api';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: (_ns?: string) => ({
+    t: (key: string, opts?: Record<string, unknown>) => {
+      if (typeof opts?.defaultValue === 'string') return opts.defaultValue;
+      return key;
+    },
+    i18n: { language: 'en' },
+  }),
+  Trans: ({ i18nKey }: { i18nKey: string }) => i18nKey,
+}));
+
+vi.mock('@/api/ingest', () => ({
+  uploadFile: vi.fn(),
+  uploadPresigned: vi.fn(),
+  previewFile: vi.fn(),
+  commitImport: vi.fn(),
+}));
+
+vi.mock('@/api/datasets', () => ({
+  commitFanOut: vi.fn(),
+}));
+
+vi.mock('@/components/import/hooks/use-ingest', () => ({
+  useUploadConfig: () => ({ data: null }),
+}));
+
+vi.mock('../FileDropzone', () => ({
+  FileDropzone: ({ onFilesAccepted }: { onFilesAccepted: (files: File[]) => void }) => (
+    <div data-testid="file-dropzone">
+      <button
+        data-testid="simulate-drop"
+        onClick={() =>
+          onFilesAccepted([new File(['{}'], 'test.gpkg', { type: 'application/octet-stream' })])
+        }
+      >
+        Drop
+      </button>
+    </div>
+  ),
+}));
+
+vi.mock('../BulkUploadProgress', () => ({
+  BulkUploadProgress: () => <div data-testid="bulk-upload-progress" />,
+}));
+
+vi.mock('../BulkReviewList', () => ({
+  BulkReviewList: ({
+    onCommitSingle,
+    onCommitAll,
+    onRemove,
+    onSheetChange,
+    entries,
+  }: {
+    onCommitSingle: (id: string, req: object) => void;
+    onCommitAll: () => void;
+    onRemove: (id: string) => void;
+    onSheetChange?: (id: string, layerName: string) => void;
+    entries: FileEntry[];
+  }) => (
+    <div data-testid="bulk-review-list">
+      {entries.map((e) => (
+        <div key={e.id} data-testid={`entry-${e.id}`} data-status={e.status}>
+          <button data-testid={`commit-${e.id}`} onClick={() => onCommitSingle(e.id, { title: e.fileName })}>
+            Commit
+          </button>
+          <button data-testid={`change-sheet-${e.id}`} onClick={() => onSheetChange?.(e.id, 'layer_b')}>
+            Change layer
+          </button>
+          <button data-testid={`remove-${e.id}`} onClick={() => onRemove(e.id)}>
+            Remove
+          </button>
+        </div>
+      ))}
+      <button data-testid="commit-all" onClick={onCommitAll}>
+        Commit All
+      </button>
+    </div>
+  ),
+}));
+
+vi.mock('../BulkTrackingList', () => ({
+  BulkTrackingList: () => <div data-testid="bulk-tracking-list" />,
+}));
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), warning: vi.fn(), error: vi.fn() },
+}));
+
+import { commitImport, previewFile, uploadFile } from '@/api/ingest';
+
+const mockUploadFile = vi.mocked(uploadFile);
+const mockPreviewFile = vi.mocked(previewFile);
+const mockCommitImport = vi.mocked(commitImport);
+
+function makeMultiLayerPreview() {
+  return {
+    job_id: 'job-1',
+    source_filename: 'test.gpkg',
+    columns: [],
+    row_count: 0,
+    geometry_type: 'Point',
+    crs: null,
+    latlon_candidates: null,
+    layer_name: 'layer_a',
+    layers: [
+      { name: 'layer_a', feature_count: 10, field_count: 3 },
+      { name: 'layer_b', feature_count: 20, field_count: 5 },
+    ],
+    sample_rows: [],
+    feature_count: 10,
+    detected_geometry_columns: null,
+  };
+}
+
+describe('UploadForm — layer change is a no-op while the entry is committing', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('does not call previewFile or revert the entry to preview when onSheetChange fires mid-commit', async () => {
+    mockUploadFile.mockResolvedValue({ job_id: 'job-1' } as never);
+    mockPreviewFile.mockResolvedValue(makeMultiLayerPreview() as never);
+    // Commit never resolves in this test, so the entry stays 'committing'
+    // for the duration -- exactly the window the r24 guard closes.
+    mockCommitImport.mockReturnValue(new Promise(() => {}));
+
+    render(<UploadForm />);
+
+    await act(async () => {
+      screen.getByTestId('simulate-drop').click();
+    });
+
+    const entryEl = await screen.findByTestId(/^entry-/);
+    const entryId = entryEl.getAttribute('data-testid')!.replace('entry-', '');
+    expect(mockPreviewFile).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      screen.getByTestId(`commit-${entryId}`).click();
+    });
+    expect(screen.getByTestId(`entry-${entryId}`)).toHaveAttribute('data-status', 'committing');
+
+    await act(async () => {
+      screen.getByTestId(`change-sheet-${entryId}`).click();
+    });
+
+    // The guard must bail out before re-previewing or reverting status.
+    expect(mockPreviewFile).toHaveBeenCalledTimes(1);
+    expect(screen.getByTestId(`entry-${entryId}`)).toHaveAttribute('data-status', 'committing');
+  });
+});

--- a/frontend/src/components/ui/__tests__/destructive-contrast.test.tsx
+++ b/frontend/src/components/ui/__tests__/destructive-contrast.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { Button } from '../button';
+import { Badge } from '../badge';
+
+/**
+ * Regression test for the destructive-variant dark-mode contrast bug:
+ * `dark:bg-destructive/60` composited over --card, read with
+ * `text-destructive-foreground` (a dark-on-dark token tuned for the SOLID
+ * light fill), measures 2.61:1 -- below the 4.5:1 WCAG 1.4.3 floor.
+ * `text-white` measures 6.24:1 against the same dark fill and >5.9:1
+ * against the light-mode solid fill, so both variants use it instead.
+ */
+describe('destructive variant contrast', () => {
+  it('button destructive variant does not pair text-destructive-foreground with the translucent dark fill', () => {
+    render(<Button variant="destructive">Delete</Button>);
+    const button = screen.getByRole('button', { name: 'Delete' });
+
+    expect(button).toHaveClass('text-white');
+    expect(button).toHaveClass('dark:bg-destructive/60');
+    expect(button.className).not.toMatch(/\btext-destructive-foreground\b/);
+  });
+
+  it('badge destructive variant does not pair text-destructive-foreground with the translucent dark fill', () => {
+    render(<Badge variant="destructive">Expired</Badge>);
+    const badge = screen.getByText('Expired');
+
+    expect(badge).toHaveClass('text-white');
+    expect(badge).toHaveClass('dark:bg-destructive/60');
+    expect(badge.className).not.toMatch(/\btext-destructive-foreground\b/);
+  });
+});

--- a/frontend/src/components/ui/badge.tsx
+++ b/frontend/src/components/ui/badge.tsx
@@ -15,8 +15,11 @@ const badgeVariants = cva(
         default: "bg-primary text-primary-foreground [a&]:hover:bg-primary/90",
         secondary:
           "bg-secondary text-secondary-foreground [a&]:hover:bg-secondary/90",
+        // fix(#1778): same dark-fill contrast fix as button.tsx's destructive
+        // variant (dark:bg-destructive/60 composited against
+        // text-destructive-foreground is 2.61:1; text-white is 6.24:1).
         destructive:
-          "bg-destructive text-destructive-foreground [a&]:hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
+          "bg-destructive text-white [a&]:hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
         outline:
           "border-border text-foreground [a&]:hover:bg-accent [a&]:hover:text-accent-foreground",
         ghost: "[a&]:hover:bg-accent [a&]:hover:text-accent-foreground",

--- a/frontend/src/components/ui/button.tsx
+++ b/frontend/src/components/ui/button.tsx
@@ -10,8 +10,13 @@ const buttonVariants = cva(
     variants: {
       variant: {
         default: "bg-primary text-primary-foreground hover:bg-primary/90",
+        // fix(#1778): destructive-foreground is tuned dark-on-dark for the
+        // solid light fill; composited at dark:bg-destructive/60 it drops
+        // to 2.61:1 against WCAG's 4.5:1 floor. text-white keeps the
+        // translucent dark fill (matches upstream shadcn) at 6.24:1, and
+        // stays >5.9:1 on the light-mode solid fill too.
         destructive:
-          "bg-destructive text-destructive-foreground hover:bg-destructive/90 focus-visible:ring-destructive dark:bg-destructive/60",
+          "bg-destructive text-white hover:bg-destructive/90 focus-visible:ring-destructive dark:bg-destructive/60",
         outline:
           "border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50",
         secondary:


### PR DESCRIPTION
Fixes three findings from the codebase audit 2026-08-30 (8dc529f17), tracked in #1778: register excerpt AUD9-fe-a11y-bulk.json, audit "do first" item 9.

All three findings were still present on main; none had already been fixed.

## Destructive button/badge dark-mode contrast

button.tsx's and badge.tsx's destructive variant paired `dark:bg-destructive/60` with `text-destructive-foreground`. That foreground token is tuned dark-on-dark for the solid light-mode fill (`--destructive-foreground: oklch(0.985 0 0)` in light, `oklch(0.25 0.05 22)` in dark). Composited at 60% over `--card` in dark mode it measures 2.61:1, below the 4.5:1 WCAG 1.4.3 floor for normal text.

I reimplemented the OKLCH to sRGB to WCAG contrast math independently rather than trusting the audit's numbers and reproduced them exactly:

- 60% destructive over dark `--card`: rgb(159, 67, 70). Against dark `--destructive-foreground` rgb(54, 23, 23): 2.61:1. Against white: 6.24:1.
- Dropping `dark:bg-destructive/60` (solid fill) against the same dark foreground: 5.63:1, which would pass, but the translucent dark fill matches a pattern already used by other variants in the same file (`dark:bg-input/30`, `dark:hover:bg-accent/50`), so I kept it and changed the text color instead.
- Light-mode solid fill against plain white: 5.98:1 (was 5.73:1 against the near-white `--destructive-foreground` token).

Both variants now use `text-white` instead of `text-destructive-foreground`, matching upstream shadcn's own destructive-button recipe. `frontend/src/components/report/ReportProblemHost.tsx` also uses `text-destructive-foreground`, but on a solid `bg-destructive` fill with no `/60` modifier, which measures 5.63:1 in dark mode and passes; left untouched.

Added `frontend/src/components/ui/__tests__/destructive-contrast.test.tsx`, which renders both variants and pins that `text-destructive-foreground` is not paired with the translucent dark fill.

## Dark-mode axe pass

`playwright.config.ts` sets no `colorScheme`, so every Playwright browser context defaults to light, and the app's `ThemeProvider` (`defaultTheme="system"`) resolves off `prefers-color-scheme` with nothing stored in `localStorage`. The entire dark palette was structurally unreachable to the gating axe suite.

`e2e/accessibility.spec.ts` had one project-wide `beforeAll`/`afterAll` (dataset, collection, map, share) and about 19 axe scans hung off routes and dialogs reachable from those fixtures. Duplicating that setup per color scheme (via a second Playwright project) would double the seeded fixtures for no reason, so instead the existing scans are wrapped in a `for (const colorScheme of ['light', 'dark'])` loop with `test.describe` and `test.use({ colorScheme })` per pass, keeping the shared `beforeAll`/`afterAll` outside the loop. Test count goes from 19 to 38 (light and dark for each route); the shared fixtures are still seeded once.

Ran the full suite (both schemes) from the :5174 worktree recipe: 38/38 passed. No dark-mode-only violation surfaced beyond the button/badge contrast fix above, which this run now also exercises.

Left alone, not part of this lane's scope: the same wcagTags list also excludes axe's `target-size` rule (tag `wcag22aa`), which the audit's third finding calls out separately for several 22px builder row controls; that finding was not in this lane's deliverable and is untouched. `playwright.builder-hardening.config.ts` and `e2e/record-detail-ux-audit.spec.ts` have the same light-mode-only gap and were not named in this lane's brief; also untouched.

## Bulk upload mid-commit guard

The #1708 r24 "no layer change mid-commit" guard, applied to `UrlImportForm.tsx`'s `handleLayerChange`, was never applied to the bulk upload path. `BulkReviewList.tsx`'s layer/sheet `<Select>` had no `disabled` state, and `UploadForm.tsx`'s `handleSheetChange` drove the entry back to `'preview'` unconditionally on any change, including while a commit was in flight. That re-enabled the commit button (and the belt-and-braces UI wiring in `ReviewFormBlock`) against a request the backend had already accepted, and a second commit on the same job id would be rejected as a 400, misreporting a still-running import as failed.

Mirrored the same guard shape UrlImportForm.tsx already carries: `disabled={entry.status === 'committing'}` on the `<Select>`, and an early `if (entry.status === 'committing' || entry.status === 'tracking') return;` in `handleSheetChange` before it touches the entry.

Added two tests: `BulkReviewList.midCommitGuard.test.tsx` pins the Select's disabled state, and `UploadForm.midCommitGuard.test.tsx` drives a full drop-preview-commit flow with a commit held pending, then confirms a mid-commit `onSheetChange` call is a no-op (no second `previewFile` call, status stays `committing`). Both tests fail without the fix (verified locally before restoring it) and pass with it.

Left alone: the audit's verification notes that `handleCommitSingle` in `UploadForm.tsx` also has no internal in-flight guard, a distinct double-commit race (rapid double-click on the commit button itself, not the layer picker) that this lane's brief did not ask to fix. `FilterPanel.tsx`, `UrlImportForm.tsx`, and `StacImportForm.tsx` rows from the same register excerpt are out of scope for this lane; the latter two are owned by lane 1712.

## Impact

Frontend and e2e test changes only. No schema, API, or config changes.

## Verification

- `cd frontend && npx vitest run src/components/ui/__tests__/destructive-contrast.test.tsx src/components/import/__tests__/BulkReviewList.midCommitGuard.test.tsx src/components/import/__tests__/UploadForm.midCommitGuard.test.tsx`: 3 files, 5 tests passed
- `cd frontend && npx vitest run` (full suite): 428 files, 5682 tests passed
- `cd frontend && npm run typecheck`: passed
- `cd frontend && npm run lint`: passed
- `cd frontend && npm run test:i18n`: passed (4 tests, no new t() keys added)
- Vite on :5174 with `API_PROXY_TARGET=http://localhost:8001`, then `E2E_ALLOW_WORKTREE=1 E2E_BASE_URL=http://localhost:5174 npx playwright test e2e/accessibility.spec.ts --project=chromium`: 38/38 passed (19 routes, light and dark)
