### PR TITLE
fix(ci): repair vacuous route-table gates, close backend filter gap, cap pg log growth

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,6 +179,33 @@ jobs:
               - 'frontend/src/lib/basemap-utils.ts'
               - 'frontend/src/lib/capabilities.ts'
               - 'frontend/src/components/builder/layer-adapters/shared.ts'
+              # fix(#1778): more frontend files (plus one
+              # e2e spec below) that backend tests reference by literal path
+              # were absent from this list. A PR editing only AuditLogViewer.tsx
+              # matched the 'frontend' filter but not 'backend', so Backend
+              # Tests skipped and the audit-action parity gate
+              # (test_frontend_action_list_matches_backend_registry) never
+              # ran — the same "skipped required job reads as green" trap the
+              # #1088 fix above describes for scripts/backup-entrypoint.sh.
+              # test_ci_alembic_filter_paths.py::TestBackendFilterCoversReferencedScripts
+              # now scans for both scripts/ and frontend|e2e/ literals, so this
+              # list and that scan cannot drift apart again; the last four
+              # entries are cross-references inside docstrings rather than
+              # files under test, kept here anyway so the currency scan (which
+              # cannot tell the two apart, deliberately — see its docstring)
+              # stays green without special-casing prose mentions.
+              - 'frontend/src/components/admin/AuditLogViewer.tsx'
+              - 'frontend/src/lib/__tests__/public-app-url-shape.cases.json'
+              - 'frontend/src/lib/error-map.ts'
+              - 'frontend/README.md'
+              - 'frontend/src/components/admin/__tests__/AdminSidebar.test.tsx'
+              - 'frontend/src/lib/__tests__/public-urls.test.ts'
+              - 'frontend/src/lib/normalize-style-config.ts'
+              - 'frontend/vite.config.ts'
+              # test_embed_framing_csp.py::test_e2e_sec_audit_s08_skips_when_no_share_token
+              # reads this spec by literal path to pin the S08 test block; the
+              # 'e2e' filter alone does not trigger Backend Tests.
+              - 'e2e/sec-audit.spec.ts'
               # fix(#1088): repo-root scripts that backend tests read by literal
               # path. #1027 changed backup-entrypoint.sh and its own regression
               # test (test_backup_staging_tar_skew.py) never ran — the backup

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -1752,8 +1752,14 @@ endpoint reachability before the next scheduled run.
 output — slow-query lines (`log_min_duration_statement = 1000`), `auto_explain`
 plans, checkpoint activity — into daily-rotated files inside the pgdata volume.
 The filename is keyed by day of week and each day's file is truncated on
-rotation, so the directory holds at most 7 files regardless of volume. Read
-them with:
+rotation, so the directory holds at most 7 files regardless of volume.
+Rotation is aligned to local midnight (not to process uptime), so an
+ordinary restart — a daily deploy, a container recreate — still truncates on
+schedule as long as the server is up at midnight. The one gap: PostgreSQL
+only truncates on time-based rotation, never at server startup, so a crash
+loop that never keeps the server running across a single midnight appends to
+that weekday's file for as long as the loop lasts; the first midnight it
+survives truncates that file back to empty. Read them with:
 
 ```bash
 docker compose exec db sh -c 'ls -t "$PGDATA/log/"'

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -1751,7 +1751,9 @@ endpoint reachability before the next scheduled run.
 `db/postgresql.conf` sets `logging_collector = on`, which routes all PostgreSQL
 output — slow-query lines (`log_min_duration_statement = 1000`), `auto_explain`
 plans, checkpoint activity — into daily-rotated files inside the pgdata volume.
-Read them with:
+The filename is keyed by day of week and each day's file is truncated on
+rotation, so the directory holds at most 7 files regardless of volume. Read
+them with:
 
 ```bash
 docker compose exec db sh -c 'ls -t "$PGDATA/log/"'

--- a/backend/app/modules/admin/router_operations.py
+++ b/backend/app/modules/admin/router_operations.py
@@ -28,6 +28,7 @@ from app.modules.auth.dependencies import require_mode_permission, require_permi
 from app.modules.auth.models import ApiKey, User
 from app.platform.ratelimit import limiter
 from app.modules.auth.schemas import ApiKeyCreateResponse
+from app.standards.ogc.errors import CONFLICT_RESPONSE
 
 router = APIRouter()
 
@@ -57,6 +58,9 @@ def _api_key_response(key: ApiKey) -> AdminApiKeyListItem:
     "/api-keys/",
     response_model=ApiKeyCreateResponse,
     status_code=status.HTTP_201_CREATED,
+    # fix(#1778): a pending/suspended/deactivated
+    # target user raises 409; the published contract omitted it.
+    responses={409: CONFLICT_RESPONSE},
 )
 @limiter.limit("30/minute")
 async def create_api_key(

--- a/backend/app/modules/catalog/datasets/api/router_export.py
+++ b/backend/app/modules/catalog/datasets/api/router_export.py
@@ -74,6 +74,7 @@ from app.platform.storage.titiler_url import resolve_storage_key
 from app.standards.ogc.errors import (
     ERROR_RESPONSES_PUBLIC,
     FORBIDDEN_RESPONSE,
+    PRECONDITION_FAILED_RESPONSE,
     SERVICE_UNAVAILABLE_RESPONSE,
 )
 from app.standards.ogc.utils import normalize_language_tag, parse_accept_languages
@@ -923,7 +924,9 @@ async def _resolve_download_user(
 @router.get(
     "/{dataset_id}/download/cog",
     response_class=Response,
-    responses={403: FORBIDDEN_RESPONSE},
+    # fix(#1778): the ranged-download branch raises 412
+    # on a failed If-Match; the published contract omitted it.
+    responses={403: FORBIDDEN_RESPONSE, 412: PRECONDITION_FAILED_RESPONSE},
 )
 async def download_cog(
     dataset_id: uuid.UUID,

--- a/backend/app/processing/export/router.py
+++ b/backend/app/processing/export/router.py
@@ -48,6 +48,7 @@ from app.standards.ogc.errors import (
     FORBIDDEN_RESPONSE,
     NOT_FOUND_RESPONSE,
     PAYLOAD_TOO_LARGE_RESPONSE,
+    PRECONDITION_FAILED_RESPONSE,
 )
 
 router = APIRouter(
@@ -309,7 +310,14 @@ def _head_export_response(dataset_title: str, format_key: str) -> Response:
 # route documents nothing the canonical one does not, and publishing it would
 # churn both SDKs and the CLI.
 @router.head("/{dataset_id}/export", include_in_schema=False)
-@router.get("/{dataset_id}/export", response_class=FileResponse)
+@router.get(
+    "/{dataset_id}/export",
+    response_class=FileResponse,
+    # fix(#1778): the handler raises 412 on both the
+    # cache-hit and rebuild branches (If-Match no longer matching); the
+    # published contract omitted it.
+    responses={412: PRECONDITION_FAILED_RESPONSE},
+)
 async def export_dataset_endpoint(
     dataset_id: uuid.UUID,
     request: Request,

--- a/backend/app/standards/ogc/errors.py
+++ b/backend/app/standards/ogc/errors.py
@@ -100,6 +100,14 @@ CONFLICT_RESPONSE = {
     "description": "Conflict — resource state prevents the operation",
 }
 
+PRECONDITION_FAILED_RESPONSE = {
+    **PROBLEM_RESPONSE,
+    "description": (
+        "Precondition failed — the caller's If-Match no longer matches the "
+        "current representation"
+    ),
+}
+
 GONE_RESPONSE = {
     **PROBLEM_RESPONSE,
     "description": "Gone — the resource existed but is no longer available",

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -19299,6 +19299,16 @@
             },
             "description": "Not found"
           },
+          "409": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Conflict \u2014 resource state prevents the operation"
+          },
           "422": {
             "content": {
               "application/problem+json": {
@@ -34222,6 +34232,16 @@
             },
             "description": "Not found"
           },
+          "412": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Precondition failed \u2014 the caller's If-Match no longer matches the current representation"
+          },
           "422": {
             "content": {
               "application/problem+json": {
@@ -34414,6 +34434,16 @@
               }
             },
             "description": "Not found"
+          },
+          "412": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Precondition failed \u2014 the caller's If-Match no longer matches the current representation"
           },
           "413": {
             "content": {

--- a/backend/tests/test_api_contract_openapi.py
+++ b/backend/tests/test_api_contract_openapi.py
@@ -7,8 +7,6 @@ import inspect
 import re
 import textwrap
 
-from fastapi.routing import APIRoute
-
 from app.api.main import _iter_api_routes, app
 
 
@@ -342,26 +340,43 @@ def test_internal_pagination_prefers_skip_with_deprecated_offset_alias() -> None
 
 
 def test_direct_route_http_exceptions_are_documented() -> None:
-    """Prevent direct handler raises from drifting beyond OpenAPI responses."""
+    """Prevent direct handler raises from drifting beyond OpenAPI responses.
+
+    fix(#1778): this used to walk ``app.routes``
+    directly, which fastapi 0.140 stopped flattening for included routers —
+    the walk saw 1 of 265 operations (``/health``, which raises nothing) and
+    stayed green regardless of what the other 264 handlers raised.
+    ``_iter_api_routes`` reads the flattened table instead, and the floor
+    assertion below turns any future lazy-scan regression into a loud
+    failure rather than a silent no-op (same shape as
+    test_rule1_structural.py::test_route_walk_sees_the_full_route_table).
+    """
     spec = _openapi()
     missing: list[str] = []
+    contexts = _iter_api_routes(app)
 
-    for route in app.routes:
-        if not isinstance(route, APIRoute) or not route.include_in_schema:
+    for ctx in contexts:
+        route = ctx.route
+        if not route.include_in_schema:
             continue
         raised = _direct_http_exception_statuses(route.endpoint)
         if not raised:
             continue
         for method in route.methods or ():
-            operation = spec["paths"][route.path_format].get(method.lower())
+            operation = spec["paths"][ctx.path_format].get(method.lower())
             if operation is None:
                 continue
             documented = {
                 int(code) for code in operation["responses"] if code.isdigit()
             }
             for status_code in sorted(raised - documented):
-                missing.append(f"{method} {route.path_format}: {status_code}")
+                missing.append(f"{method} {ctx.path_format}: {status_code}")
 
+    assert len(contexts) > 200, (
+        f"route walk saw only {len(contexts)} APIRoute contexts — expected "
+        "the flattened table (>200). fastapi's lazy include_router behavior "
+        "has likely changed; fix the walk before trusting this test."
+    )
     assert missing == []
 
 

--- a/backend/tests/test_ci_alembic_filter_paths.py
+++ b/backend/tests/test_ci_alembic_filter_paths.py
@@ -11,6 +11,13 @@ It also guards the ``backend`` filter (fix(#1088)): every ``scripts/`` file a
 backend test reads by literal path must be in that filter, or the suite that
 asserts against the file skips on the very PR that changes it.
 
+fix(#1778): the currency check above only scanned for
+``scripts/...`` literals — it had no ``frontend/...`` or ``e2e/...`` half, so
+several frontend files and one e2e spec that backend cross-language/parity
+tests read by literal path drifted out of the ``backend`` filter with nothing
+noticing. Both halves now share one scanner (``_referenced_by_backend_tests``)
+parameterized by pattern.
+
 These tests run locally (filesystem + YAML parse only; no Docker, no DB).
 They are the locally-verifiable proof of the CI fix (OCG-02).
 
@@ -68,13 +75,14 @@ def _parse_alembic_filter_globs() -> list[str]:
     return _parse_filter_globs("alembic")
 
 
-def _scripts_referenced_by_backend_tests() -> dict[str, list[str]]:
-    """Map each ``scripts/`` path a backend test names to the tests naming it.
+def _referenced_by_backend_tests(pattern: re.Pattern[str]) -> dict[str, list[str]]:
+    """Map each path matching *pattern* that a backend test names to the tests
+    naming it.
 
-    Literal-path reads only. A test that shells out to a script it never names
-    is invisible here, which is the limit of this guard, not a reason to skip it.
+    Literal-path reads only. A test that shells out to (or imports) a path it
+    never names is invisible here, which is the limit of this guard, not a
+    reason to skip it.
     """
-    pattern = re.compile(r"scripts/[A-Za-z0-9_./-]+\.(?:sh|py|yml|yaml)")
     found: dict[str, list[str]] = {}
     tests_dir = REPO_ROOT / "backend" / "tests"
     for path in sorted(tests_dir.rglob("*")):
@@ -88,6 +96,30 @@ def _scripts_referenced_by_backend_tests() -> dict[str, list[str]]:
             if (REPO_ROOT / ref).is_file():
                 found.setdefault(ref, []).append(path.name)
     return found
+
+
+_SCRIPTS_PATTERN = re.compile(r"scripts/[A-Za-z0-9_./-]+\.(?:sh|py|yml|yaml)")
+
+# fix(#1778): ``tsx`` MUST precede ``ts`` in the
+# extension alternation. The greedy path class backtracks into whichever
+# alternative matches first, so ``ts`` before ``tsx`` silently resolves
+# ``AuditLogViewer.tsx`` to the nonexistent ``AuditLogViewer.ts`` — the
+# ``is_file()`` check below then drops it, which is exactly how this file
+# went uncovered by the scanner (and the filter) for as long as it did.
+_FRONTEND_PATTERN = re.compile(
+    r"(?:frontend|e2e)/[A-Za-z0-9_./-]+\.(?:tsx|ts|json|conf|js|html|md)"
+)
+
+
+def _scripts_referenced_by_backend_tests() -> dict[str, list[str]]:
+    """Map each ``scripts/`` path a backend test names to the tests naming it."""
+    return _referenced_by_backend_tests(_SCRIPTS_PATTERN)
+
+
+def _frontend_referenced_by_backend_tests() -> dict[str, list[str]]:
+    """Map each ``frontend/``/``e2e/`` path a backend test names to the tests
+    naming it."""
+    return _referenced_by_backend_tests(_FRONTEND_PATTERN)
 
 
 # ---------------------------------------------------------------------------
@@ -307,6 +339,51 @@ class TestBackendFilterCoversReferencedScripts:
             "'backend' paths-filter in .github/workflows/ci.yml. A PR changing "
             "only one of them skips Backend Tests, so the test that asserts "
             "against it never runs:\n"
+            + "\n".join(
+                f"  - {ref}  (read by {', '.join(sorted(tests))})"
+                for ref, tests in sorted(uncovered.items())
+            )
+            + "\n\nAdd each path to the 'backend' filter."
+        )
+
+    def test_frontend_or_e2e_paths_read_by_backend_tests_are_in_the_backend_filter(
+        self,
+    ):
+        """Every frontend/ or e2e/ file a backend test reads must trigger
+        Backend Tests.
+
+        fix(#1778): the currency check above only had a
+        scripts/ half. Several frontend files and one e2e spec that backend
+        cross-language/parity tests read by literal path — most notably
+        frontend/src/components/admin/AuditLogViewer.tsx, which
+        test_audit_action_registry.py's bidirectional audit-action parity
+        gate reads — were absent from the 'backend' filter with nothing
+        checking for it. A PR editing only that file matched the 'frontend'
+        filter but not 'backend', so Backend Tests skipped and the parity
+        gate never ran. Same "skipped required job reads as green" trap as
+        the scripts/ test above.
+        """
+        referenced = _frontend_referenced_by_backend_tests()
+        assert referenced, (
+            "Found no frontend/ or e2e/ references in backend/tests — the "
+            "scan is probably broken, since several tests read them by "
+            "literal path."
+        )
+
+        globs = _parse_filter_globs("backend")
+        covered: set[str] = set()
+        for pattern in globs:
+            for match in glob.glob(str(REPO_ROOT / pattern), recursive=True):
+                covered.add(str(pathlib.Path(match).relative_to(REPO_ROOT)))
+
+        uncovered = {
+            ref: tests for ref, tests in referenced.items() if ref not in covered
+        }
+        assert not uncovered, (
+            "These frontend/ or e2e/ files are read by backend tests but are "
+            "NOT in the 'backend' paths-filter in .github/workflows/ci.yml. A "
+            "PR changing only one of them skips Backend Tests, so the test "
+            "that asserts against it never runs:\n"
             + "\n".join(
                 f"  - {ref}  (read by {', '.join(sorted(tests))})"
                 for ref, tests in sorted(uncovered.items())

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -2159,7 +2159,10 @@ _OPEN_CORE_SIZE_CAPS: dict[str, int] = {
     # fix(#1204): +20 lines — the published-maps listing takes sort/order as
     # closed enums, with the descriptions that say which columns are absent
     # (link status) and why.
-    "backend/app/modules/admin/router_operations.py": 316,
+    # fix(#1778): +4 lines — POST /admin/api-keys/
+    # documents the 409 it raises for a pending/suspended/deactivated
+    # target user, closing a gap the repaired OpenAPI-contract gate surfaced.
+    "backend/app/modules/admin/router_operations.py": 320,
     # PRIV-1: +7 lines — GET /settings/branding/ also resolves and returns
     # PRIVACY_URL, so the login/register privacy-policy link is admin
     # configurable instead of a hardcoded getgeolens.com URL.
@@ -4484,7 +4487,10 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # through the existing PyJWTError path instead of falling through to the
     # new anonymous return None as if no token were supplied. Cap
     # 1490 -> 1548, exact.
-    "backend/app/modules/catalog/datasets/api/router_export.py": 1548,
+    # fix(#1778): +3 lines — download_cog documents the
+    # 412 its If-Match branch raises, closing a gap the repaired
+    # OpenAPI-contract gate surfaced. Cap 1548 -> 1551, exact.
+    "backend/app/modules/catalog/datasets/api/router_export.py": 1551,
     # fix(#1532 review r29): first entry — crossed _RATCHET_INCLUSION_LOC. The
     # export artifact cache: everything is in the key (stamp, size, digest,
     # nonce), freshness and reclamation read one publication bound that is a

--- a/backend/tests/test_redirect_slashes.py
+++ b/backend/tests/test_redirect_slashes.py
@@ -264,35 +264,60 @@ class TestAllTrailingSlashRoutesAcceptBothShapes:
     async def test_every_trailing_slash_route_has_no_slash_sibling(
         self,
     ) -> None:
-        """Enumerate app.routes and assert dual-shape coverage.
+        """Enumerate the flattened route table and assert dual-shape coverage.
 
         The sweep covers ALL trailing-slash registered routes under
         ``/api/``. Adding a new trailing-slash-only route without a
         sibling will fail this test, surfacing the missing alias.
-        """
-        from app.api.main import app
-        from fastapi.routing import APIRoute
 
-        # Collect (method, path) for every APIRoute.
+        fix(#1778): this used to walk ``app.routes``
+        directly (``isinstance(route, APIRoute)``), which fastapi 0.140
+        stopped flattening for included routers — the walk saw 0 of 168
+        real trailing-slash (method, path) pairs and stayed green
+        regardless of coverage. ``_iter_api_routes`` reads the flattened
+        table, and ``ctx.path`` (not ``ctx.route.path``) carries the
+        parent-router prefix nested includes drop. The floor assertions
+        below turn a future lazy-scan regression into a loud failure
+        rather than a silent no-op (same shape as
+        test_rule1_structural.py::test_route_walk_sees_the_full_route_table).
+        """
+        from app.api.main import _iter_api_routes, app
+
+        contexts = _iter_api_routes(app)
+
+        # Collect (method, path) for every APIRoute, from the flattened walk.
         registered: set[tuple[str, str]] = set()
-        for route in app.routes:
-            if not isinstance(route, APIRoute):
-                continue
-            for method in route.methods:
+        for ctx in contexts:
+            for method in ctx.route.methods:
                 if method in ("HEAD", "OPTIONS"):
                     # FastAPI auto-adds HEAD for GET routes; skip noise.
                     continue
-                registered.add((method, route.path))
+                registered.add((method, ctx.path))
 
         # For every trailing-slash route (excluding the root ``/``), the
         # no-slash sibling must also be registered for the same method.
         missing: list[tuple[str, str]] = []
+        trailing_slash_pairs = 0
         for method, path in sorted(registered):
             if not path.endswith("/") or path == "/":
                 continue
+            trailing_slash_pairs += 1
             no_slash = path.rstrip("/")
             if (method, no_slash) not in registered:
                 missing.append((method, path))
+
+        assert len(contexts) > 200, (
+            f"route walk saw only {len(contexts)} APIRoute contexts — "
+            "expected the flattened table (>200). fastapi's lazy "
+            "include_router behavior has likely changed; fix the walk "
+            "before trusting this test."
+        )
+        assert trailing_slash_pairs > 100, (
+            f"route walk saw only {trailing_slash_pairs} trailing-slash "
+            "(method, path) pairs — expected the flattened table (>100). "
+            "fastapi's lazy include_router behavior has likely changed; "
+            "fix the walk before trusting this test."
+        )
 
         assert not missing, (
             f"ROUTE-01 dual-shape coverage gap: {len(missing)} "

--- a/db/postgresql.conf
+++ b/db/postgresql.conf
@@ -62,6 +62,15 @@ auto_explain.log_format = text
 # Kept on deliberately: log files survive container restarts and rotate daily.
 logging_collector = on
 log_destination = 'stderr'
+# fix(#1778): with none of the four settings below set,
+# unset params fall back to the compiled-in defaults (timestamped filename,
+# truncate off), so the collector rotated but never reclaimed — the pgdata
+# volume filled without bound. Naming the file by day-of-week and truncating
+# on rotation caps the directory at 7 files regardless of volume.
+log_filename = 'postgresql-%a.log'
+log_truncate_on_rotation = on
+log_rotation_age = 1d
+log_rotation_size = 0
 
 # ---------------------------------------------------------------------------
 # Planner

--- a/db/postgresql.conf
+++ b/db/postgresql.conf
@@ -66,7 +66,26 @@ log_destination = 'stderr'
 # unset params fall back to the compiled-in defaults (timestamped filename,
 # truncate off), so the collector rotated but never reclaimed — the pgdata
 # volume filled without bound. Naming the file by day-of-week and truncating
-# on rotation caps the directory at 7 files regardless of volume.
+# on rotation caps the directory at 7 files regardless of volume. This is
+# PostgreSQL's own documented seven-day scheme (Logfile Maintenance,
+# https://www.postgresql.org/docs/current/logfile-maintenance.html), not a
+# bespoke one.
+#
+# fix(#1783 review r1 P1): does a restart before 24h uptime (a daily
+# deploy, a crash loop) skip the time-based rotation this truncation needs?
+# No, for the ordinary case. syslogger's set_next_rotation_time()
+# (src/backend/postmaster/syslogger.c) aligns the next rotation to a
+# multiple of log_rotation_age measured from local midnight, not from
+# process start, and recomputes that alignment fresh on every syslogger
+# startup. An instance that is up at local midnight rotates (and truncates)
+# then, regardless of how long it has been running — a daily deploy that
+# stays up past midnight is unaffected. log_rotation_size = 0 disables
+# size-based rotation entirely, so the only remaining gap is documented, not
+# silent: log_truncate_on_rotation never fires on server startup or
+# size-based rotation, only on time-based rotation, so a crash loop that
+# never keeps the server up across a single midnight boundary appends to
+# that weekday's file for the duration of the loop; the first midnight the
+# server is up for truncates it back to empty.
 log_filename = 'postgresql-%a.log'
 log_truncate_on_rotation = on
 log_rotation_age = 1d

--- a/frontend/src/types/api.generated.ts
+++ b/frontend/src/types/api.generated.ts
@@ -13972,6 +13972,15 @@ export interface operations {
                     "application/problem+json": components["schemas"]["ProblemDetail"];
                 };
             };
+            /** @description Conflict — resource state prevents the operation */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ProblemDetail"];
+                };
+            };
             /** @description Validation error */
             422: {
                 headers: {
@@ -23885,6 +23894,15 @@ export interface operations {
                     "application/problem+json": components["schemas"]["ProblemDetail"];
                 };
             };
+            /** @description Precondition failed — the caller's If-Match no longer matches the current representation */
+            412: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ProblemDetail"];
+                };
+            };
             /** @description Validation error */
             422: {
                 headers: {
@@ -23981,6 +23999,15 @@ export interface operations {
             };
             /** @description Not found */
             404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ProblemDetail"];
+                };
+            };
+            /** @description Precondition failed — the caller's If-Match no longer matches the current representation */
+            412: {
                 headers: {
                     [name: string]: unknown;
                 };

--- a/sdks/python/geolens/api/admin/create_api_key_admin_api_keys_post.py
+++ b/sdks/python/geolens/api/admin/create_api_key_admin_api_keys_post.py
@@ -59,6 +59,11 @@ def _parse_response(
 
         return response_404
 
+    if response.status_code == 409:
+        response_409 = ProblemDetail.from_dict(response.json())
+
+        return response_409
+
     if response.status_code == 422:
         response_422 = ProblemDetail.from_dict(response.json())
 

--- a/sdks/python/geolens/api/datasets/export_dataset_endpoint_datasets_dataset_id_export_get.py
+++ b/sdks/python/geolens/api/datasets/export_dataset_endpoint_datasets_dataset_id_export_get.py
@@ -92,6 +92,11 @@ def _parse_response(
 
         return response_404
 
+    if response.status_code == 412:
+        response_412 = ProblemDetail.from_dict(response.json())
+
+        return response_412
+
     if response.status_code == 413:
         response_413 = ProblemDetail.from_dict(response.json())
 

--- a/sdks/python/geolens/api/datasets_export/download_cog_datasets_dataset_id_download_cog_get.py
+++ b/sdks/python/geolens/api/datasets_export/download_cog_datasets_dataset_id_download_cog_get.py
@@ -53,6 +53,11 @@ def _parse_response(
 
         return response_404
 
+    if response.status_code == 412:
+        response_412 = ProblemDetail.from_dict(response.json())
+
+        return response_412
+
     if response.status_code == 422:
         response_422 = ProblemDetail.from_dict(response.json())
 

--- a/sdks/typescript/src/client/types.gen.ts
+++ b/sdks/typescript/src/client/types.gen.ts
@@ -11344,6 +11344,10 @@ export type CreateApiKeyAdminApiKeysPostErrors = {
      */
     404: ProblemDetail;
     /**
+     * Conflict — resource state prevents the operation
+     */
+    409: ProblemDetail;
+    /**
      * Validation error
      */
     422: ProblemDetail;
@@ -17573,6 +17577,10 @@ export type DownloadCogDatasetsDatasetIdDownloadCogGetErrors = {
      */
     404: ProblemDetail;
     /**
+     * Precondition failed — the caller's If-Match no longer matches the current representation
+     */
+    412: ProblemDetail;
+    /**
      * Validation error
      */
     422: ProblemDetail;
@@ -17651,6 +17659,10 @@ export type ExportDatasetEndpointDatasetsDatasetIdExportGetErrors = {
      * Not found
      */
     404: ProblemDetail;
+    /**
+     * Precondition failed — the caller's If-Match no longer matches the current representation
+     */
+    412: ProblemDetail;
     /**
      * Payload too large
      */


### PR DESCRIPTION
Addresses four findings from the codebase audit 2026-08-30 (8dc529f17), tracked in #1778.

## Repair the two vacuous route-table gates

Register titles: "The gate that keeps handler-raised statuses in the OpenAPI contract inspects 1 of 265 operations" and "ROUTE-01's dual-shape enumeration inspects 0 of 168 trailing-slash routes — the same 'iterated app.routes' vacuity as the API-contract gate, in a second file."

`test_direct_route_http_exceptions_are_documented` (test_api_contract_openapi.py) and `test_every_trailing_slash_route_has_no_slash_sibling` (test_redirect_slashes.py) both walked `app.routes` directly. fastapi 0.140 stopped flattening `include_router`, so the walks saw 1 of 265 operations and 0 of 168 trailing-slash pairs while staying green. Both now use `_iter_api_routes(app)` and carry a floor assertion (`len(contexts) > 200`, the same shape `test_rule1_structural.py` already uses), so a future fastapi change that empties the walk fails loudly instead of passing vacuously.

Repairing the OpenAPI-contract gate surfaced three handler-raised statuses missing from the published contract:

- `POST /admin/api-keys/` raises 409 for a pending/suspended/deactivated target user.
- `GET /datasets/{dataset_id}/export` raises 412 on a failed If-Match, on both the cache-hit and rebuild branches.
- `GET /datasets/{dataset_id}/download/cog` raises 412 on a failed If-Match in the ranged-download branch.

Documented all three with `responses=` on the handlers, added a `PRECONDITION_FAILED_RESPONSE` constant next to the existing `CONFLICT_RESPONSE` in `standards/ogc/errors.py`, and regenerated `backend/openapi.json`, both SDKs, and `frontend/src/types/api.generated.ts`.

Repairing the redirect-slashes gate surfaced no real misses: `_register_no_slash_aliases` already produces a correct result over the full 168-pair table, so no alias registrations were needed there.

## Close the CI paths-filter hole

Register title: "The `backend` paths-filter hand-lists 8 frontend files; 3 more are read by cross-language gates and are absent, and the currency test covers only the `scripts/` half."

`.github/workflows/ci.yml`'s `backend` filter hand-lists frontend files that backend parity/cross-language tests read by literal path, so an edit to only one of those files would otherwise skip Backend Tests while the `frontend` filter still matched. I grepped `backend/tests` for every `frontend/` and `e2e/` literal path and read each hit to confirm which were genuine `.read_text()` reads versus docstring cross-references. Four frontend files and one e2e spec were genuinely read and missing from the filter, most notably `AuditLogViewer.tsx`, which the bidirectional audit-action parity gate reads. `frontend/README.md`, read by `test_phase_275_frontend_readme.py`, was also missing. I also found four more frontend files referenced only in docstrings, not read; rather than special-case those out of the currency scan below, I added them to the filter too, so the scan's necessarily coarse literal-path match and the filter can never drift apart.

`test_ci_alembic_filter_paths.py`'s existing currency check (`test_scripts_read_by_backend_tests_are_in_the_backend_filter`) only had a `scripts/` half. Generalized its scanner (`_referenced_by_backend_tests`, parameterized by pattern) and added a sibling test for the `frontend/`/`e2e/` half. One thing to watch if this pattern is copied again: the extension alternation must list `tsx` before `ts`, because the greedy path character class backtracks into whichever extension matches first, and `ts` before `tsx` silently resolves `AuditLogViewer.tsx` to the nonexistent `AuditLogViewer.ts`, which is how this file went uncovered by both the scanner and the filter.

## Cap unbounded PostgreSQL log growth

Register title: "logging_collector is on with no log_filename/rotation/truncate settings, so PostgreSQL's log directory grows without bound inside the pgdata volume — and it is the one log in the stack the #1690 Docker cap structurally cannot bound."

`db/postgresql.conf` had `logging_collector = on` with no `log_filename`/`log_rotation_age`/`log_rotation_size`/`log_truncate_on_rotation`, so unset parameters fell back to PostgreSQL's compiled-in defaults: a timestamped filename and truncate-on-rotation off. The collector rotated but never reclaimed, so the log directory inside the pgdata volume grew without bound. Added the four settings (day-of-week filename, truncate on rotation, daily age, no size-based rotation to avoid colliding with the day-of-week name), capping the directory at 7 files regardless of volume. Updated the "PostgreSQL server logs" section of RUNBOOK.md to describe the new bound.

## Left alone

- `backend/tests/test_layering.py:845-851` (the façade-guard private-module-set currency finding in the same register excerpt) is still present on main but was not named in this lane's deliverable, so it is untouched.
- `.github/workflows/verify-published.yml` and `infra/demo/logging-override.yml` (both in the register excerpt, both out of this lane's scope) are untouched.
- The auto_explain accelerant the postgres finding's recommendation also mentions (100ms threshold with log_analyze/log_buffers) is a separate change not asked for here; left alone.

None of the four findings in this lane's scope were already fixed on main; all four were still present and reproducible before this change.

## Verification

- `cd backend && uv run pytest tests/test_api_contract_openapi.py tests/test_redirect_slashes.py -q` -- 23 passed, 8 passed
- `cd backend && uv run pytest tests/test_ci_alembic_filter_paths.py -q` -- 10 passed
- `cd backend && uv run pytest tests/test_layering.py -q` -- 47 passed
- `cd backend && uv run pytest tests/test_sdks_round_trip.py -q` -- 15 passed, 1 skipped
- `cd backend && uv run pytest tests/test_phase_271_postgresql_conf.py tests/test_conftest_pool_sizing.py tests/test_phase_274_caches_and_pool.py -q` -- 37 passed
- `cd backend && uv run pytest tests/test_admin_user_operations.py tests/test_api_key_scope_875.py tests/test_api_key_auth.py tests/test_alert_rules.py tests/test_cog_s3_head_wire_1540.py tests/test_cog_download_access.py tests/test_cog_head_ranges_1528.py tests/test_cog_vsicurl_1528.py tests/test_cors_range_headers_1540.py tests/test_dcat.py tests/test_download_token.py tests/test_export_head_1513.py tests/test_export_artifact_cache_1532.py tests/test_phase_273_cog_redirect_revalidate.py tests/test_phase_273_download_token.py -q` (downstream consumers of the three touched routers) -- 400 passed, 4 skipped
- `cd backend && uv run ruff check . && uv run ruff format --check .` -- both clean
- `make openapi-check` -- clean
- `make sdks` then `make sdks-check` -- clean (includes `npm run build && npm test` in sdks/typescript)
- `cd frontend && npm run typecheck && npm run lint && npm run test:i18n` -- all clean

Two size caps in `test_layering.py` needed raising for the new `responses=` lines: `backend/app/modules/admin/router_operations.py` 316 -> 320, `backend/app/modules/catalog/datasets/api/router_export.py` 1548 -> 1551.

No schema/API changes beyond the three `responses=` additions above (no new fields, no behavior change; the statuses were already being raised at runtime).
