### PR TITLE
fix(ingest): decide the publish reap by observation, not by the commit's ack

### DIFF
--- a/backend/app/processing/ingest/tasks_common.py
+++ b/backend/app/processing/ingest/tasks_common.py
@@ -1146,7 +1146,7 @@ async def _cleanup_staging_on_failure(
     task_name: str,
     attempt_id: uuid.UUID | None = None,
 ) -> None:
-    """Roll back, drop staging table, and mark job as failed.
+    """Mark the job failed, then drop the staging table, in that order.
 
     Shared by ``reupload_file`` and ``reupload_service`` which have
     structurally identical exception handlers, and — fix(#1778) — by the
@@ -1164,6 +1164,15 @@ async def _cleanup_staging_on_failure(
     name skips the DROP outright, because interpolating it raises inside the
     best-effort guard below, which would log a cleanup failure on every VRT
     build failure and say nothing true.
+
+    fix(#1778 codex r2): the ORDER is the contract. The failure row is
+    written and committed BEFORE the drop is attempted, because a statement
+    error aborts the whole PostgreSQL transaction and every later statement
+    on that session raises until it is rolled back. With the drop first, a
+    lock or statement timeout on it took the failure write down with it and
+    the job sat `running` with no reason recorded. Anything added here that
+    can fail belongs after the commit, in its own guarded block, with a
+    rollback of its own wreckage.
     """
     from sqlalchemy import text
     from sqlalchemy import update as sa_update
@@ -1182,21 +1191,6 @@ async def _cleanup_staging_on_failure(
     # that dispatch on its type or re-raise it are unaffected.
     error_message = redact_url_credentials(str(exc))
     await session.rollback()
-    try:
-        if staging_table:
-            await session.execute(
-                text(
-                    f"DROP TABLE IF EXISTS {_qtable(staging_table, schema=_current_tenant_schema())}"
-                )
-            )
-            await session.commit()
-    except Exception as cleanup_exc:  # broad: cleanup is best-effort after rollback; DB may be in bad state
-        structlog.get_logger().warning(
-            f"Staging-table cleanup failed during {task_name} failure",
-            staging_table=staging_table,
-            cleanup_error=str(cleanup_exc),
-            original_error=str(exc),
-        )
 
     failure_update = sa_update(type(job)).where(type(job).id == job_id)
     if attempt_id is not None:
@@ -1218,6 +1212,43 @@ async def _cleanup_staging_on_failure(
         )
     )
     await session.commit()
+
+    # fix(#1778 codex r2): the DROP runs AFTER the failure row is committed,
+    # not before it. PostgreSQL aborts the whole transaction on any statement
+    # error, so a drop that hit a lock or statement timeout left this session
+    # unusable and the failure UPDATE that followed it raised
+    # `current transaction is aborted` — the job stayed `running` until the
+    # stale sweep and the reason nobody recorded was the one the user needed.
+    # A best-effort cleanup must never be able to swallow the write it
+    # precedes, so it goes last and rolls back its own wreckage.
+    #
+    # Placed before the rowcount return so this attempt's table is dropped
+    # even when a newer attempt already owns the job row: the name is
+    # attempt-scoped, so it is ours to clean up either way.
+    if staging_table:
+        try:
+            await session.execute(
+                text(
+                    f"DROP TABLE IF EXISTS {_qtable(staging_table, schema=_current_tenant_schema())}"
+                )
+            )
+            await session.commit()
+        except Exception as cleanup_exc:  # broad: best-effort cleanup
+            structlog.get_logger().warning(
+                f"Staging-table cleanup failed during {task_name} failure",
+                staging_table=staging_table,
+                cleanup_error=str(cleanup_exc),
+                original_error=str(exc),
+            )
+            try:
+                await session.rollback()
+            except Exception:  # broad: a dead connection cannot be rolled back
+                structlog.get_logger().warning(
+                    "staging_cleanup_rollback_failed",
+                    staging_table=staging_table,
+                    task=task_name,
+                )
+
     if attempt_id is not None and not result.rowcount:
         return
     job.status = "failed"

--- a/backend/app/processing/ingest/tasks_common.py
+++ b/backend/app/processing/ingest/tasks_common.py
@@ -1149,7 +1149,21 @@ async def _cleanup_staging_on_failure(
     """Roll back, drop staging table, and mark job as failed.
 
     Shared by ``reupload_file`` and ``reupload_service`` which have
-    structurally identical exception handlers.
+    structurally identical exception handlers, and — fix(#1778) — by the
+    import tasks that used to paste a narrower copy of the terminal write.
+    What the copies were missing is what makes this the one place to fail a
+    job: the
+    ``redact_url_credentials`` backstop on the persisted message, the
+    ``pending``-inclusive attempt fence (fix #1274 review: a worker-time
+    refusal that raises before the claim must still finalize the job it owns,
+    rather than leave it pending until the stale sweep), and the
+    ``ingest_failed`` notification an operator has switched on.
+
+    fix(#1778): ``staging_table`` is "" for the paths that have none (the VRT
+    tail, whose artifacts are object keys its own ``finally`` reaps). An empty
+    name skips the DROP outright, because interpolating it raises inside the
+    best-effort guard below, which would log a cleanup failure on every VRT
+    build failure and say nothing true.
     """
     from sqlalchemy import text
     from sqlalchemy import update as sa_update
@@ -1169,12 +1183,13 @@ async def _cleanup_staging_on_failure(
     error_message = redact_url_credentials(str(exc))
     await session.rollback()
     try:
-        await session.execute(
-            text(
-                f"DROP TABLE IF EXISTS {_qtable(staging_table, schema=_current_tenant_schema())}"
+        if staging_table:
+            await session.execute(
+                text(
+                    f"DROP TABLE IF EXISTS {_qtable(staging_table, schema=_current_tenant_schema())}"
+                )
             )
-        )
-        await session.commit()
+            await session.commit()
     except Exception as cleanup_exc:  # broad: cleanup is best-effort after rollback; DB may be in bad state
         structlog.get_logger().warning(
             f"Staging-table cleanup failed during {task_name} failure",

--- a/backend/app/processing/ingest/tasks_raster.py
+++ b/backend/app/processing/ingest/tasks_raster.py
@@ -38,6 +38,7 @@ from app.processing.ingest.tasks_raster_common import (
     _is_manifest_vrt_job,
     _reject_raw_vrt_job,
     _resolve_managed_raster_storage_keys,
+    absorb_cancellation,
     create_raster_dataset,
     extract_source_raster_metadata,
     publish_commit_landed,
@@ -632,15 +633,24 @@ async def ingest_raster(
             )
             try:
                 await session.commit()
-            except BaseException:
+            except BaseException as exc:
                 # fix(#1778): the one await on this path whose outcome is
                 # genuinely unknown — see `publish_commit_landed`. A lost
                 # acknowledgement left the reap below deleting the COG and
                 # quicklooks the committed RasterAsset had just been pointed at.
-                publish_committed = await publish_commit_landed(
+                if not await publish_commit_landed(
                     job_uuid, attempt_uuid, job_id=job_id, task="ingest_raster"
-                )
-                raise
+                ):
+                    raise
+                # fix(#1778 codex r1): stand down rather than re-raise. The
+                # dataset is durable, and the handler below would send the
+                # operator an `ingest_failed` notification for an ingest that
+                # succeeded. `final_status` deliberately stays non-complete:
+                # it also licenses deleting the uploader's staged original,
+                # and a probe answer must never reach that decision.
+                publish_committed = True
+                absorb_cancellation(exc)
+                return
             publish_committed = True
             final_status = "complete"
 
@@ -684,6 +694,21 @@ async def ingest_raster(
             )
 
     except Exception as exc:  # broad: raster ingest spans GDAL/COG/Titiler — any step can fail; record failure
+        if publish_committed:
+            # fix(#1778 codex r1): the second way this handler is reached with
+            # a durable publish behind it, and the one the stand-down above
+            # cannot cover: the optional post-commit block runs inside the same
+            # try, so a Valkey outage or a busy queue lands here after the
+            # dataset is live. Everything below states that the ingest failed,
+            # including the operator's `ingest_failed` mail, and none of it is
+            # true. Log and finish.
+            structlog.get_logger().warning(
+                "raster_post_publish_followup_failed",
+                job_id=job_id,
+                task="ingest_raster",
+                exc_info=True,
+            )
+            return
         structlog.get_logger().exception(
             "Ingest task failed",
             job_id=job_id,

--- a/backend/app/processing/ingest/tasks_raster.py
+++ b/backend/app/processing/ingest/tasks_raster.py
@@ -40,6 +40,7 @@ from app.processing.ingest.tasks_raster_common import (
     _resolve_managed_raster_storage_keys,
     create_raster_dataset,
     extract_source_raster_metadata,
+    publish_commit_landed,
 )
 from app.processing.ingest.tasks_common import (
     _bind_task_log_context,
@@ -125,6 +126,13 @@ async def ingest_raster(
     # never reaps these assets. Track them and clean up on the failure path so a
     # crash mid-ingest doesn't orphan COG/quicklook bytes under rasters/.
     written_storage_keys: list[str] = []
+    # fix(#1778): "the COG and quicklooks are published", set at the terminal
+    # commit and nowhere else. The reap below keys off THIS rather than off
+    # `final_status`, for the reason fix(#1290 review) gives in the replace
+    # tail: `final_status` also carries "did anything go wrong afterwards",
+    # which is not a question about the objects, and the broad handler sets it
+    # to "failed" even when the failure happened after the swap was durable.
+    publish_committed: bool = False
     heartbeat_task: asyncio.Task[None] | None = None
 
     try:
@@ -622,7 +630,18 @@ async def ingest_raster(
                     "progress": 1.0,
                 },
             )
-            await session.commit()
+            try:
+                await session.commit()
+            except BaseException:
+                # fix(#1778): the one await on this path whose outcome is
+                # genuinely unknown — see `publish_commit_landed`. A lost
+                # acknowledgement left the reap below deleting the COG and
+                # quicklooks the committed RasterAsset had just been pointed at.
+                publish_committed = await publish_commit_landed(
+                    job_uuid, attempt_uuid, job_id=job_id, task="ingest_raster"
+                )
+                raise
+            publish_committed = True
             final_status = "complete"
 
             # EVENT-02: notify on ingest complete (non-fatal, after commit — deferred import).
@@ -726,7 +745,7 @@ async def ingest_raster(
         # row those keys belong to was rolled back — delete_dataset will never
         # reap them. Remove them here so a crash/commit-failure mid-ingest does
         # not leave bytes under a rasters/{dataset_id}/ prefix with no DB row.
-        if final_status != "complete" and written_storage_keys:
+        if not publish_committed and written_storage_keys:
             await _cleanup_orphaned_storage_keys(written_storage_keys, job_id=job_id)
         # Clean up temp COG dir
         if tmp_dir:

--- a/backend/app/processing/ingest/tasks_raster.py
+++ b/backend/app/processing/ingest/tasks_raster.py
@@ -648,6 +648,12 @@ async def ingest_raster(
                 # succeeded. `final_status` deliberately stays non-complete:
                 # it also licenses deleting the uploader's staged original,
                 # and a probe answer must never reach that decision.
+                #
+                # fix(#1778 codex r2): nothing to reap on the way out. A first
+                # ingest supersedes no asset, so the followups this skips are
+                # the completion notification, the cache purge, the embedding
+                # defer and the metering event: all recoverable, none of them
+                # holding bytes that no row references.
                 publish_committed = True
                 absorb_cancellation(exc)
                 return

--- a/backend/app/processing/ingest/tasks_raster_common.py
+++ b/backend/app/processing/ingest/tasks_raster_common.py
@@ -18,6 +18,7 @@ from datetime import datetime, timezone
 from typing import Any
 
 import structlog
+from sqlalchemy import select
 
 from app.platform.dataset_origin import set_dataset_origin
 from app.processing.raster.cog import check_cog_compliance, extract_raster_metadata
@@ -391,3 +392,72 @@ async def _cleanup_orphaned_storage_keys(keys: list[str], *, job_id: str) -> Non
                 job_id=job_id,
                 storage_key=key,
             )
+
+
+async def publish_commit_landed(
+    job_uuid: uuid.UUID,
+    attempt_uuid: uuid.UUID,
+    *,
+    job_id: str,
+    task: str,
+) -> bool:
+    """Did the publishing commit durably land, despite the raise?
+
+    fix(#1778): #1708 codex r11's reasoning, applied to the raster and VRT
+    publish tails. A commit whose acknowledgement is lost — a dropped
+    connection, or the ``asyncio.CancelledError`` a cancel request delivers,
+    which is a BaseException the tails' ``except Exception`` never sees but
+    which their ``finally`` still runs through — may have been applied by
+    PostgreSQL all the same. Each tail set its "published" flag on the line
+    after that await, so a lost acknowledgement left the flag false and the
+    terminal cleanup deleted the exact object keys the committed row had just
+    been pointed at. Nothing
+    reclaims that: the superseded objects are still in the bucket but no row
+    points at them, so every tile request, download and STAC asset 404s until
+    an operator lists the prefix by hand.
+
+    So decide by OBSERVATION rather than by the await's outcome: read the job
+    row back on a FRESH session (the publishing session is mid-failure and
+    cannot be trusted to see anything) and ask whether this attempt's terminal
+    write is there. ``status == 'complete'`` for this exact ``attempt_id`` is
+    the signal all four of these tails can share, because every one of them
+    stamps it in the SAME transaction as the pointer swap: seeing it means the
+    swap is durable, and no other attempt can have produced it, because the
+    attempt token is fresh per attempt and each of these tasks is ``retry=0``.
+
+    A probe that itself fails returns True — standing down. The asymmetry is
+    deliberate and is #1708's: standing down on a false positive leaves objects
+    behind that an operator or a later sweep can still remove, while proceeding
+    on a false negative deletes the live raster.
+
+    Callers gate ONLY the orphaned-key cleanup on this. It is deliberately not
+    folded into ``final_status``, which also decides whether the uploader's
+    staged original may be deleted — standing down there would turn a probe
+    failure into a second, worse deletion.
+    """
+    # fix(#909)-style late bind so tests' engine patching is honored.
+    import app.core.db as db_module
+
+    from app.platform.jobs.models import IngestJob
+
+    try:
+        async with db_module.async_session() as probe:
+            status = (
+                await probe.execute(
+                    select(IngestJob.status).where(
+                        IngestJob.id == job_uuid,
+                        IngestJob.attempt_id == attempt_uuid,
+                    )
+                )
+            ).scalar_one_or_none()
+    except BaseException:
+        structlog.get_logger().warning(
+            "publish_commit_probe_failed", job_id=job_id, task=task
+        )
+        return True
+    landed = status == "complete"
+    if landed:
+        structlog.get_logger().warning(
+            "publish_commit_ack_lost_but_landed", job_id=job_id, task=task
+        )
+    return landed

--- a/backend/app/processing/ingest/tasks_raster_common.py
+++ b/backend/app/processing/ingest/tasks_raster_common.py
@@ -12,6 +12,7 @@ module, which is the kind of reach-across that makes a later split harder than
 it needs to be. They have one home now.
 """
 
+import asyncio
 import os
 import uuid
 from datetime import datetime, timezone
@@ -430,10 +431,21 @@ async def publish_commit_landed(
     behind that an operator or a later sweep can still remove, while proceeding
     on a false negative deletes the live raster.
 
-    Callers gate ONLY the orphaned-key cleanup on this. It is deliberately not
-    folded into ``final_status``, which also decides whether the uploader's
-    staged original may be deleted — standing down there would turn a probe
-    failure into a second, worse deletion.
+    fix(#1778 codex r1): a caller that gets True stands DOWN, returning
+    normally rather than re-raising into its failure handler. Gating only the
+    orphaned-key cleanup was not enough, because the handler it still entered
+    writes about a job that succeeded: ``regenerate_vrt`` reloaded the now
+    ``completed`` ``VrtGeneration`` and stamped it ``failed``, which
+    ``get_vrt_status`` reads as "this dataset has no completed generation" and
+    the stale-generation sweep reads as evidence the asset was unhealthy.
+    Nothing is lost by returning: the terminal write is durable, and the only
+    work skipped is the post-commit best-effort block those tails already
+    treat as unfailable.
+
+    What the caller must NOT do is set ``final_status`` from this. That string
+    also decides whether the uploader's staged original may be deleted, and
+    standing down there would turn a probe failure into a second, worse
+    deletion.
     """
     # fix(#909)-style late bind so tests' engine patching is honored.
     import app.core.db as db_module
@@ -461,3 +473,22 @@ async def publish_commit_landed(
             "publish_commit_ack_lost_but_landed", job_id=job_id, task=task
         )
     return landed
+
+
+def absorb_cancellation(exc: BaseException) -> None:
+    """Clear the pending cancellation a stand-down is about to stop honouring.
+
+    fix(#1778 codex r1): a tail that observes its publish landed returns
+    normally instead of re-raising, so on the cancel half of the finding it
+    swallows the ``asyncio.CancelledError`` that #1709's ``abort=True``
+    delivers. Suppressing a cancellation without saying so leaves
+    ``Task.cancelling()`` above zero, and that count is what a
+    structured-concurrency parent reads to decide whether its own body was
+    cancelled rather than merely interrupted. Every other exception type is
+    left alone, and a call outside a running task is a no-op.
+    """
+    if not isinstance(exc, asyncio.CancelledError):
+        return
+    task = asyncio.current_task()
+    if task is not None:
+        task.uncancel()

--- a/backend/app/processing/ingest/tasks_raster_replace.py
+++ b/backend/app/processing/ingest/tasks_raster_replace.py
@@ -73,6 +73,7 @@ from app.processing.ingest.tasks_raster_common import (
     _enforce_strict_cog,
     _resolve_managed_raster_storage_keys,
     extract_source_raster_metadata,
+    publish_commit_landed,
 )
 from app.processing.ingest.tasks_raster_swap import (
     _prior_asset_keys_to_reap,
@@ -684,7 +685,18 @@ async def reupload_raster(
                 schema_diff=None,
                 contacted_origin=False,
             )
-            await session.commit()
+            try:
+                await session.commit()
+            except BaseException:
+                # fix(#1778): the one await on this path whose outcome is
+                # genuinely unknown — see `publish_commit_landed`. A lost
+                # acknowledgement left the flag below false, and the terminal
+                # cleanup then deleted the three keys the committed
+                # RasterAsset had just been pointed at.
+                swap_committed = await publish_commit_landed(
+                    job_uuid, attempt_uuid, job_id=job_id, task="reupload_raster"
+                )
+                raise
             # fix(#1290 review): set in the same breath as the commit, and read
             # by the terminal cleanup instead of `final_status`. These are two
             # different facts and the cleanup needs this one: "the replacement

--- a/backend/app/processing/ingest/tasks_raster_replace.py
+++ b/backend/app/processing/ingest/tasks_raster_replace.py
@@ -82,7 +82,7 @@ from app.processing.ingest.tasks_raster_swap import (
     archived_original_asset_key,
     upsert_archived_original_row,
     reserve_replacement_bytes,
-    _run_post_swap_followups,
+    run_post_swap_followups_best_effort,
     _upsert_managed_asset_rows,
     _write_swapped_fields,
 )
@@ -705,6 +705,22 @@ async def reupload_raster(
                 # never reach that decision.
                 swap_committed = True
                 absorb_cancellation(exc)
+                # fix(#1778 codex r2): standing down from the FAILURE handler
+                # is not standing down from the success work. This call is the
+                # only deletion of the superseded COG and quicklooks, and the
+                # committed pointer already names the new keys, so returning
+                # without it strands three objects no row references and no
+                # quota counts — once per lost acknowledgement, for the life of
+                # the dataset. The helper carries its own fence, so a followup
+                # that fails still ends in this return.
+                await run_post_swap_followups_best_effort(
+                    dataset_uuid=dataset_uuid,
+                    dataset_cls=Dataset,
+                    prior_physical_keys=prior_physical_keys,
+                    written_storage_keys=written_storage_keys,
+                    job_id=job_id,
+                    dataset_id=dataset_id,
+                )
                 return
             # fix(#1290 review): set in the same breath as the commit, and read
             # by the terminal cleanup instead of `final_status`. These are two
@@ -719,29 +735,20 @@ async def reupload_raster(
             final_status = "complete"
 
         # fix(#1290 review): everything from here is optional post-commit work,
-        # fenced so it cannot be mistaken for a failed replace. The swap is
-        # durable; a cache purge that cannot reach Valkey, a reap that cannot
-        # reach storage, or an embedding defer against a busy queue are all
-        # things to log and move on from, not reasons to fail a job whose
-        # outcome is already committed and already reported as succeeded in the
-        # run row. The `swap_committed` guard in the `finally` is the
-        # structural half of this: the fence keeps today's code from raising,
-        # and the guard keeps tomorrow's from destroying anything if it does.
-        try:
-            await _run_post_swap_followups(
-                dataset_uuid=dataset_uuid,
-                dataset_cls=Dataset,
-                prior_physical_keys=prior_physical_keys,
-                written_storage_keys=written_storage_keys,
-                job_id=job_id,
-            )
-        except Exception:  # broad: nothing after the commit may fail the job
-            logger.warning(
-                "raster_replace_post_swap_followup_failed",
-                job_id=job_id,
-                dataset_id=dataset_id,
-                exc_info=True,
-            )
+        # fenced so it cannot be mistaken for a failed replace. The
+        # `swap_committed` guard in the `finally` is the structural half of
+        # this: the fence keeps today's code from raising, and the guard keeps
+        # tomorrow's from destroying anything if it does. fix(#1778 codex r2):
+        # the fence itself lives in the helper now, because the stand-down
+        # path below needs the same one.
+        await run_post_swap_followups_best_effort(
+            dataset_uuid=dataset_uuid,
+            dataset_cls=Dataset,
+            prior_physical_keys=prior_physical_keys,
+            written_storage_keys=written_storage_keys,
+            job_id=job_id,
+            dataset_id=dataset_id,
+        )
 
     except Exception as exc:  # broad: spans GDAL/COG/storage — any step can fail
         # fix(#1778 codex r1): the other three tails guard this handler on

--- a/backend/app/processing/ingest/tasks_raster_replace.py
+++ b/backend/app/processing/ingest/tasks_raster_replace.py
@@ -72,6 +72,7 @@ from app.processing.ingest.tasks_raster_common import (
     _cleanup_orphaned_storage_keys,
     _enforce_strict_cog,
     _resolve_managed_raster_storage_keys,
+    absorb_cancellation,
     extract_source_raster_metadata,
     publish_commit_landed,
 )
@@ -687,16 +688,24 @@ async def reupload_raster(
             )
             try:
                 await session.commit()
-            except BaseException:
+            except BaseException as exc:
                 # fix(#1778): the one await on this path whose outcome is
                 # genuinely unknown — see `publish_commit_landed`. A lost
                 # acknowledgement left the flag below false, and the terminal
                 # cleanup then deleted the three keys the committed
                 # RasterAsset had just been pointed at.
-                swap_committed = await publish_commit_landed(
+                if not await publish_commit_landed(
                     job_uuid, attempt_uuid, job_id=job_id, task="reupload_raster"
-                )
-                raise
+                ):
+                    raise
+                # fix(#1778 codex r1): stand down rather than re-raise, the
+                # same decision the other three tails make. `final_status`
+                # deliberately stays non-complete: it also licenses deleting
+                # the uploader's staged original, and a probe answer must
+                # never reach that decision.
+                swap_committed = True
+                absorb_cancellation(exc)
+                return
             # fix(#1290 review): set in the same breath as the commit, and read
             # by the terminal cleanup instead of `final_status`. These are two
             # different facts and the cleanup needs this one: "the replacement
@@ -735,6 +744,15 @@ async def reupload_raster(
             )
 
     except Exception as exc:  # broad: spans GDAL/COG/storage — any step can fail
+        # fix(#1778 codex r1): the other three tails guard this handler on
+        # their published flag, because each of them can reach it with a
+        # durable publish behind it and then write something untrue about it.
+        # This one carries no such write: `_run_post_swap_followups` has its
+        # own fence, so nothing between the commit and here raises, and every
+        # write below is already fenced against a completed job anyway
+        # (`update_ingest_job_for_attempt` on `running`, `record_refresh_failure`
+        # excludes terminal runs). A flag check would be a third fence with
+        # nothing left to catch.
         logger.exception("Raster replace failed", job_id=job_id, task="reupload_raster")
         async with _job_phase_session(
             job_uuid, phase="error_write", attempt_id=attempt_uuid
@@ -794,10 +812,14 @@ async def reupload_raster(
         # lossless copy, and it gets the same gate as the object-store reaper —
         # otherwise the RUNBOOK's retention promise held on S3 and quietly
         # failed on every local deployment.
-        if file_path != original_file_path:
-            Path(file_path).unlink(missing_ok=True)
-        elif final_status == "complete" and (
-            source_preserved_in_cog or lossy_original_archived
+        #
+        # One condition rather than an `if`/`elif` that repeated the same
+        # statement: the two branches always did the same thing, and merging
+        # them is what pays for the stand-down branch above without loosening
+        # the McCabe gate this function sits under.
+        if file_path != original_file_path or (
+            final_status == "complete"
+            and (source_preserved_in_cog or lossy_original_archived)
         ):
             Path(file_path).unlink(missing_ok=True)
         # fix(#1207): the client-writable staging key, which stays recreatable

--- a/backend/app/processing/ingest/tasks_raster_swap.py
+++ b/backend/app/processing/ingest/tasks_raster_swap.py
@@ -615,6 +615,48 @@ async def _run_post_swap_followups(
             await defer_embedding(embed_dataset)
 
 
+async def run_post_swap_followups_best_effort(
+    *,
+    dataset_uuid: uuid.UUID,
+    dataset_cls: type,
+    prior_physical_keys: list[str],
+    written_storage_keys: list[str],
+    job_id: str,
+    dataset_id: str,
+) -> None:
+    """``_run_post_swap_followups`` with the caller's fence built in.
+
+    fix(#1778 codex r2): the replace tail reaches this from two places now —
+    the ordinary success path and the stand-down a lost commit acknowledgement
+    takes — and both need the identical rule: the swap is durable, so a cache
+    purge that cannot reach Valkey, a reap that cannot reach storage or an
+    embedding defer against a busy queue are things to log and move on from,
+    never reasons to fail a job whose outcome is already committed and already
+    reported as succeeded in the run row. One home for that rule rather than
+    two copies of the try/except, so the two paths cannot drift.
+
+    The reap inside is what makes this worth running on the stand-down path at
+    all: it is the ONLY deletion of the superseded COG and quicklooks, and the
+    committed pointer already names the new keys, so skipping it strands
+    objects no row references and no quota counts.
+    """
+    try:
+        await _run_post_swap_followups(
+            dataset_uuid=dataset_uuid,
+            dataset_cls=dataset_cls,
+            prior_physical_keys=prior_physical_keys,
+            written_storage_keys=written_storage_keys,
+            job_id=job_id,
+        )
+    except Exception:  # broad: nothing after the commit may fail the job
+        structlog.get_logger().warning(
+            "raster_replace_post_swap_followup_failed",
+            job_id=job_id,
+            dataset_id=dataset_id,
+            exc_info=True,
+        )
+
+
 def _prior_asset_keys_to_reap(
     *,
     asset_uri: str | None,

--- a/backend/app/processing/ingest/tasks_vector.py
+++ b/backend/app/processing/ingest/tasks_vector.py
@@ -29,6 +29,7 @@ from app.processing.ingest.tasks_common import (
     _append_job_warning,
     _archive_original_file,
     _bind_task_log_context,
+    _cleanup_staging_on_failure,
     _current_tenant_schema,
     _detect_and_override_geometry,
     _emit_billing_event,
@@ -299,7 +300,6 @@ async def ingest_file(
     _bind_task_log_context(task_name="ingest_file", job_id=job_id)
     from app.processing.ingest.ogr import build_pg_conn_str, run_ogr2ogr, run_ogrinfo
     from app.processing.ingest.service import generate_table_name
-    from app.platform.jobs.models import IngestJob
 
     resolved = await resolve_ingest_attempt_or_skip(
         job_id, attempt_id, task_label="ingest"
@@ -358,9 +358,20 @@ async def ingest_file(
                     },
                 )
                 await session.commit()
-                # retry=0: no retry will ever occur, so unlink the staging
-                # file to prevent permanent orphaning.
-                Path(file_path).unlink(missing_ok=True)
+                # fix(#1778): NO unlink here — fix(#1290 review)'s correction,
+                # which reached the two raster tails and not this copy of the
+                # same block. This exit deleted the local file unconditionally,
+                # which on a local-storage install is the durable original: a
+                # worker-side validation failure (canonically: UPLOAD_MAX_SIZE_MB
+                # lowered while the job sat queued) destroyed the only copy of a
+                # file the job then recorded as failed, with nothing to diagnose
+                # from and no way to retry. The object-storage shape was already
+                # right because the thing it deletes is a downloaded scratch copy.
+                #
+                # `_should_unlink_staging` in the terminal `finally` already
+                # knows that distinction, and it runs on this return, so the
+                # correct fix is to have ONE exit decide rather than teach a
+                # second one the same rule.
                 final_status = "failed"
                 return
 
@@ -622,40 +633,49 @@ async def ingest_file(
             final_status = "complete"
 
     except Exception as exc:  # broad: ingest pipeline spans GDAL/PostGIS/S3/FS — any step can fail; record failure status
-        structlog.get_logger().exception(
-            "Ingest task failed",
-            job_id=job_id,
-            task="ingest_file",
-        )
         # Write failure status via a fresh session — phase 1/2 sessions are
         # already closed (or rolled back) by the time we get here.
         # REMED-03 / P2-05: route through _job_phase_session so the helper
-        # owns the session-lifecycle boilerplate. The yielded job is
-        # ignored — we issue a SQL UPDATE rather than mutating the ORM row
-        # so a NULL job (race with row delete) still produces a clean
-        # no-op update instead of an AttributeError.
+        # owns the session-lifecycle boilerplate.
+        #
+        # fix(#1778): the terminal write itself goes through the shared
+        # `_cleanup_staging_on_failure`, which is what `reupload_file` has
+        # always used. This tail pasted a narrower copy of its UPDATE, and the
+        # three things the copy left out are the three that matter to somebody:
+        # the `redact_url_credentials` backstop on the stored message, the
+        # `pending`-inclusive attempt fence, and the `ingest_failed`
+        # notification — so an operator who had switched failure mail on was
+        # told about raster imports and re-uploads and heard nothing when a
+        # vector file import failed.
+        #
+        # The helper owns the failure log too, and like the re-upload doors it
+        # stays silent when the attempt fence matches nothing: a superseded
+        # attempt's exception is not this job's outcome to report.
+        #
+        # It mutates the ORM row it is given, so a NULL job (race with a row
+        # delete) skips it: there is no row left to fail, and the re-raise
+        # below still records the failure on the queue row.
         async with _job_phase_session(
             job_uuid, phase="error_write", attempt_id=attempt_uuid
         ) as (
             err_session,
-            _err_job,
+            err_job,
         ):
-            from sqlalchemy import update as sa_update
-
-            await err_session.execute(
-                sa_update(IngestJob)
-                .where(
-                    IngestJob.id == job_uuid,
-                    IngestJob.attempt_id == attempt_uuid,
-                    IngestJob.status == "running",
+            if err_job is not None:
+                await _cleanup_staging_on_failure(
+                    err_session,
+                    staging_table=staging_table_name,
+                    job=err_job,
+                    exc=exc,
+                    task_name="ingest_file",
+                    attempt_id=attempt_uuid,
                 )
-                .values(
-                    status="failed",
-                    error_message=str(exc),
-                    completed_at=datetime.now(timezone.utc),
+            else:
+                structlog.get_logger().exception(
+                    "Ingest task failed",
+                    job_id=job_id,
+                    task="ingest_file",
                 )
-            )
-            await err_session.commit()
         final_status = "failed"
         raise
     finally:
@@ -791,7 +811,6 @@ async def ingest_service(
     from app.platform.extensions import get_processing_port
     from app.processing.ingest.ogr import build_pg_conn_str, run_ogr2ogr_service
     from app.processing.ingest.service import generate_table_name
-    from app.platform.jobs.models import IngestJob
     from app.platform.refresh.credentials import resolve_worker_credential
 
     # IA-P0-03 defense-in-depth: revalidate source_url at fetch time.
@@ -1107,36 +1126,35 @@ async def ingest_service(
         # holds, in whatever shape an origin echoes it back. Mutated in place
         # so the class survives for the bare re-raise the queue records.
         scrub_secret_from_exception(exc, token)
-        structlog.get_logger().exception(
-            "Ingest task failed",
-            job_id=job_id,
-            task="ingest_service",
-        )
         # Write failure status via a fresh session — phase 1/2 sessions are
         # already closed (or rolled back) by the time we get here.
-        # REMED-03 / P2-05: route through _job_phase_session.
+        # REMED-03 / P2-05: route through _job_phase_session. fix(#1778): the
+        # terminal write goes through the same shared helper
+        # `reupload_service` uses, for the reasons the sibling handler in
+        # `ingest_file` records. The exact-value scrub above still runs FIRST,
+        # so the helper's pattern-based redaction is layered on an exception
+        # that no longer carries this attempt's token in any shape.
         async with _job_phase_session(
             job_uuid, phase="error_write", attempt_id=attempt_uuid
         ) as (
             err_session,
-            _err_job,
+            err_job,
         ):
-            from sqlalchemy import update as sa_update
-
-            await err_session.execute(
-                sa_update(IngestJob)
-                .where(
-                    IngestJob.id == job_uuid,
-                    IngestJob.attempt_id == attempt_uuid,
-                    IngestJob.status == "running",
+            if err_job is not None:
+                await _cleanup_staging_on_failure(
+                    err_session,
+                    staging_table=staging_table_name,
+                    job=err_job,
+                    exc=exc,
+                    task_name="ingest_service",
+                    attempt_id=attempt_uuid,
                 )
-                .values(
-                    status="failed",
-                    error_message=str(exc),
-                    completed_at=datetime.now(timezone.utc),
+            else:
+                structlog.get_logger().exception(
+                    "Ingest task failed",
+                    job_id=job_id,
+                    task="ingest_service",
                 )
-            )
-            await err_session.commit()
         raise
     finally:
         await stop_ingest_job_heartbeat(heartbeat_task)

--- a/backend/app/processing/ingest/tasks_vrt.py
+++ b/backend/app/processing/ingest/tasks_vrt.py
@@ -38,8 +38,10 @@ from app.platform.storage import get_storage
 
 from app.processing.ingest.tasks_common import (
     _bind_task_log_context,
+    _cleanup_staging_on_failure,
     task_app,
 )
+from app.processing.ingest.tasks_raster_common import publish_commit_landed
 
 
 def _prior_generation_storage_keys_to_reap(
@@ -401,7 +403,13 @@ async def ingest_vrt(
     # later phase-2 step) reaps the VRT + quicklook bytes instead of orphaning
     # them forever — the GAP-017 guard ingest_raster already has.
     written_storage_keys: list[str] = []
-    final_status = "failed"
+    # fix(#1778): "the VRT and its quicklooks are published", set at the
+    # terminal commit and nowhere else. It replaces the `final_status` string
+    # this reap used to read, because that string was set on the line after the
+    # commit: a commit whose acknowledgement was lost left it "failed" and the
+    # reap deleted the artifact a durably committed RasterAsset names. See
+    # `publish_commit_landed`.
+    publish_committed: bool = False
     heartbeat_task: asyncio.Task[None] | None = None
 
     try:
@@ -613,8 +621,14 @@ async def ingest_vrt(
                         "completed_at": datetime.now(timezone.utc),
                     },
                 )
-                await session.commit()
-                final_status = "complete"
+                try:
+                    await session.commit()
+                except BaseException:
+                    publish_committed = await publish_commit_landed(
+                        job_uuid, attempt_uuid, job_id=job_id, task="ingest_vrt"
+                    )
+                    raise
+                publish_committed = True
 
                 # Invalidate cache
                 await invalidate_catalog_cache()
@@ -630,36 +644,44 @@ async def ingest_vrt(
                 raise
 
     except Exception as exc:  # broad: VRT pipeline includes GDAL subprocesses and rasterio — any step can fail
-        structlog.get_logger().exception(
-            "Ingest task failed",
-            extra={"job_id": job_id, "task": "ingest_vrt"},
-        )
-        # Write failure status via a fresh session.
+        # fix(#1778): write failure status via a fresh session, through the
+        # same shared helper the re-upload doors use. This tail used to paste a
+        # narrower copy of the UPDATE and emitted no `ingest_failed`
+        # notification, so a VRT build failure was silent to an operator who
+        # had failure mail on. `staging_table=""` because a VRT build has no
+        # staging table — its artifacts are the object keys the `finally`
+        # below reaps.
         async with async_session() as err_session:
-            from sqlalchemy import update as sa_update
-
-            await err_session.execute(
-                sa_update(IngestJob)
-                .where(
-                    IngestJob.id == job_uuid,
-                    IngestJob.attempt_id == attempt_uuid,
-                    IngestJob.status == "running",
+            err_job = (
+                await err_session.execute(
+                    select(IngestJob).where(
+                        IngestJob.id == job_uuid,
+                        IngestJob.attempt_id == attempt_uuid,
+                    )
                 )
-                .values(
-                    status="failed",
-                    error_message=str(exc),
-                    completed_at=datetime.now(timezone.utc),
+            ).scalar_one_or_none()
+            if err_job is not None:
+                await _cleanup_staging_on_failure(
+                    err_session,
+                    staging_table="",
+                    job=err_job,
+                    exc=exc,
+                    task_name="ingest_vrt",
+                    attempt_id=attempt_uuid,
                 )
-            )
-            await err_session.commit()
+            else:
+                structlog.get_logger().exception(
+                    "Ingest task failed",
+                    extra={"job_id": job_id, "task": "ingest_vrt"},
+                )
         raise
     finally:
         await stop_ingest_job_heartbeat(heartbeat_task)
         if tmp_dir:
             shutil.rmtree(tmp_dir, ignore_errors=True)
-        # fix(#430 BA-30): reap storage bytes written before a non-complete terminal
-        # status (mirrors ingest_raster's GAP-017 guard).
-        if final_status != "complete" and written_storage_keys:
+        # fix(#430 BA-30): reap storage bytes written before a terminal commit
+        # that never became durable (mirrors ingest_raster's GAP-017 guard).
+        if not publish_committed and written_storage_keys:
             from app.processing.ingest.tasks_raster import (
                 _cleanup_orphaned_storage_keys,
             )
@@ -754,7 +776,11 @@ async def regenerate_vrt(
     generation_heartbeat_task: asyncio.Task[None] | None = None
     written_storage_keys: list[str] = []
     prior_storage_keys: list[str] = []
-    final_status = "failed"
+    # fix(#1778): same fence as `ingest_vrt` above, for the same reason — the
+    # generation swap and the job's terminal write share one transaction, so a
+    # lost acknowledgement must not let the reap delete the generation the
+    # RasterAsset now points at. See `publish_commit_landed`.
+    publish_committed: bool = False
 
     try:
         # ----------------------------------------------------------------- #
@@ -1222,8 +1248,14 @@ async def regenerate_vrt(
                         "completed_at": datetime.now(timezone.utc),
                     },
                 )
-                await session.commit()
-                final_status = "complete"
+                try:
+                    await session.commit()
+                except BaseException:
+                    publish_committed = await publish_commit_landed(
+                        job_uuid, attempt_uuid, job_id=job_id, task="regenerate_vrt"
+                    )
+                    raise
+                publish_committed = True
 
                 from app.processing.ingest.tasks_raster import (
                     _cleanup_orphaned_storage_keys,
@@ -1302,7 +1334,7 @@ async def regenerate_vrt(
         await stop_ingest_job_heartbeat(heartbeat_task)
         if tmp_dir:
             shutil.rmtree(tmp_dir, ignore_errors=True)
-        if final_status != "complete" and written_storage_keys:
+        if not publish_committed and written_storage_keys:
             from app.processing.ingest.tasks_raster import (
                 _cleanup_orphaned_storage_keys,
             )

--- a/backend/app/processing/ingest/tasks_vrt.py
+++ b/backend/app/processing/ingest/tasks_vrt.py
@@ -41,7 +41,10 @@ from app.processing.ingest.tasks_common import (
     _cleanup_staging_on_failure,
     task_app,
 )
-from app.processing.ingest.tasks_raster_common import publish_commit_landed
+from app.processing.ingest.tasks_raster_common import (
+    absorb_cancellation,
+    publish_commit_landed,
+)
 
 
 def _prior_generation_storage_keys_to_reap(
@@ -623,11 +626,18 @@ async def ingest_vrt(
                 )
                 try:
                     await session.commit()
-                except BaseException:
-                    publish_committed = await publish_commit_landed(
+                except BaseException as exc:
+                    if not await publish_commit_landed(
                         job_uuid, attempt_uuid, job_id=job_id, task="ingest_vrt"
-                    )
-                    raise
+                    ):
+                        raise
+                    # fix(#1778 codex r1): stand down rather than re-raise, the
+                    # same decision `regenerate_vrt` makes below. The dataset
+                    # and its VRT object are durable, so the failure handler
+                    # would be writing about a job that succeeded.
+                    publish_committed = True
+                    absorb_cancellation(exc)
+                    return
                 publish_committed = True
 
                 # Invalidate cache
@@ -644,6 +654,20 @@ async def ingest_vrt(
                 raise
 
     except Exception as exc:  # broad: VRT pipeline includes GDAL subprocesses and rasterio — any step can fail
+        if publish_committed:
+            # fix(#1778 codex r1): the second way this handler is reached with
+            # a durable publish behind it, and the one the stand-down above
+            # cannot cover: `invalidate_catalog_cache` and `defer_embedding`
+            # run inside the same try, so a Valkey outage or a busy queue lands
+            # here after the dataset is live and the writes below would report
+            # a build that succeeded as failed.
+            structlog.get_logger().warning(
+                "vrt_post_publish_followup_failed",
+                job_id=job_id,
+                task="ingest_vrt",
+                exc_info=True,
+            )
+            return
         # fix(#1778): write failure status via a fresh session, through the
         # same shared helper the re-upload doors use. This tail used to paste a
         # narrower copy of the UPDATE and emitted no `ingest_failed`
@@ -1250,11 +1274,19 @@ async def regenerate_vrt(
                 )
                 try:
                     await session.commit()
-                except BaseException:
-                    publish_committed = await publish_commit_landed(
+                except BaseException as exc:
+                    if not await publish_commit_landed(
                         job_uuid, attempt_uuid, job_id=job_id, task="regenerate_vrt"
-                    )
-                    raise
+                    ):
+                        raise
+                    # fix(#1778 codex r1): stand down rather than re-raise. The
+                    # generation swap is durable, so every write the failure
+                    # handler would make is a statement about a job that
+                    # succeeded, and the generation row it stamps `failed` is
+                    # not fenced the way the job and asset writes are.
+                    publish_committed = True
+                    absorb_cancellation(exc)
+                    return
                 publish_committed = True
 
                 from app.processing.ingest.tasks_raster import (
@@ -1281,6 +1313,23 @@ async def regenerate_vrt(
                 raise
 
     except Exception as exc:  # broad: VRT regeneration includes GDAL subprocesses and rasterio — any step can fail
+        if publish_committed:
+            # fix(#1778 codex r1): the second way this handler is reached with
+            # a durable publish behind it, and the one the stand-down above
+            # cannot cover: the prior-key reap, `invalidate_catalog_cache` and
+            # `defer_embedding` all run inside the same try. The generation
+            # write below is not fenced the way the job and asset writes are,
+            # so reaching here after the swap stamped a `completed` generation
+            # `failed`, which `get_vrt_status` reads as "no completed
+            # generation" and the stale-generation sweep reads as evidence the
+            # asset was unhealthy.
+            structlog.get_logger().warning(
+                "vrt_post_publish_followup_failed",
+                job_id=job_id,
+                task="regenerate_vrt",
+                exc_info=True,
+            )
+            return
         structlog.get_logger().exception(
             "Ingest task failed",
             job_id=job_id,
@@ -1318,7 +1367,14 @@ async def regenerate_vrt(
                     select(VrtGeneration).where(VrtGeneration.id == generation_uuid)
                 )
                 gen = gen_result.scalar_one_or_none()
-                if gen:
+                # fix(#1778 codex r1): and the same rule stated at the write
+                # rather than only at the caller. The two guards above are
+                # local flags; this one is a property of the statement, so a
+                # future path into this handler cannot relabel a generation
+                # whose artifact is published, whatever it believes about the
+                # commit. It is the peer of the `current_generation_id` fence
+                # on the asset update and the `running` fence on the job.
+                if gen and gen.status != "completed":
                     gen.status = "failed"
                     gen.completed_at = datetime.now(timezone.utc)
                     if gen.started_at:

--- a/backend/app/processing/ingest/tasks_vrt.py
+++ b/backend/app/processing/ingest/tasks_vrt.py
@@ -47,6 +47,32 @@ from app.processing.ingest.tasks_raster_common import (
 )
 
 
+async def _reap_superseded_generation_objects(
+    *,
+    prior_storage_keys: list[str],
+    written_storage_keys: list[str],
+    job_id: str,
+) -> None:
+    """Delete the objects the published generation superseded.
+
+    fix(#1778 codex r2): named and shared because ``regenerate_vrt`` reaches
+    it from two places now, the ordinary success path and the stand-down a
+    lost commit acknowledgement takes. It is the ONLY deletion of the previous
+    generation's artifact, and the committed asset already names the new one,
+    so a path that skips it strands bytes no row references and no quota
+    counts.
+
+    The ``not in written`` filter is what makes a regeneration that produced
+    byte-identical output a no-op rather than a self-inflicted delete.
+    """
+    from app.processing.ingest.tasks_raster import _cleanup_orphaned_storage_keys
+
+    await _cleanup_orphaned_storage_keys(
+        [key for key in prior_storage_keys if key not in written_storage_keys],
+        job_id=job_id,
+    )
+
+
 def _prior_generation_storage_keys_to_reap(
     *,
     vrt_key: str,
@@ -635,6 +661,12 @@ async def ingest_vrt(
                     # same decision `regenerate_vrt` makes below. The dataset
                     # and its VRT object are durable, so the failure handler
                     # would be writing about a job that succeeded.
+                    #
+                    # fix(#1778 codex r2): and unlike `regenerate_vrt` there is
+                    # nothing to reap on the way out. A first build supersedes
+                    # no generation, so the followups this skips are the cache
+                    # purge and the embedding defer: both recoverable, neither
+                    # holding bytes that no row references.
                     publish_committed = True
                     absorb_cancellation(exc)
                     return
@@ -1286,19 +1318,25 @@ async def regenerate_vrt(
                     # not fenced the way the job and asset writes are.
                     publish_committed = True
                     absorb_cancellation(exc)
+                    # fix(#1778 codex r2): standing down from the FAILURE
+                    # handler is not standing down from the success work. This
+                    # is the only deletion of the superseded generation's
+                    # objects, and the committed asset already names the new
+                    # ones, so returning without it strands bytes no row
+                    # references and no quota counts. No guard: the reaper
+                    # swallows a missing provider and every per-key error, so
+                    # it cannot turn a durable publish back into a failure.
+                    await _reap_superseded_generation_objects(
+                        prior_storage_keys=prior_storage_keys,
+                        written_storage_keys=written_storage_keys,
+                        job_id=job_id,
+                    )
                     return
                 publish_committed = True
 
-                from app.processing.ingest.tasks_raster import (
-                    _cleanup_orphaned_storage_keys,
-                )
-
-                await _cleanup_orphaned_storage_keys(
-                    [
-                        key
-                        for key in prior_storage_keys
-                        if key not in written_storage_keys
-                    ],
+                await _reap_superseded_generation_objects(
+                    prior_storage_keys=prior_storage_keys,
+                    written_storage_keys=written_storage_keys,
                     job_id=job_id,
                 )
 

--- a/backend/tests/test_ingest_vector_failure_tails.py
+++ b/backend/tests/test_ingest_vector_failure_tails.py
@@ -1,0 +1,236 @@
+"""fix(#1778): the two exits a vector import takes when it does not succeed.
+
+Both were copies. The upload-safety validation exit is pasted into four ingest
+tasks and the #1290 "NO unlink" correction reached only the two raster ones, so
+on a local-storage install a worker-side validation failure deleted the user's
+only copy of the file it had just recorded as failed. The terminal failure
+write is pasted into four tasks as well, and the shared helper the re-upload
+doors use is the one that emits ``ingest_failed`` — so an operator who had
+switched failure mail on heard about raster imports and re-uploads and heard
+nothing when a vector file import, a service import or a VRT build failed.
+
+Both are asserted by driving the real task, not by reading the source.
+"""
+
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from sqlalchemy import delete, select
+
+from app.modules.auth.models import User
+from app.platform.jobs.models import IngestJob
+from app.processing.ingest.tasks_vector import ingest_file
+
+pytestmark = pytest.mark.anyio
+
+
+_GEOJSON = (
+    b'{"type":"FeatureCollection","features":['
+    b'{"type":"Feature","properties":{"name":"a"},'
+    b'"geometry":{"type":"Point","coordinates":[1.0,2.0]}}]}'
+)
+
+
+async def _admin_id(session) -> uuid.UUID:
+    return (
+        await session.execute(select(User.id).where(User.username == "admin"))
+    ).scalar_one()
+
+
+async def _queue_upload(session, *, file_path: str, user_id: uuid.UUID) -> IngestJob:
+    """A pending file-import job bound to a LOCAL staging path.
+
+    ``file_path == original_file_path`` is the shape that matters here: on a
+    local-storage install ``resolve_file_path`` returns the path unchanged, so
+    this IS the durable original rather than a downloaded scratch copy.
+    """
+    job = IngestJob(
+        source_filename="points.geojson",
+        file_path=file_path,
+        created_by=user_id,
+        status="pending",
+        user_metadata={"title": "Points"},
+    )
+    session.add(job)
+    await session.commit()
+    await session.refresh(job)
+    return job
+
+
+async def _drop_job(session, job_id: uuid.UUID) -> None:
+    await session.execute(delete(IngestJob).where(IngestJob.id == job_id))
+    await session.commit()
+
+
+class TestValidationExitKeepsTheLocalOriginal:
+    """The #1290 correction, applied to the copy that missed it.
+
+    The canonical trigger needs no attacker: lowering ``UPLOAD_MAX_SIZE_MB``
+    while a job sits queued fails it at worker pickup, and the exit used to
+    unlink unconditionally.
+    """
+
+    async def test_a_local_upload_survives_a_worker_side_validation_failure(
+        self, test_db_session, tmp_path
+    ) -> None:
+        from app.core.persistent_config import UPLOAD_MAX_SIZE_MB
+
+        source = tmp_path / "points.geojson"
+        source.write_bytes(_GEOJSON)
+        admin_id = await _admin_id(test_db_session)
+        job = await _queue_upload(
+            test_db_session, file_path=str(source), user_id=admin_id
+        )
+        job_id = job.id
+
+        try:
+            with patch.object(UPLOAD_MAX_SIZE_MB, "get", AsyncMock(return_value=0)):
+                await ingest_file.func(
+                    job_id=str(job_id),
+                    file_path=str(source),
+                    user_id=str(admin_id),
+                    attempt_id=str(job.attempt_id),
+                )
+
+            test_db_session.expire_all()
+            finished = (
+                await test_db_session.execute(
+                    select(IngestJob).where(IngestJob.id == job_id)
+                )
+            ).scalar_one()
+            assert finished.status == "failed", "precondition: the size check refused"
+            assert "exceeds the maximum" in (finished.error_message or "")
+            assert source.exists(), (
+                "the validation exit deleted the uploaded file. On a "
+                "local-storage install that is the only copy, and the job it "
+                "just recorded as failed now has nothing to diagnose from and "
+                "nothing to retry from (#1290)."
+            )
+        finally:
+            await _drop_job(test_db_session, job_id)
+
+
+class TestVectorFailureEmitsTheOperatorNotification:
+    """The terminal failure write goes through the shared helper.
+
+    Asserted through the real task so the test covers the wiring rather than
+    the helper, which ``test_event_ingest.py`` already covers on its own.
+    """
+
+    @staticmethod
+    def _capture(monkeypatch, *, toggle: bool) -> list:
+        from app.core.config import settings
+        from app.platform.notifications import events as events_mod
+
+        monkeypatch.setattr(settings, "notify_on_ingest_failed", toggle, raising=False)
+        emitted: list = []
+
+        async def _fake_notify(notification):
+            emitted.append(notification)
+
+        monkeypatch.setattr(events_mod, "notify", _fake_notify)
+        return emitted
+
+    @staticmethod
+    def _break_ogrinfo(monkeypatch, message: str) -> None:
+        async def _raise(*args, **kwargs):
+            raise RuntimeError(message)
+
+        monkeypatch.setattr(
+            "app.processing.ingest.ogr.run_ogrinfo", _raise, raising=True
+        )
+
+    async def _run_failing_import(self, session, tmp_path, monkeypatch, message):
+        source = tmp_path / "points.geojson"
+        source.write_bytes(_GEOJSON)
+        admin_id = await _admin_id(session)
+        job = await _queue_upload(session, file_path=str(source), user_id=admin_id)
+        self._break_ogrinfo(monkeypatch, message)
+        with pytest.raises(RuntimeError):
+            await ingest_file.func(
+                job_id=str(job.id),
+                file_path=str(source),
+                user_id=str(admin_id),
+                attempt_id=str(job.attempt_id),
+            )
+        return job.id
+
+    async def test_a_failed_vector_import_notifies_the_operator(
+        self, test_db_session, tmp_path, monkeypatch
+    ) -> None:
+        emitted = self._capture(monkeypatch, toggle=True)
+        message = "ogrinfo could not read the layer"
+        job_id = await self._run_failing_import(
+            test_db_session, tmp_path, monkeypatch, message
+        )
+
+        try:
+            assert len(emitted) == 1, (
+                "a vector file import failed and the operator was told "
+                f"nothing (emitted={emitted})"
+            )
+            note = emitted[0]
+            assert note.event_type == "ingest_failed"
+            assert note.data.get("task") == "ingest_file", (
+                "the notification must name the tail it came from, or this "
+                "assertion would pass on a raster path's emission"
+            )
+            assert message in (note.data.get("reason") or "")
+
+            test_db_session.expire_all()
+            finished = (
+                await test_db_session.execute(
+                    select(IngestJob).where(IngestJob.id == job_id)
+                )
+            ).scalar_one()
+            assert finished.status == "failed"
+            assert message in (finished.error_message or "")
+        finally:
+            await _drop_job(test_db_session, job_id)
+
+    async def test_nothing_is_emitted_while_the_toggle_is_off(
+        self, test_db_session, tmp_path, monkeypatch
+    ) -> None:
+        """The negative control: the assertion above is about the toggle an
+        operator actually set, not about an unconditional email."""
+        emitted = self._capture(monkeypatch, toggle=False)
+        job_id = await self._run_failing_import(
+            test_db_session, tmp_path, monkeypatch, "ogrinfo blew up"
+        )
+        try:
+            assert emitted == []
+        finally:
+            await _drop_job(test_db_session, job_id)
+
+
+class TestNoImportTailStillHandRollsItsFailureWrite:
+    """Structural, because the finding is that the write was COPIED.
+
+    Four tasks pasted a narrower version of the terminal UPDATE, and each copy
+    quietly dropped the redaction backstop, the pending-inclusive attempt
+    fence and the notification. ``ingest_raster`` keeps its own copy on
+    purpose — it is the one tail that already emits ``ingest_failed`` — and is
+    named here rather than silently skipped.
+    """
+
+    def test_the_vector_and_vrt_tails_route_through_the_shared_helper(self) -> None:
+        import inspect
+
+        from app.processing.ingest import tasks_vector, tasks_vrt
+
+        for module, funcs in (
+            (tasks_vector, ("ingest_file", "ingest_service")),
+            (tasks_vrt, ("ingest_vrt",)),
+        ):
+            for name in funcs:
+                target = getattr(module, name)
+                source = inspect.getsource(getattr(target, "func", target))
+                assert "_cleanup_staging_on_failure" in source, (
+                    f"{module.__name__}.{name} writes its own terminal "
+                    "failure row instead of routing through the shared "
+                    "helper, so its failures emit no ingest_failed "
+                    "notification"
+                )

--- a/backend/tests/test_ingest_vector_failure_tails.py
+++ b/backend/tests/test_ingest_vector_failure_tails.py
@@ -234,3 +234,112 @@ class TestNoImportTailStillHandRollsItsFailureWrite:
                     "helper, so its failures emit no ingest_failed "
                     "notification"
                 )
+
+
+class TestACleanupFailureCannotSwallowTheFailureWrite:
+    """fix(#1778 codex r2): the order inside the shared helper.
+
+    PostgreSQL aborts the whole transaction on any statement error, so with
+    the staging DROP running first, a drop that hit a lock or statement
+    timeout left the session unusable and the failure UPDATE that followed it
+    raised `current transaction is aborted`. The job stayed `running` until
+    the stale sweep, and the reason nobody recorded was the one the user
+    needed. The failure row is written and committed first now.
+    """
+
+    @staticmethod
+    def _break_the_drop(monkeypatch) -> None:
+        """Make the DROP fail at the SERVER, which is what aborts the
+        transaction. A double raised in Python would leave the session healthy
+        and the reordering counterfactual would pass for the wrong reason."""
+        import app.processing.ingest.metadata as metadata_mod
+
+        real_qtable = metadata_mod._qtable
+
+        def _malformed(table_name: str, schema: str = "data") -> str:
+            real_qtable(table_name, schema=schema)  # keep the identifier checks
+            return '"data"."x" ,,,'
+
+        monkeypatch.setattr(metadata_mod, "_qtable", _malformed, raising=True)
+
+    async def test_the_job_still_records_the_original_failure(
+        self, test_db_session, monkeypatch
+    ) -> None:
+        from app.core.db import async_session
+        from app.processing.ingest.tasks_common import _cleanup_staging_on_failure
+
+        admin_id = await _admin_id(test_db_session)
+        job = IngestJob(
+            source_filename="points.geojson",
+            created_by=admin_id,
+            status="running",
+        )
+        test_db_session.add(job)
+        await test_db_session.commit()
+        await test_db_session.refresh(job)
+        job_id = job.id
+        attempt_id = job.attempt_id
+
+        self._break_the_drop(monkeypatch)
+
+        try:
+            async with async_session() as err_session:
+                err_job = (
+                    await err_session.execute(
+                        select(IngestJob).where(IngestJob.id == job_id)
+                    )
+                ).scalar_one()
+                await _cleanup_staging_on_failure(
+                    err_session,
+                    staging_table="roads_staging_deadbeef",
+                    job=err_job,
+                    exc=RuntimeError("ogr2ogr could not read the layer"),
+                    task_name="ingest_file",
+                    attempt_id=attempt_id,
+                )
+
+            test_db_session.expire_all()
+            finished = (
+                await test_db_session.execute(
+                    select(IngestJob).where(IngestJob.id == job_id)
+                )
+            ).scalar_one()
+            assert finished.status == "failed", (
+                "a staging-table cleanup error swallowed the failure write, so "
+                "the job sits running with no reason until the stale sweep"
+            )
+            assert "could not read the layer" in (finished.error_message or "")
+            assert finished.completed_at is not None
+        finally:
+            await _drop_job(test_db_session, job_id)
+
+    def test_the_drop_runs_after_the_failure_commit(self) -> None:
+        """Structural, because the property is an ORDER and the behavioural
+        test above can only observe one half of it."""
+        import ast
+        import inspect
+
+        import app.processing.ingest.tasks_common as tc_mod
+
+        tree = ast.parse(inspect.getsource(tc_mod._cleanup_staging_on_failure))
+        drop_lines = [
+            node.lineno
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Constant)
+            and isinstance(node.value, str)
+            and "DROP TABLE IF EXISTS" in node.value
+        ]
+        status_lines = [
+            node.lineno
+            for node in ast.walk(tree)
+            if isinstance(node, ast.keyword)
+            and node.arg == "status"
+            and isinstance(node.value, ast.Constant)
+            and node.value.value == "failed"
+        ]
+        assert drop_lines and status_lines, "the helper's shape changed"
+        assert min(drop_lines) > min(status_lines), (
+            "the staging DROP runs before the failure UPDATE again. A DDL "
+            "error aborts the transaction, and every statement after it on "
+            "that session raises until a rollback."
+        )

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -3711,7 +3711,16 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # failure write moves to the shared `_cleanup_staging_on_failure` so a
     # failed build finally emits `ingest_failed`. The dead `final_status`
     # string both functions no longer read is gone. Cap 1354 -> 1386, exact.
-    "backend/app/processing/ingest/tasks_vrt.py": 1386,
+    # fix(#1778 codex r1): +56 — both VRT tails STAND DOWN on an observed
+    # publish (return instead of re-raising) and both failure handlers refuse
+    # to run at all once the publish is durable, because the generation write
+    # is not fenced the way the job and asset writes are and `get_vrt_status`
+    # plus the stale-generation sweep read what it stamps. The generation
+    # update also gained its own `status != 'completed'` fence, so the rule is
+    # stated at the write and not only at the caller. Most of the lines are the
+    # two handler comments naming the reader each false failure reaches.
+    # Cap 1386 -> 1442, exact.
+    "backend/app/processing/ingest/tasks_vrt.py": 1442,
     # fix(#1202 review r5): +29 — sweep the presigned staging key at job end.
     # A completed presigned job points file_path at its frozen copy, so this
     # reaper never touched the key the client's PUT URL can still recreate.

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -2999,7 +2999,14 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # redaction backstop, the pending-inclusive fence, the ingest_failed
     # notification) and why an empty name skips rather than logs a cleanup
     # failure on every VRT build failure. Cap 2380 -> 2395, exact.
-    "backend/app/processing/ingest/tasks_common.py": 2395,
+    # fix(#1778 codex r2): +31 — `_cleanup_staging_on_failure` writes and
+    # commits the failure row BEFORE it attempts the staging DROP, and the drop
+    # rolls back its own wreckage. A DDL error aborts the whole PostgreSQL
+    # transaction, so with the drop first a lock or statement timeout took the
+    # failure write down with it and the job sat `running` with no reason. Most
+    # of the lines are the docstring and comment stating that the order is the
+    # contract. Cap 2395 -> 2426, exact.
+    "backend/app/processing/ingest/tasks_common.py": 2426,
     # --- entered by the inclusion rule, feat(#1219 x #1222) ---------------
     # tasks_reupload crossed 1000 when two independently-reviewed features
     # met in one file: #1222's failed-contact bookkeeping (spawn-armed
@@ -3720,7 +3727,13 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # stated at the write and not only at the caller. Most of the lines are the
     # two handler comments naming the reader each false failure reaches.
     # Cap 1386 -> 1442, exact.
-    "backend/app/processing/ingest/tasks_vrt.py": 1442,
+    # fix(#1778 codex r2): +38 — the superseded-generation reap is a named
+    # helper called from both the success path and the stand-down, because it
+    # is the only deletion of the previous generation's artifact and a
+    # stand-down that skipped it stranded bytes no row references and no quota
+    # counts. `ingest_vrt` records that it has nothing to reap on that path.
+    # Cap 1442 -> 1480, exact.
+    "backend/app/processing/ingest/tasks_vrt.py": 1480,
     # fix(#1202 review r5): +29 — sweep the presigned staging key at job end.
     # A completed presigned job points file_path at its frozen copy, so this
     # reaper never touched the key the client's PUT URL can still recreate.

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -2992,7 +2992,14 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # Two thirds of it is comments — why deleting the key is safe (retry=0,
     # so the first exception is the terminal one) and why the wrapper catches
     # Exception rather than BaseException. Cap 2311 -> 2380, exact.
-    "backend/app/processing/ingest/tasks_common.py": 2380,
+    # fix(#1778): +14 — `_cleanup_staging_on_failure` skips the DROP when it is
+    # handed an empty staging-table name, which is what makes it usable by the
+    # raster and VRT tails that have no staging table. Most of it is the
+    # docstring saying what the four hand-rolled copies were each missing (the
+    # redaction backstop, the pending-inclusive fence, the ingest_failed
+    # notification) and why an empty name skips rather than logs a cleanup
+    # failure on every VRT build failure. Cap 2380 -> 2395, exact.
+    "backend/app/processing/ingest/tasks_common.py": 2395,
     # --- entered by the inclusion rule, feat(#1219 x #1222) ---------------
     # tasks_reupload crossed 1000 when two independently-reviewed features
     # met in one file: #1222's failed-contact bookkeeping (spawn-armed
@@ -3698,7 +3705,13 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # Cap 1300 -> 1344, exact.
     # fix(#1329 follow-up): +10 — bump tile_cache_version in the VRT swap
     # transaction; the third pointer-swap door finally rolls the version.
-    "backend/app/processing/ingest/tasks_vrt.py": 1354,
+    # fix(#1778): +32 — both VRT tails guard their publishing COMMIT with the
+    # shared `publish_commit_landed` probe and reap on what it observed rather
+    # than on a flag set after the await returned, and `ingest_vrt`'s terminal
+    # failure write moves to the shared `_cleanup_staging_on_failure` so a
+    # failed build finally emits `ingest_failed`. The dead `final_status`
+    # string both functions no longer read is gone. Cap 1354 -> 1386, exact.
+    "backend/app/processing/ingest/tasks_vrt.py": 1386,
     # fix(#1202 review r5): +29 — sweep the presigned staging key at job end.
     # A completed presigned job points file_path at its frozen copy, so this
     # reaper never touched the key the client's PUT URL can still recreate.
@@ -3755,7 +3768,14 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # fix(#1746 codex r1): +9 — same narrowing of the marker comment, plus the
     # note that the refresh door treats the key as a gate and not a verdict.
     # Cap 1134 -> 1143, exact.
-    "backend/app/processing/ingest/tasks_vector.py": 1143,
+    # fix(#1778): +18 — the upload-safety exit stops unlinking the file (the
+    # #1290 correction the two raster tails already carry), and both terminal
+    # failure writes move to the shared `_cleanup_staging_on_failure`, so a
+    # failed file or service import emits `ingest_failed` and persists a
+    # redacted message. Net of two hand-rolled UPDATE blocks and two now-unused
+    # IngestJob imports removed; the rest is the comment saying which exit owns
+    # the unlink decision. Cap 1143 -> 1161, exact.
+    "backend/app/processing/ingest/tasks_vector.py": 1161,
     # --- entered by the inclusion rule ------------------------------------
     # Crossed 1000 lines adding the "unable to open datasource" friendly-
     # message mapping shared by run_ogrinfo and run_ogr2ogr: the pattern

--- a/backend/tests/test_raster_replace_1221.py
+++ b/backend/tests/test_raster_replace_1221.py
@@ -34,6 +34,7 @@ block, because this suite runs against the shared dev Postgres.
 
 from __future__ import annotations
 
+import asyncio
 import contextlib
 import io
 import json as _json
@@ -5452,3 +5453,629 @@ class TestCrsAssignmentPreservesTheSamples:
             )
         finally:
             await _purge(test_db_session, dataset_id=dataset_id, record_id=record_id)
+
+
+# ---------------------------------------------------------------------------
+# 10. fix(#1778): commit ambiguity on the raster and VRT publish tails
+# ---------------------------------------------------------------------------
+
+
+@contextlib.contextmanager
+def _ack_lost_on_publish(job_id: uuid.UUID, *, failure: BaseException):
+    """Make the COMMIT that publishes ``job_id`` raise AFTER it has applied.
+
+    The shape production sees when a connection drops or a cancel lands while
+    ``COMMIT`` is in flight: PostgreSQL applied the transaction, the
+    acknowledgement never arrived. It cannot be produced through a real
+    session on demand, so the seam is ``AsyncSession.commit`` itself — run the
+    real commit, ask a FRESH session whether the job is now ``complete``, and
+    raise if it is. That fires on exactly one commit per task, the publishing
+    one, whichever phase block it lives in and without the test counting
+    commits.
+
+    The patch is torn down on exit so the test's own session can commit its
+    assertions and its purge.
+    """
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+    real_commit = AsyncSession.commit
+    fired: dict[str, int] = {"count": 0}
+
+    async def _commit(self, *args, **kwargs):
+        await real_commit(self, *args, **kwargs)
+        if fired["count"]:
+            return
+        from app.core.db import async_session
+
+        async with async_session() as probe:
+            status = (
+                await probe.execute(
+                    select(IngestJob.status).where(IngestJob.id == job_id)
+                )
+            ).scalar_one_or_none()
+        if status == "complete":
+            fired["count"] += 1
+            raise failure
+
+    AsyncSession.commit = _commit
+    try:
+        yield fired
+    finally:
+        AsyncSession.commit = real_commit
+
+
+class TestPublishCommitLandedProbe:
+    """The probe reads the row, and the row is the whole answer.
+
+    ``publish_commit_landed`` is the shared half of the fix: every publish
+    tail stamps its job ``complete`` in the SAME transaction as the pointer
+    swap, so that one column, read on a fresh session and fenced on the
+    attempt, decides whether the objects this attempt wrote are live.
+    """
+
+    @staticmethod
+    async def _job(session, *, status: str) -> IngestJob:
+        admin_id = (
+            await session.execute(select(User.id).where(User.username == "admin"))
+        ).scalar_one()
+        job = IngestJob(
+            source_filename="probe.tif",
+            created_by=admin_id,
+            status=status,
+        )
+        session.add(job)
+        await session.commit()
+        await session.refresh(job)
+        return job
+
+    async def test_complete_row_for_this_attempt_reads_as_landed(
+        self, test_db_session
+    ) -> None:
+        from app.processing.ingest.tasks_raster_common import publish_commit_landed
+
+        job = await self._job(test_db_session, status="complete")
+        try:
+            assert (
+                await publish_commit_landed(
+                    job.id, job.attempt_id, job_id=str(job.id), task="t"
+                )
+                is True
+            )
+        finally:
+            await test_db_session.execute(
+                delete(IngestJob).where(IngestJob.id == job.id)
+            )
+            await test_db_session.commit()
+
+    @pytest.mark.parametrize("status", ["running", "pending", "failed"])
+    async def test_non_complete_row_reads_as_not_landed(
+        self, test_db_session, status
+    ) -> None:
+        from app.processing.ingest.tasks_raster_common import publish_commit_landed
+
+        job = await self._job(test_db_session, status=status)
+        try:
+            assert (
+                await publish_commit_landed(
+                    job.id, job.attempt_id, job_id=str(job.id), task="t"
+                )
+                is False
+            ), (
+                f"a {status} row means the publishing transaction is not "
+                "durable, so the objects this attempt wrote are reapable"
+            )
+        finally:
+            await test_db_session.execute(
+                delete(IngestJob).where(IngestJob.id == job.id)
+            )
+            await test_db_session.commit()
+
+    async def test_a_superseded_attempt_never_reads_its_successors_commit(
+        self, test_db_session
+    ) -> None:
+        """The fence is the attempt token, not the job id."""
+        from app.processing.ingest.tasks_raster_common import publish_commit_landed
+
+        job = await self._job(test_db_session, status="complete")
+        try:
+            assert (
+                await publish_commit_landed(
+                    job.id, uuid.uuid4(), job_id=str(job.id), task="t"
+                )
+                is False
+            )
+        finally:
+            await test_db_session.execute(
+                delete(IngestJob).where(IngestJob.id == job.id)
+            )
+            await test_db_session.commit()
+
+    async def test_a_probe_that_cannot_read_stands_down(self, monkeypatch) -> None:
+        """#1708's asymmetry: an unreadable probe assumes the swap landed.
+
+        Standing down on a false positive leaves objects an operator can still
+        remove; proceeding on a false negative deletes the live raster.
+        """
+        from app.processing.ingest.tasks_raster_common import publish_commit_landed
+
+        def _no_session(*args, **kwargs):
+            raise RuntimeError("the pool is gone too")
+
+        monkeypatch.setattr("app.core.db.async_session", _no_session, raising=True)
+        assert (
+            await publish_commit_landed(
+                uuid.uuid4(), uuid.uuid4(), job_id="j", task="t"
+            )
+            is True
+        )
+
+
+class TestAckLostCommitDoesNotDeleteThePublishedRaster:
+    """fix(#1778): the audit's only irrecoverable data-loss path.
+
+    Every publish tail set its "published" flag on the line AFTER
+    ``await session.commit()``, and the terminal cleanup read that flag. A
+    commit whose acknowledgement was lost therefore reached the cleanup with
+    the flag false, and the cleanup deleted the exact object keys the
+    committed row had just been pointed at. The superseded objects are not
+    restored — the reaper of the OLD keys never ran — so nothing in the
+    product can recover the dataset.
+    """
+
+    @staticmethod
+    async def _admin(session) -> uuid.UUID:
+        return (
+            await session.execute(select(User.id).where(User.username == "admin"))
+        ).scalar_one()
+
+    @pytest.mark.parametrize(
+        "failure",
+        [
+            ConnectionResetError("the connection dropped inside COMMIT"),
+            # #1709 delivers this on demand through `abort=True`, and it is a
+            # BaseException the tails' `except Exception` never sees.
+            asyncio.CancelledError(),
+        ],
+        ids=["connection-loss", "cancellation"],
+    )
+    async def test_replace_keeps_the_cog_the_committed_row_names(
+        self, test_db_session, raster_storage, tmp_path, failure
+    ) -> None:
+        admin_id = await self._admin(test_db_session)
+        live = await _make_live_raster(
+            test_db_session, raster_storage, created_by=admin_id
+        )
+        dataset_id = live.dataset.id
+        record_id = live.dataset.record_id
+
+        source = tmp_path / "replacement.tif"
+        source.write_bytes(_geotiff_bytes(seed=91))
+        job = await _queue_replace_job(
+            test_db_session,
+            dataset_id=dataset_id,
+            user_id=admin_id,
+            file_path=str(source),
+        )
+        job_id = job.id
+        attempt_id = job.attempt_id
+
+        try:
+            with _ack_lost_on_publish(job_id, failure=failure) as fired:
+                with pytest.raises(type(failure)):
+                    await reupload_raster.func(
+                        job_id=str(job_id),
+                        dataset_id=str(dataset_id),
+                        file_path=str(source),
+                        user_id=str(admin_id),
+                        attempt_id=str(attempt_id),
+                    )
+            assert fired["count"] == 1, "the publishing commit never fired"
+
+            test_db_session.expire_all()
+            asset = (
+                await test_db_session.execute(
+                    select(RasterAsset).where(RasterAsset.dataset_id == dataset_id)
+                )
+            ).scalar_one()
+            assert asset.asset_uri != live.cog_key, (
+                "precondition: the swap is durable, so the row names the new COG"
+            )
+            for key in (
+                asset.asset_uri,
+                asset.quicklook_256_uri,
+                asset.quicklook_512_uri,
+            ):
+                assert await raster_storage.exists(key), (
+                    f"{key} was deleted after the commit that published it. "
+                    "The dataset now points at bytes that do not exist and "
+                    "nothing in the product can restore them."
+                )
+
+            finished = (
+                await test_db_session.execute(
+                    select(IngestJob).where(IngestJob.id == job_id)
+                )
+            ).scalar_one()
+            assert finished.status == "complete", (
+                "the terminal write landed with the swap, and the failure "
+                "handler is fenced on `running`, so it cannot overwrite it"
+            )
+        finally:
+            await _purge(test_db_session, dataset_id=dataset_id, record_id=record_id)
+
+    async def test_a_probe_that_observes_no_commit_still_reaps(
+        self, test_db_session, raster_storage, tmp_path, monkeypatch
+    ) -> None:
+        """The counterfactual, and the other half of the contract.
+
+        With the probe answering "not committed" — which is what it really
+        answers whenever the row is not ``complete`` for this attempt, pinned
+        above — the tail must reap exactly as it did before, or GAP-017's
+        orphaned bytes come back. It is also the shape the assertions above
+        would have had before the fix, which is what makes them load-bearing.
+        """
+        admin_id = await self._admin(test_db_session)
+        live = await _make_live_raster(
+            test_db_session, raster_storage, created_by=admin_id
+        )
+        dataset_id = live.dataset.id
+        record_id = live.dataset.record_id
+
+        source = tmp_path / "replacement.tif"
+        source.write_bytes(_geotiff_bytes(seed=92))
+        job = await _queue_replace_job(
+            test_db_session,
+            dataset_id=dataset_id,
+            user_id=admin_id,
+            file_path=str(source),
+        )
+        job_id = job.id
+        attempt_id = job.attempt_id
+
+        async def _observes_nothing(*args, **kwargs) -> bool:
+            return False
+
+        monkeypatch.setattr(
+            "app.processing.ingest.tasks_raster_replace.publish_commit_landed",
+            _observes_nothing,
+            raising=True,
+        )
+
+        try:
+            with _ack_lost_on_publish(job_id, failure=ConnectionResetError("dropped")):
+                with pytest.raises(ConnectionResetError):
+                    await reupload_raster.func(
+                        job_id=str(job_id),
+                        dataset_id=str(dataset_id),
+                        file_path=str(source),
+                        user_id=str(admin_id),
+                        attempt_id=str(attempt_id),
+                    )
+
+            test_db_session.expire_all()
+            asset = (
+                await test_db_session.execute(
+                    select(RasterAsset).where(RasterAsset.dataset_id == dataset_id)
+                )
+            ).scalar_one()
+            assert not await raster_storage.exists(asset.asset_uri), (
+                "with the commit observed as not durable the newly written "
+                "keys are orphans, and GAP-017 requires them reaped"
+            )
+        finally:
+            await _purge(test_db_session, dataset_id=dataset_id, record_id=record_id)
+
+    async def test_first_ingest_keeps_the_cog_the_committed_row_names(
+        self, test_db_session, raster_storage, tmp_path
+    ) -> None:
+        """``ingest_raster``: same tail, and its reap used to key off
+        ``final_status``, which the broad handler sets to "failed" even when
+        the failure happened after the swap was durable."""
+        from app.processing.ingest.tasks_raster import ingest_raster
+
+        admin_id = await self._admin(test_db_session)
+        source = tmp_path / "first.tif"
+        source.write_bytes(_geotiff_bytes(seed=93))
+        job = IngestJob(
+            source_filename="first.tif",
+            file_path=str(source),
+            created_by=admin_id,
+            status="pending",
+            user_metadata={"file_type": "raster", "title": "Ack-lost first ingest"},
+        )
+        test_db_session.add(job)
+        await test_db_session.commit()
+        await test_db_session.refresh(job)
+        job_id = job.id
+        attempt_id = job.attempt_id
+
+        dataset_id = record_id = None
+        try:
+            with _ack_lost_on_publish(
+                job_id, failure=ConnectionResetError("dropped")
+            ) as fired:
+                with pytest.raises(ConnectionResetError):
+                    await ingest_raster.func(
+                        job_id=str(job_id),
+                        file_path=str(source),
+                        user_id=str(admin_id),
+                        attempt_id=str(attempt_id),
+                    )
+            assert fired["count"] == 1, "the publishing commit never fired"
+
+            test_db_session.expire_all()
+            finished = (
+                await test_db_session.execute(
+                    select(IngestJob).where(IngestJob.id == job_id)
+                )
+            ).scalar_one()
+            assert finished.status == "complete"
+            dataset_id = finished.dataset_id
+            assert dataset_id is not None, "the publish transaction created the row"
+            record_id = (
+                await test_db_session.execute(
+                    select(Dataset.record_id).where(Dataset.id == dataset_id)
+                )
+            ).scalar_one()
+            asset = (
+                await test_db_session.execute(
+                    select(RasterAsset).where(RasterAsset.dataset_id == dataset_id)
+                )
+            ).scalar_one()
+            for key in (
+                asset.asset_uri,
+                asset.quicklook_256_uri,
+                asset.quicklook_512_uri,
+            ):
+                assert await raster_storage.exists(key), (
+                    f"{key} was deleted after the commit that published it"
+                )
+        finally:
+            await test_db_session.execute(
+                delete(IngestJob).where(IngestJob.id == job_id)
+            )
+            await test_db_session.commit()
+            if dataset_id is not None and record_id is not None:
+                await _purge(
+                    test_db_session, dataset_id=dataset_id, record_id=record_id
+                )
+
+    async def test_vrt_regeneration_keeps_the_generation_it_published(
+        self, test_db_session, raster_storage, monkeypatch
+    ) -> None:
+        from app.processing.ingest.tasks_vrt import regenerate_vrt
+        from app.processing.raster.models import VrtGeneration
+
+        # `regenerate_vrt` binds get_storage at module import, so the fixture's
+        # patch of `app.platform.storage.get_storage` never reaches its puts.
+        monkeypatch.setattr(
+            "app.processing.ingest.tasks_vrt.get_storage",
+            lambda: raster_storage,
+            raising=True,
+        )
+        admin_id = await self._admin(test_db_session)
+        member = await _make_live_raster(
+            test_db_session, raster_storage, created_by=admin_id
+        )
+        parent = await _make_vrt_parent(
+            test_db_session, raster_storage, created_by=admin_id, member=member
+        )
+        ids = (
+            parent.dataset.id,
+            parent.dataset.record_id,
+            member.dataset.id,
+            member.dataset.record_id,
+        )
+        parent_id = parent.dataset.id
+        prior_key = parent.cog_key
+
+        generation_id = uuid.uuid4()
+        job = IngestJob(
+            dataset_id=parent_id,
+            source_filename="regen",
+            created_by=admin_id,
+            status="pending",
+            user_metadata={"vrt_regenerate": True},
+        )
+        test_db_session.add(job)
+        test_db_session.add(
+            VrtGeneration(
+                id=generation_id,
+                vrt_dataset_id=parent_id,
+                status="pending",
+                started_at=datetime.now(timezone.utc),
+            )
+        )
+        await test_db_session.execute(
+            text(
+                "UPDATE catalog.raster_assets "
+                "SET current_generation_id = :gen, status = 'regenerating' "
+                "WHERE dataset_id = :id"
+            ),
+            {"gen": generation_id, "id": parent_id},
+        )
+        await test_db_session.commit()
+        await test_db_session.refresh(job)
+        job_id = job.id
+        attempt_id = job.attempt_id
+
+        try:
+            with _ack_lost_on_publish(
+                job_id, failure=ConnectionResetError("dropped")
+            ) as fired:
+                with pytest.raises(ConnectionResetError):
+                    await regenerate_vrt.func(
+                        job_id=str(job_id),
+                        vrt_dataset_id=str(parent_id),
+                        attempt_id=str(attempt_id),
+                        generation_id=str(generation_id),
+                    )
+            assert fired["count"] == 1, "the publishing commit never fired"
+
+            test_db_session.expire_all()
+            asset = (
+                await test_db_session.execute(
+                    select(RasterAsset).where(RasterAsset.dataset_id == parent_id)
+                )
+            ).scalar_one()
+            assert asset.asset_uri != prior_key, (
+                "precondition: the generation swap is durable"
+            )
+            assert await raster_storage.exists(asset.asset_uri), (
+                f"{asset.asset_uri} was deleted after the commit that "
+                "published it — the VRT dataset now serves nothing"
+            )
+        finally:
+            await _purge_vrt(test_db_session, ids=ids)
+
+    async def test_vrt_creation_keeps_the_artifact_it_published(
+        self, test_db_session, raster_storage
+    ) -> None:
+        """``ingest_vrt`` shares the tail even though the audit excerpt stopped
+        at the regenerate one: the dataset row and the VRT object become
+        visible in the same transaction, so a lost acknowledgement deletes
+        exactly what the committed row names."""
+        from pathlib import Path as _P
+
+        from app.processing.ingest.tasks_vrt import ingest_vrt, resolve_vrt_source_path
+
+        admin_id = await self._admin(test_db_session)
+        member = await _make_live_raster(
+            test_db_session, raster_storage, created_by=admin_id
+        )
+        member_path = _P(
+            resolve_vrt_source_path(member.asset.asset_uri, tenant_id=None)
+        )
+        member_path.parent.mkdir(parents=True, exist_ok=True)
+        member_path.write_bytes(_geotiff_bytes(seed=1))
+        # Read before the expire_all below: an expired attribute lazy-loads,
+        # and under AnyIO that raises MissingGreenlet (see _purge_vrt).
+        member_ds = member.dataset.id
+        member_rec = member.dataset.record_id
+
+        job = IngestJob(
+            source_filename="mosaic.vrt",
+            created_by=admin_id,
+            status="pending",
+            user_metadata={"title": "Ack-lost mosaic", "visibility": "public"},
+        )
+        test_db_session.add(job)
+        await test_db_session.commit()
+        await test_db_session.refresh(job)
+        job_id = job.id
+        attempt_id = job.attempt_id
+
+        vrt_ds = vrt_rec = None
+        try:
+            with _ack_lost_on_publish(
+                job_id, failure=ConnectionResetError("dropped")
+            ) as fired:
+                with pytest.raises(ConnectionResetError):
+                    await ingest_vrt.func(
+                        job_id=str(job_id),
+                        source_dataset_ids=_json.dumps([str(member_ds)]),
+                        user_id=str(admin_id),
+                        attempt_id=str(attempt_id),
+                        vrt_type="mosaic",
+                        resolution_strategy="finest",
+                    )
+            assert fired["count"] == 1, "the publishing commit never fired"
+
+            test_db_session.expire_all()
+            finished = (
+                await test_db_session.execute(
+                    select(IngestJob).where(IngestJob.id == job_id)
+                )
+            ).scalar_one()
+            assert finished.status == "complete"
+            vrt_ds = finished.dataset_id
+            assert vrt_ds is not None
+            vrt_rec = (
+                await test_db_session.execute(
+                    select(Dataset.record_id).where(Dataset.id == vrt_ds)
+                )
+            ).scalar_one()
+            asset = (
+                await test_db_session.execute(
+                    select(RasterAsset).where(RasterAsset.dataset_id == vrt_ds)
+                )
+            ).scalar_one()
+            assert await raster_storage.exists(asset.asset_uri), (
+                f"{asset.asset_uri} was deleted after the commit that published it"
+            )
+        finally:
+            await test_db_session.execute(
+                delete(IngestJob).where(IngestJob.id == job_id)
+            )
+            await test_db_session.commit()
+            if vrt_ds is not None and vrt_rec is not None:
+                await _purge_vrt(
+                    test_db_session,
+                    ids=(vrt_ds, vrt_rec, member_ds, member_rec),
+                )
+            else:
+                await _purge(
+                    test_db_session, dataset_id=member_ds, record_id=member_rec
+                )
+
+    def test_every_publish_tail_gates_its_reap_on_the_probe(self) -> None:
+        """Structural, because the finding is a SHAPE.
+
+        Each tail's orphan reap must be gated on a name the probe assigns, not
+        on a flag set after the commit returned. A fifth tail written the old
+        way, or a revert of one of these four, fails here.
+        """
+        import ast
+        import inspect
+
+        from app.processing.ingest import tasks_raster, tasks_raster_replace, tasks_vrt
+
+        checked = 0
+        for module in (tasks_raster, tasks_raster_replace, tasks_vrt):
+            tree = ast.parse(inspect.getsource(module))
+            for func in ast.walk(tree):
+                if not isinstance(func, (ast.AsyncFunctionDef, ast.FunctionDef)):
+                    continue
+                probed = {
+                    target.id
+                    for node in ast.walk(func)
+                    if isinstance(node, ast.Assign)
+                    and isinstance(node.value, ast.Await)
+                    and isinstance(node.value.value, ast.Call)
+                    and getattr(node.value.value.func, "id", None)
+                    == "publish_commit_landed"
+                    for target in node.targets
+                    if isinstance(target, ast.Name)
+                }
+                for node in ast.walk(func):
+                    if not isinstance(node, ast.Try) or not node.finalbody:
+                        continue
+                    for stmt in node.finalbody:
+                        for guard in ast.walk(stmt):
+                            if not isinstance(guard, ast.If):
+                                continue
+                            reaps = any(
+                                isinstance(call, ast.Call)
+                                and getattr(call.func, "id", None)
+                                == "_cleanup_orphaned_storage_keys"
+                                for body in guard.body
+                                for call in ast.walk(body)
+                            )
+                            if not reaps:
+                                continue
+                            names = {
+                                n.id
+                                for n in ast.walk(guard.test)
+                                if isinstance(n, ast.Name)
+                            }
+                            assert names & probed, (
+                                f"{module.__name__}.{func.name} reaps written "
+                                "storage keys behind a guard the commit probe "
+                                f"never wrote (guard reads {sorted(names)}, "
+                                f"probe assigns {sorted(probed)})"
+                            )
+                            checked += 1
+        assert checked == 4, (
+            f"expected the four publish tails, walked {checked} — a tail was "
+            "added or removed without updating this gate"
+        )

--- a/backend/tests/test_raster_replace_1221.py
+++ b/backend/tests/test_raster_replace_1221.py
@@ -5620,6 +5620,12 @@ class TestAckLostCommitDoesNotDeleteThePublishedRaster:
     committed row had just been pointed at. The superseded objects are not
     restored — the reaper of the OLD keys never ran — so nothing in the
     product can recover the dataset.
+
+    fix(#1778 codex r1): observing the publish now makes the tail STAND DOWN
+    rather than re-raise, so these tasks return normally and no failure write
+    runs at all. Gating only the reap left `regenerate_vrt` stamping the
+    `completed` VrtGeneration `failed`, which `get_vrt_status` reads as "this
+    dataset has no completed generation".
     """
 
     @staticmethod
@@ -5661,14 +5667,15 @@ class TestAckLostCommitDoesNotDeleteThePublishedRaster:
 
         try:
             with _ack_lost_on_publish(job_id, failure=failure) as fired:
-                with pytest.raises(type(failure)):
-                    await reupload_raster.func(
-                        job_id=str(job_id),
-                        dataset_id=str(dataset_id),
-                        file_path=str(source),
-                        user_id=str(admin_id),
-                        attempt_id=str(attempt_id),
-                    )
+                # Returns rather than raising: the swap is durable, so there is
+                # no failure for the handler to report (#1778 codex r1).
+                await reupload_raster.func(
+                    job_id=str(job_id),
+                    dataset_id=str(dataset_id),
+                    file_path=str(source),
+                    user_id=str(admin_id),
+                    attempt_id=str(attempt_id),
+                )
             assert fired["count"] == 1, "the publishing commit never fired"
 
             test_db_session.expire_all()
@@ -5697,8 +5704,20 @@ class TestAckLostCommitDoesNotDeleteThePublishedRaster:
                 )
             ).scalar_one()
             assert finished.status == "complete", (
-                "the terminal write landed with the swap, and the failure "
-                "handler is fenced on `running`, so it cannot overwrite it"
+                "the terminal write landed with the swap, and the tail stands "
+                "down instead of entering the handler that would report it "
+                "failed"
+            )
+            run = (
+                await test_db_session.execute(
+                    select(DatasetRefreshRun).where(
+                        DatasetRefreshRun.ingest_job_id == job_id
+                    )
+                )
+            ).scalar_one()
+            assert run.status == "succeeded", (
+                "the refresh history must record what happened, not what the "
+                "lost acknowledgement suggested"
             )
         finally:
             await _purge(test_db_session, dataset_id=dataset_id, record_id=record_id)
@@ -5766,12 +5785,24 @@ class TestAckLostCommitDoesNotDeleteThePublishedRaster:
             await _purge(test_db_session, dataset_id=dataset_id, record_id=record_id)
 
     async def test_first_ingest_keeps_the_cog_the_committed_row_names(
-        self, test_db_session, raster_storage, tmp_path
+        self, test_db_session, raster_storage, tmp_path, monkeypatch
     ) -> None:
         """``ingest_raster``: same tail, and its reap used to key off
         ``final_status``, which the broad handler sets to "failed" even when
-        the failure happened after the swap was durable."""
+        the failure happened after the swap was durable. Its handler also
+        emails the operator, so standing down is what stops a durable ingest
+        being reported as a failure (#1778 codex r1)."""
+        from app.core.config import settings
+        from app.platform.notifications import events as events_mod
         from app.processing.ingest.tasks_raster import ingest_raster
+
+        emitted: list = []
+
+        async def _fake_notify(notification):
+            emitted.append(notification)
+
+        monkeypatch.setattr(settings, "notify_on_ingest_failed", True, raising=False)
+        monkeypatch.setattr(events_mod, "notify", _fake_notify)
 
         admin_id = await self._admin(test_db_session)
         source = tmp_path / "first.tif"
@@ -5794,14 +5825,16 @@ class TestAckLostCommitDoesNotDeleteThePublishedRaster:
             with _ack_lost_on_publish(
                 job_id, failure=ConnectionResetError("dropped")
             ) as fired:
-                with pytest.raises(ConnectionResetError):
-                    await ingest_raster.func(
-                        job_id=str(job_id),
-                        file_path=str(source),
-                        user_id=str(admin_id),
-                        attempt_id=str(attempt_id),
-                    )
+                await ingest_raster.func(
+                    job_id=str(job_id),
+                    file_path=str(source),
+                    user_id=str(admin_id),
+                    attempt_id=str(attempt_id),
+                )
             assert fired["count"] == 1, "the publishing commit never fired"
+            assert [n.event_type for n in emitted] == [], (
+                "a durable ingest emailed the operator that it failed"
+            )
 
             test_db_session.expire_all()
             finished = (
@@ -5841,7 +5874,7 @@ class TestAckLostCommitDoesNotDeleteThePublishedRaster:
                 )
 
     async def test_vrt_regeneration_keeps_the_generation_it_published(
-        self, test_db_session, raster_storage, monkeypatch
+        self, client, admin_auth_header, test_db_session, raster_storage, monkeypatch
     ) -> None:
         from app.processing.ingest.tasks_vrt import regenerate_vrt
         from app.processing.raster.models import VrtGeneration
@@ -5903,13 +5936,12 @@ class TestAckLostCommitDoesNotDeleteThePublishedRaster:
             with _ack_lost_on_publish(
                 job_id, failure=ConnectionResetError("dropped")
             ) as fired:
-                with pytest.raises(ConnectionResetError):
-                    await regenerate_vrt.func(
-                        job_id=str(job_id),
-                        vrt_dataset_id=str(parent_id),
-                        attempt_id=str(attempt_id),
-                        generation_id=str(generation_id),
-                    )
+                await regenerate_vrt.func(
+                    job_id=str(job_id),
+                    vrt_dataset_id=str(parent_id),
+                    attempt_id=str(attempt_id),
+                    generation_id=str(generation_id),
+                )
             assert fired["count"] == 1, "the publishing commit never fired"
 
             test_db_session.expire_all()
@@ -5924,6 +5956,41 @@ class TestAckLostCommitDoesNotDeleteThePublishedRaster:
             assert await raster_storage.exists(asset.asset_uri), (
                 f"{asset.asset_uri} was deleted after the commit that "
                 "published it — the VRT dataset now serves nothing"
+            )
+
+            # fix(#1778 codex r1). The reap was only the deletion. The failure
+            # handler this tail used to enter also relabelled the history and
+            # the asset, and those have readers.
+            assert asset.status == "ready", (
+                f"the asset is {asset.status!r}: the failure handler ran "
+                "against a published generation"
+            )
+            assert asset.current_generation_id is None, (
+                "the publish cleared the pointer and the handler put it back"
+            )
+            generation = (
+                await test_db_session.execute(
+                    select(VrtGeneration).where(VrtGeneration.id == generation_id)
+                )
+            ).scalar_one()
+            assert generation.status == "completed", (
+                f"the generation reads {generation.status!r} for a build whose "
+                "artifact the dataset is serving"
+            )
+            assert generation.error_message is None, (
+                "a completed generation carries no failure reason"
+            )
+
+            # The reader codex named: get_vrt_status derives
+            # `last_generation_at` from the latest COMPLETED generation, so a
+            # falsely failed one erases the regeneration from the UI.
+            resp = await client.get(
+                f"/datasets/{parent_id}/vrt/status/", headers=admin_auth_header
+            )
+            assert resp.status_code == 200, resp.text
+            assert resp.json()["last_generation_at"] is not None, (
+                "the VRT status endpoint reports no completed generation for a "
+                "dataset that just published one"
             )
         finally:
             await _purge_vrt(test_db_session, ids=ids)
@@ -5970,15 +6037,14 @@ class TestAckLostCommitDoesNotDeleteThePublishedRaster:
             with _ack_lost_on_publish(
                 job_id, failure=ConnectionResetError("dropped")
             ) as fired:
-                with pytest.raises(ConnectionResetError):
-                    await ingest_vrt.func(
-                        job_id=str(job_id),
-                        source_dataset_ids=_json.dumps([str(member_ds)]),
-                        user_id=str(admin_id),
-                        attempt_id=str(attempt_id),
-                        vrt_type="mosaic",
-                        resolution_strategy="finest",
-                    )
+                await ingest_vrt.func(
+                    job_id=str(job_id),
+                    source_dataset_ids=_json.dumps([str(member_ds)]),
+                    user_id=str(admin_id),
+                    attempt_id=str(attempt_id),
+                    vrt_type="mosaic",
+                    resolution_strategy="finest",
+                )
             assert fired["count"] == 1, "the publishing commit never fired"
 
             test_db_session.expire_all()
@@ -6003,6 +6069,10 @@ class TestAckLostCommitDoesNotDeleteThePublishedRaster:
             assert await raster_storage.exists(asset.asset_uri), (
                 f"{asset.asset_uri} was deleted after the commit that published it"
             )
+            assert asset.status == "ready", (
+                f"the asset is {asset.status!r}: the failure handler ran "
+                "against a published build"
+            )
         finally:
             await test_db_session.execute(
                 delete(IngestJob).where(IngestJob.id == job_id)
@@ -6018,17 +6088,29 @@ class TestAckLostCommitDoesNotDeleteThePublishedRaster:
                     test_db_session, dataset_id=member_ds, record_id=member_rec
                 )
 
-    def test_every_publish_tail_gates_its_reap_on_the_probe(self) -> None:
+    def test_every_publish_tail_stands_down_on_an_observed_publish(self) -> None:
         """Structural, because the finding is a SHAPE.
 
-        Each tail's orphan reap must be gated on a name the probe assigns, not
-        on a flag set after the commit returned. A fifth tail written the old
-        way, or a revert of one of these four, fails here.
+        Two properties per tail, and the second is fix(#1778 codex r1): the
+        handler that probes must END the landed branch by returning, not by
+        re-raising into a failure handler that writes about a job that
+        succeeded, and it must absorb the cancellation it is choosing to stop
+        honouring. The orphan reap must still be gated on the name that
+        handler assigns rather than on a flag set after the commit returned.
+
+        A fifth tail written the old way, or a revert of any of these four,
+        fails here.
         """
         import ast
         import inspect
 
         from app.processing.ingest import tasks_raster, tasks_raster_replace, tasks_vrt
+
+        def _calls(node, name: str) -> bool:
+            return any(
+                isinstance(inner, ast.Call) and getattr(inner.func, "id", None) == name
+                for inner in ast.walk(node)
+            )
 
         checked = 0
         for module in (tasks_raster, tasks_raster_replace, tasks_vrt):
@@ -6036,17 +6118,33 @@ class TestAckLostCommitDoesNotDeleteThePublishedRaster:
             for func in ast.walk(tree):
                 if not isinstance(func, (ast.AsyncFunctionDef, ast.FunctionDef)):
                     continue
-                probed = {
-                    target.id
-                    for node in ast.walk(func)
-                    if isinstance(node, ast.Assign)
-                    and isinstance(node.value, ast.Await)
-                    and isinstance(node.value.value, ast.Call)
-                    and getattr(node.value.value.func, "id", None)
-                    == "publish_commit_landed"
-                    for target in node.targets
-                    if isinstance(target, ast.Name)
-                }
+                published: set[str] = set()
+                for handler in ast.walk(func):
+                    if not isinstance(handler, ast.ExceptHandler):
+                        continue
+                    if not _calls(handler, "publish_commit_landed"):
+                        continue
+                    where = f"{module.__name__}.{func.name}"
+                    assert any(
+                        isinstance(node, ast.Return) for node in ast.walk(handler)
+                    ), (
+                        f"{where} probes the commit and then re-raises. The "
+                        "publish is durable, so the failure handler it enters "
+                        "reports a job that succeeded as failed."
+                    )
+                    assert _calls(handler, "absorb_cancellation"), (
+                        f"{where} returns out of a caught BaseException "
+                        "without absorbing the cancellation it stops honouring"
+                    )
+                    published |= {
+                        target.id
+                        for node in ast.walk(handler)
+                        if isinstance(node, ast.Assign)
+                        for target in node.targets
+                        if isinstance(target, ast.Name)
+                    }
+                if not published:
+                    continue
                 for node in ast.walk(func):
                     if not isinstance(node, ast.Try) or not node.finalbody:
                         continue
@@ -6054,25 +6152,21 @@ class TestAckLostCommitDoesNotDeleteThePublishedRaster:
                         for guard in ast.walk(stmt):
                             if not isinstance(guard, ast.If):
                                 continue
-                            reaps = any(
-                                isinstance(call, ast.Call)
-                                and getattr(call.func, "id", None)
-                                == "_cleanup_orphaned_storage_keys"
+                            if not any(
+                                _calls(body, "_cleanup_orphaned_storage_keys")
                                 for body in guard.body
-                                for call in ast.walk(body)
-                            )
-                            if not reaps:
+                            ):
                                 continue
                             names = {
                                 n.id
                                 for n in ast.walk(guard.test)
                                 if isinstance(n, ast.Name)
                             }
-                            assert names & probed, (
+                            assert names & published, (
                                 f"{module.__name__}.{func.name} reaps written "
                                 "storage keys behind a guard the commit probe "
                                 f"never wrote (guard reads {sorted(names)}, "
-                                f"probe assigns {sorted(probed)})"
+                                f"probe assigns {sorted(published)})"
                             )
                             checked += 1
         assert checked == 4, (

--- a/backend/tests/test_raster_replace_1221.py
+++ b/backend/tests/test_raster_replace_1221.py
@@ -5653,6 +5653,11 @@ class TestAckLostCommitDoesNotDeleteThePublishedRaster:
         )
         dataset_id = live.dataset.id
         record_id = live.dataset.record_id
+        prior_keys = [
+            live.cog_key,
+            live.asset.quicklook_256_uri,
+            live.asset.quicklook_512_uri,
+        ]
 
         source = tmp_path / "replacement.tif"
         source.write_bytes(_geotiff_bytes(seed=91))
@@ -5719,6 +5724,18 @@ class TestAckLostCommitDoesNotDeleteThePublishedRaster:
                 "the refresh history must record what happened, not what the "
                 "lost acknowledgement suggested"
             )
+
+            # fix(#1778 codex r2). Standing down from the failure handler is
+            # not standing down from the success work: this is the ONLY
+            # deletion of the superseded objects, and the committed pointer
+            # already names the new ones, so skipping it strands three objects
+            # per lost acknowledgement outside quota accounting for the life of
+            # the dataset.
+            for key in prior_keys:
+                assert not await raster_storage.exists(key), (
+                    f"the superseded {key} survived the swap. Nothing "
+                    "references it and nothing counts it."
+                )
         finally:
             await _purge(test_db_session, dataset_id=dataset_id, record_id=record_id)
 
@@ -5956,6 +5973,14 @@ class TestAckLostCommitDoesNotDeleteThePublishedRaster:
             assert await raster_storage.exists(asset.asset_uri), (
                 f"{asset.asset_uri} was deleted after the commit that "
                 "published it — the VRT dataset now serves nothing"
+            )
+
+            # fix(#1778 codex r2): the superseded generation's object is the
+            # mirror obligation. The committed asset already names the new one,
+            # so a stand-down that skipped the reap would strand it outside
+            # quota accounting.
+            assert not await raster_storage.exists(prior_key), (
+                f"the superseded {prior_key} survived the generation swap"
             )
 
             # fix(#1778 codex r1). The reap was only the deletion. The failure

--- a/backend/tests/test_raster_replace_1221.py
+++ b/backend/tests/test_raster_replace_1221.py
@@ -6088,6 +6088,125 @@ class TestAckLostCommitDoesNotDeleteThePublishedRaster:
                     test_db_session, dataset_id=member_ds, record_id=member_rec
                 )
 
+    async def test_a_post_publish_followup_failure_writes_no_failure_row(
+        self, client, admin_auth_header, test_db_session, raster_storage, monkeypatch
+    ) -> None:
+        """fix(#1778 codex r1): the other way into the failure handler.
+
+        The stand-down covers the lost acknowledgement. It cannot cover this:
+        the prior-key reap, `invalidate_catalog_cache` and `defer_embedding`
+        all run inside the same `try` as the publish, so a Valkey outage
+        reaches the handler with the swap already durable. The handler's job
+        and asset writes are fenced; its generation write was not, and
+        `get_vrt_status` reads exactly that row.
+        """
+        from app.processing.ingest.tasks_vrt import regenerate_vrt
+        from app.processing.raster.models import VrtGeneration
+
+        monkeypatch.setattr(
+            "app.processing.ingest.tasks_vrt.get_storage",
+            lambda: raster_storage,
+            raising=True,
+        )
+        admin_id = await self._admin(test_db_session)
+        member = await _make_live_raster(
+            test_db_session, raster_storage, created_by=admin_id
+        )
+        parent = await _make_vrt_parent(
+            test_db_session, raster_storage, created_by=admin_id, member=member
+        )
+        ids = (
+            parent.dataset.id,
+            parent.dataset.record_id,
+            member.dataset.id,
+            member.dataset.record_id,
+        )
+        parent_id = parent.dataset.id
+
+        generation_id = uuid.uuid4()
+        job = IngestJob(
+            dataset_id=parent_id,
+            source_filename="regen",
+            created_by=admin_id,
+            status="pending",
+            user_metadata={"vrt_regenerate": True},
+        )
+        test_db_session.add(job)
+        test_db_session.add(
+            VrtGeneration(
+                id=generation_id,
+                vrt_dataset_id=parent_id,
+                status="pending",
+                started_at=datetime.now(timezone.utc),
+            )
+        )
+        await test_db_session.execute(
+            text(
+                "UPDATE catalog.raster_assets "
+                "SET current_generation_id = :gen, status = 'regenerating' "
+                "WHERE dataset_id = :id"
+            ),
+            {"gen": generation_id, "id": parent_id},
+        )
+        await test_db_session.commit()
+        await test_db_session.refresh(job)
+        job_id = job.id
+        attempt_id = job.attempt_id
+
+        async def _die(*args, **kwargs):
+            raise RuntimeError("valkey went away right after the swap")
+
+        # The first await after the publish commit that can fail.
+        monkeypatch.setattr(
+            "app.processing.ingest.tasks_vrt.invalidate_catalog_cache",
+            _die,
+            raising=True,
+        )
+
+        try:
+            await regenerate_vrt.func(
+                job_id=str(job_id),
+                vrt_dataset_id=str(parent_id),
+                attempt_id=str(attempt_id),
+                generation_id=str(generation_id),
+            )
+
+            test_db_session.expire_all()
+            generation = (
+                await test_db_session.execute(
+                    select(VrtGeneration).where(VrtGeneration.id == generation_id)
+                )
+            ).scalar_one()
+            assert generation.status == "completed", (
+                f"the generation reads {generation.status!r} because a cache "
+                "purge failed after the swap was durable"
+            )
+            assert generation.error_message is None
+            asset = (
+                await test_db_session.execute(
+                    select(RasterAsset).where(RasterAsset.dataset_id == parent_id)
+                )
+            ).scalar_one()
+            assert asset.status == "ready"
+            assert asset.current_generation_id is None
+            finished = (
+                await test_db_session.execute(
+                    select(IngestJob).where(IngestJob.id == job_id)
+                )
+            ).scalar_one()
+            assert finished.status == "complete"
+
+            resp = await client.get(
+                f"/datasets/{parent_id}/vrt/status/", headers=admin_auth_header
+            )
+            assert resp.status_code == 200, resp.text
+            assert resp.json()["last_generation_at"] is not None, (
+                "the VRT status endpoint lost the completed generation to a "
+                "failed cache purge"
+            )
+        finally:
+            await _purge_vrt(test_db_session, ids=ids)
+
     def test_every_publish_tail_stands_down_on_an_observed_publish(self) -> None:
         """Structural, because the finding is a SHAPE.
 
@@ -6172,4 +6291,56 @@ class TestAckLostCommitDoesNotDeleteThePublishedRaster:
         assert checked == 4, (
             f"expected the four publish tails, walked {checked} — a tail was "
             "added or removed without updating this gate"
+        )
+
+    def test_the_generation_failure_write_is_fenced_at_the_statement(self) -> None:
+        """fix(#1778 codex r1): the rule stated at the write, not only at the
+        caller.
+
+        The handler guard makes this branch unreachable from
+        ``regenerate_vrt``'s own paths today, which is exactly why it is
+        pinned here rather than by an execution test: the flag is a local, the
+        fence is a property of the statement, and a future path into the
+        handler must not be able to relabel a generation whose artifact the
+        dataset is serving. Its two peers, the ``current_generation_id`` fence
+        on the asset and the ``running`` fence on the job, are enforced by the
+        database predicate itself.
+        """
+        import ast
+        import inspect
+
+        from app.processing.ingest import tasks_vrt
+
+        tree = ast.parse(inspect.getsource(tasks_vrt))
+        writes = [
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Assign)
+            and any(
+                isinstance(t, ast.Attribute)
+                and t.attr == "status"
+                and getattr(t.value, "id", None) == "gen"
+                for t in node.targets
+            )
+        ]
+        assert writes, "the generation failure write moved or was renamed"
+        fenced = [
+            guard
+            for guard in ast.walk(tree)
+            if isinstance(guard, ast.If)
+            and any(write in ast.walk(guard) for write in writes)
+            and any(
+                isinstance(cmp_node, ast.Compare)
+                and any(
+                    isinstance(c, ast.Constant) and c.value == "completed"
+                    for c in cmp_node.comparators
+                )
+                for cmp_node in ast.walk(guard.test)
+            )
+        ]
+        assert fenced, (
+            "the failure handler stamps VrtGeneration.status without asking "
+            "whether the generation already completed, so a published "
+            "regeneration can be relabelled failed and get_vrt_status will "
+            "report the dataset as having no completed generation"
         )


### PR DESCRIPTION
Three findings from the codebase audit of 2026-08-30 (8dc529f17), tracked in #1778. I re-checked each one against main at 3b79588e4 before writing code; all three were still present, and none of them had been fixed by the week of merges since the audit ran.

## 1. "A cancel or connection loss during `session.commit()` makes the raster-replace failure cleanup delete the live COG the committed row now points at"

A commit whose acknowledgement is lost may still have been applied by PostgreSQL. Every raster and VRT publish tail set its "published" flag on the line after `await session.commit()` and read that flag in the terminal cleanup, so a dropped connection, or the `asyncio.CancelledError` that #1709's `abort=True` delivers, left the flag false and the cleanup deleted the exact object keys the committed row had just been pointed at. The superseded objects are not restored, because the reaper of the old keys never ran, so the dataset names bytes that no longer exist and nothing in the product can put it back.

`publish_commit_landed` in `tasks_raster_common.py` applies the reasoning `_url_import_transition_landed` already carries for the URL-import path (fix #1708 codex r11): read the row back on a fresh session and decide from what you observe, standing down when the probe itself cannot read. One helper serves every tail because all of them stamp the job `complete` in the same transaction as the pointer swap, so `status == 'complete'` fenced on this attempt's id is an exact signal, and no other attempt can produce it (fresh attempt token, `retry=0`).

Four call sites, not the three the brief named. The audit's excerpt cites `tasks_raster_replace.py`, `tasks_raster.py` and `regenerate_vrt`, but `ingest_vrt` in the same file has the same tail with the same consequence, so it is fixed here too rather than left as the one that still deletes what it published.

A tail that observes its publish landed now STANDS DOWN: it returns instead of re-raising, so no failure write runs at all. Gating only the storage reap was not enough, and codex round 1 found why. The tail still entered its failure handler, and in `regenerate_vrt` two of that handler's three writes are fenced (the job on `running`, the asset on `current_generation_id`) while the third is not: it reloads the now `completed` `VrtGeneration` and stamps it `failed`. `get_vrt_status` derives `last_generation_at` from the latest completed generation, so the regeneration vanishes from the UI, and the stale-generation sweep reads the same row as evidence the asset was unhealthy.

Returning means swallowing the `CancelledError` a cancel delivers, so `absorb_cancellation` calls `Task.uncancel()` first. Suppressing a cancellation without saying so leaves `Task.cancelling()` above zero for a structured-concurrency parent to misread.

The stand-down cannot cover every route into the handler. `invalidate_catalog_cache`, `defer_embedding`, the prior-key reap and the billing event all run inside the same `try` as the publish, so a Valkey outage lands there after the dataset is live. Three tails now refuse to run their failure writes once the published flag is set. `ingest_raster`'s is the one an operator notices, because its handler emails them that an ingest they can see in the catalog failed. `reupload_raster` keeps no such guard and says why in place: its post-swap followups have their own fence, and every write in its handler is already fenced against a completed job. The generation update also gained a `status != 'completed'` fence, so the rule is stated at the write and not only at the caller, beside the two fences that were already there.

Round 2 found the stand-down was too broad by one step: `reupload_raster` returned before `_run_post_swap_followups`, which holds the only deletion of the superseded COG and quicklooks. The committed pointer already names the new keys, so each lost acknowledgement stranded three objects that no row references and no quota counts, for the life of the dataset. Standing down from the failure handler is not standing down from the success work, so both stand-downs now run their reclaiming followup first, through a shared wrapper (`run_post_swap_followups_best_effort`) and a named `_reap_superseded_generation_objects` that carry the fence both paths need. `ingest_vrt` and `ingest_raster` were checked for the same gap: a first build supersedes nothing, and what they skip is the cache purge, the embedding defer, the completion notification and the metering event, all recoverable and none of them holding unreferenced bytes. Their comments record that.

The reap keys off the probe's answer instead of `final_status`. That also closes the post-commit half of the same class in `tasks_raster.py`: its broad handler sets `final_status = "failed"` even when the failure happened after the swap was durable, which is what fix(#1290 review) corrected in the replace tail and never carried over. `final_status` keeps deciding the staged-original deletions, deliberately, because standing down there would turn a probe failure into a second and worse deletion.

`reupload_raster` sat one point under the McCabe ceiling, so the two branches that always did the same unlink are merged into one condition to pay for the stand-down branch.

## 2. "The upload-safety validation exit is copy-pasted into four ingest tasks; the fix(#1290) NO unlink correction reached only the two raster copies"

`tasks_vector.ingest_file`'s copy still unlinked, so on a local-storage install a worker-side validation failure deleted the user's only copy of the file it had just recorded as failed. The canonical trigger needs nobody hostile: lowering `UPLOAD_MAX_SIZE_MB` while a job sits queued fails it at worker pickup. The exit now leaves the decision to `_should_unlink_staging` in the terminal `finally`, which already distinguishes a durable local original from a downloaded scratch copy and runs on that return.

## 3. "Four ingest tasks hand-roll the failure-write block instead of calling `_cleanup_staging_on_failure`"

`ingest_file`, `ingest_service` and `ingest_vrt` route through the shared helper now. The three things their copies left out are the three that matter to somebody: the `redact_url_credentials` backstop on the persisted message, the `pending`-inclusive attempt fence from fix(#1274 review), and the `ingest_failed` notification. An operator with `notify_on_ingest_failed` on was told about raster imports and re-uploads and heard nothing when a vector file import, a service import or a VRT build failed.

The helper skips its `DROP` when handed an empty staging-table name, which is what lets the VRT tail use it: interpolating `""` raises inside the best-effort guard and would have logged a cleanup failure on every VRT build failure while saying nothing true.

Round 2 found that the helper ran its `DROP` before writing the failure row. PostgreSQL aborts the whole transaction on any statement error, so a drop that hit a lock or statement timeout left the session unusable and the failure `UPDATE` that followed raised `current transaction is aborted`. The job stayed `running` with no reason recorded until the stale sweep, and routing three more tails through this helper widened that from two callers to five. The failure row is written and committed first now, and the drop runs last in its own guarded block that rolls back its own wreckage. The drop still runs before the rowcount early return, because the table name is attempt-scoped and belongs to this attempt whether or not a newer one owns the job row.

`tasks_raster.ingest_raster` keeps its own copy. It is the one tail that already emits `ingest_failed`, from two hand-written blocks, and routing it through the helper would change its subject lines and move the emission on its early validation exit. Listed under "left alone" rather than silently skipped.

## Schema, API and config impact

None. Every change is inside Procrastinate task bodies and one shared helper. `dump_openapi.py --check` passes with no drift, so no SDK or `api.generated.ts` regeneration is owed. No migration, no new setting, no user-facing copy, no new translation key.

## Verification

Run from this worktree with `.env.test` and Postgres at localhost:5434, on the committed tree at 1410c15d6.

- `uv run pytest tests/ -q -p no:randomly -k "vrt or raster or ingest or staging or reupload or job or event"`: 1957 passed, 5 skipped, 8824 deselected, 0 failed
- targeted set (`test_raster_replace_1221`, `test_ingest_vector_failure_tails`, `test_event_ingest`, `test_raster_ingest`, `test_vrt_ingest_tasks`, `test_regenerate_vrt_integration`, `test_vrt_creation_173`, `test_job_cancel_vrt`, `test_vrt_stale_sweep_gap002`, `test_vrt_lifecycle_188`, `test_service_token_redaction_1277`, `test_reupload_completion_contract_1207`): 311 passed, 0 failed
- `uv run pytest tests/test_raster_replace_1221.py -k "PublishCommitLandedProbe or AckLostCommit" -q`: 15 passed
- `uv run pytest tests/test_ingest_vector_failure_tails.py -q`: 6 passed
- `uv run pytest tests/test_layering.py -q`: 47 passed, 0 failed
- `uv run ruff check .` and `uv run ruff format --check .`: clean
- `PYTHONPATH=. uv run python scripts/dump_openapi.py --check`: exit 0, no drift

Counterfactuals, each run by restoring the pre-fix code and re-running the new tests:

- `tasks_vector.py` restored from before the first commit: the local-original test fails on the deleted upload, the notification test fails with "the operator was told nothing", and the structural gate fails. 3 failed, 1 passed.
- `tasks_raster.py` and `tasks_vrt.py` restored: the first-ingest, VRT-regeneration and VRT-creation ack-loss tests fail on a deleted artifact, and the structural gate fails. 4 failed, 3 passed.
- `tasks_raster_replace.py` restored: both parametrized replace tests fail, on the connection-loss and the cancellation shape. 2 failed.
- Round 1, stand-down removed: the VRT regeneration ack-loss test fails, because the task raises where it must now return.
- Round 1, handler guard removed: `test_a_post_publish_followup_failure_writes_no_failure_row` fails.
- Round 1, generation fence removed: `test_the_generation_failure_write_is_fenced_at_the_statement` fails.
- Round 2, `tasks_common.py` restored to the drop-first order: `test_the_job_still_records_the_original_failure` fails with `InFailedSQLTransactionError: current transaction is aborted`, and the order gate fails. 2 failed. Reordering alone was not enough to reproduce it, which is why both halves shipped: with the rollback still in place the job recovered, so the behavioural test pins the outcome and the AST gate pins the order.
- Round 2, both stand-downs returned to a bare `return`: the two replace ack-loss tests and the VRT regeneration test fail on a superseded object that survived the swap. 3 failed.

A permanent counterfactual ships with the suite: `test_a_probe_that_observes_no_commit_still_reaps` drives the same ack-loss path with the probe answering "not committed" and asserts the keys are reaped, so GAP-017's orphan cleanup is still pinned in the direction the fix must not change.

The ack-loss shape cannot be produced through a real session on demand, so the tests patch `AsyncSession.commit` to run the real commit, ask a fresh session whether the job became `complete`, and raise if it did. That fires on exactly one commit per task, the publishing one, without the test having to count commits or know which phase block it lives in. The aborted-transaction shape is produced the same way, at the server: a patched `_qtable` emits malformed DDL, because a double raising in Python would leave the session healthy and the reordering counterfactual would then pass for the wrong reason.

## Module size caps

Re-measured with `wc -l` and set exact, each with a comment saying what the lines bought:

- `tasks_common.py` 2380 to 2426
- `tasks_vrt.py` 1354 to 1480
- `tasks_vector.py` 1143 to 1161

`tasks_raster.py` (838), `tasks_raster_common.py` (494), `tasks_raster_replace.py` (854) and `tasks_raster_swap.py` (680) are under the 1000-line inclusion threshold and stay ungated.

## Noticed and left alone

- Codex round 1 raised the `VrtGeneration` overwrite that this PR had listed here as a history-row inaccuracy. It has readers, so it is fixed above rather than left; the entry is gone from this list.

- `tasks_reupload.py` carries the fourth copy of the validation exit and still unlinks at line 274, and it is where the audit's fourth excerpt row sits (orphaned attempt-scoped staging tables, and the stale "drop stale staging table from any prior failed attempt" comment at 287 to 292 that can only ever name its own attempt's table). Both verified still present. The file belongs to lane B2b on #1770, so nothing here touches it.
- `ingest_service` revalidates its URL for SSRF before `resolve_ingest_attempt_or_skip`, so that refusal escapes the task before any handler runs and leaves the job pending for the stale sweep. Unrelated to the failure-write copies, untouched.
- The audit recommends extracting the validation exit into a shared `validate_or_fail_attempt` helper. Not done: the defect is the unlink, the fourth call site is in a file this lane must not touch, and an extraction that covers only three of four copies leaves the same drift it was meant to end.
- Routing `ingest_file`'s failure through the shared helper means a superseded attempt's exception now logs nothing, because the helper returns before its log when the attempt fence matches no row. That matches `reupload_file` exactly and is the correct reading: an attempt that no longer owns the job is not reporting that job's outcome.
