### PR TITLE
fix(perf): close the anonymous request-cost ladder (audit 2026-08-30)

### DIFF
--- a/backend/app/modules/catalog/sources/router.py
+++ b/backend/app/modules/catalog/sources/router.py
@@ -1135,6 +1135,15 @@ async def preview_service_layer(
 #    worker and `docker-compose.prod.yml:294` starts two, so on a stock
 #    install these three are three per worker. They are the cheap first layer
 #    that keeps a flood off the database.
+#
+#    fix(#1778): three per worker is now the real number. slowapi scopes a
+#    limit by the request PATH unless the limiter is built with
+#    key_style="endpoint", and this route is dual-shape, so before that a
+#    caller alternating `/signin` with `/signin/` drew on two buckets and put
+#    six requests per worker onto control 4 instead of three. Measured, with
+#    control 4 raised out of the way: six 200s under the old keying, three
+#    200s then three 429s under the new. The key functions below were never
+#    the leak; they carry the user id in both.
 # 3. A PostgreSQL advisory lock per (user, portal host), held across the
 #    mint, so the count below cannot be read by two workers at once.
 # 4. The same three attempts per fifteen minutes counted from the audit rows

--- a/backend/app/platform/ratelimit.py
+++ b/backend/app/platform/ratelimit.py
@@ -16,6 +16,25 @@ four other domains import this module.
 ``_global_rate_limit`` is a callable rather than a literal because the global
 limit is admin-editable at runtime; SlowAPI re-evaluates the default per
 request, so a settings change takes effect without a restart.
+
+fix(#1778): ``key_style="endpoint"`` keys the counter on (client IP, handler)
+instead of (client IP, request path), which is slowapi's default. Under the
+default every distinct URL got its own budget, so a path-parameterised route
+handed one IP a fresh "Global Rate Limit (per second)" allowance per dataset
+id and per z/x/y. The setting operators read as a cap on anonymous request
+cost bounded nothing the caller could not multiply for free by varying a path
+segment. Handlers are enumerated by the route table, so the remaining
+multiplier is fixed at deploy time rather than chosen by the caller.
+
+Two things move with it, both recorded rather than papered over. The
+trailing-slash aliases of a dual-shape route now share one bucket, which is
+strictly stricter and is what the guard in ``tests/test_admin_rate_limit.py``
+was always asking for. Two methods on one path no longer share theirs, which
+is looser by the number of methods the route table declares; that number is
+fixed, unlike the number of URLs. Requests matching no route are unaffected
+either way: slowapi's middleware exempts a request whose handler it cannot
+resolve before key style is ever consulted
+(``slowapi/middleware.py::_should_exempt``).
 """
 
 from fastapi import Request
@@ -29,4 +48,8 @@ def _global_rate_limit(_request: Request | None = None) -> str:
     return f"{get_cached_global_rate_limit()}/second"
 
 
-limiter = Limiter(key_func=get_remote_address, default_limits=[_global_rate_limit])
+limiter = Limiter(
+    key_func=get_remote_address,
+    default_limits=[_global_rate_limit],
+    key_style="endpoint",
+)

--- a/backend/app/processing/tiles/router.py
+++ b/backend/app/processing/tiles/router.py
@@ -2331,7 +2331,17 @@ async def cluster_tile_endpoint(
     # for.
     _ensure_clusterable_dataset(meta)
 
-    additional_columns, cols_cache_key = parse_cols_param(cols, meta.column_info)
+    # fix(#1778): keyed on the effective projection, so `z`, the allowlist and
+    # the mode all reach it. They decide what the request actually changes:
+    # the cluster query emits its own `point_count`/`cluster_id` names, so a
+    # `cols=` naming one of those changes nothing at any zoom.
+    additional_columns, cols_cache_key = parse_cols_param(
+        cols,
+        meta.column_info,
+        z,
+        tile_columns=meta.tile_columns,
+        mode="cluster",
+    )
 
     cache_ttl = meta.tile_cache_ttl or settings.tile_cache_ttl
 
@@ -2494,11 +2504,15 @@ async def tile_endpoint(
     # Get column info for attribute selection
     columns = meta.column_info
 
-    # fix(#1778): `columns` gates the cache key, not just the projection. The
-    # docstring above is the published operation description, so the mechanism
-    # is written down at `parse_cols_param` instead of churning every generated
-    # SDK to say it.
-    additional_columns, cols_cache_key = parse_cols_param(cols, columns)
+    # fix(#1778): the cache key comes from the EFFECTIVE projection, not from
+    # the request, so `z` and the allowlist have to reach it. At z >= 10 the
+    # zoom default already projects every column and every valid subset
+    # collapses onto one entry. The docstring above is the published operation
+    # description, so the mechanism is written down at `parse_cols_param`
+    # instead of churning every generated SDK to say it.
+    additional_columns, cols_cache_key = parse_cols_param(
+        cols, columns, z, tile_columns=meta.tile_columns
+    )
 
     # Use per-dataset cache TTL when set, else global default
     cache_ttl = meta.tile_cache_ttl or settings.tile_cache_ttl

--- a/backend/app/processing/tiles/router.py
+++ b/backend/app/processing/tiles/router.py
@@ -754,9 +754,17 @@ async def _resolve_raster_meta(
     #
     # The lookup is under the request's value, but the STORE is under the row's
     # (see the write site below) — the request never names the entry it writes.
-    # Memory stays bounded by the LRU, and a caller varying `v` to evict entries
-    # costs at most one extra indexed read per request — the same order as the
-    # uncached miss an unknown dataset id already produces.
+    # Memory stays bounded by the LRU, and a caller varying `v` costs one extra
+    # indexed read per request in the database.
+    #
+    # fix(#1778): that read is not the whole price, and this note used to say it
+    # was ("at most one extra indexed read per request, the same order as the
+    # uncached miss an unknown dataset id already produces"). The read opens a
+    # transaction, and `get_db` holds the connection it opened until the
+    # response is written, so the real cost of a miss on the raster path was an
+    # API-pool connection pinned across the caller's whole Titiler round trip.
+    # `_resolve_raster_access` now releases it before returning; the sentence
+    # above is true again because that call site makes it true, not on its own.
     version_segment = _meta_cache_version_segment(requested_version)
     cache_key = (
         f"{base_key}:v{version_segment}" if version_segment is not None else base_key
@@ -1003,6 +1011,29 @@ async def _resolve_raster_access(
                         status_code=status.HTTP_404_NOT_FOUND,
                         detail="Dataset not found",
                     )
+
+    # fix(#1778): hand the API-pool connection back before the caller goes
+    # upstream, the same remedy fix(#1451) applied to the vector path and for
+    # the same reason: `get_db` holds whatever a `db.execute` opened until the
+    # response is written, and the only caller of this function then awaits
+    # Titiler for up to three attempts at a 30s timeout plus backoff. The pool
+    # is db_pool_size + db_max_overflow per uvicorn worker, so a handful of
+    # concurrent tile requests could park all of it on an upstream fetch and
+    # make every other request in that worker wait out db_pool_timeout.
+    #
+    # A cache-buster reaches this on every request: the meta cache is keyed
+    # under the request's `v` (#1329), which accepts any short digit run, so a
+    # caller varying it misses the snapshot each time and pays the read. The
+    # note at that key derivation prices that miss as one extra indexed read;
+    # the read was never the expensive half.
+    #
+    # Everything past here is locals. `meta` is a plain snapshot built from the
+    # row above and `storage_backend` a string, so nothing the caller touches
+    # can reopen a transaction behind its back. It is here rather than at the
+    # call site for the reason the vector twin gives: the caller cannot release
+    # what it did not know was taken. Every read on this path is read-only, so
+    # the rollback discards nothing.
+    await db.rollback()
 
     return meta, storage_backend
 
@@ -2300,7 +2331,7 @@ async def cluster_tile_endpoint(
     # for.
     _ensure_clusterable_dataset(meta)
 
-    additional_columns, cols_cache_key = parse_cols_param(cols)
+    additional_columns, cols_cache_key = parse_cols_param(cols, meta.column_info)
 
     cache_ttl = meta.tile_cache_ttl or settings.tile_cache_ttl
 
@@ -2460,10 +2491,14 @@ async def tile_endpoint(
         user=user,
     )
 
-    additional_columns, cols_cache_key = parse_cols_param(cols)
-
     # Get column info for attribute selection
     columns = meta.column_info
+
+    # fix(#1778): `columns` gates the cache key, not just the projection. The
+    # docstring above is the published operation description, so the mechanism
+    # is written down at `parse_cols_param` instead of churning every generated
+    # SDK to say it.
+    additional_columns, cols_cache_key = parse_cols_param(cols, columns)
 
     # Use per-dataset cache TTL when set, else global default
     cache_ttl = meta.tile_cache_ttl or settings.tile_cache_ttl

--- a/backend/app/processing/tiles/service.py
+++ b/backend/app/processing/tiles/service.py
@@ -112,36 +112,95 @@ def _simplify_tolerance_degrees(z: int) -> float | None:
     return _SIMPLIFY_SUBPIXEL_FACTOR * 360.0 / (_MVT_EXTENT * (2**z))
 
 
+def _effective_attr_names(
+    columns: list[dict],
+    z: int,
+    *,
+    tile_columns: list[str] | None,
+    additional_columns: list[str] | None,
+    mode: str,
+) -> set[str]:
+    """The attribute names this request would actually emit into the MVT.
+
+    ``_select_tile_columns`` resolves the zoom budget and the allowlist, and
+    then each query builder drops the names its own output cannot carry:
+    ``_build_attr_columns`` drops ``_EXCLUDED_COLUMNS``, and the cluster
+    builder drops those plus ``_CLUSTER_RESERVED_COLUMNS``, whose names the
+    cluster query emits itself. Mirroring both here is what makes this the
+    projection rather than the request.
+    """
+    excluded = _EXCLUDED_COLUMNS
+    if mode == "cluster":
+        excluded = excluded | _CLUSTER_RESERVED_COLUMNS
+    selected = _select_tile_columns(
+        columns,
+        z,
+        tile_columns=tile_columns,
+        additional_columns=additional_columns,
+    )
+    return {
+        name
+        for col in selected
+        if isinstance(col, dict)
+        and isinstance(name := col.get("name"), str)
+        and name not in excluded
+        and _COLUMN_NAME_RE.match(name)
+    }
+
+
 def parse_cols_param(
-    cols: str | None, columns: list[dict] | None
+    cols: str | None,
+    columns: list[dict] | None,
+    z: int,
+    *,
+    tile_columns: list[str] | None = None,
+    mode: str = "vector",
 ) -> tuple[list[str] | None, str]:
     """Normalize a `cols=` query param into (additional_columns, cache_key).
 
-    Sorted + deduped so the tile cache key is deterministic across param
-    permutations (`cols=a,b` and `cols=b,a` hit the same entry). Shared by the
-    vector and cluster endpoints (fix(#403)).
+    The returned list is the caller's request, validated: the names that exist
+    on this dataset, sorted and deduped. The returned key is not the request at
+    all. It is what the request ADDS to the projection the tile would have had
+    without it, so two requests that produce the same SQL produce one cache
+    entry (fix(#403) asked only for the sorted-and-deduped half of that).
 
-    fix(#1778): ``columns`` is the dataset's ``column_info``, and the result is
-    the SUBSET of the request's names that exists on it. This used to hand back
-    the caller's string verbatim and leave validation to
-    ``_select_tile_columns``, which drops an unknown name silently. The two
-    together meant `?cols=<random>` produced a fresh tile cache key holding
-    bytes byte-identical to the unfiltered tile: an anonymous caller on any
-    public dataset could loop it, miss the byte cache every time, run the full
-    ST_AsMVT behind each miss, and write an entry that evicts a legitimate tile
-    from the in-memory provider's LRU. Two requests that provably produce the
-    same bytes now produce the same key, and the key space is a function of the
-    dataset's own schema rather than of arbitrary caller input.
+    fix(#1778): both halves used to be the caller's own string, which meant the
+    key varied on input the projection ignores. Three ways that happened, and
+    the key now collapses all three:
 
-    An all-unknown `cols=` therefore returns ``(None, "")`` and is answered from
-    the same cache entry as a request with no `cols=` at all, which is what its
-    bytes were already equal to.
+    * `?cols=<random>`. ``_select_tile_columns`` drops an unknown name
+      silently, so the tile was byte-identical to the unfiltered one under a
+      fresh key.
+    * `?cols=<any valid subset>` at or above ``_DEFAULT_NO_ATTR_BELOW_ZOOM``,
+      where the zoom default already projects EVERY column. Every subset of a
+      wide table produced the same bytes under a different key, which is
+      exponentially many keys per tile rather than one bogus name at a time.
+      A name already on an explicit ``tile_columns`` allowlist is the same
+      case at any zoom.
+    * `?cols=gid`, or a cluster-reserved name on the cluster route, which no
+      query builder emits at any zoom.
+
+    Each of those cost a full ``ST_AsMVT`` on an anonymous, ``@limiter.exempt``
+    route serving public datasets, and then WROTE the result. The default
+    production stack has no Valkey, so the writes land in an
+    ``LRUCache(maxsize=50_000)`` and evict legitimate tiles.
+
+    ``z``, ``tile_columns`` and ``mode`` are what make the answer the effective
+    projection; the caller passes what it will pass to ``get_tile`` or
+    ``get_cluster_tile``. ``z`` is positional and required so a third tile
+    endpoint cannot quietly go back to keying on the request. The zoom is
+    already a cache-key segment of its own, so this suffix only has to
+    separate requests at ONE tile, which is why it carries the difference
+    rather than the whole projection: an empty suffix keeps meaning "whatever
+    this tile projects by default" and stays byte-identical to the key a
+    no-`cols=` request has always used.
     """
     if not cols:
         return None, ""
+    resolved = columns or []
     known = {
         name
-        for col in columns or []
+        for col in resolved
         if isinstance(col, dict)
         and isinstance(name := col.get("name"), str)
         and _COLUMN_NAME_RE.match(name)
@@ -150,12 +209,22 @@ def parse_cols_param(
         return None, ""
     # The raw string is bounded by the server's request-line limit, and the
     # result by the dataset's column count, so neither side of this is caller-
-    # chosen. Names are compared, never interpolated: _build_attr_columns
-    # revalidates every name it emits regardless of what reaches it.
+    # chosen. Names are compared, never interpolated: the query builders
+    # revalidate every name they emit regardless of what reaches them.
     additional = sorted({c.strip() for c in cols.split(",")} & known)
     if not additional:
         return None, ""
-    return additional, ",".join(additional)
+
+    projection = {"tile_columns": tile_columns, "mode": mode}
+    baseline = _effective_attr_names(resolved, z, additional_columns=None, **projection)
+    effective = _effective_attr_names(
+        resolved, z, additional_columns=additional, **projection
+    )
+    # `additional_columns` only ever UNIONS into the base selection, so
+    # `effective` is a superset of `baseline` and the difference identifies it
+    # uniquely for this dataset at this zoom. An empty difference means the
+    # request changed nothing, which is the no-`cols=` entry.
+    return additional, ",".join(sorted(effective - baseline))
 
 
 def _select_tile_columns(

--- a/backend/app/processing/tiles/service.py
+++ b/backend/app/processing/tiles/service.py
@@ -112,20 +112,49 @@ def _simplify_tolerance_degrees(z: int) -> float | None:
     return _SIMPLIFY_SUBPIXEL_FACTOR * 360.0 / (_MVT_EXTENT * (2**z))
 
 
-def parse_cols_param(cols: str | None) -> tuple[list[str] | None, str]:
+def parse_cols_param(
+    cols: str | None, columns: list[dict] | None
+) -> tuple[list[str] | None, str]:
     """Normalize a `cols=` query param into (additional_columns, cache_key).
 
     Sorted + deduped so the tile cache key is deterministic across param
-    permutations (`cols=a,b` and `cols=b,a` hit the same entry). Validation
-    against the dataset's column_info happens in ``_select_tile_columns``;
-    shared by the vector and cluster endpoints (fix(#403)).
+    permutations (`cols=a,b` and `cols=b,a` hit the same entry). Shared by the
+    vector and cluster endpoints (fix(#403)).
+
+    fix(#1778): ``columns`` is the dataset's ``column_info``, and the result is
+    the SUBSET of the request's names that exists on it. This used to hand back
+    the caller's string verbatim and leave validation to
+    ``_select_tile_columns``, which drops an unknown name silently. The two
+    together meant `?cols=<random>` produced a fresh tile cache key holding
+    bytes byte-identical to the unfiltered tile: an anonymous caller on any
+    public dataset could loop it, miss the byte cache every time, run the full
+    ST_AsMVT behind each miss, and write an entry that evicts a legitimate tile
+    from the in-memory provider's LRU. Two requests that provably produce the
+    same bytes now produce the same key, and the key space is a function of the
+    dataset's own schema rather than of arbitrary caller input.
+
+    An all-unknown `cols=` therefore returns ``(None, "")`` and is answered from
+    the same cache entry as a request with no `cols=` at all, which is what its
+    bytes were already equal to.
     """
     if not cols:
         return None, ""
-    raw = [c.strip() for c in cols.split(",") if c.strip()]
-    if not raw:
+    known = {
+        name
+        for col in columns or []
+        if isinstance(col, dict)
+        and isinstance(name := col.get("name"), str)
+        and _COLUMN_NAME_RE.match(name)
+    }
+    if not known:
         return None, ""
-    additional = sorted(set(raw))
+    # The raw string is bounded by the server's request-line limit, and the
+    # result by the dataset's column count, so neither side of this is caller-
+    # chosen. Names are compared, never interpolated: _build_attr_columns
+    # revalidates every name it emits regardless of what reaches it.
+    additional = sorted({c.strip() for c in cols.split(",")} & known)
+    if not additional:
+        return None, ""
     return additional, ",".join(additional)
 
 

--- a/backend/tests/test_admin_rate_limit.py
+++ b/backend/tests/test_admin_rate_limit.py
@@ -217,10 +217,12 @@ async def test_oauth_provider_create_429(
 async def test_alias_bypass_guard(client: AsyncClient, admin_auth_header: dict) -> None:
     """The no-trailing-slash alias of a dual-shape admin endpoint is ALSO rate-limited.
 
-    slowapi uses key_style="url" so /admin/users/ and /admin/users maintain
-    separate per-URL buckets — each alias has its own 30/minute limit. The
-    guarantee is that the no-slash form is NOT an unlimited bypass: exhausting
-    the no-slash alias's own bucket also yields 429 (T-1238-03).
+    fix(#1778): the limiter is built with key_style="endpoint", so both shapes
+    of the dual-shape decorator key on the one handler they share and draw on a
+    single 30/minute bucket. They used to be keyed by URL, giving each alias its
+    own allowance. Either way the guarantee this test states holds, and it is
+    the guarantee that matters: the no-slash form is NOT an unlimited bypass
+    (T-1238-03). Sharing one bucket is the stricter of the two.
 
     Strategy: exhaust the limit via the no-slash form (POST /admin/users), then
     assert that further calls to the same no-slash alias return 429.

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -4326,8 +4326,14 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # lines say at the `cols=` call site that the dataset's column set now gates
     # the cache key, since the handler docstring above it is the published
     # operation description and saying it there churns every generated SDK.
+    # fix(#1778 codex P1): +14 — that call site now hands `parse_cols_param` the
+    # zoom, the allowlist and the route mode, because validating the names was
+    # not enough: at z >= 10 the zoom default already projects every column, so
+    # every valid subset of a wide table produced one set of bytes under its own
+    # key. The key comes from the effective projection now, and each call site
+    # says which of its inputs decide that.
     # Ratchet stays exact.
-    "backend/app/processing/tiles/router.py": 2625,
+    "backend/app/processing/tiles/router.py": 2639,
     # feat(#565): the SQL sandbox validator crossed 1000 lines across the codex
     # rounds on the query endpoint: the lexical CTE-scope fix (P1) and its
     # pg_catalog.pg_user rationale, the declaration-order refinement (P1 r2),

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -4316,8 +4316,18 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # STORE key is the resolved row's, so no caller can name the entry it
     # writes and a predictable future `v` can no longer park a pre-swap
     # snapshot on the key the swap is about to make legitimate.
+    # fix(#1778): +35 — `_resolve_raster_access` hands its API-pool connection
+    # back before returning, so the caller's Titiler round trip (up to three
+    # attempts at a 30s timeout plus backoff) no longer runs with the catalog
+    # read's transaction open. Most of it is the note recording that the release
+    # belongs in the resolver rather than at either call site, and the correction
+    # to the #1329 cache-key note, which priced a cache-busting `v` as one extra
+    # indexed read and left out the connection that read pinned. Four of the
+    # lines say at the `cols=` call site that the dataset's column set now gates
+    # the cache key, since the handler docstring above it is the published
+    # operation description and saying it there churns every generated SDK.
     # Ratchet stays exact.
-    "backend/app/processing/tiles/router.py": 2590,
+    "backend/app/processing/tiles/router.py": 2625,
     # feat(#565): the SQL sandbox validator crossed 1000 lines across the codex
     # rounds on the query endpoint: the lexical CTE-scope fix (P1) and its
     # pg_catalog.pg_user rationale, the declaration-order refinement (P1 r2),

--- a/backend/tests/test_nginx_raster_proxy_ratelimit_1778.py
+++ b/backend/tests/test_nginx_raster_proxy_ratelimit_1778.py
@@ -1,0 +1,212 @@
+"""Both spellings of the raster tile route are rate limited, from one bucket (#1778).
+
+nginx defines a single ``limit_req_zone`` (``raster_anon``) and it used to be
+applied in a single place: the ``/raster-tiles/...`` location, which rewrites to
+``/tiles/raster-proxy/$dataset_id/$z/$x/$y.$fmt`` and proxies that to the api.
+The api mounts the tiles router at ``/tiles``, and ``location /api/`` rewrites
+``^/api/(.*)`` to ``/$1``, so asking for ``/api/tiles/raster-proxy/...`` reaches
+the identical handler with no ``limit_req`` at the edge, no ``@limiter.limit``
+at the app (the handler is ``@limiter.exempt``) and no ``proxy_cache``: every
+request a live Titiler COG read. The rate limit was opt-in by URL spelling, and
+only the product's own clients ever used the spelling that opts in.
+
+Measured against nginx 1.29 (alpine) with this file rendered, the upstream
+pointed at a closed port so a proxied request answers 502 and a refused one
+answers 503, and the zone temporarily narrowed to 1r/m with no burst:
+
+* without the nested location: ``/api/tiles/raster-proxy/...`` answered 502,
+  502, 502, and a following ``/raster-tiles/...`` answered 502 as well. Not
+  limited, and not even drawing on the other spelling's bucket.
+* with it: ``/api/tiles/raster-proxy/...`` answered 502 then 503, ``/api/health``
+  answered 502 twice (the outer block stays unlimited), and ``/raster-tiles/...``
+  answered 503 on its first request, which is the shared-bucket half: the tokens
+  had already been spent under the other spelling.
+
+The assertions below are structural. They resolve a sample URL through nginx's
+own location-selection rules and ask what the SELECTED block does, rather than
+naming the block, so a third route reaching the same handler inherits the
+requirement instead of quietly reintroducing the bypass.
+"""
+
+import re
+
+from tests.repo_paths import repo_root
+
+NGINX_CONF = repo_root(__file__) / "frontend" / "nginx.conf"
+
+# The path an attacker types. Whatever serves it must be throttled.
+API_SPELLING = "/api/tiles/raster-proxy/00000000-0000-0000-0000-000000000000/1/2/3.png"
+# The path the product mints, already covered before this change.
+EDGE_SPELLING = "/raster-tiles/00000000-0000-0000-0000-000000000000/tiles/1/2/3.png"
+# The control: an ordinary api route, which must stay off the tile budget.
+UNRELATED_API_PATH = "/api/health"
+
+_LOCATION_HEADER = re.compile(r"^[ \t]*location\b([^\n{]*)\{", re.M)
+_LIMIT_REQ = re.compile(r"^\s*limit_req\s+zone=(\w+)", re.M)
+_ZONE_DECL = re.compile(r"^\s*limit_req_zone\s+\S+\s+zone=(\w+):", re.M)
+
+
+def _without_comments(text: str) -> str:
+    """Drop nginx comment lines so prose can never satisfy an assertion."""
+    return "\n".join(
+        line for line in text.splitlines() if not line.lstrip().startswith("#")
+    )
+
+
+def _balanced_body(text: str, brace_index: int) -> str:
+    """Return the body between ``text[brace_index]`` and its matching brace."""
+    depth = 0
+    for index in range(brace_index, len(text)):
+        if text[index] == "{":
+            depth += 1
+        elif text[index] == "}":
+            depth -= 1
+            if depth == 0:
+                return text[brace_index + 1 : index]
+    raise AssertionError(f"unbalanced braces at offset {brace_index}")
+
+
+class _Location:
+    """One ``location`` block: its header, its own directives, its children."""
+
+    def __init__(self, header: str, body: str) -> None:
+        parts = header.split()
+        self.header = header
+        self.modifier = parts[0] if parts and parts[0] in ("=", "~", "~*", "^~") else ""
+        self.pattern = parts[1] if self.modifier else (parts[0] if parts else "")
+        self.children = _parse_locations(body)
+        self.own = body
+        for child in self.children:
+            start = self.own.index("{", self.own.index(f"location{child.header}"))
+            end = start + len(_balanced_body(self.own, start)) + 1
+            head = self.own.index(f"location{child.header}")
+            self.own = self.own[:head] + self.own[end:]
+
+    def matches(self, path: str) -> bool:
+        if self.modifier == "=":
+            return path == self.pattern
+        if self.modifier in ("~", "~*"):
+            # PCRE spells a named group `(?<name>...)`; Python spells it
+            # `(?P<name>...)`. The raster-tiles location uses four of them.
+            pattern = self.pattern.replace("(?<", "(?P<")
+            flags = re.I if self.modifier == "~*" else 0
+            return re.search(pattern, path, flags) is not None
+        if self.pattern.startswith("@"):
+            return False  # named location, reachable only by internal redirect
+        return path.startswith(self.pattern)
+
+
+def _parse_locations(text: str) -> list[_Location]:
+    """Top-level ``location`` blocks of ``text``, each with its own children."""
+    found: list[_Location] = []
+    index = 0
+    while True:
+        match = _LOCATION_HEADER.search(text, index)
+        if match is None:
+            return found
+        brace = text.index("{", match.start())
+        body = _balanced_body(text, brace)
+        found.append(_Location(match.group(1), body))
+        index = brace + len(body) + 2
+
+
+def _select(locations: list[_Location], path: str) -> _Location | None:
+    """The block nginx would serve ``path`` from, by nginx's own rules.
+
+    Exact match wins outright; otherwise the longest prefix is remembered and
+    the regexes are tried in order, with ``^~`` on the winning prefix skipping
+    them. The selected block's own children are then resolved the same way, and
+    a block with no matching child serves the request itself.
+    """
+    candidates = [loc for loc in locations if loc.matches(path)]
+    for loc in candidates:
+        if loc.modifier == "=":
+            return loc
+    prefixes = [loc for loc in candidates if loc.modifier in ("", "^~")]
+    best_prefix = max(prefixes, key=lambda loc: len(loc.pattern), default=None)
+    chosen = best_prefix
+    if best_prefix is None or best_prefix.modifier != "^~":
+        for loc in candidates:
+            if loc.modifier in ("~", "~*"):
+                chosen = loc
+                break
+    if chosen is None:
+        return None
+    return _select(chosen.children, path) or chosen
+
+
+def _tree() -> list[_Location]:
+    return _parse_locations(_without_comments(NGINX_CONF.read_text()))
+
+
+def test_the_api_spelling_of_the_raster_proxy_is_rate_limited():
+    """Whatever nginx selects for the /api/ spelling must carry limit_req."""
+    served_by = _select(_tree(), API_SPELLING)
+    assert served_by is not None, f"no location matches {API_SPELLING}"
+    assert _LIMIT_REQ.search(served_by.own), (
+        f"{API_SPELLING} is served by `location{served_by.header}`, which "
+        "declares no limit_req. That URL reaches the same api handler as the "
+        "throttled /raster-tiles/ spelling, so leaving it unthrottled makes the "
+        "rate limit opt-in by URL spelling."
+    )
+
+
+def test_both_spellings_draw_on_the_same_zone():
+    """One zone, so switching spelling mid-flood buys no fresh allowance."""
+    tree = _tree()
+    zones = {}
+    for path in (API_SPELLING, EDGE_SPELLING):
+        selected = _select(tree, path)
+        assert selected is not None, path
+        zones[path] = set(_LIMIT_REQ.findall(selected.own))
+    assert zones[API_SPELLING] and zones[EDGE_SPELLING], zones
+    assert zones[API_SPELLING] == zones[EDGE_SPELLING], (
+        "the two spellings of one handler must share a limit_req zone, or a "
+        f"caller doubles their budget by alternating between them: {zones}"
+    )
+    declared = set(_ZONE_DECL.findall(_without_comments(NGINX_CONF.read_text())))
+    assert zones[API_SPELLING] <= declared, (
+        f"limit_req names a zone with no limit_req_zone declaration: {zones}"
+    )
+
+
+def test_ordinary_api_routes_are_not_pulled_onto_the_tile_budget():
+    """The control, and the reason the block is nested rather than widened.
+
+    ``raster_anon`` is sized for tiles. Applying it to ``location /api/`` as a
+    whole would put login, search and the admin UI on a budget shaped by how
+    many tiles a tilted 3D view cold-starts with.
+    """
+    selected = _select(_tree(), UNRELATED_API_PATH)
+    assert selected is not None
+    assert not _LIMIT_REQ.search(selected.own), (
+        f"{UNRELATED_API_PATH} is served by `location{selected.header}`, which "
+        "now carries a limit_req. The tile zone must not govern general api "
+        "traffic."
+    )
+
+
+def test_the_nested_location_restates_what_nginx_does_not_inherit():
+    """``proxy_pass``, ``rewrite`` and ``set`` do not reach a nested location.
+
+    A nested block that omits them stops proxying to the api entirely, which
+    would turn this fix into a broken route rather than a throttled one. The
+    inheritable directives (``proxy_cache off``, the timeouts, the forwarded
+    headers) are deliberately NOT restated, so this test also records which
+    half is which. Measured: a 502 from this block and a 502 from
+    ``/api/health`` carry byte-identical header sets.
+    """
+    served_by = _select(_tree(), API_SPELLING)
+    assert served_by is not None
+    for directive in ("set $upstream_api", "rewrite ^/api/(.*)", "proxy_pass"):
+        assert directive in served_by.own, (
+            f"{directive!r} is missing. nginx does not inherit it into a nested "
+            "location, so without it this block answers something other than "
+            "the api's raster tile."
+        )
+    for inherited in ("proxy_cache", "add_header", "proxy_hide_header"):
+        assert inherited not in served_by.own, (
+            f"{inherited!r} is restated here. It is inherited from location "
+            "/api/, and declaring add_header or proxy_hide_header at this level "
+            "disables inheritance of the whole set rather than adding to it."
+        )

--- a/backend/tests/test_raster_proxy_releases_connection_1778.py
+++ b/backend/tests/test_raster_proxy_releases_connection_1778.py
@@ -1,0 +1,149 @@
+"""The raster proxy hands its API-pool connection back before Titiler (#1778).
+
+``_resolve_raster_meta`` caches its snapshot under the REQUEST's ``v`` (#1329),
+and ``_meta_cache_version_segment`` accepts any ASCII digit run of length 1 to
+10, so a caller varying ``v`` misses that cache on every request and pays the
+``db.execute``. The note at the key derivation priced that as one extra indexed
+read. It was not: ``get_db`` yields one session for the whole request and only
+rolls back on an exception, so the transaction that read opens is held until the
+response is written, and ``raster_tile_proxy`` then awaits Titiler for up to
+three attempts at a 30s timeout plus 0.5s and 1.0s of backoff. The connection is
+one of ``db_pool_size + db_max_overflow`` per uvicorn worker, and once they are
+all parked on an upstream fetch every other request in that worker waits out
+``db_pool_timeout`` and then errors: login, search, the admin UI.
+
+``/api/tiles/raster-proxy/...`` reaches this anonymously on any public raster,
+which is why the vector path's fix(#1451) remedy applies here too. That one
+states the same reasoning at ``_assert_dataset_still_registered`` and is pinned
+by ``test_tile_cached_authz_liveness_1451.py``; this is its raster twin.
+
+Order is the whole property, so order is what these tests read.
+"""
+
+import uuid
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from app.processing.tiles import router as tile_router
+
+pytestmark = pytest.mark.anyio
+
+
+def _row(dataset_id: uuid.UUID) -> dict:
+    """One catalog row in the shape `_resolve_raster_meta` reads."""
+    return {
+        "visibility": "public",
+        "record_status": "published",
+        "created_by": uuid.uuid4(),
+        "record_type": "raster_dataset",
+        "asset_uri": "rasters/probe.tif",
+        "storage_backend": "local",
+        "band_count": 1,
+        "dtype": "uint8",
+        "is_dem": False,
+        "band_info": None,
+        "nodata": None,
+        "tile_cache_version": 1,
+    }
+
+
+class _RecordingSession:
+    """A session that logs when it is queried and when it lets its connection go."""
+
+    def __init__(self, events: list[str], row: dict) -> None:
+        self._events = events
+        self._row = row
+
+    async def execute(self, *_args, **_kwargs):
+        self._events.append("db.execute")
+        return SimpleNamespace(
+            mappings=lambda: SimpleNamespace(one_or_none=lambda: self._row)
+        )
+
+    async def rollback(self) -> None:
+        self._events.append("db.rollback")
+
+
+async def _fetch_tile(version: str | None) -> tuple[list[str], int]:
+    """Serve one raster tile through the proxy, returning the event log."""
+    from app.core.dependencies import get_db
+    from app.modules.auth.dependencies import get_optional_user_fail_open
+
+    dataset_id = uuid.uuid4()
+    events: list[str] = []
+    session = _RecordingSession(events, _row(dataset_id))
+
+    class _Upstream:
+        async def get(self, _url):
+            events.append("titiler.get")
+            return SimpleNamespace(
+                status_code=200,
+                content=b"png",
+                headers={"content-type": "image/png"},
+            )
+
+    app = FastAPI()
+    app.include_router(tile_router.router)
+    app.dependency_overrides[get_db] = lambda: session
+    app.dependency_overrides[get_optional_user_fail_open] = lambda: None
+
+    path = f"/tiles/raster-proxy/{dataset_id}/1/2/3.png"
+    if version is not None:
+        path = f"{path}?v={version}"
+
+    with patch.object(tile_router, "_titiler_client", _Upstream()):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            response = await client.get(path)
+
+    return events, response.status_code
+
+
+async def test_the_connection_is_released_before_the_upstream_fetch():
+    """A cache-busting `v` reads the catalog, then lets go, then goes upstream."""
+    events, status_code = await _fetch_tile("4294967295")
+
+    assert status_code == 200, events
+    assert events == ["db.execute", "db.rollback", "titiler.get"], (
+        "the rollback must sit between the catalog read and the Titiler round "
+        f"trip, or the pool connection is held across it. Got {events}"
+    )
+
+
+async def test_an_unversioned_request_releases_too():
+    """The `?v=` shape is the cheap way in, not the only one.
+
+    Any first request for a dataset misses `_raster_meta_cache` and pays the
+    same read, so the release cannot be conditional on the parameter.
+    """
+    events, status_code = await _fetch_tile(None)
+
+    assert status_code == 200, events
+    assert events.index("db.rollback") < events.index("titiler.get"), events
+
+
+async def test_the_release_is_in_the_shared_resolver_not_the_proxy():
+    """Every caller of the resolver inherits it, including a future third one.
+
+    ``raster_auth_check`` is a mounted route in its own right and
+    ``raster_tile_proxy`` calls it in-process; putting the rollback in
+    ``_resolve_raster_access`` covers both without either having to remember.
+    """
+    import ast
+    import inspect
+    import textwrap
+
+    source = textwrap.dedent(inspect.getsource(tile_router._resolve_raster_access))
+    rollbacks = [
+        node
+        for node in ast.walk(ast.parse(source))
+        if isinstance(node, ast.Attribute) and node.attr == "rollback"
+    ]
+    assert rollbacks, (
+        "_resolve_raster_access must release the connection itself. A call site "
+        "cannot release what it did not know was taken."
+    )

--- a/backend/tests/test_rate_limit_key_style_1778.py
+++ b/backend/tests/test_rate_limit_key_style_1778.py
@@ -1,0 +1,116 @@
+"""The global rate limit is keyed on the handler, not on the URL (#1778).
+
+slowapi's default is ``key_style="url"``: ``_check_request_limit`` sets
+``_endpoint_key = request["path"]`` and ``__evaluate_limits`` then counts under
+``(key_func(request), _endpoint_key)``. With ``key_func=get_remote_address``
+that is (client IP, URL), so every distinct URL carried its own copy of the
+admin-editable "Global Rate Limit (per second)". On a path-parameterised route
+the caller picks the URL, so the caller picked how many budgets to have: one
+per dataset id, one per z/x/y, one per record id. openapi.json lists 46
+anonymous parameterised operations, and the expensive ones are among them
+(``/datasets/{dataset_id}/export`` runs an ogr2ogr conversion,
+``/collections/{dataset_id}/items`` returns up to 1000 features a page).
+
+``key_style="endpoint"`` counts under (client IP, ``module.function``) instead.
+The route table decides how many handlers exist, so the multiplier is fixed at
+deploy time.
+
+These tests read the property off the live app rather than off the constructor
+argument: the argument is one line, and what it is worth is that two URLs
+served by one handler draw on one bucket.
+"""
+
+import uuid
+
+import pytest
+from httpx import AsyncClient
+from slowapi.wrappers import LimitGroup
+
+from app.platform.ratelimit import limiter
+
+pytestmark = pytest.mark.anyio
+
+
+def _one_per_minute():
+    """A default-limit group of 1/minute, in slowapi's positional shape."""
+    return [
+        LimitGroup(
+            "1/minute", limiter._key_func, None, False, None, None, None, 1, False
+        )
+    ]
+
+
+def test_limiter_is_constructed_with_endpoint_key_style():
+    """The unit half: without this the behavioural test below cannot pass."""
+    assert limiter._key_style == "endpoint"
+
+
+async def test_two_urls_on_one_handler_share_one_bucket(client: AsyncClient):
+    """Three URLs, one handler, one 1/minute allowance between them.
+
+    ``/collections/{dataset_id}/items`` is anonymous, carries a path parameter
+    and has a trailing-slash alias registered against the same function, so it
+    exercises both multipliers the old keying handed out for free: a fresh
+    budget per dataset id, and a second one for the alias.
+
+    The dataset ids are random and resolve to nothing. That is deliberate: the
+    limit is evaluated in ``SlowAPIMiddleware`` before the handler runs, so a
+    404 consumes the bucket exactly as a 200 does, and the test needs no
+    fixture data to make its point.
+    """
+    original_enabled = limiter.enabled
+    original_limits = limiter._default_limits
+    try:
+        limiter.enabled = True
+        limiter._default_limits = _one_per_minute()
+        limiter._storage.reset()
+
+        first = await client.get(f"/collections/{uuid.uuid4()}/items")
+        second = await client.get(f"/collections/{uuid.uuid4()}/items")
+        alias = await client.get(f"/collections/{uuid.uuid4()}/items/")
+
+        assert first.status_code != 429, (
+            f"the first request must be inside the allowance; got {first.status_code}"
+        )
+        assert second.status_code == 429, (
+            "a second dataset id is a second URL but the same handler, so it "
+            "must draw on the allowance the first request spent. Keyed by URL "
+            f"it gets a budget of its own; got {second.status_code}"
+        )
+        assert alias.status_code == 429, (
+            "the trailing-slash alias is registered against the same function, "
+            f"so it shares that one bucket too; got {alias.status_code}"
+        )
+    finally:
+        limiter.enabled = original_enabled
+        limiter._default_limits = original_limits
+        limiter._storage.reset()
+
+
+async def test_a_different_handler_keeps_its_own_bucket(client: AsyncClient):
+    """The control: endpoint keying is not one global counter.
+
+    Without this, a limiter that 429'd everything after one request would pass
+    the test above.
+    """
+    original_enabled = limiter.enabled
+    original_limits = limiter._default_limits
+    try:
+        limiter.enabled = True
+        limiter._default_limits = _one_per_minute()
+        limiter._storage.reset()
+
+        spent = await client.get(f"/collections/{uuid.uuid4()}/items")
+        exhausted = await client.get(f"/collections/{uuid.uuid4()}/items")
+        other_handler = await client.get("/conformance")
+
+        assert spent.status_code != 429
+        assert exhausted.status_code == 429, "precondition: the bucket is spent"
+        assert other_handler.status_code != 429, (
+            "a different handler has a different key, so its own allowance is "
+            f"untouched; got {other_handler.status_code}"
+        )
+    finally:
+        limiter.enabled = original_enabled
+        limiter._default_limits = original_limits
+        limiter._storage.reset()

--- a/backend/tests/test_rate_limit_key_style_1778.py
+++ b/backend/tests/test_rate_limit_key_style_1778.py
@@ -28,6 +28,10 @@ from slowapi.wrappers import LimitGroup
 
 from app.platform.ratelimit import limiter
 
+# The signin-alias test below reuses the ArcGIS sign-in module's fixtures
+# (allow_ssrf and its per-test portal host) rather than duplicating them.
+pytest_plugins = ["tests.test_arcgis_signin"]
+
 pytestmark = pytest.mark.anyio
 
 
@@ -114,3 +118,82 @@ async def test_a_different_handler_keeps_its_own_bucket(client: AsyncClient):
         limiter.enabled = original_enabled
         limiter._default_limits = original_limits
         limiter._storage.reset()
+
+
+# ---------------------------------------------------------------------------
+# The per-route limits the key style also governs
+# ---------------------------------------------------------------------------
+#
+# A `@limiter.limit` decorator carries its own `key_func` but no `scope`, so
+# `__evaluate_limits` falls back to `lim.scope or endpoint` and counts under
+# (key_func(request), _endpoint_key). The key style therefore decides the
+# SECOND half of every per-route limit too, not just the global default.
+#
+# `POST /services/arcgis/signin/` (#1758) is where that matters most on the
+# current route table: it sends a password to a third party, so its comment
+# enumerates five controls and control 2 is "three attempts per fifteen
+# minutes". The route is dual-shape, so under URL keying the two spellings
+# were two buckets and control 2 admitted six requests per worker to the
+# database-backed control 4 behind it. Both key functions carry the user id
+# and were never the leak.
+
+
+async def test_the_arcgis_signin_aliases_share_one_bucket(
+    client: AsyncClient, admin_auth_header: dict, allow_ssrf, monkeypatch
+):
+    """Control 2 of #1758 admits three requests per worker, not six.
+
+    The database-backed budget (control 4) and the per-portal limit are raised
+    out of the way so the only thing that can refuse is the per-user slowapi
+    limit whose scope this change moves.
+    """
+    from app.modules.catalog.sources import router as sources_router, signin_guard
+
+    from tests.test_arcgis_signin import (
+        _Exchange,
+        _body,
+        _info_payload,
+        _install,
+        _json_response,
+        _token_payload,
+    )
+
+    monkeypatch.setattr(signin_guard, "_ARCGIS_SIGNIN_ATTEMPT_LIMIT", 100)
+    monkeypatch.setattr(sources_router, "_ARCGIS_SIGNIN_PORTAL_LIMIT", "100/15minutes")
+    exchange = _Exchange(
+        {
+            "info": _json_response(_info_payload()),
+            "generateToken": _json_response(_token_payload()),
+        }
+    )
+
+    original_enabled = limiter.enabled
+    try:
+        limiter.enabled = True
+        limiter._storage.reset()
+        with _install(exchange):
+            statuses = [
+                (
+                    await client.post(path, json=_body(), headers=admin_auth_header)
+                ).status_code
+                for path in (
+                    "/services/arcgis/signin/",
+                    "/services/arcgis/signin",
+                    "/services/arcgis/signin/",
+                    "/services/arcgis/signin",
+                    "/services/arcgis/signin/",
+                    "/services/arcgis/signin",
+                )
+            ]
+    finally:
+        limiter.enabled = original_enabled
+        limiter._storage.reset()
+
+    assert statuses == [200, 200, 200, 429, 429, 429], (
+        "alternating the two spellings of one handler must not buy a second "
+        f"three-attempt budget; got {statuses}"
+    )
+    assert len(exchange.posts) == 3, (
+        "and the refused half must never reach the portal; "
+        f"{len(exchange.posts)} sign-in POSTs went out"
+    )

--- a/backend/tests/test_tile_cols_cache_key_validation_1778.py
+++ b/backend/tests/test_tile_cols_cache_key_validation_1778.py
@@ -1,0 +1,165 @@
+"""An unknown `cols=` name never reaches the tile cache key (#1778).
+
+``parse_cols_param`` used to return the caller's own string as the cache-key
+segment and leave validation to ``_select_tile_columns``, which drops an
+unrecognised name silently. The two together made the key vary on input the
+projection ignored: ``?cols=<random>`` missed the byte cache every time, ran the
+full ``ST_AsMVT`` behind the miss, gzipped it, and then WROTE an entry holding
+bytes byte-identical to the unfiltered tile. The route is ``@limiter.exempt``
+and serves public datasets with no credential, so the loop is anonymous and the
+default production stack has no Valkey, which puts the writes into an
+``LRUCache(maxsize=50_000)`` where ~50k of them evict every legitimate tile.
+
+The property is simple and is what these tests state: two requests that produce
+the same bytes produce the same key. An all-unknown ``cols=`` is answered from
+the same entry as a request with no ``cols=`` at all.
+"""
+
+import uuid
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from httpx import AsyncClient
+
+from app.core.config import settings
+from app.processing.tiles.service import parse_cols_param
+
+from tests.factories import get_user_id
+from tests.test_tiles import (
+    _cleanup_data_table,
+    _create_data_table,
+    _create_tile_test_dataset,
+)
+
+# Make fixtures defined in test_tiles.py (especially _init_tile_pool_for_tests)
+# available to this module without duplicating the fixture body.
+pytest_plugins = ["tests.test_tiles"]
+
+COLUMNS = [
+    {"name": "gid", "type": "integer"},
+    {"name": "name", "type": "text"},
+    {"name": "value", "type": "integer"},
+]
+
+
+# ---------------------------------------------------------------------------
+# parse_cols_param
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "cols",
+    [
+        "does_not_exist",
+        "nope,also_nope",
+        "drop table users;--",
+        "  ,  ",
+        "1_starts_with_a_digit",
+        "x" * 500,
+    ],
+)
+def test_a_name_the_dataset_does_not_have_leaves_the_key_empty(cols: str):
+    """Nothing a request cannot project may distinguish its cache entry."""
+    assert parse_cols_param(cols, COLUMNS) == (None, "")
+
+
+def test_the_key_is_built_from_the_surviving_names_only():
+    """A partly-bogus request keys on exactly what it will project."""
+    assert parse_cols_param("value,bogus", COLUMNS) == (["value"], "value")
+    assert parse_cols_param("value", COLUMNS) == (["value"], "value")
+
+
+def test_permutations_and_duplicates_still_collapse():
+    """The #403 property survives: sorted and deduped, so orderings collide."""
+    assert parse_cols_param("value,name", COLUMNS)[1] == "name,value"
+    assert parse_cols_param("name,value", COLUMNS)[1] == "name,value"
+    assert parse_cols_param("value,value, name ", COLUMNS)[1] == "name,value"
+
+
+def test_a_dataset_with_no_column_info_projects_nothing():
+    """No column set to validate against means no name can be validated."""
+    assert parse_cols_param("value", []) == (None, "")
+    assert parse_cols_param("value", None) == (None, "")
+
+
+def test_absent_and_empty_cols_are_unchanged():
+    assert parse_cols_param(None, COLUMNS) == (None, "")
+    assert parse_cols_param("", COLUMNS) == (None, "")
+
+
+# ---------------------------------------------------------------------------
+# The HTTP path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.usefixtures("_init_tile_pool_for_tests")
+class TestUnknownColsSharesTheUnfilteredEntry:
+    """Mirrors TestTileCacheColsKey: mock the cache, read the call args.
+
+    ``get`` returns None so the route falls through to the real PostGIS path,
+    which is what makes the ``set`` assertion meaningful: the write is the half
+    that fills the LRU.
+    """
+
+    async def test_unknown_cols_reads_and_writes_the_no_cols_entry(
+        self, client: AsyncClient, test_db_session
+    ):
+        table_name = f"cols_v_{uuid.uuid4().hex[:8]}"
+        user_id = await get_user_id(test_db_session, settings.geolens_admin_username)
+        await _create_tile_test_dataset(
+            test_db_session, created_by=user_id, table_name=table_name
+        )
+        await _create_data_table(test_db_session, table_name)
+
+        try:
+            mock_cache = AsyncMock()
+            mock_cache.get.return_value = None
+            with patch(
+                "app.processing.tiles.router.get_tile_cache",
+                return_value=mock_cache,
+            ):
+                resp = await client.get(
+                    f"/tiles/data.{table_name}/2/2/2.pbf",
+                    params={"cols": uuid.uuid4().hex},
+                )
+
+            assert resp.status_code == 200
+            assert mock_cache.get.call_args.kwargs.get("cols_key") == "", (
+                "an unknown name must not distinguish the lookup key: the tile "
+                "it produces is the unfiltered one. Got "
+                f"{mock_cache.get.call_args.kwargs.get('cols_key')!r}"
+            )
+            assert mock_cache.set.call_args.kwargs.get("cols_key") == "", (
+                "nor the write key, which is the half that fills the LRU. Got "
+                f"{mock_cache.set.call_args.kwargs.get('cols_key')!r}"
+            )
+        finally:
+            await _cleanup_data_table(test_db_session, table_name)
+
+    async def test_a_real_column_still_gets_its_own_entry(
+        self, client: AsyncClient, test_db_session
+    ):
+        """The control: validation must not collapse projections that differ."""
+        table_name = f"cols_r_{uuid.uuid4().hex[:8]}"
+        user_id = await get_user_id(test_db_session, settings.geolens_admin_username)
+        await _create_tile_test_dataset(
+            test_db_session, created_by=user_id, table_name=table_name
+        )
+        await _create_data_table(test_db_session, table_name)
+
+        try:
+            mock_cache = AsyncMock()
+            mock_cache.get.return_value = None
+            with patch(
+                "app.processing.tiles.router.get_tile_cache",
+                return_value=mock_cache,
+            ):
+                resp = await client.get(
+                    f"/tiles/data.{table_name}/2/2/2.pbf",
+                    params={"cols": "value,not_a_column"},
+                )
+
+            assert resp.status_code == 200
+            assert mock_cache.get.call_args.kwargs.get("cols_key") == "value"
+        finally:
+            await _cleanup_data_table(test_db_session, table_name)

--- a/backend/tests/test_tile_cols_cache_key_validation_1778.py
+++ b/backend/tests/test_tile_cols_cache_key_validation_1778.py
@@ -1,18 +1,30 @@
-"""An unknown `cols=` name never reaches the tile cache key (#1778).
+"""The tile cache key names the effective projection, not the request (#1778).
 
 ``parse_cols_param`` used to return the caller's own string as the cache-key
-segment and leave validation to ``_select_tile_columns``, which drops an
-unrecognised name silently. The two together made the key vary on input the
-projection ignored: ``?cols=<random>`` missed the byte cache every time, ran the
-full ``ST_AsMVT`` behind the miss, gzipped it, and then WROTE an entry holding
-bytes byte-identical to the unfiltered tile. The route is ``@limiter.exempt``
-and serves public datasets with no credential, so the loop is anonymous and the
-default production stack has no Valkey, which puts the writes into an
-``LRUCache(maxsize=50_000)`` where ~50k of them evict every legitimate tile.
+segment and defer validation to ``_select_tile_columns``, which drops a name it
+does not recognise silently. So the key varied on input the projection ignores,
+and it did so in three ways that compound:
 
-The property is simple and is what these tests state: two requests that produce
-the same bytes produce the same key. An all-unknown ``cols=`` is answered from
-the same entry as a request with no ``cols=`` at all.
+* an unknown name, which is dropped and leaves the unfiltered tile under a
+  fresh key;
+* ANY valid subset at or above ``_DEFAULT_NO_ATTR_BELOW_ZOOM``, where the zoom
+  default already projects every column, so a wide public table offered
+  exponentially many keys for one set of bytes. A name already on an explicit
+  ``tile_columns`` allowlist is the same case at any zoom;
+* a name no query builder emits: ``gid``/``geom``/``geom_4326`` on either
+  route, and the cluster query's own ``point_count``/``cluster_id`` family on
+  the cluster route.
+
+Each cost a full ``ST_AsMVT`` on an anonymous, ``@limiter.exempt`` route
+serving public datasets, and then wrote the result. The default production
+stack has no Valkey, so the writes land in an ``LRUCache(maxsize=50_000)`` and
+evict legitimate tiles.
+
+The property these tests state is one sentence: two requests that produce the
+same SQL produce the same cache key. The key carries what a request ADDS to the
+projection the tile would have had anyway, which is well defined because
+``additional_columns`` only ever unions into the base selection, and which
+keeps an empty suffix meaning what it has always meant.
 """
 
 import uuid
@@ -22,7 +34,10 @@ import pytest
 from httpx import AsyncClient
 
 from app.core.config import settings
-from app.processing.tiles.service import parse_cols_param
+from app.processing.tiles.service import (
+    _DEFAULT_NO_ATTR_BELOW_ZOOM,
+    parse_cols_param,
+)
 
 from tests.factories import get_user_id
 from tests.test_tiles import (
@@ -35,15 +50,96 @@ from tests.test_tiles import (
 # available to this module without duplicating the fixture body.
 pytest_plugins = ["tests.test_tiles"]
 
+# The shape test_tiles.py's helper registers, plus a third attribute so
+# "two distinct subsets" has somewhere to go.
 COLUMNS = [
     {"name": "gid", "type": "integer"},
     {"name": "name", "type": "text"},
     {"name": "value", "type": "integer"},
+    {"name": "pop", "type": "integer"},
+    {"name": "geom", "type": "geometry"},
+    {"name": "geom_4326", "type": "geometry"},
 ]
+
+LOW = _DEFAULT_NO_ATTR_BELOW_ZOOM - 1  # zoom default projects nothing
+HIGH = _DEFAULT_NO_ATTR_BELOW_ZOOM  # zoom default projects everything
+
+
+def _key(cols, z, **kwargs):
+    return parse_cols_param(cols, COLUMNS, z, **kwargs)[1]
 
 
 # ---------------------------------------------------------------------------
-# parse_cols_param
+# At and above the zoom threshold every valid subset is the same tile
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "cols",
+    [None, "name", "value", "pop", "name,value", "name,value,pop", "pop,name"],
+)
+def test_every_subset_collapses_onto_one_key_at_high_zoom(cols):
+    """z >= the threshold projects every column, so no subset changes anything.
+
+    This is the expensive half of the finding: on a wide table the caller had
+    2**n keys for one set of bytes, and cycling them is cheaper for the caller
+    than serving them is for the server.
+    """
+    assert _key(cols, HIGH) == ""
+
+
+def test_an_allowlisted_name_adds_nothing_at_any_zoom():
+    """An explicit `tile_columns` allowlist is the same case as the zoom default."""
+    for z in (LOW, HIGH):
+        assert _key("name", z, tile_columns=["name"]) == ""
+        # ...while a name OUTSIDE the allowlist still changes the projection.
+        assert _key("value", z, tile_columns=["name"]) == "value"
+        assert _key("name,value", z, tile_columns=["name"]) == "value"
+
+
+# ---------------------------------------------------------------------------
+# Below it, the key still separates projections that really differ
+# ---------------------------------------------------------------------------
+
+
+def test_two_distinct_subsets_keep_distinct_keys_below_the_threshold():
+    """The control. Collapsing everything would be a correctness bug, not a fix."""
+    assert _key("name", LOW) == "name"
+    assert _key("value", LOW) == "value"
+    assert _key("name,value", LOW) == "name,value"
+    assert len({_key(c, LOW) for c in ("name", "value", "name,value")}) == 3
+
+
+def test_permutations_and_duplicates_still_collapse():
+    """The fix(#403) property survives: sorted and deduped."""
+    assert _key("value,name", LOW) == "name,value"
+    assert _key("name,value", LOW) == "name,value"
+    assert _key("value,value, name ", LOW) == "name,value"
+
+
+@pytest.mark.parametrize("excluded", ["gid", "geom", "geom_4326"])
+def test_a_subset_carrying_an_excluded_name_keys_as_the_subset_without_it(excluded):
+    """No query builder emits these, so naming one changes no byte."""
+    assert _key(f"name,{excluded}", LOW) == _key("name", LOW) == "name"
+    assert _key(excluded, LOW) == _key(None, LOW) == ""
+
+
+def test_the_cluster_route_also_drops_the_names_its_own_query_emits():
+    """`point_count` is an output column of the cluster query, not an input.
+
+    The vector route has no such output, so the same request is a real
+    projection change there. The key has to follow the route, which is why
+    `mode` reaches it.
+    """
+    columns = COLUMNS + [{"name": "point_count", "type": "integer"}]
+    cluster = parse_cols_param("point_count", columns, LOW, mode="cluster")[1]
+    vector = parse_cols_param("point_count", columns, LOW)[1]
+    assert cluster == ""
+    assert vector == "point_count"
+
+
+# ---------------------------------------------------------------------------
+# Names the dataset does not have
 # ---------------------------------------------------------------------------
 
 
@@ -58,33 +154,31 @@ COLUMNS = [
         "x" * 500,
     ],
 )
-def test_a_name_the_dataset_does_not_have_leaves_the_key_empty(cols: str):
+def test_a_name_the_dataset_does_not_have_leaves_the_key_empty(cols):
     """Nothing a request cannot project may distinguish its cache entry."""
-    assert parse_cols_param(cols, COLUMNS) == (None, "")
+    assert parse_cols_param(cols, COLUMNS, LOW) == (None, "")
 
 
-def test_the_key_is_built_from_the_surviving_names_only():
-    """A partly-bogus request keys on exactly what it will project."""
-    assert parse_cols_param("value,bogus", COLUMNS) == (["value"], "value")
-    assert parse_cols_param("value", COLUMNS) == (["value"], "value")
+def test_the_returned_list_is_still_the_validated_request():
+    """Only the KEY moved. The projection input is unchanged, and still filtered.
 
-
-def test_permutations_and_duplicates_still_collapse():
-    """The #403 property survives: sorted and deduped, so orderings collide."""
-    assert parse_cols_param("value,name", COLUMNS)[1] == "name,value"
-    assert parse_cols_param("name,value", COLUMNS)[1] == "name,value"
-    assert parse_cols_param("value,value, name ", COLUMNS)[1] == "name,value"
+    ``_select_tile_columns`` re-validates whatever reaches it, so handing it
+    the request rather than the difference keeps this function's two outputs
+    independently checkable.
+    """
+    assert parse_cols_param("value,bogus", COLUMNS, LOW) == (["value"], "value")
+    assert parse_cols_param("value", COLUMNS, HIGH) == (["value"], "")
 
 
 def test_a_dataset_with_no_column_info_projects_nothing():
     """No column set to validate against means no name can be validated."""
-    assert parse_cols_param("value", []) == (None, "")
-    assert parse_cols_param("value", None) == (None, "")
+    assert parse_cols_param("value", [], LOW) == (None, "")
+    assert parse_cols_param("value", None, LOW) == (None, "")
 
 
 def test_absent_and_empty_cols_are_unchanged():
-    assert parse_cols_param(None, COLUMNS) == (None, "")
-    assert parse_cols_param("", COLUMNS) == (None, "")
+    assert parse_cols_param(None, COLUMNS, LOW) == (None, "")
+    assert parse_cols_param("", COLUMNS, LOW) == (None, "")
 
 
 # ---------------------------------------------------------------------------
@@ -93,7 +187,7 @@ def test_absent_and_empty_cols_are_unchanged():
 
 
 @pytest.mark.usefixtures("_init_tile_pool_for_tests")
-class TestUnknownColsSharesTheUnfilteredEntry:
+class TestTheKeyTheRouterActuallyPasses:
     """Mirrors TestTileCacheColsKey: mock the cache, read the call args.
 
     ``get`` returns None so the route falls through to the real PostGIS path,
@@ -101,65 +195,74 @@ class TestUnknownColsSharesTheUnfilteredEntry:
     that fills the LRU.
     """
 
-    async def test_unknown_cols_reads_and_writes_the_no_cols_entry(
-        self, client: AsyncClient, test_db_session
-    ):
-        table_name = f"cols_v_{uuid.uuid4().hex[:8]}"
+    async def _cols_keys(self, client, table_name, path, cols):
+        mock_cache = AsyncMock()
+        mock_cache.get.return_value = None
+        with patch(
+            "app.processing.tiles.router.get_tile_cache",
+            return_value=mock_cache,
+        ):
+            resp = await client.get(path, params={"cols": cols})
+        assert resp.status_code in (200, 204), resp.text
+        return (
+            mock_cache.get.call_args.kwargs.get("cols_key"),
+            mock_cache.set.call_args.kwargs.get("cols_key"),
+        )
+
+    async def _dataset(self, test_db_session, prefix):
+        table_name = f"{prefix}_{uuid.uuid4().hex[:8]}"
         user_id = await get_user_id(test_db_session, settings.geolens_admin_username)
         await _create_tile_test_dataset(
             test_db_session, created_by=user_id, table_name=table_name
         )
         await _create_data_table(test_db_session, table_name)
+        return table_name
 
+    async def test_high_zoom_requests_share_the_no_cols_entry(
+        self, client: AsyncClient, test_db_session
+    ):
+        """Tile 12/2048/2048 corners on (0, 0), where the fixture's point sits.
+
+        z=12 is past the attribute-budget threshold, so the tile carries every
+        column whatever the caller asks for, and all four requests here must
+        read and write one entry.
+        """
+        table_name = await self._dataset(test_db_session, "cols_hi")
+        path = f"/tiles/data.{table_name}/12/2048/2048.pbf"
         try:
-            mock_cache = AsyncMock()
-            mock_cache.get.return_value = None
-            with patch(
-                "app.processing.tiles.router.get_tile_cache",
-                return_value=mock_cache,
-            ):
-                resp = await client.get(
-                    f"/tiles/data.{table_name}/2/2/2.pbf",
-                    params={"cols": uuid.uuid4().hex},
+            for cols in ("name", "value", "name,value", uuid.uuid4().hex):
+                get_key, set_key = await self._cols_keys(client, table_name, path, cols)
+                assert get_key == "", (
+                    f"?cols={cols} at z=12 projects what the tile already "
+                    f"carried, so it must read the default entry; got {get_key!r}"
                 )
-
-            assert resp.status_code == 200
-            assert mock_cache.get.call_args.kwargs.get("cols_key") == "", (
-                "an unknown name must not distinguish the lookup key: the tile "
-                "it produces is the unfiltered one. Got "
-                f"{mock_cache.get.call_args.kwargs.get('cols_key')!r}"
-            )
-            assert mock_cache.set.call_args.kwargs.get("cols_key") == "", (
-                "nor the write key, which is the half that fills the LRU. Got "
-                f"{mock_cache.set.call_args.kwargs.get('cols_key')!r}"
-            )
+                assert set_key == "", (
+                    f"and must write it rather than a new one; got {set_key!r}"
+                )
         finally:
             await _cleanup_data_table(test_db_session, table_name)
 
-    async def test_a_real_column_still_gets_its_own_entry(
+    async def test_low_zoom_keeps_a_real_projection_apart(
         self, client: AsyncClient, test_db_session
     ):
-        """The control: validation must not collapse projections that differ."""
-        table_name = f"cols_r_{uuid.uuid4().hex[:8]}"
-        user_id = await get_user_id(test_db_session, settings.geolens_admin_username)
-        await _create_tile_test_dataset(
-            test_db_session, created_by=user_id, table_name=table_name
-        )
-        await _create_data_table(test_db_session, table_name)
-
+        """The control at the other side of the threshold, over HTTP."""
+        table_name = await self._dataset(test_db_session, "cols_lo")
+        path = f"/tiles/data.{table_name}/2/2/2.pbf"
         try:
-            mock_cache = AsyncMock()
-            mock_cache.get.return_value = None
-            with patch(
-                "app.processing.tiles.router.get_tile_cache",
-                return_value=mock_cache,
-            ):
-                resp = await client.get(
-                    f"/tiles/data.{table_name}/2/2/2.pbf",
-                    params={"cols": "value,not_a_column"},
-                )
-
-            assert resp.status_code == 200
-            assert mock_cache.get.call_args.kwargs.get("cols_key") == "value"
+            value_key, _ = await self._cols_keys(client, table_name, path, "value")
+            name_key, _ = await self._cols_keys(client, table_name, path, "name")
+            unknown_key, unknown_set = await self._cols_keys(
+                client, table_name, path, uuid.uuid4().hex
+            )
+            assert value_key == "value"
+            assert name_key == "name"
+            assert unknown_key == "", (
+                "an unknown name must not distinguish the lookup key: the tile "
+                f"it produces is the unfiltered one. Got {unknown_key!r}"
+            )
+            assert unknown_set == "", (
+                "nor the write key, which is the half that fills the LRU. Got "
+                f"{unknown_set!r}"
+            )
         finally:
             await _cleanup_data_table(test_db_session, table_name)

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -295,6 +295,42 @@ server {
         proxy_send_timeout 600s;
         proxy_connect_timeout 30s;
 
+        # fix(#1778): the raster tile budget was opt-in by URL spelling. The
+        # `/raster-tiles/...` location above rewrites to `/tiles/raster-proxy/`
+        # and is the only thing that ever carried `limit_req`, but the same
+        # handler is reachable by asking for `/api/tiles/raster-proxy/...`
+        # directly: this block rewrites `^/api/(.*)` to `/$1` and proxies it to
+        # the api, which serves the route with no limit of its own. Every tile
+        # URL the product mints uses the throttled spelling, so the rate limit
+        # only ever governed well-behaved clients. Same zone, same burst, so the
+        # two spellings draw on ONE per-IP bucket rather than two: a caller who
+        # switches spelling mid-flood gets no fresh allowance.
+        #
+        # Done here rather than by dropping the handler's `@limiter.exempt`,
+        # because the app's global default is a general-purpose per-second cap
+        # and this route is not general-purpose traffic. The zone above is
+        # sized for tiles (600r/m with burst 200, for the 50-100+ request cold
+        # start of a tilted multi-layer 3D view); the app default would 429 the
+        # tail of exactly that fan-out, including the part of it nginx forwards
+        # on a raster_cache MISS. Cached serving is untouched either way: a
+        # raster_cache HIT never reaches the api, and this block already runs
+        # with `proxy_cache off`, so nothing that was cached before is cached
+        # differently now.
+        #
+        # Nested, so the proxy settings above are inherited rather than copied
+        # and left to drift. `proxy_pass`, `rewrite` and `set` are the three
+        # nginx does not inherit into a nested location, so they are restated
+        # (same shape as the export block below). No `add_header` and no
+        # `proxy_hide_header` here: declaring either would disable inheritance
+        # of the set this block already applies.
+        location ~ ^/api/tiles/raster-proxy/ {
+            limit_req zone=raster_anon burst=200 nodelay;
+
+            set $upstream_api ${API_UPSTREAM};
+            rewrite ^/api/(.*) /$1 break;
+            proxy_pass $upstream_api;
+        }
+
         # fix(#1532 review r15): the two routes that serve BYTE RANGES bound to a
         # strong ETag must reach the client exactly as the backend wrote them.
         #


### PR DESCRIPTION
Fixes four findings from the codebase audit 2026-08-30 (8dc529f17), tracked in #1778, that share one cause: the ladder of things bounding what an anonymous request can cost has a rung missing at every level. All four were re-verified as still present on current main before any code was written. None had been fixed since the audit.

## The "Global Rate Limit" is keyed per URL PATH, not per IP

slowapi's `Limiter` defaults to `key_style="url"`. `_check_request_limit` sets `_endpoint_key = request["path"]` and `__evaluate_limits` counts under `(key_func(request), _endpoint_key)`, so the admin-editable "Global Rate Limit (per second)" counted under (client IP, URL). On a path-parameterised route the caller picks the URL, so the caller picked how many budgets to have: one per dataset id, one per z/x/y, one per record id. `openapi.json` lists 46 anonymous parameterised operations, and the expensive ones are among them.

The limiter is now built with `key_style="endpoint"`, which counts under (client IP, `module.function`). The route table decides how many handlers exist, so the multiplier is fixed at deploy time.

Two things move with it, both recorded at the limiter rather than papered over. The trailing-slash aliases of a dual-shape route now share one bucket, which is stricter and is what the T-1238-03 guard in `test_admin_rate_limit.py` was always asking for; its docstring is corrected in the same commit. Two methods on one path no longer share theirs, which is looser by a number the route table fixes, unlike the number of URLs. Requests matching no route are unaffected either way, because `slowapi/middleware.py::_should_exempt` already exempts a request whose handler it cannot resolve, before key style is consulted.

I walked every `@limiter.limit` and `@limiter.exempt` site. No comment anywhere claimed URL keying except that one test docstring; every other one describes a per-IP or per-user limit, which endpoint keying preserves. `@limiter.exempt` is matched by function name in both styles and is unaffected.

### The ArcGIS sign-in limits (#1758)

Rebased onto main past #1758, which added the two per-route limits on `POST /services/arcgis/signin/`. They are worth calling out because the key style governs per-route limits too: a `@limiter.limit` decorator carries its own `key_func` but no `scope`, so `__evaluate_limits` falls back to `lim.scope or endpoint` and counts under `(key_func(request), _endpoint_key)`. The key functions are the first half; the key style decides the second.

They were not already handler-keyed, and nothing in them assumed URL keying either. `_signin_user_key` and `_signin_portal_key` (`sources/router.py:1211-1224`) both read the user id off `request.state` and never touch the path, and `signin_guard.py` counts committed `audit_logs` and `arcgis_signin_attempts` rows keyed on user id, account key and portal host, with no path or slowapi input anywhere in it. So no scope derivation needed changing.

What did change is that control 2 of the five controls now admits the number its own comment states. The route is dual-shape, so under URL keying `/signin` and `/signin/` were two buckets, and a caller alternating them put six requests per worker onto the database-backed control 4 rather than three. Measured with control 4 and the per-portal limit raised out of the way: six 200s under `key_style="url"`, and 200/200/200/429/429/429 under `key_style="endpoint"` with only three sign-in POSTs reaching the portal. A `fix(#1778)` note at the control list records it, and the regression test lives beside the other key-style tests rather than in the sign-in suite, to keep the hunk out of the lane working in `sources/**`.

`tests/test_arcgis_signin.py`, `tests/test_arcgis_signin_tenancy.py`, `tests/test_sources_safe_client_structural.py` and `tests/test_rule1_structural.py` all pass under endpoint keying (189 passed). No existing test hits two spellings expecting two buckets; every sign-in test uses `SIGNIN_URL = "/services/arcgis/signin/"`.

## /api/tiles/raster-proxy/ bypasses the only rate limit in the deployment

nginx declares one `limit_req_zone` and applied it in one place: the `/raster-tiles/` location, which rewrites to `/tiles/raster-proxy/` and proxies that to the api. The same handler answers `/api/tiles/raster-proxy/...` through `location /api/`, which carries no `limit_req`, `proxy_cache off`, and an `@limiter.exempt` handler behind it. The rate limit was opt-in by URL spelling, and only the product's own clients opted in.

A nested location under `/api/` now carries the same zone and burst, so both spellings draw on one per-IP bucket.

I picked that over dropping the handler's `@limiter.exempt` because it keeps cached tile serving unchanged and keeps legitimate map loads working. The app's global default is a general-purpose per-second cap; the nginx zone is sized for tiles (600r/m with burst 200, for the 50-100+ request cold start of a tilted multi-layer 3D view). Putting the app default in front of the handler would refuse the tail of exactly that fan-out, including the part nginx forwards on a `raster_cache` MISS. Cached serving is untouched under either choice, since a cache hit never reaches the api and the `/api/` block already runs with `proxy_cache off`.

Measured with the file rendered against nginx 1.29 (alpine), the upstream pointed at a closed port so a proxied request answers 502 and a refused one answers 503, and the zone temporarily narrowed to 1r/m with no burst:

- without the nested block: `/api/tiles/raster-proxy/...` answered 502, 502, 502, and a following `/raster-tiles/...` answered 502 as well. Not limited, and not even drawing on the other spelling's bucket.
- with it: 502 then 503; `/api/health` answered 502 twice, so the outer block stays unlimited; `/raster-tiles/...` answered 503 on its first request, because the tokens had already been spent under the other spelling.

`nginx -t` passes on the rendered file, and a 502 from the nested block carries a header set identical to one from `/api/health`, so the inherited security and proxy headers still apply.

## cols= is spliced into the tile cache key unvalidated

`parse_cols_param` returned the caller's string as the cache-key segment and deferred validation to `_select_tile_columns`, which drops an unrecognised name silently. So the key varied on input the projection ignores, and it did so in three ways that compound:

- an unknown name, dropped by the selector, leaving the unfiltered tile under a fresh key;
- **any** valid subset at or above the z<10 attribute budget, where the zoom default already projects every column. On a wide public table that is exponentially many keys for one set of bytes, not one bogus name at a time. A name already on an explicit `tile_columns` allowlist is the same case at any zoom;
- a name no query builder emits: `gid`/`geom`/`geom_4326` on either route, and the cluster query's own `point_count`/`cluster_id` family on the cluster route.

Each cost a full `ST_AsMVT` on an anonymous, `@limiter.exempt` route serving public datasets, and then wrote the result. The default production stack has no Valkey, so the writes land in an `LRUCache(maxsize=50_000)` and evict legitimate tiles.

The function now takes `z`, the allowlist and the route mode, resolves the projection through `_select_tile_columns`, mirrors each query builder's exclusion set, and keys on what the request **adds** to the projection the tile would have had anyway. `additional_columns` only ever unions into the base selection, so that difference identifies the projection uniquely for one dataset at one zoom, and an empty suffix keeps meaning what it always meant, so no existing cache entry changes shape. `z` is positional and required so a third tile endpoint cannot quietly go back to keying on the request.

Measured: at z=12, no cols, one column, two columns and an unknown name all read and write one entry. At z=2 two distinct subsets stay apart, `name,gid` keys as `name`, and `gid` alone keys as no cols. A name inside a `tile_columns` allowlist keys as no cols at both zooms while one outside it still keys separately. `point_count` collapses on the cluster route and stays distinct on the vector route, which is why `mode` reaches the key.

## The ?v= raster cache-buster pins a pool connection across the Titiler round trip

`_resolve_raster_meta` looks up under the request's `v` (#1329), and `_meta_cache_version_segment` accepts any ASCII digit run of length 1 to 10, so a caller varying it misses that cache on every request and pays the `db.execute`. `get_db` yields one session for the whole request and only rolls back on an exception, so that read's transaction was held until the response was written, while `raster_tile_proxy` awaited Titiler for up to three attempts at a 30s timeout plus 0.5s and 1.0s of backoff. The pool is `db_pool_size + db_max_overflow` per uvicorn worker; once it is parked on upstream fetches, every other request in that worker waits out `db_pool_timeout` and then errors.

`_resolve_raster_access` now rolls back before returning, the remedy fix(#1451) applied to the vector path for the same reason. It sits in the resolver rather than at either call site because a caller cannot release what it did not know was taken, and it covers `raster_auth_check` (a mounted route) and `raster_tile_proxy` (its in-process caller) without either having to remember. Everything past it is locals: `meta` is a plain snapshot and `storage_backend` a string, and the embed-token usage bump uses its own side session (fix(#1436)), so the rollback discards nothing. The #1329 note that priced a cache-busting `v` as "at most one extra indexed read" is corrected in place, since the read was never the expensive half.

## Schema, API and config impact

No schema change. No request or response schema change: `dump_openapi.py --check` passes with `backend/openapi.json` untouched, so no SDK regeneration is needed. I did not add `Query(max_length=...)` to `cols`, which the finding itself calls secondary, because it would change the published operation description and parameter schema and churn every generated SDK for a bound the validation supersedes. For the same reason the handler docstring is unchanged and the note about the key lives at `parse_cols_param` and in an inline comment at the call site.

Config impact is `frontend/nginx.conf` only: one nested location, no new envsubst placeholder, no change to the zone, burst, cache or headers.

Operators should know the rate-limit change is a real tightening. An integration that today gets 60 requests a second per dataset id from one IP will get 60 a second across all of them. The setting is admin-editable at runtime, so raising it needs no deploy.

Module cap: `backend/app/processing/tiles/router.py` 2590 to 2639, re-measured after each change and still exact. `tiles/service.py` is 870, under the 1000 inclusion threshold, so it stays ungated. `sources/router.py` is 1373, under the 1500 default router cap and not in the allowlist, so the nine comment lines need no cap change.

## Verification

Run from this worktree against Postgres at localhost:5434.

- `uv run pytest tests/test_layering.py -q` -> 47 passed
- `uv run pytest tests/test_rate_limit_key_style_1778.py tests/test_nginx_raster_proxy_ratelimit_1778.py tests/test_tile_cols_cache_key_validation_1778.py tests/test_raster_proxy_releases_connection_1778.py tests/test_layering.py -q` -> 70 passed (post-rebase)
- after the projection-key change: the four new files plus `test_layering.py` and seven tile suites -> 152 passed, 3 skipped
- `uv run pytest tests/test_tile_cols_cache_key_validation_1778.py tests/test_tile_cols_endpoint.py tests/test_tile_cache_cols_key.py tests/test_tile_column_allowlist.py tests/test_tiles.py tests/test_tile_cache.py tests/test_tile_cache_scope_sec009.py tests/test_tile_cache_generation_key_1429.py tests/test_tile_cached_authz_liveness_1451.py -q` -> 156 passed
- `uv run pytest tests/test_arcgis_signin.py tests/test_arcgis_signin_tenancy.py tests/test_sources_safe_client_structural.py tests/test_rule1_structural.py -q` -> 189 passed (post-rebase)
- `uv run pytest tests/test_arcgis_signin.py tests/test_arcgis_signin_tenancy.py tests/test_sources_safe_client_structural.py tests/test_rule1_structural.py tests/test_rate_limits.py tests/test_admin_rate_limit.py tests/test_middleware.py -q` -> 215 passed (post-rebase, random order)
- `uv run pytest tests/test_layering.py tests/test_rate_limit_key_style_1778.py tests/test_nginx_raster_proxy_ratelimit_1778.py tests/test_tile_cols_cache_key_validation_1778.py tests/test_raster_proxy_releases_connection_1778.py tests/test_rate_limits.py tests/test_admin_rate_limit.py tests/test_middleware.py tests/test_tiles.py tests/test_tile_cols_endpoint.py tests/test_tile_cache_cols_key.py tests/test_raster_tiles.py tests/test_raster_colormap_proxy.py -q` -> 226 passed
- `uv run pytest tests/test_tiles.py tests/test_tile_cols_endpoint.py tests/test_tile_cache_cols_key.py tests/test_tile_column_allowlist.py tests/test_tile_cache.py tests/test_tile_cache_scope_sec009.py tests/test_tile_cache_generation_key_1429.py tests/test_tile_cached_authz_liveness_1451.py -q` -> 131 passed
- `uv run pytest tests/test_raster_tiles.py tests/test_raster_colormap_proxy.py tests/test_raster_tile_url_version_1372.py tests/test_vrt_catalog_175.py tests/test_titiler_url_helper.py tests/test_optional_auth_failure_mode_1518.py -q` -> 176 passed
- `uv run pytest tests/test_vector_tile_auth.py tests/test_tile_signing.py tests/test_seed_tiles.py tests/test_worker_tile_cache_1315.py tests/test_dataset_tile_columns_metadata.py tests/test_dataset_delete_tile_cache_purge.py tests/test_phase_274_tile_cache.py tests/test_tile_gzip_offload_perf005.py -q` -> 95 passed, 3 skipped
- `uv run pytest tests/test_auth.py tests/test_rule1_structural.py tests/test_rule2_structural.py -q` -> 142 passed
- `uv run pytest tests/test_api_contract_openapi.py tests/test_health.py tests/test_module_import_seams.py tests/test_register_verification_flow.py tests/test_sandbox_query_endpoint_565.py tests/test_search_cors_1596.py tests/test_data_serving_extension.py -q` -> 173 passed
- the six pre-existing `tests/test_nginx_*.py` suites -> 21 passed
- `uv run ruff check .` and `uv run ruff format --check .` -> clean
- `PYTHONPATH=. uv run python scripts/dump_openapi.py --check` -> exit 0

Each new test was run against the un-fixed code as a counterfactual. Keying the tile cache on the requested subset rather than the effective projection fails 13 of that file's 25 tests and leaves green the 12 that guard against over-collapsing. Removing the nested nginx block fails three of the four nginx assertions and leaves the control passing. Removing `await db.rollback()` fails all three raster assertions. Forcing `key_style = "url"` makes two different URLs on one handler both pass a 1/minute limit, and makes the alternating sign-in spellings return six 200s instead of three 200s and three 429s.

## Left alone

- Three neighbouring findings in the same audit register, out of this lane's scope: the `/raster-tiles/` location has no `proxy_read_timeout` so it runs on nginx's 60s default against a handler whose worst case is about 121s; `stretch=percentile&pmin=&pmax=` buys an anonymous caller a full-raster statistics computation against a 256-entry cache and a single Titiler worker; and no `limit_conn` exists at either layer, so a rate limit cannot bound in-flight anonymous work.
- `db/postgresql.conf` statement timeouts, excluded by the lane brief as operator-facing config.
- `Query(max_length=...)` on `cols`, for the SDK-churn reason above.
- The vector `/api/tiles/data.*` routes are still unthrottled at both layers. That belongs to the `limit_conn` finding rather than this one, and the nested nginx block deliberately covers only the raster proxy so a tile-shaped zone does not start governing MVT traffic it was not sized for.
