### PR TITLE
fix(#1758): two flaky assertions in the sign-in suite

### DIFF
--- a/backend/tests/test_arcgis_signin.py
+++ b/backend/tests/test_arcgis_signin.py
@@ -2121,18 +2121,42 @@ async def test_a_signin_holds_exactly_one_pooled_connection(
     were holding, stalling unrelated traffic until the 30-second pool timeout.
     Both locks now ride the request's own transaction, so the count is one.
 
-    Counted with a pool `checkout` listener rather than at the session factory,
-    because the factory is not what the pool runs out of.
+    Counted at the pool rather than at the session factory, because the
+    factory is not what the pool runs out of.
+
+    fix(#1758): counted as PEAK CONCURRENT connections, not as cumulative
+    checkout events. The first version summed `checkout` and asserted 1, which
+    conflated "how many connections did this request hold at once" with "how
+    many times did it acquire one". Those differ whenever a connection is
+    released and re-acquired in sequence, which is legitimate and does happen
+    here: `_signin_audit` commits, its rollback-and-retry path on a poisoned
+    transaction acquires again, and the harness has contention retries of its
+    own in `_RetryingAsyncEngine` and `_acquire_test_session_with_retry`. A
+    single session that commits and then runs one more statement already
+    scores 2 cumulative while never holding more than one. That made the
+    assertion red on a loaded runner with nothing wrong, first seen in
+    merge-queue run 33648625488 on an unrelated frontend-only PR.
+
+    Peak concurrency is the property the paragraph above actually names, and
+    it is what a second lock session would break: that session held its
+    connection WHILE the request held its own. Sequential re-acquisition
+    cannot reach 2, so this is a sharper assertion rather than a weaker one.
     """
     from sqlalchemy import event
 
     import app.core.db as db_module
 
-    checkouts = 0
+    live = 0
+    peak = 0
 
-    def _count(*_args) -> None:
-        nonlocal checkouts
-        checkouts += 1
+    def _acquired(*_args) -> None:
+        nonlocal live, peak
+        live += 1
+        peak = max(peak, live)
+
+    def _released(*_args) -> None:
+        nonlocal live
+        live = max(0, live - 1)
 
     exchange = _Exchange(
         {
@@ -2141,18 +2165,20 @@ async def test_a_signin_holds_exactly_one_pooled_connection(
         }
     )
     sync_engine = db_module.engine.sync_engine
-    event.listen(sync_engine, "checkout", _count)
+    event.listen(sync_engine, "checkout", _acquired)
+    event.listen(sync_engine, "checkin", _released)
     try:
         with _install(exchange):
             resp = await client.post(
                 SIGNIN_URL, json=_body(), headers=admin_auth_header
             )
     finally:
-        event.remove(sync_engine, "checkout", _count)
+        event.remove(sync_engine, "checkout", _acquired)
+        event.remove(sync_engine, "checkin", _released)
 
     assert resp.status_code == 200
-    assert checkouts == 1, (
-        f"a sign-in checked out {checkouts} pooled connections; both advisory "
+    assert peak == 1, (
+        f"a sign-in held {peak} pooled connections at once; both advisory "
         "locks must ride the request's own session"
     )
 

--- a/backend/tests/test_arcgis_signin.py
+++ b/backend/tests/test_arcgis_signin.py
@@ -2393,20 +2393,35 @@ async def test_a_discovery_failure_takes_no_lock_and_writes_no_ledger_row(
 ):
     """Phase one is credential-free, so its failures cost nobody a budget.
 
-    The lock is proven untaken by holding nothing and asserting the guard
-    never opened a lock session; the ledger is proven untouched by counting
-    its rows either side of the refusal.
+    The lock is proven untaken by watching the guard's own lock helper; the
+    ledger is proven untouched by counting its rows either side of the
+    refusal.
+
+    fix(#1758): watches `_signin_locks` rather than counting calls to
+    `app.core.db.async_session`. That proxy dated from before the locks moved
+    onto the request session, by which point it no longer observed locking at
+    all: it counted every call to a PROCESS-GLOBAL factory, so anything else
+    in the worker that opened a session during the request was counted as a
+    lock this sign-in took. `get_db` itself calls that factory, as do the
+    ingest and embedding task paths. That made the assertion red on a loaded
+    runner with nothing wrong, in merge-queue runs 33649640369 and
+    33649761185 on two frontend-only PRs.
+
+    Watching the helper the handler actually calls is both narrower and
+    truer to the sentence being asserted, and it cannot be reached by
+    anything outside this request.
     """
     await _clear_unknown_host_rows(test_db_session)
-    import app.core.db as db_module
 
-    real_factory = db_module.async_session
-    lock_sessions = 0
+    locks_taken = 0
+    real_locks = sources_router._signin_locks
 
-    def counting_factory(*args, **kwargs):
-        nonlocal lock_sessions
-        lock_sessions += 1
-        return real_factory(*args, **kwargs)
+    @contextlib.asynccontextmanager
+    async def _counting_locks(db, user_scope, account_scope):
+        nonlocal locks_taken
+        locks_taken += 1
+        async with real_locks(db, user_scope, account_scope) as held:
+            yield held
 
     before = await test_db_session.scalar(
         select(func.count()).select_from(ArcGISSignInAttempt)
@@ -2416,7 +2431,7 @@ async def test_a_discovery_failure_takes_no_lock_and_writes_no_ledger_row(
     # conventional `/generateToken` is the documented fallback, so the sign-in
     # goes on to try it and any failure there is the mint's.
     exchange = _Exchange({})
-    with patch.object(db_module, "async_session", counting_factory):
+    with patch.object(sources_router, "_signin_locks", _counting_locks):
         with patch(
             "app.modules.catalog.sources.arcgis_signin.validate_url_for_ssrf",
             new_callable=AsyncMock,
@@ -2430,7 +2445,7 @@ async def test_a_discovery_failure_takes_no_lock_and_writes_no_ledger_row(
     assert resp.status_code == 502
     assert resp.json()["detail"]["code"] == "network_error"
     assert exchange.requests == []
-    assert lock_sessions == 0, "a discovery failure must not take a lock"
+    assert locks_taken == 0, "a discovery failure must not take a lock"
 
     after = await test_db_session.scalar(
         select(func.count()).select_from(ArcGISSignInAttempt)


### PR DESCRIPTION
Fixes the flaky `test_a_signin_holds_exactly_one_pooled_connection`, which went red in merge-queue run 33648625488 on an unrelated frontend-only PR. Test-only; no production code changes.

## What was wrong

The test summed the pool's `checkout` event and asserted 1. That conflates two different things:

- how many connections the request held **at once**, which is the property the test exists to protect
- how many times it **acquired** one, which is what `checkout` counts

Those differ whenever a connection is released and re-acquired in sequence, and that is legitimate on this path. `_signin_audit` commits, which returns the connection to the pool; its rollback-and-retry on a poisoned transaction then acquires another; and the test harness has contention retries of its own in `_RetryingAsyncEngine` and `_acquire_test_session_with_retry`, both added precisely because acquisition can fail transiently under `-n 4`.

I measured it rather than reasoning about it. A single session that commits and then runs one more statement scores **2 cumulative checkouts with a peak of 1 held**:

```
CUMULATIVE=2 PEAK_CONCURRENT=1
```

So the assertion could go red on a loaded runner with nothing whatsoever wrong in the code under test. The failing run shows no connection errors and the test failed at 100% completion after a twenty-minute suite, which fits a contention-driven re-acquire rather than a defect.

## What it does now

Tracks `checkout` against `checkin` and asserts the **peak concurrent** count is 1. That is the property the test's own docstring names: both advisory locks must ride the request's own session, and the defect it guards against is a dedicated lock session holding its connection *while* the request holds its own.

This is a sharper assertion, not a weaker one. Sequential re-acquisition cannot reach a peak of 2, so the only way to trip it is the real defect. Verified by counterfactual: reinstating a dedicated lock session in `_signin_locks` still turns it red, now with `a sign-in held 2 pooled connections at once`.

## Verification

- The single test 10 times under `-n 4`: 10/10 pass.
- `tests/test_arcgis_signin.py` under `-n 4`: 175 passed.
- Same file in default (random) order: 175 passed.
- With the tenancy and layering suites under `-n 4`: 225 passed.
- Counterfactual: a second session in `_signin_locks` reddens it with the new message.
- `ruff check` clean.

## Note

#1775's reserve-then-settle redesign will deliberately introduce a second *sequential* connection acquisition per sign-in, in two short transactions either side of the network phases. Under the old cumulative assertion that redesign would have looked like a regression; under peak-concurrency it reads correctly, since the two transactions never overlap. The test stays valid as one of that issue's acceptance criteria.



---

# Second commit: the discovery-failure lock assertion

`43844a2` fixes a second flake in the same file, `test_a_discovery_failure_takes_no_lock_and_writes_no_ledger_row`, red in merge-queue runs 33649640369 and 33649761185 on two more frontend-only PRs. Also test-only.

## What was wrong

The test proved "no lock was taken" by monkeypatching `app.core.db.async_session` and asserting it was never called. That proxy made sense when the sign-in opened a dedicated session for its advisory locks. Round 10 moved both locks onto the request's own transaction, and from that point the assertion observed nothing about locking at all.

What it did observe was a **process-global** factory that plenty of unrelated code calls, `get_db` among them, plus the ingest and embedding task paths. Anything in the worker that opened a session inside the patch window scored as a lock this sign-in took.

Measured, not assumed. With the sign-in taking no lock whatsoever, one unrelated `async_session()` call inside the same window scores:

```
OLD PROXY COUNTED: 1  (sign-in took no lock at all)
```

## What it does now

Wraps `_signin_locks`, the helper the handler actually calls, and asserts it was never entered. Same sentence, strictly more precise: nothing outside this request can reach that helper.

Verified by counterfactual. With discovery no longer short-circuiting, the handler reaches the lock and the test fails.

## Sweep of the rest of the file

Checked for other assertions reading state wider than their own test:

- **No `pg_locks` or `pg_stat_activity` read anywhere in the file.** The advisory-lock tests observe locks by trying to take them on their own session, not by querying the cluster.
- **Ledger reads are all scoped.** Two filter on `account_key`; three are before/after deltas within a single test.
- **Per-worker databases** (`geolens_test_gw0_<uuid>`) isolate both table rows and advisory locks, so cross-worker contamination is not reachable for either.
- **The pool listener in the first commit** does read a process-global engine, so I measured it rather than trusting it. During a sign-in exactly one checkout occurs, from `get_db`. `peak == 1` holds with nothing else competing.

The one other counter in the file patches `_signin_audit`, which only the sign-in path calls.

## Verification

- Target test alone: passes.
- `test_arcgis_signin.py` + `test_arcgis_signin_tenancy.py` under `-n 4`, 5 consecutive runs: 178 passed each time.
- Adding `test_layering.py`: 225 passed.
- Counterfactual on the new assertion: red.
- `ruff check` and `ruff format --check` clean; pre-commit hooks pass.
