### PR TITLE
fix(import,settings,a11y): frontend tail items from the 2026-08-30 audit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2005,12 +2005,18 @@ jobs:
 
       # fix(#524 B-036): the builder-hardening suite previously ran in NO CI
       # trigger (this job runs only the default config), so a red hardening
-      # gate on main was invisible. Chromium project only — the runner installs
-      # chromium alone, and the firefox/webkit projects are a local reviewer
-      # concern. --reporter=line keeps it from clobbering the main suite's
-      # playwright-report/ artifact.
-      - name: Run builder-hardening E2E suite (chromium)
-        run: npx playwright test -c playwright.builder-hardening.config.ts --project=chromium-hardening --reporter=line
+      # gate on main was invisible. Chromium projects only: the runner
+      # installs chromium alone, and the firefox/webkit projects are a local
+      # reviewer concern. --reporter=line keeps it from clobbering the main
+      # suite's playwright-report/ artifact.
+      #
+      # fix(#1778): chromium-hardening-dark (light-mode gap closed for this
+      # config) was defined but never selected here, so it never actually
+      # ran in CI. Both chromium projects in one invocation; still no
+      # firefox/webkit install needed since both are chromium under the
+      # hood, just a different colorScheme.
+      - name: Run builder-hardening E2E suite (chromium, light + dark)
+        run: npx playwright test -c playwright.builder-hardening.config.ts --project=chromium-hardening --project=chromium-hardening-dark --reporter=line
 
       # fix(#896): extract the failing spec names from the json reporter
       # output (playwright.config.ts) so the nightly report can say WHICH

--- a/e2e/accessibility-target-size.spec.ts
+++ b/e2e/accessibility-target-size.spec.ts
@@ -1,0 +1,94 @@
+import { test } from '@playwright/test';
+import AxeBuilder from '@axe-core/playwright';
+import { getAuthToken, seedDataset, deleteDataset, type SeededDataset } from './helpers/catalog';
+
+const BASE_URL = process.env.E2E_BASE_URL ?? 'http://localhost:8080';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function formatViolations(violations: any[]): string {
+  return violations
+    .map(
+      (v) =>
+        `[${v.id}] ${v.description} (${v.impact})\n` +
+        v.nodes.map((n) => `  - ${n.html}`).join('\n'),
+    )
+    .join('\n\n');
+}
+
+/**
+ * fix(#1778): the gating suite's `wcagTags` (accessibility.spec.ts) omits
+ * `wcag22aa`, the only tag that reaches axe-core's `target-size` rule, so
+ * the map builder's 22px row controls (StackRow.tsx, FolderGroupRow.tsx,
+ * BasemapGroupRow.tsx, UnifiedStackPanel.tsx, EmptyStackState.tsx,
+ * BasemapGroupEditorScene.tsx) are structurally invisible to CI. Adding
+ * `wcag22aa` to the gating tags would fail the suite on those controls
+ * immediately, so this is a separate, non-gating scan: it always passes and
+ * only surfaces violations (console + attachment) for the target-size work
+ * to be scoped and scheduled later.
+ *
+ * Deliberately not listed in any package.json `e2e:smoke:*` script, so the
+ * per-PR smoke gates never pick it up (same precedent as analysis.spec.ts).
+ */
+test.describe('Accessibility target-size scan (non-gating)', () => {
+  let seed: SeededDataset;
+  let mapId: string;
+
+  test.beforeAll(async () => {
+    seed = await seedDataset('A11y Target-Size Seed Dataset');
+    const headers = {
+      Authorization: `Bearer ${getAuthToken()}`,
+      'Content-Type': 'application/json',
+    };
+
+    const mapRes = await fetch(`${BASE_URL}/api/maps/`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({
+        name: `A11y Target-Size Map ${Date.now()}`,
+        description: 'Fixture for the non-gating wcag22aa target-size scan',
+      }),
+    });
+    if (!mapRes.ok) throw new Error(`map create failed: ${mapRes.status}`);
+    mapId = ((await mapRes.json()) as { id: string }).id;
+
+    const layerRes = await fetch(`${BASE_URL}/api/maps/${mapId}/layers/`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({ dataset_id: seed.id }),
+    });
+    if (!layerRes.ok) throw new Error(`layer create failed: ${layerRes.status}`);
+  });
+
+  test.afterAll(async () => {
+    if (mapId) {
+      await fetch(`${BASE_URL}/api/maps/${mapId}`, {
+        method: 'DELETE',
+        headers: { Authorization: `Bearer ${getAuthToken()}` },
+      }).catch(() => {
+        /* teardown is best-effort; the CI stack is torn down anyway */
+      });
+    }
+    if (seed) await deleteDataset(seed.id, seed.title);
+  });
+
+  test('map builder page: wcag22aa target-size scan (reports only)', async ({ page }, testInfo) => {
+    await page.goto(`/maps/${mapId}`);
+    await page.waitForLoadState('networkidle');
+
+    const results = await new AxeBuilder({ page }).withTags(['wcag22aa']).analyze();
+
+    if (results.violations.length > 0) {
+      const formatted = formatViolations(results.violations);
+      // eslint-disable-next-line no-console
+      console.warn(
+        `[wcag22aa target-size, non-gating] ${results.violations.length} violation(s):\n${formatted}`,
+      );
+      await testInfo.attach('wcag22aa-violations.txt', {
+        body: formatted,
+        contentType: 'text/plain',
+      });
+    }
+    // No assertion on results.violations by design (see module docstring):
+    // this scan reports for later scoping, it does not gate CI.
+  });
+});

--- a/e2e/builder-hardening.spec.ts
+++ b/e2e/builder-hardening.spec.ts
@@ -395,16 +395,35 @@ test.describe('Builder residual-risk hardening', () => {
     }
   });
 
-  test('public share, embed, and read-only map viewers work while unauthenticated editing stays protected', async ({ browser, request, browserName }) => {
+  test('public share, embed, and read-only map viewers work while unauthenticated editing stays protected', async ({ browser, request, browserName }, testInfo) => {
     test.skip(browserName !== 'chromium', 'permission/share variants are covered in the primary browser project');
 
+    // fix(#1778): browser.newContext() does not inherit the project's
+    // `use.colorScheme` -- that option only applies to the default
+    // context/page fixtures Playwright builds for a test, not one created
+    // manually here for an unauthenticated storageState. Read the active
+    // project's colorScheme (Playwright's own default is 'light' when the
+    // project leaves it unset) and pass it through explicitly, so the dark
+    // project actually exercises this flow under dark mode instead of
+    // silently running it in light mode regardless of the project.
+    const colorScheme = testInfo.project.use.colorScheme ?? 'light';
     const { mapId, shareToken } = await createPublicSharedMap(request, `E2E Public Share ${Date.now()}`);
-    const context = await browser.newContext({ storageState: { cookies: [], origins: [] } });
+    const context = await browser.newContext({
+      storageState: { cookies: [], origins: [] },
+      colorScheme,
+    });
     const viewer = await context.newPage();
     try {
       await viewer.goto(`${BASE_URL}/m/${shareToken}`);
       await expect(viewer.locator('text=Something went wrong')).toHaveCount(0);
       await expect(viewer.locator('canvas.maplibregl-canvas')).toBeVisible({ timeout: 20_000 });
+
+      // Confirm the manually created context actually resolved to the
+      // project's color scheme rather than silently defaulting to light.
+      const prefersDark = await viewer.evaluate(
+        () => window.matchMedia('(prefers-color-scheme: dark)').matches,
+      );
+      expect(prefersDark).toBe(colorScheme === 'dark');
 
       await viewer.goto(`${BASE_URL}/m/${shareToken}?embed=true`);
       await expect(viewer.locator('text=Something went wrong')).toHaveCount(0);

--- a/e2e/record-detail-ux-audit.spec.ts
+++ b/e2e/record-detail-ux-audit.spec.ts
@@ -121,6 +121,7 @@ async function runAudit(
   recordType: RecordType,
   viewportName: ViewportName,
   target: AuditTarget,
+  colorScheme: 'light' | 'dark' = 'light',
 ) {
   const consoleLines: string[] = [];
   const networkLines: string[] = [];
@@ -129,13 +130,17 @@ async function runAudit(
   const failures: string[] = [];
   const start = Date.now();
 
-  const screenshotPath = path.join(outputDir, 'evidence', `${recordType}-${viewportName}.png`);
-  const consoleLogPath = path.join(outputDir, 'logs', `console-${recordType}-${viewportName}.log`);
+  // fix(#1778): colorScheme is folded into the per-run evidence paths so a
+  // dark-mode pass does not silently overwrite the light-mode screenshot/log
+  // for the same record type and viewport (see the colorScheme loop below).
+  const slug = `${recordType}-${viewportName}-${colorScheme}`;
+  const screenshotPath = path.join(outputDir, 'evidence', `${slug}.png`);
+  const consoleLogPath = path.join(outputDir, 'logs', `console-${slug}.log`);
   const sharedConsoleLogPath = path.join(outputDir, 'logs', `console-${recordType}.log`);
-  const networkLogPath = path.join(outputDir, 'logs', `network-${recordType}-${viewportName}.log`);
+  const networkLogPath = path.join(outputDir, 'logs', `network-${slug}.log`);
   const sharedNetworkLogPath = path.join(outputDir, 'logs', `network-${recordType}.log`);
-  const axeLogPath = path.join(outputDir, 'logs', `axe-${recordType}-${viewportName}.log`);
-  const notesLogPath = path.join(outputDir, 'logs', `notes-${recordType}-${viewportName}.log`);
+  const axeLogPath = path.join(outputDir, 'logs', `axe-${slug}.log`);
+  const notesLogPath = path.join(outputDir, 'logs', `notes-${slug}.log`);
 
   const recordFailure = (message: string) => failures.push(message);
   const recordNote = (message: string) => notes.push(message);
@@ -376,7 +381,7 @@ async function runAudit(
     writeLines(networkLogPath, networkLines);
     writeLines(notesLogPath, notes);
 
-    const sectionHeader = [`# ${recordType} ${viewportName}`];
+    const sectionHeader = [`# ${recordType} ${viewportName} (${colorScheme})`];
     appendLines(sharedConsoleLogPath, [...sectionHeader, ...consoleLines, '']);
     appendLines(sharedNetworkLogPath, [...sectionHeader, ...networkLines, '']);
   }
@@ -385,29 +390,41 @@ async function runAudit(
 }
 
 test.describe('Record Detail UX Audit', () => {
-  test.describe('desktop', () => {
-    test.use({ viewport: { width: 1280, height: 800 } });
+  // fix(#1778): every axe scan in runAudit() runs in both color schemes,
+  // mirroring #1782's fix for e2e/accessibility.spec.ts. playwright.config.ts
+  // sets no colorScheme, so Playwright defaults to light and the
+  // ThemeProvider's "system" default (main.tsx) resolves off that media
+  // query -- the dark palette was structurally unreachable to this suite's
+  // axe scans.
+  for (const colorScheme of ['light', 'dark'] as const) {
+    test.describe(`(${colorScheme} mode)`, () => {
+      test.use({ colorScheme });
 
-    (Object.entries(manifest.targets) as Array<[RecordType, AuditTarget | null]>).forEach(
-      ([recordType, target]) => {
-        test(`${recordType} desktop audit`, async ({ page }) => {
-          test.skip(!target, `Missing QA target for ${recordType}`);
-          await runAudit(page, recordType, 'desktop', target!);
-        });
-      },
-    );
-  });
+      test.describe('desktop', () => {
+        test.use({ viewport: { width: 1280, height: 800 } });
 
-  test.describe('mobile', () => {
-    test.use({ viewport: { width: 375, height: 812 } });
+        (Object.entries(manifest.targets) as Array<[RecordType, AuditTarget | null]>).forEach(
+          ([recordType, target]) => {
+            test(`${recordType} desktop audit`, async ({ page }) => {
+              test.skip(!target, `Missing QA target for ${recordType}`);
+              await runAudit(page, recordType, 'desktop', target!, colorScheme);
+            });
+          },
+        );
+      });
 
-    (Object.entries(manifest.targets) as Array<[RecordType, AuditTarget | null]>).forEach(
-      ([recordType, target]) => {
-        test(`${recordType} mobile audit`, async ({ page }) => {
-          test.skip(!target, `Missing QA target for ${recordType}`);
-          await runAudit(page, recordType, 'mobile', target!);
-        });
-      },
-    );
-  });
+      test.describe('mobile', () => {
+        test.use({ viewport: { width: 375, height: 812 } });
+
+        (Object.entries(manifest.targets) as Array<[RecordType, AuditTarget | null]>).forEach(
+          ([recordType, target]) => {
+            test(`${recordType} mobile audit`, async ({ page }) => {
+              test.skip(!target, `Missing QA target for ${recordType}`);
+              await runAudit(page, recordType, 'mobile', target!, colorScheme);
+            });
+          },
+        );
+      });
+    });
+  }
 });

--- a/frontend/src/api/__tests__/settings-branding.test.ts
+++ b/frontend/src/api/__tests__/settings-branding.test.ts
@@ -1,0 +1,53 @@
+/**
+ * fix(#1778): updateBranding accepts Partial<BrandingConfig> -- so
+ * `updateBranding({ privacy_url: '...' })` typechecks -- but only ever
+ * forwarded `show_badge` into the PUT payload, silently dropping
+ * privacy_url (and any future BrandingConfig field). A privacy_url-only
+ * call issued `PUT /settings/` with an empty settings object and still
+ * resolved as a success.
+ *
+ * These pin the request body updateBranding builds for privacy_url alone
+ * and for both fields together, so a future field added to BrandingConfig
+ * that is not also forwarded here fails this test instead of shipping
+ * silently broken. settings.contract.test.ts already covers the
+ * show_badge-only and empty-payload cases (including the dotted
+ * `branding.show_badge` registry key), so this file does not repeat those.
+ */
+import { apiFetch } from '@/api/client';
+import { updateBranding } from '@/api/settings';
+
+vi.mock('@/api/client', () => ({
+  apiFetch: vi.fn(() => Promise.resolve({ env_only: false, tabs: {} })),
+}));
+
+const mockApiFetch = vi.mocked(apiFetch);
+
+function calledBody() {
+  const init = mockApiFetch.mock.calls[0]?.[1];
+  return JSON.parse((init?.body as string) ?? '{}');
+}
+
+describe('updateBranding forwards privacy_url', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('forwards a privacy_url-only update instead of silently dropping it', async () => {
+    await updateBranding({ privacy_url: 'https://example.com/privacy' });
+
+    expect(mockApiFetch).toHaveBeenCalledWith('/settings/', expect.objectContaining({ method: 'PUT' }));
+    expect(calledBody()).toEqual({ settings: { privacy_url: 'https://example.com/privacy' } });
+  });
+
+  it('forwards both fields together when both are given', async () => {
+    await updateBranding({ show_badge: false, privacy_url: 'https://example.com/privacy' });
+
+    expect(calledBody()).toEqual({
+      settings: { 'branding.show_badge': false, privacy_url: 'https://example.com/privacy' },
+    });
+  });
+
+  it('forwards an explicit null privacy_url (clearing the value)', async () => {
+    await updateBranding({ privacy_url: null });
+
+    expect(calledBody()).toEqual({ settings: { privacy_url: null } });
+  });
+});

--- a/frontend/src/api/settings.ts
+++ b/frontend/src/api/settings.ts
@@ -183,6 +183,11 @@ export async function updateBranding(data: Partial<BrandingConfig>): Promise<voi
   // The registry key is dotted (`branding.show_badge` in persistent_config.py),
   // not `branding_show_badge` -- the underscore spelling 400s on every save.
   if (data.show_badge !== undefined) settings['branding.show_badge'] = data.show_badge;
+  // fix(#1778): updateBranding took Partial<BrandingConfig>, which typechecks
+  // for privacy_url, but only ever forwarded show_badge, silently dropping
+  // privacy_url -- a privacy_url-only call PUT an empty settings object and
+  // still reported success.
+  if (data.privacy_url !== undefined) settings.privacy_url = data.privacy_url;
   await updateSettings(settings);
 }
 

--- a/frontend/src/components/import/UploadForm.tsx
+++ b/frontend/src/components/import/UploadForm.tsx
@@ -389,6 +389,12 @@ export function UploadForm({ onPhaseChange }: UploadFormProps) {
   ) => {
     const entry = entries.find((e) => e.id === entryId);
     if (!entry?.jobId) return;
+    // fix(#1778): same in-flight guard as handleSheetChange below. The
+    // commit button disables once this entry's status flips to
+    // 'committing', but that re-render is not guaranteed to land between
+    // two rapid clicks on the same button. Without this, a double click
+    // issued commitImport twice for one job.
+    if (entry.status === 'committing' || entry.status === 'tracking') return;
 
     updateEntry(entryId, { status: 'committing' });
     // fix(#1712): a commit is being issued for this entry — the batch

--- a/frontend/src/components/import/__tests__/UploadForm.doubleCommitGuard.test.tsx
+++ b/frontend/src/components/import/__tests__/UploadForm.doubleCommitGuard.test.tsx
@@ -1,0 +1,168 @@
+/**
+ * fix(#1778): handleCommitSingle had no in-flight guard, distinct from the
+ * layer-picker bulk guard (BulkReviewList.midCommitGuard.test.tsx /
+ * UploadForm.midCommitGuard.test.tsx) and from the in-flight upload session
+ * (#1763). The commit button only disables once the entry's status has
+ * actually re-rendered as 'committing' (isCommitting flows down through
+ * BulkReviewList -> ImportMetadataForm's submit button); a click that lands
+ * before that re-render commits reached the handler with no guard at all,
+ * so a double click issued commitImport twice for one job.
+ *
+ * This test pins the handler half: a second click on the same entry's
+ * commit button, once the first click's 'committing' status has landed,
+ * must not call commitImport again.
+ */
+import { render, screen, act } from '@/test/test-utils';
+import { UploadForm } from '../UploadForm';
+import type { FileEntry } from '@/types/api';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: (_ns?: string) => ({
+    t: (key: string, opts?: Record<string, unknown>) => {
+      if (typeof opts?.defaultValue === 'string') return opts.defaultValue;
+      return key;
+    },
+    i18n: { language: 'en' },
+  }),
+  Trans: ({ i18nKey }: { i18nKey: string }) => i18nKey,
+}));
+
+vi.mock('@/api/ingest', () => ({
+  uploadFile: vi.fn(),
+  uploadPresigned: vi.fn(),
+  previewFile: vi.fn(),
+  commitImport: vi.fn(),
+}));
+
+vi.mock('@/api/datasets', () => ({
+  commitFanOut: vi.fn(),
+}));
+
+vi.mock('@/components/import/hooks/use-ingest', () => ({
+  useUploadConfig: () => ({ data: null }),
+}));
+
+vi.mock('../FileDropzone', () => ({
+  FileDropzone: ({ onFilesAccepted }: { onFilesAccepted: (files: File[]) => void }) => (
+    <div data-testid="file-dropzone">
+      <button
+        data-testid="simulate-drop"
+        onClick={() =>
+          onFilesAccepted([new File(['{}'], 'test.geojson', { type: 'application/geo+json' })])
+        }
+      >
+        Drop
+      </button>
+    </div>
+  ),
+}));
+
+vi.mock('../BulkUploadProgress', () => ({
+  BulkUploadProgress: () => <div data-testid="bulk-upload-progress" />,
+}));
+
+vi.mock('../BulkReviewList', () => ({
+  BulkReviewList: ({
+    onCommitSingle,
+    onCommitAll,
+    onRemove,
+    entries,
+  }: {
+    onCommitSingle: (id: string, req: object) => void;
+    onCommitAll: () => void;
+    onRemove: (id: string) => void;
+    entries: FileEntry[];
+  }) => (
+    <div data-testid="bulk-review-list">
+      {entries.map((e) => (
+        <div key={e.id} data-testid={`entry-${e.id}`} data-status={e.status}>
+          <button data-testid={`commit-${e.id}`} onClick={() => onCommitSingle(e.id, { title: e.fileName })}>
+            Commit
+          </button>
+          <button data-testid={`remove-${e.id}`} onClick={() => onRemove(e.id)}>
+            Remove
+          </button>
+        </div>
+      ))}
+      <button data-testid="commit-all" onClick={onCommitAll}>
+        Commit All
+      </button>
+    </div>
+  ),
+}));
+
+vi.mock('../BulkTrackingList', () => ({
+  BulkTrackingList: () => <div data-testid="bulk-tracking-list" />,
+}));
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), warning: vi.fn(), error: vi.fn() },
+}));
+
+import { commitImport, previewFile, uploadFile } from '@/api/ingest';
+
+const mockUploadFile = vi.mocked(uploadFile);
+const mockPreviewFile = vi.mocked(previewFile);
+const mockCommitImport = vi.mocked(commitImport);
+
+function makeSingleLayerPreview() {
+  return {
+    job_id: 'job-1',
+    source_filename: 'test.geojson',
+    columns: [],
+    row_count: 0,
+    geometry_type: 'Point',
+    crs: null,
+    latlon_candidates: null,
+    layer_name: null,
+    layers: null,
+    sample_rows: [],
+    feature_count: 3,
+    detected_geometry_columns: null,
+  };
+}
+
+describe('UploadForm: handleCommitSingle in-flight guard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('two rapid clicks on the commit button issue exactly one commitImport call', async () => {
+    mockUploadFile.mockResolvedValue({ job_id: 'job-1' } as never);
+    mockPreviewFile.mockResolvedValue(makeSingleLayerPreview() as never);
+    // Commit never resolves in this test, so the entry stays 'committing'
+    // for the duration -- exactly the window a double click races.
+    mockCommitImport.mockReturnValue(new Promise(() => {}));
+
+    render(<UploadForm />);
+
+    await act(async () => {
+      screen.getByTestId('simulate-drop').click();
+    });
+
+    const entryEl = await screen.findByTestId(/^entry-/);
+    const entryId = entryEl.getAttribute('data-testid')!.replace('entry-', '');
+
+    // Two rapid clicks. Each is its own act() so the intervening re-render
+    // (status -> 'committing') lands between them, the way two separate
+    // browser click events -- and two separate calls into the SAME
+    // `handleCommitSingle` closure -- would in real double-click timing.
+    await act(async () => {
+      screen.getByTestId(`commit-${entryId}`).click();
+    });
+    await act(async () => {
+      screen.getByTestId(`commit-${entryId}`).click();
+    });
+
+    expect(mockCommitImport).toHaveBeenCalledTimes(1);
+    expect(screen.getByTestId(`entry-${entryId}`)).toHaveAttribute('data-status', 'committing');
+
+    // A third click after the status has settled to 'committing' must also
+    // be a no-op -- this is the guard's steady-state behavior, not just the
+    // same-tick race.
+    await act(async () => {
+      screen.getByTestId(`commit-${entryId}`).click();
+    });
+    expect(mockCommitImport).toHaveBeenCalledTimes(1);
+  });
+});

--- a/playwright.builder-hardening.config.ts
+++ b/playwright.builder-hardening.config.ts
@@ -46,6 +46,28 @@ export default defineConfig({
       },
       dependencies: ['setup'],
     },
+    // fix(#1778): this config set no colorScheme, so the whole suite ran
+    // light-mode only (the same gap #1782 closed for playwright.config.ts).
+    // One dark chromium project closes it here too, without tripling
+    // wall-clock by adding a dark pass to firefox-hardening and
+    // webkit-hardening as well -- those exist for cross-browser rendering
+    // parity, not theme parity.
+    {
+      name: 'chromium-hardening-dark',
+      use: {
+        ...devices['Desktop Chrome'],
+        colorScheme: 'dark',
+        launchOptions: {
+          args: [
+            '--enable-unsafe-swiftshader',
+            '--use-gl=swiftshader',
+            '--enable-webgl',
+            '--ignore-gpu-blocklist',
+          ],
+        },
+      },
+      dependencies: ['setup'],
+    },
     {
       name: 'firefox-hardening',
       use: {


### PR DESCRIPTION
Fixes four frontend tail items from the codebase audit 2026-08-30 (8dc529f17), tracked in #1778.

## Changes

"handleCommitSingle has no in-flight guard, so a double click commits twice." The commit button only disables once the entry's status has re-rendered as 'committing', so a click landing before that render reached the handler with no guard at all. Added the same guard shape used for the layer-picker bulk guard (`entry.status === 'committing' || entry.status === 'tracking'`) and a vitest pinning it. This is distinct from that layer-picker guard and from the in-flight upload session added earlier.

"updateBranding declares privacy_url in its request type and silently drops it." `updateBranding` accepts `Partial<BrandingConfig>`, so a `privacy_url`-only call typechecks, but the function only ever forwarded `show_badge`. A `privacy_url`-only call issued `PUT /settings/` with an empty settings object and still reported success. Now forwards every field `BrandingConfig` declares. Added a vitest pinning the request body for `privacy_url` alone and for both fields together. The separate, more severe finding in the same register entry, that `show_badge` itself was sent under the wrong key (`branding_show_badge` instead of the registry's `branding.show_badge`), landed in #1776 while this branch was in flight; this branch is rebased onto that fix and the new test asserts the dotted key.

"wcagTags omits wcag22aa, the 22px builder row controls would fail it." Did not add `wcag22aa` to the gating suite's tags, since it would fail immediately on the builder's 22px row controls. Instead added `e2e/accessibility-target-size.spec.ts`, a separate, non-gating scan of the map builder route with `wcag22aa` that only reports violations (console output plus a test attachment) and never fails. It is not listed in any `package.json` `e2e:smoke:*` script, so the per-PR smoke gates never pick it up (same precedent as `analysis.spec.ts`). A run against the current build found one violation to scope later: the basemap drag handle button fails axe's `target-size` rule.

"playwright.builder-hardening.config.ts and e2e/record-detail-ux-audit.spec.ts are light-mode only." Both configs set no `colorScheme`, so the dark palette was structurally unreachable to them, the same gap already closed for `accessibility.spec.ts` and `playwright.config.ts`. `record-detail-ux-audit.spec.ts`'s tests now loop over both color schemes, the same shape used for `accessibility.spec.ts`. `colorScheme` is folded into the per-run evidence file names (screenshots, console/network/axe/notes logs) so a dark pass no longer overwrites the light-mode files for the same record type and viewport. For `playwright.builder-hardening.config.ts`, added one `chromium-hardening-dark` project rather than doubling every browser project: `firefox-hardening` and `webkit-hardening` exist for cross-browser rendering parity, not theme parity, so tripling wall-clock there would buy nothing. `ci.yml`'s builder-hardening step now selects both `chromium-hardening` and `chromium-hardening-dark` in one invocation (still chromium only, no extra browser install), so this step's wall-clock roughly doubles rather than the whole hardening suite tripling.

A codex review on this PR found two gaps in the new dark project, both fixed in a follow-up commit: `builder-hardening.spec.ts`'s public-share test opens its own unauthenticated context with `browser.newContext(...)`, which does not inherit the project's `use.colorScheme` (that option only applies to the default context/page fixtures a test gets automatically), so the dark project was running that one flow in light mode regardless; and the CI step only ever passed `--project=chromium-hardening`, so `chromium-hardening-dark` was defined but never actually selected in CI. Fixed both: the manual context now reads `testInfo.project.use.colorScheme` and passes it through, with a `matchMedia('(prefers-color-scheme: dark)').matches` assertion pinning that it resolves correctly per project; and the CI step now selects both projects.

## Schema / API / config impact

None. Frontend-only, no schema, API contract, or backend config changes.

## Left alone

The wider settings-key-drift finding in the same register excerpt as the branding key mismatch (fixed by #1776, this branch is rebased onto it) is out of this lane's scope.

A pre-existing failure surfaced while verifying the dark-mode loop: the mobile vector-dataset audit in `record-detail-ux-audit.spec.ts` already fails a header-overlap check ("mobile H1 and action area overlap horizontally") in both light and dark mode identically. It reproduces the same way with or without this PR's colorScheme loop, so it is not a regression from this change. Flagging it here because this is apparently the first time anyone has actually run this spec against a real target: it requires a hand-built `e2e/fixtures/qa-targets.json` that does not ship in the repo.

## Verification

`cd frontend && npm run typecheck`: passed.
`cd frontend && npm run lint`: passed.
`cd frontend && npm run build`: passed.
`cd frontend && npx vitest run src/components/import/ src/api/__tests__/ src/hooks/__tests__/use-settings.test.ts src/components/admin/settings/`: 46 files, 392 tests passed.
`cd frontend && npm run test:i18n`: passed (no copy changed).

E2E via the `:5174` worktree recipe against main's API (`API_PROXY_TARGET=http://localhost:8001`, `E2E_ALLOW_WORKTREE=1 E2E_BASE_URL=http://localhost:5174`):

`npx playwright test e2e/accessibility-target-size.spec.ts --project=chromium`: 3 passed. Reports the one target-size violation noted above and does not fail on it.
`npx playwright test e2e/upload.spec.ts --project=chromium`: 4 passed. The single-commit path is unaffected by the new guard.
`npx playwright test -c playwright.builder-hardening.config.ts --project=chromium-hardening`: 8 passed.
`npx playwright test -c playwright.builder-hardening.config.ts --project=chromium-hardening-dark`: 8 passed on the new project.
`npx playwright test e2e/record-detail-ux-audit.spec.ts --project=chromium` against a hand-built one-target fixture: 4 passed, 2 failed (the pre-existing, colorScheme-independent header-overlap issue noted above), 12 skipped (no fixture for the other record types). Confirms the light/dark loop runs symmetrically and writes separate evidence files per scheme.

This branch was rebased onto main after #1776 merged (it also touches `frontend/src/api/settings.ts`), resolving the conflict by keeping #1776's dotted `branding.show_badge` key and adding the `privacy_url` forwarding on top of it. After the rebase, also ran the backend drift test that reads this file statically: `cd backend && uv run pytest tests/test_settings_key_drift.py tests/test_layering.py -q`, 49 passed.

After the codex-round-1 fixes above, re-ran `npx playwright test -c playwright.builder-hardening.config.ts --project=chromium-hardening --project=chromium-hardening-dark --reporter=line` via the same :5174 recipe: 14 passed (both projects, all 6 spec tests each plus setup/cleanup), confirming the matchMedia assertion resolves true under chromium-hardening-dark and false under chromium-hardening.
