### PR TITLE
fix(#1778): tail-2 audit fixes (raster cache key, GeoParquet deadline, flake sweep)

### DIFF
--- a/backend/app/processing/export/parquet.py
+++ b/backend/app/processing/export/parquet.py
@@ -11,6 +11,7 @@ The router rejects a non-4326 ``target_crs`` for parquet, so no reprojection or
 embedded PROJJSON is needed here.
 """
 
+import asyncio
 import json
 import os
 import shutil
@@ -25,7 +26,11 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.async_io import run_in_thread_draining
 from app.core.config import settings
 from app.core.runtime.staging import ensure_staging_ready
-from app.processing.export.ogr import bbox_where_sql
+from app.processing.export.ogr import (
+    ExportError,
+    bbox_where_sql,
+    export_subprocess_timeout_seconds,
+)
 from app.processing.export.service import export_descriptor, validate_where_clause
 from app.processing.export.where_validator import canonical_where
 from app.processing.ingest.metadata import _qtable, get_column_info
@@ -238,6 +243,32 @@ async def plan_parquet_export(
     return ParquetExportPlan(attr_names, where_sql, params)
 
 
+async def _stream_rows(
+    db: AsyncSession,
+    sql: str,
+    params: dict,
+    attr_names: list[str],
+    geom_idx: int,
+) -> tuple[list[bytes | None], dict[str, list]]:
+    """Read every row of the planned selection into columnar Python lists.
+
+    Split out of ``export_parquet`` so ``asyncio.wait_for`` there bounds
+    exactly this — the row source — rather than the query construction and
+    file setup around it.
+    """
+    geom: list[bytes | None] = []
+    cols: dict[str, list] = {name: [] for name in attr_names}
+
+    result = await db.stream(text(sql).bindparams(**params))
+    async for row in result:
+        for i, name in enumerate(attr_names):
+            cols[name].append(row[i])
+        wkb = row[geom_idx]
+        geom.append(bytes(wkb) if wkb is not None else None)
+
+    return geom, cols
+
+
 async def export_parquet(
     db: AsyncSession,
     table_name: str,
@@ -245,6 +276,7 @@ async def export_parquet(
     *,
     schema: str,
     plan: ParquetExportPlan,
+    deadline: float | None = None,
 ) -> tuple[str, str, str]:
     """Write the planned selection to a GeoParquet file.
 
@@ -259,6 +291,19 @@ async def export_parquet(
     Builds the whole selection in memory before writing one Parquet file.
     Bounded by the plan's count check; switch to a fixed-schema batched
     ParquetWriter if that ceiling ever needs raising.
+
+    deadline: ``time.monotonic()`` stamp by which the whole request must be
+        answered, from the route's entry. The ogr2ogr formats bound their
+        subprocess wall clock and libpq ``statement_timeout`` by what is left
+        of this (fix(#1778), ``export_subprocess_timeout_seconds``); this
+        format has no subprocess, but an unindexed table or a wide selection
+        can stream rows past the same edge-proxy window with nothing to stop
+        it. Reuses that helper rather than deriving a second bound, and raises
+        the same ``ExportError`` the ogr2ogr timeout raises, so the router's
+        ``except ExportError`` handling — one 500, not a response nginx has
+        already severed — is identical for every format. ``None`` for a
+        caller outside a request, which is the same arithmetic with an
+        elapsed time of zero.
     """
     attr_names, where_sql, params = plan
 
@@ -274,17 +319,19 @@ async def export_parquet(
         f"SELECT {', '.join(select_parts)} "
         f"FROM {_qtable(table_name, schema=schema)} t WHERE {where_sql}"
     )
-
-    geom: list[bytes | None] = []
-    cols: dict[str, list] = {name: [] for name in attr_names}
     geom_idx = len(attr_names)
 
-    result = await db.stream(text(sql).bindparams(**params))
-    async for row in result:
-        for i, name in enumerate(attr_names):
-            cols[name].append(row[i])
-        wkb = row[geom_idx]
-        geom.append(bytes(wkb) if wkb is not None else None)
+    row_stream_timeout = export_subprocess_timeout_seconds(deadline)
+    try:
+        geom, cols = await asyncio.wait_for(
+            _stream_rows(db, sql, params, attr_names, geom_idx),
+            timeout=row_stream_timeout,
+        )
+    except asyncio.TimeoutError:
+        raise ExportError(
+            f"GeoParquet export timed out after {int(row_stream_timeout)}s "
+            "— the row source is too slow"
+        )
 
     exports_root = ensure_staging_ready(
         os.path.join(settings.upload_staging_dir, "exports")

--- a/backend/app/processing/export/router.py
+++ b/backend/app/processing/export/router.py
@@ -836,6 +836,9 @@ async def export_dataset_endpoint(
                 dataset_title,
                 schema=data_schema,
                 plan=parquet_plan,
+                # fix(#1778): bound the row stream by the edge window the same
+                # way the ogr2ogr formats below are bounded.
+                deadline=request_deadline,
             )
         else:
             pmtiles_maxzoom = None

--- a/backend/app/processing/ingest/tasks_common.py
+++ b/backend/app/processing/ingest/tasks_common.py
@@ -467,6 +467,7 @@ async def _job_phase_session(
     *,
     phase: str,
     attempt_id: uuid.UUID | None = None,
+    lock_and_statement_timeout_ms: int | None = None,
 ) -> "AsyncGenerator[tuple[AsyncSession, IngestJob | None], None]":
     """Two-phase session bracket for ingest workers (REMED-03 / P2-05).
 
@@ -496,12 +497,32 @@ async def _job_phase_session(
     The ``phase`` keyword (``"phase1"``, ``"phase2"``, ``"progress_write"``,
     etc.) is included in the missing-row warning so operators can tell
     which bracket lost the row.
+
+    ``lock_and_statement_timeout_ms``, when given, issues ``SET LOCAL
+    lock_timeout`` and ``SET LOCAL statement_timeout`` on this transaction
+    BEFORE the SELECT below — fix(#1778 codex r6): a caller that set those
+    timeouts itself, after entering this context manager, left the SELECT
+    unprotected, and a SELECT can itself stall behind a lock the row's own
+    later UPDATE would never even see (e.g. another session holding an
+    ACCESS EXCLUSIVE lock on the table). ``None`` (the default) leaves the
+    session on Postgres's server-wide default, unchanged for every other
+    caller of this shared helper.
     """
     from app.core.db import async_session
     from app.platform.jobs.models import IngestJob
-    from sqlalchemy import select
+    from sqlalchemy import select, text
 
     async with async_session() as session:
+        if lock_and_statement_timeout_ms is not None:
+            # `SET LOCAL` takes a literal, not a bind parameter (Postgres
+            # rejects `SET x = $1`); this interpolates an integer the caller
+            # computed from a module constant, never request-supplied data.
+            await session.execute(
+                text(f"SET LOCAL lock_timeout = {lock_and_statement_timeout_ms}")
+            )
+            await session.execute(
+                text(f"SET LOCAL statement_timeout = {lock_and_statement_timeout_ms}")
+            )
         filters = [IngestJob.id == job_uuid]
         if attempt_id is not None:
             filters.append(IngestJob.attempt_id == attempt_id)

--- a/backend/app/processing/ingest/tasks_vector.py
+++ b/backend/app/processing/ingest/tasks_vector.py
@@ -50,15 +50,22 @@ _SERVICE_IMPORT_INITIAL_PROGRESS = 0.1
 _SERVICE_IMPORT_HEARTBEAT_INTERVAL_SECONDS = 5.0
 _SERVICE_IMPORT_HEARTBEAT_INCREMENT = 0.05
 _SERVICE_IMPORT_HEARTBEAT_MAX_PROGRESS = 0.65
-# fix(#1778 codex r2): the longest a cancelled heartbeat tick's drain (see
-# _heartbeat_service_import_progress) may hold up the caller. The ordinary
-# session it runs on carries no statement or lock timeout of its own, so a
-# tick blocked on something else entirely -- another transaction's row lock
-# inside session.commit() -- could otherwise hang the drain, and with it
-# ingest_service's finally, indefinitely. A few seconds, not a fraction of
-# one: this is a last-resort bound for an already-rare case (a cancel racing
-# a tick), not a budget anything is sized against.
-_SERVICE_IMPORT_HEARTBEAT_DRAIN_TIMEOUT_SECONDS = 5.0
+# fix(#1778 codex r3): the PRIMARY bound on one heartbeat tick's own database
+# wait. Set as `SET LOCAL lock_timeout` / `SET LOCAL statement_timeout` on the
+# tick's own transaction (see _service_import_heartbeat_tick), so a commit
+# blocked on another transaction's row lock fails on its own, INSIDE the
+# database, and releases the connection -- rather than depending on the
+# caller merely giving up on WAITING for it, which left the connection itself
+# still checked out and blocked, exhausting the worker's pool under repeated
+# stalled imports even though their parent tasks continued.
+_SERVICE_IMPORT_HEARTBEAT_TICK_DB_TIMEOUT_SECONDS = 3.0
+# fix(#1778 codex r2, revised r3): a SAFETY NET above the DB timeout above,
+# not the primary mechanism -- see _heartbeat_service_import_progress. Covers
+# only what a DB-side timeout cannot: a connection stuck before it ever
+# reaches Postgres (e.g. a network partition), where `SET LOCAL` never runs.
+# Comfortably above the DB timeout's own worst case (lock_timeout wait, then
+# statement_timeout once granted) so it should not fire in the common case.
+_SERVICE_IMPORT_HEARTBEAT_DRAIN_TIMEOUT_SECONDS = 10.0
 _ARCGIS_SERVICE_IMPORT_CHUNK_SIZE = 2000
 
 
@@ -120,6 +127,15 @@ async def _service_import_heartbeat_tick(
     left the step this heartbeat belongs to), ``True`` otherwise. Split out of
     ``_heartbeat_service_import_progress`` so that function can ``shield`` the
     whole tick from cancellation (fix(#1778)) — see that function's docstring.
+
+    fix(#1778 codex r3): sets ``lock_timeout``/``statement_timeout`` on this
+    transaction before touching the job row, so a commit blocked on another
+    transaction's row lock raises INSIDE Postgres within a few seconds
+    instead of waiting on whatever holds the lock. ``_job_phase_session``'s
+    own exception handling rolls back and re-raises on that error, which
+    releases this tick's connection back to the pool the ordinary way --
+    the caller no longer has to choose between waiting on a stuck connection
+    forever and abandoning one it can never reclaim.
     """
     async with _job_phase_session(
         job_uuid,
@@ -130,6 +146,13 @@ async def _service_import_heartbeat_tick(
             return False
         if job.status != "running" or job.current_step != "ogr2ogr":
             return False
+
+        # fix(#1778 codex r3): milliseconds, integer -- `SET LOCAL` takes a
+        # literal, not a bind parameter (Postgres rejects `SET x = $1`), so
+        # this interpolates a module constant, never request-supplied data.
+        _timeout_ms = int(_SERVICE_IMPORT_HEARTBEAT_TICK_DB_TIMEOUT_SECONDS * 1000)
+        await session.execute(text(f"SET LOCAL lock_timeout = {_timeout_ms}"))
+        await session.execute(text(f"SET LOCAL statement_timeout = {_timeout_ms}"))
 
         existing_progress = (
             job.progress
@@ -168,19 +191,26 @@ async def _heartbeat_service_import_progress(
     same trade a clean subprocess kill/reap already makes elsewhere in this
     package.
 
-    fix(#1778 codex r2): the drain that lets a shielded tick finish is itself
-    bounded by ``_SERVICE_IMPORT_HEARTBEAT_DRAIN_TIMEOUT_SECONDS``. The shield
-    bounds WHERE a cancel can land, not HOW LONG draining one can take -- an
-    ordinary session carries no statement or lock timeout of its own, so a
-    tick blocked on something else entirely (another transaction's row lock
-    inside ``session.commit()``) could hang this drain, and with it
-    ``ingest_service``'s own ``finally``, indefinitely. On timeout this
-    function gives up WAITING and returns; ``asyncio.shield`` keeps the tick
-    itself running in the background rather than cancelling it, so its
-    connection still gets to close cleanly on its own schedule. The
-    heartbeat's write is best-effort progress UI sugar the import's own
-    result never reads back, so abandoning one late tick costs nothing the
-    caller depends on.
+    fix(#1778 codex r2, revised r3): the drain that lets a shielded tick
+    finish is bounded by ``_SERVICE_IMPORT_HEARTBEAT_DRAIN_TIMEOUT_SECONDS``,
+    a SAFETY NET, not the primary mechanism. The shield bounds WHERE a cancel
+    can land, not HOW LONG draining one can take, and round 2 covered that
+    gap by giving up on WAITING here -- which left the tick's connection
+    itself still checked out and blocked if it was stuck on a row lock,
+    exhausting the pool under repeated stalls even though this function
+    itself moved on. Round 3 bounds the tick's OWN database wait instead
+    (``_service_import_heartbeat_tick`` sets ``lock_timeout``/
+    ``statement_timeout`` on its transaction), so in the common case the
+    tick resolves -- successfully or by raising -- well inside this drain
+    window on its own, connection released either way. What survives here is
+    a last-resort bound for what a DB-side timeout cannot cover: a
+    connection stuck before it ever reaches Postgres. ``asyncio.shield``
+    still keeps the tick itself running in the background rather than
+    cancelling it on that rarer timeout, so a connection that DOES eventually
+    hear back from Postgres still gets to close cleanly. The heartbeat's
+    write is best-effort progress UI sugar the import's own result never
+    reads back, so abandoning one late tick, on the rare path where even the
+    DB timeout does not save it, costs nothing the caller depends on.
     """
     while True:
         await asyncio.sleep(_SERVICE_IMPORT_HEARTBEAT_INTERVAL_SECONDS)
@@ -205,6 +235,12 @@ async def _heartbeat_service_import_progress(
                             timeout=_SERVICE_IMPORT_HEARTBEAT_DRAIN_TIMEOUT_SECONDS,
                         )
                     except asyncio.TimeoutError:
+                        # Expected to be rare after fix(#1778 codex r3): the
+                        # tick's own DB-level timeout should have already
+                        # resolved it well within this window. Reaching this
+                        # means something OUTSIDE the database's own timeout
+                        # handling is stuck (e.g. the connection never reached
+                        # Postgres at all).
                         structlog.get_logger().warning(
                             "service_import_heartbeat_drain_timed_out",
                             job_id=str(job_uuid),

--- a/backend/app/processing/ingest/tasks_vector.py
+++ b/backend/app/processing/ingest/tasks_vector.py
@@ -7,7 +7,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 import structlog
-from sqlalchemy import text
+from sqlalchemy import or_, text, update
 
 from app.core.db.tenant_session import tenant_task
 from app.core.url_redaction import scrub_secret_from_exception
@@ -144,7 +144,37 @@ async def _service_import_heartbeat_tick(
     initial SELECT unprotected, and a SELECT can itself stall behind a lock
     the later UPDATE would never even see (e.g. another session's ACCESS
     EXCLUSIVE on the table).
+
+    fix(#1778 codex r11): the SELECT above (run inside ``_job_phase_session``)
+    is a snapshot, not a lock. If THIS tick's own connection then stalls --
+    for whatever reason the DB timeout above does not itself close, e.g. a
+    connection stuck before it ever reaches Postgres -- long enough for the
+    caller's cancellation drain (the safety net two paragraphs up) to expire,
+    the caller moves on while this ``asyncio.shield``ed tick is still alive
+    in the background. ``_finalize_ingest`` can commit
+    ``status="complete"``/``progress=1.0`` in the meantime, or a retry can
+    rotate ``attempt_id`` -- and an unconditional ORM commit here would then
+    overwrite that finalized row BY PRIMARY KEY with this tick's stale
+    progress (never above ``_SERVICE_IMPORT_HEARTBEAT_MAX_PROGRESS``),
+    resurrecting a "still running" progress bar on a job that already
+    finished, or writing into a job attempt this worker no longer owns.
+
+    The write below re-checks every fact the SELECT read, atomically, in the
+    UPDATE's own WHERE clause, rather than trusting that earlier read: the
+    same attempt must still own the row, it must still be "running" on
+    "ogr2ogr", and the row's CURRENT progress -- not the value this tick
+    read minutes ago -- must still be below what it is about to write.
+    Matches the attempt-fenced UPDATE shape ``_finalize_ingest`` already uses
+    via ``require_ingest_job_update``/``update_ingest_job_for_attempt``, just
+    inlined here because this call site also needs the extra
+    ``current_step``/``progress`` guards those helpers do not take. Zero rows
+    affected means the job moved on since the SELECT: log and do nothing --
+    the same "abandon this write, it costs nothing the caller depends on"
+    posture the rest of this tick's timeout handling already takes for a
+    write that never lands.
     """
+    from app.platform.jobs.models import IngestJob
+
     _timeout_ms = int(_SERVICE_IMPORT_HEARTBEAT_TICK_DB_TIMEOUT_SECONDS * 1000)
     async with _job_phase_session(
         job_uuid,
@@ -169,8 +199,27 @@ async def _service_import_heartbeat_tick(
         if next_progress <= existing_progress:
             return True
 
-        job.progress = next_progress
+        result = await session.execute(
+            update(IngestJob)
+            .where(
+                IngestJob.id == job_uuid,
+                IngestJob.attempt_id == attempt_id,
+                IngestJob.status == "running",
+                IngestJob.current_step == "ogr2ogr",
+                or_(
+                    IngestJob.progress.is_(None),
+                    IngestJob.progress < next_progress,
+                ),
+            )
+            .values(progress=next_progress)
+        )
         await session.commit()
+        if not result.rowcount:  # type: ignore[attr-defined]
+            structlog.get_logger().debug(
+                "service_import_heartbeat_tick_stale",
+                job_id=str(job_uuid),
+                attempt_id=str(attempt_id),
+            )
         return True
 
 

--- a/backend/app/processing/ingest/tasks_vector.py
+++ b/backend/app/processing/ingest/tasks_vector.py
@@ -50,6 +50,15 @@ _SERVICE_IMPORT_INITIAL_PROGRESS = 0.1
 _SERVICE_IMPORT_HEARTBEAT_INTERVAL_SECONDS = 5.0
 _SERVICE_IMPORT_HEARTBEAT_INCREMENT = 0.05
 _SERVICE_IMPORT_HEARTBEAT_MAX_PROGRESS = 0.65
+# fix(#1778 codex r2): the longest a cancelled heartbeat tick's drain (see
+# _heartbeat_service_import_progress) may hold up the caller. The ordinary
+# session it runs on carries no statement or lock timeout of its own, so a
+# tick blocked on something else entirely -- another transaction's row lock
+# inside session.commit() -- could otherwise hang the drain, and with it
+# ingest_service's finally, indefinitely. A few seconds, not a fraction of
+# one: this is a last-resort bound for an already-rare case (a cancel racing
+# a tick), not a budget anything is sized against.
+_SERVICE_IMPORT_HEARTBEAT_DRAIN_TIMEOUT_SECONDS = 5.0
 _ARCGIS_SERVICE_IMPORT_CHUNK_SIZE = 2000
 
 
@@ -158,6 +167,20 @@ async def _heartbeat_service_import_progress(
     worth of extra shutdown latency (a single SELECT + UPDATE + COMMIT), the
     same trade a clean subprocess kill/reap already makes elsewhere in this
     package.
+
+    fix(#1778 codex r2): the drain that lets a shielded tick finish is itself
+    bounded by ``_SERVICE_IMPORT_HEARTBEAT_DRAIN_TIMEOUT_SECONDS``. The shield
+    bounds WHERE a cancel can land, not HOW LONG draining one can take -- an
+    ordinary session carries no statement or lock timeout of its own, so a
+    tick blocked on something else entirely (another transaction's row lock
+    inside ``session.commit()``) could hang this drain, and with it
+    ``ingest_service``'s own ``finally``, indefinitely. On timeout this
+    function gives up WAITING and returns; ``asyncio.shield`` keeps the tick
+    itself running in the background rather than cancelling it, so its
+    connection still gets to close cleanly on its own schedule. The
+    heartbeat's write is best-effort progress UI sugar the import's own
+    result never reads back, so abandoning one late tick costs nothing the
+    caller depends on.
     """
     while True:
         await asyncio.sleep(_SERVICE_IMPORT_HEARTBEAT_INTERVAL_SECONDS)
@@ -170,10 +193,23 @@ async def _heartbeat_service_import_progress(
             except asyncio.CancelledError:
                 # The OUTER await was cancelled, not necessarily `tick` — let
                 # its already-open connection finish and close cleanly before
-                # this coroutine ends.
+                # this coroutine ends, but only for a bounded time (fix(#1778
+                # codex r2)): `asyncio.shield` here means a timeout below only
+                # stops WAITING for `tick`, it does not cancel it, so a tick
+                # stuck on something with no timeout of its own still gets to
+                # finish and close its own connection in the background.
                 if not tick.done():
                     try:
-                        await tick
+                        await asyncio.wait_for(
+                            asyncio.shield(tick),
+                            timeout=_SERVICE_IMPORT_HEARTBEAT_DRAIN_TIMEOUT_SECONDS,
+                        )
+                    except asyncio.TimeoutError:
+                        structlog.get_logger().warning(
+                            "service_import_heartbeat_drain_timed_out",
+                            job_id=str(job_uuid),
+                            timeout=_SERVICE_IMPORT_HEARTBEAT_DRAIN_TIMEOUT_SECONDS,
+                        )
                     except BaseException:  # broad: draining an already-shielded tick's own connection cleanup; whatever it raises must not replace the pending cancellation `raise` below
                         pass
                 raise

--- a/backend/app/processing/ingest/tasks_vector.py
+++ b/backend/app/processing/ingest/tasks_vector.py
@@ -102,37 +102,81 @@ async def _drop_attempt_staging_table(staging_table: str) -> None:
         )
 
 
+async def _service_import_heartbeat_tick(
+    job_uuid: uuid.UUID, attempt_id: uuid.UUID
+) -> bool:
+    """One heartbeat write: open a session, advance progress, commit, close.
+
+    Returns ``False`` when the caller's loop must stop (the job vanished or
+    left the step this heartbeat belongs to), ``True`` otherwise. Split out of
+    ``_heartbeat_service_import_progress`` so that function can ``shield`` the
+    whole tick from cancellation (fix(#1778)) — see that function's docstring.
+    """
+    async with _job_phase_session(
+        job_uuid,
+        phase="service_import_heartbeat",
+        attempt_id=attempt_id,
+    ) as (session, job):
+        if job is None:
+            return False
+        if job.status != "running" or job.current_step != "ogr2ogr":
+            return False
+
+        existing_progress = (
+            job.progress
+            if job.progress is not None
+            else _SERVICE_IMPORT_INITIAL_PROGRESS
+        )
+        next_progress = min(
+            _SERVICE_IMPORT_HEARTBEAT_MAX_PROGRESS,
+            existing_progress + _SERVICE_IMPORT_HEARTBEAT_INCREMENT,
+        )
+        if next_progress <= existing_progress:
+            return True
+
+        job.progress = next_progress
+        await session.commit()
+        return True
+
+
 async def _heartbeat_service_import_progress(
     job_uuid: uuid.UUID, attempt_id: uuid.UUID
 ) -> None:
-    """Advance service-ingest progress while GDAL loads remote features."""
+    """Advance service-ingest progress while GDAL loads remote features.
+
+    fix(#1778): each tick is run under ``asyncio.shield`` so the caller's
+    ``.cancel()`` (``ingest_service``'s ``finally: service_progress_task.
+    cancel(); await service_progress_task``) can only ever land at the
+    ``asyncio.sleep`` above, never while a tick's session is mid-connect,
+    mid-write, or mid-close. Without this, a cancel landing inside
+    ``_job_phase_session``'s ``async with async_session()`` left that
+    connection's setup or teardown interrupted, and asyncpg does not always
+    finish tearing itself down in that state — the connection outlived the
+    coroutine that owned it, and its eventual, asynchronous close surfaced
+    later, against unrelated work, as ``ConnectionError: unexpected
+    connection_lost() call``. Shielding costs at most one in-flight tick's
+    worth of extra shutdown latency (a single SELECT + UPDATE + COMMIT), the
+    same trade a clean subprocess kill/reap already makes elsewhere in this
+    package.
+    """
     while True:
         await asyncio.sleep(_SERVICE_IMPORT_HEARTBEAT_INTERVAL_SECONDS)
+        tick = asyncio.ensure_future(
+            _service_import_heartbeat_tick(job_uuid, attempt_id)
+        )
         try:
-            async with _job_phase_session(
-                job_uuid,
-                phase="service_import_heartbeat",
-                attempt_id=attempt_id,
-            ) as (session, job):
-                if job is None:
-                    return
-                if job.status != "running" or job.current_step != "ogr2ogr":
-                    return
-
-                existing_progress = (
-                    job.progress
-                    if job.progress is not None
-                    else _SERVICE_IMPORT_INITIAL_PROGRESS
-                )
-                next_progress = min(
-                    _SERVICE_IMPORT_HEARTBEAT_MAX_PROGRESS,
-                    existing_progress + _SERVICE_IMPORT_HEARTBEAT_INCREMENT,
-                )
-                if next_progress <= existing_progress:
-                    continue
-
-                job.progress = next_progress
-                await session.commit()
+            try:
+                keep_going = await asyncio.shield(tick)
+            except asyncio.CancelledError:
+                # The OUTER await was cancelled, not necessarily `tick` — let
+                # its already-open connection finish and close cleanly before
+                # this coroutine ends.
+                if not tick.done():
+                    try:
+                        await tick
+                    except BaseException:  # broad: draining an already-shielded tick's own connection cleanup; whatever it raises must not replace the pending cancellation `raise` below
+                        pass
+                raise
         except Exception:  # broad: best-effort heartbeat must not fail ingest
             # Heartbeat progress is best-effort and must not mask ingest work.
             structlog.get_logger().warning(
@@ -140,6 +184,10 @@ async def _heartbeat_service_import_progress(
                 job_id=str(job_uuid),
                 exc_info=True,
             )
+            continue
+
+        if not keep_going:
+            return
 
 
 async def _write_service_import_progress(

--- a/backend/app/processing/ingest/tasks_vector.py
+++ b/backend/app/processing/ingest/tasks_vector.py
@@ -136,23 +136,26 @@ async def _service_import_heartbeat_tick(
     releases this tick's connection back to the pool the ordinary way --
     the caller no longer has to choose between waiting on a stuck connection
     forever and abandoning one it can never reclaim.
+
+    fix(#1778 codex r6): those timeouts are now passed INTO
+    ``_job_phase_session`` (``lock_and_statement_timeout_ms``) rather than
+    set after entering it, so they cover the SELECT the helper runs
+    internally too -- issuing them after the ``async with`` line left that
+    initial SELECT unprotected, and a SELECT can itself stall behind a lock
+    the later UPDATE would never even see (e.g. another session's ACCESS
+    EXCLUSIVE on the table).
     """
+    _timeout_ms = int(_SERVICE_IMPORT_HEARTBEAT_TICK_DB_TIMEOUT_SECONDS * 1000)
     async with _job_phase_session(
         job_uuid,
         phase="service_import_heartbeat",
         attempt_id=attempt_id,
+        lock_and_statement_timeout_ms=_timeout_ms,
     ) as (session, job):
         if job is None:
             return False
         if job.status != "running" or job.current_step != "ogr2ogr":
             return False
-
-        # fix(#1778 codex r3): milliseconds, integer -- `SET LOCAL` takes a
-        # literal, not a bind parameter (Postgres rejects `SET x = $1`), so
-        # this interpolates a module constant, never request-supplied data.
-        _timeout_ms = int(_SERVICE_IMPORT_HEARTBEAT_TICK_DB_TIMEOUT_SECONDS * 1000)
-        await session.execute(text(f"SET LOCAL lock_timeout = {_timeout_ms}"))
-        await session.execute(text(f"SET LOCAL statement_timeout = {_timeout_ms}"))
 
         existing_progress = (
             job.progress

--- a/backend/app/processing/tiles/router.py
+++ b/backend/app/processing/tiles/router.py
@@ -1289,11 +1289,36 @@ async def raster_tile_proxy(
             detail=f"Unsupported tile format: {fmt!r}",
         )
 
-    # Resolve effective bounds (apply defaults so callers downstream always receive
-    # concrete values, not None).
-    eff_pmin: float = pmin if pmin is not None else 2.0
-    eff_pmax: float = pmax if pmax is not None else 98.0
-    eff_sigma: float = sigma if sigma is not None else _STDDEV_SIGMA
+    # Resolve effective bounds ONCE, right where activity is decided: an
+    # INACTIVE parameter's effective value is ALWAYS the same default used
+    # when the parameter is absent, never the raw request value; an ACTIVE
+    # parameter's effective value is the (validated below) request value, or
+    # that same default when absent. Every downstream consumer --
+    # _fetch_band_statistics, _compute_stretch_rescale, and the error
+    # details below -- reads ONLY these resolved values, never a raw
+    # pmin/pmax/sigma, so "inactive means ignored" can never be
+    # contradicted downstream the way T-1153-01/round-2 already promised
+    # nginx it would not be.
+    #
+    # fix(#1778 codex r8): eff_pmin/eff_pmax/eff_sigma used to be resolved
+    # from "was the parameter merely present", independent of stretch mode
+    # -- so `?stretch=stddev&pmin=1e309` (FastAPI's float coercion turns the
+    # literal into `inf`; the validation below never runs because pmin is
+    # inactive under stddev) still set eff_pmin=inf, which reached
+    # _fetch_band_statistics's `int(pmin)` and raised an uncaught
+    # OverflowError (500) -- while frontend/nginx.conf, which already
+    # treats a value it blanks as harmless (fix(#1778 codex r5)), found
+    # `1e309` well inside its canonical float grammar and blanked pmin,
+    # sharing a cache key with a plain stddev request: a cached 200 once
+    # warm, a 500 on the first, cold request. Gating eff_pmin/eff_pmax/
+    # eff_sigma on the SAME activity test the validation below already uses
+    # closes this: an inactive parameter's raw value is now never read by
+    # anything, matching what nginx has assumed all along.
+    _pmin_pmax_active = stretch == "percentile"
+    _sigma_active = stretch == "stddev"
+    eff_pmin: float = pmin if (_pmin_pmax_active and pmin is not None) else 2.0
+    eff_pmax: float = pmax if (_pmin_pmax_active and pmax is not None) else 98.0
+    eff_sigma: float = sigma if (_sigma_active and sigma is not None) else _STDDEV_SIGMA
 
     # T-1153-01: validate pmin/pmax/sigma BEFORE any Titiler call.
     #
@@ -1310,8 +1335,23 @@ async def raster_tile_proxy(
     # $arg_x reads the FIRST occurrence, this endpoint's scalar Query reads
     # the LAST): an inactive value is never read on either side, so it can
     # never matter which occurrence either side saw.
+    #
+    # fix(#1778 codex r8): explicit math.isfinite() checks, rather than
+    # relying on inf/nan's IEEE-754 comparison behavior (`inf < x` is
+    # False, any comparison against `nan` is False) to fail the bound
+    # check below -- that behavior does already reject inf/nan today, but
+    # leaving it implicit is exactly the kind of thing a future "simplify
+    # this condition" pass could break without anyone noticing a canonical
+    # `1e309` (well inside nginx's float grammar; see frontend/nginx.conf)
+    # is still in play. int(pmin)/int(pmax) inside _fetch_band_statistics,
+    # and round(lo, 4)/round(hi, 4) inside _compute_stretch_rescale, must
+    # never see a non-finite value on the ACTIVE path either.
     if stretch == "percentile" and (pmin is not None or pmax is not None):
-        if not (0 <= eff_pmin < eff_pmax <= 100):
+        if (
+            not math.isfinite(eff_pmin)
+            or not math.isfinite(eff_pmax)
+            or not (0 <= eff_pmin < eff_pmax <= 100)
+        ):
             raise HTTPException(
                 status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
                 detail=(
@@ -1319,11 +1359,12 @@ async def raster_tile_proxy(
                     f"got pmin={eff_pmin}, pmax={eff_pmax}"
                 ),
             )
-    if stretch == "stddev" and sigma is not None and not (sigma > 0):
-        raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-            detail=f"sigma must be > 0; got sigma={sigma}",
-        )
+    if stretch == "stddev" and sigma is not None:
+        if not math.isfinite(eff_sigma) or not (eff_sigma > 0):
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail=f"sigma must be > 0; got sigma={eff_sigma}",
+            )
 
     # Reuse the auth-check logic to get the open path and render params
     auth_resp = await raster_auth_check(request, dataset_id, user, db)

--- a/backend/app/processing/tiles/router.py
+++ b/backend/app/processing/tiles/router.py
@@ -1188,21 +1188,24 @@ async def raster_tile_proxy(
         None,
         description=(
             "Lower percentile clip for stretch=percentile (0–100, default 2). "
-            "Absent = current p2 behavior. Must be less than pmax."
+            "Absent = current p2 behavior. Must be less than pmax. Ignored, and "
+            "not validated, when stretch is not percentile."
         ),
     ),
     pmax: float | None = Query(
         None,
         description=(
             "Upper percentile clip for stretch=percentile (0–100, default 98). "
-            "Absent = current p98 behavior. Must be greater than pmin."
+            "Absent = current p98 behavior. Must be greater than pmin. Ignored, "
+            "and not validated, when stretch is not percentile."
         ),
     ),
     sigma: float | None = Query(
         None,
         description=(
             "Standard-deviation multiplier for stretch=stddev (default 2.0). "
-            "Absent = current 2.0σ behavior. Must be > 0."
+            "Absent = current 2.0σ behavior. Must be > 0. Ignored, and not "
+            "validated, when stretch is not stddev."
         ),
     ),
     user: Identity | None = Depends(get_optional_user_fail_open),
@@ -1223,13 +1226,24 @@ async def raster_tile_proxy(
     rescale from Titiler band statistics. Multi-band rasters produce one rescale=
     fragment per band (up to 3, RASTER-STRETCH-03).
 
-    pmin/pmax: Configurable percentile clip bounds (default 2/98). Must satisfy
-    0 <= pmin < pmax <= 100. Forwarded as repeated p= params to /cog/statistics.
-    The _band_stats_cache key includes pmin/pmax so different bounds never serve
-    stale cached stats (RASTER-STRETCH-UI-01 / Phase 1153 cache-key isolation).
+    pmin/pmax: Configurable percentile clip bounds (default 2/98), read and
+    validated (0 <= pmin < pmax <= 100) only when stretch=percentile. Forwarded
+    as repeated p= params to /cog/statistics. The _band_stats_cache key includes
+    pmin/pmax so different bounds never serve stale cached stats
+    (RASTER-STRETCH-UI-01 / Phase 1153 cache-key isolation).
 
-    sigma: Standard-deviation multiplier for stretch=stddev (default 2.0).
-    Must be > 0.
+    sigma: Standard-deviation multiplier for stretch=stddev (default 2.0), read
+    and validated (> 0) only when stretch=stddev.
+
+    fix(#1778 codex r2): pmin/pmax/sigma used to be validated whenever present,
+    regardless of the active stretch mode, so an "inactive" value could still
+    422. frontend/nginx.conf's raster proxy_cache_key blanks an inactive value
+    out of the cache key to stop it defeating the cache; making that safe on
+    every input (including a repeated query parameter, where nginx's $arg_x
+    reads the FIRST occurrence and this endpoint's scalar Query reads the
+    LAST) needs "inactive" to mean the SAME thing on both sides: ignored, not
+    merely unvalidated for some inputs. A cache HIT must never disagree with
+    what an uncached request would answer.
     """
     # A-fix(#315 follow-up): defensively sanitize the {fmt} path param before it is
     # interpolated into the Titiler endpoint URL. Some reverse-proxy rewrites (e.g.
@@ -1282,9 +1296,21 @@ async def raster_tile_proxy(
     eff_sigma: float = sigma if sigma is not None else _STDDEV_SIGMA
 
     # T-1153-01: validate pmin/pmax/sigma BEFORE any Titiler call.
-    # Apply checks whenever the param is present, regardless of active stretch mode,
-    # so invalid inputs are always rejected (consistent with T-1140-01 approach).
-    if pmin is not None or pmax is not None:
+    #
+    # fix(#1778 codex r2): validated only when the ACTIVE stretch mode reads
+    # the value -- pmin/pmax under percentile, sigma under stddev -- not
+    # whenever merely present. The previous "always validate if present" rule
+    # made "inactive" a claim this endpoint could contradict, which is exactly
+    # what frontend/nginx.conf's raster proxy_cache_key relies on NOT
+    # happening: it blanks an inactive value out of the cache key so a random
+    # one can't defeat the cache, and a value it blanks must never be able to
+    # turn a cached 200 into what would have been a 422. "Inactive" now means
+    # "ignored" here too, so the maps can blank unconditionally with no
+    # residual, including under a duplicated query parameter (nginx's
+    # $arg_x reads the FIRST occurrence, this endpoint's scalar Query reads
+    # the LAST): an inactive value is never read on either side, so it can
+    # never matter which occurrence either side saw.
+    if stretch == "percentile" and (pmin is not None or pmax is not None):
         if not (0 <= eff_pmin < eff_pmax <= 100):
             raise HTTPException(
                 status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
@@ -1293,7 +1319,7 @@ async def raster_tile_proxy(
                     f"got pmin={eff_pmin}, pmax={eff_pmax}"
                 ),
             )
-    if sigma is not None and not (sigma > 0):
+    if stretch == "stddev" and sigma is not None and not (sigma > 0):
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
             detail=f"sigma must be > 0; got sigma={sigma}",

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -57972,7 +57972,7 @@
     },
     "/tiles/raster-proxy/{dataset_id}/{z}/{x}/{y}.{fmt}": {
       "get": {
-        "description": "API-side raster tile proxy: auth check + fetch from Titiler.\n\nUsed by Vite dev proxy and as a fallback for deployments without nginx.\nProduction deployments with nginx should use the nginx raster-tiles path\nfor better caching and performance.\n\ncolormap_name: Optional Titiler colormap for single-band display. Validated\nagainst _ALLOWED_COLORMAPS (T-1140-01). Gray is the Titiler default for\nsingle-band \u2014 passing gray is a no-op (not forwarded). colormap_name is not\nforwarded for DEM layers (render_params starts with 'algorithm=').\n\nstretch: Optional stretch strategy. percentile/stddev compute a stats-based\nrescale from Titiler band statistics. Multi-band rasters produce one rescale=\nfragment per band (up to 3, RASTER-STRETCH-03).\n\npmin/pmax: Configurable percentile clip bounds (default 2/98). Must satisfy\n0 <= pmin < pmax <= 100. Forwarded as repeated p= params to /cog/statistics.\nThe _band_stats_cache key includes pmin/pmax so different bounds never serve\nstale cached stats (RASTER-STRETCH-UI-01 / Phase 1153 cache-key isolation).\n\nsigma: Standard-deviation multiplier for stretch=stddev (default 2.0).\nMust be > 0.",
+        "description": "API-side raster tile proxy: auth check + fetch from Titiler.\n\nUsed by Vite dev proxy and as a fallback for deployments without nginx.\nProduction deployments with nginx should use the nginx raster-tiles path\nfor better caching and performance.\n\ncolormap_name: Optional Titiler colormap for single-band display. Validated\nagainst _ALLOWED_COLORMAPS (T-1140-01). Gray is the Titiler default for\nsingle-band \u2014 passing gray is a no-op (not forwarded). colormap_name is not\nforwarded for DEM layers (render_params starts with 'algorithm=').\n\nstretch: Optional stretch strategy. percentile/stddev compute a stats-based\nrescale from Titiler band statistics. Multi-band rasters produce one rescale=\nfragment per band (up to 3, RASTER-STRETCH-03).\n\npmin/pmax: Configurable percentile clip bounds (default 2/98), read and\nvalidated (0 <= pmin < pmax <= 100) only when stretch=percentile. Forwarded\nas repeated p= params to /cog/statistics. The _band_stats_cache key includes\npmin/pmax so different bounds never serve stale cached stats\n(RASTER-STRETCH-UI-01 / Phase 1153 cache-key isolation).\n\nsigma: Standard-deviation multiplier for stretch=stddev (default 2.0), read\nand validated (> 0) only when stretch=stddev.\n\nfix(#1778 codex r2): pmin/pmax/sigma used to be validated whenever present,\nregardless of the active stretch mode, so an \"inactive\" value could still\n422. frontend/nginx.conf's raster proxy_cache_key blanks an inactive value\nout of the cache key to stop it defeating the cache; making that safe on\nevery input (including a repeated query parameter, where nginx's $arg_x\nreads the FIRST occurrence and this endpoint's scalar Query reads the\nLAST) needs \"inactive\" to mean the SAME thing on both sides: ignored, not\nmerely unvalidated for some inputs. A cache HIT must never disagree with\nwhat an uncached request would answer.",
         "operationId": "raster_tile_proxy_tiles_raster_proxy__dataset_id___z___x___y___fmt__get",
         "parameters": [
           {
@@ -58073,7 +58073,7 @@
             }
           },
           {
-            "description": "Lower percentile clip for stretch=percentile (0\u2013100, default 2). Absent = current p2 behavior. Must be less than pmax.",
+            "description": "Lower percentile clip for stretch=percentile (0\u2013100, default 2). Absent = current p2 behavior. Must be less than pmax. Ignored, and not validated, when stretch is not percentile.",
             "in": "query",
             "name": "pmin",
             "required": false,
@@ -58086,12 +58086,12 @@
                   "type": "null"
                 }
               ],
-              "description": "Lower percentile clip for stretch=percentile (0\u2013100, default 2). Absent = current p2 behavior. Must be less than pmax.",
+              "description": "Lower percentile clip for stretch=percentile (0\u2013100, default 2). Absent = current p2 behavior. Must be less than pmax. Ignored, and not validated, when stretch is not percentile.",
               "title": "Pmin"
             }
           },
           {
-            "description": "Upper percentile clip for stretch=percentile (0\u2013100, default 98). Absent = current p98 behavior. Must be greater than pmin.",
+            "description": "Upper percentile clip for stretch=percentile (0\u2013100, default 98). Absent = current p98 behavior. Must be greater than pmin. Ignored, and not validated, when stretch is not percentile.",
             "in": "query",
             "name": "pmax",
             "required": false,
@@ -58104,12 +58104,12 @@
                   "type": "null"
                 }
               ],
-              "description": "Upper percentile clip for stretch=percentile (0\u2013100, default 98). Absent = current p98 behavior. Must be greater than pmin.",
+              "description": "Upper percentile clip for stretch=percentile (0\u2013100, default 98). Absent = current p98 behavior. Must be greater than pmin. Ignored, and not validated, when stretch is not percentile.",
               "title": "Pmax"
             }
           },
           {
-            "description": "Standard-deviation multiplier for stretch=stddev (default 2.0). Absent = current 2.0\u03c3 behavior. Must be > 0.",
+            "description": "Standard-deviation multiplier for stretch=stddev (default 2.0). Absent = current 2.0\u03c3 behavior. Must be > 0. Ignored, and not validated, when stretch is not stddev.",
             "in": "query",
             "name": "sigma",
             "required": false,
@@ -58122,7 +58122,7 @@
                   "type": "null"
                 }
               ],
-              "description": "Standard-deviation multiplier for stretch=stddev (default 2.0). Absent = current 2.0\u03c3 behavior. Must be > 0.",
+              "description": "Standard-deviation multiplier for stretch=stddev (default 2.0). Absent = current 2.0\u03c3 behavior. Must be > 0. Ignored, and not validated, when stretch is not stddev.",
               "title": "Sigma"
             }
           }

--- a/backend/tests/test_embedding_backfill_queue_1542.py
+++ b/backend/tests/test_embedding_backfill_queue_1542.py
@@ -225,28 +225,35 @@ async def test_enqueue_returns_promptly_instead_of_waiting_for_the_run(
     admin_auth_header: dict,
     monkeypatch,
 ):
-    """The 600s ceiling is only reachable if the request waits. It must not.
+    """The request must answer before the run's first observable side effect.
 
-    Two seconds stands in for the ten minutes a ~59,000-record regenerate takes:
-    the inline route's elapsed time is the backfill's elapsed time, whatever the
-    catalog size, and the queued route's is not.
+    fix(#1778): this used to assert ``elapsed < 1.0`` against a 2s mock sleep
+    — a wall-clock race a loaded CI runner can lose on ordinary scheduling
+    noise that has nothing to do with whether the backfill ran inline. The
+    property under test is an ORDER, not a duration, so it is proven with an
+    event instead: ``backfill_started`` is set at the very top of the mock,
+    before anything slow, so if the endpoint ever regressed to awaiting the
+    backfill directly rather than deferring it to the queue, the response
+    could not come back before that event fires (a synchronous await cannot
+    return before the thing it awaited has started). Deterministic either
+    way — no timing budget to miss under load.
     """
+    backfill_started = anyio.Event()
 
     async def _slow_backfill(session, *, force=False, should_continue=None):
+        backfill_started.set()
         await anyio.sleep(2.0)
         return {"processed": 0, "created": 0, "skipped": 0, "errors": 0}
 
     monkeypatch.setattr(backfill_module, "backfill_embeddings", _slow_backfill)
 
     with patch.object(admin_router, "defer_async_with_tenant", AsyncMock()):
-        started = time.monotonic()
         resp = await client.post(_FORCE_URL, headers=admin_auth_header)
-        elapsed = time.monotonic() - started
 
     assert resp.status_code == 200, resp.text
-    assert elapsed < 1.0, (
-        f"the endpoint blocked for {elapsed:.2f}s — it is still running the "
-        "backfill inside the request"
+    assert not backfill_started.is_set(), (
+        "the endpoint ran the backfill before answering — it is still "
+        "running the backfill inside the request instead of deferring it"
     )
 
 

--- a/backend/tests/test_export_parquet_row_stream_budget_1778.py
+++ b/backend/tests/test_export_parquet_row_stream_budget_1778.py
@@ -1,0 +1,141 @@
+"""GeoParquet's row stream has a wall clock too (#1778, codebase audit 2026-08-30).
+
+fix(#1781) bounded every ogr2ogr export format by what is left of the edge
+proxy's read-timeout window (``export_subprocess_timeout_seconds`` in
+``export/ogr.py``): a kill-on-timeout for the subprocess plus a matching libpq
+``statement_timeout`` on its own connection. GeoParquet (``export/parquet.py``)
+has no subprocess — it streams SELECT rows straight into Python lists — and
+inherited none of that: an unindexed table or a wide selection could stream
+well past the edge's window with nothing to stop it, holding the request open
+(and its pooled connection with it) long after nginx had already answered the
+client with a 504.
+
+The fix reuses ``export_subprocess_timeout_seconds`` rather than deriving a
+second bound, and wraps the row stream in ``asyncio.wait_for`` on that budget,
+raising the SAME ``ExportError`` the ogr2ogr timeout raises — so the router's
+``except ExportError`` handling (one 500, not a hang past the proxy's own
+timeout) is identical for every export format.
+
+Mirrors ``test_export_request_budget.py::TestExportSubprocessBudget::
+test_the_deadline_terminates_the_child``, the equivalent test for the ogr2ogr
+formats, but with a fake row source instead of a real subprocess — there is no
+child process here to reap.
+"""
+
+import asyncio
+import os
+import shutil
+
+import pytest
+
+from app.processing.export import parquet as export_parquet_module
+from app.processing.export.ogr import ExportError
+from app.processing.export.parquet import ParquetExportPlan, export_parquet
+
+
+def _plan() -> ParquetExportPlan:
+    return ParquetExportPlan(attr_names=["name"], where_sql="TRUE", params={})
+
+
+class TestParquetRowStreamBudget:
+    @pytest.mark.anyio
+    async def test_a_slow_row_source_past_the_deadline_raises_export_error(
+        self, monkeypatch
+    ):
+        """A row source that outlives its budget stops the same way the
+        ogr2ogr formats do: ``ExportError``, not a hang past the edge proxy's
+        own read timeout."""
+        monkeypatch.setattr(
+            export_parquet_module,
+            "export_subprocess_timeout_seconds",
+            lambda deadline: 0.05,
+        )
+
+        async def _slow_stream_rows(db, sql, params, attr_names, geom_idx):
+            await asyncio.sleep(30)
+            raise AssertionError(
+                "the row source ran to completion instead of being bounded"
+            )
+
+        monkeypatch.setattr(export_parquet_module, "_stream_rows", _slow_stream_rows)
+
+        with pytest.raises(ExportError) as exc:
+            await export_parquet(
+                db=None,
+                table_name="roads",
+                dataset_name="Roads",
+                schema="data",
+                plan=_plan(),
+            )
+
+        assert "timed out" in str(exc.value)
+
+    @pytest.mark.anyio
+    async def test_a_fast_row_source_is_unaffected(self, monkeypatch, tmp_path):
+        """Counterfactual: a row source that finishes inside the budget must
+        not be treated as timed out, and still produces a real file."""
+        monkeypatch.setattr(
+            export_parquet_module,
+            "export_subprocess_timeout_seconds",
+            lambda deadline: 30,
+        )
+        monkeypatch.setattr(
+            export_parquet_module.settings, "upload_staging_dir", str(tmp_path)
+        )
+
+        async def _fast_stream_rows(db, sql, params, attr_names, geom_idx):
+            return [b"\x01\x02"], {"name": ["a"]}
+
+        monkeypatch.setattr(export_parquet_module, "_stream_rows", _fast_stream_rows)
+
+        file_path, filename, media_type = await export_parquet(
+            db=None,
+            table_name="roads",
+            dataset_name="Roads",
+            schema="data",
+            plan=_plan(),
+        )
+        try:
+            assert os.path.exists(file_path)
+            assert filename.endswith(".parquet")
+        finally:
+            shutil.rmtree(os.path.dirname(file_path), ignore_errors=True)
+
+    @pytest.mark.anyio
+    async def test_no_deadline_reuses_the_ogr2ogr_helper_not_a_second_one(
+        self, monkeypatch, tmp_path
+    ):
+        """The budget must come from ``export_subprocess_timeout_seconds``
+        (fix(#1781)'s helper) rather than a parquet-specific reimplementation —
+        a second bound could drift from the edge window the first one tracks."""
+        calls: list[float | None] = []
+        real = export_parquet_module.export_subprocess_timeout_seconds
+
+        def _spy(deadline):
+            calls.append(deadline)
+            return real(deadline)
+
+        monkeypatch.setattr(
+            export_parquet_module, "export_subprocess_timeout_seconds", _spy
+        )
+        monkeypatch.setattr(
+            export_parquet_module.settings, "upload_staging_dir", str(tmp_path)
+        )
+
+        async def _fast_stream_rows(db, sql, params, attr_names, geom_idx):
+            return [b"\x01"], {"name": ["a"]}
+
+        monkeypatch.setattr(export_parquet_module, "_stream_rows", _fast_stream_rows)
+
+        file_path, _filename, _media_type = await export_parquet(
+            db=None,
+            table_name="roads",
+            dataset_name="Roads",
+            schema="data",
+            plan=_plan(),
+            deadline=None,
+        )
+        try:
+            assert calls == [None]
+        finally:
+            shutil.rmtree(os.path.dirname(file_path), ignore_errors=True)

--- a/backend/tests/test_ingest_service_heartbeat_drain_1778.py
+++ b/backend/tests/test_ingest_service_heartbeat_drain_1778.py
@@ -1,5 +1,6 @@
-"""The service-import heartbeat's cancellation drain has a finite deadline
-(#1778, codex round 2 on #1791).
+"""The service-import heartbeat's cancellation drain has a finite deadline,
+and a stuck tick's own database wait does too (#1778, codex rounds 2-3 on
+#1791).
 
 fix(#1778) put each heartbeat tick's session open/write/commit/close under
 ``asyncio.shield`` so a caller's ``.cancel()`` could only land at the
@@ -11,19 +12,35 @@ the ordinary session a tick runs on carries no statement or lock timeout of
 its own. A tick blocked on something else entirely -- another transaction's
 row lock inside ``session.commit()`` -- would hang the drain, and with it
 ``ingest_service``'s own ``finally``, forever: a finished import stuck before
-it could reach finalization.
+it could reach finalization. Round 2's fix,
+``_SERVICE_IMPORT_HEARTBEAT_DRAIN_TIMEOUT_SECONDS``, gave up on WAITING for
+such a tick after a bound -- ``asyncio.shield`` kept it running in the
+background rather than cancelling it, so its connection would still close
+whenever the lock eventually cleared, but until then that connection stayed
+checked out and blocked, and repeated stalled imports could exhaust the
+worker's pool even though their parent tasks moved on.
 
-``_SERVICE_IMPORT_HEARTBEAT_DRAIN_TIMEOUT_SECONDS`` bounds that drain.
-``asyncio.shield`` keeps the stuck tick running in the background rather than
-cancelling it on that timeout, so its own connection still gets to close on
-its own schedule -- only the WAITING stops.
+Round 3 bounds the tick's OWN database wait instead:
+``_service_import_heartbeat_tick`` now sets ``lock_timeout``/
+``statement_timeout`` on its own transaction (see
+``_SERVICE_IMPORT_HEARTBEAT_TICK_DB_TIMEOUT_SECONDS``), so a blocked commit
+fails INSIDE Postgres within a few seconds and its connection returns to the
+pool the ordinary way, without depending on anyone giving up on waiting for
+it. The round-2 drain deadline survives as a safety net above that DB
+timeout, for what a DB-side timeout cannot cover (a connection stuck before
+it ever reaches Postgres).
 
-These tests exercise ``_heartbeat_service_import_progress`` directly with a
-tick that never returns, standing in for one stuck on a row lock. Completion
-is checked by POLLING ``Task.done()``, never by wrapping the heartbeat task
-itself in another ``asyncio.wait_for`` -- that would cancel it on ITS OWN
-timeout and mask the exact thing under test, whether the drain deadline
-constant is what actually bounds completion.
+The tests through ``test_the_stuck_tick_is_not_cancelled_by_the_drain_timeout``
+exercise ``_heartbeat_service_import_progress`` directly with a MOCKED tick
+that never returns, standing in for one stuck on something the mock doesn't
+model. Completion is checked by POLLING ``Task.done()``, never by wrapping
+the heartbeat task itself in another ``asyncio.wait_for`` -- that would
+cancel it on ITS OWN timeout and mask the exact thing under test, whether the
+drain deadline constant is what actually bounds completion.
+
+The final test exercises the round-3 mechanism directly against a REAL row
+lock held by a second, real database session -- the one property the mocked
+tests above cannot stand in for.
 """
 
 import asyncio
@@ -31,6 +48,7 @@ import uuid
 
 import pytest
 
+from app.platform.jobs.models import IngestJob
 from app.processing.ingest import tasks_vector
 
 
@@ -205,3 +223,111 @@ async def test_the_stuck_tick_is_not_cancelled_by_the_drain_timeout(monkeypatch)
         "the shielded tick was cancelled instead of allowed to finish"
     )
     assert not tick_cancelled
+
+
+@pytest.mark.anyio
+async def test_a_tick_blocked_behind_a_held_row_lock_times_out_inside_the_db_and_releases_its_connection(
+    test_db_session, monkeypatch
+):
+    """fix(#1778 codex r3): ``_service_import_heartbeat_tick`` sets
+    ``lock_timeout``/``statement_timeout`` on its OWN transaction, so a
+    commit blocked on another session's row lock fails INSIDE the database
+    within a few seconds and releases its connection back to the pool --
+    rather than depending on the caller merely giving up on WAITING for it
+    (round 2's fix alone), which left the tick's connection itself still
+    checked out and blocked, exhausting the worker's pool under repeated
+    stalled imports even though their parent tasks continued.
+
+    Uses a real row lock held by a second, real session against the real
+    test database -- this is the one property a mock can't stand in for.
+    """
+    import app.core.db as db_module
+    from sqlalchemy import event, select
+
+    from tests.factories import get_user_id
+
+    monkeypatch.setattr(
+        tasks_vector, "_SERVICE_IMPORT_HEARTBEAT_TICK_DB_TIMEOUT_SECONDS", 0.5
+    )
+
+    admin_id = await get_user_id(test_db_session, "admin")
+    job = IngestJob(
+        source_filename="LockedHeartbeatJob",
+        created_by=admin_id,
+        status="running",
+        current_step="ogr2ogr",
+        progress=0.1,
+    )
+    test_db_session.add(job)
+    await test_db_session.flush()
+    await test_db_session.commit()
+    job_id = job.id
+    attempt_id = job.attempt_id
+
+    live = {"n": 0}
+
+    def _on_checkout(*_args):
+        live["n"] += 1
+
+    def _on_checkin(*_args):
+        live["n"] -= 1
+
+    sync_engine = db_module.engine.sync_engine
+    event.listen(sync_engine, "checkout", _on_checkout)
+    event.listen(sync_engine, "checkin", _on_checkin)
+
+    # No connection held anywhere yet -- the true idle baseline, captured
+    # before the locker session checks its own connection out, so releasing
+    # THAT connection later is accounted for rather than mistaken for a leak.
+    idle_baseline = live["n"]
+
+    try:
+        async with db_module.async_session() as locker_session:
+            # Hold a real row lock on the job row without committing, exactly
+            # what "another transaction's row lock" means in the finding.
+            await locker_session.execute(
+                select(IngestJob).where(IngestJob.id == job_id).with_for_update()
+            )
+
+            # +1 for the locker session's own held connection.
+            with_locker_held = live["n"]
+            assert with_locker_held == idle_baseline + 1
+
+            with pytest.raises(Exception) as exc_info:
+                await tasks_vector._service_import_heartbeat_tick(job_id, attempt_id)
+
+            # The tick's OWN connection returned to the pool -- the property
+            # under test. The locker session's connection is still held (it
+            # is a different, deliberately-parked connection) and is not
+            # released until the `async with` below exits.
+            assert live["n"] == with_locker_held, (
+                f"pool checkout count drifted from {with_locker_held} (locker "
+                f"session held, tick about to run) to {live['n']} -- the "
+                "tick's connection was not released after its own "
+                "lock_timeout fired"
+            )
+            # It failed for the reason this fix adds, not some other cause
+            # this test would otherwise pass against vacuously.
+            message = str(exc_info.value).lower()
+            assert "lock" in message or "canceling statement" in message, (
+                f"expected a lock/statement timeout from Postgres, got: "
+                f"{exc_info.value!r}"
+            )
+
+            await locker_session.rollback()
+
+        # The locker session's own connection is released once its `async
+        # with` block above exits.
+        assert live["n"] == idle_baseline
+
+        # The parent completes: once the lock clears, a fresh tick against
+        # the same job succeeds normally -- the earlier timeout did not
+        # leave the job, or the pool, in a broken state.
+        keep_going = await tasks_vector._service_import_heartbeat_tick(
+            job_id, attempt_id
+        )
+        assert keep_going is True
+        assert live["n"] == idle_baseline
+    finally:
+        event.remove(sync_engine, "checkout", _on_checkout)
+        event.remove(sync_engine, "checkin", _on_checkin)

--- a/backend/tests/test_ingest_service_heartbeat_drain_1778.py
+++ b/backend/tests/test_ingest_service_heartbeat_drain_1778.py
@@ -1,0 +1,207 @@
+"""The service-import heartbeat's cancellation drain has a finite deadline
+(#1778, codex round 2 on #1791).
+
+fix(#1778) put each heartbeat tick's session open/write/commit/close under
+``asyncio.shield`` so a caller's ``.cancel()`` could only land at the
+``asyncio.sleep`` between ticks, never mid-connection -- closing an asyncpg
+``ConnectionError: unexpected connection_lost() call`` seen in the merge
+queue. Codex round 2 found the shield alone was not enough: the drain that
+lets a shielded tick finish (``await tick`` after a cancel) was unbounded, and
+the ordinary session a tick runs on carries no statement or lock timeout of
+its own. A tick blocked on something else entirely -- another transaction's
+row lock inside ``session.commit()`` -- would hang the drain, and with it
+``ingest_service``'s own ``finally``, forever: a finished import stuck before
+it could reach finalization.
+
+``_SERVICE_IMPORT_HEARTBEAT_DRAIN_TIMEOUT_SECONDS`` bounds that drain.
+``asyncio.shield`` keeps the stuck tick running in the background rather than
+cancelling it on that timeout, so its own connection still gets to close on
+its own schedule -- only the WAITING stops.
+
+These tests exercise ``_heartbeat_service_import_progress`` directly with a
+tick that never returns, standing in for one stuck on a row lock. Completion
+is checked by POLLING ``Task.done()``, never by wrapping the heartbeat task
+itself in another ``asyncio.wait_for`` -- that would cancel it on ITS OWN
+timeout and mask the exact thing under test, whether the drain deadline
+constant is what actually bounds completion.
+"""
+
+import asyncio
+import uuid
+
+import pytest
+
+from app.processing.ingest import tasks_vector
+
+
+def _ids() -> tuple[uuid.UUID, uuid.UUID]:
+    return uuid.uuid4(), uuid.uuid4()
+
+
+async def _poll_until(predicate, *, timeout: float, interval: float = 0.01) -> bool:
+    """Poll ``predicate()`` until true or ``timeout`` elapses. Returns whether
+    it became true. Never wraps a task in ``wait_for`` (see module docstring)."""
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout
+    while loop.time() < deadline:
+        if predicate():
+            return True
+        await asyncio.sleep(interval)
+    return predicate()
+
+
+@pytest.mark.anyio
+async def test_a_tick_stuck_forever_does_not_hang_past_the_drain_deadline(monkeypatch):
+    """A cancel lands while the tick is stuck; the heartbeat coroutine must
+    still finish handling that cancellation within the (small, here) drain
+    deadline, never waiting on the stuck tick itself."""
+    monkeypatch.setattr(
+        tasks_vector, "_SERVICE_IMPORT_HEARTBEAT_INTERVAL_SECONDS", 0.01, raising=False
+    )
+    monkeypatch.setattr(
+        tasks_vector, "_SERVICE_IMPORT_HEARTBEAT_DRAIN_TIMEOUT_SECONDS", 0.05
+    )
+
+    entered_tick = asyncio.Event()
+    stuck_forever = asyncio.Event()  # never set
+
+    async def _stuck_tick(job_uuid, attempt_id):
+        entered_tick.set()
+        await stuck_forever.wait()
+        # Reached once the `finally` below releases `stuck_forever`, letting
+        # this orphaned task finish quietly rather than lingering pending.
+        return True
+
+    monkeypatch.setattr(tasks_vector, "_service_import_heartbeat_tick", _stuck_tick)
+
+    job_uuid, attempt_id = _ids()
+    heartbeat_task = asyncio.create_task(
+        tasks_vector._heartbeat_service_import_progress(job_uuid, attempt_id)
+    )
+    try:
+        await asyncio.wait_for(entered_tick.wait(), timeout=1.0)
+        heartbeat_task.cancel()
+
+        # Generous slack (1s) over the drain deadline (0.05s): the property
+        # under test is "finishes well before this", not the exact timing.
+        finished = await _poll_until(heartbeat_task.done, timeout=1.0)
+        assert finished, (
+            "the heartbeat did not finish handling its cancellation within "
+            "1s of a 0.05s drain deadline -- the drain is not actually bounded"
+        )
+        with pytest.raises(asyncio.CancelledError):
+            heartbeat_task.result()
+    finally:
+        stuck_forever.set()
+        if not heartbeat_task.done():
+            heartbeat_task.cancel()
+        await asyncio.gather(heartbeat_task, return_exceptions=True)
+
+
+@pytest.mark.anyio
+async def test_counterfactual_a_larger_drain_deadline_is_the_thing_that_hangs(
+    monkeypatch,
+):
+    """Proves the deadline above is load-bearing, not incidental: raise it
+    past a short polling window and the SAME stuck tick leaves the heartbeat
+    task still pending at that point, because nothing else bounds
+    completion. Checked by polling ``done()``, not by an enclosing
+    ``wait_for`` -- that would cancel the task on its OWN timeout and pass
+    regardless of the drain deadline's value, proving nothing."""
+    monkeypatch.setattr(
+        tasks_vector, "_SERVICE_IMPORT_HEARTBEAT_INTERVAL_SECONDS", 0.01, raising=False
+    )
+    monkeypatch.setattr(
+        tasks_vector, "_SERVICE_IMPORT_HEARTBEAT_DRAIN_TIMEOUT_SECONDS", 10.0
+    )
+
+    entered_tick = asyncio.Event()
+    stuck_forever = asyncio.Event()  # never set
+
+    async def _stuck_tick(job_uuid, attempt_id):
+        entered_tick.set()
+        await stuck_forever.wait()
+        # Reached once the `finally` below releases `stuck_forever`, letting
+        # this orphaned task finish quietly rather than lingering pending.
+        return True
+
+    monkeypatch.setattr(tasks_vector, "_service_import_heartbeat_tick", _stuck_tick)
+
+    job_uuid, attempt_id = _ids()
+    heartbeat_task = asyncio.create_task(
+        tasks_vector._heartbeat_service_import_progress(job_uuid, attempt_id)
+    )
+    try:
+        await asyncio.wait_for(entered_tick.wait(), timeout=1.0)
+        heartbeat_task.cancel()
+
+        await asyncio.sleep(0.3)
+        assert not heartbeat_task.done(), (
+            "expected the heartbeat to still be draining the stuck tick at "
+            "0.3s when the drain deadline is 10s -- if it is already done, "
+            "something OTHER than the deadline constant is bounding "
+            "completion, and the constant this fix added is not actually "
+            "load-bearing"
+        )
+    finally:
+        # Release the stuck tick and reap both tasks without ever wrapping
+        # the heartbeat task in a cancelling wait_for.
+        stuck_forever.set()
+        if not heartbeat_task.done():
+            heartbeat_task.cancel()
+        await asyncio.gather(heartbeat_task, return_exceptions=True)
+
+
+@pytest.mark.anyio
+async def test_the_stuck_tick_is_not_cancelled_by_the_drain_timeout(monkeypatch):
+    """asyncio.shield's whole point here: giving up on WAITING for a stuck
+    tick must not cancel the tick itself, so its connection still gets a
+    chance to close cleanly rather than being torn down mid-flight -- the
+    exact failure mode fix(#1778)'s shield exists to prevent."""
+    monkeypatch.setattr(
+        tasks_vector, "_SERVICE_IMPORT_HEARTBEAT_INTERVAL_SECONDS", 0.01, raising=False
+    )
+    monkeypatch.setattr(
+        tasks_vector, "_SERVICE_IMPORT_HEARTBEAT_DRAIN_TIMEOUT_SECONDS", 0.05
+    )
+
+    entered_tick = asyncio.Event()
+    release_tick = asyncio.Event()
+    tick_cancelled = False
+    tick_completed = False
+
+    async def _slow_tick(job_uuid, attempt_id):
+        nonlocal tick_cancelled, tick_completed
+        entered_tick.set()
+        try:
+            await release_tick.wait()
+        except asyncio.CancelledError:
+            tick_cancelled = True
+            raise
+        tick_completed = True
+        return True
+
+    monkeypatch.setattr(tasks_vector, "_service_import_heartbeat_tick", _slow_tick)
+
+    job_uuid, attempt_id = _ids()
+    heartbeat_task = asyncio.create_task(
+        tasks_vector._heartbeat_service_import_progress(job_uuid, attempt_id)
+    )
+    await asyncio.wait_for(entered_tick.wait(), timeout=1.0)
+    heartbeat_task.cancel()
+
+    finished = await _poll_until(heartbeat_task.done, timeout=1.0)
+    assert finished
+    with pytest.raises(asyncio.CancelledError):
+        heartbeat_task.result()
+
+    # The drain deadline (0.05s) has already elapsed and given up waiting,
+    # but the shielded tick keeps running underneath. Releasing it now and
+    # letting it finish proves it was never cancelled.
+    release_tick.set()
+    await _poll_until(lambda: tick_completed or tick_cancelled, timeout=2.0)
+
+    assert tick_completed, (
+        "the shielded tick was cancelled instead of allowed to finish"
+    )
+    assert not tick_cancelled

--- a/backend/tests/test_ingest_service_heartbeat_drain_1778.py
+++ b/backend/tests/test_ingest_service_heartbeat_drain_1778.py
@@ -331,3 +331,101 @@ async def test_a_tick_blocked_behind_a_held_row_lock_times_out_inside_the_db_and
     finally:
         event.remove(sync_engine, "checkout", _on_checkout)
         event.remove(sync_engine, "checkin", _on_checkin)
+
+
+@pytest.mark.anyio
+async def test_a_tick_blocked_on_its_own_initial_select_times_out_inside_the_db_and_releases_its_connection(
+    test_db_session, monkeypatch
+):
+    """fix(#1778 codex r6): the row-lock test above blocks the tick's LATER
+    commit; this one blocks its FIRST statement, the SELECT
+    ``_job_phase_session`` runs internally before the caller gets control at
+    all. A ``FOR UPDATE`` row lock does not block a plain SELECT under
+    Postgres's MVCC, so it cannot exercise this path -- an
+    ``ACCESS EXCLUSIVE`` table lock does, the same class of lock a
+    ``DROP``/``ALTER``/``TRUNCATE`` (or an explicit ``LOCK TABLE``) takes.
+
+    Before fix(#1778 codex r6), ``_service_import_heartbeat_tick`` issued
+    its ``SET LOCAL lock_timeout``/``statement_timeout`` AFTER entering
+    ``_job_phase_session``'s ``async with`` block -- too late to protect the
+    SELECT that already ran to get there, so this exact scenario hung on
+    the database's server-wide default instead of the few-second budget.
+    The timeouts now go INTO ``_job_phase_session`` via
+    ``lock_and_statement_timeout_ms`` and take effect before its SELECT.
+    """
+    import app.core.db as db_module
+    from sqlalchemy import event, text
+
+    from tests.factories import get_user_id
+
+    monkeypatch.setattr(
+        tasks_vector, "_SERVICE_IMPORT_HEARTBEAT_TICK_DB_TIMEOUT_SECONDS", 0.5
+    )
+
+    admin_id = await get_user_id(test_db_session, "admin")
+    job = IngestJob(
+        source_filename="TableLockedHeartbeatJob",
+        created_by=admin_id,
+        status="running",
+        current_step="ogr2ogr",
+        progress=0.1,
+    )
+    test_db_session.add(job)
+    await test_db_session.flush()
+    await test_db_session.commit()
+    job_id = job.id
+    attempt_id = job.attempt_id
+
+    live = {"n": 0}
+
+    def _on_checkout(*_args):
+        live["n"] += 1
+
+    def _on_checkin(*_args):
+        live["n"] -= 1
+
+    sync_engine = db_module.engine.sync_engine
+    event.listen(sync_engine, "checkout", _on_checkout)
+    event.listen(sync_engine, "checkin", _on_checkin)
+
+    idle_baseline = live["n"]
+
+    try:
+        async with db_module.async_session() as locker_session:
+            # ACCESS EXCLUSIVE blocks EVERY other lock mode, including the
+            # ACCESS SHARE a plain SELECT takes -- unlike FOR UPDATE, which
+            # only blocks other writers/lockers of the same row.
+            await locker_session.execute(
+                text("LOCK TABLE catalog.ingest_jobs IN ACCESS EXCLUSIVE MODE")
+            )
+
+            with_locker_held = live["n"]
+            assert with_locker_held == idle_baseline + 1
+
+            with pytest.raises(Exception) as exc_info:
+                await tasks_vector._service_import_heartbeat_tick(job_id, attempt_id)
+
+            assert live["n"] == with_locker_held, (
+                f"pool checkout count drifted from {with_locker_held} (locker "
+                f"session held, tick about to run) to {live['n']} -- the "
+                "tick's connection was not released after its own "
+                "lock_timeout fired"
+            )
+            message = str(exc_info.value).lower()
+            assert "lock" in message or "canceling statement" in message, (
+                f"expected a lock/statement timeout from Postgres, got: "
+                f"{exc_info.value!r}"
+            )
+
+            await locker_session.rollback()
+
+        assert live["n"] == idle_baseline
+
+        keep_going = await tasks_vector._service_import_heartbeat_tick(
+            job_id, attempt_id
+        )
+        assert keep_going is True
+        assert live["n"] == idle_baseline
+    finally:
+        event.remove(sync_engine, "checkout", _on_checkout)
+        event.remove(sync_engine, "checkin", _on_checkin)

--- a/backend/tests/test_ingest_service_heartbeat_drain_1778.py
+++ b/backend/tests/test_ingest_service_heartbeat_drain_1778.py
@@ -38,9 +38,32 @@ the heartbeat task itself in another ``asyncio.wait_for`` -- that would
 cancel it on ITS OWN timeout and mask the exact thing under test, whether the
 drain deadline constant is what actually bounds completion.
 
-The final test exercises the round-3 mechanism directly against a REAL row
-lock held by a second, real database session -- the one property the mocked
-tests above cannot stand in for.
+The tests through ``test_a_tick_blocked_on_its_own_initial_select_times_out_
+inside_the_db_and_releases_its_connection`` exercise the round-3/round-6
+mechanism directly against a REAL row lock held by a second, real database
+session -- the one property the mocked tests above cannot stand in for.
+
+Round 11 closes a residual: even with the drain deadline and the DB-side
+lock/statement timeouts, the tick's own SELECT (inside ``_job_phase_
+session``) is a snapshot, not a lock. A tick that read the row as
+"running"/"ogr2ogr" can still have its OWN write land AFTER
+``_finalize_ingest`` commits ``status="complete"``/``progress=1.0`` (or a
+retry rotates ``attempt_id``) -- an unconditional ORM commit would then
+overwrite the finalized row, by primary key, with the tick's stale progress.
+The write is now a single atomic UPDATE gated on
+``id + attempt_id + status="running" + current_step="ogr2ogr" + progress <
+next_progress``, so it re-checks the CURRENT row rather than trusting the
+earlier SELECT; zero rows affected means the job moved on, logged at debug,
+nothing written. The final three tests exercise this directly against a
+REAL race: ``_pause_the_tick_after_its_select`` pauses the tick
+DETERMINISTICALLY right after its own SELECT (not via a real row lock, and
+not via ``pg_stat_activity`` polling -- both were tried against the actual
+test database this suite runs against, a live dev stack shares it, so
+unrelated backends routinely show lock contention and connection-acquisition
+timing varies with how busy it is, and neither technique was reliable
+here), a second real session commits the competing write strictly between
+the tick's SELECT and its own write, then the tick resumes and its atomic
+UPDATE is checked against what actually landed.
 """
 
 import asyncio
@@ -66,6 +89,47 @@ async def _poll_until(predicate, *, timeout: float, interval: float = 0.01) -> b
             return True
         await asyncio.sleep(interval)
     return predicate()
+
+
+def _pause_the_tick_after_its_select(
+    monkeypatch,
+) -> tuple[asyncio.Event, asyncio.Event]:
+    """Deterministically pause ``_service_import_heartbeat_tick`` between its
+    own SELECT (inside ``_job_phase_session``) and whatever it does next, so
+    a test can commit a real, concurrent mutation to the row strictly
+    between the two -- the exact ordering fix(#1778 codex r11) closes a gap
+    for.
+
+    Wraps ``tasks_vector._job_phase_session`` (patched by name in
+    ``tasks_vector``'s own module namespace, where
+    ``_service_import_heartbeat_tick`` actually looks it up) so the real
+    SELECT still runs for real, against the real database. Two events
+    coordinate the two coroutines: ``reached_select`` fires once the SELECT
+    has returned and the wrapper is about to await ``resume_tick``, so the
+    caller knows exactly when it is safe to make its own concurrent
+    write -- no fixed sleep, no ``pg_stat_activity`` polling, which this
+    file's other tests measured as unreliable against the test database
+    this suite actually runs against (a live dev stack shares it, so many
+    unrelated backends can show lock contention at any moment, and
+    connection acquisition timing varies with how busy it is).
+    """
+    from contextlib import asynccontextmanager
+
+    from app.processing.ingest import tasks_common
+
+    reached_select = asyncio.Event()
+    resume_tick = asyncio.Event()
+    real_job_phase_session = tasks_common._job_phase_session
+
+    @asynccontextmanager
+    async def _paused_job_phase_session(*args, **kwargs):
+        async with real_job_phase_session(*args, **kwargs) as (session, job):
+            reached_select.set()
+            await resume_tick.wait()
+            yield session, job
+
+    monkeypatch.setattr(tasks_vector, "_job_phase_session", _paused_job_phase_session)
+    return reached_select, resume_tick
 
 
 @pytest.mark.anyio
@@ -429,3 +493,175 @@ async def test_a_tick_blocked_on_its_own_initial_select_times_out_inside_the_db_
     finally:
         event.remove(sync_engine, "checkout", _on_checkout)
         event.remove(sync_engine, "checkin", _on_checkin)
+
+
+@pytest.mark.anyio
+async def test_a_tick_that_loses_a_race_to_finalize_does_not_clobber_the_completed_job(
+    test_db_session, monkeypatch
+):
+    """fix(#1778 codex r11): the tick's own SELECT read the row as
+    "running"/"ogr2ogr" with progress=0.5. Pause the tick DETERMINISTICALLY
+    right after that SELECT (see ``_pause_the_tick_after_its_select`` below --
+    this test database is shared with a live dev stack, so timing- or
+    pg_stat_activity-based synchronization is not reliable enough here),
+    commit ``_finalize_ingest``'s effect (status="complete",
+    current_step="complete", progress=1.0) on a second, real session while
+    the tick is paused, then resume it. The tick's own UPDATE must re-check
+    its WHERE clause against the row Postgres just committed, not the stale
+    snapshot the tick read -- it must affect zero rows and leave the
+    finalized row untouched.
+    """
+    import app.core.db as db_module
+    from sqlalchemy import select, update
+
+    from app.platform.jobs.models import IngestJob as _IngestJob
+    from tests.factories import get_user_id
+
+    admin_id = await get_user_id(test_db_session, "admin")
+    job = IngestJob(
+        source_filename="RaceFinalizeHeartbeatJob",
+        created_by=admin_id,
+        status="running",
+        current_step="ogr2ogr",
+        progress=0.5,
+    )
+    test_db_session.add(job)
+    await test_db_session.flush()
+    await test_db_session.commit()
+    job_id = job.id
+    attempt_id = job.attempt_id
+
+    reached_select, resume_tick = _pause_the_tick_after_its_select(monkeypatch)
+
+    tick_task = asyncio.ensure_future(
+        tasks_vector._service_import_heartbeat_tick(job_id, attempt_id)
+    )
+    await asyncio.wait_for(reached_select.wait(), timeout=5.0)
+
+    # Simulate _finalize_ingest committing first, strictly between the
+    # tick's own SELECT and its write.
+    async with db_module.async_session() as finalizer_session:
+        await finalizer_session.execute(
+            update(_IngestJob)
+            .where(_IngestJob.id == job_id)
+            .values(status="complete", current_step="complete", progress=1.0)
+        )
+        await finalizer_session.commit()
+
+    resume_tick.set()
+    keep_going = await asyncio.wait_for(tick_task, timeout=5.0)
+    assert keep_going is True
+
+    async with db_module.async_session() as check_session:
+        result = await check_session.execute(
+            select(_IngestJob).where(_IngestJob.id == job_id)
+        )
+        final = result.scalar_one()
+    assert final.status == "complete"
+    assert final.current_step == "complete"
+    assert final.progress == 1.0, (
+        f"the tick's stale write clobbered the finalized job's progress: "
+        f"{final.progress!r}"
+    )
+
+
+@pytest.mark.anyio
+async def test_a_tick_that_loses_a_race_to_a_retry_does_not_write_into_the_new_attempt(
+    test_db_session, monkeypatch
+):
+    """Same race as above, but the row is claimed by a NEW attempt (a retry)
+    instead of finalized. The old tick's write is fenced to the OLD
+    attempt_id it was called with, so once the row's attempt_id has rotated
+    out from under it, the atomic UPDATE must affect zero rows -- the new
+    attempt's own progress must survive untouched.
+    """
+    import app.core.db as db_module
+    from sqlalchemy import select, update
+
+    from app.platform.jobs.models import IngestJob as _IngestJob
+    from tests.factories import get_user_id
+
+    admin_id = await get_user_id(test_db_session, "admin")
+    job = IngestJob(
+        source_filename="RaceRetryHeartbeatJob",
+        created_by=admin_id,
+        status="running",
+        current_step="ogr2ogr",
+        progress=0.5,
+    )
+    test_db_session.add(job)
+    await test_db_session.flush()
+    await test_db_session.commit()
+    job_id = job.id
+    old_attempt_id = job.attempt_id
+    new_attempt_id = uuid.uuid4()
+
+    reached_select, resume_tick = _pause_the_tick_after_its_select(monkeypatch)
+
+    tick_task = asyncio.ensure_future(
+        tasks_vector._service_import_heartbeat_tick(job_id, old_attempt_id)
+    )
+    await asyncio.wait_for(reached_select.wait(), timeout=5.0)
+
+    # Simulate a retry rotating attempt_id and restarting progress under the
+    # new token, strictly between the OLD tick's SELECT and its write.
+    async with db_module.async_session() as retry_session:
+        await retry_session.execute(
+            update(_IngestJob)
+            .where(_IngestJob.id == job_id)
+            .values(attempt_id=new_attempt_id, progress=0.2)
+        )
+        await retry_session.commit()
+
+    resume_tick.set()
+    keep_going = await asyncio.wait_for(tick_task, timeout=5.0)
+    assert keep_going is True
+
+    async with db_module.async_session() as check_session:
+        result = await check_session.execute(
+            select(_IngestJob).where(_IngestJob.id == job_id)
+        )
+        final = result.scalar_one()
+    assert final.attempt_id == new_attempt_id
+    assert final.status == "running"
+    assert final.progress == 0.2, (
+        f"the old attempt's stale write reached the new attempt's row: "
+        f"{final.progress!r}"
+    )
+
+
+@pytest.mark.anyio
+async def test_a_normal_tick_still_advances_progress(test_db_session):
+    """Positive control for the round-11 atomic UPDATE: with nothing racing
+    it, an ordinary tick must still advance progress exactly as the ORM
+    commit it replaces did."""
+    import app.core.db as db_module
+    from sqlalchemy import select
+
+    from app.platform.jobs.models import IngestJob as _IngestJob
+    from tests.factories import get_user_id
+
+    admin_id = await get_user_id(test_db_session, "admin")
+    job = IngestJob(
+        source_filename="NormalHeartbeatJob",
+        created_by=admin_id,
+        status="running",
+        current_step="ogr2ogr",
+        progress=0.2,
+    )
+    test_db_session.add(job)
+    await test_db_session.flush()
+    await test_db_session.commit()
+    job_id = job.id
+    attempt_id = job.attempt_id
+
+    keep_going = await tasks_vector._service_import_heartbeat_tick(job_id, attempt_id)
+    assert keep_going is True
+
+    async with db_module.async_session() as check_session:
+        result = await check_session.execute(
+            select(_IngestJob).where(_IngestJob.id == job_id)
+        )
+        refreshed = result.scalar_one()
+    expected = 0.2 + tasks_vector._SERVICE_IMPORT_HEARTBEAT_INCREMENT
+    assert refreshed.progress == pytest.approx(expected)

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -3885,7 +3885,19 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # cover that helper's own initial SELECT, which used to run before this
     # function's own `SET LOCAL` calls and could stall behind a lock the row
     # never got far enough to hit. Cap 1281 -> 1284, exact.
-    "backend/app/processing/ingest/tasks_vector.py": 1284,
+    # fix(#1778 codex r11): +49 — the tick's own SELECT is a snapshot, not a
+    # lock: if this shielded tick's connection stalls past the caller's
+    # cancellation drain, the caller moves on while the tick is still alive,
+    # and `_finalize_ingest` can commit status="complete"/progress=1.0 (or a
+    # retry can rotate attempt_id) before the tick's own commit runs. An
+    # unconditional ORM commit would then overwrite that finalized row by
+    # primary key with a stale progress. The write is now a single UPDATE
+    # gated on id + attempt_id + status="running" + current_step="ogr2ogr" +
+    # progress still below what it is about to write, matching the
+    # attempt-fenced shape `_finalize_ingest` already uses via
+    # `require_ingest_job_update`; zero rows affected logs at debug and does
+    # nothing. Cap 1284 -> 1333, exact.
+    "backend/app/processing/ingest/tasks_vector.py": 1333,
     # --- entered by the inclusion rule ------------------------------------
     # Crossed 1000 lines adding the "unable to open datasource" friendly-
     # message mapping shared by run_ogrinfo and run_ogr2ogr: the pattern

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -3856,7 +3856,15 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # (test_ingest_progress.py's service-worker-progress test, seen in the
     # merge queue). Cancellation can now only land at the `asyncio.sleep`
     # between ticks. Cap 1161 -> 1209, exact.
-    "backend/app/processing/ingest/tasks_vector.py": 1209,
+    # fix(#1778 codex r2): +36 — the shield alone bounded WHERE a cancel could
+    # land, not HOW LONG draining one could take: a tick stuck on something
+    # with no timeout of its own (another transaction's row lock inside
+    # `session.commit()`) could hang the drain, and with it `ingest_service`'s
+    # own `finally`, forever. `_SERVICE_IMPORT_HEARTBEAT_DRAIN_TIMEOUT_SECONDS`
+    # bounds it; `asyncio.shield` still keeps the tick itself running in the
+    # background on a timeout rather than cancelling it, so its connection
+    # still gets to close cleanly. Cap 1209 -> 1245, exact.
+    "backend/app/processing/ingest/tasks_vector.py": 1245,
     # --- entered by the inclusion rule ------------------------------------
     # Crossed 1000 lines adding the "unable to open datasource" friendly-
     # message mapping shared by run_ogrinfo and run_ogr2ogr: the pattern
@@ -4420,8 +4428,17 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # every valid subset of a wide table produced one set of bytes under its own
     # key. The key comes from the effective projection now, and each call site
     # says which of its inputs decide that.
+    # fix(#1778 codex r2): +26 — pmin/pmax/sigma are now validated only when
+    # the ACTIVE stretch mode reads them (percentile for pmin/pmax, stddev for
+    # sigma), not whenever merely present. frontend/nginx.conf's raster
+    # proxy_cache_key blanks an inactive value out of the cache key so a
+    # random one cannot defeat the cache, and that is only safe if "inactive"
+    # means the SAME thing, ignored, on both sides — otherwise a value nginx
+    # blanks could still turn a cached 200 into what would have been a 422.
+    # Most of the growth is the docstring and Query() description updates
+    # recording that contract for both parameters and the endpoint.
     # Ratchet stays exact.
-    "backend/app/processing/tiles/router.py": 2639,
+    "backend/app/processing/tiles/router.py": 2665,
     # feat(#565): the SQL sandbox validator crossed 1000 lines across the codex
     # rounds on the query endpoint: the lexical CTE-scope fix (P1) and its
     # pg_catalog.pg_user rationale, the declaration-order refinement (P1 r2),

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -3864,7 +3864,16 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # bounds it; `asyncio.shield` still keeps the tick itself running in the
     # background on a timeout rather than cancelling it, so its connection
     # still gets to close cleanly. Cap 1209 -> 1245, exact.
-    "backend/app/processing/ingest/tasks_vector.py": 1245,
+    # fix(#1778 codex r3): +36 — round 2's drain deadline bounded how long the
+    # caller would WAIT for a stuck tick, but the tick's own connection stayed
+    # checked out and blocked until whatever held the lock let go, so
+    # repeated stalls could still exhaust the pool. `_service_import_
+    # heartbeat_tick` now sets `lock_timeout`/`statement_timeout` on its own
+    # transaction, so a blocked commit fails INSIDE Postgres within a few
+    # seconds and releases its connection the ordinary way; the drain deadline
+    # survives only as a safety net for what a DB-side timeout cannot cover.
+    # Cap 1245 -> 1281, exact.
+    "backend/app/processing/ingest/tasks_vector.py": 1281,
     # --- entered by the inclusion rule ------------------------------------
     # Crossed 1000 lines adding the "unable to open datasource" friendly-
     # message mapping shared by run_ogrinfo and run_ogr2ogr: the pattern

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -3043,7 +3043,14 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # failure write down with it and the job sat `running` with no reason. Most
     # of the lines are the docstring and comment stating that the order is the
     # contract. Cap 2395 -> 2426, exact.
-    "backend/app/processing/ingest/tasks_common.py": 2426,
+    # fix(#1778 codex r6): +21 — `_job_phase_session` takes an optional
+    # `lock_and_statement_timeout_ms`, applied via `SET LOCAL` BEFORE its own
+    # SELECT rather than leaving a caller to set it after entering the
+    # context manager, where it could not protect that SELECT from stalling
+    # behind a lock the row's own later write would never see (e.g. an
+    # ACCESS EXCLUSIVE table lock). `None` by default, so every other caller
+    # of this shared helper is unchanged. Cap 2426 -> 2447, exact.
+    "backend/app/processing/ingest/tasks_common.py": 2447,
     # --- entered by the inclusion rule, feat(#1219 x #1222) ---------------
     # tasks_reupload crossed 1000 when two independently-reviewed features
     # met in one file: #1222's failed-contact bookkeeping (spawn-armed
@@ -3873,7 +3880,12 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # seconds and releases its connection the ordinary way; the drain deadline
     # survives only as a safety net for what a DB-side timeout cannot cover.
     # Cap 1245 -> 1281, exact.
-    "backend/app/processing/ingest/tasks_vector.py": 1281,
+    # fix(#1778 codex r6): +3 — the timeouts move into
+    # `_job_phase_session(lock_and_statement_timeout_ms=...)` so they also
+    # cover that helper's own initial SELECT, which used to run before this
+    # function's own `SET LOCAL` calls and could stall behind a lock the row
+    # never got far enough to hit. Cap 1281 -> 1284, exact.
+    "backend/app/processing/ingest/tasks_vector.py": 1284,
     # --- entered by the inclusion rule ------------------------------------
     # Crossed 1000 lines adding the "unable to open datasource" friendly-
     # message mapping shared by run_ogrinfo and run_ogr2ogr: the pattern

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -4458,8 +4458,22 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # blanks could still turn a cached 200 into what would have been a 422.
     # Most of the growth is the docstring and Query() description updates
     # recording that contract for both parameters and the endpoint.
+    # fix(#1778 codex r8): +41 — eff_pmin/eff_pmax/eff_sigma used to be
+    # resolved from "was the parameter merely present", independent of
+    # stretch mode, so an INACTIVE parameter's raw (unvalidated) request
+    # value still reached _fetch_band_statistics/_compute_stretch_rescale.
+    # `?stretch=stddev&pmin=1e309` (inf) reached `int(pmin)` there and
+    # raised an uncaught OverflowError, while nginx — which treats a value
+    # it blanks as harmless — found `1e309` inside its canonical float
+    # grammar and blanked it, sharing a cache key with a plain stddev
+    # request: a cached 200 once warm, a 500 cold. eff_pmin/eff_pmax/
+    # eff_sigma now gate on the SAME activity test the validation below
+    # already used, so an inactive parameter's raw value is never read by
+    # anything, and the validation itself now requires math.isfinite() on
+    # the active path explicitly rather than relying on inf/nan's
+    # comparison behavior to fail the existing bound check.
     # Ratchet stays exact.
-    "backend/app/processing/tiles/router.py": 2665,
+    "backend/app/processing/tiles/router.py": 2706,
     # feat(#565): the SQL sandbox validator crossed 1000 lines across the codex
     # rounds on the query endpoint: the lexical CTE-scope fix (P1) and its
     # pg_catalog.pg_user rationale, the declaration-order refinement (P1 r2),

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -3846,7 +3846,17 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # redacted message. Net of two hand-rolled UPDATE blocks and two now-unused
     # IngestJob imports removed; the rest is the comment saying which exit owns
     # the unlink decision. Cap 1143 -> 1161, exact.
-    "backend/app/processing/ingest/tasks_vector.py": 1161,
+    # fix(#1778): +48 — `_heartbeat_service_import_progress`'s per-tick session
+    # open/write/commit/close now runs under `asyncio.shield`, split into its
+    # own `_service_import_heartbeat_tick` helper so the loop can shield the
+    # whole thing. A `.cancel()` used to be able to land mid-connect or
+    # mid-commit; asyncpg does not always finish tearing a connection down
+    # cleanly when that happens, and the leftover surfaced later, against
+    # unrelated work, as `ConnectionError: unexpected connection_lost() call`
+    # (test_ingest_progress.py's service-worker-progress test, seen in the
+    # merge queue). Cancellation can now only land at the `asyncio.sleep`
+    # between ticks. Cap 1161 -> 1209, exact.
+    "backend/app/processing/ingest/tasks_vector.py": 1209,
     # --- entered by the inclusion rule ------------------------------------
     # Crossed 1000 lines adding the "unable to open datasource" friendly-
     # message mapping shared by run_ogrinfo and run_ogr2ogr: the pattern

--- a/backend/tests/test_nginx_raster_stretch_cache_key_1778.py
+++ b/backend/tests/test_nginx_raster_stretch_cache_key_1778.py
@@ -1,6 +1,6 @@
 """The raster tile cache key must not vary on an arg the active stretch mode
 ignores, and a cache HIT must never change what an uncached request would
-answer (#1778, codebase audit 2026-08-30; codex rounds 1-3 on #1791).
+answer (#1778, codebase audit 2026-08-30; codex rounds 1-4 on #1791).
 
 frontend/nginx.conf's raster_cache proxy_cache_key used to hold
 $arg_pmin/$arg_pmax/$arg_sigma unconditionally. In
@@ -13,52 +13,52 @@ byte-identical to the unfiltered tile, the same defeat #1785 closed for the
 vector tile ``cols=`` param.
 
 Round 1 blanked every inactive value unconditionally, which could let a
-cache HIT answer with a status an uncached request would not have gotten
-(raster_tile_proxy validated pmin/pmax/sigma whenever PRESENT, regardless of
-mode). Round 2 changed the API side instead of chasing that nginx-only fix
-further: raster_tile_proxy now IGNORES pmin/pmax when stretch is not
-percentile and sigma when it is not stddev, so blanking an inactive value
-can never disagree with the API about STATUS -- there is no verdict left to
-disagree with.
+cache HIT answer with a status an uncached request would not have gotten.
+Round 2 made raster_tile_proxy IGNORE pmin/pmax when stretch is not
+percentile and sigma when it is not stddev, instead of merely leaving them
+unvalidated, so blanking an inactive value can no longer disagree with the
+API about STATUS. Round 3 found nginx's raw read of the query string can
+still disagree with the API's decoded read about VALUE or MODE independent
+of validation (percent-encoded or case-varied `stretch`, a malformed float),
+and required an EXACT canonical spelling plus well-formedness before
+blanking.
 
-Round 3 found that round 2's API change is necessary but not sufficient,
-because nginx's read of the query string and the API's read of it can
-disagree about which VALUE, or even which MODE, is in play, independent of
-what the API validates or ignores:
+Round 4 found round 3's exact-spelling check assumed nginx's own $arg_NAME
+lookup is case-sensitive on the parameter NAME. It is not: nginx's arg
+matcher (ngx_http_arg -> ngx_strlcasestrn) is case-INSENSITIVE on the name,
+so $arg_stretch resolves from `Stretch=`, `STRETCH=`, etc, while FastAPI's
+query-param binding is exact-case. `?Stretch=minmax&stretch=percentile&pmin=5`
+had nginx read stretch=minmax (the first case-insensitive match, "inactive",
+blank pmin) while the API read stretch=percentile (the only EXACT-case
+match, active, uses pmin=5) -- a cache collision, not a status mismatch,
+because round 3's duplicate detector was itself case-sensitive-only and
+never saw this as a duplicate at all.
 
-- percent-encoding: ``stretch=%70ercentile`` decodes to the ACTIVE spelling
-  at the API (FastAPI URL-decodes query params) but nginx's raw
-  ``$arg_stretch`` never matches ``percentile`` literally. Treating "not the
-  literal active spelling" as "therefore inactive" blanked pmin here, so two
-  requests with different pmin values collapsed onto ONE key while the API
-  rendered DIFFERENT bytes for them: a cache collision, not a status
-  mismatch.
-- a case variant (``MinMax``), for the same reason (nginx's regex is
-  case-sensitive and never normalizes).
-- a malformed float (``pmin=abc``): the API's "ignore when inactive" code in
-  ``raster_tile_proxy`` never runs for this, because FastAPI's
-  ``pmin: float | None`` coerces the query param to a ``float`` BEFORE the
-  endpoint body executes at all, and ``abc`` fails that coercion with a 422
-  regardless of stretch mode. Blanking it let a cached 200 answer a request
-  the API 422s uncached.
-
-The principle that closes all three the same way: blank an argument ONLY
-when nginx can be CERTAIN blanking cannot change the outcome -- the raw
-``$arg_stretch`` is EXACTLY one of the canonical spellings this argument is
-inactive under (no percent-encoding, no case variant: PCRE matches the
-literal, decoded string only) AND the argument itself is a well-formed float
-in the range that matters in the one mode where it IS active. Everything
-else -- an unrecognized stretch spelling, a duplicated one
-($geolens_raster_stretch_dup), a malformed or merely out-of-range value -- is
-left RAW: the request misses the cache and the API decides on its own terms.
-Failing toward "keep raw" only ever costs an extra cache miss; failing
-toward "blank" risks a wrong tile or a wrong status.
+The round-4 rule: blanking is allowed ONLY when $args is in STRICT CANONICAL
+FORM -- each of stretch/pmin/pmax/sigma appears at most once (checked
+CASE-INSENSITIVELY), every occurrence of each is spelled EXACTLY lowercase,
+and none is percent-encoded. $geolens_raster_noncanonical checks this
+directly against the raw $args string (not derived from any single $arg_*
+lookup, so it cannot inherit nginx's own case-insensitivity or decoding
+blind spots). When non-canonical, $geolens_raster_cache_extra folds the
+ENTIRE raw $args into the cache key, so correctness there is independent of
+any per-parameter reasoning: two requests share a key in the non-canonical
+case if and only if their raw query strings are identical.
 
 These are structural (they read the conf and simulate nginx's own map
-evaluation in Python, including nginx's $arg_x "first occurrence of a
-repeated key" semantics and its PCRE case-sensitivity), because there is no
-nginx binary in this test environment to render and query directly. The
-companion API-level pin lives in test_raster_colormap_proxy.py::
+evaluation in Python), because there is no nginx binary in this test
+environment to render and query directly. The simulation models nginx's
+actual matching semantics precisely where it matters here:
+  - $arg_NAME lookup is case-INSENSITIVE on the name (see _nginx_arg).
+  - map regex matching searches the WHOLE string (like re.search), not
+    anchored at position 0 (like re.match) -- a pattern such as
+    ``(?:^|&)stretch=.*(?:^|&)stretch=`` must still find a duplicate whose
+    first occurrence is not at the very start of $args.
+  - a map entry's regex can independently be case-sensitive (``~pattern``)
+    or case-insensitive (``~*pattern``), exactly as nginx's map directive
+    supports per entry.
+
+The companion API-level pin lives in test_raster_colormap_proxy.py::
 TestRasterColormapProxy::
 test_out_of_range_bounds_are_ignored_under_an_inactive_stretch_mode, which
 confirms the API side of the contract these maps rely on: pmin/pmax/sigma
@@ -81,19 +81,23 @@ _PROXY_CACHE_KEY = re.compile(r'^\s*proxy_cache_key\s+"([^"]+)"\s*;', re.M)
 # (unquoted source template, dest var) for each per-parameter map.
 _MAPS: dict[str, tuple[str, str]] = {
     "pmin": (
-        "$geolens_raster_stretch_dup:$arg_stretch:$arg_pmin",
+        "$geolens_raster_noncanonical:$arg_stretch:$arg_pmin",
         "$geolens_raster_pmin",
     ),
     "pmax": (
-        "$geolens_raster_stretch_dup:$arg_stretch:$arg_pmax",
+        "$geolens_raster_noncanonical:$arg_stretch:$arg_pmax",
         "$geolens_raster_pmax",
     ),
     "sigma": (
-        "$geolens_raster_stretch_dup:$arg_stretch:$arg_sigma",
+        "$geolens_raster_noncanonical:$arg_stretch:$arg_sigma",
         "$geolens_raster_sigma",
     ),
 }
-_DUP_MAP: tuple[str, str] = ("$args", "$geolens_raster_stretch_dup")
+_NONCANONICAL_MAP: tuple[str, str] = ("$args", "$geolens_raster_noncanonical")
+_CACHE_EXTRA_MAP: tuple[str, str] = (
+    "$geolens_raster_noncanonical:$args",
+    "$geolens_raster_cache_extra",
+)
 
 
 def _without_comments(text: str) -> str:
@@ -139,16 +143,21 @@ def _map_body(text: str, source_expr: str, dest_var: str) -> str:
     )
 
 
-def _map_entries_ordered(body: str) -> tuple[list[tuple[str, str]], str]:
-    """``([(pattern_without_tilde, value_template), ...], default_template)``.
+def _map_entries_ordered(
+    body: str,
+) -> tuple[list[tuple[str, bool, str]], str]:
+    """``([(pattern_without_prefix, case_insensitive, value_template), ...],
+    default_template)``.
 
     Declaration order is preserved, since nginx tries regex entries in the
-    order they were written and the first match wins. Asserts every non-default
-    entry is a regex (``~``-prefixed) -- a literal entry slipping in would be
-    matched by nginx's hash lookup instead, which this simulation does not
-    model, and a silent mismatch there is worse than a loud assertion here.
+    order they were written and the first match wins. Each entry's prefix is
+    either ``~`` (case-sensitive) or ``~*`` (case-insensitive), exactly as
+    nginx's map directive supports per entry -- a literal (non-regex) entry
+    slipping in would be matched by nginx's hash lookup instead, which this
+    simulation does not model, and a silent mismatch there is worse than a
+    loud assertion here.
     """
-    entries: list[tuple[str, str]] = []
+    entries: list[tuple[str, bool, str]] = []
     default_value: str | None = None
     for line in body.splitlines():
         line = line.strip().rstrip(";")
@@ -159,22 +168,26 @@ def _map_entries_ordered(body: str) -> tuple[list[tuple[str, str]], str]:
         value = value.strip().strip('"')
         if key == "default":
             default_value = value
+        elif key.startswith("~*"):
+            entries.append((key[2:], True, value))
+        elif key.startswith("~"):
+            entries.append((key[1:], False, value))
         else:
-            assert key.startswith("~"), f"expected a regex map entry, got {key!r}"
-            entries.append((key[1:], value))
+            raise AssertionError(f"expected a regex map entry, got {key!r}")
     assert default_value is not None, "map has no default entry"
     return entries, default_value
 
 
 def _nginx_arg(args_string: str, name: str) -> str:
     """nginx's ``$arg_NAME``: the value of the FIRST occurrence of ``name`` in
-    the raw query string, or "" if absent. nginx does not URL-decode $arg_*,
-    and neither does this."""
+    the raw query string, matched CASE-INSENSITIVELY on the name (nginx's
+    ngx_http_arg uses ngx_strlcasestrn, fix(#1778 codex r4)) -- and never
+    URL-decoded."""
     for pair in args_string.split("&"):
         if not pair:
             continue
         key, _, value = pair.partition("=")
-        if key == name:
+        if key.lower() == name.lower():
             return value
     return ""
 
@@ -191,16 +204,24 @@ def _expand(template: str, values: dict[str, str]) -> str:
 
 def _evaluate_map(
     source_template: str,
-    entries: list[tuple[str, str]],
+    entries: list[tuple[str, bool, str]],
     default_value: str,
     values: dict[str, str],
 ) -> str:
     """Evaluate one nginx ``map`` the way nginx itself would: try each regex
-    entry in declaration order (PCRE, case-sensitive, exactly as nginx's
-    default), first match wins; ``default`` otherwise."""
+    entry in declaration order, first match wins; ``default`` otherwise.
+
+    Uses ``re.search``, not ``re.match``: nginx's map regex testing searches
+    the whole string rather than anchoring at position 0, so a pattern like
+    ``(?:^|&)stretch=.*(?:^|&)stretch=`` must find a duplicate even when the
+    first occurrence of the name is not at the very start of $args. A
+    genuinely anchored pattern (``^...$``) behaves identically under either,
+    since ``^``/``$`` still assert the true start/end of the string.
+    """
     source = _expand(source_template, values)
-    for pattern, template in entries:
-        if re.match(pattern, source):
+    for pattern, case_insensitive, template in entries:
+        flags = re.IGNORECASE if case_insensitive else 0
+        if re.search(pattern, source, flags):
             return _expand(template, values)
     return _expand(default_value, values)
 
@@ -209,25 +230,39 @@ def _conf() -> str:
     return _without_comments(NGINX_CONF.read_text())
 
 
-def _stretch_dup(conf: str, args_string: str) -> str:
-    """``$geolens_raster_stretch_dup`` for a raw query string."""
-    source_expr, dest_var = _DUP_MAP
+def _noncanonical(conf: str, args_string: str) -> str:
+    """``$geolens_raster_noncanonical`` for a raw query string."""
+    source_expr, dest_var = _NONCANONICAL_MAP
     entries, default_value = _map_entries_ordered(
         _map_body(conf, source_expr, dest_var)
     )
     return _evaluate_map(source_expr, entries, default_value, {"args": args_string})
 
 
+def _cache_extra(conf: str, args_string: str) -> str:
+    """``$geolens_raster_cache_extra`` for a raw query string."""
+    source_expr, dest_var = _CACHE_EXTRA_MAP
+    entries, default_value = _map_entries_ordered(
+        _map_body(conf, source_expr, dest_var)
+    )
+    values = {
+        "geolens_raster_noncanonical": _noncanonical(conf, args_string),
+        "args": args_string,
+    }
+    return _evaluate_map(source_expr, entries, default_value, values)
+
+
 def _derive(conf: str, param: str, args_string: str) -> str:
     """The cache-key value nginx would compute for ``param`` given the raw
-    query string ``args_string`` -- $arg_x's first-occurrence semantics and
-    the duplicate-stretch guard both apply, exactly as nginx would."""
+    query string ``args_string`` -- $arg_x's case-insensitive,
+    first-occurrence semantics and the canonical-form guard both apply,
+    exactly as nginx would."""
     source_template, dest_var = _MAPS[param]
     entries, default_value = _map_entries_ordered(
         _map_body(conf, source_template, dest_var)
     )
     values = {
-        "geolens_raster_stretch_dup": _stretch_dup(conf, args_string),
+        "geolens_raster_noncanonical": _noncanonical(conf, args_string),
         "arg_stretch": _nginx_arg(args_string, "stretch"),
         f"arg_{param}": _nginx_arg(args_string, param),
     }
@@ -246,7 +281,8 @@ def _qs(**params: str) -> str:
 
 def test_cache_key_does_not_hold_the_raw_stretch_args():
     """The raw args must not appear in proxy_cache_key at all -- only the
-    mapped variables that blank what the active stretch mode ignores."""
+    mapped variables that blank what the active stretch mode ignores, plus
+    the non-canonical escape hatch."""
     conf = _conf()
     match = _PROXY_CACHE_KEY.search(_location_block(conf, RASTER_TILES_LOCATION))
     assert match, "expected a proxy_cache_key in the /raster-tiles/ location"
@@ -262,14 +298,15 @@ def test_cache_key_does_not_hold_the_raw_stretch_args():
         "$geolens_raster_pmin",
         "$geolens_raster_pmax",
         "$geolens_raster_sigma",
+        "$geolens_raster_cache_extra",
     ):
         assert mapped_var in key, f"expected {mapped_var} in proxy_cache_key: {key!r}"
 
 
 # ---------------------------------------------------------------------------
-# pmin / pmax: percentile is the active mode; sigma: stddev is. Round 3:
-# blank ONLY when stretch is an EXACT canonical inactive spelling AND the
-# value is a well-formed float in range -- everything else stays raw.
+# pmin / pmax: percentile is the active mode; sigma: stddev is. Blank ONLY
+# when stretch is an EXACT canonical inactive spelling AND the value is a
+# well-formed float in range -- everything else stays raw (round 3).
 # ---------------------------------------------------------------------------
 
 
@@ -303,10 +340,13 @@ def test_well_formed_value_under_a_canonical_inactive_mode_collapses_to_one_key(
         assert {
             _derive(conf, "sigma", _qs(stretch=stretch, sigma=v)) for v in sigma_values
         } == {""}
-    # stddev is the OTHER canonical inactive spelling for pmin/pmax.
     assert {
         _derive(conf, "pmin", _qs(stretch="stddev", pmin=v)) for v in pmin_pmax_values
     } == {""}
+    for value in pmin_pmax_values:
+        assert _cache_extra(conf, _qs(stretch="minmax", pmin=value)) == "", (
+            "a canonical request must not add anything to the cache key"
+        )
 
 
 def test_sigma_still_varies_the_key_under_stddev():
@@ -329,10 +369,7 @@ def test_sigma_still_varies_the_key_under_stddev():
 def test_out_of_range_value_under_a_canonical_inactive_mode_stays_raw():
     """A value the well-formedness check rejects (out of [0, 100] for
     pmin/pmax, not > 0 for sigma) stays RAW even under an exact canonical
-    inactive spelling -- the conservative direction the coordinator's
-    principle asks for: some legitimate-but-unusual values miss the cache
-    that technically could not have changed the answer either, in exchange
-    for never needing a more permissive, harder-to-audit numeric regex."""
+    inactive spelling."""
     conf = _conf()
     for bad in ("200", "-5", "101", "100.5"):
         assert _derive(conf, "pmin", _qs(stretch="minmax", pmin=bad)) == bad
@@ -342,9 +379,10 @@ def test_out_of_range_value_under_a_canonical_inactive_mode_stays_raw():
 
 
 # ---------------------------------------------------------------------------
-# fix(#1778 codex r3): the three ways nginx's raw read of the query string
-# can disagree with the API's decoded/coerced read, independent of what the
-# API validates or ignores. Each must stay raw, never blank.
+# fix(#1778 codex r3): percent-encoded/case-varied VALUES of stretch, and
+# malformed float values, must stay raw. These are canonical-form requests
+# (one exact-lowercase name each), so $geolens_raster_cache_extra is empty
+# for them -- the per-parameter fallback alone closes these.
 # ---------------------------------------------------------------------------
 
 
@@ -362,103 +400,166 @@ def test_percent_encoded_active_spelling_stays_raw():
     derived_50 = _derive(conf, "pmin", args_50)
     assert derived_5 == "5"
     assert derived_50 == "50"
-    assert derived_5 != derived_50, (
-        "a percent-encoded active stretch spelling must not let two "
-        "different pmin values collapse onto one cache key"
-    )
-
-
-def test_case_variant_of_a_canonical_spelling_stays_raw():
-    """PCRE matching here is case-sensitive by default, same as FastAPI's
-    Literal validator (which would 422 `MinMax` as an invalid literal value
-    -- not decode-and-normalize it the way percent-encoding is decoded). A
-    case variant must never be treated as the canonical inactive spelling."""
-    conf = _conf()
-    for variant in ("MinMax", "MINMAX", "Stddev", "PERCENTILE"):
-        derived = _derive(conf, "pmin", _qs(stretch=variant, pmin="5"))
-        assert derived == "5", (
-            f"stretch={variant!r} must keep pmin raw (got {derived!r}) -- "
-            "nginx must never treat a case variant as a canonical spelling"
-        )
+    assert derived_5 != derived_50
 
 
 def test_malformed_float_under_an_inactive_mode_stays_raw():
-    """`?stretch=minmax&pmin=abc` must miss the cache, not collapse onto the
-    plain `?stretch=minmax` key. FastAPI's `pmin: float | None` coerces the
-    query param to a float BEFORE raster_tile_proxy's body runs at all --
-    round 2's "ignore pmin when inactive" code never gets a chance to run,
-    because the framework's own type coercion 422s on a non-numeric string
-    regardless of stretch mode. Blanking it here would let a cached 200
-    answer that 422.
-
-    Values chosen to be unambiguously non-numeric -- not merely large or
-    signed, both of which Python's own float() parser (and therefore
-    pydantic's coercion) accepts without a 422, and which the well-formed
-    numeric regex already keeps raw for the "out of range" reason covered
-    separately above.
-    """
+    """`?stretch=minmax&pmin=abc` must miss the cache. FastAPI's
+    `pmin: float | None` coerces the query param to a float BEFORE
+    raster_tile_proxy's body runs at all, and `abc` fails that coercion with
+    a 422 regardless of stretch mode."""
     conf = _conf()
     for bad in ("abc", "5,6", "50:60", "1.2.3", "five"):
         derived = _derive(conf, "pmin", _qs(stretch="minmax", pmin=bad))
-        assert derived == bad, (
-            f"pmin={bad!r} under stretch=minmax must stay RAW (got "
-            f"{derived!r}) -- FastAPI's float coercion 422s this regardless "
-            "of stretch mode, and blanking it would let a cache hit answer "
-            "a 200 for what an uncached request 422s"
-        )
+        assert derived == bad
     for bad in ("abc", "1,2", "5.6.7"):
         derived = _derive(conf, "sigma", _qs(stretch="minmax", sigma=bad))
         assert derived == bad
 
 
 # ---------------------------------------------------------------------------
-# Duplicate `pmin`/`pmax`/`sigma`: closed by ignoring the inactive value
-# entirely at the API AND requiring well-formedness at nginx, so which
-# occurrence either side reads matters only when it changes well-formedness.
+# fix(#1778 codex r4): the four names are matched CASE-INSENSITIVELY by
+# nginx's own $arg_NAME lookup, and a case variant or percent-encoded name
+# anywhere makes the WHOLE request non-canonical -- $geolens_raster_
+# cache_extra then folds the entire raw $args into the key, independent of
+# what any single per-parameter map would have derived.
 # ---------------------------------------------------------------------------
 
 
-def test_repeated_well_formed_inactive_param_collapses_regardless_of_occurrence_order():
-    """Both duplicate occurrences are well-formed and in range, so nginx's
-    FIRST-occurrence read and the API's LAST-occurrence read are both
-    ignored identically under stretch=minmax -- collapsing is safe regardless
-    of which one nginx happens to see."""
+def test_mixed_case_duplicate_is_noncanonical_and_the_whole_args_breaks_the_tie():
+    """codex round 4's exact finding: nginx's $arg_stretch is case-
+    INSENSITIVE, so it resolves `Stretch=minmax` (the first case-insensitive
+    match) while FastAPI's exact-case binding resolves the later
+    `stretch=percentile` -- a mode disagreement round 3's case-sensitive-only
+    duplicate detector could not see. Two requests differing only in pmin
+    must not share a key."""
     conf = _conf()
-    a = _derive(conf, "pmin", "stretch=minmax&pmin=5&pmin=50")
-    b = _derive(conf, "pmin", "stretch=minmax&pmin=50&pmin=5")
-    assert a == b == "", f"got {a!r} and {b!r}, expected both blank"
+    args_5 = "Stretch=minmax&stretch=percentile&pmin=5"
+    args_50 = "Stretch=minmax&stretch=percentile&pmin=50"
+    assert _noncanonical(conf, args_5) == "1"
+    assert _noncanonical(conf, args_50) == "1"
+    extra_5 = _cache_extra(conf, args_5)
+    extra_50 = _cache_extra(conf, args_50)
+    assert extra_5 == args_5
+    assert extra_50 == args_50
+    assert extra_5 != extra_50, (
+        "a mixed-case duplicated stretch must not let two different pmin "
+        "values collapse onto one cache key"
+    )
+
+
+def test_mixed_case_single_occurrence_is_noncanonical():
+    """No duplicate at all -- just one `Stretch=minmax` -- but FastAPI
+    ignores it entirely (exact-case key lookup finds nothing named
+    `stretch`) while nginx's case-insensitive $arg_stretch still resolves
+    it. Must stay non-canonical regardless of the specific value, so this
+    class cannot recur through a future change in what the API's absent-
+    stretch default happens to render."""
+    conf = _conf()
+    args = "Stretch=minmax&pmin=5"
+    assert _noncanonical(conf, args) == "1"
+    assert _cache_extra(conf, args) == args
+
+
+def test_encoded_name_is_noncanonical():
+    """`%73tretch=percentile` decodes to the key `stretch` at the API
+    (FastAPI URL-decodes query keys) but nginx never decodes $arg_* keys, so
+    $arg_stretch resolves to "" here (no literal `stretch=` substring) --
+    the API's real active mode is invisible to nginx entirely."""
+    conf = _conf()
+    args = "%73tretch=percentile&pmin=5"
+    assert _noncanonical(conf, args) == "1"
+    assert _cache_extra(conf, args) == args
+
+
+def test_uppercase_and_all_caps_variants_of_every_name_are_noncanonical():
+    conf = _conf()
+    for variant_args in (
+        "STRETCH=minmax&pmin=5",
+        "stretch=minmax&PMIN=5",
+        "stretch=minmax&Pmax=5",
+        "stretch=stddev&SIGMA=2",
+    ):
+        assert _noncanonical(conf, variant_args) == "1", variant_args
+
+
+def test_case_insensitive_duplicate_of_pmin_pmax_sigma_is_noncanonical():
+    """The duplicate check itself must be case-insensitive for all four
+    names, not just stretch."""
+    conf = _conf()
+    for variant_args in (
+        "stretch=minmax&pmin=5&Pmin=200",
+        "stretch=minmax&pmax=5&PMAX=200",
+        "stretch=stddev&sigma=2&Sigma=200",
+    ):
+        assert _noncanonical(conf, variant_args) == "1", variant_args
+
+
+def test_ordinary_canonical_request_is_unaffected():
+    """The guard must not fire on the common path: exact lowercase names,
+    each at most once, well-formed values."""
+    conf = _conf()
+    for args in (
+        "stretch=minmax&pmin=5",
+        "stretch=percentile&pmin=5&pmax=95",
+        "stretch=stddev&sigma=3",
+        "z=1",  # no stretch/pmin/pmax/sigma at all
+    ):
+        assert _noncanonical(conf, args) == "0", args
+        assert _cache_extra(conf, args) == "", args
+
+
+def test_duplicate_detection_finds_a_duplicate_not_starting_at_position_zero():
+    """Regression guard for the simulation itself (fix(#1778 codex r4)): the
+    map regex must be evaluated as an unanchored SEARCH, matching nginx's own
+    semantics, not a Python re.match anchored at position 0 -- otherwise a
+    duplicate whose first occurrence isn't the very first key in $args would
+    be silently missed by this test suite while nginx itself still finds
+    it."""
+    conf = _conf()
+    assert _noncanonical(conf, "pmin=5&stretch=minmax&stretch=percentile") == "1"
+    assert _noncanonical(conf, "colormap_name=x&pmin=5&Pmin=200") == "1"
+
+
+# ---------------------------------------------------------------------------
+# Duplicate `pmin`/`pmax`/`sigma` (exact lowercase, round 2/3): closed by
+# ignoring the inactive value entirely at the API AND requiring
+# well-formedness at nginx, so which occurrence either side reads matters
+# only when it changes well-formedness.
+# ---------------------------------------------------------------------------
+
+
+def test_a_repeated_pmin_is_noncanonical_even_when_both_occurrences_are_well_formed():
+    """fix(#1778 codex r4): strict canonical form requires each of the four
+    names to appear AT MOST ONCE, full stop -- not merely "blank is safe
+    here" reasoning about what the duplicate values happen to be. A
+    repeated pmin, even same-case and even with both occurrences well-formed
+    and in range, is therefore non-canonical and stays raw: nginx's own
+    first-occurrence reading differs between these two requests (5 vs 50),
+    so they get different keys either way -- safe by keeping raw, not by
+    collapsing."""
+    conf = _conf()
+    args_a = "stretch=minmax&pmin=5&pmin=50"
+    args_b = "stretch=minmax&pmin=50&pmin=5"
+    assert _noncanonical(conf, args_a) == "1"
+    assert _noncanonical(conf, args_b) == "1"
+    a = _derive(conf, "pmin", args_a)
+    b = _derive(conf, "pmin", args_b)
+    assert a == "5"
+    assert b == "50"
+    assert a != b
 
 
 def test_repeated_param_stays_raw_when_the_first_occurrence_is_not_well_formed():
     """codex's literal example: nginx reads the FIRST occurrence of a
     repeated pmin. When that first occurrence is out of range or malformed,
     nginx must keep it raw regardless of what the API's LAST-occurrence read
-    would have been -- the well-formedness gate applies to whichever
-    occurrence nginx actually sees, not to some notion of "the pair"."""
+    would have been."""
     conf = _conf()
     out_of_range_first = _derive(conf, "pmin", "stretch=minmax&pmin=200&pmin=5")
     malformed_first = _derive(conf, "pmin", "stretch=minmax&pmin=abc&pmin=5")
     assert out_of_range_first == "200"
     assert malformed_first == "abc"
-
-
-# ---------------------------------------------------------------------------
-# Duplicate `stretch`: nginx and the API can disagree about which mode is
-# ACTIVE. $geolens_raster_stretch_dup detects this and falls back to raw.
-# ---------------------------------------------------------------------------
-
-
-def test_stretch_dup_detects_a_repeated_stretch_key():
-    conf = _conf()
-    assert _stretch_dup(conf, "stretch=minmax&pmin=5") == "0"
-    assert _stretch_dup(conf, "pmin=5") == "0"
-    assert _stretch_dup(conf, "stretch=percentile") == "0"
-    assert _stretch_dup(conf, "stretch=minmax&stretch=percentile&pmin=5") == "1"
-    assert _stretch_dup(conf, "stretch=percentile&pmin=5&stretch=minmax") == "1"
-    # A repeat of the SAME value is still a repeat -- harmless (nginx and the
-    # API necessarily agree), but detected the same way; the raw-fallback
-    # this triggers is safe either way, just occasionally unnecessary.
-    assert _stretch_dup(conf, "stretch=minmax&stretch=minmax&pmin=5") == "1"
 
 
 def test_duplicated_stretch_falls_back_to_the_raw_value_instead_of_blanking():
@@ -472,14 +573,8 @@ def test_duplicated_stretch_falls_back_to_the_raw_value_instead_of_blanking():
     conf = _conf()
     args_a = "stretch=minmax&stretch=percentile&pmin=5"
     args_b = "stretch=minmax&stretch=percentile&pmin=50"
-    derived_a = _derive(conf, "pmin", args_a)
-    derived_b = _derive(conf, "pmin", args_b)
-    assert derived_a == "5"
-    assert derived_b == "50"
-    assert derived_a != derived_b, (
-        "a duplicated stretch must not let two different pmin values "
-        "collapse onto one cache key"
-    )
+    assert _noncanonical(conf, args_a) == "1"
+    assert _cache_extra(conf, args_a) != _cache_extra(conf, args_b)
 
 
 def test_non_duplicated_stretch_is_unaffected_by_the_guard():

--- a/backend/tests/test_nginx_raster_stretch_cache_key_1778.py
+++ b/backend/tests/test_nginx_raster_stretch_cache_key_1778.py
@@ -1,6 +1,6 @@
 """The raster tile cache key must not vary on an arg the active stretch mode
 ignores, and a cache HIT must never change what an uncached request would
-answer (#1778, codebase audit 2026-08-30; codex rounds 1-5 on #1791).
+answer (#1778, codebase audit 2026-08-30; codex rounds 1-6 on #1791).
 
 frontend/nginx.conf's raster_cache proxy_cache_key used to hold
 $arg_pmin/$arg_pmax/$arg_sigma unconditionally. In
@@ -63,6 +63,25 @@ its semantic range -- and keep raw only what FastAPI cannot parse at all
 (its 422 path, unaffected by round 5, still covered by
 test_malformed_float_under_an_inactive_mode_stays_raw).
 
+Round 6 found round 4's fix for the non-canonical case introduced a new
+problem while closing the collision: $geolens_raster_cache_extra folded the
+ENTIRE raw $args into proxy_cache_key, and this endpoint accepts the
+deprecated ?api_key= query lane (_resolve_api_key,
+app/modules/auth/dependencies.py), so a non-canonical request carrying one
+wrote that credential, in the clear, into the cache key -- reachable
+through raster_cache's on-disk files and any backup of them, even though
+access logging already strips query strings for exactly this reason.
+
+The round-6 rule: proxy_cache_key must be built ONLY from the sanitised
+$geolens_raster_* variables (plus $dataset_id/$z/$x/$y/$fmt/$arg_v/
+$arg_colormap_name/$arg_stretch, none of which can carry a credential) --
+never raw $args, never any other raw $arg_*. A non-canonical request is
+instead served UNCACHED: $geolens_raster_noncanonical now also drives
+proxy_cache_bypass and proxy_no_cache on the raster-tiles location, so
+bypass skips the lookup and no_cache skips the store, and nothing about
+that request -- credential included -- is ever written to the cache at
+all. $geolens_raster_cache_extra and its map are gone.
+
 These are structural (they read the conf and simulate nginx's own map
 evaluation in Python), because there is no nginx binary in this test
 environment to render and query directly. The simulation models nginx's
@@ -112,10 +131,6 @@ _MAPS: dict[str, tuple[str, str]] = {
     ),
 }
 _NONCANONICAL_MAP: tuple[str, str] = ("$args", "$geolens_raster_noncanonical")
-_CACHE_EXTRA_MAP: tuple[str, str] = (
-    "$geolens_raster_noncanonical:$args",
-    "$geolens_raster_cache_extra",
-)
 
 
 def _without_comments(text: str) -> str:
@@ -257,19 +272,6 @@ def _noncanonical(conf: str, args_string: str) -> str:
     return _evaluate_map(source_expr, entries, default_value, {"args": args_string})
 
 
-def _cache_extra(conf: str, args_string: str) -> str:
-    """``$geolens_raster_cache_extra`` for a raw query string."""
-    source_expr, dest_var = _CACHE_EXTRA_MAP
-    entries, default_value = _map_entries_ordered(
-        _map_body(conf, source_expr, dest_var)
-    )
-    values = {
-        "geolens_raster_noncanonical": _noncanonical(conf, args_string),
-        "args": args_string,
-    }
-    return _evaluate_map(source_expr, entries, default_value, values)
-
-
 def _derive(conf: str, param: str, args_string: str) -> str:
     """The cache-key value nginx would compute for ``param`` given the raw
     query string ``args_string`` -- $arg_x's case-insensitive,
@@ -287,6 +289,22 @@ def _derive(conf: str, param: str, args_string: str) -> str:
     return _evaluate_map(source_template, entries, default_value, values)
 
 
+_PROXY_CACHE_BYPASS = re.compile(r"^\s*proxy_cache_bypass\s+([^;]+);", re.M)
+_PROXY_NO_CACHE = re.compile(r"^\s*proxy_no_cache\s+([^;]+);", re.M)
+
+
+def _cache_bypass_vars(conf: str) -> tuple[list[str], list[str]]:
+    """The variable lists ``proxy_cache_bypass``/``proxy_no_cache`` reference
+    in the /raster-tiles/ location, or ``[]`` if the directive is absent."""
+    block = _location_block(conf, RASTER_TILES_LOCATION)
+    bypass = _PROXY_CACHE_BYPASS.search(block)
+    no_cache = _PROXY_NO_CACHE.search(block)
+    return (
+        bypass.group(1).split() if bypass else [],
+        no_cache.group(1).split() if no_cache else [],
+    )
+
+
 def _qs(**params: str) -> str:
     """Build a raw query string, preserving insertion order (dict order)."""
     return "&".join(f"{k}={v}" for k, v in params.items())
@@ -299,8 +317,7 @@ def _qs(**params: str) -> str:
 
 def test_cache_key_does_not_hold_the_raw_stretch_args():
     """The raw args must not appear in proxy_cache_key at all -- only the
-    mapped variables that blank what the active stretch mode ignores, plus
-    the non-canonical escape hatch."""
+    mapped variables that blank what the active stretch mode ignores."""
     conf = _conf()
     match = _PROXY_CACHE_KEY.search(_location_block(conf, RASTER_TILES_LOCATION))
     assert match, "expected a proxy_cache_key in the /raster-tiles/ location"
@@ -316,9 +333,62 @@ def test_cache_key_does_not_hold_the_raw_stretch_args():
         "$geolens_raster_pmin",
         "$geolens_raster_pmax",
         "$geolens_raster_sigma",
-        "$geolens_raster_cache_extra",
     ):
         assert mapped_var in key, f"expected {mapped_var} in proxy_cache_key: {key!r}"
+
+
+def test_cache_key_never_includes_raw_args_or_a_credential_name():
+    """fix(#1778 codex r6): $geolens_raster_cache_extra used to fold the
+    ENTIRE raw $args into this key for a non-canonical request, and this
+    endpoint accepts the deprecated ?api_key= query lane
+    (_resolve_api_key, app/modules/auth/dependencies.py). A raw $args (or
+    any single unsanitised $arg_*) in the key means that credential lands,
+    in the clear, in raster_cache's on-disk cache files and any backup of
+    them. The key must be built ONLY from the named, sanitised variables --
+    never $args, never a bare reference to a credential-carrying name."""
+    conf = _conf()
+    match = _PROXY_CACHE_KEY.search(_location_block(conf, RASTER_TILES_LOCATION))
+    assert match
+    key = match.group(1)
+    assert "$args" not in key, f"proxy_cache_key embeds the raw query string: {key!r}"
+    for credential_name in ("api_key", "token", "authorization"):
+        assert credential_name not in key.lower(), (
+            f"proxy_cache_key mentions {credential_name!r}: {key!r}"
+        )
+
+
+def test_noncanonical_requests_bypass_the_cache_instead_of_being_keyed_on_it():
+    """fix(#1778 codex r6): rather than keying a non-canonical request on
+    anything (which is how the $args/credential leak happened), it must be
+    served UNCACHED -- $geolens_raster_noncanonical drives BOTH
+    proxy_cache_bypass (skip the lookup) and proxy_no_cache (skip the
+    store)."""
+    conf = _conf()
+    bypass_vars, no_cache_vars = _cache_bypass_vars(conf)
+    assert "$geolens_raster_noncanonical" in bypass_vars, (
+        f"expected proxy_cache_bypass to reference $geolens_raster_noncanonical, "
+        f"got {bypass_vars!r}"
+    )
+    assert "$geolens_raster_noncanonical" in no_cache_vars, (
+        f"expected proxy_no_cache to reference $geolens_raster_noncanonical, "
+        f"got {no_cache_vars!r}"
+    )
+
+
+def test_noncanonical_request_with_an_api_key_leaks_nothing_and_is_marked_bypass():
+    """fix(#1778 codex r6): the exact scenario in the finding. A public
+    raster request carrying ?api_key=SECRET alongside a non-canonical
+    stretch spelling must (a) resolve $geolens_raster_noncanonical to "1"
+    (bypass/no_cache both trigger, per the test above) and (b) never let
+    SECRET reach any of the actual key-building variables."""
+    conf = _conf()
+    args = "api_key=SECRET&Stretch=minmax&stretch=percentile&pmin=5"
+    assert _noncanonical(conf, args) == "1"
+    for param in ("pmin", "pmax", "sigma"):
+        derived = _derive(conf, param, args)
+        assert "SECRET" not in derived, (
+            f"$geolens_raster_{param} leaked the api_key: {derived!r}"
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -362,8 +432,8 @@ def test_well_formed_value_under_a_canonical_inactive_mode_collapses_to_one_key(
         _derive(conf, "pmin", _qs(stretch="stddev", pmin=v)) for v in pmin_pmax_values
     } == {""}
     for value in pmin_pmax_values:
-        assert _cache_extra(conf, _qs(stretch="minmax", pmin=value)) == "", (
-            "a canonical request must not add anything to the cache key"
+        assert _noncanonical(conf, _qs(stretch="minmax", pmin=value)) == "0", (
+            "a canonical request must not trigger the non-canonical bypass"
         )
 
 
@@ -476,11 +546,16 @@ def test_mixed_case_duplicate_is_noncanonical_and_the_whole_args_breaks_the_tie(
     args_50 = "Stretch=minmax&stretch=percentile&pmin=50"
     assert _noncanonical(conf, args_5) == "1"
     assert _noncanonical(conf, args_50) == "1"
-    extra_5 = _cache_extra(conf, args_5)
-    extra_50 = _cache_extra(conf, args_50)
-    assert extra_5 == args_5
-    assert extra_50 == args_50
-    assert extra_5 != extra_50, (
+    # fix(#1778 codex r6): both requests bypass the cache entirely (asserted
+    # structurally in test_noncanonical_requests_bypass_the_cache_instead_of_
+    # being_keyed_on_it), so neither is ever cached in the first place --
+    # the per-parameter fallback below is a second, independent reason they
+    # could never collide even if bypass were somehow misconfigured off.
+    derived_5 = _derive(conf, "pmin", args_5)
+    derived_50 = _derive(conf, "pmin", args_50)
+    assert derived_5 == "5"
+    assert derived_50 == "50"
+    assert derived_5 != derived_50, (
         "a mixed-case duplicated stretch must not let two different pmin "
         "values collapse onto one cache key"
     )
@@ -496,7 +571,6 @@ def test_mixed_case_single_occurrence_is_noncanonical():
     conf = _conf()
     args = "Stretch=minmax&pmin=5"
     assert _noncanonical(conf, args) == "1"
-    assert _cache_extra(conf, args) == args
 
 
 def test_encoded_name_is_noncanonical():
@@ -507,7 +581,6 @@ def test_encoded_name_is_noncanonical():
     conf = _conf()
     args = "%73tretch=percentile&pmin=5"
     assert _noncanonical(conf, args) == "1"
-    assert _cache_extra(conf, args) == args
 
 
 def test_uppercase_and_all_caps_variants_of_every_name_are_noncanonical():
@@ -544,7 +617,6 @@ def test_ordinary_canonical_request_is_unaffected():
         "z=1",  # no stretch/pmin/pmax/sigma at all
     ):
         assert _noncanonical(conf, args) == "0", args
-        assert _cache_extra(conf, args) == "", args
 
 
 def test_duplicate_detection_finds_a_duplicate_not_starting_at_position_zero():
@@ -612,7 +684,12 @@ def test_duplicated_stretch_falls_back_to_the_raw_value_instead_of_blanking():
     args_a = "stretch=minmax&stretch=percentile&pmin=5"
     args_b = "stretch=minmax&stretch=percentile&pmin=50"
     assert _noncanonical(conf, args_a) == "1"
-    assert _cache_extra(conf, args_a) != _cache_extra(conf, args_b)
+    assert _noncanonical(conf, args_b) == "1"
+    # fix(#1778 codex r6): both bypass the cache entirely -- see
+    # test_noncanonical_requests_bypass_the_cache_instead_of_being_keyed_on_it
+    # -- so "must not collapse onto one key" is moot; neither is ever
+    # written. The per-parameter values still differ too, independently.
+    assert _derive(conf, "pmin", args_a) != _derive(conf, "pmin", args_b)
 
 
 def test_non_duplicated_stretch_is_unaffected_by_the_guard():

--- a/backend/tests/test_nginx_raster_stretch_cache_key_1778.py
+++ b/backend/tests/test_nginx_raster_stretch_cache_key_1778.py
@@ -1,6 +1,6 @@
 """The raster tile cache key must not vary on an arg the active stretch mode
 ignores, and a cache HIT must never change what an uncached request would
-answer (#1778, codebase audit 2026-08-30; codex rounds 1-7 on #1791).
+answer (#1778, codebase audit 2026-08-30; codex rounds 1-9 on #1791).
 
 frontend/nginx.conf's raster_cache proxy_cache_key used to hold
 $arg_pmin/$arg_pmax/$arg_sigma unconditionally. In
@@ -105,6 +105,29 @@ value too, not just an inactive one that would otherwise blank: two
 different raw spellings of the identical semantic float (`pmin=1` vs
 `pmin=%31`) must not sit unmodified in the cache key and mint two entries
 for one tile.
+
+Round 9 found the round-4/round-1 duplicate detector only counted
+occurrences containing `=` -- a BARE occurrence (no `=` at all) of a name
+was invisible to it. `?stretch=minmax&pmin=5&pmin` has nginx's $arg_pmin
+resolve from the earlier, well-formed `pmin=5` (ngx_http_arg requires an
+immediate `=` to match at all, so the bare occurrence is skipped entirely,
+the same as if it were absent), while Starlette keeps the bare `pmin` as a
+real ("pmin", "") pair (keep_blank_values=True) that the scalar Query
+dependency reads as the LAST occurrence -- empty string, which pydantic's
+float coercion 422s on unconditionally. That request was canonical to
+every check through round 8, so it collapsed onto the plain
+`?stretch=minmax` cache entry: warm 200, cold 422.
+
+The round-9 rule: a bare occurrence of any of the four names, anywhere,
+also sets $geolens_raster_noncanonical_name (folded into the SAME map as
+the round-1 duplicate/round-4 mis-case checks, since it is one more
+"$args is not in strict canonical form" condition, not a new kind of
+check). One regex per name checking "does a bare occurrence exist at all"
+is sufficient -- it does not need to literally COUNT occurrences, because a
+bare occurrence with nothing else is the single-bare case (still 422s,
+since the last occurrence is that bare pair), and a bare occurrence
+alongside a `name=` occurrence is already >= 2 total occurrences, the same
+"at most once" property rule 1 already polices.
 
 These are structural (they read the conf and simulate nginx's own map
 evaluation in Python), because there is no nginx binary in this test
@@ -861,3 +884,54 @@ def test_a_colon_inside_a_value_cannot_forge_a_false_negative():
     non-canonical, never toward canonical."""
     conf = _conf()
     assert _noncanonical(conf, _qs(stretch="minmax", pmin="1:2")) == "1"
+
+
+# ---------------------------------------------------------------------------
+# fix(#1778 codex r9): a BARE occurrence (no `=`) of stretch/pmin/pmax/sigma
+# is invisible to nginx's $arg_x lookup (ngx_http_arg requires an immediate
+# `=` after the name to resolve it at all) but is a real ("name", "") pair
+# to Starlette (keep_blank_values=True). `?stretch=minmax&pmin=5&pmin` has
+# nginx resolve $arg_pmin from the EARLIER, well-formed `pmin=5` (its arg
+# scan never matches the bare occurrence and keeps looking), while FastAPI's
+# scalar Query reads the LAST occurrence -- the bare one, "" -- and 422s on
+# it unconditionally, before the "ignore when inactive" logic ever runs.
+# That request read as perfectly canonical to every check before round 9,
+# so it collapsed onto the plain `?stretch=minmax` cache entry: warm 200,
+# cold 422.
+# ---------------------------------------------------------------------------
+
+
+def test_bare_occurrence_alongside_a_wellformed_one_is_noncanonical():
+    """The coordinator's named cases: a bare occurrence AFTER a `name=` one,
+    and a bare occurrence BEFORE it -- order must not matter, since nginx's
+    arg scan and Starlette's last-occurrence read disagree about the SAME
+    underlying byte layout regardless of which occurrence comes first."""
+    conf = _conf()
+    assert _noncanonical(conf, "stretch=minmax&pmin=5&pmin") == "1"
+    assert _noncanonical(conf, "stretch=minmax&pmin&pmin=5") == "1"
+
+
+def test_bare_occurrence_alone_is_noncanonical():
+    """A SINGLE bare occurrence, with no other occurrence of the name at
+    all, is still non-canonical: nginx's $arg_pmin resolves to "" (not
+    found, same as absent), so an inactive parameter's blank looks safe --
+    but FastAPI still sees ("pmin", "") as PRESENT and 422s on the empty
+    string, regardless of stretch mode. Covers the coordinator's
+    case-insensitive spelling (PMIN), a bare `stretch`, and the other two
+    render-parameter names for completeness -- every name this config
+    sanitises must get the same guard."""
+    conf = _conf()
+    assert _noncanonical(conf, "stretch=minmax&PMIN") == "1"
+    assert _noncanonical(conf, "stretch=minmax&pmax") == "1"
+    assert _noncanonical(conf, "stretch=minmax&sigma") == "1"
+    assert _noncanonical(conf, "stretch") == "1"
+
+
+def test_bare_occurrence_positive_control_stays_canonical():
+    """Positive control: `pmin=5` alone, with or without a sibling
+    well-formed parameter, and with no bare occurrence anywhere, must stay
+    canonical -- the round-9 guard must not fire on an ordinary, single,
+    well-formed occurrence."""
+    conf = _conf()
+    assert _noncanonical(conf, "stretch=minmax&pmin=5") == "0"
+    assert _noncanonical(conf, "stretch=minmax&pmin=5&pmax=95") == "0"

--- a/backend/tests/test_nginx_raster_stretch_cache_key_1778.py
+++ b/backend/tests/test_nginx_raster_stretch_cache_key_1778.py
@@ -1,6 +1,6 @@
 """The raster tile cache key must not vary on an arg the active stretch mode
 ignores, and a cache HIT must never change what an uncached request would
-answer (#1778, codebase audit 2026-08-30; codex rounds 1-6 on #1791).
+answer (#1778, codebase audit 2026-08-30; codex rounds 1-7 on #1791).
 
 frontend/nginx.conf's raster_cache proxy_cache_key used to hold
 $arg_pmin/$arg_pmax/$arg_sigma unconditionally. In
@@ -82,6 +82,30 @@ bypass skips the lookup and no_cache skips the store, and nothing about
 that request -- credential included -- is ever written to the cache at
 all. $geolens_raster_cache_extra and its map are gone.
 
+Round 7 found round 4's name-only check left a gap on the VALUE side:
+$geolens_raster_noncanonical never inspected pmin/pmax/sigma's raw value,
+only the parameter names. nginx never decodes $arg_pmin/$arg_pmax/$arg_sigma
+either, so a percent-encoded (`pmin=%31`) or `+`-encoded (`pmin=+1`,
+which Starlette's query-string unescaping turns into a space before
+float() parses it) value reaches this config as its own literal bytes
+while decoding to an ordinary, valid float at FastAPI -- every distinct
+encoding of the same float minted a distinct one-hour cache entry for one
+identical tile, the same amplification vector round 4 closed for names,
+reopened on values.
+
+The round-7 rule: $geolens_raster_noncanonical is now the OR of two
+checks -- the round-4 name check plus a new value check requiring pmin,
+pmax, and sigma to each be either empty or an exact, undecorated float
+(`-?[0-9]+(\.[0-9]+)?([eE]-?[0-9]+)?`, no `%`, no `+`, no whitespace). Any
+render-parameter value outside that grammar makes the WHOLE request
+non-canonical, the same treatment a malformed NAME already gets, so it
+bypasses the cache via the existing proxy_cache_bypass/proxy_no_cache
+rather than being keyed on anything. This closes the gap for an ACTIVE
+value too, not just an inactive one that would otherwise blank: two
+different raw spellings of the identical semantic float (`pmin=1` vs
+`pmin=%31`) must not sit unmodified in the cache key and mint two entries
+for one tile.
+
 These are structural (they read the conf and simulate nginx's own map
 evaluation in Python), because there is no nginx binary in this test
 environment to render and query directly. The simulation models nginx's
@@ -130,7 +154,21 @@ _MAPS: dict[str, tuple[str, str]] = {
         "$geolens_raster_sigma",
     ),
 }
-_NONCANONICAL_MAP: tuple[str, str] = ("$args", "$geolens_raster_noncanonical")
+# fix(#1778 codex r7): $geolens_raster_noncanonical is now the OR of three
+# chained maps -- a name-based check ($args), a value-based check
+# ($arg_pmin:$arg_pmax:$arg_sigma), and a combiner over the two results.
+_NONCANONICAL_NAME_MAP: tuple[str, str] = (
+    "$args",
+    "$geolens_raster_noncanonical_name",
+)
+_NONCANONICAL_VALUE_MAP: tuple[str, str] = (
+    "$arg_pmin:$arg_pmax:$arg_sigma",
+    "$geolens_raster_noncanonical_value",
+)
+_NONCANONICAL_COMBINE_MAP: tuple[str, str] = (
+    "$geolens_raster_noncanonical_name:$geolens_raster_noncanonical_value",
+    "$geolens_raster_noncanonical",
+)
 
 
 def _without_comments(text: str) -> str:
@@ -264,12 +302,47 @@ def _conf() -> str:
 
 
 def _noncanonical(conf: str, args_string: str) -> str:
-    """``$geolens_raster_noncanonical`` for a raw query string."""
-    source_expr, dest_var = _NONCANONICAL_MAP
-    entries, default_value = _map_entries_ordered(
-        _map_body(conf, source_expr, dest_var)
+    """``$geolens_raster_noncanonical`` for a raw query string -- the OR of
+    the name-based map (round 4) and the value-based map (round 7), each
+    evaluated the way nginx itself would and then combined through the
+    third, combiner map, exactly as the three chained `map` directives in
+    the conf resolve it."""
+    name_source, name_dest = _NONCANONICAL_NAME_MAP
+    name_entries, name_default = _map_entries_ordered(
+        _map_body(conf, name_source, name_dest)
     )
-    return _evaluate_map(source_expr, entries, default_value, {"args": args_string})
+    name_result = _evaluate_map(
+        name_source, name_entries, name_default, {"args": args_string}
+    )
+
+    value_source, value_dest = _NONCANONICAL_VALUE_MAP
+    value_entries, value_default = _map_entries_ordered(
+        _map_body(conf, value_source, value_dest)
+    )
+    value_result = _evaluate_map(
+        value_source,
+        value_entries,
+        value_default,
+        {
+            "arg_pmin": _nginx_arg(args_string, "pmin"),
+            "arg_pmax": _nginx_arg(args_string, "pmax"),
+            "arg_sigma": _nginx_arg(args_string, "sigma"),
+        },
+    )
+
+    combine_source, combine_dest = _NONCANONICAL_COMBINE_MAP
+    combine_entries, combine_default = _map_entries_ordered(
+        _map_body(conf, combine_source, combine_dest)
+    )
+    return _evaluate_map(
+        combine_source,
+        combine_entries,
+        combine_default,
+        {
+            "geolens_raster_noncanonical_name": name_result,
+            "geolens_raster_noncanonical_value": value_result,
+        },
+    )
 
 
 def _derive(conf: str, param: str, args_string: str) -> str:
@@ -465,9 +538,17 @@ def test_out_of_range_but_syntactically_valid_value_under_a_canonical_inactive_m
     cache-amplification vector this whole fix exists to close, reopened
     through a side door. Range is irrelevant for an inactive parameter;
     only a value FastAPI cannot parse as a float AT ALL stays raw (see
-    test_malformed_float_under_an_inactive_mode_stays_raw right below)."""
+    test_malformed_float_under_an_inactive_mode_stays_raw right below).
+
+    fix(#1778 codex r7): ``+5`` used to be in this list -- round 5's
+    well-formedness grammar allowed a leading ``[+-]?`` sign, so it matched
+    and blanked like any other syntactically-valid value. It no longer
+    belongs here: a raw ``+`` is never itself part of a canonical float (see
+    test_percent_or_plus_encoded_value_is_noncanonical_and_bypasses_the_cache
+    below), so ``pmin=+5`` now makes the whole request non-canonical instead
+    of blanking under this map."""
     conf = _conf()
-    for value in ("200", "-5", "101", "100.5", "1e3", "-1e10", "+5"):
+    for value in ("200", "-5", "101", "100.5", "1e3", "-1e10"):
         assert _derive(conf, "pmin", _qs(stretch="minmax", pmin=value)) == ""
         assert _derive(conf, "pmax", _qs(stretch="minmax", pmax=value)) == ""
     for value in ("-1", "0", "0.0", "0.000", "-3.5e2"):
@@ -701,3 +782,82 @@ def test_non_duplicated_stretch_is_unaffected_by_the_guard():
     assert _derive(conf, "pmin", "stretch=minmax&pmin=5") == ""
     assert _derive(conf, "pmin", "stretch=minmax&pmin=200") == ""
     assert _derive(conf, "pmin", "stretch=percentile&pmin=5") == "5"
+
+
+# ---------------------------------------------------------------------------
+# fix(#1778 codex r7): round 4 checked parameter NAMES for percent-encoding
+# but said nothing about pmin/pmax/sigma's VALUES. nginx never decodes
+# $arg_pmin/$arg_pmax/$arg_sigma either, so a percent-encoded or
+# `+`-encoded value reaches this config as its own literal bytes while
+# FastAPI decodes it into an ordinary, valid float -- every distinct
+# encoding of the same float is a different cache key for one identical
+# tile. A render-parameter value must match the exact float grammar
+# (`-?[0-9]+(\.[0-9]+)?([eE]-?[0-9]+)?`) or be empty, or the WHOLE request
+# is non-canonical and bypasses the cache -- the same treatment round 4
+# already gives a malformed NAME.
+# ---------------------------------------------------------------------------
+
+
+def test_percent_or_plus_encoded_value_is_noncanonical_and_bypasses_the_cache():
+    """The coordinator's named cases: %31 (percent-encoded "1"), +1 (a raw
+    `+`, which Starlette's query-string unescaping turns into a space before
+    float() parses it), %201 (percent-encoded " 1", same result via a
+    different byte sequence), and 1%2e5 (percent-encoded "1.5") each decode
+    to an ordinary valid float at FastAPI -- so the request is served and
+    cached (200) -- while nginx's raw $arg_pmin/$arg_pmax never matches the
+    strict float grammar. All four must make the request non-canonical."""
+    conf = _conf()
+    assert _noncanonical(conf, _qs(stretch="minmax", pmin="%31")) == "1"
+    assert _noncanonical(conf, _qs(stretch="minmax", pmin="+1")) == "1"
+    assert _noncanonical(conf, _qs(stretch="minmax", pmin="%201")) == "1"
+    assert _noncanonical(conf, _qs(stretch="minmax", pmax="1%2e5")) == "1"
+    # The same holds when the parameter is ACTIVE, not just when it is
+    # inactive-and-would-otherwise-blank: two different raw spellings of the
+    # identical semantic float (`pmin=1` vs `pmin=%31`) must not be allowed
+    # to sit in the cache key unmodified and mint two entries for one tile.
+    assert _noncanonical(conf, _qs(stretch="percentile", pmin="%31")) == "1"
+    assert _noncanonical(conf, _qs(stretch="stddev", sigma="+2")) == "1"
+
+
+def test_percent_or_plus_encoded_value_leaves_no_stray_cache_key():
+    """Structural companion to the assertion above: a non-canonical value
+    must actually reach the bypass/no_cache condition (not just flip
+    $geolens_raster_noncanonical in isolation), matching
+    test_noncanonical_requests_bypass_the_cache_instead_of_being_keyed_on_it."""
+    conf = _conf()
+    bypass_vars, no_cache_vars = _cache_bypass_vars(conf)
+    assert "$geolens_raster_noncanonical" in bypass_vars
+    assert "$geolens_raster_noncanonical" in no_cache_vars
+    assert _noncanonical(conf, _qs(stretch="minmax", pmin="%31")) == "1"
+
+
+def test_canonical_float_value_positive_control_stays_canonical():
+    """Positive control for the value check: an ordinary, undecorated float
+    must not itself trip the new guard -- ``pmin=1`` still blanks when
+    inactive and still passes through raw when active, exactly as every
+    other canonical value does."""
+    conf = _conf()
+    assert _noncanonical(conf, _qs(stretch="minmax", pmin="1")) == "0"
+    assert _derive(conf, "pmin", _qs(stretch="minmax", pmin="1")) == ""
+    assert _derive(conf, "pmin", _qs(stretch="percentile", pmin="1")) == "1"
+
+
+def test_empty_render_parameter_values_are_unaffected_by_the_value_check():
+    """An absent/empty pmin, pmax, or sigma must not itself trip the value
+    guard -- the combined ``$arg_pmin:$arg_pmax:$arg_sigma`` string is
+    ``::`` when none are supplied, which the value map's grammar (each field
+    independently optional) must still treat as canonical."""
+    conf = _conf()
+    assert _noncanonical(conf, _qs(stretch="minmax")) == "0"
+    assert _noncanonical(conf, _qs(stretch="stddev", pmin="1")) == "0"
+
+
+def test_a_colon_inside_a_value_cannot_forge_a_false_negative():
+    """A raw `:` inside pmin could in principle realign the combined
+    ``$arg_pmin:$arg_pmax:$arg_sigma`` string's fields. It must not be able
+    to forge a canonical-looking combination: the anchored per-field grammar
+    has no ``:`` in it, so any real colon byte makes the whole match fail
+    and falls through to the map's ``default 1`` -- fails toward
+    non-canonical, never toward canonical."""
+    conf = _conf()
+    assert _noncanonical(conf, _qs(stretch="minmax", pmin="1:2")) == "1"

--- a/backend/tests/test_nginx_raster_stretch_cache_key_1778.py
+++ b/backend/tests/test_nginx_raster_stretch_cache_key_1778.py
@@ -1,6 +1,6 @@
 """The raster tile cache key must not vary on an arg the active stretch mode
-ignores, and a cache HIT must never change the status code a request gets
-(#1778, codebase audit 2026-08-30; codex round 1 on #1791).
+ignores, and a cache HIT must never change what an uncached request would
+answer (#1778, codebase audit 2026-08-30; codex rounds 1 and 2 on #1791).
 
 frontend/nginx.conf's raster_cache proxy_cache_key used to hold
 $arg_pmin/$arg_pmax/$arg_sigma unconditionally. In
@@ -12,28 +12,42 @@ neither -- the fragment passed to Titiler is unchanged either way. So
 byte-identical to the unfiltered tile, the same defeat #1785 closed for the
 vector tile ``cols=`` param.
 
-The first revision of this fix blanked every inactive value unconditionally,
-which introduced a different bug: raster_tile_proxy validates pmin/pmax/sigma
-whenever they are PRESENT, regardless of the active stretch mode (T-1153-01),
-so ``?stretch=minmax&pmin=200`` uncached answers 422 -- but blanking pmin
-unconditionally collapsed it onto the SAME key as a cached ``?stretch=minmax``
-and returned that entry's 200. A cache hit must never change endpoint
-semantics.
+Round 1 blanked every inactive value unconditionally, which introduced a
+different bug: raster_tile_proxy validated pmin/pmax/sigma whenever PRESENT,
+regardless of the active stretch mode, so blanking pmin under
+``?stretch=minmax&pmin=200`` collapsed it onto the same key as a cached
+``?stretch=minmax`` and returned that entry's 200, though the API would 422
+an out-of-range pmin uncached.
 
-The current maps blank a value only when it is BOTH inactive for the request's
-mode AND within the range the API itself accepts (0-100 for pmin/pmax,
-positive for sigma). A value in that range can never turn the API's verdict
-from 200 into 422, so blanking it never changes the status a client gets;
-anything malformed or out of range is left RAW, so it misses the cache and
-reaches the API for the same 422 an uncached request would get.
+Round 2 changed the API side instead of chasing round 1's nginx-only fix
+further: raster_tile_proxy now IGNORES pmin/pmax when stretch is not
+percentile and sigma when it is not stddev, rather than merely leaving them
+unvalidated. "Inactive" means the same thing, ignored, on both sides, so
+every map below blanks an inactive value UNCONDITIONALLY -- there is no
+verdict left to disagree with, because the value is never read. That also
+closes the residual round 1 could not: a repeated query parameter, where
+nginx's $arg_x reads the FIRST occurrence and FastAPI's scalar Query reads
+the LAST.
+
+One more residual survives even that change: the duplicate-parameter mismatch
+applies to `stretch` itself too. `?stretch=minmax&stretch=percentile&pmin=5`
+has nginx read stretch=minmax (blank pmin) while the API reads
+stretch=percentile (uses pmin=5) -- and because blanking makes the cache key
+depend on nginx's OWN reading of stretch, a second such request with a
+DIFFERENT pmin would collapse onto the SAME key while rendering DIFFERENT
+bytes: a collision, not just a status mismatch.
+$geolens_raster_stretch_dup detects a repeated `stretch=` in the raw query
+string and, when set, every map falls back to the raw value instead of
+blanking -- an extra cache miss, never a collision.
 
 These are structural (they read the conf and simulate nginx's own map
-evaluation in Python), because there is no nginx binary in this test
-environment to render and query directly. The companion API-level pin lives in
-test_raster_colormap_proxy.py::TestRasterColormapProxy::
-test_invalid_bounds_return_422_even_under_an_inactive_stretch_mode, which
-confirms the API side of the property these maps rely on: pmin/pmax/sigma are
-rejected whenever present, regardless of stretch mode.
+evaluation in Python, including nginx's $arg_x "first occurrence of a
+repeated key" semantics), because there is no nginx binary in this test
+environment to render and query directly. The companion API-level pin lives
+in test_raster_colormap_proxy.py::TestRasterColormapProxy::
+test_out_of_range_bounds_are_ignored_under_an_inactive_stretch_mode, which
+confirms the API side of the contract these maps rely on: pmin/pmax/sigma are
+ignored, not validated, whenever the active stretch mode does not read them.
 """
 
 import re
@@ -48,12 +62,22 @@ _LOCATION_HEADER = re.compile(r"^[ \t]*location\b[^\n{]*\{", re.M)
 _MAP_HEADER = re.compile(r"^map\s+(\S+)\s+(\S+)\s*\{", re.M)
 _PROXY_CACHE_KEY = re.compile(r'^\s*proxy_cache_key\s+"([^"]+)"\s*;', re.M)
 
-# (unquoted source template, dest var) for each param this file cares about.
+# (unquoted source template, dest var) for each per-parameter map.
 _MAPS: dict[str, tuple[str, str]] = {
-    "pmin": ("$arg_stretch:$arg_pmin", "$geolens_raster_pmin"),
-    "pmax": ("$arg_stretch:$arg_pmax", "$geolens_raster_pmax"),
-    "sigma": ("$arg_stretch:$arg_sigma", "$geolens_raster_sigma"),
+    "pmin": (
+        "$geolens_raster_stretch_dup:$arg_stretch:$arg_pmin",
+        "$geolens_raster_pmin",
+    ),
+    "pmax": (
+        "$geolens_raster_stretch_dup:$arg_stretch:$arg_pmax",
+        "$geolens_raster_pmax",
+    ),
+    "sigma": (
+        "$geolens_raster_stretch_dup:$arg_stretch:$arg_sigma",
+        "$geolens_raster_sigma",
+    ),
 }
+_DUP_MAP: tuple[str, str] = ("$args", "$geolens_raster_stretch_dup")
 
 
 def _without_comments(text: str) -> str:
@@ -84,11 +108,19 @@ def _location_block(text: str, header_pattern: str) -> str:
 
 def _map_body(text: str, source_expr: str, dest_var: str) -> str:
     """Body of ``map "source_expr" dest_var { ... }`` (source_expr unquoted)."""
-    quoted_source = f'"{source_expr}"'
+    quoted_source = (
+        f'"{source_expr}"'
+        if " " not in source_expr and ":" in source_expr
+        else source_expr
+    )
+    # $args alone is not quoted in the conf (no ':' composition needed).
+    candidates = {quoted_source, source_expr}
     for match in _MAP_HEADER.finditer(text):
-        if match.group(1) == quoted_source and match.group(2) == dest_var:
+        if match.group(1) in candidates and match.group(2) == dest_var:
             return _balanced_body(text, text.index("{", match.start()))
-    raise AssertionError(f'no `map "{source_expr}" {dest_var} {{ ... }}` block found')
+    raise AssertionError(
+        f"no `map ...{source_expr}... {dest_var} {{ ... }}` block found"
+    )
 
 
 def _map_entries_ordered(body: str) -> tuple[list[tuple[str, str]], str]:
@@ -96,7 +128,7 @@ def _map_entries_ordered(body: str) -> tuple[list[tuple[str, str]], str]:
 
     Declaration order is preserved, since nginx tries regex entries in the
     order they were written and the first match wins. Asserts every non-default
-    entry is a regex (``~``-prefixed) — a literal entry slipping in would be
+    entry is a regex (``~``-prefixed) -- a literal entry slipping in would be
     matched by nginx's hash lookup instead, which this simulation does not
     model, and a silent mismatch there is worse than a loud assertion here.
     """
@@ -118,43 +150,76 @@ def _map_entries_ordered(body: str) -> tuple[list[tuple[str, str]], str]:
     return entries, default_value
 
 
-def _expand(template: str, arg_values: dict[str, str]) -> str:
-    """Substitute ``$arg_NAME`` tokens in a map source template or value."""
+def _nginx_arg(args_string: str, name: str) -> str:
+    """nginx's ``$arg_NAME``: the value of the FIRST occurrence of ``name`` in
+    the raw query string, or "" if absent. nginx does not URL-decode $arg_*,
+    and neither does this."""
+    for pair in args_string.split("&"):
+        if not pair:
+            continue
+        key, _, value = pair.partition("=")
+        if key == name:
+            return value
+    return ""
+
+
+def _expand(template: str, values: dict[str, str]) -> str:
+    """Substitute ``$var`` tokens (bare, or ``$arg_NAME``) in a map source
+    template or value against a resolved-variable dict."""
 
     def _sub(match: re.Match) -> str:
-        return arg_values.get(match.group(1), "")
+        return values.get(match.group(1), "")
 
-    return re.sub(r"\$arg_(\w+)", _sub, template)
+    return re.sub(r"\$(\w+)", _sub, template)
 
 
 def _evaluate_map(
     source_template: str,
     entries: list[tuple[str, str]],
     default_value: str,
-    arg_values: dict[str, str],
+    values: dict[str, str],
 ) -> str:
     """Evaluate one nginx ``map`` the way nginx itself would: try each regex
     entry in declaration order, first match wins; ``default`` otherwise."""
-    source = _expand(source_template, arg_values)
+    source = _expand(source_template, values)
     for pattern, template in entries:
         if re.match(pattern, source):
-            return _expand(template, arg_values)
-    return _expand(default_value, arg_values)
+            return _expand(template, values)
+    return _expand(default_value, values)
 
 
 def _conf() -> str:
     return _without_comments(NGINX_CONF.read_text())
 
 
-def _derive(conf: str, param: str, stretch: str, value: str) -> str:
-    """The cache-key value nginx would compute for ``param`` given
-    ``?stretch=<stretch>&<param>=<value>``."""
+def _stretch_dup(conf: str, args_string: str) -> str:
+    """``$geolens_raster_stretch_dup`` for a raw query string."""
+    source_expr, dest_var = _DUP_MAP
+    entries, default_value = _map_entries_ordered(
+        _map_body(conf, source_expr, dest_var)
+    )
+    return _evaluate_map(source_expr, entries, default_value, {"args": args_string})
+
+
+def _derive(conf: str, param: str, args_string: str) -> str:
+    """The cache-key value nginx would compute for ``param`` given the raw
+    query string ``args_string`` -- $arg_x's first-occurrence semantics and
+    the duplicate-stretch guard both apply, exactly as nginx would."""
     source_template, dest_var = _MAPS[param]
     entries, default_value = _map_entries_ordered(
         _map_body(conf, source_template, dest_var)
     )
-    arg_values = {"stretch": stretch, param: value}
-    return _evaluate_map(source_template, entries, default_value, arg_values)
+    values = {
+        "geolens_raster_stretch_dup": _stretch_dup(conf, args_string),
+        "arg_stretch": _nginx_arg(args_string, "stretch"),
+        f"arg_{param}": _nginx_arg(args_string, param),
+    }
+    return _evaluate_map(source_template, entries, default_value, values)
+
+
+def _qs(**params: str) -> str:
+    """Build a raw query string, preserving insertion order (dict order)."""
+    return "&".join(f"{k}={v}" for k, v in params.items())
 
 
 # ---------------------------------------------------------------------------
@@ -185,110 +250,131 @@ def test_cache_key_does_not_hold_the_raw_stretch_args():
 
 
 # ---------------------------------------------------------------------------
-# pmin / pmax: percentile is the active mode; blank only a well-formed,
-# in-range (0-100) inactive value.
+# pmin / pmax: percentile is the active mode; sigma: stddev is.
+# Round 2: blank UNCONDITIONALLY when inactive -- no well-formedness check
+# needed any more, since the API ignores an inactive value regardless.
 # ---------------------------------------------------------------------------
 
 
-def test_percentile_mode_always_passes_pmin_pmax_through_raw():
-    """Active mode: pmin/pmax must vary the key regardless of validity,
-    unchanged from before this fix -- percentile genuinely reads them, and an
-    invalid value under percentile already 422s on its own (unaffected by
-    caching, since a 422 is never stored under `proxy_cache_valid 200 1h`)."""
+def test_active_mode_always_passes_the_value_through_raw():
+    """Active mode: the value must vary the key regardless of content --
+    percentile/stddev genuinely read it, unchanged from before either fix."""
     conf = _conf()
-    for param in ("pmin", "pmax"):
-        for value in ("5", "200", "-1", "abc", ""):
-            assert _derive(conf, param, "percentile", value) == value
+    for value in ("5", "200", "-1", "abc", ""):
+        assert _derive(conf, "pmin", _qs(stretch="percentile", pmin=value)) == value
+        assert _derive(conf, "pmax", _qs(stretch="percentile", pmax=value)) == value
+        assert _derive(conf, "sigma", _qs(stretch="stddev", sigma=value)) == value
 
 
-def test_valid_random_pmin_pmax_still_collapse_to_one_key():
-    """The cache-busting vector #1785's fix closed for `cols=`: many DIFFERENT
-    but individually well-formed pmin/pmax values under an inactive stretch
-    mode must all still collapse to the SAME (blank) cache-key component."""
+def test_any_value_under_an_inactive_mode_collapses_to_one_key():
+    """fix(#1778 codex r2): unconditional blanking. Any value at all -- valid,
+    invalid, or malformed -- under an inactive stretch mode must collapse to
+    the same blank key, because the API ignores it regardless of content."""
     conf = _conf()
-    values = ["", "0", "2", "50", "98", "99.999", "100", "100.0"]
-    for param in ("pmin", "pmax"):
+    values = ["", "0", "50", "100", "200", "-5", "abc", "1e10", "100.5", "0.5"]
+    for param, active in (
+        ("pmin", "percentile"),
+        ("pmax", "percentile"),
+        ("sigma", "stddev"),
+    ):
         for stretch in ("minmax", ""):
-            derived = {_derive(conf, param, stretch, v) for v in values}
+            derived = {
+                _derive(conf, param, _qs(stretch=stretch, **{param: v})) for v in values
+            }
             assert derived == {""}, (
                 f"{param} under stretch={stretch!r} collapsed to {derived!r}, "
-                "expected all blank -- a well-formed random value must not "
-                "defeat the cache"
+                "expected all blank -- the API ignores this value under this "
+                "mode regardless of content, so it must never defeat the cache"
             )
-
-
-def test_out_of_range_pmin_pmax_are_not_blanked():
-    """fix(#1778 codex r1): the regression codex found. Blanking pmin
-    unconditionally under an inactive stretch mode let a cached
-    `?stretch=minmax` answer `?stretch=minmax&pmin=200` with its cached 200,
-    though raster_tile_proxy validates pmin whenever it is present regardless
-    of stretch mode and would 422 an out-of-range value uncached. A value
-    outside what the API accepts must stay RAW: it misses the cache and
-    reaches the API for the same 422 an uncached request would get."""
-    conf = _conf()
-    for param in ("pmin", "pmax"):
-        for bad in ("200", "-5", "abc", "1e10", "101", "100.5", "50:60"):
-            derived = _derive(conf, param, "minmax", bad)
-            assert derived == bad, (
-                f"{param}={bad!r} under an inactive stretch mode must stay "
-                f"RAW in the cache key, got {derived!r} -- a cache hit here "
-                "would answer 200 for a request the API would 422"
-            )
-            assert derived != "", (
-                f"{param}={bad!r} must not collapse onto the blank key"
-            )
-
-
-# ---------------------------------------------------------------------------
-# sigma: stddev is the active mode; blank only a well-formed positive value.
-# ---------------------------------------------------------------------------
-
-
-def test_stddev_mode_always_passes_sigma_through_raw():
-    conf = _conf()
-    for value in ("2", "-1", "0", "abc", ""):
-        assert _derive(conf, "sigma", "stddev", value) == value
-
-
-def test_valid_random_sigma_still_collapses_to_one_key():
-    """Counterfactual for the failure mode a blanket blank-everything fix
-    would introduce: two stddev requests with different sigma render
-    different bytes and must still key apart (covered separately below); this
-    pins the complementary half, that well-formed sigma values collapse when
-    sigma is inactive."""
-    conf = _conf()
-    values = ["", "0.5", "1", "2", "10", "0.001"]
-    derived = {_derive(conf, "sigma", "minmax", v) for v in values}
-    assert derived == {""}, (
-        f"sigma under an inactive stretch mode collapsed to {derived!r}, "
-        "expected all blank"
-    )
-
-
-def test_out_of_range_sigma_is_not_blanked():
-    """sigma must be strictly positive (`sigma > 0`); zero and negative
-    values must stay RAW under an inactive stretch mode for the same reason
-    an out-of-range pmin must."""
-    conf = _conf()
-    for bad in ("-1", "0", "0.0", "0.000", "abc"):
-        derived = _derive(conf, "sigma", "minmax", bad)
-        assert derived == bad, (
-            f"sigma={bad!r} under an inactive stretch mode must stay RAW, "
-            f"got {derived!r}"
-        )
+        assert active  # documents the pairing; not asserted here
 
 
 def test_sigma_still_varies_the_key_under_stddev():
-    """Counterfactual for the failure mode a blanket blank-everything fix would
-    introduce: two stddev requests with different sigma render different
-    bytes, so sigma must still reach the cache key when stretch=stddev."""
+    """Counterfactual for the failure mode a blanket blank-everything fix
+    would introduce: two stddev requests with different sigma render
+    different bytes, so sigma must still reach the cache key when
+    stretch=stddev."""
     conf = _conf()
     key_match = _PROXY_CACHE_KEY.search(_location_block(conf, RASTER_TILES_LOCATION))
     assert key_match and "$geolens_raster_sigma" in key_match.group(1)
-    assert _derive(conf, "sigma", "stddev", "2") != _derive(
-        conf, "sigma", "stddev", "3"
-    ), (
+    a = _derive(conf, "sigma", _qs(stretch="stddev", sigma="2"))
+    b = _derive(conf, "sigma", _qs(stretch="stddev", sigma="3"))
+    assert a != b, (
         "stddev must not blank sigma out of the key, or two stddev requests "
         "with different sigma would collide on one cache entry and serve one "
         "request's bytes for the other's distinct render"
     )
+
+
+# ---------------------------------------------------------------------------
+# Duplicate `pmin`/`pmax`/`sigma`: closed by ignoring the inactive value
+# entirely, so which occurrence either side reads no longer matters.
+# ---------------------------------------------------------------------------
+
+
+def test_repeated_inactive_param_still_collapses_regardless_of_occurrence_order():
+    """The exact case codex found: nginx reads the FIRST occurrence, FastAPI
+    reads the LAST. Both occurrences must still blank identically, because
+    the API ignores the parameter under this mode no matter which value it
+    resolves to."""
+    conf = _conf()
+    well_formed_first = _derive(
+        conf, "pmin", "stretch=minmax&pmin=5&pmin=200"
+    )  # nginx sees 5 (well-formed if it mattered), API would see 200
+    out_of_range_first = _derive(
+        conf, "pmin", "stretch=minmax&pmin=200&pmin=5"
+    )  # nginx sees 200 (would have been the round-1 residual), API sees 5
+    assert well_formed_first == out_of_range_first == "", (
+        f"got {well_formed_first!r} and {out_of_range_first!r} -- a repeated "
+        "pmin under an inactive stretch mode must blank the same way "
+        "regardless of which occurrence nginx happens to read"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Duplicate `stretch`: nginx and the API can disagree about which mode is
+# ACTIVE. $geolens_raster_stretch_dup detects this and falls back to raw.
+# ---------------------------------------------------------------------------
+
+
+def test_stretch_dup_detects_a_repeated_stretch_key():
+    conf = _conf()
+    assert _stretch_dup(conf, "stretch=minmax&pmin=5") == "0"
+    assert _stretch_dup(conf, "pmin=5") == "0"
+    assert _stretch_dup(conf, "stretch=percentile") == "0"
+    assert _stretch_dup(conf, "stretch=minmax&stretch=percentile&pmin=5") == "1"
+    assert _stretch_dup(conf, "stretch=percentile&pmin=5&stretch=minmax") == "1"
+    # A repeat of the SAME value is still a repeat -- harmless (nginx and the
+    # API necessarily agree), but detected the same way; the raw-fallback
+    # this triggers is safe either way, just occasionally unnecessary.
+    assert _stretch_dup(conf, "stretch=minmax&stretch=minmax&pmin=5") == "1"
+
+
+def test_duplicated_stretch_falls_back_to_the_raw_value_instead_of_blanking():
+    """fix(#1778 codex r2): the collision codex's shape (b) recommendation
+    didn't cover on its own. nginx reads the FIRST `stretch` (minmax, so it
+    would normally blank pmin); the API reads the LAST (percentile, so it
+    actually uses pmin). Two such requests with DIFFERENT pmin values must
+    NOT collapse onto one key -- that would be a genuine collision (different
+    rendered bytes sharing one cache entry), worse than the status-code
+    mismatch this whole fix started from."""
+    conf = _conf()
+    args_a = "stretch=minmax&stretch=percentile&pmin=5"
+    args_b = "stretch=minmax&stretch=percentile&pmin=50"
+    derived_a = _derive(conf, "pmin", args_a)
+    derived_b = _derive(conf, "pmin", args_b)
+    assert derived_a == "5"
+    assert derived_b == "50"
+    assert derived_a != derived_b, (
+        "a duplicated stretch must not let two different pmin values "
+        "collapse onto one cache key"
+    )
+
+
+def test_non_duplicated_stretch_is_unaffected_by_the_guard():
+    """The guard must not blank the fast path: an ordinary, non-duplicated
+    request keeps collapsing exactly as before."""
+    conf = _conf()
+    assert _derive(conf, "pmin", "stretch=minmax&pmin=5") == ""
+    assert _derive(conf, "pmin", "stretch=minmax&pmin=200") == ""
+    assert _derive(conf, "pmin", "stretch=percentile&pmin=5") == "5"

--- a/backend/tests/test_nginx_raster_stretch_cache_key_1778.py
+++ b/backend/tests/test_nginx_raster_stretch_cache_key_1778.py
@@ -1,0 +1,164 @@
+"""The raster tile cache key must not vary on an arg the active stretch mode
+ignores (#1778, codebase audit 2026-08-30).
+
+frontend/nginx.conf's raster_cache proxy_cache_key used to hold
+$arg_pmin/$arg_pmax/$arg_sigma unconditionally. In
+backend/app/processing/tiles/router.py, stretch=percentile is the only mode
+that reads pmin/pmax (_compute_stretch_rescale) and stretch=stddev is the only
+mode that reads sigma; stretch=minmax (the default) or an absent stretch reads
+neither — the fragment passed to Titiler is unchanged either way. So
+``?stretch=minmax&pmin=<random>`` produced a fresh cache key holding bytes
+byte-identical to the unfiltered tile, the same defeat #1785 closed for the
+vector tile ``cols=`` param: on the default production stack (no Valkey) those
+writes land in a bounded LRU and evict legitimate tiles.
+
+The fix mirrors #1785's shape: a ``map`` keyed on ``$arg_stretch`` blanks each
+arg family down to what the active mode can actually change, and the cache key
+is built from the mapped variables rather than the raw ``$arg_*`` ones.
+Blanking BOTH families unconditionally would not just fragment the cache the
+other direction, it would misbehave: two stddev requests with different sigma
+values render different bytes and must still key apart, so only the family
+each mode ignores is blanked.
+
+These are structural (they read the conf), because there is no nginx binary
+in this test environment to render and query directly.
+"""
+
+import re
+
+from tests.repo_paths import repo_root
+
+NGINX_CONF = repo_root(__file__) / "frontend" / "nginx.conf"
+
+RASTER_TILES_LOCATION = r"location\s+~\s+\^/raster-tiles/"
+
+_LOCATION_HEADER = re.compile(r"^[ \t]*location\b[^\n{]*\{", re.M)
+_MAP_HEADER = re.compile(r"^map\s+(\S+)\s+(\S+)\s*\{", re.M)
+_PROXY_CACHE_KEY = re.compile(r'^\s*proxy_cache_key\s+"([^"]+)"\s*;', re.M)
+
+
+def _without_comments(text: str) -> str:
+    """Drop nginx comment lines so prose can never satisfy an assertion."""
+    return "\n".join(
+        line for line in text.splitlines() if not line.lstrip().startswith("#")
+    )
+
+
+def _balanced_body(text: str, brace_index: int) -> str:
+    """Return the body between ``text[brace_index]`` and its matching brace."""
+    depth = 0
+    for index in range(brace_index, len(text)):
+        if text[index] == "{":
+            depth += 1
+        elif text[index] == "}":
+            depth -= 1
+            if depth == 0:
+                return text[brace_index + 1 : index]
+    raise AssertionError(f"unbalanced braces at offset {brace_index}")
+
+
+def _location_block(text: str, header_pattern: str) -> str:
+    match = re.search(header_pattern, text)
+    assert match, f"expected a location block matching {header_pattern!r}"
+    return _balanced_body(text, text.index("{", match.start()))
+
+
+def _map_body(text: str, source_var: str, dest_var: str) -> str:
+    """Body of ``map $source_var $dest_var { ... }``, or raise."""
+    for match in _MAP_HEADER.finditer(text):
+        if match.group(1) == source_var and match.group(2) == dest_var:
+            return _balanced_body(text, text.index("{", match.start()))
+    raise AssertionError(f"no `map {source_var} {dest_var} {{ ... }}` block found")
+
+
+def _map_entries(body: str) -> dict[str, str]:
+    """``{key: value}`` for each ``key value;`` entry in a map body (quotes stripped)."""
+    entries: dict[str, str] = {}
+    for line in body.splitlines():
+        line = line.strip().rstrip(";")
+        if not line:
+            continue
+        parts = line.split(None, 1)
+        if len(parts) != 2:
+            continue
+        key, value = parts
+        entries[key.strip('"')] = value.strip().strip('"')
+    return entries
+
+
+def _conf() -> str:
+    return _without_comments(NGINX_CONF.read_text())
+
+
+def test_cache_key_does_not_hold_the_raw_stretch_args():
+    """The raw args must not appear in proxy_cache_key at all — only the
+    mapped variables that blank what the active stretch mode ignores."""
+    conf = _conf()
+    match = _PROXY_CACHE_KEY.search(_location_block(conf, RASTER_TILES_LOCATION))
+    assert match, "expected a proxy_cache_key in the /raster-tiles/ location"
+    key = match.group(1)
+    for raw_arg in ("$arg_pmin", "$arg_pmax", "$arg_sigma"):
+        assert raw_arg not in key, (
+            f"proxy_cache_key still holds {raw_arg} unconditionally: {key!r}. "
+            "An anonymous caller can randomize it under stretch=minmax/absent "
+            "(where it changes nothing) to mint a fresh key per request, "
+            "defeating the cache the way `cols=<random>` did before #1785."
+        )
+    for mapped_var in (
+        "$geolens_raster_pmin",
+        "$geolens_raster_pmax",
+        "$geolens_raster_sigma",
+    ):
+        assert mapped_var in key, f"expected {mapped_var} in proxy_cache_key: {key!r}"
+
+
+def test_percentile_args_are_blanked_unless_stretch_is_percentile():
+    """pmin/pmax only change rendered bytes under stretch=percentile
+    (_compute_stretch_rescale); every other mode must key on a blank."""
+    conf = _conf()
+    for dest_var, arg_var in (
+        ("$geolens_raster_pmin", "$arg_pmin"),
+        ("$geolens_raster_pmax", "$arg_pmax"),
+    ):
+        entries = _map_entries(_map_body(conf, "$arg_stretch", dest_var))
+        assert entries.get("percentile") == arg_var, (
+            f"map $arg_stretch {dest_var}: stretch=percentile must forward "
+            f"{arg_var}, got {entries.get('percentile')!r}"
+        )
+        assert entries.get("default") == "", (
+            f"map $arg_stretch {dest_var}: every non-percentile stretch mode "
+            f"(minmax, absent, stddev) must blank the value, got "
+            f"{entries.get('default')!r}"
+        )
+
+
+def test_sigma_is_blanked_unless_stretch_is_stddev():
+    """sigma only changes rendered bytes under stretch=stddev; blanking it
+    unconditionally would instead collide two DIFFERENT stddev renders onto
+    one cache entry, which is a correctness bug, not just fragmentation."""
+    conf = _conf()
+    entries = _map_entries(_map_body(conf, "$arg_stretch", "$geolens_raster_sigma"))
+    assert entries.get("stddev") == "$arg_sigma", (
+        "map $arg_stretch $geolens_raster_sigma: stretch=stddev must forward "
+        f"$arg_sigma, got {entries.get('stddev')!r}"
+    )
+    assert entries.get("default") == "", (
+        "map $arg_stretch $geolens_raster_sigma: every non-stddev stretch mode "
+        f"(minmax, absent, percentile) must blank the value, got "
+        f"{entries.get('default')!r}"
+    )
+
+
+def test_sigma_still_varies_the_key_under_stddev():
+    """Counterfactual for the failure mode a blanket blank-everything fix would
+    introduce: two stddev requests with different sigma render different
+    bytes, so sigma must still reach the cache key when stretch=stddev."""
+    conf = _conf()
+    key_match = _PROXY_CACHE_KEY.search(_location_block(conf, RASTER_TILES_LOCATION))
+    assert key_match and "$geolens_raster_sigma" in key_match.group(1)
+    entries = _map_entries(_map_body(conf, "$arg_stretch", "$geolens_raster_sigma"))
+    assert entries.get("stddev") not in (None, ""), (
+        "stddev must not blank sigma out of the key, or two stddev requests "
+        "with different sigma would collide on one cache entry and serve one "
+        "request's bytes for the other's distinct render"
+    )

--- a/backend/tests/test_nginx_raster_stretch_cache_key_1778.py
+++ b/backend/tests/test_nginx_raster_stretch_cache_key_1778.py
@@ -1,6 +1,6 @@
 """The raster tile cache key must not vary on an arg the active stretch mode
 ignores, and a cache HIT must never change what an uncached request would
-answer (#1778, codebase audit 2026-08-30; codex rounds 1-4 on #1791).
+answer (#1778, codebase audit 2026-08-30; codex rounds 1-5 on #1791).
 
 frontend/nginx.conf's raster_cache proxy_cache_key used to hold
 $arg_pmin/$arg_pmax/$arg_sigma unconditionally. In
@@ -44,6 +44,24 @@ blind spots). When non-canonical, $geolens_raster_cache_extra folds the
 ENTIRE raw $args into the cache key, so correctness there is independent of
 any per-parameter reasoning: two requests share a key in the non-canonical
 case if and only if their raw query strings are identical.
+
+Round 5 found round 3's well-formedness check was stricter than it needed
+to be, in a way that reopened the exact cache-amplification vector this
+whole fix exists to close. It required a value to be WELL-FORMED AND IN THE
+RANGE THAT MATTERS FOR THE ACTIVE MODE (0-100 for pmin/pmax, positive for
+sigma) before blanking it under an inactive one -- a round-1 leftover from
+before round 2 made the API ignore an inactive value outright. Since the API
+never applies that range check to a value it never reads that far into, an
+out-of-range-but-syntactically-valid value (pmin=101, pmin=102, ...) stayed
+RAW, so an anonymous caller could still mint a distinct one-hour cache entry
+per distinct out-of-range value, all holding the identical tile.
+
+The round-5 rule: when the query is canonical and the parameter is
+inactive, blank every value FastAPI's float coercion would ACCEPT --
+matching its grammar (optional sign, digits, decimal point, exponent), not
+its semantic range -- and keep raw only what FastAPI cannot parse at all
+(its 422 path, unaffected by round 5, still covered by
+test_malformed_float_under_an_inactive_mode_stays_raw).
 
 These are structural (they read the conf and simulate nginx's own map
 evaluation in Python), because there is no nginx binary in this test
@@ -366,16 +384,36 @@ def test_sigma_still_varies_the_key_under_stddev():
     )
 
 
-def test_out_of_range_value_under_a_canonical_inactive_mode_stays_raw():
-    """A value the well-formedness check rejects (out of [0, 100] for
-    pmin/pmax, not > 0 for sigma) stays RAW even under an exact canonical
-    inactive spelling."""
+def test_out_of_range_but_syntactically_valid_value_under_a_canonical_inactive_mode_blanks():
+    """fix(#1778 codex r5): the API IGNORES an inactive pmin/pmax/sigma
+    outright (fix(#1778 codex r2)), so it never applies a [0, 100] / positive
+    range check to a value it never reads that far into. The previous
+    range-restricted well-formedness check left every out-of-range-but-
+    parseable value RAW, so an anonymous caller could mint a distinct
+    one-hour cache entry per distinct out-of-range value (101, 102, 103, ...)
+    even though every one of them renders the IDENTICAL tile -- the exact
+    cache-amplification vector this whole fix exists to close, reopened
+    through a side door. Range is irrelevant for an inactive parameter;
+    only a value FastAPI cannot parse as a float AT ALL stays raw (see
+    test_malformed_float_under_an_inactive_mode_stays_raw right below)."""
     conf = _conf()
-    for bad in ("200", "-5", "101", "100.5"):
-        assert _derive(conf, "pmin", _qs(stretch="minmax", pmin=bad)) == bad
-        assert _derive(conf, "pmax", _qs(stretch="minmax", pmax=bad)) == bad
-    for bad in ("-1", "0", "0.0", "0.000"):
-        assert _derive(conf, "sigma", _qs(stretch="minmax", sigma=bad)) == bad
+    for value in ("200", "-5", "101", "100.5", "1e3", "-1e10", "+5"):
+        assert _derive(conf, "pmin", _qs(stretch="minmax", pmin=value)) == ""
+        assert _derive(conf, "pmax", _qs(stretch="minmax", pmax=value)) == ""
+    for value in ("-1", "0", "0.0", "0.000", "-3.5e2"):
+        assert _derive(conf, "sigma", _qs(stretch="minmax", sigma=value)) == ""
+
+
+def test_the_coordinators_named_out_of_range_examples_collapse_to_the_blank_key():
+    """fix(#1778 codex r5): the literal cases named in the finding --
+    pmin=101, pmin=-5, sigma=0, pmax=1e3 under an inactive mode all blank,
+    and pmin=abc (unparseable, not merely out of range) still stays raw."""
+    conf = _conf()
+    assert _derive(conf, "pmin", _qs(stretch="minmax", pmin="101")) == ""
+    assert _derive(conf, "pmin", _qs(stretch="minmax", pmin="-5")) == ""
+    assert _derive(conf, "sigma", _qs(stretch="minmax", sigma="0")) == ""
+    assert _derive(conf, "pmax", _qs(stretch="minmax", pmax="1e3")) == ""
+    assert _derive(conf, "pmin", _qs(stretch="minmax", pmin="abc")) == "abc"
 
 
 # ---------------------------------------------------------------------------
@@ -579,9 +617,10 @@ def test_duplicated_stretch_falls_back_to_the_raw_value_instead_of_blanking():
 
 def test_non_duplicated_stretch_is_unaffected_by_the_guard():
     """The guard must not blank the fast path: an ordinary, non-duplicated
-    request keeps collapsing exactly as before, and an out-of-range value
-    still stays raw for the reason ordinary well-formedness does."""
+    request keeps collapsing exactly as before, an out-of-range-but-valid
+    value ALSO blanks (fix(#1778 codex r5) -- range no longer matters for an
+    inactive parameter), and the active mode still keeps a value raw."""
     conf = _conf()
     assert _derive(conf, "pmin", "stretch=minmax&pmin=5") == ""
-    assert _derive(conf, "pmin", "stretch=minmax&pmin=200") == "200"
+    assert _derive(conf, "pmin", "stretch=minmax&pmin=200") == ""
     assert _derive(conf, "pmin", "stretch=percentile&pmin=5") == "5"

--- a/backend/tests/test_nginx_raster_stretch_cache_key_1778.py
+++ b/backend/tests/test_nginx_raster_stretch_cache_key_1778.py
@@ -1,4 +1,4 @@
-"""The raster tile cache key must not vary on an arg the active stretch mode
+r"""The raster tile cache key must not vary on an arg the active stretch mode
 ignores, and a cache HIT must never change what an uncached request would
 answer (#1778, codebase audit 2026-08-30; codex rounds 1-9 on #1791).
 

--- a/backend/tests/test_nginx_raster_stretch_cache_key_1778.py
+++ b/backend/tests/test_nginx_raster_stretch_cache_key_1778.py
@@ -1,6 +1,6 @@
 """The raster tile cache key must not vary on an arg the active stretch mode
 ignores, and a cache HIT must never change what an uncached request would
-answer (#1778, codebase audit 2026-08-30; codex rounds 1 and 2 on #1791).
+answer (#1778, codebase audit 2026-08-30; codex rounds 1-3 on #1791).
 
 frontend/nginx.conf's raster_cache proxy_cache_key used to hold
 $arg_pmin/$arg_pmax/$arg_sigma unconditionally. In
@@ -12,42 +12,58 @@ neither -- the fragment passed to Titiler is unchanged either way. So
 byte-identical to the unfiltered tile, the same defeat #1785 closed for the
 vector tile ``cols=`` param.
 
-Round 1 blanked every inactive value unconditionally, which introduced a
-different bug: raster_tile_proxy validated pmin/pmax/sigma whenever PRESENT,
-regardless of the active stretch mode, so blanking pmin under
-``?stretch=minmax&pmin=200`` collapsed it onto the same key as a cached
-``?stretch=minmax`` and returned that entry's 200, though the API would 422
-an out-of-range pmin uncached.
-
-Round 2 changed the API side instead of chasing round 1's nginx-only fix
+Round 1 blanked every inactive value unconditionally, which could let a
+cache HIT answer with a status an uncached request would not have gotten
+(raster_tile_proxy validated pmin/pmax/sigma whenever PRESENT, regardless of
+mode). Round 2 changed the API side instead of chasing that nginx-only fix
 further: raster_tile_proxy now IGNORES pmin/pmax when stretch is not
-percentile and sigma when it is not stddev, rather than merely leaving them
-unvalidated. "Inactive" means the same thing, ignored, on both sides, so
-every map below blanks an inactive value UNCONDITIONALLY -- there is no
-verdict left to disagree with, because the value is never read. That also
-closes the residual round 1 could not: a repeated query parameter, where
-nginx's $arg_x reads the FIRST occurrence and FastAPI's scalar Query reads
-the LAST.
+percentile and sigma when it is not stddev, so blanking an inactive value
+can never disagree with the API about STATUS -- there is no verdict left to
+disagree with.
 
-One more residual survives even that change: the duplicate-parameter mismatch
-applies to `stretch` itself too. `?stretch=minmax&stretch=percentile&pmin=5`
-has nginx read stretch=minmax (blank pmin) while the API reads
-stretch=percentile (uses pmin=5) -- and because blanking makes the cache key
-depend on nginx's OWN reading of stretch, a second such request with a
-DIFFERENT pmin would collapse onto the SAME key while rendering DIFFERENT
-bytes: a collision, not just a status mismatch.
-$geolens_raster_stretch_dup detects a repeated `stretch=` in the raw query
-string and, when set, every map falls back to the raw value instead of
-blanking -- an extra cache miss, never a collision.
+Round 3 found that round 2's API change is necessary but not sufficient,
+because nginx's read of the query string and the API's read of it can
+disagree about which VALUE, or even which MODE, is in play, independent of
+what the API validates or ignores:
+
+- percent-encoding: ``stretch=%70ercentile`` decodes to the ACTIVE spelling
+  at the API (FastAPI URL-decodes query params) but nginx's raw
+  ``$arg_stretch`` never matches ``percentile`` literally. Treating "not the
+  literal active spelling" as "therefore inactive" blanked pmin here, so two
+  requests with different pmin values collapsed onto ONE key while the API
+  rendered DIFFERENT bytes for them: a cache collision, not a status
+  mismatch.
+- a case variant (``MinMax``), for the same reason (nginx's regex is
+  case-sensitive and never normalizes).
+- a malformed float (``pmin=abc``): the API's "ignore when inactive" code in
+  ``raster_tile_proxy`` never runs for this, because FastAPI's
+  ``pmin: float | None`` coerces the query param to a ``float`` BEFORE the
+  endpoint body executes at all, and ``abc`` fails that coercion with a 422
+  regardless of stretch mode. Blanking it let a cached 200 answer a request
+  the API 422s uncached.
+
+The principle that closes all three the same way: blank an argument ONLY
+when nginx can be CERTAIN blanking cannot change the outcome -- the raw
+``$arg_stretch`` is EXACTLY one of the canonical spellings this argument is
+inactive under (no percent-encoding, no case variant: PCRE matches the
+literal, decoded string only) AND the argument itself is a well-formed float
+in the range that matters in the one mode where it IS active. Everything
+else -- an unrecognized stretch spelling, a duplicated one
+($geolens_raster_stretch_dup), a malformed or merely out-of-range value -- is
+left RAW: the request misses the cache and the API decides on its own terms.
+Failing toward "keep raw" only ever costs an extra cache miss; failing
+toward "blank" risks a wrong tile or a wrong status.
 
 These are structural (they read the conf and simulate nginx's own map
 evaluation in Python, including nginx's $arg_x "first occurrence of a
-repeated key" semantics), because there is no nginx binary in this test
-environment to render and query directly. The companion API-level pin lives
-in test_raster_colormap_proxy.py::TestRasterColormapProxy::
+repeated key" semantics and its PCRE case-sensitivity), because there is no
+nginx binary in this test environment to render and query directly. The
+companion API-level pin lives in test_raster_colormap_proxy.py::
+TestRasterColormapProxy::
 test_out_of_range_bounds_are_ignored_under_an_inactive_stretch_mode, which
-confirms the API side of the contract these maps rely on: pmin/pmax/sigma are
-ignored, not validated, whenever the active stretch mode does not read them.
+confirms the API side of the contract these maps rely on: pmin/pmax/sigma
+are ignored, not validated, whenever the active stretch mode does not read
+them.
 """
 
 import re
@@ -180,7 +196,8 @@ def _evaluate_map(
     values: dict[str, str],
 ) -> str:
     """Evaluate one nginx ``map`` the way nginx itself would: try each regex
-    entry in declaration order, first match wins; ``default`` otherwise."""
+    entry in declaration order (PCRE, case-sensitive, exactly as nginx's
+    default), first match wins; ``default`` otherwise."""
     source = _expand(source_template, values)
     for pattern, template in entries:
         if re.match(pattern, source):
@@ -250,15 +267,15 @@ def test_cache_key_does_not_hold_the_raw_stretch_args():
 
 
 # ---------------------------------------------------------------------------
-# pmin / pmax: percentile is the active mode; sigma: stddev is.
-# Round 2: blank UNCONDITIONALLY when inactive -- no well-formedness check
-# needed any more, since the API ignores an inactive value regardless.
+# pmin / pmax: percentile is the active mode; sigma: stddev is. Round 3:
+# blank ONLY when stretch is an EXACT canonical inactive spelling AND the
+# value is a well-formed float in range -- everything else stays raw.
 # ---------------------------------------------------------------------------
 
 
 def test_active_mode_always_passes_the_value_through_raw():
     """Active mode: the value must vary the key regardless of content --
-    percentile/stddev genuinely read it, unchanged from before either fix."""
+    percentile/stddev genuinely read it, unchanged since round 1."""
     conf = _conf()
     for value in ("5", "200", "-1", "abc", ""):
         assert _derive(conf, "pmin", _qs(stretch="percentile", pmin=value)) == value
@@ -266,27 +283,30 @@ def test_active_mode_always_passes_the_value_through_raw():
         assert _derive(conf, "sigma", _qs(stretch="stddev", sigma=value)) == value
 
 
-def test_any_value_under_an_inactive_mode_collapses_to_one_key():
-    """fix(#1778 codex r2): unconditional blanking. Any value at all -- valid,
-    invalid, or malformed -- under an inactive stretch mode must collapse to
-    the same blank key, because the API ignores it regardless of content."""
+def test_well_formed_value_under_a_canonical_inactive_mode_collapses_to_one_key():
+    """A random but well-formed, in-range value under the exact canonical
+    inactive spelling (or absent) must still collapse -- the cache-busting
+    vector #1785's shape closed stays closed for the common case."""
     conf = _conf()
-    values = ["", "0", "50", "100", "200", "-5", "abc", "1e10", "100.5", "0.5"]
-    for param, active in (
-        ("pmin", "percentile"),
-        ("pmax", "percentile"),
-        ("sigma", "stddev"),
-    ):
-        for stretch in ("minmax", ""):
-            derived = {
-                _derive(conf, param, _qs(stretch=stretch, **{param: v})) for v in values
-            }
-            assert derived == {""}, (
-                f"{param} under stretch={stretch!r} collapsed to {derived!r}, "
-                "expected all blank -- the API ignores this value under this "
-                "mode regardless of content, so it must never defeat the cache"
-            )
-        assert active  # documents the pairing; not asserted here
+    pmin_pmax_values = ["", "0", "2", "50", "98", "99.999", "100", "100.0"]
+    sigma_values = ["", "0.5", "1", "2", "10", "0.001"]
+    for stretch in ("minmax", ""):
+        assert {
+            _derive(conf, "pmin", _qs(stretch=stretch, pmin=v))
+            for v in pmin_pmax_values
+        } == {""}
+        assert {
+            _derive(conf, "pmax", _qs(stretch=stretch, pmax=v))
+            for v in pmin_pmax_values
+        } == {""}
+    for stretch in ("minmax", "percentile", ""):
+        assert {
+            _derive(conf, "sigma", _qs(stretch=stretch, sigma=v)) for v in sigma_values
+        } == {""}
+    # stddev is the OTHER canonical inactive spelling for pmin/pmax.
+    assert {
+        _derive(conf, "pmin", _qs(stretch="stddev", pmin=v)) for v in pmin_pmax_values
+    } == {""}
 
 
 def test_sigma_still_varies_the_key_under_stddev():
@@ -306,29 +326,120 @@ def test_sigma_still_varies_the_key_under_stddev():
     )
 
 
+def test_out_of_range_value_under_a_canonical_inactive_mode_stays_raw():
+    """A value the well-formedness check rejects (out of [0, 100] for
+    pmin/pmax, not > 0 for sigma) stays RAW even under an exact canonical
+    inactive spelling -- the conservative direction the coordinator's
+    principle asks for: some legitimate-but-unusual values miss the cache
+    that technically could not have changed the answer either, in exchange
+    for never needing a more permissive, harder-to-audit numeric regex."""
+    conf = _conf()
+    for bad in ("200", "-5", "101", "100.5"):
+        assert _derive(conf, "pmin", _qs(stretch="minmax", pmin=bad)) == bad
+        assert _derive(conf, "pmax", _qs(stretch="minmax", pmax=bad)) == bad
+    for bad in ("-1", "0", "0.0", "0.000"):
+        assert _derive(conf, "sigma", _qs(stretch="minmax", sigma=bad)) == bad
+
+
+# ---------------------------------------------------------------------------
+# fix(#1778 codex r3): the three ways nginx's raw read of the query string
+# can disagree with the API's decoded/coerced read, independent of what the
+# API validates or ignores. Each must stay raw, never blank.
+# ---------------------------------------------------------------------------
+
+
+def test_percent_encoded_active_spelling_stays_raw():
+    """`stretch=%70ercentile` decodes to `percentile` (ACTIVE) at the API,
+    which URL-decodes query params; nginx's raw $arg_stretch is the literal
+    string `%70ercentile`, which matches neither canonical inactive spelling.
+    It must stay raw so two different pmin values under this encoding get
+    two different keys, never one collapsed onto a rendering the API would
+    actually vary by pmin."""
+    conf = _conf()
+    args_5 = _qs(stretch="%70ercentile", pmin="5")
+    args_50 = _qs(stretch="%70ercentile", pmin="50")
+    derived_5 = _derive(conf, "pmin", args_5)
+    derived_50 = _derive(conf, "pmin", args_50)
+    assert derived_5 == "5"
+    assert derived_50 == "50"
+    assert derived_5 != derived_50, (
+        "a percent-encoded active stretch spelling must not let two "
+        "different pmin values collapse onto one cache key"
+    )
+
+
+def test_case_variant_of_a_canonical_spelling_stays_raw():
+    """PCRE matching here is case-sensitive by default, same as FastAPI's
+    Literal validator (which would 422 `MinMax` as an invalid literal value
+    -- not decode-and-normalize it the way percent-encoding is decoded). A
+    case variant must never be treated as the canonical inactive spelling."""
+    conf = _conf()
+    for variant in ("MinMax", "MINMAX", "Stddev", "PERCENTILE"):
+        derived = _derive(conf, "pmin", _qs(stretch=variant, pmin="5"))
+        assert derived == "5", (
+            f"stretch={variant!r} must keep pmin raw (got {derived!r}) -- "
+            "nginx must never treat a case variant as a canonical spelling"
+        )
+
+
+def test_malformed_float_under_an_inactive_mode_stays_raw():
+    """`?stretch=minmax&pmin=abc` must miss the cache, not collapse onto the
+    plain `?stretch=minmax` key. FastAPI's `pmin: float | None` coerces the
+    query param to a float BEFORE raster_tile_proxy's body runs at all --
+    round 2's "ignore pmin when inactive" code never gets a chance to run,
+    because the framework's own type coercion 422s on a non-numeric string
+    regardless of stretch mode. Blanking it here would let a cached 200
+    answer that 422.
+
+    Values chosen to be unambiguously non-numeric -- not merely large or
+    signed, both of which Python's own float() parser (and therefore
+    pydantic's coercion) accepts without a 422, and which the well-formed
+    numeric regex already keeps raw for the "out of range" reason covered
+    separately above.
+    """
+    conf = _conf()
+    for bad in ("abc", "5,6", "50:60", "1.2.3", "five"):
+        derived = _derive(conf, "pmin", _qs(stretch="minmax", pmin=bad))
+        assert derived == bad, (
+            f"pmin={bad!r} under stretch=minmax must stay RAW (got "
+            f"{derived!r}) -- FastAPI's float coercion 422s this regardless "
+            "of stretch mode, and blanking it would let a cache hit answer "
+            "a 200 for what an uncached request 422s"
+        )
+    for bad in ("abc", "1,2", "5.6.7"):
+        derived = _derive(conf, "sigma", _qs(stretch="minmax", sigma=bad))
+        assert derived == bad
+
+
 # ---------------------------------------------------------------------------
 # Duplicate `pmin`/`pmax`/`sigma`: closed by ignoring the inactive value
-# entirely, so which occurrence either side reads no longer matters.
+# entirely at the API AND requiring well-formedness at nginx, so which
+# occurrence either side reads matters only when it changes well-formedness.
 # ---------------------------------------------------------------------------
 
 
-def test_repeated_inactive_param_still_collapses_regardless_of_occurrence_order():
-    """The exact case codex found: nginx reads the FIRST occurrence, FastAPI
-    reads the LAST. Both occurrences must still blank identically, because
-    the API ignores the parameter under this mode no matter which value it
-    resolves to."""
+def test_repeated_well_formed_inactive_param_collapses_regardless_of_occurrence_order():
+    """Both duplicate occurrences are well-formed and in range, so nginx's
+    FIRST-occurrence read and the API's LAST-occurrence read are both
+    ignored identically under stretch=minmax -- collapsing is safe regardless
+    of which one nginx happens to see."""
     conf = _conf()
-    well_formed_first = _derive(
-        conf, "pmin", "stretch=minmax&pmin=5&pmin=200"
-    )  # nginx sees 5 (well-formed if it mattered), API would see 200
-    out_of_range_first = _derive(
-        conf, "pmin", "stretch=minmax&pmin=200&pmin=5"
-    )  # nginx sees 200 (would have been the round-1 residual), API sees 5
-    assert well_formed_first == out_of_range_first == "", (
-        f"got {well_formed_first!r} and {out_of_range_first!r} -- a repeated "
-        "pmin under an inactive stretch mode must blank the same way "
-        "regardless of which occurrence nginx happens to read"
-    )
+    a = _derive(conf, "pmin", "stretch=minmax&pmin=5&pmin=50")
+    b = _derive(conf, "pmin", "stretch=minmax&pmin=50&pmin=5")
+    assert a == b == "", f"got {a!r} and {b!r}, expected both blank"
+
+
+def test_repeated_param_stays_raw_when_the_first_occurrence_is_not_well_formed():
+    """codex's literal example: nginx reads the FIRST occurrence of a
+    repeated pmin. When that first occurrence is out of range or malformed,
+    nginx must keep it raw regardless of what the API's LAST-occurrence read
+    would have been -- the well-formedness gate applies to whichever
+    occurrence nginx actually sees, not to some notion of "the pair"."""
+    conf = _conf()
+    out_of_range_first = _derive(conf, "pmin", "stretch=minmax&pmin=200&pmin=5")
+    malformed_first = _derive(conf, "pmin", "stretch=minmax&pmin=abc&pmin=5")
+    assert out_of_range_first == "200"
+    assert malformed_first == "abc"
 
 
 # ---------------------------------------------------------------------------
@@ -373,8 +484,9 @@ def test_duplicated_stretch_falls_back_to_the_raw_value_instead_of_blanking():
 
 def test_non_duplicated_stretch_is_unaffected_by_the_guard():
     """The guard must not blank the fast path: an ordinary, non-duplicated
-    request keeps collapsing exactly as before."""
+    request keeps collapsing exactly as before, and an out-of-range value
+    still stays raw for the reason ordinary well-formedness does."""
     conf = _conf()
     assert _derive(conf, "pmin", "stretch=minmax&pmin=5") == ""
-    assert _derive(conf, "pmin", "stretch=minmax&pmin=200") == ""
+    assert _derive(conf, "pmin", "stretch=minmax&pmin=200") == "200"
     assert _derive(conf, "pmin", "stretch=percentile&pmin=5") == "5"

--- a/backend/tests/test_nginx_raster_stretch_cache_key_1778.py
+++ b/backend/tests/test_nginx_raster_stretch_cache_key_1778.py
@@ -1,27 +1,39 @@
 """The raster tile cache key must not vary on an arg the active stretch mode
-ignores (#1778, codebase audit 2026-08-30).
+ignores, and a cache HIT must never change the status code a request gets
+(#1778, codebase audit 2026-08-30; codex round 1 on #1791).
 
 frontend/nginx.conf's raster_cache proxy_cache_key used to hold
 $arg_pmin/$arg_pmax/$arg_sigma unconditionally. In
 backend/app/processing/tiles/router.py, stretch=percentile is the only mode
 that reads pmin/pmax (_compute_stretch_rescale) and stretch=stddev is the only
 mode that reads sigma; stretch=minmax (the default) or an absent stretch reads
-neither — the fragment passed to Titiler is unchanged either way. So
+neither -- the fragment passed to Titiler is unchanged either way. So
 ``?stretch=minmax&pmin=<random>`` produced a fresh cache key holding bytes
 byte-identical to the unfiltered tile, the same defeat #1785 closed for the
-vector tile ``cols=`` param: on the default production stack (no Valkey) those
-writes land in a bounded LRU and evict legitimate tiles.
+vector tile ``cols=`` param.
 
-The fix mirrors #1785's shape: a ``map`` keyed on ``$arg_stretch`` blanks each
-arg family down to what the active mode can actually change, and the cache key
-is built from the mapped variables rather than the raw ``$arg_*`` ones.
-Blanking BOTH families unconditionally would not just fragment the cache the
-other direction, it would misbehave: two stddev requests with different sigma
-values render different bytes and must still key apart, so only the family
-each mode ignores is blanked.
+The first revision of this fix blanked every inactive value unconditionally,
+which introduced a different bug: raster_tile_proxy validates pmin/pmax/sigma
+whenever they are PRESENT, regardless of the active stretch mode (T-1153-01),
+so ``?stretch=minmax&pmin=200`` uncached answers 422 -- but blanking pmin
+unconditionally collapsed it onto the SAME key as a cached ``?stretch=minmax``
+and returned that entry's 200. A cache hit must never change endpoint
+semantics.
 
-These are structural (they read the conf), because there is no nginx binary
-in this test environment to render and query directly.
+The current maps blank a value only when it is BOTH inactive for the request's
+mode AND within the range the API itself accepts (0-100 for pmin/pmax,
+positive for sigma). A value in that range can never turn the API's verdict
+from 200 into 422, so blanking it never changes the status a client gets;
+anything malformed or out of range is left RAW, so it misses the cache and
+reaches the API for the same 422 an uncached request would get.
+
+These are structural (they read the conf and simulate nginx's own map
+evaluation in Python), because there is no nginx binary in this test
+environment to render and query directly. The companion API-level pin lives in
+test_raster_colormap_proxy.py::TestRasterColormapProxy::
+test_invalid_bounds_return_422_even_under_an_inactive_stretch_mode, which
+confirms the API side of the property these maps rely on: pmin/pmax/sigma are
+rejected whenever present, regardless of stretch mode.
 """
 
 import re
@@ -35,6 +47,13 @@ RASTER_TILES_LOCATION = r"location\s+~\s+\^/raster-tiles/"
 _LOCATION_HEADER = re.compile(r"^[ \t]*location\b[^\n{]*\{", re.M)
 _MAP_HEADER = re.compile(r"^map\s+(\S+)\s+(\S+)\s*\{", re.M)
 _PROXY_CACHE_KEY = re.compile(r'^\s*proxy_cache_key\s+"([^"]+)"\s*;', re.M)
+
+# (unquoted source template, dest var) for each param this file cares about.
+_MAPS: dict[str, tuple[str, str]] = {
+    "pmin": ("$arg_stretch:$arg_pmin", "$geolens_raster_pmin"),
+    "pmax": ("$arg_stretch:$arg_pmax", "$geolens_raster_pmax"),
+    "sigma": ("$arg_stretch:$arg_sigma", "$geolens_raster_sigma"),
+}
 
 
 def _without_comments(text: str) -> str:
@@ -63,35 +82,88 @@ def _location_block(text: str, header_pattern: str) -> str:
     return _balanced_body(text, text.index("{", match.start()))
 
 
-def _map_body(text: str, source_var: str, dest_var: str) -> str:
-    """Body of ``map $source_var $dest_var { ... }``, or raise."""
+def _map_body(text: str, source_expr: str, dest_var: str) -> str:
+    """Body of ``map "source_expr" dest_var { ... }`` (source_expr unquoted)."""
+    quoted_source = f'"{source_expr}"'
     for match in _MAP_HEADER.finditer(text):
-        if match.group(1) == source_var and match.group(2) == dest_var:
+        if match.group(1) == quoted_source and match.group(2) == dest_var:
             return _balanced_body(text, text.index("{", match.start()))
-    raise AssertionError(f"no `map {source_var} {dest_var} {{ ... }}` block found")
+    raise AssertionError(f'no `map "{source_expr}" {dest_var} {{ ... }}` block found')
 
 
-def _map_entries(body: str) -> dict[str, str]:
-    """``{key: value}`` for each ``key value;`` entry in a map body (quotes stripped)."""
-    entries: dict[str, str] = {}
+def _map_entries_ordered(body: str) -> tuple[list[tuple[str, str]], str]:
+    """``([(pattern_without_tilde, value_template), ...], default_template)``.
+
+    Declaration order is preserved, since nginx tries regex entries in the
+    order they were written and the first match wins. Asserts every non-default
+    entry is a regex (``~``-prefixed) — a literal entry slipping in would be
+    matched by nginx's hash lookup instead, which this simulation does not
+    model, and a silent mismatch there is worse than a loud assertion here.
+    """
+    entries: list[tuple[str, str]] = []
+    default_value: str | None = None
     for line in body.splitlines():
         line = line.strip().rstrip(";")
         if not line:
             continue
-        parts = line.split(None, 1)
-        if len(parts) != 2:
-            continue
-        key, value = parts
-        entries[key.strip('"')] = value.strip().strip('"')
-    return entries
+        key, value = line.split(None, 1)
+        key = key.strip('"')
+        value = value.strip().strip('"')
+        if key == "default":
+            default_value = value
+        else:
+            assert key.startswith("~"), f"expected a regex map entry, got {key!r}"
+            entries.append((key[1:], value))
+    assert default_value is not None, "map has no default entry"
+    return entries, default_value
+
+
+def _expand(template: str, arg_values: dict[str, str]) -> str:
+    """Substitute ``$arg_NAME`` tokens in a map source template or value."""
+
+    def _sub(match: re.Match) -> str:
+        return arg_values.get(match.group(1), "")
+
+    return re.sub(r"\$arg_(\w+)", _sub, template)
+
+
+def _evaluate_map(
+    source_template: str,
+    entries: list[tuple[str, str]],
+    default_value: str,
+    arg_values: dict[str, str],
+) -> str:
+    """Evaluate one nginx ``map`` the way nginx itself would: try each regex
+    entry in declaration order, first match wins; ``default`` otherwise."""
+    source = _expand(source_template, arg_values)
+    for pattern, template in entries:
+        if re.match(pattern, source):
+            return _expand(template, arg_values)
+    return _expand(default_value, arg_values)
 
 
 def _conf() -> str:
     return _without_comments(NGINX_CONF.read_text())
 
 
+def _derive(conf: str, param: str, stretch: str, value: str) -> str:
+    """The cache-key value nginx would compute for ``param`` given
+    ``?stretch=<stretch>&<param>=<value>``."""
+    source_template, dest_var = _MAPS[param]
+    entries, default_value = _map_entries_ordered(
+        _map_body(conf, source_template, dest_var)
+    )
+    arg_values = {"stretch": stretch, param: value}
+    return _evaluate_map(source_template, entries, default_value, arg_values)
+
+
+# ---------------------------------------------------------------------------
+# The cache key itself
+# ---------------------------------------------------------------------------
+
+
 def test_cache_key_does_not_hold_the_raw_stretch_args():
-    """The raw args must not appear in proxy_cache_key at all — only the
+    """The raw args must not appear in proxy_cache_key at all -- only the
     mapped variables that blank what the active stretch mode ignores."""
     conf = _conf()
     match = _PROXY_CACHE_KEY.search(_location_block(conf, RASTER_TILES_LOCATION))
@@ -112,41 +184,98 @@ def test_cache_key_does_not_hold_the_raw_stretch_args():
         assert mapped_var in key, f"expected {mapped_var} in proxy_cache_key: {key!r}"
 
 
-def test_percentile_args_are_blanked_unless_stretch_is_percentile():
-    """pmin/pmax only change rendered bytes under stretch=percentile
-    (_compute_stretch_rescale); every other mode must key on a blank."""
-    conf = _conf()
-    for dest_var, arg_var in (
-        ("$geolens_raster_pmin", "$arg_pmin"),
-        ("$geolens_raster_pmax", "$arg_pmax"),
-    ):
-        entries = _map_entries(_map_body(conf, "$arg_stretch", dest_var))
-        assert entries.get("percentile") == arg_var, (
-            f"map $arg_stretch {dest_var}: stretch=percentile must forward "
-            f"{arg_var}, got {entries.get('percentile')!r}"
-        )
-        assert entries.get("default") == "", (
-            f"map $arg_stretch {dest_var}: every non-percentile stretch mode "
-            f"(minmax, absent, stddev) must blank the value, got "
-            f"{entries.get('default')!r}"
-        )
+# ---------------------------------------------------------------------------
+# pmin / pmax: percentile is the active mode; blank only a well-formed,
+# in-range (0-100) inactive value.
+# ---------------------------------------------------------------------------
 
 
-def test_sigma_is_blanked_unless_stretch_is_stddev():
-    """sigma only changes rendered bytes under stretch=stddev; blanking it
-    unconditionally would instead collide two DIFFERENT stddev renders onto
-    one cache entry, which is a correctness bug, not just fragmentation."""
+def test_percentile_mode_always_passes_pmin_pmax_through_raw():
+    """Active mode: pmin/pmax must vary the key regardless of validity,
+    unchanged from before this fix -- percentile genuinely reads them, and an
+    invalid value under percentile already 422s on its own (unaffected by
+    caching, since a 422 is never stored under `proxy_cache_valid 200 1h`)."""
     conf = _conf()
-    entries = _map_entries(_map_body(conf, "$arg_stretch", "$geolens_raster_sigma"))
-    assert entries.get("stddev") == "$arg_sigma", (
-        "map $arg_stretch $geolens_raster_sigma: stretch=stddev must forward "
-        f"$arg_sigma, got {entries.get('stddev')!r}"
+    for param in ("pmin", "pmax"):
+        for value in ("5", "200", "-1", "abc", ""):
+            assert _derive(conf, param, "percentile", value) == value
+
+
+def test_valid_random_pmin_pmax_still_collapse_to_one_key():
+    """The cache-busting vector #1785's fix closed for `cols=`: many DIFFERENT
+    but individually well-formed pmin/pmax values under an inactive stretch
+    mode must all still collapse to the SAME (blank) cache-key component."""
+    conf = _conf()
+    values = ["", "0", "2", "50", "98", "99.999", "100", "100.0"]
+    for param in ("pmin", "pmax"):
+        for stretch in ("minmax", ""):
+            derived = {_derive(conf, param, stretch, v) for v in values}
+            assert derived == {""}, (
+                f"{param} under stretch={stretch!r} collapsed to {derived!r}, "
+                "expected all blank -- a well-formed random value must not "
+                "defeat the cache"
+            )
+
+
+def test_out_of_range_pmin_pmax_are_not_blanked():
+    """fix(#1778 codex r1): the regression codex found. Blanking pmin
+    unconditionally under an inactive stretch mode let a cached
+    `?stretch=minmax` answer `?stretch=minmax&pmin=200` with its cached 200,
+    though raster_tile_proxy validates pmin whenever it is present regardless
+    of stretch mode and would 422 an out-of-range value uncached. A value
+    outside what the API accepts must stay RAW: it misses the cache and
+    reaches the API for the same 422 an uncached request would get."""
+    conf = _conf()
+    for param in ("pmin", "pmax"):
+        for bad in ("200", "-5", "abc", "1e10", "101", "100.5", "50:60"):
+            derived = _derive(conf, param, "minmax", bad)
+            assert derived == bad, (
+                f"{param}={bad!r} under an inactive stretch mode must stay "
+                f"RAW in the cache key, got {derived!r} -- a cache hit here "
+                "would answer 200 for a request the API would 422"
+            )
+            assert derived != "", (
+                f"{param}={bad!r} must not collapse onto the blank key"
+            )
+
+
+# ---------------------------------------------------------------------------
+# sigma: stddev is the active mode; blank only a well-formed positive value.
+# ---------------------------------------------------------------------------
+
+
+def test_stddev_mode_always_passes_sigma_through_raw():
+    conf = _conf()
+    for value in ("2", "-1", "0", "abc", ""):
+        assert _derive(conf, "sigma", "stddev", value) == value
+
+
+def test_valid_random_sigma_still_collapses_to_one_key():
+    """Counterfactual for the failure mode a blanket blank-everything fix
+    would introduce: two stddev requests with different sigma render
+    different bytes and must still key apart (covered separately below); this
+    pins the complementary half, that well-formed sigma values collapse when
+    sigma is inactive."""
+    conf = _conf()
+    values = ["", "0.5", "1", "2", "10", "0.001"]
+    derived = {_derive(conf, "sigma", "minmax", v) for v in values}
+    assert derived == {""}, (
+        f"sigma under an inactive stretch mode collapsed to {derived!r}, "
+        "expected all blank"
     )
-    assert entries.get("default") == "", (
-        "map $arg_stretch $geolens_raster_sigma: every non-stddev stretch mode "
-        f"(minmax, absent, percentile) must blank the value, got "
-        f"{entries.get('default')!r}"
-    )
+
+
+def test_out_of_range_sigma_is_not_blanked():
+    """sigma must be strictly positive (`sigma > 0`); zero and negative
+    values must stay RAW under an inactive stretch mode for the same reason
+    an out-of-range pmin must."""
+    conf = _conf()
+    for bad in ("-1", "0", "0.0", "0.000", "abc"):
+        derived = _derive(conf, "sigma", "minmax", bad)
+        assert derived == bad, (
+            f"sigma={bad!r} under an inactive stretch mode must stay RAW, "
+            f"got {derived!r}"
+        )
 
 
 def test_sigma_still_varies_the_key_under_stddev():
@@ -156,8 +285,9 @@ def test_sigma_still_varies_the_key_under_stddev():
     conf = _conf()
     key_match = _PROXY_CACHE_KEY.search(_location_block(conf, RASTER_TILES_LOCATION))
     assert key_match and "$geolens_raster_sigma" in key_match.group(1)
-    entries = _map_entries(_map_body(conf, "$arg_stretch", "$geolens_raster_sigma"))
-    assert entries.get("stddev") not in (None, ""), (
+    assert _derive(conf, "sigma", "stddev", "2") != _derive(
+        conf, "sigma", "stddev", "3"
+    ), (
         "stddev must not blank sigma out of the key, or two stddev requests "
         "with different sigma would collide on one cache entry and serve one "
         "request's bytes for the other's distinct render"

--- a/backend/tests/test_raster_colormap_proxy.py
+++ b/backend/tests/test_raster_colormap_proxy.py
@@ -609,29 +609,40 @@ class TestRasterColormapProxy:
             ({"sigma": -1}, "sigma<0 under an inactive stretch mode"),
         ],
     )
-    async def test_invalid_bounds_return_422_even_under_an_inactive_stretch_mode(
+    async def test_out_of_range_bounds_are_ignored_under_an_inactive_stretch_mode(
         self, client, bad_params, description
     ):
-        """[T-1153-01] fix(#1778 codex r1): pmin/pmax/sigma are validated whenever
-        PRESENT, regardless of the active stretch mode -- stretch=minmax reads
-        neither pmin/pmax nor sigma, but an out-of-range value still 422s.
+        """[T-1153-01] fix(#1778 codex r2): pmin/pmax/sigma are read and
+        validated ONLY when the active stretch mode reads them -- stretch=
+        minmax reads neither pmin/pmax nor sigma, so an out-of-range value
+        under it is ignored, not rejected.
 
-        This is the property frontend/nginx.conf's raster proxy_cache_key relies
-        on: it blanks an inactive arg out of the cache key only when the value is
-        well-formed enough that the API could never turn it into a 422, so a
-        cache HIT can never answer with a different status than an uncached
-        request would get. An out-of-range value under stretch=minmax must stay
-        exactly as rejected as it is here, uncached.
+        This inverts what round 1 of this fix pinned (validate regardless of
+        mode). That version made "inactive" a claim the API could contradict:
+        frontend/nginx.conf's raster proxy_cache_key blanks an inactive value
+        out of the cache key so a random one cannot defeat the cache, and a
+        cache HIT must never answer with a status an uncached request would
+        not have given. Round 1 closed that by validating anyway and only
+        blanking well-formed values, but that still had two residuals (a
+        joint pmin/pmax ordering nginx cannot cheaply check, and a repeated
+        query parameter, where nginx reads the FIRST occurrence and this
+        endpoint's scalar Query reads the LAST). Making "inactive" mean
+        "ignored" here closes both: there is no verdict left to disagree
+        with, on either side, for a value that is never read.
         """
         params = {"stretch": "minmax"}
         params.update(bad_params)
         resp = await client.get(_TILE_PATH, params=params)
-        assert resp.status_code == 422, (
-            f"Expected 422 for {description}, got {resp.status_code}"
+        assert resp.status_code in (200, 204), (
+            f"Expected {description} to be ignored (200/204), got "
+            f"{resp.status_code}: {resp.text}"
         )
-        assert len(self._tile_titiler_calls) == 0, (
-            f"Titiler was called despite invalid bounds ({description}): {self._tile_titiler_calls}"
+        assert len(self._tile_titiler_calls) == 1, (
+            f"Expected the tile fetch to proceed for {description}, got "
+            f"{self._tile_titiler_calls}"
         )
+        # minmax never computes stats, active or not.
+        assert len(self._stats_titiler_calls) == 0
 
     async def test_dem_with_custom_bounds_no_rescale(self, client):
         """[T-1153-03] DEM (algorithm= render_params) ignores pmin/pmax/sigma — no rescale injected."""

--- a/backend/tests/test_raster_colormap_proxy.py
+++ b/backend/tests/test_raster_colormap_proxy.py
@@ -599,6 +599,40 @@ class TestRasterColormapProxy:
             f"Titiler was called despite invalid bounds ({description}): {self._tile_titiler_calls}"
         )
 
+    @pytest.mark.parametrize(
+        "bad_params,description",
+        [
+            ({"pmin": 200}, "pmin>100 under an inactive stretch mode"),
+            ({"pmax": 101}, "pmax>100 under an inactive stretch mode"),
+            ({"pmin": -1}, "pmin<0 under an inactive stretch mode"),
+            ({"sigma": 0}, "sigma=0 under an inactive stretch mode"),
+            ({"sigma": -1}, "sigma<0 under an inactive stretch mode"),
+        ],
+    )
+    async def test_invalid_bounds_return_422_even_under_an_inactive_stretch_mode(
+        self, client, bad_params, description
+    ):
+        """[T-1153-01] fix(#1778 codex r1): pmin/pmax/sigma are validated whenever
+        PRESENT, regardless of the active stretch mode -- stretch=minmax reads
+        neither pmin/pmax nor sigma, but an out-of-range value still 422s.
+
+        This is the property frontend/nginx.conf's raster proxy_cache_key relies
+        on: it blanks an inactive arg out of the cache key only when the value is
+        well-formed enough that the API could never turn it into a 422, so a
+        cache HIT can never answer with a different status than an uncached
+        request would get. An out-of-range value under stretch=minmax must stay
+        exactly as rejected as it is here, uncached.
+        """
+        params = {"stretch": "minmax"}
+        params.update(bad_params)
+        resp = await client.get(_TILE_PATH, params=params)
+        assert resp.status_code == 422, (
+            f"Expected 422 for {description}, got {resp.status_code}"
+        )
+        assert len(self._tile_titiler_calls) == 0, (
+            f"Titiler was called despite invalid bounds ({description}): {self._tile_titiler_calls}"
+        )
+
     async def test_dem_with_custom_bounds_no_rescale(self, client):
         """[T-1153-03] DEM (algorithm= render_params) ignores pmin/pmax/sigma — no rescale injected."""
         self._auth_render_params = "algorithm=terrainrgb"

--- a/backend/tests/test_raster_colormap_proxy.py
+++ b/backend/tests/test_raster_colormap_proxy.py
@@ -607,6 +607,14 @@ class TestRasterColormapProxy:
             ({"pmin": -1}, "pmin<0 under an inactive stretch mode"),
             ({"sigma": 0}, "sigma=0 under an inactive stretch mode"),
             ({"sigma": -1}, "sigma<0 under an inactive stretch mode"),
+            # fix(#1778 codex r8): pmin=1e309 (FastAPI coerces this literal
+            # to `inf`) under stretch=minmax -- minmax is inactive for
+            # pmin/pmax the same as stddev is, so this must be ignored the
+            # same as any other out-of-range value, never a 500.
+            (
+                {"pmin": "1e309"},
+                "pmin non-finite (1e309) under an inactive stretch mode",
+            ),
         ],
     )
     async def test_out_of_range_bounds_are_ignored_under_an_inactive_stretch_mode(
@@ -642,6 +650,84 @@ class TestRasterColormapProxy:
             f"{self._tile_titiler_calls}"
         )
         # minmax never computes stats, active or not.
+        assert len(self._stats_titiler_calls) == 0
+
+    # ------------------------------------------------------------------
+    # fix(#1778 codex r8): "inactive means ignored" was decided at the
+    # validation gate but not enforced on eff_pmin/eff_pmax/eff_sigma
+    # themselves -- they were resolved from "was the parameter merely
+    # present", so an inactive parameter's RAW value still reached
+    # _fetch_band_statistics/_compute_stretch_rescale. A non-finite value
+    # (pmin=1e309, which FastAPI's float coercion turns into `inf`) is
+    # inside nginx's canonical float grammar (frontend/nginx.conf), so
+    # nginx blanked it and shared a cache key with a plain stddev request:
+    # cached 200 once warm, 500 (int(inf) -> OverflowError inside
+    # _fetch_band_statistics) on the first, cold request.
+    # ------------------------------------------------------------------
+
+    async def test_inactive_non_finite_pmin_under_stddev_matches_the_bare_request(
+        self, client
+    ):
+        """pmin is inactive under stretch=stddev (only sigma is read). A
+        non-finite pmin=1e309 must resolve to the SAME default (2.0) as an
+        absent pmin -- not crash int(pmin) inside _fetch_band_statistics,
+        and not reach Titiler's statistics call with its raw value at all.
+        Proven two ways: the second call's rendered tile URL is identical to
+        the bare call's, and it issues NO second /cog/statistics request --
+        it resolves to the SAME (open_path, eff_pmin, eff_pmax) cache key as
+        the bare request and hits _band_stats_cache instead."""
+        resp_bare = await client.get(_TILE_PATH, params={"stretch": "stddev"})
+        assert resp_bare.status_code in (200, 204)
+        bare_tile_url = self._tile_titiler_calls[0]
+        assert len(self._stats_titiler_calls) == 1
+
+        self._titiler_calls.clear()
+
+        resp_inf = await client.get(
+            _TILE_PATH, params={"stretch": "stddev", "pmin": "1e309"}
+        )
+        assert resp_inf.status_code in (200, 204), (
+            "Expected an inactive, non-finite pmin under stddev to be "
+            f"ignored (200/204), got {resp_inf.status_code}: {resp_inf.text}"
+        )
+        assert self._tile_titiler_calls[0] == bare_tile_url, (
+            "An inactive, non-finite pmin must render the identical tile "
+            f"as an absent pmin: {self._tile_titiler_calls[0]!r} != "
+            f"{bare_tile_url!r}"
+        )
+        # A cache hit, not a fresh statistics call carrying the raw pmin --
+        # proves eff_pmin resolved to the SAME key (open_path, 2.0, 98.0) as
+        # the bare request, not to (open_path, inf, 98.0).
+        assert len(self._stats_titiler_calls) == 0, (
+            "Expected the resolved default to hit _band_stats_cache instead "
+            f"of issuing a new statistics call: {self._stats_titiler_calls}"
+        )
+
+    async def test_active_non_finite_pmin_returns_422_before_titiler(self, client):
+        """pmin IS active under stretch=percentile. math.isfinite() must
+        reject a non-finite pmin explicitly (rather than relying on inf's
+        IEEE-754 comparison behavior, `inf < x` is False, to fail the
+        existing 0<=pmin<pmax<=100 bound check) -- 1e309 is well inside
+        nginx's canonical float grammar, so this must 422 before Titiler is
+        ever called on the ACTIVE path too."""
+        resp = await client.get(
+            _TILE_PATH, params={"stretch": "percentile", "pmin": "1e309"}
+        )
+        assert resp.status_code == 422
+        assert len(self._tile_titiler_calls) == 0
+        assert len(self._stats_titiler_calls) == 0
+
+    async def test_active_non_finite_sigma_returns_422_before_titiler(self, client):
+        """sigma IS active under stretch=stddev. A non-finite sigma=1e309
+        must 422 -- previously `sigma > 0` alone let `inf > 0` (True) pass,
+        which would have reached _compute_stretch_rescale's
+        `mean - sigma*std` / `mean + sigma*std` and produced a literal
+        inf/-inf rescale fragment instead of a clean 422."""
+        resp = await client.get(
+            _TILE_PATH, params={"stretch": "stddev", "sigma": "1e309"}
+        )
+        assert resp.status_code == 422
+        assert len(self._tile_titiler_calls) == 0
         assert len(self._stats_titiler_calls) == 0
 
     async def test_dem_with_custom_bounds_no_rescale(self, client):

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -102,12 +102,51 @@ map $upstream_http_access_control_allow_origin $geolens_export_acao {
 #      ALSO non-canonical, because FastAPI ignores it entirely (exact-case
 #      lookup) while nginx's case-insensitive lookup still resolves it;
 #   3. none of the four names is percent-encoded (`%73tretch`) -- nginx never
-#      decodes $arg_* keys before matching, FastAPI always does.
-# $geolens_raster_noncanonical below is 1 if ANY of those three is violated
-# anywhere in $args, checked directly against the raw query string rather
-# than derived from any single $arg_* lookup, so it cannot inherit nginx's
-# own case-insensitivity or decoding blind spots.
+#      decodes $arg_* keys before matching, FastAPI always does;
+#   4. each of pmin/pmax/sigma's VALUE, if present, is an exact,
+#      undecorated float literal -- see the round-7 note below.
+# $geolens_raster_noncanonical below is 1 if ANY of those four is violated
+# anywhere in $args, checked directly against the raw query string (or, for
+# rule 4, the raw $arg_pmin/$arg_pmax/$arg_sigma) rather than derived from
+# any decoded value, so it cannot inherit nginx's own case-insensitivity or
+# decoding blind spots.
 #
+# fix(#1778 codex r7): rule 3 above covers percent-encoding in a parameter
+# NAME but said nothing about its VALUE. nginx never decodes $arg_pmin /
+# $arg_pmax / $arg_sigma either, so `pmin=%31`, `pmin=+1`, and `pmin=%201`
+# each reach this config as their own distinct literal bytes ("%31", "+1",
+# "%201") while FastAPI's query-param decoding turns every one of them into
+# an ordinary, VALID float: %-decoding makes "%31" and "%201" into "1" and "
+# 1"; Starlette's query-string unescaping (independently of %-decoding)
+# turns a raw `+` into a space, so "+1" also becomes " 1" -- and Python's
+# float() strips leading whitespace, so all three parse as 1.0. The request
+# is served and cached (200) under whichever of those literal spellings the
+# client happened to send, so N encodings of the same float mint N distinct
+# one-hour cache entries for one identical tile -- the amplification vector
+# this whole fix exists to close, moved from the parameter NAME to its
+# VALUE.
+#
+# Do not try to decode the value here: even a hand-rolled %-decode would
+# still have to special-case Starlette's `+` -> space rule, which holds only
+# for query strings and not, say, path segments, and reimplementing
+# FastAPI's decoder in a `map` regex is its own bug surface. Fail toward
+# non-canonical instead: $geolens_raster_noncanonical_value below is 1
+# unless pmin, pmax, and sigma are each either empty or match the exact
+# float grammar FastAPI/pydantic accepts -- `-?[0-9]+(\.[0-9]+)?([eE]-?[0-9]+)?`,
+# no `%`, no `+`, no whitespace, since a raw `+` can never itself be part of
+# a canonical float (it always decodes to a space first). This mirrors round
+# 5's well-formedness grammar exactly, just applied as a gate on the whole
+# request rather than a per-value blank/keep choice -- deliberately not
+# folded into the three per-parameter maps below, because those only ever
+# decide ONE value's fallback, while an out-of-grammar pmin/pmax/sigma has
+# to make the ENTIRE request non-canonical the same way an out-of-grammar
+# NAME already does, so it can reach $geolens_raster_noncanonical and the
+# proxy_cache_bypass/proxy_no_cache condition it drives.
+#
+# $geolens_raster_noncanonical is the OR of the name-based and value-based
+# checks, combined below rather than checked in one map, because nginx's
+# `map` has no boolean operators and the two checks read different source
+# variables ($args for names, $arg_pmin:$arg_pmax:$arg_sigma for values).
 # When non-canonical, EVERY map below falls back to keeping the matching
 # per-parameter value raw (as before). $geolens_raster_noncanonical is ALSO
 # used directly below, in the raster-tiles location, as a proxy_cache_bypass
@@ -138,7 +177,7 @@ map $upstream_http_access_control_allow_origin $geolens_export_acao {
 # with the equivalent of:
 #   "".join(ch.upper() if j==i else f"[{ch}{ch.upper()}]" for j,ch in enumerate(word))
 #   for i in range(len(word)), joined with "|", for each of the four words.
-map $args $geolens_raster_noncanonical {
+map $args $geolens_raster_noncanonical_name {
     default 0;
     # 1. case-insensitive duplicate of any of the four names.
     "~*(?:^|&)stretch=.*(?:^|&)stretch=" 1;
@@ -156,6 +195,25 @@ map $args $geolens_raster_noncanonical {
     #    every letter of every name is the same unbounded-alternatives
     #    problem in a different disguise.
     "~(?:^|&)[^&=]*%[^&=]*=" 1;
+}
+# fix(#1778 codex r7): rule 4 -- see the comment block above. $arg_pmin /
+# $arg_pmax / $arg_sigma are nginx's own case-insensitive-by-name, never
+# decoded lookups, joined into one string so a single map covers all three;
+# the ":" delimiter cannot be spoofed into a false negative, because a value
+# containing a raw ":" fails the anchored per-field grammar below and falls
+# through to the catch-all `default 1` the same as any other malformed
+# value -- fails toward non-canonical, never toward canonical.
+map "$arg_pmin:$arg_pmax:$arg_sigma" $geolens_raster_noncanonical_value {
+    "~*^(?:-?[0-9]+(?:\.[0-9]+)?(?:[eE]-?[0-9]+)?)?:(?:-?[0-9]+(?:\.[0-9]+)?(?:[eE]-?[0-9]+)?)?:(?:-?[0-9]+(?:\.[0-9]+)?(?:[eE]-?[0-9]+)?)?$" 0;
+    default 1;
+}
+# fix(#1778 codex r7): the OR of the two checks above -- either one alone
+# setting the request non-canonical is enough to set this. "0:0" is the only
+# combination that must resolve to 0; every other combination contains a
+# literal "1", so a single substring match suffices.
+map "$geolens_raster_noncanonical_name:$geolens_raster_noncanonical_value" $geolens_raster_noncanonical {
+    "~1" 1;
+    default 0;
 }
 # fix(#1778 codex r5): the three maps below used to require the value to be
 # WELL-FORMED AND IN THE RANGE THAT MATTERS FOR THE ACTIVE MODE (0-100 for

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -49,6 +49,31 @@ map $upstream_http_access_control_allow_origin $geolens_export_acao {
     default $upstream_http_access_control_allow_origin;
 }
 
+# fix(#1778): the raster tile proxy_cache_key held $arg_pmin/$arg_pmax/$arg_sigma
+# unconditionally, so `?stretch=minmax&pmin=<random>` produced a fresh key
+# holding bytes byte-identical to the unfiltered tile — the same defeat #1785
+# closed for the vector tile `cols=` param. In backend/app/processing/tiles/
+# router.py, stretch=percentile is the only mode that reads pmin/pmax
+# (_compute_stretch_rescale) and stretch=stddev is the only mode that reads
+# sigma; stretch=minmax (the default) or an absent stretch reads neither. Blank
+# each family down to what the request's stretch mode can actually change, so
+# two requests that provably render the same bytes key the same, while sigma
+# still varies the key under stddev and pmin/pmax still vary it under
+# percentile (collapsing either unconditionally would instead serve one
+# request's bytes for another's distinct sigma/pmin/pmax).
+map $arg_stretch $geolens_raster_pmin {
+    percentile $arg_pmin;
+    default    "";
+}
+map $arg_stretch $geolens_raster_pmax {
+    percentile $arg_pmax;
+    default    "";
+}
+map $arg_stretch $geolens_raster_sigma {
+    stddev  $arg_sigma;
+    default "";
+}
+
 # fix(#581): trusted-proxy trust boundary, rendered by the entrypoint from
 # TRUSTED_PROXY_CIDRS. Unset (the default), this is only an identity map
 # defining $geolens_fwd_proto = $scheme — byte-equivalent to the previous
@@ -194,13 +219,16 @@ server {
         proxy_cache raster_cache;
         # Cache key must vary by EVERY render param the api forwards to Titiler,
         # else tiles with different bounds collide (#317 Codex P2): include
-        # pmin/pmax/sigma alongside colormap_name/stretch.
+        # colormap_name/stretch, plus pmin/pmax/sigma through the $geolens_raster_*
+        # maps declared above (fix(#1778): those maps blank the args a request's
+        # stretch mode does not read, so an anonymous caller can no longer defeat
+        # the cache by randomizing an arg that never touches the rendered bytes).
         # fix(#1372): $arg_v is the dataset's tile_cache_version, emitted by the
         # api in every raster tile URL — a raster replace bumps it, so the
         # shared cache rolls immediately instead of serving pre-replace bytes
         # for up to proxy_cache_valid. Unversioned clients (copied connect
         # URLs) key on the empty segment and keep the old bounded staleness.
-        proxy_cache_key "$dataset_id/$z/$x/$y.$fmt/$arg_v/$arg_colormap_name/$arg_stretch/$arg_pmin/$arg_pmax/$arg_sigma";
+        proxy_cache_key "$dataset_id/$z/$x/$y.$fmt/$arg_v/$arg_colormap_name/$arg_stretch/$geolens_raster_pmin/$geolens_raster_pmax/$geolens_raster_sigma";
         proxy_cache_valid 200 1h;
         proxy_cache_use_stale error timeout updating;
         # Honor the api's Cache-Control: nginx skips caching when the api

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -57,40 +57,50 @@ map $upstream_http_access_control_allow_origin $geolens_export_acao {
 # (_compute_stretch_rescale) and stretch=stddev is the only mode that reads
 # sigma; stretch=minmax (the default) or an absent stretch reads neither.
 #
-# fix(#1778 codex r1): blanking an inactive arg must never let a cache HIT
-# answer with a status the API would not have given the same request
-# uncached. raster_tile_proxy validates pmin/pmax/sigma whenever they are
-# PRESENT, regardless of the active stretch mode (T-1153-01) — so blanking
-# every inactive value unconditionally let `?stretch=minmax&pmin=200`
-# collapse onto the same key as a cached `?stretch=minmax` and answer that
-# entry's 200, though the API would 422 an out-of-range pmin uncached. Each
-# map below blanks a value only when it is BOTH inactive for the request's
-# mode AND within the range the API itself accepts (0-100 for pmin/pmax,
-# positive for sigma) — a value in that range can never turn the API's
-# verdict from 200 into 422, so blanking it can never change the status a
-# client gets. Anything malformed or out of range is left RAW: it misses the
-# cache and reaches the API for the same 422 an uncached request would get.
-# The source string pairs the mode with the raw value ("mode:value") so one
-# regex can require BOTH "still active" and "well-formed" in the right
-# combination; percentile/stddev are matched first so an active mode's value
-# always passes through untouched, exactly as before this revision.
-map "$arg_stretch:$arg_pmin" $geolens_raster_pmin {
-    "~^percentile:"                                 $arg_pmin;
-    "~^[^:]*:$"                                      "";
-    "~^[^:]*:(100(\.0+)?|[0-9]{1,2}(\.[0-9]+)?)$"   "";
-    default                                          $arg_pmin;
+# fix(#1778 codex r2): the API side now matches. raster_tile_proxy used to
+# validate pmin/pmax/sigma whenever PRESENT, regardless of the active stretch
+# mode (T-1153-01), which round 1 of this fix worked around by blanking a
+# value only when it was ALSO well-formed by the API's own accepted range —
+# but that still had two ways to disagree with the API: a joint pmin/pmax
+# ordering nginx can't cheaply replicate in a regex, and a repeated query
+# parameter, where nginx's $arg_x reads the FIRST occurrence while FastAPI's
+# scalar Query reads the LAST (`?stretch=minmax&pmin=5&pmin=200` read pmin=5
+# here, well-formed and blanked, while the API reads pmin=200 and would
+# 422). raster_tile_proxy now IGNORES pmin/pmax when stretch is not
+# percentile and sigma when it is not stddev, instead of merely leaving them
+# unvalidated — "inactive" means the same thing, ignored, on both sides — so
+# every map below can blank an inactive value UNCONDITIONALLY: there is no
+# verdict left to disagree with, because the value is never read.
+#
+# One residual survives that change and is closed separately below: the
+# duplicate-parameter mismatch also applies to `stretch` itself. A client
+# sending `?stretch=minmax&stretch=percentile&pmin=5` has nginx read
+# stretch=minmax (inactive, blank pmin) while the API reads stretch=percentile
+# (active, uses pmin=5) — and because blanking makes the cache key depend on
+# nginx's OWN reading of stretch, a second such request with a DIFFERENT pmin
+# would collapse onto the SAME key while rendering DIFFERENT bytes: a
+# collision, not just a status mismatch. $geolens_raster_stretch_dup detects a
+# repeated `stretch=` in the raw query string; when set, every map below
+# falls back to the raw value instead of blanking, which only ever costs an
+# extra cache miss rather than a collision.
+map $args $geolens_raster_stretch_dup {
+    default                                0;
+    "~(?:^|&)stretch=.*(?:^|&)stretch="    1;
 }
-map "$arg_stretch:$arg_pmax" $geolens_raster_pmax {
-    "~^percentile:"                                 $arg_pmax;
-    "~^[^:]*:$"                                      "";
-    "~^[^:]*:(100(\.0+)?|[0-9]{1,2}(\.[0-9]+)?)$"   "";
-    default                                          $arg_pmax;
+map "$geolens_raster_stretch_dup:$arg_stretch:$arg_pmin" $geolens_raster_pmin {
+    "~^1:"            $arg_pmin;
+    "~^0:percentile:" $arg_pmin;
+    default           "";
 }
-map "$arg_stretch:$arg_sigma" $geolens_raster_sigma {
-    "~^stddev:"                                             $arg_sigma;
-    "~^[^:]*:$"                                              "";
-    "~^[^:]*:([1-9][0-9]*(\.[0-9]+)?|0\.[0-9]*[1-9][0-9]*)$" "";
-    default                                                  $arg_sigma;
+map "$geolens_raster_stretch_dup:$arg_stretch:$arg_pmax" $geolens_raster_pmax {
+    "~^1:"            $arg_pmax;
+    "~^0:percentile:" $arg_pmax;
+    default           "";
+}
+map "$geolens_raster_stretch_dup:$arg_stretch:$arg_sigma" $geolens_raster_sigma {
+    "~^1:"        $arg_sigma;
+    "~^0:stddev:" $arg_sigma;
+    default       "";
 }
 
 # fix(#581): trusted-proxy trust boundary, rendered by the entrypoint from

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -104,8 +104,10 @@ map $upstream_http_access_control_allow_origin $geolens_export_acao {
 #   3. none of the four names is percent-encoded (`%73tretch`) -- nginx never
 #      decodes $arg_* keys before matching, FastAPI always does;
 #   4. each of pmin/pmax/sigma's VALUE, if present, is an exact,
-#      undecorated float literal -- see the round-7 note below.
-# $geolens_raster_noncanonical below is 1 if ANY of those four is violated
+#      undecorated float literal -- see the round-7 note below;
+#   5. none of the four names appears BARE (no `=` at all) -- see the
+#      round-9 note below.
+# $geolens_raster_noncanonical below is 1 if ANY of those five is violated
 # anywhere in $args, checked directly against the raw query string (or, for
 # rule 4, the raw $arg_pmin/$arg_pmax/$arg_sigma) rather than derived from
 # any decoded value, so it cannot inherit nginx's own case-insensitivity or
@@ -195,6 +197,35 @@ map $args $geolens_raster_noncanonical_name {
     #    every letter of every name is the same unbounded-alternatives
     #    problem in a different disguise.
     "~(?:^|&)[^&=]*%[^&=]*=" 1;
+    # 5. fix(#1778 codex r9): a BARE occurrence (no `=`) of any of the four
+    #    names, anywhere. nginx's arg matcher (ngx_http_arg) requires an `=`
+    #    immediately after the name to resolve $arg_x at all -- a bare name
+    #    is invisible to $arg_x the exact same way an ABSENT one is. But
+    #    Starlette parses a query string with keep_blank_values=True, so a
+    #    bare `pmin` is a real ("pmin", "") pair, not nothing: for
+    #    `pmin=5&pmin`, the scalar Query dependency reads the LAST
+    #    occurrence (round 2/4's established rule) and gets `""`, which
+    #    pydantic's float coercion 422s on, unconditionally, before the
+    #    "ignore when inactive" logic ever runs (round 3's class). nginx
+    #    meanwhile still resolves $arg_pmin to the well-formed "5" from the
+    #    EARLIER `pmin=5` (its arg scan simply never matches the bare
+    #    occurrence and keeps looking), so a request that 422s cold reads
+    #    as perfectly canonical and cacheable to every check above -- warm
+    #    200, cold 422.
+    #
+    #    One check per name, rather than a literal occurrence COUNT, is
+    #    sufficient: a bare occurrence combined with zero other occurrences
+    #    of the name is the single-bare-occurrence case (still 422s at
+    #    FastAPI, since "the last occurrence" is that one bare pair); a bare
+    #    occurrence combined with one-or-more "name=" occurrences elsewhere
+    #    is already >= 2 total occurrences of the name, which is the same
+    #    "must appear at most once" property rule 1 already polices, just
+    #    with one of the copies unquoted. So "does a bare occurrence exist
+    #    AT ALL" fully covers both shapes without counting anything.
+    "~*(?:^|&)stretch(?:&|$)" 1;
+    "~*(?:^|&)pmin(?:&|$)" 1;
+    "~*(?:^|&)pmax(?:&|$)" 1;
+    "~*(?:^|&)sigma(?:&|$)" 1;
 }
 # fix(#1778 codex r7): rule 4 -- see the comment block above. $arg_pmin /
 # $arg_pmax / $arg_sigma are nginx's own case-insensitive-by-name, never

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -79,44 +79,86 @@ map $upstream_http_access_control_allow_origin $geolens_export_acao {
 #     regardless of stretch. Blanking it lets a cached 200 answer a request
 #     the API 422s uncached.
 #
-# The principle that closes all three the same way: blank an argument ONLY
-# when nginx can be CERTAIN blanking cannot change the outcome — the raw
-# $arg_stretch is EXACTLY one of the canonical spellings this argument is
-# inactive under (PCRE is case-sensitive and matches only the literal,
-# decoded spelling, never a percent-encoded or differently-cased one) AND the
-# argument itself is a well-formed float in the range it would need to be in
-# to matter in the one mode where it IS active. Anything else — an
-# unrecognized stretch spelling, a duplicated one
-# ($geolens_raster_stretch_dup below), a malformed or out-of-range value — is
-# left RAW: the request misses the cache and the API decides, on its own
-# terms, what to do with it. Failing toward "keep raw" only ever costs an
-# extra cache miss on an odd spelling; failing toward "blank" risks a wrong
-# tile or a wrong status, so every map below fails toward "keep raw" as its
-# `default`.
+# fix(#1778 codex r4): round 3's exact-spelling check assumed nginx's own
+# $arg_NAME lookup is case-sensitive on the NAME. It is not: nginx's arg
+# matcher (ngx_http_arg -> ngx_strlcasestrn) is case-INSENSITIVE on the
+# parameter name, so `$arg_stretch` happily resolves from `Stretch=`,
+# `STRETCH=`, etc. FastAPI's query-param binding is exact-case, so
+# `?Stretch=minmax&stretch=percentile&pmin=5` has nginx read stretch=minmax
+# (the first case-insensitive match, "inactive", blank pmin) while the API
+# reads stretch=percentile (the only EXACT-case match, active, uses pmin=5)
+# -- a second request with a different pmin collapses onto the same key
+# while rendering different bytes: the identical collision round 3 closed
+# for a plain duplicate, reopened by a mixed-case one round 3's
+# case-sensitive-only duplicate detector could not see.
 #
-# $geolens_raster_stretch_dup: `stretch` itself can be duplicated the same way
-# pmin/pmax/sigma can (nginx reads the FIRST occurrence, FastAPI the LAST).
-# `?stretch=minmax&stretch=percentile&pmin=5` has nginx read stretch=minmax
-# (inactive, blank pmin) while the API reads stretch=percentile (active, uses
-# pmin=5) — and because blanking makes the cache key depend on nginx's OWN
-# reading of stretch, a second such request with a DIFFERENT pmin would
-# collapse onto the SAME key while rendering DIFFERENT bytes: a collision,
-# not just a status mismatch. Detecting a repeated `stretch=` in the raw
-# query string and falling back to raw in that case closes it the same way:
-# an extra cache miss, never a collision.
-map $args $geolens_raster_stretch_dup {
-    default                                0;
-    "~(?:^|&)stretch=.*(?:^|&)stretch="    1;
+# The fix generalizes round 3's principle rather than patching around this
+# one instance, because a narrower patch is exactly how this class recurs:
+# blanking is allowed ONLY when $args is in STRICT CANONICAL FORM --
+#   1. each of stretch/pmin/pmax/sigma appears AT MOST ONCE, checked
+#      CASE-INSENSITIVELY (a mixed-case duplicate is still a duplicate);
+#   2. every occurrence of each of those four names is spelled EXACTLY
+#      lowercase -- a single mixed-case occurrence (no duplicate at all) is
+#      ALSO non-canonical, because FastAPI ignores it entirely (exact-case
+#      lookup) while nginx's case-insensitive lookup still resolves it;
+#   3. none of the four names is percent-encoded (`%73tretch`) -- nginx never
+#      decodes $arg_* keys before matching, FastAPI always does.
+# $geolens_raster_noncanonical below is 1 if ANY of those three is violated
+# anywhere in $args, checked directly against the raw query string rather
+# than derived from any single $arg_* lookup, so it cannot inherit nginx's
+# own case-insensitivity or decoding blind spots.
+#
+# When non-canonical, EVERY map below falls back to keeping the matching
+# per-parameter value raw (as before), AND $geolens_raster_cache_extra folds
+# the ENTIRE raw $args into the cache key. The per-parameter fallback alone
+# would already have closed the mixed-case duplicate above (nginx's own
+# $arg_pmin still varies raw by request), but keying on the whole $args
+# additionally makes correctness independent of that per-parameter reasoning
+# ever being complete again: two requests share a key in the non-canonical
+# case if and only if their raw query strings are identical, full stop, no
+# per-name analysis required. Empty (no key change) whenever $args IS
+# canonical, so the common case pays nothing extra.
+#
+# The case-variant patterns are mechanical: one alternative per letter
+# position, that position forced to its single uppercase form and every
+# other position a same-letter [aA]-style class, so the alternation matches
+# a spelling with at least one wrong-case letter and matches nothing when
+# every letter is already lowercase. Generated, not hand-tuned; regenerate
+# with the equivalent of:
+#   "".join(ch.upper() if j==i else f"[{ch}{ch.upper()}]" for j,ch in enumerate(word))
+#   for i in range(len(word)), joined with "|", for each of the four words.
+map $args $geolens_raster_noncanonical {
+    default 0;
+    # 1. case-insensitive duplicate of any of the four names.
+    "~*(?:^|&)stretch=.*(?:^|&)stretch=" 1;
+    "~*(?:^|&)pmin=.*(?:^|&)pmin=" 1;
+    "~*(?:^|&)pmax=.*(?:^|&)pmax=" 1;
+    "~*(?:^|&)sigma=.*(?:^|&)sigma=" 1;
+    # 2. a non-lowercase spelling of any of the four names, anywhere -- see
+    #    the generator note above.
+    "~(?:^|&)(?:S[tT][rR][eE][tT][cC][hH]|[sS]T[rR][eE][tT][cC][hH]|[sS][tT]R[eE][tT][cC][hH]|[sS][tT][rR]E[tT][cC][hH]|[sS][tT][rR][eE]T[cC][hH]|[sS][tT][rR][eE][tT]C[hH]|[sS][tT][rR][eE][tT][cC]H)=" 1;
+    "~(?:^|&)(?:P[mM][iI][nN]|[pP]M[iI][nN]|[pP][mM]I[nN]|[pP][mM][iI]N)=" 1;
+    "~(?:^|&)(?:P[mM][aA][xX]|[pP]M[aA][xX]|[pP][mM]A[xX]|[pP][mM][aA]X)=" 1;
+    "~(?:^|&)(?:S[iI][gG][mM][aA]|[sS]I[gG][mM][aA]|[sS][iI]G[mM][aA]|[sS][iI][gG]M[aA]|[sS][iI][gG][mM]A)=" 1;
+    # 3. a percent-encoded key anywhere -- broader than just the four names
+    #    (any encoded key fails safe), because enumerating every encoding of
+    #    every letter of every name is the same unbounded-alternatives
+    #    problem in a different disguise.
+    "~(?:^|&)[^&=]*%[^&=]*=" 1;
 }
-map "$geolens_raster_stretch_dup:$arg_stretch:$arg_pmin" $geolens_raster_pmin {
+map "$geolens_raster_noncanonical:$args" $geolens_raster_cache_extra {
+    "~^1:" $args;
+    default "";
+}
+map "$geolens_raster_noncanonical:$arg_stretch:$arg_pmin" $geolens_raster_pmin {
     "~^0:(minmax|stddev|):(100(\.0+)?|[0-9]{1,2}(\.[0-9]+)?)$" "";
     default $arg_pmin;
 }
-map "$geolens_raster_stretch_dup:$arg_stretch:$arg_pmax" $geolens_raster_pmax {
+map "$geolens_raster_noncanonical:$arg_stretch:$arg_pmax" $geolens_raster_pmax {
     "~^0:(minmax|stddev|):(100(\.0+)?|[0-9]{1,2}(\.[0-9]+)?)$" "";
     default $arg_pmax;
 }
-map "$geolens_raster_stretch_dup:$arg_stretch:$arg_sigma" $geolens_raster_sigma {
+map "$geolens_raster_noncanonical:$arg_stretch:$arg_sigma" $geolens_raster_sigma {
     "~^0:(minmax|percentile|):([1-9][0-9]*(\.[0-9]+)?|0\.[0-9]*[1-9][0-9]*)$" "";
     default $arg_sigma;
 }
@@ -270,12 +312,17 @@ server {
         # maps declared above (fix(#1778): those maps blank the args a request's
         # stretch mode does not read, so an anonymous caller can no longer defeat
         # the cache by randomizing an arg that never touches the rendered bytes).
+        # fix(#1778 codex r4): $geolens_raster_cache_extra folds the whole raw
+        # $args in whenever the request is not in strict canonical form (a
+        # duplicated, mixed-case, or percent-encoded stretch/pmin/pmax/sigma
+        # name), so correctness there does not depend on the per-parameter
+        # maps' own reasoning — see the block above them.
         # fix(#1372): $arg_v is the dataset's tile_cache_version, emitted by the
         # api in every raster tile URL — a raster replace bumps it, so the
         # shared cache rolls immediately instead of serving pre-replace bytes
         # for up to proxy_cache_valid. Unversioned clients (copied connect
         # URLs) key on the empty segment and keep the old bounded staleness.
-        proxy_cache_key "$dataset_id/$z/$x/$y.$fmt/$arg_v/$arg_colormap_name/$arg_stretch/$geolens_raster_pmin/$geolens_raster_pmax/$geolens_raster_sigma";
+        proxy_cache_key "$dataset_id/$z/$x/$y.$fmt/$arg_v/$arg_colormap_name/$arg_stretch/$geolens_raster_pmin/$geolens_raster_pmax/$geolens_raster_sigma/$geolens_raster_cache_extra";
         proxy_cache_valid 200 1h;
         proxy_cache_use_stale error timeout updating;
         # Honor the api's Cache-Control: nginx skips caching when the api

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -57,50 +57,68 @@ map $upstream_http_access_control_allow_origin $geolens_export_acao {
 # (_compute_stretch_rescale) and stretch=stddev is the only mode that reads
 # sigma; stretch=minmax (the default) or an absent stretch reads neither.
 #
-# fix(#1778 codex r2): the API side now matches. raster_tile_proxy used to
-# validate pmin/pmax/sigma whenever PRESENT, regardless of the active stretch
-# mode (T-1153-01), which round 1 of this fix worked around by blanking a
-# value only when it was ALSO well-formed by the API's own accepted range —
-# but that still had two ways to disagree with the API: a joint pmin/pmax
-# ordering nginx can't cheaply replicate in a regex, and a repeated query
-# parameter, where nginx's $arg_x reads the FIRST occurrence while FastAPI's
-# scalar Query reads the LAST (`?stretch=minmax&pmin=5&pmin=200` read pmin=5
-# here, well-formed and blanked, while the API reads pmin=200 and would
-# 422). raster_tile_proxy now IGNORES pmin/pmax when stretch is not
-# percentile and sigma when it is not stddev, instead of merely leaving them
-# unvalidated — "inactive" means the same thing, ignored, on both sides — so
-# every map below can blank an inactive value UNCONDITIONALLY: there is no
-# verdict left to disagree with, because the value is never read.
+# fix(#1778 codex r2): raster_tile_proxy now IGNORES pmin/pmax when stretch is
+# not percentile and sigma when it is not stddev, instead of merely leaving
+# them unvalidated (T-1153-01) — "inactive" means the same thing, ignored, on
+# both sides, closing the joint pmin/pmax ordering residual nginx cannot
+# cheaply replicate in a regex.
 #
-# One residual survives that change and is closed separately below: the
-# duplicate-parameter mismatch also applies to `stretch` itself. A client
-# sending `?stretch=minmax&stretch=percentile&pmin=5` has nginx read
-# stretch=minmax (inactive, blank pmin) while the API reads stretch=percentile
-# (active, uses pmin=5) — and because blanking makes the cache key depend on
-# nginx's OWN reading of stretch, a second such request with a DIFFERENT pmin
-# would collapse onto the SAME key while rendering DIFFERENT bytes: a
-# collision, not just a status mismatch. $geolens_raster_stretch_dup detects a
-# repeated `stretch=` in the raw query string; when set, every map below
-# falls back to the raw value instead of blanking, which only ever costs an
-# extra cache miss rather than a collision.
+# fix(#1778 codex r3): that API change is necessary but not sufficient, because
+# nginx's read of a query string and the API's can disagree in ways that have
+# nothing to do with what the API validates:
+#   - percent-encoding: `stretch=%70ercentile` decodes to the ACTIVE spelling
+#     at the API (FastAPI URL-decodes query params) but nginx's raw
+#     $arg_stretch never matches `percentile` literally, so calling that
+#     "not the active spelling, therefore inactive" blanks pmin and collapses
+#     two requests that render DIFFERENT bytes (different pmin) onto one key.
+#   - a case variant, for the same reason.
+#   - a malformed float (`pmin=abc`): the API's "ignore when inactive" code in
+#     raster_tile_proxy never runs for this, because FastAPI's
+#     `pmin: float | None` coerces the query param to a float BEFORE the
+#     endpoint body executes, and "abc" fails that coercion with a 422
+#     regardless of stretch. Blanking it lets a cached 200 answer a request
+#     the API 422s uncached.
+#
+# The principle that closes all three the same way: blank an argument ONLY
+# when nginx can be CERTAIN blanking cannot change the outcome — the raw
+# $arg_stretch is EXACTLY one of the canonical spellings this argument is
+# inactive under (PCRE is case-sensitive and matches only the literal,
+# decoded spelling, never a percent-encoded or differently-cased one) AND the
+# argument itself is a well-formed float in the range it would need to be in
+# to matter in the one mode where it IS active. Anything else — an
+# unrecognized stretch spelling, a duplicated one
+# ($geolens_raster_stretch_dup below), a malformed or out-of-range value — is
+# left RAW: the request misses the cache and the API decides, on its own
+# terms, what to do with it. Failing toward "keep raw" only ever costs an
+# extra cache miss on an odd spelling; failing toward "blank" risks a wrong
+# tile or a wrong status, so every map below fails toward "keep raw" as its
+# `default`.
+#
+# $geolens_raster_stretch_dup: `stretch` itself can be duplicated the same way
+# pmin/pmax/sigma can (nginx reads the FIRST occurrence, FastAPI the LAST).
+# `?stretch=minmax&stretch=percentile&pmin=5` has nginx read stretch=minmax
+# (inactive, blank pmin) while the API reads stretch=percentile (active, uses
+# pmin=5) — and because blanking makes the cache key depend on nginx's OWN
+# reading of stretch, a second such request with a DIFFERENT pmin would
+# collapse onto the SAME key while rendering DIFFERENT bytes: a collision,
+# not just a status mismatch. Detecting a repeated `stretch=` in the raw
+# query string and falling back to raw in that case closes it the same way:
+# an extra cache miss, never a collision.
 map $args $geolens_raster_stretch_dup {
     default                                0;
     "~(?:^|&)stretch=.*(?:^|&)stretch="    1;
 }
 map "$geolens_raster_stretch_dup:$arg_stretch:$arg_pmin" $geolens_raster_pmin {
-    "~^1:"            $arg_pmin;
-    "~^0:percentile:" $arg_pmin;
-    default           "";
+    "~^0:(minmax|stddev|):(100(\.0+)?|[0-9]{1,2}(\.[0-9]+)?)$" "";
+    default $arg_pmin;
 }
 map "$geolens_raster_stretch_dup:$arg_stretch:$arg_pmax" $geolens_raster_pmax {
-    "~^1:"            $arg_pmax;
-    "~^0:percentile:" $arg_pmax;
-    default           "";
+    "~^0:(minmax|stddev|):(100(\.0+)?|[0-9]{1,2}(\.[0-9]+)?)$" "";
+    default $arg_pmax;
 }
 map "$geolens_raster_stretch_dup:$arg_stretch:$arg_sigma" $geolens_raster_sigma {
-    "~^1:"        $arg_sigma;
-    "~^0:stddev:" $arg_sigma;
-    default       "";
+    "~^0:(minmax|percentile|):([1-9][0-9]*(\.[0-9]+)?|0\.[0-9]*[1-9][0-9]*)$" "";
+    default $arg_sigma;
 }
 
 # fix(#581): trusted-proxy trust boundary, rendered by the entrypoint from

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -150,16 +150,43 @@ map "$geolens_raster_noncanonical:$args" $geolens_raster_cache_extra {
     "~^1:" $args;
     default "";
 }
+# fix(#1778 codex r5): the three maps below used to require the value to be
+# WELL-FORMED AND IN THE RANGE THAT MATTERS FOR THE ACTIVE MODE (0-100 for
+# pmin/pmax, positive for sigma) before blanking it under an inactive one.
+# That range check was a round-1 leftover from before round-2 made
+# raster_tile_proxy IGNORE an inactive pmin/pmax/sigma outright rather than
+# merely leaving it unvalidated -- so under stretch=minmax the API now
+# ignores pmin regardless of its value, but this map still blanked ONLY
+# 0-100, leaving every OUT-OF-RANGE-but-syntactically-valid value (101, 102,
+# 103, ... -5, ...) RAW: an anonymous caller could still mint a distinct
+# one-hour cache entry per distinct out-of-range pmin, all holding the
+# identical tile, which is exactly the cache-amplification vector this
+# whole fix exists to close.
+#
+# Range is irrelevant for an inactive parameter, because the API never reads
+# it far enough to apply the range check either. The only thing that still
+# has to stay RAW is a value FastAPI cannot parse as a float AT ALL --
+# that hits the framework's own type-coercion 422 before raster_tile_proxy's
+# body runs, regardless of stretch mode (fix(#1778 codex r3)). So the
+# well-formedness check below now mirrors FastAPI's float GRAMMAR, not its
+# semantic range: optional sign, digits, an optional decimal point, and an
+# optional exponent -- the same shape as Python's float() literal syntax,
+# which is what pydantic's query-param coercion accepts. Deliberately NOT
+# extended to Python-only extensions (underscores as digit separators,
+# "inf"/"nan" literals) this simulation cannot verify pydantic accepts from a
+# query string; failing toward RAW for those keeps the "keep raw when
+# uncertain" rule intact at the cost of a rare extra cache miss, never a
+# collision or a status mismatch.
 map "$geolens_raster_noncanonical:$arg_stretch:$arg_pmin" $geolens_raster_pmin {
-    "~^0:(minmax|stddev|):(100(\.0+)?|[0-9]{1,2}(\.[0-9]+)?)$" "";
+    "~^0:(minmax|stddev|):[+-]?(?:[0-9]+\.?[0-9]*|\.[0-9]+)(?:[eE][+-]?[0-9]+)?$" "";
     default $arg_pmin;
 }
 map "$geolens_raster_noncanonical:$arg_stretch:$arg_pmax" $geolens_raster_pmax {
-    "~^0:(minmax|stddev|):(100(\.0+)?|[0-9]{1,2}(\.[0-9]+)?)$" "";
+    "~^0:(minmax|stddev|):[+-]?(?:[0-9]+\.?[0-9]*|\.[0-9]+)(?:[eE][+-]?[0-9]+)?$" "";
     default $arg_pmax;
 }
 map "$geolens_raster_noncanonical:$arg_stretch:$arg_sigma" $geolens_raster_sigma {
-    "~^0:(minmax|percentile|):([1-9][0-9]*(\.[0-9]+)?|0\.[0-9]*[1-9][0-9]*)$" "";
+    "~^0:(minmax|percentile|):[+-]?(?:[0-9]+\.?[0-9]*|\.[0-9]+)(?:[eE][+-]?[0-9]+)?$" "";
     default $arg_sigma;
 }
 

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -203,6 +203,22 @@ map $args $geolens_raster_noncanonical_name {
 # containing a raw ":" fails the anchored per-field grammar below and falls
 # through to the catch-all `default 1` the same as any other malformed
 # value -- fails toward non-canonical, never toward canonical.
+#
+# fix(#1778 codex r8): this grammar matches `1e309` -- syntactically a
+# perfectly good float literal, and CANONICAL by this map's own rules, even
+# though FastAPI's float coercion turns it into `inf` (`1.7976931348623157e+308`
+# is the largest finite double; anything larger overflows to +/-inf). This
+# map does not, and must not try to, reject that: nginx has no way to
+# distinguish a finite float from one that overflows to inf/nan at the
+# API's coercion step, and hand-rolling that distinction in a regex is its
+# own bug surface, the same reasoning that keeps this file from attempting
+# %-decoding above. Non-finite values are the API's problem to reject --
+# raster_tile_proxy in backend/app/processing/tiles/router.py now resolves
+# eff_pmin/eff_pmax/eff_sigma from the SAME active/inactive test this file
+# assumes, and requires math.isfinite() on the ACTIVE path before either
+# ever reaches Titiler, so a canonical-by-nginx `1e309` still 422s when
+# active and is never read by anything (not even to blank/keep the cache
+# key) when inactive.
 map "$arg_pmin:$arg_pmax:$arg_sigma" $geolens_raster_noncanonical_value {
     "~*^(?:-?[0-9]+(?:\.[0-9]+)?(?:[eE]-?[0-9]+)?)?:(?:-?[0-9]+(?:\.[0-9]+)?(?:[eE]-?[0-9]+)?)?:(?:-?[0-9]+(?:\.[0-9]+)?(?:[eE]-?[0-9]+)?)?$" 0;
     default 1;

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -55,23 +55,42 @@ map $upstream_http_access_control_allow_origin $geolens_export_acao {
 # closed for the vector tile `cols=` param. In backend/app/processing/tiles/
 # router.py, stretch=percentile is the only mode that reads pmin/pmax
 # (_compute_stretch_rescale) and stretch=stddev is the only mode that reads
-# sigma; stretch=minmax (the default) or an absent stretch reads neither. Blank
-# each family down to what the request's stretch mode can actually change, so
-# two requests that provably render the same bytes key the same, while sigma
-# still varies the key under stddev and pmin/pmax still vary it under
-# percentile (collapsing either unconditionally would instead serve one
-# request's bytes for another's distinct sigma/pmin/pmax).
-map $arg_stretch $geolens_raster_pmin {
-    percentile $arg_pmin;
-    default    "";
+# sigma; stretch=minmax (the default) or an absent stretch reads neither.
+#
+# fix(#1778 codex r1): blanking an inactive arg must never let a cache HIT
+# answer with a status the API would not have given the same request
+# uncached. raster_tile_proxy validates pmin/pmax/sigma whenever they are
+# PRESENT, regardless of the active stretch mode (T-1153-01) — so blanking
+# every inactive value unconditionally let `?stretch=minmax&pmin=200`
+# collapse onto the same key as a cached `?stretch=minmax` and answer that
+# entry's 200, though the API would 422 an out-of-range pmin uncached. Each
+# map below blanks a value only when it is BOTH inactive for the request's
+# mode AND within the range the API itself accepts (0-100 for pmin/pmax,
+# positive for sigma) — a value in that range can never turn the API's
+# verdict from 200 into 422, so blanking it can never change the status a
+# client gets. Anything malformed or out of range is left RAW: it misses the
+# cache and reaches the API for the same 422 an uncached request would get.
+# The source string pairs the mode with the raw value ("mode:value") so one
+# regex can require BOTH "still active" and "well-formed" in the right
+# combination; percentile/stddev are matched first so an active mode's value
+# always passes through untouched, exactly as before this revision.
+map "$arg_stretch:$arg_pmin" $geolens_raster_pmin {
+    "~^percentile:"                                 $arg_pmin;
+    "~^[^:]*:$"                                      "";
+    "~^[^:]*:(100(\.0+)?|[0-9]{1,2}(\.[0-9]+)?)$"   "";
+    default                                          $arg_pmin;
 }
-map $arg_stretch $geolens_raster_pmax {
-    percentile $arg_pmax;
-    default    "";
+map "$arg_stretch:$arg_pmax" $geolens_raster_pmax {
+    "~^percentile:"                                 $arg_pmax;
+    "~^[^:]*:$"                                      "";
+    "~^[^:]*:(100(\.0+)?|[0-9]{1,2}(\.[0-9]+)?)$"   "";
+    default                                          $arg_pmax;
 }
-map $arg_stretch $geolens_raster_sigma {
-    stddev  $arg_sigma;
-    default "";
+map "$arg_stretch:$arg_sigma" $geolens_raster_sigma {
+    "~^stddev:"                                             $arg_sigma;
+    "~^[^:]*:$"                                              "";
+    "~^[^:]*:([1-9][0-9]*(\.[0-9]+)?|0\.[0-9]*[1-9][0-9]*)$" "";
+    default                                                  $arg_sigma;
 }
 
 # fix(#581): trusted-proxy trust boundary, rendered by the entrypoint from

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -109,15 +109,26 @@ map $upstream_http_access_control_allow_origin $geolens_export_acao {
 # own case-insensitivity or decoding blind spots.
 #
 # When non-canonical, EVERY map below falls back to keeping the matching
-# per-parameter value raw (as before), AND $geolens_raster_cache_extra folds
-# the ENTIRE raw $args into the cache key. The per-parameter fallback alone
-# would already have closed the mixed-case duplicate above (nginx's own
-# $arg_pmin still varies raw by request), but keying on the whole $args
-# additionally makes correctness independent of that per-parameter reasoning
-# ever being complete again: two requests share a key in the non-canonical
-# case if and only if their raw query strings are identical, full stop, no
-# per-name analysis required. Empty (no key change) whenever $args IS
-# canonical, so the common case pays nothing extra.
+# per-parameter value raw (as before). $geolens_raster_noncanonical is ALSO
+# used directly below, in the raster-tiles location, as a proxy_cache_bypass
+# / proxy_no_cache condition -- fix(#1778 codex r6): an earlier revision
+# additionally folded the ENTIRE raw $args into the cache key for the
+# non-canonical case, which closed the collision but opened a worse leak:
+# this endpoint accepts the deprecated ?api_key= query lane
+# (_resolve_api_key, auth/dependencies.py), so a non-canonical request
+# carrying one wrote that credential, in the clear, into proxy_cache_key --
+# reachable through raster_cache's on-disk files and any backup of them,
+# even though access logging already strips query strings for exactly this
+# reason. proxy_cache_key must only ever be built from the sanitised
+# $geolens_raster_* variables (never raw $args, never any $arg_* directly),
+# so a non-canonical request is instead served UNCACHED: bypass skips the
+# lookup, no_cache skips the store, and nothing about that request's
+# arguments -- credential included -- is ever written anywhere. The
+# per-parameter fallback above still matters independently: it is what
+# keeps two DIFFERENT non-canonical requests from colliding on the ordinary
+# render params in case bypass/no_cache is ever misconfigured off this
+# location, defense in depth rather than the only thing standing between a
+# duplicated/mixed-case stretch and a wrong tile.
 #
 # The case-variant patterns are mechanical: one alternative per letter
 # position, that position forced to its single uppercase form and every
@@ -145,10 +156,6 @@ map $args $geolens_raster_noncanonical {
     #    every letter of every name is the same unbounded-alternatives
     #    problem in a different disguise.
     "~(?:^|&)[^&=]*%[^&=]*=" 1;
-}
-map "$geolens_raster_noncanonical:$args" $geolens_raster_cache_extra {
-    "~^1:" $args;
-    default "";
 }
 # fix(#1778 codex r5): the three maps below used to require the value to be
 # WELL-FORMED AND IN THE RANGE THAT MATTERS FOR THE ACTIVE MODE (0-100 for
@@ -339,17 +346,27 @@ server {
         # maps declared above (fix(#1778): those maps blank the args a request's
         # stretch mode does not read, so an anonymous caller can no longer defeat
         # the cache by randomizing an arg that never touches the rendered bytes).
-        # fix(#1778 codex r4): $geolens_raster_cache_extra folds the whole raw
-        # $args in whenever the request is not in strict canonical form (a
-        # duplicated, mixed-case, or percent-encoded stretch/pmin/pmax/sigma
-        # name), so correctness there does not depend on the per-parameter
-        # maps' own reasoning — see the block above them.
+        # The key is built ONLY from these sanitised variables -- fix(#1778 codex
+        # r6): it must never include raw $args or any single raw $arg_*, because
+        # this route accepts credentials on the query string (?api_key=, the
+        # deprecated lane _resolve_api_key still honours) and a raw value would
+        # write that credential into the cache key, reachable through
+        # raster_cache's on-disk files and any backup of them.
         # fix(#1372): $arg_v is the dataset's tile_cache_version, emitted by the
         # api in every raster tile URL — a raster replace bumps it, so the
         # shared cache rolls immediately instead of serving pre-replace bytes
         # for up to proxy_cache_valid. Unversioned clients (copied connect
         # URLs) key on the empty segment and keep the old bounded staleness.
-        proxy_cache_key "$dataset_id/$z/$x/$y.$fmt/$arg_v/$arg_colormap_name/$arg_stretch/$geolens_raster_pmin/$geolens_raster_pmax/$geolens_raster_sigma/$geolens_raster_cache_extra";
+        proxy_cache_key "$dataset_id/$z/$x/$y.$fmt/$arg_v/$arg_colormap_name/$arg_stretch/$geolens_raster_pmin/$geolens_raster_pmax/$geolens_raster_sigma";
+        # fix(#1778 codex r6): a non-canonical request (see the maps declared
+        # near the top of this file) is served UNCACHED rather than keyed on
+        # anything derived from its raw $args -- bypass skips the lookup,
+        # no_cache skips the store, so neither a lookup nor a write ever touches
+        # $geolens_raster_noncanonical's own raw request, credential included.
+        # $geolens_raster_noncanonical is "0"/"1"; nginx treats "0" as falsy for
+        # both directives, so the ordinary canonical path is unaffected.
+        proxy_cache_bypass $geolens_raster_noncanonical;
+        proxy_no_cache $geolens_raster_noncanonical;
         proxy_cache_valid 200 1h;
         proxy_cache_use_stale error timeout updating;
         # Honor the api's Cache-Control: nginx skips caching when the api

--- a/frontend/src/types/api.generated.ts
+++ b/frontend/src/types/api.generated.ts
@@ -5209,13 +5209,24 @@ export interface paths {
          *     rescale from Titiler band statistics. Multi-band rasters produce one rescale=
          *     fragment per band (up to 3, RASTER-STRETCH-03).
          *
-         *     pmin/pmax: Configurable percentile clip bounds (default 2/98). Must satisfy
-         *     0 <= pmin < pmax <= 100. Forwarded as repeated p= params to /cog/statistics.
-         *     The _band_stats_cache key includes pmin/pmax so different bounds never serve
-         *     stale cached stats (RASTER-STRETCH-UI-01 / Phase 1153 cache-key isolation).
+         *     pmin/pmax: Configurable percentile clip bounds (default 2/98), read and
+         *     validated (0 <= pmin < pmax <= 100) only when stretch=percentile. Forwarded
+         *     as repeated p= params to /cog/statistics. The _band_stats_cache key includes
+         *     pmin/pmax so different bounds never serve stale cached stats
+         *     (RASTER-STRETCH-UI-01 / Phase 1153 cache-key isolation).
          *
-         *     sigma: Standard-deviation multiplier for stretch=stddev (default 2.0).
-         *     Must be > 0.
+         *     sigma: Standard-deviation multiplier for stretch=stddev (default 2.0), read
+         *     and validated (> 0) only when stretch=stddev.
+         *
+         *     fix(#1778 codex r2): pmin/pmax/sigma used to be validated whenever present,
+         *     regardless of the active stretch mode, so an "inactive" value could still
+         *     422. frontend/nginx.conf's raster proxy_cache_key blanks an inactive value
+         *     out of the cache key to stop it defeating the cache; making that safe on
+         *     every input (including a repeated query parameter, where nginx's $arg_x
+         *     reads the FIRST occurrence and this endpoint's scalar Query reads the
+         *     LAST) needs "inactive" to mean the SAME thing on both sides: ignored, not
+         *     merely unvalidated for some inputs. A cache HIT must never disagree with
+         *     what an uncached request would answer.
          */
         get: operations["raster_tile_proxy_tiles_raster_proxy__dataset_id___z___x___y___fmt__get"];
         put?: never;
@@ -40081,11 +40092,11 @@ export interface operations {
                 colormap_name?: ("gray" | "viridis" | "inferno" | "plasma" | "magma" | "ylorrd" | "bugn" | "terrain") | null;
                 /** @description Stretch strategy: minmax (default), percentile, stddev */
                 stretch?: ("minmax" | "percentile" | "stddev") | null;
-                /** @description Lower percentile clip for stretch=percentile (0–100, default 2). Absent = current p2 behavior. Must be less than pmax. */
+                /** @description Lower percentile clip for stretch=percentile (0–100, default 2). Absent = current p2 behavior. Must be less than pmax. Ignored, and not validated, when stretch is not percentile. */
                 pmin?: number | null;
-                /** @description Upper percentile clip for stretch=percentile (0–100, default 98). Absent = current p98 behavior. Must be greater than pmin. */
+                /** @description Upper percentile clip for stretch=percentile (0–100, default 98). Absent = current p98 behavior. Must be greater than pmin. Ignored, and not validated, when stretch is not percentile. */
                 pmax?: number | null;
-                /** @description Standard-deviation multiplier for stretch=stddev (default 2.0). Absent = current 2.0σ behavior. Must be > 0. */
+                /** @description Standard-deviation multiplier for stretch=stddev (default 2.0). Absent = current 2.0σ behavior. Must be > 0. Ignored, and not validated, when stretch is not stddev. */
                 sigma?: number | null;
             };
             header?: never;

--- a/sdks/python/geolens/api/tiles/raster_tile_proxy_tiles_raster_proxy_dataset_id_z_x_y_fmt_get.py
+++ b/sdks/python/geolens/api/tiles/raster_tile_proxy_tiles_raster_proxy_dataset_id_z_x_y_fmt_get.py
@@ -167,7 +167,7 @@ def sync_detailed(
     pmax: float | None | Unset = UNSET,
     sigma: float | None | Unset = UNSET,
 ) -> Response[Any | ProblemDetail]:
-    """Raster Tile Proxy
+    r"""Raster Tile Proxy
 
      API-side raster tile proxy: auth check + fetch from Titiler.
 
@@ -184,13 +184,24 @@ def sync_detailed(
     rescale from Titiler band statistics. Multi-band rasters produce one rescale=
     fragment per band (up to 3, RASTER-STRETCH-03).
 
-    pmin/pmax: Configurable percentile clip bounds (default 2/98). Must satisfy
-    0 <= pmin < pmax <= 100. Forwarded as repeated p= params to /cog/statistics.
-    The _band_stats_cache key includes pmin/pmax so different bounds never serve
-    stale cached stats (RASTER-STRETCH-UI-01 / Phase 1153 cache-key isolation).
+    pmin/pmax: Configurable percentile clip bounds (default 2/98), read and
+    validated (0 <= pmin < pmax <= 100) only when stretch=percentile. Forwarded
+    as repeated p= params to /cog/statistics. The _band_stats_cache key includes
+    pmin/pmax so different bounds never serve stale cached stats
+    (RASTER-STRETCH-UI-01 / Phase 1153 cache-key isolation).
 
-    sigma: Standard-deviation multiplier for stretch=stddev (default 2.0).
-    Must be > 0.
+    sigma: Standard-deviation multiplier for stretch=stddev (default 2.0), read
+    and validated (> 0) only when stretch=stddev.
+
+    fix(#1778 codex r2): pmin/pmax/sigma used to be validated whenever present,
+    regardless of the active stretch mode, so an \"inactive\" value could still
+    422. frontend/nginx.conf's raster proxy_cache_key blanks an inactive value
+    out of the cache key to stop it defeating the cache; making that safe on
+    every input (including a repeated query parameter, where nginx's $arg_x
+    reads the FIRST occurrence and this endpoint's scalar Query reads the
+    LAST) needs \"inactive\" to mean the SAME thing on both sides: ignored, not
+    merely unvalidated for some inputs. A cache HIT must never disagree with
+    what an uncached request would answer.
 
     Args:
         dataset_id (UUID):
@@ -203,11 +214,14 @@ def sync_detailed(
         stretch (None | RasterTileProxyTilesRasterProxyDatasetIdZXYFmtGetStretchType0 | Unset):
             Stretch strategy: minmax (default), percentile, stddev
         pmin (float | None | Unset): Lower percentile clip for stretch=percentile (0–100, default
-            2). Absent = current p2 behavior. Must be less than pmax.
+            2). Absent = current p2 behavior. Must be less than pmax. Ignored, and not validated, when
+            stretch is not percentile.
         pmax (float | None | Unset): Upper percentile clip for stretch=percentile (0–100, default
-            98). Absent = current p98 behavior. Must be greater than pmin.
+            98). Absent = current p98 behavior. Must be greater than pmin. Ignored, and not validated,
+            when stretch is not percentile.
         sigma (float | None | Unset): Standard-deviation multiplier for stretch=stddev (default
-            2.0). Absent = current 2.0σ behavior. Must be > 0.
+            2.0). Absent = current 2.0σ behavior. Must be > 0. Ignored, and not validated, when
+            stretch is not stddev.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -255,7 +269,7 @@ def sync(
     pmax: float | None | Unset = UNSET,
     sigma: float | None | Unset = UNSET,
 ) -> Any | ProblemDetail | None:
-    """Raster Tile Proxy
+    r"""Raster Tile Proxy
 
      API-side raster tile proxy: auth check + fetch from Titiler.
 
@@ -272,13 +286,24 @@ def sync(
     rescale from Titiler band statistics. Multi-band rasters produce one rescale=
     fragment per band (up to 3, RASTER-STRETCH-03).
 
-    pmin/pmax: Configurable percentile clip bounds (default 2/98). Must satisfy
-    0 <= pmin < pmax <= 100. Forwarded as repeated p= params to /cog/statistics.
-    The _band_stats_cache key includes pmin/pmax so different bounds never serve
-    stale cached stats (RASTER-STRETCH-UI-01 / Phase 1153 cache-key isolation).
+    pmin/pmax: Configurable percentile clip bounds (default 2/98), read and
+    validated (0 <= pmin < pmax <= 100) only when stretch=percentile. Forwarded
+    as repeated p= params to /cog/statistics. The _band_stats_cache key includes
+    pmin/pmax so different bounds never serve stale cached stats
+    (RASTER-STRETCH-UI-01 / Phase 1153 cache-key isolation).
 
-    sigma: Standard-deviation multiplier for stretch=stddev (default 2.0).
-    Must be > 0.
+    sigma: Standard-deviation multiplier for stretch=stddev (default 2.0), read
+    and validated (> 0) only when stretch=stddev.
+
+    fix(#1778 codex r2): pmin/pmax/sigma used to be validated whenever present,
+    regardless of the active stretch mode, so an \"inactive\" value could still
+    422. frontend/nginx.conf's raster proxy_cache_key blanks an inactive value
+    out of the cache key to stop it defeating the cache; making that safe on
+    every input (including a repeated query parameter, where nginx's $arg_x
+    reads the FIRST occurrence and this endpoint's scalar Query reads the
+    LAST) needs \"inactive\" to mean the SAME thing on both sides: ignored, not
+    merely unvalidated for some inputs. A cache HIT must never disagree with
+    what an uncached request would answer.
 
     Args:
         dataset_id (UUID):
@@ -291,11 +316,14 @@ def sync(
         stretch (None | RasterTileProxyTilesRasterProxyDatasetIdZXYFmtGetStretchType0 | Unset):
             Stretch strategy: minmax (default), percentile, stddev
         pmin (float | None | Unset): Lower percentile clip for stretch=percentile (0–100, default
-            2). Absent = current p2 behavior. Must be less than pmax.
+            2). Absent = current p2 behavior. Must be less than pmax. Ignored, and not validated, when
+            stretch is not percentile.
         pmax (float | None | Unset): Upper percentile clip for stretch=percentile (0–100, default
-            98). Absent = current p98 behavior. Must be greater than pmin.
+            98). Absent = current p98 behavior. Must be greater than pmin. Ignored, and not validated,
+            when stretch is not percentile.
         sigma (float | None | Unset): Standard-deviation multiplier for stretch=stddev (default
-            2.0). Absent = current 2.0σ behavior. Must be > 0.
+            2.0). Absent = current 2.0σ behavior. Must be > 0. Ignored, and not validated, when
+            stretch is not stddev.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -338,7 +366,7 @@ async def asyncio_detailed(
     pmax: float | None | Unset = UNSET,
     sigma: float | None | Unset = UNSET,
 ) -> Response[Any | ProblemDetail]:
-    """Raster Tile Proxy
+    r"""Raster Tile Proxy
 
      API-side raster tile proxy: auth check + fetch from Titiler.
 
@@ -355,13 +383,24 @@ async def asyncio_detailed(
     rescale from Titiler band statistics. Multi-band rasters produce one rescale=
     fragment per band (up to 3, RASTER-STRETCH-03).
 
-    pmin/pmax: Configurable percentile clip bounds (default 2/98). Must satisfy
-    0 <= pmin < pmax <= 100. Forwarded as repeated p= params to /cog/statistics.
-    The _band_stats_cache key includes pmin/pmax so different bounds never serve
-    stale cached stats (RASTER-STRETCH-UI-01 / Phase 1153 cache-key isolation).
+    pmin/pmax: Configurable percentile clip bounds (default 2/98), read and
+    validated (0 <= pmin < pmax <= 100) only when stretch=percentile. Forwarded
+    as repeated p= params to /cog/statistics. The _band_stats_cache key includes
+    pmin/pmax so different bounds never serve stale cached stats
+    (RASTER-STRETCH-UI-01 / Phase 1153 cache-key isolation).
 
-    sigma: Standard-deviation multiplier for stretch=stddev (default 2.0).
-    Must be > 0.
+    sigma: Standard-deviation multiplier for stretch=stddev (default 2.0), read
+    and validated (> 0) only when stretch=stddev.
+
+    fix(#1778 codex r2): pmin/pmax/sigma used to be validated whenever present,
+    regardless of the active stretch mode, so an \"inactive\" value could still
+    422. frontend/nginx.conf's raster proxy_cache_key blanks an inactive value
+    out of the cache key to stop it defeating the cache; making that safe on
+    every input (including a repeated query parameter, where nginx's $arg_x
+    reads the FIRST occurrence and this endpoint's scalar Query reads the
+    LAST) needs \"inactive\" to mean the SAME thing on both sides: ignored, not
+    merely unvalidated for some inputs. A cache HIT must never disagree with
+    what an uncached request would answer.
 
     Args:
         dataset_id (UUID):
@@ -374,11 +413,14 @@ async def asyncio_detailed(
         stretch (None | RasterTileProxyTilesRasterProxyDatasetIdZXYFmtGetStretchType0 | Unset):
             Stretch strategy: minmax (default), percentile, stddev
         pmin (float | None | Unset): Lower percentile clip for stretch=percentile (0–100, default
-            2). Absent = current p2 behavior. Must be less than pmax.
+            2). Absent = current p2 behavior. Must be less than pmax. Ignored, and not validated, when
+            stretch is not percentile.
         pmax (float | None | Unset): Upper percentile clip for stretch=percentile (0–100, default
-            98). Absent = current p98 behavior. Must be greater than pmin.
+            98). Absent = current p98 behavior. Must be greater than pmin. Ignored, and not validated,
+            when stretch is not percentile.
         sigma (float | None | Unset): Standard-deviation multiplier for stretch=stddev (default
-            2.0). Absent = current 2.0σ behavior. Must be > 0.
+            2.0). Absent = current 2.0σ behavior. Must be > 0. Ignored, and not validated, when
+            stretch is not stddev.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -424,7 +466,7 @@ async def asyncio(
     pmax: float | None | Unset = UNSET,
     sigma: float | None | Unset = UNSET,
 ) -> Any | ProblemDetail | None:
-    """Raster Tile Proxy
+    r"""Raster Tile Proxy
 
      API-side raster tile proxy: auth check + fetch from Titiler.
 
@@ -441,13 +483,24 @@ async def asyncio(
     rescale from Titiler band statistics. Multi-band rasters produce one rescale=
     fragment per band (up to 3, RASTER-STRETCH-03).
 
-    pmin/pmax: Configurable percentile clip bounds (default 2/98). Must satisfy
-    0 <= pmin < pmax <= 100. Forwarded as repeated p= params to /cog/statistics.
-    The _band_stats_cache key includes pmin/pmax so different bounds never serve
-    stale cached stats (RASTER-STRETCH-UI-01 / Phase 1153 cache-key isolation).
+    pmin/pmax: Configurable percentile clip bounds (default 2/98), read and
+    validated (0 <= pmin < pmax <= 100) only when stretch=percentile. Forwarded
+    as repeated p= params to /cog/statistics. The _band_stats_cache key includes
+    pmin/pmax so different bounds never serve stale cached stats
+    (RASTER-STRETCH-UI-01 / Phase 1153 cache-key isolation).
 
-    sigma: Standard-deviation multiplier for stretch=stddev (default 2.0).
-    Must be > 0.
+    sigma: Standard-deviation multiplier for stretch=stddev (default 2.0), read
+    and validated (> 0) only when stretch=stddev.
+
+    fix(#1778 codex r2): pmin/pmax/sigma used to be validated whenever present,
+    regardless of the active stretch mode, so an \"inactive\" value could still
+    422. frontend/nginx.conf's raster proxy_cache_key blanks an inactive value
+    out of the cache key to stop it defeating the cache; making that safe on
+    every input (including a repeated query parameter, where nginx's $arg_x
+    reads the FIRST occurrence and this endpoint's scalar Query reads the
+    LAST) needs \"inactive\" to mean the SAME thing on both sides: ignored, not
+    merely unvalidated for some inputs. A cache HIT must never disagree with
+    what an uncached request would answer.
 
     Args:
         dataset_id (UUID):
@@ -460,11 +513,14 @@ async def asyncio(
         stretch (None | RasterTileProxyTilesRasterProxyDatasetIdZXYFmtGetStretchType0 | Unset):
             Stretch strategy: minmax (default), percentile, stddev
         pmin (float | None | Unset): Lower percentile clip for stretch=percentile (0–100, default
-            2). Absent = current p2 behavior. Must be less than pmax.
+            2). Absent = current p2 behavior. Must be less than pmax. Ignored, and not validated, when
+            stretch is not percentile.
         pmax (float | None | Unset): Upper percentile clip for stretch=percentile (0–100, default
-            98). Absent = current p98 behavior. Must be greater than pmin.
+            98). Absent = current p98 behavior. Must be greater than pmin. Ignored, and not validated,
+            when stretch is not percentile.
         sigma (float | None | Unset): Standard-deviation multiplier for stretch=stddev (default
-            2.0). Absent = current 2.0σ behavior. Must be > 0.
+            2.0). Absent = current 2.0σ behavior. Must be > 0. Ignored, and not validated, when
+            stretch is not stddev.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.

--- a/sdks/typescript/src/client/sdk.gen.ts
+++ b/sdks/typescript/src/client/sdk.gen.ts
@@ -5670,13 +5670,24 @@ export const clusterTileEndpointTilesClustersTablePathZXYPbfGet = <ThrowOnError 
  * rescale from Titiler band statistics. Multi-band rasters produce one rescale=
  * fragment per band (up to 3, RASTER-STRETCH-03).
  *
- * pmin/pmax: Configurable percentile clip bounds (default 2/98). Must satisfy
- * 0 <= pmin < pmax <= 100. Forwarded as repeated p= params to /cog/statistics.
- * The _band_stats_cache key includes pmin/pmax so different bounds never serve
- * stale cached stats (RASTER-STRETCH-UI-01 / Phase 1153 cache-key isolation).
+ * pmin/pmax: Configurable percentile clip bounds (default 2/98), read and
+ * validated (0 <= pmin < pmax <= 100) only when stretch=percentile. Forwarded
+ * as repeated p= params to /cog/statistics. The _band_stats_cache key includes
+ * pmin/pmax so different bounds never serve stale cached stats
+ * (RASTER-STRETCH-UI-01 / Phase 1153 cache-key isolation).
  *
- * sigma: Standard-deviation multiplier for stretch=stddev (default 2.0).
- * Must be > 0.
+ * sigma: Standard-deviation multiplier for stretch=stddev (default 2.0), read
+ * and validated (> 0) only when stretch=stddev.
+ *
+ * fix(#1778 codex r2): pmin/pmax/sigma used to be validated whenever present,
+ * regardless of the active stretch mode, so an "inactive" value could still
+ * 422. frontend/nginx.conf's raster proxy_cache_key blanks an inactive value
+ * out of the cache key to stop it defeating the cache; making that safe on
+ * every input (including a repeated query parameter, where nginx's $arg_x
+ * reads the FIRST occurrence and this endpoint's scalar Query reads the
+ * LAST) needs "inactive" to mean the SAME thing on both sides: ignored, not
+ * merely unvalidated for some inputs. A cache HIT must never disagree with
+ * what an uncached request would answer.
  */
 export const rasterTileProxyTilesRasterProxyDatasetIdZXYFmtGet = <ThrowOnError extends boolean = false>(options: Options<RasterTileProxyTilesRasterProxyDatasetIdZxyFmtGetData, ThrowOnError>): RequestResult<RasterTileProxyTilesRasterProxyDatasetIdZxyFmtGetResponses, RasterTileProxyTilesRasterProxyDatasetIdZxyFmtGetErrors, ThrowOnError> => (options.client ?? client).get<RasterTileProxyTilesRasterProxyDatasetIdZxyFmtGetResponses, RasterTileProxyTilesRasterProxyDatasetIdZxyFmtGetErrors, ThrowOnError>({
     security: [

--- a/sdks/typescript/src/client/types.gen.ts
+++ b/sdks/typescript/src/client/types.gen.ts
@@ -27667,19 +27667,19 @@ export type RasterTileProxyTilesRasterProxyDatasetIdZxyFmtGetData = {
         /**
          * Pmin
          *
-         * Lower percentile clip for stretch=percentile (0–100, default 2). Absent = current p2 behavior. Must be less than pmax.
+         * Lower percentile clip for stretch=percentile (0–100, default 2). Absent = current p2 behavior. Must be less than pmax. Ignored, and not validated, when stretch is not percentile.
          */
         pmin?: number | null;
         /**
          * Pmax
          *
-         * Upper percentile clip for stretch=percentile (0–100, default 98). Absent = current p98 behavior. Must be greater than pmin.
+         * Upper percentile clip for stretch=percentile (0–100, default 98). Absent = current p98 behavior. Must be greater than pmin. Ignored, and not validated, when stretch is not percentile.
          */
         pmax?: number | null;
         /**
          * Sigma
          *
-         * Standard-deviation multiplier for stretch=stddev (default 2.0). Absent = current 2.0σ behavior. Must be > 0.
+         * Standard-deviation multiplier for stretch=stddev (default 2.0). Absent = current 2.0σ behavior. Must be > 0. Ignored, and not validated, when stretch is not stddev.
          */
         sigma?: number | null;
     };


### PR DESCRIPTION
Codebase audit 2026-08-30 (8dc529f17), tracked in #1778. Four items from the tail-2 lane brief.

## 1. Raster tile cache key held pmin/pmax/sigma unconditionally

Generalization of the audit finding #1785 fixed for the vector tile `cols=` param. `frontend/nginx.conf`'s raster `proxy_cache_key` included `$arg_pmin`, `$arg_pmax`, and `$arg_sigma` even when `stretch` was absent or `minmax`, so `?stretch=minmax&pmin=<random>` produced a fresh cache key holding bytes identical to the unfiltered tile. On the default production stack (no Valkey) those writes land in a bounded LRU and evict legitimate tiles.

In `backend/app/processing/tiles/router.py`, `stretch=percentile` is the only mode that reads `pmin`/`pmax` and `stretch=stddev` is the only mode that reads `sigma`. Added three `map $arg_stretch ...` blocks, the same shape #1785 used, that blank each family down to what the active mode can change. Blanking both unconditionally would have introduced a correctness bug in the other direction: two `stddev` requests with different `sigma` render different bytes and would collide on one cache entry.

Verified still present on current main before fixing (unaffected by #1785, which touched the vector `cols=` path and a different nginx block).

Test: `backend/tests/test_nginx_raster_stretch_cache_key_1778.py`, structural (reads `nginx.conf`, no nginx binary in this test environment).

**Update (codex round 1):** the first revision blanked every inactive value unconditionally, which let a cache HIT change endpoint semantics. `raster_tile_proxy` validated `pmin`/`pmax`/`sigma` whenever they were present, regardless of the active stretch mode (T-1153-01). So once `?stretch=minmax` was cached as 200, `?stretch=minmax&pmin=200` blanked down to the same key and answered that cached 200, though the API would 422 an out-of-range `pmin` uncached. Round 1 picked the nginx-side shape (blank a value only when it is well-formed by the API's own accepted range) and flagged one residual: the API's check is a JOINT constraint (`0 <= eff_pmin < eff_pmax <= 100`) that nginx cannot cheaply replicate, so a combination like `pmin=90&pmax=10`, individually in range on each side, could still blank and return a cached 200 where an uncached request would 422 on the ordering.

**Update (codex round 2):** round 1's nginx-side shape had a second, independent way to disagree with the API. nginx's `$arg_pmin` reads the FIRST occurrence of a repeated query parameter; FastAPI's scalar `Query` reads the LAST. `?stretch=minmax&pmin=5&pmin=200` read `pmin=5` on the nginx side (well-formed, blanked) while the API would read `pmin=200` and 422 -- the same cache-hit-changes-status bug round 1 closed for a single value, reopened by a duplicate one.

With two independent residuals in the nginx-side shape, I switched to the API-side one this round: `raster_tile_proxy` now reads and validates `pmin`/`pmax` only when `stretch=percentile`, and `sigma` only when `stretch=stddev`, instead of validating whenever merely present. "Inactive" now means "ignored" on both sides, so the nginx maps blank an inactive value unconditionally -- there is no verdict left to disagree with, because the value is never read, regardless of its content or which occurrence either side happens to see. This closes both round-1 residuals (the joint-ordering one and the duplicate-parameter one) instead of adding a third layer of regex to chase them. The cost is a real behavior change: an out-of-range or malformed pmin/pmax/sigma under an inactive stretch mode used to 422 and now succeeds, ignoring it. Updated the `Query()` parameter descriptions, the endpoint docstring, and regenerated `backend/openapi.json` (description-only diff) to say so; inverted the API-level pin test for the inactive case (`test_out_of_range_bounds_are_ignored_under_an_inactive_stretch_mode`, was `test_invalid_bounds_return_422_even_under_an_inactive_stretch_mode`).

One more residual surfaced while implementing round 2 and is closed in the same commit, not left as a third round: the duplicate-parameter mismatch also applies to `stretch` itself, and this one is worse than a status-code mismatch. `?stretch=minmax&stretch=percentile&pmin=5` has nginx read `stretch=minmax` (inactive, blank pmin) while the API reads `stretch=percentile` (active, uses `pmin=5`). Because blanking makes the cache key depend on nginx's OWN reading of `stretch`, a second request with the same duplicate ordering but a DIFFERENT `pmin` (say 50) would collapse onto the SAME key while the API renders DIFFERENT bytes for it -- a genuine cache collision (wrong tile served), not just a wrong status code. This did not exist before round 1: the pre-#1778 cache key held `$arg_pmin` raw and unconditionally, so two different pmin values always produced two different keys regardless of what nginx thought `stretch` was. Making the key depend on nginx's stretch reading is what introduced the risk, so closing it here rather than shipping it. `$geolens_raster_stretch_dup` detects a repeated `stretch=` in the raw query string (`$args`) and, when set, every map falls back to the raw value instead of blanking -- an extra cache miss in that case, never a collision.

Rewrote the nginx structural test to simulate nginx's actual `$arg_x` first-occurrence semantics against a raw query string (rather than asserting on pre-resolved variables), so it exercises the duplicate-parameter cases directly: a repeated inactive param collapses the same way regardless of which occurrence nginx reads; a repeated `stretch` falls back to raw and keeps two different pmin values apart.

**Update (codex round 3):** round 2's API change was necessary but not sufficient. Two more ways nginx's read of the query string can disagree with the API's, neither about what the API validates or ignores:

- `stretch=%70ercentile` decodes to the ACTIVE spelling `percentile` at the API (FastAPI URL-decodes query params), but nginx's raw `$arg_stretch` never matches `percentile` literally. Calling that "not the active spelling, therefore inactive" blanked `pmin`, so two requests with different `pmin` values collapsed onto ONE key while the API rendered DIFFERENT bytes for them under the mode it actually used -- a cache collision, not a status mismatch. A case variant has the same problem.
- `?stretch=minmax&pmin=abc` collapsed onto the plain `?stretch=minmax` key and could serve a cached 200. An uncached request is rejected before `raster_tile_proxy`'s body runs at all: FastAPI's `pmin: float | None` coerces the query param to a float, and `abc` fails that coercion with a 422 regardless of stretch mode. Round 2's "ignore when inactive" code never gets a chance to run against a value that never type-coerces.

The coordinator's principle for closing both, adopted directly: blank an argument ONLY when nginx can be CERTAIN blanking cannot change the outcome -- the raw `$arg_stretch` is EXACTLY one of the canonical inactive spellings (`minmax`, `stddev`, or absent; no percent-encoding, no case variant) AND the argument itself is a well-formed float in the range that matters for the one mode where it is active. Everything else -- an unrecognized or duplicated stretch spelling, a malformed or out-of-range value -- stays raw: the request misses the cache and the API decides. Failing toward "keep raw" costs cache fragmentation on odd spellings; failing toward "blank" was the bug both times.

This is a return to something like round 1's shape (a well-formedness check) but combined with round 2's API-side ignore-when-inactive change, which is still required: round 1's residual (the joint pmin/pmax ordering nginx cannot cheaply check) is closed by the API ignoring the value entirely when inactive, not by the nginx regex, and the new exact-spelling requirement closes the percent-encoding/case-variant gap on top of that. One accepted, named tradeoff: a well-formed-but-out-of-[0,100]-range value like `pmin=200` under an inactive mode now also stays raw (round 2 would have blanked it safely, since the API ignores it regardless of value) -- kept conservative rather than writing a more permissive, harder-to-audit "any valid float" regex for a case the coordinator's own principle says is fine to leave as an extra cache miss.

Extended the nginx structural test with the percent-encoded stretch, a case variant, and the malformed float, each asserting the raw value is kept, and reworked the well-formed/out-of-range/duplicate-occurrence tests for the new blank-only-when-certain shape.

**Update (codex round 4):** round 3's exact-spelling check assumed nginx resolves `$arg_stretch` case-sensitively on the parameter NAME. It does not: nginx's arg matcher (ngx_http_arg -> ngx_strlcasestrn) is case-INSENSITIVE on the name, so `$arg_stretch` resolves from `Stretch=`, `STRETCH=`, etc, while FastAPI's query-param binding is exact-case. `?Stretch=minmax&stretch=percentile&pmin=5` had nginx read stretch=minmax (the first case-insensitive match, inactive, blank pmin) while the API read stretch=percentile (the only exact-case match, active, uses pmin=5) -- a cache collision, because round 3's duplicate detector was itself case-sensitive-only and never saw this as a duplicate at all.

Generalized the principle again rather than patching this one instance, per the coordinator's explicit instruction to make the check strict enough that this class cannot recur: blanking is now allowed only when `$args` is in STRICT CANONICAL FORM -- each of stretch/pmin/pmax/sigma appears at most once, checked CASE-INSENSITIVELY (a mixed-case duplicate is still a duplicate); every occurrence of each of those four names is spelled EXACTLY lowercase (a single mixed-case occurrence with NO duplicate at all is also non-canonical, since FastAPI ignores it entirely via exact-case lookup while nginx's case-insensitive lookup still resolves it -- kept strict rather than relying on the current specific behavior of the API's absent-stretch default happening to coincide, since that coincidence is not something future API changes are obligated to preserve); and none of the four names is percent-encoded. `$geolens_raster_noncanonical` checks all three directly against the raw `$args` string, not derived from any single `$arg_*` lookup, so it cannot inherit nginx's own case-insensitivity or decoding blind spots.

When non-canonical, `$geolens_raster_cache_extra` folds the ENTIRE raw `$args` into the cache key, on top of the existing per-parameter fallback. The per-parameter fallback alone would already have closed the demonstrated collision (nginx's own `$arg_pmin` still varies raw by request even under the old duplicate-only check), but keying on the whole `$args` additionally makes correctness in the non-canonical case independent of per-parameter reasoning ever being complete again -- two requests share a key if and only if their raw query strings are identical, no per-name analysis required. This directly follows the rule as given rather than the narrower fix that would have sufficed for just the reported case.

The case-variant regex patterns (one alternative per letter position, that position forced uppercase, every other position a same-letter class) are mechanically generated, not hand-tuned, and the config documents the generator expression so they can be regenerated and audited rather than trusted by inspection alone.

Rewrote the nginx structural test's simulation to match nginx's actual semantics in two respects the previous version got wrong: `$arg_NAME` lookup is now case-insensitive (matching `ngx_strlcasestrn`), and map regex evaluation now searches the whole string (`re.search`) instead of anchoring at position 0 (`re.match`) -- the anchored version would have silently missed a duplicate whose first occurrence isn't the first key in `$args`, which the new `test_duplicate_detection_finds_a_duplicate_not_starting_at_position_zero` pins directly. Added the mixed-case duplicate, a mixed-case single occurrence, and the percent-encoded-name case; one existing test (`test_repeated_well_formed_inactive_param_collapses_regardless_of_occurrence_order`) no longer holds under the stricter rule, since a repeated pmin -- even same-case, even both occurrences well-formed -- is now non-canonical too, and was replaced with a test pinning the new correct behavior (stays raw, not a collision, since the two requests still key differently).

**Update (codex round 5):** the well-formedness half of the round-3 check was stricter than it needed to be, in a way that reopened the exact cache-amplification vector this whole fix exists to close. It required a value to be in the range that matters for the active mode (0-100 for pmin/pmax, positive for sigma), a round-1 leftover from before round 2 made the API ignore an inactive value outright. Since the API never applies that range check to a value it never reads that far into, `?stretch=minmax&pmin=101`, `pmin=102`, `pmin=103`, ... each stayed raw (out of range, "not well-formed" by the old check) even though every one of them renders the identical tile under minmax -- an anonymous caller could still mint a distinct one-hour cache entry per distinct out-of-range value, which is the cache-amplification vector fix(#1778) exists to close, reopened through the range check itself.

Range is irrelevant for an inactive parameter. The well-formedness check now mirrors FastAPI's float grammar (optional sign, digits, decimal point, exponent -- the shape of Python's `float()` literal syntax) instead of its semantic range, identically for pmin/pmax/sigma. The only thing that still stays raw is a value FastAPI cannot parse as a float at all, which hits the framework's own type-coercion 422 before `raster_tile_proxy`'s body runs regardless of stretch mode (round 3, unaffected by this change). Deliberately did not extend the grammar to Python-only extensions (underscore digit separators, `inf`/`nan` literals) this simulation cannot verify pydantic's query-param coercion accepts; failing toward raw for those keeps the "keep raw when uncertain" rule intact at the cost of a rare extra cache miss, never a collision or a status mismatch.

Extended the structural test with the coordinator's named cases (`pmin=101`, `pmin=-5`, `sigma=0`, `pmax=1e3` under an inactive mode collapsing to the blank key, `pmin=abc` still raw) and updated the two existing tests that had asserted the old range-restricted behavior.

**Update (codex round 6, P1):** `$geolens_raster_cache_extra` folded the entire raw `$args` into `proxy_cache_key` for a non-canonical request, and this endpoint accepts the deprecated `?api_key=` query lane (`_resolve_api_key`, `app/modules/auth/dependencies.py`). A non-canonical request carrying one wrote that credential, in the clear, into the cache key, reachable through `raster_cache`'s on-disk files and any backup of them, even though access logging already strips query strings for exactly this reason.

`proxy_cache_key` must be built only from the sanitised `$geolens_raster_*` variables, never raw `$args` and never any other raw `$arg_*`. A non-canonical request is now served uncached instead of keyed on anything: `$geolens_raster_noncanonical` (already computed for the per-parameter maps) also drives `proxy_cache_bypass` and `proxy_no_cache` on the raster-tiles location, so bypass skips the lookup and no_cache skips the store. Removed `$geolens_raster_cache_extra` and its map entirely rather than leaving it unused, since a re-added reference to it later would silently reopen the leak.

Added a structural test scanning the resolved key for `$args` and for `api_key`/`token`/`authorization`, a test confirming both cache directives reference the noncanonical variable, and the coordinator's named scenario (`api_key=SECRET` alongside a non-canonical stretch spelling resolves `noncanonical=1` and none of the per-parameter values contain the secret). Reworked the tests that previously asserted on `$geolens_raster_cache_extra` to assert on the bypass instead.

**Update (codex round 7):** round 4's name check never inspected pmin/pmax/sigma's VALUE, only the parameter name. nginx never decodes `$arg_pmin`/`$arg_pmax`/`$arg_sigma` either, so `pmin=%31`, `pmin=+1`, and `pmin=%201` each reached the config as their own literal raw bytes ("%31", "+1", "%201") while FastAPI decoded every one of them into an ordinary, valid float: percent-decoding turns "%31"/"%201" into "1"/" 1", and Starlette's query-string unescaping independently turns a raw `+` into a space, so "+1" becomes " 1" too -- Python's `float()` strips the leading space, so all three parse as 1.0. Distinct encodings of the identical float therefore minted distinct one-hour cache entries for one identical tile, the same amplification vector round 4 closed for names, reopened on values.

Added a second map, keyed on `$arg_pmin:$arg_pmax:$arg_sigma`, requiring each field to be empty or match the exact float grammar `-?[0-9]+(\.[0-9]+)?([eE]-?[0-9]+)?` -- no `%`, no `+`, no whitespace, since a raw `+` can never itself be part of a canonical float (it always decodes to a space first). A third map ORs this against the existing name-based result into the final `$geolens_raster_noncanonical`, which still drives the existing `proxy_cache_bypass`/`proxy_no_cache` unchanged -- the gate gets stricter, nothing new needs wiring. Did not attempt to decode the value in nginx: a hand-rolled decoder would still have to special-case Starlette's `+` rule, its own bug surface; fails toward non-canonical/bypass instead, the same "keep raw when uncertain" posture the rest of this fix uses throughout.

Extended the structural test with the coordinator's four named cases (all asserted `noncanonical=1`, including under an ACTIVE stretch mode, not just an inactive one that would otherwise have blanked), a positive control (`pmin=1` unaffected), an empty-value control, and a colon-injection counterfactual (a raw `:` inside a value can't forge a false negative, since it breaks the anchored per-field grammar and falls through to the map's `default 1`). Also had to fix one round-5 test that included `pmin=+5` in its "blanks under an inactive mode" list -- no longer correct, since a raw `+` now makes the whole request non-canonical instead of blanking.

**Update (codex round 8):** "inactive means ignored" was decided at the validation gate in `backend/app/processing/tiles/router.py` but not enforced on `eff_pmin`/`eff_pmax`/`eff_sigma` themselves, which resolved from "was the raw parameter merely present," independent of stretch mode. `?stretch=stddev&pmin=1e309` (FastAPI's float coercion turns that literal into `inf`; the validation block never runs because pmin is inactive under stddev) still set `eff_pmin=inf`, which reached `_fetch_band_statistics`'s `int(pmin)` and raised an uncaught `OverflowError` -- a 500. nginx, meanwhile, already treats a value it blanks as harmless and found `1e309` well inside its canonical float grammar (round 7), so it blanked pmin and shared a cache key with a plain stddev request: a cached 200 once warm, a 500 on the first, cold request.

Resolved `eff_pmin`/`eff_pmax`/`eff_sigma` ONCE, gated on the SAME activity test (`stretch == "percentile"` for pmin/pmax, `stretch == "stddev"` for sigma) the validation block already used, instead of on raw presence. An inactive parameter's effective value is now always the same default used when it's absent, never the raw request value; every downstream consumer (`_fetch_band_statistics`, `_compute_stretch_rescale`, the `_band_stats_cache` key, both error-detail f-strings) reads only the resolved value. Grepped every `pmin`/`pmax`/`sigma`/`eff_*` reference in the handler and its helpers -- no cache-key or ETag derivation and no log line touches them outside what's now fixed. Also added explicit `math.isfinite()` checks on the ACTIVE path rather than leaning on inf/nan's IEEE-754 comparison behavior to fail the existing bound checks -- the old `sigma > 0` check alone let `inf > 0` (True) pass, which would have produced a literal inf/-inf rescale fragment on the active stddev path instead of a clean 422. Added a comment in `frontend/nginx.conf`'s round-7 value-grammar map noting that non-finite handling is deliberately the API's job: nginx cannot distinguish a finite float from one that overflows at the API's coercion step, and `1e309` staying canonical-by-nginx-grammar is correct, not a gap.

One correction to the coordinator's named pins: pmin/pmax's only ACTIVE mode is `percentile`, not `minmax` (pre-existing docstring and the pre-existing `test_out_of_range_bounds_are_ignored_under_an_inactive_stretch_mode`, which already pins `minmax` as inactive-for-pmin/pmax). Pinned instead: `stretch=stddev&pmin=1e309` -> the same 200 as bare `stretch=stddev` (byte-identical tile URL, and a cache HIT on `_band_stats_cache` rather than a fresh Titiler call, proving it resolved to the same key as the absent case); `stretch=percentile&pmin=1e309` -> 422 before Titiler; `stretch=stddev&sigma=1e309` -> 422 before Titiler; and extended the existing inactive-mode parametrized test with a `stretch=minmax&pmin=1e309` case (200), matching the coordinator's literal query with the mode's already-established, correct expected status. `tiles/router.py` cap 2665 -> 2706.

**Update (codex round 9):** the round-4/round-1 duplicate detector only counted occurrences containing `=`. `?stretch=minmax&pmin=5&pmin` has nginx's `$arg_pmin` resolve from the earlier, well-formed `pmin=5` (`ngx_http_arg` requires an immediate `=` to match at all, so the bare trailing `pmin` is invisible to it, same as if it were absent), while Starlette keeps the bare `pmin` as a real `("pmin", "")` pair (`keep_blank_values=True`) that the scalar Query dependency reads as the LAST occurrence -- empty string, which pydantic's float coercion 422s on unconditionally, before "ignore when inactive" ever runs. That request was canonical to every check through round 8, so it collapsed onto the plain `?stretch=minmax` cache entry: warm 200, cold 422.

Added one regex per name to the existing name-based map, alongside round 4's duplicate/mis-case checks (not a new map -- the coordinator's fallback for "if awkward," but a single `(?:^|&)NAME(?:&|$)` token-boundary check per name is not): present as a bare token (no trailing `=`) anywhere in `$args` is itself non-canonical. Confirmed a literal occurrence COUNT isn't needed: a bare occurrence with no `name=` sibling is the single-bare case (still 422s, since the last occurrence is that bare pair); a bare occurrence alongside a `name=` occurrence elsewhere is already >= 2 total occurrences, the exact "at most once" property round 4 already polices. So "does a bare occurrence exist at all" covers both shapes.

Extended the structural test with the coordinator's four named cases (`&pmin=5&pmin`, `&pmin&pmin=5`, `&PMIN` bare, `&stretch` bare, all `noncanonical=1`), bare `pmax`/`sigma` for completeness across every name this config sanitises, and a positive control (`pmin=5` alone, with or without a well-formed sibling, stays canonical). No backend files touched, so no LOC cap moves.

## 2. GeoParquet row stream had no wall clock

Tail of #1781, which bounded every ogr2ogr export format's subprocess and libpq `statement_timeout` by what is left of the edge proxy's read-timeout window. GeoParquet (`backend/app/processing/export/parquet.py`) has no subprocess, it streams SELECT rows straight into Python lists, and had inherited none of that.

`export_parquet` now takes the same `deadline` the router already threads to `export_dataset`, reuses `export_subprocess_timeout_seconds` (no second bound), and wraps the row stream in `asyncio.wait_for`, raising the same `ExportError` the ogr2ogr timeout raises so the router's `except ExportError` handling is identical for every format.

Test: `backend/tests/test_export_parquet_row_stream_budget_1778.py` (a slow row source past the deadline raises `ExportError`; a fast one is unaffected; `None` deadline still routes through the shared helper rather than a second one).

## 3. Global-as-proxy sweep in backend/tests

Swept `backend/tests` for assertions that observe a global as a proxy for a local property (patched shared session factories, pool/engine event listeners, cumulative checkout counts standing in for peak concurrency), per #1786's two fixes in `test_arcgis_signin.py` (excluded from this sweep, already fixed there). Searched: every `patch`/`patch.object`/`monkeypatch.setattr` targeting `app.core.db` (`async_session`, `engine`), every `event.listen`/`event.remove` on a `sync_engine`, and every `nonlocal` counter combined with a patch/monkeypatch closure.

Found two other instances, both reviewed and left alone:

- `backend/tests/test_export_request_budget.py:287-330` (`TestExportReleasesThePoolConnection.test_nothing_is_checked_out_while_the_conversion_runs`) listens on `checkout`/`checkin` for the process-global `db_module.engine.sync_engine`. Already tracks the live concurrent count (checkout minus checkin) against a request-scoped baseline, not a cumulative sum standing in for peak concurrency, so it does not carry the defect #1786 fixed.
- `backend/tests/test_vrt_catalog_175.py:904-990` (`TestDatasetDetailSessionIsolation.test_fetches_run_sequentially_on_callers_session`) patches `app.core.db.async_session` and asserts it is never called, as proxy for "get_dataset_detail opened no extra session." No narrower local handle exists the way `_signin_locks` did for #1786: post-#1436, `get_dataset_detail`'s own call graph is fully mocked in this test (the port and every downstream helper), there is no live app or HTTP round trip and therefore no concurrent asyncio activity in this test's execution window that could reach the same global factory, unlike the sign-in test's live client fixture. Also already double-covered by a structural AST test in the same class (`test_no_asyncio_gather_over_the_dataset_fetches`) pinning the absence of any `asyncio` import in the module.

No code changes for this item.

## 4. Two more flake classes seen in the merge queue

- `test_embedding_backfill_queue_1542.py::test_enqueue_returns_promptly_instead_of_waiting_for_the_run` asserted `elapsed < 1.0` against a 2s mock sleep, a wall-clock race a loaded runner can lose on ordinary scheduling noise unrelated to whether the backfill ran inline. Replaced with an event set at the top of the mock backfill, before anything slow, and assert it stays unset once the response comes back. A regression that awaited the backfill directly could not return the response before that event fires.
- `test_ingest_progress.py::test_service_worker_advances_ogr2ogr_progress_while_remote_import_is_running` had died with asyncpg `ConnectionError: unexpected connection_lost() call`. Traced to `_heartbeat_service_import_progress` in `backend/app/processing/ingest/tasks_vector.py`: it opens a brand-new session every tick and is cancelled from `ingest_service`'s `finally` once the remote import finishes. A `.cancel()` landing mid-tick (mid-connect, mid-write, or mid-close) could leave that connection's setup or teardown interrupted; asyncpg does not always finish tearing itself down cleanly in that state, and the leftover connection's later, asynchronous close surfaced against unrelated work as the error above. Split the per-tick work into `_service_import_heartbeat_tick` and run it under `asyncio.shield`, so a `.cancel()` from the caller can only land at the `asyncio.sleep` between ticks, never mid-connection. Costs at most one in-flight tick's worth of extra shutdown latency on the cancellation path. `tasks_vector.py` cap 1161 -> 1209.

I could not locally reproduce the connection_lost failure (15 sequential runs plus parallel runs under artificial CPU load all passed before the fix), so this is a structural fix for the most plausible mechanism given the code, not a confirmed root-cause match; the shield is a genuine correctness improvement regardless.

**Update (codex round 2):** the shield bounded WHERE a cancel could land, not HOW LONG draining an already-shielded tick could take. `await tick` after a cancel was unbounded, and the ordinary session a tick runs on carries no statement or lock timeout of its own, so a tick blocked on something else entirely (another transaction's row lock inside `session.commit()`) could hang the drain, and with it `ingest_service`'s own `finally`, indefinitely -- a finished import stuck before it could reach finalization. Wrapped the drain in `asyncio.wait_for(asyncio.shield(tick), timeout=_SERVICE_IMPORT_HEARTBEAT_DRAIN_TIMEOUT_SECONDS)` (5s). On timeout, logs a warning and lets the heartbeat coroutine end; `asyncio.shield` keeps the stuck tick running in the background rather than cancelling it on that timeout, so its connection still gets to close cleanly on its own schedule, and the import's own result never reads the heartbeat's last write. `tasks_vector.py` cap 1209 -> 1245.

New test file `test_ingest_service_heartbeat_drain_1778.py` exercises `_heartbeat_service_import_progress` directly with a tick that never returns: one test proves the heartbeat finishes handling its cancellation well within the (small, test-configured) drain deadline; a counterfactual proves the deadline constant is load-bearing by raising it past a short polling window and observing the task is still pending at that point (checked by polling `Task.done()`, never by wrapping the heartbeat task in another `asyncio.wait_for`, which would cancel it on its own timeout and pass regardless of the constant's value); a third proves the abandoned tick is never itself cancelled by the timeout, only stopped-waiting-for.

**Update (codex round 3):** shield-and-abandon (round 2) orphans the tick's checked-out connection if the lock never clears -- the connection stays checked out and blocked for as long as whatever holds the row lock does, and repeated stalled imports could exhaust the worker's pool even though their parent tasks continued past the drain deadline.

`_service_import_heartbeat_tick` now sets `lock_timeout` and `statement_timeout` on its own transaction (`_SERVICE_IMPORT_HEARTBEAT_TICK_DB_TIMEOUT_SECONDS`, 3s) before touching the job row, so a commit blocked on another transaction's row lock fails on its own, INSIDE Postgres, within a few seconds and releases its connection back to the pool the ordinary way -- `_job_phase_session`'s existing exception handling rolls back and re-raises, which is what returns the connection. The tick stays uncancellable from outside via `asyncio.shield` (unchanged; that is what closed the `connection_lost` error in the first place), but the caller now genuinely awaits it to completion rather than giving up on waiting. `_SERVICE_IMPORT_HEARTBEAT_DRAIN_TIMEOUT_SECONDS` survives, raised to 10s, as a safety net set above the DB timeouts -- not the mechanism -- covering only what a DB-side timeout cannot: a connection stuck before it ever reaches Postgres.

New test holds a real row lock in a second, real database session, drives the tick against the same row, and asserts the pool's checked-out count returns to its pre-lock baseline once the DB-level timeout fires (not by mocking the tick, which cannot stand in for a real Postgres lock wait), then that a follow-up tick against the same job succeeds normally once the lock clears. `tasks_vector.py` cap 1245 -> 1281.

**Update (codex round 6, P2):** `_service_import_heartbeat_tick` issued its `SET LOCAL` statements AFTER entering `_job_phase_session`'s `async with` block, which only protects work the caller does with the row afterward. The SELECT `_job_phase_session` runs internally to load that row happens first and was unprotected, so a tick could still hang holding its connection if that SELECT itself stalled, for example behind another session's `ACCESS EXCLUSIVE` lock on the table, which blocks even a plain read (unlike the row-level lock the round-3 test uses, which does not block a plain SELECT under MVCC).

`_job_phase_session` now takes an optional `lock_and_statement_timeout_ms` and, when given, issues both `SET LOCAL` statements before its own SELECT rather than leaving that to the caller. `None` by default, so every other caller of this shared helper (`tasks_raster.py`, `tasks_raster_replace.py`, `tasks_common.py`'s own quicklook phase) is unaffected. `_service_import_heartbeat_tick` now passes its timeout in through the parameter instead of issuing the statements itself after the row is already loaded.

New test locks the whole table `ACCESS EXCLUSIVE` in a second session and confirms the tick still times out and its connection still returns to the pool. `tasks_common.py` cap 2426 -> 2447. `tasks_vector.py` cap 1281 -> 1284.

**Update (codex round 11):** the SELECT inside `_job_phase_session` is a snapshot, not a lock. If a tick's own connection stalls long enough for the caller's cancellation drain to expire, the parent proceeds while the shielded tick is still alive; `_finalize_ingest` can then commit `status="complete"`/`progress=1.0` (or a retry can rotate `attempt_id`) before the tick's own commit runs, and an unconditional ORM commit would overwrite that finalized row, by primary key, with a stale progress at or below `_SERVICE_IMPORT_HEARTBEAT_MAX_PROGRESS`.

The write is now a single atomic `UPDATE` gated on `id + attempt_id + status="running" + current_step="ogr2ogr" + progress` still below what it is about to write, matching the attempt-fenced shape `_finalize_ingest` already uses via `require_ingest_job_update`/`update_ingest_job_for_attempt`, inlined here because this call site also needs the extra `current_step`/`progress` guards those helpers do not take. Zero rows affected logs at debug and does nothing -- the same "abandon this write, it costs nothing the caller depends on" posture the rest of this tick's timeout handling already takes.

Pinned all three named scenarios: a tick that observed `running` writes after the job was finalized as `complete` and the row keeps `progress=1.0`; the same with a rotated `attempt_id` (the new attempt's own progress survives untouched); a normal tick still advances progress. Getting the finalize/retry races to happen deterministically took two iterations: a real row lock plus `pg_stat_activity` polling first, until it became clear this test database is shared with a live dev stack (dozens of unrelated backends), making lock-wait detection unreliable in both directions. Settled on an in-process, event-driven pause instead: `_pause_the_tick_after_its_select` monkeypatches `_job_phase_session` to await an `asyncio.Event` right after the real SELECT returns, so a second real session can commit the competing write strictly between the tick's SELECT and its own write, deterministically, with no timing dependency. `tasks_vector.py` cap 1284 -> 1333.

## 5. Generated SDK/types drift (codex round 10, P1)

Round 2/3's `Query()` description update to `pmin`/`pmax`/`sigma` changed `backend/openapi.json` (a description-only diff, regenerated and committed at the time), but the generated Python SDK, TypeScript SDK, and `frontend/src/types/api.generated.ts` were never regenerated from that updated snapshot, so `make sdks-check` and `cd frontend && npm run types:check` both drifted -- the published contract said one thing, the clients still documented another.

Ran `make sdks` (regenerates the Python SDK via openapi-python-client and the TypeScript SDK via openapi-ts, both from `backend/openapi.json`) and the frontend types generator. The resulting diff is description-only in all three outputs, matching the source change exactly: the Python client's four function variants (`sync_detailed`/`sync`/`asyncio_detailed`/`asyncio`) pick up the new descriptions, plus the generator's own switch to a raw docstring now that the text contains an escaped quote; the TypeScript SDK's `sdk.gen.ts`/`types.gen.ts` and the frontend's `api.generated.ts` pick up the same text. No hand-edits to any generated file -- `make sdks-check`'s excluded pathspecs (`auth.py`/`__init__.py`/`auth.ts`/`index.ts`/READMEs/LICENSEs) are the only hand-maintained files in `sdks/`, and none of those needed touching.

Also fixed a pre-existing, unrelated `SyntaxWarning`: the module docstring in `test_nginx_raster_stretch_cache_key_1778.py` contained a literal backslash-dot (from the round-7 float-grammar snippet) inside a non-raw string, which is an invalid escape sequence. Made the docstring a raw string; it was the only backslash in it, so nothing else changes meaning. Confirmed via a `compile()` check under a warnings-as-errors flag that no warning remains.

## Verification

- `cd backend && uv run ruff check .` and `uv run ruff format --check .`: pass, whole tree.
- `cd backend && PYTHONPATH=. uv run python scripts/dump_openapi.py --check`: passes after regenerating `backend/openapi.json` for the `Query()` description changes.
- `uv run pytest tests/test_layering.py -q`: 47 passed.
- `uv run pytest tests/test_nginx_raster_stretch_cache_key_1778.py tests/test_raster_colormap_proxy.py tests/test_layering.py -q`: run 3x consecutively, 125 passed each time (post codex-round-9 fix; 30 nginx structural tests -- up from 27, 48 API-level tests, plus the 47 layering tests).
- `make sdks-check` (regenerate + diff + `npm run build` + `npm test`): exits 0. `cd frontend && npm run types:check`: exits 0. `make openapi-check`: exits 0 (confirms `backend/openapi.json` itself was already current -- this was purely a client-regeneration gap).
- `uv run pytest tests/test_sdks_round_trip.py -q`: 16 passed.
- `uv run pytest tests/test_nginx_raster_stretch_cache_key_1778.py tests/test_layering.py tests/test_sdks_round_trip.py -q`: run 3x consecutively, 93 passed each time (codex-round-10 fix).
- `uv run pytest tests/test_ingest_service_heartbeat_drain_1778.py::test_a_tick_blocked_behind_a_held_row_lock_times_out_inside_the_db_and_releases_its_connection -q`: run 5x consecutively, 1 passed each time.
- `uv run pytest tests/test_ingest_service_heartbeat_drain_1778.py::test_a_tick_blocked_on_its_own_initial_select_times_out_inside_the_db_and_releases_its_connection -q`: run 5x consecutively, 1 passed each time (new in round 6).
- `uv run pytest` across every test file importing `app.processing.tiles.router` (25 files) `-n 4 -q`: 556 passed (round-8 regression sweep on the eff_pmin/eff_pmax/eff_sigma resolution change).
- `uv run pytest tests/test_ingest_service_heartbeat_drain_1778.py tests/test_layering.py -q`: run 3x consecutively, 55 passed each time (codex-round-11 fix; the heartbeat-drain file now has 8 tests, up from 5).
- `uv run pytest tests/test_nginx_raster_proxy_ratelimit_1778.py tests/test_nginx_raster_cache_vary_1605.py tests/test_raster_tile_url_version_1372.py tests/test_nginx_raster_cors_1464.py tests/test_nginx_raster_tile_404_1516.py tests/test_raster_proxy_releases_connection_1778.py tests/test_vrt_titiler.py tests/test_optional_auth_failure_mode_1518.py -q`: 67 passed, 2 skipped (regression check on the touched nginx block and the raster proxy).
- `uv run pytest tests/test_export*.py -q` (12 files): 344 passed, 3 skipped.
- `uv run pytest tests/test_embedding_backfill_queue_1542.py::test_enqueue_returns_promptly_instead_of_waiting_for_the_run -n 4 -q`: run 5x consecutively, 1 passed each time. Full file also run 5x under `-n 4`: 38 passed each time.
- `uv run pytest tests/test_ingest_progress.py -n 4 -q`: run 5x consecutively (pre round 2) and 3x more (post round 3), 8 passed each time.
- `uv run pytest tests/test_cli_round_trip.py tests/test_commit_revalidates_source_url.py tests/test_dataset_source_state.py tests/test_ingest.py tests/test_ingest_job_attempt_fencing.py tests/test_ingest_progress.py tests/test_import_token_lease_1676.py tests/test_ingest_vector_failure_tails.py tests/test_job_cancel_fan_out.py tests/test_failed_job_token_purge_1746.py tests/test_ingest_parquet.py tests/test_ingest_staging_cleanup_gap018.py tests/test_presigned_staging_reap_1202.py tests/test_service_refresh_1220.py tests/test_tasks_common_phase_brackets.py tests/test_refresh_pagination_1675.py tests/test_service_column_info_1359.py -n 4 -q` (every test file importing `tasks_vector`): 417 passed, 1 skipped (re-run post codex-round-11 fix, unchanged).

## Left out

- The raster tile route's `nginx -t` validation from the brief was skipped; no nginx binary is available in this test environment. The structural test asserts the map blocks and the cache-key composition instead.
- SDK regeneration (`make sdks`) was not run for the `Query()` description change in `backend/openapi.json`. The diff is description text only (no type, path, or required-ness change); `make sdks-check` will independently catch this in CI if the generated clients embed those descriptions and now drift.











