### PR TITLE
fix(e2e): reinstate swallowed assertions and skip-guard escapes across 6 specs

### DIFF
--- a/backend/tests/test_semantic_search_rate_limit_1778.py
+++ b/backend/tests/test_semantic_search_rate_limit_1778.py
@@ -1,0 +1,142 @@
+"""Pin SEC-S11: /search/datasets/ enforces its OWN per-route rate limit,
+never the global one -- against an isolated app instance with both limits
+set to known values.
+
+fix(#1778 review round 5): e2e/sec-audit.spec.ts's S11 test spent four
+rounds trying to prove this by bursting the live, shared dev stack --
+impossible to pin reliably there, since the e2e suite cannot set
+semantic_search_rate_limit or global_rate_limit and cannot isolate itself
+from other concurrent traffic hitting the same stack. That test is now a
+smoke check only (one request, either a 200 or a 429 naming a per-minute
+limit -- both prove the route and its decorator are wired end to end). The
+actual discriminating assertions -- exact threshold, and that a 429's body
+names the per-route limit rather than the global one -- live here instead,
+against the `client` fixture's dedicated test app and engine
+(conftest.py), with slowapi's process-wide limiter enabled/reset/disabled
+within the test per test_rate_limits.py's established pattern.
+
+Also pins that @limiter.limit(_semantic_search_rate_limit) is still present
+on search_datasets_endpoint at all (a "decorator present" structural check):
+without it, a PR that accidentally removed the decorator would only be
+caught if it also happened to break something else visibly.
+"""
+
+import time
+import uuid
+
+import pytest
+from httpx import AsyncClient
+
+from app.core.persistent_config import _sync_rate_limit_cache
+from app.modules.catalog.search.router import search_datasets_endpoint
+from app.platform.ratelimit import limiter
+
+pytestmark = pytest.mark.anyio
+
+
+def _set_cache_limit(key: str, value: int) -> None:
+    """Inject a known limit into the sync cache so the slowapi callable picks it up."""
+    _sync_rate_limit_cache[key] = (value, time.monotonic())
+
+
+def _clear_cache_limit(key: str) -> None:
+    _sync_rate_limit_cache.pop(key, None)
+
+
+def _reset_limiter_storage() -> None:
+    if hasattr(limiter, "_storage") and hasattr(limiter._storage, "reset"):
+        limiter._storage.reset()
+
+
+def test_semantic_search_rate_limit_decorator_present():
+    """search_datasets_endpoint still carries its own per-route limiter.
+
+    slowapi registers a callable limit_value (our _semantic_search_rate_limit)
+    in Limiter._dynamic_route_limits, keyed by "<module>.<qualname>" (see
+    extension.py's __limit_decorator). override_defaults defaults to True
+    (slowapi's own default, and search/router.py does not override it), which
+    EXCLUDES the global default_limits for this route entirely --
+    extension.py's __evaluate_limits only adds default_limits back in when
+    `combined_defaults = all(not limit.override_defaults for limit in
+    route_limits)` is True, i.e. only when EVERY route limit opted out of
+    override_defaults. That is why the global limiter cannot structurally
+    answer a /search/datasets/ request: this route only ever evaluates its
+    own dynamic limit.
+    """
+    key = f"{search_datasets_endpoint.__module__}.{search_datasets_endpoint.__name__}"
+    dynamic_limits = limiter._dynamic_route_limits.get(key, [])
+    assert dynamic_limits, (
+        f"expected a dynamic rate limit registered for {key} -- "
+        "@limiter.limit(_semantic_search_rate_limit) may have been removed "
+        "from search_datasets_endpoint"
+    )
+    assert all(group.override_defaults for group in dynamic_limits), (
+        "search_datasets_endpoint's rate limit must keep override_defaults=True "
+        "(slowapi's default -- search/router.py passes no explicit value) so "
+        "the global default_limits never apply alongside it. If this is ever "
+        "changed deliberately, the 'never per 1 second' assertion in "
+        "test_semantic_search_rate_limit_pins_per_route_not_global needs "
+        "revisiting too."
+    )
+
+
+async def test_semantic_search_rate_limit_pins_per_route_not_global(
+    client: AsyncClient,
+):
+    """A 429 from /search/datasets/ names the per-route per-minute limit,
+    never the global per-second one, and firing lands exactly at the
+    configured per-route threshold.
+
+    Sets semantic_search_rate_limit=5 and global_rate_limit=1000 (so the
+    global limiter, even if it somehow did apply, could never plausibly fire
+    first within this test) via the sync cache the slowapi callables read
+    directly, sends 6 unique-query requests, and asserts:
+      - requests 1-5 succeed (200)
+      - request 6 is rate-limited (429)
+      - the 429 body's `detail` is exactly "5 per 1 minute" (slowapi's
+        str(limits.RateLimitItem) format for a per-route Limit(5, MINUTE) --
+        see api/main.py's _rate_limit_handler, which round-trips
+        exc.detail unchanged into the ProblemDetail body)
+      - detail never contains "per 1 second" (the global limiter's format
+        for the same RateLimitItem stringification), confirming the global
+        limiter did not answer
+    """
+    _set_cache_limit("semantic_search_rate_limit", 5)
+    _set_cache_limit("global_rate_limit", 1000)
+    limiter.enabled = True
+    _reset_limiter_storage()
+
+    try:
+        statuses: list[int] = []
+        rate_limited_bodies: list[dict] = []
+        for _ in range(6):
+            resp = await client.get(
+                f"/search/datasets/?q=sec-s11-pin-{uuid.uuid4().hex}"
+            )
+            statuses.append(resp.status_code)
+            if resp.status_code == 429:
+                rate_limited_bodies.append(resp.json())
+
+        assert statuses[:5] == [200] * 5, (
+            f"expected the first 5 requests (at the configured limit) to succeed, "
+            f"got statuses={statuses}"
+        )
+        assert statuses[5] == 429, (
+            f"expected the 6th request (over the configured limit) to be "
+            f"rate-limited, got statuses={statuses}"
+        )
+
+        assert rate_limited_bodies, "no 429 response body was captured"
+        for body in rate_limited_bodies:
+            detail = body.get("detail")
+            assert detail == "5 per 1 minute", (
+                f"expected the 429 body to name the per-route per-minute limit "
+                f"exactly ('5 per 1 minute'), got {detail!r} -- a body reading "
+                f"'... per 1 second' would mean the GLOBAL limiter answered "
+                f"instead of the per-route one under test"
+            )
+    finally:
+        limiter.enabled = False
+        _clear_cache_limit("semantic_search_rate_limit")
+        _clear_cache_limit("global_rate_limit")
+        _reset_limiter_storage()

--- a/e2e/accessibility-locale.spec.ts
+++ b/e2e/accessibility-locale.spec.ts
@@ -40,6 +40,12 @@ test.describe('Accessibility locale scan — de (non-gating)', () => {
   let mapId: string;
 
   test.beforeAll(async () => {
+    // fix(review #1792 round 3): seedDataset alone can poll for up to 60s
+    // (helpers/catalog.ts's seedFixtureDataset), which is Playwright's
+    // default hook timeout with nothing left over for the map/layer calls
+    // below. Give this hook real margin.
+    test.setTimeout(120_000);
+
     seed = await seedDataset('A11y Locale Seed Dataset');
     const headers = {
       Authorization: `Bearer ${getAuthToken()}`,

--- a/e2e/accessibility-locale.spec.ts
+++ b/e2e/accessibility-locale.spec.ts
@@ -1,0 +1,115 @@
+import { test } from '@playwright/test';
+import AxeBuilder from '@axe-core/playwright';
+import { getAuthToken, seedDataset, deleteDataset, type SeededDataset } from './helpers/catalog';
+
+const BASE_URL = process.env.E2E_BASE_URL ?? 'http://localhost:8080';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function formatViolations(violations: any[]): string {
+  return violations
+    .map(
+      (v) =>
+        `[${v.id}] ${v.description} (${v.impact})\n` +
+        v.nodes.map((n) => `  - ${n.html}`).join('\n'),
+    )
+    .join('\n\n');
+}
+
+/**
+ * fix(#1778): playwright.config.ts pins `locale: 'en-US'` for every project,
+ * so es/fr/de bundles never render under the gating axe suite in
+ * accessibility.spec.ts — only the dark-mode half of that finding (#1782)
+ * has been closed so far. A full 4-locale x N-route x 2-color-scheme sweep
+ * folded into the gating suite would multiply its wall-clock well past the
+ * "stays under 2 minutes" budget, so this mirrors the wcag22aa precedent
+ * (#1790, accessibility-target-size.spec.ts): a separate, non-gating scan
+ * that only reports (console + attachment), scoped to `de` (German strings
+ * run longest of the three non-English locales, so it is the locale most
+ * likely to break layouts sized for English) over the densest few routes:
+ * the map builder sidebar, the dataset detail page, and the admin settings
+ * forms.
+ *
+ * Deliberately not listed in any package.json `e2e:smoke:*` script, so the
+ * per-PR smoke gates never pick it up (same precedent as
+ * accessibility-target-size.spec.ts and analysis.spec.ts).
+ */
+test.describe('Accessibility locale scan — de (non-gating)', () => {
+  test.use({ locale: 'de' });
+
+  let seed: SeededDataset;
+  let mapId: string;
+
+  test.beforeAll(async () => {
+    seed = await seedDataset('A11y Locale Seed Dataset');
+    const headers = {
+      Authorization: `Bearer ${getAuthToken()}`,
+      'Content-Type': 'application/json',
+    };
+
+    const mapRes = await fetch(`${BASE_URL}/api/maps/`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({
+        name: `A11y Locale Map ${Date.now()}`,
+        description: 'Fixture for the non-gating de locale scan',
+      }),
+    });
+    if (!mapRes.ok) throw new Error(`map create failed: ${mapRes.status}`);
+    mapId = ((await mapRes.json()) as { id: string }).id;
+
+    const layerRes = await fetch(`${BASE_URL}/api/maps/${mapId}/layers/`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({ dataset_id: seed.id }),
+    });
+    if (!layerRes.ok) throw new Error(`layer create failed: ${layerRes.status}`);
+  });
+
+  test.afterAll(async () => {
+    if (mapId) {
+      await fetch(`${BASE_URL}/api/maps/${mapId}`, {
+        method: 'DELETE',
+        headers: { Authorization: `Bearer ${getAuthToken()}` },
+      }).catch(() => {
+        /* teardown is best-effort; the CI stack is torn down anyway */
+      });
+    }
+    if (seed) await deleteDataset(seed.id, seed.title);
+  });
+
+  async function scanAndReport(page: import('@playwright/test').Page, testInfo: import('@playwright/test').TestInfo, label: string) {
+    const results = await new AxeBuilder({ page })
+      .withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'])
+      .analyze();
+
+    if (results.violations.length > 0) {
+      const formatted = formatViolations(results.violations);
+      // eslint-disable-next-line no-console
+      console.warn(`[de locale scan, non-gating] ${label}: ${results.violations.length} violation(s):\n${formatted}`);
+      await testInfo.attach(`de-locale-violations-${label}.txt`, {
+        body: formatted,
+        contentType: 'text/plain',
+      });
+    }
+    // No assertion on results.violations by design (see module docstring):
+    // this scan reports for later scoping, it does not gate CI.
+  }
+
+  test('map builder page: de locale scan (reports only)', async ({ page }, testInfo) => {
+    await page.goto(`/maps/${mapId}`);
+    await page.waitForLoadState('networkidle');
+    await scanAndReport(page, testInfo, 'map-builder');
+  });
+
+  test('dataset detail page: de locale scan (reports only)', async ({ page }, testInfo) => {
+    await page.goto(`/datasets/${seed.id}`);
+    await page.waitForLoadState('networkidle');
+    await scanAndReport(page, testInfo, 'dataset-detail');
+  });
+
+  test('admin settings page: de locale scan (reports only)', async ({ page }, testInfo) => {
+    await page.goto('/admin/settings');
+    await page.waitForLoadState('networkidle');
+    await scanAndReport(page, testInfo, 'admin-settings');
+  });
+});

--- a/e2e/accessibility.spec.ts
+++ b/e2e/accessibility.spec.ts
@@ -16,6 +16,23 @@ function formatViolations(violations: any[]): string {
     .join('\n\n');
 }
 
+// fix(review #1792 round 4): `waitForLoadState('networkidle')` covers the
+// document/asset load, not a subsequent React Query fetch -- a scan that
+// runs right after it can land mid-loading-state (a skeleton or spinner)
+// instead of the populated page, and axe never sees the real content. Every
+// loading indicator in this app renders through one of two shared
+// primitives: components/ui/skeleton.tsx's `<Skeleton>` (stamped
+// `data-slot="skeleton"`, e.g. DataTableSkeleton on the admin list pages,
+// DatasetCardSkeleton on search) or a lucide `Loader2` spinner (rendered
+// with the `animate-spin` class, e.g. AttributeTable's data-tab loading
+// state) -- so waiting for both to clear is a generic, page-agnostic proxy
+// for "the query settled", without needing a bespoke selector per route.
+async function waitForLoadingIndicatorsToClear(page: import('@playwright/test').Page) {
+  await expect(page.locator('[data-slot="skeleton"], .animate-spin')).toHaveCount(0, {
+    timeout: 15_000,
+  });
+}
+
 test.describe('Accessibility - WCAG 2AA', () => {
   let builderMapId: string;
   let builderMapName: string;
@@ -173,6 +190,10 @@ test.describe('Accessibility - WCAG 2AA', () => {
         test('public search page has no accessibility violations', async ({ page }) => {
           await page.goto('/');
           await page.waitForLoadState('networkidle');
+          // fix(review #1792 round 4): SearchPage renders a DatasetCardSkeleton
+          // grid while `isLoading && !data`, before this scan waited for it
+          // to clear -- see waitForLoadingIndicatorsToClear's comment.
+          await waitForLoadingIndicatorsToClear(page);
 
           const results = await new AxeBuilder({ page })
             .withTags(wcagTags)
@@ -395,6 +416,13 @@ test.describe('Accessibility - WCAG 2AA', () => {
         test(`${name} page has no accessibility violations`, async ({ page }) => {
           await page.goto(path);
           await page.waitForLoadState('networkidle');
+          // fix(review #1792 round 4): several of these routes (the admin
+          // list pages especially) fetch their own data after mount and
+          // render a skeleton/spinner until it resolves -- see
+          // waitForLoadingIndicatorsToClear's comment. Applied to the whole
+          // loop rather than only the admin routes since it is a no-op
+          // wait (passes immediately) on any route with nothing to clear.
+          await waitForLoadingIndicatorsToClear(page);
 
           const results = await new AxeBuilder({ page })
             .withTags(wcagTags)
@@ -418,6 +446,11 @@ test.describe('Accessibility - WCAG 2AA', () => {
             page.getByRole('heading', { name: datasetTitle, exact: true }),
           ).toBeVisible();
           await page.waitForLoadState('networkidle');
+          // fix(review #1792 round 4): the data tab's AttributeTable fetches
+          // rows independently of the dataset payload the heading above
+          // proves loaded, and shows its own Loader2 spinner until that
+          // settles -- see waitForLoadingIndicatorsToClear's comment.
+          await waitForLoadingIndicatorsToClear(page);
 
           const scan = new AxeBuilder({ page })
             .withTags(wcagTags)
@@ -452,6 +485,19 @@ test.describe('Accessibility - WCAG 2AA', () => {
 
         const dialog = page.getByRole('dialog', { name: 'Share' });
         await expect(dialog).toBeVisible();
+
+        // fix(review #1792 round 4): SharePanel's useMapShareToken query is
+        // still loading the instant the dialog mounts, so `hasShareToken`
+        // reads false and the dialog renders the "Get share link" button --
+        // scanning immediately raced that query and covered the wrong
+        // branch. builderMapId's share token was created directly via the
+        // API in beforeAll, not through this session's own UI, so
+        // SharePanel never held the raw token locally and always resolves
+        // into the "Regenerate link" branch (rawShareToken absent,
+        // hasShareToken true) once the query settles. Wait for that button.
+        await expect(dialog.getByRole('button', { name: 'Regenerate link' })).toBeVisible({
+          timeout: 15_000,
+        });
 
         const results = await new AxeBuilder({ page })
           .withTags(wcagTags)

--- a/e2e/accessibility.spec.ts
+++ b/e2e/accessibility.spec.ts
@@ -157,19 +157,23 @@ test.describe('Accessibility - WCAG 2AA', () => {
     test.describe(`(${colorScheme} mode)`, () => {
       test.use({ colorScheme });
 
-      test('public search page has no accessibility violations', async ({ page }) => {
-        await page.goto('/');
-        await page.waitForLoadState('networkidle');
-
-        const results = await new AxeBuilder({ page })
-          .withTags(wcagTags)
-          .analyze();
-
-        expect(results.violations, formatViolations(results.violations)).toEqual([]);
-      });
-
       test.describe('logged-out routes', () => {
         test.use({ storageState: { cookies: [], origins: [] } });
+
+        // fix(#1778): this test sat OUTSIDE the logged-out describe block, so
+        // it inherited the chromium project's authenticated storageState —
+        // the anonymous landing page was never actually scanned under that
+        // name. Moved inside so "public" means logged-out.
+        test('public search page has no accessibility violations', async ({ page }) => {
+          await page.goto('/');
+          await page.waitForLoadState('networkidle');
+
+          const results = await new AxeBuilder({ page })
+            .withTags(wcagTags)
+            .analyze();
+
+          expect(results.violations, formatViolations(results.violations)).toEqual([]);
+        });
 
         test('login page has no accessibility violations', async ({ page }) => {
           await page.goto('/login');
@@ -360,10 +364,27 @@ test.describe('Accessibility - WCAG 2AA', () => {
 
       // fix(#438): A11Y-12 — the audit found Import, Settings, and Collections
       // uncovered. Same wcagTags contract as the routes above.
+      //
+      // fix(#1778): the admin overview scan above only ever covered
+      // /admin — App.tsx declares seven further real admin routes
+      // (admin/users, admin/jobs, admin/shared-maps, admin/audit,
+      // admin/saml, admin/settings/:tab, admin/config-ops) that were never
+      // scanned, including the densest forms in the app (SettingsAuthTab,
+      // SettingsAITab, SamlProvidersSection). Extend this same loop rather
+      // than hand-duplicating the scan body.
       for (const { name, path } of [
         { name: 'import', path: '/import' },
         { name: 'settings', path: '/settings' },
         { name: 'collections', path: '/collections' },
+        { name: 'admin users', path: '/admin/users' },
+        { name: 'admin jobs', path: '/admin/jobs' },
+        { name: 'admin shared maps', path: '/admin/shared-maps' },
+        { name: 'admin audit', path: '/admin/audit' },
+        { name: 'admin saml', path: '/admin/saml' },
+        { name: 'admin settings general', path: '/admin/settings/general' },
+        { name: 'admin settings auth', path: '/admin/settings/auth' },
+        { name: 'admin settings ai', path: '/admin/settings/ai' },
+        { name: 'admin config-ops', path: '/admin/config-ops' },
       ]) {
         test(`${name} page has no accessibility violations`, async ({ page }) => {
           await page.goto(path);
@@ -376,6 +397,63 @@ test.describe('Accessibility - WCAG 2AA', () => {
           expect(results.violations, formatViolations(results.violations)).toEqual([]);
         });
       }
+
+      // fix(#1778): the dataset detail scan above only ever covered the
+      // default Overview tab — the Data (attribute table), Schema
+      // (structure), Sources, and Access tabs render their own panel body
+      // and were never scanned. Tabs are addressable by URL hash
+      // (DatasetPage.tsx's getInitialTab), so no interaction is needed to
+      // reach them.
+      for (const tab of ['data', 'structure', 'sources', 'access'] as const) {
+        test(`dataset detail ${tab} tab has no accessibility violations`, async ({ page }) => {
+          await page.goto(`/datasets/${datasetId}#${tab}`);
+          await page.waitForLoadState('networkidle');
+          await expect(
+            page.getByRole('heading', { name: datasetTitle, exact: true }),
+          ).toBeVisible();
+          await page.waitForLoadState('networkidle');
+
+          const scan = new AxeBuilder({ page })
+            .withTags(wcagTags)
+            .exclude('.maplibregl-map');
+
+          // fix(#1778): this scan found a real, pre-existing contrast
+          // violation on the access tab: AccessTab.tsx's API-URL chip pairs
+          // text-(--code-muted) on bg-(--code-chrome) at 4.15:1 in both
+          // themes (index.css defines --code-muted the same in both color
+          // schemes), under the 4.5:1 floor. That is a separate design-token
+          // bug, not part of this item's scope (route coverage) — excluded
+          // here so the new coverage can gate, and left alone otherwise; see
+          // the PR description.
+          if (tab === 'access') {
+            scan.exclude('.text-\\(--code-muted\\)');
+          }
+
+          const results = await scan.analyze();
+
+          expect(results.violations, formatViolations(results.violations)).toEqual([]);
+        });
+      }
+
+      // fix(#1778): SharePanel/ShareDialog (the sharing/embed surface) was
+      // never opened by this suite.
+      test('share dialog has no accessibility violations', async ({ page }) => {
+        await page.goto(`/maps/${builderMapId}`);
+        await page.waitForLoadState('networkidle');
+
+        await expect(page.getByTestId('builder-sidebar')).toBeVisible({ timeout: 15_000 });
+        await page.getByRole('button', { name: 'Share' }).click();
+
+        const dialog = page.getByRole('dialog', { name: 'Share' });
+        await expect(dialog).toBeVisible();
+
+        const results = await new AxeBuilder({ page })
+          .withTags(wcagTags)
+          .include('[role="dialog"]')
+          .analyze();
+
+        expect(results.violations, formatViolations(results.violations)).toEqual([]);
+      });
 
       test.describe('register (logged out)', () => {
         test.use({ storageState: { cookies: [], origins: [] } });

--- a/e2e/accessibility.spec.ts
+++ b/e2e/accessibility.spec.ts
@@ -26,6 +26,12 @@ test.describe('Accessibility - WCAG 2AA', () => {
   let collectionName: string;
 
   test.beforeAll(async () => {
+    // fix(review #1792 round 3): seedDataset alone can poll for up to 60s
+    // (helpers/catalog.ts's seedFixtureDataset), which is Playwright's
+    // default hook timeout with nothing left over for the collection/map/
+    // layer/share calls this hook also makes. Give this hook real margin.
+    test.setTimeout(120_000);
+
     // Use a separate dataset because this suite publishes it for anonymous
     // checks and must not change the shared catalog fixture.
     const seeded = await seedDataset('A11y Seed Dataset');

--- a/e2e/export-runtime.spec.ts
+++ b/e2e/export-runtime.spec.ts
@@ -322,9 +322,33 @@ function isSqlIdentifier(value: string): boolean {
   return /^[A-Za-z_][A-Za-z0-9_]*$/.test(value);
 }
 
+// fix(review #1792 round 6): JSON.parse loses precision above
+// Number.MAX_SAFE_INTEGER -- not just fractional rounding, the parsed
+// integer can differ from the true value entirely (9007199254740995
+// becomes 9007199254740996, a database value that may not even exist).
+// This recovers the EXACT digits the server actually returned for one
+// specific property key, straight from the raw response text, without a
+// general big-number-safe JSON parser: a targeted regex over the raw
+// bytes rather than a reviver over an already-lossy parse.
+function extractRawIntegerValues(rawText: string, propertyKey: string): bigint[] {
+  const escapedKey = propertyKey.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  // `(?![\d.eE])` requires the digit run to end here -- excludes matching
+  // just the integer prefix of a larger float/exponential token (e.g. the
+  // "123" in "123.456" or "123e10"), which is not this function's problem
+  // to solve (see the floating-column branch in buildWherePredicate).
+  const pattern = new RegExp(`"${escapedKey}"\\s*:\\s*(-?\\d+)(?![\\d.eE])`, 'g');
+  const values: bigint[] = [];
+  let match: RegExpExecArray | null;
+  while ((match = pattern.exec(rawText)) !== null) {
+    values.push(BigInt(match[1]));
+  }
+  return values;
+}
+
 function buildWherePredicate(
   baseline: GeoJsonFeatureCollection,
   columnInfo: Array<{ name?: string }> | null | undefined,
+  baselineRawText?: string,
 ): WherePredicate | null {
   const allowedColumns = new Map<string, string>();
   let nonNullFallback:
@@ -394,15 +418,76 @@ function buildWherePredicate(
     // at a dataset with fractional column values. Use the exact observed
     // maximum instead of a rounded one: `value >= value` is always true for
     // the identical float, so the row that produced it can never be
-    // excluded by this comparison.
-    const threshold = maxValue;
+    // excluded by this comparison -- for a value JS's own JSON.parse
+    // rendered exactly, which is not guaranteed (see below).
     const { columnName, propertyKey } = numericColumn;
+
+    // fix(review #1792 round 6): `maxValue` came from JSON.parse, which for
+    // a BIGINT above Number.MAX_SAFE_INTEGER does not just lose fractional
+    // precision -- it can round to a DIFFERENT integer entirely (e.g.
+    // 9007199254740995 becomes 9007199254740996), so `maxValue` here may
+    // not be a value the database ever returned, and `column >= maxValue`
+    // could exclude the true maximal row. A high-precision NUMERIC/float
+    // has the same failure mode in miniature (small relative rounding in
+    // the low-order digits). Two different margins, because the two cases
+    // need different treatment: a BIGINT is a whole number with no value
+    // between v-1 and v, so once we know the TRUE integer maximum exactly
+    // (recovered from the raw response text, since JSON.parse already threw
+    // that away), subtracting exactly 1 is both necessary and sufficient.
+    // A float has no such gap to exploit, so a proportional margin below
+    // the (still only approximately correct) parsed value is used instead
+    // -- 1e-9 relative is far larger than a double's ~1e-15 relative
+    // rounding error, so it comfortably covers it without needing the raw
+    // text at all.
+    //
+    // `Number.isInteger` alone cannot tell a BIGINT column from a NUMERIC/
+    // float column that currently happens to hold a whole number -- a
+    // double this large has no fractional bits left to distinguish them
+    // with. Postgres's actual BIGINT range (+/-2^63-1) can, though: a
+    // magnitude beyond it cannot possibly be a real BIGINT value, so it is
+    // routed to the proportional-margin path instead (e.g. the
+    // 1.2345678901234567e20 pin below, which is a whole JS double but far
+    // past BIGINT's ~9.22e18 ceiling).
+    const BIGINT_MAX_MAGNITUDE = 9223372036854775807; // Postgres bigint upper bound, 2^63 - 1
+    let clauseValue: string;
+    let evaluateThreshold: number;
+
+    if (
+      Number.isInteger(maxValue) &&
+      !Number.isSafeInteger(maxValue) &&
+      Math.abs(maxValue) <= BIGINT_MAX_MAGNITUDE &&
+      baselineRawText
+    ) {
+      const rawValues = extractRawIntegerValues(baselineRawText, propertyKey);
+      if (rawValues.length > 0) {
+        const trueMax = rawValues.reduce((a, b) => (b > a ? b : a));
+        const thresholdBigInt = trueMax - 1n;
+        clauseValue = thresholdBigInt.toString();
+        evaluateThreshold = Number(thresholdBigInt);
+      } else {
+        // Raw text extraction found nothing for this property (unexpected
+        // given the parsed scan above found it) -- fall back to the parsed
+        // value rather than failing outright.
+        clauseValue = formatNumericLiteral(maxValue);
+        evaluateThreshold = maxValue;
+      }
+    } else if (Number.isSafeInteger(maxValue)) {
+      // A safe integer's JSON round-trip is exact; nothing to correct.
+      clauseValue = formatNumericLiteral(maxValue);
+      evaluateThreshold = maxValue;
+    } else {
+      const margin = Math.abs(maxValue) * 1e-9 + Number.EPSILON;
+      const safeThreshold = maxValue - margin;
+      clauseValue = formatNumericLiteral(safeThreshold);
+      evaluateThreshold = safeThreshold;
+    }
+
     return {
-      clause: `${columnName} >= ${formatNumericLiteral(threshold)}`,
+      clause: `${columnName} >= ${clauseValue}`,
       propertyKey,
       evaluate: (candidate) => {
         const value = candidate[propertyKey];
-        return typeof value === 'number' && Number.isFinite(value) && value >= threshold;
+        return typeof value === 'number' && Number.isFinite(value) && value >= evaluateThreshold;
       },
     };
   }
@@ -572,10 +657,10 @@ async function resolveRuntimeDataset(
   request: APIRequestContext,
   authHeader: Record<string, string>,
   datasetId: string,
-): Promise<{ dataset: DatasetDetail; baseline: GeoJsonFeatureCollection }> {
+): Promise<{ dataset: DatasetDetail; baseline: GeoJsonFeatureCollection; baselineRawText: string }> {
   async function resolveCandidate(
     datasetId: string,
-  ): Promise<{ dataset: DatasetDetail; baseline: GeoJsonFeatureCollection } | null> {
+  ): Promise<{ dataset: DatasetDetail; baseline: GeoJsonFeatureCollection; baselineRawText: string } | null> {
     const detailResponse = await request.get(`/api/datasets/${datasetId}`, {
       headers: authHeader,
     });
@@ -609,6 +694,10 @@ async function resolveRuntimeDataset(
     if (baseline.features.length === 0) {
       return null;
     }
+    // fix(review #1792 round 6): kept alongside the parsed `baseline` so
+    // buildWherePredicate can recover exact BIGINT digits JSON.parse
+    // already discarded -- see extractRawIntegerValues.
+    const baselineRawText = baselineBody.toString('utf8');
 
     const baselinePositions = collectFeatureCollectionPositions(baseline);
     if (
@@ -625,7 +714,7 @@ async function resolveRuntimeDataset(
       return null;
     }
 
-    if (!buildWherePredicate(baseline, detail.column_info)) {
+    if (!buildWherePredicate(baseline, detail.column_info, baselineRawText)) {
       return null;
     }
 
@@ -654,7 +743,7 @@ async function resolveRuntimeDataset(
       return null;
     }
 
-    return { dataset: detail, baseline };
+    return { dataset: detail, baseline, baselineRawText };
   }
 
   const resolved = await resolveCandidate(datasetId);
@@ -690,12 +779,83 @@ test.describe('formatNumericLiteral', () => {
   });
 });
 
+// fix(review #1792 round 6): pure-logic pin for buildWherePredicate's
+// threshold computation, independent of any live request. Covers the two
+// precision-loss shapes JSON.parse can introduce: a BIGINT above
+// Number.MAX_SAFE_INTEGER (parses to a DIFFERENT integer, not just a
+// rounded one) and a high-precision NUMERIC/float whose magnitude is
+// beyond even BIGINT's range (so it cannot be recovered exactly from raw
+// text the way a BIGINT can -- see buildWherePredicate's own comment for
+// why the two need different treatment).
+test.describe('buildWherePredicate precision', () => {
+  const columnInfo = [{ name: 'value' }];
+
+  function syntheticBaseline(propertyValue: number): GeoJsonFeatureCollection {
+    return {
+      type: 'FeatureCollection',
+      features: [
+        {
+          type: 'Feature',
+          properties: { value: propertyValue },
+          geometry: null,
+        },
+      ],
+    };
+  }
+
+  test('an unsafe BIGINT-range integer gets a threshold strictly below the true value', () => {
+    // A string, not a number literal: 9007199254740995 written directly in
+    // this file's own source would be rounded by the SAME double-precision
+    // limit this test exists to work around, before the test ever ran.
+    const trueValueText = '9007199254740995';
+    const trueValueBigInt = BigInt(trueValueText);
+
+    // What a real response body parses to -- JSON.parse rounds this to a
+    // DIFFERENT integer (...996), which is what buildWherePredicate's own
+    // scan of `baseline.features` would observe as `maxValue`.
+    const parsedValue = JSON.parse(trueValueText) as number;
+    expect(Number.isSafeInteger(parsedValue)).toBe(false);
+    expect(BigInt(parsedValue)).not.toBe(trueValueBigInt);
+
+    const baselineRawText = `{"type":"FeatureCollection","features":[{"type":"Feature","properties":{"value":${trueValueText}},"geometry":null}]}`;
+    const predicate = buildWherePredicate(
+      syntheticBaseline(parsedValue),
+      columnInfo,
+      baselineRawText,
+    );
+
+    expect(predicate).toBeTruthy();
+    const clauseValueText = predicate!.clause.split('>=')[1].trim();
+    // Exact BigInt comparison: this is the whole point of the raw-text
+    // recovery, so tolerate no float round-trip here either.
+    expect(BigInt(clauseValueText) < trueValueBigInt).toBe(true);
+  });
+
+  test('a NUMERIC-like value beyond BIGINT range gets a threshold strictly below the true value', () => {
+    const trueValue = 1.2345678901234567e20;
+    // Sanity: this is genuinely past what BIGINT (2^63-1 =~ 9.22e18) can
+    // hold, and a whole number as far as JS's own double precision can
+    // tell -- exactly the case that can't be told apart from a BIGINT by
+    // Number.isInteger alone, and needs the magnitude check to route to
+    // the proportional-margin path instead of the (inapplicable) BigInt one.
+    expect(Number.isInteger(trueValue)).toBe(true);
+    expect(Number.isSafeInteger(trueValue)).toBe(false);
+
+    const predicate = buildWherePredicate(syntheticBaseline(trueValue), columnInfo);
+
+    expect(predicate).toBeTruthy();
+    const clauseValue = Number(predicate!.clause.split('>=')[1].trim());
+    expect(clauseValue).toBeLessThan(trueValue);
+  });
+});
+
 test.describe('Runtime export integrity', () => {
   test.describe.configure({ mode: 'serial' });
 
   let authHeader: Record<string, string>;
   let dataset: DatasetDetail;
   let baseline: GeoJsonFeatureCollection;
+  let baselineRawText: string;
   let baselineExtent: BBox;
   let auditDateFrom: string;
   let lastBboxFilter: string | null = null;
@@ -730,6 +890,7 @@ test.describe('Runtime export integrity', () => {
     );
     dataset = runtimeContext.dataset;
     baseline = runtimeContext.baseline;
+    baselineRawText = runtimeContext.baselineRawText;
 
     const extentFromDataset = toBBox(dataset.extent_bbox);
     const extentFromFeatures = computeBBoxFromPositions(
@@ -877,7 +1038,7 @@ test.describe('Runtime export integrity', () => {
   });
 
   test('semantic where filter returns a property-matching subset', async ({ request }) => {
-    const predicate = buildWherePredicate(baseline, dataset.column_info);
+    const predicate = buildWherePredicate(baseline, dataset.column_info, baselineRawText);
     expect(predicate).toBeTruthy();
     const predicateValue = predicate as WherePredicate;
     lastWhereFilter = predicateValue.clause;
@@ -909,7 +1070,7 @@ test.describe('Runtime export integrity', () => {
     request,
   }) => {
     const auditBbox = lastBboxFilter ?? serializeBBox(buildInteriorBBox(baselineExtent));
-    const fallbackPredicate = buildWherePredicate(baseline, dataset.column_info);
+    const fallbackPredicate = buildWherePredicate(baseline, dataset.column_info, baselineRawText);
     expect(fallbackPredicate).toBeTruthy();
     const auditWhereClause =
       lastWhereFilter ?? (fallbackPredicate as WherePredicate).clause;

--- a/e2e/export-runtime.spec.ts
+++ b/e2e/export-runtime.spec.ts
@@ -289,6 +289,17 @@ function buildWherePredicate(
     allowedColumns.set(column.name.toLowerCase(), column.name);
   }
 
+  // fix(#1778): the threshold used to come from the FIRST feature's numeric
+  // value, returned on the spot. The seeded runtime fixture inserts
+  // value=10,20,30 in that order, so the clause was always `value >= 10` —
+  // every seeded row satisfies it, so a `where` param silently dropped
+  // (wrong column, inverted operator, ignored entirely) produced the same
+  // full result set as a correctly-applied filter. Scan every feature for
+  // the first numeric column and use its MAXIMUM observed value instead, so
+  // the clause is genuinely selective against the seeded fixture.
+  let numericColumn: { columnName: string; propertyKey: string } | null = null;
+  let maxValue = -Infinity;
+
   for (const feature of baseline.features) {
     const properties = feature.properties ?? {};
 
@@ -299,15 +310,13 @@ function buildWherePredicate(
       }
 
       if (typeof rawValue === 'number' && Number.isFinite(rawValue)) {
-        const threshold = Number(rawValue.toFixed(6));
-        return {
-          clause: `${columnName} >= ${threshold}`,
-          propertyKey,
-          evaluate: (candidate) => {
-            const value = candidate[propertyKey];
-            return typeof value === 'number' && Number.isFinite(value) && value >= threshold;
-          },
-        };
+        if (!numericColumn) {
+          numericColumn = { columnName, propertyKey };
+        }
+        if (numericColumn.propertyKey === propertyKey) {
+          maxValue = Math.max(maxValue, rawValue);
+        }
+        continue;
       }
 
       if (
@@ -321,6 +330,19 @@ function buildWherePredicate(
         };
       }
     }
+  }
+
+  if (numericColumn) {
+    const threshold = Number(maxValue.toFixed(6));
+    const { columnName, propertyKey } = numericColumn;
+    return {
+      clause: `${columnName} >= ${threshold}`,
+      propertyKey,
+      evaluate: (candidate) => {
+        const value = candidate[propertyKey];
+        return typeof value === 'number' && Number.isFinite(value) && value >= threshold;
+      },
+    };
   }
 
   if (nonNullFallback) {
@@ -708,7 +730,20 @@ test.describe('Runtime export integrity', () => {
       `bbox=${bboxParam}`,
     ]);
 
+    // fix(#1778): neither assertion below required a non-empty result, so a
+    // regression that made the bbox filter match nothing (inverted operator,
+    // wrong column, an SRID mismatch) passed this test — the `for` loop
+    // simply never ran. `toBeGreaterThan(0)` holds generally: the interior
+    // bbox keeps the central 60% of the extent on each axis, which excludes
+    // some geometry only when it also contains some.
+    expect(filtered.features.length).toBeGreaterThan(0);
     expect(filtered.features.length).toBeLessThanOrEqual(baseline.features.length);
+    if (ownedDataset) {
+      // Against the auto-seeded runtime fixture (west/center/east, evenly
+      // spaced) the 20% inset on each axis excludes west and east and keeps
+      // only center — pin the exact count rather than just "fewer than all".
+      expect(filtered.features.length).toBe(1);
+    }
 
     for (const feature of filtered.features) {
       const featureBBox = computeFeatureBBox(feature);
@@ -729,7 +764,18 @@ test.describe('Runtime export integrity', () => {
       `where=${encodeURIComponent(predicateValue.clause)}`,
     ]);
 
+    // fix(#1778): same empty-result gap as the bbox test above.
+    // buildWherePredicate's threshold is now the column's MAXIMUM observed
+    // value (see its comment), so the row that produced that maximum always
+    // satisfies `>=` — the result is never empty.
+    expect(filtered.features.length).toBeGreaterThan(0);
     expect(filtered.features.length).toBeLessThanOrEqual(baseline.features.length);
+    if (ownedDataset) {
+      // Against the auto-seeded runtime fixture, value=10/20/30 are
+      // distinct, so `value >= 30` is satisfied by exactly one feature —
+      // pin the exact count rather than just "fewer than all".
+      expect(filtered.features.length).toBe(1);
+    }
 
     for (const feature of filtered.features) {
       const properties = feature.properties ?? {};

--- a/e2e/export-runtime.spec.ts
+++ b/e2e/export-runtime.spec.ts
@@ -452,6 +452,18 @@ function buildWherePredicate(
     let clauseValue: string;
     let evaluateThreshold: number;
 
+    // fix(review #1792 round 7): a raw token that fails the regex's
+    // `(?![\d.eE])` lookahead -- e.g. a NUMERIC maximum serialized as
+    // "9007199254740995.1", which JSON.parse rounds to the unsafe integer
+    // 9007199254740996 -- used to fall through to the `rawValues.length ===
+    // 0` branch below and emit that rounded-UP parsed value verbatim. That
+    // value can be strictly GREATER than the true maximum, so
+    // `column >= clauseValue` could exclude the very row that produced it.
+    // Exact BigInt recovery failing means the value was never an exact
+    // integer literal in the response text at all, which is exactly the
+    // condition the proportional-margin (epsilon) path below exists to
+    // handle -- so route there instead of using the unchanged parsed value.
+    let exactBigIntThreshold: bigint | null = null;
     if (
       Number.isInteger(maxValue) &&
       !Number.isSafeInteger(maxValue) &&
@@ -461,16 +473,13 @@ function buildWherePredicate(
       const rawValues = extractRawIntegerValues(baselineRawText, propertyKey);
       if (rawValues.length > 0) {
         const trueMax = rawValues.reduce((a, b) => (b > a ? b : a));
-        const thresholdBigInt = trueMax - 1n;
-        clauseValue = thresholdBigInt.toString();
-        evaluateThreshold = Number(thresholdBigInt);
-      } else {
-        // Raw text extraction found nothing for this property (unexpected
-        // given the parsed scan above found it) -- fall back to the parsed
-        // value rather than failing outright.
-        clauseValue = formatNumericLiteral(maxValue);
-        evaluateThreshold = maxValue;
+        exactBigIntThreshold = trueMax - 1n;
       }
+    }
+
+    if (exactBigIntThreshold !== null) {
+      clauseValue = exactBigIntThreshold.toString();
+      evaluateThreshold = Number(exactBigIntThreshold);
     } else if (Number.isSafeInteger(maxValue)) {
       // A safe integer's JSON round-trip is exact; nothing to correct.
       clauseValue = formatNumericLiteral(maxValue);
@@ -847,6 +856,42 @@ test.describe('buildWherePredicate precision', () => {
     const clauseValue = Number(predicate!.clause.split('>=')[1].trim());
     expect(clauseValue).toBeLessThan(trueValue);
   });
+
+  test('a raw decimal token past MAX_SAFE_INTEGER falls back to the epsilon margin, not the rounded parse', () => {
+    // fix(review #1792 round 7): a NUMERIC column can genuinely hold a
+    // fractional value out here, e.g. "9007199254740995.1" -- the regex in
+    // extractRawIntegerValues deliberately excludes this token (its
+    // `(?![\d.eE])` lookahead requires the digit run to end cleanly, not
+    // run into a `.`), so raw-text recovery finds nothing for it. What
+    // JSON.parse itself does to it is the trap: at this magnitude doubles
+    // are spaced 2 apart, so parsing silently ROUNDS UP to the next whole
+    // double (9007199254740996), which is strictly GREATER than the true
+    // value. Emitting that rounded value unchanged as the threshold would
+    // make `column >= threshold` exclude the very row that produced it.
+    const trueValueText = '9007199254740995.1';
+    const trueValue = Number(trueValueText);
+    expect(Number.isInteger(trueValue)).toBe(true);
+    expect(Number.isSafeInteger(trueValue)).toBe(false);
+    // Confirms the rounding actually happened, i.e. this pin exercises the
+    // failure mode it claims to: the parsed double is NOT the true value.
+    // Comparing as Number would compare two equally-rounded doubles (the
+    // ".1" literal and its own truncated integer part land on the SAME
+    // double at this magnitude) -- BigInt on the integer-valued `trueValue`
+    // is exact, so it correctly shows the parse rounded past the true
+    // integer part rather than merely dropping the fraction.
+    expect(BigInt(trueValue) > BigInt(trueValueText.split('.')[0])).toBe(true);
+
+    const baselineRawText = `{"type":"FeatureCollection","features":[{"type":"Feature","properties":{"value":${trueValueText}},"geometry":null}]}`;
+    const predicate = buildWherePredicate(
+      syntheticBaseline(trueValue),
+      columnInfo,
+      baselineRawText,
+    );
+
+    expect(predicate).toBeTruthy();
+    const clauseValue = Number(predicate!.clause.split('>=')[1].trim());
+    expect(clauseValue).toBeLessThan(trueValue);
+  });
 });
 
 test.describe('Runtime export integrity', () => {
@@ -987,14 +1032,23 @@ test.describe('Runtime export integrity', () => {
     // small epsilon, so the request is guaranteed to intersect at least that
     // feature regardless of dataset topology. This works identically for
     // `ownedDataset` and for E2E_EXPORT_DATASET_ID.
-    const observedFeature = baseline.features[0];
+    // fix(review #1792 round 7): `baseline.features[0]` assumed the FIRST
+    // feature has computable geometry, but resolveCandidate only checks
+    // that SOME feature across the whole collection contributes a position
+    // (collectFeatureCollectionPositions skips null/empty geometry per
+    // feature without failing the collection) -- a custom dataset via
+    // E2E_EXPORT_DATASET_ID can have a null-geometry row first and still
+    // pass that check. Select the first feature computeFeatureBBox()
+    // actually succeeds on instead of assuming index 0 is it.
+    const observedFeature = baseline.features.find(
+      (feature) => computeFeatureBBox(feature) !== null,
+    );
     expect(
       observedFeature,
-      'baseline export returned no features to build a bbox around',
+      'no feature in the baseline export has a computable geometry to build a bbox around',
     ).toBeTruthy();
-    const observedBBox = computeFeatureBBox(observedFeature);
-    expect(observedBBox, 'observed feature has no computable geometry').toBeTruthy();
-    const targetBBox = padBBox(observedBBox as BBox, 0.0001);
+    const observedBBox = computeFeatureBBox(observedFeature!) as BBox;
+    const targetBBox = padBBox(observedBBox, 0.0001);
 
     lastBboxFilter = serializeBBox(targetBBox);
     const bboxParam = encodeURIComponent(lastBboxFilter);

--- a/e2e/export-runtime.spec.ts
+++ b/e2e/export-runtime.spec.ts
@@ -219,6 +219,14 @@ function intersectsBBox(a: BBox, b: BBox): boolean {
   return !(a[2] < b[0] || a[0] > b[2] || a[3] < b[1] || a[1] > b[3]);
 }
 
+// fix(review #1792): pads a bbox (or a degenerate single-point bbox) out by
+// `epsilon` on every side, guaranteeing a non-degenerate span (the API
+// rejects a zero-width/height bbox, per buildInteriorBBox's own comment)
+// while staying tight enough to exclude sibling features in a small fixture.
+function padBBox(bbox: BBox, epsilon: number): BBox {
+  return [bbox[0] - epsilon, bbox[1] - epsilon, bbox[2] + epsilon, bbox[3] + epsilon];
+}
+
 function hasProjectedCoordinateSemantics(
   coordinates: Array<[number, number]>,
 ): boolean {
@@ -723,8 +731,27 @@ test.describe('Runtime export integrity', () => {
   });
 
   test('semantic bbox filter returns an intersecting subset', async ({ request }) => {
-    const interiorBBox = buildInteriorBBox(baselineExtent);
-    lastBboxFilter = serializeBBox(interiorBBox);
+    // fix(review #1792): shrinking the dataset's OWN reported extent by 20%
+    // does not guarantee any feature falls inside the shrunk box. For an
+    // externally supplied dataset (the E2E_EXPORT_DATASET_ID escape hatch
+    // above) with a sparse or corner-clustered distribution, the interior
+    // inset can legitimately contain nothing, and the toBeGreaterThan(0)
+    // assertion below would then flag a healthy filter as broken. Build the
+    // bbox around one OBSERVED feature's own coordinates instead -- taken
+    // from `baseline`, the already-fetched unfiltered export -- padded by a
+    // small epsilon, so the request is guaranteed to intersect at least that
+    // feature regardless of dataset topology. This works identically for
+    // `ownedDataset` and for E2E_EXPORT_DATASET_ID.
+    const observedFeature = baseline.features[0];
+    expect(
+      observedFeature,
+      'baseline export returned no features to build a bbox around',
+    ).toBeTruthy();
+    const observedBBox = computeFeatureBBox(observedFeature);
+    expect(observedBBox, 'observed feature has no computable geometry').toBeTruthy();
+    const targetBBox = padBBox(observedBBox as BBox, 0.0001);
+
+    lastBboxFilter = serializeBBox(targetBBox);
     const bboxParam = encodeURIComponent(lastBboxFilter);
     const filtered = await exportGeoJson(request, authHeader, dataset.id, [
       `bbox=${bboxParam}`,
@@ -733,15 +760,26 @@ test.describe('Runtime export integrity', () => {
     // fix(#1778): neither assertion below required a non-empty result, so a
     // regression that made the bbox filter match nothing (inverted operator,
     // wrong column, an SRID mismatch) passed this test — the `for` loop
-    // simply never ran. `toBeGreaterThan(0)` holds generally: the interior
-    // bbox keeps the central 60% of the extent on each axis, which excludes
-    // some geometry only when it also contains some.
+    // simply never ran. `toBeGreaterThan(0)` now holds unconditionally: the
+    // bbox above is built to contain the observed feature.
     expect(filtered.features.length).toBeGreaterThan(0);
     expect(filtered.features.length).toBeLessThanOrEqual(baseline.features.length);
+
+    // The observed feature itself must come back. Matched by geometry
+    // rather than an id: both this call and `baseline` come from the same
+    // GeoJSON export endpoint with no reprojection, so coordinates are
+    // byte-identical, and the export response does not carry a stable
+    // feature id to match on instead.
+    const observedGeometryJson = JSON.stringify(observedFeature.geometry);
+    const containsObserved = filtered.features.some(
+      (feature) => JSON.stringify(feature.geometry) === observedGeometryJson,
+    );
+    expect(containsObserved).toBe(true);
+
     if (ownedDataset) {
-      // Against the auto-seeded runtime fixture (west/center/east, evenly
-      // spaced) the 20% inset on each axis excludes west and east and keeps
-      // only center — pin the exact count rather than just "fewer than all".
+      // Against the auto-seeded runtime fixture (west/center/east, spaced
+      // ~5 degrees apart) a 0.0001-degree pad around one point never reaches
+      // its neighbors -- pin the exact count rather than just "at least 1".
       expect(filtered.features.length).toBe(1);
     }
 
@@ -749,7 +787,7 @@ test.describe('Runtime export integrity', () => {
       const featureBBox = computeFeatureBBox(feature);
       expect(featureBBox).toBeTruthy();
       if (featureBBox) {
-        expect(intersectsBBox(featureBBox, interiorBBox)).toBeTruthy();
+        expect(intersectsBBox(featureBBox, targetBBox)).toBeTruthy();
       }
     }
   });

--- a/e2e/export-runtime.spec.ts
+++ b/e2e/export-runtime.spec.ts
@@ -636,6 +636,13 @@ test.describe('Runtime export integrity', () => {
   let ownedDataset: OwnedDataset | null = null;
 
   test.beforeAll(async ({ request }) => {
+    // fix(review #1792 round 3): seedRuntimeDataset's own ingest-and-poll
+    // loop can run for up to 60s (its `for (let attempt = 0; attempt < 60;
+    // attempt += 1)` below), which is Playwright's default hook timeout
+    // with nothing left over for the login and resolveRuntimeDataset calls
+    // this hook also makes. Give this hook real margin.
+    test.setTimeout(120_000);
+
     const token = await loginAsAdmin(request);
     authHeader = { Authorization: `Bearer ${token}` };
     auditDateFrom = new Date(Date.now() - 5_000).toISOString();

--- a/e2e/export-runtime.spec.ts
+++ b/e2e/export-runtime.spec.ts
@@ -341,7 +341,17 @@ function buildWherePredicate(
   }
 
   if (numericColumn) {
-    const threshold = Number(maxValue.toFixed(6));
+    // fix(review #1792 round 2): Number(maxValue.toFixed(6)) can round the
+    // observed maximum UP (1.2345678 -> 1.234568), which would make
+    // `column >= threshold` exclude the very row that produced the maximum
+    // -- the clause would then match nothing. The auto-seeded runtime
+    // fixture's values (10/20/30) are integers, so toFixed(6) never
+    // triggered this, but the E2E_EXPORT_DATASET_ID escape hatch can point
+    // at a dataset with fractional column values. Use the exact observed
+    // maximum instead of a rounded one: `value >= value` is always true for
+    // the identical float, so the row that produced it can never be
+    // excluded by this comparison.
+    const threshold = maxValue;
     const { columnName, propertyKey } = numericColumn;
     return {
       clause: `${columnName} >= ${threshold}`,

--- a/e2e/export-runtime.spec.ts
+++ b/e2e/export-runtime.spec.ts
@@ -274,6 +274,50 @@ function serializeBBox(bbox: BBox): string {
   return bbox.map((value) => Number(value.toFixed(6))).join(',');
 }
 
+// fix(review #1792 round 5): a number string-interpolated directly (e.g.
+// `${threshold}` below) goes through JS's default Number-to-string
+// conversion, which switches to scientific notation below 1e-6 or at/above
+// 1e21 -- (1e-7).toString() === '1e-7', (1e21).toString() === '1e+21'. The
+// backend's -where clause parser (validate_where_clause) reads that `e` as
+// a bare SQL identifier, not part of a numeric literal, and rejects the
+// clause. Expand scientific notation back to a plain decimal string before
+// it reaches a clause. Pure string/digit manipulation on the exact digits
+// JS already chose -- never touches the value itself, so it can never round
+// (in particular, never rounds above the observed maximum the round-2 fix
+// depends on).
+function formatNumericLiteral(value: number): string {
+  const raw = String(value);
+  const match = raw.match(/^(-?)(\d+)(?:\.(\d+))?e([+-]\d+)$/i);
+  if (!match) {
+    return raw;
+  }
+
+  const [, sign, intDigits, fracDigits = '', expStr] = match;
+  const exponent = Number(expStr);
+  const digits = intDigits + fracDigits;
+  // Where the decimal point lands once the exponent shifts it, counted from
+  // the start of `digits` (intDigits followed directly by fracDigits).
+  const pointPos = intDigits.length + exponent;
+
+  let expanded: string;
+  if (pointPos <= 0) {
+    // |value| < 1: leading zeros after the point, then the digits.
+    expanded = `0.${'0'.repeat(-pointPos)}${digits}`;
+  } else if (pointPos >= digits.length) {
+    // Large integer: pad the digits out with trailing zeros.
+    expanded = digits + '0'.repeat(pointPos - digits.length);
+  } else {
+    // The point lands inside the digit string.
+    expanded = `${digits.slice(0, pointPos)}.${digits.slice(pointPos)}`;
+  }
+
+  if (expanded.includes('.')) {
+    expanded = expanded.replace(/0+$/, '').replace(/\.$/, '');
+  }
+
+  return sign + expanded;
+}
+
 function isSqlIdentifier(value: string): boolean {
   return /^[A-Za-z_][A-Za-z0-9_]*$/.test(value);
 }
@@ -354,7 +398,7 @@ function buildWherePredicate(
     const threshold = maxValue;
     const { columnName, propertyKey } = numericColumn;
     return {
-      clause: `${columnName} >= ${threshold}`,
+      clause: `${columnName} >= ${formatNumericLiteral(threshold)}`,
       propertyKey,
       evaluate: (candidate) => {
         const value = candidate[propertyKey];
@@ -622,6 +666,29 @@ async function resolveRuntimeDataset(
     `Runtime export dataset ${datasetId} did not satisfy format and target_crs semantic preconditions`,
   );
 }
+
+// fix(review #1792 round 5): pure-logic pin for formatNumericLiteral,
+// independent of any live request -- the two inputs are exactly where
+// JS's Number-to-string conversion switches to scientific notation (see
+// the function's own comment).
+test.describe('formatNumericLiteral', () => {
+  test('expands a value just below the small-number scientific-notation threshold', () => {
+    expect(String(1e-7)).toBe('1e-7'); // sanity: this is the input JS would otherwise emit as-is
+    expect(formatNumericLiteral(1e-7)).toBe('0.0000001');
+  });
+
+  test('expands a value at the large-number scientific-notation threshold', () => {
+    expect(String(1e21)).toBe('1e+21'); // sanity: this is the input JS would otherwise emit as-is
+    expect(formatNumericLiteral(1e21)).toBe('1000000000000000000000');
+  });
+
+  test('leaves values JS already renders as plain decimals untouched', () => {
+    expect(formatNumericLiteral(1e-6)).toBe('0.000001');
+    expect(formatNumericLiteral(1e20)).toBe('100000000000000000000');
+    expect(formatNumericLiteral(30)).toBe('30');
+    expect(formatNumericLiteral(-1e-7)).toBe('-0.0000001');
+  });
+});
 
 test.describe('Runtime export integrity', () => {
   test.describe.configure({ mode: 'serial' });

--- a/e2e/post-impl-validation.spec.ts
+++ b/e2e/post-impl-validation.spec.ts
@@ -53,8 +53,10 @@ test.describe.serial('Post-impl validation', () => {
       localStorage.setItem('geolens-auth', JSON.stringify({ state: { token: t, user: { username: 'admin', roles: ['admin'] } }, version: 0 }));
     }, authToken);
     await page.reload();
+    // fix(#1778): a bare .catch(() => {}) swallowed the rejection this expect()
+    // exists to raise, so a rendered error boundary passed the test silently.
     // Page should not show error boundary
-    await expect(page.locator('text=Something went wrong')).not.toBeVisible({ timeout: 5000 }).catch(() => {});
+    await expect(page.locator('text=Something went wrong')).not.toBeVisible({ timeout: 5000 });
     // Should have some content
     await expect(page.locator('body')).not.toBeEmpty();
   });
@@ -66,8 +68,10 @@ test.describe.serial('Post-impl validation', () => {
     }, authToken);
     await page.reload();
     await page.waitForLoadState('networkidle');
+    // fix(#1778): same swallow as test 2 above — the error-boundary check
+    // could never fail.
     // Should see maps page content
-    await expect(page.locator('body')).not.toHaveText('Page error', { timeout: 10000 }).catch(() => {});
+    await expect(page.locator('body')).not.toHaveText('Page error', { timeout: 10000 });
     expect(page.url()).toContain('/maps');
   });
 
@@ -157,12 +161,14 @@ test.describe.serial('Post-impl validation', () => {
     await viewerPage.goto(`${BASE}/m/${shareData.token}`);
     await viewerPage.waitForLoadState('networkidle');
 
+    // fix(#1778): dropped the swallowing .catch() so a rendered error boundary
+    // fails this test, and asserted on hasCanvas instead of computing it and
+    // never reading it — a blank viewer used to pass on the URL check alone.
     // Should not show "Something went wrong" error boundary
-    await expect(viewerPage.locator('text=Something went wrong')).not.toBeVisible({ timeout: 10000 }).catch(() => {});
+    await expect(viewerPage.locator('text=Something went wrong')).not.toBeVisible({ timeout: 10000 });
 
     // Should render a map canvas
-    const hasCanvas = await viewerPage.locator('canvas').isVisible().catch(() => false);
-    // Canvas may take time for WebGL init - just verify no crash
+    await expect(viewerPage.locator('canvas').first()).toBeVisible({ timeout: 15000 });
     expect(viewerPage.url()).toContain('/m/');
 
     await viewerPage.close();
@@ -268,14 +274,22 @@ test.describe.serial('Post-impl validation', () => {
   });
 
   test('12. Admin settings page loads without crash', async ({ page }) => {
+    // fix(#1778): dropped the manual localStorage-set-then-reload dance —
+    // the chromium project's storageState already authenticates every test
+    // in this file (see playwright.config.ts), so the extra reload was pure
+    // redundancy. It also raced the SPA's own client-side
+    // /admin/settings -> /admin/settings/general redirect: with the
+    // swallowed .catch() this always reported success either way, so the
+    // race was invisible; asserting for real surfaced it as a flake
+    // (occasionally landing back on /login). A single goto with the
+    // project's own auth avoids the race outright.
     await page.goto(`${BASE}/admin/settings`);
-    await page.evaluate((t) => {
-      localStorage.setItem('geolens-auth', JSON.stringify({ state: { token: t, user: { username: 'admin', roles: ['admin'] } }, version: 0 }));
-    }, authToken);
-    await page.reload();
     await page.waitForLoadState('networkidle');
 
     // Should not show error boundary
-    await expect(page.locator('text=Something went wrong')).not.toBeVisible({ timeout: 5000 }).catch(() => {});
+    await expect(page.locator('text=Something went wrong')).not.toBeVisible({ timeout: 5000 });
+    await expect(page.getByRole('heading', { level: 1, name: 'General' })).toBeVisible({
+      timeout: 10000,
+    });
   });
 });

--- a/e2e/post-impl-validation.spec.ts
+++ b/e2e/post-impl-validation.spec.ts
@@ -70,8 +70,14 @@ test.describe.serial('Post-impl validation', () => {
     await page.waitForLoadState('networkidle');
     // fix(#1778): same swallow as test 2 above — the error-boundary check
     // could never fail.
+    //
+    // fix(review #1792): `toHaveText` normalizes and compares the WHOLE
+    // element text, so `body` (header/nav/footer chrome plus page content)
+    // never equals exactly 'Page error' even when an error boundary IS
+    // rendering it -- this assertion passed in exactly the failure state.
+    // `toContainText` checks substring containment instead.
     // Should see maps page content
-    await expect(page.locator('body')).not.toHaveText('Page error', { timeout: 10000 });
+    await expect(page.locator('body')).not.toContainText('Page error', { timeout: 10000 });
     expect(page.url()).toContain('/maps');
   });
 

--- a/e2e/reupload-multi-layer-gpkg.spec.ts
+++ b/e2e/reupload-multi-layer-gpkg.spec.ts
@@ -117,41 +117,16 @@ const SOMETHING_ELSE_GEOJSON = JSON.stringify({
 test.describe('GPKG-01: Multi-layer GPKG reupload', () => {
   test.setTimeout(120_000);
 
-  test('Scenario A — happy path: default-selects previous source_layer from prior IngestJob', async ({ page, request }) => {
-    test.slow();
-
-    // Seed: upload a single-layer GeoJSON first so source_layer="buildings" is recorded
-    // (The import flow names the layer from the first ogrinfo layer.)
-    // This creates a dataset with a completed IngestJob having source_layer set.
-    // Due to the complexity of full ingest in headless tests, we skip the seed step
-    // and instead test the UI layer-select flow directly by uploading the multi-layer GPKG.
-    // The full round-trip post-condition (source_layer persisted) is covered by backend tests.
-
-    await page.goto('/');
-
-    // Navigate to import page to create a fresh dataset with multi-layer GPKG
-    await page.goto('/import');
-    await page.waitForLoadState('domcontentloaded');
-
-    // Wait for the upload tab / dropzone
-    const fileInput = page.locator('input[type="file"]').first();
-    await expect(fileInput).toBeAttached({ timeout: 15_000 });
-    await fileInput.setInputFiles(FIXTURE_PATH);
-
-    // After upload + ogrinfo, the multi-layer GPKG should show the layer-select step
-    // (BulkReviewList or single-file preview depending on version)
-    // Wait for either the layer table or a layer-related heading
-    const layerTableOrStep = page.locator(
-      '[data-testid="bulk-review-list"], [data-testid="layer-select-table"], .layer-select, [role="table"]',
-    );
-    await expect(layerTableOrStep.first()).toBeVisible({ timeout: 30_000 }).catch(() => {
-      // If the import UI shows preview differently, just verify the page loaded successfully
-      // without an error state
-    });
-
-    // The spec confirms the file was accepted (no error state visible)
-    await expect(page.locator('.text-destructive, [data-testid="error-state"]').first()).not.toBeVisible({ timeout: 5_000 }).catch(() => { /* ok */ });
-  });
+  // fix(#1778): Scenario A ("happy path: default-selects previous source_layer")
+  // used to assert on two `.catch(() => {})`-swallowed expects against
+  // selectors ('[data-testid="bulk-review-list"]', '[data-testid="layer-select-table"]')
+  // that exist only in this file's own vitest mocks, never in app source — the
+  // test could only fail if /import had no file input at all. The behavior it
+  // was named for (multi-layer fan-out commit, per-layer results) is covered
+  // for real by frontend/src/components/import/__tests__/UploadForm.multiLayerFanOut.test.tsx,
+  // which asserts against actual component output rather than a soft-swallowed
+  // e2e selector guess. Scenario B below covers the reupload-dialog layer-select
+  // path with hard assertions instead.
 
   test('Scenario B — ReuploadDialog file path: layer-select + missing-layer warning', async ({ page, request }) => {
     test.slow();
@@ -165,8 +140,12 @@ test.describe('GPKG-01: Multi-layer GPKG reupload', () => {
         headers: { Authorization: `Bearer ${token}` },
       });
       if (resp.ok()) {
-        const body = await resp.json() as { results?: Array<{ id: string; record_type?: string }> };
-        const all = body.results ?? [];
+        // fix(#1778): DatasetListResponse's field is `datasets`, not `results`
+        // (backend/openapi.json has no `results` key on this schema) — the
+        // old read always produced an empty array here, so datasetId always
+        // came from the DOM-scrape fallback below regardless of dataset type.
+        const body = await resp.json() as { datasets?: Array<{ id: string; record_type?: string }> };
+        const all = body.datasets ?? [];
         // Pick the first dataset, preferring vector datasets
         const vector = all.find((d) => d.record_type === 'vector_dataset');
         datasetId = (vector ?? all[0])?.id ?? null;
@@ -187,10 +166,12 @@ test.describe('GPKG-01: Multi-layer GPKG reupload', () => {
       }
     }
 
-    if (!datasetId) {
-      test.skip(true, 'No dataset found to test reupload flow — skipping (Phase 1060 live MCP will verify)');
-      return;
-    }
+    // fix(#1778): this used to be a test.skip(true, ...) — with the `results`
+    // → `datasets` fix above, the CI catalog is always seeded
+    // (e2e/auth.setup.ts's seedDataset, plus the demo seed script's own
+    // vector datasets), so a missing datasetId is a real failure, not a
+    // legitimate empty-catalog outcome.
+    expect(datasetId, 'reupload flow needs a seeded vector dataset to target').toBeTruthy();
 
     const dataset = { id: datasetId };
     await page.goto(`/datasets/${dataset.id}`);
@@ -198,16 +179,14 @@ test.describe('GPKG-01: Multi-layer GPKG reupload', () => {
 
     // Open "More" menu and click "Re-Upload"
     const moreBtn = page.getByRole('button', { name: /more|actions/i }).first();
-    if (!await moreBtn.isVisible({ timeout: 5_000 }).catch(() => false)) {
-      test.skip(true, 'Could not find More button on dataset detail — skipping');
-      return;
-    }
+    // fix(#1778): the Re-Upload affordance disappearing is exactly the
+    // regression e2e/dataset-detail.spec.ts (IMPORT-04) exists to catch —
+    // skipping here instead of failing let that regression turn this test
+    // green-as-skipped.
+    await expect(moreBtn).toBeVisible({ timeout: 5_000 });
     await moreBtn.click();
     const reuploadMenuItem = page.getByRole('menuitem', { name: /re-?upload/i }).first();
-    if (!await reuploadMenuItem.isVisible({ timeout: 3_000 }).catch(() => false)) {
-      test.skip(true, 'Re-Upload menu item not found — skipping');
-      return;
-    }
+    await expect(reuploadMenuItem).toBeVisible({ timeout: 3_000 });
     await reuploadMenuItem.click();
 
     // Source selector should appear
@@ -228,30 +207,34 @@ test.describe('GPKG-01: Multi-layer GPKG reupload', () => {
     );
     await expect(layerSelectOrPreview.first()).toBeVisible({ timeout: 30_000 });
 
-    if (await page.getByTestId('reupload-file-layer-select').isVisible({ timeout: 1_000 }).catch(() => false)) {
-      // Multi-layer path: verify both layer rows are present
-      await expect(page.getByText('buildings')).toBeVisible({ timeout: 5_000 });
-      await expect(page.getByText('addresses')).toBeVisible({ timeout: 5_000 });
+    // fix(#1778): FIXTURE_PATH (multi-layer-gpkg.gpkg) is a known multi-layer
+    // file, so the layer-select step is not an optional branch — it is
+    // exactly the silent-data-swap symptom GPKG-01 exists to catch. Asserting
+    // it unconditionally means a regression that skips straight to preview
+    // (the old "acceptable, not a failure" branch) now fails this test.
+    await expect(page.getByTestId('reupload-file-layer-select')).toBeVisible({ timeout: 5_000 });
 
-      // Preview button should be visible
-      const previewBtn = page.getByRole('button', { name: 'Preview Layer' });
-      await expect(previewBtn).toBeVisible({ timeout: 5_000 });
+    // Multi-layer path: verify both layer rows are present
+    await expect(page.getByText('buildings')).toBeVisible({ timeout: 5_000 });
+    await expect(page.getByText('addresses')).toBeVisible({ timeout: 5_000 });
 
-      // If a row is already selected (previous_source_layer pre-selection), preview is enabled;
-      // otherwise click a row to select
-      if (await previewBtn.isDisabled({ timeout: 1_000 }).catch(() => false)) {
-        await page.getByText('buildings').first().click();
-        await expect(previewBtn).toBeEnabled({ timeout: 3_000 });
-      }
+    // Preview button should be visible
+    const previewBtn = page.getByRole('button', { name: 'Preview Layer' });
+    await expect(previewBtn).toBeVisible({ timeout: 5_000 });
 
-      // Click Preview Layer
-      await previewBtn.click();
-
-      // Should transition to preview step
-      await expect(page.getByRole('button', { name: 'Confirm Re-Upload' })).toBeVisible({
-        timeout: 30_000,
-      });
+    // If a row is already selected (previous_source_layer pre-selection), preview is enabled;
+    // otherwise click a row to select
+    if (await previewBtn.isDisabled({ timeout: 1_000 }).catch(() => false)) {
+      await page.getByText('buildings').first().click();
+      await expect(previewBtn).toBeEnabled({ timeout: 3_000 });
     }
-    // (If single-layer: straight to preview — acceptable, not a failure)
+
+    // Click Preview Layer
+    await previewBtn.click();
+
+    // Should transition to preview step
+    await expect(page.getByRole('button', { name: 'Confirm Re-Upload' })).toBeVisible({
+      timeout: 30_000,
+    });
   });
 });

--- a/e2e/sec-audit.spec.ts
+++ b/e2e/sec-audit.spec.ts
@@ -2,33 +2,150 @@
 //
 // Run: npx playwright test e2e/sec-audit.spec.ts --project=chromium
 //
-// Many tests need a private dataset / raster / second editor user. Provide via env:
-//   SEC_AUDIT_API_URL                  default /api
-//   SEC_AUDIT_PRIVATE_RECORD_ID        STAC record_id for a private published raster (S01)
-//   SEC_AUDIT_PRIVATE_DATASET_ID       a dataset owned by user A with visibility=private (S02/S03/S05)
-//   SEC_AUDIT_EDITOR_B_TOKEN           bearer token for a second editor user (not the dataset's owner) (S02/S03)
-//   SEC_AUDIT_EDITOR_A_TOKEN           bearer token for the dataset owner (S03 cleanup)
-//   SEC_AUDIT_SSRF_TEST_REDIRECTOR     a public URL that 302-redirects to 169.254.169.254 (S04)
-// Tests that lack the env var skip with a printed reason rather than fail.
+// fix(#1778): S01/S02/S03/S05/S08/S09 used to read hand-provisioned env vars
+// (SEC_AUDIT_PRIVATE_DATASET_ID etc.) that nothing in CI ever set, so those
+// tests skipped on every run and the file reported green while covering 8
+// of 19 cases. beforeAll below seeds the same fixtures in-spec instead, the
+// way e2e/auth.setup.ts seeds a shared dataset and e2e/auth.spec.ts creates
+// its throwaway e2e-logout-probe user.
+//
+// S04 (SSRF redirect bypass) is the one case left out: it needs a live
+// external URL that 302-redirects to 169.254.169.254, which cannot be
+// provisioned safely in CI. That behavior is covered by
+// backend/tests/test_ssrf_redirect.py, so the test is removed below rather
+// than left permanently skipped — see the comment where it used to be.
+//
+//   SEC_AUDIT_API_URL         override the API base (default /api)
+//   SEC_AUDIT_FRONTEND_URL    override the frontend base for S08 (default E2E_BASE_URL)
 
 import { test, expect } from '@playwright/test';
+import { getAuthToken, seedDataset, seedDemDataset, deleteDataset } from './helpers/catalog';
 
 const API = process.env.SEC_AUDIT_API_URL || '/api';
+const BASE_URL = process.env.E2E_BASE_URL ?? 'http://localhost:8080';
+
+let privateDatasetId = '';
+let privateDatasetTitle = '';
+let privateRasterId = '';
+let privateRasterTitle = '';
+let publicDatasetId = '';
+let publicDatasetTitle = '';
+let editorBToken = '';
+let editorBUserId = '';
+let shareToken = '';
+let shareMapId = '';
+
+function adminHeaders(): Record<string, string> {
+  return {
+    Authorization: `Bearer ${getAuthToken()}`,
+    'Content-Type': 'application/json',
+  };
+}
+
+test.beforeAll(async () => {
+  const headers = adminHeaders();
+
+  // S01: private, published raster. The STAC /stac/items/{id} endpoint uses
+  // Dataset.id as the item id (backend/tests/test_stac_visibility.py), and
+  // ingest defaults a new dataset to visibility=private, record_status=published.
+  const raster = await seedDemDataset();
+  privateRasterId = raster.id;
+  privateRasterTitle = raster.title;
+
+  // S02/S03/S05: private vector dataset owned by the seeding admin account.
+  const priv = await seedDataset('Sec Audit Private');
+  privateDatasetId = priv.id;
+  privateDatasetTitle = priv.title;
+
+  // S09: public, published vector dataset.
+  const pub = await seedDataset('Sec Audit Public');
+  publicDatasetId = pub.id;
+  publicDatasetTitle = pub.title;
+  const publishRes = await fetch(`${BASE_URL}/api/datasets/${publicDatasetId}`, {
+    method: 'PATCH',
+    headers,
+    body: JSON.stringify({ visibility: 'public', record_status: 'published' }),
+  });
+  if (!publishRes.ok) {
+    throw new Error(`sec-audit: could not publish public dataset: ${publishRes.status}`);
+  }
+
+  // S02/S03: a second, non-admin editor who owns neither dataset above.
+  const editorBUsername = `sec-audit-editor-b-${Date.now()}`;
+  const editorBPassword = 'Sec-Audit-Editor-B-42';
+  const createUserRes = await fetch(`${BASE_URL}/api/admin/users/`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({ username: editorBUsername, password: editorBPassword, role: 'editor' }),
+  });
+  if (!createUserRes.ok) {
+    throw new Error(`sec-audit: could not create editor B: ${createUserRes.status}`);
+  }
+  editorBUserId = ((await createUserRes.json()) as { id: string }).id;
+
+  const loginRes = await fetch(`${BASE_URL}/api/auth/login/`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({ username: editorBUsername, password: editorBPassword }).toString(),
+  });
+  if (!loginRes.ok) {
+    throw new Error(`sec-audit: could not log in editor B: ${loginRes.status}`);
+  }
+  editorBToken = ((await loginRes.json()) as { access_token: string }).access_token;
+
+  // S08: a public map with a share token.
+  const mapRes = await fetch(`${BASE_URL}/api/maps/`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({ name: `Sec Audit Share Map ${Date.now()}` }),
+  });
+  if (!mapRes.ok) {
+    throw new Error(`sec-audit: could not create share map: ${mapRes.status}`);
+  }
+  shareMapId = ((await mapRes.json()) as { id: string }).id;
+  const mapPublishRes = await fetch(`${BASE_URL}/api/maps/${shareMapId}`, {
+    method: 'PUT',
+    headers,
+    body: JSON.stringify({ visibility: 'public' }),
+  });
+  if (!mapPublishRes.ok) {
+    throw new Error(`sec-audit: could not publish share map: ${mapPublishRes.status}`);
+  }
+  const shareRes = await fetch(`${BASE_URL}/api/maps/${shareMapId}/share/`, {
+    method: 'POST',
+    headers,
+  });
+  if (!shareRes.ok) {
+    throw new Error(`sec-audit: could not create share token: ${shareRes.status}`);
+  }
+  shareToken = ((await shareRes.json()) as { token: string }).token;
+});
+
+test.afterAll(async () => {
+  const headers = adminHeaders();
+  if (shareMapId) {
+    await fetch(`${BASE_URL}/api/maps/${shareMapId}`, { method: 'DELETE', headers }).catch(() => {});
+  }
+  if (editorBUserId) {
+    await fetch(`${BASE_URL}/api/admin/users/${editorBUserId}`, { method: 'DELETE', headers }).catch(() => {});
+  }
+  if (privateDatasetId) await deleteDataset(privateDatasetId, privateDatasetTitle);
+  if (publicDatasetId) await deleteDataset(publicDatasetId, publicDatasetTitle);
+  if (privateRasterId) await deleteDataset(privateRasterId, privateRasterTitle);
+});
 
 // ─────────────────────────────────────────────────────────────────────────────
 // S01 — STAC visibility bypass (anonymous read of private raster)
 // ─────────────────────────────────────────────────────────────────────────────
 
 test('S01 STAC visibility — anonymous cannot read a private raster STAC item', async ({ request }) => {
-  const recordId = process.env.SEC_AUDIT_PRIVATE_RECORD_ID;
-  test.skip(!recordId, 'Set SEC_AUDIT_PRIVATE_RECORD_ID to a private published raster');
+  const recordId = privateRasterId;
   const res = await request.get(`${API}/stac/items/${recordId}`);
   expect([401, 403, 404]).toContain(res.status());
 });
 
 test('S01 STAC visibility — anonymous /stac/search does not return private rasters', async ({ request }) => {
-  const recordId = process.env.SEC_AUDIT_PRIVATE_RECORD_ID;
-  test.skip(!recordId, 'Set SEC_AUDIT_PRIVATE_RECORD_ID to a private published raster');
+  const recordId = privateRasterId;
   const res = await request.get(`${API}/stac/search?ids=${recordId}`);
   // Either denied (401/403) or empty features list — never the private item back
   if (res.status() === 200) {
@@ -44,9 +161,8 @@ test('S01 STAC visibility — anonymous /stac/search does not return private ras
 // ─────────────────────────────────────────────────────────────────────────────
 
 test('S02 IDOR — editor B cannot PATCH another user\'s private dataset', async ({ request }) => {
-  const datasetId = process.env.SEC_AUDIT_PRIVATE_DATASET_ID;
-  const tokenB = process.env.SEC_AUDIT_EDITOR_B_TOKEN;
-  test.skip(!datasetId || !tokenB, 'Set SEC_AUDIT_PRIVATE_DATASET_ID and SEC_AUDIT_EDITOR_B_TOKEN');
+  const datasetId = privateDatasetId;
+  const tokenB = editorBToken;
   const res = await request.patch(`${API}/datasets/${datasetId}/`, {
     headers: {
       Authorization: `Bearer ${tokenB}`,
@@ -58,9 +174,8 @@ test('S02 IDOR — editor B cannot PATCH another user\'s private dataset', async
 });
 
 test('S02 IDOR — editor B cannot DELETE another user\'s private dataset', async ({ request }) => {
-  const datasetId = process.env.SEC_AUDIT_PRIVATE_DATASET_ID;
-  const tokenB = process.env.SEC_AUDIT_EDITOR_B_TOKEN;
-  test.skip(!datasetId || !tokenB, 'Set SEC_AUDIT_PRIVATE_DATASET_ID and SEC_AUDIT_EDITOR_B_TOKEN');
+  const datasetId = privateDatasetId;
+  const tokenB = editorBToken;
   const res = await request.delete(`${API}/datasets/${datasetId}/`, {
     headers: { Authorization: `Bearer ${tokenB}` },
   });
@@ -68,24 +183,27 @@ test('S02 IDOR — editor B cannot DELETE another user\'s private dataset', asyn
 });
 
 test('S02 IDOR — editor B cannot bulk-delete another user\'s private dataset', async ({ request }) => {
-  const datasetId = process.env.SEC_AUDIT_PRIVATE_DATASET_ID;
-  const tokenB = process.env.SEC_AUDIT_EDITOR_B_TOKEN;
-  test.skip(!datasetId || !tokenB, 'Set SEC_AUDIT_PRIVATE_DATASET_ID and SEC_AUDIT_EDITOR_B_TOKEN');
+  const datasetId = privateDatasetId;
+  const tokenB = editorBToken;
+  // fix(#1778): BulkDeleteRequest's schema is `{ datasets: [{ dataset_id,
+  // confirm_title }] }` (backend/openapi.json), not `{ dataset_ids: [...] }`
+  // — the old payload always 422'd before authorization was ever reached,
+  // which the permanent skip guard hid. bulk_delete_datasets_endpoint
+  // (router.py) isolates per-item failures rather than rejecting the whole
+  // batch, so a denied item surfaces as HTTP 200 with a per-item
+  // status: 'error', never a top-level 401/403/404.
   const res = await request.post(`${API}/datasets/bulk-delete/`, {
     headers: {
       Authorization: `Bearer ${tokenB}`,
       'Content-Type': 'application/json',
     },
-    data: { dataset_ids: [datasetId] },
+    data: { datasets: [{ dataset_id: datasetId, confirm_title: privateDatasetTitle }] },
   });
-  // Either fully rejected (403/401) OR succeeds with a per-id failure (200/207 with deleted=0)
-  if (res.status() === 200 || res.status() === 207) {
-    const body = await res.json();
-    const deleted = body.deleted ?? body.deleted_ids ?? [];
-    expect(deleted).not.toContain(datasetId);
-  } else {
-    expect([401, 403, 404]).toContain(res.status());
-  }
+  expect(res.status()).toBe(200);
+  const body = await res.json();
+  const results = body.results ?? [];
+  const item = results.find((r: { dataset_id: string }) => r.dataset_id === datasetId);
+  expect(item?.status).not.toBe('deleted');
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -93,9 +211,8 @@ test('S02 IDOR — editor B cannot bulk-delete another user\'s private dataset',
 // ─────────────────────────────────────────────────────────────────────────────
 
 test('S03 IDOR — editor B cannot add a column to another user\'s private dataset', async ({ request }) => {
-  const datasetId = process.env.SEC_AUDIT_PRIVATE_DATASET_ID;
-  const tokenB = process.env.SEC_AUDIT_EDITOR_B_TOKEN;
-  test.skip(!datasetId || !tokenB, 'Set SEC_AUDIT_PRIVATE_DATASET_ID and SEC_AUDIT_EDITOR_B_TOKEN');
+  const datasetId = privateDatasetId;
+  const tokenB = editorBToken;
   const res = await request.post(`${API}/datasets/${datasetId}/columns/`, {
     headers: {
       Authorization: `Bearer ${tokenB}`,
@@ -107,9 +224,8 @@ test('S03 IDOR — editor B cannot add a column to another user\'s private datas
 });
 
 test('S03 IDOR — editor B cannot DROP a column on another user\'s private dataset', async ({ request }) => {
-  const datasetId = process.env.SEC_AUDIT_PRIVATE_DATASET_ID;
-  const tokenB = process.env.SEC_AUDIT_EDITOR_B_TOKEN;
-  test.skip(!datasetId || !tokenB, 'Set SEC_AUDIT_PRIVATE_DATASET_ID and SEC_AUDIT_EDITOR_B_TOKEN');
+  const datasetId = privateDatasetId;
+  const tokenB = editorBToken;
   // Use a column name that almost certainly exists on a default ingested table
   const res = await request.delete(`${API}/datasets/${datasetId}/columns/gid`, {
     headers: { Authorization: `Bearer ${tokenB}` },
@@ -119,36 +235,20 @@ test('S03 IDOR — editor B cannot DROP a column on another user\'s private data
 
 // ─────────────────────────────────────────────────────────────────────────────
 // S04 — SSRF redirect bypass on external source connectors
+//
+// fix(#1778): removed rather than left permanently skipped. This test needs
+// a live external URL that 302-redirects to 169.254.169.254; CI has no such
+// endpoint and standing one up is a real infrastructure dependency, not a
+// fixture this spec can seed. The redirect-revalidation behavior itself is
+// covered by backend/tests/test_ssrf_redirect.py, which mocks the redirect.
 // ─────────────────────────────────────────────────────────────────────────────
-
-test('S04 SSRF — /sources/probe/ rejects redirect target to private IP', async ({ request }) => {
-  const tokenA = process.env.SEC_AUDIT_EDITOR_A_TOKEN;
-  const redirector = process.env.SEC_AUDIT_SSRF_TEST_REDIRECTOR;
-  test.skip(!tokenA || !redirector, 'Set SEC_AUDIT_EDITOR_A_TOKEN and SEC_AUDIT_SSRF_TEST_REDIRECTOR (a URL that 302s to 169.254.169.254)');
-  const res = await request.post(`${API}/sources/probe/`, {
-    headers: {
-      Authorization: `Bearer ${tokenA}`,
-      'Content-Type': 'application/json',
-    },
-    data: { url: redirector },
-  });
-  if (res.status() === 200) {
-    const body = await res.text();
-    // Must not have followed redirect to IMDS / private host
-    expect(body).not.toMatch(/169\.254\.169\.254|iam\/security-credentials|instance-identity/i);
-    expect(body).not.toMatch(/listen_addresses|pg_hba|PostgreSQL/i);
-  } else {
-    expect([400, 403, 422]).toContain(res.status());
-  }
-});
 
 // ─────────────────────────────────────────────────────────────────────────────
 // S05 — pgvector /datasets/{id}/related/ visibility bypass
 // ─────────────────────────────────────────────────────────────────────────────
 
 test('S05 VEC-IDOR — anonymous /related/ on a private dataset returns no oracle', async ({ request }) => {
-  const datasetId = process.env.SEC_AUDIT_PRIVATE_DATASET_ID;
-  test.skip(!datasetId, 'Set SEC_AUDIT_PRIVATE_DATASET_ID');
+  const datasetId = privateDatasetId;
   const res = await request.get(`${API}/datasets/${datasetId}/related/`);
   // After fix: 401/403/404. Before fix: 200 with empty or partial list (oracle).
   // Empty 200 is also accepted as long as no similarity scores leak.
@@ -178,8 +278,6 @@ test('S06 — admin user with known-public password "demodemo" cannot log in', a
 // ─────────────────────────────────────────────────────────────────────────────
 
 test('S08 — /m/<share_token> HTML response has frame-ancestors CSP (or is admin-restricted)', async ({ request }) => {
-  const shareToken = process.env.SEC_AUDIT_SHARE_TOKEN;
-  test.skip(!shareToken, 'Set SEC_AUDIT_SHARE_TOKEN to a public share token');
   // The frontend host serves /m/* — derive from API base
   const frontendBase = process.env.SEC_AUDIT_FRONTEND_URL || 'http://localhost:8080';
   const res = await request.get(`${frontendBase}/m/${shareToken}?embed=true`, {
@@ -202,10 +300,15 @@ test('S08 — /m/<share_token> HTML response has frame-ancestors CSP (or is admi
 // ─────────────────────────────────────────────────────────────────────────────
 
 test('S09 — dataset export -where rejects UNION / subqueries', async ({ request }) => {
-  const datasetId = process.env.SEC_AUDIT_PUBLIC_DATASET_ID;
-  test.skip(!datasetId, 'Set SEC_AUDIT_PUBLIC_DATASET_ID to a public exportable dataset');
+  const datasetId = publicDatasetId;
   const malicious = `gid > 0 UNION SELECT 1, 2, 3`;
-  const res = await request.get(`${API}/datasets/${datasetId}/export.csv?where=${encodeURIComponent(malicious)}`);
+  // fix(#1778): the export route is /datasets/{id}/export?format=csv, not
+  // /datasets/{id}/export.csv (backend/openapi.json has no such path) — the
+  // old URL always 404'd before the -where parser ever ran, which the
+  // permanent skip guard hid.
+  const res = await request.get(
+    `${API}/datasets/${datasetId}/export?format=csv&where=${encodeURIComponent(malicious)}`,
+  );
   expect([400, 422, 403]).toContain(res.status());
 });
 
@@ -224,8 +327,10 @@ test('S11 — burst of unique semantic queries gets rate-limited', async ({ requ
   );
   const statuses = responses.map(r => r.status());
   const has429 = statuses.includes(429);
-  // Until S11 ships, allow this to be informational — skip if no 429 observed
-  test.skip(!has429, 'Per-route rate limit not yet shipped (S11 follow-up)');
+  // fix(#1778): the skip guard fired on exactly the outcome this test exists
+  // to catch, so it could never go red. The per-route decorator has shipped
+  // (search/router.py's search_datasets_endpoint carries
+  // @limiter.limit(_semantic_search_rate_limit), default 30/minute) — gate on it.
   expect(has429).toBe(true);
 });
 

--- a/e2e/sec-audit.spec.ts
+++ b/e2e/sec-audit.spec.ts
@@ -653,12 +653,23 @@ test('S11 — burst of unique semantic queries gets rate-limited', async ({ requ
   // shipped (search/router.py's search_datasets_endpoint carries
   // @limiter.limit(_semantic_search_rate_limit)) -- gate on it.
   //
-  // fix(review #1792): a hardcoded 80-request burst assumed the 30/minute
-  // default, but semantic_search_rate_limit is a runtime admin setting
-  // (persistent_config.py) an operator can raise up to 1000. Read the
-  // actual configured value through /settings/all/ (admin-only) using the
-  // same shared admin session every other fixture in this file uses, and
-  // send exactly one more request than that.
+  // fix(review #1792 round 4, final shape): this test has now cost four
+  // rounds -- read the configured limit instead of hardcoding it (round 1),
+  // stop mutating the shared setting (round 1), and now: no hard ceiling on
+  // how high an operator can configure it, paced so the global limiter
+  // cannot fire from our own burst, and a positive assertion that the 429
+  // actually came from the PER-ROUTE limiter rather than the global one.
+  //
+  // Two independent SlowAPI limits apply to every request here:
+  // _global_rate_limit (platform/ratelimit.py, default_limits, no
+  // override_defaults on the route decorator so both stack) and
+  // _semantic_search_rate_limit (the per-route decorator under test). A
+  // Promise.all burst sends everything in one instant, which can trip the
+  // per-SECOND global limiter well before the per-MINUTE route limiter --
+  // and slowapi's 429 body (str(limits.RateLimitItem), e.g. "30 per 1
+  // minute" vs "60 per 1 second") is the only way to tell which one fired.
+  test.slow();
+
   const settingsRes = await request.get(`${apiBase}/settings/all/`, {
     headers: { Authorization: `Bearer ${getAuthToken()}` },
   });
@@ -666,9 +677,9 @@ test('S11 — burst of unique semantic queries gets rate-limited', async ({ requ
   const settingsBody = (await settingsRes.json()) as {
     tabs: Record<string, Array<{ key: string; value: unknown }>>;
   };
-  const rateLimitItem = Object.values(settingsBody.tabs)
-    .flat()
-    .find((item) => item.key === 'semantic_search_rate_limit');
+  const settingsItems = Object.values(settingsBody.tabs).flat();
+
+  const rateLimitItem = settingsItems.find((item) => item.key === 'semantic_search_rate_limit');
   expect(
     rateLimitItem,
     'semantic_search_rate_limit setting not found in /settings/all/',
@@ -676,26 +687,97 @@ test('S11 — burst of unique semantic queries gets rate-limited', async ({ requ
   const configuredLimit = Number(rateLimitItem?.value);
   expect(Number.isFinite(configuredLimit) && configuredLimit > 0).toBe(true);
 
-  // The e2e suite shares one admin session across parallel specs, so this
-  // deliberately does NOT set/restore the limit -- mutating a global setting
-  // here would race whatever else is reading it concurrently. A configured
-  // ceiling above 200 would make this test send hundreds of load-generating
-  // requests just to find the boundary; fail loudly with the observed value
-  // instead of doing that silently.
-  const REQUEST_CEILING = 200;
+  const globalLimitItem = settingsItems.find((item) => item.key === 'global_rate_limit');
+  expect(globalLimitItem, 'global_rate_limit setting not found in /settings/all/').toBeTruthy();
+  const globalLimit = Number(globalLimitItem?.value);
+  expect(Number.isFinite(globalLimit) && globalLimit > 0).toBe(true);
+
+  // The global limiter is per-second; over any 60s window it admits
+  // `globalLimit * 60` requests at most. If the per-route limit is at or
+  // above that, the global bucket empties no later than the route bucket
+  // does, so a 429 late in the burst cannot be attributed to one limiter
+  // over the other by construction -- no pacing or body-text check fixes
+  // that. Fail loudly (not test.skip) naming both values: a skip here would
+  // hide exactly the kind of "passes for the wrong reason" gap this test
+  // has been rebuilt four times to close.
   expect(
     configuredLimit,
-    `semantic_search_rate_limit is ${configuredLimit}, above this test's ` +
-      `${REQUEST_CEILING}-request ceiling -- raise the ceiling deliberately ` +
-      'or lower the configured limit for this environment',
-  ).toBeLessThanOrEqual(REQUEST_CEILING);
+    `semantic_search_rate_limit is ${configuredLimit}/minute, not below the ` +
+      `global_rate_limit's ${globalLimit}/second (${globalLimit * 60}/minute ` +
+      'equivalent) -- this test cannot tell which limiter answered a 429 ' +
+      'when the global bucket cannot outlast the route bucket. Raise ' +
+      'global_rate_limit or lower semantic_search_rate_limit for this ' +
+      'environment.',
+  ).toBeLessThan(globalLimit * 60);
 
+  // The e2e suite shares one admin session across parallel specs, so this
+  // deliberately does NOT set/restore either setting -- mutating a global
+  // setting here would race whatever else is reading it concurrently.
   const requestCount = configuredLimit + 1;
-  const responses = await Promise.all(
-    Array.from({ length: requestCount }, (_, i) =>
-      request.get(`${apiBase}/search/datasets/?q=sec-audit-S11-unique-token-${i}`)
-    ),
-  );
-  const statuses = responses.map((r) => r.status());
-  expect(statuses).toContain(429);
+
+  // Pace the burst at 40 requests/second, comfortably under
+  // _DEFAULT_GLOBAL_RATE_LIMIT (60/second, platform/ratelimit.py) so this
+  // test's own traffic cannot trip the global limiter. That is a fixed
+  // pacing choice, not adaptive: an environment with global_rate_limit
+  // deliberately lowered below 40 would fire the global limiter here too,
+  // but that is a separate, unrelated deployment choice this test does not
+  // attempt to detect -- the discriminability guard above only covers
+  // whether the per-route limit can outlast the global one, not whether
+  // this pacing outruns a nonstandard global setting.
+  const BATCH_SIZE = 40;
+  const rateLimitBodies: Array<{ detail?: string }> = [];
+  let sawOtherStatus = false;
+
+  // A batch of up to BATCH_SIZE concurrent requests can transiently exceed
+  // the dev DB pool (SQLAlchemy's default is 10 + 3 overflow = 13
+  // connections) before the rate limiter has rejected the requests over
+  // configuredLimit -- verified directly against this stack's own logs:
+  // `sqlalchemy.exc.TimeoutError: QueuePool limit of size 10 overflow 3
+  // reached`, surfacing as a 500. That is pool contention, not the search
+  // endpoint or the rate limiter behaving incorrectly, so retry a 5xx (never
+  // a 429, which is a real answer) a couple of times before treating it as
+  // a genuine failure.
+  async function getWithRetry(url: string) {
+    let res = await request.get(url);
+    for (let attempt = 0; attempt < 2 && res.status() >= 500; attempt += 1) {
+      await new Promise((resolve) => setTimeout(resolve, 250 * (attempt + 1)));
+      res = await request.get(url);
+    }
+    return res;
+  }
+
+  for (let sent = 0; sent < requestCount; sent += BATCH_SIZE) {
+    const batchSize = Math.min(BATCH_SIZE, requestCount - sent);
+    const batch = await Promise.all(
+      Array.from({ length: batchSize }, (_, i) => {
+        const index = sent + i;
+        return getWithRetry(`${apiBase}/search/datasets/?q=sec-audit-S11-unique-token-${index}`);
+      }),
+    );
+    for (const res of batch) {
+      if (res.status() === 429) {
+        rateLimitBodies.push((await res.json()) as { detail?: string });
+      } else if (res.status() !== 200) {
+        sawOtherStatus = true;
+      }
+    }
+    if (sent + BATCH_SIZE < requestCount) {
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+    }
+  }
+
+  expect(sawOtherStatus, 'every non-429 response should be a plain 200').toBe(false);
+  expect(rateLimitBodies.length, 'burst should trigger at least one 429').toBeGreaterThan(0);
+
+  // Distinguish which limiter answered: slowapi's RateLimitExceeded detail
+  // is str(limits.RateLimitItem) -- "<N> per 1 minute" for the per-route
+  // limit under test, "<N> per 1 second" for the global one. Paced under
+  // BATCH_SIZE/second, only the route limiter should ever fire, but assert
+  // that directly rather than assuming the pacing alone proves it.
+  const routeLimitText = `${configuredLimit} per 1 minute`;
+  const matchedRouteLimit = rateLimitBodies.some((body) => body.detail === routeLimitText);
+  expect(
+    matchedRouteLimit,
+    `expected a 429 naming "${routeLimitText}"; got: ${JSON.stringify(rateLimitBodies)}`,
+  ).toBe(true);
 });

--- a/e2e/sec-audit.spec.ts
+++ b/e2e/sec-audit.spec.ts
@@ -192,12 +192,17 @@ test('S01 STAC visibility — anonymous cannot read a private raster STAC item',
 test('S01 STAC visibility — anonymous /stac/search does not return private rasters', async ({ request }) => {
   const recordId = privateRasterId;
   const res = await request.get(`${apiBase}/stac/search?ids=${recordId}`);
-  // Either denied (401/403) or empty features list — never the private item back
+  // fix(review #1792 round 3): this `if` had no `else` -- any non-200 status
+  // (including a 500) fell through with no assertion at all, so a broken
+  // endpoint passed silently. Either denied (401/403/404) or an empty
+  // features list -- never the private item back.
   if (res.status() === 200) {
     const body = await res.json();
     const features = body.features ?? [];
     const hit = features.find((f: { id: string }) => f.id === recordId);
     expect(hit).toBeUndefined();
+  } else {
+    expect([401, 403, 404]).toContain(res.status());
   }
 });
 
@@ -225,6 +230,13 @@ test('S02 IDOR — editor B cannot PATCH another user\'s private dataset', async
 });
 
 test('S02 IDOR — editor B cannot DELETE another user\'s private dataset', async ({ request }) => {
+  // fix(review #1792 round 3): the positive control below calls
+  // seedDataset(), which alone can poll for up to 60s (helpers/catalog.ts's
+  // seedFixtureDataset) -- the same 60s as Playwright's default TEST
+  // timeout, with nothing left over for the denial request, the owner
+  // delete, or cleanup. test.slow() triples it.
+  test.slow();
+
   const datasetId = privateDatasetId;
   const tokenB = editorBToken;
   // fix(review #1792): delete_dataset_endpoint requires a DatasetDeleteRequest
@@ -486,8 +498,22 @@ test('S08 — embed frame-policy endpoint reflects the actual embed-token state'
     // (422), not the service-layer ValueError->400 conversion in
     // create_embed_token_endpoint -- confirmed against the live endpoint.
     expect(restrictedRes.status()).toBe(422);
-    const body = (await restrictedRes.json()) as { detail?: string };
-    expect(body.detail).toContain('Advanced sharing controls');
+    const body = (await restrictedRes.json()) as { detail?: unknown };
+    // fix(review #1792 round 3): a vanilla FastAPI 422 body has `detail` as
+    // an array of {loc, msg, type} objects, and `expect(array).toContain(
+    // 'a substring')` compares array ELEMENTS for equality -- against
+    // objects, that never matches, so the check would always pass or always
+    // fail depending on framework defaults rather than on the actual error
+    // text. Verified directly against this endpoint (probed with curl and
+    // read api/main.py's global RequestValidationError override) that
+    // GeoLens flattens every 422 to a single `detail` STRING via the
+    // problem+json ProblemDetail handler in standards/ogc/errors.py, which
+    // its own docstring says applies to "every other operation" beyond the
+    // OGC/STAC paths it was written for -- so `body.detail` is a string
+    // here today. Stringify defensively anyway so this keeps working
+    // unchanged if that ever becomes an array for this endpoint specifically.
+    const detailText = typeof body.detail === 'string' ? body.detail : JSON.stringify(body.detail);
+    expect(detailText).toContain('Advanced sharing controls');
   }
 
   // Smoke check only: the viewer shell itself still loads for a plain share
@@ -516,6 +542,105 @@ test('S09 — dataset export -where rejects UNION / subqueries', async ({ reques
     `${apiBase}/datasets/${datasetId}/export?format=csv&where=${encodeURIComponent(malicious)}`,
   );
   expect([400, 422, 403]).toContain(res.status());
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// S13 — /search/facets/ rejects oversized q
+// ─────────────────────────────────────────────────────────────────────────────
+
+test('S13 — /search/facets/ rejects q longer than 1000 chars', async ({ request }) => {
+  const longQ = 'a'.repeat(5000);
+  const res = await request.get(`${apiBase}/search/facets/?q=${encodeURIComponent(longQ)}`);
+  // After fix: 422 (Pydantic validation). Pre-fix: 200 with seq-scan.
+  // fix(review #1792 round 3): dropped 429 tolerance -- it was only ever
+  // defensive against the S11 burst test running before this one and
+  // saturating the rate limiter; S11 now runs last in this file (see its
+  // section below), and /search/facets/ carries no semantic-search
+  // per-route limit of its own (WR-02, search/router.py) to begin with.
+  expect([400, 422]).toContain(res.status());
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Hygiene regression — ensure SQL injection sentinels remain blocked
+// ─────────────────────────────────────────────────────────────────────────────
+
+test('hygiene — SQLi sentinel in search q does not crash or return all rows', async ({ request }) => {
+  // fix(review #1792 round 3): accepting [400, 422, 429] alongside 200, with
+  // the actual shape check only inside `if (status === 200)`, meant this
+  // test could pass on a 429 from the S11 burst test above without ever
+  // reading the response body -- so it verified nothing about the sentinel.
+  // S11 now runs last in this file, so a plain search string is always
+  // expected to succeed; require 200 and check the shape unconditionally.
+  const res = await request.get(`${apiBase}/search/datasets/?q=` + encodeURIComponent(`' OR '1'='1`));
+  expect(res.status()).toBe(200);
+  const body = await res.json();
+  const features = body.features ?? [];
+  // Sentinel should match nothing; ensure response is bounded (LIMIT 200 cap)
+  expect(features.length).toBeLessThanOrEqual(200);
+});
+
+test('hygiene — pgvector embedding never appears in search response', async ({ request }) => {
+  // fix(review #1792 round 3): the `if (status === 200)` with no `else` let
+  // this pass on any non-200 (a 429 from the S11 burst test above included)
+  // without ever inspecting a single feature. S11 now runs last in this
+  // file, so a plain search string is always expected to succeed.
+  const res = await request.get(`${apiBase}/search/datasets/?q=test`);
+  expect(res.status()).toBe(200);
+  const body = await res.json();
+  const features = body.features ?? [];
+  expect(Array.isArray(features)).toBe(true);
+  for (const f of features) {
+    expect(f.embedding).toBeUndefined();
+    expect(f.vector).toBeUndefined();
+    expect(f.properties?.embedding).toBeUndefined();
+    expect(f.properties?.vector).toBeUndefined();
+  }
+});
+
+test('hygiene — pg_trgm operator-abuse handled safely (no syntax error, fast response)', async ({ request }) => {
+  // fix(review #1792 round 3): accepting [200, 400, 422, 429] with no body
+  // check even on 200 meant this test never actually confirmed the query
+  // returned a real, well-formed result -- only that *some* status in a
+  // wide list came back fast. S11 now runs last in this file, so this
+  // operator-abuse string is always expected to succeed like any other
+  // benign query; require 200 and check the response is a real feature
+  // list, not just a fast non-crash.
+  const malicious = '! | !';
+  const start = Date.now();
+  const res = await request.get(`${apiBase}/search/datasets/?q=${encodeURIComponent(malicious)}`);
+  const elapsed = Date.now() - start;
+  expect(elapsed).toBeLessThan(3000);
+  expect(res.status()).toBe(200);
+  const body = await res.json();
+  expect(Array.isArray(body.features)).toBe(true);
+});
+
+test('hygiene — malformed bbox is rejected', async ({ request }) => {
+  // fix(review #1792 round 3): dropped 429 tolerance -- only ever defensive
+  // against the S11 burst test running before this one; S11 now runs last.
+  const res = await request.get(`${apiBase}/search/datasets/?bbox=0,0,1`);
+  expect([400, 422]).toContain(res.status());
+});
+
+test('hygiene — CORS does not grant credentials to an untrusted origin', async ({ request }) => {
+  const origin = 'http://attacker.example';
+  const appResponse = await request.get(`${apiBase}/auth/me/`, {
+    headers: { Origin: origin },
+  });
+  expect(appResponse.headers()['access-control-allow-origin']).toBeUndefined();
+  expect(appResponse.headers()['access-control-allow-credentials']).toBeUndefined();
+
+  // Anonymous standards routes may use a wildcard, but never with credentials.
+  const standardsResponse = await request.get(`${apiBase}/`, {
+    headers: { Origin: 'http://attacker.example' },
+  });
+  const standardsOrigin = standardsResponse.headers()['access-control-allow-origin'];
+  expect(standardsOrigin).not.toBe(origin);
+  if (standardsOrigin === '*') {
+    expect(
+      standardsResponse.headers()['access-control-allow-credentials'],
+    ).toBeUndefined();
+  }
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -573,81 +698,4 @@ test('S11 — burst of unique semantic queries gets rate-limited', async ({ requ
   );
   const statuses = responses.map((r) => r.status());
   expect(statuses).toContain(429);
-});
-
-// ─────────────────────────────────────────────────────────────────────────────
-// S13 — /search/facets/ rejects oversized q
-// ─────────────────────────────────────────────────────────────────────────────
-
-test('S13 — /search/facets/ rejects q longer than 1000 chars', async ({ request }) => {
-  const longQ = 'a'.repeat(5000);
-  const res = await request.get(`${apiBase}/search/facets/?q=${encodeURIComponent(longQ)}`);
-  // After fix: 422 (Pydantic validation). Pre-fix: 200 with seq-scan.
-  // 429: the S11 burst test above can leave the per-IP rate limiter saturated
-  // within the same window — a safe rejection still satisfies this hygiene check.
-  expect([400, 422, 429]).toContain(res.status());
-});
-
-// ─────────────────────────────────────────────────────────────────────────────
-// Hygiene regression — ensure SQL injection sentinels remain blocked
-// ─────────────────────────────────────────────────────────────────────────────
-
-test('hygiene — SQLi sentinel in search q does not crash or return all rows', async ({ request }) => {
-  const res = await request.get(`${apiBase}/search/datasets/?q=` + encodeURIComponent(`' OR '1'='1`));
-  expect([200, 400, 422, 429]).toContain(res.status()); // 429: safe rate-limit rejection (S11 burst bleed)
-  if (res.status() === 200) {
-    const body = await res.json();
-    const features = body.features ?? [];
-    // Sentinel should match nothing; ensure response is bounded (LIMIT 200 cap)
-    expect(features.length).toBeLessThanOrEqual(200);
-  }
-});
-
-test('hygiene — pgvector embedding never appears in search response', async ({ request }) => {
-  const res = await request.get(`${apiBase}/search/datasets/?q=test`);
-  if (res.status() === 200) {
-    const body = await res.json();
-    const features = body.features ?? [];
-    for (const f of features) {
-      expect(f.embedding).toBeUndefined();
-      expect(f.vector).toBeUndefined();
-      expect(f.properties?.embedding).toBeUndefined();
-      expect(f.properties?.vector).toBeUndefined();
-    }
-  }
-});
-
-test('hygiene — pg_trgm operator-abuse handled safely (no syntax error, fast response)', async ({ request }) => {
-  const malicious = '! | !';
-  const start = Date.now();
-  const res = await request.get(`${apiBase}/search/datasets/?q=${encodeURIComponent(malicious)}`);
-  const elapsed = Date.now() - start;
-  expect(elapsed).toBeLessThan(3000);
-  expect([200, 400, 422, 429]).toContain(res.status()); // 429: safe rate-limit rejection (S11 burst bleed)
-});
-
-test('hygiene — malformed bbox is rejected', async ({ request }) => {
-  const res = await request.get(`${apiBase}/search/datasets/?bbox=0,0,1`);
-  expect([400, 422, 429]).toContain(res.status()); // 429: safe rate-limit rejection (S11 burst bleed)
-});
-
-test('hygiene — CORS does not grant credentials to an untrusted origin', async ({ request }) => {
-  const origin = 'http://attacker.example';
-  const appResponse = await request.get(`${apiBase}/auth/me/`, {
-    headers: { Origin: origin },
-  });
-  expect(appResponse.headers()['access-control-allow-origin']).toBeUndefined();
-  expect(appResponse.headers()['access-control-allow-credentials']).toBeUndefined();
-
-  // Anonymous standards routes may use a wildcard, but never with credentials.
-  const standardsResponse = await request.get(`${apiBase}/`, {
-    headers: { Origin: 'http://attacker.example' },
-  });
-  const standardsOrigin = standardsResponse.headers()['access-control-allow-origin'];
-  expect(standardsOrigin).not.toBe(origin);
-  if (standardsOrigin === '*') {
-    expect(
-      standardsResponse.headers()['access-control-allow-credentials'],
-    ).toBeUndefined();
-  }
 });

--- a/e2e/sec-audit.spec.ts
+++ b/e2e/sec-audit.spec.ts
@@ -49,82 +49,121 @@ function adminHeaders(): Record<string, string> {
 }
 
 test.beforeAll(async () => {
+  // fix(review #1792 round 2): this hook used to seed five fixtures
+  // sequentially. The two ingest-backed ones alone (raster + private
+  // vector) can each poll for up to 60s (helpers/catalog.ts's
+  // seedFixtureDataset), so a slow worker could blow past Playwright's
+  // default 60s hook timeout before the public-dataset ingest even started.
+  // The five fixtures below are independent of each other, so run them
+  // concurrently -- real wall-clock is bounded by the single slowest chain,
+  // not the sum -- and set an explicit hook timeout as a margin on top of
+  // that for a loaded CI runner.
+  test.setTimeout(240_000);
+
   const headers = adminHeaders();
 
-  // S01: private, published raster. The STAC /stac/items/{id} endpoint uses
-  // Dataset.id as the item id (backend/tests/test_stac_visibility.py), and
-  // ingest defaults a new dataset to visibility=private, record_status=published.
-  const raster = await seedDemDataset();
-  privateRasterId = raster.id;
-  privateRasterTitle = raster.title;
+  const seedRaster = async () => {
+    // S01: private, published raster. The STAC /stac/items/{id} endpoint
+    // uses Dataset.id as the item id (backend/tests/test_stac_visibility.py),
+    // and ingest defaults a new dataset to visibility=private,
+    // record_status=published.
+    const raster = await seedDemDataset();
+    privateRasterId = raster.id;
+    privateRasterTitle = raster.title;
+  };
 
-  // S02/S03/S05: private vector dataset owned by the seeding admin account.
-  const priv = await seedDataset('Sec Audit Private');
-  privateDatasetId = priv.id;
-  privateDatasetTitle = priv.title;
+  const seedPrivate = async () => {
+    // S02/S03/S05: private vector dataset owned by the seeding admin account.
+    const priv = await seedDataset('Sec Audit Private');
+    privateDatasetId = priv.id;
+    privateDatasetTitle = priv.title;
+  };
 
-  // S09: public, published vector dataset.
-  const pub = await seedDataset('Sec Audit Public');
-  publicDatasetId = pub.id;
-  publicDatasetTitle = pub.title;
-  const publishRes = await fetch(`${apiBase}/datasets/${publicDatasetId}`, {
-    method: 'PATCH',
-    headers,
-    body: JSON.stringify({ visibility: 'public', record_status: 'published' }),
-  });
-  if (!publishRes.ok) {
-    throw new Error(`sec-audit: could not publish public dataset: ${publishRes.status}`);
-  }
+  const seedPublic = async () => {
+    // S09: public, published vector dataset.
+    const pub = await seedDataset('Sec Audit Public');
+    publicDatasetId = pub.id;
+    publicDatasetTitle = pub.title;
+    const publishRes = await fetch(`${apiBase}/datasets/${publicDatasetId}`, {
+      method: 'PATCH',
+      headers,
+      body: JSON.stringify({ visibility: 'public', record_status: 'published' }),
+    });
+    if (!publishRes.ok) {
+      throw new Error(`sec-audit: could not publish public dataset: ${publishRes.status}`);
+    }
+  };
 
-  // S02/S03: a second, non-admin editor who owns neither dataset above.
-  const editorBUsername = `sec-audit-editor-b-${Date.now()}`;
-  const editorBPassword = 'Sec-Audit-Editor-B-42';
-  const createUserRes = await fetch(`${apiBase}/admin/users/`, {
-    method: 'POST',
-    headers,
-    body: JSON.stringify({ username: editorBUsername, password: editorBPassword, role: 'editor' }),
-  });
-  if (!createUserRes.ok) {
-    throw new Error(`sec-audit: could not create editor B: ${createUserRes.status}`);
-  }
-  editorBUserId = ((await createUserRes.json()) as { id: string }).id;
+  const seedEditorB = async () => {
+    // S02/S03: a second, non-admin editor who owns neither dataset above.
+    const editorBUsername = `sec-audit-editor-b-${Date.now()}`;
+    const editorBPassword = 'Sec-Audit-Editor-B-42';
+    const createUserRes = await fetch(`${apiBase}/admin/users/`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({ username: editorBUsername, password: editorBPassword, role: 'editor' }),
+    });
+    if (!createUserRes.ok) {
+      throw new Error(`sec-audit: could not create editor B: ${createUserRes.status}`);
+    }
+    editorBUserId = ((await createUserRes.json()) as { id: string }).id;
 
-  const loginRes = await fetch(`${apiBase}/auth/login/`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-    body: new URLSearchParams({ username: editorBUsername, password: editorBPassword }).toString(),
-  });
-  if (!loginRes.ok) {
-    throw new Error(`sec-audit: could not log in editor B: ${loginRes.status}`);
-  }
-  editorBToken = ((await loginRes.json()) as { access_token: string }).access_token;
+    const loginRes = await fetch(`${apiBase}/auth/login/`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({ username: editorBUsername, password: editorBPassword }).toString(),
+    });
+    if (!loginRes.ok) {
+      throw new Error(`sec-audit: could not log in editor B: ${loginRes.status}`);
+    }
+    editorBToken = ((await loginRes.json()) as { access_token: string }).access_token;
+  };
 
-  // S08: a public map with a share token.
-  const mapRes = await fetch(`${apiBase}/maps/`, {
-    method: 'POST',
-    headers,
-    body: JSON.stringify({ name: `Sec Audit Share Map ${Date.now()}` }),
-  });
-  if (!mapRes.ok) {
-    throw new Error(`sec-audit: could not create share map: ${mapRes.status}`);
-  }
-  shareMapId = ((await mapRes.json()) as { id: string }).id;
-  const mapPublishRes = await fetch(`${apiBase}/maps/${shareMapId}`, {
-    method: 'PUT',
-    headers,
-    body: JSON.stringify({ visibility: 'public' }),
-  });
-  if (!mapPublishRes.ok) {
-    throw new Error(`sec-audit: could not publish share map: ${mapPublishRes.status}`);
-  }
-  const shareRes = await fetch(`${apiBase}/maps/${shareMapId}/share/`, {
-    method: 'POST',
-    headers,
-  });
-  if (!shareRes.ok) {
-    throw new Error(`sec-audit: could not create share token: ${shareRes.status}`);
-  }
-  shareToken = ((await shareRes.json()) as { token: string }).token;
+  const seedShareMap = async () => {
+    // S08: a public map with a share token and one layer -- create_embed_token
+    // (embed_tokens/service.py) refuses to mint a token for a map with no
+    // layers ("Map has no layers to scope"), so this needs publicDatasetId
+    // from seedPublic() above. Sequenced after the concurrent batch below
+    // rather than folded into it: the map/layer/publish/share calls here are
+    // all sub-second, so waiting for the one ingest this chain actually
+    // depends on costs nothing worth parallelizing further.
+    const mapRes = await fetch(`${apiBase}/maps/`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({ name: `Sec Audit Share Map ${Date.now()}` }),
+    });
+    if (!mapRes.ok) {
+      throw new Error(`sec-audit: could not create share map: ${mapRes.status}`);
+    }
+    shareMapId = ((await mapRes.json()) as { id: string }).id;
+    const layerRes = await fetch(`${apiBase}/maps/${shareMapId}/layers`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({ dataset_id: publicDatasetId }),
+    });
+    if (!layerRes.ok) {
+      throw new Error(`sec-audit: could not add share map layer: ${layerRes.status}`);
+    }
+    const mapPublishRes = await fetch(`${apiBase}/maps/${shareMapId}`, {
+      method: 'PUT',
+      headers,
+      body: JSON.stringify({ visibility: 'public' }),
+    });
+    if (!mapPublishRes.ok) {
+      throw new Error(`sec-audit: could not publish share map: ${mapPublishRes.status}`);
+    }
+    const shareRes = await fetch(`${apiBase}/maps/${shareMapId}/share/`, {
+      method: 'POST',
+      headers,
+    });
+    if (!shareRes.ok) {
+      throw new Error(`sec-audit: could not create share token: ${shareRes.status}`);
+    }
+    shareToken = ((await shareRes.json()) as { token: string }).token;
+  };
+
+  await Promise.all([seedRaster(), seedPrivate(), seedPublic(), seedEditorB()]);
+  await seedShareMap();
 });
 
 test.afterAll(async () => {
@@ -346,22 +385,120 @@ test('S06 — admin user with known-public password "demodemo" cannot log in', a
 // S08 — Embed-token framing (after fix: per-token frame-ancestors CSP exists)
 // ─────────────────────────────────────────────────────────────────────────────
 
-test('S08 — /m/<share_token> HTML response has frame-ancestors CSP (or is admin-restricted)', async ({ request }) => {
-  // The frontend host serves /m/* — derive from API base
-  const frontendBase = process.env.SEC_AUDIT_FRONTEND_URL || 'http://localhost:8080';
-  const res = await request.get(`${frontendBase}/m/${shareToken}?embed=true`, {
+test('S08 — embed frame-policy endpoint reflects the actual embed-token state', async ({ request }) => {
+  // fix(review #1792 round 2): the edge reads the embed token from the `et`
+  // query param, not the share token in the path (frontend/nginx.conf's
+  // `location ~ ^/m/` forwards $arg_et to /embed/frame-policy). Without
+  // `et`, embed_frame_policy (public_router.py) always emits NO
+  // frame-ancestors directive at all -- so the old assertion passed only
+  // because X-Frame-Options is intentionally omitted on this route (see the
+  // nginx SEC-S08 comment), never because a real per-token policy was
+  // exercised.
+  //
+  // Implementing that fix surfaced a further problem: the nginx `auth_request`
+  // wiring that injects this CSP onto /m/* is PRODUCTION-only (the root
+  // Dockerfile builds nginx + frontend/nginx.conf). docker-compose.yml's dev
+  // stack -- what E2E_ALLOW_WORKTREE runs against, and what CI's own
+  // e2e-test/e2e-smoke jobs run against -- serves the frontend straight off
+  // Vite's dev server (frontend/Dockerfile.dev), which has no auth_request
+  // wiring and emits no CSP for /m/* at all, for ANY token. Confirmed
+  // directly: `curl -D- 'http://localhost:8080/m/<token>?embed=true&et=<any
+  // value>'` returns 200 with no Content-Security-Policy header whatsoever,
+  // valid token, invalid token, or none. So a request against
+  // `${frontendBase}/m/...` can never exercise the real policy in this
+  // environment, no matter what fixtures this test creates.
+  //
+  // /api/embed/frame-policy (public_router.py) IS the actual policy logic,
+  // reachable directly regardless of which edge fronts it -- its own
+  // docstring says so: "correct when the API is hit without the edge in
+  // front". Test against it directly instead, so the token-validation and
+  // allowed-origins logic is genuinely exercised.
+  const headers = adminHeaders();
+
+  async function fetchFramePolicy(token?: string) {
+    const query = token ? `?token=${encodeURIComponent(token)}` : '';
+    return request.get(`${apiBase}/embed/frame-policy${query}`);
+  }
+
+  // No token: documented behavior (embed_frame_policy's `if not token:`
+  // branch) is open framing, no frame-ancestors directive emitted at all --
+  // assert exactly that, as its own case, rather than folding it into the
+  // token-present checks below.
+  const plainRes = await fetchFramePolicy();
+  expect(plainRes.status()).toBe(200);
+  expect(plainRes.headers()['content-security-policy'] || '').not.toContain('frame-ancestors');
+  expect(plainRes.headers()['x-embed-frame-ancestors'] ?? '').toBe('');
+
+  // A garbage token (present but not real): fail-closed 'none'. This is the
+  // strongest, edition-independent proof that the endpoint actually
+  // validates the token rather than always leaving framing open.
+  const garbageRes = await fetchFramePolicy('sec-audit-s08-not-a-real-token');
+  expect(garbageRes.status()).toBe(200);
+  expect(garbageRes.headers()['content-security-policy'] || '').toContain("frame-ancestors 'none'");
+  expect(garbageRes.headers()['x-embed-frame-ancestors']).toBe("frame-ancestors 'none'");
+
+  // A real, unrestricted embed token (the only kind a Community deployment
+  // can mint -- see the domain-restricted branch below) is VALID but has no
+  // allowed_origins, so it also produces open framing. Together with the
+  // garbage-token case above, this distinguishes "valid but unrestricted"
+  // from "invalid", which the CSP output alone cannot on its own.
+  const unrestrictedRes = await request.post(`${apiBase}/maps/${shareMapId}/embed-tokens/`, {
+    headers,
+    data: {},
+  });
+  expect(unrestrictedRes.ok()).toBeTruthy();
+  const unrestrictedToken = ((await unrestrictedRes.json()) as { raw_token: string }).raw_token;
+  const unrestrictedPolicyRes = await fetchFramePolicy(unrestrictedToken);
+  expect(unrestrictedPolicyRes.status()).toBe(200);
+  expect(
+    unrestrictedPolicyRes.headers()['content-security-policy'] || '',
+  ).not.toContain('frame-ancestors');
+  expect(unrestrictedPolicyRes.headers()['x-embed-frame-ancestors'] ?? '').toBe('');
+
+  // A domain-restricted embed token is an advanced-sharing capability gated
+  // by is_enterprise() (embed_tokens/service.py's create_embed_token). This
+  // dev stack runs Community edition (GET /api/settings/edition/), which
+  // cannot mint one at all -- test.skip()ing that case would reproduce
+  // exactly the "permanently skipped, never proven" pattern the rest of
+  // this file was rebuilt to eliminate. Instead: attempt the creation
+  // regardless of edition and branch on the actual response, so this
+  // assertion is meaningful either way and needs no skip.
+  const restrictedOrigin = 'https://sec-audit-allowed.example';
+  const restrictedRes = await request.post(`${apiBase}/maps/${shareMapId}/embed-tokens/`, {
+    headers,
+    data: { allowed_origins: [restrictedOrigin] },
+  });
+  if (restrictedRes.status() === 201) {
+    // Enterprise: the domain lock actually applies -- the allowed origin
+    // must be named in frame-ancestors.
+    const restrictedToken = ((await restrictedRes.json()) as { raw_token: string }).raw_token;
+    const restrictedPolicyRes = await fetchFramePolicy(restrictedToken);
+    expect(restrictedPolicyRes.status()).toBe(200);
+    expect(restrictedPolicyRes.headers()['content-security-policy'] || '').toContain(
+      `frame-ancestors 'self' ${restrictedOrigin}`,
+    );
+  } else {
+    // Community (this stack): the advanced-sharing capability gate is the
+    // thing under test here -- it must actively refuse a domain lock, not
+    // silently downgrade it to an unrestricted token. EmbedTokenCreate's own
+    // @model_validator (schemas.py) checks is_enterprise() before the
+    // handler body ever runs, so this is a Pydantic validation failure
+    // (422), not the service-layer ValueError->400 conversion in
+    // create_embed_token_endpoint -- confirmed against the live endpoint.
+    expect(restrictedRes.status()).toBe(422);
+    const body = (await restrictedRes.json()) as { detail?: string };
+    expect(body.detail).toContain('Advanced sharing controls');
+  }
+
+  // Smoke check only: the viewer shell itself still loads for a plain share
+  // in this environment (no CSP assertion here -- see the module comment
+  // above for why that specific header cannot be exercised via this route
+  // outside a production nginx deployment).
+  const frontendBase = process.env.SEC_AUDIT_FRONTEND_URL || BASE_URL;
+  const shellRes = await request.get(`${frontendBase}/m/${shareToken}?embed=true`, {
     headers: { Accept: 'text/html' },
   });
-  if (res.status() === 200) {
-    // After S08 fix: either CSP frame-ancestors carries the embed-token's allowed_origins,
-    // or the response is admin-only (no public embed). DENY/SAMEORIGIN with no CSP is the pre-fix state.
-    const csp = res.headers()['content-security-policy'] || '';
-    const xfo = res.headers()['x-frame-options'] || '';
-    const hasFrameAncestors = csp.includes('frame-ancestors');
-    const isRestrictive = ['DENY', 'SAMEORIGIN'].includes(xfo.toUpperCase());
-    // Fail only the pre-fix state: SAMEORIGIN+no CSP frame-ancestors (= product contradiction)
-    expect(hasFrameAncestors || !isRestrictive).toBe(true);
-  }
+  expect(shellRes.status()).toBe(200);
 });
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/e2e/sec-audit.spec.ts
+++ b/e2e/sec-audit.spec.ts
@@ -538,10 +538,30 @@ test('S09 — dataset export -where rejects UNION / subqueries', async ({ reques
   // /datasets/{id}/export.csv (backend/openapi.json has no such path) — the
   // old URL always 404'd before the -where parser ever ran, which the
   // permanent skip guard hid.
+
+  // Positive control: the identical anonymous request, with no `where` at
+  // all, against the same public/published dataset. publicDatasetId is
+  // published by beforeAll (see the seedPublic PATCH above), and the
+  // export route resolves the caller through get_optional_user + a
+  // check_dataset_access_or_anonymous gate (processing/export/router.py),
+  // so a plain export of a public dataset must succeed anonymously. This
+  // proves any 403 below would come from validate_where_clause() rejecting
+  // the malicious clause -- not from an anonymous-export authorization
+  // regression that would 403 every request here regardless of `where`,
+  // silently satisfying this test without the parser ever running.
+  const controlRes = await request.get(`${apiBase}/datasets/${datasetId}/export?format=csv`);
+  expect(controlRes.ok(), 'positive control: anonymous export of a public dataset must succeed').toBeTruthy();
+
   const res = await request.get(
     `${apiBase}/datasets/${datasetId}/export?format=csv&where=${encodeURIComponent(malicious)}`,
   );
-  expect([400, 422, 403]).toContain(res.status());
+  // fix(review #1792 round 9): 403 dropped from the accepted set -- with the
+  // positive control above proving the route is reachable anonymously, a
+  // 403 here can only mean the malicious `where` never reached
+  // validate_where_clause() at all (e.g. an authorization regression that
+  // 403s the export before parsing), which is precisely the UNION/subquery
+  // defense this test exists to exercise.
+  expect([400, 422]).toContain(res.status());
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -568,38 +588,24 @@ test('S13 — /search/facets/ rejects q longer than 1000 chars', async ({ reques
 // /search/datasets/ route (malformed-bbox included -- same endpoint, a
 // `bbox` param rather than `q`), so their combined request count competes
 // for the same per-route bucket as every other test in this file that hits
-// it. Round 3 fixed this by moving the burst test (S11, now a single-request
-// smoke at the end of this file) after these so it could not exhaust the
-// bucket first; round 5 removes the remaining assumption that "S11 runs
-// last" makes 200 the only possible outcome here, since a deployment can
-// configure semantic_search_rate_limit low enough that these four requests
-// alone exceed it. Read the configured limit once, and treat a 429 whose
-// body names a per-minute limit as an equally valid outcome for these
-// specific requests whenever the limit cannot possibly cover all of them --
-// no pacing, no burst, no ceiling.
+// it.
+//
+// fix(review #1792 round 9): round 5's "accept a 429 only when the
+// configured limit is below this describe block's own request count" logic
+// assumed this describe block is the only source of traffic against the
+// bucket. It is not: in a full nightly run, search.spec.ts also hits
+// /search/datasets/ against the same server (and, if the limiter keys on
+// IP rather than per-user, the same bucket), so a configured limit that
+// comfortably covers these four requests ALONE can still be exhausted by
+// the time they run, and an unconditional `expect(200)` would then fail a
+// perfectly healthy rate limiter. There is no configured-limit threshold
+// that can rule this out, since it depends on traffic this suite doesn't
+// control -- so a 429 is accepted here unconditionally, gated only on it
+// actually looking like the per-route semantic-search limiter (a
+// `Retry-After` header, per _rate_limit_handler in api/main.py, plus a
+// detail naming a per-minute limit) rather than some other failure mode.
+// No pacing, no burst, no settings lookup, no ceiling.
 test.describe('Hygiene — /search/datasets/ requests', () => {
-  const HYGIENE_REQUEST_COUNT = 4;
-  let configuredLimit: number;
-
-  test.beforeAll(async ({ request }) => {
-    const settingsRes = await request.get(`${apiBase}/settings/all/`, {
-      headers: { Authorization: `Bearer ${getAuthToken()}` },
-    });
-    expect(settingsRes.ok()).toBeTruthy();
-    const settingsBody = (await settingsRes.json()) as {
-      tabs: Record<string, Array<{ key: string; value: unknown }>>;
-    };
-    const rateLimitItem = Object.values(settingsBody.tabs)
-      .flat()
-      .find((item) => item.key === 'semantic_search_rate_limit');
-    expect(
-      rateLimitItem,
-      'semantic_search_rate_limit setting not found in /settings/all/',
-    ).toBeTruthy();
-    configuredLimit = Number(rateLimitItem?.value);
-    expect(Number.isFinite(configuredLimit) && configuredLimit > 0).toBe(true);
-  });
-
   // Returns the parsed body when the request is accepted (200), or null when
   // it was rejected by the rate limiter in a way this suite has decided is
   // an acceptable outcome for these specific requests (see the describe-level
@@ -607,7 +613,8 @@ test.describe('Hygiene — /search/datasets/ requests', () => {
   async function expectAcceptedOrRateLimited(
     res: Awaited<ReturnType<import('@playwright/test').APIRequestContext['get']>>,
   ): Promise<Record<string, unknown> | null> {
-    if (res.status() === 429 && configuredLimit < HYGIENE_REQUEST_COUNT + 1) {
+    if (res.status() === 429) {
+      expect(res.headers()['retry-after']).toBeTruthy();
       const body = (await res.json()) as { detail?: string };
       expect(body.detail).toMatch(/ per 1 minute$/);
       return null;
@@ -656,7 +663,8 @@ test.describe('Hygiene — /search/datasets/ requests', () => {
 
   test('malformed bbox is rejected', async ({ request }) => {
     const res = await request.get(`${apiBase}/search/datasets/?bbox=0,0,1`);
-    if (res.status() === 429 && configuredLimit < HYGIENE_REQUEST_COUNT + 1) {
+    if (res.status() === 429) {
+      expect(res.headers()['retry-after']).toBeTruthy();
       const body = (await res.json()) as { detail?: string };
       expect(body.detail).toMatch(/ per 1 minute$/);
       return;

--- a/e2e/sec-audit.spec.ts
+++ b/e2e/sec-audit.spec.ts
@@ -564,62 +564,105 @@ test('S13 — /search/facets/ rejects q longer than 1000 chars', async ({ reques
 // Hygiene regression — ensure SQL injection sentinels remain blocked
 // ─────────────────────────────────────────────────────────────────────────────
 
-test('hygiene — SQLi sentinel in search q does not crash or return all rows', async ({ request }) => {
-  // fix(review #1792 round 3): accepting [400, 422, 429] alongside 200, with
-  // the actual shape check only inside `if (status === 200)`, meant this
-  // test could pass on a 429 from the S11 burst test above without ever
-  // reading the response body -- so it verified nothing about the sentinel.
-  // S11 now runs last in this file, so a plain search string is always
-  // expected to succeed; require 200 and check the shape unconditionally.
-  const res = await request.get(`${apiBase}/search/datasets/?q=` + encodeURIComponent(`' OR '1'='1`));
-  expect(res.status()).toBe(200);
-  const body = await res.json();
-  const features = body.features ?? [];
-  // Sentinel should match nothing; ensure response is bounded (LIMIT 200 cap)
-  expect(features.length).toBeLessThanOrEqual(200);
-});
+// fix(review #1792 round 5): the four tests below all hit the rate-limited
+// /search/datasets/ route (malformed-bbox included -- same endpoint, a
+// `bbox` param rather than `q`), so their combined request count competes
+// for the same per-route bucket as every other test in this file that hits
+// it. Round 3 fixed this by moving the burst test (S11, now a single-request
+// smoke at the end of this file) after these so it could not exhaust the
+// bucket first; round 5 removes the remaining assumption that "S11 runs
+// last" makes 200 the only possible outcome here, since a deployment can
+// configure semantic_search_rate_limit low enough that these four requests
+// alone exceed it. Read the configured limit once, and treat a 429 whose
+// body names a per-minute limit as an equally valid outcome for these
+// specific requests whenever the limit cannot possibly cover all of them --
+// no pacing, no burst, no ceiling.
+test.describe('Hygiene — /search/datasets/ requests', () => {
+  const HYGIENE_REQUEST_COUNT = 4;
+  let configuredLimit: number;
 
-test('hygiene — pgvector embedding never appears in search response', async ({ request }) => {
-  // fix(review #1792 round 3): the `if (status === 200)` with no `else` let
-  // this pass on any non-200 (a 429 from the S11 burst test above included)
-  // without ever inspecting a single feature. S11 now runs last in this
-  // file, so a plain search string is always expected to succeed.
-  const res = await request.get(`${apiBase}/search/datasets/?q=test`);
-  expect(res.status()).toBe(200);
-  const body = await res.json();
-  const features = body.features ?? [];
-  expect(Array.isArray(features)).toBe(true);
-  for (const f of features) {
-    expect(f.embedding).toBeUndefined();
-    expect(f.vector).toBeUndefined();
-    expect(f.properties?.embedding).toBeUndefined();
-    expect(f.properties?.vector).toBeUndefined();
+  test.beforeAll(async ({ request }) => {
+    const settingsRes = await request.get(`${apiBase}/settings/all/`, {
+      headers: { Authorization: `Bearer ${getAuthToken()}` },
+    });
+    expect(settingsRes.ok()).toBeTruthy();
+    const settingsBody = (await settingsRes.json()) as {
+      tabs: Record<string, Array<{ key: string; value: unknown }>>;
+    };
+    const rateLimitItem = Object.values(settingsBody.tabs)
+      .flat()
+      .find((item) => item.key === 'semantic_search_rate_limit');
+    expect(
+      rateLimitItem,
+      'semantic_search_rate_limit setting not found in /settings/all/',
+    ).toBeTruthy();
+    configuredLimit = Number(rateLimitItem?.value);
+    expect(Number.isFinite(configuredLimit) && configuredLimit > 0).toBe(true);
+  });
+
+  // Returns the parsed body when the request is accepted (200), or null when
+  // it was rejected by the rate limiter in a way this suite has decided is
+  // an acceptable outcome for these specific requests (see the describe-level
+  // comment above). Any other outcome fails via the embedded expect() calls.
+  async function expectAcceptedOrRateLimited(
+    res: Awaited<ReturnType<import('@playwright/test').APIRequestContext['get']>>,
+  ): Promise<Record<string, unknown> | null> {
+    if (res.status() === 429 && configuredLimit < HYGIENE_REQUEST_COUNT + 1) {
+      const body = (await res.json()) as { detail?: string };
+      expect(body.detail).toMatch(/ per 1 minute$/);
+      return null;
+    }
+    expect(res.status()).toBe(200);
+    return res.json();
   }
-});
 
-test('hygiene — pg_trgm operator-abuse handled safely (no syntax error, fast response)', async ({ request }) => {
-  // fix(review #1792 round 3): accepting [200, 400, 422, 429] with no body
-  // check even on 200 meant this test never actually confirmed the query
-  // returned a real, well-formed result -- only that *some* status in a
-  // wide list came back fast. S11 now runs last in this file, so this
-  // operator-abuse string is always expected to succeed like any other
-  // benign query; require 200 and check the response is a real feature
-  // list, not just a fast non-crash.
-  const malicious = '! | !';
-  const start = Date.now();
-  const res = await request.get(`${apiBase}/search/datasets/?q=${encodeURIComponent(malicious)}`);
-  const elapsed = Date.now() - start;
-  expect(elapsed).toBeLessThan(3000);
-  expect(res.status()).toBe(200);
-  const body = await res.json();
-  expect(Array.isArray(body.features)).toBe(true);
-});
+  test('SQLi sentinel in search q does not crash or return all rows', async ({ request }) => {
+    const res = await request.get(`${apiBase}/search/datasets/?q=` + encodeURIComponent(`' OR '1'='1`));
+    const body = await expectAcceptedOrRateLimited(res);
+    if (body) {
+      const features = (body.features as unknown[]) ?? [];
+      // Sentinel should match nothing; ensure response is bounded (LIMIT 200 cap)
+      expect(features.length).toBeLessThanOrEqual(200);
+    }
+  });
 
-test('hygiene — malformed bbox is rejected', async ({ request }) => {
-  // fix(review #1792 round 3): dropped 429 tolerance -- only ever defensive
-  // against the S11 burst test running before this one; S11 now runs last.
-  const res = await request.get(`${apiBase}/search/datasets/?bbox=0,0,1`);
-  expect([400, 422]).toContain(res.status());
+  test('pgvector embedding never appears in search response', async ({ request }) => {
+    const res = await request.get(`${apiBase}/search/datasets/?q=test`);
+    const body = await expectAcceptedOrRateLimited(res);
+    if (body) {
+      const features = (body.features as Array<Record<string, unknown>>) ?? [];
+      expect(Array.isArray(features)).toBe(true);
+      for (const f of features) {
+        expect(f.embedding).toBeUndefined();
+        expect(f.vector).toBeUndefined();
+        const properties = f.properties as Record<string, unknown> | undefined;
+        expect(properties?.embedding).toBeUndefined();
+        expect(properties?.vector).toBeUndefined();
+      }
+    }
+  });
+
+  test('pg_trgm operator-abuse handled safely (no syntax error, fast response)', async ({ request }) => {
+    const malicious = '! | !';
+    const start = Date.now();
+    const res = await request.get(`${apiBase}/search/datasets/?q=${encodeURIComponent(malicious)}`);
+    const elapsed = Date.now() - start;
+    expect(elapsed).toBeLessThan(3000);
+    const body = await expectAcceptedOrRateLimited(res);
+    if (body) {
+      expect(Array.isArray(body.features)).toBe(true);
+    }
+  });
+
+  test('malformed bbox is rejected', async ({ request }) => {
+    const res = await request.get(`${apiBase}/search/datasets/?bbox=0,0,1`);
+    if (res.status() === 429 && configuredLimit < HYGIENE_REQUEST_COUNT + 1) {
+      const body = (await res.json()) as { detail?: string };
+      expect(body.detail).toMatch(/ per 1 minute$/);
+      return;
+    }
+    expect([400, 422]).toContain(res.status());
+  });
 });
 
 test('hygiene — CORS does not grant credentials to an untrusted origin', async ({ request }) => {
@@ -647,137 +690,36 @@ test('hygiene — CORS does not grant credentials to an untrusted origin', async
 // S11 — Per-route rate limiting on semantic search
 // ─────────────────────────────────────────────────────────────────────────────
 
-test('S11 — burst of unique semantic queries gets rate-limited', async ({ request }) => {
+test('S11 — /search/datasets/ has semantic-search rate limiting wired (smoke)', async ({ request }) => {
   // fix(#1778): the skip guard used to fire on exactly the outcome this test
   // exists to catch, so it could never go red. The per-route decorator has
   // shipped (search/router.py's search_datasets_endpoint carries
   // @limiter.limit(_semantic_search_rate_limit)) -- gate on it.
   //
-  // fix(review #1792 round 4, final shape): this test has now cost four
-  // rounds -- read the configured limit instead of hardcoding it (round 1),
-  // stop mutating the shared setting (round 1), and now: no hard ceiling on
-  // how high an operator can configure it, paced so the global limiter
-  // cannot fire from our own burst, and a positive assertion that the 429
-  // actually came from the PER-ROUTE limiter rather than the global one.
-  //
-  // Two independent SlowAPI limits apply to every request here:
-  // _global_rate_limit (platform/ratelimit.py, default_limits, no
-  // override_defaults on the route decorator so both stack) and
-  // _semantic_search_rate_limit (the per-route decorator under test). A
-  // Promise.all burst sends everything in one instant, which can trip the
-  // per-SECOND global limiter well before the per-MINUTE route limiter --
-  // and slowapi's 429 body (str(limits.RateLimitItem), e.g. "30 per 1
-  // minute" vs "60 per 1 second") is the only way to tell which one fired.
-  test.slow();
-
-  const settingsRes = await request.get(`${apiBase}/settings/all/`, {
-    headers: { Authorization: `Bearer ${getAuthToken()}` },
-  });
-  expect(settingsRes.ok()).toBeTruthy();
-  const settingsBody = (await settingsRes.json()) as {
-    tabs: Record<string, Array<{ key: string; value: unknown }>>;
-  };
-  const settingsItems = Object.values(settingsBody.tabs).flat();
-
-  const rateLimitItem = settingsItems.find((item) => item.key === 'semantic_search_rate_limit');
-  expect(
-    rateLimitItem,
-    'semantic_search_rate_limit setting not found in /settings/all/',
-  ).toBeTruthy();
-  const configuredLimit = Number(rateLimitItem?.value);
-  expect(Number.isFinite(configuredLimit) && configuredLimit > 0).toBe(true);
-
-  const globalLimitItem = settingsItems.find((item) => item.key === 'global_rate_limit');
-  expect(globalLimitItem, 'global_rate_limit setting not found in /settings/all/').toBeTruthy();
-  const globalLimit = Number(globalLimitItem?.value);
-  expect(Number.isFinite(globalLimit) && globalLimit > 0).toBe(true);
-
-  // The global limiter is per-second; over any 60s window it admits
-  // `globalLimit * 60` requests at most. If the per-route limit is at or
-  // above that, the global bucket empties no later than the route bucket
-  // does, so a 429 late in the burst cannot be attributed to one limiter
-  // over the other by construction -- no pacing or body-text check fixes
-  // that. Fail loudly (not test.skip) naming both values: a skip here would
-  // hide exactly the kind of "passes for the wrong reason" gap this test
-  // has been rebuilt four times to close.
-  expect(
-    configuredLimit,
-    `semantic_search_rate_limit is ${configuredLimit}/minute, not below the ` +
-      `global_rate_limit's ${globalLimit}/second (${globalLimit * 60}/minute ` +
-      'equivalent) -- this test cannot tell which limiter answered a 429 ' +
-      'when the global bucket cannot outlast the route bucket. Raise ' +
-      'global_rate_limit or lower semantic_search_rate_limit for this ' +
-      'environment.',
-  ).toBeLessThan(globalLimit * 60);
-
-  // The e2e suite shares one admin session across parallel specs, so this
-  // deliberately does NOT set/restore either setting -- mutating a global
-  // setting here would race whatever else is reading it concurrently.
-  const requestCount = configuredLimit + 1;
-
-  // Pace the burst at 40 requests/second, comfortably under
-  // _DEFAULT_GLOBAL_RATE_LIMIT (60/second, platform/ratelimit.py) so this
-  // test's own traffic cannot trip the global limiter. That is a fixed
-  // pacing choice, not adaptive: an environment with global_rate_limit
-  // deliberately lowered below 40 would fire the global limiter here too,
-  // but that is a separate, unrelated deployment choice this test does not
-  // attempt to detect -- the discriminability guard above only covers
-  // whether the per-route limit can outlast the global one, not whether
-  // this pacing outruns a nonstandard global setting.
-  const BATCH_SIZE = 40;
-  const rateLimitBodies: Array<{ detail?: string }> = [];
-  let sawOtherStatus = false;
-
-  // A batch of up to BATCH_SIZE concurrent requests can transiently exceed
-  // the dev DB pool (SQLAlchemy's default is 10 + 3 overflow = 13
-  // connections) before the rate limiter has rejected the requests over
-  // configuredLimit -- verified directly against this stack's own logs:
-  // `sqlalchemy.exc.TimeoutError: QueuePool limit of size 10 overflow 3
-  // reached`, surfacing as a 500. That is pool contention, not the search
-  // endpoint or the rate limiter behaving incorrectly, so retry a 5xx (never
-  // a 429, which is a real answer) a couple of times before treating it as
-  // a genuine failure.
-  async function getWithRetry(url: string) {
-    let res = await request.get(url);
-    for (let attempt = 0; attempt < 2 && res.status() >= 500; attempt += 1) {
-      await new Promise((resolve) => setTimeout(resolve, 250 * (attempt + 1)));
-      res = await request.get(url);
-    }
-    return res;
+  // fix(review #1792 round 5): this test spent four rounds trying to pin the
+  // actual discriminating behavior (is a 429 really from the per-route
+  // limiter and not the global one? does it fire exactly at the configured
+  // threshold?) against a live, shared, admin-configurable dev stack --
+  // structurally unreliable there, since this suite can neither set
+  // semantic_search_rate_limit or global_rate_limit nor isolate itself from
+  // other concurrent traffic hitting the same stack (rounds 1-4 tried
+  // reading the config, pacing bursts below the global limit, and retrying
+  // through DB-pool contention, and still could not fully close the gap).
+  // That pin now lives in backend/tests/test_semantic_search_rate_limit_1778.py,
+  // against an isolated app instance with both limits set to known values --
+  // it also covers the "decorator still present" structural check. This is a
+  // smoke test only: one request, either a plain 200 (well under whatever
+  // the deployment's limit is) or a 429 whose body names a per-minute limit
+  // (already past it) -- both prove the route and its rate-limit decorator
+  // are wired end to end through the real deployment, with no burst and no
+  // ceiling to maintain here.
+  const res = await request.get(
+    `${apiBase}/search/datasets/?q=sec-audit-S11-smoke-${Date.now()}`,
+  );
+  if (res.status() === 429) {
+    const body = (await res.json()) as { detail?: string };
+    expect(body.detail).toMatch(/ per 1 minute$/);
+  } else {
+    expect(res.status()).toBe(200);
   }
-
-  for (let sent = 0; sent < requestCount; sent += BATCH_SIZE) {
-    const batchSize = Math.min(BATCH_SIZE, requestCount - sent);
-    const batch = await Promise.all(
-      Array.from({ length: batchSize }, (_, i) => {
-        const index = sent + i;
-        return getWithRetry(`${apiBase}/search/datasets/?q=sec-audit-S11-unique-token-${index}`);
-      }),
-    );
-    for (const res of batch) {
-      if (res.status() === 429) {
-        rateLimitBodies.push((await res.json()) as { detail?: string });
-      } else if (res.status() !== 200) {
-        sawOtherStatus = true;
-      }
-    }
-    if (sent + BATCH_SIZE < requestCount) {
-      await new Promise((resolve) => setTimeout(resolve, 1000));
-    }
-  }
-
-  expect(sawOtherStatus, 'every non-429 response should be a plain 200').toBe(false);
-  expect(rateLimitBodies.length, 'burst should trigger at least one 429').toBeGreaterThan(0);
-
-  // Distinguish which limiter answered: slowapi's RateLimitExceeded detail
-  // is str(limits.RateLimitItem) -- "<N> per 1 minute" for the per-route
-  // limit under test, "<N> per 1 second" for the global one. Paced under
-  // BATCH_SIZE/second, only the route limiter should ever fire, but assert
-  // that directly rather than assuming the pacing alone proves it.
-  const routeLimitText = `${configuredLimit} per 1 minute`;
-  const matchedRouteLimit = rateLimitBodies.some((body) => body.detail === routeLimitText);
-  expect(
-    matchedRouteLimit,
-    `expected a 429 naming "${routeLimitText}"; got: ${JSON.stringify(rateLimitBodies)}`,
-  ).toBe(true);
 });

--- a/e2e/sec-audit.spec.ts
+++ b/e2e/sec-audit.spec.ts
@@ -15,14 +15,20 @@
 // backend/tests/test_ssrf_redirect.py, so the test is removed below rather
 // than left permanently skipped — see the comment where it used to be.
 //
-//   SEC_AUDIT_API_URL         override the API base (default /api)
 //   SEC_AUDIT_FRONTEND_URL    override the frontend base for S08 (default E2E_BASE_URL)
 
 import { test, expect } from '@playwright/test';
 import { getAuthToken, seedDataset, seedDemDataset, deleteDataset } from './helpers/catalog';
 
-const API = process.env.SEC_AUDIT_API_URL || '/api';
 const BASE_URL = process.env.E2E_BASE_URL ?? 'http://localhost:8080';
+// fix(review #1792): SEC_AUDIT_API_URL used to let audit requests target a
+// different host than the one fixtures were seeded on -- nothing in CI or
+// any playwright*.config.ts ever set it, but if it had been, every
+// IDOR/visibility assertion below would have passed vacuously (a foreign id
+// 404s against the wrong host regardless of authorization). Removed the
+// override; one apiBase feeds seeding, publishing, and auditing alike, so
+// they cannot drift apart.
+const apiBase = `${BASE_URL}/api`;
 
 let privateDatasetId = '';
 let privateDatasetTitle = '';
@@ -61,7 +67,7 @@ test.beforeAll(async () => {
   const pub = await seedDataset('Sec Audit Public');
   publicDatasetId = pub.id;
   publicDatasetTitle = pub.title;
-  const publishRes = await fetch(`${BASE_URL}/api/datasets/${publicDatasetId}`, {
+  const publishRes = await fetch(`${apiBase}/datasets/${publicDatasetId}`, {
     method: 'PATCH',
     headers,
     body: JSON.stringify({ visibility: 'public', record_status: 'published' }),
@@ -73,7 +79,7 @@ test.beforeAll(async () => {
   // S02/S03: a second, non-admin editor who owns neither dataset above.
   const editorBUsername = `sec-audit-editor-b-${Date.now()}`;
   const editorBPassword = 'Sec-Audit-Editor-B-42';
-  const createUserRes = await fetch(`${BASE_URL}/api/admin/users/`, {
+  const createUserRes = await fetch(`${apiBase}/admin/users/`, {
     method: 'POST',
     headers,
     body: JSON.stringify({ username: editorBUsername, password: editorBPassword, role: 'editor' }),
@@ -83,7 +89,7 @@ test.beforeAll(async () => {
   }
   editorBUserId = ((await createUserRes.json()) as { id: string }).id;
 
-  const loginRes = await fetch(`${BASE_URL}/api/auth/login/`, {
+  const loginRes = await fetch(`${apiBase}/auth/login/`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
     body: new URLSearchParams({ username: editorBUsername, password: editorBPassword }).toString(),
@@ -94,7 +100,7 @@ test.beforeAll(async () => {
   editorBToken = ((await loginRes.json()) as { access_token: string }).access_token;
 
   // S08: a public map with a share token.
-  const mapRes = await fetch(`${BASE_URL}/api/maps/`, {
+  const mapRes = await fetch(`${apiBase}/maps/`, {
     method: 'POST',
     headers,
     body: JSON.stringify({ name: `Sec Audit Share Map ${Date.now()}` }),
@@ -103,7 +109,7 @@ test.beforeAll(async () => {
     throw new Error(`sec-audit: could not create share map: ${mapRes.status}`);
   }
   shareMapId = ((await mapRes.json()) as { id: string }).id;
-  const mapPublishRes = await fetch(`${BASE_URL}/api/maps/${shareMapId}`, {
+  const mapPublishRes = await fetch(`${apiBase}/maps/${shareMapId}`, {
     method: 'PUT',
     headers,
     body: JSON.stringify({ visibility: 'public' }),
@@ -111,7 +117,7 @@ test.beforeAll(async () => {
   if (!mapPublishRes.ok) {
     throw new Error(`sec-audit: could not publish share map: ${mapPublishRes.status}`);
   }
-  const shareRes = await fetch(`${BASE_URL}/api/maps/${shareMapId}/share/`, {
+  const shareRes = await fetch(`${apiBase}/maps/${shareMapId}/share/`, {
     method: 'POST',
     headers,
   });
@@ -124,10 +130,10 @@ test.beforeAll(async () => {
 test.afterAll(async () => {
   const headers = adminHeaders();
   if (shareMapId) {
-    await fetch(`${BASE_URL}/api/maps/${shareMapId}`, { method: 'DELETE', headers }).catch(() => {});
+    await fetch(`${apiBase}/maps/${shareMapId}`, { method: 'DELETE', headers }).catch(() => {});
   }
   if (editorBUserId) {
-    await fetch(`${BASE_URL}/api/admin/users/${editorBUserId}`, { method: 'DELETE', headers }).catch(() => {});
+    await fetch(`${apiBase}/admin/users/${editorBUserId}`, { method: 'DELETE', headers }).catch(() => {});
   }
   if (privateDatasetId) await deleteDataset(privateDatasetId, privateDatasetTitle);
   if (publicDatasetId) await deleteDataset(publicDatasetId, publicDatasetTitle);
@@ -140,13 +146,13 @@ test.afterAll(async () => {
 
 test('S01 STAC visibility — anonymous cannot read a private raster STAC item', async ({ request }) => {
   const recordId = privateRasterId;
-  const res = await request.get(`${API}/stac/items/${recordId}`);
+  const res = await request.get(`${apiBase}/stac/items/${recordId}`);
   expect([401, 403, 404]).toContain(res.status());
 });
 
 test('S01 STAC visibility — anonymous /stac/search does not return private rasters', async ({ request }) => {
   const recordId = privateRasterId;
-  const res = await request.get(`${API}/stac/search?ids=${recordId}`);
+  const res = await request.get(`${apiBase}/stac/search?ids=${recordId}`);
   // Either denied (401/403) or empty features list — never the private item back
   if (res.status() === 200) {
     const body = await res.json();
@@ -163,7 +169,13 @@ test('S01 STAC visibility — anonymous /stac/search does not return private ras
 test('S02 IDOR — editor B cannot PATCH another user\'s private dataset', async ({ request }) => {
   const datasetId = privateDatasetId;
   const tokenB = editorBToken;
-  const res = await request.patch(`${API}/datasets/${datasetId}/`, {
+  // fix(review #1792): the real route is /datasets/{dataset_id} with NO
+  // trailing slash (backend/openapi.json has a single, slash-less entry;
+  // redirect_slashes=False means a trailing-slash request 404s before the
+  // handler runs). The old URL's 404 happened to fall inside this test's
+  // accepted [401, 403, 404] range, so it passed without ever exercising
+  // check_dataset_write_access.
+  const res = await request.patch(`${apiBase}/datasets/${datasetId}`, {
     headers: {
       Authorization: `Bearer ${tokenB}`,
       'Content-Type': 'application/json',
@@ -176,10 +188,40 @@ test('S02 IDOR — editor B cannot PATCH another user\'s private dataset', async
 test('S02 IDOR — editor B cannot DELETE another user\'s private dataset', async ({ request }) => {
   const datasetId = privateDatasetId;
   const tokenB = editorBToken;
-  const res = await request.delete(`${API}/datasets/${datasetId}/`, {
-    headers: { Authorization: `Bearer ${tokenB}` },
+  // fix(review #1792): delete_dataset_endpoint requires a DatasetDeleteRequest
+  // body with confirm_title (router.py:530-549) -- an empty DELETE 422s
+  // before the ownership check ever runs, so this failed on a correct
+  // server regardless of authorization. Send the real title so the only
+  // thing that can still refuse the request is authorization. Also dropped
+  // the trailing slash: the real route is /datasets/{dataset_id} with NONE
+  // (backend/openapi.json has a single, slash-less entry; redirect_slashes
+  // =False means a trailing-slash request 404s before the handler runs) --
+  // the old URL's 404 fell inside this test's accepted range too, so it
+  // passed without ever exercising check_dataset_write_access. Building the
+  // positive control below (same body, real owner) surfaced this: it kept
+  // 404ing even for the owner until the slash was dropped.
+  const res = await request.delete(`${apiBase}/datasets/${datasetId}`, {
+    headers: { Authorization: `Bearer ${tokenB}`, 'Content-Type': 'application/json' },
+    data: { confirm_title: privateDatasetTitle },
   });
   expect([401, 403, 404]).toContain(res.status());
+
+  // Positive control: the identical request shape, from the actual owner,
+  // succeeds -- proves the 401/403/404 above comes from authorization, not
+  // from the server rejecting the body itself for everyone. Uses its own
+  // throwaway dataset (not privateDatasetId, which S03 and S05 below still
+  // need) so this test owns its own create/delete lifecycle rather than
+  // reaching into the shared beforeAll fixtures.
+  const throwaway = await seedDataset('Sec Audit S02 Positive Control');
+  try {
+    const ownerRes = await request.delete(`${apiBase}/datasets/${throwaway.id}`, {
+      headers: { Authorization: `Bearer ${getAuthToken()}`, 'Content-Type': 'application/json' },
+      data: { confirm_title: throwaway.title },
+    });
+    expect(ownerRes.status()).toBe(204);
+  } finally {
+    await deleteDataset(throwaway.id, throwaway.title);
+  }
 });
 
 test('S02 IDOR — editor B cannot bulk-delete another user\'s private dataset', async ({ request }) => {
@@ -192,7 +234,7 @@ test('S02 IDOR — editor B cannot bulk-delete another user\'s private dataset',
   // (router.py) isolates per-item failures rather than rejecting the whole
   // batch, so a denied item surfaces as HTTP 200 with a per-item
   // status: 'error', never a top-level 401/403/404.
-  const res = await request.post(`${API}/datasets/bulk-delete/`, {
+  const res = await request.post(`${apiBase}/datasets/bulk-delete/`, {
     headers: {
       Authorization: `Bearer ${tokenB}`,
       'Content-Type': 'application/json',
@@ -201,9 +243,18 @@ test('S02 IDOR — editor B cannot bulk-delete another user\'s private dataset',
   });
   expect(res.status()).toBe(200);
   const body = await res.json();
-  const results = body.results ?? [];
-  const item = results.find((r: { dataset_id: string }) => r.dataset_id === datasetId);
-  expect(item?.status).not.toBe('deleted');
+  // fix(review #1792): `item?.status` on an ABSENT result item is
+  // `undefined`, and `expect(undefined).not.toBe('deleted')` passes
+  // trivially -- a response that dropped the target dataset from `results`
+  // entirely (or never included it) satisfied this assertion just as well
+  // as a genuine denial. Assert the item exists, then assert its actual
+  // status and the top-level count, both of which BulkDeleteResponse always
+  // returns (backend/openapi.json).
+  const results: Array<{ dataset_id: string; status: string }> = body.results ?? [];
+  const item = results.find((r) => r.dataset_id === datasetId);
+  expect(item, 'bulk-delete response should include a result for the target dataset').toBeTruthy();
+  expect(item?.status).toBe('error');
+  expect(body.deleted).toBe(0);
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -213,12 +264,27 @@ test('S02 IDOR — editor B cannot bulk-delete another user\'s private dataset',
 test('S03 IDOR — editor B cannot add a column to another user\'s private dataset', async ({ request }) => {
   const datasetId = privateDatasetId;
   const tokenB = editorBToken;
-  const res = await request.post(`${API}/datasets/${datasetId}/columns/`, {
+  // fix(review #1792): column DDL lives under /layers/{dataset_id}/columns/,
+  // not /datasets/{dataset_id}/columns/ (backend/openapi.json has no such
+  // /datasets path at all -- add_column_endpoint and drop_column_endpoint
+  // are both registered on layers_router). The old URL 404'd unconditionally,
+  // which fell inside this test's accepted range, so it passed without ever
+  // reaching add_column_endpoint's check_dataset_write_access. The body
+  // shape was also wrong: AddColumnRequest wraps the definition in a
+  // `column` object (`{ column: { name, type } }`), not top-level
+  // `{ name, type }`. Fixing both surfaced a THIRD latent bug: the column
+  // name 'sec_audit_S03' has always failed ColumnDef's own name validator
+  // (lowercase letters/digits/underscores only) with a 422 -- "body.column.
+  // name: Value error, Column name 'sec_audit_S03' must start with a
+  // lowercase letter and contain only lowercase letters, digits, and
+  // underscores" -- which Pydantic raises before the handler body (and so
+  // before check_dataset_write_access) ever runs. Lowercased it.
+  const res = await request.post(`${apiBase}/layers/${datasetId}/columns/`, {
     headers: {
       Authorization: `Bearer ${tokenB}`,
       'Content-Type': 'application/json',
     },
-    data: { name: 'sec_audit_S03', type: 'text' },
+    data: { column: { name: 'sec_audit_s03', type: 'text' } },
   });
   expect([401, 403, 404]).toContain(res.status());
 });
@@ -226,8 +292,11 @@ test('S03 IDOR — editor B cannot add a column to another user\'s private datas
 test('S03 IDOR — editor B cannot DROP a column on another user\'s private dataset', async ({ request }) => {
   const datasetId = privateDatasetId;
   const tokenB = editorBToken;
+  // fix(review #1792): same /layers/{dataset_id}/columns/{column_name} path
+  // fix as the add-column test above (drop_column_endpoint is on
+  // layers_router too; no trailing slash on this one per openapi.json).
   // Use a column name that almost certainly exists on a default ingested table
-  const res = await request.delete(`${API}/datasets/${datasetId}/columns/gid`, {
+  const res = await request.delete(`${apiBase}/layers/${datasetId}/columns/gid`, {
     headers: { Authorization: `Bearer ${tokenB}` },
   });
   expect([401, 403, 404]).toContain(res.status());
@@ -249,7 +318,7 @@ test('S03 IDOR — editor B cannot DROP a column on another user\'s private data
 
 test('S05 VEC-IDOR — anonymous /related/ on a private dataset returns no oracle', async ({ request }) => {
   const datasetId = privateDatasetId;
-  const res = await request.get(`${API}/datasets/${datasetId}/related/`);
+  const res = await request.get(`${apiBase}/datasets/${datasetId}/related/`);
   // After fix: 401/403/404. Before fix: 200 with empty or partial list (oracle).
   // Empty 200 is also accepted as long as no similarity scores leak.
   if (res.status() === 200) {
@@ -266,7 +335,7 @@ test('S05 VEC-IDOR — anonymous /related/ on a private dataset returns no oracl
 // ─────────────────────────────────────────────────────────────────────────────
 
 test('S06 — admin user with known-public password "demodemo" cannot log in', async ({ request }) => {
-  const res = await request.post(`${API}/auth/login/`, {
+  const res = await request.post(`${apiBase}/auth/login/`, {
     headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
     form: { username: 'admin', password: 'demodemo' },
   });
@@ -307,7 +376,7 @@ test('S09 — dataset export -where rejects UNION / subqueries', async ({ reques
   // old URL always 404'd before the -where parser ever ran, which the
   // permanent skip guard hid.
   const res = await request.get(
-    `${API}/datasets/${datasetId}/export?format=csv&where=${encodeURIComponent(malicious)}`,
+    `${apiBase}/datasets/${datasetId}/export?format=csv&where=${encodeURIComponent(malicious)}`,
   );
   expect([400, 422, 403]).toContain(res.status());
 });
@@ -317,21 +386,56 @@ test('S09 — dataset export -where rejects UNION / subqueries', async ({ reques
 // ─────────────────────────────────────────────────────────────────────────────
 
 test('S11 — burst of unique semantic queries gets rate-limited', async ({ request }) => {
-  // Send 80 unique queries; with a 30/min per-route limit we should see 429s.
-  // With only the 60/sec global limit and unique strings, all 80 pass.
-  // After fix this becomes a regression pin for the per-route decorator.
+  // fix(#1778): the skip guard used to fire on exactly the outcome this test
+  // exists to catch, so it could never go red. The per-route decorator has
+  // shipped (search/router.py's search_datasets_endpoint carries
+  // @limiter.limit(_semantic_search_rate_limit)) -- gate on it.
+  //
+  // fix(review #1792): a hardcoded 80-request burst assumed the 30/minute
+  // default, but semantic_search_rate_limit is a runtime admin setting
+  // (persistent_config.py) an operator can raise up to 1000. Read the
+  // actual configured value through /settings/all/ (admin-only) using the
+  // same shared admin session every other fixture in this file uses, and
+  // send exactly one more request than that.
+  const settingsRes = await request.get(`${apiBase}/settings/all/`, {
+    headers: { Authorization: `Bearer ${getAuthToken()}` },
+  });
+  expect(settingsRes.ok()).toBeTruthy();
+  const settingsBody = (await settingsRes.json()) as {
+    tabs: Record<string, Array<{ key: string; value: unknown }>>;
+  };
+  const rateLimitItem = Object.values(settingsBody.tabs)
+    .flat()
+    .find((item) => item.key === 'semantic_search_rate_limit');
+  expect(
+    rateLimitItem,
+    'semantic_search_rate_limit setting not found in /settings/all/',
+  ).toBeTruthy();
+  const configuredLimit = Number(rateLimitItem?.value);
+  expect(Number.isFinite(configuredLimit) && configuredLimit > 0).toBe(true);
+
+  // The e2e suite shares one admin session across parallel specs, so this
+  // deliberately does NOT set/restore the limit -- mutating a global setting
+  // here would race whatever else is reading it concurrently. A configured
+  // ceiling above 200 would make this test send hundreds of load-generating
+  // requests just to find the boundary; fail loudly with the observed value
+  // instead of doing that silently.
+  const REQUEST_CEILING = 200;
+  expect(
+    configuredLimit,
+    `semantic_search_rate_limit is ${configuredLimit}, above this test's ` +
+      `${REQUEST_CEILING}-request ceiling -- raise the ceiling deliberately ` +
+      'or lower the configured limit for this environment',
+  ).toBeLessThanOrEqual(REQUEST_CEILING);
+
+  const requestCount = configuredLimit + 1;
   const responses = await Promise.all(
-    Array.from({ length: 80 }, (_, i) =>
-      request.get(`${API}/search/datasets/?q=sec-audit-S11-unique-token-${i}`)
+    Array.from({ length: requestCount }, (_, i) =>
+      request.get(`${apiBase}/search/datasets/?q=sec-audit-S11-unique-token-${i}`)
     ),
   );
-  const statuses = responses.map(r => r.status());
-  const has429 = statuses.includes(429);
-  // fix(#1778): the skip guard fired on exactly the outcome this test exists
-  // to catch, so it could never go red. The per-route decorator has shipped
-  // (search/router.py's search_datasets_endpoint carries
-  // @limiter.limit(_semantic_search_rate_limit), default 30/minute) — gate on it.
-  expect(has429).toBe(true);
+  const statuses = responses.map((r) => r.status());
+  expect(statuses).toContain(429);
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -340,7 +444,7 @@ test('S11 — burst of unique semantic queries gets rate-limited', async ({ requ
 
 test('S13 — /search/facets/ rejects q longer than 1000 chars', async ({ request }) => {
   const longQ = 'a'.repeat(5000);
-  const res = await request.get(`${API}/search/facets/?q=${encodeURIComponent(longQ)}`);
+  const res = await request.get(`${apiBase}/search/facets/?q=${encodeURIComponent(longQ)}`);
   // After fix: 422 (Pydantic validation). Pre-fix: 200 with seq-scan.
   // 429: the S11 burst test above can leave the per-IP rate limiter saturated
   // within the same window — a safe rejection still satisfies this hygiene check.
@@ -352,7 +456,7 @@ test('S13 — /search/facets/ rejects q longer than 1000 chars', async ({ reques
 // ─────────────────────────────────────────────────────────────────────────────
 
 test('hygiene — SQLi sentinel in search q does not crash or return all rows', async ({ request }) => {
-  const res = await request.get(`${API}/search/datasets/?q=` + encodeURIComponent(`' OR '1'='1`));
+  const res = await request.get(`${apiBase}/search/datasets/?q=` + encodeURIComponent(`' OR '1'='1`));
   expect([200, 400, 422, 429]).toContain(res.status()); // 429: safe rate-limit rejection (S11 burst bleed)
   if (res.status() === 200) {
     const body = await res.json();
@@ -363,7 +467,7 @@ test('hygiene — SQLi sentinel in search q does not crash or return all rows', 
 });
 
 test('hygiene — pgvector embedding never appears in search response', async ({ request }) => {
-  const res = await request.get(`${API}/search/datasets/?q=test`);
+  const res = await request.get(`${apiBase}/search/datasets/?q=test`);
   if (res.status() === 200) {
     const body = await res.json();
     const features = body.features ?? [];
@@ -379,27 +483,27 @@ test('hygiene — pgvector embedding never appears in search response', async ({
 test('hygiene — pg_trgm operator-abuse handled safely (no syntax error, fast response)', async ({ request }) => {
   const malicious = '! | !';
   const start = Date.now();
-  const res = await request.get(`${API}/search/datasets/?q=${encodeURIComponent(malicious)}`);
+  const res = await request.get(`${apiBase}/search/datasets/?q=${encodeURIComponent(malicious)}`);
   const elapsed = Date.now() - start;
   expect(elapsed).toBeLessThan(3000);
   expect([200, 400, 422, 429]).toContain(res.status()); // 429: safe rate-limit rejection (S11 burst bleed)
 });
 
 test('hygiene — malformed bbox is rejected', async ({ request }) => {
-  const res = await request.get(`${API}/search/datasets/?bbox=0,0,1`);
+  const res = await request.get(`${apiBase}/search/datasets/?bbox=0,0,1`);
   expect([400, 422, 429]).toContain(res.status()); // 429: safe rate-limit rejection (S11 burst bleed)
 });
 
 test('hygiene — CORS does not grant credentials to an untrusted origin', async ({ request }) => {
   const origin = 'http://attacker.example';
-  const appResponse = await request.get(`${API}/auth/me/`, {
+  const appResponse = await request.get(`${apiBase}/auth/me/`, {
     headers: { Origin: origin },
   });
   expect(appResponse.headers()['access-control-allow-origin']).toBeUndefined();
   expect(appResponse.headers()['access-control-allow-credentials']).toBeUndefined();
 
   // Anonymous standards routes may use a wildcard, but never with credentials.
-  const standardsResponse = await request.get(`${API}/`, {
+  const standardsResponse = await request.get(`${apiBase}/`, {
     headers: { Origin: 'http://attacker.example' },
   });
   const standardsOrigin = standardsResponse.headers()['access-control-allow-origin'];


### PR DESCRIPTION
codebase audit 2026-08-30 (8dc529f17), tracked in #1778.

This lane covers the 9 e2e test-integrity findings assigned to M8: swallowed assertions, skip guards that are the failure condition, dead selectors, empty-result passes, and axe coverage gaps for admin routes, dataset tabs, the share dialog, and locales.

## Status per finding

1. "The gating axe suite runs only in light mode and only in en-US, so the entire dark palette and all three non-English locales are never scanned" -- the dark-mode half was already fixed by #1782 before this lane started. The locale half was still open. Fixed with a new non-gating scan, `e2e/accessibility-locale.spec.ts`, mirroring the wcag22aa precedent from #1790: a full 4-locale sweep folded into the gating suite would add too much wall-clock, so this scans the three densest routes (map builder, dataset detail, admin settings) under `de` and only reports, never fails.

2. "wcagTags omits wcag22aa, so axe's target-size rule never runs" -- already fixed by #1790 (`e2e/accessibility-target-size.spec.ts`, a separate non-gating scan). No changes made; left that file untouched per the lane brief.

3. "The axe suite never scans any admin sub-route, the dataset detail tabs, or the share dialog; the 'public' search-page scan runs authenticated" -- confirmed still present on main. Extended `accessibility.spec.ts`'s route loop with the 8 uncovered admin routes and 3 admin/settings tabs, added a tab loop for the dataset detail page (data/structure/sources/access), added a share dialog scan, and moved the "public search page" test inside the logged-out describe block; it was outside that block and running authenticated. This surfaced a real, separate contrast bug on the dataset access tab (AccessTab.tsx's API-URL chip, 4.15:1 against a 4.5:1 floor, same value in both themes). Excluded that one element from the scan with a comment explaining why, rather than fixing an unrelated design token in the same PR. Flagging it here for a follow-up.

4. "Release-gating spec post-impl-validation.spec.ts swallows its only assertions with .catch(() => {})" -- confirmed. Removed the four swallows, asserted on the previously-discarded `hasCanvas` value in test 6, and added a positive assertion to test 12. Fixing test 12 for real surfaced a genuine flake: a redundant localStorage-set-then-reload dance that raced the app's own client-side redirect and occasionally landed back on /login. Removed the redundant reload (the project's storageState already authenticates every test in the file); re-ran 3 times afterward with no flake.

5. "e2e/sec-audit.spec.ts: 11 of 19 tests are permanently skipped, and S11's skip guard IS its failure condition" -- confirmed. Removed S11's skip guard; the per-route rate limiter it claimed was unshipped has shipped. Seeded fixtures in-spec for S01/S02/S03/S05/S08/S09 instead of relying on hand-provisioned env vars nothing in CI ever sets, following the pattern e2e/auth.setup.ts and e2e/auth.spec.ts already use. Removed S04 (SSRF redirect bypass) rather than leaving it permanently skipped; it needs a live external redirector, which is infrastructure this spec cannot provision, and the behavior is covered by backend/tests/test_ssrf_redirect.py. Activating S02's bulk-delete test and S09 for the first time surfaced two more dormant bugs predating the skip guards: S02 sent the wrong request shape for BulkDeleteRequest, and S09 hit a path that has never existed (`/export.csv` instead of `/export?format=csv`). Fixed both.

6. "reupload-multi-layer-gpkg.spec.ts Scenario A swallows both of its assertions with .catch(() => {})" -- confirmed. Removed Scenario A; its selectors exist only in this file's own vitest mocks, and the real behavior is covered by UploadForm.multiLayerFanOut.test.tsx.

7. "reupload Scenario B: three test.skip guards whose condition is the failure condition, plus the GPKG assertions gated behind an if" -- confirmed. Replaced the three skips with hard failures and the trailing conditional layer-select block with an unconditional assertion.

8. "reupload Scenario B reads a `results` key that /api/datasets/ has never returned" -- confirmed. Fixed to `datasets`, matching the two sibling specs that already get this right.

9. "export-runtime's bbox and where filter tests both pass on an empty result set" -- confirmed. Added `toBeGreaterThan(0)` to both, and changed the where-filter's threshold selection to use the column's maximum observed value instead of the first feature's value, so the clause is genuinely selective against the seeded fixture instead of matching everything. Pinned exact counts (1 of 3) against the auto-seeded fixture specifically, since a documented escape hatch lets a manual run point at an arbitrary dataset whose topology this test cannot assume.

## Schema/API/config impact

None. All changes are to `e2e/*.spec.ts` files.

## Left alone

- `seedDatasetViaAPI` and `deleteDataset` in reupload-multi-layer-gpkg.spec.ts (lines 28-100) are dead code with wrong `/import/upload/...` paths; the real prefix is `/ingest/...`. Outside item 6-8's named line ranges.
- The AccessTab.tsx color-contrast bug found while extending dataset-tab coverage (see item 3 above).

## Verification

Ran every changed or added spec against the live dev stack at localhost:8080, which serves main, from this worktree, per AGENTS.md's spec-only-change allowance:

```
E2E_ALLOW_WORKTREE=1 E2E_BASE_URL=http://localhost:8080 npx playwright test <spec> --project=<chromium|api>
```

- accessibility-locale.spec.ts: 3/3 pass
- accessibility.spec.ts (targeted grep on new/moved tests, light and dark): 26/26 pass
- post-impl-validation.spec.ts: 14/14 pass (test 12 re-run 3x standalone after the flake fix, no failures)
- sec-audit.spec.ts: 19/19 pass (S04 removed, so 19 of the original 20 test bodies remain)
- reupload-multi-layer-gpkg.spec.ts: 1/1 passes (Scenario B; Scenario A removed)
- export-runtime.spec.ts (`--project=api`): 8/8 pass

Backend was not touched, so `tests/test_layering.py` and ruff were not run. No new `t()` keys were added, so `npm run test:i18n` was not run.


## Round 1 review (head b2e38c6fa, review 5096344073)

Six threads, all in specs this PR touched. Fixed all six in one push (head 5fcb98ca0).

1. sec-audit.spec.ts S02 DELETE (P1): the DELETE sent no body, but delete_dataset_endpoint requires a DatasetDeleteRequest with confirm_title, so it 422'd before the ownership check ever ran. Sent the real confirm_title, and added a positive control (the owner, on a throwaway dataset it creates and cleans up itself, succeeds with 204). Building that control surfaced a second bug in the same test and its PATCH sibling: the URL carried a trailing slash, and the real route is /datasets/{dataset_id} with none, so both tests' 404 was a route miss, not an authorization check. Chasing the same bug class into S03 found the column-DDL tests were pointed at a URL prefix (/datasets/{id}/columns/) that does not exist at all; the real routes are under /layers/{id}/columns/, with a different request-body shape, and a third bug the first two were masking: the test column name failed the API's own naming validator. Fixed all four (route, path, body shape, name) in the S02/S03 tests.

2. sec-audit.spec.ts SEC_AUDIT_API_URL (P1): confirmed nothing in .github/workflows/*.yml or any playwright*.config.ts sets it. Removed the override; one apiBase derived from E2E_BASE_URL now feeds fixture seeding and every audit request.

3. sec-audit.spec.ts bulk-delete (P2): `item?.status` on an absent result item was `undefined`, and `not.toBe('deleted')` passed on that trivially. Now asserts the item exists, then its status and the top-level deleted count.

4. post-impl-validation.spec.ts (P2): `not.toHaveText('Page error')` compares the whole body text, which never equals that string exactly even with an error boundary rendered inside the page chrome, so it passed in the failure state. Switched to `not.toContainText`.

5. export-runtime.spec.ts bbox test (P2): shrinking the dataset's own extent by 20% does not guarantee a feature falls inside it, particularly for the E2E_EXPORT_DATASET_ID escape hatch pointing at an arbitrary dataset. Rebuilt the bbox around one observed feature's own coordinates (padded by a small epsilon) instead, which works for both ownedDataset and the escape hatch, and added a geometry-match assertion that the observed feature comes back in the result. The exact-count pin stays restricted to ownedDataset.

6. sec-audit.spec.ts S11 (P2): read the actual configured semantic_search_rate_limit through /settings/all/ (admin session) instead of hardcoding 80, and send limit + 1 requests. Does not set/restore the setting, since the suite shares one admin session across parallel specs. A configured value above a 200-request ceiling fails loudly naming the value rather than sending hundreds of requests.

Verified: reran every touched spec against the live dev stack the same way as before. sec-audit.spec.ts 20/20 (18 tests + setup/cleanup; the S02 DELETE positive control re-run standalone twice more with no flake, and before the route fixes it reproducibly returned 404 instead of 204 for the owner, confirming the bug and the fix). post-impl-validation.spec.ts 14/14. export-runtime.spec.ts (--project=api) 8/8.


## Round 2 review (head 5fcb98ca0, review 5096490260)

Four P2s. Fixed all four in one push (head 026545f54).

1. sec-audit.spec.ts S08 frame-ancestors: the old test hit /m/<share_token> with no `et` param, so the edge could never emit a per-token frame-ancestors directive and the assertion passed only because X-Frame-Options is intentionally absent on that route. Rebuilt around real embed tokens (no token, a garbage token, a real unrestricted token, a domain-restricted token). Implementing that surfaced a bigger issue: the nginx auth_request wiring that injects this CSP is production-only (the root Dockerfile builds nginx + frontend/nginx.conf); the docker-compose.yml dev stack that E2E_ALLOW_WORKTREE and CI's own e2e-test/e2e-smoke jobs run against serves the frontend off Vite's dev server instead, which emits no CSP for /m/* at all, for any token, confirmed directly with curl. Moved the real assertions onto /api/embed/frame-policy, the actual policy logic, documented as directly testable without the edge in front; kept a 200-only smoke check on the /m/ viewer route. The domain-restricted case is gated behind is_enterprise() and this stack runs Community edition, so that branch creates the token and checks the actual response (201 vs. the advanced-sharing rejection) rather than skipping.

2. sec-audit.spec.ts beforeAll timeout: parallelized the four independent fixture chains (raster, private vector, public vector, editor B) with Promise.all and set an explicit 240s hook timeout. The share-map chain runs after, since it now needs a layer from the public dataset (embed tokens refuse an empty map) that the concurrent batch produces.

3. export-runtime.spec.ts toFixed(6) rounding: switched the where-clause threshold to the exact observed maximum instead of a value rounded to 6 decimals, which could round up and exclude the row that produced it.

4. sec-audit.spec.ts SEC_AUDIT_FRONTEND_URL fallback: switched the literal 'http://localhost:8080' default to BASE_URL.

Verified: reran both touched specs against the live dev stack the same way as before. sec-audit.spec.ts 20/20 (18 tests + setup/cleanup, including S08 standalone and in the full run). export-runtime.spec.ts (--project=api) 8/8.


## Round 3 review (head 026545f54, review 5096624938)

One P1 and four P2s. Each is an instance of a class that recurs across the specs this PR touched, so the fix swept every changed spec for the whole class, not just the flagged line. Fixed in one push (head af5177ac3).

1. sec-audit.spec.ts detail-shape assertion (P1): verified directly (curl probe plus reading api/main.py's global RequestValidationError override, whose docstring says it flattens every 422 to a single problem+json `detail` string for "every other operation" beyond the OGC/STAC paths it was written for) that `body.detail` is a string here, not a vanilla FastAPI array of {loc, msg, type} objects, so the original check was already comparing the right shape. Made it robust to either shape anyway. Swept every other 422/400 body assertion in the touched specs for the same question: this was the only one that reads `.detail`.

2. sec-audit.spec.ts limiter-exhaustion ordering (P2): S11's burst ran before S13 and three hygiene tests that hit the same rate-limited endpoint (or tolerated 429 defensively). Moved S11 to the end of the file. Tightened the three named hygiene tests (SQLi, pgvector-leak, pg_trgm) to require 200 and check the body unconditionally instead of only inside `if (status === 200)` with 429 accepted; pg_trgm's check didn't read the body at all before. Dropped the now-stale 429 tolerance from S13 and malformed-bbox, which test rejection behavior and no longer share endpoint state with S11. Swept the touched specs for any other burst that could exhaust a limiter before a sibling: S11 is the only one.

3. seedDataset()/seedRuntimeDataset() timeouts (P2): the helper alone can poll for up to 60s, matching Playwright's default hook/test timeout with nothing left over for the rest of the work. Fixed the flagged accessibility-locale.spec.ts beforeAll, then swept every touched spec for the same shape: accessibility.spec.ts's beforeAll (also seeds a dataset plus several more sequential calls) and export-runtime.spec.ts's beforeAll (its own inline ingest-and-poll loop) had the identical gap. sec-audit.spec.ts's S02 DELETE test seeds a throwaway dataset inline with no timeout of its own, so that got test.slow(). sec-audit.spec.ts's main beforeAll already had a 240s timeout from round 2, and reupload-multi-layer-gpkg.spec.ts already carries a describe-level 120s timeout; post-impl-validation.spec.ts seeds no datasets. No other gaps found.

4. sec-audit.spec.ts STAC-search fallthrough (P2): the S01 /stac/search test's `if (status === 200)` had no `else`, so any non-200 fell through with no assertion. Added the else, matching the sibling S01 items-by-id test and S05's already-correct shape. Swept the touched specs for every other `if (status === 200)` with no else: S05 already has one, and the two hits inside the hygiene tests are resolved by the limiter-ordering fix above.

Verified: reran every touched spec against the live dev stack the same way as before. sec-audit.spec.ts 20/20 (18 tests + setup/cleanup, S13 and hygiene tests now running and passing on a real 200 before S11, which runs last and still passes). accessibility-locale.spec.ts 5/5. accessibility.spec.ts (targeted grep on the beforeAll-dependent tests, light and dark) 8/8. export-runtime.spec.ts (--project=api) 8/8.


## Round 4 review (head baccf5483, review 5096747403)

Three P2s. This closes out the S11 rate-limit test, which had cost four rounds, in its final shape rather than another adjustment. Fixed in one push (head baccf5483).

1. S11 hard 200 ceiling: dropped it. The test now sends configuredLimit + 1 requests for any value the validator permits, up to 1000.

2. S11 pacing and limiter discrimination: paced the burst in batches of at most 40 requests/second (under the 60/second global default), so a Promise.all-in-one-instant burst can no longer trip the global limiter before the per-route one under test. Added a positive check that a 429's body names the per-route limit specifically: slowapi's RateLimitExceeded detail is str(limits.RateLimitItem), "<N> per 1 minute" for the route limit vs "<N> per 1 second" for the global one. Added a discriminability guard before sending anything: if the configured per-route limit is not below the global limiter's per-minute equivalent, the test fails loudly naming both values rather than skipping, since no pacing or body-text check can attribute a 429 to one limiter over the other in that case.

Verifying the paced burst against the live stack surfaced a further, distinct issue: batches of concurrent requests intermittently 500'd with a real `sqlalchemy.exc.TimeoutError: QueuePool limit of size 10 overflow 3 reached` in the API container's own logs, i.e. this test's own concurrency against the dev DB's 13-connection pool, not a defect in the search endpoint or the rate limiter. Added a short bounded retry for 5xx responses only (never 429, a real answer) before treating one as failure; three consecutive live runs passed cleanly afterward.

3. accessibility.spec.ts share-dialog scan: SharePanel's useMapShareToken query is still loading when the dialog mounts, so the scan covered the "Get share link" branch instead of the persisted-token controls. Waited for the "Regenerate link" button before scanning. Swept the other axe scans added in this PR for the same gap: added a generic waitForLoadingIndicatorsToClear(page) helper (waits for both the shared Skeleton component's `data-slot="skeleton"` marker and the lucide Loader2 spinner's `animate-spin` class to clear) and applied it to the public search page test, the dataset tabs loop, and the admin-sub-route loop. Left accessibility-locale.spec.ts alone: it has the same theoretical race, but that file is explicitly non-gating (reports only, never fails), so the race degrades diagnostic value rather than correctness, and it was not named in this review.

Verified: ran every touched spec against the live dev stack the same way as before. sec-audit.spec.ts 20/20 (18 tests + setup/cleanup; S11 re-run standalone 3 additional times after the retry fix, all clean). accessibility.spec.ts (targeted grep covering every touched test, light and dark) 40/40 across two runs.



## Round 5 review (head baccf5483, review 5096890583)

Three P2s, two of them the rate-limit test again. This is the fifth round on it, so it changes shape rather than parameters. Fixed in one push (head 3c21294fd).

1 and 2. Rate limiting: the e2e stack cannot control the limiter's identity or the configured limits, so any burst-based assertion there stays configuration-dependent -- four rounds of adjusting request counts, pacing, and discrimination logic against the live, shared, admin-configurable dev stack proved that. Moved the actual pin into the backend.

Added `backend/tests/test_semantic_search_rate_limit_1778.py` against an isolated app instance (the existing `client` fixture's dedicated test engine, with slowapi's process-wide limiter enabled/reset/disabled within the test per `test_rate_limits.py`'s established pattern): a structural check that `search_datasets_endpoint` is still registered with its rate-limit decorator, and a discriminating test that sets `semantic_search_rate_limit=5` and `global_rate_limit=1000` via the sync cache, sends 6 unique-query requests, and asserts the first 5 succeed, the 6th is 429, and its body names the per-route per-minute limit exactly ("5 per 1 minute"), never the global per-second one.

Writing that test surfaced that the mechanism described in round 3/4's comments was wrong: slowapi's `@limiter.limit(...)` defaults `override_defaults=True`, and `search/router.py`'s decorator doesn't override that, so the global limiter cannot structurally answer a `/search/datasets/` request at all. There was never actually a "which limiter fired" ambiguity to resolve at the e2e layer, only the resource-contention one round 4's retry logic handled. The backend test now pins the real mechanism directly.

`e2e/sec-audit.spec.ts`'s S11 is now a smoke test: one request, either a 200 or a 429 whose body names a per-minute limit -- both prove the route and its decorator are wired end to end. No burst, no ceiling, no pacing.

The four hygiene tests that hit `/search/datasets/` (SQLi, pgvector-leak, pg_trgm, and malformed-bbox, which uses a `bbox` param on the same route) read the configured limit once in a shared `beforeAll` and accept a 429 naming a per-minute limit as valid for those specific requests only when the configured limit is below the hygiene request count plus one; otherwise they require 200. No pacing logic remains in the spec.

3. `export-runtime.spec.ts`: JS renders a number below 1e-6 or at/above 1e21 in scientific notation, and round 2's threshold fix string-interpolated the value directly into the where clause, so `validate_where_clause()` reads the `e` as a bare identifier and rejects it. Added `formatNumericLiteral()`, a pure string/digit expansion of the exact digits JS already chose (no rounding, so it keeps round 2's "never excludes the row that produced the maximum" property), applied at the one interpolation site. Pinned with a standalone, request-free `test.describe` covering `1e-7` and `1e21` (the exact boundary values) plus values JS already renders as plain decimals.

Verified: ran every touched spec against the live dev stack the same way as before, and the new backend test on the host (`cd backend && set -a && source ../.env.test && set +a && uv run pytest tests/test_semantic_search_rate_limit_1778.py -v` against localhost:5434) -- 2/2, also run alongside `test_rate_limits.py` and `test_rate_limit_key_style_1778.py` (12/12, no interference through shared limiter state), `test_layering.py` (47/47), ruff check, and ruff format --check. `sec-audit.spec.ts` 20/20, re-run twice for stability, now ~40-55s instead of ~1.1min. `export-runtime.spec.ts` 11/11, including the three new pin tests.


## Round 6 review (head 3c21294fd, review 5096999683)

One P2 at `e2e/export-runtime.spec.ts:398`. Fixed in one push (head 2efbec8ff).

A BIGINT above 2^53 or a high-precision NUMERIC gets rounded when the baseline JSON is parsed (`9007199254740995` becomes `9007199254740996`), so `column >= <max>` could exclude the row that supplied the maximum. The two cases need different treatment:

- BIGINT (an integer, not safely representable, and within Postgres's actual bigint range of +/-2^63-1): recovers the exact digits from the raw response text via a new `extractRawIntegerValues()` helper (a targeted regex over the raw bytes for one specific property key, not a general big-number-safe JSON parser), then subtracts exactly 1 as a BigInt operation -- a whole BIGINT column has no value between v-1 and v, so this can never exclude the true maximal row. Threading the raw response text through required widening `resolveCandidate`/`resolveRuntimeDataset`'s return shape and the `beforeAll` that consumes it, since `buildWherePredicate` previously only ever saw the already-parsed baseline.
- NUMERIC/float, including a value whose magnitude exceeds even BIGINT's range (so it cannot be a real BIGINT and the raw-text recovery does not apply): subtracts a margin of `Math.abs(v) * 1e-9 + Number.EPSILON` from the parsed value, comfortably larger than a double's ~1e-15 relative rounding error.

`Number.isInteger` alone cannot tell a BIGINT column from a NUMERIC/float column that currently happens to hold a whole number -- a double that large has no fractional bits left to distinguish them with. Postgres's actual BIGINT range can: a magnitude beyond ~9.22e18 cannot possibly be a real BIGINT value, so it routes to the proportional-margin path instead.

Pinned with two pure-logic tests (`buildWherePredicate precision`, no live request) covering the two example inputs from the review: `9007199254740995` (written as a string in the test source, since a plain number literal would be rounded by the same double-precision limit the test exists to work around) and `1.2345678901234567e20` (confirmed as a whole JS double past BIGINT's ceiling, so it exercises the magnitude-routing decision, not just the epsilon-margin arithmetic). Both assert the rendered clause value is strictly below the true input value.

Verified: ran `export-runtime.spec.ts` against the live dev stack the same way as before, re-run twice for stability -- 13/13 both times, including the two new precision pins and the live "semantic where filter" test (which exercises the safe-integer path against the seeded fixture's plain 10/20/30 values, unaffected by this change).



## Round 7 review (head 2efbec8ff, review 5101556956)

Two P2s, both in `e2e/export-runtime.spec.ts`. Fixed in one push (head b1b6aee4b).

1. `:990` -- the bbox test took `baseline.features[0]` as the feature to build its bbox around, but `resolveRuntimeDataset()`'s own geometry check only requires that SOME feature in the collection contribute a position (`collectFeatureCollectionPositions` skips a null/empty-geometry feature rather than failing the whole collection), so a custom dataset via the `E2E_EXPORT_DATASET_ID` escape hatch can have a null-geometry row first and still pass. Switched to `baseline.features.find((feature) => computeFeatureBBox(feature) !== null)`, with a clear failure message if no feature has computable geometry at all.

2. `:472` -- when `extractRawIntegerValues()` finds zero raw matches for a property, that means the token didn't parse as a clean integer in the raw response text at all -- e.g. a NUMERIC column serialized as `"9007199254740995.1"`, correctly excluded by the regex's `(?![\d.eE])` lookahead since it's followed by `.1`. The old fallback then emitted the already-rounded-up parsed value (`9007199254740996`, since JSON.parse has no fractional bits left at this magnitude and rounds to the nearest whole double) unchanged as the threshold, which can exceed the true value and exclude the row that produced it. Restructured so exact BigInt recovery either succeeds and is used, or the code falls through to the same epsilon-margin path used for ordinary NUMERIC/float values -- there's no third case.

Pinned with a new test in `buildWherePredicate precision` using `9007199254740995.1`: confirms via `Number.isInteger`/`Number.isSafeInteger` that the parse lands in the unsafe-integer range, confirms via `BigInt` that the parse actually rounded past the true value (a plain `Number` comparison here would compare two equally-rounded doubles and prove nothing, since the literal and its own truncated integer part collide onto the same double at this magnitude), then asserts the rendered clause value is strictly below the true value.

Verified: ran `export-runtime.spec.ts` against the live dev stack the same way as before, re-run twice for stability -- 14/14 both times, including the new decimal-token pin and the live "semantic bbox filter" test.



## Round 8 review (head b1b6aee4b, review 5101872529)

Two P2s, both in `e2e/sec-audit.spec.ts`. Fixed in one push (head ff2f99da4).

1. `:544` -- S09's WHERE-parser test accepted 403 alongside the parser-rejection statuses (400/422) for a malicious UNION clause. `publicDatasetId` is created and explicitly published by `beforeAll`, so a 403 there could mean the anonymous-export authorization gate short-circuited the request before `validate_where_clause()` ever ran -- an anonymous-export regression could satisfy this test without the UNION/subquery defense being exercised at all. Added a positive control first: the identical anonymous request with no `where` at all, against the same public dataset, asserted to succeed (the export route resolves anonymous callers through `get_optional_user` + `check_dataset_access_or_anonymous`). Dropped 403 from the accepted set for the malicious request itself, so a 403 there can now only mean the parser rejected it.

   Swept the rest of the file for the same shape: every other `[401, 403, 404]` assertion is a dedicated IDOR/authorization test (S01-S03, S05), where 403 is the actual outcome under test, not a stand-in accepted alongside a parser/validator status -- several of those already carry their own positive control (e.g. S02's DELETE test, which proves the identical request succeeds for the real owner). No other site needed the same fix.

2. `:610` -- the `Hygiene — /search/datasets/ requests` describe block (S11's sibling SQLi/pgvector/pg_trgm/bbox tests) only accepted a 429 as valid when the configured `semantic_search_rate_limit` was below its own 4-request count, on the assumption that this block is the only traffic against the shared limiter bucket. It isn't: in a full run, `search.spec.ts` also hits `/search/datasets/` against the same server, so a configured limit that comfortably covers these 4 requests alone can still be exhausted by the time they run, and the unconditional `expect(200)` fallback would then fail a healthy rate limiter on a legitimate 429. Removed the settings lookup and request-count threshold entirely -- a 429 is now accepted unconditionally, gated only on it actually looking like the per-route limiter (a `Retry-After` header, per `_rate_limit_handler` in `api/main.py`, plus a `detail` naming a per-minute limit) rather than on a request count this suite can't bound.

Verified: ran `search.spec.ts` then `sec-audit.spec.ts` against the live dev stack from the worktree path, individually and back to back, twice each -- 24/24 passing throughout, including the new S09 positive control and the (now limiter-isolated) hygiene block.
