### PR TITLE
fix(standards): STAC/OGC pagination determinism and datetime correctness

### DIFF
--- a/backend/app/modules/catalog/collections/service.py
+++ b/backend/app/modules/catalog/collections/service.py
@@ -243,9 +243,17 @@ async def get_collection_datasets(
     total = total_result.scalar_one()
 
     # Paginated results ordered by sort_order then added_at
+    # fix(#1778): sort_order server-defaults to 0 for every row and added_at
+    # is not unique either, so a batch of rows added in one INSERT ties on
+    # both columns and OFFSET/LIMIT paging over the tie has no defined
+    # order. dataset_id is unique within a single collection's rows.
     paginated_stmt = (
         filtered_stmt.options(joinedload(Dataset.record))
-        .order_by(CollectionDataset.sort_order, CollectionDataset.added_at)
+        .order_by(
+            CollectionDataset.sort_order,
+            CollectionDataset.added_at,
+            CollectionDataset.dataset_id,
+        )
         .offset(skip)
         .limit(limit)
     )

--- a/backend/app/modules/catalog/records/service.py
+++ b/backend/app/modules/catalog/records/service.py
@@ -116,8 +116,11 @@ async def list_contacts(
     """List contacts for a record, ordered by sort_order, with pagination."""
     result = await session.execute(
         select(RecordContact)
+        # fix(#1778): sort_order server-defaults to 0, so contacts added
+        # without an explicit order tie on it -- OFFSET/LIMIT paging over
+        # the tie had no defined row order. RecordContact.id is unique.
         .where(RecordContact.record_id == record_id)
-        .order_by(RecordContact.sort_order)
+        .order_by(RecordContact.sort_order, RecordContact.id)
         .offset(skip)
         .limit(limit)
     )

--- a/backend/app/modules/catalog/search/router.py
+++ b/backend/app/modules/catalog/search/router.py
@@ -822,7 +822,11 @@ async def list_collections(
     count_stmt = select(func.count()).select_from(ds_base.subquery())
     total_datasets = (await db.execute(count_stmt)).scalar_one()
 
-    ds_stmt = ds_base.offset(offset).limit(limit)
+    # fix(#1778): no ORDER BY meant OFFSET/LIMIT paging had no defined row
+    # order -- add a deterministic tiebreaker before paging, matching the
+    # STAC peer routers.
+    ds_stmt = ds_base.order_by(Record.created_at.desc(), Dataset.id.desc())
+    ds_stmt = ds_stmt.offset(offset).limit(limit)
     ds_result = await db.execute(ds_stmt)
     datasets = ds_result.scalars().unique().all()
 

--- a/backend/app/modules/catalog/search/service_filters.py
+++ b/backend/app/modules/catalog/search/service_filters.py
@@ -4,11 +4,11 @@ from __future__ import annotations
 
 import uuid as uuid_mod
 from dataclasses import dataclass
-from datetime import date
+from datetime import date, timedelta
 from typing import Literal, TypedDict
 
 from fastapi import HTTPException, status
-from sqlalchemy import exists, func, literal_column, or_, select
+from sqlalchemy import and_, exists, func, literal_column, or_, select
 from sqlalchemy.orm import aliased
 
 from app.core.geo import make_bbox_filter
@@ -308,13 +308,39 @@ def _apply_common_filters(stmt, filters: SearchFilters, *, skip_text: bool = Fal
         stmt = stmt.where(Record.source_organization == filters.source_organization)
     if filters.datetime_param:
         dt_start, dt_end = parse_ogc_datetime(filters.datetime_param)
+        # fix(#1778): the bare `.is_(None)` arms below matched a record with
+        # NO temporal extent at all for ANY datetime filter, unconditionally
+        # -- datetime=1900-01-01 returned a record created in 2026. The STAC
+        # peer (stac/router.py _apply_datetime_filter) hit the same bug and
+        # was fixed by comparing the record's own advertised fallback
+        # instant (created_at, see build_time in record_metadata.py) instead
+        # of admitting every null-temporal row. Port that fix here, keeping
+        # the existing open-ended reading (temporal_end/temporal_start NULL
+        # with the OTHER bound set) for records that do have a defined start
+        # or end.
+        null_temporal = Record.temporal_start.is_(None) & Record.temporal_end.is_(None)
         if dt_start is not None:
             stmt = stmt.where(
-                or_(Record.temporal_end >= dt_start, Record.temporal_end.is_(None))
+                or_(
+                    Record.temporal_end >= dt_start,
+                    and_(
+                        Record.temporal_end.is_(None), Record.temporal_start.isnot(None)
+                    ),
+                    and_(null_temporal, Record.created_at >= dt_start),
+                )
             )
         if dt_end is not None:
             stmt = stmt.where(
-                or_(Record.temporal_start <= dt_end, Record.temporal_start.is_(None))
+                or_(
+                    Record.temporal_start <= dt_end,
+                    and_(
+                        Record.temporal_start.is_(None), Record.temporal_end.isnot(None)
+                    ),
+                    and_(
+                        null_temporal,
+                        Record.created_at < dt_end + timedelta(days=1),
+                    ),
+                )
             )
     if filters.collection_id is not None:
         stmt = stmt.where(

--- a/backend/app/standards/ogc/router.py
+++ b/backend/app/standards/ogc/router.py
@@ -882,6 +882,13 @@ async def get_collection_items(
         active_params["bbox"] = bbox
     if datetime_param:
         active_params["datetime"] = datetime_param
+    # fix(#1778): include_geometry is excluded from property_filters (it is
+    # listed in ogc_reserved) and was never added here either, so a client
+    # that opted out of geometry on page 1 got it back on page 2 via the
+    # rel=next link this block builds, and the self link stopped describing
+    # the request that produced the response.
+    if not include_geometry:
+        active_params["include_geometry"] = "false"
     if filter_expr is not None:
         active_params["filter"] = filter_expr
         if filter_lang != "cql2-text":

--- a/backend/app/standards/stac/router.py
+++ b/backend/app/standards/stac/router.py
@@ -1827,6 +1827,17 @@ def _apply_datetime_filter(stmt, datetime_str: str):
         if start is not None:
             stmt = stmt.where(
                 (Record.temporal_end >= start)
+                # fix(#1778): a record with temporal_start set and
+                # temporal_end NULL (an open-ended/ongoing extent) fell
+                # through every arm here -- temporal_end >= start reads
+                # NULL, temporal_start >= start is false for any start in
+                # the past, and null_temporal is false since temporal_start
+                # IS set. The single-instant branch below already treats a
+                # NULL temporal_end as open (its range_contains OR-arm), so
+                # an interval query for a later instant matched fewer
+                # records than the instant alone. Mirror the end-bound
+                # clause's own open-start arm below, symmetrically.
+                | (Record.temporal_end.is_(None) & Record.temporal_start.isnot(None))
                 | (Record.temporal_start >= start)
                 | (null_temporal & (Record.created_at >= start))
             )

--- a/backend/app/standards/stac/router.py
+++ b/backend/app/standards/stac/router.py
@@ -664,8 +664,17 @@ async def get_collections(
     coll_result = await db.execute(select(Collection))
     collections = coll_result.scalars().all()
 
-    # Four independent metadata queries -- run concurrently with separate
-    # sessions (async sessions are not safe to share across gather tasks).
+    # fix(#1778): these four aggregates used to asyncio.gather with each
+    # branch opening its own async_session() -- a nested pool checkout on
+    # top of the connection this request already holds via `db` (get_db
+    # never commits on the read path, so that connection stays checked out
+    # for the whole request). 5 checkouts per anonymous, uncached request
+    # exhausts the default 13-connection pool at 3 concurrent requests. Run
+    # them sequentially on the caller's own session instead, the same trade
+    # made in service_query.py's dataset-detail fetch (fix #1436 codex
+    # review): these are grouped-aggregate queries over the same joined
+    # set, so the wall-clock cost of sequencing them is negligible next to
+    # that risk, and unlike dataset-detail this endpoint is anonymous.
 
     async def _fetch_extents() -> dict[str, tuple]:
         extent_stmt = (
@@ -685,14 +694,11 @@ async def get_collections(
         extent_stmt = apply_visibility_filter(
             extent_stmt, user, user_roles, Record, DatasetGrant
         )
-        async with _db_module.async_session() as s:
-            rows = await s.execute(extent_stmt)
-            return {
-                (str(r[0]) if r[0] is not None else STAC_UNASSIGNED_COLLECTION_ID): r[
-                    1:
-                ]
-                for r in rows.all()
-            }
+        rows = await db.execute(extent_stmt)
+        return {
+            (str(r[0]) if r[0] is not None else STAC_UNASSIGNED_COLLECTION_ID): r[1:]
+            for r in rows.all()
+        }
 
     async def _fetch_keywords() -> dict[str, list[str]]:
         kw_stmt = (
@@ -710,19 +716,16 @@ async def get_collections(
         kw_stmt = apply_visibility_filter(
             kw_stmt, user, user_roles, Record, DatasetGrant
         )
-        async with _db_module.async_session() as s:
-            rows = await s.execute(kw_stmt)
-            result: dict[str, list[str]] = {}
-            for row in rows.all():
-                kws = row[1]
-                if kws:
-                    key = (
-                        str(row[0])
-                        if row[0] is not None
-                        else STAC_UNASSIGNED_COLLECTION_ID
-                    )
-                    result[key] = sorted([k for k in kws if k])
-            return result
+        rows = await db.execute(kw_stmt)
+        result: dict[str, list[str]] = {}
+        for row in rows.all():
+            kws = row[1]
+            if kws:
+                key = (
+                    str(row[0]) if row[0] is not None else STAC_UNASSIGNED_COLLECTION_ID
+                )
+                result[key] = sorted([k for k in kws if k])
+        return result
 
     async def _fetch_projection_codes() -> dict[str, list[str]]:
         RasterAsset = get_catalog_port().raster_asset_orm_class()
@@ -741,32 +744,24 @@ async def get_collections(
         epsg_stmt = apply_visibility_filter(
             epsg_stmt, user, user_roles, Record, DatasetGrant
         )
-        async with _db_module.async_session() as s:
-            rows = await s.execute(epsg_stmt)
-            result: dict[str, list[int]] = {}
-            for row in rows.all():
-                codes = row[1]
-                if codes:
-                    key = (
-                        str(row[0])
-                        if row[0] is not None
-                        else STAC_UNASSIGNED_COLLECTION_ID
-                    )
-                    result[key] = [
-                        f"EPSG:{code}" for code in sorted(c for c in codes if c)
-                    ]
-            return result
+        rows = await db.execute(epsg_stmt)
+        result: dict[str, list[int]] = {}
+        for row in rows.all():
+            codes = row[1]
+            if codes:
+                key = (
+                    str(row[0]) if row[0] is not None else STAC_UNASSIGNED_COLLECTION_ID
+                )
+                result[key] = [f"EPSG:{code}" for code in sorted(c for c in codes if c)]
+        return result
 
     async def _fetch_has_unassigned() -> bool:
-        async with _db_module.async_session() as s:
-            return await _has_unassigned_items(s, user, user_roles)
+        return await _has_unassigned_items(db, user, user_roles)
 
-    extent_map, keywords_map, projection_map, has_unassigned = await asyncio.gather(
-        _fetch_extents(),
-        _fetch_keywords(),
-        _fetch_projection_codes(),
-        _fetch_has_unassigned(),
-    )
+    extent_map = await _fetch_extents()
+    keywords_map = await _fetch_keywords()
+    projection_map = await _fetch_projection_codes()
+    has_unassigned = await _fetch_has_unassigned()
 
     stac_collections = []
     for coll in collections:

--- a/backend/app/standards/stac/router.py
+++ b/backend/app/standards/stac/router.py
@@ -1042,6 +1042,12 @@ async def get_collection_items(
     total = (await db.execute(count_stmt)).scalar() or 0
 
     # Paginate
+    # fix(#1778): no ORDER BY meant OFFSET/LIMIT paging had no defined row
+    # order -- a plan change between page fetches could duplicate or drop
+    # items across the rel=next chain. Record.created_at is a non-unique
+    # server-default, so add Dataset.id as a tiebreaker, matching the
+    # convention _resolve_sort_order already uses for dataset listings.
+    stmt = stmt.order_by(Record.created_at.desc(), Dataset.id.desc())
     stmt = stmt.offset(offset).limit(limit)
     result = await db.execute(stmt)
     datasets = result.unique().scalars().all()
@@ -1516,6 +1522,9 @@ async def _execute_search(
     total = (await db.execute(count_stmt)).scalar() or 0
 
     # Apply pagination
+    # fix(#1778): same missing-ORDER-BY hazard as get_collection_items -- add
+    # a deterministic tiebreaker before paging.
+    stmt = stmt.order_by(Record.created_at.desc(), Dataset.id.desc())
     stmt = stmt.offset(offset).limit(limit)
     result = await db.execute(stmt)
     datasets = result.unique().scalars().all()

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1998,6 +1998,14 @@ def test_decomposed_service_modules_stay_within_size_budgets() -> None:
         # each branch here inverts, so the pair can be kept in step by reading
         # rather than by running the equivalence suite. Cap 372 -> 433, exact.
         "backend/app/platform/extensions/defaults_extensions.py": 433,
+        # fix(#1778): +16 over the 350 default -- _apply_common_filters'
+        # datetime block replaces two bare `.is_(None)` OR-arms (which
+        # unconditionally matched every null-temporal record for ANY
+        # datetime filter) with the same null_temporal & created_at
+        # fallback comparison the already-fixed STAC peer uses, while
+        # preserving the existing open-ended reading for records that do
+        # have one bound set. Cap 350 -> 366, exact.
+        "backend/app/modules/catalog/search/service_filters.py": 366,
     }
 
     files_to_check = list(facade_line_budgets)

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -4314,7 +4314,9 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # `_legacy_keywords_body`, the `_LEGACY_FILTER_LANG_PARAM` fallback, and
     # the comments that only existed to explain them. Cap lowered
     # 1536 -> 1489, exact.
-    "backend/app/modules/catalog/search/router.py": 1489,
+    # fix(#1778): +4 -- deterministic ORDER BY tiebreaker on the paginated
+    # per-dataset OGC collections query. Cap 1489 -> 1493, exact.
+    "backend/app/modules/catalog/search/router.py": 1493,
     # fix(#474): negotiate localized STAC record text; fix(#475) adds the
     # unassigned Collection and matching HTTP Link navigation. fix(#506): keep
     # validated STAC item responses wire-compatible with serializer output.
@@ -4484,7 +4486,10 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # it now generates.
     # feat(export/pmtiles): +9 — PMTiles joined `_DISTRIBUTION_TEMPLATES` the
     # same way, plus the row-count docstring update.
-    "backend/app/modules/catalog/records/service.py": 1026,
+    # fix(#1778): +3 -- RecordContact.id tiebreaker on the paginated contacts
+    # list, sort_order being a non-unique server-default. Cap 1026 -> 1029,
+    # exact.
+    "backend/app/modules/catalog/records/service.py": 1029,
     # fix(#1528): crossed the inclusion threshold, and this is the file the
     # inclusion rule's own comment named as one of the two "routers-by-role the
     # glob's filename match cannot see ... watched by nothing until they cross

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -4354,7 +4354,12 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # refactor(stac): -1 — the raster-asset reads go through CatalogPort, so
     # the DatasetAsset select and the deferred raster-queries import give way
     # to port calls. Cap 1855 -> 1854, still exact.
-    "backend/app/standards/stac/router.py": 1854,
+    # fix(#1778): +15 -- deterministic ORDER BY tiebreakers on the two
+    # paginated item queries, the open-ended interval-datetime fix, and
+    # replacing the four nested async_session() pool checkouts in
+    # get_collections with sequential reuse of the caller's own session.
+    # Cap 1854 -> 1869, exact.
+    "backend/app/standards/stac/router.py": 1869,
     # Central tenant-bound scope resolution replaced duplicated inline logic.
     # fix(#836): +1 — the RASTER_FAMILY_RECORD_TYPES import that replaces four
     # pasted family literals. Same +1 on the stac and search routers.

--- a/backend/tests/test_ogc_features.py
+++ b/backend/tests/test_ogc_features.py
@@ -407,6 +407,46 @@ async def test_collection_items_pagination(
 
 
 @pytest.mark.anyio
+async def test_pagination_links_preserve_include_geometry_false(
+    client: AsyncClient, public_dataset: Dataset
+):
+    """fix(#1778): include_geometry=false must survive into the self and
+    next pagination links.
+
+    include_geometry is excluded from property_filters (it's in
+    ogc_reserved) and, before the fix, was never added to active_params
+    either -- so a client opting out of geometry on page 1 silently got it
+    back on page 2 via the rel=next link this endpoint builds.
+    """
+    resp1 = await client.get(
+        f"/collections/{public_dataset.id}/items",
+        params={"limit": 2, "include_geometry": "false"},
+    )
+    assert resp1.status_code == 200
+    data1 = resp1.json()
+    assert all(f["geometry"] is None for f in data1["features"])
+
+    self_link = next((link for link in data1["links"] if link["rel"] == "self"), None)
+    assert self_link is not None
+    assert "include_geometry=false" in self_link["href"]
+
+    next_link = next((link for link in data1["links"] if link["rel"] == "next"), None)
+    assert next_link is not None, "Missing 'next' pagination link"
+    assert "include_geometry=false" in next_link["href"]
+
+    # Follow it: page 2 must still honor the opt-out, not just advertise it.
+    from urllib.parse import urlparse
+
+    parsed = urlparse(next_link["href"])
+    path_and_query = parsed.path + (f"?{parsed.query}" if parsed.query else "")
+    resp2 = await client.get(path_and_query)
+    assert resp2.status_code == 200
+    data2 = resp2.json()
+    assert data2["features"], "expected page 2 to have features"
+    assert all(f["geometry"] is None for f in data2["features"])
+
+
+@pytest.mark.anyio
 async def test_collection_items_invalid_bbox(
     client: AsyncClient, public_dataset: Dataset
 ):

--- a/backend/tests/test_search_datetime.py
+++ b/backend/tests/test_search_datetime.py
@@ -233,6 +233,74 @@ async def test_datetime_no_filter_returns_all(
 
 
 # ---------------------------------------------------------------------------
+# fix(#1778): a null-temporal record (no temporal_start/temporal_end) matched
+# ANY datetime filter unconditionally via the bare `.is_(None)` OR-arm in
+# _apply_common_filters (service_filters.py) -- datetime=1900-01-01 matched a
+# record actually created in 2026. dataset_to_ogc_record advertises
+# datetime=created_at for these records, so compare that same fallback
+# instant instead, mirroring the already-fixed STAC peer
+# (stac/router.py _apply_datetime_filter).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_datetime_1900_excludes_null_temporal_record_via_ogc_items(
+    client: AsyncClient,
+    admin_auth_header: dict,
+    datetime_datasets: dict,
+):
+    """GET /collections/datasets/items?datetime=1900-01-01 must not match a
+    null-temporal record created now."""
+    resp = await client.get(
+        "/collections/datasets/items",
+        params={"datetime": "1900-01-01", "limit": 100},
+        headers=admin_auth_header,
+    )
+    assert resp.status_code == 200
+    ids = [f["id"] for f in resp.json()["features"]]
+    assert str(datetime_datasets["ds_none"].id) not in ids
+
+
+@pytest.mark.anyio
+async def test_datetime_1900_excludes_null_temporal_record_via_search(
+    client: AsyncClient,
+    admin_auth_header: dict,
+    datetime_datasets: dict,
+):
+    """Same fix, same shared filter, via /search/datasets/ directly."""
+    resp = await client.get(
+        "/search/datasets/",
+        params={"datetime": "1900-01-01", "limit": 100},
+        headers=admin_auth_header,
+    )
+    assert resp.status_code == 200
+    ids = [f["id"] for f in resp.json()["features"]]
+    assert str(datetime_datasets["ds_none"].id) not in ids
+
+
+@pytest.mark.anyio
+async def test_datetime_own_day_still_matches_null_temporal_record(
+    client: AsyncClient,
+    admin_auth_header: dict,
+    datetime_datasets: dict,
+    test_db_session,
+):
+    """BA-13 intent preserved: the record's own advertised fallback instant
+    (created_at) still matches -- the fix narrows the match, it does not
+    remove the fallback."""
+    record = await test_db_session.get(Record, datetime_datasets["ds_none"].record_id)
+    own_day = record.created_at.date().isoformat()
+    resp = await client.get(
+        "/collections/datasets/items",
+        params={"datetime": own_day, "limit": 100},
+        headers=admin_auth_header,
+    )
+    assert resp.status_code == 200
+    ids = [f["id"] for f in resp.json()["features"]]
+    assert str(datetime_datasets["ds_none"].id) in ids
+
+
+# ---------------------------------------------------------------------------
 # fix(#315): malformed datetime -> 400 (not 500) on every datetime chokepoint
 # ---------------------------------------------------------------------------
 

--- a/backend/tests/test_stac_collections_pool_checkouts.py
+++ b/backend/tests/test_stac_collections_pool_checkouts.py
@@ -1,0 +1,111 @@
+"""fix(#1778): /stac/collections held up to 5 concurrent DB-pool connections
+per in-flight request.
+
+Codebase audit 2026-08-30 (8dc529f17): ``get_collections`` (stac/router.py)
+executes ``select(Collection)`` on its own request-scoped ``db`` (which
+``get_db`` never commits on the read path, so that connection stays checked
+out for the whole request), then ``asyncio.gather``s four more aggregate
+queries, each opening its own ``async_session()``. That is 5 checkouts for
+one anonymous, uncached request; 3 concurrent requests exhaust the default
+13-connection pool (``db_pool_size=10`` + ``db_max_overflow=3``).
+
+Same event-listener technique test_export_request_budget.py uses for its
+pool-checkout test: listen on ``checkout``/``checkin`` on the app's own
+engine and track live/peak concurrently-held connections, with the request's
+own connection as a positive control so the counter can't pass vacuously.
+"""
+
+import uuid
+from datetime import date
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import event, update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.modules.catalog.datasets.domain.models import Dataset, Record
+
+from tests.factories import get_user_id
+
+
+async def _create_raster(
+    session: AsyncSession, *, created_by: uuid.UUID, name: str
+) -> Dataset:
+    """Public+published raster Record+Dataset so the four aggregate queries
+    in get_collections have at least one row to group over."""
+    record = Record(
+        title=name,
+        summary=f"Pool checkout test: {name}",
+        visibility="public",
+        record_status="published",
+        record_type="raster_dataset",
+        created_by=created_by,
+    )
+    session.add(record)
+    await session.flush()
+    dataset = Dataset(
+        record_id=record.id,
+        table_name=f"ds_{uuid.uuid4().hex[:12]}",
+        srid=4326,
+        source_format="geotiff",
+        source_filename="test.tif",
+    )
+    session.add(dataset)
+    await session.flush()
+    await session.execute(
+        update(Record)
+        .where(Record.id == record.id)
+        .values(created_at=date(2024, 3, 14))
+    )
+    await session.commit()
+    await session.refresh(dataset)
+    return dataset
+
+
+@pytest.mark.anyio
+async def test_stac_collections_does_not_hold_more_than_one_pool_connection(
+    client: AsyncClient, test_db_session: AsyncSession
+):
+    admin_id = await get_user_id(test_db_session, "admin")
+    await _create_raster(
+        test_db_session, created_by=admin_id, name=f"pool-{uuid.uuid4().hex[:8]}"
+    )
+
+    import app.core.db as db_module
+
+    live = {"n": 0}
+    peak = {"n": 0}
+
+    def _on_checkout(dbapi_connection, connection_record, connection_proxy):
+        live["n"] += 1
+        peak["n"] = max(peak["n"], live["n"])
+
+    def _on_checkin(dbapi_connection, connection_record):
+        live["n"] -= 1
+
+    sync_engine = db_module.engine.sync_engine
+    event.listen(sync_engine, "checkout", _on_checkout)
+    event.listen(sync_engine, "checkin", _on_checkin)
+
+    try:
+        baseline = live["n"]
+        resp = await client.get("/stac/collections")
+    finally:
+        event.remove(sync_engine, "checkout", _on_checkout)
+        event.remove(sync_engine, "checkin", _on_checkin)
+
+    assert resp.status_code == 200, resp.text
+    # Positive control: the counter observed at least the request's own
+    # connection, so it is capable of seeing a held connection at all.
+    assert peak["n"] >= baseline + 1
+
+    # fix(#1778): the finding. On main this hits baseline + 5 (the request's
+    # own connection plus four nested async_session() checkouts running
+    # concurrently under asyncio.gather); the fix runs the four aggregates
+    # sequentially on the caller's own session, so only the request's own
+    # connection is ever held.
+    assert peak["n"] <= baseline + 1, (
+        f"peak concurrent pool checkouts {peak['n']} exceeded baseline "
+        f"{baseline} + 1 -- /stac/collections held more than its own "
+        "connection at once"
+    )

--- a/backend/tests/test_stac_datetime_filter.py
+++ b/backend/tests/test_stac_datetime_filter.py
@@ -8,6 +8,7 @@ matched a record created in 2026).
 """
 
 import uuid
+from datetime import date
 
 import pytest
 from httpx import AsyncClient
@@ -29,6 +30,35 @@ async def _create_null_temporal_raster(
         record_status="published",
         record_type="raster_dataset",
         created_by=created_by,
+    )
+    session.add(record)
+    await session.flush()
+    dataset = Dataset(
+        record_id=record.id,
+        table_name=f"ds_{uuid.uuid4().hex[:12]}",
+        srid=4326,
+        source_format="geotiff",
+        source_filename="test.tif",
+    )
+    session.add(dataset)
+    await session.commit()
+    await session.refresh(dataset)
+    return dataset
+
+
+async def _create_open_ended_raster(
+    session: AsyncSession, *, created_by: uuid.UUID, name: str, temporal_start: date
+) -> Dataset:
+    """Public+published raster Record with temporal_start SET and
+    temporal_end NULL -- an open-ended/ongoing temporal extent."""
+    record = Record(
+        title=name,
+        summary=f"Open-ended STAC datetime test: {name}",
+        visibility="public",
+        record_status="published",
+        record_type="raster_dataset",
+        created_by=created_by,
+        temporal_start=temporal_start,
     )
     session.add(record)
     await session.flush()
@@ -119,3 +149,55 @@ async def test_advertised_fallback_instant_matches_null_temporal_record(
     own_day = record.created_at.date().isoformat()
     ids = await _search_ids(client, f"{own_day}T00:00:00Z", ids=str(ds.id))
     assert str(ds.id) in ids
+
+
+# ---------------------------------------------------------------------------
+# fix(#1778): an interval must not drop an open-ended record that the single
+# instant inside that same interval matches. The interval branch's start
+# clause read a NULL temporal_end as "open" only via the null_temporal (both
+# NULL) arm -- a record with temporal_start SET and temporal_end NULL (an
+# ongoing/open-ended extent) fell through every arm, so `datetime=<instant>`
+# matched it but `datetime=<instant>/<instant+1day>` (a strictly WIDER window
+# containing that instant) did not.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_interval_matches_open_ended_record_the_instant_alone_matches(
+    client: AsyncClient, test_db_session: AsyncSession
+):
+    """Narrowing an interval to the instant it contains must not gain a match
+    the interval itself lacked."""
+    admin_id = await get_user_id(test_db_session, "admin")
+    ds = await _create_open_ended_raster(
+        test_db_session,
+        created_by=admin_id,
+        name="Open Ended Interval Parity",
+        temporal_start=date(2015, 6, 1),
+    )
+    instant_ids = await _search_ids(client, "2021-06-15T00:00:00Z", ids=str(ds.id))
+    interval_ids = await _search_ids(
+        client, "2021-06-15T00:00:00Z/2021-06-16T00:00:00Z", ids=str(ds.id)
+    )
+    assert str(ds.id) in instant_ids
+    assert str(ds.id) in interval_ids
+
+
+@pytest.mark.anyio
+async def test_interval_excludes_open_ended_record_starting_after_the_interval(
+    client: AsyncClient, test_db_session: AsyncSession
+):
+    """Counterexample guard: the open-end fix must not over-match -- a
+    record whose temporal_start is entirely after the interval's end still
+    has no overlap and must stay excluded."""
+    admin_id = await get_user_id(test_db_session, "admin")
+    ds = await _create_open_ended_raster(
+        test_db_session,
+        created_by=admin_id,
+        name="Open Ended Future Start",
+        temporal_start=date(2030, 1, 1),
+    )
+    ids = await _search_ids(
+        client, "2021-06-15T00:00:00Z/2021-06-16T00:00:00Z", ids=str(ds.id)
+    )
+    assert str(ds.id) not in ids

--- a/backend/tests/test_stac_ogc_pagination_order.py
+++ b/backend/tests/test_stac_ogc_pagination_order.py
@@ -1,0 +1,423 @@
+"""Deterministic pagination coverage for OFFSET/LIMIT endpoints that had no
+row-order tiebreaker.
+
+fix(#1778): codebase audit 2026-08-30 (8dc529f17) found three STAC/OGC
+OFFSET/LIMIT endpoints with NO ``order_by`` at all (STAC collection items,
+STAC search, OGC ``/collections``) and two siblings whose ``order_by`` sorted
+on non-unique server-default columns (collection membership ``sort_order``,
+record contact ``sort_order``). PostgreSQL gives no row-order guarantee for
+an unordered/tied-order query, so a plan change between page fetches can
+duplicate some rows and drop others.
+
+Two kinds of coverage per endpoint:
+
+- A structural check that captures the actual SQL sent to Postgres (via a
+  before_cursor_execute listener on the test engine, the same event-capture
+  technique test_export_request_budget.py uses for pool checkouts) and
+  asserts the paginated query has an ORDER BY at all, or -- for the two
+  siblings that already had one on a non-unique column -- that the unique
+  tiebreaker column is in it. This is what actually fails on main: main
+  emits no ORDER BY (or one without the tiebreaker) full stop, so this is
+  deterministic regardless of physical row order or plan choice.
+- A behavioral no-dupes/no-drops walk across tied rows, mirroring
+  test_search_pagination.py (#315), kept as end-to-end confirmation the fix
+  doesn't change the response shape. On a small, static, single-connection
+  test table Postgres tends to return heap order deterministically even
+  without an ORDER BY, so this half alone does not fail on main -- the
+  structural check above is the counterfactual that does.
+"""
+
+import uuid
+from contextlib import contextmanager
+from datetime import date
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import event, text, update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.modules.catalog.datasets.domain.models import (
+    Dataset,
+    Record,
+    RecordContact,
+)
+
+from tests.factories import get_user_id
+
+FIXED_TS = date(2024, 3, 14)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+@contextmanager
+def _capture_sql():
+    """Capture raw SQL text sent to the test database's engine.
+
+    Same before_cursor_execute event-listener technique the pool-checkout
+    test in test_export_request_budget.py uses for "checkout"/"checkin" --
+    listens on db_module.engine.sync_engine, which the `client` fixture has
+    already pointed at the test database.
+    """
+    import app.core.db as db_module
+
+    captured: list[str] = []
+
+    def _on_execute(conn, cursor, statement, parameters, context, executemany):
+        captured.append(statement)
+
+    sync_engine = db_module.engine.sync_engine
+    event.listen(sync_engine, "before_cursor_execute", _on_execute)
+    try:
+        yield captured
+    finally:
+        event.remove(sync_engine, "before_cursor_execute", _on_execute)
+
+
+async def _create_tied_raster(
+    session: AsyncSession, *, created_by: uuid.UUID, name: str
+) -> Dataset:
+    """Public+published raster Record+Dataset with created_at pinned to a
+    shared fixed timestamp, so every seeded row ties on created_at."""
+    record = Record(
+        title=name,
+        summary=f"Pagination order test: {name}",
+        visibility="public",
+        record_status="published",
+        record_type="raster_dataset",
+        created_by=created_by,
+    )
+    session.add(record)
+    await session.flush()
+    dataset = Dataset(
+        record_id=record.id,
+        table_name=f"ds_{uuid.uuid4().hex[:12]}",
+        srid=4326,
+        source_format="geotiff",
+        source_filename="test.tif",
+    )
+    session.add(dataset)
+    await session.flush()
+    await session.execute(
+        update(Record).where(Record.id == record.id).values(created_at=FIXED_TS)
+    )
+    await session.commit()
+    await session.refresh(dataset)
+    return dataset
+
+
+async def _walk_pages(
+    client: AsyncClient, path: str, base_params: dict, *, page_size: int
+) -> list[str]:
+    """Walk a StacItemCollectionResponse-shaped endpoint page by page,
+    collecting feature ids in order, using numberMatched to know when to
+    stop."""
+    all_ids: list[str] = []
+    offset = 0
+    while True:
+        params = {**base_params, "limit": page_size, "offset": offset}
+        resp = await client.get(path, params=params)
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        all_ids.extend(f["id"] for f in data["features"])
+        offset += page_size
+        if offset >= data["numberMatched"]:
+            break
+        if offset > data["numberMatched"] + page_size * 5:
+            pytest.fail("pagination did not terminate")
+    return all_ids
+
+
+# ---------------------------------------------------------------------------
+# STAC /stac/collections/{id}/items -- get_collection_items
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_stac_collection_items_pagination_no_dupes_no_drops(
+    client: AsyncClient, test_db_session: AsyncSession
+):
+    admin_id = await get_user_id(test_db_session, "admin")
+    prefix = f"stac-items-order-{uuid.uuid4().hex[:8]}"
+    datasets = [
+        await _create_tied_raster(
+            test_db_session, created_by=admin_id, name=f"{prefix}-{i}"
+        )
+        for i in range(7)
+    ]
+    expected = {str(ds.id) for ds in datasets}
+
+    # Datasets not added to any Collection surface under the unassigned
+    # pseudo-collection.
+    with _capture_sql() as captured:
+        paged = await _walk_pages(
+            client, "/stac/collections/geolens-unassigned/items", {}, page_size=2
+        )
+    seen = [pid for pid in paged if pid in expected]
+
+    assert len(seen) == len(set(seen)), "duplicate ids paging STAC collection items"
+    assert set(seen) == expected, "missing/extra ids paging STAC collection items"
+
+    # fix(#1778): the counterfactual -- on main the paginated dataset query
+    # carries no ORDER BY at all, so this fails there regardless of the
+    # (Postgres-plan-dependent, not reliably reproducible in a small static
+    # test table) dupe/drop symptom above.
+    paginated_sql = [
+        s for s in captured if "OFFSET" in s.upper() and "catalog.datasets" in s
+    ]
+    assert paginated_sql, "expected at least one paginated dataset query"
+    assert all("ORDER BY" in s.upper() for s in paginated_sql), (
+        "paginated STAC collection-items query has no ORDER BY"
+    )
+
+
+# ---------------------------------------------------------------------------
+# STAC /stac/search -- _execute_search
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_stac_search_pagination_no_dupes_no_drops(
+    client: AsyncClient, test_db_session: AsyncSession
+):
+    admin_id = await get_user_id(test_db_session, "admin")
+    prefix = f"stac-search-order-{uuid.uuid4().hex[:8]}"
+    datasets = [
+        await _create_tied_raster(
+            test_db_session, created_by=admin_id, name=f"{prefix}-{i}"
+        )
+        for i in range(7)
+    ]
+    expected = {str(ds.id) for ds in datasets}
+    ids_param = ",".join(sorted(expected))
+
+    with _capture_sql() as captured:
+        paged = await _walk_pages(
+            client, "/stac/search", {"ids": ids_param}, page_size=2
+        )
+    seen = [pid for pid in paged if pid in expected]
+
+    assert len(seen) == len(set(seen)), "duplicate ids paging STAC search"
+    assert set(seen) == expected, "missing/extra ids paging STAC search"
+
+    # fix(#1778): the counterfactual -- fails on main, no ORDER BY at all.
+    paginated_sql = [
+        s for s in captured if "OFFSET" in s.upper() and "catalog.datasets" in s
+    ]
+    assert paginated_sql, "expected at least one paginated dataset query"
+    assert all("ORDER BY" in s.upper() for s in paginated_sql), (
+        "paginated STAC search query has no ORDER BY"
+    )
+
+
+# ---------------------------------------------------------------------------
+# OGC /collections -- list_collections (per-dataset feature collections)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_ogc_collections_list_pagination_no_dupes_no_drops(
+    client: AsyncClient, test_db_session: AsyncSession, admin_auth_header: dict
+):
+    # No filter param exists on this endpoint, so truncate first for a known
+    # total -- otherwise there is no numberMatched/count to page against.
+    await test_db_session.execute(text("TRUNCATE TABLE catalog.datasets CASCADE"))
+    await test_db_session.commit()
+
+    admin_id = await get_user_id(test_db_session, "admin")
+    prefix = f"ogc-coll-order-{uuid.uuid4().hex[:8]}"
+    datasets = [
+        await _create_tied_raster(
+            test_db_session, created_by=admin_id, name=f"{prefix}-{i}"
+        )
+        for i in range(7)
+    ]
+    expected = {str(ds.id) for ds in datasets}
+
+    from urllib.parse import urlparse
+
+    all_ids: list[str] = []
+    path_and_query = "/collections?limit=2"
+    seen_pages = 0
+    with _capture_sql() as captured:
+        while path_and_query and seen_pages <= len(expected) + 2:
+            resp = await client.get(path_and_query, headers=admin_auth_header)
+            assert resp.status_code == 200, resp.text
+            data = resp.json()
+            all_ids.extend(c["id"] for c in data["collections"] if c["id"] in expected)
+            next_link = next(
+                (link for link in data["links"] if link["rel"] == "next"), None
+            )
+            if next_link is None:
+                break
+            parsed = urlparse(next_link["href"])
+            path_and_query = parsed.path + (f"?{parsed.query}" if parsed.query else "")
+            seen_pages += 1
+
+    assert len(all_ids) == len(set(all_ids)), "duplicate ids paging OGC /collections"
+    assert set(all_ids) == expected, "missing/extra ids paging OGC /collections"
+
+    # fix(#1778): the counterfactual -- fails on main, no ORDER BY at all.
+    paginated_sql = [
+        s for s in captured if "OFFSET" in s.upper() and "catalog.datasets" in s
+    ]
+    assert paginated_sql, "expected at least one paginated dataset query"
+    assert all("ORDER BY" in s.upper() for s in paginated_sql), (
+        "paginated OGC /collections query has no ORDER BY"
+    )
+
+
+# ---------------------------------------------------------------------------
+# /catalog/collections/{id}/datasets/ -- get_collection_datasets
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_collection_datasets_pagination_no_dupes_no_drops(
+    client: AsyncClient, test_db_session: AsyncSession, admin_auth_header: dict
+):
+    admin_id = await get_user_id(test_db_session, "admin")
+    prefix = f"coll-ds-order-{uuid.uuid4().hex[:8]}"
+    datasets = [
+        await _create_tied_raster(
+            test_db_session, created_by=admin_id, name=f"{prefix}-{i}"
+        )
+        for i in range(7)
+    ]
+    expected = {str(ds.id) for ds in datasets}
+
+    resp = await client.post(
+        "/catalog/collections/",
+        json={"name": f"Pagination Order {uuid.uuid4().hex[:8]}"},
+        headers=admin_auth_header,
+    )
+    assert resp.status_code == 201, resp.text
+    coll_id = resp.json()["id"]
+
+    # A single POST inserts every CollectionDataset row inside one
+    # transaction, so added_at (server default now()) and sort_order
+    # (server default 0) tie across all seven rows -- exactly the hazard
+    # #1778 flagged.
+    resp = await client.post(
+        f"/catalog/collections/{coll_id}/datasets/",
+        json={"dataset_ids": sorted(expected)},
+        headers=admin_auth_header,
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["added"] == 7
+
+    all_ids: list[str] = []
+    skip = 0
+    with _capture_sql() as captured:
+        while skip <= len(expected) + 2:
+            resp = await client.get(
+                f"/catalog/collections/{coll_id}/datasets/",
+                params={"skip": skip, "limit": 2},
+                headers=admin_auth_header,
+            )
+            assert resp.status_code == 200, resp.text
+            data = resp.json()
+            page_ids = [d["id"] for d in data["datasets"]]
+            if not page_ids:
+                break
+            all_ids.extend(page_ids)
+            skip += 2
+
+    assert len(all_ids) == len(set(all_ids)), "duplicate ids paging collection datasets"
+    assert set(all_ids) == expected, "missing/extra ids paging collection datasets"
+
+    # fix(#1778): the counterfactual -- on main, ORDER BY exists but only on
+    # sort_order/added_at (both tied for every row here), no dataset_id
+    # tiebreaker, so this fails there even though an ORDER BY is present.
+    # dataset_id also appears in the JOIN condition, so isolate the ORDER BY
+    # clause itself rather than searching the whole statement text.
+    paginated_sql = [
+        s for s in captured if "OFFSET" in s.upper() and "collection_datasets" in s
+    ]
+    assert paginated_sql, "expected at least one paginated collection-datasets query"
+    for s in paginated_sql:
+        order_clause = s.upper().split("ORDER BY", 1)[-1].split("LIMIT", 1)[0]
+        assert "DATASET_ID" in order_clause, (
+            "paginated collection-datasets query has no dataset_id tiebreaker "
+            f"in ORDER BY: {order_clause!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# /records/{id}/contacts/ -- list_contacts
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_record_contacts_pagination_no_dupes_no_drops(
+    client: AsyncClient, test_db_session: AsyncSession, admin_auth_header: dict
+):
+    admin_id = await get_user_id(test_db_session, "admin")
+    record = Record(
+        title="Contact Pagination Order",
+        summary="Record for #1778 contact pagination coverage",
+        visibility="public",
+        record_status="published",
+        created_by=admin_id,
+    )
+    test_db_session.add(record)
+    await test_db_session.flush()
+    dataset = Dataset(
+        record_id=record.id,
+        table_name=f"ds_{uuid.uuid4().hex[:12]}",
+        srid=4326,
+        geometry_type="Point",
+        feature_count=1,
+        source_format="geojson",
+        source_filename="test.geojson",
+    )
+    test_db_session.add(dataset)
+    await test_db_session.flush()
+
+    expected_ids = set()
+    for i in range(7):
+        contact = RecordContact(
+            record_id=record.id,
+            # sort_order defaults to 0 for every row -- the tie #1778 flags.
+            role="pointOfContact",
+            name=f"Contact {i}",
+        )
+        test_db_session.add(contact)
+        await test_db_session.flush()
+        expected_ids.add(str(contact.id))
+    await test_db_session.commit()
+
+    all_ids: list[str] = []
+    skip = 0
+    with _capture_sql() as captured:
+        while skip <= len(expected_ids) + 2:
+            resp = await client.get(
+                f"/records/{record.id}/contacts/",
+                params={"skip": skip, "limit": 2},
+                headers=admin_auth_header,
+            )
+            assert resp.status_code == 200, resp.text
+            data = resp.json()
+            page_ids = [c["id"] for c in data["contacts"]]
+            if not page_ids:
+                break
+            all_ids.extend(page_ids)
+            skip += 2
+
+    assert len(all_ids) == len(set(all_ids)), "duplicate ids paging record contacts"
+    assert set(all_ids) == expected_ids, "missing/extra ids paging record contacts"
+
+    # fix(#1778): the counterfactual -- on main, ORDER BY exists but only on
+    # sort_order (tied at 0 for every row here), no id tiebreaker.
+    paginated_sql = [
+        s for s in captured if "OFFSET" in s.upper() and "record_contacts" in s
+    ]
+    assert paginated_sql, "expected at least one paginated record-contacts query"
+    for s in paginated_sql:
+        order_clause = s.upper().split("ORDER BY", 1)[-1].split("LIMIT", 1)[0]
+        assert "RECORD_CONTACTS.ID" in order_clause, (
+            "paginated record-contacts query has no id tiebreaker in ORDER BY: "
+            f"{order_clause!r}"
+        )


### PR DESCRIPTION
## Summary

Six findings from the codebase audit 2026-08-30 (8dc529f17), tracked in #1778, all in `backend/app/standards/stac/`, `backend/app/standards/ogc/`, and `backend/app/modules/catalog/search|collections|records/`. All six were reproduced against current main before being fixed; none had already been fixed by other work.

- Three OFFSET/LIMIT paginated endpoints (STAC collection items, STAC search, OGC `/collections`) had no `ORDER BY` at all, so PostgreSQL gives no row-order guarantee across the `rel=next` chain a harvesting client follows. Added `Record.created_at` + `Dataset.id` as a deterministic tiebreaker, matching the convention `list_datasets`/`list_maps` already use.
- Two lower-severity siblings (collection membership, record contacts) had an `ORDER BY` but only on a non-unique server-default column, so a batch insert still had no defined order among tied rows. Added each row's own unique id as a tiebreaker.
- `GET /stac/collections` opened 4 extra nested DB-pool connections via `asyncio.gather`, on top of the one the request itself already holds open (`get_db` never commits on the read path) -- 5 checkouts per anonymous, uncached request, exhausting the default 13-connection pool at 3 concurrent requests. Now runs the four aggregates sequentially on the caller's own session, the same trade already made in `service_query.py`'s dataset-detail fetch (fix #1436 codex review).
- OGC Records `datetime=` filtering (`_apply_common_filters`) matched a record with no temporal extent for ANY datetime value, unconditionally -- `datetime=1900-01-01` matched a record created in 2026. Ported the fix the STAC peer already carries: compare against the record's own advertised fallback instant (`created_at`) instead of admitting every null-temporal row.
- STAC's interval datetime filter disagreed with its own instant-query branch about what a NULL `temporal_end` means: a record with `temporal_start` set and `temporal_end` NULL (open-ended/ongoing) matched a single instant but not a strictly wider interval containing that instant. Added the missing open-end arm, mirroring the end-bound clause's existing open-start arm.
- `include_geometry=false` was dropped from OGC Features pagination links, so a client opting out of geometry on page 1 got it back on page 2 via `rel=next`, silently paying for and receiving the payload it opted out of.

## Verification

Each fix has a dedicated test verified to fail on main (fixes reverted via `git stash`) and pass with the fix restored:

- `backend/tests/test_stac_ogc_pagination_order.py` (new) -- structural SQL-capture check (before_cursor_execute on the test engine) asserting the tiebreaker is in the compiled `ORDER BY`, plus a behavioral no-dupes/no-drops walk across tied rows for all five pagination endpoints.
- `backend/tests/test_stac_collections_pool_checkouts.py` (new) -- checkout/checkin event listener asserting peak concurrent pool checkouts during one `/stac/collections` request.
- `backend/tests/test_search_datetime.py` -- three new cases against the existing null-temporal fixture.
- `backend/tests/test_stac_datetime_filter.py` -- interval/instant parity test plus a counterexample guard (a record starting after the interval stays excluded).
- `backend/tests/test_ogc_features.py` -- pagination-link `include_geometry=false` preservation, following the actual `next` link to confirm page 2 too.

Commands run from the worktree (`cd backend && set -a && source ../.env.test && set +a && uv run pytest ... -q`):
- `tests/test_stac_ogc_pagination_order.py tests/test_stac_collections_pool_checkouts.py tests/test_search_datetime.py tests/test_stac_datetime_filter.py tests/test_ogc_features.py` -- 55 passed (also passed under `-n 4`)
- `tests/test_ogc_pagination.py tests/test_search_pagination.py tests/test_stac_api.py tests/test_collections.py` -- all passed as part of a combined 132-test run with the above
- `tests/test_collections.py tests/test_ogc_collection_metadata.py tests/test_ogc_cql2_filtering.py tests/test_ogc_discovery.py tests/test_ogc_features_filter.py tests/test_ogc_language_utils.py tests/test_ogc_public_access.py tests/test_ogc_queryables.py tests/test_ogc_record_enrichment.py tests/test_ogc_record_properties.py tests/test_ogc_records_conformance.py tests/test_records_authz_sec001.py tests/test_records_related.py -n 4` -- 323 passed
- `tests/test_search.py tests/test_search_cache.py tests/test_search_facets.py tests/test_stac_search_dos_sec023.py tests/test_stac_search_validation.py tests/test_stac_visibility.py tests/test_stac_visibility_5xx.py tests/test_stac_serializer.py tests/test_stac_validation.py tests/test_stac_record_output.py -n 4` -- 138 passed
- `tests/test_stac_api.py tests/test_stac_integration.py tests/test_stac_import.py tests/test_stac_asset_model.py tests/test_stac_limit_bbox_conformance.py tests/test_record_subresource_edits.py -n 4` -- 95 passed
- `tests/test_layering.py` -- 47 passed
- `uv run ruff check .` and `uv run ruff format --check .` -- clean
- `PYTHONPATH=. uv run python scripts/dump_openapi.py --check` -- clean (no schema changes; none of these fixes touch a request/response model)

## Schema/API impact

None. No request or response schema changed. `include_geometry` was already an accepted query parameter; the fix only changes what the pagination links carry forward.

## LOC caps raised

All in `backend/tests/test_layering.py`, each set to the file's exact new line count:
- `backend/app/modules/catalog/search/router.py`: 1489 -> 1493
- `backend/app/standards/stac/router.py`: 1854 -> 1869
- `backend/app/modules/catalog/records/service.py`: 1026 -> 1029
- `backend/app/modules/catalog/search/service_filters.py` (private-service budget): 350 -> 366

## Left alone

Nothing scoped to this lane's excerpt was left unfixed. Two collision-avoidance notes from the lane brief did not apply: none of the touched files (`standards/stac/router.py`, `standards/ogc/router.py`, `modules/catalog/search/router.py`, `modules/catalog/search/service_filters.py`, `modules/catalog/collections/service.py`, `modules/catalog/records/service.py`) overlap the active lanes named in LANE-AUD-COMMON.md (#1770, #1774, #1757/#1759/#1763).

codebase audit 2026-08-30 (8dc529f17), tracked in #1778.