### PR TITLE
fix(builder): six save and map-sync findings from the 2026-08-30 audit

### DIFF
--- a/frontend/src/components/builder/BuilderMap.tsx
+++ b/frontend/src/components/builder/BuilderMap.tsx
@@ -45,6 +45,7 @@ import {
   ensureRasterDemTerrainSource,
   normalizeTerrainExaggeration,
   refreshVectorSourceTiles,
+  registerBasemapStyleGeneration,
   TERRAIN_SOURCE_ID,
 } from './map-sync';
 import { resolveTerrainSourceLayer } from './map-stack';
@@ -659,6 +660,12 @@ export const BuilderMap = memo(function BuilderMap({
     (e: MapLibreEvent) => {
       const map = e.target;
       mapRef.current = map;
+      // fix(#1778 codex round 5): FIRST thing in the map-creation path, so this
+      // is the earliest-registered `style.load` listener and the basemap paint
+      // cache is already invalidated by the time any appearance pass runs
+      // against a newly loaded style. Registering it lazily from the appearance
+      // helper would put it behind the persistent handler below.
+      registerBasemapStyleGeneration(map);
       // Phase 1051 WR-04: keep state mirror in sync with the ref so consumers
       // (e.g. MapCoordReadout) re-render when the map binds.
       setMapInstance(map);

--- a/frontend/src/components/builder/__tests__/map-sync.basemap-revert.test.ts
+++ b/frontend/src/components/builder/__tests__/map-sync.basemap-revert.test.ts
@@ -17,31 +17,63 @@ import { describe, it, expect, vi } from 'vitest';
 import type { StyleSpecification } from 'maplibre-gl';
 import { applyBasemapConfigToMap } from '@/components/builder/map-sync';
 import { DEFAULT_BASEMAP_CONFIG } from '@/lib/basemap-utils';
+import type { MapBasemapConfig } from '@/types/api';
 
 /** A map mock whose setPaintProperty MUTATES the style it hands back, which is
- *  what the real MapLibre map does and what the bug depended on. */
-function createLiveStyleMap(layers: StyleSpecification['layers']) {
-  const style = {
-    version: 8 as const,
-    sources: {},
-    layers: layers.map((layer) => ({ ...layer, paint: { ...('paint' in layer ? layer.paint : {}) } })),
-  } as unknown as StyleSpecification;
-  const byId = new Map(style.layers.map((layer) => [layer.id, layer]));
+ *  what the real MapLibre map does and what the bug depended on.
+ *
+ *  `loadStyle` replaces the whole style on the SAME map object and fires any
+ *  registered `style.load` listeners, which is what `setStyle` does on a
+ *  basemap swap. `setPaintProperty(key, undefined)` deletes the key, matching
+ *  maplibre's serializer, which omits a paint property whose value is
+ *  undefined. */
+function createLiveStyleMap(initialLayers: StyleSpecification['layers']) {
+  let style = {} as StyleSpecification;
+  let byId = new Map<string, { id: string; paint?: Record<string, unknown> }>();
+  const styleLoadListeners: (() => void)[] = [];
+
+  function install(layers: StyleSpecification['layers']) {
+    style = {
+      version: 8 as const,
+      sources: {},
+      layers: layers.map((layer) => ({ ...layer, paint: { ...('paint' in layer ? layer.paint : {}) } })),
+    } as unknown as StyleSpecification;
+    byId = new Map(
+      style.layers.map((layer) => [layer.id, layer as { id: string; paint?: Record<string, unknown> }]),
+    );
+  }
+  install(initialLayers);
+
   return {
     getStyle: vi.fn(() => style),
     getLayer: vi.fn((id: string) => byId.get(id)),
     setLayoutProperty: vi.fn(),
     setPaintProperty: vi.fn((id: string, key: string, value: unknown) => {
-      const layer = byId.get(id) as { paint?: Record<string, unknown> } | undefined;
+      const layer = byId.get(id);
       if (!layer) return;
       layer.paint = { ...(layer.paint ?? {}) };
       if (value === undefined) delete layer.paint[key];
       else layer.paint[key] = value;
     }),
-    on: vi.fn(),
-    paintOf: (id: string) => ((byId.get(id) as { paint?: Record<string, unknown> })?.paint ?? {}),
+    on: vi.fn((event: string, cb: () => void) => {
+      if (event === 'style.load') styleLoadListeners.push(cb);
+    }),
+    /** Simulate setStyle: a brand new style on the same map, then style.load. */
+    loadStyle(layers: StyleSpecification['layers']) {
+      install(layers);
+      for (const cb of [...styleLoadListeners]) cb();
+    },
+    paintOf: (id: string) => (byId.get(id)?.paint ?? {}),
   };
 }
+
+const waterLayer = (color: string) => ([
+  { id: 'water', type: 'fill', source: 'openmaptiles', paint: { 'fill-color': color } },
+] as unknown as StyleSpecification['layers']);
+
+const POSITRON_WATER = '#a0c8f0';
+const DARK_WATER = '#1b2733';
+const MONOCHROME_WATER = '#d9dde0';
 
 describe('applyBasemapConfigToMap revert passes', () => {
   it('restores the original water fill when land_water_tone returns to default', () => {
@@ -106,25 +138,65 @@ describe('applyBasemapConfigToMap revert passes', () => {
 
     applyBasemapConfigToMap(map as never, { ...DEFAULT_BASEMAP_CONFIG });
     expect(map.paintOf('water')['fill-outline-color']).toBe('#123456');
+    // And the foreign write must not have disturbed this layer's own revert.
+    expect(map.paintOf('water')['fill-color']).toBe('#a0c8f0');
   });
 
-  it('drops the pristine snapshot when a new style loads', () => {
-    const map = createLiveStyleMap([
-      { id: 'water', type: 'fill', source: 'openmaptiles', paint: { 'fill-color': '#a0c8f0' } },
-    ] as unknown as StyleSpecification['layers']);
+  // fix(#1778 codex round 2 P1): the pristine snapshot used to be dropped by a
+  // `style.load` listener this module attached lazily, which meant it was always
+  // registered AFTER BuilderMap's persistent handler and therefore ran after the
+  // appearance pass that handler triggers. Detection is now synchronous and
+  // per key, so listener order cannot matter. Both tests below would fail with
+  // the listener-based invalidation: the first because the appearance listener
+  // is registered first, the second because no listener exists at all.
+  it('re-snapshots pristine across two style swaps that share a layer id', () => {
+    const map = createLiveStyleMap(waterLayer(POSITRON_WATER));
+    const config: { current: MapBasemapConfig } = {
+      current: { ...DEFAULT_BASEMAP_CONFIG, land_water_tone: 'monochrome' },
+    };
+    // Stand-in for BuilderMap's persistent style.load handler, registered
+    // BEFORE any appearance call, exactly as the real one is.
+    map.on('style.load', () => applyBasemapConfigToMap(map as never, config.current));
 
+    // Cycle 1: positron.
+    map.loadStyle(waterLayer(POSITRON_WATER));
+    expect(map.paintOf('water')['fill-color']).toBe(MONOCHROME_WATER);
+
+    // Cycle 2: dark. Same layer id, different pristine colour.
+    map.loadStyle(waterLayer(DARK_WATER));
+    expect(map.paintOf('water')['fill-color']).toBe(MONOCHROME_WATER);
+
+    // The second style's pristine must be the second style's own paint.
+    config.current = { ...DEFAULT_BASEMAP_CONFIG };
+    applyBasemapConfigToMap(map as never, config.current);
+    expect(map.paintOf('water')['fill-color']).toBe(DARK_WATER);
+
+    // Back to positron, and its own pristine must come back too.
+    config.current = { ...DEFAULT_BASEMAP_CONFIG, land_water_tone: 'monochrome' };
+    map.loadStyle(waterLayer(POSITRON_WATER));
+    expect(map.paintOf('water')['fill-color']).toBe(MONOCHROME_WATER);
+    config.current = { ...DEFAULT_BASEMAP_CONFIG };
+    applyBasemapConfigToMap(map as never, config.current);
+    expect(map.paintOf('water')['fill-color']).toBe(POSITRON_WATER);
+  });
+
+  it('never writes the previous basemap colour onto a style that just loaded', () => {
+    const map = createLiveStyleMap(waterLayer(POSITRON_WATER));
     applyBasemapConfigToMap(map as never, { ...DEFAULT_BASEMAP_CONFIG, land_water_tone: 'muted' });
     expect(map.paintOf('water')['fill-color']).toBe('#d8e5e8');
 
-    // A basemap swap replaces the style; positron and dark share layer ids, so
-    // a cache that survived it would restore the previous basemap's colours.
-    const styleLoad = map.on.mock.calls.find((c) => c[0] === 'style.load')?.[1] as () => void;
-    expect(styleLoad).toBeTypeOf('function');
-    map.setPaintProperty('water', 'fill-color', '#1b2733');
-    styleLoad();
-
-    applyBasemapConfigToMap(map as never, { ...DEFAULT_BASEMAP_CONFIG, land_water_tone: 'muted' });
+    // No style.load listener is registered anywhere in this test, so nothing
+    // can clear a cache before the appearance pass below runs.
+    map.loadStyle(waterLayer(DARK_WATER));
+    map.setPaintProperty.mockClear();
     applyBasemapConfigToMap(map as never, { ...DEFAULT_BASEMAP_CONFIG });
-    expect(map.paintOf('water')['fill-color']).toBe('#1b2733');
+
+    expect(map.paintOf('water')['fill-color']).toBe(DARK_WATER);
+    // Nothing at all was written for this key: dark's own paint already IS the
+    // target. The old code wrote positron's pristine over it.
+    const fillColorWrites = map.setPaintProperty.mock.calls.filter(
+      (c) => c[0] === 'water' && c[1] === 'fill-color',
+    );
+    expect(fillColorWrites).toEqual([]);
   });
 });

--- a/frontend/src/components/builder/__tests__/map-sync.basemap-revert.test.ts
+++ b/frontend/src/components/builder/__tests__/map-sync.basemap-revert.test.ts
@@ -1,0 +1,130 @@
+/**
+ * fix(#1778): "applyBasemapConfigToMap's paint diff can never CLEAR a basemap
+ * override" (codebase audit 2026-08-30).
+ *
+ * applyBasemapConfigToMap reads the LIVE style, so on a revert pass the value
+ * `applyBasemapConfigToStyle` produced was the tint the PREVIOUS pass had
+ * written; it compared equal and nothing was written back. The map stayed
+ * tinted for the rest of the session while React state, the stack row and the
+ * saved payload all said "default".
+ *
+ * Every test here therefore runs the helper TWICE against a map whose
+ * `getStyle()` reflects the first pass's writes. The existing coverage in
+ * BuilderMap.unit.test.ts uses a fixed style and only asserts the apply
+ * direction, which is why the revert direction went unnoticed.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import type { StyleSpecification } from 'maplibre-gl';
+import { applyBasemapConfigToMap } from '@/components/builder/map-sync';
+import { DEFAULT_BASEMAP_CONFIG } from '@/lib/basemap-utils';
+
+/** A map mock whose setPaintProperty MUTATES the style it hands back, which is
+ *  what the real MapLibre map does and what the bug depended on. */
+function createLiveStyleMap(layers: StyleSpecification['layers']) {
+  const style = {
+    version: 8 as const,
+    sources: {},
+    layers: layers.map((layer) => ({ ...layer, paint: { ...('paint' in layer ? layer.paint : {}) } })),
+  } as unknown as StyleSpecification;
+  const byId = new Map(style.layers.map((layer) => [layer.id, layer]));
+  return {
+    getStyle: vi.fn(() => style),
+    getLayer: vi.fn((id: string) => byId.get(id)),
+    setLayoutProperty: vi.fn(),
+    setPaintProperty: vi.fn((id: string, key: string, value: unknown) => {
+      const layer = byId.get(id) as { paint?: Record<string, unknown> } | undefined;
+      if (!layer) return;
+      layer.paint = { ...(layer.paint ?? {}) };
+      if (value === undefined) delete layer.paint[key];
+      else layer.paint[key] = value;
+    }),
+    on: vi.fn(),
+    paintOf: (id: string) => ((byId.get(id) as { paint?: Record<string, unknown> })?.paint ?? {}),
+  };
+}
+
+describe('applyBasemapConfigToMap revert passes', () => {
+  it('restores the original water fill when land_water_tone returns to default', () => {
+    const map = createLiveStyleMap([
+      { id: 'water', type: 'fill', source: 'openmaptiles', paint: { 'fill-color': '#a0c8f0' } },
+    ] as unknown as StyleSpecification['layers']);
+
+    applyBasemapConfigToMap(map as never, { ...DEFAULT_BASEMAP_CONFIG, land_water_tone: 'monochrome' });
+    expect(map.paintOf('water')['fill-color']).toBe('#d9dde0');
+
+    applyBasemapConfigToMap(map as never, { ...DEFAULT_BASEMAP_CONFIG });
+    expect(map.paintOf('water')['fill-color']).toBe('#a0c8f0');
+  });
+
+  it('restores the original background colour when the override is cleared', () => {
+    const map = createLiveStyleMap([
+      { id: 'background', type: 'background', paint: { 'background-color': '#fafaf8' } },
+    ] as unknown as StyleSpecification['layers']);
+
+    applyBasemapConfigToMap(map as never, { ...DEFAULT_BASEMAP_CONFIG, background_color: '#101820' });
+    expect(map.paintOf('background')['background-color']).toBe('#101820');
+
+    applyBasemapConfigToMap(map as never, null);
+    expect(map.paintOf('background')['background-color']).toBe('#fafaf8');
+  });
+
+  it('restores hillshade paint when relief_contrast is cleared', () => {
+    const map = createLiveStyleMap([
+      { id: 'hillshade', type: 'hillshade', source: 'terrain', paint: { 'hillshade-exaggeration': 0.2 } },
+    ] as unknown as StyleSpecification['layers']);
+
+    applyBasemapConfigToMap(map as never, { ...DEFAULT_BASEMAP_CONFIG, relief_contrast: 'strong' });
+    expect(map.paintOf('hillshade')['hillshade-exaggeration']).toBe(0.85);
+    expect(map.paintOf('hillshade')['hillshade-shadow-color']).toBe('#47545c');
+
+    applyBasemapConfigToMap(map as never, { ...DEFAULT_BASEMAP_CONFIG });
+    expect(map.paintOf('hillshade')['hillshade-exaggeration']).toBe(0.2);
+    // A key the pristine style never carried is unset, not left stranded.
+    expect(map.paintOf('hillshade')).not.toHaveProperty('hillshade-shadow-color');
+  });
+
+  it('clears the label halo width stamped by label_mode subtle', () => {
+    const map = createLiveStyleMap([
+      { id: 'place-label', type: 'symbol', source: 'openmaptiles', paint: { 'text-color': '#333' } },
+    ] as unknown as StyleSpecification['layers']);
+
+    applyBasemapConfigToMap(map as never, { ...DEFAULT_BASEMAP_CONFIG, label_mode: 'subtle' });
+    expect(map.paintOf('place-label')['text-halo-width']).toBe(0.8);
+
+    applyBasemapConfigToMap(map as never, { ...DEFAULT_BASEMAP_CONFIG, label_mode: 'full' });
+    expect(map.paintOf('place-label')).not.toHaveProperty('text-halo-width');
+  });
+
+  it('leaves paint keys this helper never wrote alone', () => {
+    const map = createLiveStyleMap([
+      { id: 'water', type: 'fill', source: 'openmaptiles', paint: { 'fill-color': '#a0c8f0' } },
+    ] as unknown as StyleSpecification['layers']);
+
+    applyBasemapConfigToMap(map as never, { ...DEFAULT_BASEMAP_CONFIG, land_water_tone: 'muted' });
+    // Stand in for applySublayerOverrides, which runs right after this helper.
+    map.setPaintProperty('water', 'fill-outline-color', '#123456');
+
+    applyBasemapConfigToMap(map as never, { ...DEFAULT_BASEMAP_CONFIG });
+    expect(map.paintOf('water')['fill-outline-color']).toBe('#123456');
+  });
+
+  it('drops the pristine snapshot when a new style loads', () => {
+    const map = createLiveStyleMap([
+      { id: 'water', type: 'fill', source: 'openmaptiles', paint: { 'fill-color': '#a0c8f0' } },
+    ] as unknown as StyleSpecification['layers']);
+
+    applyBasemapConfigToMap(map as never, { ...DEFAULT_BASEMAP_CONFIG, land_water_tone: 'muted' });
+    expect(map.paintOf('water')['fill-color']).toBe('#d8e5e8');
+
+    // A basemap swap replaces the style; positron and dark share layer ids, so
+    // a cache that survived it would restore the previous basemap's colours.
+    const styleLoad = map.on.mock.calls.find((c) => c[0] === 'style.load')?.[1] as () => void;
+    expect(styleLoad).toBeTypeOf('function');
+    map.setPaintProperty('water', 'fill-color', '#1b2733');
+    styleLoad();
+
+    applyBasemapConfigToMap(map as never, { ...DEFAULT_BASEMAP_CONFIG, land_water_tone: 'muted' });
+    applyBasemapConfigToMap(map as never, { ...DEFAULT_BASEMAP_CONFIG });
+    expect(map.paintOf('water')['fill-color']).toBe('#1b2733');
+  });
+});

--- a/frontend/src/components/builder/__tests__/map-sync.basemap-revert.test.ts
+++ b/frontend/src/components/builder/__tests__/map-sync.basemap-revert.test.ts
@@ -15,7 +15,7 @@
  */
 import { describe, it, expect, vi } from 'vitest';
 import type { StyleSpecification } from 'maplibre-gl';
-import { applyBasemapConfigToMap } from '@/components/builder/map-sync';
+import { applyBasemapConfigToMap, registerBasemapStyleGeneration } from '@/components/builder/map-sync';
 import { DEFAULT_BASEMAP_CONFIG } from '@/lib/basemap-utils';
 import type { MapBasemapConfig } from '@/types/api';
 
@@ -198,5 +198,74 @@ describe('applyBasemapConfigToMap revert passes', () => {
       (c) => c[0] === 'water' && c[1] === 'fill-color',
     );
     expect(fillColorWrites).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// fix(#1778 codex round 5 P2): the residual the round-2 note flagged. Per-key
+// equality reconciliation cannot see a swap whose new NATIVE value equals the
+// override the old style was carrying, because nothing changed from the paint's
+// point of view. A style-generation counter closes it, and the counter only
+// works if its listener is the earliest one registered, which is why
+// registerBasemapStyleGeneration lives in the map-creation path rather than in
+// an appearance pass.
+// ---------------------------------------------------------------------------
+describe('registerBasemapStyleGeneration', () => {
+  it('registers exactly one style.load listener, and only once per map', () => {
+    const map = createLiveStyleMap(waterLayer(POSITRON_WATER));
+
+    registerBasemapStyleGeneration(map as never);
+    registerBasemapStyleGeneration(map as never);
+    registerBasemapStyleGeneration(map as never);
+
+    const styleLoadRegistrations = map.on.mock.calls.filter((c) => c[0] === 'style.load');
+    expect(styleLoadRegistrations).toHaveLength(1);
+  });
+
+  it('tolerates a partial map mock with no `on`', () => {
+    expect(() => registerBasemapStyleGeneration({} as never)).not.toThrow();
+  });
+
+  it('re-snapshots pristine when the new style natively carries the old override value', () => {
+    const map = createLiveStyleMap(waterLayer(POSITRON_WATER));
+    const config: { current: MapBasemapConfig } = {
+      current: { ...DEFAULT_BASEMAP_CONFIG, land_water_tone: 'monochrome' },
+    };
+
+    // Registration order as production has it: the generation listener goes on
+    // in the map-creation path, BEFORE the appearance handler exists.
+    registerBasemapStyleGeneration(map as never);
+    map.on('style.load', () => applyBasemapConfigToMap(map as never, config.current));
+
+    map.loadStyle(waterLayer(POSITRON_WATER));
+    expect(map.paintOf('water')['fill-color']).toBe(MONOCHROME_WATER);
+
+    // Style B's OWN water colour is exactly the override style A was carrying,
+    // so every cached key still compares equal and the per-key reconciliation
+    // sees nothing at all.
+    map.loadStyle(waterLayer(MONOCHROME_WATER));
+    expect(map.paintOf('water')['fill-color']).toBe(MONOCHROME_WATER);
+
+    // Clearing the override must leave B's native colour in place, not restore
+    // A's. Counterfactual: without the generation counter this writes
+    // POSITRON_WATER.
+    config.current = { ...DEFAULT_BASEMAP_CONFIG };
+    applyBasemapConfigToMap(map as never, config.current);
+    expect(map.paintOf('water')['fill-color']).toBe(MONOCHROME_WATER);
+  });
+
+  it('still reverts to the styles own pristine after a generation bump', () => {
+    const map = createLiveStyleMap(waterLayer(POSITRON_WATER));
+    registerBasemapStyleGeneration(map as never);
+
+    applyBasemapConfigToMap(map as never, { ...DEFAULT_BASEMAP_CONFIG, land_water_tone: 'monochrome' });
+    expect(map.paintOf('water')['fill-color']).toBe(MONOCHROME_WATER);
+
+    map.loadStyle(waterLayer(DARK_WATER));
+    applyBasemapConfigToMap(map as never, { ...DEFAULT_BASEMAP_CONFIG, land_water_tone: 'monochrome' });
+    expect(map.paintOf('water')['fill-color']).toBe(MONOCHROME_WATER);
+
+    applyBasemapConfigToMap(map as never, { ...DEFAULT_BASEMAP_CONFIG });
+    expect(map.paintOf('water')['fill-color']).toBe(DARK_WATER);
   });
 });

--- a/frontend/src/components/builder/__tests__/map-sync.data-driven-cols.test.ts
+++ b/frontend/src/components/builder/__tests__/map-sync.data-driven-cols.test.ts
@@ -202,6 +202,44 @@ describe('getDataDrivenColumnsForLayer', () => {
     });
     expect(cols).toEqual([]);
   });
+
+  // fix(#1778): the symbol adapter's per-category icon-image is a data-driven
+  // LAYOUT expression, so the paint walk cannot reach it. Counterfactual: on
+  // main both cases return [] and the tile request omits the column, so every
+  // feature renders the fallback icon below z10.
+  it('extracts the symbol category column from style_config.symbol', () => {
+    const cols = getDataDrivenColumnsForLayer({
+      style_config: {
+        render_mode: 'symbol',
+        symbol: { categoryColumn: 'facility_type', categories: [{ value: 'school', icon: 'school' }] },
+      },
+      paint: {},
+    });
+    expect(cols).toEqual(['facility_type']);
+  });
+
+  it('extracts the symbol category column stashed under style_config.builder', () => {
+    const cols = getDataDrivenColumnsForLayer({
+      style_config: {
+        render_mode: 'symbol',
+        builder: { symbol: { categoryColumn: 'hazard_class' } },
+      },
+      paint: {},
+    });
+    expect(cols).toEqual(['hazard_class']);
+  });
+
+  it('prefers the top-level symbol config over the builder-stashed one', () => {
+    const cols = getDataDrivenColumnsForLayer({
+      style_config: {
+        render_mode: 'symbol',
+        symbol: { categoryColumn: 'top_level' },
+        builder: { symbol: { categoryColumn: 'stashed' } },
+      },
+      paint: {},
+    });
+    expect(cols).toEqual(['top_level']);
+  });
 });
 
 describe('getDataDrivenColumnsForSource', () => {

--- a/frontend/src/components/builder/__tests__/map-sync.data-driven-cols.test.ts
+++ b/frontend/src/components/builder/__tests__/map-sync.data-driven-cols.test.ts
@@ -240,6 +240,37 @@ describe('getDataDrivenColumnsForLayer', () => {
     });
     expect(cols).toEqual(['top_level']);
   });
+
+  // fix(#1778 codex round 2 P2): `style_config.symbol ?? style_config.builder.symbol`
+  // picked ONE object whole, so a categoryColumn stashed under `builder` was
+  // dropped the moment any top-level symbol object existed. The adapter merges
+  // the two field by field, and the tile column list has to resolve the column
+  // from the same merged object or the icons fall back below z10 exactly as if
+  // the column had never been read.
+  // Counterfactual: with the `??`, both cases below return [].
+  it('merges a builder-stashed category column under a partial top-level symbol config', () => {
+    const cols = getDataDrivenColumnsForLayer({
+      style_config: {
+        render_mode: 'symbol',
+        symbol: { iconSize: 1.5 },
+        builder: { symbol: { categoryColumn: 'kind' } },
+      },
+      paint: {},
+    });
+    expect(cols).toEqual(['kind']);
+  });
+
+  it('merges when the top-level symbol config carries no icon fields at all', () => {
+    const cols = getDataDrivenColumnsForLayer({
+      style_config: {
+        render_mode: 'symbol',
+        symbol: {},
+        builder: { symbol: { categoryColumn: 'kind' } },
+      },
+      paint: {},
+    });
+    expect(cols).toEqual(['kind']);
+  });
 });
 
 describe('getDataDrivenColumnsForSource', () => {

--- a/frontend/src/components/builder/__tests__/map-sync.dedupe.test.ts
+++ b/frontend/src/components/builder/__tests__/map-sync.dedupe.test.ts
@@ -21,6 +21,11 @@ Object.defineProperty(window, 'location', {
 
 function createMockMap() {
   const sources = new Map<string, { type: string; tiles?: string[] }>();
+  // fix(#1778): record the whole spec, not just the id. getStyle() on a real
+  // map reports each layer's `source`, and the orphan prune reads it to tell a
+  // managed data layer apart from a basemap layer that happens to be named
+  // `layer-*`.
+  const layerSpecs = new Map<string, { id: string; source?: string }>();
   const layerIds = new Set<string>();
   return {
     getSource: vi.fn((id: string) => sources.get(id) ?? null),
@@ -30,12 +35,14 @@ function createMockMap() {
     removeSource: vi.fn((id: string) => {
       sources.delete(id);
     }),
-    addLayer: vi.fn((layer: { id: string }) => {
+    addLayer: vi.fn((layer: { id: string; source?: string }) => {
       layerIds.add(layer.id);
+      layerSpecs.set(layer.id, layer);
     }),
     getLayer: vi.fn((id: string) => (layerIds.has(id) ? { id } : null)),
     removeLayer: vi.fn((id: string) => {
       layerIds.delete(id);
+      layerSpecs.delete(id);
     }),
     setLayoutProperty: vi.fn(),
     setPaintProperty: vi.fn(),
@@ -45,7 +52,7 @@ function createMockMap() {
     getFilter: vi.fn().mockReturnValue(null),
     isStyleLoaded: vi.fn(() => true),
     getStyle: vi.fn(() => ({
-      layers: Array.from(layerIds).map((id) => ({ id })),
+      layers: Array.from(layerIds).map((id) => layerSpecs.get(id) ?? { id }),
     })),
     moveLayer: vi.fn(),
     setLayerZoomRange: vi.fn(),
@@ -233,6 +240,54 @@ describe('syncLayersToMap dedupes addSource by dataset_table_name', () => {
 
     // The shared source must NOT be removed — the other layer still uses it.
     expect(map.removeSource).not.toHaveBeenCalledWith('source-data-reefs');
+  });
+
+  // fix(#1778): the source prune is keyed on the SOURCE, and the whole prune
+  // body sits behind `if (desiredSources.has(sourceId)) continue`. Under the
+  // SF-04 dedupe the deleted layer's source is still desired by its sibling, so
+  // nothing ever reclaimed the orphan layer rows. They kept rendering with no
+  // stack row, no legend entry and no way to remove them short of a reload.
+  // Counterfactual: on main the three assertions below all find the layers
+  // still present.
+  it('removes the layer rows of a deleted layer whose deduped source is still shared', () => {
+    const layers: SyncLayerInput[] = [
+      makeLayer({ id: 'l1', dataset_id: 'ds-reefs', dataset_table_name: 'reefs' }),
+      makeLayer({ id: 'l2', dataset_id: 'ds-reefs', dataset_table_name: 'reefs' }),
+    ];
+    const tokenMap = new Map<string, TileToken>([['ds-reefs', makeVectorToken()]]);
+
+    syncLayersToMap(map, layers, tokenMap, undefined, managedSourcesRef, { current: '' });
+    expect(map.getLayer('layer-l1')).toBeTruthy();
+
+    // The companions the delete path would normally have swept, left behind
+    // because removePerLayerCompanions ran mid-style-swap.
+    map.addLayer({ id: 'layer-l1-outline', type: 'line', source: 'source-data-reefs' } as never);
+    map.addLayer({ id: 'layer-l1-label', type: 'symbol', source: 'source-data-reefs' } as never);
+
+    syncLayersToMap(map, [layers[1]], tokenMap, undefined, managedSourcesRef, { current: '' });
+
+    expect(map.getLayer('layer-l1')).toBeNull();
+    expect(map.getLayer('layer-l1-outline')).toBeNull();
+    expect(map.getLayer('layer-l1-label')).toBeNull();
+    // The surviving sibling and the shared source are untouched.
+    expect(map.getLayer('layer-l2')).toBeTruthy();
+    expect(map.removeSource).not.toHaveBeenCalledWith('source-data-reefs');
+  });
+
+  it('leaves style layers outside the managed layer- namespace alone', () => {
+    const layers: SyncLayerInput[] = [
+      makeLayer({ id: 'l1', dataset_id: 'ds-reefs', dataset_table_name: 'reefs' }),
+    ];
+    const tokenMap = new Map<string, TileToken>([['ds-reefs', makeVectorToken()]]);
+    syncLayersToMap(map, layers, tokenMap, undefined, managedSourcesRef, { current: '' });
+
+    map.addLayer({ id: 'water', type: 'fill', source: 'openmaptiles' } as never);
+    map.addLayer({ id: 'ephemeral-result-fill', type: 'fill', source: 'ephemeral' } as never);
+
+    syncLayersToMap(map, layers, tokenMap, undefined, managedSourcesRef, { current: '' });
+
+    expect(map.getLayer('water')).toBeTruthy();
+    expect(map.getLayer('ephemeral-result-fill')).toBeTruthy();
   });
 
   it('two non-cluster vector layers on the SAME dataset BOTH render (2nd layer on a shared source still gets added)', () => {

--- a/frontend/src/components/builder/hooks/__tests__/builder-layer-mutations.test.ts
+++ b/frontend/src/components/builder/hooks/__tests__/builder-layer-mutations.test.ts
@@ -26,6 +26,8 @@ function makeMap(overrides: {
     isStyleLoaded: overrides.isStyleLoaded ?? vi.fn(() => true),
     getLayer: overrides.getLayer ?? vi.fn((id: string) => ({ id })),
     removeLayer: overrides.removeLayer ?? vi.fn(),
+    // fix(#1778): the helper defers to `idle` when the style is mid-swap.
+    once: vi.fn(),
   };
 }
 
@@ -177,6 +179,46 @@ describe('removePerLayerCompanions — per-render-mode regression (MAP-17)', () 
     removePerLayerCompanions(map as never, ['l1'], renderModeByLayerId);
 
     expect(removeLayer).not.toHaveBeenCalled();
+  });
+
+  // fix(#1778): the bare early return above used to be the whole story, so a
+  // delete during a basemap style swap left the companions on the map for the
+  // rest of the session: no stack row, no legend entry, unclickable, and baked
+  // into any capture taken afterwards. Counterfactual: on main `once` is never
+  // called and the retry assertion below fails.
+  it('Test 7b: style not loaded → retries the sweep on idle', () => {
+    const removeLayer = vi.fn();
+    const isStyleLoaded = vi.fn(() => false);
+    const map = makeMap({ isStyleLoaded, removeLayer });
+    const renderModeByLayerId = new Map([['l1', 'fill']]);
+
+    removePerLayerCompanions(map as never, ['l1'], renderModeByLayerId);
+    expect(removeLayer).not.toHaveBeenCalled();
+
+    const idleCall = map.once.mock.calls.find((c) => c[0] === 'idle');
+    expect(idleCall).toBeDefined();
+    isStyleLoaded.mockReturnValue(true);
+    (idleCall![1] as () => void)();
+
+    expect(removeLayer).toHaveBeenCalledWith('layer-l1');
+    expect(removeLayer).toHaveBeenCalledWith('layer-l1-outline');
+    expect(removeLayer).toHaveBeenCalledWith('layer-l1-extrusion');
+  });
+
+  it('Test 7c: replays a single-pass iterable on the idle retry', () => {
+    const removeLayer = vi.fn();
+    const isStyleLoaded = vi.fn(() => false);
+    const map = makeMap({ isStyleLoaded, removeLayer });
+    // A Set's iterator is re-iterable, but a generator's is not, so the retry
+    // must not depend on the caller's iterable surviving a second walk.
+    function* once(): Generator<string> { yield 'l1'; }
+
+    removePerLayerCompanions(map as never, once());
+    const idleCall = map.once.mock.calls.find((c) => c[0] === 'idle');
+    isStyleLoaded.mockReturnValue(true);
+    (idleCall![1] as () => void)();
+
+    expect(removeLayer).toHaveBeenCalledWith('layer-l1');
   });
 
   it('Test 8: multiple layer ids in one call → sweeps each independently', () => {

--- a/frontend/src/components/builder/hooks/__tests__/use-builder-layers-save-integration.test.ts
+++ b/frontend/src/components/builder/hooks/__tests__/use-builder-layers-save-integration.test.ts
@@ -275,6 +275,46 @@ describe('fix(#1778): delete prunes the Save-diff baseline on an already-dirty m
     expect(diff.updated).toEqual([{ id: 'keep', opacity: 0.4 }]);
   });
 
+  // fix(#1778 codex round 1 P2): the baseline prune used to run only when the
+  // WHOLE batch succeeded. On a partial success the confirmed-deleted rows left
+  // local state anyway, so they stayed in both baselines, the next Save
+  // re-emitted them in diff.removed, and the stale-conflict recovery fired (or
+  // the save failed outright when the refetch was unavailable).
+  // Counterfactual: drop the prune from the partial branch and diff.removed
+  // carries bulk-a.
+  it('partial bulk delete prunes only the confirmed-deleted ids from the baselines', async () => {
+    const keep = makeBuilderLayer({ id: 'keep', dataset_id: 'ds-keep', sort_order: 0 });
+    const a = makeBuilderLayer({ id: 'bulk-a', dataset_id: 'ds-a', sort_order: 1 });
+    const b = makeBuilderLayer({ id: 'bulk-b', dataset_id: 'ds-b', sort_order: 2 });
+    const { result } = renderCombined(makeBuilderMap([keep, a, b]));
+
+    act(() => { result.current.handleOpacityChange('keep', 0.4); });
+    expect(result.current.hasUnsavedChanges).toBe(true);
+
+    mockBulkDeleteLayers.mockResolvedValueOnce({
+      deleted: ['bulk-a'],
+      failed: [{ id: 'bulk-b', reason: 'layer in use' }],
+    });
+    await act(async () => { await result.current.handleBulkDelete(new Set(['bulk-a', 'bulk-b'])); });
+
+    // bulk-b's delete failed, so it is back in local state.
+    expect(result.current.localLayers.map((l) => l.id)).toContain('bulk-b');
+    expect(result.current.localLayers.map((l) => l.id)).not.toContain('bulk-a');
+    // Only the confirmed-deleted id leaves the refetch-resync baseline. Checked
+    // before the save, because a clean map lets the apiLayers resync effect
+    // rehydrate this ref from the (static) mock map payload.
+    expect(result.current.savedLayerBaseline.map((l) => l.id)).toContain('bulk-b');
+    expect(result.current.savedLayerBaseline.map((l) => l.id)).not.toContain('bulk-a');
+
+    await act(async () => { await result.current.handleSave(); });
+
+    expect(mockPatchMapLayersMutateAsync).toHaveBeenCalledOnce();
+    const [{ diff }] = mockPatchMapLayersMutateAsync.mock.calls[0];
+    // bulk-a is gone server-side, so naming it would be the stale diff again.
+    // bulk-b is still on the server and still local, so it is not removed either.
+    expect(diff.removed).toBeUndefined();
+  });
+
   it('bulk delete after an unrelated edit emits no removed ids', async () => {
     const keep = makeBuilderLayer({ id: 'keep', dataset_id: 'ds-keep', sort_order: 0 });
     const a = makeBuilderLayer({ id: 'bulk-a', dataset_id: 'ds-a', sort_order: 1 });

--- a/frontend/src/components/builder/hooks/__tests__/use-builder-layers-save-integration.test.ts
+++ b/frontend/src/components/builder/hooks/__tests__/use-builder-layers-save-integration.test.ts
@@ -28,13 +28,13 @@ import { act } from '@testing-library/react';
 import { useRef } from 'react';
 import { renderHook } from '@/test/test-utils';
 import { useBuilderLayers } from '@/components/builder/hooks/use-builder-layers';
-import { useBuilderSave, __resetThumbnailDebounceForTests } from '@/components/builder/hooks/use-builder-save';
+import { useBuilderSave, __resetThumbnailDebounceForTests, type SaveBaselineSync } from '@/components/builder/hooks/use-builder-save';
 import {
   makeBuilderLayer,
   makeBuilderMap,
 } from '@/components/builder/__tests__/fixtures/map-builder-fixtures';
 import { isFolderGroupLayer } from '@/lib/layer-capabilities';
-import type { MapLayerResponse, MapResponse } from '@/types/api';
+import type { MapResponse } from '@/types/api';
 
 type MaplibreMap = import('maplibre-gl').Map;
 
@@ -65,6 +65,14 @@ vi.mock('sonner', () => ({
   toast: { success: vi.fn(), error: vi.fn(), warning: vi.fn(), info: vi.fn() },
 }));
 
+const mockBulkDeleteLayers = vi.fn();
+vi.mock('@/api/maps', () => ({
+  bulkDeleteLayersApi: (...args: unknown[]) => mockBulkDeleteLayers(...args),
+  getMap: vi.fn(),
+  uploadThumbnail: vi.fn(() => Promise.resolve()),
+  uploadOgImage: vi.fn(() => Promise.resolve()),
+}));
+
 // useUnsavedGuard's useBlocker requires a Data Router; MemoryRouter (used by
 // the shared renderHook wrapper) doesn't provide one — stub it like
 // use-builder-save.test.ts does.
@@ -86,7 +94,7 @@ function useCombinedBuilder(
   // fix(#392): the SAME callback-ref bridge MapBuilderPage owns between
   // useBuilderLayers and useBuilderSave — see MapBuilderPage.tsx (~line 204+7)
   // and use-builder-save.ts's `saveBaselineSyncRef` effect.
-  const saveBaselineSyncRef = useRef<(layer: MapLayerResponse) => void>(() => {});
+  const saveBaselineSyncRef = useRef<SaveBaselineSync>({ add: () => {}, remove: () => {} });
 
   const layers = useBuilderLayers(
     mapData,
@@ -121,11 +129,12 @@ function useCombinedBuilder(
 
 function renderCombined(mapData: MapResponse, mapId = 'map-1') {
   const mutate = vi.fn();
+  const removeMutate = vi.fn();
   const addLayerMutation = { mutate } as unknown as Parameters<typeof useBuilderLayers>[3];
-  const removeLayerMutation = { mutate: vi.fn() } as unknown as Parameters<typeof useBuilderLayers>[4];
+  const removeLayerMutation = { mutate: removeMutate } as unknown as Parameters<typeof useBuilderLayers>[4];
 
   const out = renderHook(() => useCombinedBuilder(mapData, mapId, addLayerMutation, removeLayerMutation));
-  return { ...out, mutate };
+  return { ...out, mutate, removeMutate };
 }
 
 describe('fix(#392): duplicate-layer-on-save P1 — Save-diff baseline sync', () => {
@@ -217,5 +226,72 @@ describe('fix(#392): duplicate-layer-on-save P1 — Save-diff baseline sync', ()
     expect(createdUpdate).toBeDefined();
     const builder = (createdUpdate?.style_config as { builder?: { folderGroupId?: string } } | undefined)?.builder;
     expect(builder?.folderGroupId).toBe(groupId);
+  });
+});
+
+/**
+ * fix(#1778): "layer deletes prune the clean-state baseline but never the
+ * save-diff baseline, so a delete on an already-dirty map guarantees a stale
+ * diff on the next save" (codebase audit 2026-08-30).
+ *
+ * There are two baselines. `savedLayerBaselineRef` (use-builder-layers) IS
+ * pruned by both delete paths. The save-diff baseline `baselineLayersRef`
+ * (use-builder-save) only refreshes while the map is CLEAN, and the bridge
+ * between them was add-only, so "style something, then delete a layer, then
+ * save" emitted the already-deleted id in diff.removed. The backend rejects
+ * that with 400 "Layer diff references layer ids outside this map".
+ *
+ * Counterfactual: with the `remove` half of the bridge taken out, both tests
+ * below see `diff.removed` carry the deleted id.
+ */
+describe('fix(#1778): delete prunes the Save-diff baseline on an already-dirty map', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    __resetThumbnailDebounceForTests();
+    mockUpdateMapMutateAsync.mockImplementation(async (payload: { id: string }) => ({ id: payload.id, layers: [] }));
+    mockPatchMapLayersMutateAsync.mockResolvedValue({ id: 'map-1', layers: [] });
+  });
+
+  it('single delete after an unrelated edit emits no removed id', async () => {
+    const keep = makeBuilderLayer({ id: 'keep', dataset_id: 'ds-keep', sort_order: 0 });
+    const doomed = makeBuilderLayer({ id: 'doomed', dataset_id: 'ds-doomed', sort_order: 1 });
+    const { result, removeMutate } = renderCombined(makeBuilderMap([keep, doomed]));
+
+    // Dirty the map first. This is the precondition that froze the baseline.
+    act(() => { result.current.handleOpacityChange('keep', 0.4); });
+    expect(result.current.hasUnsavedChanges).toBe(true);
+
+    act(() => { result.current.handleRemove('doomed'); });
+    expect(removeMutate).toHaveBeenCalledOnce();
+    const [, handlers] = removeMutate.mock.calls[0];
+    act(() => { handlers.onSuccess(); });
+
+    await act(async () => { await result.current.handleSave(); });
+
+    expect(mockPatchMapLayersMutateAsync).toHaveBeenCalledOnce();
+    const [{ diff }] = mockPatchMapLayersMutateAsync.mock.calls[0];
+    expect(diff.removed).toBeUndefined();
+    // The real edit still goes out.
+    expect(diff.updated).toEqual([{ id: 'keep', opacity: 0.4 }]);
+  });
+
+  it('bulk delete after an unrelated edit emits no removed ids', async () => {
+    const keep = makeBuilderLayer({ id: 'keep', dataset_id: 'ds-keep', sort_order: 0 });
+    const a = makeBuilderLayer({ id: 'bulk-a', dataset_id: 'ds-a', sort_order: 1 });
+    const b = makeBuilderLayer({ id: 'bulk-b', dataset_id: 'ds-b', sort_order: 2 });
+    const { result } = renderCombined(makeBuilderMap([keep, a, b]));
+
+    act(() => { result.current.handleOpacityChange('keep', 0.4); });
+    expect(result.current.hasUnsavedChanges).toBe(true);
+
+    mockBulkDeleteLayers.mockResolvedValueOnce({ deleted: ['bulk-a', 'bulk-b'], failed: [] });
+    await act(async () => { await result.current.handleBulkDelete(new Set(['bulk-a', 'bulk-b'])); });
+
+    await act(async () => { await result.current.handleSave(); });
+
+    expect(mockPatchMapLayersMutateAsync).toHaveBeenCalledOnce();
+    const [{ diff }] = mockPatchMapLayersMutateAsync.mock.calls[0];
+    expect(diff.removed).toBeUndefined();
+    expect(diff.updated).toEqual([{ id: 'keep', opacity: 0.4 }]);
   });
 });

--- a/frontend/src/components/builder/hooks/__tests__/use-builder-layers.add-dataset.test.ts
+++ b/frontend/src/components/builder/hooks/__tests__/use-builder-layers.add-dataset.test.ts
@@ -89,7 +89,7 @@ function renderBuilderLayers(
   const removeLayerMutation = { mutate: vi.fn() } as unknown as Parameters<typeof useBuilderLayers>[4];
   // fix(#392): 6th positional param bridging into useBuilderSave's Save-diff baseline.
   const saveBaselineSync = vi.fn();
-  const saveBaselineSyncRef = { current: saveBaselineSync } as unknown as Parameters<typeof useBuilderLayers>[5];
+  const saveBaselineSyncRef = { current: { add: saveBaselineSync, remove: () => {} } } as unknown as Parameters<typeof useBuilderLayers>[5];
 
   const out = renderHook(() =>
     useBuilderLayers(

--- a/frontend/src/components/builder/hooks/__tests__/use-builder-layers.bulk-ops.test.ts
+++ b/frontend/src/components/builder/hooks/__tests__/use-builder-layers.bulk-ops.test.ts
@@ -121,7 +121,7 @@ function renderBuilderLayers(
 
   // fix(#392): 6th positional param bridging into useBuilderSave's Save-diff
   // baseline — a plain no-op ref is sufficient for tests that don't assert on it.
-  const saveBaselineSyncRef = { current: () => {} } as unknown as Parameters<typeof useBuilderLayers>[5];
+  const saveBaselineSyncRef = { current: { add: () => {}, remove: () => {} } } as unknown as Parameters<typeof useBuilderLayers>[5];
 
   const out = renderHook(() =>
     useBuilderLayers(

--- a/frontend/src/components/builder/hooks/__tests__/use-builder-layers.clean-recheck.test.ts
+++ b/frontend/src/components/builder/hooks/__tests__/use-builder-layers.clean-recheck.test.ts
@@ -25,7 +25,7 @@ function render(mapData: MapResponse) {
       'map-1',
       { mutate: vi.fn() } as unknown as Parameters<typeof useBuilderLayers>[3],
       { mutate: vi.fn() } as unknown as Parameters<typeof useBuilderLayers>[4],
-      { current: () => {} } as unknown as Parameters<typeof useBuilderLayers>[5],
+      { current: { add: () => {}, remove: () => {} } } as unknown as Parameters<typeof useBuilderLayers>[5],
     ),
   );
 }

--- a/frontend/src/components/builder/hooks/__tests__/use-builder-layers.cluster-defer.test.ts
+++ b/frontend/src/components/builder/hooks/__tests__/use-builder-layers.cluster-defer.test.ts
@@ -73,7 +73,7 @@ function renderBuilderLayersHook(
   const addLayerMutation = { mutate: vi.fn() } as unknown as Parameters<typeof useBuilderLayers>[3];
   const removeLayerMutation = { mutate: vi.fn() } as unknown as Parameters<typeof useBuilderLayers>[4];
   // fix(#392): 6th positional param bridging into useBuilderSave's Save-diff baseline.
-  const saveBaselineSyncRef = { current: () => {} } as unknown as Parameters<typeof useBuilderLayers>[5];
+  const saveBaselineSyncRef = { current: { add: () => {}, remove: () => {} } } as unknown as Parameters<typeof useBuilderLayers>[5];
   return renderHook(() =>
     useBuilderLayers(mapData, mapRef, 'map-cluster', addLayerMutation, removeLayerMutation, saveBaselineSyncRef),
   );

--- a/frontend/src/components/builder/hooks/__tests__/use-builder-layers.dedupe.test.ts
+++ b/frontend/src/components/builder/hooks/__tests__/use-builder-layers.dedupe.test.ts
@@ -46,7 +46,7 @@ function renderBuilder(mapData: MapResponse, mapRef: React.RefObject<MaplibreMap
   const addLayerMutation = { mutate: vi.fn() } as unknown as Parameters<typeof useBuilderLayers>[3];
   const removeLayerMutation = { mutate: vi.fn() } as unknown as Parameters<typeof useBuilderLayers>[4];
   // fix(#392): 6th positional param bridging into useBuilderSave's Save-diff baseline.
-  const saveBaselineSyncRef = { current: () => {} } as unknown as Parameters<typeof useBuilderLayers>[5];
+  const saveBaselineSyncRef = { current: { add: () => {}, remove: () => {} } } as unknown as Parameters<typeof useBuilderLayers>[5];
   return renderHook(() =>
     useBuilderLayers(mapData, mapRef, 'map-1', addLayerMutation, removeLayerMutation, saveBaselineSyncRef),
   );

--- a/frontend/src/components/builder/hooks/__tests__/use-builder-layers.delete.test.ts
+++ b/frontend/src/components/builder/hooks/__tests__/use-builder-layers.delete.test.ts
@@ -102,7 +102,7 @@ function renderBuilderLayers(
 
   // fix(#392): 6th positional param bridging into useBuilderSave's Save-diff
   // baseline — a plain no-op ref is sufficient for tests that don't assert on it.
-  const saveBaselineSyncRef = { current: () => {} } as unknown as Parameters<typeof useBuilderLayers>[5];
+  const saveBaselineSyncRef = { current: { add: () => {}, remove: () => {} } } as unknown as Parameters<typeof useBuilderLayers>[5];
 
   const out = renderHook(() =>
     useBuilderLayers(

--- a/frontend/src/components/builder/hooks/__tests__/use-builder-layers.duplicate-group.test.tsx
+++ b/frontend/src/components/builder/hooks/__tests__/use-builder-layers.duplicate-group.test.tsx
@@ -41,7 +41,7 @@ function renderBuilderLayers(
   const removeLayerMutation = { mutate: vi.fn() } as unknown as Parameters<typeof useBuilderLayers>[4];
   // fix(#392): 6th positional param bridging into useBuilderSave's Save-diff baseline.
   const saveBaselineSync = vi.fn();
-  const saveBaselineSyncRef = { current: saveBaselineSync } as unknown as Parameters<typeof useBuilderLayers>[5];
+  const saveBaselineSyncRef = { current: { add: saveBaselineSync, remove: () => {} } } as unknown as Parameters<typeof useBuilderLayers>[5];
 
   const out = renderHook(() =>
     useBuilderLayers(

--- a/frontend/src/components/builder/hooks/__tests__/use-builder-layers.groups.test.ts
+++ b/frontend/src/components/builder/hooks/__tests__/use-builder-layers.groups.test.ts
@@ -28,7 +28,7 @@ function renderBuilderLayers(
   const addLayerMutation = { mutate: vi.fn() } as unknown as Parameters<typeof useBuilderLayers>[3];
   const removeLayerMutation = { mutate: vi.fn() } as unknown as Parameters<typeof useBuilderLayers>[4];
   // fix(#392): 6th positional param bridging into useBuilderSave's Save-diff baseline.
-  const saveBaselineSyncRef = { current: () => {} } as unknown as Parameters<typeof useBuilderLayers>[5];
+  const saveBaselineSyncRef = { current: { add: () => {}, remove: () => {} } } as unknown as Parameters<typeof useBuilderLayers>[5];
 
   return renderHook(() =>
     useBuilderLayers(

--- a/frontend/src/components/builder/hooks/__tests__/use-builder-layers.style-clipboard.test.ts
+++ b/frontend/src/components/builder/hooks/__tests__/use-builder-layers.style-clipboard.test.ts
@@ -55,7 +55,7 @@ function renderBuilderLayers(mapData: MapResponse | undefined) {
   const addLayerMutation = { mutate: vi.fn(), mutateAsync: vi.fn() } as unknown as Parameters<typeof useBuilderLayers>[3];
   const removeLayerMutation = { mutate: vi.fn(), mutateAsync: vi.fn() } as unknown as Parameters<typeof useBuilderLayers>[4];
   // fix(#392): 6th positional param bridging into useBuilderSave's Save-diff baseline.
-  const saveBaselineSyncRef = { current: () => {} } as unknown as Parameters<typeof useBuilderLayers>[5];
+  const saveBaselineSyncRef = { current: { add: () => {}, remove: () => {} } } as unknown as Parameters<typeof useBuilderLayers>[5];
   return renderHook(() =>
     useBuilderLayers(mapData, makeMapRef(), MAP_ID, addLayerMutation, removeLayerMutation, saveBaselineSyncRef),
   );

--- a/frontend/src/components/builder/hooks/__tests__/use-builder-layers.swap-idle-retry.test.ts
+++ b/frontend/src/components/builder/hooks/__tests__/use-builder-layers.swap-idle-retry.test.ts
@@ -58,7 +58,7 @@ function renderBuilderLayersHook(
     mutate: vi.fn(),
   } as unknown as Parameters<typeof useBuilderLayers>[4];
   // fix(#392): 6th positional param bridging into useBuilderSave's Save-diff baseline.
-  const saveBaselineSyncRef = { current: () => {} } as unknown as Parameters<typeof useBuilderLayers>[5];
+  const saveBaselineSyncRef = { current: { add: () => {}, remove: () => {} } } as unknown as Parameters<typeof useBuilderLayers>[5];
   return renderHook(() =>
     useBuilderLayers(
       mapData,

--- a/frontend/src/components/builder/hooks/__tests__/use-builder-layers.terrain-teardown.test.ts
+++ b/frontend/src/components/builder/hooks/__tests__/use-builder-layers.terrain-teardown.test.ts
@@ -103,7 +103,7 @@ function renderBuilderLayers(mapData: MapResponse, opts?: { removeFails?: boolea
   } as unknown as Parameters<typeof useBuilderLayers>[4];
 
   // fix(#392): 6th positional param bridging into useBuilderSave's Save-diff baseline.
-  const saveBaselineSyncRef = { current: () => {} } as unknown as Parameters<typeof useBuilderLayers>[5];
+  const saveBaselineSyncRef = { current: { add: () => {}, remove: () => {} } } as unknown as Parameters<typeof useBuilderLayers>[5];
   return renderHook(() =>
     useBuilderLayers(mapData, makeMapRef(), MAP_ID, addLayerMutation, removeLayerMutation, saveBaselineSyncRef),
   );

--- a/frontend/src/components/builder/hooks/__tests__/use-builder-layers.test.ts
+++ b/frontend/src/components/builder/hooks/__tests__/use-builder-layers.test.ts
@@ -24,7 +24,7 @@ function renderBuilderLayers(
   const addLayerMutation = { mutate: addLayerMutate } as unknown as Parameters<typeof useBuilderLayers>[3];
   const removeLayerMutation = { mutate: removeLayerMutate } as unknown as Parameters<typeof useBuilderLayers>[4];
   // fix(#392): 6th positional param bridging into useBuilderSave's Save-diff baseline.
-  const saveBaselineSyncRef = { current: () => {} } as unknown as Parameters<typeof useBuilderLayers>[5];
+  const saveBaselineSyncRef = { current: { add: () => {}, remove: () => {} } } as unknown as Parameters<typeof useBuilderLayers>[5];
 
   const hook = renderHook(() =>
     useBuilderLayers(
@@ -80,7 +80,7 @@ describe('useBuilderLayers', () => {
     const addLayerMutation = { mutate: vi.fn() } as unknown as Parameters<typeof useBuilderLayers>[3];
     const removeLayerMutation = { mutate: vi.fn() } as unknown as Parameters<typeof useBuilderLayers>[4];
     // fix(#392): 6th positional param bridging into useBuilderSave's Save-diff baseline.
-    const saveBaselineSyncRef = { current: () => {} } as unknown as Parameters<typeof useBuilderLayers>[5];
+    const saveBaselineSyncRef = { current: { add: () => {}, remove: () => {} } } as unknown as Parameters<typeof useBuilderLayers>[5];
     const { result, rerender } = renderHook(() =>
       useBuilderLayers(mapData, mapRef, 'map-1', addLayerMutation, removeLayerMutation, saveBaselineSyncRef),
     );
@@ -97,7 +97,7 @@ describe('useBuilderLayers', () => {
     const mapRef = { current: null } as React.RefObject<MaplibreMap | null>;
     const addLayerMutation = { mutate: vi.fn() } as unknown as Parameters<typeof useBuilderLayers>[3];
     const removeLayerMutation = { mutate: vi.fn() } as unknown as Parameters<typeof useBuilderLayers>[4];
-    const saveBaselineSyncRef = { current: () => {} } as unknown as Parameters<typeof useBuilderLayers>[5];
+    const saveBaselineSyncRef = { current: { add: () => {}, remove: () => {} } } as unknown as Parameters<typeof useBuilderLayers>[5];
     const { result, rerender } = renderHook(() =>
       useBuilderLayers(mapData, mapRef, 'map-1', addLayerMutation, removeLayerMutation, saveBaselineSyncRef),
     );

--- a/frontend/src/components/builder/hooks/__tests__/use-builder-layers.zoom-to-layer.test.ts
+++ b/frontend/src/components/builder/hooks/__tests__/use-builder-layers.zoom-to-layer.test.ts
@@ -28,7 +28,7 @@ function renderWithLayer(bbox: number[] | null) {
       'map-1',
       { mutate: vi.fn() } as unknown as Parameters<typeof useBuilderLayers>[3],
       { mutate: vi.fn() } as unknown as Parameters<typeof useBuilderLayers>[4],
-      { current: () => {} } as unknown as Parameters<typeof useBuilderLayers>[5],
+      { current: { add: () => {}, remove: () => {} } } as unknown as Parameters<typeof useBuilderLayers>[5],
     ),
   );
 

--- a/frontend/src/components/builder/hooks/__tests__/use-builder-save.test.ts
+++ b/frontend/src/components/builder/hooks/__tests__/use-builder-save.test.ts
@@ -286,7 +286,7 @@ describe('reconcileLayerDiffWithServer (#1778)', () => {
         updated: [{ id: 'a', opacity: 0.5 }, { id: 'gone', opacity: 0.5 }],
         removed: ['b', 'alsoGone'],
       },
-      new Set(['a', 'b']),
+      ['a', 'b'],
     );
     expect(out.added).toHaveLength(1);
     expect(out.updated).toEqual([{ id: 'a', opacity: 0.5 }]);
@@ -296,13 +296,13 @@ describe('reconcileLayerDiffWithServer (#1778)', () => {
   it('drops order entries the server does not have or is about to remove', () => {
     const out = reconcileLayerDiffWithServer(
       { removed: ['b'], order: ['a', 'b', 'gone'] },
-      new Set(['a', 'b']),
+      ['a', 'b'],
     );
     expect(out.order).toEqual(['a']);
   });
 
   it('omits order entirely when nothing survives, so the server does not renumber', () => {
-    const out = reconcileLayerDiffWithServer({ order: ['gone'] }, new Set(['a']));
+    const out = reconcileLayerDiffWithServer({ order: ['gone'] }, ['a']);
     expect(out.order).toBeUndefined();
   });
 
@@ -311,9 +311,40 @@ describe('reconcileLayerDiffWithServer (#1778)', () => {
     // refetched baseline would emit it as `removed`; reconciling cannot.
     const out = reconcileLayerDiffWithServer(
       { updated: [{ id: 'a', opacity: 0.5 }] },
-      new Set(['a', 'addedByAnotherSession']),
+      ['a', 'addedByAnotherSession'],
     );
     expect(out.removed).toBeUndefined();
+  });
+
+  // fix(#1778 codex round 1): apply_layer_diff numbers the ids it is given from
+  // 0 and appends every surviving layer the order omitted, so sending only the
+  // locally known survivors would push a remotely added layer to the bottom.
+  // Counterfactual: filtering instead of merging yields ['B', 'A'], which the
+  // backend applies as [B, A, X].
+  it('leaves a remotely added layer at its server position when merging the local order', () => {
+    const out = reconcileLayerDiffWithServer(
+      { order: ['B', 'A'] },
+      ['A', 'X', 'B'],
+    );
+    expect(out.order).toEqual(['B', 'X', 'A']);
+  });
+
+  it('merges around a locally deleted layer and several unseen ones', () => {
+    // Server: [A, X, B, Y, C]. This session deleted B and reordered to [C, A].
+    const out = reconcileLayerDiffWithServer(
+      { removed: ['B'], order: ['C', 'A'] },
+      ['A', 'X', 'B', 'Y', 'C'],
+    );
+    // B drops out; X and Y hold positions 1 and 2 of what remains.
+    expect(out.order).toEqual(['C', 'X', 'Y', 'A']);
+  });
+
+  it('leaves an unchanged local order alone when the server has unseen layers', () => {
+    const out = reconcileLayerDiffWithServer(
+      { order: ['A', 'B'] },
+      ['A', 'X', 'B'],
+    );
+    expect(out.order).toEqual(['A', 'X', 'B']);
   });
 });
 
@@ -1158,6 +1189,52 @@ describe('useBuilderSave', () => {
     // The metadata PUT carries NO layers array, so nothing is overwritten.
     expect(mockUpdateMapMutateAsync).toHaveBeenCalledTimes(1);
     expect(mockUpdateMapMutateAsync.mock.calls[0][0].data.layers).toBeUndefined();
+  });
+
+  // fix(#1778 codex round 1 P2): the retry must not move a layer this session
+  // never saw. apply_layer_diff numbers the given ids from 0 and appends every
+  // omitted survivor, so sending only [layer-b, layer-a] would leave the
+  // remotely added layer-x at the bottom. Counterfactual: filter instead of
+  // merge and the retried order is ['layer-b', 'layer-a'].
+  it('merges the local reorder into the server sequence around a remotely added layer', async () => {
+    mockPatchMapLayersMutateAsync.mockRejectedValueOnce(
+      new ApiError(
+        'Layer diff references layer ids outside this map',
+        400,
+        'Layer diff references layer ids outside this map',
+      ),
+    );
+    // Another session added layer-x between the two this session knows, and
+    // deleted layer-gone that this session had removed locally too.
+    mockGetMap.mockResolvedValueOnce({
+      id: 'map-1',
+      layers: [{ id: 'layer-a' }, { id: 'layer-x' }, { id: 'layer-b' }],
+    });
+
+    const a = makeLayer({ id: 'layer-a', dataset_id: 'ds-a', sort_order: 0 });
+    const b = makeLayer({ id: 'layer-b', dataset_id: 'ds-b', sort_order: 1 });
+    const goneElsewhere = makeLayer({ id: 'layer-gone', dataset_id: 'ds-gone', sort_order: 2 });
+    let state = makeSaveState({ localLayers: [a, b, goneElsewhere] });
+    const { result, rerender } = renderHook(() => useBuilderSave(state));
+    // This session reorders b above a and deletes layer-gone.
+    state = makeSaveState({
+      localLayers: [
+        makeLayer({ id: 'layer-b', dataset_id: 'ds-b', sort_order: 0 }),
+        makeLayer({ id: 'layer-a', dataset_id: 'ds-a', sort_order: 1 }),
+      ],
+      hasUnsavedChanges: true,
+    });
+    rerender();
+
+    await act(async () => {
+      await result.current.handleSave();
+    });
+
+    expect(mockPatchMapLayersMutateAsync).toHaveBeenCalledTimes(2);
+    expect(mockPatchMapLayersMutateAsync.mock.calls[0][0].diff.order).toEqual(['layer-b', 'layer-a']);
+    const retried = mockPatchMapLayersMutateAsync.mock.calls[1][0].diff;
+    expect(retried.order).toEqual(['layer-b', 'layer-x', 'layer-a']);
+    expect(retried.removed).toBeUndefined();
   });
 
   it('skips the retry PATCH when nothing survives the reconcile', async () => {

--- a/frontend/src/components/builder/hooks/__tests__/use-builder-save.test.ts
+++ b/frontend/src/components/builder/hooks/__tests__/use-builder-save.test.ts
@@ -13,7 +13,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { MemoryRouter } from 'react-router';
 import { TooltipProvider } from '@/components/ui/tooltip';
 import { renderHook } from '@/test/test-utils';
-import { buildLayerDiff, useBuilderSave, __resetThumbnailDebounceForTests } from '@/components/builder/hooks/use-builder-save';
+import { buildLayerDiff, reconcileLayerDiffWithServer, useBuilderSave, __resetThumbnailDebounceForTests } from '@/components/builder/hooks/use-builder-save';
 import { stampPersistedFolderGroupExpanded } from '@/components/builder/folder-groups';
 import { usePluginStore } from '@/stores/map-plugin-store';
 import type { MapLayerResponse } from '@/types/api';
@@ -52,7 +52,11 @@ vi.mock('@/hooks/use-settings', () => ({
 
 const mockUploadThumbnail = vi.fn((..._args: unknown[]) => Promise.resolve());
 const mockUploadOgImage = vi.fn((..._args: unknown[]) => Promise.resolve());
+// fix(#1778): the stale-diff recovery refetches the map to learn which layer
+// ids the server still has.
+const mockGetMap = vi.fn();
 vi.mock('@/api/maps', () => ({
+  getMap: (...args: unknown[]) => mockGetMap(...args),
   uploadThumbnail: (...args: unknown[]) => mockUploadThumbnail(...args),
   uploadOgImage: (...args: unknown[]) => mockUploadOgImage(...args),
 }));
@@ -224,7 +228,7 @@ function makeSaveState(overrides: Partial<SaveState> = {}): SaveState {
     hasThumbnail: true,
     // fix(#392): the real MapBuilderPage owns this ref; tests that don't
     // exercise the layer-create → save-baseline bridge get a plain no-op ref.
-    saveBaselineSyncRef: { current: () => {} },
+    saveBaselineSyncRef: { current: { add: () => {}, remove: () => {} } },
     ...overrides,
   };
 }
@@ -273,6 +277,45 @@ function renderHookWithQueryClient(state: SaveState, queryClient: QueryClient) {
 }
 
 /* ── Tests ─────────────────────────────────────────── */
+
+describe('reconcileLayerDiffWithServer (#1778)', () => {
+  it('drops updated and removed ids the server no longer has', () => {
+    const out = reconcileLayerDiffWithServer(
+      {
+        added: [{ dataset_id: 'ds-new', sort_order: 0 } as never],
+        updated: [{ id: 'a', opacity: 0.5 }, { id: 'gone', opacity: 0.5 }],
+        removed: ['b', 'alsoGone'],
+      },
+      new Set(['a', 'b']),
+    );
+    expect(out.added).toHaveLength(1);
+    expect(out.updated).toEqual([{ id: 'a', opacity: 0.5 }]);
+    expect(out.removed).toEqual(['b']);
+  });
+
+  it('drops order entries the server does not have or is about to remove', () => {
+    const out = reconcileLayerDiffWithServer(
+      { removed: ['b'], order: ['a', 'b', 'gone'] },
+      new Set(['a', 'b']),
+    );
+    expect(out.order).toEqual(['a']);
+  });
+
+  it('omits order entirely when nothing survives, so the server does not renumber', () => {
+    const out = reconcileLayerDiffWithServer({ order: ['gone'] }, new Set(['a']));
+    expect(out.order).toBeUndefined();
+  });
+
+  it('never introduces a removal for a layer this session has not seen', () => {
+    // The server has a layer another session added. Rebuilding the diff from a
+    // refetched baseline would emit it as `removed`; reconciling cannot.
+    const out = reconcileLayerDiffWithServer(
+      { updated: [{ id: 'a', opacity: 0.5 }] },
+      new Set(['a', 'addedByAnotherSession']),
+    );
+    expect(out.removed).toBeUndefined();
+  });
+});
 
 describe('buildLayerDiff', () => {
   it('classifies added layers without baseline IDs', () => {
@@ -993,7 +1036,9 @@ describe('useBuilderSave', () => {
 
   it('falls back to full layer replacement when PATCH returns a structural error', async () => {
     mockPatchMapLayersMutateAsync.mockRejectedValueOnce(
-      new ApiError('Layer order references unknown or removed layers', 400, 'Layer order references unknown or removed layers'),
+      // fix(#1778): 405 is now the only shape that escalates to a full PUT. A
+      // 400 with a diff-integrity detail is a conflict, covered separately below.
+      new ApiError('Method Not Allowed', 405, 'Method Not Allowed'),
     );
     const baseline = makeLayer({ paint: { 'fill-color': '#000000' } });
     let state = makeSaveState({ localLayers: [baseline] });
@@ -1022,7 +1067,9 @@ describe('useBuilderSave', () => {
 
   it('omits virtual folder rows from full replacement fallback payloads', async () => {
     mockPatchMapLayersMutateAsync.mockRejectedValueOnce(
-      new ApiError('Layer order references unknown or removed layers', 400, 'Layer order references unknown or removed layers'),
+      // fix(#1778): 405 is now the only shape that escalates to a full PUT. A
+      // 400 with a diff-integrity detail is a conflict, covered separately below.
+      new ApiError('Method Not Allowed', 405, 'Method Not Allowed'),
     );
     const baseline = makeLayer({ id: 'layer-1' });
     const group = {
@@ -1059,6 +1106,157 @@ describe('useBuilderSave', () => {
         },
       },
     });
+  });
+
+  // -------------------------------------------------------------------------
+  // fix(#1778): "a stale-diff 400 from PATCH /maps/{id}/layers is misread as
+  // 'endpoint unsupported' and escalated to a full PUT that overwrites the
+  // server's layer set" (codebase audit 2026-08-30).
+  //
+  // The backend raises these exact details when the diff names layer ids the
+  // map no longer has, which means another session changed the map. The old
+  // predicate matched them with /layer|order|.../i on statuses 400/404/409/422
+  // and converted the one conflict signal into an unconditional overwrite.
+  //
+  // Counterfactual on main: every case below sees updateMap called with a
+  // `layers` array (this session's whole local list, sent as a wholesale
+  // replacement) instead of a re-diffed PATCH.
+  // -------------------------------------------------------------------------
+  it('re-diffs against the server instead of overwriting when the diff is stale', async () => {
+    mockPatchMapLayersMutateAsync.mockRejectedValueOnce(
+      new ApiError(
+        'Layer diff references layer ids outside this map',
+        400,
+        'Layer diff references layer ids outside this map',
+      ),
+    );
+    // The server no longer has layer-2: another session deleted it.
+    mockGetMap.mockResolvedValueOnce({ id: 'map-1', layers: [{ id: 'layer-1' }] });
+
+    const kept = makeLayer({ id: 'layer-1', paint: { 'fill-color': '#000000' } });
+    const goneElsewhere = makeLayer({ id: 'layer-2', dataset_id: 'dataset-2', sort_order: 1 });
+    let state = makeSaveState({ localLayers: [kept, goneElsewhere] });
+    const { result, rerender } = renderHook(() => useBuilderSave(state));
+    state = makeSaveState({
+      localLayers: [makeLayer({ id: 'layer-1', paint: { 'fill-color': '#ff0000' } })],
+      hasUnsavedChanges: true,
+    });
+    rerender();
+
+    await act(async () => {
+      await result.current.handleSave();
+    });
+
+    expect(mockGetMap).toHaveBeenCalledWith('map-1');
+    expect(mockPatchMapLayersMutateAsync).toHaveBeenCalledTimes(2);
+    // First attempt named the id the server had already dropped.
+    expect(mockPatchMapLayersMutateAsync.mock.calls[0][0].diff.removed).toEqual(['layer-2']);
+    // The retry drops it and keeps the real edit.
+    const retried = mockPatchMapLayersMutateAsync.mock.calls[1][0].diff;
+    expect(retried.removed).toBeUndefined();
+    expect(retried.updated).toEqual([{ id: 'layer-1', paint: { 'fill-color': '#ff0000' } }]);
+    // The metadata PUT carries NO layers array, so nothing is overwritten.
+    expect(mockUpdateMapMutateAsync).toHaveBeenCalledTimes(1);
+    expect(mockUpdateMapMutateAsync.mock.calls[0][0].data.layers).toBeUndefined();
+  });
+
+  it('skips the retry PATCH when nothing survives the reconcile', async () => {
+    mockPatchMapLayersMutateAsync.mockRejectedValueOnce(
+      new ApiError(
+        'Layer order references unknown or removed layers',
+        400,
+        'Layer order references unknown or removed layers',
+      ),
+    );
+    mockGetMap.mockResolvedValueOnce({ id: 'map-1', layers: [] });
+
+    const goneElsewhere = makeLayer({ id: 'layer-9' });
+    let state = makeSaveState({ localLayers: [goneElsewhere] });
+    const { result, rerender } = renderHook(() => useBuilderSave(state));
+    state = makeSaveState({ localLayers: [], hasUnsavedChanges: true });
+    rerender();
+
+    await act(async () => {
+      await result.current.handleSave();
+    });
+
+    expect(mockPatchMapLayersMutateAsync).toHaveBeenCalledTimes(1);
+    expect(mockUpdateMapMutateAsync.mock.calls[0][0].data.layers).toBeUndefined();
+  });
+
+  it('warns that layers changed elsewhere after a recovered save', async () => {
+    const { toast } = await import('sonner');
+    mockPatchMapLayersMutateAsync.mockRejectedValueOnce(
+      new ApiError(
+        'Layer diff references layer ids outside this map',
+        400,
+        'Layer diff references layer ids outside this map',
+      ),
+    );
+    mockGetMap.mockResolvedValueOnce({ id: 'map-1', layers: [{ id: 'layer-1' }] });
+
+    let state = makeSaveState({ localLayers: [makeLayer({ id: 'layer-1' }), makeLayer({ id: 'layer-2' })] });
+    const { result, rerender } = renderHook(() => useBuilderSave(state));
+    state = makeSaveState({ localLayers: [makeLayer({ id: 'layer-1' })], hasUnsavedChanges: true });
+    rerender();
+
+    await act(async () => {
+      await result.current.handleSave();
+    });
+
+    expect(toast.warning).toHaveBeenCalledWith('toasts.mapSavedAfterRemoteChange');
+    expect(toast.warning).not.toHaveBeenCalledWith('toasts.mapSavedFullResync');
+    expect(state.setHasUnsavedChanges).toHaveBeenCalledWith(false);
+  });
+
+  it('reports a conflict rather than overwriting when the recovery itself fails', async () => {
+    const { toast } = await import('sonner');
+    mockPatchMapLayersMutateAsync.mockRejectedValueOnce(
+      new ApiError(
+        'Layer diff references layer ids outside this map',
+        400,
+        'Layer diff references layer ids outside this map',
+      ),
+    );
+    mockGetMap.mockRejectedValueOnce(new Error('offline'));
+
+    let state = makeSaveState({ localLayers: [makeLayer({ id: 'layer-1' }), makeLayer({ id: 'layer-2' })] });
+    const { result, rerender } = renderHook(() => useBuilderSave(state));
+    state = makeSaveState({ localLayers: [makeLayer({ id: 'layer-1' })], hasUnsavedChanges: true });
+    rerender();
+
+    await act(async () => {
+      await result.current.handleSave();
+    });
+
+    expect(toast.error).toHaveBeenCalledWith('toasts.saveConflictReload');
+    expect(mockUpdateMapMutateAsync).not.toHaveBeenCalled();
+    expect(state.setHasUnsavedChanges).not.toHaveBeenCalledWith(false);
+    expect(result.current.saveStatus).toBe('failed');
+  });
+
+  it('leaves a genuine validation rejection on the failure path', async () => {
+    const { toast } = await import('sonner');
+    // A 422 with prose the OLD predicate matched via /validation/i. It is not a
+    // stale diff and not a missing endpoint, so it must simply fail.
+    mockPatchMapLayersMutateAsync.mockRejectedValueOnce(
+      new ApiError('Layer validation failed', 422, 'Layer validation failed'),
+    );
+    let state = makeSaveState({ localLayers: [makeLayer({ paint: { 'fill-color': '#000000' } })] });
+    const { result, rerender } = renderHook(() => useBuilderSave(state));
+    state = makeSaveState({
+      localLayers: [makeLayer({ paint: { 'fill-color': '#ff0000' } })],
+      hasUnsavedChanges: true,
+    });
+    rerender();
+
+    await act(async () => {
+      await result.current.handleSave();
+    });
+
+    expect(mockGetMap).not.toHaveBeenCalled();
+    expect(mockUpdateMapMutateAsync).not.toHaveBeenCalled();
+    expect(toast.error).toHaveBeenCalledWith('toasts.saveFailed');
   });
 
   it('does not clear unsaved changes when save fails', async () => {

--- a/frontend/src/components/builder/hooks/__tests__/use-builder-save.test.ts
+++ b/frontend/src/components/builder/hooks/__tests__/use-builder-save.test.ts
@@ -1312,6 +1312,128 @@ describe('useBuilderSave', () => {
     expect(result.current.saveStatus).toBe('failed');
   });
 
+  // fix(#1778 codex round 3 P1): 404 is the compatibility case the full PUT
+  // exists for. A backend predating PATCH /maps/{id}/layers answers 404 for the
+  // unknown route, so narrowing "unsupported" to 405/501 alone would have made
+  // every layer-edit save fail against such a deployment.
+  // Counterfactual: drop 404 from ROUTE_LEVEL_UNSUPPORTED_STATUSES and the two
+  // route-missing cases stop reaching updateMap.
+  it('falls back to a full PUT when the layer-diff route answers 404 with no JSON detail', async () => {
+    mockPatchMapLayersMutateAsync.mockRejectedValueOnce(
+      // An edge proxy in front of the API: no JSON body at all, so apiFetch
+      // leaves `body` undefined and only the localized message remains.
+      new ApiError('Not found', 404, undefined),
+    );
+    let state = makeSaveState({ localLayers: [makeLayer({ paint: { 'fill-color': '#000000' } })] });
+    const { result, rerender } = renderHook(() => useBuilderSave(state));
+    state = makeSaveState({
+      localLayers: [makeLayer({ paint: { 'fill-color': '#ff0000' } })],
+      hasUnsavedChanges: true,
+    });
+    rerender();
+
+    await act(async () => {
+      await result.current.handleSave();
+    });
+
+    expect(mockGetMap).not.toHaveBeenCalled();
+    expect(mockUpdateMapMutateAsync).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          layers: [expect.objectContaining({ paint: { 'fill-color': '#ff0000' } })],
+        }),
+      }),
+    );
+  });
+
+  it('falls back to a full PUT on FastAPI\'s own route-missing 404 detail', async () => {
+    mockPatchMapLayersMutateAsync.mockRejectedValueOnce(
+      new ApiError('Not Found', 404, 'Not Found'),
+    );
+    let state = makeSaveState({ localLayers: [makeLayer({ paint: { 'fill-color': '#000000' } })] });
+    const { result, rerender } = renderHook(() => useBuilderSave(state));
+    state = makeSaveState({
+      localLayers: [makeLayer({ paint: { 'fill-color': '#ff0000' } })],
+      hasUnsavedChanges: true,
+    });
+    rerender();
+
+    await act(async () => {
+      await result.current.handleSave();
+    });
+
+    expect(mockUpdateMapMutateAsync.mock.calls[0][0].data.layers).toBeDefined();
+  });
+
+  // The route's OWN 404: the map is gone, not the route. A full PUT would only
+  // 404 again, so this has to surface instead of pretending the endpoint is
+  // missing. There is no 404 for a stale layer id; the backend raises 400.
+  it('surfaces a map-not-found 404 instead of escalating to a full PUT', async () => {
+    const { toast } = await import('sonner');
+    mockPatchMapLayersMutateAsync.mockRejectedValueOnce(
+      new ApiError('Map not found', 404, 'Map not found'),
+    );
+    let state = makeSaveState({ localLayers: [makeLayer({ paint: { 'fill-color': '#000000' } })] });
+    const { result, rerender } = renderHook(() => useBuilderSave(state));
+    state = makeSaveState({
+      localLayers: [makeLayer({ paint: { 'fill-color': '#ff0000' } })],
+      hasUnsavedChanges: true,
+    });
+    rerender();
+
+    await act(async () => {
+      await result.current.handleSave();
+    });
+
+    expect(mockUpdateMapMutateAsync).not.toHaveBeenCalled();
+    expect(toast.error).toHaveBeenCalledWith('toasts.saveFailed');
+  });
+
+  it('surfaces the id-carrying map-not-found 404 the diff service raises', async () => {
+    mockPatchMapLayersMutateAsync.mockRejectedValueOnce(
+      new ApiError(
+        'Map 0d3f2a1e-0000-4000-8000-000000000000 not found',
+        404,
+        'Map 0d3f2a1e-0000-4000-8000-000000000000 not found',
+      ),
+    );
+    let state = makeSaveState({ localLayers: [makeLayer({ paint: { 'fill-color': '#000000' } })] });
+    const { result, rerender } = renderHook(() => useBuilderSave(state));
+    state = makeSaveState({
+      localLayers: [makeLayer({ paint: { 'fill-color': '#ff0000' } })],
+      hasUnsavedChanges: true,
+    });
+    rerender();
+
+    await act(async () => {
+      await result.current.handleSave();
+    });
+
+    expect(mockUpdateMapMutateAsync).not.toHaveBeenCalled();
+  });
+
+  it('surfaces a 400 whose detail is not the stale-diff one', async () => {
+    const { toast } = await import('sonner');
+    mockPatchMapLayersMutateAsync.mockRejectedValueOnce(
+      new ApiError('Layer count exceeds maximum 50', 400, 'Layer count exceeds maximum 50'),
+    );
+    let state = makeSaveState({ localLayers: [makeLayer({ paint: { 'fill-color': '#000000' } })] });
+    const { result, rerender } = renderHook(() => useBuilderSave(state));
+    state = makeSaveState({
+      localLayers: [makeLayer({ paint: { 'fill-color': '#ff0000' } })],
+      hasUnsavedChanges: true,
+    });
+    rerender();
+
+    await act(async () => {
+      await result.current.handleSave();
+    });
+
+    expect(mockGetMap).not.toHaveBeenCalled();
+    expect(mockUpdateMapMutateAsync).not.toHaveBeenCalled();
+    expect(toast.error).toHaveBeenCalledWith('toasts.saveFailed');
+  });
+
   it('leaves a genuine validation rejection on the failure path', async () => {
     const { toast } = await import('sonner');
     // A 422 with prose the OLD predicate matched via /validation/i. It is not a

--- a/frontend/src/components/builder/hooks/__tests__/use-layer-map-sync.raf.test.ts
+++ b/frontend/src/components/builder/hooks/__tests__/use-layer-map-sync.raf.test.ts
@@ -7,6 +7,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 import { useLayerMapSync } from '../use-layer-map-sync';
 import { __resetForTest } from '@/lib/builder/raf-coalesce';
+import { applyMasterOpacity } from '@/components/builder/map-sync';
 import type { MapLayerResponse } from '@/types/api';
 import type { Map as MaplibreMap } from 'maplibre-gl';
 
@@ -31,6 +32,9 @@ vi.mock('@/components/builder/map-sync', () => ({
   getLayerType: vi.fn(() => 'fill'),
   resolveAdapterType: vi.fn(() => 'fill'),
   applyMasterOpacity: vi.fn(),
+  // fix(#1778 codex round 4): applyLayerOpacityToMap consults this before it
+  // writes, so the drain-order test below needs it present.
+  isDemTerrainVisualSuppressed: vi.fn(() => false),
   // Phase 1050 SF-04: use-layer-map-sync now routes through this helper.
   // The PERF-04 test only asserts call counts (does not validate sourceId
   // values), so a simple per-layer string is sufficient here.
@@ -243,5 +247,105 @@ describe('useLayerMapSync — rAF paint coalescing (PERF-04)', () => {
     const syncPaintCallsBeforeFlush = mockSyncPaint.mock.calls.length;
     raf.flush();
     expect(mockSyncPaint.mock.calls.length).toBe(syncPaintCallsBeforeFlush);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// fix(#1778 codex round 4 P2): the deferred-write replay drain has to be
+// deterministic. A paint write does not touch the map itself, it queues
+// adapter.syncPaint on the next animation frame, so replaying it alongside
+// synchronous writes put it LAST in wall-clock order however early it was made.
+// fillAdapter.syncPaint applies the input.opacity it captured (via
+// applyMasterOpacity), so a queued paint edit followed by an opacity edit ended
+// with the older frame overwriting the newer opacity.
+// Counterfactual: remove the flushCoalescedFrame call from drainLayerWrites and
+// the order assertion below inverts.
+// ---------------------------------------------------------------------------
+describe('useLayerMapSync: deferred replay drains paint work synchronously (#1778)', () => {
+  let raf: ReturnType<typeof mockRaf>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    raf = mockRaf();
+    vi.stubGlobal('requestAnimationFrame', raf.requestAnimationFrame);
+    vi.stubGlobal('cancelAnimationFrame', raf.cancelAnimationFrame);
+  });
+
+  afterEach(() => {
+    __resetForTest();
+    raf.flush();
+    vi.unstubAllGlobals();
+  });
+
+  it('a paint edit queued during a style swap lands BEFORE a later opacity edit', () => {
+    const layer = makeLayer();
+    const mapStub = makeMapStub();
+    const isStyleLoaded = mapStub.isStyleLoaded as unknown as ReturnType<typeof vi.fn>;
+    // The basemap style is mid-swap, so the paint write is deferred.
+    isStyleLoaded.mockReturnValue(false);
+    const mapRef = { current: mapStub };
+
+    const { result, rerender } = renderHook(
+      ({ layers }: { layers: MapLayerResponse[] }) =>
+        useLayerMapSync(layers, vi.fn(), vi.fn(), mapRef),
+      { initialProps: { layers: [layer] } },
+    );
+
+    // A: paint edit, queued behind `idle`.
+    act(() => { result.current.handlePaintChange(layer.id, { 'fill-color': '#00ff00' }); });
+    expect(mockSyncPaint).not.toHaveBeenCalled();
+
+    // The style finishes loading before `idle` fires.
+    isStyleLoaded.mockReturnValue(true);
+    rerender({ layers: [{ ...layer, paint: { ...layer.paint, 'fill-color': '#00ff00' } }] });
+
+    // B: opacity edit. The queued paint must be drained and FLUSHED first.
+    act(() => { result.current.handleOpacityChange(layer.id, 0.25); });
+
+    const opacityMock = vi.mocked(applyMasterOpacity);
+    expect(mockSyncPaint).toHaveBeenCalledTimes(1);
+    expect(opacityMock).toHaveBeenCalledTimes(1);
+    // Chronological order is the whole point: paint A, then opacity B.
+    expect(mockSyncPaint.mock.invocationCallOrder[0])
+      .toBeLessThan(opacityMock.mock.invocationCallOrder[0]);
+    expect(opacityMock.mock.calls[0][4]).toBe(0.25);
+
+    // Advancing a frame must not replay the older paint on top of the opacity.
+    act(() => { raf.flush(); });
+    expect(mockSyncPaint).toHaveBeenCalledTimes(1);
+    expect(opacityMock.mock.invocationCallOrder.at(-1))
+      .toBeGreaterThan(mockSyncPaint.mock.invocationCallOrder.at(-1)!);
+  });
+
+  it('replays a paint edit and a later opacity edit in order from the idle listener', () => {
+    const layer = makeLayer();
+    const mapStub = makeMapStub();
+    const isStyleLoaded = mapStub.isStyleLoaded as unknown as ReturnType<typeof vi.fn>;
+    isStyleLoaded.mockReturnValue(false);
+    const onceCalls: [string, () => void][] = [];
+    (mapStub as unknown as { once: unknown }).once = vi.fn((event: string, cb: () => void) => {
+      onceCalls.push([event, cb]);
+    });
+    const mapRef = { current: mapStub };
+
+    const { result } = renderHook(() =>
+      useLayerMapSync([layer], vi.fn(), vi.fn(), mapRef),
+    );
+
+    act(() => { result.current.handlePaintChange(layer.id, { 'fill-color': '#00ff00' }); });
+    act(() => { result.current.handleOpacityChange(layer.id, 0.25); });
+    expect(mockSyncPaint).not.toHaveBeenCalled();
+
+    isStyleLoaded.mockReturnValue(true);
+    const idle = onceCalls.find(([event]) => event === 'idle');
+    expect(idle).toBeDefined();
+    act(() => { idle![1](); });
+
+    const opacityMock = vi.mocked(applyMasterOpacity);
+    expect(mockSyncPaint.mock.invocationCallOrder[0])
+      .toBeLessThan(opacityMock.mock.invocationCallOrder[0]);
+
+    act(() => { raf.flush(); });
+    expect(mockSyncPaint).toHaveBeenCalledTimes(1);
   });
 });

--- a/frontend/src/components/builder/hooks/__tests__/use-layer-map-sync.test.ts
+++ b/frontend/src/components/builder/hooks/__tests__/use-layer-map-sync.test.ts
@@ -1924,6 +1924,100 @@ describe('useLayerMapSync: applyLayerUpdate idle retry (#1778)', () => {
     );
   });
 
+  // fix(#1778 codex round 3 P2): isStyleLoaded() flips true BEFORE `idle` fires,
+  // so a second edit landing in that window wrote immediately and was then
+  // overwritten by the older queued callback. The reviewer's shape: toggle a
+  // layer off during a basemap swap and back on before idle, and the map ends
+  // up hidden while React state says visible.
+  // Counterfactual: restore the single captured `map.once('idle', () =>
+  // writeToMap(map))` and both cases below end on 'none'.
+  it('a newer edit wins when the style loads before idle fires', () => {
+    const layer = makeLayer({ visible: true });
+    const mapStub = makeMapStub();
+    const isStyleLoaded = mapStub.isStyleLoaded as ReturnType<typeof vi.fn>;
+    isStyleLoaded.mockReturnValue(false);
+    const mapRef = { current: mapStub };
+
+    const { result, rerender } = renderHook(
+      ({ layers }: { layers: MapLayerResponse[] }) =>
+        useLayerMapSync(layers, vi.fn(), vi.fn(), mapRef),
+      { initialProps: { layers: [layer] } },
+    );
+
+    // A: hide the layer while the basemap style is still swapping.
+    act(() => { result.current.handleToggleVisibility(layer.id, false); });
+    expect(mapStub.setLayoutProperty).not.toHaveBeenCalled();
+    const idleCall = (mapStub.once as ReturnType<typeof vi.fn>).mock.calls.find((c) => c[0] === 'idle');
+    expect(idleCall).toBeDefined();
+
+    // The style finishes loading, but `idle` has not fired yet.
+    isStyleLoaded.mockReturnValue(true);
+
+    // B: show it again. The queued A must be drained BEFORE B, not after.
+    rerender({ layers: [makeLayer({ visible: false })] });
+    act(() => { result.current.handleToggleVisibility(layer.id, true); });
+
+    // Firing the stale listener afterwards must be a no-op.
+    act(() => { (idleCall![1] as () => void)(); });
+
+    const visibilityWrites = (mapStub.setLayoutProperty as ReturnType<typeof vi.fn>).mock.calls
+      .filter((c) => c[0] === `layer-${LAYER_ID}` && c[1] === 'visibility')
+      .map((c) => c[2]);
+    expect(visibilityWrites.at(-1)).toBe('visible');
+  });
+
+  it('replays two edits queued before idle in the order they were made', () => {
+    const layer = makeLayer({ visible: true });
+    const mapStub = makeMapStub();
+    (mapStub.isStyleLoaded as ReturnType<typeof vi.fn>).mockReturnValue(false);
+    const mapRef = { current: mapStub };
+
+    const { result, rerender } = renderHook(
+      ({ layers }: { layers: MapLayerResponse[] }) =>
+        useLayerMapSync(layers, vi.fn(), vi.fn(), mapRef),
+      { initialProps: { layers: [layer] } },
+    );
+
+    act(() => { result.current.handleToggleVisibility(layer.id, false); });
+    rerender({ layers: [makeLayer({ visible: false })] });
+    act(() => { result.current.handleToggleVisibility(layer.id, true); });
+
+    // One listener for the layer, not two.
+    const idleCalls = (mapStub.once as ReturnType<typeof vi.fn>).mock.calls.filter((c) => c[0] === 'idle');
+    expect(idleCalls).toHaveLength(1);
+
+    (mapStub.isStyleLoaded as ReturnType<typeof vi.fn>).mockReturnValue(true);
+    act(() => { (idleCalls[0][1] as () => void)(); });
+
+    const visibilityWrites = (mapStub.setLayoutProperty as ReturnType<typeof vi.fn>).mock.calls
+      .filter((c) => c[0] === `layer-${LAYER_ID}` && c[1] === 'visibility')
+      .map((c) => c[2]);
+    expect(visibilityWrites).toEqual(['none', 'visible']);
+  });
+
+  it('keeps a queued layout write when a visibility edit for the same layer follows', () => {
+    const layer = makeLayer({ visible: true, layout: {} });
+    const mapStub = makeMapStub();
+    (mapStub.isStyleLoaded as ReturnType<typeof vi.fn>).mockReturnValue(false);
+    const mapRef = { current: mapStub };
+
+    const { result } = renderHook(() =>
+      useLayerMapSync([layer], vi.fn(), vi.fn(), mapRef),
+    );
+
+    act(() => { result.current.handleLayoutChange(layer.id, { 'line-cap': 'round' }); });
+    act(() => { result.current.handleToggleVisibility(layer.id, false); });
+
+    (mapStub.isStyleLoaded as ReturnType<typeof vi.fn>).mockReturnValue(true);
+    const idleCall = (mapStub.once as ReturnType<typeof vi.fn>).mock.calls.find((c) => c[0] === 'idle');
+    act(() => { (idleCall![1] as () => void)(); });
+
+    // A cancel-and-replace scheme keyed on the layer alone would have dropped
+    // the layout write; queueing keeps both.
+    expect(mapStub.setLayoutProperty).toHaveBeenCalledWith(`layer-${LAYER_ID}`, 'line-cap', 'round');
+    expect(mapStub.setLayoutProperty).toHaveBeenCalledWith(`layer-${LAYER_ID}`, 'visibility', 'none');
+  });
+
   it('writes straight through when the style is loaded (no idle listener)', () => {
     const layer = makeLayer({ visible: true });
     const mapStub = makeMapStub();

--- a/frontend/src/components/builder/hooks/__tests__/use-layer-map-sync.test.ts
+++ b/frontend/src/components/builder/hooks/__tests__/use-layer-map-sync.test.ts
@@ -94,6 +94,9 @@ const makeLayer = (overrides: Partial<MapLayerResponse> = {}): MapLayerResponse 
 function makeMapStub(existingLayerIds: string[] = ALL_COMPANION_IDS) {
   const existing = new Set(existingLayerIds);
   return {
+    // fix(#1778): applyLayerUpdate defers the map write to `idle` when the
+    // style is mid-swap instead of dropping it.
+    once: vi.fn(),
     isStyleLoaded: vi.fn(() => true),
     getLayer: vi.fn((id: string) => (existing.has(id) ? { id } : undefined)),
     getSource: vi.fn(() => undefined),
@@ -1845,5 +1848,98 @@ describe('useLayerMapSync — handleOpacityChange drives fill-layer-opacity (#16
     expect(writes).toContainEqual([`layer-${LAYER_ID}-outline`, 'line-layer-opacity', 0.5]);
     expect(writes).not.toContainEqual([`layer-${LAYER_ID}`, 'fill-opacity', 0.15]);
     expect(writes).not.toContainEqual([`layer-${LAYER_ID}-outline`, 'line-opacity', expect.anything()]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// fix(#1778): applyLayerUpdate dropped the map side-effect whenever the style
+// was mid-swap, with no retry. React state was already committed, and generic
+// LAYOUT is the one property class syncLayersToMap never re-applies, so the
+// divergence was permanent for the session: the layer saved a layout the map
+// was not showing. Counterfactual: on main `once` is never called and the
+// post-idle assertions below find no writes.
+// ---------------------------------------------------------------------------
+describe('useLayerMapSync: applyLayerUpdate idle retry (#1778)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('replays a layout write on idle when the style was not loaded', () => {
+    const layer = makeLayer({ layout: { 'line-dasharray': [3, 2] } });
+    const mapStub = makeMapStub();
+    (mapStub.isStyleLoaded as ReturnType<typeof vi.fn>).mockReturnValue(false);
+    const mapRef = { current: mapStub };
+    const setLocalLayers = vi.fn();
+
+    const { result } = renderHook(() =>
+      useLayerMapSync([layer], setLocalLayers, vi.fn(), mapRef),
+    );
+
+    act(() => {
+      result.current.handleLayoutChange(layer.id, { 'line-cap': 'round' });
+    });
+
+    // React state took the edit; the map write is deferred, not lost.
+    expect(setLocalLayers).toHaveBeenCalled();
+    expect(mapStub.setLayoutProperty).not.toHaveBeenCalledWith(
+      `layer-${LAYER_ID}`, 'line-cap', 'round',
+    );
+
+    const idleCall = (mapStub.once as ReturnType<typeof vi.fn>).mock.calls.find((c) => c[0] === 'idle');
+    expect(idleCall).toBeDefined();
+    (mapStub.isStyleLoaded as ReturnType<typeof vi.fn>).mockReturnValue(true);
+    act(() => { (idleCall![1] as () => void)(); });
+
+    expect(mapStub.setLayoutProperty).toHaveBeenCalledWith(
+      `layer-${LAYER_ID}`, 'line-cap', 'round',
+    );
+    // The clear-removed-props loop rides the same retry.
+    expect(mapStub.setPaintProperty).toHaveBeenCalledWith(
+      `layer-${LAYER_ID}`, 'line-dasharray', undefined,
+    );
+  });
+
+  it('replays a visibility write on idle when the style was not loaded', () => {
+    const layer = makeLayer({ visible: true });
+    const mapStub = makeMapStub();
+    (mapStub.isStyleLoaded as ReturnType<typeof vi.fn>).mockReturnValue(false);
+    const mapRef = { current: mapStub };
+
+    const { result } = renderHook(() =>
+      useLayerMapSync([layer], vi.fn(), vi.fn(), mapRef),
+    );
+
+    act(() => {
+      result.current.handleToggleVisibility(layer.id);
+    });
+    expect(mapStub.setLayoutProperty).not.toHaveBeenCalled();
+
+    const idleCall = (mapStub.once as ReturnType<typeof vi.fn>).mock.calls.find((c) => c[0] === 'idle');
+    expect(idleCall).toBeDefined();
+    (mapStub.isStyleLoaded as ReturnType<typeof vi.fn>).mockReturnValue(true);
+    act(() => { (idleCall![1] as () => void)(); });
+
+    expect(mapStub.setLayoutProperty).toHaveBeenCalledWith(
+      `layer-${LAYER_ID}`, 'visibility', 'none',
+    );
+  });
+
+  it('writes straight through when the style is loaded (no idle listener)', () => {
+    const layer = makeLayer({ visible: true });
+    const mapStub = makeMapStub();
+    const mapRef = { current: mapStub };
+
+    const { result } = renderHook(() =>
+      useLayerMapSync([layer], vi.fn(), vi.fn(), mapRef),
+    );
+
+    act(() => {
+      result.current.handleToggleVisibility(layer.id);
+    });
+
+    expect(mapStub.setLayoutProperty).toHaveBeenCalledWith(
+      `layer-${LAYER_ID}`, 'visibility', 'none',
+    );
+    expect((mapStub.once as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(0);
   });
 });

--- a/frontend/src/components/builder/hooks/builder-layer-mutations.ts
+++ b/frontend/src/components/builder/hooks/builder-layer-mutations.ts
@@ -95,7 +95,17 @@ export function removePerLayerCompanions(
   layerIds: Iterable<string>,
   renderModeByLayerId?: Map<string, string>,
 ): void {
-  if (!map || !map.isStyleLoaded()) return;
+  if (!map) return;
+  // fix(#1778): a bare early return here left the companions on the map for the
+  // rest of the session. A delete during a basemap style swap is exactly when
+  // isStyleLoaded() is false, and nothing calls this again. Retry on idle,
+  // matching BuilderMap's sync effect and use-render-mode-layers. The ids are
+  // materialized first because the caller's Iterable may be single-pass.
+  if (!map.isStyleLoaded()) {
+    const pending = [...layerIds];
+    map.once?.('idle', () => removePerLayerCompanions(map, pending, renderModeByLayerId));
+    return;
+  }
   for (const id of layerIds) {
     const renderMode = renderModeByLayerId?.get(id) ?? null;
     const companionIds = deriveCompanionIds(id, renderMode);

--- a/frontend/src/components/builder/hooks/use-builder-layers.ts
+++ b/frontend/src/components/builder/hooks/use-builder-layers.ts
@@ -16,6 +16,7 @@ import type { MapBasemapConfig, MapLayerResponse, MapResponse, MapTerrainConfig,
 import type { useAddLayer, useRemoveLayer } from '@/hooks/use-maps';
 import { useEphemeralLayers } from '@/components/builder/hooks/use-ephemeral-layers';
 import { useLayerMapSync } from '@/components/builder/hooks/use-layer-map-sync';
+import type { SaveBaselineSync } from '@/components/builder/hooks/use-builder-save';
 import {
   buildDuplicateRenderingInput,
   removePerLayerCompanions,
@@ -80,7 +81,7 @@ export function useBuilderLayers(
   // Invoked by handleAddDataset/handleDuplicateRendering so the Save-diff
   // baseline learns about server-created layers immediately, instead of only
   // on a clean-state resync — see use-builder-save.ts for the full rationale.
-  saveBaselineSyncRef: React.MutableRefObject<(layer: MapLayerResponse) => void>,
+  saveBaselineSyncRef: React.MutableRefObject<SaveBaselineSync>,
 ) {
   const [searchParams, setSearchParams] = useSearchParams();
   const { t } = useTranslation('builder');
@@ -204,6 +205,7 @@ export function useBuilderLayers(
     localTerrainConfig,
     setLocalTerrainConfig,
     savedLayerBaselineRef,
+    saveBaselineSyncRef,
     copiedStyleRef,
     syncStyleConfigToMap,
     mvtSourceLayerPrefix,
@@ -578,6 +580,11 @@ export function useBuilderLayers(
           savedLayerBaselineRef.current = savedLayerBaselineRef.current.filter(
             (l) => l.id !== layerId,
           );
+          // fix(#1778): prune the SAVE-diff baseline too. It only refreshes
+          // while the map is clean, so a delete on an already-dirty map used to
+          // leave this id behind and the next save's diff.removed named a row
+          // the server had already dropped, a 400 the client then misread.
+          saveBaselineSyncRef.current?.remove([layerId]);
           toast.success(t('toasts.layerRemoved'));
         },
         onError: () => {
@@ -598,7 +605,7 @@ export function useBuilderLayers(
         },
       },
     );
-  }, [mapId, mapInstanceRef, removeLayerMutation, localTerrainConfig, t]);
+  }, [mapId, mapInstanceRef, removeLayerMutation, localTerrainConfig, saveBaselineSyncRef, t]);
 
   const handleAddDataset = useCallback(
     (
@@ -697,7 +704,7 @@ export function useBuilderLayers(
               }
               // fix(#392): also register the pure server layer into the Save-diff baseline so
               // Save doesn't treat this just-created layer as diff.added and PATCH a duplicate.
-              saveBaselineSyncRef.current?.(createdLayer);
+              saveBaselineSyncRef.current?.add(createdLayer);
               // fix(#392): mark dirty whenever existing siblings were renumbered —
               // the non-grouped branch above renumbers every existing layer's
               // sort_order locally, but the backend does not renumber sibling rows
@@ -841,7 +848,7 @@ export function useBuilderLayers(
           ];
           // fix(#392): also register the pure server layer into the Save-diff baseline so
           // Save doesn't treat this just-created layer as diff.added and PATCH a duplicate.
-          saveBaselineSyncRef.current?.(createdLayer);
+          saveBaselineSyncRef.current?.add(createdLayer);
           // fix(#392): the splice above always renumbers the FULL local
           // array (adjacent-insert, not append) — this is a real, unpersisted
           // diff for grouped AND non-grouped duplicates alike. Mark dirty

--- a/frontend/src/components/builder/hooks/use-builder-save.ts
+++ b/frontend/src/components/builder/hooks/use-builder-save.ts
@@ -13,7 +13,7 @@ import { useUpdateMap, useDuplicateMap, usePatchMapLayers } from '@/hooks/use-ma
 import { useEnabledPlugins } from '@/hooks/use-settings';
 import { useEdition } from '@/hooks/use-edition';
 import { getLayerColors, extractStyleHints } from '@/components/map/layer-icons';
-import { uploadThumbnail, uploadOgImage } from '@/api/maps';
+import { getMap, uploadThumbnail, uploadOgImage } from '@/api/maps';
 import { extractPlaceholders, validatePlaceholders } from '@/lib/popup-template';
 import type { MapBasemapConfig, MapLayerDiffRequest, MapLayerInput, MapLayerPatch, MapLayerResponse, MapResponse, MapTerrainConfig, MapUpdateRequest } from '@/types/api';
 import { usePluginStore } from '@/stores/map-plugin-store';
@@ -672,11 +672,70 @@ function hasDiff(diff: MapLayerDiffRequest): boolean {
   );
 }
 
+// fix(#1778): only a status that means "this deployment has no layer-diff
+// endpoint" may escalate to the lossy full PUT. 405 (method not allowed) and
+// 501 (not implemented) are the two a router without the route can produce;
+// the old predicate also matched 400/404/409/422 with a prose regex, which is
+// exactly the shape the backend uses for a STALE diff. See
+// isStaleLayerDiffError below.
 function isUnsupportedLayerPatchError(error: unknown): boolean {
   if (!(error instanceof ApiError)) return false;
-  if (![400, 404, 409, 422].includes(error.status)) return false;
+  return error.status === 405 || error.status === 501;
+}
+
+// fix(#1778): the two details apply_layer_diff raises when the diff names layer
+// ids the map no longer has (backend service_diff.py). That means someone else
+// changed this map's layers since this session loaded it, so overwriting the
+// map with the stale client's snapshot would resurrect what they deleted and
+// delete what they added. Recover by re-diffing against the server instead.
+const STALE_LAYER_DIFF_DETAIL =
+  /Layer diff references layer ids outside this map|Layer order references unknown or removed layers/i;
+
+/** fix(#1778): raised when the stale-diff recovery below cannot complete, so
+ *  the outer catch can say "the map changed elsewhere" instead of the generic
+ *  save-failed message. */
+class StaleLayerDiffError extends Error {
+  constructor() {
+    super('Layer diff could not be reconciled with the current map');
+    this.name = 'StaleLayerDiffError';
+  }
+}
+
+function isStaleLayerDiffError(error: unknown): boolean {
+  if (!(error instanceof ApiError)) return false;
+  if (error.status !== 400) return false;
   const detail = typeof error.body === 'string' ? error.body : error.message;
-  return /layer|order|unknown|removed|unsupported|validation/i.test(detail);
+  return STALE_LAYER_DIFF_DETAIL.test(detail);
+}
+
+/**
+ * fix(#1778): drop the parts of a rejected diff the server can no longer apply.
+ *
+ * Deliberately NOT a fresh `buildLayerDiff` against the refetched map: a layer
+ * another session ADDED is absent from this session's `localLayers`, so a full
+ * re-diff would emit it as `removed` and delete it. Reconciling the diff we
+ * already built keeps the recovery strictly additive to server state: ids the
+ * server no longer has are simply dropped, and anything this session did not
+ * touch is left alone.
+ */
+export function reconcileLayerDiffWithServer(
+  diff: MapLayerDiffRequest,
+  serverLayerIds: Set<string>,
+): MapLayerDiffRequest {
+  const next: MapLayerDiffRequest = {};
+  if (diff.added?.length) next.added = diff.added;
+  const updated = diff.updated?.filter((patch) => serverLayerIds.has(patch.id));
+  if (updated?.length) next.updated = updated;
+  const removed = diff.removed?.filter((id) => serverLayerIds.has(id));
+  if (removed?.length) next.removed = removed;
+  const removedSet = new Set(removed ?? []);
+  if (diff.order) {
+    // The backend rejects an order that names an unknown id or one being
+    // removed in the same call, and it only ever orders pre-existing rows.
+    const order = diff.order.filter((id) => serverLayerIds.has(id) && !removedSet.has(id));
+    if (order.length > 0) next.order = order;
+  }
+  return next;
 }
 
 export interface LayerDiffResult {
@@ -685,6 +744,13 @@ export interface LayerDiffResult {
 }
 
 export type BuilderSaveStatus = 'saved' | 'unsaved' | 'saving' | 'failed';
+
+/** Bridge between the layer-mutation hooks and useBuilderSave's diff baseline.
+ *  fix(#392) added `add`; fix(#1778) added the symmetric `remove`. */
+export interface SaveBaselineSync {
+  add: (layer: MapLayerResponse) => void;
+  remove: (layerIds: Iterable<string>) => void;
+}
 
 export function buildLayerDiff(
   baselineLayers: MapLayerResponse[],
@@ -801,8 +867,10 @@ interface SaveState {
   /** fix(#392): callback ref populated by useBuilderSave and invoked by
    *  useBuilderLayers' layer-create paths (handleAddDataset / handleDuplicateRendering)
    *  so the server-created layer is registered into the Save-diff baseline
-   *  the moment it is inserted — see the effect below for the full rationale. */
-  saveBaselineSyncRef: React.MutableRefObject<(layer: MapLayerResponse) => void>;
+   *  the moment it is inserted (see the effect below for the full rationale).
+   *  fix(#1778): `remove` is the delete half, called by the single and bulk
+   *  delete paths alongside their savedLayerBaselineRef prune. */
+  saveBaselineSyncRef: React.MutableRefObject<SaveBaselineSync>;
   /** POLISH-01 (Phase 1233-01): set to true when the builder was opened with a
    *  ?add_dataset URL param so the first auto-capture is deferred until the
    *  layer-add effect has synced localLayers. Omit (or set false) for normal
@@ -887,10 +955,23 @@ export function useBuilderSave(state: SaveState) {
     // baseline unaware of the new server id, so buildLayerDiff reports it as
     // diff.added and the PATCH endpoint creates a duplicate. Register the PURE
     // server layer (no local grouping/reorder) so grouping/order still diff normally.
-    state.saveBaselineSyncRef.current = (layer: MapLayerResponse) => {
-      if (!baselineLayersRef.current.some((l) => l.id === layer.id)) {
-        baselineLayersRef.current = [...baselineLayersRef.current, { ...layer }];
-      }
+    state.saveBaselineSyncRef.current = {
+      add: (layer: MapLayerResponse) => {
+        if (!baselineLayersRef.current.some((l) => l.id === layer.id)) {
+          baselineLayersRef.current = [...baselineLayersRef.current, { ...layer }];
+        }
+      },
+      // fix(#1778): the mirror of `add`. The baseline effect above only
+      // refreshes while the map is CLEAN, so a delete on an already-dirty map
+      // left the deleted ids in this baseline; the next save then emitted them
+      // in diff.removed and the backend rejected the whole diff. The delete
+      // paths prune savedLayerBaselineRef already. This keeps the save-diff
+      // baseline in step with them.
+      remove: (layerIds: Iterable<string>) => {
+        const ids = new Set(layerIds);
+        if (ids.size === 0) return;
+        baselineLayersRef.current = baselineLayersRef.current.filter((l) => !ids.has(l.id));
+      },
     };
   });
 
@@ -985,6 +1066,30 @@ export function useBuilderSave(state: SaveState) {
           try {
             await patchMapLayers.mutateAsync({ id, diff });
           } catch (error) {
+            // fix(#1778): a stale diff is a CONFLICT, not a missing endpoint.
+            // Refetch the map, drop the ids the server no longer has, and retry
+            // the PATCH. A failure here falls through to the outer catch with a
+            // dedicated message; it must never reach the full PUT below.
+            if (isStaleLayerDiffError(error)) {
+              try {
+                const fresh = await getMap(id);
+                const serverLayerIds = new Set((fresh.layers ?? []).map((l) => l.id));
+                const reconciled = reconcileLayerDiffWithServer(diff, serverLayerIds);
+                if (hasDiff(reconciled)) {
+                  await patchMapLayers.mutateAsync({ id, diff: reconciled });
+                }
+              } catch {
+                throw new StaleLayerDiffError();
+              }
+              await updateMap.mutateAsync({ id, data: metadataPayload });
+              baselineLayersRef.current = stampPersistedFolderGroupExpanded(localLayers, groupMeta);
+              toast.warning(t('toasts.mapSavedAfterRemoteChange'));
+              if (!editedDuringSave(state, sentPluginSet)) {
+                state.setHasUnsavedChanges(false);
+              }
+              if (map && id) captureThumbnail(map, id, queryClient, localLayers);
+              return;
+            }
             if (!isUnsupportedLayerPatchError(error)) throw error;
             // fix(#430 V-01): this fallback converts a rejected partial PATCH into a
             // full PUT replacement (every layer re-serialized via toLayerInput,
@@ -1033,6 +1138,13 @@ export function useBuilderSave(state: SaveState) {
       }
     } catch (err) {
       setLastSaveFailed(true);
+      // fix(#1778): the map's layers changed in another session and the diff
+      // could not be reconciled. Say so, rather than reporting a generic
+      // failure or overwriting the map with this session's stale snapshot.
+      if (err instanceof StaleLayerDiffError) {
+        toast.error(t('toasts.saveConflictReload'));
+        return;
+      }
       // Detect FastAPI 422 popup_config rejection and surface a structured toast.
       // err.body is the raw detail value from the response (may be an array of
       // {loc, msg, type} objects for validation errors). Any unexpected shape

--- a/frontend/src/components/builder/hooks/use-builder-save.ts
+++ b/frontend/src/components/builder/hooks/use-builder-save.ts
@@ -717,25 +717,66 @@ function isStaleLayerDiffError(error: unknown): boolean {
  * already built keeps the recovery strictly additive to server state: ids the
  * server no longer has are simply dropped, and anything this session did not
  * touch is left alone.
+ *
+ * `serverLayerIds` is the refetched map's layer SEQUENCE in server sort order,
+ * not just a membership set, because the order reconciliation below needs
+ * positions.
  */
 export function reconcileLayerDiffWithServer(
   diff: MapLayerDiffRequest,
-  serverLayerIds: Set<string>,
+  serverLayerIds: readonly string[],
 ): MapLayerDiffRequest {
+  const serverIdSet = new Set(serverLayerIds);
   const next: MapLayerDiffRequest = {};
   if (diff.added?.length) next.added = diff.added;
-  const updated = diff.updated?.filter((patch) => serverLayerIds.has(patch.id));
+  const updated = diff.updated?.filter((patch) => serverIdSet.has(patch.id));
   if (updated?.length) next.updated = updated;
-  const removed = diff.removed?.filter((id) => serverLayerIds.has(id));
+  const removed = diff.removed?.filter((id) => serverIdSet.has(id));
   if (removed?.length) next.removed = removed;
   const removedSet = new Set(removed ?? []);
   if (diff.order) {
-    // The backend rejects an order that names an unknown id or one being
-    // removed in the same call, and it only ever orders pre-existing rows.
-    const order = diff.order.filter((id) => serverLayerIds.has(id) && !removedSet.has(id));
+    const order = mergeOrderWithServerSequence(diff.order, serverLayerIds, removedSet);
     if (order.length > 0) next.order = order;
   }
   return next;
+}
+
+/**
+ * fix(#1778 codex round 1): merge this session's relative order into the
+ * server's current sequence instead of sending only the ids this session knows.
+ *
+ * `apply_layer_diff` numbers the ids it is given from 0 and then APPENDS every
+ * surviving layer the order omitted. A bare filter would therefore take server
+ * order [A, X, B] with local order [B, A], send [B, A], and strand the remotely
+ * added X at the end as [B, A, X], moving a layer this session never saw. The
+ * stable merge walks the surviving server sequence and substitutes the next
+ * locally ordered survivor at each position a locally known layer already
+ * occupies, so unseen ids keep their server positions: [B, X, A].
+ *
+ * Ids being removed in the same call are dropped, because the backend rejects
+ * an order that names one, and so are ids the server no longer has.
+ */
+function mergeOrderWithServerSequence(
+  localOrder: readonly string[],
+  serverLayerIds: readonly string[],
+  removedIds: ReadonlySet<string>,
+): string[] {
+  const serverIdSet = new Set(serverLayerIds);
+  const localSurvivors = localOrder.filter(
+    (id) => serverIdSet.has(id) && !removedIds.has(id),
+  );
+  if (localSurvivors.length === 0) return [];
+  const localSurvivorSet = new Set(localSurvivors);
+  const merged: string[] = [];
+  let nextLocal = 0;
+  for (const id of serverLayerIds) {
+    if (removedIds.has(id)) continue;
+    // Every position a locally known survivor occupies is filled from the local
+    // sequence, in order. The counts match because localSurvivors is exactly the
+    // subset of surviving server ids this session ordered.
+    merged.push(localSurvivorSet.has(id) ? localSurvivors[nextLocal++] : id);
+  }
+  return merged;
 }
 
 export interface LayerDiffResult {
@@ -1073,7 +1114,9 @@ export function useBuilderSave(state: SaveState) {
             if (isStaleLayerDiffError(error)) {
               try {
                 const fresh = await getMap(id);
-                const serverLayerIds = new Set((fresh.layers ?? []).map((l) => l.id));
+                // GET /maps/{id} returns layers ordered by sort_order, so this is
+                // the server's current sequence, which the order merge needs.
+                const serverLayerIds = (fresh.layers ?? []).map((l) => l.id);
                 const reconciled = reconcileLayerDiffWithServer(diff, serverLayerIds);
                 if (hasDiff(reconciled)) {
                   await patchMapLayers.mutateAsync({ id, diff: reconciled });

--- a/frontend/src/components/builder/hooks/use-builder-save.ts
+++ b/frontend/src/components/builder/hooks/use-builder-save.ts
@@ -673,14 +673,38 @@ function hasDiff(diff: MapLayerDiffRequest): boolean {
 }
 
 // fix(#1778): only a status that means "this deployment has no layer-diff
-// endpoint" may escalate to the lossy full PUT. 405 (method not allowed) and
-// 501 (not implemented) are the two a router without the route can produce;
-// the old predicate also matched 400/404/409/422 with a prose regex, which is
-// exactly the shape the backend uses for a STALE diff. See
-// isStaleLayerDiffError below.
+// endpoint" may escalate to the lossy full PUT. The old predicate matched
+// 400/404/409/422 with a prose regex, which is exactly the shape the backend
+// uses for a STALE diff. See isStaleLayerDiffError below.
+//
+// fix(#1778 codex round 3): 404 is back, because it is the compatibility case
+// the PUT fallback exists for. A backend predating PATCH /maps/{id}/layers
+// answers 404 for the unknown route (FastAPI sends {"detail": "Not Found"}; an
+// edge proxy in front of it may send no JSON at all), and without 404 here
+// every layer-edit save against such a deployment would fail outright. 405 and
+// 501 are the other route-level answers.
+const ROUTE_LEVEL_UNSUPPORTED_STATUSES = new Set([404, 405, 501]);
+
+// The one legitimate 404 the route produces for ITSELF: the map is gone, not
+// the route (router.py's "Map not found", and apply_layer_diff's
+// "Map {id} not found"). A full PUT would only 404 again, so this surfaces as a
+// save failure instead. There is no 404 for a stale LAYER id: apply_layer_diff
+// raises ValueError for those and the router maps them to 400, which is what
+// isStaleLayerDiffError matches on, by detail and not by status alone.
+const MAP_NOT_FOUND_DETAIL = /^Map\b.*\bnot found$/i;
+
+/** The backend detail string, preferring the raw `detail` apiFetch stored on
+ *  the error. `message` has already been through translateApiErrorDetail and
+ *  may be localized, so it is only a fallback for a non-string detail. */
+function apiErrorDetailText(error: ApiError): string {
+  return typeof error.body === 'string' ? error.body : error.message;
+}
+
 function isUnsupportedLayerPatchError(error: unknown): boolean {
   if (!(error instanceof ApiError)) return false;
-  return error.status === 405 || error.status === 501;
+  if (!ROUTE_LEVEL_UNSUPPORTED_STATUSES.has(error.status)) return false;
+  if (error.status !== 404) return true;
+  return !MAP_NOT_FOUND_DETAIL.test(apiErrorDetailText(error));
 }
 
 // fix(#1778): the two details apply_layer_diff raises when the diff names layer
@@ -704,8 +728,7 @@ class StaleLayerDiffError extends Error {
 function isStaleLayerDiffError(error: unknown): boolean {
   if (!(error instanceof ApiError)) return false;
   if (error.status !== 400) return false;
-  const detail = typeof error.body === 'string' ? error.body : error.message;
-  return STALE_LAYER_DIFF_DETAIL.test(detail);
+  return STALE_LAYER_DIFF_DETAIL.test(apiErrorDetailText(error));
 }
 
 /**

--- a/frontend/src/components/builder/hooks/use-bulk-layer-actions.ts
+++ b/frontend/src/components/builder/hooks/use-bulk-layer-actions.ts
@@ -16,6 +16,7 @@ import {
   removePerLayerCompanions,
   shouldClearTerrainOnDelete,
 } from '@/components/builder/hooks/builder-layer-mutations';
+import type { SaveBaselineSync } from '@/components/builder/hooks/use-builder-save';
 import {
   type GroupedLayer,
   clearPersistedFolderGroup,
@@ -96,6 +97,9 @@ interface UseBulkLayerActionsParams {
   localTerrainConfig: MapTerrainConfig | null;
   setLocalTerrainConfig: React.Dispatch<React.SetStateAction<MapTerrainConfig | null>>;
   savedLayerBaselineRef: React.MutableRefObject<MapLayerResponse[]>;
+  /** fix(#1778): the save-diff baseline bridge; its `remove` half is called
+   *  alongside the savedLayerBaselineRef prune below. */
+  saveBaselineSyncRef: React.MutableRefObject<SaveBaselineSync>;
   copiedStyleRef: React.RefObject<CopiedStyle | null>;
   syncStyleConfigToMap: SyncStyleConfigToMap;
   mvtSourceLayerPrefix?: string | null;
@@ -164,6 +168,7 @@ export function useBulkLayerActions({
   localTerrainConfig,
   setLocalTerrainConfig,
   savedLayerBaselineRef,
+  saveBaselineSyncRef,
   copiedStyleRef,
   syncStyleConfigToMap,
   mvtSourceLayerPrefix,
@@ -484,6 +489,11 @@ export function useBulkLayerActions({
         savedLayerBaselineRef.current = pruneEmptyFolderGroups(
           savedLayerBaselineRef.current.filter((l) => !idsToDeleteSet.has(l.id)),
         );
+        // fix(#1778): the save-diff baseline needs the same prune. It only
+        // refreshes while the map is clean, so a bulk delete on an already-dirty
+        // map otherwise left these ids in it and the next save's diff.removed
+        // named rows the server had already dropped.
+        saveBaselineSyncRef.current?.remove(idsToDeleteSet);
         await queryClient.invalidateQueries({ queryKey: ['map', mapId] });
         toast.success(t('bulkActions.deleteSuccess', { count: idsToDelete.length }));
         return true;
@@ -563,6 +573,7 @@ export function useBulkLayerActions({
     setHasUnsavedChanges,
     mapInstanceRef,
     savedLayerBaselineRef,
+    saveBaselineSyncRef,
     t,
     queryClient,
   ]);

--- a/frontend/src/components/builder/hooks/use-bulk-layer-actions.ts
+++ b/frontend/src/components/builder/hooks/use-bulk-layer-actions.ts
@@ -527,6 +527,17 @@ export function useBulkLayerActions({
       // child is returning.
       const deletedIds = new Set(result.deleted);
       const failedIds = new Set(result.failed.map((f) => f.id));
+      // fix(#1778 codex round 1): the confirmed-deleted rows leave local state
+      // here just as they do on the full-success path, so BOTH baselines need
+      // the same prune. Without it the next Save re-emitted them in
+      // diff.removed, tripped the stale-conflict recovery and its warning, and
+      // failed outright whenever the refetch was unavailable. Only groups whose
+      // every child was actually deleted are pruned: a failed child is not in
+      // deletedIds, so its container still has a member and survives.
+      savedLayerBaselineRef.current = pruneEmptyFolderGroups(
+        savedLayerBaselineRef.current.filter((l) => !deletedIds.has(l.id)),
+      );
+      saveBaselineSyncRef.current?.remove(deletedIds);
       setLocalLayers((current) =>
         restoreFailedLayers(
           current.filter((l) => !deletedIds.has(l.id)),

--- a/frontend/src/components/builder/hooks/use-layer-map-sync.ts
+++ b/frontend/src/components/builder/hooks/use-layer-map-sync.ts
@@ -9,7 +9,7 @@ import {
 } from '@/components/builder/layer-adapters/shared';
 import type { PaintPropertyName } from '@/components/builder/layer-adapters/shared';
 import { mixedFamilyFilter } from '@/components/builder/layer-adapters/mixed-adapter';
-import { coalesceFrame } from '@/lib/builder/raf-coalesce';
+import { coalesceFrame, flushCoalescedFrame } from '@/lib/builder/raf-coalesce';
 // fix(#394) VT-03/VT-04: single source of truth for the MVT source-layer name.
 import { getMvtSourceLayerName } from '@/lib/tile-utils';
 import { reconcileColorClassification } from '@/lib/color-ramps';
@@ -367,6 +367,36 @@ export function clearExcludedPaintOnMap(
   }
 }
 
+/** The rAF coalesce key for a layer's batched paint write. Owned here because
+ *  handlePaintChange queues under it and applyLayerUpdate's replay drain has to
+ *  flush the same entry. fix(#1778 codex round 4). */
+function paintCoalesceKey(layerId: string): string {
+  return `paint:${layerId}`;
+}
+
+/**
+ * Replay a layer's deferred map writes in the order they were made.
+ *
+ * fix(#1778 codex round 4): a paint write does not touch the map itself, it
+ * queues `adapter.syncPaint` on the next animation frame, so replaying it
+ * alongside synchronous writes put it LAST in wall-clock order however early it
+ * was made. `fillAdapter.syncPaint` applies the `input.opacity` it captured, so
+ * a queued paint edit followed by an opacity edit ended with the older frame
+ * overwriting the newer opacity. Flushing the layer's pending frame after each
+ * replayed write restores chronological order and leaves the paint callback's
+ * closure semantics alone.
+ */
+function drainLayerWrites(
+  writes: readonly ((target: MaplibreMap) => void)[],
+  map: MaplibreMap,
+  layerId: string,
+): void {
+  for (const write of writes) {
+    write(map);
+    flushCoalescedFrame(paintCoalesceKey(layerId));
+  }
+}
+
 export function useLayerMapSync(
   localLayers: MapLayerResponse[],
   setLocalLayers: React.Dispatch<React.SetStateAction<MapLayerResponse[]>>,
@@ -507,7 +537,7 @@ export function useLayerMapSync(
           // Ignore a listener that was already flushed or superseded below.
           if (pending.get(layerId)?.listener !== listener) return;
           pending.delete(layerId);
-          for (const write of writes) write(map);
+          drainLayerWrites(writes, map, layerId);
         };
         pending.set(layerId, { writes, listener });
         map.once?.('idle', listener);
@@ -518,7 +548,7 @@ export function useLayerMapSync(
         // this newer write is applied last and wins.
         pending.delete(layerId);
         map.off?.('idle', queued.listener);
-        for (const write of queued.writes) write(map);
+        drainLayerWrites(queued.writes, map, layerId);
       }
       writeToMap(map);
     },
@@ -578,7 +608,7 @@ export function useLayerMapSync(
           // Paint writes coalesce via rAF (PERF-04); visibility/filter/order remain
           // synchronous because they're idempotent and cheap, and synchronous
           // semantics let UI toggles feel instant.
-          coalesceFrame(`paint:${layerId}`, () => adapter.syncPaint(map, input));
+          coalesceFrame(paintCoalesceKey(layerId), () => adapter.syncPaint(map, input));
         },
       );
     },

--- a/frontend/src/components/builder/hooks/use-layer-map-sync.ts
+++ b/frontend/src/components/builder/hooks/use-layer-map-sync.ts
@@ -384,6 +384,12 @@ export function useLayerMapSync(
     layersRef.current = localLayers;
   }, [localLayers]);
 
+  // fix(#1778 codex round 3): map writes deferred to `idle` because the style
+  // was mid-swap, keyed by layer id and replayed in order. See applyLayerUpdate.
+  const pendingMapWritesRef = useRef(
+    new Map<string, { writes: ((target: MaplibreMap) => void)[]; listener: () => void }>(),
+  );
+
   // Shared state-mutation + live-map-update pipeline for layer edits.
   // Collapses the dup 30-line boilerplate from paint/opacity/layout/style
   // handlers into one place (KISS-2). `updater` produces the new layer spec
@@ -478,9 +484,41 @@ export function useLayerMapSync(
       // syncLayersToMap does not re-apply, and generic LAYOUT is exactly that
       // class, since only handleLayoutChange ever writes it. Retry on idle,
       // matching BuilderMap's sync effect and use-render-mode-layers.
+      //
+      // fix(#1778 codex round 3): the deferred writes are QUEUED per layer and
+      // replayed in the order they were made, never as one captured value.
+      // isStyleLoaded() flips true before `idle` fires, so a second edit landing
+      // in that window used to write immediately and then be overwritten by the
+      // older queued callback: toggle a layer off during a basemap swap and back
+      // on before idle, and the map ended up hidden while state said visible.
+      // Each applyFn closes over its own value (nextVisible, newOpacity,
+      // newLayout), so re-reading the latest layer at fire time would not help;
+      // replaying oldest-first does, because the newest write lands last.
+      const pending = pendingMapWritesRef.current;
+      const queued = pending.get(layerId);
       if (!map.isStyleLoaded()) {
-        map.once?.('idle', () => writeToMap(map));
+        if (queued) {
+          // A listener is already armed for this layer; ride it.
+          queued.writes.push(writeToMap);
+          return;
+        }
+        const writes: ((target: MaplibreMap) => void)[] = [writeToMap];
+        const listener = () => {
+          // Ignore a listener that was already flushed or superseded below.
+          if (pending.get(layerId)?.listener !== listener) return;
+          pending.delete(layerId);
+          for (const write of writes) write(map);
+        };
+        pending.set(layerId, { writes, listener });
+        map.once?.('idle', listener);
         return;
+      }
+      if (queued) {
+        // The style finished loading before `idle`. Drain the backlog first so
+        // this newer write is applied last and wins.
+        pending.delete(layerId);
+        map.off?.('idle', queued.listener);
+        for (const write of queued.writes) write(map);
       }
       writeToMap(map);
     },

--- a/frontend/src/components/builder/hooks/use-layer-map-sync.ts
+++ b/frontend/src/components/builder/hooks/use-layer-map-sync.ts
@@ -461,16 +461,28 @@ export function useLayerMapSync(
 
       if (!applyFn) return;
       const map = mapInstanceRef.current;
-      if (!map || !map.isStyleLoaded()) return;
+      if (!map) return;
       // For the map side-effect we re-apply updater to the ref snapshot: the
       // map call is idempotent and the stale-ref issue only affects React state
       // composition, not the live-map sync. This keeps the applyFn signature
       // stable (it receives the just-computed updated layer, not a stale one).
       const { layer: normalized, exclusions } = normalize(existing, updater(existing));
-      // A key that merely stopped being present cannot be expressed in a paint object,
-      // so the removal needs an explicit undefined write before the adapter repaint.
-      if (exclusions) clearExcludedPaintOnMap(map, layerId, exclusions);
-      applyFn(map, normalized);
+      const writeToMap = (target: MaplibreMap) => {
+        // A key that merely stopped being present cannot be expressed in a paint object,
+        // so the removal needs an explicit undefined write before the adapter repaint.
+        if (exclusions) clearExcludedPaintOnMap(target, layerId, exclusions);
+        applyFn(target, normalized);
+      };
+      // fix(#1778): React state is already committed above, so dropping the map
+      // write here left the two permanently out of step for anything
+      // syncLayersToMap does not re-apply, and generic LAYOUT is exactly that
+      // class, since only handleLayoutChange ever writes it. Retry on idle,
+      // matching BuilderMap's sync effect and use-render-mode-layers.
+      if (!map.isStyleLoaded()) {
+        map.once?.('idle', () => writeToMap(map));
+        return;
+      }
+      writeToMap(map);
     },
     [setLocalLayers, setHasUnsavedChanges, mapInstanceRef],
   );
@@ -673,6 +685,13 @@ export function useLayerMapSync(
     [applyLayerUpdate, mvtSourceLayerPrefix],
   );
 
+  // fix(#1778): this is the SOLE writer of generic layout on a live layer, by
+  // design rather than by accident. syncLayersToMap re-applies paint, filter and
+  // the private _minzoom/_maxzoom keys on every state change, but never a
+  // layer's `layout` block, and only the line/symbol/cluster/mixed adapters
+  // touch layout at all. The clear-removed-props loop below is likewise the only
+  // code anywhere that unsets a layout key. Anything that changes a layer's
+  // layout must therefore route through here, or the map keeps the old value.
   const handleLayoutChange = useCallback(
     (layerId: string, newLayout: Record<string, unknown>) => {
       const prevLayout = (layersRef.current.find((l) => l.id === layerId)?.layout ?? {}) as Record<string, unknown>;

--- a/frontend/src/components/builder/layer-adapters/symbol-adapter.ts
+++ b/frontend/src/components/builder/layer-adapters/symbol-adapter.ts
@@ -2,7 +2,7 @@ import type { Map as MaplibreMap } from 'maplibre-gl';
 import type { AdapterLayerInput, LayerAdapter } from './types';
 import { syncOwnedLayoutProperties, syncOwnedPaintProperties, syncSingleLayerVisibility, syncLayerFilter } from './shared';
 import { MAP_COLORS } from '@/lib/map-colors';
-import type { SymbolStyleConfig } from '@/types/api';
+import type { StyleConfig, SymbolStyleConfig } from '@/types/api';
 import { DEFAULT_POINT_LABEL_OFFSET, LABEL_FONT_STACK } from '../label-layer-utils';
 
 const DEFAULT_ICON = 'marker';
@@ -39,13 +39,30 @@ const SYMBOL_OWNED_PAINT_PROPERTIES = [
   'text-opacity',
 ] as const;
 
-function getSymbolConfig(input: AdapterLayerInput): SymbolStyleConfig {
-  const styleConfig = input.style_config ?? {};
-  const builder = styleConfig.builder ?? {};
+/**
+ * Merge a layer's symbol config from the two places it can live.
+ *
+ * `style_config.builder.symbol` is the legacy stash and `style_config.symbol`
+ * is the current home; a layer can carry BOTH, with the top-level object
+ * winning field by field. fix(#1778 codex round 2): exported because map-sync
+ * resolves `categoryColumn` for the tile column list and a top-level
+ * `?? builder.symbol` picked whichever object existed rather than merging, so a
+ * `categoryColumn` stashed under `builder` was dropped whenever any top-level
+ * symbol object was present.
+ */
+export function resolveSymbolConfig(
+  styleConfig: StyleConfig | null | undefined,
+): SymbolStyleConfig {
+  const config = styleConfig ?? {};
+  const builder = config.builder ?? {};
   return {
     ...(builder.symbol ?? {}),
-    ...(styleConfig.symbol ?? {}),
+    ...(config.symbol ?? {}),
   };
+}
+
+function getSymbolConfig(input: AdapterLayerInput): SymbolStyleConfig {
+  return resolveSymbolConfig(input.style_config);
 }
 
 function spriteIconId(icon: string): string {

--- a/frontend/src/components/builder/map-sync.ts
+++ b/frontend/src/components/builder/map-sync.ts
@@ -26,6 +26,7 @@ import type { AdapterLayerInput, LayerAdapter } from './layer-adapters/types';
 import { buildLabelLayerSpec, syncLabelLayer } from './label-layer-utils';
 import { clusterCircleLayerId, clusterCountLayerId, getClusterSourceOptions } from './layer-adapters/cluster-adapter';
 import { mixedLinesLayerId, mixedPointsLayerId } from './layer-adapters/mixed-adapter';
+import { resolveSymbolConfig } from './layer-adapters/symbol-adapter';
 import { getClusterSourceStrategy } from './cluster-source';
 import { syncColorReliefLayer } from './color-relief-sync';
 import { buildColormapTileUrl } from './layer-adapters/raster-adapter';
@@ -346,8 +347,7 @@ function basemapStyleLayers(style: StyleSpecification, sourcePrefix: string) {
   ) as StyleSpecification['layers'];
 }
 
-/** fix(#1778): the pristine paint of every basemap-owned style layer, captured
- *  before this module first overrode it and dropped whenever a new style loads.
+/** fix(#1778): what this module knows about one basemap-owned layer's paint.
  *
  *  applyBasemapConfigToMap feeds `map.getStyle()`, the LIVE and already-mutated
  *  style, into applyBasemapConfigToStyle, and the appearance helpers
@@ -355,37 +355,81 @@ function basemapStyleLayers(style: StyleSpecification, sourcePrefix: string) {
  *  on their default value. On a revert pass the "next" value was therefore the
  *  tint the previous pass wrote, compared equal, and nothing was written: the
  *  map stayed tinted for the rest of the session while React state, the stack
- *  row and the saved payload all said "default". Diffing against pristine is
+ *  row and the saved payload all said "default". Diffing against `pristine` is
  *  what makes "no override" a target state the writer can express. */
-const pristineBasemapPaint = new WeakMap<MaplibreMap, Map<string, Record<string, unknown>>>();
-/** Paint keys THIS module last wrote per basemap layer, so a key the current
- *  config no longer sets can be restored without touching keys owned by
- *  applySublayerOverrides or by the style itself. */
-const stampedBasemapPaintKeys = new WeakMap<MaplibreMap, Map<string, Set<string>>>();
-const pristineInvalidatorAttached = new WeakSet<MaplibreMap>();
+interface BasemapLayerPaintState {
+  /** The layer's paint before this module overrode it. */
+  pristine: Record<string, unknown>;
+  /** The paint this module believes is live: `pristine` with everything it has
+   *  since written on top. A live value that disagrees means somebody else
+   *  wrote the key, and the most important somebody is a new style. */
+  expected: Record<string, unknown>;
+  /** Keys currently carrying an override, so a key the config stops setting can
+   *  be restored without touching keys owned by applySublayerOverrides or by
+   *  the style itself. */
+  stamped: Set<string>;
+}
 
-function basemapPaintCaches(map: MaplibreMap) {
-  if (!pristineInvalidatorAttached.has(map)) {
-    pristineInvalidatorAttached.add(map);
-    // A new style means new pristine values. Without this a basemap swap
-    // between two styles that share layer ids (openfreemap positron/dark do)
-    // would restore the previous basemap's colors onto the new one.
-    map.on?.('style.load', () => {
-      pristineBasemapPaint.delete(map);
-      stampedBasemapPaintKeys.delete(map);
-    });
+const basemapPaintStates = new WeakMap<MaplibreMap, Map<string, BasemapLayerPaintState>>();
+
+function basemapPaintStateFor(map: MaplibreMap): Map<string, BasemapLayerPaintState> {
+  let states = basemapPaintStates.get(map);
+  if (!states) {
+    states = new Map();
+    basemapPaintStates.set(map, states);
   }
-  let pristine = pristineBasemapPaint.get(map);
-  if (!pristine) {
-    pristine = new Map();
-    pristineBasemapPaint.set(map, pristine);
+  return states;
+}
+
+/**
+ * fix(#1778 codex round 2 P1): detect a style change SYNCHRONOUSLY, here, per
+ * key, instead of clearing the cache from a `style.load` listener.
+ *
+ * The listener could never be right: BuilderMap registers its own persistent
+ * `style.load` handler when the map mounts, and that handler calls
+ * applyMapBasemapAppearance. Any listener this module attached was therefore
+ * registered later and ran later, so on a swap between two styles that share
+ * layer ids the appearance pass saw the OLD pristine values, wrote the previous
+ * basemap's colours onto the new style, and the contaminated paint then became
+ * the next pristine snapshot.
+ *
+ * A style-generation token would fix the ordering but not the detection: every
+ * cheap style-identity field in this codebase moves for unrelated reasons
+ * (`sprite` is rewritten by the symbol adapter's `addSprite`, and `layers` and
+ * `sources` change on every data-layer add), and a token that cannot see a
+ * difference between two styles is silently back to the same bug. Comparing
+ * each cached key against the value this module last left there needs no token
+ * and catches any writer, a new style included.
+ *
+ * Per KEY rather than per layer on purpose: applySublayerOverrides runs
+ * immediately after this helper and rewrites the `*-opacity` keys, so a
+ * layer-level check would discard that layer's whole snapshot every pass and
+ * re-baseline the tint as pristine. Those opacity keys are harmless to
+ * re-snapshot because applyMasterOpacity writes them absolutely on every pass
+ * and never consults their pristine value.
+ */
+function reconcileBasemapPaintState(
+  state: BasemapLayerPaintState | undefined,
+  livePaint: Record<string, unknown>,
+): BasemapLayerPaintState {
+  if (!state) {
+    return { pristine: { ...livePaint }, expected: { ...livePaint }, stamped: new Set() };
   }
-  let stamped = stampedBasemapPaintKeys.get(map);
-  if (!stamped) {
-    stamped = new Map();
-    stampedBasemapPaintKeys.set(map, stamped);
+  for (const [key, live] of Object.entries(livePaint)) {
+    if (key in state.expected && state.expected[key] === live) continue;
+    state.pristine[key] = live;
+    state.expected[key] = live;
+    state.stamped.delete(key);
   }
-  return { pristine, stamped };
+  for (const key of Object.keys(state.expected)) {
+    // maplibre omits a paint key whose value was set to undefined, so a key
+    // that has left the serialized paint is one this module no longer knows.
+    if (key in livePaint) continue;
+    delete state.pristine[key];
+    delete state.expected[key];
+    state.stamped.delete(key);
+  }
+  return state;
 }
 
 /** UX-03 (Phase 1051 Plan 06): when `basemap_position === 'top'`, move all
@@ -449,17 +493,16 @@ export function applyBasemapConfigToMap(
   // fix(#1778): capture the pristine paint the FIRST time each basemap layer is
   // seen (before this call writes anything), then build `next` from pristine
   // rather than from the live style, so reverting an override is expressible.
-  const { pristine, stamped } = basemapPaintCaches(map);
+  // fix(#1778 codex round 2): reconcile first, so a key the live style no longer
+  // agrees with this module about is re-snapshotted before it is read.
+  const paintStates = basemapPaintStateFor(map);
   const pristineLayers = basemapOnlyStyle.layers.map((layer) => {
-    const livePaint = 'paint' in layer
+    const livePaint = ('paint' in layer
       ? (layer.paint as Record<string, unknown> | undefined)
-      : undefined;
-    let cached = pristine.get(layer.id);
-    if (!cached) {
-      cached = { ...(livePaint ?? {}) };
-      pristine.set(layer.id, cached);
-    }
-    return { ...layer, paint: cached };
+      : undefined) ?? {};
+    const state = reconcileBasemapPaintState(paintStates.get(layer.id), livePaint);
+    paintStates.set(layer.id, state);
+    return { ...layer, paint: { ...state.pristine } };
   }) as StyleSpecification['layers'];
   const nextStyle = applyBasemapConfigToStyle(
     { ...basemapOnlyStyle, layers: pristineLayers },
@@ -484,27 +527,35 @@ export function applyBasemapConfigToMap(
 
     const currentPaint = 'paint' in current ? current.paint as Record<string, unknown> | undefined : undefined;
     const nextPaint = 'paint' in next ? next.paint as Record<string, unknown> | undefined : undefined;
-    const pristinePaint = pristine.get(current.id) ?? {};
-    const previouslyStamped = stamped.get(current.id) ?? new Set<string>();
+    const state = paintStates.get(current.id);
+    const pristinePaint = state?.pristine ?? {};
     // The union is what makes a revert reachable: `next` alone misses a key the
     // OLD config stamped and this one does not set at all (text-halo-width from
     // label_mode 'subtle' is the canonical case). Keys are restricted to what
     // this function itself wrote, so applySublayerOverrides' writes and the
     // style's own paint are never clobbered.
-    const keysToWrite = new Set<string>([...Object.keys(nextPaint ?? {}), ...previouslyStamped]);
+    const keysToWrite = new Set<string>([
+      ...Object.keys(nextPaint ?? {}),
+      ...(state?.stamped ?? []),
+    ]);
     const nowStamped = new Set<string>();
     for (const key of keysToWrite) {
       const target = nextPaint && key in nextPaint ? nextPaint[key] : pristinePaint[key];
       if (target !== pristinePaint[key]) nowStamped.add(key);
-      if (target === currentPaint?.[key]) continue;
+      if (target === currentPaint?.[key]) {
+        if (state) state.expected[key] = target;
+        continue;
+      }
       try {
         setDynamicPaintProperty(map, current.id, key, target);
+        // Recorded only on success: a throw leaves the live value untouched, so
+        // the expectation must stay whatever it already was.
+        if (state) state.expected[key] = target;
       } catch (error) {
         if (import.meta.env.DEV) console.warn('[map-sync] basemap paint sync failed', current.id, key, error);
       }
     }
-    if (nowStamped.size > 0) stamped.set(current.id, nowStamped);
-    else stamped.delete(current.id);
+    if (state) state.stamped = nowStamped;
   }
 }
 
@@ -734,10 +785,13 @@ export function getDataDrivenColumnsForLayer(
   const labelCol = layer.label_config?.column;
   if (typeof labelCol === 'string' && labelCol) cols.add(labelCol);
   // fix(#1778): the symbol adapter's per-category `icon-image` is the other
-  // data-driven LAYOUT expression the paint walk below cannot reach. Merge
-  // order matches getSymbolConfig in symbol-adapter.ts so a builder-stashed
-  // config and a top-level one both resolve.
-  const symbolCol = (layer.style_config?.symbol ?? layer.style_config?.builder?.symbol)?.categoryColumn;
+  // data-driven LAYOUT expression the paint walk below cannot reach.
+  // fix(#1778 codex round 2): resolved through the SAME merge the adapter uses,
+  // not `style_config.symbol ?? style_config.builder.symbol`. That picked one
+  // object whole, so a `categoryColumn` stashed under `builder` was dropped as
+  // soon as any top-level symbol object existed, and the icons fell back below
+  // z10 exactly as if the column had never been read.
+  const symbolCol = resolveSymbolConfig(layer.style_config).categoryColumn;
   if (typeof symbolCol === 'string' && symbolCol) cols.add(symbolCol);
   // Walk MapLibre expressions for `["get", "<name>"]` / `["has", "<name>"]`
   // references — the canonical ways to read a feature property. Used for both

--- a/frontend/src/components/builder/map-sync.ts
+++ b/frontend/src/components/builder/map-sync.ts
@@ -1313,6 +1313,47 @@ function removeStaleSourcesAndLayers(
   }
 }
 
+/** fix(#1778): remove managed data layers whose logical layer is gone even when
+ *  their SOURCE is still wanted.
+ *
+ *  removeStaleSourcesAndLayers is keyed on the source, so under the SF-04
+ *  dedupe (two layers on one dataset share `source-data-${table}`) deleting one
+ *  of them leaves the source DESIRED and its layer rows are never reclaimed.
+ *  The delete path's own cleanup (removePerLayerCompanions) is best-effort, so
+ *  this walk is the backstop that closes the class rather than one instance.
+ *
+ *  Scoped on three conditions at once, so a basemap layer that happens to be
+ *  named `layer-*` and anything a plugin added are left alone: the id starts
+ *  with the managed `layer-` prefix, the layer sits on a data source (every
+ *  managed layer does, including the label and color-relief companions), and
+ *  the id is absent from the companion-id expansion of the desired set. */
+function removeOrphanManagedLayers(
+  map: MaplibreMap,
+  desiredLayerIds: Iterable<string>,
+  sourcePrefix: string,
+  prefix: string | undefined,
+) {
+  const style = map.getStyle();
+  if (!style?.layers) return;
+  const managedPrefix = `${prefix ?? ''}layer-`;
+  const keep = new Set<string>();
+  for (const id of desiredLayerIds) {
+    const ids = getCompanionLayerIds(id, prefix);
+    for (const companion of [
+      ids.layer, ids.outline, ids.extrusion, ids.arrow, ids.label,
+      ids.colorRelief, ids.cluster, ids.clusterCount, ids.mixedLines, ids.mixedPoints,
+    ]) {
+      keep.add(companion);
+    }
+  }
+  for (const styleLayer of style.layers) {
+    if (!styleLayer.id.startsWith(managedPrefix)) continue;
+    if (isBasemapOwnedLayer(styleLayer, sourcePrefix)) continue;
+    if (keep.has(styleLayer.id)) continue;
+    if (map.getLayer(styleLayer.id)) map.removeLayer(styleLayer.id);
+  }
+}
+
 // ---------------------------------------------------------------------------
 
 /** Imperatively add/sync all data layers to the map. Safe to call repeatedly.
@@ -1420,6 +1461,11 @@ export function syncLayersToMap(
   }
 
   try {
+    // fix(#1778): layer-aware prune first, so an orphan on a still-shared
+    // deduped source is reclaimed. Ordered before the source prune because the
+    // source prune's removeLayersUsingSource depends on the layer set only for
+    // sources it is about to drop.
+    removeOrphanManagedLayers(map, renderableLayers.map((l) => l.id), sourcePrefix, prefix);
     removeStaleSourcesAndLayers(map, currentSources, desiredSources, sourcePrefix, prefix);
     managedSourcesRef.current = desiredSources;
   } catch (err) {

--- a/frontend/src/components/builder/map-sync.ts
+++ b/frontend/src/components/builder/map-sync.ts
@@ -346,12 +346,46 @@ function basemapStyleLayers(style: StyleSpecification, sourcePrefix: string) {
   ) as StyleSpecification['layers'];
 }
 
-function changedPaintKeys(
-  before: Record<string, unknown> | undefined,
-  after: Record<string, unknown> | undefined,
-) {
-  if (!after) return [];
-  return Object.keys(after).filter((key) => before?.[key] !== after[key]);
+/** fix(#1778): the pristine paint of every basemap-owned style layer, captured
+ *  before this module first overrode it and dropped whenever a new style loads.
+ *
+ *  applyBasemapConfigToMap feeds `map.getStyle()`, the LIVE and already-mutated
+ *  style, into applyBasemapConfigToStyle, and the appearance helpers
+ *  (applyLandWaterTone / applyBackgroundColor / applyReliefContrast) are no-ops
+ *  on their default value. On a revert pass the "next" value was therefore the
+ *  tint the previous pass wrote, compared equal, and nothing was written: the
+ *  map stayed tinted for the rest of the session while React state, the stack
+ *  row and the saved payload all said "default". Diffing against pristine is
+ *  what makes "no override" a target state the writer can express. */
+const pristineBasemapPaint = new WeakMap<MaplibreMap, Map<string, Record<string, unknown>>>();
+/** Paint keys THIS module last wrote per basemap layer, so a key the current
+ *  config no longer sets can be restored without touching keys owned by
+ *  applySublayerOverrides or by the style itself. */
+const stampedBasemapPaintKeys = new WeakMap<MaplibreMap, Map<string, Set<string>>>();
+const pristineInvalidatorAttached = new WeakSet<MaplibreMap>();
+
+function basemapPaintCaches(map: MaplibreMap) {
+  if (!pristineInvalidatorAttached.has(map)) {
+    pristineInvalidatorAttached.add(map);
+    // A new style means new pristine values. Without this a basemap swap
+    // between two styles that share layer ids (openfreemap positron/dark do)
+    // would restore the previous basemap's colors onto the new one.
+    map.on?.('style.load', () => {
+      pristineBasemapPaint.delete(map);
+      stampedBasemapPaintKeys.delete(map);
+    });
+  }
+  let pristine = pristineBasemapPaint.get(map);
+  if (!pristine) {
+    pristine = new Map();
+    pristineBasemapPaint.set(map, pristine);
+  }
+  let stamped = stampedBasemapPaintKeys.get(map);
+  if (!stamped) {
+    stamped = new Map();
+    stampedBasemapPaintKeys.set(map, stamped);
+  }
+  return { pristine, stamped };
 }
 
 /** UX-03 (Phase 1051 Plan 06): when `basemap_position === 'top'`, move all
@@ -412,8 +446,23 @@ export function applyBasemapConfigToMap(
     ...style,
     layers: basemapStyleLayers(style, sourcePrefix),
   };
+  // fix(#1778): capture the pristine paint the FIRST time each basemap layer is
+  // seen (before this call writes anything), then build `next` from pristine
+  // rather than from the live style, so reverting an override is expressible.
+  const { pristine, stamped } = basemapPaintCaches(map);
+  const pristineLayers = basemapOnlyStyle.layers.map((layer) => {
+    const livePaint = 'paint' in layer
+      ? (layer.paint as Record<string, unknown> | undefined)
+      : undefined;
+    let cached = pristine.get(layer.id);
+    if (!cached) {
+      cached = { ...(livePaint ?? {}) };
+      pristine.set(layer.id, cached);
+    }
+    return { ...layer, paint: cached };
+  }) as StyleSpecification['layers'];
   const nextStyle = applyBasemapConfigToStyle(
-    basemapOnlyStyle,
+    { ...basemapOnlyStyle, layers: pristineLayers },
     basemapConfig,
     showBasemapLabels,
   );
@@ -435,13 +484,27 @@ export function applyBasemapConfigToMap(
 
     const currentPaint = 'paint' in current ? current.paint as Record<string, unknown> | undefined : undefined;
     const nextPaint = 'paint' in next ? next.paint as Record<string, unknown> | undefined : undefined;
-    for (const key of changedPaintKeys(currentPaint, nextPaint)) {
+    const pristinePaint = pristine.get(current.id) ?? {};
+    const previouslyStamped = stamped.get(current.id) ?? new Set<string>();
+    // The union is what makes a revert reachable: `next` alone misses a key the
+    // OLD config stamped and this one does not set at all (text-halo-width from
+    // label_mode 'subtle' is the canonical case). Keys are restricted to what
+    // this function itself wrote, so applySublayerOverrides' writes and the
+    // style's own paint are never clobbered.
+    const keysToWrite = new Set<string>([...Object.keys(nextPaint ?? {}), ...previouslyStamped]);
+    const nowStamped = new Set<string>();
+    for (const key of keysToWrite) {
+      const target = nextPaint && key in nextPaint ? nextPaint[key] : pristinePaint[key];
+      if (target !== pristinePaint[key]) nowStamped.add(key);
+      if (target === currentPaint?.[key]) continue;
       try {
-        setDynamicPaintProperty(map, current.id, key, nextPaint?.[key]);
+        setDynamicPaintProperty(map, current.id, key, target);
       } catch (error) {
         if (import.meta.env.DEV) console.warn('[map-sync] basemap paint sync failed', current.id, key, error);
       }
     }
+    if (nowStamped.size > 0) stamped.set(current.id, nowStamped);
+    else stamped.delete(current.id);
   }
 }
 

--- a/frontend/src/components/builder/map-sync.ts
+++ b/frontend/src/components/builder/map-sync.ts
@@ -370,14 +370,63 @@ interface BasemapLayerPaintState {
   stamped: Set<string>;
 }
 
-const basemapPaintStates = new WeakMap<MaplibreMap, Map<string, BasemapLayerPaintState>>();
+/** The per-layer states, tagged with the style generation they describe. */
+interface BasemapPaintCache {
+  generation: number;
+  states: Map<string, BasemapLayerPaintState>;
+}
+
+const basemapPaintStates = new WeakMap<MaplibreMap, BasemapPaintCache>();
+const basemapStyleGenerations = new WeakMap<MaplibreMap, { value: number }>();
+const generationListenerAttached = new WeakSet<MaplibreMap>();
+
+/**
+ * Start counting style generations for `map`.
+ *
+ * fix(#1778 codex round 5): per-key equality reconciliation cannot see a swap
+ * whose new native value happens to equal the override the old style was
+ * carrying (style A's water overridden to #d9dde0, style B's native water also
+ * #d9dde0). Nothing has changed from the paint's point of view, so clearing the
+ * override afterwards restored A's colour. A generation counter closes that,
+ * and unlike a style-identity token it does not depend on fields that move for
+ * unrelated reasons (`sprite` is rewritten by the symbol adapter's `addSprite`;
+ * `layers` and `sources` change on every data-layer add).
+ *
+ * MUST be called from the map-creation path (BuilderMap and ViewerMap
+ * `onLoad`), never lazily from an appearance pass. That is what makes this the
+ * earliest-registered `style.load` listener, so it has already bumped the
+ * counter by the time BuilderMap's own persistent handler triggers an
+ * appearance pass on the new style. Registering it lazily would reproduce the
+ * round-2 ordering bug exactly.
+ *
+ * Idempotent: a second call for the same map is a no-op, so a remount that
+ * reuses the instance cannot double-count.
+ */
+export function registerBasemapStyleGeneration(map: MaplibreMap): void {
+  if (generationListenerAttached.has(map)) return;
+  generationListenerAttached.add(map);
+  const counter = basemapStyleGenerations.get(map) ?? { value: 0 };
+  basemapStyleGenerations.set(map, counter);
+  // Partial map mocks in tests lack `on`, hence the optional call.
+  map.on?.('style.load', () => {
+    counter.value += 1;
+  });
+}
+
+/** Zero when no counter is registered, so a surface that has not opted in
+ *  degrades to the equality reconciliation alone rather than misbehaving. */
+function currentBasemapStyleGeneration(map: MaplibreMap): number {
+  return basemapStyleGenerations.get(map)?.value ?? 0;
+}
 
 function basemapPaintStateFor(map: MaplibreMap): Map<string, BasemapLayerPaintState> {
-  let states = basemapPaintStates.get(map);
-  if (!states) {
-    states = new Map();
-    basemapPaintStates.set(map, states);
-  }
+  const generation = currentBasemapStyleGeneration(map);
+  const cache = basemapPaintStates.get(map);
+  // A generation bump means a different style is loaded; everything cached
+  // describes the previous one, so treat it as empty and re-snapshot.
+  if (cache && cache.generation === generation) return cache.states;
+  const states = new Map<string, BasemapLayerPaintState>();
+  basemapPaintStates.set(map, { generation, states });
   return states;
 }
 
@@ -393,13 +442,13 @@ function basemapPaintStateFor(map: MaplibreMap): Map<string, BasemapLayerPaintSt
  * basemap's colours onto the new style, and the contaminated paint then became
  * the next pristine snapshot.
  *
- * A style-generation token would fix the ordering but not the detection: every
- * cheap style-identity field in this codebase moves for unrelated reasons
- * (`sprite` is rewritten by the symbol adapter's `addSprite`, and `layers` and
- * `sources` change on every data-layer add), and a token that cannot see a
- * difference between two styles is silently back to the same bug. Comparing
- * each cached key against the value this module last left there needs no token
- * and catches any writer, a new style included.
+ * fix(#1778 codex round 5): this is now the SECOND line of defence.
+ * registerBasemapStyleGeneration drops the whole cache when the style
+ * generation moves, which covers the one case equality cannot see: a new style
+ * whose native value equals the override the old one was carrying. The
+ * per-key comparison stays because it catches every OTHER writer, needs no
+ * cooperation from the surface hosting the map, and keeps working on a surface
+ * that never registered a counter.
  *
  * Per KEY rather than per layer on purpose: applySublayerOverrides runs
  * immediately after this helper and rewrites the `*-opacity` keys, so a

--- a/frontend/src/components/builder/map-sync.ts
+++ b/frontend/src/components/builder/map-sync.ts
@@ -702,6 +702,9 @@ export interface SourceIdLayer {
  *  - paint expressions of shape `["get", "<colname>"]` — generic catch-all
  *  - `label_config.column` — label text-field is a LAYOUT property the paint
  *    walk cannot see, which is exactly why an explicit read is required here
+ *  - `style_config.symbol.categoryColumn` (#1778): the per-category
+ *    `icon-image` match is the other data-driven LAYOUT expression, so a
+ *    category-styled symbol layer fell back to its default icon below z10
  *  - `filter` expressions (builder-audit #338 P1-03) — a filter that references a
  *    column NOT also used by paint/label would otherwise evaluate against
  *    missing properties at z<10, producing empty/inconsistent rendering.
@@ -730,6 +733,12 @@ export function getDataDrivenColumnsForLayer(
   // property — a LAYOUT expression the paint walk below cannot reach.
   const labelCol = layer.label_config?.column;
   if (typeof labelCol === 'string' && labelCol) cols.add(labelCol);
+  // fix(#1778): the symbol adapter's per-category `icon-image` is the other
+  // data-driven LAYOUT expression the paint walk below cannot reach. Merge
+  // order matches getSymbolConfig in symbol-adapter.ts so a builder-stashed
+  // config and a top-level one both resolve.
+  const symbolCol = (layer.style_config?.symbol ?? layer.style_config?.builder?.symbol)?.categoryColumn;
+  if (typeof symbolCol === 'string' && symbolCol) cols.add(symbolCol);
   // Walk MapLibre expressions for `["get", "<name>"]` / `["has", "<name>"]`
   // references — the canonical ways to read a feature property. Used for both
   // paint values AND the filter (P1-03), so filter-only columns survive the

--- a/frontend/src/components/viewer/ViewerMap.tsx
+++ b/frontend/src/components/viewer/ViewerMap.tsx
@@ -35,7 +35,7 @@ import type { Map as MaplibreMap } from 'maplibre-gl';
 import type { MapBasemapConfig, MapTerrainConfig, SharedLayerResponse } from '@/types/api';
 import { getAdapter } from '@/components/builder/layer-adapters/registry';
 import type { AdapterLayerInput } from '@/components/builder/layer-adapters/types';
-import { resolveAdapterType, prefixed, getDataDrivenColumnsForLayer } from '@/components/builder/map-sync';
+import { resolveAdapterType, prefixed, getDataDrivenColumnsForLayer, registerBasemapStyleGeneration } from '@/components/builder/map-sync';
 import { applyMapBasemapAppearance, syncMapComposition } from '@/components/builder/map-composition-sync';
 import type { SyncLayerInput } from '@/components/builder/map-sync';
 import { asFeatureCollection, fetchBoundedGeoJson } from '@/api/geojson-z';
@@ -382,6 +382,12 @@ export const ViewerMap = memo(function ViewerMap({
     (e: MapLibreEvent) => {
       const map = e.target;
       mapRef.current = map;
+      // fix(#1778 codex round 5): FIRST thing in the map-creation path, so this
+      // is the earliest-registered `style.load` listener and the basemap paint
+      // cache is already invalidated by the time any appearance pass runs
+      // against a newly loaded style. Registering it lazily from the appearance
+      // helper would put it behind the persistent handler below.
+      registerBasemapStyleGeneration(map);
 
       // First-party vs third-party request classification
       // (chore(#835): shared `isThirdPartyTileUrl` in lib/tile-utils). Used to

--- a/frontend/src/i18n/locales/de/builder.json
+++ b/frontend/src/i18n/locales/de/builder.json
@@ -892,6 +892,8 @@
   "toasts": {
     "mapSaved": "Karte gespeichert",
     "mapSavedFullResync": "Karte gespeichert, aber eine vollständige Neusynchronisierung war erforderlich. Bitte Layer-Stil überprüfen.",
+    "mapSavedAfterRemoteChange": "Gespeichert. Einige Layer wurden bereits in einer anderen Sitzung geändert, diese Änderungen wurden übersprungen.",
+    "saveConflictReload": "Diese Karte wurde in einer anderen Sitzung geändert. Laden Sie die Karte neu, um die aktuelle Version zu erhalten, und speichern Sie erneut.",
     "saveFailed": "Karte konnte nicht gespeichert werden",
     "saveFailedWithDetail": "Karte konnte nicht gespeichert werden: {{detail}}",
     "layerRemoved": "Layer entfernt",

--- a/frontend/src/i18n/locales/en/builder.json
+++ b/frontend/src/i18n/locales/en/builder.json
@@ -892,6 +892,8 @@
   "toasts": {
     "mapSaved": "Map saved",
     "mapSavedFullResync": "Map saved, but required a full re-sync. Please double-check layer styling.",
+    "mapSavedAfterRemoteChange": "Saved. Some layers had already changed in another session, so those edits were skipped.",
+    "saveConflictReload": "This map changed in another session. Reload the map to get the latest version, then save again.",
     "saveFailed": "Failed to save map",
     "saveFailedWithDetail": "Failed to save map: {{detail}}",
     "layerRemoved": "Layer removed",

--- a/frontend/src/i18n/locales/es/builder.json
+++ b/frontend/src/i18n/locales/es/builder.json
@@ -892,6 +892,8 @@
   "toasts": {
     "mapSaved": "Mapa guardado",
     "mapSavedFullResync": "Mapa guardado, pero requirió una resincronización completa. Verifique el estilo de las capas.",
+    "mapSavedAfterRemoteChange": "Guardado. Algunas capas ya habían cambiado en otra sesión, por lo que esas ediciones se omitieron.",
+    "saveConflictReload": "Este mapa cambió en otra sesión. Vuelva a cargar el mapa para obtener la última versión y guarde de nuevo.",
     "saveFailed": "Error al guardar el mapa",
     "saveFailedWithDetail": "Error al guardar el mapa: {{detail}}",
     "layerRemoved": "Capa eliminada",

--- a/frontend/src/i18n/locales/fr/builder.json
+++ b/frontend/src/i18n/locales/fr/builder.json
@@ -892,6 +892,8 @@
   "toasts": {
     "mapSaved": "Carte enregistrée",
     "mapSavedFullResync": "Carte enregistrée, mais une resynchronisation complète a été nécessaire. Vérifiez le style des couches.",
+    "mapSavedAfterRemoteChange": "Enregistré. Certaines couches avaient déjà changé dans une autre session, ces modifications ont donc été ignorées.",
+    "saveConflictReload": "Cette carte a changé dans une autre session. Rechargez la carte pour obtenir la dernière version, puis enregistrez à nouveau.",
     "saveFailed": "Échec de l'enregistrement de la carte",
     "saveFailedWithDetail": "Échec de l'enregistrement de la carte : {{detail}}",
     "layerRemoved": "Couche supprimée",

--- a/frontend/src/lib/builder/raf-coalesce.ts
+++ b/frontend/src/lib/builder/raf-coalesce.ts
@@ -73,6 +73,42 @@ export function coalesceFrame(key: string, fn: () => void): void {
   }
 }
 
+/**
+ * Run the frame queued under `key` RIGHT NOW, if there is one, and leave every
+ * other key queued for the frame that was already scheduled.
+ *
+ * fix(#1778 codex round 3/4): useLayerMapSync queues map writes per layer while
+ * the basemap style is swapping and replays them in order once it settles. Most
+ * replayed writes are synchronous, but a paint write only re-queues
+ * `adapter.syncPaint` here, so it landed a frame LATER than the writes replayed
+ * after it. `fillAdapter.syncPaint` applies `input.opacity` (see
+ * applyMasterOpacity), so a queued paint edit followed by an opacity edit
+ * finished with the older frame overwriting the newer opacity. Flushing the
+ * layer's pending frame between replayed writes keeps the drain in
+ * chronological order without changing what any paint callback closes over.
+ *
+ * Not a general-purpose escape hatch: outside that replay this module's
+ * last-write-wins-per-frame contract is the point.
+ */
+export function flushCoalescedFrame(key: string): void {
+  const fn = pending.get(key);
+  if (!fn) return;
+  pending.delete(key);
+  // Cancel BEFORE invoking, so a coalesceFrame call made inside `fn` schedules
+  // a fresh frame rather than joining one that is about to fire empty.
+  if (pending.size === 0 && rafHandle !== null) {
+    cancelAnimationFrame(rafHandle);
+    rafHandle = null;
+  }
+  try {
+    fn();
+  } catch (e) {
+    if (import.meta.env.DEV) {
+      console.debug('[raf-coalesce] Error in flushed fn:', e);
+    }
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Test-only introspection helpers (harmless in production — tree-shakeable)
 // ---------------------------------------------------------------------------

--- a/frontend/src/pages/MapBuilderPage.tsx
+++ b/frontend/src/pages/MapBuilderPage.tsx
@@ -93,7 +93,7 @@ import { useBuilderDialogs } from '@/components/builder/hooks/use-builder-dialog
 import { useBuilderEditorScene, type BuilderEditorScene } from '@/components/builder/hooks/use-builder-editor-scene';
 import { useFilteredFeatureCount } from '@/components/builder/hooks/use-filtered-feature-count';
 import { useBuilderLayers } from '@/components/builder/hooks/use-builder-layers';
-import { useBuilderSave } from '@/components/builder/hooks/use-builder-save';
+import { useBuilderSave, type SaveBaselineSync } from '@/components/builder/hooks/use-builder-save';
 import { TERRAIN_SOURCE_ID, normalizeTerrainExaggeration, isHillshadeTerrainBound } from '@/components/builder/map-sync';
 import { resolveTerrainSourceLayer } from '@/components/builder/map-stack';
 import { effectiveDemRenderMode } from '@/lib/dem-render-mode';
@@ -261,7 +261,7 @@ export function MapBuilderPage() {
   // handleDuplicateRendering invoke it right after a layer-create mutation
   // succeeds, so Save never re-diffs that layer as `added` and PATCHes a
   // duplicate. See use-builder-save.ts for the full rationale.
-  const saveBaselineSyncRef = useRef<(layer: MapLayerResponse) => void>(() => {});
+  const saveBaselineSyncRef = useRef<SaveBaselineSync>({ add: () => {}, remove: () => {} });
   const layers = useBuilderLayers(
     mapData,
     mapInstanceRef,


### PR DESCRIPTION
Six frontend findings from the codebase audit 2026-08-30 (8dc529f17), tracked in #1778. All six still reproduce on current main; none of them were fixed by the merges since the audit. One commit per finding, each with a test that fails on main.

No schema, API or config impact. Frontend only. Two new `builder:toasts` keys in all four locales.

## A stale-diff 400 from PATCH /maps/{id}/layers is misread as "endpoint unsupported" and escalated to a full PUT that overwrites the server's layer set

`isUnsupportedLayerPatchError` matched statuses 400, 404, 409 and 422 with `/layer|order|unknown|removed|unsupported|validation/i`. That is exactly the shape the backend produces for a STALE diff: `apply_layer_diff` raises "Layer diff references layer ids outside this map" and "Layer order references unknown or removed layers", and `router.py` maps both to a 400 with the detail verbatim. So the one signal meaning "someone else changed this map's layers" became an unconditional PUT of this session's whole layer list, resurrecting what the other session deleted and deleting what it added.

The escalation is now limited to 405 and 501. A stale diff refetches the map, drops the ids the server no longer has, and retries the PATCH. The recovery reconciles the diff that was already built rather than re-diffing against the refetched map, because a layer another session ADDED is absent from this session's `localLayers` and a full re-diff would emit it as `removed`. If the refetch or the retry fails, the save reports a conflict and touches nothing.

Counterfactual: restore the old predicate and disable the conflict branch, and the five new cases in `use-builder-save.test.ts` fail, with `updateMap` called carrying a `layers` array in each.

## Layer deletes prune the clean-state baseline but never the save-diff baseline

Both delete paths prune `savedLayerBaselineRef`. The save-diff baseline `baselineLayersRef` only refreshes while the map is clean, and `saveBaselineSyncRef` was add-only, so "edit a layer's colour, delete another layer, save" always emitted the already-deleted id in `diff.removed` and triggered the finding above. The bridge is now `{ add, remove }` and the single and bulk delete paths call `remove` next to their existing prune.

Counterfactual: make `remove` a no-op and both new cases in `use-builder-layers-save-integration.test.ts` see the deleted id in `diff.removed`.

## applyBasemapConfigToMap's paint diff can never CLEAR a basemap override

The helper reads the live, already-mutated style, and `applyLandWaterTone` / `applyBackgroundColor` / `applyReliefContrast` return the layer untouched on their default value. On a revert pass the computed value was the tint the previous pass wrote, it compared equal, and nothing was written. Reverting a land/water tone, a background colour or a relief contrast left the map tinted for the session while state, the stack row and the saved payload all said "default", and `label_mode` subtle-to-full stranded `text-halo-width: 0.8` the same way.

Each basemap layer's pristine paint is now cached the first time it is seen and the target is computed from pristine. The write set is the union of the keys the new config sets and the keys this function stamped earlier, so a key the old config wrote and the new one does not set at all is restored too. Keys this function never wrote are left alone, so `applySublayerOverrides` and the style's own paint are untouched. The cache is dropped on `style.load`, because positron and dark share layer ids and a snapshot that outlived a basemap swap would repaint the new basemap with the old one's colours.

Counterfactual: `map-sync.basemap-revert.test.ts` runs the helper twice against a `getStyle()` that reflects the first pass's writes; five of its six cases fail on main.

## getDataDrivenColumnsForLayer misses style_config.symbol.categoryColumn

The helper reads `label_config.column` explicitly because a layout expression is invisible to the paint walk. The symbol adapter builds a second data-driven layout expression from `style_config.symbol.categoryColumn`, and that one was never read, so a point layer with per-category icons rendered every feature with the fallback icon below zoom 10 and snapped into place at z10. Read next to the label column, using `getSymbolConfig`'s merge order so a builder-stashed config resolves too. The helper is shared, so the builder and the viewer both pick it up.

Counterfactual: three new cases in `map-sync.data-driven-cols.test.ts` return `[]` on main.

## removeStaleSourcesAndLayers prunes by SOURCE only, so an orphan layer on a still-shared deduped source is unreclaimable

The prune body sits behind a skip for sources still desired. Under the SF-04 dedupe two layers on one dataset share `source-data-${table}`, so deleting one left the source desired and its layer rows were never reclaimed: they kept rendering with no stack row, no legend entry, unclickable, and baked into any capture taken afterwards.

`removePerLayerCompanions`, which the delete paths call first, used a bare early return when the style was not loaded, which is exactly what happens during a basemap swap. It now retries on idle like every sibling in the builder, materializing the ids first so a single-pass iterable survives the retry. And `syncLayersToMap` walks the style once for managed layer rows whose logical layer is no longer desired. The walk requires all three of: the managed `layer-` prefix, a data source, and absence from the companion-id expansion of the desired set, so basemap layers and plugin layers are out of scope.

Counterfactual: the new dedupe case finds `layer-l1` plus its outline and label still present on main, and the two idle-retry cases in `builder-layer-mutations.test.ts` find `once` never called.

## applyLayerUpdate drops the map side-effect on !isStyleLoaded() with no retry

React state was committed and the map write abandoned, with nothing in the code path to run it later. Paint and filter self-heal because `syncLayersToMap` re-applies both; generic layout does not, since only `handleLayoutChange` writes it and `syncLayersToMap` re-applies only `_minzoom`/`_maxzoom`. Applying an Advanced JSON layout block, or hitting Revert to saved, during a style swap left the layer dirty and about to save a layout the map was not showing. Now retries on idle, replaying the normalized layer computed at call time. `handleLayoutChange` also gains a comment saying it is the sole writer of generic layout, which it has been by accident.

Counterfactual: two of the three new cases in `use-layer-map-sync.test.ts` fail on main.

## Verification

Run from the worktree.

- `npm run typecheck` clean
- `npm run lint` clean
- `npm run test:i18n` 4 passed
- `npx vitest run` 437 files, 5788 tests, all passed
- Every counterfactual above was run by reverting the relevant hunk and confirming the new tests go red, then restoring
- Playwright via the worktree recipe (Vite on :5174 with `API_PROXY_TARGET=http://localhost:8001`, `E2E_ALLOW_WORKTREE=1`): `builder.spec.ts`, `builder-styling.spec.ts`, `builder-unified-stack.spec.ts` 32 passed 1 skipped; `builder-v1-5.spec.ts` 4 passed; `builder-dem-editor.spec.ts` 2 passed 1 failed

The one Playwright failure is `builder-dem-editor.spec.ts:110`, and it is an artifact of the :5174 recipe rather than this branch. It passes against the main stack on :8080, and it fails on :5174 with main's source checked out over this branch's, so the difference is the harness, not the change.

## Left alone

- `handleLayoutChange` reads `prevLayout` off `layersRef.current`, which is written in an effect, so two layout writes in the same tick make the second one's clear-removed-props loop operate on a pre-first-write snapshot. The audit lists this as secondary to the retry finding and does not carry it into the recommendation; fixing it needs a synchronously written pending-layout journal, which is a larger change than the retry.
- After a recovered conflict save, a layer this session still shows but the server has already dropped stays in `localLayers` until the query invalidation refetches. The next save would name it again and recover again, so it converges, but the diff does not prune local state directly. `SaveState` carries no `setLocalLayers`, so doing it here would widen the hook's surface.
- Removing a basemap sublayer override does not revert its paint either. That is the same shape as the third finding but in `applySublayerOverrides`, which the audit did not raise and this lane did not touch.


## Codex round 1 (a0e63a9ca)

Two P2s, both on the conflict-recovery path added by the first finding. Both fixed in one push.

**Preserve remote additions when reordering during a stale save.** The retry filtered `diff.order` down to the ids this session still knew about. `apply_layer_diff` numbers the ids it is given from 0 and then appends every surviving layer the order omitted, so with server order `[A, X, B]` where X is remotely new and a local order of `[B, A]`, the retry sent `[B, A]` and the server applied `[B, A, X]`, moving a layer this session never saw. Reconciliation now takes the refetched map's layer sequence rather than a membership set (GET /maps/{id} returns them in sort order) and `mergeOrderWithServerSequence` does the stable merge the reviewer described: walk the surviving server sequence, substitute the next locally ordered survivor at each position a locally known layer already occupies, leave unseen ids at their server positions. The reviewer's pin gives `[B, X, A]`. Three unit cases and one end-to-end case cover it; the end-to-end one asserts the first PATCH sent `['layer-b','layer-a']` and the retry sent `['layer-b','layer-x','layer-a']`.

**Prune confirmed deletions after a partial bulk delete.** The baseline prune ran only when the whole batch succeeded, but the confirmed-deleted rows leave local state on the partial path too, so they stayed in both baselines, the next Save re-emitted them in `diff.removed` and tripped the stale-conflict recovery and its warning, and the save failed outright whenever the refetch was unavailable. Both baselines now drop every id in `result.deleted` before the failed rows are restored. `pruneEmptyFolderGroups` stays correct there because a child whose delete failed is not in `result.deleted`, so its container still has a member.

Counterfactual for both: swapping the merge back to the filter and dropping the two prune lines turns the five new cases red.

Re-verified on a0e63a9ca: `npm run typecheck` clean, `npm run lint` clean, `npm run test:i18n` 4 passed, `npx vitest run src/components/builder src/components/viewer src/pages` 193 files and 2717 tests passed, and the builder e2e subset on :5174 (`builder`, `builder-styling`, `builder-unified-stack`, `builder-v1-5`) 36 passed 1 skipped. `builder.spec.ts:798` failed once in that subset and passed alone and on a clean re-run of the whole subset, so it is flake rather than a regression.


## Codex round 2 (aa01643b4)

One P1 and one P2, both in `map-sync.ts`. Both fixed in one push.

**P1, invalidate the pristine cache without depending on listener order.** The cache was dropped by a `style.load` listener this module attached lazily on its first appearance call. BuilderMap registers its own persistent `style.load` handler at mount and that handler calls `applyMapBasemapAppearance`, so this module's listener was always registered later and always ran later. A swap between two basemaps sharing layer ids therefore ran an appearance pass against the previous style's pristine values, wrote the old basemap's colours onto the new style, and let that contaminated paint become the next pristine snapshot.

Detection is now synchronous and inside the helper. Each cached layer carries `expected`, the paint this module believes is live (its pristine snapshot plus everything it has since written), and `reconcileBasemapPaintState` re-snapshots any key whose live value disagrees before it is read. The listener is gone.

I did not add a style-generation token, and the reasoning is on the review thread: a token fixes the ordering but not the detection, and every cheap style-identity field here moves for unrelated reasons (`sprite` is rewritten by the symbol adapter's `addSprite`; `layers` and `sources` change on every data-layer add). A token stable enough not to fire spuriously, which is the worse failure since it re-snapshots our own tint as pristine, is one that cannot tell positron from dark. The per-key comparison needs no token and catches any writer. It is per key rather than per layer because `applySublayerOverrides` runs immediately after this helper and rewrites the `*-opacity` keys; a layer-level check would discard the whole snapshot every pass.

The reviewer's pin is in, with the appearance listener registered first: two `style.load` cycles between styles sharing the layer id `water`, asserting the second style's pristine is its own colour and not the first's tint, plus a third cycle back. A second test registers no `style.load` listener at all, swaps the style, applies the default config, and asserts nothing was written for `fill-color`.

**P2, merge both symbol config sources.** The tile column list resolved `categoryColumn` with `style_config.symbol ?? style_config.builder.symbol`, which picks one object whole while the adapter merges both field by field, so a column stashed in the legacy builder config was dropped as soon as any top-level symbol object existed (including an empty one, since `{}` is not nullish). `symbol-adapter.ts` now exports the merge as `resolveSymbolConfig` and both callers use it. Pinned with top-level `{ iconSize: 1.5 }` plus builder `{ categoryColumn: 'kind' }`, and with an empty top-level object.

Counterfactual for both: removing the reconciliation and restoring the `??` turns the four new cases red.

Re-verified on aa01643b4: `npm run typecheck` clean, `npm run lint` clean, `npm run test:i18n` 4 passed, `npx vitest run src/components/builder src/components/viewer src/pages src/lib` 248 files and 3973 tests passed, and the builder e2e subset on :5174 (`builder`, `builder-styling`, `builder-unified-stack`, `builder-v1-5`) 36 passed 1 skipped, with both basemap-swap cases in `builder.spec.ts` among them.


## Codex round 3 (92eaffa60)

One P1 and one P2. Both fixed in one push.

**P1, restore the 404 compatibility fallback.** Narrowing "endpoint unsupported" to 405 and 501 in the first commit broke the case the full PUT exists for: a backend predating `PATCH /maps/{id}/layers` answers 404 for the unknown route, FastAPI with a `"Not Found"` detail and an edge proxy in front of it with no JSON at all, so every layer-edit save against such a deployment would have failed outright. 404 is back in the route-level set, minus the one 404 the route raises for itself. `"Map not found"` (router lookup) and `"Map {id} not found"` (`apply_layer_diff`) mean the map is gone rather than the route, and a full PUT would only 404 again, so they surface as a save failure.

On the reviewer's conditional: there is no 404 for a missing layer id inside the route. `apply_layer_diff` raises `ValueError` for both stale-diff cases and `router.py` maps ValueError to 404 only when the detail starts with "Map " and ends with "not found", so a stale layer id is always a 400. `isStaleLayerDiffError` already matched on the two detail strings rather than the status. Both predicates now read the detail through one helper that prefers `error.body`, the raw backend detail, over `error.message`, which has been through `translateApiErrorDetail` and may be localized.

Five pins: 404 with no JSON detail falls back to PUT; 404 with FastAPI's `"Not Found"` falls back to PUT; 404 `"Map not found"` and 404 `"Map {uuid} not found"` both surface `toasts.saveFailed` without calling `updateMap`; a 400 with an unrelated detail surfaces the error with no refetch and no PUT.

**P2, cancel or supersede a queued idle write.** `isStyleLoaded()` turns true before `idle` fires, so an edit landing in that window wrote immediately and the older queued callback then restored the previous value: toggle a layer off during a basemap swap and back on before idle, and the map ended up hidden while React state said visible.

Deferred writes are now queued per layer and replayed oldest first, and a write that finds the style loaded drains that layer's backlog before applying itself, so the newest edit always lands last. The stale listener is guarded by an identity check, so firing it afterwards is a no-op.

I did not take the read-latest shape the reviewer preferred, and the reasoning is on the thread: the value each write applies lives in the applyFn closure, not in the layer argument. `handleToggleVisibility` closes over `nextVisible`, `handleOpacityChange` over `newOpacity`, and `handleLayoutChange` over both `newLayout` and `prevLayout` and takes no layer argument at all, so a fresher layer would be handed to a stale applyFn. Queueing also covers the "per layout key where relevant" half without a channel key: cancel-and-replace keyed on the layer alone would drop a pending layout write as soon as a visibility toggle for the same layer arrived, while replaying in order keeps both.

Three pins: schedule A while loading, flip `isStyleLoaded()` true, apply B, then fire the stale listener, and the last visibility write is `visible`; two edits queued before idle replay as `['none', 'visible']` from a single listener; a layout write queued before a visibility toggle on the same layer survives.

Counterfactual for both: dropping 404 back out of the set and restoring the single captured `map.once('idle', ...)` turns the five new cases red.

Re-verified on 92eaffa60: `npm run typecheck` clean, `npm run lint` clean, `npm run test:i18n` 4 passed, `npx vitest run src/components/builder src/components/viewer src/pages src/lib` 248 files and 3981 tests passed, and the builder e2e subset on :5174 (`builder`, `builder-styling`, `builder-unified-stack`, `builder-v1-5`) 36 passed 1 skipped.


## Codex round 4 (c558b8189)

One P2, on the deferred-write replay the previous round introduced.

The drain was not in chronological order. A paint write does not touch the map itself, it queues `adapter.syncPaint` on the next animation frame, so replaying it alongside synchronous writes put it last in wall-clock order however early it was made. `fillAdapter.syncPaint` calls `applyMasterOpacity` with the `input.opacity` it captured, so a queued paint edit followed by an opacity edit ended with the older frame overwriting the newer opacity.

Fixed with the synchronous flush the reviewer preferred. `raf-coalesce` gains `flushCoalescedFrame(key)`, which runs the frame queued under one key immediately and leaves every other key on the frame already scheduled. It cancels that scheduled frame only when nothing is left pending, and cancels before invoking, so a `coalesceFrame` call made inside the callback schedules a fresh frame rather than joining one about to fire empty. Outside the replay drain the module's last-write-wins-per-frame contract is untouched, which is why this is a targeted flush rather than a general one.

Both replay paths now go through one drain helper that flushes the layer's pending frame after each replayed write. The final write on the drain-then-apply path keeps normal rAF coalescing, since it is already the newest value. The coalesce key has a single owner now, so `handlePaintChange` and the drain cannot disagree about which entry to flush.

Two pins: paint(A) queued during a swap, `isStyleLoaded()` flips true, opacity(B) applied, and `syncPaint`'s `invocationCallOrder` is less than `applyMasterOpacity`'s with the opacity write carrying 0.25 and no further `syncPaint` on the next frame; and the same pair replayed from the idle listener.

Counterfactual: removing the `flushCoalescedFrame` call from the drain turns both red.

Re-verified on c558b8189: `npm run typecheck` clean, `npm run lint` clean, `npm run test:i18n` 4 passed, `npx vitest run src/components/builder src/components/viewer src/pages src/lib` 248 files and 3983 tests passed, and the builder e2e subset on :5174 (`builder`, `builder-styling`, `builder-unified-stack`, `builder-v1-5`) 36 passed 1 skipped. The API container was returning 503 as the first pass started and `builder-unified-stack.spec.ts:617` failed on it; it passed alone and on a clean re-run of the whole subset once the API was healthy.


## Codex round 5 (ddb54792d)

One P2: the residual flagged in the round-2 note. Per-key equality reconciliation cannot see a style swap whose new native value equals the override the old style was carrying. Style A's water overridden to the monochrome tint, style B's own water already that colour, and nothing has changed from the paint's point of view, so clearing the override afterwards restored A's colour.

`registerBasemapStyleGeneration(map)` bumps a counter on `style.load`, and the paint cache is tagged with the generation it describes, so `basemapPaintStateFor` treats any difference as an empty cache before pristine values are read. The counter lives in the same module-level WeakMap keyed by map instance as the paint states.

The registration site is the point. It is the first statement after `mapRef.current = map` in BuilderMap's `handleLoad` and in ViewerMap's, which makes it the earliest-registered `style.load` listener by construction, so the counter has already moved by the time BuilderMap's own persistent handler triggers an appearance pass on the new style. Registering it lazily from the appearance helper would reproduce the round-2 ordering bug it replaces. The call is idempotent, so a remount reusing the instance cannot double-count, and it is a no-op on a partial map mock with no `on`.

A counter rather than a style-identity token because every cheap identity field here moves for unrelated reasons: the symbol adapter rewrites `sprite` through `addSprite`, and `layers` and `sources` change on every data-layer add.

The per-key equality reconciliation stays as the second line of defence. It catches every other writer, needs no cooperation from the surface hosting the map, and keeps a surface that never registers a counter working.

Pins: style A's water overridden to `#d9dde0`, swap to a style whose native water is `#d9dde0`, clear the override, water stays `#d9dde0`; `registerBasemapStyleGeneration` registers exactly one `style.load` listener across three calls and does not throw without `on`; a normal swap still reverts to the new style's own pristine. All seven round-2 tests pass unchanged, with the appearance listener registered first and no generation listener at all, which is the equality path carrying them.

Counterfactual: removing the generation comparison makes the equal-value pin assert `'#a0c8f0'`, style A's colour, which is the exact reported symptom.

Re-verified on ddb54792d: `npm run typecheck` clean, `npm run lint` clean, `npm run test:i18n` 4 passed, `npx vitest run src/components/builder src/components/viewer src/pages src/lib` 248 files and 3987 tests passed, and the builder e2e subset on :5174 (`builder`, `builder-styling`, `builder-unified-stack`, `builder-v1-5`) 36 passed 1 skipped on a clean first run.
