### PR TITLE
fix(viewer): embed anonymity, redaction, basemap fallback, gradient stops, draw history

### DIFF
--- a/frontend/src/components/builder/BuilderMap.tsx
+++ b/frontend/src/components/builder/BuilderMap.tsx
@@ -361,7 +361,7 @@ export const BuilderMap = memo(function BuilderMap({
     () => isBlank
       ? toMaplibreStyle(BLANK_BASEMAP_ID)
       : toMaplibreStyle(basemapEntry?.url ?? fallbackUrl, basemapEntry?.attribution),
-    [isBlank, basemapEntry?.url, basemapEntry?.attribution],
+    [isBlank, basemapEntry?.url, basemapEntry?.attribution, fallbackUrl],
   );
   // chore(#835): shared fetch-and-sanitize path (see use-remote-basemap-style).
   // Builder-specific behavior rides the callbacks: reset the SF-08 first-load

--- a/frontend/src/components/builder/BuilderMap.tsx
+++ b/frontend/src/components/builder/BuilderMap.tsx
@@ -10,6 +10,7 @@ import {
   makeStyleImageMissingResolver,
   toMaplibreStyle,
   BLANK_BASEMAP_ID,
+  FALLBACK_BASEMAP_STYLE_URL,
 } from '@/lib/basemap-utils';
 import { buildClusterTileUrl, buildSignedTileUrl, buildTileTransformRequest, isMvtSourceLayerConfigReady, refreshRasterTileSources } from '@/lib/tile-utils';
 import { toMapLibreAttribution } from '@/lib/attribution-safety';
@@ -355,7 +356,7 @@ export const BuilderMap = memo(function BuilderMap({
   );
   const isBlank = basemapStyle === BLANK_BASEMAP_ID;
   const basemapEntry = isBlank ? undefined : findBasemapById(basemaps ?? [], basemapStyle);
-  const fallbackUrl = 'https://tiles.openfreemap.org/styles/positron';
+  const fallbackUrl = FALLBACK_BASEMAP_STYLE_URL;
   const styleValue = useMemo(
     () => isBlank
       ? toMaplibreStyle(BLANK_BASEMAP_ID)

--- a/frontend/src/components/builder/LineGradientControls.tsx
+++ b/frontend/src/components/builder/LineGradientControls.tsx
@@ -34,6 +34,22 @@ function ensureStopIds(
   }));
 }
 
+/**
+ * fix(round1 #1795, P2): count adjacent pairs that are NOT strictly
+ * ascending (`next <= prev`) — the same condition maplibre-gl's
+ * `interpolate` parser rejects. Used to compare a proposed stop list
+ * against the one it replaces, so commitStops can block a commit that makes
+ * ordering WORSE without also blocking incremental repair of an
+ * already-invalid legacy list (e.g. one saved by the old repeated-Add bug).
+ */
+function countOrderViolations(stops: ReadonlyArray<{ position: number }>): number {
+  let count = 0;
+  for (let i = 1; i < stops.length; i++) {
+    if (stops[i].position <= stops[i - 1].position) count++;
+  }
+  return count;
+}
+
 // Permissive allowlist for the raw-expression structural validator. The goal
 // is to reject obvious garbage (random strings, plain objects, unknown ops)
 // before commit; full MapLibre semantic validation happens at runtime.
@@ -183,16 +199,22 @@ export function LineGradientControls({ paint, styleConfig, onPaintProp, onBuilde
   const isCustomExpression = paintExpr != null && parsedFromPaint == null;
 
   function commitStops(nextStops: WorkingStop[]) {
-    // fix(#1778): refuse a non-ascending (equal or descending) stop list
-    // before it reaches paint. maplibre-gl's `interpolate` parser rejects the
-    // whole expression when adjacent positions are not STRICTLY ascending
-    // (`stops[i][0] >= label` is an error, so equal positions fail too), and
-    // an invalid expression would otherwise persist into the saved
-    // style_config. Leave pendingPositionEdits untouched here so a typed
-    // duplicate value still surfaces the duplicatePosition warning below.
-    for (let i = 1; i < nextStops.length; i++) {
-      if (nextStops[i].position <= nextStops[i - 1].position) return;
-    }
+    // fix(#1778, round1 #1795 P2): refuse a commit that makes stop
+    // ordering WORSE, not any commit that leaves some violation in place.
+    // A blanket "any non-ascending pair refuses" rule blocked incremental
+    // repair of a legacy list saved by the old repeated-Add bug (e.g.
+    // [0, 1, 1, 1]) — removing one duplicate, moving one stop, or even
+    // just recoloring one became a no-op, because the repaired list still
+    // had a violation somewhere else. Comparing violation COUNTS lets any
+    // commit that holds steady or improves through, and still blocks a
+    // commit that newly introduces or worsens non-ascending positions —
+    // maplibre-gl's `interpolate` parser rejects the whole expression when
+    // adjacent positions are not STRICTLY ascending (`stops[i][0] >= label`
+    // is an error, so equal positions violate too). Leave
+    // pendingPositionEdits untouched here so a typed duplicate value still
+    // surfaces the duplicatePosition warning below.
+    const previousViolations = liveStops ? countOrderViolations(liveStops) : 0;
+    if (countOrderViolations(nextStops) > previousViolations) return;
     // Compose the next paint snapshot once and pass it to both callbacks so the
     // upstream save sees a single consistent state. Without `nextPaint`,
     // `onBuilderChange` would resolve `paint` from a stale closure and shadow

--- a/frontend/src/components/builder/LineGradientControls.tsx
+++ b/frontend/src/components/builder/LineGradientControls.tsx
@@ -50,6 +50,29 @@ function countOrderViolations(stops: ReadonlyArray<{ position: number }>): numbe
   return count;
 }
 
+/**
+ * fix(round5 #1795, P2): comparing total violation counts alone lets a
+ * position edit SWAP one violation for a different one at the same total
+ * count — e.g. [0, 0.5, 0.5, 1] -> [0, 0.5, 0.4, 1] keeps the count at 1
+ * (the duplicate at (1,2) becomes a descending pair at (1,2) instead) but
+ * still commits a list maplibre-gl rejects. Returns the indices (into
+ * `next`) whose POSITION differs from `prev` at the same array index —
+ * only meaningful when `prev` and `next` are the same length (an add/remove
+ * changes the shape entirely and is governed by the total-count check
+ * alone, same as a colour-only or removal edit).
+ */
+function editedPositionIndices(
+  prev: ReadonlyArray<{ position: number }> | null,
+  next: ReadonlyArray<{ position: number }>,
+): number[] {
+  if (!prev || prev.length !== next.length) return [];
+  const indices: number[] = [];
+  for (let i = 0; i < next.length; i++) {
+    if (next[i].position !== prev[i].position) indices.push(i);
+  }
+  return indices;
+}
+
 // Permissive allowlist for the raw-expression structural validator. The goal
 // is to reject obvious garbage (random strings, plain objects, unknown ops)
 // before commit; full MapLibre semantic validation happens at runtime.
@@ -215,6 +238,20 @@ export function LineGradientControls({ paint, styleConfig, onPaintProp, onBuilde
     // surfaces the duplicatePosition warning below.
     const previousViolations = liveStops ? countOrderViolations(liveStops) : 0;
     if (countOrderViolations(nextStops) > previousViolations) return;
+    // fix(round5 #1795 P2): the total-count check above is not enough on
+    // its own — it lets a position edit SWAP one violation for a different
+    // one at the same count (e.g. [0, 0.5, 0.5, 1] -> [0, 0.5, 0.4, 1]: the
+    // duplicate at (1,2) becomes a descending pair at (1,2) instead, count
+    // stays 1, but the result is still a list maplibre-gl rejects). For
+    // every index whose POSITION actually changed (colour-only and
+    // add/remove edits touch none), both pairs it participates in — (i-1,i)
+    // and (i,i+1) — must be strictly ascending after the edit. A colour-only
+    // change or a structural add/remove has no edited index here, so it
+    // stays governed by the total-count check alone.
+    for (const i of editedPositionIndices(liveStops, nextStops)) {
+      if (i > 0 && nextStops[i - 1].position >= nextStops[i].position) return;
+      if (i < nextStops.length - 1 && nextStops[i].position >= nextStops[i + 1].position) return;
+    }
     // Compose the next paint snapshot once and pass it to both callbacks so the
     // upstream save sees a single consistent state. Without `nextPaint`,
     // `onBuilderChange` would resolve `paint` from a stale closure and shadow

--- a/frontend/src/components/builder/LineGradientControls.tsx
+++ b/frontend/src/components/builder/LineGradientControls.tsx
@@ -183,6 +183,16 @@ export function LineGradientControls({ paint, styleConfig, onPaintProp, onBuilde
   const isCustomExpression = paintExpr != null && parsedFromPaint == null;
 
   function commitStops(nextStops: WorkingStop[]) {
+    // fix(#1778): refuse a non-ascending (equal or descending) stop list
+    // before it reaches paint. maplibre-gl's `interpolate` parser rejects the
+    // whole expression when adjacent positions are not STRICTLY ascending
+    // (`stops[i][0] >= label` is an error, so equal positions fail too), and
+    // an invalid expression would otherwise persist into the saved
+    // style_config. Leave pendingPositionEdits untouched here so a typed
+    // duplicate value still surfaces the duplicatePosition warning below.
+    for (let i = 1; i < nextStops.length; i++) {
+      if (nextStops[i].position <= nextStops[i - 1].position) return;
+    }
     // Compose the next paint snapshot once and pass it to both callbacks so the
     // upstream save sees a single consistent state. Without `nextPaint`,
     // `onBuilderChange` would resolve `paint` from a stale closure and shadow
@@ -244,17 +254,33 @@ export function LineGradientControls({ paint, styleConfig, onPaintProp, onBuilde
 
   function addStop() {
     if (!liveStops || liveStops.length < 2) return;
-    const last = liveStops[liveStops.length - 1];
-    const prev = liveStops[liveStops.length - 2];
-    const newPosition = Math.round(((prev.position + last.position) / 2) * 100) / 100;
+    // fix(#1778): bisect the WIDEST gap, not always the last pair. Bisecting
+    // the last pair repeatedly (0.5, 0.75, 0.88, ...) converges on the final
+    // stop's position — the 7th click used to duplicate it outright, and
+    // every click after that kept doing so.
+    const sorted = [...liveStops].sort((a, b) => a.position - b.position);
+    let gapIndex = 1;
+    let gapSize = -Infinity;
+    for (let i = 1; i < sorted.length; i++) {
+      const size = sorted[i].position - sorted[i - 1].position;
+      if (size > gapSize) {
+        gapSize = size;
+        gapIndex = i;
+      }
+    }
+    // Refuse when no gap has room for a new, distinct rounded position — with
+    // the 0.01 UI rounding step, a narrower gap collapses onto a neighbor and
+    // commitStops's ascending-order guard would refuse it anyway.
+    if (gapSize < 0.02) return;
+    const before = sorted[gapIndex - 1];
+    const after = sorted[gapIndex];
+    const newPosition = Math.round(((before.position + after.position) / 2) * 100) / 100;
     // Keep stops in sorted (monotonically increasing position) order so the
     // canonical interpolate-linear-line-progress expression renders correctly.
     const next: WorkingStop[] = [
-      ...liveStops,
-      { position: newPosition, color: last.color, id: crypto.randomUUID() },
-    ]
-      .slice()
-      .sort((a, b) => a.position - b.position);
+      ...sorted,
+      { position: newPosition, color: after.color, id: crypto.randomUUID() },
+    ].sort((a, b) => a.position - b.position);
     commitStops(next);
   }
 

--- a/frontend/src/components/builder/__tests__/LineGradientControls.test.tsx
+++ b/frontend/src/components/builder/__tests__/LineGradientControls.test.tsx
@@ -150,6 +150,74 @@ describe('LineGradientControls — UI', () => {
     expect(lastExpr[7]).toBe(1);
   });
 
+  it('ui: repeated Add stop clicks bisect the widest gap instead of converging on the last stop (fix #1778)', async () => {
+    const onPaintProp = vi.fn();
+    const onBuilderChange = vi.fn();
+    const user = userEvent.setup();
+    let stops: Array<{ position: number; color: string; id?: string }> = [
+      { position: 0, color: '#000' },
+      { position: 1, color: '#fff' },
+    ];
+    const { rerender } = render(
+      <LineGradientControls
+        paint={{ 'line-gradient': stopsToLineGradientExpression(stops) }}
+        styleConfig={{ builder: { lineGradient: { stops } } } as unknown as StyleConfig}
+        onPaintProp={onPaintProp}
+        onBuilderChange={onBuilderChange}
+        t={t}
+      />,
+    );
+    const addButton = () => screen.getByRole('button', { name: 'style.lineGradient.addStop' });
+    // Click enough times that the old last-pair-bisection scheme would have
+    // duplicated the endpoint (previously reproduced by click 7), rerendering
+    // with each commit so liveStops actually accumulates like the real app.
+    for (let i = 0; i < 7; i++) {
+      // eslint-disable-next-line no-await-in-loop -- each click depends on the previous commit's rerender
+      await user.click(addButton());
+      const lastBuilderCall = onBuilderChange.mock.calls[onBuilderChange.mock.calls.length - 1];
+      stops = lastBuilderCall[0].lineGradient.stops;
+      rerender(
+        <LineGradientControls
+          paint={{ 'line-gradient': stopsToLineGradientExpression(stops) }}
+          styleConfig={{ builder: { lineGradient: { stops } } } as unknown as StyleConfig}
+          onPaintProp={onPaintProp}
+          onBuilderChange={onBuilderChange}
+          t={t}
+        />,
+      );
+    }
+    // Strictly ascending, no duplicates — the invariant maplibre-gl enforces.
+    for (let i = 1; i < stops.length; i++) {
+      expect(stops[i].position).toBeGreaterThan(stops[i - 1].position);
+    }
+    expect(stops.length).toBe(9); // 2 initial + 7 added
+  });
+
+  it('ui: typing a duplicate stop position refuses the commit instead of writing a rejected expression (fix #1778)', () => {
+    const onPaintProp = vi.fn();
+    const onBuilderChange = vi.fn();
+    const stops = [{ position: 0, color: '#000' }, { position: 1, color: '#fff' }];
+    const expr = stopsToLineGradientExpression(stops);
+    render(
+      <LineGradientControls
+        paint={{ 'line-gradient': expr }}
+        styleConfig={{ builder: { lineGradient: { stops } } } as unknown as StyleConfig}
+        onPaintProp={onPaintProp}
+        onBuilderChange={onBuilderChange}
+        t={t}
+      />,
+    );
+    const positionInputs = screen.getAllByRole('spinbutton', { name: 'style.lineGradient.position' });
+    // Type 0 into the second stop, duplicating the first stop's position.
+    fireEvent.change(positionInputs[1], { target: { value: '0' } });
+    // Neither callback fired a commit with the duplicate — commitStops refused it.
+    const gradientCalls = onPaintProp.mock.calls.filter((c: unknown[]) => c[0] === 'line-gradient');
+    expect(gradientCalls).toHaveLength(0);
+    expect(onBuilderChange).not.toHaveBeenCalled();
+    // The duplicate-position warning still surfaces so the user sees why.
+    expect(screen.getByText('style.lineGradient.duplicatePosition')).toBeInTheDocument();
+  });
+
   it('ui: line-gradient remove buttons are disabled at the minimum of 2 stops', () => {
     const expr = stopsToLineGradientExpression([{ position: 0, color: '#000' }, { position: 1, color: '#fff' }]);
     render(<LineGradientControls paint={{ 'line-gradient': expr }} styleConfig={{ builder: { lineGradient: { stops: [{ position: 0, color: '#000' }, { position: 1, color: '#fff' }] } } } as unknown as StyleConfig} onPaintProp={vi.fn()} onBuilderChange={vi.fn()} t={t} />);

--- a/frontend/src/components/builder/__tests__/LineGradientControls.test.tsx
+++ b/frontend/src/components/builder/__tests__/LineGradientControls.test.tsx
@@ -217,6 +217,123 @@ describe('LineGradientControls — UI', () => {
     expect(screen.getByText('style.lineGradient.duplicatePosition')).toBeInTheDocument();
   });
 
+  // fix(round1 #1795, P2): a legacy list saved by the old repeated-Add bug
+  // (e.g. [0, 1, 1, 1]) has violations already present. A blanket refusal
+  // on ANY violation made every repair of such a list a no-op. commitStops
+  // now compares violation COUNTS and only blocks a commit that makes
+  // ordering worse than what it replaces.
+  describe('ui: incremental repair of a legacy non-ascending stop list (fix round1 #1795)', () => {
+    it('removing one duplicate from [0, 1, 1, 1] commits (count improves)', () => {
+      const onPaintProp = vi.fn();
+      const onBuilderChange = vi.fn();
+      const stops = [
+        { position: 0, color: '#000', id: 'a' },
+        { position: 1, color: '#111', id: 'b' },
+        { position: 1, color: '#222', id: 'c' },
+        { position: 1, color: '#333', id: 'd' },
+      ];
+      render(
+        <LineGradientControls
+          paint={{ 'line-gradient': stopsToLineGradientExpression(stops) }}
+          styleConfig={{ builder: { lineGradient: { stops } } } as unknown as StyleConfig}
+          onPaintProp={onPaintProp}
+          onBuilderChange={onBuilderChange}
+          t={t}
+        />,
+      );
+      const removeButtons = screen.getAllByRole('button', { name: 'style.lineGradient.removeStop' });
+      fireEvent.click(removeButtons[3]); // remove the last duplicate (id 'd')
+
+      const gradientCalls = onPaintProp.mock.calls.filter((c: unknown[]) => c[0] === 'line-gradient');
+      expect(gradientCalls.length).toBeGreaterThan(0);
+      const lastBuilderCall = onBuilderChange.mock.calls[onBuilderChange.mock.calls.length - 1];
+      const committedStops = lastBuilderCall[0].lineGradient.stops as Array<{ position: number }>;
+      expect(committedStops.map((s) => s.position)).toEqual([0, 1, 1]);
+    });
+
+    it('moving one stop from [0, 1, 1, 1] to [0, 0.5, 1, 1] commits (count improves)', () => {
+      const onPaintProp = vi.fn();
+      const onBuilderChange = vi.fn();
+      const stops = [
+        { position: 0, color: '#000', id: 'a' },
+        { position: 1, color: '#111', id: 'b' },
+        { position: 1, color: '#222', id: 'c' },
+        { position: 1, color: '#333', id: 'd' },
+      ];
+      render(
+        <LineGradientControls
+          paint={{ 'line-gradient': stopsToLineGradientExpression(stops) }}
+          styleConfig={{ builder: { lineGradient: { stops } } } as unknown as StyleConfig}
+          onPaintProp={onPaintProp}
+          onBuilderChange={onBuilderChange}
+          t={t}
+        />,
+      );
+      const positionInputs = screen.getAllByRole('spinbutton', { name: 'style.lineGradient.position' });
+      fireEvent.change(positionInputs[1], { target: { value: '0.5' } });
+
+      const lastBuilderCall = onBuilderChange.mock.calls[onBuilderChange.mock.calls.length - 1];
+      const committedStops = lastBuilderCall[0].lineGradient.stops as Array<{ position: number }>;
+      expect(committedStops.map((s) => s.position)).toEqual([0, 0.5, 1, 1]);
+    });
+
+    it('a colour-only change on a legacy duplicate list still commits (count unchanged)', async () => {
+      const onPaintProp = vi.fn();
+      const onBuilderChange = vi.fn();
+      const user = userEvent.setup();
+      const stops = [
+        { position: 0, color: '#000000', id: 'a' },
+        { position: 1, color: '#111111', id: 'b' },
+        { position: 1, color: '#222222', id: 'c' },
+      ];
+      render(
+        <LineGradientControls
+          paint={{ 'line-gradient': stopsToLineGradientExpression(stops) }}
+          styleConfig={{ builder: { lineGradient: { stops } } } as unknown as StyleConfig}
+          onPaintProp={onPaintProp}
+          onBuilderChange={onBuilderChange}
+          t={t}
+        />,
+      );
+      // Open the swatch popover for the second stop (#111111) and change its
+      // hex value — updateStopColor -> commitStops with positions unchanged.
+      await user.click(screen.getByTitle('#111111'));
+      const hexInput = await screen.findByRole('textbox');
+      fireEvent.change(hexInput, { target: { value: '#abcdef' } });
+
+      const lastBuilderCall = onBuilderChange.mock.calls[onBuilderChange.mock.calls.length - 1];
+      expect(lastBuilderCall).toBeDefined();
+      const committedStops = lastBuilderCall[0].lineGradient.stops as Array<{ position: number; color: string }>;
+      expect(committedStops.map((s) => s.position)).toEqual([0, 1, 1]);
+      expect(committedStops[1].color.toLowerCase()).toBe('#abcdef');
+    });
+
+    it('from [0, 0.5, 1], setting the middle stop to 1 is refused (count would increase)', () => {
+      const onPaintProp = vi.fn();
+      const onBuilderChange = vi.fn();
+      const stops = [
+        { position: 0, color: '#000', id: 'a' },
+        { position: 0.5, color: '#111', id: 'b' },
+        { position: 1, color: '#222', id: 'c' },
+      ];
+      render(
+        <LineGradientControls
+          paint={{ 'line-gradient': stopsToLineGradientExpression(stops) }}
+          styleConfig={{ builder: { lineGradient: { stops } } } as unknown as StyleConfig}
+          onPaintProp={onPaintProp}
+          onBuilderChange={onBuilderChange}
+          t={t}
+        />,
+      );
+      const positionInputs = screen.getAllByRole('spinbutton', { name: 'style.lineGradient.position' });
+      fireEvent.change(positionInputs[1], { target: { value: '1' } });
+
+      const gradientCalls = onPaintProp.mock.calls.filter((c: unknown[]) => c[0] === 'line-gradient');
+      expect(gradientCalls).toHaveLength(0);
+      expect(onBuilderChange).not.toHaveBeenCalled();
+    });
+  });
+
   it('ui: line-gradient remove buttons are disabled at the minimum of 2 stops', () => {
     const expr = stopsToLineGradientExpression([{ position: 0, color: '#000' }, { position: 1, color: '#fff' }]);
     render(<LineGradientControls paint={{ 'line-gradient': expr }} styleConfig={{ builder: { lineGradient: { stops: [{ position: 0, color: '#000' }, { position: 1, color: '#fff' }] } } } as unknown as StyleConfig} onPaintProp={vi.fn()} onBuilderChange={vi.fn()} t={t} />);

--- a/frontend/src/components/builder/__tests__/LineGradientControls.test.tsx
+++ b/frontend/src/components/builder/__tests__/LineGradientControls.test.tsx
@@ -172,7 +172,6 @@ describe('LineGradientControls — UI', () => {
     // duplicated the endpoint (previously reproduced by click 7), rerendering
     // with each commit so liveStops actually accumulates like the real app.
     for (let i = 0; i < 7; i++) {
-      // eslint-disable-next-line no-await-in-loop -- each click depends on the previous commit's rerender
       await user.click(addButton());
       const lastBuilderCall = onBuilderChange.mock.calls[onBuilderChange.mock.calls.length - 1];
       stops = lastBuilderCall[0].lineGradient.stops;

--- a/frontend/src/components/builder/__tests__/LineGradientControls.test.tsx
+++ b/frontend/src/components/builder/__tests__/LineGradientControls.test.tsx
@@ -332,6 +332,61 @@ describe('LineGradientControls — UI', () => {
       expect(gradientCalls).toHaveLength(0);
       expect(onBuilderChange).not.toHaveBeenCalled();
     });
+
+    // fix(round5 #1795, P2): a total-count comparison alone let a position
+    // edit SWAP one violation for a different one at the same count.
+    it('from [0, 0.5, 0.5, 1], moving index 2 to 0.4 is refused (swaps the violation, count stays 1)', () => {
+      const onPaintProp = vi.fn();
+      const onBuilderChange = vi.fn();
+      const stops = [
+        { position: 0, color: '#000', id: 'a' },
+        { position: 0.5, color: '#111', id: 'b' },
+        { position: 0.5, color: '#222', id: 'c' },
+        { position: 1, color: '#333', id: 'd' },
+      ];
+      render(
+        <LineGradientControls
+          paint={{ 'line-gradient': stopsToLineGradientExpression(stops) }}
+          styleConfig={{ builder: { lineGradient: { stops } } } as unknown as StyleConfig}
+          onPaintProp={onPaintProp}
+          onBuilderChange={onBuilderChange}
+          t={t}
+        />,
+      );
+      const positionInputs = screen.getAllByRole('spinbutton', { name: 'style.lineGradient.position' });
+      fireEvent.change(positionInputs[2], { target: { value: '0.4' } });
+
+      const gradientCalls = onPaintProp.mock.calls.filter((c: unknown[]) => c[0] === 'line-gradient');
+      expect(gradientCalls).toHaveLength(0);
+      expect(onBuilderChange).not.toHaveBeenCalled();
+    });
+
+    it('from [0, 0.5, 0.5, 1], moving index 2 to 0.6 commits (both pairs it touches are ascending)', () => {
+      const onPaintProp = vi.fn();
+      const onBuilderChange = vi.fn();
+      const stops = [
+        { position: 0, color: '#000', id: 'a' },
+        { position: 0.5, color: '#111', id: 'b' },
+        { position: 0.5, color: '#222', id: 'c' },
+        { position: 1, color: '#333', id: 'd' },
+      ];
+      render(
+        <LineGradientControls
+          paint={{ 'line-gradient': stopsToLineGradientExpression(stops) }}
+          styleConfig={{ builder: { lineGradient: { stops } } } as unknown as StyleConfig}
+          onPaintProp={onPaintProp}
+          onBuilderChange={onBuilderChange}
+          t={t}
+        />,
+      );
+      const positionInputs = screen.getAllByRole('spinbutton', { name: 'style.lineGradient.position' });
+      fireEvent.change(positionInputs[2], { target: { value: '0.6' } });
+
+      const lastBuilderCall = onBuilderChange.mock.calls[onBuilderChange.mock.calls.length - 1];
+      expect(lastBuilderCall).toBeDefined();
+      const committedStops = lastBuilderCall[0].lineGradient.stops as Array<{ position: number }>;
+      expect(committedStops.map((s) => s.position)).toEqual([0, 0.5, 0.6, 1]);
+    });
   });
 
   it('ui: line-gradient remove buttons are disabled at the minimum of 2 stops', () => {

--- a/frontend/src/components/dataset/DatasetMap.tsx
+++ b/frontend/src/components/dataset/DatasetMap.tsx
@@ -290,6 +290,12 @@ export const DatasetMap = memo(function DatasetMap({
   const stableHistoryBaseline = useCallback(() => {
     historyBaselineRef.current();
   }, []);
+  // fix(round4 #1795): onSelectionLost needs handleSelectionLost, same
+  // circular-dep break as onEditFinish/onHistoryBaseline above.
+  const selectionLostRef = useRef<(id: string | number) => void>(() => {});
+  const stableSelectionLost = useCallback((id: string | number) => {
+    selectionLostRef.current(id);
+  }, []);
 
   const handleDrawFinish = useCallback(
     (feature: Feature<Geometry, GeoJsonProperties>) => {
@@ -316,7 +322,7 @@ export const DatasetMap = memo(function DatasetMap({
     undo,
     canUndo,
     resetHistory,
-  } = useTerraDraw(mapInstance, handleDrawFinish, stableEditFinish, stableHistoryBaseline);
+  } = useTerraDraw(mapInstance, handleDrawFinish, stableEditFinish, stableHistoryBaseline, stableSelectionLost);
 
   // --- Feature editing hook (all CRUD logic) ---
   const {
@@ -326,6 +332,7 @@ export const DatasetMap = memo(function DatasetMap({
     handleDeleteFeature,
     handleEditFinish,
     handleHistoryBaseline,
+    handleSelectionLost,
     handleEditAttributeSubmit,
     selectFeatureFromMap,
     cleanupOverlayListener,
@@ -348,6 +355,7 @@ export const DatasetMap = memo(function DatasetMap({
   saveAndRefreshRef.current = saveAndRefresh;
   editFinishRef.current = handleEditFinish;
   historyBaselineRef.current = handleHistoryBaseline;
+  selectionLostRef.current = handleSelectionLost;
 
   // Clean up overlay listeners on unmount
   useEffect(() => {

--- a/frontend/src/components/dataset/DatasetMap.tsx
+++ b/frontend/src/components/dataset/DatasetMap.tsx
@@ -308,6 +308,7 @@ export const DatasetMap = memo(function DatasetMap({
     clear,
     undo,
     canUndo,
+    resetHistory,
   } = useTerraDraw(mapInstance, handleDrawFinish, stableEditFinish);
 
   // --- Feature editing hook (all CRUD logic) ---
@@ -332,6 +333,7 @@ export const DatasetMap = memo(function DatasetMap({
     addFeatures,
     selectFeature: tdSelectFeature,
     clear,
+    resetHistory,
   });
 
   // Keep refs current for callbacks that break circular deps

--- a/frontend/src/components/dataset/DatasetMap.tsx
+++ b/frontend/src/components/dataset/DatasetMap.tsx
@@ -3,7 +3,14 @@ import { useTranslation } from 'react-i18next';
 import { Map as MapGL, Source, Layer, NavigationControl } from '@vis.gl/react-maplibre';
 import { useTheme } from '@/components/theme-provider';
 import { useBasemaps, useMapDefaults, useTileConfig } from '@/hooks/use-settings';
-import { getThemeBasemap, makeStyleImageMissingResolver, toMaplibreStyle, findBasemapById } from '@/lib/basemap-utils';
+import {
+  getThemeBasemap,
+  makeStyleImageMissingResolver,
+  toMaplibreStyle,
+  findBasemapById,
+  FALLBACK_BASEMAP_STYLE_URL,
+  FALLBACK_BASEMAP_STYLE_URL_DARK,
+} from '@/lib/basemap-utils';
 import { BasemapToggle } from '@/components/map/BasemapToggle';
 import { useDrawingStore } from '@/stores/drawing-store';
 import { useTerraDraw } from '@/components/drawing/hooks/use-terra-draw';
@@ -164,9 +171,7 @@ export const DatasetMap = memo(function DatasetMap({
     initialBasemapStyle.current = bm
       ? toMaplibreStyle(bm.url, bm.attribution)
       : toMaplibreStyle(
-          resolvedTheme === 'dark'
-            ? 'https://tiles.openfreemap.org/styles/dark'
-            : 'https://tiles.openfreemap.org/styles/positron',
+          resolvedTheme === 'dark' ? FALLBACK_BASEMAP_STYLE_URL_DARK : FALLBACK_BASEMAP_STYLE_URL,
         );
   }
 

--- a/frontend/src/components/dataset/DatasetMap.tsx
+++ b/frontend/src/components/dataset/DatasetMap.tsx
@@ -283,6 +283,13 @@ export const DatasetMap = memo(function DatasetMap({
   const stableEditFinish = useCallback((tdId: string, feature: Feature) => {
     editFinishRef.current(tdId, feature);
   }, []);
+  // fix(round2 #1795): onHistoryBaseline needs handleHistoryBaseline, which
+  // also comes from useFeatureEditing (needs TerraDraw) — same circular-dep
+  // break as onEditFinish above.
+  const historyBaselineRef = useRef<() => void>(() => {});
+  const stableHistoryBaseline = useCallback(() => {
+    historyBaselineRef.current();
+  }, []);
 
   const handleDrawFinish = useCallback(
     (feature: Feature<Geometry, GeoJsonProperties>) => {
@@ -309,7 +316,7 @@ export const DatasetMap = memo(function DatasetMap({
     undo,
     canUndo,
     resetHistory,
-  } = useTerraDraw(mapInstance, handleDrawFinish, stableEditFinish);
+  } = useTerraDraw(mapInstance, handleDrawFinish, stableEditFinish, stableHistoryBaseline);
 
   // --- Feature editing hook (all CRUD logic) ---
   const {
@@ -318,6 +325,7 @@ export const DatasetMap = memo(function DatasetMap({
     handleSaveEdit,
     handleDeleteFeature,
     handleEditFinish,
+    handleHistoryBaseline,
     handleEditAttributeSubmit,
     selectFeatureFromMap,
     cleanupOverlayListener,
@@ -339,6 +347,7 @@ export const DatasetMap = memo(function DatasetMap({
   // Keep refs current for callbacks that break circular deps
   saveAndRefreshRef.current = saveAndRefresh;
   editFinishRef.current = handleEditFinish;
+  historyBaselineRef.current = handleHistoryBaseline;
 
   // Clean up overlay listeners on unmount
   useEffect(() => {

--- a/frontend/src/components/dataset/__tests__/DatasetMap.test.tsx
+++ b/frontend/src/components/dataset/__tests__/DatasetMap.test.tsx
@@ -121,6 +121,7 @@ const terraDrawState = vi.hoisted(() => ({
   clear: vi.fn(),
   undo: vi.fn(),
   canUndo: false,
+  resetHistory: vi.fn(),
 }));
 
 vi.mock('@/components/drawing/hooks/use-terra-draw', () => ({

--- a/frontend/src/components/dataset/hooks/__tests__/use-feature-editing.test.ts
+++ b/frontend/src/components/dataset/hooks/__tests__/use-feature-editing.test.ts
@@ -88,6 +88,7 @@ interface EditingOverrides {
   addFeatures?: (features: Feature[]) => { id?: string | number; valid: boolean }[];
   selectFeature?: (id: string) => void;
   clear?: () => void;
+  resetHistory?: () => void;
 }
 
 function renderEditing(map: MaplibreMap, overrides: EditingOverrides = {}) {
@@ -98,6 +99,7 @@ function renderEditing(map: MaplibreMap, overrides: EditingOverrides = {}) {
     addFeatures: overrides.addFeatures ?? vi.fn(() => []),
     selectFeature: overrides.selectFeature ?? vi.fn(),
     clear: overrides.clear ?? vi.fn(),
+    resetHistory: overrides.resetHistory ?? vi.fn(),
   };
   const hook = renderHook(() =>
     useFeatureEditing({
@@ -338,6 +340,90 @@ describe('useFeatureEditing — post-mutation cleanup skipped after a stale iden
 
     expect(removeFeatures).toHaveBeenCalledWith(['td-7']);
     expect(useDrawingStore.getState().selectedFeature).toBeNull();
+  });
+});
+
+// fix(round1 #1795): a drag/vertex edit only marks the edit dirty
+// (handleEditFinish) — it is not persisted until Save. The undo history for
+// that pending edit must survive until it actually settles: a successful
+// save, or a cancel/deselection (performDeselect, shared by both).
+describe('useFeatureEditing — undo history reset on settle, not on finish (fix round1 #1795)', () => {
+  const baseAuth = useDrawingStore.getState();
+
+  beforeEach(() => {
+    useDrawingStore.setState(baseAuth, true);
+    updateMutateAsync.mockClear();
+  });
+
+  it('handleSaveEdit resets the undo history once the update settles normally', async () => {
+    useDrawingStore.setState({ selectedFeature: { gid: 7, tdId: 'td-7', properties: {} } });
+    const resetHistory = vi.fn();
+    const getSnapshotFeature = vi.fn(() => ({
+      type: 'Feature' as const,
+      geometry: { type: 'Point' as const, coordinates: [0, 0] },
+      properties: {},
+    }));
+    const map = { getLayer: vi.fn(() => true), getFilter: vi.fn(() => null), setFilter: vi.fn(), getSource: vi.fn(() => undefined) } as unknown as MaplibreMap;
+    const { result } = renderEditing(map, { getSnapshotFeature, resetHistory });
+
+    await act(async () => {
+      await result.current.handleSaveEdit();
+    });
+
+    expect(resetHistory).toHaveBeenCalledTimes(1);
+  });
+
+  it('handleSaveEdit does NOT reset the undo history when cleanup is skipped for a stale identity', async () => {
+    useDrawingStore.setState({ selectedFeature: { gid: 7, tdId: 'td-7', properties: {} } });
+    const update = deferred<unknown>();
+    updateMutateAsync.mockReturnValueOnce(update.promise);
+    const resetHistory = vi.fn();
+    const getSnapshotFeature = vi.fn(() => ({
+      type: 'Feature' as const,
+      geometry: { type: 'Point' as const, coordinates: [0, 0] },
+      properties: {},
+    }));
+    const map = { getLayer: vi.fn(() => true), getFilter: vi.fn(() => null), setFilter: vi.fn(), getSource: vi.fn(() => undefined) } as unknown as MaplibreMap;
+    const { result } = renderEditing(map, { getSnapshotFeature, resetHistory });
+
+    const saving = result.current.handleSaveEdit();
+    act(() => {
+      useDrawingStore.getState().bumpSessionEpoch();
+    });
+    update.resolve({});
+    await act(async () => {
+      await saving;
+    });
+
+    expect(resetHistory).not.toHaveBeenCalled();
+  });
+
+  it('performDeselect (also used for Cancel) resets the undo history', () => {
+    useDrawingStore.setState({ selectedFeature: { gid: 7, tdId: 'td-7', properties: {} } });
+    const resetHistory = vi.fn();
+    const removeFeatures = vi.fn();
+    const map = { getLayer: vi.fn(() => true), getFilter: vi.fn(() => null), setFilter: vi.fn(), getSource: vi.fn(() => undefined) } as unknown as MaplibreMap;
+    const { result } = renderEditing(map, { removeFeatures, resetHistory });
+
+    act(() => {
+      result.current.performDeselect();
+    });
+
+    expect(resetHistory).toHaveBeenCalledTimes(1);
+    expect(useDrawingStore.getState().selectedFeature).toBeNull();
+  });
+
+  it('performDeselect is a no-op (including no history reset) when nothing is selected', () => {
+    useDrawingStore.setState({ selectedFeature: null });
+    const resetHistory = vi.fn();
+    const map = { getLayer: vi.fn(() => true), getFilter: vi.fn(() => null), setFilter: vi.fn(), getSource: vi.fn(() => undefined) } as unknown as MaplibreMap;
+    const { result } = renderEditing(map, { resetHistory });
+
+    act(() => {
+      result.current.performDeselect();
+    });
+
+    expect(resetHistory).not.toHaveBeenCalled();
   });
 });
 

--- a/frontend/src/components/dataset/hooks/__tests__/use-feature-editing.test.ts
+++ b/frontend/src/components/dataset/hooks/__tests__/use-feature-editing.test.ts
@@ -347,12 +347,13 @@ describe('useFeatureEditing — post-mutation cleanup skipped after a stale iden
 // (handleEditFinish) — it is not persisted until Save. The undo history for
 // that pending edit must survive until it actually settles: a successful
 // save, or a cancel/deselection (performDeselect, shared by both).
-describe('useFeatureEditing — undo history reset on settle, not on finish (fix round1 #1795)', () => {
+describe('useFeatureEditing — undo history reset on settle, not on finish (fix round1/round2 #1795)', () => {
   const baseAuth = useDrawingStore.getState();
 
   beforeEach(() => {
     useDrawingStore.setState(baseAuth, true);
     updateMutateAsync.mockClear();
+    deleteMutateAsync.mockClear();
   });
 
   it('handleSaveEdit resets the undo history once the update settles normally', async () => {
@@ -424,6 +425,105 @@ describe('useFeatureEditing — undo history reset on settle, not on finish (fix
     });
 
     expect(resetHistory).not.toHaveBeenCalled();
+  });
+
+  // fix(round2 #1795, P2): handleDeleteFeature's success path removed the
+  // feature and cleared the selection but never reset the undo history —
+  // canUndo stayed true and Undo restored the deleted geometry as a
+  // client-side ghost. Reset at the same point handleSaveEdit does, after
+  // the stale-epoch check.
+  it('handleDeleteFeature resets the undo history once the delete settles normally', async () => {
+    useDrawingStore.setState({ selectedFeature: { gid: 7, tdId: 'td-7', properties: {} } });
+    const resetHistory = vi.fn();
+    const removeFeatures = vi.fn();
+    const map = { getLayer: vi.fn(() => true), getFilter: vi.fn(() => null), setFilter: vi.fn(), getSource: vi.fn(() => undefined) } as unknown as MaplibreMap;
+    const { result } = renderEditing(map, { removeFeatures, resetHistory });
+
+    await act(async () => {
+      await result.current.handleDeleteFeature();
+    });
+
+    expect(resetHistory).toHaveBeenCalledTimes(1);
+  });
+
+  it('handleDeleteFeature does NOT reset the undo history when cleanup is skipped for a stale identity', async () => {
+    useDrawingStore.setState({ selectedFeature: { gid: 7, tdId: 'td-7', properties: {} } });
+    const del = deferred<unknown>();
+    deleteMutateAsync.mockReturnValueOnce(del.promise);
+    const resetHistory = vi.fn();
+    const removeFeatures = vi.fn();
+    const map = { getLayer: vi.fn(() => true), getFilter: vi.fn(() => null), setFilter: vi.fn(), getSource: vi.fn(() => undefined) } as unknown as MaplibreMap;
+    const { result } = renderEditing(map, { removeFeatures, resetHistory });
+
+    const deleting = result.current.handleDeleteFeature();
+    act(() => {
+      useDrawingStore.getState().bumpSessionEpoch();
+    });
+    del.resolve({});
+    await act(async () => {
+      await deleting;
+    });
+
+    expect(resetHistory).not.toHaveBeenCalled();
+  });
+});
+
+// fix(round2 #1795, P2): Terra Draw's undo() reverts snapshots and updates
+// canUndo, but never touched isEditDirty — undoing all the way back to the
+// original geometry still triggered the unsaved-changes confirmation on
+// Cancel/Done/mode-switch. handleHistoryBaseline is what use-terra-draw's
+// onHistoryBaseline callback fires into; a subsequent edit re-dirties
+// normally through the existing handleEditFinish.
+describe('useFeatureEditing — handleHistoryBaseline clears isEditDirty (fix round2 #1795)', () => {
+  const baseAuth = useDrawingStore.getState();
+
+  beforeEach(() => {
+    useDrawingStore.setState(baseAuth, true);
+  });
+
+  it('clears isEditDirty when the undo ring reports it reached baseline', () => {
+    const map = { getLayer: vi.fn(() => true), getFilter: vi.fn(() => null), setFilter: vi.fn(), getSource: vi.fn(() => undefined) } as unknown as MaplibreMap;
+    const { result } = renderEditing(map);
+
+    act(() => {
+      result.current.handleEditFinish('td-7', {
+        type: 'Feature',
+        geometry: { type: 'Point', coordinates: [0, 0] },
+        properties: {},
+      });
+    });
+    expect(useDrawingStore.getState().isEditDirty).toBe(true);
+
+    act(() => {
+      result.current.handleHistoryBaseline();
+    });
+    expect(useDrawingStore.getState().isEditDirty).toBe(false);
+  });
+
+  it('a subsequent edit re-dirties normally after a baseline reset (drag, undo, drag)', () => {
+    const map = { getLayer: vi.fn(() => true), getFilter: vi.fn(() => null), setFilter: vi.fn(), getSource: vi.fn(() => undefined) } as unknown as MaplibreMap;
+    const { result } = renderEditing(map);
+
+    act(() => {
+      result.current.handleEditFinish('td-7', {
+        type: 'Feature',
+        geometry: { type: 'Point', coordinates: [0, 0] },
+        properties: {},
+      });
+    });
+    act(() => {
+      result.current.handleHistoryBaseline();
+    });
+    expect(useDrawingStore.getState().isEditDirty).toBe(false);
+
+    act(() => {
+      result.current.handleEditFinish('td-7', {
+        type: 'Feature',
+        geometry: { type: 'Point', coordinates: [1, 1] },
+        properties: {},
+      });
+    });
+    expect(useDrawingStore.getState().isEditDirty).toBe(true);
   });
 });
 

--- a/frontend/src/components/dataset/hooks/__tests__/use-feature-editing.test.ts
+++ b/frontend/src/components/dataset/hooks/__tests__/use-feature-editing.test.ts
@@ -527,6 +527,56 @@ describe('useFeatureEditing — handleHistoryBaseline clears isEditDirty (fix ro
   });
 });
 
+// fix(round4 #1795, P2): undo() restored a snapshot that no longer contains
+// the feature that was selected before the undo — Terra Draw's own select
+// state has nothing left to re-select. handleSelectionLost clears our
+// selection store too, so it agrees with what Terra Draw actually has.
+describe('useFeatureEditing — handleSelectionLost clears the selection store (fix round4 #1795)', () => {
+  const baseAuth = useDrawingStore.getState();
+
+  beforeEach(() => {
+    useDrawingStore.setState(baseAuth, true);
+  });
+
+  it('clears selectedFeature (and isEditDirty) when the lost id matches the current selection', () => {
+    useDrawingStore.setState({ selectedFeature: { gid: 7, tdId: 'td-7', properties: {} }, isEditDirty: true });
+    const map = { getLayer: vi.fn(() => true), getFilter: vi.fn(() => null), setFilter: vi.fn(), getSource: vi.fn(() => undefined) } as unknown as MaplibreMap;
+    const { result } = renderEditing(map);
+
+    act(() => {
+      result.current.handleSelectionLost('td-7');
+    });
+
+    expect(useDrawingStore.getState().selectedFeature).toBeNull();
+    expect(useDrawingStore.getState().isEditDirty).toBe(false);
+  });
+
+  it('does nothing when the lost id does not match the current selection (a newer selection has since replaced it)', () => {
+    useDrawingStore.setState({ selectedFeature: { gid: 9, tdId: 'td-9', properties: {} }, isEditDirty: true });
+    const map = { getLayer: vi.fn(() => true), getFilter: vi.fn(() => null), setFilter: vi.fn(), getSource: vi.fn(() => undefined) } as unknown as MaplibreMap;
+    const { result } = renderEditing(map);
+
+    act(() => {
+      result.current.handleSelectionLost('td-7');
+    });
+
+    expect(useDrawingStore.getState().selectedFeature).toEqual({ gid: 9, tdId: 'td-9', properties: {} });
+    expect(useDrawingStore.getState().isEditDirty).toBe(true);
+  });
+
+  it('does nothing when nothing is currently selected', () => {
+    useDrawingStore.setState({ selectedFeature: null });
+    const map = { getLayer: vi.fn(() => true), getFilter: vi.fn(() => null), setFilter: vi.fn(), getSource: vi.fn(() => undefined) } as unknown as MaplibreMap;
+    const { result } = renderEditing(map);
+
+    act(() => {
+      result.current.handleSelectionLost('td-7');
+    });
+
+    expect(useDrawingStore.getState().selectedFeature).toBeNull();
+  });
+});
+
 // fix(#1761 review round 4): the epoch-change cleanup (DatasetMap's
 // finishDrawingSession) clears Terra Draw but, before this, not the overlay
 // ref/source that saveAndRefresh populates for instant visibility while a

--- a/frontend/src/components/dataset/hooks/use-feature-editing.ts
+++ b/frontend/src/components/dataset/hooks/use-feature-editing.ts
@@ -422,6 +422,25 @@ export function useFeatureEditing({
     setEditDirty(false);
   }, [setEditDirty]);
 
+  /**
+   * fix(round4 #1795): undo() restored a snapshot that no longer contains
+   * the feature that was selected before the undo — Terra Draw's own
+   * select state has nothing left to re-select. Clear our selection store
+   * too, so it agrees with what Terra Draw actually has (a stale selection
+   * here would keep showing the action bar for a feature that no longer
+   * exists on the canvas). Guarded on the CURRENT selection matching the id
+   * this fired for, in case a newer selection has since replaced it.
+   */
+  const handleSelectionLost = useCallback(
+    (id: string | number) => {
+      const sf = useDrawingStore.getState().selectedFeature;
+      if (sf && sf.tdId === String(id)) {
+        clearSelectedFeature();
+      }
+    },
+    [clearSelectedFeature],
+  );
+
   /** Select a feature from the map by clicking on it. */
   const selectFeatureFromMap = useCallback(
     async (map: MaplibreMap, point: Point) => {
@@ -507,6 +526,7 @@ export function useFeatureEditing({
     handleDeleteFeature,
     handleEditFinish,
     handleHistoryBaseline,
+    handleSelectionLost,
     handleEditAttributeSubmit,
     selectFeatureFromMap,
     reloadTiles,

--- a/frontend/src/components/dataset/hooks/use-feature-editing.ts
+++ b/frontend/src/components/dataset/hooks/use-feature-editing.ts
@@ -82,6 +82,9 @@ interface UseFeatureEditingOptions {
   addFeatures: (features: Feature[]) => { id?: string | number; valid: boolean }[];
   selectFeature: (id: string) => void;
   clear: () => void;
+  /** fix(round1 #1795): reset the undo ring once a pending edit settles
+   *  (save, cancel, or deselection) — NOT on every drag/vertex finish. */
+  resetHistory: () => void;
 }
 
 /**
@@ -109,6 +112,7 @@ export function useFeatureEditing({
   addFeatures,
   selectFeature: tdSelectFeature,
   clear,
+  resetHistory,
 }: UseFeatureEditingOptions) {
   const { t } = useTranslation('dataset');
   const createFeature = useCreateFeature();
@@ -260,7 +264,11 @@ export function useFeatureEditing({
     const map = mapRef.current;
     if (map) showAllFeaturesInTiles(map);
     clearSelectedFeature();
-  }, [mapRef, removeFeatures, clearSelectedFeature]);
+    // fix(round1 #1795): deselection (also used for Cancel — see
+    // DatasetMap's handleDeselect) discards any pending, un-saved undo
+    // history for the edit just abandoned.
+    resetHistory();
+  }, [mapRef, removeFeatures, clearSelectedFeature, resetHistory]);
 
   /** Save edited geometry for the selected feature. */
   const handleSaveEdit = useCallback(async () => {
@@ -296,6 +304,9 @@ export function useFeatureEditing({
       const map = mapRef.current;
       if (map) showAllFeaturesInTiles(map);
       clearSelectedFeature();
+      // fix(round1 #1795): the edit just landed server-side — the pending
+      // undo history it belonged to is no longer meaningful.
+      resetHistory();
     } catch (err) {
       // fix(#1761 review round 7): mirror the success branch's recheck —
       // a failed update is feedback for whoever issued it, not whoever is
@@ -304,7 +315,7 @@ export function useFeatureEditing({
       // fix(#458 E-36): keep the backend detail.
       toast.error(formatMutationError('dataset:map.featureUpdateFailed', err));
     }
-  }, [datasetId, tableName, mapRef, getSnapshotFeature, updateFeatureMutation, removeFeatures, clearSelectedFeature, reloadTiles, t]);
+  }, [datasetId, tableName, mapRef, getSnapshotFeature, updateFeatureMutation, removeFeatures, clearSelectedFeature, reloadTiles, resetHistory, t]);
 
   /** Delete the selected feature. */
   const handleDeleteFeature = useCallback(async () => {

--- a/frontend/src/components/dataset/hooks/use-feature-editing.ts
+++ b/frontend/src/components/dataset/hooks/use-feature-editing.ts
@@ -337,6 +337,10 @@ export function useFeatureEditing({
       const map = mapRef.current;
       if (map) showAllFeaturesInTiles(map);
       clearSelectedFeature();
+      // fix(round2 #1795): the deleted feature no longer exists — its
+      // pending undo history (which would restore it as a client-side
+      // ghost) is no longer meaningful. Same point handleSaveEdit resets at.
+      resetHistory();
     } catch (err) {
       // fix(#1761 review round 7): mirror the success branch's recheck —
       // a failed delete is feedback for whoever issued it, not whoever is
@@ -345,7 +349,7 @@ export function useFeatureEditing({
       // fix(#458 E-36): keep the backend detail.
       toast.error(formatMutationError('dataset:map.featureDeleteFailed', err));
     }
-  }, [datasetId, tableName, mapRef, deleteFeatureMutation, removeFeatures, clearSelectedFeature, reloadTiles, t]);
+  }, [datasetId, tableName, mapRef, deleteFeatureMutation, removeFeatures, clearSelectedFeature, reloadTiles, resetHistory, t]);
 
   /** Update attributes of the selected feature. */
   // fix(#1761 review round 4): returns whether the caller may treat this
@@ -406,6 +410,17 @@ export function useFeatureEditing({
     },
     [setEditDirty],
   );
+
+  /**
+   * fix(round2 #1795): Terra Draw's undo() popped the ring back to its
+   * earliest recorded snapshot — the displayed geometry is once again
+   * whatever was there when the ring started, so there is no longer a
+   * pending edit to confirm away on Cancel/Done/mode-switch. A subsequent
+   * drag/vertex edit re-dirties normally via handleEditFinish above.
+   */
+  const handleHistoryBaseline = useCallback(() => {
+    setEditDirty(false);
+  }, [setEditDirty]);
 
   /** Select a feature from the map by clicking on it. */
   const selectFeatureFromMap = useCallback(
@@ -491,6 +506,7 @@ export function useFeatureEditing({
     handleSaveEdit,
     handleDeleteFeature,
     handleEditFinish,
+    handleHistoryBaseline,
     handleEditAttributeSubmit,
     selectFeatureFromMap,
     reloadTiles,

--- a/frontend/src/components/drawing/hooks/__tests__/use-terra-draw.undo-history.test.ts
+++ b/frontend/src/components/drawing/hooks/__tests__/use-terra-draw.undo-history.test.ts
@@ -156,14 +156,24 @@ describe('useTerraDraw — undo history bound (fix #1778)', () => {
 // geometry still triggered the unsaved-changes confirmation on Cancel/Done/
 // mode-switch. onHistoryBaseline is the signal the editing layer uses to
 // clear isEditDirty at exactly the right moment.
-describe('useTerraDraw — onHistoryBaseline (fix round2 #1795)', () => {
-  it('fires onHistoryBaseline only on the undo() call that pops the ring back to its earliest snapshot', () => {
+describe('useTerraDraw — onHistoryBaseline (fix round2/round3 #1795)', () => {
+  // fix(round3 #1795): with a captured baseline, reaching the ring's own
+  // oldest entry (round2's old "atBaseline" condition) is NOT the true
+  // pre-edit snapshot — it's just as far as the RING goes. One more undo
+  // step, falling back to baselineRef, is what actually restores the
+  // original geometry and fires the callback.
+  it('fires onHistoryBaseline only on the undo() call that reaches the TRUE captured baseline, not when the ring itself is merely exhausted', () => {
     const map = fakeMap();
     const onHistoryBaseline = vi.fn();
     const { result } = renderHook(() => useTerraDraw(map, vi.fn(), null, onHistoryBaseline));
     const td = lastInstance!;
 
-    // Three snapshots recorded (ring length 3): two undos are available.
+    // Selecting a feature captures the TRUE pre-edit baseline outside the ring.
+    act(() => {
+      result.current.selectFeature('feat-1');
+    });
+
+    // Three snapshots recorded (ring length 3).
     act(() => {
       td.emit('change');
       td.emit('change');
@@ -171,14 +181,22 @@ describe('useTerraDraw — onHistoryBaseline (fix round2 #1795)', () => {
     });
     expect(result.current.canUndo).toBe(true);
 
-    // First undo: ring still has more than one entry left — not at baseline yet.
+    // First undo: ring still has more than one entry left.
     act(() => {
       result.current.undo();
     });
     expect(onHistoryBaseline).not.toHaveBeenCalled();
     expect(result.current.canUndo).toBe(true);
 
-    // Second undo: ring collapses to its earliest entry — baseline reached.
+    // Second undo: only the ring's own oldest entry remains. NOT the true
+    // baseline yet — canUndo stays true only because a baseline was captured.
+    act(() => {
+      result.current.undo();
+    });
+    expect(onHistoryBaseline).not.toHaveBeenCalled();
+    expect(result.current.canUndo).toBe(true);
+
+    // Third undo: the ring is now empty — the TRUE baseline is restored.
     act(() => {
       result.current.undo();
     });
@@ -222,20 +240,99 @@ describe('useTerraDraw — onHistoryBaseline (fix round2 #1795)', () => {
     expect(onHistoryBaseline).not.toHaveBeenCalled();
   });
 
-  it('an undo() call while already at baseline (no-op) does not re-fire onHistoryBaseline', () => {
+  it('an undo() call after the ring is already exhausted with no baseline (no-op) does not fire onHistoryBaseline', () => {
     const map = fakeMap();
     const onHistoryBaseline = vi.fn();
     const { result } = renderHook(() => useTerraDraw(map, vi.fn(), null, onHistoryBaseline));
     const td = lastInstance!;
 
+    // No selectFeature()/setMode() call — no baseline captured.
     act(() => {
       td.emit('change');
     });
-    expect(result.current.canUndo).toBe(false); // one snapshot only — already at baseline
+    // fix(round3 #1795): with no captured baseline, one ring entry is as far
+    // as undo can verifiably go — canUndo is false, same as before this fix.
+    expect(result.current.canUndo).toBe(false);
 
     act(() => {
-      result.current.undo(); // guarded no-op: historyRef.length <= 1
+      result.current.undo(); // guarded no-op: canUndoFrom(1, false) === false
     });
     expect(onHistoryBaseline).not.toHaveBeenCalled();
+  });
+
+  // fix(round3 #1795, P2 pin): after more than MAX_UNDO_HISTORY (50) change
+  // events in one drag, the ring's shift() evicts the original pre-edit
+  // snapshot. Undo must still reach the TRUE original geometry — not
+  // whatever the ring's own (now-not-original) oldest surviving entry is —
+  // and onHistoryBaseline must fire exactly once, on that final step.
+  it('undoing past an evicted ring restores the TRUE pre-edit baseline, not a stale ring entry (60 changes, cap 50)', () => {
+    const map = fakeMap();
+    const onHistoryBaseline = vi.fn();
+    const { result } = renderHook(() => useTerraDraw(map, vi.fn(), null, onHistoryBaseline));
+    const td = lastInstance!;
+
+    const baselineSnapshot = [{ properties: { mode: 'point', tag: 'baseline' } }] as unknown[];
+    td.getSnapshot.mockReturnValue(baselineSnapshot);
+    act(() => {
+      result.current.selectFeature('feat-1');
+    });
+
+    // 60 change events — the ring (cap 50) evicts its oldest 10 entries, so
+    // its surviving oldest entry ("change-11") is NOT the true baseline.
+    for (let i = 1; i <= 60; i++) {
+      td.getSnapshot.mockReturnValue([{ properties: { mode: 'point', tag: `change-${i}` } }] as unknown[]);
+      act(() => {
+        td.emit('change');
+      });
+    }
+    expect(result.current.canUndo).toBe(true);
+
+    let undoCount = 0;
+    while (result.current.canUndo && undoCount < 200) {
+      act(() => {
+        result.current.undo();
+      });
+      undoCount++;
+    }
+
+    // 50 ring entries take exactly 50 undo() calls to exhaust: 49 step
+    // through the ring, the 50th falls back to the true baseline.
+    expect(undoCount).toBe(50);
+    expect(onHistoryBaseline).toHaveBeenCalledTimes(1);
+    const lastAddFeaturesCall = td.addFeatures.mock.calls[td.addFeatures.mock.calls.length - 1];
+    expect(lastAddFeaturesCall[0]).toEqual(baselineSnapshot);
+  });
+
+  // fix(round3 #1795, P2 pin): if the session's baseline was never captured
+  // (e.g. change events reached the hook before any recognized
+  // session-start point ran), undo must refuse to fabricate one — the ring
+  // stops at its own oldest entry and onHistoryBaseline never fires, so
+  // isEditDirty stays true.
+  it('with the baseline deliberately missing, onHistoryBaseline never fires even after undo is fully exhausted', () => {
+    const map = fakeMap();
+    const onHistoryBaseline = vi.fn();
+    const { result } = renderHook(() => useTerraDraw(map, vi.fn(), null, onHistoryBaseline));
+    const td = lastInstance!;
+
+    // No selectFeature()/setMode() call anywhere in this test.
+    act(() => {
+      td.emit('change');
+      td.emit('change');
+      td.emit('change');
+    });
+    expect(result.current.canUndo).toBe(true);
+
+    let undoCount = 0;
+    while (result.current.canUndo && undoCount < 200) {
+      act(() => {
+        result.current.undo();
+      });
+      undoCount++;
+    }
+
+    // Refused to go past the ring's own oldest entry without a verified baseline.
+    expect(undoCount).toBe(2);
+    expect(onHistoryBaseline).not.toHaveBeenCalled();
+    expect(result.current.canUndo).toBe(false);
   });
 });

--- a/frontend/src/components/drawing/hooks/__tests__/use-terra-draw.undo-history.test.ts
+++ b/frontend/src/components/drawing/hooks/__tests__/use-terra-draw.undo-history.test.ts
@@ -336,3 +336,117 @@ describe('useTerraDraw — onHistoryBaseline (fix round2/round3 #1795)', () => {
     expect(result.current.canUndo).toBe(false);
   });
 });
+
+// fix(round4 #1795, P2): undo()'s restoring draw.clear() drops Terra Draw's
+// own select-mode state and edit handles. Without re-selecting afterward,
+// the app's selection store still shows the feature selected, but Terra
+// Draw does not — the user has to click the geometry again before dragging
+// or editing vertices.
+describe('useTerraDraw — undo() re-selects the previously selected feature (fix round4 #1795)', () => {
+  it('re-selects after restoring an intermediate ring snapshot, in the correct order (clear, addFeatures, THEN selectFeature)', () => {
+    const map = fakeMap();
+    const { result } = renderHook(() => useTerraDraw(map, vi.fn(), null));
+    const td = lastInstance!;
+
+    const callLog: string[] = [];
+    td.clear.mockImplementation(() => { callLog.push('clear'); });
+    td.addFeatures.mockImplementation((f: unknown) => { callLog.push(`addFeatures:${JSON.stringify(f)}`); });
+    td.selectFeature.mockImplementation((id: string | number) => { callLog.push(`selectFeature:${id}`); });
+
+    const withFeature = (tag: string) => [{ id: 'feat-1', properties: { mode: 'point', tag } }] as unknown[];
+
+    td.getSnapshot.mockReturnValue(withFeature('baseline'));
+    act(() => {
+      result.current.selectFeature('feat-1');
+    });
+    expect(td.selectFeature).toHaveBeenCalledWith('feat-1');
+    callLog.length = 0;
+
+    td.getSnapshot.mockReturnValue(withFeature('change-1'));
+    act(() => { td.emit('change'); });
+    td.getSnapshot.mockReturnValue(withFeature('change-2'));
+    act(() => { td.emit('change'); });
+
+    act(() => {
+      result.current.undo();
+    });
+
+    expect(td.addFeatures).toHaveBeenCalledWith(withFeature('change-1'));
+    expect(td.selectFeature).toHaveBeenCalledWith('feat-1');
+    // Terra Draw's own select state/edit handles only exist AFTER the
+    // feature is back on the canvas — selectFeature must run after
+    // addFeatures, both of which run after clear().
+    expect(callLog).toEqual([
+      'clear',
+      `addFeatures:${JSON.stringify(withFeature('change-1'))}`,
+      'selectFeature:feat-1',
+    ]);
+  });
+
+  // fix(round4 #1795): the round3 baseline-fallback undo (ring exhausted,
+  // restoring baselineRef) shares the SAME restoration code path as a
+  // ring-internal undo — this pins that the re-select fix covers it too.
+  it('re-selects after falling back to the true baseline (round3 baseline-fallback path)', () => {
+    const map = fakeMap();
+    const { result } = renderHook(() => useTerraDraw(map, vi.fn(), null));
+    const td = lastInstance!;
+
+    const withFeature = (tag: string) => [{ id: 'feat-1', properties: { mode: 'point', tag } }] as unknown[];
+
+    td.getSnapshot.mockReturnValue(withFeature('baseline'));
+    act(() => {
+      result.current.selectFeature('feat-1');
+    });
+    (td.selectFeature as ReturnType<typeof vi.fn>).mockClear();
+
+    td.getSnapshot.mockReturnValue(withFeature('change-1'));
+    act(() => { td.emit('change'); });
+
+    // One change only — ring length 1. This undo pops the ring to empty and
+    // falls back to the TRUE baseline (fix round3 #1795), not a ring entry.
+    act(() => {
+      result.current.undo();
+    });
+
+    expect(td.addFeatures).toHaveBeenCalledWith(withFeature('baseline'));
+    expect(td.selectFeature).toHaveBeenCalledWith('feat-1');
+    expect(result.current.canUndo).toBe(false);
+  });
+
+  it('clears the selection record and reports onSelectionLost when the restored snapshot no longer has that feature', () => {
+    const map = fakeMap();
+    const onSelectionLost = vi.fn();
+    const { result } = renderHook(() => useTerraDraw(map, vi.fn(), null, undefined, onSelectionLost));
+    const td = lastInstance!;
+
+    td.getSnapshot.mockReturnValue([{ id: 'feat-1', properties: { mode: 'point', tag: 'baseline' } }] as unknown[]);
+    act(() => {
+      result.current.selectFeature('feat-1');
+    });
+    (td.selectFeature as ReturnType<typeof vi.fn>).mockClear();
+
+    // The restored ring entries never contain feat-1 (only a different feature).
+    td.getSnapshot.mockReturnValue([{ id: 'other-feat', properties: { mode: 'point', tag: 'change-1' } }] as unknown[]);
+    act(() => { td.emit('change'); });
+    td.getSnapshot.mockReturnValue([{ id: 'other-feat', properties: { mode: 'point', tag: 'change-2' } }] as unknown[]);
+    act(() => { td.emit('change'); });
+
+    act(() => {
+      result.current.undo();
+    });
+
+    expect(td.selectFeature).not.toHaveBeenCalled();
+    expect(onSelectionLost).toHaveBeenCalledTimes(1);
+    expect(onSelectionLost).toHaveBeenCalledWith('feat-1');
+
+    // A second undo (falling back to the true baseline, which DOES have
+    // feat-1) must not still think feat-1 is selected from a stale record —
+    // it was cleared, so onSelectionLost is not reported a second time and
+    // selectFeature is not spuriously called either.
+    act(() => {
+      result.current.undo();
+    });
+    expect(td.selectFeature).not.toHaveBeenCalled();
+    expect(onSelectionLost).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/components/drawing/hooks/__tests__/use-terra-draw.undo-history.test.ts
+++ b/frontend/src/components/drawing/hooks/__tests__/use-terra-draw.undo-history.test.ts
@@ -1,0 +1,121 @@
+// fix(#1778): Terra Draw undo history grew without bound and was never reset
+// on the feature-edit (drag) path. These tests mock the `terra-draw` and
+// `terra-draw-maplibre-gl-adapter` packages so the hook's `change`/`finish`
+// handlers can be driven directly, without a real WebGL map.
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import type { Map as MaplibreMap } from 'maplibre-gl';
+import { useTerraDraw } from '@/components/drawing/hooks/use-terra-draw';
+
+type Listener = (...args: unknown[]) => void;
+
+class FakeTerraDraw {
+  listeners: Record<string, Listener[]> = {};
+  enabled = true;
+  on(event: string, cb: Listener) {
+    (this.listeners[event] ??= []).push(cb);
+  }
+  off(event: string, cb: Listener) {
+    this.listeners[event] = (this.listeners[event] ?? []).filter((c) => c !== cb);
+  }
+  emit(event: string, ...args: unknown[]) {
+    for (const cb of [...(this.listeners[event] ?? [])]) cb(...args);
+  }
+  start = vi.fn();
+  stop = vi.fn();
+  getSnapshot = vi.fn(() => [{ properties: { mode: 'point' } }] as unknown[]);
+  getSnapshotFeature = vi.fn((id: string | number) => ({
+    type: 'Feature',
+    id,
+    properties: { mode: 'point' },
+    geometry: { type: 'Point', coordinates: [0, 0] },
+  }));
+  removeFeatures = vi.fn();
+  addFeatures = vi.fn();
+  clear = vi.fn();
+  selectFeature = vi.fn();
+  setMode = vi.fn();
+}
+
+let lastInstance: FakeTerraDraw | null = null;
+
+vi.mock('terra-draw', () => ({
+  TerraDraw: vi.fn().mockImplementation(function TerraDrawCtor() {
+    lastInstance = new FakeTerraDraw();
+    return lastInstance;
+  }),
+  TerraDrawPointMode: vi.fn(),
+  TerraDrawLineStringMode: vi.fn(),
+  TerraDrawPolygonMode: vi.fn(),
+  TerraDrawRectangleMode: vi.fn(),
+  TerraDrawCircleMode: vi.fn(),
+  TerraDrawFreehandMode: vi.fn(),
+  TerraDrawSelectMode: vi.fn(),
+}));
+
+vi.mock('terra-draw-maplibre-gl-adapter', () => ({
+  TerraDrawMapLibreGLAdapter: vi.fn(),
+}));
+
+function fakeMap(): MaplibreMap {
+  return {
+    getStyle: () => ({ layers: [], sources: {} }),
+    removeLayer: vi.fn(),
+    removeSource: vi.fn(),
+  } as unknown as MaplibreMap;
+}
+
+afterEach(() => {
+  lastInstance = null;
+});
+
+describe('useTerraDraw — undo history bound (fix #1778)', () => {
+  it('caps history growth instead of retaining one snapshot per change event forever', () => {
+    const map = fakeMap();
+    const { result } = renderHook(() => useTerraDraw(map, vi.fn(), null));
+    const td = lastInstance!;
+
+    // Simulate a long drag/freehand trace: far more `change` events than the
+    // 50-entry cap, with no 'finish' in between (mirrors the reported class:
+    // one full store snapshot pushed per mousemove-derived update).
+    act(() => {
+      for (let i = 0; i < 200; i++) td.emit('change');
+    });
+
+    // Count how many undo steps are actually available. An unbounded ring
+    // would allow 199 undos (200 pushes); a ring capped at 50 allows at
+    // most 49.
+    let undoCount = 0;
+    while (result.current.canUndo && undoCount < 500) {
+      act(() => {
+        result.current.undo();
+      });
+      undoCount++;
+    }
+    expect(undoCount).toBeLessThanOrEqual(49);
+    expect(undoCount).toBeGreaterThan(0);
+  });
+
+  it('resets undo history on a committed feature edit (dragFeature), not just on draw/setMode/clear', () => {
+    const map = fakeMap();
+    const onEditFinish = vi.fn();
+    const { result } = renderHook(() => useTerraDraw(map, vi.fn(), onEditFinish));
+    const td = lastInstance!;
+
+    // Push enough 'change' snapshots (as if dragging a feature) to make undo available.
+    act(() => {
+      td.emit('change');
+      td.emit('change');
+    });
+    expect(result.current.canUndo).toBe(true);
+
+    // Commit the drag — this is the 'finish' event with a drag action, which
+    // previously reset nothing.
+    act(() => {
+      td.emit('finish', 'feat-1', { action: 'dragFeature', mode: 'select' });
+    });
+
+    expect(onEditFinish).toHaveBeenCalledWith('feat-1', expect.anything());
+    expect(result.current.canUndo).toBe(false);
+  });
+});

--- a/frontend/src/components/drawing/hooks/__tests__/use-terra-draw.undo-history.test.ts
+++ b/frontend/src/components/drawing/hooks/__tests__/use-terra-draw.undo-history.test.ts
@@ -450,3 +450,64 @@ describe('useTerraDraw — undo() re-selects the previously selected feature (fi
     expect(onSelectionLost).toHaveBeenCalledTimes(1);
   });
 });
+
+// fix(round5 #1795, P2): on the real selection path, addFeatures() and
+// draw.selectFeature() synchronously emit `change` events — without a
+// guard, the ring already holds those seed snapshots by the time
+// selectFeature() captures the session's baseline, so canUndo/isEditDirty
+// read as "dirty" right after just selecting a feature, before any actual
+// edit happened.
+describe('useTerraDraw — selecting a feature does not seed the undo ring (fix round5 #1795)', () => {
+  it('selecting a feature (which synchronously emits change, like the real selection path) leaves canUndo false and the ring empty', () => {
+    const map = fakeMap();
+    const { result } = renderHook(() => useTerraDraw(map, vi.fn(), null));
+    const td = lastInstance!;
+
+    // Simulate the real selection path: draw.selectFeature() synchronously
+    // fires a `change` event, same as terra-draw's actual select mode does.
+    td.getSnapshot.mockReturnValue([{ id: 'feat-1', properties: { mode: 'point', tag: 'seed' } }] as unknown[]);
+    td.selectFeature.mockImplementation(() => { td.emit('change'); });
+
+    act(() => {
+      result.current.selectFeature('feat-1');
+    });
+
+    expect(result.current.canUndo).toBe(false);
+    // The ring is truly empty, not "1 seed entry" masquerading as a real
+    // edit — a further undo() has nothing to restore.
+    act(() => {
+      result.current.undo();
+    });
+    expect(td.addFeatures).not.toHaveBeenCalled();
+  });
+
+  it('one drag after selection, then one undo: canUndo goes false and the drag is fully reverted to the true baseline', () => {
+    const map = fakeMap();
+    const onHistoryBaseline = vi.fn();
+    const { result } = renderHook(() => useTerraDraw(map, vi.fn(), null, onHistoryBaseline));
+    const td = lastInstance!;
+
+    const baselineSnapshot = [{ id: 'feat-1', properties: { mode: 'point', tag: 'baseline' } }] as unknown[];
+    td.getSnapshot.mockReturnValue(baselineSnapshot);
+    // Selection itself synchronously seeds a `change` event.
+    td.selectFeature.mockImplementation(() => { td.emit('change'); });
+    act(() => {
+      result.current.selectFeature('feat-1');
+    });
+    expect(result.current.canUndo).toBe(false);
+
+    // One drag.
+    td.selectFeature.mockImplementation(() => {});
+    td.getSnapshot.mockReturnValue([{ id: 'feat-1', properties: { mode: 'point', tag: 'dragged' } }] as unknown[]);
+    act(() => { td.emit('change'); });
+    expect(result.current.canUndo).toBe(true);
+
+    act(() => {
+      result.current.undo();
+    });
+
+    expect(result.current.canUndo).toBe(false);
+    expect(onHistoryBaseline).toHaveBeenCalledTimes(1);
+    expect(td.addFeatures).toHaveBeenCalledWith(baselineSnapshot);
+  });
+});

--- a/frontend/src/components/drawing/hooks/__tests__/use-terra-draw.undo-history.test.ts
+++ b/frontend/src/components/drawing/hooks/__tests__/use-terra-draw.undo-history.test.ts
@@ -96,7 +96,11 @@ describe('useTerraDraw — undo history bound (fix #1778)', () => {
     expect(undoCount).toBeGreaterThan(0);
   });
 
-  it('resets undo history on a committed feature edit (dragFeature), not just on draw/setMode/clear', () => {
+  // fix(round1 #1795, P2): a drag/vertex edit only marks the edit dirty
+  // (use-feature-editing's handleEditFinish) — it is not persisted until
+  // Save, so Undo must still be able to revert it. Resetting history right
+  // on 'finish' disabled Undo for a pending, unsaved edit.
+  it('keeps undo history available after a committed feature edit (dragFeature) finishes — Undo still reverts it', () => {
     const map = fakeMap();
     const onEditFinish = vi.fn();
     const { result } = renderHook(() => useTerraDraw(map, vi.fn(), onEditFinish));
@@ -109,13 +113,40 @@ describe('useTerraDraw — undo history bound (fix #1778)', () => {
     });
     expect(result.current.canUndo).toBe(true);
 
-    // Commit the drag — this is the 'finish' event with a drag action, which
-    // previously reset nothing.
+    // Commit the drag — this is the 'finish' event with a drag action.
     act(() => {
       td.emit('finish', 'feat-1', { action: 'dragFeature', mode: 'select' });
     });
 
     expect(onEditFinish).toHaveBeenCalledWith('feat-1', expect.anything());
+    // Undo is still enabled and can revert the just-finished drag.
+    expect(result.current.canUndo).toBe(true);
+    act(() => {
+      result.current.undo();
+    });
+    expect(td.clear).toHaveBeenCalled();
+    expect(td.addFeatures).toHaveBeenCalled();
+  });
+
+  // fix(round1 #1795, P2): the pending edit's history is discarded once it
+  // actually settles — save, cancel, or deselection — via the exposed
+  // resetHistory(), not by the hook itself reacting to 'finish'.
+  it('resetHistory() disables Undo once the caller settles the pending edit (e.g. after Save)', () => {
+    const map = fakeMap();
+    const onEditFinish = vi.fn();
+    const { result } = renderHook(() => useTerraDraw(map, vi.fn(), onEditFinish));
+    const td = lastInstance!;
+
+    act(() => {
+      td.emit('change');
+      td.emit('change');
+      td.emit('finish', 'feat-1', { action: 'dragFeature', mode: 'select' });
+    });
+    expect(result.current.canUndo).toBe(true);
+
+    act(() => {
+      result.current.resetHistory();
+    });
     expect(result.current.canUndo).toBe(false);
   });
 });

--- a/frontend/src/components/drawing/hooks/__tests__/use-terra-draw.undo-history.test.ts
+++ b/frontend/src/components/drawing/hooks/__tests__/use-terra-draw.undo-history.test.ts
@@ -150,3 +150,92 @@ describe('useTerraDraw — undo history bound (fix #1778)', () => {
     expect(result.current.canUndo).toBe(false);
   });
 });
+
+// fix(round2 #1795, P2): undo() reverts snapshots and updates canUndo, but
+// never touched isEditDirty — undoing all the way back to the original
+// geometry still triggered the unsaved-changes confirmation on Cancel/Done/
+// mode-switch. onHistoryBaseline is the signal the editing layer uses to
+// clear isEditDirty at exactly the right moment.
+describe('useTerraDraw — onHistoryBaseline (fix round2 #1795)', () => {
+  it('fires onHistoryBaseline only on the undo() call that pops the ring back to its earliest snapshot', () => {
+    const map = fakeMap();
+    const onHistoryBaseline = vi.fn();
+    const { result } = renderHook(() => useTerraDraw(map, vi.fn(), null, onHistoryBaseline));
+    const td = lastInstance!;
+
+    // Three snapshots recorded (ring length 3): two undos are available.
+    act(() => {
+      td.emit('change');
+      td.emit('change');
+      td.emit('change');
+    });
+    expect(result.current.canUndo).toBe(true);
+
+    // First undo: ring still has more than one entry left — not at baseline yet.
+    act(() => {
+      result.current.undo();
+    });
+    expect(onHistoryBaseline).not.toHaveBeenCalled();
+    expect(result.current.canUndo).toBe(true);
+
+    // Second undo: ring collapses to its earliest entry — baseline reached.
+    act(() => {
+      result.current.undo();
+    });
+    expect(onHistoryBaseline).toHaveBeenCalledTimes(1);
+    expect(result.current.canUndo).toBe(false);
+  });
+
+  it('does NOT fire onHistoryBaseline from resetHistory(), clear(), or setMode() — only from undo()', () => {
+    const map = fakeMap();
+    const onHistoryBaseline = vi.fn();
+    const { result } = renderHook(() => useTerraDraw(map, vi.fn(), null, onHistoryBaseline));
+    const td = lastInstance!;
+
+    act(() => {
+      td.emit('change');
+      td.emit('change');
+    });
+    expect(result.current.canUndo).toBe(true);
+
+    act(() => {
+      result.current.resetHistory();
+    });
+    expect(onHistoryBaseline).not.toHaveBeenCalled();
+
+    act(() => {
+      td.emit('change');
+      td.emit('change');
+    });
+    act(() => {
+      result.current.clear();
+    });
+    expect(onHistoryBaseline).not.toHaveBeenCalled();
+
+    act(() => {
+      td.emit('change');
+      td.emit('change');
+    });
+    act(() => {
+      result.current.setMode('point');
+    });
+    expect(onHistoryBaseline).not.toHaveBeenCalled();
+  });
+
+  it('an undo() call while already at baseline (no-op) does not re-fire onHistoryBaseline', () => {
+    const map = fakeMap();
+    const onHistoryBaseline = vi.fn();
+    const { result } = renderHook(() => useTerraDraw(map, vi.fn(), null, onHistoryBaseline));
+    const td = lastInstance!;
+
+    act(() => {
+      td.emit('change');
+    });
+    expect(result.current.canUndo).toBe(false); // one snapshot only — already at baseline
+
+    act(() => {
+      result.current.undo(); // guarded no-op: historyRef.length <= 1
+    });
+    expect(onHistoryBaseline).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/drawing/hooks/use-terra-draw.ts
+++ b/frontend/src/components/drawing/hooks/use-terra-draw.ts
@@ -259,6 +259,12 @@ export function isMultiPartGeometry(geometry: Geometry): boolean {
  *   geometry is once again whatever was there when the ring started, so
  *   there is nothing pending to confirm away on Cancel/Done/mode-switch. A
  *   subsequent edit re-dirties normally via onEditFinish.
+ * @param onSelectionLost - fix(round4 #1795): callback invoked when undo()
+ *   restores a snapshot that no longer contains the feature that was
+ *   selected before the undo (the rebuilt canvas has nothing left to
+ *   re-select). The editing layer uses this to clear its own selection
+ *   state, so it does not keep showing a feature as selected that Terra
+ *   Draw no longer has.
  * @returns setMode, stop, isReady, and feature manipulation methods
  */
 export function useTerraDraw(
@@ -266,6 +272,7 @@ export function useTerraDraw(
   onFinish: (feature: Feature) => void,
   onEditFinish: ((tdId: string, feature: Feature) => void) | null = null,
   onHistoryBaseline?: () => void,
+  onSelectionLost?: (id: string | number) => void,
 ): {
   setMode: (mode: string) => void;
   stop: () => void;
@@ -292,6 +299,9 @@ export function useTerraDraw(
   const onHistoryBaselineRef = useRef(onHistoryBaseline);
   onHistoryBaselineRef.current = onHistoryBaseline;
 
+  const onSelectionLostRef = useRef(onSelectionLost);
+  onSelectionLostRef.current = onSelectionLost;
+
   // Track the current Terra Draw instance
   const drawRef = useRef<TerraDraw | null>(null);
 
@@ -303,6 +313,12 @@ export function useTerraDraw(
   // this session" — undo() must never report reaching baseline in that
   // case (see undo() below).
   const baselineRef = useRef<GeoJSONStoreFeatures<GeoJSONStoreGeometries>[] | null>(null);
+  // fix(round4 #1795): the id of whatever feature the app most recently
+  // selected via selectFeature() below. Restoring a snapshot in undo()
+  // calls draw.clear() first, which drops Terra Draw's own select-mode
+  // state and edit handles — this ref is how undo() knows what to
+  // re-select afterward. null means "nothing selected for this session."
+  const selectedFeatureIdRef = useRef<string | number | null>(null);
   const isRestoringRef = useRef(false);
   const [canUndo, setCanUndo] = useState(false);
 
@@ -369,6 +385,9 @@ export function useTerraDraw(
         // fix(round3 #1795): the committed feature's session is over — its
         // baseline snapshot is no longer meaningful.
         baselineRef.current = null;
+        // fix(round4 #1795): a fresh-draw session has no "selected existing
+        // feature" concept in the first place, but clear defensively.
+        selectedFeatureIdRef.current = null;
       } else if (
         context.action === 'dragFeature' ||
         context.action === 'dragCoordinate' ||
@@ -428,6 +447,8 @@ export function useTerraDraw(
       // capture its baseline (the canvas as setMode left it) OUTSIDE the
       // bounded ring so it survives eviction later in this session.
       baselineRef.current = filteredSnapshot(draw);
+      // fix(round4 #1795): a mode switch ends whatever selection preceded it.
+      selectedFeatureIdRef.current = null;
     },
     [draw],
   );
@@ -462,6 +483,10 @@ export function useTerraDraw(
       // bounded ring, so a long drag that later evicts the ring's oldest
       // entries can still undo all the way back to it.
       baselineRef.current = filteredSnapshot(draw);
+      // fix(round4 #1795): remember what's selected so undo()'s restoring
+      // draw.clear() (which drops Terra Draw's select-mode state and edit
+      // handles) can re-select it afterward.
+      selectedFeatureIdRef.current = id;
     },
     [draw],
   );
@@ -487,15 +512,39 @@ export function useTerraDraw(
     // already have been evicted by the MAX_UNDO_HISTORY cap — so the
     // correct "one step further back" state is the TRUE pre-edit baseline
     // captured outside the ring, not an assumption that the ring's start
-    // IS the baseline.
+    // IS the baseline. Both the ring-internal step and this baseline
+    // fallback flow through the SAME restoration below, so the re-select
+    // fix(round4 #1795) just below covers both.
     const prev = historyRef.current.length > 0
       ? historyRef.current[historyRef.current.length - 1]
       : baselineRef.current;
+
+    // fix(round4 #1795): preserve the selected feature's id BEFORE
+    // draw.clear() below drops Terra Draw's select-mode state and edit
+    // handles — otherwise the app's own selection store still shows the
+    // feature selected, but Terra Draw no longer has it selected and the
+    // user has to click the geometry again before dragging or editing
+    // vertices.
+    const selectedId = selectedFeatureIdRef.current;
 
     isRestoringRef.current = true;
     draw.clear();
     if (prev && prev.length > 0) {
       draw.addFeatures(prev);
+    }
+    // fix(round4 #1795): re-select only if that id is still present in the
+    // restored features. Call draw.selectFeature() directly (not this
+    // hook's own selectFeature() wrapper above) — that wrapper also
+    // captures a NEW baseline and would overwrite the one this undo just
+    // fell back to.
+    if (selectedId != null && prev?.some((f) => f.id === selectedId)) {
+      draw.selectFeature(selectedId);
+    } else if (selectedId != null) {
+      // The previously selected feature no longer exists in the restored
+      // snapshot — clear our own record and tell the editing layer so its
+      // selection store agrees with what Terra Draw actually has.
+      selectedFeatureIdRef.current = null;
+      onSelectionLostRef.current?.(selectedId);
     }
     // Defer flag reset so any synchronous or microtask change events are still suppressed
     queueMicrotask(() => {
@@ -525,6 +574,8 @@ export function useTerraDraw(
     setCanUndo(false);
     // fix(round3 #1795): the session this baseline belonged to is over.
     baselineRef.current = null;
+    // fix(round4 #1795): draw.clear() above already removed it from the canvas.
+    selectedFeatureIdRef.current = null;
   }, [draw]);
 
   // fix(round1 #1795): the undo ring reset a caller asks for WITHOUT
@@ -537,6 +588,10 @@ export function useTerraDraw(
     // fix(round3 #1795): the session this baseline belonged to has settled
     // (save/cancel/deselection) — clear it alongside the ring.
     baselineRef.current = null;
+    // fix(round4 #1795): the caller (save/cancel/deselection) already owns
+    // clearing its own selection store — this just keeps our own record in
+    // sync so a stale id never survives into a later session.
+    selectedFeatureIdRef.current = null;
   }, []);
 
   return {

--- a/frontend/src/components/drawing/hooks/use-terra-draw.ts
+++ b/frontend/src/components/drawing/hooks/use-terra-draw.ts
@@ -320,6 +320,13 @@ export function useTerraDraw(
   // re-select afterward. null means "nothing selected for this session."
   const selectedFeatureIdRef = useRef<string | number | null>(null);
   const isRestoringRef = useRef(false);
+  // fix(round5 #1795): on the real selection path, addFeatures() and
+  // draw.selectFeature() synchronously emit `change` events — without this
+  // guard, the ring already holds those seed snapshots by the time
+  // selectFeature() below captures the session's baseline, so Undo reads as
+  // available (and isEditDirty stays set) right after just selecting a
+  // feature, before any actual edit happened.
+  const isSeedingSessionRef = useRef(false);
   const [canUndo, setCanUndo] = useState(false);
 
   // State to trigger re-render when draw instance is ready
@@ -416,7 +423,7 @@ export function useTerraDraw(
     if (!draw) return;
 
     const handler = () => {
-      if (isRestoringRef.current) return;
+      if (isRestoringRef.current || isSeedingSessionRef.current) return;
 
       const snapshot = filteredSnapshot(draw);
       historyRef.current.push(snapshot);
@@ -477,7 +484,13 @@ export function useTerraDraw(
   const selectFeature = useCallback(
     (id: string) => {
       if (!draw?.enabled) return;
+      // fix(round5 #1795): draw.selectFeature() synchronously emits its own
+      // `change` event (select-mode entering/decorating the feature) —
+      // suppress the ring listener for it so this seed event is never
+      // recorded at all.
+      isSeedingSessionRef.current = true;
       draw.selectFeature(id);
+      isSeedingSessionRef.current = false;
       // fix(round3 #1795): selecting an existing feature starts its edit
       // session — capture the TRUE pre-edit snapshot now, outside the
       // bounded ring, so a long drag that later evicts the ring's oldest
@@ -487,6 +500,17 @@ export function useTerraDraw(
       // draw.clear() (which drops Terra Draw's select-mode state and edit
       // handles) can re-select it afterward.
       selectedFeatureIdRef.current = id;
+      // fix(round5 #1795): unconditionally clear the ring here too — on the
+      // REAL selection path, the app calls addFeatures() (to load the
+      // existing feature onto the canvas) BEFORE calling this selectFeature(),
+      // and that addFeatures() call ALSO synchronously emits `change`,
+      // outside the guard above since it runs before this function does.
+      // Clearing here retroactively wipes out any such seed snapshots, so
+      // an edit session starts with Undo disabled and an empty ring, not
+      // "already dirty" from events that happened before anything was
+      // actually edited.
+      historyRef.current = [];
+      setCanUndo(false);
     },
     [draw],
   );

--- a/frontend/src/components/drawing/hooks/use-terra-draw.ts
+++ b/frontend/src/components/drawing/hooks/use-terra-draw.ts
@@ -21,6 +21,30 @@ import { MAP_COLORS } from '@/lib/map-colors';
 const MAX_UNDO_HISTORY = 50;
 
 /**
+ * fix(round3 #1795): the single filtered-snapshot reader shared by the
+ * `change` handler (ring entries) and the baseline capture points below —
+ * 'select'/'static' entries are select-mode's own UI decoration (selection
+ * handles), not the geometry being edited.
+ */
+function filteredSnapshot(
+  draw: TerraDraw,
+): GeoJSONStoreFeatures<GeoJSONStoreGeometries>[] {
+  return draw.getSnapshot().filter(
+    (f) => !['select', 'static'].includes(f.properties?.mode as string),
+  );
+}
+
+/**
+ * fix(round3 #1795): whether a further undo step exists. Normally true
+ * while the ring holds more than one entry; once only the ring's OLDEST
+ * entry remains, a further step exists only if a true pre-edit baseline was
+ * captured to fall back to — otherwise this is as far back as we can go.
+ */
+function canUndoFrom(ringLength: number, hasBaseline: boolean): boolean {
+  return ringLength > 1 || (ringLength === 1 && hasBaseline);
+}
+
+/**
  * Create fresh Terra Draw mode instances. Must be called per-mount because
  * TerraDraw internally registers modes on construction — reusing mode objects
  * across mounts (e.g. after error boundary recovery) causes
@@ -273,6 +297,12 @@ export function useTerraDraw(
 
   // Undo history state
   const historyRef = useRef<GeoJSONStoreFeatures<GeoJSONStoreGeometries>[][]>([]);
+  // fix(round3 #1795): the TRUE pre-edit snapshot, held OUTSIDE the bounded
+  // ring so it survives eviction once a long drag pushes past
+  // MAX_UNDO_HISTORY change events. null means "no baseline captured for
+  // this session" — undo() must never report reaching baseline in that
+  // case (see undo() below).
+  const baselineRef = useRef<GeoJSONStoreFeatures<GeoJSONStoreGeometries>[] | null>(null);
   const isRestoringRef = useRef(false);
   const [canUndo, setCanUndo] = useState(false);
 
@@ -336,6 +366,9 @@ export function useTerraDraw(
         // Reset undo history — the feature was committed, not an in-progress sketch
         historyRef.current = [];
         setCanUndo(false);
+        // fix(round3 #1795): the committed feature's session is over — its
+        // baseline snapshot is no longer meaningful.
+        baselineRef.current = null;
       } else if (
         context.action === 'dragFeature' ||
         context.action === 'dragCoordinate' ||
@@ -366,16 +399,16 @@ export function useTerraDraw(
     const handler = () => {
       if (isRestoringRef.current) return;
 
-      const snapshot = draw.getSnapshot().filter(
-        (f) => !['select', 'static'].includes(f.properties?.mode as string),
-      );
+      const snapshot = filteredSnapshot(draw);
       historyRef.current.push(snapshot);
       // fix(#1778): drop the oldest entry once the ring exceeds its cap —
       // still enough undo depth for normal use, without unbounded growth.
+      // fix(round3 #1795): the true pre-edit baseline lives in baselineRef,
+      // OUTSIDE this ring, so eviction here never loses it.
       if (historyRef.current.length > MAX_UNDO_HISTORY) {
         historyRef.current.shift();
       }
-      setCanUndo(historyRef.current.length > 1);
+      setCanUndo(canUndoFrom(historyRef.current.length, baselineRef.current !== null));
     };
 
     draw.on('change', handler);
@@ -391,6 +424,10 @@ export function useTerraDraw(
       // Reset undo history on mode change to prevent cross-mode undo
       historyRef.current = [];
       setCanUndo(false);
+      // fix(round3 #1795): a mode switch starts a fresh edit/draw session —
+      // capture its baseline (the canvas as setMode left it) OUTSIDE the
+      // bounded ring so it survives eviction later in this session.
+      baselineRef.current = filteredSnapshot(draw);
     },
     [draw],
   );
@@ -420,6 +457,11 @@ export function useTerraDraw(
     (id: string) => {
       if (!draw?.enabled) return;
       draw.selectFeature(id);
+      // fix(round3 #1795): selecting an existing feature starts its edit
+      // session — capture the TRUE pre-edit snapshot now, outside the
+      // bounded ring, so a long drag that later evicts the ring's oldest
+      // entries can still undo all the way back to it.
+      baselineRef.current = filteredSnapshot(draw);
     },
     [draw],
   );
@@ -432,13 +474,23 @@ export function useTerraDraw(
   );
 
   const undo = useCallback(() => {
-    if (!draw?.enabled || historyRef.current.length <= 1) return;
+    if (!draw?.enabled) return;
+    const hasBaseline = baselineRef.current !== null;
+    if (!canUndoFrom(historyRef.current.length, hasBaseline)) return;
 
-    // Pop the current state
+    // Pop the current (top) state off the ring.
     historyRef.current.pop();
 
-    // Get the previous state
-    const prev = historyRef.current[historyRef.current.length - 1];
+    // fix(round3 #1795): what we restore. If the ring still holds an
+    // entry, that's the previous intermediate state, same as before. If
+    // popping just emptied the ring, the ring's own oldest entry may
+    // already have been evicted by the MAX_UNDO_HISTORY cap — so the
+    // correct "one step further back" state is the TRUE pre-edit baseline
+    // captured outside the ring, not an assumption that the ring's start
+    // IS the baseline.
+    const prev = historyRef.current.length > 0
+      ? historyRef.current[historyRef.current.length - 1]
+      : baselineRef.current;
 
     isRestoringRef.current = true;
     draw.clear();
@@ -450,14 +502,18 @@ export function useTerraDraw(
       isRestoringRef.current = false;
     });
 
-    const atBaseline = historyRef.current.length <= 1;
-    setCanUndo(!atBaseline);
-    // fix(round2 #1795): signal the ring has been popped all the way back to
-    // its earliest recorded snapshot BY UNDO (as opposed to a
-    // draw/setMode/clear/resetHistory reset) — the editing layer uses this
-    // to clear isEditDirty, since the displayed geometry is once again
-    // whatever was there when the ring started.
-    if (atBaseline) {
+    // fix(round3 #1795): we are AT the true baseline only when the ring is
+    // now empty AND a baseline was actually captured for this session — a
+    // ring merely reaching length 0 with no captured baseline (or, before
+    // this fix, just reaching length <= 1) is NOT a verified return to the
+    // original pre-edit geometry, so it must never report baseline.
+    const atTrueBaseline = historyRef.current.length === 0 && hasBaseline;
+    setCanUndo(canUndoFrom(historyRef.current.length, hasBaseline));
+    // fix(round2 #1795): signal a verified return to the true pre-edit
+    // snapshot — the editing layer uses this to clear isEditDirty, since
+    // the displayed geometry is once again whatever was there before this
+    // edit session started.
+    if (atTrueBaseline) {
       onHistoryBaselineRef.current?.();
     }
   }, [draw]);
@@ -467,6 +523,8 @@ export function useTerraDraw(
     draw.clear();
     historyRef.current = [];
     setCanUndo(false);
+    // fix(round3 #1795): the session this baseline belonged to is over.
+    baselineRef.current = null;
   }, [draw]);
 
   // fix(round1 #1795): the undo ring reset a caller asks for WITHOUT
@@ -476,6 +534,9 @@ export function useTerraDraw(
   const resetHistory = useCallback(() => {
     historyRef.current = [];
     setCanUndo(false);
+    // fix(round3 #1795): the session this baseline belonged to has settled
+    // (save/cancel/deselection) — clear it alongside the ring.
+    baselineRef.current = null;
   }, []);
 
   return {

--- a/frontend/src/components/drawing/hooks/use-terra-draw.ts
+++ b/frontend/src/components/drawing/hooks/use-terra-draw.ts
@@ -227,12 +227,21 @@ export function isMultiPartGeometry(geometry: Geometry): boolean {
  * @param map - MapLibre map instance (null until map loads)
  * @param onFinish - callback invoked with the completed GeoJSON Feature after draw
  * @param onEditFinish - callback invoked with tdId and feature after edit (drag/vertex), null when not in editing context
+ * @param onHistoryBaseline - fix(round2 #1795): callback invoked when undo()
+ *   pops the ring back down to its earliest recorded snapshot (canUndo
+ *   transitions to false AS A RESULT OF an undo() call, not of a
+ *   draw/setMode/clear/resetHistory reset). The editing layer uses this to
+ *   clear isEditDirty — undoing all the way back means the displayed
+ *   geometry is once again whatever was there when the ring started, so
+ *   there is nothing pending to confirm away on Cancel/Done/mode-switch. A
+ *   subsequent edit re-dirties normally via onEditFinish.
  * @returns setMode, stop, isReady, and feature manipulation methods
  */
 export function useTerraDraw(
   map: MaplibreMap | null,
   onFinish: (feature: Feature) => void,
   onEditFinish: ((tdId: string, feature: Feature) => void) | null = null,
+  onHistoryBaseline?: () => void,
 ): {
   setMode: (mode: string) => void;
   stop: () => void;
@@ -255,6 +264,9 @@ export function useTerraDraw(
 
   const onEditFinishRef = useRef(onEditFinish);
   onEditFinishRef.current = onEditFinish;
+
+  const onHistoryBaselineRef = useRef(onHistoryBaseline);
+  onHistoryBaselineRef.current = onHistoryBaseline;
 
   // Track the current Terra Draw instance
   const drawRef = useRef<TerraDraw | null>(null);
@@ -438,7 +450,16 @@ export function useTerraDraw(
       isRestoringRef.current = false;
     });
 
-    setCanUndo(historyRef.current.length > 1);
+    const atBaseline = historyRef.current.length <= 1;
+    setCanUndo(!atBaseline);
+    // fix(round2 #1795): signal the ring has been popped all the way back to
+    // its earliest recorded snapshot BY UNDO (as opposed to a
+    // draw/setMode/clear/resetHistory reset) — the editing layer uses this
+    // to clear isEditDirty, since the displayed geometry is once again
+    // whatever was there when the ring started.
+    if (atBaseline) {
+      onHistoryBaselineRef.current?.();
+    }
   }, [draw]);
 
   const clear = useCallback(() => {

--- a/frontend/src/components/drawing/hooks/use-terra-draw.ts
+++ b/frontend/src/components/drawing/hooks/use-terra-draw.ts
@@ -244,6 +244,10 @@ export function useTerraDraw(
   clear: () => void;
   undo: () => void;
   canUndo: boolean;
+  /** fix(round1 #1795): reset the undo ring without touching the canvas —
+   *  callers own WHEN a pending edit's history should be discarded (save,
+   *  cancel, deselection), not this hook (see resetHistory below). */
+  resetHistory: () => void;
 } {
   // Use refs to avoid stale closures in event listeners
   const onFinishRef = useRef(onFinish);
@@ -325,13 +329,14 @@ export function useTerraDraw(
         context.action === 'dragCoordinate' ||
         context.action === 'dragCoordinateResize'
       ) {
-        // Existing feature edited — pass to onEditFinish, keep on canvas
+        // Existing feature edited — pass to onEditFinish, keep on canvas.
+        // fix(round1 #1795): do NOT reset history here. A drag/vertex edit
+        // only marks the edit dirty (use-feature-editing's handleEditFinish)
+        // — it is not persisted until Save, so Undo must still be able to
+        // revert it. History resets when the pending edit actually settles:
+        // on save (handleSaveEdit) or on cancel/deselection (performDeselect),
+        // both of which call the resetHistory() this hook now exposes.
         onEditFinishRef.current?.(String(id), feature as Feature);
-        // fix(#1778): reset undo history on a committed edit, same as the
-        // 'draw' branch above — otherwise history keeps accumulating for the
-        // whole select-mode editing session instead of resetting per edit.
-        historyRef.current = [];
-        setCanUndo(false);
       }
     };
 
@@ -443,6 +448,15 @@ export function useTerraDraw(
     setCanUndo(false);
   }, [draw]);
 
+  // fix(round1 #1795): the undo ring reset a caller asks for WITHOUT
+  // touching the drawn canvas — clear() above removes features too, which
+  // save/cancel/deselection do themselves (via removeFeatures) before or
+  // instead of calling this.
+  const resetHistory = useCallback(() => {
+    historyRef.current = [];
+    setCanUndo(false);
+  }, []);
+
   return {
     setMode,
     stop,
@@ -454,5 +468,6 @@ export function useTerraDraw(
     clear,
     undo,
     canUndo,
+    resetHistory,
   };
 }

--- a/frontend/src/components/drawing/hooks/use-terra-draw.ts
+++ b/frontend/src/components/drawing/hooks/use-terra-draw.ts
@@ -15,6 +15,11 @@ import type { Map as MaplibreMap } from 'maplibre-gl';
 import type { Feature, Geometry } from 'geojson';
 import { MAP_COLORS } from '@/lib/map-colors';
 
+// fix(#1778): bound the undo ring so a long drag/freehand trace (one full
+// store snapshot per `change` event, with no prior cap) cannot grow memory
+// without limit for the duration of a single editing session.
+const MAX_UNDO_HISTORY = 50;
+
 /**
  * Create fresh Terra Draw mode instances. Must be called per-mount because
  * TerraDraw internally registers modes on construction — reusing mode objects
@@ -322,6 +327,11 @@ export function useTerraDraw(
       ) {
         // Existing feature edited — pass to onEditFinish, keep on canvas
         onEditFinishRef.current?.(String(id), feature as Feature);
+        // fix(#1778): reset undo history on a committed edit, same as the
+        // 'draw' branch above — otherwise history keeps accumulating for the
+        // whole select-mode editing session instead of resetting per edit.
+        historyRef.current = [];
+        setCanUndo(false);
       }
     };
 
@@ -343,6 +353,11 @@ export function useTerraDraw(
         (f) => !['select', 'static'].includes(f.properties?.mode as string),
       );
       historyRef.current.push(snapshot);
+      // fix(#1778): drop the oldest entry once the ring exceeds its cap —
+      // still enough undo depth for normal use, without unbounded growth.
+      if (historyRef.current.length > MAX_UNDO_HISTORY) {
+        historyRef.current.shift();
+      }
       setCanUndo(historyRef.current.length > 1);
     };
 

--- a/frontend/src/components/search/BboxMapPicker.tsx
+++ b/frontend/src/components/search/BboxMapPicker.tsx
@@ -6,7 +6,12 @@ import type { Map as MaplibreMap } from 'maplibre-gl';
 import { useTranslation } from 'react-i18next';
 import { useTheme } from '@/components/theme-provider';
 import { useBasemaps } from '@/hooks/use-settings';
-import { getThemeBasemap, toMaplibreStyle } from '@/lib/basemap-utils';
+import {
+  getThemeBasemap,
+  toMaplibreStyle,
+  FALLBACK_BASEMAP_STYLE_URL,
+  FALLBACK_BASEMAP_STYLE_URL_DARK,
+} from '@/lib/basemap-utils';
 import { MAP_COLORS } from '@/lib/map-colors';
 import 'maplibre-gl/dist/maplibre-gl.css';
 // feat(#846): wires maplibre v6's worker URL. Side-effect import, kept out of
@@ -29,9 +34,7 @@ export function BboxMapPicker({ onBboxSelected }: BboxMapPickerProps) {
     const themeBasemap = getThemeBasemap(basemaps ?? [], resolvedTheme);
     if (themeBasemap) return toMaplibreStyle(themeBasemap.url, themeBasemap.attribution);
     return toMaplibreStyle(
-      resolvedTheme === 'dark'
-        ? 'https://tiles.openfreemap.org/styles/dark'
-        : 'https://tiles.openfreemap.org/styles/positron',
+      resolvedTheme === 'dark' ? FALLBACK_BASEMAP_STYLE_URL_DARK : FALLBACK_BASEMAP_STYLE_URL,
     );
   }, [basemaps, resolvedTheme]);
 

--- a/frontend/src/components/search/SpatialFilterPanel.tsx
+++ b/frontend/src/components/search/SpatialFilterPanel.tsx
@@ -21,7 +21,12 @@ import {
 import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
 import { useTheme } from '@/components/theme-provider';
 import { useBasemaps } from '@/hooks/use-settings';
-import { getThemeBasemap, toMaplibreStyle } from '@/lib/basemap-utils';
+import {
+  getThemeBasemap,
+  toMaplibreStyle,
+  FALLBACK_BASEMAP_STYLE_URL,
+  FALLBACK_BASEMAP_STYLE_URL_DARK,
+} from '@/lib/basemap-utils';
 import { MAP_COLORS } from '@/lib/map-colors';
 import 'maplibre-gl/dist/maplibre-gl.css';
 // feat(#846): wires maplibre v6's worker URL. Side-effect import, kept out of
@@ -110,9 +115,7 @@ export function SpatialFilterPanel({
     const themeBasemap = getThemeBasemap(basemaps ?? [], resolvedTheme);
     if (themeBasemap) return toMaplibreStyle(themeBasemap.url, themeBasemap.attribution);
     return toMaplibreStyle(
-      resolvedTheme === 'dark'
-        ? 'https://tiles.openfreemap.org/styles/dark'
-        : 'https://tiles.openfreemap.org/styles/positron',
+      resolvedTheme === 'dark' ? FALLBACK_BASEMAP_STYLE_URL_DARK : FALLBACK_BASEMAP_STYLE_URL,
     );
   }, [basemaps, resolvedTheme]);
 

--- a/frontend/src/components/viewer/ViewerMap.tsx
+++ b/frontend/src/components/viewer/ViewerMap.tsx
@@ -10,6 +10,7 @@ import {
   toMaplibreStyle,
   resolveBasemapId,
   BLANK_BASEMAP_ID,
+  FALLBACK_BASEMAP_STYLE_URL,
 } from '@/lib/basemap-utils';
 import { buildClusterTileUrl, buildSignedTileUrl, buildTileTransformRequest, getMvtSourceLayerName, isMvtSourceLayerConfigReady, isThirdPartyTileUrl, refreshRasterTileSources, resolveTileBaseUrl } from '@/lib/tile-utils';
 import { useRemoteBasemapStyle } from '@/components/map/hooks/use-remote-basemap-style';
@@ -308,7 +309,9 @@ export const ViewerMap = memo(function ViewerMap({
   const effectiveBasemap = isBlank
     ? undefined
     : findBasemapById(basemaps ?? [], basemapStyle);
-  const fallbackUrl = 'https://basemaps.cartocdn.com/gl/positron-gl-style/style.json';
+  // fix(#1778): was a lone CARTO fallback with no attribution string; every
+  // other map surface falls back to OpenFreeMap.
+  const fallbackUrl = FALLBACK_BASEMAP_STYLE_URL;
   const styleValue = useMemo(
     // chore(#835): pass the basemap's configured attribution through, matching
     // BuilderMap/DatasetMap — the viewer (the public surface where attribution

--- a/frontend/src/lib/__tests__/basemap-utils.test.ts
+++ b/frontend/src/lib/__tests__/basemap-utils.test.ts
@@ -15,6 +15,8 @@ import {
   LIGHT_PRESET_ID,
   DARK_PRESET_ID,
   BLANK_BASEMAP_ID,
+  FALLBACK_BASEMAP_STYLE_URL,
+  FALLBACK_BASEMAP_STYLE_URL_DARK,
 } from '../basemap-utils';
 import type { BasemapEntry } from '@/api/settings';
 
@@ -479,6 +481,15 @@ describe('preset IDs', () => {
 
   it('DARK_PRESET_ID is openfreemap-dark', () => {
     expect(DARK_PRESET_ID).toBe('openfreemap-dark');
+  });
+});
+
+// fix(#1778): every map surface must fall back to the same basemap provider.
+// ViewerMap previously hardcoded a CARTO style URL no other surface used.
+describe('FALLBACK_BASEMAP_STYLE_URL', () => {
+  it('is the shared OpenFreeMap style, not a vendor-specific URL', () => {
+    expect(FALLBACK_BASEMAP_STYLE_URL).toBe('https://tiles.openfreemap.org/styles/positron');
+    expect(FALLBACK_BASEMAP_STYLE_URL_DARK).toBe('https://tiles.openfreemap.org/styles/dark');
   });
 });
 

--- a/frontend/src/lib/__tests__/tile-utils.test.ts
+++ b/frontend/src/lib/__tests__/tile-utils.test.ts
@@ -345,6 +345,26 @@ describe('buildTileTransformRequest', () => {
     });
   });
 
+  it('sends no Bearer header for raster tiles on the embed viewer surface, even with no embedToken (fix #1778)', () => {
+    useAuthStore.setState({ token: 'jwt-abc' });
+    const originalLocation = window.location;
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: { ...originalLocation, pathname: '/m/share-123', search: '?embed=true' },
+    });
+    try {
+      const transform = buildTileTransformRequest();
+      expect(transform('/raster-tiles/ds-1/tiles/1/2/3.png')).toEqual({
+        url: `${window.location.origin}/raster-tiles/ds-1/tiles/1/2/3.png`,
+      });
+    } finally {
+      Object.defineProperty(window, 'location', {
+        configurable: true,
+        value: originalLocation,
+      });
+    }
+  });
+
   it('honors a late-arriving CDN config through getTileConfig', () => {
     const config: { cdn_base_url: string | null } = { cdn_base_url: null };
     const transform = buildTileTransformRequest({

--- a/frontend/src/lib/basemap-utils.ts
+++ b/frontend/src/lib/basemap-utils.ts
@@ -101,6 +101,15 @@ const RELIEF_PALETTE: Record<
 /** Fallback glyphs for inline styles (raster basemaps) so text labels render. */
 const FALLBACK_GLYPHS = 'https://tiles.openfreemap.org/fonts/{fontstack}/{range}.pbf';
 
+/**
+ * fix(#1778): the shared basemap-style fallback, used whenever the basemap
+ * list has not loaded yet or a configured id fails to resolve. Every map
+ * surface must fall back to the same provider — ViewerMap previously fell
+ * back to a CARTO style no other surface touches, with no attribution.
+ */
+export const FALLBACK_BASEMAP_STYLE_URL = 'https://tiles.openfreemap.org/styles/positron';
+export const FALLBACK_BASEMAP_STYLE_URL_DARK = 'https://tiles.openfreemap.org/styles/dark';
+
 const BLANK_THUMBNAIL = `data:image/svg+xml,${encodeURIComponent(
   '<svg xmlns="http://www.w3.org/2000/svg" width="160" height="160" viewBox="0 0 160 160">' +
   '<rect fill="#f3f4f6" width="160" height="160" rx="8" stroke="#d1d5db" stroke-width="2" stroke-dasharray="8 4"/>' +

--- a/frontend/src/lib/report/__tests__/redact.test.ts
+++ b/frontend/src/lib/report/__tests__/redact.test.ts
@@ -53,6 +53,12 @@ describe('redact', () => {
     expect(out).toContain('/m/[redacted]');
   });
 
+  it('strips the raw embed token query param (fix #1778)', () => {
+    const out = redact('https://geolens.io/m/2fXkR9m3pL8qW4vN7tY?embed=true&et=et_9abf3c1d2e5f6071');
+    expect(out).not.toContain('et_9abf3c1d2e5f6071');
+    expect(out).toContain('et=[redacted]');
+  });
+
   it('does not redact the /maps/:id builder route', () => {
     expect(redact('https://geolens.io/maps/42')).toContain('/maps/42');
   });

--- a/frontend/src/lib/report/redact.ts
+++ b/frontend/src/lib/report/redact.ts
@@ -38,6 +38,12 @@ const SENSITIVE_KEYS = [
   'phpsessid',
   'sid',
   'cookie',
+  // fix(#1778): the embed viewer's `et=` query param (embed-tokens/service.py
+  // mints `et_<token>`, not JWT-shaped, so the eyJ… rule misses it). The `\b`
+  // anchor above keeps this two-letter key from matching inside words like
+  // `target` or `street`.
+  'et',
+  'embed_token',
 ].join('|');
 
 const RULES: RedactionRule[] = [

--- a/frontend/src/lib/tile-utils.ts
+++ b/frontend/src/lib/tile-utils.ts
@@ -1,4 +1,5 @@
 import { getEnvConfig } from '@/lib/env';
+import { isEmbedViewer } from '@/lib/embed-context';
 import { useAuthStore } from '@/stores/auth-store';
 
 /**
@@ -67,7 +68,10 @@ export interface TileTransformRequestOptions {
  *   (fix(#394) SH-02/B-022: the header is a credential — never send it to
  *   third-party basemap sprite/glyph/tile CDNs),
  * - otherwise `Authorization: Bearer <jwt>` on first-party `/raster-tiles/`
- *   requests (raster tiles carry no signed URL, unlike vector tiles — #819).
+ *   requests (raster tiles carry no signed URL, unlike vector tiles — #819),
+ *   except on the embed viewer surface (fix(#1778): `isEmbedViewer()` stays
+ *   out of the signed-in session entirely, so a raster tile must never carry
+ *   the viewer's own JWT even when no `embedToken` was supplied).
  *
  * NOTE (react-maplibre v8): the `transformRequest` PROP is ignored after
  * mount — each map must wire this via `onLoad` + `map.setTransformRequest()`.
@@ -87,7 +91,11 @@ export function buildTileTransformRequest(
     const headers: Record<string, string> = {};
     if (options.embedToken && !isThirdPartyTileUrl(url, tileConfig)) {
       headers['X-Embed-Token'] = options.embedToken;
-    } else if (absUrl.includes('/raster-tiles/') && !isThirdPartyTileUrl(url, tileConfig)) {
+    } else if (
+      absUrl.includes('/raster-tiles/') &&
+      !isThirdPartyTileUrl(url, tileConfig) &&
+      !isEmbedViewer()
+    ) {
       const token = useAuthStore.getState().token;
       if (token) headers.Authorization = `Bearer ${token}`;
     }


### PR DESCRIPTION
Fixes from the codebase audit 2026-08-30 (8dc529f17), tracked in #1778. Lane M3B: viewer, drawing and embed.

## Fixed

**Embed viewer attaches the signed-in user's JWT to raster tile requests, defeating the isEmbedViewer anonymity invariant**
`buildTileTransformRequest` (frontend/src/lib/tile-utils.ts) now checks `isEmbedViewer()` before falling back to the `Authorization: Bearer` header on first-party `/raster-tiles/` requests. Previously a bare embed link with no `embedToken`, opened by a signed-in user on the same origin, leaked the viewer's own session JWT to raster tile requests. Vitest added: a raster tile request under the embed viewer surface carries no Authorization header even when a JWT is present in the auth store. Fails on main, passes with the fix.

**The raw embed token (`et=` query param) survives report redaction**
Added `et` and `embed_token` to SENSITIVE_KEYS in frontend/src/lib/report/redact.ts. The two-letter key is safe against unrelated substrings because of the existing `\b` anchor. Vitest added confirming the token no longer survives redaction. Fails on main, passes with the fix.

**Viewer falls back to a CARTO basemap while every other surface falls back to OpenFreeMap**
Exported `FALLBACK_BASEMAP_STYLE_URL` / `FALLBACK_BASEMAP_STYLE_URL_DARK` from frontend/src/lib/basemap-utils.ts and pointed ViewerMap, BuilderMap, DatasetMap, SpatialFilterPanel and BboxMapPicker at the shared constants, replacing five hardcoded literals (one of them the CARTO URL with no attribution string). Vitest added on the exported constants; fails on main (undefined import), passes with the fix.

**A non-ascending gradient stop position is committed straight into `line-gradient`, and maplibre-gl 6.5.0 rejects the whole expression**
`commitStops` (frontend/src/components/builder/LineGradientControls.tsx) now refuses a non-strictly-ascending stop list before it reaches paint or the saved style_config. `addStop` now bisects the widest gap instead of always the last pair, so repeated clicks no longer converge on and duplicate the final stop's position. Two Vitest cases added: typing a duplicate position refuses the commit, and 7 consecutive Add-stop clicks stay strictly ascending. Both fail on main, pass with the fix.

**Terra Draw undo history grows without bound and is never reset on the feature-edit path**
frontend/src/components/drawing/hooks/use-terra-draw.ts now caps the undo ring at 50 entries and resets it on a committed dragFeature/dragCoordinate/dragCoordinateResize edit, matching the existing reset on draw/setMode/clear. New test file mocks `terra-draw` and `terra-draw-maplibre-gl-adapter` to drive the hook's change/finish handlers directly. Two cases: unbounded growth is capped (199 vs 49 undo steps available), and canUndo resets to false after a committed drag. Both fail on main, pass with the fix.

## Left alone

**Three parallel implementations of builder-vs-paint swatch precedence** (LayerLegend.tsx `viewerSwatchStyle`, LegendPlugin.tsx `getSwatchStyleFromPaint`, layer-icons.tsx `extractStyleHints`). Still present on main. Per the lane brief's threshold, I attempted a shared-helper extraction covering the two byte-identical SwatchStyle producers (viewer + builder legend), keeping each caller's own geometry-type resolution untouched (LayerLegend reads the raw `geometry_type`; LegendPlugin infers it via `inferGeometryType` — reconciling that is a deliberate behavior decision, not a mechanical dedup). The resulting diff came to 150 changed lines across 3 files (77 insertions, 73 deletions), over the ~80-line cap, so it's reverted here and left for a follow-up.

## Verification

- `cd frontend && npx vitest run <touched test files>` — 423 tests passed across 35 files.
- `npm run typecheck` — clean.
- `npm run lint` — clean (0 errors, 0 warnings).
- `npm run test:i18n` — passed (no new `t()` keys added).
- Each new/modified test verified against the pre-fix source to confirm it fails on main (counterfactual), per item above.


## Round 1 (review 5096394306, head fcc738248)

Two P2s, both fixed at f915add0a.

**use-terra-draw.ts:334 — resetting undo history on every drag/vertex finish disabled Undo for a pending, unsaved edit.** A drag/vertex edit only marks the edit dirty (use-feature-editing's handleEditFinish); it isn't persisted until Save. use-terra-draw now exposes `resetHistory()`, a ring reset that does not touch the canvas. The `finish` handler no longer resets on a dragFeature/dragCoordinate/dragCoordinateResize commit. use-feature-editing calls `resetHistory()` from `handleSaveEdit`'s success path and from `performDeselect` (which also backs Cancel), so the ring survives through a pending edit and clears once it settles (save, cancel, or deselection). The round-0 test that asserted the reset-on-finish behavior was rewritten to assert the opposite (Undo stays enabled and reverts the drag); a new test confirms `resetHistory()` disables it. Two more tests in use-feature-editing.test.ts confirm handleSaveEdit and performDeselect each call it.

**LineGradientControls.tsx:195 — the blanket "refuse any non-ascending list" blocked incremental repair of a legacy stop list.** A map saved by the old repeated-Add bug (e.g. `[0, 1, 1, 1]`) already has adjacent-position violations, so any commit that still left a violation somewhere else was refused — removing one duplicate, moving one stop, or recoloring one all became no-ops. `commitStops` now compares the adjacent-pair violation count of the proposed list against the list it replaces, and refuses only when the count increases. New vitest cases pin the three scenarios from the review: removing one duplicate from `[0,1,1,1]` commits, moving a stop to `[0,0.5,1,1]` commits, and setting the middle of `[0,0.5,1]` to `1` is refused; a fourth case confirms a colour-only change (count unchanged) still commits.

Verification: `npm run typecheck` clean, `npm run lint` clean (0 warnings), and targeted vitest across all touched suites (LineGradientControls.test.tsx, use-terra-draw tests, use-feature-editing.test.ts, DatasetMap.test.tsx, DatasetMap.lazy.test.tsx) — 142 + 50 tests passed. Each new/changed test verified against the pre-round-1 source (fcc738248) to confirm it fails there.


## Round 2 (review 5096469632, head f915add0a)

Two P2s, both consequences of the round-1 undo change. Fixed together at 99d89f423.

**use-feature-editing.ts:309 — handleDeleteFeature's success path never called resetHistory().** It removed the feature and cleared the selection but left canUndo true, so Undo could restore the deleted geometry as a client-side ghost. Now calls `resetHistory()` right after `clearSelectedFeature()`, the same point handleSaveEdit resets at, after the stale-epoch check.

**use-terra-draw.ts:336 — undo() never touched isEditDirty.** Reverting all the way back to the original geometry still triggered the unsaved-changes confirmation on Cancel, Done, and mode switch. use-terra-draw now exposes an `onHistoryBaseline` callback, fired only when `undo()` pops the ring back to its earliest recorded snapshot (not on a draw/setMode/clear/resetHistory reset). use-feature-editing wires it to a new `handleHistoryBaseline` that clears `isEditDirty`; a subsequent drag/vertex edit re-dirties normally through the existing `handleEditFinish`. DatasetMap threads the callback through the same ref pattern already used for `onEditFinish`.

Per the policy-after-detection note, audited every edit-session exit and every isEditDirty derivation site before wiring: save success and delete success now both reset history, and both already cleared isEditDirty via `clearSelectedFeature`. Cancel/deselect (`performDeselect`) already resets history and clears isEditDirty. Identity-change teardown (`finishDrawingSession` / `clearDrawing`) already resets both via the store's `CLEARED_STATE`. Mode switch already resets history via `setMode()` and routes through `performDeselect` when a feature is selected, which clears isEditDirty. `DatasetPage.tsx`'s page-level dirty flag reads the same store value reactively, so it picks up the fix with no separate wiring. No other exit or derivation site needed a change.

Verification: `npm run typecheck` clean, `npm run lint` clean (0 warnings), targeted vitest across all touched suites (use-terra-draw.undo-history.test.ts, use-feature-editing.test.ts, DatasetMap.test.tsx, DatasetMap.lazy.test.tsx, LineGradientControls.test.tsx) — 149 tests passed. Each new/changed assertion verified against the pre-round-2 source (f915add0a) to confirm it fails there (4 new tests, all failed on the prior commit, all pass now).


## Round 3 (review 5096534546, head 99d89f423)

One P2, fixed at 22106a862.

**use-terra-draw.ts:376 — the bounded undo ring's shift() could evict the true pre-edit snapshot.** After more than 50 `change` events in one drag, the ring's cap dropped the original snapshot along with older intermediate ones. Undoing back to ring length 1 then fired `onHistoryBaseline` against whatever the ring's oldest surviving entry happened to be, not the true original geometry — `isEditDirty` cleared while Undo was disabled and a residual edit could be discarded without confirmation on Done or a mode switch.

Added `baselineRef`, holding the true pre-edit snapshot outside the bounded ring. It's captured when an edit session starts (`selectFeature()`, `setMode()`) and cleared everywhere `resetHistory()` already clears (`resetHistory()`, `clear()`, the draw-finish branch), so it stays in lockstep with the ring's own reset points. The ring itself is unchanged — it still holds only intermediate snapshots and may still evict its oldest entries. `undo()` now falls back to `baselineRef` once the ring empties, and `onHistoryBaseline` fires only when the canvas is verified at that true baseline (ring length 0 **and** a baseline was captured). If no baseline was captured for the session, undo stops at the ring's own oldest entry, same as before this fix, and never reports baseline — `isEditDirty` stays true.

Pinned with two new vitest cases: 60 `change` events against the 50-entry cap, undo repeatedly until `canUndo` is false, and the final `addFeatures` call carries the true baseline snapshot with `onHistoryBaseline` firing exactly once; and, with the baseline deliberately missing, `onHistoryBaseline` never fires even after undo is fully exhausted. Also updated the round-2 test that assumed reaching the ring's own oldest entry was the baseline — with a captured baseline that's no longer true, it now takes one further undo step to correctly fall back to `baselineRef`.

Verification: `npm run typecheck` clean, `npm run lint` clean (0 warnings), targeted vitest across all touched suites (use-terra-draw.undo-history.test.ts, use-feature-editing.test.ts, DatasetMap.test.tsx, DatasetMap.lazy.test.tsx) — 101 tests passed. The two new pinned tests, and the round-2 test's tightened assertions, verified against the pre-round-3 source (99d89f423) to confirm they fail there (3 of 8 tests in the file failed on the prior commit; all 8 pass now).


## Round 4 (review 5096597241, head 22106a862)

One P2, fixed at e44cb2ffd.

**use-terra-draw.ts:493 — undo()'s restoration path never re-selected the feature.** It called `draw.clear()` (which drops Terra Draw's own select-mode state and edit handles) and then only `addFeatures()`. The Zustand `selectedFeature` store stayed set, so the action bar kept showing the feature as selected, but the user had to click the geometry again before dragging or editing vertices — Terra Draw itself no longer considered anything selected.

Added `selectedFeatureIdRef`, recording whatever feature the app selects via `selectFeature()` — captured at the same edit-session-start points as round 3's `baselineRef` (`selectFeature()`, `setMode()`) and cleared at the same reset points (`resetHistory()`, `clear()`, the draw-finish branch). `undo()` now preserves that id before `draw.clear()`, restores the geometry via `addFeatures()` as before, then calls `draw.selectFeature()` directly (not this hook's own `selectFeature()` wrapper, which would recapture a new baseline) once the feature is back on the canvas — selection only makes sense after the geometry exists again. If the id is no longer present in the restored snapshot, a new `onSelectionLost` callback fires instead of re-selecting; `use-feature-editing.ts` wires it to a new `handleSelectionLost` that clears the selection store, guarded on the id still matching the current selection (in case a newer selection has since replaced it).

Both the ring-internal undo step and round 3's baseline-fallback step (when the ring itself is exhausted) flow through this same restoration code, so the fix covers both — verified explicitly with a dedicated test for the baseline-fallback path.

Pinned with vitest: re-select fires in the correct order (`clear`, then `addFeatures`, then `selectFeature`) for a ring-internal undo; the same for the baseline-fallback undo; `onSelectionLost` fires (and `selectFeature` is not called) when the restored snapshot no longer contains the feature, and does not re-fire on a subsequent undo once the record is already cleared; `handleSelectionLost` clears the store only when the lost id matches the current selection, leaves a newer selection alone, and no-ops when nothing is selected.

Verification: `npm run typecheck` clean, `npm run lint` clean (0 warnings), targeted vitest across all touched suites (use-terra-draw.undo-history.test.ts, use-feature-editing.test.ts, DatasetMap.test.tsx, DatasetMap.lazy.test.tsx) — 107 tests passed. The 6 new assertions verified against the pre-round-4 source (22106a862) to confirm they fail there; all pass at e44cb2ffd.


## Round 5 (review 5096696754, head e44cb2ffd)

Two P2s, fixed at ce4d8cca7.

**use-terra-draw.ts:485 — selection seeded the undo ring with pre-session snapshots.** On the real selection path, `addFeatures()` (loading the existing feature) and `draw.selectFeature()` (selecting it) both synchronously emit `change` events, so by the time `selectFeature()` captured the baseline, the ring already held one or more entries — `canUndo` (and, through `onHistoryBaseline`, `isEditDirty`) read as dirty right after just selecting a feature, before any actual edit happened.

`selectFeature()` now suppresses the change listener with a new `isSeedingSessionRef` flag (checked alongside `isRestoringRef`) while it calls `draw.selectFeature()`, so that call's own seed event is never recorded, and unconditionally clears the ring and recomputes `canUndo` (false) right after. That unconditional clear also wipes out `addFeatures()`'s own seed event — that call happens before this hook's `selectFeature()` in the real flow (`selectFeatureFromMap` calls `addFeatures()` then `selectFeature()`), so it's outside the guard's reach and needs the ring-clear-after as a second line of defense.

**LineGradientControls.tsx:217 — comparing total violation counts let a position edit swap one violation for another.** `[0, 0.5, 0.5, 1]` edited to `[0, 0.5, 0.4, 1]` keeps the count at 1 (the duplicate at (1,2) becomes a descending pair at (1,2) instead) and still committed a list maplibre-gl rejects.

`commitStops` now also checks, for every index whose position actually changed between the previous and proposed stop list, that both pairs it participates in — (i-1,i) and (i,i+1) — are strictly ascending after the edit. A colour-only change or a structural add/remove touches no position at a fixed index, so those stay governed by the total-count check alone, preserving the existing incremental-repair behavior for those cases.

Pinned with vitest matching the coordinator's exact scenarios: selecting a feature (with a mock that synchronously emits `change`, matching the real path) leaves `canUndo` false and the ring truly empty; one drag then one undo takes `canUndo` back to false and restores the true baseline; `[0,0.5,0.5,1]` to `[0,0.5,0.4,1]` is refused; `[0,0.5,0.5,1]` to `[0,0.5,0.6,1]` commits; the existing colour-change and removal tests on `[0,1,1,1]` from round 1 still commit.

Verification: `npm run typecheck` clean, `npm run lint` clean (0 warnings), targeted vitest across all touched suites (use-terra-draw.undo-history.test.ts, use-feature-editing.test.ts, DatasetMap.test.tsx, DatasetMap.lazy.test.tsx, LineGradientControls.test.tsx) — 161 tests passed. The 5 new/discriminating assertions verified against the pre-round-5 source (e44cb2ffd) to confirm they fail there; all pass at ce4d8cca7.
