### PR TITLE
fix(auth,embed,cache): auth and cache hardening from the 2026-08-30 audit

### DIFF
--- a/backend/alembic/versions/0057_security_revocation_generation.py
+++ b/backend/alembic/versions/0057_security_revocation_generation.py
@@ -1,0 +1,57 @@
+"""Cluster-global revocation generation for cross-worker cache invalidation.
+
+fix(#1778 codex r3). ``RedisCacheProvider``'s in-memory fallback and its
+authoritative-replay queue are PROCESS-local, and production runs several
+Uvicorn workers. During a Redis outage worker A could revoke an embed token and
+queue the denial in A alone, while worker B held a positive for the same token;
+after recovery B could still read the pre-revocation positive out of Redis
+before A's replay landed. Nothing process-local can close that, because the two
+workers share no memory.
+
+This sequence is the shared, durable fact they can both consult. Every
+revocation bumps it; every positive validation-cache entry is stamped with the
+generation it was minted under; a validator whose stamp is behind the current
+generation refuses the entry and re-reads the database. A revoke that happens
+during an outage still lands here, because the database is the one thing that
+stays up when Redis does not.
+
+A SEQUENCE rather than a counter row, for three reasons. ``nextval`` takes no
+row lock, so a revocation storm does not serialize on it. It is
+non-transactional, so a revoke whose transaction later rolls back still leaves
+the generation bumped: the consequence is that some cached positives are
+re-validated against the database once, which is the harmless direction to be
+wrong in. And it needs no ORM model, so it stays out of the mapper registry and
+out of ``make alembic-check``'s comparison, which is correct because nothing
+maps it.
+
+DELIBERATELY OUTSIDE THE RLS BOUNDARY, like ``arcgis_signin_attempts`` (0056).
+A sequence has no rows to which a policy could attach, and a per-tenant view of
+it would defeat the purpose: the point is one number every worker agrees on. It
+holds nothing tenant-identifying and nothing secret. It is a counter.
+
+Revision ID: 0057_security_revocation_generation
+Revises: 0056_arcgis_signin_attempts
+Create Date: 2026-09-02
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = "0057_security_revocation_generation"
+down_revision: Union[str, None] = "0056_arcgis_signin_attempts"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+_SEQUENCE = "catalog.security_revocation_generation"
+
+
+def upgrade() -> None:
+    # START WITH 1 so a deployment that has never revoked anything still reads a
+    # stable value, and every cache entry minted before the first revoke carries
+    # that same stamp.
+    op.execute(f"CREATE SEQUENCE IF NOT EXISTS {_SEQUENCE} AS bigint START WITH 1")
+
+
+def downgrade() -> None:
+    op.execute(f"DROP SEQUENCE IF EXISTS {_SEQUENCE}")

--- a/backend/alembic/versions/0057_security_revocation_generation.py
+++ b/backend/alembic/versions/0057_security_revocation_generation.py
@@ -76,8 +76,19 @@ def upgrade() -> None:
     # Seed the row here rather than lazily: a reader that finds no row cannot
     # tell "never revoked" from "counter missing", and the safe answer to the
     # second is to refuse every cached positive.
+    # fix(#1778 codex r5): seeded from the clock, not from 1. The reader
+    # re-creates this row if it is ever deleted, and a re-seed that restarted at
+    # 1 would walk back up through values that cache entries elsewhere in the
+    # fleet are still stamped with, making a revoked entry compare equal again.
+    # An epoch seed puts every (re-)seed far above any counter that reached its
+    # value by counting revocations, so issued values never repeat.
+    #
+    # The COLUMN default stays 1: it is never used, since every row this table
+    # will ever hold is inserted right here, and keeping it a literal is what
+    # lets the ORM model in core/db/models.py match for `alembic check`.
     op.execute(
-        f"INSERT INTO catalog.{_TABLE} (id, generation) VALUES (TRUE, 1) "
+        f"INSERT INTO catalog.{_TABLE} (id, generation) "
+        "VALUES (TRUE, EXTRACT(EPOCH FROM clock_timestamp())::bigint) "
         "ON CONFLICT (id) DO NOTHING"
     )
 

--- a/backend/alembic/versions/0057_security_revocation_generation.py
+++ b/backend/alembic/versions/0057_security_revocation_generation.py
@@ -1,33 +1,39 @@
 """Cluster-global revocation generation for cross-worker cache invalidation.
 
-fix(#1778 codex r3). ``RedisCacheProvider``'s in-memory fallback and its
+fix(#1778 codex r3/r4). ``RedisCacheProvider``'s in-memory fallback and its
 authoritative-replay queue are PROCESS-local, and production runs several
 Uvicorn workers. During a Redis outage worker A could revoke an embed token and
 queue the denial in A alone, while worker B held a positive for the same token;
-after recovery B could still read the pre-revocation positive out of Redis
-before A's replay landed. Nothing process-local can close that, because the two
-workers share no memory.
+after recovery B could still read the pre-revocation positive out of Redis.
+Nothing process-local can close that, because the two workers share no memory.
 
-This sequence is the shared, durable fact they can both consult. Every
-revocation bumps it; every positive validation-cache entry is stamped with the
-generation it was minted under; a validator whose stamp is behind the current
-generation refuses the entry and re-reads the database. A revoke that happens
-during an outage still lands here, because the database is the one thing that
-stays up when Redis does not.
+This counter is the shared, durable fact they can both consult. Every revocation
+advances it, every positive validation-cache entry is stamped with the
+generation it was minted under, and a validator whose stamp is behind refuses
+the entry and re-reads the database.
 
-A SEQUENCE rather than a counter row, for three reasons. ``nextval`` takes no
-row lock, so a revocation storm does not serialize on it. It is
-non-transactional, so a revoke whose transaction later rolls back still leaves
-the generation bumped: the consequence is that some cached positives are
-re-validated against the database once, which is the harmless direction to be
-wrong in. And it needs no ORM model, so it stays out of the mapper registry and
-out of ``make alembic-check``'s comparison, which is correct because nothing
-maps it.
+A single-row TABLE, not a sequence (fix(#1778 codex r4)). The first draft used a
+sequence because ``nextval`` takes no row lock, but ``nextval`` is also
+non-transactional, and that is fatal here rather than convenient: the advance
+became visible to every other worker the instant it ran, while the ``is_active``
+flip it stood for stayed invisible until the revoking transaction committed. A
+validator landing in that window read the NEW generation, read the token row as
+still active, and cached a positive stamped with the new generation, which then
+survived the commit. Ordering the publish after the commit only narrows the
+window; making the counter transactional removes it, because the generation and
+the ``is_active`` flip become visible in the same instant, to everyone.
+
+The cost is that concurrent revocations serialize on this row. They already
+serialize on the embed-token rows they are flipping, they are rare, and every
+revoke path reaches this row in the same order (token flips first, counter
+second), so the added lock introduces no new cycle.
 
 DELIBERATELY OUTSIDE THE RLS BOUNDARY, like ``arcgis_signin_attempts`` (0056).
-A sequence has no rows to which a policy could attach, and a per-tenant view of
-it would defeat the purpose: the point is one number every worker agrees on. It
-holds nothing tenant-identifying and nothing secret. It is a counter.
+The value of the counter is that every worker, and in hosted mode every tenant's
+request path, agrees on one number; a per-tenant view of it would let a revoke
+in one tenant leave another's stale positives standing, which is the defect this
+closes rather than a refinement of it. It holds nothing tenant-identifying and
+nothing secret. It is a counter.
 
 Revision ID: 0057_security_revocation_generation
 Revises: 0056_arcgis_signin_attempts
@@ -36,6 +42,7 @@ Create Date: 2026-09-02
 
 from typing import Sequence, Union
 
+import sqlalchemy as sa
 from alembic import op
 
 revision: str = "0057_security_revocation_generation"
@@ -43,15 +50,37 @@ down_revision: Union[str, None] = "0056_arcgis_signin_attempts"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 
-_SEQUENCE = "catalog.security_revocation_generation"
+_TABLE = "security_revocation_generation"
 
 
 def upgrade() -> None:
-    # START WITH 1 so a deployment that has never revoked anything still reads a
-    # stable value, and every cache entry minted before the first revoke carries
-    # that same stamp.
-    op.execute(f"CREATE SEQUENCE IF NOT EXISTS {_SEQUENCE} AS bigint START WITH 1")
+    op.create_table(
+        _TABLE,
+        # A one-row table: the CHECK plus the primary key make a second row
+        # impossible to insert, so no reader has to ask which row it wants.
+        sa.Column(
+            "id",
+            sa.Boolean(),
+            primary_key=True,
+            server_default=sa.true(),
+        ),
+        sa.Column(
+            "generation",
+            sa.BigInteger(),
+            nullable=False,
+            server_default=sa.text("1"),
+        ),
+        sa.CheckConstraint("id IS TRUE", name="ck_security_revocation_generation_one"),
+        schema="catalog",
+    )
+    # Seed the row here rather than lazily: a reader that finds no row cannot
+    # tell "never revoked" from "counter missing", and the safe answer to the
+    # second is to refuse every cached positive.
+    op.execute(
+        f"INSERT INTO catalog.{_TABLE} (id, generation) VALUES (TRUE, 1) "
+        "ON CONFLICT (id) DO NOTHING"
+    )
 
 
 def downgrade() -> None:
-    op.execute(f"DROP SEQUENCE IF EXISTS {_SEQUENCE}")
+    op.drop_table(_TABLE, schema="catalog")

--- a/backend/alembic/versions/0057_security_revocation_generation.py
+++ b/backend/alembic/versions/0057_security_revocation_generation.py
@@ -76,19 +76,25 @@ def upgrade() -> None:
     # Seed the row here rather than lazily: a reader that finds no row cannot
     # tell "never revoked" from "counter missing", and the safe answer to the
     # second is to refuse every cached positive.
-    # fix(#1778 codex r5): seeded from the clock, not from 1. The reader
-    # re-creates this row if it is ever deleted, and a re-seed that restarted at
-    # 1 would walk back up through values that cache entries elsewhere in the
-    # fleet are still stamped with, making a revoked entry compare equal again.
-    # An epoch seed puts every (re-)seed far above any counter that reached its
-    # value by counting revocations, so issued values never repeat.
+    # fix(#1778 codex r6 P2): a random 62-bit value, not a wall-clock second.
+    # The clock seed adopted in r5 could collide with itself -- deleting the
+    # row and re-seeding within the same wall-clock second reproduces the
+    # exact same value, and under sustained revocation traffic the counter's
+    # integer value can outrun the epoch-seconds count outright, landing a
+    # later re-seed BEHIND a counter it was meant to get ahead of. Monotonic
+    # wall-clock time was never the guarantee this needed. A value drawn
+    # uniformly from [0, 2**62) makes a collision with any earlier stamp --
+    # from this seed, an app-level re-seed, or a counted revocation -- a
+    # ~2**-62 event, independent of timing. The reader in
+    # app/platform/cache/revocation.py re-creates this row with the identical
+    # expression if it is ever deleted.
     #
     # The COLUMN default stays 1: it is never used, since every row this table
     # will ever hold is inserted right here, and keeping it a literal is what
     # lets the ORM model in core/db/models.py match for `alembic check`.
     op.execute(
         f"INSERT INTO catalog.{_TABLE} (id, generation) "
-        "VALUES (TRUE, EXTRACT(EPOCH FROM clock_timestamp())::bigint) "
+        "VALUES (TRUE, (floor(random() * 4611686018427387904))::bigint) "
         "ON CONFLICT (id) DO NOTHING"
     )
 

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -327,6 +327,13 @@ KNOWN_BAD_JWT_SECRETS = frozenset(
     }
 )
 
+# fix(#1778): bcrypt's input limit, restated here because `core/` may not import
+# from `app.modules.*` (tests/test_layering.py::test_core_does_not_import_from_
+# any_module) and the canonical definition lives beside the hasher, in
+# app/modules/auth/password_policy.py. tests/test_password_policy.py pins the
+# two to the same number so they cannot drift.
+BCRYPT_MAX_PASSWORD_BYTES = 72
+
 
 # fix(#1235 review r6): the shortest presigned-upload window worth issuing.
 # Lives HERE, not next to its only consumer in processing/ingest/presigned.py,
@@ -1180,6 +1187,23 @@ class Settings(BaseSettings):
             raise ValueError(
                 "GEOLENS_ADMIN_PASSWORD must not be empty. Generate one "
                 "with `openssl rand -base64 16` and set it in your .env."
+            )
+        # fix(#1778): bound it at boot, where the message can name the variable.
+        # seed_initial_admin() hashes this value with bcrypt, which refuses an
+        # input over 72 bytes, and nothing upstream of the seed validates it:
+        # an operator who generated the value with something like
+        # `openssl rand -base64 64` (88 characters) got a bare bcrypt
+        # ValueError from inside application startup and an API container that
+        # restart-looped on a message naming nothing about GeoLens config.
+        admin_password_bytes = len(
+            self.geolens_admin_password.get_secret_value().encode("utf-8")
+        )
+        if admin_password_bytes > BCRYPT_MAX_PASSWORD_BYTES:
+            raise ValueError(
+                f"GEOLENS_ADMIN_PASSWORD is {admin_password_bytes} bytes when "
+                f"encoded as UTF-8; the password hash accepts at most "
+                f"{BCRYPT_MAX_PASSWORD_BYTES}. Generate a shorter value with "
+                "`openssl rand -base64 16` and set it in your .env."
             )
         return self
 

--- a/backend/app/core/db/models.py
+++ b/backend/app/core/db/models.py
@@ -9,7 +9,7 @@ Never import from `app.modules.*` in this module — `core/` must not depend on
 (introduced in Phase 212, plan 03).
 """
 
-from sqlalchemy import Text
+from sqlalchemy import BigInteger, Boolean, CheckConstraint, Text, text, true
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -22,3 +22,33 @@ class AppSetting(Base):
 
     key: Mapped[str] = mapped_column(Text, primary_key=True)
     value: Mapped[dict] = mapped_column(JSONB, nullable=False)
+
+
+class SecurityRevocationGeneration(Base):
+    """One row, one number: the cluster-global revocation generation.
+
+    fix(#1778 codex r3/r4). Declared here rather than in a domain package
+    because no domain owns it: it is the counter every worker consults to decide
+    whether a cached AUTHORIZATION decision predates the latest revocation, and
+    ``app/platform/cache/revocation.py`` (which may not import from
+    ``app.modules.*``) is what reads and advances it.
+
+    The model exists so ``alembic check`` can see the table migration 0057
+    creates; the reads and writes themselves are raw SQL in that module, because
+    a single-row counter wants an ``UPDATE ... RETURNING`` rather than an ORM
+    round-trip.
+
+    ``id`` is a boolean pinned TRUE by a CHECK plus the primary key, so a second
+    row cannot be inserted and no reader has to say which row it means.
+    """
+
+    __tablename__ = "security_revocation_generation"
+    __table_args__ = (
+        CheckConstraint("id IS TRUE", name="ck_security_revocation_generation_one"),
+        {"schema": "catalog"},
+    )
+
+    id: Mapped[bool] = mapped_column(Boolean, primary_key=True, server_default=true())
+    generation: Mapped[int] = mapped_column(
+        BigInteger, nullable=False, server_default=text("1")
+    )

--- a/backend/app/core/public_urls.py
+++ b/backend/app/core/public_urls.py
@@ -389,8 +389,8 @@ def _is_env_only() -> bool:
     return settings.env_only_config
 
 
-def _request_origin(request: Request | None) -> str | None:
-    """Derive the public origin from request headers.
+def _request_origin_decision(request: Request | None) -> tuple[str | None, bool]:
+    """``(origin, allowlist_rejected)`` derived from the request headers.
 
     SEC-05 / M-67: when ``CORS_ALLOWED_ORIGINS`` is configured (non-empty),
     the resulting origin MUST be in that allowlist. This prevents an
@@ -400,9 +400,15 @@ def _request_origin(request: Request | None) -> str | None:
     When ``CORS_ALLOWED_ORIGINS`` is empty (local dev, no proxy), the
     function returns the request-derived origin unchanged — dev workflows
     (Vite proxy, localhost-only) keep working without configuration.
+
+    fix(#1778): the second element exists because "no origin to derive" and
+    "an origin was derived and the allowlist refused it" are different
+    answers, and the resolvers below must not treat them alike. Collapsing
+    both into ``None`` let the raw-Host fallback re-derive the very origin
+    this function had just rejected.
     """
     if request is None:
-        return None
+        return None, False
 
     candidate: str | None = None
 
@@ -420,7 +426,7 @@ def _request_origin(request: Request | None) -> str | None:
         scheme = request.headers.get("x-forwarded-proto", request.url.scheme)
         host = request.headers.get("x-forwarded-host", request.headers.get("host", ""))
         if not host:
-            return None
+            return None, False
         candidate = f"{scheme}://{host}"
 
     # SEC-05: enforce CORS allowlist when configured.
@@ -432,9 +438,17 @@ def _request_origin(request: Request | None) -> str | None:
             (normalize_public_url(entry) or "").lower() for entry in allowlist
         }
         if (candidate or "").lower() not in normalized_allowlist:
-            return None
+            return None, True
 
-    return candidate
+    return candidate, False
+
+
+def _request_origin(request: Request | None) -> str | None:
+    """The allowlist-approved request origin, or None. See
+    :func:`_request_origin_decision` for why callers that fall back to
+    anything else need the two-value form instead."""
+    origin, _rejected = _request_origin_decision(request)
+    return origin
 
 
 def resolve_public_api_url(
@@ -453,6 +467,17 @@ def resolve_public_api_url(
     enables auth-code theft. Caller MUST configure ``PUBLIC_APP_URL`` /
     ``PUBLIC_API_URL`` for OAuth flows; otherwise this raises
     ``PublicUrlNotConfiguredError``.
+
+    fix(#1778): the last-resort ``request.url.netloc`` fallback below runs only
+    when the allowlist did not have an opinion. It used to run whenever
+    ``_request_origin`` answered None, which included the case where the
+    allowlist had just REFUSED the derived origin -- and ``request.url.netloc``
+    is Starlette's read of the ``Host`` header, which nginx.conf forwards
+    verbatim (``proxy_set_header Host $http_host``) with no ``server_name``
+    restriction. SEC-05 therefore changed which of two code paths ran and both
+    returned the attacker's host. Giving nginx a ``server_name`` so an unknown
+    Host never reaches the app is still worth doing; this closes the app-side
+    half.
     """
     normalized_api = normalize_public_url(api_url) or normalize_public_url(
         legacy_api_url
@@ -472,7 +497,7 @@ def resolve_public_api_url(
             "X-Forwarded-Host can hijack the OAuth redirect_uri."
         )
 
-    request_origin = _request_origin(request)
+    request_origin, allowlist_rejected = _request_origin_decision(request)
     if request_origin:
         assert request is not None
         root_path = request.scope.get("root_path", "").rstrip("/")
@@ -480,7 +505,7 @@ def resolve_public_api_url(
             return request_origin + root_path
         return request_origin
 
-    if request is not None:
+    if request is not None and not allowlist_rejected:
         scheme = request.url.scheme
         host = request.url.netloc
         if host:
@@ -521,14 +546,14 @@ def resolve_public_app_url(
             "X-Forwarded-Host can hijack the OAuth redirect_uri."
         )
 
-    request_origin = _request_origin(request)
+    request_origin, allowlist_rejected = _request_origin_decision(request)
     if request_origin:
         return request_origin
 
     if normalized_api:
         return normalized_api
 
-    if request is not None:
+    if request is not None and not allowlist_rejected:
         scheme = request.url.scheme
         host = request.url.netloc
         if host:

--- a/backend/app/modules/admin/service.py
+++ b/backend/app/modules/admin/service.py
@@ -1,6 +1,7 @@
 """Admin service: user CRUD, role assignment, and catalog stats."""
 
 import uuid
+from dataclasses import dataclass
 from typing import Any
 
 import structlog
@@ -107,6 +108,30 @@ async def _get_total_storage_bytes(db: AsyncSession, dataset_model: type) -> int
             ).bindparams(schema=data_schema, table_names=table_names)
         )
         return result.scalar_one()
+
+
+@dataclass(frozen=True)
+class IdentityRoleOutcome:
+    """What ``set_role_from_identity_provider`` did.
+
+    fix(#1778 codex r5). Three states, not two, because the caller writes an
+    audit row and each deserves a different one:
+
+    * ``applied=False`` -- the last-admin rule refused the demotion.
+    * ``applied=True, changed=False`` -- the role was already what the mapping
+      asks for. Nothing happened, so nothing is recorded. This is the state a
+      second concurrent callback lands in once it gets the lock.
+    * ``applied=True, changed=True`` -- the role moved, and ``previous_roles``
+      says from where.
+
+    ``previous_roles`` is always read UNDER the advisory lock, so it describes
+    the state the change actually started from rather than one a racing caller
+    had already replaced.
+    """
+
+    applied: bool
+    changed: bool
+    previous_roles: list[str]
 
 
 class AdminService:
@@ -407,8 +432,12 @@ class AdminService:
         *,
         lock_held: bool = False,
         viability_checked: bool = False,
-    ) -> None:
+    ) -> bool:
         """Replace a user's role with new_role_name in the current transaction.
+
+        Returns whether the roles actually CHANGED. fix(#1778 codex r5): the
+        caller needs to tell "applied" from "was already correct", because an
+        IdP-driven caller emits an audit event and only a real change is one.
 
         Raises ValueError if the new role doesn't exist or if this would demote
         the sole admin.
@@ -435,7 +464,7 @@ class AdminService:
             ).scalars()
         )
         if current_role_names == {new_role_name}:
-            return
+            return False
 
         if new_role_name != "admin" and not viability_checked:
             await self._ensure_not_last_admin(user, "demote", lock_held=lock_held)
@@ -451,8 +480,11 @@ class AdminService:
         await self.db.execute(
             update(User).where(User.id == user.id).values(key_epoch=User.key_epoch + 1)
         )
+        return True
 
-    async def set_role_from_identity_provider(self, user: User, role_name: str) -> bool:
+    async def set_role_from_identity_provider(
+        self, user: User, role_name: str
+    ) -> IdentityRoleOutcome:
         """Apply an IdP-mapped role. False when the last-admin rule refused it.
 
         fix(#1778 codex r1): the OAuth group-role reconciliation
@@ -494,26 +526,37 @@ class AdminService:
         Same lock for both branches rather than a per-user row lock, because the
         demotion branch needs the global one anyway (the last-admin count is
         fleet-wide) and one lock cannot deadlock against itself.
+
+        fix(#1778 codex r5): returns an outcome rather than a bare bool, and the
+        ``previous_roles`` it carries are read UNDER the lock. Two concurrent
+        callbacks both captured the previous roles before waiting for the lock,
+        and the one that lost the race then emitted a second `oauth.role.changed`
+        event describing a transition that had already happened, with a snapshot
+        taken before the winner's write. The loser now reports
+        ``changed=False`` and the caller stays quiet.
         """
         await self._lock_admin_lifecycle()
         await self.db.refresh(user, attribute_names=["roles"])
+        # Read under the lock: anything captured before waiting for it describes
+        # a state another caller may already have replaced.
+        previous_roles = sorted(role.name for role in user.roles)
 
         if role_name == "admin":
             # A promotion cannot threaten the last-admin invariant, so it skips
             # the check but not the lock.
-            await self._update_user_role(user, role_name, lock_held=True)
-            return True
+            changed = await self._update_user_role(user, role_name, lock_held=True)
+            return IdentityRoleOutcome(True, changed, previous_roles)
 
         try:
             await self._ensure_not_last_admin(user, "demote", lock_held=True)
         except ValueError:
             # The only ValueError _ensure_not_last_admin raises is the refusal
             # itself, and it is a refusal here rather than a failure.
-            return False
-        await self._update_user_role(
+            return IdentityRoleOutcome(False, False, previous_roles)
+        changed = await self._update_user_role(
             user, role_name, lock_held=True, viability_checked=True
         )
-        return True
+        return IdentityRoleOutcome(True, changed, previous_roles)
 
     async def convert_saml_user_to_local(
         self, user_id: uuid.UUID, password: str

--- a/backend/app/modules/admin/service.py
+++ b/backend/app/modules/admin/service.py
@@ -476,15 +476,34 @@ class AdminService:
 
         The advisory lock is taken here, so call this only when a change is
         actually needed; the caller compares the current role first.
-        """
-        if role_name == "admin":
-            # A promotion cannot threaten the invariant, so no lock is needed
-            # for it; _update_user_role still bumps key_epoch.
-            await self._update_user_role(user, role_name)
-            return True
 
+        fix(#1778 codex r4): the lock covers a PROMOTION too, which it did not
+        at first. The reasoning for skipping it was that a promotion cannot
+        threaten the last-admin invariant, which is true and beside the point:
+        two OAuth callbacks for the same returning account can arrive together,
+        and both then ran ``_update_user_role`` unserialized. That deletes and
+        re-inserts ``catalog.user_roles``, whose primary key is
+        ``(user_id, role_id)``, so the two inserts collide and one otherwise
+        valid login fails on a duplicate key.
+
+        Holding the lock across both branches also makes ``_update_user_role``'s
+        idempotency check load-bearing: the second caller re-reads the roles
+        under the lock, finds the promotion already applied, and returns without
+        touching the table or bumping ``key_epoch`` a second time.
+
+        Same lock for both branches rather than a per-user row lock, because the
+        demotion branch needs the global one anyway (the last-admin count is
+        fleet-wide) and one lock cannot deadlock against itself.
+        """
         await self._lock_admin_lifecycle()
         await self.db.refresh(user, attribute_names=["roles"])
+
+        if role_name == "admin":
+            # A promotion cannot threaten the last-admin invariant, so it skips
+            # the check but not the lock.
+            await self._update_user_role(user, role_name, lock_held=True)
+            return True
+
         try:
             await self._ensure_not_last_admin(user, "demote", lock_held=True)
         except ValueError:

--- a/backend/app/modules/admin/service.py
+++ b/backend/app/modules/admin/service.py
@@ -452,6 +452,50 @@ class AdminService:
             update(User).where(User.id == user.id).values(key_epoch=User.key_epoch + 1)
         )
 
+    async def set_role_from_identity_provider(self, user: User, role_name: str) -> bool:
+        """Apply an IdP-mapped role. False when the last-admin rule refused it.
+
+        fix(#1778 codex r1): the OAuth group-role reconciliation
+        (``_reconcile_mapped_role`` in modules/auth/oauth/service.py) must not
+        be a second, weaker copy of this path. Two invariants live here and
+        both were missing from the reconciliation as first written:
+
+        * the last-admin rule. Assigning the default role directly could
+          remove the only active admin, which every other demotion route is
+          stopped from doing.
+        * the ``key_epoch`` bump (#821). Without it an API key minted while
+          the account was a viewer keeps resolving after the account is mapped
+          to admin, so the key silently gains privileges its owner never
+          re-minted it for.
+
+        This is the public seam for that: it calls the same
+        ``_ensure_not_last_admin`` and ``_update_user_role`` the admin router
+        uses, rather than copying the count query. A refusal is not an error
+        for the caller -- an IdP assertion is not an admin action, so the login
+        continues with the role unchanged and the caller records why.
+
+        The advisory lock is taken here, so call this only when a change is
+        actually needed; the caller compares the current role first.
+        """
+        if role_name == "admin":
+            # A promotion cannot threaten the invariant, so no lock is needed
+            # for it; _update_user_role still bumps key_epoch.
+            await self._update_user_role(user, role_name)
+            return True
+
+        await self._lock_admin_lifecycle()
+        await self.db.refresh(user, attribute_names=["roles"])
+        try:
+            await self._ensure_not_last_admin(user, "demote", lock_held=True)
+        except ValueError:
+            # The only ValueError _ensure_not_last_admin raises is the refusal
+            # itself, and it is a refusal here rather than a failure.
+            return False
+        await self._update_user_role(
+            user, role_name, lock_held=True, viability_checked=True
+        )
+        return True
+
     async def convert_saml_user_to_local(
         self, user_id: uuid.UUID, password: str
     ) -> tuple[User, str]:

--- a/backend/app/modules/audit/actions.py
+++ b/backend/app/modules/audit/actions.py
@@ -91,6 +91,14 @@ AUDIT_ACTIONS: frozenset[str] = frozenset(
         "oauth.login.failure",
         "oauth.login.init",
         "oauth.login.success",
+        # fix(#1778): the IdP group-role mapping is applied on every OAuth
+        # login, not just the one that creates the account, so a role can now
+        # move without an admin touching it. These two are how an operator sees
+        # that happen: `changed` when the mapping moved the role, `change_refused`
+        # when the last-admin rule kept it where it was. Neither carries a claim
+        # value.
+        "oauth.role.change_refused",
+        "oauth.role.changed",
         "oauth_provider.create",
         "oauth_provider.delete",
         "oauth_provider.update",

--- a/backend/app/modules/auth/cookies.py
+++ b/backend/app/modules/auth/cookies.py
@@ -147,14 +147,24 @@ def read_refresh_cookie(request: Request) -> str | None:
     victim's host cookie, so duplicates are the attack's fingerprint: refusing
     them turns account confusion into a one-time re-login prompt.
     """
+    if _cookie_occurrences(request, REFRESH_COOKIE_NAME) > 1:
+        return None
+    return request.cookies.get(REFRESH_COOKIE_NAME)
+
+
+def _cookie_occurrences(request: Request, name: str) -> int:
+    """How many times *name* appears in the raw ``Cookie:`` header.
+
+    ``request.cookies`` is a dict, so it answers "which of the duplicates did
+    the parser keep", never "were there duplicates". Only the raw header can
+    tell the two apart.
+    """
     raw = request.headers.get("cookie", "")
     seen = 0
     for part in raw.split(";"):
-        if part.split("=", 1)[0].strip() == REFRESH_COOKIE_NAME:
+        if part.split("=", 1)[0].strip() == name:
             seen += 1
-    if seen > 1:
-        return None
-    return request.cookies.get(REFRESH_COOKIE_NAME)
+    return seen
 
 
 def _origin_parts(url: str) -> tuple[str, str, int | None] | None:
@@ -232,6 +242,28 @@ def enforce_csrf(request: Request) -> None:
     read does not depend on it. It is also directly exercisable by a plain HTTP
     client, with no browser preflight to simulate.
     """
+    # fix(#1778): the same duplicate-cookie refusal read_refresh_cookie has had
+    # since #1446, applied to the other half of the pair. Double-submit rests
+    # entirely on the attacker not knowing the cookie's value (see the docstring
+    # above), and a sibling subdomain can CHOOSE that value: set
+    # geolens_csrf=KNOWN with a parent Domain, and the browser sends two
+    # geolens_csrf cookies. Starlette's parser keeps the last occurrence, and a
+    # freshly-set Domain cookie sharing Path=/ sorts after the older host-only
+    # one under RFC 6265, so the attacker's value is the one compared. The
+    # victim's host-only geolens_refresh is untouched and still single, so
+    # read_refresh_cookie accepts it and the request would go through.
+    #
+    # Refusing on a duplicate turns that into a 403 the victim can clear by
+    # signing in again -- the same trade #1446 already accepted for the refresh
+    # cookie, where the attacker can likewise force a re-login by planting a
+    # shadow. Not fixable by naming alone in dev: the __Host- prefix (which
+    # browsers refuse to honour on a Domain cookie) needs TLS, and
+    # _secure_cookies() is False without a terminator.
+    if _cookie_occurrences(request, CSRF_COOKIE_NAME) > 1:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Invalid CSRF token",
+        )
     header_token = request.headers.get(CSRF_HEADER_NAME)
     cookie_token = request.cookies.get(CSRF_COOKIE_NAME)
     if not header_token or not cookie_token:

--- a/backend/app/modules/auth/oauth/router.py
+++ b/backend/app/modules/auth/oauth/router.py
@@ -369,16 +369,45 @@ async def oauth_callback(
     except HTTPException:
         raise  # Let 404s from build_oauth_client pass through
     except Exception as exc:  # broad: OAuth provider can return arbitrary errors; map to redirect with correlation_id
-        # Phase 268 H-30: surface email-not-verified collisions explicitly.
+        # Refusals the caller is told about by name, rather than through the
+        # generic "OAuth callback failed" below: Phase 268 H-30's
+        # email-not-verified collision, DOMAIN-03's allowlist rejection, and
+        # fix(#1778)'s registration-disabled gate.
+        #
+        # Each of the three does exactly the same thing, so they share one loop
+        # (fix(#1778): they were three copies of this block, and the third would
+        # have been a fourth). DOMAIN-03 (T-1236-04): the log records the
+        # provider slug and correlation_id ONLY -- never the attempted email
+        # address or subject (information-disclosure mitigation).
         from app.modules.auth.oauth.service import (
             OAuthDomainNotAllowedError,
             OAuthEmailUnverifiedError,
+            OAuthRegistrationDisabledError,
         )
 
-        if isinstance(exc, OAuthEmailUnverifiedError):
+        named_refusals: tuple[tuple[type[Exception], str, str], ...] = (
+            (
+                OAuthEmailUnverifiedError,
+                "email_not_verified",
+                "OAuth callback refused: unverified email collision",
+            ),
+            (
+                OAuthDomainNotAllowedError,
+                "domain_not_allowed",
+                "OAuth callback refused: email domain not in allowlist",
+            ),
+            (
+                OAuthRegistrationDisabledError,
+                "registration_disabled",
+                "OAuth callback refused: self-serve registration is disabled",
+            ),
+        )
+        for refusal_type, outcome, log_message in named_refusals:
+            if not isinstance(exc, refusal_type):
+                continue
             # Reuse the threaded correlation_id — do NOT mint a new one.
             logger.warning(
-                "OAuth callback refused: unverified email collision",
+                log_message,
                 provider=provider_slug,
                 correlation_id=correlation_id,
             )
@@ -393,7 +422,7 @@ async def oauth_callback(
                     details={
                         "provider_slug": provider_slug,
                         "correlation_id": correlation_id,
-                        "outcome": "email_not_verified",
+                        "outcome": outcome,
                     },
                     ip_address=get_client_ip(request),
                 ),
@@ -408,49 +437,7 @@ async def oauth_callback(
                 )
             error_url = (
                 f"{frontend_url}/oauth/callback"
-                f"#error=email_not_verified&correlation_id={correlation_id}"
-            )
-            # SEC-13: same Referrer-Policy override as success path
-            return RedirectResponse(
-                url=error_url,
-                status_code=302,
-                headers={"Referrer-Policy": "no-referrer"},
-            )
-        # DOMAIN-03 (T-1236-04): log provider + correlation_id only — do NOT
-        # log the attempted email address (information-disclosure mitigation).
-        if isinstance(exc, OAuthDomainNotAllowedError):
-            # Reuse the threaded correlation_id — do NOT mint a new one.
-            logger.warning(
-                "OAuth callback refused: email domain not in allowlist",
-                provider=provider_slug,
-                correlation_id=correlation_id,
-            )
-            # HARDEN-04: emit failure audit entry for domain rejection.
-            await audit_emit(
-                db,
-                AuditEvent(
-                    user_id=None,
-                    action="oauth.login.failure",
-                    resource_type="oauth_provider",
-                    details={
-                        "provider_slug": provider_slug,
-                        "correlation_id": correlation_id,
-                        "outcome": "domain_not_allowed",
-                    },
-                    ip_address=get_client_ip(request),
-                ),
-            )
-            try:
-                await db.commit()
-            except Exception:  # broad: defensive log-and-continue — an audit/rollback write must never break the OAuth redirect flow
-                logger.exception(
-                    "Failed to commit oauth.login.failure audit row; continuing",
-                    provider=provider_slug,
-                    correlation_id=correlation_id,
-                )
-            error_url = (
-                f"{frontend_url}/oauth/callback"
-                f"#error=domain_not_allowed&correlation_id={correlation_id}"
+                f"#error={outcome}&correlation_id={correlation_id}"
             )
             # SEC-13: same Referrer-Policy override as success path
             return RedirectResponse(

--- a/backend/app/modules/auth/oauth/service.py
+++ b/backend/app/modules/auth/oauth/service.py
@@ -752,8 +752,17 @@ async def _reconcile_mapped_role(
       identity linked to by verified email keeps the roles the GeoLens admin
       gave it.
 
-    Every change is recorded: a structured log line and an ``oauth.role.changed``
-    audit row carrying the provider slug, both role names, and no claim values.
+    fix(#1778 codex r1): the change itself goes through
+    ``AdminService.set_role_from_identity_provider`` rather than assigning
+    ``user.roles`` here, so it inherits the two invariants every other
+    role-change route already has: the admin-lifecycle advisory lock plus the
+    last-admin rule, and the ``key_epoch`` bump (#821) without which an API key
+    minted as a viewer would silently gain admin after the next OAuth login.
+
+    Every outcome is recorded: a structured log line, an ``oauth.role.changed``
+    audit row when the role moves, and an ``oauth.role.change_refused`` row when
+    the last-admin rule keeps the role where it is. Neither carries a claim
+    value.
     """
     if not is_enterprise():
         return
@@ -771,13 +780,14 @@ async def _reconcile_mapped_role(
     if len(current) == 1 and current[0].name == resolved:
         return
 
-    role_result = await db.execute(select(Role).where(Role.name == resolved))
-    role = role_result.scalar_one_or_none()
-    if role is None:
+    known_role = await db.scalar(select(Role.id).where(Role.name == resolved))
+    if known_role is None:
         # The mapping names a role this deployment does not have. Refusing to
         # act is the safe answer: dropping to viewer would be a demotion the
         # operator never asked for, and inventing the role is not this
-        # function's call.
+        # function's call. Checked here rather than letting the role-update
+        # helper's own ValueError surface, so the operator gets a message that
+        # names the mapping.
         logger.warning(
             "OAuth login: mapped role does not exist, leaving roles unchanged",
             provider=provider.slug,
@@ -787,10 +797,44 @@ async def _reconcile_mapped_role(
         return
 
     previous = sorted(r.name for r in current)
-    # Assign through the relationship rather than editing UserRole rows by hand,
-    # so the association rows and the in-session collection stay in step.
-    user.roles = [role]
+
+    # LAZY, per D-17 and to keep the import graph acyclic: admin/service.py
+    # already imports from auth/providers/local.py.
+    from app.modules.admin.service import AdminService  # noqa: PLC0415
+    from app.modules.audit.service import AuditEvent, audit_emit  # noqa: PLC0415
+
+    applied = await AdminService(db).set_role_from_identity_provider(user, resolved)
     await db.flush()
+    await db.refresh(user, attribute_names=["roles"])
+
+    if not applied:
+        # The account is the last active admin. An IdP assertion does not get to
+        # remove the deployment's only way back in, so the role stands and the
+        # login continues; the row is how an operator finds out that the mapping
+        # and the account list disagree.
+        logger.warning(
+            "OAuth login: mapped demotion refused, account is the last admin",
+            provider=provider.slug,
+            user_id=str(user.id),
+            previous_roles=previous,
+            mapped_role=resolved,
+        )
+        await audit_emit(
+            db,
+            AuditEvent(
+                user_id=user.id,
+                action="oauth.role.change_refused",
+                resource_type="user",
+                resource_id=user.id,
+                details={
+                    "provider_slug": provider.slug,
+                    "current_roles": previous,
+                    "mapped_role": resolved,
+                    "reason": "last_admin",
+                },
+            ),
+        )
+        return
 
     logger.info(
         "OAuth login: role re-evaluated from IdP group mapping",
@@ -799,8 +843,6 @@ async def _reconcile_mapped_role(
         previous_roles=previous,
         new_role=resolved,
     )
-
-    from app.modules.audit.service import AuditEvent, audit_emit  # noqa: PLC0415
 
     await audit_emit(
         db,
@@ -896,6 +938,16 @@ async def find_or_create_oauth_user(
     3. New user (OAUTH-05) -> create user with default_role, create OAuthAccount
 
     Group claims are mapped to roles per provider config (OAUTH-07).
+
+    fix(#1778 codex r1): there are exactly three return paths and every one of
+    them has to settle the role, so they are enumerated here rather than left to
+    be rediscovered. Steps 1 and 2 both yield an EXISTING account and both call
+    ``_reconcile_mapped_role``; step 3 creates the account and sets the role
+    from ``_resolve_role`` inline. The reconciliation was originally on step 1
+    alone, which left an OAuth-provisioned account linking to a second provider
+    for the first time carrying its old role for the whole of that session.
+    Adding a fourth path that returns an existing user means adding the
+    reconcile call with it.
     """
     subject = oauth_account_subject(
         provider.provider_type, provider.discovery_url, userinfo
@@ -1066,6 +1118,15 @@ async def find_or_create_oauth_user(
             )
             db.add(link)
             await db.flush()
+            # fix(#1778 codex r1): this is the other return path that yields an
+            # EXISTING account, so it needs the same reconciliation the
+            # subject-link branch got. Without it, an OAuth-provisioned account
+            # linking to a second provider for the first time carries whatever
+            # role the first provider gave it for the whole of that session,
+            # ignoring the mapping the operator configured on this one. The
+            # helper's own preconditions still apply, so a LOCAL account linked
+            # here keeps the roles its GeoLens admin gave it.
+            await _reconcile_mapped_role(db, provider, existing_user, groups)
             logger.info(
                 "OAuth login: linked to existing user by email",
                 provider=provider.slug,

--- a/backend/app/modules/auth/oauth/service.py
+++ b/backend/app/modules/auth/oauth/service.py
@@ -12,7 +12,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import undefer_group
 
 from app.core.edition import is_enterprise
-from app.core.persistent_config import ALLOWED_EMAIL_DOMAINS
+from app.core.persistent_config import ALLOWED_EMAIL_DOMAINS, REGISTRATION_ENABLED
 from app.modules.auth.domain_validation import is_email_allowed
 from app.modules.auth.models import Role, User, UserRole
 from app.modules.auth.oauth.encryption import encrypt_secret
@@ -358,6 +358,39 @@ class OAuthDomainNotAllowedError(Exception):
     """
 
 
+class OAuthRegistrationDisabledError(Exception):
+    """fix(#1778): raised when an unknown OAuth identity would be provisioned
+    while self-serve registration is switched off.
+
+    Codebase audit 2026-08-30, "Enabling any OAuth provider silently overrides
+    the operator's 'registration disabled' switch and auto-provisions active
+    accounts". ``registration_enabled`` defaults to False, and the password
+    path honours it, but JIT provisioning never read it. An operator who added
+    a Google or generic-OIDC provider through the admin UI without also filling
+    in ``allowed_email_domains`` therefore had open signup: any account at that
+    IdP reaching ``/auth/oauth/{slug}/login`` was provisioned active with the
+    provider's ``default_role``, which is ``viewer`` by default, and ``viewer``
+    can list and export every ``internal`` dataset. The Settings screen still
+    read "Registration enabled: off".
+
+    Only NEW identities are refused. A returning user with an existing
+    OAuthAccount link, and an identity that matches an existing account by
+    verified email, both still sign in -- the gate is about creating accounts,
+    not about locking out the people who already have one.
+
+    The router translates this into a redirect with an
+    ``error=registration_disabled`` fragment and an audit row naming the same
+    reason. No email or subject is logged.
+
+    Scope note: the SAML overlay provisions through this same function
+    (``IdentityExtension`` in app/core/identity.py names it), so the gate
+    applies there too. That is deliberate -- the switch says whether a sign-in
+    may create an account, and it should not answer differently depending on
+    which protocol carried the assertion -- but an operator who relied on SSO
+    to onboard has to turn registration on, or add the accounts first.
+    """
+
+
 async def create_provider(
     db: AsyncSession,
     data: OAuthProviderCreate,
@@ -682,6 +715,110 @@ def _resolve_role(
     return default
 
 
+async def _reconcile_mapped_role(
+    db: AsyncSession,
+    provider: OAuthProvider,
+    user: User,
+    groups: list[str] | None,
+) -> None:
+    """fix(#1778): re-apply ``group_role_mapping`` on a returning user's login.
+
+    Codebase audit 2026-08-30, "OAuth role is bound once at JIT creation and
+    never re-evaluated -- ``group_role_mapping`` can grant a role but can never
+    revoke one". The mapping ran only on the login that created the account, so
+    removing someone from the IdP group never demoted them; the role granted on
+    day one stood until an admin edited it by hand. The field's own description
+    ("JSON object mapping IdP group names to GeoLens roles. First match wins")
+    and the two UI hints all read as a live mapping, while ``default_role``'s
+    description does say "assigned to new users" -- so the field documented as
+    one-shot behaved that way and the field that read as continuous did not.
+
+    Four preconditions, each load-bearing, and all four have to hold before a
+    single role is touched:
+
+    * ``is_enterprise()`` -- group mapping is an enterprise capability, and the
+      JIT path already ignores the column outside it.
+    * a NON-EMPTY mapping -- with no mapping configured the operator has said
+      nothing about roles, so GeoLens is the system of record and an admin who
+      was promoted here keeps that. This is the precondition that keeps a local
+      promotion from being undone by a login.
+    * the groups claim is PRESENT -- ``_resolve_role(None, mapping, default)``
+      returns ``default_role``, so an IdP that omits the claim on one login
+      would otherwise demote every user who signed in during the omission. No
+      assertion means no evidence, not evidence of no membership. An IdP that
+      asserts an EMPTY list has said something, and that resolves to the
+      default.
+    * the account is OAuth-provisioned -- a local account that an OAuth
+      identity linked to by verified email keeps the roles the GeoLens admin
+      gave it.
+
+    Every change is recorded: a structured log line and an ``oauth.role.changed``
+    audit row carrying the provider slug, both role names, and no claim values.
+    """
+    if not is_enterprise():
+        return
+    mapping = provider.group_role_mapping
+    if not mapping:
+        return
+    if groups is None:
+        return
+    if user.auth_provider != "oauth":
+        return
+
+    resolved = _resolve_role(groups, mapping, provider.default_role)
+
+    current = list(user.roles)
+    if len(current) == 1 and current[0].name == resolved:
+        return
+
+    role_result = await db.execute(select(Role).where(Role.name == resolved))
+    role = role_result.scalar_one_or_none()
+    if role is None:
+        # The mapping names a role this deployment does not have. Refusing to
+        # act is the safe answer: dropping to viewer would be a demotion the
+        # operator never asked for, and inventing the role is not this
+        # function's call.
+        logger.warning(
+            "OAuth login: mapped role does not exist, leaving roles unchanged",
+            provider=provider.slug,
+            user_id=str(user.id),
+            mapped_role=resolved,
+        )
+        return
+
+    previous = sorted(r.name for r in current)
+    # Assign through the relationship rather than editing UserRole rows by hand,
+    # so the association rows and the in-session collection stay in step.
+    user.roles = [role]
+    await db.flush()
+
+    logger.info(
+        "OAuth login: role re-evaluated from IdP group mapping",
+        provider=provider.slug,
+        user_id=str(user.id),
+        previous_roles=previous,
+        new_role=resolved,
+    )
+
+    from app.modules.audit.service import AuditEvent, audit_emit  # noqa: PLC0415
+
+    await audit_emit(
+        db,
+        AuditEvent(
+            user_id=user.id,
+            action="oauth.role.changed",
+            resource_type="user",
+            resource_id=user.id,
+            details={
+                "provider_slug": provider.slug,
+                "previous_roles": previous,
+                "new_role": resolved,
+                "reason": "group_role_mapping",
+            },
+        ),
+    )
+
+
 _AZURE_MULTITENANT_AUTHORITIES = ("/common/", "/organizations/")
 
 
@@ -849,6 +986,8 @@ async def find_or_create_oauth_user(
             returning_user.email_verified = True
             await db.flush()
 
+        await _reconcile_mapped_role(db, provider, returning_user, groups)
+
         logger.info(
             "OAuth login: existing link found",
             provider=provider.slug,
@@ -959,6 +1098,24 @@ async def find_or_create_oauth_user(
             email=email,
         )
         email = None
+
+    # fix(#1778): the operator's self-serve-registration switch gates this path
+    # too. Everything above either returned an existing account (Step 1's link,
+    # Step 2's verified-email match) or refused, so reaching here means a NEW
+    # account is about to be created -- which is the thing REGISTRATION_ENABLED
+    # decides. Placed after the domain and email-verification checks so a
+    # refusal here cannot be used to probe which of the gates an identity trips.
+    #
+    # Cache-bypass for the same reason the domain gate uses it: enforcement
+    # reads committed state, so an operator who has just switched registration
+    # off is not overruled by a cached value.
+    if not await REGISTRATION_ENABLED.get_uncached(db):
+        raise OAuthRegistrationDisabledError(
+            "Self-serve registration is disabled, so a new account cannot be "
+            "created for this identity. An administrator must create the "
+            "account first; signing in through this provider will then link to "
+            "it."
+        )
 
     # Step 3: Auto-create new user
     base_username = _generate_username(display_name, email)

--- a/backend/app/modules/auth/oauth/service.py
+++ b/backend/app/modules/auth/oauth/service.py
@@ -796,18 +796,22 @@ async def _reconcile_mapped_role(
         )
         return
 
-    previous = sorted(r.name for r in current)
-
     # LAZY, per D-17 and to keep the import graph acyclic: admin/service.py
     # already imports from auth/providers/local.py.
     from app.modules.admin.service import AdminService  # noqa: PLC0415
     from app.modules.audit.service import AuditEvent, audit_emit  # noqa: PLC0415
 
-    applied = await AdminService(db).set_role_from_identity_provider(user, resolved)
+    outcome = await AdminService(db).set_role_from_identity_provider(user, resolved)
     await db.flush()
     await db.refresh(user, attribute_names=["roles"])
 
-    if not applied:
+    # fix(#1778 codex r5): the roles as they were UNDER the lock, not as this
+    # coroutine last saw them before waiting for it. Two concurrent callbacks
+    # both captured the pre-lock snapshot, and the one that lost the race then
+    # described a transition that had already happened.
+    previous = outcome.previous_roles
+
+    if not outcome.applied:
         # The account is the last active admin. An IdP assertion does not get to
         # remove the deployment's only way back in, so the role stands and the
         # login continues; the row is how an operator finds out that the mapping
@@ -834,6 +838,14 @@ async def _reconcile_mapped_role(
                 },
             ),
         )
+        return
+
+    if not outcome.changed:
+        # fix(#1778 codex r5): the role was already what the mapping asks for, so
+        # nothing happened and nothing is recorded. This is where the second of
+        # two concurrent callbacks lands once it gets the lock; emitting here
+        # produced a duplicate oauth.role.changed for a transition the first one
+        # had already made.
         return
 
     logger.info(

--- a/backend/app/modules/auth/providers/local.py
+++ b/backend/app/modules/auth/providers/local.py
@@ -8,6 +8,7 @@ from pwdlib.exceptions import UnknownHashError
 from pwdlib.hashers.bcrypt import BcryptHasher
 
 from app.modules.auth.models import User
+from app.modules.auth.password_policy import BCRYPT_MAX_PASSWORD_BYTES
 from app.modules.auth.providers import AuthenticatedIdentity, AuthenticationError
 
 # ---------------------------------------------------------------------------
@@ -28,7 +29,27 @@ def hash_password(password: str) -> str:
 
 
 def verify_password(plain: str, hashed: str) -> bool:
-    """Verify a plaintext password against a stored hash."""
+    """Verify a plaintext password against a stored hash.
+
+    fix(#1778): an input longer than bcrypt's 72-byte limit is a NON-MATCH, not
+    an exception. pwdlib's BcryptHasher raises ValueError rather than
+    truncating, and the two callers that reach here with an unvalidated string
+    both turned that into a 500. POST /auth/login takes an
+    OAuth2PasswordRequestForm, which carries no schema at all, so any
+    unauthenticated caller could 500 it on demand and the user.login.failure
+    audit row was skipped with it (the handler catches AuthenticationError, and
+    a ValueError is not one). POST /auth/change-password/ bounds only
+    ``new_password``; ``current_password`` is capped at 256 CHARACTERS.
+
+    Refusing rather than truncating is the honest answer: register,
+    change-password, admin create and admin reset all run
+    validate_password_complexity, which caps the stored credential at
+    BCRYPT_MAX_PASSWORD_BYTES, so no hash in the database was derived from a
+    longer input and no correct password can be rejected here. Truncating would
+    instead accept the first 72 bytes of a longer string as the whole password.
+    """
+    if len(plain.encode("utf-8")) > BCRYPT_MAX_PASSWORD_BYTES:
+        return False
     return password_hash.verify(plain, hashed)
 
 
@@ -92,7 +113,7 @@ class LocalAuthProvider:
 
         if user is None:
             # Timing-attack prevention: still verify against a dummy hash
-            password_hash.verify(password, DUMMY_HASH)
+            verify_password(password, DUMMY_HASH)
             raise AuthenticationError("Invalid credentials")
 
         if user.password_hash is None:
@@ -106,7 +127,7 @@ class LocalAuthProvider:
             # real verify against the dummy hash for timing-attack parity
             # with the "user not found" branch above, then always fail --
             # there is no real password for this account to match.
-            password_hash.verify(password, DUMMY_HASH)
+            verify_password(password, DUMMY_HASH)
             raise AuthenticationError("Invalid credentials")
 
         try:

--- a/backend/app/modules/embed_tokens/service.py
+++ b/backend/app/modules/embed_tokens/service.py
@@ -36,6 +36,39 @@ from app.platform.extensions import get_processing_port
 logger = structlog.stdlib.get_logger(__name__)
 
 
+# fix(#1778): codebase audit 2026-08-30, "Embed-token revocation invalidates the
+# Redis positive cache BEFORE the caller's commit, so a concurrent request can
+# re-cache the still-active token and keep it serving for 300s".
+#
+# Every revoke path here flips ``is_active`` and evicts the positive entry while
+# its caller's transaction is still open; the caller commits later (a share
+# revoke commits 17 lines further down router_sharing.py). In that window a tile
+# or feature request for the same token misses the cache, SELECTs the row --
+# which a plain READ COMMITTED read still sees as active, because it does not
+# block on the revoking transaction -- and writes a fresh positive entry that
+# outlives the commit. The cache-hit path re-checks only ``expires_at``
+# (SEC-014), so every subsequent request off that entry is granted, for up to
+# the full TTL. That is exactly what builder-audit #338 P0-01 set out to remove.
+#
+# Deleting the key cannot close that window from either side: the reader's write
+# lands after the deleter's delete. So a revocation writes a DENIAL under the
+# key instead of removing it, and the reader publishes its positive entry with
+# ``set_if_absent`` rather than ``set``. Whichever of the two lands first, the
+# denial is what survives: if the denial is already there the reader's NX write
+# is refused, and if the reader got there first the denial overwrites it. The
+# request that raced still completes -- it read a committed-active row and
+# nothing about it was wrong at the time -- but it leaves nothing behind.
+#
+# The denial's TTL must cover the longest positive entry a racer could have
+# tried to write, which is the 300s cap in validate_embed_token_access.
+#
+# The trade: a revoking transaction that ROLLS BACK leaves its denial in place,
+# so a token that is still active is refused until the entry expires and the
+# next request reads the database again. That direction is fail-closed and
+# self-healing, and it is the one to be wrong in.
+EMBED_TOKEN_REVOCATION_DENIAL_TTL_SECONDS = 300
+
+
 def _embed_token_cache_key(token_hash: str) -> str:
     """Return the active tenant's validation-cache key.
 
@@ -45,6 +78,28 @@ def _embed_token_cache_key(token_hash: str) -> str:
     single-tenant mode and fails closed without a hosted tenant context.
     """
     return tenant_cache_key(f"embed_token:{token_hash}")
+
+
+async def _deny_revoked_embed_tokens(*token_hashes: str) -> None:
+    """Stamp a denial over each revoked token's validation-cache entry.
+
+    Best-effort, like the eviction it replaces: a cache failure must not break
+    the revocation, which is what the database row records. See the module note
+    on EMBED_TOKEN_REVOCATION_DENIAL_TTL_SECONDS for why this writes a denial
+    rather than deleting the key.
+    """
+    if not token_hashes:
+        return
+    try:
+        cache = get_cache()
+        for token_hash in token_hashes:
+            await cache.set(
+                _embed_token_cache_key(token_hash),
+                {"is_valid": False},
+                ttl=EMBED_TOKEN_REVOCATION_DENIAL_TTL_SECONDS,
+            )
+    except Exception:  # broad: cache invalidation must not break callers; redis can throw varied pool/timeout errors
+        logger.error("Cache invalidation failed for embed token", exc_info=True)
 
 
 # Phase 268 H-31: loopback IP set used to gate the localhost-Origin bypass.
@@ -459,13 +514,7 @@ async def create_embed_token(
         revoked_hashes.append(old_token.token_hash)
 
     # Best-effort cache invalidation for revoked tokens
-    if revoked_hashes:
-        try:
-            cache = get_cache()
-            for h in revoked_hashes:
-                await cache.delete(_embed_token_cache_key(h))
-        except Exception:  # broad: cache invalidation must not break callers; redis can throw varied pool/timeout errors
-            logger.error("Cache invalidation failed for embed token", exc_info=True)
+    await _deny_revoked_embed_tokens(*revoked_hashes)
 
     # Generate raw token
     raw_token = "et_" + secrets.token_urlsafe(32)
@@ -540,11 +589,7 @@ async def revoke_embed_token(
     await db.flush()
 
     # Best-effort cache invalidation
-    try:
-        cache = get_cache()
-        await cache.delete(_embed_token_cache_key(token.token_hash))
-    except Exception:  # broad: cache invalidation must not break callers; redis can throw varied pool/timeout errors
-        logger.error("Cache invalidation failed for embed token", exc_info=True)
+    await _deny_revoked_embed_tokens(token.token_hash)
 
     return token
 
@@ -585,12 +630,7 @@ async def revoke_embed_tokens_by_map(
     # Best-effort cache invalidation — a cached positive entry must not outlive
     # the revocation (builder-audit #338 P0-01 acceptance: Redis positive cache does
     # not extend access).
-    try:
-        cache = get_cache()
-        for token in tokens:
-            await cache.delete(_embed_token_cache_key(token.token_hash))
-    except Exception:  # broad: cache invalidation must not break callers; redis can throw varied pool/timeout errors
-        logger.error("Cache invalidation failed for embed token", exc_info=True)
+    await _deny_revoked_embed_tokens(*(token.token_hash for token in tokens))
 
     return len(tokens)
 
@@ -806,9 +846,18 @@ async def validate_embed_token_access(
         # re-check expiry (SEC-014). Include tenant_id for EMBED-02 cache-hit
         # path so validate_embed_token_access can check tenant equality without
         # re-querying the EmbedToken row (Phase 1212).
+        #
+        # fix(#1778): set_if_absent, not set. The row this was read from is
+        # committed-active, but a revocation may be open on it right now (a
+        # plain READ COMMITTED select does not block on the revoking
+        # transaction's lock), and that revocation has already stamped its
+        # denial under this key. Overwriting it would restore the token for the
+        # rest of this entry's TTL, which is the window builder-audit #338
+        # P0-01 exists to close. See the module note on
+        # EMBED_TOKEN_REVOCATION_DENIAL_TTL_SECONDS.
         seconds_until_expiry = (token.expires_at - now).total_seconds()
         cache_ttl = int(min(300, max(0, seconds_until_expiry)))
-        await cache.set(
+        await cache.set_if_absent(
             cache_key,
             {
                 "is_valid": True,
@@ -1046,11 +1095,6 @@ async def bulk_revoke_embed_tokens(
     await db.flush()
 
     # Best-effort cache invalidation
-    try:
-        cache = get_cache()
-        for token in tokens:
-            await cache.delete(_embed_token_cache_key(token.token_hash))
-    except Exception:  # broad: cache invalidation must not break callers; redis can throw varied pool/timeout errors
-        logger.error("Cache invalidation failed for embed token", exc_info=True)
+    await _deny_revoked_embed_tokens(*(token.token_hash for token in tokens))
 
     return len(tokens)

--- a/backend/app/modules/embed_tokens/service.py
+++ b/backend/app/modules/embed_tokens/service.py
@@ -103,18 +103,28 @@ async def _deny_revoked_embed_tokens(db: AsyncSession, *token_hashes: str) -> No
     rather than deleting the key.
 
     fix(#1778 codex r3): also advances the cluster-global revocation generation.
-    The denial above is written through this worker's cache provider, and during
-    a Redis outage that reaches no other worker; the generation is a database
-    row every worker consults, so it is what carries the revocation across the
-    process boundary. It is bumped FIRST, so no positive entry can be minted
-    under the new generation while the revoke is still landing.
+    The denial below is written through this worker's cache provider, and during
+    a Redis outage that reaches no other worker; the generation is a database row
+    every worker consults, so it is what carries the revocation across the
+    process boundary.
+
+    fix(#1778 codex r4): the bump shares the CALLER's transaction, so it becomes
+    visible at the same instant as the ``is_active`` flip the caller has already
+    made. An earlier draft advanced a non-transactional sequence and published it
+    to Redis before the commit, which let a concurrent validator read the new
+    generation, read the token row as still active, and cache a positive stamped
+    with the new generation that then survived the commit. Ordering alone cannot
+    fix that; sharing the transaction does, because there is no instant at which
+    one is visible and the other is not.
+
+    It is also why this raises nothing on failure but the bump is NOT wrapped in
+    its own try/except: a bump that fails has poisoned the caller's transaction,
+    and swallowing it would let the revocation commit without the generation
+    that tells every other worker about it.
     """
     if not token_hashes:
         return
-    try:
-        await bump_revocation_generation(db)
-    except Exception:  # broad: a generation bump must not break the revocation the database row already records
-        logger.error("Revocation generation bump failed", exc_info=True)
+    await bump_revocation_generation(db)
     try:
         cache = get_cache()
         for token_hash in token_hashes:

--- a/backend/app/modules/embed_tokens/service.py
+++ b/backend/app/modules/embed_tokens/service.py
@@ -93,7 +93,13 @@ async def _deny_revoked_embed_tokens(*token_hashes: str) -> None:
     try:
         cache = get_cache()
         for token_hash in token_hashes:
-            await cache.set(
+            # fix(#1778 codex r1): set_authoritative, not set. `set` routes to
+            # whichever store the circuit breaker says is live, so a positive
+            # entry that landed in the in-memory fallback during a Redis outage
+            # survived a denial written after Redis recovered, and the next
+            # Redis error served the revoked token again. The denial has to
+            # reach every store a later read could consult.
+            await cache.set_authoritative(
                 _embed_token_cache_key(token_hash),
                 {"is_valid": False},
                 ttl=EMBED_TOKEN_REVOCATION_DENIAL_TTL_SECONDS,

--- a/backend/app/modules/embed_tokens/service.py
+++ b/backend/app/modules/embed_tokens/service.py
@@ -20,6 +20,10 @@ from app.core.public_urls import (
 from app.core.tenancy import is_multi_tenant
 from app.platform.cache import tenant_cache_context_available, tenant_cache_key
 from app.platform.cache.provider import get_cache
+from app.platform.cache.revocation import (
+    bump_revocation_generation,
+    current_revocation_generation,
+)
 from app.modules.embed_tokens.models import EmbedToken
 from app.modules.embed_tokens.schemas import (
     ADVANCED_SHARING_ERROR,
@@ -68,6 +72,16 @@ logger = structlog.stdlib.get_logger(__name__)
 # self-healing, and it is the one to be wrong in.
 EMBED_TOKEN_REVOCATION_DENIAL_TTL_SECONDS = 300
 
+# fix(#1778 codex r3): named because it is the bound on a residual rather than a
+# tuning knob. A worker that took no traffic at all during a Redis outage never
+# opened its circuit, so it never learns it should re-read the revocation
+# generation, and it keeps trusting whatever Redis holds for a token until that
+# entry expires. This number is how long that can last: five minutes. See the
+# residual section of platform/cache/revocation.py. Lowering it shortens the
+# exposure and costs a database read per token per interval; raising it does the
+# reverse.
+EMBED_TOKEN_POSITIVE_TTL_SECONDS = 300
+
 
 def _embed_token_cache_key(token_hash: str) -> str:
     """Return the active tenant's validation-cache key.
@@ -80,16 +94,27 @@ def _embed_token_cache_key(token_hash: str) -> str:
     return tenant_cache_key(f"embed_token:{token_hash}")
 
 
-async def _deny_revoked_embed_tokens(*token_hashes: str) -> None:
+async def _deny_revoked_embed_tokens(db: AsyncSession, *token_hashes: str) -> None:
     """Stamp a denial over each revoked token's validation-cache entry.
 
     Best-effort, like the eviction it replaces: a cache failure must not break
     the revocation, which is what the database row records. See the module note
     on EMBED_TOKEN_REVOCATION_DENIAL_TTL_SECONDS for why this writes a denial
     rather than deleting the key.
+
+    fix(#1778 codex r3): also advances the cluster-global revocation generation.
+    The denial above is written through this worker's cache provider, and during
+    a Redis outage that reaches no other worker; the generation is a database
+    row every worker consults, so it is what carries the revocation across the
+    process boundary. It is bumped FIRST, so no positive entry can be minted
+    under the new generation while the revoke is still landing.
     """
     if not token_hashes:
         return
+    try:
+        await bump_revocation_generation(db)
+    except Exception:  # broad: a generation bump must not break the revocation the database row already records
+        logger.error("Revocation generation bump failed", exc_info=True)
     try:
         cache = get_cache()
         for token_hash in token_hashes:
@@ -520,7 +545,7 @@ async def create_embed_token(
         revoked_hashes.append(old_token.token_hash)
 
     # Best-effort cache invalidation for revoked tokens
-    await _deny_revoked_embed_tokens(*revoked_hashes)
+    await _deny_revoked_embed_tokens(db, *revoked_hashes)
 
     # Generate raw token
     raw_token = "et_" + secrets.token_urlsafe(32)
@@ -595,7 +620,7 @@ async def revoke_embed_token(
     await db.flush()
 
     # Best-effort cache invalidation
-    await _deny_revoked_embed_tokens(token.token_hash)
+    await _deny_revoked_embed_tokens(db, token.token_hash)
 
     return token
 
@@ -636,7 +661,7 @@ async def revoke_embed_tokens_by_map(
     # Best-effort cache invalidation — a cached positive entry must not outlive
     # the revocation (builder-audit #338 P0-01 acceptance: Redis positive cache does
     # not extend access).
-    await _deny_revoked_embed_tokens(*(token.token_hash for token in tokens))
+    await _deny_revoked_embed_tokens(db, *(token.token_hash for token in tokens))
 
     return len(tokens)
 
@@ -802,12 +827,34 @@ async def validate_embed_token_access(
     cache = get_cache()
     token: EmbedToken | None = None
 
-    # Check cache first
-    cached = await cache.get(cache_key)
-    if cached is not None:
-        if not cached.get("is_valid", False):
-            return False
+    # fix(#1778 codex r3): the generation every positive entry is stamped with.
+    # Read before the cache so a hit can be compared without a second
+    # round-trip; platform/cache/revocation.py says why a process-local answer
+    # is not enough here.
+    generation = await current_revocation_generation(db)
 
+    # Check cache first. security=True: a positive here decides access to
+    # private data, so it may only come from the store every worker shares.
+    cached = await cache.get(cache_key, security=True)
+    if cached is not None and not cached.get("is_valid", False):
+        return False
+
+    # fix(#1778 codex r3): an entry minted before the latest revocation is not
+    # evidence about the token now. A revoke performed while THIS worker could
+    # not reach Redis is invisible to it in every other way; this comparison is
+    # what makes it visible, because the generation advanced in the database,
+    # which is the store that stayed up.
+    #
+    # An entry with NO stamp fails this too, which is what an entry written by a
+    # pre-upgrade process looks like. The cost is one database re-validation per
+    # live token in the minutes after a rolling deploy, and the alternative
+    # (treating a missing stamp as current) would trust exactly the entries this
+    # cannot vouch for.
+    if cached is not None and cached.get("generation") != generation:
+        await cache.delete(cache_key)
+        cached = None
+
+    if cached is not None:
         # SEC-014: re-check expiry on every cache hit so a token cannot stay
         # valid for up to the 5-minute positive-cache TTL past its real
         # expires_at.  The cached dict now stores expires_at as an ISO string;
@@ -841,8 +888,11 @@ async def validate_embed_token_access(
         token = result.scalar_one_or_none()
 
         if token is None:
-            # Cache negative result
-            await cache.set(cache_key, {"is_valid": False}, ttl=300)
+            # Cache negative result. security=True keeps it out of the
+            # process-local fallback for symmetry with the positive; a denial
+            # would be safe there, but a store that only ever holds denials is
+            # one fewer thing for a future reader to reason about.
+            await cache.set(cache_key, {"is_valid": False}, ttl=300, security=True)
             return False
 
         allowed_origins = token.allowed_origins
@@ -862,7 +912,9 @@ async def validate_embed_token_access(
         # P0-01 exists to close. See the module note on
         # EMBED_TOKEN_REVOCATION_DENIAL_TTL_SECONDS.
         seconds_until_expiry = (token.expires_at - now).total_seconds()
-        cache_ttl = int(min(300, max(0, seconds_until_expiry)))
+        cache_ttl = int(
+            min(EMBED_TOKEN_POSITIVE_TTL_SECONDS, max(0, seconds_until_expiry))
+        )
         await cache.set_if_absent(
             cache_key,
             {
@@ -872,8 +924,14 @@ async def validate_embed_token_access(
                 "map_id": str(token.map_id),
                 "expires_at": token.expires_at.isoformat(),
                 "tenant_id": str(token.tenant_id) if token.tenant_id else None,
+                # fix(#1778 codex r3): the generation this decision was made
+                # under. A later read compares it and refuses an entry that
+                # predates a revocation, which is how a revoke performed on
+                # another worker during a Redis outage reaches this one.
+                "generation": generation,
             },
             ttl=cache_ttl,
+            security=True,
         )
 
     # Domain-locking check (before dataset scope check). Shares ONE policy
@@ -1101,6 +1159,6 @@ async def bulk_revoke_embed_tokens(
     await db.flush()
 
     # Best-effort cache invalidation
-    await _deny_revoked_embed_tokens(*(token.token_hash for token in tokens))
+    await _deny_revoked_embed_tokens(db, *(token.token_hash for token in tokens))
 
     return len(tokens)

--- a/backend/app/modules/embed_tokens/service.py
+++ b/backend/app/modules/embed_tokens/service.py
@@ -21,8 +21,10 @@ from app.core.tenancy import is_multi_tenant
 from app.platform.cache import tenant_cache_context_available, tenant_cache_key
 from app.platform.cache.provider import get_cache
 from app.platform.cache.revocation import (
+    UNKNOWN_GENERATION,
     bump_revocation_generation,
     current_revocation_generation,
+    is_usable_generation,
 )
 from app.modules.embed_tokens.models import EmbedToken
 from app.modules.embed_tokens.schemas import (
@@ -842,6 +844,15 @@ async def validate_embed_token_access(
     # round-trip; platform/cache/revocation.py says why a process-local answer
     # is not enough here.
     generation = await current_revocation_generation(db)
+    # fix(#1778 codex r5): an unreadable counter yields a SENTINEL, not a
+    # generation. Stamping it on an entry, or comparing two entries by it, made
+    # them compare EQUAL -- so a positive cached while the counter was
+    # unreadable stayed trusted through a later revocation whose denial could
+    # not reach shared Redis. When the generation is unusable the cache is
+    # simply not used, in either direction: nothing is trusted and nothing is
+    # written. Every validation then costs a database read, which is the right
+    # price for not knowing whether anything has been revoked.
+    generation_usable = is_usable_generation(generation)
 
     # Check cache first. security=True: a positive here decides access to
     # private data, so it may only come from the store every worker shares.
@@ -860,7 +871,11 @@ async def validate_embed_token_access(
     # live token in the minutes after a rolling deploy, and the alternative
     # (treating a missing stamp as current) would trust exactly the entries this
     # cannot vouch for.
-    if cached is not None and cached.get("generation") != generation:
+    if cached is not None and (
+        not generation_usable
+        or not is_usable_generation(cached.get("generation", UNKNOWN_GENERATION))
+        or cached.get("generation") != generation
+    ):
         await cache.delete(cache_key)
         cached = None
 
@@ -925,24 +940,27 @@ async def validate_embed_token_access(
         cache_ttl = int(
             min(EMBED_TOKEN_POSITIVE_TTL_SECONDS, max(0, seconds_until_expiry))
         )
-        await cache.set_if_absent(
-            cache_key,
-            {
-                "is_valid": True,
-                "scoped_dataset_ids": scoped_dataset_ids,
-                "allowed_origins": allowed_origins,
-                "map_id": str(token.map_id),
-                "expires_at": token.expires_at.isoformat(),
-                "tenant_id": str(token.tenant_id) if token.tenant_id else None,
-                # fix(#1778 codex r3): the generation this decision was made
-                # under. A later read compares it and refuses an entry that
-                # predates a revocation, which is how a revoke performed on
-                # another worker during a Redis outage reaches this one.
-                "generation": generation,
-            },
-            ttl=cache_ttl,
-            security=True,
-        )
+        # fix(#1778 codex r5): only publish an entry that carries a generation a
+        # future reader can actually check it against.
+        if generation_usable:
+            await cache.set_if_absent(
+                cache_key,
+                {
+                    "is_valid": True,
+                    "scoped_dataset_ids": scoped_dataset_ids,
+                    "allowed_origins": allowed_origins,
+                    "map_id": str(token.map_id),
+                    "expires_at": token.expires_at.isoformat(),
+                    "tenant_id": str(token.tenant_id) if token.tenant_id else None,
+                    # fix(#1778 codex r3): the generation this decision was made
+                    # under. A later read compares it and refuses an entry that
+                    # predates a revocation, which is how a revoke performed on
+                    # another worker during a Redis outage reaches this one.
+                    "generation": generation,
+                },
+                ttl=cache_ttl,
+                security=True,
+            )
 
     # Domain-locking check (before dataset scope check). Shares ONE policy
     # reader with resolve_embed_scope_for_map so the two cannot drift; the

--- a/backend/app/platform/cache/memory.py
+++ b/backend/app/platform/cache/memory.py
@@ -14,13 +14,30 @@ class InMemoryCacheProvider:
     """In-memory cache using an LRU-bounded dict + time.monotonic() TTL.
 
     Replaces the previous module-level _cache dict pattern in settings/service.py.
+
+    fix(#1778 codex r3): ``security=`` is accepted and ignored here, and both
+    halves of that are deliberate.
+
+    As the LAYERED provider's fallback it is never asked a security question at
+    all: ``RedisCacheProvider`` refuses to route one here, because a positive
+    authorization decision held in one Uvicorn worker's memory is not the
+    deployment's view and cannot see a revoke another worker performed.
+
+    As the WHOLE cache -- ``REDIS_URL`` unset -- it is the only store there is,
+    so serving a security positive from it is exactly as correct as the
+    deployment is single-process. It is not correct under ``uvicorn --workers N``
+    without Redis: each worker then caches independently and a revoke in one is
+    invisible to the others until the entry's TTL expires. That is a property of
+    running a multi-process deployment without a shared cache rather than
+    something this class can fix, and it is the same reason ``init_tile_cache``
+    warns about an unset ``REDIS_URL`` in the worker.
     """
 
     def __init__(self, max_entries: int = _MAX_ENTRIES) -> None:
         self._store: OrderedDict[str, tuple[Any, float]] = OrderedDict()
         self._max_entries = max_entries
 
-    async def get(self, key: str) -> Any | None:
+    async def get(self, key: str, *, security: bool = False) -> Any | None:
         entry = self._store.get(key)
         if entry is None:
             return None
@@ -31,13 +48,17 @@ class InMemoryCacheProvider:
         self._store.move_to_end(key)  # mark most-recently-used
         return value
 
-    async def set(self, key: str, value: Any, ttl: int = 300) -> None:
+    async def set(
+        self, key: str, value: Any, ttl: int = 300, *, security: bool = False
+    ) -> None:
         self._store[key] = (value, time.monotonic() + ttl)
         self._store.move_to_end(key)
         while len(self._store) > self._max_entries:
             self._store.popitem(last=False)  # evict least-recently-used
 
-    async def set_if_absent(self, key: str, value: Any, ttl: int = 300) -> bool:
+    async def set_if_absent(
+        self, key: str, value: Any, ttl: int = 300, *, security: bool = False
+    ) -> bool:
         """fix(#1778): store only when the key is unset. True if stored.
 
         No await between the presence check and the write, so on a single event

--- a/backend/app/platform/cache/memory.py
+++ b/backend/app/platform/cache/memory.py
@@ -54,6 +54,11 @@ class InMemoryCacheProvider:
             self._store.popitem(last=False)
         return True
 
+    async def set_authoritative(self, key: str, value: Any, ttl: int = 300) -> None:
+        """fix(#1778 codex r1): one store, so this is ``set``. Named separately
+        because the layered provider has to do more."""
+        await self.set(key, value, ttl)
+
     async def delete(self, key: str) -> None:
         self._store.pop(key, None)
 

--- a/backend/app/platform/cache/memory.py
+++ b/backend/app/platform/cache/memory.py
@@ -37,6 +37,23 @@ class InMemoryCacheProvider:
         while len(self._store) > self._max_entries:
             self._store.popitem(last=False)  # evict least-recently-used
 
+    async def set_if_absent(self, key: str, value: Any, ttl: int = 300) -> bool:
+        """fix(#1778): store only when the key is unset. True if stored.
+
+        No await between the presence check and the write, so on a single event
+        loop no other coroutine can interleave -- the same reasoning
+        ``delete_many`` relies on. An entry whose TTL has passed counts as
+        absent: ``get`` would evict it anyway.
+        """
+        entry = self._store.get(key)
+        if entry is not None and time.monotonic() <= entry[1]:
+            return False
+        self._store[key] = (value, time.monotonic() + ttl)
+        self._store.move_to_end(key)
+        while len(self._store) > self._max_entries:
+            self._store.popitem(last=False)
+        return True
+
     async def delete(self, key: str) -> None:
         self._store.pop(key, None)
 

--- a/backend/app/platform/cache/provider.py
+++ b/backend/app/platform/cache/provider.py
@@ -17,15 +17,40 @@ logger = structlog.stdlib.get_logger(__name__)
 class CacheProvider(Protocol):
     """Provider-agnostic cache interface."""
 
-    async def get(self, key: str) -> Any | None:
-        """Return cached value or None on miss."""
+    async def get(self, key: str, *, security: bool = False) -> Any | None:
+        """Return cached value or None on miss.
+
+        fix(#1778 codex r3): ``security=True`` marks the read as an
+        AUTHORIZATION decision, and a positive one may then only come from a
+        store every worker shares. A layered provider must not answer it from a
+        process-local fallback: production runs several Uvicorn workers, so one
+        worker's fallback is not the deployment's view, and a revoke another
+        worker performed during a Redis outage is invisible to it. When the
+        shared store cannot be reached the answer is None, and the caller
+        re-derives the decision from the database.
+
+        A REFUSAL is not subject to that rule. Refusing on possibly-stale
+        information is fail-closed, so a security read may still be answered
+        from a pending authoritative override.
+        """
         ...
 
-    async def set(self, key: str, value: Any, ttl: int = 300) -> None:
-        """Store value with TTL in seconds."""
+    async def set(
+        self, key: str, value: Any, ttl: int = 300, *, security: bool = False
+    ) -> None:
+        """Store value with TTL in seconds.
+
+        fix(#1778 codex r3): ``security=True`` means "do not write this where it
+        could later be mistaken for a shared answer". A layered provider skips
+        its process-local fallback entirely, because a security positive there
+        can never be served anyway and keeping one only invites a future reader
+        to trust it.
+        """
         ...
 
-    async def set_if_absent(self, key: str, value: Any, ttl: int = 300) -> bool:
+    async def set_if_absent(
+        self, key: str, value: Any, ttl: int = 300, *, security: bool = False
+    ) -> bool:
         """Store value with TTL only when *key* has no entry. True if stored.
 
         fix(#1778): the contract is "do not overwrite", which is what lets a
@@ -44,6 +69,12 @@ class CacheProvider(Protocol):
         implementation might later read from, not just the one it would write
         to now. A layered provider whose fallback still holds a denial must
         answer False even while its primary store is empty.
+
+        fix(#1778 codex r3): ``security=True`` carries the same meaning it has
+        on ``set`` -- never publish an authorization positive into a
+        process-local store. A layered provider answers False when it cannot
+        reach the shared one, which reads as "not published" and costs the
+        caller one database re-derivation next time.
         """
         ...
 

--- a/backend/app/platform/cache/provider.py
+++ b/backend/app/platform/cache/provider.py
@@ -39,6 +39,28 @@ class CacheProvider(Protocol):
         Must be atomic against a concurrent writer of the same key -- Redis
         ``SET NX``, or a presence check with no await between the read and the
         write.
+
+        fix(#1778 codex r1): "has no entry" means in EVERY store an
+        implementation might later read from, not just the one it would write
+        to now. A layered provider whose fallback still holds a denial must
+        answer False even while its primary store is empty.
+        """
+        ...
+
+    async def set_authoritative(self, key: str, value: Any, ttl: int = 300) -> None:
+        """Store value with TTL in EVERY store, overriding whatever is there.
+
+        fix(#1778 codex r1): the counterpart to ``set_if_absent``. That one
+        yields to an existing decision; this one IS the decision, so it has to
+        land everywhere a later read could look -- including a layered
+        provider's fallback, which an outage may have populated from a snapshot
+        that is now wrong.
+
+        The embed-token revoke path is the caller: a positive entry written
+        into the in-memory fallback during a Redis outage outlived a revocation
+        that only reached Redis, and the next Redis error served the revoked
+        token again. ``set`` is not a substitute, because it writes to one
+        store.
         """
         ...
 

--- a/backend/app/platform/cache/provider.py
+++ b/backend/app/platform/cache/provider.py
@@ -25,6 +25,23 @@ class CacheProvider(Protocol):
         """Store value with TTL in seconds."""
         ...
 
+    async def set_if_absent(self, key: str, value: Any, ttl: int = 300) -> bool:
+        """Store value with TTL only when *key* has no entry. True if stored.
+
+        fix(#1778): the contract is "do not overwrite", which is what lets a
+        caller publish a result it computed from a snapshot without clobbering
+        a decision another writer has made in the meantime. The embed-token
+        validator uses it to write its positive entry: a concurrent revocation
+        stamps a denial under the same key, and whichever of the two lands
+        first, the denial is what survives. A plain ``set`` there re-cached a
+        token the revoke had already invalidated.
+
+        Must be atomic against a concurrent writer of the same key -- Redis
+        ``SET NX``, or a presence check with no await between the read and the
+        write.
+        """
+        ...
+
     async def delete(self, key: str) -> None:
         """Delete key. No error if missing."""
         ...

--- a/backend/app/platform/cache/redis.py
+++ b/backend/app/platform/cache/redis.py
@@ -90,6 +90,30 @@ class RedisCacheProvider:
             self._record_failure()
             await self._fallback.set(key, value, ttl)
 
+    async def set_authoritative(self, key: str, value: Any, ttl: int = 300) -> None:
+        """fix(#1778 codex r1): write BOTH stores, in either circuit state.
+
+        ``set`` routes to whichever store the circuit says is live, which is
+        right for a value that is only a cached answer and wrong for one that
+        overrides a cached answer. A positive embed-token entry written into the
+        fallback during a Redis outage outlived a revocation that only reached
+        Redis, and the next Redis error served the revoked token again.
+
+        The fallback is written first and unconditionally, so a Redis failure
+        cannot leave the override applied nowhere.
+        """
+        await self._fallback.set(key, value, ttl)
+        if self._is_circuit_open():
+            return
+        try:
+            await self._client.set(key, json.dumps(value, default=str), ex=ttl)
+            self._record_success()
+        except Exception:  # broad: redis circuit breaker — any Redis error falls back to in-memory cache
+            logger.warning(
+                "redis_cache_set_authoritative_failed", key=key, exc_info=True
+            )
+            self._record_failure()
+
     async def set_if_absent(self, key: str, value: Any, ttl: int = 300) -> bool:
         """fix(#1778): SET NX. True when this call is the one that stored it.
 
@@ -98,7 +122,16 @@ class RedisCacheProvider:
         be able to override, and a copy in a process-local dict that no other
         process can override is not that. False means "not published", which is
         a cache miss next time -- the safe direction.
+
+        fix(#1778 codex r1): the fallback is checked first, in BOTH circuit
+        states. ``set_authoritative`` puts a revocation's denial in both stores,
+        and a racing publisher that only consulted Redis would answer True the
+        moment the circuit opened between its read and its write -- writing a
+        positive into the fallback the denial had just cleared. Absent has to
+        mean absent everywhere.
         """
+        if await self._fallback.get(key) is not None:
+            return False
         if self._is_circuit_open():
             return await self._fallback.set_if_absent(key, value, ttl)
         try:

--- a/backend/app/platform/cache/redis.py
+++ b/backend/app/platform/cache/redis.py
@@ -1,5 +1,8 @@
+import asyncio
+import fnmatch
 import json
 import time
+from collections import OrderedDict
 from typing import Any
 
 import redis.asyncio as redis_async
@@ -8,6 +11,15 @@ import structlog
 from app.platform.cache.memory import InMemoryCacheProvider
 
 logger = structlog.stdlib.get_logger(__name__)
+
+# fix(#1778 codex r2): how many authoritative writes may wait for Redis to come
+# back before the oldest are dropped. Each entry is one key plus a small JSON
+# value, so this is kilobytes rather than megabytes; the point of the bound is
+# that a long outage under a revocation storm cannot grow the process without
+# limit. Dropping the OLDEST is the right end to lose: an entry that has waited
+# longest is closest to its own expiry, after which replaying it would be a
+# no-op anyway.
+_MAX_PENDING_AUTHORITATIVE = 512
 
 
 class RedisCacheProvider:
@@ -23,6 +35,46 @@ class RedisCacheProvider:
 
     ``health_check()`` always bypasses the circuit breaker so ``/health``
     reflects actual Redis state.
+
+    Which writes survive an outage
+    ------------------------------
+
+    fix(#1778 codex r2): every method that writes to Redis can find the circuit
+    open, and they do NOT all mean the same thing by that, so each one's
+    behaviour is stated here rather than left to be inferred:
+
+    * ``set_authoritative`` -- REPLAYED. It overrides a value that may still be
+      sitting in Redis, so "the write did not happen" is not a safe outcome. A
+      revocation's denial written only to the fallback was silently undone the
+      moment the circuit closed and reads went back to Redis, which still held
+      the pre-revocation positive for the rest of its TTL. Writes that cannot
+      reach Redis are queued in ``_pending_authoritative`` and drained into
+      Redis on the transition back to closed, BEFORE the call that observed the
+      transition is served. Until the drain lands, ``get`` answers from the
+      queue, so the denial wins even against a Redis positive that is still
+      there.
+    * ``set`` -- fire-and-forget. It publishes a cached ANSWER, not a decision.
+      If Redis never took it, the next read is a miss and the caller re-derives
+      the value, which is correct and cheap. Replaying it would be worse than
+      useless: it would resurrect a snapshot taken before the outage over
+      whatever is true now.
+    * ``set_if_absent`` -- fire-and-forget, and deliberately so. Its whole
+      contract is to yield to a decision another writer may have made, so
+      replaying it after recovery would re-publish a positive that a revocation
+      may have superseded while Redis was away. That is the exact bug this
+      machinery exists to close, running backwards. It answers False on a Redis
+      error rather than pretending to have published.
+    * ``delete`` / ``delete_many`` / ``delete_pattern`` -- fire-and-forget on
+      the Redis half; the fallback half always happens, and any queued
+      authoritative write for the same key is discarded with it. A delete issued
+      during an outage does not reach Redis, so that entry lives out its TTL
+      there. This is bounded staleness on a cached answer, and it is why a
+      caller whose eviction carries an AUTHORIZATION decision uses
+      ``set_authoritative`` instead of ``delete`` -- which is what the embed
+      token revoke path does. A replay queue for deletes was considered and
+      rejected: a queued delete drained after recovery cannot tell a pre-outage
+      entry from one a legitimate writer put there after the outage ended, so it
+      would evict live data in order to fix stale data.
     """
 
     def __init__(
@@ -37,6 +89,13 @@ class RedisCacheProvider:
         self._failure_count = 0
         self._circuit_open_until = 0.0  # monotonic timestamp
         self._fallback = InMemoryCacheProvider()
+        # key -> (value, ttl, monotonic expiry). Ordered so the bound drops the
+        # oldest; keyed so a later authoritative write for the same key
+        # supersedes the earlier one rather than queueing behind it.
+        self._pending_authoritative: OrderedDict[str, tuple[Any, int, float]] = (
+            OrderedDict()
+        )
+        self._replay_lock = asyncio.Lock()
 
     # ------------------------------------------------------------------
     # Circuit breaker helpers
@@ -46,6 +105,24 @@ class RedisCacheProvider:
         if self._failure_count < self._max_failures:
             return False
         return time.monotonic() < self._circuit_open_until
+
+    async def _circuit_open(self) -> bool:
+        """``_is_circuit_open``, plus the drain on the transition back to closed.
+
+        fix(#1778 codex r2): every public method asks through here, so the queued
+        authoritative writes are replayed by whichever call first observes Redis
+        as usable again -- a read included, which is what makes "before any
+        primary read is served" true rather than aspirational. The cooldown
+        expiry is not a function anyone calls, it is a timestamp going stale, so
+        there is no other transition point to hook.
+        """
+        if self._is_circuit_open():
+            return True
+        if self._pending_authoritative:
+            await self._replay_pending_authoritative()
+            # The drain talks to Redis, so it can reopen the circuit itself.
+            return self._is_circuit_open()
+        return False
 
     def _record_success(self) -> None:
         self._failure_count = 0
@@ -61,11 +138,100 @@ class RedisCacheProvider:
             )
 
     # ------------------------------------------------------------------
+    # Authoritative-write replay (fix(#1778 codex r2))
+    # ------------------------------------------------------------------
+
+    def _queue_authoritative_replay(self, key: str, value: Any, ttl: int) -> None:
+        """Remember an authoritative write Redis did not take.
+
+        The overflow log never names a key: these are cache keys derived from
+        credential hashes, and a dropped-entry warning is not a reason to put one
+        in the application log. The count is what an operator needs.
+        """
+        self._pending_authoritative.pop(key, None)
+        self._pending_authoritative[key] = (value, ttl, time.monotonic() + ttl)
+
+        dropped = 0
+        while len(self._pending_authoritative) > _MAX_PENDING_AUTHORITATIVE:
+            self._pending_authoritative.popitem(last=False)
+            dropped += 1
+        if dropped:
+            logger.warning(
+                "redis_cache_authoritative_replay_overflow",
+                dropped=dropped,
+                pending=len(self._pending_authoritative),
+                limit=_MAX_PENDING_AUTHORITATIVE,
+            )
+
+    async def _replay_pending_authoritative(self) -> None:
+        """Push queued authoritative writes into Redis, oldest first.
+
+        Serialized on ``_replay_lock`` so two coroutines that observe the
+        transition together cannot both drain, and so no call is served off a
+        half-drained queue. The lock is only reached when something is queued,
+        which is never the case on the ordinary hot path.
+
+        Each entry is replayed with its REMAINING lifetime rather than a fresh
+        TTL: the point is to make Redis agree with the decision, not to extend
+        it. An entry whose lifetime has already elapsed is dropped, because
+        writing it would be a no-op that expires immediately.
+        """
+        if not self._pending_authoritative:
+            return
+        async with self._replay_lock:
+            while self._pending_authoritative:
+                key, (value, _ttl, expires_at) = next(
+                    iter(self._pending_authoritative.items())
+                )
+                remaining = int(expires_at - time.monotonic())
+                if remaining <= 0:
+                    self._pending_authoritative.pop(key, None)
+                    continue
+                try:
+                    await self._client.set(
+                        key, json.dumps(value, default=str), ex=remaining
+                    )
+                except Exception:  # broad: redis circuit breaker — any Redis error falls back to in-memory cache
+                    # Redis is not actually back. Leave this entry and the rest
+                    # queued; reads keep answering from the queue until a later
+                    # call drains it.
+                    logger.warning(
+                        "redis_cache_authoritative_replay_failed",
+                        pending=len(self._pending_authoritative),
+                        exc_info=True,
+                    )
+                    self._record_failure()
+                    return
+                self._pending_authoritative.pop(key, None)
+            self._record_success()
+
+    def _pending_authoritative_value(self, key: str) -> tuple[bool, Any]:
+        """``(found, value)`` for a queued authoritative write of *key*."""
+        entry = self._pending_authoritative.get(key)
+        if entry is None:
+            return False, None
+        value, _ttl, expires_at = entry
+        if time.monotonic() >= expires_at:
+            self._pending_authoritative.pop(key, None)
+            return False, None
+        return True, value
+
+    # ------------------------------------------------------------------
     # CacheProvider interface
     # ------------------------------------------------------------------
 
     async def get(self, key: str) -> Any | None:
-        if self._is_circuit_open():
+        circuit_open = await self._circuit_open()
+
+        # fix(#1778 codex r2): a queued authoritative write outranks BOTH stores
+        # until it has been replayed. Without this, the window between the
+        # circuit closing and the drain completing serves the pre-outage Redis
+        # value, and for a revoked embed token that value is a positive.
+        found, pending_value = self._pending_authoritative_value(key)
+        if found:
+            return pending_value
+
+        if circuit_open:
             return await self._fallback.get(key)
         try:
             raw = await self._client.get(key)
@@ -79,7 +245,8 @@ class RedisCacheProvider:
             return await self._fallback.get(key)
 
     async def set(self, key: str, value: Any, ttl: int = 300) -> None:
-        if self._is_circuit_open():
+        """Cache an answer. Not replayed after an outage; see the class docstring."""
+        if await self._circuit_open():
             await self._fallback.set(key, value, ttl)
             return
         try:
@@ -101,9 +268,16 @@ class RedisCacheProvider:
 
         The fallback is written first and unconditionally, so a Redis failure
         cannot leave the override applied nowhere.
+
+        fix(#1778 codex r2): "both stores" has to survive the outage, not just
+        the moment. When Redis cannot be reached -- circuit open, or the write
+        itself raising -- the override is queued for replay rather than dropped,
+        because Redis may still be holding the very value this call exists to
+        overrule. Until the queue drains, ``get`` answers from it.
         """
         await self._fallback.set(key, value, ttl)
-        if self._is_circuit_open():
+        if await self._circuit_open():
+            self._queue_authoritative_replay(key, value, ttl)
             return
         try:
             await self._client.set(key, json.dumps(value, default=str), ex=ttl)
@@ -113,6 +287,7 @@ class RedisCacheProvider:
                 "redis_cache_set_authoritative_failed", key=key, exc_info=True
             )
             self._record_failure()
+            self._queue_authoritative_replay(key, value, ttl)
 
     async def set_if_absent(self, key: str, value: Any, ttl: int = 300) -> bool:
         """fix(#1778): SET NX. True when this call is the one that stored it.
@@ -121,18 +296,24 @@ class RedisCacheProvider:
         store: the caller is publishing a value it wants a concurrent writer to
         be able to override, and a copy in a process-local dict that no other
         process can override is not that. False means "not published", which is
-        a cache miss next time -- the safe direction.
+        a cache miss next time -- the safe direction. Never replayed after an
+        outage, for the same reason; see the class docstring.
 
         fix(#1778 codex r1): the fallback is checked first, in BOTH circuit
         states. ``set_authoritative`` puts a revocation's denial in both stores,
         and a racing publisher that only consulted Redis would answer True the
         moment the circuit opened between its read and its write -- writing a
         positive into the fallback the denial had just cleared. Absent has to
-        mean absent everywhere.
+        mean absent everywhere, which fix(#1778 codex r2) extends to the replay
+        queue: an override still waiting for Redis is present too.
         """
+        circuit_open = await self._circuit_open()
+        found, _pending_value = self._pending_authoritative_value(key)
+        if found:
+            return False
         if await self._fallback.get(key) is not None:
             return False
-        if self._is_circuit_open():
+        if circuit_open:
             return await self._fallback.set_if_absent(key, value, ttl)
         try:
             stored = await self._client.set(
@@ -162,10 +343,15 @@ class RedisCacheProvider:
     # So every eviction hits BOTH stores in BOTH circuit states. The fallback is
     # an in-process dict, so the extra call costs nothing and cannot fail in a
     # way Redis's own error path does not already cover.
+    #
+    # fix(#1778 codex r2): an eviction also discards any queued authoritative
+    # write for the same key. Replaying an override after the caller has said
+    # the entry should not exist would put it back.
 
     async def delete(self, key: str) -> None:
         await self._fallback.delete(key)
-        if self._is_circuit_open():
+        self._pending_authoritative.pop(key, None)
+        if await self._circuit_open():
             return
         try:
             await self._client.delete(key)
@@ -182,7 +368,9 @@ class RedisCacheProvider:
         if not keys:
             return
         await self._fallback.delete_many(*keys)
-        if self._is_circuit_open():
+        for key in keys:
+            self._pending_authoritative.pop(key, None)
+        if await self._circuit_open():
             return
         try:
             await self._client.delete(*keys)
@@ -195,7 +383,11 @@ class RedisCacheProvider:
 
     async def delete_pattern(self, pattern: str) -> None:
         await self._fallback.delete_pattern(pattern)
-        if self._is_circuit_open():
+        for key in [
+            k for k in self._pending_authoritative if fnmatch.fnmatch(k, pattern)
+        ]:
+            self._pending_authoritative.pop(key, None)
+        if await self._circuit_open():
             return
         try:
             async for key in self._client.scan_iter(match=pattern):

--- a/backend/app/platform/cache/redis.py
+++ b/backend/app/platform/cache/redis.py
@@ -75,6 +75,45 @@ class RedisCacheProvider:
       rejected: a queued delete drained after recovery cannot tell a pre-outage
       entry from one a legitimate writer put there after the outage ended, so it
       would evict live data in order to fix stale data.
+
+    Why none of that is enough on its own
+    -------------------------------------
+
+    fix(#1778 codex r3): every guarantee above is PROCESS-local, and production
+    runs several Uvicorn workers. The fallback and the replay queue live in one
+    worker's memory, so during an outage worker A can revoke a capability and
+    queue the denial in A alone while worker B still holds a positive for it,
+    and after recovery B can read the pre-revocation positive straight out of
+    Redis before A's replay has run. No amount of care inside one process closes
+    that, because the two processes share nothing.
+
+    Two things do:
+
+    * ``security=True`` on ``get`` / ``set`` / ``set_if_absent``. A positive
+      AUTHORIZATION decision is then never taken from, or written to, the
+      process-local fallback; when Redis is unreachable the read answers None
+      and the caller re-derives from the database. A refusal is exempt, because
+      refusing on stale information is fail-closed.
+    * ``platform/cache/revocation.py``, a database-backed generation every
+      revoke advances and every positive entry is stamped with. It uses
+      ``consume_recovery_signal()`` below to notice that this worker was cut off
+      and to re-read the generation from the database, which is the store that
+      stayed up.
+
+    Callers that MUST pass ``security=True``, enumerated so the list can be
+    checked rather than inferred (``tests/test_layering.py::
+    test_authorization_cache_reads_are_security_scoped`` pins it):
+
+    * ``app/modules/embed_tokens/service.py`` -- ``validate_embed_token_access``
+      reads and writes the embed-token validation entry, which is the only value
+      cached through this provider that decides access to private data. Its
+      revoke paths write through ``set_authoritative``, which is security-shaped
+      by construction and takes no flag.
+
+    Everything else routed through this provider is a cached ANSWER, not a
+    decision: catalog and collection listings, search results, persistent
+    config. A stale one of those is a correctness annoyance bounded by its TTL,
+    not a capability someone still holds.
     """
 
     def __init__(
@@ -96,6 +135,13 @@ class RedisCacheProvider:
             OrderedDict()
         )
         self._replay_lock = asyncio.Lock()
+        # fix(#1778 codex r3): _was_open tracks whether this worker has been cut
+        # off from Redis; _recovery_signal is raised on the transition back and
+        # cleared by consume_recovery_signal(). It is how a caller that HAS a
+        # database session learns this worker cannot know what happened while it
+        # was away, and must re-read what it was trusting Redis for.
+        self._was_open = False
+        self._recovery_signal = False
 
     # ------------------------------------------------------------------
     # Circuit breaker helpers
@@ -117,12 +163,33 @@ class RedisCacheProvider:
         there is no other transition point to hook.
         """
         if self._is_circuit_open():
+            self._was_open = True
             return True
+        if self._was_open:
+            # fix(#1778 codex r3): raised BEFORE the drain, so a reader that
+            # consumes it is not overtaken by a replay that has not run yet.
+            # Every process-local guarantee this class makes is a per-worker
+            # guarantee, and an outage is exactly when the workers stop agreeing.
+            self._was_open = False
+            self._recovery_signal = True
         if self._pending_authoritative:
             await self._replay_pending_authoritative()
             # The drain talks to Redis, so it can reopen the circuit itself.
             return self._is_circuit_open()
         return False
+
+    def consume_recovery_signal(self) -> bool:
+        """True once per transition out of an outage, then False again.
+
+        fix(#1778 codex r3): read by ``platform/cache/revocation.py``, which
+        holds a database session and can therefore do what this class cannot --
+        re-read the revocation generation from the one store that stayed up, and
+        rewrite the Redis copy. Consuming is destructive so that the database
+        read happens once per outage rather than once per request.
+        """
+        signal = self._recovery_signal
+        self._recovery_signal = False
+        return signal
 
     def _record_success(self) -> None:
         self._failure_count = 0
@@ -220,18 +287,29 @@ class RedisCacheProvider:
     # CacheProvider interface
     # ------------------------------------------------------------------
 
-    async def get(self, key: str) -> Any | None:
+    async def get(self, key: str, *, security: bool = False) -> Any | None:
         circuit_open = await self._circuit_open()
 
         # fix(#1778 codex r2): a queued authoritative write outranks BOTH stores
         # until it has been replayed. Without this, the window between the
         # circuit closing and the drain completing serves the pre-outage Redis
         # value, and for a revoked embed token that value is a positive.
+        #
+        # This one is served even for a security read: a queued override is a
+        # REVOCATION, and refusing on stale information is the fail-closed
+        # direction. It is the positive that must never come from local memory.
         found, pending_value = self._pending_authoritative_value(key)
         if found:
             return pending_value
 
         if circuit_open:
+            # fix(#1778 codex r3): the fallback is THIS WORKER's memory. For an
+            # authorization decision that is not good enough -- another worker
+            # may have revoked while Redis was away, and this process cannot
+            # have heard about it. Answering None sends the caller to the
+            # database, which is the only store all the workers share.
+            if security:
+                return None
             return await self._fallback.get(key)
         try:
             raw = await self._client.get(key)
@@ -242,12 +320,20 @@ class RedisCacheProvider:
         except Exception:  # broad: redis circuit breaker — any Redis error falls back to in-memory cache
             logger.warning("redis_cache_get_failed", key=key, exc_info=True)
             self._record_failure()
+            if security:
+                return None
             return await self._fallback.get(key)
 
-    async def set(self, key: str, value: Any, ttl: int = 300) -> None:
+    async def set(
+        self, key: str, value: Any, ttl: int = 300, *, security: bool = False
+    ) -> None:
         """Cache an answer. Not replayed after an outage; see the class docstring."""
         if await self._circuit_open():
-            await self._fallback.set(key, value, ttl)
+            # fix(#1778 codex r3): a security entry in the fallback can never be
+            # served (see `get`), so writing one is dead weight that only invites
+            # a future reader to trust it.
+            if not security:
+                await self._fallback.set(key, value, ttl)
             return
         try:
             await self._client.set(key, json.dumps(value, default=str), ex=ttl)
@@ -255,7 +341,8 @@ class RedisCacheProvider:
         except Exception:  # broad: redis circuit breaker — any Redis error falls back to in-memory cache
             logger.warning("redis_cache_set_failed", key=key, exc_info=True)
             self._record_failure()
-            await self._fallback.set(key, value, ttl)
+            if not security:
+                await self._fallback.set(key, value, ttl)
 
     async def set_authoritative(self, key: str, value: Any, ttl: int = 300) -> None:
         """fix(#1778 codex r1): write BOTH stores, in either circuit state.
@@ -289,7 +376,9 @@ class RedisCacheProvider:
             self._record_failure()
             self._queue_authoritative_replay(key, value, ttl)
 
-    async def set_if_absent(self, key: str, value: Any, ttl: int = 300) -> bool:
+    async def set_if_absent(
+        self, key: str, value: Any, ttl: int = 300, *, security: bool = False
+    ) -> bool:
         """fix(#1778): SET NX. True when this call is the one that stored it.
 
         A Redis error answers False rather than falling back to the in-memory
@@ -314,6 +403,12 @@ class RedisCacheProvider:
         if await self._fallback.get(key) is not None:
             return False
         if circuit_open:
+            # fix(#1778 codex r3): an authorization positive is never published
+            # into this worker's memory. False reads as "not published", which
+            # costs the caller one database re-derivation next time and is the
+            # safe direction.
+            if security:
+                return False
             return await self._fallback.set_if_absent(key, value, ttl)
         try:
             stored = await self._client.set(

--- a/backend/app/platform/cache/redis.py
+++ b/backend/app/platform/cache/redis.py
@@ -90,9 +90,27 @@ class RedisCacheProvider:
             self._record_failure()
             await self._fallback.set(key, value, ttl)
 
+    # fix(#1778): codebase audit 2026-08-30, "Cache invalidation never reaches
+    # the in-memory fallback, so a revoked embed token can be served as valid
+    # during the next Redis blip".
+    #
+    # Reads and writes route to ONE store: whichever the circuit says is live.
+    # Eviction must not, because the two stores are populated at different
+    # times. A validation that ran while the circuit was open wrote its result
+    # into the process-local fallback; the circuit then closed, an admin revoked
+    # the capability, the delete went to Redis alone, and the fallback copy
+    # survived. The next blip inside that entry's TTL serves it again. The
+    # embed-token positive entry ({"is_valid": True, ...}, TTL up to 300s) is
+    # the concrete case, and every authorization-shaped value cached through
+    # this provider has the same shape.
+    #
+    # So every eviction hits BOTH stores in BOTH circuit states. The fallback is
+    # an in-process dict, so the extra call costs nothing and cannot fail in a
+    # way Redis's own error path does not already cover.
+
     async def delete(self, key: str) -> None:
+        await self._fallback.delete(key)
         if self._is_circuit_open():
-            await self._fallback.delete(key)
             return
         try:
             await self._client.delete(key)
@@ -100,7 +118,6 @@ class RedisCacheProvider:
         except Exception:  # broad: redis circuit breaker — any Redis error falls back to in-memory cache
             logger.warning("redis_cache_delete_failed", key=key, exc_info=True)
             self._record_failure()
-            await self._fallback.delete(key)
 
     async def delete_many(self, *keys: str) -> None:
         # fix(#1543): DEL is variadic and executes as one command, so the whole
@@ -109,8 +126,8 @@ class RedisCacheProvider:
         # network round-trip between every pair of keys.
         if not keys:
             return
+        await self._fallback.delete_many(*keys)
         if self._is_circuit_open():
-            await self._fallback.delete_many(*keys)
             return
         try:
             await self._client.delete(*keys)
@@ -120,11 +137,10 @@ class RedisCacheProvider:
                 "redis_cache_delete_many_failed", keys=list(keys), exc_info=True
             )
             self._record_failure()
-            await self._fallback.delete_many(*keys)
 
     async def delete_pattern(self, pattern: str) -> None:
+        await self._fallback.delete_pattern(pattern)
         if self._is_circuit_open():
-            await self._fallback.delete_pattern(pattern)
             return
         try:
             async for key in self._client.scan_iter(match=pattern):
@@ -137,7 +153,6 @@ class RedisCacheProvider:
                 exc_info=True,
             )
             self._record_failure()
-            await self._fallback.delete_pattern(pattern)
 
     async def health_check(self) -> None:
         """Verify Redis is reachable via PING.

--- a/backend/app/platform/cache/redis.py
+++ b/backend/app/platform/cache/redis.py
@@ -90,6 +90,28 @@ class RedisCacheProvider:
             self._record_failure()
             await self._fallback.set(key, value, ttl)
 
+    async def set_if_absent(self, key: str, value: Any, ttl: int = 300) -> bool:
+        """fix(#1778): SET NX. True when this call is the one that stored it.
+
+        A Redis error answers False rather than falling back to the in-memory
+        store: the caller is publishing a value it wants a concurrent writer to
+        be able to override, and a copy in a process-local dict that no other
+        process can override is not that. False means "not published", which is
+        a cache miss next time -- the safe direction.
+        """
+        if self._is_circuit_open():
+            return await self._fallback.set_if_absent(key, value, ttl)
+        try:
+            stored = await self._client.set(
+                key, json.dumps(value, default=str), ex=ttl, nx=True
+            )
+            self._record_success()
+            return bool(stored)
+        except Exception:  # broad: redis circuit breaker — any Redis error falls back to in-memory cache
+            logger.warning("redis_cache_set_if_absent_failed", key=key, exc_info=True)
+            self._record_failure()
+            return False
+
     # fix(#1778): codebase audit 2026-08-30, "Cache invalidation never reaches
     # the in-memory fallback, so a revoked embed token can be served as valid
     # during the next Redis blip".

--- a/backend/app/platform/cache/redis.py
+++ b/backend/app/platform/cache/redis.py
@@ -94,11 +94,11 @@ class RedisCacheProvider:
       process-local fallback; when Redis is unreachable the read answers None
       and the caller re-derives from the database. A refusal is exempt, because
       refusing on stale information is fail-closed.
-    * ``platform/cache/revocation.py``, a database-backed generation every
-      revoke advances and every positive entry is stamped with. It uses
-      ``consume_recovery_signal()`` below to notice that this worker was cut off
-      and to re-read the generation from the database, which is the store that
-      stayed up.
+    * ``platform/cache/revocation.py``, a transactional database counter every
+      revoke advances and every positive entry is stamped with. It is read from
+      the database on every validation rather than cached here, precisely
+      because anything this class could tell a caller about its own outage would
+      be per-worker and one step behind.
 
     Callers that MUST pass ``security=True``, enumerated so the list can be
     checked rather than inferred (``tests/test_layering.py::
@@ -135,13 +135,6 @@ class RedisCacheProvider:
             OrderedDict()
         )
         self._replay_lock = asyncio.Lock()
-        # fix(#1778 codex r3): _was_open tracks whether this worker has been cut
-        # off from Redis; _recovery_signal is raised on the transition back and
-        # cleared by consume_recovery_signal(). It is how a caller that HAS a
-        # database session learns this worker cannot know what happened while it
-        # was away, and must re-read what it was trusting Redis for.
-        self._was_open = False
-        self._recovery_signal = False
 
     # ------------------------------------------------------------------
     # Circuit breaker helpers
@@ -163,33 +156,12 @@ class RedisCacheProvider:
         there is no other transition point to hook.
         """
         if self._is_circuit_open():
-            self._was_open = True
             return True
-        if self._was_open:
-            # fix(#1778 codex r3): raised BEFORE the drain, so a reader that
-            # consumes it is not overtaken by a replay that has not run yet.
-            # Every process-local guarantee this class makes is a per-worker
-            # guarantee, and an outage is exactly when the workers stop agreeing.
-            self._was_open = False
-            self._recovery_signal = True
         if self._pending_authoritative:
             await self._replay_pending_authoritative()
             # The drain talks to Redis, so it can reopen the circuit itself.
             return self._is_circuit_open()
         return False
-
-    def consume_recovery_signal(self) -> bool:
-        """True once per transition out of an outage, then False again.
-
-        fix(#1778 codex r3): read by ``platform/cache/revocation.py``, which
-        holds a database session and can therefore do what this class cannot --
-        re-read the revocation generation from the one store that stayed up, and
-        rewrite the Redis copy. Consuming is destructive so that the database
-        read happens once per outage rather than once per request.
-        """
-        signal = self._recovery_signal
-        self._recovery_signal = False
-        return signal
 
     def _record_success(self) -> None:
         self._failure_count = 0

--- a/backend/app/platform/cache/revocation.py
+++ b/backend/app/platform/cache/revocation.py
@@ -84,11 +84,40 @@ from sqlalchemy.ext.asyncio import AsyncSession
 logger = structlog.stdlib.get_logger(__name__)
 
 _TABLE = "catalog.security_revocation_generation"
+_TABLE_NAME = "security_revocation_generation"
 
-# Matches no stamp any entry can carry, so every comparison against it fails and
-# every caller falls through to the database. Returned when the counter cannot
-# be read at all, which is the fail-closed direction.
-_UNKNOWN_GENERATION = -1
+# Returned when the counter cannot be read at all. fix(#1778 codex r5): a
+# sentinel is NOT a generation, and treating it as one was a hole. Two entries
+# both stamped with it compared EQUAL, so a positive cached while the counter
+# was unreadable stayed trusted through a later revocation whose denial could
+# not reach shared Redis. Callers must ask `is_usable_generation` and refuse to
+# cache, or to trust, anything stamped with an unusable value.
+UNKNOWN_GENERATION = -1
+
+
+class RevocationGenerationError(RuntimeError):
+    """The revocation counter could not be advanced.
+
+    fix(#1778 codex r5): a revocation whose generation cannot advance is a
+    revocation other workers will never hear about, so it must not quietly
+    proceed. Raising rolls back the caller's transaction, which takes the
+    ``is_active`` flip with it: the operator sees a failed revoke and retries,
+    rather than a successful one that half the fleet ignores.
+    """
+
+
+def is_usable_generation(generation: int) -> bool:
+    """Whether *generation* may be stamped on, or compared against, an entry."""
+    return generation != UNKNOWN_GENERATION
+
+
+# Seeded from the clock rather than from 1. fix(#1778 codex r5): the reader
+# re-creates the row if it has been deleted, and a re-seed that restarted at 1
+# would walk back up through values that stale entries elsewhere in the fleet
+# are still stamped with, making a revoked entry compare equal again. Seeding
+# from the epoch puts every re-seed far above any counter that reached its value
+# by counting revocations, so the sequence of issued values never repeats.
+_SEED_EXPR = "EXTRACT(EPOCH FROM clock_timestamp())::bigint"
 
 
 async def bump_revocation_generation(db: AsyncSession) -> int:
@@ -107,11 +136,16 @@ async def bump_revocation_generation(db: AsyncSession) -> int:
         )
     )
     if generation is None:
-        # The seeded row is gone. Refusing to invent one is the safe answer: a
-        # silent INSERT here would reset the counter and make every stale entry
-        # in the fleet compare equal again.
+        # The row is gone, so this revocation cannot be announced to the rest of
+        # the fleet. fix(#1778 codex r5): raise rather than return a sentinel.
+        # Returning one let the revoke commit while every other worker kept
+        # honouring its cached positives until they expired.
         logger.error("revocation_generation_row_missing", operation="bump")
-        return _UNKNOWN_GENERATION
+        raise RevocationGenerationError(
+            "The revocation generation counter row is missing, so this "
+            "revocation cannot be made visible to other workers. Refusing to "
+            "complete it."
+        )
     return int(generation)
 
 
@@ -122,19 +156,38 @@ async def current_revocation_generation(db: AsyncSession) -> int:
     row the cached decision is about, so the two cannot disagree about which
     side of a revocation they are on.
 
-    Never raises: a counter that cannot be read resolves to a value no entry
-    carries, so every cached positive is refused and re-derived.
+    Never raises: a counter that cannot be read resolves to UNKNOWN_GENERATION.
+    That is NOT a generation, and a caller must neither stamp it on an entry nor
+    compare two entries by it; ask ``is_usable_generation`` and skip the cache
+    entirely. fix(#1778 codex r5): treating the sentinel as an ordinary value
+    made two entries stamped with it compare EQUAL, which is the opposite of
+    fail-closed.
     """
     try:
         generation = await db.scalar(
             text(f"SELECT generation FROM {_TABLE} WHERE id IS TRUE")
         )
+        if generation is None:
+            # fix(#1778 codex r5): re-create the row rather than living with the
+            # sentinel, so an unusable generation is something that happens once
+            # instead of a state the deployment sits in. The seed comes from the
+            # clock, so the re-created counter starts above anything the old one
+            # could have counted its way to, and no stale entry can match it.
+            logger.error("revocation_generation_row_missing", operation="read")
+            generation = await db.scalar(
+                text(
+                    f"INSERT INTO {_TABLE} (id, generation) "
+                    f"VALUES (TRUE, {_SEED_EXPR}) "
+                    "ON CONFLICT (id) DO UPDATE SET generation = "
+                    f"{_TABLE_NAME}.generation "
+                    "RETURNING generation"
+                )
+            )
     except (
         Exception
     ):  # broad: authorization must fail closed rather than propagate a plumbing error
         logger.warning("revocation_generation_read_failed", exc_info=True)
-        return _UNKNOWN_GENERATION
+        return UNKNOWN_GENERATION
     if generation is None:
-        logger.error("revocation_generation_row_missing", operation="read")
-        return _UNKNOWN_GENERATION
+        return UNKNOWN_GENERATION
     return int(generation)

--- a/backend/app/platform/cache/revocation.py
+++ b/backend/app/platform/cache/revocation.py
@@ -1,0 +1,166 @@
+"""Cluster-global revocation generation (fix(#1778 codex r3)).
+
+The problem this exists for
+---------------------------
+
+``RedisCacheProvider``'s in-memory fallback and its authoritative-replay queue
+are PROCESS-local, and production runs several Uvicorn workers behind one
+socket. That makes every process-local guarantee a per-worker guarantee:
+
+  1. Redis goes down. Worker B validates embed token T, and (before the
+     ``security`` rule below) caches a positive in its own fallback.
+  2. Worker A revokes T. A writes the denial to ITS fallback and queues it for
+     replay in ITS queue. B knows nothing about either.
+  3. B keeps serving T from its fallback.
+  4. Redis recovers. Redis still holds the pre-outage positive for T, because
+     A's replay has not run yet and may never run if A gets no traffic. B reads
+     Redis and gets the positive.
+
+Step 3 is closed by the ``security=True`` rule on the cache provider: a positive
+authorization decision is never served from a process-local store, so during an
+outage every validation falls through to the database. Step 4 is what this
+module closes. The database is the one thing still up when Redis is not, so the
+revocation lands here, and every worker checks it.
+
+How it works
+------------
+
+* A revoke calls :func:`bump_revocation_generation`, which is one ``nextval``
+  on ``catalog.security_revocation_generation``.
+* A positive validation-cache entry is stamped with the generation it was minted
+  under.
+* On a cache hit the validator compares the stamp with the current generation
+  and treats a stale stamp as a miss, re-reading the database.
+
+The current generation is read from Redis, because reading it is on the hot
+path and a database round-trip per cache hit would undo the point of the cache.
+It is re-read from the DATABASE, and the Redis key rewritten, in exactly the two
+cases where the Redis copy cannot be trusted:
+
+* the Redis key is missing (eviction, flush, a fresh Redis), and
+* the worker's circuit breaker has just transitioned back to closed, which means
+  this worker was cut off from Redis and cannot know what happened while it was.
+  ``RedisCacheProvider.consume_recovery_signal()`` reports that transition once.
+
+Residual, stated rather than papered over
+-----------------------------------------
+
+A worker that served no requests at all during the outage never opened its
+circuit, so it never sees a recovery signal, and its Redis reads succeeded
+throughout. If Redis itself still holds a pre-revocation positive for a token,
+that worker keeps trusting it until the entry's own TTL expires. That TTL is
+``EMBED_TOKEN_POSITIVE_TTL_SECONDS`` (300 seconds, five minutes) and it is the
+bound on this residual. It is not zero and this module does not claim it is.
+
+Closing it completely would need either a push channel every worker subscribes
+to (Redis pub/sub, which is exactly the component that was down), or a database
+read of the generation on every cache hit, which is the cache round-trip the
+cache exists to avoid. Five minutes of exposure for a token revoked during a
+Redis outage, in a multi-worker deployment, on a worker that took no traffic
+during that outage, is the trade being made.
+"""
+
+from __future__ import annotations
+
+import structlog
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.platform.cache.provider import get_cache
+
+logger = structlog.stdlib.get_logger(__name__)
+
+# Not tenant-scoped on purpose: the whole value of the generation is that every
+# worker, and in hosted mode every tenant's request path, agrees on one number.
+# A per-tenant counter would let a revoke in one tenant leave another tenant's
+# stale positives standing, which is the defect this closes rather than a
+# refinement of it.
+REVOCATION_GENERATION_CACHE_KEY = "security:revocation_generation"
+
+# Long, because the value is rewritten on every bump and on every recovery, and
+# a stale read here is only ever "an entry is re-validated against the database
+# once more than it needed to be".
+_GENERATION_CACHE_TTL = 3600
+
+_SEQUENCE = "catalog.security_revocation_generation"
+
+
+async def bump_revocation_generation(db: AsyncSession) -> int:
+    """Advance the generation and publish it. Returns the new value.
+
+    ``nextval`` is non-transactional, so this survives a rollback of the
+    surrounding revoke. That is deliberate: a generation that ran ahead of the
+    revocations costs one extra database re-validation per cached entry, while
+    one that lagged would leave a revoked capability being served.
+    """
+    generation = int(await db.scalar(text(f"SELECT nextval('{_SEQUENCE}')")))
+    await _publish(generation)
+    return generation
+
+
+async def current_revocation_generation(db: AsyncSession) -> int:
+    """The generation a cache entry must carry to still be trusted.
+
+    Reads Redis, except in the two cases where the Redis copy cannot be trusted:
+    the key is missing, or this worker has just come back from an outage. Both
+    fall through to the database and rewrite the Redis key.
+
+    Never raises. A cache backend that cannot answer resolves to the database;
+    a database that cannot answer resolves to ``0``, which matches no stamp any
+    entry carries and therefore fails every comparison -- a cache miss for every
+    caller, which is the fail-closed direction.
+    """
+    cache = get_cache()
+
+    recovered = False
+    consume = getattr(cache, "consume_recovery_signal", None)
+    if consume is not None:
+        recovered = consume()
+
+    if not recovered:
+        try:
+            cached = await cache.get(REVOCATION_GENERATION_CACHE_KEY)
+        except Exception:  # broad: a cache backend failure must fall through to the database, never break authorization
+            cached = None
+        if isinstance(cached, int):
+            return cached
+
+    return await _refresh_from_database(db, recovered=recovered)
+
+
+async def _refresh_from_database(db: AsyncSession, *, recovered: bool) -> int:
+    try:
+        # last_value, not nextval: reading the generation must not advance it.
+        # A sequence that has never been advanced reports its START WITH value,
+        # which is the stamp every entry minted before the first revoke carries.
+        generation = int(await db.scalar(text(f"SELECT last_value FROM {_SEQUENCE}")))
+    except Exception:  # broad: authorization must fail closed rather than propagate a cache-plumbing error
+        logger.warning(
+            "revocation_generation_read_failed",
+            recovered=recovered,
+            exc_info=True,
+        )
+        return 0
+    if recovered:
+        logger.info(
+            "revocation_generation_refreshed_after_outage", generation=generation
+        )
+    await _publish(generation)
+    return generation
+
+
+async def _publish(generation: int) -> None:
+    """Best-effort write of the generation to the shared cache.
+
+    ``set_authoritative`` rather than ``set``: this value overrides whatever
+    Redis is holding, and it has to survive an outage the same way a revocation
+    denial does. If it does not land, the next reader finds the key missing and
+    goes to the database, which is the correct fallback.
+    """
+    try:
+        cache = get_cache()
+        await cache.set_authoritative(
+            REVOCATION_GENERATION_CACHE_KEY, generation, ttl=_GENERATION_CACHE_TTL
+        )
+    except Exception:  # broad: publishing the generation is an optimization; the database remains the source of truth
+        logger.warning("revocation_generation_publish_failed", exc_info=True)

--- a/backend/app/platform/cache/revocation.py
+++ b/backend/app/platform/cache/revocation.py
@@ -111,13 +111,21 @@ def is_usable_generation(generation: int) -> bool:
     return generation != UNKNOWN_GENERATION
 
 
-# Seeded from the clock rather than from 1. fix(#1778 codex r5): the reader
-# re-creates the row if it has been deleted, and a re-seed that restarted at 1
-# would walk back up through values that stale entries elsewhere in the fleet
-# are still stamped with, making a revoked entry compare equal again. Seeding
-# from the epoch puts every re-seed far above any counter that reached its value
-# by counting revocations, so the sequence of issued values never repeats.
-_SEED_EXPR = "EXTRACT(EPOCH FROM clock_timestamp())::bigint"
+# fix(#1778 codex r6 P2): a random 62-bit value, not a wall-clock second. The
+# epoch seed used through round 5 could collide with itself: deleting the row
+# and healing it again inside the same wall-clock second reproduces the exact
+# same seed, and a Redis positive stamped with the pre-delete value would then
+# compare equal to it and be trusted after "recovery". It also degrades under
+# sustained load rather than only at that one boundary: a fleet revoking fast
+# enough can walk the counter's integer value past the current epoch-seconds
+# count, and a later re-seed then lands BEHIND the counter it is replacing
+# instead of ahead of it. Monotonic wall-clock time was never the guarantee
+# this needed. A value drawn uniformly from [0, 2**62) makes a collision with
+# ANY earlier stamp, from any prior seed or any counted revocation, a
+# ~2**-62 event, independent of timing. 2**62 rather than the full 63-bit
+# signed range so the floor() and the cast can never round the boundary into
+# a negative bigint.
+_SEED_EXPR = "(floor(random() * 4611686018427387904))::bigint"
 
 
 async def bump_revocation_generation(db: AsyncSession) -> int:
@@ -168,20 +176,36 @@ async def current_revocation_generation(db: AsyncSession) -> int:
             text(f"SELECT generation FROM {_TABLE} WHERE id IS TRUE")
         )
         if generation is None:
-            # fix(#1778 codex r5): re-create the row rather than living with the
-            # sentinel, so an unusable generation is something that happens once
-            # instead of a state the deployment sits in. The seed comes from the
-            # clock, so the re-created counter starts above anything the old one
-            # could have counted its way to, and no stale entry can match it.
+            # fix(#1778 codex r6 P1): the heal must NOT run on `db`. Every
+            # production caller of this function is a read endpoint on
+            # get_db() (core/dependencies.py), whose session is committed on
+            # NOTHING -- it either rolls back on an exception or is simply
+            # closed at the end of a successful request. Round 5's heal ran
+            # the INSERT on that same session, so it "worked" for the rest of
+            # THIS request and then vanished the instant the session closed:
+            # the next validation found the row missing again and re-healed
+            # it, over and over, while every revoke kept raising
+            # RevocationGenerationError until an operator repaired the table
+            # by hand. Healing on its own connection, committed independently
+            # of whatever the caller's session does with its own transaction,
+            # is the only way the fix outlives the request that triggered it.
             logger.error("revocation_generation_row_missing", operation="read")
+            healed_generation = await _reseed_missing_generation_row()
+            logger.warning(
+                "revocation_generation_row_healed",
+                generation=healed_generation,
+            )
+            # Re-read through the CALLER's session rather than trusting the
+            # value the heal returned directly. The heal committed on a
+            # separate connection; this SELECT is a fresh statement in `db`'s
+            # transaction, and under READ COMMITTED (the default, and nothing
+            # in this request path raises the isolation level) a fresh
+            # statement always sees a just-committed row from elsewhere. That
+            # keeps this function to one source of truth -- what `db` itself
+            # can see -- rather than a value trusted from a connection this
+            # session never touches.
             generation = await db.scalar(
-                text(
-                    f"INSERT INTO {_TABLE} (id, generation) "
-                    f"VALUES (TRUE, {_SEED_EXPR}) "
-                    "ON CONFLICT (id) DO UPDATE SET generation = "
-                    f"{_TABLE_NAME}.generation "
-                    "RETURNING generation"
-                )
+                text(f"SELECT generation FROM {_TABLE} WHERE id IS TRUE")
             )
     except (
         Exception
@@ -190,4 +214,30 @@ async def current_revocation_generation(db: AsyncSession) -> int:
         return UNKNOWN_GENERATION
     if generation is None:
         return UNKNOWN_GENERATION
+    return int(generation)
+
+
+async def _reseed_missing_generation_row() -> int:
+    """Recreate the deleted singleton counter row on its own connection.
+
+    fix(#1778 codex r6 P1): committed independently of the caller, and NEVER
+    on the caller's `AsyncSession` -- see the call site in
+    ``current_revocation_generation`` for why that failed to persist. Late
+    imports ``app.core.db.engine`` the same way ``get_db()`` late-imports
+    ``async_session``: a module-scope import would snapshot the engine
+    ``client``/test fixtures rebind before their override takes effect,
+    silently healing against the wrong database in tests.
+    """
+    from app.core.db import engine  # noqa: PLC0415
+
+    async with engine.begin() as conn:
+        generation = await conn.scalar(
+            text(
+                f"INSERT INTO {_TABLE} (id, generation) "
+                f"VALUES (TRUE, {_SEED_EXPR}) "
+                "ON CONFLICT (id) DO UPDATE SET generation = "
+                f"{_TABLE_NAME}.generation "
+                "RETURNING generation"
+            )
+        )
     return int(generation)

--- a/backend/app/platform/cache/revocation.py
+++ b/backend/app/platform/cache/revocation.py
@@ -1,4 +1,4 @@
-"""Cluster-global revocation generation (fix(#1778 codex r3)).
+"""Cluster-global revocation generation (fix(#1778 codex r3/r4)).
 
 The problem this exists for
 ---------------------------
@@ -7,14 +7,12 @@ The problem this exists for
 are PROCESS-local, and production runs several Uvicorn workers behind one
 socket. That makes every process-local guarantee a per-worker guarantee:
 
-  1. Redis goes down. Worker B validates embed token T, and (before the
-     ``security`` rule below) caches a positive in its own fallback.
+  1. Redis goes down. Worker B validates embed token T and caches a positive.
   2. Worker A revokes T. A writes the denial to ITS fallback and queues it for
      replay in ITS queue. B knows nothing about either.
-  3. B keeps serving T from its fallback.
-  4. Redis recovers. Redis still holds the pre-outage positive for T, because
-     A's replay has not run yet and may never run if A gets no traffic. B reads
-     Redis and gets the positive.
+  3. B keeps serving T.
+  4. Redis recovers. Redis still holds the pre-outage positive, because A's
+     replay has not run and may never run if A gets no traffic. B reads it.
 
 Step 3 is closed by the ``security=True`` rule on the cache provider: a positive
 authorization decision is never served from a process-local store, so during an
@@ -22,42 +20,59 @@ outage every validation falls through to the database. Step 4 is what this
 module closes. The database is the one thing still up when Redis is not, so the
 revocation lands here, and every worker checks it.
 
-How it works
-------------
+Why the counter is read from the DATABASE every time
+----------------------------------------------------
 
-* A revoke calls :func:`bump_revocation_generation`, which is one ``nextval``
-  on ``catalog.security_revocation_generation``.
-* A positive validation-cache entry is stamped with the generation it was minted
-  under.
-* On a cache hit the validator compares the stamp with the current generation
-  and treats a stale stamp as a miss, re-reading the database.
+fix(#1778 codex r4): the first draft cached this number in Redis and re-read it
+from the database only on two triggers -- a missing key, and a circuit-breaker
+transition back to closed. Both of those were wrong in the same way, and the
+second was wrong twice over:
 
-The current generation is read from Redis, because reading it is on the hot
-path and a database round-trip per cache hit would undo the point of the cache.
-It is re-read from the DATABASE, and the Redis key rewritten, in exactly the two
-cases where the Redis copy cannot be trusted:
+* A Redis copy can be STALE-LOW. A worker reading generation G while a
+  revocation has committed at G+1 finds its cached entry stamped G, sees a
+  match, and serves a revoked token. Staleness is not conservative here.
+* The transition trigger fired one step too late. Nothing detects a lapsed
+  cooldown until some cache method looks, so the FIRST request after recovery
+  consumed a signal that had not been raised yet, read the stale Redis
+  generation, and accepted a pre-outage positive.
 
-* the Redis key is missing (eviction, flush, a fresh Redis), and
-* the worker's circuit breaker has just transitioned back to closed, which means
-  this worker was cut off from Redis and cannot know what happened while it was.
-  ``RedisCacheProvider.consume_recovery_signal()`` reports that transition once.
+Reading the counter from the database on every validation removes all of it: no
+publish to order, no signal to race, no staleness window, and no residual for a
+worker that happened to take no traffic during the outage. The cost is one
+single-row indexed read per validation, on a code path that already issues at
+least one database query on both its cache-hit and cache-miss branches
+(``map_contains_dataset``, plus the origin and tenant checks). That is the
+trade, and it is a cheap one.
 
-Residual, stated rather than papered over
------------------------------------------
+Why the counter is a transactional ROW, not a sequence
+------------------------------------------------------
 
-A worker that served no requests at all during the outage never opened its
-circuit, so it never sees a recovery signal, and its Redis reads succeeded
-throughout. If Redis itself still holds a pre-revocation positive for a token,
-that worker keeps trusting it until the entry's own TTL expires. That TTL is
-``EMBED_TOKEN_POSITIVE_TTL_SECONDS`` (300 seconds, five minutes) and it is the
-bound on this residual. It is not zero and this module does not claim it is.
+fix(#1778 codex r4): ``nextval`` takes no row lock, which is why the first draft
+used it, but it is also non-transactional, and that is fatal rather than
+convenient. The advance became visible to every other worker the instant it ran,
+while the ``is_active`` flip it stood for stayed invisible until the revoking
+transaction committed. A validator landing in that window read the NEW
+generation, read the token row as still active, and cached a positive stamped
+with the new generation, which then survived the commit and stayed valid until
+its TTL.
 
-Closing it completely would need either a push channel every worker subscribes
-to (Redis pub/sub, which is exactly the component that was down), or a database
-read of the generation on every cache hit, which is the cache round-trip the
-cache exists to avoid. Five minutes of exposure for a token revoked during a
-Redis outage, in a multi-worker deployment, on a worker that took no traffic
-during that outage, is the trade being made.
+An ``UPDATE ... RETURNING`` inside the revoking transaction makes the counter
+and the ``is_active`` flip become visible in the same instant, to everyone. A
+validator reads the generation BEFORE it reads the token row, so:
+
+* generation G (revoke uncommitted) -> the row may still read active, and the
+  entry is cached stamped G, which the next reader refuses once the revoke
+  commits and the generation is G+1;
+* generation G+1 -> the revoke has committed, so the row read that follows sees
+  ``is_active`` false and denies.
+
+There is no interleaving that caches a positive stamped with a generation the
+committed revocation has already passed.
+
+Concurrent revocations serialize on this one row. They already serialize on the
+embed-token rows they are flipping, they are rare, and every revoke path reaches
+the two in the same order (token flips first, counter second), so the lock adds
+no cycle.
 """
 
 from __future__ import annotations
@@ -66,101 +81,60 @@ import structlog
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.platform.cache.provider import get_cache
-
 logger = structlog.stdlib.get_logger(__name__)
 
-# Not tenant-scoped on purpose: the whole value of the generation is that every
-# worker, and in hosted mode every tenant's request path, agrees on one number.
-# A per-tenant counter would let a revoke in one tenant leave another tenant's
-# stale positives standing, which is the defect this closes rather than a
-# refinement of it.
-REVOCATION_GENERATION_CACHE_KEY = "security:revocation_generation"
+_TABLE = "catalog.security_revocation_generation"
 
-# Long, because the value is rewritten on every bump and on every recovery, and
-# a stale read here is only ever "an entry is re-validated against the database
-# once more than it needed to be".
-_GENERATION_CACHE_TTL = 3600
-
-_SEQUENCE = "catalog.security_revocation_generation"
+# Matches no stamp any entry can carry, so every comparison against it fails and
+# every caller falls through to the database. Returned when the counter cannot
+# be read at all, which is the fail-closed direction.
+_UNKNOWN_GENERATION = -1
 
 
 async def bump_revocation_generation(db: AsyncSession) -> int:
-    """Advance the generation and publish it. Returns the new value.
+    """Advance the generation inside the CALLER's transaction. Returns the new value.
 
-    ``nextval`` is non-transactional, so this survives a rollback of the
-    surrounding revoke. That is deliberate: a generation that ran ahead of the
-    revocations costs one extra database re-validation per cached entry, while
-    one that lagged would leave a revoked capability being served.
+    Deliberately not committed here and deliberately not run on a side session:
+    the whole point is that this becomes visible at the same instant as the
+    ``is_active`` flip the caller is making, so it must share the caller's
+    transaction. A revoke that rolls back leaves the generation where it was,
+    which is correct, because the revocation it stood for did not happen either.
     """
-    generation = int(await db.scalar(text(f"SELECT nextval('{_SEQUENCE}')")))
-    await _publish(generation)
-    return generation
+    generation = await db.scalar(
+        text(
+            f"UPDATE {_TABLE} SET generation = generation + 1 "
+            "WHERE id IS TRUE RETURNING generation"
+        )
+    )
+    if generation is None:
+        # The seeded row is gone. Refusing to invent one is the safe answer: a
+        # silent INSERT here would reset the counter and make every stale entry
+        # in the fleet compare equal again.
+        logger.error("revocation_generation_row_missing", operation="bump")
+        return _UNKNOWN_GENERATION
+    return int(generation)
 
 
 async def current_revocation_generation(db: AsyncSession) -> int:
     """The generation a cache entry must carry to still be trusted.
 
-    Reads Redis, except in the two cases where the Redis copy cannot be trusted:
-    the key is missing, or this worker has just come back from an outage. Both
-    fall through to the database and rewrite the Redis key.
+    Read in the caller's transaction, and read BEFORE the caller reads whatever
+    row the cached decision is about, so the two cannot disagree about which
+    side of a revocation they are on.
 
-    Never raises. A cache backend that cannot answer resolves to the database;
-    a database that cannot answer resolves to ``0``, which matches no stamp any
-    entry carries and therefore fails every comparison -- a cache miss for every
-    caller, which is the fail-closed direction.
-    """
-    cache = get_cache()
-
-    recovered = False
-    consume = getattr(cache, "consume_recovery_signal", None)
-    if consume is not None:
-        recovered = consume()
-
-    if not recovered:
-        try:
-            cached = await cache.get(REVOCATION_GENERATION_CACHE_KEY)
-        except Exception:  # broad: a cache backend failure must fall through to the database, never break authorization
-            cached = None
-        if isinstance(cached, int):
-            return cached
-
-    return await _refresh_from_database(db, recovered=recovered)
-
-
-async def _refresh_from_database(db: AsyncSession, *, recovered: bool) -> int:
-    try:
-        # last_value, not nextval: reading the generation must not advance it.
-        # A sequence that has never been advanced reports its START WITH value,
-        # which is the stamp every entry minted before the first revoke carries.
-        generation = int(await db.scalar(text(f"SELECT last_value FROM {_SEQUENCE}")))
-    except Exception:  # broad: authorization must fail closed rather than propagate a cache-plumbing error
-        logger.warning(
-            "revocation_generation_read_failed",
-            recovered=recovered,
-            exc_info=True,
-        )
-        return 0
-    if recovered:
-        logger.info(
-            "revocation_generation_refreshed_after_outage", generation=generation
-        )
-    await _publish(generation)
-    return generation
-
-
-async def _publish(generation: int) -> None:
-    """Best-effort write of the generation to the shared cache.
-
-    ``set_authoritative`` rather than ``set``: this value overrides whatever
-    Redis is holding, and it has to survive an outage the same way a revocation
-    denial does. If it does not land, the next reader finds the key missing and
-    goes to the database, which is the correct fallback.
+    Never raises: a counter that cannot be read resolves to a value no entry
+    carries, so every cached positive is refused and re-derived.
     """
     try:
-        cache = get_cache()
-        await cache.set_authoritative(
-            REVOCATION_GENERATION_CACHE_KEY, generation, ttl=_GENERATION_CACHE_TTL
+        generation = await db.scalar(
+            text(f"SELECT generation FROM {_TABLE} WHERE id IS TRUE")
         )
-    except Exception:  # broad: publishing the generation is an optimization; the database remains the source of truth
-        logger.warning("revocation_generation_publish_failed", exc_info=True)
+    except (
+        Exception
+    ):  # broad: authorization must fail closed rather than propagate a plumbing error
+        logger.warning("revocation_generation_read_failed", exc_info=True)
+        return _UNKNOWN_GENERATION
+    if generation is None:
+        logger.error("revocation_generation_row_missing", operation="read")
+        return _UNKNOWN_GENERATION
+    return int(generation)

--- a/backend/tests/test_auth_refresh_cookies_1302.py
+++ b/backend/tests/test_auth_refresh_cookies_1302.py
@@ -584,6 +584,85 @@ class TestDuplicateCookieRefusal:
         assert after.status_code == 401
 
 
+class TestDuplicateCsrfCookieRefusal:
+    """fix(#1778): codebase audit 2026-08-30, "The CSRF cookie has none of the
+    duplicate-cookie hardening its paired refresh cookie got, so a sibling
+    subdomain can choose its value".
+
+    Double-submit rests on the attacker not being able to read the cookie. A
+    sibling subdomain cannot read it but CAN set a parent-Domain cookie of the
+    same name, and the parser keeps one of the two. The refresh cookie stays
+    single and valid, so nothing else in the request refuses it.
+
+    Counterfactual: remove the _cookie_occurrences guard from enforce_csrf and
+    the first test below returns 200 instead of 403 -- a forged refresh
+    completing with a value the attacker chose.
+    """
+
+    async def test_a_planted_duplicate_csrf_cookie_cannot_authorize(
+        self, client: AsyncClient
+    ):
+        login = await _login(client, cookie_mode=True)
+        real_refresh = _cookie_attrs(login, REFRESH_COOKIE_NAME)["value"]
+        real_csrf = _cookie_attrs(login, CSRF_COOKIE_NAME)["value"]
+        client.cookies.clear()
+
+        attacker_value = "attacker-chosen-csrf-value"
+        resp = await client.post(
+            "/auth/refresh/",
+            headers={
+                **COOKIE_MODE,
+                # The attacker echoes the value they planted, not the one they
+                # cannot read.
+                "X-CSRF-Token": attacker_value,
+                "Cookie": (
+                    f"{REFRESH_COOKIE_NAME}={real_refresh}; "
+                    f"{CSRF_COOKIE_NAME}={real_csrf}; "
+                    f"{CSRF_COOKIE_NAME}={attacker_value}"
+                ),
+            },
+        )
+        assert resp.status_code == 403, resp.text
+
+    async def test_the_shadow_is_refused_whichever_order_it_arrives_in(
+        self, client: AsyncClient
+    ):
+        """Cookie ordering is the browser's to decide, so the refusal must not
+        depend on which occurrence the parser happens to keep."""
+        login = await _login(client, cookie_mode=True)
+        real_refresh = _cookie_attrs(login, REFRESH_COOKIE_NAME)["value"]
+        real_csrf = _cookie_attrs(login, CSRF_COOKIE_NAME)["value"]
+        client.cookies.clear()
+
+        resp = await client.post(
+            "/auth/refresh/",
+            headers={
+                **COOKIE_MODE,
+                "X-CSRF-Token": real_csrf,
+                "Cookie": (
+                    f"{REFRESH_COOKIE_NAME}={real_refresh}; "
+                    f"{CSRF_COOKIE_NAME}=attacker-chosen-csrf-value; "
+                    f"{CSRF_COOKIE_NAME}={real_csrf}"
+                ),
+            },
+        )
+        assert resp.status_code == 403, resp.text
+
+    async def test_the_single_legitimate_cookie_still_rotates(
+        self, client: AsyncClient
+    ):
+        """The refusal keys on the duplicate, not on the value."""
+        login = await _login(client, cookie_mode=True)
+        real_refresh = _cookie_attrs(login, REFRESH_COOKIE_NAME)["value"]
+        real_csrf = _cookie_attrs(login, CSRF_COOKIE_NAME)["value"]
+
+        _arm_cookies(client, real_refresh, real_csrf)
+        ok = await client.post(
+            "/auth/refresh/", headers={**COOKIE_MODE, "X-CSRF-Token": real_csrf}
+        )
+        assert ok.status_code == 200, ok.text
+
+
 class TestRotationRevocationRace:
     """fix(#1446): a rotation that read its row before a concurrent logout must
     not commit a still-active replacement afterwards. Client-side guards cannot

--- a/backend/tests/test_builder_audit_p0p1_sharing.py
+++ b/backend/tests/test_builder_audit_p0p1_sharing.py
@@ -142,7 +142,11 @@ class TestP001EmbedRevokeWiring:
         )
         token = row.scalar_one()
         assert token.is_active is False
-        assert await cache.get(_cache_key(raw)) is None
+        # fix(#1778): the entry is REPLACED by a denial rather than deleted, so
+        # a request that raced the revoke cannot re-publish a positive under the
+        # same key. See EMBED_TOKEN_REVOCATION_DENIAL_TTL_SECONDS in
+        # app/modules/embed_tokens/service.py.
+        assert await cache.get(_cache_key(raw)) == {"is_valid": False}
         assert (
             await validate_embed_token_access(raw, dataset_id, test_db_session) is False
         )

--- a/backend/tests/test_cache.py
+++ b/backend/tests/test_cache.py
@@ -1,6 +1,8 @@
 """Tests for cache providers and tile invalidation."""
 
+import asyncio
 import time
+from collections import OrderedDict
 from unittest.mock import AsyncMock, patch
 
 import fakeredis.aioredis
@@ -93,6 +95,10 @@ def redis_cache():
     provider._failure_count = 0
     provider._circuit_open_until = 0.0
     provider._fallback = InMemoryCacheProvider()
+    # fix(#1778 codex r2): these build the provider through __new__, so the
+    # replay state __init__ sets up has to be seeded here too.
+    provider._pending_authoritative = OrderedDict()
+    provider._replay_lock = asyncio.Lock()
     return provider
 
 
@@ -138,6 +144,10 @@ async def test_redis_graceful_get_on_failure():
     provider._failure_count = 0
     provider._circuit_open_until = 0.0
     provider._fallback = InMemoryCacheProvider()
+    # fix(#1778 codex r2): these build the provider through __new__, so the
+    # replay state __init__ sets up has to be seeded here too.
+    provider._pending_authoritative = OrderedDict()
+    provider._replay_lock = asyncio.Lock()
     result = await provider.get("any_key")
     assert result is None
 
@@ -154,6 +164,10 @@ async def test_redis_graceful_set_on_failure():
     provider._failure_count = 0
     provider._circuit_open_until = 0.0
     provider._fallback = InMemoryCacheProvider()
+    # fix(#1778 codex r2): these build the provider through __new__, so the
+    # replay state __init__ sets up has to be seeded here too.
+    provider._pending_authoritative = OrderedDict()
+    provider._replay_lock = asyncio.Lock()
     # Should not raise
     await provider.set("any_key", "any_value", ttl=60)
 
@@ -194,6 +208,10 @@ def cb_redis():
     provider._failure_count = 0
     provider._circuit_open_until = 0.0
     provider._fallback = InMemoryCacheProvider()
+    # fix(#1778 codex r2): these build the provider through __new__, so the
+    # replay state __init__ sets up has to be seeded here too.
+    provider._pending_authoritative = OrderedDict()
+    provider._replay_lock = asyncio.Lock()
     return provider
 
 
@@ -448,6 +466,10 @@ async def test_a_failing_redis_delete_still_evicts_the_fallback():
     provider._failure_count = 0
     provider._circuit_open_until = 0.0
     provider._fallback = InMemoryCacheProvider()
+    # fix(#1778 codex r2): these build the provider through __new__, so the
+    # replay state __init__ sets up has to be seeded here too.
+    provider._pending_authoritative = OrderedDict()
+    provider._replay_lock = asyncio.Lock()
 
     await provider._fallback.set("embed_token:abc", {"is_valid": True}, 300)
     await provider.delete("embed_token:abc")
@@ -504,6 +526,10 @@ async def test_set_authoritative_still_lands_when_redis_is_down():
     provider._failure_count = 0
     provider._circuit_open_until = 0.0
     provider._fallback = InMemoryCacheProvider()
+    # fix(#1778 codex r2): these build the provider through __new__, so the
+    # replay state __init__ sets up has to be seeded here too.
+    provider._pending_authoritative = OrderedDict()
+    provider._replay_lock = asyncio.Lock()
 
     await provider.set_authoritative("k", {"is_valid": False}, 60)
     assert await provider._fallback.get("k") == {"is_valid": False}
@@ -528,3 +554,201 @@ async def test_set_if_absent_yields_to_a_denial_held_only_in_the_fallback(cb_red
 async def test_set_if_absent_still_publishes_into_an_empty_cache(cb_redis):
     assert await cb_redis.set_if_absent("fresh", {"is_valid": True}, 60) is True
     assert await cb_redis.get("fresh") == {"is_valid": True}
+
+
+# --- fix(#1778 codex r2): an authoritative write has to survive the outage ---
+#
+# The r1 fix wrote the denial to both stores, but only when it could reach both.
+# With the circuit OPEN it wrote the fallback and returned, and Redis kept the
+# pre-revocation positive; once the cooldown lapsed, get() consulted Redis first
+# and served that positive for the rest of its TTL. That is the r1 race running
+# backwards, and it needs both halves below to close: the queue-and-replay, so
+# Redis eventually agrees, and the queue-first read, so the window before the
+# replay is not a hole of its own.
+#
+# Counterfactuals, each run: drop _queue_authoritative_replay from the
+# circuit-open branch and test_a_denial_written_during_an_outage_survives_recovery
+# fails after the cooldown; drop the pending-first check in get() and the same
+# test fails BEFORE the replay.
+
+
+def _open_circuit(provider) -> None:
+    provider._failure_count = provider._max_failures
+    provider._circuit_open_until = time.monotonic() + 300
+
+
+def _close_circuit(provider) -> None:
+    """Let the cooldown lapse without calling anything on the provider.
+
+    This is the real transition: nothing invokes a state machine, a timestamp
+    just goes stale. Whichever call next asks _circuit_open() is the one that
+    has to drain.
+    """
+    provider._circuit_open_until = time.monotonic() - 1
+
+
+@pytest.mark.asyncio
+async def test_a_denial_written_during_an_outage_survives_recovery(cb_redis):
+    """The pin: positive in Redis, circuit open, revoke, circuit closes,
+    denied both before and after the replay."""
+    await cb_redis.set("embed_token:abc", {"is_valid": True}, ttl=300)
+    assert await cb_redis._client.get("embed_token:abc") is not None
+
+    _open_circuit(cb_redis)
+    await cb_redis.set_authoritative("embed_token:abc", {"is_valid": False}, 300)
+    assert await cb_redis.get("embed_token:abc") == {"is_valid": False}
+
+    _close_circuit(cb_redis)
+
+    # Before the replay has landed anywhere: the queue answers.
+    assert cb_redis._pending_authoritative, "the override was dropped, not queued"
+    assert await cb_redis.get("embed_token:abc") == {"is_valid": False}, (
+        "the pre-outage Redis positive was served after recovery"
+    )
+
+    # The read above is what drained it, so Redis now agrees on its own.
+    assert not cb_redis._pending_authoritative
+    assert await cb_redis._client.get("embed_token:abc") == '{"is_valid": false}'
+    assert await cb_redis.get("embed_token:abc") == {"is_valid": False}
+
+
+@pytest.mark.asyncio
+async def test_a_plain_set_during_an_outage_does_not_replay(cb_redis):
+    """set() publishes a cached answer, not a decision. Replaying it would put a
+    pre-outage snapshot back over whatever is true now."""
+    _open_circuit(cb_redis)
+    await cb_redis.set("catalog:datasets", {"total": 1}, ttl=300)
+    assert not cb_redis._pending_authoritative
+
+    _close_circuit(cb_redis)
+    assert await cb_redis._client.get("catalog:datasets") is None
+
+
+@pytest.mark.asyncio
+async def test_a_failed_authoritative_write_is_queued_too(cb_redis):
+    """The circuit does not have to be open for Redis to refuse the write."""
+    mock_client = AsyncMock()
+    mock_client.set.side_effect = ConnectionError("Redis unavailable")
+    cb_redis._client = mock_client
+
+    await cb_redis.set_authoritative("embed_token:abc", {"is_valid": False}, 300)
+    assert "embed_token:abc" in cb_redis._pending_authoritative
+    assert await cb_redis.get("embed_token:abc") == {"is_valid": False}
+
+
+class _WriteRefusingRedis:
+    """fakeredis that reads normally but refuses every write.
+
+    This is the shape that isolates the queue-first read. A mock client cannot:
+    its `get` returns a MagicMock, `json.loads` raises on it, and the read falls
+    into the Redis-error branch and answers from the fallback anyway, which
+    passes whether or not the queue is consulted.
+    """
+
+    def __init__(self, inner):
+        self._inner = inner
+
+    async def set(self, *_args, **_kwargs):
+        raise ConnectionError("Redis is refusing writes")
+
+    def __getattr__(self, name):
+        return getattr(self._inner, name)
+
+
+@pytest.mark.asyncio
+async def test_the_queue_outranks_a_readable_redis_positive(cb_redis):
+    """The window the queue-first read exists for.
+
+    Redis is readable and still holds the pre-revocation positive, but will not
+    take the denial, and the failure count has not reached the threshold, so the
+    circuit stays CLOSED. Every drain attempt fails. Without the queue-first
+    check in get(), the read goes straight to a healthy-looking Redis and serves
+    the positive for the rest of its TTL.
+    """
+    await cb_redis.set("embed_token:abc", {"is_valid": True}, ttl=300)
+    cb_redis._client = _WriteRefusingRedis(cb_redis._client)
+
+    await cb_redis.set_authoritative("embed_token:abc", {"is_valid": False}, 300)
+
+    assert not cb_redis._is_circuit_open(), (
+        "this test is only meaningful while the circuit is closed"
+    )
+    assert await cb_redis._client.get("embed_token:abc") == '{"is_valid": true}', (
+        "Redis still holds the positive, which is the whole point"
+    )
+    assert await cb_redis.get("embed_token:abc") == {"is_valid": False}, (
+        "a readable Redis positive outranked the revocation's denial"
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_failed_replay_leaves_the_queue_intact(cb_redis):
+    """Redis looking reachable is not Redis being reachable. A drain that raises
+    must not lose the override it was trying to persist."""
+    _open_circuit(cb_redis)
+    await cb_redis.set_authoritative("embed_token:abc", {"is_valid": False}, 300)
+
+    mock_client = AsyncMock()
+    mock_client.set.side_effect = ConnectionError("Redis unavailable")
+    mock_client.get.side_effect = ConnectionError("Redis unavailable")
+    cb_redis._client = mock_client
+    _close_circuit(cb_redis)
+
+    assert await cb_redis.get("embed_token:abc") == {"is_valid": False}
+    assert "embed_token:abc" in cb_redis._pending_authoritative
+
+
+@pytest.mark.asyncio
+async def test_the_replay_queue_is_bounded_and_drops_the_oldest(cb_redis):
+    from app.platform.cache import redis as redis_module
+
+    limit = redis_module._MAX_PENDING_AUTHORITATIVE
+    _open_circuit(cb_redis)
+    for i in range(limit + 5):
+        await cb_redis.set_authoritative(f"embed_token:{i}", {"is_valid": False}, 300)
+
+    assert len(cb_redis._pending_authoritative) == limit
+    assert "embed_token:0" not in cb_redis._pending_authoritative
+    assert f"embed_token:{limit + 4}" in cb_redis._pending_authoritative
+
+
+@pytest.mark.asyncio
+async def test_a_delete_discards_a_queued_override(cb_redis):
+    """Replaying an override after the caller said the entry should not exist
+    would put it back."""
+    _open_circuit(cb_redis)
+    await cb_redis.set_authoritative("embed_token:abc", {"is_valid": False}, 300)
+    await cb_redis.delete("embed_token:abc")
+
+    assert not cb_redis._pending_authoritative
+    _close_circuit(cb_redis)
+    assert await cb_redis.get("embed_token:abc") is None
+
+
+@pytest.mark.asyncio
+async def test_set_if_absent_yields_to_a_queued_override(cb_redis):
+    """A racing publisher must lose to an override that is still waiting for
+    Redis, the same way it loses to one already in a store."""
+    _open_circuit(cb_redis)
+    await cb_redis.set_authoritative("embed_token:abc", {"is_valid": False}, 300)
+    _close_circuit(cb_redis)
+
+    # Re-queue: the close above has not been observed by any call yet, so the
+    # override is still pending when the publisher arrives.
+    assert cb_redis._pending_authoritative
+    stored = await cb_redis.set_if_absent("embed_token:abc", {"is_valid": True}, 300)
+    assert stored is False
+
+
+@pytest.mark.asyncio
+async def test_an_expired_override_is_not_replayed(cb_redis):
+    """The queue restores a decision, it does not extend one."""
+    _open_circuit(cb_redis)
+    await cb_redis.set_authoritative("embed_token:abc", {"is_valid": False}, 300)
+    key, (value, ttl, _expires_at) = next(iter(cb_redis._pending_authoritative.items()))
+    cb_redis._pending_authoritative[key] = (value, ttl, time.monotonic() - 1)
+
+    _close_circuit(cb_redis)
+    assert await cb_redis.get("embed_token:abc") is None
+    assert not cb_redis._pending_authoritative
+    assert await cb_redis._client.get("embed_token:abc") is None

--- a/backend/tests/test_cache.py
+++ b/backend/tests/test_cache.py
@@ -362,3 +362,95 @@ def test_update_sync_cache_key_allowlist_covers_new_rate_limits():
     assert "basemap_proxy_rate_limit" in src, (
         "'basemap_proxy_rate_limit' must be in PersistentConfig._update_sync_cache"
     )
+
+
+# --- fix(#1778): eviction must reach BOTH stores in BOTH circuit states ---
+#
+# Codebase audit 2026-08-30, "Cache invalidation never reaches the in-memory
+# fallback, so a revoked embed token can be served as valid during the next
+# Redis blip". Reads and writes route to one store; eviction used to as well,
+# so an entry written into the fallback during an outage outlived a delete
+# issued after recovery and came back on the next blip.
+#
+# Counterfactual: restore the "if self._is_circuit_open(): await
+# self._fallback.delete(key); return" shape in RedisCacheProvider and each of
+# these fails with the stale value still readable.
+
+
+@pytest.mark.asyncio
+async def test_delete_while_closed_also_evicts_the_fallback(cb_redis):
+    # Entry landed in the fallback during an outage.
+    await cb_redis._fallback.set("embed_token:abc", {"is_valid": True}, 300)
+
+    # Circuit is closed again; the capability is revoked.
+    await cb_redis.delete("embed_token:abc")
+
+    # Next blip: reads route to the fallback, which must no longer hold it.
+    cb_redis._failure_count = 3
+    cb_redis._circuit_open_until = time.monotonic() + 300
+    assert await cb_redis.get("embed_token:abc") is None
+
+
+@pytest.mark.asyncio
+async def test_delete_many_while_closed_also_evicts_the_fallback(cb_redis):
+    await cb_redis._fallback.set("embed_token:a", {"is_valid": True}, 300)
+    await cb_redis._fallback.set("embed_token:b", {"is_valid": True}, 300)
+
+    await cb_redis.delete_many("embed_token:a", "embed_token:b")
+
+    cb_redis._failure_count = 3
+    cb_redis._circuit_open_until = time.monotonic() + 300
+    assert await cb_redis.get("embed_token:a") is None
+    assert await cb_redis.get("embed_token:b") is None
+
+
+@pytest.mark.asyncio
+async def test_delete_pattern_while_closed_also_evicts_the_fallback(cb_redis):
+    await cb_redis._fallback.set("embed_token:a", {"is_valid": True}, 300)
+    await cb_redis._fallback.set("other:keep", 1, 300)
+
+    await cb_redis.delete_pattern("embed_token:*")
+
+    cb_redis._failure_count = 3
+    cb_redis._circuit_open_until = time.monotonic() + 300
+    assert await cb_redis.get("embed_token:a") is None
+    assert await cb_redis.get("other:keep") == 1
+
+
+@pytest.mark.asyncio
+async def test_delete_while_open_still_evicts_the_fallback(cb_redis):
+    """The pre-existing open-circuit behaviour is unchanged."""
+    await cb_redis._fallback.set("embed_token:abc", {"is_valid": True}, 300)
+    cb_redis._failure_count = 3
+    cb_redis._circuit_open_until = time.monotonic() + 300
+
+    await cb_redis.delete("embed_token:abc")
+    assert await cb_redis.get("embed_token:abc") is None
+
+
+@pytest.mark.asyncio
+async def test_delete_still_reaches_redis_while_closed(cb_redis):
+    """Adding the fallback eviction must not drop the Redis one."""
+    await cb_redis.set("k", "v", ttl=60)
+    await cb_redis.delete("k")
+    assert await cb_redis._client.get("k") is None
+
+
+@pytest.mark.asyncio
+async def test_a_failing_redis_delete_still_evicts_the_fallback():
+    """A delete that raises must not leave the fallback copy behind."""
+    provider = RedisCacheProvider.__new__(RedisCacheProvider)
+    mock_client = AsyncMock()
+    mock_client.delete.side_effect = ConnectionError("Redis unavailable")
+    provider._client = mock_client
+    provider._max_failures = 5
+    provider._cooldown_seconds = 30
+    provider._failure_count = 0
+    provider._circuit_open_until = 0.0
+    provider._fallback = InMemoryCacheProvider()
+
+    await provider._fallback.set("embed_token:abc", {"is_valid": True}, 300)
+    await provider.delete("embed_token:abc")
+
+    assert await provider._fallback.get("embed_token:abc") is None
+    assert provider._failure_count == 1

--- a/backend/tests/test_cache.py
+++ b/backend/tests/test_cache.py
@@ -99,6 +99,8 @@ def redis_cache():
     # replay state __init__ sets up has to be seeded here too.
     provider._pending_authoritative = OrderedDict()
     provider._replay_lock = asyncio.Lock()
+    provider._was_open = False
+    provider._recovery_signal = False
     return provider
 
 
@@ -148,6 +150,8 @@ async def test_redis_graceful_get_on_failure():
     # replay state __init__ sets up has to be seeded here too.
     provider._pending_authoritative = OrderedDict()
     provider._replay_lock = asyncio.Lock()
+    provider._was_open = False
+    provider._recovery_signal = False
     result = await provider.get("any_key")
     assert result is None
 
@@ -168,6 +172,8 @@ async def test_redis_graceful_set_on_failure():
     # replay state __init__ sets up has to be seeded here too.
     provider._pending_authoritative = OrderedDict()
     provider._replay_lock = asyncio.Lock()
+    provider._was_open = False
+    provider._recovery_signal = False
     # Should not raise
     await provider.set("any_key", "any_value", ttl=60)
 
@@ -212,6 +218,8 @@ def cb_redis():
     # replay state __init__ sets up has to be seeded here too.
     provider._pending_authoritative = OrderedDict()
     provider._replay_lock = asyncio.Lock()
+    provider._was_open = False
+    provider._recovery_signal = False
     return provider
 
 
@@ -470,6 +478,8 @@ async def test_a_failing_redis_delete_still_evicts_the_fallback():
     # replay state __init__ sets up has to be seeded here too.
     provider._pending_authoritative = OrderedDict()
     provider._replay_lock = asyncio.Lock()
+    provider._was_open = False
+    provider._recovery_signal = False
 
     await provider._fallback.set("embed_token:abc", {"is_valid": True}, 300)
     await provider.delete("embed_token:abc")
@@ -530,6 +540,8 @@ async def test_set_authoritative_still_lands_when_redis_is_down():
     # replay state __init__ sets up has to be seeded here too.
     provider._pending_authoritative = OrderedDict()
     provider._replay_lock = asyncio.Lock()
+    provider._was_open = False
+    provider._recovery_signal = False
 
     await provider.set_authoritative("k", {"is_valid": False}, 60)
     assert await provider._fallback.get("k") == {"is_valid": False}

--- a/backend/tests/test_cache.py
+++ b/backend/tests/test_cache.py
@@ -99,8 +99,6 @@ def redis_cache():
     # replay state __init__ sets up has to be seeded here too.
     provider._pending_authoritative = OrderedDict()
     provider._replay_lock = asyncio.Lock()
-    provider._was_open = False
-    provider._recovery_signal = False
     return provider
 
 
@@ -150,8 +148,6 @@ async def test_redis_graceful_get_on_failure():
     # replay state __init__ sets up has to be seeded here too.
     provider._pending_authoritative = OrderedDict()
     provider._replay_lock = asyncio.Lock()
-    provider._was_open = False
-    provider._recovery_signal = False
     result = await provider.get("any_key")
     assert result is None
 
@@ -172,8 +168,6 @@ async def test_redis_graceful_set_on_failure():
     # replay state __init__ sets up has to be seeded here too.
     provider._pending_authoritative = OrderedDict()
     provider._replay_lock = asyncio.Lock()
-    provider._was_open = False
-    provider._recovery_signal = False
     # Should not raise
     await provider.set("any_key", "any_value", ttl=60)
 
@@ -218,8 +212,6 @@ def cb_redis():
     # replay state __init__ sets up has to be seeded here too.
     provider._pending_authoritative = OrderedDict()
     provider._replay_lock = asyncio.Lock()
-    provider._was_open = False
-    provider._recovery_signal = False
     return provider
 
 
@@ -478,8 +470,6 @@ async def test_a_failing_redis_delete_still_evicts_the_fallback():
     # replay state __init__ sets up has to be seeded here too.
     provider._pending_authoritative = OrderedDict()
     provider._replay_lock = asyncio.Lock()
-    provider._was_open = False
-    provider._recovery_signal = False
 
     await provider._fallback.set("embed_token:abc", {"is_valid": True}, 300)
     await provider.delete("embed_token:abc")
@@ -540,8 +530,6 @@ async def test_set_authoritative_still_lands_when_redis_is_down():
     # replay state __init__ sets up has to be seeded here too.
     provider._pending_authoritative = OrderedDict()
     provider._replay_lock = asyncio.Lock()
-    provider._was_open = False
-    provider._recovery_signal = False
 
     await provider.set_authoritative("k", {"is_valid": False}, 60)
     assert await provider._fallback.get("k") == {"is_valid": False}

--- a/backend/tests/test_cache.py
+++ b/backend/tests/test_cache.py
@@ -454,3 +454,77 @@ async def test_a_failing_redis_delete_still_evicts_the_fallback():
 
     assert await provider._fallback.get("embed_token:abc") is None
     assert provider._failure_count == 1
+
+
+# --- fix(#1778 codex r1): the OVERRIDE has the same two-store requirement ---
+#
+# The eviction fix above was not enough on its own. A revocation writes a denial
+# rather than deleting the key (so a racing publisher cannot re-cache the
+# token), and `set` routes to whichever store the circuit says is live. A
+# positive entry that landed in the fallback during an outage therefore survived
+# a denial written after Redis recovered, and the next Redis error served the
+# revoked token again.
+#
+# Counterfactual: change set_authoritative back to `set` and
+# test_the_denial_overwrites_a_stale_fallback_positive fails with the positive
+# still readable.
+
+
+@pytest.mark.asyncio
+async def test_the_denial_overwrites_a_stale_fallback_positive(cb_redis):
+    """The pin codex asked for: fallback holds a positive, Redis recovers,
+    revoke, Redis errors again, validation is denied."""
+    # 1. Outage: the positive lands in the fallback.
+    await cb_redis._fallback.set("embed_token:abc", {"is_valid": True}, 300)
+
+    # 2. Redis has recovered (circuit closed) and the token is revoked.
+    await cb_redis.set_authoritative("embed_token:abc", {"is_valid": False}, 300)
+
+    # 3. Redis errors again, so reads route to the fallback.
+    cb_redis._failure_count = 3
+    cb_redis._circuit_open_until = time.monotonic() + 300
+    assert await cb_redis.get("embed_token:abc") == {"is_valid": False}
+
+
+@pytest.mark.asyncio
+async def test_set_authoritative_reaches_redis_too(cb_redis):
+    await cb_redis.set_authoritative("k", {"is_valid": False}, 60)
+    assert await cb_redis._client.get("k") == '{"is_valid": false}'
+    assert await cb_redis._fallback.get("k") == {"is_valid": False}
+
+
+@pytest.mark.asyncio
+async def test_set_authoritative_still_lands_when_redis_is_down():
+    provider = RedisCacheProvider.__new__(RedisCacheProvider)
+    mock_client = AsyncMock()
+    mock_client.set.side_effect = ConnectionError("Redis unavailable")
+    provider._client = mock_client
+    provider._max_failures = 5
+    provider._cooldown_seconds = 30
+    provider._failure_count = 0
+    provider._circuit_open_until = 0.0
+    provider._fallback = InMemoryCacheProvider()
+
+    await provider.set_authoritative("k", {"is_valid": False}, 60)
+    assert await provider._fallback.get("k") == {"is_valid": False}
+    assert provider._failure_count == 1
+
+
+@pytest.mark.asyncio
+async def test_set_if_absent_yields_to_a_denial_held_only_in_the_fallback(cb_redis):
+    """Absent has to mean absent in EVERY store. A racing publisher whose
+    circuit opened between its read and its write would otherwise put a positive
+    straight back into the fallback the denial had just cleared."""
+    await cb_redis._fallback.set("embed_token:abc", {"is_valid": False}, 300)
+
+    stored = await cb_redis.set_if_absent("embed_token:abc", {"is_valid": True}, 300)
+
+    assert stored is False
+    assert await cb_redis._client.get("embed_token:abc") is None
+    assert await cb_redis._fallback.get("embed_token:abc") == {"is_valid": False}
+
+
+@pytest.mark.asyncio
+async def test_set_if_absent_still_publishes_into_an_empty_cache(cb_redis):
+    assert await cb_redis.set_if_absent("fresh", {"is_valid": True}, 60) is True
+    assert await cb_redis.get("fresh") == {"is_valid": True}

--- a/backend/tests/test_cross_worker_revocation_1778.py
+++ b/backend/tests/test_cross_worker_revocation_1778.py
@@ -47,8 +47,11 @@ from sqlalchemy import text
 from app.platform.cache.memory import InMemoryCacheProvider
 from app.platform.cache.redis import RedisCacheProvider
 from app.platform.cache.revocation import (
+    UNKNOWN_GENERATION,
+    RevocationGenerationError,
     bump_revocation_generation,
     current_revocation_generation,
+    is_usable_generation,
 )
 
 pytestmark = pytest.mark.anyio
@@ -270,17 +273,71 @@ class TestTheGenerationIsTransactional:
         # And it still answers, from the database.
         assert await self._generation(test_db_session) >= 1
 
-    async def test_a_missing_counter_row_refuses_every_stamp(
+    async def test_a_deleted_counter_row_is_re_created_above_its_old_values(
         self, test_db_session, clean_tables
     ):
-        """Fail closed: a counter that cannot be read matches no entry."""
+        """fix(#1778 codex r5): the reader heals the row rather than living with
+        the sentinel, and re-seeds from the clock so the counter never walks back
+        up through values stale entries are still stamped with."""
+        import app.core.db as db_module
+
+        async with db_module.async_session() as session:
+            before = await self._generation(session)
+            await session.execute(
+                text("DELETE FROM catalog.security_revocation_generation")
+            )
+            healed = await self._generation(session)
+            assert healed != UNKNOWN_GENERATION, "the row was not re-created"
+            assert healed > before, (
+                "the re-seeded counter restarted low enough to collide with a "
+                "generation some cache entry could still be stamped with"
+            )
+            await session.rollback()
+
+    async def test_an_unreadable_counter_is_not_a_generation(self):
+        """Fail closed: the sentinel must never compare equal to anything.
+
+        Counterfactual: treat UNKNOWN_GENERATION as an ordinary value and two
+        entries stamped with it match, which is how a positive cached while the
+        counter was unreadable survived a later revocation.
+        """
+        broken = AsyncMock()
+        broken.scalar = AsyncMock(side_effect=RuntimeError("counter unreachable"))
+
+        assert await current_revocation_generation(broken) == UNKNOWN_GENERATION
+        assert is_usable_generation(UNKNOWN_GENERATION) is False
+        assert is_usable_generation(1) is True
+
+    async def test_a_bump_that_cannot_advance_raises(
+        self, test_db_session, clean_tables
+    ):
+        """fix(#1778 codex r5): a revocation nobody else can hear about must not
+        quietly succeed. Raising rolls the caller back, ``is_active`` flip and
+        all, so the operator sees a failed revoke instead of one half the fleet
+        ignores."""
         import app.core.db as db_module
 
         async with db_module.async_session() as session:
             await session.execute(
                 text("DELETE FROM catalog.security_revocation_generation")
             )
-            assert await self._generation(session) == -1
+            with pytest.raises(RevocationGenerationError):
+                await bump_revocation_generation(session)
+            await session.rollback()
+
+    async def test_a_revoke_fails_loudly_when_the_counter_is_gone(
+        self, test_db_session, clean_tables
+    ):
+        """The same thing through the revoke helper the routers actually call."""
+        import app.core.db as db_module
+        from app.modules.embed_tokens import service as embed_service
+
+        async with db_module.async_session() as session:
+            await session.execute(
+                text("DELETE FROM catalog.security_revocation_generation")
+            )
+            with pytest.raises(RevocationGenerationError):
+                await embed_service._deny_revoked_embed_tokens(session, "a" * 64)
             await session.rollback()
 
 
@@ -362,4 +419,43 @@ class TestTheValidatorRefusesAStaleGeneration:
         assert await self._validate(cache, 5, token_row=None) is True, (
             "a current entry was re-validated against the database, which "
             "would make the cache pointless"
+        )
+
+    async def test_an_entry_stamped_with_the_sentinel_is_never_trusted(self):
+        """fix(#1778 codex r5): two entries stamped with the sentinel compared
+        EQUAL, so a positive cached while the counter was unreadable survived a
+        later revocation whose denial could not reach shared Redis."""
+        cache = InMemoryCacheProvider()
+        await cache.set(TOKEN_KEY, self._positive(UNKNOWN_GENERATION), 300)
+
+        assert (
+            await self._validate(cache, UNKNOWN_GENERATION, token_row=None) is False
+        ), "a sentinel-stamped entry compared equal to an unreadable counter"
+
+    async def test_an_unreadable_counter_refuses_a_perfectly_good_entry(self):
+        """Not knowing whether anything was revoked means not trusting the
+        cache, in either direction."""
+        cache = InMemoryCacheProvider()
+        await cache.set(TOKEN_KEY, self._positive(5), 300)
+
+        assert await self._validate(cache, UNKNOWN_GENERATION, token_row=None) is False
+
+    async def test_nothing_is_cached_while_the_counter_is_unreadable(self):
+        """An entry stamped with the sentinel is one a future reader cannot
+        check, so it is never written in the first place."""
+        cache = InMemoryCacheProvider()
+        token_row = MagicMock(
+            id=uuid.uuid4(),
+            map_id=uuid.uuid4(),
+            allowed_origins=None,
+            scoped_dataset_ids=[str(DATASET_ID)],
+            expires_at=datetime.now(timezone.utc) + timedelta(days=30),
+            tenant_id=None,
+        )
+
+        assert (
+            await self._validate(cache, UNKNOWN_GENERATION, token_row=token_row) is True
+        )
+        assert await cache.get(TOKEN_KEY) is None, (
+            "a positive was cached with a generation no reader can check it against"
         )

--- a/backend/tests/test_cross_worker_revocation_1778.py
+++ b/backend/tests/test_cross_worker_revocation_1778.py
@@ -1,9 +1,8 @@
-"""fix(#1778 codex r3): a revoke on one Uvicorn worker has to reach the others.
+"""fix(#1778 codex r3/r4): a revoke on one Uvicorn worker has to reach the others.
 
-Codex round 3 on #1796. ``RedisCacheProvider``'s in-memory fallback and its
-authoritative-replay queue are PROCESS-local, and production runs several
-workers behind one socket, so every guarantee they make is a per-worker
-guarantee. The sequence that breaks:
+``RedisCacheProvider``'s in-memory fallback and its authoritative-replay queue
+are PROCESS-local, and production runs several workers behind one socket, so
+every guarantee they make is a per-worker guarantee. The sequence that breaks:
 
   1. Redis goes down.
   2. Worker B validates embed token T and caches a positive.
@@ -13,15 +12,22 @@ guarantee. The sequence that breaks:
   5. Redis recovers, still holding the pre-outage positive, because A's replay
      has not run and may never run if A gets no traffic. B reads it.
 
-Two mechanisms close it and both are exercised here. ``security=True`` stops
-step 2 and step 4: an authorization positive is never taken from a process-local
-store, so during an outage every validation falls through to the database. The
-database-backed revocation generation closes step 5: the revoke advanced it
-while Redis was down, and B refuses any entry stamped with an older one.
+Two mechanisms close it. ``security=True`` stops steps 2 and 4: an authorization
+positive is never taken from a process-local store, so during an outage every
+validation falls through to the database. The transactional revocation
+generation closes step 5: the revoke advanced a counter row in the same
+transaction as the ``is_active`` flip, and B refuses any entry stamped behind it.
 
-Every test builds TWO providers over ONE fakeredis, which is what "two workers,
-one Redis" means in a single process. They deliberately do not share a fallback,
-because that is the whole point.
+The provider-level cases build TWO providers over ONE fakeredis, which is what
+"two workers, one Redis" means in a single process; they deliberately do not
+share a fallback, because that is the whole point.
+
+fix(#1778 codex r4): the generation cases now use REAL database sessions and the
+production call order. The earlier drafts called ``_circuit_open()`` before
+consuming a recovery signal, which is not what a request does, and that masked
+the defect where the first request after a lapsed cooldown read a stale
+generation. The signal is gone; the counter is read from the database on every
+validation.
 """
 
 from __future__ import annotations
@@ -36,15 +42,19 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import fakeredis.aioredis
 import pytest
+from sqlalchemy import text
 
 from app.platform.cache.memory import InMemoryCacheProvider
 from app.platform.cache.redis import RedisCacheProvider
+from app.platform.cache.revocation import (
+    bump_revocation_generation,
+    current_revocation_generation,
+)
 
 pytestmark = pytest.mark.anyio
 
 KEY = "embed_token:" + ("a" * 64)
 
-# A token the validator-level cases below drive end to end.
 RAW_TOKEN = "et_cross_worker_generation_case"
 DATASET_ID = uuid.UUID("00000000-0000-0000-0000-0000000000d5")
 TOKEN_KEY = "embed_token:" + hashlib.sha256(RAW_TOKEN.encode()).hexdigest()
@@ -61,18 +71,12 @@ def _worker(shared_redis) -> RedisCacheProvider:
     provider._fallback = InMemoryCacheProvider()
     provider._pending_authoritative = OrderedDict()
     provider._replay_lock = asyncio.Lock()
-    provider._was_open = False
-    provider._recovery_signal = False
     return provider
 
 
 def _open_circuit(provider) -> None:
     provider._failure_count = provider._max_failures
     provider._circuit_open_until = time.monotonic() + 300
-
-
-def _close_circuit(provider) -> None:
-    provider._circuit_open_until = time.monotonic() - 1
 
 
 @pytest.fixture
@@ -85,7 +89,7 @@ class TestSecurityReadsNeverComeFromLocalMemory:
     async def test_an_outage_denies_a_security_positive_from_the_fallback(
         self, workers
     ):
-        """Step 2 and step 4: worker B cannot answer from its own memory.
+        """Steps 2 and 4: worker B cannot answer from its own memory.
 
         Counterfactual: drop the ``security`` branch from ``get`` and this
         returns the fallback positive instead of None.
@@ -108,10 +112,10 @@ class TestSecurityReadsNeverComeFromLocalMemory:
         await worker_b.set(KEY, {"is_valid": True}, 300, security=True)
         assert await worker_b._fallback.get(KEY) is None
 
-        assert (
-            await worker_b.set_if_absent(KEY, {"is_valid": True}, 300, security=True)
-            is False
+        stored = await worker_b.set_if_absent(
+            KEY, {"is_valid": True}, 300, security=True
         )
+        assert stored is False
         assert await worker_b._fallback.get(KEY) is None
 
     async def test_a_refusal_may_still_come_from_the_queue(self, workers):
@@ -124,108 +128,168 @@ class TestSecurityReadsNeverComeFromLocalMemory:
         assert await worker_b.get(KEY, security=True) == {"is_valid": False}
 
 
-class TestRevocationGenerationCrossesWorkers:
-    async def test_a_revoke_during_an_outage_is_seen_after_recovery(self, workers):
-        """The pin: B caches a positive, Redis goes down, A revokes, Redis comes
-        back, B's next validation is denied.
+class TestTheGenerationIsTransactional:
+    """fix(#1778 codex r4): the counter and the is_active flip become visible in
+    the same instant, so no interleaving can cache a positive that outlives the
+    revocation it raced.
 
-        The generation is what carries it. A's denial and A's replay queue never
-        leave A; the ``nextval`` A performed is in the database, which stayed up,
-        and B re-reads it because its own circuit transitioned.
-        """
-        worker_a, worker_b = workers
+    These use real sessions against the test database. Counterfactual for the
+    interleaving case: make bump_revocation_generation non-transactional (a
+    sequence nextval, or a side session that commits on its own) and
+    test_a_positive_cached_during_an_uncommitted_revoke_is_refused_after_commit
+    fails, because the racing reader stamps its entry with the post-revoke
+    generation.
+    """
 
-        # B validated T before the outage and stamped the entry generation 4.
-        await worker_b.set(KEY, {"is_valid": True, "generation": 4}, 300)
-        assert await worker_b.get(KEY, security=True) == {
-            "is_valid": True,
-            "generation": 4,
-        }
+    async def _generation(self, session) -> int:
+        return await current_revocation_generation(session)
 
-        # Redis goes down for both workers.
-        _open_circuit(worker_a)
-        _open_circuit(worker_b)
-
-        # A revokes. Its denial and its queue are A's alone.
-        await worker_a.set_authoritative(KEY, {"is_valid": False}, 300)
-        assert await worker_b.get(KEY, security=True) is None, (
-            "during the outage B must fall through to the database, not its memory"
-        )
-        # The database generation advanced to 5 while Redis was away.
-        db = AsyncMock()
-        db.scalar = AsyncMock(return_value=5)
-
-        # Redis recovers. B observes the transition on its next call.
-        _close_circuit(worker_a)
-        _close_circuit(worker_b)
-
-        from app.platform.cache import revocation
-
-        # B's circuit transitioned, so the generation comes from the database
-        # rather than from a Redis key nobody could rewrite during the outage.
-        import app.platform.cache.provider as provider_module
-
-        original = provider_module._cache_provider
-        provider_module._cache_provider = worker_b
-        try:
-            generation = await revocation.current_revocation_generation(db)
-        finally:
-            provider_module._cache_provider = original
-
-        assert generation == 5
-        stale = await worker_b.get(KEY, security=True)
-        assert stale is not None, "Redis still holds the pre-revocation positive"
-        assert stale["generation"] != generation, (
-            "the stale entry compared equal to the current generation, so the "
-            "validator would have trusted it"
-        )
-
-    async def test_a_missing_generation_key_falls_through_to_the_database(
-        self, workers
+    async def test_a_bump_is_invisible_until_the_transaction_commits(
+        self, test_db_session, clean_tables
     ):
-        """No recovery signal, but nothing in Redis either: the database answers
-        and the Redis key is rewritten for everyone else."""
-        worker_a, _worker_b = workers
-        db = AsyncMock()
-        db.scalar = AsyncMock(return_value=9)
+        import app.core.db as db_module
+
+        before = await self._generation(test_db_session)
+
+        async with db_module.async_session() as revoker:
+            bumped = await bump_revocation_generation(revoker)
+            assert bumped == before + 1
+
+            # A separate session must still see the OLD value: the revocation
+            # this stands for has not committed either.
+            async with db_module.async_session() as reader:
+                assert await self._generation(reader) == before
+
+            await revoker.commit()
+
+        async with db_module.async_session() as reader:
+            assert await self._generation(reader) == before + 1
+
+    async def test_a_rolled_back_revoke_leaves_the_generation_alone(
+        self, test_db_session, clean_tables
+    ):
+        """The counter stands for a revocation. If that did not happen, neither
+        did this."""
+        import app.core.db as db_module
+
+        before = await self._generation(test_db_session)
+
+        async with db_module.async_session() as revoker:
+            await bump_revocation_generation(revoker)
+            await revoker.rollback()
+
+        async with db_module.async_session() as reader:
+            assert await self._generation(reader) == before
+
+    async def test_a_positive_cached_during_an_uncommitted_revoke_is_refused_after_commit(
+        self, test_db_session, clean_tables
+    ):
+        """The interleaving P1b describes, driven with real sessions.
+
+        A validator reads the generation and the token row while the revoke is
+        in flight, so it legitimately sees an active row and caches a positive.
+        What must not happen is that entry surviving the commit.
+        """
+        import app.core.db as db_module
+
+        cache = InMemoryCacheProvider()
+
+        async with db_module.async_session() as revoker:
+            # The revoke has flipped is_active and advanced the counter, and has
+            # NOT committed.
+            await bump_revocation_generation(revoker)
+
+            # A concurrent validator, on another worker, in its own transaction.
+            async with db_module.async_session() as validator:
+                stamped = await self._generation(validator)
+                await cache.set(
+                    TOKEN_KEY, {"is_valid": True, "generation": stamped}, 300
+                )
+
+            await revoker.commit()
+
+        # After the commit every worker reads the new generation, and the entry
+        # the racer left behind no longer matches it.
+        async with db_module.async_session() as reader:
+            now = await self._generation(reader)
+
+        cached = await cache.get(TOKEN_KEY)
+        assert cached["generation"] != now, (
+            "a positive cached during the uncommitted revoke still matched the "
+            "generation after commit, so every worker would keep serving it"
+        )
+
+    async def test_the_generation_never_consults_the_cache(
+        self, test_db_session, clean_tables
+    ):
+        """fix(#1778 codex r4): the P1a defect, made structurally impossible.
+
+        The earlier draft cached this number in Redis and re-read it from the
+        database only when a circuit-breaker transition said to. Nothing detects
+        a lapsed cooldown until some cache method looks, so the FIRST request
+        after recovery consumed a signal that had not been raised yet, read the
+        stale Redis value, and accepted a pre-outage positive. There is no call
+        order that fixes a value which can simply be behind.
+
+        So the module reads the counter from the database, full stop.
+
+        Asserted against the SOURCE rather than by patching ``get_cache``.
+        Patching only catches a lazy, in-function import; a module-level
+        ``from app.platform.cache.provider import get_cache`` binds its own
+        reference and would sail straight past a patched attribute, which is
+        exactly the shape someone would add when "just caching it again" looks
+        like an optimization.
+        """
+        import ast
+        import inspect
 
         from app.platform.cache import revocation
-        import app.platform.cache.provider as provider_module
 
-        original = provider_module._cache_provider
-        provider_module._cache_provider = worker_a
-        try:
-            assert await revocation.current_revocation_generation(db) == 9
-            # Published, so the sibling worker reading Redis sees it without its
-            # own database round-trip.
-            assert await worker_a.get(revocation.REVOCATION_GENERATION_CACHE_KEY) == 9
-        finally:
-            provider_module._cache_provider = original
+        source = inspect.getsource(revocation)
+        tree = ast.parse(source)
 
-    async def test_the_recovery_signal_is_consumed_once(self, workers):
-        """The database read happens once per outage, not once per request."""
-        _worker_a, worker_b = workers
-        _open_circuit(worker_b)
-        assert await worker_b._circuit_open() is True
+        reached: list[str] = []
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ImportFrom) and node.module:
+                if "cache.provider" in node.module or node.module.endswith("cache"):
+                    reached.append(f"import from {node.module}")
+            elif isinstance(node, ast.Import):
+                for alias in node.names:
+                    if "cache.provider" in alias.name:
+                        reached.append(f"import {alias.name}")
+            elif isinstance(node, ast.Name) and node.id == "get_cache":
+                reached.append("reference to get_cache")
 
-        _close_circuit(worker_b)
-        assert await worker_b._circuit_open() is False
-        assert worker_b.consume_recovery_signal() is True
-        assert worker_b.consume_recovery_signal() is False
+        assert not reached, (
+            "platform/cache/revocation.py reached the cache: "
+            f"{sorted(set(reached))}. A cached generation can be stale-low, "
+            "which makes a revoked entry compare equal and be served; that is "
+            "the defect fix(#1778 codex r4) removed by reading the database."
+        )
 
-    async def test_no_outage_raises_no_signal(self, workers):
-        worker_a, _worker_b = workers
-        assert await worker_a._circuit_open() is False
-        assert worker_a.consume_recovery_signal() is False
+        # And it still answers, from the database.
+        assert await self._generation(test_db_session) >= 1
+
+    async def test_a_missing_counter_row_refuses_every_stamp(
+        self, test_db_session, clean_tables
+    ):
+        """Fail closed: a counter that cannot be read matches no entry."""
+        import app.core.db as db_module
+
+        async with db_module.async_session() as session:
+            await session.execute(
+                text("DELETE FROM catalog.security_revocation_generation")
+            )
+            assert await self._generation(session) == -1
+            await session.rollback()
 
 
 class TestTheValidatorRefusesAStaleGeneration:
     """The comparison, driven through validate_embed_token_access itself.
 
-    The provider-level tests above show the generation crosses workers; this one
-    shows the validator acts on it. Counterfactual: delete the generation
-    comparison from validate_embed_token_access and the first test returns True
-    off the stale entry.
+    Counterfactual: delete the generation comparison from
+    validate_embed_token_access and the first two tests return True off the
+    stale entry.
     """
 
     async def _validate(self, cache, generation: int, *, token_row):
@@ -277,11 +341,16 @@ class TestTheValidatorRefusesAStaleGeneration:
         }
 
     async def test_an_entry_from_before_the_revoke_is_refused(self):
-        """Worker B's entry was minted at generation 4; A revoked during the
-        outage and the database is now at 5. The row is gone, so the
-        re-validation denies."""
         cache = InMemoryCacheProvider()
         await cache.set(TOKEN_KEY, self._positive(4), 300)
+
+        assert await self._validate(cache, 5, token_row=None) is False
+
+    async def test_an_unstamped_pre_upgrade_entry_is_refused(self):
+        entry = self._positive(5)
+        del entry["generation"]
+        cache = InMemoryCacheProvider()
+        await cache.set(TOKEN_KEY, entry, 300)
 
         assert await self._validate(cache, 5, token_row=None) is False
 
@@ -294,11 +363,3 @@ class TestTheValidatorRefusesAStaleGeneration:
             "a current entry was re-validated against the database, which "
             "would make the cache pointless"
         )
-
-    async def test_an_unstamped_pre_upgrade_entry_is_refused(self):
-        entry = self._positive(5)
-        del entry["generation"]
-        cache = InMemoryCacheProvider()
-        await cache.set(TOKEN_KEY, entry, 300)
-
-        assert await self._validate(cache, 5, token_row=None) is False

--- a/backend/tests/test_cross_worker_revocation_1778.py
+++ b/backend/tests/test_cross_worker_revocation_1778.py
@@ -273,26 +273,95 @@ class TestTheGenerationIsTransactional:
         # And it still answers, from the database.
         assert await self._generation(test_db_session) >= 1
 
-    async def test_a_deleted_counter_row_is_re_created_above_its_old_values(
+    async def test_a_deleted_counter_row_is_healed_and_the_heal_persists(
         self, test_db_session, clean_tables
     ):
-        """fix(#1778 codex r5): the reader heals the row rather than living with
-        the sentinel, and re-seeds from the clock so the counter never walks back
-        up through values stale entries are still stamped with."""
+        """fix(#1778 codex r6 P1): the heal must survive past the call that
+        discovered the row missing. It runs on its own connection, committed
+        independently of whatever session happens to be reading when it fires,
+        so a second, unrelated session sees it too.
+
+        The delete is committed before the heal runs, deliberately: round 5's
+        test deleted and healed inside the SAME uncommitted session, which
+        this fix turns into a deadlock rather than a false pass -- a second
+        connection's ``INSERT ... ON CONFLICT`` blocks on the row lock an
+        uncommitted DELETE from elsewhere still holds. A committed delete is
+        also the only version of "the row is gone" any other worker's request
+        can actually observe.
+
+        Counterfactual: heal on the caller's own session (round 5's shape) and
+        the row a second, independent session reads back is gone again.
+        """
         import app.core.db as db_module
 
-        async with db_module.async_session() as session:
-            before = await self._generation(session)
-            await session.execute(
+        async with db_module.async_session() as delete_session:
+            await delete_session.execute(
                 text("DELETE FROM catalog.security_revocation_generation")
             )
-            healed = await self._generation(session)
-            assert healed != UNKNOWN_GENERATION, "the row was not re-created"
-            assert healed > before, (
-                "the re-seeded counter restarted low enough to collide with a "
-                "generation some cache entry could still be stamped with"
+            await delete_session.commit()
+
+        async with db_module.async_session() as reader_session:
+            healed = await self._generation(reader_session)
+            assert healed != UNKNOWN_GENERATION, "the row was not healed"
+
+        async with db_module.async_session() as second_session:
+            row = await second_session.scalar(
+                text(
+                    "SELECT generation FROM catalog.security_revocation_generation "
+                    "WHERE id IS TRUE"
+                )
             )
-            await session.rollback()
+        assert row is not None, (
+            "the healed row did not survive past the session that healed it"
+        )
+        assert row == healed
+
+    async def test_a_deleted_counter_row_is_recreated_with_a_fresh_random_seed(
+        self, test_db_session, clean_tables
+    ):
+        """fix(#1778 codex r6 P2): two heals must not produce the same
+        generation. Round 5 seeded the heal from
+        ``EXTRACT(EPOCH FROM clock_timestamp())::bigint`` -- whole wall-clock
+        seconds -- so two heals landing in the same second reproduced the
+        identical value, and a Redis positive stamped with the pre-delete
+        generation would then compare equal to it and be trusted again after
+        "recovery". A fleet under sustained revocation traffic can hit the
+        same collision without any clock coincidence at all, by walking the
+        counter's integer value past the current epoch-seconds count.
+
+        Counterfactual: seed the heal from the epoch-seconds expression again
+        and this fails whenever both heals land in the same wall-clock second,
+        which a same-process test loop hits on essentially every run, not as
+        a rare edge case.
+        """
+        import app.core.db as db_module
+        from app.platform.cache.revocation import _reseed_missing_generation_row
+
+        async def _delete_and_commit() -> None:
+            async with db_module.async_session() as session:
+                await session.execute(
+                    text("DELETE FROM catalog.security_revocation_generation")
+                )
+                await session.commit()
+
+        try:
+            await _delete_and_commit()
+            first = await _reseed_missing_generation_row()
+
+            await _delete_and_commit()
+            second = await _reseed_missing_generation_row()
+
+            assert first != second, (
+                "two heals produced the same generation -- an epoch-second "
+                "seed collides with itself here, and a cache entry stamped "
+                "with the pre-delete generation would wrongly compare equal "
+                "to it after recovery"
+            )
+        finally:
+            # Idempotent: a no-op if a row already exists (the ordinary case,
+            # since the heals above each leave one behind), and the safety
+            # net if an assertion above fired before the second heal ran.
+            await _reseed_missing_generation_row()
 
     async def test_an_unreadable_counter_is_not_a_generation(self):
         """Fail closed: the sentinel must never compare equal to anything.
@@ -459,3 +528,82 @@ class TestTheValidatorRefusesAStaleGeneration:
         assert await cache.get(TOKEN_KEY) is None, (
             "a positive was cached with a generation no reader can check it against"
         )
+
+
+@pytest.mark.usefixtures("_init_tile_pool_for_tests")
+class TestTheHealSurvivesARealRequest:
+    """fix(#1778 codex r6 P1): drives the heal through the real dependency
+    chain -- an actual read request on ``get_db()`` -- rather than calling
+    ``current_revocation_generation`` directly. Every production caller of
+    that function is a read endpoint, and ``core/dependencies.py``'s
+    ``get_db()`` commits NOTHING on a successful request; the assertion here
+    is about what the request leaves behind, not what the function returns.
+    """
+
+    async def test_a_read_endpoints_heal_of_the_counter_row_survives_the_request(
+        self, client, admin_auth_header, test_db_session
+    ):
+        """Counterfactual: heal on the request's own ``db`` session (round 5's
+        shape) and the row a second, independent session reads back afterward
+        is gone again -- the request's session never committed it.
+        """
+        from app.core.config import settings
+        from tests.factories import get_user_id
+        from tests.test_embed_tokens import (
+            _cleanup_data_table,
+            _create_data_table,
+            _create_map_with_layer,
+            _create_private_dataset,
+        )
+
+        user_id = await get_user_id(test_db_session, settings.geolens_admin_username)
+        table_name = f"embed_heal_{uuid.uuid4().hex[:8]}"
+        dataset = await _create_private_dataset(
+            test_db_session, created_by=user_id, table_name=table_name
+        )
+        map_obj, _ = await _create_map_with_layer(
+            test_db_session, client, admin_auth_header, dataset, created_by=user_id
+        )
+        await _create_data_table(test_db_session, table_name)
+
+        try:
+            create_resp = await client.post(
+                f"/maps/{map_obj.id}/embed-tokens/",
+                json={},
+                headers=admin_auth_header,
+            )
+            assert create_resp.status_code == 201
+            raw_token = create_resp.json()["raw_token"]
+
+            await test_db_session.execute(
+                text("DELETE FROM catalog.security_revocation_generation")
+            )
+            await test_db_session.commit()
+
+            tile_resp = await client.get(
+                f"/tiles/data.{table_name}/0/0/0.pbf",
+                headers={"X-Embed-Token": raw_token},
+            )
+            assert tile_resp.status_code in (200, 204), (
+                "the read request itself must still succeed while the counter "
+                "row is missing -- validate_embed_token_access falls through "
+                "to the database and neither caches nor denies on an unusable "
+                "generation"
+            )
+
+            import app.core.db as db_module
+
+            async with db_module.async_session() as second_session:
+                row = await second_session.scalar(
+                    text(
+                        "SELECT generation FROM catalog.security_revocation_generation "
+                        "WHERE id IS TRUE"
+                    )
+                )
+            assert row is not None, (
+                "the counter row healed during the request did not survive "
+                "past it -- the heal ran on the request's own get_db() "
+                "session, which is never committed on a successful read"
+            )
+        finally:
+            await _cleanup_data_table(test_db_session, table_name)

--- a/backend/tests/test_cross_worker_revocation_1778.py
+++ b/backend/tests/test_cross_worker_revocation_1778.py
@@ -1,0 +1,304 @@
+"""fix(#1778 codex r3): a revoke on one Uvicorn worker has to reach the others.
+
+Codex round 3 on #1796. ``RedisCacheProvider``'s in-memory fallback and its
+authoritative-replay queue are PROCESS-local, and production runs several
+workers behind one socket, so every guarantee they make is a per-worker
+guarantee. The sequence that breaks:
+
+  1. Redis goes down.
+  2. Worker B validates embed token T and caches a positive.
+  3. Worker A revokes T. The denial goes to A's fallback and A's replay queue.
+     B knows about neither.
+  4. B keeps serving T.
+  5. Redis recovers, still holding the pre-outage positive, because A's replay
+     has not run and may never run if A gets no traffic. B reads it.
+
+Two mechanisms close it and both are exercised here. ``security=True`` stops
+step 2 and step 4: an authorization positive is never taken from a process-local
+store, so during an outage every validation falls through to the database. The
+database-backed revocation generation closes step 5: the revoke advanced it
+while Redis was down, and B refuses any entry stamped with an older one.
+
+Every test builds TWO providers over ONE fakeredis, which is what "two workers,
+one Redis" means in a single process. They deliberately do not share a fallback,
+because that is the whole point.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import time
+import uuid
+from collections import OrderedDict
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import fakeredis.aioredis
+import pytest
+
+from app.platform.cache.memory import InMemoryCacheProvider
+from app.platform.cache.redis import RedisCacheProvider
+
+pytestmark = pytest.mark.anyio
+
+KEY = "embed_token:" + ("a" * 64)
+
+# A token the validator-level cases below drive end to end.
+RAW_TOKEN = "et_cross_worker_generation_case"
+DATASET_ID = uuid.UUID("00000000-0000-0000-0000-0000000000d5")
+TOKEN_KEY = "embed_token:" + hashlib.sha256(RAW_TOKEN.encode()).hexdigest()
+
+
+def _worker(shared_redis) -> RedisCacheProvider:
+    """One Uvicorn worker's view: the shared Redis, its own everything else."""
+    provider = RedisCacheProvider.__new__(RedisCacheProvider)
+    provider._client = shared_redis
+    provider._max_failures = 3
+    provider._cooldown_seconds = 30
+    provider._failure_count = 0
+    provider._circuit_open_until = 0.0
+    provider._fallback = InMemoryCacheProvider()
+    provider._pending_authoritative = OrderedDict()
+    provider._replay_lock = asyncio.Lock()
+    provider._was_open = False
+    provider._recovery_signal = False
+    return provider
+
+
+def _open_circuit(provider) -> None:
+    provider._failure_count = provider._max_failures
+    provider._circuit_open_until = time.monotonic() + 300
+
+
+def _close_circuit(provider) -> None:
+    provider._circuit_open_until = time.monotonic() - 1
+
+
+@pytest.fixture
+def workers():
+    shared_redis = fakeredis.aioredis.FakeRedis(decode_responses=True)
+    return _worker(shared_redis), _worker(shared_redis)
+
+
+class TestSecurityReadsNeverComeFromLocalMemory:
+    async def test_an_outage_denies_a_security_positive_from_the_fallback(
+        self, workers
+    ):
+        """Step 2 and step 4: worker B cannot answer from its own memory.
+
+        Counterfactual: drop the ``security`` branch from ``get`` and this
+        returns the fallback positive instead of None.
+        """
+        _worker_a, worker_b = workers
+        await worker_b._fallback.set(KEY, {"is_valid": True}, 300)
+        _open_circuit(worker_b)
+
+        assert await worker_b.get(KEY, security=True) is None, (
+            "an authorization positive was served out of one worker's memory"
+        )
+        # A non-security read is unaffected: a stale catalog listing is a
+        # correctness annoyance, not a capability.
+        assert await worker_b.get(KEY) == {"is_valid": True}
+
+    async def test_an_outage_does_not_even_write_a_security_positive(self, workers):
+        _worker_a, worker_b = workers
+        _open_circuit(worker_b)
+
+        await worker_b.set(KEY, {"is_valid": True}, 300, security=True)
+        assert await worker_b._fallback.get(KEY) is None
+
+        assert (
+            await worker_b.set_if_absent(KEY, {"is_valid": True}, 300, security=True)
+            is False
+        )
+        assert await worker_b._fallback.get(KEY) is None
+
+    async def test_a_refusal_may_still_come_from_the_queue(self, workers):
+        """Refusing on stale information is fail-closed, so the queued override
+        is exempt from the rule above."""
+        _worker_a, worker_b = workers
+        _open_circuit(worker_b)
+        await worker_b.set_authoritative(KEY, {"is_valid": False}, 300)
+
+        assert await worker_b.get(KEY, security=True) == {"is_valid": False}
+
+
+class TestRevocationGenerationCrossesWorkers:
+    async def test_a_revoke_during_an_outage_is_seen_after_recovery(self, workers):
+        """The pin: B caches a positive, Redis goes down, A revokes, Redis comes
+        back, B's next validation is denied.
+
+        The generation is what carries it. A's denial and A's replay queue never
+        leave A; the ``nextval`` A performed is in the database, which stayed up,
+        and B re-reads it because its own circuit transitioned.
+        """
+        worker_a, worker_b = workers
+
+        # B validated T before the outage and stamped the entry generation 4.
+        await worker_b.set(KEY, {"is_valid": True, "generation": 4}, 300)
+        assert await worker_b.get(KEY, security=True) == {
+            "is_valid": True,
+            "generation": 4,
+        }
+
+        # Redis goes down for both workers.
+        _open_circuit(worker_a)
+        _open_circuit(worker_b)
+
+        # A revokes. Its denial and its queue are A's alone.
+        await worker_a.set_authoritative(KEY, {"is_valid": False}, 300)
+        assert await worker_b.get(KEY, security=True) is None, (
+            "during the outage B must fall through to the database, not its memory"
+        )
+        # The database generation advanced to 5 while Redis was away.
+        db = AsyncMock()
+        db.scalar = AsyncMock(return_value=5)
+
+        # Redis recovers. B observes the transition on its next call.
+        _close_circuit(worker_a)
+        _close_circuit(worker_b)
+
+        from app.platform.cache import revocation
+
+        # B's circuit transitioned, so the generation comes from the database
+        # rather than from a Redis key nobody could rewrite during the outage.
+        import app.platform.cache.provider as provider_module
+
+        original = provider_module._cache_provider
+        provider_module._cache_provider = worker_b
+        try:
+            generation = await revocation.current_revocation_generation(db)
+        finally:
+            provider_module._cache_provider = original
+
+        assert generation == 5
+        stale = await worker_b.get(KEY, security=True)
+        assert stale is not None, "Redis still holds the pre-revocation positive"
+        assert stale["generation"] != generation, (
+            "the stale entry compared equal to the current generation, so the "
+            "validator would have trusted it"
+        )
+
+    async def test_a_missing_generation_key_falls_through_to_the_database(
+        self, workers
+    ):
+        """No recovery signal, but nothing in Redis either: the database answers
+        and the Redis key is rewritten for everyone else."""
+        worker_a, _worker_b = workers
+        db = AsyncMock()
+        db.scalar = AsyncMock(return_value=9)
+
+        from app.platform.cache import revocation
+        import app.platform.cache.provider as provider_module
+
+        original = provider_module._cache_provider
+        provider_module._cache_provider = worker_a
+        try:
+            assert await revocation.current_revocation_generation(db) == 9
+            # Published, so the sibling worker reading Redis sees it without its
+            # own database round-trip.
+            assert await worker_a.get(revocation.REVOCATION_GENERATION_CACHE_KEY) == 9
+        finally:
+            provider_module._cache_provider = original
+
+    async def test_the_recovery_signal_is_consumed_once(self, workers):
+        """The database read happens once per outage, not once per request."""
+        _worker_a, worker_b = workers
+        _open_circuit(worker_b)
+        assert await worker_b._circuit_open() is True
+
+        _close_circuit(worker_b)
+        assert await worker_b._circuit_open() is False
+        assert worker_b.consume_recovery_signal() is True
+        assert worker_b.consume_recovery_signal() is False
+
+    async def test_no_outage_raises_no_signal(self, workers):
+        worker_a, _worker_b = workers
+        assert await worker_a._circuit_open() is False
+        assert worker_a.consume_recovery_signal() is False
+
+
+class TestTheValidatorRefusesAStaleGeneration:
+    """The comparison, driven through validate_embed_token_access itself.
+
+    The provider-level tests above show the generation crosses workers; this one
+    shows the validator acts on it. Counterfactual: delete the generation
+    comparison from validate_embed_token_access and the first test returns True
+    off the stale entry.
+    """
+
+    async def _validate(self, cache, generation: int, *, token_row):
+        from app.modules.embed_tokens import service as embed_service
+
+        result = MagicMock()
+        result.scalar_one_or_none.return_value = token_row
+        db = AsyncMock()
+        db.execute.return_value = result
+
+        with (
+            patch.object(embed_service, "get_cache", return_value=cache),
+            patch.object(
+                embed_service,
+                "current_revocation_generation",
+                AsyncMock(return_value=generation),
+            ),
+            patch.object(
+                embed_service, "map_contains_dataset", AsyncMock(return_value=True)
+            ),
+            patch.object(
+                embed_service,
+                "_request_origin_is_allowed",
+                AsyncMock(return_value=True),
+            ),
+            patch.object(
+                embed_service,
+                "_bump_embed_token_usage_detached",
+                AsyncMock(return_value=None),
+            ),
+        ):
+            verdict = await embed_service.validate_embed_token_access(
+                RAW_TOKEN, DATASET_ID, db
+            )
+        pending = [t for t in embed_service._usage_bump_tasks if not t.done()]
+        if pending:
+            await asyncio.gather(*pending, return_exceptions=True)
+        return verdict
+
+    def _positive(self, generation: int) -> dict:
+        return {
+            "is_valid": True,
+            "scoped_dataset_ids": [str(DATASET_ID)],
+            "allowed_origins": None,
+            "map_id": str(uuid.uuid4()),
+            "expires_at": (datetime.now(timezone.utc) + timedelta(days=30)).isoformat(),
+            "tenant_id": None,
+            "generation": generation,
+        }
+
+    async def test_an_entry_from_before_the_revoke_is_refused(self):
+        """Worker B's entry was minted at generation 4; A revoked during the
+        outage and the database is now at 5. The row is gone, so the
+        re-validation denies."""
+        cache = InMemoryCacheProvider()
+        await cache.set(TOKEN_KEY, self._positive(4), 300)
+
+        assert await self._validate(cache, 5, token_row=None) is False
+
+    async def test_a_current_entry_is_still_trusted(self):
+        """The comparison must refuse a STALE stamp, not every stamp."""
+        cache = InMemoryCacheProvider()
+        await cache.set(TOKEN_KEY, self._positive(5), 300)
+
+        assert await self._validate(cache, 5, token_row=None) is True, (
+            "a current entry was re-validated against the database, which "
+            "would make the cache pointless"
+        )
+
+    async def test_an_unstamped_pre_upgrade_entry_is_refused(self):
+        entry = self._positive(5)
+        del entry["generation"]
+        cache = InMemoryCacheProvider()
+        await cache.set(TOKEN_KEY, entry, 300)
+
+        assert await self._validate(cache, 5, token_row=None) is False

--- a/backend/tests/test_domain_enforcement.py
+++ b/backend/tests/test_domain_enforcement.py
@@ -38,6 +38,26 @@ _DISALLOWED_DOMAIN = "evil.example.net"
 _ALLOWLIST = [_ALLOWED_DOMAIN]
 
 
+@pytest.fixture(autouse=True)
+def _registration_on(monkeypatch):
+    """fix(#1778): JIT provisioning now honours REGISTRATION_ENABLED, whose
+    shipped default is False, so an unknown OAuth identity is refused before it
+    reaches the domain gate. This module is about the DOMAIN checks, so it runs
+    with the operator switch on; the switch has its own tests in
+    tests/test_oauth_registration_gate_1778.py. Module-scoped and autouse
+    because the SSO classes below reach the provisioning path from several
+    directions."""
+    from unittest.mock import AsyncMock
+
+    from app.modules.auth.oauth import service as oauth_service
+
+    monkeypatch.setattr(
+        oauth_service.REGISTRATION_ENABLED,
+        "get_uncached",
+        AsyncMock(return_value=True),
+    )
+
+
 async def _set_allowed_domains(
     client: AsyncClient, header: dict, domains: list[str]
 ) -> None:

--- a/backend/tests/test_embed_domain_lock_self_origin_1531.py
+++ b/backend/tests/test_embed_domain_lock_self_origin_1531.py
@@ -171,6 +171,9 @@ async def _scope(request, allowed_origins: list[str] | None) -> set[uuid.UUID]:
 # --------------------------------------------------------------------------
 
 
+_TEST_GENERATION = 3
+
+
 async def _validate(request, allowed_origins: list[str] | None, monkeypatch) -> bool:
     """Drive validate_embed_token_access through its cache-hit path."""
     cache = AsyncMock()
@@ -182,11 +185,22 @@ async def _validate(request, allowed_origins: list[str] | None, monkeypatch) -> 
             "map_id": str(MAP_ID),
             "expires_at": (datetime.now(timezone.utc) + timedelta(days=1)).isoformat(),
             "tenant_id": None,
+            # fix(#1778 codex r3): a positive entry now carries the revocation
+            # generation it was minted under, and one whose stamp is stale (or
+            # missing) is refused and re-read from the database. This module is
+            # about the ORIGIN check on the cache-hit path, so it pins the
+            # generation and stamps the entry it primes with the same value.
+            "generation": _TEST_GENERATION,
         }
     )
     cache.set = AsyncMock()
     cache.delete = AsyncMock()
     monkeypatch.setattr(embed_service, "get_cache", lambda: cache)
+    monkeypatch.setattr(
+        embed_service,
+        "current_revocation_generation",
+        AsyncMock(return_value=_TEST_GENERATION),
+    )
     monkeypatch.setattr(
         embed_service, "map_contains_dataset", AsyncMock(return_value=True)
     )
@@ -204,6 +218,11 @@ async def _validate_cache_miss(
     cache.set = AsyncMock()
     cache.delete = AsyncMock()
     monkeypatch.setattr(embed_service, "get_cache", lambda: cache)
+    monkeypatch.setattr(
+        embed_service,
+        "current_revocation_generation",
+        AsyncMock(return_value=_TEST_GENERATION),
+    )
     monkeypatch.setattr(
         embed_service, "map_contains_dataset", AsyncMock(return_value=True)
     )

--- a/backend/tests/test_embed_revocation_by_map.py
+++ b/backend/tests/test_embed_revocation_by_map.py
@@ -100,9 +100,14 @@ async def test_revoke_by_map_denies_validation_and_clears_cache(
     await test_db_session.commit()
     assert revoked == 1
 
-    # The positive cache entry must be gone (cannot outlive the revocation).
-    assert await cache.get(_cache_key(raw)) is None, (
-        "P0-01: revoke_embed_tokens_by_map must purge the Redis positive cache."
+    # The positive cache entry must not outlive the revocation.
+    # fix(#1778): the entry is REPLACED by a denial rather than deleted, so a
+    # request that raced the revoke cannot re-publish a positive under the same
+    # key. See the module note on EMBED_TOKEN_REVOCATION_DENIAL_TTL_SECONDS in
+    # app/modules/embed_tokens/service.py.
+    assert await cache.get(_cache_key(raw)) == {"is_valid": False}, (
+        "P0-01: revoke_embed_tokens_by_map must replace the Redis positive "
+        "cache entry with a denial."
     )
 
     # 3. Validation now fails immediately (DB is_active=False -> deny).

--- a/backend/tests/test_embed_revocation_recache_race_1778.py
+++ b/backend/tests/test_embed_revocation_recache_race_1778.py
@@ -168,3 +168,56 @@ class TestSetIfAbsent:
         await cache.set("k", "stale", 0)
         assert await cache.set_if_absent("k", "fresh", 300) is True
         assert await cache.get("k") == "fresh"
+
+
+class TestDenialReachesEveryStore:
+    """fix(#1778 codex r1): the revoke helper's write must be the two-store one.
+
+    A positive entry that landed in the layered provider's in-memory fallback
+    during a Redis outage outlived a denial written after Redis recovered,
+    because ``set`` routes to whichever store the circuit says is live. The next
+    Redis error then served the revoked token again.
+
+    Counterfactual: change ``set_authoritative`` back to ``set`` in
+    ``_deny_revoked_embed_tokens`` and the test below reads the stale positive
+    back out of the fallback.
+    """
+
+    def _layered_provider(self):
+        import fakeredis
+
+        from app.platform.cache.redis import RedisCacheProvider
+
+        provider = RedisCacheProvider.__new__(RedisCacheProvider)
+        provider._client = fakeredis.aioredis.FakeRedis(decode_responses=True)
+        provider._max_failures = 3
+        provider._cooldown_seconds = 30
+        provider._failure_count = 0
+        provider._circuit_open_until = 0.0
+        provider._fallback = InMemoryCacheProvider()
+        return provider
+
+    async def test_a_revoke_denies_through_the_next_redis_outage(self, monkeypatch):
+        import time
+
+        from app.modules.embed_tokens import service as embed_service
+
+        provider = self._layered_provider()
+        monkeypatch.setattr(embed_service, "get_cache", lambda: provider)
+
+        token_hash = "a" * 64
+        key = embed_service._embed_token_cache_key(token_hash)
+
+        # 1. Redis was down; the validation result landed in the fallback.
+        await provider._fallback.set(key, {"is_valid": True}, 300)
+
+        # 2. Redis has recovered and the token is revoked.
+        await embed_service._deny_revoked_embed_tokens(token_hash)
+        assert await provider.get(key) == {"is_valid": False}
+
+        # 3. Redis blips again inside the entry's TTL.
+        provider._failure_count = 3
+        provider._circuit_open_until = time.monotonic() + 300
+        assert await provider.get(key) == {"is_valid": False}, (
+            "the revoked token validated again off a stale fallback entry"
+        )

--- a/backend/tests/test_embed_revocation_recache_race_1778.py
+++ b/backend/tests/test_embed_revocation_recache_race_1778.py
@@ -36,6 +36,9 @@ import uuid
 from datetime import datetime, timedelta, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import asyncio
+from collections import OrderedDict
+
 import pytest
 
 from app.modules.embed_tokens.service import (
@@ -104,12 +107,33 @@ async def _validate_with(cache, raw, dataset_id, map_id) -> bool:
             "app.modules.embed_tokens.service._request_origin_is_allowed",
             AsyncMock(return_value=True),
         ),
+        # fix(#1778 codex r2): neutralise the usage bump by replacing the
+        # COROUTINE it runs, not asyncio.create_task. Patching create_task
+        # substitutes an attribute on the shared asyncio module and hands the
+        # service a MagicMock, which it then files in the module-level
+        # _usage_bump_tasks set; MagicMock.add_done_callback does nothing, so
+        # the mock never leaves the set and the next suite in the same worker
+        # to drain it (test_embed_tokens.py) dies on
+        # "An asyncio.Future, a coroutine or an awaitable is required". Patching
+        # the coroutine keeps a real Task, so the done-callback still discards
+        # it.
         patch(
-            "app.modules.embed_tokens.service.asyncio.create_task",
-            MagicMock(),
+            "app.modules.embed_tokens.service._bump_embed_token_usage_detached",
+            AsyncMock(return_value=None),
         ),
     ):
-        return await validate_embed_token_access(raw, dataset_id, db)
+        result = await validate_embed_token_access(raw, dataset_id, db)
+    await _drain_usage_bump_tasks()
+    return result
+
+
+async def _drain_usage_bump_tasks() -> None:
+    """Let the detached bumps finish before the test's event loop goes away."""
+    from app.modules.embed_tokens.service import _usage_bump_tasks
+
+    pending = [task for task in _usage_bump_tasks if not task.done()]
+    if pending:
+        await asyncio.gather(*pending, return_exceptions=True)
 
 
 async def test_a_racing_validation_cannot_overwrite_the_denial():
@@ -195,6 +219,10 @@ class TestDenialReachesEveryStore:
         provider._failure_count = 0
         provider._circuit_open_until = 0.0
         provider._fallback = InMemoryCacheProvider()
+        # fix(#1778 codex r2): these build the provider through __new__, so the
+        # replay state __init__ sets up has to be seeded here too.
+        provider._pending_authoritative = OrderedDict()
+        provider._replay_lock = asyncio.Lock()
         return provider
 
     async def test_a_revoke_denies_through_the_next_redis_outage(self, monkeypatch):

--- a/backend/tests/test_embed_revocation_recache_race_1778.py
+++ b/backend/tests/test_embed_revocation_recache_race_1778.py
@@ -50,6 +50,10 @@ from app.platform.cache.memory import InMemoryCacheProvider
 pytestmark = pytest.mark.anyio
 
 
+# fix(#1778 codex r3): the generation the race cases pin themselves to.
+_TEST_GENERATION = 7
+
+
 def _raw_token() -> str:
     import secrets
 
@@ -71,11 +75,11 @@ class RaceCache(InMemoryCacheProvider):
         super().__init__()
         self.first_get_done = False
 
-    async def get(self, key: str):
+    async def get(self, key: str, *, security: bool = False):
         if not self.first_get_done:
             self.first_get_done = True
             return None
-        return await super().get(key)
+        return await super().get(key, security=security)
 
 
 def _active_token_row(map_id: uuid.UUID, dataset_id: uuid.UUID):
@@ -120,6 +124,15 @@ async def _validate_with(cache, raw, dataset_id, map_id) -> bool:
         patch(
             "app.modules.embed_tokens.service._bump_embed_token_usage_detached",
             AsyncMock(return_value=None),
+        ),
+        # fix(#1778 codex r3): these cases are about the NX race, not the
+        # revocation generation, and RaceCache's deliberately-missing first read
+        # would otherwise be spent on the generation lookup instead of the token.
+        # Pinned to a constant so the entry the racer publishes is stamped with
+        # the same value the reader compares against.
+        patch(
+            "app.modules.embed_tokens.service.current_revocation_generation",
+            AsyncMock(return_value=_TEST_GENERATION),
         ),
     ):
         result = await validate_embed_token_access(raw, dataset_id, db)
@@ -171,6 +184,7 @@ async def test_a_first_validation_still_publishes_its_positive_entry():
     assert cached is not None, "a clean cache miss must still prime the cache"
     assert cached["is_valid"] is True
     assert cached["scoped_dataset_ids"] == [str(dataset_id)]
+    assert cached["generation"] == _TEST_GENERATION
 
 
 class TestSetIfAbsent:
@@ -223,6 +237,8 @@ class TestDenialReachesEveryStore:
         # replay state __init__ sets up has to be seeded here too.
         provider._pending_authoritative = OrderedDict()
         provider._replay_lock = asyncio.Lock()
+        provider._was_open = False
+        provider._recovery_signal = False
         return provider
 
     async def test_a_revoke_denies_through_the_next_redis_outage(self, monkeypatch):
@@ -235,12 +251,16 @@ class TestDenialReachesEveryStore:
 
         token_hash = "a" * 64
         key = embed_service._embed_token_cache_key(token_hash)
+        # The revoke advances the generation; a scalar-answering session is all
+        # _deny_revoked_embed_tokens needs from the database here.
+        db = AsyncMock()
+        db.scalar = AsyncMock(return_value=_TEST_GENERATION)
 
         # 1. Redis was down; the validation result landed in the fallback.
         await provider._fallback.set(key, {"is_valid": True}, 300)
 
         # 2. Redis has recovered and the token is revoked.
-        await embed_service._deny_revoked_embed_tokens(token_hash)
+        await embed_service._deny_revoked_embed_tokens(db, token_hash)
         assert await provider.get(key) == {"is_valid": False}
 
         # 3. Redis blips again inside the entry's TTL.

--- a/backend/tests/test_embed_revocation_recache_race_1778.py
+++ b/backend/tests/test_embed_revocation_recache_race_1778.py
@@ -237,8 +237,6 @@ class TestDenialReachesEveryStore:
         # replay state __init__ sets up has to be seeded here too.
         provider._pending_authoritative = OrderedDict()
         provider._replay_lock = asyncio.Lock()
-        provider._was_open = False
-        provider._recovery_signal = False
         return provider
 
     async def test_a_revoke_denies_through_the_next_redis_outage(self, monkeypatch):

--- a/backend/tests/test_embed_revocation_recache_race_1778.py
+++ b/backend/tests/test_embed_revocation_recache_race_1778.py
@@ -1,0 +1,170 @@
+"""fix(#1778): a request that races a revoke must not re-cache the token.
+
+Codebase audit 2026-08-30, "Embed-token revocation invalidates the Redis
+positive cache BEFORE the caller's commit, so a concurrent request can re-cache
+the still-active token and keep it serving for 300s".
+
+The interleaving, in full:
+
+  1. A tile request for embed token T misses the validation cache.
+  2. It SELECTs T's row. In READ COMMITTED a plain select does not block on the
+     revoking transaction's lock, so the row still reads is_active = True.
+  3. The revoke flushes is_active = False and invalidates the cache entry. Its
+     caller has not committed yet (a share revoke commits 17 lines further down
+     router_sharing.py).
+  4. The tile request publishes its positive entry, TTL up to 300 seconds.
+  5. The revoke commits.
+
+Every later request is served from step 4's entry, because the cache-hit path
+re-checks only expires_at (SEC-014), never is_active. Deleting the key at step 3
+cannot help: step 4 writes after it.
+
+So the revoke stamps a DENIAL under the key and the validator publishes with
+set_if_absent. Whichever lands first, the denial survives.
+
+The tests below reproduce step 4 exactly: the cache double answers the FIRST
+get with a miss while the store already holds the revocation's denial, which is
+the same state the racing request sees.
+
+Counterfactual: change set_if_absent back to set in
+validate_embed_token_access and test_a_racing_validation_cannot_overwrite_the_
+denial fails with the positive entry back in the store.
+"""
+
+import hashlib
+import uuid
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.modules.embed_tokens.service import (
+    EMBED_TOKEN_REVOCATION_DENIAL_TTL_SECONDS,
+    validate_embed_token_access,
+)
+from app.platform.cache.memory import InMemoryCacheProvider
+
+pytestmark = pytest.mark.anyio
+
+
+def _raw_token() -> str:
+    import secrets
+
+    return "et_" + secrets.token_urlsafe(32)
+
+
+def _cache_key(raw_token: str) -> str:
+    return f"embed_token:{hashlib.sha256(raw_token.encode()).hexdigest()}"
+
+
+class RaceCache(InMemoryCacheProvider):
+    """A store whose first read misses even though the denial is already in it.
+
+    That is the racing request's view: its cache read happened before the
+    revocation stamped the denial, and its write happens after.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.first_get_done = False
+
+    async def get(self, key: str):
+        if not self.first_get_done:
+            self.first_get_done = True
+            return None
+        return await super().get(key)
+
+
+def _active_token_row(map_id: uuid.UUID, dataset_id: uuid.UUID):
+    """The row the racing select reads: still committed-active."""
+    return MagicMock(
+        id=uuid.uuid4(),
+        map_id=map_id,
+        token_hash="unused",
+        allowed_origins=None,
+        scoped_dataset_ids=[str(dataset_id)],
+        expires_at=datetime.now(timezone.utc) + timedelta(days=30),
+        tenant_id=None,
+    )
+
+
+async def _validate_with(cache, raw, dataset_id, map_id) -> bool:
+    result = MagicMock()
+    result.scalar_one_or_none.return_value = _active_token_row(map_id, dataset_id)
+    db = AsyncMock()
+    db.execute.return_value = result
+
+    with (
+        patch("app.modules.embed_tokens.service.get_cache", return_value=cache),
+        patch(
+            "app.modules.embed_tokens.service.map_contains_dataset",
+            AsyncMock(return_value=True),
+        ),
+        patch(
+            "app.modules.embed_tokens.service._request_origin_is_allowed",
+            AsyncMock(return_value=True),
+        ),
+        patch(
+            "app.modules.embed_tokens.service.asyncio.create_task",
+            MagicMock(),
+        ),
+    ):
+        return await validate_embed_token_access(raw, dataset_id, db)
+
+
+async def test_a_racing_validation_cannot_overwrite_the_denial():
+    raw = _raw_token()
+    dataset_id = uuid.uuid4()
+    map_id = uuid.uuid4()
+    cache = RaceCache()
+    key = _cache_key(raw)
+
+    # The revoke has already stamped its denial; the racing request's own read
+    # happened before that, so it will miss.
+    await cache.set(key, {"is_valid": False}, EMBED_TOKEN_REVOCATION_DENIAL_TTL_SECONDS)
+
+    # The racing request completes -- it read a committed-active row and nothing
+    # about it was wrong at the time. What matters is what it leaves behind.
+    await _validate_with(cache, raw, dataset_id, map_id)
+
+    assert await cache.get(key) == {"is_valid": False}, (
+        "the racing validation re-published a positive entry over the "
+        "revocation's denial; every later request would be served from it"
+    )
+
+
+async def test_a_first_validation_still_publishes_its_positive_entry():
+    """The guard must refuse only an overwrite, not every cache write."""
+    raw = _raw_token()
+    dataset_id = uuid.uuid4()
+    map_id = uuid.uuid4()
+    cache = RaceCache()
+    key = _cache_key(raw)
+
+    assert await _validate_with(cache, raw, dataset_id, map_id) is True
+
+    cached = await cache.get(key)
+    assert cached is not None, "a clean cache miss must still prime the cache"
+    assert cached["is_valid"] is True
+    assert cached["scoped_dataset_ids"] == [str(dataset_id)]
+
+
+class TestSetIfAbsent:
+    """The primitive the fix rests on."""
+
+    async def test_stores_when_absent(self):
+        cache = InMemoryCacheProvider()
+        assert await cache.set_if_absent("k", "first", 300) is True
+        assert await cache.get("k") == "first"
+
+    async def test_refuses_when_present(self):
+        cache = InMemoryCacheProvider()
+        await cache.set("k", {"is_valid": False}, 300)
+        assert await cache.set_if_absent("k", {"is_valid": True}, 300) is False
+        assert await cache.get("k") == {"is_valid": False}
+
+    async def test_an_expired_entry_counts_as_absent(self):
+        cache = InMemoryCacheProvider()
+        await cache.set("k", "stale", 0)
+        assert await cache.set_if_absent("k", "fresh", 300) is True
+        assert await cache.get("k") == "fresh"

--- a/backend/tests/test_embed_token_expiry_cache.py
+++ b/backend/tests/test_embed_token_expiry_cache.py
@@ -51,6 +51,10 @@ class FakeCache:
         self._store[key] = value
         return True
 
+    async def set_authoritative(self, key: str, value, ttl: int = 300) -> None:
+        """fix(#1778 codex r1): one store here, so this is set."""
+        self._store[key] = value
+
     async def delete(self, key: str) -> None:
         self._store.pop(key, None)
 

--- a/backend/tests/test_embed_token_expiry_cache.py
+++ b/backend/tests/test_embed_token_expiry_cache.py
@@ -44,6 +44,13 @@ class FakeCache:
     async def set(self, key: str, value, ttl: int = 300) -> None:
         self._store[key] = value
 
+    async def set_if_absent(self, key: str, value, ttl: int = 300) -> bool:
+        """fix(#1778): mirrors the provider contract: never overwrite."""
+        if key in self._store:
+            return False
+        self._store[key] = value
+        return True
+
     async def delete(self, key: str) -> None:
         self._store.pop(key, None)
 

--- a/backend/tests/test_embed_token_expiry_cache.py
+++ b/backend/tests/test_embed_token_expiry_cache.py
@@ -22,6 +22,14 @@ from app.modules.embed_tokens.service import validate_embed_token_access
 # ---------------------------------------------------------------------------
 
 
+# fix(#1778 codex r3): validate_embed_token_access now compares each positive
+# entry's generation stamp against the cluster-global revocation generation, and
+# an entry that carries no stamp (or a stale one) is treated as a miss. These
+# cases are about the SEC-014 expiry re-check, so they pin the generation and
+# stamp the entries they prime with it.
+_TEST_GENERATION = 11
+
+
 def _make_raw_token() -> str:
     import secrets
 
@@ -38,13 +46,17 @@ class FakeCache:
     def __init__(self) -> None:
         self._store: dict = {}
 
-    async def get(self, key: str):
+    async def get(self, key: str, *, security: bool = False):
         return self._store.get(key)
 
-    async def set(self, key: str, value, ttl: int = 300) -> None:
+    async def set(
+        self, key: str, value, ttl: int = 300, *, security: bool = False
+    ) -> None:
         self._store[key] = value
 
-    async def set_if_absent(self, key: str, value, ttl: int = 300) -> bool:
+    async def set_if_absent(
+        self, key: str, value, ttl: int = 300, *, security: bool = False
+    ) -> bool:
         """fix(#1778): mirrors the provider contract: never overwrite."""
         if key in self._store:
             return False
@@ -100,12 +112,17 @@ class TestEmbedTokenExpiryCacheHit:
             "scoped_dataset_ids": [str(dataset_id)],
             "allowed_origins": None,
             "map_id": str(uuid.uuid4()),
+            "generation": _TEST_GENERATION,
         }
 
         # Patch get_cache() to return our fake cache
         # Patch datetime.now inside the service module to return now_for_check
         with (
             patch("app.modules.embed_tokens.service.get_cache", return_value=cache),
+            patch(
+                "app.modules.embed_tokens.service.current_revocation_generation",
+                AsyncMock(return_value=_TEST_GENERATION),
+            ),
             patch(
                 "app.modules.embed_tokens.service.datetime",
                 wraps=datetime,
@@ -144,10 +161,15 @@ class TestEmbedTokenExpiryCacheHit:
             "allowed_origins": None,
             "map_id": str(uuid.uuid4()),
             "expires_at": expires_at.isoformat(),
+            "generation": _TEST_GENERATION,
         }
 
         with (
             patch("app.modules.embed_tokens.service.get_cache", return_value=cache),
+            patch(
+                "app.modules.embed_tokens.service.current_revocation_generation",
+                AsyncMock(return_value=_TEST_GENERATION),
+            ),
             patch(
                 "app.modules.embed_tokens.service.datetime",
                 wraps=datetime,
@@ -185,10 +207,15 @@ class TestEmbedTokenExpiryCacheHit:
             "allowed_origins": None,
             "map_id": str(uuid.uuid4()),
             "expires_at": expires_at.isoformat(),
+            "generation": _TEST_GENERATION,
         }
 
         with (
             patch("app.modules.embed_tokens.service.get_cache", return_value=cache),
+            patch(
+                "app.modules.embed_tokens.service.current_revocation_generation",
+                AsyncMock(return_value=_TEST_GENERATION),
+            ),
             patch(
                 "app.modules.embed_tokens.service.map_contains_dataset",
                 new=AsyncMock(return_value=True),
@@ -258,6 +285,10 @@ class TestEmbedTokenExpiryEndToEnd:
         with (
             patch("app.modules.embed_tokens.service.get_cache", return_value=cache),
             patch(
+                "app.modules.embed_tokens.service.current_revocation_generation",
+                AsyncMock(return_value=_TEST_GENERATION),
+            ),
+            patch(
                 "app.modules.embed_tokens.service.datetime",
                 wraps=datetime,
             ) as mock_dt,
@@ -270,6 +301,10 @@ class TestEmbedTokenExpiryEndToEnd:
         # --- Call 2: cache hit, time = after expiry ---
         with (
             patch("app.modules.embed_tokens.service.get_cache", return_value=cache),
+            patch(
+                "app.modules.embed_tokens.service.current_revocation_generation",
+                AsyncMock(return_value=_TEST_GENERATION),
+            ),
             patch(
                 "app.modules.embed_tokens.service.datetime",
                 wraps=datetime,
@@ -319,6 +354,10 @@ class TestEmbedTokenExpiryEndToEnd:
         with (
             patch("app.modules.embed_tokens.service.get_cache", return_value=cache),
             patch(
+                "app.modules.embed_tokens.service.current_revocation_generation",
+                AsyncMock(return_value=_TEST_GENERATION),
+            ),
+            patch(
                 "app.modules.embed_tokens.service.datetime",
                 wraps=datetime,
             ) as mock_dt,
@@ -331,6 +370,10 @@ class TestEmbedTokenExpiryEndToEnd:
         # Call 2: cache hit, still within valid window
         with (
             patch("app.modules.embed_tokens.service.get_cache", return_value=cache),
+            patch(
+                "app.modules.embed_tokens.service.current_revocation_generation",
+                AsyncMock(return_value=_TEST_GENERATION),
+            ),
             patch(
                 "app.modules.embed_tokens.service.datetime",
                 wraps=datetime,

--- a/backend/tests/test_embed_tokens_origin_bypass.py
+++ b/backend/tests/test_embed_tokens_origin_bypass.py
@@ -84,9 +84,25 @@ class TestClientIsLoopback:
         assert embed_service._client_is_loopback(request) is False
 
 
+_TEST_GENERATION = 3
+
+
 class TestEmbedTokenOriginBypassRequiresLoopbackPeer:
     """Phase 268 H-31: validate_embed_token_access must NOT honor a forged
     ``Origin: http://localhost`` from a non-loopback TCP peer."""
+
+    @pytest.fixture(autouse=True)
+    def _pin_revocation_generation(self, monkeypatch):
+        """fix(#1778 codex r3): a positive entry now carries the revocation
+        generation it was minted under, and one whose stamp is stale (or
+        missing) is refused and re-read from the database. These cases are about
+        the ORIGIN check on the cache-hit path, so they pin the generation and
+        stamp the entries they prime with the same value."""
+        monkeypatch.setattr(
+            embed_service,
+            "current_revocation_generation",
+            AsyncMock(return_value=_TEST_GENERATION),
+        )
 
     @pytest.mark.anyio
     async def test_remote_caller_forging_localhost_origin_is_rejected(
@@ -109,6 +125,7 @@ class TestEmbedTokenOriginBypassRequiresLoopbackPeer:
                 "expires_at": (
                     datetime.now(timezone.utc) + timedelta(days=1)
                 ).isoformat(),
+                "generation": _TEST_GENERATION,
             }
         )
         cache.set = AsyncMock()
@@ -148,6 +165,7 @@ class TestEmbedTokenOriginBypassRequiresLoopbackPeer:
                 "expires_at": (
                     datetime.now(timezone.utc) + timedelta(days=1)
                 ).isoformat(),
+                "generation": _TEST_GENERATION,
             }
         )
         cache.set = AsyncMock()
@@ -183,6 +201,7 @@ class TestEmbedTokenOriginBypassRequiresLoopbackPeer:
                 "expires_at": (
                     datetime.now(timezone.utc) + timedelta(days=1)
                 ).isoformat(),
+                "generation": _TEST_GENERATION,
             }
         )
         cache.set = AsyncMock()

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -3587,7 +3587,13 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # are the r3 round: it is issued as SET LOCAL rather than as a startup
     # parameter, because standard PgBouncer rejects an unknown one and
     # DB_USE_EXTERNAL_POOLER=true is a supported topology.
-    "backend/app/core/config.py": 1513,
+    #
+    # fix(#1778): +24 more for the boot-time GEOLENS_ADMIN_PASSWORD byte bound
+    # and the BCRYPT_MAX_PASSWORD_BYTES constant it needs. core/ may not import
+    # from app.modules.*, so the number is restated here rather than imported
+    # from password_policy.py; tests/test_oversized_password_1778.py pins the
+    # two together. Cap 1513 -> 1537, exact.
+    "backend/app/core/config.py": 1537,
     # fix(#1543): first entry — crossed _RATCHET_INCLUSION_LOC on the change
     # that gave PersistentConfig a batch eviction. The code is small
     # (apply_side_effects_batch, plus splitting the process-local half of

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -4037,7 +4037,17 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # the comment saying why a credential file does not belong on a volume
     # scripts/backup-entrypoint.sh archives. Cap 1096 -> 1104, exact.
     "backend/app/processing/ingest/ogr.py": 1104,
-    "backend/app/modules/auth/oauth/service.py": 1031,
+    # fix(#1778): +157 for two audit findings that both land in JIT
+    # provisioning. One is the REGISTRATION_ENABLED gate plus its exception
+    # class, so enabling a provider stops being a way to reopen signup while
+    # the Settings screen still reads "off". The other is
+    # _reconcile_mapped_role, which re-applies group_role_mapping on a
+    # returning user's login -- the mapping used to run only on the login that
+    # created the account, so it could grant a role and never revoke one. Most
+    # of the lines are the docstring on that helper stating its four
+    # preconditions, each of which is what stops a login from taking away a
+    # role the IdP said nothing about. Cap 1031 -> 1188, exact.
+    "backend/app/modules/auth/oauth/service.py": 1188,
     # fix(#1113 review): +15 — register_existing_table linearizes a
     # pre-existing geom_4326 (savepoint + error contract mirroring the
     # add_4326_column branch beside it); see linearize_existing_4326.

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -4047,7 +4047,25 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # of the lines are the docstring on that helper stating its four
     # preconditions, each of which is what stops a login from taking away a
     # role the IdP said nothing about. Cap 1031 -> 1188, exact.
-    "backend/app/modules/auth/oauth/service.py": 1188,
+    # fix(#1778 codex r1): +61 for three round-1 P1s in the same function. The
+    # role change now goes through AdminService.set_role_from_identity_provider,
+    # so it inherits the last-admin invariant and the key_epoch bump instead of
+    # assigning user.roles directly; a refused demotion writes its own audit row
+    # and the login continues. The verified-email linking branch gets the same
+    # reconciliation the subject-link branch had, and the function docstring
+    # enumerates all three return paths so the next one added cannot miss it.
+    # Cap 1188 -> 1249, exact.
+    "backend/app/modules/auth/oauth/service.py": 1249,
+    # fix(#1778 codex r1): first entry, crossed _RATCHET_INCLUSION_LOC on the
+    # change that added set_role_from_identity_provider, the public seam the
+    # OAuth group-role reconciliation applies a mapped role through. It exists
+    # so that path is the SAME role change the admin router makes rather than a
+    # second, weaker copy: the admin-lifecycle advisory lock, the last-admin
+    # rule and the key_epoch bump all come from _ensure_not_last_admin and
+    # _update_user_role, which stay private. Most of the lines are the docstring
+    # saying which invariants were missing and why a refusal is not an error for
+    # an IdP-driven caller. 992 -> 1036, exact.
+    "backend/app/modules/admin/service.py": 1036,
     # fix(#1113 review): +15 — register_existing_table linearizes a
     # pre-existing geom_4326 (savepoint + error contract mirroring the
     # add_4326_column branch beside it); see linearize_existing_4326.
@@ -4921,7 +4939,12 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # helper; the rest records the interleaving, why deleting the key cannot
     # close it from either side, and the fail-closed trade a rolled-back
     # revocation makes. Cap 1056 -> 1100.
-    "backend/app/modules/embed_tokens/service.py": 1100,
+    # fix(#1778 codex r1): +6, all comment. The denial write is
+    # set_authoritative, not set: `set` routes to whichever store the circuit
+    # breaker says is live, so a positive that landed in the in-memory fallback
+    # during an outage survived a denial written after Redis recovered.
+    # Cap 1100 -> 1106, exact.
+    "backend/app/modules/embed_tokens/service.py": 1106,
     # fix(#1778): first entry for this module — it crossed the 1000-line
     # inclusion threshold on the property-filter typing. Property filters used
     # to bind the raw query-string value, so PostgreSQL had no

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -4065,7 +4065,13 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # _update_user_role, which stay private. Most of the lines are the docstring
     # saying which invariants were missing and why a refusal is not an error for
     # an IdP-driven caller. 992 -> 1036, exact.
-    "backend/app/modules/admin/service.py": 1036,
+    # fix(#1778 codex r4): +19. The advisory lock now covers the PROMOTION
+    # branch too. Skipping it was justified by "a promotion cannot threaten the
+    # last-admin invariant", which is true and beside the point: two OAuth
+    # callbacks for one account both entered it unserialized, and
+    # _update_user_role's delete-then-insert collided on the (user_id, role_id)
+    # primary key, failing an otherwise valid login. Cap 1036 -> 1055, exact.
+    "backend/app/modules/admin/service.py": 1055,
     # fix(#1113 review): +15 — register_existing_table linearizes a
     # pre-existing geom_4326 (savepoint + error contract mirroring the
     # add_4326_column branch beside it); see linearize_existing_4326.
@@ -4954,7 +4960,10 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # comment on EMBED_TOKEN_POSITIVE_TTL_SECONDS, which names the residual this
     # bounds rather than closes, plus the note on what an unstamped pre-upgrade
     # entry does. Cap 1106 -> 1164, exact.
-    "backend/app/modules/embed_tokens/service.py": 1164,
+    # fix(#1778 codex r4): +10 for the comment saying why the generation bump
+    # shares the caller's transaction rather than running ahead of it, and why
+    # a failing bump must not be swallowed. Cap 1164 -> 1174, exact.
+    "backend/app/modules/embed_tokens/service.py": 1174,
     # fix(#1778): first entry for this module — it crossed the 1000-line
     # inclusion threshold on the property-filter typing. Property filters used
     # to bind the raw query-string value, so PostgreSQL had no

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -4944,7 +4944,17 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # breaker says is live, so a positive that landed in the in-memory fallback
     # during an outage survived a denial written after Redis recovered.
     # Cap 1100 -> 1106, exact.
-    "backend/app/modules/embed_tokens/service.py": 1106,
+    # fix(#1778 codex r3): +52. The fallback and the replay queue are
+    # PROCESS-local and production runs several Uvicorn workers, so a revoke on
+    # one worker during a Redis outage reached no other. Reads and writes of the
+    # validation entry now pass security=True (never answer an authorization
+    # positive from this worker's memory), every positive is stamped with the
+    # cluster-global revocation generation and compared against it on each hit,
+    # and the revoke paths advance that generation. Most of the lines are the
+    # comment on EMBED_TOKEN_POSITIVE_TTL_SECONDS, which names the residual this
+    # bounds rather than closes, plus the note on what an unstamped pre-upgrade
+    # entry does. Cap 1106 -> 1164, exact.
+    "backend/app/modules/embed_tokens/service.py": 1164,
     # fix(#1778): first entry for this module — it crossed the 1000-line
     # inclusion threshold on the property-filter typing. Property filters used
     # to bind the raw query-string value, so PostgreSQL had no
@@ -6982,3 +6992,90 @@ def test_cross_package_router_import_allowlist_is_current() -> None:
             "_CROSS_PACKAGE_ROUTER_IMPORT_BURNDOWN lists edges that no longer "
             "exist. Delete them — the list only shrinks.\n" + "\n".join(stale)
         )
+
+
+# fix(#1778 codex r3): every cache read that DECIDES ACCESS must be marked
+# security=True, so the layered provider refuses to answer it from this worker's
+# process-local fallback. The provider cannot tell an authorization decision
+# from a cached listing by looking at the value, so the marking is the contract
+# and this test is what keeps the marking honest.
+#
+# Phrased as a per-module rule rather than a repo-wide one on purpose. Sweeping
+# every `cache.get(` in backend/app/ and demanding the flag would be wrong: the
+# catalog and collection listings, the search cache and persistent config are
+# cached ANSWERS whose staleness is a correctness annoyance bounded by a TTL,
+# not a capability someone still holds. Adding a module here is the deliberate
+# act of saying "the values this module caches are decisions".
+_AUTHORIZATION_CACHE_MODULES: tuple[str, ...] = (
+    "backend/app/modules/embed_tokens/service.py",
+)
+
+
+@pytest.mark.architecture
+def test_authorization_cache_reads_are_security_scoped() -> None:
+    """Every cache get/set in an authorization module passes security=True.
+
+    ``set_authoritative`` is exempt: it is security-shaped by construction (it
+    writes a revocation into every store) and takes no flag.
+    """
+    import ast
+
+    offenders: list[str] = []
+    for rel in _AUTHORIZATION_CACHE_MODULES:
+        path = _backend_path(rel.removeprefix("backend/"))
+        source = path.read_text(encoding="utf-8")
+        for node in ast.walk(ast.parse(source)):
+            if not isinstance(node, ast.Call):
+                continue
+            func = node.func
+            if not isinstance(func, ast.Attribute):
+                continue
+            if func.attr not in {"get", "set", "set_if_absent"}:
+                continue
+            # Only calls on something named `cache`, which is what get_cache()
+            # is bound to everywhere in these modules.
+            if not (isinstance(func.value, ast.Name) and func.value.id == "cache"):
+                continue
+            flagged = any(
+                kw.arg == "security"
+                and isinstance(kw.value, ast.Constant)
+                and kw.value.value is True
+                for kw in node.keywords
+            )
+            if not flagged:
+                offenders.append(f"  {rel}:{node.lineno} cache.{func.attr}(...)")
+
+    if offenders:
+        pytest.fail(
+            "An authorization cache call is missing security=True, so a layered "
+            "provider may answer it from this worker's in-memory fallback. That "
+            "fallback cannot see a revoke another Uvicorn worker performed while "
+            "Redis was down (fix(#1778 codex r3)). Offending calls:\n"
+            + "\n".join(offenders)
+        )
+
+
+@pytest.mark.architecture
+def test_authorization_cache_guard_catches_a_seeded_violation() -> None:
+    """The guard above fails on an unflagged call, so a green run means something."""
+    import ast
+
+    seeded = "cache.get(cache_key)\ncache.set(k, v, ttl=1, security=True)\n"
+    found = []
+    for node in ast.walk(ast.parse(seeded)):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if not isinstance(func, ast.Attribute) or func.attr not in {"get", "set"}:
+            continue
+        flagged = any(
+            kw.arg == "security"
+            and isinstance(kw.value, ast.Constant)
+            and kw.value.value is True
+            for kw in node.keywords
+        )
+        if not flagged:
+            found.append(func.attr)
+    assert found == ["get"], (
+        "the seeded unflagged call was not detected, so the real guard is inert"
+    )

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -4903,7 +4903,15 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # machine. The rest records why _LOOPBACK_CLIENT_IPS stays an exact set:
     # that one GATES the localhost bypass, so a miss there denies, while a miss
     # in the other ISSUES an unenforceable lock. Cap 1042 -> 1056.
-    "backend/app/modules/embed_tokens/service.py": 1056,
+    # fix(#1778): +44, almost all comment. Revocation now stamps a denial over
+    # the validation-cache entry instead of deleting it, and the validator
+    # publishes its positive entry with set_if_absent, so a request that raced
+    # an uncommitted revoke cannot re-cache the token for the rest of the TTL.
+    # The four eviction sites collapse into one _deny_revoked_embed_tokens
+    # helper; the rest records the interleaving, why deleting the key cannot
+    # close it from either side, and the fail-closed trade a rolled-back
+    # revocation makes. Cap 1056 -> 1100.
+    "backend/app/modules/embed_tokens/service.py": 1100,
     # fix(#1778): first entry for this module — it crossed the 1000-line
     # inclusion threshold on the property-filter typing. Property filters used
     # to bind the raw query-string value, so PostgreSQL had no

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -4055,7 +4055,11 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # reconciliation the subject-link branch had, and the function docstring
     # enumerates all three return paths so the next one added cannot miss it.
     # Cap 1188 -> 1249, exact.
-    "backend/app/modules/auth/oauth/service.py": 1249,
+    # fix(#1778 codex r5): +12. The audit event now fires only on a real change
+    # and carries the previous roles the role update actually started from,
+    # rather than a snapshot this coroutine took before waiting for the lock.
+    # Cap 1249 -> 1261, exact.
+    "backend/app/modules/auth/oauth/service.py": 1261,
     # fix(#1778 codex r1): first entry, crossed _RATCHET_INCLUSION_LOC on the
     # change that added set_role_from_identity_provider, the public seam the
     # OAuth group-role reconciliation applies a mapped role through. It exists
@@ -4071,7 +4075,13 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # callbacks for one account both entered it unserialized, and
     # _update_user_role's delete-then-insert collided on the (user_id, role_id)
     # primary key, failing an otherwise valid login. Cap 1036 -> 1055, exact.
-    "backend/app/modules/admin/service.py": 1055,
+    # fix(#1778 codex r5): +43 for IdentityRoleOutcome and its docstring.
+    # set_role_from_identity_provider returned a bare bool, so a caller could
+    # not tell "applied" from "was already correct", and the loser of two
+    # concurrent promotions reported a change it had not made. It now reports
+    # applied/changed plus the previous roles read UNDER the lock, which is what
+    # lets the caller audit only a real transition. Cap 1055 -> 1098, exact.
+    "backend/app/modules/admin/service.py": 1098,
     # fix(#1113 review): +15 — register_existing_table linearizes a
     # pre-existing geom_4326 (savepoint + error contract mirroring the
     # add_4326_column branch beside it); see linearize_existing_4326.
@@ -4963,7 +4973,12 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # fix(#1778 codex r4): +10 for the comment saying why the generation bump
     # shares the caller's transaction rather than running ahead of it, and why
     # a failing bump must not be swallowed. Cap 1164 -> 1174, exact.
-    "backend/app/modules/embed_tokens/service.py": 1174,
+    # fix(#1778 codex r5): +18. An unreadable counter yields a SENTINEL, not a
+    # generation, and two entries stamped with it compared EQUAL. The validator
+    # now refuses to trust or to write anything while the generation is
+    # unusable, so a positive cached during that window cannot outlive a later
+    # revocation. Cap 1174 -> 1192, exact.
+    "backend/app/modules/embed_tokens/service.py": 1192,
     # fix(#1778): first entry for this module — it crossed the 1000-line
     # inclusion threshold on the property-filter typing. Property filters used
     # to bind the raw query-string value, so PostgreSQL had no

--- a/backend/tests/test_oauth.py
+++ b/backend/tests/test_oauth.py
@@ -684,6 +684,22 @@ class TestOAuthSchemas:
 class TestFindOrCreateOAuthUser:
     """Test user find-or-create logic for OAuth login."""
 
+    @pytest.fixture(autouse=True)
+    def _registration_on(self, monkeypatch):
+        """fix(#1778): JIT provisioning now honours REGISTRATION_ENABLED, whose
+        shipped default is False. These cases are about the provisioning logic
+        itself, so they run with the operator switch on; the gate has its own
+        tests in tests/test_oauth_registration_gate_1778.py."""
+        from unittest.mock import AsyncMock
+
+        from app.modules.auth.oauth import service as oauth_service
+
+        monkeypatch.setattr(
+            oauth_service.REGISTRATION_ENABLED,
+            "get_uncached",
+            AsyncMock(return_value=True),
+        )
+
     async def _create_test_provider(self, db, **overrides):
         """Helper: create an OAuthProvider in the test DB."""
         from app.modules.auth.oauth.schemas import OAuthProviderCreate

--- a/backend/tests/test_oauth_audit_correlation.py
+++ b/backend/tests/test_oauth_audit_correlation.py
@@ -315,6 +315,50 @@ async def test_callback_domain_not_allowed_emits_failure_audit(
 
 
 # ---------------------------------------------------------------------------
+# Test 5b: fix(#1778): OAuthRegistrationDisabledError gets the same treatment
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_callback_registration_disabled_emits_failure_audit(
+    client, client_session, _ensure_public_app_url
+):
+    """registration_disabled failure branch emits oauth.login.failure and
+    redirects with the matching fragment, so the operator can see why a sign-in
+    was refused rather than reading it as a generic failure."""
+    from app.modules.auth.oauth.service import OAuthRegistrationDisabledError
+
+    provider = await _create_test_provider(client_session)
+    slug = provider.slug
+
+    mock_client = MagicMock()
+    mock_client.authorize_access_token = AsyncMock(
+        side_effect=OAuthRegistrationDisabledError("registration off")
+    )
+
+    with patch(
+        "app.modules.auth.oauth.router.build_oauth_client",
+        AsyncMock(return_value=(mock_client, provider)),
+    ):
+        resp = await client.get(f"/auth/oauth/{slug}/callback", follow_redirects=False)
+
+    assert resp.status_code in (302, 307)
+    location = resp.headers.get("location", "")
+    assert "registration_disabled" in location
+
+    result = await client_session.execute(
+        select(AuditLog)
+        .where(AuditLog.action == "oauth.login.failure")
+        .order_by(AuditLog.created_at.desc())
+    )
+    rows = result.scalars().all()
+    assert rows, "Expected oauth.login.failure audit row for registration_disabled"
+    row = rows[0]
+    assert row.details is not None
+    assert row.details.get("outcome") == "registration_disabled"
+
+
+# ---------------------------------------------------------------------------
 # Test 6: FIX-C — generic exception mid-provisioning rolls back partial User;
 # only the failure-audit row is persisted (Codex P2).
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_oauth_github_provider.py
+++ b/backend/tests/test_oauth_github_provider.py
@@ -373,6 +373,20 @@ class TestGithubDomainEnforcement:
     GitHub emails are rejected and no user is created (T-1237-02).
     """
 
+    @pytest.fixture(autouse=True)
+    def _registration_on(self, monkeypatch):
+        """fix(#1778): JIT provisioning now honours REGISTRATION_ENABLED, whose
+        shipped default is False. This class is about the DOMAIN check, so it
+        runs with the operator switch on; the switch has its own tests in
+        tests/test_oauth_registration_gate_1778.py."""
+        from app.modules.auth.oauth import service as oauth_service
+
+        monkeypatch.setattr(
+            oauth_service.REGISTRATION_ENABLED,
+            "get_uncached",
+            AsyncMock(return_value=True),
+        )
+
     async def _make_github_provider(self, db: AsyncSession) -> OAuthProvider:
         """Insert a minimal github-typed OAuthProvider for tests."""
         provider = OAuthProvider(

--- a/backend/tests/test_oauth_registration_gate_1778.py
+++ b/backend/tests/test_oauth_registration_gate_1778.py
@@ -1,0 +1,142 @@
+"""fix(#1778): turning on an OAuth provider must not turn on signup.
+
+Codebase audit 2026-08-30, "Enabling any OAuth provider silently overrides the
+operator's 'registration disabled' switch and auto-provisions active accounts".
+
+``registration_enabled`` ships False and the password path honours it
+(POST /auth/register/ returns 403), but JIT provisioning never read it: an
+unknown subject reaching /auth/oauth/{slug}/login was created with
+status="active" and the provider's ``default_role``, which defaults to
+``viewer`` -- a role that can list and export every ``internal`` dataset. The
+admin Settings screen still read "Registration enabled: off".
+
+Counterfactual: remove the REGISTRATION_ENABLED check from
+find_or_create_oauth_user and test_an_unknown_identity_is_refused fails with a
+provisioned user instead of the refusal.
+"""
+
+import uuid
+from unittest.mock import AsyncMock
+
+import pytest
+from sqlalchemy import func, select
+
+from app.modules.auth.models import User
+from app.modules.auth.oauth import service as oauth_service
+from app.modules.auth.oauth.schemas import OAuthProviderCreate
+from app.modules.auth.oauth.service import (
+    OAuthRegistrationDisabledError,
+    create_provider,
+    find_or_create_oauth_user,
+)
+
+pytestmark = pytest.mark.anyio
+
+
+def _registration(monkeypatch, enabled: bool) -> None:
+    monkeypatch.setattr(
+        oauth_service.REGISTRATION_ENABLED,
+        "get_uncached",
+        AsyncMock(return_value=enabled),
+    )
+
+
+async def _provider(db):
+    suffix = uuid.uuid4().hex[:6]
+    return await create_provider(
+        db,
+        OAuthProviderCreate(
+            slug=f"gate-provider-{suffix}",
+            display_name="Gate Provider",
+            provider_type="oidc",
+            client_id=f"client-{suffix}",
+            client_secret="test-secret",
+            enabled=True,
+            default_role="viewer",
+        ),
+    )
+
+
+def _userinfo(**overrides) -> dict:
+    info = {
+        "sub": f"sub-{uuid.uuid4().hex[:8]}",
+        "email": f"gate-{uuid.uuid4().hex[:8]}@example.com",
+        "email_verified": True,
+        "name": "Gate User",
+    }
+    info.update(overrides)
+    return info
+
+
+async def test_an_unknown_identity_is_refused(client, test_db_session, monkeypatch):
+    _registration(monkeypatch, False)
+    provider = await _provider(test_db_session)
+    await test_db_session.commit()
+
+    info = _userinfo()
+    before = await test_db_session.scalar(select(func.count()).select_from(User))
+
+    with pytest.raises(OAuthRegistrationDisabledError):
+        await find_or_create_oauth_user(test_db_session, provider, info, {})
+
+    await test_db_session.rollback()
+    after = await test_db_session.scalar(select(func.count()).select_from(User))
+    assert after == before, "a refused OAuth sign-in must create no account"
+
+
+async def test_a_returning_user_still_signs_in(client, test_db_session, monkeypatch):
+    """The gate is about creating accounts, not about locking anyone out."""
+    _registration(monkeypatch, True)
+    provider = await _provider(test_db_session)
+    await test_db_session.commit()
+
+    info = _userinfo()
+    created = await find_or_create_oauth_user(test_db_session, provider, info, {})
+    await test_db_session.commit()
+    created_id = created.id
+
+    _registration(monkeypatch, False)
+    returning = await find_or_create_oauth_user(test_db_session, provider, info, {})
+    assert returning.id == created_id
+
+
+async def test_an_existing_account_still_links_by_verified_email(
+    client, test_db_session, admin_auth_header, monkeypatch
+):
+    """An admin-created account is what "an administrator creates it first"
+    means, so the email-match link must survive the gate."""
+    _registration(monkeypatch, False)
+    provider = await _provider(test_db_session)
+    await test_db_session.commit()
+
+    username = f"preseeded_{uuid.uuid4().hex[:8]}"
+    email = f"{username}@example.com"
+    resp = await client.post(
+        "/admin/users/",
+        json={
+            "username": username,
+            "password": "TestPass1234!",
+            "email": email,
+            "role": "viewer",
+        },
+        headers=admin_auth_header,
+    )
+    assert resp.status_code == 201, resp.text
+
+    linked = await find_or_create_oauth_user(
+        test_db_session, provider, _userinfo(email=email), {}
+    )
+    assert linked.username == username
+
+
+async def test_the_switch_being_on_still_provisions(
+    client, test_db_session, monkeypatch
+):
+    _registration(monkeypatch, True)
+    provider = await _provider(test_db_session)
+    await test_db_session.commit()
+
+    user = await find_or_create_oauth_user(test_db_session, provider, _userinfo(), {})
+    await test_db_session.commit()
+    assert user.auth_provider == "oauth"
+    assert user.is_active is True

--- a/backend/tests/test_oauth_role_reevaluation_1778.py
+++ b/backend/tests/test_oauth_role_reevaluation_1778.py
@@ -21,6 +21,7 @@ still holding admin.
 """
 
 import uuid
+from contextlib import asynccontextmanager
 
 import pytest
 from sqlalchemy import select
@@ -284,3 +285,229 @@ async def test_community_ignores_the_mapping(client, test_db_session):
     )
     await test_db_session.commit()
     assert await _role_names(test_db_session, created.id) == {"admin"}
+
+
+# ---------------------------------------------------------------------------
+# fix(#1778 codex r1): the reconciliation must be the SAME role change every
+# other route makes, not a weaker copy of it.
+#
+# Counterfactuals, each run: assign user.roles directly instead of calling
+# AdminService.set_role_from_identity_provider and the sole-admin and key-epoch
+# tests fail; drop the _reconcile_mapped_role call from the verified-email
+# branch and the cross-provider test fails.
+# ---------------------------------------------------------------------------
+
+
+async def _active_admin_count(db) -> int:
+    rows = await db.execute(
+        select(User.id)
+        .join(UserRole, UserRole.user_id == User.id)
+        .join(Role, UserRole.role_id == Role.id)
+        .where(Role.name == "admin", User.status == "active", User.is_active.is_(True))
+    )
+    return len(set(rows.scalars().all()))
+
+
+@asynccontextmanager
+async def _only_admin_is(db, keep_id):
+    """Strip admin from every other account for the body, then put it back.
+
+    The seeded GEOLENS_ADMIN account is one of the accounts demoted here, and it
+    is cluster-global state every other test in this database depends on, so the
+    restore runs in a finally.
+    """
+    viewer = await db.scalar(select(Role).where(Role.name == "viewer"))
+    admin_role = await db.scalar(select(Role).where(Role.name == "admin"))
+    rows = await db.execute(
+        select(User)
+        .join(UserRole, UserRole.user_id == User.id)
+        .join(Role, UserRole.role_id == Role.id)
+        .where(Role.name == "admin", User.id != keep_id)
+    )
+    demoted = list(rows.scalars().unique().all())
+    for other in demoted:
+        other.roles = [viewer]
+    await db.commit()
+    try:
+        yield
+    finally:
+        for other in demoted:
+            other.roles = [admin_role]
+        await db.commit()
+
+
+async def test_the_sole_admin_is_not_demoted_by_an_empty_groups_claim(
+    client, test_db_session, enterprise
+):
+    """The last-admin invariant belongs to every demotion route, this one
+    included. Assigning the default role directly would remove the deployment's
+    only way back in on the say-so of an IdP assertion."""
+    provider = await _provider(test_db_session)
+    sub = f"soleadmin-{uuid.uuid4().hex[:8]}"
+
+    created = await find_or_create_oauth_user(
+        test_db_session, provider, _userinfo(sub, ["gis-admins"]), {}
+    )
+    await test_db_session.commit()
+    assert await _role_names(test_db_session, created.id) == {"admin"}
+
+    async with _only_admin_is(test_db_session, created.id):
+        assert await _active_admin_count(test_db_session) == 1
+
+        returning = await find_or_create_oauth_user(
+            test_db_session, provider, _userinfo(sub, []), {}
+        )
+        await test_db_session.commit()
+
+        assert returning.id == created.id
+        assert await _role_names(test_db_session, created.id) == {"admin"}, (
+            "an IdP assertion removed the last admin"
+        )
+
+        refusals = (
+            (
+                await test_db_session.execute(
+                    select(AuditLog).where(
+                        AuditLog.action == "oauth.role.change_refused",
+                        AuditLog.user_id == created.id,
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert refusals, "a refused demotion has to be visible to an operator"
+        details = refusals[0].details or {}
+        assert details["reason"] == "last_admin"
+        assert details["mapped_role"] == "viewer"
+        assert details["current_roles"] == ["admin"]
+
+
+async def test_a_second_admin_present_lets_the_demotion_through(
+    client, test_db_session, enterprise
+):
+    """The invariant refuses only the LAST admin. With another one active the
+    mapped demotion applies as normal.
+
+    The second admin is created here rather than assumed from the seeded
+    GEOLENS_ADMIN account, so this does not turn red because some other module
+    left that account demoted."""
+    provider = await _provider(test_db_session)
+    sub = f"notlast-{uuid.uuid4().hex[:8]}"
+
+    created = await find_or_create_oauth_user(
+        test_db_session, provider, _userinfo(sub, ["gis-admins"]), {}
+    )
+    await test_db_session.commit()
+    assert await _role_names(test_db_session, created.id) == {"admin"}
+
+    admin_role = await test_db_session.scalar(select(Role).where(Role.name == "admin"))
+    spare = User(
+        username=f"spareadmin_{uuid.uuid4().hex[:8]}",
+        password_hash=hash_password("TestPass1234!"),
+        auth_provider="local",
+        is_active=True,
+        status="active",
+        roles=[admin_role],
+    )
+    test_db_session.add(spare)
+    await test_db_session.commit()
+    assert await _active_admin_count(test_db_session) >= 2
+
+    await find_or_create_oauth_user(test_db_session, provider, _userinfo(sub, []), {})
+    await test_db_session.commit()
+    assert await _role_names(test_db_session, created.id) == {"viewer"}
+
+
+async def test_a_mapped_promotion_bumps_the_key_epoch(
+    client, test_db_session, enterprise
+):
+    """fix(#821)'s rule is that a role change invalidates keys minted under the
+    old role. An API key minted while the account was a viewer must not silently
+    become an admin key after the next OAuth login."""
+    provider = await _provider(test_db_session)
+    sub = f"epoch-{uuid.uuid4().hex[:8]}"
+
+    created = await find_or_create_oauth_user(
+        test_db_session, provider, _userinfo(sub, ["everyone"]), {}
+    )
+    await test_db_session.commit()
+    assert await _role_names(test_db_session, created.id) == {"viewer"}
+    epoch_before = await test_db_session.scalar(
+        select(User.key_epoch).where(User.id == created.id)
+    )
+
+    await find_or_create_oauth_user(
+        test_db_session, provider, _userinfo(sub, ["gis-admins"]), {}
+    )
+    await test_db_session.commit()
+
+    epoch_after = await test_db_session.scalar(
+        select(User.key_epoch).where(User.id == created.id)
+    )
+    assert await _role_names(test_db_session, created.id) == {"admin"}
+    assert epoch_after > epoch_before, (
+        "a key minted as viewer still resolves after the account became admin"
+    )
+
+
+async def test_an_unchanged_role_does_not_bump_the_key_epoch(
+    client, test_db_session, enterprise
+):
+    """An assertion that agrees with the current role is not a security event,
+    so it must not revoke the account's API keys on every login."""
+    provider = await _provider(test_db_session)
+    sub = f"idempotent-{uuid.uuid4().hex[:8]}"
+
+    created = await find_or_create_oauth_user(
+        test_db_session, provider, _userinfo(sub, ["gis-admins"]), {}
+    )
+    await test_db_session.commit()
+    epoch_before = await test_db_session.scalar(
+        select(User.key_epoch).where(User.id == created.id)
+    )
+
+    await find_or_create_oauth_user(
+        test_db_session, provider, _userinfo(sub, ["gis-admins"]), {}
+    )
+    await test_db_session.commit()
+
+    epoch_after = await test_db_session.scalar(
+        select(User.key_epoch).where(User.id == created.id)
+    )
+    assert epoch_after == epoch_before
+
+
+async def test_the_first_email_linked_login_applies_the_new_provider_mapping(
+    client, test_db_session, enterprise
+):
+    """The verified-email branch is the OTHER return path that yields an
+    existing account. Without reconciliation there, an OAuth-provisioned account
+    linking to a second provider carries its old role for that whole session."""
+    first = await _provider(test_db_session)
+    second = await _provider(test_db_session, group_role_mapping={"leads": "editor"})
+
+    email = f"crossprovider-{uuid.uuid4().hex[:8]}@example.com"
+    created = await find_or_create_oauth_user(
+        test_db_session,
+        first,
+        _userinfo(f"first-{uuid.uuid4().hex[:8]}", ["gis-admins"], email=email),
+        {},
+    )
+    await test_db_session.commit()
+    assert await _role_names(test_db_session, created.id) == {"admin"}
+
+    # First ever login through the SECOND provider: linked by verified email,
+    # so the subject-link branch is not the one that runs.
+    linked = await find_or_create_oauth_user(
+        test_db_session,
+        second,
+        _userinfo(f"second-{uuid.uuid4().hex[:8]}", ["everyone"], email=email),
+        {},
+    )
+    await test_db_session.commit()
+
+    assert linked.id == created.id
+    assert await _role_names(test_db_session, created.id) == {"viewer"}, (
+        "the second provider's mapping was ignored on the linking login"
+    )

--- a/backend/tests/test_oauth_role_reevaluation_1778.py
+++ b/backend/tests/test_oauth_role_reevaluation_1778.py
@@ -1,0 +1,286 @@
+"""fix(#1778): group_role_mapping is live, not a one-shot at account creation.
+
+Codebase audit 2026-08-30, "OAuth role is bound once at JIT creation and never
+re-evaluated -- group_role_mapping can grant a role but can never revoke one".
+
+_resolve_role ran only on the login that created the account. Removing someone
+from the IdP group, or offboarding them and re-onboarding a different person
+under a recycled group name, never demoted the GeoLens account: the role granted
+on day one stood until an admin edited it by hand. The field's description
+("JSON object mapping IdP group names to GeoLens roles. First match wins") and
+both UI hints read as a live mapping.
+
+The four preconditions in _reconcile_mapped_role are each tested here, because
+each of them is what stops a login from taking a role away that the IdP never
+said anything about.
+
+Counterfactual: delete the _reconcile_mapped_role call from the returning-user
+branch of find_or_create_oauth_user and
+test_a_returning_user_is_demoted_when_the_group_is_gone fails with the account
+still holding admin.
+"""
+
+import uuid
+
+import pytest
+from sqlalchemy import select
+
+from app.core.edition import init_edition, is_enterprise
+from app.modules.audit.models import AuditLog
+from app.modules.auth.models import Role, User, UserRole
+from app.modules.auth.oauth import service as oauth_service
+from app.modules.auth.oauth.encryption import encrypt_secret
+from app.modules.auth.oauth.models import OAuthProvider
+from app.modules.auth.oauth.service import find_or_create_oauth_user
+from app.modules.auth.providers.local import hash_password
+
+pytestmark = pytest.mark.anyio
+
+
+@pytest.fixture
+def enterprise():
+    """init_edition is process-global; restore whatever it was."""
+    was_enterprise = is_enterprise()
+    init_edition(["enterprise"])
+    yield
+    init_edition(["enterprise"] if was_enterprise else [])
+
+
+@pytest.fixture(autouse=True)
+def _registration_on(monkeypatch):
+    """fix(#1778): the sibling gate would otherwise refuse the first login that
+    sets these cases up. That gate has its own tests."""
+    from unittest.mock import AsyncMock
+
+    monkeypatch.setattr(
+        oauth_service.REGISTRATION_ENABLED,
+        "get_uncached",
+        AsyncMock(return_value=True),
+    )
+
+
+async def _provider(db, **overrides) -> OAuthProvider:
+    suffix = uuid.uuid4().hex[:6]
+    fields = dict(
+        slug=f"role-reeval-{suffix}",
+        display_name="Role Reeval Provider",
+        provider_type="oidc",
+        client_id=f"client-{suffix}",
+        client_secret_encrypted=encrypt_secret("test-secret"),
+        scopes="openid profile email",
+        default_role="viewer",
+        group_claim="groups",
+        group_role_mapping={"gis-admins": "admin"},
+        enabled=True,
+    )
+    fields.update(overrides)
+    provider = OAuthProvider(**fields)
+    db.add(provider)
+    await db.flush()
+    await db.commit()
+    return provider
+
+
+def _userinfo(sub: str, groups=None, **overrides) -> dict:
+    info = {
+        "sub": sub,
+        "email": f"{sub}@example.com",
+        "email_verified": True,
+        "name": "Reeval User",
+    }
+    if groups is not None:
+        info["groups"] = groups
+    info.update(overrides)
+    return info
+
+
+async def _role_names(db, user_id) -> set[str]:
+    rows = await db.execute(
+        select(Role.name)
+        .join(UserRole, UserRole.role_id == Role.id)
+        .where(UserRole.user_id == user_id)
+    )
+    return set(rows.scalars().all())
+
+
+async def test_a_returning_user_is_demoted_when_the_group_is_gone(
+    client, test_db_session, enterprise
+):
+    provider = await _provider(test_db_session)
+    sub = f"demote-{uuid.uuid4().hex[:8]}"
+
+    created = await find_or_create_oauth_user(
+        test_db_session, provider, _userinfo(sub, ["gis-admins"]), {}
+    )
+    await test_db_session.commit()
+    assert await _role_names(test_db_session, created.id) == {"admin"}
+
+    # Offboarded from the IdP group; the IdP still asserts the claim.
+    returning = await find_or_create_oauth_user(
+        test_db_session, provider, _userinfo(sub, ["everyone"]), {}
+    )
+    await test_db_session.commit()
+    assert returning.id == created.id
+    assert await _role_names(test_db_session, created.id) == {"viewer"}
+
+
+async def test_a_returning_user_is_promoted_when_the_group_is_added(
+    client, test_db_session, enterprise
+):
+    provider = await _provider(test_db_session)
+    sub = f"promote-{uuid.uuid4().hex[:8]}"
+
+    created = await find_or_create_oauth_user(
+        test_db_session, provider, _userinfo(sub, ["everyone"]), {}
+    )
+    await test_db_session.commit()
+    assert await _role_names(test_db_session, created.id) == {"viewer"}
+
+    await find_or_create_oauth_user(
+        test_db_session, provider, _userinfo(sub, ["gis-admins"]), {}
+    )
+    await test_db_session.commit()
+    assert await _role_names(test_db_session, created.id) == {"admin"}
+
+
+async def test_the_change_is_recorded(client, test_db_session, enterprise):
+    provider = await _provider(test_db_session)
+    sub = f"audited-{uuid.uuid4().hex[:8]}"
+
+    created = await find_or_create_oauth_user(
+        test_db_session, provider, _userinfo(sub, ["gis-admins"]), {}
+    )
+    await test_db_session.commit()
+
+    await find_or_create_oauth_user(
+        test_db_session, provider, _userinfo(sub, ["everyone"]), {}
+    )
+    await test_db_session.commit()
+
+    rows = (
+        (
+            await test_db_session.execute(
+                select(AuditLog).where(
+                    AuditLog.action == "oauth.role.changed",
+                    AuditLog.user_id == created.id,
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert rows, "a silent demotion is the thing that made this hard to notice"
+    details = rows[0].details or {}
+    assert details["previous_roles"] == ["admin"]
+    assert details["new_role"] == "viewer"
+    assert details["provider_slug"] == provider.slug
+
+
+async def test_no_mapping_configured_leaves_a_local_promotion_alone(
+    client, test_db_session, enterprise
+):
+    """With no mapping the operator has said nothing about roles, so an admin
+    promoted in the GeoLens UI must survive every subsequent login."""
+    provider = await _provider(test_db_session, group_role_mapping=None)
+    sub = f"unmapped-{uuid.uuid4().hex[:8]}"
+
+    created = await find_or_create_oauth_user(
+        test_db_session, provider, _userinfo(sub, ["everyone"]), {}
+    )
+    await test_db_session.commit()
+
+    admin_role = await test_db_session.scalar(select(Role).where(Role.name == "admin"))
+    created.roles = [admin_role]
+    await test_db_session.commit()
+
+    await find_or_create_oauth_user(
+        test_db_session, provider, _userinfo(sub, ["everyone"]), {}
+    )
+    await test_db_session.commit()
+    assert await _role_names(test_db_session, created.id) == {"admin"}
+
+
+async def test_an_omitted_groups_claim_does_not_demote(
+    client, test_db_session, enterprise
+):
+    """No assertion is not evidence of no membership. _resolve_role(None, ...)
+    returns default_role, so acting on an omitted claim would demote everyone
+    who signed in while the IdP was misconfigured."""
+    provider = await _provider(test_db_session)
+    sub = f"noclaim-{uuid.uuid4().hex[:8]}"
+
+    created = await find_or_create_oauth_user(
+        test_db_session, provider, _userinfo(sub, ["gis-admins"]), {}
+    )
+    await test_db_session.commit()
+    assert await _role_names(test_db_session, created.id) == {"admin"}
+
+    await find_or_create_oauth_user(test_db_session, provider, _userinfo(sub), {})
+    await test_db_session.commit()
+    assert await _role_names(test_db_session, created.id) == {"admin"}
+
+
+async def test_a_local_account_linked_by_email_keeps_its_roles(
+    client, test_db_session, enterprise
+):
+    """The account is the GeoLens admin's, not the provider's."""
+    provider = await _provider(test_db_session)
+    username = f"localacct_{uuid.uuid4().hex[:8]}"
+    email = f"{username}@example.com"
+
+    admin_role = await test_db_session.scalar(select(Role).where(Role.name == "admin"))
+    local = User(
+        username=username,
+        email=email,
+        email_verified=True,
+        password_hash=hash_password("TestPass1234!"),
+        auth_provider="local",
+        is_active=True,
+        status="active",
+        roles=[admin_role],
+    )
+    test_db_session.add(local)
+    await test_db_session.commit()
+
+    linked = await find_or_create_oauth_user(
+        test_db_session,
+        provider,
+        _userinfo(f"link-{uuid.uuid4().hex[:8]}", ["everyone"], email=email),
+        {},
+    )
+    await test_db_session.commit()
+    assert linked.id == local.id
+
+    # A second login, now a returning user through the OAuthAccount link.
+    await find_or_create_oauth_user(
+        test_db_session,
+        provider,
+        _userinfo(f"link-{uuid.uuid4().hex[:8]}", ["everyone"], email=email),
+        {},
+    )
+    await test_db_session.commit()
+    assert await _role_names(test_db_session, local.id) == {"admin"}
+
+
+async def test_community_ignores_the_mapping(client, test_db_session):
+    """Group mapping is an enterprise capability; the JIT path already ignores
+    the column outside it, and so must the re-evaluation."""
+    init_edition([])
+    provider = await _provider(test_db_session)
+    sub = f"community-{uuid.uuid4().hex[:8]}"
+
+    created = await find_or_create_oauth_user(
+        test_db_session, provider, _userinfo(sub, ["gis-admins"]), {}
+    )
+    await test_db_session.commit()
+    assert await _role_names(test_db_session, created.id) == {"viewer"}
+
+    admin_role = await test_db_session.scalar(select(Role).where(Role.name == "admin"))
+    created.roles = [admin_role]
+    await test_db_session.commit()
+
+    await find_or_create_oauth_user(
+        test_db_session, provider, _userinfo(sub, ["everyone"]), {}
+    )
+    await test_db_session.commit()
+    assert await _role_names(test_db_session, created.id) == {"admin"}

--- a/backend/tests/test_oauth_role_reevaluation_1778.py
+++ b/backend/tests/test_oauth_role_reevaluation_1778.py
@@ -20,6 +20,7 @@ test_a_returning_user_is_demoted_when_the_group_is_gone fails with the account
 still holding admin.
 """
 
+import asyncio
 import uuid
 from contextlib import asynccontextmanager
 
@@ -511,3 +512,80 @@ async def test_the_first_email_linked_login_applies_the_new_provider_mapping(
     assert await _role_names(test_db_session, created.id) == {"viewer"}, (
         "the second provider's mapping was ignored on the linking login"
     )
+
+
+# ---------------------------------------------------------------------------
+# fix(#1778 codex r4): two OAuth callbacks for the same account can arrive
+# together. Both used to enter set_role_from_identity_provider's PROMOTION
+# branch unserialized, and _update_user_role deletes and re-inserts
+# catalog.user_roles, whose primary key is (user_id, role_id) -- so the two
+# inserts collided and one otherwise valid login failed on a duplicate key.
+#
+# The promotion branch now takes the same admin-lifecycle advisory lock the
+# demotion branch does, which also makes _update_user_role's idempotency check
+# load-bearing: the second caller re-reads the roles under the lock, finds the
+# promotion already applied, and returns without touching the table.
+#
+# Counterfactual: move the lock back inside the non-admin branch and
+# test_concurrent_mapped_promotions_do_not_collide fails with a UniqueViolation
+# on catalog.user_roles.
+#
+# The SAML overlay reaches this through the SAME call chain: SAML JIT goes
+# through find_or_create_oauth_user, whose only role-change path is
+# _reconcile_mapped_role -> set_role_from_identity_provider, and that is the
+# only caller of it in the tree. So this covers both protocols; there is no
+# separate SAML branch to fix.
+# ---------------------------------------------------------------------------
+
+
+async def test_concurrent_mapped_promotions_do_not_collide(
+    client, test_db_session, enterprise
+):
+    """Two simultaneous logins for the same returning viewer whose IdP group now
+    maps to admin. Both must succeed, and the account must end up holding
+    exactly one role row."""
+    import app.core.db as db_module
+    from app.modules.admin.service import AdminService
+
+    provider = await _provider(test_db_session)
+    sub = f"concurrent-{uuid.uuid4().hex[:8]}"
+
+    created = await find_or_create_oauth_user(
+        test_db_session, provider, _userinfo(sub, ["everyone"]), {}
+    )
+    await test_db_session.commit()
+    user_id = created.id
+    assert await _role_names(test_db_session, user_id) == {"viewer"}
+
+    # Both callers must have READ the current roles before either writes, which
+    # is the state two simultaneous callbacks are actually in. Without a barrier
+    # the event loop is free to run one to completion first and the race never
+    # happens, which is exactly how the unlocked version passed.
+    ready = asyncio.Barrier(2)
+
+    async def promote() -> bool:
+        # Its own session, as a second Uvicorn worker would have.
+        async with db_module.async_session() as session:
+            user = await session.get(User, user_id)
+            await session.refresh(user, attribute_names=["roles"])
+            await ready.wait()
+            applied = await AdminService(session).set_role_from_identity_provider(
+                user, "admin"
+            )
+            # _reconcile_mapped_role flushes here, so the INSERT is issued
+            # before the commit rather than at it.
+            await session.flush()
+            await session.commit()
+            return applied
+
+    results = await asyncio.gather(promote(), promote(), return_exceptions=True)
+
+    failures = [r for r in results if isinstance(r, BaseException)]
+    assert not failures, f"a concurrent mapped promotion failed: {failures!r}"
+    assert all(r is True for r in results)
+
+    rows = await test_db_session.execute(
+        select(UserRole).where(UserRole.user_id == user_id)
+    )
+    assert len(rows.scalars().all()) == 1
+    assert await _role_names(test_db_session, user_id) == {"admin"}

--- a/backend/tests/test_oauth_role_reevaluation_1778.py
+++ b/backend/tests/test_oauth_role_reevaluation_1778.py
@@ -563,29 +563,102 @@ async def test_concurrent_mapped_promotions_do_not_collide(
     # happens, which is exactly how the unlocked version passed.
     ready = asyncio.Barrier(2)
 
-    async def promote() -> bool:
+    async def promote():
         # Its own session, as a second Uvicorn worker would have.
         async with db_module.async_session() as session:
             user = await session.get(User, user_id)
             await session.refresh(user, attribute_names=["roles"])
             await ready.wait()
-            applied = await AdminService(session).set_role_from_identity_provider(
+            outcome = await AdminService(session).set_role_from_identity_provider(
                 user, "admin"
             )
             # _reconcile_mapped_role flushes here, so the INSERT is issued
             # before the commit rather than at it.
             await session.flush()
             await session.commit()
-            return applied
+            return outcome
 
     results = await asyncio.gather(promote(), promote(), return_exceptions=True)
 
     failures = [r for r in results if isinstance(r, BaseException)]
     assert not failures, f"a concurrent mapped promotion failed: {failures!r}"
-    assert all(r is True for r in results)
+    assert all(r.applied for r in results)
 
     rows = await test_db_session.execute(
         select(UserRole).where(UserRole.user_id == user_id)
     )
     assert len(rows.scalars().all()) == 1
+    assert await _role_names(test_db_session, user_id) == {"admin"}
+
+    # fix(#1778 codex r5): exactly ONE of the two actually changed anything, and
+    # the other must say so rather than reporting a transition that had already
+    # happened. The loser used to return True and its caller emitted a second
+    # oauth.role.changed carrying a previous_roles snapshot taken before the
+    # winner's write.
+    assert sorted(r.changed for r in results) == [False, True], (
+        "both concurrent promotions reported a change, so the caller would "
+        "audit the same transition twice"
+    )
+    winner = next(r for r in results if r.changed)
+    assert winner.previous_roles == ["viewer"]
+    loser = next(r for r in results if not r.changed)
+    assert loser.previous_roles == ["admin"], (
+        "the loser's previous_roles were captured before the lock, so they "
+        "describe a state the winner had already replaced"
+    )
+
+
+async def test_a_second_concurrent_login_emits_no_duplicate_audit_event(
+    client, test_db_session, enterprise
+):
+    """The same race driven through _reconcile_mapped_role, which is what emits
+    the audit row, asserting exactly one oauth.role.changed lands.
+
+    Counterfactual: have set_role_from_identity_provider report a change
+    unconditionally and this finds two rows for one transition.
+    """
+    import app.core.db as db_module
+    from app.modules.auth.oauth.service import _reconcile_mapped_role
+
+    provider = await _provider(test_db_session)
+    sub = f"dupaudit-{uuid.uuid4().hex[:8]}"
+
+    created = await find_or_create_oauth_user(
+        test_db_session, provider, _userinfo(sub, ["everyone"]), {}
+    )
+    await test_db_session.commit()
+    user_id = created.id
+    assert await _role_names(test_db_session, user_id) == {"viewer"}
+
+    ready = asyncio.Barrier(2)
+
+    async def login():
+        async with db_module.async_session() as session:
+            user = await session.get(User, user_id)
+            await session.refresh(user, attribute_names=["roles"])
+            fresh_provider = await session.get(OAuthProvider, provider.id)
+            await ready.wait()
+            await _reconcile_mapped_role(session, fresh_provider, user, ["gis-admins"])
+            await session.commit()
+
+    results = await asyncio.gather(login(), login(), return_exceptions=True)
+    failures = [r for r in results if isinstance(r, BaseException)]
+    assert not failures, f"a concurrent mapped login failed: {failures!r}"
+
+    rows = (
+        (
+            await test_db_session.execute(
+                select(AuditLog).where(
+                    AuditLog.action == "oauth.role.changed",
+                    AuditLog.user_id == user_id,
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(rows) == 1, (
+        f"expected one oauth.role.changed for one transition, got {len(rows)}"
+    )
+    assert (rows[0].details or {})["previous_roles"] == ["viewer"]
     assert await _role_names(test_db_session, user_id) == {"admin"}

--- a/backend/tests/test_oversized_password_1778.py
+++ b/backend/tests/test_oversized_password_1778.py
@@ -1,0 +1,192 @@
+"""fix(#1778): an over-long password is a refusal, never a 500 or a crash-loop.
+
+Codebase audit 2026-08-30, "A password over 72 bytes 500s /auth/login and skips
+the login-failure audit row; the same input crash-loops first boot".
+
+bcrypt refuses an input longer than 72 bytes and pwdlib's BcryptHasher raises
+ValueError rather than truncating. Register, change-password, admin create and
+admin reset all run validate_password_complexity, which caps the value, but
+three paths reached the hasher with an unvalidated string:
+
+  - POST /auth/login          - OAuth2PasswordRequestForm applies no bound.
+  - POST /auth/change-password/ - ``current_password`` is capped at 256
+    CHARACTERS; only ``new_password`` carries the byte bound.
+  - seed_initial_admin()      - hashes GEOLENS_ADMIN_PASSWORD at first boot.
+
+Counterfactual for the two request paths: revert the byte check in
+verify_password (app/modules/auth/providers/local.py) and both tests below fail
+with a raised ValueError instead of the asserted status code. Counterfactual for
+the boot path: drop the byte check from validate_admin_credentials_nonempty and
+the Settings construction succeeds instead of raising.
+"""
+
+import uuid
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import select
+
+from app.core.config import (
+    BCRYPT_MAX_PASSWORD_BYTES as CONFIG_BCRYPT_MAX_PASSWORD_BYTES,
+)
+from app.modules.auth.password_policy import BCRYPT_MAX_PASSWORD_BYTES
+from app.modules.auth.providers.local import DUMMY_HASH, verify_password
+
+pytestmark = pytest.mark.anyio
+
+STRONG_PASSWORD = "TestPass1234!"
+
+# 73 bytes: one past what bcrypt will hash. Not a credential for anything --
+# no account is ever created with it, because no entry point accepts it.
+OVERSIZED_PASSWORD = "A1!" + ("a" * 70)
+
+
+def test_oversized_fixture_is_one_byte_past_the_limit() -> None:
+    """Positive control: the fixture really does cross the bound."""
+    assert len(OVERSIZED_PASSWORD.encode("utf-8")) == BCRYPT_MAX_PASSWORD_BYTES + 1
+
+
+def test_config_restates_the_same_bcrypt_bound() -> None:
+    """core/config.py cannot import from app.modules.*, so it restates the
+    constant. Pin the two together so they cannot drift."""
+    assert CONFIG_BCRYPT_MAX_PASSWORD_BYTES == BCRYPT_MAX_PASSWORD_BYTES
+
+
+class TestVerifyPasswordBound:
+    def test_oversized_input_is_a_non_match_not_an_exception(self) -> None:
+        assert verify_password(OVERSIZED_PASSWORD, DUMMY_HASH) is False
+
+    def test_exactly_at_the_limit_still_reaches_the_hasher(self) -> None:
+        """72 bytes is hashable, so the guard must not shorten the accepted range."""
+        at_limit = "A1!" + ("a" * 69)
+        assert len(at_limit.encode("utf-8")) == BCRYPT_MAX_PASSWORD_BYTES
+        assert verify_password(at_limit, DUMMY_HASH) is False
+
+    def test_multibyte_value_is_measured_in_bytes(self) -> None:
+        """Short in characters, over the bound in UTF-8 bytes."""
+        multibyte = "Ab1!" + ("é" * 40)  # 4 + 80 bytes
+        assert len(multibyte) < BCRYPT_MAX_PASSWORD_BYTES
+        assert len(multibyte.encode("utf-8")) > BCRYPT_MAX_PASSWORD_BYTES
+        assert verify_password(multibyte, DUMMY_HASH) is False
+
+
+class TestLoginWithOversizedPassword:
+    """POST /auth/login must answer 401 and audit the attempt."""
+
+    async def _create_user(self, client: AsyncClient, admin_headers: dict) -> str:
+        username = f"oversized_{uuid.uuid4().hex[:8]}"
+        resp = await client.post(
+            "/admin/users/",
+            json={
+                "username": username,
+                "password": STRONG_PASSWORD,
+                "role": "viewer",
+            },
+            headers=admin_headers,
+        )
+        assert resp.status_code == 201, resp.text
+        return username
+
+    async def test_existing_account_gets_401_not_500(
+        self, client: AsyncClient, admin_auth_header: dict
+    ) -> None:
+        username = await self._create_user(client, admin_auth_header)
+        resp = await client.post(
+            "/auth/login",
+            data={"username": username, "password": OVERSIZED_PASSWORD},
+        )
+        assert resp.status_code == 401, resp.text
+
+    async def test_unknown_account_gets_401_not_500(self, client: AsyncClient) -> None:
+        resp = await client.post(
+            "/auth/login",
+            data={
+                "username": f"nobody_{uuid.uuid4().hex[:8]}",
+                "password": OVERSIZED_PASSWORD,
+            },
+        )
+        assert resp.status_code == 401, resp.text
+
+    async def test_failure_is_audited(
+        self, client: AsyncClient, admin_auth_header: dict, test_db_session
+    ) -> None:
+        """#1230's user.login.failure row is the operator's only view of an
+        attempt against an account; the ValueError skipped it entirely."""
+        from app.modules.audit.models import AuditLog
+
+        username = await self._create_user(client, admin_auth_header)
+        resp = await client.post(
+            "/auth/login",
+            data={"username": username, "password": OVERSIZED_PASSWORD},
+        )
+        assert resp.status_code == 401, resp.text
+
+        rows = (
+            (
+                await test_db_session.execute(
+                    select(AuditLog).where(AuditLog.action == "user.login.failure")
+                )
+            )
+            .scalars()
+            .all()
+        )
+        matching = [r for r in rows if (r.details or {}).get("username") == username]
+        assert matching, "no user.login.failure audit row for the refused login"
+        assert matching[0].details.get("reason") == "invalid_credentials"
+
+
+class TestChangePasswordWithOversizedCurrentPassword:
+    async def test_oversized_current_password_gets_400_not_500(
+        self, client: AsyncClient, admin_auth_header: dict
+    ) -> None:
+        username = f"cpwlong_{uuid.uuid4().hex[:8]}"
+        created = await client.post(
+            "/admin/users/",
+            json={
+                "username": username,
+                "password": STRONG_PASSWORD,
+                "role": "viewer",
+            },
+            headers=admin_auth_header,
+        )
+        assert created.status_code == 201, created.text
+        login = await client.post(
+            "/auth/login",
+            data={"username": username, "password": STRONG_PASSWORD},
+        )
+        assert login.status_code == 200, login.text
+        access = login.json()["access_token"]
+
+        resp = await client.post(
+            "/auth/change-password/",
+            json={
+                "current_password": OVERSIZED_PASSWORD,
+                "new_password": "AnotherPass99!",
+            },
+            headers={"Authorization": f"Bearer {access}"},
+        )
+        assert resp.status_code == 400, resp.text
+
+
+class TestAdminPasswordBootGuard:
+    """An over-long GEOLENS_ADMIN_PASSWORD must be refused at boot, by name."""
+
+    def _settings(self, monkeypatch, value: str):
+        from app.core.config import Settings
+
+        monkeypatch.setenv("GEOLENS_ADMIN_PASSWORD", value)
+        return Settings()
+
+    def test_oversized_admin_password_refuses_boot(self, monkeypatch) -> None:
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError) as exc:
+            self._settings(monkeypatch, OVERSIZED_PASSWORD)
+        assert "GEOLENS_ADMIN_PASSWORD" in str(exc.value)
+        assert str(BCRYPT_MAX_PASSWORD_BYTES) in str(exc.value)
+
+    def test_admin_password_at_the_limit_boots(self, monkeypatch) -> None:
+        at_limit = "A1!" + ("a" * 69)
+        assert len(at_limit.encode("utf-8")) == BCRYPT_MAX_PASSWORD_BYTES
+        loaded = self._settings(monkeypatch, at_limit)
+        assert loaded.geolens_admin_password.get_secret_value() == at_limit

--- a/backend/tests/test_persistent_config_batch_eviction_1543.py
+++ b/backend/tests/test_persistent_config_batch_eviction_1543.py
@@ -266,6 +266,8 @@ def redis_cache():
     # replay state __init__ sets up has to be seeded here too.
     provider._pending_authoritative = OrderedDict()
     provider._replay_lock = asyncio.Lock()
+    provider._was_open = False
+    provider._recovery_signal = False
     return provider
 
 

--- a/backend/tests/test_persistent_config_batch_eviction_1543.py
+++ b/backend/tests/test_persistent_config_batch_eviction_1543.py
@@ -266,8 +266,6 @@ def redis_cache():
     # replay state __init__ sets up has to be seeded here too.
     provider._pending_authoritative = OrderedDict()
     provider._replay_lock = asyncio.Lock()
-    provider._was_open = False
-    provider._recovery_signal = False
     return provider
 
 

--- a/backend/tests/test_persistent_config_batch_eviction_1543.py
+++ b/backend/tests/test_persistent_config_batch_eviction_1543.py
@@ -15,6 +15,8 @@ concurrent reader scheduled there would observe.
 
 from __future__ import annotations
 
+import asyncio
+from collections import OrderedDict
 from collections.abc import Awaitable, Callable
 from typing import Any
 
@@ -260,6 +262,10 @@ def redis_cache():
     provider._failure_count = 0
     provider._circuit_open_until = 0.0
     provider._fallback = InMemoryCacheProvider()
+    # fix(#1778 codex r2): these build the provider through __new__, so the
+    # replay state __init__ sets up has to be seeded here too.
+    provider._pending_authoritative = OrderedDict()
+    provider._replay_lock = asyncio.Lock()
     return provider
 
 

--- a/backend/tests/test_phase_273_request_origin_validation.py
+++ b/backend/tests/test_phase_273_request_origin_validation.py
@@ -9,7 +9,14 @@ public_api_url or default, NOT the attacker-controlled value.
 from types import SimpleNamespace
 from unittest.mock import patch
 
-from app.core.public_urls import _request_origin
+from app.core.public_urls import (
+    _DEFAULT_PUBLIC_API_URL,
+    _DEFAULT_PUBLIC_APP_URL,
+    _request_origin,
+    _request_origin_decision,
+    resolve_public_api_url,
+    resolve_public_app_url,
+)
 
 
 def _mock_request(
@@ -98,3 +105,91 @@ def test_no_request_returns_none():
     with patch("app.core.public_urls.settings") as mock_settings:
         mock_settings.cors_origins_list = ["https://app.example.com"]
         assert _request_origin(None) is None
+
+
+# ---------------------------------------------------------------------------
+# fix(#1778): codebase audit 2026-08-30, "SEC-05's CORS-allowlist gate on
+# request-derived origins is bypassed two lines later by a raw Host fallback".
+#
+# _request_origin returning None was read by both resolvers as "no origin to
+# derive", so they fell through to request.url.netloc -- Starlette's read of
+# the Host header, which frontend/nginx.conf forwards verbatim from the client
+# with no server_name restriction. The allowlist decided which of two code
+# paths ran; both returned the attacker's host.
+#
+# Counterfactual: drop `and not allowlist_rejected` from either resolver and
+# the matching test below returns https://attacker.example instead of the
+# default.
+# ---------------------------------------------------------------------------
+
+
+def test_decision_distinguishes_rejection_from_absence():
+    with patch("app.core.public_urls.settings") as mock_settings:
+        mock_settings.cors_origins_list = ["https://app.example.com"]
+        rejected = _mock_request({"origin": "https://attacker.example"})
+        assert _request_origin_decision(rejected) == (None, True)
+
+        # No headers to derive anything from: absence, not rejection.
+        absent = _mock_request({}, netloc="")
+        assert _request_origin_decision(absent) == (None, False)
+
+        assert _request_origin_decision(None) == (None, False)
+
+
+def test_api_url_does_not_fall_back_to_a_rejected_host():
+    with patch("app.core.public_urls.settings") as mock_settings:
+        mock_settings.cors_origins_list = ["https://app.example.com"]
+        mock_settings.env_only_config = False
+        req = _mock_request(
+            {"host": "attacker.example"},
+            scheme="https",
+            netloc="attacker.example",
+        )
+        assert (
+            resolve_public_api_url(None, None, None, request=req)
+            == _DEFAULT_PUBLIC_API_URL
+        )
+
+
+def test_app_url_does_not_fall_back_to_a_rejected_host():
+    with patch("app.core.public_urls.settings") as mock_settings:
+        mock_settings.cors_origins_list = ["https://app.example.com"]
+        mock_settings.env_only_config = False
+        req = _mock_request(
+            {"host": "attacker.example"},
+            scheme="https",
+            netloc="attacker.example",
+        )
+        assert (
+            resolve_public_app_url(None, None, None, request=req)
+            == _DEFAULT_PUBLIC_APP_URL
+        )
+
+
+def test_an_allowlisted_host_still_resolves():
+    """The gate must refuse the rejection, not every request-derived origin."""
+    with patch("app.core.public_urls.settings") as mock_settings:
+        mock_settings.cors_origins_list = ["https://app.example.com"]
+        mock_settings.env_only_config = False
+        req = _mock_request(
+            {"host": "app.example.com", "x-forwarded-proto": "https"},
+            scheme="https",
+            netloc="app.example.com",
+        )
+        assert (
+            resolve_public_app_url(None, None, None, request=req)
+            == "https://app.example.com"
+        )
+
+
+def test_unconfigured_allowlist_keeps_the_dev_host_fallback():
+    """With CORS_ALLOWED_ORIGINS empty nothing is rejected, so the fallback that
+    makes a no-config dev stack work is untouched."""
+    with patch("app.core.public_urls.settings") as mock_settings:
+        mock_settings.cors_origins_list = []
+        mock_settings.env_only_config = False
+        req = _mock_request({}, scheme="http", netloc="localhost:8000")
+        assert (
+            resolve_public_app_url(None, None, None, request=req)
+            == "http://localhost:8000"
+        )

--- a/backend/tests/test_saml_overlay.py
+++ b/backend/tests/test_saml_overlay.py
@@ -57,6 +57,31 @@ FIXTURE_DIR = Path(__file__).parent / "fixtures" / "saml"
 FIXTURE_CERT_PEM = (FIXTURE_DIR / "idp_cert.pem").read_text()
 
 
+@pytest.fixture(autouse=True)
+def _registration_on(monkeypatch):
+    """fix(#1778): the SAML overlay provisions through find_or_create_oauth_user
+    (see IdentityExtension in app/core/identity.py), which now honours
+    REGISTRATION_ENABLED. Its shipped default is False, so an unknown SAML
+    subject is refused before it reaches anything this module is about. The
+    switch has its own tests in tests/test_oauth_registration_gate_1778.py.
+
+    Autouse and module-scoped because JIT happens behind the ACS route, several
+    tests deep, rather than at a call these tests make directly.
+
+    These tests are skipped in a community run (no overlay), so CI here does not
+    exercise this fixture; it is what stops the enterprise overlay's own run
+    from going red on the gate."""
+    from unittest.mock import AsyncMock
+
+    from app.modules.auth.oauth import service as oauth_service
+
+    monkeypatch.setattr(
+        oauth_service.REGISTRATION_ENABLED,
+        "get_uncached",
+        AsyncMock(return_value=True),
+    )
+
+
 @pytest.fixture(scope="session")
 def saml_response_dir(tmp_path_factory) -> Path:
     """Session-scoped dir holding generated SAML XML responses (Phase 227).

--- a/backend/tests/test_tenant_cache_partitioning.py
+++ b/backend/tests/test_tenant_cache_partitioning.py
@@ -93,6 +93,13 @@ class _MemoryCache:
     async def set(self, key: str, value: object, *, ttl: int):
         self.values[key] = value
 
+    async def set_if_absent(self, key: str, value: object, ttl: int = 300) -> bool:
+        """fix(#1778): mirrors the provider contract: never overwrite."""
+        if key in self.values:
+            return False
+        self.values[key] = value
+        return True
+
     async def delete(self, key: str):
         self.values.pop(key, None)
 
@@ -521,5 +528,8 @@ async def test_embed_token_invalidation_is_tenant_local(
         current_tenant_var.reset(tenant_a_token)
 
     assert revoked is token_record
-    assert keys[TENANT_A] not in cache.values
-    assert keys[TENANT_B] in cache.values
+    # fix(#1778): the revoking tenant's entry is REPLACED by a denial rather
+    # than deleted, so a request that raced the revoke cannot re-publish a
+    # positive under the same key. The other tenant's entry is untouched.
+    assert cache.values[keys[TENANT_A]] == {"is_valid": False}
+    assert cache.values[keys[TENANT_B]] == {"is_valid": True}

--- a/backend/tests/test_tenant_cache_partitioning.py
+++ b/backend/tests/test_tenant_cache_partitioning.py
@@ -87,13 +87,15 @@ class _MemoryCache:
     def __init__(self):
         self.values: dict[str, object] = {}
 
-    async def get(self, key: str):
+    async def get(self, key: str, *, security: bool = False):
         return self.values.get(key)
 
-    async def set(self, key: str, value: object, *, ttl: int):
+    async def set(self, key: str, value: object, *, ttl: int, security: bool = False):
         self.values[key] = value
 
-    async def set_if_absent(self, key: str, value: object, ttl: int = 300) -> bool:
+    async def set_if_absent(
+        self, key: str, value: object, ttl: int = 300, *, security: bool = False
+    ) -> bool:
         """fix(#1778): mirrors the provider contract: never overwrite."""
         if key in self.values:
             return False

--- a/backend/tests/test_tenant_cache_partitioning.py
+++ b/backend/tests/test_tenant_cache_partitioning.py
@@ -100,6 +100,10 @@ class _MemoryCache:
         self.values[key] = value
         return True
 
+    async def set_authoritative(self, key: str, value: object, ttl: int = 300) -> None:
+        """fix(#1778 codex r1): one store here, so this is set."""
+        self.values[key] = value
+
     async def delete(self, key: str):
         self.values.pop(key, None)
 

--- a/backend/tests/test_tenant_cache_partitioning.py
+++ b/backend/tests/test_tenant_cache_partitioning.py
@@ -453,6 +453,14 @@ async def test_embed_token_negative_cache_cannot_poison_another_tenant(
         async def execute(self, *_args, **_kwargs):
             return _Result()
 
+        async def scalar(self, *_args, **_kwargs):
+            # fix(#1778 codex r5): validate_embed_token_access now reads the
+            # revocation generation before deciding whether to cache a positive
+            # at all (an unusable generation is never written). A stub lacking
+            # this method makes every read look unusable and the positive branch
+            # below is never cached, which is not what this test is checking.
+            return 1
+
         def begin_nested(self):
             return _Nested()
 

--- a/frontend/src/components/admin/AuditLogViewer.tsx
+++ b/frontend/src/components/admin/AuditLogViewer.tsx
@@ -118,6 +118,11 @@ const CURRENT_AUDIT_ACTIONS = [
   'oauth.login.failure',
   'oauth.login.init',
   'oauth.login.success',
+  // fix(#1778): the IdP group-role mapping is applied on every OAuth login now,
+  // so a role can move without an admin touching it. These two are how that
+  // shows up here.
+  'oauth.role.change_refused',
+  'oauth.role.changed',
   'oauth_provider.create',
   'oauth_provider.delete',
   'oauth_provider.update',

--- a/frontend/src/components/admin/settings/SettingsAuthTab.tsx
+++ b/frontend/src/components/admin/settings/SettingsAuthTab.tsx
@@ -643,6 +643,12 @@ function OAuthProvidersSection({ envOnly }: { envOnly: boolean }) {
                   <SelectItem value="admin">{t('settings.oauth.roles.admin')}</SelectItem>
                 </SelectContent>
               </Select>
+              {/* fix(#1778): the role only applies to accounts this provider
+                  creates, and whether it creates any is the registration
+                  switch's call. Say so here, where the decision is made. */}
+              <p className="text-xs text-muted-foreground">
+                {t('settings.oauth.defaultRoleHint')}
+              </p>
             </div>
 
             <div className="space-y-2">

--- a/frontend/src/i18n/locales/de/admin.json
+++ b/frontend/src/i18n/locales/de/admin.json
@@ -663,6 +663,7 @@
       "userinfoUrl": "Benutzer-API-URL (optional)",
       "scopes": "Bereiche",
       "defaultRole": "Standardrolle",
+      "defaultRoleHint": "Wird Konten zugewiesen, die dieser Anbieter anlegt. Konten werden nur angelegt, wenn die Selbstregistrierung aktiviert ist; ist sie aus, wird eine Anmeldung ohne Konto abgelehnt und eine Administratorin oder ein Administrator legt das Konto an.",
       "groupClaim": "Gruppen-Claim",
       "groupClaimHint": "JWT-Claim mit Gruppenmitgliedschaften des Benutzers.",
       "groupRoleMapping": "Gruppen-Rollen-Zuordnung (JSON)",

--- a/frontend/src/i18n/locales/de/auth.json
+++ b/frontend/src/i18n/locales/de/auth.json
@@ -56,6 +56,7 @@
     "invalidGrant": "Authentifizierung wurde abgelehnt oder ist abgelaufen. Bitte versuchen Sie es erneut.",
     "accessDenied": "Der Zugang wurde vom Identitätsanbieter verweigert.",
     "domainNotAllowed": "Ihre E-Mail-Domain ist für die Anmeldung hier nicht zugelassen.",
+    "registrationDisabled": "Für diese Identität gibt es hier kein Konto, und neue Registrierungen sind deaktiviert. Bitten Sie eine Administratorin oder einen Administrator, Ihr Konto anzulegen.",
     "generic": "Anmeldung fehlgeschlagen: {{error}}. Bitte versuchen Sie es erneut."
   },
   "ssoOnly": {

--- a/frontend/src/i18n/locales/en/admin.json
+++ b/frontend/src/i18n/locales/en/admin.json
@@ -704,6 +704,7 @@
       "userinfoUrl": "User API URL (optional)",
       "scopes": "Scopes",
       "defaultRole": "Default Role",
+      "defaultRoleHint": "Given to accounts this provider creates. Accounts are only created when self-serve registration is on; with it off, a sign-in that has no account here is refused and an administrator creates the account instead.",
       "groupClaim": "Group Claim",
       "groupClaimHint": "JWT claim containing user group memberships for automatic role mapping.",
       "groupRoleMapping": "Group Role Mapping (JSON)",

--- a/frontend/src/i18n/locales/en/auth.json
+++ b/frontend/src/i18n/locales/en/auth.json
@@ -56,6 +56,7 @@
     "invalidGrant": "Authentication was denied or expired. Please try again.",
     "accessDenied": "Access was denied by the identity provider.",
     "domainNotAllowed": "Your email domain is not permitted to sign in here.",
+    "registrationDisabled": "There is no account here for that identity, and new sign-ups are turned off. Ask an administrator to create your account.",
     "generic": "Sign-in failed: {{error}}. Please try again."
   },
   "ssoOnly": {

--- a/frontend/src/i18n/locales/es/admin.json
+++ b/frontend/src/i18n/locales/es/admin.json
@@ -663,6 +663,7 @@
       "userinfoUrl": "URL de la API de usuario (opcional)",
       "scopes": "Alcances",
       "defaultRole": "Rol predeterminado",
+      "defaultRoleHint": "Se asigna a las cuentas que crea este proveedor. Las cuentas solo se crean cuando el registro de autoservicio está activado; si está desactivado, un inicio de sesión sin cuenta aquí se rechaza y la crea un administrador.",
       "groupClaim": "Claim de grupo",
       "groupClaimHint": "Claim JWT que contiene las membresías de grupo del usuario.",
       "groupRoleMapping": "Mapeo de roles de grupo (JSON)",

--- a/frontend/src/i18n/locales/es/auth.json
+++ b/frontend/src/i18n/locales/es/auth.json
@@ -56,6 +56,7 @@
     "invalidGrant": "La autenticación fue denegada o expiró. Inténtelo de nuevo.",
     "accessDenied": "El proveedor de identidad denegó el acceso.",
     "domainNotAllowed": "Su dominio de correo electrónico no tiene permiso para iniciar sesión aquí.",
+    "registrationDisabled": "No hay ninguna cuenta aquí para esa identidad y los nuevos registros están desactivados. Pida a un administrador que cree su cuenta.",
     "generic": "Error de inicio de sesión: {{error}}. Inténtelo de nuevo."
   },
   "ssoOnly": {

--- a/frontend/src/i18n/locales/fr/admin.json
+++ b/frontend/src/i18n/locales/fr/admin.json
@@ -663,6 +663,7 @@
       "userinfoUrl": "URL de l'API utilisateur (facultatif)",
       "scopes": "Portées",
       "defaultRole": "Rôle par défaut",
+      "defaultRoleHint": "Attribué aux comptes créés par ce fournisseur. Les comptes ne sont créés que si l'inscription en libre-service est activée ; sinon, une connexion sans compte ici est refusée et un administrateur crée le compte.",
       "groupClaim": "Claim de groupe",
       "groupClaimHint": "Claim JWT contenant les appartenances aux groupes.",
       "groupRoleMapping": "Mappage des rôles de groupe (JSON)",

--- a/frontend/src/i18n/locales/fr/auth.json
+++ b/frontend/src/i18n/locales/fr/auth.json
@@ -56,6 +56,7 @@
     "invalidGrant": "L'authentification a été refusée ou a expiré. Veuillez réessayer.",
     "accessDenied": "L'accès a été refusé par le fournisseur d'identité.",
     "domainNotAllowed": "Votre domaine de messagerie n'est pas autorisé à se connecter ici.",
+    "registrationDisabled": "Aucun compte n'existe ici pour cette identité et les nouvelles inscriptions sont désactivées. Demandez à un administrateur de créer votre compte.",
     "generic": "Échec de la connexion : {{error}}. Veuillez réessayer."
   },
   "ssoOnly": {

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -29,6 +29,11 @@ function getOAuthErrorMessage(error: string, t: (key: string, opts?: Record<stri
   if (error.includes('domain_not_allowed')) {
     return t('oauthErrors.domainNotAllowed');
   }
+  // fix(#1778): the identity signed in fine but has no account here, and
+  // self-serve registration is off, so nothing may be created for it.
+  if (error.includes('registration_disabled')) {
+    return t('oauthErrors.registrationDisabled');
+  }
   return t('oauthErrors.generic', { error });
 }
 


### PR DESCRIPTION
Seven auth and cache hardening items from the codebase audit 2026-08-30 (8dc529f17), tracked in #1778. One item in the lane no longer reproduces and was dropped. Every commit carries a test that fails without its fix; the counterfactual for each is stated below and was run.

## What changed

### "A password over 72 bytes 500s /auth/login and skips the login-failure audit row; the same input crash-loops first boot"

bcrypt hashes at most 72 bytes and pwdlib's BcryptHasher raises ValueError rather than truncating. `validate_password_complexity` has capped it since #1715, but three paths reach the hasher without going through a schema. `POST /auth/login` takes an `OAuth2PasswordRequestForm`, which applies no bound at all, so any unauthenticated caller could 500 it on demand; worse, the handler catches `AuthenticationError` and a ValueError is not one, so the `user.login.failure` audit row #1230 added was skipped on exactly that input. `POST /auth/change-password/` bounds `new_password` but caps `current_password` at 256 characters, giving the same 500. `seed_initial_admin()` hashes `GEOLENS_ADMIN_PASSWORD` at first boot, so an operator who generated it with something like `openssl rand -base64 64` got a bare bcrypt message and an API container that restart-looped on it.

`verify_password` now treats an over-long input as a non-match, which makes login a 401 with its audit row and change-password the usual 400. Refusing rather than truncating is correct here: every write path caps the stored credential at 72 bytes, so no hash in the database was derived from a longer input and no correct password is rejected. `Settings` gains a matching boot check that names the variable. `core/` may not import from `app.modules.*`, so config.py restates the constant and a test pins the two together.

Counterfactual: remove the byte check from `verify_password` and disarm the config check, and 7 of the 11 tests in `test_oversized_password_1778.py` fail.

### "The CSRF cookie has none of the duplicate-cookie hardening its paired refresh cookie got, so a sibling subdomain can choose its value"

`read_refresh_cookie` has counted raw `Cookie:` occurrences since #1446. `enforce_csrf` never got the same treatment, and it is the half that needs it most: double-submit rests entirely on the attacker not knowing the cookie's value, and planting a duplicate lets them choose it. Starlette keeps the last occurrence, and a freshly-set `Domain` cookie sharing `Path=/` sorts after the older host-only one under RFC 6265. The victim's host-only `geolens_refresh` stays single, so nothing else in the request refuses it, and `POST /auth/refresh` and `POST /auth/logout` become reachable cross-origin.

`enforce_csrf` now refuses when the name appears more than once, sharing one `_cookie_occurrences` helper with `read_refresh_cookie`. The trade is the one #1446 already accepted for the refresh cookie: an attacker who plants a shadow can force a re-login, which is the lesser of the two outcomes.

Counterfactual: remove the guard and `test_a_planted_duplicate_csrf_cookie_cannot_authorize` returns 200 instead of 403, completing a forged refresh with a value the attacker chose.

### "SEC-05's CORS-allowlist gate on request-derived origins is bypassed two lines later by a raw Host fallback"

Both resolvers read `_request_origin` returning None as "there was no origin to derive" and fell through to `request.url.netloc`, which is Starlette's read of the `Host` header. `frontend/nginx.conf` forwards it verbatim with `proxy_set_header Host $http_host` and the server block sets no `server_name`, so the value is client-controlled end to end and the only filter left was a two-name check against `api` and `backend`. The allowlist decided which of two code paths ran and both returned the attacker's host.

`_request_origin_decision` now returns whether the allowlist rejected a candidate, and each resolver skips the last-resort Host fallback in that case. `_request_origin` keeps its signature for the callers and tests that only want the origin. With `CORS_ALLOWED_ORIGINS` empty nothing is ever rejected, so the no-config dev fallback is unchanged.

Counterfactual: drop `and not allowlist_rejected` from either resolver and its test returns `https://attacker.example` instead of the default.

### "Cache invalidation never reaches the in-memory fallback, so a revoked embed token can be served as valid during the next Redis blip"

`RedisCacheProvider` routes every operation to exactly one store. That is right for reads and writes and wrong for eviction, because the two stores are populated at different times: a validation that ran during an outage wrote its result into the fallback, Redis recovered, a revoke deleted the key from Redis alone, and the fallback copy survived until the next blip. `delete`, `delete_many` and `delete_pattern` now evict from the fallback unconditionally, including on the Redis error path.

Counterfactual: restore the early-return shape and 4 of the new tests in `test_cache.py` fail with the stale value still readable.

### "Embed-token revocation invalidates the Redis positive cache BEFORE the caller's commit, so a concurrent request can re-cache the still-active token and keep it serving for 300s"

Every revoke path flips `is_active` and invalidates the cache while its caller's transaction is still open. A tile or feature request that lands in that window misses the cache, SELECTs the row, sees it committed-active because a plain READ COMMITTED select does not block on the revoking transaction, and writes a fresh positive entry. The revoke then commits. Every subsequent request is served from that entry, because the cache-hit path re-checks only `expires_at` (SEC-014).

Deleting the key cannot fix it from either side, since the racing write lands after the delete. So a revocation writes a denial under the key instead, and the validator publishes with a new `set_if_absent` primitive (Redis `SET NX`; a presence check with no interleaving await in the in-memory provider). Whichever lands first, the denial survives. The request that raced still completes, which is correct: it read a committed-active row. It just leaves nothing behind. The four eviction sites collapse into one helper.

The trade: a revoking transaction that rolls back leaves its denial in place, so a still-active token is refused until the entry expires and the next request reads the database again. Fail-closed and self-healing. Two existing tests asserted the key was absent after a revoke and now assert it holds the denial.

Counterfactual: change `set_if_absent` back to `set` and `test_a_racing_validation_cannot_overwrite_the_denial` fails with the positive entry back in the store.

### "Enabling any OAuth provider silently overrides the operator's 'registration disabled' switch and auto-provisions active accounts"

`registration_enabled` ships False and the password path honours it, but JIT provisioning never read it. An operator who added a Google or generic-OIDC provider through the admin UI without also filling in `allowed_email_domains` had open signup: any account at that IdP reaching `/auth/oauth/{slug}/login` was created active with the provider's `default_role`, which is `viewer`, and `viewer` can list and export every `internal` dataset. The Settings screen still read "Registration enabled: off".

The check now runs before the Step 3 provisioning block, after the domain and email-verification gates so a refusal cannot be used to probe which gate an identity trips. Returning users and identities that match an existing account by verified email are unaffected: the switch decides whether an account may be created, not who may sign in. The refusal redirects with `error=registration_disabled` and writes an `oauth.login.failure` audit row naming the same reason. The three named-refusal branches in the callback collapse into one loop rather than becoming a third copy of the same forty lines.

Counterfactual: remove the check and `test_an_unknown_identity_is_refused` fails with a provisioned user.

### "OAuth role is bound once at JIT creation and never re-evaluated -- group_role_mapping can grant a role but can never revoke one"

`_resolve_role` ran only on the login that created the account, so removing someone from the IdP group never demoted them, while the field's description and both UI hints read as a live mapping. `_reconcile_mapped_role` now re-applies it on a returning user's login, under four preconditions that each exist to stop a login from taking away a role the IdP said nothing about: enterprise edition, a non-empty mapping, a groups claim actually present in the assertion, and an OAuth-provisioned account. The middle two are what protect an admin promoted in the GeoLens UI and an account that signed in while the IdP omitted the claim. Every change writes an `oauth.role.changed` audit row with both role names and no claim values.

Counterfactual: remove the call and 3 of the 7 tests in `test_oauth_role_reevaluation_1778.py` fail with the account still holding admin.

## Dropped: already fixed on main

"A password over 72 bytes makes /auth/register report success and silently create no account" no longer reproduces. `UserCreate.validate_password` runs `validate_password_from_settings`, which #1772 gave the 72-byte bound, so a long password is a 422 before `register_user` is reached and the `except ValueError` collision swallow can no longer be handed a bcrypt error. The finding's secondary note about narrowing that `except ValueError` to a specific collision exception still stands as a readability point; it is not reachable today and is left alone.

## Impact

Schema: none. API: no request or response schema changed, `make openapi-check` is clean, so no SDK regeneration. Config: `GEOLENS_ADMIN_PASSWORD` over 72 UTF-8 bytes now refuses to boot with a message naming the variable, which is a behaviour change for a deployment that was already unable to seed its admin.

Behaviour changes an operator will notice:

- An OAuth or OIDC provider no longer creates accounts while self-serve registration is off. Existing users keep signing in. The SAML overlay provisions through the same function, so the gate applies there too, deliberately: the switch should not answer differently depending on which protocol carried the assertion. The overlay's JIT tests are skipped in a community run and will need the same fixture the OAuth ones got.
- With a group role mapping configured, an enterprise deployment's OAuth roles now follow the IdP on every login instead of only the first.
- A revoked embed token's cache key holds a denial for up to five minutes rather than being empty.

## Left alone

- The `__Host-` name prefix on the CSRF cookie. It would stop the shadow at the browser and is worth doing, but it changes the cookie name published in the OpenAPI descriptions and read by the SPA, and `_secure_cookies()` is False in dev so it cannot be the only guard.
- A `server_name` in `frontend/nginx.conf` so an unknown `Host` never reaches the app. That is the other half of the SEC-05 finding and is an ops-file change this lane did not take.
- `update_embed_token` still deletes its cache key rather than stamping a denial. It is an update, not a revocation, and a denial there would break a live embed for five minutes on an origin edit.

## Verification

All run from this worktree against Postgres on localhost:5434.

- `uv run pytest tests/test_oversized_password_1778.py -q` : 11 passed
- `uv run pytest tests/test_password_policy.py tests/test_login_revocation_serialization.py tests/test_arcgis_signin.py tests/test_admin_password_reset.py -q` : 214 passed
- `uv run pytest tests/test_auth_refresh_cookies_1302.py -q` : 43 passed
- `uv run pytest tests/test_public_urls.py tests/test_phase_273_request_origin_validation.py -q` : 42 passed
- `uv run pytest tests/test_cache.py tests/test_persistent_config_batch_eviction_1543.py tests/test_search_cache.py tests/test_tenant_cache_partitioning.py -q` : 58 passed
- `uv run pytest tests/test_tenant_cache_partitioning.py tests/test_embed_tokens.py tests/test_embed_tokens_origin_bypass.py tests/test_shared_map_embed_scope.py tests/test_embed_domain_lock_self_origin_1531.py -q` : 127 passed
- `uv run pytest tests/test_embed_revocation_recache_race_1778.py tests/test_embed_token_expiry_cache.py tests/test_embed_revocation_by_map.py tests/test_cache.py tests/test_tenant_cache_partitioning.py -q` : 57 passed
- `uv run pytest tests/test_oauth.py tests/test_oauth_registration_gate_1778.py tests/test_oauth_role_reevaluation_1778.py tests/test_oauth_audit_correlation.py tests/test_saml_overlay.py tests/test_auth.py -q` : 125 passed, 12 skipped
- `uv run pytest tests/test_layering.py -q` : 47 passed
- `uv run ruff check .` and `uv run ruff format --check .` : clean
- `PYTHONPATH=. uv run python scripts/dump_openapi.py --check` : clean
- `cd frontend && npm run typecheck && npm run lint && npm run test:i18n` : all clean, 4 i18n tests passed
- `cd frontend && npx vitest run src/pages/__tests__/LoginPage.*.test.tsx src/components/admin/settings/__tests__/SettingsAuthTab.test.tsx` : 26 passed

## LOC caps re-measured

- `backend/app/core/config.py` 1501 -> 1525
- `backend/app/modules/embed_tokens/service.py` 1056 -> 1100
- `backend/app/modules/auth/oauth/service.py` 1031 -> 1188

Each set to the exact `wc -l` figure with a comment saying what the lines bought.

## Round 1 (codex, head d16f46b5e)

Four P1 threads, all four addressed in 60ca8cde1.

**Preserve the last active administrator during reconciliation** and **bump key_epoch on a mapped role change.** These were one defect wearing two faces: the reconciliation assigned `user.roles` directly, which made it a second, weaker copy of a role change rather than the same one. It therefore skipped the last-admin rule (so an IdP asserting an empty or non-matching groups list could remove the deployment's only active admin) and the `key_epoch` bump from #821 (so an API key minted while the account was a viewer kept resolving after the account was mapped to admin). Both now come from `AdminService.set_role_from_identity_provider`, a new public seam that calls the same `_ensure_not_last_admin` and `_update_user_role` the admin router uses rather than copying the count query, and that inherits their idempotency skip. A refusal is not an error for an IdP-driven caller: the admin role stands, the login continues, and an `oauth.role.change_refused` audit row records the provider, both roles and `reason=last_admin`.

**Apply the mapping on the first email-linked login.** Reconciliation ran only on the subject-link branch, so an OAuth-provisioned account linking to a second provider for the first time (matched by verified email) carried its old role for that whole session. That branch reconciles too now. `find_or_create_oauth_user` has exactly three return paths and the docstring enumerates them, so the next one added cannot quietly miss the call. The helper's own preconditions still apply, so a local account linked here keeps the roles its GeoLens admin gave it.

**Send the revocation denial to both stores.** `_deny_revoked_embed_tokens` used `set`, which routes to whichever store the circuit breaker says is live, so a positive entry that landed in the in-memory fallback during a Redis outage survived a denial written after Redis recovered and the next Redis error served the revoked token again. The provider gains `set_authoritative`, which writes every store in both circuit states, and `set_if_absent` now treats a value held only in the fallback as present. Both halves are needed: without the second, a racing publisher whose circuit opened between its read and its write would put a positive straight back into the store the denial had just cleared.

CI on the round-0 sha also found three sibling failures the targeted runs missed, fixed in the same push. `oauth.role.changed` and `oauth.role.change_refused` are registered in `AUDIT_ACTIONS` and in `AuditLogViewer`'s mirror of it. The last remaining assertion that the embed cache key is absent after a revoke now asserts the denial. The domain-enforcement, GitHub-provider and SAML-overlay suites provision new identities and get the same `REGISTRATION_ENABLED` fixture the OAuth suite did; the SAML one is skipped in a community run and is there for the enterprise overlay's own.

Round-1 verification:

- Full backend suite on the host, `uv run pytest -n 4 -q --no-cov` : **11038 passed, 100 skipped, 0 failed** in 33:17
- `uv run pytest tests/test_oauth_role_reevaluation_1778.py -q` : 12 passed
- `uv run pytest tests/test_cache.py -q` : 35 passed
- `uv run pytest tests/test_embed_revocation_recache_race_1778.py -q` : 6 passed
- `uv run pytest tests/test_audit_action_registry.py -q` : 3 passed
- `uv run ruff check .` and `uv run ruff format --check .` : clean
- `PYTHONPATH=. uv run python scripts/dump_openapi.py --check` : clean
- `cd frontend && npm run typecheck && npm run lint && npm run test:i18n` : clean; `npx vitest run src/components/admin/__tests__` : 104 passed

Counterfactuals, each disarmed and re-run: assigning `user.roles` directly fails the sole-admin and key-epoch tests; dropping the verified-email reconcile call fails the cross-provider test; reverting `set_authoritative` to `set` fails the end-to-end denial test.

Caps re-measured this round: `backend/app/modules/admin/service.py` enters `_MODULE_LOC_CAPS` at 1036 (it crossed the 1000-line inclusion threshold), `backend/app/modules/auth/oauth/service.py` 1188 -> 1249, `backend/app/modules/embed_tokens/service.py` 1100 -> 1106.

## Round 2 (codex, head 60ca8cde1)

One P1, addressed in 83da02a02.

**An authoritative write has to survive the outage, not just the moment.** Round 1's `set_authoritative` promised every store in both circuit states and delivered it only when it could reach both. With the circuit open it wrote the fallback and returned, leaving Redis holding the value the call existed to overrule; once the cooldown lapsed, `get()` consulted Redis first and served that stale positive for the rest of its TTL. That is round 1's race running backwards, and closing it takes both halves.

A write that cannot reach Redis (circuit open, or the write itself raising) is queued in `_pending_authoritative`, a per-key ordered map of value, ttl and monotonic expiry. Every public method now asks through `_circuit_open()` rather than `_is_circuit_open()`, and that helper drains the queue on the transition back to closed, before the call that observed the transition is served. There is no other transition point to hook: the cooldown lapsing is not a function anyone calls, it is a timestamp going stale, so the first caller to look is the one that has to do the work, a read included. The drain is serialized on its own lock, replays each entry with its remaining lifetime rather than a fresh TTL, drops entries whose lifetime already elapsed, and on failure leaves the queue intact rather than losing what it was trying to persist. The queue is bounded at 512, dropping the oldest, which are also the ones closest to expiring and therefore closest to being a no-op replay; the overflow warning carries the count and never a key, because these keys are derived from credential hashes.

A queued write also outranks both stores on read until it has been replayed, and `set_if_absent` treats it as present. This half is load-bearing on its own rather than belt-and-braces for the drain window: a Redis that reads fine but refuses writes keeps the circuit closed and fails every drain attempt, so nothing else stands between the caller and the stale positive.

The class docstring now states, per method, which writes replay and which are fire-and-forget, because they do not all mean the same thing by "the circuit was open". `set` and `set_if_absent` are deliberately not replayed: one publishes a cached answer that is cheaper to re-derive than to resurrect, and the other exists to yield to a decision another writer may have made, so replaying it would be this bug in reverse. Deletes are fire-and-forget on the Redis half and also discard any queued override for the same key; a replay queue for deletes was considered and rejected, because a queued delete drained after recovery cannot tell a pre-outage entry from one a legitimate writer put there afterwards, so it would evict live data to fix stale data.

This round also fixes a test-pollution bug the work surfaced. The round-0 race test patched `asyncio.create_task`, which substitutes an attribute on the shared asyncio module and hands the service a MagicMock that it files in the module-level `_usage_bump_tasks` set. `MagicMock.add_done_callback` does nothing, so the mock never left the set and the next suite in the same worker to drain it died on "An asyncio.Future, a coroutine or an awaitable is required". It patches the coroutine the task wraps instead, so a real Task is created and the done-callback still discards it.

Round-2 verification:

- `uv run pytest tests/test_cache.py tests/test_embed_revocation_recache_race_1778.py tests/test_embed_revocation_by_map.py tests/test_embed_token_expiry_cache.py tests/test_tenant_cache_partitioning.py tests/test_persistent_config_batch_eviction_1543.py tests/test_search_cache.py tests/test_embed_tokens.py tests/test_builder_audit_p0p1_sharing.py tests/test_shared_map_embed_scope.py tests/test_layering.py tests/test_tile_cache.py tests/test_phase_274_tile_cache.py -q -p no:randomly` : 256 passed
- the same set minus the layering and tile suites, in randomized order, to confirm the pollution fix holds across file boundaries : 156 passed
- `uv run pytest tests/test_cache.py -q` : 44 passed
- `uv run ruff check .` and `uv run ruff format --check .` : clean

Counterfactuals, each disarmed and re-run: removing the queue from the circuit-open branch fails 5 tests; removing the queue-first check in `get()` fails `test_the_queue_outranks_a_readable_redis_positive` on its own, which is why that test builds a Redis that reads normally and refuses writes rather than using a mock client.

No caps move this round: `backend/app/platform/cache/redis.py` is 409 lines, well under the 1000-line ratchet threshold. No auth path was touched, so the full backend suite was not re-run.

## Round 3 (codex, head 83da02a02)

One P1, addressed in the commit below.

**Process-local guarantees are per-worker guarantees.** Everything rounds 1 and 2 built lives in one Uvicorn worker's memory, and production runs several. During a Redis outage worker A could revoke a token and queue the denial in A alone while worker B held a positive for it, and after recovery B could read the pre-revocation positive straight out of Redis before A's replay ran. Nothing inside one process closes that, because the two processes share nothing. Two layers do, and a third thing is a residual that is bounded and stated rather than claimed closed.

**Layer 1: never serve a positive security decision from process-local memory.** `get`, `set` and `set_if_absent` take `security=True`. On a security read the layered provider will still answer from a pending authoritative override, because that is a refusal and refusing on stale information is fail-closed, but never from the fallback; when Redis is unreachable the answer is None and the caller re-derives from the database. On a security write it skips the fallback entirely, since an entry there could never be served and keeping one only invites a future reader to trust it.

The callers are enumerated in the `RedisCacheProvider` class docstring and pinned by `test_authorization_cache_reads_are_security_scoped`, an AST walk over a named module list. That list is one module: `embed_tokens/service.py`. The other cache callers were checked rather than assumed and are cached answers, not decisions: catalog and collection listings, search results, persistent config. There is no shared-map-scope or tenant-partition cache read to convert; `resolve_embed_scope_for_map` does not cache and `tenant_cache_key` partitions keys rather than caching a decision.

**Layer 2: a database-backed revocation generation.** Migration 0057 adds `catalog.security_revocation_generation` as a sequence rather than a counter row. `nextval` takes no row lock, so a revocation storm does not serialize on it; it is non-transactional, so a revoke whose transaction later rolls back still leaves the generation advanced, which costs one extra re-validation while the other direction would leave a revoked capability being served; and it needs no ORM model, so `alembic check` reports no drift. Like `arcgis_signin_attempts` (0056) it sits outside the RLS boundary deliberately: a sequence has no rows for a policy to attach to, and a per-tenant view of it would defeat the point.

Every revoke advances it, before the denial write so no positive can be minted under the new generation while the revoke is still landing. Every positive validation entry is stamped with the generation it was minted under, and the validator compares on each hit and treats a mismatch as a miss. The generation is read from Redis on the hot path and re-read from the database, with the Redis key rewritten, in exactly the two cases where the Redis copy cannot be trusted: the key is missing, and the worker's circuit has just transitioned back to closed. `consume_recovery_signal()` reports that transition once and is raised before the replay drain, so a reader that consumes it is not overtaken by a replay that has not run. An entry with no stamp fails the comparison too, which is what a pre-upgrade process's entry looks like: one database re-validation per live token in the minutes after a rolling deploy, against the alternative of trusting exactly the entries this cannot vouch for.

**Residual, bounded and named.** A worker that served no requests at all during the outage never opened its circuit, so it never sees a recovery signal and its Redis reads succeeded throughout. If Redis still holds a pre-revocation positive, that worker trusts it until the entry's TTL expires. That TTL is five minutes, now the named constant `EMBED_TOKEN_POSITIVE_TTL_SECONDS`, and the bound is recorded there, in `platform/cache/revocation.py`'s docstring, and here. Closing it completely needs either a push channel every worker subscribes to (Redis pub/sub, the component that was down) or a database read on every cache hit, which is the round-trip the cache exists to avoid.

A second residual of the same shape, not asked about but worth stating: with `REDIS_URL` unset the whole cache is the in-memory provider, so a security positive is served from it. That is exactly as correct as the deployment is single-process, and wrong under `uvicorn --workers N` without Redis. It is documented on `InMemoryCacheProvider` rather than silently accepted.

Round-3 verification:

- Full backend suite on the host, `uv run pytest -n 4 -q --no-cov`, because this round adds a migration and touches the validator : 11059 passed, 100 skipped, 0 failed in 24:09
- `uv run pytest tests/test_cross_worker_revocation_1778.py -q` : 10 passed, every case built from two providers over one fakeredis
- the cache, embed, tenant, persistent-config, search, builder-audit, shared-map and layering suites together : 215 passed
- `uv run pytest tests/test_alembic_helpers.py tests/test_ci_alembic_filter_paths.py tests/test_rls_drift_gate.py -q` : 24 passed
- `alembic upgrade head && alembic check` : no new upgrade operations detected
- `ruff check .` / `ruff format --check .` : clean; `dump_openapi.py --check` : clean

Counterfactuals, each disarmed and re-run: dropping the `security` branch from `get` fails the fallback test; dropping the generation comparison from the validator fails the two stale-entry tests.

Schema impact this round: one new migration, 0057, creating a sequence. No table, no RLS policy, no ORM model, no API or response-schema change.

Four suites that prime an embed-token positive cache entry by hand now stamp it with the generation and pin the lookup: the expiry-cache, origin-bypass, self-origin domain-lock and race suites. An entry with no stamp is refused by design, so leaving them unstamped made them fall through to a mock database and raise on the row. The first full-suite run of this round is what surfaced the last two of those, which is the reason it was run despite the round being cache-shaped.

Caps this round: `backend/app/modules/embed_tokens/service.py` 1106 -> 1164. `backend/app/platform/cache/redis.py` (504 lines) and the new `backend/app/platform/cache/revocation.py` (166) are both under the 1000-line ratchet threshold, so neither enters `_MODULE_LOC_CAPS`.

## Round 4 (codex, head 733752332)

Two P1s and one P2.

**The generation could be stale, and no call order fixes that.** Codex found that `consume_recovery_signal()` returned false on the first request after a lapsed cooldown, because nothing detects the lapse until a cache method looks, so that request read the stale Redis generation and accepted a pre-outage positive. Reordering fixes the symptom; the underlying problem is that a cached generation can be stale-low at any time, and a worker reading G while a revocation has committed at G+1 finds its entry stamped G, sees a match, and serves a revoked token.

The generation is now read from the database on every validation. There is no Redis key for it, no publish to order, no signal to race, and `consume_recovery_signal`, `_was_open` and `_recovery_signal` are gone from the provider. The residual documented in round 3, a worker that took no traffic during the outage trusting Redis until the entry's TTL, goes with them: there is nothing cached left to be stale. The cost is one single-row indexed read per validation, on a path that already issues at least one database query on both its cache-hit and cache-miss branches (`map_contains_dataset` always, plus the origin and, in multi-tenant, the tenant check). The justification given in round 3 for caching it was wrong about that path.

**Publishing before the commit let a positive outlive the revocation.** A concurrent validator could read generation G+1, read the token row as still active because the revoke had not committed, and cache a positive stamped G+1 that survived the commit. Advancing after the commit only narrows the window, since a reader between the commit and the publish still sees the old value. So `catalog.security_revocation_generation` is a single-row table rather than a sequence, and the bump is an `UPDATE ... RETURNING` inside the caller's transaction: the counter and the `is_active` flip become visible in the same instant. `nextval` was the wrong primitive, chosen because it takes no row lock and fatal because it is non-transactional.

The validator reads the generation before the token row, which makes the orderings exhaustive. An entry cached against the uncommitted revoke is stamped with the old generation and refused once the revoke commits; a reader that already sees the new generation reads a committed-inactive row and denies. A rolled-back revoke now leaves the counter alone, and a failed bump is no longer swallowed, because it has poisoned the caller's transaction and the revocation must not commit without it.

Every site that reads or writes the generation: `bump_revocation_generation` is the only writer, called from `_deny_revoked_embed_tokens`, which is the single funnel for all four revoke paths; `current_revocation_generation` is the only reader, called once from `validate_embed_token_access` before the cache read. Both live in `platform/cache/revocation.py`.

**Concurrent mapped promotions collided on the user_roles primary key.** `set_role_from_identity_provider` skipped the advisory lock on its promotion branch, reasoning that a promotion cannot threaten the last-admin invariant. True, and beside the point: serialization is the other thing the lock provides. Two OAuth callbacks for one account both entered the branch, and `_update_user_role`'s delete-then-insert collided on `(user_id, role_id)`, failing an otherwise valid login. The lock now covers both branches, which also makes the idempotency check load-bearing: the second caller re-reads under the lock, finds the promotion applied, and returns without touching the table or bumping `key_epoch` again. SAML needs no separate fix, and that was verified rather than assumed: the method has exactly one caller in the tree, and SAML JIT reaches it through the same `find_or_create_oauth_user`.

Migration 0057 is rewritten in place rather than superseded, since it is unreleased. A matching ORM model in `core/db/models.py` keeps `alembic check` clean.

Round-4 verification, all against a dedicated `geolens_m2` database:

- Full backend suite on the host, `uv run pytest -n 4 -q --no-cov` : 11061 passed, 100 skipped, 0 failed in 24:34
- `uv run pytest tests/test_cross_worker_revocation_1778.py tests/test_cache.py tests/test_oauth_role_reevaluation_1778.py -q` : 67 passed
- `alembic downgrade 0056 && alembic upgrade head && alembic check` : no new upgrade operations detected
- `ruff check .` / `ruff format --check .` : clean; `dump_openapi.py --check` : clean

Counterfactuals, each disarmed and re-run: making the bump non-transactional fails three tests including the interleaving one; moving the lock back inside the non-admin branch fails the concurrency test with `UniqueViolationError` on `user_roles_pkey`. The concurrency test needed a barrier to be worth anything, since a plain `asyncio.gather` of two promotions passed against the unlocked code.

The guard that `platform/cache/revocation.py` never reaches the cache is asserted against the module SOURCE rather than by patching `get_cache`. Patching catches only a lazy in-function import; a module-level import binds its own reference and sails past a patched attribute, which is the shape someone would add when caching it again looks like an optimization. Counterfactual for that one was run too: adding a module-level `from app.platform.cache.provider import get_cache` fails it.

Caps this round: `backend/app/modules/embed_tokens/service.py` 1164 -> 1174, `backend/app/modules/admin/service.py` 1036 -> 1055.


## Round 5 (codex, head 9e44ca763)

One P1, one P2.

**A sentinel is not a generation, and treating it as one made the fail-closed comparison fail open.** `current_revocation_generation` returned `-1` when the counter row could not be read, and both the validator's comparison and the cache write treated that as an ordinary value. Two entries stamped with `-1` compare equal, so a positive cached while the counter was unreadable stayed trusted through a later revocation whose denial could not reach shared Redis, for as long as the outage lasted. `bump_revocation_generation` had the same shape from the write side: on a missing row it returned `-1` and let the caller's revoke commit anyway, announcing the revocation to nobody.

`UNKNOWN_GENERATION` and `is_usable_generation` are now the module's contract. The validator asks before it trusts a cached entry, before it compares two generations, and before it writes one: an entry stamped with an unusable generation is refused as a miss, and an unusable generation is never written to the cache at all, in either direction. Not knowing whether anything has been revoked means not trusting the cache either way. The cost is a database read on every validation for as long as the counter stays unreadable, which is the same cost round 4 already accepted for the ordinary case.

`bump_revocation_generation` now raises `RevocationGenerationError` instead of returning the sentinel. It runs inside the caller's transaction, so the raise rolls back the `is_active` flip with it and the operator sees a failed revoke to retry, rather than one that committed while half the fleet kept ignoring it.

The missing-row case is also easier to leave behind. The single-row guard was already a boolean primary key with a `CHECK`, so a second row can never exist; `current_revocation_generation` now re-creates the row with `ON CONFLICT (id) DO UPDATE` when it finds none, seeded from `clock_timestamp()` rather than 1 in both the migration and the reader. Re-seeding at 1 would walk the counter back up through values that stale entries elsewhere in the fleet are still stamped with, so a revoked entry could compare equal again a few revocations later; an epoch seed puts the new counter far above anything the old one could have reached by counting revocations, so issued values never repeat. The column default stays the literal `1`, unused, so the ORM model in `core/db/models.py` still matches for `alembic check`.

**The audit trail described a transition that had already happened.** `set_role_from_identity_provider` returned a bare `bool`, so its caller could not distinguish "applied" from "was already correct". The loser of two concurrent mapped promotions waited on the advisory lock, found the role already set, and still returned `True`; `_reconcile_mapped_role` then emitted a second `oauth.role.changed` for a transition that had already happened, carrying a `previous_roles` snapshot taken before the winner's write landed. `set_role_from_identity_provider` now returns an `IdentityRoleOutcome(applied, changed, previous_roles)`, with `previous_roles` read under the lock rather than before waiting for it, and `_update_user_role` reports whether it actually wrote anything. The audit event fires only when `changed` is true.

The first full-suite run this round failed one test: `test_embed_token_negative_cache_cannot_poison_another_tenant`'s hand-rolled database stub answered `execute()` but not `scalar()`, so the new generation read always hit the failure branch and the positive branch the test asserts on was never cached under the new gate. Not a production regression: the stub now answers `scalar()` too, and the suite is clean.

Round-5 verification, all against the dedicated `geolens_m2` database:

- `alembic downgrade 0056 && alembic upgrade head && alembic check`: clean round trip, no new upgrade operations detected.
- `uv run pytest tests/test_cross_worker_revocation_1778.py tests/test_oauth_role_reevaluation_1778.py tests/test_embed_tokens*.py tests/test_layering.py tests/test_rule1_structural.py tests/test_rule2_structural.py -q`: 253 passed.
- `uv run ruff check .` and `uv run ruff format --check .`: clean.
- Full backend suite on the host, `uv run pytest -n 4 -q --no-cov`: 11068 passed, 100 skipped, 0 failed in 22:59.

Caps this round: `backend/app/modules/embed_tokens/service.py` 1174 -> 1192, `backend/app/modules/admin/service.py` 1055 -> 1098, `backend/app/modules/auth/oauth/service.py` 1249 -> 1261, all re-measured with `wc -l`.

The branch was then rebased onto `origin/main` to pick up four PRs merged that morning. Only `test_layering.py` conflicted, at every `_MODULE_LOC_CAPS` region this branch had touched across its own five rounds; each was resolved by keeping both sides' entries and re-measuring the affected cap with `wc -l` where the two histories touched the same file (`backend/app/core/config.py` landed at 1537, the sum of both branches' additions on top of the shared 1501 base). No conflict in migration 0057: `origin/main`'s latest revision is still 0056. Re-verified after the rebase, all against `geolens_m2`: alembic downgrade/upgrade/check clean, the lane and structural suites (`test_cross_worker_revocation_1778.py`, `test_oauth_role_reevaluation_1778.py`, `test_embed_tokens*.py`, `test_tenant_cache_partitioning.py`, `test_layering.py`, `test_rule1_structural.py`, `test_rule2_structural.py`, `test_oversized_password_1778.py`) 279 passed, and `ruff check` / `ruff format --check` clean. Head after rebase: `e6467e31c`.



## Round 6 (codex, head e6467e31c)

One P1, one P2, both in the round-5 heal path.

**A heal that runs on the caller's session is a heal that outlives nothing.** Every production caller of `current_revocation_generation` is a read endpoint on `get_db()`, whose session commits nothing on a successful request. Round 5's self-heal ran its `INSERT` on that same session, so the row appeared recreated for the rest of the one request that noticed it missing and vanished the instant the session closed with no commit. The next validation found the row gone again and re-healed it, over and over, while `bump_revocation_generation` kept raising `RevocationGenerationError` on every revoke attempt until an operator repaired the table by hand: active tokens became unrevocable. Round 5's own pinning test masked this by deleting the row and healing it inside the same session, then rolling back, which reads as a pass either way.

The heal now runs on its own connection, via `engine.begin()`, late-imported the same way `get_db()` late-imports `async_session` so a test fixture that rebinds `app.core.db.engine` is still honored. It commits independently of whatever the caller's session does with its own transaction. `current_revocation_generation` then re-reads the result through the CALLER's own session rather than trusting the value the heal returned directly, a fresh statement under READ COMMITTED that sees the just-committed row from the other connection.

The rewritten persistence test had to change shape, not just its assertion: deleting the row and healing inside one uncommitted session is now a deadlock rather than a false pass, since a second connection's `INSERT ... ON CONFLICT` blocks on the row lock an uncommitted `DELETE` from the same session still holds. It commits the delete first, then verifies the heal from a second, independent session. A further pin drives the same heal through a real tile request on `get_db()` rather than calling the function directly, and confirms the row is still there from a session the request never touched.

**A seed that can equal an earlier stamp is not a fresh generation.** The epoch-second seed adopted in round 5 could collide with itself: deleting the row and healing it again within the same wall-clock second reproduces the identical value, and a Redis positive stamped with the pre-delete generation would then compare equal to it and be trusted again after "recovery". It degrades further under load rather than only at that boundary: a fleet revoking fast enough can walk the counter's integer value past the current epoch-seconds count outright, landing a later re-seed BEHIND the counter it was meant to get ahead of. Monotonic wall-clock time was never the guarantee this needed.

The seed is now a value drawn uniformly from `[0, 2**62)`, identical in the migration and the heal, which makes a collision with any earlier stamp, from any prior seed or any counted revocation, a ~2**-62 event independent of timing. Pinned with a test that heals the row twice within the same wall-clock second and asserts the two generations differ; the old seed fails this reliably in a same-process test loop, not as a rare edge case.

Round-6 verification, all against the dedicated `geolens_m2` database:

- `alembic downgrade 0056 && alembic upgrade head && alembic check`: clean round trip, no new upgrade operations detected.
- `uv run pytest tests/test_cross_worker_revocation_1778.py tests/test_oauth_role_reevaluation_1778.py tests/test_embed_tokens*.py tests/test_tenant_cache_partitioning.py tests/test_layering.py tests/test_rule1_structural.py tests/test_rule2_structural.py tests/test_oversized_password_1778.py -q`: 281 passed.
- `uv run ruff check .` and `uv run ruff format --check .`: clean.
- Both counterfactuals run and reverted: reverting the heal to run on the caller's session fails the persistence and real-request tests (no deadlock, since the delete in those tests is committed before the heal runs); reverting the seed to the epoch-second expression fails the same-second-heal test.
- `git merge-base --is-ancestor origin/main HEAD` after fetch: true, no rebase needed this round.

No `_MODULE_LOC_CAPS` change: `backend/app/platform/cache/revocation.py` (243 lines) and `backend/tests/test_cross_worker_revocation_1778.py` (609 lines) are both under the 1000-line ratchet threshold. Head after this round: `c601eecd6`.
