### PR TITLE
fix(features): five feature-service findings from the 2026-08-30 audit

### DIFF
--- a/backend/app/api/middleware/cors.py
+++ b/backend/app/api/middleware/cors.py
@@ -230,7 +230,10 @@ class DynamicCORSMiddleware(BaseHTTPMiddleware):
             "X-GeoLens-Source-Dataset-Count, X-GeoLens-Serialized-Dataset-Count, "
             "X-GeoLens-Excluded-Dataset-Count, "
             "X-GeoLens-Metadata-Fallback-Dataset-Count, "
-            "X-GeoLens-Metadata-Fallback-Fields"
+            "X-GeoLens-Metadata-Fallback-Fields, "
+            # fix(#1778): says whether numberMatched is exact or the planner's
+            # estimate on a filtered feature page.
+            "X-GeoLens-Number-Matched"
         )
         response.headers["Access-Control-Max-Age"] = "3600"
 
@@ -351,6 +354,9 @@ class DynamicCORSMiddleware(BaseHTTPMiddleware):
             "X-GeoLens-Source-Dataset-Count, X-GeoLens-Serialized-Dataset-Count, "
             "X-GeoLens-Excluded-Dataset-Count, "
             "X-GeoLens-Metadata-Fallback-Dataset-Count, "
-            "X-GeoLens-Metadata-Fallback-Fields"
+            "X-GeoLens-Metadata-Fallback-Fields, "
+            # fix(#1778): says whether numberMatched is exact or the planner's
+            # estimate on a filtered feature page.
+            "X-GeoLens-Number-Matched"
         )
         response.headers["Access-Control-Max-Age"] = "3600"

--- a/backend/app/core/db/pg_ranges.py
+++ b/backend/app/core/db/pg_ranges.py
@@ -1,0 +1,77 @@
+"""Value ranges for PostgreSQL's fixed-width numeric types (fix(#1778 review r2)).
+
+A caller-supplied literal can be a perfectly good Python number and still be
+wrong for the column it is compared against, and how that fails depends on the
+SQL the compiler happens to emit. Three shapes, all measured on PostgreSQL 18
+with asyncpg:
+
+  - ``?ratio=1e100`` on a ``real`` column, through the property-filter path.
+    SQLAlchemy's ``REAL()`` bind emits no narrowing cast, so PostgreSQL
+    promotes the stored float4 and compares in float8. No error, no match:
+    HTTP 200 with zero features.
+  - ``?construction_year=2147483648`` on an ``integer`` column, bound
+    ``BigInteger`` so the asyncpg cast matches the numeric family. ``int4 =
+    int8`` is a legal comparison no stored value can satisfy. Again 200 with
+    zero features.
+  - ``filter=ratio = 1e100``, through CQL2, which compiles to
+    ``ratio = CAST($1::FLOAT AS REAL)``. That cast DOES overflow:
+    ``NumericValueOutOfRangeError``, SQLSTATE 22003.
+
+The first two answer a question the caller did not ask; the third was an
+unhandled 500. Checking the range before the query makes all three a 400 that
+names the property and the bound it broke, rather than leaving the outcome to
+which cast the compiler chose.
+
+``bigint`` is here for a fourth reason: a Python int outside int8 cannot be
+encoded at all, and asyncpg's failure arrives as ``sqlalchemy.exc.DBAPIError``
+-- the base class, not ``DataError`` -- so nothing that caught ``DataError``
+ever saw it.
+"""
+
+from __future__ import annotations
+
+# Inclusive bounds, per PostgreSQL's documented numeric type limits.
+PG_INTEGER_RANGES: dict[str, tuple[int, int]] = {
+    "smallint": (-32768, 32767),
+    "integer": (-2147483648, 2147483647),
+    "bigint": (-(2**63), 2**63 - 1),
+}
+
+# Largest finite float4. A float8 above it has no float4 counterpart, so a
+# comparison against a real column can never match.
+FLOAT4_MAX = 3.4028234663852886e38
+
+INT8_MIN, INT8_MAX = PG_INTEGER_RANGES["bigint"]
+
+
+def check_pg_value_range(pg_type: str, value: object) -> None:
+    """Raise ValueError when *value* is out of range for *pg_type*.
+
+    The message states the bound, so a caller reading the 400 learns which
+    limit it broke rather than only that something was rejected. Types with no
+    fixed width (``numeric``, ``double precision``, text, temporal) have no
+    bound to check and pass through.
+    """
+    bounds = PG_INTEGER_RANGES.get(pg_type)
+    if bounds is not None and isinstance(value, int) and not isinstance(value, bool):
+        low, high = bounds
+        if not low <= value <= high:
+            raise ValueError(f"must be between {low} and {high} for a {pg_type} column")
+    if pg_type == "real" and isinstance(value, float):
+        if abs(value) > FLOAT4_MAX:
+            raise ValueError(
+                f"magnitude must not exceed {FLOAT4_MAX:g} for a real column"
+            )
+
+
+def check_int8_range(name: str, value: int) -> None:
+    """Raise ValueError when an integer bind cannot be encoded as int8.
+
+    For the pagination integers, which are caller-supplied and reach the driver
+    untyped. FastAPI's ``int`` has no upper bound, so ``?offset=10**23`` used to
+    surface as a 500 from the asyncpg encode path on both routers.
+    """
+    if not INT8_MIN <= value <= INT8_MAX:
+        raise ValueError(
+            f"Invalid value for {name}: must be between {INT8_MIN} and {INT8_MAX}"
+        )

--- a/backend/app/core/db/sqlstate.py
+++ b/backend/app/core/db/sqlstate.py
@@ -53,6 +53,45 @@ _OPERATIONAL_CLASSES = frozenset(
 )
 
 
+# States that mean "the caller's value does not fit the column it was compared
+# against", as opposed to an outage or a bug in our own SQL.
+#
+# fix(#1778 review r2): one definition, read by the OGC items handler and the
+# native features list, because they had drifted. The OGC router carried this
+# set inline while the native one tested a narrower `BAD_QUERY_INPUT`, so the
+# same failure was a 400 through one endpoint and a 503 through the other.
+#
+# Class 22 is data_exception as a whole. asyncpg reports a client-side encode
+# failure (an int outside int8, say) as plain 22000 on a bare
+# ``sqlalchemy.exc.DBAPIError`` -- NOT a ``DataError``, which is why catching
+# ``DataError`` alone missed it and both routers 500'd.
+TYPE_FAULT_SQLSTATES = frozenset(
+    {
+        "42883",  # undefined_function — no operator for the pair
+        "42804",  # datatype_mismatch
+        "42846",  # cannot_coerce
+        "42P18",  # indeterminate_datatype
+    }
+)
+
+
+def is_caller_type_fault(exc: DBAPIError) -> bool:
+    """True when the database refused a caller-supplied value's type or range.
+
+    A DataError carrying no SQLSTATE counts: the driver raised before the
+    server answered, and for this class of error that means it could not encode
+    what the caller sent.
+    """
+    from sqlalchemy.exc import DataError
+
+    code = sqlstate(exc) or ""
+    return (
+        code.startswith("22")
+        or code in TYPE_FAULT_SQLSTATES
+        or (isinstance(exc, DataError) and not code)
+    )
+
+
 def sqlstate(exc: DBAPIError) -> str | None:
     """Return the five-character SQLSTATE for a SQLAlchemy DBAPI error, if any.
 

--- a/backend/app/modules/catalog/datasets/domain/_sql_safety.py
+++ b/backend/app/modules/catalog/datasets/domain/_sql_safety.py
@@ -51,3 +51,26 @@ def _safe_table_ref(table_name: str, schema: str = "data") -> str:
     if not SAFE_TABLE_NAME_RE.match(schema):
         raise ValueError(f"Invalid schema name: {schema!r}")
     return f'"{schema}"."{table_name}"'
+
+
+def _safe_column_ref(name: str) -> str:
+    """Return a double-quoted column identifier for use inside ``text()``.
+
+    fix(#1778): the row browser interpolated column names bare, so a column
+    whose name is a SQL reserved word (``desc``, ``order``, ``user`` -- routine
+    ogr2ogr output from DBF fields, and nothing renames them on ingest) turned
+    every SELECT and every ILIKE filter for that dataset into a syntax error.
+    The sibling read paths already quote: ``layers.service._qcol``,
+    ``features.service.live_property_columns`` and
+    ``processing.ingest.metadata_sql._sql_quote_ident``, whose escaping this
+    mirrors.
+
+    Embedded double quotes are doubled (the PostgreSQL-standard escape) and
+    colons are backslash-escaped, because SQLAlchemy ``text()`` reads ``:name``
+    as a bind parameter even inside a quoted identifier. The output is
+    therefore valid only inside ``text()``.
+
+    Quoting is not a substitute for validation: callers still filter names
+    through ``SAFE_TABLE_NAME_RE`` or ``SAFE_COLUMN_NAME_RE`` first.
+    """
+    return '"' + name.replace('"', '""').replace(":", "\\:") + '"'

--- a/backend/app/modules/catalog/datasets/domain/service_create.py
+++ b/backend/app/modules/catalog/datasets/domain/service_create.py
@@ -24,6 +24,7 @@ from app.modules.catalog.datasets.domain.models import (
     Record,
 )
 from app.modules.catalog.datasets.domain.schemas import IngestionResult
+from app.modules.catalog.features.service import is_writable_feature_column
 from app.modules.catalog.datasets.domain.service_relationships import (
     auto_detect_relationships,
 )
@@ -60,6 +61,21 @@ async def create_empty_dataset(
             raise ValueError(
                 f"Invalid column name: {col.name!r}. "
                 "Must start with a letter or underscore and contain only alphanumeric characters and underscores."
+            )
+        # fix(#1778): SAFE_COLUMN_NAME_RE allows a leading underscore and has
+        # no length bound, but the feature write path can address neither, so
+        # `POST /datasets/empty` with a column named `_notes` used to create a
+        # real column that the feature API could then never write — POST and
+        # PUT answered 201/200 with the value silently dropped. A name longer
+        # than 63 characters is worse: PostgreSQL truncates the identifier in
+        # the DDL while column_info keeps the full string, so the truncated
+        # name GET returns is rejected as unknown and the full one is dropped.
+        # Refuse at creation rather than build an unwritable column.
+        if not is_writable_feature_column(lower_name):
+            raise ValueError(
+                f"Invalid column name: {col.name!r}. "
+                "A column name is at most 63 characters, starts with a letter, "
+                "and holds only letters, digits and underscores."
             )
         if lower_name in _RESERVED_COLUMNS:
             raise ValueError(

--- a/backend/app/modules/catalog/datasets/domain/service_query.py
+++ b/backend/app/modules/catalog/datasets/domain/service_query.py
@@ -22,7 +22,10 @@ from app.modules.catalog.authorization import (
     apply_visibility_filter,
     can_view_dataset_provenance,
 )
-from app.modules.catalog.datasets.domain._sql_safety import SAFE_TABLE_NAME_RE
+from app.modules.catalog.datasets.domain._sql_safety import (
+    SAFE_TABLE_NAME_RE,
+    _safe_column_ref,
+)
 from app.modules.catalog.datasets.domain.models import (
     Dataset,
     DatasetGrant,
@@ -310,7 +313,11 @@ _GEOM_COLUMN_NAMES = frozenset({"geom", "geom_4326", "wkb_geometry"})
 
 
 def _build_select_cols(column_info: list[dict]) -> list[str]:
-    """Return the non-geometry columns to project, with `gid` always present."""
+    """Return the non-geometry columns to project, with `gid` always present.
+
+    fix(#1778): names are emitted quoted. Membership is still decided on the
+    bare name, so quote at emission rather than in the list.
+    """
     select_cols: list[str] = []
     has_gid = False
     for c in column_info:
@@ -319,11 +326,11 @@ def _build_select_cols(column_info: list[dict]) -> list[str]:
             continue
         if c.get("type") == "USER-DEFINED" or name in _GEOM_COLUMN_NAMES:
             continue
-        select_cols.append(name)
+        select_cols.append(_safe_column_ref(name))
         if name == "gid":
             has_gid = True
     if not has_gid:
-        select_cols.insert(0, "gid")
+        select_cols.insert(0, _safe_column_ref("gid"))
     return select_cols
 
 
@@ -343,7 +350,10 @@ def _build_where_filters(
         if col_name not in valid_columns:
             continue
         param_key = f"f_{col_name}"
-        where_clauses.append(f"CAST({col_name} AS text) ILIKE :{param_key}")
+        # fix(#1778): quoted, for the same reason as _build_select_cols.
+        where_clauses.append(
+            f"CAST({_safe_column_ref(col_name)} AS text) ILIKE :{param_key}"
+        )
         bind_params[param_key] = f"%{search_term}%"
     return " WHERE " + " AND ".join(where_clauses), bind_params
 

--- a/backend/app/modules/catalog/features/router.py
+++ b/backend/app/modules/catalog/features/router.py
@@ -49,6 +49,8 @@ from app.modules.catalog.features.service import (
     UnwritablePropertyError,
     delete_feature,
     effective_geometry_type,
+    feature_bounds,
+    geojson_bounds,
     get_feature_by_id,
     get_features,
     get_features_geojson_z,
@@ -582,7 +584,15 @@ async def create_feature(
         await db.rollback()
         raise _feature_write_db_error(exc)
 
-    await refresh_dataset_metadata(db, dataset)
+    # fix(#1778): one row added, at a known envelope. No table scan when that
+    # envelope is already inside the stored extent.
+    await refresh_dataset_metadata(
+        db,
+        dataset,
+        count_delta=1,
+        touched_bounds=[geojson_bounds(body.geometry.model_dump())],
+        added_geometry_type=body.geometry.type,
+    )
     dataset.record.updated_by = user.id
     await audit_emit(
         db,
@@ -657,6 +667,10 @@ async def replace_single_feature(
     await require_dataset_editing_enabled(db)
     _require_feature_table(dataset)
 
+    # fix(#1778): read where the row is BEFORE moving it. A primary-key lookup,
+    # and it is what lets the metadata refresh skip the full-table aggregate.
+    prior_bounds = await feature_bounds(db, dataset.table_name, gid)
+
     try:
         row = await replace_feature(
             db,
@@ -688,7 +702,14 @@ async def replace_single_feature(
         await db.rollback()
         raise _feature_write_db_error(exc)
 
-    await refresh_dataset_metadata(db, dataset)
+    # fix(#1778): row count unchanged; the extent is unchanged too when both
+    # the old and the new envelope sit strictly inside it.
+    await refresh_dataset_metadata(
+        db,
+        dataset,
+        count_delta=0,
+        touched_bounds=[prior_bounds, geojson_bounds(body.geometry.model_dump())],
+    )
     dataset.record.updated_by = user.id
     await audit_emit(
         db,
@@ -754,6 +775,14 @@ async def patch_single_feature(
     await require_dataset_editing_enabled(db)
     _require_feature_table(dataset)
 
+    # fix(#1778): see replace_single_feature. Read even on a property-only
+    # PATCH is avoidable, so this runs only when the body carries geometry.
+    prior_bounds = (
+        await feature_bounds(db, dataset.table_name, gid)
+        if body.geometry is not None
+        else None
+    )
+
     try:
         row = await update_feature(
             db,
@@ -787,7 +816,13 @@ async def patch_single_feature(
 
     # Only refresh metadata if geometry changed (extent may change)
     if body.geometry is not None:
-        await refresh_dataset_metadata(db, dataset)
+        # fix(#1778): same reasoning as replace.
+        await refresh_dataset_metadata(
+            db,
+            dataset,
+            count_delta=0,
+            touched_bounds=[prior_bounds, geojson_bounds(body.geometry.model_dump())],
+        )
     dataset.record.updated_by = user.id
     await audit_emit(
         db,
@@ -846,6 +881,9 @@ async def delete_single_feature(
     await require_dataset_editing_enabled(db)
     _require_feature_table(dataset)
 
+    # fix(#1778): see replace_single_feature; the row is gone after the delete.
+    prior_bounds = await feature_bounds(db, dataset.table_name, gid)
+
     try:
         await delete_feature(db, dataset.table_name, gid)
     except ValueError as e:
@@ -862,7 +900,11 @@ async def delete_single_feature(
         await db.rollback()
         raise _feature_write_db_error(exc)
 
-    await refresh_dataset_metadata(db, dataset)
+    # fix(#1778): one row removed. A row strictly inside the stored extent was
+    # not defining any side of it, so the extent cannot shrink.
+    await refresh_dataset_metadata(
+        db, dataset, count_delta=-1, touched_bounds=[prior_bounds]
+    )
     dataset.record.updated_by = user.id
     await audit_emit(
         db,

--- a/backend/app/modules/catalog/features/router.py
+++ b/backend/app/modules/catalog/features/router.py
@@ -46,6 +46,7 @@ from app.modules.catalog.features.schemas import (
     inline_json_schema,
 )
 from app.modules.catalog.features.service import (
+    UnwritablePropertyError,
     delete_feature,
     effective_geometry_type,
     get_feature_by_id,
@@ -567,6 +568,11 @@ async def create_feature(
             await effective_geometry_type(db, dataset),
             dataset_srid=dataset.srid,
         )
+    except UnwritablePropertyError as e:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail=str(e),
+        )
     except ValueError as e:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
@@ -663,6 +669,11 @@ async def replace_single_feature(
             await effective_geometry_type(db, dataset),
             dataset_srid=dataset.srid,
         )
+    except UnwritablePropertyError as e:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail=str(e),
+        )
     except ValueError as e:
         if "not found" in str(e).lower():
             raise HTTPException(
@@ -754,6 +765,11 @@ async def patch_single_feature(
             # fix(#430 codex r7): generic for created datasets — see effective_geometry_type
             await effective_geometry_type(db, dataset),
             dataset_srid=dataset.srid,
+        )
+    except UnwritablePropertyError as e:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail=str(e),
         )
     except ValueError as e:
         if "not found" in str(e).lower():

--- a/backend/app/modules/catalog/features/router.py
+++ b/backend/app/modules/catalog/features/router.py
@@ -19,7 +19,13 @@ from sqlalchemy.exc import DBAPIError, OperationalError, ProgrammingError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.modules.audit.service import AuditEvent, audit_emit
-from app.core.db.sqlstate import BAD_QUERY_INPUT, TABLE_ABSENT, is_operational, sqlstate
+from app.core.db.sqlstate import (
+    BAD_QUERY_INPUT,
+    TABLE_ABSENT,
+    is_caller_type_fault,
+    is_operational,
+    sqlstate,
+)
 from app.core.identity import Identity
 from app.core.record_types import RASTER_FAMILY_RECORD_TYPES
 from app.modules.auth.dependencies import (
@@ -369,12 +375,21 @@ async def list_features(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=str(e),
         )
-    except (ProgrammingError, OperationalError) as exc:
+    except DBAPIError as exc:
         # fix(#1778): a type-shaped sqlstate with a property filter active is
         # the filter value, not an outage. Reporting it as a retryable 503 sent
         # clients into a pointless retry loop and polluted availability
         # monitoring with what is a query-shape bug.
-        if property_filters and sqlstate(exc) in BAD_QUERY_INPUT:
+        #
+        # fix(#1778 review r2): catch DBAPIError, not just its ProgrammingError
+        # and OperationalError subclasses, and classify with the same helper the
+        # OGC items handler uses. asyncpg reports a value it cannot encode as a
+        # bare DBAPIError with SQLSTATE 22000, which was neither, so it escaped
+        # as a 500 here while the sibling endpoint answered 400 for the same
+        # request. The 503 and 500 branches below keep their existing shape: an
+        # unrecognized state stays an honest 500 rather than being reported as
+        # an outage.
+        if property_filters and is_caller_type_fault(exc):
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail=(
@@ -382,10 +397,12 @@ async def list_features(
                     "column types"
                 ),
             )
-        raise HTTPException(
-            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-            detail="Dataset table is unavailable",
-        )
+        if isinstance(exc, (ProgrammingError, OperationalError)):
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail="Dataset table is unavailable",
+            )
+        raise
 
     # Build GeoJSON features
     features = [

--- a/backend/app/modules/catalog/features/router.py
+++ b/backend/app/modules/catalog/features/router.py
@@ -359,7 +359,26 @@ async def list_features(
             include_geometry=include_geometry,
             cached_feature_count=dataset.feature_count,
         )
-    except (ProgrammingError, OperationalError):
+    except ValueError as e:
+        # fix(#1778): an unparseable property-filter value is the caller's bug,
+        # rejected before the query runs.
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(e),
+        )
+    except (ProgrammingError, OperationalError) as exc:
+        # fix(#1778): a type-shaped sqlstate with a property filter active is
+        # the filter value, not an outage. Reporting it as a retryable 503 sent
+        # clients into a pointless retry loop and polluted availability
+        # monitoring with what is a query-shape bug.
+        if property_filters and sqlstate(exc) in BAD_QUERY_INPUT:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=(
+                    "Property filter is not evaluable against this dataset's "
+                    "column types"
+                ),
+            )
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail="Dataset table is unavailable",

--- a/backend/app/modules/catalog/features/router.py
+++ b/backend/app/modules/catalog/features/router.py
@@ -49,7 +49,6 @@ from app.modules.catalog.features.service import (
     UnwritablePropertyError,
     delete_feature,
     effective_geometry_type,
-    feature_bounds,
     geojson_bounds,
     get_feature_by_id,
     get_features,
@@ -351,7 +350,7 @@ async def list_features(
 
     # Query features
     try:
-        rows, total, total_is_estimate = await get_features(
+        page = await get_features(
             db,
             dataset.table_name,
             limit=limit,
@@ -395,7 +394,7 @@ async def list_features(
             geometry=row["geometry"],
             properties=row["properties"],
         )
-        for row in rows
+        for row in page.rows
     ]
 
     # Build pagination links
@@ -417,7 +416,10 @@ async def list_features(
         },
     ]
 
-    if offset + limit < total:
+    # fix(#1778 review r1): `next` follows the over-fetched row, not the count.
+    # numberMatched may be the planner's estimate, and an estimate at or below
+    # `offset + limit` used to drop the link with a full page on screen.
+    if page.has_more:
         next_params = {"offset": str(offset + limit), "limit": str(limit)}
         next_params.update(active_params)
         links.append(
@@ -444,7 +446,7 @@ async def list_features(
         )
 
     response = GeoJSONFeatureCollection(
-        numberMatched=total,
+        numberMatched=page.total,
         numberReturned=len(features),
         features=features,
         links=links,
@@ -453,7 +455,7 @@ async def list_features(
     return JSONResponse(
         content=response.model_dump(mode="json"),
         media_type="application/geo+json",
-        headers=number_matched_headers(total_is_estimate),
+        headers=number_matched_headers(page.total_is_estimate),
     )
 
 
@@ -667,12 +669,8 @@ async def replace_single_feature(
     await require_dataset_editing_enabled(db)
     _require_feature_table(dataset)
 
-    # fix(#1778): read where the row is BEFORE moving it. A primary-key lookup,
-    # and it is what lets the metadata refresh skip the full-table aggregate.
-    prior_bounds = await feature_bounds(db, dataset.table_name, gid)
-
     try:
-        row = await replace_feature(
+        written = await replace_feature(
             db,
             dataset.table_name,
             gid,
@@ -702,13 +700,19 @@ async def replace_single_feature(
         await db.rollback()
         raise _feature_write_db_error(exc)
 
+    row = written.feature
+
     # fix(#1778): row count unchanged; the extent is unchanged too when both
-    # the old and the new envelope sit strictly inside it.
+    # the old and the new envelope sit strictly inside it. The old envelope
+    # comes back from the UPDATE that overwrote it (fix(#1778 review r1)).
     await refresh_dataset_metadata(
         db,
         dataset,
         count_delta=0,
-        touched_bounds=[prior_bounds, geojson_bounds(body.geometry.model_dump())],
+        touched_bounds=[
+            written.prior_bounds,
+            geojson_bounds(body.geometry.model_dump()),
+        ],
     )
     dataset.record.updated_by = user.id
     await audit_emit(
@@ -775,16 +779,8 @@ async def patch_single_feature(
     await require_dataset_editing_enabled(db)
     _require_feature_table(dataset)
 
-    # fix(#1778): see replace_single_feature. Read even on a property-only
-    # PATCH is avoidable, so this runs only when the body carries geometry.
-    prior_bounds = (
-        await feature_bounds(db, dataset.table_name, gid)
-        if body.geometry is not None
-        else None
-    )
-
     try:
-        row = await update_feature(
+        written = await update_feature(
             db,
             dataset.table_name,
             gid,
@@ -814,6 +810,8 @@ async def patch_single_feature(
         await db.rollback()
         raise _feature_write_db_error(exc)
 
+    row = written.feature
+
     # Only refresh metadata if geometry changed (extent may change)
     if body.geometry is not None:
         # fix(#1778): same reasoning as replace.
@@ -821,7 +819,10 @@ async def patch_single_feature(
             db,
             dataset,
             count_delta=0,
-            touched_bounds=[prior_bounds, geojson_bounds(body.geometry.model_dump())],
+            touched_bounds=[
+                written.prior_bounds,
+                geojson_bounds(body.geometry.model_dump()),
+            ],
         )
     dataset.record.updated_by = user.id
     await audit_emit(
@@ -881,11 +882,10 @@ async def delete_single_feature(
     await require_dataset_editing_enabled(db)
     _require_feature_table(dataset)
 
-    # fix(#1778): see replace_single_feature; the row is gone after the delete.
-    prior_bounds = await feature_bounds(db, dataset.table_name, gid)
-
     try:
-        await delete_feature(db, dataset.table_name, gid)
+        # fix(#1778 review r1): the DELETE returns the envelope it removed, so
+        # the metadata refresh reasons about the version actually deleted.
+        prior_bounds = await delete_feature(db, dataset.table_name, gid)
     except ValueError as e:
         if "not found" in str(e).lower():
             raise HTTPException(

--- a/backend/app/modules/catalog/features/router.py
+++ b/backend/app/modules/catalog/features/router.py
@@ -52,6 +52,7 @@ from app.modules.catalog.features.service import (
     get_features,
     get_features_geojson_z,
     insert_feature,
+    number_matched_headers,
     parse_bbox,
     refresh_dataset_metadata,
     replace_feature,
@@ -347,7 +348,7 @@ async def list_features(
 
     # Query features
     try:
-        rows, total = await get_features(
+        rows, total, total_is_estimate = await get_features(
             db,
             dataset.table_name,
             limit=limit,
@@ -449,6 +450,7 @@ async def list_features(
     return JSONResponse(
         content=response.model_dump(mode="json"),
         media_type="application/geo+json",
+        headers=number_matched_headers(total_is_estimate),
     )
 
 

--- a/backend/app/modules/catalog/features/service.py
+++ b/backend/app/modules/catalog/features/service.py
@@ -4,15 +4,18 @@ from __future__ import annotations
 
 import math
 import re
-from collections.abc import Sequence
-from typing import TYPE_CHECKING
+from collections.abc import Callable, Sequence
+from datetime import date, datetime, timezone
+from decimal import Decimal, InvalidOperation
+from typing import TYPE_CHECKING, Any
 
 from shapely import to_geojson
 from shapely.errors import GEOSException
 from shapely.geometry import shape as shapely_shape
 from shapely.geometry.base import BaseGeometry
 from shapely.validation import explain_validity
-from sqlalchemy import func, text
+from sqlalchemy import bindparam, func, text
+from sqlalchemy import types as sa_types
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.geo import seam_extent_wkt_for_table
@@ -23,6 +26,122 @@ if TYPE_CHECKING:
 
 # Column name validation for SQL identifier safety
 _COLUMN_NAME_RE = re.compile(r"^[a-z][a-z0-9_]{0,62}$")
+
+# Widest signed integer PostgreSQL will compare against a bigint bind.
+_INT8_MIN = -(2**63)
+_INT8_MAX = 2**63
+
+
+def _parse_int(raw: str) -> int:
+    value = int(raw)
+    if not _INT8_MIN <= value < _INT8_MAX:
+        raise ValueError("out of range for an integer column")
+    return value
+
+
+def _parse_float(raw: str) -> float:
+    value = float(raw)
+    if not math.isfinite(value):
+        raise ValueError("must be a finite number")
+    return value
+
+
+def _parse_decimal(raw: str) -> Decimal:
+    try:
+        value = Decimal(raw)
+    except InvalidOperation as exc:
+        raise ValueError("must be a decimal number") from exc
+    if not value.is_finite():
+        raise ValueError("must be a finite number")
+    return value
+
+
+_BOOLEAN_LITERALS = {
+    "true": True,
+    "t": True,
+    "yes": True,
+    "y": True,
+    "1": True,
+    "false": False,
+    "f": False,
+    "no": False,
+    "n": False,
+    "0": False,
+}
+
+
+def _parse_bool(raw: str) -> bool:
+    try:
+        return _BOOLEAN_LITERALS[raw.strip().lower()]
+    except KeyError as exc:
+        raise ValueError("must be true or false") from exc
+
+
+def _parse_naive_timestamp(raw: str) -> datetime:
+    # A `timestamp without time zone` column cannot be compared with an aware
+    # value: asyncpg refuses it at bind time. Normalize to UTC, the same
+    # narrowing standards/ogc/filtering.py applies to CQL2 literals.
+    value = datetime.fromisoformat(raw)
+    if value.tzinfo is not None:
+        value = value.astimezone(timezone.utc).replace(tzinfo=None)
+    return value
+
+
+# fix(#1778): property filters bound the raw query-string value, so SQLAlchemy
+# typed every bind VARCHAR and PostgreSQL had no `bigint = character varying`
+# operator: EVERY non-text property filter failed with 42883, which the OGC
+# items handler then reported as a retryable 503. The queryables document
+# (Part 3) advertises these columns as integer/number/boolean/date, so a
+# conformant client was led straight into it. Each pg type here therefore
+# carries the parser that turns the query-string value into a Python value and
+# the database type the bind is compiled with. The families and their database
+# types mirror `sa_type_for_pg` in standards/ogc/filtering.py, for the reason
+# recorded there: a float8-cast bind against a REAL column promotes the stored
+# float4 and stops comparing equal.
+#
+# The set is exactly the set the queryables document advertises as filterable.
+# A column of any other type keeps the raw string bind, and the routers now
+# classify the resulting type-shaped sqlstate as the caller's 400.
+_PROPERTY_FILTER_BINDS: dict[str, tuple[Callable[[str], Any], Any]] = {
+    "text": (str, sa_types.Text()),
+    "character varying": (str, sa_types.Text()),
+    "character": (str, sa_types.Text()),
+    "smallint": (_parse_int, sa_types.BigInteger()),
+    "integer": (_parse_int, sa_types.BigInteger()),
+    "bigint": (_parse_int, sa_types.BigInteger()),
+    "real": (_parse_float, sa_types.REAL()),
+    "double precision": (_parse_float, sa_types.Float()),
+    "numeric": (_parse_decimal, sa_types.Numeric()),
+    "boolean": (_parse_bool, sa_types.Boolean()),
+    "date": (date.fromisoformat, sa_types.Date()),
+    "timestamp without time zone": (_parse_naive_timestamp, sa_types.DateTime()),
+    "timestamp with time zone": (
+        datetime.fromisoformat,
+        sa_types.DateTime(timezone=True),
+    ),
+}
+
+
+def _property_filter_bind(param_name: str, column: str, pg_type: str | None, raw: str):
+    """Return a typed BindParameter for one `column = value` filter, or None.
+
+    None means "no mapping for this column type": the caller keeps today's raw
+    string bind, and the routers classify whatever the database says about it.
+    Raises ValueError, naming the property, when the value does not parse for
+    the column's type — the caller's 400, not a database round trip.
+    """
+    mapping = _PROPERTY_FILTER_BINDS.get(pg_type or "")
+    if mapping is None:
+        return None
+    parse, sa_type = mapping
+    try:
+        value = parse(raw)
+    except (ValueError, TypeError) as exc:
+        raise ValueError(
+            f"Invalid value for property {column!r} (type {pg_type}): {exc}"
+        ) from exc
+    return bindparam(param_name, value, type_=sa_type)
+
 
 # Maps GeoJSON geometry type to the set of compatible PostGIS geometry types.
 # Single types are allowed into Multi columns (PostGIS promotes implicitly).
@@ -241,6 +360,41 @@ async def _projected_row_source(
     )
 
 
+async def _property_filter_predicates(
+    db: AsyncSession,
+    table_name: str,
+    property_filters: dict,
+    allowed_columns: set[str],
+) -> tuple[list[str], dict, list]:
+    """Compose the `"col" = :prop_col` predicates for the property filters.
+
+    Returns (where_clauses, raw_string_binds, typed_binds). fix(#1778): the
+    live schema decides how each value is typed, so the read costs one
+    information_schema round trip, and only when a property filter is present.
+    A column whose type has no mapping keeps the raw string bind it has always
+    had.
+    """
+    live_types = {
+        col["name"]: col.get("type")
+        for col in await get_feature_queryable_columns(db, table_name)
+        if isinstance(col.get("name"), str)
+    }
+    clauses: list[str] = []
+    raw_binds: dict = {}
+    typed_binds: list = []
+    for col, val in property_filters.items():
+        if col not in allowed_columns or not _COLUMN_NAME_RE.match(col):
+            continue
+        param_name = f"prop_{col}"
+        clauses.append(f'"{col}" = :{param_name}')
+        bind = _property_filter_bind(param_name, col, live_types.get(col), val)
+        if bind is None:
+            raw_binds[param_name] = val
+        else:
+            typed_binds.append(bind)
+    return clauses, raw_binds, typed_binds
+
+
 async def get_features(
     db: AsyncSession,
     table_name: str,
@@ -274,6 +428,16 @@ async def get_features(
     the binds built here, and typed so the asyncpg cast matches the column —
     codex r3). It joins ``where_clauses`` so the data query, count query,
     and cached-count bypass all compose exactly like ``bbox``.
+
+    fix(#1778): ``property_filters`` values arrive as query-string text and are
+    bound with the database type of the column they name, read from the live
+    schema. A value that does not parse for that type raises ValueError naming
+    the property; routers report it as a 400.
+
+    Raises
+    ------
+    ValueError
+        If a property-filter value cannot be parsed for its column's type.
     """
     # Build SELECT columns over the projected row (see live_property_columns
     # for why geom must never reach to_jsonb).
@@ -314,12 +478,13 @@ async def get_features(
         bind_values["maxx"] = bbox[2]
         bind_values["maxy"] = bbox[3]
 
+    typed_binds: list = []
     if property_filters and allowed_columns:
-        for col, val in property_filters.items():
-            if col in allowed_columns and _COLUMN_NAME_RE.match(col):
-                param_name = f"prop_{col}"
-                where_clauses.append(f'"{col}" = :{param_name}')
-                bind_values[param_name] = val
+        prop_clauses, prop_raw_binds, typed_binds = await _property_filter_predicates(
+            db, table_name, property_filters, allowed_columns
+        )
+        where_clauses.extend(prop_clauses)
+        bind_values.update(prop_raw_binds)
 
     if cql2_where:
         where_clauses.append(cql2_where)
@@ -351,12 +516,17 @@ async def get_features(
         bind_values["offset"] = offset
     bind_values["limit"] = limit
 
-    def _with_cql2_binds(stmt):
-        # typed BindParameters (codex r3) — see the cql2_binds docstring note
-        return stmt.bindparams(*cql2_binds) if cql2_binds else stmt
+    # Typed BindParameters (codex r3) — see the cql2_binds docstring note — plus
+    # the property-filter binds typed from the live schema (fix(#1778)). Both
+    # sets name parameters that appear in the data query AND in the count query,
+    # so one list serves both.
+    extra_binds = [*(cql2_binds or ()), *typed_binds]
+
+    def _with_extra_binds(stmt):
+        return stmt.bindparams(*extra_binds) if extra_binds else stmt
 
     result = await db.execute(
-        _with_cql2_binds(text(data_sql).bindparams(**bind_values))
+        _with_extra_binds(text(data_sql).bindparams(**bind_values))
     )
     rows = [dict(row._mapping) for row in result.all()]
 
@@ -382,7 +552,7 @@ async def get_features(
             f"t {count_where_sql}"
         )
         count_result = await db.execute(
-            _with_cql2_binds(text(count_sql).bindparams(**count_bind))
+            _with_extra_binds(text(count_sql).bindparams(**count_bind))
         )
         total = count_result.scalar_one()
 

--- a/backend/app/modules/catalog/features/service.py
+++ b/backend/app/modules/catalog/features/service.py
@@ -19,6 +19,7 @@ from sqlalchemy import bindparam, func, select, text
 from sqlalchemy import types as sa_types
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.db.pg_ranges import check_int8_range, check_pg_value_range
 from app.core.geo import seam_extent_wkt_for_table
 from app.platform.extensions import get_catalog_port
 
@@ -28,16 +29,11 @@ if TYPE_CHECKING:
 # Column name validation for SQL identifier safety
 _COLUMN_NAME_RE = re.compile(r"^[a-z][a-z0-9_]{0,62}$")
 
-# Widest signed integer PostgreSQL will compare against a bigint bind.
-_INT8_MIN = -(2**63)
-_INT8_MAX = 2**63
-
 
 def _parse_int(raw: str) -> int:
-    value = int(raw)
-    if not _INT8_MIN <= value < _INT8_MAX:
-        raise ValueError("out of range for an integer column")
-    return value
+    # The per-type bound is applied by check_pg_value_range, which knows
+    # whether the column is int2, int4 or int8 (fix(#1778 review r2)).
+    return int(raw)
 
 
 def _parse_float(raw: str) -> float:
@@ -137,6 +133,12 @@ def _property_filter_bind(param_name: str, column: str, pg_type: str | None, raw
     parse, sa_type = mapping
     try:
         value = parse(raw)
+        # fix(#1778 review r2): in range for the COLUMN, not merely parseable
+        # as a Python value. 1e100 against a real column and 2147483648 against
+        # an integer column are both legal comparisons that no stored value can
+        # satisfy, so they used to answer 200 with zero features -- a silently
+        # wrong answer to a question the caller did not ask.
+        check_pg_value_range(pg_type or "", value)
     except (ValueError, TypeError) as exc:
         raise ValueError(
             f"Invalid value for property {column!r} (type {pg_type}): {exc}"
@@ -595,8 +597,22 @@ async def get_features(
     Raises
     ------
     ValueError
-        If a property-filter value cannot be parsed for its column's type.
+        If a property-filter value cannot be parsed for its column's type or
+        falls outside that type's range, or if a pagination integer falls
+        outside int8 (fix(#1778 review r2)). Routers report all of these as
+        400s naming the property or parameter and the bound it broke.
     """
+    # fix(#1778 review r2): the pagination integers are caller values that reach
+    # the driver untyped, and FastAPI's `int` has no upper bound. A value
+    # outside int8 cannot be encoded at all: asyncpg raises a bare
+    # sqlalchemy.exc.DBAPIError with SQLSTATE 22000 from inside its encode
+    # path, which neither router caught, so `?offset=10**23` was a 500. Refuse
+    # it here, where the message can name the parameter.
+    check_int8_range("limit", limit)
+    check_int8_range("offset", offset)
+    if after_gid is not None:
+        check_int8_range("after_gid", after_gid)
+
     # Build SELECT columns over the projected row (see live_property_columns
     # for why geom must never reach to_jsonb).
     if has_geometry and include_geometry:

--- a/backend/app/modules/catalog/features/service.py
+++ b/backend/app/modules/catalog/features/service.py
@@ -549,6 +549,39 @@ async def _bounded_total(
     return max(counted, estimate), True
 
 
+def _floor_estimated_total(
+    total: int,
+    *,
+    total_is_estimate: bool,
+    served: int,
+    offset: int,
+    has_more: bool,
+) -> int:
+    """Raise an estimated total to the rows the page can prove exist.
+
+    fix(#1778 review r1): an estimate below the rows a page is about to show
+    makes numberMatched contradict the features beside it in the same response.
+
+    fix(#1778 review r3): it may only count rows that exist, and only when the
+    total is an estimate to begin with.
+
+      - An EXACT count is never raised. It already counted the whole match set,
+        so anything above it is fiction.
+      - An empty page proves nothing. The r1 form floored by `offset +
+        len(rows)` unconditionally, which invented matches out of the offset:
+        five features asked for at offset 100 returned an empty page and
+        reported numberMatched 100.
+      - A keyset page passes `offset=0`, because the query ignores `offset`
+        when `after_gid` is set. The rows in hand are all such a page can
+        prove, and borrowing an offset the query never applied would invent
+        matches the same way.
+    """
+    if not total_is_estimate or served == 0:
+        return total
+    floor = offset + served + (1 if has_more else 0)
+    return max(total, floor)
+
+
 async def get_features(
     db: AsyncSession,
     table_name: str,
@@ -730,12 +763,13 @@ async def get_features(
             db, table_name, count_where_sql, count_bind, _with_extra_binds
         )
 
-    # fix(#1778 review r1): the total never claims fewer rows than this page has
-    # already shown, plus the one more we know is there. An estimate below the
-    # cap, or a stale cached feature_count, would otherwise make numberMatched
-    # contradict the features beside it in the same response.
-    served = offset + len(rows)
-    total = max(total, served + 1 if has_more else served)
+    total = _floor_estimated_total(
+        total,
+        total_is_estimate=total_is_estimate,
+        served=len(rows),
+        offset=0 if use_keyset else offset,
+        has_more=has_more,
+    )
     return FeaturePage(rows, total, total_is_estimate, has_more)
 
 

--- a/backend/app/modules/catalog/features/service.py
+++ b/backend/app/modules/catalog/features/service.py
@@ -165,10 +165,46 @@ GEOJSON_TYPE_MAP: dict[str, set[str]] = {
 _MULTI_TYPES = {"MULTIPOINT", "MULTILINESTRING", "MULTIPOLYGON"}
 
 
+class UnwritablePropertyError(ValueError):
+    """A column that exists but that the feature write path cannot address.
+
+    fix(#1778): two guards disagreed about what a legal column is.
+    ``_reject_unknown_properties`` admitted any key present in column_info,
+    and the write loops then silently skipped whatever ``_COLUMN_NAME_RE``
+    rejected — a strictly narrower pattern than every producer of column_info.
+    ``create_empty_dataset`` validated against SAFE_COLUMN_NAME_RE (leading
+    underscore allowed, no length bound), ``get_column_info`` copies
+    information_schema verbatim, and the READ projection deliberately supports
+    names this regex rejects (``live_property_columns`` escapes colons because
+    registered Socrata exports ship columns literally named ``:id``).
+
+    So a dataset with a ``_notes`` or ``:id`` column returned that key from GET
+    but could not write it: POST and PUT answered 201/200 with the value never
+    stored, and on PUT the column was not even NULLed, contradicting the
+    documented "Columns not present in properties are set to NULL". Silent
+    write loss behind a success response is the worst shape for a data-editing
+    API, and it is exactly what an editing UI's read-modify-write round trip
+    hits. Refusing names the write path cannot address turns it into a 422.
+    """
+
+
+def is_writable_feature_column(name: str) -> bool:
+    """Whether the feature write path can address a column by this name.
+
+    The canonical predicate: ``create_empty_dataset`` refuses to build a column
+    that would fail it, and the write guards refuse to half-write one that
+    already exists.
+    """
+    return bool(_COLUMN_NAME_RE.match(name))
+
+
 def _reject_unknown_properties(
-    properties: dict | None, column_info: list[dict]
+    properties: dict | None,
+    column_info: list[dict],
+    *,
+    replaces_all: bool = False,
 ) -> None:
-    """Raise ValueError if a property key names no real attribute column.
+    """Raise if a property key names no real attribute column, or an unwritable one.
 
     fix(#458 E-25): writers used to silently drop unknown keys. On PUT that is a
     footgun — a misspelled key isn't written AND the intended column is nulled
@@ -176,13 +212,27 @@ def _reject_unknown_properties(
     Rejecting unknown keys up front surfaces the typo as a 400 instead. Reserved
     system columns (gid/geom/…) are absent from column_info, so a write attempt
     against them is correctly reported here too.
+
+    fix(#1778): a key naming a real column the write loop would then skip is
+    refused as well (see UnwritablePropertyError). ``replaces_all`` is the PUT
+    spelling: replace writes EVERY known column, so one unwritable column in
+    column_info makes the whole documented replacement impossible, whether or
+    not the request mentions it.
     """
-    if not properties:
-        return
     allowed = {c["name"] for c in column_info}
-    unknown = sorted(k for k in properties if k not in allowed)
-    if unknown:
-        raise ValueError(f"Unknown property columns: {', '.join(unknown)}")
+    if properties:
+        unknown = sorted(k for k in properties if k not in allowed)
+        if unknown:
+            raise ValueError(f"Unknown property columns: {', '.join(unknown)}")
+    named = allowed if replaces_all else {k for k in (properties or {}) if k in allowed}
+    unwritable = sorted(n for n in named if not is_writable_feature_column(n))
+    if unwritable:
+        raise UnwritablePropertyError(
+            f"Unwritable property columns: {', '.join(unwritable)}. "
+            "A writable column name is at most 63 characters, starts with a "
+            "lowercase letter, and holds only lowercase letters, digits and "
+            "underscores."
+        )
 
 
 def _geometry_sql(dataset_geometry_type: str) -> str:
@@ -897,7 +947,9 @@ async def replace_feature(
     """
     _validate_geometry_type(geometry.get("type", ""), dataset_geometry_type)
     normalized_geom = _validate_geometry_structure(geometry)
-    _reject_unknown_properties(properties, column_info)
+    # fix(#1778): replace nulls every known column, so an unwritable one makes
+    # the documented semantics unachievable even when the request omits it.
+    _reject_unknown_properties(properties, column_info, replaces_all=True)
 
     geojson_str = to_geojson(normalized_geom)
     geom_expr, geom_4326_expr = _geom_write_exprs(dataset_geometry_type, dataset_srid)

--- a/backend/app/modules/catalog/features/service.py
+++ b/backend/app/modules/catalog/features/service.py
@@ -15,7 +15,7 @@ from shapely.errors import GEOSException
 from shapely.geometry import shape as shapely_shape
 from shapely.geometry.base import BaseGeometry
 from shapely.validation import explain_validity
-from sqlalchemy import bindparam, func, text
+from sqlalchemy import bindparam, func, select, text
 from sqlalchemy import types as sa_types
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -1152,12 +1152,209 @@ async def _derive_created_geometry_type(session: AsyncSession, table_name: str) 
     return "GEOMETRY"
 
 
-async def refresh_dataset_metadata(session: AsyncSession, dataset: Dataset) -> None:
+Bounds = tuple[float, float, float, float]
+
+
+def geojson_bounds(geometry: dict | None) -> Bounds | None:
+    """The (minx, miny, maxx, maxy) envelope of a GeoJSON geometry, or None.
+
+    GeoJSON is WGS84 by spec, so the result is directly comparable with the
+    stored ``geom_4326`` extent even for a dataset whose ``geom`` column keeps
+    a projected source CRS.
+    """
+    if not geometry:
+        return None
+    try:
+        geom = shapely_shape(geometry)
+    except (GEOSException, ValueError, TypeError, AttributeError):
+        return None
+    if geom.is_empty:
+        return None
+    minx, miny, maxx, maxy = geom.bounds
+    return (float(minx), float(miny), float(maxx), float(maxy))
+
+
+async def feature_bounds(db: AsyncSession, table_name: str, gid: int) -> Bounds | None:
+    """The stored envelope of one feature, or None when it has no geometry.
+
+    A primary-key lookup, so callers can afford it on every write to learn
+    whether the row they are about to move or delete could have been defining
+    the dataset's extent.
+    """
+    result = await db.execute(
+        text(
+            f"SELECT ST_XMin(geom_4326), ST_YMin(geom_4326), "
+            f"ST_XMax(geom_4326), ST_YMax(geom_4326) "
+            f"FROM {get_catalog_port().quote_table(table_name)} WHERE gid = :gid"
+        ).bindparams(gid=gid)
+    )
+    row = result.first()
+    if row is None or any(v is None for v in row):
+        return None
+    return (float(row[0]), float(row[1]), float(row[2]), float(row[3]))
+
+
+async def _stored_extent_box(session: AsyncSession, dataset: Dataset) -> Bounds | None:
+    """The dataset's stored extent as a box, when reasoning about it is sound.
+
+    None unless the stored extent is a simple POLYGON. An antimeridian-crossing
+    dataset stores the two-ring MULTIPOLYGON `seam_extent_wkt_for_table`
+    produces (fix(#934)), whose ST_XMin/ST_XMax are -180/180: a longitude in
+    the gap would test as inside a box the geometry never occupies.
+    """
+    from app.modules.catalog.datasets.domain.models import Record
+
+    result = await session.execute(
+        select(
+            func.GeometryType(Record.spatial_extent),
+            func.ST_XMin(Record.spatial_extent),
+            func.ST_YMin(Record.spatial_extent),
+            func.ST_XMax(Record.spatial_extent),
+            func.ST_YMax(Record.spatial_extent),
+        ).where(Record.id == dataset.record_id)
+    )
+    row = result.first()
+    if row is None or row[0] != "POLYGON" or any(v is None for v in row[1:]):
+        return None
+    return (float(row[1]), float(row[2]), float(row[3]), float(row[4]))
+
+
+def _strictly_inside(inner: Bounds, outer: Bounds) -> bool:
+    """True when `inner` sits strictly within `outer` on all four sides.
+
+    Strict on purpose, and the same test for a row being added, removed or
+    moved. A row that only touches the boundary may be the row that DEFINES
+    that side, so removing or moving it can shrink the extent; a row strictly
+    inside cannot change it whichever way it is written.
+    """
+    return (
+        outer[0] < inner[0]
+        and outer[1] < inner[1]
+        and inner[2] < outer[2]
+        and inner[3] < outer[3]
+    )
+
+
+def _merged_created_geometry_type(current: str | None, added: str | None) -> str | None:
+    """The display geometry_type after ONE geometry of `added` type is inserted.
+
+    Mirrors `_derive_created_geometry_type`'s rules over the row types it would
+    see, without the DISTINCT scan. None when the answer is not decidable from
+    the stored value alone, which sends the caller back to the scan.
+
+    Insert only. A delete or a moved geometry can NARROW the derived type (the
+    last polygon leaving a mixed layer), and no merge of the stored value can
+    see that.
+    """
+    if not current or not added:
+        return None
+    current = current.strip().upper()
+    added = added.strip().upper()
+    if added not in _CONCRETE_GEOMETRY_TYPES:
+        return None
+    if current == "GEOMETRY":
+        # Already the honest fallback for a cross-family mix; one more row
+        # cannot make it narrower.
+        return "GEOMETRY"
+    if current not in _CONCRETE_GEOMETRY_TYPES:
+        return None
+    if current == added:
+        return current
+    if current.removeprefix("MULTI") == added.removeprefix("MULTI"):
+        family = current.removeprefix("MULTI")
+        return (
+            f"MULTI{family}" if family in ("POINT", "LINESTRING", "POLYGON") else None
+        )
+    return "GEOMETRY"
+
+
+async def _apply_incremental_metadata(
+    session: AsyncSession,
+    dataset: Dataset,
+    *,
+    count_delta: int,
+    touched_bounds: Sequence[Bounds | None],
+    added_geometry_type: str | None,
+) -> bool:
+    """Update feature_count alone when the write provably left the extent alone.
+
+    Returns False when the fast path does not apply, and the caller falls back
+    to the full recompute.
+
+    fix(#1778): `_refresh_count_and_extent` runs one unqualified
+    COUNT(*) + ST_Extent over the whole table, so every single-feature edit
+    seq-scanned the layer inside the request transaction, with a second scan
+    over `ST_ShiftLongitude(geom_4326)` whenever the naive extent is wider than
+    180 degrees and a third `SELECT DISTINCT GeometryType(...)` for created
+    datasets. There is no bulk feature endpoint, so a client digitizing 200
+    points issued 200 requests and paid it 200 times.
+    """
+    from app.modules.catalog.datasets.domain.models import Dataset as DatasetModel
+
+    if not isinstance(dataset.feature_count, int):
+        return False
+    new_count = dataset.feature_count + count_delta
+    # A layer emptied by this write must have its extent nulled, and one whose
+    # count was already wrong must be recounted rather than adjusted.
+    if new_count < 1:
+        return False
+    if not touched_bounds or any(b is None for b in touched_bounds):
+        return False
+
+    is_created_generic = dataset.source_format == "created" and (
+        await _geom_column_is_generic(session, dataset.table_name)
+    )
+    if is_created_generic:
+        # Only an insert can be settled without the DISTINCT scan.
+        if count_delta <= 0:
+            return False
+        if (
+            _merged_created_geometry_type(dataset.geometry_type, added_geometry_type)
+            != (dataset.geometry_type or "").strip().upper()
+        ):
+            return False
+
+    box = await _stored_extent_box(session, dataset)
+    if box is None:
+        return False
+    if not all(_strictly_inside(b, box) for b in touched_bounds if b is not None):
+        return False
+
+    if count_delta:
+        # SQL-side so two concurrent writes cannot both read N and write N+1.
+        dataset.feature_count = DatasetModel.feature_count + count_delta
+    await session.flush()
+    return True
+
+
+async def refresh_dataset_metadata(
+    session: AsyncSession,
+    dataset: Dataset,
+    *,
+    count_delta: int | None = None,
+    touched_bounds: Sequence[Bounds | None] | None = None,
+    added_geometry_type: str | None = None,
+) -> None:
     """Refresh feature_count and extent on a Dataset after write operations.
 
     Uses a single COUNT(*) + ST_Extent query instead of the full
     extract_metadata pipeline (which runs 5 queries).
+
+    fix(#1778): when the caller can say how many rows the write added or
+    removed and where the geometry it touched sits, and every touched envelope
+    is strictly inside the stored extent, the extent provably did not change
+    and no scan runs at all. Called with no keywords, the full recompute
+    behaviour is unchanged.
     """
+    if count_delta is not None and await _apply_incremental_metadata(
+        session,
+        dataset,
+        count_delta=count_delta,
+        touched_bounds=touched_bounds or (),
+        added_geometry_type=added_geometry_type,
+    ):
+        return
+
     feature_count, extent_wkt = await _refresh_count_and_extent(
         session, dataset.table_name
     )

--- a/backend/app/modules/catalog/features/service.py
+++ b/backend/app/modules/catalog/features/service.py
@@ -8,7 +8,7 @@ import re
 from collections.abc import Callable, Sequence
 from datetime import date, datetime, timezone
 from decimal import Decimal, InvalidOperation
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, NamedTuple
 
 from shapely import to_geojson
 from shapely.errors import GEOSException
@@ -465,6 +465,25 @@ async def _property_filter_predicates(
 # `offset + limit < total` cannot truncate pagination at the cap.
 _FILTERED_COUNT_CAP = 20_000
 
+
+class FeaturePage(NamedTuple):
+    """One page of features plus what the caller needs to paginate it.
+
+    fix(#1778 review r1): ``has_more`` exists because ``total`` may be the
+    planner's estimate. A router that decided its `next` link from
+    ``offset + limit < total`` would drop the link mid-result-set whenever the
+    estimate came back at or below the rows already served, stranding the
+    caller with a full page and nowhere to go. Whether another row exists is a
+    fact about the rows, so it is answered by over-fetching one and never by
+    the count.
+    """
+
+    rows: list[dict]
+    total: int
+    total_is_estimate: bool
+    has_more: bool
+
+
 NUMBER_MATCHED_HEADER = "X-GeoLens-Number-Matched"
 
 
@@ -543,13 +562,16 @@ async def get_features(
     after_gid: int | None = None,
     cql2_where: str | None = None,
     cql2_binds: Sequence | None = None,
-) -> tuple[list[dict], int, bool]:
+) -> FeaturePage:
     """Fetch paginated features from a data table as GeoJSON-ready dicts.
 
-    Returns (rows, total_count, total_is_estimate) where each row has gid,
-    geometry, and properties. ``total_is_estimate`` is True when the filtered
-    match set is larger than ``_FILTERED_COUNT_CAP`` and ``total_count`` is the
-    planner's row estimate rather than an exact count (fix(#1778)).
+    Returns a ``FeaturePage`` whose rows each have gid, geometry and
+    properties. ``total_is_estimate`` is True when the filtered match set is
+    larger than ``_FILTERED_COUNT_CAP`` and ``total`` is the planner's row
+    estimate rather than an exact count (fix(#1778)). ``has_more`` says whether
+    a further row exists after this page, measured by fetching one more row
+    than asked for; pagination links must be built from it and never from
+    ``total`` (fix(#1778 review r1)).
 
     Phase 269 H-24: when ``after_gid`` is provided, uses keyset pagination
     (``WHERE gid > :after_gid``) instead of OFFSET. This avoids the
@@ -650,7 +672,9 @@ async def get_features(
             f"{where_sql} ORDER BY gid LIMIT :limit OFFSET :offset"
         )
         bind_values["offset"] = offset
-    bind_values["limit"] = limit
+    # One row past the page, so `has_more` is a fact about the rows rather than
+    # a comparison against a count that may be estimated (fix(#1778 review r1)).
+    bind_values["limit"] = limit + 1
 
     # Typed BindParameters (codex r3) — see the cql2_binds docstring note — plus
     # the property-filter binds typed from the live schema (fix(#1778)). Both
@@ -665,6 +689,9 @@ async def get_features(
         _with_extra_binds(text(data_sql).bindparams(**bind_values))
     )
     rows = [dict(row._mapping) for row in result.all()]
+    has_more = len(rows) > limit
+    if has_more:
+        rows = rows[:limit]
 
     # Count query (same WHERE *minus* the after_gid cursor, no LIMIT/OFFSET).
     # The keyset cursor must be excluded from the count so total reflects the
@@ -676,17 +703,24 @@ async def get_features(
 
     # Use cached feature_count when no filters are active
     if not count_where_clauses and cached_feature_count is not None:
-        return rows, cached_feature_count, False
+        total, total_is_estimate = cached_feature_count, False
+    else:
+        count_bind = {
+            k: v
+            for k, v in bind_values.items()
+            if k not in ("limit", "offset", "after_gid")
+        }
+        total, total_is_estimate = await _bounded_total(
+            db, table_name, count_where_sql, count_bind, _with_extra_binds
+        )
 
-    count_bind = {
-        k: v
-        for k, v in bind_values.items()
-        if k not in ("limit", "offset", "after_gid")
-    }
-    total, total_is_estimate = await _bounded_total(
-        db, table_name, count_where_sql, count_bind, _with_extra_binds
-    )
-    return rows, total, total_is_estimate
+    # fix(#1778 review r1): the total never claims fewer rows than this page has
+    # already shown, plus the one more we know is there. An estimate below the
+    # cap, or a stale cached feature_count, would otherwise make numberMatched
+    # contradict the features beside it in the same response.
+    served = offset + len(rows)
+    total = max(total, served + 1 if has_more else served)
+    return FeaturePage(rows, total, total_is_estimate, has_more)
 
 
 async def get_features_geojson_z(
@@ -764,6 +798,16 @@ async def get_feature_by_id(
 # ---------------------------------------------------------------------------
 # Write operations
 # ---------------------------------------------------------------------------
+
+
+class FeatureWrite(NamedTuple):
+    """The written feature plus the envelope of the version it overwrote.
+
+    ``prior_bounds`` is None when the overwritten row carried no geometry.
+    """
+
+    feature: dict
+    prior_bounds: "Bounds | None"
 
 
 async def _geom_column_is_generic(session: AsyncSession, table_name: str) -> bool:
@@ -967,18 +1011,18 @@ async def replace_feature(
             sets.append(f'"{col_name}" = :{param}')
             params[param] = properties.get(col_name)
 
-    sql = (
-        f"UPDATE {get_catalog_port().quote_table(table_name)} "
-        f"SET {', '.join(sets)} WHERE gid = :gid"
+    sql = _update_capturing_prior_bounds(
+        get_catalog_port().quote_table(table_name), sets
     )
     result = await db.execute(text(sql).bindparams(**params))
-    if result.rowcount == 0:
+    prior = result.first()
+    if prior is None:
         raise ValueError("Feature not found")
 
     row = await get_feature_by_id(db, table_name, gid)
     if row is None:
         raise RuntimeError(f"Feature {gid} not found immediately after replace")
-    return row
+    return FeatureWrite(row, _prior_bounds_from_row(prior))
 
 
 async def update_feature(
@@ -1023,36 +1067,44 @@ async def update_feature(
     if not sets:
         raise ValueError("Nothing to update")
 
-    sql = (
-        f"UPDATE {get_catalog_port().quote_table(table_name)} "
-        f"SET {', '.join(sets)} WHERE gid = :gid"
+    sql = _update_capturing_prior_bounds(
+        get_catalog_port().quote_table(table_name), sets
     )
     result = await db.execute(text(sql).bindparams(**params))
-    if result.rowcount == 0:
+    prior = result.first()
+    if prior is None:
         raise ValueError("Feature not found")
 
     row = await get_feature_by_id(db, table_name, gid)
     if row is None:
         raise RuntimeError(f"Feature {gid} not found immediately after update")
-    return row
+    return FeatureWrite(row, _prior_bounds_from_row(prior))
 
 
 async def delete_feature(
     db: AsyncSession,
     table_name: str,
     gid: int,
-) -> None:
-    """Hard-delete a feature by gid.
+) -> Bounds | None:
+    """Hard-delete a feature by gid, returning the envelope it removed.
+
+    The envelope comes back from the DELETE itself, so it describes the row
+    version this statement actually removed even if another transaction moved
+    the feature first (see _PRIOR_BOUNDS_COLS). None when the deleted row had
+    no geometry.
 
     Raises ValueError if the feature does not exist.
     """
     result = await db.execute(
         text(
-            f"DELETE FROM {get_catalog_port().quote_table(table_name)} WHERE gid = :gid"
+            f"DELETE FROM {get_catalog_port().quote_table(table_name)} "
+            f"WHERE gid = :gid RETURNING {_PRIOR_BOUNDS_COLS}"
         ).bindparams(gid=gid)
     )
-    if result.rowcount == 0:
+    row = result.first()
+    if row is None:
         raise ValueError("Feature not found")
+    return _prior_bounds_from_row(row)
 
 
 async def _refresh_count_and_extent(
@@ -1174,33 +1226,78 @@ def geojson_bounds(geometry: dict | None) -> Bounds | None:
     return (float(minx), float(miny), float(maxx), float(maxy))
 
 
-async def feature_bounds(db: AsyncSession, table_name: str, gid: int) -> Bounds | None:
-    """The stored envelope of one feature, or None when it has no geometry.
+# The envelope of the row version a write is about to overwrite or remove.
+#
+# fix(#1778 review r1): this used to be a separate unlocked SELECT taken before
+# the mutation, which is a read-then-write race: a concurrent edit could move
+# the feature out of the stored extent and commit in the gap, leaving the first
+# writer holding envelope values that were true when it looked and false when
+# it wrote. It would then take the incremental fast path and leave the expanded
+# extent behind. The capture is now part of the mutating statement, so the
+# envelope is always the version that statement actually replaced or deleted.
+_PRIOR_BOUNDS_COLS = (
+    "ST_XMin(geom_4326) AS prior_minx, ST_YMin(geom_4326) AS prior_miny, "
+    "ST_XMax(geom_4326) AS prior_maxx, ST_YMax(geom_4326) AS prior_maxy"
+)
 
-    A primary-key lookup, so callers can afford it on every write to learn
-    whether the row they are about to move or delete could have been defining
-    the dataset's extent.
-    """
-    result = await db.execute(
-        text(
-            f"SELECT ST_XMin(geom_4326), ST_YMin(geom_4326), "
-            f"ST_XMax(geom_4326), ST_YMax(geom_4326) "
-            f"FROM {get_catalog_port().quote_table(table_name)} WHERE gid = :gid"
-        ).bindparams(gid=gid)
+
+def _prior_bounds_from_row(row) -> Bounds | None:
+    """Read the four prior-envelope columns off a RETURNING row."""
+    values = (
+        row.prior_minx,
+        row.prior_miny,
+        row.prior_maxx,
+        row.prior_maxy,
     )
-    row = result.first()
-    if row is None or any(v is None for v in row):
+    if any(v is None for v in values):
         return None
-    return (float(row[0]), float(row[1]), float(row[2]), float(row[3]))
+    return (
+        float(values[0]),
+        float(values[1]),
+        float(values[2]),
+        float(values[3]),
+    )
 
 
-async def _stored_extent_box(session: AsyncSession, dataset: Dataset) -> Bounds | None:
-    """The dataset's stored extent as a box, when reasoning about it is sound.
+def _update_capturing_prior_bounds(quoted_table: str, sets: list[str]) -> str:
+    """UPDATE that returns the envelope of the row version it overwrote.
+
+    The CTE takes ``FOR UPDATE`` on the target row, so a concurrent writer is
+    waited for and the envelope read is the latest committed version rather
+    than whatever a separate earlier statement happened to see. The outer
+    UPDATE joins the locked row by its primary key, and RETURNING reads the
+    prior values out of the CTE, which the UPDATE itself has already
+    overwritten.
+    """
+    return (
+        f"WITH prior AS (SELECT gid, {_PRIOR_BOUNDS_COLS} "
+        f"FROM {quoted_table} WHERE gid = :gid FOR UPDATE) "
+        f"UPDATE {quoted_table} AS t SET {', '.join(sets)} "
+        f"FROM prior WHERE t.gid = prior.gid "
+        f"RETURNING prior.prior_minx, prior.prior_miny, "
+        f"prior.prior_maxx, prior.prior_maxy"
+    )
+
+
+async def _lock_stored_extent_box(
+    session: AsyncSession, dataset: Dataset
+) -> Bounds | None:
+    """The dataset's stored extent as a box, with the record row locked.
 
     None unless the stored extent is a simple POLYGON. An antimeridian-crossing
     dataset stores the two-ring MULTIPOLYGON `seam_extent_wkt_for_table`
     produces (fix(#934)), whose ST_XMin/ST_XMax are -180/180: a longitude in
     the gap would test as inside a box the geometry never occupies.
+
+    fix(#1778 review r1): FOR UPDATE, and taken by BOTH metadata paths before
+    either reads the extent. Otherwise two writers on one dataset can interleave
+    read-decide-write: one skips the recompute because its geometry is inside
+    the extent it read, while the other shrinks that extent from an aggregate
+    taken before the first row landed. Every writer here goes on to update the
+    dataset row anyway, so it already serialized with its peers at commit; the
+    lock only moves that serialization ahead of the decision that depends on it.
+    Both paths take the record row before the dataset row, which is the order
+    the ORM flushes them in.
     """
     from app.modules.catalog.datasets.domain.models import Record
 
@@ -1211,7 +1308,9 @@ async def _stored_extent_box(session: AsyncSession, dataset: Dataset) -> Bounds 
             func.ST_YMin(Record.spatial_extent),
             func.ST_XMax(Record.spatial_extent),
             func.ST_YMax(Record.spatial_extent),
-        ).where(Record.id == dataset.record_id)
+        )
+        .where(Record.id == dataset.record_id)
+        .with_for_update()
     )
     row = result.first()
     if row is None or row[0] != "POLYGON" or any(v is None for v in row[1:]):
@@ -1275,6 +1374,7 @@ async def _apply_incremental_metadata(
     count_delta: int,
     touched_bounds: Sequence[Bounds | None],
     added_geometry_type: str | None,
+    stored_box: Bounds | None,
 ) -> bool:
     """Update feature_count alone when the write provably left the extent alone.
 
@@ -1314,10 +1414,11 @@ async def _apply_incremental_metadata(
         ):
             return False
 
-    box = await _stored_extent_box(session, dataset)
-    if box is None:
+    if stored_box is None:
         return False
-    if not all(_strictly_inside(b, box) for b in touched_bounds if b is not None):
+    if not all(
+        _strictly_inside(b, stored_box) for b in touched_bounds if b is not None
+    ):
         return False
 
     if count_delta:
@@ -1346,12 +1447,18 @@ async def refresh_dataset_metadata(
     and no scan runs at all. Called with no keywords, the full recompute
     behaviour is unchanged.
     """
+    # fix(#1778 review r1): taken before EITHER branch reads the extent, so a
+    # skip decision cannot be invalidated by a concurrent recompute. See
+    # _lock_stored_extent_box.
+    stored_box = await _lock_stored_extent_box(session, dataset)
+
     if count_delta is not None and await _apply_incremental_metadata(
         session,
         dataset,
         count_delta=count_delta,
         touched_bounds=touched_bounds or (),
         added_geometry_type=added_geometry_type,
+        stored_box=stored_box,
     ):
         return
 

--- a/backend/app/modules/catalog/features/service.py
+++ b/backend/app/modules/catalog/features/service.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import math
 import re
 from collections.abc import Callable, Sequence
@@ -395,6 +396,88 @@ async def _property_filter_predicates(
     return clauses, raw_binds, typed_binds
 
 
+# fix(#1778): rows a filtered count will visit before it stops being exact.
+#
+# The cached feature_count fast path applies only to a COMPLETELY unfiltered
+# request, so one bbox, property filter or CQL2 filter put a full filtered
+# COUNT(*) on EVERY page — including keyset pages, whose whole point is
+# constant-time access. Paging 50 pages of a multi-million-row layer cost 50
+# full GiST scans with ST_Intersects rechecks, so the caller saw constant-time
+# row fetch and O(N) latency per page.
+#
+# Counting inside a LIMIT bounds that: the scan stops once the cap is reached,
+# so the per-page cost has a ceiling instead of scaling with the match set. The
+# count stays EXACT up to the cap, which covers any result set a client would
+# actually page through (100 pages at the OGC max page size); past it the
+# planner's own row estimate answers, and the response says so with an
+# X-GeoLens-Number-Matched: estimated header. The estimate is never reported
+# below the rows already counted, so a `next` link driven by
+# `offset + limit < total` cannot truncate pagination at the cap.
+_FILTERED_COUNT_CAP = 20_000
+
+NUMBER_MATCHED_HEADER = "X-GeoLens-Number-Matched"
+
+
+def number_matched_headers(total_is_estimate: bool) -> dict[str, str]:
+    """Response headers saying how ``numberMatched`` was produced.
+
+    OGC API Features defines no response member for "this count is
+    approximate", and the field is not optional in GeoLens's own schemas, so
+    the distinction rides on a header. Callers that display the number, or
+    compare it against the rows they received, need to know which they got.
+    The header is in the CORS expose list, so a browser client can read it.
+    """
+    return {NUMBER_MATCHED_HEADER: "estimated"} if total_is_estimate else {}
+
+
+async def _planner_row_estimate(
+    db: AsyncSession, quoted_table: str, where_sql: str, binds: dict, apply_binds
+) -> int:
+    """The planner's row estimate for the filtered predicate, or 0.
+
+    EXPLAIN without ANALYZE plans the statement and does not run it, so this
+    costs planning time rather than a scan. It is deliberately NOT wrapped in a
+    try/except: it plans the exact predicate the data query just executed
+    successfully, so a failure here is the same class the routers already
+    classify, and swallowing it would leave the session in a failed
+    transaction with the real cause hidden.
+    """
+    result = await db.execute(
+        apply_binds(
+            text(
+                f"EXPLAIN (FORMAT JSON) SELECT 1 FROM {quoted_table} t {where_sql}"
+            ).bindparams(**binds)
+        )
+    )
+    payload = result.scalar_one()
+    if isinstance(payload, (str, bytes)):
+        payload = json.loads(payload)
+    return int(payload[0]["Plan"]["Plan Rows"])
+
+
+async def _bounded_total(
+    db: AsyncSession, table_name: str, where_sql: str, binds: dict, apply_binds
+) -> tuple[int, bool]:
+    """Count the filtered rows, exactly up to `_FILTERED_COUNT_CAP`.
+
+    Returns (total, total_is_estimate).
+    """
+    quoted = get_catalog_port().quote_table(table_name)
+    capped_result = await db.execute(
+        apply_binds(
+            text(
+                f"SELECT COUNT(*) FROM (SELECT 1 FROM {quoted} t {where_sql} "
+                f"LIMIT :count_cap) s"
+            ).bindparams(**binds, count_cap=_FILTERED_COUNT_CAP + 1)
+        )
+    )
+    counted = int(capped_result.scalar_one())
+    if counted <= _FILTERED_COUNT_CAP:
+        return counted, False
+    estimate = await _planner_row_estimate(db, quoted, where_sql, binds, apply_binds)
+    return max(counted, estimate), True
+
+
 async def get_features(
     db: AsyncSession,
     table_name: str,
@@ -410,10 +493,13 @@ async def get_features(
     after_gid: int | None = None,
     cql2_where: str | None = None,
     cql2_binds: Sequence | None = None,
-) -> tuple[list[dict], int]:
+) -> tuple[list[dict], int, bool]:
     """Fetch paginated features from a data table as GeoJSON-ready dicts.
 
-    Returns (rows, total_count) where each row has gid, geometry, and properties.
+    Returns (rows, total_count, total_is_estimate) where each row has gid,
+    geometry, and properties. ``total_is_estimate`` is True when the filtered
+    match set is larger than ``_FILTERED_COUNT_CAP`` and ``total_count`` is the
+    planner's row estimate rather than an exact count (fix(#1778)).
 
     Phase 269 H-24: when ``after_gid`` is provided, uses keyset pagination
     (``WHERE gid > :after_gid``) instead of OFFSET. This avoids the
@@ -540,23 +626,17 @@ async def get_features(
 
     # Use cached feature_count when no filters are active
     if not count_where_clauses and cached_feature_count is not None:
-        total = cached_feature_count
-    else:
-        count_bind = {
-            k: v
-            for k, v in bind_values.items()
-            if k not in ("limit", "offset", "after_gid")
-        }
-        count_sql = (
-            f"SELECT COUNT(*) FROM {get_catalog_port().quote_table(table_name)} "
-            f"t {count_where_sql}"
-        )
-        count_result = await db.execute(
-            _with_extra_binds(text(count_sql).bindparams(**count_bind))
-        )
-        total = count_result.scalar_one()
+        return rows, cached_feature_count, False
 
-    return rows, total
+    count_bind = {
+        k: v
+        for k, v in bind_values.items()
+        if k not in ("limit", "offset", "after_gid")
+    }
+    total, total_is_estimate = await _bounded_total(
+        db, table_name, count_where_sql, count_bind, _with_extra_binds
+    )
+    return rows, total, total_is_estimate
 
 
 async def get_features_geojson_z(

--- a/backend/app/standards/ogc/filtering.py
+++ b/backend/app/standards/ogc/filtering.py
@@ -27,6 +27,7 @@ from typing import Any
 from fastapi import HTTPException, status
 from pydantic import BaseModel, Field
 
+from app.core.db.pg_ranges import check_pg_value_range
 from app.modules.catalog.datasets.domain.models import Dataset, Record
 from app.standards.ogc.utils import build_url
 from app.modules.catalog.search.schemas import OGCRecordResponse
@@ -536,13 +537,14 @@ def _checked_value(value, pg_type: str | None, errors: list[str]):
     if pg_type in _STRING_PG_TYPES:
         ok = isinstance(value, str)
     elif pg_type in _INTEGER_PG_TYPES:
-        # int8 bound: an out-of-range literal would raise inside the driver's
-        # encode path rather than compare (fix(#1614 codex r5)).
-        ok = (
-            isinstance(value, int)
-            and not isinstance(value, bool)
-            and -(2**63) <= value < 2**63
-        )
+        # fix(#1614 codex r5) took the int8 bound, because an out-of-range
+        # literal raises inside the driver's encode path rather than comparing.
+        # fix(#1778 review r2) narrows it to the column's OWN width through the
+        # same table the property-filter path reads: `cat = 2147483648` on an
+        # integer column is a legal int4/int8 comparison that no stored value
+        # can satisfy, so it answered 200 with zero features instead of saying
+        # the literal was out of range.
+        ok = isinstance(value, int) and not isinstance(value, bool)
     elif pg_type in _NUMBER_PG_TYPES:
         # Python's JSON decoder accepts NaN/Infinity tokens; `height <
         # Infinity` would otherwise match every finite row instead of being
@@ -560,6 +562,11 @@ def _checked_value(value, pg_type: str | None, errors: list[str]):
         errors.append(
             f"literal {value!r} does not match the property's {pg_type!r} type"
         )
+        return value
+    try:
+        check_pg_value_range(pg_type, value)
+    except ValueError as exc:
+        errors.append(f"literal {value!r} {exc}")
     return value
 
 

--- a/backend/app/standards/ogc/router.py
+++ b/backend/app/standards/ogc/router.py
@@ -26,6 +26,7 @@ from app.modules.catalog.features.service import (
     get_feature_by_id,
     get_feature_queryable_columns,
     get_features,
+    number_matched_headers,
     parse_bbox,
 )
 from app.platform.extensions import (
@@ -814,7 +815,7 @@ async def get_collection_items(
         # fix(#430 BA-15): over-fetch one row so a full page can be distinguished from
         # a full *final* page; otherwise a feature count that is an exact multiple
         # of `limit` emits a phantom keyset `next` to an empty page.
-        rows, total = await get_features(
+        rows, total, total_is_estimate = await get_features(
             db,
             dataset.table_name,
             limit=limit + 1,
@@ -980,7 +981,10 @@ async def get_collection_items(
     if dataset.table_name:
         await _emit_ogc_usage_event(dataset.table_name)
 
-    headers = {"Content-Crs": "<http://www.opengis.net/def/crs/OGC/1.3/CRS84>"}
+    headers = {
+        "Content-Crs": "<http://www.opengis.net/def/crs/OGC/1.3/CRS84>",
+        **number_matched_headers(total_is_estimate),
+    }
     if link_value := link_header_value(links):
         headers["Link"] = link_value
     return JSONResponse(

--- a/backend/app/standards/ogc/router.py
+++ b/backend/app/standards/ogc/router.py
@@ -5,12 +5,13 @@ import structlog
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response, status
 from fastapi.responses import JSONResponse
 from sqlalchemy import select
-from sqlalchemy.exc import DataError, OperationalError, ProgrammingError
+from sqlalchemy.exc import DBAPIError, OperationalError, ProgrammingError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.config import settings
 from app.core.record_types import RASTER_FAMILY_RECORD_TYPES
 from app.core.db.tenant_session import current_tenant_var
+from app.core.db.sqlstate import is_caller_type_fault
 from app.core.dependencies import get_db
 from app.core.geo import extent_to_bbox
 from app.core.identity import Identity
@@ -82,15 +83,6 @@ COLD_WARMING_RESPONSE: dict = {
 # table": undefined operator/function, datatype mismatch, cannot coerce,
 # indeterminate datatype. Deliberately NOT the whole 42 class — 42P01 is the
 # missing-table 503 and e.g. 42501 (privilege) is an operator problem.
-_TYPE_FAULT_SQLSTATES = {"42883", "42804", "42846", "42P18"}
-
-
-def _pg_sqlstate(exc: Exception) -> str | None:
-    """SQLSTATE from a SQLAlchemy-wrapped asyncpg error, if present."""
-    orig = getattr(exc, "orig", None)
-    return getattr(orig, "sqlstate", None) or getattr(orig, "pgcode", None)
-
-
 async def _emit_ogc_usage_event(table_name: str) -> None:
     """Emit an OGC-serve usage event through the billing-import-free seam (METER-03).
 
@@ -839,7 +831,7 @@ async def get_collection_items(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=str(exc),
         )
-    except (ProgrammingError, OperationalError, DataError) as exc:
+    except DBAPIError as exc:
         # feat(#1614): with a filter active, a type-shaped database error is
         # the filter itself — e.g. a property-property comparison between
         # incomparable types that pre-validation lets through. Report those
@@ -853,14 +845,14 @@ async def get_collection_items(
         # predicate too. Gating this branch on `cql2_where is not None` alone
         # reported every type-shaped property-filter failure as a retryable
         # 503, so clients retried forever against what is a query-shape bug.
-        sqlstate = _pg_sqlstate(exc) or ""
+        #
+        # fix(#1778 review r2): the classification moved to
+        # `is_caller_type_fault`, which the native features list now reads too;
+        # the two had drifted. The catch widened to DBAPIError for the same
+        # reason it did there: asyncpg reports a value it cannot encode as a
+        # bare DBAPIError with SQLSTATE 22000, which no subclass here matched.
         caller_predicate = cql2_where is not None or bool(property_filters)
-        filter_fault = caller_predicate and (
-            sqlstate.startswith("22")
-            or sqlstate in _TYPE_FAULT_SQLSTATES
-            or (isinstance(exc, DataError) and not sqlstate)
-        )
-        if filter_fault:
+        if caller_predicate and is_caller_type_fault(exc):
             source = "CQL2 filter" if cql2_where is not None else "Property filter"
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
@@ -869,12 +861,12 @@ async def get_collection_items(
                     "property types"
                 ),
             )
-        if isinstance(exc, DataError):
-            raise
-        raise HTTPException(
-            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-            detail="Dataset table is temporarily unavailable",
-        )
+        if isinstance(exc, (ProgrammingError, OperationalError)):
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail="Dataset table is temporarily unavailable",
+            )
+        raise
 
     # Convert rows to GeoJSON features
     features = []

--- a/backend/app/standards/ogc/router.py
+++ b/backend/app/standards/ogc/router.py
@@ -829,6 +829,13 @@ async def get_collection_items(
             cql2_where=cql2_where,
             cql2_binds=cql2_binds,
         )
+    except ValueError as exc:
+        # fix(#1778): an unparseable property-filter value is rejected before
+        # the query runs, naming the property.
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(exc),
+        )
     except (ProgrammingError, OperationalError, DataError) as exc:
         # feat(#1614): with a filter active, a type-shaped database error is
         # the filter itself — e.g. a property-property comparison between
@@ -839,17 +846,23 @@ async def get_collection_items(
         # client-side bind DataErrors. Everything else (dropped connection,
         # cancellation, missing table) keeps the retryable 503 so monitoring
         # and clients classify outages correctly.
+        # fix(#1778): the property-filter extension is a caller-supplied
+        # predicate too. Gating this branch on `cql2_where is not None` alone
+        # reported every type-shaped property-filter failure as a retryable
+        # 503, so clients retried forever against what is a query-shape bug.
         sqlstate = _pg_sqlstate(exc) or ""
-        filter_fault = cql2_where is not None and (
+        caller_predicate = cql2_where is not None or bool(property_filters)
+        filter_fault = caller_predicate and (
             sqlstate.startswith("22")
             or sqlstate in _TYPE_FAULT_SQLSTATES
             or (isinstance(exc, DataError) and not sqlstate)
         )
         if filter_fault:
+            source = "CQL2 filter" if cql2_where is not None else "Property filter"
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail=(
-                    "CQL2 filter is not evaluable against this collection's "
+                    f"{source} is not evaluable against this collection's "
                     "property types"
                 ),
             )

--- a/backend/app/standards/ogc/router.py
+++ b/backend/app/standards/ogc/router.py
@@ -812,13 +812,15 @@ async def get_collection_items(
         cql2_where, cql2_binds = compile_feature_cql2_ast(filter_ast, queryables)
 
     try:
-        # fix(#430 BA-15): over-fetch one row so a full page can be distinguished from
-        # a full *final* page; otherwise a feature count that is an exact multiple
-        # of `limit` emits a phantom keyset `next` to an empty page.
-        rows, total, total_is_estimate = await get_features(
+        # fix(#430 BA-15): a full page must be distinguishable from a full
+        # *final* page, or a feature count that is an exact multiple of `limit`
+        # emits a phantom keyset `next` to an empty page. fix(#1778 review r1):
+        # the over-fetch that answers it moved into get_features, which reports
+        # it as `has_more`, so every caller gets the same answer.
+        page = await get_features(
             db,
             dataset.table_name,
-            limit=limit + 1,
+            limit=limit,
             offset=offset,
             after_gid=after_gid,
             bbox=bbox_parsed,
@@ -874,12 +876,9 @@ async def get_collection_items(
             detail="Dataset table is temporarily unavailable",
         )
 
-    has_more = len(rows) > limit
-    rows = rows[:limit]
-
     # Convert rows to GeoJSON features
     features = []
-    for row in rows:
+    for row in page.rows:
         features.append(
             {
                 "type": "Feature",
@@ -942,8 +941,8 @@ async def get_collection_items(
     # H-24: emit a keyset `next` link when more rows exist — primary path.
     # Fall back to offset-based `next`/`prev` for legacy clients only when
     # the request itself used offset.
-    if rows and has_more:
-        next_after_gid = rows[-1]["gid"]
+    if page.rows and page.has_more:
+        next_after_gid = page.rows[-1]["gid"]
         links.append(
             OGCLink(
                 rel="next",
@@ -951,7 +950,10 @@ async def get_collection_items(
                 type="application/geo+json",
             )
         )
-    elif after_gid is None and offset + limit < total:
+    elif after_gid is None and page.has_more:
+        # fix(#1778 review r1): was `offset + limit < total`. numberMatched may
+        # be the planner's estimate, and an estimate at or below the rows
+        # already served would have dropped the link mid-result-set.
         links.append(
             OGCLink(
                 rel="next",
@@ -969,7 +971,7 @@ async def get_collection_items(
         )
 
     response_data = OGCFeatureItemsResponse(
-        numberMatched=total,
+        numberMatched=page.total,
         numberReturned=len(features),
         features=features,
         links=links,
@@ -983,7 +985,7 @@ async def get_collection_items(
 
     headers = {
         "Content-Crs": "<http://www.opengis.net/def/crs/OGC/1.3/CRS84>",
-        **number_matched_headers(total_is_estimate),
+        **number_matched_headers(page.total_is_estimate),
     }
     if link_value := link_header_value(links):
         headers["Link"] = link_value

--- a/backend/tests/test_dataset_rows_reserved_columns.py
+++ b/backend/tests/test_dataset_rows_reserved_columns.py
@@ -1,0 +1,103 @@
+"""fix(#1778): the row browser must survive a column named after a SQL keyword.
+
+``get_dataset_rows`` interpolated column identifiers bare, so ``SELECT gid, desc
+FROM data.x`` was a PostgreSQL syntax error (42601). 42601 is in none of the
+sqlstate sets ``get_dataset_rows`` degrades on, so the endpoint 5xx'd for that
+dataset permanently -- for anonymous callers on a public dataset too. Nothing
+renames SQL keywords on ingest: ``rename_reserved_columns`` only touches
+gid/geom/geometry/geom_4326/fid/ogc_fid, and ``desc``/``order``/``user`` are
+routine ogr2ogr output from DBF fields.
+
+The same dataset reads fine through /features, which quotes its identifiers,
+so before this fix the failure looked like data corruption rather than quoting.
+
+Requires the Docker test database.
+"""
+
+import uuid
+
+import pytest
+from sqlalchemy import text
+
+from app.modules.catalog.datasets.domain.service import get_dataset_rows
+
+pytestmark = pytest.mark.anyio
+
+# Every one of these is a reserved word in PostgreSQL and every one survives
+# ogr2ogr's DBF laundering as a plain lowercase identifier.
+RESERVED_COLUMNS = ["desc", "order", "user", "group", "end", "to"]
+
+
+async def _make_table(session) -> str:
+    table = f"rows_1778_{uuid.uuid4().hex[:10]}"
+    cols = ", ".join(f'"{name}" text' for name in RESERVED_COLUMNS)
+    await session.execute(
+        text(
+            f"CREATE TABLE data.{table} ("
+            "gid serial PRIMARY KEY, geom_4326 geometry(Point, 4326), "
+            f"{cols})"
+        )
+    )
+    values = ", ".join(f":v{i}" for i in range(len(RESERVED_COLUMNS)))
+    quoted = ", ".join(f'"{name}"' for name in RESERVED_COLUMNS)
+    await session.execute(
+        text(
+            f"INSERT INTO data.{table} (geom_4326, {quoted}) VALUES "
+            f"(ST_SetSRID(ST_MakePoint(1, 2), 4326), {values})"
+        ).bindparams(
+            **{f"v{i}": f"value-{name}" for i, name in enumerate(RESERVED_COLUMNS)}
+        )
+    )
+    await session.commit()
+    return table
+
+
+def _column_info() -> list[dict]:
+    return [
+        {"name": "gid", "type": "integer", "ordinal_position": 1},
+        {"name": "geom_4326", "type": "USER-DEFINED", "ordinal_position": 2},
+        *(
+            {"name": name, "type": "text", "ordinal_position": i}
+            for i, name in enumerate(RESERVED_COLUMNS, start=3)
+        ),
+    ]
+
+
+async def test_reserved_word_columns_are_projected(test_db_session) -> None:
+    """The page renders instead of raising a 42601 syntax error."""
+    table = await _make_table(test_db_session)
+    try:
+        rows, _total, _cols, _cursor = await get_dataset_rows(
+            test_db_session, table, column_info=_column_info()
+        )
+    finally:
+        await test_db_session.execute(text(f"DROP TABLE IF EXISTS data.{table}"))
+        await test_db_session.commit()
+
+    assert len(rows) == 1
+    for name in RESERVED_COLUMNS:
+        assert rows[0][name] == f"value-{name}"
+
+
+async def test_reserved_word_column_filter_matches(test_db_session) -> None:
+    """`filter[desc]=...` composes into the ILIKE clause without a syntax error."""
+    table = await _make_table(test_db_session)
+    try:
+        matched, _total, _cols, _cursor = await get_dataset_rows(
+            test_db_session,
+            table,
+            column_info=_column_info(),
+            filters={"desc": "value-desc"},
+        )
+        missed, _total, _cols, _cursor = await get_dataset_rows(
+            test_db_session,
+            table,
+            column_info=_column_info(),
+            filters={"desc": "no-such-value"},
+        )
+    finally:
+        await test_db_session.execute(text(f"DROP TABLE IF EXISTS data.{table}"))
+        await test_db_session.commit()
+
+    assert len(matched) == 1
+    assert missed == []

--- a/backend/tests/test_export_antimeridian.py
+++ b/backend/tests/test_export_antimeridian.py
@@ -316,13 +316,13 @@ class TestAntimeridianExportEndToEnd:
         from app.modules.catalog.features.service import get_features
         from app.processing.export.parquet import export_parquet
 
-        rows, _total, _estimated = await get_features(
+        page = await get_features(
             test_db_session,
             antimeridian_table,
             limit=100,
             bbox=CROSSING_BBOX,
         )
-        features_names = sorted(r["properties"]["name"] for r in rows)
+        features_names = sorted(r["properties"]["name"] for r in page.rows)
 
         # fix(#1513): planning (introspection + filter validation + the bounded
         # count) is a separate phase from writing, so the route can decide a

--- a/backend/tests/test_export_antimeridian.py
+++ b/backend/tests/test_export_antimeridian.py
@@ -316,7 +316,7 @@ class TestAntimeridianExportEndToEnd:
         from app.modules.catalog.features.service import get_features
         from app.processing.export.parquet import export_parquet
 
-        rows, _total = await get_features(
+        rows, _total, _estimated = await get_features(
             test_db_session,
             antimeridian_table,
             limit=100,

--- a/backend/tests/test_features_bounded_count.py
+++ b/backend/tests/test_features_bounded_count.py
@@ -31,7 +31,9 @@ pytestmark = pytest.mark.anyio
 ROW_COUNT = 30
 
 
-async def _create_dataset(session, *, created_by: uuid.UUID) -> Dataset:
+async def _create_dataset(
+    session, *, created_by: uuid.UUID, rows: int = ROW_COUNT
+) -> Dataset:
     table_name = f"test_bc_{uuid.uuid4().hex[:8]}"
     await session.execute(
         text(
@@ -43,7 +45,7 @@ async def _create_dataset(session, *, created_by: uuid.UUID) -> Dataset:
         )
     )
     await session.execute(text(f"GRANT SELECT ON data.{table_name} TO geolens_reader"))
-    for i in range(ROW_COUNT):
+    for i in range(rows):
         await session.execute(
             text(
                 f"INSERT INTO data.{table_name} (geom, geom_4326, era) VALUES ("
@@ -69,7 +71,7 @@ async def _create_dataset(session, *, created_by: uuid.UUID) -> Dataset:
         table_name=table_name,
         srid=4326,
         geometry_type="POINT",
-        feature_count=ROW_COUNT,
+        feature_count=rows,
         column_info=[{"name": "era", "type": "text"}],
         source_format="created",
     )
@@ -363,3 +365,136 @@ async def test_the_ogc_items_page_links_on_at_the_cap_boundary(
     assert data["numberReturned"] == 200
     assert [li for li in data["links"] if li["rel"] == "next"]
     assert data["numberMatched"] >= 20_200
+
+
+# ---------------------------------------------------------------------------
+# fix(#1778 review r3): the floor may only count rows that exist.
+# ---------------------------------------------------------------------------
+
+SMALL_ROW_COUNT = 5
+
+
+@pytest.fixture
+async def small_dataset(client: AsyncClient, test_db_session):
+    """Five matching rows, so an offset of 100 lands well past the end."""
+    admin_id = await get_user_id(test_db_session, "admin")
+    dataset = await _create_dataset(
+        test_db_session, created_by=admin_id, rows=SMALL_ROW_COUNT
+    )
+    yield dataset
+    await test_db_session.execute(
+        text(f"DROP TABLE IF EXISTS data.{dataset.table_name}")
+    )
+    await test_db_session.commit()
+
+
+async def test_native_offset_past_the_end_reports_the_true_total(
+    client: AsyncClient, small_dataset: Dataset, admin_auth_header
+):
+    """An empty page proves nothing, so it must not raise the count."""
+    resp = await client.get(
+        f"/datasets/{small_dataset.id}/features/",
+        params={"era": "Art Deco", "offset": 100, "limit": 10},
+        headers=admin_auth_header,
+    )
+
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["numberReturned"] == 0
+    assert data["numberMatched"] == SMALL_ROW_COUNT
+    assert not [li for li in data["links"] if li["rel"] == "next"]
+
+
+async def test_ogc_offset_past_the_end_reports_the_true_total(
+    client: AsyncClient, small_dataset: Dataset
+):
+    resp = await client.get(
+        f"/collections/{small_dataset.id}/items",
+        params={"era": "Art Deco", "offset": 100, "limit": 10},
+    )
+
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["numberReturned"] == 0
+    assert data["numberMatched"] == SMALL_ROW_COUNT
+    assert not [li for li in data["links"] if li["rel"] == "next"]
+
+
+async def test_a_keyset_page_reports_the_true_total_and_ignores_offset(
+    client: AsyncClient, counted_dataset: Dataset, test_db_session
+):
+    """The query ignores `offset` under after_gid, so the floor must too."""
+    first_gid = (
+        await test_db_session.execute(
+            text(f"SELECT MIN(gid) FROM data.{counted_dataset.table_name}")
+        )
+    ).scalar_one()
+
+    resp = await client.get(
+        f"/collections/{counted_dataset.id}/items",
+        params={
+            "era": "Art Deco",
+            "after_gid": first_gid,
+            "offset": 100,
+            "limit": 10,
+        },
+    )
+
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["numberReturned"] == 10
+    assert data["numberMatched"] == ROW_COUNT
+
+
+async def test_an_exact_count_is_never_raised(small_dataset: Dataset, test_db_session):
+    """A full page of an exact count stays at the count, not count + 1."""
+    page = await features_service.get_features(
+        test_db_session,
+        small_dataset.table_name,
+        limit=2,
+        property_filters={"era": "Art Deco"},
+        allowed_columns={"era"},
+        cached_feature_count=SMALL_ROW_COUNT,
+    )
+
+    assert len(page.rows) == 2
+    assert page.has_more is True
+    assert page.total_is_estimate is False
+    assert page.total == SMALL_ROW_COUNT
+
+
+async def test_an_estimated_full_page_still_floors_to_offset_plus_rows(
+    deep_dataset: Dataset, test_db_session, estimate_forced_low
+):
+    """The r1 property the r3 narrowing must not have thrown away."""
+    page = await features_service.get_features(
+        test_db_session,
+        deep_dataset.table_name,
+        limit=200,
+        offset=20_000,
+        property_filters={"era": "Art Deco"},
+        allowed_columns={"era"},
+        cached_feature_count=DEEP_ROW_COUNT,
+    )
+
+    assert page.total_is_estimate is True
+    assert page.has_more is True
+    assert page.total == 20_000 + 200 + 1
+
+
+async def test_an_estimated_empty_page_is_not_floored(
+    deep_dataset: Dataset, test_db_session, estimate_forced_low
+):
+    """Past the end, even an estimate has no rows to prove anything with."""
+    page = await features_service.get_features(
+        test_db_session,
+        deep_dataset.table_name,
+        limit=200,
+        offset=DEEP_ROW_COUNT + 1_000,
+        property_filters={"era": "Art Deco"},
+        allowed_columns={"era"},
+        cached_feature_count=DEEP_ROW_COUNT,
+    )
+
+    assert page.rows == []
+    assert page.total < DEEP_ROW_COUNT + 1_000

--- a/backend/tests/test_features_bounded_count.py
+++ b/backend/tests/test_features_bounded_count.py
@@ -93,7 +93,7 @@ async def counted_dataset(client: AsyncClient, test_db_session):
 async def test_a_filtered_count_below_the_cap_is_exact(
     counted_dataset: Dataset, test_db_session
 ):
-    rows, total, estimated = await features_service.get_features(
+    page = await features_service.get_features(
         test_db_session,
         counted_dataset.table_name,
         limit=5,
@@ -102,9 +102,9 @@ async def test_a_filtered_count_below_the_cap_is_exact(
         cached_feature_count=ROW_COUNT,
     )
 
-    assert len(rows) == 5
-    assert total == ROW_COUNT
-    assert estimated is False
+    assert len(page.rows) == 5
+    assert page.total == ROW_COUNT
+    assert page.total_is_estimate is False
 
 
 async def test_a_filtered_count_above_the_cap_stops_and_estimates(
@@ -113,7 +113,7 @@ async def test_a_filtered_count_above_the_cap_stops_and_estimates(
     """Past the cap the scan stops and the planner answers instead."""
     monkeypatch.setattr(features_service, "_FILTERED_COUNT_CAP", 5)
 
-    _rows, total, estimated = await features_service.get_features(
+    page = await features_service.get_features(
         test_db_session,
         counted_dataset.table_name,
         limit=2,
@@ -122,10 +122,10 @@ async def test_a_filtered_count_above_the_cap_stops_and_estimates(
         cached_feature_count=ROW_COUNT,
     )
 
-    assert estimated is True
+    assert page.total_is_estimate is True
     # Never below the rows already counted, so `offset + limit < total`
     # pagination cannot truncate at the cap.
-    assert total > 5
+    assert page.total > 5
 
 
 async def test_the_unfiltered_page_still_uses_the_cached_count(
@@ -134,22 +134,22 @@ async def test_the_unfiltered_page_still_uses_the_cached_count(
     """The fast path is untouched: no filter, no count query, never an estimate."""
     monkeypatch.setattr(features_service, "_FILTERED_COUNT_CAP", 1)
 
-    _rows, total, estimated = await features_service.get_features(
+    page = await features_service.get_features(
         test_db_session,
         counted_dataset.table_name,
         limit=2,
         cached_feature_count=ROW_COUNT,
     )
 
-    assert total == ROW_COUNT
-    assert estimated is False
+    assert page.total == ROW_COUNT
+    assert page.total_is_estimate is False
 
 
 async def test_the_keyset_cursor_is_still_excluded_from_the_count(
     counted_dataset: Dataset, test_db_session
 ):
     """The total is the whole match set, not the rows after the cursor."""
-    _rows, total, estimated = await features_service.get_features(
+    page = await features_service.get_features(
         test_db_session,
         counted_dataset.table_name,
         limit=5,
@@ -159,8 +159,8 @@ async def test_the_keyset_cursor_is_still_excluded_from_the_count(
         cached_feature_count=ROW_COUNT,
     )
 
-    assert total == ROW_COUNT
-    assert estimated is False
+    assert page.total == ROW_COUNT
+    assert page.total_is_estimate is False
 
 
 async def test_an_exact_page_carries_no_estimate_header(
@@ -204,3 +204,162 @@ async def test_the_estimate_header_is_readable_cross_origin(
     }
     assert "content-crs" in exposed, "the anonymous standards policy did not apply"
     assert "x-geolens-number-matched" in exposed
+
+
+# ---------------------------------------------------------------------------
+# fix(#1778 review r1): pagination must not depend on the estimated total.
+# ---------------------------------------------------------------------------
+
+DEEP_ROW_COUNT = 20_300
+
+
+async def _create_deep_dataset(session, *, created_by: uuid.UUID) -> Dataset:
+    """A layer with more matching rows than the exact-count cap."""
+    table_name = f"test_dp_{uuid.uuid4().hex[:8]}"
+    await session.execute(
+        text(
+            f"CREATE TABLE data.{table_name} ("
+            "gid SERIAL PRIMARY KEY, "
+            "geom geometry(Point, 4326), "
+            "geom_4326 geometry(Point, 4326), "
+            "era TEXT)"
+        )
+    )
+    await session.execute(text(f"GRANT SELECT ON data.{table_name} TO geolens_reader"))
+    await session.execute(
+        text(
+            f"INSERT INTO data.{table_name} (geom, geom_4326, era) "
+            "SELECT ST_SetSRID(ST_MakePoint(-74.0, 40.0 + i / 1000000.0), 4326), "
+            "       ST_SetSRID(ST_MakePoint(-74.0, 40.0 + i / 1000000.0), 4326), "
+            "       'Art Deco' "
+            "FROM generate_series(1, :n) AS i"
+        ).bindparams(n=DEEP_ROW_COUNT)
+    )
+
+    record = Record(
+        title=f"Deep paging {table_name}",
+        summary="More matches than the exact-count cap",
+        theme_category=["test"],
+        visibility="public",
+        record_status="published",
+        created_by=created_by,
+    )
+    session.add(record)
+    await session.flush()
+    dataset = Dataset(
+        record_id=record.id,
+        table_name=table_name,
+        srid=4326,
+        geometry_type="POINT",
+        feature_count=DEEP_ROW_COUNT,
+        column_info=[{"name": "era", "type": "text"}],
+        source_format="created",
+    )
+    session.add(dataset)
+    await session.commit()
+    await session.refresh(dataset)
+    return dataset
+
+
+@pytest.fixture
+async def deep_dataset(client: AsyncClient, test_db_session):
+    admin_id = await get_user_id(test_db_session, "admin")
+    dataset = await _create_deep_dataset(test_db_session, created_by=admin_id)
+    yield dataset
+    await test_db_session.execute(
+        text(f"DROP TABLE IF EXISTS data.{dataset.table_name}")
+    )
+    await test_db_session.commit()
+
+
+@pytest.fixture
+def estimate_forced_low(monkeypatch):
+    """Make the planner estimate useless, the way a stale ANALYZE would."""
+
+    async def _low(*_args, **_kwargs):
+        return 0
+
+    monkeypatch.setattr(features_service, "_planner_row_estimate", _low)
+
+
+async def test_a_low_estimate_does_not_strand_a_full_page(
+    client: AsyncClient,
+    deep_dataset: Dataset,
+    admin_auth_header,
+    estimate_forced_low,
+):
+    """The page at the cap boundary still links to the rest of the result set.
+
+    With the count capped at 20000 and the estimate forced low, `total` lands at
+    20001. A `next` link decided by `offset + limit < total` reads
+    20200 < 20001 as false and disappears with a full page on screen and 100
+    rows still to come.
+    """
+    resp = await client.get(
+        f"/datasets/{deep_dataset.id}/features/",
+        params={"era": "Art Deco", "offset": 20_000, "limit": 200},
+        headers=admin_auth_header,
+    )
+
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["numberReturned"] == 200
+    next_link = next((li for li in data["links"] if li["rel"] == "next"), None)
+    assert next_link is not None, "a full page with rows remaining must link on"
+    assert "offset=20200" in next_link["href"]
+    # numberMatched may be an estimate, but it may never contradict the rows
+    # already served beside it.
+    assert data["numberMatched"] >= 20_200
+
+
+async def test_the_last_page_emits_no_next_link(
+    client: AsyncClient,
+    deep_dataset: Dataset,
+    admin_auth_header,
+    estimate_forced_low,
+):
+    resp = await client.get(
+        f"/datasets/{deep_dataset.id}/features/",
+        params={"era": "Art Deco", "offset": 20_200, "limit": 200},
+        headers=admin_auth_header,
+    )
+
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["numberReturned"] == DEEP_ROW_COUNT - 20_200
+    assert not [li for li in data["links"] if li["rel"] == "next"]
+
+
+async def test_has_more_is_measured_from_the_rows_not_the_total(
+    deep_dataset: Dataset, test_db_session, estimate_forced_low
+):
+    """The mechanism, separate from the link it feeds."""
+    page = await features_service.get_features(
+        test_db_session,
+        deep_dataset.table_name,
+        limit=200,
+        offset=20_000,
+        property_filters={"era": "Art Deco"},
+        allowed_columns={"era"},
+        cached_feature_count=DEEP_ROW_COUNT,
+    )
+
+    assert len(page.rows) == 200
+    assert page.has_more is True
+    assert page.total_is_estimate is True
+
+
+async def test_the_ogc_items_page_links_on_at_the_cap_boundary(
+    client: AsyncClient, deep_dataset: Dataset, estimate_forced_low
+):
+    """The OGC handler reads the same has_more rather than re-deriving one."""
+    resp = await client.get(
+        f"/collections/{deep_dataset.id}/items",
+        params={"era": "Art Deco", "offset": 20_000, "limit": 200},
+    )
+
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["numberReturned"] == 200
+    assert [li for li in data["links"] if li["rel"] == "next"]
+    assert data["numberMatched"] >= 20_200

--- a/backend/tests/test_features_bounded_count.py
+++ b/backend/tests/test_features_bounded_count.py
@@ -1,0 +1,206 @@
+"""fix(#1778): a filtered feature page must not pay a full COUNT(*) every time.
+
+`get_features` only reached its cached-feature_count fast path on a completely
+unfiltered request, and it deliberately strips the keyset cursor from the count
+so the total reflects the whole match set. One bbox or property filter
+therefore put a full filtered COUNT(*) on EVERY page, including the keyset
+pages whose entire purpose is constant-time access: 50 pages cost 50 full
+scans, and the OGC caller saw constant-time row fetch with O(N) latency per
+page.
+
+The count now runs inside a LIMIT, so it is exact up to `_FILTERED_COUNT_CAP`
+and bounded past it, where the planner's row estimate answers instead and the
+response carries `X-GeoLens-Number-Matched: estimated`.
+
+Requires the Docker test database.
+"""
+
+import uuid
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import text
+
+from app.modules.catalog.features import service as features_service
+from app.modules.catalog.datasets.domain.models import Dataset, Record
+
+from tests.factories import get_user_id
+
+pytestmark = pytest.mark.anyio
+
+ROW_COUNT = 30
+
+
+async def _create_dataset(session, *, created_by: uuid.UUID) -> Dataset:
+    table_name = f"test_bc_{uuid.uuid4().hex[:8]}"
+    await session.execute(
+        text(
+            f"CREATE TABLE data.{table_name} ("
+            "gid SERIAL PRIMARY KEY, "
+            "geom geometry(Point, 4326), "
+            "geom_4326 geometry(Point, 4326), "
+            "era TEXT)"
+        )
+    )
+    await session.execute(text(f"GRANT SELECT ON data.{table_name} TO geolens_reader"))
+    for i in range(ROW_COUNT):
+        await session.execute(
+            text(
+                f"INSERT INTO data.{table_name} (geom, geom_4326, era) VALUES ("
+                "ST_SetSRID(ST_MakePoint(-74.0, :lat), 4326), "
+                "ST_SetSRID(ST_MakePoint(-74.0, :lat), 4326), 'Art Deco')"
+            ).bindparams(lat=40.0 + i / 1000.0)
+        )
+    # So the planner has real statistics to estimate from.
+    await session.execute(text(f"ANALYZE data.{table_name}"))
+
+    record = Record(
+        title=f"Bounded count {table_name}",
+        summary="Bounded filtered counts",
+        theme_category=["test"],
+        visibility="public",
+        record_status="published",
+        created_by=created_by,
+    )
+    session.add(record)
+    await session.flush()
+    dataset = Dataset(
+        record_id=record.id,
+        table_name=table_name,
+        srid=4326,
+        geometry_type="POINT",
+        feature_count=ROW_COUNT,
+        column_info=[{"name": "era", "type": "text"}],
+        source_format="created",
+    )
+    session.add(dataset)
+    await session.commit()
+    await session.refresh(dataset)
+    return dataset
+
+
+@pytest.fixture
+async def counted_dataset(client: AsyncClient, test_db_session):
+    admin_id = await get_user_id(test_db_session, "admin")
+    dataset = await _create_dataset(test_db_session, created_by=admin_id)
+    yield dataset
+    await test_db_session.execute(
+        text(f"DROP TABLE IF EXISTS data.{dataset.table_name}")
+    )
+    await test_db_session.commit()
+
+
+async def test_a_filtered_count_below_the_cap_is_exact(
+    counted_dataset: Dataset, test_db_session
+):
+    rows, total, estimated = await features_service.get_features(
+        test_db_session,
+        counted_dataset.table_name,
+        limit=5,
+        property_filters={"era": "Art Deco"},
+        allowed_columns={"era"},
+        cached_feature_count=ROW_COUNT,
+    )
+
+    assert len(rows) == 5
+    assert total == ROW_COUNT
+    assert estimated is False
+
+
+async def test_a_filtered_count_above_the_cap_stops_and_estimates(
+    counted_dataset: Dataset, test_db_session, monkeypatch
+):
+    """Past the cap the scan stops and the planner answers instead."""
+    monkeypatch.setattr(features_service, "_FILTERED_COUNT_CAP", 5)
+
+    _rows, total, estimated = await features_service.get_features(
+        test_db_session,
+        counted_dataset.table_name,
+        limit=2,
+        property_filters={"era": "Art Deco"},
+        allowed_columns={"era"},
+        cached_feature_count=ROW_COUNT,
+    )
+
+    assert estimated is True
+    # Never below the rows already counted, so `offset + limit < total`
+    # pagination cannot truncate at the cap.
+    assert total > 5
+
+
+async def test_the_unfiltered_page_still_uses_the_cached_count(
+    counted_dataset: Dataset, test_db_session, monkeypatch
+):
+    """The fast path is untouched: no filter, no count query, never an estimate."""
+    monkeypatch.setattr(features_service, "_FILTERED_COUNT_CAP", 1)
+
+    _rows, total, estimated = await features_service.get_features(
+        test_db_session,
+        counted_dataset.table_name,
+        limit=2,
+        cached_feature_count=ROW_COUNT,
+    )
+
+    assert total == ROW_COUNT
+    assert estimated is False
+
+
+async def test_the_keyset_cursor_is_still_excluded_from_the_count(
+    counted_dataset: Dataset, test_db_session
+):
+    """The total is the whole match set, not the rows after the cursor."""
+    _rows, total, estimated = await features_service.get_features(
+        test_db_session,
+        counted_dataset.table_name,
+        limit=5,
+        after_gid=10,
+        property_filters={"era": "Art Deco"},
+        allowed_columns={"era"},
+        cached_feature_count=ROW_COUNT,
+    )
+
+    assert total == ROW_COUNT
+    assert estimated is False
+
+
+async def test_an_exact_page_carries_no_estimate_header(
+    client: AsyncClient, counted_dataset: Dataset
+):
+    resp = await client.get(
+        f"/collections/{counted_dataset.id}/items", params={"era": "Art Deco"}
+    )
+
+    assert resp.status_code == 200
+    assert resp.json()["numberMatched"] == ROW_COUNT
+    assert "x-geolens-number-matched" not in resp.headers
+
+
+async def test_an_estimated_page_says_so_in_a_header(
+    client: AsyncClient, counted_dataset: Dataset, monkeypatch
+):
+    monkeypatch.setattr(features_service, "_FILTERED_COUNT_CAP", 5)
+
+    resp = await client.get(
+        f"/collections/{counted_dataset.id}/items", params={"era": "Art Deco"}
+    )
+
+    assert resp.status_code == 200
+    assert resp.headers["x-geolens-number-matched"] == "estimated"
+    assert resp.json()["numberMatched"] > 5
+
+
+async def test_the_estimate_header_is_readable_cross_origin(
+    client: AsyncClient, counted_dataset: Dataset
+):
+    """A response header outside Fetch's safelist is invisible, not merely undocumented."""
+    resp = await client.get(
+        f"/collections/{counted_dataset.id}/items",
+        headers={"Origin": "https://example.invalid"},
+    )
+
+    exposed = {
+        name.strip().lower()
+        for name in resp.headers.get("access-control-expose-headers", "").split(",")
+    }
+    assert "content-crs" in exposed, "the anonymous standards policy did not apply"
+    assert "x-geolens-number-matched" in exposed

--- a/backend/tests/test_features_incremental_metadata.py
+++ b/backend/tests/test_features_incremental_metadata.py
@@ -502,3 +502,167 @@ async def test_a_stale_feature_count_is_recounted_not_adjusted(
 )
 def test_the_geometry_type_merge_matches_the_scan_it_replaces(current, added, expected):
     assert features_service._merged_created_geometry_type(current, added) == expected
+
+
+# ---------------------------------------------------------------------------
+# fix(#1778 review r1): the prior envelope must come from the mutation itself.
+# ---------------------------------------------------------------------------
+
+# Far outside the seeded extent, so an extent computed with this row present
+# differs from one computed without it.
+FAR_AWAY = (-71.0, 44.0)
+
+
+async def _stale_read(session, table_name: str, gid: int):
+    """The shape the fast path used to rely on: an unlocked SELECT of its own.
+
+    Kept in the test rather than in the service, because demonstrating that
+    this read goes stale is the whole point.
+    """
+    row = (
+        await session.execute(
+            text(
+                f"SELECT ST_XMin(geom_4326), ST_YMin(geom_4326), "
+                f"ST_XMax(geom_4326), ST_YMax(geom_4326) "
+                f"FROM data.{table_name} WHERE gid = :gid"
+            ).bindparams(gid=gid)
+        )
+    ).first()
+    return None if row is None else tuple(float(v) for v in row)
+
+
+async def _move_far_away_in_another_session(table_name: str, gid: int) -> None:
+    """A second connection moves the feature out of the extent and commits."""
+    import app.core.db as db_module
+
+    async with db_module.async_session() as other:
+        await other.execute(
+            text(
+                f"UPDATE data.{table_name} SET "
+                "geom = ST_SetSRID(ST_MakePoint(:lng, :lat), 4326), "
+                "geom_4326 = ST_SetSRID(ST_MakePoint(:lng, :lat), 4326) "
+                "WHERE gid = :gid"
+            ).bindparams(lng=FAR_AWAY[0], lat=FAR_AWAY[1], gid=gid)
+        )
+        await other.commit()
+
+
+async def _interior_gid(session, table_name: str) -> int:
+    return (
+        await session.execute(
+            text(f"SELECT gid FROM data.{table_name} WHERE ST_X(geom_4326) = -73.95")
+        )
+    ).scalar_one()
+
+
+async def test_delete_captures_the_version_it_actually_removed(
+    sketch_dataset: Dataset, test_db_session, aggregate_calls
+):
+    """A concurrent move committed after the old pre-read cannot be missed.
+
+    Session A looks at the row, session B moves it outside the extent and
+    commits, session A deletes. The envelope the DELETE returns is B's, so the
+    fast path is refused and the extent recomputes. Reading the bounds in a
+    statement of its own would have handed A the pre-move envelope, which is
+    strictly inside the extent, and A would have skipped the aggregate and left
+    the expanded extent behind.
+    """
+    table = sketch_dataset.table_name
+    gid = await _interior_gid(test_db_session, table)
+    stale = await _stale_read(test_db_session, table, gid)
+
+    await _move_far_away_in_another_session(table, gid)
+
+    removed = await features_service.delete_feature(test_db_session, table, gid)
+
+    assert stale is not None
+    assert removed == (FAR_AWAY[0], FAR_AWAY[1], FAR_AWAY[0], FAR_AWAY[1])
+    assert removed != stale, "the separate read was the stale one"
+
+    await features_service.refresh_dataset_metadata(
+        test_db_session,
+        sketch_dataset,
+        count_delta=-1,
+        touched_bounds=[removed],
+    )
+    assert aggregate_calls == [table]
+
+
+async def test_replace_captures_the_version_it_actually_overwrote(
+    sketch_dataset: Dataset, test_db_session, aggregate_calls
+):
+    """Same race on the update path, closed by the locking CTE."""
+    table = sketch_dataset.table_name
+    gid = await _interior_gid(test_db_session, table)
+    stale = await _stale_read(test_db_session, table, gid)
+
+    await _move_far_away_in_another_session(table, gid)
+
+    written = await features_service.replace_feature(
+        test_db_session,
+        table,
+        gid,
+        INSIDE,
+        {"name": "moved back"},
+        [{"name": "name", "type": "text"}],
+        "POINT",
+        dataset_srid=4326,
+    )
+
+    assert written.prior_bounds == (
+        FAR_AWAY[0],
+        FAR_AWAY[1],
+        FAR_AWAY[0],
+        FAR_AWAY[1],
+    )
+    assert written.prior_bounds != stale
+
+    await features_service.refresh_dataset_metadata(
+        test_db_session,
+        sketch_dataset,
+        count_delta=0,
+        touched_bounds=[written.prior_bounds, features_service.geojson_bounds(INSIDE)],
+    )
+    assert aggregate_calls == [table]
+
+
+async def test_a_deleted_row_without_geometry_reports_no_bounds(
+    sketch_dataset: Dataset, test_db_session
+):
+    """A NULL geometry is not an envelope of zero size, and must not read as one."""
+    table = sketch_dataset.table_name
+    gid = (
+        await test_db_session.execute(
+            text(
+                f"INSERT INTO data.{table} (geom, geom_4326, name) "
+                "VALUES (NULL, NULL, 'no geometry') RETURNING gid"
+            )
+        )
+    ).scalar_one()
+
+    assert await features_service.delete_feature(test_db_session, table, gid) is None
+
+
+async def test_deleting_a_missing_feature_still_raises(
+    sketch_dataset: Dataset, test_db_session
+):
+    with pytest.raises(ValueError, match="not found"):
+        await features_service.delete_feature(
+            test_db_session, sketch_dataset.table_name, 987654321
+        )
+
+
+async def test_replacing_a_missing_feature_still_raises(
+    sketch_dataset: Dataset, test_db_session
+):
+    with pytest.raises(ValueError, match="not found"):
+        await features_service.replace_feature(
+            test_db_session,
+            sketch_dataset.table_name,
+            987654321,
+            INSIDE,
+            {"name": "nobody"},
+            [{"name": "name", "type": "text"}],
+            "POINT",
+            dataset_srid=4326,
+        )

--- a/backend/tests/test_features_incremental_metadata.py
+++ b/backend/tests/test_features_incremental_metadata.py
@@ -1,0 +1,504 @@
+"""fix(#1778): a single-feature edit must not seq-scan the whole layer.
+
+`_refresh_count_and_extent` runs one unqualified COUNT(*) + ST_Extent over the
+entire table, inside the request transaction, on every insert, replace, delete
+and geometry-bearing patch. A dataset wider than 180 degrees pays a second scan
+over `ST_ShiftLongitude(geom_4326)`, and a created dataset a third
+`SELECT DISTINCT GeometryType(...)`. There is no bulk feature endpoint, so a
+client digitizing 200 points issued 200 requests and paid it 200 times.
+
+When the caller can say how many rows the write added or removed and where the
+geometry it touched sits, and every touched envelope is strictly inside the
+stored extent, the extent provably did not change and no aggregate runs.
+
+Requires the Docker test database.
+"""
+
+import uuid
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import func, select, text, update
+
+from app.modules.catalog.features import service as features_service
+from app.modules.catalog.datasets.domain.models import Dataset, Record
+
+from tests.factories import get_user_id
+
+pytestmark = pytest.mark.anyio
+
+# Extent of the seeded rows: (-74.00, 40.70) .. (-73.90, 40.80).
+SEED_POINTS = [(-74.00, 40.70), (-73.90, 40.80), (-73.95, 40.75)]
+INSIDE = {"type": "Point", "coordinates": [-73.96, 40.74]}
+OUTSIDE = {"type": "Point", "coordinates": [-73.80, 40.90]}
+INSIDE_POLYGON = {
+    "type": "Polygon",
+    "coordinates": [
+        [
+            [-73.96, 40.74],
+            [-73.95, 40.74],
+            [-73.95, 40.75],
+            [-73.96, 40.74],
+        ]
+    ],
+}
+
+
+async def _create_sketch_dataset(
+    session, *, created_by: uuid.UUID, source_format: str = "geojson"
+) -> Dataset:
+    table_name = f"test_im_{uuid.uuid4().hex[:8]}"
+    await session.execute(
+        text(
+            f"CREATE TABLE data.{table_name} ("
+            "gid SERIAL PRIMARY KEY, "
+            "geom geometry(Geometry, 4326), "
+            "geom_4326 geometry(Geometry, 4326), "
+            "name TEXT)"
+        )
+    )
+    await session.execute(text(f"GRANT SELECT ON data.{table_name} TO geolens_reader"))
+    for lng, lat in SEED_POINTS:
+        await session.execute(
+            text(
+                f"INSERT INTO data.{table_name} (geom, geom_4326, name) VALUES ("
+                "ST_SetSRID(ST_MakePoint(:lng, :lat), 4326), "
+                "ST_SetSRID(ST_MakePoint(:lng, :lat), 4326), 'seed')"
+            ).bindparams(lng=lng, lat=lat)
+        )
+
+    record = Record(
+        title=f"Incremental metadata {table_name}",
+        summary="Sketch layer",
+        theme_category=["test"],
+        visibility="private",
+        record_status="published",
+        created_by=created_by,
+    )
+    session.add(record)
+    await session.flush()
+    dataset = Dataset(
+        record_id=record.id,
+        table_name=table_name,
+        srid=4326,
+        geometry_type="GEOMETRY" if source_format == "created" else "POINT",
+        feature_count=0,
+        column_info=[{"name": "name", "type": "text"}],
+        source_format=source_format,
+    )
+    session.add(dataset)
+    await session.flush()
+    # Seed feature_count, spatial_extent and geometry_type the honest way.
+    await features_service.refresh_dataset_metadata(session, dataset)
+    await session.commit()
+    await session.refresh(dataset)
+    return dataset
+
+
+@pytest.fixture
+async def sketch_dataset(client: AsyncClient, test_db_session):
+    """An ordinary ingested layer: its display geometry_type never re-derives."""
+    admin_id = await get_user_id(test_db_session, "admin")
+    dataset = await _create_sketch_dataset(test_db_session, created_by=admin_id)
+    yield dataset
+    await test_db_session.execute(
+        text(f"DROP TABLE IF EXISTS data.{dataset.table_name}")
+    )
+    await test_db_session.commit()
+
+
+@pytest.fixture
+async def created_dataset(client: AsyncClient, test_db_session):
+    """A created layer on a generic geometry column, where the type re-derives."""
+    admin_id = await get_user_id(test_db_session, "admin")
+    dataset = await _create_sketch_dataset(
+        test_db_session, created_by=admin_id, source_format="created"
+    )
+    yield dataset
+    await test_db_session.execute(
+        text(f"DROP TABLE IF EXISTS data.{dataset.table_name}")
+    )
+    await test_db_session.commit()
+
+
+@pytest.fixture
+def aggregate_calls(monkeypatch):
+    """Record every full-table COUNT(*) + ST_Extent the request runs."""
+    calls: list[str] = []
+    original = features_service._refresh_count_and_extent
+
+    async def _spy(session, table_name):
+        calls.append(table_name)
+        return await original(session, table_name)
+
+    monkeypatch.setattr(features_service, "_refresh_count_and_extent", _spy)
+    return calls
+
+
+async def _state(session, dataset: Dataset) -> tuple[int, str | None]:
+    row = (
+        await session.execute(
+            select(Dataset.feature_count, func.ST_AsText(Record.spatial_extent))
+            .join(Record, Record.id == Dataset.record_id)
+            .where(Dataset.id == dataset.id)
+        )
+    ).one()
+    return int(row[0]), row[1]
+
+
+async def test_an_insert_inside_the_extent_runs_no_aggregate(
+    client: AsyncClient,
+    sketch_dataset: Dataset,
+    admin_auth_header,
+    test_db_session,
+    aggregate_calls,
+):
+    before_count, before_extent = await _state(test_db_session, sketch_dataset)
+
+    resp = await client.post(
+        f"/datasets/{sketch_dataset.id}/features/",
+        json={"geometry": INSIDE, "properties": {"name": "inside"}},
+        headers=admin_auth_header,
+    )
+
+    assert resp.status_code == 201, resp.text
+    assert aggregate_calls == []
+    after_count, after_extent = await _state(test_db_session, sketch_dataset)
+    assert after_count == before_count + 1
+    assert after_extent == before_extent
+
+
+async def test_an_insert_outside_the_extent_still_recomputes(
+    client: AsyncClient,
+    sketch_dataset: Dataset,
+    admin_auth_header,
+    test_db_session,
+    aggregate_calls,
+):
+    _before_count, before_extent = await _state(test_db_session, sketch_dataset)
+
+    resp = await client.post(
+        f"/datasets/{sketch_dataset.id}/features/",
+        json={"geometry": OUTSIDE, "properties": {"name": "outside"}},
+        headers=admin_auth_header,
+    )
+
+    assert resp.status_code == 201, resp.text
+    assert aggregate_calls == [sketch_dataset.table_name]
+    _after_count, after_extent = await _state(test_db_session, sketch_dataset)
+    assert after_extent != before_extent
+
+
+async def test_an_insert_that_widens_the_geometry_type_recomputes(
+    client: AsyncClient,
+    created_dataset: Dataset,
+    admin_auth_header,
+    test_db_session,
+    aggregate_calls,
+):
+    """A created generic layer's display type can change; only a scan can say."""
+    resp = await client.post(
+        f"/datasets/{created_dataset.id}/features/",
+        json={"geometry": INSIDE_POLYGON, "properties": {"name": "poly"}},
+        headers=admin_auth_header,
+    )
+
+    assert resp.status_code == 201, resp.text
+    assert aggregate_calls == [created_dataset.table_name]
+    row = (
+        await test_db_session.execute(
+            select(Dataset.geometry_type).where(Dataset.id == created_dataset.id)
+        )
+    ).scalar_one()
+    assert row == "GEOMETRY"
+
+
+async def test_an_insert_of_the_same_type_into_a_created_layer_runs_no_aggregate(
+    client: AsyncClient,
+    created_dataset: Dataset,
+    admin_auth_header,
+    test_db_session,
+    aggregate_calls,
+):
+    """The merge answers what the DISTINCT scan would have, without the scan."""
+    before_count, before_extent = await _state(test_db_session, created_dataset)
+
+    resp = await client.post(
+        f"/datasets/{created_dataset.id}/features/",
+        json={"geometry": INSIDE, "properties": {"name": "inside"}},
+        headers=admin_auth_header,
+    )
+
+    assert resp.status_code == 201, resp.text
+    assert aggregate_calls == []
+    after_count, after_extent = await _state(test_db_session, created_dataset)
+    assert after_count == before_count + 1
+    assert after_extent == before_extent
+
+
+async def test_a_delete_from_a_created_layer_still_recomputes(
+    client: AsyncClient,
+    created_dataset: Dataset,
+    admin_auth_header,
+    test_db_session,
+    aggregate_calls,
+):
+    """A removed row can NARROW the derived display type, and only a scan sees that.
+
+    The deliberate limit of the fast path: on a created generic layer it covers
+    inserts only.
+    """
+    gid = (
+        await test_db_session.execute(
+            text(
+                f"SELECT gid FROM data.{created_dataset.table_name} "
+                "WHERE ST_X(geom_4326) = -73.95"
+            )
+        )
+    ).scalar_one()
+
+    resp = await client.delete(
+        f"/datasets/{created_dataset.id}/features/{gid}", headers=admin_auth_header
+    )
+
+    assert resp.status_code == 204, resp.text
+    assert aggregate_calls == [created_dataset.table_name]
+
+
+async def test_deleting_an_interior_row_runs_no_aggregate(
+    client: AsyncClient,
+    sketch_dataset: Dataset,
+    admin_auth_header,
+    test_db_session,
+    aggregate_calls,
+):
+    """The interior seed point defines no side of the extent."""
+    gid = (
+        await test_db_session.execute(
+            text(
+                f"SELECT gid FROM data.{sketch_dataset.table_name} "
+                "WHERE ST_X(geom_4326) = -73.95"
+            )
+        )
+    ).scalar_one()
+    before_count, before_extent = await _state(test_db_session, sketch_dataset)
+
+    resp = await client.delete(
+        f"/datasets/{sketch_dataset.id}/features/{gid}", headers=admin_auth_header
+    )
+
+    assert resp.status_code == 204, resp.text
+    assert aggregate_calls == []
+    after_count, after_extent = await _state(test_db_session, sketch_dataset)
+    assert after_count == before_count - 1
+    assert after_extent == before_extent
+
+
+async def test_deleting_a_corner_row_shrinks_the_extent(
+    client: AsyncClient,
+    sketch_dataset: Dataset,
+    admin_auth_header,
+    test_db_session,
+    aggregate_calls,
+):
+    """A row on the boundary may be the row that defines it, so it recomputes."""
+    gid = (
+        await test_db_session.execute(
+            text(
+                f"SELECT gid FROM data.{sketch_dataset.table_name} "
+                "WHERE ST_X(geom_4326) = -74.0"
+            )
+        )
+    ).scalar_one()
+    _before_count, before_extent = await _state(test_db_session, sketch_dataset)
+
+    resp = await client.delete(
+        f"/datasets/{sketch_dataset.id}/features/{gid}", headers=admin_auth_header
+    )
+
+    assert resp.status_code == 204, resp.text
+    assert aggregate_calls == [sketch_dataset.table_name]
+    _after_count, after_extent = await _state(test_db_session, sketch_dataset)
+    assert after_extent != before_extent
+
+
+async def test_moving_a_feature_within_the_extent_runs_no_aggregate(
+    client: AsyncClient,
+    sketch_dataset: Dataset,
+    admin_auth_header,
+    test_db_session,
+    aggregate_calls,
+):
+    gid = (
+        await test_db_session.execute(
+            text(
+                f"SELECT gid FROM data.{sketch_dataset.table_name} "
+                "WHERE ST_X(geom_4326) = -73.95"
+            )
+        )
+    ).scalar_one()
+    before_count, before_extent = await _state(test_db_session, sketch_dataset)
+
+    resp = await client.patch(
+        f"/datasets/{sketch_dataset.id}/features/{gid}",
+        json={"geometry": INSIDE},
+        headers=admin_auth_header,
+    )
+
+    assert resp.status_code == 200, resp.text
+    assert aggregate_calls == []
+    after_count, after_extent = await _state(test_db_session, sketch_dataset)
+    assert after_count == before_count
+    assert after_extent == before_extent
+
+
+async def test_moving_a_feature_out_of_the_extent_recomputes(
+    client: AsyncClient,
+    sketch_dataset: Dataset,
+    admin_auth_header,
+    test_db_session,
+    aggregate_calls,
+):
+    gid = (
+        await test_db_session.execute(
+            text(
+                f"SELECT gid FROM data.{sketch_dataset.table_name} "
+                "WHERE ST_X(geom_4326) = -73.95"
+            )
+        )
+    ).scalar_one()
+    _before_count, before_extent = await _state(test_db_session, sketch_dataset)
+
+    resp = await client.patch(
+        f"/datasets/{sketch_dataset.id}/features/{gid}",
+        json={"geometry": OUTSIDE},
+        headers=admin_auth_header,
+    )
+
+    assert resp.status_code == 200, resp.text
+    assert aggregate_calls == [sketch_dataset.table_name]
+    _after_count, after_extent = await _state(test_db_session, sketch_dataset)
+    assert after_extent != before_extent
+
+
+async def test_replacing_a_feature_within_the_extent_runs_no_aggregate(
+    client: AsyncClient,
+    sketch_dataset: Dataset,
+    admin_auth_header,
+    test_db_session,
+    aggregate_calls,
+):
+    """PUT is wired the same way as PATCH-with-geometry."""
+    gid = (
+        await test_db_session.execute(
+            text(
+                f"SELECT gid FROM data.{sketch_dataset.table_name} "
+                "WHERE ST_X(geom_4326) = -73.95"
+            )
+        )
+    ).scalar_one()
+    before_count, before_extent = await _state(test_db_session, sketch_dataset)
+
+    resp = await client.put(
+        f"/datasets/{sketch_dataset.id}/features/{gid}",
+        json={"geometry": INSIDE, "properties": {"name": "moved"}},
+        headers=admin_auth_header,
+    )
+
+    assert resp.status_code == 200, resp.text
+    assert aggregate_calls == []
+    after_count, after_extent = await _state(test_db_session, sketch_dataset)
+    assert after_count == before_count
+    assert after_extent == before_extent
+
+
+async def test_a_property_only_patch_still_touches_no_metadata(
+    client: AsyncClient,
+    sketch_dataset: Dataset,
+    admin_auth_header,
+    test_db_session,
+    aggregate_calls,
+):
+    """The pre-existing short-circuit is unchanged, and reads no prior bounds."""
+    gid = (
+        await test_db_session.execute(
+            text(f"SELECT MIN(gid) FROM data.{sketch_dataset.table_name}")
+        )
+    ).scalar_one()
+
+    resp = await client.patch(
+        f"/datasets/{sketch_dataset.id}/features/{gid}",
+        json={"properties": {"name": "renamed"}},
+        headers=admin_auth_header,
+    )
+
+    assert resp.status_code == 200, resp.text
+    assert aggregate_calls == []
+
+
+async def test_a_seam_extent_always_recomputes(
+    sketch_dataset: Dataset, test_db_session, aggregate_calls
+):
+    """A two-ring antimeridian extent cannot be reasoned about as a box.
+
+    ST_XMin/ST_XMax of the MULTIPOLYGON `seam_extent_wkt_for_table` produces are
+    -180/180, so a longitude in the gap would test as inside a box the dataset
+    never occupies.
+    """
+    await test_db_session.execute(
+        update(Record)
+        .where(Record.id == sketch_dataset.record_id)
+        .values(
+            spatial_extent=func.ST_GeomFromText(
+                "MULTIPOLYGON(((150 -10, 180 -10, 180 10, 150 10, 150 -10)), "
+                "((-180 -10, -110 -10, -110 10, -180 10, -180 -10)))",
+                4326,
+            )
+        )
+    )
+    await test_db_session.flush()
+
+    await features_service.refresh_dataset_metadata(
+        test_db_session,
+        sketch_dataset,
+        count_delta=1,
+        touched_bounds=[(0.0, 0.0, 0.0, 0.0)],
+        added_geometry_type="Point",
+    )
+
+    assert aggregate_calls == [sketch_dataset.table_name]
+
+
+async def test_a_stale_feature_count_is_recounted_not_adjusted(
+    sketch_dataset: Dataset, test_db_session, aggregate_calls
+):
+    """The increment only applies to a count that is currently a number."""
+    sketch_dataset.feature_count = None
+
+    await features_service.refresh_dataset_metadata(
+        test_db_session,
+        sketch_dataset,
+        count_delta=1,
+        touched_bounds=[(-73.96, 40.74, -73.96, 40.74)],
+        added_geometry_type="Point",
+    )
+
+    assert aggregate_calls == [sketch_dataset.table_name]
+
+
+@pytest.mark.parametrize(
+    ("current", "added", "expected"),
+    [
+        ("POINT", "Point", "POINT"),
+        ("POINT", "MultiPoint", "MULTIPOINT"),
+        ("MULTIPOINT", "Point", "MULTIPOINT"),
+        ("POINT", "Polygon", "GEOMETRY"),
+        ("GEOMETRY", "Point", "GEOMETRY"),
+        ("GEOMETRYCOLLECTION", "GeometryCollection", "GEOMETRYCOLLECTION"),
+        ("GEOMETRYCOLLECTION", "Point", "GEOMETRY"),
+        ("POINT", None, None),
+        (None, "Point", None),
+    ],
+)
+def test_the_geometry_type_merge_matches_the_scan_it_replaces(current, added, expected):
+    assert features_service._merged_created_geometry_type(current, added) == expected

--- a/backend/tests/test_features_property_filter_types.py
+++ b/backend/tests/test_features_property_filter_types.py
@@ -1,0 +1,220 @@
+"""fix(#1778): property filters on non-text columns must work, and must not 503.
+
+`get_features` bound every property-filter value as the raw query-string
+string, so SQLAlchemy typed the bind VARCHAR and PostgreSQL had no
+`bigint = character varying` operator. Every non-text property filter failed
+with 42883, and the OGC items handler classified that as
+`503 Dataset table is temporarily unavailable` because its caller-fault branch
+was gated on a CQL2 `filter=` being present. Clients retried forever against
+what is a query-shape bug, and the Part 3 queryables document advertises those
+columns as integer/number/boolean/date, so a conformant client was led
+straight into it.
+
+Requires the Docker test database.
+"""
+
+import uuid
+from datetime import date, datetime
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import text
+
+from app.modules.catalog.datasets.domain.models import Dataset, Record
+
+from tests.factories import get_user_id
+
+pytestmark = pytest.mark.anyio
+
+
+async def _create_typed_dataset(session, *, created_by: uuid.UUID) -> Dataset:
+    """A table with one column per advertised queryable family, plus a uuid.
+
+    ``ref`` (uuid) is deliberately outside the mapped set: it exercises the
+    fallback, where the raw string bind still reaches the database and the
+    router has to classify the resulting sqlstate.
+    """
+    table_name = f"test_pf_{uuid.uuid4().hex[:8]}"
+    await session.execute(
+        text(
+            f"CREATE TABLE data.{table_name} ("
+            "gid SERIAL PRIMARY KEY, "
+            "geom geometry(Point, 4326), "
+            "geom_4326 geometry(Point, 4326), "
+            "era TEXT, "
+            "construction_year INTEGER, "
+            "height_roof DOUBLE PRECISION, "
+            "ratio REAL, "
+            "price NUMERIC(12, 2), "
+            "landmark BOOLEAN, "
+            "surveyed DATE, "
+            "built TIMESTAMP, "
+            "ref UUID)"
+        )
+    )
+    await session.execute(text(f"GRANT SELECT ON data.{table_name} TO geolens_reader"))
+
+    rows = [
+        ("Art Deco", 1931, 100.0, 0.5, 19.99, True, "1931-05-01", 40.70),
+        ("Art Deco", 1931, 100.0, 0.5, 19.99, True, "1931-05-01", 40.71),
+        ("Brutalist", 1968, 42.5, 0.25, 20.00, False, "1968-02-02", 40.72),
+    ]
+    for era, year, height, ratio, price, landmark, surveyed, lat in rows:
+        await session.execute(
+            text(
+                f"INSERT INTO data.{table_name} "
+                "(geom, geom_4326, era, construction_year, height_roof, ratio, "
+                "price, landmark, surveyed, built, ref) VALUES ("
+                "ST_SetSRID(ST_MakePoint(-74.0, :lat), 4326), "
+                "ST_SetSRID(ST_MakePoint(-74.0, :lat), 4326), "
+                ":era, :year, :height, :ratio, :price, :landmark, :surveyed, "
+                ":built, gen_random_uuid())"
+            ).bindparams(
+                lat=lat,
+                era=era,
+                year=year,
+                height=height,
+                ratio=ratio,
+                price=price,
+                landmark=landmark,
+                surveyed=date.fromisoformat(surveyed),
+                built=datetime.fromisoformat(f"{surveyed}T09:30:00"),
+            )
+        )
+
+    record = Record(
+        title=f"Property filter types {table_name}",
+        summary="Typed property filters",
+        theme_category=["test"],
+        visibility="public",
+        record_status="published",
+        created_by=created_by,
+    )
+    session.add(record)
+    await session.flush()
+    dataset = Dataset(
+        record_id=record.id,
+        table_name=table_name,
+        srid=4326,
+        geometry_type="POINT",
+        feature_count=len(rows),
+        column_info=[
+            {"name": "era", "type": "text"},
+            {"name": "construction_year", "type": "integer"},
+            {"name": "height_roof", "type": "double precision"},
+            {"name": "ratio", "type": "real"},
+            {"name": "price", "type": "numeric"},
+            {"name": "landmark", "type": "boolean"},
+            {"name": "surveyed", "type": "date"},
+            {"name": "built", "type": "timestamp without time zone"},
+            {"name": "ref", "type": "uuid"},
+        ],
+        source_format="created",
+    )
+    session.add(dataset)
+    await session.commit()
+    await session.refresh(dataset)
+    return dataset
+
+
+@pytest.fixture
+async def typed_dataset(client: AsyncClient, test_db_session):
+    admin_id = await get_user_id(test_db_session, "admin")
+    dataset = await _create_typed_dataset(test_db_session, created_by=admin_id)
+    yield dataset
+    await test_db_session.execute(
+        text(f"DROP TABLE IF EXISTS data.{dataset.table_name}")
+    )
+    await test_db_session.commit()
+
+
+def _items_url(dataset: Dataset) -> str:
+    return f"/collections/{dataset.id}/items"
+
+
+@pytest.mark.parametrize(
+    ("param", "value", "expected"),
+    [
+        ("era", "Art Deco", 2),
+        ("construction_year", "1931", 2),
+        ("height_roof", "100", 2),
+        ("ratio", "0.5", 2),
+        ("price", "19.99", 2),
+        ("landmark", "true", 2),
+        ("surveyed", "1968-02-02", 1),
+        ("built", "1968-02-02T09:30:00", 1),
+    ],
+)
+async def test_ogc_property_filter_matches_on_every_queryable_type(
+    client: AsyncClient, typed_dataset: Dataset, param, value, expected
+):
+    """Each type the queryables document advertises is actually filterable."""
+    resp = await client.get(_items_url(typed_dataset), params={param: value})
+
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["numberMatched"] == expected
+    assert data["numberReturned"] == expected
+
+
+async def test_ogc_property_filter_rejects_an_unparseable_value(
+    client: AsyncClient, typed_dataset: Dataset
+):
+    """A value that is not an integer is the caller's 400, naming the property."""
+    resp = await client.get(
+        _items_url(typed_dataset), params={"construction_year": "not-a-year"}
+    )
+
+    assert resp.status_code == 400
+    assert "construction_year" in resp.json()["detail"]
+
+
+async def test_ogc_property_filter_on_unmapped_type_is_a_400_not_a_503(
+    client: AsyncClient, typed_dataset: Dataset
+):
+    """A uuid column keeps the raw bind; the type-shaped failure is not an outage."""
+    resp = await client.get(_items_url(typed_dataset), params={"ref": "1931"})
+
+    assert resp.status_code == 400
+    assert "Property filter" in resp.json()["detail"]
+
+
+async def test_native_features_property_filter_matches_an_integer(
+    client: AsyncClient, typed_dataset: Dataset, admin_auth_header
+):
+    """The native /datasets/{id}/features/ path binds the same way."""
+    resp = await client.get(
+        f"/datasets/{typed_dataset.id}/features/",
+        params={"construction_year": "1931"},
+        headers=admin_auth_header,
+    )
+
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["numberMatched"] == 2
+
+
+async def test_native_features_property_filter_rejects_an_unparseable_value(
+    client: AsyncClient, typed_dataset: Dataset, admin_auth_header
+):
+    resp = await client.get(
+        f"/datasets/{typed_dataset.id}/features/",
+        params={"construction_year": "not-a-year"},
+        headers=admin_auth_header,
+    )
+
+    assert resp.status_code == 400
+    assert "construction_year" in resp.json()["detail"]
+
+
+async def test_cql2_filter_fault_message_is_unchanged(
+    client: AsyncClient, typed_dataset: Dataset
+):
+    """Widening the caller-fault gate must not re-label the CQL2 message."""
+    resp = await client.get(
+        _items_url(typed_dataset),
+        params={"filter": "ref = 'not-a-uuid'"},
+    )
+
+    assert resp.status_code == 400
+    assert "CQL2 filter" in resp.json()["detail"]

--- a/backend/tests/test_features_property_filter_types.py
+++ b/backend/tests/test_features_property_filter_types.py
@@ -218,3 +218,162 @@ async def test_cql2_filter_fault_message_is_unchanged(
 
     assert resp.status_code == 400
     assert "CQL2 filter" in resp.json()["detail"]
+
+
+# ---------------------------------------------------------------------------
+# fix(#1778 review r2): a value the driver cannot encode for the bound type.
+# ---------------------------------------------------------------------------
+
+OUT_OF_RANGE = [
+    ("ratio", "1e100", "3.40282e+38"),
+    ("construction_year", "2147483648", "2147483647"),
+]
+OUT_OF_RANGE_IDS = ["real-overflows-float4", "integer-overflows-int4"]
+
+
+@pytest.mark.parametrize(
+    ("param", "value", "expected_in_detail"), OUT_OF_RANGE, ids=OUT_OF_RANGE_IDS
+)
+async def test_ogc_out_of_range_property_value_is_a_400(
+    client: AsyncClient, typed_dataset: Dataset, param, value, expected_in_detail
+):
+    """Out of range for the COLUMN, not merely for Python."""
+    resp = await client.get(_items_url(typed_dataset), params={param: value})
+
+    assert resp.status_code == 400, resp.text
+    detail = resp.json()["detail"]
+    assert param in detail
+    assert expected_in_detail in detail
+
+
+@pytest.mark.parametrize(
+    ("param", "value", "expected_in_detail"), OUT_OF_RANGE, ids=OUT_OF_RANGE_IDS
+)
+async def test_native_out_of_range_property_value_is_a_400(
+    client: AsyncClient,
+    typed_dataset: Dataset,
+    admin_auth_header,
+    param,
+    value,
+    expected_in_detail,
+):
+    resp = await client.get(
+        f"/datasets/{typed_dataset.id}/features/",
+        params={param: value},
+        headers=admin_auth_header,
+    )
+
+    assert resp.status_code == 400, resp.text
+    detail = resp.json()["detail"]
+    assert param in detail
+    assert expected_in_detail in detail
+
+
+@pytest.mark.parametrize(
+    ("param", "value"),
+    [("ratio", "0.5"), ("construction_year", "1931"), ("price", "19.99")],
+)
+async def test_in_range_values_still_match(
+    client: AsyncClient, typed_dataset: Dataset, param, value
+):
+    """The vacuity guard: the range checks must not reject ordinary values."""
+    resp = await client.get(_items_url(typed_dataset), params={param: value})
+
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["numberMatched"] == 2
+
+
+# ---------------------------------------------------------------------------
+# The rest of the enumeration: every typed bind built from a caller value.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("param", ["offset", "after_gid"])
+async def test_ogc_pagination_integer_outside_int8_is_a_400(
+    client: AsyncClient, typed_dataset: Dataset, param
+):
+    """asyncpg cannot encode it, and used to raise past both routers as a 500.
+
+    FastAPI's `int` has no upper bound, so these arrive as ordinary Python
+    integers and fail inside the driver's encode path with a bare
+    sqlalchemy.exc.DBAPIError carrying SQLSTATE 22000 -- not a DataError, which
+    is why catching that alone did not help.
+    """
+    resp = await client.get(
+        _items_url(typed_dataset), params={param: "100000000000000000000000"}
+    )
+
+    assert resp.status_code == 400, resp.text
+    assert param in resp.json()["detail"]
+
+
+async def test_native_offset_outside_int8_is_a_400(
+    client: AsyncClient, typed_dataset: Dataset, admin_auth_header
+):
+    resp = await client.get(
+        f"/datasets/{typed_dataset.id}/features/",
+        params={"offset": "100000000000000000000000"},
+        headers=admin_auth_header,
+    )
+
+    assert resp.status_code == 400, resp.text
+    assert "offset" in resp.json()["detail"]
+
+
+async def test_a_large_but_encodable_offset_still_answers(
+    client: AsyncClient, typed_dataset: Dataset, admin_auth_header
+):
+    """The vacuity guard: the bound is int8, not something smaller."""
+    resp = await client.get(
+        f"/datasets/{typed_dataset.id}/features/",
+        params={"offset": str(2**63 - 1)},
+        headers=admin_auth_header,
+    )
+
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["numberReturned"] == 0
+
+
+@pytest.mark.parametrize(
+    ("expression", "expected_in_detail"),
+    [
+        ("construction_year = 2147483648", "2147483647"),
+        ("ratio = 1e100", "3.40282e+38"),
+    ],
+    ids=["integer-overflows-int4", "real-overflows-float4"],
+)
+async def test_cql2_out_of_range_literal_is_a_400(
+    client: AsyncClient, typed_dataset: Dataset, expression, expected_in_detail
+):
+    """The CQL2 comparison path reads the same range table."""
+    resp = await client.get(_items_url(typed_dataset), params={"filter": expression})
+
+    assert resp.status_code == 400, resp.text
+    assert expected_in_detail in resp.json()["detail"]
+
+
+async def test_cql2_in_range_literal_still_matches(
+    client: AsyncClient, typed_dataset: Dataset
+):
+    resp = await client.get(
+        _items_url(typed_dataset), params={"filter": "construction_year = 1931"}
+    )
+
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["numberMatched"] == 2
+
+
+async def test_a_bbox_of_finite_but_huge_floats_is_not_a_500(
+    client: AsyncClient, typed_dataset: Dataset
+):
+    """bbox binds float8, which has no narrowing step to overflow.
+
+    Included because it is part of the same enumeration: the bbox floats are
+    caller values that reach the driver, and parse_bbox already refuses the
+    non-finite ones, so there is nothing further to bound here.
+    """
+    resp = await client.get(
+        _items_url(typed_dataset), params={"bbox": "-1e30,-89,1e30,89"}
+    )
+
+    assert resp.status_code == 200, resp.text

--- a/backend/tests/test_features_unwritable_columns.py
+++ b/backend/tests/test_features_unwritable_columns.py
@@ -1,0 +1,208 @@
+"""fix(#1778): a property the write path cannot address must be refused, not dropped.
+
+Two guards disagreed about what a legal column is. `_reject_unknown_properties`
+admitted any key present in column_info; the write loops then silently skipped
+whatever `_COLUMN_NAME_RE` rejected, which is strictly narrower than every
+producer of column_info. So a dataset with a `_notes` column returned that key
+from GET and answered 201/200 on a write with the value never stored -- and on
+PUT the column was not even NULLed, contradicting the documented "Columns not
+present in properties are set to NULL". Silent write loss behind a success
+response is exactly what an editing UI's read-modify-write round trip hits.
+
+The hole was reachable with no external data: `POST /datasets/create/` validated
+column names against SAFE_COLUMN_NAME_RE, which allows a leading underscore and
+has no length bound, so it happily built a column the feature API could never
+write.
+
+Requires the Docker test database.
+"""
+
+import uuid
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import text
+
+from app.modules.catalog.datasets.domain.models import Dataset, Record
+
+from tests.factories import get_user_id
+
+pytestmark = pytest.mark.anyio
+
+POINT = {"type": "Point", "coordinates": [-74.0, 40.7]}
+
+
+async def _create_dataset_with_unwritable_column(
+    session, *, created_by: uuid.UUID
+) -> Dataset:
+    """A table carrying `_notes`, the shape create_empty_dataset used to allow."""
+    table_name = f"test_uw_{uuid.uuid4().hex[:8]}"
+    await session.execute(
+        text(
+            f"CREATE TABLE data.{table_name} ("
+            "gid SERIAL PRIMARY KEY, "
+            "geom geometry(Geometry, 4326), "
+            "geom_4326 geometry(Geometry, 4326), "
+            "name TEXT, "
+            '"_notes" TEXT)'
+        )
+    )
+    await session.execute(text(f"GRANT SELECT ON data.{table_name} TO geolens_reader"))
+
+    record = Record(
+        title=f"Unwritable column {table_name}",
+        summary="Latent unwritable column",
+        theme_category=["test"],
+        visibility="private",
+        record_status="published",
+        created_by=created_by,
+    )
+    session.add(record)
+    await session.flush()
+    dataset = Dataset(
+        record_id=record.id,
+        table_name=table_name,
+        srid=4326,
+        geometry_type="GEOMETRY",
+        feature_count=0,
+        column_info=[
+            {"name": "name", "type": "text"},
+            {"name": "_notes", "type": "text"},
+        ],
+        source_format="created",
+    )
+    session.add(dataset)
+    await session.commit()
+    await session.refresh(dataset)
+    return dataset
+
+
+@pytest.fixture
+async def unwritable_dataset(client: AsyncClient, test_db_session):
+    admin_id = await get_user_id(test_db_session, "admin")
+    dataset = await _create_dataset_with_unwritable_column(
+        test_db_session, created_by=admin_id
+    )
+    yield dataset
+    await test_db_session.execute(
+        text(f"DROP TABLE IF EXISTS data.{dataset.table_name}")
+    )
+    await test_db_session.commit()
+
+
+async def test_post_refuses_an_unwritable_property_instead_of_dropping_it(
+    client: AsyncClient, unwritable_dataset: Dataset, admin_auth_header
+):
+    resp = await client.post(
+        f"/datasets/{unwritable_dataset.id}/features/",
+        json={"geometry": POINT, "properties": {"_notes": "keep me"}},
+        headers=admin_auth_header,
+    )
+
+    assert resp.status_code == 422, resp.text
+    assert "_notes" in resp.json()["detail"]
+
+
+async def test_post_still_accepts_a_writable_property(
+    client: AsyncClient, unwritable_dataset: Dataset, admin_auth_header
+):
+    """The refusal is per property on POST, not a blanket lock on the dataset."""
+    resp = await client.post(
+        f"/datasets/{unwritable_dataset.id}/features/",
+        json={"geometry": POINT, "properties": {"name": "Alpha"}},
+        headers=admin_auth_header,
+    )
+
+    assert resp.status_code == 201, resp.text
+    assert resp.json()["properties"]["name"] == "Alpha"
+
+
+async def test_patch_refuses_an_unwritable_property(
+    client: AsyncClient, unwritable_dataset: Dataset, admin_auth_header
+):
+    created = await client.post(
+        f"/datasets/{unwritable_dataset.id}/features/",
+        json={"geometry": POINT, "properties": {"name": "Alpha"}},
+        headers=admin_auth_header,
+    )
+    gid = created.json()["id"]
+
+    resp = await client.patch(
+        f"/datasets/{unwritable_dataset.id}/features/{gid}",
+        json={"properties": {"_notes": "keep me"}},
+        headers=admin_auth_header,
+    )
+
+    assert resp.status_code == 422, resp.text
+    assert "_notes" in resp.json()["detail"]
+
+
+async def test_put_refuses_the_dataset_because_replace_nulls_every_column(
+    client: AsyncClient, unwritable_dataset: Dataset, admin_auth_header
+):
+    """PUT sets every known column, so one unwritable column breaks the contract."""
+    created = await client.post(
+        f"/datasets/{unwritable_dataset.id}/features/",
+        json={"geometry": POINT, "properties": {"name": "Alpha"}},
+        headers=admin_auth_header,
+    )
+    gid = created.json()["id"]
+
+    resp = await client.put(
+        f"/datasets/{unwritable_dataset.id}/features/{gid}",
+        json={"geometry": POINT, "properties": {"name": "Beta"}},
+        headers=admin_auth_header,
+    )
+
+    assert resp.status_code == 422, resp.text
+    assert "_notes" in resp.json()["detail"]
+
+
+async def test_an_unknown_property_is_still_a_400(
+    client: AsyncClient, unwritable_dataset: Dataset, admin_auth_header
+):
+    """The pre-existing unknown-key contract (fix(#458 E-25)) is unchanged."""
+    resp = await client.post(
+        f"/datasets/{unwritable_dataset.id}/features/",
+        json={"geometry": POINT, "properties": {"nosuchcolumn": "x"}},
+        headers=admin_auth_header,
+    )
+
+    assert resp.status_code == 400
+    assert "nosuchcolumn" in resp.json()["detail"]
+
+
+@pytest.mark.parametrize(
+    "column_name",
+    ["_notes", "n" * 64],
+    ids=["leading-underscore", "over-63-characters"],
+)
+async def test_creating_an_unwritable_column_is_refused(
+    client: AsyncClient, admin_auth_header, column_name
+):
+    """The hole is closed where it opens: no such column gets built at all."""
+    resp = await client.post(
+        "/datasets/create/",
+        json={
+            "title": f"Unwritable column {uuid.uuid4().hex[:8]}",
+            "columns": [{"name": column_name, "type": "text"}],
+        },
+        headers=admin_auth_header,
+    )
+
+    assert resp.status_code == 400, resp.text
+    assert "column name" in resp.json()["detail"].lower()
+
+
+async def test_a_writable_column_still_creates(client: AsyncClient, admin_auth_header):
+    """The vacuity guard: the refusal must not have closed the ordinary path."""
+    resp = await client.post(
+        "/datasets/create/",
+        json={
+            "title": f"Writable column {uuid.uuid4().hex[:8]}",
+            "columns": [{"name": "Notes", "type": "text"}],
+        },
+        headers=admin_auth_header,
+    )
+
+    assert resp.status_code in (200, 201), resp.text

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -4735,7 +4735,19 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # at all, and why the type merge is insert-only (a delete can narrow the
     # derived type and no merge of the stored value can see that).
     # Cap 1187 -> 1384, exact.
-    "backend/app/modules/catalog/features/service.py": 1384,
+    #
+    # fix(#1778 review r1): +107 for two review findings. The page now
+    # over-fetches one row and reports `has_more`, because a `next` link
+    # decided by `offset + limit < total` disappears with a full page on screen
+    # whenever the count is the planner's estimate; whether another row exists
+    # is a fact about rows, so FeaturePage carries it and no router re-derives
+    # one. And the envelope a write overwrites is captured BY the mutating
+    # statement (DELETE ... RETURNING, and a locking CTE for UPDATE) instead of
+    # by an unlocked SELECT before it, with the record row locked before either
+    # metadata path reads the extent. The lines are the two NamedTuples, the
+    # prior-bounds SQL helpers, and the comments recording which race each
+    # closes. Cap 1384 -> 1491, exact.
+    "backend/app/modules/catalog/features/service.py": 1491,
 }
 
 

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1812,7 +1812,15 @@ def test_decomposed_service_modules_stay_within_size_budgets() -> None:
         # concurrent raster/VRT detail requests exhaust the default (10 + 3)
         # pool this way. Three fast point lookups aren't worth that risk.
         # Cap 443 -> 429, exact.
-        "backend/app/modules/catalog/datasets/domain/service_query.py": 429,
+        # fix(#1778): +10 — the row browser emits quoted column identifiers.
+        # A column named after a SQL keyword (``desc``, ``order``, ``user`` —
+        # ogr2ogr's DBF output, and nothing renames them on ingest) made every
+        # SELECT and every ILIKE filter a 42601 syntax error, which is in none
+        # of the sqlstate sets this module degrades on, so the endpoint 5xx'd
+        # for that dataset forever. The lines are the import, the two call
+        # sites and the docstring note saying membership is decided on the bare
+        # name so quoting happens at emission. Cap 429 -> 439, exact.
+        "backend/app/modules/catalog/datasets/domain/service_query.py": 439,
         # fix(#1452): first explicit cap for this module — it sat under the
         # 350 default until the detach landed. +65 over the pre-change 350:
         # _reap_managed_storage (the reap loop both branches had inline,

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -4710,7 +4710,16 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # keyed on `offset + limit < total` would otherwise truncate pagination at
     # the cap), plus the docstring on _planner_row_estimate saying why it is
     # deliberately not wrapped in a try/except. Cap 1055 -> 1135, exact.
-    "backend/app/modules/catalog/features/service.py": 1135,
+    #
+    # fix(#1778): +52 for UnwritablePropertyError and is_writable_feature_column.
+    # A key naming a real column that _COLUMN_NAME_RE rejects used to be
+    # silently skipped by the write loop, so POST and PUT answered 201/200 with
+    # the value never stored, and PUT did not even NULL the column it documents
+    # as nulled. Most of the growth is the exception's docstring listing which
+    # producer of column_info admits which names, because the fix is a
+    # disagreement between two guards and a reader has to see both to keep them
+    # in step. Cap 1135 -> 1187, exact.
+    "backend/app/modules/catalog/features/service.py": 1187,
 }
 
 

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -4680,6 +4680,26 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # that one GATES the localhost bypass, so a miss there denies, while a miss
     # in the other ISSUES an unenforceable lock. Cap 1042 -> 1056.
     "backend/app/modules/embed_tokens/service.py": 1056,
+    # fix(#1778): first entry for this module — it crossed the 1000-line
+    # inclusion threshold on the property-filter typing. Property filters used
+    # to bind the raw query-string value, so PostgreSQL had no
+    # `bigint = character varying` operator and every non-text filter failed
+    # with 42883, which the OGC items handler reported as a retryable 503.
+    # The growth is the pg-type -> (parser, database type) table, the parsers
+    # that reject a non-finite float / an out-of-int8-range integer / an
+    # unparseable date, and the extracted `_property_filter_predicates`
+    # (get_features was at ruff's C901 ceiling without it). Roughly half is the
+    # comment recording WHY each numeric family keeps its own database type,
+    # which is a correctness property a future reader would otherwise collapse
+    # into one Float.
+    #
+    # The clean split when it next grows is the banner already in the file:
+    # everything below "Write operations" moves to a sibling module behind a
+    # re-export facade, because `standards/ogc/router.py` and
+    # `standards/stac/router.py` may import `features.service` and nothing
+    # else under features (_STANDARDS_MODULE_IMPORT_SURFACE), and several
+    # tests reach private names through it.
+    "backend/app/modules/catalog/features/service.py": 1055,
 }
 
 

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -4719,7 +4719,23 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # producer of column_info admits which names, because the fix is a
     # disagreement between two guards and a reader has to see both to keep them
     # in step. Cap 1135 -> 1187, exact.
-    "backend/app/modules/catalog/features/service.py": 1187,
+    #
+    # fix(#1778): +197 for the incremental metadata refresh.
+    # `_refresh_count_and_extent` runs one unqualified COUNT(*) + ST_Extent over
+    # the whole table on every single-feature write, plus a second scan over
+    # ST_ShiftLongitude past 180 degrees of width and a third DISTINCT
+    # GeometryType for created datasets; there is no bulk feature endpoint, so a
+    # client digitizing 200 points paid it 200 times. The new pieces are
+    # geojson_bounds / feature_bounds (where the write touched),
+    # _stored_extent_box, _strictly_inside, _merged_created_geometry_type and
+    # _apply_incremental_metadata. Most of the growth is the reasoning each of
+    # them has to carry, because every one is a claim that a scan can be
+    # skipped: why the containment test is STRICT (a row on the boundary may be
+    # the row defining it), why a two-ring seam extent cannot be read as a box
+    # at all, and why the type merge is insert-only (a delete can narrow the
+    # derived type and no merge of the stored value can see that).
+    # Cap 1187 -> 1384, exact.
+    "backend/app/modules/catalog/features/service.py": 1384,
 }
 
 

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -4747,7 +4747,18 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # metadata path reads the extent. The lines are the two NamedTuples, the
     # prior-bounds SQL helpers, and the comments recording which race each
     # closes. Cap 1384 -> 1491, exact.
-    "backend/app/modules/catalog/features/service.py": 1491,
+    #
+    # fix(#1778 review r2): +16 for the range checks. A caller value can be a
+    # good Python number and still be wrong for the column, and how that failed
+    # depended on which cast the compiler emitted: the property-filter path
+    # answered 200 with zero features, the CQL2 path overflowed a real cast
+    # with SQLSTATE 22003, and a pagination int outside int8 could not be
+    # encoded at all. The lines are the two check calls, the int8 bound on
+    # limit/offset/after_gid, and the comments recording which of those three
+    # shapes each one closes; the tables and the messages live in
+    # core/db/pg_ranges.py, which standards/ogc/filtering.py reads too.
+    # Cap 1491 -> 1507, exact.
+    "backend/app/modules/catalog/features/service.py": 1507,
 }
 
 

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -4699,7 +4699,18 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # `standards/stac/router.py` may import `features.service` and nothing
     # else under features (_STANDARDS_MODULE_IMPORT_SURFACE), and several
     # tests reach private names through it.
-    "backend/app/modules/catalog/features/service.py": 1055,
+    #
+    # fix(#1778): +80 for the bounded filtered count. The cached-feature_count
+    # fast path applied only to a COMPLETELY unfiltered request, so one bbox or
+    # property filter put a full filtered COUNT(*) on EVERY page, including the
+    # keyset pages whose whole point is constant-time access. The count now runs
+    # inside a LIMIT and the planner answers past the cap. Most of the growth is
+    # the comment on _FILTERED_COUNT_CAP recording what the cap buys and why the
+    # estimate is never reported below the rows already counted (a `next` link
+    # keyed on `offset + limit < total` would otherwise truncate pagination at
+    # the cap), plus the docstring on _planner_row_estimate saying why it is
+    # deliberately not wrapped in a try/except. Cap 1055 -> 1135, exact.
+    "backend/app/modules/catalog/features/service.py": 1135,
 }
 
 

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -4758,7 +4758,18 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # shapes each one closes; the tables and the messages live in
     # core/db/pg_ranges.py, which standards/ogc/filtering.py reads too.
     # Cap 1491 -> 1507, exact.
-    "backend/app/modules/catalog/features/service.py": 1507,
+    #
+    # fix(#1778 review r3): +34 for _floor_estimated_total. The r1 floor read
+    # `offset + len(rows)` unconditionally, which invented matches out of the
+    # offset: five features asked for at offset 100 answered an empty page and
+    # reported numberMatched 100, and a keyset page borrowed an offset its own
+    # query had ignored. Extracted rather than narrowed in place, because
+    # get_features was back at ruff's C901 ceiling and because each of the
+    # three conditions is a claim about what a page can PROVE -- an exact count
+    # is never raised, an empty page proves nothing, and a keyset page can
+    # prove only the rows in hand. That reasoning is most of the added lines.
+    # Cap 1507 -> 1541, exact.
+    "backend/app/modules/catalog/features/service.py": 1541,
 }
 
 


### PR DESCRIPTION
Five findings from the codebase audit 2026-08-30 (8dc529f17), tracked in #1778. All five still reproduced on current main (base cac6842b7); none had been fixed by an earlier merge. One commit per finding, each with a test that fails on main.

## Dataset rows endpoint interpolates bare column identifiers, so a reserved-word column permanently 500s the table browser

`get_dataset_rows` interpolated column names bare into the SELECT list and the ILIKE filter clause, so `SELECT gid, desc FROM data.x` was a 42601 syntax error. 42601 is in none of the sqlstate sets that function degrades on, so the endpoint returned 5xx for that dataset forever, for anonymous callers on a public dataset too. Nothing renames SQL keywords on ingest: `rename_reserved_columns` acts only on gid/geom/geometry/geom_4326/fid/ogc_fid, while `desc`, `order`, `user`, `group`, `end` and `to` are routine ogr2ogr output from DBF fields.

Both sites now emit through `_safe_column_ref`, a helper in the dataset domain's `_sql_safety` module that mirrors the escaping already used by `layers.service._qcol`, `features.service.live_property_columns` and `processing.ingest.metadata_sql._sql_quote_ident`. Membership tests still compare bare names, so quoting happens at emission.

Counterfactual: `tests/test_dataset_rows_reserved_columns.py` (2 tests) both fail on main with `sqlalchemy.exc.ProgrammingError` 42601.

## OGC Features property filter on any non-text column returns 503, even with a valid value

Property filters bound the raw query-string value, so SQLAlchemy typed the bind VARCHAR and PostgreSQL has no `bigint = character varying` operator. Every non-text property filter failed with 42883, on both the OGC items endpoint and the native features list, and the OGC handler's caller-fault branch was gated on a CQL2 `filter=` being present, so it fell through to `503 Dataset table is temporarily unavailable`. Clients retried forever against a query-shape bug and the queryables document led conformant clients straight into it.

Each filter value is now bound with the database type of the column it names, read from the live schema, covering exactly the types the queryables document advertises as filterable. The numeric families keep their own database types for the reason recorded in `standards/ogc/filtering.py`: a float8-cast bind against a REAL column promotes the stored float4 and stops comparing equal. A value that does not parse is a 400 naming the property, decided before any database round trip. A column of an unadvertised type keeps the raw string bind, and both routers now classify the type-shaped sqlstate that produces as the caller's 400.

Counterfactual: `tests/test_features_property_filter_types.py`, 11 of 13 fail on main (the two text-column cases pass, which is why the bug survived CI).

## Feature pagination runs a full filtered COUNT(*) on every page whenever any filter is active

The cached feature_count fast path applies only to a completely unfiltered request, and the count deliberately strips the keyset cursor, so one bbox or property filter put a full filtered COUNT(*) on every page, including the keyset pages whose entire purpose is constant-time access.

I took the cap-with-an-estimate-flag option rather than compute-once-per-cursor-chain, because it needs no new query parameter and therefore no OpenAPI or SDK change. The count now runs inside a LIMIT: exact up to 20000 matches, and past that the planner's row estimate answers. The estimate is never reported below the rows already counted, so a `next` link keyed on `offset + limit < total` cannot truncate pagination at the cap.

`numberMatched` keeps its place in both response schemas. Which of the two a page carries rides on a new `X-GeoLens-Number-Matched: estimated` response header, present only when estimated, added to both CORS expose lists so a browser client can read it. Response headers are not part of the OpenAPI snapshot, so `make openapi-check` stays clean.

Counterfactual: `tests/test_features_bounded_count.py` (7 tests). On main `get_features` returns two values and never bounds the count, so the estimate cases fail.

## Every single-feature edit runs a full-table COUNT(*)+ST_Extent seq scan

`_refresh_count_and_extent` runs one unqualified aggregate over the whole table after every insert, replace, delete and geometry-bearing patch, plus a second scan over `ST_ShiftLongitude` past 180 degrees of width and a third `SELECT DISTINCT GeometryType(...)` for created datasets. There is no bulk feature endpoint, so digitizing 200 points costs 200 of them.

The write handlers now say how many rows the write added or removed and where the geometry it touched sits: the new envelope from the request body, the prior envelope from a primary-key lookup before the row is moved or deleted. When every touched envelope is strictly inside the stored extent, the extent provably did not change and no aggregate runs; feature_count moves by the delta, as a SQL-side expression so two concurrent writes cannot both read N and write N+1.

Three guards keep that sound, each documented at the code. The containment test is strict, because a row that only touches a side may be the row defining it. A two-ring antimeridian extent is refused outright: ST_XMin/ST_XMax of the MULTIPOLYGON `seam_extent_wkt_for_table` produces are -180/180, so a longitude in the gap would test as inside a box the dataset never occupies. And on a created layer with a generic geometry column the fast path covers inserts only, because a removed or moved geometry can narrow the derived display type.

Counterfactual: `tests/test_features_incremental_metadata.py` (22 tests), 16 fail on main.

## A property whose column name fails the write path's stricter regex is silently dropped with a 200/201

`_reject_unknown_properties` admitted any key present in column_info and the write loops then skipped whatever `_COLUMN_NAME_RE` rejected, a strictly narrower pattern than every producer of column_info. A dataset with a `_notes` column returned that key from GET but could not write it: POST and PUT answered 201/200 with the value never stored, and PUT did not even NULL the column, contradicting its own documented replacement semantics.

A supplied property naming a column the write path cannot address is now a 422 naming the column. PUT is stricter: replace writes every known column, so one unwritable column in column_info makes the documented replacement impossible whether or not the request mentions it. The hole is also closed where it opens, per the audit's note about the 63-character bound: `POST /datasets/create/` refuses a column name the write path could not address, so no such column gets built. That covers the over-63-character case, where PostgreSQL truncates the identifier in the DDL while column_info keeps the full string. The bound lands in the service rather than on `ColumnDefinition.name`, which keeps the OpenAPI snapshot unchanged.

Counterfactual: `tests/test_features_unwritable_columns.py` (8 tests), 5 fail on main.

## Schema, API and config impact

No request or response schema changed. `backend/openapi.json` is unchanged (`dump_openapi.py --check` exits 0), so no SDK, CLI or frontend-types regeneration. 422 was already declared in `ERROR_RESPONSES_WRITE`. The one API-surface addition is the `X-GeoLens-Number-Matched` response header and its two entries in the CORS expose lists. No migration, no config.

## Verification

Run from this worktree with `.env.test` against Postgres on localhost:5434 (the file is gitignored and was deleted afterwards).

- `uv run pytest tests/test_dataset_rows_reserved_columns.py tests/test_features_property_filter_types.py tests/test_features_bounded_count.py tests/test_features_unwritable_columns.py tests/test_features_incremental_metadata.py tests/test_features_crud.py tests/test_layering.py tests/test_cors_range_headers_1540.py tests/test_cors_vary_origin_1602.py tests/test_search_cors_1596.py -q` -> 202 passed
- `uv run pytest tests/test_ogc_features.py tests/test_ogc_features_filter.py tests/test_ogc_pagination.py tests/test_ogc_queryables.py tests/test_ogc_public_access.py -q` -> 135 passed
- `uv run pytest tests/test_ogc_cql2_filtering.py tests/test_ogc_collection_metadata.py tests/test_dataset_rows.py tests/test_datasets.py tests/test_rule1_structural.py tests/test_standards_layering.py tests/test_dataset_rows_db_errors.py -q` -> 155 passed
- `uv run pytest tests/test_stac_api.py tests/test_stac_integration.py tests/test_stac_visibility.py tests/test_export.py tests/test_export_access.py tests/test_export_antimeridian.py tests/test_feature_geometry_limits.py tests/test_features_geojson_z.py -q` -> 152 passed
- `uv run pytest tests/test_analysis_materialize.py tests/test_analysis_preview.py tests/test_audit.py tests/test_dp01_ingest_write_path.py tests/test_sql_safety.py tests/test_codeql_qtable_suppressions.py tests/test_rule2_structural.py -q` -> 345 passed
- `uv run pytest tests/test_layering.py -q` -> 47 passed
- `uv run ruff check . && uv run ruff format --check .` -> clean, 1105 files formatted
- `PYTHONPATH=. uv run python scripts/dump_openapi.py --check` -> exit 0

Each counterfactual was measured by reverting only `backend/app/` to the commit's parent, rerunning the new test file, and restoring.

## Caps raised

- `backend/app/modules/catalog/datasets/domain/service_query.py`: 429 -> 439
- `backend/app/modules/catalog/features/service.py`: first entry, 1055, then 1135, 1187, 1384 as the later commits landed. It crossed the 1000-line inclusion threshold in this PR. The entry records the clean split for when it next grows: everything below the "Write operations" banner moves to a sibling module behind a re-export facade, because `standards/ogc/router.py` and `standards/stac/router.py` may import `features.service` and nothing else under features, and several tests reach private names through it.

## Left alone

- `features/router.py` optimistic concurrency, out of scope for this lane.
- The antimeridian seam trigger still fires on naive extent width rather than an actual crossing, so a globe-spanning dataset pays the shifted-domain scan whenever it does recompute. Deciding a real crossing needs the shifted aggregate the check exists to avoid, and the insert and edit fast paths take it off the common path.
- The audit also suggested a `SET LOCAL statement_timeout` around the inline recompute. Not done: a statement timeout aborts the surrounding transaction, so it would fail the user's edit rather than degrade the metadata, unless the aggregate is moved into its own savepoint.
- The audit's optional suggestion of adding 42601 to a sqlstate set was not taken. With the identifiers quoted, that path cannot emit 42601, and a future escape is better caught by the quoting than reclassified.



## Review round 1

Both findings were in `features/service.py`, fixed in 7b4bf0855.

**P1, pagination depending on the estimated total.** With the exact count capped at 20000 and a planner underestimate, `total` clamps to 20001, and the native features router decided `next` from `offset + limit < total`: at offset 20000 with limit 200 a full page came back with no link to the remaining rows. `get_features` now fetches one row past the page, drops it from the payload, and reports `has_more` on a `FeaturePage`; the native handler and the OGC items handler both build `next` from that. The over-fetch the OGC handler used to do for itself moved into the service, so `limit + 1` happens once rather than in each caller. STAC shares no pagination here: `standards/stac/router.py` imports only `parse_bbox` from this module. `total` is additionally floored at the rows already served plus the one more known to exist, so `numberMatched` cannot contradict the features beside it.

**P2, the prior-bounds read racing the mutation.** The envelope a write overwrites is now captured by the mutating statement: `DELETE ... RETURNING` for deletes, and for the two update paths a CTE that takes `FOR UPDATE` on the target row and returns the values it overwrote, so the envelope is the version that statement actually replaced. `replace_feature` and `update_feature` return a `FeatureWrite(feature, prior_bounds)` and the routers read it from the write; the unlocked helper is deleted rather than left for a future caller.

The same push closes the half the prior-bounds capture did not: the stored extent was also read unlocked, so two writers on one dataset could still interleave read-decide-write, one skipping the recompute because its geometry was inside the extent it read while the other shrank that extent from an aggregate taken before the first row landed. Both metadata paths now read the extent `FOR UPDATE` before either decides anything. Every writer that reaches `refresh_dataset_metadata` updates the dataset row before commit anyway, so it already serialized with its peers; the lock only moves that serialization ahead of the decision that depends on it, and both paths take the record row before the dataset row, matching the ORM's flush order.

### Round 1 verification

- `uv run pytest tests/test_features_bounded_count.py tests/test_features_incremental_metadata.py tests/test_features_unwritable_columns.py tests/test_features_property_filter_types.py tests/test_features_crud.py tests/test_features_geojson_z.py tests/test_export_antimeridian.py tests/test_extent_producers_934.py tests/test_dataset_rows_reserved_columns.py -q` -> 152 passed
- `uv run pytest tests/test_ogc_features.py tests/test_ogc_features_filter.py tests/test_ogc_pagination.py tests/test_ogc_queryables.py tests/test_ogc_public_access.py -q` -> 135 passed
- `uv run pytest tests/test_stac_api.py tests/test_stac_integration.py tests/test_export.py tests/test_export_access.py tests/test_rule1_structural.py tests/test_standards_layering.py tests/test_audit.py tests/test_analysis_preview.py -q` -> 203 passed
- `uv run pytest tests/test_layering.py -q` -> 47 passed
- `uv run ruff check . && uv run ruff format --check .` -> clean
- `PYTHONPATH=. uv run python scripts/dump_openapi.py --check` -> exit 0

New pins. P1: 20300 matching rows with `_planner_row_estimate` forced to 0, offset 20000 limit 200 emits `next` with `offset=20200` and `numberMatched >= 20200`; the last page at offset 20200 returns 100 rows and no `next`; the same boundary through the OGC items handler; and a service-level assertion that `has_more` is true while `total_is_estimate` is true. P2: two sessions on :5434, where session A reads the envelope with a plain SELECT, a second session moves the feature far outside the extent and commits, and A then deletes or replaces it; the captured envelope equals the moved-to point, differs from A's own earlier read, and the refresh runs the aggregate rather than the fast path. Plus a NULL-geometry delete reporting no bounds, and missing-gid raises on both paths.

Counterfactual against the parent commit: 9 of these fail, the P1 link case with "a full page with rows remaining must link on".

Cap for `features/service.py` raised 1384 -> 1491 in the same commit.



## Review round 2

One P2 on the native handler's exception tuple, fixed in 6f36932a0. Measuring it first changed what the fix had to be, so both corrections are recorded here.

The reported example does not reproduce as a 500. `?ratio=1e100` on a REAL column goes through the property-filter path, where SQLAlchemy's `REAL()` bind emits no narrowing cast: PostgreSQL promotes the stored float4, compares in float8, and answers 200 with zero features. `?construction_year=2147483648` on an INTEGER column is the same shape, bound BigInteger, where `int4 = int8` is a legal comparison no stored value can satisfy. Both are worse than the reported 500, because a confident wrong answer is harder to notice than an error.

SQLSTATE 22003 is real, on the other path: `filter=ratio = 1e100` compiles to `ratio = CAST($1::FLOAT AS REAL)` and that cast does overflow. The exception class is not `DataError` either. SQLAlchemy's asyncpg dialect wraps both `NumericValueOutOfRangeError` and `asyncpg.exceptions.DataError` into the base `sqlalchemy.exc.DBAPIError`, so `except DataError` never fired and the OGC handler 500'd on it too; adding `DataError` to the native tuple would have fixed nothing.

Both routers now catch `DBAPIError` and classify through one shared `is_caller_type_fault` in `core/db/sqlstate.py`. They had genuinely drifted, which is the half of the finding that held exactly: the OGC handler carried the type-fault set inline while the native list tested a narrower `BAD_QUERY_INPUT`, so one failure was a 400 through one endpoint and a 503 through the other. The 503 and 500 branches keep their existing shape, so an unrecognized state stays an honest 500 rather than being reported as an outage.

The pre-execution range checks are what actually turn the two pinned cases into 400s. `core/db/pg_ranges.py` holds the int2/int4/int8 bounds and the float4 magnitude; the property-filter path and the CQL2 comparison path both read it, which also replaces the single int8 bound CQL2 had been applying to smallint, integer and bigint alike.

Every typed bind built from a caller value in the features service, and where each now goes:

| bind | handling |
| --- | --- |
| property filters | parse, then `check_pg_value_range`, a 400 naming the property and the bound |
| CQL2 comparison literals | the same table, through `_checked_value` |
| limit / offset / after_gid | `check_int8_range`, a 400 naming the parameter. FastAPI's `int` has no upper bound, so `?offset=10**23` was a 500 on both routers |
| bbox | binds float8, which has no narrowing step to overflow, and `parse_bbox` already refuses non-finite values. Left alone |
| OGC `datetime` | reaches the pagination-link builder only, never a bind |

### Round 2 verification

- `uv run pytest tests/test_features_property_filter_types.py -q` -> 28 passed
- `uv run pytest tests/test_ogc_features.py tests/test_ogc_features_filter.py tests/test_ogc_cql2_filtering.py tests/test_ogc_queryables.py tests/test_ogc_pagination.py tests/test_ogc_public_access.py -q` -> 165 passed
- `uv run pytest tests/test_features_bounded_count.py tests/test_features_incremental_metadata.py tests/test_features_unwritable_columns.py tests/test_features_crud.py tests/test_features_geojson_z.py tests/test_dataset_rows_db_errors.py tests/test_dataset_rows_reserved_columns.py tests/test_export_antimeridian.py -q` -> 152 passed
- `uv run pytest tests/test_stac_api.py tests/test_stac_integration.py tests/test_stac_search_validation.py tests/test_export.py tests/test_export_access.py tests/test_rule1_structural.py tests/test_standards_layering.py tests/test_datasets.py -q` -> 175 passed
- `uv run pytest tests/test_layering.py -q` -> 47 passed
- `uv run ruff check . && uv run ruff format --check .` -> clean
- `PYTHONPATH=. uv run python scripts/dump_openapi.py --check` -> exit 0

New pins: `1e100` on REAL and `2147483648` on INTEGER are 400s naming the property and the bound on both routers; the same two through CQL2; `offset` and `after_gid` past int8 on both; plus vacuity guards that in-range values still match, that `offset = 2**63 - 1` still answers 200, and that a huge finite bbox is not a 500. Against the parent commit 9 of these fail, 5 as silent 200s and 4 as uncaught 500s.

Cap for `features/service.py` raised 1491 -> 1507 in the same commit.



## Review round 3

One P2 on the total floor added in round 1, fixed in 917c37005. Reproduced against the parent commit before changing anything: five matches asked for at offset 100 reported `numberMatched: 100` on both routers, and a keyset page with `after_gid` plus `offset=100` reported 111 against a thirty-row match set.

The r1 floor read `offset + len(rows)` unconditionally, so it invented matches out of the offset rather than reporting what the query found. It is now a claim about rows that exist, and only ever raises an estimate:

- An exact count is never raised. It already counted the whole match set, so anything above it is fiction. That also stops a full page of an exact count reporting `count + 1`.
- An empty page proves nothing and leaves the total alone.
- A keyset page floors by the rows in hand only, because the query ignores `offset` when `after_gid` is set and borrowing an offset it never applied would invent matches the same way.

The property the floor exists for is unchanged: an estimate below the rows a page is about to show still floors to `offset + len(rows) + 1`, so `numberMatched` cannot contradict the features beside it in the same response.

Extracted to `_floor_estimated_total` rather than narrowed in place, because `get_features` was back at ruff's C901 ceiling at 16 and because each of the three conditions is a separate claim that wants its reason recorded beside it.

### Round 3 verification

- `uv run pytest tests/test_layering.py tests/test_features_bounded_count.py -q` -> 64 passed
- `uv run pytest tests/test_ogc_features.py tests/test_ogc_features_filter.py tests/test_ogc_pagination.py tests/test_ogc_cql2_filtering.py tests/test_ogc_queryables.py tests/test_ogc_public_access.py -q` -> 165 passed
- `uv run pytest tests/test_features_property_filter_types.py tests/test_features_incremental_metadata.py tests/test_features_unwritable_columns.py tests/test_features_crud.py tests/test_features_geojson_z.py tests/test_export_antimeridian.py tests/test_dataset_rows_reserved_columns.py -q` -> 143 passed
- `uv run pytest tests/test_stac_api.py tests/test_stac_integration.py tests/test_export.py tests/test_export_access.py tests/test_rule1_structural.py tests/test_standards_layering.py tests/test_datasets.py -q` -> 167 passed
- `uv run ruff check . && uv run ruff format --check .` -> clean
- `PYTHONPATH=. uv run python scripts/dump_openapi.py --check` -> exit 0

New pins: five matches at offset 100 report 5 with no `next`, on the native endpoint and on OGC items; a keyset page with `after_gid` and a bogus `offset=100` reports the true 30; an exact count with a full page stays at the count rather than count + 1; an estimated low count with a full page still floors to exactly `20000 + 200 + 1`; and an estimated count on a page past the end is not floored at all. Four fail on the parent commit, with the measured values 100, 100, 111 and 21300.

Cap for `features/service.py` raised 1507 -> 1541 in the same commit.
