### PR TITLE
fix(ingest,raster,analysis): raster and analysis lifecycle items from the 2026-08-30 audit

### DIFF
--- a/backend/app/core/raster_bands.py
+++ b/backend/app/core/raster_bands.py
@@ -1,0 +1,71 @@
+"""Normalisation for the `raster_assets.band_info` JSONB column.
+
+fix(#1778). `band_info` is schemaless and has two producers that never agreed
+on a shape, and two serializers that each read one of them.
+
+Producer A, `extract_raster_metadata` (local ingest), writes
+`{index, dtype, nodata, color_interp, unit?}`. Producer B, `fetch_cog_info` (a
+remote COG described through the STAC import path), writes `{min, max, mean}`.
+The canonical shape is A: it is what every locally ingested raster carries,
+what the STAC serializer was written against, and the only one of the two that
+says anything a `raster:bands` entry needs.
+
+B is normalised on READ rather than migrated. The two readers are the only
+consumers, and neither can be handed a shape it does not understand without
+this normalisation anyway, so a data migration would buy nothing the readers do
+not already have to do.
+
+It lives in `core/` because both readers need it and they sit on opposite sides
+of a layering rule: `app/modules/catalog/` may not import `app.processing.*`
+(CATPORT-02/04), and the STAC half of the pair is
+`app/processing/raster/models.py`. A shared low-level module is the seam that
+keeps the two representations of one dataset from disagreeing about a band
+again, which is the defect this file exists to close.
+"""
+
+# The three non-numeric values the STAC Raster Extension accepts for `nodata`.
+_STAC_NODATA_SENTINELS = ("nan", "inf", "-inf")
+
+
+def band_display_name(band: dict) -> str | None:
+    """The band's human-readable name, from whichever key carries it.
+
+    Producer A writes the colour interpretation under `color_interp`. Nothing
+    writes `name`, which is what the OGC Records serializer used to read, so
+    every locally ingested raster reported band names through STAC and not
+    through Records.
+    """
+    return band.get("name") or band.get("color_interp")
+
+
+def stac_band_nodata(value: object) -> float | int | str | None:
+    """A `raster:bands[].nodata` value the STAC Raster Extension accepts.
+
+    The extension allows a number, or the strings "nan", "inf" and "-inf".
+    Producer A stores `str(src.nodata)`, so a raster with nodata 0 arrives here
+    as `"0.0"` and used to be published verbatim: a string where the schema
+    requires a number, which fails validation and hands pystac and rio-stac
+    consumers the wrong type.
+
+    Anything that parses as a number is emitted as a number; the three named
+    sentinels pass through as the strings the extension defines; anything else
+    is dropped, because an unparseable nodata is not a value a conforming
+    consumer can act on.
+
+    `bool` is rejected rather than emitted as 0/1: it is an `int` subclass in
+    Python, and no raster carries a boolean nodata, so a True here means the
+    column holds something this function should not be guessing about.
+    """
+    if value is None or isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        return value
+    if not isinstance(value, str):
+        return None
+    text = value.strip()
+    if text.lower() in _STAC_NODATA_SENTINELS:
+        return text.lower()
+    try:
+        return float(text)
+    except ValueError:
+        return None

--- a/backend/app/modules/catalog/search/service_records.py
+++ b/backend/app/modules/catalog/search/service_records.py
@@ -13,6 +13,7 @@ if TYPE_CHECKING:
 import structlog
 
 from app.core.config import settings
+from app.core.raster_bands import band_display_name, stac_band_nodata
 from app.core.record_types import RASTER_FAMILY_RECORD_TYPES
 from app.modules.catalog.datasets.domain.models import Dataset
 from app.modules.catalog.datasets.domain.source_freshness import (
@@ -503,35 +504,45 @@ def dataset_to_ogc_record(
         if raster_meta.get("band_count"):
             ogc_record["properties"]["band_count"] = raster_meta["band_count"]
 
-        # Build bands array from band_info
+        # Build bands array from band_info.
+        # fix(#1778): through the same two normalisers the STAC serializer
+        # uses (`app.core.raster_bands`), so one dataset cannot report a band
+        # one way here and another way there. `name` used to be read directly, a key no producer writes,
+        # so the colour interpretation of every locally ingested raster was
+        # dropped from this representation alone. Empty entries are skipped for
+        # the reason given in `to_stac_properties`.
         bands = []
         band_info = raster_meta.get("band_info")
         if band_info and isinstance(band_info, list):
             for bi in band_info:
+                if not isinstance(bi, dict):
+                    continue
                 band_entry: dict = {}
-                if isinstance(bi, dict):
-                    if bi.get("name"):
-                        band_entry["name"] = bi["name"]
-                    if bi.get("dtype"):
-                        band_entry["data_type"] = bi["dtype"]
-                    if bi.get("nodata") is not None:
-                        band_entry["nodata"] = bi["nodata"]
-                    elif raster_meta.get("nodata") is None:
-                        # fix(#1805 review round 4 P2): this band's own
-                        # stats don't carry a nodata value, but the asset
-                        # WAS probed (band_info exists) and its
-                        # authoritative RasterAsset.nodata column is None --
-                        # NoData is confirmed absent, not merely unrecorded
-                        # for this band. Emit the key explicitly so the
-                        # client can tell "absent" from "unavailable"
-                        # (OGCRasterBand.nodata omitted below means the
-                        # latter -- e.g. a remote COG whose band-level
-                        # stats carry only min/max/mean even though the
-                        # asset-level column IS set).
-                        band_entry["nodata"] = None
-                    if bi.get("description"):
-                        band_entry["description"] = bi["description"]
-                bands.append(band_entry)
+                band_name = band_display_name(bi)
+                if band_name:
+                    band_entry["name"] = band_name
+                if bi.get("dtype"):
+                    band_entry["data_type"] = bi["dtype"]
+                nodata = stac_band_nodata(bi.get("nodata"))
+                if nodata is not None:
+                    band_entry["nodata"] = nodata
+                elif raster_meta.get("nodata") is None:
+                    # fix(#1805 review round 4 P2): kept across the move to
+                    # the shared normaliser. This band's own stats don't
+                    # carry a value `stac_band_nodata` can parse, but the
+                    # asset WAS probed (band_info exists) and its
+                    # authoritative RasterAsset.nodata column is None --
+                    # NoData is confirmed absent, not merely unrecorded for
+                    # this band. Emit the key explicitly so the client can
+                    # tell "absent" from "unavailable" (nodata omitted below
+                    # means the latter -- e.g. a remote COG whose band-level
+                    # stats carry only min/max/mean even though the
+                    # asset-level column IS set).
+                    band_entry["nodata"] = None
+                if bi.get("description"):
+                    band_entry["description"] = bi["description"]
+                if band_entry:
+                    bands.append(band_entry)
         if bands:
             ogc_record["properties"]["raster:bands"] = bands
 

--- a/backend/app/platform/jobs/router.py
+++ b/backend/app/platform/jobs/router.py
@@ -63,6 +63,9 @@ from app.platform.jobs.sweep import (
     stale_pending_cutoff_seconds,
     stale_pending_unbound_values,
     sweep_stale_vrt_assets,  # noqa: F401 -- re-exported, see __all__
+    unadopted_analysis_table_from_metadata,  # noqa: F401 -- re-exported, see __all__
+    unpublished_storage_keys_from_metadata,  # noqa: F401 -- re-exported, see __all__
+    _reap_unadopted_analysis_outputs,  # noqa: F401 -- re-exported, see __all__
 )
 from app.platform.storage.titiler_url import resolve_current_storage_key
 from app.standards.ogc.errors import CONFLICT_RESPONSE, ERROR_RESPONSES_AUTH
@@ -1255,4 +1258,10 @@ __all__ = [
     "stale_pending_cutoff_seconds",
     "stale_pending_unbound_values",
     "sweep_stale_vrt_assets",
+    # fix(#1778): the startup recovery pass reaps the same pre-commit raster
+    # objects and analysis outputs the periodic sweep does, through the same
+    # façade.
+    "_reap_unadopted_analysis_outputs",
+    "unadopted_analysis_table_from_metadata",
+    "unpublished_storage_keys_from_metadata",
 ]

--- a/backend/app/platform/jobs/router.py
+++ b/backend/app/platform/jobs/router.py
@@ -66,6 +66,7 @@ from app.platform.jobs.sweep import (
     unadopted_analysis_table_from_metadata,  # noqa: F401 -- re-exported, see __all__
     unpublished_storage_keys_from_metadata,  # noqa: F401 -- re-exported, see __all__
     _reap_unadopted_analysis_outputs,  # noqa: F401 -- re-exported, see __all__
+    reap_unpublished_storage_keys,  # noqa: F401 -- re-exported, see __all__
 )
 from app.platform.storage.titiler_url import resolve_current_storage_key
 from app.standards.ogc.errors import CONFLICT_RESPONSE, ERROR_RESPONSES_AUTH
@@ -1262,6 +1263,7 @@ __all__ = [
     # objects and analysis outputs the periodic sweep does, through the same
     # façade.
     "_reap_unadopted_analysis_outputs",
+    "reap_unpublished_storage_keys",
     "unadopted_analysis_table_from_metadata",
     "unpublished_storage_keys_from_metadata",
 ]

--- a/backend/app/platform/jobs/router.py
+++ b/backend/app/platform/jobs/router.py
@@ -63,7 +63,7 @@ from app.platform.jobs.sweep import (
     stale_pending_cutoff_seconds,
     stale_pending_unbound_values,
     sweep_stale_vrt_assets,  # noqa: F401 -- re-exported, see __all__
-    unadopted_analysis_table_from_metadata,  # noqa: F401 -- re-exported, see __all__
+    unadopted_analysis_tables_from_metadata,  # noqa: F401 -- re-exported, see __all__
     unpublished_storage_keys_from_metadata,  # noqa: F401 -- re-exported, see __all__
     _reap_unadopted_analysis_outputs,  # noqa: F401 -- re-exported, see __all__
     reap_unpublished_storage_keys,  # noqa: F401 -- re-exported, see __all__
@@ -1264,6 +1264,6 @@ __all__ = [
     # façade.
     "_reap_unadopted_analysis_outputs",
     "reap_unpublished_storage_keys",
-    "unadopted_analysis_table_from_metadata",
+    "unadopted_analysis_tables_from_metadata",
     "unpublished_storage_keys_from_metadata",
 ]

--- a/backend/app/platform/jobs/sweep.py
+++ b/backend/app/platform/jobs/sweep.py
@@ -866,6 +866,39 @@ async def _live_referenced_storage_keys(keys: tuple[str, ...]) -> set[str]:
 STORAGE_KEY_FINAL_OUTCOMES = frozenset({"deleted", "refused"})
 
 
+# fix(#1778 codex r9): the settled keys come off the recorded list one by one,
+# and the field is dropped only when the list empties. Expressed as SQL rather
+# than read-modify-write in Python because two rows can name overlapping keys
+# and the sweep must not race itself.
+#
+# `jsonb_exists_any` rather than the `?|` operator it implements: `?` is not a
+# bind marker for SQLAlchemy, but keeping it out of the string leaves nothing
+# for a driver or a future dialect to misread. Every bind is cast explicitly,
+# because `jsonb - $1` is ambiguous between the text, integer and text[] forms
+# until the parameter has a type.
+_CLEAR_SETTLED_STORAGE_KEYS_SQL = """
+UPDATE catalog.ingest_jobs SET user_metadata =
+  CASE WHEN (
+         SELECT coalesce(jsonb_agg(k), '[]'::jsonb)
+         FROM jsonb_array_elements_text(user_metadata -> (:field)::text) AS k
+         WHERE NOT (k = ANY((:settled)::text[]))
+       ) = '[]'::jsonb
+       THEN user_metadata - (:field)::text
+       ELSE jsonb_set(
+              user_metadata,
+              ARRAY[(:field)::text],
+              (
+                SELECT coalesce(jsonb_agg(k), '[]'::jsonb)
+                FROM jsonb_array_elements_text(user_metadata -> (:field)::text) AS k
+                WHERE NOT (k = ANY((:settled)::text[]))
+              )
+            )
+  END
+WHERE jsonb_typeof(user_metadata -> (:field)::text) = 'array'
+  AND jsonb_exists_any(user_metadata -> (:field)::text, (:settled)::text[])
+"""
+
+
 async def _clear_settled_artifact_records(
     *,
     storage_keys: set[str] = frozenset(),  # type: ignore[assignment]
@@ -895,7 +928,7 @@ async def _clear_settled_artifact_records(
     correctness.
     """
     from sqlalchemy import Text, bindparam, cast, literal
-    from sqlalchemy.dialects.postgresql import JSONB
+    from sqlalchemy.dialects.postgresql import ARRAY
 
     from app.core.db import async_session
     from app.platform.jobs.models import IngestJob
@@ -909,26 +942,19 @@ async def _clear_settled_artifact_records(
     try:
         async with async_session() as session:
             if storage_keys:
+                # fix(#1778 codex r9): remove the settled KEYS, not the whole
+                # field. The record accumulates across attempts now, so a
+                # retried job's row names the previous attempt's objects as
+                # well as this one's, and dropping the field wholesale would
+                # forget keys this pass never reached an answer about. The
+                # field itself goes only once nothing is left owed on it,
+                # which is what lets the retention purge finally take the row.
                 await session.execute(
-                    update(IngestJob)
-                    .where(
-                        IngestJob.user_metadata[UNPUBLISHED_STORAGE_KEYS_FIELD].is_not(
-                            None
+                    text(_CLEAR_SETTLED_STORAGE_KEYS_SQL).bindparams(
+                        bindparam("field", value=UNPUBLISHED_STORAGE_KEYS_FIELD),
+                        bindparam(
+                            "settled", value=sorted(storage_keys), type_=ARRAY(Text)
                         ),
-                        IngestJob.user_metadata[UNPUBLISHED_STORAGE_KEYS_FIELD].op(
-                            "<@"
-                        )(
-                            bindparam(
-                                "settled_keys",
-                                value=sorted(storage_keys),
-                                type_=JSONB,
-                            )
-                        ),
-                    )
-                    .values(
-                        user_metadata=IngestJob.user_metadata.op("-")(
-                            cast(literal(UNPUBLISHED_STORAGE_KEYS_FIELD), Text)
-                        )
                     )
                 )
             if analysis_job_ids:

--- a/backend/app/platform/jobs/sweep.py
+++ b/backend/app/platform/jobs/sweep.py
@@ -794,20 +794,23 @@ def unpublished_storage_keys_from_metadata(
     )
 
 
-def unadopted_analysis_table_from_metadata(user_metadata: object) -> str | None:
-    """Read the output table an analysis job named on its own job row.
+def unadopted_analysis_tables_from_metadata(user_metadata: object) -> tuple[str, ...]:
+    """Read EVERY output table an analysis job named on its own job row.
 
     fix(#1778). The name is generated inside the worker and every DROP of it
     lives in a handler a SIGKILL never runs, so the table used to survive with
     no catalog row and nothing able to name it. ``drop_unadopted_analysis_output``
     re-validates the identifier before it reaches DDL; this only reads it.
-    """
-    from app.processing.analysis.tasks import ANALYSIS_OUTPUT_TABLE_FIELD
 
-    if not isinstance(user_metadata, dict):
-        return None
-    name = user_metadata.get(ANALYSIS_OUTPUT_TABLE_FIELD)
-    return name if isinstance(name, str) and name else None
+    fix(#1778 codex r10): all of them, not one. The record accumulates across
+    attempts now, because a retry keeps the row and its old name would
+    otherwise be overwritten. Delegated to the writer's own normaliser so the
+    two cannot disagree about the shape, including about the string an existing
+    row still holds.
+    """
+    from app.processing.analysis.tasks import recorded_analysis_output_tables
+
+    return recorded_analysis_output_tables(user_metadata)
 
 
 async def _live_referenced_storage_keys(keys: tuple[str, ...]) -> set[str]:
@@ -876,33 +879,62 @@ STORAGE_KEY_FINAL_OUTCOMES = frozenset({"deleted", "refused"})
 # for a driver or a future dialect to misread. Every bind is cast explicitly,
 # because `jsonb - $1` is ambiguous between the text, integer and text[] forms
 # until the parameter has a type.
-_CLEAR_SETTLED_STORAGE_KEYS_SQL = """
+# fix(#1778 codex r10): how many artifact-owing rows one pass collects. The set
+# shrinks only as reaps succeed, so a backlog can outlive several passes, and a
+# pass that took all of one would hold its reaping session open across every
+# delete in it. What this leaves behind, the next pass picks up.
+_ARTIFACT_REAP_BATCH = 500
+
+
+# fix(#1778 codex r10): `analysis_out_table` has a real pre-PR production
+# shape this SQL has to keep clearing — a plain JSONB string, from a row an
+# earlier build wrote before the field became a list. `unpublished_storage_keys`
+# never had that shape (it was born a list in r9), so the STRING arm below is
+# dead code for that field and exercised only by the analysis one. Read it as
+# a one-element list would: a string that IS the settled value clears the
+# field outright, the same as an array that empties out. Without this arm the
+# WHERE clause's `jsonb_typeof(...) = 'array'` guard silently excluded every
+# legacy row from ever matching, so a reap that dropped the table correctly
+# left the pointer on the row forever and the retention purge could never
+# take it — the exact "row the retention purge refuses to delete" state this
+# whole mechanism exists to make temporary, turned permanent.
+_CLEAR_SETTLED_LIST_SQL = """
 UPDATE catalog.ingest_jobs SET user_metadata =
-  CASE WHEN (
-         SELECT coalesce(jsonb_agg(k), '[]'::jsonb)
-         FROM jsonb_array_elements_text(user_metadata -> (:field)::text) AS k
-         WHERE NOT (k = ANY((:settled)::text[]))
-       ) = '[]'::jsonb
-       THEN user_metadata - (:field)::text
-       ELSE jsonb_set(
-              user_metadata,
-              ARRAY[(:field)::text],
-              (
-                SELECT coalesce(jsonb_agg(k), '[]'::jsonb)
-                FROM jsonb_array_elements_text(user_metadata -> (:field)::text) AS k
-                WHERE NOT (k = ANY((:settled)::text[]))
-              )
-            )
+  CASE
+    WHEN jsonb_typeof(user_metadata -> (:field)::text) = 'array' THEN
+      CASE WHEN (
+             SELECT coalesce(jsonb_agg(k), '[]'::jsonb)
+             FROM jsonb_array_elements_text(user_metadata -> (:field)::text) AS k
+             WHERE NOT (k = ANY((:settled)::text[]))
+           ) = '[]'::jsonb
+           THEN user_metadata - (:field)::text
+           ELSE jsonb_set(
+                  user_metadata,
+                  ARRAY[(:field)::text],
+                  (
+                    SELECT coalesce(jsonb_agg(k), '[]'::jsonb)
+                    FROM jsonb_array_elements_text(user_metadata -> (:field)::text) AS k
+                    WHERE NOT (k = ANY((:settled)::text[]))
+                  )
+                )
+      END
+    ELSE user_metadata - (:field)::text
   END
-WHERE jsonb_typeof(user_metadata -> (:field)::text) = 'array'
-  AND jsonb_exists_any(user_metadata -> (:field)::text, (:settled)::text[])
+WHERE (
+        jsonb_typeof(user_metadata -> (:field)::text) = 'array'
+        AND jsonb_exists_any(user_metadata -> (:field)::text, (:settled)::text[])
+      )
+   OR (
+        jsonb_typeof(user_metadata -> (:field)::text) = 'string'
+        AND (user_metadata ->> (:field)::text) = ANY((:settled)::text[])
+      )
 """
 
 
 async def _clear_settled_artifact_records(
     *,
     storage_keys: set[str] = frozenset(),  # type: ignore[assignment]
-    analysis_job_ids: set[uuid.UUID] = frozenset(),  # type: ignore[assignment]
+    analysis_tables: set[str] = frozenset(),  # type: ignore[assignment]
 ) -> None:
     """Drop the job-row record of artifacts that are now accounted for.
 
@@ -927,17 +959,16 @@ async def _clear_settled_artifact_records(
     row it may delete, and failing to do it costs one more sweep, not
     correctness.
     """
-    from sqlalchemy import Text, bindparam, cast, literal
+    from sqlalchemy import Text, bindparam
     from sqlalchemy.dialects.postgresql import ARRAY
 
     from app.core.db import async_session
-    from app.platform.jobs.models import IngestJob
     from app.processing.analysis.tasks import ANALYSIS_OUTPUT_TABLE_FIELD
     from app.processing.ingest.tasks_raster_common import (
         UNPUBLISHED_STORAGE_KEYS_FIELD,
     )
 
-    if not storage_keys and not analysis_job_ids:
+    if not storage_keys and not analysis_tables:
         return
     try:
         async with async_session() as session:
@@ -950,31 +981,26 @@ async def _clear_settled_artifact_records(
                 # field itself goes only once nothing is left owed on it,
                 # which is what lets the retention purge finally take the row.
                 await session.execute(
-                    text(_CLEAR_SETTLED_STORAGE_KEYS_SQL).bindparams(
+                    text(_CLEAR_SETTLED_LIST_SQL).bindparams(
                         bindparam("field", value=UNPUBLISHED_STORAGE_KEYS_FIELD),
                         bindparam(
                             "settled", value=sorted(storage_keys), type_=ARRAY(Text)
                         ),
                     )
                 )
-            if analysis_job_ids:
-                # fix(#1778 codex r7): addressed by row id, not by name. A name
-                # was never a safe key for this: two jobs could hold one, so
-                # settling the old job's table stripped the new job's recovery
-                # pointer with it. Names are job-scoped now and the id is the
-                # direct expression of what was settled either way.
+            if analysis_tables:
+                # fix(#1778 codex r10): by VALUE, through the same statement the
+                # storage keys use. r7 keyed this on the row id, which was safe
+                # only while a row named one table; the record accumulates
+                # across attempts now, so clearing "the field for this job"
+                # would forget a name this pass never answered for. A name is a
+                # safe key again because it carries the attempt that made it.
                 await session.execute(
-                    update(IngestJob)
-                    .where(
-                        IngestJob.id.in_(sorted(analysis_job_ids)),
-                        IngestJob.user_metadata[
-                            ANALYSIS_OUTPUT_TABLE_FIELD
-                        ].astext.is_not(None),
-                    )
-                    .values(
-                        user_metadata=IngestJob.user_metadata.op("-")(
-                            cast(literal(ANALYSIS_OUTPUT_TABLE_FIELD), Text)
-                        )
+                    text(_CLEAR_SETTLED_LIST_SQL).bindparams(
+                        bindparam("field", value=ANALYSIS_OUTPUT_TABLE_FIELD),
+                        bindparam(
+                            "settled", value=sorted(analysis_tables), type_=ARRAY(Text)
+                        ),
                     )
                 )
             await session.commit()
@@ -982,7 +1008,7 @@ async def _clear_settled_artifact_records(
         log.warning(
             "Failed to clear settled artifact records",
             key_count=len(storage_keys),
-            job_count=len(analysis_job_ids),
+            table_count=len(analysis_tables),
         )
 
 
@@ -1108,11 +1134,13 @@ async def _reap_unadopted_analysis_outputs(
     # permanently. Only a final outcome settles; "failed" is retryable and
     # keeps the record. The try/except stays for a failure the callee does not
     # catch at all, and it deliberately does not settle either.
-    # fix(#1778 codex r7): keyed on the JOB, not on the name. The reap passes
-    # the owning job so the drop can refuse a table that job did not create,
-    # and the record clearing addresses rows by id so it cannot strip a
-    # different job's pointer that happens to share a name.
-    settled: set[uuid.UUID] = set()
+    # fix(#1778 codex r10): names, and settled by name. r7 carried (job, table)
+    # pairs so the drop could check ownership against the job, and r10 moved
+    # that proof into the name itself: it carries the job AND the attempt that
+    # made it, so no two attempts of one job can name one table and the name is
+    # a safe key for the clear again. The drop still re-derives the check from
+    # the scope, which is what refuses a name from a foreign row.
+    settled: set[str] = set()
     async with async_session() as session:
         for job_uuid, out_table in set(out_tables):
             try:
@@ -1127,13 +1155,13 @@ async def _reap_unadopted_analysis_outputs(
                 log.warning("Failed to reap unadopted analysis output")
                 continue
             if outcome in ANALYSIS_OUTPUT_FINAL_OUTCOMES:
-                settled.add(job_uuid)
+                settled.add(out_table)
             else:
                 log.warning(
                     "Analysis output reap did not settle, retrying next sweep",
                     outcome=outcome,
                 )
-    await _clear_settled_artifact_records(analysis_job_ids=settled)
+    await _clear_settled_artifact_records(analysis_tables=settled)
 
 
 def _stale_generation_storage_keys(
@@ -1816,6 +1844,25 @@ async def fail_stale_jobs(
     pending_rows += bound_pending_rows
     pending_job_ids += [row[0] for row in bound_pending_rows]
 
+    # fix(#1778 codex r4/r10): "this row still names an artifact nothing has
+    # reaped". The retention purge refuses to delete such a row, so the record
+    # survives for a later pass to retry, and the artifact collection below
+    # starts from the same predicate so the two can never disagree about which
+    # rows still owe something.
+    #
+    # A string test on the JSONB blob, never a cast: the same rule the `s3_key`
+    # clause states, because a malformed value must not be able to throw and
+    # fail the whole bulk pass.
+    from app.processing.analysis.tasks import ANALYSIS_OUTPUT_TABLE_FIELD
+    from app.processing.ingest.tasks_raster_common import (
+        UNPUBLISHED_STORAGE_KEYS_FIELD,
+    )
+
+    carries_unreaped_artifacts = or_(
+        IngestJob.user_metadata[UNPUBLISHED_STORAGE_KEYS_FIELD].is_not(None),
+        IngestJob.user_metadata[ANALYSIS_OUTPUT_TABLE_FIELD].is_not(None),
+    )
+
     running_cutoff = now - timedelta(seconds=JOB_TIMEOUT_SECONDS)
     running_result = await db.execute(
         update(IngestJob)
@@ -1835,21 +1882,6 @@ async def fail_stale_jobs(
     )
     running_rows = list(running_result.all())
     running_job_ids = [row[0] for row in running_rows]
-    # fix(#1778): resolved here, deleted only after this pass's commit lands,
-    # the rule every other external artifact in this function follows. Lists
-    # rather than tuples because the retention purge below appends to them:
-    # fix(#1778 codex r4) made the purge the LAST owner of these two fields,
-    # for the rows that reached a terminal status on their own.
-    unpublished_storage_keys = [
-        key
-        for _job_id, user_metadata_, _created_by in running_rows
-        for key in unpublished_storage_keys_from_metadata(user_metadata_)
-    ]
-    unadopted_analysis_tables = [
-        (job_id_, name)
-        for job_id_, user_metadata_, _created_by in running_rows
-        if (name := unadopted_analysis_table_from_metadata(user_metadata_)) is not None
-    ]
 
     # fix(#1550 review): the row and its audit trail are settled by the same
     # actor, in the same transaction. After a hard kill this sweep is the only
@@ -2107,35 +2139,6 @@ async def fail_stale_jobs(
         # row normally. A reap that fails leaves the fields in place and the
         # next sweep tries again.
         #
-        # A string test on the JSONB blob, never a cast: the same rule the
-        # `s3_key` clause above states, because a malformed value must not be
-        # able to throw and fail the whole bulk pass.
-        from app.processing.analysis.tasks import ANALYSIS_OUTPUT_TABLE_FIELD
-        from app.processing.ingest.tasks_raster_common import (
-            UNPUBLISHED_STORAGE_KEYS_FIELD,
-        )
-
-        carries_unreaped_artifacts = or_(
-            IngestJob.user_metadata[UNPUBLISHED_STORAGE_KEYS_FIELD].is_not(None),
-            IngestJob.user_metadata[ANALYSIS_OUTPUT_TABLE_FIELD].astext.is_not(None),
-        )
-        # fix(#1778 codex r7): the id comes back with the metadata, because the
-        # analysis reap is keyed on the owning job now rather than on a name
-        # two jobs could hold.
-        retained_for_reap = await db.execute(
-            select(IngestJob.id, IngestJob.user_metadata).where(
-                *purge_clauses, carries_unreaped_artifacts
-            )
-        )
-        for retained_id, retained_metadata in retained_for_reap.all():
-            unpublished_storage_keys.extend(
-                unpublished_storage_keys_from_metadata(retained_metadata)
-            )
-            if (
-                name := unadopted_analysis_table_from_metadata(retained_metadata)
-            ) is not None:
-                unadopted_analysis_tables.append((retained_id, name))
-
         # Single DELETE .. RETURNING re-applies every predicate atomically at
         # delete time — a SELECT-then-DELETE-by-id pair let /jobs/{id}/retry
         # flip a candidate back to pending between the two statements and
@@ -2185,6 +2188,49 @@ async def fail_stale_jobs(
             deleted_paths -= set(survivors.scalars())
         staged_paths_considered = len(deleted_paths)
 
+    # fix(#1778 codex r10): ONE collection, and it answers only "does this row
+    # still owe a reap". It replaces the two that came before it, and both of
+    # them could miss rows that owed one.
+    #
+    # The running-row collection saw only rows THIS pass moved off `running`,
+    # so a job that failed on an earlier pass, or that later SUCCEEDED with a
+    # dead attempt's keys carried over on its row, was never looked at again.
+    # The retention collection sat inside the purge block behind the purge's
+    # own clauses, so it skipped anything the retention cutoff had not reached
+    # and anything the latest-complete exemption held back -- and a job can be
+    # its dataset's latest complete job and still owe a reap for the attempt
+    # that failed before it.
+    #
+    # So: terminal status, still carrying a record, whatever its age and
+    # whatever else exempts it from deletion. It runs outside the retention
+    # block because a deployment with retention disabled still owes these
+    # reaps. It sits after every status write above so a row this pass just
+    # settled is already terminal to it. Bounded, because the set is only as
+    # small as the reaps that have succeeded, and a pass that tried to take all
+    # of a large backlog would hold its session open across every delete; what
+    # it does not reach, the next pass does.
+    artifact_rows = await db.execute(
+        select(IngestJob.id, IngestJob.user_metadata)
+        .where(
+            IngestJob.status.not_in(("pending", "running")),
+            carries_unreaped_artifacts,
+        )
+        .limit(_ARTIFACT_REAP_BATCH)
+    )
+    unpublished_storage_keys: list[str] = []
+    # The row id rides along so the drop can still refuse a name that is not
+    # this job's. Ownership is proved by the name's scope; carrying the id is
+    # what lets the drop check it without a second read.
+    unadopted_analysis_tables: list[tuple[uuid.UUID, str]] = []
+    for artifact_id, artifact_metadata in artifact_rows.all():
+        unpublished_storage_keys.extend(
+            unpublished_storage_keys_from_metadata(artifact_metadata)
+        )
+        unadopted_analysis_tables.extend(
+            (artifact_id, name)
+            for name in unadopted_analysis_tables_from_metadata(artifact_metadata)
+        )
+
     outcome = StaleCleanupOutcome(
         pending_failed=len(pending_job_ids) - pending_cancelled,
         pending_cancelled=pending_cancelled,
@@ -2201,8 +2247,8 @@ async def fail_stale_jobs(
         _staged_presigned_keys=tuple(sorted(deleted_presigned_keys)),
         _refresh_runs_reconciled=cancelled_runs,
         _stale_generation_storage_keys=stale_generation_storage_keys,
-        _unpublished_storage_keys=tuple(unpublished_storage_keys),
-        _unadopted_analysis_tables=tuple(unadopted_analysis_tables),
+        _unpublished_storage_keys=tuple(sorted(set(unpublished_storage_keys))),
+        _unadopted_analysis_tables=tuple(sorted(set(unadopted_analysis_tables))),
     )
     if commit:
         # Never remove an external artifact for a DELETE that may still roll

--- a/backend/app/platform/jobs/sweep.py
+++ b/backend/app/platform/jobs/sweep.py
@@ -1638,17 +1638,20 @@ async def fail_stale_jobs(
     running_rows = list(running_result.all())
     running_job_ids = [row[0] for row in running_rows]
     # fix(#1778): resolved here, deleted only after this pass's commit lands,
-    # the rule every other external artifact in this function follows.
-    unpublished_storage_keys = tuple(
+    # the rule every other external artifact in this function follows. Lists
+    # rather than tuples because the retention purge below appends to them:
+    # fix(#1778 codex r4) made the purge the LAST owner of these two fields,
+    # for the rows that reached a terminal status on their own.
+    unpublished_storage_keys = [
         key
         for _job_id, user_metadata_, _created_by in running_rows
         for key in unpublished_storage_keys_from_metadata(user_metadata_)
-    )
-    unadopted_analysis_tables = tuple(
+    ]
+    unadopted_analysis_tables = [
         name
         for _job_id, user_metadata_, _created_by in running_rows
         if (name := unadopted_analysis_table_from_metadata(user_metadata_)) is not None
-    )
+    ]
 
     # fix(#1550 review): the row and its audit trail are settled by the same
     # actor, in the same transaction. After a hard kill this sweep is the only
@@ -1898,6 +1901,26 @@ async def fail_stale_jobs(
         deleted_rows = deleted.all()
         terminal_jobs_purged = len(deleted_rows)
         deleted_paths = {fp for (_id, fp, _um) in deleted_rows if fp}
+        # fix(#1778 codex r4): the row being deleted is the last thing that can
+        # name these. The two stale-job passes only read the rows they move OFF
+        # `running`, so a job that reached `failed` or `cancelled` on its own
+        # and whose in-process best-effort cleanup then failed (a storage blip,
+        # a DROP that lost a lock race) keeps its objects and its output table
+        # with the record still pointing at them, and nothing looks again. This
+        # purge is the last actor that holds the pointer, so it is the last
+        # chance to use it. Both reaps run after this function's commit and
+        # both carry survivor checks, so a key or a table something live still
+        # owns is refused rather than deleted.
+        unpublished_storage_keys.extend(
+            key
+            for (_id, _fp, um) in deleted_rows
+            for key in unpublished_storage_keys_from_metadata(um)
+        )
+        unadopted_analysis_tables.extend(
+            name
+            for (_id, _fp, um) in deleted_rows
+            if (name := unadopted_analysis_table_from_metadata(um)) is not None
+        )
         # fix(#1202 review r5): a purged presigned job's staging key is the one
         # reference left to an object the client's PUT URL can still recreate.
         deleted_presigned_keys = {
@@ -1950,8 +1973,8 @@ async def fail_stale_jobs(
         _staged_presigned_keys=tuple(sorted(deleted_presigned_keys)),
         _refresh_runs_reconciled=cancelled_runs,
         _stale_generation_storage_keys=stale_generation_storage_keys,
-        _unpublished_storage_keys=unpublished_storage_keys,
-        _unadopted_analysis_tables=unadopted_analysis_tables,
+        _unpublished_storage_keys=tuple(unpublished_storage_keys),
+        _unadopted_analysis_tables=tuple(unadopted_analysis_tables),
     )
     if commit:
         # Never remove an external artifact for a DELETE that may still roll

--- a/backend/app/platform/jobs/sweep.py
+++ b/backend/app/platform/jobs/sweep.py
@@ -858,6 +858,14 @@ async def _live_referenced_storage_keys(keys: tuple[str, ...]) -> set[str]:
         return {row[0] for row in (await session.execute(stmt)).all() if row[0]}
 
 
+# fix(#1778 codex r6): the outcomes that license forgetting a storage key,
+# the peer of `ANALYSIS_OUTPUT_FINAL_OUTCOMES`. "refused" is final because a
+# key a live row names is answered, not pending: re-refusing it every sweep
+# forever would pin the job row for the life of the dataset. "failed" is the
+# only outcome that keeps the record, and it is the whole point of the split.
+STORAGE_KEY_FINAL_OUTCOMES = frozenset({"deleted", "refused"})
+
+
 async def _clear_settled_artifact_records(
     *,
     storage_keys: set[str] = frozenset(),  # type: ignore[assignment]
@@ -997,28 +1005,38 @@ async def reap_unpublished_storage_keys(
     # is what licenses clearing them off the job row. A delete that raised is
     # absent from it on purpose, so its row keeps the record and the next
     # sweep retries.
+    #
+    # fix(#1778 codex r6): the outcome is named, and the settle keys off the
+    # NAME rather than off where a statement sits in a try block. This arm was
+    # already correct, and correct by an ordering an edit could undo without
+    # looking wrong -- which is precisely how the analysis arm came to settle
+    # tables whose DROP had failed. Both arms now read the same way.
     settled: set[str] = set()
     for key in keys:
         if key in live:
             skipped += 1
-            settled.add(key)
+            outcome = "refused"
             log.warning(
                 "Refused to reap a raster object a live row still names",
                 storage_key=key,
             )
-            continue
-        try:
-            from app.platform.storage import get_storage
+        else:
+            try:
+                from app.platform.storage import get_storage
 
-            await get_storage().delete(resolve_current_storage_key(key))
-            reaped += 1
+                await get_storage().delete(resolve_current_storage_key(key))
+            except Exception:  # broad: best-effort staging cleanup
+                failures += 1
+                outcome = "failed"
+                log.warning(
+                    "Failed to reap unpublished raster object for stale job",
+                    storage_key=key,
+                )
+            else:
+                reaped += 1
+                outcome = "deleted"
+        if outcome in STORAGE_KEY_FINAL_OUTCOMES:
             settled.add(key)
-        except Exception:  # broad: best-effort staging cleanup
-            failures += 1
-            log.warning(
-                "Failed to reap unpublished raster object for stale job",
-                storage_key=key,
-            )
     await _clear_settled_artifact_records(storage_keys=settled)
     return (reaped, skipped, failures)
 
@@ -1042,24 +1060,42 @@ async def _reap_unadopted_analysis_outputs(out_tables: tuple[str, ...]) -> None:
     from app.core.db.tenant_schema import tenant_data_schema
     from app.core.db.tenant_session import current_tenant_var
     from app.core.tenancy import is_multi_tenant
-    from app.processing.analysis.tasks import drop_unadopted_analysis_output
+    from app.processing.analysis.tasks import (
+        ANALYSIS_OUTPUT_FINAL_OUTCOMES,
+        drop_unadopted_analysis_output,
+    )
 
     schema = tenant_data_schema(current_tenant_var.get() if is_multi_tenant() else None)
     # fix(#1778 codex r5): the peer of the storage reaper's `settled` set. A
     # table this pass reached a final answer about (dropped, or left alone
     # because a dataset row adopted it) comes off the job row; one whose drop
-    # raised stays on it, so the row survives the retention purge and the next
-    # sweep tries again.
+    # did not resolve stays on it, so the row survives the retention purge and
+    # the next sweep tries again.
+    #
+    # fix(#1778 codex r6): keyed on what the call REPORTS, not on whether it
+    # returned. `drop_unadopted_analysis_output` catches its own probe and DROP
+    # failures, so "it did not raise" was true of a failed cleanup too, and
+    # settling on that stripped the table's last durable name and orphaned it
+    # permanently. Only a final outcome settles; "failed" is retryable and
+    # keeps the record. The try/except stays for a failure the callee does not
+    # catch at all, and it deliberately does not settle either.
     settled: set[str] = set()
     async with async_session() as session:
         for out_table in set(out_tables):
             try:
-                await drop_unadopted_analysis_output(
+                outcome = await drop_unadopted_analysis_output(
                     session, out_table=out_table, schema=schema, job_id="stale_sweep"
                 )
-                settled.add(out_table)
             except Exception:  # broad: best-effort cleanup of one orphan
                 log.warning("Failed to reap unadopted analysis output")
+                continue
+            if outcome in ANALYSIS_OUTPUT_FINAL_OUTCOMES:
+                settled.add(out_table)
+            else:
+                log.warning(
+                    "Analysis output reap did not settle, retrying next sweep",
+                    outcome=outcome,
+                )
     await _clear_settled_artifact_records(analysis_tables=settled)
 
 

--- a/backend/app/platform/jobs/sweep.py
+++ b/backend/app/platform/jobs/sweep.py
@@ -737,23 +737,13 @@ async def _reap_committed_staged_paths(
 
     # fix(#1778): a killed raster ingest or replace's own pre-commit objects,
     # named on the job row before the puts and withheld from deletion until
-    # this point for the reason `_reap_stale_generation_storage` gives. Safe
-    # without a survivor query: every one of those tails stamps the job's
-    # terminal status in the SAME transaction as the pointer it publishes, so a
-    # row this pass just moved off `running` cannot have a durable publish
-    # behind it, and the keys it names are therefore referenced by nothing.
-    for unpublished_key in outcome._unpublished_storage_keys:
-        try:
-            from app.platform.storage import get_storage
-
-            await get_storage().delete(resolve_current_storage_key(unpublished_key))
-            storage_objects_reaped += 1
-        except Exception:  # broad: best-effort staging cleanup
-            staged_cleanup_failures += 1
-            log.warning(
-                "Failed to reap unpublished raster object for stale job",
-                storage_key=unpublished_key,
-            )
+    # this point for the reason `_reap_stale_generation_storage` gives.
+    reaped, skipped, failures = await reap_unpublished_storage_keys(
+        outcome._unpublished_storage_keys
+    )
+    storage_objects_reaped += reaped
+    staged_paths_skipped += skipped
+    staged_cleanup_failures += failures
 
     # fix(#1778): the analysis peer of the loop above. Same rule, same reason:
     # the table is dropped only once the row that stopped owning it is durable.
@@ -818,6 +808,102 @@ def unadopted_analysis_table_from_metadata(user_metadata: object) -> str | None:
         return None
     name = user_metadata.get(ANALYSIS_OUTPUT_TABLE_FIELD)
     return name if isinstance(name, str) and name else None
+
+
+async def _live_referenced_storage_keys(keys: tuple[str, ...]) -> set[str]:
+    """Which of ``keys`` a live catalog row still points at.
+
+    fix(#1778 codex r1). Catalog rows hold LOGICAL keys, which is the form the
+    job row records and the form this sweep carries, so the comparison is a
+    plain match with no tenant resolution on either side.
+
+    Three columns on ``raster_assets`` (the published COG or VRT and its two
+    quicklooks) plus ``dataset_assets.href`` (the kept pre-conversion original,
+    and every other counted asset). Together those are every column in the
+    schema that names an object under `rasters/` or `originals/`.
+    """
+    from sqlalchemy import union_all
+
+    from app.core.db import async_session
+    from app.platform.extensions import get_catalog_port
+    from app.processing.raster.models import RasterAsset
+
+    DatasetAsset = get_catalog_port().dataset_asset_orm_class()
+    key_list = list(keys)
+    async with async_session() as session:
+        stmt = union_all(
+            select(RasterAsset.asset_uri.label("key")).where(
+                RasterAsset.asset_uri.in_(key_list)
+            ),
+            select(RasterAsset.quicklook_256_uri.label("key")).where(
+                RasterAsset.quicklook_256_uri.in_(key_list)
+            ),
+            select(RasterAsset.quicklook_512_uri.label("key")).where(
+                RasterAsset.quicklook_512_uri.in_(key_list)
+            ),
+            select(DatasetAsset.href.label("key")).where(
+                DatasetAsset.href.in_(key_list)
+            ),
+        )
+        return {row[0] for row in (await session.execute(stmt)).all() if row[0]}
+
+
+async def reap_unpublished_storage_keys(
+    keys: tuple[str, ...],
+) -> tuple[int, int, int]:
+    """Delete a dead attempt's pre-commit objects, but never a live one.
+
+    Returns ``(reaped, skipped, failures)``.
+
+    fix(#1778 codex r1): the survivor check lives HERE, in the only function
+    that deletes these keys, rather than only at the two sites that record
+    them. A raster replace whose conversion reproduces the published COG byte
+    for byte derives the same content hash, so the keys it intends to write are
+    the keys the dataset is serving. The recording sites now subtract what the
+    live asset names, but that is a promise each writer has to keep; this is
+    the one that holds whatever the job row says, including for a job row
+    written by a version of this code that did not know to subtract.
+
+    A survivor query that fails deletes NOTHING. The asymmetry is the one every
+    reaper in this module makes: leaving objects behind is recoverable by the
+    next pass or an operator, and deleting the raster a dataset is serving is
+    not.
+    """
+    if not keys:
+        return (0, 0, 0)
+
+    try:
+        live = await _live_referenced_storage_keys(keys)
+    except Exception:  # broad: an unreadable catalog must not license a delete
+        log.warning(
+            "Skipped unpublished raster reap, survivor query failed",
+            key_count=len(keys),
+        )
+        return (0, len(keys), 0)
+
+    reaped = 0
+    skipped = 0
+    failures = 0
+    for key in keys:
+        if key in live:
+            skipped += 1
+            log.warning(
+                "Refused to reap a raster object a live row still names",
+                storage_key=key,
+            )
+            continue
+        try:
+            from app.platform.storage import get_storage
+
+            await get_storage().delete(resolve_current_storage_key(key))
+            reaped += 1
+        except Exception:  # broad: best-effort staging cleanup
+            failures += 1
+            log.warning(
+                "Failed to reap unpublished raster object for stale job",
+                storage_key=key,
+            )
+    return (reaped, skipped, failures)
 
 
 async def _reap_unadopted_analysis_outputs(out_tables: tuple[str, ...]) -> None:

--- a/backend/app/platform/jobs/sweep.py
+++ b/backend/app/platform/jobs/sweep.py
@@ -1864,13 +1864,31 @@ async def fail_stale_jobs(
     )
 
     running_cutoff = now - timedelta(seconds=JOB_TIMEOUT_SECONDS)
-    running_result = await db.execute(
-        update(IngestJob)
+    # fix(#1778 audit r12): the candidate set is read through its own `FOR
+    # UPDATE SKIP LOCKED` subquery rather than matched directly in the
+    # UPDATE's WHERE clause. A phase-2 write now holds `FOR NO KEY UPDATE` on
+    # its job row for as long as its own session stays open (see
+    # `_job_phase_session`'s `require_status` docstring) -- a bare `UPDATE
+    # ... WHERE status = 'running'` sharing this statement would have to WAIT
+    # for that lock on every row it scans, and a `lock_timeout` on a
+    # set-based UPDATE like this one does not skip the one busy row, it
+    # cancels the WHOLE statement, failing every OTHER genuinely stale job in
+    # the same pass along with it. `SKIP LOCKED` excludes exactly the rows a
+    # live phase-2 transaction currently owns and touches nothing else, so a
+    # row a worker is actively finishing is simply left for the next pass
+    # rather than costing this one its entire batch.
+    running_candidates = (
+        select(IngestJob.id)
         .where(
             IngestJob.status == "running",
             func.coalesce(IngestJob.heartbeat_at, IngestJob.started_at)
             < running_cutoff,
         )
+        .with_for_update(skip_locked=True)
+    )
+    running_result = await db.execute(
+        update(IngestJob)
+        .where(IngestJob.id.in_(running_candidates))
         .values(
             status="failed",
             error_message=(

--- a/backend/app/platform/jobs/sweep.py
+++ b/backend/app/platform/jobs/sweep.py
@@ -363,6 +363,18 @@ class StaleCleanupOutcome:
     _stale_generation_storage_keys: tuple[str, ...] = field(
         default=(), repr=False, compare=False
     )
+    # fix(#1778): logical object keys a raster ingest or replace named on its
+    # job row before writing them, carried out to whoever commits under the
+    # same rule as the two fields above. Logical, not tenant-resolved: the reap
+    # resolves them in its own tenant context, like _staged_presigned_keys.
+    _unpublished_storage_keys: tuple[str, ...] = field(
+        default=(), repr=False, compare=False
+    )
+    # fix(#1778): analysis output tables named on the job rows this pass
+    # settled, dropped after the settling commit under the same rule.
+    _unadopted_analysis_tables: tuple[str, ...] = field(
+        default=(), repr=False, compare=False
+    )
 
     @property
     def total_cleaned(self) -> int:
@@ -723,6 +735,30 @@ async def _reap_committed_staged_paths(
                 storage_key=stale_key,
             )
 
+    # fix(#1778): a killed raster ingest or replace's own pre-commit objects,
+    # named on the job row before the puts and withheld from deletion until
+    # this point for the reason `_reap_stale_generation_storage` gives. Safe
+    # without a survivor query: every one of those tails stamps the job's
+    # terminal status in the SAME transaction as the pointer it publishes, so a
+    # row this pass just moved off `running` cannot have a durable publish
+    # behind it, and the keys it names are therefore referenced by nothing.
+    for unpublished_key in outcome._unpublished_storage_keys:
+        try:
+            from app.platform.storage import get_storage
+
+            await get_storage().delete(resolve_current_storage_key(unpublished_key))
+            storage_objects_reaped += 1
+        except Exception:  # broad: best-effort staging cleanup
+            staged_cleanup_failures += 1
+            log.warning(
+                "Failed to reap unpublished raster object for stale job",
+                storage_key=unpublished_key,
+            )
+
+    # fix(#1778): the analysis peer of the loop above. Same rule, same reason:
+    # the table is dropped only once the row that stopped owning it is durable.
+    await _reap_unadopted_analysis_outputs(outcome._unadopted_analysis_tables)
+
     return replace(
         outcome,
         local_files_reaped=local_files_reaped,
@@ -730,6 +766,90 @@ async def _reap_committed_staged_paths(
         staged_paths_skipped=staged_paths_skipped,
         staged_cleanup_failures=staged_cleanup_failures,
     )
+
+
+def unpublished_storage_keys_from_metadata(
+    user_metadata: object,
+) -> tuple[str, ...]:
+    """Read the object keys a killed raster tail named on its own job row.
+
+    fix(#1778). ``written_storage_keys`` is a local list, so a SIGKILL or an
+    OOM between the puts and the terminal ``finally`` reclaimed nothing: the
+    key embeds a dataset id the rolled-back transaction took with it, and no
+    row, no ``delete_dataset`` prefix reap and no staging reconciler
+    (``STAGING_PREFIX`` is ``staging/`` only) could name the objects again. The
+    tails now write the keys to ``user_metadata`` before the puts, and the two
+    stale-job passes are the remaining owners.
+
+    Defensive about the shape because ``user_metadata`` is a schemaless JSONB
+    blob: a non-list, or a list carrying anything but the two managed prefixes,
+    yields nothing. That prefix check is the only thing standing between a
+    hand-edited job row and an arbitrary delete, so it is not optional.
+    """
+    from app.processing.ingest.tasks_raster_common import (
+        UNPUBLISHED_STORAGE_KEYS_FIELD,
+    )
+
+    if not isinstance(user_metadata, dict):
+        return ()
+    raw = user_metadata.get(UNPUBLISHED_STORAGE_KEYS_FIELD)
+    if not isinstance(raw, list):
+        return ()
+    return tuple(
+        key
+        for key in raw
+        if isinstance(key, str)
+        and key.startswith(("rasters/", "originals/"))
+        and ".." not in key
+    )
+
+
+def unadopted_analysis_table_from_metadata(user_metadata: object) -> str | None:
+    """Read the output table an analysis job named on its own job row.
+
+    fix(#1778). The name is generated inside the worker and every DROP of it
+    lives in a handler a SIGKILL never runs, so the table used to survive with
+    no catalog row and nothing able to name it. ``drop_unadopted_analysis_output``
+    re-validates the identifier before it reaches DDL; this only reads it.
+    """
+    from app.processing.analysis.tasks import ANALYSIS_OUTPUT_TABLE_FIELD
+
+    if not isinstance(user_metadata, dict):
+        return None
+    name = user_metadata.get(ANALYSIS_OUTPUT_TABLE_FIELD)
+    return name if isinstance(name, str) and name else None
+
+
+async def _reap_unadopted_analysis_outputs(out_tables: tuple[str, ...]) -> None:
+    """Drop the analysis outputs of jobs this pass just settled.
+
+    fix(#1778). Its own session, opened after the settling commit, for the two
+    reasons the storage reaps give: a DROP inside the sweep transaction would
+    block the whole pass on a lock the dead worker might still hold, and
+    deleting before the settle is durable can destroy an output a rolled-back
+    reconciliation still owns. Empty is the common case and opens nothing.
+
+    The tenant context is the caller's: both callers run inside
+    ``tenant_job_context`` per tenant in multi-tenant mode, the same context
+    the analysis worker resolved its schema under.
+    """
+    if not out_tables:
+        return
+    from app.core.db import async_session
+    from app.core.db.tenant_schema import tenant_data_schema
+    from app.core.db.tenant_session import current_tenant_var
+    from app.core.tenancy import is_multi_tenant
+    from app.processing.analysis.tasks import drop_unadopted_analysis_output
+
+    schema = tenant_data_schema(current_tenant_var.get() if is_multi_tenant() else None)
+    async with async_session() as session:
+        for out_table in out_tables:
+            try:
+                await drop_unadopted_analysis_output(
+                    session, out_table=out_table, schema=schema, job_id="stale_sweep"
+                )
+            except Exception:  # broad: best-effort cleanup of one orphan
+                log.warning("Failed to reap unadopted analysis output")
 
 
 def _stale_generation_storage_keys(
@@ -1431,6 +1551,18 @@ async def fail_stale_jobs(
     )
     running_rows = list(running_result.all())
     running_job_ids = [row[0] for row in running_rows]
+    # fix(#1778): resolved here, deleted only after this pass's commit lands,
+    # the rule every other external artifact in this function follows.
+    unpublished_storage_keys = tuple(
+        key
+        for _job_id, user_metadata_, _created_by in running_rows
+        for key in unpublished_storage_keys_from_metadata(user_metadata_)
+    )
+    unadopted_analysis_tables = tuple(
+        name
+        for _job_id, user_metadata_, _created_by in running_rows
+        if (name := unadopted_analysis_table_from_metadata(user_metadata_)) is not None
+    )
 
     # fix(#1550 review): the row and its audit trail are settled by the same
     # actor, in the same transaction. After a hard kill this sweep is the only
@@ -1732,6 +1864,8 @@ async def fail_stale_jobs(
         _staged_presigned_keys=tuple(sorted(deleted_presigned_keys)),
         _refresh_runs_reconciled=cancelled_runs,
         _stale_generation_storage_keys=stale_generation_storage_keys,
+        _unpublished_storage_keys=unpublished_storage_keys,
+        _unadopted_analysis_tables=unadopted_analysis_tables,
     )
     if commit:
         # Never remove an external artifact for a DELETE that may still roll

--- a/backend/app/platform/jobs/sweep.py
+++ b/backend/app/platform/jobs/sweep.py
@@ -822,30 +822,133 @@ async def _live_referenced_storage_keys(keys: tuple[str, ...]) -> set[str]:
     and every other counted asset). Together those are every column in the
     schema that names an object under `rasters/` or `originals/`.
     """
-    from sqlalchemy import union_all
+    from sqlalchemy import Text, any_, bindparam, union_all
+    from sqlalchemy.dialects.postgresql import ARRAY
 
     from app.core.db import async_session
     from app.platform.extensions import get_catalog_port
     from app.processing.raster.models import RasterAsset
 
     DatasetAsset = get_catalog_port().dataset_asset_orm_class()
-    key_list = list(keys)
+    # fix(#1778 codex r5): ONE array parameter, shared by all four arms, rather
+    # than four IN clauses that expand to one bind per key each. At four times
+    # the key count this query crossed asyncpg's 32767-argument ceiling from
+    # about 8192 keys, and the caller's "a survivor query that fails deletes
+    # nothing" rule then skipped every delete. Correct in isolation, and by
+    # then the retention purge had committed the deletion of the rows that were
+    # those keys' last durable owners, so the objects leaked for good. The
+    # argument count is one now, whatever the key count, and reusing the same
+    # BindParameter object in all four arms is what keeps it at one.
+    keys_param = bindparam("reap_keys", value=list(keys), type_=ARRAY(Text))
     async with async_session() as session:
         stmt = union_all(
             select(RasterAsset.asset_uri.label("key")).where(
-                RasterAsset.asset_uri.in_(key_list)
+                RasterAsset.asset_uri == any_(keys_param)
             ),
             select(RasterAsset.quicklook_256_uri.label("key")).where(
-                RasterAsset.quicklook_256_uri.in_(key_list)
+                RasterAsset.quicklook_256_uri == any_(keys_param)
             ),
             select(RasterAsset.quicklook_512_uri.label("key")).where(
-                RasterAsset.quicklook_512_uri.in_(key_list)
+                RasterAsset.quicklook_512_uri == any_(keys_param)
             ),
             select(DatasetAsset.href.label("key")).where(
-                DatasetAsset.href.in_(key_list)
+                DatasetAsset.href == any_(keys_param)
             ),
         )
         return {row[0] for row in (await session.execute(stmt)).all() if row[0]}
+
+
+async def _clear_settled_artifact_records(
+    *,
+    storage_keys: set[str] = frozenset(),  # type: ignore[assignment]
+    analysis_tables: set[str] = frozenset(),  # type: ignore[assignment]
+) -> None:
+    """Drop the job-row record of artifacts that are now accounted for.
+
+    fix(#1778 codex r5). The job row is the durable pending-reap record: the
+    retention purge refuses to delete a row that still names an unreaped
+    artifact, so a reap that fails as a whole is retried by the next sweep
+    instead of losing its last owner. That only terminates if success clears
+    the record, which is what this does.
+
+    "Accounted for" is deliberately wider than "deleted": a key a live row
+    still names was REFUSED, and refusing it again every sweep forever would
+    pin the job row for the life of the dataset. Both outcomes are final
+    answers about the object; only an error is not.
+
+    Storage keys clear as a set, not per key. A row names all three of its
+    objects at once, and clearing the field while one of them is still
+    unresolved would drop the other two from the record with it -- hence the
+    containment test, which fires only when every key the row names is in the
+    accounted set.
+
+    Best effort by the same rule as its callers: this buys the NEXT purge a
+    row it may delete, and failing to do it costs one more sweep, not
+    correctness.
+    """
+    from sqlalchemy import Text, any_, bindparam, cast, literal
+    from sqlalchemy.dialects.postgresql import ARRAY, JSONB
+
+    from app.core.db import async_session
+    from app.platform.jobs.models import IngestJob
+    from app.processing.analysis.tasks import ANALYSIS_OUTPUT_TABLE_FIELD
+    from app.processing.ingest.tasks_raster_common import (
+        UNPUBLISHED_STORAGE_KEYS_FIELD,
+    )
+
+    if not storage_keys and not analysis_tables:
+        return
+    try:
+        async with async_session() as session:
+            if storage_keys:
+                await session.execute(
+                    update(IngestJob)
+                    .where(
+                        IngestJob.user_metadata[UNPUBLISHED_STORAGE_KEYS_FIELD].is_not(
+                            None
+                        ),
+                        IngestJob.user_metadata[UNPUBLISHED_STORAGE_KEYS_FIELD].op(
+                            "<@"
+                        )(
+                            bindparam(
+                                "settled_keys",
+                                value=sorted(storage_keys),
+                                type_=JSONB,
+                            )
+                        ),
+                    )
+                    .values(
+                        user_metadata=IngestJob.user_metadata.op("-")(
+                            cast(literal(UNPUBLISHED_STORAGE_KEYS_FIELD), Text)
+                        )
+                    )
+                )
+            if analysis_tables:
+                await session.execute(
+                    update(IngestJob)
+                    .where(
+                        IngestJob.user_metadata[ANALYSIS_OUTPUT_TABLE_FIELD].astext
+                        == any_(
+                            bindparam(
+                                "settled_tables",
+                                value=sorted(analysis_tables),
+                                type_=ARRAY(Text),
+                            )
+                        )
+                    )
+                    .values(
+                        user_metadata=IngestJob.user_metadata.op("-")(
+                            cast(literal(ANALYSIS_OUTPUT_TABLE_FIELD), Text)
+                        )
+                    )
+                )
+            await session.commit()
+    except Exception:  # broad: costs one more sweep, never correctness
+        log.warning(
+            "Failed to clear settled artifact records",
+            key_count=len(storage_keys),
+            table_count=len(analysis_tables),
+        )
 
 
 async def reap_unpublished_storage_keys(
@@ -869,6 +972,12 @@ async def reap_unpublished_storage_keys(
     next pass or an operator, and deleting the raster a dataset is serving is
     not.
     """
+    # fix(#1778 codex r5): deduplicated once, here, so the survivor query and
+    # the delete loop each see a key exactly once and the counts below mean
+    # "distinct objects" rather than "list entries". Two purged rows can name
+    # one prefix, and a sweep that reaps a whole retention window can hand this
+    # tens of thousands of keys.
+    keys = tuple(dict.fromkeys(keys))
     if not keys:
         return (0, 0, 0)
 
@@ -884,9 +993,15 @@ async def reap_unpublished_storage_keys(
     reaped = 0
     skipped = 0
     failures = 0
+    # fix(#1778 codex r5): keys this pass reached a final answer about, which
+    # is what licenses clearing them off the job row. A delete that raised is
+    # absent from it on purpose, so its row keeps the record and the next
+    # sweep retries.
+    settled: set[str] = set()
     for key in keys:
         if key in live:
             skipped += 1
+            settled.add(key)
             log.warning(
                 "Refused to reap a raster object a live row still names",
                 storage_key=key,
@@ -897,12 +1012,14 @@ async def reap_unpublished_storage_keys(
 
             await get_storage().delete(resolve_current_storage_key(key))
             reaped += 1
+            settled.add(key)
         except Exception:  # broad: best-effort staging cleanup
             failures += 1
             log.warning(
                 "Failed to reap unpublished raster object for stale job",
                 storage_key=key,
             )
+    await _clear_settled_artifact_records(storage_keys=settled)
     return (reaped, skipped, failures)
 
 
@@ -928,14 +1045,22 @@ async def _reap_unadopted_analysis_outputs(out_tables: tuple[str, ...]) -> None:
     from app.processing.analysis.tasks import drop_unadopted_analysis_output
 
     schema = tenant_data_schema(current_tenant_var.get() if is_multi_tenant() else None)
+    # fix(#1778 codex r5): the peer of the storage reaper's `settled` set. A
+    # table this pass reached a final answer about (dropped, or left alone
+    # because a dataset row adopted it) comes off the job row; one whose drop
+    # raised stays on it, so the row survives the retention purge and the next
+    # sweep tries again.
+    settled: set[str] = set()
     async with async_session() as session:
-        for out_table in out_tables:
+        for out_table in set(out_tables):
             try:
                 await drop_unadopted_analysis_output(
                     session, out_table=out_table, schema=schema, job_id="stale_sweep"
                 )
+                settled.add(out_table)
             except Exception:  # broad: best-effort cleanup of one orphan
                 log.warning("Failed to reap unadopted analysis output")
+    await _clear_settled_artifact_records(analysis_tables=settled)
 
 
 def _stale_generation_storage_keys(
@@ -1882,45 +2007,72 @@ async def fail_stale_jobs(
                 + _RECHECK_TRANSFER_MARGIN_SECONDS
             ),
         )
+        purge_clauses = [
+            IngestJob.status.not_in(("pending", "running")),
+            func.coalesce(IngestJob.completed_at, IngestJob.created_at)
+            < retention_cutoff,
+            IngestJob.id.not_in(latest_complete_ids),
+            IngestJob.id.not_in(latest_manifest_ids),
+            not_(presigned_url_may_still_be_live),
+        ]
+        # fix(#1778 codex r4) made the purge feed the two artifact reaps, on
+        # the reasoning that the row it is about to delete is the last thing
+        # that can name them: the stale passes only read rows they move OFF
+        # `running`, so a job that reached `failed` or `cancelled` on its own
+        # and whose in-process cleanup then failed once keeps its objects with
+        # the record still pointing at them and nothing looks again.
+        #
+        # fix(#1778 codex r5): feeding the reap is not enough, because the reap
+        # runs AFTER this function's commit and can fail as a whole. When it
+        # does, the pointer is already gone and the objects leak for good.
+        #
+        # So a row that still names an unreaped artifact is not purged at all.
+        # The row IS the durable pending-reap record the retry needs: it costs
+        # no new table, it is what the reapers already read, and it survives
+        # exactly until the artifacts it names are accounted for, at which
+        # point the reaper clears the two fields and the next pass purges the
+        # row normally. A reap that fails leaves the fields in place and the
+        # next sweep tries again.
+        #
+        # A string test on the JSONB blob, never a cast: the same rule the
+        # `s3_key` clause above states, because a malformed value must not be
+        # able to throw and fail the whole bulk pass.
+        from app.processing.analysis.tasks import ANALYSIS_OUTPUT_TABLE_FIELD
+        from app.processing.ingest.tasks_raster_common import (
+            UNPUBLISHED_STORAGE_KEYS_FIELD,
+        )
+
+        carries_unreaped_artifacts = or_(
+            IngestJob.user_metadata[UNPUBLISHED_STORAGE_KEYS_FIELD].is_not(None),
+            IngestJob.user_metadata[ANALYSIS_OUTPUT_TABLE_FIELD].astext.is_not(None),
+        )
+        retained_for_reap = await db.execute(
+            select(IngestJob.user_metadata).where(
+                *purge_clauses, carries_unreaped_artifacts
+            )
+        )
+        for retained_metadata in retained_for_reap.scalars():
+            unpublished_storage_keys.extend(
+                unpublished_storage_keys_from_metadata(retained_metadata)
+            )
+            if (
+                name := unadopted_analysis_table_from_metadata(retained_metadata)
+            ) is not None:
+                unadopted_analysis_tables.append(name)
+
         # Single DELETE .. RETURNING re-applies every predicate atomically at
         # delete time — a SELECT-then-DELETE-by-id pair let /jobs/{id}/retry
         # flip a candidate back to pending between the two statements and
-        # still lose the row (codex P2 r10 on #434).
+        # still lose the row (codex P2 r10 on #434). The exemption above is a
+        # predicate here rather than an id list for the same reason.
         deleted = await db.execute(
             delete(IngestJob)
-            .where(
-                IngestJob.status.not_in(("pending", "running")),
-                func.coalesce(IngestJob.completed_at, IngestJob.created_at)
-                < retention_cutoff,
-                IngestJob.id.not_in(latest_complete_ids),
-                IngestJob.id.not_in(latest_manifest_ids),
-                not_(presigned_url_may_still_be_live),
-            )
+            .where(*purge_clauses, not_(carries_unreaped_artifacts))
             .returning(IngestJob.id, IngestJob.file_path, IngestJob.user_metadata)
         )
         deleted_rows = deleted.all()
         terminal_jobs_purged = len(deleted_rows)
         deleted_paths = {fp for (_id, fp, _um) in deleted_rows if fp}
-        # fix(#1778 codex r4): the row being deleted is the last thing that can
-        # name these. The two stale-job passes only read the rows they move OFF
-        # `running`, so a job that reached `failed` or `cancelled` on its own
-        # and whose in-process best-effort cleanup then failed (a storage blip,
-        # a DROP that lost a lock race) keeps its objects and its output table
-        # with the record still pointing at them, and nothing looks again. This
-        # purge is the last actor that holds the pointer, so it is the last
-        # chance to use it. Both reaps run after this function's commit and
-        # both carry survivor checks, so a key or a table something live still
-        # owns is refused rather than deleted.
-        unpublished_storage_keys.extend(
-            key
-            for (_id, _fp, um) in deleted_rows
-            for key in unpublished_storage_keys_from_metadata(um)
-        )
-        unadopted_analysis_tables.extend(
-            name
-            for (_id, _fp, um) in deleted_rows
-            if (name := unadopted_analysis_table_from_metadata(um)) is not None
-        )
         # fix(#1202 review r5): a purged presigned job's staging key is the one
         # reference left to an object the client's PUT URL can still recreate.
         deleted_presigned_keys = {

--- a/backend/app/platform/jobs/sweep.py
+++ b/backend/app/platform/jobs/sweep.py
@@ -372,7 +372,7 @@ class StaleCleanupOutcome:
     )
     # fix(#1778): analysis output tables named on the job rows this pass
     # settled, dropped after the settling commit under the same rule.
-    _unadopted_analysis_tables: tuple[str, ...] = field(
+    _unadopted_analysis_tables: tuple[tuple[uuid.UUID, str], ...] = field(
         default=(), repr=False, compare=False
     )
 
@@ -869,7 +869,7 @@ STORAGE_KEY_FINAL_OUTCOMES = frozenset({"deleted", "refused"})
 async def _clear_settled_artifact_records(
     *,
     storage_keys: set[str] = frozenset(),  # type: ignore[assignment]
-    analysis_tables: set[str] = frozenset(),  # type: ignore[assignment]
+    analysis_job_ids: set[uuid.UUID] = frozenset(),  # type: ignore[assignment]
 ) -> None:
     """Drop the job-row record of artifacts that are now accounted for.
 
@@ -894,8 +894,8 @@ async def _clear_settled_artifact_records(
     row it may delete, and failing to do it costs one more sweep, not
     correctness.
     """
-    from sqlalchemy import Text, any_, bindparam, cast, literal
-    from sqlalchemy.dialects.postgresql import ARRAY, JSONB
+    from sqlalchemy import Text, bindparam, cast, literal
+    from sqlalchemy.dialects.postgresql import JSONB
 
     from app.core.db import async_session
     from app.platform.jobs.models import IngestJob
@@ -904,7 +904,7 @@ async def _clear_settled_artifact_records(
         UNPUBLISHED_STORAGE_KEYS_FIELD,
     )
 
-    if not storage_keys and not analysis_tables:
+    if not storage_keys and not analysis_job_ids:
         return
     try:
         async with async_session() as session:
@@ -931,18 +931,19 @@ async def _clear_settled_artifact_records(
                         )
                     )
                 )
-            if analysis_tables:
+            if analysis_job_ids:
+                # fix(#1778 codex r7): addressed by row id, not by name. A name
+                # was never a safe key for this: two jobs could hold one, so
+                # settling the old job's table stripped the new job's recovery
+                # pointer with it. Names are job-scoped now and the id is the
+                # direct expression of what was settled either way.
                 await session.execute(
                     update(IngestJob)
                     .where(
-                        IngestJob.user_metadata[ANALYSIS_OUTPUT_TABLE_FIELD].astext
-                        == any_(
-                            bindparam(
-                                "settled_tables",
-                                value=sorted(analysis_tables),
-                                type_=ARRAY(Text),
-                            )
-                        )
+                        IngestJob.id.in_(sorted(analysis_job_ids)),
+                        IngestJob.user_metadata[
+                            ANALYSIS_OUTPUT_TABLE_FIELD
+                        ].astext.is_not(None),
                     )
                     .values(
                         user_metadata=IngestJob.user_metadata.op("-")(
@@ -955,7 +956,7 @@ async def _clear_settled_artifact_records(
         log.warning(
             "Failed to clear settled artifact records",
             key_count=len(storage_keys),
-            table_count=len(analysis_tables),
+            job_count=len(analysis_job_ids),
         )
 
 
@@ -1041,7 +1042,9 @@ async def reap_unpublished_storage_keys(
     return (reaped, skipped, failures)
 
 
-async def _reap_unadopted_analysis_outputs(out_tables: tuple[str, ...]) -> None:
+async def _reap_unadopted_analysis_outputs(
+    out_tables: tuple[tuple[uuid.UUID, str], ...],
+) -> None:
     """Drop the analysis outputs of jobs this pass just settled.
 
     fix(#1778). Its own session, opened after the settling commit, for the two
@@ -1079,24 +1082,32 @@ async def _reap_unadopted_analysis_outputs(out_tables: tuple[str, ...]) -> None:
     # permanently. Only a final outcome settles; "failed" is retryable and
     # keeps the record. The try/except stays for a failure the callee does not
     # catch at all, and it deliberately does not settle either.
-    settled: set[str] = set()
+    # fix(#1778 codex r7): keyed on the JOB, not on the name. The reap passes
+    # the owning job so the drop can refuse a table that job did not create,
+    # and the record clearing addresses rows by id so it cannot strip a
+    # different job's pointer that happens to share a name.
+    settled: set[uuid.UUID] = set()
     async with async_session() as session:
-        for out_table in set(out_tables):
+        for job_uuid, out_table in set(out_tables):
             try:
                 outcome = await drop_unadopted_analysis_output(
-                    session, out_table=out_table, schema=schema, job_id="stale_sweep"
+                    session,
+                    out_table=out_table,
+                    schema=schema,
+                    job_id=str(job_uuid),
+                    owner_job_uuid=job_uuid,
                 )
             except Exception:  # broad: best-effort cleanup of one orphan
                 log.warning("Failed to reap unadopted analysis output")
                 continue
             if outcome in ANALYSIS_OUTPUT_FINAL_OUTCOMES:
-                settled.add(out_table)
+                settled.add(job_uuid)
             else:
                 log.warning(
                     "Analysis output reap did not settle, retrying next sweep",
                     outcome=outcome,
                 )
-    await _clear_settled_artifact_records(analysis_tables=settled)
+    await _clear_settled_artifact_records(analysis_job_ids=settled)
 
 
 def _stale_generation_storage_keys(
@@ -1809,8 +1820,8 @@ async def fail_stale_jobs(
         for key in unpublished_storage_keys_from_metadata(user_metadata_)
     ]
     unadopted_analysis_tables = [
-        name
-        for _job_id, user_metadata_, _created_by in running_rows
+        (job_id_, name)
+        for job_id_, user_metadata_, _created_by in running_rows
         if (name := unadopted_analysis_table_from_metadata(user_metadata_)) is not None
     ]
 
@@ -2082,19 +2093,22 @@ async def fail_stale_jobs(
             IngestJob.user_metadata[UNPUBLISHED_STORAGE_KEYS_FIELD].is_not(None),
             IngestJob.user_metadata[ANALYSIS_OUTPUT_TABLE_FIELD].astext.is_not(None),
         )
+        # fix(#1778 codex r7): the id comes back with the metadata, because the
+        # analysis reap is keyed on the owning job now rather than on a name
+        # two jobs could hold.
         retained_for_reap = await db.execute(
-            select(IngestJob.user_metadata).where(
+            select(IngestJob.id, IngestJob.user_metadata).where(
                 *purge_clauses, carries_unreaped_artifacts
             )
         )
-        for retained_metadata in retained_for_reap.scalars():
+        for retained_id, retained_metadata in retained_for_reap.all():
             unpublished_storage_keys.extend(
                 unpublished_storage_keys_from_metadata(retained_metadata)
             )
             if (
                 name := unadopted_analysis_table_from_metadata(retained_metadata)
             ) is not None:
-                unadopted_analysis_tables.append(name)
+                unadopted_analysis_tables.append((retained_id, name))
 
         # Single DELETE .. RETURNING re-applies every predicate atomically at
         # delete time — a SELECT-then-DELETE-by-id pair let /jobs/{id}/retry

--- a/backend/app/platform/jobs/worker.py
+++ b/backend/app/platform/jobs/worker.py
@@ -215,11 +215,11 @@ async def _recover_stale_jobs_for_current_scope() -> None:
         from app.platform.jobs.router import (
             _reap_stale_generation_storage,
             _reap_unadopted_analysis_outputs,
+            reap_unpublished_storage_keys,
             sweep_stale_vrt_assets,
             unadopted_analysis_table_from_metadata,
             unpublished_storage_keys_from_metadata,
         )
-        from app.platform.storage.titiler_url import resolve_current_storage_key
 
         (
             vrt_assets_recovered,
@@ -238,12 +238,14 @@ async def _recover_stale_jobs_for_current_scope() -> None:
         # periodic sweep for that class: an OOM-killed worker is restarted, and
         # the restart runs this before any lifespan sweeper gets there, so
         # without it the keys are settled `failed` here and never seen again.
-        # Resolved from the rows this pass just moved off `running`, and
-        # deleted only after the commit above, for the reason the line above
-        # gives.
-        await _reap_stale_generation_storage(
+        # Read off the rows this pass just moved off `running`, and deleted
+        # only after the commit above, for the reason the line above gives.
+        # fix(#1778 codex r1): through the shared reaper, which carries the
+        # survivor check and the tenant resolution, so this pass cannot delete
+        # a key a live row still names either.
+        await reap_unpublished_storage_keys(
             tuple(
-                resolve_current_storage_key(key)
+                key
                 for job in stale_jobs
                 for key in unpublished_storage_keys_from_metadata(job.user_metadata)
             )

--- a/backend/app/platform/jobs/worker.py
+++ b/backend/app/platform/jobs/worker.py
@@ -217,7 +217,7 @@ async def _recover_stale_jobs_for_current_scope() -> None:
             _reap_unadopted_analysis_outputs,
             reap_unpublished_storage_keys,
             sweep_stale_vrt_assets,
-            unadopted_analysis_table_from_metadata,
+            unadopted_analysis_tables_from_metadata,
             unpublished_storage_keys_from_metadata,
         )
 
@@ -251,14 +251,14 @@ async def _recover_stale_jobs_for_current_scope() -> None:
             )
         )
         # fix(#1778): and the analysis peer, same pass, same ordering.
-        # fix(#1778 codex r7): (job, table) pairs, so the drop can refuse a
-        # table the job it is reaping did not create.
+        # fix(#1778 codex r7/r10): (job, table) pairs, so the drop can refuse a
+        # table the job it is reaping did not create, and ALL of the names a
+        # row records, because the record accumulates across attempts.
         await _reap_unadopted_analysis_outputs(
             tuple(
                 (job.id, name)
                 for job in stale_jobs
-                if (name := unadopted_analysis_table_from_metadata(job.user_metadata))
-                is not None
+                for name in unadopted_analysis_tables_from_metadata(job.user_metadata)
             )
         )
         total = len(stale_jobs) + len(orphaned_jobs)

--- a/backend/app/platform/jobs/worker.py
+++ b/backend/app/platform/jobs/worker.py
@@ -251,9 +251,11 @@ async def _recover_stale_jobs_for_current_scope() -> None:
             )
         )
         # fix(#1778): and the analysis peer, same pass, same ordering.
+        # fix(#1778 codex r7): (job, table) pairs, so the drop can refuse a
+        # table the job it is reaping did not create.
         await _reap_unadopted_analysis_outputs(
             tuple(
-                name
+                (job.id, name)
                 for job in stale_jobs
                 if (name := unadopted_analysis_table_from_metadata(job.user_metadata))
                 is not None

--- a/backend/app/platform/jobs/worker.py
+++ b/backend/app/platform/jobs/worker.py
@@ -104,13 +104,26 @@ async def _recover_stale_jobs_for_current_scope() -> None:
         # Mirrors fail_stale_jobs (router.py:39) which the lifespan
         # sweeper runs every 5 minutes for the same purpose. The advisory
         # lock ensures startup recovery and the sweeper don't collide.
-        stale_result = await session.execute(
-            update(IngestJob)
+        #
+        # fix(#1778 audit r12): the candidate set is read through its own
+        # `FOR UPDATE SKIP LOCKED` subquery, mirroring fail_stale_jobs's own
+        # fix for the identical race -- see that query's comment for why a
+        # `lock_timeout` on this set-based UPDATE would abort the WHOLE
+        # batch on one busy row rather than skipping just that row. A row a
+        # live phase-2 transaction holds `FOR NO KEY UPDATE` on is excluded
+        # here and picked up by a later pass once that transaction ends.
+        stale_candidates = (
+            select(IngestJob.id)
             .where(
                 IngestJob.status == "running",
                 func.coalesce(IngestJob.heartbeat_at, IngestJob.started_at)
                 < stale_cutoff,
             )
+            .with_for_update(skip_locked=True)
+        )
+        stale_result = await session.execute(
+            update(IngestJob)
+            .where(IngestJob.id.in_(stale_candidates))
             .values(
                 status="failed",
                 error_message=(

--- a/backend/app/platform/jobs/worker.py
+++ b/backend/app/platform/jobs/worker.py
@@ -214,8 +214,12 @@ async def _recover_stale_jobs_for_current_scope() -> None:
         # consistent — mirrors the fail_stale_jobs periodic sweep.
         from app.platform.jobs.router import (
             _reap_stale_generation_storage,
+            _reap_unadopted_analysis_outputs,
             sweep_stale_vrt_assets,
+            unadopted_analysis_table_from_metadata,
+            unpublished_storage_keys_from_metadata,
         )
+        from app.platform.storage.titiler_url import resolve_current_storage_key
 
         (
             vrt_assets_recovered,
@@ -229,6 +233,30 @@ async def _recover_stale_jobs_for_current_scope() -> None:
         # restored ownership is durable can orphan a 'ready' asset against
         # bytes a rolled-back commit never actually freed for deletion.
         await _reap_stale_generation_storage(stale_generation_storage_keys)
+        # fix(#1778): the same treatment for a killed raster ingest or
+        # replace's own pre-commit objects. This pass matters more than the
+        # periodic sweep for that class: an OOM-killed worker is restarted, and
+        # the restart runs this before any lifespan sweeper gets there, so
+        # without it the keys are settled `failed` here and never seen again.
+        # Resolved from the rows this pass just moved off `running`, and
+        # deleted only after the commit above, for the reason the line above
+        # gives.
+        await _reap_stale_generation_storage(
+            tuple(
+                resolve_current_storage_key(key)
+                for job in stale_jobs
+                for key in unpublished_storage_keys_from_metadata(job.user_metadata)
+            )
+        )
+        # fix(#1778): and the analysis peer, same pass, same ordering.
+        await _reap_unadopted_analysis_outputs(
+            tuple(
+                name
+                for job in stale_jobs
+                if (name := unadopted_analysis_table_from_metadata(job.user_metadata))
+                is not None
+            )
+        )
         total = len(stale_jobs) + len(orphaned_jobs)
         if total or vrt_assets_recovered:
             log.info(

--- a/backend/app/processing/analysis/tasks.py
+++ b/backend/app/processing/analysis/tasks.py
@@ -839,7 +839,11 @@ def analysis_output_scope(job_uuid: uuid.UUID, attempt_uuid: uuid.UUID) -> str:
 
 
 def analysis_output_table_name(
-    base: str, job_uuid: uuid.UUID, attempt_uuid: uuid.UUID
+    base: str,
+    job_uuid: uuid.UUID,
+    attempt_uuid: uuid.UUID,
+    *,
+    collision_suffix: int | None = None,
 ) -> str:
     """The physical name ONE attempt of one job may write its output to.
 
@@ -858,11 +862,23 @@ def analysis_output_table_name(
     r9, and every reaper iterates all of them. So the name identifies one
     attempt's table and the record remembers every attempt's.
 
-    The base is trimmed to leave room for the scope, which keeps the result
-    inside PostgreSQL's 63-byte identifier limit.
+    fix(#1778 audit r11): ``collision_suffix`` names the `_N` tag
+    ``resolve_analysis_output_table``'s walk tries, and it has to be applied
+    HERE, on the original ``base``, not by the caller pre-pending `_N` to
+    ``base`` and calling this again. The base is trimmed to leave room for
+    the scope AND the tag together, computed fresh from ``base`` every call
+    -- the same idiom `generate_table_name`'s own `_with_collision_suffix`
+    uses, and for the identical reason: trimming an ALREADY-TRIMMED string a
+    second time truncates the very characters that make one candidate differ
+    from the next. A ``base`` at or past the reserved limit (46 chars with no
+    tag) used to make every walked candidate identical once trimmed, so a
+    redelivery of the same attempt with an existing scoped table exhausted
+    the whole `_N` walk and raised instead of self-healing.
     """
-    suffix = analysis_output_scope(job_uuid, attempt_uuid)
-    return f"{base[: _ANALYSIS_TABLE_MAX_CHARS - len(suffix)]}{suffix}"
+    scope = analysis_output_scope(job_uuid, attempt_uuid)
+    tag = f"_{collision_suffix}" if collision_suffix is not None else ""
+    limit = _ANALYSIS_TABLE_MAX_CHARS - len(scope) - len(tag)
+    return f"{base[:limit]}{tag}{scope}"
 
 
 def analysis_output_table_belongs_to(out_table: str, job_uuid: uuid.UUID) -> bool:
@@ -920,6 +936,13 @@ async def resolve_analysis_output_table(
     standard filters information_schema to relations the current role has
     privileges on, and an orphan this role never granted itself is exactly the
     one this has to see.
+
+    fix(#1778 audit r11): every candidate below is derived from the SAME
+    original ``base`` via ``collision_suffix``, never by pre-pending `_N` to
+    ``base`` and trimming again. ``analysis_output_table_name`` reserves room
+    for the tag itself now, so a long ``base`` still yields a genuinely
+    distinct candidate per suffix instead of the same truncated string N
+    times over.
     """
     probe_prefix = base[:_SCOPED_PROBE_CHARS]
     taken = {
@@ -939,7 +962,7 @@ async def resolve_analysis_output_table(
         return candidate
     for suffix in range(2, _MAX_SCOPED_COLLISION_SUFFIX + 1):
         candidate = analysis_output_table_name(
-            f"{base}_{suffix}", job_uuid, attempt_uuid
+            base, job_uuid, attempt_uuid, collision_suffix=suffix
         )
         if candidate not in taken:
             return candidate

--- a/backend/app/processing/analysis/tasks.py
+++ b/backend/app/processing/analysis/tasks.py
@@ -334,21 +334,9 @@ async def _fail_cancelled_job(
             # no row means the DROP is safe. If the probe itself errors,
             # prefer leaking the table to dropping a registered dataset's
             # storage.
-            if out_table is not None:
-                adopted = True
-                try:
-                    adopted = await _output_table_adopted(session, out_table)
-                except Exception:  # broad: prefer leak over loss
-                    logger.warning("analysis.adoption_probe_failed", job_id=job_id)
-                    await session.rollback()
-                if not adopted:
-                    try:
-                        await session.execute(
-                            text(f'DROP TABLE IF EXISTS "{schema}"."{out_table}"')
-                        )
-                        await session.commit()
-                    except Exception:  # broad: best-effort cleanup of the orphan
-                        await session.rollback()
+            await drop_unadopted_analysis_output(
+                session, out_table=out_table, schema=schema, job_id=job_id
+            )
             return
         await session.commit()
         if out_table is not None:
@@ -786,6 +774,62 @@ async def _output_table_adopted(session: AsyncSession, out_table: str) -> bool:
     return (await session.execute(stmt)).first() is not None
 
 
+# fix(#1778): the `user_metadata` field an analysis job names its output table
+# under. `out_table` is generated inside the worker and nothing durable carried
+# it, so a SIGKILL after the materialize commit left `data.<out_table>` (plus
+# its GIST index, up to MAX_OUTPUT_BYTES) with no catalog row, no DROP and no
+# reconciler that could ever name it. The name is written in the SAME
+# transaction that creates the table, so the two become durable together and a
+# row that has one has the other.
+ANALYSIS_OUTPUT_TABLE_FIELD = "analysis_out_table"
+
+# A generated analysis table name, as `generate_table_name` produces them. The
+# name reaches the sweeps through a schemaless JSONB blob and is interpolated
+# into DDL, so it is re-checked at every use rather than trusted for having
+# been sanitized once.
+_ANALYSIS_TABLE_NAME_RE = re.compile(r"^[a-z_][a-z0-9_]{0,62}$")
+
+
+async def drop_unadopted_analysis_output(
+    session: AsyncSession,
+    *,
+    out_table: str | None,
+    schema: str,
+    job_id: str,
+) -> None:
+    """Drop an analysis output table no dataset row has adopted.
+
+    fix(#1778): the probe-then-drop the two fence-miss handlers already ran,
+    lifted into one function so the stale-job sweeps can apply the same policy
+    to a job whose worker was killed outright. Failure direction is the one
+    those handlers chose: an adoption probe that itself errors reports adopted,
+    so an unreadable catalog leaks a table rather than dropping a registered
+    dataset's storage.
+
+    The name is re-validated here because the sweeps read it out of
+    ``user_metadata``, a JSONB blob with no schema, and it is interpolated into
+    a DDL statement that takes no bind parameters.
+    """
+    if out_table is None:
+        return
+    if not _ANALYSIS_TABLE_NAME_RE.match(out_table):
+        logger.warning("analysis.output_table_name_rejected", job_id=job_id)
+        return
+    adopted = True
+    try:
+        adopted = await _output_table_adopted(session, out_table)
+    except Exception:  # broad: prefer leak over loss
+        logger.warning("analysis.adoption_probe_failed", job_id=job_id)
+        await session.rollback()
+    if adopted:
+        return
+    try:
+        await session.execute(text(f'DROP TABLE IF EXISTS "{schema}"."{out_table}"'))
+        await session.commit()
+    except Exception:  # broad: best-effort cleanup of the orphan
+        await session.rollback()
+
+
 async def _mark_job_failed(
     session: AsyncSession,
     *,
@@ -832,21 +876,9 @@ async def _mark_job_failed(
         # DROP is safe. Failure direction stays safe: if the probe itself
         # errors, prefer leaking the table to dropping a registered
         # dataset's storage.
-        if out_table is not None:
-            adopted = True
-            try:
-                adopted = await _output_table_adopted(session, out_table)
-            except Exception:  # broad: prefer leak over loss
-                logger.warning("analysis.adoption_probe_failed", job_id=job_id)
-                await session.rollback()
-            if not adopted:
-                try:
-                    await session.execute(
-                        text(f'DROP TABLE IF EXISTS "{schema}"."{out_table}"')
-                    )
-                    await session.commit()
-                except Exception:  # broad: best-effort cleanup of the orphan
-                    await session.rollback()
+        await drop_unadopted_analysis_output(
+            session, out_table=out_table, schema=schema, job_id=job_id
+        )
         return
     await session.commit()
     if out_table is not None:
@@ -1163,6 +1195,16 @@ async def _materialize(
             )
 
             out_table, collision_warning = await generate_table_name(title, session)
+            # fix(#1778): the name, on the durable row, in the same transaction
+            # that creates the table (the commit after ANALYZE below). Without
+            # it a hard kill after that commit left the table unreachable: the
+            # stale sweep is a plain status UPDATE, every DROP of this table
+            # lives in a handler this process would never run, and no
+            # reconciler can name a table nothing recorded.
+            job.user_metadata = {
+                **(job.user_metadata or {}),
+                ANALYSIS_OUTPUT_TABLE_FIELD: out_table,
+            }
             if collision_warning:
                 # fix(#786): persisted like the upload path (tasks_vector) —
                 # the job-status endpoint surfaces

--- a/backend/app/processing/analysis/tasks.py
+++ b/backend/app/processing/analysis/tasks.py
@@ -788,57 +788,164 @@ async def _output_table_adopted(session: AsyncSession, out_table: str) -> bool:
 ANALYSIS_OUTPUT_TABLE_FIELD = "analysis_out_table"
 
 
-# The job scope an analysis output table carries. 16 hex characters of the job
-# id, the width `attempt_scoped_staging_table` uses for the same purpose on the
-# vector tails' staging tables.
-_ANALYSIS_JOB_SCOPE_CHARS = 16
+def recorded_analysis_output_tables(user_metadata: object) -> tuple[str, ...]:
+    """Every output table name a job row records, in the order recorded.
+
+    fix(#1778 codex r10): the field is a LIST that each attempt appends to. A
+    plain string is what it held before this commit and is read as a
+    one-element list, so an existing row keeps its pointer. Anything else
+    yields nothing rather than raising, because this reads a schemaless JSONB
+    blob.
+    """
+    if not isinstance(user_metadata, dict):
+        return ()
+    recorded = user_metadata.get(ANALYSIS_OUTPUT_TABLE_FIELD)
+    if isinstance(recorded, str):
+        return (recorded,) if recorded else ()
+    if not isinstance(recorded, list):
+        return ()
+    return tuple(name for name in recorded if isinstance(name, str) and name)
+
+
+def append_analysis_output_record(user_metadata: "dict | None", out_table: str) -> dict:
+    """Add ``out_table`` to the record without dropping what is already there.
+
+    fix(#1778 codex r10): `/jobs/{id}/retry` preserves ``user_metadata``, so
+    writing this attempt's name over the field dropped the previous attempt's
+    and stranded its table with nothing naming it. Appending is what lets every
+    reaper iterate all of them.
+    """
+    names = list(recorded_analysis_output_tables(user_metadata))
+    if out_table not in names:
+        names.append(out_table)
+    return {**(user_metadata or {}), ANALYSIS_OUTPUT_TABLE_FIELD: names}
+
+
+# fix(#1778 codex r10): the scope an analysis output table carries, 8 hex
+# characters of the job and 8 of the attempt. Job alone was not enough: a retry
+# keeps `IngestJob.id` and changes only `attempt_id`, so every attempt of one
+# job derived the same name and a sweep holding attempt 1's could drop the
+# table attempt 2 had just created under it.
+_ANALYSIS_SCOPE_CHARS = 8
 _ANALYSIS_TABLE_MAX_CHARS = 63
 
 
-def analysis_output_table_name(base: str, job_uuid: uuid.UUID) -> str:
-    """The physical name ONE analysis job's output may occupy.
+def analysis_output_scope(job_uuid: uuid.UUID, attempt_uuid: uuid.UUID) -> str:
+    """The suffix that says which attempt of which job owns a table."""
+    return (
+        f"_{job_uuid.hex[:_ANALYSIS_SCOPE_CHARS]}"
+        f"{attempt_uuid.hex[:_ANALYSIS_SCOPE_CHARS]}"
+    )
 
-    fix(#1778 codex r7). The name used to be the bare slug of the title, which
-    two jobs could hold in sequence, and that is a name the durable reaper
-    cannot use safely. An old failed job keeps `analysis_out_table` on its row
-    until the reap succeeds; once its table is gone the name is free again
-    (nothing retires it, because an unregistered output never became a
-    dataset), so a new analysis with the same title is handed the same name.
-    Let the new job commit its CTAS between the sweep's adoption probe and its
-    DROP and the sweep destroys the NEW job's table, then the name-keyed record
-    clearing erases the new job's recovery pointer along with the old one's.
 
-    Scoping the name by the job closes that at the root rather than by
-    ordering: no two jobs can name one table, so there is no interleaving to
-    get wrong, the adoption probe cannot be raced, and the sweep can verify
-    ownership from the name itself with no marker, registry or lock. It is the
-    same convention `attempt_scoped_staging_table` applies to staging tables
-    and `attempt_scoped_raster_base_key` applies to replace object keys.
+def analysis_output_table_name(
+    base: str, job_uuid: uuid.UUID, attempt_uuid: uuid.UUID
+) -> str:
+    """The physical name ONE attempt of one job may write its output to.
 
-    Scoped by JOB and not by attempt on purpose. A retry reuses the job row,
-    and therefore the single `analysis_out_table` field on it; an attempt-scoped
-    name would change under that field on every retry and strand the previous
-    attempt's orphan with nothing naming it. `generate_table_name` still runs
-    first and still walks its `_N` suffixes, so a retry whose predecessor left
-    an orphan lands on a different base and does not collide with itself.
+    fix(#1778 codex r7) scoped this by job, which stopped two DIFFERENT jobs
+    sharing a name. fix(#1778 codex r10) adds the attempt, because a retry is
+    the same job: `/jobs/{id}/retry` keeps the id and mints a new attempt
+    token, so every attempt derived one name. A stale sweep could capture
+    attempt 1's name, settle the job `failed`, and then probe and drop while
+    attempt 2 was creating that same name -- and the ownership check passed,
+    because the name really was this job's.
 
-    The base is trimmed to leave room for the scope, which is what keeps the
-    result inside PostgreSQL's 63-byte identifier limit.
+    The objection to attempt scoping in r8 was that it strands the previous
+    attempt's orphan with nothing naming it, since the row has one field. That
+    is answered by making the record accumulate: it holds a LIST of names that
+    each attempt appends to, exactly as `unpublished_storage_keys` does since
+    r9, and every reaper iterates all of them. So the name identifies one
+    attempt's table and the record remembers every attempt's.
+
+    The base is trimmed to leave room for the scope, which keeps the result
+    inside PostgreSQL's 63-byte identifier limit.
     """
-    suffix = f"_{job_uuid.hex[:_ANALYSIS_JOB_SCOPE_CHARS]}"
+    suffix = analysis_output_scope(job_uuid, attempt_uuid)
     return f"{base[: _ANALYSIS_TABLE_MAX_CHARS - len(suffix)]}{suffix}"
 
 
 def analysis_output_table_belongs_to(out_table: str, job_uuid: uuid.UUID) -> bool:
-    """Whether ``out_table`` is the output name ``job_uuid`` would have taken.
+    """Whether ``out_table`` carries ``job_uuid``'s scope.
 
-    fix(#1778 codex r7): the ownership check the sweeps make before they drop
-    anything. The name embeds the job that created it, so this needs no catalog
-    read, no comment and no lock, and it cannot be raced by a name that has
-    been handed on: a table this returns True for was created by this job or by
-    nothing at all.
+    fix(#1778 codex r7): the ownership check every reaper makes before it drops
+    anything. The name embeds its owner, so this needs no catalog read, no
+    comment and no lock.
+
+    fix(#1778 codex r10): the attempt half is required to be PRESENT but is not
+    compared, because the reaper reads the name off the row that recorded it
+    and so already knows the attempt was one of this job's. What this refuses
+    is a name belonging to a different job, or one with no scope at all.
     """
-    return out_table.endswith(f"_{job_uuid.hex[:_ANALYSIS_JOB_SCOPE_CHARS]}")
+    return (
+        re.search(
+            rf"_{re.escape(job_uuid.hex[:_ANALYSIS_SCOPE_CHARS])}"
+            rf"[0-9a-f]{{{_ANALYSIS_SCOPE_CHARS}}}$",
+            out_table,
+        )
+        is not None
+    )
+
+
+# fix(#1778 codex r10): how many `_N` walks the scoped-name probe makes before
+# giving up, and how much of the base it probes on. Same bound and same reason
+# as `generate_table_name`'s own.
+_MAX_SCOPED_COLLISION_SUFFIX = 20
+_SCOPED_PROBE_CHARS = 20
+
+
+async def resolve_analysis_output_table(
+    session: AsyncSession,
+    *,
+    base: str,
+    job_uuid: uuid.UUID,
+    attempt_uuid: uuid.UUID,
+    schema: str,
+) -> str:
+    """The scoped output name, collision-checked AS SCOPED.
+
+    fix(#1778 codex r10). ``generate_table_name`` walks its ``_N`` suffixes
+    against the UNSCOPED base while the relation on disk carries the scope, so
+    its candidate set and the names that actually exist never intersected: a
+    base of ``parcels`` probes ``parcels%``, finds ``parcels_ab12cd34ef56ab78``
+    in pg_class, asks whether ``parcels`` is taken, and hands back ``parcels``
+    unsuffixed, which scopes straight back onto the occupied name and fails at
+    CREATE TABLE. Attempt scoping makes that rare, because a retry gets a
+    different suffix, but not unreachable: the same attempt can be delivered
+    twice, and then the scoped name is identical.
+
+    So the walk happens here, on the name that will actually be created. One
+    prefix probe answers every candidate, and it reads pg_class rather than
+    information_schema for the reason ``generate_table_name`` gives: the
+    standard filters information_schema to relations the current role has
+    privileges on, and an orphan this role never granted itself is exactly the
+    one this has to see.
+    """
+    probe_prefix = base[:_SCOPED_PROBE_CHARS]
+    taken = {
+        row[0]
+        for row in (
+            await session.execute(
+                text(
+                    "SELECT c.relname FROM pg_catalog.pg_class c"
+                    " JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace"
+                    " WHERE n.nspname = :schema AND c.relname LIKE :pattern"
+                ).bindparams(schema=schema, pattern=f"{probe_prefix}%")
+            )
+        ).all()
+    }
+    candidate = analysis_output_table_name(base, job_uuid, attempt_uuid)
+    if candidate not in taken:
+        return candidate
+    for suffix in range(2, _MAX_SCOPED_COLLISION_SUFFIX + 1):
+        candidate = analysis_output_table_name(
+            f"{base}_{suffix}", job_uuid, attempt_uuid
+        )
+        if candidate not in taken:
+            return candidate
+    raise ValueError(
+        "Could not find a free analysis output table name for this attempt."
+    )
 
 
 # A generated analysis table name, as `generate_table_name` produces them. The
@@ -1307,22 +1414,37 @@ async def _materialize(
             )
 
             _base_table, collision_warning = await generate_table_name(title, session)
-            # fix(#1778 codex r7): scoped by this job, so no other job can ever
-            # be handed the same physical name. `generate_table_name` still
-            # chooses the readable half and still walks its `_N` suffixes
-            # against live relations, retired names and the catalog, so a retry
-            # whose predecessor left an orphan does not collide with itself.
-            out_table = analysis_output_table_name(_base_table, uuid.UUID(job_id))
+            # fix(#1778 codex r7/r10): scoped by this job AND this attempt, so
+            # neither another job nor another attempt of this one can be handed
+            # the same physical name. `generate_table_name` still chooses the
+            # readable half and still collides against the catalog and the
+            # retired names, which is what the eventual dataset table_name
+            # needs; the `_N` walk that matters for the RELATION is the scoped
+            # one below, because the unscoped walk can never see a scoped name.
+            out_table = await resolve_analysis_output_table(
+                session,
+                base=_base_table,
+                job_uuid=uuid.UUID(job_id),
+                attempt_uuid=attempt_id,
+                schema=_schema,
+            )
             # fix(#1778): the name, on the durable row, in the same transaction
             # that creates the table (the commit after ANALYZE below). Without
             # it a hard kill after that commit left the table unreachable: the
             # stale sweep is a plain status UPDATE, every DROP of this table
             # lives in a handler this process would never run, and no
             # reconciler can name a table nothing recorded.
-            job.user_metadata = {
-                **(job.user_metadata or {}),
-                ANALYSIS_OUTPUT_TABLE_FIELD: out_table,
-            }
+            #
+            # fix(#1778 codex r10): a LIST that each attempt APPENDS to, the
+            # shape `unpublished_storage_keys` took in r9 and for the same
+            # reason. `/jobs/{id}/retry` preserves `user_metadata`, so writing
+            # this attempt's name over the field dropped the previous attempt's
+            # and stranded its table with nothing naming it. A string from
+            # before this commit is read as a one-element list, so an existing
+            # row keeps its pointer.
+            job.user_metadata = append_analysis_output_record(
+                job.user_metadata, out_table
+            )
             if collision_warning:
                 # fix(#786): persisted like the upload path (tasks_vector) —
                 # the job-status endpoint surfaces

--- a/backend/app/processing/analysis/tasks.py
+++ b/backend/app/processing/analysis/tasks.py
@@ -335,7 +335,11 @@ async def _fail_cancelled_job(
             # prefer leaking the table to dropping a registered dataset's
             # storage.
             await drop_unadopted_analysis_output(
-                session, out_table=out_table, schema=schema, job_id=job_id
+                session,
+                out_table=out_table,
+                schema=schema,
+                job_id=job_id,
+                owner_job_uuid=uuid.UUID(job_id),
             )
             return
         await session.commit()
@@ -783,6 +787,60 @@ async def _output_table_adopted(session: AsyncSession, out_table: str) -> bool:
 # row that has one has the other.
 ANALYSIS_OUTPUT_TABLE_FIELD = "analysis_out_table"
 
+
+# The job scope an analysis output table carries. 16 hex characters of the job
+# id, the width `attempt_scoped_staging_table` uses for the same purpose on the
+# vector tails' staging tables.
+_ANALYSIS_JOB_SCOPE_CHARS = 16
+_ANALYSIS_TABLE_MAX_CHARS = 63
+
+
+def analysis_output_table_name(base: str, job_uuid: uuid.UUID) -> str:
+    """The physical name ONE analysis job's output may occupy.
+
+    fix(#1778 codex r7). The name used to be the bare slug of the title, which
+    two jobs could hold in sequence, and that is a name the durable reaper
+    cannot use safely. An old failed job keeps `analysis_out_table` on its row
+    until the reap succeeds; once its table is gone the name is free again
+    (nothing retires it, because an unregistered output never became a
+    dataset), so a new analysis with the same title is handed the same name.
+    Let the new job commit its CTAS between the sweep's adoption probe and its
+    DROP and the sweep destroys the NEW job's table, then the name-keyed record
+    clearing erases the new job's recovery pointer along with the old one's.
+
+    Scoping the name by the job closes that at the root rather than by
+    ordering: no two jobs can name one table, so there is no interleaving to
+    get wrong, the adoption probe cannot be raced, and the sweep can verify
+    ownership from the name itself with no marker, registry or lock. It is the
+    same convention `attempt_scoped_staging_table` applies to staging tables
+    and `attempt_scoped_raster_base_key` applies to replace object keys.
+
+    Scoped by JOB and not by attempt on purpose. A retry reuses the job row,
+    and therefore the single `analysis_out_table` field on it; an attempt-scoped
+    name would change under that field on every retry and strand the previous
+    attempt's orphan with nothing naming it. `generate_table_name` still runs
+    first and still walks its `_N` suffixes, so a retry whose predecessor left
+    an orphan lands on a different base and does not collide with itself.
+
+    The base is trimmed to leave room for the scope, which is what keeps the
+    result inside PostgreSQL's 63-byte identifier limit.
+    """
+    suffix = f"_{job_uuid.hex[:_ANALYSIS_JOB_SCOPE_CHARS]}"
+    return f"{base[: _ANALYSIS_TABLE_MAX_CHARS - len(suffix)]}{suffix}"
+
+
+def analysis_output_table_belongs_to(out_table: str, job_uuid: uuid.UUID) -> bool:
+    """Whether ``out_table`` is the output name ``job_uuid`` would have taken.
+
+    fix(#1778 codex r7): the ownership check the sweeps make before they drop
+    anything. The name embeds the job that created it, so this needs no catalog
+    read, no comment and no lock, and it cannot be raced by a name that has
+    been handed on: a table this returns True for was created by this job or by
+    nothing at all.
+    """
+    return out_table.endswith(f"_{job_uuid.hex[:_ANALYSIS_JOB_SCOPE_CHARS]}")
+
+
 # A generated analysis table name, as `generate_table_name` produces them. The
 # name reaches the sweeps through a schemaless JSONB blob and is interpolated
 # into DDL, so it is re-checked at every use rather than trusted for having
@@ -814,6 +872,7 @@ async def drop_unadopted_analysis_output(
     out_table: str | None,
     schema: str,
     job_id: str,
+    owner_job_uuid: uuid.UUID,
 ) -> AnalysisOutputOutcome:
     """Drop an analysis output table no dataset row has adopted.
 
@@ -826,6 +885,13 @@ async def drop_unadopted_analysis_output(
     The name is re-validated here because the sweeps read it out of
     ``user_metadata``, a JSONB blob with no schema, and it is interpolated into
     a DDL statement that takes no bind parameters.
+
+    fix(#1778 codex r7): ``owner_job_uuid`` is the job whose record is being
+    reaped, and a name that is not that job's is refused. It is required, with
+    no default. The in-worker handlers would pass their own id either way, so
+    an optional gate would have bought nothing but a way to forget it: the
+    caller that most needs the check is a sweep acting on a name read off a row
+    that may be older than the table now standing at it.
 
     fix(#1778 codex r6): it REPORTS, rather than returning the same ``None``
     whether it dropped the table or failed to. The two fence-miss handlers can
@@ -845,6 +911,15 @@ async def drop_unadopted_analysis_output(
         return "skipped"
     if not _ANALYSIS_TABLE_NAME_RE.match(out_table):
         logger.warning("analysis.output_table_name_rejected", job_id=job_id)
+        return "invalid"
+    # fix(#1778 codex r7): the ownership gate. A sweep reaping a job's record
+    # may only drop the table THAT job named, and the name says which job that
+    # is. Without this the sweep was free to drop a table a different job had
+    # since created under a reused name, between the adoption probe and the
+    # DROP. "invalid" rather than "failed": a name that is not this job's can
+    # never become this job's, so retrying it forever would pin the row.
+    if not analysis_output_table_belongs_to(out_table, owner_job_uuid):
+        logger.warning("analysis.output_table_not_owned", job_id=job_id)
         return "invalid"
     try:
         adopted = await _output_table_adopted(session, out_table)
@@ -910,7 +985,11 @@ async def _mark_job_failed(
         # errors, prefer leaking the table to dropping a registered
         # dataset's storage.
         await drop_unadopted_analysis_output(
-            session, out_table=out_table, schema=schema, job_id=job_id
+            session,
+            out_table=out_table,
+            schema=schema,
+            job_id=job_id,
+            owner_job_uuid=uuid.UUID(job_id),
         )
         return
     await session.commit()
@@ -1227,7 +1306,13 @@ async def _materialize(
                 mask_table_ref=mask_table_ref,
             )
 
-            out_table, collision_warning = await generate_table_name(title, session)
+            _base_table, collision_warning = await generate_table_name(title, session)
+            # fix(#1778 codex r7): scoped by this job, so no other job can ever
+            # be handed the same physical name. `generate_table_name` still
+            # chooses the readable half and still walks its `_N` suffixes
+            # against live relations, retired names and the catalog, so a retry
+            # whose predecessor left an orphan does not collide with itself.
+            out_table = analysis_output_table_name(_base_table, uuid.UUID(job_id))
             # fix(#1778): the name, on the durable row, in the same transaction
             # that creates the table (the commit after ANALYZE below). Without
             # it a hard kill after that commit left the table unreachable: the

--- a/backend/app/processing/analysis/tasks.py
+++ b/backend/app/processing/analysis/tasks.py
@@ -14,7 +14,7 @@ import re
 import uuid
 from datetime import datetime, timezone
 from types import SimpleNamespace
-from typing import Any
+from typing import Any, Literal
 
 import structlog
 from prometheus_client import Counter
@@ -790,44 +790,77 @@ ANALYSIS_OUTPUT_TABLE_FIELD = "analysis_out_table"
 _ANALYSIS_TABLE_NAME_RE = re.compile(r"^[a-z_][a-z0-9_]{0,62}$")
 
 
+# fix(#1778 codex r6): what `drop_unadopted_analysis_output` actually managed
+# to establish. The distinction that matters to the stale-job sweeps is FINAL
+# versus RETRYABLE: a caller may forget the table's name only once the answer
+# can never change, because that name is the last durable pointer to it.
+#
+#   "adopted"  a dataset row owns the table. Final: it is not an orphan.
+#   "dropped"  the DROP committed. Final: there is nothing left to name.
+#   "invalid"  the recorded name is not an identifier `generate_table_name`
+#              could have produced, so no table of that name was made by this
+#              system and no retry can change the string. Final.
+#   "skipped"  nothing was named. Final, vacuously.
+#   "failed"   the probe or the DROP raised. NOT final. The table may exist and
+#              be unadopted, so the record has to survive for the next sweep.
+ANALYSIS_OUTPUT_FINAL_OUTCOMES = frozenset({"adopted", "dropped", "invalid", "skipped"})
+
+AnalysisOutputOutcome = Literal["skipped", "invalid", "adopted", "dropped", "failed"]
+
+
 async def drop_unadopted_analysis_output(
     session: AsyncSession,
     *,
     out_table: str | None,
     schema: str,
     job_id: str,
-) -> None:
+) -> AnalysisOutputOutcome:
     """Drop an analysis output table no dataset row has adopted.
 
     fix(#1778): the probe-then-drop the two fence-miss handlers already ran,
     lifted into one function so the stale-job sweeps can apply the same policy
     to a job whose worker was killed outright. Failure direction is the one
-    those handlers chose: an adoption probe that itself errors reports adopted,
-    so an unreadable catalog leaks a table rather than dropping a registered
-    dataset's storage.
+    those handlers chose: an adoption probe that itself errors leaks a table
+    rather than dropping a registered dataset's storage.
 
     The name is re-validated here because the sweeps read it out of
     ``user_metadata``, a JSONB blob with no schema, and it is interpolated into
     a DDL statement that takes no bind parameters.
+
+    fix(#1778 codex r6): it REPORTS, rather than returning the same ``None``
+    whether it dropped the table or failed to. The two fence-miss handlers can
+    ignore that -- they are inside the worker, and the job row still names the
+    table afterwards -- but the sweeps cannot. They clear the recorded name on
+    the strength of this call, and the name is the last durable pointer to the
+    table, so a swallowed failure read as success stripped the record and left
+    the table orphaned for good: exactly the leak this function exists to stop,
+    reintroduced by the function itself.
+
+    Note that a probe that RAISES is "failed" and not "adopted". Treating an
+    unreadable catalog as adoption is the right call for whether to DROP -- it
+    prefers a leak to destroying a live dataset's storage -- and the wrong one
+    for whether the question is settled, because nothing was established.
     """
     if out_table is None:
-        return
+        return "skipped"
     if not _ANALYSIS_TABLE_NAME_RE.match(out_table):
         logger.warning("analysis.output_table_name_rejected", job_id=job_id)
-        return
-    adopted = True
+        return "invalid"
     try:
         adopted = await _output_table_adopted(session, out_table)
     except Exception:  # broad: prefer leak over loss
         logger.warning("analysis.adoption_probe_failed", job_id=job_id)
         await session.rollback()
+        return "failed"
     if adopted:
-        return
+        return "adopted"
     try:
         await session.execute(text(f'DROP TABLE IF EXISTS "{schema}"."{out_table}"'))
         await session.commit()
     except Exception:  # broad: best-effort cleanup of the orphan
         await session.rollback()
+        return "failed"
+    return "dropped"
 
 
 async def _mark_job_failed(

--- a/backend/app/processing/ingest/tasks_common.py
+++ b/backend/app/processing/ingest/tasks_common.py
@@ -527,6 +527,25 @@ async def _job_phase_session(
     that legitimately runs before the row reaches ``running`` (phase 1, ahead
     of the claim) or one that must record something regardless of status
     (``error_write``).
+
+    fix(#1778 audit r12): the round-11 check above closed the case where the
+    sweep had ALREADY failed the row before this SELECT ran, but a plain
+    SELECT is not a lock — the sweep can still fail the row in the window
+    BETWEEN this read and the phase's own first irreversible write (a storage
+    put), which is the same leak by a narrower door. When ``require_status``
+    is given the SELECT below takes ``FOR NO KEY UPDATE``, so it holds a row
+    lock for as long as this phase's session stays open, which every current
+    ``require_status`` caller does across its own puts and up to its first
+    ``commit()``. The sweep's own transition query is the one that must
+    contend with this lock; see ``fail_stale_jobs`` in ``sweep.py`` and the
+    startup recovery pass in ``worker.py``, both rewritten to a `SELECT ...
+    FOR UPDATE SKIP LOCKED` candidate subquery so a row this lock protects is
+    excluded from that pass rather than blocking (or, worse, aborting) the
+    whole bulk transition. ``NO KEY UPDATE`` rather than plain ``UPDATE``: it
+    still conflicts with anything that needs to exclude a concurrent writer,
+    but not with a hypothetical ``FOR KEY SHARE`` reader this row's primary
+    key might someday gain a foreign-key referrer against, which ``ingest_
+    jobs`` does not have today but costs nothing to leave room for.
     """
     from app.core.db import async_session
     from app.platform.jobs.models import IngestJob
@@ -548,7 +567,13 @@ async def _job_phase_session(
             filters.append(IngestJob.attempt_id == attempt_id)
         if require_status is not None:
             filters.append(IngestJob.status == require_status)
-        result = await session.execute(select(IngestJob).where(*filters))
+        stmt = select(IngestJob).where(*filters)
+        if require_status is not None:
+            # fix(#1778 audit r12): held through this phase's own first
+            # irreversible write and up to its next commit — see the
+            # docstring above.
+            stmt = stmt.with_for_update(key_share=True)
+        result = await session.execute(stmt)
         job = result.scalar_one_or_none()
         if job is None:
             structlog.get_logger().warning(

--- a/backend/app/processing/ingest/tasks_common.py
+++ b/backend/app/processing/ingest/tasks_common.py
@@ -468,6 +468,7 @@ async def _job_phase_session(
     phase: str,
     attempt_id: uuid.UUID | None = None,
     lock_and_statement_timeout_ms: int | None = None,
+    require_status: str | None = None,
 ) -> "AsyncGenerator[tuple[AsyncSession, IngestJob | None], None]":
     """Two-phase session bracket for ingest workers (REMED-03 / P2-05).
 
@@ -507,6 +508,25 @@ async def _job_phase_session(
     ACCESS EXCLUSIVE lock on the table). ``None`` (the default) leaves the
     session on Postgres's server-wide default, unchanged for every other
     caller of this shared helper.
+
+    fix(#1778 audit r11): ``require_status`` is None by default, matching the
+    original ``attempt_id``-only fence — every job-row write in this codebase
+    that goes through ``update_ingest_job_for_attempt`` (``heartbeat.py``)
+    already defaults to requiring ``status == "running"`` on top of the
+    attempt match; this helper was the one loader missing that second half.
+    The gap: a stale sweep can fail a job on heartbeat timeout while the
+    worker that owns it is only paused (a GC pause, a slow syscall) rather
+    than dead, WITHOUT any retry having happened yet — so the row's
+    ``attempt_id`` is unchanged and an ``attempt_id``-only fence still
+    matches. The paused worker resumes, its phase-2 load passes, and it
+    proceeds to write whatever that phase writes to a row the sweep already
+    declared terminal. For a raster tail that write is an object-storage put,
+    which no database rollback can undo, so admitting the row here is the
+    actual leak, not just a stale read. Pass ``require_status="running"`` at
+    any phase that must not resume this way; leave it ``None`` at a phase
+    that legitimately runs before the row reaches ``running`` (phase 1, ahead
+    of the claim) or one that must record something regardless of status
+    (``error_write``).
     """
     from app.core.db import async_session
     from app.platform.jobs.models import IngestJob
@@ -526,6 +546,8 @@ async def _job_phase_session(
         filters = [IngestJob.id == job_uuid]
         if attempt_id is not None:
             filters.append(IngestJob.attempt_id == attempt_id)
+        if require_status is not None:
+            filters.append(IngestJob.status == require_status)
         result = await session.execute(select(IngestJob).where(*filters))
         job = result.scalar_one_or_none()
         if job is None:
@@ -533,6 +555,7 @@ async def _job_phase_session(
                 "Ingest job not found in phase, skipping",
                 job_id=str(job_uuid),
                 phase=phase,
+                require_status=require_status,
             )
             try:
                 yield session, None

--- a/backend/app/processing/ingest/tasks_raster.py
+++ b/backend/app/processing/ingest/tasks_raster.py
@@ -29,6 +29,7 @@ from app.platform.jobs.models import owned_presigned_staging_key
 from app.processing.ingest.tasks_raster_swap import (
     archive_lossy_original,
     archived_original_asset_key,
+    archived_original_uri,
     upsert_archived_original_row,
 )
 from app.processing.ingest.tasks_raster_common import (
@@ -42,6 +43,7 @@ from app.processing.ingest.tasks_raster_common import (
     create_raster_dataset,
     extract_source_raster_metadata,
     publish_commit_landed,
+    record_unpublished_storage_keys,
 )
 from app.processing.ingest.tasks_common import (
     _bind_task_log_context,
@@ -379,6 +381,35 @@ async def ingest_raster(
         asset_sha256 = await asyncio.to_thread(sha256_file, local_cog_path)
         cog_size = os.path.getsize(local_cog_path)
 
+        # fix(#1778): the dataset id is decided HERE rather than by the phase-2
+        # INSERT, because the object keys below embed it and the durable job
+        # row has to be able to name them before the transaction that could
+        # roll that id away ever opens. Nothing else changes: phase 2 hands
+        # this id to create_*_dataset and `base_key` is built from the same
+        # value it always was.
+        planned_dataset_id = uuid.uuid4()
+        _base_key = f"rasters/{planned_dataset_id}/{asset_sha256}"
+        _unpublished_keys = [
+            f"{_base_key}/source.vrt"
+            if is_manifest_vrt
+            else f"{_base_key}/source.cog.tif",
+            f"{_base_key}/quicklook_256.png",
+            f"{_base_key}/quicklook_512.png",
+            # The kept original of a lossy conversion. Its key is content-
+            # derived and the dataset id is brand new here, so this attempt is
+            # necessarily the only writer of it - unlike the replace tail,
+            # where the same key can already hold an earlier upload's archive
+            # and must not be registered.
+            archived_original_uri(planned_dataset_id, source_sha256=source_sha256),
+        ]
+        await record_unpublished_storage_keys(
+            job_uuid,
+            attempt_uuid,
+            keys=_unpublished_keys,
+            job_id=job_id,
+            task="ingest_raster",
+        )
+
         # REMED-02 / ingest-audit P2-07: quicklook generation is the other
         # multi-second hotspot. Brief-session write before the two
         # generate_quicklook calls so the UI advances. Routed through
@@ -439,6 +470,7 @@ async def ingest_raster(
                     vrt_type=um.get("vrt_type", "mosaic"),
                     resolution_strategy=um.get("resolution_strategy", "finest"),
                     source_dataset_ids=[],
+                    dataset_id=planned_dataset_id,
                 )
             else:
                 record, dataset, raster_asset = await create_raster_dataset(
@@ -455,6 +487,7 @@ async def ingest_raster(
                     summary=um.get("summary"),
                     visibility=um.get("visibility", "private"),
                     record_status=um.get("record_status", "published"),
+                    dataset_id=planned_dataset_id,
                 )
 
             # feat(#1472): the manifest's credit line. Covers both branches
@@ -505,15 +538,24 @@ async def ingest_raster(
                 ql512_key,
             )
 
-            # GAP-017: record each key right after its put so the failure
-            # path can delete exactly what was written (and nothing more).
+            # GAP-017: record each key so the failure path can delete exactly
+            # what was written (and nothing more).
+            #
+            # fix(#1778): registered BEFORE the put, not after it, which is the
+            # rule archive_lossy_original already follows (tasks_raster_swap.py).
+            # Ownership is registered by INTENT: both providers drain their
+            # worker thread before re-raising CancelledError, so a cancelled put
+            # can have COMPLETED, and CancelledError is a BaseException, so an
+            # append below it never runs and the finished object is left with
+            # nothing naming it. Reaping a key the write never created is an
+            # idempotent no-op, so the other direction costs nothing.
+            written_storage_keys.append(_storage_cog_key)
             with open(local_cog_path, "rb") as fobj:
                 await storage.put(_storage_cog_key, fobj)
-            written_storage_keys.append(_storage_cog_key)
-            await storage.put(_storage_ql256_key, io.BytesIO(ql256))
             written_storage_keys.append(_storage_ql256_key)
-            await storage.put(_storage_ql512_key, io.BytesIO(ql512))
+            await storage.put(_storage_ql256_key, io.BytesIO(ql256))
             written_storage_keys.append(_storage_ql512_key)
+            await storage.put(_storage_ql512_key, io.BytesIO(ql512))
 
             # 11. Update asset URIs and create distribution.
             # asset_uri stays as the logical (un-prefixed) key — the tenant

--- a/backend/app/processing/ingest/tasks_raster.py
+++ b/backend/app/processing/ingest/tasks_raster.py
@@ -402,7 +402,7 @@ async def ingest_raster(
             # and must not be registered.
             archived_original_uri(planned_dataset_id, source_sha256=source_sha256),
         ]
-        await record_unpublished_storage_keys(
+        if not await record_unpublished_storage_keys(
             job_uuid,
             attempt_uuid,
             keys=_unpublished_keys,
@@ -419,7 +419,14 @@ async def ingest_raster(
             attempt_scope=str(planned_dataset_id),
             job_id=job_id,
             task="ingest_raster",
-        )
+        ):
+            # fix(#1778 audit): a confirmed fence miss. Phase 2's own
+            # attempt-fenced load below would catch this too, but stopping
+            # here is what actually keeps the recorder's contract ("do not
+            # write what nothing records") rather than depending on a second
+            # guard downstream to make it true, and it skips the quicklook
+            # generation this dead attempt no longer needs.
+            return
 
         # REMED-02 / ingest-audit P2-07: quicklook generation is the other
         # multi-second hotspot. Brief-session write before the two

--- a/backend/app/processing/ingest/tasks_raster.py
+++ b/backend/app/processing/ingest/tasks_raster.py
@@ -406,6 +406,12 @@ async def ingest_raster(
             job_uuid,
             attempt_uuid,
             keys=_unpublished_keys,
+            # fix(#1778 codex r1): empty, and provably so. Every key above is
+            # under a dataset id generated three lines up, so no row can name
+            # one. The replace tail passes the live asset's keys here, because
+            # an identical re-upload derives the same content hash and would
+            # otherwise register the objects the dataset is serving.
+            already_published=(),
             job_id=job_id,
             task="ingest_raster",
         )

--- a/backend/app/processing/ingest/tasks_raster.py
+++ b/backend/app/processing/ingest/tasks_raster.py
@@ -452,9 +452,19 @@ async def ingest_raster(
         # P2-05): create DB records, store assets, commit job. Re-load the
         # job in a fresh session — its attributes were already snapshotted
         # into ``um`` / ``source_filename`` above.
+        #
+        # fix(#1778 audit r11): require_status="running". The load used to
+        # match on (job, attempt) alone, so a row the stale sweep already
+        # failed on a heartbeat timeout, WITHOUT a retry rotating the
+        # attempt, still matched -- and this phase puts objects to storage,
+        # which no rollback can undo. A worker only paused, not dead, could
+        # resume here and write bytes nothing durable names.
         # ----------------------------------------------------------------- #
         async with _job_phase_session(
-            job_uuid, phase="phase2", attempt_id=attempt_uuid
+            job_uuid,
+            phase="phase2",
+            attempt_id=attempt_uuid,
+            require_status="running",
         ) as (session, job):
             if job is None:
                 return

--- a/backend/app/processing/ingest/tasks_raster.py
+++ b/backend/app/processing/ingest/tasks_raster.py
@@ -412,6 +412,11 @@ async def ingest_raster(
             # an identical re-upload derives the same content hash and would
             # otherwise register the objects the dataset is serving.
             already_published=(),
+            # fix(#1778 codex r3): every key above sits under this id, and it
+            # is generated per task invocation, so a retry cannot reproduce
+            # one. That is this tail's attempt fence; the replace tail has a
+            # fixed dataset id and uses its attempt id instead.
+            attempt_scope=str(planned_dataset_id),
             job_id=job_id,
             task="ingest_raster",
         )

--- a/backend/app/processing/ingest/tasks_raster_common.py
+++ b/backend/app/processing/ingest/tasks_raster_common.py
@@ -169,12 +169,19 @@ async def create_raster_dataset(
     visibility: str,
     record_status: str = "published",
     original_srid: int | None = None,
+    dataset_id: uuid.UUID | None = None,
 ) -> tuple:
     """Create Record + Dataset + RasterAsset records for a raster ingest.
 
     ``meta`` describes the CONVERTED COG — the file this dataset will serve
     (fix(#1290 review)). ``original_srid`` is the one value that must describe
     the upload instead, so the caller reads it off the source and passes it in.
+
+    fix(#1778): ``dataset_id`` lets the caller decide the id BEFORE this
+    transaction opens. The object keys the tail is about to write embed it, and
+    naming them on the durable job row is only possible if the id exists while
+    that row can still be written to. Default None keeps every other caller on
+    the database-generated id.
 
     Returns (record, dataset, raster_asset).
     """
@@ -224,6 +231,7 @@ async def create_raster_dataset(
 
     table_name = f"raster_{record.id.hex[:16]}"
     dataset = Dataset(
+        **({"id": dataset_id} if dataset_id is not None else {}),
         record_id=record.id,
         table_name=table_name,
         source_format="geotiff",
@@ -492,3 +500,82 @@ def absorb_cancellation(exc: BaseException) -> None:
     task = asyncio.current_task()
     if task is not None:
         task.uncancel()
+
+
+# fix(#1778): the `user_metadata` field a raster tail names its pre-commit
+# object keys under. `written_storage_keys` is a local list, so a SIGKILL or an
+# OOM between the puts and the terminal `finally` reclaimed nothing: `base_key`
+# embeds a dataset id that rolls back with the transaction, so no row, no
+# `delete_dataset` prefix reap and no staging reconciler (`STAGING_PREFIX` is
+# `staging/` only) could ever name the objects again. The VRT publish path
+# already had an out-of-process owner for this class
+# (`_stale_generation_storage_keys` in the job sweep); this field extends the
+# same shape to `rasters/` and `originals/`.
+UNPUBLISHED_STORAGE_KEYS_FIELD = "unpublished_storage_keys"
+
+
+async def record_unpublished_storage_keys(
+    job_uuid: uuid.UUID,
+    attempt_uuid: uuid.UUID,
+    *,
+    keys: list[str],
+    job_id: str,
+    task: str,
+) -> None:
+    """Persist the object keys this attempt is ABOUT to write, best effort.
+
+    fix(#1778). One JSONB write, committed on its own session before the
+    publishing transaction opens, which is what makes the keys nameable after
+    the process is gone. Logical keys (never tenant-resolved) so the sweep
+    resolves them in its own tenant context, the way it already does for
+    ``_staged_presigned_keys``.
+
+    Ordering is the whole mechanism and it is narrow. This must run BEFORE the
+    phase-2 session takes the ``ingest_jobs`` row lock (phase 2's first
+    statements dirty ``current_step``/``progress``): a second session updating
+    that row while phase 2 holds it would block until phase 2 ended, and phase
+    2 would be waiting on this call. So it lives beside the pre-phase-2
+    progress write, never inside phase 2.
+
+    A JSONB merge rather than an assignment, so it cannot clobber a field a
+    later write adds, and fenced on ``attempt_id`` so a retry's keys never land
+    on another attempt's row.
+
+    Failure is swallowed. This buys reclaimability for a crash that may not
+    happen; refusing the ingest over it would trade a possible leak for a
+    certain failure.
+    """
+    from sqlalchemy import bindparam, func, text, update
+    from sqlalchemy.dialects.postgresql import JSONB
+
+    import app.core.db as db_module
+
+    from app.platform.jobs.models import IngestJob
+
+    if not keys:
+        return
+    try:
+        async with db_module.async_session() as session:
+            await session.execute(
+                update(IngestJob)
+                .where(
+                    IngestJob.id == job_uuid,
+                    IngestJob.attempt_id == attempt_uuid,
+                )
+                .values(
+                    user_metadata=func.coalesce(
+                        IngestJob.user_metadata, text("'{}'::jsonb")
+                    ).op("||")(
+                        bindparam(
+                            "unpublished_patch",
+                            value={UNPUBLISHED_STORAGE_KEYS_FIELD: list(keys)},
+                            type_=JSONB,
+                        )
+                    )
+                )
+            )
+            await session.commit()
+    except Exception:  # broad: reclaimability is best effort, the ingest is not
+        structlog.get_logger().warning(
+            "unpublished_storage_keys_not_recorded", job_id=job_id, task=task
+        )

--- a/backend/app/processing/ingest/tasks_raster_common.py
+++ b/backend/app/processing/ingest/tasks_raster_common.py
@@ -512,6 +512,42 @@ def absorb_cancellation(exc: BaseException) -> None:
 # already had an out-of-process owner for this class
 # (`_stale_generation_storage_keys` in the job sweep); this field extends the
 # same shape to `rasters/` and `originals/`.
+def attempt_scoped_raster_base_key(
+    dataset_id: uuid.UUID,
+    attempt_id: uuid.UUID,
+    asset_sha256: str,
+) -> str:
+    """The object prefix ONE replace attempt may write under.
+
+    fix(#1778 codex r3). The replace tail used to key on dataset id plus the
+    content hash alone, which is deterministic across attempts: re-running the
+    same upload derives the same three keys. That is a collision the durable
+    reaper cannot survive. ``fail_stale_jobs`` commits, and that commit both
+    settles the dead attempt and releases the dataset's active-run reservation
+    through the refresh-run sweep, so a replacement can be admitted while the
+    post-commit cleanup is still running. The new attempt then writes the same
+    keys the reaper is about to delete, after the survivor snapshot and before
+    the delete, with no row naming them yet, and its own commit lands a
+    ``RasterAsset`` pointing at bytes that are gone.
+
+    Attempt fencing closes that structurally rather than by ordering, which is
+    what the VRT publish path already does with
+    ``rasters/{id}/generations/{generation_id}/``: no two attempts can name the
+    same object, so there is no window left to get the ordering wrong in. Same
+    convention as ``attempt_scoped_staging_table``, which fences the vector
+    tails' staging tables on the identical fact.
+
+    The content hash stays in the key. It is what invariant 10 rests on (a
+    replacement cannot overwrite the live asset in place) and it keeps the
+    stored key content-addressed; the attempt segment makes it
+    attempt-addressed as well.
+
+    The first-ingest tail needs no equivalent: its keys sit under a dataset id
+    generated inside the task, so a retry produces a different one.
+    """
+    return f"rasters/{dataset_id}/attempts/{attempt_id}/{asset_sha256}"
+
+
 UNPUBLISHED_STORAGE_KEYS_FIELD = "unpublished_storage_keys"
 
 
@@ -521,6 +557,7 @@ async def record_unpublished_storage_keys(
     *,
     keys: list[str],
     already_published: "Iterable[str]",
+    attempt_scope: str,
     job_id: str,
     task: str,
 ) -> None:
@@ -548,6 +585,18 @@ async def record_unpublished_storage_keys(
     The reaper carries the second half of this: it refuses to delete a key a
     live row still references, whatever the job row says.
 
+    fix(#1778 codex r3): ``attempt_scope`` is a token unique to this attempt,
+    and a key that does not contain it is DROPPED rather than recorded. That is
+    the rule the recorded set has to satisfy for the reaper to be safe at all,
+    because the reaper deletes on the strength of "the attempt that wrote this
+    is gone": a key two attempts can both name is one the reaper can delete out
+    from under the live one. Checking it here, at the single point where keys
+    become durable, is what stops a future writer from recording a shared key
+    and finding out about it from a support ticket. The replace tail's token is
+    its attempt id, carried by every key through
+    ``attempt_scoped_raster_base_key``; the first-ingest tail's is the dataset
+    id it generates per attempt.
+
     Ordering is the whole mechanism and it is narrow. This must run BEFORE the
     phase-2 session takes the ``ingest_jobs`` row lock (phase 2's first
     statements dirty ``current_step``/``progress``): a second session updating
@@ -571,7 +620,12 @@ async def record_unpublished_storage_keys(
     from app.platform.jobs.models import IngestJob
 
     published = set(already_published)
-    unpublished = [key for key in keys if key not in published]
+    candidates = [key for key in keys if key not in published]
+    unpublished = [key for key in candidates if attempt_scope in key]
+    if len(unpublished) < len(candidates):
+        structlog.get_logger().warning(
+            "unpublished_storage_key_not_attempt_scoped", job_id=job_id, task=task
+        )
     if not unpublished:
         return
     try:

--- a/backend/app/processing/ingest/tasks_raster_common.py
+++ b/backend/app/processing/ingest/tasks_raster_common.py
@@ -560,8 +560,27 @@ async def record_unpublished_storage_keys(
     attempt_scope: str,
     job_id: str,
     task: str,
-) -> None:
+) -> bool:
     """Persist the object keys this attempt is ABOUT to write, best effort.
+
+    Returns whether the caller may proceed to write those objects. ``False``
+    means this attempt is DEFINITIVELY fenced out: the ``(job_uuid,
+    attempt_uuid)`` pair matched no row, which happens when the stale sweep
+    fails the row on a heartbeat timeout while this worker is merely paused
+    (a GC pause, a slow syscall) rather than dead, and a retry has since
+    minted a new attempt on the same job. Every other fenced job-row write in
+    this codebase checks its match (``update_ingest_job_for_attempt`` in
+    ``heartbeat.py`` returns ``bool(rowcount)`` and every caller branches on
+    a miss); this one used to be the exception, silently committing nothing
+    and letting the caller carry on to write objects a dead attempt's row
+    would never record. A worker killed after that point leaves the objects
+    with no reference anywhere, the #1778 leak class reopened at the one
+    recorder that did not check its own fence.
+
+    An unreachable database or any other transient failure is a DIFFERENT
+    case and still returns ``True``: nothing there proves this attempt is
+    gone, and refusing to proceed over it would trade a possible leak for a
+    certain one. Only a confirmed zero-row match is a confirmed fence miss.
 
     fix(#1778). One JSONB write, committed on its own session before the
     publishing transaction opens, which is what makes the keys nameable after
@@ -608,9 +627,10 @@ async def record_unpublished_storage_keys(
     later write adds, and fenced on ``attempt_id`` so a retry's keys never land
     on another attempt's row.
 
-    Failure is swallowed. This buys reclaimability for a crash that may not
-    happen; refusing the ingest over it would trade a possible leak for a
-    certain failure.
+    A transient failure is swallowed, same as before. This buys
+    reclaimability for a crash that may not happen; refusing the ingest over
+    an error that says nothing about the fence would trade a possible leak
+    for a certain failure.
     """
     from sqlalchemy import bindparam, case, func, text, update
     from sqlalchemy.dialects.postgresql import JSONB
@@ -627,7 +647,7 @@ async def record_unpublished_storage_keys(
             "unpublished_storage_key_not_attempt_scoped", job_id=job_id, task=task
         )
     if not unpublished:
-        return
+        return True
     # fix(#1778 codex r9): APPEND to what the row already names, never replace
     # it. `/jobs/{id}/retry` preserves `user_metadata`, so a retried ingest
     # reached this with the previous attempt's keys still on the row; a merge
@@ -659,7 +679,7 @@ async def record_unpublished_storage_keys(
     )
     try:
         async with db_module.async_session() as session:
-            await session.execute(
+            result = await session.execute(
                 update(IngestJob)
                 .where(
                     IngestJob.id == job_uuid,
@@ -680,3 +700,15 @@ async def record_unpublished_storage_keys(
         structlog.get_logger().warning(
             "unpublished_storage_keys_not_recorded", job_id=job_id, task=task
         )
+        # An error here says nothing about the fence, so it does not license
+        # an abort. See the docstring: only a confirmed zero-row match does.
+        return True
+    if not result.rowcount:  # type: ignore[attr-defined]
+        # fix(#1778 audit): a confirmed miss. This attempt no longer owns the
+        # row, so the objects it is about to write would have nothing durable
+        # naming them; the caller must not write them.
+        structlog.get_logger().warning(
+            "unpublished_storage_keys_fence_missed", job_id=job_id, task=task
+        )
+        return False
+    return True

--- a/backend/app/processing/ingest/tasks_raster_common.py
+++ b/backend/app/processing/ingest/tasks_raster_common.py
@@ -612,7 +612,7 @@ async def record_unpublished_storage_keys(
     happen; refusing the ingest over it would trade a possible leak for a
     certain failure.
     """
-    from sqlalchemy import bindparam, func, text, update
+    from sqlalchemy import bindparam, case, func, text, update
     from sqlalchemy.dialects.postgresql import JSONB
 
     import app.core.db as db_module
@@ -628,6 +628,35 @@ async def record_unpublished_storage_keys(
         )
     if not unpublished:
         return
+    # fix(#1778 codex r9): APPEND to what the row already names, never replace
+    # it. `/jobs/{id}/retry` preserves `user_metadata`, so a retried ingest
+    # reached this with the previous attempt's keys still on the row; a merge
+    # that set the field to this attempt's keys alone dropped them, and an
+    # attempt whose own best-effort delete had also failed lost its objects'
+    # last durable pointer with it. Neither stale pass nor the retention purge
+    # could then name them.
+    #
+    # A flat list that each attempt extends, rather than a map keyed by
+    # attempt. Which attempt wrote a key is not something any reader needs --
+    # the question every one of them asks is "is this key still owed a reap" --
+    # and keeping the shape a list means the reader is unchanged and a row
+    # written before this commit still reaps.
+    #
+    # The CASE keeps it total: `jsonb || jsonb` concatenates two arrays, but
+    # would fold an array into a non-array, so anything that is not an array
+    # is replaced rather than appended to.
+    _existing_keys = func.coalesce(
+        IngestJob.user_metadata[UNPUBLISHED_STORAGE_KEYS_FIELD],
+        text("'[]'::jsonb"),
+    )
+    _new_keys = bindparam("unpublished_patch", value=unpublished, type_=JSONB)
+    _accumulated_keys = case(
+        (
+            func.jsonb_typeof(_existing_keys) == "array",
+            _existing_keys.op("||")(_new_keys),
+        ),
+        else_=_new_keys,
+    )
     try:
         async with db_module.async_session() as session:
             await session.execute(
@@ -640,10 +669,8 @@ async def record_unpublished_storage_keys(
                     user_metadata=func.coalesce(
                         IngestJob.user_metadata, text("'{}'::jsonb")
                     ).op("||")(
-                        bindparam(
-                            "unpublished_patch",
-                            value={UNPUBLISHED_STORAGE_KEYS_FIELD: unpublished},
-                            type_=JSONB,
+                        func.jsonb_build_object(
+                            UNPUBLISHED_STORAGE_KEYS_FIELD, _accumulated_keys
                         )
                     )
                 )

--- a/backend/app/processing/ingest/tasks_raster_common.py
+++ b/backend/app/processing/ingest/tasks_raster_common.py
@@ -16,6 +16,7 @@ import asyncio
 import os
 import uuid
 from datetime import datetime, timezone
+from collections.abc import Iterable
 from typing import Any
 
 import structlog
@@ -519,6 +520,7 @@ async def record_unpublished_storage_keys(
     attempt_uuid: uuid.UUID,
     *,
     keys: list[str],
+    already_published: "Iterable[str]",
     job_id: str,
     task: str,
 ) -> None:
@@ -529,6 +531,22 @@ async def record_unpublished_storage_keys(
     the process is gone. Logical keys (never tenant-resolved) so the sweep
     resolves them in its own tenant context, the way it already does for
     ``_staged_presigned_keys``.
+
+    fix(#1778 codex r1): ``already_published`` is what the LIVE asset names,
+    and it is subtracted here rather than at either call site. A replace whose
+    conversion reproduces the published COG byte for byte (re-uploading the
+    same file) derives the same ``asset_sha256``, so the three keys this
+    attempt intends ARE the three keys the dataset is currently serving. A
+    crash any time after this write, even before the first put, then handed the
+    stale-job reaper permission to delete the live COG and both quicklooks. The
+    in-process failure cleanup has always excluded ``prior_physical_keys``; the
+    durable record has to carry the same exclusion, because the process that
+    knows it is the one that may not be there. Subtracting inside this function
+    rather than at the call sites means a future writer of intended keys gets
+    the exclusion by having to answer the question.
+
+    The reaper carries the second half of this: it refuses to delete a key a
+    live row still references, whatever the job row says.
 
     Ordering is the whole mechanism and it is narrow. This must run BEFORE the
     phase-2 session takes the ``ingest_jobs`` row lock (phase 2's first
@@ -552,7 +570,9 @@ async def record_unpublished_storage_keys(
 
     from app.platform.jobs.models import IngestJob
 
-    if not keys:
+    published = set(already_published)
+    unpublished = [key for key in keys if key not in published]
+    if not unpublished:
         return
     try:
         async with db_module.async_session() as session:
@@ -568,7 +588,7 @@ async def record_unpublished_storage_keys(
                     ).op("||")(
                         bindparam(
                             "unpublished_patch",
-                            value={UNPUBLISHED_STORAGE_KEYS_FIELD: list(keys)},
+                            value={UNPUBLISHED_STORAGE_KEYS_FIELD: unpublished},
                             type_=JSONB,
                         )
                     )

--- a/backend/app/processing/ingest/tasks_raster_replace.py
+++ b/backend/app/processing/ingest/tasks_raster_replace.py
@@ -324,6 +324,21 @@ async def reupload_raster(
                 quicklook_256_uri=raster_asset.quicklook_256_uri,
                 quicklook_512_uri=raster_asset.quicklook_512_uri,
             )
+            # fix(#1778 codex r1): the same three objects in LOGICAL form. The
+            # durable reaper works in logical keys (it resolves them in its own
+            # tenant context), so comparing against the physical list above
+            # would silently match nothing on a hosted deployment and leave the
+            # live asset reapable. Same reason `_prior_asset_keys_to_reap`
+            # gives for keeping its own two lists in one form.
+            prior_logical_keys = [
+                key
+                for key in (
+                    raster_asset.asset_uri,
+                    raster_asset.quicklook_256_uri,
+                    raster_asset.quicklook_512_uri,
+                )
+                if key
+            ]
 
             # feat(#1219): pending -> running on the run row this job's commit
             # door already reserved. Raster reuses that admission gate rather
@@ -468,8 +483,15 @@ async def reupload_raster(
         # SIGKILL between the puts and the terminal `finally` leaves them with
         # no reference anywhere: the swap rolled back, so the live asset still
         # names the OLD keys and `delete_dataset`'s prefix reap only runs when
-        # the dataset is deleted. The content hash makes this prefix this
-        # attempt's alone, so the sweep can never reach what is still serving.
+        # the dataset is deleted.
+        #
+        # fix(#1778 codex r1): the content hash does NOT make this prefix this
+        # attempt's alone, which an earlier revision of this comment claimed.
+        # Re-uploading the file the dataset already serves converts to the same
+        # COG and hashes to the same `asset_sha256`, so all three keys below
+        # are the ones currently being served. `already_published` is what
+        # keeps them out of the durable record; the reaper's own survivor check
+        # is the second half.
         #
         # The kept original is deliberately NOT registered here. Its key is
         # derived from the SOURCE hash, so re-uploading bytes this dataset has
@@ -486,6 +508,7 @@ async def reupload_raster(
                 f"{_replace_base_key}/quicklook_256.png",
                 f"{_replace_base_key}/quicklook_512.png",
             ],
+            already_published=prior_logical_keys,
             job_id=job_id,
             task="reupload_raster",
         )

--- a/backend/app/processing/ingest/tasks_raster_replace.py
+++ b/backend/app/processing/ingest/tasks_raster_replace.py
@@ -506,7 +506,7 @@ async def reupload_raster(
         _replace_base_key = attempt_scoped_raster_base_key(
             dataset_uuid, attempt_uuid, asset_sha256
         )
-        await record_unpublished_storage_keys(
+        if not await record_unpublished_storage_keys(
             job_uuid,
             attempt_uuid,
             keys=[
@@ -518,7 +518,14 @@ async def reupload_raster(
             attempt_scope=str(attempt_uuid),
             job_id=job_id,
             task="reupload_raster",
-        )
+        ):
+            # fix(#1778 audit): a confirmed fence miss. Phase 2's own
+            # attempt-fenced load below would catch this too, but stopping
+            # here is what actually keeps the recorder's contract ("do not
+            # write what nothing records") rather than depending on a second
+            # guard downstream to make it true, and it skips the quicklook
+            # generation this dead attempt no longer needs.
+            return
 
         await _stamp_progress(
             job_uuid,

--- a/backend/app/processing/ingest/tasks_raster_replace.py
+++ b/backend/app/processing/ingest/tasks_raster_replace.py
@@ -75,6 +75,7 @@ from app.processing.ingest.tasks_raster_common import (
     absorb_cancellation,
     extract_source_raster_metadata,
     publish_commit_landed,
+    record_unpublished_storage_keys,
 )
 from app.processing.ingest.tasks_raster_swap import (
     _prior_asset_keys_to_reap,
@@ -328,6 +329,17 @@ async def reupload_raster(
             # door already reserved. Raster reuses that admission gate rather
             # than opening a second one, so there is nothing to create here.
             await claim_run_for_job(session, job_uuid)
+            # fix(#1778): committed HERE rather than at the end of the block.
+            # `claim_run_for_job` -> `transition_run` issues an UPDATE ...
+            # RETURNING on `dataset_refresh_runs`, so the run row stays
+            # exclusively locked until this transaction ends. The download
+            # below is the multi-GB phase a user is most likely to abandon, and
+            # `cancel_job` runs its own run transition under a 2s lock_timeout:
+            # holding the row across the download turned every cancel in that
+            # window into a 409 `job_finishing` whose rollback also discarded
+            # the job cancellation it had already written. One extra round trip
+            # buys a cancellable download.
+            await session.commit()
 
             from app.processing.ingest.service import resolve_file_path
 
@@ -379,15 +391,11 @@ async def reupload_raster(
             um: dict = job.user_metadata or {}
             source_filename: str | None = job.source_filename
 
-            # The claim above rides its own commit, but `claim_run_for_job`
-            # does not — and this session closes at the end of the block, so
-            # without this the pending -> running transition rolls back. The
-            # run then sits `pending` for the whole conversion, and
-            # `record_refresh_success` (which expects `running`) declines to
-            # finalize it: a successful replace would leave a stuck active
-            # reservation that the admission index honors by refusing every
-            # later refresh until the sweep. Same commit `reupload_file` ends
-            # its phase 1 with.
+            # The pending -> running transition is already durable (committed
+            # above the download). This closes the read transaction
+            # `_validate_upload_file_safety` opened, so the block does not hand
+            # an idle-in-transaction connection back to the pool. Same commit
+            # `reupload_file` ends its phase 1 with.
             await session.commit()
 
         # ----------------------------------------------------------------- #
@@ -455,6 +463,33 @@ async def reupload_raster(
         asset_sha256 = await asyncio.to_thread(sha256_file, local_cog_path)
         cog_size = os.path.getsize(local_cog_path)
 
+        # fix(#1778): name the three objects phase 2 is about to write on the
+        # durable job row, before phase 2 takes the `ingest_jobs` row lock. A
+        # SIGKILL between the puts and the terminal `finally` leaves them with
+        # no reference anywhere: the swap rolled back, so the live asset still
+        # names the OLD keys and `delete_dataset`'s prefix reap only runs when
+        # the dataset is deleted. The content hash makes this prefix this
+        # attempt's alone, so the sweep can never reach what is still serving.
+        #
+        # The kept original is deliberately NOT registered here. Its key is
+        # derived from the SOURCE hash, so re-uploading bytes this dataset has
+        # already archived resolves to an object an earlier replace wrote and a
+        # live `dataset_assets` row still points at. `archive_lossy_original`
+        # registers it only when its own pre-write probe proves absence, and
+        # that probe result is not available this early.
+        _replace_base_key = f"rasters/{dataset_uuid}/{asset_sha256}"
+        await record_unpublished_storage_keys(
+            job_uuid,
+            attempt_uuid,
+            keys=[
+                f"{_replace_base_key}/source.cog.tif",
+                f"{_replace_base_key}/quicklook_256.png",
+                f"{_replace_base_key}/quicklook_512.png",
+            ],
+            job_id=job_id,
+            task="reupload_raster",
+        )
+
         await _stamp_progress(
             job_uuid,
             attempt_uuid,
@@ -508,13 +543,19 @@ async def reupload_raster(
 
             # The new content hash gives these a prefix the live asset does not
             # share, so these three puts cannot touch what is still serving.
+            #
+            # fix(#1778): registered BEFORE the put, the rule
+            # archive_lossy_original states two files away. A cancelled put can
+            # have completed (both providers drain the worker thread), and
+            # CancelledError is a BaseException, so an append below the put
+            # never runs and leaves the object unreferenced.
+            written_storage_keys.append(_storage_cog_key)
             with open(local_cog_path, "rb") as fobj:
                 await storage.put(_storage_cog_key, fobj)
-            written_storage_keys.append(_storage_cog_key)
-            await storage.put(_storage_ql256_key, io.BytesIO(ql256))
             written_storage_keys.append(_storage_ql256_key)
-            await storage.put(_storage_ql512_key, io.BytesIO(ql512))
+            await storage.put(_storage_ql256_key, io.BytesIO(ql256))
             written_storage_keys.append(_storage_ql512_key)
+            await storage.put(_storage_ql512_key, io.BytesIO(ql512))
 
             # fix(#1290 review): every field below reads the CONVERTED COG's
             # own metadata. Persisting the source's described a file the

--- a/backend/app/processing/ingest/tasks_raster_replace.py
+++ b/backend/app/processing/ingest/tasks_raster_replace.py
@@ -10,8 +10,10 @@ pointer.
 
 **Invariant 10, last-known-good is sacred.** The previous COG is not deleted or
 overwritten until the replacement has been written to storage AND read back
-successfully. The new asset lands under keys derived from its own content hash,
-so it cannot collide with the live asset's; the pointer moves in a single
+successfully. The new asset lands under keys derived from this attempt's id and
+its own content hash, so it can collide neither with the live asset's nor with
+another attempt's (fix(#1778 codex r3) added the first half of that; see
+``attempt_scoped_raster_base_key``); the pointer moves in a single
 transaction alongside the tile-cache bump; and only after that transaction
 commits are the superseded objects reaped. Every failure before the commit
 leaves the old COG serving tiles, which is what the dataset's map layers keep
@@ -73,6 +75,7 @@ from app.processing.ingest.tasks_raster_common import (
     _enforce_strict_cog,
     _resolve_managed_raster_storage_keys,
     absorb_cancellation,
+    attempt_scoped_raster_base_key,
     extract_source_raster_metadata,
     publish_commit_landed,
     record_unpublished_storage_keys,
@@ -485,13 +488,14 @@ async def reupload_raster(
         # names the OLD keys and `delete_dataset`'s prefix reap only runs when
         # the dataset is deleted.
         #
-        # fix(#1778 codex r1): the content hash does NOT make this prefix this
-        # attempt's alone, which an earlier revision of this comment claimed.
-        # Re-uploading the file the dataset already serves converts to the same
-        # COG and hashes to the same `asset_sha256`, so all three keys below
-        # are the ones currently being served. `already_published` is what
-        # keeps them out of the durable record; the reaper's own survivor check
-        # is the second half.
+        # fix(#1778 codex r3): the prefix is attempt-scoped, so these three keys
+        # are this attempt's alone: not the live asset's (which an identical
+        # re-upload would otherwise reproduce exactly, since it converts to the
+        # same COG and hashes the same), and not a later attempt's (which the
+        # reaper would otherwise be able to delete after its survivor snapshot
+        # and before its delete, once this pass's commit released the run
+        # reservation). `already_published` and the reaper's survivor check
+        # both stay, as defence in depth behind the key layout.
         #
         # The kept original is deliberately NOT registered here. Its key is
         # derived from the SOURCE hash, so re-uploading bytes this dataset has
@@ -499,7 +503,9 @@ async def reupload_raster(
         # live `dataset_assets` row still points at. `archive_lossy_original`
         # registers it only when its own pre-write probe proves absence, and
         # that probe result is not available this early.
-        _replace_base_key = f"rasters/{dataset_uuid}/{asset_sha256}"
+        _replace_base_key = attempt_scoped_raster_base_key(
+            dataset_uuid, attempt_uuid, asset_sha256
+        )
         await record_unpublished_storage_keys(
             job_uuid,
             attempt_uuid,
@@ -509,6 +515,7 @@ async def reupload_raster(
                 f"{_replace_base_key}/quicklook_512.png",
             ],
             already_published=prior_logical_keys,
+            attempt_scope=str(attempt_uuid),
             job_id=job_id,
             task="reupload_raster",
         )
@@ -554,7 +561,12 @@ async def reupload_raster(
             from app.platform.storage import get_storage
 
             storage = get_storage()
-            base_key = f"rasters/{dataset.id}/{asset_sha256}"
+            # fix(#1778 codex r3): the same derivation the durable record used,
+            # through the one helper, so the two cannot drift into recording
+            # one prefix and writing another.
+            base_key = attempt_scoped_raster_base_key(
+                dataset.id, attempt_uuid, asset_sha256
+            )
             cog_key = f"{base_key}/source.cog.tif"
             ql256_key = f"{base_key}/quicklook_256.png"
             ql512_key = f"{base_key}/quicklook_512.png"

--- a/backend/app/processing/ingest/tasks_raster_replace.py
+++ b/backend/app/processing/ingest/tasks_raster_replace.py
@@ -541,9 +541,17 @@ async def reupload_raster(
         # ----------------------------------------------------------------- #
         # Phase 2 (short-lived session): write the new objects, then swap the
         # pointer and all its dependent rows in ONE transaction.
+        #
+        # fix(#1778 audit r11): require_status="running", same reason as the
+        # sibling in tasks_raster.py -- an (job, attempt)-only fence still
+        # matches a row the stale sweep already failed without a retry
+        # rotating the attempt, and this phase puts objects to storage.
         # ----------------------------------------------------------------- #
         async with _job_phase_session(
-            job_uuid, phase="phase2", attempt_id=attempt_uuid
+            job_uuid,
+            phase="phase2",
+            attempt_id=attempt_uuid,
+            require_status="running",
         ) as (session, job):
             if job is None:
                 return

--- a/backend/app/processing/ingest/tasks_reupload.py
+++ b/backend/app/processing/ingest/tasks_reupload.py
@@ -234,6 +234,14 @@ async def reupload_file(
             # `started_at` deliberately stays at dispatch time, so the gap to
             # this write IS the queue wait.
             await claim_run_for_job(session, job_uuid)
+            # fix(#1778): committed before the download, not after it. The
+            # transition holds a row lock on `dataset_refresh_runs` until this
+            # transaction ends, and `cancel_job` transitions that same row under
+            # a 2s lock_timeout, so holding it across `resolve_file_path` made
+            # every cancel during the staging download return 409
+            # `job_finishing` and roll back the job cancellation it had already
+            # committed. The raster peer commits at the same point.
+            await session.commit()
 
             # Resolve S3 key to local file for ogr2ogr
             from app.processing.ingest.service import resolve_file_path

--- a/backend/app/processing/ingest/tasks_vector.py
+++ b/backend/app/processing/ingest/tasks_vector.py
@@ -672,9 +672,24 @@ async def ingest_file(
         # P2-05): post-ogr2ogr finalization. Re-load the job in a fresh
         # session — its attributes were already snapshotted into
         # ``um`` / ``source_filename`` / ``layer_name`` above.
+        #
+        # fix(#1778 audit r11): require_status="running". _finalize_ingest's
+        # own terminal write already fences on status via
+        # require_ingest_job_update (default expected_status="running"), so a
+        # fenced-out attempt cannot resurrect a row the sweep failed -- the
+        # transaction rolls back and no row is left wrong. But nothing here
+        # keeps a paused, not-dead worker from wastefully running the whole
+        # finalize pipeline (grant_reader_access, dataset creation, quality
+        # scoring) against a doomed row first; this stops it at the door,
+        # for the same reason the raster tails' phase 2 does now, even
+        # though vector ingest writes no untracked storage object that a
+        # rollback cannot undo.
         # ----------------------------------------------------------------- #
         async with _job_phase_session(
-            job_uuid, phase="phase2", attempt_id=attempt_uuid
+            job_uuid,
+            phase="phase2",
+            attempt_id=attempt_uuid,
+            require_status="running",
         ) as (session, job):
             if job is None:
                 return
@@ -1184,9 +1199,17 @@ async def ingest_service(
 
         # ----------------------------------------------------------------- #
         # Phase 2 (short-lived session): post-ogr2ogr finalization.
+        #
+        # fix(#1778 audit r11): require_status="running", same reasoning as
+        # the sibling in ingest_file above -- this phase's own terminal write
+        # is already fenced by status through require_ingest_job_update, this
+        # closes the door earlier rather than wasting the finalize work.
         # ----------------------------------------------------------------- #
         async with _job_phase_session(
-            job_uuid, phase="phase2", attempt_id=attempt_uuid
+            job_uuid,
+            phase="phase2",
+            attempt_id=attempt_uuid,
+            require_status="running",
         ) as (session, job):
             if job is None:
                 return

--- a/backend/app/processing/ingest/tasks_vrt.py
+++ b/backend/app/processing/ingest/tasks_vrt.py
@@ -4,7 +4,7 @@ Storage portability (STOR-03/04, Phase 1210):
   VRTs are stored with provider-agnostic SourceFilename nodes (logical keys +
   relativeToVRT="1"). The rewrite pass (rewrite_vrt_sources) runs AFTER metadata
   extraction and quicklook generation at each store site — the in-flight tmp .vrt
-  used by read_vrt_metadata / render_vrt_quicklook must hold concrete,
+  used by extract_raster_metadata / generate_quicklook must hold concrete,
   resolvable paths; only the stored copy is normalised to logical keys.
 
   At open-time, resolve_open_path (app.platform.storage.titiler_url) reconstructs
@@ -30,11 +30,11 @@ from app.platform.jobs.heartbeat import (
 )
 from app.core.db import tenant_task
 from app.processing.embeddings.helpers import defer_embedding
-from app.processing.raster.cog import sha256_file
+from app.processing.raster.cog import extract_raster_metadata, sha256_file
+from app.processing.raster.quicklook import generate_quicklook
 from app.processing.raster.vrt import (
     build_vrt,
-    read_vrt_metadata,
-    render_vrt_quicklook,
+    gdal_safe_open_env,
     resolve_vrt_source_path,
 )
 from app.processing.raster.vrt_rewrite import rewrite_vrt_sources
@@ -49,6 +49,40 @@ from app.processing.ingest.tasks_raster_common import (
     absorb_cancellation,
     publish_commit_landed,
 )
+
+
+def read_vrt_metadata(vrt_path: str) -> dict:
+    """``extract_raster_metadata`` on a built VRT, under the safe open env.
+
+    fix(#1778). Steps 6 and 8 below open every ``/vsis3`` source the assembled
+    VRT names, in-process rather than through a subprocess, so they are the one
+    place in this task that ``GDAL_SUBPROCESS_TIMEOUT_SECONDS`` does not reach.
+    ``_VRT_SAFE_ENV`` carries the ``GDAL_HTTP_*`` clamps that bound them, and a
+    rasterio ``Env`` sets thread-local GDAL config, so the env has to be entered
+    INSIDE the ``asyncio.to_thread`` call rather than around it. That is the
+    whole reason this is a function and not a ``with`` block at the call site.
+
+    fix(#1778 codex r3): it lives in THIS module, and calls
+    ``extract_raster_metadata`` through the module global rather than a local
+    import, because that name is a patch target
+    (``test_regenerate_vrt_integration``'s ``quicklook_stub`` patches its peer
+    the same way). An earlier revision put both wrappers in ``raster/vrt.py``
+    with function-level imports, which removed the attribute the fixture
+    patches and made the patch a no-op in the same stroke.
+    """
+    with gdal_safe_open_env():
+        return extract_raster_metadata(vrt_path)
+
+
+def render_vrt_quicklook(vrt_path: str, size: int) -> bytes:
+    """``generate_quicklook`` on a built VRT, under the safe open env.
+
+    fix(#1778): the peer of :func:`read_vrt_metadata` and the heavier of the
+    two, since it reads pixels from every source rather than headers. Same
+    module-global call for the same reason.
+    """
+    with gdal_safe_open_env():
+        return generate_quicklook(vrt_path, size)
 
 
 async def _reap_superseded_generation_objects(

--- a/backend/app/processing/ingest/tasks_vrt.py
+++ b/backend/app/processing/ingest/tasks_vrt.py
@@ -48,6 +48,7 @@ from app.processing.ingest.tasks_common import (
 from app.processing.ingest.tasks_raster_common import (
     absorb_cancellation,
     publish_commit_landed,
+    record_unpublished_storage_keys,
 )
 
 
@@ -558,6 +559,38 @@ async def ingest_vrt(
         asset_sha256 = await asyncio.to_thread(sha256_file, vrt_path)
         vrt_size = os.path.getsize(vrt_path)
 
+        # fix(#1778 codex r4): the same treatment `ingest_raster` gets, and for
+        # the same reason. Steps 10 and 11 put the VRT and its quicklooks
+        # before the terminal commit, and `written_storage_keys` is a local
+        # list: a kill between the put and that commit loses it with the
+        # process AND rolls back the dataset row whose id the keys embed, so
+        # nothing left alive could reconstruct them. Recording the intended
+        # keys on the durable job row before the first put is what makes them
+        # nameable, and both stale-job passes reap what no live row references.
+        #
+        # The id is decided here rather than by the phase-2 INSERT because the
+        # keys embed it and the job row has to be able to name them before the
+        # transaction that can roll it away opens. It is generated per task
+        # invocation, so a retry cannot reproduce one: that is this tail's
+        # attempt fence, the same one `ingest_raster` relies on, and the reason
+        # these keys need no `attempts/` segment of their own.
+        planned_dataset_id = uuid.uuid4()
+        _vrt_base_key = f"rasters/{planned_dataset_id}/{asset_sha256}"
+        await record_unpublished_storage_keys(
+            job_uuid,
+            attempt_uuid,
+            keys=[
+                f"{_vrt_base_key}/source.vrt",
+                f"{_vrt_base_key}/quicklook_256.png",
+                f"{_vrt_base_key}/quicklook_512.png",
+            ],
+            # A brand new dataset id: no row can already name one of these.
+            already_published=(),
+            attempt_scope=str(planned_dataset_id),
+            job_id=job_id,
+            task="ingest_vrt",
+        )
+
         # 8. Generate quicklooks (non-fatal)
         ql256: bytes | None = None
         ql512: bytes | None = None
@@ -606,6 +639,7 @@ async def ingest_vrt(
                     vrt_type=vrt_type,
                     resolution_strategy=resolution_strategy,
                     source_dataset_ids=ids,
+                    dataset_id=planned_dataset_id,
                 )
 
                 # 10. Store VRT and quicklooks to managed storage
@@ -614,6 +648,10 @@ async def ingest_vrt(
                 from app.platform.storage import get_storage
 
                 storage = get_storage()
+                # fix(#1778 codex r4): the same value the durable record above
+                # named, since `dataset.id` IS `planned_dataset_id`. Written as
+                # the dataset's own id rather than the local so the key still
+                # reads as a property of the row it belongs to.
                 base_key = f"rasters/{dataset.id}/{asset_sha256}"
                 vrt_key = f"{base_key}/source.vrt"
 

--- a/backend/app/processing/ingest/tasks_vrt.py
+++ b/backend/app/processing/ingest/tasks_vrt.py
@@ -576,7 +576,7 @@ async def ingest_vrt(
         # these keys need no `attempts/` segment of their own.
         planned_dataset_id = uuid.uuid4()
         _vrt_base_key = f"rasters/{planned_dataset_id}/{asset_sha256}"
-        await record_unpublished_storage_keys(
+        if not await record_unpublished_storage_keys(
             job_uuid,
             attempt_uuid,
             keys=[
@@ -589,7 +589,14 @@ async def ingest_vrt(
             attempt_scope=str(planned_dataset_id),
             job_id=job_id,
             task="ingest_vrt",
-        )
+        ):
+            # fix(#1778 audit): a confirmed fence miss. Phase 2's own
+            # attempt-fenced load below would catch this too, but stopping
+            # here is what actually keeps the recorder's contract ("do not
+            # write what nothing records") rather than depending on a second
+            # guard downstream to make it true, and it skips the quicklook
+            # generation this dead attempt no longer needs.
+            return
 
         # 8. Generate quicklooks (non-fatal)
         ql256: bytes | None = None

--- a/backend/app/processing/ingest/tasks_vrt.py
+++ b/backend/app/processing/ingest/tasks_vrt.py
@@ -4,7 +4,7 @@ Storage portability (STOR-03/04, Phase 1210):
   VRTs are stored with provider-agnostic SourceFilename nodes (logical keys +
   relativeToVRT="1"). The rewrite pass (rewrite_vrt_sources) runs AFTER metadata
   extraction and quicklook generation at each store site — the in-flight tmp .vrt
-  used by extract_raster_metadata / generate_quicklook must hold concrete,
+  used by read_vrt_metadata / render_vrt_quicklook must hold concrete,
   resolvable paths; only the stored copy is normalised to logical keys.
 
   At open-time, resolve_open_path (app.platform.storage.titiler_url) reconstructs
@@ -30,9 +30,13 @@ from app.platform.jobs.heartbeat import (
 )
 from app.core.db import tenant_task
 from app.processing.embeddings.helpers import defer_embedding
-from app.processing.raster.cog import extract_raster_metadata, sha256_file
-from app.processing.raster.quicklook import generate_quicklook
-from app.processing.raster.vrt import build_vrt, resolve_vrt_source_path
+from app.processing.raster.cog import sha256_file
+from app.processing.raster.vrt import (
+    build_vrt,
+    read_vrt_metadata,
+    render_vrt_quicklook,
+    resolve_vrt_source_path,
+)
 from app.processing.raster.vrt_rewrite import rewrite_vrt_sources
 from app.platform.storage import get_storage
 
@@ -242,6 +246,7 @@ async def create_vrt_dataset(
     record_status: str = "published",
     snapshot_at: datetime | None = None,
     built_from: dict | None = None,
+    dataset_id: uuid.UUID | None = None,
 ) -> tuple:
     """Create Record + Dataset + RasterAsset records for a VRT dataset.
 
@@ -250,6 +255,10 @@ async def create_vrt_dataset(
     - source_format=None (avoids chk_datasets_source_format constraint)
     - Sets vrt_type and resolution_strategy on RasterAsset
     - Inserts vrt_source_links rows with position ordering
+
+    fix(#1778): ``dataset_id`` has the same job it has on
+    ``create_raster_dataset``: let the manifest-VRT tail name its object keys
+    on the durable job row before this transaction opens.
 
     Returns (record, dataset, raster_asset).
     """
@@ -292,6 +301,7 @@ async def create_vrt_dataset(
 
     table_name = f"vrt_{record.id.hex[:16]}"
     dataset = Dataset(
+        **({"id": dataset_id} if dataset_id is not None else {}),
         record_id=record.id,
         table_name=table_name,
         source_format=None,  # VRT datasets have no source_format (avoids chk constraint)
@@ -506,7 +516,7 @@ async def ingest_vrt(
         )
 
         # 6. Extract metadata from assembled VRT
-        meta = await asyncio.to_thread(extract_raster_metadata, vrt_path)
+        meta = await asyncio.to_thread(read_vrt_metadata, vrt_path)
         if not meta.get("crs_wkt"):
             raise ValueError("Assembled VRT has no coordinate reference system.")
 
@@ -518,8 +528,8 @@ async def ingest_vrt(
         ql256: bytes | None = None
         ql512: bytes | None = None
         try:
-            ql256 = await asyncio.to_thread(generate_quicklook, vrt_path, 256)
-            ql512 = await asyncio.to_thread(generate_quicklook, vrt_path, 512)
+            ql256 = await asyncio.to_thread(render_vrt_quicklook, vrt_path, 256)
+            ql512 = await asyncio.to_thread(render_vrt_quicklook, vrt_path, 512)
         except Exception:  # broad: quicklook generation is non-fatal; rasterio rendering can fail for any reason
             logger_vrt.warning(
                 "Quicklook generation failed for VRT %s", job_id, exc_info=True
@@ -610,16 +620,19 @@ async def ingest_vrt(
                     ql512_key, tenant_id=current_tenant_var.get()
                 )
 
+                # fix(#1778): registered before the put, per
+                # archive_lossy_original's rule. A cancelled put can have
+                # completed, and CancelledError skips every statement below it.
+                written_storage_keys.append(_storage_vrt_key)
                 with open(vrt_path, "rb") as fobj:
                     await storage.put(_storage_vrt_key, fobj)
-                written_storage_keys.append(_storage_vrt_key)
 
                 if ql256 is not None:
-                    await storage.put(_storage_ql256_key, io.BytesIO(ql256))
                     written_storage_keys.append(_storage_ql256_key)
+                    await storage.put(_storage_ql256_key, io.BytesIO(ql256))
                 if ql512 is not None:
-                    await storage.put(_storage_ql512_key, io.BytesIO(ql512))
                     written_storage_keys.append(_storage_ql512_key)
+                    await storage.put(_storage_ql512_key, io.BytesIO(ql512))
 
                 # 11. Update asset URIs and create distribution.
                 # asset_uri stays as the logical (un-prefixed) key — the tenant
@@ -1031,7 +1044,7 @@ async def regenerate_vrt(
         )
 
         # 6 & 7. Extract metadata (also serves as post-validation)
-        meta = await asyncio.to_thread(extract_raster_metadata, vrt_path)
+        meta = await asyncio.to_thread(read_vrt_metadata, vrt_path)
         if not meta.get("crs_wkt"):
             raise ValueError("Regenerated VRT has no coordinate reference system.")
 
@@ -1043,8 +1056,8 @@ async def regenerate_vrt(
         ql256: bytes | None = None
         ql512: bytes | None = None
         try:
-            ql256 = await asyncio.to_thread(generate_quicklook, vrt_path, 256)
-            ql512 = await asyncio.to_thread(generate_quicklook, vrt_path, 512)
+            ql256 = await asyncio.to_thread(render_vrt_quicklook, vrt_path, 256)
+            ql512 = await asyncio.to_thread(render_vrt_quicklook, vrt_path, 512)
         except Exception:  # broad: quicklook generation is non-fatal; rasterio rendering can fail for any reason
             logger_regen.warning(
                 "Quicklook regeneration failed for VRT %s",
@@ -1099,16 +1112,19 @@ async def regenerate_vrt(
             next_ql512_uri, tenant_id=_ctv.get()
         )
 
+        # fix(#1778): registered before the put, per archive_lossy_original's
+        # rule. A cancelled put can have completed, and CancelledError skips
+        # every statement below it.
+        written_storage_keys.append(next_vrt_physical_key)
         with open(vrt_path, "rb") as fobj:
             await storage.put(next_vrt_physical_key, fobj)
-        written_storage_keys.append(next_vrt_physical_key)
 
         if ql256 is not None:
-            await storage.put(next_ql256_physical_key, io.BytesIO(ql256))
             written_storage_keys.append(next_ql256_physical_key)
+            await storage.put(next_ql256_physical_key, io.BytesIO(ql256))
         if ql512 is not None:
-            await storage.put(next_ql512_physical_key, io.BytesIO(ql512))
             written_storage_keys.append(next_ql512_physical_key)
+            await storage.put(next_ql512_physical_key, io.BytesIO(ql512))
 
         prior_storage_keys = _prior_generation_storage_keys_to_reap(
             vrt_key=vrt_storage_key,

--- a/backend/app/processing/ingest/tasks_vrt.py
+++ b/backend/app/processing/ingest/tasks_vrt.py
@@ -612,12 +612,23 @@ async def ingest_vrt(
         # ----------------------------------------------------------------- #
         # Phase 2 (short-lived session): create DB records, store assets,
         # commit job.
+        #
+        # fix(#1778 audit r11): status == "running" joins the attempt fence.
+        # A stale sweep can fail this job on heartbeat timeout WITHOUT a
+        # retry ever rotating the attempt token, so an (id, attempt)-only
+        # match still passed for a worker that was merely paused, not dead --
+        # and this phase puts the VRT and its quicklooks to storage, which no
+        # rollback can undo. This does not use `_job_phase_session` (the
+        # shared helper other tails go through) because it never adopted the
+        # helper in the first place; the fence has to match by hand here for
+        # the same reason.
         # ----------------------------------------------------------------- #
         async with async_session() as session:
             result = await session.execute(
                 select(IngestJob).where(
                     IngestJob.id == job_uuid,
                     IngestJob.attempt_id == attempt_uuid,
+                    IngestJob.status == "running",
                 )
             )
             job = result.scalar_one_or_none()
@@ -1217,12 +1228,26 @@ async def regenerate_vrt(
         # ----------------------------------------------------------------- #
         # Phase 2 (short-lived session): update RasterAsset metadata, mark
         # job complete, update dataset footprint.
+        #
+        # fix(#1778 audit r11): status == "running" joins the attempt fence.
+        # The `current_generation_id` check below already refuses a NEWER
+        # generation's publish from overwriting this one, but says nothing
+        # about a job the stale sweep already failed without any newer
+        # generation existing yet -- `vrt_asset.current_generation_id` lives
+        # on a different row than `ingest_jobs.status` and the sweep never
+        # touches it. Without this, a worker only paused, not dead, could
+        # still complete the job and switch the live pointer onto this
+        # generation's objects after the sweep declared it dead. The objects
+        # written above are unaffected either way: they are reaped by the
+        # separate stale-generation mechanism (`sweep_stale_vrt_assets`) on
+        # their own timeout, independent of this fence.
         # ----------------------------------------------------------------- #
         async with async_session() as session:
             result = await session.execute(
                 select(IngestJob).where(
                     IngestJob.id == job_uuid,
                     IngestJob.attempt_id == attempt_uuid,
+                    IngestJob.status == "running",
                 )
             )
             job = result.scalar_one_or_none()

--- a/backend/app/processing/ingest/tasks_vrt.py
+++ b/backend/app/processing/ingest/tasks_vrt.py
@@ -622,14 +622,24 @@ async def ingest_vrt(
         # shared helper other tails go through) because it never adopted the
         # helper in the first place; the fence has to match by hand here for
         # the same reason.
+        #
+        # fix(#1778 audit r12): `.with_for_update(key_share=True)` closes the
+        # window a plain status check leaves open -- a SELECT is not a lock,
+        # so the sweep could still fail this row between this read and the
+        # puts below completing (see the sibling fix in `_job_phase_session`'s
+        # docstring for the full shape). The lock is held for as long as this
+        # session stays open, which is through the puts and up to the commit
+        # below.
         # ----------------------------------------------------------------- #
         async with async_session() as session:
             result = await session.execute(
-                select(IngestJob).where(
+                select(IngestJob)
+                .where(
                     IngestJob.id == job_uuid,
                     IngestJob.attempt_id == attempt_uuid,
                     IngestJob.status == "running",
                 )
+                .with_for_update(key_share=True)
             )
             job = result.scalar_one_or_none()
             if job is None:
@@ -1241,6 +1251,24 @@ async def regenerate_vrt(
         # written above are unaffected either way: they are reaped by the
         # separate stale-generation mechanism (`sweep_stale_vrt_assets`) on
         # their own timeout, independent of this fence.
+        #
+        # fix(#1778 audit r12): deliberately NOT locked here, unlike the
+        # sibling phase-2 sites. This job row is loaded BEFORE the RasterAsset
+        # row a few lines down, and `cancel_job` (jobs/router.py) takes those
+        # two locks in the opposite order for a vrt_regenerate job (asset
+        # first, job second) specifically to avoid an AB-BA deadlock between
+        # itself and this worker -- see that function's own comment on why
+        # asset-first is the worker's invariant. Locking the job row here
+        # would put it back in job-then-asset order and reopen exactly that
+        # cycle. The residual TOCTOU this leaves is narrow and already
+        # bounded: the objects above are written either way and reaped by
+        # `sweep_stale_vrt_assets` on their own timeout regardless of this
+        # fence, and `current_generation_id` still refuses a stale publish
+        # once a newer generation exists. What a sweep-inserted status flip
+        # in this exact window could still do is let a paused-not-dead worker
+        # complete over a row the sweep just failed, the same class round 11
+        # already narrowed considerably; closing it completely here is not
+        # worth reordering these two locks.
         # ----------------------------------------------------------------- #
         async with async_session() as session:
             result = await session.execute(

--- a/backend/app/processing/raster/models.py
+++ b/backend/app/processing/raster/models.py
@@ -20,6 +20,11 @@ from sqlalchemy.orm import Mapped, mapped_column
 from app.core.db import Base
 from app.core.geo import wkt_metres_per_unit
 
+# fix(#1778): shared with the OGC Records serializer, which cannot import from
+# `app.processing` (CATPORT-02/04). See the module docstring for the two
+# producer shapes these two functions reconcile.
+from app.core.raster_bands import band_display_name, stac_band_nodata
+
 
 class RasterAsset(Base):
     __tablename__ = "raster_assets"
@@ -141,14 +146,24 @@ class RasterAsset(Base):
         if self.band_info:
             bands = []
             for b in self.band_info:
+                if not isinstance(b, dict):
+                    continue
                 band: dict = {}
                 if b.get("dtype"):
                     band["data_type"] = b["dtype"]
-                if b.get("nodata") is not None:
-                    band["nodata"] = b["nodata"]
-                if b.get("color_interp"):
-                    band["name"] = b["color_interp"]
-                bands.append(band)
+                nodata = stac_band_nodata(b.get("nodata"))
+                if nodata is not None:
+                    band["nodata"] = nodata
+                name = band_display_name(b)
+                if name:
+                    band["name"] = name
+                # fix(#1778): an empty entry is dropped rather than appended.
+                # A Producer-B row carries none of the three keys above, so
+                # this list used to come out as `[{}, {}, {}]` and `if bands:`
+                # published it: structurally invalid, and worse than omitting
+                # the field.
+                if band:
+                    bands.append(band)
             if bands:
                 props["raster:bands"] = bands
 

--- a/backend/app/processing/raster/quicklook.py
+++ b/backend/app/processing/raster/quicklook.py
@@ -59,6 +59,30 @@ def generate_quicklook(cog_path: str, size: int) -> bytes:
                     out_w, out_h = cand_w, cand_h
                     break
 
+        # fix(#1778): the selection above bounds nothing by itself. It takes the
+        # SMALLEST level whose long edge still reaches `size`, so when the
+        # ladder bottoms out above that (`gdaladdo` builds five levels, and
+        # `prepare_with_overviews` skips it entirely for a source that already
+        # carries its own) the smallest available level is the one read, at
+        # whatever size it happens to be. `out_shape` then drives the
+        # allocation, so a 200k x 200k source shipped with a single 2x internal
+        # overview asked for ~30 GB and took the worker with it, from a file
+        # inside the 500 MB upload cap.
+        #
+        # 2x is the bound a COMPLETE ladder already gives for free: when the
+        # levels reach below `size`, the chosen one is under twice it by
+        # construction, since the next smaller level would be half of it. So
+        # this changes nothing for a well-formed COG and only bites where the
+        # ladder stops short. The headroom is worth keeping rather than reading
+        # at `size` outright, because `_crop_to_valid` crops this array before
+        # it is resized, and cropping a quarter of a nodata-heavy raster at the
+        # target size upscales the result.
+        max_edge = size * 2
+        if max(out_w, out_h) > max_edge:
+            scale = max_edge / max(out_w, out_h)
+            out_w = max(1, round(out_w * scale))
+            out_h = max(1, round(out_h * scale))
+
         nodata = src.nodata
 
         if src.count >= 3:

--- a/backend/app/processing/raster/vrt.py
+++ b/backend/app/processing/raster/vrt.py
@@ -118,34 +118,6 @@ def gdal_safe_open_env():
     return rasterio.Env(**_VRT_SAFE_ENV)
 
 
-def read_vrt_metadata(vrt_path: str) -> dict:
-    """``extract_raster_metadata`` on a built VRT, under the safe open env.
-
-    fix(#1778). The VRT names remote sources, so this read is the one place a
-    raster task touches object storage in-process rather than through a
-    subprocess. Rasterio's ``Env`` sets thread-local GDAL config, so entering it
-    has to happen inside the ``asyncio.to_thread`` call and not around it --
-    which is the whole reason this wrapper exists rather than a ``with`` block
-    at the call site.
-    """
-    from app.processing.raster.cog import extract_raster_metadata
-
-    with gdal_safe_open_env():
-        return extract_raster_metadata(vrt_path)
-
-
-def render_vrt_quicklook(vrt_path: str, size: int) -> bytes:
-    """``generate_quicklook`` on a built VRT, under the safe open env.
-
-    fix(#1778): the peer of :func:`read_vrt_metadata`, and the heavier of the
-    two -- it reads pixels from every source rather than headers.
-    """
-    from app.processing.raster.quicklook import generate_quicklook
-
-    with gdal_safe_open_env():
-        return generate_quicklook(vrt_path, size)
-
-
 # fix(#430 BA-29): raster GDAL CLIs run synchronously inside asyncio.to_thread, and
 # Python threads aren't killable — a hung child (malformed TIFF, stalled /vsi
 # read) would pin a ThreadPoolExecutor thread forever and eventually starve every
@@ -630,9 +602,9 @@ def shift_vrt_longitude_frame(vrt_path: str) -> None:
     task open every ``/vsis3`` source in-thread, at a larger scale than the
     probe did (metadata extraction, then two quicklook renders). What bounds
     those is the ``GDAL_HTTP_*`` clamps in ``_VRT_SAFE_ENV``, applied through
-    ``read_vrt_metadata`` and ``render_vrt_quicklook`` below, which enter
-    ``gdal_safe_open_env`` INSIDE the worker thread because a rasterio ``Env``
-    is thread-local.
+    ``tasks_vrt.read_vrt_metadata`` and ``tasks_vrt.render_vrt_quicklook``,
+    which enter :func:`gdal_safe_open_env` INSIDE the worker thread because a
+    rasterio ``Env`` is thread-local.
 
     ``gdalbuildvrt`` has already opened every source, under that timeout, and
     written what this needs: per-source ``DstRect`` geometry, the hull

--- a/backend/app/processing/raster/vrt.py
+++ b/backend/app/processing/raster/vrt.py
@@ -28,9 +28,22 @@ from app.core.geo import (
 # means user-uploaded VRTs reject URL and /vsi sources outright
 # (ingest/validation.py) and the raster pipeline only opens managed-storage
 # paths (bucket from settings, key validated by resolve_storage_key).
+#
+# fix(#1778): the three GDAL_HTTP_* clamps bound how long a single VSI read may
+# stall. `GDAL_SUBPROCESS_TIMEOUT_SECONDS` below bounds only the subprocesses;
+# an in-process read (`extract_raster_metadata` and `generate_quicklook` on a
+# built VRT, both run under `asyncio.to_thread`) had no bound at all, and a
+# Python thread is not killable, so one stalled object-storage source pinned a
+# pool thread for good. Enough of them starve every other `to_thread` in the
+# worker, which is the failure `build_vrt`'s docstring says it removed by
+# dropping its pre-build source probe. These are seconds; the retry count is
+# what turns a flaky read into a failure rather than a hang.
 _VRT_SAFE_ENV: dict[str, str] = {
     "CPL_VSIL_CURL_ALLOWED_EXTENSIONS": "tif,tiff,vrt",
     "VRT_VIRTUAL_OVERVIEWS": "NO",
+    "GDAL_HTTP_CONNECTTIMEOUT": "30",
+    "GDAL_HTTP_TIMEOUT": "300",
+    "GDAL_HTTP_MAX_RETRY": "3",
 }
 
 
@@ -103,6 +116,34 @@ def gdal_safe_open_env():
     import rasterio
 
     return rasterio.Env(**_VRT_SAFE_ENV)
+
+
+def read_vrt_metadata(vrt_path: str) -> dict:
+    """``extract_raster_metadata`` on a built VRT, under the safe open env.
+
+    fix(#1778). The VRT names remote sources, so this read is the one place a
+    raster task touches object storage in-process rather than through a
+    subprocess. Rasterio's ``Env`` sets thread-local GDAL config, so entering it
+    has to happen inside the ``asyncio.to_thread`` call and not around it --
+    which is the whole reason this wrapper exists rather than a ``with`` block
+    at the call site.
+    """
+    from app.processing.raster.cog import extract_raster_metadata
+
+    with gdal_safe_open_env():
+        return extract_raster_metadata(vrt_path)
+
+
+def render_vrt_quicklook(vrt_path: str, size: int) -> bytes:
+    """``generate_quicklook`` on a built VRT, under the safe open env.
+
+    fix(#1778): the peer of :func:`read_vrt_metadata`, and the heavier of the
+    two -- it reads pixels from every source rather than headers.
+    """
+    from app.processing.raster.quicklook import generate_quicklook
+
+    with gdal_safe_open_env():
+        return generate_quicklook(vrt_path, size)
 
 
 # fix(#430 BA-29): raster GDAL CLIs run synchronously inside asyncio.to_thread, and
@@ -583,6 +624,15 @@ def shift_vrt_longitude_frame(vrt_path: str) -> None:
     stalled VRT jobs would starve every other ``to_thread`` in the worker. The
     module comment on ``GDAL_SUBPROCESS_TIMEOUT_SECONDS`` names that hazard
     already; the probe reintroduced it.
+
+    fix(#1778): removing the probe did NOT remove the hazard from the pipeline,
+    and this docstring used to read as though it had. Steps 6 and 8 of the same
+    task open every ``/vsis3`` source in-thread, at a larger scale than the
+    probe did (metadata extraction, then two quicklook renders). What bounds
+    those is the ``GDAL_HTTP_*`` clamps in ``_VRT_SAFE_ENV``, applied through
+    ``read_vrt_metadata`` and ``render_vrt_quicklook`` below, which enter
+    ``gdal_safe_open_env`` INSIDE the worker thread because a rasterio ``Env``
+    is thread-local.
 
     ``gdalbuildvrt`` has already opened every source, under that timeout, and
     written what this needs: per-source ``DstRect`` geometry, the hull

--- a/backend/tests/test_analysis_materialize.py
+++ b/backend/tests/test_analysis_materialize.py
@@ -1969,12 +1969,19 @@ class TestMaterializeWorker:
         fix(#692): generate_table_name now sidesteps live relations, so the
         lost race is simulated by pinning the generated name to the occupied
         one — exactly what happens when two jobs draw the same name in the
-        window between generation and CREATE."""
+        window between generation and CREATE.
+
+        fix(#1778 codex r7): the occupied table is created at the name this
+        JOB will derive, because the output name is scoped by the job now. The
+        race is the same one; only where the name comes from has changed."""
+        from app.processing.analysis.tasks import analysis_output_table_name
+
         admin_id = await get_user_id(test_db_session, "admin")
         ds = await _create_polygon_dataset(test_db_session, created_by=admin_id)
         job = await _create_job(test_db_session, admin_id)
         title = f"Collide {uuid.uuid4().hex[:6]}"
-        expected = f"collide_{uuid.uuid4().hex[:6]}"
+        base = f"collide_{uuid.uuid4().hex[:6]}"
+        expected = analysis_output_table_name(base, job.id)
         await test_db_session.execute(
             text(f'CREATE TABLE data."{expected}" (marker integer)')
         )
@@ -1982,7 +1989,7 @@ class TestMaterializeWorker:
 
         with patch(
             "app.processing.ingest.service.generate_table_name",
-            AsyncMock(return_value=(expected, None)),
+            AsyncMock(return_value=(base, None)),
         ):
             await _materialize(
                 job_id=str(job.id),
@@ -2023,7 +2030,14 @@ class TestMaterializeWorker:
         during registration) used to poison its title forever — the name
         generator collided only against the catalog, so every retry died on
         CREATE TABLE. It now probes information_schema too: the retry lands
-        on a _2 suffix and the orphan is left untouched for an operator."""
+        on a _2 suffix and the orphan is left untouched for an operator.
+
+        fix(#1778 codex r7): the output name carries a job scope now, so the
+        suffix walk is no longer what keeps the retry off the orphan. The walk
+        still runs and still lands on _2, and this keeps asserting it, but the
+        guarantee underneath is stronger: a name embedding a job id could not
+        have collided with the orphan even without it."""
+        from app.processing.analysis.tasks import analysis_output_table_name
         from app.processing.ingest.service import generate_table_name
 
         admin_id = await get_user_id(test_db_session, "admin")
@@ -2050,7 +2064,7 @@ class TestMaterializeWorker:
         from app.modules.catalog.datasets.domain.models import Dataset
 
         new_ds = await test_db_session.get(Dataset, job.dataset_id)
-        assert new_ds.table_name == f"{orphan}_2"
+        assert new_ds.table_name == analysis_output_table_name(f"{orphan}_2", job.id)
         cols = (
             (
                 await test_db_session.execute(

--- a/backend/tests/test_analysis_materialize.py
+++ b/backend/tests/test_analysis_materialize.py
@@ -1434,18 +1434,27 @@ class TestMaterializeWorker:
         skip cleanup entirely — a sweep that failed the row before the
         cancel bookkeeping ran left the committed output table leaking
         forever. It now runs the same adoption probe as _mark_job_failed and
-        drops the table when no dataset row adopted it."""
+        drops the table when no dataset row adopted it.
+
+        fix(#1778 codex r10): the table has to carry THIS job and attempt's
+        scope, or `drop_unadopted_analysis_output`'s ownership check refuses
+        it on purpose — a name that is not this job's can never become this
+        job's. An unscoped name tested a case production code never produces;
+        the realistic one is a cancelled attempt's own committed table."""
+        from app.processing.analysis.tasks import analysis_output_table_name
+
         admin_id = await get_user_id(test_db_session, "admin")
-        table_name = f"orphan_{uuid.uuid4().hex[:12]}"
+        job = await _create_job(test_db_session, admin_id)
+        assert job.attempt_id is not None
+        base = f"orphan_{uuid.uuid4().hex[:6]}"
+        table_name = analysis_output_table_name(base, job.id, job.attempt_id)
         await test_db_session.execute(
             text(f"CREATE TABLE data.{table_name} (gid SERIAL PRIMARY KEY)")
         )
         await test_db_session.commit()
-        job = await _create_job(test_db_session, admin_id)
         job.status = "failed"
         job.error_message = "Stale: heartbeat lease expired"
         await test_db_session.commit()
-        assert job.attempt_id is not None
 
         async with core_db.async_session() as working_session:
             await _fail_cancelled_job(
@@ -1973,7 +1982,18 @@ class TestMaterializeWorker:
 
         fix(#1778 codex r7): the occupied table is created at the name this
         JOB will derive, because the output name is scoped by the job now. The
-        race is the same one; only where the name comes from has changed."""
+        race is the same one; only where the name comes from has changed.
+
+        fix(#1778 codex r10): the collision-check now runs against the SCOPED
+        candidate (`resolve_analysis_output_table`), which reads pg_class
+        before CREATE and would self-heal to a `_2` suffix if it saw the
+        occupied name sitting there when it probed. So pinning only
+        `generate_table_name` is no longer enough to reproduce a lost race --
+        the probe would just avoid the collision this test means to force.
+        `resolve_analysis_output_table` is pinned too, to the occupied name,
+        which is what a probe that ran a moment before the other job's CREATE
+        would have returned: "free", followed immediately by a CREATE that
+        loses."""
         from app.processing.analysis.tasks import analysis_output_table_name
 
         admin_id = await get_user_id(test_db_session, "admin")
@@ -1981,15 +2001,21 @@ class TestMaterializeWorker:
         job = await _create_job(test_db_session, admin_id)
         title = f"Collide {uuid.uuid4().hex[:6]}"
         base = f"collide_{uuid.uuid4().hex[:6]}"
-        expected = analysis_output_table_name(base, job.id)
+        expected = analysis_output_table_name(base, job.id, job.attempt_id)
         await test_db_session.execute(
             text(f'CREATE TABLE data."{expected}" (marker integer)')
         )
         await test_db_session.commit()
 
-        with patch(
-            "app.processing.ingest.service.generate_table_name",
-            AsyncMock(return_value=(base, None)),
+        with (
+            patch(
+                "app.processing.ingest.service.generate_table_name",
+                AsyncMock(return_value=(base, None)),
+            ),
+            patch(
+                "app.processing.analysis.tasks.resolve_analysis_output_table",
+                AsyncMock(return_value=expected),
+            ),
         ):
             await _materialize(
                 job_id=str(job.id),
@@ -2064,7 +2090,9 @@ class TestMaterializeWorker:
         from app.modules.catalog.datasets.domain.models import Dataset
 
         new_ds = await test_db_session.get(Dataset, job.dataset_id)
-        assert new_ds.table_name == analysis_output_table_name(f"{orphan}_2", job.id)
+        assert new_ds.table_name == analysis_output_table_name(
+            f"{orphan}_2", job.id, job.attempt_id
+        )
         cols = (
             (
                 await test_db_session.execute(

--- a/backend/tests/test_analysis_output_reap_1778.py
+++ b/backend/tests/test_analysis_output_reap_1778.py
@@ -837,6 +837,76 @@ class TestAttemptScopingPins:
             )
             await test_db_session.commit()
 
+    def test_a_long_base_still_yields_distinct_collision_suffixes(self) -> None:
+        """fix(#1778 audit r11): the identifier-length bug, at the unit
+        level. Before this fix, `analysis_output_table_name` reserved room
+        for the scope but not for a collision tag applied afterward, so the
+        walk's `f"{base}_{suffix}"` pre-pend got trimmed away entirely once
+        `base` was at or past the 46-char reservation point -- every suffix
+        in the walk produced the SAME candidate."""
+        from app.processing.analysis.tasks import analysis_output_table_name
+
+        job_id = uuid.uuid4()
+        attempt_id = uuid.uuid4()
+        base = "a" * 60
+
+        first = analysis_output_table_name(base, job_id, attempt_id)
+        second = analysis_output_table_name(
+            base, job_id, attempt_id, collision_suffix=2
+        )
+
+        assert len(first) <= 63
+        assert len(second) <= 63
+        assert first != second, "a long base must still yield distinct suffixes"
+
+    @pytest.mark.anyio
+    async def test_a_long_base_with_an_existing_table_self_heals_to_a_suffix(
+        self, test_db_session
+    ) -> None:
+        """fix(#1778 audit r11): the same bug, end to end against real
+        Postgres. Before this fix, the walk inside
+        `resolve_analysis_output_table` re-trimmed an already-trimmed
+        candidate on every iteration, so a 60-char base with its scoped
+        table already occupied exhausted every `_N` suffix and raised
+        instead of landing on `_2`."""
+        from sqlalchemy import text
+
+        from app.processing.analysis.tasks import (
+            analysis_output_table_name,
+            resolve_analysis_output_table,
+        )
+
+        job_id = uuid.uuid4()
+        attempt_id = uuid.uuid4()
+        base = "a" * 60
+
+        occupied = analysis_output_table_name(base, job_id, attempt_id)
+        assert len(occupied) <= 63
+        await test_db_session.execute(
+            text(f'CREATE TABLE data."{occupied}" (marker integer)')
+        )
+        await test_db_session.commit()
+
+        try:
+            resolved = await resolve_analysis_output_table(
+                test_db_session,
+                base=base,
+                job_uuid=job_id,
+                attempt_uuid=attempt_id,
+                schema="data",
+            )
+
+            assert resolved != occupied
+            assert len(resolved) <= 63
+            assert resolved == analysis_output_table_name(
+                base, job_id, attempt_id, collision_suffix=2
+            )
+        finally:
+            await test_db_session.execute(
+                text(f'DROP TABLE IF EXISTS data."{occupied}"')
+            )
+            await test_db_session.commit()
+
 
 def _mock_db_for_fail_stale(
     *, running_rows: list, artifact_rows: list | None = None

--- a/backend/tests/test_analysis_output_reap_1778.py
+++ b/backend/tests/test_analysis_output_reap_1778.py
@@ -30,20 +30,21 @@ class TestUnadoptedAnalysisOutput:
         is exactly a job row whose table exists.
         """
         source = _source("processing/analysis/tasks.py")
-        assert "ANALYSIS_OUTPUT_TABLE_FIELD: out_table," in source
+        assert "job.user_metadata = append_analysis_output_record(" in source
         lines = source.splitlines()
-        # fix(#1778 codex r7): the name is scoped by the job after
-        # `generate_table_name` chooses its readable half, so the assignment
-        # this ordering hangs off is the scoping call.
+        # fix(#1778 codex r7/r10): the name is resolved (scoped by job AND
+        # attempt, collision-checked as scoped) after `generate_table_name`
+        # chooses its readable half, so the assignment this ordering hangs
+        # off is the resolving call.
         generated = next(
             i
             for i, line in enumerate(lines)
-            if "out_table = analysis_output_table_name(" in line
+            if "out_table = await resolve_analysis_output_table(" in line
         )
         persisted = next(
             i
             for i, line in enumerate(lines)
-            if "ANALYSIS_OUTPUT_TABLE_FIELD: out_table," in line
+            if "job.user_metadata = append_analysis_output_record(" in line
         )
         commit = next(
             i
@@ -55,17 +56,27 @@ class TestUnadoptedAnalysisOutput:
     @pytest.mark.parametrize(
         "metadata,expected",
         [
-            (None, None),
-            ({}, None),
-            ({"analysis_out_table": ""}, None),
-            ({"analysis_out_table": 7}, None),
-            ({"analysis_out_table": "parcels_buffered"}, "parcels_buffered"),
+            (None, ()),
+            ({}, ()),
+            ({"analysis_out_table": ""}, ()),
+            ({"analysis_out_table": 7}, ()),
+            # fix(#1778 codex r10): a plain string is what a row written
+            # before this commit still holds, and is read as a one-element
+            # list so its pointer survives.
+            ({"analysis_out_table": "parcels_buffered"}, ("parcels_buffered",)),
+            (
+                {"analysis_out_table": ["parcels_buffered", "parcels_buffered_2"]},
+                ("parcels_buffered", "parcels_buffered_2"),
+            ),
+            # A non-string entry in the list is dropped, not raised on --
+            # this reads a schemaless JSONB blob.
+            ({"analysis_out_table": ["a", 7, "", "b"]}, ("a", "b")),
         ],
     )
-    def test_the_name_is_read_back_off_the_job_row(self, metadata, expected) -> None:
-        from app.platform.jobs.sweep import unadopted_analysis_table_from_metadata
+    def test_the_names_are_read_back_off_the_job_row(self, metadata, expected) -> None:
+        from app.platform.jobs.sweep import unadopted_analysis_tables_from_metadata
 
-        assert unadopted_analysis_table_from_metadata(metadata) == expected
+        assert unadopted_analysis_tables_from_metadata(metadata) == expected
 
     @pytest.mark.asyncio
     async def test_an_unadopted_table_is_dropped(self) -> None:
@@ -132,13 +143,23 @@ class TestUnadoptedAnalysisOutput:
 
     @pytest.mark.asyncio
     async def test_fail_stale_jobs_carries_the_table_out_of_a_running_row(self) -> None:
+        """fix(#1778 codex r10): the running-row transition no longer collects
+        the name directly -- that moved into the unconditional
+        artifact-carrying SELECT that runs after the retention block (see
+        that query's own docstring in sweep.py). Against real Postgres it
+        runs inside the same uncommitted transaction as the UPDATE above it
+        and sees the row's new status, so the split changes nothing about
+        same-pass reaping; the double routes the fixture through the query
+        that answers it now.
+        """
         from app.platform.jobs.sweep import fail_stale_jobs
 
         job_uuid = uuid.uuid4()
         mock_db = _mock_db_for_fail_stale(
-            running_rows=[
-                (job_uuid, {"analysis_out_table": "parcels_buffered"}, None),
-            ]
+            running_rows=[(job_uuid, None, None)],
+            artifact_rows=[
+                (job_uuid, {"analysis_out_table": "parcels_buffered"}),
+            ],
         )
         reap = AsyncMock()
         with patch("app.platform.jobs.sweep._reap_unadopted_analysis_outputs", reap):
@@ -262,8 +283,11 @@ class TestOnlyASettledArtifactLosesItsRecord:
         ):
             await _reap_unadopted_analysis_outputs(((job_uuid, self.TABLE),))
 
+        # fix(#1778 codex r10): settled by VALUE, not by owning job id -- the
+        # record accumulates across attempts now, so clearing "the field for
+        # this job" would forget a name this pass never answered for.
         clear.assert_awaited_once_with(
-            analysis_job_ids={job_uuid} if settles else set()
+            analysis_tables={self.TABLE} if settles else set()
         )
 
     @pytest.mark.asyncio
@@ -281,7 +305,7 @@ class TestOnlyASettledArtifactLosesItsRecord:
         ):
             await _reap_unadopted_analysis_outputs(((uuid.uuid4(), self.TABLE),))
 
-        clear.assert_awaited_once_with(analysis_job_ids=set())
+        clear.assert_awaited_once_with(analysis_tables=set())
 
     @pytest.mark.anyio
     async def test_a_failed_drop_leaves_the_job_row_naming_the_table(
@@ -322,6 +346,49 @@ class TestOnlyASettledArtifactLosesItsRecord:
         ).scalar_one()
         assert row.user_metadata.get("analysis_out_table") == self.TABLE, (
             "a failed drop must leave the table's last durable name on the row"
+        )
+
+    @pytest.mark.anyio
+    async def test_a_legacy_string_shaped_record_clears_on_settle(
+        self, test_db_session
+    ) -> None:
+        """fix(#1778 codex r10): a pre-PR row still holds a plain JSONB
+        string, not a list. `unadopted_analysis_tables_from_metadata` already
+        reads it as a one-element list, so the table gets dropped either way
+        -- but the clearing SQL originally kept its `jsonb_typeof(...) =
+        'array'` guard, which never matched a string, so a legacy row's
+        pointer survived a successful reap forever and the retention purge
+        could never take the row. The clearing SQL now has a matching arm for
+        the string shape."""
+        from sqlalchemy import select
+
+        from app.platform.jobs.models import IngestJob
+        from app.platform.jobs.sweep import _reap_unadopted_analysis_outputs
+
+        job = IngestJob(
+            status="failed",
+            file_path="",
+            user_metadata={"analysis_out_table": self.TABLE},
+        )
+        test_db_session.add(job)
+        await test_db_session.flush()
+        job_id = job.id
+        await test_db_session.commit()
+
+        with patch(
+            "app.processing.analysis.tasks.drop_unadopted_analysis_output",
+            AsyncMock(return_value="dropped"),
+        ):
+            await _reap_unadopted_analysis_outputs(((job_id, self.TABLE),))
+
+        test_db_session.expire_all()
+        row = (
+            await test_db_session.execute(
+                select(IngestJob).where(IngestJob.id == job_id)
+            )
+        ).scalar_one()
+        assert "analysis_out_table" not in (row.user_metadata or {}), (
+            "a settled legacy string-shaped record must clear so the row can be purged"
         )
 
     @pytest.mark.asyncio
@@ -396,16 +463,18 @@ class TestOnlyASettledArtifactLosesItsRecord:
             )
 
 
-def analysis_output_table_name_for_test(base: str, job_uuid) -> str:
+def analysis_output_table_name_for_test(base: str, job_uuid, attempt_uuid=None) -> str:
     from app.processing.analysis.tasks import analysis_output_table_name
 
-    return analysis_output_table_name(base, job_uuid)
+    return analysis_output_table_name(base, job_uuid, attempt_uuid or uuid.uuid4())
 
 
-def _output_name_for(job_uuid) -> str:
+def _output_name_for(job_uuid, attempt_uuid=None) -> str:
     from app.processing.analysis.tasks import analysis_output_table_name
 
-    return analysis_output_table_name("parcels_buffered", job_uuid)
+    return analysis_output_table_name(
+        "parcels_buffered", job_uuid, attempt_uuid or uuid.uuid4()
+    )
 
 
 class TestAnalysisOutputNamesAreJobScoped:
@@ -418,25 +487,47 @@ class TestAnalysisOutputNamesAreJobScoped:
     commit its CTAS between the sweep's adoption probe and its DROP and the
     sweep destroyed the NEW job's table, and the name-keyed record clearing
     then erased the new job's recovery pointer along with the old one's.
+
+    fix(#1778 codex r10): job scoping alone left one gap open -- `/jobs/{id}/
+    retry` keeps `IngestJob.id` and mints a new attempt token, so every retry
+    of one job derived the SAME name. A stale sweep could capture attempt 1's
+    name, settle the job `failed`, and then probe and drop while attempt 2
+    was creating that same name, and the ownership check passed because the
+    name really was this job's. The scope now carries the attempt too.
     """
 
     def test_two_jobs_never_derive_the_same_name(self) -> None:
         from app.processing.analysis.tasks import analysis_output_table_name
 
-        first = analysis_output_table_name("parcels_buffered", uuid.uuid4())
-        second = analysis_output_table_name("parcels_buffered", uuid.uuid4())
+        first = analysis_output_table_name(
+            "parcels_buffered", uuid.uuid4(), uuid.uuid4()
+        )
+        second = analysis_output_table_name(
+            "parcels_buffered", uuid.uuid4(), uuid.uuid4()
+        )
         assert first != second
         assert first.startswith("parcels_buffered_")
         assert second.startswith("parcels_buffered_")
 
-    def test_one_job_derives_a_stable_name(self) -> None:
-        """A retry reuses the job row, and therefore the single field on it."""
+    def test_two_attempts_of_one_job_never_derive_the_same_name(self) -> None:
+        """fix(#1778 codex r10): the gap job scoping alone left open."""
         from app.processing.analysis.tasks import analysis_output_table_name
 
         job_uuid = uuid.uuid4()
-        assert analysis_output_table_name("x", job_uuid) == analysis_output_table_name(
-            "x", job_uuid
-        )
+        first = analysis_output_table_name("parcels_buffered", job_uuid, uuid.uuid4())
+        second = analysis_output_table_name("parcels_buffered", job_uuid, uuid.uuid4())
+        assert first != second
+
+    def test_one_attempt_derives_a_stable_name(self) -> None:
+        """The same (job, attempt) pair is idempotent -- what a retry of a
+        retry that reuses the same attempt token would need."""
+        from app.processing.analysis.tasks import analysis_output_table_name
+
+        job_uuid = uuid.uuid4()
+        attempt_uuid = uuid.uuid4()
+        assert analysis_output_table_name(
+            "x", job_uuid, attempt_uuid
+        ) == analysis_output_table_name("x", job_uuid, attempt_uuid)
 
     def test_the_name_stays_inside_the_identifier_limit(self) -> None:
         from app.processing.analysis.tasks import (
@@ -444,17 +535,16 @@ class TestAnalysisOutputNamesAreJobScoped:
             analysis_output_table_name,
         )
 
-        name = analysis_output_table_name("a" * 60, uuid.uuid4())
+        name = analysis_output_table_name("a" * 60, uuid.uuid4(), uuid.uuid4())
         assert len(name) <= 63
         assert _ANALYSIS_TABLE_NAME_RE.match(name)
 
     def test_the_materialize_path_scopes_the_generated_name(self) -> None:
-        """`generate_table_name` still chooses the readable half."""
+        """`generate_table_name` still chooses the readable half; the scoped
+        collision walk happens separately, in `resolve_analysis_output_table`
+        (fix(#1778 codex r10))."""
         source = _source("processing/analysis/tasks.py")
-        assert (
-            "out_table = analysis_output_table_name(_base_table, uuid.UUID(job_id))"
-            in source
-        )
+        assert "out_table = await resolve_analysis_output_table(" in source
         assert "out_table, collision_warning = await generate_table_name" not in source
 
     @pytest.mark.asyncio
@@ -523,11 +613,12 @@ class TestAnalysisOutputNamesAreJobScoped:
         test_db_session.add_all([old_job, new_job])
         await test_db_session.flush()
         old_id, new_id = old_job.id, new_job.id
-        old_table = analysis_output_table_name(base, old_id)
-        new_table = analysis_output_table_name(base, new_id)
+        old_table = analysis_output_table_name(base, old_id, old_job.attempt_id)
+        new_table = analysis_output_table_name(base, new_id, new_job.attempt_id)
         assert old_table != new_table, "the whole point of the scope"
-        old_job.user_metadata = {"analysis_out_table": old_table}
-        new_job.user_metadata = {"analysis_out_table": new_table}
+        # List-shaped, the current writer's shape (fix(#1778 codex r10)).
+        old_job.user_metadata = {"analysis_out_table": [old_table]}
+        new_job.user_metadata = {"analysis_out_table": [new_table]}
         # Only the NEW job's table exists: the old one's was already dropped,
         # which is what freed the name in the first place.
         await test_db_session.execute(
@@ -558,7 +649,7 @@ class TestAnalysisOutputNamesAreJobScoped:
                     )
                 ).scalars()
             }
-            assert rows[new_id].get("analysis_out_table") == new_table, (
+            assert rows[new_id].get("analysis_out_table") == [new_table], (
                 "the sweep erased the new job's recovery pointer"
             )
             assert "analysis_out_table" not in rows[old_id], (
@@ -571,7 +662,185 @@ class TestAnalysisOutputNamesAreJobScoped:
             await test_db_session.commit()
 
 
-def _mock_db_for_fail_stale(*, running_rows: list) -> AsyncMock:
+class TestAttemptScopingPins:
+    """fix(#1778 codex r10): the three scenarios named in the round-10
+    review, each pinned against real Postgres.
+    """
+
+    @pytest.mark.anyio
+    async def test_a_stale_sweep_drops_only_the_dead_attempts_table(
+        self, test_db_session
+    ) -> None:
+        """(a) attempt 1's table survives a crash and a stale sweep captures
+        its name; by the time the sweep's drop runs, attempt 2 (the retry --
+        same job row, a NEW attempt token) has already created its own table
+        and appended its name to the same field. The sweep must drop only
+        attempt 1's table and leave attempt 2's recovery pointer alone."""
+        from sqlalchemy import select, text
+
+        from app.platform.jobs.models import IngestJob
+        from app.platform.jobs.sweep import _reap_unadopted_analysis_outputs
+        from app.processing.analysis.tasks import (
+            analysis_output_table_name,
+            append_analysis_output_record,
+        )
+
+        job = IngestJob(status="failed", file_path="")
+        test_db_session.add(job)
+        await test_db_session.flush()
+        attempt_1 = job.attempt_id
+        base = f"parcels_{uuid.uuid4().hex[:6]}"
+        table_1 = analysis_output_table_name(base, job.id, attempt_1)
+        await test_db_session.execute(
+            text(f'CREATE TABLE data."{table_1}" (marker integer)')
+        )
+
+        # The retry: same job row, a new attempt, its own table, appended --
+        # never overwriting -- onto the same field (fix(#1778 codex r10)).
+        attempt_2 = uuid.uuid4()
+        job.attempt_id = attempt_2
+        table_2 = analysis_output_table_name(base, job.id, attempt_2)
+        await test_db_session.execute(
+            text(f'CREATE TABLE data."{table_2}" (marker integer)')
+        )
+        job.user_metadata = append_analysis_output_record(None, table_1)
+        job.user_metadata = append_analysis_output_record(job.user_metadata, table_2)
+        await test_db_session.commit()
+        job_id = job.id
+
+        try:
+            # The stale sweep captured attempt 1's name before the retry
+            # committed; it reaps only the (job, table) pair it was handed.
+            await _reap_unadopted_analysis_outputs(((job_id, table_1),))
+
+            table_1_gone = (
+                await test_db_session.execute(
+                    text("SELECT to_regclass(:ref)").bindparams(ref=f"data.{table_1}")
+                )
+            ).scalar_one()
+            assert table_1_gone is None, "attempt 1's dead table must be dropped"
+
+            table_2_survives = (
+                await test_db_session.execute(
+                    text("SELECT to_regclass(:ref)").bindparams(ref=f"data.{table_2}")
+                )
+            ).scalar_one()
+            assert table_2_survives is not None, (
+                "the sweep dropped the RETRY's live table"
+            )
+
+            test_db_session.expire_all()
+            row = (
+                await test_db_session.execute(
+                    select(IngestJob).where(IngestJob.id == job_id)
+                )
+            ).scalar_one()
+            assert row.user_metadata.get("analysis_out_table") == [table_2], (
+                "attempt 2's recovery pointer must survive the reap of attempt 1's"
+            )
+        finally:
+            await test_db_session.execute(
+                text(f'DROP TABLE IF EXISTS data."{table_2}"')
+            )
+            await test_db_session.commit()
+
+    @pytest.mark.anyio
+    async def test_carried_over_keys_reap_on_the_datasets_latest_complete_job(
+        self, test_db_session
+    ) -> None:
+        """(b) the OLD collection ran only inside the retention purge block,
+        gated by the same `purge_clauses` that exempt a dataset's
+        latest-complete job -- so a successful retry that carries a dead
+        attempt's storage key forward on its OWN row (record_unpublished_
+        storage_keys preserves it; nothing settles it just because the retry
+        succeeded) was never looked at, because that row is by definition the
+        one the exemption protects. The artifact-carrying SELECT now runs
+        unconditionally, with no purge_clauses at all, so it sees the row
+        regardless of whether it is the dataset's latest complete job."""
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        from app.platform.jobs.models import IngestJob
+        from app.platform.jobs.router import fail_stale_jobs
+        from tests.factories import create_dataset, get_user_id
+
+        admin_id = await get_user_id(test_db_session, "admin")
+        ds = await create_dataset(test_db_session, created_by=admin_id)
+
+        carried_key = f"rasters/{ds.id}/attempts/dead/abc/source.cog.tif"
+        job = IngestJob(
+            dataset_id=ds.id,
+            status="complete",
+            file_path="",
+            user_metadata={"unpublished_storage_keys": [carried_key]},
+        )
+        test_db_session.add(job)
+        await test_db_session.commit()
+
+        storage = MagicMock()
+        storage.delete = AsyncMock()
+        with patch("app.platform.storage.get_storage", return_value=storage):
+            outcome = await fail_stale_jobs(test_db_session, detailed=True)
+
+        assert carried_key in outcome._unpublished_storage_keys, (
+            "the dataset's own latest-complete job must still be checked "
+            "for a carried-over key from a dead attempt"
+        )
+        storage.delete.assert_awaited_once_with(carried_key)
+
+    @pytest.mark.anyio
+    async def test_the_same_attempt_delivered_twice_self_heals_to_a_suffix(
+        self, test_db_session
+    ) -> None:
+        """(c) resolve_analysis_output_table's own docstring: attempt scoping
+        makes a retry colliding with itself rare but not unreachable -- the
+        SAME attempt can be delivered twice (redelivery after an ack the
+        first delivery never got to send). `generate_table_name`'s own `_N`
+        walk only ever probes the UNSCOPED base, so both deliveries are
+        handed the same base and scope onto the same occupied name.
+        `resolve_analysis_output_table` collision-checks the SCOPED candidate
+        directly and self-heals to a suffix instead of failing at CREATE
+        TABLE."""
+        from sqlalchemy import text
+
+        from app.processing.analysis.tasks import (
+            analysis_output_table_name,
+            resolve_analysis_output_table,
+        )
+
+        job_id = uuid.uuid4()
+        attempt_id = uuid.uuid4()
+        base = f"parcels_{uuid.uuid4().hex[:6]}"
+
+        # The first delivery's table, already committed.
+        first_delivery_table = analysis_output_table_name(base, job_id, attempt_id)
+        await test_db_session.execute(
+            text(f'CREATE TABLE data."{first_delivery_table}" (marker integer)')
+        )
+        await test_db_session.commit()
+
+        try:
+            resolved = await resolve_analysis_output_table(
+                test_db_session,
+                base=base,
+                job_uuid=job_id,
+                attempt_uuid=attempt_id,
+                schema="data",
+            )
+
+            assert resolved != first_delivery_table
+            assert resolved == analysis_output_table_name(
+                f"{base}_2", job_id, attempt_id
+            )
+        finally:
+            await test_db_session.execute(
+                text(f'DROP TABLE IF EXISTS data."{first_delivery_table}"')
+            )
+            await test_db_session.commit()
+
+
+def _mock_db_for_fail_stale(
+    *, running_rows: list, artifact_rows: list | None = None
+) -> AsyncMock:
     """A session double for ``fail_stale_jobs`` with real running-row metadata.
 
     The peer helper in ``test_vrt_stale_sweep_gap002`` hands every job row a
@@ -579,8 +848,10 @@ def _mock_db_for_fail_stale(*, running_rows: list) -> AsyncMock:
     this states the same execute() ordering with the rows filled in. Ordering,
     top to bottom: unbound pending UPDATE, bound pending UPDATE, running
     UPDATE, childless fan-out UPDATE, VRT generation UPDATE, two RasterAsset
-    UPDATEs, two refresh-run UPDATEs, the retention purge DELETE, and the
-    post-expiry presigned SELECT.
+    UPDATEs, two refresh-run UPDATEs, the retention purge DELETE, the
+    artifact-carrying SELECT (fix(#1778 codex r10): unconditional, outside the
+    retention block -- see that query's own docstring), and the post-expiry
+    presigned SELECT.
     """
     results = []
 
@@ -609,17 +880,15 @@ def _mock_db_for_fail_stale(*, running_rows: list) -> AsyncMock:
         result.scalars.return_value = []
         results.append(result)
 
-    # fix(#1778 codex r5): the purge reads its exempted rows first - terminal
-    # rows that still name an unreaped artifact, which it refuses to delete so
-    # the record survives for the next sweep to retry. None here.
-    retained = MagicMock()
-    # fix(#1778 codex r7): (id, user_metadata) pairs; none in these fixtures.
-    retained.all.return_value = []
-    results.append(retained)
-
     purge = MagicMock()
     purge.all.return_value = []
     results.append(purge)
+
+    # fix(#1778 codex r10): the artifact-carrying SELECT, unconditional and
+    # run after the retention block. (id, user_metadata) pairs.
+    artifact = MagicMock()
+    artifact.all.return_value = list(artifact_rows or [])
+    results.append(artifact)
 
     post_expiry = MagicMock()
     post_expiry.all.return_value = []

--- a/backend/tests/test_analysis_output_reap_1778.py
+++ b/backend/tests/test_analysis_output_reap_1778.py
@@ -32,10 +32,13 @@ class TestUnadoptedAnalysisOutput:
         source = _source("processing/analysis/tasks.py")
         assert "ANALYSIS_OUTPUT_TABLE_FIELD: out_table," in source
         lines = source.splitlines()
+        # fix(#1778 codex r7): the name is scoped by the job after
+        # `generate_table_name` chooses its readable half, so the assignment
+        # this ordering hangs off is the scoping call.
         generated = next(
             i
             for i, line in enumerate(lines)
-            if "out_table, collision_warning = await generate_table_name(" in line
+            if "out_table = analysis_output_table_name(" in line
         )
         persisted = next(
             i
@@ -68,32 +71,42 @@ class TestUnadoptedAnalysisOutput:
     async def test_an_unadopted_table_is_dropped(self) -> None:
         from app.processing.analysis.tasks import drop_unadopted_analysis_output
 
+        job_uuid = uuid.uuid4()
+        owned = analysis_output_table_name_for_test("parcels_buffered", job_uuid)
         session = AsyncMock()
         probe = MagicMock()
         probe.first.return_value = None
         session.execute = AsyncMock(return_value=probe)
 
         await drop_unadopted_analysis_output(
-            session, out_table="parcels_buffered", schema="data", job_id="j"
+            session,
+            out_table=owned,
+            schema="data",
+            job_id="j",
+            owner_job_uuid=job_uuid,
         )
 
         statements = [str(call.args[0]) for call in session.execute.await_args_list]
         assert any(
-            'DROP TABLE IF EXISTS "data"."parcels_buffered"' in stmt
-            for stmt in statements
+            f'DROP TABLE IF EXISTS "data"."{owned}"' in stmt for stmt in statements
         )
 
     @pytest.mark.asyncio
     async def test_an_adopted_table_is_left_alone(self) -> None:
         from app.processing.analysis.tasks import drop_unadopted_analysis_output
 
+        job_uuid = uuid.uuid4()
         session = AsyncMock()
         probe = MagicMock()
         probe.first.return_value = (1,)
         session.execute = AsyncMock(return_value=probe)
 
         await drop_unadopted_analysis_output(
-            session, out_table="parcels_buffered", schema="data", job_id="j"
+            session,
+            out_table=analysis_output_table_name_for_test("parcels_buffered", job_uuid),
+            schema="data",
+            job_id="j",
+            owner_job_uuid=job_uuid,
         )
 
         statements = [str(call.args[0]) for call in session.execute.await_args_list]
@@ -112,6 +125,7 @@ class TestUnadoptedAnalysisOutput:
             out_table='parcels"; DROP TABLE catalog.datasets; --',
             schema="data",
             job_id="j",
+            owner_job_uuid=uuid.uuid4(),
         )
 
         session.execute.assert_not_awaited()
@@ -120,17 +134,19 @@ class TestUnadoptedAnalysisOutput:
     async def test_fail_stale_jobs_carries_the_table_out_of_a_running_row(self) -> None:
         from app.platform.jobs.sweep import fail_stale_jobs
 
+        job_uuid = uuid.uuid4()
         mock_db = _mock_db_for_fail_stale(
             running_rows=[
-                (uuid.uuid4(), {"analysis_out_table": "parcels_buffered"}, None),
+                (job_uuid, {"analysis_out_table": "parcels_buffered"}, None),
             ]
         )
         reap = AsyncMock()
         with patch("app.platform.jobs.sweep._reap_unadopted_analysis_outputs", reap):
             outcome = await fail_stale_jobs(mock_db, detailed=True)
 
-        assert outcome._unadopted_analysis_tables == ("parcels_buffered",)
-        reap.assert_awaited_once_with(("parcels_buffered",))
+        # fix(#1778 codex r7): (job, table), so the drop can verify ownership.
+        assert outcome._unadopted_analysis_tables == ((job_uuid, "parcels_buffered"),)
+        reap.assert_awaited_once_with(((job_uuid, "parcels_buffered"),))
 
 
 class TestOnlyASettledArtifactLosesItsRecord:
@@ -186,11 +202,13 @@ class TestOnlyASettledArtifactLosesItsRecord:
     ) -> None:
         from app.processing.analysis.tasks import drop_unadopted_analysis_output
 
+        job_uuid = uuid.uuid4()
         outcome = await drop_unadopted_analysis_output(
             self._session_double(adopted=adopted, drop_raises=drop_raises),
-            out_table=self.TABLE,
+            out_table=analysis_output_table_name_for_test(self.TABLE, job_uuid),
             schema="data",
             job_id="j",
+            owner_job_uuid=job_uuid,
         )
 
         assert outcome == expected
@@ -206,7 +224,11 @@ class TestOnlyASettledArtifactLosesItsRecord:
 
         session = AsyncMock()
         outcome = await drop_unadopted_analysis_output(
-            session, out_table='x"; DROP TABLE y; --', schema="data", job_id="j"
+            session,
+            out_table='x"; DROP TABLE y; --',
+            schema="data",
+            job_id="j",
+            owner_job_uuid=uuid.uuid4(),
         )
 
         assert outcome == "invalid"
@@ -230,6 +252,7 @@ class TestOnlyASettledArtifactLosesItsRecord:
         from app.platform.jobs.sweep import _reap_unadopted_analysis_outputs
 
         clear = AsyncMock()
+        job_uuid = uuid.uuid4()
         with (
             patch(
                 "app.processing.analysis.tasks.drop_unadopted_analysis_output",
@@ -237,10 +260,10 @@ class TestOnlyASettledArtifactLosesItsRecord:
             ),
             patch("app.platform.jobs.sweep._clear_settled_artifact_records", clear),
         ):
-            await _reap_unadopted_analysis_outputs((self.TABLE,))
+            await _reap_unadopted_analysis_outputs(((job_uuid, self.TABLE),))
 
         clear.assert_awaited_once_with(
-            analysis_tables={self.TABLE} if settles else set()
+            analysis_job_ids={job_uuid} if settles else set()
         )
 
     @pytest.mark.asyncio
@@ -256,9 +279,9 @@ class TestOnlyASettledArtifactLosesItsRecord:
             ),
             patch("app.platform.jobs.sweep._clear_settled_artifact_records", clear),
         ):
-            await _reap_unadopted_analysis_outputs((self.TABLE,))
+            await _reap_unadopted_analysis_outputs(((uuid.uuid4(), self.TABLE),))
 
-        clear.assert_awaited_once_with(analysis_tables=set())
+        clear.assert_awaited_once_with(analysis_job_ids=set())
 
     @pytest.mark.anyio
     async def test_a_failed_drop_leaves_the_job_row_naming_the_table(
@@ -289,7 +312,7 @@ class TestOnlyASettledArtifactLosesItsRecord:
             "app.processing.analysis.tasks.drop_unadopted_analysis_output",
             AsyncMock(return_value="failed"),
         ):
-            await _reap_unadopted_analysis_outputs((self.TABLE,))
+            await _reap_unadopted_analysis_outputs(((job_id, self.TABLE),))
 
         test_db_session.expire_all()
         row = (
@@ -373,6 +396,181 @@ class TestOnlyASettledArtifactLosesItsRecord:
             )
 
 
+def analysis_output_table_name_for_test(base: str, job_uuid) -> str:
+    from app.processing.analysis.tasks import analysis_output_table_name
+
+    return analysis_output_table_name(base, job_uuid)
+
+
+def _output_name_for(job_uuid) -> str:
+    from app.processing.analysis.tasks import analysis_output_table_name
+
+    return analysis_output_table_name("parcels_buffered", job_uuid)
+
+
+class TestAnalysisOutputNamesAreJobScoped:
+    """fix(#1778 codex r7): two jobs could hold one physical table name.
+
+    An old failed analysis keeps `analysis_out_table` on its row until the reap
+    succeeds. Once its table is gone the name is free again -- nothing retires
+    it, because an unregistered output never became a dataset -- so a new
+    analysis with the same title was handed the same name. Let the new job
+    commit its CTAS between the sweep's adoption probe and its DROP and the
+    sweep destroyed the NEW job's table, and the name-keyed record clearing
+    then erased the new job's recovery pointer along with the old one's.
+    """
+
+    def test_two_jobs_never_derive_the_same_name(self) -> None:
+        from app.processing.analysis.tasks import analysis_output_table_name
+
+        first = analysis_output_table_name("parcels_buffered", uuid.uuid4())
+        second = analysis_output_table_name("parcels_buffered", uuid.uuid4())
+        assert first != second
+        assert first.startswith("parcels_buffered_")
+        assert second.startswith("parcels_buffered_")
+
+    def test_one_job_derives_a_stable_name(self) -> None:
+        """A retry reuses the job row, and therefore the single field on it."""
+        from app.processing.analysis.tasks import analysis_output_table_name
+
+        job_uuid = uuid.uuid4()
+        assert analysis_output_table_name("x", job_uuid) == analysis_output_table_name(
+            "x", job_uuid
+        )
+
+    def test_the_name_stays_inside_the_identifier_limit(self) -> None:
+        from app.processing.analysis.tasks import (
+            _ANALYSIS_TABLE_NAME_RE,
+            analysis_output_table_name,
+        )
+
+        name = analysis_output_table_name("a" * 60, uuid.uuid4())
+        assert len(name) <= 63
+        assert _ANALYSIS_TABLE_NAME_RE.match(name)
+
+    def test_the_materialize_path_scopes_the_generated_name(self) -> None:
+        """`generate_table_name` still chooses the readable half."""
+        source = _source("processing/analysis/tasks.py")
+        assert (
+            "out_table = analysis_output_table_name(_base_table, uuid.UUID(job_id))"
+            in source
+        )
+        assert "out_table, collision_warning = await generate_table_name" not in source
+
+    @pytest.mark.asyncio
+    async def test_the_sweep_refuses_a_table_the_job_did_not_create(self) -> None:
+        """The ownership gate, stated as its own unit.
+
+        The name says which job created it, so this needs no catalog read, no
+        comment and no lock: a table the check passes was created by this job
+        or by nothing at all.
+        """
+        from app.processing.analysis.tasks import drop_unadopted_analysis_output
+
+        session = AsyncMock()
+        outcome = await drop_unadopted_analysis_output(
+            session,
+            out_table=_output_name_for(uuid.uuid4()),
+            schema="data",
+            job_id="j",
+            owner_job_uuid=uuid.uuid4(),
+        )
+
+        assert outcome == "invalid"
+        session.execute.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_the_sweep_accepts_the_table_the_job_did_create(self) -> None:
+        from app.processing.analysis.tasks import drop_unadopted_analysis_output
+
+        job_uuid = uuid.uuid4()
+        session = AsyncMock()
+        probe = MagicMock()
+        probe.first.return_value = None
+        session.execute = AsyncMock(return_value=probe)
+
+        outcome = await drop_unadopted_analysis_output(
+            session,
+            out_table=_output_name_for(job_uuid),
+            schema="data",
+            job_id="j",
+            owner_job_uuid=job_uuid,
+        )
+
+        assert outcome == "dropped"
+
+    @pytest.mark.anyio
+    async def test_a_new_jobs_table_and_record_survive_the_old_jobs_reap(
+        self, test_db_session
+    ) -> None:
+        """The interleaving, against real Postgres.
+
+        The old job row names its own table, which is already gone -- that is
+        what used to free the name. A new job creates its table and records it.
+        The sweep reaps the old row. The new job's table and its recovery
+        pointer both survive, and the old row's record clears so its row can
+        finally be purged.
+        """
+        from sqlalchemy import select, text
+
+        from app.platform.jobs.models import IngestJob
+        from app.platform.jobs.sweep import _reap_unadopted_analysis_outputs
+        from app.processing.analysis.tasks import analysis_output_table_name
+
+        base = f"parcels_{uuid.uuid4().hex[:6]}"
+        old_job = IngestJob(status="failed", file_path="")
+        new_job = IngestJob(status="failed", file_path="")
+        test_db_session.add_all([old_job, new_job])
+        await test_db_session.flush()
+        old_id, new_id = old_job.id, new_job.id
+        old_table = analysis_output_table_name(base, old_id)
+        new_table = analysis_output_table_name(base, new_id)
+        assert old_table != new_table, "the whole point of the scope"
+        old_job.user_metadata = {"analysis_out_table": old_table}
+        new_job.user_metadata = {"analysis_out_table": new_table}
+        # Only the NEW job's table exists: the old one's was already dropped,
+        # which is what freed the name in the first place.
+        await test_db_session.execute(
+            text(f'CREATE TABLE data."{new_table}" (marker integer)')
+        )
+        await test_db_session.commit()
+
+        try:
+            await _reap_unadopted_analysis_outputs(((old_id, old_table),))
+
+            still_there = (
+                await test_db_session.execute(
+                    text(
+                        "SELECT 1 FROM pg_catalog.pg_class c"
+                        " JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace"
+                        " WHERE n.nspname = 'data' AND c.relname = :t"
+                    ).bindparams(t=new_table)
+                )
+            ).first()
+            assert still_there, "the sweep dropped the new job's table"
+
+            test_db_session.expire_all()
+            rows = {
+                row.id: row.user_metadata
+                for row in (
+                    await test_db_session.execute(
+                        select(IngestJob).where(IngestJob.id.in_([old_id, new_id]))
+                    )
+                ).scalars()
+            }
+            assert rows[new_id].get("analysis_out_table") == new_table, (
+                "the sweep erased the new job's recovery pointer"
+            )
+            assert "analysis_out_table" not in rows[old_id], (
+                "the old job's record must clear so its row can be purged"
+            )
+        finally:
+            await test_db_session.execute(
+                text(f'DROP TABLE IF EXISTS data."{new_table}"')
+            )
+            await test_db_session.commit()
+
+
 def _mock_db_for_fail_stale(*, running_rows: list) -> AsyncMock:
     """A session double for ``fail_stale_jobs`` with real running-row metadata.
 
@@ -415,7 +613,8 @@ def _mock_db_for_fail_stale(*, running_rows: list) -> AsyncMock:
     # rows that still name an unreaped artifact, which it refuses to delete so
     # the record survives for the next sweep to retry. None here.
     retained = MagicMock()
-    retained.scalars.return_value = []
+    # fix(#1778 codex r7): (id, user_metadata) pairs; none in these fixtures.
+    retained.all.return_value = []
     results.append(retained)
 
     purge = MagicMock()

--- a/backend/tests/test_analysis_output_reap_1778.py
+++ b/backend/tests/test_analysis_output_reap_1778.py
@@ -170,6 +170,13 @@ def _mock_db_for_fail_stale(*, running_rows: list) -> AsyncMock:
         result.scalars.return_value = []
         results.append(result)
 
+    # fix(#1778 codex r5): the purge reads its exempted rows first - terminal
+    # rows that still name an unreaped artifact, which it refuses to delete so
+    # the record survives for the next sweep to retry. None here.
+    retained = MagicMock()
+    retained.scalars.return_value = []
+    results.append(retained)
+
     purge = MagicMock()
     purge.all.return_value = []
     results.append(purge)

--- a/backend/tests/test_analysis_output_reap_1778.py
+++ b/backend/tests/test_analysis_output_reap_1778.py
@@ -1,0 +1,184 @@
+"""Codebase audit 2026-08-30, orphaned analysis output (tracked in #1778).
+
+A hard worker kill after the materialize commit left ``data.<out_table>`` and
+its GIST index behind with no catalog row: the name was generated inside the
+worker, nothing durable carried it, and every DROP of it lives in a handler a
+SIGKILL never runs.
+"""
+
+import uuid
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+APP = Path(__file__).resolve().parents[1] / "app"
+
+
+def _source(rel: str) -> str:
+    return (APP / rel).read_text()
+
+
+class TestUnadoptedAnalysisOutput:
+    def test_the_generated_name_is_persisted_next_to_the_collision_warning(
+        self,
+    ) -> None:
+        """Written unconditionally, in the transaction that creates the table.
+
+        The two facts become durable together, so a job row that names a table
+        is exactly a job row whose table exists.
+        """
+        source = _source("processing/analysis/tasks.py")
+        assert "ANALYSIS_OUTPUT_TABLE_FIELD: out_table," in source
+        lines = source.splitlines()
+        generated = next(
+            i
+            for i, line in enumerate(lines)
+            if "out_table, collision_warning = await generate_table_name(" in line
+        )
+        persisted = next(
+            i
+            for i, line in enumerate(lines)
+            if "ANALYSIS_OUTPUT_TABLE_FIELD: out_table," in line
+        )
+        commit = next(
+            i
+            for i, line in enumerate(lines)
+            if i > persisted and "await session.commit()" in line
+        )
+        assert generated < persisted < commit
+
+    @pytest.mark.parametrize(
+        "metadata,expected",
+        [
+            (None, None),
+            ({}, None),
+            ({"analysis_out_table": ""}, None),
+            ({"analysis_out_table": 7}, None),
+            ({"analysis_out_table": "parcels_buffered"}, "parcels_buffered"),
+        ],
+    )
+    def test_the_name_is_read_back_off_the_job_row(self, metadata, expected) -> None:
+        from app.platform.jobs.sweep import unadopted_analysis_table_from_metadata
+
+        assert unadopted_analysis_table_from_metadata(metadata) == expected
+
+    @pytest.mark.asyncio
+    async def test_an_unadopted_table_is_dropped(self) -> None:
+        from app.processing.analysis.tasks import drop_unadopted_analysis_output
+
+        session = AsyncMock()
+        probe = MagicMock()
+        probe.first.return_value = None
+        session.execute = AsyncMock(return_value=probe)
+
+        await drop_unadopted_analysis_output(
+            session, out_table="parcels_buffered", schema="data", job_id="j"
+        )
+
+        statements = [str(call.args[0]) for call in session.execute.await_args_list]
+        assert any(
+            'DROP TABLE IF EXISTS "data"."parcels_buffered"' in stmt
+            for stmt in statements
+        )
+
+    @pytest.mark.asyncio
+    async def test_an_adopted_table_is_left_alone(self) -> None:
+        from app.processing.analysis.tasks import drop_unadopted_analysis_output
+
+        session = AsyncMock()
+        probe = MagicMock()
+        probe.first.return_value = (1,)
+        session.execute = AsyncMock(return_value=probe)
+
+        await drop_unadopted_analysis_output(
+            session, out_table="parcels_buffered", schema="data", job_id="j"
+        )
+
+        statements = [str(call.args[0]) for call in session.execute.await_args_list]
+        assert not any("DROP TABLE" in stmt for stmt in statements)
+
+    @pytest.mark.asyncio
+    async def test_a_name_that_is_not_an_identifier_never_reaches_ddl(self) -> None:
+        """The name arrives through JSONB and is interpolated into DDL."""
+        from app.processing.analysis.tasks import drop_unadopted_analysis_output
+
+        session = AsyncMock()
+        session.execute = AsyncMock()
+
+        await drop_unadopted_analysis_output(
+            session,
+            out_table='parcels"; DROP TABLE catalog.datasets; --',
+            schema="data",
+            job_id="j",
+        )
+
+        session.execute.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_fail_stale_jobs_carries_the_table_out_of_a_running_row(self) -> None:
+        from app.platform.jobs.sweep import fail_stale_jobs
+
+        mock_db = _mock_db_for_fail_stale(
+            running_rows=[
+                (uuid.uuid4(), {"analysis_out_table": "parcels_buffered"}, None),
+            ]
+        )
+        reap = AsyncMock()
+        with patch("app.platform.jobs.sweep._reap_unadopted_analysis_outputs", reap):
+            outcome = await fail_stale_jobs(mock_db, detailed=True)
+
+        assert outcome._unadopted_analysis_tables == ("parcels_buffered",)
+        reap.assert_awaited_once_with(("parcels_buffered",))
+
+
+def _mock_db_for_fail_stale(*, running_rows: list) -> AsyncMock:
+    """A session double for ``fail_stale_jobs`` with real running-row metadata.
+
+    The peer helper in ``test_vrt_stale_sweep_gap002`` hands every job row a
+    ``None`` metadata blob, which is exactly the column these findings read, so
+    this states the same execute() ordering with the rows filled in. Ordering,
+    top to bottom: unbound pending UPDATE, bound pending UPDATE, running
+    UPDATE, childless fan-out UPDATE, VRT generation UPDATE, two RasterAsset
+    UPDATEs, two refresh-run UPDATEs, the retention purge DELETE, and the
+    post-expiry presigned SELECT.
+    """
+    results = []
+
+    unbound = MagicMock()
+    unbound.all.return_value = []
+    results.append(unbound)
+
+    bound = MagicMock()
+    bound.all.return_value = []
+    results.append(bound)
+
+    running = MagicMock()
+    running.all.return_value = list(running_rows)
+    results.append(running)
+
+    fanout = MagicMock()
+    fanout.scalars.return_value = []
+    results.append(fanout)
+
+    generations = MagicMock()
+    generations.all.return_value = []
+    results.append(generations)
+
+    for _ in range(4):
+        result = MagicMock()
+        result.scalars.return_value = []
+        results.append(result)
+
+    purge = MagicMock()
+    purge.all.return_value = []
+    results.append(purge)
+
+    post_expiry = MagicMock()
+    post_expiry.all.return_value = []
+    results.append(post_expiry)
+
+    mock_db = AsyncMock()
+    mock_db.execute = AsyncMock(side_effect=results)
+    mock_db.commit = AsyncMock()
+    return mock_db

--- a/backend/tests/test_analysis_output_reap_1778.py
+++ b/backend/tests/test_analysis_output_reap_1778.py
@@ -6,6 +6,7 @@ worker, nothing durable carried it, and every DROP of it lives in a handler a
 SIGKILL never runs.
 """
 
+import ast
 import uuid
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -130,6 +131,246 @@ class TestUnadoptedAnalysisOutput:
 
         assert outcome._unadopted_analysis_tables == ("parcels_buffered",)
         reap.assert_awaited_once_with(("parcels_buffered",))
+
+
+class TestOnlyASettledArtifactLosesItsRecord:
+    """fix(#1778 codex r6): "it did not raise" is not "it is done".
+
+    `drop_unadopted_analysis_output` catches its own probe and DROP failures,
+    so it returned the same `None` whether it dropped the table or failed to.
+    The sweep read that as success, `_clear_settled_artifact_records` stripped
+    the table's last durable name off the job row, the retention purge then
+    deleted the row, and the table was orphaned for good: the exact leak that
+    function exists to prevent, reintroduced by the function itself.
+
+    The rule is now stated once per arm and keyed on a NAMED outcome rather
+    than on control flow, because the storage arm was correct only by where a
+    statement sat inside a try block.
+    """
+
+    TABLE = "parcels_buffered"
+    KEY = "rasters/ds/attempts/a/abc/source.cog.tif"
+
+    @staticmethod
+    def _session_double(*, adopted, drop_raises: bool = False):
+        """A session whose probe answers `adopted` and whose DROP may raise."""
+        session = AsyncMock()
+
+        async def _execute(stmt, *_a, **_kw):
+            sql = str(stmt)
+            if "DROP TABLE" in sql:
+                if drop_raises:
+                    raise RuntimeError("lock timeout")
+                return MagicMock()
+            if isinstance(adopted, Exception):
+                raise adopted
+            probe = MagicMock()
+            probe.first.return_value = (1,) if adopted else None
+            return probe
+
+        session.execute = AsyncMock(side_effect=_execute)
+        return session
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "adopted,drop_raises,expected",
+        [
+            (False, False, "dropped"),
+            (True, False, "adopted"),
+            (False, True, "failed"),
+            (RuntimeError("catalog unreadable"), False, "failed"),
+        ],
+    )
+    async def test_the_helper_reports_what_it_established(
+        self, adopted, drop_raises, expected
+    ) -> None:
+        from app.processing.analysis.tasks import drop_unadopted_analysis_output
+
+        outcome = await drop_unadopted_analysis_output(
+            self._session_double(adopted=adopted, drop_raises=drop_raises),
+            out_table=self.TABLE,
+            schema="data",
+            job_id="j",
+        )
+
+        assert outcome == expected
+
+    @pytest.mark.asyncio
+    async def test_a_name_that_is_not_an_identifier_is_final(self) -> None:
+        """No retry can change the string, so keeping the record would pin
+        the job row forever."""
+        from app.processing.analysis.tasks import (
+            ANALYSIS_OUTPUT_FINAL_OUTCOMES,
+            drop_unadopted_analysis_output,
+        )
+
+        session = AsyncMock()
+        outcome = await drop_unadopted_analysis_output(
+            session, out_table='x"; DROP TABLE y; --', schema="data", job_id="j"
+        )
+
+        assert outcome == "invalid"
+        assert outcome in ANALYSIS_OUTPUT_FINAL_OUTCOMES
+        session.execute.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "outcome,settles",
+        [
+            ("dropped", True),
+            ("adopted", True),
+            ("invalid", True),
+            ("skipped", True),
+            ("failed", False),
+        ],
+    )
+    async def test_the_analysis_arm_settles_only_on_a_final_outcome(
+        self, outcome: str, settles: bool
+    ) -> None:
+        from app.platform.jobs.sweep import _reap_unadopted_analysis_outputs
+
+        clear = AsyncMock()
+        with (
+            patch(
+                "app.processing.analysis.tasks.drop_unadopted_analysis_output",
+                AsyncMock(return_value=outcome),
+            ),
+            patch("app.platform.jobs.sweep._clear_settled_artifact_records", clear),
+        ):
+            await _reap_unadopted_analysis_outputs((self.TABLE,))
+
+        clear.assert_awaited_once_with(
+            analysis_tables={self.TABLE} if settles else set()
+        )
+
+    @pytest.mark.asyncio
+    async def test_a_drop_that_raises_outright_also_keeps_the_record(self) -> None:
+        """The callee catches its own failures; this covers one it does not."""
+        from app.platform.jobs.sweep import _reap_unadopted_analysis_outputs
+
+        clear = AsyncMock()
+        with (
+            patch(
+                "app.processing.analysis.tasks.drop_unadopted_analysis_output",
+                AsyncMock(side_effect=RuntimeError("connection reset")),
+            ),
+            patch("app.platform.jobs.sweep._clear_settled_artifact_records", clear),
+        ):
+            await _reap_unadopted_analysis_outputs((self.TABLE,))
+
+        clear.assert_awaited_once_with(analysis_tables=set())
+
+    @pytest.mark.anyio
+    async def test_a_failed_drop_leaves_the_job_row_naming_the_table(
+        self, test_db_session
+    ) -> None:
+        """The pin, end to end against real Postgres.
+
+        A DROP that raises must leave `analysis_out_table` on the row, because
+        that name is the only remaining pointer to the orphan and the retention
+        purge exempts rows that still carry one.
+        """
+        from sqlalchemy import select
+
+        from app.platform.jobs.models import IngestJob
+        from app.platform.jobs.sweep import _reap_unadopted_analysis_outputs
+
+        job = IngestJob(
+            status="failed",
+            file_path="",
+            user_metadata={"analysis_out_table": self.TABLE},
+        )
+        test_db_session.add(job)
+        await test_db_session.flush()
+        job_id = job.id
+        await test_db_session.commit()
+
+        with patch(
+            "app.processing.analysis.tasks.drop_unadopted_analysis_output",
+            AsyncMock(return_value="failed"),
+        ):
+            await _reap_unadopted_analysis_outputs((self.TABLE,))
+
+        test_db_session.expire_all()
+        row = (
+            await test_db_session.execute(
+                select(IngestJob).where(IngestJob.id == job_id)
+            )
+        ).scalar_one()
+        assert row.user_metadata.get("analysis_out_table") == self.TABLE, (
+            "a failed drop must leave the table's last durable name on the row"
+        )
+
+    @pytest.mark.asyncio
+    async def test_a_delete_that_raises_leaves_the_key_on_the_record(self) -> None:
+        """The storage arm's half of the same rule."""
+        from app.platform.jobs.sweep import reap_unpublished_storage_keys
+
+        clear = AsyncMock()
+        storage = MagicMock()
+        storage.delete = AsyncMock(side_effect=RuntimeError("s3 unavailable"))
+        with (
+            patch("app.platform.storage.get_storage", return_value=storage),
+            patch(
+                "app.platform.jobs.sweep._live_referenced_storage_keys",
+                AsyncMock(return_value=set()),
+            ),
+            patch("app.platform.jobs.sweep._clear_settled_artifact_records", clear),
+        ):
+            reaped, skipped, failures = await reap_unpublished_storage_keys((self.KEY,))
+
+        assert (reaped, skipped, failures) == (0, 0, 1)
+        clear.assert_awaited_once_with(storage_keys=set())
+
+    def test_every_arm_that_clears_a_record_keys_off_a_named_outcome(self) -> None:
+        """Enumerated, so a third arm cannot quietly repeat this.
+
+        Codex charges one round per sibling site, and the two arms here reached
+        the same bug from opposite directions: the analysis one by trusting a
+        callee that swallowed, the storage one by relying on where a statement
+        sat in a try block. Any future caller of the clearing helper has to
+        appear in this list and consult a FINAL-outcome set.
+        """
+        source = (APP / "platform/jobs/sweep.py").read_text()
+        tree = ast.parse(source)
+        callers: set[str] = set()
+        stack: list[str] = []
+
+        def walk(node: ast.AST) -> None:
+            for child in ast.iter_child_nodes(node):
+                if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                    stack.append(child.name)
+                    walk(child)
+                    stack.pop()
+                    continue
+                if (
+                    isinstance(child, ast.Call)
+                    and isinstance(child.func, ast.Name)
+                    and child.func.id == "_clear_settled_artifact_records"
+                    and stack
+                ):
+                    callers.add(stack[-1])
+                walk(child)
+
+        walk(tree)
+        assert callers == {
+            "reap_unpublished_storage_keys",
+            "_reap_unadopted_analysis_outputs",
+        }, callers
+
+        for name, vocabulary in (
+            ("reap_unpublished_storage_keys", "STORAGE_KEY_FINAL_OUTCOMES"),
+            ("_reap_unadopted_analysis_outputs", "ANALYSIS_OUTPUT_FINAL_OUTCOMES"),
+        ):
+            fn = next(
+                node
+                for node in tree.body
+                if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+                and node.name == name
+            )
+            assert vocabulary in ast.unparse(fn), (
+                f"{name} clears records without consulting {vocabulary}"
+            )
 
 
 def _mock_db_for_fail_stale(*, running_rows: list) -> AsyncMock:

--- a/backend/tests/test_band_info_shapes_1778.py
+++ b/backend/tests/test_band_info_shapes_1778.py
@@ -1,0 +1,102 @@
+"""Codebase audit 2026-08-30, band_info and STAC nodata (tracked in #1778).
+
+``raster:bands`` published a numeric nodata as the string the producer stored,
+published ``[{}, {}, {}]`` for a remotely described COG, and the OGC Records
+peer dropped the band name of every locally ingested raster because it read a
+key no producer writes.
+"""
+
+import uuid
+
+import pytest
+
+
+def _raster_asset(band_info):
+    from app.processing.raster.models import RasterAsset
+
+    return RasterAsset(
+        dataset_id=uuid.uuid4(),
+        asset_uri="rasters/x/y/source.cog.tif",
+        sha256="0" * 64,
+        band_info=band_info,
+    )
+
+
+class TestBandInfoShapes:
+    def test_stac_nodata_is_published_as_a_number(self) -> None:
+        """``extract_raster_metadata`` stores ``str(src.nodata)``."""
+        asset = _raster_asset(
+            [{"index": 1, "dtype": "uint8", "nodata": "0.0", "color_interp": "Red"}]
+        )
+        bands = asset.to_stac_properties()["raster:bands"]
+        assert bands == [{"data_type": "uint8", "nodata": 0.0, "name": "Red"}]
+        assert isinstance(bands[0]["nodata"], float)
+
+    @pytest.mark.parametrize("sentinel", ["nan", "inf", "-inf", "NaN"])
+    def test_the_extension_sentinels_stay_strings(self, sentinel: str) -> None:
+        asset = _raster_asset([{"dtype": "float32", "nodata": sentinel}])
+        bands = asset.to_stac_properties()["raster:bands"]
+        assert bands[0]["nodata"] == sentinel.lower()
+
+    def test_an_unparseable_nodata_is_dropped(self) -> None:
+        asset = _raster_asset([{"dtype": "uint8", "nodata": "unknown"}])
+        assert "nodata" not in asset.to_stac_properties()["raster:bands"][0]
+
+    def test_a_remotely_described_cog_publishes_no_empty_bands(self) -> None:
+        """``fetch_cog_info`` writes ``{min, max, mean}`` and nothing else."""
+        asset = _raster_asset([{"min": 0, "max": 255, "mean": 12.5} for _ in range(3)])
+        assert "raster:bands" not in asset.to_stac_properties()
+
+    def test_the_ogc_records_serializer_reports_the_band_name(self) -> None:
+        """``color_interp`` is the key the local producer writes; nothing
+        writes the ``name`` this serializer used to read."""
+        bands = _ogc_bands(
+            [
+                {"index": 1, "dtype": "uint8", "color_interp": "Red"},
+                {"index": 2, "dtype": "uint8", "color_interp": "Green"},
+                {"index": 3, "dtype": "uint8", "color_interp": "Blue"},
+            ]
+        )
+        assert [band["name"] for band in bands] == ["Red", "Green", "Blue"]
+
+    def test_the_two_serializers_agree_on_one_band_info(self) -> None:
+        band_info = [
+            {"index": 1, "dtype": "uint16", "nodata": "0.0", "color_interp": "Gray"}
+        ]
+        stac = _raster_asset(band_info).to_stac_properties()["raster:bands"]
+        ogc = _ogc_bands(band_info)
+        assert stac[0]["name"] == ogc[0]["name"] == "Gray"
+        assert stac[0]["nodata"] == ogc[0]["nodata"] == 0.0
+
+
+def _ogc_bands(band_info: list[dict]) -> list[dict]:
+    """``raster:bands`` as the OGC Records representation publishes them.
+
+    Transient ORM instances rather than a session: the serializer is
+    synchronous and reads attributes, so nothing here needs to be persisted.
+    """
+    from datetime import datetime, timezone
+
+    from app.modules.catalog.datasets.domain.models import Dataset, Record
+    from app.modules.catalog.search.service_records import dataset_to_ogc_record
+
+    now = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    record = Record(
+        id=uuid.uuid4(),
+        title="raster",
+        record_type="raster_dataset",
+        visibility="public",
+        record_status="published",
+        created_at=now,
+        updated_at=now,
+    )
+    dataset = Dataset(
+        id=uuid.uuid4(), record_id=record.id, table_name="raster_x", srid=4326
+    )
+    dataset.record = record
+    result = dataset_to_ogc_record(
+        dataset,
+        "https://example.test",
+        raster_meta={"band_count": len(band_info), "band_info": band_info},
+    )
+    return result["properties"].get("raster:bands", [])

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -3481,9 +3481,13 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # its own probe and DROP failures, so a failed cleanup stripped the table's
     # last durable name and orphaned it; the storage arm was correct only by
     # where a statement sat inside a try block. `STORAGE_KEY_FINAL_OUTCOMES`
-    # and the try/else restructure are most of the growth. Cap 2252 -> 2288,
-    # exact.
-    "backend/app/platform/jobs/sweep.py": 2288,
+    # and the try/else restructure are most of the growth. Cap 2252 -> 2288.
+    # fix(#1778 codex r7): +14. The analysis reap is keyed on the owning JOB
+    # rather than on a table name two jobs could hold in sequence: it carries
+    # (job, table) pairs, hands the owner to the drop so it can refuse a table
+    # that job did not create, and clears the record by row id. Cap 2288 ->
+    # 2302, exact.
+    "backend/app/platform/jobs/sweep.py": 2302,
     # fix(#1709 review r8 B): first entry — crossed the 1000-line inclusion
     # threshold at 1010 when refresh.cancelled attribution was corrected to
     # name the CANCELLING user (cancel_active_run_for_job and
@@ -4509,8 +4513,18 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # call, and the name is the table's last durable pointer, so a swallowed
     # failure read as success orphaned the table permanently. The five outcomes
     # and the note on why a raised probe is "failed" and not "adopted" are the
-    # growth. Cap 1462 -> 1495, exact.
-    "backend/app/processing/analysis/tasks.py": 1495,
+    # growth. Cap 1462 -> 1495.
+    # fix(#1778 codex r7): +79. Output table names are scoped by the job that
+    # creates them, so two jobs can never hold one physical name and the sweep
+    # can verify ownership from the name alone, with no marker, registry or
+    # lock. `analysis_output_table_name` and `analysis_output_table_belongs_to`
+    # plus the ownership gate in the drop are the code; the docstring stating
+    # the interleaving that made a shared name unsafe, and why the scope is by
+    # job and not by attempt, is most of the growth. The gate is a REQUIRED
+    # keyword with no default: the in-worker handlers pass their own id either
+    # way, so an optional one would have bought nothing but a way to forget it.
+    # Cap 1495 -> 1580, exact.
+    "backend/app/processing/analysis/tasks.py": 1580,
     # Tenant-owned media now crosses the shared logical-to-physical storage
     # seam; explicit storage-failure responses keep the runtime/OpenAPI contract
     # aligned. Keep the ratchet exact after the import/decorator expansion.

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -3227,7 +3227,12 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # fix(#1746 codex r1): +5 — the marker comment now states the claim
     # narrowly ("the last successful pull was MADE with a token"), because the
     # worker never sees a challenge on the happy path. Cap 1278 -> 1283, exact.
-    "backend/app/processing/ingest/tasks_reupload.py": 1283,
+    # fix(#1778): +8. The pending -> running run transition is committed
+    # before `resolve_file_path` instead of after it, plus the comment saying
+    # why. Holding the `dataset_refresh_runs` row lock across the staging
+    # download made every cancel in that window a 409 that also rolled back the
+    # job cancellation it had already written. Cap 1283 -> 1291, exact.
+    "backend/app/processing/ingest/tasks_reupload.py": 1291,
     # --- entered by the inclusion rule, feat(#1266) -----------------------
     # The refresh door crossed 1000 when it gained its third execution
     # strategy. Two thirds of the addition is the STAC dispatcher, which is

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -3998,7 +3998,13 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # keys on the job row first, the way `ingest_raster` does. Most of the
     # growth is the comment saying why the id is decided outside phase 2.
     # Cap 1530 -> 1568, exact.
-    "backend/app/processing/ingest/tasks_vrt.py": 1568,
+    # fix(#1778 audit): +7. record_unpublished_storage_keys now reports a
+    # confirmed fence miss rather than silently committing nothing, and this
+    # call site checks it: a miss means a retry has already superseded this
+    # attempt, so it returns before generating quicklooks or ever reaching
+    # phase 2, instead of relying on phase 2's own attempt-fenced load to
+    # catch it downstream. Cap 1568 -> 1575, exact.
+    "backend/app/processing/ingest/tasks_vrt.py": 1575,
     # fix(#1202 review r5): +29 — sweep the presigned staging key at job end.
     # A completed presigned job points file_path at its frozen copy, so this
     # reaper never touched the key the client's PUT URL can still recreate.

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -3474,8 +3474,16 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # row names it) so the next pass can purge the row. The survivor query also
     # went from four IN clauses to one shared array bind, because four binds
     # per key crossed asyncpg's 32767-argument ceiling at about 8192 keys and
-    # the resulting failure skipped every delete. Cap 2100 -> 2252, exact.
-    "backend/app/platform/jobs/sweep.py": 2252,
+    # the resulting failure skipped every delete. Cap 2100 -> 2252.
+    # fix(#1778 codex r6): +36. Both arms that clear an artifact record now key
+    # the settle off a NAMED outcome instead of off control flow. The analysis
+    # arm was reading "the call returned" as success, but the callee catches
+    # its own probe and DROP failures, so a failed cleanup stripped the table's
+    # last durable name and orphaned it; the storage arm was correct only by
+    # where a statement sat inside a try block. `STORAGE_KEY_FINAL_OUTCOMES`
+    # and the try/else restructure are most of the growth. Cap 2252 -> 2288,
+    # exact.
+    "backend/app/platform/jobs/sweep.py": 2288,
     # fix(#1709 review r8 B): first entry — crossed the 1000-line inclusion
     # threshold at 1010 when refresh.cancelled attribution was corrected to
     # name the CANCELLING user (cancel_active_run_for_job and
@@ -4494,8 +4502,15 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # probe-then-drop the two fence-miss handlers each carried inline is now one
     # `drop_unadopted_analysis_output` the stale-job sweeps call too. The
     # helper's docstring and its identifier re-validation are most of the net
-    # growth; the two inlined copies came out. Cap 1420 -> 1462, exact.
-    "backend/app/processing/analysis/tasks.py": 1462,
+    # growth; the two inlined copies came out. Cap 1420 -> 1462.
+    # fix(#1778 codex r6): +33. `drop_unadopted_analysis_output` returns what
+    # it established rather than the same None whether it dropped the table or
+    # failed to. The sweep clears the recorded name on the strength of that
+    # call, and the name is the table's last durable pointer, so a swallowed
+    # failure read as success orphaned the table permanently. The five outcomes
+    # and the note on why a raised probe is "failed" and not "adopted" are the
+    # growth. Cap 1462 -> 1495, exact.
+    "backend/app/processing/analysis/tasks.py": 1495,
     # Tenant-owned media now crosses the shared logical-to-physical storage
     # seam; explicit storage-failure responses keep the runtime/OpenAPI contract
     # aligned. Keep the ratchet exact after the import/decorator expansion.

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -4443,7 +4443,13 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # that this table was CTAS'd here so delete may reclaim it. Without the
     # flag it is indistinguishable from an operator's registered table and
     # every analysis output would leak one on delete. Cap 1413 -> 1420, exact.
-    "backend/app/processing/analysis/tasks.py": 1420,
+    # fix(#1778): +42. The generated output table name is persisted to
+    # `user_metadata` in the transaction that creates the table, and the
+    # probe-then-drop the two fence-miss handlers each carried inline is now one
+    # `drop_unadopted_analysis_output` the stale-job sweeps call too. The
+    # helper's docstring and its identifier re-validation are most of the net
+    # growth; the two inlined copies came out. Cap 1420 -> 1462, exact.
+    "backend/app/processing/analysis/tasks.py": 1462,
     # Tenant-owned media now crosses the shared logical-to-physical storage
     # seam; explicit storage-failure responses keep the runtime/OpenAPI contract
     # aligned. Keep the ratchet exact after the import/decorator expansion.

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -3449,9 +3449,17 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # `_reap_unadopted_analysis_outputs` do the same for an analysis output
     # table; both are collected in `fail_stale_jobs` and deleted only after its
     # commit, alongside the existing stale-generation keys. Roughly half of it
-    # is the docstrings stating why neither reap needs a survivor query and why
-    # the analysis one takes its own session. Cap 1857 -> 1991, exact.
-    "backend/app/platform/jobs/sweep.py": 1991,
+    # is the docstrings stating why the analysis reap takes its own session.
+    # Cap 1857 -> 1991.
+    # fix(#1778 codex r1): +86. The raster reap gained a survivor check that an
+    # earlier revision argued it did not need: an identical re-upload derives
+    # the same content hash, so a replace's intended keys can BE the live
+    # asset's, and a crash then licensed deleting the raster the dataset was
+    # serving. `_live_referenced_storage_keys` asks the four columns that name
+    # an object, `reap_unpublished_storage_keys` refuses what they return and
+    # deletes nothing at all when the query fails, and both stale-job passes
+    # go through it. Cap 1991 -> 2077, exact.
+    "backend/app/platform/jobs/sweep.py": 2077,
     # fix(#1709 review r8 B): first entry — crossed the 1000-line inclusion
     # threshold at 1010 when refresh.cancelled attribution was corrected to
     # name the CANCELLING user (cancel_active_run_for_job and

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -3458,8 +3458,15 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # serving. `_live_referenced_storage_keys` asks the four columns that name
     # an object, `reap_unpublished_storage_keys` refuses what they return and
     # deletes nothing at all when the query fails, and both stale-job passes
-    # go through it. Cap 1991 -> 2077, exact.
-    "backend/app/platform/jobs/sweep.py": 2077,
+    # go through it. Cap 1991 -> 2077.
+    # fix(#1778 codex r4): +23. The retention purge is the LAST actor holding a
+    # pointer to a terminal job's unpublished keys and analysis output table,
+    # so a job that failed on its own and whose best-effort cleanup then failed
+    # once had nothing left looking at it. Its DELETE ... RETURNING already
+    # carried `user_metadata`; the rows now feed the same two post-commit reaps
+    # the running-row sweep feeds, survivor checks included. Cap 2077 -> 2100,
+    # exact.
+    "backend/app/platform/jobs/sweep.py": 2100,
     # fix(#1709 review r8 B): first entry — crossed the 1000-line inclusion
     # threshold at 1010 when refresh.cancelled attribution was corrected to
     # name the CANCELLING user (cancel_active_run_for_job and
@@ -3941,9 +3948,15 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # VRT integration and source-management suites, and putting the wrappers in
     # `raster/vrt.py` with function-level imports removed the attributes AND
     # would have made the patches no-ops once restored. The docstrings say so,
-    # because the next reader will want to move them back. Cap 1496 -> 1530,
-    # exact.
-    "backend/app/processing/ingest/tasks_vrt.py": 1530,
+    # because the next reader will want to move them back. Cap 1496 -> 1530.
+    # fix(#1778 codex r4): +38. `ingest_vrt` puts the VRT and its quicklooks
+    # before the terminal commit and recorded nothing, so a kill in between
+    # lost `written_storage_keys` with the process AND rolled back the dataset
+    # id the keys embed. It now preselects that id and records the intended
+    # keys on the job row first, the way `ingest_raster` does. Most of the
+    # growth is the comment saying why the id is decided outside phase 2.
+    # Cap 1530 -> 1568, exact.
+    "backend/app/processing/ingest/tasks_vrt.py": 1568,
     # fix(#1202 review r5): +29 — sweep the presigned staging key at job end.
     # A completed presigned job points file_path at its frozen copy, so this
     # reaper never touched the key the client's PUT URL can still recreate.

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -3433,7 +3433,16 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # migration, plus the two residual gaps it records (the one-statement
     # window between a door's own commit and the stamp, and S3-mode direct
     # uploads landing in the bound half). Cap 1827 -> 1857, exact.
-    "backend/app/platform/jobs/sweep.py": 1857,
+    # fix(#1778): +134. Two out-of-process reapers for artifacts a hard kill
+    # used to strand forever. `unpublished_storage_keys_from_metadata` reads the
+    # `rasters/`/`originals/` keys a raster tail named on its own job row before
+    # writing them, and `unadopted_analysis_table_from_metadata` plus
+    # `_reap_unadopted_analysis_outputs` do the same for an analysis output
+    # table; both are collected in `fail_stale_jobs` and deleted only after its
+    # commit, alongside the existing stale-generation keys. Roughly half of it
+    # is the docstrings stating why neither reap needs a survivor query and why
+    # the analysis one takes its own session. Cap 1857 -> 1991, exact.
+    "backend/app/platform/jobs/sweep.py": 1991,
     # fix(#1709 review r8 B): first entry — crossed the 1000-line inclusion
     # threshold at 1010 when refresh.cancelled attribution was corrected to
     # name the CANCELLING user (cancel_active_run_for_job and
@@ -3904,7 +3913,13 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # stand-down that skipped it stranded bytes no row references and no quota
     # counts. `ingest_vrt` records that it has nothing to reap on that path.
     # Cap 1442 -> 1480, exact.
-    "backend/app/processing/ingest/tasks_vrt.py": 1480,
+    # fix(#1778): +16. The storage keys are registered before their puts
+    # rather than after (a cancelled put can have completed), the two in-thread
+    # source reads go through the safe-open-env wrappers in `raster/vrt.py`, and
+    # `create_vrt_dataset` accepts a caller-chosen dataset id so the manifest
+    # tail can name its object keys before phase 2 opens. Cap 1480 -> 1496,
+    # exact.
+    "backend/app/processing/ingest/tasks_vrt.py": 1496,
     # fix(#1202 review r5): +29 — sweep the presigned staging key at job end.
     # A completed presigned job points file_path at its frozen copy, so this
     # reaper never touched the key the client's PUT URL can still recreate.

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -3493,7 +3493,22 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # field only once nothing is owed on it, which is a correlated statement
     # rather than an operator, and the comment says why the binds are cast and
     # why it uses jsonb_exists_any over `?|`. Cap 2302 -> 2328, exact.
-    "backend/app/platform/jobs/sweep.py": 2328,
+    # fix(#1778 codex r10): +46. The analysis output record now accumulates
+    # across attempts too (same shape `unpublished_storage_keys` took in r9),
+    # keyed and cleared by TABLE NAME rather than by job id, because a job
+    # can now name more than one table. `unadopted_analysis_table_from_metadata`
+    # became `unadopted_analysis_tables_from_metadata`, delegating to the
+    # writer's own normaliser so the two cannot disagree about the shape. The
+    # two artifact collections that used to run inside `fail_stale_jobs`
+    # (running-row transitions, and the retention purge's exempted-rows
+    # SELECT) are replaced by one unconditional SELECT after the retention
+    # block, because both could miss a row that owed a reap -- a job that
+    # failed on an earlier pass, or one whose dead attempt's keys were carried
+    # over onto a row that is now its dataset's latest complete job and so
+    # exempt from the purge. `_CLEAR_SETTLED_LIST_SQL` also gained an arm for
+    # the field's pre-PR plain-string shape, which the array-only WHERE clause
+    # had silently excluded from ever clearing. Cap 2328 -> 2374, exact.
+    "backend/app/platform/jobs/sweep.py": 2374,
     # fix(#1709 review r8 B): first entry — crossed the 1000-line inclusion
     # threshold at 1010 when refresh.cancelled attribution was corrected to
     # name the CANCELLING user (cancel_active_run_for_job and
@@ -4530,7 +4545,20 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # keyword with no default: the in-worker handlers pass their own id either
     # way, so an optional one would have bought nothing but a way to forget it.
     # Cap 1495 -> 1580, exact.
-    "backend/app/processing/analysis/tasks.py": 1580,
+    # fix(#1778 codex r10): +122. The scope grows an attempt half — job scoping
+    # alone left a retry able to derive the same name as its predecessor, since
+    # `/jobs/{id}/retry` keeps `IngestJob.id` and only mints a new attempt
+    # token. `analysis_output_table_name` takes both now, and the record
+    # accumulates across attempts (`recorded_analysis_output_tables`,
+    # `append_analysis_output_record`) rather than overwriting, the shape
+    # `unpublished_storage_keys` took in r9 and for the same reason: overwriting
+    # a retry's own field dropped the previous attempt's pointer. The other
+    # half of the growth is `resolve_analysis_output_table`, which
+    # collision-checks the SCOPED candidate against pg_class directly —
+    # `generate_table_name`'s own `_N` walk only ever probed the unscoped base,
+    # so it could hand back a name that scoped straight onto an orphan a
+    # previous attempt of the same job left behind. Cap 1580 -> 1702, exact.
+    "backend/app/processing/analysis/tasks.py": 1702,
     # Tenant-owned media now crosses the shared logical-to-physical storage
     # seam; explicit storage-failure responses keep the runtime/OpenAPI contract
     # aligned. Keep the ratchet exact after the import/decorator expansion.

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -3464,9 +3464,18 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # so a job that failed on its own and whose best-effort cleanup then failed
     # once had nothing left looking at it. Its DELETE ... RETURNING already
     # carried `user_metadata`; the rows now feed the same two post-commit reaps
-    # the running-row sweep feeds, survivor checks included. Cap 2077 -> 2100,
-    # exact.
-    "backend/app/platform/jobs/sweep.py": 2100,
+    # the running-row sweep feeds, survivor checks included. Cap 2077 -> 2100.
+    # fix(#1778 codex r5): +152. Feeding the reap was not enough, because the
+    # reap runs after the commit and can fail as a whole, and by then the
+    # pointer is gone. The purge now refuses to delete a row that still names
+    # an unreaped artifact, which makes the job row the durable pending-reap
+    # record a retry needs without a new table, and both reapers clear that
+    # record once they have a final answer (deleted, or refused because a live
+    # row names it) so the next pass can purge the row. The survivor query also
+    # went from four IN clauses to one shared array bind, because four binds
+    # per key crossed asyncpg's 32767-argument ceiling at about 8192 keys and
+    # the resulting failure skipped every delete. Cap 2100 -> 2252, exact.
+    "backend/app/platform/jobs/sweep.py": 2252,
     # fix(#1709 review r8 B): first entry — crossed the 1000-line inclusion
     # threshold at 1010 when refresh.cancelled attribution was corrected to
     # name the CANCELLING user (cancel_active_run_for_job and

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -3158,7 +3158,17 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # behind a lock the row's own later write would never see (e.g. an
     # ACCESS EXCLUSIVE table lock). `None` by default, so every other caller
     # of this shared helper is unchanged. Cap 2426 -> 2447, exact.
-    "backend/app/processing/ingest/tasks_common.py": 2447,
+    # fix(#1778 audit r11): +23, rebased onto the above rather than the 2426
+    # baseline it was originally measured against. `_job_phase_session` also
+    # gains `require_status`, an independent optional status predicate that
+    # joins the attempt fence, addressing a coexisting gap: an (id, attempt)
+    # -only match still admitted a row the stale sweep had already failed on
+    # a heartbeat timeout, with no retry having rotated the attempt token
+    # yet, so a worker only paused could resume and write whatever that
+    # phase writes. The two parameters are independent and both now live on
+    # the same signature. Almost all of the growth is the docstring stating
+    # which phases must pass which. Cap 2447 -> 2470, exact.
+    "backend/app/processing/ingest/tasks_common.py": 2470,
     # --- entered by the inclusion rule, feat(#1219 x #1222) ---------------
     # tasks_reupload crossed 1000 when two independently-reviewed features
     # met in one file: #1222's failed-contact bookkeeping (spawn-armed
@@ -4004,7 +4014,16 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # attempt, so it returns before generating quicklooks or ever reaching
     # phase 2, instead of relying on phase 2's own attempt-fenced load to
     # catch it downstream. Cap 1568 -> 1575, exact.
-    "backend/app/processing/ingest/tasks_vrt.py": 1575,
+    # fix(#1778 audit r11): +25. Neither of this file's two "phase 2" blocks
+    # goes through `_job_phase_session` (they predate the helper and match
+    # the fence by hand), so both gain `IngestJob.status == "running"`
+    # directly in their own SELECT, matching the sibling tails. The
+    # `ingest_vrt` one closes the same object-storage leak the other raster
+    # tails' phase 2 does; the `regenerate_vrt` one closes a job-completion
+    # race the existing `current_generation_id` check does not cover, since
+    # that field lives on a different row than `ingest_jobs.status` and the
+    # sweep never touches it. Cap 1575 -> 1600, exact.
+    "backend/app/processing/ingest/tasks_vrt.py": 1600,
     # fix(#1202 review r5): +29 — sweep the presigned staging key at job end.
     # A completed presigned job points file_path at its frozen copy, so this
     # reaper never touched the key the client's PUT URL can still recreate.
@@ -4112,7 +4131,17 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # attempt-fenced shape `_finalize_ingest` already uses via
     # `require_ingest_job_update`; zero rows affected logs at debug and does
     # nothing. Cap 1284 -> 1333, exact.
-    "backend/app/processing/ingest/tasks_vector.py": 1333,
+    # fix(#1778 audit r11): +23, rebased onto the above rather than the 1161
+    # baseline it was originally measured against. Both of this file's
+    # "phase 2" call sites (`ingest_file`, `ingest_service`) gain
+    # `require_status="running"` on their `_job_phase_session` load. Neither
+    # writes an untracked storage object -- each phase's own terminal write
+    # already fences on status via `require_ingest_job_update`, so a
+    # fenced-out attempt cannot resurrect a failed row -- but this stops a
+    # paused, not-dead worker from running the whole finalize pipeline
+    # against a doomed row in the first place, for consistency with the
+    # raster tails. Cap 1333 -> 1356, exact.
+    "backend/app/processing/ingest/tasks_vector.py": 1356,
     # --- entered by the inclusion rule ------------------------------------
     # Crossed 1000 lines adding the "unable to open datasource" friendly-
     # message mapping shared by run_ogrinfo and run_ogr2ogr: the pattern
@@ -4564,7 +4593,16 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # `generate_table_name`'s own `_N` walk only ever probed the unscoped base,
     # so it could hand back a name that scoped straight onto an orphan a
     # previous attempt of the same job left behind. Cap 1580 -> 1702, exact.
-    "backend/app/processing/analysis/tasks.py": 1702,
+    # fix(#1778 audit r11): +23. `analysis_output_table_name` takes an
+    # optional `collision_suffix` now instead of the caller pre-pending `_N`
+    # to `base` and calling it again -- the second trim of an already-trimmed
+    # string threw away the very characters that made one candidate differ
+    # from the next, so a `base` at or past the reservation point made every
+    # walked suffix identical and exhausted the whole `_N` walk instead of
+    # self-healing. The tag is reserved for up front, in the same limit
+    # computation as the scope, the idiom `generate_table_name`'s own
+    # `_with_collision_suffix` already uses. Cap 1702 -> 1725, exact.
+    "backend/app/processing/analysis/tasks.py": 1725,
     # Tenant-owned media now crosses the shared logical-to-physical storage
     # seam; explicit storage-failure responses keep the runtime/OpenAPI contract
     # aligned. Keep the ratchet exact after the import/decorator expansion.

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -3168,7 +3168,14 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # phase writes. The two parameters are independent and both now live on
     # the same signature. Almost all of the growth is the docstring stating
     # which phases must pass which. Cap 2447 -> 2470, exact.
-    "backend/app/processing/ingest/tasks_common.py": 2470,
+    # fix(#1778 audit r12): +25. `require_status`'s SELECT now takes `FOR NO
+    # KEY UPDATE`, closing the TOCTOU a plain status check left open: the
+    # sweep could still fail a row in the window between the read and the
+    # phase's first put, since a SELECT is not a lock. Most of the growth is
+    # the docstring stating why `NO KEY UPDATE` over plain `UPDATE`, and
+    # pointing at the sweep-side fixes that now have to contend with this
+    # lock instead of racing past it. Cap 2470 -> 2495, exact.
+    "backend/app/processing/ingest/tasks_common.py": 2495,
     # --- entered by the inclusion rule, feat(#1219 x #1222) ---------------
     # tasks_reupload crossed 1000 when two independently-reviewed features
     # met in one file: #1222's failed-contact bookkeeping (spawn-armed
@@ -3518,7 +3525,15 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # exempt from the purge. `_CLEAR_SETTLED_LIST_SQL` also gained an arm for
     # the field's pre-PR plain-string shape, which the array-only WHERE clause
     # had silently excluded from ever clearing. Cap 2328 -> 2374, exact.
-    "backend/app/platform/jobs/sweep.py": 2374,
+    # fix(#1778 audit r12): +18. The running-jobs UPDATE now reads its
+    # candidates through a `FOR UPDATE SKIP LOCKED` subquery instead of
+    # matching them directly in the UPDATE's own WHERE clause, so a row a
+    # live phase-2 transaction holds locked is excluded from the pass
+    # instead of blocking it, or, if this were guarded by a `lock_timeout`
+    # instead, aborting the entire batch on one busy row. Most of the growth
+    # is the comment stating why a set-based UPDATE cannot use `lock_timeout`
+    # the way a single-row write does. Cap 2374 -> 2392, exact.
+    "backend/app/platform/jobs/sweep.py": 2392,
     # fix(#1709 review r8 B): first entry — crossed the 1000-line inclusion
     # threshold at 1010 when refresh.cancelled attribution was corrected to
     # name the CANCELLING user (cancel_active_run_for_job and
@@ -4023,7 +4038,17 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # race the existing `current_generation_id` check does not cover, since
     # that field lives on a different row than `ingest_jobs.status` and the
     # sweep never touches it. Cap 1575 -> 1600, exact.
-    "backend/app/processing/ingest/tasks_vrt.py": 1600,
+    # fix(#1778 audit r12): +28. `ingest_vrt`'s hand-matched phase-2 SELECT
+    # gains `.with_for_update(key_share=True)`, the same TOCTOU close as the
+    # other two raster tails, since its puts sit inside this same session
+    # exactly like theirs do. `regenerate_vrt`'s own phase-2 SELECT is
+    # deliberately left unlocked -- most of the growth here is the comment
+    # explaining why: it loads the job row before a RasterAsset row a few
+    # lines down, and `cancel_job` locks those two in the opposite order for
+    # a vrt_regenerate job specifically to avoid an AB-BA deadlock with this
+    # worker, so locking the job row here first would reopen that cycle. Cap
+    # 1600 -> 1628, exact.
+    "backend/app/processing/ingest/tasks_vrt.py": 1628,
     # fix(#1202 review r5): +29 — sweep the presigned staging key at job end.
     # A completed presigned job points file_path at its frozen copy, so this
     # reaper never touched the key the client's PUT URL can still recreate.

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -3934,9 +3934,16 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # rather than after (a cancelled put can have completed), the two in-thread
     # source reads go through the safe-open-env wrappers in `raster/vrt.py`, and
     # `create_vrt_dataset` accepts a caller-chosen dataset id so the manifest
-    # tail can name its object keys before phase 2 opens. Cap 1480 -> 1496,
+    # tail can name its object keys before phase 2 opens. Cap 1480 -> 1496.
+    # fix(#1778 codex r3): +34. The two safe-env wrappers moved here from
+    # `raster/vrt.py` and call `extract_raster_metadata` / `generate_quicklook`
+    # through this module's globals. Those two names are patch targets for the
+    # VRT integration and source-management suites, and putting the wrappers in
+    # `raster/vrt.py` with function-level imports removed the attributes AND
+    # would have made the patches no-ops once restored. The docstrings say so,
+    # because the next reader will want to move them back. Cap 1496 -> 1530,
     # exact.
-    "backend/app/processing/ingest/tasks_vrt.py": 1496,
+    "backend/app/processing/ingest/tasks_vrt.py": 1530,
     # fix(#1202 review r5): +29 — sweep the presigned staging key at job end.
     # A completed presigned job points file_path at its frozen copy, so this
     # reaper never touched the key the client's PUT URL can still recreate.

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -3486,8 +3486,14 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # rather than on a table name two jobs could hold in sequence: it carries
     # (job, table) pairs, hands the owner to the drop so it can refuse a table
     # that job did not create, and clears the record by row id. Cap 2288 ->
-    # 2302, exact.
-    "backend/app/platform/jobs/sweep.py": 2302,
+    # 2302.
+    # fix(#1778 codex r9): +26. The storage-key record accumulates across
+    # attempts now, so clearing it wholesale would forget keys the pass never
+    # answered for. The clear removes the settled keys one by one and drops the
+    # field only once nothing is owed on it, which is a correlated statement
+    # rather than an operator, and the comment says why the binds are cast and
+    # why it uses jsonb_exists_any over `?|`. Cap 2302 -> 2328, exact.
+    "backend/app/platform/jobs/sweep.py": 2328,
     # fix(#1709 review r8 B): first entry — crossed the 1000-line inclusion
     # threshold at 1010 when refresh.cancelled attribution was corrected to
     # name the CANCELLING user (cancel_active_run_for_job and

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1701,7 +1701,16 @@ def test_decomposed_service_modules_stay_within_size_budgets() -> None:
         # client-side grid-alignment check can compare each axis
         # independently, matching the backend's _check_grid_alignment.
         # Cap 539 -> 548, exact.
-        "backend/app/modules/catalog/search/service_records.py": 548,
+        # fix(#1778): +11, rebased onto the above rather than the 526 baseline
+        # it was originally measured against. The band array now builds
+        # through the shared `app.core.raster_bands` normalisers, so this
+        # representation stops dropping the colour-interpretation name of
+        # every locally ingested raster (it read a `name` key no producer
+        # writes) and stops emitting empty band entries for a remotely
+        # described COG, while keeping the round-4-P2 explicit-null case
+        # above (moved to sit beside the normaliser call it now depends on).
+        # Cap 548 -> 559, exact.
+        "backend/app/modules/catalog/search/service_records.py": 559,
         # fix(#448): +~40 LOC — query-embedding hot-path deadline (asyncio.wait_for
         # wrapper) + the gated/approximated vector-only match COUNT in
         # _run_rrf_merge (perf audit 2026-07-10 §2d). Cap 350 → 390

--- a/backend/tests/test_raster_object_ownership_1778.py
+++ b/backend/tests/test_raster_object_ownership_1778.py
@@ -765,6 +765,9 @@ class TestRetentionPurgeIsTheLastOwner:
                 "app.platform.jobs.sweep._reap_unadopted_analysis_outputs",
                 analysis_reap,
             ),
+            patch(
+                "app.platform.jobs.sweep._clear_settled_artifact_records", AsyncMock()
+            ),
         ):
             outcome = await fail_stale_jobs(mock_db, detailed=True)
 
@@ -800,6 +803,9 @@ class TestRetentionPurgeIsTheLastOwner:
                 "app.platform.jobs.sweep._live_referenced_storage_keys",
                 AsyncMock(return_value={self.KEY}),
             ),
+            patch(
+                "app.platform.jobs.sweep._clear_settled_artifact_records", AsyncMock()
+            ),
         ):
             outcome = await fail_stale_jobs(mock_db, detailed=True)
 
@@ -832,6 +838,277 @@ class TestRetentionPurgeIsTheLastOwner:
             await fail_stale_jobs(mock_db, detailed=True)
 
         storage.delete.assert_not_awaited()
+
+
+class TestReapScalesAndStaysRetryable:
+    """fix(#1778 codex r5): the two ways a whole sweep's worth of keys was lost.
+
+    The survivor query expanded its key list into four `IN` clauses, so its
+    argument count was four per key. Past roughly 8192 keys that crosses
+    asyncpg's 32767-argument ceiling, the query raises, and the reaper's own
+    "an unreadable catalog deletes nothing" rule skips every delete. That rule
+    is right, but the retention purge had already committed the deletion of the
+    rows that were those keys' last durable owners, so the objects leaked for
+    good.
+    """
+
+    @pytest.mark.anyio
+    async def test_ten_thousand_keys_run_as_one_argument(self, test_db_session) -> None:
+        """Against real Postgres, so the argument ceiling is the real one.
+
+        The survivor check has to still work at this size, not merely not
+        raise: the live key is planted among ten thousand orphans and has to
+        come back.
+        """
+        from app.modules.catalog.datasets.domain.models import Dataset, Record
+        from app.platform.jobs.sweep import _live_referenced_storage_keys
+        from app.processing.raster.models import RasterAsset
+
+        record = Record(
+            title="live raster",
+            visibility="private",
+            record_status="published",
+            record_type="raster_dataset",
+        )
+        test_db_session.add(record)
+        await test_db_session.flush()
+        dataset = Dataset(
+            record_id=record.id,
+            table_name=f"ds_{uuid.uuid4().hex[:12]}",
+            srid=4326,
+            source_format="geotiff",
+        )
+        test_db_session.add(dataset)
+        await test_db_session.flush()
+        live_key = f"rasters/{dataset.id}/attempts/live/abc/source.cog.tif"
+        test_db_session.add(
+            RasterAsset(
+                dataset_id=dataset.id,
+                asset_uri=live_key,
+                storage_backend="local",
+            )
+        )
+        await test_db_session.commit()
+
+        keys = tuple(
+            [
+                f"rasters/{dataset.id}/attempts/dead-{i}/abc/source.cog.tif"
+                for i in range(10_000)
+            ]
+            + [live_key]
+        )
+        assert len(keys) * 4 > 32_767, "the case has to exceed the bind ceiling"
+
+        live = await _live_referenced_storage_keys(keys)
+
+        assert live == {live_key}
+
+    @pytest.mark.asyncio
+    async def test_duplicate_keys_are_deleted_once(self) -> None:
+        from app.platform.jobs.sweep import reap_unpublished_storage_keys
+
+        key = "rasters/ds/attempts/a/abc/source.cog.tif"
+        storage = MagicMock()
+        storage.delete = AsyncMock()
+        with (
+            patch("app.platform.storage.get_storage", return_value=storage),
+            patch(
+                "app.platform.jobs.sweep._live_referenced_storage_keys",
+                AsyncMock(return_value=set()),
+            ),
+            patch(
+                "app.platform.jobs.sweep._clear_settled_artifact_records", AsyncMock()
+            ),
+        ):
+            reaped, skipped, failures = await reap_unpublished_storage_keys(
+                (key, key, key)
+            )
+
+        assert (reaped, skipped, failures) == (1, 0, 0)
+        assert storage.delete.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_the_purge_will_not_delete_a_row_that_still_owns_an_artifact(
+        self, monkeypatch
+    ) -> None:
+        """The durable pending-reap record, and why it is the job row.
+
+        The reap runs after this function's commit and can fail as a whole. If
+        the purge had already deleted the row, the pointer is gone and the
+        objects leak; keeping the row until the artifacts are accounted for
+        makes the failure retryable and costs no new table.
+        """
+        from sqlalchemy.sql.dml import Delete
+
+        from app.core.config import settings
+        from app.platform.jobs.sweep import fail_stale_jobs
+
+        monkeypatch.setattr(settings, "ingest_jobs_retention_days", 30)
+        mock_db = _mock_db_for_fail_stale(
+            running_rows=[],
+            purged_rows=[
+                (
+                    uuid.uuid4(),
+                    None,
+                    {"unpublished_storage_keys": ["rasters/a/attempts/b/c/x.tif"]},
+                )
+            ],
+        )
+        storage = MagicMock()
+        storage.delete = AsyncMock()
+        with (
+            patch("app.platform.storage.get_storage", return_value=storage),
+            patch(
+                "app.platform.jobs.sweep._live_referenced_storage_keys",
+                AsyncMock(return_value=set()),
+            ),
+            patch(
+                "app.platform.jobs.sweep._clear_settled_artifact_records", AsyncMock()
+            ),
+        ):
+            await fail_stale_jobs(mock_db, detailed=True)
+
+        deletes = [
+            call.args[0]
+            for call in mock_db.execute.await_args_list
+            if isinstance(call.args[0], Delete)
+        ]
+        assert len(deletes) == 1
+        where_sql = str(deletes[0].compile(compile_kwargs={"literal_binds": True}))
+        assert "unpublished_storage_keys" in where_sql, (
+            "the purge must exempt rows that still name an unreaped artifact, "
+            "got: " + where_sql
+        )
+        assert "analysis_out_table" in where_sql
+
+    @pytest.mark.asyncio
+    async def test_a_delete_that_raised_keeps_its_record(self) -> None:
+        """Only a final answer clears the row, and an error is not one."""
+        from app.platform.jobs.sweep import reap_unpublished_storage_keys
+
+        settled = AsyncMock()
+        good = "rasters/ds/attempts/a/abc/quicklook_256.png"
+        bad = "rasters/ds/attempts/a/abc/source.cog.tif"
+        storage = MagicMock()
+        storage.delete = AsyncMock(
+            side_effect=lambda key: (
+                (_ for _ in ()).throw(RuntimeError("no")) if key == bad else None
+            )
+        )
+        with (
+            patch("app.platform.storage.get_storage", return_value=storage),
+            patch(
+                "app.platform.jobs.sweep._live_referenced_storage_keys",
+                AsyncMock(return_value=set()),
+            ),
+            patch("app.platform.jobs.sweep._clear_settled_artifact_records", settled),
+        ):
+            reaped, skipped, failures = await reap_unpublished_storage_keys((good, bad))
+
+        assert (reaped, skipped, failures) == (1, 0, 1)
+        settled.assert_awaited_once_with(storage_keys={good})
+
+    @pytest.mark.asyncio
+    async def test_a_refused_key_still_clears_its_record(self) -> None:
+        """Refusing is a final answer too.
+
+        A key a live row names is refused on every pass. Leaving it on the
+        record would pin the job row for the life of the dataset.
+        """
+        from app.platform.jobs.sweep import reap_unpublished_storage_keys
+
+        settled = AsyncMock()
+        key = "rasters/ds/attempts/a/abc/source.cog.tif"
+        storage = MagicMock()
+        storage.delete = AsyncMock()
+        with (
+            patch("app.platform.storage.get_storage", return_value=storage),
+            patch(
+                "app.platform.jobs.sweep._live_referenced_storage_keys",
+                AsyncMock(return_value={key}),
+            ),
+            patch("app.platform.jobs.sweep._clear_settled_artifact_records", settled),
+        ):
+            await reap_unpublished_storage_keys((key,))
+
+        storage.delete.assert_not_awaited()
+        settled.assert_awaited_once_with(storage_keys={key})
+
+    @pytest.mark.asyncio
+    async def test_a_failed_survivor_query_clears_nothing(self) -> None:
+        from app.platform.jobs.sweep import reap_unpublished_storage_keys
+
+        settled = AsyncMock()
+        with (
+            patch(
+                "app.platform.jobs.sweep._live_referenced_storage_keys",
+                AsyncMock(side_effect=RuntimeError("catalog unreadable")),
+            ),
+            patch("app.platform.jobs.sweep._clear_settled_artifact_records", settled),
+        ):
+            reaped, skipped, failures = await reap_unpublished_storage_keys(
+                ("rasters/ds/attempts/a/abc/source.cog.tif",)
+            )
+
+        assert (reaped, skipped, failures) == (0, 1, 0)
+        settled.assert_not_awaited()
+
+    @pytest.mark.anyio
+    async def test_clearing_takes_the_record_off_only_a_fully_settled_row(
+        self, test_db_session
+    ) -> None:
+        """Against real Postgres: the containment test and the key removal.
+
+        A row names all three of its objects at once, so clearing the field
+        while one is unresolved would drop the other two from the record with
+        it.
+        """
+        from sqlalchemy import select
+
+        from app.platform.jobs.models import IngestJob
+        from app.platform.jobs.sweep import _clear_settled_artifact_records
+
+        done = IngestJob(
+            status="failed",
+            file_path="",
+            user_metadata={
+                "unpublished_storage_keys": ["rasters/a/x.tif", "rasters/a/y.png"],
+                "keep_me": True,
+            },
+        )
+        partial = IngestJob(
+            status="failed",
+            file_path="",
+            user_metadata={
+                "unpublished_storage_keys": ["rasters/a/x.tif", "rasters/b/z.tif"]
+            },
+        )
+        test_db_session.add_all([done, partial])
+        await test_db_session.flush()
+        # Snapshotted before the commit: it expires every instance, and the
+        # next attribute read would be lazy I/O on an async session.
+        done_id, partial_id = done.id, partial.id
+        await test_db_session.commit()
+
+        await _clear_settled_artifact_records(
+            storage_keys={"rasters/a/x.tif", "rasters/a/y.png"}
+        )
+
+        test_db_session.expire_all()
+        rows = {
+            row.id: row.user_metadata
+            for row in (
+                await test_db_session.execute(
+                    select(IngestJob).where(IngestJob.id.in_([done_id, partial_id]))
+                )
+            ).scalars()
+        }
+        assert rows[done_id] == {"keep_me": True}, (
+            "a fully settled row loses the record and keeps everything else"
+        )
+        assert "unpublished_storage_keys" in rows[partial_id], (
+            "a row with an unsettled key keeps its whole record for the retry"
+        )
 
 
 def _mock_db_for_fail_stale(
@@ -874,8 +1151,15 @@ def _mock_db_for_fail_stale(
         result.scalars.return_value = []
         results.append(result)
 
+    # fix(#1778 codex r5): the exempted-row SELECT the purge issues first.
+    # These fixtures drive the reaps through it rather than through the DELETE,
+    # because a row that still names an artifact is deliberately NOT deleted.
+    retained = MagicMock()
+    retained.scalars.return_value = [um for (_id, _fp, um) in (purged_rows or [])]
+    results.append(retained)
+
     purge = MagicMock()
-    purge.all.return_value = list(purged_rows or [])
+    purge.all.return_value = []
     results.append(purge)
     # fix(#1778 codex r4): the purge only issues its survivor SELECT when a
     # deleted row carried a file_path, and these fixtures carry none.

--- a/backend/tests/test_raster_object_ownership_1778.py
+++ b/backend/tests/test_raster_object_ownership_1778.py
@@ -236,6 +236,7 @@ class TestIdenticalReplacementKeepsTheLiveAsset:
                 uuid.uuid4(),
                 keys=list(self.LIVE),
                 already_published=self.LIVE,
+                attempt_scope="dataset-1",
                 job_id="j",
                 task="reupload_raster",
             )
@@ -258,6 +259,7 @@ class TestIdenticalReplacementKeepsTheLiveAsset:
                 uuid.uuid4(),
                 keys=[fresh, *self.LIVE],
                 already_published=self.LIVE,
+                attempt_scope="dataset-1",
                 job_id="j",
                 task="reupload_raster",
             )
@@ -403,6 +405,156 @@ class TestLiveReferenceQuery:
             original,
         }
         assert orphan not in live
+
+
+class TestAttemptScopedReplaceKeys:
+    """fix(#1778 codex r3): the reaper's TOCTOU against a re-admitted replace.
+
+    `fail_stale_jobs` commits once, and that commit settles the dead attempt
+    AND releases the dataset's active-run reservation through the refresh-run
+    sweep. The post-commit cleanup then runs with the door open: a replacement
+    can be admitted, and while the reaper is between its survivor snapshot and
+    its delete, that new attempt can write objects no row names yet. With keys
+    derived from dataset id plus content hash alone, a retry of the same upload
+    derived the SAME keys, so the reaper deleted the new attempt's bytes and
+    the new attempt then committed a `RasterAsset` pointing at nothing.
+
+    Closed by the key layout rather than by ordering, which is what the VRT
+    publish path already does with `generations/{generation_id}/`. Ordering
+    fixes here would have had to survive every future caller of the reaper; a
+    key two attempts cannot both name has no window to order around.
+    """
+
+    DATASET = uuid.UUID("11111111-1111-1111-1111-111111111111")
+    SHA = "b" * 64
+
+    def _keys(self, attempt: uuid.UUID) -> list[str]:
+        from app.processing.ingest.tasks_raster_common import (
+            attempt_scoped_raster_base_key,
+        )
+
+        base = attempt_scoped_raster_base_key(self.DATASET, attempt, self.SHA)
+        return [
+            f"{base}/source.cog.tif",
+            f"{base}/quicklook_256.png",
+            f"{base}/quicklook_512.png",
+        ]
+
+    def test_two_attempts_of_the_same_upload_share_no_key(self) -> None:
+        """Identical dataset, identical bytes, identical conversion."""
+        first = self._keys(uuid.uuid4())
+        second = self._keys(uuid.uuid4())
+        assert set(first).isdisjoint(second)
+
+    def test_the_key_still_carries_the_content_hash(self) -> None:
+        """Invariant 10 rests on it: a replacement cannot overwrite in place."""
+        for key in self._keys(uuid.uuid4()):
+            assert self.SHA in key
+            assert key.startswith(f"rasters/{self.DATASET}/")
+
+    @pytest.mark.asyncio
+    async def test_a_replacement_admitted_mid_reap_keeps_its_objects(self) -> None:
+        """The review's scenario, end to end through the reaper.
+
+        The stale attempt's keys are reaped and the newly admitted attempt's
+        survive, even though nothing references either set at snapshot time.
+        """
+        from app.platform.jobs.sweep import reap_unpublished_storage_keys
+
+        stale = self._keys(uuid.uuid4())
+        admitted_mid_reap = self._keys(uuid.uuid4())
+
+        storage = MagicMock()
+        storage.delete = AsyncMock()
+        with (
+            patch("app.platform.storage.get_storage", return_value=storage),
+            # Neither set is referenced yet: the stale attempt rolled back and
+            # the new one has not committed its pointer.
+            patch(
+                "app.platform.jobs.sweep._live_referenced_storage_keys",
+                AsyncMock(return_value=set()),
+            ),
+        ):
+            reaped, skipped, failures = await reap_unpublished_storage_keys(
+                tuple(stale)
+            )
+
+        assert (reaped, skipped, failures) == (3, 0, 0)
+        deleted = {call.args[0] for call in storage.delete.await_args_list}
+        assert deleted == set(stale)
+        assert deleted.isdisjoint(admitted_mid_reap)
+
+    @pytest.mark.asyncio
+    async def test_a_key_outside_this_attempt_is_never_recorded(self) -> None:
+        """The rule the recorded set must satisfy for the reaper to be safe.
+
+        A future writer that derives a key two attempts can both name gets it
+        dropped here rather than discovering the collision from a deleted
+        raster.
+        """
+        from app.processing.ingest.tasks_raster_common import (
+            UNPUBLISHED_STORAGE_KEYS_FIELD,
+            record_unpublished_storage_keys,
+        )
+
+        attempt = uuid.uuid4()
+        mine = self._keys(attempt)
+        shared = f"rasters/{self.DATASET}/{self.SHA}/source.cog.tif"
+
+        session = AsyncMock()
+        maker = MagicMock()
+        maker.return_value.__aenter__ = AsyncMock(return_value=session)
+        maker.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("app.core.db.async_session", maker):
+            await record_unpublished_storage_keys(
+                uuid.uuid4(),
+                attempt,
+                keys=[*mine, shared],
+                already_published=(),
+                attempt_scope=str(attempt),
+                job_id="j",
+                task="reupload_raster",
+            )
+
+        session.execute.assert_awaited_once()
+        stmt = session.execute.await_args.args[0]
+        recorded = stmt.compile().params["unpublished_patch"]
+        assert recorded == {UNPUBLISHED_STORAGE_KEYS_FIELD: mine}
+
+    def test_the_replace_tail_derives_both_key_sets_from_the_one_helper(
+        self,
+    ) -> None:
+        """Recording one prefix and writing another would be silent."""
+        source = _source("processing/ingest/tasks_raster_replace.py")
+        # Exactly two calls: the durable record and the put block. A third
+        # would mean a third derivation to keep in step.
+        assert source.count("attempt_scoped_raster_base_key(") == 2
+        assert 'rasters/{dataset_uuid}/{asset_sha256}"' not in source
+        assert 'rasters/{dataset.id}/{asset_sha256}"' not in source
+
+    def test_the_first_ingest_tail_is_fenced_by_its_generated_dataset_id(
+        self,
+    ) -> None:
+        """Its keys need no attempt segment, and this is why."""
+        source = _source("processing/ingest/tasks_raster.py")
+        lines = source.splitlines()
+        generated = next(
+            i
+            for i, line in enumerate(lines)
+            if "planned_dataset_id = uuid.uuid4()" in line
+        )
+        used = next(
+            i
+            for i, line in enumerate(lines)
+            if i > generated and '_base_key = f"rasters/{planned_dataset_id}/' in line
+        )
+        scoped = next(
+            i
+            for i, line in enumerate(lines)
+            if i > used and "attempt_scope=str(planned_dataset_id)" in line
+        )
+        assert generated < used < scoped
 
 
 def _mock_db_for_fail_stale(*, running_rows: list) -> AsyncMock:

--- a/backend/tests/test_raster_object_ownership_1778.py
+++ b/backend/tests/test_raster_object_ownership_1778.py
@@ -1,0 +1,239 @@
+"""Codebase audit 2026-08-30, pre-commit raster objects (tracked in #1778).
+
+Two findings that share one subject, the ownership of an object written
+before the transaction that would publish it:
+
+- The COG, VRT and quicklook puts registered their key AFTER the write, so a
+  cancelled put that had already completed (both storage providers drain the
+  worker thread before re-raising) left an object nothing could name.
+- Objects written under ``rasters/`` and ``originals/`` before the terminal
+  commit had no out-of-process reaper, unlike the VRT generation prefix.
+"""
+
+import uuid
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+APP = Path(__file__).resolve().parents[1] / "app"
+
+
+def _source(rel: str) -> str:
+    return (APP / rel).read_text()
+
+
+class TestRegisterBeforeWrite:
+    """Every ``written_storage_keys.append`` precedes the put it describes."""
+
+    # (module, key expression) for each managed object a raster tail writes
+    # before its terminal commit.
+    SITES = [
+        ("processing/ingest/tasks_raster.py", "_storage_cog_key"),
+        ("processing/ingest/tasks_raster.py", "_storage_ql256_key"),
+        ("processing/ingest/tasks_raster.py", "_storage_ql512_key"),
+        ("processing/ingest/tasks_raster_replace.py", "_storage_cog_key"),
+        ("processing/ingest/tasks_raster_replace.py", "_storage_ql256_key"),
+        ("processing/ingest/tasks_raster_replace.py", "_storage_ql512_key"),
+        ("processing/ingest/tasks_vrt.py", "_storage_vrt_key"),
+        ("processing/ingest/tasks_vrt.py", "_storage_ql256_key"),
+        ("processing/ingest/tasks_vrt.py", "_storage_ql512_key"),
+        ("processing/ingest/tasks_vrt.py", "next_vrt_physical_key"),
+        ("processing/ingest/tasks_vrt.py", "next_ql256_physical_key"),
+        ("processing/ingest/tasks_vrt.py", "next_ql512_physical_key"),
+    ]
+
+    @pytest.mark.parametrize("module,key", SITES)
+    def test_key_is_registered_before_its_put(self, module: str, key: str) -> None:
+        lines = _source(module).splitlines()
+        appends = [
+            i
+            for i, line in enumerate(lines)
+            if f"written_storage_keys.append({key})" in line
+        ]
+        puts = [i for i, line in enumerate(lines) if f"storage.put({key}" in line]
+        assert len(appends) == 1, f"{module}: {key} registered {len(appends)} times"
+        assert len(puts) == 1, f"{module}: {key} put {len(puts)} times"
+        assert appends[0] < puts[0], (
+            f"{module}: {key} is registered after its put. A cancelled put can "
+            "have completed on the provider, and CancelledError is a "
+            "BaseException, so nothing below the put runs and the finished "
+            "object is left with no reference."
+        )
+
+
+class TestUnpublishedStorageKeys:
+    def test_both_raster_tails_record_their_keys_before_phase_2(self) -> None:
+        """The write has to precede the phase-2 session, not sit inside it.
+
+        Phase 2's first statements dirty the ingest_jobs row, so a second
+        session writing that row while phase 2 held it would block until phase
+        2 ended, and phase 2 would be waiting on the write.
+        """
+        for module in (
+            "processing/ingest/tasks_raster.py",
+            "processing/ingest/tasks_raster_replace.py",
+        ):
+            lines = _source(module).splitlines()
+            record = next(
+                (
+                    i
+                    for i, line in enumerate(lines)
+                    if "await record_unpublished_storage_keys(" in line
+                ),
+                None,
+            )
+            assert record is not None, f"{module} never records its keys"
+            phase2 = next(i for i, line in enumerate(lines) if 'phase="phase2"' in line)
+            assert record < phase2, f"{module} records its keys inside phase 2"
+
+    @pytest.mark.parametrize(
+        "metadata,expected",
+        [
+            (None, ()),
+            ({}, ()),
+            ({"unpublished_storage_keys": "rasters/x/y"}, ()),
+            ({"unpublished_storage_keys": [1, None]}, ()),
+            # Only the two managed prefixes, and no traversal: the value comes
+            # out of a schemaless JSONB blob and drives a delete.
+            ({"unpublished_storage_keys": ["staging/a/b"]}, ()),
+            ({"unpublished_storage_keys": ["rasters/../secrets"]}, ()),
+            (
+                {"unpublished_storage_keys": ["rasters/a/b.tif", "originals/a/c"]},
+                ("rasters/a/b.tif", "originals/a/c"),
+            ),
+        ],
+    )
+    def test_only_managed_keys_are_read_back(self, metadata, expected) -> None:
+        from app.platform.jobs.sweep import unpublished_storage_keys_from_metadata
+
+        assert unpublished_storage_keys_from_metadata(metadata) == expected
+
+    @pytest.mark.asyncio
+    async def test_the_post_commit_reap_deletes_them(self) -> None:
+        from app.platform.jobs.sweep import (
+            StaleCleanupOutcome,
+            _reap_committed_staged_paths,
+        )
+
+        outcome = StaleCleanupOutcome(
+            pending_failed=0,
+            running_failed=1,
+            vrt_assets_recovered=0,
+            vrt_generations_failed=0,
+            terminal_jobs_purged=0,
+            staged_paths_considered=0,
+            local_files_reaped=0,
+            storage_objects_reaped=0,
+            staged_paths_skipped=0,
+            staged_cleanup_failures=0,
+            _unpublished_storage_keys=(
+                "rasters/d/abc/source.cog.tif",
+                "originals/d/abc",
+            ),
+        )
+        storage = MagicMock()
+        storage.delete = AsyncMock()
+        with patch("app.platform.storage.get_storage", return_value=storage):
+            result = await _reap_committed_staged_paths(outcome)
+
+        assert result.storage_objects_reaped == 2
+        assert {call.args[0] for call in storage.delete.await_args_list} == {
+            "rasters/d/abc/source.cog.tif",
+            "originals/d/abc",
+        }
+
+    @pytest.mark.asyncio
+    async def test_fail_stale_jobs_carries_them_out_of_a_running_row(self) -> None:
+        """The keys reach the outcome, and only after the settling commit."""
+        from app.platform.jobs.sweep import fail_stale_jobs
+
+        keys = ["rasters/d/abc/source.cog.tif", "rasters/d/abc/quicklook_256.png"]
+        mock_db = _mock_db_for_fail_stale(
+            running_rows=[
+                (uuid.uuid4(), {"unpublished_storage_keys": keys}, None),
+            ]
+        )
+        storage = MagicMock()
+        storage.delete = AsyncMock()
+        with patch("app.platform.storage.get_storage", return_value=storage):
+            outcome = await fail_stale_jobs(mock_db, detailed=True)
+
+        assert outcome._unpublished_storage_keys == tuple(keys)
+        assert {call.args[0] for call in storage.delete.await_args_list} == set(keys)
+
+    @pytest.mark.asyncio
+    async def test_a_rolled_back_settle_deletes_nothing(self) -> None:
+        from app.platform.jobs.sweep import fail_stale_jobs
+
+        mock_db = _mock_db_for_fail_stale(
+            running_rows=[
+                (
+                    uuid.uuid4(),
+                    {"unpublished_storage_keys": ["rasters/d/abc/source.cog.tif"]},
+                    None,
+                ),
+            ]
+        )
+        mock_db.commit.side_effect = RuntimeError("commit failed")
+        storage = MagicMock()
+        storage.delete = AsyncMock()
+        with (
+            patch("app.platform.storage.get_storage", return_value=storage),
+            pytest.raises(RuntimeError, match="commit failed"),
+        ):
+            await fail_stale_jobs(mock_db, detailed=True)
+
+        storage.delete.assert_not_awaited()
+
+
+def _mock_db_for_fail_stale(*, running_rows: list) -> AsyncMock:
+    """A session double for ``fail_stale_jobs`` with real running-row metadata.
+
+    The peer helper in ``test_vrt_stale_sweep_gap002`` hands every job row a
+    ``None`` metadata blob, which is exactly the column these findings read, so
+    this states the same execute() ordering with the rows filled in. Ordering,
+    top to bottom: unbound pending UPDATE, bound pending UPDATE, running
+    UPDATE, childless fan-out UPDATE, VRT generation UPDATE, two RasterAsset
+    UPDATEs, two refresh-run UPDATEs, the retention purge DELETE, and the
+    post-expiry presigned SELECT.
+    """
+    results = []
+
+    unbound = MagicMock()
+    unbound.all.return_value = []
+    results.append(unbound)
+
+    bound = MagicMock()
+    bound.all.return_value = []
+    results.append(bound)
+
+    running = MagicMock()
+    running.all.return_value = list(running_rows)
+    results.append(running)
+
+    fanout = MagicMock()
+    fanout.scalars.return_value = []
+    results.append(fanout)
+
+    generations = MagicMock()
+    generations.all.return_value = []
+    results.append(generations)
+
+    for _ in range(4):
+        result = MagicMock()
+        result.scalars.return_value = []
+        results.append(result)
+
+    purge = MagicMock()
+    purge.all.return_value = []
+    results.append(purge)
+
+    post_expiry = MagicMock()
+    post_expiry.all.return_value = []
+    results.append(post_expiry)
+
+    mock_db = AsyncMock()
+    mock_db.execute = AsyncMock(side_effect=results)
+    mock_db.commit = AsyncMock()
+    return mock_db

--- a/backend/tests/test_raster_object_ownership_1778.py
+++ b/backend/tests/test_raster_object_ownership_1778.py
@@ -134,7 +134,13 @@ class TestUnpublishedStorageKeys:
         )
         storage = MagicMock()
         storage.delete = AsyncMock()
-        with patch("app.platform.storage.get_storage", return_value=storage):
+        with (
+            patch("app.platform.storage.get_storage", return_value=storage),
+            patch(
+                "app.platform.jobs.sweep._live_referenced_storage_keys",
+                AsyncMock(return_value=set()),
+            ),
+        ):
             result = await _reap_committed_staged_paths(outcome)
 
         assert result.storage_objects_reaped == 2
@@ -156,7 +162,13 @@ class TestUnpublishedStorageKeys:
         )
         storage = MagicMock()
         storage.delete = AsyncMock()
-        with patch("app.platform.storage.get_storage", return_value=storage):
+        with (
+            patch("app.platform.storage.get_storage", return_value=storage),
+            patch(
+                "app.platform.jobs.sweep._live_referenced_storage_keys",
+                AsyncMock(return_value=set()),
+            ),
+        ):
             outcome = await fail_stale_jobs(mock_db, detailed=True)
 
         assert outcome._unpublished_storage_keys == tuple(keys)
@@ -185,6 +197,212 @@ class TestUnpublishedStorageKeys:
             await fail_stale_jobs(mock_db, detailed=True)
 
         storage.delete.assert_not_awaited()
+
+
+class TestIdenticalReplacementKeepsTheLiveAsset:
+    """fix(#1778 codex r1): a re-upload of the file the dataset already serves.
+
+    The replacement converts to the same COG and hashes to the same
+    ``asset_sha256``, so the three keys the replace tail intends to write are
+    the three keys the live ``RasterAsset`` names. Before this, recording them
+    as unpublished handed both stale-job passes permission to delete the served
+    COG and its quicklooks after a crash, even one before the first put.
+    """
+
+    LIVE = [
+        "rasters/dataset-1/samehash/source.cog.tif",
+        "rasters/dataset-1/samehash/quicklook_256.png",
+        "rasters/dataset-1/samehash/quicklook_512.png",
+    ]
+
+    @staticmethod
+    def _session_double() -> tuple:
+        session = AsyncMock()
+        maker = MagicMock()
+        maker.return_value.__aenter__ = AsyncMock(return_value=session)
+        maker.return_value.__aexit__ = AsyncMock(return_value=False)
+        return session, maker
+
+    @pytest.mark.asyncio
+    async def test_the_live_keys_are_never_recorded_as_unpublished(self) -> None:
+        from app.processing.ingest.tasks_raster_common import (
+            record_unpublished_storage_keys,
+        )
+
+        session, maker = self._session_double()
+        with patch("app.core.db.async_session", maker):
+            await record_unpublished_storage_keys(
+                uuid.uuid4(),
+                uuid.uuid4(),
+                keys=list(self.LIVE),
+                already_published=self.LIVE,
+                job_id="j",
+                task="reupload_raster",
+            )
+
+        # Nothing left to record, so no write at all.
+        session.execute.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_a_genuinely_new_key_is_still_recorded(self) -> None:
+        from app.processing.ingest.tasks_raster_common import (
+            UNPUBLISHED_STORAGE_KEYS_FIELD,
+            record_unpublished_storage_keys,
+        )
+
+        session, maker = self._session_double()
+        fresh = "rasters/dataset-1/newhash/source.cog.tif"
+        with patch("app.core.db.async_session", maker):
+            await record_unpublished_storage_keys(
+                uuid.uuid4(),
+                uuid.uuid4(),
+                keys=[fresh, *self.LIVE],
+                already_published=self.LIVE,
+                job_id="j",
+                task="reupload_raster",
+            )
+
+        session.execute.assert_awaited_once()
+        stmt = session.execute.await_args.args[0]
+        recorded = stmt.compile().params["unpublished_patch"]
+        assert recorded == {UNPUBLISHED_STORAGE_KEYS_FIELD: [fresh]}
+
+    @pytest.mark.asyncio
+    async def test_the_reaper_refuses_a_key_a_live_row_names(self) -> None:
+        """The second half: it holds whatever the job row says.
+
+        A job row written before the exclusion existed still names the live
+        keys, and this is the pass that has to refuse them.
+        """
+        from app.platform.jobs.sweep import reap_unpublished_storage_keys
+
+        orphan = "rasters/dataset-1/deadhash/source.cog.tif"
+        storage = MagicMock()
+        storage.delete = AsyncMock()
+        with (
+            patch("app.platform.storage.get_storage", return_value=storage),
+            patch(
+                "app.platform.jobs.sweep._live_referenced_storage_keys",
+                AsyncMock(return_value=set(self.LIVE)),
+            ),
+        ):
+            reaped, skipped, failures = await reap_unpublished_storage_keys(
+                (*self.LIVE, orphan)
+            )
+
+        assert (reaped, skipped, failures) == (1, 3, 0)
+        assert [call.args[0] for call in storage.delete.await_args_list] == [orphan]
+
+    @pytest.mark.asyncio
+    async def test_an_unreadable_catalog_deletes_nothing(self) -> None:
+        """Leaking an object is recoverable; deleting a served raster is not."""
+        from app.platform.jobs.sweep import reap_unpublished_storage_keys
+
+        storage = MagicMock()
+        storage.delete = AsyncMock()
+        with (
+            patch("app.platform.storage.get_storage", return_value=storage),
+            patch(
+                "app.platform.jobs.sweep._live_referenced_storage_keys",
+                AsyncMock(side_effect=RuntimeError("catalog unreadable")),
+            ),
+        ):
+            reaped, skipped, failures = await reap_unpublished_storage_keys(
+                tuple(self.LIVE)
+            )
+
+        assert (reaped, skipped, failures) == (0, 3, 0)
+        storage.delete.assert_not_awaited()
+
+    def test_every_site_that_records_intended_keys_states_the_exclusion(self) -> None:
+        """Enumerated rather than assumed: two writers, both answering."""
+        found = set()
+        for module in sorted((APP / "processing").rglob("*.py")):
+            text = module.read_text()
+            if "await record_unpublished_storage_keys(" not in text:
+                continue
+            rel = str(module.relative_to(APP))
+            found.add(rel)
+            assert text.count("await record_unpublished_storage_keys(") == text.count(
+                "already_published="
+            ), rel
+        assert found == {
+            "processing/ingest/tasks_raster.py",
+            "processing/ingest/tasks_raster_replace.py",
+        }, found
+
+
+class TestLiveReferenceQuery:
+    """The survivor check against a real catalog, not a double.
+
+    The reaper's refusal is only as good as this query, and it spans four
+    columns across two tables, so it is worth running rather than mocking.
+    """
+
+    @pytest.mark.anyio
+    async def test_it_finds_every_column_that_names_an_object(
+        self, test_db_session
+    ) -> None:
+        from app.modules.catalog.datasets.domain.models import Dataset, Record
+        from app.platform.jobs.sweep import _live_referenced_storage_keys
+        from app.processing.raster.models import DatasetAsset, RasterAsset
+
+        record = Record(
+            title="live raster",
+            visibility="private",
+            record_status="published",
+            record_type="raster_dataset",
+        )
+        test_db_session.add(record)
+        await test_db_session.flush()
+        dataset = Dataset(
+            record_id=record.id,
+            table_name=f"ds_{uuid.uuid4().hex[:12]}",
+            srid=4326,
+            source_format="geotiff",
+        )
+        test_db_session.add(dataset)
+        await test_db_session.flush()
+        base = f"rasters/{dataset.id}/livehash"
+        original = f"originals/{dataset.id}/livehash"
+        test_db_session.add(
+            RasterAsset(
+                dataset_id=dataset.id,
+                asset_uri=f"{base}/source.cog.tif",
+                quicklook_256_uri=f"{base}/quicklook_256.png",
+                quicklook_512_uri=f"{base}/quicklook_512.png",
+                storage_backend="local",
+            )
+        )
+        test_db_session.add(
+            DatasetAsset(
+                dataset_id=dataset.id,
+                key="archived_original:livehash",
+                href=original,
+                media_type="image/tiff",
+                roles=["archive"],
+            )
+        )
+        await test_db_session.commit()
+
+        orphan = f"rasters/{dataset.id}/deadhash/source.cog.tif"
+        live = await _live_referenced_storage_keys(
+            (
+                f"{base}/source.cog.tif",
+                f"{base}/quicklook_256.png",
+                f"{base}/quicklook_512.png",
+                original,
+                orphan,
+            )
+        )
+
+        assert live == {
+            f"{base}/source.cog.tif",
+            f"{base}/quicklook_256.png",
+            f"{base}/quicklook_512.png",
+            original,
+        }
+        assert orphan not in live
 
 
 def _mock_db_for_fail_stale(*, running_rows: list) -> AsyncMock:

--- a/backend/tests/test_raster_object_ownership_1778.py
+++ b/backend/tests/test_raster_object_ownership_1778.py
@@ -10,6 +10,7 @@ before the transaction that would publish it:
   commit had no out-of-process reaper, unlike the VRT generation prefix.
 """
 
+import ast
 import uuid
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -317,7 +318,12 @@ class TestIdenticalReplacementKeepsTheLiveAsset:
         storage.delete.assert_not_awaited()
 
     def test_every_site_that_records_intended_keys_states_the_exclusion(self) -> None:
-        """Enumerated rather than assumed: two writers, both answering."""
+        """Enumerated rather than assumed: three writers, all answering.
+
+        fix(#1778 codex r4): `ingest_vrt` joined the set. Its keys sit under a
+        dataset id it generates per task invocation, so its answer is the empty
+        one, but it still has to give it.
+        """
         found = set()
         for module in sorted((APP / "processing").rglob("*.py")):
             text = module.read_text()
@@ -331,6 +337,7 @@ class TestIdenticalReplacementKeepsTheLiveAsset:
         assert found == {
             "processing/ingest/tasks_raster.py",
             "processing/ingest/tasks_raster_replace.py",
+            "processing/ingest/tasks_vrt.py",
         }, found
 
 
@@ -557,7 +564,279 @@ class TestAttemptScopedReplaceKeys:
         assert generated < used < scoped
 
 
-def _mock_db_for_fail_stale(*, running_rows: list) -> AsyncMock:
+# (module path relative to backend/app, enclosing function) ->
+# (expected put count, the durable owner that can name the key without this
+# process). A site not listed here must call `record_unpublished_storage_keys`
+# in the same function, before its puts. Counts are exact in both directions:
+# a new put inside an already-justified function has to be argued for on its
+# own rather than riding the existing entry, which is the rule
+# `test_rule2_structural`'s allowlists follow for the same reason.
+PUT_SITES_WITH_ANOTHER_OWNER: dict[tuple[str, str], tuple[int, str]] = {
+    ("processing/ingest/tasks_vrt.py", "regenerate_vrt"): (
+        3,
+        "generation-scoped keys, rebuilt from the durable VrtGeneration row by "
+        "_stale_generation_storage_keys in the job sweep (feat(#1267)) - the "
+        "mechanism this finding's recorder was modelled on",
+    ),
+    ("processing/ingest/tasks_common.py", "_archive_original_file"): (
+        1,
+        "originals/{dataset_id}/: the first-ingest tail records it as intent "
+        "(archived_original_uri under a dataset id it generates), and the "
+        "replace tail deliberately does not, because the same content-derived "
+        "key can already hold an earlier upload's archive that a live "
+        "dataset_assets row names - archive_lossy_original's own pre-write "
+        "probe is what decides that one",
+    ),
+    ("processing/ingest/tasks_common.py", "_generate_quicklook"): (
+        1,
+        "vectors/{dataset_id}/quicklook_256.png, written after the vector "
+        "dataset row is committed, so delete_dataset's vectors/ prefix reap "
+        "owns it (fix(#430 BA-17))",
+    ),
+    ("processing/ingest/service.py", "save_upload_file"): (
+        2,
+        "staging/: owned by the staging reconciler and the presigned-staging "
+        "sweep, which start from the objects rather than from a row",
+    ),
+    ("processing/ingest/router.py", "_put_staging_object"): (
+        1,
+        "staging/: same two owners as save_upload_file",
+    ),
+    ("processing/export/artifact_cache.py", "_write"): (
+        1,
+        "the export artifact cache, reaped by its own TTL sweep",
+    ),
+}
+
+
+class TestEveryPutSiteHasAnOwner:
+    """fix(#1778 codex r4): no object may be written with nothing able to name it.
+
+    The finding this file exists for is a key that outlives the process that
+    could have deleted it. `written_storage_keys` is a local list, so any put
+    before the terminal commit is one SIGKILL away from an orphan whose prefix
+    embeds an id the rollback took away. `record_unpublished_storage_keys` is
+    the answer for the three ingest tails; every other put site needs an owner
+    that can reconstruct the key from something durable, and this is where that
+    claim is written down instead of assumed.
+    """
+
+    @staticmethod
+    def _put_sites() -> dict[tuple[str, str], int]:
+        sites: dict[tuple[str, str], int] = {}
+        for module in sorted((APP / "processing").rglob("*.py")):
+            rel = str(module.relative_to(APP))
+            stack: list[str] = []
+
+            def walk(node: ast.AST) -> None:
+                for child in ast.iter_child_nodes(node):
+                    if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                        stack.append(child.name)
+                        walk(child)
+                        stack.pop()
+                        continue
+                    if (
+                        isinstance(child, ast.Call)
+                        and isinstance(child.func, ast.Attribute)
+                        and child.func.attr == "put"
+                        and stack
+                    ):
+                        sites[(rel, stack[-1])] = sites.get((rel, stack[-1]), 0) + 1
+                    walk(child)
+
+            walk(ast.parse(module.read_text()))
+        return sites
+
+    @staticmethod
+    def _records_intent(rel: str) -> set[str]:
+        """Functions in one module that record their intended keys."""
+        recording: set[str] = set()
+        stack: list[str] = []
+
+        def walk(node: ast.AST) -> None:
+            for child in ast.iter_child_nodes(node):
+                if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                    stack.append(child.name)
+                    walk(child)
+                    stack.pop()
+                    continue
+                if (
+                    isinstance(child, ast.Call)
+                    and isinstance(child.func, ast.Name)
+                    and child.func.id == "record_unpublished_storage_keys"
+                    and stack
+                ):
+                    recording.add(stack[-1])
+                walk(child)
+
+        walk(ast.parse((APP / rel).read_text()))
+        return recording
+
+    def test_no_put_site_is_left_without_an_owner(self) -> None:
+        unowned = []
+        for (rel, func), count in sorted(self._put_sites().items()):
+            if (rel, func) in PUT_SITES_WITH_ANOTHER_OWNER:
+                continue
+            if func in self._records_intent(rel):
+                continue
+            unowned.append(f"{rel}::{func} ({count} put(s))")
+        assert not unowned, (
+            "these storage puts have no owner that can name the key after the "
+            "writing process is gone. Either record the intended keys with "
+            "record_unpublished_storage_keys before the first put, or add a "
+            "PUT_SITES_WITH_ANOTHER_OWNER entry naming the reaper that can "
+            "reconstruct them:\n" + "\n".join(unowned)
+        )
+
+    def test_the_three_recording_tails_record_before_they_put(self) -> None:
+        """Order matters as much as presence: a record after the put is lost."""
+        for rel, func in (
+            ("processing/ingest/tasks_raster.py", "ingest_raster"),
+            ("processing/ingest/tasks_raster_replace.py", "reupload_raster"),
+            ("processing/ingest/tasks_vrt.py", "ingest_vrt"),
+        ):
+            lines = (APP / rel).read_text().splitlines()
+            record = next(
+                i
+                for i, line in enumerate(lines)
+                if "await record_unpublished_storage_keys(" in line
+            )
+            first_put = next(
+                i for i, line in enumerate(lines) if "await storage.put(" in line
+            )
+            assert record < first_put, f"{rel}::{func} records after its first put"
+
+    def test_the_justifications_are_exact_in_both_directions(self) -> None:
+        """A justified function may not silently acquire a second put."""
+        sites = self._put_sites()
+        for key, (expected, justification) in PUT_SITES_WITH_ANOTHER_OWNER.items():
+            assert key in sites, f"stale allowlist entry: {key[0]}::{key[1]}"
+            assert sites[key] == expected, (
+                f"{key[0]}::{key[1]} has {sites[key]} puts, entry says {expected}"
+            )
+            assert len(justification) > 40, key
+
+
+class TestRetentionPurgeIsTheLastOwner:
+    """fix(#1778 codex r4): the row being deleted is the last thing naming these.
+
+    The two stale-job passes only read the rows they move OFF `running`. A job
+    that reached `failed` or `cancelled` on its own, whose in-process
+    best-effort cleanup then failed once (a storage blip, a DROP that lost a
+    lock race), keeps its objects and its output table with the record still
+    pointing at them, and nothing looks again. The retention purge holds that
+    pointer right up to the moment it discards it, so it is the last chance to
+    use it.
+    """
+
+    KEY = "rasters/purged-ds/attempts/dead/abc/source.cog.tif"
+
+    @pytest.mark.asyncio
+    async def test_a_failed_job_whose_cleanup_raised_is_reaped_by_the_purge(
+        self, monkeypatch
+    ) -> None:
+        from app.core.config import settings
+        from app.platform.jobs.sweep import fail_stale_jobs
+
+        monkeypatch.setattr(settings, "ingest_jobs_retention_days", 30)
+        mock_db = _mock_db_for_fail_stale(
+            running_rows=[],
+            purged_rows=[
+                (
+                    uuid.uuid4(),
+                    None,
+                    {
+                        "unpublished_storage_keys": [self.KEY],
+                        "analysis_out_table": "parcels_buffered",
+                    },
+                )
+            ],
+        )
+        storage = MagicMock()
+        storage.delete = AsyncMock()
+        analysis_reap = AsyncMock()
+        with (
+            patch("app.platform.storage.get_storage", return_value=storage),
+            patch(
+                "app.platform.jobs.sweep._live_referenced_storage_keys",
+                AsyncMock(return_value=set()),
+            ),
+            patch(
+                "app.platform.jobs.sweep._reap_unadopted_analysis_outputs",
+                analysis_reap,
+            ),
+        ):
+            outcome = await fail_stale_jobs(mock_db, detailed=True)
+
+        assert outcome._unpublished_storage_keys == (self.KEY,)
+        assert [call.args[0] for call in storage.delete.await_args_list] == [self.KEY]
+        analysis_reap.assert_awaited_once_with(("parcels_buffered",))
+
+    @pytest.mark.asyncio
+    async def test_a_purged_row_naming_a_live_key_deletes_nothing(
+        self, monkeypatch
+    ) -> None:
+        """The survivor check applies to this door too.
+
+        A row can be purged while the object it named is the one a dataset is
+        serving: an ingest that succeeded and whose recorded intent was never
+        cleared off the row still carries the published key.
+        """
+        from app.core.config import settings
+        from app.platform.jobs.sweep import fail_stale_jobs
+
+        monkeypatch.setattr(settings, "ingest_jobs_retention_days", 30)
+        mock_db = _mock_db_for_fail_stale(
+            running_rows=[],
+            purged_rows=[
+                (uuid.uuid4(), None, {"unpublished_storage_keys": [self.KEY]})
+            ],
+        )
+        storage = MagicMock()
+        storage.delete = AsyncMock()
+        with (
+            patch("app.platform.storage.get_storage", return_value=storage),
+            patch(
+                "app.platform.jobs.sweep._live_referenced_storage_keys",
+                AsyncMock(return_value={self.KEY}),
+            ),
+        ):
+            outcome = await fail_stale_jobs(mock_db, detailed=True)
+
+        assert outcome._unpublished_storage_keys == (self.KEY,)
+        storage.delete.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_a_rolled_back_purge_deletes_nothing(self, monkeypatch) -> None:
+        from app.core.config import settings
+        from app.platform.jobs.sweep import fail_stale_jobs
+
+        monkeypatch.setattr(settings, "ingest_jobs_retention_days", 30)
+        mock_db = _mock_db_for_fail_stale(
+            running_rows=[],
+            purged_rows=[
+                (uuid.uuid4(), None, {"unpublished_storage_keys": [self.KEY]})
+            ],
+        )
+        mock_db.commit.side_effect = RuntimeError("commit failed")
+        storage = MagicMock()
+        storage.delete = AsyncMock()
+        with (
+            patch("app.platform.storage.get_storage", return_value=storage),
+            patch(
+                "app.platform.jobs.sweep._live_referenced_storage_keys",
+                AsyncMock(return_value=set()),
+            ),
+            pytest.raises(RuntimeError, match="commit failed"),
+        ):
+            await fail_stale_jobs(mock_db, detailed=True)
+
+        storage.delete.assert_not_awaited()
+
+
+def _mock_db_for_fail_stale(
+    *, running_rows: list, purged_rows: list | None = None
+) -> AsyncMock:
     """A session double for ``fail_stale_jobs`` with real running-row metadata.
 
     The peer helper in ``test_vrt_stale_sweep_gap002`` hands every job row a
@@ -596,8 +875,13 @@ def _mock_db_for_fail_stale(*, running_rows: list) -> AsyncMock:
         results.append(result)
 
     purge = MagicMock()
-    purge.all.return_value = []
+    purge.all.return_value = list(purged_rows or [])
     results.append(purge)
+    # fix(#1778 codex r4): the purge only issues its survivor SELECT when a
+    # deleted row carried a file_path, and these fixtures carry none.
+    assert not any(row[1] for row in (purged_rows or [])), (
+        "a purged row with a file_path adds one SELECT this double does not model"
+    )
 
     post_expiry = MagicMock()
     post_expiry.all.return_value = []

--- a/backend/tests/test_raster_object_ownership_1778.py
+++ b/backend/tests/test_raster_object_ownership_1778.py
@@ -152,14 +152,28 @@ class TestUnpublishedStorageKeys:
 
     @pytest.mark.asyncio
     async def test_fail_stale_jobs_carries_them_out_of_a_running_row(self) -> None:
-        """The keys reach the outcome, and only after the settling commit."""
+        """The keys reach the outcome, and only after the settling commit.
+
+        fix(#1778 codex r10): the running-row transition no longer collects
+        keys directly -- that collection moved into the unconditional
+        artifact-carrying SELECT that runs after the retention block, so a
+        row this pass just failed is seen through that query instead. Against
+        real Postgres the SELECT runs inside the same uncommitted
+        transaction as the UPDATE above it and sees the new status, so the
+        two-query split changes nothing about same-pass reaping; the double
+        has to route the fixture through the query that actually answers it
+        now, which is why this passes the row as ``purged_rows`` rather than
+        ``running_rows``.
+        """
         from app.platform.jobs.sweep import fail_stale_jobs
 
+        job_uuid = uuid.uuid4()
         keys = ["rasters/d/abc/source.cog.tif", "rasters/d/abc/quicklook_256.png"]
         mock_db = _mock_db_for_fail_stale(
-            running_rows=[
-                (uuid.uuid4(), {"unpublished_storage_keys": keys}, None),
-            ]
+            running_rows=[(job_uuid, None, None)],
+            purged_rows=[
+                (job_uuid, None, {"unpublished_storage_keys": keys}),
+            ],
         )
         storage = MagicMock()
         storage.delete = AsyncMock()
@@ -172,7 +186,7 @@ class TestUnpublishedStorageKeys:
         ):
             outcome = await fail_stale_jobs(mock_db, detailed=True)
 
-        assert outcome._unpublished_storage_keys == tuple(keys)
+        assert outcome._unpublished_storage_keys == tuple(sorted(keys))
         assert {call.args[0] for call in storage.delete.await_args_list} == set(keys)
 
     @pytest.mark.asyncio
@@ -1359,17 +1373,6 @@ def _mock_db_for_fail_stale(
         result.scalars.return_value = []
         results.append(result)
 
-    # fix(#1778 codex r5): the exempted-row SELECT the purge issues first.
-    # These fixtures drive the reaps through it rather than through the DELETE,
-    # because a row that still names an artifact is deliberately NOT deleted.
-    retained = MagicMock()
-    # fix(#1778 codex r7): (id, user_metadata), because the analysis reap is
-    # keyed on the owning job now rather than on a name two jobs could hold.
-    retained.all.return_value = [
-        (job_row_id, um) for (job_row_id, _fp, um) in (purged_rows or [])
-    ]
-    results.append(retained)
-
     purge = MagicMock()
     purge.all.return_value = []
     results.append(purge)
@@ -1378,6 +1381,19 @@ def _mock_db_for_fail_stale(
     assert not any(row[1] for row in (purged_rows or [])), (
         "a purged row with a file_path adds one SELECT this double does not model"
     )
+
+    # fix(#1778 codex r10): the artifact-carrying SELECT, unconditional and
+    # run AFTER the retention block (it used to be the exempted-row SELECT
+    # the purge issued first, inside the block). These fixtures drive the
+    # reaps through it rather than through the DELETE, because a row that
+    # still names an artifact is deliberately NOT purged.
+    artifact_rows = MagicMock()
+    # fix(#1778 codex r7): (id, user_metadata), because the analysis reap is
+    # keyed on the owning job now rather than on a name two jobs could hold.
+    artifact_rows.all.return_value = [
+        (job_row_id, um) for (job_row_id, _fp, um) in (purged_rows or [])
+    ]
+    results.append(artifact_rows)
 
     post_expiry = MagicMock()
     post_expiry.all.return_value = []

--- a/backend/tests/test_raster_object_ownership_1778.py
+++ b/backend/tests/test_raster_object_ownership_1778.py
@@ -248,7 +248,6 @@ class TestIdenticalReplacementKeepsTheLiveAsset:
     @pytest.mark.asyncio
     async def test_a_genuinely_new_key_is_still_recorded(self) -> None:
         from app.processing.ingest.tasks_raster_common import (
-            UNPUBLISHED_STORAGE_KEYS_FIELD,
             record_unpublished_storage_keys,
         )
 
@@ -267,8 +266,11 @@ class TestIdenticalReplacementKeepsTheLiveAsset:
 
         session.execute.assert_awaited_once()
         stmt = session.execute.await_args.args[0]
+        # fix(#1778 codex r9): the bind is the array the attempt appends; the
+        # field name reaches the statement through jsonb_build_object, because
+        # the value now concatenates onto whatever the row already names.
         recorded = stmt.compile().params["unpublished_patch"]
-        assert recorded == {UNPUBLISHED_STORAGE_KEYS_FIELD: [fresh]}
+        assert recorded == [fresh]
 
     @pytest.mark.asyncio
     async def test_the_reaper_refuses_a_key_a_live_row_names(self) -> None:
@@ -500,7 +502,6 @@ class TestAttemptScopedReplaceKeys:
         raster.
         """
         from app.processing.ingest.tasks_raster_common import (
-            UNPUBLISHED_STORAGE_KEYS_FIELD,
             record_unpublished_storage_keys,
         )
 
@@ -527,7 +528,7 @@ class TestAttemptScopedReplaceKeys:
         session.execute.assert_awaited_once()
         stmt = session.execute.await_args.args[0]
         recorded = stmt.compile().params["unpublished_patch"]
-        assert recorded == {UNPUBLISHED_STORAGE_KEYS_FIELD: mine}
+        assert recorded == mine
 
     def test_the_replace_tail_derives_both_key_sets_from_the_one_helper(
         self,
@@ -1111,6 +1112,211 @@ class TestReapScalesAndStaysRetryable:
         assert "unpublished_storage_keys" in rows[partial_id], (
             "a row with an unsettled key keeps its whole record for the retry"
         )
+
+
+class TestTheRecordAccumulatesAcrossAttempts:
+    """fix(#1778 codex r9): a retry used to forget the previous attempt's keys.
+
+    `/jobs/{id}/retry` preserves `user_metadata`, so a retried ingest reached
+    the recorder with attempt 1's keys still on the row. The JSONB merge set
+    the field to attempt 2's keys alone, and an attempt whose own best-effort
+    delete had also failed lost its objects' last durable pointer with it:
+    neither stale pass nor the retention purge could name them afterwards.
+
+    The record is a flat list each attempt extends. Which attempt wrote a key
+    is not something any reader needs -- every one of them asks only whether a
+    key is still owed a reap -- and keeping the shape a list is what lets a row
+    written before this commit still reap.
+    """
+
+    @staticmethod
+    async def _record(job_id, attempt_uuid, keys):
+        from app.processing.ingest.tasks_raster_common import (
+            record_unpublished_storage_keys,
+        )
+
+        await record_unpublished_storage_keys(
+            job_id,
+            attempt_uuid,
+            keys=keys,
+            already_published=(),
+            attempt_scope="",
+            job_id=str(job_id),
+            task="ingest_raster",
+        )
+
+    @staticmethod
+    async def _reload(session, job_id):
+        from sqlalchemy import select
+
+        from app.platform.jobs.models import IngestJob
+
+        session.expire_all()
+        return (
+            await session.execute(select(IngestJob).where(IngestJob.id == job_id))
+        ).scalar_one()
+
+    @pytest.mark.anyio
+    async def test_a_retry_keeps_the_previous_attempts_keys(
+        self, test_db_session
+    ) -> None:
+        from app.platform.jobs.models import IngestJob
+        from app.platform.jobs.sweep import unpublished_storage_keys_from_metadata
+
+        attempt_one, attempt_two = uuid.uuid4(), uuid.uuid4()
+        job = IngestJob(status="failed", file_path="", attempt_id=attempt_one)
+        test_db_session.add(job)
+        await test_db_session.flush()
+        job_id = job.id
+        await test_db_session.commit()
+
+        first = ["rasters/a/attempts/one/h/source.cog.tif"]
+        await self._record(job_id, attempt_one, first)
+
+        # The retry keeps user_metadata and takes a new attempt token.
+        row = await self._reload(test_db_session, job_id)
+        row.attempt_id = attempt_two
+        await test_db_session.commit()
+
+        second = ["rasters/a/attempts/two/h/source.cog.tif"]
+        await self._record(job_id, attempt_two, second)
+
+        row = await self._reload(test_db_session, job_id)
+        assert unpublished_storage_keys_from_metadata(row.user_metadata) == tuple(
+            first + second
+        ), "attempt 1's objects lost their last durable pointer"
+
+    @pytest.mark.anyio
+    async def test_clearing_removes_only_the_settled_keys(
+        self, test_db_session
+    ) -> None:
+        """A key whose delete raised keeps its place in the record."""
+        from app.platform.jobs.models import IngestJob
+        from app.platform.jobs.sweep import (
+            _clear_settled_artifact_records,
+            unpublished_storage_keys_from_metadata,
+        )
+
+        settled = "rasters/a/attempts/one/h/source.cog.tif"
+        unsettled = "rasters/a/attempts/two/h/source.cog.tif"
+        job = IngestJob(
+            status="failed",
+            file_path="",
+            user_metadata={
+                "unpublished_storage_keys": [settled, unsettled],
+                "keep_me": True,
+            },
+        )
+        test_db_session.add(job)
+        await test_db_session.flush()
+        job_id = job.id
+        await test_db_session.commit()
+
+        await _clear_settled_artifact_records(storage_keys={settled})
+
+        row = await self._reload(test_db_session, job_id)
+        assert unpublished_storage_keys_from_metadata(row.user_metadata) == (
+            unsettled,
+        ), "the unsettled key must survive for the next sweep"
+        assert row.user_metadata["keep_me"] is True
+
+        await _clear_settled_artifact_records(storage_keys={unsettled})
+
+        row = await self._reload(test_db_session, job_id)
+        assert "unpublished_storage_keys" not in row.user_metadata, (
+            "the field goes once nothing is owed, so the purge can take the row"
+        )
+        assert row.user_metadata["keep_me"] is True
+
+    @pytest.mark.anyio
+    async def test_both_attempts_keys_are_reaped_in_one_sweep(
+        self, test_db_session
+    ) -> None:
+        """End to end: the pin the review asked for.
+
+        Attempt 1 fails with a failed delete, the retry writes new keys, both
+        attempts' keys are on the row, one sweep reaps both, and the record
+        clears only for what it settled.
+        """
+        from app.platform.jobs.models import IngestJob
+        from app.platform.jobs.sweep import reap_unpublished_storage_keys
+
+        first = "rasters/a/attempts/one/h/source.cog.tif"
+        second = "rasters/a/attempts/two/h/source.cog.tif"
+        job = IngestJob(
+            status="failed",
+            file_path="",
+            user_metadata={"unpublished_storage_keys": [first, second]},
+        )
+        test_db_session.add(job)
+        await test_db_session.flush()
+        job_id = job.id
+        await test_db_session.commit()
+
+        storage = MagicMock()
+        storage.delete = AsyncMock()
+        with (
+            patch("app.platform.storage.get_storage", return_value=storage),
+            patch(
+                "app.platform.jobs.sweep._live_referenced_storage_keys",
+                AsyncMock(return_value=set()),
+            ),
+        ):
+            reaped, skipped, failures = await reap_unpublished_storage_keys(
+                (first, second)
+            )
+
+        assert (reaped, skipped, failures) == (2, 0, 0)
+        assert {call.args[0] for call in storage.delete.await_args_list} == {
+            first,
+            second,
+        }
+        row = await self._reload(test_db_session, job_id)
+        assert "unpublished_storage_keys" not in row.user_metadata
+
+    @pytest.mark.anyio
+    async def test_a_row_written_before_this_commit_still_reaps(
+        self, test_db_session
+    ) -> None:
+        """A plain list is the shape both before and after, by design."""
+        from app.platform.jobs.models import IngestJob
+        from app.platform.jobs.sweep import (
+            _clear_settled_artifact_records,
+            unpublished_storage_keys_from_metadata,
+        )
+
+        legacy = "rasters/legacy/h/source.cog.tif"
+        job = IngestJob(
+            status="failed",
+            file_path="",
+            user_metadata={"unpublished_storage_keys": [legacy]},
+        )
+        test_db_session.add(job)
+        await test_db_session.flush()
+        job_id = job.id
+        await test_db_session.commit()
+
+        row = await self._reload(test_db_session, job_id)
+        assert unpublished_storage_keys_from_metadata(row.user_metadata) == (legacy,)
+
+        await _clear_settled_artifact_records(storage_keys={legacy})
+
+        row = await self._reload(test_db_session, job_id)
+        assert "unpublished_storage_keys" not in row.user_metadata
+
+    def test_the_recorder_is_the_only_writer_of_the_record(self) -> None:
+        """Enumerated, so a second writer cannot reintroduce the replace."""
+        writers = set()
+        for module in sorted(APP.rglob("*.py")):
+            body = module.read_text()
+            if "UNPUBLISHED_STORAGE_KEYS_FIELD" not in body:
+                continue
+            if "update(IngestJob)" in body or "UPDATE catalog.ingest_jobs" in body:
+                writers.add(str(module.relative_to(APP)))
+        assert writers == {
+            "processing/ingest/tasks_raster_common.py",
+            "platform/jobs/sweep.py",
+        }, writers
 
 
 def _mock_db_for_fail_stale(

--- a/backend/tests/test_raster_object_ownership_1778.py
+++ b/backend/tests/test_raster_object_ownership_1778.py
@@ -214,6 +214,119 @@ class TestUnpublishedStorageKeys:
         storage.delete.assert_not_awaited()
 
 
+class TestRecorderChecksItsOwnFence:
+    """fix(#1778 audit): every other fenced job-row write in this codebase
+    checks its match. ``update_ingest_job_for_attempt`` in ``heartbeat.py``
+    returns ``bool(rowcount)`` and every caller branches on a miss; this
+    recorder used to be the one exception, silently committing nothing when
+    the ``(job, attempt)`` pair it was handed no longer owned the row.
+
+    Reachable when the stale sweep fails a row on heartbeat timeout while the
+    original worker is merely paused (a GC pause, a slow syscall) rather than
+    dead, and a retry mints a new attempt on the same job: the paused worker
+    resumes, calls this recorder with its own dead attempt token, and used to
+    get told nothing about the miss. A kill before its own in-process cleanup
+    then left the staged objects it was about to write with no row naming
+    them anywhere -- the #1778 leak class reopened at the one recorder that
+    did not check its fence.
+    """
+
+    @pytest.mark.anyio
+    async def test_a_fenced_out_attempt_gets_no_write_and_a_false_return(
+        self, test_db_session
+    ) -> None:
+        from sqlalchemy import select
+
+        from app.platform.jobs.models import IngestJob
+        from app.processing.ingest.tasks_raster_common import (
+            UNPUBLISHED_STORAGE_KEYS_FIELD,
+            record_unpublished_storage_keys,
+        )
+
+        job = IngestJob(status="running", file_path="")
+        test_db_session.add(job)
+        await test_db_session.flush()
+        job_id = job.id
+        dead_attempt = job.attempt_id
+        assert dead_attempt is not None
+
+        # The retry: a new attempt supersedes this one on the same row,
+        # exactly what /jobs/{id}/retry does. The paused worker still holds
+        # `dead_attempt` and knows nothing of this yet.
+        job.attempt_id = uuid.uuid4()
+        await test_db_session.commit()
+
+        key = f"rasters/{job_id}/dead/abc/source.cog.tif"
+        proceed = await record_unpublished_storage_keys(
+            job_id,
+            dead_attempt,
+            keys=[key],
+            already_published=(),
+            attempt_scope="dead",
+            job_id=str(job_id),
+            task="ingest_raster",
+        )
+
+        assert proceed is False, (
+            "a fenced-out attempt must not be told it may proceed to write"
+        )
+
+        test_db_session.expire_all()
+        row = (
+            await test_db_session.execute(
+                select(IngestJob).where(IngestJob.id == job_id)
+            )
+        ).scalar_one()
+        assert UNPUBLISHED_STORAGE_KEYS_FIELD not in (row.user_metadata or {}), (
+            "the dead attempt's write must not have landed on the retry's row"
+        )
+
+    @pytest.mark.anyio
+    async def test_the_live_attempt_still_gets_a_true_return(
+        self, test_db_session
+    ) -> None:
+        """The other side of the same check: a live attempt is unaffected."""
+        from app.platform.jobs.models import IngestJob
+        from app.processing.ingest.tasks_raster_common import (
+            record_unpublished_storage_keys,
+        )
+
+        job = IngestJob(status="running", file_path="")
+        test_db_session.add(job)
+        await test_db_session.flush()
+        job_id = job.id
+        attempt_id = job.attempt_id
+        await test_db_session.commit()
+
+        key = f"rasters/{job_id}/live/abc/source.cog.tif"
+        proceed = await record_unpublished_storage_keys(
+            job_id,
+            attempt_id,
+            keys=[key],
+            already_published=(),
+            attempt_scope="live",
+            job_id=str(job_id),
+            task="ingest_raster",
+        )
+
+        assert proceed is True
+
+    def test_every_caller_treats_a_fence_miss_as_abort(self) -> None:
+        """A caller that ignored the return value would still write objects
+        nothing records, once the recorder itself learned to report a fence
+        miss. Enumerated across the same three sites
+        ``test_every_site_that_records_intended_keys_states_the_exclusion``
+        pins, so a future caller cannot add itself without answering this
+        too."""
+        for rel in (
+            "processing/ingest/tasks_raster.py",
+            "processing/ingest/tasks_raster_replace.py",
+            "processing/ingest/tasks_vrt.py",
+        ):
+            source = (APP / rel).read_text()
+            assert "if not await record_unpublished_storage_keys(" in source, rel
+
+
 class TestIdenticalReplacementKeepsTheLiveAsset:
     """fix(#1778 codex r1): a re-upload of the file the dataset already serves.
 

--- a/backend/tests/test_raster_object_ownership_1778.py
+++ b/backend/tests/test_raster_object_ownership_1778.py
@@ -739,11 +739,12 @@ class TestRetentionPurgeIsTheLastOwner:
         from app.platform.jobs.sweep import fail_stale_jobs
 
         monkeypatch.setattr(settings, "ingest_jobs_retention_days", 30)
+        purged_job_id = uuid.uuid4()
         mock_db = _mock_db_for_fail_stale(
             running_rows=[],
             purged_rows=[
                 (
-                    uuid.uuid4(),
+                    purged_job_id,
                     None,
                     {
                         "unpublished_storage_keys": [self.KEY],
@@ -773,7 +774,8 @@ class TestRetentionPurgeIsTheLastOwner:
 
         assert outcome._unpublished_storage_keys == (self.KEY,)
         assert [call.args[0] for call in storage.delete.await_args_list] == [self.KEY]
-        analysis_reap.assert_awaited_once_with(("parcels_buffered",))
+        # fix(#1778 codex r7): (job, table), so the drop can verify ownership.
+        analysis_reap.assert_awaited_once_with(((purged_job_id, "parcels_buffered"),))
 
     @pytest.mark.asyncio
     async def test_a_purged_row_naming_a_live_key_deletes_nothing(
@@ -1155,7 +1157,11 @@ def _mock_db_for_fail_stale(
     # These fixtures drive the reaps through it rather than through the DELETE,
     # because a row that still names an artifact is deliberately NOT deleted.
     retained = MagicMock()
-    retained.scalars.return_value = [um for (_id, _fp, um) in (purged_rows or [])]
+    # fix(#1778 codex r7): (id, user_metadata), because the analysis reap is
+    # keyed on the owning job now rather than on a name two jobs could hold.
+    retained.all.return_value = [
+        (job_row_id, um) for (job_row_id, _fp, um) in (purged_rows or [])
+    ]
     results.append(retained)
 
     purge = MagicMock()

--- a/backend/tests/test_raster_read_bounds_1778.py
+++ b/backend/tests/test_raster_read_bounds_1778.py
@@ -132,7 +132,7 @@ class TestVrtSourceReadTimeouts:
     def test_the_wrappers_enter_the_env_inside_the_worker_thread(self) -> None:
         """A rasterio Env is thread-local, so the ``with`` must be in the
         function ``to_thread`` runs, not around the await."""
-        tree = ast.parse(_source("processing/raster/vrt.py"))
+        tree = ast.parse(_source("processing/ingest/tasks_vrt.py"))
         for name in ("read_vrt_metadata", "render_vrt_quicklook"):
             fn = next(
                 node
@@ -146,3 +146,36 @@ class TestVrtSourceReadTimeouts:
                 for w in withs
                 for item in w.items
             ), f"{name} does not enter gdal_safe_open_env"
+
+    @pytest.mark.parametrize(
+        "wrapper,patched",
+        [
+            ("read_vrt_metadata", "extract_raster_metadata"),
+            ("render_vrt_quicklook", "generate_quicklook"),
+        ],
+    )
+    def test_the_wrapper_calls_through_the_patchable_module_attribute(
+        self, monkeypatch, wrapper: str, patched: str
+    ) -> None:
+        """fix(#1778 codex r3): the names the integration fixtures patch.
+
+        `test_regenerate_vrt_integration`'s `quicklook_stub` does
+        `monkeypatch.setattr("app.processing.ingest.tasks_vrt.generate_quicklook",
+        ...)`, so the wrapper has to both keep that attribute on the module and
+        resolve it at call time. A local import inside the wrapper satisfies
+        neither: it removes the attribute (AttributeError at fixture setup) and,
+        once restored by hand, would silently ignore the stub and run the real
+        renderer against a VRT built from remote sources.
+        """
+        from app.processing.ingest import tasks_vrt
+
+        seen: list[tuple] = []
+
+        def _stub(*args):
+            seen.append(args)
+            return "stubbed"
+
+        monkeypatch.setattr(tasks_vrt, patched, _stub)
+        args = ("some.vrt",) if wrapper == "read_vrt_metadata" else ("some.vrt", 256)
+        assert getattr(tasks_vrt, wrapper)(*args) == "stubbed"
+        assert seen == [args]

--- a/backend/tests/test_raster_read_bounds_1778.py
+++ b/backend/tests/test_raster_read_bounds_1778.py
@@ -1,0 +1,148 @@
+"""Codebase audit 2026-08-30, unbounded raster reads (tracked in #1778).
+
+Two findings about a read with no ceiling on it:
+
+- ``generate_quicklook`` sized its read from the source dimensions rather than
+  from ``size``, so one uploaded file inside the 500 MB cap could OOM the
+  worker.
+- The VRT task opens every ``/vsis3`` source in-thread twice, with no GDAL HTTP
+  timeout, and a Python thread is not killable.
+"""
+
+import ast
+from pathlib import Path
+
+import pytest
+
+APP = Path(__file__).resolve().parents[1] / "app"
+
+
+def _source(rel: str) -> str:
+    return (APP / rel).read_text()
+
+
+class _ReadProbe(Exception):
+    """Raised by the fake dataset instead of allocating the array asked for."""
+
+
+class _FakeSrc:
+    """The narrow slice of a rasterio dataset ``generate_quicklook`` reads.
+
+    ``read`` records the requested ``out_shape`` and raises rather than
+    allocating it. Allocating is what this finding is about: on the unfixed
+    code the first case below asks for a 100000 x 100000 array, and a test that
+    honoured the request would reproduce the OOM rather than report it.
+    """
+
+    def __init__(self, *, width: int, height: int, overviews: list[int]) -> None:
+        self.width = width
+        self.height = height
+        self.count = 1
+        self.nodata = None
+        self.units = ()
+        self._overviews = overviews
+        self.read_shape: tuple[int, ...] | None = None
+
+    def overviews(self, _band: int) -> list[int]:
+        return self._overviews
+
+    def read(self, _indexes, out_shape=None, resampling=None):
+        self.read_shape = out_shape
+        raise _ReadProbe
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_exc):
+        return False
+
+
+class TestQuicklookReadBound:
+    def _requested_shape(self, monkeypatch, src: _FakeSrc) -> tuple[int, ...]:
+        import rasterio
+
+        from app.processing.raster import quicklook
+
+        monkeypatch.setattr(rasterio, "open", lambda *_a, **_kw: src)
+        with pytest.raises(_ReadProbe):
+            quicklook.generate_quicklook("ignored.tif", 512)
+        assert src.read_shape is not None
+        return src.read_shape
+
+    def test_a_ladder_that_stops_short_still_reads_at_most_2x_size(
+        self, monkeypatch
+    ) -> None:
+        """The finding's case: a huge source whose ladder bottoms out above size.
+
+        200000 // 2 is 100000, the only level available, and it used to be the
+        shape passed to ``read`` — a ~30 GB allocation from a file inside the
+        500 MB upload cap.
+        """
+        src = _FakeSrc(width=200_000, height=200_000, overviews=[2])
+        assert max(self._requested_shape(monkeypatch, src)[-2:]) <= 1024
+
+    def test_no_overviews_at_all_is_bounded_too(self, monkeypatch) -> None:
+        src = _FakeSrc(width=40_000, height=30_000, overviews=[])
+        # Aspect ratio survives the clamp.
+        assert self._requested_shape(monkeypatch, src)[-2:] == (768, 1024)
+
+    def test_a_complete_ladder_is_unchanged(self, monkeypatch) -> None:
+        """The bound is what a full ladder already gives, so it must not bite.
+
+        8192 // 16 = 512 is the smallest level reaching `size`, and that is
+        exactly what the selection loop picked before this change.
+        """
+        src = _FakeSrc(width=8192, height=8192, overviews=[2, 4, 8, 16, 32])
+        assert self._requested_shape(monkeypatch, src)[-2:] == (512, 512)
+
+
+# ---------------------------------------------------------------------------
+# The VRT task's in-thread source reads are bounded
+# ---------------------------------------------------------------------------
+
+
+class TestVrtSourceReadTimeouts:
+    def test_the_safe_env_bounds_a_stalled_vsi_read(self) -> None:
+        from app.processing.raster.vrt import _VRT_SAFE_ENV, gdal_safe_env
+
+        for key in (
+            "GDAL_HTTP_TIMEOUT",
+            "GDAL_HTTP_CONNECTTIMEOUT",
+            "GDAL_HTTP_MAX_RETRY",
+        ):
+            assert key in _VRT_SAFE_ENV, key
+            assert gdal_safe_env()[key] == _VRT_SAFE_ENV[key]
+
+    def test_the_open_env_carries_the_same_clamps(self) -> None:
+        """The subprocess env and the in-process env cannot drift."""
+        from app.processing.raster.vrt import _VRT_SAFE_ENV, gdal_safe_open_env
+
+        env = gdal_safe_open_env()
+        for key, value in _VRT_SAFE_ENV.items():
+            assert env.options[key] == value
+
+    def test_the_vrt_task_reads_sources_through_the_safe_env_wrappers(self) -> None:
+        """Both steps that open every source in-thread, in both VRT tails."""
+        source = _source("processing/ingest/tasks_vrt.py")
+        assert "asyncio.to_thread(extract_raster_metadata, vrt_path)" not in source
+        assert "asyncio.to_thread(generate_quicklook, vrt_path" not in source
+        assert source.count("asyncio.to_thread(read_vrt_metadata, vrt_path)") == 2
+        assert source.count("asyncio.to_thread(render_vrt_quicklook, vrt_path") == 4
+
+    def test_the_wrappers_enter_the_env_inside_the_worker_thread(self) -> None:
+        """A rasterio Env is thread-local, so the ``with`` must be in the
+        function ``to_thread`` runs, not around the await."""
+        tree = ast.parse(_source("processing/raster/vrt.py"))
+        for name in ("read_vrt_metadata", "render_vrt_quicklook"):
+            fn = next(
+                node
+                for node in tree.body
+                if isinstance(node, ast.FunctionDef) and node.name == name
+            )
+            withs = [n for n in ast.walk(fn) if isinstance(n, ast.With)]
+            assert any(
+                isinstance(item.context_expr, ast.Call)
+                and getattr(item.context_expr.func, "id", None) == "gdal_safe_open_env"
+                for w in withs
+                for item in w.items
+            ), f"{name} does not enter gdal_safe_open_env"

--- a/backend/tests/test_raster_replace_1221.py
+++ b/backend/tests/test_raster_replace_1221.py
@@ -1113,11 +1113,22 @@ class TestIdempotentReplace:
     async def test_replacing_with_the_identical_file_keeps_the_asset_readable(
         self, test_db_session, raster_storage, tmp_path
     ) -> None:
-        """Replace twice with the same bytes. The second conversion hashes to
-        the key the first one published, so the new object IS the live object —
-        and a reap that only asked "what was the previous pointer" would delete
-        the raster the dataset is serving. The filter on both cleanup paths is
-        what makes this a no-op instead."""
+        """Replace twice with the same bytes.
+
+        The second conversion hashes to what the first one published, and this
+        used to make the new object BE the live object: same dataset id, same
+        content hash, same three keys. A reap that only asked "what was the
+        previous pointer" then deleted the raster the dataset was serving, and
+        the filter on both cleanup paths was what made it a no-op.
+
+        fix(#1778 codex r3): the keys carry an attempt segment now, so the two
+        attempts cannot name one object at all and the collision this test was
+        written for is unreachable. What it pins instead is the pair of
+        properties that collision threatened: the published COG is readable
+        after the second replace, and the superseded one is gone rather than
+        orphaned. The content hash is still shared, which is what keeps this a
+        test about identical bytes.
+        """
         admin_id = (
             await test_db_session.execute(
                 select(User.id).where(User.username == "admin")
@@ -1160,12 +1171,22 @@ class TestIdempotentReplace:
                 ).scalar_one()
                 keys.append(asset.asset_uri)
 
-            assert keys[0] == keys[1], (
-                "identical bytes must hash to one key — otherwise this test is "
-                "no longer exercising the collision it exists for"
+            assert keys[0] != keys[1], (
+                "attempt fencing must give each attempt its own key — a shared "
+                "one is what let the stale-job reaper delete a live raster"
+            )
+            first_sha, second_sha = (key.split("/")[-2] for key in keys)
+            assert first_sha == second_sha, (
+                "identical bytes must still hash to one value — otherwise this "
+                "test is no longer about an identical re-upload"
             )
             assert await raster_storage.exists(keys[1]), (
                 "the live COG was reaped by its own replacement"
+            )
+            assert not await raster_storage.exists(keys[0]), (
+                "the superseded COG must be reaped, not orphaned: with the two "
+                "attempts writing distinct keys, the post-swap followups are "
+                "the only thing that removes the first one"
             )
         finally:
             await _purge(test_db_session, dataset_id=dataset_id, record_id=record_id)

--- a/backend/tests/test_refresh_run_lock_1778.py
+++ b/backend/tests/test_refresh_run_lock_1778.py
@@ -1,0 +1,50 @@
+"""Codebase audit 2026-08-30, cancelling a re-upload (tracked in #1778).
+
+Phase 1 held the ``dataset_refresh_runs`` row lock across the staging
+download, so ``POST /jobs/{id}/cancel`` returned 409 ``job_finishing`` for the
+whole multi-GB download and the rollback discarded the job cancellation it had
+already committed.
+"""
+
+from pathlib import Path
+
+import pytest
+
+APP = Path(__file__).resolve().parents[1] / "app"
+
+
+def _source(rel: str) -> str:
+    return (APP / rel).read_text()
+
+
+class TestRunLockReleasedBeforeDownload:
+    """``claim_run_for_job`` is committed before ``resolve_file_path`` runs."""
+
+    MODULES = [
+        "processing/ingest/tasks_raster_replace.py",
+        "processing/ingest/tasks_reupload.py",
+    ]
+
+    @pytest.mark.parametrize("module", MODULES)
+    def test_a_commit_separates_the_claim_from_the_download(self, module: str) -> None:
+        lines = _source(module).splitlines()
+        claim = next(
+            i for i, line in enumerate(lines) if "await claim_run_for_job(" in line
+        )
+        download = next(
+            i
+            for i, line in enumerate(lines)
+            if i > claim and "await resolve_file_path(" in line
+        )
+        between = [
+            line
+            for line in lines[claim + 1 : download]
+            if "await session.commit()" in line
+        ]
+        assert between, (
+            f"{module}: the pending -> running run transition is not committed "
+            "between the claim and the staging download. transition_run's "
+            "UPDATE ... RETURNING keeps the dataset_refresh_runs row locked "
+            "for the whole download, and cancel_job transitions that same row "
+            "under a 2s lock_timeout."
+        )

--- a/backend/tests/test_search.py
+++ b/backend/tests/test_search.py
@@ -1587,7 +1587,11 @@ async def test_search_datasets_raster_band_nodata_presence(
     shape the client's tri-state nodataState() depends on telling apart.
 
     Pins both states plus the "defined" state as a sanity anchor:
-      - A defined nodata value serializes as that value.
+      - A defined nodata value serializes as that value. fix(#1778): through
+        the shared `stac_band_nodata` normaliser, a defined value now
+        serializes as a NUMBER rather than the raw stored string, since the
+        STAC Raster Extension requires one; the three sentinel strings
+        (nan/inf/-inf) still pass through as strings.
       - Confirmed-absent (RasterAsset.nodata column is None, band lacks its
         own key) serializes as an explicit `nodata: null` -- the key IS
         present.
@@ -1655,7 +1659,7 @@ async def test_search_datasets_raster_band_nodata_presence(
     features = {f["id"]: f for f in resp.json()["features"]}
 
     defined_band = features[str(defined_ds.id)]["properties"]["raster:bands"][0]
-    assert defined_band["nodata"] == "-9999"
+    assert defined_band["nodata"] == -9999.0
 
     absent_band = features[str(absent_ds.id)]["properties"]["raster:bands"][0]
     assert "nodata" in absent_band

--- a/backend/tests/test_tasks_common_phase_brackets.py
+++ b/backend/tests/test_tasks_common_phase_brackets.py
@@ -326,3 +326,84 @@ def test_every_phase2_site_requires_running() -> None:
         source = (APP / rel).read_text()
         count = source.count(needle)
         assert count >= minimum, (rel, needle, "expected", minimum, "got", count)
+
+
+# ---------------------------------------------------------------------------
+# The row lock (fix(#1778 audit r12))
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_a_locked_phase_two_row_is_skipped_not_blocked_by_the_sweep(
+    test_db_session,
+) -> None:
+    """fix(#1778 audit r12): the pin for the TOCTOU round 11 left open. A
+    plain SELECT is not a lock, so the sweep could still fail a row in the
+    window between ``_job_phase_session``'s read and the phase's first
+    irreversible write. ``require_status`` now takes ``FOR NO KEY UPDATE``,
+    and ``fail_stale_jobs``'s running-job transition reads its candidates
+    through a ``FOR UPDATE SKIP LOCKED`` subquery, so a row phase 2 is
+    actively holding is excluded from that pass rather than blocking it (or,
+    for the bulk statement the old code used, aborting the whole pass).
+
+    A genuinely separate connection, not a mock: ``async_session()`` opens
+    its own session/transaction against the same real Postgres instance
+    ``test_db_session`` and the phase-2 hold below both use, which is what
+    makes the row lock a real interleaving rather than a same-transaction
+    no-op.
+    """
+    from datetime import datetime, timedelta, timezone
+
+    from app.core.db import async_session
+    from app.platform.jobs.router import fail_stale_jobs
+
+    job_id = await _create_pending_job(test_db_session)
+    async with _job_phase_session(job_id, phase="phase1") as (session, job):
+        assert job is not None
+        job.status = "running"
+        job.started_at = datetime.now(timezone.utc) - timedelta(hours=2)
+        job.heartbeat_at = None
+        await session.commit()
+    assert await _select_status(test_db_session, job_id) == "running"
+
+    # Phase 2 holding the lock across its first put: acquiring it here and
+    # keeping the transaction open is exactly what `require_status="running"`
+    # does inside `_job_phase_session`, for as long as the caller's session
+    # stays open.
+    async with _job_phase_session(job_id, phase="phase2", require_status="running") as (
+        locked_session,
+        locked_job,
+    ):
+        assert locked_job is not None
+
+        async with async_session() as sweep_session:
+            await fail_stale_jobs(sweep_session, detailed=True)
+
+        # Still running: SKIP LOCKED excluded this row from that pass
+        # instead of blocking on it or failing the pass outright.
+        assert await _select_status(test_db_session, job_id) == "running"
+
+    # The lock is released once phase 2's own session closes. A later sweep
+    # pass now sees the row (still past its cutoff) and settles it.
+    async with async_session() as sweep_session:
+        await fail_stale_jobs(sweep_session, detailed=True)
+
+    assert await _select_status(test_db_session, job_id) == "failed"
+
+
+def test_both_running_job_transitions_use_skip_locked() -> None:
+    """fix(#1778 audit r12): the sweep side of the fix has two independent
+    copies -- ``fail_stale_jobs`` (the periodic sweeper) and the worker's own
+    startup recovery pass -- and both had the identical bulk-UPDATE race, so
+    both need the identical fix. The interleaving test above exercises
+    ``fail_stale_jobs`` end to end; this pins that ``worker.py``'s mirror
+    was not left on the old bare ``UPDATE ... WHERE status = 'running'``,
+    which would still block (or, with a `lock_timeout`, abort the WHOLE
+    batch) on a row a live phase 2 holds locked."""
+    needle = ".with_for_update(skip_locked=True)"
+    for rel in (
+        "platform/jobs/sweep.py",
+        "platform/jobs/worker.py",
+    ):
+        source = (APP / rel).read_text()
+        assert needle in source, rel

--- a/backend/tests/test_tasks_common_phase_brackets.py
+++ b/backend/tests/test_tasks_common_phase_brackets.py
@@ -15,11 +15,20 @@ the helper exposes so a future change cannot silently regress them:
 4. ``commit_persists_on_normal_exit`` — explicit ``session.commit()`` inside
    the block persists (caller owns the commit decision; the helper does not
    auto-commit on exit).
+5. ``require_status`` (fix(#1778 audit r11)) — an optional status predicate
+   that joins the attempt fence. Without it, a row the stale sweep already
+   failed on a heartbeat timeout, with no retry having rotated the attempt
+   token yet, still matched an ``(id, attempt)``-only fence: a worker only
+   paused, not dead, could resume and write whatever that phase writes to a
+   row already declared terminal. A test at the end of this file also pins
+   every current phase-2 call site across the ingest tails to make sure the
+   parameter is actually passed where it matters, not just implemented.
 """
 
 from __future__ import annotations
 
 import uuid as _uuid
+from pathlib import Path
 
 import pytest
 from sqlalchemy import select
@@ -28,6 +37,8 @@ from app.platform.jobs.models import IngestJob
 from app.processing.ingest.tasks_common import _job_phase_session
 
 from tests.factories import get_user_id
+
+APP = Path(__file__).resolve().parents[1] / "app"
 
 
 async def _get_admin_id(session):
@@ -225,3 +236,93 @@ async def test_phase_session_commit_persists_on_normal_exit(test_db_session):
         await session.commit()
 
     assert await _select_status(test_db_session, job_id) == "running"
+
+
+# ---------------------------------------------------------------------------
+# 5. require_status (fix(#1778 audit r11))
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_phase_session_require_status_admits_a_matching_row(test_db_session):
+    """``require_status="running"`` admits a row whose status already
+    matches, the same as the default (no status filter) admits any status."""
+    job_id = await _create_pending_job(test_db_session)
+    async with _job_phase_session(job_id, phase="phase1") as (session, job):
+        job.status = "running"
+        await session.commit()
+
+    async with _job_phase_session(job_id, phase="phase2", require_status="running") as (
+        session,
+        job,
+    ):
+        assert job is not None
+        assert job.status == "running"
+
+
+@pytest.mark.anyio
+async def test_phase_session_require_status_refuses_a_terminal_row(test_db_session):
+    """The pin for the finding itself. A row the stale sweep already failed,
+    with its attempt token UNCHANGED because no retry has rotated it yet,
+    must not be admitted to a phase requiring ``"running"`` -- an
+    ``(id, attempt)``-only fence still matches such a row, which is exactly
+    the gap a worker only paused, not dead, could resume through and go on
+    to write whatever that phase writes.
+    """
+    job_id = await _create_pending_job(test_db_session)
+    async with _job_phase_session(job_id, phase="phase1") as (session, job):
+        attempt_id = job.attempt_id
+        job.status = "running"
+        await session.commit()
+
+    # The stale sweep: fails the row WITHOUT rotating attempt_id, exactly
+    # what a heartbeat-timeout failure does before any retry exists.
+    async with _job_phase_session(job_id, phase="phase1") as (session, job):
+        job.status = "failed"
+        await session.commit()
+
+    async with _job_phase_session(
+        job_id,
+        phase="phase2",
+        attempt_id=attempt_id,
+        require_status="running",
+    ) as (session, job):
+        assert job is None, (
+            "a row the sweep already failed must not be admitted to a "
+            "phase requiring status == 'running', even under the same "
+            "attempt token"
+        )
+
+    # The counterfactual, inline: without require_status, the exact same
+    # (id, attempt) fence still admits the failed row.
+    async with _job_phase_session(job_id, phase="phase2", attempt_id=attempt_id) as (
+        session,
+        job,
+    ):
+        assert job is not None
+        assert job.status == "failed"
+
+
+# ---------------------------------------------------------------------------
+# Every phase-2 site is wired, not just the helper
+# ---------------------------------------------------------------------------
+
+
+def test_every_phase2_site_requires_running() -> None:
+    """fix(#1778 audit r11): the mechanism above is only as good as its
+    callers. Enumerated across the four sites that go through
+    ``_job_phase_session`` and the two in ``tasks_vrt.py`` that predate the
+    helper and match the fence by hand, so a future phase-2 site cannot be
+    added without answering this too.
+    """
+    # (relative path, needle, minimum occurrences)
+    expectations = [
+        ("processing/ingest/tasks_raster.py", 'require_status="running"', 1),
+        ("processing/ingest/tasks_raster_replace.py", 'require_status="running"', 1),
+        ("processing/ingest/tasks_vector.py", 'require_status="running"', 2),
+        ("processing/ingest/tasks_vrt.py", 'IngestJob.status == "running"', 2),
+    ]
+    for rel, needle, minimum in expectations:
+        source = (APP / rel).read_text()
+        count = source.count(needle)
+        assert count >= minimum, (rel, needle, "expected", minimum, "got", count)

--- a/backend/tests/test_tenant_staging_storage_keys.py
+++ b/backend/tests/test_tenant_staging_storage_keys.py
@@ -415,13 +415,18 @@ async def test_cleanup_and_retention_reaper_delete_only_tenant_key(
     # fix(#1709 review r7): nine — the childless-`fanned_out` reconciliation
     # (a fan-out parent whose dispatch died before its first child
     # committed) runs between the running-jobs sweep and the VRT sweep.
-    # fix(#1778 codex r5/r7): ten — the retention purge reads its exempted
-    # rows first, the terminal rows that still name an unreaped artifact,
-    # which it refuses to delete so the record survives for the next sweep to
-    # retry. Missing it here shifted every later result by one: the purge's
-    # DELETE consumed the survivor SELECT's double, `deleted_paths` came back
-    # empty and the tenant-scoped delete this test exists for was never made.
-    empty_scalars = [MagicMock() for _ in range(10)]
+    # fix(#1778 codex r5/r7): nine — the retention purge used to read its
+    # exempted rows first, the terminal rows that still name an unreaped
+    # artifact, which it refused to delete so the record survived for the
+    # next sweep to retry. Missing it here shifted every later result by one:
+    # the purge's DELETE consumed the survivor SELECT's double, `deleted_paths`
+    # came back empty and the tenant-scoped delete this test exists for was
+    # never made.
+    # fix(#1778 codex r10): back down to nine — that exempted-rows SELECT
+    # moved OUT of this block entirely, into the unconditional
+    # artifact-carrying SELECT that now runs after the purge (see below), so
+    # nothing here answers it any more.
+    empty_scalars = [MagicMock() for _ in range(9)]
     for result in empty_scalars:
         result.scalars.return_value = []
         result.all.return_value = []
@@ -433,12 +438,17 @@ async def test_cleanup_and_retention_reaper_delete_only_tenant_key(
     deleted.all.return_value = [(uuid.uuid4(), logical, None)]
     survivors = MagicMock()
     survivors.scalars.return_value = []
+    # fix(#1778 codex r10): the artifact-carrying SELECT, unconditional and
+    # run after the retention block. No rows in this fixture carry an
+    # unreaped artifact.
+    artifact_rows = MagicMock()
+    artifact_rows.all.return_value = []
     # fix(#1202 review r8): one more SELECT for the post-expiry staging sweep.
     post_expiry = MagicMock()
     post_expiry.all.return_value = []
     db = AsyncMock()
     db.execute = AsyncMock(
-        side_effect=[*empty_scalars, deleted, survivors, post_expiry]
+        side_effect=[*empty_scalars, deleted, survivors, artifact_rows, post_expiry]
     )
 
     with _tenant_mode(monkeypatch, "multi_tenant", TENANT_A):

--- a/backend/tests/test_tenant_staging_storage_keys.py
+++ b/backend/tests/test_tenant_staging_storage_keys.py
@@ -415,7 +415,13 @@ async def test_cleanup_and_retention_reaper_delete_only_tenant_key(
     # fix(#1709 review r7): nine — the childless-`fanned_out` reconciliation
     # (a fan-out parent whose dispatch died before its first child
     # committed) runs between the running-jobs sweep and the VRT sweep.
-    empty_scalars = [MagicMock() for _ in range(9)]
+    # fix(#1778 codex r5/r7): ten — the retention purge reads its exempted
+    # rows first, the terminal rows that still name an unreaped artifact,
+    # which it refuses to delete so the record survives for the next sweep to
+    # retry. Missing it here shifted every later result by one: the purge's
+    # DELETE consumed the survivor SELECT's double, `deleted_paths` came back
+    # empty and the tenant-scoped delete this test exists for was never made.
+    empty_scalars = [MagicMock() for _ in range(10)]
     for result in empty_scalars:
         result.scalars.return_value = []
         result.all.return_value = []

--- a/backend/tests/test_vrt_stale_sweep_gap002.py
+++ b/backend/tests/test_vrt_stale_sweep_gap002.py
@@ -229,6 +229,15 @@ def _make_mock_db_for_fail_stale(
         mock_result.scalars.return_value = returned_ids
         results.append(mock_result)
 
+    # fix(#1778 codex r5): the purge now reads its exempted rows first - the
+    # terminal rows that still name an unreaped artifact, which it refuses to
+    # delete so the record survives for the next sweep to retry. None of these
+    # fixtures carry one, so an empty scalars() keeps each test stating only
+    # what it cares about.
+    retained_result = MagicMock()
+    retained_result.scalars.return_value = []
+    results.append(retained_result)
+
     normalized_candidates = [
         row if len(row) == 3 else (uuid.uuid4(), row[0], None)
         for row in (purge_candidates or [])
@@ -517,11 +526,16 @@ async def test_fail_stale_jobs_purges_terminal_jobs_past_retention():
     # fix(#1274 review): legacy-completion recorder then abandonment cancel)
     # + the purge DELETE + the post-expiry staging SELECT.
     # fix(#1709 review r7): +1 — the childless-`fanned_out` reconciliation.
-    assert mock_db.execute.await_count == 11
-    # Indexes 7-8 are the refresh-run sweep now; the purge shifted to 9.
+    # fix(#1778 codex r5): +1 — the purge reads its exempted rows first, the
+    # terminal rows that still name an unreaped artifact. It refuses to delete
+    # those, so the record survives for the next sweep to retry rather than
+    # being discarded by a reap that may fail after this function commits.
+    assert mock_db.execute.await_count == 12
+    # Indexes 7-8 are the refresh-run sweep now; index 9 is the exempted-row
+    # SELECT and the purge DELETE shifted to 10.
     # fix(#1709 review r7): +1 — the childless-`fanned_out` reconciliation
     # sits at index 3, between the running-jobs sweep and the VRT sweep.
-    purge_stmt = mock_db.execute.await_args_list[9].args[0]
+    purge_stmt = mock_db.execute.await_args_list[10].args[0]
     assert isinstance(purge_stmt, Delete)
     where_sql = str(purge_stmt.compile(compile_kwargs={"literal_binds": True}))
     assert "'pending'" in where_sql and "'running'" in where_sql, (

--- a/backend/tests/test_vrt_stale_sweep_gap002.py
+++ b/backend/tests/test_vrt_stale_sweep_gap002.py
@@ -235,7 +235,8 @@ def _make_mock_db_for_fail_stale(
     # fixtures carry one, so an empty scalars() keeps each test stating only
     # what it cares about.
     retained_result = MagicMock()
-    retained_result.scalars.return_value = []
+    # fix(#1778 codex r7): (id, user_metadata) pairs; none in these fixtures.
+    retained_result.all.return_value = []
     results.append(retained_result)
 
     normalized_candidates = [

--- a/backend/tests/test_vrt_stale_sweep_gap002.py
+++ b/backend/tests/test_vrt_stale_sweep_gap002.py
@@ -133,6 +133,7 @@ def _make_mock_db_for_fail_stale(
     stale_vrt_generations: list | None = None,
     purge_candidates: list | None = None,
     surviving_paths: list[str] | None = None,
+    artifact_rows: list | None = None,
 ) -> AsyncMock:
     """Build a mock AsyncSession for fail_stale_jobs.
 
@@ -160,6 +161,13 @@ def _make_mock_db_for_fail_stale(
          are normalized below so each test keeps stating only what it cares
          about.
       6. optional surviving-path SELECT when a deleted row had a file_path
+      7. fix(#1778 codex r10): the artifact-carrying SELECT (id,
+         user_metadata) that feeds both reapers, run unconditionally after
+         the retention block — a deployment with retention disabled still
+         owes these reaps, which is why it sits outside the
+         ``ingest_jobs_retention_days > 0`` guard rather than beside the
+         purge. It replaces the old exempted-rows-first SELECT that used to
+         run INSIDE the purge block ahead of the DELETE.
     """
     results = []
     for index, returned_ids in enumerate(
@@ -229,16 +237,6 @@ def _make_mock_db_for_fail_stale(
         mock_result.scalars.return_value = returned_ids
         results.append(mock_result)
 
-    # fix(#1778 codex r5): the purge now reads its exempted rows first - the
-    # terminal rows that still name an unreaped artifact, which it refuses to
-    # delete so the record survives for the next sweep to retry. None of these
-    # fixtures carry one, so an empty scalars() keeps each test stating only
-    # what it cares about.
-    retained_result = MagicMock()
-    # fix(#1778 codex r7): (id, user_metadata) pairs; none in these fixtures.
-    retained_result.all.return_value = []
-    results.append(retained_result)
-
     normalized_candidates = [
         row if len(row) == 3 else (uuid.uuid4(), row[0], None)
         for row in (purge_candidates or [])
@@ -251,6 +249,14 @@ def _make_mock_db_for_fail_stale(
         survivors_result = MagicMock()
         survivors_result.scalars.return_value = surviving_paths or []
         results.append(survivors_result)
+
+    # fix(#1778 codex r10): the artifact-carrying SELECT, unconditional and
+    # outside the retention block — see the docstring above. None of these
+    # fixtures carry an unreaped artifact, so an empty .all() keeps each test
+    # stating only what it cares about.
+    artifact_rows_result = MagicMock()
+    artifact_rows_result.all.return_value = artifact_rows or []
+    results.append(artifact_rows_result)
 
     # fix(#1202 review r8): the post-expiry presigned-staging sweep issues one
     # more SELECT after the purge. No candidates in these fixtures, so an empty
@@ -525,18 +531,20 @@ async def test_fail_stale_jobs_purges_terminal_jobs_past_retention():
     # VRT asset UPDATE split into two (ready / degraded, fix(#1322 review
     # round 3)) + the refresh-run sweep's TWO statements (feat(#1219),
     # fix(#1274 review): legacy-completion recorder then abandonment cancel)
-    # + the purge DELETE + the post-expiry staging SELECT.
+    # + the purge DELETE + the artifact-carrying SELECT + the post-expiry
+    # staging SELECT.
     # fix(#1709 review r7): +1 — the childless-`fanned_out` reconciliation.
-    # fix(#1778 codex r5): +1 — the purge reads its exempted rows first, the
-    # terminal rows that still name an unreaped artifact. It refuses to delete
-    # those, so the record survives for the next sweep to retry rather than
-    # being discarded by a reap that may fail after this function commits.
+    # fix(#1778 codex r10): the purge no longer reads exempted rows itself —
+    # that SELECT moved out of the retention block into the unconditional
+    # artifact-carrying query below, which is what keeps the total the same
+    # even though the purge DELETE shifts one slot earlier.
     assert mock_db.execute.await_count == 12
-    # Indexes 7-8 are the refresh-run sweep now; index 9 is the exempted-row
-    # SELECT and the purge DELETE shifted to 10.
+    # Indexes 7-8 are the refresh-run sweep now; the purge DELETE sits at 9
+    # (no survivors SELECT here, since the one purge candidate has no file
+    # path) and the artifact-carrying SELECT at 10.
     # fix(#1709 review r7): +1 — the childless-`fanned_out` reconciliation
     # sits at index 3, between the running-jobs sweep and the VRT sweep.
-    purge_stmt = mock_db.execute.await_args_list[10].args[0]
+    purge_stmt = mock_db.execute.await_args_list[9].args[0]
     assert isinstance(purge_stmt, Delete)
     where_sql = str(purge_stmt.compile(compile_kwargs={"literal_binds": True}))
     assert "'pending'" in where_sql and "'running'" in where_sql, (
@@ -700,10 +708,14 @@ async def test_fail_stale_jobs_retention_zero_disables_purge(monkeypatch):
     # 5 sweeps (two pending clauses since fix(#1234)) plus the VRT asset
     # UPDATE split into two (ready / degraded, fix(#1322 review round 3))
     # plus the refresh-run sweep's two statements (feat(#1219), fix(#1274
-    # review)) and no purge DELETE, plus the post-expiry staging SELECT,
-    # which is independent of retention.
+    # review)) and no purge DELETE, plus the artifact-carrying SELECT and the
+    # post-expiry staging SELECT, both independent of retention.
     # fix(#1709 review r7): +1 — the childless-`fanned_out` reconciliation.
-    assert mock_db.execute.await_count == 10
+    # fix(#1778 codex r10): +1 — the artifact-carrying SELECT runs outside the
+    # retention block on purpose, so a deployment with retention disabled
+    # still owes a reap for a row that carries an unpublished storage key or
+    # an unadopted analysis table.
+    assert mock_db.execute.await_count == 11
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Codebase audit 2026-08-30 (8dc529f17), tracked in #1778. Lane M6, raster and analysis lifecycle: nine findings, eight fixed, one already closed on main.

## Already fixed on main, skipped

**"A cancel or connection loss during `session.commit()` makes the raster-replace failure cleanup delete the live COG the committed row now points at"** does not reproduce. #1784 landed `publish_commit_landed` in `tasks_raster_common.py` and all four publish tails (`tasks_raster.py:641`, `tasks_raster_replace.py:697`, `tasks_vrt.py:656` and `:1310`) now decide by observation on a fresh session and stand down rather than re-raise. Nothing left to do.

## Fixed

**"Cancelling a re-upload 409s for the whole staging download"** (CONFIRMED). `claim_run_for_job` goes through `transition_run`, whose `UPDATE ... RETURNING` holds the `dataset_refresh_runs` row until the transaction ends, and phase 1 then downloaded the staged upload inside it. `cancel_job` transitions the same row under a 2s `lock_timeout`, so every cancel during the download hit 55P03 and returned 409 `job_finishing`, and the rollback discarded the `status='cancelled'` the job CAS had already committed. Both tails now commit immediately after the claim. Counterfactual: `TestRunLockReleasedBeforeDownload` fails on main for both modules (no commit between the claim and `resolve_file_path`), passes after.

**"The COG, VRT and quicklook puts register their keys AFTER the write"** (CONFIRMED). Both storage providers drain the worker thread before re-raising `CancelledError`, so a cancelled put can have completed, and `CancelledError` is a `BaseException`, so the `append` below it never runs. `archive_lossy_original` was rewritten to register by intent one function away; the other twelve sites now match it. Counterfactual: `TestRegisterBeforeWrite` fails on main for all twelve (module, key) pairs, passes after.

**"Objects written under `rasters/` and `originals/` before the terminal commit have no out-of-process reaper"** (CONFIRMED). `written_storage_keys` is a local list, so a SIGKILL or OOM between the puts and the terminal `finally` reclaimed nothing: `base_key` embeds a dataset id that rolls back with the transaction, and no row, no `delete_dataset` prefix reap and no staging reconciler could name the objects again. Each raster tail now writes the keys it is about to create onto the job row, in its own committed session before phase 2 takes that row's lock, and both stale-job passes reap them after their own settling commit. No survivor query: every one of these tails stamps the job's terminal status in the same transaction as the pointer it publishes, so a row this pass moves off `running` cannot have a durable publish behind it. The kept original is registered on first ingest only, because on the replace path its key is content-derived and can already hold an earlier upload's archive. Counterfactual: `TestUnpublishedStorageKeys` fails on main (helper absent, `_reap_committed_staged_paths` reaps nothing, `fail_stale_jobs` carries nothing), passes after.

**"A hard worker kill after the materialize commit leaks the analysis output table"** (CONFIRMED). The name is now persisted to `user_metadata` in the transaction that creates the table, and the probe-then-drop the two fence-miss handlers carried inline becomes one `drop_unadopted_analysis_output` the two stale-job passes call. It keeps those handlers' leak-over-loss direction and re-validates the identifier, because the name now arrives through a schemaless JSONB blob and is interpolated into DDL. The reap takes its own session after the settling commit so a DROP cannot block the sweep on a lock a dead worker might still hold. Counterfactual: `TestUnadoptedAnalysisOutput` fails on main, passes after.

**"generate_quicklook reads an unbounded array"** (CONFIRMED). The read is clamped to twice the target edge, aspect ratio preserved. That is the bound a complete overview ladder already gives, so a well-formed COG reads exactly what it read before and only a ladder that stops short is affected; the headroom is kept rather than reading at `size` outright because `_crop_to_valid` crops before the resize. Counterfactual: `TestQuicklookReadBound` fails on main, where a 200k x 200k source with one 2x overview asks for a 100000 x 100000 array. The fake dataset records the requested shape and raises instead of allocating it, so the test reports the OOM rather than reproducing it.

**"The unkillable-stalled-source hazard is reintroduced two steps later in the same task"** (CONFIRMED). `_VRT_SAFE_ENV` gains `GDAL_HTTP_CONNECTTIMEOUT`, `GDAL_HTTP_TIMEOUT` and `GDAL_HTTP_MAX_RETRY`, which reach both `gdal_safe_env` and `gdal_safe_open_env`, and steps 6 and 8 of both VRT tails go through `read_vrt_metadata` / `render_vrt_quicklook`, which enter the env inside the worker thread because a rasterio `Env` is thread-local. `build_vrt`'s docstring now says the hazard is bounded rather than gone. No `GDAL_HTTP_FOLLOWLOCATION` anywhere. Counterfactual: `TestVrtSourceReadTimeouts` fails on main, passes after.

**"STAC `raster:bands[].nodata` is published as a numeric string"** and **"band_info is a polymorphic JSONB blob with two incompatible producer shapes"** (both CONFIRMED, fixed together). Chose to normalise on read rather than migrate, which the brief allows: the two readers are the only consumers and neither can be handed a shape it does not understand without normalising anyway. Canonical shape is `extract_raster_metadata`'s. `stac_band_nodata` emits a number for anything that parses, keeps the three extension sentinels as strings and drops the rest; `band_display_name` reads `color_interp` as well as `name`; an empty entry is skipped, so a remotely described COG omits the field instead of publishing `[{}, {}, {}]`. Both live in `app/core/raster_bands.py` because `app/modules/catalog/` may not import `app.processing` (CATPORT-02/04) and the two serializers sit on either side of that line. Counterfactual: `TestBandInfoShapes` fails on main, passes after. The new fixtures build from the producer's real shape rather than the idealised dict the two existing tests hand-build.

## Schema, API and config impact

None. No migration, no request or response schema change, no new setting. The three GDAL HTTP clamps are process-internal constants. `user_metadata` gains two keys on rows the workers already write, both in an existing schemaless JSONB column.

## Module LOC caps raised

- `platform/jobs/sweep.py` 1857 to 1991: the two reapers, their metadata readers and the docstrings stating why neither needs a survivor query.
- `processing/analysis/tasks.py` 1420 to 1462: the shared `drop_unadopted_analysis_output` and its identifier check, less the two inlined copies it replaces.
- `processing/ingest/tasks_vrt.py` 1480 to 1496: register-before-put, the safe-env wrappers, the caller-chosen dataset id.
- `processing/ingest/tasks_reupload.py` 1283 to 1291: the early commit and its rationale.
- `modules/catalog/search/service_records.py` 526 to 537 (the decomposed-module budget, not `_MODULE_LOC_CAPS`): the band array built through the shared normalisers.

Each set to the exact measured figure.

## Verification

Run from the worktree against Postgres on 5434.

- `pytest tests/test_layering.py tests/test_rule1_structural.py tests/test_rule2_structural.py` plus the five new files: 202 passed.
- `pytest tests/test_raster_replace_1221.py tests/test_raster_ingest.py tests/test_raster_ingest_orphan_cleanup_gap017.py tests/test_vrt_stale_sweep_gap002.py tests/test_stale_pending_reaper.py tests/test_tenant_job_recovery.py tests/test_presigned_staging_reap_1202.py tests/test_staging_orphan_reconcile_1249.py tests/test_ingest_job_attempt_fencing.py`: 333 passed.
- `pytest tests/test_analysis_materialize.py tests/test_analysis_provenance.py tests/test_jobs_retry_analysis_copy.py tests/test_stac_asset_model.py tests/test_vrt_catalog_175.py tests/test_quicklook_predicate.py tests/test_raster_dataset_assets_bug041.py tests/test_ogc_record_properties.py tests/test_ogc_record_enrichment.py`: 227 passed.
- Counterfactual: with `backend/app` reverted to `origin/main` and the five new files in place, 45 of 51 failed. The six that passed are the ones that assert unchanged behaviour on purpose (the three lower-case nodata sentinels, the complete-ladder no-op, the commit-failure case, and the env drift check).
- `ruff check .` and `ruff format --check .` clean over the whole backend.

## Left alone

- `reupload_service`'s phase 1 has the same claim-then-work shape as the two tails fixed here, but the work between the claim and the commit is cheap reads and a `DROP TABLE IF EXISTS`, not a multi-GB download. Out of this lane's scope.
- The `originals/` key on the replace path is deliberately not registered for the sweep, for the reason given above. `archive_lossy_original` still registers it when its own pre-write probe proves absence, which is the narrower and correct condition.
- `tasks_reupload.py` is also in the scope of #1770; the hunk here is one commit and one comment, so a rebase should be trivial.
- Producer B's `{min, max, mean}` values are dropped rather than mapped to a `statistics` object. That is a feature, not a defect, and it belongs with whatever adds statistics support.


## Round 1

One P1, on `tasks_raster_replace.py`. Fixed in `e274bd1df`.

**Exclude already-live raster keys from stale-job reaping.** An identical re-upload breaks the assumption the durable reaper shipped on. A replacement that converts to the same COG derives the same `asset_sha256`, so `rasters/{dataset_id}/{sha}/` is the prefix the dataset is already serving, and the three keys the replace tail recorded as "about to write" were the three keys the live `RasterAsset` names. A crash at any point after that write, including before the first put, then let both stale-job passes delete the served COG and its quicklooks. The in-process failure cleanup has always excluded `prior_physical_keys`; the durable record had no equivalent, and the comment beside it asserted the opposite.

Fixed in two halves, because either alone leaves the hole open to the next writer.

At write time, `record_unpublished_storage_keys` takes `already_published` and subtracts it before the JSONB write, inside the function rather than at the call sites, so a future writer of intended keys gets the exclusion by having to answer the question. The replace tail passes the live asset's three keys in logical form, captured in phase 1 beside the physical list it already captured: the durable record is logical, so comparing against `prior_physical_keys` would match nothing on a hosted deployment while looking correct. The first-ingest tail passes an empty set, provably empty because every key it records sits under a dataset id generated three lines earlier.

At reap time, `reap_unpublished_storage_keys` owns a survivor check and is the only function that deletes these keys. It asks the four columns that can name an object under `rasters/` or `originals/` (`raster_assets.asset_uri`, `.quicklook_256_uri`, `.quicklook_512_uri`, `dataset_assets.href`) and refuses anything they return, whatever the job row says, including a row written by a version of this code that did not know to subtract. A survivor query that raises deletes nothing, the same leak-over-loss direction the rest of the module takes. Both the periodic sweep and the worker's startup recovery go through it.

Enumeration of every site that records intended keys: `tasks_raster.py` and `tasks_raster_replace.py`, and nothing else. The two re-upload tails record no storage keys (their only change here is the run-lock commit), the VRT regeneration path has its own generation reaper and is untouched, and the analysis path records a table name whose reaper already gates on the adoption probe. `test_every_site_that_records_intended_keys_states_the_exclusion` walks `app/processing/` and pins that set plus the rule that every call passes `already_published`.

Counterfactual: `TestIdenticalReplacementKeepsTheLiveAsset` and `TestLiveReferenceQuery` in `backend/tests/test_raster_object_ownership_1778.py`. Six tests, all failing on `fdc3d4a4e` and passing on `e274bd1df`. They pin the case the review named: the live keys are never recorded, a genuinely new key still is, the reaper refuses the three live keys while still deleting a genuinely orphaned key handed to it in the same batch, an unreadable catalog deletes nothing, and the survivor query runs against real Postgres rows across all four columns rather than a double.

Cap moved: `_MODULE_LOC_CAPS` for `platform/jobs/sweep.py` 1991 to 2077, exact, reason in the entry.

Verification after the fix: `pytest tests/test_layering.py tests/test_rule1_structural.py tests/test_rule2_structural.py` 151 passed; the five audit test files plus `test_vrt_stale_sweep_gap002.py`, `test_stale_pending_reaper.py`, `test_tenant_job_recovery.py`, `test_presigned_staging_reap_1202.py` 186 passed; `test_raster_replace_1221.py`, `test_raster_ingest.py`, `test_raster_ingest_orphan_cleanup_gap017.py`, `test_ingest_job_attempt_fencing.py`, `test_staging_orphan_reconcile_1249.py` 204 passed. `ruff check .` and `ruff format --check .` clean.


## Round 3

CI on `e274bd1df` (run 33700485230, Backend Tests): 11049 passed, 5 errors, all at fixture setup in `tests/test_regenerate_vrt_integration.py` with `AttributeError: module app.processing.ingest.tasks_vrt has no attribute generate_quicklook`. Fixed in `c91a25c9b`.

Mine. The safe-env wrappers I added for the stalled-source finding went into `raster/vrt.py` with function-level imports, which dropped both `extract_raster_metadata` and `generate_quicklook` out of `tasks_vrt`'s namespace. Two suites patch those attributes there: `quicklook_stub` in the regeneration integration tests, and two `TestAddSource` cases in `test_vrt_source_management_174.py` that stub both.

Restoring the attribute on its own would have been worse than the error it fixed. The wrappers would still have called their own local import, so the stub would have been installed, ignored, and the real renderer would have run against a VRT built from remote sources, in tests written to avoid exactly that. So the wrappers move into `tasks_vrt.py` and call both names through this module's globals, which is what makes a patch take effect at call time. `raster/vrt.py` keeps `_VRT_SAFE_ENV` and `gdal_safe_open_env`, and its `shift_vrt_longitude_frame` docstring now points at the two callers by their new home.

Counterfactual for the routing, which is the half no error message announces: with the attribute restored but a local import inside the wrapper, `test_the_wrapper_calls_through_the_patchable_module_attribute[render_vrt_quicklook-generate_quicklook]` fails while everything else passes. The CI error itself is the counterfactual for the missing attribute.

Swept `tests/` for every attribute patch naming a symbol this PR moved. The only removals in the whole PR were those two `tasks_vrt` imports; `sweep.py`, `worker.py`, `analysis/tasks.py`, `tasks_raster.py`, `tasks_raster_replace.py`, `raster/models.py` and `service_records.py` only gained names, and `create_raster_dataset` / `create_vrt_dataset` only gained a defaulted keyword. Grep across `tests/` for `tasks_vrt.`, `tasks_raster.`, `tasks_raster_replace.`, `tasks_raster_common.`, `jobs.sweep.`, `jobs.worker.`, `analysis.tasks.`, `raster.vrt.`, `raster.quicklook.`, `raster.models.` and `search.service_records.` returned 28 files; the two above are the only ones naming a symbol that moved.

Ran every one of those files:

- `test_regenerate_vrt_integration.py`, `test_vrt_source_management_174.py`: 48 passed.
- `test_vrt_creation_173.py`, `test_vrt_rewrite.py`, `test_vrt_source_authz_1172.py`, `test_vrt_staged_mutation_1327.py`, `test_vrt_stale_sweep_gap002.py`, `test_worker.py`, `test_stalled_queue_sweep_624.py`, `test_tenant_job_recovery.py`, `test_stale_pending_reaper.py`, `test_defer_orphan_guard.py`: 198 passed.
- `test_analysis_intersect.py`, `test_analysis_materialize.py`, `test_analysis_preview.py`, `test_cog_head_ranges_1528.py`, `test_ingest_raster_open_failure_message.py`, `test_strict_cog_enforcement.py`, `test_tasks_common_phase_brackets.py`, `test_rule2_structural.py`: 407 passed.
- `test_layering.py` plus the five audit files: 56 passed on the read-bounds and layering pair, the rest unchanged from round 1.
- `ruff check .` and `ruff format --check .` clean.

Cap moved: `_MODULE_LOC_CAPS` for `processing/ingest/tasks_vrt.py` 1496 to 1530, exact, reason in the entry. `raster/vrt.py` shrank by the same wrappers and is not capped.


### Round 3 review

One P1 on `sweep.py`, fixed in `ab229f43d`.

**Fence new replacements before deleting stale keys.** `fail_stale_jobs` commits once, and that commit settles the dead attempt AND releases the dataset's active-run reservation through the refresh-run sweep, so the post-commit cleanup runs with the door open. Replace keys were derived from dataset id plus content hash alone, so a retry of the same upload derived exactly the keys the reaper was holding: land the new attempt's puts between the survivor snapshot and the delete, with no row naming them yet, and the reaper removes them, after which the new attempt commits a `RasterAsset` pointing at nothing. My comment on the reaper had argued this away, claiming no survivor query was needed because a row still `running` cannot have a durable publish behind it. That is true of the attempt being reaped and says nothing about the next one.

Closed structurally rather than by ordering. Replace objects now live under `rasters/{dataset}/attempts/{attempt}/{sha}/`, the shape the VRT publish path already uses for the same reason (`generations/{generation_id}/`) and the convention `attempt_scoped_staging_table` applies to the vector tails' staging tables. Two attempts cannot name one object, so there is no window left to order around and no future caller of the reaper can reopen it. One helper, `attempt_scoped_raster_base_key`, derives it for both the durable record and the put block, because recording one prefix and writing another would be silent. The content hash stays in the key: invariant 10 rests on a replacement never overwriting the live asset in place.

The ordering fallback was the weaker option, not just the cheaper one. Deleting before the settling commit is what `_reap_stale_generation_storage`'s docstring warns against: a commit that then fails leaves the objects gone while the job row is still `running`, so a resumed worker publishes a pointer to deleted bytes. That trades one instance of this failure for another, and it would put storage I/O for an unbounded key list inside the sweep transaction.

Nothing parses the key's depth, so read paths are unaffected: `asset_uri` is read back from the row, `resolve_storage_key` only prefixes tenants, `delete_dataset` reaps the `rasters/{dataset_id}/` prefix which still contains it, and `vrt_rewrite` uses `posixpath.relpath`, which already emits `../..` for cross-dataset members.

`record_unpublished_storage_keys` also takes `attempt_scope` now and drops any key that does not carry it, checked at the single point where keys become durable. The first-ingest tail passes the dataset id it generates per task invocation, which is its own attempt fence and the reason its keys need no extra segment. The round-1 exclusion and the reaper's survivor check both stay, as defence in depth behind a layout that makes the collision unreachable.

Counterfactual: `TestAttemptScopedReplaceKeys` in `backend/tests/test_raster_object_ownership_1778.py` plus the updated `TestIdempotentReplace` in `test_raster_replace_1221.py`. Seven tests, all failing on `c91a25c9b` and passing on `ab229f43d`. They pin the review's scenario directly (a replacement admitted mid-reap keeps its objects while the stale attempt's are still reaped, with the survivor snapshot empty for both sets), two attempts of the same upload sharing no key, the hash surviving in the key, a key outside the attempt never being recorded, both derivations going through the one helper, and the first-ingest fence being ordered correctly. `TestIdempotentReplace` kept its subject and changed its assertion, since the collision it exercised is now unreachable: identical bytes still hash to one value, the published COG is still readable, and the superseded object is now reaped rather than orphaned, which the shared key made unobservable.

Verification: replace, ingest, orphan-cleanup, dataset-assets and layering suites 208 passed; tile, VRT, VRT-rewrite, regeneration-integration, source-management and distribution suites 209 passed; structural, audit and sweep suites 219 passed. `ruff check .` and `ruff format --check .` clean.

No cap moved this round: none of the three files touched is in `_MODULE_LOC_CAPS`.


## Round 4

Two P2s, both keys that never reached an owner outside the process that wrote them. Both fixed in `b137a1195`.

**Persist the initial VRT keys.** `ingest_vrt` was the one publish tail the reaper was extended past without extending the recorder to. It puts the VRT and its quicklooks before the terminal commit, `written_storage_keys` is a local list that dies with the process, and the generated dataset id the keys embed rolls back with the transaction, so nothing left alive could reconstruct them. It now does what `ingest_raster` does: the dataset id is preselected before phase 2 opens and handed to `create_vrt_dataset`, and the three intended keys are written to the job row before the first put, where both stale passes reap them under the survivor check. Attempt scoping is satisfied without an `attempts/` segment, and `attempt_scope=str(planned_dataset_id)` is what says so: the id is generated per task invocation, so a retry produces a different one, and the recorder rejects any key that does not carry the token.

**Every put site now has to name its owner.** `TestEveryPutSiteHasAnOwner` walks every `storage.put` under `app/processing/` by AST and requires the enclosing function to either call `record_unpublished_storage_keys` in the same function, before its puts, or carry a `PUT_SITES_WITH_ANOTHER_OWNER` entry naming the reaper that can reconstruct the key from something durable. Eighteen sites: nine record intent (three tails, three keys each) and six functions take an entry.

- `regenerate_vrt` (3): generation-scoped, rebuilt from the `VrtGeneration` row by `_stale_generation_storage_keys`.
- `_archive_original_file` (1): recorded by first ingest; deliberately probe-gated on replace, because the content-derived key can already hold an earlier upload's archive that a live `dataset_assets` row names.
- `_generate_quicklook` (1): `vectors/{dataset_id}/`, written post-commit, owned by `delete_dataset`'s prefix reap.
- `save_upload_file` (2) and `_put_staging_object` (1): `staging/`, owned by the staging reconciler and the presigned-staging sweep.
- `artifact_cache._write` (1): the export artifact cache and its TTL sweep.

Counts are exact in both directions, so a new put inside a justified function fails on its own rather than riding the entry, and the failure message names the site: on `ab229f43d` it prints `processing/ingest/tasks_vrt.py::ingest_vrt (3 put(s))`. A second test pins the ordering for all three recording tails, since a record after the put is lost with the process just the same.

**The retention purge is the last owner.** The two stale passes only read rows they move off `running`, so a job that reached `failed` or `cancelled` on its own, whose in-process best-effort cleanup then failed once, kept its objects and its output table with the record still naming them and nothing looking again. The purge's `DELETE ... RETURNING` already carried `user_metadata` (widened for the presigned staging key in #1202), so this is routing rather than a query change: those rows now feed the same two post-commit reaps the running-row sweep feeds. Both survivor checks apply, which matters more on this door: a purged row can legitimately name a key a dataset is serving, since an ingest that succeeded and never had its recorded intent cleared is purgeable once past retention.

Counterfactual: `TestEveryPutSiteHasAnOwner` and `TestRetentionPurgeIsTheLastOwner`, plus the round-1 writer enumeration which now names three tails. Five of the seven fail on `ab229f43d` and pass on `b137a1195`; the two that pass on both assert properties the earlier code also had (the allowlist counts for the six justified sites, and a rolled-back purge deleting nothing).

Verification: the ownership and layering suites 88 passed; VRT creation, catalog, regeneration-integration, source-management, stale-sweep and stale-pending suites 247 passed; structural, audit, worker, recovery and staging suites 228 passed; replace, ingest, orphan-cleanup, attempt-fencing and defer-guard suites 172 passed. `ruff check .` and `ruff format --check .` clean.

Caps moved, both exact with the reason in the entry: `processing/ingest/tasks_vrt.py` 1530 to 1568, `platform/jobs/sweep.py` 2077 to 2100.


## Round 5

One P2 on `sweep.py`, two halves. Fixed in `cc72c6abc`.

**The survivor query outgrew asyncpg's argument ceiling.** Four `IN` clauses over the same key list is four binds per key, so from about 8192 keys the query raises `the number of query arguments cannot exceed 32767`. The reaper's own "an unreadable catalog deletes nothing" rule then skipped every delete, which is correct in isolation and lossy in context: the retention purge had already committed the deletion of the rows that were those keys' last durable owners. It is now a single `BindParameter` of `ARRAY(Text)`, the same object in all four arms, compared with `= ANY(...)`, so the argument count is one whatever the key count. Keys are deduplicated once at the top of the reaper, so the query and the delete loop each see a key exactly once.

**The job row is the pending-reap record.** I took the second option offered. The purge no longer deletes a row that still names an unreaped artifact, and the reapers clear that record once they have a final answer about it, at which point the next pass purges the row normally. A reap that fails leaves the fields in place and the next sweep retries.

Reordering the reap to before the commit was the other option and it is worse here. The deletes are storage I/O over a list that can run to tens of thousands of keys, and running them inside the sweep's transaction holds a pooled connection and an open transaction for the whole of it, which is the hazard gh #100 exists for and which this module's two-phase session rule is written against; rolling the purge back on failure would additionally need a savepoint around the `DELETE`. The exemption keeps the I/O post-commit, bounds the loss the same way, and needs no new table.

Two decisions worth naming, both stated in the code. "Accounted for" is wider than "deleted": a key a live row still names is refused, and refusing it again on every sweep forever would pin the job row for the life of the dataset, so both outcomes clear the record and only an error keeps it. And storage keys clear as a set through a JSONB containment test rather than per key, because a row names all three of its objects at once and clearing the field while one is unresolved would drop the other two from the record with it.

Counterfactual: `TestReapScalesAndStaysRetryable`, seven tests, all failing on `b137a1195` and passing on `cc72c6abc`. The two pins the review named are exercised against real Postgres rather than a double: ten thousand keys in one sweep with a live key planted among them and still returned by the survivor check (the test asserts `len(keys) * 4 > 32767`, so it cannot silently stop covering the ceiling), and the containment clear on a fully settled row and a partly settled one. The rest cover the purge's exemption predicates, a delete that raised keeping its record while its siblings clear, a refused key clearing its record, a failed survivor query clearing nothing, and duplicate keys being deleted once.

Three shared session doubles gained the exempted-row `SELECT` the purge now issues first, and `test_fail_stale_jobs_purges_terminal_jobs_past_retention`'s pinned execute count moves 11 to 12 with the `DELETE` at index 10.

Verification: layering, rule 1 and rule 2 suites 151 passed; the ownership, VRT stale-sweep, stale-pending, tenant-recovery, jobs-router and layering suites 240 passed before the cap bump and clean after; the audit, worker, staging and analysis-materialize suites 213 passed; replace, ingest, orphan-cleanup, regeneration-integration, source-management and attempt-fencing suites 209 passed. `ruff check .` and `ruff format --check .` clean.

Cap moved: `_MODULE_LOC_CAPS` for `platform/jobs/sweep.py` 2100 to 2252, exact, with the reason in the entry.


## Round 6

One P2 on `sweep.py`, mine from round 5. Fixed in `76a47b31d`.

**A cleanup that failed was being recorded as settled.** `drop_unadopted_analysis_output` catches its own adoption-probe and DROP failures, so it returned the same `None` whether it had dropped the table or failed to. Round 5's "only a final answer clears the record" rule was built on top of that, reading "it did not raise" as success: `_clear_settled_artifact_records` stripped the table's last durable name off the job row, the retention purge deleted the row, and the table was orphaned permanently. The leak the function exists to prevent, reintroduced by the function itself.

It reports now. Five outcomes, split by whether the answer can still change: `adopted`, `dropped`, `invalid` and `skipped` are final and license forgetting the name; `failed` keeps the record so the next sweep retries. `invalid` is final on purpose, because a name that is not an identifier `generate_table_name` could have produced names no table this system made and no retry can change the string, so keeping it would pin the job row forever.

A probe that RAISES is `failed`, not `adopted`. Treating an unreadable catalog as adoption is the right call for deciding whether to DROP, since it prefers a leak to destroying a live dataset's storage, and the wrong one for deciding whether the question is settled, because nothing was established. Those two decisions were sharing a variable and now do not. The two fence-miss handlers inside the worker ignore the return; they leave the job row naming the table either way.

**Both arms, not just the reported one.** There are exactly two callers of `_clear_settled_artifact_records`, and no scratch or export reaper feeds it. The storage arm was already correct, but only by where `settled.add(key)` sat inside a try block, which is one edit away from the analysis arm's bug. Both arms now name the outcome and settle off the name: `STORAGE_KEY_FINAL_OUTCOMES` is the peer of the analysis set, and a `try/else` makes it structurally impossible for a raised delete to be counted as a deleted one. `refused` is final on that side for the same reason `adopted` is on this one, and with the same consequence if it were not. `test_every_arm_that_clears_a_record_keys_off_a_named_outcome` enumerates the callers by AST, pins the set, and requires each to consult its final-outcome vocabulary, so a third arm has to be added deliberately.

Counterfactual: `TestOnlyASettledArtifactLosesItsRecord`, fourteen tests. Eight fail on `cc72c6abc` and all pass on `76a47b31d`; the six that pass on both assert behaviour the previous commit already had, including the storage arm, which is the point of having checked it rather than assumed it. The pin the review asked for runs against real Postgres: a DROP that raises leaves `analysis_out_table` on the job row, which is what keeps the row exempt from the retention purge and the orphan reachable.

Verification: layering, rule 1 and rule 2 suites 151 passed; ownership, analysis-reap, VRT stale-sweep, stale-pending, tenant-recovery, jobs-router and worker suites 232 passed; analysis materialize, intersect, provenance, preview, retry-copy and the remaining audit suites 259 passed. `ruff check .` and `ruff format --check .` clean.

Caps moved, both exact with the reason in the entry: `platform/jobs/sweep.py` 2252 to 2288, `processing/analysis/tasks.py` 1462 to 1495.


## Round 8

One P1 from the round-7 review, plus that round's red CI. Both in `fad79fa77`.

**Two jobs could hold one physical table name.** Nothing retires an analysis output's name, because an unregistered output never became a dataset, so once an old failed job's table was gone `generate_table_name` handed the same name to the next analysis with the same title. Let that new job commit its CTAS between the sweep's adoption probe and its DROP and the sweep destroyed the new job's table, and the name-keyed record clearing then erased the new job's recovery pointer along with the old one's.

Fixed at the root. `analysis_output_table_name` appends 16 hex characters of the job id, the width and formula `attempt_scoped_staging_table` already uses for staging tables and `attempt_scoped_raster_base_key` uses for replace object keys. No two jobs can name one table, so there is no interleaving left to get wrong, the adoption probe cannot be raced, and the sweep verifies ownership from the name alone: no comment, no registry row, no advisory lock, and no name-based lookup left that would need one.

Scoped by job and not by attempt, deliberately. A retry reuses the job row and therefore the single `analysis_out_table` field on it, so an attempt-scoped name would change under that field on every retry and strand the previous attempt's orphan with nothing naming it, which is the leak this whole thread is about. `generate_table_name` still runs first and still walks its `_N` suffixes against live relations, retired names and the catalog, so a retry whose predecessor left an orphan does not collide with itself.

`drop_unadopted_analysis_output` takes the job whose record is being reaped and refuses a name that is not that job's, as `invalid` rather than `failed`, because a name that is not this job's can never become this job's and retrying it forever would pin the row. The parameter is required with no default: the in-worker handlers pass their own id either way, so an optional gate would have bought nothing but a way to forget it. The sweeps carry `(job, table)` pairs and the record clearing is addressed by row id, so it cannot strip a different job's pointer even in principle.

Every site that derives or matches an output name is in this push: `generate_table_name` (unchanged), the materialize site, the adoption probe (unchanged and now unraceable), the drop, `unadopted_analysis_table_from_metadata`, both sweep collection sites, `_reap_unadopted_analysis_outputs`, the worker's startup recovery, and the record clearing. No UI or route reads `analysis_out_table`; it appears nowhere in `frontend/src`, `sdks`, `cli` or `mcp`.

Two existing tests moved with the change rather than being weakened. `test_orphan_physical_table_self_heals_to_suffix` still asserts the `_2` walk, now against the scoped name. `test_name_collision_preserves_existing_table` creates the occupied table at the name the job will derive, because that is where the CREATE race lives now.

**The red CI on `76a47b31d`** was the same round-5 change seen from another angle. `test_cleanup_and_retention_reaper_delete_only_tenant_key` builds its own ordered session double, and the retention purge gained a statement that the double never got, so every later result shifted by one: the purge's `DELETE` consumed the survivor `SELECT`'s double, `deleted_paths` came back empty and the tenant-scoped delete the test exists for was never made. Round 7 turned that silent skip into a loud `ValueError`, which is how it reproduced on the host. The double carries the extra result now and sets both accessors on it, so it is correct against either shape. I grepped all 17 tests that drive `fail_stale_jobs` or `recover_stale_jobs` for ordered doubles and for `await_count` / `assert_awaited*` on `delete` and `execute`; that file was the only inline double not already updated.

Counterfactual: `TestAnalysisOutputNamesAreJobScoped`, seven tests, all failing on `76a47b31d` and passing on `fad79fa77`, including the interleaving pin against real Postgres. With the app reverted and only the double fixed, `test_tenant_staging_storage_keys` passes, which is what identifies the double as that failure's whole cause.

Verification: layering, rule 1 and rule 2 suites 151 passed; the tenant-staging, VRT stale-sweep, stale-pending, presigned-reap, staging-reconcile, ownership and analysis-reap suites 253 passed; the remaining sweep-driving suites (embedding backfill, fan-out cancel, refresh gate, refresh observability, jobs router, attempt fencing, tenant recovery, worker) 145 passed; the analysis materialize, intersect, provenance, preview, retry-copy and AI-chat suites 280 passed. `ruff check .` and `ruff format --check .` clean.

Caps moved, both exact with the reason in the entry: `processing/analysis/tasks.py` 1495 to 1580, `platform/jobs/sweep.py` 2288 to 2302.


## Round 9

One P2 from the round-8 review, fixed in `80410c8d3`.

**A retry forgot the previous attempt's keys.** `/jobs/{id}/retry` preserves `user_metadata`, so a retried raster ingest reached the recorder with attempt 1's keys still on the row, and the JSONB merge set the field to attempt 2's keys alone. An attempt that failed after writing objects and whose own best-effort delete also failed lost those objects' last durable pointer the moment it was retried, and neither stale recovery nor the retention purge could name them again.

The record is a flat list each attempt extends. A map keyed by attempt was the other option offered and it buys nothing here: which attempt wrote a key is not a question any reader asks, and every reader asks the same one, whether a key is still owed a reap. Keeping the shape a list is also what makes the old-shape requirement free rather than a compatibility branch, since a row written before this commit already is a list. The append is a `CASE` on `jsonb_typeof`, because `jsonb || jsonb` concatenates two arrays but would fold the array into a non-array as a single element.

**The clearing moved with it.** Dropping the whole field once every key in it was settled was right while the field held one attempt's keys and wrong the moment it holds two: a pass that settled only the newer attempt's keys would forget the older ones, which is the same loss by another route. It now removes the settled keys one at a time and drops the field only when nothing is left owed on it, which is what still lets the retention purge take the row. A key whose delete raised keeps its place, so the next sweep retries it: the round-6 named-outcome rule reaching the record itself rather than only the decision to clear.

Two details in that statement, since it is the gnarliest SQL in the file. It uses `jsonb_exists_any` rather than the `?|` operator it implements, because `?` is not a bind marker for SQLAlchemy but keeping it out of the string leaves nothing for a driver or a future dialect to misread. And every bind is cast explicitly, because `jsonb - $1` is ambiguous between the text, integer and `text[]` forms until the parameter has a type.

**Enumeration.** Writers: `record_unpublished_storage_keys`, called by the three raster tails, and the clearing statement. Nothing in the vector, reupload or analysis paths writes this field: the vector and reupload tails register no storage keys at all, which `TestEveryPutSiteHasAnOwner` already pins, and analysis writes `analysis_out_table`, a different field with its own reaper. Retry and the recovery pass do not set it either; retry's role is that it PRESERVES `user_metadata`, which is what made the replace lossy. `test_the_recorder_is_the_only_writer_of_the_record` walks `app/` and pins the two modules that can write it. Readers are unchanged and verified against both shapes: `unpublished_storage_keys_from_metadata`, the purge's exemption predicate, `reap_unpublished_storage_keys`, the worker's stale recovery, and the clearing helper. The AST gate is unaffected.

Counterfactual: `TestTheRecordAccumulatesAcrossAttempts`, five tests, four against real Postgres. The two that pin the defects fail on `fad79fa77` with `attempt 1's objects lost their last durable pointer`, and pass on `80410c8d3`. The other three pass on both, which is why they were written: they assert what this change had to preserve, not what it introduced.

Verification: layering, rule 1 and rule 2 suites 151 passed; the ownership, analysis-reap, VRT stale-sweep, tenant-staging, stale-pending, presigned-reap, staging-reconcile, tenant-recovery, worker and jobs-router suites 273 passed; the raster replace, ingest, orphan-cleanup, regeneration-integration and attempt-fencing suites 167 passed. `ruff check .` and `ruff format --check .` clean.

Cap moved: `_MODULE_LOC_CAPS` for `platform/jobs/sweep.py` 2302 to 2328, exact, with the reason in the entry. `tasks_raster_common.py` is not capped.


## Round 10

One P1 and two P2 from the round-9 review, fixed in `6548bca26`.

**Job scoping alone left a retry able to collide with itself.** `/jobs/{id}/retry` keeps `IngestJob.id` and only mints a new attempt token, so every attempt of one job derived the identical job-scoped output name. A stale sweep could capture attempt 1's name, settle the job `failed`, and then run its probe and DROP while attempt 2 was creating that same name under it. The ownership check passed either way, because the name really was this job's; it just was not this attempt's.

The scope now carries the attempt too: `analysis_output_table_name` takes `job_uuid` and `attempt_uuid`, and the physical name embeds both. `analysis_out_table` on the job row becomes a list each attempt appends to, the shape `unpublished_storage_keys` took in round 9 and for the identical reason: overwriting the field on a retry stranded the previous attempt's name with nothing left naming it. Every reaper now iterates all of a job's recorded names, and the ownership check still refuses a name whose job segment does not match, so a sweep holding attempt 1's name can never touch attempt 2's table even though both belong to the same job.

An existing row from before this commit still holds a plain string. It reads as a one-element list, so its table still gets dropped, but the record-clearing SQL had kept an array-only `WHERE jsonb_typeof(...) = 'array'` guard, which never matched a string and would have left that row's pointer on it forever, permanently exempt from the retention purge. The clearing statement gained a matching arm for the string shape, pinned against real Postgres.

**`generate_table_name`'s own collision walk never saw the scoped name.** It collision-checks the unscoped base and hands that back; the relation on disk carries the scope appended below. A retry whose predecessor's table survived derived the same occupied name again and failed at `CREATE TABLE` instead of self-healing to a suffix, because nothing had ever probed the name that was actually going to be created.

Closed with `resolve_analysis_output_table`, which collision-checks the scoped candidate against `pg_class` directly and walks its own `_N` suffixes on the scoped name. With attempt scoping in place this race is rarer than it reads: two attempts of one job usually get different tokens. It is not gone. The same attempt can be delivered twice, a redelivery after an ack that never landed, and both deliveries derive the identical scoped name. That is the scenario the fix pins.

**The retention purge's own exemptions hid rows that owed a reap.** `fail_stale_jobs` collected artifacts two ways: from rows this pass moved off `running`, and from a query inside the retention-purge block that shared the purge's own predicates, including the per-dataset latest-complete exemption. A job that failed on an earlier pass was invisible to the first path, and a successful retry carrying a dead attempt's storage keys forward on its own row is exactly what the second path's exemption protects, since that row is by definition the dataset's latest complete job. Neither path ever looked at either case, and the keys or the table name leaked for as long as the row stood.

Replaced both with one unconditional `SELECT` that runs after the retention block, gated only on terminal status and "this row still names something unreaped," with no purge clauses at all. It runs even when retention is disabled, since a deployment with retention off still owes these reaps, and it feeds both reapers from the same result.

Also fixes the round-9 CI failure on `test_fence_missed_cancel_drops_unadopted_table`: the test built an unscoped table name, which the new ownership check correctly refused to drop under the attempt model. Updated to build a properly scoped name for the job and attempt under test, which is the realistic case: a cancelled attempt's own committed, unadopted table.

Enumeration of every writer and reader of `analysis_out_table` and `unpublished_storage_keys`: writers are `append_analysis_output_record` (analysis, on the materialize commit) and `record_unpublished_storage_keys` (the three raster tails, unchanged this round). Readers are `recorded_analysis_output_tables` / `unadopted_analysis_tables_from_metadata`, `unpublished_storage_keys_from_metadata`, the two reapers, and the clearing statement, which is now the single clearing path for both fields. The AST caller gate over `_clear_settled_artifact_records` is unchanged; the set of callers did not grow, only what each one passes.

Counterfactuals, all against `80410c8d3` via a patch file, never a stash:

- Attempt 1's table survives, a stale sweep captures its name, attempt 2 creates and records its own table on the same job row before the sweep's drop runs. The sweep drops only attempt 1's table; attempt 2's recovery pointer survives untouched. Fails on the prior commit with an `ImportError`, since the attempt-scoped writer this pins did not exist yet.
- A retry succeeds and its job row is the dataset's only, and therefore latest, complete job, but still carries a storage key from the dead attempt before it. The next sweep reaps the key anyway. Fails on the prior commit with a real assertion, not an import error: `outcome._unpublished_storage_keys` comes back empty because that commit's collection is still gated by the latest-complete exemption.
- The same attempt delivered twice: a table already committed at the exact `(base, job, attempt)` scoped name, then `resolve_analysis_output_table` called with the same three inputs. It returns the `_2`-suffixed scoped name rather than the occupied one. Fails on the prior commit with an `ImportError`, since the function did not exist.
- The legacy plain-string clearing arm: a job row with `analysis_out_table` set to a bare string, reaped and settled. The field clears. Reverting only the SQL's `WHERE` clause reproduces the leak: the row's pointer survives the reap.

Verification, from the worktree against Postgres on 5434: `test_analysis_materialize.py`, `test_analysis_provenance.py`, `test_jobs_retry_analysis_copy.py`, `test_analysis_output_reap_1778.py`, `test_raster_object_ownership_1778.py`, `test_vrt_stale_sweep_gap002.py`, `test_stale_pending_reaper.py`, `test_tenant_job_recovery.py`, `test_tenant_staging_storage_keys.py`, `test_jobs_router.py`, `test_job_cancel_fan_out.py`, `test_presigned_staging_reap_1202.py`, `test_staging_orphan_reconcile_1249.py`, `test_ingest_job_attempt_fencing.py`, `test_raster_replace_1221.py`, `test_raster_ingest.py`, `test_raster_ingest_orphan_cleanup_gap017.py`, `test_stac_asset_model.py`, `test_vrt_catalog_175.py`, `test_quicklook_predicate.py`, `test_raster_dataset_assets_bug041.py`, `test_ogc_record_properties.py`, `test_ogc_record_enrichment.py`, `test_worker.py`, `test_layering.py`, `test_rule1_structural.py`, `test_rule2_structural.py`: 882 passed. `ruff check .` and `ruff format --check .` clean over the whole backend.

Caps moved, exact: `platform/jobs/sweep.py` 2328 to 2374, for the attempt-plural reader, the string-shaped clearing arm, and the single unconditional artifact-carrying query replacing the two it absorbs. `processing/analysis/tasks.py` 1580 to 1702, for the attempt half of the scope, the accumulating record, and `resolve_analysis_output_table`'s own scoped collision walk.



**(audit) The unpublished-storage-keys recorder never checked its own fence.** Fixed in `8f033cf41`. `record_unpublished_storage_keys` fences its write on `(job id, attempt id)`, same as every other in-flight job-row write in this codebase, but it was the one that never checked whether the `UPDATE` actually matched a row. Reachable when the stale sweep fails a job on heartbeat timeout while the original worker is only paused, a GC pause or a slow syscall, rather than dead, and a retry mints a new attempt on the same job. The paused worker resumes holding its now-dead attempt token, calls this recorder, and the write used to commit nothing, silently. A kill before that worker's own in-process cleanup then left the staged objects it was about to write with no row naming them anywhere, the same leak class this whole area exists to close, reopened at the one recorder that did not check its fence.

The function now reports whether the caller may proceed. A confirmed zero-row match returns false and logs a warning in the same shape as the existing `unpublished_storage_key_not_attempt_scoped` one. A transient failure, an unreachable database or anything else that raises, still returns true and is swallowed as before: nothing there proves the attempt is gone, and refusing to proceed over it would trade a possible leak for a certain one. All three call sites, `ingest_raster`, the replace tail, `ingest_vrt`, check the return value and abort before quicklook generation on a miss. Phase 2's own attempt-fenced load would catch the same miss further down each of these three paths today, but the recorder's own contract should not depend on that second guard existing.

Pinned against real Postgres: a job's attempt id is rotated out from under a token the test still holds, the retry, and the recorder is called with that stale token. It returns false and the row's `user_metadata` is unaffected. A live attempt still returns true. Both fail on the prior commit, one on a missing return value entirely, the other on `None` where `False` was expected. A third test enumerates the three call sites and pins that each one checks the return.

Verification: `test_raster_object_ownership_1778.py`, `test_raster_ingest.py`, `test_raster_replace_1221.py`, `test_raster_ingest_orphan_cleanup_gap017.py`, `test_vrt_creation_173.py`, `test_vrt_source_management_174.py`, `test_regenerate_vrt_integration.py`, `test_stalled_queue_sweep_624.py`, `test_worker.py`, `test_tenant_job_recovery.py`, `test_ingest_job_attempt_fencing.py`, `test_stac_asset_model.py`, `test_vrt_catalog_175.py` under `-n 4`: 370 passed. `test_layering.py`, `test_rule1_structural.py`, `test_rule2_structural.py`: 151 passed. `ruff check .` and `ruff format --check .` clean.

Cap raised, exact: `processing/ingest/tasks_vrt.py` 1568 to 1575.



## Round 11

Two P2s from the round-10 review, fixed in `decb4c455`.

**A long output-table base exhausted the collision walk instead of self-healing.** `analysis_output_table_name` reserved room for the attempt scope but not for a collision tag applied afterward. `resolve_analysis_output_table`'s walk built each candidate by pre-pending `_2`, `_3`, and so on to `base` and calling `analysis_output_table_name` again, which trims to make room for the scope every time it runs. Once `base` sat at or past the 46-character reservation point, the appended tag landed past where that second trim cut, so every suffix in the walk produced the same already-trimmed string. A redelivery of the same attempt, with its own scoped table from the first delivery still standing, exhausted all 19 suffixes and raised instead of landing on `_2`.

`analysis_output_table_name` now takes an optional `collision_suffix` and reserves room for the tag itself, computed fresh from the original `base` on every call rather than trimming an already-trimmed string. This is the same idiom `generate_table_name`'s own `_with_collision_suffix` already uses a few hundred lines away in the ingest service, for the identical reason: a walker has to compute its limit from the source string, not from its own previous output. The resolver's loop now passes `collision_suffix=suffix` instead of concatenating.

Pinned two ways. A unit test confirms a 60-character base yields distinct candidates for consecutive suffixes. A real-Postgres test creates the scoped table for a 60-character base, then calls `resolve_analysis_output_table` with the identical inputs and confirms it returns a distinct `_2`-suffixed name under 63 bytes. Both fail on the prior commit; the Postgres one reproduces the exact `ValueError` the finding named.

**Phase 2 fenced on attempt alone, not on status.** `ingest_raster`, the raster replace tail, and `ingest_vrt` load their phase-2 row by `(job id, attempt id)`, with no status predicate. A stale sweep can fail a job on heartbeat timeout while the worker that owns it is only paused, a GC pause or a slow syscall, rather than dead, and no retry has happened yet to rotate the attempt token. The row's `attempt_id` is unchanged in that case, so the attempt-only fence still matched, and the resumed worker's phase 2 admitted it and went on to put objects to storage. No database rollback can undo an S3 put, so admitting the row there was the actual leak, not merely a stale read.

`_job_phase_session`, the shared bracket all three tails go through for this load, gains an optional `require_status` parameter. The three raster/VRT phase-2 sites now pass `require_status="running"`. `ingest_vrt`'s `regenerate_vrt` path predates the shared helper and matches the fence by hand in its own `async_session()` block, so it gets the identical predicate added directly to its `SELECT`. Its existing `current_generation_id` check already refuses a newer generation's publish from overwriting this one, but says nothing about a job the sweep failed before any newer generation existed, because that field lives on `RasterAsset`, a different row than `ingest_jobs.status`, and the sweep never touches it. This closes a distinct gap in the same function rather than duplicating the existing check.

Also grepped, as asked, for every other loader keyed on `(job, attempt)` without a status predicate. `ingest_file` and `ingest_service` go through the same `_job_phase_session` helper and now pass `require_status="running"` too, for a narrower reason than the raster tails: neither writes an untracked storage object, and each already fences its own terminal write on status through `require_ingest_job_update` (default `expected_status="running"`), so a fenced-out attempt there rolls back the whole transaction rather than resurrecting a failed job. The fix there buys consistency and fails fast on a doomed transaction rather than closing a leak. `reupload_file`, `reupload_service`, and analysis materialize were checked and found already aligned: all three call `update_ingest_job_for_attempt` directly, which has defaulted to `expected_status="running"` since before this PR, so nothing changed there.

Pinned against real Postgres: a row moved to `running`, then failed by hand under the same attempt token with no retry and no rotation, then loaded through `_job_phase_session` with `require_status="running"`. It refuses, `job is None`. The identical load without `require_status` still admits the failed row, the counterfactual stated inline in the same test. A separate source-enumeration test pins that the parameter actually reaches all six call sites, not just the helper. Every one of these fails against the prior commit.

Verification, from the worktree against Postgres on 5434: `test_analysis_output_reap_1778.py`, `test_analysis_materialize.py`, `test_tasks_common_phase_brackets.py`, `test_quicklook_async_context.py`, `test_raster_object_ownership_1778.py`, `test_raster_ingest.py`, `test_raster_replace_1221.py`, `test_raster_ingest_orphan_cleanup_gap017.py`, `test_vrt_creation_173.py`, `test_vrt_source_management_174.py`, `test_regenerate_vrt_integration.py`, `test_stalled_queue_sweep_624.py`, `test_worker.py`, `test_tenant_job_recovery.py`, `test_ingest_job_attempt_fencing.py`, `test_stac_asset_model.py`, `test_vrt_catalog_175.py`, `test_ingest.py`, `test_ingest_fan_out.py`, `test_ingest_progress.py`, `test_ingest_vector_failure_tails.py`, `test_reupload.py`, `test_reupload_service.py`, `test_service_refresh_1220.py`, `test_staging_pipeline_integration.py`, `test_jobs_router.py`, `test_vrt_stale_sweep_gap002.py`, `test_tenant_staging_storage_keys.py`, `test_layering.py`, `test_rule1_structural.py`, `test_rule2_structural.py` under `-n 4`: 974 passed. `ruff check .` and `ruff format --check .` clean over the whole backend.

Caps raised, exact: `processing/analysis/tasks.py` 1702 to 1725, for the collision-suffix reservation. `processing/ingest/tasks_common.py` 2426 to 2449, for `require_status` and the docstring stating which phases must pass it. `processing/ingest/tasks_vector.py` 1161 to 1184, for the two phase-2 sites and the comment on why they change even without an object-storage leak to close. `processing/ingest/tasks_vrt.py` 1575 to 1600, for both hand-matched phase-2 blocks.



## Round 12

One P2 from the round-11 review, fixed in `76babb5ad`.

**A plain SELECT is not a lock.** `require_status` closed the case where the sweep had already failed a job before phase 2 loaded it. It said nothing about the window between that read and the phase's own first irreversible write, an object-storage put no database rollback can undo. The sweep can still flip the row from `running` to `failed` in that window, and the ownership record `record_unpublished_storage_keys` wrote gets swept and cleared along with it, on the reasoning that nothing was ever written. A worker resuming through that exact gap then writes objects nothing durably names, and if its own in-process cleanup fails too, they orphan for good.

`_job_phase_session`'s SELECT now takes `FOR NO KEY UPDATE` whenever `require_status` is given, held for as long as the caller's session stays open. Every current `require_status` caller already spans its puts inside that same session and runs up to its next commit, so this closes the window without changing when anything else happens. `NO KEY UPDATE` rather than plain `UPDATE`: it still conflicts with anything that needs to exclude a concurrent writer, but costs nothing today and leaves room for a future `FOR KEY SHARE` reader this row's primary key does not have yet.

The sweep side has to contend with that lock instead of racing past it. `fail_stale_jobs`'s running-to-failed transition and the worker's own startup recovery pass, an independent copy of the identical query, both used to match candidates directly in the `UPDATE`'s `WHERE` clause. A `lock_timeout` was the other option on the table, but neither of these statements touches one row: both are set-based `UPDATE`s over every stale job at once, and a `lock_timeout` on a statement shaped that way does not skip the one busy row, it cancels the WHOLE statement, failing every other genuinely stale job in the same pass along with it. Both queries now read their candidates through a `SELECT ... FOR UPDATE SKIP LOCKED` subquery instead, which excludes exactly the rows a live phase-2 transaction owns and leaves everything else untouched. A row a worker is actively finishing is simply picked up on the next pass rather than costing the whole batch.

Applied to raster ingest, the raster replace tail, and `ingest_vrt`'s own hand-matched phase 2, all three of which hold their puts inside the same session this lock now protects. `regenerate_vrt`'s phase 2 is deliberately left unlocked. It loads the job row before a `RasterAsset` row a few lines down, and `cancel_job` takes those two locks in the opposite order for a `vrt_regenerate` job specifically to avoid an AB-BA deadlock with this worker, an invariant that function's own comment already states. Locking the job row first here would put it back in job-then-asset order and reopen that exact cycle. The gain would have been narrow anyway: `regenerate_vrt`'s objects are already written by the time this `SELECT` runs, and they're reaped by the separate `sweep_stale_vrt_assets` mechanism on its own timeout regardless of this fence. What stays open is a paused, not dead, worker completing over a row the sweep just failed in that exact window, a class round 11's `require_status` already narrowed considerably. Closing it fully was not worth reordering two locks the rest of the codebase already depends on staying in a specific order.

Counterfactual, a real interleaving rather than a mock: one session holds the phase-2 lock open, mirroring what `require_status="running"` does inside a real task. A genuinely separate session then runs `fail_stale_jobs` against the same row, past its cutoff. The row is still `running` afterward, `SKIP LOCKED` excluded it rather than blocking on it or racing past it. Releasing the lock and running the sweep again then settles it. Both assertions fail against the parent commit, where the row flips to `failed` mid-lock because no lock exists yet to contend with. A source-enumeration test separately pins that both running-job transitions use the `SKIP LOCKED` subquery, not just the one the interleaving test exercises directly.

Verification, from the worktree against Postgres on 5434: `test_tasks_common_phase_brackets.py`, `test_quicklook_async_context.py`, `test_raster_object_ownership_1778.py`, `test_raster_ingest.py`, `test_raster_replace_1221.py`, `test_raster_ingest_orphan_cleanup_gap017.py`, `test_vrt_creation_173.py`, `test_vrt_source_management_174.py`, `test_regenerate_vrt_integration.py`, `test_stalled_queue_sweep_624.py`, `test_worker.py`, `test_tenant_job_recovery.py`, `test_ingest_job_attempt_fencing.py`, `test_stac_asset_model.py`, `test_vrt_catalog_175.py`, `test_ingest.py`, `test_ingest_fan_out.py`, `test_ingest_progress.py`, `test_ingest_vector_failure_tails.py`, `test_reupload.py`, `test_reupload_service.py`, `test_service_refresh_1220.py`, `test_staging_pipeline_integration.py`, `test_jobs_router.py`, `test_vrt_stale_sweep_gap002.py`, `test_tenant_staging_storage_keys.py`, `test_stale_pending_reaper.py`, `test_job_cancel_fan_out.py`, `test_job_cancel_vrt.py`, `test_presigned_staging_reap_1202.py`, `test_staging_orphan_reconcile_1249.py`, `test_analysis_output_reap_1778.py`, `test_analysis_materialize.py`, `test_layering.py`, `test_rule1_structural.py`, `test_rule2_structural.py` under `-n 4`: 1125 passed. `ruff check .` and `ruff format --check .` clean over the whole backend.

Caps raised, exact: `processing/ingest/tasks_common.py` 2470 to 2495, for `require_status`'s lock and the docstring explaining `NO KEY UPDATE`. `platform/jobs/sweep.py` 2374 to 2392, for the `SKIP LOCKED` subquery and the comment on why a `lock_timeout` cannot substitute for it here. `processing/ingest/tasks_vrt.py` 1600 to 1628, for `ingest_vrt`'s lock and the comment explaining why `regenerate_vrt` deliberately does not get one.
