### PR TITLE
fix(e2e): wait for the dataset tile itself instead of networkidle

### DIFF
--- a/e2e/vector-tile-pipeline.spec.ts
+++ b/e2e/vector-tile-pipeline.spec.ts
@@ -88,11 +88,31 @@ test.describe('Vector tile pipeline', () => {
   test('MVT tiles are requested and served for a vector dataset', async ({ page }) => {
     const mvt: { url: string; status: number }[] = [];
     const thirdPartyPbf: string[] = [];
+    let inFlightDatasetTiles = 0;
 
     page.on('response', (r) => {
       const url = r.url();
       if (isDatasetTile(url)) mvt.push({ url, status: r.status() });
       else if (url.includes('.pbf')) thirdPartyPbf.push(url);
+    });
+
+    // fix(#1624): track in-flight dataset tile requests directly, rather than
+    // `networkidle`. Load states are sticky per document: once the page had
+    // already reached networkidle during the pre-dataset gap, a later
+    // `waitForLoadState('networkidle')` resolved immediately without opening a
+    // new quiet window, so sibling tiles in the same batch could still be in
+    // flight and a later 4xx/5xx was missed. These listeners are registered
+    // before navigation for the same reason as the response wait below: a
+    // request that starts during `goto` or before the canvas check must still
+    // be counted.
+    page.on('request', (r) => {
+      if (isDatasetTile(r.url())) inFlightDatasetTiles++;
+    });
+    page.on('requestfinished', (r) => {
+      if (isDatasetTile(r.url())) inFlightDatasetTiles--;
+    });
+    page.on('requestfailed', (r) => {
+      if (isDatasetTile(r.url())) inFlightDatasetTiles--;
     });
 
     // fix(#1624): register this wait before navigation. The `page.on('response')`
@@ -120,11 +140,23 @@ test.describe('Vector tile pipeline', () => {
     // through to the length assertion, which still reports the real #8186
     // signature.
     await firstDatasetTile.catch(() => undefined);
-    // The dataset source is now confirmed added, so the remaining tiles in
-    // this batch are already in flight or complete: networkidle here waits
-    // out that trailing traffic instead of racing its start, so the status
-    // check below sees every response, not just the first.
-    await page.waitForLoadState('networkidle');
+
+    // Wait for the current batch of dataset tile requests to finish, then
+    // debounce: MapLibre can issue a second batch after the fit-to-bounds
+    // settles, so only stop once `mvt.length` holds steady across two
+    // consecutive 500ms samples.
+    await expect.poll(() => inFlightDatasetTiles, { timeout: 20_000 }).toBe(0);
+    let previousMvtLength: number | null = null;
+    await expect
+      .poll(
+        () => {
+          const isStable = mvt.length === previousMvtLength;
+          previousMvtLength = mvt.length;
+          return isStable;
+        },
+        { timeout: 20_000, intervals: [500] },
+      )
+      .toBe(true);
 
     // THE assertion. Zero here is the #8186 silent-worker signature. Scoped to
     // this dataset's own route, so third-party basemap/glyph .pbf traffic

--- a/e2e/vector-tile-pipeline.spec.ts
+++ b/e2e/vector-tile-pipeline.spec.ts
@@ -100,7 +100,19 @@ test.describe('Vector tile pipeline', () => {
     // The map fits to the dataset's bounds on load, so tiles for the data's own
     // extent are requested without needing an explicit zoom-to-layer.
     await expect(page.locator('canvas.maplibregl-canvas')).toBeVisible({ timeout: 20_000 });
-    await page.waitForLoadState('networkidle');
+
+    // fix(#1624): wait for the dataset's own first tile instead of `networkidle`.
+    // A trace on the dev stack showed basemap tiles finish, then a ~580ms
+    // client-side gap (map load event, transformRequest install, dataset source
+    // add) before the six signed dataset tile requests fire — well inside
+    // networkidle's 500ms quiet window under host load. That let the assertion
+    // below run before the dataset source was even added, reporting "no tiles
+    // requested" with a perfectly healthy pipeline. A timeout here falls
+    // through to the length assertion, which still reports the real #8186
+    // signature.
+    await page
+      .waitForResponse((r) => isDatasetTile(r.url()), { timeout: 20_000 })
+      .catch(() => undefined);
 
     // THE assertion. Zero here is the #8186 silent-worker signature. Scoped to
     // this dataset's own route, so third-party basemap/glyph .pbf traffic

--- a/e2e/vector-tile-pipeline.spec.ts
+++ b/e2e/vector-tile-pipeline.spec.ts
@@ -95,6 +95,15 @@ test.describe('Vector tile pipeline', () => {
       else if (url.includes('.pbf')) thirdPartyPbf.push(url);
     });
 
+    // fix(#1624): register this wait before navigation. The `page.on('response')`
+    // collector above sees every tile regardless of timing, but a
+    // `waitForResponse` registered after `goto` cannot match a response that
+    // already arrived during navigation or before the canvas check completes —
+    // a healthy fast run would then burn the full timeout for nothing.
+    const firstDatasetTile = page.waitForResponse((r) => isDatasetTile(r.url()), {
+      timeout: 20_000,
+    });
+
     await page.goto(`/datasets/${datasetId}`);
     await page.waitForURL(new RegExp(`/datasets/${datasetId}$`));
     // The map fits to the dataset's bounds on load, so tiles for the data's own
@@ -110,9 +119,12 @@ test.describe('Vector tile pipeline', () => {
     // requested" with a perfectly healthy pipeline. A timeout here falls
     // through to the length assertion, which still reports the real #8186
     // signature.
-    await page
-      .waitForResponse((r) => isDatasetTile(r.url()), { timeout: 20_000 })
-      .catch(() => undefined);
+    await firstDatasetTile.catch(() => undefined);
+    // The dataset source is now confirmed added, so the remaining tiles in
+    // this batch are already in flight or complete: networkidle here waits
+    // out that trailing traffic instead of racing its start, so the status
+    // check below sees every response, not just the first.
+    await page.waitForLoadState('networkidle');
 
     // THE assertion. Zero here is the #8186 silent-worker signature. Scoped to
     // this dataset's own route, so third-party basemap/glyph .pbf traffic

--- a/e2e/vector-tile-pipeline.spec.ts
+++ b/e2e/vector-tile-pipeline.spec.ts
@@ -141,22 +141,22 @@ test.describe('Vector tile pipeline', () => {
     // signature.
     await firstDatasetTile.catch(() => undefined);
 
-    // Wait for the current batch of dataset tile requests to finish, then
-    // debounce: MapLibre can issue a second batch after the fit-to-bounds
-    // settles, so only stop once `mvt.length` holds steady across two
-    // consecutive 500ms samples.
-    await expect.poll(() => inFlightDatasetTiles, { timeout: 20_000 }).toBe(0);
+    // fix(#1624): fold the zero-in-flight check into the same predicate as the
+    // debounce, rechecked on every poll tick. Sampling them separately (wait
+    // for zero, then only watch `mvt.length`) left a gap: if a second batch
+    // starts after in-flight was observed at zero and a response takes longer
+    // than the 500ms poll interval, `mvt.length` would look unchanged while a
+    // request was still outstanding, and a later 4xx/5xx from it would be
+    // missed. `settled()` requires both zero in-flight AND an unchanged
+    // `mvt.length` on the same tick, so any new in-flight request resets the
+    // stability streak regardless of whether it has produced a response yet.
     let previousMvtLength: number | null = null;
-    await expect
-      .poll(
-        () => {
-          const isStable = mvt.length === previousMvtLength;
-          previousMvtLength = mvt.length;
-          return isStable;
-        },
-        { timeout: 20_000, intervals: [500] },
-      )
-      .toBe(true);
+    const settled = (): boolean => {
+      const isStable = inFlightDatasetTiles === 0 && mvt.length === previousMvtLength;
+      previousMvtLength = mvt.length;
+      return isStable;
+    };
+    await expect.poll(settled, { timeout: 20_000, intervals: [500] }).toBe(true);
 
     // THE assertion. Zero here is the #8186 silent-worker signature. Scoped to
     // this dataset's own route, so third-party basemap/glyph .pbf traffic


### PR DESCRIPTION
## What was racy

`e2e/vector-tile-pipeline.spec.ts` ("MVT tiles are requested and served for a vector dataset") waited for `canvas.maplibregl-canvas` to be visible, then `page.waitForLoadState('networkidle')`, then asserted at least one of the dataset's own tile responses had been seen.

A Playwright trace on the dev stack showed the basemap tiles finish, then a roughly 580ms client-side gap (map load event, transformRequest install, dataset source add), then the six signed dataset tile requests (`/api/tiles/data.<table>/{z}/{x}/{y}.pbf?sig=...`, status 200/204). `networkidle`'s 500ms quiet window can fire inside that gap under host load, so the assertion sometimes ran before the dataset source was even added and reported "no tiles requested" with a perfectly healthy pipeline.

## Fix

Replace the `networkidle` wait with an explicit wait for the first dataset tile response (`page.waitForResponse` matching `isDatasetTile`), placed before the existing assertions. The `page.on('response')` collector is unchanged, so the length and status checks still run over everything actually seen. A timeout on the new wait falls through to the existing length assertion, which still reports the real #8186 silent-worker failure message.

## Verification

- `E2E_ALLOW_WORKTREE=1 npx playwright test e2e/vector-tile-pipeline.spec.ts --project=chromium --retries=0` against the shared dev stack: 3/3 passed, 3 runs in a row.
- No root ESLint config or root tsconfig covers `e2e/`, so `npx eslint` and `npx tsc --noEmit` were skipped (confirmed: `npx eslint e2e/vector-tile-pipeline.spec.ts` errors with "couldn't find an eslint.config.*", and no tsconfig outside `frontend/` exists).

Spec-only; no app code. Related: #1624 (the spec's origin).


## Round 2

Two issues found in review: the tile wait was registered after `goto`, so a response that already arrived during navigation could not match it, wasting the full timeout on a healthy run; and resolving on the first tile meant the status assertion missed a later tile that came back non-200/204. Fixed by creating the response promise before navigation and waiting for `networkidle` after the first tile is seen (safe at that point, since the dataset source is confirmed added, so it only waits out the tail of an already-started batch instead of racing its start).

Verified again from the worktree against the shared dev stack: 3 runs of `E2E_ALLOW_WORKTREE=1 npx playwright test e2e/vector-tile-pipeline.spec.ts --project=chromium --retries=0`, all passed, plus one run with `--repeat-each 3`, all passed.



## Round 3

One more issue found in review: load states are sticky per document, so once the page had already reached networkidle during the pre-dataset gap, the round-2 `waitForLoadState('networkidle')` resolved immediately without opening a new quiet window, and a sibling tile in the same batch could still be in flight and its later 4xx/5xx status missed.

Replaced it with direct in-flight tracking: `request`/`requestfinished`/`requestfailed` listeners registered before navigation count in-flight dataset tile requests. After the first tile response, the test waits for that count to reach zero, then debounces on `mvt.length` holding steady across two consecutive 500ms samples, since MapLibre can issue a second batch after the fit-to-bounds settles. The status check then runs over the full, settled set.

Verified again from the worktree against the shared dev stack: 3 runs of `E2E_ALLOW_WORKTREE=1 npx playwright test e2e/vector-tile-pipeline.spec.ts --project=chromium --retries=0`, all passed, plus one run with `--repeat-each 3`, all passed.



## Round 4

One more issue found in review: the round-3 fix sampled zero-in-flight and length-stability separately. If a second batch started right after in-flight was observed at zero, and a response for it took longer than the 500ms poll interval, `mvt.length` would look unchanged while a request was still outstanding, and a later 4xx/5xx from it could be missed.

Folded both checks into one predicate, `settled()`, evaluated on every poll tick: it requires `inFlightDatasetTiles === 0` and an unchanged `mvt.length` on the same tick. Any new in-flight request now resets the stability streak immediately, before it has even produced a response. Dropped the separate zero-in-flight poll since the combined predicate subsumes it.

Verified again from the worktree against the shared dev stack: 3 runs of `E2E_ALLOW_WORKTREE=1 npx playwright test e2e/vector-tile-pipeline.spec.ts --project=chromium --retries=0`, all passed, plus one run with `--repeat-each 3`, all passed.
