### PR TITLE
fix(cli): keep the retained refresh token with the bearer on backend fallback

### DIFF
--- a/cli/geolens_cli/auth.py
+++ b/cli/geolens_cli/auth.py
@@ -475,6 +475,45 @@ def _load_refresh_fingerprint(instance: str) -> Optional[str]:
         raise KeyringCredentialUnreadable("refresh_fingerprint", str(exc)) from exc
 
 
+def _rewrite_refresh_fingerprint(
+    instance: str, bearer_token: str, *, no_keyring: bool
+) -> None:
+    """Rewrite ONLY the pairing fingerprint to match ``bearer_token``,
+    without touching the refresh token value itself.
+
+    fix(#1778 round 31): used by try_refresh() when a rotation renews
+    the access token but the server does NOT issue a new refresh
+    token -- the existing (unrotated) refresh token still needs its
+    fingerprint updated to the NEW bearer, or the next refresh attempt
+    would find it "mismatched" against the very rotation this call
+    just performed and discard a perfectly good, still-valid refresh
+    token as if it were stale.
+
+    fix(#1807 round 2): still the right call whenever the bearer stayed
+    in the backend it was already in, which is every rotation but the
+    fallback one. Rewriting the unchanged refresh SECRET there (what
+    round 1 did unconditionally) asks a second account for a write
+    nothing needs, and a keyring that accepts the bearer and
+    fingerprint accounts while refusing the refresh one -- with no
+    usable file fallback behind it -- then loses a rotation this helper
+    would have completed: try_refresh() reports failure with the new
+    bearer already stored against the OLD fingerprint, and the next
+    attempt discards a still-valid refresh token as unpaired. Only the
+    backend-MOVED case needs the whole pair rewritten; see
+    try_refresh().
+    """
+    fingerprint = _fingerprint_bearer(bearer_token)
+    if not no_keyring:
+        try:
+            keyring.set_password(
+                SERVICE, _keyring_account_refresh_fingerprint(instance), fingerprint
+            )
+            return
+        except KeyringError as exc:
+            log.warning("keyring_unavailable_falling_back_to_file", error=str(exc))
+    _set_credential_field(instance, "refresh_fingerprint", fingerprint)
+
+
 def _delete_keyring_refresh_entries(instance: str) -> None:
     """Best-effort delete of the refresh token AND its pairing
     fingerprint from the KEYRING only, leaving the file side alone.
@@ -1454,10 +1493,23 @@ def try_refresh(instance: str) -> Optional[str]:
     looking for a refresh_token in the FILE -- answered "keyring,"
     wrote the newly rotated bearer there, and had it shadowed by the
     stale file bearer that outranks it. Commands refreshed on every
-    call instead of converging. Both branches now write the refresh
-    token and its fingerprint together through ``store_refresh_token()``
-    into the backend the bearer ACTUALLY landed in, and the superseded
-    keyring copy is dropped once the file write has committed.
+    call instead of converging. A rotation whose bearer MOVED backends
+    now writes the refresh token and its fingerprint together through
+    ``store_refresh_token()`` into the backend the bearer actually
+    landed in, and drops the superseded keyring copy once that write
+    has committed.
+
+    fix(#1807 round 2): only when it moved. Rewriting the unchanged
+    refresh SECRET on every retained-token rotation (round 1) needs a
+    write to an account that had nothing to say, and a keyring that
+    accepts the bearer and fingerprint accounts while refusing the
+    refresh one -- with an unusable credentials.toml behind it -- lost
+    a rotation the fingerprint-only path completes: this returned
+    ``None`` with the new bearer already stored against the OLD
+    fingerprint, so the next attempt discarded a still-valid refresh
+    token as unpaired. An unchanged backend takes
+    ``_rewrite_refresh_fingerprint()`` again, which touches exactly the
+    one member that is actually stale.
     """
     try:
         refresh = load_refresh_token_strict(instance)
@@ -1535,6 +1587,10 @@ def try_refresh(instance: str) -> Optional[str]:
     # a whole or is reported as a whole. Never logs a token value.
     try:
         backend = store_bearer_token(instance, new_access, no_keyring=no_keyring)
+        # fix(#1807 round 2): did the bearer actually land in the backend
+        # this rotation asked for? Only the keyring -> file fallback is a
+        # MOVE; `no_keyring` already means "the file, deliberately."
+        backend_moved = not no_keyring and backend != "keyring"
         new_refresh = getattr(parsed, "refresh_token", None)
         if new_refresh:
             store_refresh_token(
@@ -1565,16 +1621,31 @@ def try_refresh(instance: str) -> Optional[str]:
             # file-backed bearer shadows it under load_bearer_token()'s
             # file-over-keyring precedence: every subsequent command
             # 401s, refreshes, and 401s again instead of converging.
-            # The retained token is now rewritten through
-            # store_refresh_token() -- value AND fingerprint together,
-            # into the bearer's ACTUAL backend -- exactly as the
+            # A MOVED bearer therefore takes the whole retained pair
+            # with it, through store_refresh_token(), exactly as the
             # new-refresh-token branch above already does.
-            store_refresh_token(
-                instance,
-                refresh,
-                bearer_token=new_access,
-                no_keyring=(backend != "keyring"),
-            )
+            #
+            # fix(#1807 round 2): only when it moved. Round 1 rewrote
+            # the pair unconditionally, which asks a second keyring
+            # account for a write of a secret that did not change --
+            # and a keyring accepting the bearer and fingerprint
+            # accounts while refusing the refresh one, with no usable
+            # file fallback behind it, then turned a rotation this
+            # branch used to complete into a reported failure, with the
+            # new bearer already stored against the OLD fingerprint for
+            # the next attempt to discard as unpaired. Unchanged
+            # backend -> update the fingerprint member alone, in place.
+            if backend_moved:
+                store_refresh_token(
+                    instance,
+                    refresh,
+                    bearer_token=new_access,
+                    no_keyring=(backend != "keyring"),
+                )
+            else:
+                _rewrite_refresh_fingerprint(
+                    instance, new_access, no_keyring=(backend != "keyring")
+                )
     except Exception as exc:
         log.warning(
             "refresh_rotated_but_not_stored",
@@ -1594,7 +1665,7 @@ def try_refresh(instance: str) -> Optional[str]:
     # never raises), only after the file write above has already
     # committed, and only on the keyring side: the file holds the copy
     # that must survive.
-    if not no_keyring and backend != "keyring":
+    if backend_moved:
         _delete_keyring_refresh_entries(instance)
     # fix(#1778 review round 19): the round-17 marker write below used
     # to be unconditional AND fatal -- an unwritable credentials.toml

--- a/cli/geolens_cli/auth.py
+++ b/cli/geolens_cli/auth.py
@@ -475,30 +475,25 @@ def _load_refresh_fingerprint(instance: str) -> Optional[str]:
         raise KeyringCredentialUnreadable("refresh_fingerprint", str(exc)) from exc
 
 
-def _rewrite_refresh_fingerprint(
-    instance: str, bearer_token: str, *, no_keyring: bool
-) -> None:
-    """Rewrite ONLY the pairing fingerprint to match ``bearer_token``,
-    without touching the refresh token value itself.
+def _delete_keyring_refresh_entries(instance: str) -> None:
+    """Best-effort delete of the refresh token AND its pairing
+    fingerprint from the KEYRING only, leaving the file side alone.
+    Never raises -- see ``_discard_unpaired_refresh_token()`` (which
+    calls this for its own keyring half) for why every step here
+    swallows KeyringError/OSError, and
+    tests/test_best_effort_helpers_never_raise.py for the gate.
 
-    fix(#1778 round 31): used by try_refresh() when a rotation renews
-    the access token but the server does NOT issue a new refresh
-    token -- the existing (unrotated) refresh token still needs its
-    fingerprint updated to the NEW bearer, or the next refresh attempt
-    would find it "mismatched" against the very rotation this call
-    just performed and discard a perfectly good, still-valid refresh
-    token as if it were stale.
+    fix(#1807): try_refresh() also needs exactly this half on its own,
+    with the file side deliberately untouched -- when a rotation falls
+    back from the keyring to credentials.toml, the pair is REWRITTEN to
+    the file and only the superseded keyring copy has to go. Deleting
+    both sides there would throw away the copy just written.
     """
-    fingerprint = _fingerprint_bearer(bearer_token)
-    if not no_keyring:
+    for account_fn in (_keyring_account_refresh, _keyring_account_refresh_fingerprint):
         try:
-            keyring.set_password(
-                SERVICE, _keyring_account_refresh_fingerprint(instance), fingerprint
-            )
-            return
-        except KeyringError as exc:
-            log.warning("keyring_unavailable_falling_back_to_file", error=str(exc))
-    _set_credential_field(instance, "refresh_fingerprint", fingerprint)
+            keyring.delete_password(SERVICE, account_fn(instance))
+        except (KeyringError, OSError):
+            pass
 
 
 def _discard_unpaired_refresh_token(instance: str) -> None:
@@ -524,11 +519,7 @@ def _discard_unpaired_refresh_token(instance: str) -> None:
     OSError, logs once, and continues -- see
     tests/test_best_effort_helpers_never_raise.py.
     """
-    for account_fn in (_keyring_account_refresh, _keyring_account_refresh_fingerprint):
-        try:
-            keyring.delete_password(SERVICE, account_fn(instance))
-        except (KeyringError, OSError):
-            pass
+    _delete_keyring_refresh_entries(instance)
     try:
         data = _read_credentials_file()
         section = data.get(instance)
@@ -1453,6 +1444,20 @@ def try_refresh(instance: str) -> Optional[str]:
     no refresh attempt, exactly one warning, ``None`` -- never
     deleting on an unknown. Only a CONFIRMED absence or a CONFIRMED
     mismatch reaches the destructive discard-and-warn path below.
+
+    fix(#1807): round 31's "the server issued no new refresh token"
+    branch rewrote only the pairing FINGERPRINT into the bearer's
+    actual backend and left the retained refresh token itself wherever
+    it already was. A keyring bearer write that fell back to the file
+    therefore split the retained pair across backends, and the next
+    refresh's ``_detect_credential_backend()`` -- which decides by
+    looking for a refresh_token in the FILE -- answered "keyring,"
+    wrote the newly rotated bearer there, and had it shadowed by the
+    stale file bearer that outranks it. Commands refreshed on every
+    call instead of converging. Both branches now write the refresh
+    token and its fingerprint together through ``store_refresh_token()``
+    into the backend the bearer ACTUALLY landed in, and the superseded
+    keyring copy is dropped once the file write has committed.
     """
     try:
         refresh = load_refresh_token_strict(instance)
@@ -1547,8 +1552,28 @@ def try_refresh(instance: str) -> Optional[str]:
             # refresh attempt would find this pairing "mismatched"
             # against the rotation this call just performed, and
             # wrongly discard a perfectly good refresh token as stale.
-            _rewrite_refresh_fingerprint(
-                instance, new_access, no_keyring=(backend != "keyring")
+            #
+            # fix(#1807): round 31 rewrote only the FINGERPRINT, which
+            # is enough while the bearer lands where `no_keyring` said
+            # it would, and wrong the moment store_bearer_token() falls
+            # back to the file on its own. That split the retained pair
+            # across backends -- fingerprint in the file, refresh token
+            # still in the keyring -- and the next refresh's
+            # _detect_credential_backend() (which looks for a
+            # refresh_token in the FILE) therefore answered "keyring"
+            # and wrote the new bearer there, where the stale
+            # file-backed bearer shadows it under load_bearer_token()'s
+            # file-over-keyring precedence: every subsequent command
+            # 401s, refreshes, and 401s again instead of converging.
+            # The retained token is now rewritten through
+            # store_refresh_token() -- value AND fingerprint together,
+            # into the bearer's ACTUAL backend -- exactly as the
+            # new-refresh-token branch above already does.
+            store_refresh_token(
+                instance,
+                refresh,
+                bearer_token=new_access,
+                no_keyring=(backend != "keyring"),
             )
     except Exception as exc:
         log.warning(
@@ -1560,6 +1585,17 @@ def try_refresh(instance: str) -> Optional[str]:
             ),
         )
         return None
+    # fix(#1807): the rotation above asked for the keyring and landed in
+    # the file, so the refresh token now lives in BOTH backends -- the
+    # copy just written, and the superseded keyring one it was moved
+    # from. The file copy wins every read, so the leftover is not
+    # actively wrong, but it is a spendable credential for a session
+    # this profile no longer tracks there. Dropped best-effort (it
+    # never raises), only after the file write above has already
+    # committed, and only on the keyring side: the file holds the copy
+    # that must survive.
+    if not no_keyring and backend != "keyring":
+        _delete_keyring_refresh_entries(instance)
     # fix(#1778 review round 19): the round-17 marker write below used
     # to be unconditional AND fatal -- an unwritable credentials.toml
     # (read-only or full XDG config dir) raised straight out of

--- a/cli/tests/test_best_effort_helpers_never_raise.py
+++ b/cli/tests/test_best_effort_helpers_never_raise.py
@@ -12,6 +12,9 @@ every failure point the helper's own docstring claims to tolerate:
 
 - _discard_unpaired_refresh_token() -- keyring deletes AND the file
   read/write, all raising.
+- _delete_keyring_refresh_entries() -- its keyring half, which
+  fix(#1807) factored out for try_refresh()'s backend-fallback path
+  and which carries the same contract.
 - _restore_credentials() -- keyring deletes/sets AND the file
   read/write, all raising.
 - delete_credentials()'s own keyring loop -- all four accounts raising
@@ -108,3 +111,26 @@ class TestDeleteCredentialsKeyringLoopNeverRaises:
         # Must not raise -- the file is healthy, so _clear_credential_
         # section() at the end completes normally too.
         _auth.delete_credentials(INSTANCE)
+
+
+class TestDeleteKeyringRefreshEntriesNeverRaises:
+    """fix(#1807): the keyring half of _discard_unpaired_refresh_token(),
+    factored out because try_refresh() needs exactly that half on its
+    own when a rotation falls back to the file (the file side there
+    holds the copy that must survive). It inherits the same
+    never-raises contract, so it is enumerated here too."""
+
+    def test_both_keyring_deletes_raise(
+        self, tmp_xdg_home, mock_keyring, monkeypatch
+    ) -> None:
+        monkeypatch.setattr("keyring.delete_password", _raise_keyring_error)
+        # Must not raise.
+        _auth._delete_keyring_refresh_entries(INSTANCE)
+
+    def test_keyring_deletes_raise_os_error(
+        self, tmp_xdg_home, mock_keyring, monkeypatch
+    ) -> None:
+        monkeypatch.setattr("keyring.delete_password", _raise_os_error)
+        # Must not raise -- some keyring backends surface an OSError
+        # rather than a KeyringError.
+        _auth._delete_keyring_refresh_entries(INSTANCE)

--- a/cli/tests/test_credential_resolution_matrix.py
+++ b/cli/tests/test_credential_resolution_matrix.py
@@ -31,13 +31,22 @@ OS-level permission error, and a value that is neither "bearer" nor
 failure, never silently collapse to "absent".
 
 24 (marker, keyring) combinations x 2 env states = 48 matrix rows.
+
+fix(#1807): plus one row the table's axes cannot express, at the
+bottom of this file -- the BACKEND itself moving mid-rotation, when
+store_bearer_token() falls back from the keyring to credentials.toml
+and the retained refresh token has to follow it. See that section's
+own comment for the finding.
 """
 from __future__ import annotations
 
 import pathlib as _pathlib
+from http import HTTPStatus
+from types import SimpleNamespace
 
 import pytest
 import typer
+from keyring.errors import KeyringError
 
 from geolens_cli import auth as _auth
 from geolens_cli import config as _config
@@ -217,3 +226,173 @@ class TestCredentialResolutionMatrixEnvSet:
         assert sdk.credential_kind == "bearer"
         assert sdk.credential_provenance == "env"
         assert sdk.client.token == ENV_TOKEN
+
+
+# ---------------------------------------------------------------------------
+# fix(#1807): the backend-fallback row of the refresh pairing matrix.
+#
+# Every row above holds the BACKEND fixed: a credential written to the
+# keyring stays in the keyring. store_bearer_token() can break that on
+# its own, though -- a transient or account-specific KeyringError makes
+# it fall back to credentials.toml even when the caller asked for the
+# keyring -- and try_refresh()'s "the server issued no new refresh
+# token" branch used to move only the pairing fingerprint with it,
+# leaving the retained refresh token behind in the keyring.
+#
+# The next refresh then read the two halves from different backends:
+# _detect_credential_backend() looks for a refresh_token in the FILE,
+# found none, answered "keyring," and wrote the newly rotated bearer
+# there -- where the stale file-backed bearer written by the fallback
+# outranks it under load_bearer_token()'s file-over-keyring precedence.
+# Every later command 401s, refreshes, 401s again, and never converges.
+#
+# This row drives the whole sequence through the real CLI: a bearer
+# whose keyring write fails once, a refresh response with no
+# replacement refresh token, then a second expiry with the keyring
+# healthy again.
+# ---------------------------------------------------------------------------
+
+OLD_BEARER = "kr-bearer-token-expired"
+RETAINED_REFRESH = "kr-refresh-token-retained"
+
+
+class _FakeAuthServer:
+    """A /auth/me + /auth/refresh pair where only the most recently
+    issued access token is accepted, and a refresh never issues a
+    replacement refresh token (the exact response shape this row is
+    about)."""
+
+    def __init__(self) -> None:
+        self.issued: list[str] = []
+        self.refresh_calls = 0
+        self.accepted: set[str] = set()
+
+    def issue(self, token: str) -> str:
+        self.issued.append(token)
+        self.accepted = {token}
+        return token
+
+    def expire_all(self) -> None:
+        self.accepted = set()
+
+    def refresh_endpoint(self, **kwargs):
+        self.refresh_calls += 1
+        rotated = self.issue(f"rotated-access-token-{self.refresh_calls}")
+        return SimpleNamespace(
+            status_code=HTTPStatus.OK,
+            # No replacement refresh token -- the retained one stays valid.
+            parsed=SimpleNamespace(access_token=rotated, refresh_token=None),
+        )
+
+    def me_endpoint(self, **kwargs):
+        presented = getattr(kwargs.get("client"), "token", None)
+        if presented not in self.accepted:
+            return SimpleNamespace(status_code=HTTPStatus.UNAUTHORIZED, parsed=None)
+        return SimpleNamespace(
+            status_code=HTTPStatus.OK,
+            parsed=SimpleNamespace(email="alice@example.com", id="u-1", role="admin"),
+        )
+
+
+class TestRefreshPairingBackendFallbackRow:
+    """fix(#1807): a keyring bearer write that falls back to the file
+    must take the RETAINED refresh token and its fingerprint with it,
+    and the profile must then converge on the file backend instead of
+    refreshing on every command."""
+
+    def _setup(self, mock_keyring, monkeypatch) -> tuple[_FakeAuthServer, dict]:
+        # A keyring-backed interactive session: bearer + refresh token
+        # + the fingerprint pairing them (round 31).
+        mock_keyring[("geolens", INSTANCE)] = OLD_BEARER
+        mock_keyring[("geolens", f"{INSTANCE}:refresh")] = RETAINED_REFRESH
+        mock_keyring[("geolens", f"{INSTANCE}:refresh_fp")] = _auth._fingerprint_bearer(
+            OLD_BEARER
+        )
+        _config.write_default_instance(INSTANCE, username="alice")
+
+        # The bearer ACCOUNT specifically refuses writes while this flag
+        # is on -- store_bearer_token()'s documented fallback trigger.
+        # Every other account (and this one, once the flag clears)
+        # writes normally.
+        fail_bearer_write = {"on": True}
+
+        def flaky_set_password(svc: str, user: str, pwd: str) -> None:
+            if fail_bearer_write["on"] and user == INSTANCE:
+                raise KeyringError("this account is temporarily locked")
+            mock_keyring[(svc, user)] = pwd
+
+        monkeypatch.setattr("keyring.set_password", flaky_set_password)
+
+        server = _FakeAuthServer()
+        server.issue(OLD_BEARER)
+        server.expire_all()  # the stored bearer is already expired
+        monkeypatch.setattr(
+            "geolens.api.auth.refresh_auth_refresh_post.sync_detailed",
+            server.refresh_endpoint,
+        )
+        monkeypatch.setattr(
+            "geolens.api.auth.me_auth_me_get.sync_detailed", server.me_endpoint
+        )
+        return server, fail_bearer_write
+
+    def test_retained_refresh_token_follows_the_bearer_into_the_file(
+        self, runner, tmp_xdg_home, mock_keyring, monkeypatch
+    ) -> None:
+        from geolens_cli.main import app
+
+        server, _ = self._setup(mock_keyring, monkeypatch)
+
+        result = runner.invoke(app, ["whoami"])
+
+        assert result.exit_code == 0, result.output
+        assert server.refresh_calls == 1
+        rotated = server.issued[-1]
+
+        section = _auth._read_credentials_file()[INSTANCE]
+        assert section["bearer_token"] == rotated, (
+            "the keyring write failed, so the rotated bearer must be in the file"
+        )
+        assert section["refresh_token"] == RETAINED_REFRESH, (
+            "the retained refresh token must move to the bearer's ACTUAL "
+            "backend, not stay behind in the keyring"
+        )
+        assert section["refresh_fingerprint"] == _auth._fingerprint_bearer(rotated), (
+            "the fingerprint must pair the retained token with the NEW bearer"
+        )
+        assert ("geolens", f"{INSTANCE}:refresh") not in mock_keyring, (
+            "the superseded keyring copy of the refresh token must be dropped"
+        )
+        assert ("geolens", f"{INSTANCE}:refresh_fp") not in mock_keyring, (
+            "the superseded keyring copy of the fingerprint must be dropped"
+        )
+
+    def test_the_next_refresh_converges_instead_of_looping(
+        self, runner, tmp_xdg_home, mock_keyring, monkeypatch
+    ) -> None:
+        from geolens_cli.main import app
+
+        server, fail_bearer_write = self._setup(mock_keyring, monkeypatch)
+
+        # 1. The expired stored bearer 401s, the fallback rotation runs.
+        assert runner.invoke(app, ["whoami"]).exit_code == 0
+        assert server.refresh_calls == 1
+
+        # 2. That rotated token expires too, with the keyring healthy
+        #    again -- the state the loop used to start from.
+        fail_bearer_write["on"] = False
+        server.expire_all()
+        assert runner.invoke(app, ["whoami"]).exit_code == 0
+        assert server.refresh_calls == 2
+
+        # 3. Nothing has expired since, so this command must simply use
+        #    the credential step 2 stored. Before the fix it read the
+        #    stale file bearer (step 2 wrote its rotation to the
+        #    keyring, where the file shadows it) and refreshed again.
+        result = runner.invoke(app, ["whoami"])
+        assert result.exit_code == 0, result.output
+        assert server.refresh_calls == 2, (
+            "a converged profile must not refresh again -- the bearer "
+            "resolved here is shadowed by a stale copy in the other backend"
+        )
+        resolved = _auth.load_bearer_token(INSTANCE)
+        assert resolved is not None and resolved.value == server.issued[-1]

--- a/cli/tests/test_credential_resolution_matrix.py
+++ b/cli/tests/test_credential_resolution_matrix.py
@@ -396,3 +396,101 @@ class TestRefreshPairingBackendFallbackRow:
         )
         resolved = _auth.load_bearer_token(INSTANCE)
         assert resolved is not None and resolved.value == server.issued[-1]
+
+
+# ---------------------------------------------------------------------------
+# fix(#1807 round 2): the row above's mirror -- the backend does NOT move,
+# and the retained refresh token's own keyring account is the one refusing
+# writes (readable, and paired to a bearer that just rotated; the bearer and
+# fingerprint accounts still accept writes) with no usable credentials.toml
+# behind it.
+#
+# Rewriting the whole retained pair here, as the first cut of #1807 did,
+# asks that account for a write of a secret that did not change -- the
+# write fails, the file fallback fails, and try_refresh() reports a
+# rotation the server already performed as a failure, with the new bearer
+# stored against the OLD fingerprint. The next attempt then reads that
+# mismatch and discards a still-valid refresh token as unpaired. Updating
+# only the fingerprint member, in place, completes the rotation.
+# ---------------------------------------------------------------------------
+
+
+class TestRefreshPairingRefreshAccountWriteRejectedRow:
+    """fix(#1807 round 2): a retained refresh token whose backend did not
+    move must not be rewritten -- only the fingerprint pairing it to the
+    new bearer is stale, and the account holding the token may well
+    refuse the write."""
+
+    def _setup(self, mock_keyring, monkeypatch) -> _FakeAuthServer:
+        mock_keyring[("geolens", INSTANCE)] = OLD_BEARER
+        mock_keyring[("geolens", f"{INSTANCE}:refresh")] = RETAINED_REFRESH
+        mock_keyring[("geolens", f"{INSTANCE}:refresh_fp")] = _auth._fingerprint_bearer(
+            OLD_BEARER
+        )
+        _config.write_default_instance(INSTANCE, username="alice")
+
+        # The refresh ACCOUNT alone rejects writes; it stays readable,
+        # and the bearer + fingerprint accounts write normally.
+        def picky_set_password(svc: str, user: str, pwd: str) -> None:
+            if user == f"{INSTANCE}:refresh":
+                raise KeyringError("this account is not writable")
+            mock_keyring[(svc, user)] = pwd
+
+        monkeypatch.setattr("keyring.set_password", picky_set_password)
+
+        # ...and there is no credentials.toml fallback behind it, so a
+        # write that reaches the file fails outright rather than quietly
+        # succeeding in the other backend.
+        def unwritable(*_a, **_k):
+            raise OSError("read-only file system")
+
+        monkeypatch.setattr(_auth, "_write_credentials_file", unwritable)
+
+        server = _FakeAuthServer()
+        server.issue(OLD_BEARER)
+        server.expire_all()
+        monkeypatch.setattr(
+            "geolens.api.auth.refresh_auth_refresh_post.sync_detailed",
+            server.refresh_endpoint,
+        )
+        monkeypatch.setattr(
+            "geolens.api.auth.me_auth_me_get.sync_detailed", server.me_endpoint
+        )
+        return server
+
+    def test_only_the_fingerprint_is_rewritten_when_the_backend_did_not_move(
+        self, runner, tmp_xdg_home, mock_keyring, monkeypatch
+    ) -> None:
+        from geolens_cli.main import app
+
+        server = self._setup(mock_keyring, monkeypatch)
+
+        result = runner.invoke(app, ["whoami"])
+
+        assert result.exit_code == 0, result.output
+        assert server.refresh_calls == 1
+        rotated = server.issued[-1]
+
+        assert mock_keyring[("geolens", INSTANCE)] == rotated
+        assert mock_keyring[
+            ("geolens", f"{INSTANCE}:refresh_fp")
+        ] == _auth._fingerprint_bearer(rotated), (
+            "the fingerprint is the only member that went stale -- it must "
+            "be updated in place, in the backend the pair already lives in"
+        )
+        assert mock_keyring[("geolens", f"{INSTANCE}:refresh")] == RETAINED_REFRESH, (
+            "the retained token itself did not change; rewriting it needs a "
+            "write this account refuses"
+        )
+        assert not _config.credentials_path().exists(), (
+            "nothing should have been pushed to the file backend here"
+        )
+
+        # Still paired on the next resolve: the rotated bearer expires,
+        # and the retained token is spent again rather than discarded as
+        # unpaired.
+        server.expire_all()
+        result = runner.invoke(app, ["whoami"])
+        assert result.exit_code == 0, result.output
+        assert server.refresh_calls == 2
+        assert mock_keyring[("geolens", f"{INSTANCE}:refresh")] == RETAINED_REFRESH


### PR DESCRIPTION
## What

`try_refresh()` in `cli/geolens_cli/auth.py` now persists a **retained** refresh token (the case where the server renews the access token but issues no replacement refresh token) through `store_refresh_token()` — value and pairing fingerprint together — into the backend the bearer **actually** landed in, and drops the superseded keyring copy once the file write has committed.

## Why

Round 31 rewrote only the pairing FINGERPRINT in that branch. That is enough while the bearer lands where `_detect_credential_backend()` said it would, and wrong the moment `store_bearer_token()` falls back from the keyring to `credentials.toml` on its own (a locked or account-specific `KeyringError`): the fingerprint moved to the file, the refresh token stayed in the keyring.

The next refresh then read the two halves from different backends. `_detect_credential_backend()` decides by looking for a `refresh_token` in the FILE, found none, answered "keyring", and wrote the newly rotated bearer there — where the stale file-backed bearer written by the earlier fallback outranks it under `load_bearer_token()`'s file-over-keyring precedence. Every later command 401s, refreshes, and 401s again instead of converging.

The keyring deletion reuses the keyring half of `_discard_unpaired_refresh_token()`, factored out as `_delete_keyring_refresh_entries()` so the file side — which now holds the only copy — is deliberately left alone. It keeps the same never-raises contract and is enumerated in `test_best_effort_helpers_never_raise.py`. `_rewrite_refresh_fingerprint()` had exactly one call site and is gone.

Invariants left intact: `_CREDENTIAL_SET` is unchanged, the three-state strict reads and the pairing check are untouched, and the new write still satisfies both structural gates in `test_refresh_token_backend_derivation.py` (`no_keyring=(backend != "keyring")` derived from the store call's real outcome, plus `bearer_token=` for pairing).

Fixes #1807.

Part of the 2026-08-30 audit tracked in #1778 (deferred from codex round 32 on #1802 under the merge-on-no-P1 policy).

## Tests

A backend-fallback row on the refresh pairing matrix (`cli/tests/test_credential_resolution_matrix.py`) — a dimension the existing table's axes cannot express, since every other row holds the backend fixed. It drives the whole sequence through the real CLI (`whoami` against a fake `/auth/me` + `/auth/refresh` pair): a bearer whose keyring write fails once, a refresh response with no replacement refresh token, then a second expiry with the keyring healthy again.

Counterfactual (both rows run against the unfixed `auth.py`):

- `test_retained_refresh_token_follows_the_bearer_into_the_file` — `KeyError: 'refresh_token'`; the retained token never reaches the file.
- `test_the_next_refresh_converges_instead_of_looping` — `assert 3 == 2`; the third command refreshes again, which is the loop the issue describes.

Both pass with the fix.

## Verification

```
cd cli && uv run --extra dev python -m pytest -q          # 647 passed (643 before, +4)
cd cli && uv run --extra dev ruff check geolens_cli tests/test_credential_resolution_matrix.py tests/test_best_effort_helpers_never_raise.py
cd cli && uv run --extra dev ruff format --diff geolens_cli/auth.py tests/test_credential_resolution_matrix.py
```

`ruff format --check` is red across `cli/` on `main` already (32 files) — the repo's ruff gate runs with `working-directory: backend`. The `--diff` above confirms none of the reformat hunks touch a line this PR adds.

No schema, API, or config impact. CLI-only, no SDK regeneration needed.


---

## Round 2 (codex round 1 P2, `auth.py:1576`)

Valid finding. Round 1 rewrote the retained refresh token through `store_refresh_token()` on **every** no-new-refresh-token rotation, including the ordinary one where the bearer landed in the backend it was already in — asking a second keyring account for a write of a secret that did not change.

Regression that opens: a keyring whose refresh account is readable but rejects writes, while the bearer and fingerprint accounts accept them, with no usable `credentials.toml` behind it. The write fails, the file fallback fails, and `try_refresh()` reports a rotation the server already performed as a failure — leaving the new bearer stored against the OLD fingerprint, so the next attempt discards a still-valid refresh token as unpaired. The pre-#1807 fingerprint-only path completed that rotation.

The retained-token branch now turns on whether the bearer actually moved backends:

- **unchanged** (the common case, and every `--no-keyring` profile) → `_rewrite_refresh_fingerprint()`, restored, touching exactly the one member that went stale;
- **moved** (keyring → file fallback) → the full `store_refresh_token()` migration plus the keyring cleanup, which is what this PR is about.

One `backend_moved` predicate gates both the write and the cleanup, so they cannot disagree about whether a move happened.

New matrix row: `TestRefreshPairingRefreshAccountWriteRejectedRow` — unchanged backend, refresh account rejects writes, no file fallback. Asserts the refresh succeeds, the fingerprint is updated in place, the retained token is untouched, nothing reaches the file, and the token is still paired and spendable on the next expiry.

Counterfactual against `732fb1089` (the round 1 head): the new row fails with `assert 3 == 0` — `SystemExit(3)`, EXIT_AUTH, the lost rotation. The two backend-fallback rows pass either way, as required.

```
cd cli && uv run --extra dev python -m pytest -q          # 648 passed (+1)
cd cli && uv run --extra dev python -m pytest -q tests/test_best_effort_helpers_never_raise.py tests/test_refresh_token_backend_derivation.py tests/test_credential_set_structural.py tests/test_refresh.py   # 70 passed
cd cli && uv run --extra dev ruff check geolens_cli tests/test_credential_resolution_matrix.py tests/test_best_effort_helpers_never_raise.py
```

The never-raise gate and both backend-derivation structural gates stay green: the two remaining `store_refresh_token()` call sites still derive `no_keyring=(backend != "keyring")` and pass `bearer_token=`.
