### PR TITLE
fix(ci): make the a11y and license jobs fail with a name instead of hanging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1707,6 +1707,19 @@ jobs:
     runs-on: ubuntu-latest
     if: always()  # run even if other jobs fail
     timeout-minutes: 5
+    # fix(#1816 round 2): job-scoped, not step-scoped. Codex round 1 on #1818
+    # caught that a step-level env: on "Install frontend dependencies" only
+    # covers `npm ci` — the next step's two `npx --yes license-checker`
+    # calls fetch that package over the network too (it's in neither
+    # package.json nor package-lock.json, unlike `npx playwright` elsewhere
+    # in this file, which resolves to the lockfile-installed binary and
+    # never hits the registry). A step-scoped var left those npx fetches on
+    # npm's 300000ms default, so a stall there could still eat the whole
+    # 5-minute job cap silently. Job-level env covers both steps.
+    env:
+      NPM_CONFIG_FETCH_TIMEOUT: "30000"
+      NPM_CONFIG_FETCH_RETRIES: "2"
+      NPM_CONFIG_LOGLEVEL: http
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
@@ -1729,11 +1742,9 @@ jobs:
         # fetch-timeout makes a stalled fetch fail (and retry) fast
         # instead of silently eating the job cap; NPM_CONFIG_LOGLEVEL=http
         # prints the request line for each fetch, so a future stall names
-        # the package/URL instead of five minutes of silence.
-        env:
-          NPM_CONFIG_FETCH_TIMEOUT: "30000"
-          NPM_CONFIG_FETCH_RETRIES: "2"
-          NPM_CONFIG_LOGLEVEL: http
+        # the package/URL instead of five minutes of silence. (Settings are
+        # job-scoped above so they also cover the npx license-checker
+        # fetches in the next step.)
         run: npm ci
 
       - name: Run license-checker (blocking — curated allowlist)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -962,6 +962,14 @@ jobs:
 
       - name: Install TypeScript SDK dependencies (locked)
         working-directory: sdks/typescript
+        # fix(#1816): same npm-ci-stall settings as License Check
+        # (frontend)'s Install step, applied here for consistency —
+        # any job restoring the npm cache and then fetching from the
+        # registry can hit the same registry stall.
+        env:
+          NPM_CONFIG_FETCH_TIMEOUT: "30000"
+          NPM_CONFIG_FETCH_RETRIES: "2"
+          NPM_CONFIG_LOGLEVEL: http
         run: npm ci
 
       - name: Regenerate SDKs and check for drift
@@ -1605,6 +1613,14 @@ jobs:
           cache-dependency-path: frontend/package-lock.json
 
       - name: Install dependencies
+        # fix(#1816): same npm-ci-stall settings as License Check
+        # (frontend)'s Install step, applied here for consistency —
+        # any job restoring the npm cache and then fetching from the
+        # registry can hit the same registry stall.
+        env:
+          NPM_CONFIG_FETCH_TIMEOUT: "30000"
+          NPM_CONFIG_FETCH_RETRIES: "2"
+          NPM_CONFIG_LOGLEVEL: http
         run: npm ci
 
       - name: Verify generated API types
@@ -1661,6 +1677,14 @@ jobs:
           cache-dependency-path: frontend/package-lock.json
 
       - name: Install dependencies
+        # fix(#1816): same npm-ci-stall settings as License Check
+        # (frontend)'s Install step, applied here for consistency —
+        # any job restoring the npm cache and then fetching from the
+        # registry can hit the same registry stall.
+        env:
+          NPM_CONFIG_FETCH_TIMEOUT: "30000"
+          NPM_CONFIG_FETCH_RETRIES: "2"
+          NPM_CONFIG_LOGLEVEL: http
         run: npm ci
 
       - name: Run tests with coverage
@@ -1694,6 +1718,22 @@ jobs:
 
       - name: Install frontend dependencies (locked)
         working-directory: frontend
+        # fix(#1816): three PR runs on 2026-09-03 (License Check job,
+        # runs 33814256132, 33817442567 x2) printed nothing for five
+        # minutes after the npm cache restored, then hit the job's
+        # timeout-minutes cap with the run marked "cancelled" rather
+        # than failed. npm's own defaults (`npm config list -l`:
+        # fetch-timeout=300000, fetch-retries=2) let one stalled
+        # registry connection sit for up to five minutes per attempt,
+        # which is the whole job budget here on its own. Lowering
+        # fetch-timeout makes a stalled fetch fail (and retry) fast
+        # instead of silently eating the job cap; NPM_CONFIG_LOGLEVEL=http
+        # prints the request line for each fetch, so a future stall names
+        # the package/URL instead of five minutes of silence.
+        env:
+          NPM_CONFIG_FETCH_TIMEOUT: "30000"
+          NPM_CONFIG_FETCH_RETRIES: "2"
+          NPM_CONFIG_LOGLEVEL: http
         run: npm ci
 
       - name: Run license-checker (blocking — curated allowlist)
@@ -1962,6 +2002,14 @@ jobs:
           cache-dependency-path: package-lock.json
 
       - name: Install dependencies
+        # fix(#1816): same npm-ci-stall settings as License Check
+        # (frontend)'s Install step, applied here for consistency —
+        # any job restoring the npm cache and then fetching from the
+        # registry can hit the same registry stall.
+        env:
+          NPM_CONFIG_FETCH_TIMEOUT: "30000"
+          NPM_CONFIG_FETCH_RETRIES: "2"
+          NPM_CONFIG_LOGLEVEL: http
         run: npm ci
 
       - name: Install Playwright Browsers
@@ -2139,6 +2187,14 @@ jobs:
           cache-dependency-path: package-lock.json
 
       - name: Install dependencies
+        # fix(#1816): same npm-ci-stall settings as License Check
+        # (frontend)'s Install step, applied here for consistency —
+        # any job restoring the npm cache and then fetching from the
+        # registry can hit the same registry stall.
+        env:
+          NPM_CONFIG_FETCH_TIMEOUT: "30000"
+          NPM_CONFIG_FETCH_RETRIES: "2"
+          NPM_CONFIG_LOGLEVEL: http
         run: npm ci
 
       - name: Install Playwright Browsers
@@ -2409,6 +2465,14 @@ jobs:
           cache-dependency-path: package-lock.json
 
       - name: Install dependencies
+        # fix(#1816): same npm-ci-stall settings as License Check
+        # (frontend)'s Install step, applied here for consistency —
+        # any job restoring the npm cache and then fetching from the
+        # registry can hit the same registry stall.
+        env:
+          NPM_CONFIG_FETCH_TIMEOUT: "30000"
+          NPM_CONFIG_FETCH_RETRIES: "2"
+          NPM_CONFIG_LOGLEVEL: http
         run: npm ci
 
       - name: Install Playwright Browsers
@@ -2466,8 +2530,40 @@ jobs:
             sleep 10
           done
 
+      # fix(#1817): 2026-09-03 runs 33790017112 and 33815788642 both hit this
+      # job's 15-minute cap with the log frozen at "Running 68 tests using 1
+      # worker" — GitHub then marks every step "cancelled", which the two
+      # upload steps below (correctly) skip via !cancelled(), so the ejected
+      # #1798 queue run left no report to look at. playwright.config.ts's CI
+      # reporter set ([github, html, json]) writes only at the end, so
+      # nothing streams to the log while a run is in progress; --reporter
+      # here is scoped to this invocation only (CLI --reporter replaces,
+      # rather than merges with, the config value) and keeps `html` so the
+      # report-upload step still has something to upload, while adding
+      # `line` for a per-test line as each test finishes.
+      #
+      # --timeout makes this job's per-test default explicit rather than
+      # inherited from playwright.config.ts (60_000ms there today). Measured
+      # on the two passing runs above, the step itself took 4m11s/4m29s for
+      # 68 tests (~3.8s/test average), so 60s leaves ~15x headroom on a
+      # normal test; the one test that legitimately needs more (the
+      # beforeAll hook in accessibility.spec.ts, which calls
+      # test.setTimeout(120_000) for its own seeding) already overrides its
+      # own timeout and is unaffected by this default.
+      #
+      # --global-timeout turns a real hang into a Playwright-reported
+      # failure (named test + stack, and a report artifact) instead of a
+      # GitHub cancellation. 480s (8 min) is ~1.8x the ~4.5-minute normal
+      # run and leaves several minutes of this job's 15-minute cap for the
+      # steps before and after (checkout/env/compose-up/npm-ci/browser-
+      # install ran in 2m45s-4m29s across the two measured passing runs).
       - name: Run accessibility tests
-        run: npx playwright test e2e/accessibility.spec.ts e2e/keyboard-nav.spec.ts --project=chromium
+        run: >-
+          npx playwright test e2e/accessibility.spec.ts e2e/keyboard-nav.spec.ts
+          --project=chromium
+          --reporter=line,html
+          --timeout=60000
+          --global-timeout=480000
 
       - name: Upload test results
         if: ${{ !cancelled() }}


### PR DESCRIPTION
## Summary

- **Accessibility (axe + keyboard-nav)**: on 2026-09-03 this job hit its 15-minute cap twice (runs 33790017112, and the #1798 queue run 33815788642), with the log frozen at `Running 68 tests using 1 worker` and nothing after. The job's CI reporter set (`[github, html, json]`, from `playwright.config.ts`) only writes at the end of a run, so a slow or hung run streams nothing to the log while in progress, and a job-cap cancellation marks every step `cancelled`, which the report-upload steps correctly skip (`if: ${{ !cancelled() }}`) — so the ejected queue run left no report to inspect. Scoped `--reporter=line,html` to this step's own invocation (CLI `--reporter` replaces, rather than merges with, the config value — kept `html` so the upload step still has something), added an explicit `--timeout=60000` matching the config's current per-test default, and `--global-timeout=480000` (8 min) so a genuine hang ends as a Playwright-reported failure (named test + stack + report artifact) instead of a bare GitHub cancellation.
- **License Check (frontend)**: hit its 5-minute job timeout on three PR runs the same day (#1770 run 33814256132, #1815 run 33817442567 x2), stalled for exactly five minutes on `Install frontend dependencies (locked)` right after the npm cache restored. `npm config list -l` shows npm's own defaults are `fetch-timeout=300000` (5 min) and `fetch-retries=2` — one stalled registry connection can eat the entire job budget in a single attempt. Lowered `NPM_CONFIG_FETCH_TIMEOUT` to 30s, pinned `NPM_CONFIG_FETCH_RETRIES=2` explicitly, and added `NPM_CONFIG_LOGLEVEL=http` so a future stall prints the request line (names the package/URL) instead of five minutes of silence.
- Applied the same three env vars to every other `npm ci` step in `ci.yml` (`sdks-check`, `frontend-lint`, `frontend-test`, `e2e-test`, `e2e-smoke`, `accessibility`) since they all restore the same npm cache and hit the same registry, so the same stall could hit any of them.

No assertions were weakened, `timeout-minutes` values are unchanged (measured passing accessibility runs took 7m30s-8m55s total, well under the 15-minute cap once a hang self-terminates instead of consuming the whole budget), and caching keys are untouched.

## Why these values

- `--timeout=60000`: matches `playwright.config.ts`'s current default. The two measured passing runs (33808900309, 33784340399) took 4m11s/4m29s for 68 tests (~3.8s/test average), so 60s leaves ~15x headroom on a normal test. The one hook needing more (`accessibility.spec.ts`'s `beforeAll`, seeding fixtures) already calls its own `test.setTimeout(120_000)`, which overrides the CLI default and is unaffected.
- `--global-timeout=480000` (8 min): ~1.8x the ~4.5-minute normal run, and leaves several minutes of the job's 15-minute cap for the steps before/after (checkout/env/compose-up/npm-ci/browser-install took 2m45s-4m29s across the two measured passing runs).
- `NPM_CONFIG_FETCH_TIMEOUT=30000`: well under npm's 300000ms default, which is exactly the observed 5-minute stall duration; a stalled fetch now fails fast enough for npm's built-in retries to still complete inside the job's 5-minute cap.
- `NPM_CONFIG_FETCH_RETRIES=2`: npm's existing default, pinned explicitly rather than left implicit.
- `NPM_CONFIG_LOGLEVEL=http`: prints one line per HTTP request without npm's `verbose`/`silly` levels' extra noise.

## Verification

- `pre-commit run --files .github/workflows/ci.yml` — passed (no `actionlint` hook is registered in this repo's `.pre-commit-config.yaml`; ran `actionlint .github/workflows/ci.yml` directly instead and diffed its output against `origin/main`'s — identical pre-existing shellcheck SC2086 info-level findings, no new findings from this change).
- `E2E_ALLOW_WORKTREE=1 npx playwright test --list e2e/accessibility.spec.ts e2e/keyboard-nav.spec.ts --project=chromium --reporter=line,html --timeout=60000 --global-timeout=480000` — all flags accepted, lists the same 68 tests seen in the hung runs' logs.
- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` — parses cleanly.

Fixes #1817
Fixes #1816

---

## Round 2 (codex)

Codex round 1 found one P2: the `env:` block for #1816 was scoped to the "Install frontend dependencies" step (`npm ci` only), but the next step in `license-check` runs two `npx --yes license-checker` calls, and `license-checker` is in neither `package.json` nor `package-lock.json` — so those calls fetch it over the network too, still on npm's 300000ms default `fetch-timeout`. (Contrast with `npx playwright` elsewhere in this file, which is a lockfile devDependency and resolves locally, no fetch involved.)

Fix: moved the three `NPM_CONFIG_*` vars from the step's `env:` to job-level `env:` on `license-check`, so both `npm ci` and the `npx license-checker` calls are covered. Checked every other `npx` invocation in `ci.yml` — all of them are `npx playwright` (install/test), which is in the root `package-lock.json`, so no other job has this gap.

Verification: `python3 -c "import yaml; yaml.safe_load(...)"` (clean), `actionlint .github/workflows/ci.yml` (same 4 pre-existing shellcheck SC2086 info findings as before, no new ones), `pre-commit run --files .github/workflows/ci.yml` (passed).

Head: d7ed6d35b77bcf969f4198fe88bcec2f9d0f0405
