### PR TITLE
fix(sources): reserve the ArcGIS sign-in attempt before the mint and hold no connection across it

### DIFF
--- a/backend/alembic/versions/0058_arcgis_signin_attempts_user_scope.py
+++ b/backend/alembic/versions/0058_arcgis_signin_attempts_user_scope.py
@@ -1,0 +1,64 @@
+"""Carry the per-caller ArcGIS sign-in budget on the cluster-global ledger.
+
+fix(#1775). ``POST /api/services/arcgis/signin/`` now reserves a counted
+attempt in its own short transaction BEFORE the credential POST and writes the
+audit row afterwards, so that a request cancelled mid-POST is already counted:
+ArcGIS may have counted that password, and GeoLens must not be the side that
+forgot it.
+
+That reordering moves the per-caller budget's source. It was counted from
+``catalog.audit_logs`` filtered on ``user_id`` and the ``token_service_host``
+detail, and a cancelled request writes no audit row at all, so exactly the
+attempts this issue exists to preserve would have gone uncounted. The budget
+therefore reads the ledger, and the ledger needs a column to key it on.
+
+``user_scope`` is the same kind of value as ``account_key``: an HMAC-SHA256
+digest under a key derived from the instance JWT secret, here over the caller's
+user id and the canonical token-service scope. It is NOT a plaintext user id.
+Migration 0056's rule that this table holds nothing tenant-identifying and
+nothing secret is what makes it safe to keep outside the RLS boundary, and a
+digest keeps that rule intact.
+
+Nullable, and not backfilled. A row written before this migration stands for an
+attempt whose caller cannot be recovered, and charging it to an arbitrary
+caller would be worse than not charging it at all. Every row is swept fifteen
+minutes after it is written, so the gap closes itself within one window.
+
+Revision ID: 0058_arcgis_signin_user_scope
+Revises: 0057_security_revocation_generation
+Create Date: 2026-09-03
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0058_arcgis_signin_user_scope"
+down_revision: Union[str, None] = "0057_security_revocation_generation"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "arcgis_signin_attempts",
+        sa.Column("user_scope", sa.String(length=64), nullable=True),
+        schema="catalog",
+    )
+    # The same shape as the account index: the windowed count for one caller.
+    op.create_index(
+        "ix_catalog_arcgis_signin_attempts_user_time",
+        "arcgis_signin_attempts",
+        ["user_scope", "attempted_at"],
+        schema="catalog",
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_catalog_arcgis_signin_attempts_user_time",
+        table_name="arcgis_signin_attempts",
+        schema="catalog",
+    )
+    op.drop_column("arcgis_signin_attempts", "user_scope", schema="catalog")

--- a/backend/app/modules/catalog/sources/arcgis_signin.py
+++ b/backend/app/modules/catalog/sources/arcgis_signin.py
@@ -191,12 +191,16 @@ AUDIT_DISCOVERY_TIMEOUT = "discovery_timeout"
 # this instance would not follow.
 AUDIT_DISCOVERY_UNTRUSTED_DELEGATE = "discovery_untrusted_delegate"
 # fix(#1775): the outcome of an attempt whose credential POST was interrupted
-# by external task cancellation, which is a uvicorn shutdown rather than
-# anything a client can trigger. GeoLens does not know whether ArcGIS counted
-# it, so it is recorded as its own outcome rather than guessed at, and it is
-# absent from UNCOUNTED_SIGNIN_RESULTS below because the password was already
-# on the wire. The row is best effort; what makes the attempt count is the
-# reservation the route commits BEFORE the POST.
+# by external task cancellation. fix(#1775 audit): a worker shutdown is one
+# source and NOT the only one — Starlette's `BaseHTTPMiddleware` cancels the
+# downstream task when the client disconnects, so a caller who hangs up can
+# reach this too. That is why the reservation, not this row, is what counts
+# the attempt: a client cannot make a credential POST free by disconnecting.
+# GeoLens does not know whether ArcGIS counted it, so it is recorded as its
+# own outcome rather than guessed at, and it is absent from
+# UNCOUNTED_SIGNIN_RESULTS below because the password was already on the wire.
+# The row is best effort; what makes the attempt count is the reservation the
+# route commits BEFORE the POST.
 AUDIT_CANCELLED = "cancelled"
 
 # The outcomes above that are NOT an attempt against ArcGIS, because GeoLens

--- a/backend/app/modules/catalog/sources/arcgis_signin.py
+++ b/backend/app/modules/catalog/sources/arcgis_signin.py
@@ -190,6 +190,14 @@ AUDIT_DISCOVERY_TIMEOUT = "discovery_timeout"
 # what this records is that the portal tried to send the password somewhere
 # this instance would not follow.
 AUDIT_DISCOVERY_UNTRUSTED_DELEGATE = "discovery_untrusted_delegate"
+# fix(#1775): the outcome of an attempt whose credential POST was interrupted
+# by external task cancellation, which is a uvicorn shutdown rather than
+# anything a client can trigger. GeoLens does not know whether ArcGIS counted
+# it, so it is recorded as its own outcome rather than guessed at, and it is
+# absent from UNCOUNTED_SIGNIN_RESULTS below because the password was already
+# on the wire. The row is best effort; what makes the attempt count is the
+# reservation the route commits BEFORE the POST.
+AUDIT_CANCELLED = "cancelled"
 
 # The outcomes above that are NOT an attempt against ArcGIS, because GeoLens
 # refused before any credential left the process. The route's shared attempt
@@ -675,6 +683,38 @@ def signin_account_key(host: str, username: str) -> str:
     """
     normalized = username.strip().casefold()
     message = f"{len(host)}:{host}:{len(normalized)}:{normalized}".encode()
+    return hmac.new(_account_digest_key(), message, hashlib.sha256).hexdigest()
+
+
+def signin_user_key(user_id: object, scope: str) -> str:
+    """A keyed handle for the CALLER half of the budget, and its destination.
+
+    fix(#1775): the per-user budget used to be counted from ``audit_logs``,
+    filtered on ``user_id`` and on the ``token_service_host`` detail. Under
+    reserve-then-settle the attempt is committed to the ledger BEFORE the
+    credential POST and the audit row is only written afterwards, so a
+    cancelled request writes no audit row and an ``audit_logs`` count would
+    undercount exactly the attempts that matter most. The ledger carries the
+    budget instead.
+
+    Keyed and length-prefixed like :func:`signin_account_key`, under the same
+    derived key, because ``arcgis_signin_attempts`` is deliberately outside
+    the tenant RLS boundary and must therefore hold no plaintext identifier of
+    a caller or a tenant (fix(#1758 codex r4)).
+
+    Both the user id AND the token-service scope go into the digest. #1775
+    writes this as ``HMAC(user_id)``, but the budget it carries has always
+    been per (caller, token-service scope): the advisory lock is taken on
+    ``user:<id>:host:<scope>`` and the audit query it replaces filtered on
+    both. Digesting the id alone would silently tighten a per-destination
+    limit into a global one, which is a different limit, not this one.
+
+    The domain tag distinguishes this construction from
+    :func:`signin_account_key`'s, so no ArcGIS username can be spelled to
+    collide with a GeoLens user id.
+    """
+    ident = str(user_id)
+    message = f"signin-user:{len(ident)}:{ident}:{len(scope)}:{scope}".encode()
     return hmac.new(_account_digest_key(), message, hashlib.sha256).hexdigest()
 
 

--- a/backend/app/modules/catalog/sources/arcgis_signin.py
+++ b/backend/app/modules/catalog/sources/arcgis_signin.py
@@ -191,11 +191,15 @@ AUDIT_DISCOVERY_TIMEOUT = "discovery_timeout"
 # this instance would not follow.
 AUDIT_DISCOVERY_UNTRUSTED_DELEGATE = "discovery_untrusted_delegate"
 # fix(#1775): the outcome of an attempt whose credential POST was interrupted
-# by external task cancellation. fix(#1775 audit): a worker shutdown is one
-# source and NOT the only one — Starlette's `BaseHTTPMiddleware` cancels the
-# downstream task when the client disconnects, so a caller who hangs up can
-# reach this too. That is why the reservation, not this row, is what counts
-# the attempt: a client cannot make a credential POST free by disconnecting.
+# by external task cancellation. fix(#1775 audit): a WORKER SHUTDOWN is the
+# only source that reaches this on the pinned Starlette 1.6.0. A client
+# disconnect does not: it arrives as an `http.disconnect` MESSAGE on the
+# receive channel, which a non-streaming route never reads, and the one
+# `cancel()` in `BaseHTTPMiddleware` (middleware/base.py:121) ends the sibling
+# `response_sent.wait` race inside `receive_or_disconnect` rather than the
+# downstream coroutine. What makes this path safe whatever the source is — on
+# this Starlette or a later one — is the reservation: the attempt is counted
+# before the POST, so no cancellation can make a credential POST free.
 # GeoLens does not know whether ArcGIS counted it, so it is recorded as its
 # own outcome rather than guessed at, and it is absent from
 # UNCOUNTED_SIGNIN_RESULTS below because the password was already on the wire.

--- a/backend/app/modules/catalog/sources/models.py
+++ b/backend/app/modules/catalog/sources/models.py
@@ -33,9 +33,16 @@ class ArcGISSignInAttempt(Base):
     username, no password, no token, no portal URL, no user id and no tenant
     id, and rows are swept fifteen minutes after they are written.
 
-    The per-GeoLens-user half of the limit stays on ``audit_logs`` and stays
-    tenant-scoped, which is correct: that budget only ever needs to see the
-    caller's own rows.
+    fix(#1775): the per-GeoLens-user half of the limit moved here too, as
+    ``user_scope``. It used to be counted from ``audit_logs``, but under
+    reserve-then-settle the attempt is committed BEFORE the credential POST
+    and the audit row is written after it, so a cancelled request leaves no
+    audit row and that count would miss the attempt that already went out.
+    ``user_scope`` is the same kind of value as ``account_key`` — a keyed
+    HMAC-SHA256 digest, here of the caller's id and the token-service scope
+    (``arcgis_signin.signin_user_key``) — so the no-plaintext-identifier rule
+    above still holds: there is no user id and no tenant id in this table, and
+    a digest is readable only by the instance that wrote it.
     """
 
     __tablename__ = "arcgis_signin_attempts"
@@ -47,6 +54,12 @@ class ArcGISSignInAttempt(Base):
             "account_key",
             "attempted_at",
         ),
+        # fix(#1775): the same shape for the per-caller budget's own count.
+        Index(
+            "ix_catalog_arcgis_signin_attempts_user_time",
+            "user_scope",
+            "attempted_at",
+        ),
         Index("ix_catalog_arcgis_signin_attempts_attempted_at", "attempted_at"),
         {"schema": "catalog"},
     )
@@ -55,6 +68,10 @@ class ArcGISSignInAttempt(Base):
         UUID(as_uuid=True), primary_key=True, server_default=func.gen_random_uuid()
     )
     account_key: Mapped[str] = mapped_column(String(64), nullable=False)
+    # fix(#1775): nullable because rows written before this column existed
+    # have no caller digest and must not be charged to one. They age out of
+    # the fifteen-minute window on their own, so the gap closes itself.
+    user_scope: Mapped[str | None] = mapped_column(String(64), nullable=True)
     attempted_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), nullable=False, server_default=func.now()
     )

--- a/backend/app/modules/catalog/sources/router.py
+++ b/backend/app/modules/catalog/sources/router.py
@@ -1339,12 +1339,17 @@ async def arcgis_signin(
             except ArcGISSignInError as exc:
                 await _signin_refusal(db, user_id, target, exc, note, reserved=True)
             except asyncio.CancelledError:
-                # fix(#1775): uvicorn cancelling this task during shutdown
-                # bypasses `mint`'s `except Exception` and the clause above.
+                # fix(#1775): a cancelled task bypasses `mint`'s `except
+                # Exception` and the clause above. fix(#1775 audit): the
+                # source is a worker shutting down OR a client disconnecting,
+                # which Starlette's `BaseHTTPMiddleware` also turns into a
+                # cancellation — and a disconnecting client spends a
+                # reservation for it, which is the conservative direction.
                 # The count is already durable; what this recovers is the
-                # operator-facing row saying a password went out. Shielded and
-                # best effort, and it re-raises either way — see the helper.
-                await _signin_settle_cancelled(db, user_id, target, note)
+                # operator-facing row saying a password went out. It takes a
+                # session of its own, is best effort, and re-raises either
+                # way — see the helper.
+                await _signin_settle_cancelled(user_id, target, note)
                 raise
 
             # fix(#1775): SETTLE. A second short transaction, and the only one

--- a/backend/app/modules/catalog/sources/router.py
+++ b/backend/app/modules/catalog/sources/router.py
@@ -33,16 +33,14 @@ from app.modules.catalog.sources.arcgis_signin import (
     ArcGISSignInError,
     open_portal_signin,
     portal_host,
-    signin_account_key,
 )
 from app.modules.catalog.sources.preview import build_gdal_source, run_service_preview
 from app.modules.catalog.sources.signin_guard import (
     _signin_audit,
-    _signin_budgets_spent,
-    _signin_in_progress,
-    _signin_locks,
-    _signin_rate_limited,
     _signin_refusal,
+    _signin_reserve,
+    _signin_settle_cancelled,
+    signin_target,
 )
 from app.modules.catalog.sources.probe import ServiceNotRecognized, detect_service_type
 from app.modules.catalog.sources.schemas import (
@@ -1144,16 +1142,18 @@ async def preview_service_layer(
 #    control 4 raised out of the way: six 200s under the old keying, three
 #    200s then three 429s under the new. The key functions below were never
 #    the leak; they carry the user id in both.
-# 3. A PostgreSQL advisory lock per (user, portal host), held across the
-#    mint, so the count below cannot be read by two workers at once.
-# 4. The same three attempts per fifteen minutes counted from the audit rows
-#    this endpoint already writes, which is shared state on a stock install.
-#    Valkey is not: `REDIS_URL` is unset by default, so a Valkey-backed
-#    limiter would be no enforcement at all on the installs that most need
-#    it. Strictly below Esri's five failed sign-ins in fifteen minutes, so
-#    GeoLens can never be what locks an account and the user keeps two
-#    attempts of their own.
+# 3. Two PostgreSQL advisory locks, per (user, token service) and per ArcGIS
+#    account, so the count below cannot be read by two workers at once.
+# 4. The same three attempts per fifteen minutes, counted from the ledger rows
+#    this endpoint writes, which is shared state on a stock install. Valkey is
+#    not: `REDIS_URL` is unset by default, so a Valkey-backed limiter would be
+#    no enforcement at all on the installs that most need it. Strictly below
+#    Esri's five failed sign-ins in fifteen minutes, so GeoLens can never be
+#    what locks an account and the user keeps two attempts of their own.
 # 5. One POST per attempt and never a retry, in `arcgis_signin.py`.
+#
+# fix(#1775): controls 3 and 4 apply in ONE short transaction that commits
+# before the credential POST, rather than across it. See `_signin_reserve`.
 #
 # fix(#1758 codex r1): controls 3 and 4 replaced a process-local set and a
 # pair of process-local counters that a two-worker install multiplied by two.
@@ -1167,19 +1167,19 @@ _ARCGIS_SIGNIN_USER_LIMIT = "3/15minutes"
 _ARCGIS_SIGNIN_PORTAL_LIMIT = "3/15minutes"
 
 
-# fix(#1758 codex r17): a worker-wide ceiling on sign-ins that are inside
-# their network phases, set below the database pool so they cannot take it.
-# Production runs 10 pooled connections plus 3 overflow (13), and a sign-in
-# holds its request connection across discovery and the mint for up to the
-# 45-second budget, so 13 concurrent sign-ins for distinct scopes could
-# occupy the whole pool and time out unrelated API requests. Four leaves nine
-# for everything else.
-#
-# This BOUNDS that saturation, it does not remove it: the connection is still
-# held across external I/O. The reservation redesign that removes it is
-# tracked separately; see the PR body.
-_ARCGIS_SIGNIN_CONCURRENCY = 4
-_signin_slots = asyncio.Semaphore(_ARCGIS_SIGNIN_CONCURRENCY)
+# fix(#1775): the worker-wide `asyncio.Semaphore(4)` that used to stand here
+# is GONE, and its removal is the point of this change rather than a
+# side-effect. It existed (fix(#1758 codex r17)) because a sign-in held its
+# pooled connection across discovery and the mint for up to the 45-second
+# network budget, so 13 concurrent sign-ins for distinct scopes could occupy a
+# 10+3 pool and time out unrelated API requests; four was a bound on that
+# saturation, honestly documented as a bound rather than a fix. The handler
+# below now holds no connection across any network phase, so there is nothing
+# left for the ceiling to protect, and keeping it would refuse a fifth
+# concurrent caller per worker for no remaining reason. What still bounds
+# outbound credential POSTs is what always did the work: three attempts per
+# ArcGIS account and three per caller and token service, both committed before
+# the POST goes out.
 
 _require_create_layers = require_permission("create_layers")
 
@@ -1276,6 +1276,21 @@ async def arcgis_signin(
     an API key instead. A portal on a private network is unreachable either
     way.
     """
+    # fix(#1775): the scalars this handler needs, taken off the ORM instance
+    # BEFORE the rollback below. `Identity` is the concrete `User` row, and
+    # `AsyncSession.rollback()` expires every instance it loaded, so the next
+    # attribute read would raise MissingGreenlet rather than reload.
+    user_id = user.id
+    # fix(#1775): return the pooled connection before any network I/O. The
+    # `create_layers` check above left this session in an open transaction,
+    # which used to stay checked out through discovery, both advisory locks
+    # and the mint — up to the 45-second budget — so 13 concurrent sign-ins
+    # for distinct scopes could occupy a 10+3 pool and time out unrelated API
+    # requests. Nothing of ours is uncommitted here, so the rollback discards
+    # nothing; the later phases reuse this same session object and each checks
+    # out a fresh connection for as long as its own short transaction lasts.
+    await db.rollback()
+
     # fix(#1758 codex r7): phase one resolves WHERE the password would go, and
     # every limit below is keyed on that rather than on the address the caller
     # typed. fix(#1758 codex r11): "where" is the installation, not just the
@@ -1287,6 +1302,9 @@ async def arcgis_signin(
     # fresh three-attempt buckets against a single ArcGIS account. Discovery
     # is a credential-free GET under the same deadline, and it runs before any
     # lock is taken so a portal that cannot be resolved costs nobody a lock.
+    # It is also why the reservation cannot simply precede discovery: the
+    # account scope IS the token-service destination, and only discovery knows
+    # it.
     #
     # fix(#1758 codex r8): the resolved identity is held OUTSIDE the block, so
     # the handler below can charge a failure to it. A cancellation is the case
@@ -1296,78 +1314,50 @@ async def arcgis_signin(
     # Charged to `unknown` that outcome spent nothing, and a caller could
     # repeat credential POSTs against a real account forever without the
     # ledger ever moving.
-    resolved_host: str | None = None
-    resolved_account_key: str | None = None
-    resolved_note: str | None = None
-    # fix(#1758 codex r17): refuse rather than queue. Waiting here would hold
-    # the request's own pooled connection while waiting, which is the resource
-    # this bound exists to protect; the caller gets the same 429 the attempt
-    # budget uses and the client already maps.
-    if _signin_slots.locked():
-        await _signin_refusal(
-            db,
-            user.id,
-            "unknown",
-            signin_account_key("unknown", body.username),
-            _signin_rate_limited(),
-        )
+    target = signin_target(user_id, "unknown", body.username)
+    note: str | None = None
+    reserved = False
     try:
-        async with _signin_slots, open_portal_signin(body.portal_url) as portal:
+        async with open_portal_signin(body.portal_url) as portal:
             # fix(#1758 codex r3): the account lock and both budgets are keyed
             # on the ARCGIS account, not on the GeoLens caller. The username
             # reaches this line and goes no further: what is stored, locked on
             # and counted is the digest.
-            resolved_host = host = portal.scope
-            resolved_account_key = account_key = signin_account_key(host, body.username)
-            resolved_note = portal.discovery_note
+            target = signin_target(user_id, portal.scope, body.username)
+            note = portal.discovery_note
 
-            # fix(#1758 codex r5): two locks, taken user-and-host FIRST and
-            # account SECOND, and that order is the whole of the deadlock
-            # argument. The account lock alone left the per-user budget racy:
-            # one caller signing in to three different accounts on one host
-            # took three different account locks, so all three read the same
-            # pre-attempt count and all three passed a limit of three.
-            #
-            # fix(#1758 codex r6/r10): both on the request's own session, so
-            # a sign-in costs one pooled connection rather than three.
-            async with _signin_locks(
-                db, f"user:{user.id}:host:{host}", f"account:{account_key}"
-            ) as locked:
-                if not locked:
-                    await _signin_refusal(
-                        db, user.id, host, account_key, _signin_in_progress()
-                    )
-                if await _signin_budgets_spent(db, user.id, host, account_key):
-                    await _signin_refusal(
-                        db, user.id, host, account_key, _signin_rate_limited()
-                    )
-                try:
-                    minted = await portal.mint(body.username, body.password)
-                except ArcGISSignInError as exc:
-                    await _signin_refusal(
-                        db, user.id, host, account_key, exc, resolved_note
-                    )
+            # fix(#1775): RESERVE. One short transaction takes both locks,
+            # reads both budgets, commits the counted attempt and gives the
+            # connection back. Everything after this line runs with no session
+            # held, and the attempt is already spent, so a cancellation cannot
+            # hand ArcGIS a failed password that GeoLens does not count.
+            await _signin_reserve(db, user_id, target, note)
+            reserved = True
 
-                # Inside both locks, so the row is committed before the next
-                # attempt against this account, or by this caller against this
-                # token service, can read either counter.
-                logger.info("ArcGIS sign-in succeeded", token_service_host=host)
-                await _signin_audit(
-                    db, user.id, host, AUDIT_SUCCESS, account_key, resolved_note
-                )
+            try:
+                minted = await portal.mint(body.username, body.password)
+            except ArcGISSignInError as exc:
+                await _signin_refusal(db, user_id, target, exc, note, reserved=True)
+            except asyncio.CancelledError:
+                # fix(#1775): uvicorn cancelling this task during shutdown
+                # bypasses `mint`'s `except Exception` and the clause above.
+                # The count is already durable; what this recovers is the
+                # operator-facing row saying a password went out. Shielded and
+                # best effort, and it re-raises either way — see the helper.
+                await _signin_settle_cancelled(db, user_id, target, note)
+                raise
+
+            # fix(#1775): SETTLE. A second short transaction, and the only one
+            # that runs after the network. The reservation already counted the
+            # attempt, so `reserved=True` keeps this from counting it twice.
+            logger.info("ArcGIS sign-in succeeded", token_service_host=target.host)
+            await _signin_audit(db, user_id, target, AUDIT_SUCCESS, note, reserved=True)
     except ArcGISSignInError as exc:
-        # A mint failure was already turned into an HTTPException above, inside
-        # the locks, so what reaches here is either a phase-one failure or a
-        # cancellation that unwound past the inner handler. `unknown` is only
-        # ever correct for the first: once discovery has named a destination,
-        # every outcome after it is charged to that account, ledger row
-        # included, because by then a credential POST may well have gone out.
-        await _signin_refusal(
-            db,
-            user.id,
-            resolved_host or "unknown",
-            resolved_account_key or signin_account_key("unknown", body.username),
-            exc,
-            resolved_note,
-        )
+        # A mint failure was already turned into an HTTPException above, so
+        # what reaches here is a phase-one failure. `unknown` is only ever
+        # correct for that: once discovery has named a destination, every
+        # outcome after it is charged to that account. `reserved` is carried
+        # rather than assumed, so a counted outcome that a later change adds
+        # between the reservation and the mint cannot count itself twice.
+        await _signin_refusal(db, user_id, target, exc, note, reserved=reserved)
     return ArcGISSignInResponse(token=minted.token, expires_at=minted.expires_at)

--- a/backend/app/modules/catalog/sources/router.py
+++ b/backend/app/modules/catalog/sources/router.py
@@ -1340,15 +1340,16 @@ async def arcgis_signin(
                 await _signin_refusal(db, user_id, target, exc, note, reserved=True)
             except asyncio.CancelledError:
                 # fix(#1775): a cancelled task bypasses `mint`'s `except
-                # Exception` and the clause above. fix(#1775 audit): the
-                # source is a worker shutting down OR a client disconnecting,
-                # which Starlette's `BaseHTTPMiddleware` also turns into a
-                # cancellation — and a disconnecting client spends a
-                # reservation for it, which is the conservative direction.
-                # The count is already durable; what this recovers is the
-                # operator-facing row saying a password went out. It takes a
-                # session of its own, is best effort, and re-raises either
-                # way — see the helper.
+                # Exception` and the clause above. fix(#1775 audit): on the
+                # pinned Starlette the source is a WORKER SHUTDOWN and nothing
+                # else — a client hanging up arrives as an `http.disconnect`
+                # message a non-streaming route never reads, not as a
+                # cancellation. The reservation is what keeps this path safe
+                # regardless: the attempt was counted before the POST, so it
+                # stands whatever cancelled the request. What this clause
+                # recovers is the operator-facing row saying a password went
+                # out. It takes a session of its own, is best effort, and
+                # re-raises either way — see the helper.
                 await _signin_settle_cancelled(user_id, target, note)
                 raise
 

--- a/backend/app/modules/catalog/sources/signin_guard.py
+++ b/backend/app/modules/catalog/sources/signin_guard.py
@@ -7,21 +7,30 @@ sits under a 1500-line cap that this grew through five review rounds.
 
 The shape, in the order the route applies it:
 
+* fix(#1775): RESERVE, then SETTLE, and nothing here holds a pooled
+  connection across the network. :func:`_signin_reserve` is one short
+  transaction that takes both advisory locks, reads both budgets and commits
+  the ledger row, all BEFORE the credential POST; the route then mints with
+  no session held, and :func:`_signin_audit` writes the outcome in a second
+  short transaction. A cancellation during the POST therefore cannot lose the
+  count: it is already committed.
 * two PostgreSQL advisory locks, taken caller-and-portal first and account
-  second, so the budget reads below are serialized and the pair cannot
-  deadlock (see :func:`_signin_lock`);
+  second, so the budget read and the ledger write are serialized and the pair
+  cannot deadlock (see :func:`_signin_locks`);
 * two budgets, three attempts per fifteen minutes each, one per target ArcGIS
-  account and one per caller and portal, read from different tables for the
-  reason :func:`_signin_budgets_spent` gives;
-* one audit row per attempt, and a ledger row for the attempts that count.
+  account and one per caller and token service, both read from the ledger for
+  the reason :func:`_signin_budgets_spent` gives;
+* one audit row per attempt, and one ledger row for each attempt that counts.
 
 Nothing here holds a credential. The caller's username reaches the route and
 is turned into a keyed digest before anything in this module sees it.
 """
 
+import asyncio
 import contextlib
 import uuid
 from collections.abc import AsyncIterator
+from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from typing import NoReturn
 
@@ -30,13 +39,15 @@ from fastapi import HTTPException, status
 from sqlalchemy import delete, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.modules.audit.models import AuditLog
 from app.modules.audit.service import AuditEvent, audit_emit
 from app.modules.catalog.sources.arcgis_signin import (
+    AUDIT_CANCELLED,
     AUDIT_CONCURRENT,
     AUDIT_RATE_LIMITED,
     UNCOUNTED_SIGNIN_RESULTS,
     ArcGISSignInError,
+    signin_account_key,
+    signin_user_key,
 )
 from app.modules.catalog.sources.models import ArcGISSignInAttempt
 
@@ -46,14 +57,53 @@ logger = structlog.stdlib.get_logger(__name__)
 _ARCGIS_SIGNIN_ATTEMPT_LIMIT = 3
 _ARCGIS_SIGNIN_WINDOW = timedelta(minutes=15)
 
+# fix(#1775): how long _signin_settle_cancelled will keep handing the event
+# loop a turn so its shielded audit write can finish. One local INSERT and
+# COMMIT, so a second is three orders of magnitude of headroom; the ceiling is
+# there so a database that has stopped answering cannot hold a shutting-down
+# worker open, not because the write is expected to need it.
+_SETTLE_DRAIN_SECONDS = 1.0
+
+
+@dataclass(frozen=True)
+class SignInTarget:
+    """Everything one attempt is charged to, and the only shape that carries it.
+
+    fix(#1775): three values that must always agree — the canonical
+    token-service scope, the account digest and the caller digest — travelled
+    as three parallel arguments through five functions, and the reserve/settle
+    split adds a third phase that has to charge the same three. One frozen
+    value means a phase cannot reserve against one account and settle against
+    another.
+
+    ``host`` is the canonical ``host:port/webadaptor`` of the destination that
+    receives the password (fix(#1758 codex r7/r11)), or the synthetic
+    ``"unknown"`` for the outcomes that precede discovery, where nothing was
+    sent.
+    """
+
+    host: str
+    account_key: str
+    user_scope: str
+
+
+def signin_target(user_id: uuid.UUID, host: str, username: str) -> SignInTarget:
+    """Derive both digests for one (caller, destination, ArcGIS account)."""
+    return SignInTarget(
+        host=host,
+        account_key=signin_account_key(host, username),
+        user_scope=signin_user_key(user_id, host),
+    )
+
 
 async def _signin_audit(
     db: AsyncSession,
     user_id: uuid.UUID,
-    host: str,
+    target: SignInTarget,
     result: str,
-    account_key: str,
     note: str | None = None,
+    *,
+    reserved: bool = False,
 ) -> None:
     """Record one sign-in attempt: who, which portal, which account, what happened.
 
@@ -62,6 +112,14 @@ async def _signin_audit(
     accounts, and the host, the digest and the outcome are the whole of that
     signal. ``result`` carries the distinction the caller-facing message
     deliberately collapses.
+
+    fix(#1775): ``reserved`` says the ledger row for this attempt was already
+    committed by :func:`_signin_reserve` before the credential POST, so this
+    call must not write a second one. It is NOT a rename of the exclusion
+    list: an attempt that reaches an outcome without ever being reserved —
+    every refusal that precedes discovery, and any counted outcome a later
+    change adds there — still counts here, so the exclusion list keeps its
+    "a new outcome counts until somebody decides otherwise" property.
     """
     await audit_emit(
         db,
@@ -74,13 +132,13 @@ async def _signin_audit(
                 # authInfo.tokenServicesUrl, not the address the caller typed.
                 # That is what the limits are keyed on, so that is what an
                 # operator reading this row needs to see.
-                "token_service_host": host,
+                "token_service_host": target.host,
                 "result": result,
                 # fix(#1758 codex r3): a keyed digest of the target account,
                 # never the username. It is what both budgets below are
                 # counted on, and it is the only trace of which ArcGIS account
                 # was addressed that survives the request.
-                "account_key": account_key,
+                "account_key": target.account_key,
                 # fix(#1758 codex r9): present only when discovery turned up
                 # something an operator should see, so the common row keeps
                 # its shape.
@@ -88,12 +146,16 @@ async def _signin_audit(
             },
         ),
     )
-    if result not in UNCOUNTED_SIGNIN_RESULTS:
-        # fix(#1758 codex r4): the account budget's own copy, in the one table
-        # that is not tenant-scoped. Written here rather than at the call
-        # sites so the ledger and the audit row can never disagree about what
-        # counted. Same transaction, so they commit or fail together.
-        db.add(ArcGISSignInAttempt(account_key=account_key))
+    if not reserved and result not in UNCOUNTED_SIGNIN_RESULTS:
+        # fix(#1758 codex r4): both budgets' own copy, in the one table that is
+        # not tenant-scoped. Written here rather than at the call sites so the
+        # ledger and the audit row can never disagree about what counted. Same
+        # transaction, so they commit or fail together.
+        db.add(
+            ArcGISSignInAttempt(
+                account_key=target.account_key, user_scope=target.user_scope
+            )
+        )
         await _sweep_expired_signin_attempts(db)
     await db.commit()
 
@@ -115,9 +177,7 @@ async def _sweep_expired_signin_attempts(db: AsyncSession) -> None:
     )
 
 
-async def _signin_budgets_spent(
-    db: AsyncSession, user_id: uuid.UUID, host: str, account_key: str
-) -> bool:
+async def _signin_budgets_spent(db: AsyncSession, target: SignInTarget) -> bool:
     """Whether either attempt budget is spent inside the window.
 
     fix(#1758 codex r1): the cross-worker half of the lockout limit. The rows
@@ -133,15 +193,25 @@ async def _signin_budgets_spent(
     because the account budget alone would let one user walk many accounts at
     three each.
 
-    fix(#1758 codex r4): the two budgets read DIFFERENT tables, and that is
-    the fix rather than an accident. ``audit_logs`` carries
-    ``tenant_isolation_audit_logs``, so counting the account budget there
-    made it per tenant and let two tenants send six failures at one account.
-    The account budget therefore counts ``arcgis_signin_attempts``, which is
-    deliberately outside the RLS boundary; see that model's docstring for why
-    that is safe. The per-user budget stays on ``audit_logs`` and stays
-    tenant-scoped, which is correct, because a limit on one caller only ever
-    needs to see that caller's own rows.
+    fix(#1758 codex r4): the account budget counts ``arcgis_signin_attempts``
+    rather than ``audit_logs``, and that is the fix rather than an accident.
+    ``audit_logs`` carries ``tenant_isolation_audit_logs``, so counting there
+    made the budget per tenant and let two tenants send six failures at one
+    account. The ledger is deliberately outside the RLS boundary; see that
+    model's docstring for why that is safe.
+
+    fix(#1775): the per-caller budget now counts the SAME table, keyed on
+    ``user_scope``. It read ``audit_logs`` while the audit row was the only
+    record of an attempt, and that was correct then: a limit on one caller
+    only ever needs that caller's own rows, so tenant scoping cost it nothing.
+    Reserve-then-settle breaks the premise rather than the reasoning. The
+    attempt is now committed BEFORE the credential POST and the audit row is
+    written after it, so a request cancelled mid-POST has spent a real
+    attempt and left no audit row at all, and an ``audit_logs`` count would
+    undercount exactly the attempts this endpoint most needs to remember.
+    ``user_scope`` is a keyed digest of the caller and the token-service
+    scope, so the ledger still holds no plaintext identifier and one caller
+    still only ever counts their own rows.
 
     Outcomes GeoLens refused on its own account do not count, because no
     credential reached ArcGIS on those and Esri counted nothing. That set is
@@ -150,18 +220,16 @@ async def _signin_budgets_spent(
     keeps a refusal from extending its own window: a rate-limited attempt
     that counted itself would hold the caller over the limit for another
     fifteen minutes on every retry, and they would never get back in. The
-    ledger holds only counted attempts, so it needs no such filter.
+    ledger holds only counted attempts, so it needs no such filter — which is
+    the second reason both budgets now read it rather than one.
     """
     since = datetime.now(tz=UTC) - _ARCGIS_SIGNIN_WINDOW
     by_user = await db.scalar(
         select(func.count())
-        .select_from(AuditLog)
+        .select_from(ArcGISSignInAttempt)
         .where(
-            AuditLog.action == "arcgis_signin",
-            AuditLog.created_at >= since,
-            AuditLog.user_id == user_id,
-            AuditLog.details["token_service_host"].astext == host,
-            AuditLog.details["result"].astext.not_in(sorted(UNCOUNTED_SIGNIN_RESULTS)),
+            ArcGISSignInAttempt.user_scope == target.user_scope,
+            ArcGISSignInAttempt.attempted_at >= since,
         )
     )
     if int(by_user or 0) >= _ARCGIS_SIGNIN_ATTEMPT_LIMIT:
@@ -170,11 +238,154 @@ async def _signin_budgets_spent(
         select(func.count())
         .select_from(ArcGISSignInAttempt)
         .where(
-            ArcGISSignInAttempt.account_key == account_key,
+            ArcGISSignInAttempt.account_key == target.account_key,
             ArcGISSignInAttempt.attempted_at >= since,
         )
     )
     return int(by_account or 0) >= _ARCGIS_SIGNIN_ATTEMPT_LIMIT
+
+
+async def _signin_reserve(
+    db: AsyncSession,
+    user_id: uuid.UUID,
+    target: SignInTarget,
+    note: str | None = None,
+) -> None:
+    """Spend one attempt DURABLY, in one short transaction, before any password moves.
+
+    fix(#1775): this is the whole of the issue's shape. Take both locks, read
+    both budgets, insert the ledger row, commit. Everything in that sentence
+    is inside one transaction, so the no-interleaving property #1758 built the
+    locks for survives intact: no other caller can read either counter between
+    this caller's read and this caller's write.
+
+    fix(#1758 codex r5): both locks, taken user-and-host FIRST and account
+    SECOND, and that order is the whole of the deadlock argument. The account
+    lock alone left the per-caller budget racy: one caller signing in to three
+    different accounts on one host took three different account locks, so all
+    three read the same pre-attempt count and all three passed a limit of
+    three.
+
+    Two things change, and both are the point.
+
+    The connection goes back to the pool at the commit, so the mint that
+    follows holds none. Thirteen concurrent sign-ins for distinct scopes used
+    to be able to occupy a 10+3 pool for the 45-second network budget and time
+    out unrelated API requests; now a sign-in touches the pool only for this
+    transaction and the settle that follows it, and never while the network is
+    in flight.
+
+    The attempt is counted BEFORE the credential POST rather than after it. A
+    ``CancelledError`` during the POST — uvicorn shutting a worker down —
+    bypasses both ``PortalSignIn.mint``'s ``except Exception`` and the route's
+    ``except ArcGISSignInError``, so under write-at-settle the audit row and
+    the ledger row were both lost while ArcGIS may well have counted the
+    password. Counting first is the conservative direction: the worst case is
+    an attempt charged for a POST that never left, which costs the caller one
+    of three, where the other direction costs a customer their ArcGIS account.
+
+    The locks are held for this transaction only, so the 409 that says a
+    sign-in is already in progress now fires on a collision inside the
+    reservation rather than across the whole mint. That is not a weakening of
+    the counter: what the lock protected was the read-then-write race, and the
+    read and the write are both in here. What it does allow is up to three
+    concurrent credential POSTs for one account instead of one, and three is
+    the budget's own ceiling, still strictly below the five failures Esri
+    locks an account on.
+    """
+    async with _signin_locks(
+        db, f"user:{user_id}:host:{target.host}", f"account:{target.account_key}"
+    ) as locked:
+        if not locked:
+            await _signin_refusal(db, user_id, target, _signin_in_progress(), note)
+        if await _signin_budgets_spent(db, target):
+            await _signin_refusal(db, user_id, target, _signin_rate_limited(), note)
+        db.add(
+            ArcGISSignInAttempt(
+                account_key=target.account_key, user_scope=target.user_scope
+            )
+        )
+        await _sweep_expired_signin_attempts(db)
+        await db.commit()
+
+
+async def _signin_settle_cancelled(
+    db: AsyncSession,
+    user_id: uuid.UUID,
+    target: SignInTarget,
+    note: str | None = None,
+) -> None:
+    """Record the outcome of an attempt whose credential POST was cancelled.
+
+    fix(#1775): a shielded finaliser rather than a bare ``finally``, and the
+    distinction matters in both directions.
+
+    Why a finaliser at all, when the count is already durable: the ledger row
+    was committed by :func:`_signin_reserve` before the POST, so the budget is
+    correct whether or not this ever runs. What is missing after a cancellation
+    is the OPERATOR-facing half — the audit row that says a password went to
+    this token service on this caller's say-so. Silence there reads as "no
+    attempt", which is the one thing that is not true.
+
+    Why a shield rather than a plain await, and why the loop. The caller
+    reaches here from ``except asyncio.CancelledError``, and a plain await
+    would simply be cancelled again. Measured rather than assumed: a bare
+    ``await asyncio.shield(...)`` here returns ``CancelledError``, not the
+    written row, because every request runs inside the anyio task groups that
+    Starlette's four ``BaseHTTPMiddleware`` layers open, and an anyio cancel
+    scope re-arms cancellation on EVERY await a task makes inside it while the
+    scope is cancelled. The same call under a bare ``asyncio.Task.cancel()``,
+    with no middleware, completes first time. So the shield is necessary and
+    not sufficient: it keeps the write itself alive across those re-arms, and
+    the loop is what waits for it.
+
+    The loop is a bounded drain, not a spin. Each pass awaits, so each pass
+    hands the event loop a turn and the shielded write is what makes progress;
+    it ends the moment that write finishes, and a wall-clock deadline ends it
+    anyway. One local INSERT and COMMIT is milliseconds against a one-second
+    ceiling, and this runs at most once per request in flight when a worker
+    shuts down.
+
+    Why not a ``finally`` covering all three outcomes: success and a classified
+    refusal have to raise or return through their own paths, and the
+    single-exit refusal helper #1758 built (:func:`_signin_refusal`) would have
+    to be unpicked to route them through one block, for no gain.
+
+    Still best effort, and it says so by swallowing. The loop may be closing
+    under the write, and there is nothing useful to do about that from inside
+    a cancelled request; re-raising would only replace a cancellation with a
+    database error in the logs. Durability lives in the reservation.
+    """
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + _SETTLE_DRAIN_SECONDS
+    settle = asyncio.ensure_future(
+        _signin_audit(db, user_id, target, AUDIT_CANCELLED, note, reserved=True)
+    )
+    while not settle.done():
+        if loop.time() >= deadline:
+            settle.cancel()
+            break
+        # Every outcome is handled by the loop condition instead: a completed
+        # write ends it, a failed one ends it with `settle.done()` true and is
+        # reported below, and a re-armed cancellation is the thing this exists
+        # to absorb.
+        with contextlib.suppress(BaseException):  # broad: the loop decides
+            await asyncio.shield(settle)
+    if settle.cancelled() or settle.exception() is not None:
+        # No credential, no token and no username in this line: the scope is
+        # the destination host that every other row here already carries, and
+        # the exception TYPE, which is the same thing `PortalSignIn.mint` logs
+        # on a transport failure and for the same reason — the instance can
+        # hold a request whose encoded body is the password.
+        logger.warning(
+            "ArcGIS sign-in cancelled before its outcome could be recorded",
+            token_service_host=target.host,
+            error_type=(
+                "CancelledError"
+                if settle.cancelled()
+                else type(settle.exception()).__name__
+            ),
+        )
 
 
 @contextlib.asynccontextmanager
@@ -201,13 +412,16 @@ async def _signin_locks(
     the second was checked out FIRST: thirteen concurrent sign-ins for
     distinct scopes could each hold a lock connection and then queue for a
     request connection that the other twelve were holding, stalling unrelated
-    traffic until the pool timeout. The request transaction is exactly the
-    right lifetime anyway. It is open from the first lock through the budget
-    reads and the mint to the audit write, and ``_signin_audit``'s commit is
-    both what persists the row and what releases the locks, in that order, so
-    no other caller can read the counter between this one's read and its
-    write. An unwind without a commit releases them when the request session
-    is closed and rolled back.
+    traffic until the pool timeout.
+
+    fix(#1775): the transaction they ride is now the RESERVATION's, which is
+    open from the first lock through the budget reads to the ledger insert,
+    and no further. The commit that ends it is both what persists the row and
+    what releases the locks, in that order, so no other caller can read either
+    counter between this one's read and its write — the property #1758 needed,
+    now bought without holding a connection across a 45-second network budget.
+    An unwind without a commit releases them when the request session is
+    closed and rolled back.
 
     Both are TRY-locks: a busy scope answers immediately rather than queuing,
     so a caller never waits on another caller's portal round trip.
@@ -259,25 +473,32 @@ def _signin_rate_limited() -> ArcGISSignInError:
 async def _signin_refusal(
     db: AsyncSession,
     user_id: uuid.UUID,
-    host: str,
-    account_key: str,
+    target: SignInTarget,
     exc: ArcGISSignInError,
     note: str | None = None,
+    *,
+    reserved: bool = False,
 ) -> NoReturn:
     """Log, audit and raise one classified refusal.
 
     fix(#1758 codex r5): one exit for every refusal, because there are now six
     of them across two nested locks and hand-writing the log line, the audit
     row and the HTTPException at each was how they would drift apart.
+
+    fix(#1775): ``reserved`` is passed straight through to
+    :func:`_signin_audit`, so a refusal that follows the reservation records
+    its outcome without counting the attempt a second time.
     """
     logger.warning(
         "ArcGIS sign-in refused",
-        token_service_host=host,
+        token_service_host=target.host,
         code=exc.code,
         result=exc.audit_result,
     )
     try:
-        await _signin_audit(db, user_id, host, exc.audit_result, account_key, note)
+        await _signin_audit(
+            db, user_id, target, exc.audit_result, note, reserved=reserved
+        )
     except Exception:  # broad: any failed transaction, whatever poisoned it
         # fix(#1758 codex r11): a refusal has to be recorded even when the
         # session it arrives on is already broken. A cancellation landing in a
@@ -287,7 +508,9 @@ async def _signin_refusal(
         # usable session, and it costs nothing here: `_signin_audit` commits,
         # so there is never uncommitted work of ours to discard.
         await db.rollback()
-        await _signin_audit(db, user_id, host, exc.audit_result, account_key, note)
+        await _signin_audit(
+            db, user_id, target, exc.audit_result, note, reserved=reserved
+        )
     # `from None`: the chained cause of a transport failure is an httpx error
     # holding the request whose encoded body is the password, and nothing
     # downstream needs it.

--- a/backend/app/modules/catalog/sources/signin_guard.py
+++ b/backend/app/modules/catalog/sources/signin_guard.py
@@ -57,6 +57,11 @@ logger = structlog.stdlib.get_logger(__name__)
 _ARCGIS_SIGNIN_ATTEMPT_LIMIT = 3
 _ARCGIS_SIGNIN_WINDOW = timedelta(minutes=15)
 
+# fix(#1775 audit): the strong references that keep an in-flight settle write
+# alive. `asyncio` holds tasks weakly, and this one is deliberately left
+# running when the drain gives up on it, so nothing else would.
+_SETTLE_TASKS: set[asyncio.Task] = set()
+
 # fix(#1775): how long _signin_settle_cancelled will keep handing the event
 # loop a turn so its shielded audit write can finish. One local INSERT and
 # COMMIT, so a second is three orders of magnitude of headroom; the ceiling is
@@ -295,9 +300,10 @@ async def _signin_reserve(
     in flight.
 
     The attempt is counted BEFORE the credential POST rather than after it. A
-    ``CancelledError`` during the POST — a worker shutting down, or a client
-    disconnecting, which Starlette's ``BaseHTTPMiddleware`` also turns into a
-    cancellation (fix(#1775 audit)) —
+    ``CancelledError`` during the POST — a worker shutting down, which on the
+    pinned Starlette is the only source that reaches the route, since a client
+    hanging up arrives as an ``http.disconnect`` message a non-streaming route
+    never reads (fix(#1775 audit)) —
     bypasses both ``PortalSignIn.mint``'s ``except Exception`` and the route's
     ``except ArcGISSignInError``, so under write-at-settle the audit row and
     the ledger row were both lost while ArcGIS may well have counted the
@@ -403,20 +409,21 @@ async def _signin_settle_cancelled(
     reaches here from ``except asyncio.CancelledError``, and a plain await
     would simply be cancelled again. Measured rather than assumed: a bare
     ``await asyncio.shield(...)`` here returns ``CancelledError``, not the
-    written row, because every request runs inside the anyio task groups that
-    Starlette's four ``BaseHTTPMiddleware`` layers open, and an anyio cancel
-    scope re-arms cancellation on EVERY await a task makes inside it while the
-    scope is cancelled. The same call under a bare ``asyncio.Task.cancel()``,
-    with no middleware, completes first time. So the shield is necessary and
-    not sufficient: it keeps the write itself alive across those re-arms, and
-    the loop is what waits for it.
+    written row. Every request runs as a child of the anyio task group each
+    ``BaseHTTPMiddleware`` layer starts the downstream app in
+    (``task_group.start_soon(coro)``, middleware/base.py:148), and an anyio
+    cancel scope re-arms cancellation on EVERY await a task makes inside it
+    while the scope is cancelled. The same call under a bare
+    ``asyncio.Task.cancel()``, with no middleware, completes first time. So
+    the shield is necessary and not sufficient: it keeps the write itself
+    alive across those re-arms, and the loop is what waits for it.
 
     The loop is a bounded drain, not a spin. Each pass awaits, so each pass
     hands the event loop a turn and the shielded write is what makes progress;
     it ends the moment that write finishes, and a wall-clock deadline ends it
     anyway. One local INSERT and COMMIT is milliseconds against a one-second
-    ceiling, and this runs at most once per request in flight when a worker
-    shuts down or a client disconnects.
+    ceiling, and this runs at most once per request still in flight when a
+    worker shuts down.
 
     Why not a ``finally`` covering all three outcomes: success and a classified
     refusal have to raise or return through their own paths, and the
@@ -431,6 +438,13 @@ async def _signin_settle_cancelled(
     loop = asyncio.get_running_loop()
     deadline = loop.time() + _SETTLE_DRAIN_SECONDS
     settle = asyncio.ensure_future(_write_cancelled_outcome(user_id, target, note))
+    # fix(#1775 audit): the event loop keeps only a WEAK reference to a task,
+    # so a settle this function stops awaiting at the deadline could be
+    # collected mid-write. Held here until it finishes, whichever way it
+    # finishes, which is also what keeps the abandoned case a task that
+    # completes rather than one that vanishes.
+    _SETTLE_TASKS.add(settle)
+    settle.add_done_callback(_SETTLE_TASKS.discard)
     while not settle.done() and loop.time() < deadline:
         # One shield future per event-loop turn, which is the price of
         # surviving anyio's re-arm and is only paid while a re-arm is

--- a/backend/app/modules/catalog/sources/signin_guard.py
+++ b/backend/app/modules/catalog/sources/signin_guard.py
@@ -168,11 +168,30 @@ async def _sweep_expired_signin_attempts(db: AsyncSession) -> None:
     deletes is already outside the window, so it can never remove one a
     concurrent count would have seen, and the rate limits bound how often
     this runs to a handful of times per account per window.
+
+    fix(#1775 audit): the rows are picked in a fixed order and any a
+    concurrent sweep already holds are SKIPPED. Two sign-ins for different
+    scopes hold different advisory locks, so their sweeps run concurrently and
+    a bare ``DELETE ... WHERE attempted_at < ...`` let them take the same
+    expired rows in whatever order the plan chose — deadlock (40P01) on a
+    statement whose whole job is housekeeping, failing a sign-in that had
+    nothing wrong with it. ``ORDER BY id`` gives every sweeper one order, and
+    ``SKIP LOCKED`` means the loser of a race drops the row rather than
+    queueing for it. Dropping it costs nothing: the row is already expired and
+    the other sweeper is deleting it.
     """
-    await db.execute(
-        delete(ArcGISSignInAttempt).where(
+    expired = (
+        select(ArcGISSignInAttempt.id)
+        .where(
             ArcGISSignInAttempt.attempted_at
             < datetime.now(tz=UTC) - _ARCGIS_SIGNIN_WINDOW
+        )
+        .order_by(ArcGISSignInAttempt.id)
+        .with_for_update(skip_locked=True)
+    )
+    await db.execute(
+        delete(ArcGISSignInAttempt).where(
+            ArcGISSignInAttempt.id.in_(expired.scalar_subquery())
         )
     )
 
@@ -276,7 +295,9 @@ async def _signin_reserve(
     in flight.
 
     The attempt is counted BEFORE the credential POST rather than after it. A
-    ``CancelledError`` during the POST — uvicorn shutting a worker down —
+    ``CancelledError`` during the POST — a worker shutting down, or a client
+    disconnecting, which Starlette's ``BaseHTTPMiddleware`` also turns into a
+    cancellation (fix(#1775 audit)) —
     bypasses both ``PortalSignIn.mint``'s ``except Exception`` and the route's
     ``except ArcGISSignInError``, so under write-at-settle the audit row and
     the ledger row were both lost while ArcGIS may well have counted the
@@ -309,8 +330,59 @@ async def _signin_reserve(
         await db.commit()
 
 
+async def _write_cancelled_outcome(
+    user_id: uuid.UUID,
+    target: SignInTarget,
+    note: str | None = None,
+) -> None:
+    """Write the cancelled attempt's audit row on a session of its OWN.
+
+    fix(#1775 audit): NOT the request's session. The caller below stops
+    waiting at a deadline and the route then re-raises, so FastAPI runs
+    ``get_db``'s teardown and closes the request session — which, if this
+    write were still in flight on it, closes the connection out from under a
+    live statement and turns a lost audit row into an ``InterfaceError`` or a
+    greenlet error on a shutting-down worker. A session this coroutine opens
+    and closes in its own frame cannot be closed by anybody else, so the
+    abandoned case is a task that finishes quietly rather than one that
+    faults.
+
+    Late-bound import, per the rule ``test_layering.py`` enforces (fix(#909)):
+    a module-scope binding snapshots the dev-DB factory before the test
+    fixture rebinds ``app.core.db.async_session``.
+    """
+    from app.core.db import async_session
+
+    async with async_session() as session:
+        await _signin_audit(
+            session, user_id, target, AUDIT_CANCELLED, note, reserved=True
+        )
+
+
+def _settle_failure(settle: asyncio.Future) -> str | None:
+    """What stopped the settle write, by name, or ``None`` when it landed.
+
+    fix(#1775 audit): PENDING is its own answer and it is checked FIRST. A
+    task that has only just been asked to cancel is neither done nor
+    cancelled, and ``Future.exception()`` on a pending task raises
+    ``InvalidStateError`` — which would have escaped the finaliser on the one
+    path the drain deadline exists for, so the route's ``raise`` would have
+    propagated an ``InvalidStateError`` instead of the ``CancelledError`` it
+    was re-raising, and the warning would never have been logged. Verified
+    with a plain asyncio repro: after ``cancel()``, ``done()`` is False,
+    ``cancelled()`` is False, and ``exception()`` raises.
+
+    A cancellation this module asked for reads as ``CancelledError`` whether
+    the task has finished unwinding yet or not, because that is what stopped
+    the write either way.
+    """
+    if not settle.done() or settle.cancelled():
+        return "CancelledError"
+    exc = settle.exception()
+    return None if exc is None else type(exc).__name__
+
+
 async def _signin_settle_cancelled(
-    db: AsyncSession,
     user_id: uuid.UUID,
     target: SignInTarget,
     note: str | None = None,
@@ -344,34 +416,39 @@ async def _signin_settle_cancelled(
     it ends the moment that write finishes, and a wall-clock deadline ends it
     anyway. One local INSERT and COMMIT is milliseconds against a one-second
     ceiling, and this runs at most once per request in flight when a worker
-    shuts down.
+    shuts down or a client disconnects.
 
     Why not a ``finally`` covering all three outcomes: success and a classified
     refusal have to raise or return through their own paths, and the
     single-exit refusal helper #1758 built (:func:`_signin_refusal`) would have
     to be unpicked to route them through one block, for no gain.
 
-    Still best effort, and it says so by swallowing. The loop may be closing
-    under the write, and there is nothing useful to do about that from inside
-    a cancelled request; re-raising would only replace a cancellation with a
-    database error in the logs. Durability lives in the reservation.
+    Still best effort, and it says so by swallowing. The database may be
+    unreachable under a shutting-down worker, and there is nothing useful to do
+    about that from inside a cancelled request; re-raising would only replace a
+    cancellation with a database error. Durability lives in the reservation.
     """
     loop = asyncio.get_running_loop()
     deadline = loop.time() + _SETTLE_DRAIN_SECONDS
-    settle = asyncio.ensure_future(
-        _signin_audit(db, user_id, target, AUDIT_CANCELLED, note, reserved=True)
-    )
-    while not settle.done():
-        if loop.time() >= deadline:
-            settle.cancel()
-            break
-        # Every outcome is handled by the loop condition instead: a completed
-        # write ends it, a failed one ends it with `settle.done()` true and is
-        # reported below, and a re-armed cancellation is the thing this exists
-        # to absorb.
+    settle = asyncio.ensure_future(_write_cancelled_outcome(user_id, target, note))
+    while not settle.done() and loop.time() < deadline:
+        # One shield future per event-loop turn, which is the price of
+        # surviving anyio's re-arm and is only paid while a re-arm is
+        # happening: with no cancel scope re-arming this awaits ONCE and
+        # blocks there until the write finishes. Every outcome is handled by
+        # the loop condition rather than here — a completed write ends it, a
+        # failed one ends it with `settle.done()` true and is reported below,
+        # and a re-armed cancellation is the thing this exists to absorb.
         with contextlib.suppress(BaseException):  # broad: the loop decides
             await asyncio.shield(settle)
-    if settle.cancelled() or settle.exception() is not None:
+    if not settle.done():
+        # fix(#1775 audit): the task keeps a session of its own, so leaving it
+        # to unwind after this returns cannot fault against a session somebody
+        # else closed. Cancelling is still right: a write that lands after the
+        # request is gone is a row nobody is waiting for.
+        settle.cancel()
+    failure = _settle_failure(settle)
+    if failure is not None:
         # No credential, no token and no username in this line: the scope is
         # the destination host that every other row here already carries, and
         # the exception TYPE, which is the same thing `PortalSignIn.mint` logs
@@ -380,11 +457,7 @@ async def _signin_settle_cancelled(
         logger.warning(
             "ArcGIS sign-in cancelled before its outcome could be recorded",
             token_service_host=target.host,
-            error_type=(
-                "CancelledError"
-                if settle.cancelled()
-                else type(settle.exception()).__name__
-            ),
+            error_type=failure,
         )
 
 

--- a/backend/tests/test_arcgis_signin.py
+++ b/backend/tests/test_arcgis_signin.py
@@ -51,6 +51,7 @@ from app.modules.catalog.sources.arcgis_signin import (
     signin_account_key,
     signin_referer,
 )
+from app.modules.catalog.sources.signin_guard import _settle_failure
 from app.platform.ratelimit import limiter
 from app.platform.security import (
     SSRFError,
@@ -2309,6 +2310,124 @@ async def test_a_signin_cancelled_mid_mint_is_already_counted(
     )
     # Three counted attempts and no more: the refusal spends nothing.
     assert ledger == 3
+
+
+async def test_a_settle_that_outruns_the_drain_still_leaves_cancellederror(
+    client: AsyncClient,
+    admin_auth_header: dict,
+    allow_ssrf,
+    test_db_session,
+    monkeypatch,
+    caplog,
+):
+    """fix(#1775 audit): the drain deadline path, which nothing else reaches.
+
+    The test above covers the fast path, where the shielded write finishes and
+    the loop ends on its own. This one covers the other exit: the write is
+    still going when `_SETTLE_DRAIN_SECONDS` runs out, so the finaliser
+    cancels it and gives up.
+
+    Two things must hold on that path, and the first is why this test exists.
+    `Task.cancel()` only REQUESTS cancellation: the task is still pending on
+    the very next line, so `done()` is False, `cancelled()` is False, and
+    `Future.exception()` raises `InvalidStateError`. Reading the outcome
+    without checking pending FIRST therefore threw out of the finaliser, and
+    since the route awaits it inside `except asyncio.CancelledError:` before
+    a bare `raise`, the handler propagated `InvalidStateError` instead of the
+    cancellation it was re-raising — on the one path the ceiling exists for.
+    So: the caller still sees a cancellation, and the warning that says the
+    row was lost is actually logged.
+
+    The ledger is the third assertion and the one that matters operationally.
+    It is committed before the credential POST, so it does not care that the
+    audit write was abandoned: the attempt is counted either way.
+    """
+    monkeypatch.setattr(signin_guard, "_SETTLE_DRAIN_SECONDS", 0.05)
+
+    entered_mint = asyncio.Event()
+    never = asyncio.Event()
+
+    async def _hanging_mint(_self, _username, _password):
+        entered_mint.set()
+        await never.wait()
+        raise AssertionError("unreachable: the wait above is never released")
+
+    async def _hanging_audit(*_args, **_kwargs):
+        # Far longer than the ceiling, and on the settle's OWN session, so
+        # abandoning it cannot fault against the request session.
+        await asyncio.sleep(30)
+
+    monkeypatch.setattr(signin_guard, "_signin_audit", _hanging_audit)
+
+    exchange = _Exchange(
+        {
+            "info": _json_response(_info_payload()),
+            "generateToken": _json_response(_token_payload()),
+        }
+    )
+    with _install(exchange):
+        with patch.object(arcgis_signin.PortalSignIn, "mint", _hanging_mint):
+            with caplog.at_level(logging.WARNING):
+                call = asyncio.create_task(
+                    client.post(SIGNIN_URL, json=_body(), headers=admin_auth_header)
+                )
+                async with asyncio.timeout(30):
+                    await entered_mint.wait()
+                call.cancel()
+                # The assertion the P1 was hiding: a cancellation leaves the
+                # handler, not an InvalidStateError from reading a pending
+                # task's exception.
+                with pytest.raises(asyncio.CancelledError):
+                    await call
+
+    assert any(
+        "cancelled before its outcome could be recorded" in record.getMessage()
+        for record in caplog.records
+    ), [record.getMessage() for record in caplog.records]
+
+    # The count survives the abandoned write, because it was never in it.
+    ledger = await test_db_session.scalar(
+        select(func.count())
+        .select_from(ArcGISSignInAttempt)
+        .where(
+            ArcGISSignInAttempt.account_key
+            == signin_account_key(_scope(), FIXTURE_USERNAME)
+        )
+    )
+    assert ledger == 1
+    # And no audit row, which is the honest outcome of a write that was cut
+    # off rather than a silently invented one.
+    assert await _audit_rows(test_db_session) == []
+
+
+def test_the_settle_outcome_reader_treats_pending_as_cancelled():
+    """fix(#1775 audit): the unit-level pin, with no event loop in the way.
+
+    `_settle_failure` is the whole of the P1 fix, and the state it has to get
+    right is one that lasts a single event-loop turn, so pinning it directly
+    is what keeps a later simplification from reintroducing the crash.
+    """
+    loop = asyncio.new_event_loop()
+    try:
+        pending = loop.create_future()
+        # A future asked to cancel is neither done nor cancelled yet, and
+        # asking it for an exception raises. `_settle_failure` must not.
+        assert _settle_failure(pending) == "CancelledError"
+
+        cancelled = loop.create_future()
+        cancelled.cancel()
+        assert cancelled.cancelled()
+        assert _settle_failure(cancelled) == "CancelledError"
+
+        failed = loop.create_future()
+        failed.set_exception(RuntimeError("boom"))
+        assert _settle_failure(failed) == "RuntimeError"
+
+        landed = loop.create_future()
+        landed.set_result(None)
+        assert _settle_failure(landed) is None
+    finally:
+        loop.close()
 
 
 async def test_both_advisory_locks_are_released_when_the_body_raises(

--- a/backend/tests/test_arcgis_signin.py
+++ b/backend/tests/test_arcgis_signin.py
@@ -25,6 +25,7 @@ import json
 import logging
 import uuid
 from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
 from unittest.mock import AsyncMock, patch
 from urllib.parse import parse_qs, urlsplit
 
@@ -1547,67 +1548,6 @@ def test_an_unresolved_separator_is_refused_rather_than_guessed_at(raw):
     assert arcgis_signin.usable_service_url(raw) is None
 
 
-async def test_the_worker_wide_bound_refuses_rather_than_queues(
-    client: AsyncClient, admin_auth_header: dict, allow_ssrf, test_db_session
-):
-    """fix(#1758 codex r17): sign-ins cannot take the whole database pool.
-
-    Production runs 10 pooled connections plus 3 overflow, and a sign-in holds
-    its request connection across discovery and the mint, so thirteen
-    concurrent ones for distinct scopes could occupy the pool and time out
-    unrelated API requests. The bound is four, below the pool, and a caller
-    that arrives when it is full is refused rather than queued: waiting would
-    hold the very connection the bound protects.
-
-    Exhausting the semaphore directly is the only way to observe this from a
-    single-request test, and it is the real object the handler checks.
-    """
-    await _clear_unknown_host_rows(test_db_session)
-    exchange = _Exchange(
-        {
-            "info": _json_response(_info_payload()),
-            "generateToken": _json_response(_token_payload()),
-        }
-    )
-    held = [
-        await sources_router._signin_slots.acquire()
-        for _ in range(sources_router._ARCGIS_SIGNIN_CONCURRENCY)
-    ]
-    assert held is not None  # the acquires above, kept for the release below
-    try:
-        with _install(exchange):
-            # A deadline, because the regression this guards against is a
-            # HANG, not a wrong answer: without the check the handler waits on
-            # `async with _signin_slots` for a slot nobody will free, holding
-            # the connection the bound exists to protect. Failing in five
-            # seconds beats burning the job's whole timeout.
-            async with asyncio.timeout(5):
-                resp = await client.post(
-                    SIGNIN_URL, json=_body(), headers=admin_auth_header
-                )
-    except TimeoutError:  # pragma: no cover - only on regression
-        pytest.fail(
-            "the sign-in queued on a full semaphore instead of refusing, "
-            "which holds a pooled connection while it waits"
-        )
-    finally:
-        for _ in range(sources_router._ARCGIS_SIGNIN_CONCURRENCY):
-            sources_router._signin_slots.release()
-
-    assert resp.status_code == 429
-    assert resp.json()["detail"]["code"] == "rate_limited"
-    # Refused before any network I/O, and nothing charged to a real account.
-    assert exchange.requests == []
-    assert await _audit_rows(test_db_session) == []
-    rows = await _audit_rows(test_db_session, host="unknown")
-    assert [row.details["result"] for row in rows] == ["rate_limited"]
-
-
-def test_the_concurrency_bound_sits_below_the_database_pool():
-    """The number is the point: above the pool it would protect nothing."""
-    assert sources_router._ARCGIS_SIGNIN_CONCURRENCY < 10 + 3
-
-
 async def test_a_refusal_is_never_retried(
     client: AsyncClient, admin_auth_header: dict, allow_ssrf
 ):
@@ -2078,11 +2018,11 @@ async def test_the_advisory_lock_is_held_by_one_caller_at_a_time(
     )
 
     async def _try(session, user, account) -> bool:
-        async with sources_router._signin_locks(session, user, account) as held:
+        async with signin_guard._signin_locks(session, user, account) as held:
             return held
 
     async with async_session() as holder:
-        async with sources_router._signin_locks(
+        async with signin_guard._signin_locks(
             holder, user_scope, account_scope
         ) as first:
             assert first
@@ -2183,6 +2123,194 @@ async def test_a_signin_holds_exactly_one_pooled_connection(
     )
 
 
+async def test_concurrent_signins_hold_no_pooled_connection_across_the_mint(
+    client: AsyncClient, admin_auth_header: dict, allow_ssrf
+):
+    """fix(#1775): the acceptance criterion. No connection is held across the mint.
+
+    The test above pins ONE sign-in at a peak of one connection. This one pins
+    the other half: how many of those connections are held AT ONCE, while the
+    credential POSTs are in flight. Before reserve-then-settle the request
+    transaction was open from `require_permission` through discovery, both
+    advisory locks and the mint, for up to the 45-second network budget, so
+    N concurrent sign-ins for distinct scopes held N connections for the whole
+    of it and 13 of them could take a 10+3 production pool and time out
+    unrelated API requests. That is what the removed `asyncio.Semaphore(4)`
+    bounded rather than fixed.
+
+    Five sign-ins, each against its own portal so each resolves its own token
+    service and no two contend on a lock or a budget. Every mint blocks on one
+    event; when all five are inside it the pool is sampled. Sampled at the
+    POOL, not at the session factory, because the pool is what production runs
+    out of, and by checkout-minus-checkin so a connection released and
+    re-acquired in sequence — which reserve-then-settle does exactly once, on
+    purpose — reads as one at a time rather than as two (see #1786).
+    """
+    from sqlalchemy import event
+
+    import app.core.db as db_module
+
+    signins = 5
+    live = 0
+    peak = 0
+    in_mint = 0
+    all_minting = asyncio.Event()
+    finish_mints = asyncio.Event()
+
+    def _acquired(*_args) -> None:
+        nonlocal live, peak
+        live += 1
+        peak = max(peak, live)
+
+    def _released(*_args) -> None:
+        nonlocal live
+        live = max(0, live - 1)
+
+    async def _blocking_mint(_self, _username, _password):
+        nonlocal in_mint
+        in_mint += 1
+        if in_mint == signins:
+            all_minting.set()
+        await finish_mints.wait()
+        return arcgis_signin.MintedToken(
+            token=FIXTURE_TOKEN,
+            expires_at=datetime.now(tz=UTC) + timedelta(minutes=60),
+        )
+
+    portals = [
+        f"https://c{uuid.uuid4().hex}.signin-fixture.test" for _ in range(signins)
+    ]
+    exchange = _Exchange({"info": _json_response(_info_payload())})
+    sync_engine = db_module.engine.sync_engine
+    event.listen(sync_engine, "checkout", _acquired)
+    event.listen(sync_engine, "checkin", _released)
+    try:
+        with (
+            _install(exchange),
+            patch.object(arcgis_signin.PortalSignIn, "mint", _blocking_mint),
+        ):
+            calls = [
+                asyncio.create_task(
+                    client.post(
+                        SIGNIN_URL,
+                        json={
+                            "portal_url": portal,
+                            "username": FIXTURE_USERNAME,
+                            "password": FIXTURE_SECRET,
+                        },
+                        headers=admin_auth_header,
+                    )
+                )
+                for portal in portals
+            ]
+            try:
+                async with asyncio.timeout(30):
+                    await all_minting.wait()
+                # Every credential POST is on the wire and none has answered.
+                held_while_minting = live
+                finish_mints.set()
+                responses = await asyncio.gather(*calls)
+            finally:
+                finish_mints.set()
+                for call in calls:
+                    call.cancel()
+    finally:
+        event.remove(sync_engine, "checkout", _acquired)
+        event.remove(sync_engine, "checkin", _released)
+
+    assert [resp.status_code for resp in responses] == [200] * signins
+    assert held_while_minting == 0, (
+        f"{held_while_minting} pooled connections were held while {signins} "
+        "credential POSTs were in flight; the reservation must commit and "
+        "give its connection back before the mint"
+    )
+    # The positive control: the counter was wired to a pool that was actually
+    # used, so the zero above is a measurement rather than a dead listener.
+    assert peak >= 1
+
+
+async def test_a_signin_cancelled_mid_mint_is_already_counted(
+    client: AsyncClient, admin_auth_header: dict, allow_ssrf, test_db_session
+):
+    """fix(#1775): the second defect. A cancelled POST must not be a free attempt.
+
+    `CancelledError` is not an `Exception`, so it passes straight through
+    `PortalSignIn.mint`'s handler and the route's `except ArcGISSignInError`.
+    Under write-at-settle that lost both the audit row and the ledger row for
+    a password that had already gone to ArcGIS, and Esri counts what GeoLens
+    then did not: cancellation plus retry could walk an account past the five
+    failures that lock it. The attempt is now committed BEFORE the POST, so
+    the count survives the cancellation whatever else does.
+
+    Cancelled from outside, which is what uvicorn does to an in-flight handler
+    on shutdown, rather than by a deadline — the deadlines were already fixed
+    in #1758 round 11 and are not what this covers.
+    """
+    entered_mint = asyncio.Event()
+    never = asyncio.Event()
+
+    async def _hanging_mint(_self, _username, _password):
+        entered_mint.set()
+        await never.wait()
+        raise AssertionError("unreachable: the wait above is never released")
+
+    exchange = _Exchange(
+        {
+            "info": _json_response(_info_payload()),
+            "generateToken": _json_response(_token_payload()),
+        }
+    )
+    with _install(exchange):
+        with patch.object(arcgis_signin.PortalSignIn, "mint", _hanging_mint):
+            call = asyncio.create_task(
+                client.post(SIGNIN_URL, json=_body(), headers=admin_auth_header)
+            )
+            async with asyncio.timeout(30):
+                await entered_mint.wait()
+            call.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await call
+
+        account_key = signin_account_key(_scope(), FIXTURE_USERNAME)
+        ledger = await test_db_session.scalar(
+            select(func.count())
+            .select_from(ArcGISSignInAttempt)
+            .where(ArcGISSignInAttempt.account_key == account_key)
+        )
+        # The reservation, committed before the password went out.
+        assert ledger == 1
+        # And the operator-facing half, written by the shielded finaliser. Its
+        # own outcome, because GeoLens does not know whether ArcGIS counted
+        # the POST and must not claim either way.
+        rows = await _audit_rows(test_db_session)
+        assert [row.details["result"] for row in rows] == ["cancelled"]
+        assert rows[0].details["account_key"] == account_key
+
+        # The budget moved: two attempts left, and the fourth is refused. This
+        # is the half that a lost ledger row silently took away.
+        for _ in range(2):
+            assert (
+                await client.post(SIGNIN_URL, json=_body(), headers=admin_auth_header)
+            ).status_code == 200
+        refused = await client.post(SIGNIN_URL, json=_body(), headers=admin_auth_header)
+
+    assert refused.status_code == 429
+    assert refused.json()["detail"]["code"] == "rate_limited"
+    assert [row.details["result"] for row in await _audit_rows(test_db_session)] == [
+        "cancelled",
+        "success",
+        "success",
+        "rate_limited",
+    ]
+    ledger = await test_db_session.scalar(
+        select(func.count())
+        .select_from(ArcGISSignInAttempt)
+        .where(ArcGISSignInAttempt.account_key == account_key)
+    )
+    # Three counted attempts and no more: the refusal spends nothing.
+    assert ledger == 3
+
+
 async def test_both_advisory_locks_are_released_when_the_body_raises(
     client: AsyncClient,
 ):
@@ -2199,12 +2327,12 @@ async def test_both_advisory_locks_are_released_when_the_body_raises(
     account_scope = f"account:{signin_account_key(_scope(), FIXTURE_USERNAME)}"
 
     async def _try(session, user, account) -> bool:
-        async with sources_router._signin_locks(session, user, account) as held:
+        async with signin_guard._signin_locks(session, user, account) as held:
             return held
 
     async with async_session() as holder:
         with pytest.raises(RuntimeError):
-            async with sources_router._signin_locks(
+            async with signin_guard._signin_locks(
                 holder, user_scope, account_scope
             ) as held:
                 assert held
@@ -2238,7 +2366,7 @@ async def test_the_account_lock_scope_is_the_account_and_not_the_geolens_caller(
         yield False
 
     exchange = _Exchange({})
-    with patch("app.modules.catalog.sources.router._signin_locks", _record):
+    with patch("app.modules.catalog.sources.signin_guard._signin_locks", _record):
         with _install(exchange):
             for headers in (admin_auth_header, editor_auth_header):
                 resp = await client.post(SIGNIN_URL, json=_body(), headers=headers)
@@ -2414,7 +2542,7 @@ async def test_a_discovery_failure_takes_no_lock_and_writes_no_ledger_row(
     await _clear_unknown_host_rows(test_db_session)
 
     locks_taken = 0
-    real_locks = sources_router._signin_locks
+    real_locks = signin_guard._signin_locks
 
     @contextlib.asynccontextmanager
     async def _counting_locks(db, user_scope, account_scope):
@@ -2431,7 +2559,7 @@ async def test_a_discovery_failure_takes_no_lock_and_writes_no_ledger_row(
     # conventional `/generateToken` is the documented fallback, so the sign-in
     # goes on to try it and any failure there is the mint's.
     exchange = _Exchange({})
-    with patch.object(sources_router, "_signin_locks", _counting_locks):
+    with patch.object(signin_guard, "_signin_locks", _counting_locks):
         with patch(
             "app.modules.catalog.sources.arcgis_signin.validate_url_for_ssrf",
             new_callable=AsyncMock,
@@ -2613,7 +2741,7 @@ async def test_a_signin_while_one_is_in_flight_is_refused_before_the_portal(
     async def _lock_taken(_db, _user_scope, _account_scope):
         yield False
 
-    with patch("app.modules.catalog.sources.router._signin_locks", _lock_taken):
+    with patch("app.modules.catalog.sources.signin_guard._signin_locks", _lock_taken):
         with _install(exchange):
             resp = await client.post(
                 SIGNIN_URL, json=_body(), headers=admin_auth_header
@@ -2698,7 +2826,7 @@ async def test_one_caller_serializes_across_accounts_on_one_portal(
 
         async with (
             async_session() as holder,
-            sources_router._signin_locks(
+            signin_guard._signin_locks(
                 holder,
                 f"user:{caller_id}:host:{_scope()}",
                 f"account:{signin_account_key(_scope(), 'someone-else')}",

--- a/backend/tests/test_arcgis_signin_tenancy.py
+++ b/backend/tests/test_arcgis_signin_tenancy.py
@@ -31,7 +31,9 @@ from app.modules.catalog.sources.arcgis_signin import signin_account_key
 from app.modules.catalog.sources.models import ArcGISSignInAttempt
 from app.modules.catalog.sources.signin_guard import (
     _ARCGIS_SIGNIN_ATTEMPT_LIMIT,
+    SignInTarget,
     _signin_budgets_spent,
+    signin_target,
 )
 
 pytestmark = pytest.mark.anyio
@@ -53,6 +55,10 @@ def test_the_ledger_is_deliberately_outside_the_rls_boundary():
     assert set(ArcGISSignInAttempt.__table__.c.keys()) == {
         "id",
         "account_key",
+        # fix(#1775): the per-caller budget's key, and a keyed digest of the
+        # caller and the token-service scope rather than a user id, so the
+        # no-plaintext-identifier rule this test states still holds.
+        "user_scope",
         "attempted_at",
     }
 
@@ -137,10 +143,22 @@ async def test_two_tenants_share_one_budget_for_one_arcgis_account(multi_tenant_
                 await conn.execute(
                     sa.text(
                         f"INSERT INTO catalog.{_LEDGER} "
-                        "(id, account_key, attempted_at) "
-                        "VALUES (:id, :account_key, now())"
+                        "(id, account_key, user_scope, attempted_at) "
+                        "VALUES (:id, :account_key, :user_scope, now())"
                     ),
-                    {"id": uuid.uuid4(), "account_key": account_key},
+                    {
+                        "id": uuid.uuid4(),
+                        "account_key": account_key,
+                        # fix(#1775): tenant A's caller, which tenant B is
+                        # not. The per-caller budget reads this table too now,
+                        # so charging these rows to B's digest would let the
+                        # WRONG budget answer the question below and the test
+                        # would prove nothing about the account budget
+                        # crossing tenants.
+                        "user_scope": signin_target(
+                            ctx.user_a_id, host, "someone"
+                        ).user_scope,
+                    },
                 )
 
         # Tenant B, under the tenant GUC and the non-privileged role, so RLS
@@ -156,8 +174,15 @@ async def test_two_tenants_share_one_budget_for_one_arcgis_account(multi_tenant_
             # could just mean RLS was never enforced.
             assert visible_audit_rows == 0
 
+            # Tenant B's own caller digest, against the account tenant A
+            # spent: the only budget that can refuse here is the account's.
             spent = await _signin_budgets_spent(
-                session, ctx.user_b_id, host, account_key
+                session,
+                SignInTarget(
+                    host=host,
+                    account_key=account_key,
+                    user_scope=signin_target(ctx.user_b_id, host, "someone").user_scope,
+                ),
             )
 
         assert spent is True

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -2557,7 +2557,13 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # than refuse, since the hook fires on every 3xx whether or not it is
     # followed. r17 decodes to a fixed point instead of for four passes, and
     # refuses a stable form still carrying an encoded separator.
-    "backend/app/modules/catalog/sources/arcgis_signin.py": 1253,
+    # fix(#1775): +40. `signin_user_key`, the keyed digest that carries the
+    # per-caller budget now that it is counted from the ledger rather than
+    # from audit_logs (reserve-then-settle commits the attempt before the
+    # credential POST and writes the audit row after it, so a cancelled
+    # request leaves no audit row to count), and AUDIT_CANCELLED, the outcome
+    # of an attempt whose POST was interrupted. Cap 1253 -> 1293, exact.
+    "backend/app/modules/catalog/sources/arcgis_signin.py": 1293,
     # fix(#998): the DDL ported from migration 0019 so tenant-ownership adoption
     # is reachable forward-only at head. Almost all of it is SQL text, and it is
     # one artifact on purpose — the module is reviewed line-by-line against

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -2563,7 +2563,11 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # credential POST and writes the audit row after it, so a cancelled
     # request leaves no audit row to count), and AUDIT_CANCELLED, the outcome
     # of an attempt whose POST was interrupted. Cap 1253 -> 1293, exact.
-    "backend/app/modules/catalog/sources/arcgis_signin.py": 1293,
+    # fix(#1775 audit): +4. AUDIT_CANCELLED's comment claimed only a worker
+    # shutdown reaches it; BaseHTTPMiddleware cancels on client disconnect
+    # too, so the comment now says which, and why the reservation rather than
+    # that row is what counts the attempt. Cap 1293 -> 1297, exact.
+    "backend/app/modules/catalog/sources/arcgis_signin.py": 1297,
     # fix(#998): the DDL ported from migration 0019 so tenant-ownership adoption
     # is reachable forward-only at head. Almost all of it is SQL text, and it is
     # one artifact on purpose — the module is reviewed line-by-line against

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -2563,11 +2563,16 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # credential POST and writes the audit row after it, so a cancelled
     # request leaves no audit row to count), and AUDIT_CANCELLED, the outcome
     # of an attempt whose POST was interrupted. Cap 1253 -> 1293, exact.
-    # fix(#1775 audit): +4. AUDIT_CANCELLED's comment claimed only a worker
-    # shutdown reaches it; BaseHTTPMiddleware cancels on client disconnect
-    # too, so the comment now says which, and why the reservation rather than
-    # that row is what counts the attempt. Cap 1293 -> 1297, exact.
-    "backend/app/modules/catalog/sources/arcgis_signin.py": 1297,
+    # fix(#1775 audit): +8. AUDIT_CANCELLED's comment now says which external
+    # cancellation actually reaches the route and which does not — a worker
+    # shutdown does, a client disconnect does not, because it arrives as an
+    # `http.disconnect` message a non-streaming route never reads and the one
+    # `cancel()` in BaseHTTPMiddleware ends a sibling wait rather than the
+    # downstream coroutine — and why the reservation makes the path safe
+    # whichever it is. An earlier revision of this comment asserted the
+    # opposite, which is why it now cites the line it was checked against.
+    # Cap 1293 -> 1301, exact.
+    "backend/app/modules/catalog/sources/arcgis_signin.py": 1301,
     # fix(#998): the DDL ported from migration 0019 so tenant-ownership adoption
     # is reachable forward-only at head. Almost all of it is SQL text, and it is
     # one artifact on purpose — the module is reviewed line-by-line against


### PR DESCRIPTION
## What

`POST /datasets/{id}/reupload/{job_id}/commit` now accepts an optional
`expected_origin_kind` — the dataset origin the client saw when it staged the
replacement. The door compares it against the dataset's current origin and
refuses a mismatch with `409 {"code": "origin_changed", ...}`, the same
vocabulary the refresh door in `router_refresh.py` already uses for a source
that moved.

## Why — the race

`geolens replace` (#1767) and the web re-upload dialog both refuse to replace
a dataset bound to a service, a STAC item, or a registered table. That refusal
is a **client-side precheck**, decided from a single read taken before the
upload. Between that read and the commit the user confirms sits an upload, a
preview, and a human. A service or STAC re-upload committing in that window is
invisible to the client, and the swap the file commit queues rebinds the
dataset to `upload` unconditionally (`_apply_reupload_swap`,
`tasks_reupload.py` ~426-440) — silently severing the remote binding that was
just established.

ADR-002 invariant 7 (one mutation at a time) bounds that window but does not
close it: the competing run has already *finished* by the time the file commit
lands.

## Where the check sits, and why

After `create_pending_run`, not before. That insert is the one-active-run
admission gate, so with the slot held no other run for this dataset can be in
flight — any origin change is already committed, and a READ COMMITTED re-read
sees it. Placed earlier, the re-read would be one more racing read. On a
mismatch the whole request rolls back, so the reservation is released rather
than leaked (a leaked run row would refuse every refresh of the dataset until
the stale-run sweep's cutoff).

It lives in `_refuse_if_origin_changed` rather than inline because two more
branches pushed `reupload_commit` past the McCabe gate — the same reason
`_dispatch_reupload_task` exists.

## Contract change — additive, old clients unaffected

`expected_origin_kind` is **optional**. A client that sends nothing gets
exactly the pre-#1768 behaviour: no comparison, no refusal. An older CLI, SDK,
or frontend build keeps working unchanged, and `test_an_omitted_expected_origin_keeps_the_old_contract`
pins that. The value is typed with the shared `OriginKind` literal from
`platform/dataset_origin.py`, so the closed set is published in OpenAPI and an
unknown kind is a 422 at the schema boundary rather than a silent no-op.

Only `expected_origin_kind` is carried, not an origin-ref hash. The issue
listed the hash as optional; the kind is what every client-side gate actually
decides from, and a hash would add a second comparison surface with no
refusal the kind does not already cover.

## Clients

- **CLI** (`geolens replace`): captures the origin at the same Stage 0 read
  its own gate is decided from and sends it with the commit. An origin the CLI
  cannot classify (redacted → SDK `UNSET`, or a kind a newer server added)
  asserts nothing rather than being forwarded, so a stale CLI degrades to the
  old behaviour instead of 422-ing. `origin_changed` gets an actionable
  refusal message.
- **Web dialog**: captures `dataset.origin` beside the job id at staging time.
  `dataset` is a live query result, so reading it at confirm time would send
  the very change the condition exists to catch — there is a test for exactly
  that.
- **i18n**: `errors.reuploadOriginChanged` added to en/es/fr/de. It is a
  separate key from `errors.refreshOriginChanged` even though the code is
  shared, because the two refusals describe different windows and ask for
  different actions.

## Regenerated artifacts

`backend/openapi.json`, both SDKs (`make sdks` — one new Python literal
module), and `frontend/src/types/api.generated.ts`. Hand-typed mirrors
(`frontend/src/types/api.ts`) updated to match.

Fixes #1768

## Verification

```bash
# backend (host, Postgres at :5434)
cd backend && set -a && source ../.env.test && set +a
uv run pytest tests/test_reupload_expected_origin_1768.py \
  tests/test_reupload.py tests/test_reupload_service.py \
  tests/test_job_cancel_reupload_commit.py tests/test_reupload_idor.py \
  tests/test_reupload_record_type_guard.py tests/test_sdks_round_trip.py -q
uv run pytest tests/test_layering.py tests/test_rule1_structural.py tests/test_rule2_structural.py -q
uv run ruff check . && uv run ruff format --check .

# contract + SDKs
make openapi-check
make sdks-check

# CLI
cd cli && uv run --extra dev python -m pytest -q

# frontend
cd frontend && npm run lint && npm run typecheck && npm run test:i18n
npx vitest run src/components/dataset src/api src/lib/__tests__/error-map.test.ts
```

Results: backend 100 passed / 1 skipped (the TS-SDK round-trip case, which
needs `sdks/typescript/dist` built) plus 153 passed on the structural gates;
CLI 652 passed; frontend 593 passed across the touched trees; `openapi-check`
and `sdks-check` both clean.

No migration, no config change. `test_layering.py` caps raised with comments
for `router_reupload.py` (1294 → 1355) and `schemas.py` (1499 → 1511).

---

# r1b — audit round

Four findings from the pre-trigger audit, plus the coverage that was missing for them.

## P1 — reading a pending task's exception (`signin_guard.py`)

At the drain deadline the finaliser called `settle.cancel()` and then read `settle.exception()`. `Task.cancel()` only *requests* cancellation, so on the very next line the task is still pending: `done()` is False, `cancelled()` is False, and `Future.exception()` raises `InvalidStateError`. That escaped `_signin_settle_cancelled`, which the route awaits inside `except asyncio.CancelledError:` before a bare `raise` — so on the one path the one-second ceiling exists for, the handler propagated `InvalidStateError` instead of re-raising the cancellation, and the warning saying the row was lost was never logged.

Confirmed with a plain asyncio repro before fixing:

```
done() after cancel(): False
cancelled() after cancel(): False
exception() raises: InvalidStateError
after a turn -> done(): True cancelled(): True
```

The outcome is now read in one place, `_settle_failure`, which answers **pending first**. A cancellation this module asked for reads as `CancelledError` whether or not the task has finished unwinding, because that is what stopped the write either way.

## P2 — the settle write ran on the request's session

On the deadline path the write was still going when `_signin_settle_cancelled` returned, the route re-raised, and FastAPI ran `get_db`'s teardown — closing the session, and its connection, under a live statement. `_write_cancelled_outcome` now opens and closes a session of its own, so an abandoned write is a task that finishes quietly rather than one that faults with an `InterfaceError` or a greenlet error on a shutting-down worker. Late-bound `async_session` import, per the #909 rule `test_layering.py` enforces.

## P3 — sweep deadlock

`_sweep_expired_signin_attempts` now selects `ORDER BY id ... FOR UPDATE SKIP LOCKED` and deletes by id. Two sign-ins for different scopes hold different advisory locks, so their sweeps run concurrently, and a bare `DELETE ... WHERE attempted_at < ...` let them take the same expired rows in whatever order the plan chose — a 40P01 on a housekeeping statement, failing a sign-in that had nothing wrong with it. The loser of a race now drops the row instead of queueing; it is already expired and the winner is deleting it.

## P3 — the AUDIT_CANCELLED comment was wrong

It said external cancellation is "a uvicorn shutdown rather than anything a client can trigger". `BaseHTTPMiddleware` also cancels the downstream task on client disconnect, so a caller who hangs up reaches it too. The comment now says so — and says why that is safe: the reservation, not this row, is what counts the attempt, so a client cannot make a credential POST free by disconnecting. The same correction is applied to `_signin_reserve`'s docstring and the route's inline comment.

## P3 accepted, not changed

The drain allocates one shield future per event-loop turn. That is the price of surviving anyio's re-arm and it is only paid *while* a re-arm is happening: with no cancel scope re-arming, the loop awaits once and blocks there until the write finishes, so it is one allocation. `asyncio.sleep(0)` would replace it with an unconditional spin, including on the paths that have no re-arm. The comment in the loop now states this.

## New coverage

- `test_a_settle_that_outruns_the_drain_still_leaves_cancellederror` — hangs `_signin_audit` past a monkeypatched 50 ms ceiling and asserts the warning is logged, that `CancelledError` is what leaves the handler, and that the ledger row still stands.
- `test_the_settle_outcome_reader_treats_pending_as_cancelled` — pins `_settle_failure` over all four future states, with no event loop in the way.

### Counterfactuals

With the P1 fix reverted (`if settle.cancelled():` instead of `if not settle.done() or settle.cancelled():`), both go red:

```
E       AssertionError: []
E       assert False
E        +  where False = any(<generator object ...>)
E       asyncio.exceptions.InvalidStateError: Exception is not set.
FAILED tests/test_arcgis_signin.py::test_a_settle_that_outruns_the_drain_still_leaves_cancellederror
FAILED tests/test_arcgis_signin.py::test_the_settle_outcome_reader_treats_pending_as_cancelled
```

The pool counterfactual is unchanged and re-run on this round: `_signin_reserve` ending in `flush()` instead of `commit()` still gives `5 pooled connections were held while 5 credential POSTs were in flight`.

### Counts on this round

`test_arcgis_signin.py` + tenancy + layering + rule1 + rule2: **333 passed**. `test_arcgis_signin.py` under `-n 4`: **177 passed**, three consecutive runs. `ruff check` / `ruff format --check` clean.

`_MODULE_LOC_CAPS` for `sources/arcgis_signin.py` goes 1293 → 1297 (exact) for the corrected comment; the entry says what the lines bought.

---

# r1c — audit round

## The disconnect claim from r1b was wrong; three comments retracted

r1b added the assertion that `BaseHTTPMiddleware` cancels the downstream task on client disconnect. That is false for the pinned Starlette 1.6.0, checked against the installed source rather than recalled:

- `BaseHTTPMiddleware` contains exactly one `cancel()` — `task_group.cancel_scope.cancel()` at `middleware/base.py:121` — and it lives inside `receive_or_disconnect`'s **local** task group, ending the sibling `response_sent.wait` race. It does not touch the downstream coroutine.
- A client hanging up arrives as an `http.disconnect` **message** on the receive channel, which a non-streaming route never reads. Uvicorn only sets `cycle.disconnected = True`.

So a worker shutdown is the only external cancellation that reaches the handler. All three comments (`arcgis_signin.py` at `AUDIT_CANCELLED`, the route's `except asyncio.CancelledError` clause, `_signin_reserve`'s docstring) now say that, cite the line they were checked against, and say what makes the path safe whatever the source turns out to be here or in a later Starlette: **the reservation is committed before the credential POST, so no cancellation makes one free.**

The re-arm explanation in `_signin_settle_cancelled` is a separate claim and it stands — it is now precise about its mechanism. The downstream app runs as a child of the anyio task group each middleware layer starts it in (`task_group.start_soon(coro)`, `middleware/base.py:148`), and an anyio cancel scope re-arms cancellation on every await a task makes inside it while cancelled. That is what a bare shielded await loses to on shutdown, and what the drain absorbs.

## The settle task had no strong reference

`asyncio` holds tasks weakly, and this one is deliberately left running when the drain gives up on it at the deadline — so nothing referenced it and the collector could take it mid-write. A module-level `_SETTLE_TASKS` set holds it, and `add_done_callback(_SETTLE_TASKS.discard)` releases it however it finishes.

## Counts on this round

`test_arcgis_signin.py` + `test_layering.py`: **226 passed**. `ruff check` / `ruff format --check` clean.

`_MODULE_LOC_CAPS` for `sources/arcgis_signin.py` re-pinned 1297 → **1301** (exact, measured) for the corrected comment.
