### PR TITLE
fix(reupload): refuse a commit whose expected origin no longer matches

### DIFF
--- a/backend/app/modules/catalog/datasets/api/router_reupload.py
+++ b/backend/app/modules/catalog/datasets/api/router_reupload.py
@@ -60,6 +60,7 @@ from app.platform.refresh.service import (
     create_pending_run,
     make_refresh_run_failed_rollback,
 )
+from app.platform.dataset_origin import classify_origin
 from app.platform.extensions import get_catalog_port
 from app.core.persistent_config import UPLOAD_MAX_SIZE_MB, get_allowed_extensions_list
 from app.modules.quota.service import check_replacement_quota
@@ -593,6 +594,60 @@ def _require_reupload_source(job, is_service_refresh: bool) -> None:
         )
 
 
+async def _refuse_if_origin_changed(
+    db: AsyncSession, dataset, expected_origin_kind: str | None
+) -> None:
+    """Refuse a commit whose expected origin is no longer the dataset's.
+
+    fix(#1768): `geolens replace` and the web re-upload dialog both refuse to
+    replace a dataset bound to a service, a STAC item, or a registered table,
+    and both decide that from a SINGLE read taken before the upload. Between
+    that read and the commit the user confirms sits an upload, a preview and a
+    human — and a service or STAC re-upload committing in that window rebinds
+    the dataset invisibly to them. The swap the commit queues then rebinds it
+    to `upload` unconditionally (`_apply_reupload_swap` in tasks_reupload.py),
+    severing the binding that was just established.
+
+    Called AFTER `create_pending_run`, which is what makes the re-read
+    decisive rather than one more racing read: with the one-active-run slot
+    held, no other run for this dataset can be in flight, so any origin change
+    is already committed and a READ COMMITTED re-read sees it. Same shape as
+    the refresh door's own re-read (`router_refresh.py`) and deliberately the
+    same `origin_changed` code, so a client learns one word for "the source
+    moved under you".
+
+    ``None`` asserts nothing and returns: the field is optional, so a client
+    that sends none — an older CLI or SDK — gets exactly the pre-#1768
+    behaviour. Only ``record_type`` is left unrefreshed, because no path
+    changes a dataset's record type; ``source_format`` is the half that moves.
+    """
+    if expected_origin_kind is None:
+        return
+    await db.refresh(dataset, ["source_format"])
+    current_origin_kind = classify_origin(
+        dataset.source_format, dataset.record.record_type
+    )
+    if current_origin_kind == expected_origin_kind:
+        return
+    # Releases the reservation along with the merged job metadata: a leaked run
+    # row would refuse every refresh of this dataset until the stale-run
+    # sweep's cutoff.
+    await db.rollback()
+    raise HTTPException(
+        status_code=status.HTTP_409_CONFLICT,
+        detail={
+            "code": "origin_changed",
+            "message": (
+                "This dataset's source changed after this replacement was "
+                "staged, so nothing was queued. Re-check the dataset's source "
+                "and start the replacement again."
+            ),
+            "origin_kind": current_origin_kind,
+            "expected_origin_kind": expected_origin_kind,
+        },
+    )
+
+
 async def _dispatch_reupload_task(
     db: AsyncSession,
     *,
@@ -841,6 +896,12 @@ async def reupload_commit(
                 ),
             },
         ) from exc
+
+    # fix(#1768): the origin door, and it has to be HERE — after the run row
+    # took the one-active-run admission slot, not before it. See
+    # `_refuse_if_origin_changed` for why the reservation is what makes the
+    # re-read decisive.
+    await _refuse_if_origin_changed(db, dataset, request.expected_origin_kind)
 
     # feat(#1676): staged before the commit, exactly as the refresh door
     # stages its own, so a configured-but-unreachable store rolls the whole

--- a/backend/app/modules/catalog/datasets/domain/schemas.py
+++ b/backend/app/modules/catalog/datasets/domain/schemas.py
@@ -24,6 +24,7 @@ from app.modules.catalog.sources.schemas import (
     reject_service_auth_conflict,
 )
 from app.platform.analysis_sql import MAX_SPATIAL_JOIN_FIELDS
+from app.platform.dataset_origin import OriginKind
 
 
 # feat(#1222): built from the probe's own closed vocabulary rather than
@@ -782,6 +783,17 @@ class ReuploadPreviewRequest(BaseModel):
 
 class ReuploadCommitRequest(BaseModel):
     srid_override: int | None = Field(default=None, ge=1, le=998999)
+    expected_origin_kind: OriginKind | None = Field(
+        default=None,
+        description=(
+            "The dataset origin the client saw when it staged this "
+            "replacement. When set, the commit is refused with 409 "
+            "`origin_changed` if the dataset's origin no longer matches, so a "
+            "service, STAC or registered-table binding established after the "
+            "upload is not silently rebound to an upload. Optional: a client "
+            "that omits it keeps the pre-#1768 behaviour."
+        ),
+    )
     token: str | None = Field(
         default=None, max_length=1000, description=DEPRECATED_TOKEN_SUFFIX.strip()
     )

--- a/backend/app/platform/dataset_origin.py
+++ b/backend/app/platform/dataset_origin.py
@@ -33,7 +33,7 @@ layer may import.
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Literal
 
 from app.core.record_types import RASTER_FAMILY_RECORD_TYPES
 
@@ -81,6 +81,13 @@ _ORIGINLESS_RECORD_TYPES: frozenset[str] = frozenset({"collection", "vrt_dataset
 ORIGIN_KINDS: frozenset[str] = frozenset(
     {"upload", "postgis", "service", "stac", "created"}
 )
+
+# fix(#1768): the same vocabulary as a request-model annotation, so a door that
+# takes an origin kind as INPUT rejects an unknown one at the schema boundary
+# and publishes the closed set in OpenAPI. Kept beside the frozenset it
+# mirrors; `test_reupload_expected_origin_1768.py` asserts the two agree, so a
+# kind added to one alone fails a test rather than a request.
+OriginKind = Literal["upload", "postgis", "service", "stac", "created"]
 
 # The response-boundary spelling of "never determined". Deliberately absent
 # from chk_datasets_source_health / chk_datasets_schema_drift_status: with

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -14218,6 +14218,25 @@
             ],
             "title": "Srid Override"
           },
+          "expected_origin_kind": {
+            "anyOf": [
+              {
+                "enum": [
+                  "upload",
+                  "postgis",
+                  "service",
+                  "stac",
+                  "created"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "The dataset origin the client saw when it staged this replacement. When set, the commit is refused with 409 `origin_changed` if the dataset's origin no longer matches, so a service, STAC or registered-table binding established after the upload is not silently rebound to an upload. Optional: a client that omits it keeps the pre-#1768 behaviour.",
+            "title": "Expected Origin Kind"
+          },
           "token": {
             "anyOf": [
               {

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -4054,7 +4054,16 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # The rest is the note on why `auth` joins `token` in the model_dump
     # exclusion: user_metadata is a durable JSONB column and that dump is a
     # whitelist by omission. Cap 1282 -> 1294, exact.
-    "backend/app/modules/catalog/datasets/api/router_reupload.py": 1294,
+    # fix(#1768): +61. `_refuse_if_origin_changed` re-reads the dataset's
+    # origin after the run row takes the one-active-run slot and refuses a
+    # stale `expected_origin_kind` with 409 `origin_changed`. It is a helper
+    # rather than an inline block because two more branches in the handler
+    # crossed the McCabe gate, which is the same reason `_dispatch_reupload_task`
+    # exists. Most of the lines are its docstring: which window the condition
+    # closes, why the reservation is what makes the re-read decisive instead of
+    # one more racing read, and why an absent value asserts nothing.
+    # Cap 1294 -> 1355, exact.
+    "backend/app/modules/catalog/datasets/api/router_reupload.py": 1355,
     # fix(#1218 review): +5 — VRT assembly stamps last_refreshed_at like every
     # other creation path, so a post-migration VRT does not report null while
     # a backfilled one carries a timestamp, with a note on why it is a Python
@@ -4653,7 +4662,12 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # deprecated `token` at once. Both are imported from the sources schema
     # rather than restated here, so the four doors cannot describe the same
     # credential four ways. Cap 1483 -> 1499, exact.
-    "backend/app/modules/catalog/datasets/domain/schemas.py": 1499,
+    # fix(#1768): +12. `ReuploadCommitRequest.expected_origin_kind`, typed with
+    # the shared `OriginKind` literal from platform/dataset_origin.py rather
+    # than a second spelling of the vocabulary, plus the description telling a
+    # client author what the field buys and that omitting it is supported.
+    # Cap 1499 -> 1511, exact.
+    "backend/app/modules/catalog/datasets/domain/schemas.py": 1511,
     # --- entered by the inclusion rule, feat(#953/#954/#955/#956) ----------
     # tasks.py crossed 1000 for the first time here because the four operations
     # are deliberately concentrated rather than spread: it grows by one branch

--- a/backend/tests/test_reupload_expected_origin_1768.py
+++ b/backend/tests/test_reupload_expected_origin_1768.py
@@ -1,0 +1,312 @@
+"""The re-upload commit door's expected-origin condition (#1768).
+
+`geolens replace` and the web re-upload dialog both refuse to replace a
+dataset whose origin is a service, a STAC item, or a registered table. That
+refusal is a CLIENT-side precheck: the client reads the origin once, then
+uploads, previews, and waits for a human to confirm. Anything that rebinds
+the dataset in that window is invisible to it, and the swap the commit queues
+rebinds unconditionally to `upload` (`_apply_reupload_swap` in
+tasks_reupload.py) — so a service or STAC binding established mid-flow was
+severed by a commit that looked, to the client, exactly like the one it had
+checked.
+
+The commit body now carries the origin the client SAW. The door re-reads the
+dataset's current origin after the run row takes the one-active-run admission
+slot and refuses a mismatch with 409 `origin_changed` — the same code the
+refresh door already uses when a source moves under a queued run.
+
+The field is optional, so the pre-#1768 contract is still exercised here: a
+body that omits it commits exactly as before.
+"""
+
+from __future__ import annotations
+
+import typing
+import uuid
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import select, update
+from unittest.mock import patch
+
+from app.modules.catalog.datasets.domain.models import Dataset
+from app.platform.dataset_origin import ORIGIN_KINDS, OriginKind
+from app.platform.jobs.models import IngestJob
+from app.platform.refresh.models import DatasetRefreshRun
+from app.platform.refresh.service import create_pending_run
+
+from tests.factories import create_dataset, get_user_id
+
+pytestmark = pytest.mark.anyio
+
+
+# (source_format, the origin kind classify_origin derives from it). Every
+# kind a vector dataset can carry, so the door is proven for the three the
+# clients refuse to replace (service, stac, postgis) as well as the two they
+# allow. `postgis` is spelled as a NULL source_format rather than by
+# registering a real table: registration mutates cluster-global reader grants
+# and would force this module into `_TENANCY_GLOBAL_STATE_MODULES`, and the
+# door reads nothing that a real registration would add.
+ORIGIN_CASES: list[tuple[str | None, str]] = [
+    ("geojson", "upload"),
+    ("wfs", "service"),
+    ("stac", "stac"),
+    (None, "postgis"),
+    ("created", "created"),
+]
+
+#: An origin kind that is not the one under test, for the stale-value case.
+_OTHER_KIND = {
+    "upload": "service",
+    "service": "upload",
+    "stac": "upload",
+    "postgis": "upload",
+    "created": "upload",
+}
+
+
+async def _seed_committable_reupload(session, *, source_format: str | None):
+    """Dataset + bound pending re-upload job — the state a client reaches
+    after uploading its replacement and before it confirms."""
+    admin_id = await get_user_id(session, "admin")
+    dataset = await create_dataset(
+        session, created_by=admin_id, source_format=source_format
+    )
+    job = IngestJob(
+        dataset_id=dataset.id,
+        status="pending",
+        attempt_id=uuid.uuid4(),
+        source_filename="parcels.gpkg",
+        file_path="/tmp/fake-reupload-1768.gpkg",
+        created_by=admin_id,
+        user_metadata={"reupload": True, "dataset_id": str(dataset.id)},
+    )
+    session.add(job)
+    await session.commit()
+    await session.refresh(job)
+    return dataset, job
+
+
+async def _runs_for(session, dataset_id) -> list[DatasetRefreshRun]:
+    result = await session.execute(
+        select(DatasetRefreshRun).where(DatasetRefreshRun.dataset_id == dataset_id)
+    )
+    return list(result.scalars().all())
+
+
+async def _noop_defer(fn, rollback=None, db=None, job=None):
+    """Skip Procrastinate: this module tests the door, not the dispatch."""
+    return None
+
+
+class TestExpectedOriginMatches:
+    @pytest.mark.parametrize("source_format,origin_kind", ORIGIN_CASES)
+    async def test_commit_is_accepted_when_the_origin_still_matches(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session,
+        source_format: str | None,
+        origin_kind: str,
+    ):
+        """The whole point of the condition is that it costs a correct client
+        nothing: the origin the client saw is still the origin, so the commit
+        is queued exactly as it was before #1768."""
+        dataset, job = await _seed_committable_reupload(
+            test_db_session, source_format=source_format
+        )
+
+        with patch(
+            "app.modules.catalog.datasets.api.router_reupload.defer_with_orphan_guard",
+            side_effect=_noop_defer,
+        ):
+            resp = await client.post(
+                f"/datasets/{dataset.id}/reupload/{job.id}/commit",
+                json={"expected_origin_kind": origin_kind},
+                headers=admin_auth_header,
+            )
+
+        assert resp.status_code == 202, resp.text
+        assert resp.json()["status"] == "pending"
+        runs = await _runs_for(test_db_session, dataset.id)
+        assert [run.ingest_job_id for run in runs] == [job.id]
+
+
+class TestExpectedOriginNoLongerMatches:
+    @pytest.mark.parametrize("source_format,origin_kind", ORIGIN_CASES)
+    async def test_commit_is_refused_when_the_origin_is_not_the_one_seen(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session,
+        source_format: str | None,
+        origin_kind: str,
+    ):
+        """One case per origin kind: a client that captured some OTHER kind is
+        refused, and the refusal names both sides so the client can say what
+        changed rather than just that something did."""
+        dataset, job = await _seed_committable_reupload(
+            test_db_session, source_format=source_format
+        )
+        stale = _OTHER_KIND[origin_kind]
+
+        resp = await client.post(
+            f"/datasets/{dataset.id}/reupload/{job.id}/commit",
+            json={"expected_origin_kind": stale},
+            headers=admin_auth_header,
+        )
+
+        assert resp.status_code == 409, resp.text
+        detail = resp.json()["detail"]
+        assert detail["code"] == "origin_changed"
+        assert detail["origin_kind"] == origin_kind
+        assert detail["expected_origin_kind"] == stale
+
+        # Nothing was reserved, so the next dispatch is admitted immediately.
+        assert await _runs_for(test_db_session, dataset.id) == []
+        await test_db_session.refresh(job)
+        assert job.status == "pending"
+
+    async def test_an_omitted_expected_origin_keeps_the_old_contract(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session,
+    ):
+        """Additive, and provably so: a client that sends no
+        `expected_origin_kind` commits over a service origin exactly as every
+        client did before #1768. This is the compatibility guarantee, not an
+        oversight — an older CLI or SDK must keep working."""
+        dataset, job = await _seed_committable_reupload(
+            test_db_session, source_format="wfs"
+        )
+
+        with patch(
+            "app.modules.catalog.datasets.api.router_reupload.defer_with_orphan_guard",
+            side_effect=_noop_defer,
+        ):
+            resp = await client.post(
+                f"/datasets/{dataset.id}/reupload/{job.id}/commit",
+                json={},
+                headers=admin_auth_header,
+            )
+
+        assert resp.status_code == 202, resp.text
+
+    async def test_an_unknown_origin_kind_is_rejected_by_the_schema(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session,
+    ):
+        dataset, job = await _seed_committable_reupload(
+            test_db_session, source_format="geojson"
+        )
+
+        resp = await client.post(
+            f"/datasets/{dataset.id}/reupload/{job.id}/commit",
+            json={"expected_origin_kind": "sftp"},
+            headers=admin_auth_header,
+        )
+
+        assert resp.status_code == 422, resp.text
+
+
+def _rebinding_create_pending_run(session_factory, dataset_id):
+    """Wrap the real `create_pending_run`: commit a service rebinding of the
+    dataset on a SEPARATE session first, then proceed.
+
+    This is the #1768 race made deterministic. The rebinding lands after the
+    client captured `upload` and after the door's own first read of the
+    dataset, which is exactly the window a concurrent service or STAC
+    re-upload commits in. It runs before the real helper for the same reason
+    the cancel race in `test_job_cancel_reupload_commit.py` does: once the
+    helper flushes, the request holds row locks the side session would wait
+    on forever.
+    """
+
+    async def _wrapped(session, **kwargs):
+        async with session_factory() as side_session:
+            await side_session.execute(
+                update(Dataset)
+                .where(Dataset.id == dataset_id)
+                .values(
+                    source_format="wfs",
+                    origin_uri="https://example.test/wfs",
+                    origin_ref={
+                        "kind": "service",
+                        "service_type": "wfs",
+                        "url": "https://example.test/wfs",
+                        "layer_id": "parcels",
+                    },
+                )
+            )
+            await side_session.commit()
+        return await create_pending_run(session, **kwargs)
+
+    return _wrapped
+
+
+class TestOriginChangesBetweenCaptureAndCommit:
+    async def test_a_rebinding_mid_flow_is_refused_and_left_intact(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session,
+    ):
+        """The bug from the issue, end to end: the client saw `upload`, a
+        service binding commits while it was uploading and confirming, and the
+        commit must not install the file swap that would sever it."""
+        from app.core.db import async_session
+
+        dataset, job = await _seed_committable_reupload(
+            test_db_session, source_format="geojson"
+        )
+
+        with patch(
+            "app.modules.catalog.datasets.api.router_reupload.create_pending_run",
+            side_effect=_rebinding_create_pending_run(async_session, dataset.id),
+        ):
+            resp = await client.post(
+                f"/datasets/{dataset.id}/reupload/{job.id}/commit",
+                json={"expected_origin_kind": "upload"},
+                headers=admin_auth_header,
+            )
+
+        assert resp.status_code == 409, resp.text
+        detail = resp.json()["detail"]
+        assert detail["code"] == "origin_changed"
+        assert detail["origin_kind"] == "service"
+        assert detail["expected_origin_kind"] == "upload"
+
+        # The binding that landed mid-flow survives untouched — that is the
+        # harm #1768 is about, not the refusal.
+        await test_db_session.refresh(dataset)
+        assert dataset.source_format == "wfs"
+        assert dataset.origin_ref["kind"] == "service"
+        assert dataset.origin_uri == "https://example.test/wfs"
+
+        # And nothing is stranded: no run row holds the admission index, and
+        # the job is still committable once the client re-reads the origin.
+        assert await _runs_for(test_db_session, dataset.id) == []
+        await test_db_session.refresh(job)
+        assert job.status == "pending"
+
+        admin_id = await get_user_id(test_db_session, "admin")
+        run = await create_pending_run(
+            test_db_session,
+            dataset_id=dataset.id,
+            origin_kind="upload",
+            trigger="manual",
+            triggered_by=admin_id,
+            ingest_job_id=job.id,
+            feature_count_before=1,
+        )
+        await test_db_session.commit()
+        assert run.status == "pending"
+
+
+def test_origin_kind_literal_mirrors_the_origin_vocabulary():
+    """`OriginKind` is the request-model spelling of `ORIGIN_KINDS`. A kind
+    added to one alone must fail here rather than in a request."""
+    assert set(typing.get_args(OriginKind)) == ORIGIN_KINDS

--- a/cli/geolens_cli/main.py
+++ b/cli/geolens_cli/main.py
@@ -1412,6 +1412,12 @@ def replace(
             dataset_resp, expected=_replace.GET_DATASET_OK_STATUS
         )
 
+        # fix(#1768): captured HERE, at the same read the refusal below is
+        # decided from, and sent with the commit. The gate is a client-side
+        # precheck and everything after it — upload, preview, confirm — is a
+        # window the server has to referee.
+        expected_origin_kind = _replace.captured_origin_kind(dataset)
+
         refusal = _replace.origin_refusal_message(getattr(dataset, "origin", None))
         if refusal is not None:
             state.output.error(refusal)
@@ -1482,7 +1488,11 @@ def replace(
             dataset_id=dataset_uuid,
             job_id=job_id,
             client=sdk.client,
-            body=_replace.build_commit_request(layer_name=layer, srid_override=srid),
+            body=_replace.build_commit_request(
+                layer_name=layer,
+                srid_override=srid,
+                expected_origin_kind=expected_origin_kind,
+            ),
         )
         commit = _replace.unwrap_or_raise(commit_resp, expected=_replace.COMMIT_OK_STATUS)
     except _replace.ReplaceRequestError as exc:

--- a/cli/geolens_cli/replace.py
+++ b/cli/geolens_cli/replace.py
@@ -169,6 +169,21 @@ def origin_refusal_message(origin: Optional[str]) -> Optional[str]:
     return by_kind[origin]
 
 
+def captured_origin_kind(dataset: Any) -> Optional[str]:
+    """The origin kind to assert at commit, or None to assert nothing.
+
+    fix(#1768): normalizes what the generated model can hand back — a kind,
+    ``None``, or the SDK's ``UNSET`` sentinel for a reader the server redacts
+    the field from — down to "a kind this CLI recognizes, or nothing". A kind
+    the server added after this build is deliberately dropped rather than
+    forwarded: the server would 422 a value its own enum does not carry, and
+    turning a stale CLI into a hard failure is worse than leaving the flow at
+    its pre-#1768 behaviour.
+    """
+    origin = getattr(dataset, "origin", None)
+    return origin if origin in KNOWN_ORIGIN_KINDS else None
+
+
 # ---------------------------------------------------------------------------
 # Request builders
 # ---------------------------------------------------------------------------
@@ -185,15 +200,33 @@ def build_preview_request(layer_name: Optional[str]) -> Any:
 
 
 def build_commit_request(
-    *, layer_name: Optional[str], srid_override: Optional[int]
+    *,
+    layer_name: Optional[str],
+    srid_override: Optional[int],
+    expected_origin_kind: Optional[str] = None,
 ) -> Any:
-    """Build a ReuploadCommitRequest. No ``token``; replace is file-only."""
+    """Build a ReuploadCommitRequest. No ``token``; replace is file-only.
+
+    fix(#1768): ``expected_origin_kind`` is the origin ``origin_refusal_message``
+    above read and allowed, sent back so the commit door can refuse if it is no
+    longer the dataset's origin. Everything between that read and this request
+    — the upload, the preview, the confirmation prompt — is a window in which a
+    service or STAC re-upload can bind the dataset to a remote source, and the
+    swap this commit queues would rebind it to ``upload`` and sever it. An
+    origin the CLI could not classify (``None``, or a kind the server added
+    after this build) is left UNSET rather than guessed: the server treats an
+    absent value as "no condition", which is the pre-#1768 behaviour and the
+    right answer when the client has no captured origin to assert.
+    """
     from geolens.models.reupload_commit_request import ReuploadCommitRequest
     from geolens.types import UNSET
 
     return ReuploadCommitRequest(
         layer_name=layer_name if layer_name is not None else UNSET,
         srid_override=srid_override if srid_override is not None else UNSET,
+        expected_origin_kind=(
+            expected_origin_kind if expected_origin_kind in KNOWN_ORIGIN_KINDS else UNSET
+        ),
     )
 
 
@@ -267,6 +300,15 @@ _REFUSAL_MESSAGES: dict[str, str] = {
     "refresh_not_applicable": (
         "This dataset's data comes from a remote service origin, not an "
         "upload. Run `geolens refresh <dataset-id>` to update it instead."
+    ),
+    # fix(#1768): the commit door found a different origin than the one the
+    # Stage 0 read allowed. Nothing was queued and nothing was severed; the
+    # user has to look at the dataset again before deciding, which is why this
+    # does not suggest re-running the same command.
+    "origin_changed": (
+        "This dataset's source changed while the replacement was being "
+        "prepared, so nothing was queued. Check the dataset's source before "
+        "replacing its data."
     ),
     "dataset_busy": (
         "A refresh or re-upload is already running for this dataset. Wait "

--- a/cli/tests/test_replace.py
+++ b/cli/tests/test_replace.py
@@ -1089,3 +1089,119 @@ class TestReplaceRasterDataset:
 
         assert result.exit_code == EXIT_USAGE, result.output
         assert "--layer" in result.output
+
+
+class TestReplaceSendsTheOriginItSaw:
+    """fix(#1768): the origin gate above is a client-side precheck. The commit
+    carries the origin that gate read, so the server can refuse if the dataset
+    was rebound during the upload/preview/confirm window."""
+
+    def test_commit_carries_the_origin_from_the_pre_fetch(
+        self, runner, tmp_xdg_home, mock_keyring, monkeypatch, sample_geojson
+    ) -> None:
+        from geolens_cli.main import app
+
+        _seed_login(mock_keyring)
+        _patch_dataset(monkeypatch, _ok_dataset(origin="upload"))
+        _patch_upload(monkeypatch, _ok_upload())
+        _patch_preview(monkeypatch, _ok_preview())
+
+        seen: dict[str, object] = {}
+
+        def _capture(**kw):
+            seen["body"] = kw["body"]
+            return _ok_commit()
+
+        monkeypatch.setattr(
+            "geolens.api.datasets_reupload."
+            "reupload_commit_datasets_dataset_id_reupload_job_id_commit_post."
+            "sync_detailed",
+            _capture,
+        )
+
+        result = runner.invoke(
+            app, ["replace", str(DATASET_ID), str(sample_geojson), "--yes"]
+        )
+
+        assert result.exit_code == 0, result.output
+        assert seen["body"].expected_origin_kind == "upload"
+
+    def test_an_origin_changed_409_is_actionable(
+        self, runner, tmp_xdg_home, mock_keyring, monkeypatch, sample_geojson
+    ) -> None:
+        from geolens_cli.main import app
+
+        _seed_login(mock_keyring)
+        _patch_dataset(monkeypatch, _ok_dataset(origin="upload"))
+        _patch_upload(monkeypatch, _ok_upload())
+        _patch_preview(monkeypatch, _ok_preview())
+        _patch_commit(
+            monkeypatch,
+            _problem(
+                409,
+                {
+                    "code": "origin_changed",
+                    "message": "backend detail",
+                    "origin_kind": "service",
+                    "expected_origin_kind": "upload",
+                },
+            ),
+        )
+
+        result = runner.invoke(
+            app, ["replace", str(DATASET_ID), str(sample_geojson), "--yes"]
+        )
+
+        assert result.exit_code == 1, result.output
+        assert "source changed" in result.output
+
+
+class TestCapturedOriginKind:
+    def test_a_known_kind_is_asserted(self) -> None:
+        from types import SimpleNamespace
+
+        from geolens_cli.replace import captured_origin_kind
+
+        assert captured_origin_kind(SimpleNamespace(origin="stac")) == "stac"
+
+    @pytest.mark.parametrize("origin", [None, "sftp"])
+    def test_an_unclassifiable_origin_asserts_nothing(self, origin) -> None:
+        from types import SimpleNamespace
+
+        from geolens_cli.replace import captured_origin_kind
+
+        assert captured_origin_kind(SimpleNamespace(origin=origin)) is None
+
+    def test_the_sdk_unset_sentinel_asserts_nothing(self) -> None:
+        """A reader the server redacts `origin` from gets UNSET, not a kind —
+        forwarding that sentinel would 422 the commit."""
+        from types import SimpleNamespace
+
+        from geolens.types import UNSET
+
+        from geolens_cli.replace import captured_origin_kind
+
+        assert captured_origin_kind(SimpleNamespace(origin=UNSET)) is None
+
+
+class TestBuildCommitRequestOrigin:
+    def test_a_known_kind_is_sent(self) -> None:
+        from geolens_cli.replace import build_commit_request
+
+        req = build_commit_request(
+            layer_name=None, srid_override=None, expected_origin_kind="service"
+        )
+        assert req.expected_origin_kind == "service"
+
+    @pytest.mark.parametrize("kind", [None, "sftp"])
+    def test_an_unknown_or_missing_kind_is_left_unset(self, kind) -> None:
+        """UNSET, not null: the field is optional server-side and an absent
+        value is the pre-#1768 contract an older client already gets."""
+        from geolens.types import UNSET
+
+        from geolens_cli.replace import build_commit_request
+
+        req = build_commit_request(
+            layer_name=None, srid_override=None, expected_origin_kind=kind
+        )
+        assert req.expected_origin_kind is UNSET

--- a/frontend/src/api/__tests__/datasets.contract.test.ts
+++ b/frontend/src/api/__tests__/datasets.contract.test.ts
@@ -1,6 +1,10 @@
 import { apiFetch } from '@/api/client';
-import { reuploadDataset, setTargetStatus } from '@/api/datasets';
-import type { ReuploadResponse, StatusUpdateResponse } from '@/types/api';
+import { reuploadCommit, reuploadDataset, setTargetStatus } from '@/api/datasets';
+import type {
+  ReuploadCommitResponse,
+  ReuploadResponse,
+  StatusUpdateResponse,
+} from '@/types/api';
 
 vi.mock('@/api/client', () => ({
   apiFetch: vi.fn(),
@@ -57,4 +61,44 @@ describe('reuploadDataset timeout', () => {
     const [, options] = mockApiFetch.mock.calls[0];
     expect(options?.timeoutMs).toBeGreaterThan(30_000);
   });
+});
+
+// fix(#1768): the commit body's expected-origin condition. `expected_origin_kind`
+// is optional server-side, and an ABSENT key is the pre-#1768 contract — so the
+// caller must omit it rather than send null when it has no captured origin.
+describe('reuploadCommit expected-origin condition', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('sends the captured origin kind when one is given', async () => {
+    mockApiFetch.mockResolvedValueOnce({
+      job_id: 'job-1',
+      status: 'pending',
+      message: 'Re-upload queued',
+    } satisfies ReuploadCommitResponse);
+
+    await reuploadCommit('dataset-1', 'job-1', null, undefined, undefined, 'service');
+
+    const [, options] = mockApiFetch.mock.calls[0];
+    expect(JSON.parse(String(options?.body))).toMatchObject({
+      expected_origin_kind: 'service',
+    });
+  });
+
+  it.each([[undefined], [null]])(
+    'omits the key entirely when the origin is %s',
+    async (origin) => {
+      mockApiFetch.mockResolvedValueOnce({
+        job_id: 'job-1',
+        status: 'pending',
+        message: 'Re-upload queued',
+      } satisfies ReuploadCommitResponse);
+
+      await reuploadCommit('dataset-1', 'job-1', null, undefined, undefined, origin);
+
+      const [, options] = mockApiFetch.mock.calls[0];
+      expect(JSON.parse(String(options?.body))).not.toHaveProperty(
+        'expected_origin_kind',
+      );
+    },
+  );
 });

--- a/frontend/src/api/datasets.ts
+++ b/frontend/src/api/datasets.ts
@@ -6,6 +6,7 @@ import { uploadChunks } from './_presignedUpload';
 import { pushReportEntry, reportNetworkError } from '@/lib/report';
 import type {
   CreateDatasetRequest,
+  DatasetOrigin,
   DatasetResponse,
   DatasetRowsResponse,
   DatasetUpdateRequest,
@@ -231,11 +232,18 @@ export async function reuploadCommit(
   token?: string,
   // GPKG-01 Phase 1058: user-chosen layer for multi-layer GPKG files
   layerName?: string,
+  // fix(#1768): the dataset origin the dialog saw when it staged this
+  // replacement. The commit door refuses with 409 `origin_changed` if the
+  // dataset was rebound to a service, STAC or registered-table source while
+  // the user was uploading and confirming. Optional server-side, so omitting
+  // it is the pre-#1768 behaviour rather than an error.
+  expectedOriginKind?: DatasetOrigin | null,
 ): Promise<ReuploadCommitResponse> {
   const payload: ReuploadCommitRequest = {
     srid_override: sridOverride ?? null,
     ...(token ? { token } : {}),
     ...(layerName !== undefined ? { layer_name: layerName } : {}),
+    ...(expectedOriginKind ? { expected_origin_kind: expectedOriginKind } : {}),
   };
 
   return apiFetch<ReuploadCommitResponse>(`/datasets/${datasetId}/reupload/${jobId}/commit`, {

--- a/frontend/src/components/dataset/ReuploadDialog.tsx
+++ b/frontend/src/components/dataset/ReuploadDialog.tsx
@@ -121,6 +121,16 @@ function isLikelyProtectedServiceFailure(message: string): boolean {
   return AUTH_ERROR_HINTS.some((hint) => normalized.includes(hint));
 }
 
+/** fix(#1768 round 1): the commit door's expected-origin refusal, read off the
+ *  raw `detail` ApiError carries in `body` rather than off the translated
+ *  message — the copy is locale-dependent, the code is not. */
+function isOriginChangedError(err: unknown): boolean {
+  if (!(err instanceof ApiError) || err.status !== 409) return false;
+  const body = err.body;
+  if (typeof body !== 'object' || body === null) return false;
+  return (body as { code?: unknown }).code === 'origin_changed';
+}
+
 export function ReuploadDialog({
   dataset,
   open,
@@ -470,6 +480,16 @@ export function ReuploadDialog({
       });
       setStep('tracking');
     } catch (err) {
+      // fix(#1768 round 1): an `origin_changed` refusal is proof that the
+      // `dataset` prop this dialog captured from is stale — the server just
+      // read an origin the cache is not serving. Without this, `handleRetry`
+      // clears the captured origin and the next staging re-captures the SAME
+      // stale value from the unchanged prop, so the refusal's own "start the
+      // replacement again" advice 409s forever until a manual reload. Fired
+      // here in the catch, ahead of every path that can stage another job.
+      if (isOriginChangedError(err)) {
+        queryClient.invalidateQueries({ queryKey: queryKeys.datasets.detail(dataset.id) });
+      }
       const message = err instanceof Error ? err.message : t('reupload.commitFailed');
       setError(
         sourceType === 'service_url'
@@ -478,7 +498,7 @@ export function ReuploadDialog({
       );
       setStep('error');
     }
-  }, [dataset.id, jobId, stagedOriginKind, sourceType, serviceToken, selectedFileLayer, commitMutation, appendRetryGuidance, t]);
+  }, [dataset.id, jobId, stagedOriginKind, sourceType, serviceToken, selectedFileLayer, commitMutation, queryClient, appendRetryGuidance, t]);
 
   const handleRetry = useCallback(() => {
     setError(null);

--- a/frontend/src/components/dataset/ReuploadDialog.tsx
+++ b/frontend/src/components/dataset/ReuploadDialog.tsx
@@ -41,6 +41,7 @@ import { reuploadPresigned } from '@/api/datasets';
 import { getGeometryTypeLabel } from '@/i18n/labels';
 import { formatNumber } from '@/lib/format';
 import type {
+  DatasetOrigin,
   DatasetResponse,
   ReuploadPreviewResponse,
   ReuploadSourceType,
@@ -134,6 +135,13 @@ export function ReuploadDialog({
   const [step, setStep] = useState<ReuploadStep>('source-select');
   const [sourceType, setSourceType] = useState<ReuploadSourceType | null>(null);
   const [jobId, setJobId] = useState<string | null>(null);
+  // fix(#1768): the dataset's origin as it was when this replacement was
+  // staged, captured beside the job id and sent with the commit. Between
+  // staging and the user's confirmation a service or STAC re-upload can bind
+  // this dataset to a remote source; the swap the commit queues would rebind
+  // it to `upload` and sever that binding, so the server refuses the commit
+  // when the origin it reads is no longer this one.
+  const [stagedOriginKind, setStagedOriginKind] = useState<DatasetOrigin | null>(null);
   const [preview, setPreview] = useState<ReuploadPreviewResponse | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [selectedFile, setSelectedFile] = useState<File | null>(null);
@@ -167,6 +175,7 @@ export function ReuploadDialog({
     setStep('source-select');
     setSourceType(null);
     setJobId(null);
+    setStagedOriginKind(null);
     setPreview(null);
     setError(null);
     setSelectedFile(null);
@@ -255,6 +264,7 @@ export function ReuploadDialog({
     setError(null);
     setPreview(null);
     setJobId(null);
+    setStagedOriginKind(null);
     setProbeResult(null);
     setSelectedLayer(null);
     if (nextSource === 'file') {
@@ -282,6 +292,7 @@ export function ReuploadDialog({
           });
         }
         setJobId(uploadResult.job_id);
+        setStagedOriginKind(dataset.origin ?? null);
 
         // #1289: raster has no schema-preview step — the preview endpoint
         // returns 400 for raster by design (nothing for ogrinfo to diff a
@@ -325,7 +336,7 @@ export function ReuploadDialog({
         setStep('error');
       }
     },
-    [dataset.id, isRaster, uploadMutation, previewMutation, uploadConfig?.presigned_uploads, t],
+    [dataset.id, dataset.origin, isRaster, uploadMutation, previewMutation, uploadConfig?.presigned_uploads, t],
   );
 
   const handleServiceConnect = useCallback(
@@ -389,6 +400,7 @@ export function ReuploadDialog({
           },
         });
         setJobId(previewResult.job_id);
+        setStagedOriginKind(dataset.origin ?? null);
         setPreview(previewResult);
         setStep('preview');
       } catch (err) {
@@ -405,7 +417,7 @@ export function ReuploadDialog({
         setStep('layer-select');
       }
     },
-    [dataset.id, probeResult, servicePreviewMutation, serviceToken, t, appendRetryGuidance],
+    [dataset.id, dataset.origin, probeResult, servicePreviewMutation, serviceToken, t, appendRetryGuidance],
   );
 
   // GPKG-01 Phase 1058: handler for file-path layer selection.
@@ -451,6 +463,10 @@ export function ReuploadDialog({
         jobId,
         token,
         ...(selectedFileLayer !== null ? { layerName: selectedFileLayer } : {}),
+        // fix(#1768): the origin as of staging, not as of now — `dataset` is a
+        // live query result, so reading it here would re-read the very change
+        // this condition exists to catch and always agree with the server.
+        expectedOriginKind: stagedOriginKind,
       });
       setStep('tracking');
     } catch (err) {
@@ -462,12 +478,13 @@ export function ReuploadDialog({
       );
       setStep('error');
     }
-  }, [dataset.id, jobId, sourceType, serviceToken, selectedFileLayer, commitMutation, appendRetryGuidance, t]);
+  }, [dataset.id, jobId, stagedOriginKind, sourceType, serviceToken, selectedFileLayer, commitMutation, appendRetryGuidance, t]);
 
   const handleRetry = useCallback(() => {
     setError(null);
     setPreview(null);
     setJobId(null);
+    setStagedOriginKind(null);
     if (sourceType === 'service_url') {
       setProbeResult(null);
       setSelectedLayer(null);

--- a/frontend/src/components/dataset/__tests__/ReuploadDialog.test.tsx
+++ b/frontend/src/components/dataset/__tests__/ReuploadDialog.test.tsx
@@ -10,6 +10,8 @@ import {
 } from '@/components/dataset/hooks/use-dataset';
 import { useJobStatus, useUploadConfig } from '@/components/import/hooks/use-ingest';
 import { probeService } from '@/api/ingest';
+import { ApiError } from '@/api/client';
+import { queryKeys } from '@/lib/query-keys';
 import { ReuploadDialog } from '../ReuploadDialog';
 import type { DatasetResponse, ProbeResponse, ReuploadPreviewResponse } from '@/types/api';
 
@@ -593,6 +595,86 @@ describe('ReuploadDialog', () => {
       expect(commitMutateAsync).toHaveBeenCalled();
     });
     expect(commitMutateAsync.mock.calls[0][0].expectedOriginKind).toBe('upload');
+  });
+
+  // fix(#1768 round 1): the refusal tells the user to start the replacement
+  // again, and `handleRetry` clears the captured origin — but the origin is
+  // re-captured from the `dataset` prop, which is served from the cache the
+  // server just disagreed with. Without the invalidation the retry re-sends
+  // the same stale kind and 409s forever.
+  it('invalidates the dataset detail query when the commit reports origin_changed', async () => {
+    const user = userEvent.setup();
+    commitMutateAsync.mockRejectedValueOnce(
+      new ApiError('This dataset’s source changed', 409, {
+        code: 'origin_changed',
+        origin_kind: 'service',
+        expected_origin_kind: 'upload',
+      }),
+    );
+
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, gcTime: 0 }, mutations: { retry: false } },
+    });
+    const invalidate = vi
+      .spyOn(queryClient, 'invalidateQueries')
+      .mockResolvedValue(undefined);
+
+    rtlRender(
+      <QueryClientProvider client={queryClient}>
+        <ReuploadDialog
+          dataset={{ ...makeDataset(), origin: 'upload' }}
+          open
+          onOpenChange={vi.fn()}
+        />
+      </QueryClientProvider>,
+    );
+
+    await openFileSource(user);
+    await dropFile();
+    await screen.findByRole('button', { name: 'Confirm Re-Upload' });
+    await user.click(screen.getByRole('button', { name: 'Confirm Re-Upload' }));
+
+    await waitFor(() => {
+      expect(invalidate).toHaveBeenCalledWith({
+        queryKey: queryKeys.datasets.detail('dataset-1'),
+      });
+    });
+  });
+
+  it('does not invalidate the dataset detail query for an unrelated commit failure', async () => {
+    // The counterfactual's other half: the invalidation is keyed on the
+    // refusal code, not fired on every commit error.
+    const user = userEvent.setup();
+    commitMutateAsync.mockRejectedValueOnce(
+      new ApiError('A refresh is already running', 409, { code: 'dataset_busy' }),
+    );
+
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, gcTime: 0 }, mutations: { retry: false } },
+    });
+    const invalidate = vi
+      .spyOn(queryClient, 'invalidateQueries')
+      .mockResolvedValue(undefined);
+
+    rtlRender(
+      <QueryClientProvider client={queryClient}>
+        <ReuploadDialog
+          dataset={{ ...makeDataset(), origin: 'upload' }}
+          open
+          onOpenChange={vi.fn()}
+        />
+      </QueryClientProvider>,
+    );
+
+    await openFileSource(user);
+    await dropFile();
+    await screen.findByRole('button', { name: 'Confirm Re-Upload' });
+    await user.click(screen.getByRole('button', { name: 'Confirm Re-Upload' }));
+
+    await screen.findByText('A refresh is already running');
+    expect(invalidate).not.toHaveBeenCalledWith({
+      queryKey: queryKeys.datasets.detail('dataset-1'),
+    });
   });
 });
 

--- a/frontend/src/components/dataset/__tests__/ReuploadDialog.test.tsx
+++ b/frontend/src/components/dataset/__tests__/ReuploadDialog.test.tsx
@@ -502,6 +502,98 @@ describe('ReuploadDialog', () => {
     // There should be NO "File:" header line in service-URL preview
     expect(screen.queryByText(/^File:/)).not.toBeInTheDocument();
   });
+
+  // fix(#1768): the commit carries the origin the dialog SAW when it staged
+  // the replacement, so the server can refuse a dataset rebound mid-flow
+  // instead of severing the new binding on the swap.
+  it('sends the origin it saw with a file-source commit', async () => {
+    const user = userEvent.setup();
+    render(
+      <ReuploadDialog
+        dataset={{ ...makeDataset(), origin: 'upload' }}
+        open
+        onOpenChange={vi.fn()}
+      />,
+    );
+
+    await openFileSource(user);
+    await dropFile();
+    await screen.findByRole('button', { name: 'Confirm Re-Upload' });
+    await user.click(screen.getByRole('button', { name: 'Confirm Re-Upload' }));
+
+    await waitFor(() => {
+      expect(commitMutateAsync).toHaveBeenCalled();
+    });
+    expect(commitMutateAsync.mock.calls[0][0].expectedOriginKind).toBe('upload');
+  });
+
+  it('sends the origin it saw with a service-source commit', async () => {
+    const user = userEvent.setup();
+    render(
+      <ReuploadDialog
+        dataset={{ ...makeDataset(), origin: 'service' }}
+        open
+        onOpenChange={vi.fn()}
+      />,
+    );
+
+    await openServicePreview(user);
+    await user.click(screen.getByRole('button', { name: 'Confirm Re-Upload' }));
+
+    await waitFor(() => {
+      expect(commitMutateAsync).toHaveBeenCalled();
+    });
+    expect(commitMutateAsync.mock.calls[0][0].expectedOriginKind).toBe('service');
+  });
+
+  it('asserts no origin when the dataset reports none', async () => {
+    const user = userEvent.setup();
+    renderDialog();
+
+    await openFileSource(user);
+    await dropFile();
+    await screen.findByRole('button', { name: 'Confirm Re-Upload' });
+    await user.click(screen.getByRole('button', { name: 'Confirm Re-Upload' }));
+
+    await waitFor(() => {
+      expect(commitMutateAsync).toHaveBeenCalled();
+    });
+    expect(commitMutateAsync.mock.calls[0][0].expectedOriginKind).toBeNull();
+  });
+
+  it('sends the staged origin, not the origin the live dataset now reports', async () => {
+    // The point of the condition: `dataset` is a live query result, so a
+    // rebinding that lands mid-flow updates the prop. Reading it at confirm
+    // time would send the changed value and always agree with the server,
+    // which is exactly the race #1768 is about.
+    const user = userEvent.setup();
+    const { rerender } = render(
+      <ReuploadDialog
+        dataset={{ ...makeDataset(), origin: 'upload' }}
+        open
+        onOpenChange={vi.fn()}
+      />,
+    );
+
+    await openFileSource(user);
+    await dropFile();
+    await screen.findByRole('button', { name: 'Confirm Re-Upload' });
+
+    rerender(
+      <ReuploadDialog
+        dataset={{ ...makeDataset(), origin: 'service' }}
+        open
+        onOpenChange={vi.fn()}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Confirm Re-Upload' }));
+
+    await waitFor(() => {
+      expect(commitMutateAsync).toHaveBeenCalled();
+    });
+    expect(commitMutateAsync.mock.calls[0][0].expectedOriginKind).toBe('upload');
+  });
 });
 
 // GPKG-01 Phase 1058: multi-layer file path tests

--- a/frontend/src/components/dataset/hooks/__tests__/use-dataset.test.ts
+++ b/frontend/src/components/dataset/hooks/__tests__/use-dataset.test.ts
@@ -152,7 +152,8 @@ describe('useReuploadCommit', () => {
     });
   });
 
-  it('passes datasetId, jobId, sridOverride, token, layerName through to reuploadCommit', async () => {
+  // fix(#1768): expectedOriginKind joined the positional tail.
+  it('passes datasetId, jobId, sridOverride, token, layerName, expectedOriginKind through to reuploadCommit', async () => {
     mockReuploadCommit.mockResolvedValueOnce({ message: 'ok' } as never);
     const { result } = renderWithClient();
 
@@ -162,9 +163,33 @@ describe('useReuploadCommit', () => {
       sridOverride: 4326,
       token: 'tok',
       layerName: 'layer-a',
+      expectedOriginKind: 'service',
     });
 
-    expect(mockReuploadCommit).toHaveBeenCalledWith('ds-1', 'j1', 4326, 'tok', 'layer-a');
+    expect(mockReuploadCommit).toHaveBeenCalledWith(
+      'ds-1',
+      'j1',
+      4326,
+      'tok',
+      'layer-a',
+      'service',
+    );
+  });
+
+  it('forwards an absent expectedOriginKind as undefined, asserting nothing', async () => {
+    mockReuploadCommit.mockResolvedValueOnce({ message: 'ok' } as never);
+    const { result } = renderWithClient();
+
+    await result.current.mutateAsync({ datasetId: 'ds-1', jobId: 'j1' });
+
+    expect(mockReuploadCommit).toHaveBeenCalledWith(
+      'ds-1',
+      'j1',
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+    );
   });
 
   it('does NOT invalidate jobStatusByDataset when reuploadCommit rejects', async () => {

--- a/frontend/src/components/dataset/hooks/use-dataset.ts
+++ b/frontend/src/components/dataset/hooks/use-dataset.ts
@@ -23,6 +23,7 @@ import {
 import { cancelJob } from '@/api/ingest';
 import type {
   CreateDatasetRequest,
+  DatasetOrigin,
   DatasetUpdateRequest,
   AttributeMetadataUpdate,
   ReuploadServicePreviewRequest,
@@ -175,13 +176,17 @@ export function useReuploadCommit() {
       sridOverride,
       token,
       layerName,
+      // fix(#1768): the origin the dialog captured when it staged the
+      // replacement, so the commit door can refuse a mid-flow rebinding.
+      expectedOriginKind,
     }: {
       datasetId: string;
       jobId: string;
       sridOverride?: number | null;
       token?: string;
       layerName?: string;
-    }) => reuploadCommit(datasetId, jobId, sridOverride, token, layerName),
+      expectedOriginKind?: DatasetOrigin | null;
+    }) => reuploadCommit(datasetId, jobId, sridOverride, token, layerName, expectedOriginKind),
     // REMED-01 (ingest-audit P2-06): invalidate the dataset-detail warnings
     // banner cache so it refetches the new ingest job's warnings. The
     // useDatasetJobStatus query uses `staleTime: Infinity` and would

--- a/frontend/src/i18n/locales/de/common.json
+++ b/frontend/src/i18n/locales/de/common.json
@@ -187,6 +187,7 @@
     "arcgisPortalHostInvalid": "Diese Portaladresse ist kein verwendbarer Hostname. Überprüfen Sie die URL, zum Beispiel https://ihre-org.maps.arcgis.com.",
     "refreshServiceTokenRequired": "Die Quelle dieses Datensatzes benötigt eine Dienst-Anmeldeinformation zur Aktualisierung. Geben Sie unten eine an, um fortzufahren.",
     "refreshSourceUrlBlocked": "Die gespeicherte Quell-URL dieses Datensatzes hat eine Sicherheitsprüfung nicht bestanden und kann nicht automatisch aktualisiert werden. Wenden Sie sich an einen Administrator.",
+    "reuploadOriginChanged": "Die Quelle dieses Datensatzes hat sich geändert, während die Ersetzung vorbereitet wurde, daher wurde nichts in die Warteschlange gestellt. Prüfen Sie die Quelle des Datensatzes, bevor Sie seine Daten ersetzen.",
     "unknownLayers": "Diese Layer wurden in der hochgeladenen Datei nicht gefunden: {{layers}}.",
     "sourceValidationCrsMismatch": "Das Koordinatenreferenzsystem der Quelle {{source}} stimmt nicht mit den anderen Quellen überein.",
     "sourceValidationBandCountMismatch": "Die Bandanzahl der Quelle {{source}} stimmt nicht mit den anderen Quellen überein.",

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -312,6 +312,7 @@
     "arcgisPortalHostInvalid": "That portal address isn't a usable hostname. Check the URL, for example https://your-org.maps.arcgis.com.",
     "refreshServiceTokenRequired": "This dataset's source needs a service credential to refresh. Provide one below to continue.",
     "refreshSourceUrlBlocked": "This dataset's stored source URL failed a safety check and can't be refreshed automatically. Contact an administrator.",
+    "reuploadOriginChanged": "This dataset's source changed while the replacement was being prepared, so nothing was queued. Check the dataset's source before replacing its data.",
     "unknownLayers": "These layers were not found in the uploaded file: {{layers}}.",
     "sourceValidationCrsMismatch": "Source {{source}}'s coordinate reference system doesn't match the other sources.",
     "sourceValidationBandCountMismatch": "Source {{source}}'s band count doesn't match the other sources.",

--- a/frontend/src/i18n/locales/es/common.json
+++ b/frontend/src/i18n/locales/es/common.json
@@ -187,6 +187,7 @@
     "arcgisPortalHostInvalid": "Esa dirección de portal no es un nombre de host utilizable. Verifique la URL, por ejemplo https://tu-org.maps.arcgis.com.",
     "refreshServiceTokenRequired": "La fuente de este conjunto de datos necesita una credencial de servicio para actualizarse. Proporciona una a continuación para continuar.",
     "refreshSourceUrlBlocked": "La URL de origen almacenada de este conjunto de datos no superó una comprobación de seguridad y no se puede actualizar automáticamente. Contacta con un administrador.",
+    "reuploadOriginChanged": "La fuente de este conjunto de datos cambió mientras se preparaba el reemplazo, así que no se puso nada en cola. Revisa la fuente del conjunto de datos antes de reemplazar sus datos.",
     "unknownLayers": "No se encontraron estas capas en el archivo subido: {{layers}}.",
     "sourceValidationCrsMismatch": "El sistema de referencia de coordenadas de la fuente {{source}} no coincide con las demás fuentes.",
     "sourceValidationBandCountMismatch": "El número de bandas de la fuente {{source}} no coincide con las demás fuentes.",

--- a/frontend/src/i18n/locales/fr/common.json
+++ b/frontend/src/i18n/locales/fr/common.json
@@ -187,6 +187,7 @@
     "arcgisPortalHostInvalid": "Cette adresse de portail n'est pas un nom d'hôte utilisable. Vérifiez l'URL, par exemple https://votre-org.maps.arcgis.com.",
     "refreshServiceTokenRequired": "La source de ce jeu de données nécessite un identifiant de service pour être actualisée. Fournissez-en un ci-dessous pour continuer.",
     "refreshSourceUrlBlocked": "L'URL source enregistrée de ce jeu de données a échoué à un contrôle de sécurité et ne peut pas être actualisée automatiquement. Contactez un administrateur.",
+    "reuploadOriginChanged": "La source de ce jeu de données a changé pendant la préparation du remplacement, rien n'a donc été mis en file d'attente. Vérifiez la source du jeu de données avant de remplacer ses données.",
     "unknownLayers": "Ces couches sont introuvables dans le fichier importé : {{layers}}.",
     "sourceValidationCrsMismatch": "Le système de référence de coordonnées de la source {{source}} ne correspond pas aux autres sources.",
     "sourceValidationBandCountMismatch": "Le nombre de bandes de la source {{source}} ne correspond pas aux autres sources.",

--- a/frontend/src/lib/__tests__/error-map.test.ts
+++ b/frontend/src/lib/__tests__/error-map.test.ts
@@ -110,6 +110,36 @@ describe('API error localization boundary', () => {
     ).toEqual({ key: 'errors.refreshDatasetBusy' });
   });
 
+  // fix(#1768): the re-upload commit door returns the SAME `origin_changed`
+  // code as the refresh door with different copy, so the two must land on
+  // different keys — a shared key would tell a user replacing a file that a
+  // refresh was queued.
+  it('maps the re-upload door origin_changed apart from the refresh one', () => {
+    expect(
+      classifyApiError(
+        {
+          code: 'origin_changed',
+          message:
+            "This dataset's source changed after this replacement was staged, so nothing was queued. Re-check the dataset's source and start the replacement again.",
+          origin_kind: 'service',
+          expected_origin_kind: 'upload',
+        },
+        409,
+      ),
+    ).toEqual({ key: 'errors.reuploadOriginChanged' });
+
+    expect(
+      classifyApiError(
+        {
+          code: 'origin_changed',
+          message:
+            "This dataset's source changed while the refresh was being queued, so it was not started. Check the new source and try again.",
+        },
+        409,
+      ),
+    ).toEqual({ key: 'errors.refreshOriginChanged' });
+  });
+
   it('maps the STAC door refusal wordings introduced by #1266 (#1332)', () => {
     expect(
       classifyApiError(

--- a/frontend/src/lib/error-map.ts
+++ b/frontend/src/lib/error-map.ts
@@ -116,6 +116,14 @@ const EXACT_ERROR_KEYS: Record<string, ApiErrorDescriptor['key']> = {
     'errors.refreshDatasetBusy',
   "This dataset's source changed while the refresh was being queued, so it was not started. Check the new source and try again.":
     'errors.refreshOriginChanged',
+  // fix(#1768): the re-upload commit door's own `origin_changed`. Same code,
+  // different literal and a different key, because the two refusals describe
+  // different windows: the refresh one is "between your click and the queue",
+  // this one is "between the upload you staged and the commit you just
+  // confirmed", and the action it asks for is to look at the source before
+  // replacing anything, not to retry.
+  "This dataset's source changed after this replacement was staged, so nothing was queued. Re-check the dataset's source and start the replacement again.":
+    'errors.reuploadOriginChanged',
   'This dataset is backed by a registered table in this instance, which needs no service credential. Send the request without a token.':
     'errors.refreshCredentialNotApplicable',
   // fix(#1332): the STAC door's wordings of the same taxonomy states,

--- a/frontend/src/types/api.generated.ts
+++ b/frontend/src/types/api.generated.ts
@@ -11510,6 +11510,11 @@ export interface components {
             /** Srid Override */
             srid_override?: number | null;
             /**
+             * Expected Origin Kind
+             * @description The dataset origin the client saw when it staged this replacement. When set, the commit is refused with 409 `origin_changed` if the dataset's origin no longer matches, so a service, STAC or registered-table binding established after the upload is not silently rebound to an upload. Optional: a client that omits it keeps the pre-#1768 behaviour.
+             */
+            expected_origin_kind?: ("upload" | "postgis" | "service" | "stac" | "created") | null;
+            /**
              * Token
              * @description Deprecated: use the auth object with method bearer.
              */

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -1003,6 +1003,13 @@ export interface ReuploadCommitRequest {
   token?: string;
   // GPKG-01 Phase 1058: user-chosen layer for multi-layer GPKG files
   layer_name?: string;
+  /** fix(#1768): the dataset origin the client saw when it staged this
+   *  replacement. The commit door compares it against the dataset's current
+   *  origin and refuses with 409 `origin_changed` when they differ, so a
+   *  service, STAC or registered-table binding established during the
+   *  upload/preview/confirm window is not silently rebound to an upload.
+   *  Optional — omitting it is the pre-#1768 contract. */
+  expected_origin_kind?: DatasetOrigin | null;
 }
 
 export interface DatasetVersionResponse {

--- a/sdks/python/geolens/models/__init__.py
+++ b/sdks/python/geolens/models/__init__.py
@@ -606,6 +606,9 @@ from .resend_verification_request import ResendVerificationRequest
 from .reserved_rename_detail import ReservedRenameDetail
 from .reserved_rename_warning import ReservedRenameWarning
 from .reupload_commit_request import ReuploadCommitRequest
+from .reupload_commit_request_expected_origin_kind_type_0 import (
+    ReuploadCommitRequestExpectedOriginKindType0,
+)
 from .reupload_commit_response import ReuploadCommitResponse
 from .reupload_preview_request import ReuploadPreviewRequest
 from .reupload_preview_response import ReuploadPreviewResponse
@@ -1196,6 +1199,7 @@ __all__ = (
     "ReservedRenameDetail",
     "ReservedRenameWarning",
     "ReuploadCommitRequest",
+    "ReuploadCommitRequestExpectedOriginKindType0",
     "ReuploadCommitResponse",
     "ReuploadPreviewRequest",
     "ReuploadPreviewResponse",

--- a/sdks/python/geolens/models/reupload_commit_request.py
+++ b/sdks/python/geolens/models/reupload_commit_request.py
@@ -8,6 +8,12 @@ from attrs import field as _attrs_field
 
 from ..types import UNSET, Unset
 
+from ..models.reupload_commit_request_expected_origin_kind_type_0 import (
+    check_reupload_commit_request_expected_origin_kind_type_0,
+)
+from ..models.reupload_commit_request_expected_origin_kind_type_0 import (
+    ReuploadCommitRequestExpectedOriginKindType0,
+)
 from typing import cast
 
 if TYPE_CHECKING:
@@ -22,6 +28,10 @@ class ReuploadCommitRequest:
     """
     Attributes:
         srid_override (int | None | Unset):
+        expected_origin_kind (None | ReuploadCommitRequestExpectedOriginKindType0 | Unset): The dataset origin the
+            client saw when it staged this replacement. When set, the commit is refused with 409 `origin_changed` if the
+            dataset's origin no longer matches, so a service, STAC or registered-table binding established after the upload
+            is not silently rebound to an upload. Optional: a client that omits it keeps the pre-#1768 behaviour.
         token (None | str | Unset): Deprecated: use the auth object with method bearer.
         layer_name (None | str | Unset):
         auth (None | ServiceAuthRequest | Unset): Structured credential for a protected service. Mutually exclusive with
@@ -29,6 +39,9 @@ class ReuploadCommitRequest:
     """
 
     srid_override: int | None | Unset = UNSET
+    expected_origin_kind: (
+        None | ReuploadCommitRequestExpectedOriginKindType0 | Unset
+    ) = UNSET
     token: None | str | Unset = UNSET
     layer_name: None | str | Unset = UNSET
     auth: None | ServiceAuthRequest | Unset = UNSET
@@ -42,6 +55,14 @@ class ReuploadCommitRequest:
             srid_override = UNSET
         else:
             srid_override = self.srid_override
+
+        expected_origin_kind: None | str | Unset
+        if isinstance(self.expected_origin_kind, Unset):
+            expected_origin_kind = UNSET
+        elif isinstance(self.expected_origin_kind, str):
+            expected_origin_kind = self.expected_origin_kind
+        else:
+            expected_origin_kind = self.expected_origin_kind
 
         token: None | str | Unset
         if isinstance(self.token, Unset):
@@ -68,6 +89,8 @@ class ReuploadCommitRequest:
         field_dict.update({})
         if srid_override is not UNSET:
             field_dict["srid_override"] = srid_override
+        if expected_origin_kind is not UNSET:
+            field_dict["expected_origin_kind"] = expected_origin_kind
         if token is not UNSET:
             field_dict["token"] = token
         if layer_name is not UNSET:
@@ -91,6 +114,31 @@ class ReuploadCommitRequest:
             return cast(int | None | Unset, data)
 
         srid_override = _parse_srid_override(d.pop("srid_override", UNSET))
+
+        def _parse_expected_origin_kind(
+            data: object,
+        ) -> None | ReuploadCommitRequestExpectedOriginKindType0 | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, str):
+                    raise TypeError()
+                expected_origin_kind_type_0 = (
+                    check_reupload_commit_request_expected_origin_kind_type_0(data)
+                )
+
+                return expected_origin_kind_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(
+                None | ReuploadCommitRequestExpectedOriginKindType0 | Unset, data
+            )
+
+        expected_origin_kind = _parse_expected_origin_kind(
+            d.pop("expected_origin_kind", UNSET)
+        )
 
         def _parse_token(data: object) -> None | str | Unset:
             if data is None:
@@ -129,6 +177,7 @@ class ReuploadCommitRequest:
 
         reupload_commit_request = cls(
             srid_override=srid_override,
+            expected_origin_kind=expected_origin_kind,
             token=token,
             layer_name=layer_name,
             auth=auth,

--- a/sdks/python/geolens/models/reupload_commit_request_expected_origin_kind_type_0.py
+++ b/sdks/python/geolens/models/reupload_commit_request_expected_origin_kind_type_0.py
@@ -1,0 +1,25 @@
+from typing import Literal, cast
+
+ReuploadCommitRequestExpectedOriginKindType0 = Literal[
+    "created", "postgis", "service", "stac", "upload"
+]
+
+REUPLOAD_COMMIT_REQUEST_EXPECTED_ORIGIN_KIND_TYPE_0_VALUES: set[
+    ReuploadCommitRequestExpectedOriginKindType0
+] = {
+    "created",
+    "postgis",
+    "service",
+    "stac",
+    "upload",
+}
+
+
+def check_reupload_commit_request_expected_origin_kind_type_0(
+    value: str,
+) -> ReuploadCommitRequestExpectedOriginKindType0:
+    if value in REUPLOAD_COMMIT_REQUEST_EXPECTED_ORIGIN_KIND_TYPE_0_VALUES:
+        return cast(ReuploadCommitRequestExpectedOriginKindType0, value)
+    raise TypeError(
+        f"Unexpected value {value!r}. Expected one of {REUPLOAD_COMMIT_REQUEST_EXPECTED_ORIGIN_KIND_TYPE_0_VALUES!r}"
+    )

--- a/sdks/typescript/src/client/types.gen.ts
+++ b/sdks/typescript/src/client/types.gen.ts
@@ -8329,6 +8329,12 @@ export type ReuploadCommitRequest = {
      */
     srid_override?: number | null;
     /**
+     * Expected Origin Kind
+     *
+     * The dataset origin the client saw when it staged this replacement. When set, the commit is refused with 409 `origin_changed` if the dataset's origin no longer matches, so a service, STAC or registered-table binding established after the upload is not silently rebound to an upload. Optional: a client that omits it keeps the pre-#1768 behaviour.
+     */
+    expected_origin_kind?: 'upload' | 'postgis' | 'service' | 'stac' | 'created' | null;
+    /**
      * Token
      *
      * Deprecated: use the auth object with method bearer.


### PR DESCRIPTION
## What

`POST /datasets/{id}/reupload/{job_id}/commit` now accepts an optional
`expected_origin_kind` — the dataset origin the client saw when it staged the
replacement. The door compares it against the dataset's current origin and
refuses a mismatch with `409 {"code": "origin_changed", ...}`, the same
vocabulary the refresh door in `router_refresh.py` already uses for a source
that moved.

## Why — the race

`geolens replace` (#1767) and the web re-upload dialog both refuse to replace
a dataset bound to a service, a STAC item, or a registered table. That refusal
is a **client-side precheck**, decided from a single read taken before the
upload. Between that read and the commit the user confirms sits an upload, a
preview, and a human. A service or STAC re-upload committing in that window is
invisible to the client, and the swap the file commit queues rebinds the
dataset to `upload` unconditionally (`_apply_reupload_swap`,
`tasks_reupload.py` ~426-440) — silently severing the remote binding that was
just established.

ADR-002 invariant 7 (one mutation at a time) bounds that window but does not
close it: the competing run has already *finished* by the time the file commit
lands.

## Where the check sits, and why

After `create_pending_run`, not before. That insert is the one-active-run
admission gate, so with the slot held no other run for this dataset can be in
flight — any origin change is already committed, and a READ COMMITTED re-read
sees it. Placed earlier, the re-read would be one more racing read. On a
mismatch the whole request rolls back, so the reservation is released rather
than leaked (a leaked run row would refuse every refresh of the dataset until
the stale-run sweep's cutoff).

It lives in `_refuse_if_origin_changed` rather than inline because two more
branches pushed `reupload_commit` past the McCabe gate — the same reason
`_dispatch_reupload_task` exists.

## Contract change — additive, old clients unaffected

`expected_origin_kind` is **optional**. A client that sends nothing gets
exactly the pre-#1768 behaviour: no comparison, no refusal. An older CLI, SDK,
or frontend build keeps working unchanged, and `test_an_omitted_expected_origin_keeps_the_old_contract`
pins that. The value is typed with the shared `OriginKind` literal from
`platform/dataset_origin.py`, so the closed set is published in OpenAPI and an
unknown kind is a 422 at the schema boundary rather than a silent no-op.

Only `expected_origin_kind` is carried, not an origin-ref hash. The issue
listed the hash as optional; the kind is what every client-side gate actually
decides from, and a hash would add a second comparison surface with no
refusal the kind does not already cover.

## Clients

- **CLI** (`geolens replace`): captures the origin at the same Stage 0 read
  its own gate is decided from and sends it with the commit. An origin the CLI
  cannot classify (redacted → SDK `UNSET`, or a kind a newer server added)
  asserts nothing rather than being forwarded, so a stale CLI degrades to the
  old behaviour instead of 422-ing. `origin_changed` gets an actionable
  refusal message.
- **Web dialog**: captures `dataset.origin` beside the job id at staging time.
  `dataset` is a live query result, so reading it at confirm time would send
  the very change the condition exists to catch — there is a test for exactly
  that.
- **i18n**: `errors.reuploadOriginChanged` added to en/es/fr/de. It is a
  separate key from `errors.refreshOriginChanged` even though the code is
  shared, because the two refusals describe different windows and ask for
  different actions.

## Regenerated artifacts

`backend/openapi.json`, both SDKs (`make sdks` — one new Python literal
module), and `frontend/src/types/api.generated.ts`. Hand-typed mirrors
(`frontend/src/types/api.ts`) updated to match.

Fixes #1768

## Verification

```bash
# backend (host, Postgres at :5434)
cd backend && set -a && source ../.env.test && set +a
uv run pytest tests/test_reupload_expected_origin_1768.py \
  tests/test_reupload.py tests/test_reupload_service.py \
  tests/test_job_cancel_reupload_commit.py tests/test_reupload_idor.py \
  tests/test_reupload_record_type_guard.py tests/test_sdks_round_trip.py -q
uv run pytest tests/test_layering.py tests/test_rule1_structural.py tests/test_rule2_structural.py -q
uv run ruff check . && uv run ruff format --check .

# contract + SDKs
make openapi-check
make sdks-check

# CLI
cd cli && uv run --extra dev python -m pytest -q

# frontend
cd frontend && npm run lint && npm run typecheck && npm run test:i18n
npx vitest run src/components/dataset src/api src/lib/__tests__/error-map.test.ts
```

Results: backend 100 passed / 1 skipped (the TS-SDK round-trip case, which
needs `sdks/typescript/dist` built) plus 153 passed on the structural gates;
CLI 652 passed; frontend 593 passed across the touched trees; `openapi-check`
and `sdks-check` both clean.

No migration, no config change. `test_layering.py` caps raised with comments
for `router_reupload.py` (1294 → 1355) and `schemas.py` (1499 → 1511).
