### PR TITLE
fix(refresh): re-derive geom_4326 for registered tables so out-of-band writes render

### DIFF
--- a/backend/app/modules/catalog/datasets/domain/models.py
+++ b/backend/app/modules/catalog/datasets/domain/models.py
@@ -622,6 +622,10 @@ class Dataset(Base):
         content (feature edits, column DDL, tile_columns, reupload) — the
         post-commit Valkey purge cannot reach CDN/browser caches keyed on the
         tile URL. fix(#525 B-038)
+
+        Writes an ABSOLUTE value read off this instance, so it is correct only
+        while the caller holds this row; one that does not must use
+        ``bump_tile_cache_version_atomic`` (ingest/tasks_common). #1738 r1
         """
         self.tile_cache_version = (self.tile_cache_version or 1) + 1
 

--- a/backend/app/processing/ingest/metadata.py
+++ b/backend/app/processing/ingest/metadata.py
@@ -72,10 +72,15 @@ from app.processing.ingest.metadata_mercator import (
     clip_to_mercator_bounds,  # noqa: F401 -- re-exported, see __all__
 )
 from app.processing.ingest.metadata_projection import (
+    REPAIR_APPLIED,  # noqa: F401 -- re-exported, see __all__
+    REPAIR_GENERATED,  # noqa: F401 -- re-exported, see __all__
+    REPAIR_NO_GEOMETRY,  # noqa: F401 -- re-exported, see __all__
+    Geom4326Repair,  # noqa: F401 -- re-exported, see __all__
     add_4326_column,  # noqa: F401 -- re-exported, see __all__
     ensure_geom_4326_gist_index,  # noqa: F401 -- re-exported, see __all__
     grant_reader_access,  # noqa: F401 -- re-exported, see __all__
     linearize_existing_4326,  # noqa: F401 -- re-exported, see __all__
+    rederive_geom_4326,  # noqa: F401 -- re-exported, see __all__
 )
 from app.processing.ingest.metadata_quality import (
     _score_attribute_completeness,  # noqa: F401 -- re-exported, see __all__
@@ -92,6 +97,10 @@ from app.processing.ingest.metadata_sql import (
 )
 
 __all__ = [
+    "REPAIR_APPLIED",
+    "REPAIR_GENERATED",
+    "REPAIR_NO_GEOMETRY",
+    "Geom4326Repair",
     "_ABSTRACT_TO_CONCRETE_GEOMETRY_TYPE",
     "_BOX3D_RE",
     "_DEGREE_UNIT_SRTEXT_RE",
@@ -139,6 +148,7 @@ __all__ = [
     "grant_reader_access",
     "linearize_existing_4326",
     "promote_z_to_elev",
+    "rederive_geom_4326",
     "refresh_attribute_metadata",
     "rename_reserved_columns",
 ]

--- a/backend/app/processing/ingest/metadata.py
+++ b/backend/app/processing/ingest/metadata.py
@@ -76,10 +76,12 @@ from app.processing.ingest.metadata_projection import (
     REPAIR_GENERATED,  # noqa: F401 -- re-exported, see __all__
     REPAIR_NO_GEOMETRY,  # noqa: F401 -- re-exported, see __all__
     Geom4326Repair,  # noqa: F401 -- re-exported, see __all__
+    Geom4326State,  # noqa: F401 -- re-exported, see __all__
     add_4326_column,  # noqa: F401 -- re-exported, see __all__
     ensure_geom_4326_gist_index,  # noqa: F401 -- re-exported, see __all__
     grant_reader_access,  # noqa: F401 -- re-exported, see __all__
     linearize_existing_4326,  # noqa: F401 -- re-exported, see __all__
+    probe_geom_4326,  # noqa: F401 -- re-exported, see __all__
     rederive_geom_4326,  # noqa: F401 -- re-exported, see __all__
 )
 from app.processing.ingest.metadata_quality import (
@@ -101,6 +103,7 @@ __all__ = [
     "REPAIR_GENERATED",
     "REPAIR_NO_GEOMETRY",
     "Geom4326Repair",
+    "Geom4326State",
     "_ABSTRACT_TO_CONCRETE_GEOMETRY_TYPE",
     "_BOX3D_RE",
     "_DEGREE_UNIT_SRTEXT_RE",
@@ -147,6 +150,7 @@ __all__ = [
     "get_table_srid",
     "grant_reader_access",
     "linearize_existing_4326",
+    "probe_geom_4326",
     "promote_z_to_elev",
     "rederive_geom_4326",
     "refresh_attribute_metadata",

--- a/backend/app/processing/ingest/metadata_projection.py
+++ b/backend/app/processing/ingest/metadata_projection.py
@@ -5,14 +5,38 @@ make a landed table readable by the tile, feature and analysis surfaces.
 ``add_4326_column`` writes the render column (2D and linear, with its GIST
 index); ``linearize_existing_4326`` enforces that same invariant on a column
 the pipeline never wrote, since registration skips ``add_4326_column`` when a
-BYO table already carries one; ``grant_reader_access`` hands the finished
-table to the reader role.
+BYO table already carries one; ``rederive_geom_4326`` re-applies the whole
+invariant to a registered table its owner has written to since (#1738);
+``grant_reader_access`` hands the finished table to the reader role.
 """
+
+from typing import NamedTuple
 
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.processing.ingest.metadata_sql import _qtable
+
+
+def _geom_4326_expr(source_srid: int) -> str:
+    """The expression that derives ``geom_4326`` from ``geom``.
+
+    One definition, because two paths write the column from the source
+    geometry — the registration/ingest write (:func:`add_4326_column`) and the
+    out-of-band repair (:func:`rederive_geom_4326`) — and a drift between them
+    would make a refresh rewrite every row of every table forever while
+    "fixing" nothing.
+
+    fix(#1113 review r16): linearize IN THE SOURCE CRS, then reproject. An
+    arc is defined by its control points, and CRS transforms are nonlinear:
+    transforming the control points first and densifying after traces the
+    arc in the wrong space, so ST_CurveToLine(ST_Transform(...)) yields a
+    materially different shape from the correct
+    ST_Transform(ST_CurveToLine(...)).
+    """
+    if source_srid == 4326:
+        return "ST_Force2D(ST_CurveToLine(ST_SetSRID(geom, 4326)))"
+    return "ST_Force2D(ST_Transform(ST_CurveToLine(geom), 4326))"
 
 
 async def add_4326_column(
@@ -51,17 +75,11 @@ async def add_4326_column(
         )
     )
 
-    # fix(#1113 review r16): linearize IN THE SOURCE CRS, then reproject. An
-    # arc is defined by its control points, and CRS transforms are nonlinear:
-    # transforming the control points first and densifying after traces the
-    # arc in the wrong space, so ST_CurveToLine(ST_Transform(...)) yields a
-    # materially different shape from the correct
-    # ST_Transform(ST_CurveToLine(...)).
-    if source_srid == 4326:
-        rewrite_expr = "ST_Force2D(ST_CurveToLine(ST_SetSRID(geom, 4326)))"
-    else:
-        rewrite_expr = "ST_Force2D(ST_Transform(ST_CurveToLine(geom), 4326))"
-    # codeql[py/sql-injection] fix(#1615): table via _qtable (metadata_sql.py); rewrite_expr is one of the two literals above
+    # The expression itself, and the reason it linearizes before it
+    # reprojects, live on _geom_4326_expr — the repair path writes the same
+    # column and must write it the same way.
+    rewrite_expr = _geom_4326_expr(source_srid)
+    # codeql[py/sql-injection] fix(#1615): table via _qtable (metadata_sql.py); rewrite_expr is one of _geom_4326_expr's two literals
     await session.execute(text(f"UPDATE {tref} SET geom_4326 = {rewrite_expr}"))
 
     await ensure_geom_4326_gist_index(session, table_name, schema=schema)
@@ -75,6 +93,143 @@ async def add_4326_column(
     # (_finalize_ingest at tasks_common.py:821) owns the phase-2 commit
     # boundary so a downstream failure rolls back the ALTER + UPDATE +
     # CREATE INDEX above atomically.
+
+
+REPAIR_APPLIED = "applied"
+REPAIR_NO_GEOMETRY = "no_geometry"
+REPAIR_GENERATED = "generated"
+
+
+class Geom4326Repair(NamedTuple):
+    """What one re-derive pass did to a table, for the run to report.
+
+    ``rows_rewritten`` is the drift signal: a table nobody wrote to since the
+    last pass reports 0, and a repeated non-zero count means the owner's
+    writes keep arriving between refreshes.
+    """
+
+    outcome: str
+    column_added: bool
+    index_added: bool
+    rows_rewritten: int
+
+
+async def rederive_geom_4326(
+    session: AsyncSession,
+    table_name: str,
+    source_srid: int,
+    *,
+    schema: str = "data",
+) -> Geom4326Repair:
+    """Re-apply the geom_4326 invariant to a table written to outside GeoLens.
+
+    fix(#1738): ``geom_4326`` is a plain column, populated once — by
+    :func:`add_4326_column` at registration, and afterwards only by GeoLens's
+    own feature-edit writes. A registered table's owner keeps writing to it
+    directly (registration copies no data and serves from the live relation),
+    and nothing re-derives the column for those writes. An ``UPDATE geom``, a
+    ``DELETE`` plus re-``INSERT``, and ``ogr2ogr -overwrite`` (which drops the
+    table and recreates it without the column, its index, or the reader grant)
+    all leave rows whose render geometry is stale or NULL. Every reader
+    filters on ``geom_4326 && <envelope>`` and ``NULL && anything`` is NULL,
+    so those rows are silently invisible rather than visibly wrong.
+
+    This is that invariant re-applied from OUTSIDE the table, which is what
+    makes it survive ``-overwrite``: the same ADD COLUMN, the same expression
+    and the same index-if-absent registration uses, each idempotent, so a
+    recreated table gets its column and index back rather than needing the
+    dataset deleted and registered again.
+
+    **The UPDATE is scoped to rows whose stored value would actually change**,
+    compared through ``ST_AsBinary`` — that is what keeps a refresh of an
+    untouched table to one sequential scan with no writes and no bloat, which
+    in turn is what makes this safe to run on every refresh rather than behind
+    a separate button. The scope is deliberately NOT ``geom_4326 IS NULL OR
+    ...``: a row whose ``geom`` is NULL has a NULL render geometry that is
+    already correct, and the IS NULL disjunct would rewrite every such row
+    NULL-to-NULL on every pass — a write that changes nothing, and a drift
+    count that lies.
+
+    A STORED GENERATED ``geom_4326`` is skipped for the reason
+    :func:`linearize_existing_4326` skips it: PostgreSQL rejects any
+    non-DEFAULT write to a generated column at parse time, and such a column
+    re-derives itself on every write anyway, so there is nothing to repair.
+
+    A table with no ``geom`` column is skipped too — registration admits
+    non-spatial tables (#1359), and #1737 refuses a spatial table whose
+    geometry lives under another name, so "no geom" here means an attribute
+    table rather than a broken one.
+
+    One benign interaction, recorded because it looks like drift and is not:
+    GeoLens's own feature edits write ``geom_4326`` from the request's GeoJSON
+    and ``geom`` by transforming that into the dataset's SRID
+    (``features/service.py``), so on a projected dataset the stored render
+    value is the original rather than a round trip. The first pass after such
+    an edit normalizes it to ``ST_Transform(geom, 4326)`` — a sub-millimetre
+    change, counted as one drifted row — and then converges, because the next
+    pass compares that expression against itself.
+
+    The caller owns the transaction, the statement deadline and the reader
+    GRANT; this function only touches the column and its index.
+    """
+    tref = _qtable(table_name, schema=schema)
+
+    # One probe for all three questions, and the same pair of column names
+    # registration looks for. ``udt_name`` is checked because a plain column
+    # that happens to be called ``geom`` is not a geometry: Find_SRID would
+    # raise on it, and the UPDATE below would too.
+    probe = (
+        await session.execute(
+            text(
+                "SELECT column_name, udt_name, is_generated "
+                "FROM information_schema.columns "
+                "WHERE table_schema = :schema AND table_name = :table "
+                "  AND column_name IN ('geom', 'geom_4326')"
+            ).bindparams(schema=schema, table=table_name)
+        )
+    ).all()
+    columns = {row.column_name: row for row in probe}
+
+    source = columns.get("geom")
+    if source is None or source.udt_name != "geometry":
+        return Geom4326Repair(REPAIR_NO_GEOMETRY, False, False, 0)
+
+    render = columns.get("geom_4326")
+    if render is not None and render.is_generated == "ALWAYS":
+        return Geom4326Repair(REPAIR_GENERATED, False, False, 0)
+
+    if render is None:
+        # Gated on the probe, NOT left to ``IF NOT EXISTS``: ALTER TABLE takes
+        # ACCESS EXCLUSIVE whether or not it changes anything, and a lock
+        # request that is merely QUEUED already blocks every reader arriving
+        # behind it. Issuing it on the ordinary path — a registered table that
+        # still has its column — would put a brief stop-the-world on somebody
+        # else's table on every refresh. ``IF NOT EXISTS`` stays as the race
+        # guard for a column added between the probe and here.
+        await session.execute(
+            text(
+                # codeql[py/sql-injection] fix(#1738): identifiers validated by _qtable (metadata_sql.py)
+                f"ALTER TABLE {tref} "
+                f"ADD COLUMN IF NOT EXISTS geom_4326 geometry(Geometry, 4326)"
+            )
+        )
+
+    rewrite_expr = _geom_4326_expr(source_srid)
+    result = await session.execute(
+        text(
+            # codeql[py/sql-injection] fix(#1738): table via _qtable (metadata_sql.py); rewrite_expr is one of _geom_4326_expr's two literals
+            f"UPDATE {tref} SET geom_4326 = {rewrite_expr} "
+            f"WHERE ST_AsBinary(geom_4326) IS DISTINCT FROM "
+            f"      ST_AsBinary({rewrite_expr})"
+        )
+    )
+    index_added = await ensure_geom_4326_gist_index(session, table_name, schema=schema)
+    return Geom4326Repair(
+        REPAIR_APPLIED,
+        render is None,
+        index_added,
+        result.rowcount if result.rowcount and result.rowcount > 0 else 0,
+    )
 
 
 async def linearize_existing_4326(
@@ -191,8 +346,13 @@ async def linearize_existing_4326(
 
 async def ensure_geom_4326_gist_index(
     session: AsyncSession, table_name: str, *, schema: str = "data"
-) -> None:
+) -> bool:
     """Create the GIST index on geom_4326 if this table doesn't have one.
+
+    Returns whether an index was created. fix(#1738): the repair path reports
+    what it restored on a table recreated behind GeoLens's back, and "the
+    spatial index was missing" is the part of that report an operator can act
+    on. Every other caller ignores the value.
 
     fix(#448): the previous ``CREATE INDEX IF NOT EXISTS idx_<table>_geom_4326``
     matched by NAME schema-wide, not per-table. On a second re-ingest the
@@ -216,7 +376,7 @@ async def ensure_geom_4326_gist_index(
         ).bindparams(schema=schema, tn=table_name)
     )
     if has_col.first() is None:
-        return
+        return False
 
     has_gist = await session.execute(
         text(
@@ -232,6 +392,8 @@ async def ensure_geom_4326_gist_index(
                 f"CREATE INDEX ON {_qtable(table_name, schema)} USING GIST (geom_4326)"
             )
         )
+        return True
+    return False
 
 
 async def grant_reader_access(

--- a/backend/app/processing/ingest/metadata_projection.py
+++ b/backend/app/processing/ingest/metadata_projection.py
@@ -6,7 +6,8 @@ make a landed table readable by the tile, feature and analysis surfaces.
 index); ``linearize_existing_4326`` enforces that same invariant on a column
 the pipeline never wrote, since registration skips ``add_4326_column`` when a
 BYO table already carries one; ``rederive_geom_4326`` re-applies the whole
-invariant to a registered table its owner has written to since (#1738);
+invariant to a registered table its owner has written to since (#1738), over
+the column state ``probe_geom_4326`` reads;
 ``grant_reader_access`` hands the finished table to the reader role.
 """
 
@@ -100,6 +101,56 @@ REPAIR_NO_GEOMETRY = "no_geometry"
 REPAIR_GENERATED = "generated"
 
 
+class Geom4326State(NamedTuple):
+    """What the two geometry columns look like right now.
+
+    Split out of :func:`rederive_geom_4326` (#1738 round 1) so the caller can
+    decide what to do BEFORE resolving the source SRID. ``get_table_srid``
+    wraps PostGIS ``Find_SRID``, which RAISES for a table with no registered
+    geometry column rather than returning NULL — so a registered non-spatial
+    table (#1359 admits them) reached the repair as an exception, was reported
+    as a failure, and skipped the reader grant that follows it.
+    """
+
+    source_is_geometry: bool
+    has_render: bool
+    render_generated: bool
+
+    @property
+    def rederivable(self) -> bool:
+        """Whether re-deriving the render column is possible at all."""
+        return self.source_is_geometry and not self.render_generated
+
+
+async def probe_geom_4326(
+    session: AsyncSession, table_name: str, *, schema: str = "data"
+) -> Geom4326State:
+    """Read the state of ``geom`` and ``geom_4326`` in one query.
+
+    The same pair of column names registration looks for. ``udt_name`` is
+    checked because a plain column that happens to be called ``geom`` is not a
+    geometry: ``Find_SRID`` would raise on it, and the UPDATE would too.
+    """
+    rows = (
+        await session.execute(
+            text(
+                "SELECT column_name, udt_name, is_generated "
+                "FROM information_schema.columns "
+                "WHERE table_schema = :schema AND table_name = :table "
+                "  AND column_name IN ('geom', 'geom_4326')"
+            ).bindparams(schema=schema, table=table_name)
+        )
+    ).all()
+    columns = {row.column_name: row for row in rows}
+    source = columns.get("geom")
+    render = columns.get("geom_4326")
+    return Geom4326State(
+        source_is_geometry=source is not None and source.udt_name == "geometry",
+        has_render=render is not None,
+        render_generated=render is not None and render.is_generated == "ALWAYS",
+    )
+
+
 class Geom4326Repair(NamedTuple):
     """What one re-derive pass did to a table, for the run to report.
 
@@ -120,6 +171,7 @@ async def rederive_geom_4326(
     source_srid: int,
     *,
     schema: str = "data",
+    state: Geom4326State | None = None,
 ) -> Geom4326Repair:
     """Re-apply the geom_4326 invariant to a table written to outside GeoLens.
 
@@ -174,31 +226,19 @@ async def rederive_geom_4326(
     """
     tref = _qtable(table_name, schema=schema)
 
-    # One probe for all three questions, and the same pair of column names
-    # registration looks for. ``udt_name`` is checked because a plain column
-    # that happens to be called ``geom`` is not a geometry: Find_SRID would
-    # raise on it, and the UPDATE below would too.
-    probe = (
-        await session.execute(
-            text(
-                "SELECT column_name, udt_name, is_generated "
-                "FROM information_schema.columns "
-                "WHERE table_schema = :schema AND table_name = :table "
-                "  AND column_name IN ('geom', 'geom_4326')"
-            ).bindparams(schema=schema, table=table_name)
-        )
-    ).all()
-    columns = {row.column_name: row for row in probe}
+    # ``state`` is accepted rather than always probed because the caller has
+    # to know these answers first anyway: whether to resolve the source SRID
+    # at all depends on them (see Geom4326State). Probed here when absent so
+    # the function still stands on its own.
+    if state is None:
+        state = await probe_geom_4326(session, table_name, schema=schema)
 
-    source = columns.get("geom")
-    if source is None or source.udt_name != "geometry":
+    if not state.source_is_geometry:
         return Geom4326Repair(REPAIR_NO_GEOMETRY, False, False, 0)
-
-    render = columns.get("geom_4326")
-    if render is not None and render.is_generated == "ALWAYS":
+    if state.render_generated:
         return Geom4326Repair(REPAIR_GENERATED, False, False, 0)
 
-    if render is None:
+    if not state.has_render:
         # Gated on the probe, NOT left to ``IF NOT EXISTS``: ALTER TABLE takes
         # ACCESS EXCLUSIVE whether or not it changes anything, and a lock
         # request that is merely QUEUED already blocks every reader arriving
@@ -226,7 +266,7 @@ async def rederive_geom_4326(
     index_added = await ensure_geom_4326_gist_index(session, table_name, schema=schema)
     return Geom4326Repair(
         REPAIR_APPLIED,
-        render is None,
+        not state.has_render,
         index_added,
         result.rowcount if result.rowcount and result.rowcount > 0 else 0,
     )

--- a/backend/app/processing/ingest/service.py
+++ b/backend/app/processing/ingest/service.py
@@ -658,6 +658,14 @@ async def register_existing_table(
     STORED GENERATED ``geom_4326`` columns fall under the same
     contract -- their generation expression must produce linear output.
 
+    fix(#1738): "does not police the table afterward" now means "does not
+    police it continuously". Nothing here changed, and the owner's direct
+    writes still leave ``geom_4326`` stale or NULL -- invisible to tiles,
+    feature reads, extent and analysis, because every reader filters on that
+    column. What picks them up is Refresh: ``refresh_postgis`` re-derives the
+    column before it re-measures, and restores the column, its GiST index and
+    the reader grant when the table was dropped and recreated without them.
+
     fix(#1452): ``managed`` declares that the CALLER created the table it is
     handing over, so deleting the resulting dataset may drop it again. It
     defaults to False because the two register endpoints take a table name

--- a/backend/app/processing/ingest/tasks_common.py
+++ b/backend/app/processing/ingest/tasks_common.py
@@ -2027,6 +2027,44 @@ async def invalidate_tile_cache_for_table(table_name: str) -> None:
         await tile_cache.invalidate_table(table_name)
 
 
+async def bump_tile_cache_version_atomic(
+    session: "AsyncSession", Dataset: Any, dataset_id: uuid.UUID
+) -> int | None:
+    """Roll the ``_v=`` cache-buster from a writer that holds no row lock.
+
+    fix(#1738 round 1): the sibling of ``Dataset.bump_tile_cache_version``,
+    for the one case that helper cannot serve. That helper reads the counter
+    off a loaded instance and writes back an absolute value, which is correct
+    only while the caller holds the datasets row — the way
+    ``refresh_postgis``'s phase 3 does, under the ``FOR UPDATE`` it takes for
+    its superseded guard.
+
+    A writer without that lock cannot use it, and taking the lock would not
+    help: the feature-edit routers (``features/router.py``) bump through a
+    plain read-modify-write and never lock the row, so an absolute write
+    computed from a read they took earlier lands on top of anything committed
+    in between. One side locking does not serialize a race the other side is
+    not playing. ``tile_cache_version = tile_cache_version + 1`` in the
+    database does, because the increment is evaluated against the row as it
+    is at write time.
+
+    Returns the new value, so the caller reports and logs the version it
+    actually published rather than the one it hoped for. Still called in the
+    same transaction as the tile-content change it describes, which is the
+    contract on both spellings.
+    """
+    from sqlalchemy import func as sa_func
+    from sqlalchemy import update as sa_update
+
+    return await session.scalar(
+        sa_update(Dataset)
+        .where(Dataset.id == dataset_id)
+        .values(tile_cache_version=sa_func.coalesce(Dataset.tile_cache_version, 1) + 1)
+        .returning(Dataset.tile_cache_version)
+        .execution_options(synchronize_session=False)
+    )
+
+
 # What PostGIS records in ``geometry_columns.type`` for an untyped column.
 # A specific value ("POLYGON", "MULTILINESTRING", ...) describes what the
 # column will accept; this one describes nothing.

--- a/backend/app/processing/ingest/tasks_postgis_refresh.py
+++ b/backend/app/processing/ingest/tasks_postgis_refresh.py
@@ -60,6 +60,7 @@ from app.platform.refresh.service import (
 )
 from app.processing.ingest.tasks_common import (
     _bind_task_log_context,
+    _current_tenant_role,
     _current_tenant_schema,
     _declared_geometry_type,
     _derived_record_type,
@@ -95,6 +96,59 @@ _ERROR_CODE_MISSING = "source_missing"
 _ERROR_CODE_INACCESSIBLE = "source_inaccessible"
 _ERROR_CODE_GENERIC = "postgis_refresh_failed"
 _ERROR_CODE_SUPERSEDED = "superseded"
+
+# fix(#1738): the repair phase's own statement deadline, in milliseconds.
+#
+# `install_api_statement_timeout` runs in the API process only (`api/main.py`;
+# the docstring on `core/statement_timeout.py` says so explicitly), so a
+# worker statement has NO deadline at all. Every other statement this task
+# issues is a read under a read-only snapshot; the repair below is the one
+# write it makes to a relation GeoLens does not own, and an unbounded UPDATE
+# there holds row locks on somebody else's table for as long as it takes.
+#
+# Five minutes: far longer than the common case (a table nobody wrote to
+# matches no rows, so the statement is one sequential scan), and short enough
+# that a table too large to re-derive inside it gives the deadline back rather
+# than sitting on the owner's locks. The bound is on the whole repair
+# transaction, not just the UPDATE, because the DDL takes an ACCESS EXCLUSIVE
+# lock and waiting for one is exactly as blocking as holding one.
+_REPAIR_STATEMENT_TIMEOUT_MS = 300_000
+
+# fix(#1738): and a much shorter bound on WAITING for a lock, which is a
+# different hazard from holding one.
+#
+# The repair takes ACCESS EXCLUSIVE when it has to add the column back to a
+# recreated table, and a lock request that is merely QUEUED already blocks
+# every reader that arrives behind it. Waiting out the statement deadline for
+# one would therefore stall the owner's own traffic for five minutes to fix a
+# column. Five seconds instead: on a busy table the repair gives its queue
+# position back and reports itself blocked, and the next refresh tries again.
+_REPAIR_LOCK_TIMEOUT_MS = 5_000
+
+# query_canceled — what `statement_timeout` raises. And lock_not_available,
+# what `lock_timeout` raises; they are distinguished because they mean
+# different things to whoever reads the log line: too much data to re-derive
+# inside the deadline, versus somebody else using the table right now.
+_STATEMENT_TIMEOUT_SQLSTATE = "57014"
+_LOCK_TIMEOUT_SQLSTATE = "55P03"
+
+# Coded outcomes for the repair phase, logged on every run. They are NOT run
+# error codes: a failed repair does not fail the refresh (see
+# `_repair_geom_4326`), so none of these ever reaches the run ledger.
+_REPAIR_REPAIRED = "repaired"
+_REPAIR_NOT_APPLICABLE = "not_applicable"
+_REPAIR_TIMED_OUT = "timed_out"
+_REPAIR_BLOCKED = "blocked"
+_REPAIR_FAILED = "failed"
+
+
+class _RepairReport(NamedTuple):
+    """What phase 1.5 did, for the log line and for the tests."""
+
+    code: str
+    rows_rewritten: int = 0
+    column_added: bool = False
+    index_added: bool = False
 
 
 class _Verdict(NamedTuple):
@@ -310,6 +364,150 @@ async def _relation_exists(session: Any, *, schema: str, table: str) -> bool:
     )
 
 
+async def _repair_geom_4326(
+    dataset_uuid: uuid.UUID, Dataset: Any, *, schema: str, role: str
+) -> _RepairReport:
+    """Phase 1.5: re-derive this table's render column before measuring it.
+
+    fix(#1738): ``geom_4326`` is written once, at registration, and never
+    again. The owner of a registered table keeps writing to it — that is the
+    whole premise of registering one — and none of those writes touch the
+    render column every GeoLens reader filters on, so an ``UPDATE geom``, a
+    ``DELETE`` plus re-``INSERT``, or an ``ogr2ogr -overwrite`` leaves rows
+    that are silently invisible in tiles, feature reads, extent and analysis.
+
+    Refresh is the right place for the correction: it is the existing
+    user-facing "make the catalog agree with the table" action, with an
+    admission gate, a run ledger and a history behind it, and it already bumps
+    the tile version and purges the tile cache. It is also the only place the
+    fix can live and still survive ``-overwrite``, because that drops the
+    table: a trigger, a generated column or an index would go with it, and
+    only an invariant re-applied from outside comes back.
+
+    **Before the measurement, in its own session and transaction**, so the
+    measurement in phase 2 measures the repaired table under its own READ ONLY
+    REPEATABLE READ snapshot, and so the tile-version bump below is already
+    committed when phase 2 reads `content_version` — a bump landing after that
+    read would trip phase 3's superseded guard against this task's own write.
+
+    **Bounded twice**, because holding a lock and waiting for one are
+    different hazards on a relation GeoLens does not own — see
+    ``_REPAIR_STATEMENT_TIMEOUT_MS`` and ``_REPAIR_LOCK_TIMEOUT_MS``.
+
+    **Never fatal.** A refresh whose repair could not run still has a
+    measurement to take, and that measurement is what the user asked for; the
+    outcome is returned and logged instead. This is also what keeps the change
+    from adding a failure mode to a strategy that had none: if the repair
+    cannot write, the dataset is left exactly as broken as it already was, not
+    more so.
+    """
+    from app.core.db import async_session
+    from app.processing.ingest.metadata import (
+        REPAIR_APPLIED,
+        get_table_srid,
+        grant_reader_access,
+        rederive_geom_4326,
+    )
+
+    report = _RepairReport(_REPAIR_NOT_APPLICABLE)
+    purge_table: str | None = None
+
+    async with async_session() as session:
+        try:
+            # SET LOCAL, spelled as set_config(..., is_local => true) so the
+            # statement stays static SQL with a bound value — `SET` takes no
+            # parameters, and interpolating the numbers would put a dynamic
+            # text() site in this module for no gain. Both bounds are set
+            # before anything else runs in this transaction, so every
+            # statement below is covered, DDL included.
+            await session.execute(
+                text(
+                    "SELECT set_config('statement_timeout', :ms, true), "
+                    "       set_config('lock_timeout', :lock_ms, true)"
+                ),
+                {
+                    "ms": str(_REPAIR_STATEMENT_TIMEOUT_MS),
+                    "lock_ms": str(_REPAIR_LOCK_TIMEOUT_MS),
+                },
+            )
+            dataset = await session.get(Dataset, dataset_uuid)
+            if dataset is None:
+                return _RepairReport(_REPAIR_NOT_APPLICABLE)
+            try:
+                table_name = _resolve_bound_table(dataset, schema=schema)
+            except PostgisRefreshError:
+                # A binding fault is phase 2's to report, with the message and
+                # the error code it already owns. Repairing nothing here keeps
+                # this phase from changing any existing failure path.
+                return _RepairReport(_REPAIR_NOT_APPLICABLE)
+            if not await _relation_exists(session, schema=schema, table=table_name):
+                # Same: the "missing" verdict belongs to the measurement.
+                return _RepairReport(_REPAIR_NOT_APPLICABLE)
+
+            srid = await get_table_srid(session, table_name, schema=schema)
+            repair = await rederive_geom_4326(
+                session, table_name, srid or 4326, schema=schema
+            )
+            if repair.outcome != REPAIR_APPLIED:
+                await session.rollback()
+                return _RepairReport(_REPAIR_NOT_APPLICABLE)
+
+            # Idempotent, and the other half of what `-overwrite` destroys:
+            # the recreated table carries no GRANT, and a split runtime role
+            # would then read nothing through it.
+            await grant_reader_access(session, table_name, schema=schema, role=role)
+
+            if repair.rows_rewritten:
+                # Gated on rewritten ROWS, not on the column or the index.
+                # Restoring an index changes how a tile is computed and not
+                # what it contains, and a column added to a table with nothing
+                # in it renders the same nothing; a table that had rows and
+                # lost the column has all of them in this count anyway. The
+                # contract on this method is that it is bumped in the same
+                # transaction as a change to tile CONTENT, so anything looser
+                # would bust every cached tile of every registered dataset on
+                # the first refresh after this ships.
+                #
+                # It busts browser and CDN copies through the `_v=` parameter,
+                # which the server-side purge below cannot reach.
+                dataset.bump_tile_cache_version()
+                purge_table = table_name
+            await session.commit()
+            report = _RepairReport(
+                _REPAIR_REPAIRED,
+                repair.rows_rewritten,
+                repair.column_added,
+                repair.index_added,
+            )
+        except Exception as exc:  # broad: the repair is best-effort — see the docstring
+            await session.rollback()
+            codes = set(_chained_sqlstates(exc))
+            if _STATEMENT_TIMEOUT_SQLSTATE in codes:
+                code = _REPAIR_TIMED_OUT
+            elif _LOCK_TIMEOUT_SQLSTATE in codes:
+                code = _REPAIR_BLOCKED
+            else:
+                code = _REPAIR_FAILED
+            logger.warning(
+                "geom_4326 repair did not complete",
+                dataset_id=str(dataset_uuid),
+                repair=code,
+                exc_info=True,
+            )
+            return _RepairReport(code)
+
+    if purge_table is not None:
+        # Outside the transaction, because it is not part of it: the MVT cache
+        # key has no content-version dimension, so cached tiles are served
+        # until they expire and the rows this repair just made visible would
+        # stay invisible behind them. The end-of-run purge repeats this on the
+        # success path; doing it here as well is what makes the repair visible
+        # even when the measurement that follows fails.
+        await invalidate_tile_cache_for_table(purge_table)
+
+    return report
+
+
 class _RecordAs:
     """The record as the measurement implies it, for scoring only.
 
@@ -495,6 +693,27 @@ async def refresh_postgis(
         )
 
         schema = _current_tenant_schema()
+
+        # ----------------------------------------------------------------- #
+        # Phase 1.5: REPAIR the render column, before anything measures it.
+        #
+        # fix(#1738). The one write this task makes to the registered table,
+        # deliberately ahead of the read-only phase below rather than inside
+        # it: that phase declares `postgresql_readonly=True` precisely so a
+        # write from it fails loudly. Non-fatal by design — see
+        # `_repair_geom_4326`.
+        # ----------------------------------------------------------------- #
+        repair = await _repair_geom_4326(
+            dataset_uuid, Dataset, schema=schema, role=_current_tenant_role()
+        )
+        logger.info(
+            "geom_4326 repair phase finished",
+            dataset_id=dataset_id,
+            repair=repair.code,
+            rows_rewritten=repair.rows_rewritten,
+            column_added=repair.column_added,
+            index_added=repair.index_added,
+        )
 
         async with async_session() as session:
             # fix(#1313 review round 4): established on the CONNECTION, before

--- a/backend/app/processing/ingest/tasks_postgis_refresh.py
+++ b/backend/app/processing/ingest/tasks_postgis_refresh.py
@@ -66,6 +66,7 @@ from app.processing.ingest.tasks_common import (
     _derived_record_type,
     _effective_geometry_type,
     _retire_geometry_attribute_row,
+    bump_tile_cache_version_atomic,
     invalidate_tile_cache_for_table,
     stamp_failed_origin_health,
     task_app,
@@ -149,6 +150,10 @@ class _RepairReport(NamedTuple):
     rows_rewritten: int = 0
     column_added: bool = False
     index_added: bool = False
+    # The version the bump actually published, read back from the increment
+    # rather than computed here (fix(#1738 round 1)); None when nothing was
+    # rewritten and so nothing was bumped.
+    tile_cache_version: int | None = None
 
 
 class _Verdict(NamedTuple):
@@ -394,6 +399,13 @@ async def _repair_geom_4326(
     different hazards on a relation GeoLens does not own — see
     ``_REPAIR_STATEMENT_TIMEOUT_MS`` and ``_REPAIR_LOCK_TIMEOUT_MS``.
 
+    **The reader GRANT is re-issued whatever the geometry turned out to be**
+    (fix(#1738 round 1)). It is the third thing ``-overwrite`` destroys, and
+    losing it does not depend on the render column needing a rewrite: a table
+    recreated with a valid STORED GENERATED ``geom_4326``, or one with no
+    geometry at all, needs no re-derive and still cannot be read by
+    ``geolens_reader`` until the grant comes back.
+
     **Never fatal.** A refresh whose repair could not run still has a
     measurement to take, and that measurement is what the user asked for; the
     outcome is returned and logged instead. This is also what keeps the change
@@ -403,9 +415,9 @@ async def _repair_geom_4326(
     """
     from app.core.db import async_session
     from app.processing.ingest.metadata import (
-        REPAIR_APPLIED,
         get_table_srid,
         grant_reader_access,
+        probe_geom_4326,
         rederive_geom_4326,
     )
 
@@ -430,11 +442,21 @@ async def _repair_geom_4326(
                     "lock_ms": str(_REPAIR_LOCK_TIMEOUT_MS),
                 },
             )
-            dataset = await session.get(Dataset, dataset_uuid)
-            if dataset is None:
+            # Columns rather than the ORM instance: the only thing needed off
+            # the row is the binding, and the version bump below is a SQL
+            # increment, so this session never holds a Dataset whose
+            # `tile_cache_version` could go stale under it.
+            binding = (
+                await session.execute(
+                    select(Dataset.origin_ref, Dataset.table_name).where(
+                        Dataset.id == dataset_uuid
+                    )
+                )
+            ).first()
+            if binding is None:
                 return _RepairReport(_REPAIR_NOT_APPLICABLE)
             try:
-                table_name = _resolve_bound_table(dataset, schema=schema)
+                table_name = _resolve_bound_table(binding, schema=schema)
             except PostgisRefreshError:
                 # A binding fault is phase 2's to report, with the message and
                 # the error code it already owns. Repairing nothing here keeps
@@ -444,40 +466,60 @@ async def _repair_geom_4326(
                 # Same: the "missing" verdict belongs to the measurement.
                 return _RepairReport(_REPAIR_NOT_APPLICABLE)
 
-            srid = await get_table_srid(session, table_name, schema=schema)
-            repair = await rederive_geom_4326(
-                session, table_name, srid or 4326, schema=schema
-            )
-            if repair.outcome != REPAIR_APPLIED:
-                await session.rollback()
-                return _RepairReport(_REPAIR_NOT_APPLICABLE)
+            # fix(#1738 round 1): probed BEFORE the SRID is resolved, rather
+            # than inside the re-derive. `get_table_srid` wraps PostGIS
+            # `Find_SRID`, which RAISES rather than returning NULL for a table
+            # with no registered geometry column — so a registered non-spatial
+            # table (#1359 admits them) used to reach this as an exception, be
+            # reported as a repair failure on every refresh, and skip the
+            # grant below.
+            state = await probe_geom_4326(session, table_name, schema=schema)
+            repair = None
+            if state.rederivable:
+                srid = await get_table_srid(session, table_name, schema=schema)
+                repair = await rederive_geom_4326(
+                    session, table_name, srid or 4326, schema=schema, state=state
+                )
 
-            # Idempotent, and the other half of what `-overwrite` destroys:
-            # the recreated table carries no GRANT, and a split runtime role
-            # would then read nothing through it.
+            # fix(#1738 round 1): unconditionally, not only when the render
+            # column was rewritten. The GRANT is the third thing `-overwrite`
+            # destroys, and it is destroyed whatever the recreated table's
+            # geometry looks like — including the two shapes that need no
+            # re-derive at all: a valid STORED GENERATED `geom_4326`, and a
+            # non-spatial table. Gating it on the re-derive let both pass a
+            # refresh while `geolens_reader` still could not read them.
+            # Idempotent, and the same call registration makes.
             await grant_reader_access(session, table_name, schema=schema, role=role)
 
-            if repair.rows_rewritten:
+            tile_version = None
+            if repair is not None and repair.rows_rewritten:
                 # Gated on rewritten ROWS, not on the column or the index.
                 # Restoring an index changes how a tile is computed and not
                 # what it contains, and a column added to a table with nothing
                 # in it renders the same nothing; a table that had rows and
                 # lost the column has all of them in this count anyway. The
-                # contract on this method is that it is bumped in the same
+                # contract on the bump is that it happens in the same
                 # transaction as a change to tile CONTENT, so anything looser
                 # would bust every cached tile of every registered dataset on
                 # the first refresh after this ships.
                 #
-                # It busts browser and CDN copies through the `_v=` parameter,
-                # which the server-side purge below cannot reach.
-                dataset.bump_tile_cache_version()
+                # fix(#1738 round 1): the ATOMIC spelling, because this
+                # transaction holds no lock on the datasets row and the
+                # feature-edit routers write the counter without one either —
+                # see `bump_tile_cache_version_atomic`. It busts browser and
+                # CDN copies through the `_v=` parameter, which the
+                # server-side purge below cannot reach.
+                tile_version = await bump_tile_cache_version_atomic(
+                    session, Dataset, dataset_uuid
+                )
                 purge_table = table_name
             await session.commit()
             report = _RepairReport(
-                _REPAIR_REPAIRED,
-                repair.rows_rewritten,
-                repair.column_added,
-                repair.index_added,
+                _REPAIR_REPAIRED if repair is not None else _REPAIR_NOT_APPLICABLE,
+                repair.rows_rewritten if repair is not None else 0,
+                repair.column_added if repair is not None else False,
+                repair.index_added if repair is not None else False,
+                tile_version,
             )
         except Exception as exc:  # broad: the repair is best-effort — see the docstring
             await session.rollback()
@@ -713,6 +755,7 @@ async def refresh_postgis(
             rows_rewritten=repair.rows_rewritten,
             column_added=repair.column_added,
             index_added=repair.index_added,
+            tile_cache_version=repair.tile_cache_version,
         )
 
         async with async_session() as session:

--- a/backend/app/processing/ingest/tasks_postgis_refresh.py
+++ b/backend/app/processing/ingest/tasks_postgis_refresh.py
@@ -136,6 +136,11 @@ _LOCK_TIMEOUT_SQLSTATE = "55P03"
 # Coded outcomes for the repair phase, logged on every run. They are NOT run
 # error codes: a failed repair does not fail the refresh (see
 # `_repair_geom_4326`), so none of these ever reaches the run ledger.
+#
+# They describe the RENDER COLUMN only. The reader grant and the GiST index
+# are restored on every outcome where the table is there and the column
+# exists, so `not_applicable` still means work may have been done — read
+# `index_added` on the report for that half (fix(#1738 rounds 1 and 2)).
 _REPAIR_REPAIRED = "repaired"
 _REPAIR_NOT_APPLICABLE = "not_applicable"
 _REPAIR_TIMED_OUT = "timed_out"
@@ -399,12 +404,13 @@ async def _repair_geom_4326(
     different hazards on a relation GeoLens does not own — see
     ``_REPAIR_STATEMENT_TIMEOUT_MS`` and ``_REPAIR_LOCK_TIMEOUT_MS``.
 
-    **The reader GRANT is re-issued whatever the geometry turned out to be**
-    (fix(#1738 round 1)). It is the third thing ``-overwrite`` destroys, and
-    losing it does not depend on the render column needing a rewrite: a table
-    recreated with a valid STORED GENERATED ``geom_4326``, or one with no
-    geometry at all, needs no re-derive and still cannot be read by
-    ``geolens_reader`` until the grant comes back.
+    **The reader GRANT and the GiST index are restored whatever the geometry
+    turned out to be** (fix(#1738 rounds 1 and 2)). They are the other two
+    things ``-overwrite`` destroys, and losing them does not depend on the
+    render column needing a rewrite: a table recreated with a valid STORED
+    GENERATED ``geom_4326`` needs no re-derive, and without these two it is
+    unreadable by ``geolens_reader`` and sequentially scanned by every bbox
+    predicate the readers issue.
 
     **Never fatal.** A refresh whose repair could not run still has a
     measurement to take, and that measurement is what the user asked for; the
@@ -415,6 +421,7 @@ async def _repair_geom_4326(
     """
     from app.core.db import async_session
     from app.processing.ingest.metadata import (
+        ensure_geom_4326_gist_index,
         get_table_srid,
         grant_reader_access,
         probe_geom_4326,
@@ -481,6 +488,23 @@ async def _repair_geom_4326(
                     session, table_name, srid or 4326, schema=schema, state=state
                 )
 
+            # fix(#1738 round 2): the index, on the same rule as the grant
+            # below — every outcome where the column EXISTS, not only the one
+            # where it had to be rewritten. `rederive_geom_4326` was the only
+            # caller of the index helper, so an overwrite that recreated the
+            # table with a valid STORED GENERATED `geom_4326` (nothing to
+            # re-derive) left the dataset with no GiST index at all, and every
+            # bbox predicate the readers issue — `geom_4326 && <envelope>` —
+            # fell back to a sequential scan on a table GeoLens does not own.
+            if repair is not None:
+                index_added = repair.index_added
+            elif state.has_render:
+                index_added = await ensure_geom_4326_gist_index(
+                    session, table_name, schema=schema
+                )
+            else:
+                index_added = False
+
             # fix(#1738 round 1): unconditionally, not only when the render
             # column was rewritten. The GRANT is the third thing `-overwrite`
             # destroys, and it is destroyed whatever the recreated table's
@@ -518,7 +542,7 @@ async def _repair_geom_4326(
                 _REPAIR_REPAIRED if repair is not None else _REPAIR_NOT_APPLICABLE,
                 repair.rows_rewritten if repair is not None else 0,
                 repair.column_added if repair is not None else False,
-                repair.index_added if repair is not None else False,
+                index_added,
                 tile_version,
             )
         except Exception as exc:  # broad: the repair is best-effort — see the docstring

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -220,6 +220,7 @@ _TENANCY_GLOBAL_STATE_MODULES = {
     "test_analysis_materialize",  # register_existing_table → grant_reader_access
     "test_registered_delete_detach_1452",  # same: registers real tables
     "test_register_geom_column_name_1737",  # same: its accept-case registers
+    "test_registered_geom_4326_rederive_1738",  # same: registers, and REVOKEs
     "test_embed_tokens",
     "test_features_crud",
     "test_features_geojson_z",

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -2798,7 +2798,10 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # fix(#1738): +10 — the re-exports the repair path resolves against
     # (rederive_geom_4326, the Geom4326Repair it returns, and its three
     # outcome constants) plus their __all__ entries. Cap 144 -> 154, exact.
-    "backend/app/processing/ingest/metadata.py": 154,
+    # fix(#1738 round 1): +4 — probe_geom_4326 and the Geom4326State it
+    # returns, split out so the caller can tell a non-spatial table from a
+    # repairable one BEFORE resolving the SRID. Cap 154 -> 158, exact.
+    "backend/app/processing/ingest/metadata.py": 158,
     # ingest/router.py is also scanned by the router-glob gate; this exact
     # ratchet overrides its 1500 default so the remaining runway to the cliff
     # cannot be spent silently.
@@ -3293,7 +3296,13 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # the docstring stating why `NO KEY UPDATE` over plain `UPDATE`, and
     # pointing at the sweep-side fixes that now have to contend with this
     # lock instead of racing past it. Cap 2470 -> 2495, exact.
-    "backend/app/processing/ingest/tasks_common.py": 2495,
+    # fix(#1738 round 1): +38 — bump_tile_cache_version_atomic, the sibling of
+    # Dataset.bump_tile_cache_version for a writer that holds no row lock.
+    # Most of it is the docstring arguing why the lock is not the fix: the
+    # feature-edit routers roll the counter through a plain read-modify-write
+    # and never take one, so one side locking does not serialize a race the
+    # other side is not playing. Cap 2495 -> 2533, exact.
+    "backend/app/processing/ingest/tasks_common.py": 2533,
     # --- entered by the inclusion rule, feat(#1219 x #1222) ---------------
     # tasks_reupload crossed 1000 when two independently-reviewed features
     # met in one file: #1222's failed-contact bookkeeping (spawn-armed
@@ -4531,7 +4540,18 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # and the first version of this phase sat on that queue for the full five
     # minutes in a test. `_REPAIR_LOCK_TIMEOUT_MS` gives the position back
     # after five seconds instead. Cap 842 -> 1061, exact.
-    "backend/app/processing/ingest/tasks_postgis_refresh.py": 1061,
+    # fix(#1738 round 1): +43 for two review findings and the defect the first
+    # of them uncovered. The reader GRANT is now re-issued whatever the
+    # geometry turned out to be — it is the third thing -overwrite destroys
+    # and losing it does not depend on the render column needing a rewrite, so
+    # gating it on the re-derive let a recreated table with a generated
+    # geom_4326 pass a refresh unreadable. Probing the columns before
+    # resolving the SRID is what that exposed: Find_SRID RAISES for a table
+    # with no geometry, so every refresh of a registered non-spatial dataset
+    # was a logged repair failure that also skipped the grant. And the version
+    # bump moved to the atomic helper, because this transaction holds no row
+    # lock. Cap 1061 -> 1104, exact.
+    "backend/app/processing/ingest/tasks_postgis_refresh.py": 1104,
     # --- entered by the inclusion rule, feat(#765) -------------------------
     # First time this module crosses 1000. main sat at 994, six lines under the
     # gate, so it was going to fire on whoever added next; it fired here.

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -2795,7 +2795,10 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # threshold, so none needs an entry here yet. What is left below is the
     # re-export façade every existing importer and mock.patch target resolves
     # against. Cap 2151 -> 144, exact.
-    "backend/app/processing/ingest/metadata.py": 144,
+    # fix(#1738): +10 — the re-exports the repair path resolves against
+    # (rederive_geom_4326, the Geom4326Repair it returns, and its three
+    # outcome constants) plus their __all__ entries. Cap 144 -> 154, exact.
+    "backend/app/processing/ingest/metadata.py": 154,
     # ingest/router.py is also scanned by the router-glob gate; this exact
     # ratchet overrides its 1500 default so the remaining runway to the cliff
     # cannot be spent silently.
@@ -4501,7 +4504,34 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # and turn one layer's failure into a 500. The parent is reloaded in the
     # same breath, and the log line reads a snapshotted id rather than the
     # instance it just expired. Cap 1500 -> 1513, exact.
-    "backend/app/processing/ingest/service.py": 1513,
+    # fix(#1738): +8 of docstring, no code. register_existing_table's stated
+    # contract was "linearize once, do not police the table afterward", which
+    # a reader could take as "the owner's writes are picked up somehow". They
+    # are not: they are picked up by Refresh, which now re-derives geom_4326.
+    # The paragraph says which writes go stale and what recovers them, so the
+    # next reader does not have to find that out from a broken dataset.
+    # Cap 1513 -> 1521, exact.
+    "backend/app/processing/ingest/service.py": 1521,
+    # fix(#1738): first entry, crossed _RATCHET_INCLUSION_LOC (842 -> 1019) on
+    # the change that gave this task a repair phase. What the growth bought:
+    # `geom_4326` on a registered table was written once, at registration, and
+    # never re-derived, so an `UPDATE geom`, a DELETE+INSERT reload, or an
+    # `ogr2ogr -overwrite` left rows that every reader filters out — silently
+    # invisible, because `NULL && <envelope>` is NULL. Phase 1.5 re-applies
+    # the invariant from outside the table, which is the only shape that
+    # survives -overwrite dropping it. Most of the added lines are the
+    # docstring and the constant comments carrying the two properties a later
+    # reader would otherwise simplify away: the phase runs BEFORE the
+    # read-only measurement (which declares postgresql_readonly=True precisely
+    # so a write from it fails), and it installs its own statement deadline
+    # because `install_api_statement_timeout` is an API-process concern and a
+    # worker UPDATE on a customer's relation would otherwise be unbounded.
+    # The second bound is the one measurement forced: ADD COLUMN takes ACCESS
+    # EXCLUSIVE, a QUEUED lock request already blocks every reader behind it,
+    # and the first version of this phase sat on that queue for the full five
+    # minutes in a test. `_REPAIR_LOCK_TIMEOUT_MS` gives the position back
+    # after five seconds instead. Cap 842 -> 1061, exact.
+    "backend/app/processing/ingest/tasks_postgis_refresh.py": 1061,
     # --- entered by the inclusion rule, feat(#765) -------------------------
     # First time this module crosses 1000. main sat at 994, six lines under the
     # gate, so it was going to fire on whoever added next; it fired here.

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -4551,7 +4551,14 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # was a logged repair failure that also skipped the grant. And the version
     # bump moved to the atomic helper, because this transaction holds no row
     # lock. Cap 1061 -> 1104, exact.
-    "backend/app/processing/ingest/tasks_postgis_refresh.py": 1104,
+    # fix(#1738 round 2): +24 — the GiST index restore moves onto the same
+    # rule as the grant: every outcome where the column exists, not only the
+    # one where it had to be rewritten. `rederive_geom_4326` was the only
+    # caller of the index helper, so an overwrite that recreated the table
+    # with a valid STORED GENERATED `geom_4326` left the dataset with no
+    # spatial index and every `geom_4326 && <envelope>` predicate the readers
+    # issue fell back to a sequential scan. Cap 1104 -> 1128, exact.
+    "backend/app/processing/ingest/tasks_postgis_refresh.py": 1128,
     # --- entered by the inclusion rule, feat(#765) -------------------------
     # First time this module crosses 1000. main sat at 994, six lines under the
     # gate, so it was going to fire on whoever added next; it fired here.

--- a/backend/tests/test_registered_geom_4326_rederive_1738.py
+++ b/backend/tests/test_registered_geom_4326_rederive_1738.py
@@ -1,0 +1,699 @@
+"""fix(#1738): out-of-band writes to a registered table have to become visible.
+
+Registering an existing table copies no data: the catalog points at the live
+relation and every read is served from it. ``geom_4326`` is the exception —
+it is a plain column that ``register_existing_table`` populates ONCE, and
+nothing re-derives it afterwards. So the owner's own writes, which are the
+entire reason to register a table rather than upload one, land in ``geom``
+and are never rendered:
+
+* ``UPDATE ... SET geom = ...`` moves a feature that keeps drawing in its old
+  place;
+* ``DELETE`` + ``INSERT`` (an ETL's ordinary reload) lands rows with a NULL
+  render geometry;
+* ``ogr2ogr -overwrite`` drops the table and recreates it with no
+  ``geom_4326`` column, no GiST index and no reader grant at all.
+
+None of these is visibly wrong, which is what makes the bug expensive: every
+reader filters on ``geom_4326 && <envelope>``, and ``NULL && anything`` is
+NULL, so an affected row is silently absent from tiles, feature reads, the
+extent and analysis rather than drawn in the wrong place.
+
+The assertions below are therefore about what the REAL readers return —
+``processing.tiles.service.get_tile`` (the MVT the browser gets) and
+``catalog.features.service.get_features`` (the bbox-filtered feature read) —
+before and after a refresh. Asserting on the column itself would prove the
+UPDATE ran and nothing about whether the dataset renders.
+
+Every test registers a real table through ``register_existing_table``, so
+this module joins ``_TENANCY_GLOBAL_STATE_MODULES`` in ``conftest``:
+``grant_reader_access`` mutates cluster-global GRANTs and the file otherwise
+flakes under ``-n 4``.
+"""
+
+from __future__ import annotations
+
+import math
+import time
+import uuid
+from contextlib import asynccontextmanager
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import select, text
+from sqlalchemy.orm import joinedload
+
+from app.modules.catalog.datasets.api import router_refresh
+from app.modules.catalog.datasets.domain.models import Dataset
+from app.modules.catalog.features.service import get_features
+from app.platform.jobs.models import IngestJob
+from app.platform.refresh.models import DatasetRefreshRun
+from app.processing.ingest import tasks_postgis_refresh
+from app.processing.ingest.tasks_postgis_refresh import refresh_postgis
+from tests.factories import get_user_id
+
+pytestmark = [
+    pytest.mark.anyio,
+    pytest.mark.usefixtures("_init_tile_pool_for_tests"),
+]
+
+# Two places far enough apart to sit in different tiles at z6 and in disjoint
+# bboxes: lower Manhattan and central Paris.
+_HERE = (-73.98, 40.75)
+_THERE = (2.35, 48.86)
+_ZOOM = 6
+
+
+def _bbox(lon: float, lat: float) -> list[float]:
+    """A small envelope around one point, for the feature bbox filter."""
+    return [lon - 0.05, lat - 0.05, lon + 0.05, lat + 0.05]
+
+
+def _tile_xy(lon: float, lat: float, z: int) -> tuple[int, int]:
+    """The slippy-map tile containing a point — the same arithmetic MapLibre does."""
+    n = 2**z
+    x = int((lon + 180.0) / 360.0 * n)
+    y = int((1.0 - math.asinh(math.tan(math.radians(lat))) / math.pi) / 2.0 * n)
+    return x, y
+
+
+# ---------------------------------------------------------------------------
+# Fixtures and helpers
+# ---------------------------------------------------------------------------
+
+
+async def _create_source_table(session, table_name: str, *, lon: float, lat: float):
+    """A table exactly as an owner would leave it: `geom`, and no `geom_4326`.
+
+    This is what registration is handed. The render column, its index and the
+    reader grant are all things GeoLens adds on the way in.
+    """
+    await session.execute(
+        text(
+            f'CREATE TABLE data."{table_name}" ('
+            f"  gid serial PRIMARY KEY,"
+            f"  name text,"
+            f"  geom geometry(Point, 4326)"
+            f")"
+        )
+    )
+    await session.execute(
+        text(
+            f'INSERT INTO data."{table_name}" (name, geom) '  # noqa: S608
+            f"VALUES ('a', ST_SetSRID(ST_MakePoint(:lon, :lat), 4326))"
+        ),
+        {"lon": lon, "lat": lat},
+    )
+    await session.commit()
+
+
+async def _register(session, table_name: str, admin_id: uuid.UUID):
+    """Register the table through the real service, and commit.
+
+    Returns the three plain values the tests need rather than the ORM
+    instance: every commit and rollback below expires it, and reading an
+    expired attribute outside the greenlet raises MissingGreenlet rather than
+    lazily loading.
+    """
+    from app.processing.ingest.schemas import RegisterRequest
+    from app.processing.ingest.service import register_existing_table
+
+    dataset = await register_existing_table(
+        session,
+        RegisterRequest(table_name=table_name, title=f"Registered {table_name}"),
+        SimpleNamespace(id=admin_id),
+    )
+    await session.commit()
+    await session.refresh(dataset)
+    return SimpleNamespace(
+        id=dataset.id,
+        record_id=dataset.record_id,
+        column_info=dataset.column_info,
+    )
+
+
+async def _drop(session, table_name: str) -> None:
+    await session.rollback()
+    await session.execute(text(f'DROP TABLE IF EXISTS data."{table_name}" CASCADE'))
+    await session.commit()
+
+
+@asynccontextmanager
+async def _dispatch_harness():
+    """Patch the deferred task so the door queues nothing real."""
+    task = MagicMock()
+    task.defer_async = AsyncMock(return_value=None)
+    port = MagicMock()
+    port.refresh_postgis_task.return_value = task
+    with patch.object(router_refresh, "get_catalog_port", return_value=port):
+        yield task
+
+
+async def _refresh(session, client: AsyncClient, headers: dict, dataset_id: uuid.UUID):
+    """Dispatch through the real door and run the worker, as the queue would.
+
+    ``.func`` is the Procrastinate-registered callable, so the admission gate,
+    the run ledger, the heartbeat and the failure handler all run for real.
+
+    The test session is closed out first. It is a SECOND connection to the
+    same table, and a SELECT through it leaves an ACCESS SHARE lock held for
+    the rest of its transaction — which the worker's ADD COLUMN would then
+    queue behind until its lock timeout, reporting the repair blocked. That
+    is correct behaviour (see the blocked test below) and an artefact of the
+    harness rather than of the scenario under test.
+    """
+    await session.rollback()
+
+    async with _dispatch_harness():
+        resp = await client.post(f"/datasets/{dataset_id}/refresh", headers=headers)
+    assert resp.status_code == 202, resp.text
+    payload = resp.json()
+
+    job = (
+        await session.execute(
+            select(IngestJob).where(IngestJob.id == uuid.UUID(payload["job_id"]))
+        )
+    ).scalar_one()
+    await refresh_postgis.func(
+        job_id=payload["job_id"],
+        dataset_id=payload["dataset_id"],
+        attempt_id=str(job.attempt_id),
+    )
+    return payload
+
+
+async def _reload(session, dataset_id: uuid.UUID) -> Dataset:
+    session.expire_all()
+    return (
+        await session.execute(
+            select(Dataset)
+            .options(joinedload(Dataset.record))
+            .where(Dataset.id == dataset_id)
+        )
+    ).scalar_one()
+
+
+async def _features_at(session, table_name: str, point: tuple[float, float]) -> int:
+    """How many features the REAL feature read returns in a bbox around a point."""
+    await session.rollback()
+    page = await get_features(
+        session,
+        table_name,
+        limit=50,
+        bbox=_bbox(*point),
+        has_geometry=True,
+    )
+    return len(page.rows)
+
+
+async def _tile_at(
+    table_name: str, point: tuple[float, float], columns
+) -> bytes | None:
+    """The MVT the tile endpoint would serve for the tile containing a point."""
+    from app.processing.tiles.pool import get_tile_pool
+    from app.processing.tiles.service import get_tile
+
+    x, y = _tile_xy(*point, _ZOOM)
+    return await get_tile(get_tile_pool(), table_name, _ZOOM, x, y, columns or [])
+
+
+async def _column_exists(session, table_name: str, column: str) -> bool:
+    await session.rollback()
+    return bool(
+        await session.scalar(
+            text(
+                "SELECT EXISTS (SELECT 1 FROM information_schema.columns "
+                "WHERE table_schema = 'data' AND table_name = :t "
+                "AND column_name = :c)"
+            ),
+            {"t": table_name, "c": column},
+        )
+    )
+
+
+async def _has_gist_index(session, table_name: str) -> bool:
+    await session.rollback()
+    return bool(
+        await session.scalar(
+            text(
+                "SELECT EXISTS (SELECT 1 FROM pg_indexes "
+                "WHERE schemaname = 'data' AND tablename = :t "
+                "AND indexdef LIKE '%USING gist (geom_4326)%')"
+            ),
+            {"t": table_name},
+        )
+    )
+
+
+async def _reader_can_select(session, table_name: str) -> bool:
+    await session.rollback()
+    return bool(
+        await session.scalar(
+            text(
+                "SELECT has_table_privilege('geolens_reader', "
+                "format('%I.%I', 'data', CAST(:t AS text)), 'SELECT')"
+            ),
+            {"t": table_name},
+        )
+    )
+
+
+# ---------------------------------------------------------------------------
+# The load-bearing case: an out-of-band write is invisible until Refresh
+# ---------------------------------------------------------------------------
+
+
+async def test_an_out_of_band_geometry_update_renders_only_after_refresh(
+    client: AsyncClient, admin_auth_header: dict, test_db_session
+) -> None:
+    """`UPDATE ... SET geom` moves the feature; nothing moves the render column.
+
+    Both readers are asserted at BOTH locations, before and after, because a
+    one-sided assertion cannot tell "the refresh fixed it" from "the reader
+    never filtered on geometry in the first place".
+    """
+    admin_id = await get_user_id(test_db_session, "admin")
+    table_name = f"rd_upd_{uuid.uuid4().hex[:10]}"
+    await _create_source_table(test_db_session, table_name, lon=_HERE[0], lat=_HERE[1])
+
+    try:
+        dataset = await _register(test_db_session, table_name, admin_id)
+        columns = dataset.column_info
+
+        # The owner moves the feature, touching only their own column.
+        await test_db_session.execute(
+            text(
+                f'UPDATE data."{table_name}" '  # noqa: S608
+                f"SET geom = ST_SetSRID(ST_MakePoint(:lon, :lat), 4326)"
+            ),
+            {"lon": _THERE[0], "lat": _THERE[1]},
+        )
+        await test_db_session.commit()
+
+        # The bug: every reader still shows the OLD position.
+        assert await _features_at(test_db_session, table_name, _HERE) == 1
+        assert await _features_at(test_db_session, table_name, _THERE) == 0
+        assert await _tile_at(table_name, _HERE, columns) is not None
+        assert await _tile_at(table_name, _THERE, columns) is None
+
+        await _refresh(test_db_session, client, admin_auth_header, dataset.id)
+
+        assert await _features_at(test_db_session, table_name, _HERE) == 0
+        assert await _features_at(test_db_session, table_name, _THERE) == 1
+        assert await _tile_at(table_name, _HERE, columns) is None
+        assert await _tile_at(table_name, _THERE, columns) is not None
+    finally:
+        await _drop(test_db_session, table_name)
+
+
+async def test_a_delete_and_reinsert_reload_renders_only_after_refresh(
+    client: AsyncClient, admin_auth_header: dict, test_db_session
+) -> None:
+    """An ETL's ordinary reload lands rows whose render geometry is NULL.
+
+    ``NULL && <envelope>`` is NULL, so the new rows are absent rather than
+    misplaced — the dataset looks EMPTY while the table is full. The stored
+    extent is asserted too: it is what spatial search and the map's initial
+    viewport read, and it has to move with the data.
+    """
+    admin_id = await get_user_id(test_db_session, "admin")
+    table_name = f"rd_del_{uuid.uuid4().hex[:10]}"
+    await _create_source_table(test_db_session, table_name, lon=_HERE[0], lat=_HERE[1])
+
+    try:
+        dataset = await _register(test_db_session, table_name, admin_id)
+        columns = dataset.column_info
+
+        await test_db_session.execute(text(f'DELETE FROM data."{table_name}"'))  # noqa: S608
+        await test_db_session.execute(
+            text(
+                f'INSERT INTO data."{table_name}" (name, geom) '  # noqa: S608
+                f"SELECT 'reloaded-' || i, "
+                f"       ST_SetSRID(ST_MakePoint(:lon, :lat), 4326) "
+                f"FROM generate_series(1, 3) AS i"
+            ),
+            {"lon": _THERE[0], "lat": _THERE[1]},
+        )
+        await test_db_session.commit()
+
+        assert await _features_at(test_db_session, table_name, _THERE) == 0
+        assert await _tile_at(table_name, _THERE, columns) is None
+
+        await _refresh(test_db_session, client, admin_auth_header, dataset.id)
+
+        assert await _features_at(test_db_session, table_name, _THERE) == 3
+        assert await _tile_at(table_name, _THERE, columns) is not None
+
+        reloaded = await _reload(test_db_session, dataset.id)
+        assert reloaded.feature_count == 3
+        # The extent is stored as a 4326 polygon; it has to contain the new
+        # position and not the old one.
+        assert await test_db_session.scalar(
+            text(
+                "SELECT ST_Intersects(spatial_extent, "
+                "  ST_SetSRID(ST_MakePoint(:lon, :lat), 4326)) "
+                "FROM catalog.records WHERE id = :rid"
+            ),
+            {"lon": _THERE[0], "lat": _THERE[1], "rid": reloaded.record_id},
+        )
+    finally:
+        await _drop(test_db_session, table_name)
+
+
+async def test_an_overwrite_restores_the_column_the_index_and_the_grant(
+    client: AsyncClient, admin_auth_header: dict, test_db_session
+) -> None:
+    """`ogr2ogr -overwrite` drops the table; the repair has to rebuild it.
+
+    This is the case that decided the design: nothing IN the table survives a
+    DROP, so a trigger, a generated column or an index would all be gone with
+    it. Only an invariant re-applied from outside — the same ADD COLUMN,
+    expression, index-if-absent and GRANT registration uses — brings the
+    dataset back without deleting it and registering it again, which would
+    cost its id, its permalinks and its saved maps.
+    """
+    admin_id = await get_user_id(test_db_session, "admin")
+    table_name = f"rd_ovr_{uuid.uuid4().hex[:10]}"
+    await _create_source_table(test_db_session, table_name, lon=_HERE[0], lat=_HERE[1])
+
+    try:
+        dataset = await _register(test_db_session, table_name, admin_id)
+        columns = dataset.column_info
+        assert await _column_exists(test_db_session, table_name, "geom_4326")
+
+        # -overwrite, simulated exactly: same name, source column only.
+        await test_db_session.execute(text(f'DROP TABLE data."{table_name}" CASCADE'))
+        await test_db_session.execute(
+            text(
+                f'CREATE TABLE data."{table_name}" ('
+                f"  gid serial PRIMARY KEY, name text, "
+                f"  geom geometry(Point, 4326))"
+            )
+        )
+        await test_db_session.execute(
+            text(
+                f'INSERT INTO data."{table_name}" (name, geom) '  # noqa: S608
+                f"VALUES ('rewritten', ST_SetSRID(ST_MakePoint(:lon, :lat), 4326))"
+            ),
+            {"lon": _THERE[0], "lat": _THERE[1]},
+        )
+        # ogr2ogr's new table carries no grant of ours. Revoked explicitly so
+        # the assertion does not depend on this cluster's default privileges.
+        await test_db_session.execute(
+            text(f'REVOKE ALL ON data."{table_name}" FROM geolens_reader')
+        )
+        await test_db_session.commit()
+
+        assert not await _column_exists(test_db_session, table_name, "geom_4326")
+        assert not await _has_gist_index(test_db_session, table_name)
+        assert not await _reader_can_select(test_db_session, table_name)
+
+        await _refresh(test_db_session, client, admin_auth_header, dataset.id)
+
+        assert await _column_exists(test_db_session, table_name, "geom_4326")
+        assert await _has_gist_index(test_db_session, table_name)
+        assert await _reader_can_select(test_db_session, table_name)
+        assert await _features_at(test_db_session, table_name, _THERE) == 1
+        assert await _tile_at(table_name, _THERE, columns) is not None
+    finally:
+        await _drop(test_db_session, table_name)
+
+
+# ---------------------------------------------------------------------------
+# Cost: the scan is unconditional, the writes are not
+# ---------------------------------------------------------------------------
+
+
+async def test_a_refresh_that_finds_no_drift_rewrites_no_rows(
+    client: AsyncClient, admin_auth_header: dict, test_db_session
+) -> None:
+    """Idempotence, which is what makes this safe to run on every refresh.
+
+    The UPDATE is scoped to rows whose stored value would actually change, so
+    a table nobody wrote to costs one sequential scan and no writes — no
+    bloat, no autovacuum debt, and a re-derive count an operator can read as
+    a drift signal rather than as noise.
+    """
+    admin_id = await get_user_id(test_db_session, "admin")
+    table_name = f"rd_idem_{uuid.uuid4().hex[:10]}"
+    await _create_source_table(test_db_session, table_name, lon=_HERE[0], lat=_HERE[1])
+
+    try:
+        dataset = await _register(test_db_session, table_name, admin_id)
+        await test_db_session.commit()
+
+        # Registration has just written the column with the same expression,
+        # so even the FIRST repair has nothing to do.
+        first = await tasks_postgis_refresh._repair_geom_4326(
+            dataset.id, Dataset, schema="data", role="geolens_reader"
+        )
+        assert first.code == tasks_postgis_refresh._REPAIR_REPAIRED
+        assert (first.rows_rewritten, first.column_added, first.index_added) == (
+            0,
+            False,
+            False,
+        )
+
+        await _refresh(test_db_session, client, admin_auth_header, dataset.id)
+
+        second = await tasks_postgis_refresh._repair_geom_4326(
+            dataset.id, Dataset, schema="data", role="geolens_reader"
+        )
+        assert second.code == tasks_postgis_refresh._REPAIR_REPAIRED
+        assert second.rows_rewritten == 0
+    finally:
+        await _drop(test_db_session, table_name)
+
+
+async def test_only_the_rows_that_moved_are_rewritten(
+    test_db_session,
+) -> None:
+    """A bulk out-of-band reload rewrites exactly its own rows, and no more.
+
+    The size is the point: this is the fixture the repair's cost was measured
+    on, and it pins that the count reported back is the number of rows that
+    actually changed rather than the table's size.
+    """
+    admin_id = await get_user_id(test_db_session, "admin")
+    table_name = f"rd_bulk_{uuid.uuid4().hex[:10]}"
+    await _create_source_table(test_db_session, table_name, lon=_HERE[0], lat=_HERE[1])
+
+    try:
+        dataset = await _register(test_db_session, table_name, admin_id)
+
+        await test_db_session.execute(
+            text(
+                f'INSERT INTO data."{table_name}" (name, geom) '  # noqa: S608
+                f"SELECT 'bulk-' || i, ST_SetSRID(ST_MakePoint("
+                f"  :lon + mod(i, 100) * 0.001, :lat + (i / 100) * 0.001), 4326) "
+                f"FROM generate_series(1, 5000) AS i"
+            ),
+            {"lon": _THERE[0], "lat": _THERE[1]},
+        )
+        await test_db_session.commit()
+
+        started = time.perf_counter()
+        report = await tasks_postgis_refresh._repair_geom_4326(
+            dataset.id, Dataset, schema="data", role="geolens_reader"
+        )
+        elapsed = time.perf_counter() - started
+        print(f"\n#1738 repair of 5000 drifted rows took {elapsed:.3f}s")
+
+        assert report.code == tasks_postgis_refresh._REPAIR_REPAIRED
+        # The one pre-existing row was already correct.
+        assert report.rows_rewritten == 5000
+
+        again = await tasks_postgis_refresh._repair_geom_4326(
+            dataset.id, Dataset, schema="data", role="geolens_reader"
+        )
+        assert again.rows_rewritten == 0
+    finally:
+        await _drop(test_db_session, table_name)
+
+
+# ---------------------------------------------------------------------------
+# The deadline, and what happens when it fires
+# ---------------------------------------------------------------------------
+
+
+async def test_the_repair_runs_under_a_statement_deadline_and_gives_up_quietly(
+    client: AsyncClient, admin_auth_header: dict, test_db_session, monkeypatch
+) -> None:
+    """The worker has no statement timeout, so the repair installs its own.
+
+    ``install_api_statement_timeout`` is an API-process concern, so a worker
+    UPDATE on a relation GeoLens does not own would otherwise hold locks on
+    somebody else's table indefinitely. When the deadline fires the refresh
+    must still do the job it was asked to do — re-measure — and report the
+    repair as incomplete, rather than turning a metadata recount into a new
+    way for this strategy to fail.
+
+    The deadline is proven by making the repair sleep past it, which is also
+    what proves ``SET LOCAL`` reached the session that runs the repair: with
+    no deadline installed the sleep simply succeeds.
+    """
+    admin_id = await get_user_id(test_db_session, "admin")
+    table_name = f"rd_slow_{uuid.uuid4().hex[:10]}"
+    await _create_source_table(test_db_session, table_name, lon=_HERE[0], lat=_HERE[1])
+
+    async def _sleepy_rederive(session, *args, **kwargs):
+        await session.execute(text("SELECT pg_sleep(5)"))
+        raise AssertionError("the statement deadline should have fired")
+
+    try:
+        dataset = await _register(test_db_session, table_name, admin_id)
+
+        monkeypatch.setattr(tasks_postgis_refresh, "_REPAIR_STATEMENT_TIMEOUT_MS", 250)
+        with patch(
+            "app.processing.ingest.metadata.rederive_geom_4326",
+            new=_sleepy_rederive,
+        ):
+            report = await tasks_postgis_refresh._repair_geom_4326(
+                dataset.id, Dataset, schema="data", role="geolens_reader"
+            )
+            assert report.code == tasks_postgis_refresh._REPAIR_TIMED_OUT
+            assert report.rows_rewritten == 0
+
+            payload = await _refresh(
+                test_db_session, client, admin_auth_header, dataset.id
+            )
+
+        # The refresh itself completed: the measurement is what the user asked
+        # for, and a repair that could not run leaves the dataset exactly as it
+        # was rather than failing the run.
+        job = (
+            await test_db_session.execute(
+                select(IngestJob).where(IngestJob.id == uuid.UUID(payload["job_id"]))
+            )
+        ).scalar_one()
+        await test_db_session.refresh(job)
+        assert job.status == "complete"
+
+        run = (
+            await test_db_session.execute(
+                select(DatasetRefreshRun).where(
+                    DatasetRefreshRun.dataset_id == dataset.id
+                )
+            )
+        ).scalar_one()
+        await test_db_session.refresh(run)
+        assert run.status == "succeeded"
+    finally:
+        await _drop(test_db_session, table_name)
+
+
+async def test_the_repair_gives_up_its_lock_queue_position_on_a_busy_table(
+    test_db_session,
+) -> None:
+    """Adding the column back takes ACCESS EXCLUSIVE on somebody else's table.
+
+    A lock request that is merely QUEUED already blocks every reader arriving
+    behind it, so waiting out the five-minute statement deadline for one would
+    stall the owner's own traffic for five minutes in order to fix a column.
+    The repair therefore carries a short ``lock_timeout`` as well, gives the
+    queue position back, and reports itself blocked; the next refresh tries
+    again.
+
+    Staged with a real conflicting lock — a second session holding ACCESS
+    SHARE through an open SELECT — because the property is about lock
+    conflicts and a mocked one would prove only that the mock was wired up.
+    """
+    admin_id = await get_user_id(test_db_session, "admin")
+    table_name = f"rd_lock_{uuid.uuid4().hex[:10]}"
+    await _create_source_table(test_db_session, table_name, lon=_HERE[0], lat=_HERE[1])
+
+    try:
+        dataset = await _register(test_db_session, table_name, admin_id)
+
+        # The column is gone (as after -overwrite), so the repair must ALTER.
+        await test_db_session.execute(
+            text(f'ALTER TABLE data."{table_name}" DROP COLUMN geom_4326')
+        )
+        await test_db_session.commit()
+
+        with (
+            patch.object(tasks_postgis_refresh, "_REPAIR_LOCK_TIMEOUT_MS", 250),
+            patch.object(tasks_postgis_refresh, "_REPAIR_STATEMENT_TIMEOUT_MS", 60_000),
+        ):
+            # This session's SELECT holds ACCESS SHARE for the rest of its
+            # transaction, which is exactly what a reader of a live registered
+            # table looks like.
+            await test_db_session.execute(text(f'SELECT 1 FROM data."{table_name}"'))  # noqa: S608
+
+            started = time.perf_counter()
+            report = await tasks_postgis_refresh._repair_geom_4326(
+                dataset.id, Dataset, schema="data", role="geolens_reader"
+            )
+            elapsed = time.perf_counter() - started
+
+        assert report.code == tasks_postgis_refresh._REPAIR_BLOCKED
+        # Bounded by the LOCK timeout, not by the statement deadline.
+        assert elapsed < 30
+        await test_db_session.rollback()
+        assert not await _column_exists(test_db_session, table_name, "geom_4326")
+    finally:
+        await _drop(test_db_session, table_name)
+
+
+# ---------------------------------------------------------------------------
+# The two tables the repair must not write to
+# ---------------------------------------------------------------------------
+
+
+async def test_a_generated_render_column_is_skipped_rather_than_written(
+    test_db_session,
+) -> None:
+    """PostgreSQL rejects any non-DEFAULT write to a generated column.
+
+    Same refusal ``linearize_existing_4326`` makes, and for the same reason:
+    such a column re-derives itself on every write, so there is nothing to
+    repair and an UPDATE would fail at parse time even with a WHERE that
+    matches no rows.
+    """
+    from app.processing.ingest.metadata import REPAIR_GENERATED, rederive_geom_4326
+
+    table_name = f"rd_gen_{uuid.uuid4().hex[:10]}"
+    await test_db_session.execute(
+        text(
+            f'CREATE TABLE data."{table_name}" ('
+            f"  gid serial PRIMARY KEY,"
+            f"  geom geometry(Point, 4326),"
+            f"  geom_4326 geometry(Geometry, 4326) GENERATED ALWAYS AS "
+            f"    (ST_Force2D(ST_CurveToLine(ST_SetSRID(geom, 4326)))) STORED"
+            f")"
+        )
+    )
+    await test_db_session.commit()
+
+    try:
+        repair = await rederive_geom_4326(test_db_session, table_name, 4326)
+        assert repair.outcome == REPAIR_GENERATED
+        assert repair.rows_rewritten == 0
+    finally:
+        await _drop(test_db_session, table_name)
+
+
+async def test_a_table_with_no_geometry_is_skipped(test_db_session) -> None:
+    """Registration admits attribute tables (#1359); the repair must too.
+
+    A spatial table whose geometry hides under another name is refused at
+    registration (#1737), so "no geom column" here means a legitimately
+    non-spatial dataset rather than a broken one.
+    """
+    from app.processing.ingest.metadata import REPAIR_NO_GEOMETRY, rederive_geom_4326
+
+    table_name = f"rd_flat_{uuid.uuid4().hex[:10]}"
+    await test_db_session.execute(
+        text(f'CREATE TABLE data."{table_name}" (gid serial PRIMARY KEY, code text)')
+    )
+    await test_db_session.commit()
+
+    try:
+        repair = await rederive_geom_4326(test_db_session, table_name, 4326)
+        assert repair.outcome == REPAIR_NO_GEOMETRY
+        assert (repair.column_added, repair.rows_rewritten) == (False, 0)
+        assert not await _column_exists(test_db_session, table_name, "geom_4326")
+    finally:
+        await _drop(test_db_session, table_name)

--- a/backend/tests/test_registered_geom_4326_rederive_1738.py
+++ b/backend/tests/test_registered_geom_4326_rederive_1738.py
@@ -651,20 +651,26 @@ async def test_the_repair_gives_up_its_lock_queue_position_on_a_busy_table(
 
 
 # ---------------------------------------------------------------------------
-# The grant is not conditional on the re-derive
+# The grant and the index are not conditional on the re-derive
 # ---------------------------------------------------------------------------
 
 
-async def test_a_recreated_generated_column_still_gets_its_reader_grant_back(
+async def test_a_recreated_generated_column_gets_its_index_and_grant_back(
     client: AsyncClient, admin_auth_header: dict, test_db_session
 ) -> None:
-    """fix(#1738 round 1): the GRANT is the third thing `-overwrite` destroys.
+    """The GRANT and the INDEX are the other two things `-overwrite` destroys.
 
-    Losing it does not depend on the render column needing a rewrite. A table
-    recreated with a valid STORED GENERATED `geom_4326` re-derives itself on
-    every write, so the repair has nothing to do to the column — and gating
-    the grant on the re-derive let exactly that table pass a refresh while
-    `geolens_reader` still could not read a row of it.
+    Losing them does not depend on the render column needing a rewrite. A
+    table recreated with a valid STORED GENERATED `geom_4326` re-derives
+    itself on every write, so the repair has nothing to do to the column — and
+    gating the other two restorations on the re-derive let exactly that table
+    pass a refresh unreadable by `geolens_reader` (fix(#1738 round 1)) and
+    with no GiST index behind the `geom_4326 && <envelope>` predicate every
+    reader issues (fix(#1738 round 2)).
+
+    A generated column is the case that isolates them: it is the one shape
+    where the render values are already correct and the two things around
+    them are still missing.
     """
     admin_id = await get_user_id(test_db_session, "admin")
     table_name = f"rd_gengr_{uuid.uuid4().hex[:8]}"
@@ -696,19 +702,25 @@ async def test_a_recreated_generated_column_still_gets_its_reader_grant_back(
         )
         await test_db_session.commit()
 
+        # A freshly created table carries neither: CREATE TABLE makes no
+        # index, and the grant was revoked above.
         assert not await _reader_can_select(test_db_session, table_name)
+        assert not await _has_gist_index(test_db_session, table_name)
 
         report = await tasks_postgis_refresh._repair_geom_4326(
             dataset.id, Dataset, schema="data", role="geolens_reader"
         )
-        # Nothing to re-derive, and the grant restored anyway.
+        # Nothing to re-derive, and both of the others restored anyway.
         assert report.code == tasks_postgis_refresh._REPAIR_NOT_APPLICABLE
         assert report.rows_rewritten == 0
+        assert report.index_added is True
         assert await _reader_can_select(test_db_session, table_name)
+        assert await _has_gist_index(test_db_session, table_name)
 
         # And through the real refresh, which must not fail on it either.
         await _refresh(test_db_session, client, admin_auth_header, dataset.id)
         assert await _reader_can_select(test_db_session, table_name)
+        assert await _has_gist_index(test_db_session, table_name)
         assert await _features_at(test_db_session, table_name, _THERE) == 1
     finally:
         await _drop(test_db_session, table_name)

--- a/backend/tests/test_registered_geom_4326_rederive_1738.py
+++ b/backend/tests/test_registered_geom_4326_rederive_1738.py
@@ -247,6 +247,19 @@ async def _has_gist_index(session, table_name: str) -> bool:
     )
 
 
+async def _stored_version(session, dataset_id: uuid.UUID) -> int:
+    """The dataset's `tile_cache_version` as the database holds it.
+
+    Read as a column, past this session's identity map: the worker rolls the
+    counter from its own transaction, so an ORM instance loaded here could
+    answer from before it.
+    """
+    await session.rollback()
+    return await session.scalar(
+        select(Dataset.tile_cache_version).where(Dataset.id == dataset_id)
+    )
+
+
 async def _reader_can_select(session, table_name: str) -> bool:
     await session.rollback()
     return bool(
@@ -633,6 +646,187 @@ async def test_the_repair_gives_up_its_lock_queue_position_on_a_busy_table(
         assert elapsed < 30
         await test_db_session.rollback()
         assert not await _column_exists(test_db_session, table_name, "geom_4326")
+    finally:
+        await _drop(test_db_session, table_name)
+
+
+# ---------------------------------------------------------------------------
+# The grant is not conditional on the re-derive
+# ---------------------------------------------------------------------------
+
+
+async def test_a_recreated_generated_column_still_gets_its_reader_grant_back(
+    client: AsyncClient, admin_auth_header: dict, test_db_session
+) -> None:
+    """fix(#1738 round 1): the GRANT is the third thing `-overwrite` destroys.
+
+    Losing it does not depend on the render column needing a rewrite. A table
+    recreated with a valid STORED GENERATED `geom_4326` re-derives itself on
+    every write, so the repair has nothing to do to the column — and gating
+    the grant on the re-derive let exactly that table pass a refresh while
+    `geolens_reader` still could not read a row of it.
+    """
+    admin_id = await get_user_id(test_db_session, "admin")
+    table_name = f"rd_gengr_{uuid.uuid4().hex[:8]}"
+    await _create_source_table(test_db_session, table_name, lon=_HERE[0], lat=_HERE[1])
+
+    try:
+        dataset = await _register(test_db_session, table_name, admin_id)
+
+        # -overwrite, into a table whose render column is generated.
+        await test_db_session.execute(text(f'DROP TABLE data."{table_name}" CASCADE'))
+        await test_db_session.execute(
+            text(
+                f'CREATE TABLE data."{table_name}" ('
+                f"  gid serial PRIMARY KEY, name text,"
+                f"  geom geometry(Point, 4326),"
+                f"  geom_4326 geometry(Geometry, 4326) GENERATED ALWAYS AS "
+                f"    (ST_Force2D(ST_CurveToLine(ST_SetSRID(geom, 4326)))) STORED)"
+            )
+        )
+        await test_db_session.execute(
+            text(
+                f'INSERT INTO data."{table_name}" (name, geom) '  # noqa: S608
+                f"VALUES ('generated', ST_SetSRID(ST_MakePoint(:lon, :lat), 4326))"
+            ),
+            {"lon": _THERE[0], "lat": _THERE[1]},
+        )
+        await test_db_session.execute(
+            text(f'REVOKE ALL ON data."{table_name}" FROM geolens_reader')
+        )
+        await test_db_session.commit()
+
+        assert not await _reader_can_select(test_db_session, table_name)
+
+        report = await tasks_postgis_refresh._repair_geom_4326(
+            dataset.id, Dataset, schema="data", role="geolens_reader"
+        )
+        # Nothing to re-derive, and the grant restored anyway.
+        assert report.code == tasks_postgis_refresh._REPAIR_NOT_APPLICABLE
+        assert report.rows_rewritten == 0
+        assert await _reader_can_select(test_db_session, table_name)
+
+        # And through the real refresh, which must not fail on it either.
+        await _refresh(test_db_session, client, admin_auth_header, dataset.id)
+        assert await _reader_can_select(test_db_session, table_name)
+        assert await _features_at(test_db_session, table_name, _THERE) == 1
+    finally:
+        await _drop(test_db_session, table_name)
+
+
+async def test_a_registered_non_spatial_table_is_not_a_repair_failure(
+    test_db_session,
+) -> None:
+    """fix(#1738 round 1): `Find_SRID` raises; it does not return NULL.
+
+    Registration admits tables with no geometry (#1359), and resolving the
+    source SRID before knowing whether there IS one turned every refresh of
+    such a dataset into a logged repair failure — which also skipped the
+    reader grant. The SRID is resolved only once the probe says there is a
+    geometry column to resolve it for.
+    """
+    admin_id = await get_user_id(test_db_session, "admin")
+    table_name = f"rd_flatreg_{uuid.uuid4().hex[:8]}"
+    await test_db_session.execute(
+        text(
+            f'CREATE TABLE data."{table_name}" '
+            f"(gid serial PRIMARY KEY, code text, population integer)"
+        )
+    )
+    await test_db_session.execute(
+        text(
+            f'INSERT INTO data."{table_name}" (code, population) '  # noqa: S608
+            f"VALUES ('a', 1)"
+        )
+    )
+    await test_db_session.commit()
+
+    try:
+        dataset = await _register(test_db_session, table_name, admin_id)
+        await test_db_session.execute(
+            text(f'REVOKE ALL ON data."{table_name}" FROM geolens_reader')
+        )
+        await test_db_session.commit()
+
+        report = await tasks_postgis_refresh._repair_geom_4326(
+            dataset.id, Dataset, schema="data", role="geolens_reader"
+        )
+        assert report.code == tasks_postgis_refresh._REPAIR_NOT_APPLICABLE
+        assert report.code != tasks_postgis_refresh._REPAIR_FAILED
+        # The grant reaches an attribute table too — registration grants it.
+        assert await _reader_can_select(test_db_session, table_name)
+        assert not await _column_exists(test_db_session, table_name, "geom_4326")
+    finally:
+        await _drop(test_db_session, table_name)
+
+
+# ---------------------------------------------------------------------------
+# The version bump survives a writer that does not lock
+# ---------------------------------------------------------------------------
+
+
+async def test_the_version_bump_does_not_lose_a_concurrent_increment(
+    test_db_session,
+) -> None:
+    """fix(#1738 round 1): the counter is incremented in the database.
+
+    The repair holds no lock on the datasets row, and the feature-edit
+    routers roll the counter through a plain read-modify-write without one
+    either — so an absolute value computed from an earlier read lands on top
+    of whatever committed in between. Staged here as that exact shape: a
+    stale in-memory value written after the repair's increment, then the
+    repair again. `tile_cache_version = tile_cache_version + 1` evaluated at
+    write time cannot be clobbered by the read it never took.
+    """
+    admin_id = await get_user_id(test_db_session, "admin")
+    table_name = f"rd_bump_{uuid.uuid4().hex[:8]}"
+    await _create_source_table(test_db_session, table_name, lon=_HERE[0], lat=_HERE[1])
+
+    try:
+        dataset = await _register(test_db_session, table_name, admin_id)
+
+        await test_db_session.execute(
+            text(
+                f'UPDATE data."{table_name}" '  # noqa: S608
+                f"SET geom = ST_SetSRID(ST_MakePoint(:lon, :lat), 4326)"
+            ),
+            {"lon": _THERE[0], "lat": _THERE[1]},
+        )
+        await test_db_session.commit()
+
+        before = await _stored_version(test_db_session, dataset.id)
+        first = await tasks_postgis_refresh._repair_geom_4326(
+            dataset.id, Dataset, schema="data", role="geolens_reader"
+        )
+        # The report carries the version the increment actually published,
+        # read back from the UPDATE rather than computed in Python.
+        assert first.rows_rewritten == 1
+        assert first.tile_cache_version == before + 1
+        assert await _stored_version(test_db_session, dataset.id) == before + 1
+
+        # A second drifting write, and a repair whose increment is evaluated
+        # against the row as it stands rather than against `before`.
+        await test_db_session.execute(
+            text(
+                f'UPDATE data."{table_name}" '  # noqa: S608
+                f"SET geom = ST_SetSRID(ST_MakePoint(:lon, :lat), 4326)"
+            ),
+            {"lon": _HERE[0], "lat": _HERE[1]},
+        )
+        await test_db_session.commit()
+
+        second = await tasks_postgis_refresh._repair_geom_4326(
+            dataset.id, Dataset, schema="data", role="geolens_reader"
+        )
+        assert second.tile_cache_version == before + 2
+        assert await _stored_version(test_db_session, dataset.id) == before + 2
+
+        # And a pass that rewrites nothing publishes no new version.
+        third = await tasks_postgis_refresh._repair_geom_4326(
+            dataset.id, Dataset, schema="data", role="geolens_reader"
+        )
+        assert (third.rows_rewritten, third.tile_cache_version) == (0, None)
+        assert await _stored_version(test_db_session, dataset.id) == before + 2
     finally:
         await _drop(test_db_session, table_name)
 


### PR DESCRIPTION
## The bug

`geom_4326` on a registered table is a plain column, written **once** — by `add_4326_column` at registration — and never re-derived (design §1). Registration copies no data and serves from the live relation, so the owner keeps writing to that table directly, and none of those writes touch the render column:

- `UPDATE ... SET geom = ...` moves the feature; it keeps drawing where it used to be.
- `DELETE` + `INSERT` (an ETL's ordinary reload) lands rows whose `geom_4326` is NULL.
- `ogr2ogr -overwrite` drops the table and recreates it with no `geom_4326` column, no GiST index and no reader grant at all.

Every reader filters on `geom_4326 && <envelope>`, and `NULL && anything` is NULL (§1), so affected rows go **silently invisible** — tiles, feature reads, extent, OGC/CQL2, exports, analysis — rather than visibly wrong. `refresh_postgis` could not fix it: its measurement phase runs `postgresql_readonly=True` on purpose. Latent since #1265.

Fixes #1738.

## Why option (d)

Design §2 prices five options and §3 recommends (d), a re-derive phase inside `refresh_postgis`:

- **(a) STORED generated column** — PostgreSQL rejects any non-DEFAULT write to a generated column, which breaks in-app feature editing on every registered dataset (`features/service.py`), and an out-of-band INSERT with a different SRID starts raising inside the owner's ETL. Plus a full rewrite under ACCESS EXCLUSIVE.
- **(b) BEFORE INSERT OR UPDATE trigger** — a per-row trigger on somebody else's table silently changes the semantics of their bulk loads. A larger claim on a table we promise not to own than adding a column is, and invisible to them.
- **(c) drop the column, read through a functional index** — `geom_4326` is a name in ~38 backend modules, in the analysis sandbox's managed-column model and in the NL→SQL prompt contract. Out on blast radius.
- **(e) detect and warn** — tells an operator their data is invisible without giving them a fix; re-registration is not one, since it costs the dataset id, its permalinks and its saved maps.
- **Nothing in-table survives `-overwrite`** (§2, closing paragraph): the table is dropped, taking (a), (b) and (c)'s index with it. Only an invariant GeoLens re-applies **from outside** comes back — which is (d).

Refresh is also where the machinery already is: an admission gate, a run ledger, a user-visible history, a tile-version bump and a cache purge.

## What this does

**`rederive_geom_4326`** (`metadata_projection.py`) re-applies the whole invariant with the same DDL registration uses: `ADD COLUMN IF NOT EXISTS`, the same derive expression (now factored into `_geom_4326_expr`, so the write path and the repair path cannot drift), and `ensure_geom_4326_gist_index`. It skips a STORED GENERATED column (same refusal `linearize_existing_4326` makes) and a table with no geometry (#1359 attribute tables).

**Phase 1.5 in `refresh_postgis`** (`_repair_geom_4326`) runs it in its own session and transaction, **before** the read-only measurement phase (§3.1), then re-issues `grant_reader_access`. Reading `content_version` after the repair (§3.3) is free, because phase 2 already reads it after this point.

`register_existing_table`'s docstring is corrected (§3.4): the owner's direct writes are picked up by Refresh, not continuously.

### `-overwrite` behaviour

The recreated table gets its column, its GiST index and its `geolens_reader` GRANT back, against the same dataset id — no delete-and-re-add. Pinned by `test_an_overwrite_restores_the_column_the_index_and_the_grant`, which asserts all three are absent first.

### Only rows that changed

`UPDATE ... WHERE ST_AsBinary(geom_4326) IS DISTINCT FROM ST_AsBinary(<expr>)` — one statement, not a ctid-batched loop, because the statement **can** be bounded (below) and because one statement keeps the whole repair atomic: a table is either fully re-derived or untouched, never half. Deliberately *not* `geom_4326 IS NULL OR ...`: a row whose `geom` is NULL already has the correct NULL render value, and that disjunct would rewrite every such row NULL-to-NULL on every pass, which is both a pointless write and a drift count that lies.

The tile-version bump and the cache purge are gated on rewritten **rows**, not on the column or the index: restoring an index changes how a tile is computed, not what it contains, so a looser gate would bust every cached tile of every registered dataset on the first refresh after this ships.

### The timeout bound

`install_api_statement_timeout` is installed by the API process only, so a worker statement has no deadline at all. The repair phase sets **two** through `set_config(..., is_local => true)` (static SQL, bound values):

- `_REPAIR_STATEMENT_TIMEOUT_MS = 300_000` — the work bound.
- `_REPAIR_LOCK_TIMEOUT_MS = 5_000` — the wait bound. Measurement forced this one: `ADD COLUMN` takes ACCESS EXCLUSIVE, a merely *queued* lock request already blocks every reader behind it, and the first version of this phase sat on that queue for the full five minutes in a test. Five seconds gives the queue position back instead.

Both are non-fatal and coded (`timed_out`, `blocked`, `failed`, `not_applicable`, `repaired`), logged on every run. A repair that cannot write leaves the dataset exactly as broken as it already was and the refresh still takes its measurement — the change adds no failure mode to a strategy that had none.

## Schema / API / config impact

**None.** No Alembic migration (so merging does not take the dev API down), no API surface, no config, no OpenAPI or SDK regeneration. Registration-time behaviour is unchanged; the new work only runs when someone presses Refresh.

## Verification

```
cd backend && set -a && source ../.env.test && set +a && uv run pytest \
  tests/test_registered_geom_4326_rederive_1738.py \
  tests/test_postgis_refresh_1265.py \
  tests/test_register_geom_column_name_1737.py \
  tests/test_registered_delete_detach_1452.py \
  tests/test_staging_pipeline.py tests/test_phase_2_commit_boundary.py \
  tests/test_layering.py tests/test_rule1_structural.py \
  tests/test_rule2_structural.py tests/test_codeql_qtable_suppressions.py -q
cd backend && uv run ruff check . && uv run ruff format --check .
```

Full backend suite on this branch: **11721 passed, 100 skipped** (23:27, `-n 4`).

Measured: re-deriving 5,000 out-of-band rows took **0.19 s**; a refresh that finds no drift rewrites 0 rows.
