### PR TITLE
test(maps,raster): event-ordered stalled-PUT assertion and isolated VRT-stamp storage

### DIFF
--- a/backend/tests/test_maps_asset_object_cleanup_1778.py
+++ b/backend/tests/test_maps_asset_object_cleanup_1778.py
@@ -434,9 +434,14 @@ class TestAStalledUploadDoesNotBlockOtherWriters:
         ``delete_map_endpoint`` takes ``lock_map_for_asset_write`` itself, so
         this also proves two DIFFERENT requests' calls into the same helper
         do not deadlock or serialize on an unrelated stalled write.
-        """
-        import time
 
+        fix(#1809): this used to assert a wall-clock bound (``elapsed < 2``),
+        which failed under CI load with no product bug (2.147s observed on
+        #1798). The property under test isn't "fast" but "does not wait on
+        the stalled PUT", so assert ordering instead: the delete's response
+        is observed while the PUT is still parked on ``release_put``, proven
+        by the upload task still being unfinished at that point.
+        """
         map_id = await _create_map(client, admin_auth_header)
 
         storage = _storage()
@@ -461,12 +466,16 @@ class TestAStalledUploadDoesNotBlockOtherWriters:
         )
         await asyncio.wait_for(put_entered.wait(), timeout=10)
 
-        started = time.monotonic()
         delete_resp = await client.delete(f"/maps/{map_id}", headers=admin_auth_header)
-        elapsed = time.monotonic() - started
 
         assert delete_resp.status_code == 204, delete_resp.text
-        assert elapsed < 2, elapsed
+        # The upload is still blocked on release_put here: if the delete had
+        # instead waited on the stalled PUT (e.g. serialized behind it), the
+        # only way to reach this line is for the PUT to have already been
+        # released, which it has not been.
+        assert not upload.done(), (
+            "the delete waited on the stalled PUT instead of running independently"
+        )
 
         release_put.set()
         # The map is gone by the time the stalled PUT's lock acquisition

--- a/backend/tests/test_raster_replace_1221.py
+++ b/backend/tests/test_raster_replace_1221.py
@@ -122,8 +122,12 @@ def _ds(record_type: str):
 def raster_storage(tmp_path, monkeypatch):
     """A real LocalStorageProvider on a tmp dir, installed on every lookup path.
 
-    Both the task and the reapers resolve ``get_storage`` from
-    ``app.platform.storage`` at call time, so one patch covers all of them.
+    Most callers resolve ``get_storage`` from ``app.platform.storage`` at call
+    time, so one patch would cover them. Two modules bind the name at import
+    time instead and need their own patch or they keep reading the real
+    process-wide storage singleton (``app.platform.storage.provider._storage``,
+    set for the test by the ``client`` fixture to ITS OWN tmp dir, a different
+    one than this fixture's) rather than the object this fixture hands back.
     """
     storage = LocalStorageProvider(str(tmp_path / "objects"))
     monkeypatch.setattr(
@@ -135,6 +139,21 @@ def raster_storage(tmp_path, monkeypatch):
     # outside tmp_path.
     monkeypatch.setattr(
         "app.processing.ingest.tasks_common.get_storage", lambda: storage, raising=True
+    )
+    # fix(#1813): `tasks_vrt` ALSO binds get_storage at module import (its own
+    # `from app.platform.storage import get_storage`, used by `regenerate_vrt`).
+    # Without this, every VRT-stamp test that drives a real regeneration
+    # (`_run_regeneration`) writes and reaps generation objects against
+    # whatever storage the `client` fixture's tmp dir currently is, not this
+    # fixture's — silently, since `LocalStorageProvider.delete` no-ops on a
+    # missing key and the mismatched writes still succeed. Harmless for these
+    # tests' own assertions (they only read `last_regenerated_at`), but it is
+    # the same class of import-time-binding gap `tasks_common` already needed
+    # patched above, and leaves the seed VRT this fixture wrote never actually
+    # reaped. `test_regenerate_vrt_integration.py`'s own `local_storage`
+    # fixture documents the identical rule for the identical reason.
+    monkeypatch.setattr(
+        "app.processing.ingest.tasks_vrt.get_storage", lambda: storage, raising=True
     )
     return storage
 


### PR DESCRIPTION
## Summary

**#1809** — `test_a_stalled_og_image_put_does_not_block_a_concurrent_delete` asserted a 2s wall-clock bound (`elapsed < 2`) and failed under CI load at 2.147s (#1798). Replaced it with an event-ordering assertion: after the delete's 204 response is observed, assert the upload task is still not done — proof the delete didn't wait on the stalled PUT, without depending on wall-clock timing. Test intent (delete never queues behind a stalled write) is unchanged.

**#1813** — the `raster_storage` fixture in `test_raster_replace_1221.py` patched `app.platform.storage.get_storage` and `app.processing.ingest.tasks_common.get_storage`, but `app.processing.ingest.tasks_vrt.py` also binds `get_storage` at import time (`from app.platform.storage import get_storage`, used by `regenerate_vrt`) — the exact gap `tasks_common` already needed its own patch for, documented in the fixture's own comment. Unpatched, every VRT-stamp test that drives a real regeneration (`_run_regeneration`) wrote and reaped generation objects against whatever storage the `client` fixture's own tmp dir currently was, not this fixture's tmp dir — silently, because `LocalStorageProvider.delete` no-ops on a missing key. `test_regenerate_vrt_integration.py`'s own `local_storage` fixture documents the identical rule for the identical reason. Added the missing `tasks_vrt.get_storage` patch.

### On reproducing #1813

I could not reproduce the reported `-n 4` cross-file failure on this hardware despite extensive attempts:
- `test_raster_replace_1221.py`'s VRT-stamp classes alone, and combined with every `test_raster*.py`/`test_vrt*.py` sibling, serially and under real `-n 4` — all green.
- `test_regenerate_vrt_integration.py` (the other module that patches `tasks_vrt.get_storage`, a plausible fifth "sibling") combined with `test_raster_replace_1221.py` — green.
- The full backend suite under `-n 4`: **11712 passed, 100 skipped, 0 failed**.

The storage-resolution gap above is a real, demonstrable defect in the exact fixture the issue points at, and matches the bug class the issue names (an import-time-bound helper the fixture's patch doesn't reach) — fixed regardless of whether it's the precise CI trigger, since it leaves the fixture's own seed VRT object un-reaped and the regeneration objects landing outside the test's own storage root.

## Test plan

- [x] `test_a_stalled_og_image_put_does_not_block_a_concurrent_delete` alone, looped 20x: 20/20 pass.
- [x] `test_maps_asset_object_cleanup_1778.py` under `-n 4` (with its file's siblings): 52 passed.
- [x] `test_raster_replace_1221.py` alone: 127 passed.
- [x] `test_raster_ingest.py` + `test_raster_ingest_orphan_cleanup_gap017.py` + `test_raster_object_ownership_1778.py` + `test_regenerate_vrt_integration.py` + `test_raster_replace_1221.py`, both file orders, serial: 217 passed each.
- [x] Same five files under `-n 4`, three consecutive runs: 217 passed each time.
- [x] Full backend suite under `-n 4`: 11712 passed, 100 skipped, 0 failed.
- [x] `backend/tests/test_layering.py`: 49 passed.
- [x] `cd backend && uv run ruff check . && uv run ruff format --check .`: clean.

Fixes #1809
Fixes #1813