### PR TITLE
fix(redaction): treat authkey and maxar_api_key as sensitive query params; refresh two service-auth docstrings

### DIFF
--- a/backend/app/core/url_redaction.py
+++ b/backend/app/core/url_redaction.py
@@ -51,9 +51,17 @@ SENSITIVE_QUERY_PARAMS = frozenset(
         "api-key",
         "api_key",
         "apikey",
+        # fix(#1755 item 7 lane B3): ArcGIS's own query-parameter name for a
+        # token, distinct from the generic "api_key"/"token" already here —
+        # a stored ArcGIS pointer or a GDAL-composed query can carry it and
+        # it needs the same redaction the others already get.
+        "authkey",
         "client_secret",
         "code",
         "key",
+        # fix(#1755 item 7 lane B3): Maxar's named API key query parameter,
+        # for the same reason as "authkey" above.
+        "maxar_api_key",
         "password",
         "refresh_token",
         "sig",

--- a/backend/app/modules/catalog/datasets/api/router_refresh.py
+++ b/backend/app/modules/catalog/datasets/api/router_refresh.py
@@ -328,11 +328,13 @@ async def _require_service_token_if_marked(db, dataset, dataset_id, token):
     fix(#1746 codex r2): "where it is possible" is the whole of this function,
     and it is not every service.
 
-    ArcGIS is asked. Its probe target IS the resource the worker reads: the
-    layer's ``?f=json``, which answers 499 "Token Required" for an org-only
-    layer and 498 for a token it rejected. A healthy answer there is real
-    evidence the token-less refresh will work, so a false marker costs one
-    probe and never a refusal.
+    ArcGIS is asked. fix(#1755 item 15): its probe target is no longer the
+    layer's ``?f=json`` — since #1754 round 6, ``probe_arcgis_origin`` reads
+    ``<layer>/query`` (composed by ``build_arcgis_count_query_url``), the
+    same resource the worker's ``build_gdal_source`` fetches, which answers
+    499 "Token Required" for an org-only layer and 498 for a token it
+    rejected. A healthy answer there is real evidence the token-less refresh
+    will work, so a false marker costs one probe and never a refusal.
 
     WFS and OGC API Features are refused outright, with no probe. Their probe
     target is the capabilities document or the landing page, which is a

--- a/backend/app/modules/catalog/sources/origin_probe.py
+++ b/backend/app/modules/catalog/sources/origin_probe.py
@@ -30,6 +30,14 @@ an operator to replace data that is still sitting there.
 ``healthy`` is a status below 400, matching what the VRT probe has always
 meant by "the file is there".
 
+fix(#1755 item 7): the ArcGIS branch (:func:`probe_arcgis_origin`) reads
+past the status code, because ArcGIS reports its own auth refusals as an
+error envelope inside an HTTP 200 body rather than a 401/403. It parses the
+JSON body's ``error.code`` field and maps ``498``/``499`` (a rejected or
+required token) onto ``inaccessible``/``auth_required`` — the same verdict
+the generic 401/403 split above reaches for every other origin, reached
+here by reading the provider body instead of the status line.
+
 ### Why ``detail`` is a code and not a sentence
 
 ``source_health_detail`` is persisted and served on ordinary dataset reads

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -3650,7 +3650,11 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # a reference, and configures the deferred task's queue with the verdict
     # so a worker from the release before this PR never dequeues a header
     # line its own validator cannot parse. Cap 1364 -> 1374, exact.
-    "backend/app/modules/catalog/datasets/api/router_refresh.py": 1374,
+    # fix(#1755 item 15): +2 — corrected the `_require_service_token_if_marked`
+    # docstring, which still described the ArcGIS probe reading the layer's
+    # `?f=json`; since #1754 round 6 it reads `<layer>/query` via
+    # `build_arcgis_count_query_url`. Cap 1374 -> 1376, exact.
+    "backend/app/modules/catalog/datasets/api/router_refresh.py": 1376,
     # fix(#1335): stac_resolve.py's 1040 lines were split along their natural
     # seams — verdict taxonomy, identity checks, the asset gate (SSRF + COG
     # probe), and the by-search fallback each moved into a sibling module,

--- a/backend/tests/test_url_redaction_sec.py
+++ b/backend/tests/test_url_redaction_sec.py
@@ -370,6 +370,40 @@ def test_redact_query_credentials_preserves_non_sensitive_query() -> None:
     assert redact_query_credentials("f=json&where=1%3D1") == "f=json&where=1%3D1"
 
 
+# fix(#1755 item 7 lane B3): "authkey" (ArcGIS) and "maxar_api_key" (Maxar)
+# joined SENSITIVE_QUERY_PARAMS alongside the existing generic names. One
+# case per name, plus the mixed-case spelling since matching is
+# case-insensitive (_is_sensitive_query_param lowercases before comparing).
+@pytest.mark.parametrize(
+    "param_name",
+    [
+        "authkey",
+        "AuthKey",
+        "AUTHKEY",
+        "maxar_api_key",
+        "Maxar_Api_Key",
+        "MAXAR_API_KEY",
+    ],
+)
+def test_redact_query_credentials_masks_authkey_and_maxar_api_key(
+    param_name: str,
+) -> None:
+    redacted = redact_query_credentials(f"f=json&{param_name}=secret")
+
+    assert "secret" not in redacted
+    assert "f=json" in redacted
+
+
+def test_redact_query_credentials_leaves_unrelated_param_untouched() -> None:
+    # Positive control: a param name that merely contains "key" as a
+    # substring ("keyword") must not be treated as sensitive by the new
+    # entries, and its value must survive redaction unchanged.
+    assert (
+        redact_query_credentials("keyword=roads&authkey=secret")
+        == "keyword=roads&authkey=%3Credacted%3E"
+    )
+
+
 def test_has_url_credentials_detects_blank_sensitive_param() -> None:
     assert has_url_credentials("https://example.com/arcgis?token=")
 


### PR DESCRIPTION
## Summary

Lane B3 + issue #1755 items 7 and 15 — a small, self-contained cleanup with no behavior change beyond the redaction addition.

- **Lane B3**: adds `authkey` (ArcGIS) and `maxar_api_key` (Maxar) to `SENSITIVE_QUERY_PARAMS` in `backend/app/core/url_redaction.py`. Both are named query parameters distinct from the generic `api_key`/`token` entries already there, so a stored service pointer or a GDAL-composed query carrying either was not being redacted.
- **#1755 item 7**: `origin_probe.py`'s module docstring described only the three-value health vocabulary and the generic 401/403 split. It now also states that `probe_arcgis_origin` reads a provider error body (`error.code` 498/499) rather than the status line — that branch was added by #1746 but the module docstring was never updated to say so.
- **#1755 item 15**: `_require_service_token_if_marked`'s docstring in `router_refresh.py` said the ArcGIS probe reads the layer's `?f=json`. Since #1754 round 6 it reads `<layer>/query` via `build_arcgis_count_query_url` — verified against the current `probe_arcgis_origin` implementation before editing. Docstring only, no code change.

`router_refresh.py` grew by 2 lines from the docstring fix, so the `_MODULE_LOC_CAPS` entry in `backend/tests/test_layering.py` is raised 1374 -> 1376 in the same commit, per repo convention.

Closes nothing; addresses #1755 items 7 and 15.

## Test plan

- [x] `cd backend && uv run ruff check . && uv run ruff format --check .`
- [x] `uv run pytest tests/test_url_redaction_sec.py tests/test_layering.py tests/test_service_auth_transport_1746.py tests/test_source_health_1222.py tests/test_refresh_gate_1269.py tests/test_refresh_observability_1268.py tests/test_service_refresh_1220.py tests/test_postgis_refresh_1265.py tests/test_stac_refresh_1266.py tests/test_services_wfs_pure.py tests/test_vrt_lifecycle_188.py -q` — 985 passed
- [x] New parametrised tests: one case per new sensitive name (`authkey`, `maxar_api_key`) plus a mixed/upper-case spelling of each (matching is case-insensitive), plus a positive control that an unrelated `keyword` param is untouched