### PR TITLE
fix(#1755): coded preview refusals, redacted defer cause, guarded finally cleanups

### DIFF
--- a/backend/app/modules/catalog/sources/router.py
+++ b/backend/app/modules/catalog/sources/router.py
@@ -90,6 +90,7 @@ from app.platform.service_endpoints import (
     OGC_JSON_ACCEPT,
     CrossOriginEndpointError,
     EndpointCheckFailedError,
+    HrefTooLongError,
     assert_endpoints_stay_on_origin,
 )
 from app.platform.security import (
@@ -659,6 +660,134 @@ async def _fail_preview(
         status_code=status.HTTP_502_BAD_GATEWAY,
         detail="Failed to preview remote layer. The service may be unavailable or the layer format is unsupported.",
     )
+
+
+# fix(#1755 item 9): every typed refusal `run_service_preview` and its
+# callees can raise, mapped to a coded 4xx here rather than at the bottom of
+# `preview_service_layer`'s broad `except Exception`. The preview pipeline
+# (`preview.py`, `service_endpoints.py::assert_endpoints_stay_on_origin`,
+# `service_items.py::materialise_oapif_items`) already converts every one of
+# these into an `HTTPException` at its own raise site, and both of those
+# functions' docstrings commit to raising nothing else — so in the code as it
+# stands today, this map is never consulted. It exists for the day one of
+# those internal contracts is broken by a future edit: without it, the only
+# thing standing between a typed refusal and a 500 would be that a callee
+# happened to keep its promise. `tests/test_services_endpoints.py`'s
+# `TestPreviewEndpoint` pins each branch by mocking `run_service_preview`
+# directly, bypassing the internal wrapping the same way a regression would.
+#
+# Ordered specific-to-general because `SSRFError` and `HrefTooLongError` are
+# both `ValueError` subclasses (`platform/security.py`,
+# `platform/service_endpoints.py`): an `isinstance(exc, ValueError)` branch
+# placed first would swallow both under the generic message and lose their
+# more specific one.
+def _preview_refusal_response(exc: Exception) -> HTTPException | None:
+    """Map a typed preview refusal to its coded 4xx, or None if unrecognized.
+
+    Returns None for anything this does not recognize, so the caller's own
+    `except Exception` remains the last resort for a genuine bug rather than
+    this function guessing at a status code for it.
+
+    No branch here echoes `str(exc)`: `CrossOriginEndpointError.policy` and
+    `EndpointCheckFailedError.policy` (which `ItemFetchFailedError` inherits)
+    are themselves fixed per-class strings — the same ones `/probe` already
+    returns for the identical classes — never the httpx error text a
+    provider's response could shape (kept off `.policy` and off `.reason`
+    instead, per those classes' own docstrings). The other three branches use
+    a message composed here, for the same reason.
+    """
+    if isinstance(exc, (CrossOriginEndpointError, EndpointCheckFailedError)):
+        # Covers `ItemFetchFailedError` too: it subclasses
+        # `EndpointCheckFailedError` (`platform/service_items.py`) so every
+        # door that already answers the description-check refusal answers
+        # the items-page one the same way.
+        return HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail={"code": exc.code, "message": exc.policy, "field": exc.field},
+        )
+    if isinstance(exc, SSRFError):
+        # fix(#1770 round 49 P3) reasoning mirrored here: `str(exc)` can carry
+        # a redirect-chosen hostname (`SSRFResolutionError`), so the client
+        # gets the fixed policy phrase `/probe` already uses instead.
+        return HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="redirect target refused by SSRF policy",
+        )
+    if isinstance(exc, HrefTooLongError):
+        # A malformed-but-safe class of the same "provider named an address
+        # this cannot act on" refusal as the two above; the href itself is
+        # never in this exception's own message either
+        # (`bounded_service_url`'s docstring).
+        return HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail="A service-advertised link exceeded the length limit.",
+        )
+    if isinstance(exc, ValueError):
+        # The remaining source is `build_credential_header`
+        # (`core/service_tokens.py`), which raises `ValueError` with one of a
+        # handful of fixed policy strings when a credential reaches it in a
+        # shape the door in front of it should have already refused — never
+        # a value the caller submitted or a provider chose.
+        return HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="The request could not be processed with the given credential.",
+        )
+    return None
+
+
+async def _run_service_preview_or_refuse(
+    db: AsyncSession,
+    user_id: uuid.UUID,
+    url: str,
+    layer: str,
+    gdal_source: str,
+    layer_arg: str,
+    *,
+    credential: ServiceCredential | None,
+) -> dict:
+    """`run_service_preview`, with every typed refusal mapped before it escapes.
+
+    `IngestionError` and `HTTPException` pass through unchanged: the caller
+    uses `IngestionError` to trigger the WFS namespace retry, and an
+    `HTTPException` — the header-token-charset refusal `run_service_preview`
+    itself already raises as one (#1746) — is already a finished answer.
+    Anything else is checked against `_preview_refusal_response`; a match is
+    audited and raised as the coded HTTPException, and anything that map does
+    not recognize is re-raised untouched for the caller's broad
+    `except Exception` to turn into a logged 500, same as before this
+    function existed.
+    """
+    try:
+        return await run_service_preview(gdal_source, layer_arg, credential=credential)
+    except (IngestionError, HTTPException):
+        raise
+    except Exception as exc:  # broad: classifying every typed refusal `run_service_preview` and its callees can raise, so none of them falls through to the 500 below
+        http_exc = _preview_refusal_response(exc)
+        if http_exc is None:
+            raise
+        safe_url = redact_url_credentials(url)
+        logger.warning(
+            "Preview refused",
+            url=safe_url,
+            layer=layer,
+            reason_class=type(exc).__name__,
+        )
+        await audit_emit(
+            db,
+            AuditEvent(
+                user_id=user_id,
+                action="preview_service_layer",
+                resource_type="service_url",
+                details={
+                    "url": safe_url,
+                    "layer": layer,
+                    "result": "refused",
+                    "reason_class": type(exc).__name__,
+                },
+            ),
+        )
+        await db.commit()
+        raise http_exc from None
 
 
 async def _create_preview_job(
@@ -1289,8 +1418,14 @@ async def preview_service_layer(
 
     # Step 3: Run ogrinfo preview
     try:
-        preview_data = await run_service_preview(
-            gdal_source, layer_arg, credential=service_credential
+        preview_data = await _run_service_preview_or_refuse(
+            db,
+            user.id,
+            request.url,
+            request.layer_name,
+            gdal_source,
+            layer_arg,
+            credential=service_credential,
         )
     except IngestionError:
         # Step 4: WFS namespace retry -- if layer_name has a colon prefix, retry without it
@@ -1311,8 +1446,14 @@ async def preview_service_layer(
                     order_field=None,
                     result_limit=5,
                 )
-                preview_data = await run_service_preview(
-                    retry_source, retry_layer, credential=service_credential
+                preview_data = await _run_service_preview_or_refuse(
+                    db,
+                    user.id,
+                    request.url,
+                    request.layer_name,
+                    retry_source,
+                    retry_layer,
+                    credential=service_credential,
                 )
             except (IngestionError, ValueError):
                 logger.warning(

--- a/backend/app/platform/jobs/defer_guard.py
+++ b/backend/app/platform/jobs/defer_guard.py
@@ -86,12 +86,30 @@ class DeferFailed(HTTPException):
     Same rule the review applied to ``_finalize`` one layer up: a helper that
     performs a state change reports whether it happened, rather than leaving the
     caller to assume.
+
+    fix(#1755 item 10): ``cause`` is the exception that made the guard raise —
+    either the dispatch marker write (`stamp_commit_attempted`) or the
+    ``defer_call`` itself. Both used to collapse into the same fixed 503 body,
+    so a bug inside the closure that builds the defer call (a `TypeError` from
+    a bad argument, say) read identically to Procrastinate's queue genuinely
+    being unreachable, and only ``str(cause)`` — never logged or returned here
+    — told the two apart. ``cause_class`` is ``type(cause).__name__``: a
+    Python identifier, never the exception's own message, so it cannot carry a
+    credential or a provider-chosen string the way ``str(cause)`` can. It goes
+    in ``detail`` as a coded field precisely because it is safe to return —
+    the raw message is not, and stays out of both the body and this
+    exception's own attributes.
     """
 
-    def __init__(self, *, rolled_back: bool) -> None:
+    def __init__(self, *, rolled_back: bool, cause: BaseException) -> None:
+        self.cause_class = type(cause).__name__
         super().__init__(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-            detail="Task queue unavailable, please retry",
+            detail={
+                "code": "queue_unavailable",
+                "message": "Task queue unavailable, please retry",
+                "cause_class": self.cause_class,
+            },
         )
         self.rolled_back = rolled_back
 
@@ -298,13 +316,13 @@ async def defer_with_orphan_guard(
                 "dispatch marker write"
             )
         rolled_back = await _settle_after_failed_dispatch(rollback, stamp_exc, db)
-        raise DeferFailed(rolled_back=rolled_back) from stamp_exc
+        raise DeferFailed(rolled_back=rolled_back, cause=stamp_exc) from stamp_exc
 
     try:
         await defer_call()
     except Exception as defer_exc:  # broad: defer_async can throw various job-runner errors; orphan-guard handles all
         rolled_back = await _settle_after_failed_dispatch(rollback, defer_exc, db)
-        raise DeferFailed(rolled_back=rolled_back) from defer_exc
+        raise DeferFailed(rolled_back=rolled_back, cause=defer_exc) from defer_exc
 
 
 async def settle_ingest_job_failed(

--- a/backend/app/processing/ingest/tasks_reupload.py
+++ b/backend/app/processing/ingest/tasks_reupload.py
@@ -9,7 +9,7 @@ import structlog
 from sqlalchemy import select, update
 
 from app.core.db.tenant_session import tenant_task
-from app.core.url_redaction import scrub_secret_from_exception
+from app.core.url_redaction import redact_exception_text, scrub_secret_from_exception
 from app.platform.cache.tiles import invalidate_catalog_cache
 from app.platform.dataset_origin import classify_origin, service_layer_identity
 from app.platform.jobs.heartbeat import (
@@ -79,6 +79,28 @@ async def _drop_attempt_staging_table(staging_table: str) -> None:
             "attempt_staging_cleanup_failed",
             staging_table=staging_table,
             exc_info=True,
+        )
+
+
+async def _finally_cleanup(coro, *, what: str, job_id: str) -> None:
+    """Run one `finally`-block cleanup step; log rather than raise a failure.
+
+    fix(#1755 item 11): `reupload_service`'s `finally` block used to await
+    `stop_ingest_job_heartbeat` and `_drop_attempt_staging_table` bare, so an
+    exception from either replaced whatever the `try`/`except` above it was
+    already propagating -- silently turning an ingest failure into an
+    unrelated cleanup error in the queue row and the caller's `except`.
+    `_drop_attempt_staging_table` already swallows everything it raises
+    internally; routing it through here too is defence in depth against that
+    contract changing without this call site noticing.
+    """
+    try:
+        await coro
+    except Exception as exc:  # broad: a finally-block cleanup must never replace the exception it is propagating past
+        structlog.get_logger().exception(
+            f"{what} cleanup failed",
+            job_id=job_id,
+            error=redact_exception_text(exc),
         )
 
 
@@ -1293,5 +1315,19 @@ async def reupload_service(
             await err_session.commit()
         raise
     finally:
-        await stop_ingest_job_heartbeat(heartbeat_task)
-        await _drop_attempt_staging_table(staging_tn)
+        # fix(#1755 item 11): routed through `_finally_cleanup` so a failure
+        # in either call logs rather than replacing the ingest exception
+        # `raise` above is propagating (or the OTHER cleanup call, since each
+        # runs regardless of whether its sibling failed). `purge_token_on_
+        # failure` (`tasks_common.py`), the decorator around this task, still
+        # sees whatever exception `reupload_service` itself raised.
+        await _finally_cleanup(
+            stop_ingest_job_heartbeat(heartbeat_task),
+            what="reupload_service heartbeat",
+            job_id=str(job_uuid),
+        )
+        await _finally_cleanup(
+            _drop_attempt_staging_table(staging_tn),
+            what="reupload_service staging",
+            job_id=str(job_uuid),
+        )

--- a/backend/app/processing/ingest/tasks_vector.py
+++ b/backend/app/processing/ingest/tasks_vector.py
@@ -10,7 +10,7 @@ import structlog
 from sqlalchemy import or_, text, update
 
 from app.core.db.tenant_session import tenant_task
-from app.core.url_redaction import scrub_secret_from_exception
+from app.core.url_redaction import redact_exception_text, scrub_secret_from_exception
 from app.platform.dataset_origin import service_layer_identity
 from app.platform.jobs.heartbeat import (
     attempt_scoped_staging_table,
@@ -115,6 +115,28 @@ async def _drop_attempt_staging_table(staging_table: str) -> None:
             "attempt_staging_cleanup_failed",
             staging_table=staging_table,
             exc_info=True,
+        )
+
+
+async def _finally_cleanup(coro, *, what: str, job_id: str) -> None:
+    """Run one `finally`-block cleanup step; log rather than raise a failure.
+
+    fix(#1755 item 11): `ingest_service`'s `finally` block used to await
+    `stop_ingest_job_heartbeat` and `_drop_attempt_staging_table` bare, so an
+    exception from either replaced whatever the `try`/`except` above it was
+    already propagating -- silently turning an ingest failure into an
+    unrelated cleanup error in the queue row and the caller's `except`.
+    `_drop_attempt_staging_table` already swallows everything it raises
+    internally; routing it through here too is defence in depth against that
+    contract changing without this call site noticing.
+    """
+    try:
+        await coro
+    except Exception as exc:  # broad: a finally-block cleanup must never replace the exception it is propagating past
+        structlog.get_logger().exception(
+            f"{what} cleanup failed",
+            job_id=job_id,
+            error=redact_exception_text(exc),
         )
 
 
@@ -1352,5 +1374,19 @@ async def ingest_service(
                 )
         raise
     finally:
-        await stop_ingest_job_heartbeat(heartbeat_task)
-        await _drop_attempt_staging_table(staging_table_name)
+        # fix(#1755 item 11): routed through `_finally_cleanup` so a failure
+        # in either call logs rather than replacing the ingest exception
+        # `raise` above is propagating (or the OTHER cleanup call, since each
+        # runs regardless of whether its sibling failed). `purge_token_on_
+        # failure` (`tasks_common.py`), the decorator around this task, still
+        # sees whatever exception `ingest_service` itself raised.
+        await _finally_cleanup(
+            stop_ingest_job_heartbeat(heartbeat_task),
+            what="ingest_service heartbeat",
+            job_id=job_id,
+        )
+        await _finally_cleanup(
+            _drop_attempt_staging_table(staging_table_name),
+            what="ingest_service staging",
+            job_id=job_id,
+        )

--- a/backend/tests/test_defer_orphan_guard.py
+++ b/backend/tests/test_defer_orphan_guard.py
@@ -119,6 +119,101 @@ class TestDeferWithOrphanGuard:
 
         asyncio.run(_check())
 
+    def test_defer_failed_cause_class_names_the_defer_call_exception(self):
+        """fix(#1755 item 10): the 503 body carries the CLASS of whatever made
+        the guard raise, coded and redacted -- never the exception's own
+        message, which can carry a credential or provider-chosen text.
+        """
+
+        async def _check():
+            from app.platform.jobs.defer_guard import (
+                DeferFailed,
+                defer_with_orphan_guard,
+            )
+
+            mock_db = AsyncMock()
+            mock_db.commit = AsyncMock()
+
+            class _QueueOutage(RuntimeError):
+                pass
+
+            async def _defer() -> None:
+                raise _QueueOutage("connection refused: 10.0.0.9:5432 secret=abc123")
+
+            async def _rollback(exc: BaseException) -> None:
+                return None
+
+            with pytest.raises(DeferFailed) as exc_info:
+                await defer_with_orphan_guard(
+                    _defer, rollback=_rollback, db=mock_db, job=_job()
+                )
+
+            assert exc_info.value.status_code == 503
+            assert exc_info.value.cause_class == "_QueueOutage"
+            assert exc_info.value.detail["cause_class"] == "_QueueOutage"
+            # The raw message -- including the address and the fake
+            # credential-shaped substring above -- never reaches the body.
+            assert "10.0.0.9" not in str(exc_info.value.detail)
+            assert "secret=abc123" not in str(exc_info.value.detail)
+            assert (
+                exc_info.value.detail["message"]
+                == "Task queue unavailable, please retry"
+            )
+
+        asyncio.run(_check())
+
+    def test_defer_failed_cause_class_names_the_dispatch_marker_exception(self):
+        """fix(#1755 item 10): a failure BEFORE the defer call -- the #1744
+        dispatch-attempted marker write -- gets a DIFFERENT `cause_class`
+        than a `defer_call` failure, even though both produce the identical
+        503 status and fixed message. This is what makes the two shapes
+        (a bug in the closure that built the dispatch vs. the queue itself
+        being unreachable) distinguishable without ever inspecting the raw
+        exception text.
+        """
+
+        async def _check():
+            from app.platform.jobs.defer_guard import (
+                DeferFailed,
+                defer_with_orphan_guard,
+            )
+
+            class _ClosureBug(ValueError):
+                pass
+
+            mock_db = AsyncMock()
+            mock_db.commit = AsyncMock()
+            mock_db.execute = AsyncMock(side_effect=_ClosureBug("bad argument shape"))
+            mock_db.rollback = AsyncMock()
+            mock_db.refresh = AsyncMock()
+
+            async def _defer() -> None:  # pragma: no cover - never reached
+                raise AssertionError(
+                    "defer_call must not run: the marker write failed first"
+                )
+
+            async def _rollback(exc: BaseException) -> None:
+                return None
+
+            with pytest.raises(DeferFailed) as exc_info:
+                await defer_with_orphan_guard(
+                    _defer, rollback=_rollback, db=mock_db, job=_job()
+                )
+
+            assert exc_info.value.status_code == 503
+            assert exc_info.value.cause_class == "_ClosureBug"
+            assert exc_info.value.detail["cause_class"] == "_ClosureBug"
+            assert "bad argument shape" not in str(exc_info.value.detail)
+            # Same fixed body shape as a defer_call-stage failure -- only
+            # `cause_class` tells the two apart.
+            assert (
+                exc_info.value.detail["message"]
+                == "Task queue unavailable, please retry"
+            )
+            assert exc_info.value.detail["code"] == "queue_unavailable"
+
+        asyncio.run(_check())
+
     def test_rollback_failure_still_raises_503(self):
         """If rollback itself raises, helper still surfaces the 503 to the client."""
 

--- a/backend/tests/test_failed_job_token_purge_1746.py
+++ b/backend/tests/test_failed_job_token_purge_1746.py
@@ -25,15 +25,22 @@ from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
+from httpx import AsyncClient
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.modules.catalog.datasets.domain.models import Dataset, Record
+from app.platform.jobs.heartbeat import (
+    stop_ingest_job_heartbeat as _real_stop_heartbeat,
+)
+from app.platform.jobs.models import IngestJob
 from app.platform.jobs.sweep import purge_terminal_job_tokens
 from app.processing.ingest import tasks_reupload, tasks_vector
 from app.processing.ingest.tasks_common import (
     purge_queued_job_token,
     purge_token_on_failure,
 )
+from tests.factories import get_user_id
 
 pytestmark = pytest.mark.anyio
 
@@ -279,3 +286,235 @@ class TestBothServiceTasksAreWired:
             assert "token" not in await _read_args(test_db_session, row_id)
         finally:
             await _drop_queue(test_db_session, queue)
+
+
+class TestCleanupFailuresDoNotMaskTheOriginalException:
+    """fix(#1755 item 11): a `finally`-block cleanup failure must not replace
+    the ingest exception, and the #1753 token purge must still run.
+
+    Each test fails the task with a distinctive exception from well past
+    staging-table setup (so `stop_ingest_job_heartbeat` and
+    `_drop_attempt_staging_table` both have real state to act on), then makes
+    BOTH cleanup calls in the `finally` block also raise. The mocked cleanup
+    still runs the real cleanup underneath (cancels the real heartbeat task,
+    drops the real staging table) before raising, so this pins the wrapping
+    itself rather than merely skipping the cleanup work. Without the item-11
+    fix, the ingest exception raised below is replaced by whichever cleanup
+    call runs first — `pytest.raises` would see `ValueError`/`KeyError`
+    instead of the ingest exception, which is exactly what these tests
+    refuse.
+    """
+
+    async def test_ingest_service_cleanup_failure_does_not_mask_the_original(
+        self,
+        client: AsyncClient,  # ensures app.core.db.async_session points at the test DB
+        test_db_session: AsyncSession,
+        monkeypatch,
+    ):
+        admin_id = await get_user_id(test_db_session, "admin")
+        job = IngestJob(
+            source_filename="Cleanup Failure Service",
+            source_url="https://services.example.com/svc/FeatureServer",
+            source_layer="0",
+            created_by=admin_id,
+            status="pending",
+            user_metadata={
+                "title": "Cleanup Failure Service",
+                "visibility": "private",
+                "service_type": "ArcGIS FeatureServer",
+                "layer_id": "0",
+                "geometry_type": None,
+                "source_columns": [],
+            },
+        )
+        test_db_session.add(job)
+        await test_db_session.commit()
+        await test_db_session.refresh(job)
+        job_id = job.id
+        attempt_id = job.attempt_id
+        assert attempt_id is not None
+
+        queue = f"tok-purge-{uuid.uuid4().hex[:12]}"
+        args = {
+            "job_id": str(job_id),
+            "attempt_id": str(attempt_id),
+            "source_url": job.source_url,
+            "source_layer": "0",
+            "user_id": str(admin_id),
+            "token": FAKE_TOKEN,
+        }
+        row_id = await _queue_row(
+            test_db_session, status="doing", queue_name=queue, args=args
+        )
+
+        async def _validate_url_noop(_url: str) -> None:
+            return None
+
+        async def _boom_credential(*_args, **_kwargs) -> str | None:
+            raise RuntimeError("simulated ingest failure")
+
+        async def _stop_heartbeat_and_raise(task) -> None:
+            # Real cleanup first (cancels the real background task), THEN the
+            # simulated failure — proves the wrapping, not merely that
+            # cleanup was skipped.
+            await _real_stop_heartbeat(task)
+            raise ValueError("cleanup boom: heartbeat")
+
+        real_drop_staging = tasks_vector._drop_attempt_staging_table
+
+        async def _drop_staging_and_raise(staging_table: str) -> None:
+            await real_drop_staging(staging_table)
+            raise KeyError("cleanup boom: staging")
+
+        monkeypatch.setattr(
+            "app.platform.security.validate_url_for_ssrf", _validate_url_noop
+        )
+        monkeypatch.setattr(
+            "app.platform.refresh.credentials.resolve_worker_credential",
+            _boom_credential,
+        )
+        monkeypatch.setattr(
+            tasks_vector, "stop_ingest_job_heartbeat", _stop_heartbeat_and_raise
+        )
+        monkeypatch.setattr(
+            tasks_vector, "_drop_attempt_staging_table", _drop_staging_and_raise
+        )
+
+        try:
+            context = SimpleNamespace(job=SimpleNamespace(id=row_id))
+            with pytest.raises(RuntimeError, match="simulated ingest failure"):
+                await tasks_vector.ingest_service(
+                    context,
+                    job_id=str(job_id),
+                    attempt_id=str(attempt_id),
+                    source_url=job.source_url,
+                    source_layer="0",
+                    user_id=str(admin_id),
+                    token=FAKE_TOKEN,
+                )
+
+            after = await _read_args(test_db_session, row_id)
+            assert "token" not in after, "the #1753 purge must still run"
+        finally:
+            await _drop_queue(test_db_session, queue)
+
+    async def test_reupload_service_cleanup_failure_does_not_mask_the_original(
+        self,
+        client: AsyncClient,  # ensures app.core.db.async_session points at the test DB
+        test_db_session: AsyncSession,
+        monkeypatch,
+    ):
+        admin_id = await get_user_id(test_db_session, "admin")
+        table_name = f"ds_cleanup_{uuid.uuid4().hex[:12]}"
+        record = Record(
+            title="Cleanup Failure Reupload",
+            summary="fix(#1755 item 11) fixture",
+            visibility="private",
+            record_status="published",
+            created_by=admin_id,
+        )
+        test_db_session.add(record)
+        await test_db_session.flush()
+        dataset = Dataset(
+            record_id=record.id,
+            table_name=table_name,
+            feature_count=1,
+            source_format="arcgis_featureserver",
+            source_filename="quakes",
+            source_url="https://services.example.com/svc/FeatureServer/0",
+        )
+        test_db_session.add(dataset)
+        await test_db_session.commit()
+        await test_db_session.refresh(dataset)
+        dataset_id = dataset.id
+
+        job = IngestJob(
+            dataset_id=dataset_id,
+            source_filename="quakes",
+            source_url="https://services.example.com/svc/FeatureServer/0",
+            source_layer="0",
+            created_by=admin_id,
+            status="pending",
+            user_metadata={
+                "reupload": True,
+                "dataset_id": str(dataset_id),
+                "service_type": "ArcGIS FeatureServer",
+                "layer_id": 0,
+                "source_type": "service_url",
+            },
+        )
+        test_db_session.add(job)
+        await test_db_session.commit()
+        await test_db_session.refresh(job)
+        job_id = job.id
+        attempt_id = job.attempt_id
+        assert attempt_id is not None
+
+        queue = f"tok-purge-{uuid.uuid4().hex[:12]}"
+        args = {
+            "job_id": str(job_id),
+            "attempt_id": str(attempt_id),
+            "dataset_id": str(dataset_id),
+            "source_url": job.source_url,
+            "source_layer": "0",
+            "user_id": str(admin_id),
+            "token": FAKE_TOKEN,
+        }
+        row_id = await _queue_row(
+            test_db_session, status="doing", queue_name=queue, args=args
+        )
+
+        async def _validate_url_noop(_url: str) -> None:
+            return None
+
+        def _boom_service_type(_raw: str):
+            raise RuntimeError("simulated reupload failure")
+
+        async def _stop_heartbeat_and_raise(task) -> None:
+            await _real_stop_heartbeat(task)
+            raise ValueError("cleanup boom: heartbeat")
+
+        real_drop_staging = tasks_reupload._drop_attempt_staging_table
+
+        async def _drop_staging_and_raise(staging_table: str) -> None:
+            await real_drop_staging(staging_table)
+            raise KeyError("cleanup boom: staging")
+
+        monkeypatch.setattr(
+            "app.platform.security.validate_url_for_ssrf", _validate_url_noop
+        )
+        # fix(#1755 item 11) test: `resolve_service_type` runs AFTER
+        # `staging_tn`/`heartbeat_task` are both set, so failing here (rather
+        # than at credential resolution, which runs before either) is what
+        # gives both cleanup calls real state to act on.
+        monkeypatch.setattr(tasks_reupload, "resolve_service_type", _boom_service_type)
+        monkeypatch.setattr(
+            tasks_reupload, "stop_ingest_job_heartbeat", _stop_heartbeat_and_raise
+        )
+        monkeypatch.setattr(
+            tasks_reupload, "_drop_attempt_staging_table", _drop_staging_and_raise
+        )
+
+        try:
+            context = SimpleNamespace(job=SimpleNamespace(id=row_id))
+            with pytest.raises(RuntimeError, match="simulated reupload failure"):
+                await tasks_reupload.reupload_service(
+                    context,
+                    job_id=str(job_id),
+                    attempt_id=str(attempt_id),
+                    dataset_id=str(dataset_id),
+                    source_url=job.source_url,
+                    source_layer="0",
+                    user_id=str(admin_id),
+                    token=FAKE_TOKEN,
+                )
+
+            after = await _read_args(test_db_session, row_id)
+            assert "token" not in after, "the #1753 purge must still run"
+        finally:
+            await _drop_queue(test_db_session, queue)
+            await test_db_session.rollback()
+            await test_db_session.execute(
+                text(f'DROP TABLE IF EXISTS data."{table_name}" CASCADE')
+            )
+            await test_db_session.commit()

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -2717,7 +2717,13 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # hostname into the 400 body or the persisted audit reason -- both now
     # carry a fixed policy string; the raw text stays in the server-side log
     # line only. Cap 1625 -> 1639, exact.
-    "backend/app/modules/catalog/sources/router.py": 1639,
+    # fix(#1755 item 9): +141. `_preview_refusal_response` and
+    # `_run_service_preview_or_refuse` map every typed refusal
+    # `run_service_preview` and its callees can raise to a coded 4xx before
+    # `preview_service_layer`'s broad `except Exception`, so a future edit
+    # that breaks one of those callees' "raises only HTTPException" contracts
+    # degrades to a coded 4xx instead of a 500. Cap 1639 -> 1780, exact.
+    "backend/app/modules/catalog/sources/router.py": 1780,
     # fix(#998): the DDL ported from migration 0019 so tenant-ownership adoption
     # is reachable forward-only at head. Almost all of it is SQL text, and it is
     # one artifact on purpose — the module is reviewed line-by-line against
@@ -3568,7 +3574,13 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # failure. Same finding as the refresh door's 422, one layer down; the
     # lines are the comment recording that the two messages have to agree.
     # Cap 1291 -> 1297, exact.
-    "backend/app/processing/ingest/tasks_reupload.py": 1297,
+    # fix(#1755 item 11): +36. `reupload_service`'s `finally` block routes
+    # both cleanup calls through the new shared `_finally_cleanup` helper, so
+    # a heartbeat-stop or staging-drop failure logs (redacted, exc_info)
+    # rather than replacing the ingest exception in flight; the #1753 token
+    # purge still runs, since the helper never re-raises. Cap 1297 -> 1333,
+    # exact.
+    "backend/app/processing/ingest/tasks_reupload.py": 1333,
     # --- entered by the inclusion rule, feat(#1266) -----------------------
     # The refresh door crossed 1000 when it gained its third execution
     # strategy. Two thirds of the addition is the STAC dispatcher, which is
@@ -4536,7 +4548,13 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # paused, not-dead worker from running the whole finalize pipeline
     # against a doomed row in the first place, for consistency with the
     # raster tails. Cap 1333 -> 1356, exact.
-    "backend/app/processing/ingest/tasks_vector.py": 1356,
+    # fix(#1755 item 11): +36. `ingest_service`'s `finally` block routes both
+    # cleanup calls through the new shared `_finally_cleanup` helper, so a
+    # heartbeat-stop or staging-drop failure logs (redacted, exc_info)
+    # rather than replacing the ingest exception in flight; the #1753 token
+    # purge still runs, since the helper never re-raises. Cap 1356 -> 1392,
+    # exact.
+    "backend/app/processing/ingest/tasks_vector.py": 1392,
     # --- entered by the inclusion rule ------------------------------------
     # Crossed 1000 lines adding the "unable to open datasource" friendly-
     # message mapping shared by run_ogrinfo and run_ogr2ogr: the pattern

--- a/backend/tests/test_services_endpoints.py
+++ b/backend/tests/test_services_endpoints.py
@@ -522,6 +522,200 @@ class TestPreviewEndpoint:
             )
             assert resp.status_code == 500
 
+    # -----------------------------------------------------------------
+    # fix(#1755 item 9): one test per typed refusal `run_service_preview`
+    # and its callees can raise, so `preview_service_layer`'s broad
+    # `except Exception` never turns one into a 500 the way it turned
+    # `RuntimeError` into one above. Each mocks `run_service_preview`
+    # directly (as `test_preview_unexpected_error` and
+    # `test_preview_ogrinfo_failure` already do above), bypassing the
+    # internal wrapping the classes normally go through, which is exactly
+    # what proves the ROUTER's own mapping — not a callee's — is what
+    # answers. Counterfactual: with `_preview_refusal_response` deleted (or
+    # its branch for the class under test removed), every one of these
+    # falls through to `except Exception` and asserts 500, same as
+    # `test_preview_unexpected_error`.
+    # -----------------------------------------------------------------
+
+    async def test_preview_cross_origin_endpoint_returns_422(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        mock_validate_ssrf,
+        mock_build_gdal_source,
+    ):
+        """A description naming a foreign operation endpoint is a 422, not a 500."""
+        from app.platform.service_endpoints import CrossOriginEndpointError
+
+        with patch(
+            "app.modules.catalog.sources.router.run_service_preview",
+            new_callable=AsyncMock,
+            side_effect=CrossOriginEndpointError("https://evil.example.com"),
+        ):
+            resp = await client.post(
+                "/services/preview/",
+                json={
+                    "url": "https://example.com/wfs",
+                    "service_type": "WFS 2.0.0",
+                    "layer_name": "buildings",
+                    "auth": {"method": "basic", "username": "u", "password": "p"},
+                },
+                headers=admin_auth_header,
+            )
+            assert resp.status_code == 422, resp.text
+            detail = resp.json()["detail"]
+            assert detail["code"] == "cross_origin_endpoint"
+            # The service-chosen credential value is never in the body.
+            assert "p" != detail["message"]
+
+    async def test_preview_endpoint_check_failed_returns_422(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        mock_validate_ssrf,
+        mock_build_gdal_source,
+    ):
+        """A description that could not be read is a 422, not a 500."""
+        from app.platform.service_endpoints import EndpointCheckFailedError
+
+        with patch(
+            "app.modules.catalog.sources.router.run_service_preview",
+            new_callable=AsyncMock,
+            side_effect=EndpointCheckFailedError(
+                "httpx.ConnectError: raw provider text"
+            ),
+        ):
+            resp = await client.post(
+                "/services/preview/",
+                json={
+                    "url": "https://example.com/wfs",
+                    "service_type": "WFS 2.0.0",
+                    "layer_name": "buildings",
+                    "auth": {"method": "basic", "username": "u", "password": "p"},
+                },
+                headers=admin_auth_header,
+            )
+            assert resp.status_code == 422, resp.text
+            detail = resp.json()["detail"]
+            assert detail["code"] == "endpoint_check_failed"
+            # `.reason` (the raw httpx text) never reaches the body.
+            assert "raw provider text" not in resp.text
+
+    async def test_preview_item_fetch_failed_returns_422(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        mock_validate_ssrf,
+        mock_build_gdal_source,
+    ):
+        """An OGC API items page that could not be read is a 422, not a 500.
+
+        `ItemFetchFailedError` subclasses `EndpointCheckFailedError`
+        (`platform/service_items.py`), so it matches the same `isinstance`
+        branch — this test pins that the subclass relationship is what the
+        mapping relies on, not a duplicated class list.
+        """
+        from app.platform.service_items import ItemFetchFailedError
+
+        with patch(
+            "app.modules.catalog.sources.router.run_service_preview",
+            new_callable=AsyncMock,
+            side_effect=ItemFetchFailedError("items link leaves the origin"),
+        ):
+            resp = await client.post(
+                "/services/preview/",
+                json={
+                    "url": "https://example.com/collections/x",
+                    "service_type": "OGC API Features",
+                    "layer_name": "x",
+                    "auth": {"method": "basic", "username": "u", "password": "p"},
+                },
+                headers=admin_auth_header,
+            )
+            assert resp.status_code == 422, resp.text
+            assert resp.json()["detail"]["code"] == "endpoint_check_failed"
+
+    async def test_preview_ssrf_error_mid_preview_returns_400(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        mock_validate_ssrf,
+        mock_build_gdal_source,
+    ):
+        """An SSRF refusal raised INSIDE run_service_preview (a redirect hop,
+        not the door's pre-flight `validate_url_for_ssrf`) is a 400, and never
+        echoes a redirect-chosen hostname (`SSRFResolutionError`'s own text).
+        """
+        with patch(
+            "app.modules.catalog.sources.router.run_service_preview",
+            new_callable=AsyncMock,
+            side_effect=SSRFResolutionError(
+                "Could not resolve hostname: internal-only.example.com (10.0.0.5)"
+            ),
+        ):
+            resp = await client.post(
+                "/services/preview/",
+                json={
+                    "url": "https://example.com/wfs",
+                    "service_type": "WFS 2.0.0",
+                    "layer_name": "buildings",
+                },
+                headers=admin_auth_header,
+            )
+            assert resp.status_code == 400, resp.text
+            assert "10.0.0.5" not in resp.text
+            assert "internal-only.example.com" not in resp.text
+
+    async def test_preview_href_too_long_returns_422(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        mock_validate_ssrf,
+        mock_build_gdal_source,
+    ):
+        """An over-length service-advertised href is a 422, not a 500."""
+        from app.platform.service_endpoints import HrefTooLongError
+
+        with patch(
+            "app.modules.catalog.sources.router.run_service_preview",
+            new_callable=AsyncMock,
+            side_effect=HrefTooLongError("next href exceeds 8192 bytes"),
+        ):
+            resp = await client.post(
+                "/services/preview/",
+                json={
+                    "url": "https://example.com/wfs",
+                    "service_type": "WFS 2.0.0",
+                    "layer_name": "buildings",
+                },
+                headers=admin_auth_header,
+            )
+            assert resp.status_code == 422, resp.text
+
+    async def test_preview_credential_header_value_error_returns_400(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        mock_validate_ssrf,
+        mock_build_gdal_source,
+    ):
+        """A plain ValueError from build_credential_header is a 400, not a 500."""
+        with patch(
+            "app.modules.catalog.sources.router.run_service_preview",
+            new_callable=AsyncMock,
+            side_effect=ValueError("unsupported credential method"),
+        ):
+            resp = await client.post(
+                "/services/preview/",
+                json={
+                    "url": "https://example.com/wfs",
+                    "service_type": "WFS 2.0.0",
+                    "layer_name": "buildings",
+                },
+                headers=admin_auth_header,
+            )
+            assert resp.status_code == 400, resp.text
+
     async def test_preview_creates_ingest_job(
         self,
         client: AsyncClient,


### PR DESCRIPTION
Addresses items 9, 10, and 11 from #1755 (follow-ups from the #1746 authenticated-service import wave).

## Item 9 — `preview_service_layer`'s broad `except Exception` could turn a typed refusal into a 500

`run_service_preview` and its callees (`preview.py`, `service_endpoints.py::assert_endpoints_stay_on_origin`, `service_items.py::materialise_oapif_items`) already convert every typed refusal into an `HTTPException` at their own raise sites today, but that safety depended entirely on those internal contracts holding. `preview_service_layer`'s catch-all had only one `except HTTPException: raise` clause (from #1752) standing between any OTHER exception class and a 500.

Both calls to `run_service_preview` (the initial attempt and the WFS-namespace retry) now go through a new `_run_service_preview_or_refuse` helper, which maps every typed refusal to its coded 4xx via `_preview_refusal_response` before the broad catch-all is ever reached — so a future edit that breaks one of those "raises only HTTPException" contracts degrades to a coded 4xx instead of a silent 500.

| Exception class | Status | Notes |
|---|---|---|
| `CrossOriginEndpointError` | 422 | `{code, message, field}` — `.policy` is a fixed per-class string (same shape `/probe` already returns) |
| `EndpointCheckFailedError` | 422 | same shape; also covers `ItemFetchFailedError` (subclasses it) |
| `SSRFError` | 400 | fixed policy phrase — `SSRFResolutionError`'s message can carry a redirect-chosen hostname, never echoed (mirrors the `/probe` fix from #1770 round 49 P3) |
| `HrefTooLongError` | 422 | fixed message; defence in depth — already pre-wrapped into the two classes above at every current raise site |
| `ValueError` (fixed-policy, e.g. `build_credential_header`) | 400 | fixed message |
| `IngestionError`, `HTTPException` | unchanged | pass through untouched — used for the namespace-retry signal and already-finished answers respectively |

One endpoint test per class in `test_services_endpoints.py::TestPreviewEndpoint`, each mocking `run_service_preview` directly (bypassing the internal wrapping the same way a regression would). Verified as a counterfactual: disabling the `CrossOriginEndpointError`/`EndpointCheckFailedError` branch locally turned those three tests back into 500s.

## Item 10 — `DeferFailed`'s 503 body discarded the cause

`defer_with_orphan_guard` raised `DeferFailed(rolled_back=...) from stamp_exc`/`from defer_exc`, but the 503 body was a fixed string with no way to tell a bug in the dispatching closure (stamp-write failure, or a `TypeError` inside the caller's `defer_call`) from a genuine Procrastinate/queue outage.

`DeferFailed` now takes a `cause: BaseException` and carries `cause_class = type(cause).__name__` — the exception's TYPE name only, never its message — both as an attribute and as a coded field in the 503 `detail`. The body stays free of raw text (no `str(cause)` anywhere), while `cause_class` distinguishes the two failure shapes.

Two new tests in `test_defer_orphan_guard.py` cover both shapes (a `defer_call` failure and a dispatch-marker-write failure), asserting the raw exception text never reaches the body while `cause_class` differs correctly between them.

## Item 11 — a `finally`-block cleanup failure could replace the original ingest exception

Both service tasks' `finally` blocks (`ingest_service` in `tasks_vector.py`, `reupload_service` in `tasks_reupload.py`) awaited `stop_ingest_job_heartbeat` and `_drop_attempt_staging_table` bare — an exception from either would silently replace whatever the task's own `try`/`except` was already propagating.

Both now route through a new `_finally_cleanup` helper (one copy per module, since the two task modules deliberately don't import each other) that logs a cleanup failure (redacted via `redact_exception_text`, with `exc_info`) instead of raising it. The #1753 token purge (`purge_token_on_failure`, the decorator wrapping both tasks) still runs in every path, since neither cleanup's `except` re-raises.

Two new DB-backed tests in `test_failed_job_token_purge_1746.py` drive the real tasks (via the fully-decorated `Task` object, with a `JobContext` so `purge_token_on_failure` actually fires) with a controlled ingest failure plus a controlled failure in BOTH cleanup calls, asserting the original exception type still propagates and the queued row's token is purged. Verified as a counterfactual: temporarily removing `_finally_cleanup`'s try/except made the `ingest_service` test fail with the cleanup's `ValueError` instead of the ingest `RuntimeError`.

## Schema/API impact

None. The `/services/preview` 4xx bodies for the newly-mapped classes are new response shapes for cases that previously either already answered correctly (via the internal wrapping) or would have been an undifferentiated 500. `DeferFailed`'s `detail` changes from a bare string to a small dict (adds `code`/`cause_class`, keeps `message`); no caller reads `.detail` today (checked `admin/router.py`'s only consumer, which reads `.rolled_back`).

## LOC caps

`_MODULE_LOC_CAPS` raised for the three touched capped files, each with a comment on what the lines bought: `sources/router.py` 1639→1780, `tasks_vector.py` 1356→1392, `tasks_reupload.py` 1297→1333.

## Verification

```
cd backend && uv run ruff check . && uv run ruff format --check .
cd backend && uv run pytest tests/test_layering.py tests/test_rule1_structural.py tests/test_rule2_structural.py -q
cd backend && uv run pytest tests/test_services_endpoints.py tests/test_defer_orphan_guard.py tests/test_commit_attempted_marker_doors.py tests/test_failed_job_token_purge_1746.py -q
cd backend && uv run pytest tests/test_door_token_policy_1746.py tests/test_service_auth_contract_1746.py tests/test_service_auth_transport_1746.py tests/test_preview_token_sec021.py tests/test_service_refresh_1220.py tests/test_reupload_idor.py tests/test_reupload.py -q
```

All green (233 + 586 tests respectively across the two broader sweeps).

Refs #1755