### PR TITLE
fix(tests): freeze the router clock in the degraded-S3 URL-import tests (#1808)

### DIFF
--- a/backend/tests/test_url_import_1705.py
+++ b/backend/tests/test_url_import_1705.py
@@ -17,6 +17,7 @@ import inspect
 import time
 import uuid
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 import httpx
@@ -96,6 +97,28 @@ def _install_transport(monkeypatch, handler, *, validate=None):
         validate if validate is not None else AsyncMock(),
     )
     return recorded
+
+
+def _freeze_router_clock(monkeypatch) -> None:
+    """Pin the ``time.monotonic()`` the router sees to one fixed instant.
+
+    fix(#1808): every stage-budget check in the handler measures a
+    deadline set once at request start, so the tiny artificial budgets
+    below are also racing real elapsed time. Under load, work ahead of
+    the check a test means to exercise can exhaust the budget first, and
+    a budget refusal (502) wins instead — observed in CI as
+    ``assert 502 == 413``. Frozen, every check sees the same instant and
+    the ordering is the one the test states.
+
+    Only the name bound in the router's module namespace is replaced;
+    the real ``time`` module (which asyncio's timers read) is untouched,
+    so bounded waits still time out on real wall-clock time.
+    """
+    frozen_at = time.monotonic()
+    monkeypatch.setattr(
+        "app.processing.ingest.router.time",
+        SimpleNamespace(monotonic=lambda: frozen_at),
+    )
 
 
 async def _get_job(test_db_session, job_id: str) -> IngestJob | None:
@@ -1640,6 +1663,11 @@ class TestUrlImportDegradedS3Failure:
         actually ends. Modeled with a delete that would hang for minutes:
         the response must arrive anyway."""
         monkeypatch.setattr(settings, "storage_provider", "s3")
+        # fix(#1808): this budget is tighter still (1s). If real elapsed
+        # time eats it before `_stage_put_bounded` runs, that call raises
+        # `_StagePutAbandoned` without ever creating `put_task`, and the
+        # reaper this test asserts on is never attached.
+        _freeze_router_clock(monkeypatch)
         monkeypatch.setattr(
             "app.processing.ingest.router.stage_total_budget_seconds",
             lambda: 1,
@@ -1709,6 +1737,11 @@ class TestUrlImportDegradedS3Failure:
         rejects the file (plenty of budget left) and the delete hangs: the
         response must still arrive, and the job must still be stamped."""
         monkeypatch.setattr(settings, "storage_provider", "s3")
+        # fix(#1808): freeze before the budget is derived. Otherwise a
+        # stall anywhere ahead of the quota race this test sets up — a
+        # slow pool checkout, a loaded runner — exhausts the 2s budget
+        # and `_remaining_fetch_budget` answers 502 in place of the 413.
+        _freeze_router_clock(monkeypatch)
         # Small budget so the bounded wait resolves fast in the test; the
         # production value is the joint stage budget's remainder.
         monkeypatch.setattr(


### PR DESCRIPTION
## Root cause

Both tests in `TestUrlImportDegradedS3Failure` shrink the joint stage budget to 1-2s so their bounded waits resolve fast, but every budget check in `upload_from_url` measures a real `time.monotonic()` deadline set once at request start. Any stall between that line and the check a test means to exercise — a slow pool checkout, a loaded runner under `pytest -n 4` — spends the whole budget, and the handler answers a budget refusal instead: `_remaining_fetch_budget` raises 502 before the fetch, or `_stage_put_bounded` raises `_StagePutAbandoned` (also 502) without ever creating the put task. In CI that surfaced as `assert 502 == 413` on `test_non_timeout_failure_bounds_its_cleanup`; the sibling `test_abandoned_put_hands_cleanup_to_the_reaper` has the same exposure on its 1s budget, where the reaper it asserts on would never be attached.

## The fix

Test-only. A `_freeze_router_clock` helper pins the `time` name bound in `app.processing.ingest.router`'s own module namespace to one instant, applied in both tests before the budget is derived, so every budget check sees the same instant and the ordering is the one each test states. The real `time` module is untouched — asyncio's timers read it directly — so `asyncio.wait(..., timeout=...)` still waits real wall-clock time and the bounded waits still genuinely time out, which is the behaviour under test.

No product-code change. The handler's ordering is correct; at the production budget (~510s) the pre-fetch work cannot exhaust it, and the 502 is the right answer when it genuinely does.

## Reproduction

The flake did not reproduce on a 16-core host: `tests/test_url_import_1705.py -n 4` was 0/10 failures, and 0/3 at `-n 8` with 12 CPU hogs, 0/2 at `-n 12` with 48. So the mechanism was pinned instead, with a scratch copy of the test carrying a 2.5s stall injected ahead of the fetch (standing in for CI contention), parametrized over the freeze:

- before: 502, `"Not enough time remained in the request budget to download this file"` — the exact CI symptom, 1/1
- after (same stall, `_freeze_router_clock` applied): 413, 0/1

Post-fix: `tests/test_url_import_1705.py -n 4` 10/10 clean (81 passed each), `ruff check` / `ruff format --check` clean.

Closes #1808