### PR TITLE
feat(sources): send the ArcGIS token as an Authorization header instead of a query parameter

### DIFF
--- a/backend/app/core/service_tokens.py
+++ b/backend/app/core/service_tokens.py
@@ -36,12 +36,22 @@ from enum import StrEnum
 # this charset exists to prevent. Constraining it to base64url would reject
 # legitimate ArcGIS tokens for a danger that path does not have.
 #
-# This set answers three questions at once, and lane C2 changed none of them:
+# This set answers FOUR questions at once, and lane C2 changed none of them:
 # it names the formats whose credential (a) is judged by
 # ``HEADER_TOKEN_CHARSET``, (b) is written to ``GDAL_HTTP_HEADER_FILE``, and
 # (c) is checked by ``assert_endpoints_stay_on_origin`` because GDAL follows
-# the service's own description with the header attached. All three still
+# the service's own description with the header attached, and (d) crosses to
+# the worker as a finished header LINE rather than as a bare token
+# (``platform/service_auth.py::wire_credential``, plan D9). All four still
 # exclude ArcGIS.
+#
+# fix(#1840 audit round 1): (d) was missing from this list, and its omission
+# is what produced a P1. ``wire_credential`` selected the bare-token branch by
+# asking whether ``build_credential_header`` answered None, which was
+# equivalent to this set until lane C2 taught the builder to compose an ArcGIS
+# header for the httpx transport. Every consumer of this set now asks
+# ``requires_header_token_policy`` by name; none infers the answer from the
+# builder. Anything added to this list must do the same.
 HEADER_AUTH_SERVICE_FORMATS: frozenset[str] = frozenset({"wfs", "ogcapi_features"})
 
 # feat(C2). ArcGIS's own service format, spelled here rather than imported from

--- a/backend/app/core/service_tokens.py
+++ b/backend/app/core/service_tokens.py
@@ -29,12 +29,48 @@ from contextvars import ContextVar
 from dataclasses import dataclass
 from enum import StrEnum
 
-# The services whose credential travels as an Authorization header. ArcGIS is
-# deliberately absent: its token is a query parameter, urlencoded into the
-# ESRIJSON source URL, so it never becomes a header line and never carries the
-# smuggling risk this charset exists to prevent. Constraining it to base64url
-# would reject legitimate ArcGIS tokens for a danger that path does not have.
+# The services whose credential becomes a line in the 0600 GDAL header file.
+# ArcGIS is deliberately absent, and stays absent: on the GDAL/ogr2ogr path its
+# token is still a query parameter, urlencoded into the ESRIJSON source URL, so
+# it never becomes a header line there and never carries the smuggling risk
+# this charset exists to prevent. Constraining it to base64url would reject
+# legitimate ArcGIS tokens for a danger that path does not have.
+#
+# This set answers three questions at once, and lane C2 changed none of them:
+# it names the formats whose credential (a) is judged by
+# ``HEADER_TOKEN_CHARSET``, (b) is written to ``GDAL_HTTP_HEADER_FILE``, and
+# (c) is checked by ``assert_endpoints_stay_on_origin`` because GDAL follows
+# the service's own description with the header attached. All three still
+# exclude ArcGIS.
 HEADER_AUTH_SERVICE_FORMATS: frozenset[str] = frozenset({"wfs", "ogcapi_features"})
+
+# feat(C2). ArcGIS's own service format, spelled here rather than imported from
+# ``modules/catalog/sources/adapters/arcgis.py`` because ``core/`` may not
+# import ``app.modules.*``; the adapter re-exports this name, so its importers
+# are unchanged.
+ARCGIS_SERVICE_FORMAT = "arcgis_featureserver"
+
+# feat(C2): the formats whose credential travels as an HTTP header on
+# GeoLens's OWN httpx requests, which is a wider set than the one above.
+# ArcGIS Server has accepted ``Authorization: Bearer <token>`` since 10.5.1 and
+# hosted ArcGIS Online always has; measured live on 2026-09-04 with a
+# referer-bound token against services6.arcgis.com, where the header form and
+# the ``?token=`` form return the same count and no ``Referer`` is needed.
+# Sending it as a header keeps the token out of the request URL, and so out of
+# httpx's ``HTTP Request: GET ...`` INFO log line, out of proxy and
+# load-balancer access logs, and out of the exception text an origin quotes
+# back.
+#
+# A separate set rather than a widened ``HEADER_AUTH_SERVICE_FORMATS`` because
+# all three of that set's questions are still no for ArcGIS: the base64url
+# charset would refuse ArcGIS tokens holding ``+`` or ``/``, nothing writes an
+# ArcGIS credential to the GDAL header file, and the ArcGIS adapter composes
+# every URL it reads from the base URL rather than following an endpoint the
+# service describes, so there is no foreign-operation-endpoint class for
+# ``assert_endpoints_stay_on_origin`` to bound.
+HEADER_TRANSPORT_SERVICE_FORMATS: frozenset[str] = HEADER_AUTH_SERVICE_FORMATS | {
+    ARCGIS_SERVICE_FORMAT
+}
 
 # SEC-FU-04 (sec-audit-20260519.md line 535, Phase 1063-03): JWT-shaped tokens
 # use the base64url charset (RFC 4648 §5) plus dot separators (RFC 7519 —
@@ -79,8 +115,25 @@ def header_token_rejection_reason(token: str | None) -> str | None:
 
 
 def requires_header_token_policy(source_format: str | None) -> bool:
-    """Whether *source_format*'s credential travels as an Authorization header."""
+    """Whether *source_format*'s credential becomes a GDAL header-file line.
+
+    Which is also the question ``HEADER_TOKEN_CHARSET`` and
+    ``assert_endpoints_stay_on_origin`` ask. Not the same question as
+    :func:`sends_credential_as_header`, which is about GeoLens's own httpx
+    requests and includes ArcGIS.
+    """
     return source_format in HEADER_AUTH_SERVICE_FORMATS
+
+
+def sends_credential_as_header(source_format: str | None) -> bool:
+    """Whether *source_format*'s credential travels as an HTTP header.
+
+    feat(C2). The gate ``build_credential_header`` reads. Wider than
+    :func:`requires_header_token_policy` by exactly ArcGIS, whose token became
+    an ``Authorization: Bearer`` header on the httpx path in lane C2 while
+    staying a query parameter on the GDAL path.
+    """
+    return source_format in HEADER_TRANSPORT_SERVICE_FORMATS
 
 
 # ---------------------------------------------------------------------------
@@ -368,20 +421,72 @@ def reset_registered_credential_secrets() -> None:
     _REGISTERED_CREDENTIAL_SECRETS.set(frozenset())
 
 
+def _composes_a_header(
+    service_format: str | None, method: CredentialMethod | str
+) -> bool:
+    """Whether ``build_credential_header`` should compose anything at all.
+
+    Three refusals, kept out of the builder so its own body stays one branch
+    per method. A format whose credential does not travel as a header, the
+    ``none`` method, and -- feat(C2) -- ArcGIS asked for a method it has no
+    spelling for. Basic and a named API key have no ArcGIS form at all
+    (``service_carries_method`` refuses them at every door), so answering
+    False keeps the builder from composing a header the service could never
+    read rather than trusting that the doors refused first.
+    """
+    if not sends_credential_as_header(service_format):
+        return False
+    if method == CredentialMethod.NONE:
+        return False
+    return not (
+        service_format == ARCGIS_SERVICE_FORMAT and method != CredentialMethod.BEARER
+    )
+
+
+def _bearer_token_rejection(auth: ServiceCredential) -> str | None:
+    """Why *auth*'s bearer token cannot become an Authorization value.
+
+    feat(C2): two charsets, one per transport, chosen by the service format.
+
+    A WFS or OGC API Features token becomes a line in a 0600 file libcurl
+    parses, where a stray CR or LF is a header-smuggling primitive, so it is
+    held to ``HEADER_TOKEN_CHARSET`` (base64url plus a length floor). An
+    ArcGIS token never reaches that file -- the GDAL path percent-encodes it
+    into the ESRIJSON source URL instead -- and legitimately holds ``+`` or
+    ``/``, which base64url refuses, so it is judged as a header VALUE:
+    printable ASCII with no whitespace. That still bans every whitespace
+    character, CR and LF included, so the smuggling class is closed on both
+    paths; only the collateral damage differs.
+
+    Returns the POLICY and never the token, on the same reasoning as every
+    other message in this module.
+    """
+    if auth.service_format == ARCGIS_SERVICE_FORMAT:
+        # Rejects ``None`` on its own, unlike its header-token sibling, which
+        # reads ``None`` as "no token supplied and none required".
+        return credential_input_rejection_reason(auth.token)
+    return header_token_rejection_reason(auth.token)
+
+
 def build_credential_header(
     auth: ServiceCredential | None,
 ) -> tuple[str, str] | None:
     """The one producer of a credential header, as a name and value pair.
 
     Returns ``None`` when no header should be sent at all: no credential, or a
-    service format whose credential does not travel as a header. That second
-    case is the ArcGIS invariant, and it is expressed as an allowlist of the
-    formats in ``HEADER_AUTH_SERVICE_FORMATS`` rather than as a denylist of
-    ArcGIS, so a format nobody thought about degrades to no header rather than
-    to a smuggled one. The cost is that a caller which does not set
+    service format whose credential does not travel as a header. That is
+    expressed as an allowlist, ``HEADER_TRANSPORT_SERVICE_FORMATS``, rather
+    than as a denylist, so a format nobody thought about degrades to no header
+    rather than to a smuggled one. The cost is that a caller which does not set
     ``service_format`` gets no header, and the resulting failure is a 401 from
     the origin, which is loud, rather than an Authorization line inside a URL
     query, which is not.
+
+    feat(C2): ArcGIS is in that allowlist now, for its bearer token only. What
+    is composed here is what GeoLens's own httpx requests send; the GDAL path
+    still percent-encodes the same token into the ESRIJSON source URL and never
+    reaches this function, which is why ``HEADER_AUTH_SERVICE_FORMATS`` (the
+    header-FILE set, and the base64url charset that goes with it) is unchanged.
 
     Raises ``ValueError`` when the inputs for the chosen method are unusable.
     The message is the policy and never the value, because it becomes a 422
@@ -407,15 +512,13 @@ def build_credential_header(
     """
     if auth is None:
         return None
-    if not requires_header_token_policy(auth.service_format):
-        return None
 
     method = auth.method
-    if method == CredentialMethod.NONE:
+    if not _composes_a_header(auth.service_format, method):
         return None
 
     if method == CredentialMethod.BEARER:
-        reason = header_token_rejection_reason(auth.token)
+        reason = _bearer_token_rejection(auth)
         if auth.token is None or reason is not None:
             raise ValueError(reason or HEADER_TOKEN_POLICY)
         pair = ("Authorization", f"{BEARER_SCHEME}{auth.token}")

--- a/backend/app/core/service_tokens.py
+++ b/backend/app/core/service_tokens.py
@@ -49,9 +49,20 @@ from enum import StrEnum
 # is what produced a P1. ``wire_credential`` selected the bare-token branch by
 # asking whether ``build_credential_header`` answered None, which was
 # equivalent to this set until lane C2 taught the builder to compose an ArcGIS
-# header for the httpx transport. Every consumer of this set now asks
-# ``requires_header_token_policy`` by name; none infers the answer from the
-# builder. Anything added to this list must do the same.
+# header for the httpx transport.
+#
+# fix(#1840 audit round 2): so the rule for a consumer of this set is that it
+# must not depend on the builder's answer to learn the FORMAT. The three
+# consumers that decide by format ask ``requires_header_token_policy`` by name
+# (``wire_credential``, ``sources/router.py::_probe_credential_line``,
+# ``processing/ingest/ogr.py::_sanitize_authorization_token``). Three others
+# still branch on ``pair is not None`` -- ``sources/preview.py``'s two header
+# file writers and ``sources/router.py::_fetch_ogcapi_collection_srid`` -- and
+# that is sound only because each is already fenced by its caller to a WFS or
+# OAPIF source (a ``gdal_source.startswith("WFS:"/"OAPIF:")`` test, or a
+# credential the caller bound to ``ogcapi_features``). Un-fencing any of those
+# means gating it on the predicate at the same time; the builder's answer is
+# not a substitute for asking.
 HEADER_AUTH_SERVICE_FORMATS: frozenset[str] = frozenset({"wfs", "ogcapi_features"})
 
 # feat(C2). ArcGIS's own service format, spelled here rather than imported from

--- a/backend/app/core/service_tokens.py
+++ b/backend/app/core/service_tokens.py
@@ -73,14 +73,15 @@ ARCGIS_SERVICE_FORMAT = "arcgis_featureserver"
 
 # feat(C2): the formats whose credential travels as an HTTP header on
 # GeoLens's OWN httpx requests, which is a wider set than the one above.
-# ArcGIS Server has accepted ``Authorization: Bearer <token>`` since 10.5.1 and
-# hosted ArcGIS Online always has; measured live on 2026-09-04 with a
-# referer-bound token against services6.arcgis.com, where the header form and
-# the ``?token=`` form return the same count and no ``Referer`` is needed.
-# Sending it as a header keeps the token out of the request URL, and so out of
-# httpx's ``HTTP Request: GET ...`` INFO log line, out of proxy and
-# load-balancer access logs, and out of the exception text an origin quotes
-# back.
+# ArcGIS Server has accepted a bearer token in a header since 10.5.1 and hosted
+# ArcGIS Online always has; measured live on 2026-09-04 with a referer-bound
+# token against services6.arcgis.com, where both header forms and the
+# ``?token=`` form return the same count and no ``Referer`` is needed. The name
+# sent is ``X-Esri-Authorization`` (see ``ESRI_AUTHORIZATION_HEADER`` below for
+# why the standard one is not safe on Enterprise). Sending it as a header keeps
+# the token out of the request URL, and so out of httpx's ``HTTP Request:
+# GET ...`` INFO log line, out of proxy and load-balancer access logs, and out
+# of the exception text an origin quotes back.
 #
 # A separate set rather than a widened ``HEADER_AUTH_SERVICE_FORMATS`` because
 # all three of that set's questions are still no for ArcGIS: the base64url
@@ -151,7 +152,8 @@ def sends_credential_as_header(source_format: str | None) -> bool:
 
     feat(C2). The gate ``build_credential_header`` reads. Wider than
     :func:`requires_header_token_policy` by exactly ArcGIS, whose token became
-    an ``Authorization: Bearer`` header on the httpx path in lane C2 while
+    an ``X-Esri-Authorization: Bearer`` header on the httpx path in lane C2
+    while
     staying a query parameter on the GDAL path.
     """
     return source_format in HEADER_TRANSPORT_SERVICE_FORMATS
@@ -211,6 +213,25 @@ HEADER_LINE_SEPARATOR = ": "
 # The scheme prefix the bearer branch composes, and the prefix the worker
 # recognizes to decide that the stricter base64url charset applies.
 BEARER_SCHEME = "Bearer "
+
+# fix(#1840 codex round 1): the header ArcGIS's own bearer token travels under.
+# Esri documents this name precisely BECAUSE a deployment may consume the
+# standard one: on ArcGIS Enterprise behind a Web Adaptor, or with web-tier
+# authentication (IWA or PKI in IIS), IIS answers 401/403 to a request carrying
+# `Authorization` before ArcGIS ever sees it, so the JSON envelope that the
+# 499 fallback keys on is never produced. Hosted ArcGIS Online accepts either
+# (measured 2026-09-04, rows 3-6 of plan section 9 question 1), so the name
+# that also works on Enterprise is the one to send.
+#
+# Rule A's objection -- a custom header name is forwarded verbatim across a
+# cross-origin redirect where `Authorization` is stripped -- does not apply on
+# the httpx path, because this exact name is in `_ALWAYS_CREDENTIAL_HEADERS`
+# (`app/platform/security.py:143`) and `_refuse_cross_origin_credential`
+# (same file, ~line 187, called from `_revalidate_redirect` at ~line 234)
+# REFUSES such a hop rather than following it. That is strictly louder than
+# httpx's silent strip of `Authorization`. GDAL never sends this: the ArcGIS
+# ingest path still percent-encodes the token into the ESRIJSON source URL.
+ESRI_AUTHORIZATION_HEADER = "X-Esri-Authorization"
 
 # The basic branch's, named for the same reason: the redactor recognizes it to
 # decide that what follows is base64 of a username and password, and so has a
@@ -542,6 +563,10 @@ def build_credential_header(
         reason = _bearer_token_rejection(auth)
         if auth.token is None or reason is not None:
             raise ValueError(reason or HEADER_TOKEN_POLICY)
+        if auth.service_format == ARCGIS_SERVICE_FORMAT:
+            esri_pair = (ESRI_AUTHORIZATION_HEADER, f"{BEARER_SCHEME}{auth.token}")
+            register_credential_secret(credential_header_line(esri_pair))
+            return esri_pair
         pair = ("Authorization", f"{BEARER_SCHEME}{auth.token}")
         register_credential_secret(credential_header_line(pair))
         return pair

--- a/backend/app/core/url_redaction.py
+++ b/backend/app/core/url_redaction.py
@@ -356,7 +356,10 @@ def scrub_registered_credentials(text: str) -> str:
 
     ``app.core.service_tokens.register_credential_secret`` is called at the
     one place a credential header is ever composed
-    (``build_credential_header``), so by the time anything downstream calls
+    (``build_credential_header``) and -- fix(#1840 audit round 1) -- at the one
+    place a credential is deliberately put in a URL instead
+    (``adapters/arcgis.py::_query_form_credential``, the pre-10.5.1 ArcGIS
+    fallback), so by the time anything downstream calls
     this, every secret in play for this request/job is already registered --
     exact-value redaction (``scrub_secret_value``, which also expands to the
     Basic cleartext and every URL-encoded form) then finds it wherever it

--- a/backend/app/modules/catalog/sources/adapters/arcgis.py
+++ b/backend/app/modules/catalog/sources/adapters/arcgis.py
@@ -20,7 +20,7 @@ from app.core.service_tokens import (
 )
 from app.core.url_redaction import redact_exception_text
 from app.platform.probe_bounds import bounded_probe_read
-from app.platform.security import SSRFError
+from app.platform.security import SSRFError, same_origin
 from app.platform.service_endpoints import (
     DEFAULT_CHECK_TIMEOUT,
     OGC_JSON_ACCEPT,
@@ -56,10 +56,11 @@ ARCGIS_HEADER_TOKEN_MIN_VERSION = (10, 5, 1)
 
 # ArcGIS reports an auth refusal as an error envelope inside an HTTP 200 body.
 # 499 means "Token Required": no usable token was seen at all, which is also
-# exactly what a pre-10.5.1 server says when it ignores the Authorization
-# header, and so is what triggers the query-form retry. 498 means a token WAS
-# read and rejected, so the header transport worked and a retry would only
-# resend a bad token.
+# exactly what a pre-10.5.1 server says when it ignores the credential header,
+# and so is what triggers the query-form retry. 498 means a token WAS read and
+# rejected, so the header transport worked and a retry would only resend a bad
+# token. A deployment whose WEB TIER eats the header never reaches either code;
+# `_WEB_TIER_AUTH_STATUSES` below is that case.
 _ARCGIS_TOKEN_REQUIRED_CODE = 499
 _ARCGIS_TOKEN_ERROR_CODES = frozenset({498, _ARCGIS_TOKEN_REQUIRED_CODE})
 
@@ -320,6 +321,52 @@ def arcgis_request_auth(
     return {pair[0]: pair[1]}, None
 
 
+# fix(#1840 codex round 1): the statuses a web tier answers BEFORE ArcGIS is
+# reached. On ArcGIS Enterprise behind a Web Adaptor, or with web-tier
+# authentication (IWA or PKI in IIS), the server in front consumes the
+# credential header and refuses at the HTTP layer, so `bounded_probe_read`'s
+# `raise_for_status()` fires and no JSON envelope is ever produced -- the 499
+# fallback below cannot see such a deployment at all.
+_WEB_TIER_AUTH_STATUSES = frozenset({401, 403})
+
+
+def _is_web_tier_refusal(exc: httpx.HTTPStatusError, requested_url: str) -> bool:
+    """Whether *exc* is a front-end refusal worth one query-form retry.
+
+    Three bounds, all of them about not turning a real 401 into a credential
+    replay somewhere else. The status has to be 401 or 403; the response must
+    not have come through a redirect (``history`` empty), because a refusal
+    from a host we were bounced to says nothing about the host we addressed;
+    and the responding URL has to be the same origin as the one asked for.
+    """
+    response = exc.response
+    if response is None or response.status_code not in _WEB_TIER_AUTH_STATUSES:
+        return False
+    if response.history:
+        return False
+    return same_origin(str(response.url), requested_url)
+
+
+async def _read_with_query_token(
+    client: httpx.AsyncClient,
+    build_url: Callable[[str | None], str],
+    token: str,
+) -> object:
+    """The query-form read both fallbacks land on. Never retried again.
+
+    Composing through ``_query_form_credential`` rather than inline is what
+    registers the token with the exact-value scrubber before it goes into a
+    URL (fix(#1840 audit round 1)), and having exactly one of these is what
+    bounds the whole fallback to a single extra request: nothing it calls can
+    reach either fallback branch again.
+    """
+    retry_headers, retry_token = _query_form_credential(token)
+    body, _ = await bounded_probe_read(
+        client, build_url(retry_token), headers=retry_headers, accept=OGC_JSON_ACCEPT
+    )
+    return json.loads(body)
+
+
 async def read_arcgis_json(
     client: httpx.AsyncClient,
     build_url: Callable[[str | None], str],
@@ -327,37 +374,49 @@ async def read_arcgis_json(
     *,
     current_version: object = None,
 ) -> object:
-    """One bounded ArcGIS JSON read, with the token in an Authorization header.
+    """One bounded ArcGIS JSON read, with the token in a credential header.
 
     feat(C2). *build_url* is handed the token that belongs in the QUERY, which
     is ``None`` on the header path, so each caller keeps composing its own
     parameters while only one place decides where the credential goes.
 
-    The retry is the version gate's safety net rather than a second policy: a
-    pre-10.5.1 server that never reported its version ignores the header and
-    answers 499 "Token Required" in an HTTP 200 envelope, and that answer is
-    the evidence the header transport did not work here. 498 is not retried --
-    it means a token was read and rejected, so the header arrived.
+    Two fallbacks to the query form, both bounded to exactly one extra request
+    on the same validated URL, and both landing on ``_read_with_query_token``
+    so neither can chain into the other:
+
+    * An HTTP 200 whose JSON envelope carries error 499 "Token Required". That
+      is what an ArcGIS Server older than 10.5.1 says when it ignores the
+      header and therefore sees no token. 498 is NOT retried -- it means a
+      token was read and rejected, so the header arrived.
+    * fix(#1840 codex round 1): an HTTP 401 or 403 on the request itself. A
+      Web Adaptor or web-tier authentication (IWA/PKI in IIS) in front of
+      ArcGIS Enterprise consumes the credential header and refuses before
+      ArcGIS runs, so there is no envelope for the first fallback to read, and
+      an authenticated probe, preview or import would fail on a portal where
+      ``?token=`` had always worked. Bounded by ``_is_web_tier_refusal``:
+      same origin, no redirect in between, and only those two statuses. A
+      second 401 propagates, because ``_read_with_query_token`` catches
+      nothing.
 
     Raises whatever ``bounded_probe_read`` raises, plus ``ValueError`` from
     ``json.loads``; every caller already handles both.
     """
     headers, query_token = arcgis_request_auth(token, current_version=current_version)
-    body, _ = await bounded_probe_read(
-        client, build_url(query_token), headers=headers, accept=OGC_JSON_ACCEPT
-    )
+    requested_url = build_url(query_token)
+    try:
+        body, _ = await bounded_probe_read(
+            client, requested_url, headers=headers, accept=OGC_JSON_ACCEPT
+        )
+    except httpx.HTTPStatusError as exc:
+        if not headers or not token or not _is_web_tier_refusal(exc, requested_url):
+            raise
+        return await _read_with_query_token(client, build_url, token)
     data = json.loads(body)
     if not headers or _arcgis_error_code(data) != _ARCGIS_TOKEN_REQUIRED_CODE:
         return data
-    # fix(#1840 audit round 1): through the same chooser, so the retry
-    # registers the token for exact-value scrubbing exactly as the version
-    # gate's own fallback does. `token` is truthy here -- `headers` is
-    # non-empty, which only happens for a token that composed a header.
-    _retry_headers, retry_token = _query_form_credential(token or "")
-    body, _ = await bounded_probe_read(
-        client, build_url(retry_token), headers=_retry_headers, accept=OGC_JSON_ACCEPT
-    )
-    return json.loads(body)
+    # `token` is truthy here: `headers` is non-empty, which only happens for a
+    # token that composed a header.
+    return await _read_with_query_token(client, build_url, token or "")
 
 
 def _query_token_suffix(query_token: str | None) -> str:

--- a/backend/app/modules/catalog/sources/adapters/arcgis.py
+++ b/backend/app/modules/catalog/sources/adapters/arcgis.py
@@ -14,9 +14,11 @@ from app.core.service_tokens import (
     CredentialMethod,
     ServiceCredential,
     build_credential_header,
+    register_credential_secret,
 )
 from app.core.url_redaction import redact_exception_text
 from app.platform.probe_bounds import bounded_probe_read
+from app.platform.security import SSRFError
 from app.platform.service_endpoints import (
     DEFAULT_CHECK_TIMEOUT,
     OGC_JSON_ACCEPT,
@@ -208,6 +210,9 @@ def parse_arcgis_current_version(value: object) -> tuple[int, int, int] | None:
         return (major, int(parts[1]), int(parts[2]))
     fraction = parts[1]
     if len(fraction) == 2:
+        # Note: this reads a hypothetical "10.10" as 10.1.0 rather than
+        # 10.10.0, which would fall to the query form. Esri has shipped no
+        # such version, and above 10.9 the numbering went to 11.x.
         return (major, int(fraction[0]), int(fraction[1]))
     return (major, int(fraction), 0)
 
@@ -239,6 +244,26 @@ def _arcgis_error_code(data: object) -> int | None:
     return code if isinstance(code, int) else None
 
 
+def _query_form_credential(token: str) -> tuple[dict[str, str], str | None]:
+    """The pre-10.5.1 fallback: no headers, the bare token for the query.
+
+    fix(#1840 audit round 1): the ONE place the query form is chosen, and the
+    reason it is a function rather than three ``return {}, token`` lines. On
+    the header path ``build_credential_header`` registers the line it composes
+    with ``register_credential_secret``, so ``redact_exception_text`` and the
+    structlog ``_scrub_text`` processor can scrub the credential out of
+    anything that echoes it back BY EXACT VALUE. Nothing registered the token
+    on this branch, which is precisely the branch that puts it in a URL -- and
+    ArcGIS answers an auth refusal with a server-chosen ``message`` that this
+    module logs at WARNING. Redaction there fell back to pattern matching on a
+    ``token=`` query key, the shape-dependent coverage #1770 round 43
+    introduced the registry to replace. Registered here so both transports
+    are covered by the same exact-value scrub.
+    """
+    register_credential_secret(token)
+    return {}, token
+
+
 def arcgis_request_auth(
     token: str | None, *, current_version: object = None
 ) -> tuple[dict[str, str], str | None]:
@@ -259,7 +284,7 @@ def arcgis_request_auth(
     if not token:
         return {}, None
     if not arcgis_accepts_header_token(current_version):
-        return {}, token
+        return _query_form_credential(token)
     try:
         pair = build_credential_header(
             ServiceCredential(
@@ -269,9 +294,9 @@ def arcgis_request_auth(
             )
         )
     except ValueError:
-        return {}, token
+        return _query_form_credential(token)
     if pair is None:
-        return {}, token
+        return _query_form_credential(token)
     return {pair[0]: pair[1]}, None
 
 
@@ -304,8 +329,13 @@ async def read_arcgis_json(
     data = json.loads(body)
     if not headers or _arcgis_error_code(data) != _ARCGIS_TOKEN_REQUIRED_CODE:
         return data
+    # fix(#1840 audit round 1): through the same chooser, so the retry
+    # registers the token for exact-value scrubbing exactly as the version
+    # gate's own fallback does. `token` is truthy here -- `headers` is
+    # non-empty, which only happens for a token that composed a header.
+    _retry_headers, retry_token = _query_form_credential(token or "")
     body, _ = await bounded_probe_read(
-        client, build_url(token), headers={}, accept=OGC_JSON_ACCEPT
+        client, build_url(retry_token), headers=_retry_headers, accept=OGC_JSON_ACCEPT
     )
     return json.loads(body)
 
@@ -382,6 +412,19 @@ async def _probe_arcgis_service_within_deadline(
         # 499 retry is what covers a pre-10.5.1 server here, since there is no
         # earlier document to have read `currentVersion` from.
         data = await read_arcgis_json(client, _service_info_url, token)
+    except SSRFError:
+        # fix(#1840 audit round 1): FIRST, because `SSRFError` subclasses
+        # `ValueError` (`platform/security.py`) and the `except (ValueError,
+        # TypeError)` below is the clause that catches `json.loads` failing.
+        # Before lane C2 the network read and the parse sat in two separate
+        # `try` blocks, so a refused redirect hop -- a blocked address, or a
+        # cross-origin one that would have forwarded a credential header --
+        # propagated to the `/probe` door and became its coded refusal.
+        # Folding the parse into the request's `try` silently downgraded that
+        # to "not an ArcGIS service", and the caller then went on trying the
+        # remaining probes. The SSRF itself was still blocked; the ANSWER the
+        # operator gets is what regressed.
+        raise
     except (
         httpx.HTTPStatusError,
         httpx.TransportError,

--- a/backend/app/modules/catalog/sources/adapters/arcgis.py
+++ b/backend/app/modules/catalog/sources/adapters/arcgis.py
@@ -11,9 +11,11 @@ import structlog
 
 from app.core.service_tokens import (
     ARCGIS_SERVICE_FORMAT,
+    HEADER_TOKEN_MIN_LENGTH,
     CredentialMethod,
     ServiceCredential,
     build_credential_header,
+    credential_input_rejection_reason,
     register_credential_secret,
 )
 from app.core.url_redaction import redact_exception_text
@@ -259,8 +261,26 @@ def _query_form_credential(token: str) -> tuple[dict[str, str], str | None]:
     ``token=`` query key, the shape-dependent coverage #1770 round 43
     introduced the registry to replace. Registered here so both transports
     are covered by the same exact-value scrub.
+
+    fix(#1840 audit round 2): with a floor, because exact-value scrubbing is
+    a substring replacement over every log line in the request's context and
+    a short value is a substring of ordinary text. ArcGIS is the one transport
+    whose token is never held to ``HEADER_TOKEN_CHARSET`` -- ``credential_or_422``
+    returns before that check for a URL-query format -- so nothing upstream
+    rejects a four-character one. Measured: registering ``json`` rewrote
+    ``https://json.example.com`` to ``https://***.example.com`` in that
+    request's own logs, which corrupts the diagnostics the redactor exists to
+    make safe rather than protecting anything (a real AGO token is a hundred
+    characters of base64url). The same floor and charset the header transport
+    already applies is what decides: a value that could not have been a header
+    credential is not registered, and is not scrubbed. The credential still
+    reaches the origin either way; only the log-scrub registration is gated.
     """
-    register_credential_secret(token)
+    if (
+        credential_input_rejection_reason(token) is None
+        and len(token) >= HEADER_TOKEN_MIN_LENGTH
+    ):
+        register_credential_secret(token)
     return {}, token
 
 

--- a/backend/app/modules/catalog/sources/adapters/arcgis.py
+++ b/backend/app/modules/catalog/sources/adapters/arcgis.py
@@ -3,11 +3,18 @@
 import asyncio
 import json
 import re
+from collections.abc import Callable
 from urllib.parse import quote, urlencode, urlparse
 
 import httpx
 import structlog
 
+from app.core.service_tokens import (
+    ARCGIS_SERVICE_FORMAT,
+    CredentialMethod,
+    ServiceCredential,
+    build_credential_header,
+)
 from app.core.url_redaction import redact_exception_text
 from app.platform.probe_bounds import bounded_probe_read
 from app.platform.service_endpoints import (
@@ -18,11 +25,39 @@ from app.platform.service_endpoints import (
 
 logger = structlog.stdlib.get_logger(__name__)
 
-# What this adapter is, in the vocabulary ``build_credential_header`` reads.
-# Deliberately absent from ``HEADER_AUTH_SERVICE_FORMATS``: an ArcGIS token is
-# percent-encoded into the service URL, so the builder answers None for it and
-# no header is ever composed for this transport (plan D9).
-ARCGIS_SERVICE_FORMAT = "arcgis_featureserver"
+# Re-exported so every existing importer of ``ARCGIS_SERVICE_FORMAT`` from this
+# module keeps working; the literal itself lives in ``core/service_tokens.py``
+# now, beside the two sets that decide what a format's credential may become,
+# because ``core/`` may not import ``app.modules.*`` (feat(C2)).
+__all__ = [
+    "ARCGIS_SERVICE_FORMAT",
+    "ArcGISTokenError",
+    "arcgis_accepts_header_token",
+    "arcgis_request_auth",
+    "build_arcgis_count_query_url",
+    "enrich_arcgis_feature_counts",
+    "fetch_arcgis_feature_count",
+    "fetch_arcgis_layer_preview",
+    "fetch_arcgis_pagination_info",
+    "normalize_arcgis_url",
+    "parse_arcgis_current_version",
+    "probe_arcgis_service",
+]
+
+# feat(C2). ArcGIS Server started reading a bearer token from an HTTP header at
+# 10.5.1; before that the ``token`` query parameter was the only transport it
+# understood. Everything at or above this, and hosted ArcGIS Online whatever it
+# reports, gets the header.
+ARCGIS_HEADER_TOKEN_MIN_VERSION = (10, 5, 1)
+
+# ArcGIS reports an auth refusal as an error envelope inside an HTTP 200 body.
+# 499 means "Token Required": no usable token was seen at all, which is also
+# exactly what a pre-10.5.1 server says when it ignores the Authorization
+# header, and so is what triggers the query-form retry. 498 means a token WAS
+# read and rejected, so the header transport worked and a retry would only
+# resend a bad token.
+_ARCGIS_TOKEN_REQUIRED_CODE = 499
+_ARCGIS_TOKEN_ERROR_CODES = frozenset({498, _ARCGIS_TOKEN_REQUIRED_CODE})
 
 
 class ArcGISTokenError(Exception):
@@ -139,6 +174,172 @@ def normalize_arcgis_url(url: str) -> tuple[str, int | None]:
     return clean_url, layer_id
 
 
+def parse_arcgis_current_version(value: object) -> tuple[int, int, int] | None:
+    """Parse an ArcGIS ``currentVersion`` into a comparable triple.
+
+    feat(C2). Esri does not spell this the way semver does. ``currentVersion``
+    is a NUMBER, and a patch release is encoded as a second fractional digit:
+    10.5.1 is reported as ``10.51``, 10.4.1 as ``10.41``, while 10.5 is
+    ``10.5``. So ``10.5`` and ``10.51`` are two releases either side of the
+    line this function exists to draw, and reading them as floats puts
+    ``10.51`` above ``10.5`` for the wrong reason and ``10.5`` above ``10.41``
+    for another wrong reason. Dotted three-part strings ("10.5.1") are read
+    literally, because ArcGIS Enterprise's own documentation uses that spelling
+    in prose.
+
+    Returns ``None`` for anything unparseable, including ``None`` itself, and
+    every caller treats that as "version unknown".
+
+    The two-digit rule is ambiguous in principle for a hypothetical ``x.10``,
+    which this reads as ``x.1.0`` rather than ``x.10.0``. Esri has shipped no
+    such version, and the only comparison made here is against 10.5.1, where
+    both readings of any ``11.x`` land on the same side.
+    """
+    if value is None or isinstance(value, bool):
+        return None
+    text = str(value).strip()
+    if not re.fullmatch(r"\d+(\.\d+)*", text):
+        return None
+    parts = text.split(".")
+    major = int(parts[0])
+    if len(parts) == 1:
+        return (major, 0, 0)
+    if len(parts) >= 3:
+        return (major, int(parts[1]), int(parts[2]))
+    fraction = parts[1]
+    if len(fraction) == 2:
+        return (major, int(fraction[0]), int(fraction[1]))
+    return (major, int(fraction), 0)
+
+
+def arcgis_accepts_header_token(current_version: object = None) -> bool:
+    """Whether this service reads a token from the Authorization header.
+
+    feat(C2). True unless the service reported a version older than 10.5.1.
+    An unknown or unparseable version is treated as new enough, because the
+    only deployments that cannot read the header are ArcGIS Server releases
+    from before 2017 and every one of those DOES report a version; hosted
+    ArcGIS Online is the common case and it reports 11.x. A wrong guess in
+    this direction is one extra request (the 499 retry below), and a wrong
+    guess in the other direction would put the token back in the URL for
+    everyone.
+    """
+    parsed = parse_arcgis_current_version(current_version)
+    return parsed is None or parsed >= ARCGIS_HEADER_TOKEN_MIN_VERSION
+
+
+def _arcgis_error_code(data: object) -> int | None:
+    """The ArcGIS error code in an HTTP 200 envelope, if there is one."""
+    if not isinstance(data, dict):
+        return None
+    error = data.get("error")
+    if not isinstance(error, dict):
+        return None
+    code = error.get("code")
+    return code if isinstance(code, int) else None
+
+
+def arcgis_request_auth(
+    token: str | None, *, current_version: object = None
+) -> tuple[dict[str, str], str | None]:
+    """How one ArcGIS request presents *token*: headers, and a query token.
+
+    feat(C2). Exactly one half is ever populated. The header form is the
+    default and the query form is the documented fallback for ArcGIS Server
+    older than 10.5.1; ``build_credential_header`` composes the header, so this
+    adapter is not a second producer of one (see
+    ``tests/test_credential_producer_structural.py``).
+
+    A token the builder refuses -- one holding whitespace or a non-ASCII
+    character, which no ArcGIS token does -- degrades to the query form rather
+    than failing the read, because the query form percent-encodes it and that
+    is exactly what this path did before lane C2. Nothing about the refused
+    value is logged: it is a credential.
+    """
+    if not token:
+        return {}, None
+    if not arcgis_accepts_header_token(current_version):
+        return {}, token
+    try:
+        pair = build_credential_header(
+            ServiceCredential(
+                method=CredentialMethod.BEARER,
+                service_format=ARCGIS_SERVICE_FORMAT,
+                token=token,
+            )
+        )
+    except ValueError:
+        return {}, token
+    if pair is None:
+        return {}, token
+    return {pair[0]: pair[1]}, None
+
+
+async def read_arcgis_json(
+    client: httpx.AsyncClient,
+    build_url: Callable[[str | None], str],
+    token: str | None = None,
+    *,
+    current_version: object = None,
+) -> object:
+    """One bounded ArcGIS JSON read, with the token in an Authorization header.
+
+    feat(C2). *build_url* is handed the token that belongs in the QUERY, which
+    is ``None`` on the header path, so each caller keeps composing its own
+    parameters while only one place decides where the credential goes.
+
+    The retry is the version gate's safety net rather than a second policy: a
+    pre-10.5.1 server that never reported its version ignores the header and
+    answers 499 "Token Required" in an HTTP 200 envelope, and that answer is
+    the evidence the header transport did not work here. 498 is not retried --
+    it means a token was read and rejected, so the header arrived.
+
+    Raises whatever ``bounded_probe_read`` raises, plus ``ValueError`` from
+    ``json.loads``; every caller already handles both.
+    """
+    headers, query_token = arcgis_request_auth(token, current_version=current_version)
+    body, _ = await bounded_probe_read(
+        client, build_url(query_token), headers=headers, accept=OGC_JSON_ACCEPT
+    )
+    data = json.loads(body)
+    if not headers or _arcgis_error_code(data) != _ARCGIS_TOKEN_REQUIRED_CODE:
+        return data
+    body, _ = await bounded_probe_read(
+        client, build_url(token), headers={}, accept=OGC_JSON_ACCEPT
+    )
+    return json.loads(body)
+
+
+def _query_token_suffix(query_token: str | None) -> str:
+    """``&token=<percent-encoded>``, or nothing at all.
+
+    fix(#1746 codex r7): percent-encode the token before concatenating it into
+    a URL -- a URL-reserved character in a raw token (``'``, ``#``, ``&``) can
+    change what the request means and, in a log line, end the ``URL_LIKE_RE``
+    match early enough to escape the redactor entirely. Only the pre-10.5.1
+    fallback reaches this now.
+    """
+    return f"&token={quote(query_token, safe='')}" if query_token else ""
+
+
+def build_arcgis_layer_info_url(
+    base_url: str, layer_id: int | str, query_token: str | None = None
+) -> str:
+    """``<service>/<layer>?f=json``, the layer's own metadata document.
+
+    feat(C2): one builder for the two callers that read it
+    (``fetch_arcgis_pagination_info`` and ``fetch_arcgis_layer_preview``), on
+    the same reasoning as ``build_arcgis_count_query_url`` -- and because the
+    version this module gates on is read out of exactly this document.
+    """
+    base = base_url.rstrip("/")
+    safe_layer_id = str(layer_id).strip("/")
+    params: dict[str, str] = {"f": "json"}
+    if query_token:
+        params["token"] = query_token
+    return f"{base}/{safe_layer_id}?{urlencode(params)}"
+
+
 async def probe_arcgis_service(
     base_url: str, client: httpx.AsyncClient, token: str | None = None
 ) -> dict | None:
@@ -166,37 +367,37 @@ async def _probe_arcgis_service_within_deadline(
     unchanged: it is not a `TimeoutError`, so the wrapper's `except
     TimeoutError` does not intercept it.
     """
+
+    def _service_info_url(query_token: str | None) -> str:
+        return f"{base_url}?f=json{_query_token_suffix(query_token)}"
+
     try:
-        # fix(#1746 codex r7): percent-encode the token before concatenating it
-        # into the URL -- a URL-reserved character in a raw token (', #, &)
-        # can change what the request means and, in a log line, end the
-        # URL_LIKE_RE match early enough to escape the redactor entirely.
-        query = f"{base_url}?f=json" + (
-            f"&token={quote(token, safe='')}" if token else ""
-        )
         # fix(#1770 round 41 P1): bounded read, not a plain `client.get` --
         # see `bounded_probe_read`'s docstring. `EndpointCheckFailedError`
         # joins the two httpx types this already caught: whatever the cause,
         # this degrades to "not an ArcGIS service" the same way.
-        body, _ = await bounded_probe_read(
-            client, query, headers={}, accept=OGC_JSON_ACCEPT
-        )
+        #
+        # feat(C2): this is the FIRST request to the service, so no version is
+        # known yet and the header form is what goes out. `read_arcgis_json`'s
+        # 499 retry is what covers a pre-10.5.1 server here, since there is no
+        # earlier document to have read `currentVersion` from.
+        data = await read_arcgis_json(client, _service_info_url, token)
     except (
         httpx.HTTPStatusError,
         httpx.TransportError,
         EndpointCheckFailedError,
     ) as exc:
-        # fix(#1770 round 39): this request embeds OUR OWN token in the URL
-        # (see the fix(#1746 codex r7) comment above) -- an HTTPStatusError's
-        # message quotes that whole URL back, so the caught exception's text
-        # must be redacted, not just the href a response body carries.
+        # fix(#1770 round 39): an HTTPStatusError's message quotes the whole
+        # request URL back, so the caught exception's text must be redacted,
+        # not just the href a response body carries. feat(C2) narrows what is
+        # in that URL -- the token is a header now, except on the pre-10.5.1
+        # fallback -- without removing the need: `build_credential_header`
+        # registers the composed line for exact-value scrubbing, and the
+        # fallback still puts `token=` in the query.
         logger.debug(
             "ArcGIS probe failed for %s: %s", base_url, redact_exception_text(exc)
         )
         return None
-
-    try:
-        data = json.loads(body)
     except (ValueError, TypeError):
         return None
 
@@ -217,7 +418,7 @@ async def _probe_arcgis_service_within_deadline(
         logger.warning(
             "ArcGIS error response: url=%s code=%s message=%s", base_url, code, message
         )
-        if code in (498, 499):  # Invalid/expired token
+        if code in _ARCGIS_TOKEN_ERROR_CODES:  # Invalid/expired token
             raise ArcGISTokenError(code, message)
         return None
 
@@ -278,22 +479,38 @@ async def enrich_arcgis_feature_counts(
     layers: list[dict],
     client: httpx.AsyncClient,
     token: str | None = None,
+    *,
+    current_version: object = None,
 ) -> list[dict]:
     """Enrich ArcGIS layers with feature counts.
 
     Fetches returnCountOnly=true for each layer. Uses asyncio.Semaphore(5)
     for concurrency limiting. On failure, keeps feature_count=None.
 
-    fix(#1770 round 44 P1): this request carries the request-scoped ArcGIS
-    ``token=`` query parameter, and `assert_endpoints_stay_on_origin` never
-    runs a bound for it at all -- it returns immediately for any
+    fix(#1755 item 14): the count query is composed by
+    ``build_arcgis_count_query_url`` rather than hand-rolled here for a third
+    time. Two behaviours change with the fold, both deliberate. The
+    ``where`` parameter is now percent-encoded by ``urlencode`` (``1%3D1``
+    either way) and the parameter ORDER follows the builder's, so a test
+    pinning the old literal string sees a different URL for the same request.
+    And on the pre-10.5.1 fallback the token is percent-encoded by
+    ``urlencode`` rather than by a hand-written ``quote(token, safe='')``,
+    which differs for a token containing reserved characters -- ``urlencode``
+    leaves nothing dangerous unencoded, but a ``+`` in a token now renders as
+    ``%2B`` where the old concatenation also produced ``%2B``, and a space
+    renders as ``+`` rather than ``%20``. ArcGIS decodes both.
+
+    fix(#1770 round 44 P1): the read is bounded (``bounded_probe_read`` under
+    ``DEFAULT_CHECK_TIMEOUT``) because ``assert_endpoints_stay_on_origin``
+    never runs a bound for ArcGIS at all -- it returns immediately for any
     ``service_format`` outside `HEADER_AUTH_SERVICE_FORMATS`
-    (``requires_header_token_policy``), which ArcGIS is deliberately not a
-    member of (the token travels in the URL, never as a header). The
-    ``client.get`` this used had no byte cap, no decoded-size cap, httpx's
-    default transparent decompression, and only the per-inactivity timeout,
-    so a hostile or compromised layer endpoint could exhaust the process on
-    this read with nothing else in the request path bounding it first.
+    (``requires_header_token_policy``), which ArcGIS is still not a member of.
+    feat(C2) did not change that: the endpoint check exists for a service that
+    DESCRIBES a foreign operation endpoint GDAL then follows, and this adapter
+    composes every URL it reads from ``base_url`` itself, dereferencing no
+    server-chosen href. A redirect away from that origin is the one remaining
+    way the credential could travel, and httpx drops ``Authorization`` across
+    a cross-origin redirect while ``make_safe_client`` re-validates every hop.
     """
     semaphore = asyncio.Semaphore(5)
 
@@ -302,17 +519,17 @@ async def enrich_arcgis_feature_counts(
             layer_id = layer.get("id")
             if layer_id is None:
                 return {**layer, "feature_count": None}
-            # fix(#1746 codex r7): same percent-encoding as probe_arcgis_service
-            # above -- see its comment.
-            url = (
-                f"{base_url}/{layer_id}/query?where=1%3D1&returnCountOnly=true&f=json"
-            ) + (f"&token={quote(token, safe='')}" if token else "")
+            layer_url = f"{base_url.rstrip('/')}/{layer_id}"
             try:
                 async with asyncio.timeout(DEFAULT_CHECK_TIMEOUT):
-                    body, _ = await bounded_probe_read(
-                        client, url, headers={}, accept=OGC_JSON_ACCEPT
+                    data = await read_arcgis_json(
+                        client,
+                        lambda query_token: build_arcgis_count_query_url(
+                            layer_url, query_token
+                        ),
+                        token,
+                        current_version=current_version,
                     )
-                    data = json.loads(body)
                 # fix(#1770 round 45 P2): a `200 5`/`200 []` response is valid
                 # JSON but not a dict, and `"error" in data`/`data.get(...)`
                 # on either raises `TypeError`/`AttributeError` -- neither
@@ -338,8 +555,15 @@ async def enrich_arcgis_feature_counts(
     return list(enriched)
 
 
-def build_arcgis_count_query_url(layer_url: str, token: str | None = None) -> str:
+def build_arcgis_count_query_url(layer_url: str, query_token: str | None = None) -> str:
     """The bounded count query for one FeatureServer layer.
+
+    feat(C2): *query_token* is the pre-10.5.1 fallback only. On the header
+    transport it is ``None`` and the returned URL carries no credential at all,
+    which is the point -- it is the URL httpx logs at INFO as ``HTTP Request:
+    GET ...``, the URL a proxy records, and the URL an origin quotes back in an
+    error. ``arcgis_request_auth`` decides which of the two it is; nothing
+    calls this with a raw token except through that decision.
 
     ``<layer>/query?where=1=1&returnCountOnly=true&f=json`` — the smallest
     request that exercises the QUERY operation, which is the operation
@@ -353,6 +577,10 @@ def build_arcgis_count_query_url(layer_url: str, token: str | None = None) -> st
     document would call it healthy and then fail in the worker. One builder,
     so the probe and the count fetcher cannot drift into probing one endpoint
     and depending on another.
+
+    fix(#1755 item 14): ``enrich_arcgis_feature_counts`` was the third
+    hand-rolled copy of this query and now calls this instead, so the builder
+    is finally the only producer the name promises.
     """
     # A stored origin_uri is provenance, not a curated endpoint: it can carry
     # a query string, a fragment, or an already-appended /query. Strip all
@@ -366,8 +594,8 @@ def build_arcgis_count_query_url(layer_url: str, token: str | None = None) -> st
         "returnCountOnly": "true",
         "f": "json",
     }
-    if token:
-        params["token"] = token
+    if query_token:
+        params["token"] = query_token
     return f"{clean}/query?{urlencode(params)}"
 
 
@@ -376,31 +604,35 @@ async def fetch_arcgis_feature_count(
     layer_id: int | str,
     client: httpx.AsyncClient,
     token: str | None = None,
+    *,
+    current_version: object = None,
 ) -> int | None:
     """Fetch a layer feature count from ArcGIS REST query metadata.
 
     fix(#1770 round 44 P1): same reasoning as `enrich_arcgis_feature_counts`
-    above -- this carries the request-scoped ArcGIS ``token=`` and
-    `assert_endpoints_stay_on_origin` runs no bound for it at all. Reads
-    through `bounded_probe_read` under `DEFAULT_CHECK_TIMEOUT` now, matching
-    the four service-type probes. `ArcGISTokenError`/`ValueError`/
-    `httpx.HTTPError` propagate unchanged to the caller, which already
-    handles them (`tasks_vector.py`'s ingest path, and
-    `fetch_arcgis_layer_preview` below); `EndpointCheckFailedError`/
+    above -- `assert_endpoints_stay_on_origin` runs no bound for ArcGIS at
+    all, so this reads through `bounded_probe_read` under
+    `DEFAULT_CHECK_TIMEOUT`, matching the four service-type probes.
+    `ArcGISTokenError`/`ValueError`/`httpx.HTTPError` propagate unchanged to
+    the caller, which already handles them (`tasks_vector.py`'s ingest path,
+    and `fetch_arcgis_layer_preview` below); `EndpointCheckFailedError`/
     `TimeoutError` join that same contract, since both mean the same thing
     to a caller as any other unreadable-response failure.
+
+    feat(C2): the token is an ``Authorization: Bearer`` header now, so the URL
+    this composes carries no credential (see ``build_arcgis_count_query_url``).
     """
     base = base_url.rstrip("/")
     safe_layer_id = str(layer_id).strip("/")
+    layer_url = f"{base}/{safe_layer_id}"
 
     async with asyncio.timeout(DEFAULT_CHECK_TIMEOUT):
-        body, _ = await bounded_probe_read(
+        data = await read_arcgis_json(
             client,
-            build_arcgis_count_query_url(f"{base}/{safe_layer_id}", token),
-            headers={},
-            accept=OGC_JSON_ACCEPT,
+            lambda query_token: build_arcgis_count_query_url(layer_url, query_token),
+            token,
+            current_version=current_version,
         )
-        data = json.loads(body)
     # fix(#1770 round 45 P2): same reasoning as `_fetch_count` above -- a
     # `200 5`/`200 []` response is valid JSON but not a dict, and this
     # function has no local `except` at all around the checks below, so an
@@ -412,7 +644,7 @@ async def fetch_arcgis_feature_count(
         error_info = data["error"]
         code = error_info.get("code", 0)
         message = error_info.get("message", "Unknown ArcGIS error")
-        if code in (498, 499):
+        if code in _ARCGIS_TOKEN_ERROR_CODES:
             raise ArcGISTokenError(code, message)
         return None
 
@@ -427,29 +659,34 @@ async def fetch_arcgis_pagination_info(
     layer_id: int | str,
     client: httpx.AsyncClient,
     token: str | None = None,
+    *,
+    current_version: object = None,
 ) -> tuple[int | None, bool, str | None]:
     """Fetch ArcGIS pagination support, page size, and stable order field.
 
     fix(#1770 round 44 P1): same reasoning as `enrich_arcgis_feature_counts`
-    above -- this carries the request-scoped ArcGIS ``token=`` and
-    `assert_endpoints_stay_on_origin` runs no bound for it at all. Reads
-    through `bounded_probe_read` under `DEFAULT_CHECK_TIMEOUT`.
+    above -- `assert_endpoints_stay_on_origin` runs no bound for ArcGIS at
+    all, so this reads through `bounded_probe_read` under
+    `DEFAULT_CHECK_TIMEOUT`.
+
+    feat(C2): the token is an ``Authorization: Bearer`` header now. This is
+    also the document ``currentVersion`` is read from, so a caller that has
+    already fetched it (``fetch_arcgis_layer_preview``) passes the version in
+    and skips the retry; this one has not, so it relies on the 499 retry.
     """
     base = base_url.rstrip("/")
     safe_layer_id = str(layer_id).strip("/")
-    params: dict[str, str] = {"f": "json"}
-    if token:
-        params["token"] = token
 
     try:
         async with asyncio.timeout(DEFAULT_CHECK_TIMEOUT):
-            body, _ = await bounded_probe_read(
+            data = await read_arcgis_json(
                 client,
-                f"{base}/{safe_layer_id}?{urlencode(params)}",
-                headers={},
-                accept=OGC_JSON_ACCEPT,
+                lambda query_token: build_arcgis_layer_info_url(
+                    base, safe_layer_id, query_token
+                ),
+                token,
+                current_version=current_version,
             )
-            data = json.loads(body)
     except (
         httpx.HTTPError,
         ValueError,
@@ -471,7 +708,7 @@ async def fetch_arcgis_pagination_info(
         error_info = data["error"]
         code = error_info.get("code", 0)
         message = error_info.get("message", "Unknown ArcGIS error")
-        if code in (498, 499):
+        if code in _ARCGIS_TOKEN_ERROR_CODES:
             raise ArcGISTokenError(code, message)
         return None, False, None
 
@@ -507,33 +744,35 @@ async def fetch_arcgis_layer_preview(
     Raises ``ArcGISTokenError`` on token errors so the router can surface a
     403. Other HTTP/parse failures raise ``httpx.HTTPError``/``ValueError``.
 
-    fix(#1770 round 44 P1): the metadata and sample-row reads below both
-    carry the request-scoped ArcGIS ``token=``, and (same reasoning as
-    `enrich_arcgis_feature_counts`) `assert_endpoints_stay_on_origin` never
-    bounds an ArcGIS-format read at all. Both now go through
+    fix(#1770 round 44 P1): (same reasoning as `enrich_arcgis_feature_counts`)
+    `assert_endpoints_stay_on_origin` never bounds an ArcGIS-format read at
+    all, so the metadata and sample-row reads below both go through
     `bounded_probe_read` under `DEFAULT_CHECK_TIMEOUT`; `EndpointCheckFailedError`/
     `TimeoutError` join the metadata read's propagation to the caller
     (`router.py`'s `except (httpx.HTTPError, ValueError, ...)`, widened to
     match) and the sample-row/feature-count reads' own local `except`
     clauses below (already best-effort, degrade to an empty/`None` result).
+
+    feat(C2): the token travels as an ``Authorization: Bearer`` header. The
+    metadata read is the one that discovers ``currentVersion``, so the two
+    reads after it are told what this service is and a pre-10.5.1 server costs
+    one retry rather than three.
     """
     base = base_url.rstrip("/")
     safe_layer_id = str(layer_id).strip("/")
 
     # --- Layer metadata: fields, geometry type, CRS, name ---
     # Query params are percent-encoded via urlencode so a token containing
-    # URL-reserved characters (+, &, %) cannot corrupt the query string.
-    meta_params: dict[str, str] = {"f": "json"}
-    if token:
-        meta_params["token"] = token
+    # URL-reserved characters (+, &, %) cannot corrupt the query string on the
+    # pre-10.5.1 fallback.
     async with asyncio.timeout(DEFAULT_CHECK_TIMEOUT):
-        meta_body, _ = await bounded_probe_read(
+        meta = await read_arcgis_json(
             client,
-            f"{base}/{safe_layer_id}?{urlencode(meta_params)}",
-            headers={},
-            accept=OGC_JSON_ACCEPT,
+            lambda query_token: build_arcgis_layer_info_url(
+                base, safe_layer_id, query_token
+            ),
+            token,
         )
-        meta = json.loads(meta_body)
 
     # fix(#1770 round 45 P2): a `200 5`/`200 []` response is valid JSON but
     # not a dict. `.get("fields", [])` below would raise `AttributeError`,
@@ -551,7 +790,7 @@ async def fetch_arcgis_layer_preview(
         error_info = meta["error"]
         code = error_info.get("code", 0)
         message = error_info.get("message", "Unknown ArcGIS error")
-        if code in (498, 499):
+        if code in _ARCGIS_TOKEN_ERROR_CODES:
             raise ArcGISTokenError(code, message)
         raise ValueError(f"ArcGIS layer metadata error ({code}): {message}")
 
@@ -575,26 +814,30 @@ async def fetch_arcgis_layer_preview(
         srid = None
 
     layer_name = meta.get("name")
+    # feat(C2): read once, from the document that was fetched anyway, and
+    # handed to both reads below so they pick the transport directly instead
+    # of discovering it from a 499.
+    current_version = meta.get("currentVersion")
 
     # --- Sample rows: small bounded query ---
     sample_rows: list[dict] = []
-    query_params: dict[str, str] = {
-        "where": "1=1",
-        "outFields": "*",
-        "resultRecordCount": str(sample_limit),
-        "f": "json",
-    }
-    if token:
-        query_params["token"] = token
+
+    def _sample_url(query_token: str | None) -> str:
+        query_params: dict[str, str] = {
+            "where": "1=1",
+            "outFields": "*",
+            "resultRecordCount": str(sample_limit),
+            "f": "json",
+        }
+        if query_token:
+            query_params["token"] = query_token
+        return f"{base}/{safe_layer_id}/query?{urlencode(query_params)}"
+
     try:
         async with asyncio.timeout(DEFAULT_CHECK_TIMEOUT):
-            sample_body, _ = await bounded_probe_read(
-                client,
-                f"{base}/{safe_layer_id}/query?{urlencode(query_params)}",
-                headers={},
-                accept=OGC_JSON_ACCEPT,
+            sample_data = await read_arcgis_json(
+                client, _sample_url, token, current_version=current_version
             )
-            sample_data = json.loads(sample_body)
         # fix(#1770 round 45 P2): same reasoning as the metadata read above
         # -- a non-dict `sample_data` degrades to "no sample rows" here
         # (this read already treats its own failures as best-effort),
@@ -624,7 +867,7 @@ async def fetch_arcgis_layer_preview(
     feature_count: int | None = None
     try:
         feature_count = await fetch_arcgis_feature_count(
-            base, safe_layer_id, client, token=token
+            base, safe_layer_id, client, token=token, current_version=current_version
         )
     except (
         httpx.HTTPError,

--- a/backend/app/modules/catalog/sources/preview.py
+++ b/backend/app/modules/catalog/sources/preview.py
@@ -215,6 +215,19 @@ def build_gdal_source(
             params["resultRecordCount"] = result_limit
         if result_offset is not None:
             params["resultOffset"] = result_offset
+        # feat(C2): deliberately still the query form, and the one ArcGIS
+        # transport lane C2 did NOT move. The httpx adapter sends
+        # ``Authorization: Bearer`` now, but GDAL reads a credential only from
+        # ``GDAL_HTTP_HEADER_FILE``, which is process-global (measured for
+        # #1770 and recorded in ``platform/service_items``) and whose writer
+        # holds every line to ``HEADER_TOKEN_CHARSET``. An ArcGIS token
+        # legitimately contains ``+`` or ``/``, which that charset refuses, so
+        # moving this path would mean either widening the base64url rule that
+        # exists to stop header smuggling into libcurl, or refusing tokens that
+        # work today. The exposure this leaves -- the token in the subprocess
+        # argv and in GDAL's error text -- is bounded where it lands:
+        # ``run_ogr2ogr_service`` redacts before the text becomes an exception,
+        # and #1753 purges the job row.
         if token:
             params["token"] = token
         query_url = f"{safe_base_url}/{safe_layer_id}/query?{urlencode(params)}"

--- a/backend/app/modules/catalog/sources/probe.py
+++ b/backend/app/modules/catalog/sources/probe.py
@@ -263,8 +263,16 @@ async def detect_service_type(
         result = await _arcgis_probe(base_url)
         if result is not None:
             _arcgis_carries(credential)
+            # feat(C2): the probe just read `currentVersion` out of the
+            # service document, so the count queries know which token
+            # transport this deployment understands without discovering it
+            # again from a 499.
             enriched = await enrich_arcgis_feature_counts(
-                base_url, result["layers"], client, token=token
+                base_url,
+                result["layers"],
+                client,
+                token=token,
+                current_version=result.get("version"),
             )
             return _build_arcgis_response(
                 result, enriched, base_url, selected_layer_id=layer_id
@@ -304,8 +312,14 @@ async def detect_service_type(
     arcgis_result = await _arcgis_probe(base_url)
     if arcgis_result is not None:
         _arcgis_carries(credential)
+        # feat(C2): same as the fast path above -- the version came back with
+        # the service document.
         enriched = await enrich_arcgis_feature_counts(
-            base_url, arcgis_result["layers"], client, token=token
+            base_url,
+            arcgis_result["layers"],
+            client,
+            token=token,
+            current_version=arcgis_result.get("version"),
         )
         return _build_arcgis_response(
             arcgis_result, enriched, base_url, selected_layer_id=layer_id

--- a/backend/app/modules/catalog/sources/router.py
+++ b/backend/app/modules/catalog/sources/router.py
@@ -514,7 +514,7 @@ def _probe_credential_line(
 
     fix(#1840 audit round 1): gated on ``requires_header_token_policy`` rather
     than on the builder answering None. The two stopped being equivalent when
-    lane C2 taught the builder to compose an ``Authorization: Bearer`` header
+    lane C2 taught the builder to compose an ``X-Esri-Authorization`` header
     for ArcGIS's own httpx requests, and this function feeds
     ``assert_endpoints_stay_on_origin``, which is about a service DESCRIBING a
     foreign operation endpoint that GDAL then follows with a header file

--- a/backend/app/modules/catalog/sources/router.py
+++ b/backend/app/modules/catalog/sources/router.py
@@ -35,6 +35,7 @@ from app.core.service_tokens import (
     ServiceCredential,
     build_credential_header,
     credential_header_line,
+    requires_header_token_policy,
 )
 from app.modules.catalog.sources.adapters.arcgis import (
     ARCGIS_SERVICE_FORMAT,
@@ -509,10 +510,20 @@ def _probe_credential_line(
 
     fix(#1746 B2b review r14): the probe holds a credential bound to whichever
     transport its URL looked like, and the check needs it bound to the format
-    detection just established. Composed by the one builder, which answers None
-    for a format that carries no header at all.
+    detection just established. Composed by the one builder.
+
+    fix(#1840 audit round 1): gated on ``requires_header_token_policy`` rather
+    than on the builder answering None. The two stopped being equivalent when
+    lane C2 taught the builder to compose an ``Authorization: Bearer`` header
+    for ArcGIS's own httpx requests, and this function feeds
+    ``assert_endpoints_stay_on_origin``, which is about a service DESCRIBING a
+    foreign operation endpoint that GDAL then follows with a header file
+    attached -- a WFS/OAPIF question only. It was inert either way, because
+    that check early-returns on the same predicate, but a line composed here
+    for a format that never becomes a header file is a claim about the wrong
+    transport waiting for its consumer's guard to be relaxed.
     """
-    if credential is None:
+    if credential is None or not requires_header_token_policy(service_format):
         return None
     pair = build_credential_header(replace(credential, service_format=service_format))
     return None if pair is None else credential_header_line(pair)

--- a/backend/app/platform/service_auth.py
+++ b/backend/app/platform/service_auth.py
@@ -239,6 +239,21 @@ def wire_credential(
 
     ``service_format`` defaults to the one already on the credential, which is
     what an in-process caller of plan D2 sets when it constructs one directly.
+
+    fix(#1840 audit round 1): the ArcGIS branch is selected by
+    ``requires_header_token_policy`` and NOT by "the builder answered None".
+    Lane C2 taught ``build_credential_header`` to compose an
+    ``Authorization: Bearer`` header for ArcGIS -- for GeoLens's own httpx
+    requests, which is a different transport from this one -- and that silently
+    killed the branch below, so this handed the worker the string
+    ``Authorization: Bearer <token>`` as ``token``. ``build_gdal_source`` then
+    percent-encoded the whole line into ``&token=Authorization%3A+Bearer+...``
+    and every authenticated ArcGIS ingest, refresh and reupload failed at the
+    origin, after the single-use credential had already been spent. The
+    question this function asks is whether the credential becomes a header
+    LINE, which is what ``requires_header_token_policy`` answers and what
+    ``HEADER_AUTH_SERVICE_FORMATS`` is the set for; asking the builder was a
+    proxy for it that stopped being equivalent.
     """
     resolved = (
         service_format
@@ -248,6 +263,10 @@ def wire_credential(
     bound = credential_or_422(credential, service_format=resolved)
     if bound is None:
         return None
+    if not requires_header_token_policy(resolved):
+        # A URL-query transport: ArcGIS, whose worker-side token is the bare
+        # value `build_gdal_source` percent-encodes into the ESRIJSON source.
+        return bearer_token_for_credential(bound)
     pair = build_credential_header(bound)
     if pair is None:
         return bearer_token_for_credential(bound)

--- a/backend/app/platform/service_auth.py
+++ b/backend/app/platform/service_auth.py
@@ -243,7 +243,7 @@ def wire_credential(
     fix(#1840 audit round 1): the ArcGIS branch is selected by
     ``requires_header_token_policy`` and NOT by "the builder answered None".
     Lane C2 taught ``build_credential_header`` to compose an
-    ``Authorization: Bearer`` header for ArcGIS -- for GeoLens's own httpx
+    ``X-Esri-Authorization: Bearer`` header for ArcGIS -- for GeoLens's own httpx
     requests, which is a different transport from this one -- and that silently
     killed the branch below, so this handed the worker the string
     ``Authorization: Bearer <token>`` as ``token``. ``build_gdal_source`` then

--- a/backend/app/processing/ingest/ogr.py
+++ b/backend/app/processing/ingest/ogr.py
@@ -169,17 +169,9 @@ def _legacy_bearer_line(token: str, service_format: str) -> str:
     the answer is the shape policy rather than a bearer-specific message: from
     here the two cases are indistinguishable, and the value is not named.
     """
-    # fix(#1840 audit round 1): the format gate is asked HERE, before the
-    # builder, rather than being inferred from the builder answering None.
-    # Lane C2 taught `build_credential_header` to compose a header for ArcGIS
-    # -- for GeoLens's own httpx requests, never for this file -- so "the
-    # builder said None" stopped meaning "this format carries no header line".
-    # Both call sites still gate on the same two formats before reaching here;
-    # this is the trust-boundary copy of that rule, which is where AGENTS.md
-    # says the worker's own check belongs, and it is what keeps an ArcGIS
-    # token out of GDAL_HTTP_HEADER_FILE if a caller's gate is ever relaxed.
-    if not requires_header_token_policy(service_format):
-        raise ValueError(HEADER_LINE_SHAPE_POLICY)
+    # fix(#1840 audit round 2): the format gate moved UP, to
+    # `_sanitize_authorization_token`'s own entry, so it covers a finished
+    # line as well as this bare-token branch. See the comment there.
     try:
         pair = build_credential_header(
             ServiceCredential(
@@ -191,9 +183,9 @@ def _legacy_bearer_line(token: str, service_format: str) -> str:
     except ValueError:
         raise ValueError(HEADER_LINE_SHAPE_POLICY) from None
     if pair is None:
-        # A service format that carries no header at all. The gate above and
-        # the callers' own both cover this; it exists because a silent empty
-        # line would be worse than a refusal.
+        # A service format that carries no header at all. The gate at the
+        # entry and the callers' own both cover this; it exists because a
+        # silent empty line would be worse than a refusal.
         raise ValueError(HEADER_LINE_SHAPE_POLICY)
     return credential_header_line(pair)
 
@@ -256,6 +248,19 @@ def _sanitize_authorization_token(
     """
     if header_line is None:
         return None
+    # fix(#1840 audit round 2): the format gate belongs HERE, at the entry to
+    # the only function this module sanitizes a header-file line through, not
+    # inside `_legacy_bearer_line`. Round 1 put it there, which covered a bare
+    # token arriving for an ArcGIS job and not a FINISHED line arriving for
+    # one -- so `_sanitize_authorization_token("Authorization: Bearer <tok>",
+    # service_format="arcgis_featureserver")` returned the line, and the claim
+    # that this keeps an ArcGIS credential out of GDAL_HTTP_HEADER_FILE if a
+    # caller's gate is relaxed was only half true. Both shapes are refused
+    # now. Both call sites still gate on the same two formats before reaching
+    # here; this is the trust-boundary copy of that rule, which is where
+    # AGENTS.md says the worker's own check belongs.
+    if not requires_header_token_policy(service_format):
+        raise ValueError(HEADER_LINE_SHAPE_POLICY)
     name, separator, value = header_line.partition(HEADER_LINE_SEPARATOR)
     if not separator:
         return _legacy_bearer_line(header_line, service_format)

--- a/backend/app/processing/ingest/ogr.py
+++ b/backend/app/processing/ingest/ogr.py
@@ -34,6 +34,7 @@ from app.core.service_tokens import (
     build_credential_header,
     credential_header_line,
     register_credential_secret,
+    requires_header_token_policy,
 )
 from app.core.url_redaction import redact_url_credentials
 
@@ -168,6 +169,17 @@ def _legacy_bearer_line(token: str, service_format: str) -> str:
     the answer is the shape policy rather than a bearer-specific message: from
     here the two cases are indistinguishable, and the value is not named.
     """
+    # fix(#1840 audit round 1): the format gate is asked HERE, before the
+    # builder, rather than being inferred from the builder answering None.
+    # Lane C2 taught `build_credential_header` to compose a header for ArcGIS
+    # -- for GeoLens's own httpx requests, never for this file -- so "the
+    # builder said None" stopped meaning "this format carries no header line".
+    # Both call sites still gate on the same two formats before reaching here;
+    # this is the trust-boundary copy of that rule, which is where AGENTS.md
+    # says the worker's own check belongs, and it is what keeps an ArcGIS
+    # token out of GDAL_HTTP_HEADER_FILE if a caller's gate is ever relaxed.
+    if not requires_header_token_policy(service_format):
+        raise ValueError(HEADER_LINE_SHAPE_POLICY)
     try:
         pair = build_credential_header(
             ServiceCredential(
@@ -179,9 +191,9 @@ def _legacy_bearer_line(token: str, service_format: str) -> str:
     except ValueError:
         raise ValueError(HEADER_LINE_SHAPE_POLICY) from None
     if pair is None:
-        # A service format that carries no header at all. The caller gates on
-        # the two that do, so this is unreachable from the one call site and
-        # exists because a silent empty line would be worse than a refusal.
+        # A service format that carries no header at all. The gate above and
+        # the callers' own both cover this; it exists because a silent empty
+        # line would be worse than a refusal.
         raise ValueError(HEADER_LINE_SHAPE_POLICY)
     return credential_header_line(pair)
 

--- a/backend/tests/test_arcgis_auth.py
+++ b/backend/tests/test_arcgis_auth.py
@@ -54,14 +54,15 @@ def _mock_transport_client(handle) -> httpx.AsyncClient:
 
 
 @pytest.mark.asyncio
-async def test_arcgis_probe_sends_the_token_as_an_authorization_header():
+async def test_arcgis_probe_sends_the_token_as_an_esri_authorization_header():
     """feat(C2): the token is a header, and the URL carries no credential.
 
     This test used to assert the exact opposite -- ``token=mytoken`` in the
-    URL and no ``Authorization`` header at all -- because that was the only
+    URL and no credential header at all -- because that was the only
     transport ArcGIS was believed to accept here. Measured live on 2026-09-04
-    against a referer-bound token on services6.arcgis.com, ``Authorization:
-    Bearer`` returns the same count as ``?token=``, so the credential moved
+    against a referer-bound token on services6.arcgis.com, both
+    ``X-Esri-Authorization: Bearer`` and ``Authorization: Bearer`` return the
+    same count as ``?token=``, so the credential moved
     out of the URL: out of httpx's ``HTTP Request: GET ...`` INFO line, out of
     proxy access logs, and out of the text an origin quotes back in an error.
     """
@@ -85,7 +86,7 @@ async def test_arcgis_probe_sends_the_token_as_an_authorization_header():
 
     assert len(recorded) == 1
     assert "token" not in str(recorded[0].url)
-    assert recorded[0].headers["Authorization"] == "Bearer mytoken"
+    assert recorded[0].headers["X-Esri-Authorization"] == "Bearer mytoken"
 
 
 @pytest.mark.asyncio
@@ -124,7 +125,7 @@ async def test_arcgis_probe_falls_back_to_an_encoded_query_token_on_499():
     assert "token" not in str(recorded[0].url)
     url_called = str(recorded[1].url)
     assert "token=AA%27%23%26ULTRASECRET" in url_called
-    assert "Authorization" not in recorded[1].headers
+    assert "X-Esri-Authorization" not in recorded[1].headers
     assert "'" not in url_called
     assert "#" not in url_called
     assert "&ULTRA" not in url_called
@@ -137,7 +138,7 @@ async def test_enrich_arcgis_feature_counts_uses_the_header_and_the_one_builder(
     Two things at once, because the fold is what made the second possible.
     The per-layer count query is composed by ``build_arcgis_count_query_url``
     now rather than by a third hand-rolled concatenation, and the token it
-    would have concatenated is an ``Authorization`` header, so the URL this
+    would have concatenated is an ``X-Esri-Authorization`` header, so the URL this
     site issues is byte-identical to the one the health probe issues.
 
     fix(#1770 round 44 P1): this read goes through `bounded_probe_read`
@@ -166,7 +167,7 @@ async def test_enrich_arcgis_feature_counts_uses_the_header_and_the_one_builder(
         "https://services.arcgis.com/svc/FeatureServer/0"
     )
     assert "token" not in str(recorded[0].url)
-    assert recorded[0].headers["Authorization"] == "Bearer AA'#&ULTRASECRET"
+    assert recorded[0].headers["X-Esri-Authorization"] == "Bearer AA'#&ULTRASECRET"
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_arcgis_auth.py
+++ b/backend/tests/test_arcgis_auth.py
@@ -7,6 +7,7 @@ import pytest
 
 from app.modules.catalog.sources.adapters.arcgis import (
     ArcGISTokenError,
+    build_arcgis_count_query_url,
     enrich_arcgis_feature_counts,
     fetch_arcgis_pagination_info,
     probe_arcgis_service,
@@ -53,14 +54,28 @@ def _mock_transport_client(handle) -> httpx.AsyncClient:
 
 
 @pytest.mark.asyncio
-async def test_arcgis_probe_no_bearer_header():
-    """Verify the ArcGIS probe sends token only as query param, not as Authorization header."""
+async def test_arcgis_probe_sends_the_token_as_an_authorization_header():
+    """feat(C2): the token is a header, and the URL carries no credential.
+
+    This test used to assert the exact opposite -- ``token=mytoken`` in the
+    URL and no ``Authorization`` header at all -- because that was the only
+    transport ArcGIS was believed to accept here. Measured live on 2026-09-04
+    against a referer-bound token on services6.arcgis.com, ``Authorization:
+    Bearer`` returns the same count as ``?token=``, so the credential moved
+    out of the URL: out of httpx's ``HTTP Request: GET ...`` INFO line, out of
+    proxy access logs, and out of the text an origin quotes back in an error.
+    """
     recorded: list[httpx.Request] = []
 
     def handle(request: httpx.Request) -> httpx.Response:
         recorded.append(request)
         return _streaming_json_response(
-            {"layers": [{"id": 0, "name": "test", "geometryType": "esriGeometryPoint"}]}
+            {
+                "currentVersion": 11.3,
+                "layers": [
+                    {"id": 0, "name": "test", "geometryType": "esriGeometryPoint"}
+                ],
+            }
         )
 
     async with _mock_transport_client(handle) as client:
@@ -68,32 +83,34 @@ async def test_arcgis_probe_no_bearer_header():
             "https://services.arcgis.com/svc/FeatureServer", client, token="mytoken"
         )
 
-    # The URL should include the token as a query parameter
     assert len(recorded) == 1
-    assert "token=mytoken" in str(recorded[0].url)
-
-    # No Authorization header should have been sent
-    assert "Authorization" not in recorded[0].headers
+    assert "token" not in str(recorded[0].url)
+    assert recorded[0].headers["Authorization"] == "Bearer mytoken"
 
 
 @pytest.mark.asyncio
-async def test_arcgis_probe_encodes_url_reserved_characters_in_token():
-    """fix(#1746 codex r7): a token with URL-reserved characters must be encoded.
+async def test_arcgis_probe_falls_back_to_an_encoded_query_token_on_499():
+    """fix(#1746 codex r7) and feat(C2): the pre-10.5.1 fallback still encodes.
 
-    probe_arcgis_service() concatenates the token into the query string by
-    hand (unlike the sibling call sites that pass it through httpx's
-    ``params=``, which encodes automatically). The token validators only
-    reject whitespace/control characters, so ``'``, ``#``, and ``&`` all
-    pass through and were kept literal here -- a raw ``#`` truncates the
-    URL at a fragment boundary and a raw ``&`` starts a bogus new query
-    parameter, either of which leaks the tail of the token into the actual
-    request AND lets it escape the log redactor's URL match.
+    A token with URL-reserved characters must be percent-encoded when it does
+    travel in a query string: a raw ``#`` truncates the URL at a fragment
+    boundary and a raw ``&`` starts a bogus new query parameter, either of
+    which leaks the tail of the token into the actual request AND lets it
+    escape the log redactor's URL match.
+
+    Reaching that path now takes a server that answers 499 "Token Required"
+    to the header form, which is exactly what an ArcGIS Server older than
+    10.5.1 does -- it never reads the header, so it sees no token at all.
     """
     recorded: list[httpx.Request] = []
 
     def handle(request: httpx.Request) -> httpx.Response:
         recorded.append(request)
-        return _streaming_json_response({"layers": []})
+        if "token=" not in str(request.url):
+            return _streaming_json_response(
+                {"error": {"code": 499, "message": "Token Required"}}
+            )
+        return _streaming_json_response({"currentVersion": "10.4", "layers": []})
 
     async with _mock_transport_client(handle) as client:
         await probe_arcgis_service(
@@ -102,21 +119,28 @@ async def test_arcgis_probe_encodes_url_reserved_characters_in_token():
             token="AA'#&ULTRASECRET",
         )
 
-    url_called = str(recorded[0].url)
+    assert len(recorded) == 2
+    # The first attempt is the header form and carries nothing in the URL.
+    assert "token" not in str(recorded[0].url)
+    url_called = str(recorded[1].url)
     assert "token=AA%27%23%26ULTRASECRET" in url_called
+    assert "Authorization" not in recorded[1].headers
     assert "'" not in url_called
     assert "#" not in url_called
     assert "&ULTRA" not in url_called
 
 
 @pytest.mark.asyncio
-async def test_enrich_arcgis_feature_counts_encodes_url_reserved_characters_in_token():
-    """fix(#1746 codex r7): the second raw string-concatenation site.
+async def test_enrich_arcgis_feature_counts_uses_the_header_and_the_one_builder():
+    """fix(#1755 item 14) and feat(C2).
 
-    Same issue and same fix as the probe above, in
-    ``enrich_arcgis_feature_counts()``'s per-layer count query.
+    Two things at once, because the fold is what made the second possible.
+    The per-layer count query is composed by ``build_arcgis_count_query_url``
+    now rather than by a third hand-rolled concatenation, and the token it
+    would have concatenated is an ``Authorization`` header, so the URL this
+    site issues is byte-identical to the one the health probe issues.
 
-    fix(#1770 round 44 P1): this read now goes through `bounded_probe_read`
+    fix(#1770 round 44 P1): this read goes through `bounded_probe_read`
     (`client.stream`), so `AsyncMock(spec=httpx.AsyncClient)` -- which cannot
     fake the async-context-manager protocol `.stream()` returns -- is
     replaced with a real client over `MockTransport`, per this file's own
@@ -129,18 +153,20 @@ async def test_enrich_arcgis_feature_counts_encodes_url_reserved_characters_in_t
         return _streaming_json_response({"count": 5})
 
     async with _mock_transport_client(handle) as client:
-        await enrich_arcgis_feature_counts(
+        enriched = await enrich_arcgis_feature_counts(
             "https://services.arcgis.com/svc/FeatureServer",
             [{"id": 0, "name": "layer0"}],
             client,
             token="AA'#&ULTRASECRET",
+            current_version="11.3",
         )
 
-    url_called = str(recorded[0].url)
-    assert "token=AA%27%23%26ULTRASECRET" in url_called
-    assert "'" not in url_called
-    assert "#" not in url_called
-    assert "&ULTRA" not in url_called
+    assert enriched[0]["feature_count"] == 5
+    assert str(recorded[0].url) == build_arcgis_count_query_url(
+        "https://services.arcgis.com/svc/FeatureServer/0"
+    )
+    assert "token" not in str(recorded[0].url)
+    assert recorded[0].headers["Authorization"] == "Bearer AA'#&ULTRASECRET"
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_arcgis_header_transport_c2.py
+++ b/backend/tests/test_arcgis_header_transport_c2.py
@@ -1,0 +1,576 @@
+"""The ArcGIS token travels as an Authorization header (lane C2).
+
+Measured live on 2026-09-04 before any of this was written, against
+``Cons_Map_WFL1/FeatureServer/0`` on services6.arcgis.com with a token minted
+by ``generateToken`` using ``client=referer``:
+
+======================================  ==================================
+no credential                           499 "Token Required" in an HTTP 200
+``?token=`` (the control)               ``{"count": 9567}``
+``X-Esri-Authorization: Bearer <t>``    ``{"count": 9567}``
+``Authorization: Bearer <t>``           ``{"count": 9567}``
+a wrong or absent ``Referer``           no difference on any of the above
+======================================  ==================================
+
+``Authorization`` rather than ``X-Esri-Authorization`` is plan rule A: GDAL
+and libcurl strip ``Authorization`` on a cross-host redirect and forward a
+custom header verbatim, and httpx does the same, so the standard name is the
+one that survives a hostile 302 without needing a rule of its own. No
+``Referer`` is sent, because none is needed.
+
+What these tests pin, in order: the version parser and the gate it feeds, the
+transport chooser, the header actually reaching every read the adapter makes,
+the URL carrying nothing on any of them, the pre-10.5.1 fallback and what
+triggers it, and the two security invariants -- a cross-origin redirect does
+not carry the header, and no token can reach httpx's ``HTTP Request: GET ...``
+INFO line because it is no longer in the URL.
+"""
+
+import json as _json
+import logging
+
+import httpx
+import pytest
+
+from app.core.service_tokens import (
+    ARCGIS_SERVICE_FORMAT,
+    HEADER_AUTH_SERVICE_FORMATS,
+    HEADER_TRANSPORT_SERVICE_FORMATS,
+    requires_header_token_policy,
+    sends_credential_as_header,
+)
+from app.modules.catalog.sources.adapters.arcgis import (
+    ARCGIS_HEADER_TOKEN_MIN_VERSION,
+    arcgis_accepts_header_token,
+    arcgis_request_auth,
+    build_arcgis_count_query_url,
+    enrich_arcgis_feature_counts,
+    fetch_arcgis_feature_count,
+    fetch_arcgis_layer_preview,
+    fetch_arcgis_pagination_info,
+    parse_arcgis_current_version,
+    probe_arcgis_service,
+)
+
+_BASE = (
+    "https://services6.arcgis.com/ZrVlS0wslq8Nvq5I/arcgis/rest/services/X/FeatureServer"
+)
+_TOKEN = "tok-C2+slash/AND.more_"
+
+
+def _stream(data: dict, status_code: int = 200) -> httpx.Response:
+    """A response whose body supports the streaming read the adapter uses.
+
+    ``httpx.Response(200, json=...)`` materialises the body at construction, so
+    ``client.stream(...)``'s ``aiter_raw()`` over one raises ``StreamConsumed``.
+    """
+    raw = _json.dumps(data).encode()
+
+    async def _chunks():
+        yield raw
+
+    return httpx.Response(status_code, content=_chunks())
+
+
+def _client(handle) -> httpx.AsyncClient:
+    return httpx.AsyncClient(transport=httpx.MockTransport(handle))
+
+
+_HOSTED_SERVICE = {
+    "currentVersion": 11.3,
+    "layers": [{"id": 0, "name": "Parcels", "geometryType": "esriGeometryPolygon"}],
+}
+_HOSTED_LAYER = {
+    "currentVersion": 11.3,
+    "name": "Parcels",
+    "geometryType": "esriGeometryPolygon",
+    "objectIdField": "OBJECTID",
+    "maxRecordCount": 2000,
+    "advancedQueryCapabilities": {"supportsPagination": True},
+    "fields": [{"name": "OBJECTID", "type": "esriFieldTypeOID"}],
+    "extent": {"spatialReference": {"latestWkid": 4326}},
+}
+
+
+# ---------------------------------------------------------------------------
+# The version gate
+# ---------------------------------------------------------------------------
+
+
+class TestTheVersionParser:
+    """Esri encodes a patch release as a second fractional digit.
+
+    10.5.1 is reported as ``10.51``, so a float comparison against 10.5 puts
+    the two in the right order for the wrong reason and 10.41 (10.4.1) above
+    10.5 for a wrong one. This is the whole reason the parser exists.
+    """
+
+    @pytest.mark.parametrize(
+        ("value", "expected"),
+        [
+            ("10.5", (10, 5, 0)),
+            ("10.51", (10, 5, 1)),
+            ("10.5.1", (10, 5, 1)),
+            ("10.4", (10, 4, 0)),
+            ("10.41", (10, 4, 1)),
+            ("10.3", (10, 3, 0)),
+            ("10.61", (10, 6, 1)),
+            ("10.91", (10, 9, 1)),
+            ("11.3", (11, 3, 0)),
+            ("11", (11, 0, 0)),
+            ("11.3.1", (11, 3, 1)),
+            (10.51, (10, 5, 1)),
+            (10.5, (10, 5, 0)),
+            (11, (11, 0, 0)),
+            ("  11.3  ", (11, 3, 0)),
+        ],
+    )
+    def test_it_parses(self, value: object, expected: tuple[int, int, int]) -> None:
+        assert parse_arcgis_current_version(value) == expected
+
+    @pytest.mark.parametrize(
+        "value", [None, "", "unknown", "v10.5", "10.5-beta", "10..5", True, False, []]
+    )
+    def test_it_gives_up_rather_than_guessing(self, value: object) -> None:
+        assert parse_arcgis_current_version(value) is None
+
+    def test_the_order_the_gate_depends_on(self) -> None:
+        """The one comparison this is all for, spelled out."""
+        assert parse_arcgis_current_version("10.5") < ARCGIS_HEADER_TOKEN_MIN_VERSION
+        assert parse_arcgis_current_version("10.41") < ARCGIS_HEADER_TOKEN_MIN_VERSION
+        assert parse_arcgis_current_version("10.51") >= ARCGIS_HEADER_TOKEN_MIN_VERSION
+        assert parse_arcgis_current_version("11.3") >= ARCGIS_HEADER_TOKEN_MIN_VERSION
+
+
+class TestTheHeaderGate:
+    @pytest.mark.parametrize(
+        "version", ["10.51", "10.6", "10.9", "11.0", "11.3", 11.3, "10.5.1"]
+    )
+    def test_new_enough_uses_the_header(self, version: object) -> None:
+        assert arcgis_accepts_header_token(version) is True
+
+    @pytest.mark.parametrize("version", ["10.5", "10.4", "10.41", "10.3", "9.3", 10.4])
+    def test_older_than_10_5_1_uses_the_query(self, version: object) -> None:
+        assert arcgis_accepts_header_token(version) is False
+
+    @pytest.mark.parametrize("version", [None, "", "unknown"])
+    def test_unknown_uses_the_header(self, version: object) -> None:
+        """Hosted ArcGIS Online is the common case and every ArcGIS Server old
+        enough to need the query form does report a version. A wrong guess in
+        this direction costs one retry; the other direction would put the
+        token back in the URL for everyone."""
+        assert arcgis_accepts_header_token(version) is True
+
+
+class TestTheTransportChooser:
+    def test_the_header_is_the_default(self) -> None:
+        headers, query_token = arcgis_request_auth(_TOKEN)
+        assert headers == {"Authorization": f"Bearer {_TOKEN}"}
+        assert query_token is None
+
+    def test_an_old_server_gets_the_query_form(self) -> None:
+        headers, query_token = arcgis_request_auth(_TOKEN, current_version="10.4")
+        assert headers == {}
+        assert query_token == _TOKEN
+
+    @pytest.mark.parametrize("token", [None, ""])
+    def test_no_token_means_neither(self, token: str | None) -> None:
+        assert arcgis_request_auth(token) == ({}, None)
+
+    def test_a_token_that_cannot_be_a_header_value_degrades_to_the_query(
+        self,
+    ) -> None:
+        """The builder refuses whitespace and non-ASCII. No ArcGIS token looks
+        like that, but degrading to the query form (which percent-encodes it)
+        keeps the pre-C2 behaviour rather than failing a read outright, and
+        nothing about the value is logged."""
+        headers, query_token = arcgis_request_auth("has space")
+        assert headers == {}
+        assert query_token == "has space"
+
+    def test_the_two_halves_are_never_both_populated(self) -> None:
+        for version in (None, "11.3", "10.4", "nonsense"):
+            headers, query_token = arcgis_request_auth(_TOKEN, current_version=version)
+            assert bool(headers) != bool(query_token)
+
+
+class TestTheFormatSets:
+    """The GDAL header-FILE question and the httpx header question are two,
+    and lane C2 moved ArcGIS across exactly one of them."""
+
+    def test_arcgis_sends_a_header_but_is_not_a_header_file_format(self) -> None:
+        assert sends_credential_as_header(ARCGIS_SERVICE_FORMAT) is True
+        assert requires_header_token_policy(ARCGIS_SERVICE_FORMAT) is False
+        assert ARCGIS_SERVICE_FORMAT not in HEADER_AUTH_SERVICE_FORMATS
+        assert ARCGIS_SERVICE_FORMAT in HEADER_TRANSPORT_SERVICE_FORMATS
+
+    def test_the_two_header_file_formats_are_in_both(self) -> None:
+        for source_format in ("wfs", "ogcapi_features"):
+            assert requires_header_token_policy(source_format) is True
+            assert sends_credential_as_header(source_format) is True
+
+    def test_a_format_nobody_taught_it_is_in_neither(self) -> None:
+        for source_format in (None, "", "stac", "geojson"):
+            assert sends_credential_as_header(source_format) is False
+
+
+# ---------------------------------------------------------------------------
+# Every read the adapter makes
+# ---------------------------------------------------------------------------
+
+
+class TestEveryReadSendsTheHeaderAndNoQueryToken:
+    """One case per read site, because each composes its own URL.
+
+    A site that grew back a ``token=`` would still return the right answer and
+    would only be visible here.
+    """
+
+    pytestmark = pytest.mark.asyncio
+
+    async def _record(self, call) -> list[httpx.Request]:
+        recorded: list[httpx.Request] = []
+
+        def handle(request: httpx.Request) -> httpx.Response:
+            recorded.append(request)
+            url = str(request.url)
+            if "returnCountOnly" in url:
+                return _stream({"count": 9567})
+            if url.rstrip("/").endswith("FeatureServer"):
+                return _stream(_HOSTED_SERVICE)
+            if "/query" in url:
+                return _stream({"features": [{"attributes": {"OBJECTID": 1}}]})
+            return _stream(_HOSTED_LAYER)
+
+        async with _client(handle) as client:
+            await call(client)
+        assert recorded, "positive control: no request was made"
+        return recorded
+
+    @staticmethod
+    def _assert_clean(recorded: list[httpx.Request]) -> None:
+        for request in recorded:
+            assert request.headers["Authorization"] == f"Bearer {_TOKEN}"
+            assert "token" not in str(request.url)
+            assert _TOKEN not in str(request.url)
+            # feat(C2) sends no Referer: measured, and not needed even for a
+            # referer-bound token.
+            assert "referer" not in {name.lower() for name in request.headers}
+            # Rule A: the standard name, not the Esri-specific one.
+            assert "x-esri-authorization" not in {
+                name.lower() for name in request.headers
+            }
+
+    async def test_the_service_probe(self) -> None:
+        self._assert_clean(
+            await self._record(lambda c: probe_arcgis_service(_BASE, c, token=_TOKEN))
+        )
+
+    async def test_the_count_enrichment(self) -> None:
+        self._assert_clean(
+            await self._record(
+                lambda c: enrich_arcgis_feature_counts(
+                    _BASE, [{"id": 0, "name": "Parcels"}], c, token=_TOKEN
+                )
+            )
+        )
+
+    async def test_the_feature_count(self) -> None:
+        self._assert_clean(
+            await self._record(
+                lambda c: fetch_arcgis_feature_count(_BASE, 0, c, token=_TOKEN)
+            )
+        )
+
+    async def test_the_pagination_info(self) -> None:
+        self._assert_clean(
+            await self._record(
+                lambda c: fetch_arcgis_pagination_info(_BASE, 0, c, token=_TOKEN)
+            )
+        )
+
+    async def test_the_layer_preview(self) -> None:
+        """Three reads in one call: layer metadata, sample rows, count."""
+        recorded = await self._record(
+            lambda c: fetch_arcgis_layer_preview(_BASE, 0, c, token=_TOKEN)
+        )
+        assert len(recorded) == 3
+        self._assert_clean(recorded)
+
+    async def test_an_anonymous_read_sends_no_header_at_all(self) -> None:
+        recorded = await self._record(lambda c: probe_arcgis_service(_BASE, c))
+        assert "authorization" not in {n.lower() for n in recorded[0].headers}
+        assert "token" not in str(recorded[0].url)
+
+
+class TestTheCountQueryHasOneProducer:
+    """fix(#1755 item 14): ``enrich_arcgis_feature_counts`` hand-rolled the
+    count query a third time. Folded into the builder, so the enrichment, the
+    single-layer fetch and the health probe cannot drift into asking three
+    slightly different questions."""
+
+    pytestmark = pytest.mark.asyncio
+
+    async def test_the_enrichment_and_the_single_fetch_issue_the_same_url(
+        self,
+    ) -> None:
+        recorded: list[str] = []
+
+        def handle(request: httpx.Request) -> httpx.Response:
+            recorded.append(str(request.url))
+            return _stream({"count": 9567})
+
+        async with _client(handle) as client:
+            await enrich_arcgis_feature_counts(
+                _BASE, [{"id": 7, "name": "Parcels"}], client, token=_TOKEN
+            )
+            await fetch_arcgis_feature_count(_BASE, 7, client, token=_TOKEN)
+
+        assert recorded[0] == recorded[1]
+        assert recorded[0] == build_arcgis_count_query_url(f"{_BASE}/7")
+
+    async def test_the_fallback_token_is_encoded_by_the_builder(self) -> None:
+        """The encoding change #1755 item 14 asked to be called out: the
+        fold moved the fallback token from a hand-written ``quote(token,
+        safe='')`` to ``urlencode``, which is what the other two sites always
+        used."""
+        url = build_arcgis_count_query_url(f"{_BASE}/0", "AA'#&ULTRASECRET")
+        assert "token=AA%27%23%26ULTRASECRET" in url
+        assert "#" not in url
+        assert "&ULTRA" not in url
+
+
+# ---------------------------------------------------------------------------
+# The pre-10.5.1 fallback
+# ---------------------------------------------------------------------------
+
+
+class TestThePreTenFiveOneFallback:
+    pytestmark = pytest.mark.asyncio
+
+    async def test_a_known_old_version_goes_straight_to_the_query_form(self) -> None:
+        """One request, not two: the caller already read ``currentVersion``."""
+        recorded: list[httpx.Request] = []
+
+        def handle(request: httpx.Request) -> httpx.Response:
+            recorded.append(request)
+            return _stream({"count": 12})
+
+        async with _client(handle) as client:
+            count = await fetch_arcgis_feature_count(
+                _BASE, 0, client, token=_TOKEN, current_version="10.4"
+            )
+
+        assert count == 12
+        assert len(recorded) == 1
+        assert "authorization" not in {n.lower() for n in recorded[0].headers}
+        assert "token=" in str(recorded[0].url)
+
+    async def test_a_499_to_the_header_form_retries_with_the_query(self) -> None:
+        """The probe has no version yet, so this is how an old server is
+        found: it ignores the header, sees no token, and says so."""
+        recorded: list[httpx.Request] = []
+
+        def handle(request: httpx.Request) -> httpx.Response:
+            recorded.append(request)
+            if "token=" not in str(request.url):
+                return _stream({"error": {"code": 499, "message": "Token Required"}})
+            return _stream({"currentVersion": "10.4", "layers": []})
+
+        async with _client(handle) as client:
+            result = await probe_arcgis_service(_BASE, client, token=_TOKEN)
+
+        assert result is not None
+        assert len(recorded) == 2
+        assert recorded[0].headers["Authorization"] == f"Bearer {_TOKEN}"
+        assert "token" not in str(recorded[0].url)
+        assert "authorization" not in {n.lower() for n in recorded[1].headers}
+        assert "token=" in str(recorded[1].url)
+
+    async def test_a_498_is_not_retried(self) -> None:
+        """498 means a token WAS read and rejected, so the header arrived and
+        resending the same bad token in a query buys one request and no
+        information. The token challenge still reaches the caller."""
+        recorded: list[httpx.Request] = []
+
+        def handle(request: httpx.Request) -> httpx.Response:
+            recorded.append(request)
+            return _stream({"error": {"code": 498, "message": "Invalid Token"}})
+
+        async with _client(handle) as client:
+            with pytest.raises(Exception) as raised:
+                await probe_arcgis_service(_BASE, client, token=_TOKEN)
+
+        assert "498" in str(raised.value)
+        assert len(recorded) == 1
+
+    async def test_an_anonymous_499_is_not_retried(self) -> None:
+        """With no token there is no second transport to try."""
+        recorded: list[httpx.Request] = []
+
+        def handle(request: httpx.Request) -> httpx.Response:
+            recorded.append(request)
+            return _stream({"error": {"code": 499, "message": "Token Required"}})
+
+        async with _client(handle) as client:
+            with pytest.raises(Exception):
+                await probe_arcgis_service(_BASE, client)
+
+        assert len(recorded) == 1
+
+    async def test_the_preview_reads_the_version_once_and_reuses_it(self) -> None:
+        """The layer document is fetched anyway, so an old server costs the
+        preview one retry rather than one per read."""
+        recorded: list[httpx.Request] = []
+
+        def handle(request: httpx.Request) -> httpx.Response:
+            recorded.append(request)
+            url = str(request.url)
+            if "token=" not in url:
+                return _stream({"error": {"code": 499, "message": "Token Required"}})
+            if "returnCountOnly" in url:
+                return _stream({"count": 3})
+            if "/query" in url:
+                return _stream({"features": []})
+            return _stream({**_HOSTED_LAYER, "currentVersion": "10.4"})
+
+        async with _client(handle) as client:
+            preview = await fetch_arcgis_layer_preview(_BASE, 0, client, token=_TOKEN)
+
+        assert preview["feature_count"] == 3
+        # metadata (header, 499) + metadata (query) + sample + count = 4.
+        assert len(recorded) == 4
+        assert all("token=" in str(r.url) for r in recorded[1:])
+
+
+# ---------------------------------------------------------------------------
+# Security invariants
+# ---------------------------------------------------------------------------
+
+
+class TestACrossOriginRedirectDoesNotCarryTheHeader:
+    """Rule A, httpx half, and why ``Authorization`` is the name to use.
+
+    httpx drops ``Authorization`` itself when a redirect leaves the origin,
+    and forwards any other header verbatim -- which is why a custom name
+    (``X-Esri-Authorization``) has to be declared to ``make_safe_client`` and
+    this one does not. Recorded per hop, because a test that only reads the
+    final request cannot tell a dropped header from one that was never sent.
+    """
+
+    pytestmark = pytest.mark.asyncio
+
+    @staticmethod
+    def _redirecting(location: str):
+        recorded: list[httpx.Request] = []
+
+        def handle(request: httpx.Request) -> httpx.Response:
+            recorded.append(request)
+            if len(recorded) == 1:
+                return httpx.Response(302, headers={"Location": location})
+            return _stream({"count": 1})
+
+        return handle, recorded
+
+    async def test_another_origin_gets_no_credential(self) -> None:
+        handle, recorded = self._redirecting("https://elsewhere.example/harvest")
+        async with httpx.AsyncClient(
+            transport=httpx.MockTransport(handle), follow_redirects=True
+        ) as client:
+            await fetch_arcgis_feature_count(_BASE, 0, client, token=_TOKEN)
+
+        assert len(recorded) == 2
+        assert recorded[0].headers["Authorization"] == f"Bearer {_TOKEN}"
+        assert "authorization" not in {n.lower() for n in recorded[1].headers}
+        assert recorded[1].url.host == "elsewhere.example"
+        assert all(_TOKEN not in str(r.url) for r in recorded)
+
+    async def test_a_same_origin_redirect_still_authenticates(self) -> None:
+        """The counterfactual: without it, the test above would pass for a
+        client that simply never sent the header."""
+        handle, recorded = self._redirecting(f"{_BASE}/0/query?moved=1")
+        async with httpx.AsyncClient(
+            transport=httpx.MockTransport(handle), follow_redirects=True
+        ) as client:
+            await fetch_arcgis_feature_count(_BASE, 0, client, token=_TOKEN)
+
+        assert len(recorded) == 2
+        assert recorded[1].headers["Authorization"] == f"Bearer {_TOKEN}"
+
+    async def test_the_query_fallback_does_not_follow_a_redirect_either(self) -> None:
+        """On the pre-10.5.1 path the credential is in the request URL, and a
+        redirect target is chosen by the SERVICE, so it carries none of our
+        query string. Pinned so a future 'preserve the query across the
+        redirect' convenience cannot land unnoticed."""
+        handle, recorded = self._redirecting("https://elsewhere.example/harvest")
+        async with httpx.AsyncClient(
+            transport=httpx.MockTransport(handle), follow_redirects=True
+        ) as client:
+            await fetch_arcgis_feature_count(
+                _BASE, 0, client, token=_TOKEN, current_version="10.4"
+            )
+
+        assert "token=" in str(recorded[0].url)
+        assert "token=" not in str(recorded[1].url)
+
+
+class TestTheTokenCannotReachTheHttpxRequestLog:
+    """httpx logs every request at INFO as ``HTTP Request: GET <url> ...``.
+
+    That line is the reason the transport moved at all: it is emitted before
+    any GeoLens redactor sees it and it renders the URL verbatim. With the
+    token out of the URL there is nothing in it to redact.
+    """
+
+    pytestmark = pytest.mark.asyncio
+
+    @staticmethod
+    async def _httpx_log_lines(**kwargs) -> list[str]:
+        """Every line the ``httpx`` logger emits during one count fetch.
+
+        A handler attached directly to that logger rather than ``caplog``:
+        ``caplog`` reads records that reach the ROOT logger, and this suite's
+        app configuration leaves nothing there to read (the same trap that
+        makes ``caplog`` blind to structlog records). Attaching here reads the
+        line at the point httpx writes it, which is the point that matters.
+        """
+        captured: list[str] = []
+
+        class _Capture(logging.Handler):
+            def emit(self, record: logging.LogRecord) -> None:
+                captured.append(record.getMessage())
+
+        logger = logging.getLogger("httpx")
+        handler = _Capture()
+        previous_level, previous_disabled = logger.level, logger.disabled
+        logger.addHandler(handler)
+        logger.setLevel(logging.INFO)
+        logger.disabled = False
+        try:
+
+            def handle(request: httpx.Request) -> httpx.Response:
+                return _stream({"count": 1})
+
+            async with _client(handle) as client:
+                await fetch_arcgis_feature_count(_BASE, 0, client, **kwargs)
+        finally:
+            logger.removeHandler(handler)
+            logger.setLevel(previous_level)
+            logger.disabled = previous_disabled
+        return captured
+
+    async def test_no_token_appears_in_the_httpx_request_log(self) -> None:
+        lines = await self._httpx_log_lines(token=_TOKEN)
+        assert lines, "positive control: httpx logged nothing to compare"
+        assert all("HTTP Request" in line for line in lines)
+        assert all(_TOKEN not in line for line in lines)
+        assert all("token" not in line for line in lines)
+
+    async def test_the_positive_control_the_old_transport_would_have_failed(
+        self,
+    ) -> None:
+        """The same read on the pre-10.5.1 fallback DOES put the token in that
+        line. Without this the test above could pass for a request that never
+        carried a credential at all."""
+        lines = await self._httpx_log_lines(token=_TOKEN, current_version="10.4")
+        assert any("token=" in line for line in lines)

--- a/backend/tests/test_arcgis_header_transport_c2.py
+++ b/backend/tests/test_arcgis_header_transport_c2.py
@@ -1,4 +1,4 @@
-"""The ArcGIS token travels as an Authorization header (lane C2).
+"""The ArcGIS token travels as an X-Esri-Authorization header (lane C2).
 
 Measured live on 2026-09-04 before any of this was written, against
 ``Cons_Map_WFL1/FeatureServer/0`` on services6.arcgis.com with a token minted
@@ -12,22 +12,33 @@ no credential                           499 "Token Required" in an HTTP 200
 a wrong or absent ``Referer``           no difference on any of the above
 ======================================  ==================================
 
-``Authorization`` rather than ``X-Esri-Authorization`` is plan rule A: GDAL
-and libcurl strip ``Authorization`` on a cross-host redirect and forward a
-custom header verbatim, and httpx does the same, so the standard name is the
-one that survives a hostile 302 without needing a rule of its own. No
-``Referer`` is sent, because none is needed.
+Hosted ArcGIS Online takes either name. ``X-Esri-Authorization`` is what is
+sent (fix(#1840 codex round 1)), because Esri documents that name precisely
+for the case AGOL cannot show: on ArcGIS Enterprise behind a Web Adaptor, or
+with web-tier authentication (IWA/PKI in IIS), the front end consumes the
+standard ``Authorization`` header and answers 401/403 before ArcGIS produces
+any JSON at all.
+
+Rule A's objection to a custom header name -- that a cross-origin redirect
+forwards it verbatim where ``Authorization`` would be stripped -- is answered
+on the httpx path by ``security.py``'s ``_ALWAYS_CREDENTIAL_HEADERS``, which
+lists this exact name so ``_refuse_cross_origin_credential`` REFUSES the hop
+rather than following it. That is louder than a silent strip, and it is what
+``TestACrossOriginRedirectIsRefused`` pins. No ``Referer`` is sent, because
+none is needed.
 
 What these tests pin, in order: the version parser and the gate it feeds, the
 transport chooser, the header actually reaching every read the adapter makes,
-the URL carrying nothing on any of them, the pre-10.5.1 fallback and what
-triggers it, and the two security invariants -- a cross-origin redirect does
-not carry the header, and no token can reach httpx's ``HTTP Request: GET ...``
-INFO line because it is no longer in the URL.
+the URL carrying nothing on any of them, the two query-form fallbacks (the
+pre-10.5.1 499 envelope and the web-tier 401/403) and what triggers each, and
+the two security invariants -- a cross-origin redirect carrying the credential
+is refused, and no token can reach httpx's ``HTTP Request: GET ...`` INFO line
+because it is no longer in the URL.
 """
 
 import json as _json
 import logging
+from unittest.mock import AsyncMock
 
 import httpx
 import pytest
@@ -56,6 +67,7 @@ from app.modules.catalog.sources.adapters.arcgis import (
     parse_arcgis_current_version,
     probe_arcgis_service,
 )
+from app.platform import security as security_mod
 from app.platform.security import SSRFError
 
 _BASE = (
@@ -171,7 +183,7 @@ class TestTheHeaderGate:
 class TestTheTransportChooser:
     def test_the_header_is_the_default(self) -> None:
         headers, query_token = arcgis_request_auth(_TOKEN)
-        assert headers == {"Authorization": f"Bearer {_TOKEN}"}
+        assert headers == {"X-Esri-Authorization": f"Bearer {_TOKEN}"}
         assert query_token is None
 
     def test_an_old_server_gets_the_query_form(self) -> None:
@@ -256,16 +268,16 @@ class TestEveryReadSendsTheHeaderAndNoQueryToken:
     @staticmethod
     def _assert_clean(recorded: list[httpx.Request]) -> None:
         for request in recorded:
-            assert request.headers["Authorization"] == f"Bearer {_TOKEN}"
+            assert request.headers["X-Esri-Authorization"] == f"Bearer {_TOKEN}"
             assert "token" not in str(request.url)
             assert _TOKEN not in str(request.url)
             # feat(C2) sends no Referer: measured, and not needed even for a
             # referer-bound token.
             assert "referer" not in {name.lower() for name in request.headers}
-            # Rule A: the standard name, not the Esri-specific one.
-            assert "x-esri-authorization" not in {
-                name.lower() for name in request.headers
-            }
+            # fix(#1840 codex round 1): the Esri-specific name, NOT the
+            # standard one -- a web tier in front of ArcGIS Enterprise
+            # consumes `Authorization` and refuses before ArcGIS runs.
+            assert "authorization" not in {name.lower() for name in request.headers}
 
     async def test_the_service_probe(self) -> None:
         self._assert_clean(
@@ -388,7 +400,7 @@ class TestThePreTenFiveOneFallback:
 
         assert result is not None
         assert len(recorded) == 2
-        assert recorded[0].headers["Authorization"] == f"Bearer {_TOKEN}"
+        assert recorded[0].headers["X-Esri-Authorization"] == f"Bearer {_TOKEN}"
         assert "token" not in str(recorded[0].url)
         assert "authorization" not in {n.lower() for n in recorded[1].headers}
         assert "token=" in str(recorded[1].url)
@@ -454,70 +466,240 @@ class TestThePreTenFiveOneFallback:
 # ---------------------------------------------------------------------------
 
 
-class TestACrossOriginRedirectDoesNotCarryTheHeader:
-    """Rule A, httpx half, and why ``Authorization`` is the name to use.
+class TestTheWebTierRefusalFallback:
+    """fix(#1840 codex round 1): the case AGOL cannot demonstrate.
 
-    httpx drops ``Authorization`` itself when a redirect leaves the origin,
-    and forwards any other header verbatim -- which is why a custom name
-    (``X-Esri-Authorization``) has to be declared to ``make_safe_client`` and
-    this one does not. Recorded per hop, because a test that only reads the
-    final request cannot tell a dropped header from one that was never sent.
+    On ArcGIS Enterprise behind a Web Adaptor, or with web-tier authentication
+    (IWA or PKI in IIS), the front end consumes the credential header and
+    answers 401/403 at the HTTP layer. ``bounded_probe_read``'s
+    ``raise_for_status()`` fires, so execution never reaches the 499 envelope
+    fallback -- a portal where ``?token=`` had always worked would have
+    started failing on every authenticated probe, preview and import.
     """
 
     pytestmark = pytest.mark.asyncio
 
     @staticmethod
-    def _redirecting(location: str):
+    def _web_tier(status: int, *, refuse_query_too: bool = False):
+        recorded: list[httpx.Request] = []
+
+        def handle(request: httpx.Request) -> httpx.Response:
+            recorded.append(request)
+            if "token=" in str(request.url):
+                if refuse_query_too:
+                    return httpx.Response(status)
+                return _stream({"count": 4242})
+            return httpx.Response(status)
+
+        return handle, recorded
+
+    @pytest.mark.parametrize("status", [401, 403])
+    async def test_a_web_tier_refusal_retries_with_the_query_form(
+        self, status: int
+    ) -> None:
+        handle, recorded = self._web_tier(status)
+
+        async with _client(handle) as client:
+            count = await fetch_arcgis_feature_count(_BASE, 0, client, token=_TOKEN)
+
+        assert count == 4242
+        assert len(recorded) == 2
+        assert recorded[0].headers["X-Esri-Authorization"] == f"Bearer {_TOKEN}"
+        assert "token" not in str(recorded[0].url)
+        assert "x-esri-authorization" not in {n.lower() for n in recorded[1].headers}
+        assert "token=" in str(recorded[1].url)
+        # Same origin, same layer: the retry is the same question asked the
+        # other way, not a different endpoint.
+        assert recorded[1].url.host == recorded[0].url.host
+        assert recorded[1].url.path == recorded[0].url.path
+
+    @pytest.mark.parametrize("status", [401, 403])
+    async def test_a_second_refusal_propagates(self, status: int) -> None:
+        """Bounded to one extra request: no loop, and the operator sees the
+        real status rather than a degraded 'not an ArcGIS service'."""
+        handle, recorded = self._web_tier(status, refuse_query_too=True)
+
+        async with _client(handle) as client:
+            with pytest.raises(httpx.HTTPStatusError) as raised:
+                await fetch_arcgis_feature_count(_BASE, 0, client, token=_TOKEN)
+
+        assert raised.value.response.status_code == status
+        assert len(recorded) == 2
+
+    @pytest.mark.parametrize("status", [400, 404, 429, 500, 502, 503])
+    async def test_no_other_status_triggers_the_retry(self, status: int) -> None:
+        """The counterfactual for the status bound. A 500 is not a web tier
+        eating the header, and retrying one would resend the credential in a
+        URL for no reason."""
+        recorded: list[httpx.Request] = []
+
+        def handle(request: httpx.Request) -> httpx.Response:
+            recorded.append(request)
+            return httpx.Response(status)
+
+        async with _client(handle) as client:
+            with pytest.raises(httpx.HTTPStatusError):
+                await fetch_arcgis_feature_count(_BASE, 0, client, token=_TOKEN)
+
+        assert len(recorded) == 1
+
+    async def test_an_anonymous_401_is_not_retried(self) -> None:
+        """With no token there is no second transport to try."""
+        recorded: list[httpx.Request] = []
+
+        def handle(request: httpx.Request) -> httpx.Response:
+            recorded.append(request)
+            return httpx.Response(401)
+
+        async with _client(handle) as client:
+            with pytest.raises(httpx.HTTPStatusError):
+                await fetch_arcgis_feature_count(_BASE, 0, client)
+
+        assert len(recorded) == 1
+
+    async def test_a_401_after_a_redirect_is_not_retried(self) -> None:
+        """The origin bound. A refusal from a host we were bounced to says
+        nothing about the host we addressed, and replaying the credential to
+        it in a URL is exactly what must not happen."""
         recorded: list[httpx.Request] = []
 
         def handle(request: httpx.Request) -> httpx.Response:
             recorded.append(request)
             if len(recorded) == 1:
-                return httpx.Response(302, headers={"Location": location})
-            return _stream({"count": 1})
+                return httpx.Response(
+                    302, headers={"Location": "https://elsewhere.example/harvest"}
+                )
+            return httpx.Response(401)
 
-        return handle, recorded
-
-    async def test_another_origin_gets_no_credential(self) -> None:
-        handle, recorded = self._redirecting("https://elsewhere.example/harvest")
         async with httpx.AsyncClient(
             transport=httpx.MockTransport(handle), follow_redirects=True
         ) as client:
-            await fetch_arcgis_feature_count(_BASE, 0, client, token=_TOKEN)
+            with pytest.raises(httpx.HTTPStatusError):
+                await fetch_arcgis_feature_count(_BASE, 0, client, token=_TOKEN)
 
         assert len(recorded) == 2
-        assert recorded[0].headers["Authorization"] == f"Bearer {_TOKEN}"
-        assert "authorization" not in {n.lower() for n in recorded[1].headers}
-        assert recorded[1].url.host == "elsewhere.example"
-        assert all(_TOKEN not in str(r.url) for r in recorded)
+        assert all("token=" not in str(r.url) for r in recorded)
 
-    async def test_a_same_origin_redirect_still_authenticates(self) -> None:
+    async def test_the_401_fallback_registers_the_token(self) -> None:
+        """It lands on the same `_query_form_credential` the version gate uses,
+        so the scrub registration is not a second thing to remember."""
+        reset_registered_credential_secrets()
+        handle, _recorded = self._web_tier(401)
+
+        async with _client(handle) as client:
+            await fetch_arcgis_feature_count(_BASE, 0, client, token=_TOKEN)
+
+        assert _TOKEN in registered_credential_secrets()
+
+    async def test_a_200_envelope_499_still_takes_the_other_path(self) -> None:
+        """The two fallbacks are separate branches; neither replaced the
+        other, and neither can chain into the other."""
+        recorded: list[httpx.Request] = []
+
+        def handle(request: httpx.Request) -> httpx.Response:
+            recorded.append(request)
+            if "token=" not in str(request.url):
+                return _stream({"error": {"code": 499, "message": "Token Required"}})
+            return _stream({"count": 7})
+
+        async with _client(handle) as client:
+            count = await fetch_arcgis_feature_count(_BASE, 0, client, token=_TOKEN)
+
+        assert count == 7
+        assert len(recorded) == 2
+
+
+class TestACrossOriginRedirectIsRefused:
+    """Rule A, httpx half, and why the Esri name is safe to use here.
+
+    httpx drops ``Authorization`` on a cross-origin redirect by itself and
+    forwards every other header verbatim, which is the whole of rule A's
+    objection to a custom name. On this path the answer is louder than a
+    strip: ``X-Esri-Authorization`` is in ``_ALWAYS_CREDENTIAL_HEADERS``
+    (``app/platform/security.py:143``), so ``_refuse_cross_origin_credential``
+    (same file, ~line 187) raises ``SSRFError`` from ``_revalidate_redirect``
+    (~line 234) BEFORE the second request is issued. Every client on these
+    paths comes from ``make_safe_client``, which installs that hook.
+
+    Recorded per hop, because a test that only reads the final request cannot
+    tell a refused hop from one that was never attempted.
+    """
+
+    pytestmark = pytest.mark.asyncio
+
+    @pytest.fixture
+    def redirecting(self, monkeypatch):
+        """A ``make_safe_client`` whose transport is a MockTransport.
+
+        The hook under test lives on the client, so the transport is what has
+        to be faked -- patching ``make_safe_client`` itself would remove the
+        thing being asserted. ``validate_url_for_ssrf`` is stubbed because
+        these hostnames do not resolve.
+        """
+
+        def install(location: str) -> list[httpx.Request]:
+            recorded: list[httpx.Request] = []
+
+            def handle(request: httpx.Request) -> httpx.Response:
+                recorded.append(request)
+                if len(recorded) == 1:
+                    return httpx.Response(302, headers={"Location": location})
+                return _stream({"count": 1})
+
+            monkeypatch.setattr(
+                security_mod, "make_safe_transport", lambda: httpx.MockTransport(handle)
+            )
+            monkeypatch.setattr(security_mod, "validate_url_for_ssrf", AsyncMock())
+            return recorded
+
+        return install
+
+    async def test_another_origin_refuses_the_hop(self, redirecting) -> None:
+        recorded = redirecting("https://elsewhere.example/harvest")
+
+        async with security_mod.make_safe_client() as client:
+            with pytest.raises(SSRFError) as raised:
+                await fetch_arcgis_feature_count(_BASE, 0, client, token=_TOKEN)
+
+        # One request only: the refusal lands on the hop, before the second
+        # is issued, so the credential never reaches the other origin at all.
+        assert len(recorded) == 1
+        assert recorded[0].headers["X-Esri-Authorization"] == f"Bearer {_TOKEN}"
+        assert _TOKEN not in str(raised.value)
+
+    async def test_a_same_origin_redirect_still_authenticates(
+        self, redirecting
+    ) -> None:
         """The counterfactual: without it, the test above would pass for a
-        client that simply never sent the header."""
-        handle, recorded = self._redirecting(f"{_BASE}/0/query?moved=1")
-        async with httpx.AsyncClient(
-            transport=httpx.MockTransport(handle), follow_redirects=True
-        ) as client:
+        client that simply never sent the header, or that refused every
+        redirect."""
+        recorded = redirecting(f"{_BASE}/0/query?moved=1")
+
+        async with security_mod.make_safe_client() as client:
             await fetch_arcgis_feature_count(_BASE, 0, client, token=_TOKEN)
 
         assert len(recorded) == 2
-        assert recorded[1].headers["Authorization"] == f"Bearer {_TOKEN}"
+        assert recorded[1].headers["X-Esri-Authorization"] == f"Bearer {_TOKEN}"
 
-    async def test_the_query_fallback_does_not_follow_a_redirect_either(self) -> None:
+    async def test_the_query_fallback_does_not_follow_a_redirect_either(
+        self, redirecting
+    ) -> None:
         """On the pre-10.5.1 path the credential is in the request URL, and a
         redirect target is chosen by the SERVICE, so it carries none of our
-        query string. Pinned so a future 'preserve the query across the
-        redirect' convenience cannot land unnoticed."""
-        handle, recorded = self._redirecting("https://elsewhere.example/harvest")
-        async with httpx.AsyncClient(
-            transport=httpx.MockTransport(handle), follow_redirects=True
-        ) as client:
+        query string. No header goes out, so the hop is not refused -- it is
+        followed, and arrives with nothing. Pinned so a future 'preserve the
+        query across the redirect' convenience cannot land unnoticed."""
+        recorded = redirecting("https://elsewhere.example/harvest")
+
+        async with security_mod.make_safe_client() as client:
             await fetch_arcgis_feature_count(
                 _BASE, 0, client, token=_TOKEN, current_version="10.4"
             )
 
+        assert len(recorded) == 2
         assert "token=" in str(recorded[0].url)
         assert "token=" not in str(recorded[1].url)
+        assert "x-esri-authorization" not in {n.lower() for n in recorded[1].headers}
 
 
 class TestTheTokenCannotReachTheHttpxRequestLog:
@@ -695,7 +877,9 @@ class TestTheQueryFallbackRegistersItsSecret:
         headers, query_token = arcgis_request_auth(_TOKEN)
         assert query_token is None
         assert headers  # positive control: a header was composed
-        assert f"Authorization: Bearer {_TOKEN}" in registered_credential_secrets()
+        assert (
+            f"X-Esri-Authorization: Bearer {_TOKEN}" in registered_credential_secrets()
+        )
 
     def test_nothing_is_registered_without_a_token(self) -> None:
         """The counterfactual: the registry is not simply always non-empty."""

--- a/backend/tests/test_arcgis_header_transport_c2.py
+++ b/backend/tests/test_arcgis_header_transport_c2.py
@@ -36,9 +36,13 @@ from app.core.service_tokens import (
     ARCGIS_SERVICE_FORMAT,
     HEADER_AUTH_SERVICE_FORMATS,
     HEADER_TRANSPORT_SERVICE_FORMATS,
+    registered_credential_secrets,
     requires_header_token_policy,
+    reset_registered_credential_secrets,
     sends_credential_as_header,
 )
+from app.core.url_redaction import scrub_registered_credentials
+from app.modules.catalog.sources.adapters import arcgis as arcgis_mod
 from app.modules.catalog.sources.adapters.arcgis import (
     ARCGIS_HEADER_TOKEN_MIN_VERSION,
     arcgis_accepts_header_token,
@@ -51,6 +55,7 @@ from app.modules.catalog.sources.adapters.arcgis import (
     parse_arcgis_current_version,
     probe_arcgis_service,
 )
+from app.platform.security import SSRFError
 
 _BASE = (
     "https://services6.arcgis.com/ZrVlS0wslq8Nvq5I/arcgis/rest/services/X/FeatureServer"
@@ -574,3 +579,105 @@ class TestTheTokenCannotReachTheHttpxRequestLog:
         carried a credential at all."""
         lines = await self._httpx_log_lines(token=_TOKEN, current_version="10.4")
         assert any("token=" in line for line in lines)
+
+
+# ---------------------------------------------------------------------------
+# Audit round 1
+# ---------------------------------------------------------------------------
+
+
+class TestARefusedRedirectHopStillReachesTheDoor:
+    """fix(#1840 audit round 1).
+
+    ``SSRFError`` subclasses ``ValueError`` (``platform/security.py``), and the
+    first cut of this lane folded ``json.loads`` into the request's own ``try``
+    -- so ``except (ValueError, TypeError): return None``, which exists to
+    degrade an unparseable body to "not an ArcGIS service", started swallowing
+    a refused redirect hop as well. The SSRF stayed blocked either way; what
+    regressed is the ANSWER: the ``/probe`` door's coded refusal became "not
+    recognized", and the caller went on trying the other probes.
+    """
+
+    pytestmark = pytest.mark.asyncio
+
+    async def test_an_ssrf_refusal_propagates(self, monkeypatch) -> None:
+        async def _refuse(*_args, **_kwargs):
+            raise SSRFError("redirect target refused: evil.example.com")
+
+        monkeypatch.setattr(arcgis_mod, "bounded_probe_read", _refuse)
+
+        async with _client(lambda _request: _stream({})) as client:
+            with pytest.raises(SSRFError):
+                await probe_arcgis_service(_BASE, client, token=_TOKEN)
+
+    async def test_an_unparseable_body_still_degrades_to_none(self) -> None:
+        """The counterfactual. Without it the test above would pass for a
+        probe that had stopped catching parse failures at all."""
+
+        def handle(_request: httpx.Request) -> httpx.Response:
+            async def _chunks():
+                yield b"<html>not json</html>"
+
+            return httpx.Response(200, content=_chunks())
+
+        async with _client(handle) as client:
+            assert await probe_arcgis_service(_BASE, client, token=_TOKEN) is None
+
+
+class TestTheQueryFallbackRegistersItsSecret:
+    """fix(#1840 audit round 1).
+
+    ``build_credential_header`` registers the line it composes, so the header
+    transport is covered by the exact-value scrub #1770 round 43 introduced.
+    The query fallback composes no header and so registered nothing -- on
+    exactly the branch that puts the token in a URL, and where this module
+    logs the server's own ``message`` at WARNING (``ArcGIS error response:
+    url=%s code=%s message=%s``). Redaction there fell back to matching the
+    ``token=`` query key by shape, which is the coverage the registry exists
+    to replace.
+    """
+
+    def test_the_version_gated_fallback_registers_the_token(self) -> None:
+        reset_registered_credential_secrets()
+        headers, query_token = arcgis_request_auth(_TOKEN, current_version="10.4")
+        assert (headers, query_token) == ({}, _TOKEN)
+        assert _TOKEN in registered_credential_secrets()
+        scrubbed = scrub_registered_credentials(f"Invalid token supplied: {_TOKEN}")
+        assert _TOKEN not in scrubbed
+
+    def test_the_unusable_value_fallback_registers_the_token(self) -> None:
+        reset_registered_credential_secrets()
+        unusable = "has space"
+        assert arcgis_request_auth(unusable) == ({}, unusable)
+        assert unusable in registered_credential_secrets()
+
+    def test_the_header_path_registers_the_composed_line(self) -> None:
+        """The pre-existing half, asserted beside it so the two are read
+        together."""
+        reset_registered_credential_secrets()
+        headers, query_token = arcgis_request_auth(_TOKEN)
+        assert query_token is None
+        assert headers  # positive control: a header was composed
+        assert f"Authorization: Bearer {_TOKEN}" in registered_credential_secrets()
+
+    def test_nothing_is_registered_without_a_token(self) -> None:
+        """The counterfactual: the registry is not simply always non-empty."""
+        reset_registered_credential_secrets()
+        assert arcgis_request_auth(None) == ({}, None)
+        assert registered_credential_secrets() == frozenset()
+
+    @pytest.mark.asyncio
+    async def test_the_499_retry_registers_before_it_re_reads(self) -> None:
+        """The retry composes its URL directly rather than through the version
+        gate, so it needs a registration of its own."""
+        reset_registered_credential_secrets()
+
+        def handle(request: httpx.Request) -> httpx.Response:
+            if "token=" not in str(request.url):
+                return _stream({"error": {"code": 499, "message": "Token Required"}})
+            return _stream({"currentVersion": "10.4", "layers": []})
+
+        async with _client(handle) as client:
+            await probe_arcgis_service(_BASE, client, token=_TOKEN)
+
+        assert _TOKEN in registered_credential_secrets()

--- a/backend/tests/test_arcgis_header_transport_c2.py
+++ b/backend/tests/test_arcgis_header_transport_c2.py
@@ -35,6 +35,7 @@ import pytest
 from app.core.service_tokens import (
     ARCGIS_SERVICE_FORMAT,
     HEADER_AUTH_SERVICE_FORMATS,
+    HEADER_TOKEN_MIN_LENGTH,
     HEADER_TRANSPORT_SERVICE_FORMATS,
     registered_credential_secrets,
     requires_header_token_policy,
@@ -645,11 +646,47 @@ class TestTheQueryFallbackRegistersItsSecret:
         scrubbed = scrub_registered_credentials(f"Invalid token supplied: {_TOKEN}")
         assert _TOKEN not in scrubbed
 
-    def test_the_unusable_value_fallback_registers_the_token(self) -> None:
+    def test_the_unusable_value_fallback_does_not_register(self) -> None:
+        """fix(#1840 audit round 2): a value that could not have been a header
+        credential is not registered either. It still reaches the origin in
+        the query; only the log-scrub registration is gated."""
         reset_registered_credential_secrets()
         unusable = "has space"
         assert arcgis_request_auth(unusable) == ({}, unusable)
-        assert unusable in registered_credential_secrets()
+        assert registered_credential_secrets() == frozenset()
+
+    @pytest.mark.parametrize("short", ["json", "abc", "a", "tok"])
+    def test_a_short_token_is_not_registered(self, short: str) -> None:
+        """fix(#1840 audit round 2): exact-value scrubbing is a substring
+        replacement over every log line in the request's context, so a short
+        value corrupts ordinary text instead of protecting a credential.
+        ArcGIS is the one transport that never meets ``HEADER_TOKEN_CHARSET``
+        (``credential_or_422`` returns before that check for a URL-query
+        format), so nothing upstream rejects a four-character token. Measured:
+        registering ``json`` rewrote ``https://json.example.com`` to
+        ``https://***.example.com`` in that request's own logs.
+        """
+        reset_registered_credential_secrets()
+        headers, query_token = arcgis_request_auth(short, current_version="10.4")
+        assert (headers, query_token) == ({}, short)
+        assert registered_credential_secrets() == frozenset()
+        assert scrub_registered_credentials("https://json.example.com") == (
+            "https://json.example.com"
+        )
+
+    def test_a_token_at_the_floor_is_registered(self) -> None:
+        """The counterfactual for the floor: one character longer and it is
+        registered, so the gate is a length rule and not a switched-off
+        registration."""
+        reset_registered_credential_secrets()
+        at_floor = "a" * HEADER_TOKEN_MIN_LENGTH
+        assert arcgis_request_auth(at_floor, current_version="10.4") == ({}, at_floor)
+        assert at_floor in registered_credential_secrets()
+
+        reset_registered_credential_secrets()
+        below = "a" * (HEADER_TOKEN_MIN_LENGTH - 1)
+        assert arcgis_request_auth(below, current_version="10.4") == ({}, below)
+        assert registered_credential_secrets() == frozenset()
 
     def test_the_header_path_registers_the_composed_line(self) -> None:
         """The pre-existing half, asserted beside it so the two are read

--- a/backend/tests/test_credential_policy.py
+++ b/backend/tests/test_credential_policy.py
@@ -389,7 +389,10 @@ class TestBuildCredentialHeaderReturnsNone:
 
         An ArcGIS token is judged as a header VALUE (printable ASCII, no
         whitespace) rather than by ``HEADER_TOKEN_CHARSET``, so ``+``, ``/``
-        and a token shorter than the WFS/OAPIF floor all compose. Those rules
+        and a token shorter than the WFS/OAPIF floor all compose. The header
+        NAME is Esri's own (fix(#1840 codex round 1)): a Web Adaptor or
+        web-tier authentication in front of ArcGIS Enterprise consumes the
+        standard one and refuses before ArcGIS runs. Those rules
         exist for a credential written into a file libcurl parses; an ArcGIS
         token never reaches that file, and refusing ``+`` would refuse
         legitimate ArcGIS tokens for a danger this path does not have.
@@ -400,7 +403,7 @@ class TestBuildCredentialHeaderReturnsNone:
                 service_format=ARCGIS_FORMAT,
                 token=token,
             )
-        ) == ("Authorization", f"Bearer {token}")
+        ) == ("X-Esri-Authorization", f"Bearer {token}")
 
     @pytest.mark.parametrize("token", [None, "", "has space", "café"])
     def test_an_arcgis_token_that_cannot_be_a_header_value_is_refused(

--- a/backend/tests/test_credential_policy.py
+++ b/backend/tests/test_credential_policy.py
@@ -351,13 +351,18 @@ class TestBuildCredentialHeaderReturnsNone:
     def test_no_credential(self, auth: ServiceCredential | None) -> None:
         assert build_credential_header(auth) is None
 
-    @pytest.mark.parametrize("method", ["none", "bearer", "basic", "header", "oauth"])
-    def test_arcgis_never_gets_a_header_whatever_the_method(self, method: str) -> None:
-        """D9's invariant at the one place it can be tested in isolation.
+    @pytest.mark.parametrize("method", ["none", "basic", "header", "oauth"])
+    def test_arcgis_gets_no_header_for_a_method_it_cannot_carry(
+        self, method: str
+    ) -> None:
+        """feat(C2) narrowed D9's invariant from every method to three.
 
         Every field is populated, so nothing here returns None for want of an
-        input. An ArcGIS token is percent-encoded into a URL query, so a
-        header line composed for it would land inside a query string.
+        input. ArcGIS has no basic or named-API-key spelling at all, and the
+        GDAL path still percent-encodes the bearer token into the source URL,
+        so a header line composed for any of these would land inside a query
+        string. The bearer case is the one that changed and is covered by
+        ``test_arcgis_gets_a_bearer_header`` below.
         """
         assert (
             build_credential_header(
@@ -373,6 +378,45 @@ class TestBuildCredentialHeaderReturnsNone:
             )
             is None
         )
+
+    @pytest.mark.parametrize(
+        "token",
+        ["tok+slash/", "AA'#&ULTRASECRET", GOOD_BEARER, "a" * 3],
+        ids=["reserved-chars", "url-reserved", "base64url", "shorter-than-the-floor"],
+    )
+    def test_arcgis_gets_a_bearer_header(self, token: str) -> None:
+        """feat(C2), and the vocabulary difference that goes with it.
+
+        An ArcGIS token is judged as a header VALUE (printable ASCII, no
+        whitespace) rather than by ``HEADER_TOKEN_CHARSET``, so ``+``, ``/``
+        and a token shorter than the WFS/OAPIF floor all compose. Those rules
+        exist for a credential written into a file libcurl parses; an ArcGIS
+        token never reaches that file, and refusing ``+`` would refuse
+        legitimate ArcGIS tokens for a danger this path does not have.
+        """
+        assert build_credential_header(
+            ServiceCredential(
+                method=CredentialMethod.BEARER,
+                service_format=ARCGIS_FORMAT,
+                token=token,
+            )
+        ) == ("Authorization", f"Bearer {token}")
+
+    @pytest.mark.parametrize("token", [None, "", "has space", "café"])
+    def test_an_arcgis_token_that_cannot_be_a_header_value_is_refused(
+        self, token: str | None
+    ) -> None:
+        """The floor the value charset still enforces: no whitespace, ASCII
+        only. CR and LF are whitespace, so the header-smuggling class this
+        rule exists for is closed on the ArcGIS path too."""
+        with pytest.raises(ValueError):
+            build_credential_header(
+                ServiceCredential(
+                    method=CredentialMethod.BEARER,
+                    service_format=ARCGIS_FORMAT,
+                    token=token,
+                )
+            )
 
     @pytest.mark.parametrize(
         "service_format", [None, "stac", "geojson", "shapefile", ""]

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -2666,6 +2666,22 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # opposite, which is why it now cites the line it was checked against.
     # Cap 1293 -> 1301, exact.
     "backend/app/modules/catalog/sources/arcgis_signin.py": 1301,
+    # feat(C2) / fix(#1840): crossed _RATCHET_INCLUSION_LOC when the ArcGIS
+    # credential moved out of the request URL and into a header. What the
+    # growth bought, in one list: the version gate Esri's own `currentVersion`
+    # spelling needs (`parse_arcgis_current_version`, where 10.5.1 reports as
+    # `10.51` and a float comparison gets two releases the wrong way round),
+    # the one transport chooser (`arcgis_request_auth`) so no read decides for
+    # itself where the credential goes, one bounded reader
+    # (`read_arcgis_json`) with the two query-form fallbacks a real deployment
+    # needs -- a pre-10.5.1 server's 499 envelope and a Web Adaptor's 401/403
+    # before ArcGIS is ever reached -- plus `build_arcgis_layer_info_url` and
+    # the fold of the third hand-rolled count query into
+    # `build_arcgis_count_query_url` (#1755 item 14). Most of the added lines
+    # are the comments carrying the measurements those decisions rest on;
+    # without them the next reader re-derives the Esri version encoding and
+    # the web-tier case from scratch. Cap set at 1015, exact.
+    "backend/app/modules/catalog/sources/adapters/arcgis.py": 1015,
     # feat(#1746 B2b): first explicit entry for this file, which rode the 1500
     # default until the service-auth wave. #1758 added the ArcGIS sign-in
     # endpoint and its rate-limit wiring, and this lane added the credential

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -4670,7 +4670,13 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # already gate on the same two formats; this is the trust-boundary copy
     # AGENTS.md requires, and the comment is the argument for keeping both.
     # Cap 1354 -> 1366, exact.
-    "backend/app/processing/ingest/ogr.py": 1366,
+    # fix(#1840 audit round 2): +5. That gate moved up to
+    # `_sanitize_authorization_token`'s own entry, because inside
+    # `_legacy_bearer_line` it covered only the BARE-token branch -- a
+    # finished `Authorization: Bearer <tok>` line arriving for an ArcGIS job
+    # walked straight through to the header file. Both shapes refused now, and
+    # the comment at each end says which half it is. Cap 1366 -> 1371, exact.
+    "backend/app/processing/ingest/ogr.py": 1371,
     # fix(#1778): +157 for two audit findings that both land in JIT
     # provisioning. One is the REGISTRATION_ENABLED gate plus its exception
     # class, so enabling a provider stops being a way to reopen signup while

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -2723,7 +2723,13 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # `preview_service_layer`'s broad `except Exception`, so a future edit
     # that breaks one of those callees' "raises only HTTPException" contracts
     # degrades to a coded 4xx instead of a 500. Cap 1639 -> 1780, exact.
-    "backend/app/modules/catalog/sources/router.py": 1780,
+    # fix(#1840 audit round 1): +11. `_probe_credential_line` gates on
+    # `requires_header_token_policy` rather than on `build_credential_header`
+    # answering None, plus the import and the docstring paragraph saying why
+    # the two stopped being equivalent when lane C2 taught the builder to
+    # compose an ArcGIS header for the httpx transport. Cap 1780 -> 1791,
+    # exact.
+    "backend/app/modules/catalog/sources/router.py": 1791,
     # fix(#998): the DDL ported from migration 0019 so tenant-ownership adoption
     # is reachable forward-only at head. Almost all of it is SQL text, and it is
     # one artifact on purpose — the module is reviewed line-by-line against
@@ -4656,7 +4662,15 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # header`, the registry's only other producer, so the exact-value scrub
     # pass was inert for the whole worker service-import path on the
     # format every current job actually uses. Cap 1342 -> 1354, exact.
-    "backend/app/processing/ingest/ogr.py": 1354,
+    # fix(#1840 audit round 1): +12. `_legacy_bearer_line` asks
+    # `requires_header_token_policy` itself before reaching the builder,
+    # instead of inferring "this format carries no header line" from the
+    # builder answering None -- which stopped being true when lane C2 taught
+    # it to compose an ArcGIS header for the httpx transport. Both call sites
+    # already gate on the same two formats; this is the trust-boundary copy
+    # AGENTS.md requires, and the comment is the argument for keeping both.
+    # Cap 1354 -> 1366, exact.
+    "backend/app/processing/ingest/ogr.py": 1366,
     # fix(#1778): +157 for two audit findings that both land in JIT
     # provisioning. One is the REGISTRATION_ENABLED gate plus its exception
     # class, so enabling a provider stops being a way to reopen signup while

--- a/backend/tests/test_service_auth_transport_1746.py
+++ b/backend/tests/test_service_auth_transport_1746.py
@@ -37,6 +37,7 @@ import os
 import uuid
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
+from urllib.parse import quote
 
 import httpx
 import pytest
@@ -587,10 +588,130 @@ class TestNoArcgisUrlCarriesAnAuthorizationHeader:
             assert token in url
 
     def test_the_count_url_carries_nothing_on_the_header_transport(self):
-        """feat(C2): the default, which is what httpx logs at INFO."""
-        url = arcgis_mod.build_arcgis_count_query_url(f"{_ARCGIS_BASE}/0")
+        """feat(C2): the default, which is what httpx logs at INFO.
+
+        fix(#1840 audit round 1): this asserted only that a count URL built
+        with NO token argument contains no token, which has been true in every
+        revision -- it passed unchanged against the parent and was therefore
+        worth nothing as evidence for this lane. It now drives the transport
+        DECISION, which is the thing that changed: ``arcgis_request_auth`` is
+        what chooses, and it did not exist before C2.
+        """
+        token = "tok" + _value()
+        headers, query_token = arcgis_mod.arcgis_request_auth(token)
+        assert headers == {"Authorization": f"Bearer {token}"}
+        assert query_token is None
+
+        url = arcgis_mod.build_arcgis_count_query_url(f"{_ARCGIS_BASE}/0", query_token)
         assert "token" not in url
         assert "Authorization" not in url
+        assert token not in url
+
+    def test_the_worker_gets_the_bare_arcgis_token_not_a_header_line(self):
+        """fix(#1840 audit round 1): the P1 this class was narrowed past.
+
+        ``wire_credential`` is the one string that crosses to the worker under
+        the kwarg ``token``, and for ArcGIS it must be the BARE token, because
+        ``build_gdal_source`` percent-encodes whatever it gets into
+        ``&token=`` in the ESRIJSON source URL. It used to select that branch
+        by asking whether ``build_credential_header`` answered None, and lane
+        C2 made the builder answer with a pair -- so the worker was handed
+        ``Authorization: Bearer <token>`` and every authenticated ArcGIS
+        import, refresh and reupload sent ``token=Authorization%3A+Bearer+...``
+        and got a 498/499, after the single-use credential had been spent.
+
+        Driven end to end through the three functions that disagreed, rather
+        than asserting on the builder, because the builder answering a pair is
+        correct now and the bug was one consumer's reading of that answer.
+        """
+        from app.modules.catalog.sources.preview import build_gdal_source
+        from app.platform.service_auth import wire_credential
+
+        token = "tok+slash/" + _value()
+        credential = ServiceCredential(
+            method=CredentialMethod.BEARER,
+            service_format="arcgis_featureserver",
+            token=token,
+        )
+
+        wired = wire_credential(credential)
+        assert wired == token
+        assert "Authorization" not in wired
+
+        source, _layer = build_gdal_source(
+            "ArcGIS FeatureServer", _ARCGIS_BASE, "Parcels", 0, token=wired
+        )
+        count_url = arcgis_mod.build_arcgis_count_query_url(f"{_ARCGIS_BASE}/0", wired)
+        for url in (source, count_url):
+            assert "Authorization" not in url
+            assert "Bearer" not in url
+            assert f"token={quote(token, safe='')}" in url
+
+        # And the httpx side of the same credential still gets the header,
+        # so this pins the split rather than a revert of the lane.
+        headers, query_token = arcgis_mod.arcgis_request_auth(wired)
+        assert headers == {"Authorization": f"Bearer {token}"}
+        assert query_token is None
+
+    @pytest.mark.parametrize("service_format", ["wfs", "ogcapi_features"])
+    def test_the_two_header_file_formats_still_wire_a_finished_line(
+        self, service_format
+    ):
+        """The counterfactual for the test above: without it, that one would
+        pass for a ``wire_credential`` that had stopped composing lines at
+        all."""
+        from app.platform.service_auth import wire_credential
+
+        token = "tok" + _value()
+        wired = wire_credential(
+            ServiceCredential(
+                method=CredentialMethod.BEARER,
+                service_format=service_format,
+                token=token,
+            )
+        )
+        assert wired == f"Authorization: Bearer {token}"
+
+    def test_the_endpoint_check_line_is_none_for_arcgis(self):
+        """fix(#1840 audit round 1), the sibling consumer.
+
+        ``_probe_credential_line`` feeds ``assert_endpoints_stay_on_origin``,
+        which is a question about a service DESCRIBING a foreign operation
+        endpoint that GDAL follows with a header file attached -- WFS and OGC
+        API only. It read the builder's answer too, and started returning an
+        ArcGIS header line. Inert, because the check early-returns on the same
+        predicate, but it was a claim about the wrong transport waiting for
+        that guard to be relaxed.
+        """
+        from app.modules.catalog.sources.router import _probe_credential_line
+
+        credential = ServiceCredential(
+            method=CredentialMethod.BEARER,
+            service_format="arcgis_featureserver",
+            token="tok" + _value(),
+        )
+        assert _probe_credential_line(credential, "arcgis_featureserver") is None
+        assert _probe_credential_line(credential, "wfs") is not None
+
+    def test_the_worker_refuses_to_write_an_arcgis_header_file_line(self):
+        """fix(#1840 audit round 1): the trust-boundary copy of the rule.
+
+        Both callers of ``_sanitize_authorization_token`` gate on the two
+        header-file formats already. This is the worker's own check, which
+        AGENTS.md requires to stand on its own rather than resting on a
+        validator two processes away, and which is what keeps an ArcGIS token
+        out of ``GDAL_HTTP_HEADER_FILE`` if a caller's gate is relaxed.
+        """
+        from app.processing.ingest.ogr import _sanitize_authorization_token
+
+        token = "tok" + _value()
+        with pytest.raises(ValueError):
+            _sanitize_authorization_token(token, service_format="arcgis_featureserver")
+        # The counterfactual: the same bare token IS composed for WFS.
+        assert (
+            _sanitize_authorization_token(token, service_format="wfs")
+            == f"Authorization: Bearer {token}"
+        )
 
     def test_the_paged_import_path_composes_no_credential_header(self):
         """The positive control names the string it is looking for.

--- a/backend/tests/test_service_auth_transport_1746.py
+++ b/backend/tests/test_service_auth_transport_1746.py
@@ -566,7 +566,7 @@ class TestNoArcgisUrlCarriesAnAuthorizationHeader:
                 token=token,
             )
         )
-        assert pair == ("Authorization", f"Bearer {token}")
+        assert pair == ("X-Esri-Authorization", f"Bearer {token}")
 
     def test_no_composed_arcgis_url_contains_the_string(self):
         """Every ArcGIS URL this codebase composes, with a token in it.
@@ -599,7 +599,7 @@ class TestNoArcgisUrlCarriesAnAuthorizationHeader:
         """
         token = "tok" + _value()
         headers, query_token = arcgis_mod.arcgis_request_auth(token)
-        assert headers == {"Authorization": f"Bearer {token}"}
+        assert headers == {"X-Esri-Authorization": f"Bearer {token}"}
         assert query_token is None
 
         url = arcgis_mod.build_arcgis_count_query_url(f"{_ARCGIS_BASE}/0", query_token)
@@ -650,7 +650,7 @@ class TestNoArcgisUrlCarriesAnAuthorizationHeader:
         # And the httpx side of the same credential still gets the header,
         # so this pins the split rather than a revert of the lane.
         headers, query_token = arcgis_mod.arcgis_request_auth(wired)
-        assert headers == {"Authorization": f"Bearer {token}"}
+        assert headers == {"X-Esri-Authorization": f"Bearer {token}"}
         assert query_token is None
 
     @pytest.mark.parametrize("service_format", ["wfs", "ogcapi_features"])
@@ -1619,7 +1619,7 @@ class TestABearerTokenIsJudgedAfterDetection:
         # header VALUE instead.
         arcgis = [r for r in recorded if "f=json" in r.url.query.decode()]
         assert arcgis
-        assert arcgis[0].headers["Authorization"] == f"Bearer {token}"
+        assert arcgis[0].headers["X-Esri-Authorization"] == f"Bearer {token}"
         assert all(token not in str(r.url) for r in recorded)
         assert all("tok%2Bslash%2F" not in str(r.url) for r in recorded)
 

--- a/backend/tests/test_service_auth_transport_1746.py
+++ b/backend/tests/test_service_auth_transport_1746.py
@@ -517,23 +517,28 @@ class TestUnusableInputsAreRefusedAtTheDoor:
 
 
 class TestNoArcgisUrlCarriesAnAuthorizationHeader:
-    """The builder answers None for ArcGIS, so nothing can compose one there.
+    """No ArcGIS URL ever contains a header line, and only bearer gets one.
 
-    An ArcGIS credential is percent-encoded straight into a URL query
-    (``build_gdal_source``, ``build_arcgis_count_query_url``, the paged import
-    path), so a builder that ever returned a line for an ArcGIS credential
-    would put ``Authorization: Basic ...`` inside a query string.
+    feat(C2) narrowed this class rather than deleting it. The httpx path now
+    sends ``Authorization: Bearer <token>``, which is what lane C2 measured
+    live. What must NOT change is the GDAL side: ``build_gdal_source`` and the
+    paged import path still percent-encode the token into the ESRIJSON source
+    URL, so a builder that put a header line into one of those would produce
+    ``Authorization: Basic ...`` inside a query string. And basic and a named
+    API key still get nothing at all, because ArcGIS has no spelling for
+    either.
     """
 
     @pytest.mark.parametrize(
         "method",
         [
-            CredentialMethod.BEARER,
             CredentialMethod.BASIC,
             CredentialMethod.HEADER_KEY,
         ],
     )
-    def test_the_builder_composes_nothing_for_an_arcgis_credential(self, method):
+    def test_the_builder_composes_nothing_for_a_method_arcgis_cannot_carry(
+        self, method
+    ):
         credential = ServiceCredential(
             method=method,
             service_format="arcgis_featureserver",
@@ -545,8 +550,30 @@ class TestNoArcgisUrlCarriesAnAuthorizationHeader:
         )
         assert build_credential_header(credential) is None
 
+    def test_the_builder_composes_a_bearer_header_for_arcgis(self):
+        """feat(C2): the one method ArcGIS does carry.
+
+        And it is composed by the same single producer every other transport
+        goes through, so the exact-value scrub registration
+        (``register_credential_secret``) covers it too.
+        """
+        token = "tok+slash/" + _value()
+        pair = build_credential_header(
+            ServiceCredential(
+                method=CredentialMethod.BEARER,
+                service_format="arcgis_featureserver",
+                token=token,
+            )
+        )
+        assert pair == ("Authorization", f"Bearer {token}")
+
     def test_no_composed_arcgis_url_contains_the_string(self):
-        """Every ArcGIS URL this codebase composes, with a token in it."""
+        """Every ArcGIS URL this codebase composes, with a token in it.
+
+        The GDAL source keeps its token: that path hands ogr2ogr a URL and has
+        no header of its own (see this class's docstring). The count URL takes
+        one only on the pre-10.5.1 fallback, and this passes one explicitly.
+        """
         from app.modules.catalog.sources.preview import build_gdal_source
 
         token = "tok" + _value()
@@ -559,22 +586,26 @@ class TestNoArcgisUrlCarriesAnAuthorizationHeader:
             assert "Authorization" not in url
             assert token in url
 
-    def test_neither_arcgis_module_composes_a_credential_header(self):
+    def test_the_count_url_carries_nothing_on_the_header_transport(self):
+        """feat(C2): the default, which is what httpx logs at INFO."""
+        url = arcgis_mod.build_arcgis_count_query_url(f"{_ARCGIS_BASE}/0")
+        assert "token" not in url
+        assert "Authorization" not in url
+
+    def test_the_paged_import_path_composes_no_credential_header(self):
         """The positive control names the string it is looking for.
 
-        A source-text assertion, because the ArcGIS transport is C2's lane and
-        this is the invariant that lane must not break: an adapter that grew a
-        header would pass every behavioural test here while putting a
-        credential where the query goes.
+        A source-text assertion, scoped to the WORKER's paged ArcGIS fetch,
+        which hands GDAL a URL. feat(C2) removed the adapter from this check
+        because the adapter now legitimately calls the shared builder; the
+        tree-wide rule that no SECOND composer appears anywhere is
+        ``test_credential_producer_structural.py``'s job, and it covers both
+        modules.
         """
-        adapter_source = inspect.getsource(arcgis_mod)
         paged_source = inspect.getsource(tasks_vector._fetch_arcgis_import_page_info)
-        assert "token" in adapter_source, "positive control: the file was read"
-        for source in (adapter_source, paged_source):
-            # The only mention either module may make of the header is the
-            # comment saying it composes none.
-            assert "Authorization:" not in source
-            assert "build_credential_header(" not in source
+        assert "token" in paged_source, "positive control: the source was read"
+        assert "Authorization" not in paged_source
+        assert "build_credential_header(" not in paged_source
 
 
 # ---------------------------------------------------------------------------
@@ -1444,14 +1475,17 @@ class TestABearerTokenIsJudgedAfterDetection:
 
         assert resp.status_code == 200, resp.text
         assert resp.json()["service_type"] == "ArcGIS FeatureServer"
-        # The token reached the service the way that transport carries one,
-        # percent-encoded into the query, and never as a header.
+        # feat(C2): the token reached the service as an Authorization header
+        # and no part of it is in any URL. The vocabulary point is unchanged
+        # and is the reason this test exists: `+` and `/` are outside
+        # `HEADER_TOKEN_CHARSET`, which is the WFS/OAPIF header-FILE rule, and
+        # an ArcGIS token is still not judged by it -- it is judged as a
+        # header VALUE instead.
         arcgis = [r for r in recorded if "f=json" in r.url.query.decode()]
         assert arcgis
-        assert "tok%2Bslash%2F" in str(arcgis[0].url)
-        assert all(
-            "authorization" not in {n.lower() for n in r.headers} for r in recorded
-        )
+        assert arcgis[0].headers["Authorization"] == f"Bearer {token}"
+        assert all(token not in str(r.url) for r in recorded)
+        assert all("tok%2Bslash%2F" not in str(r.url) for r in recorded)
 
     async def test_a_token_no_adapter_can_use_is_refused_after_detection(
         self, client, admin_auth_header: dict
@@ -1477,9 +1511,16 @@ class TestABearerTokenIsJudgedAfterDetection:
         assert detail["code"] == "invalid_service_token"
         assert detail["message"] == HEADER_TOKEN_POLICY
         assert token not in resp.text
-        # No credential left the process under a header, on any hop.
+        # feat(C2): the ArcGIS probe fires here too and now presents the token
+        # as a bearer header, so the invariant is no longer "no Authorization
+        # anywhere". It is that no OTHER credential shape went out, and that
+        # nothing carried the token in a URL: the two header-auth adapters
+        # still refused to compose this token, which is why the answer is the
+        # policy rather than "service not recognized".
+        assert all(token not in str(r.url) for r in recorded)
         assert all(
-            "authorization" not in {n.lower() for n in r.headers} for r in recorded
+            r.headers.get("Authorization") in (None, f"Bearer {token}")
+            for r in recorded
         )
 
     async def test_an_unrecognized_service_still_says_so(
@@ -1621,7 +1662,9 @@ class TestABearerTokenIsJudgedAfterDetection:
 
         assert resp.status_code == 200, resp.text
         assert resp.json()["service_type"] == "ArcGIS FeatureServer"
-        assert [r for r in recorded if token in str(r.url)]
+        # feat(C2): the token travelled, as a header rather than in the query.
+        assert [r for r in recorded if r.headers.get("Authorization")]
+        assert all(token not in str(r.url) for r in recorded)
 
     async def test_the_anonymous_fallback_is_untouched(
         self, client, admin_auth_header: dict

--- a/backend/tests/test_service_auth_transport_1746.py
+++ b/backend/tests/test_service_auth_transport_1746.py
@@ -694,22 +694,37 @@ class TestNoArcgisUrlCarriesAnAuthorizationHeader:
         assert _probe_credential_line(credential, "wfs") is not None
 
     def test_the_worker_refuses_to_write_an_arcgis_header_file_line(self):
-        """fix(#1840 audit round 1): the trust-boundary copy of the rule.
+        """fix(#1840 audit rounds 1 and 2): the trust-boundary copy of the rule.
 
         Both callers of ``_sanitize_authorization_token`` gate on the two
         header-file formats already. This is the worker's own check, which
         AGENTS.md requires to stand on its own rather than resting on a
         validator two processes away, and which is what keeps an ArcGIS token
         out of ``GDAL_HTTP_HEADER_FILE`` if a caller's gate is relaxed.
+
+        Round 1 put that gate inside ``_legacy_bearer_line``, the BARE-token
+        branch, so a finished line arriving for an ArcGIS job walked straight
+        through and the guarantee was half a guarantee. Both shapes are
+        parametrized here for that reason.
         """
         from app.processing.ingest.ogr import _sanitize_authorization_token
 
         token = "tok" + _value()
-        with pytest.raises(ValueError):
-            _sanitize_authorization_token(token, service_format="arcgis_featureserver")
-        # The counterfactual: the same bare token IS composed for WFS.
+        for arriving in (token, f"Authorization: Bearer {token}"):
+            with pytest.raises(ValueError):
+                _sanitize_authorization_token(
+                    arriving, service_format="arcgis_featureserver"
+                )
+        # The counterfactual: both shapes pass for WFS, so the refusal above
+        # is about the format and not about the shape.
         assert (
             _sanitize_authorization_token(token, service_format="wfs")
+            == f"Authorization: Bearer {token}"
+        )
+        assert (
+            _sanitize_authorization_token(
+                f"Authorization: Bearer {token}", service_format="wfs"
+            )
             == f"Authorization: Bearer {token}"
         )
 


### PR DESCRIPTION
The ArcGIS token stops travelling in the query string on GeoLens's own httpx
requests and travels as `Authorization: Bearer <token>` instead. That takes it
out of the request URL, which is the point: httpx logs every outbound request
at INFO as `HTTP Request: GET <url> "HTTP/1.1 200 OK"`, and that line is
written before any GeoLens redactor sees it. A query token also reaches proxy
and load-balancer access logs, and comes back inside the text an origin quotes
in an error.

## What moved

Five reads, all in `adapters/arcgis.py`: the service probe, the per-layer count
enrichment, the single-layer feature count, the pagination/layer-info read, and
both reads of the layer preview. The GDAL/ogr2ogr ingest path did not move; see
below.

The header is composed by `build_credential_header` in `core/service_tokens.py`
rather than by the adapter, so there is still exactly one producer of a
credential header in the tree and `test_credential_producer_structural.py` still
passes unchanged. `HEADER_AUTH_SERVICE_FORMATS` is untouched — it answers **four**
questions (the base64url charset, the GDAL header file,
`assert_endpoints_stay_on_origin`, and what crosses to the worker as a finished
header line rather than a bare token) and ArcGIS is still no to all four. A
second set, `HEADER_TRANSPORT_SERVICE_FORMATS`, answers the one question that
changed, and `sends_credential_as_header()` is the gate the builder now reads.
Every consumer of the first set that decides *by format* asks
`requires_header_token_policy` by name rather than inferring it from what the
builder returned — that is audit-round-1's fix, see below. Three others still
branch on `pair is not None` (`preview.py`'s two header-file writers and
`router.py::_fetch_ogcapi_collection_srid`), which is sound only because each is
already fenced by its caller to a WFS or OAPIF source; un-fencing any of them
means gating it on the predicate at the same time.

An ArcGIS bearer token is judged as a header VALUE (printable ASCII, no
whitespace) rather than by `HEADER_TOKEN_CHARSET`. The base64url rule exists
because a WFS/OAPIF credential becomes a line in a file libcurl parses, where a
stray CR or LF is a smuggling primitive; an ArcGIS token never reaches that file
and legitimately holds `+` or `/`. The value charset still bans every whitespace
character, CR and LF included, so the smuggling class stays closed. Basic and a
named API key still get no header at all — ArcGIS has no spelling for either.

The header name is `X-Esri-Authorization`, which is plan D5's original
recommendation — see the codex round 1 section for why the standard name was
tried first and why it does not survive contact with ArcGIS Enterprise. No
`Referer` header is sent anywhere; it was measured unnecessary, including for a
referer-bound token. No `GDAL_HTTP_FOLLOWLOCATION` was added anywhere.

## The version-gated fallback

ArcGIS Server has read a bearer token from a header since 10.5.1; older releases
understand only `token=`. `parse_arcgis_current_version` reads the version out of
the service or layer document that is fetched anyway, and
`arcgis_accepts_header_token` draws the line. Esri's own spelling is the trap the
parser exists for: `currentVersion` is a NUMBER and a patch release is a second
fractional digit, so 10.5.1 reports as `10.51` and 10.4.1 as `10.41` while 10.5
is `10.5` — a float comparison orders `10.5` and `10.51` correctly for the wrong
reason and `10.41` above `10.5` for another wrong one. Unknown or unparseable is
treated as new enough, because hosted ArcGIS Online is the common case (it
reported `12` on the live check) and every server old enough to need the query
form does report a version.

The probe's first request has no version to read yet, so there is one safety
net: an HTTP 200 carrying error 499 "Token Required" — exactly what a pre-10.5.1
server says when it ignores the header and therefore sees no token — retries
once with the query form. 498 is not retried, because 498 means a token WAS read
and rejected, so the header arrived. The layer preview reads `currentVersion`
from the metadata document it fetches first and hands it to its other two reads,
so an old server costs one retry rather than three.

On the fallback path the token is still percent-encoded
(`fix(#1746 codex r7)`) before it goes anywhere near a URL.

## #1755 item 14: one producer of the count-query URL

`enrich_arcgis_feature_counts` hand-rolled `<layer>/query?where=1%3D1&returnCountOnly=true&f=json`
for a third time. It calls `build_arcgis_count_query_url` now, so the
enrichment, `fetch_arcgis_feature_count` and the health/refresh probe issue a
byte-identical URL. Two behaviours change with the fold, as the issue asked to
have called out: the parameter order follows the builder's, and on the
pre-10.5.1 fallback the token is encoded by `urlencode` rather than by a
hand-written `quote(token, safe='')`. Both encode every reserved character;
`urlencode` renders a space as `+` where `quote` produced `%20`, and ArcGIS
decodes both. With the header transport the count URL carries no token at all.

## The ingest path: evidence, and why it did not move

The worker's ArcGIS *metadata* reads already go through this adapter over httpx
(`tasks_vector._fetch_arcgis_import_page_info` → `fetch_arcgis_pagination_info`
and `fetch_arcgis_feature_count`), so those moved to the header with everything
else and needed no change of their own.

The feature *data* is fetched by ogr2ogr from an `ESRIJSON:<url>?…&token=…`
source built by `build_gdal_source`, and it stays there. GDAL reads a credential
only from `GDAL_HTTP_HEADER_FILE`, and the writer of that file
(`processing/ingest/ogr.py`, `_sanitize_authorization_token`) holds every line to
`HEADER_TOKEN_CHARSET` — base64url plus a length floor. An ArcGIS token
legitimately contains `+` or `/`, so moving this path means either widening the
charset that exists to stop header smuggling into libcurl, or refusing tokens
that work today. Neither is a trade worth making for a path whose residual
exposure (the token in the subprocess argv and in GDAL's error text) is already
bounded where it lands: `run_ogr2ogr_service` redacts before the text becomes an
exception, and #1753 purges the job row. The reasoning is recorded as a comment
at the `build_gdal_source` branch so the next reader does not have to re-derive
it, and `TestNoArcgisUrlCarriesAnAuthorizationHeader` still pins that the paged
worker fetch composes no header.

## Security invariants

- **Same-origin coverage.** `assert_endpoints_stay_on_origin` still does not run
  for ArcGIS, and that is correct rather than a gap: it exists for a service that
  *describes* a foreign operation endpoint GDAL then follows, and this adapter
  composes every URL it reads from the submitted base URL, dereferencing no
  server-chosen href. The one remaining way the credential could leave the origin
  is a redirect.
- **The header is per-request, never a client-wide default.** It is attached to
  the one validated URL each read composes; no `httpx.AsyncClient` gets a
  `headers=` default, so nothing can ride along.
- **Redirects.** `make_safe_client()` and its `_revalidate_redirect` hook are
  unchanged and still re-validate every hop. `x-esri-authorization` is in
  `_ALWAYS_CREDENTIAL_HEADERS` (`platform/security.py:143`), so
  `_refuse_cross_origin_credential` **refuses** a cross-origin hop carrying it
  rather than following it — louder than httpx's silent strip of
  `Authorization`. Pinned per hop with a `MockTransport` behind a real
  `make_safe_client`: the cross-origin case raises `SSRFError` after exactly one
  request (the second is never issued), and the counterfactual — a same-origin
  redirect — still authenticates, so the test cannot pass for a client that
  never sent the header or that refused every redirect.
- **Nothing about a token is logged.** The builder registers the composed line
  with `register_credential_secret` on the branch that composes it, the same as
  every other transport, so exact-value scrubbing covers it. A token that cannot
  be a header value at all degrades to the query form without logging anything
  about the value.

## Live check (read-only, redacted)

Minted with the Keychain credential against `njhighlands.maps.arcgis.com`
(`client=referer`), then run through the code path as it now stands against the
org-only layer `Cons_Map_WFL1/FeatureServer/0` (re-run after the codex round 1
header change):

```
transport chosen: ['X-Esri-Authorization'] query_token: None
header sent: X-Esri-Authorization: Bearer <TOKEN>
probe service_type: ArcGIS FeatureServer
probe version: 12
probe layer count: 19
feature count (header transport): 9567
no credential -> ArcGISTokenError ArcGIS token error (499): Token Required
preview: {'srid': 3857, 'geometry_type': 'Polygon',
          'layer_name': 'COMM_DevelopmentThreatScore', 'feature_count': 9567,
          'columns': 57, 'sample_rows': 5}

requests issued (redacted):
  200 .../Cons_Map_WFL1/FeatureServer?f=json
  200 .../Cons_Map_WFL1/FeatureServer/0/query?where=1%3D1&returnCountOnly=true&f=json
  200 .../Cons_Map_WFL1/FeatureServer/0/query?where=1%3D1&returnCountOnly=true&f=json
  200 .../Cons_Map_WFL1/FeatureServer/0?f=json
  200 .../Cons_Map_WFL1/FeatureServer/0/query?where=1%3D1&outFields=%2A&resultRecordCount=5&f=json
  200 .../Cons_Map_WFL1/FeatureServer/0/query?where=1%3D1&returnCountOnly=true&f=json

token appears in any request URL: False
```

The 499 line is the negative control: the same read with no credential is
refused, so the 9567 above is the header doing the work. Hosted AGOL reports
`currentVersion: 12`, which the parser reads as `(12, 0, 0)` and the gate sends
down the header path. No request carried a `Referer`, and no fallback fired.

## Audit round 1

A pre-trigger adversarial audit of the first push found one P1 and three
smaller items. All are fixed in the second commit.

**P1 — the worker was handed a header line instead of the bare ArcGIS token.**
`wire_credential` is the one string that crosses to the worker under the kwarg
`token`, and for ArcGIS it must be the bare value, because `build_gdal_source`
percent-encodes whatever it gets into `&token=` in the ESRIJSON source URL. It
selected that branch by asking whether `build_credential_header` answered
`None` — a proxy for `requires_header_token_policy` that stopped being
equivalent the moment this lane taught the builder to compose an ArcGIS header
for the httpx transport. Measured on the first push: `wire_credential` returned
`'Authorization: Bearer <tok>'` where the parent returned `'<tok>'`, so
`build_gdal_source` emitted `&token=Authorization%3A+Bearer+…` and every
authenticated ArcGIS import, refresh and reupload would have failed at the
origin *after* spending its single-use credential. Fixed by gating on
`requires_header_token_policy(resolved)`; measured after: `wire_credential`
returns the bare token again and WFS/OAPIF still wire a finished line.

The root cause was a stale enumeration: `HEADER_AUTH_SERVICE_FORMATS`'s comment
listed three consumers and `wire_credential` was a fourth. That comment now
lists four and says every consumer must ask the predicate by name. Two sibling
consumers were converted at the same time: `_probe_credential_line` (which had
started returning an ArcGIS line into `assert_endpoints_stay_on_origin` — inert,
because that check early-returns on the same predicate, but a claim about the
wrong transport waiting for a guard to be relaxed), and the worker's own
`_legacy_bearer_line`, which now refuses a non-header-file format outright.
That last one is defence in depth at the trust boundary, where AGENTS.md says
the worker's check must stand on its own rather than resting on a validator two
processes away.

Tests: `test_the_worker_gets_the_bare_arcgis_token_not_a_header_line` drives
`wire_credential` → `build_gdal_source` → `build_arcgis_count_query_url` end to
end, plus a WFS/OAPIF counterfactual so it cannot pass for a `wire_credential`
that stopped composing lines at all;
`test_the_endpoint_check_line_is_none_for_arcgis` and
`test_the_worker_refuses_to_write_an_arcgis_header_file_line` cover the two
siblings, each with its own positive control.

**P2 — a refused redirect hop was being swallowed by the ArcGIS probe.**
`SSRFError` subclasses `ValueError`, and folding `json.loads` into the request's
own `try` put the network call under the `except (ValueError, TypeError)` that
exists to degrade an unparseable body to "not an ArcGIS service". The SSRF was
still blocked; what regressed is the answer the operator gets — the `/probe`
door's coded refusal became "not recognized" and the caller went on trying the
other probes. Fixed with `except SSRFError: raise` ahead of that clause.
Counterfactual measured: with the clause removed,
`test_an_ssrf_refusal_propagates` fails and its
`test_an_unparseable_body_still_degrades_to_none` sibling still passes, so the
test is pinned to exactly the behaviour that changed.

**P2 — the query fallback registered no secret.** `build_credential_header`
registers the line it composes, so the header transport is covered by the
exact-value scrub #1770 round 43 introduced; the pre-10.5.1 fallback composed
nothing and so registered nothing — on precisely the branch that puts the token
in a URL, and where this module logs the server's own `message` at WARNING.
Redaction there fell back to matching a `token=` query key by shape, which is
the coverage the registry exists to replace. All three query-form returns (the
version gate, the unusable-value degrade, and the 499 retry, which composed its
URL directly) now go through one `_query_form_credential` that registers first.
Measured: `scrub_registered_credentials("Invalid token supplied: <tok>")` →
`"Invalid token supplied: ***"` on the fallback, where it previously returned
the token verbatim.

**P3 — one new test was vacuous.**
`test_the_count_url_carries_nothing_on_the_header_transport` asserted only that
a count URL built with no token argument contains no token, which has been true
in every revision and passed unchanged against the parent. It now drives
`arcgis_request_auth`, the transport decision that is the thing this lane
introduced, so it cannot exist on the parent at all.

**Note only.** `parse_arcgis_current_version("10.10")` reads as `10.1.0` rather
than `10.10.0` and would take the query fallback. Esri has shipped no such
version and went from 10.9 to 11.x; recorded as a comment at the branch.

## Audit round 2

Verdict NO_P1, every round-1 item confirmed closed. Three small items, all
fixed in the third commit.

**P2 — the ArcGIS refusal only covered half the shapes.** Round 1 put the
format gate inside `_legacy_bearer_line`, which is the *bare-token* branch, so
a finished `Authorization: Bearer <tok>` line arriving for an ArcGIS job walked
straight through to the header file and the "keeps an ArcGIS token out of
`GDAL_HTTP_HEADER_FILE`" claim was half true. Hoisted to
`_sanitize_authorization_token`'s own entry, which is the one function this
module sanitizes a header-file line through. Measured after: both shapes refuse
for `arcgis_featureserver` and both still compose for `wfs`, so the refusal is
about the format and not the shape. The test is parametrized over both.

**P3 — the fallback scrub registration had no floor.** ArcGIS is the one
transport whose token never meets `HEADER_TOKEN_CHARSET` (`credential_or_422`
returns before that check for a URL-query format), so nothing upstream rejects
a four-character one — and exact-value scrubbing is a substring replacement
over every log line in the request's context. Measured before: registering
`json` rewrote `https://json.example.com` to `https://***.example.com` in that
request's own logs, corrupting the diagnostics the redactor exists to make
safe. `_query_form_credential` now registers only a value that passes
`credential_input_rejection_reason` *and* meets `HEADER_TOKEN_MIN_LENGTH`.
Measured after: `json`, `abc`, 7 chars and `has space` register nothing and
`https://json.example.com` survives intact; 8 chars and a real-shaped token
register and scrub to `***`. The credential still reaches the origin either
way — only the log-scrub registration is gated.

**P3 — the enumeration comment overclaimed.** "None infers the answer from the
builder" was false for three sites. Corrected in `service_tokens.py` and above:
the three that decide by format ask the predicate by name; the three that
branch on `pair is not None` are each fenced by an OAPIF/WFS-only caller
condition, and un-fencing one means gating it at the same time.

*Noted, no action:* `register_credential_secret` calls inside the
`asyncio.gather` tasks in `enrich_arcgis_feature_counts` are invisible to the
parent context. Inert, because `_fetch_count` does its own logging in-task.

## Codex round 1

One P1, fixed in the fourth commit.

**The standard header name is not safe on ArcGIS Enterprise.** The lane shipped
`Authorization: Bearer` on rule A grounds. On a deployment behind a Web Adaptor,
or with web-tier authentication (IWA or PKI in IIS), the front end consumes that
header and answers 401/403 *before* ArcGIS runs — so `bounded_probe_read`'s
`raise_for_status()` fires and the 499-envelope fallback, which only reads an
HTTP 200 body, never gets a turn. An authenticated probe, preview or import
would have started failing on a portal where `?token=` had always worked.

Two changes:

1. **The header is `X-Esri-Authorization` now**, which is what plan D5
   recommended and what Esri documents for exactly this reason. Rule A's
   objection — a custom name is forwarded verbatim across a cross-origin
   redirect where `Authorization` is stripped — does not bite here:
   `x-esri-authorization` is already in `_ALWAYS_CREDENTIAL_HEADERS`
   (`platform/security.py:143`), so `_refuse_cross_origin_credential` (same
   file, ~187, called from `_revalidate_redirect` at ~234) **refuses** the hop
   instead of following it. The redirect test asserts that refusal — one request
   issued, `SSRFError` raised, second never sent — rather than a silent strip.
   The AGOL live check confirms the name works there too (rows 3/4 of plan
   section 9 Q1, and the re-run above).
2. **A second, bounded fallback**: an HTTP 401 or 403 on the request itself
   retries once with the query form on the same validated URL, registering the
   token with the scrubber first through the same `_query_form_credential` the
   version gate uses. `_is_web_tier_refusal` bounds it to those two statuses, to
   a response with an empty redirect `history`, and to the same origin as the
   URL asked for — a refusal from a host we were bounced to says nothing about
   the host we addressed, and replaying a credential to it is exactly what must
   not happen. Both fallbacks land on one `_read_with_query_token`, which
   catches nothing, so a second 401 propagates and neither branch can chain into
   the other.

Tests: 401 → retry succeeds, 403 → retry succeeds, a second 401/403 →
propagates after exactly two requests, 400/404/429/500/502/503 → no retry at
all, an anonymous 401 → no retry, a 401 *after* a redirect → no retry and no
token in any URL, the 401 fallback registers with the scrubber, and a 200-body
499 still takes the other branch. GDAL is untouched: the ESRIJSON source URL
still carries `token=`.

`.planning/2026-09-01-service-auth-PLAN.md` D5 carries the outcome line.

## API, schema and config impact

None. No migration, no OpenAPI change, no new setting, no SDK regeneration. No
`t()` string changed: the import wizard's `credentialHelpText` already says a
bearer token is sent as an Authorization header, which this makes true of ArcGIS
too, and no locale string claims the token travels in the URL.

## Verification

```
cd backend
uv run ruff check . && uv run ruff format --check .
uv run pytest tests/test_arcgis_header_transport_c2.py tests/test_arcgis_auth.py \
  tests/test_arcgis_signin.py tests/test_arcgis_signin_tenancy.py \
  tests/test_probe_classification.py tests/test_service_auth_transport_1746.py \
  tests/test_service_auth_contract_1746.py tests/test_credential_policy.py \
  tests/test_credential_producer_structural.py tests/test_door_token_policy_1746.py \
  tests/test_1746_stdlib_log_redaction.py tests/test_url_redaction_sec.py \
  tests/test_service_token_redaction_1277.py tests/test_preview_token_sec021.py \
  tests/test_refresh_pagination_1675.py tests/test_service_column_info_1359.py \
  tests/test_dataset_source_state.py tests/test_layering.py \
  tests/test_rule1_structural.py tests/test_rule2_structural.py \
  tests/test_service_refresh_1220.py tests/test_ingest_ogr_pure.py \
  tests/test_import_token_lease_1676.py tests/test_failed_job_token_purge_1746.py \
  tests/test_credential_scrub_middleware.py tests/test_connector_extension.py
```

The last six joined the sweep in audit round 1: they are the suites that cover
`wire_credential`'s doors, the worker's header-file writer, the single-use
credential lease and purge, and the exact-value scrub registry.

`adapters/arcgis.py`, `core/service_tokens.py`, `platform/service_auth.py` and
`sources/probe.py` are all under the 1000-line ratchet threshold and need no
cap. Three ratcheted entries, each with its rationale at the entry in the
commit that moved it: `sources/router.py` 1780 → 1791 (round 1, the
`_probe_credential_line` gate), `processing/ingest/ogr.py` 1354 → 1366 → 1371
(round 1's worker gate, then round 2 moving it up to cover a finished line as
well as a bare token), and `sources/adapters/arcgis.py`, which crossed the
1000-line threshold in codex round 1 and gains its first cap at 1015.

Part of the service-auth plan (lane C2); addresses #1755 item 14.
