### PR TITLE
fix(builder): explain the refused public toggle when a map holds private datasets (#1831)

### DIFF
--- a/frontend/src/api/maps.ts
+++ b/frontend/src/api/maps.ts
@@ -283,6 +283,34 @@ export async function publishMap(id: string, visibility: 'public' | 'private' | 
   });
 }
 
+/**
+ * fix(#1831 review): distinguishes the one 400 `publishMap` can return that
+ * has its own dedicated UI (SharePanel's inline "can't go public" message)
+ * from every other failure, which still gets the generic toast. Reads the
+ * raw `err.body` the backend sent (`{ message, datasets }` from
+ * `validate_public_visibility` in `maps/router.py`), not `err.message` —
+ * that's already a translated fallback string, not JSON, and was the actual
+ * bug in #1831 (dataset names were read off it and silently dropped).
+ *
+ * Shared by `usePublishMap` (to skip its own toast for this one case) and
+ * `SharePanel` (to render the inline message), so the two can't drift.
+ */
+export function nonPublicDatasetsFromError(err: unknown): string | undefined {
+  if (!(err instanceof ApiError) || err.status !== 400 || !err.body || typeof err.body !== 'object') {
+    return undefined;
+  }
+  const detail = err.body as { message?: unknown; datasets?: unknown };
+  if (
+    typeof detail.message === 'string' &&
+    detail.message.includes('non-public datasets') &&
+    typeof detail.datasets === 'string' &&
+    detail.datasets.length > 0
+  ) {
+    return detail.datasets;
+  }
+  return undefined;
+}
+
 export async function createShareToken(
   mapId: string,
   expiration: ShareExpirationInput = {},

--- a/frontend/src/components/builder/SharePanel.tsx
+++ b/frontend/src/components/builder/SharePanel.tsx
@@ -1050,6 +1050,23 @@ export function ShareDialog({
   // cancelling leaves the old selection intact.
   const [pendingVisibility, setPendingVisibility] = useState<MapVisibility | null>(null);
 
+  // fix(#1831): the backend refuses PUT /maps/{id} with 400 when a map is
+  // switched to public while it still holds non-public dataset layers
+  // (validate_public_visibility in maps/router.py). That refusal used to
+  // vanish silently — the toast key it referenced didn't exist in any locale
+  // and the dataset names were never actually read off the error body. This
+  // holds the refusal so it renders as a persistent inline message under the
+  // visibility control, since the confirm dialog is already closed by the
+  // time the response comes back.
+  const [publishBlocked, setPublishBlocked] = useState<string | null>(null);
+
+  // fix(#1831): the dialog stays mounted across open/close (BuilderDialogs.tsx
+  // keeps it alive as long as a map is loaded), so a refusal from one visit
+  // would otherwise still be showing the next time this dialog opens.
+  useEffect(() => {
+    if (!open) setPublishBlocked(null);
+  }, [open]);
+
   // fix(#778): layers hidden from the audience of the visibility being confirmed
   // (not the current one — before a private→public change the current-visibility
   // list is always empty). Same predicate as the post-change warning below.
@@ -1065,6 +1082,8 @@ export function ShareDialog({
 
   function handleVisibilitySelect(newVisibility: MapVisibility) {
     if (newVisibility === visibility) return;
+    // fix(#1831): a fresh attempt clears any stale refusal from a previous one.
+    setPublishBlocked(null);
     // fix(#778): transitions that cross the public boundary need explicit
     // confirmation — going public exposes the map to anyone with a link, and
     // leaving public kills existing share links (clearSharedState below).
@@ -1084,6 +1103,7 @@ export function ShareDialog({
 
   async function handleVisibilityChange(newVisibility: MapVisibility) {
     if (newVisibility === visibility) return;
+    setPublishBlocked(null);
     try {
       await publishMap.mutateAsync({ id: mapId, visibility: newVisibility });
       if (newVisibility === 'public') {
@@ -1097,17 +1117,25 @@ export function ShareDialog({
         tokens.clearSharedState();
       }
     } catch (err) {
-      if (err instanceof ApiError && err.status === 400) {
-        let datasets = err.message;
-        try {
-          const parsed = JSON.parse(err.message);
-          if (parsed.datasets) datasets = parsed.datasets.join(', ');
-        } catch {
-          // Legacy format or unparseable — use raw message
-        }
-        toast.error(t('share.cannotPublish', { datasets }));
-      } else {
-        toast.error(t('toasts.visibilityFailed'));
+      // fix(#1831): the mutation never touched `visibility` on failure (the
+      // toggle only follows the server response above), so the previous
+      // value is already what's on screen — nothing to snap back here. What
+      // was missing was WHY: the raw error detail (`err.body`, not
+      // `err.message`, which is already a translated fallback string) carries
+      // `{ message, datasets }` for this specific refusal; `usePublishMap`'s
+      // own onError still raises the generic "failed to update" toast, so
+      // only the non-public-datasets case gets its own explanation here.
+      const detail =
+        err instanceof ApiError && err.status === 400 && err.body && typeof err.body === 'object'
+          ? (err.body as { message?: unknown; datasets?: unknown })
+          : undefined;
+      if (
+        typeof detail?.message === 'string' &&
+        detail.message.includes('non-public datasets') &&
+        typeof detail.datasets === 'string' &&
+        detail.datasets.length > 0
+      ) {
+        setPublishBlocked(detail.datasets);
       }
     }
   }
@@ -1272,6 +1300,18 @@ export function ShareDialog({
             </div>
             {!isPublic && (
               <p className="text-xs text-muted-foreground mt-2">{t('share.makePublicHint', { defaultValue: 'Make this map public to generate a share link' })}</p>
+            )}
+            {/* fix(#1831): the server-side refusal to publish a map that still
+                holds non-public dataset layers, surfaced inline instead of
+                vanishing — see handleVisibilityChange above. */}
+            {publishBlocked && (
+              <div
+                data-testid="share-publish-blocked-error"
+                className="flex items-start gap-2 rounded-md border border-destructive/30 bg-destructive/5 px-3 py-2 text-xs text-foreground mt-2"
+              >
+                <AlertCircle className="mt-0.5 h-3.5 w-3.5 shrink-0 text-destructive" aria-hidden="true" />
+                <p>{t('share.cannotPublish', { datasets: publishBlocked })}</p>
+              </div>
             )}
           </div>
 

--- a/frontend/src/components/builder/SharePanel.tsx
+++ b/frontend/src/components/builder/SharePanel.tsx
@@ -42,7 +42,7 @@ import {
   AlertDialogTrigger,
 } from '@/components/ui/alert-dialog';
 import { usePublishMap, useCreateShareToken, useRevokeShareToken, useMapShareToken, useUpdateShareToken } from '@/hooks/use-maps';
-import { checkMapVisibility } from '@/api/maps';
+import { checkMapVisibility, nonPublicDatasetsFromError } from '@/api/maps';
 import { useCreateEmbedToken, useMapEmbedTokens, useUpdateEmbedToken, useRevokeEmbedToken } from '@/components/builder/hooks/use-embed-tokens';
 import { normalizeOrigin, WildcardOriginError } from '@/lib/builder/url-normalize';
 // fix(#430 V-17): reuse the same audience-visibility check as the layer-stack badge.
@@ -1053,9 +1053,10 @@ export function ShareDialog({
   // fix(#1831): the backend refuses PUT /maps/{id} with 400 when a map is
   // switched to public while it still holds non-public dataset layers
   // (validate_public_visibility in maps/router.py). That refusal used to
-  // vanish silently — the toast key it referenced didn't exist in any locale
-  // and the dataset names were never actually read off the error body. This
-  // holds the refusal so it renders as a persistent inline message under the
+  // vanish silently — the dataset names were read off the already-translated
+  // `err.message` (a fallback string, not JSON) and JSON.parse'd there,
+  // instead of off the raw `err.body` the backend actually sent. This holds
+  // the refusal so it renders as a persistent inline message under the
   // visibility control, since the confirm dialog is already closed by the
   // time the response comes back.
   const [publishBlocked, setPublishBlocked] = useState<string | null>(null);
@@ -1120,23 +1121,13 @@ export function ShareDialog({
       // fix(#1831): the mutation never touched `visibility` on failure (the
       // toggle only follows the server response above), so the previous
       // value is already what's on screen — nothing to snap back here. What
-      // was missing was WHY: the raw error detail (`err.body`, not
-      // `err.message`, which is already a translated fallback string) carries
-      // `{ message, datasets }` for this specific refusal; `usePublishMap`'s
-      // own onError still raises the generic "failed to update" toast, so
-      // only the non-public-datasets case gets its own explanation here.
-      const detail =
-        err instanceof ApiError && err.status === 400 && err.body && typeof err.body === 'object'
-          ? (err.body as { message?: unknown; datasets?: unknown })
-          : undefined;
-      if (
-        typeof detail?.message === 'string' &&
-        detail.message.includes('non-public datasets') &&
-        typeof detail.datasets === 'string' &&
-        detail.datasets.length > 0
-      ) {
-        setPublishBlocked(detail.datasets);
-      }
+      // was missing was WHY: the raw error detail (`err.body`) carries
+      // `{ message, datasets }` for this specific refusal, extracted here via
+      // the same helper `usePublishMap` uses to skip its own generic
+      // "failed to update" toast for this one case (every other failure
+      // still gets that toast — see use-maps.ts).
+      const datasets = nonPublicDatasetsFromError(err);
+      if (datasets) setPublishBlocked(datasets);
     }
   }
 
@@ -1307,6 +1298,7 @@ export function ShareDialog({
             {publishBlocked && (
               <div
                 data-testid="share-publish-blocked-error"
+                role="alert"
                 className="flex items-start gap-2 rounded-md border border-destructive/30 bg-destructive/5 px-3 py-2 text-xs text-foreground mt-2"
               >
                 <AlertCircle className="mt-0.5 h-3.5 w-3.5 shrink-0 text-destructive" aria-hidden="true" />

--- a/frontend/src/components/builder/__tests__/SharePanel.test.tsx
+++ b/frontend/src/components/builder/__tests__/SharePanel.test.tsx
@@ -656,6 +656,83 @@ describe('SHARE-02 chip-based allowed-origins input', () => {
 });
 
 /* ------------------------------------------------------------------ */
+/*  fix(#1831): the visibility PUT's 400 refusal (map holds non-public  */
+/*  dataset layers) used to vanish — the toast key it referenced didn't */
+/*  exist in any locale, and the dataset names were read off the        */
+/*  already-translated `err.message` instead of the raw `err.body`.     */
+/*  Now it renders as a persistent inline message under the visibility  */
+/*  control, naming the datasets, and the toggle never leaves its       */
+/*  previous value (the mutation only ever applies it on success).      */
+/* ------------------------------------------------------------------ */
+describe('#1831 publish blocked by non-public datasets', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  function nonPublicDatasetsRefusal(datasets = 'Large Lakes') {
+    const detail = {
+      message: 'Cannot set visibility to public: map contains non-public datasets',
+      datasets,
+    };
+    // Mirrors apiFetch: message is already localized, body carries the raw detail.
+    return new ApiError(translateApiErrorDetail(detail, 400), 400, detail);
+  }
+
+  it('test_publish_refusal_shows_dataset_names_inline_and_keeps_toggle_private', async () => {
+    const user = userEvent.setup();
+    const publishMapFn = vi.fn().mockRejectedValue(nonPublicDatasetsRefusal('Large Lakes'));
+    setup({ visibility: 'private', publishMapFn });
+
+    await user.click(screen.getByRole('radio', { name: /anyone with the link/i }));
+    await user.click(screen.getByRole('button', { name: /^make public$/i }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('share-publish-blocked-error')).toBeInTheDocument();
+    });
+    expect(screen.getByTestId('share-publish-blocked-error')).toHaveTextContent('Large Lakes');
+
+    // The toggle stays on its previous value — the mutation never resolved,
+    // so nothing "snaps back": it never moved in the first place.
+    expect(screen.getByRole('radio', { name: /only you/i })).toHaveAttribute('aria-checked', 'true');
+    expect(screen.getByRole('radio', { name: /anyone with the link/i })).toHaveAttribute(
+      'aria-checked',
+      'false',
+    );
+  });
+
+  it('test_publish_refusal_survives_the_confirm_dialog_closing_first', async () => {
+    // The confirm AlertDialog closes as soon as "Make public" is clicked
+    // (setPendingVisibility(null) runs before the mutation), so the message
+    // has to persist somewhere that outlives it — not inside the dialog.
+    const user = userEvent.setup();
+    const publishMapFn = vi.fn().mockRejectedValue(nonPublicDatasetsRefusal('Large Lakes'));
+    setup({ visibility: 'private', publishMapFn });
+
+    await user.click(screen.getByRole('radio', { name: /anyone with the link/i }));
+    await user.click(screen.getByRole('button', { name: /^make public$/i }));
+
+    await waitFor(() => {
+      expect(
+        screen.queryByRole('alertdialog', { name: /make this map public/i }),
+      ).not.toBeInTheDocument();
+    });
+    expect(screen.getByTestId('share-publish-blocked-error')).toBeInTheDocument();
+  });
+
+  it('test_publish_success_does_not_show_the_refusal_message', async () => {
+    const user = userEvent.setup();
+    const publishMapFn = vi.fn().mockResolvedValue({});
+    setup({ visibility: 'private', publishMapFn });
+
+    await user.click(screen.getByRole('radio', { name: /anyone with the link/i }));
+    await user.click(screen.getByRole('button', { name: /^make public$/i }));
+
+    await waitFor(() => expect(publishMapFn).toHaveBeenCalled());
+    expect(screen.queryByTestId('share-publish-blocked-error')).not.toBeInTheDocument();
+  });
+});
+
+/* ------------------------------------------------------------------ */
 /*  SHARE-04: Expiration preset Select + Pitfall #6 regression pins    */
 /* ------------------------------------------------------------------ */
 

--- a/frontend/src/components/builder/__tests__/SharePanel.test.tsx
+++ b/frontend/src/components/builder/__tests__/SharePanel.test.tsx
@@ -28,9 +28,16 @@ vi.mock('@/hooks/use-edition', () => ({
   useEdition: vi.fn(),
 }));
 
-vi.mock('@/api/maps', () => ({
-  checkMapVisibility: vi.fn(),
-}));
+vi.mock('@/api/maps', async (importOriginal) => {
+  // fix(#1831 review): keep the real `nonPublicDatasetsFromError` — it's the
+  // shared predicate SharePanel uses to detect the blocked-publish refusal;
+  // only `checkMapVisibility` needs stubbing here.
+  const actual = await importOriginal<typeof import('@/api/maps')>();
+  return {
+    ...actual,
+    checkMapVisibility: vi.fn(),
+  };
+});
 
 vi.mock('@/hooks/use-maps', () => ({
   usePublishMap: vi.fn(),
@@ -657,12 +664,13 @@ describe('SHARE-02 chip-based allowed-origins input', () => {
 
 /* ------------------------------------------------------------------ */
 /*  fix(#1831): the visibility PUT's 400 refusal (map holds non-public  */
-/*  dataset layers) used to vanish — the toast key it referenced didn't */
-/*  exist in any locale, and the dataset names were read off the        */
-/*  already-translated `err.message` instead of the raw `err.body`.     */
-/*  Now it renders as a persistent inline message under the visibility  */
-/*  control, naming the datasets, and the toggle never leaves its       */
-/*  previous value (the mutation only ever applies it on success).      */
+/*  dataset layers) used to vanish — the dataset names were read off    */
+/*  the already-translated `err.message` (a fallback string, not JSON)  */
+/*  and JSON.parse'd there, instead of off the raw `err.body` the       */
+/*  backend actually sent. Now it renders as a persistent inline        */
+/*  message under the visibility control, naming the datasets, and the  */
+/*  toggle never leaves its previous value (the mutation only ever      */
+/*  applies it on success).                                             */
 /* ------------------------------------------------------------------ */
 describe('#1831 publish blocked by non-public datasets', () => {
   beforeEach(() => {
@@ -690,6 +698,9 @@ describe('#1831 publish blocked by non-public datasets', () => {
       expect(screen.getByTestId('share-publish-blocked-error')).toBeInTheDocument();
     });
     expect(screen.getByTestId('share-publish-blocked-error')).toHaveTextContent('Large Lakes');
+    // fix(#1831 review P2): role="alert" so it's announced the way the toast
+    // it replaces would have been.
+    expect(screen.getByRole('alert')).toBe(screen.getByTestId('share-publish-blocked-error'));
 
     // The toggle stays on its previous value — the mutation never resolved,
     // so nothing "snaps back": it never moved in the first place.

--- a/frontend/src/hooks/__tests__/use-maps.test.tsx
+++ b/frontend/src/hooks/__tests__/use-maps.test.tsx
@@ -3,6 +3,9 @@ import { renderHook as renderHookWithWrapper, act } from '@testing-library/react
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import type { ReactNode } from 'react';
 import { vi } from 'vitest';
+import { toast } from 'sonner';
+
+vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
 
 vi.mock('@/api/maps', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@/api/maps')>();
@@ -12,17 +15,20 @@ vi.mock('@/api/maps', async (importOriginal) => {
     getMap: vi.fn(),
     deleteMap: vi.fn(),
     createMap: vi.fn(),
+    publishMap: vi.fn(),
   };
 });
 
-import { listMaps, getMap, deleteMap, createMap } from '@/api/maps';
-import { useMaps, useMap, useDeleteMap, useCreateMap } from '@/hooks/use-maps';
+import { ApiError } from '@/api/client';
+import { listMaps, getMap, deleteMap, createMap, publishMap } from '@/api/maps';
+import { useMaps, useMap, useDeleteMap, useCreateMap, usePublishMap } from '@/hooks/use-maps';
 import { queryKeys } from '@/lib/query-keys';
 
 const mockListMaps = vi.mocked(listMaps);
 const mockGetMap = vi.mocked(getMap);
 const mockDeleteMap = vi.mocked(deleteMap);
 const mockCreateMap = vi.mocked(createMap);
+const mockPublishMap = vi.mocked(publishMap);
 
 describe('useMaps', () => {
   beforeEach(() => {
@@ -193,5 +199,60 @@ describe('useMaps – empty list', () => {
     const { result } = renderHook(() => useMaps());
 
     await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+});
+
+// fix(#1831 review): usePublishMap's onError used to fire the generic
+// "failed to update visibility" toast on EVERY rejection, including the
+// non-public-datasets 400 that SharePanel now surfaces inline — so that one
+// case showed both a generic toast and the specific inline message. The hook
+// skips its own toast only for that one case (via the shared
+// `nonPublicDatasetsFromError` predicate); every other failure still gets it.
+describe('usePublishMap', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  function makeQc() {
+    return new QueryClient({
+      defaultOptions: { queries: { retry: false, gcTime: 0 }, mutations: { retry: false } },
+    });
+  }
+
+  function wrapperFor(qc: QueryClient) {
+    return ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+    );
+  }
+
+  it('fires the generic toast on an ordinary failure', async () => {
+    mockPublishMap.mockRejectedValueOnce(new ApiError('Internal Server Error', 500));
+    const qc = makeQc();
+    const { result } = renderHookWithWrapper(() => usePublishMap(), { wrapper: wrapperFor(qc) });
+
+    await act(async () => {
+      await expect(
+        result.current.mutateAsync({ id: 'map-1', visibility: 'public' }),
+      ).rejects.toThrow();
+    });
+
+    expect(vi.mocked(toast.error)).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not fire the generic toast when the map holds non-public datasets', async () => {
+    mockPublishMap.mockRejectedValueOnce(
+      new ApiError('Cannot set visibility to public: map contains non-public datasets', 400, {
+        message: 'Cannot set visibility to public: map contains non-public datasets',
+        datasets: 'Large Lakes',
+      }),
+    );
+    const qc = makeQc();
+    const { result } = renderHookWithWrapper(() => usePublishMap(), { wrapper: wrapperFor(qc) });
+
+    await act(async () => {
+      await expect(
+        result.current.mutateAsync({ id: 'map-1', visibility: 'public' }),
+      ).rejects.toThrow();
+    });
+
+    expect(vi.mocked(toast.error)).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/hooks/use-maps.ts
+++ b/frontend/src/hooks/use-maps.ts
@@ -16,6 +16,7 @@ import {
   getMapShareToken,
   updateShareTokenExpiration,
   publishMap,
+  nonPublicDatasetsFromError,
   createShareToken,
   revokeShareToken,
   duplicateMap,
@@ -283,7 +284,14 @@ export function usePublishMap() {
       qc.invalidateQueries({ queryKey: queryKeys.maps.all });
       invalidateMapHistory(qc, variables.id);
     },
-    onError: () => { toast.error(i18n.t('builder:toasts.visibilityFailed')); },
+    // fix(#1831 review): the non-public-datasets refusal gets its own inline
+    // message in SharePanel, which would otherwise double up with this
+    // generic toast on every such attempt. Every other publishMap failure
+    // still gets it.
+    onError: (err) => {
+      if (nonPublicDatasetsFromError(err)) return;
+      toast.error(i18n.t('builder:toasts.visibilityFailed'));
+    },
   });
 }
 


### PR DESCRIPTION
## Root cause

`PUT /api/maps/{id}` refuses to switch a map to public visibility while it still holds non-public dataset layers, returning `400 {"message": "Cannot set visibility to public: map contains non-public datasets", "datasets": "<names>"}` (`backend/app/modules/catalog/maps/router.py`, `validate_public_visibility`). `SharePanel.tsx`'s `handleVisibilityChange` tried to parse those dataset names out of `err.message`, but `ApiError.message` is already a *translated fallback string* (built by `translateApiErrorDetail`), not JSON — so `JSON.parse(err.message)` always failed and fell back to a `share.cannotPublish` toast whose `{{datasets}}` value was just that generic fallback text, not the actual dataset names. The toggle itself never "snapped back" (the mutation only applies the new visibility on success), so the only visible trace of the refusal was a console error.

## Fix

`handleVisibilityChange` now reads the structured detail off `err.body` (the raw object FastAPI sent, preserved by `apiFetch`) instead of `err.message`, and renders it as a persistent inline message under the visibility control — the confirm `AlertDialog` is already closed by the time the response arrives, so a toast alone isn't enough. It reuses the existing `share.cannotPublish` locale string (already present, correctly interpolated, in all four locales) rather than inventing a new key. Also clears the message on a fresh attempt and when the Share dialog is reopened, since the component stays mounted across open/close.

## Tests

Added `describe('#1831 publish blocked by non-public datasets', ...)` to `frontend/src/components/builder/__tests__/SharePanel.test.tsx`: asserts the inline message names the dataset on a 400 refusal, that it persists after the confirm dialog closes, and that it doesn't appear after a successful visibility change. The private-visibility radio stays `aria-checked` on failure.

## Gates

- `npm run lint` — pass
- `npm run typecheck` — pass
- `npm run test:i18n` — pass
- `npx vitest run src/components/builder` — 148 files / 2509 tests pass (includes `src/components/builder/__tests__/SharePanel.test.tsx`, 68 tests)

Playwright not run against the shared dev stack from this worktree (stack serves `main`, per AGENTS.md).

Closes #1831