### PR TITLE
chore(release): v1.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and releases use semantic versioning.
 
 ## [Unreleased]
 
+## [1.18.0] - 2026-09-04
+
 ### Added
 
 - **WFS and OGC API Features service imports now accept a username and
@@ -387,6 +389,84 @@ and releases use semantic versioning.
   other's base URL, bearer token, or API key on the object the first caller is
   still holding (#1802).
 
+- **A WFS or OGC API Features header token outside the accepted character set
+  is now refused before any credential is spent.** Import commit and reupload
+  commit used to accept such a token, stash it as a single-use credential, and
+  only have the worker refuse it once the request reached ogr2ogr, burning
+  the credential for nothing; service preview used a weaker check and
+  accepted a token commit would later reject. All three doors now return the
+  same 422 the refresh door already gave, before anything is staged or spent
+  (#1752).
+
+- **The ArcGIS import preview now shows the layer's feature count**, the same
+  number probe already reported but preview previously left blank. Separately,
+  the GDAL bearer-token header file used during import is written to the
+  staging directory instead of the system temp directory, and a periodic
+  sweep now removes one left behind by a crashed worker after an hour (#1751).
+
+- **Several small service-import fixes from an internal audit.** The service
+  token field in the import wizard, the reupload dialog, and the refresh
+  dialog no longer invites a password manager to offer to save it or fill in
+  the signed-in admin's own password. An ArcGIS sign-in failure now shows the
+  same clear message a WFS auth failure already did, instead of falling back
+  to a generic "Access denied." The token help text no longer points at the
+  ArcGIS `generateToken` HTML form, which no longer renders; it explains the
+  API-key and `client=referer` alternatives instead. And a layer picker no
+  longer collapses two same-named layers from one service into a single row
+  (#1750).
+
+- **The optional `cloud-dev` profile's Valkey cache now actually starts.** It
+  tried to drop from root to its own user with a capability its own
+  `cap_drop: [ALL]` had already removed, so it exited immediately on every
+  install that enabled the profile, silently leaving `REDIS_URL` unset.
+  Valkey now runs as its own user from the start, skipping the privilege drop
+  it could never complete (#1747).
+
+- **PostgreSQL's own log directory no longer grows without bound inside the
+  data volume.** Log rotation was enabled with no filename pattern, rotation
+  age, or truncate-on-rotation setting, so the collector rotated files but
+  never reclaimed them. Logs now rotate daily, truncate on rotation, and are
+  capped at 7 files regardless of volume; RUNBOOK.md's server-logs section
+  describes the new bound (#1783).
+
+- **A failed vector file import, service import, or VRT build now notifies
+  the operator the same way a failed raster import or re-upload already
+  did**, if `notify_on_ingest_failed` is on. The four ingest tasks had grown
+  separate copies of the failure-write logic, and only the raster and
+  re-upload copies ever sent the notification (#1784).
+
+- **Two storage and database leaks from a hard worker crash are now cleaned
+  up instead of surviving forever.** A raster or VRT ingest that wrote its
+  COG, quicklooks, or VRT to object storage and was then killed before its
+  terminal commit left those objects unreferenced by any row and unreachable
+  by any existing sweep; the job row now records the keys it is about to
+  write, and the periodic and startup recovery sweeps reap them once the job
+  is confirmed not to have landed. A hard kill after an analysis
+  `materialize` commit left the same gap for the output table it had just
+  created; both sweeps now drop an output table nothing ever adopted (#1803).
+
+- **Worker process metrics and a completed-job counter that had read zero
+  since the initial release are fixed.** The worker never started the RSS
+  and connection-pool metric collectors the API process already runs, even
+  though it hosts GDAL/ogr2ogr and carries a much larger memory limit.
+  Separately, `geolens_jobs_completed_total` was derived from counting rows
+  in a status the worker's own retention setting deletes before they can be
+  counted, so the metric, the matching RUNBOOK entry, and the "Job
+  throughput" Grafana panel never moved. It is now incremented at the job's
+  terminal transition instead. A finished queue job that failed, was
+  cancelled, or was aborted was also never purged from the job-queue table;
+  it now follows the same `INGEST_JOBS_RETENTION_DAYS` window the ingest-jobs
+  mirror already uses (#1804).
+
+- **Three admin-configurable settings that had no admin UI control now have
+  one.** `semantic_search_rate_limit` and `basemap_proxy_rate_limit` had no
+  environment-variable fallback at all, and `email_verification_required`'s
+  own docstring claimed the admin UI was the only way to set it; all three
+  are now exposed on their respective settings tabs. Separately, the SAML
+  provider admin page was gated on a coarser permission check than the API
+  behind it enforces, the same drift already corrected for the Settings tabs
+  by an earlier fix; it now uses the same mode-aware check (#1805).
+
 ### Security
 
 - **ArcGIS sign-in attempts are now counted before the credential is sent,
@@ -396,6 +476,13 @@ and releases use semantic versioning.
   against an account. This release adds migration `0058`, which adds a
   `user_scope` column to the sign-in attempt ledger; it runs automatically
   as part of the normal upgrade (#1820).
+
+- **A service token could remain readable on a failed import or re-upload job
+  row until the next cleanup sweep.** A worker that failed a job dispatched
+  with a WFS, OGC API Features, or ArcGIS credential left the token in the
+  job's stored arguments, since only a successful job's row was deleted. Both
+  tasks now strip their own token on any terminal failure, and the periodic
+  stale-job sweep strips it from any row a crashed worker left behind (#1753).
 
 - **Two more sensitive query parameters are now redacted from logs and
   stored source URLs.** `authkey` (ArcGIS) and `maxar_api_key` (Maxar) join
@@ -3430,7 +3517,8 @@ regression-covered fixes:
 - Initial public release of the GeoLens catalog, API, map builder, CLI, SDKs,
   Docker development stack, and public documentation entrypoints.
 
-[Unreleased]: https://github.com/geolens-io/geolens/compare/v1.17.0...HEAD
+[Unreleased]: https://github.com/geolens-io/geolens/compare/v1.18.0...HEAD
+[1.18.0]: https://github.com/geolens-io/geolens/compare/v1.17.0...v1.18.0
 [1.17.0]: https://github.com/geolens-io/geolens/compare/v1.16.1...v1.17.0
 [1.16.1]: https://github.com/geolens-io/geolens/compare/v1.16.0...v1.16.1
 [1.16.0]: https://github.com/geolens-io/geolens/compare/v1.15.1...v1.16.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -399,10 +399,15 @@ and releases use semantic versioning.
   (#1752).
 
 - **The ArcGIS import preview now shows the layer's feature count**, the same
-  number probe already reported but preview previously left blank. Separately,
-  the GDAL bearer-token header file used during import is written to the
-  staging directory instead of the system temp directory, and a periodic
-  sweep now removes one left behind by a crashed worker after an hour (#1751).
+  number probe already reported but preview previously left blank.
+  Separately, the GDAL bearer-token header file used during import now
+  lives on a container-private tmpfs instead of an untracked spot in the
+  system temp directory, so it disappears the moment the container
+  restarts and is never archived by the job that backs up the staging
+  volume. The worker clears any file a crashed run left behind at its own
+  next boot; it runs no periodic sweep of its own, and the API's periodic
+  sweep looks at its own container's tmpfs, not the worker's, so it cannot
+  reach one (#1751).
 
 - **Several small service-import fixes from an internal audit.** The service
   token field in the import wizard, the reupload dialog, and the refresh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -467,7 +467,30 @@ and releases use semantic versioning.
   behind it enforces, the same drift already corrected for the Settings tabs
   by an earlier fix; it now uses the same mode-aware check (#1805).
 
+- **The map builder's Share panel now explains a refused public toggle.**
+  Turning a map public while it still holds non-public dataset layers was
+  refused by the API with a 400, but the panel could not parse the response
+  and swallowed it, so the toggle appeared to do nothing. The refusal now
+  renders as an inline message under the visibility control, names the
+  datasets that block it, and is announced to screen readers; the duplicate
+  generic error toast no longer also fires for the same failure (#1841).
+
 ### Security
+
+- **The ArcGIS token GeoLens sends on its own probe, preview, count, and
+  pagination requests now travels as an `Authorization: Bearer` header
+  instead of a `?token=` query parameter,** so it no longer appears in a
+  request URL or in the HTTP client's own request-log line, which redaction
+  runs too late to see. An ArcGIS Server older than 10.5.1, read from the
+  service's own `currentVersion`, keeps the query form, since it does not
+  read a bearer header. The GDAL fetch that pulls the feature data itself is
+  unchanged and still uses the query form: the worker's header file only
+  accepts a base64url-shaped token, which an ArcGIS token is not guaranteed to
+  be, and that path was already redacted from job arguments and error text.
+  Also: an SSRF refusal encountered while probing an ArcGIS service now
+  reaches the caller instead of degrading to a generic "unhealthy" answer,
+  and the query-form fallback now registers its token with the log scrubber
+  the same way the header form already did (#1840).
 
 - **ArcGIS sign-in attempts are now counted before the credential is sent,
   not after.** A sign-in request cancelled mid-flight could previously go

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -478,15 +478,23 @@ and releases use semantic versioning.
 ### Security
 
 - **The ArcGIS token GeoLens sends on its own probe, preview, count, and
-  pagination requests now travels as an `Authorization: Bearer` header
-  instead of a `?token=` query parameter,** so it no longer appears in a
-  request URL or in the HTTP client's own request-log line, which redaction
-  runs too late to see. An ArcGIS Server older than 10.5.1, read from the
-  service's own `currentVersion`, keeps the query form, since it does not
-  read a bearer header. The GDAL fetch that pulls the feature data itself is
+  pagination requests now travels as an `X-Esri-Authorization: Bearer`
+  header instead of a `?token=` query parameter,** so it no longer appears
+  in a request URL or in the HTTP client's own request-log line, which
+  redaction runs too late to see. Esri's own header name is used rather than
+  the standard `Authorization`, because a portal behind a Web Adaptor with its
+  own web-tier authentication (IWA or PKI) consumes the standard header before
+  ArcGIS ever sees the request; if a portal still answers such a request with
+  an HTTP 401 or 403, GeoLens retries once with the query form on the same
+  origin.
+  An ArcGIS Server older than 10.5.1, read from the service's own
+  `currentVersion`, keeps the query form outright, since it does not read a
+  bearer header at all. The GDAL fetch that pulls the feature data itself is
   unchanged and still uses the query form: the worker's header file only
-  accepts a base64url-shaped token, which an ArcGIS token is not guaranteed to
-  be, and that path was already redacted from job arguments and error text.
+  accepts a base64url-shaped token, which an ArcGIS token is not guaranteed
+  to be, and that path was already redacted from job arguments and error
+  text. A single function now builds the count-query URL everywhere it is
+  needed, rather than three copies each composing it slightly differently.
   Also: an SSRF refusal encountered while probing an ArcGIS service now
   reaches the caller instead of degrading to a generic "unhealthy" answer,
   and the query-form fallback now registers its token with the log scrubber

--- a/backend/app/api/main.py
+++ b/backend/app/api/main.py
@@ -824,7 +824,7 @@ _is_production = settings.is_production
 # no metadata to read. We fall back to the current published line so import never
 # crashes. Keep this fallback in lockstep with backend/pyproject.toml — it is one
 # of the sites `make bump` rewrites.
-_FALLBACK_APP_VERSION = "1.17.0"
+_FALLBACK_APP_VERSION = "1.18.0"
 
 
 def _resolve_app_version() -> str:

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -18984,7 +18984,7 @@
     "summary": "PostGIS-native geospatial data catalog with OGC API Features and Records support",
     "termsOfService": "https://github.com/geolens-io/geolens/blob/main/LICENSE",
     "title": "GeoLens API",
-    "version": "1.17.0"
+    "version": "1.18.0"
   },
   "openapi": "3.1.0",
   "paths": {

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geolens-backend"
-version = "1.17.0"
+version = "1.18.0"
 description = "PostGIS-native GIS data catalog"
 # Docker image (Dockerfile) ships python:3.14-slim (see the Dockerfile FROM for
 # the exact patch pin) as the project's tested runtime.

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -838,7 +838,7 @@ wheels = [
 
 [[package]]
 name = "geolens-backend"
-version = "1.17.0"
+version = "1.18.0"
 source = { virtual = "." }
 dependencies = [
     { name = "alembic" },

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "geolens-cli"
-version = "1.17.0"
+version = "1.18.0"
 description = "Apache-2.0 command-line interface for the GeoLens API. Login, scan, publish, and export STAC against any GeoLens instance."
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/docs-contract.json
+++ b/docs-contract.json
@@ -1,6 +1,6 @@
 {
   "_comment": "Canonical cross-surface facts for the GeoLens README, marketing site (getgeolens.com/src), and docs site (getgeolens.com/docs). Validated against scripts/install.sh + backend/pyproject.toml by scripts/check_docs_contract.py (geolens CI). The getgeolens.com repo vendors a copy and enforces the same `forbidden` list in its own CI. See docs-internal/DOC-CONSISTENCY-STRATEGY for the full design. Edit a fact ONCE here (and in its canonical source) — the gates make every surface follow.",
-  "version": "1.17.0",
+  "version": "1.18.0",
   "install": {
     "oneLiner": "curl -fsSL https://getgeolens.com/install.sh | sh",
     "sourceBuild": "bash scripts/install.sh",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "1.17.0",
+  "version": "1.18.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "1.17.0",
+      "version": "1.18.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.17.0",
+  "version": "1.18.0",
   "type": "module",
   "license": "Apache-2.0",
   "author": "Carto Concepts, LLC",

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "geolens-mcp"
-version = "1.17.0"
+version = "1.18.0"
 description = "Apache-2.0 read-only Model Context Protocol (MCP) server for GeoLens. Lets coding agents discover datasets, inspect schemas, and ask spatial questions against any GeoLens instance."
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/mcp/server.json
+++ b/mcp/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.geolens-io/geolens",
   "title": "GeoLens",
   "description": "Read-only access to a self-hosted GeoLens spatial catalog: datasets, features, maps, sandboxed SQL.",
-  "version": "1.17.0",
+  "version": "1.18.0",
   "websiteUrl": "https://docs.getgeolens.com/",
   "repository": {
     "url": "https://github.com/geolens-io/geolens",
@@ -14,7 +14,7 @@
     {
       "registryType": "pypi",
       "identifier": "geolens-mcp",
-      "version": "1.17.0",
+      "version": "1.18.0",
       "transport": {
         "type": "stdio"
       },

--- a/mcp/uv.lock
+++ b/mcp/uv.lock
@@ -225,7 +225,7 @@ wheels = [
 
 [[package]]
 name = "geolens"
-version = "1.17.0"
+version = "1.18.0"
 source = { editable = "../sdks/python" }
 dependencies = [
     { name = "attrs" },
@@ -244,7 +244,7 @@ requires-dist = [
 
 [[package]]
 name = "geolens-mcp"
-version = "1.17.0"
+version = "1.18.0"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "geolens",
-  "version": "1.17.0",
+  "version": "1.18.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "geolens",
-      "version": "1.17.0",
+      "version": "1.18.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@axe-core/playwright": "^4.13.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geolens",
-  "version": "1.17.0",
+  "version": "1.18.0",
   "private": true,
   "license": "Apache-2.0",
   "author": "Carto Concepts, LLC",

--- a/sdks/python/.openapi-python-client.yaml
+++ b/sdks/python/.openapi-python-client.yaml
@@ -4,7 +4,7 @@ project_name_override: geolens
 package_name_override: geolens
 # Rewritten on every `make sdks` run by scripts/sync_sdk_versions.py to match
 # backend/openapi.json info.version. Do not edit by hand.
-package_version_override: 1.17.0
+package_version_override: 1.18.0
 
 # Cleaner enum output (matches our pydantic v2 backend's enum emission).
 literal_enums: true

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "geolens"
-version = "1.17.0"
+version = "1.18.0"
 description = "Auto-generated Python SDK for the GeoLens API. Typed clients with Bearer + API-key auth helpers."
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/sdks/typescript/package-lock.json
+++ b/sdks/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@geolens/sdk",
-  "version": "1.17.0",
+  "version": "1.18.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@geolens/sdk",
-      "version": "1.17.0",
+      "version": "1.18.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@hey-api/client-fetch": "0.13.1"

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geolens/sdk",
-  "version": "1.17.0",
+  "version": "1.18.0",
   "description": "Auto-generated TypeScript SDK for the GeoLens API. Typed clients with Bearer + API-key auth helpers.",
   "license": "Apache-2.0",
   "author": "Carto Concepts, LLC",


### PR DESCRIPTION
## Summary

Release-prep PR for v1.18.0 (2026-09-04).

### Changelog completeness pass (#1839)

Added entries to `## [Unreleased]` for findings that had landed on main but
had no changelog sentence yet, then cut the section over to `## [1.18.0] -
2026-09-04`. New entries, by PR:

- #1752 — strict header-token policy now enforced at import commit, reupload
  commit and preview, not only refresh
- #1751 — ArcGIS preview shows feature count; GDAL header tempfiles moved to
  staging with a stale-file sweep
- #1750 — service-token input hardening, ArcGIS error mapping, help text, and
  a layer-picker key fix for same-named layers
- #1747 — the `cloud-dev` profile's Valkey cache now actually starts
- #1783 — PostgreSQL's own log directory now rotates and is capped
- #1784 — a failed vector/service import or VRT build now sends the
  ingest-failure notification, matching raster import/re-upload
- #1803 — orphaned raster/VRT storage objects and leaked analysis output
  tables from a hard worker crash are now reaped
- #1804 — worker process metrics and the completed-job counter (both read
  zero since release) are fixed; terminal job-queue rows are now purged
- #1805 — three settings gained admin UI controls; the SAML admin page's
  permission gate now matches the API behind it
- #1753 — a service token no longer stays readable on a failed job row until
  the next sweep (Security)

#1840 and #1841 are still open as of this PR, so nothing was added for them;
#1838 is test-only.

### Version bump

`make bump VERSION=1.18.0` rewrote all 21 version sites (18 files). The
CHANGELOG compare-links step (`[Unreleased]`/`[1.18.0]`) is now written by
`make bump` itself (#1765 landed since 1.17.0), so no manual edit was needed.

## Gate results

- `make version-check` — OK, all 21 sites agree on 1.18.0, CHANGELOG section
  and compare links present
- `python3 scripts/check_public_surface.py` — passed, 71 files scanned
- `grep '"version"' backend/openapi.json` — `1.18.0`
- `git diff --stat` (pre-commit) — 18 files changed, matching the expected
  bump-site list

## Test plan

- [x] `make version-check`
- [x] `python3 scripts/check_public_surface.py`
- [ ] `make sdks-check` / `make openapi-check` (defer to CI; no source change
      requires SDK regeneration here)

