### PR TITLE
fix(logging): deep-redact structured extras so job context never carries a credential

### DIFF
--- a/backend/app/core/logging_config.py
+++ b/backend/app/core/logging_config.py
@@ -71,6 +71,19 @@ Locals are where a secret variable itself would leak regardless of any
 string scrub, so removing rich from dev closes that path too, not only the
 one the string scrub covers. Dev keeps every other `ConsoleRenderer` default
 (colours included) — only the exception formatter changed.
+
+fix(#1844): #1746 fixed the `event` string and left the STRUCTURED half of
+the same record alone, because `_redact_sensitive_fields` only ever looked at
+top-level keys. `structlog.stdlib.ExtraAdder()` lifts a stdlib record's whole
+`extra` mapping in, and third-party code decides what that mapping holds:
+Procrastinate's worker puts `context.job.log_context()` there, which is the
+job's `task_kwargs` verbatim plus a rendered `call_string` copy of the same
+kwargs. On a default install (no credential store configured) the wire
+credential IS a task kwarg, so every authenticated service import and reupload
+wrote it to the operator log twice per line, on three INFO lines, before the
+task body ran. `_redact_sensitive_fields` now walks container values through
+`redact_nested()`, which redacts denylisted keys at depth and applies the same
+`_scrub_text` to nested strings.
 """
 
 import logging
@@ -106,12 +119,29 @@ _SENSITIVE_FIELDS: frozenset[str] = frozenset(
         "authorization",
         "secret",
         "client_secret",
+        # fix(#1844): a credential-store reference is a single-use bearer
+        # capability with a TTL that the sweepers actively RENEW while the job
+        # sits `todo`, so whoever reads it out of a log line before the worker
+        # claims it can redeem it instead. It is a secret, not a correlation
+        # id, and it travels beside the token in exactly the same places.
+        "credential_ref",
     }
 )
 
 # Depth ceiling for redact_nested(). Audit payloads are two or three levels at
 # most; this only exists so a caller-supplied cyclic structure terminates.
 _MAX_REDACT_DEPTH = 8
+
+# fix(#1844): keys `_redact_sensitive_fields` must never hand to
+# `redact_nested()`. The deep walk returns a LIST for every sequence it
+# rebuilds, and `exc_info` is a `(type, value, traceback)` TUPLE that a
+# renderer downstream unpacks positionally. `format_exc_info` pops it before
+# this processor runs today, so this is a guard against a chain reordering
+# rather than a live case -- and it costs one set lookup per field. The rest
+# of `ProcessorFormatter`'s meta keys (`_record`, `_from_structlog`) need no
+# entry: a LogRecord is not a Mapping or a sequence, so the walk skips them on
+# the isinstance check anyway.
+_NEVER_WALKED_FIELDS: frozenset[str] = frozenset({"exc_info", "positional_args"})
 
 # fix(#1778): share-link and embed paths carry a bearer capability as a PATH
 # segment, so no keyed-field redactor can reach it -- `_redact_sensitive_fields`
@@ -133,13 +163,26 @@ def safe_access_log_path(path: str) -> str:
     return _CAPABILITY_PATH_RE.sub(r"\g<prefix>[REDACTED]", path, count=1)
 
 
+# fix(#1844): the names whose RENDERED value this scrub redacts. `token` has
+# been here since #1746; `credential_ref` joins it because a store reference is
+# a redeemable capability and not a correlation id (see `_SENSITIVE_FIELDS`).
+# Both are matched under a word boundary, so `token_hint=` and a hypothetical
+# `credential_reference=` still do not match: a boundary never falls between
+# two word characters, so a name that merely CONTAINS one of these as a
+# sub-word is left alone.
+#
+# Only a QUOTED value is redacted, which is what keeps the operator signal the
+# #1746 note below wanted: `Job.call_string` renders `None` unquoted, so
+# `credential_ref=None` stays legible and `credential_ref='...'` becomes
+# `credential_ref='[REDACTED]'`. "Was a credential attached to this job" is
+# still answerable from the log; "which one" is not.
+_REDACTED_REPR_NAMES: tuple[str, ...] = ("token", "credential_ref")
+_REPR_NAME_ALTERNATION = "|".join(_REDACTED_REPR_NAMES)
+
 # fix(#1746): catches a token value rendered either as a Python dict repr
 # (`{'token': 'abc', ...}`) or as `key=value!r` keyword arguments — the shape
 # `Job.call_string` actually produces, e.g.
-# `ingest_service[1270](token='abc', credential_ref=None)`. `\btoken\b`
-# excludes `credential_ref=` and `token_hint=`: a word boundary never falls
-# between "n" and "_", so a name that merely CONTAINS "token" as a sub-word
-# never matches either branch.
+# `ingest_service[1270](token='abc', credential_ref=None)`.
 #
 # fix(#1746 codex r3): the value body is `(?:\\.|[^\\])*?`, not a bare `.*?`.
 # `repr()` of a string containing BOTH quote styles picks one as the
@@ -160,11 +203,13 @@ def safe_access_log_path(path: str) -> str:
 # leaves exactly one way to consume each character, so an unterminated match
 # fails in time linear in the input length instead.
 _TOKEN_VALUE_RE = re.compile(
-    r"""
+    rf"""
     (?:
-        (?P<dq>['\"])token(?P=dq)\s*:\s*(?P<dv>['\"])(?:\\.|[^\\])*?(?P=dv)
+        (?P<dq>['\"])(?P<dname>{_REPR_NAME_ALTERNATION})(?P=dq)
+        \s*:\s*(?P<dv>['\"])(?:\\.|[^\\])*?(?P=dv)
       |
-        \btoken\b\s*=\s*(?P<kv>['\"])(?:\\.|[^\\])*?(?P=kv)
+        \b(?P<kname>{_REPR_NAME_ALTERNATION})\b
+        \s*=\s*(?P<kv>['\"])(?:\\.|[^\\])*?(?P=kv)
     )
     """,
     re.VERBOSE,
@@ -177,9 +222,10 @@ def _redact_token_value_repr(value: str) -> str:
     def _sub(match: re.Match[str]) -> str:
         if match.group("dq") is not None:
             quote, value_quote = match.group("dq"), match.group("dv")
-            return f"{quote}token{quote}: {value_quote}[REDACTED]{value_quote}"
+            name = match.group("dname")
+            return f"{quote}{name}{quote}: {value_quote}[REDACTED]{value_quote}"
         value_quote = match.group("kv")
-        return f"token={value_quote}[REDACTED]{value_quote}"
+        return f"{match.group('kname')}={value_quote}[REDACTED]{value_quote}"
 
     return _TOKEN_VALUE_RE.sub(_sub, value)
 
@@ -278,14 +324,31 @@ def _scrub_text(value: str) -> str:
 def _redact_sensitive_fields(
     _logger: Any, _method_name: str, event_dict: MutableMapping[str, Any]
 ) -> MutableMapping[str, Any]:
-    """Redact top-level event_dict values whose key is in the denylist.
+    """Redact event_dict values whose key is in the denylist.
 
     Case-insensitive on key. Replaces the value with the literal string
     "[REDACTED]" regardless of original type (str / int / dict / etc.).
-    Shallow only — does not recursively walk nested dicts. This is a
-    deliberate trade-off: structlog idiomatic usage logs flat key/value
-    pairs; recursing would amplify the redactor's CPU cost on every log
-    line.
+
+    fix(#1844): a value that is itself a CONTAINER goes through
+    `redact_nested()` instead of being emitted verbatim. Shallowness used to be
+    the documented trade-off here -- structlog's idiomatic usage is flat
+    key/value pairs, and recursing costs CPU on every line -- but
+    `structlog.stdlib.ExtraAdder()` (see `setup_logging`) lifts a stdlib
+    record's whole `extra` mapping into this event dict, and a third-party
+    library decides what goes in there. Procrastinate's worker sets
+    `extra["job"] = context.job.log_context()` on `Loaded job info`,
+    `Starting job` and every outcome line, and `log_context()` is `asdict()`
+    plus `call_string`, so it carries the job's `task_kwargs` verbatim AND a
+    second rendered copy. On the service-import and reupload paths those
+    kwargs are the wire credential itself whenever no credential store is
+    configured, which is the default install. The `event` half of those three
+    lines has been scrubbed since #1746; the `job` half was not, twice per
+    line. It leaks before the task body runs, so nothing the task itself does
+    can help.
+
+    The walk is gated on the value actually being a container, so a flat
+    record -- every request-path line -- still costs one `isinstance` per
+    field and nothing else. `redact_nested()` keeps its own depth ceiling.
 
     fix(#1746): the key-based loop above only ever sees STRUCTURED fields, so
     it cannot catch a secret embedded in the rendered MESSAGE STRING itself —
@@ -306,6 +369,12 @@ def _redact_sensitive_fields(
     for key in list(event_dict.keys()):
         if key.lower() in _SENSITIVE_FIELDS:
             event_dict[key] = "[REDACTED]"
+            continue
+        value = event_dict[key]
+        if key in _NEVER_WALKED_FIELDS:
+            continue
+        if isinstance(value, (Mapping, list, tuple, set)):
+            event_dict[key] = redact_nested(value)
     event = event_dict.get("event")
     if isinstance(event, str):
         event_dict["event"] = _scrub_text(event)
@@ -316,25 +385,33 @@ def _redact_sensitive_fields(
 
 
 def redact_nested(value: Any, _depth: int = 0) -> Any:
-    """Deep-redact denylisted keys in a nested payload.
+    """Deep-redact denylisted keys and scrub nested strings in a payload.
 
-    The processor above is shallow on purpose: it runs on every log line and
-    recursing there would put the walk in the hot path. This is the opt-in
-    counterpart for a payload that is known to be nested AND known to be worth
-    the cost, which today means the audit event logged when a sink drops it
-    (fix(#1491)).
+    Two callers, one policy. ``platform/audit.py`` uses it for the audit event
+    logged when a sink drops a row (fix(#1491)): ``persistent_config`` puts
+    ``old_value``/``new_value`` into ``details``, and a ``basemaps`` setting
+    carries an ``api_key`` inside a basemap entry — nested two levels down,
+    where a shallow pass cannot see it, and ``details`` is not itself a
+    denylisted key. ``_redact_sensitive_fields`` uses it for any container that
+    reaches the event dict, which is how a third-party library's stdlib
+    ``extra`` gets covered (see that function for the Procrastinate case).
 
-    That path needs it. ``persistent_config`` puts ``old_value``/``new_value``
-    into ``details``, and a ``basemaps`` setting carries ``api_key`` inside a
-    basemap entry — nested two levels down, where the shallow pass cannot see
-    it. ``details`` is not itself a denylisted key, so without this the whole
-    payload was emitted verbatim, and precisely during an audit failure.
+    fix(#1844): every nested ``str`` also goes through ``_scrub_text``, the
+    same scrub ``event`` and ``exception`` already get. A denylisted KEY is not
+    the only way a credential travels inside a container: Procrastinate renders
+    the job's kwargs a second time into ``call_string``, under a key
+    (``call_string``) that is not sensitive and holds a value that is. Key
+    redaction cannot reach the copy inside a string, and pattern scrubbing
+    cannot reach a value stored under a key it does not recognise, so the two
+    passes are complements rather than alternatives.
 
-    Depth is capped because ``details`` is caller-supplied and need not be
+    Depth is capped because a payload here is caller-supplied and need not be
     JSON-derived; a self-referencing structure would otherwise not terminate.
     """
     if _depth >= _MAX_REDACT_DEPTH:
         return "[TRUNCATED]"
+    if isinstance(value, str):
+        return _scrub_text(value)
     if isinstance(value, Mapping):
         return {
             key: (

--- a/backend/app/core/logging_config.py
+++ b/backend/app/core/logging_config.py
@@ -163,12 +163,28 @@ def safe_access_log_path(path: str) -> str:
     return _CAPABILITY_PATH_RE.sub(r"\g<prefix>[REDACTED]", path, count=1)
 
 
-# fix(#1844): the names whose RENDERED value this scrub redacts. `token` has
-# been here since #1746; `credential_ref` joins it because a store reference is
-# a redeemable capability and not a correlation id (see `_SENSITIVE_FIELDS`).
-# Both are matched under a word boundary, so `token_hint=` and a hypothetical
+# fix(#1844 audit round 1): the names whose RENDERED value this scrub redacts
+# are `_SENSITIVE_FIELDS` itself, not a hand-kept subset of it.
+#
+# The first cut of this listed `token` and `credential_ref`, which is 2 of the
+# 14 names on the denylist -- so the other 12 were redacted as KEYS and then
+# emitted verbatim in the `call_string` rendering sitting beside them in the
+# same record. That is precisely the asymmetry that produced this PR's own
+# finding: a key pass and a text pass that disagree about what counts as a
+# secret leave the difference in the log. Deriving both from one set is what
+# stops the two halves drifting apart again;
+# `test_repr_scrub_covers_every_denylisted_name` pins the equality so adding a
+# name to the denylist can never again cover only half the record.
+#
+# Longest-first so the alternation is deterministic and a name that is a
+# suffix of another cannot shadow it. `re.escape` because the denylist holds
+# names with regex-significant characters (`x-api-key`). IGNORECASE for parity
+# with the key pass, which has always compared `key.lower()`: `Token='...'`
+# renders exactly as readily as `token='...'`.
+#
+# Matching is under a word boundary, so `token_hint=` and a hypothetical
 # `credential_reference=` still do not match: a boundary never falls between
-# two word characters, so a name that merely CONTAINS one of these as a
+# two word characters, so a name that merely CONTAINS a denylisted one as a
 # sub-word is left alone.
 #
 # Only a QUOTED value is redacted, which is what keeps the operator signal the
@@ -176,8 +192,10 @@ def safe_access_log_path(path: str) -> str:
 # `credential_ref=None` stays legible and `credential_ref='...'` becomes
 # `credential_ref='[REDACTED]'`. "Was a credential attached to this job" is
 # still answerable from the log; "which one" is not.
-_REDACTED_REPR_NAMES: tuple[str, ...] = ("token", "credential_ref")
-_REPR_NAME_ALTERNATION = "|".join(_REDACTED_REPR_NAMES)
+_REDACTED_REPR_NAMES: tuple[str, ...] = tuple(
+    sorted(_SENSITIVE_FIELDS, key=lambda name: (-len(name), name))
+)
+_REPR_NAME_ALTERNATION = "|".join(re.escape(name) for name in _REDACTED_REPR_NAMES)
 
 # fix(#1746): catches a token value rendered either as a Python dict repr
 # (`{'token': 'abc', ...}`) or as `key=value!r` keyword arguments — the shape
@@ -212,7 +230,7 @@ _TOKEN_VALUE_RE = re.compile(
         \s*=\s*(?P<kv>['\"])(?:\\.|[^\\])*?(?P=kv)
     )
     """,
-    re.VERBOSE,
+    re.VERBOSE | re.IGNORECASE,
 )
 
 
@@ -374,7 +392,19 @@ def _redact_sensitive_fields(
         if key in _NEVER_WALKED_FIELDS:
             continue
         if isinstance(value, (Mapping, list, tuple, set)):
-            event_dict[key] = redact_nested(value)
+            # fix(#1844 audit round 1): a container in `extra` is third-party
+            # input all the way down, and `redact_nested()` calls `.items()`,
+            # iterates and takes `len()` on objects this module never
+            # constructed. A lazy Mapping whose `.items()` raises would take
+            # the exception out through the processor chain and cost the whole
+            # log line -- during an incident, on a record someone put a
+            # credential in. Falling back to the redacted placeholder loses the
+            # payload and keeps the line, which is the right direction for both
+            # failure modes.
+            try:
+                event_dict[key] = redact_nested(value)
+            except Exception:  # noqa: BLE001 - see comment above
+                event_dict[key] = "[UNREDACTABLE]"
     event = event_dict.get("event")
     if isinstance(event, str):
         event_dict["event"] = _scrub_text(event)

--- a/backend/app/core/url_redaction.py
+++ b/backend/app/core/url_redaction.py
@@ -399,15 +399,6 @@ def redact_exception_text(exc: BaseException) -> str:
     return scrub_registered_credentials(redact_url_credentials(str(exc)))
 
 
-# fix(#1844 codex r1): shortest DERIVED variant `_secret_variants` will expand
-# a registered secret into. Deliberately equal to
-# `core.service_tokens.HEADER_TOKEN_MIN_LENGTH` (8), the floor the bearer
-# grammar already enforces, but spelled here rather than imported: this module
-# is imported by `core.logging_config` and must not reach into the service-token
-# layer to answer a question about its own string handling.
-MIN_DERIVED_VARIANT_LENGTH = 8
-
-
 def _basic_cleartext(blob: str) -> set[str]:
     """The username and password inside a base64 basic credential.
 
@@ -477,38 +468,32 @@ def _secret_variants(secret: str) -> list[str]:
     of the pair matches none of it. So the pair is decoded and both halves join
     the variants, alongside every encoded form.
     """
-    derived: set[str] = set()
+    # fix(#1844 codex r2): there is NO length floor here, on the derived forms
+    # or on the secret itself. Round 1 added one and it was wrong: a floor
+    # decides which VALID credentials stop being scrubbed.
+    # `credential_input_rejection_reason` (`core/service_tokens.py`) accepts any
+    # nonempty printable username, password or header value with no minimum, so
+    # a Basic password of `admin` and a six-character named API key are both
+    # well-formed credentials a user can really configure -- and a floor of 8
+    # silently stopped redacting them from worker logs and from the persisted
+    # exception text. The malformed-short-bearer case the floor was reaching
+    # for is closed at the other end instead, by
+    # `_sanitize_authorization_token` validating before it registers; a VALID
+    # bearer is already at least `HEADER_TOKEN_MIN_LENGTH`, so a bearer-derived
+    # bare token can never be short in the first place.
+    #
+    # Over-scrubbing a short secret stays the deliberate trade-off documented
+    # on `scrub_secret_value` below. Under-scrubbing a valid one is not a trade
+    # this module gets to make.
+    forms = {secret}
     _, separator, tail = secret.partition(HEADER_LINE_SEPARATOR)
     if separator and tail:
-        derived.add(tail)
+        forms.add(tail)
         _, space, rest = tail.partition(" ")
         if space and rest:
-            derived.add(rest)
+            forms.add(rest)
         if tail.startswith(BASIC_SCHEME):
-            derived.update(_basic_cleartext(tail[len(BASIC_SCHEME) :]))
-    # fix(#1844 codex r1): the floor applies to DERIVED forms only, never to
-    # the registered secret itself.
-    #
-    # The two halves are not the same risk. The secret a caller registered is
-    # scrubbed at any length, which is `scrub_secret_value`'s documented
-    # trade-off just below: over-scrubbing a short token is the safe direction,
-    # and refusing to redact a four-character credential to keep a log tidy
-    # would be the wrong call. A DERIVED form is different, because nobody
-    # chose it -- this function invented it by splitting on `": "`, on a space,
-    # or by base64-decoding a blob. A one-character bearer token or a
-    # two-character basic username expands into a substring that occurs in
-    # ordinary English, and every later scrub in the same request or job then
-    # rewrites unrelated text, destroying the log wholesale rather than
-    # redacting one value in it.
-    #
-    # `MIN_DERIVED_VARIANT_LENGTH` matches `HEADER_TOKEN_MIN_LENGTH`, the floor
-    # the bearer validator already enforces, so a well-formed bearer credential
-    # loses nothing. What it drops is the expansion of a line that should never
-    # have reached the registry -- belt to `_sanitize_authorization_token`'s
-    # braces, since that one now validates before it registers.
-    forms = {secret} | {
-        form for form in derived if len(form) >= MIN_DERIVED_VARIANT_LENGTH
-    }
+            forms.update(_basic_cleartext(tail[len(BASIC_SCHEME) :]))
     variants = set()
     for form in forms:
         variants.update({form, quote(form, safe=""), quote_plus(form)})

--- a/backend/app/core/url_redaction.py
+++ b/backend/app/core/url_redaction.py
@@ -399,6 +399,15 @@ def redact_exception_text(exc: BaseException) -> str:
     return scrub_registered_credentials(redact_url_credentials(str(exc)))
 
 
+# fix(#1844 codex r1): shortest DERIVED variant `_secret_variants` will expand
+# a registered secret into. Deliberately equal to
+# `core.service_tokens.HEADER_TOKEN_MIN_LENGTH` (8), the floor the bearer
+# grammar already enforces, but spelled here rather than imported: this module
+# is imported by `core.logging_config` and must not reach into the service-token
+# layer to answer a question about its own string handling.
+MIN_DERIVED_VARIANT_LENGTH = 8
+
+
 def _basic_cleartext(blob: str) -> set[str]:
     """The username and password inside a base64 basic credential.
 
@@ -468,15 +477,38 @@ def _secret_variants(secret: str) -> list[str]:
     of the pair matches none of it. So the pair is decoded and both halves join
     the variants, alongside every encoded form.
     """
-    forms = {secret}
+    derived: set[str] = set()
     _, separator, tail = secret.partition(HEADER_LINE_SEPARATOR)
     if separator and tail:
-        forms.add(tail)
+        derived.add(tail)
         _, space, rest = tail.partition(" ")
         if space and rest:
-            forms.add(rest)
+            derived.add(rest)
         if tail.startswith(BASIC_SCHEME):
-            forms.update(_basic_cleartext(tail[len(BASIC_SCHEME) :]))
+            derived.update(_basic_cleartext(tail[len(BASIC_SCHEME) :]))
+    # fix(#1844 codex r1): the floor applies to DERIVED forms only, never to
+    # the registered secret itself.
+    #
+    # The two halves are not the same risk. The secret a caller registered is
+    # scrubbed at any length, which is `scrub_secret_value`'s documented
+    # trade-off just below: over-scrubbing a short token is the safe direction,
+    # and refusing to redact a four-character credential to keep a log tidy
+    # would be the wrong call. A DERIVED form is different, because nobody
+    # chose it -- this function invented it by splitting on `": "`, on a space,
+    # or by base64-decoding a blob. A one-character bearer token or a
+    # two-character basic username expands into a substring that occurs in
+    # ordinary English, and every later scrub in the same request or job then
+    # rewrites unrelated text, destroying the log wholesale rather than
+    # redacting one value in it.
+    #
+    # `MIN_DERIVED_VARIANT_LENGTH` matches `HEADER_TOKEN_MIN_LENGTH`, the floor
+    # the bearer validator already enforces, so a well-formed bearer credential
+    # loses nothing. What it drops is the expansion of a line that should never
+    # have reached the registry -- belt to `_sanitize_authorization_token`'s
+    # braces, since that one now validates before it registers.
+    forms = {secret} | {
+        form for form in derived if len(form) >= MIN_DERIVED_VARIANT_LENGTH
+    }
     variants = set()
     for form in forms:
         variants.update({form, quote(form, safe=""), quote_plus(form)})

--- a/backend/app/processing/ingest/ogr.py
+++ b/backend/app/processing/ingest/ogr.py
@@ -282,10 +282,21 @@ def _sanitize_authorization_token(
     # covered). Without this, the whole worker service-import path relied on
     # the two explicit `scrub_secret_from_exception` calls and nothing else
     # -- no log line this function's own caller emits was scrubbed by exact
-    # value. Registers the VALUE (`Bearer <token>`/`Basic <blob>`/a named
-    # key's own value), never `name`: the header name is not the secret and
-    # is often a word ("Authorization") worth leaving visible in a log.
-    register_credential_secret(value)
+    # value.
+    #
+    # fix(#1844): registers the LINE, not the value. Round 49 registered
+    # `value` to keep the header NAME out of the registry, on the reasoning
+    # that "Authorization" is a word worth leaving visible in a log. That goal
+    # was right and the mechanism was the wrong half: `_secret_variants`
+    # (`core/url_redaction.py`) derives the bare token, the basic blob and the
+    # decoded `user:pass` cleartext only from a secret that CONTAINS `": "`,
+    # so registering `Bearer <tok>` expanded to nothing and the worker -- the
+    # one process that spends the credential against a hostile origin -- could
+    # not scrub the bare token an origin echoes back, nor the username an
+    # origin names in "authentication failed for user alice". Registering the
+    # line expands to every shape and still never yields the bare word
+    # `Authorization`, because the tail always starts after the `": "`.
+    register_credential_secret(header_line)
     if not value.startswith(BEARER_SCHEME):
         return header_line
 

--- a/backend/app/processing/ingest/ogr.py
+++ b/backend/app/processing/ingest/ogr.py
@@ -296,25 +296,35 @@ def _sanitize_authorization_token(
     # origin names in "authentication failed for user alice". Registering the
     # line expands to every shape and still never yields the bare word
     # `Authorization`, because the tail always starts after the `": "`.
-    register_credential_secret(header_line)
-    if not value.startswith(BEARER_SCHEME):
-        return header_line
+    #
+    # fix(#1844 codex r1): and it registers only AFTER the bearer grammar below
+    # has been checked. The registration used to sit here, above those checks,
+    # so a line this function goes on to REFUSE still seeded the registry --
+    # and `Authorization: Bearer e` seeds the one-character variant `e`, after
+    # which every `_scrub_text` for the rest of the job replaces every "e" in
+    # every log line with the redaction marker. That destroys the diagnostic
+    # exactly when something upstream has let a malformed credential through,
+    # which is when it is most needed. A refused line is not a secret in play,
+    # so nothing is registered for it.
+    if value.startswith(BEARER_SCHEME):
+        token = value[len(BEARER_SCHEME) :]
+        if len(token) < HEADER_TOKEN_MIN_LENGTH:
+            raise ValueError(
+                "SEC-FU-04: Authorization token is empty or implausibly short "
+                f"(minimum {HEADER_TOKEN_MIN_LENGTH} characters required to "
+                "prevent single-char attack payloads)."
+            )
+        bad = [c for c in token if c not in HEADER_TOKEN_CHARSET]
+        if bad:
+            sample = bad[0]
+            raise ValueError(
+                f"SEC-FU-04: Authorization token contains non-base64url "
+                f"character (first offender: {sample!r}); only "
+                "[A-Za-z0-9._\\-=] are permitted to prevent CRLF header "
+                "smuggling via GDAL_HTTP_HEADERS env var."
+            )
 
-    token = value[len(BEARER_SCHEME) :]
-    if len(token) < HEADER_TOKEN_MIN_LENGTH:
-        raise ValueError(
-            "SEC-FU-04: Authorization token is empty or implausibly short "
-            f"(minimum {HEADER_TOKEN_MIN_LENGTH} characters required to "
-            "prevent single-char attack payloads)."
-        )
-    bad = [c for c in token if c not in HEADER_TOKEN_CHARSET]
-    if bad:
-        sample = bad[0]
-        raise ValueError(
-            f"SEC-FU-04: Authorization token contains non-base64url character "
-            f"(first offender: {sample!r}); only [A-Za-z0-9._\\-=] are permitted "
-            "to prevent CRLF header smuggling via GDAL_HTTP_HEADERS env var."
-        )
+    register_credential_secret(header_line)
     return header_line
 
 

--- a/backend/tests/test_1746_stdlib_log_redaction.py
+++ b/backend/tests/test_1746_stdlib_log_redaction.py
@@ -30,11 +30,13 @@ import base64
 import json
 import logging
 import time
+from collections.abc import Mapping
 
 import pytest
 from procrastinate.jobs import Job
 
 from app.core.logging_config import (
+    _REDACTED_REPR_NAMES,
     _SENSITIVE_FIELDS,
     _redact_token_value_repr,
     _scrub_text,
@@ -896,3 +898,110 @@ def test_a_cyclic_extra_terminates():
 
     assert time.monotonic() - started < 5
     assert "[TRUNCATED]" in json.dumps(data["payload"])
+
+
+def test_repr_scrub_covers_every_denylisted_name():
+    """fix(#1844 audit round 1): the key pass and the text pass must agree.
+
+    The first cut of the rendered-value scrub knew `token` and
+    `credential_ref` -- 2 of the 14 denylisted names -- so the other 12 were
+    redacted as keys and then emitted verbatim in the `call_string` rendering
+    beside them. That is the same key-pass/text-pass asymmetry that produced
+    this PR's own finding, one level down. Pinning the two sets equal is what
+    keeps adding a name to the denylist from covering only half a record.
+    """
+    assert set(_REDACTED_REPR_NAMES) == _SENSITIVE_FIELDS
+
+
+@pytest.mark.parametrize("name", sorted(_SENSITIVE_FIELDS))
+def test_every_denylisted_name_is_redacted_in_both_rendered_shapes(name):
+    """Each denylisted name, in the kwarg shape and the dict-repr shape.
+
+    Not a restatement of the set equality above: this exercises the compiled
+    alternation, so a name the set contains but the regex cannot actually
+    match (an unescaped metacharacter, a boundary that never falls where the
+    name starts) fails here rather than passing on the set comparison alone.
+    """
+    kwarg = _scrub_text(f"call({name}='ULTRASECRET')")
+    mapping = _scrub_text(f"{{'{name}': 'ULTRASECRET'}}")
+
+    assert "ULTRASECRET" not in kwarg, kwarg
+    assert "ULTRASECRET" not in mapping, mapping
+
+
+def test_rendered_names_are_matched_case_insensitively():
+    """The key pass has always compared `key.lower()`; the text pass now does too.
+
+    `Token='...'` reaches a log line exactly as readily as `token='...'` --
+    third-party code picks the casing -- and a case-sensitive text pass would
+    reopen the same asymmetry in a narrower form.
+    """
+    assert "ULTRASECRET" not in _scrub_text("call(Token='ULTRASECRET')")
+    assert "ULTRASECRET" not in _scrub_text("call(API_KEY='ULTRASECRET')")
+
+
+def test_a_sub_word_name_is_still_left_alone():
+    """Positive control for the two tests above.
+
+    They are absence claims, and a scrub that simply redacted every quoted
+    value would satisfy both. The word-boundary rule that keeps `token_hint`
+    legible has to survive the switch to the full denylist.
+    """
+    text = "call(token_hint='ab', credential_reference='keepme')"
+
+    assert _scrub_text(text) == text
+
+
+def test_worker_job_context_is_redacted_in_the_console_renderer_too():
+    """The JSON assertions have a console twin, because dev and prod differ.
+
+    `setup_logging()` picks `ConsoleRenderer` when `json_logs` is false, and
+    that renderer reaches the containers by a different path -- `repr()` of
+    the already-walked structure rather than `json.dumps`. A fix verified only
+    against the JSON renderer would be unverified for every self-hoster
+    running the default console output.
+    """
+    job = _authenticated_service_job()
+    extra = _worker_log_extra(job, "start_job")
+
+    lines = _emit_through_real_pipeline(
+        "procrastinate.worker",
+        logging.INFO,
+        f"Starting job {job.call_string}",
+        extra=extra,
+    )
+
+    assert len(lines) == 1
+    for spelling in _JOB_CREDENTIAL_SPELLINGS:
+        assert spelling not in lines[0], spelling
+    assert "[REDACTED]" in lines[0]
+    # Positive control: the container really is rendered into this line, so the
+    # absence assertions above are not passing on a dropped field.
+    assert "dataset_id" in lines[0]
+
+
+def test_a_container_that_raises_costs_the_payload_and_not_the_line():
+    """fix(#1844 audit round 1): `extra` is third-party input all the way down.
+
+    `redact_nested()` calls `.items()` on objects this module never built. A
+    lazy Mapping that raises there would take the exception out through the
+    processor chain and cost the entire record -- during an incident, on a
+    line someone put a credential in. The payload is dropped instead.
+    """
+
+    class _Exploding(Mapping):
+        def __iter__(self):
+            raise RuntimeError("boom")
+
+        def __len__(self):
+            return 1
+
+        def __getitem__(self, key):
+            raise RuntimeError("boom")
+
+    _, data = _emit_json_with_extra(
+        "app.worker", logging.INFO, "hostile", {"payload": _Exploding()}
+    )
+
+    assert data["payload"] == "[UNREDACTABLE]"
+    assert data["event"] == "hostile"

--- a/backend/tests/test_1746_stdlib_log_redaction.py
+++ b/backend/tests/test_1746_stdlib_log_redaction.py
@@ -26,6 +26,7 @@ loggers, and (as of fix #1746 codex r5) ``httpx``/``httpcore`` (see
 the autouse fixture below for why it needs to.
 """
 
+import base64
 import json
 import logging
 import time
@@ -33,11 +34,25 @@ import time
 import pytest
 from procrastinate.jobs import Job
 
-from app.core.logging_config import _redact_token_value_repr, _scrub_text
+from app.core.logging_config import (
+    _SENSITIVE_FIELDS,
+    _redact_token_value_repr,
+    _scrub_text,
+)
 from app.core.url_redaction import URL_LIKE_RE
 from tests._logging_state import configured_logging
 
 _TOKEN = "SECRETTOKEN123"
+# fix(#1844): the throwaway credential the job-context tests below put on the
+# wire. Deliberately unmistakable filler rather than anything that reads like a
+# real credential, while still carrying every SHAPE the scrubber has to
+# recognise: a finished basic header line, the base64 blob inside it, and the
+# two cleartext halves that blob decodes to.
+_BASIC_USER = "AAAAAAAAA"
+_BASIC_SECRET = "BBBBBBBBB"
+_BASIC_BLOB = base64.b64encode(f"{_BASIC_USER}:{_BASIC_SECRET}".encode()).decode()
+_BASIC_LINE = f"Authorization: Basic {_BASIC_BLOB}"
+_CREDENTIAL_REF = "REF00000000000001"
 _ARCGIS_URL = f"https://services6.arcgis.com/x/FeatureServer/0?f=json&token={_TOKEN}"
 # fix(#1746 codex r11): an apostrophe in the URL PATH (not the token) stops
 # URL_LIKE_RE's match before the query ever starts -- see _QUERY_TAIL_RE's
@@ -87,7 +102,13 @@ def _restore_httpx_logger_disabled_flag():
 
 
 def _emit_through_real_pipeline(
-    logger_name: str, level: int, message: str
+    logger_name: str,
+    level: int,
+    message: str,
+    *,
+    extra: dict | None = None,
+    json_logs: bool = False,
+    log_level: str = "INFO",
 ) -> list[str]:
     """Run `setup_logging()` for real and capture what reaches the root logger.
 
@@ -96,17 +117,42 @@ def _emit_through_real_pipeline(
     `foreign_pre_chain` includes `_redact_sensitive_fields`), so redaction is
     exercised exactly as it runs in production rather than by calling the
     processor function directly.
+
+    fix(#1844): `extra` is passed straight through to the stdlib call.
+    Every test written for #1746 emitted a message and nothing else, which is
+    exactly why the P1-2 leak stayed green through that whole review: the
+    processor chain's `structlog.stdlib.ExtraAdder()` lifts a stdlib record's
+    `extra` mapping into the event dict, and no test here ever put anything
+    there. `json_logs` / `log_level` are exposed for the same reason -- the
+    worker's first job line is a DEBUG one, and the structured half of a
+    record is far easier to assert on when the renderer emits JSON.
     """
-    with configured_logging(json_logs=False, log_level="INFO", production=True):
+    with configured_logging(json_logs=json_logs, log_level=log_level, production=True):
         root = logging.getLogger()
         capture = _ListHandler()
         capture.setFormatter(root.handlers[0].formatter)
         root.addHandler(capture)
         try:
-            logging.getLogger(logger_name).log(level, message)
+            logging.getLogger(logger_name).log(level, message, extra=extra)
         finally:
             root.removeHandler(capture)
     return capture.lines
+
+
+def _emit_json_with_extra(
+    logger_name: str, level: int, message: str, extra: dict, log_level: str = "INFO"
+) -> tuple[str, dict]:
+    """`_emit_through_real_pipeline` with JSON output, returning (line, parsed)."""
+    lines = _emit_through_real_pipeline(
+        logger_name,
+        level,
+        message,
+        extra=extra,
+        json_logs=True,
+        log_level=log_level,
+    )
+    assert len(lines) == 1
+    return lines[0], json.loads(lines[0])
 
 
 def test_httpx_info_request_line_never_reaches_the_handler():
@@ -618,3 +664,235 @@ def test_scrub_text_leaves_a_bare_question_mark_in_prose_unchanged():
     text = "are we done? yes, all set"
 
     assert _scrub_text(text) == text
+
+
+def _worker_log_extra(job: Job, action: str) -> dict:
+    """The `extra` mapping Procrastinate's worker actually attaches to a record.
+
+    Mirrors `procrastinate/worker.py`'s `Worker._log_extra()` (pinned
+    procrastinate 3.9.0): an `action`, a `worker` dict, and `job` set to
+    `context.job.log_context()`. `log_context()` is the load-bearing part and
+    is called for real here rather than hand-typed, so this breaks if
+    Procrastinate ever changes what it puts in there instead of silently
+    staying green against a guess.
+    """
+    return {
+        "action": action,
+        "worker": {
+            "name": "worker-0",
+            "worker_id": 0,
+            "job_id": job.id,
+            "queues": ["ingest-auth-v2"],
+        },
+        "job": job.log_context(),
+    }
+
+
+def _authenticated_service_job() -> Job:
+    """A job shaped like the ones the default install actually queues.
+
+    `credential_store_available()` is False whenever `REDIS_URL` is unset --
+    which is how `.env.example` ships -- so `resolve_dispatch_credential()`
+    returns the raw wire credential and it crosses the queue as the `token`
+    kwarg of every authenticated service import and reupload.
+    """
+    return Job(
+        id=1270,
+        queue="ingest-auth-v2",
+        lock=None,
+        queueing_lock=None,
+        task_name="ingest_service",
+        task_kwargs={
+            "job_id": "abc",
+            "token": _BASIC_LINE,
+            "credential_ref": _CREDENTIAL_REF,
+            "dataset_id": "d-42",
+        },
+    )
+
+
+# Every spelling of the throwaway credential that must not survive the
+# pipeline: the finished header line, the base64 blob inside it, and the two
+# cleartext halves an origin's own error text would name ("authentication
+# failed for user AAAAAAAAA"). The store reference joins them because it is
+# redeemable too.
+_JOB_CREDENTIAL_SPELLINGS = (
+    _BASIC_LINE,
+    _BASIC_BLOB,
+    _BASIC_USER,
+    _BASIC_SECRET,
+    _CREDENTIAL_REF,
+)
+
+# The three records `procrastinate/worker.py` emits per job, with the level and
+# message text each one really uses: `_process_job()`'s DEBUG "Loaded job info"
+# and INFO "Starting job", and `_log_job_outcome()`'s outcome line.
+_WORKER_JOB_RECORDS = (
+    ("loaded_job_info", logging.DEBUG, "Loaded job info, about to start job {call}"),
+    ("start_job", logging.INFO, "Starting job {call}"),
+    ("job_error", logging.ERROR, "Job {call} ended with status: Error, lasted 1.000 s"),
+)
+
+
+@pytest.mark.parametrize(
+    ("action", "level", "template"),
+    _WORKER_JOB_RECORDS,
+    ids=[record[0] for record in _WORKER_JOB_RECORDS],
+)
+def test_worker_job_context_never_carries_a_credential(action, level, template):
+    """fix(#1844): the structured half of every worker job line.
+
+    #1746 scrubbed the `event` STRING of exactly these three records and
+    stopped there, because `_redact_sensitive_fields` only looked at top-level
+    keys and no test in this file ever passed an `extra=`. The worker's
+    `extra["job"]` is `Job.log_context()`, which carries `task_kwargs`
+    verbatim AND a second rendered copy in `call_string`, so the credential
+    went out twice per line, at INFO, before the task body ran -- early enough
+    that nothing the task does about its own log context can help.
+    """
+    job = _authenticated_service_job()
+    extra = _worker_log_extra(job, action)
+    message = template.format(call=job.call_string)
+
+    # Pin the premise: the credential really is in this record, in both halves,
+    # before the pipeline sees it.
+    assert _BASIC_LINE in message
+    assert extra["job"]["task_kwargs"]["token"] == _BASIC_LINE
+    assert _BASIC_LINE in extra["job"]["call_string"]
+
+    line, data = _emit_json_with_extra(
+        "procrastinate.worker", level, message, extra, log_level="DEBUG"
+    )
+
+    for spelling in _JOB_CREDENTIAL_SPELLINGS:
+        assert spelling not in line, spelling
+    assert data["job"]["task_kwargs"]["token"] == "[REDACTED]"
+    assert data["job"]["task_kwargs"]["credential_ref"] == "[REDACTED]"
+    assert "[REDACTED]" in data["job"]["call_string"]
+    assert "[REDACTED]" in data["event"]
+    # The non-secret kwargs an operator debugging a stuck job actually needs
+    # are untouched, in both the structured copy and the rendered one.
+    assert data["job"]["task_kwargs"]["dataset_id"] == "d-42"
+    assert data["job"]["task_name"] == "ingest_service"
+    assert "dataset_id='d-42'" in data["job"]["call_string"]
+    assert data["action"] == action
+
+
+def test_an_extra_container_reaches_the_rendered_line_at_all():
+    """Positive control for the assertions above.
+
+    Every one of them is an ABSENCE claim, and an absence claim passes
+    vacuously if `extra` never reaches the output in the first place -- a
+    dropped record, an `ExtraAdder` that is not in the chain, a renderer that
+    ignores unknown fields. This pins the opposite: a container under a
+    non-sensitive key, holding a string with no credential shape, arrives
+    whole.
+    """
+    extra = {"job": {"task_kwargs": {"dataset_id": "d-42"}, "attempts": 3}}
+
+    _, data = _emit_json_with_extra("procrastinate.worker", logging.INFO, "hi", extra)
+
+    assert data["job"] == {"task_kwargs": {"dataset_id": "d-42"}, "attempts": 3}
+
+
+def test_the_same_job_context_leaks_through_a_shallow_key_pass():
+    """Positive control on the MECHANISM, not just on delivery.
+
+    Shows what the shallow pass this fix replaced would have emitted for the
+    identical record: a top-level key-only walk leaves `job` untouched, so
+    both copies of the credential survive. Written against the real
+    `log_context()` so it measures the payload the worker sends rather than a
+    restatement of the fix.
+    """
+    job = _authenticated_service_job()
+    event_dict = dict(_worker_log_extra(job, "start_job"))
+    event_dict["event"] = f"Starting job {job.call_string}"
+
+    shallow = {
+        key: ("[REDACTED]" if key.lower() in _SENSITIVE_FIELDS else value)
+        for key, value in event_dict.items()
+    }
+
+    assert shallow["job"]["task_kwargs"]["token"] == _BASIC_LINE
+    assert _BASIC_BLOB in shallow["job"]["call_string"]
+
+
+def test_credential_ref_absence_stays_distinguishable_from_a_real_ref():
+    """Redacting a ref must not cost the operator the one bit they need.
+
+    "Did this job carry a credential at all" is the question a stuck-job
+    triage actually asks, and `Job.call_string` renders `None` UNQUOTED. The
+    rendered-value scrub only touches a QUOTED value, so absence still reads
+    as `credential_ref=None` while a real ref reads as `[REDACTED]`.
+    """
+    job = Job(
+        id=1271,
+        queue="ingest-auth-v2",
+        lock=None,
+        queueing_lock=None,
+        task_name="ingest_service",
+        task_kwargs={"job_id": "abc", "token": None, "credential_ref": None},
+    )
+    extra = _worker_log_extra(job, "start_job")
+
+    _, data = _emit_json_with_extra(
+        "procrastinate.worker", logging.INFO, f"Starting job {job.call_string}", extra
+    )
+
+    assert "credential_ref=None" in data["job"]["call_string"]
+    assert "credential_ref=None" in data["event"]
+
+
+def test_nested_url_credential_in_an_extra_is_scrubbed():
+    """The deep walk scrubs nested STRINGS, not only denylisted keys.
+
+    A credential does not have to sit under a name the denylist knows.
+    `call_string` is the case that matters in production -- a rendered copy of
+    the kwargs, under a key that is not sensitive -- and this pins the same
+    behaviour for the other shape a nested string can carry, a URL with a
+    credential query. Key redaction cannot reach either one.
+    """
+    extra = {"job": {"detail": f"GET {_ARCGIS_URL} failed", "attempts": 1}}
+
+    line, data = _emit_json_with_extra(
+        "procrastinate.worker", logging.INFO, "outcome", extra
+    )
+
+    assert _TOKEN not in line
+    assert "?<redacted>" in data["job"]["detail"]
+    assert "services6.arcgis.com" in data["job"]["detail"]
+
+
+def test_a_flat_record_is_left_alone_by_the_deep_walk():
+    """The walk is gated on the value being a container.
+
+    Over-redaction destroys log usefulness, and this is the hot path: every
+    request-path line is flat. Scalars under non-sensitive keys must come
+    through exactly as they went in.
+    """
+    extra = {"job_id": "abc", "task": "ingest_vrt", "attempts": 2, "ok": True}
+
+    _, data = _emit_json_with_extra("app.worker", logging.INFO, "flat", extra)
+
+    for key, value in extra.items():
+        assert data[key] == value
+
+
+def test_a_cyclic_extra_terminates():
+    """`extra` is third-party input, so the walk must not trust its shape.
+
+    Procrastinate builds a plain JSON-able dict today, but the processor runs
+    on whatever any library puts in `extra`. `redact_nested()`'s depth ceiling
+    is what makes a self-referencing structure terminate; without it this
+    hangs the logging call on the event loop rather than raising.
+    """
+    cyclic: dict = {"name": "loop"}
+    cyclic["self"] = cyclic
+
+    started = time.monotonic()
+    _, data = _emit_json_with_extra(
+        "app.worker", logging.INFO, "cycle", {"payload": cyclic}
+    )
+
+    assert time.monotonic() - started < 5
+    assert "[TRUNCATED]" in json.dumps(data["payload"])

--- a/backend/tests/test_1746_stdlib_log_redaction.py
+++ b/backend/tests/test_1746_stdlib_log_redaction.py
@@ -31,6 +31,7 @@ import json
 import logging
 import time
 from collections.abc import Mapping
+from urllib.parse import urlsplit
 
 import pytest
 from procrastinate.jobs import Job
@@ -861,8 +862,17 @@ def test_nested_url_credential_in_an_extra_is_scrubbed():
     )
 
     assert _TOKEN not in line
-    assert "?<redacted>" in data["job"]["detail"]
-    assert "services6.arcgis.com" in data["job"]["detail"]
+    # fix(#1844 audit round 1): compare the host EXACTLY, and the string as a
+    # whole, rather than asserting the hostname is a substring of the scrubbed
+    # detail. `"services6.arcgis.com" in <text>` is satisfied by
+    # `services6.arcgis.com.evil.test` too, so as an assertion about a URL it
+    # says less than it looks like it says -- and CodeQL flags the shape
+    # (py/incomplete-url-substring-sanitization) whether or not the particular
+    # use is a sanitiser. Deriving the expectation from `_ARCGIS_URL` keeps it
+    # in step with the constant.
+    scrubbed = data["job"]["detail"].removeprefix("GET ").removesuffix(" failed")
+    assert urlsplit(scrubbed).hostname == "services6.arcgis.com"
+    assert scrubbed == f"{_ARCGIS_URL.partition('?')[0]}?<redacted>"
 
 
 def test_a_flat_record_is_left_alone_by_the_deep_walk():

--- a/backend/tests/test_ingest_ogr_pure.py
+++ b/backend/tests/test_ingest_ogr_pure.py
@@ -1414,35 +1414,75 @@ class TestSecFu04SanitizeAuthorizationToken:
 
         assert token not in reflected
 
-    def test_sec_fu_04_a_short_derived_variant_is_never_expanded(self) -> None:
-        """fix(#1844 codex r1): the floor covers forms nobody chose.
+    def test_sec_fu_04_a_valid_short_basic_pair_still_expands_to_both_halves(
+        self,
+    ) -> None:
+        """fix(#1844 codex r2): no length floor on a derived variant.
 
-        `_secret_variants` invents derived forms by splitting on `": "`, on a
-        space, and by base64-decoding a Basic blob. A two-character username
-        expands into a substring that occurs in ordinary English, so every
-        later scrub in the job would rewrite unrelated text. The registered
-        secret itself keeps its documented no-floor treatment: over-scrubbing
-        a short credential someone actually holds is the safe direction, while
-        over-scrubbing a fragment this module invented is not.
+        Round 1 added one and it was wrong. `credential_input_rejection_reason`
+        (`core/service_tokens.py`) accepts any nonempty printable username or
+        password with no minimum, so a one-character half is a VALID credential
+        a user can really configure, not a malformed one -- and a floor decides
+        which valid credentials stop being scrubbed. A Basic password of
+        `admin` had exactly this regression: `authentication failed for user
+        admin` stopped being redacted out of worker logs and the persisted
+        exception text.
+
+        Over-scrubbing a short secret is the deliberate trade-off documented on
+        `scrub_secret_value`. Under-scrubbing a valid one is not a trade this
+        module gets to make.
         """
         import base64
 
+        from app.core.logging_config import _scrub_text
+        from app.core.service_tokens import reset_registered_credential_secrets
         from app.core.url_redaction import _secret_variants
 
-        line = f"Authorization: Basic {base64.b64encode(b'a:b').decode()}"
+        user, other_half = "a", "b"
+        blob = base64.b64encode(f"{user}:{other_half}".encode()).decode()
+        line = f"Authorization: Basic {blob}"
 
-        variants = _secret_variants(line)
+        reset_registered_credential_secrets()
+        try:
+            assert _sanitize(line) == line
+            variants = _secret_variants(line)
+            named = _scrub_text(f"authentication failed for user {user}")
+        finally:
+            reset_registered_credential_secrets()
 
-        assert line in variants
-        assert "a" not in variants
-        assert "b" not in variants
+        assert user in variants
+        assert other_half in variants
+        # End to end, not just in the variant list: the origin's own wording
+        # for the half is what reaches a log, and it comes back redacted.
+        assert user not in named
+
+    def test_sec_fu_04_a_valid_short_named_header_key_is_still_scrubbed(self) -> None:
+        """The same regression on the named-header method.
+
+        A header key has no length floor either, so a six-character API key is
+        well-formed. This is a separate branch of `_secret_variants` from the
+        Basic pair above (the tail after `": "`, with no scheme word to strip),
+        so covering only one would leave the other free to regress.
+        """
+        from app.core.logging_config import _scrub_text
+        from app.core.service_tokens import reset_registered_credential_secrets
+
+        key = "k3yk3y"
+
+        reset_registered_credential_secrets()
+        try:
+            _sanitize(f"X-Api-Key: {key}")
+            reflected = _scrub_text(f"origin rejected {key} at the door")
+        finally:
+            reset_registered_credential_secrets()
+
+        assert key not in reflected
 
     def test_sec_fu_04_a_long_basic_pair_still_expands_to_both_halves(self) -> None:
-        """Positive control for the floor: it must not gut the real expansion.
+        """The ordinary case, so the short ones above are not the only coverage.
 
         The reason the halves are derived at all is that an origin's own error
-        text names them ("authentication failed for user ..."). A floor that
-        dropped every half would quietly undo the fix this PR makes.
+        text names them ("authentication failed for user ...").
         """
         import base64
 

--- a/backend/tests/test_ingest_ogr_pure.py
+++ b/backend/tests/test_ingest_ogr_pure.py
@@ -1220,9 +1220,14 @@ class TestSecFu04SanitizeAuthorizationToken:
         current job actually uses, and only the two explicit
         `scrub_secret_from_exception` calls covered exceptions -- an
         ordinary log line calling `_scrub_text` directly was not covered at
-        all. Counterfactual: remove the `register_credential_secret(value)`
+        all. Counterfactual: remove the `register_credential_secret(...)`
         call from `_sanitize_authorization_token` and the secret below
         survives `_scrub_text` untouched.
+
+        fix(#1844): that call registers the LINE now, not the value -- see
+        `test_sec_fu_04_registration_expands_to_every_wire_shape` below for
+        the shapes only the line expands to. A named API key's own value is
+        the tail of its own line, so this test reads the same either way.
         """
         from app.core.logging_config import _scrub_text
         from app.core.service_tokens import reset_registered_credential_secrets
@@ -1251,3 +1256,87 @@ class TestSecFu04SanitizeAuthorizationToken:
             reset_registered_credential_secrets()
 
         assert "never-sanitized" in rendered
+
+    def test_sec_fu_04_registration_expands_to_every_wire_shape(self) -> None:
+        """fix(#1844): register the LINE, because only a line expands.
+
+        `_secret_variants` (`core/url_redaction.py`) derives the bare token,
+        the basic blob and the decoded `user:pass` cleartext from a secret
+        that CONTAINS `": "`, and from nothing else. Round 49 registered the
+        VALUE (`Bearer <tok>` / `Basic <blob>`) to keep the header NAME out of
+        the registry, which meant the worker -- the one process that spends
+        the credential against a hostile origin -- registered a shape the
+        expansion could not open. So an origin echoing the bare token back in
+        a URL path, or naming the basic username in its own error text
+        ("authentication failed for user ..."), passed the exact-value scrub
+        untouched, and only the two explicit `scrub_secret_from_exception`
+        calls (which are handed the full line) covered anything.
+
+        The name is still never registered on its own: every variant starts
+        after the `": "`, so the bare word `Authorization` stays legible.
+        """
+        import base64
+
+        from app.core.logging_config import _scrub_text
+        from app.core.service_tokens import reset_registered_credential_secrets
+
+        user, other_half = "AAAAAAAAA", "BBBBBBBBB"
+        blob = base64.b64encode(f"{user}:{other_half}".encode()).decode()
+
+        reset_registered_credential_secrets()
+        try:
+            assert _sanitize(f"Authorization: Basic {blob}") == (
+                f"Authorization: Basic {blob}"
+            )
+            echoed_blob = _scrub_text(f"GDAL error on https://host/oops/{blob}")
+            named_user = _scrub_text(f"authentication failed for user {user}")
+            named_half = _scrub_text(f"rejected {other_half} at the origin")
+            header_name = _scrub_text("an Authorization header was sent")
+        finally:
+            reset_registered_credential_secrets()
+
+        assert blob not in echoed_blob
+        assert user not in named_user
+        assert other_half not in named_half
+        assert "Authorization" in header_name
+
+    def test_sec_fu_04_a_bearer_token_is_registered_without_its_scheme(self) -> None:
+        """The other half of the same expansion, on the bearer format.
+
+        An origin that reflects the credential reflects the TOKEN, not the
+        `Bearer ` wrapper GeoLens put around it, so the bare token has to be a
+        registered variant in its own right.
+        """
+        from app.core.logging_config import _scrub_text
+        from app.core.service_tokens import reset_registered_credential_secrets
+
+        token = "AAAAAAAAAAAAAAAAAAAA"
+
+        reset_registered_credential_secrets()
+        try:
+            _sanitize(f"Authorization: Bearer {token}")
+            reflected = _scrub_text(f"GDAL error on https://host/oops/{token}")
+        finally:
+            reset_registered_credential_secrets()
+
+        assert token not in reflected
+
+    def test_sec_fu_04_an_unregistered_bare_token_is_not_scrubbed(self) -> None:
+        """Positive control for the two tests above.
+
+        Both are absence claims about a value the scrubber is supposed to know
+        by exact match. If `_scrub_text` were replacing everything, or the
+        probe strings were somehow not reaching it, they would pass with the
+        registration removed. A token of the same shape that was never
+        sanitised survives.
+        """
+        from app.core.logging_config import _scrub_text
+        from app.core.service_tokens import reset_registered_credential_secrets
+
+        reset_registered_credential_secrets()
+        try:
+            rendered = _scrub_text("GDAL error on https://host/oops/CCCCCCCCCCCCCCCC")
+        finally:
+            reset_registered_credential_secrets()
+
+        assert "CCCCCCCCCCCCCCCC" in rendered

--- a/backend/tests/test_ingest_ogr_pure.py
+++ b/backend/tests/test_ingest_ogr_pure.py
@@ -1340,3 +1340,118 @@ class TestSecFu04SanitizeAuthorizationToken:
             reset_registered_credential_secrets()
 
         assert "CCCCCCCCCCCCCCCC" in rendered
+
+    def test_sec_fu_04_a_refused_short_bearer_registers_nothing(self) -> None:
+        """fix(#1844 codex r1): a line this function REFUSES is not a secret.
+
+        Registration used to run above the bearer grammar checks, so a refused
+        line still seeded the registry. `Authorization: Bearer e` seeded the
+        one-character variant `e`, and every later `_scrub_text` in the same
+        job then replaced every "e" in every log line with the redaction
+        marker -- destroying the diagnostic exactly when something upstream
+        had let a malformed credential through.
+        """
+        from app.core.logging_config import _scrub_text
+        from app.core.service_tokens import (
+            registered_credential_secrets,
+            reset_registered_credential_secrets,
+        )
+
+        reset_registered_credential_secrets()
+        try:
+            with pytest.raises(ValueError):
+                _sanitize("Authorization: Bearer e")
+
+            registered = set(registered_credential_secrets())
+            prose = _scrub_text("the feature set never loaded")
+        finally:
+            reset_registered_credential_secrets()
+
+        assert registered == set()
+        # The whole point: unrelated text is untouched afterwards.
+        assert prose == "the feature set never loaded"
+
+    def test_sec_fu_04_a_refused_bad_charset_bearer_registers_nothing(self) -> None:
+        """The other refusal on the same branch, for the same reason.
+
+        Both raises sit below the registration now, so neither can seed the
+        registry. Covering only the length one would leave the charset one to
+        regress on its own.
+        """
+        from app.core.service_tokens import (
+            registered_credential_secrets,
+            reset_registered_credential_secrets,
+        )
+
+        reset_registered_credential_secrets()
+        try:
+            with pytest.raises(ValueError):
+                _sanitize("Authorization: Bearer valid.jwt.sig!")
+            registered = set(registered_credential_secrets())
+        finally:
+            reset_registered_credential_secrets()
+
+        assert registered == set()
+
+    def test_sec_fu_04_an_accepted_line_is_still_registered(self) -> None:
+        """Positive control: moving the call must not disable it.
+
+        Both tests above are absence claims about the registry, and deleting
+        the registration entirely would satisfy both. A well-formed bearer
+        still registers and still expands to its bare token.
+        """
+        from app.core.logging_config import _scrub_text
+        from app.core.service_tokens import reset_registered_credential_secrets
+
+        token = "AAAAAAAAAAAAAAAAAAAA"
+
+        reset_registered_credential_secrets()
+        try:
+            _sanitize(f"Authorization: Bearer {token}")
+            reflected = _scrub_text(f"GDAL error on https://host/oops/{token}")
+        finally:
+            reset_registered_credential_secrets()
+
+        assert token not in reflected
+
+    def test_sec_fu_04_a_short_derived_variant_is_never_expanded(self) -> None:
+        """fix(#1844 codex r1): the floor covers forms nobody chose.
+
+        `_secret_variants` invents derived forms by splitting on `": "`, on a
+        space, and by base64-decoding a Basic blob. A two-character username
+        expands into a substring that occurs in ordinary English, so every
+        later scrub in the job would rewrite unrelated text. The registered
+        secret itself keeps its documented no-floor treatment: over-scrubbing
+        a short credential someone actually holds is the safe direction, while
+        over-scrubbing a fragment this module invented is not.
+        """
+        import base64
+
+        from app.core.url_redaction import _secret_variants
+
+        line = f"Authorization: Basic {base64.b64encode(b'a:b').decode()}"
+
+        variants = _secret_variants(line)
+
+        assert line in variants
+        assert "a" not in variants
+        assert "b" not in variants
+
+    def test_sec_fu_04_a_long_basic_pair_still_expands_to_both_halves(self) -> None:
+        """Positive control for the floor: it must not gut the real expansion.
+
+        The reason the halves are derived at all is that an origin's own error
+        text names them ("authentication failed for user ..."). A floor that
+        dropped every half would quietly undo the fix this PR makes.
+        """
+        import base64
+
+        from app.core.url_redaction import _secret_variants
+
+        user, other_half = "AAAAAAAAA", "BBBBBBBBB"
+        blob = base64.b64encode(f"{user}:{other_half}".encode()).decode()
+
+        variants = _secret_variants(f"Authorization: Basic {blob}")
+
+        assert user in variants
+        assert other_half in variants

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -4692,7 +4692,15 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # finished `Authorization: Bearer <tok>` line arriving for an ArcGIS job
     # walked straight through to the header file. Both shapes refused now, and
     # the comment at each end says which half it is. Cap 1366 -> 1371, exact.
-    "backend/app/processing/ingest/ogr.py": 1371,
+    # fix(#1844): +11. `_sanitize_authorization_token` registers the header
+    # LINE rather than the value it carries. `_secret_variants` derives the
+    # bare token, the basic blob and the decoded cleartext only from a secret
+    # containing `": "`, so registering `Bearer <tok>` expanded to nothing and
+    # the worker could not exact-scrub what an origin echoes back. The added
+    # lines are the comment saying why the earlier reasoning (keep the header
+    # NAME out of the registry) is still satisfied by the line.
+    # Cap 1371 -> 1382, exact.
+    "backend/app/processing/ingest/ogr.py": 1382,
     # fix(#1778): +157 for two audit findings that both land in JIT
     # provisioning. One is the REGISTRATION_ENABLED gate plus its exception
     # class, so enabling a provider stops being a way to reopen signup while

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -4700,7 +4700,14 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # lines are the comment saying why the earlier reasoning (keep the header
     # NAME out of the registry) is still satisfied by the line.
     # Cap 1371 -> 1382, exact.
-    "backend/app/processing/ingest/ogr.py": 1382,
+    # fix(#1844 codex r1): +10. The bearer length and charset checks moved
+    # above the registration, so a line this function REFUSES no longer seeds
+    # the exact-value registry -- `Authorization: Bearer e` used to register
+    # the variant `e` and turn every later log line into redaction markers.
+    # The lines are the guarded branch plus the comment saying which failure
+    # the ordering prevents.
+    # Cap 1382 -> 1392, exact.
+    "backend/app/processing/ingest/ogr.py": 1392,
     # fix(#1778): +157 for two audit findings that both land in JIT
     # provisioning. One is the REGISTRATION_ENABLED gate plus its exception
     # class, so enabling a provider stops being a way to reopen signup while

--- a/backend/tests/test_phase_273_log_redaction.py
+++ b/backend/tests/test_phase_273_log_redaction.py
@@ -73,15 +73,39 @@ def test_processor_redacts_non_string_values():
     assert out["token"] == "[REDACTED]"
 
 
-def test_processor_does_not_recurse_into_nested_dicts():
-    """Documented limitation: redaction is shallow, nested dicts are not walked.
+def test_processor_recurses_into_nested_dicts():
+    """fix(#1844): the deliberate change this test's predecessor demanded.
 
-    This test pins the trade-off — if behavior changes to recursive in the
-    future, the test fails and forces a deliberate change.
+    It used to pin the opposite -- "redaction is shallow, nested dicts are not
+    walked" -- as a documented CPU trade-off, and said in its own docstring
+    that changing the behaviour should have to fail a test first. This is that
+    change, made on purpose: `structlog.stdlib.ExtraAdder()` lifts a stdlib
+    record's whole `extra` mapping into the event dict, so what sits one level
+    down is decided by third-party code, not by our own call sites. Procrastinate
+    puts the job's `task_kwargs` there, which on a default install is the wire
+    credential itself.
+
+    The trade-off did not disappear, it moved: the walk is gated on the value
+    being a container, so a flat record still costs one isinstance per field.
+    `test_processor_leaves_safe_fields_unchanged` above covers that path.
     """
     out = _redact_sensitive_fields(None, "info", {"nested": {"token": "secret"}})
-    # Top-level "nested" is not in the denylist; its inner "token" is left as-is
-    assert out == {"nested": {"token": "secret"}}
+
+    assert out == {"nested": {"token": "[REDACTED]"}}
+
+
+def test_processor_scrubs_strings_inside_a_nested_container():
+    """A nested string is scrubbed even under a key the denylist never matches.
+
+    Key redaction and pattern scrubbing are complements: Procrastinate renders
+    the same kwargs a second time into `call_string`, whose KEY is not
+    sensitive and whose VALUE is.
+    """
+    out = _redact_sensitive_fields(
+        None, "info", {"job": {"call_string": "run(token='secret')"}}
+    )
+
+    assert out["job"]["call_string"] == "run(token='[REDACTED]')"
 
 
 def test_processor_handles_empty_dict():


### PR DESCRIPTION
Security fix from the adversarial security audit of 2026-09-04 (audited commit `4e3600e37`, v1.18.0), sections P1-2, P2-1 and P3-1. Both findings were re-verified against current `main` before anything changed here; both still reproduce.

## P1-2, the P1: the worker's job context wrote the credential to the operator log

`structlog.stdlib.ExtraAdder()` is in the processor chain, so a stdlib record's whole `extra` mapping is lifted into the event dict, and third-party code decides what that mapping holds. Procrastinate's worker sets `extra["job"] = context.job.log_context()`, and `log_context()` is `asdict()` plus `call_string` — the job's `task_kwargs` verbatim, and a second rendered copy of the same kwargs.

`_redact_sensitive_fields` was shallow and key-based. It replaced denylisted top-level keys and applied `_scrub_text` to exactly two fields, `event` and `exception`. `redact_nested()`, the deep counterpart, existed in the same module but was opt-in for one audit path and was not in the chain. #1746 fixed the `event` half of these same three records; the structured half went out unredacted, twice per line.

On installs without a credential store the credential reaches the job context as a task argument. The three records are `Loaded job info` (DEBUG), `Starting job` (INFO) and the outcome line. All three fire before the task body runs, so the task's own log-context handling cannot help even in principle.

Container values now go through `redact_nested()`, which redacts denylisted keys at depth and applies the same `_scrub_text` to nested strings, so the `call_string` copy is covered as well as `task_kwargs`. Key redaction and pattern scrubbing are complements here rather than alternatives: `call_string` sits under a key the denylist does not know, holding a value it needs to reach.

The walk is gated on the value actually being a container, so a flat record — every request-path line — still costs one isinstance per field and nothing else. `redact_nested()` keeps its existing depth ceiling, which matters more now that the input is third-party. `exc_info` is excluded from the walk: the deep pass rebuilds every sequence as a list, and that field is a tuple a renderer unpacks positionally. `format_exc_info` pops it before this processor runs today, so that guard is against a chain reordering rather than a live case.

## P2-1: the worker registered a shape the exact-value scrub cannot expand

`_sanitize_authorization_token` registered the header VALUE, so the worker registered `Bearer <tok>` or `Basic <blob>`. `_secret_variants` derives the bare token, the basic blob and the decoded cleartext only from a secret containing `": "`, so that registration expanded to nothing, in the one process that spends the credential against a hostile origin. An origin reflecting the bare token into a URL path, or naming the basic username in its own error text, passed the scrub untouched.

It registers the line now. That expands to every shape and still never yields the bare word `Authorization`, since every variant starts after the `": "` — which is what round 49's reasoning for registering the value was after in the first place.

## P3-1: `credential_ref` on the denylist

A store reference is a redeemable single-use capability with a TTL that the sweepers actively renew while the job sits `todo`, so a log reader who sees one before the worker claims it can redeem it instead. It rides the same `extra["job"]` dict.

The rendered-value scrub covers it too, not only the denylist, because otherwise the `call_string` copy survives. Only a QUOTED value is redacted, which keeps the bit an operator triaging a stuck job actually needs: `Job.call_string` renders `None` unquoted, so absence still reads as `credential_ref=None` while a real ref reads as `[REDACTED]`.

## Audit round 1

Two follow-ups from the pre-trigger audit, in a third commit.

The rendered-value scrub knew 2 of the 14 denylisted names, so the other 12 were redacted as keys and then emitted verbatim in the `call_string` rendering beside them -- the same key-pass/text-pass asymmetry as the finding above, one level down. The alternation is built from `_SENSITIVE_FIELDS` now, longest-first, `re.escape`d because the denylist holds names with regex-significant characters, and case-insensitive for parity with the key pass, which has always compared `key.lower()`. One test pins the two sets equal; a second walks every name through both rendered shapes, so a name the set contains but the compiled regex cannot match fails there rather than passing on the set comparison alone. Reverting to the two-name tuple fails exactly those 12 names plus the two pins.

The deep walk is wrapped. `extra` is third-party input all the way down and `redact_nested()` calls `.items()` on objects this module never constructed, so a lazy Mapping that raises would take the exception out through the processor chain and cost the whole log line -- during an incident, on a record someone put a credential in. The payload drops to `[UNREDACTABLE]` and the line survives.

The job-context assertions also gained a console-renderer twin, since `ConsoleRenderer` reaches the containers through `repr()` rather than `json.dumps` and is what a self-hoster on default settings actually gets.

## Sweep for other `extra=` producers

Asked for in the brief. Under `backend/app/`, the genuine stdlib `logger.*(..., extra={...})` producers are in `processing/ingest/tasks_vrt.py` (3), `tasks_raster.py` (3), `tasks_common.py` (2), `api/main.py`, `modules/catalog/search/service_semantic.py` and `service_records.py` (2). All carry scalars except `tasks_vrt.py`'s `changes` list, which is a list of VRT rewrite descriptions and carries no credential; it is walked and scrubbed by the same pass now.

Three things that look like producers and are not. `processing/tiles/router.py`'s `log_extra` is splatted into a structlog call as `**log_extra`, so those become top-level keyed fields the existing shallow pass already covered. `modules/admin/backfill_jobs.py`'s `extra=` is an audit-event kwarg. `modules/auth/router.py`'s is a notification-payload kwarg.

`backend/app/platform/` has no stdlib `extra=` producer at all, the refresh scheduler and `platform/jobs/*` included. That absence claim has a positive control: the same trees hold 260 matches for "extra", so the search was not blind. httpx event hooks do not log with `extra=`; `platform/security.py`'s `_redirect_hook` validates and raises. httpx's own request line stays covered by #1746 (silenced to WARNING, scrubbed above that).

So Procrastinate's worker is the only producer that puts a credential-bearing container into `extra`, which is why the fix is at the processor rather than at a call site.

## Verification

Counterfactuals were run, not assumed. Reverting the container walk and re-running reproduces the leak in both renderers, with the credential present in `job.task_kwargs.token` and again in `job.call_string`; 5 of the new tests fail. Reverting the registration to the value makes the basic blob, the username and the other cleartext half all survive `_scrub_text`, and 2 of the new tests fail.

Host pytest, from this worktree against Postgres at `localhost:5434`:

Re-run at the round-1 head:

- `tests/test_1746_stdlib_log_redaction.py tests/test_ingest_ogr_pure.py tests/test_phase_273_log_redaction.py tests/test_credential_producer_structural.py tests/test_credential_scrub_middleware.py tests/test_service_token_redaction_1277.py tests/test_rule1_structural.py tests/test_rule2_structural.py tests/test_layering.py` — 389 passed
- `tests/test_audit_details_json_1484.py tests/test_audit_sink.py tests/test_audit_savepoint_isolation_1491.py tests/test_audit.py tests/test_logging_conftest_guard.py tests/test_service_auth_transport_1746.py tests/test_service_auth_contract_1746.py tests/test_engine_hides_bound_parameters.py tests/test_failed_job_token_purge_1746.py tests/test_import_token_lease_1676.py tests/test_service_refresh_1220.py tests/test_credential_renewal_tenancy_1277.py tests/test_oauth.py tests/test_oauth_audit_correlation.py tests/test_config_ops_unit.py` — 688 passed
- `tests/test_refresh_gate_1269.py tests/test_optional_auth_failure_mode_1518.py tests/test_connector_extension.py tests/test_tenant_job_recovery.py tests/test_jobs_router.py` — covered in the pre-round-1 run, 258 passed alongside the credential suites
- `uv run ruff check .` and `uv run ruff format --check .` — clean

New tests emit through the real `setup_logging` pipeline with `extra={"job": <a real procrastinate.jobs.Job(...).log_context()>}`, parametrized over the three worker records at the level each one really uses. Test credentials are throwaway filler that carries the shapes the scrubber has to recognise and reads like nothing real.

Two positive controls, because every assertion in the main test is an absence claim. One pins that a container under a non-sensitive key reaches the rendered line at all, so a dropped record or a missing `ExtraAdder` cannot make the suite pass vacuously. The other runs the identical real `log_context()` through a top-level key-only pass and shows both copies of the credential surviving.

## Impact

No schema change, no API change, no config change, no new dependency. Nothing is stored. Behaviour change is confined to log output: a container value in a log record is now walked, and `credential_ref` is redacted where it appears as a keyed field or a quoted rendered value.

## Noticed and left alone

`test_processor_does_not_recurse_into_nested_dicts` pinned the old shallow behaviour and said in its own docstring that changing it should have to fail a test first. It is inverted here rather than deleted, since that tripwire did its job.

`_MODULE_LOC_CAPS` for `processing/ingest/ogr.py` raised 1371 to 1382, exact, re-measured with `wc -l`, with a comment saying what the lines bought.

P2-2 from the same audit (the Rule 2 CLI allowlist justification) is not touched here: it is downstream of P1-1, which is another lane's.
