### PR TITLE
fix(sources): SSRF refusals answered as themselves, depth-bomb guards on two remaining JSON reads, staging tables excluded from discovery

### DIFF
--- a/backend/app/modules/catalog/sources/adapters/arcgis.py
+++ b/backend/app/modules/catalog/sources/adapters/arcgis.py
@@ -704,6 +704,18 @@ async def enrich_arcgis_feature_counts(
                 ValueError,
                 KeyError,
             ):
+                # fix(#1858 audit P2-2): `SSRFError` is a `ValueError`, so a
+                # refused redirect hop lands here, and it stays here on
+                # purpose. This read establishes ONE OPTIONAL FACT about one
+                # layer, the probe answers 200 without it, and the import
+                # that follows fetches the same endpoint under the same
+                # guard. Raising would let a single layer's redirect end a
+                # probe of a service with fifty of them. The rule, shared
+                # with the three sibling clauses below and with
+                # `adapters/ogcapi.py`: a refusal on a read whose failure
+                # means "one optional fact is unknown" stays a degrade; a
+                # refusal on a read whose failure ends the adapter is raised,
+                # which is what `probe_arcgis_service` does.
                 return {**layer, "feature_count": None}
 
     enriched = await asyncio.gather(*[_fetch_count(layer) for layer in layers])
@@ -849,6 +861,11 @@ async def fetch_arcgis_pagination_info(
         EndpointCheckFailedError,
         TimeoutError,
     ):
+        # fix(#1858 audit P2-2): a refused hop degrades here for the reason
+        # given at `_fetch_count` above. The optional fact is "this layer
+        # supports pagination"; the one caller is the worker, whose own broad
+        # handler degrades identically, so raising would change nothing it
+        # reports and would remove the fallback an import relies on.
         return None, False, None
 
     # fix(#1770 round 49 P3): same reasoning as `_fetch_count`/`fetch_arcgis_
@@ -1008,6 +1025,12 @@ async def fetch_arcgis_layer_preview(
         EndpointCheckFailedError,
         TimeoutError,
     ) as exc:
+        # fix(#1858 audit P2-2): a refused hop degrades here for the reason
+        # given at `_fetch_count` above. The optional fact is the sample
+        # rows; the preview is already usable without them, and the metadata
+        # read that decides whether this layer can be previewed at all runs
+        # above without a local handler, so a refusal there still reaches the
+        # door.
         logger.debug(
             "ArcGIS sample-row fetch failed for %s/%s: %s",
             base,
@@ -1031,6 +1054,9 @@ async def fetch_arcgis_layer_preview(
         EndpointCheckFailedError,
         TimeoutError,
     ) as exc:
+        # fix(#1858 audit P2-2): a refused hop degrades here for the reason
+        # given at `_fetch_count` above. The optional fact is the row count
+        # shown beside the preview.
         logger.debug(
             "ArcGIS feature-count fetch failed for %s/%s: %s",
             base,

--- a/backend/app/modules/catalog/sources/adapters/arcgis.py
+++ b/backend/app/modules/catalog/sources/adapters/arcgis.py
@@ -347,6 +347,35 @@ def _is_web_tier_refusal(exc: httpx.HTTPStatusError, requested_url: str) -> bool
     return same_origin(str(response.url), requested_url)
 
 
+def _arcgis_parsed_json(body: bytes) -> object:
+    """``json.loads(body)``, with a depth bomb turned into a typed refusal.
+
+    fix(#1858): a JSON depth bomb -- 300,000 nested ``[`` at under two bytes
+    each -- is a ~600 KB document, so it passes every byte and structural-token
+    cap ``bounded_probe_read`` applies (``structural_tokens`` counts brackets,
+    not nesting depth, so it cannot see this shape at all). ``json.loads`` then
+    raises ``RecursionError``, which is a ``RuntimeError`` and therefore caught
+    by none of this module's ``except (ValueError, TypeError)`` clauses nor by
+    any caller's. It reached ``/services/probe``, ``/services/preview`` and
+    ``GET /datasets/{id}/health`` as a bare 500 with no audit row, and killed
+    the ArcGIS worker reads unclassified. ``platform/service_endpoints.py``
+    (``_parsed_json``), ``platform/service_items.py`` and
+    ``sources/router.py`` each closed this on their own reads in #1770 round
+    44; these two were the sites that never adopted it.
+
+    ``ValueError`` is deliberately NOT converted. It is already part of
+    ``read_arcgis_json``'s published contract and every caller handles it, so
+    rewriting it would change the coded outcome of an ordinary unparseable
+    response for no gain. ``EndpointCheckFailedError`` is what
+    ``bounded_probe_read`` already raises out of these same two calls, so the
+    new class lands on a type every caller was written for.
+    """
+    try:
+        return json.loads(body)
+    except RecursionError as exc:
+        raise EndpointCheckFailedError(str(exc)) from None
+
+
 async def _read_with_query_token(
     client: httpx.AsyncClient,
     build_url: Callable[[str | None], str],
@@ -364,7 +393,7 @@ async def _read_with_query_token(
     body, _ = await bounded_probe_read(
         client, build_url(retry_token), headers=retry_headers, accept=OGC_JSON_ACCEPT
     )
-    return json.loads(body)
+    return _arcgis_parsed_json(body)
 
 
 async def read_arcgis_json(
@@ -399,7 +428,11 @@ async def read_arcgis_json(
       nothing.
 
     Raises whatever ``bounded_probe_read`` raises, plus ``ValueError`` from
-    ``json.loads``; every caller already handles both.
+    ``json.loads``; every caller already handles both. fix(#1858): a
+    ``RecursionError`` from a depth bomb is not a ``ValueError`` and no caller
+    handled it, so the parse runs through ``_arcgis_parsed_json``, which
+    reports it as the ``EndpointCheckFailedError`` this function already
+    raises for a body over the read bounds.
     """
     headers, query_token = arcgis_request_auth(token, current_version=current_version)
     requested_url = build_url(query_token)
@@ -411,7 +444,7 @@ async def read_arcgis_json(
         if not headers or not token or not _is_web_tier_refusal(exc, requested_url):
             raise
         return await _read_with_query_token(client, build_url, token)
-    data = json.loads(body)
+    data = _arcgis_parsed_json(body)
     if not headers or _arcgis_error_code(data) != _ARCGIS_TOKEN_REQUIRED_CODE:
         return data
     # `token` is truthy here: `headers` is non-empty, which only happens for a

--- a/backend/app/modules/catalog/sources/adapters/ogcapi.py
+++ b/backend/app/modules/catalog/sources/adapters/ogcapi.py
@@ -194,6 +194,13 @@ async def _resolve_conformance(
         conf_data = json.loads(conf_body)
         conforms_to = conf_data.get("conformsTo", [])
     except SSRFError:
+        # fix(#1858 audit P2-2): swallowed ON PURPOSE, unlike the
+        # `/collections` fetch below. `abs_href` is an address the LANDING
+        # DOCUMENT chose, this read establishes one optional fact, and the
+        # `data` link decides when it is unestablished -- so a refused hop
+        # here leaves the probe able to answer, and ending it would let any
+        # service make itself undetectable by advertising a blocked
+        # conformance href.
         logger.warning(
             "OGC API probe: conformance link blocked by SSRF check",
             href=redact_url_credentials(abs_href),
@@ -329,10 +336,22 @@ async def _probe_ogcapi_within_deadline(
         )
         col_data = json.loads(col_body)
     except SSRFError:
+        # fix(#1858 audit P2-2): re-raised, not degraded. This clause ENDS
+        # the adapter either way -- `return None` here is `probe_ogcapi`
+        # answering "not an OGC API service" -- so swallowing it costs the
+        # door the only truthful answer it could have given and gains
+        # nothing. `probe_service_url` and the preview door both have an
+        # `except SSRFError` that reports a refused hop as itself, and
+        # `_header_auth_probe` now lets one through to reach them. The rule
+        # this follows, and the reason the four best-effort clauses in
+        # `adapters/arcgis.py` and `_resolve_conformance` above keep their
+        # degrade: a refusal on a read whose failure means "one optional
+        # fact is unknown" stays a degrade; a refusal on a read whose
+        # failure ends the adapter is raised.
         logger.warning(
             "OGC API probe: collections URL blocked by SSRF check", url=collections_url
         )
-        return None
+        raise
     except Exception as exc:  # broad: collections fetch — httpx/JSON/bound failures can throw varied errors; degrade to None
         logger.debug(
             "OGC API probe: collections fetch failed",

--- a/backend/app/modules/catalog/sources/arcgis_signin.py
+++ b/backend/app/modules/catalog/sources/arcgis_signin.py
@@ -824,11 +824,22 @@ async def _fetch_json(
                 return response.status_code, None
         try:
             return response.status_code, json.loads(raw)
-        except ValueError:
-            return response.status_code, None
-        try:
-            return response.status_code, json.loads(raw)
-        except ValueError:
+        except (ValueError, RecursionError):
+            # fix(#1858): `RecursionError` joins `ValueError`. A balanced
+            # nesting costs two bytes a level, so the deepest document that
+            # fits inside `_MAX_RESPONSE_BYTES` above is ~131,000 levels --
+            # and the decoder gives up on a stack overflow well before that
+            # (measured at ~120,000 on CPython 3.14, and lower on any thread
+            # with a smaller stack). The cap therefore does not bound this
+            # shape. `RecursionError` is a `RuntimeError` rather than a
+            # `ValueError`, so it escaped this clause and fell through to the
+            # door's broad transport handler, which recorded `unreachable` --
+            # a fact about the NETWORK -- for a portal that answered
+            # perfectly well with a document this module cannot read.
+            # `unreadable_response` is the outcome that describes it, and it
+            # is the one every other unreadable portal answer already gets.
+            # The duplicate, unreachable copy of this same try/except that
+            # has sat below it since #1758 is removed in the same edit.
             return response.status_code, None
 
 

--- a/backend/app/modules/catalog/sources/origin_probe.py
+++ b/backend/app/modules/catalog/sources/origin_probe.py
@@ -486,11 +486,22 @@ async def fetch_json_document(
         return result, None, final_url
     try:
         return result, json.loads(raw), final_url
-    except ValueError:
+    except (ValueError, RecursionError):
         # Deliberately not folded into the handler above: a body that is not
         # JSON is not a transport failure, and classifying it as one would
         # report `network_error` for an origin that answered perfectly well
         # with an HTML error page.
+        #
+        # fix(#1858): `RecursionError` joins it. A JSON depth bomb -- 300,000
+        # nested `[` at under two bytes each -- is a ~600 KB body, so it is
+        # under `max_bytes` (2 MiB here) and there is no other cap on this
+        # path. It is a `RuntimeError`, not a `ValueError`, so it escaped both
+        # this clause and the broad transport handler above, which has already
+        # returned by the time the parse runs. `GET /datasets/{id}/health`
+        # answered 500 and wrote neither `last_checked_at` nor a verdict, and
+        # the three STAC resolve paths died unclassified. `unexpected_status`
+        # is the right verdict for both shapes: the origin answered, and what
+        # it answered with is not something GeoLens can act on.
         return _UNREADABLE_DOCUMENT, None, final_url
 
 

--- a/backend/app/modules/catalog/sources/probe.py
+++ b/backend/app/modules/catalog/sources/probe.py
@@ -46,6 +46,7 @@ from app.modules.catalog.sources.adapters.ogcapi import probe_ogcapi
 from app.modules.catalog.sources.adapters.wfs import probe_wfs
 from app.modules.catalog.sources.classify import classify_layer_kind
 from app.modules.catalog.sources.schemas import LayerInfo, ProbeResponse
+from app.platform.security import SSRFError
 
 logger = structlog.stdlib.get_logger(__name__)
 
@@ -221,6 +222,26 @@ async def detect_service_type(
     async def _header_auth_probe(probe) -> dict | None:
         try:
             return await probe(url, client, credential=credential)
+        except SSRFError:
+            # fix(#1858): FIRST, because `SSRFError` subclasses `ValueError`
+            # (`platform/security.py`) and the clause below reads a
+            # `ValueError` as "this credential cannot become a header". The
+            # two header-auth adapters catch only
+            # `(httpx.HTTPStatusError, httpx.TransportError,
+            # EndpointCheckFailedError)`, so a refused redirect hop -- raised
+            # by `_revalidate_redirect` from a response hook, or by the guard
+            # transport at connect time -- landed here and was recorded as a
+            # credential refusal. Three answers were wrong at once: a probe
+            # carrying NO credential was told its token was invalid;
+            # `SSRFResolutionError` interpolates the redirect-chosen hostname
+            # into its message, and `refusals[0]` carried that into the 422
+            # body and the persisted audit reason, which is exactly what
+            # `router.py`'s fixed `ssrf_policy_message` exists to prevent; and
+            # `probe_service_url`'s `except SSRFError` handler, which answers
+            # 400 `ssrf_blocked` and writes the matching audit row, never ran
+            # for these two adapters. `probe_arcgis_service` got the same
+            # clause in #1840 (`adapters/arcgis.py`) for this reason.
+            raise
         except ValueError as exc:
             refusals.append(str(exc))
             logger.debug(

--- a/backend/app/modules/catalog/sources/router.py
+++ b/backend/app/modules/catalog/sources/router.py
@@ -746,6 +746,55 @@ def _preview_refusal_response(exc: Exception) -> HTTPException | None:
     return None
 
 
+async def _refuse_preview(
+    db: AsyncSession,
+    user_id: uuid.UUID,
+    url: str,
+    layer: str,
+    exc: Exception,
+) -> None:
+    """Audit a typed preview refusal and raise its coded 4xx, or return.
+
+    fix(#1858 audit P2-1): extracted from ``_run_service_preview_or_refuse``
+    so the ArcGIS preview branch, which does not go through that function at
+    all, answers a refusal the same way the WFS and OGC API branches of the
+    same door do. Returning rather than re-raising for an unrecognized class
+    leaves the bare ``raise`` with the caller, where the traceback is.
+
+    Nothing here echoes ``str(exc)``: the message comes from
+    ``_preview_refusal_response``, and the audit row records the exception's
+    CLASS NAME, which is a GeoLens fact rather than anything a provider
+    chose. That matters most for ``SSRFResolutionError``, whose own message
+    carries the redirect-chosen hostname.
+    """
+    http_exc = _preview_refusal_response(exc)
+    if http_exc is None:
+        return
+    safe_url = redact_url_credentials(url)
+    logger.warning(
+        "Preview refused",
+        url=safe_url,
+        layer=layer,
+        reason_class=type(exc).__name__,
+    )
+    await audit_emit(
+        db,
+        AuditEvent(
+            user_id=user_id,
+            action="preview_service_layer",
+            resource_type="service_url",
+            details={
+                "url": safe_url,
+                "layer": layer,
+                "result": "refused",
+                "reason_class": type(exc).__name__,
+            },
+        ),
+    )
+    await db.commit()
+    raise http_exc from None
+
+
 async def _run_service_preview_or_refuse(
     db: AsyncSession,
     user_id: uuid.UUID,
@@ -773,32 +822,8 @@ async def _run_service_preview_or_refuse(
     except (IngestionError, HTTPException):
         raise
     except Exception as exc:  # broad: classifying every typed refusal `run_service_preview` and its callees can raise, so none of them falls through to the 500 below
-        http_exc = _preview_refusal_response(exc)
-        if http_exc is None:
-            raise
-        safe_url = redact_url_credentials(url)
-        logger.warning(
-            "Preview refused",
-            url=safe_url,
-            layer=layer,
-            reason_class=type(exc).__name__,
-        )
-        await audit_emit(
-            db,
-            AuditEvent(
-                user_id=user_id,
-                action="preview_service_layer",
-                resource_type="service_url",
-                details={
-                    "url": safe_url,
-                    "layer": layer,
-                    "result": "refused",
-                    "reason_class": type(exc).__name__,
-                },
-            ),
-        )
-        await db.commit()
-        raise http_exc from None
+        await _refuse_preview(db, user_id, url, layer, exc)
+        raise
 
 
 async def _create_preview_job(
@@ -1359,6 +1384,21 @@ async def preview_service_layer(
                     "ArcGIS token and try again."
                 ),
             )
+        except SSRFError as exc:
+            # fix(#1858 audit P2-1): FIRST, because `SSRFError` subclasses
+            # `ValueError` (`platform/security.py`) and the tuple below reads
+            # a `ValueError` as "this layer could not be previewed".
+            # `fetch_arcgis_layer_preview`'s metadata read has no local
+            # `except`, so a hop refused by `_revalidate_redirect` or by the
+            # guard transport reached that tuple and became
+            # `_fail_preview`'s 502 `ogrinfo_failed` -- naming a tool that
+            # never ran, on a door whose WFS and OGC API branches answer the
+            # same event as a 400 through `_preview_refusal_response`. Same
+            # split this PR closed on `/probe` in `sources/probe.py`, left
+            # standing on this door: one event, one classification, whichever
+            # adapter met it.
+            await _refuse_preview(db, user.id, request.url, request.layer_name, exc)
+            raise  # unreachable: `_preview_refusal_response` maps every `SSRFError`
         except (
             httpx.HTTPError,
             ValueError,

--- a/backend/app/platform/jobs/heartbeat.py
+++ b/backend/app/platform/jobs/heartbeat.py
@@ -1,6 +1,7 @@
 """Worker lease helpers for long-running ingest jobs."""
 
 import asyncio
+import re
 import uuid
 from datetime import datetime, timezone
 
@@ -30,10 +31,40 @@ class StaleIngestAttempt(RuntimeError):
     """Raised when a worker no longer owns the job attempt it received."""
 
 
+# fix(#1858): the shape `attempt_scoped_staging_table` produces, written once
+# so the code that RECOGNISES one of these names cannot drift from the code
+# that makes one. Deliberately narrow: `_staging_` followed by exactly a
+# `uuid4().hex`, anchored at the end. `generate_table_name` slugifies a
+# user-chosen title, so `parcels_staging`, `parcels_old` and `parcels_staging_
+# area` are all names a person can legitimately ask for, and a predicate wide
+# enough to cover them would refuse their registration. The spelling is a
+# POSIX regular expression because PostgreSQL's `~` and Python's `re` agree on
+# exactly this subset, which is what lets one string serve the SQL half of the
+# rule and the Python half (`backend/tests/test_staging_table_names_1858.py`
+# checks the two engines against each other).
+ATTEMPT_STAGING_NAME_PATTERN = r"_staging_[0-9a-f]{32}$"
+
+_ATTEMPT_STAGING_NAME_RE = re.compile(ATTEMPT_STAGING_NAME_PATTERN)
+
+
 def attempt_scoped_staging_table(base_table: str, attempt_id: uuid.UUID) -> str:
     """Return a PostgreSQL-safe physical staging name owned by one attempt."""
     suffix = f"_staging_{attempt_id.hex}"
     return f"{base_table[: 63 - len(suffix)]}{suffix}"
+
+
+def is_attempt_scoped_staging_table(table_name: str) -> bool:
+    """Whether *table_name* is a physical staging table owned by an attempt.
+
+    fix(#1858): these are created inside an import and dropped in its
+    ``finally``, so one only survives a worker that was SIGKILLed or
+    OOM-killed between the two. Nothing reaps the survivor -- the sweeps in
+    ``platform/jobs/sweep.py`` cover storage objects, analysis outputs and VRT
+    generations, and none of them looks at PostGIS tables -- so table
+    discovery listed it and bulk registration bound a permanent dataset to a
+    table the next attempt is entitled to ``ALTER ... RENAME`` away.
+    """
+    return _ATTEMPT_STAGING_NAME_RE.search(table_name) is not None
 
 
 async def resolve_ingest_job_attempt(

--- a/backend/app/processing/ingest/service.py
+++ b/backend/app/processing/ingest/service.py
@@ -46,6 +46,10 @@ from app.platform.jobs.defer_guard import (
     defer_with_orphan_guard,
     make_ingest_job_failed_rollback,
 )
+from app.platform.jobs.heartbeat import (
+    ATTEMPT_STAGING_NAME_PATTERN,
+    is_attempt_scoped_staging_table,
+)
 from app.platform.jobs.models import IngestJob, commit_attempted_marker
 from app.platform.storage.titiler_url import resolve_current_storage_key
 
@@ -114,6 +118,7 @@ async def discover_unregistered_tables(
     else:
         tenant_join_clause = ""
         bind_params = dict(schema=schema, limit=limit)
+    bind_params["attempt_staging_pattern"] = ATTEMPT_STAGING_NAME_PATTERN
 
     result = await session.execute(
         text(
@@ -140,6 +145,13 @@ async def discover_unregistered_tables(
                 AND d.table_name IS NULL
                 AND t.table_name NOT LIKE '%\\_staging' ESCAPE '\\'
                 AND t.table_name NOT LIKE '%\\_old' ESCAPE '\\'
+                -- fix(#1858): the two patterns above are the swap's names.
+                -- `attempt_scoped_staging_table` produces
+                -- `<base>_staging_<32 hex>`, which ends in neither, so a
+                -- staging table leaked by a worker that died mid-import was
+                -- listed here and permanently registerable. Same expression
+                -- the registration refusal uses.
+                AND t.table_name !~ :attempt_staging_pattern
                 AND t.table_name != 'spatial_ref_sys'
             ORDER BY t.table_name
             LIMIT :limit
@@ -693,6 +705,24 @@ async def register_existing_table(
     # target data_t_{tid} in multi_tenant rather than the shared 'data' schema.
     _tid = current_tenant_var.get() if is_multi_tenant() else None
     _schema = tenant_data_schema(_tid)
+
+    # fix(#1858): refused on the NAME alone, before the database is touched.
+    # Discovery hides these (same expression, one query above), but bulk
+    # registration takes a table name straight from the caller, so hiding one
+    # was never the same as refusing it. A dataset bound to a staging table is
+    # bound to storage the next import attempt owns and will rename away, and
+    # a registration racing a LIVE import leaves the dataset pointing at
+    # nothing. Only the attempt-scoped shape is refused: `parcels_staging` and
+    # `parcels_old` are names `generate_table_name` can produce from an
+    # ordinary title, and the analysis materialize path registers through this
+    # same function.
+    if is_attempt_scoped_staging_table(table_name):
+        raise ValueError(
+            f"Table '{table_name}' is an import staging table. It belongs to a "
+            "single import attempt and is dropped when that attempt ends, so a "
+            "dataset registered against it would lose its rows. Rename the "
+            "table if you mean to keep it."
+        )
 
     # Verify table exists in the correct schema
     result = await session.execute(

--- a/backend/tests/test_arcgis_header_transport_c2.py
+++ b/backend/tests/test_arcgis_header_transport_c2.py
@@ -69,6 +69,12 @@ from app.modules.catalog.sources.adapters.arcgis import (
 )
 from app.platform import security as security_mod
 from app.platform.security import SSRFError
+from app.platform.service_endpoints import (
+    MAX_DOCUMENT_BYTES,
+    MAX_DOCUMENT_TOKENS,
+    EndpointCheckFailedError,
+    structural_tokens,
+)
 
 _BASE = (
     "https://services6.arcgis.com/ZrVlS0wslq8Nvq5I/arcgis/rest/services/X/FeatureServer"
@@ -902,3 +908,80 @@ class TestTheQueryFallbackRegistersItsSecret:
             await probe_arcgis_service(_BASE, client, token=_TOKEN)
 
         assert _TOKEN in registered_credential_secrets()
+
+
+_DEPTH_BOMB = b"[" * 300_000 + b"]" * 300_000
+
+
+def test_the_depth_bomb_premise() -> None:
+    """Every bound the bomb below has to pass, and the exception it produces.
+
+    Pinned so that a future Python whose decoder stops recursing, or a future
+    cap that starts catching this shape, fails HERE rather than letting the
+    tests in the class below pass while exercising nothing.
+    """
+    assert len(_DEPTH_BOMB) < MAX_DOCUMENT_BYTES
+    assert structural_tokens(_DEPTH_BOMB) < MAX_DOCUMENT_TOKENS
+    with pytest.raises(RecursionError):
+        _json.loads(_DEPTH_BOMB)
+
+
+class TestAJsonDepthBombIsACodedRefusalNotACrash:
+    """fix(#1858, backend audit 2026-09-04 P2-2).
+
+    ``_parsed_json`` in ``platform/service_endpoints.py`` was written for this
+    exact body in #1770 round 44; ``read_arcgis_json`` and its query-form
+    fallback never adopted it. A balanced nesting 300,000 deep costs two bytes
+    a level, so the document is ~600 KB: under ``MAX_DOCUMENT_BYTES`` by two
+    orders of magnitude, and under ``MAX_DOCUMENT_TOKENS`` because
+    ``structural_tokens`` counts brackets rather than nesting depth and so
+    cannot see this shape at all. ``json.loads`` answers ``RecursionError``,
+    which is a ``RuntimeError``: caught by none of this module's ``except
+    (ValueError, TypeError)`` clauses, none of its callers', and none of the
+    doors'.
+    """
+
+    pytestmark = pytest.mark.asyncio
+
+    def _stream_bomb(self, _request: httpx.Request) -> httpx.Response:
+        async def _chunks():
+            yield _DEPTH_BOMB
+
+        return httpx.Response(200, content=_chunks())
+
+    async def test_the_service_document_read_is_a_typed_refusal(self) -> None:
+        async with _client(self._stream_bomb) as client:
+            with pytest.raises(EndpointCheckFailedError):
+                await arcgis_mod.read_arcgis_json(
+                    client, lambda _q: f"{_BASE}?f=json", _TOKEN
+                )
+
+    async def test_the_query_form_fallback_read_is_a_typed_refusal(self) -> None:
+        """The pre-10.5.1 path parses a second body, in its own function.
+
+        The first read answers the 499 envelope that triggers the fallback, so
+        the bomb is the body ``_read_with_query_token`` parses.
+        """
+        seen: list[httpx.Request] = []
+
+        def handle(request: httpx.Request) -> httpx.Response:
+            seen.append(request)
+            if len(seen) == 1:
+                return _stream({"error": {"code": 499, "message": "Token Required"}})
+            return self._stream_bomb(request)
+
+        async with _client(handle) as client:
+            with pytest.raises(EndpointCheckFailedError):
+                await arcgis_mod.read_arcgis_json(
+                    client,
+                    lambda q: build_arcgis_count_query_url(f"{_BASE}/0", q),
+                    _TOKEN,
+                )
+        assert len(seen) == 2
+
+    async def test_the_probe_degrades_rather_than_crashing(self) -> None:
+        """What the door sees: ``probe_arcgis_service`` already catches the
+        typed refusal, so the bomb becomes "not an ArcGIS service" instead of
+        an exception with no handler anywhere above it."""
+        async with _client(self._stream_bomb) as client:
+            assert await probe_arcgis_service(_BASE, client, token=_TOKEN) is None

--- a/backend/tests/test_arcgis_signin.py
+++ b/backend/tests/test_arcgis_signin.py
@@ -1846,6 +1846,43 @@ async def test_a_sign_in_page_instead_of_an_answer_is_a_network_error(
     assert [row.details["result"] for row in rows] == ["unreadable_response"]
 
 
+async def test_a_json_depth_bomb_is_an_unreadable_answer_not_a_crash(
+    client: AsyncClient, admin_auth_header: dict, allow_ssrf, test_db_session
+):
+    """fix(#1858, backend audit 2026-09-04 P2-2).
+
+    The byte cap does not bound nesting depth. A balanced nesting costs two
+    bytes a level, so the deepest document that fits inside
+    `_MAX_RESPONSE_BYTES` is ~131,000 levels, and the decoder overflows its
+    stack well before that. `RecursionError` is a `RuntimeError` rather than a
+    `ValueError`, so the parse's own except clause did not catch it, and the
+    attempt was recorded as `unreachable` -- a fact about the network -- for a
+    portal that answered perfectly well with a document this module cannot
+    read.
+    """
+    bomb = b"[" * 120_000 + b"]" * 120_000
+    # The premise, both halves: it fits inside the cap, and the decoder does
+    # give up on it. Without this the test could pass while exercising the
+    # oversized branch, or nothing at all.
+    assert len(bomb) < arcgis_signin._MAX_RESPONSE_BYTES
+    with pytest.raises(RecursionError):
+        json.loads(bomb)
+
+    exchange = _Exchange(
+        {
+            "info": _json_response(_info_payload()),
+            "generateToken": _stream_response(body=bomb),
+        }
+    )
+    with _install(exchange):
+        resp = await client.post(SIGNIN_URL, json=_body(), headers=admin_auth_header)
+
+    assert resp.status_code == 502
+    assert resp.json()["detail"]["code"] == "network_error"
+    rows = await _audit_rows(test_db_session)
+    assert [row.details["result"] for row in rows] == ["unreadable_response"]
+
+
 async def test_an_oversized_answer_is_not_read_to_the_end(
     client: AsyncClient, admin_auth_header: dict, allow_ssrf, monkeypatch
 ):

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -5003,7 +5003,15 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # The paragraph says which writes go stale and what recovers them, so the
     # next reader does not have to find that out from a broken dataset.
     # Cap 1560 -> 1568, exact.
-    "backend/app/processing/ingest/service.py": 1568,
+    # fix(#1858): +30. Table discovery and registration now read one
+    # expression for "this is an import staging table", where discovery's
+    # `NOT LIKE '%\\_staging'` matched neither shape
+    # `attempt_scoped_staging_table` produces. The lines are the refusal
+    # itself, its bound parameter, and the comment saying why only the
+    # attempt-scoped shape is refused rather than every `_staging`/`_old`
+    # name, since `generate_table_name` can produce those from a title.
+    # Cap 1568 -> 1598, exact.
+    "backend/app/processing/ingest/service.py": 1598,
     # fix(#1738): first entry, crossed _RATCHET_INCLUSION_LOC (842 -> 1019) on
     # the change that gave this task a repair phase. What the growth bought:
     # `geom_4326` on a registered table was written once, at registration, and

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -2694,7 +2694,13 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # a `RecursionError` no caller catches. Most of the lines are the
     # docstring recording why `ValueError` is deliberately left alone.
     # Cap 1015 -> 1048, exact.
-    "backend/app/modules/catalog/sources/adapters/arcgis.py": 1048,
+    # fix(#1858 audit P2-2): +26. Comments only. Four best-effort clauses
+    # here catch `ValueError` and therefore `SSRFError`, and each now says
+    # why a refused hop stays a degrade rather than being raised: the read
+    # establishes one optional fact and the adapter answers without it. The
+    # rule and its converse are stated once at `_fetch_count` and referred to
+    # from the other three. Cap 1048 -> 1074, exact.
+    "backend/app/modules/catalog/sources/adapters/arcgis.py": 1074,
     # feat(#1746 B2b): first explicit entry for this file, which rode the 1500
     # default until the service-auth wave. #1758 added the ArcGIS sign-in
     # endpoint and its rate-limit wiring, and this lane added the credential
@@ -2758,7 +2764,14 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # the two stopped being equivalent when lane C2 taught the builder to
     # compose an ArcGIS header for the httpx transport. Cap 1780 -> 1791,
     # exact.
-    "backend/app/modules/catalog/sources/router.py": 1791,
+    # fix(#1858 audit P2-1): +40. `_refuse_preview` is extracted from
+    # `_run_service_preview_or_refuse` so the ArcGIS preview branch, which
+    # never went through that function, answers a refused redirect hop the
+    # way the WFS and OGC API branches of the same door already do, instead
+    # of reporting `ogrinfo_failed` for a tool that never ran. The extraction
+    # is net-neutral; the lines are the helper's own docstring and the new
+    # clause's comment. Cap 1791 -> 1831, exact.
+    "backend/app/modules/catalog/sources/router.py": 1831,
     # fix(#998): the DDL ported from migration 0019 so tenant-ownership adoption
     # is reachable forward-only at head. Almost all of it is SQL text, and it is
     # one artifact on purpose — the module is reviewed line-by-line against

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -2665,7 +2665,14 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # whichever it is. An earlier revision of this comment asserted the
     # opposite, which is why it now cites the line it was checked against.
     # Cap 1293 -> 1301, exact.
-    "backend/app/modules/catalog/sources/arcgis_signin.py": 1301,
+    # fix(#1858): +11. The capped read's JSON parse also catches
+    # `RecursionError` now (a depth bomb fits inside `_MAX_RESPONSE_BYTES`,
+    # and the decoder gives up on a stack overflow rather than a
+    # `ValueError`), with the arithmetic recorded so nobody re-derives which
+    # of the two bounds actually holds. A duplicated, unreachable copy of the
+    # same try/except is deleted in the same edit, which is why the net is
+    # smaller than the comment. Cap 1301 -> 1312, exact.
+    "backend/app/modules/catalog/sources/arcgis_signin.py": 1312,
     # feat(C2) / fix(#1840): crossed _RATCHET_INCLUSION_LOC when the ArcGIS
     # credential moved out of the request URL and into a header. What the
     # growth bought, in one list: the version gate Esri's own `currentVersion`
@@ -2681,7 +2688,13 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # are the comments carrying the measurements those decisions rest on;
     # without them the next reader re-derives the Esri version encoding and
     # the web-tier case from scratch. Cap set at 1015, exact.
-    "backend/app/modules/catalog/sources/adapters/arcgis.py": 1015,
+    # fix(#1858): +33. `_arcgis_parsed_json` is the one place both of this
+    # module's remote-body parses go through, so a JSON depth bomb becomes
+    # the `EndpointCheckFailedError` every caller already handles instead of
+    # a `RecursionError` no caller catches. Most of the lines are the
+    # docstring recording why `ValueError` is deliberately left alone.
+    # Cap 1015 -> 1048, exact.
+    "backend/app/modules/catalog/sources/adapters/arcgis.py": 1048,
     # feat(#1746 B2b): first explicit entry for this file, which rode the 1500
     # default until the service-auth wave. #1758 added the ArcGIS sign-in
     # endpoint and its rate-limit wiring, and this lane added the credential

--- a/backend/tests/test_services_endpoints.py
+++ b/backend/tests/test_services_endpoints.py
@@ -8,16 +8,37 @@ Requirements:
   - Alembic migrations must be applied
 """
 
+import json
 import uuid
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
 import pytest
 from httpx import AsyncClient
+from sqlalchemy import select
 
+from app.modules.audit.models import AuditLog
 from app.modules.catalog.sources.probe import ServiceNotRecognized
 from app.modules.catalog.sources.schemas import LayerInfo, ProbeResponse
 from app.platform.security import SSRFError, SSRFResolutionError
+
+
+async def _probe_audit_rows(session, url: str) -> list[AuditLog]:
+    """This test's `probe_service` audit rows, oldest first.
+
+    Scoped to the probed URL: one database is shared across every test on an
+    xdist worker, so a query on the action alone would read rows written by
+    tests that ran before this one.
+    """
+    result = await session.execute(
+        select(AuditLog)
+        .where(
+            AuditLog.action == "probe_service",
+            AuditLog.details["url"].astext == url,
+        )
+        .order_by(AuditLog.created_at)
+    )
+    return list(result.scalars().all())
 
 
 # ---------------------------------------------------------------------------
@@ -242,6 +263,60 @@ class TestProbeEndpoint:
 
         assert resp.status_code == 400
         assert redirect_host not in resp.text
+
+    async def test_probe_header_auth_ssrf_is_not_a_credential_refusal(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        mock_validate_ssrf,
+        test_db_session,
+    ) -> None:
+        """fix(#1858, `sources/probe.py::_header_auth_probe`).
+
+        `SSRFError` subclasses `ValueError`, and the two header-auth adapters
+        catch only httpx and endpoint-check failures, so a refused redirect
+        hop reached `_header_auth_probe`'s `except ValueError` and was
+        recorded as a credential refusal. This probe carries NO credential at
+        all, so the old answer -- 422 `invalid_service_token` -- was untrue
+        twice over, and `SSRFResolutionError`'s message put the
+        redirect-chosen hostname into both the response body and the
+        persisted audit reason, which is what the fixed `ssrf_policy_message`
+        one clause below exists to prevent.
+        """
+        redirect_host = "sec6-redirect-chosen-target.invalid"
+        probe_url = "https://sec6-header-auth.example.com/service"
+        with (
+            patch(
+                "app.modules.catalog.sources.probe.probe_ogcapi",
+                new_callable=AsyncMock,
+                side_effect=SSRFResolutionError(
+                    f"Could not resolve hostname: {redirect_host}"
+                ),
+            ),
+            patch(
+                "app.modules.catalog.sources.probe.probe_wfs",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+            patch(
+                "app.modules.catalog.sources.probe.probe_arcgis_service",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+        ):
+            resp = await client.post(
+                "/services/probe/",
+                json={"url": probe_url},
+                headers=admin_auth_header,
+            )
+
+        assert resp.status_code == 400
+        assert resp.json()["detail"] == "redirect target refused by SSRF policy"
+        assert redirect_host not in resp.text
+
+        rows = await _probe_audit_rows(test_db_session, probe_url)
+        assert [row.details["result"] for row in rows] == ["ssrf_blocked"]
+        assert redirect_host not in json.dumps(rows[0].details)
 
     async def test_probe_timeout(
         self,

--- a/backend/tests/test_services_endpoints.py
+++ b/backend/tests/test_services_endpoints.py
@@ -334,6 +334,80 @@ class TestProbeEndpoint:
         assert [row.details["result"] for row in rows] == ["ssrf_blocked"]
         assert redirect_host not in json.dumps(rows[0].details)
 
+    async def test_probe_ogcapi_collections_ssrf_reaches_the_door(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        mock_validate_ssrf,
+        test_db_session,
+    ) -> None:
+        """fix(#1858 audit P2-2, `adapters/ogcapi.py` `/collections` step).
+
+        That clause caught `SSRFError` and returned None, which is
+        `probe_ogcapi` saying "not an OGC API service". The probe then tried
+        WFS and ArcGIS against the same refused origin and the door answered
+        `ServiceNotRecognized`, so a blocked redirect on the collections
+        listing was indistinguishable from a URL that is simply not a
+        service. The clause ends the adapter either way, so re-raising costs
+        nothing and is the only truthful answer available.
+        """
+        redirect_host = "sec6-collections-redirect-target.invalid"
+        probe_url = "https://sec6-oapif.example.com/service"
+        landing = json.dumps(
+            {
+                "conformsTo": [
+                    "http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/core"
+                ]
+            }
+        ).encode()
+
+        async def _read(_client, url, **_kwargs):
+            if url.endswith("/collections"):
+                raise SSRFResolutionError(
+                    f"Could not resolve hostname: {redirect_host}"
+                )
+            return landing, url
+
+        with (
+            patch(
+                "app.modules.catalog.sources.adapters.ogcapi.bounded_probe_read",
+                new=_read,
+            ),
+            patch(
+                "app.modules.catalog.sources.adapters.ogcapi.validate_url_for_ssrf",
+                new_callable=AsyncMock,
+            ),
+            # The two sibling adapters are silenced so this clause is the ONLY
+            # thing in the run that can raise `SSRFError`. Without that they
+            # reach the network with a hostname that does not resolve, the
+            # guard transport raises `SSRFResolutionError` of its own, and the
+            # door answers 400 whether or not the clause under test re-raises
+            # -- a test that passes on its own counterfactual.
+            patch(
+                "app.modules.catalog.sources.probe.probe_wfs",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+            patch(
+                "app.modules.catalog.sources.probe.probe_arcgis_service",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+        ):
+            resp = await client.post(
+                "/services/probe/",
+                json={"url": probe_url},
+                headers=admin_auth_header,
+            )
+
+        assert resp.status_code == 400, resp.text
+        assert resp.json()["detail"] == "redirect target refused by SSRF policy"
+        assert redirect_host not in resp.text
+
+        rows = await _probe_audit_rows(test_db_session, probe_url)
+        assert [row.details["result"] for row in rows] == ["ssrf_blocked"]
+        assert redirect_host not in json.dumps(rows[0].details)
+
     async def test_probe_timeout(
         self,
         client: AsyncClient,
@@ -914,6 +988,98 @@ class TestPreviewEndpoint:
         assert len(data["sample_rows"]) == 2
         # ArcGIS responses surface attributes (not GeoJSON properties).
         assert data["sample_rows"][0]["title"] == "Bulletin A"
+
+    async def test_preview_arcgis_ssrf_is_not_an_ogrinfo_failure(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        mock_validate_ssrf,
+        test_db_session,
+    ):
+        """fix(#1858 audit P2-1, `sources/router.py` ArcGIS preview branch).
+
+        `fetch_arcgis_layer_preview`'s metadata read has no local `except`, so
+        an `SSRFError` from the redirect revalidation hook or the guard
+        transport reached the branch's `except (..., ValueError, ...)` tuple
+        and became `_fail_preview`'s 502 `ogrinfo_failed` -- naming a tool
+        that never ran. The WFS and OGC API branches of the SAME door answer
+        that event as a 400 with the fixed policy string, so one event was
+        classified two ways depending on which adapter met it, and an
+        operator grepping for blocked-redirect events saw neither.
+        """
+        redirect_host = "sec6-preview-redirect-target.invalid"
+        preview_url = (
+            "https://sec6-preview-ssrf.example.com/arcgis/rest/services/X/FeatureServer"
+        )
+
+        async def _refuse(*_args, **_kwargs):
+            raise SSRFResolutionError(f"Could not resolve hostname: {redirect_host}")
+
+        with patch(
+            "app.modules.catalog.sources.adapters.arcgis.bounded_probe_read",
+            new=_refuse,
+        ):
+            resp = await client.post(
+                "/services/preview/",
+                json={
+                    "url": preview_url,
+                    "service_type": "ArcGIS FeatureServer",
+                    "layer_name": "0",
+                    "layer_id": 0,
+                },
+                headers=admin_auth_header,
+            )
+
+        assert resp.status_code == 400, resp.text
+        assert resp.json()["detail"] == "redirect target refused by SSRF policy"
+        assert redirect_host not in resp.text
+
+        rows = await _preview_audit_rows(test_db_session, preview_url)
+        assert [row.details["result"] for row in rows] == ["refused"]
+        assert rows[0].details["reason_class"] == "SSRFResolutionError"
+        assert redirect_host not in json.dumps(rows[0].details)
+
+    async def test_preview_wfs_ssrf_answers_the_same_way(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        mock_validate_ssrf,
+        mock_build_gdal_source,
+        test_db_session,
+    ):
+        """The other half of the door, pinned beside it.
+
+        Without this the test above could pass for a door that had started
+        answering 400 for everything. Both branches now reach one helper, so
+        the status, the message and the audit row are identical.
+        """
+        redirect_host = "sec6-wfs-redirect-target.invalid"
+        preview_url = "https://sec6-preview-wfs.example.com/wfs"
+
+        with patch(
+            "app.modules.catalog.sources.router.run_service_preview",
+            new_callable=AsyncMock,
+            side_effect=SSRFResolutionError(
+                f"Could not resolve hostname: {redirect_host}"
+            ),
+        ):
+            resp = await client.post(
+                "/services/preview/",
+                json={
+                    "url": preview_url,
+                    "service_type": "WFS 2.0.0",
+                    "layer_name": "buildings",
+                },
+                headers=admin_auth_header,
+            )
+
+        assert resp.status_code == 400, resp.text
+        assert resp.json()["detail"] == "redirect target refused by SSRF policy"
+        assert redirect_host not in resp.text
+
+        rows = await _preview_audit_rows(test_db_session, preview_url)
+        assert [row.details["result"] for row in rows] == ["refused"]
+        assert rows[0].details["reason_class"] == "SSRFResolutionError"
 
     async def test_preview_arcgis_json_depth_bomb_is_coded_not_a_crash(
         self,

--- a/backend/tests/test_services_endpoints.py
+++ b/backend/tests/test_services_endpoints.py
@@ -23,6 +23,22 @@ from app.modules.catalog.sources.schemas import LayerInfo, ProbeResponse
 from app.platform.security import SSRFError, SSRFResolutionError
 
 
+async def _preview_audit_rows(session, url: str) -> list[AuditLog]:
+    """This test's `preview_service_layer` audit rows, oldest first.
+
+    Scoped to the previewed URL for the same reason as `_probe_audit_rows`.
+    """
+    result = await session.execute(
+        select(AuditLog)
+        .where(
+            AuditLog.action == "preview_service_layer",
+            AuditLog.details["url"].astext == url,
+        )
+        .order_by(AuditLog.created_at)
+    )
+    return list(result.scalars().all())
+
+
 async def _probe_audit_rows(session, url: str) -> list[AuditLog]:
     """This test's `probe_service` audit rows, oldest first.
 
@@ -898,6 +914,50 @@ class TestPreviewEndpoint:
         assert len(data["sample_rows"]) == 2
         # ArcGIS responses surface attributes (not GeoJSON properties).
         assert data["sample_rows"][0]["title"] == "Bulletin A"
+
+    async def test_preview_arcgis_json_depth_bomb_is_coded_not_a_crash(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        mock_validate_ssrf,
+        test_db_session,
+    ):
+        """fix(#1858, backend audit 2026-09-04 P2-2).
+
+        `read_arcgis_json` parsed the layer metadata document with a bare
+        `json.loads`. A balanced nesting 300,000 deep is a ~600 KB body, so it
+        clears every byte and structural-token bound the read applies, and
+        `json.loads` answers `RecursionError` -- a `RuntimeError`, caught by
+        neither this door's except chain nor the adapter's. The preview
+        answered 500 and wrote no audit row, contradicting the handler
+        docstring's promise that every attempt is audit-logged.
+        """
+        bomb = b"[" * 300_000 + b"]" * 300_000
+        preview_url = (
+            "https://sec6-bomb.example.com/arcgis/rest/services/X/FeatureServer"
+        )
+
+        async def _bomb_read(_client, url, **_kwargs):
+            return bomb, url
+
+        with patch(
+            "app.modules.catalog.sources.adapters.arcgis.bounded_probe_read",
+            new=_bomb_read,
+        ):
+            resp = await client.post(
+                "/services/preview/",
+                json={
+                    "url": preview_url,
+                    "service_type": "ArcGIS FeatureServer",
+                    "layer_name": "0",
+                    "layer_id": 0,
+                },
+                headers=admin_auth_header,
+            )
+
+        assert resp.status_code == 502, resp.text
+        rows = await _preview_audit_rows(test_db_session, preview_url)
+        assert [row.details["result"] for row in rows] == ["ogrinfo_failed"]
 
     async def test_preview_arcgis_persists_normalized_layer(
         self,

--- a/backend/tests/test_source_health_1222.py
+++ b/backend/tests/test_source_health_1222.py
@@ -1151,6 +1151,73 @@ class TestArcgisAuthEnvelope:
         assert dataset.source_health_detail == AUTH_REQUIRED
 
 
+class TestAJsonDepthBombIsAVerdictNotACrash:
+    """fix(#1858, backend audit 2026-09-04 P2-2).
+
+    A balanced nesting 300,000 deep costs two bytes a level, so the document
+    is ~600 KB and passes ``fetch_json_document``'s own 2 MiB cap with room to
+    spare. ``json.loads`` answers ``RecursionError``, a ``RuntimeError``
+    subclass, so it was caught neither by the parse's ``except ValueError``
+    nor by the broad transport handler above it, which has already returned by
+    the time the parse runs. ``POST /datasets/{id}/source-health/`` answered
+    500 and wrote neither a verdict nor ``last_checked_at``, which is the one
+    thing an operator most needs dated after a failed probe.
+    """
+
+    _BOMB = b"[" * 300_000 + b"]" * 300_000
+
+    def _bomb_handler(self, _request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, content=self._BOMB)
+
+    def test_the_premise(self) -> None:
+        """The bomb is under the cap, and the decoder does raise on it.
+
+        Without this, a future Python whose decoder stops recursing would let
+        the two tests below pass while exercising nothing.
+        """
+        assert len(self._BOMB) < MAX_DOCUMENT_BYTES
+        with pytest.raises(RecursionError):
+            json.loads(self._BOMB)
+
+    async def test_the_document_read_reports_unexpected_status(
+        self, probe_transport
+    ) -> None:
+        install, _ = probe_transport
+        install(self._bomb_handler)
+
+        result, body, _url = await fetch_json_document(_ITEM)
+
+        assert result.health == INACCESSIBLE
+        assert result.detail == UNEXPECTED_STATUS
+        assert result.detail in DETAIL_CODES
+        assert body is None
+        # Not the oversized signal: this body fits, it just cannot be read.
+        assert result.oversized is False
+
+    async def test_end_to_end_the_health_door_persists_a_verdict(
+        self, client, admin_auth_header, test_db_session, probe_transport
+    ) -> None:
+        install, _ = probe_transport
+        install(self._bomb_handler)
+        admin_id = await get_user_id(test_db_session, "admin")
+        dataset = await _service_dataset(test_db_session, created_by=admin_id)
+
+        resp = await client.post(
+            f"/datasets/{dataset.id}/source-health/", headers=admin_auth_header
+        )
+
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["source_health"] == INACCESSIBLE
+        assert body["source_health_detail"] == UNEXPECTED_STATUS
+
+        await test_db_session.refresh(dataset)
+        assert dataset.source_health == INACCESSIBLE
+        assert dataset.source_health_detail in DETAIL_CODES
+        # The origin answered, so the contact clock is stamped.
+        assert dataset.last_checked_at is not None
+
+
 class TestServiceOriginProbe:
     async def test_reachable_service_endpoint_is_healthy(
         self, client, admin_auth_header, test_db_session, probe_transport

--- a/backend/tests/test_staging_table_names_1858.py
+++ b/backend/tests/test_staging_table_names_1858.py
@@ -1,0 +1,169 @@
+"""fix(#1858): attempt-scoped staging tables are hidden and unregisterable.
+
+``attempt_scoped_staging_table`` (``platform/jobs/heartbeat.py``) produces
+``<base>_staging_<32 hex>``. Table discovery excluded ``%_staging`` and
+``%_old``, and neither pattern matches that name, so a staging table left
+behind by a worker killed between ``run_ogr2ogr`` and the swap was listed by
+``GET /ingest/discover/`` and registerable through
+``POST /ingest/register/bulk/`` as a permanent dataset. Nothing reaps such a
+table: the sweeps in ``platform/jobs/sweep.py`` cover storage objects,
+analysis outputs and VRT generations, and none of them looks at PostGIS
+tables. Reaping orphans is deliberately out of scope here; hiding and refusing
+them is what this pins.
+
+The predicate is one POSIX regular expression evaluated by two engines --
+PostgreSQL's ``~`` in the discovery query, Python's ``re`` in the registration
+refusal -- so the first test checks the two against each other rather than
+trusting that they agree.
+"""
+
+import uuid as _uuid
+from types import SimpleNamespace
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.platform.jobs.heartbeat import (
+    ATTEMPT_STAGING_NAME_PATTERN,
+    attempt_scoped_staging_table,
+    is_attempt_scoped_staging_table,
+)
+from tests.factories import get_user_id
+
+pytestmark = pytest.mark.anyio
+
+
+# The producer's own output, plus the names that must stay registerable.
+# `generate_table_name` slugifies a user-chosen title, so every entry below
+# with `expected=False` is a name an operator can legitimately ask for.
+_NAMES: list[tuple[str, bool]] = [
+    ("parcels", False),
+    ("parcels_staging", False),
+    ("parcels_old", False),
+    ("parcels_staging_area", False),
+    ("staging", False),
+    # Right shape, wrong length: 31 and 33 hex characters.
+    ("parcels_staging_" + "a" * 31, False),
+    ("parcels_staging_" + "a" * 33, False),
+    # Right length, not hexadecimal.
+    ("parcels_staging_" + "z" * 32, False),
+    ("parcels_staging_03ff872f1a2b4c5d8e9f0a1b2c3d4e5f", True),
+    ("_staging_03ff872f1a2b4c5d8e9f0a1b2c3d4e5f", True),
+]
+
+
+def test_the_producer_and_the_recognizer_agree() -> None:
+    """Whatever the producer makes, the recognizer knows.
+
+    The two live next to each other for this reason: a change to the suffix
+    that did not reach the pattern would silently reopen the hole, and this is
+    the assertion that would not survive it.
+    """
+    for base in ("parcels", "a", "x" * 80):
+        name = attempt_scoped_staging_table(base, _uuid.uuid4())
+        assert is_attempt_scoped_staging_table(name), name
+        assert len(name) <= 63
+
+
+@pytest.mark.parametrize(("name", "expected"), _NAMES)
+def test_python_reads_the_pattern_as_intended(name: str, expected: bool) -> None:
+    assert is_attempt_scoped_staging_table(name) is expected
+
+
+async def test_postgres_reads_the_pattern_the_same_way(
+    test_db_session: AsyncSession,
+) -> None:
+    """The discovery query evaluates the pattern; the refusal evaluates it in
+    Python. One string, two engines, and nothing else checks that they agree.
+
+    This is also the measurement the audit made against the live database: the
+    old ``NOT LIKE '%\\_staging'`` predicate answered "keep" for
+    ``parcels_staging_03ff872f...``.
+    """
+    for name, expected in _NAMES:
+        matched = await test_db_session.scalar(
+            text("SELECT :name ~ :pattern").bindparams(
+                name=name, pattern=ATTEMPT_STAGING_NAME_PATTERN
+            )
+        )
+        assert matched is expected, name
+
+
+async def test_discovery_omits_a_leaked_staging_table(
+    test_db_session: AsyncSession,
+) -> None:
+    """The failure the audit found: a leaked staging table offered for import.
+
+    A sibling ordinary table is created alongside it and asserted present, so
+    a discovery call that returned nothing at all cannot pass this.
+    """
+    from app.processing.ingest.service import discover_unregistered_tables
+
+    prefix = f"sec6_{_uuid.uuid4().hex[:8]}"
+    ordinary = f"{prefix}_parcels"
+    leaked = attempt_scoped_staging_table(ordinary, _uuid.uuid4())
+
+    for table in (ordinary, leaked):
+        await test_db_session.execute(
+            text(f'CREATE TABLE data."{table}" (gid serial PRIMARY KEY, name text)')
+        )
+    await test_db_session.commit()
+
+    try:
+        found = {
+            table.table_name
+            for table in await discover_unregistered_tables(test_db_session, limit=5000)
+        }
+        assert ordinary in found
+        assert leaked not in found
+    finally:
+        await test_db_session.rollback()
+        for table in (ordinary, leaked):
+            await test_db_session.execute(
+                text(f'DROP TABLE IF EXISTS data."{table}" CASCADE')
+            )
+        await test_db_session.commit()
+
+
+async def test_registration_refuses_a_staging_table(
+    test_db_session: AsyncSession,
+) -> None:
+    """Hiding one was never the same as refusing it.
+
+    ``POST /ingest/register/bulk/`` takes the table name from the caller, so
+    the discovery filter never stood between a leaked staging table and a
+    permanent dataset bound to it.
+    """
+    from app.processing.ingest.schemas import RegisterRequest
+    from app.processing.ingest.service import register_existing_table
+
+    admin_id = await get_user_id(test_db_session, "admin")
+    leaked = attempt_scoped_staging_table(
+        f"sec6_{_uuid.uuid4().hex[:8]}_parcels", _uuid.uuid4()
+    )
+
+    await test_db_session.execute(
+        text(f'CREATE TABLE data."{leaked}" (gid serial PRIMARY KEY, name text)')
+    )
+    await test_db_session.commit()
+
+    try:
+        with pytest.raises(ValueError) as excinfo:
+            await register_existing_table(
+                test_db_session,
+                RegisterRequest(table_name=leaked, title="Leaked Staging"),
+                SimpleNamespace(id=admin_id),
+            )
+
+        message = str(excinfo.value)
+        # The name has to be in it: an operator looking at a list of tables
+        # needs to know which one was refused.
+        assert leaked in message
+        assert "staging" in message
+    finally:
+        await test_db_session.rollback()
+        await test_db_session.execute(
+            text(f'DROP TABLE IF EXISTS data."{leaked}" CASCADE')
+        )
+        await test_db_session.commit()


### PR DESCRIPTION
Three findings from the codebase audit 2026-09-04 (security P2-9, backend P2-1, P2-2, P2-3), all in the service-import surface, one commit each, all reproduced on `origin/main` at cd9567fde before anything was changed. A fourth commit answers a pre-trigger audit of this PR, which found the first commit's classification fix left standing on two sibling paths.

## 1. A mid-probe SSRF refusal came back as a bad credential

`_header_auth_probe` in `backend/app/modules/catalog/sources/probe.py` caught a bare `ValueError` to record "this credential cannot become a header". `SSRFError` subclasses `ValueError`, `SSRFResolutionError` subclasses that, and the two header-auth adapters catch only `httpx.HTTPStatusError`, `httpx.TransportError` and `EndpointCheckFailedError`. A redirect hop refused by the per-hop revalidation hook, or an address refused by the guard transport at connect time, landed in the credential clause.

Measured on main, with no credential in the request at all:

```
POST /api/services/probe
-> 422 {"code":"invalid_service_token",
        "message":"Could not resolve hostname: sec6-redirect-chosen-target.invalid"}
```

Three answers wrong at once. The caller sent no token and was told the token was invalid. The hostname in that message is chosen by the service, through its own `Location` header, and it reached both the response body and the persisted audit reason, which is what the fixed policy string in the door's `except SSRFError` was written to stop. And that handler, which answers 400 `ssrf_blocked` and writes the matching audit row, was dead for two of the three adapters, so one event was classified two ways depending on which adapter met it. The SSRF itself was blocked throughout.

Fix: `except SSRFError: raise` ahead of the `except ValueError`, the clause `probe_arcgis_service` already carries from #1840 for the same subclass-ordering reason. After the fix the same request answers 400, `redirect target refused by SSRF policy`, one `ssrf_blocked` audit row, and the hostname appears in neither.

The first sweep grepped for a bare `except ValueError:` and so missed the clauses that name `ValueError` inside a tuple, where two more of these were sitting. Those are commit 4, below. The surface was then re-swept by walking every `ExceptHandler` node in the eleven service-import modules; the script is not committed, but the result is the table.

| Site | Verdict |
| --- | --- |
| `probe.py` `_header_auth_probe` | fixed here |
| `sources/router.py:1362` ArcGIS preview | fixed in commit 4 |
| `adapters/ogcapi.py` `/collections` | fixed in commit 4 |
| `adapters/arcgis.py:699/845/1005/1027`, `adapters/ogcapi.py` `_resolve_conformance` | deliberate degrades, documented in commit 4 |
| `adapters/arcgis.py:527` | already `except SSRFError: raise` (#1840) |
| `adapters/arcgis.py:317/556` | pure credential building, and the clause after the #1840 re-raise |
| `preview.py:524` | parses subprocess output, no network call in the `try` |
| `origin_probe.py:305` | wraps a pure URL builder |
| `origin_probe.py:257/474/489` | the two broad transport handlers classify SSRF explicitly through `_classify_failure`; the third parses an already-fetched body |
| `sources/router.py:608/955/1041/1200` | name `SSRFError` explicitly |
| `sources/router.py:272/286/543/1306` | pure validation and type resolution |
| `sources/router.py:351/431` | connector extension paths, outside the probe surface. The detail is a fixed string, so nothing is reflected |
| `sources/router.py:1406/1469` | wraps `build_gdal_source` (pure) and `_run_service_preview_or_refuse`, which raises `HTTPException`. `_preview_refusal_response` orders `SSRFError` first |
| `arcgis_signin.py` (nine clauses) | URL and payload parsing with no network read, plus four that name `SSRFError` or `SSRFResolutionError` explicitly and one ordered after them with a comment saying why |
| `adapters/stac.py:164`, `adapters/wfs.py` | pure URL resolution; `wfs.py` has no such clause |
| `datasets/api/router_refresh.py` | two `except SSRFError` clauses, no `ValueError` clause |

## 2. Three remote-JSON reads had no depth-bomb guard

`_parsed_json` in `platform/service_endpoints.py` was written for a JSON depth bomb in #1770 round 44, and `platform/service_items.py` and `sources/router.py` adopted the same shape on their own reads. Three reads on caller-reachable bodies never did.

A balanced nesting costs two bytes a level, so 300,000 levels is a 600 KB document. `structural_tokens` counts brackets rather than nesting depth, so it cannot see this shape, and the byte caps are orders of magnitude higher. `json.loads` answers `RecursionError`, a `RuntimeError`, caught by no `except ValueError` on these paths.

- `read_arcgis_json` and its query-form fallback now parse through `_arcgis_parsed_json`, which reports the bomb as the `EndpointCheckFailedError` that `bounded_probe_read` already raises out of the same two calls, so every caller was written for it. `ValueError` is deliberately left alone: it is part of the published contract and rewriting it would change the coded outcome of an ordinary unparseable response. `/services/preview` answered 500 with no audit row before this, contradicting the handler docstring's promise that every attempt is audit-logged.
- `fetch_json_document` in `sources/origin_probe.py` reports `unexpected_status`, the verdict a body that is not JSON already gets. `POST /datasets/{id}/source-health/` answered 500 and wrote neither the verdict nor `last_checked_at`.
- The capped read in `sources/arcgis_signin.py` records `unreadable_response`. Without it the error reached the broad transport handler, which recorded `unreachable`, a fact about the network, for a portal that answered with a document. The byte cap does not bound this shape: the deepest document that fits inside `_MAX_RESPONSE_BYTES` is about 131,000 levels and the decoder gives up around 120,000. A duplicated, unreachable copy of that same try/except, present since #1758, is deleted in the same edit.

`read_arcgis_json`'s docstring claimed every caller handled both exceptions it raised, which stopped being true once `RecursionError` became reachable. Corrected.

Every `json.loads` on a remote body in `backend/app` was checked. The rest were already covered: `service_endpoints.py:1139`, `service_items.py:483` and `sources/router.py:607` name `RecursionError` explicitly; `adapters/stac.py:266` and the three sites in `adapters/ogcapi.py` sit under broad `except Exception` degrades. The remaining `json.loads` calls on this surface parse ogrinfo's own stdout rather than a remote body; GDAL's decoder is the first bound there and no guard was added.

## 3. Attempt-scoped staging tables were discoverable and registerable

`attempt_scoped_staging_table` produces `<base>_staging_<32 hex>`. Discovery excluded `%_staging` and `%_old`, and that name ends in neither. Confirmed against Postgres: the old predicate answers "keep" for `parcels_staging_03ff872f...`.

A staging table is created inside an import and dropped in its `finally`, so one only survives a worker killed between the two. Nothing reaps the survivor. The sweeps in `platform/jobs/sweep.py` cover storage objects, analysis outputs and VRT generations, and none looks at PostGIS tables. `GET /ingest/discover/` therefore listed the leaked table, its own docstring saying it excludes staging tables, and `POST /ingest/register/bulk/` bound a permanent dataset to it. A non-spatial staging table registered outright; a spatial one was refused by the geometry-column check from #1737, which is luck rather than design. A registration racing a live import binds a dataset to a table the worker is about to rename away.

The pattern lives beside the producer in `platform/jobs/heartbeat.py`, written once as a POSIX regular expression because PostgreSQL's operator and Python's `re` agree on this subset. Discovery binds it as a parameter, registration runs it on the name before touching the database.

Only the attempt-scoped shape is refused. `generate_table_name` slugifies a user-chosen title, so `parcels_staging`, `parcels_old` and `parcels_staging_area` are names an operator can legitimately ask for, and the analysis materialize path registers through this same function. A wider predicate would refuse those.

Reaping orphaned staging tables is out of scope. Nothing here drops a table.

## 4. The same split, still standing on two sibling paths

Found by an adversarial audit of this PR at 17ea6455b, not by the 09-04 audit.

`/services/preview`, ArcGIS branch. `fetch_arcgis_layer_preview`'s metadata read has no local handler, so an `SSRFError` reached the branch's `except (httpx.HTTPError, ValueError, EndpointCheckFailedError, TimeoutError)` tuple and came out as `_fail_preview`'s 502 `ogrinfo_failed`, naming a tool that never ran. The WFS and OGC API branches of the same door answer that event as a 400 with the fixed policy string, so it was the finding from section 1 exactly, on a door section 1 did not touch. The audit-and-raise half of `_run_service_preview_or_refuse` is extracted as `_refuse_preview` and both branches call it, so the status, the message and the audit row are composed once. The row records the exception class name and never its message, which is what keeps `SSRFResolutionError`'s redirect-chosen hostname out of the database.

`probe_ogcapi`'s `/collections` step caught `SSRFError` and returned None, which is the adapter saying "not an OGC API service". The probe then tried WFS and ArcGIS against the same refused origin and the door answered `ServiceNotRecognized`. That clause ends the adapter either way, so it re-raises now.

Five sibling clauses catch `ValueError` and therefore `SSRFError` and keep their degrade, each saying so where it sits. The rule, stated at `_fetch_count` and referred to from the rest: a refusal on a read whose failure means one optional fact is unknown stays a degrade; a refusal on a read whose failure ends the adapter is raised. A per-layer feature count, pagination support, preview sample rows, a preview row count and an advertised conformance href are all optional facts, and raising on the last would let any service make itself undetectable by advertising a blocked conformance link.

One process note worth recording. The first cut of the `/collections` test passed on its own counterfactual: with the OGC API adapter stubbed, the two sibling adapters reached the network with a hostname that does not resolve and produced an `SSRFError` of their own, so the door answered 400 either way. They are stubbed now, and the counterfactual answers "Couldn't detect service type".

## Schema, API and config impact

None. No migration, no request or response schema change, no new setting. `scripts/dump_openapi.py --check` exits 0, so no snapshot or SDK regeneration is needed. No credential, token or provider-chosen hostname is logged or persisted anywhere in this change.

## Verification

Run from the worktree against Postgres on localhost:5434.

```
tests/test_services_endpoints.py                 51 passed
tests/test_arcgis_header_transport_c2.py         98 passed
tests/test_probe_classification.py               25 passed
tests/test_source_health_1222.py                101 passed
tests/test_arcgis_signin.py                     178 passed
tests/test_staging_table_names_1858.py           14 passed
tests/test_service_auth_transport_1746.py       374 passed
tests/test_arcgis_auth.py                        38 passed
tests/test_preview_token_sec021.py               12 passed
tests/test_stac_import.py                        30 passed
tests/test_register_geom_column_name_1737.py      2 passed
tests/test_registered_delete_detach_1452.py      30 passed
tests/test_analysis_materialize.py               99 passed
tests/test_reupload.py                           44 passed
tests/test_ingest.py                             45 passed
tests/test_credential_producer_structural.py     36 passed
tests/test_codeql_qtable_suppressions.py          9 passed
tests/test_layering.py                           50 passed
tests/test_rule1_structural.py                    6 passed
tests/test_rule2_structural.py                  102 passed
ruff check .                                    All checks passed
ruff format --check .                           1166 files already formatted
scripts/dump_openapi.py --check                 exit 0
```

Counterfactuals, each run by reverting only that change:

- Item 1: the probe answers 422 `invalid_service_token` with the redirect-chosen hostname in the body.
- Item 2: an uncaught `RecursionError` at both ArcGIS parse sites, a 500 from the source-health door, and `unreachable` instead of `unreadable_response` at the sign-in door.
- Item 3: discovery lists the leaked staging table and registration does not raise.
- Item 4: the ArcGIS preview answers 502 `"Failed to preview remote layer"` with an `ogrinfo_failed` audit row, and the OGC API probe answers `"Couldn't detect service type"`. The WFS preview test passes without the change, which is what makes it the positive control for the ArcGIS one.

Every new test pins its own premise as well as the behaviour, so a future Python whose decoder stops recursing, or a cap that starts catching the bomb, fails on the premise rather than passing while exercising nothing.

Caps re-measured with `wc -l` and set to the exact figure: `adapters/arcgis.py` 1015 to 1074, `arcgis_signin.py` 1301 to 1312, `processing/ingest/service.py` 1568 to 1598, `sources/router.py` 1791 to 1831.
