### PR TITLE
fix(auth): route every OAuth request through the SSRF-safe transport

### DIFF
--- a/backend/app/modules/auth/oauth/router.py
+++ b/backend/app/modules/auth/oauth/router.py
@@ -136,6 +136,23 @@ def _endpoint_refused(
     )
 
 
+def _loggable_hostname(url: str) -> str | None:
+    """The hostname for the operator log, or None when the URL will not parse.
+
+    fix(#1861 codex r1): the refusal path must not raise. urlparse rejects a
+    malformed authority such as ``http://[invalid/token`` with ValueError, so
+    validate_url_for_ssrf never reaches its own checks and the refusal branch
+    receives exactly the string that cannot be parsed. Parsing it a second time
+    there raised inside the handler, replacing the sanitized 503 with an
+    unhandled 500 on an unauthenticated route. None reads as unparseable in the
+    log line, and error_type carries the reason.
+    """
+    try:
+        return urlparse(url).hostname
+    except ValueError:
+        return None
+
+
 async def _validate_discovery_endpoints(
     provider_slug: str, metadata: dict[str, object]
 ) -> None:
@@ -150,9 +167,10 @@ async def _validate_discovery_endpoints(
             await validate_url_for_ssrf(url)
         except ValueError as exc:
             # SSRFError and SSRFResolutionError are both ValueError, which is
-            # also what the row-level check raises.
+            # also what the row-level check raises, and so is the plain
+            # ValueError urlparse raises on a malformed authority.
             raise _endpoint_refused(
-                provider_slug, exc, endpoint=key, host=urlparse(url).hostname
+                provider_slug, exc, endpoint=key, host=_loggable_hostname(url)
             ) from exc
 
 

--- a/backend/app/modules/auth/oauth/router.py
+++ b/backend/app/modules/auth/oauth/router.py
@@ -1,8 +1,10 @@
 """OAuth/OIDC flow endpoints: login redirect, callback, and public provider list."""
 
 import uuid
+from urllib.parse import urlparse
 
 import structlog
+from authlib.integrations.httpx_client import AsyncOAuth2Client
 from authlib.integrations.starlette_client import OAuth
 from authlib.integrations.starlette_client.apps import StarletteOAuth2App
 from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
@@ -41,16 +43,147 @@ logger = structlog.stdlib.get_logger(__name__)
 router = APIRouter(prefix="/auth/oauth", tags=["Auth"], responses=ERROR_RESPONSES_AUTH)
 
 
-class _SSRFSafeOAuth2App(StarletteOAuth2App):
-    """Create a fresh IP-pinning transport for each Authlib HTTP session."""
+class _SSRFSafeOAuth2Client(AsyncOAuth2Client):
+    """Authlib's HTTP client, with the transport decided here and not by a caller.
 
-    def _get_session(self):
+    fix(#1861): the app class below installed the IP-pinning transport in
+    ``_get_session`` alone. In authlib 1.7.2 that hook serves discovery
+    (``base_client/async_app.py:78``) and JWKS
+    (``base_client/async_openid.py:25``); the token exchange
+    (``async_app.py:126``) and the userinfo fetch (``async_app.py:90``, reached
+    from ``async_openid.py:36``) build their client through
+    ``_get_oauth_client`` (``base_client/sync_app.py:236``), which returned a
+    stock httpx transport. Those two requests are the ones carrying the client
+    secret and the access token. All four hooks construct ``self.client_cls``,
+    so this is the single place that reaches every one of them.
+
+    ``_get_oauth_client`` also merges the discovery document into the httpx
+    client kwargs (``sync_app.py:239``, ``client_kwargs.update(metadata)``), so
+    a document carrying a ``transport``, ``mounts``, ``proxy``, ``verify`` or
+    ``follow_redirects`` key would otherwise be choosing the transport security
+    of the request that carries the secret. They are set here, after that
+    merge; ``verify`` and ``cert`` need no entry because httpx reads them only
+    when it builds the transport itself.
+    """
+
+    def __init__(self, *args, **kwargs):
         from app.platform.security import make_safe_transport
 
-        client_kwargs = {**self.client_kwargs, "transport": make_safe_transport()}
-        session = self.client_cls(**client_kwargs)
-        session.headers["User-Agent"] = self._user_agent
-        return session
+        kwargs["transport"] = make_safe_transport()
+        # httpx consults a per-scheme mount before ``transport``, and builds
+        # one from ``proxy``. Both are part of pinning the transport rather
+        # than separate rules, and an empty ``mounts`` does not clear what
+        # ``proxy`` added, so both are set. Passing a transport at all already
+        # stops httpx reading proxies from the environment
+        # (``_client.py``: ``allow_env_proxies = trust_env and transport is None``),
+        # which is why an operator's proxy configuration is unaffected.
+        kwargs["mounts"] = {}
+        kwargs["proxy"] = None
+        # httpx's own default, pinned so that it stays the default: nothing
+        # here follows a redirect, so neither the client secret nor the access
+        # token can cross an origin behind a 302. That is the strongest form of
+        # the rule ``_ALWAYS_CREDENTIAL_HEADERS`` in platform/security.py
+        # applies to the hops that do happen.
+        kwargs["follow_redirects"] = False
+        super().__init__(*args, **kwargs)
+
+
+# The endpoints authlib reads out of a discovery document and then fetches:
+# ``token_endpoint`` (async_app.py:125), ``userinfo_endpoint``
+# (async_openid.py:36), ``jwks_uri`` (async_openid.py:21) and
+# ``authorization_endpoint`` (async_app.py:101, which is handed to the
+# browser). A provider configured by discovery URL leaves the matching columns
+# empty on its row, so validate_provider_server_endpoints never sees the
+# address a request actually goes to. This list stays matched to the calls that
+# exist: refusing a login over an endpoint nothing fetches is a false refusal
+# rather than a defence.
+_DISCOVERY_ENDPOINT_KEYS = (
+    "authorization_endpoint",
+    "token_endpoint",
+    "userinfo_endpoint",
+    "jwks_uri",
+)
+
+_ENDPOINT_REFUSED_DETAIL = "OAuth provider endpoint is not permitted"
+
+
+def _endpoint_refused(
+    provider_slug: str,
+    exc: Exception,
+    *,
+    endpoint: str | None = None,
+    host: str | None = None,
+) -> HTTPException:
+    """Log the operator-facing detail and return the refusal for the caller to raise.
+
+    fix(#1861): one helper for both sources of an endpoint, the provider row
+    and the discovery document, so the two cannot drift into different status
+    codes or different disclosure. The response names no host: these routes are
+    unauthenticated and an SSRFError message carries the hostname it was asked
+    to resolve. The operator log gets the provider, which endpoint was refused
+    and its hostname, which is what fixing the configuration needs.
+    """
+    logger.warning(
+        "OAuth provider endpoint rejected",
+        provider=provider_slug,
+        endpoint=endpoint,
+        host=host,
+        error_type=type(exc).__name__,
+    )
+    return HTTPException(
+        status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+        detail=_ENDPOINT_REFUSED_DETAIL,
+    )
+
+
+async def _validate_discovery_endpoints(
+    provider_slug: str, metadata: dict[str, object]
+) -> None:
+    """Refuse a discovery document that aims an OAuth request at a private address."""
+    from app.platform.security import validate_url_for_ssrf
+
+    for key in _DISCOVERY_ENDPOINT_KEYS:
+        url = metadata.get(key)
+        if not isinstance(url, str) or not url:
+            continue
+        try:
+            await validate_url_for_ssrf(url)
+        except ValueError as exc:
+            # SSRFError and SSRFResolutionError are both ValueError, which is
+            # also what the row-level check raises.
+            raise _endpoint_refused(
+                provider_slug, exc, endpoint=key, host=urlparse(url).hostname
+            ) from exc
+
+
+class _SSRFSafeOAuth2App(StarletteOAuth2App):
+    """Every Authlib session this app builds goes through the safe transport."""
+
+    client_cls = _SSRFSafeOAuth2Client
+
+    # One validation per app instance, and build_oauth_client builds one per
+    # request. Nothing rewrites the endpoints after they are read: authlib
+    # caches the document under ``_loaded_at`` and only ever adds ``jwks``.
+    _endpoints_validated = False
+
+    async def load_server_metadata(self) -> dict:
+        """Validate the endpoints the discovery document supplies, once.
+
+        fix(#1861): this is the policy half, deciding whether an address is
+        one this deployment will talk to at all. The pinning transport on
+        _SSRFSafeOAuth2Client is the enforcement half: it re-resolves at
+        connect time, so a document that passes here and rebinds afterwards
+        still reaches nothing internal.
+        """
+        metadata = await super().load_server_metadata()
+        # Only a discovery document introduces an endpoint the row-level check
+        # in build_oauth_client has not already resolved. Without one, authlib
+        # keeps the registered columns in server_metadata, and re-resolving
+        # them here would refuse a provider that check just passed.
+        if self._server_metadata_url and not self._endpoints_validated:
+            await _validate_discovery_endpoints(self.name, metadata)
+            self._endpoints_validated = True
+        return metadata
 
 
 def _id_token_claims_options(
@@ -94,20 +227,16 @@ async def build_oauth_client(provider_slug: str, db: AsyncSession) -> tuple:
 
     # Validate every persisted endpoint before decrypting the client secret.
     # This protects legacy rows as well as configurations written through CRUD
-    # or config import. Authlib receives the same IP-pinning transport below,
-    # closing the DNS-rebinding gap between validation and request dispatch.
+    # or config import. fix(#1861): it covers the four columns on the row and
+    # nothing else, so a provider configured by discovery URL has its endpoints
+    # checked in _SSRFSafeOAuth2App.load_server_metadata instead. Either way
+    # every Authlib session, whichever hook builds it, then connects through
+    # the IP-pinning transport, which closes the DNS-rebinding gap between the
+    # check and request dispatch.
     try:
         await validate_provider_server_endpoints(provider)
     except ValueError as exc:
-        logger.warning(
-            "OAuth provider endpoint rejected",
-            provider=provider_slug,
-            error_type=type(exc).__name__,
-        )
-        raise HTTPException(
-            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-            detail="OAuth provider endpoint is not permitted",
-        ) from exc
+        raise _endpoint_refused(provider_slug, exc) from exc
 
     client_secret = decrypt_secret(provider.client_secret_encrypted)
 

--- a/backend/tests/test_oauth_destination_security.py
+++ b/backend/tests/test_oauth_destination_security.py
@@ -52,6 +52,11 @@ ELSEWHERE_TOKEN_URL = "https://elsewhere.example.net/token"
 # validator stay hermetic.
 LOOPBACK_TOKEN_URL = "http://127.0.0.1:9/token"
 LOOPBACK_USERINFO_URL = "http://127.0.0.1:9/userinfo"
+# An unclosed bracket in the authority: urlparse refuses this outright, so
+# validate_url_for_ssrf raises before reaching any of its own checks.
+MALFORMED_TOKEN_URL = "http://[invalid/token"
+CALLBACK_URL = "https://app.example.com/callback"
+ISSUER = "https://idp.example.com"
 DISCOVERY_DOCUMENT = {
     "issuer": "https://idp.example.com",
     "authorization_endpoint": "https://idp.example.com/authorize",
@@ -705,39 +710,89 @@ async def test_every_discovered_endpoint_is_ssrf_validated(
     }
 
 
+async def _discovery_refusal(
+    db: AsyncSession, authlib_transport, token_endpoint: str
+) -> tuple:
+    """Drive one login against a document naming *token_endpoint*.
+
+    Returns the refusal, the warning the operator log received, and every
+    request the client actually made. The real validator runs: both addresses
+    used here are literals that need no DNS, so these assert the shipped policy
+    rather than a stand-in for it.
+    """
+    from app.modules.auth.oauth import router as router_module
+
+    provider = await _make_discovery_provider(db)
+    await db.commit()
+    recorded = authlib_transport(
+        lambda _request: httpx.Response(
+            200, json={"issuer": ISSUER, "token_endpoint": token_endpoint}
+        )
+    )
+    client, _ = await _client_for(db, provider)
+
+    with (
+        patch.object(router_module, "logger") as logger,
+        pytest.raises(HTTPException) as exc_info,
+    ):
+        await client.fetch_access_token(
+            code=uuid.uuid4().hex, redirect_uri=CALLBACK_URL
+        )
+
+    return exc_info.value, logger.warning.call_args, recorded
+
+
 @pytest.mark.anyio
 async def test_a_private_discovered_token_endpoint_refuses_the_login(
     test_db_session: AsyncSession, authlib_transport
 ) -> None:
-    """A refusal before the exchange, so the client secret is never sent.
-
-    The real validator runs here: a literal address needs no DNS, so the
-    refusal is the shipped policy rather than a stand-in for it.
-    """
-    provider = await _make_discovery_provider(test_db_session)
-    await test_db_session.commit()
-    recorded = authlib_transport(
-        lambda _request: httpx.Response(
-            200,
-            json={
-                "issuer": "https://idp.example.com",
-                "token_endpoint": LOOPBACK_TOKEN_URL,
-            },
-        )
+    """A refusal before the exchange, so the client secret is never sent."""
+    refusal, warning, recorded = await _discovery_refusal(
+        test_db_session, authlib_transport, LOOPBACK_TOKEN_URL
     )
-    client, _ = await _client_for(test_db_session, provider)
 
-    with pytest.raises(HTTPException) as exc_info:
-        await client.fetch_access_token(
-            code=uuid.uuid4().hex, redirect_uri="https://app.example.com/callback"
-        )
-
-    assert exc_info.value.status_code == 503
+    assert refusal.status_code == 503
     # The route is unauthenticated, so the refusal names no address.
-    assert "127.0.0.1" not in exc_info.value.detail
+    assert "127.0.0.1" not in refusal.detail
     # Only the discovery document was fetched; nothing was posted to the
     # endpoint the document named.
     assert [str(request.url) for request in recorded] == [DISCOVERY_URL]
+    assert warning.args == ("OAuth provider endpoint rejected",)
+    assert warning.kwargs["endpoint"] == "token_endpoint"
+    assert warning.kwargs["host"] == "127.0.0.1"
+
+
+@pytest.mark.anyio
+async def test_a_malformed_discovered_endpoint_refuses_without_reparsing(
+    test_db_session: AsyncSession, authlib_transport
+) -> None:
+    """fix(#1861 codex r1): the refusal path itself must not raise.
+
+    urlparse rejects a malformed authority with ValueError, so
+    validate_url_for_ssrf raises before reaching its own checks and the refusal
+    branch receives exactly the string that will not parse. Deriving a hostname
+    for the log from it a second time raised inside the handler, which turned
+    the sanitized 503 into an unhandled 500 on an unauthenticated route.
+    """
+    refusal, warning, recorded = await _discovery_refusal(
+        test_db_session, authlib_transport, MALFORMED_TOKEN_URL
+    )
+    private, private_warning, _ = await _discovery_refusal(
+        test_db_session, authlib_transport, LOOPBACK_TOKEN_URL
+    )
+
+    assert refusal.status_code == private.status_code == 503
+    assert refusal.detail == private.detail
+    # Nothing of the offending URL reaches the caller.
+    assert "invalid" not in refusal.detail
+    assert [str(request.url) for request in recorded] == [DISCOVERY_URL]
+    # The same log line as every other refusal, with the one field that cannot
+    # be derived left empty rather than raised over.
+    assert warning.args == private_warning.args
+    assert set(warning.kwargs) == set(private_warning.kwargs)
+    assert warning.kwargs["endpoint"] == "token_endpoint"
+    assert warning.kwargs["host"] is None
+    assert warning.kwargs["error_type"] == "ValueError"
 
 
 @pytest.mark.anyio

--- a/backend/tests/test_oauth_destination_security.py
+++ b/backend/tests/test_oauth_destination_security.py
@@ -1,5 +1,6 @@
 """Security regression tests for OAuth endpoint and credential binding."""
 
+import ssl
 import uuid
 from unittest.mock import AsyncMock, patch
 
@@ -21,8 +22,10 @@ from app.modules.auth.oauth.service import (
     update_provider,
     validate_provider_server_endpoints,
 )
+from app.platform import security
 from app.platform.config_ops.exceptions import ConfigValidationError
 from app.platform.config_ops.service import _apply_oauth_providers
+from app.platform.security import SSRFError, _SSRFGuardTransport
 
 
 async def _make_oidc_provider(db: AsyncSession, *, host: str = "idp.example.com"):
@@ -40,6 +43,22 @@ async def _make_oidc_provider(db: AsyncSession, *, host: str = "idp.example.com"
             userinfo_url=f"https://{host}/userinfo",
         ),
     )
+
+
+DISCOVERY_URL = "https://idp.example.com/.well-known/openid-configuration"
+TOKEN_URL = "https://idp.example.com/token"
+ELSEWHERE_TOKEN_URL = "https://elsewhere.example.net/token"
+# A literal address resolves without DNS, so the tests that use the real
+# validator stay hermetic.
+LOOPBACK_TOKEN_URL = "http://127.0.0.1:9/token"
+LOOPBACK_USERINFO_URL = "http://127.0.0.1:9/userinfo"
+DISCOVERY_DOCUMENT = {
+    "issuer": "https://idp.example.com",
+    "authorization_endpoint": "https://idp.example.com/authorize",
+    "token_endpoint": TOKEN_URL,
+    "userinfo_endpoint": "https://idp.example.com/userinfo",
+    "jwks_uri": "https://idp.example.com/jwks",
+}
 
 
 @pytest.mark.anyio
@@ -513,6 +532,14 @@ async def test_runtime_validation_checks_all_server_endpoints(
 async def test_authlib_sessions_receive_fresh_safe_transports(
     test_db_session: AsyncSession,
 ) -> None:
+    """Both client hooks, not just the one discovery uses.
+
+    fix(#1861): ``_get_session`` serves discovery and JWKS;
+    ``_get_oauth_client`` serves the token exchange and the userinfo fetch,
+    which are the two requests carrying the client secret and the access
+    token. Before this fix only the first hook was covered, and the assertion
+    below called only that hook, so the gap was invisible here.
+    """
     from app.modules.auth.oauth.router import build_oauth_client
 
     provider = await _make_oidc_provider(test_db_session)
@@ -536,13 +563,290 @@ async def test_authlib_sessions_receive_fresh_safe_transports(
         ),
     ):
         oauth_client, _ = await build_oauth_client(provider.slug, test_db_session)
-        first = oauth_client._get_session()
-        second = oauth_client._get_session()
-        await first.aclose()
-        await second.aclose()
+        sessions = [
+            oauth_client._get_session(),
+            oauth_client._get_session(),
+            oauth_client._get_oauth_client(),
+            oauth_client._get_oauth_client(token_endpoint=TOKEN_URL),
+        ]
+        for session in sessions:
+            await session.aclose()
 
-    assert len(transports) == 2
-    assert transports[0] is not transports[1]
+    assert len(transports) == 4
+    assert len(set(id(transport) for transport in transports)) == 4
+
+
+async def _client_for(db: AsyncSession, provider) -> tuple:
+    """Build the router's authlib client with the row-level check stubbed out.
+
+    The stored endpoints are the subject of the tests above; these ones are
+    about what happens after that check has passed.
+    """
+    from app.modules.auth.oauth.router import build_oauth_client
+
+    with patch(
+        "app.modules.auth.oauth.router.validate_provider_server_endpoints",
+        new=AsyncMock(),
+    ):
+        return await build_oauth_client(provider.slug, db)
+
+
+async def _make_discovery_provider(db: AsyncSession):
+    suffix = uuid.uuid4().hex[:8]
+    return await create_provider(
+        db,
+        OAuthProviderCreate(
+            slug=f"discovery-{suffix}",
+            display_name="Discovery Security",
+            provider_type="oidc",
+            client_id=f"client-{suffix}",
+            client_secret=uuid.uuid4().hex,
+            discovery_url=DISCOVERY_URL,
+        ),
+    )
+
+
+@pytest.fixture
+def authlib_transport(monkeypatch):
+    """Answer every authlib request from a mock transport the factory returns.
+
+    Patching ``make_safe_transport`` rather than reaching into the client keeps
+    the client under test the one the router actually builds: a hook that
+    stopped calling the factory would get a real transport, nothing here would
+    answer it, and the test would fail rather than pass quietly.
+    """
+
+    def install(handler) -> list[httpx.Request]:
+        recorded: list[httpx.Request] = []
+
+        def handle(request: httpx.Request) -> httpx.Response:
+            recorded.append(request)
+            return handler(request)
+
+        monkeypatch.setattr(
+            security, "make_safe_transport", lambda: httpx.MockTransport(handle)
+        )
+        return recorded
+
+    return install
+
+
+@pytest.mark.anyio
+async def test_token_exchange_refuses_a_private_address(
+    test_db_session: AsyncSession,
+) -> None:
+    """The finding: this request carries the client secret.
+
+    The endpoint validators are stubbed out so the refusal can only come from
+    the transport the client dialled with, which is the half that survives a
+    DNS answer changing between validation and connect.
+    """
+    provider = await _make_oidc_provider(test_db_session)
+    await test_db_session.commit()
+    client, _ = await _client_for(test_db_session, provider)
+    client.access_token_url = LOOPBACK_TOKEN_URL
+
+    with (
+        patch("app.platform.security.validate_url_for_ssrf", new=AsyncMock()),
+        pytest.raises(SSRFError) as raised,
+    ):
+        await client.fetch_access_token(
+            code=uuid.uuid4().hex, redirect_uri="https://app.example.com/callback"
+        )
+
+    assert "private/internal networks" in str(raised.value)
+
+
+@pytest.mark.anyio
+async def test_userinfo_fetch_refuses_a_private_address(
+    test_db_session: AsyncSession,
+) -> None:
+    """The same finding for the request that carries the access token."""
+    provider = await _make_oidc_provider(test_db_session)
+    await test_db_session.commit()
+    client, _ = await _client_for(test_db_session, provider)
+    client.server_metadata["userinfo_endpoint"] = LOOPBACK_USERINFO_URL
+
+    with (
+        patch("app.platform.security.validate_url_for_ssrf", new=AsyncMock()),
+        pytest.raises(SSRFError) as raised,
+    ):
+        await client.userinfo(
+            token={"access_token": uuid.uuid4().hex, "token_type": "Bearer"}
+        )
+
+    assert "private/internal networks" in str(raised.value)
+
+
+@pytest.mark.anyio
+async def test_every_discovered_endpoint_is_ssrf_validated(
+    test_db_session: AsyncSession, authlib_transport
+) -> None:
+    """The four endpoints authlib reads out of the document and then fetches.
+
+    None of them is on the provider row, so ``validate_provider_server_
+    endpoints`` never sees the address any request actually goes to.
+    """
+    provider = await _make_discovery_provider(test_db_session)
+    await test_db_session.commit()
+    authlib_transport(lambda _request: httpx.Response(200, json=DISCOVERY_DOCUMENT))
+    client, _ = await _client_for(test_db_session, provider)
+
+    with patch(
+        "app.platform.security.validate_url_for_ssrf", new=AsyncMock()
+    ) as validate:
+        await client.load_server_metadata()
+
+    assert {call.args[0] for call in validate.await_args_list} == {
+        DISCOVERY_DOCUMENT["authorization_endpoint"],
+        DISCOVERY_DOCUMENT["token_endpoint"],
+        DISCOVERY_DOCUMENT["userinfo_endpoint"],
+        DISCOVERY_DOCUMENT["jwks_uri"],
+    }
+
+
+@pytest.mark.anyio
+async def test_a_private_discovered_token_endpoint_refuses_the_login(
+    test_db_session: AsyncSession, authlib_transport
+) -> None:
+    """A refusal before the exchange, so the client secret is never sent.
+
+    The real validator runs here: a literal address needs no DNS, so the
+    refusal is the shipped policy rather than a stand-in for it.
+    """
+    provider = await _make_discovery_provider(test_db_session)
+    await test_db_session.commit()
+    recorded = authlib_transport(
+        lambda _request: httpx.Response(
+            200,
+            json={
+                "issuer": "https://idp.example.com",
+                "token_endpoint": LOOPBACK_TOKEN_URL,
+            },
+        )
+    )
+    client, _ = await _client_for(test_db_session, provider)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await client.fetch_access_token(
+            code=uuid.uuid4().hex, redirect_uri="https://app.example.com/callback"
+        )
+
+    assert exc_info.value.status_code == 503
+    # The route is unauthenticated, so the refusal names no address.
+    assert "127.0.0.1" not in exc_info.value.detail
+    # Only the discovery document was fetched; nothing was posted to the
+    # endpoint the document named.
+    assert [str(request.url) for request in recorded] == [DISCOVERY_URL]
+
+
+@pytest.mark.anyio
+async def test_a_discovery_document_cannot_weaken_the_client(
+    test_db_session: AsyncSession,
+) -> None:
+    """authlib merges the document into the httpx client kwargs.
+
+    ``_get_oauth_client`` does ``client_kwargs.update(metadata)``, so every key
+    in the document is a candidate httpx client argument. A document choosing
+    ``verify``, ``mounts`` or ``follow_redirects`` would be choosing the
+    transport security of the request that carries the client secret.
+    """
+    provider = await _make_oidc_provider(test_db_session)
+    await test_db_session.commit()
+    client, _ = await _client_for(test_db_session, provider)
+
+    built = client._get_oauth_client(
+        token_endpoint=TOKEN_URL,
+        verify=False,
+        follow_redirects=True,
+        max_redirects=20,
+        mounts={"all://": httpx.MockTransport(lambda _r: httpx.Response(200))},
+        proxy="http://elsewhere.example.net:3128",
+    )
+    try:
+        # httpx internals, asserted directly because the claim is about the
+        # client that gets dialled, not about what was passed to it. A mount
+        # and a proxy both take precedence over ``transport``, so the question
+        # is which transport the token endpoint resolves to.
+        assert isinstance(built._transport, _SSRFGuardTransport)
+        assert built._mounts == {}
+        assert built._transport_for_url(httpx.URL(TOKEN_URL)) is built._transport
+        assert built.follow_redirects is False
+        assert built._transport._pool._ssl_context.verify_mode == ssl.CERT_REQUIRED
+        assert built._transport._pool._ssl_context.check_hostname is True
+    finally:
+        await built.aclose()
+
+
+@pytest.mark.anyio
+async def test_the_token_exchange_client_does_not_follow_a_redirect(
+    test_db_session: AsyncSession, authlib_transport
+) -> None:
+    """No hop, so nothing the exchange sends can reach the origin a 302 names.
+
+    httpx drops ``Authorization`` across an origin change by itself, but under
+    ``client_secret_post`` the secret travels in the request body and a 307
+    repeats that body. Not following at all is what makes the question moot,
+    and it is also httpx's default: the assertion is that the default cannot be
+    turned back on from outside, including by the discovery document that
+    authlib merges into these very kwargs.
+
+    The client here is the one ``fetch_access_token`` builds; the positive
+    control below shows the exchange going through it.
+    """
+    provider = await _make_oidc_provider(test_db_session)
+    await test_db_session.commit()
+    recorded = authlib_transport(
+        lambda _request: httpx.Response(302, headers={"Location": ELSEWHERE_TOKEN_URL})
+    )
+    client, _ = await _client_for(test_db_session, provider)
+
+    built = client._get_oauth_client(token_endpoint=TOKEN_URL, follow_redirects=True)
+    try:
+        response = await built.request(
+            "POST", TOKEN_URL, withhold_token=True, data={"code": uuid.uuid4().hex}
+        )
+    finally:
+        await built.aclose()
+
+    assert response.status_code == 302
+    assert [request.url.host for request in recorded] == ["idp.example.com"]
+
+
+@pytest.mark.anyio
+async def test_a_normal_exchange_still_succeeds_through_the_safe_client(
+    test_db_session: AsyncSession, authlib_transport
+) -> None:
+    """Positive control: the transport is pinned, not broken.
+
+    Every request here is answered by a transport the factory produced, so a
+    hook that skipped the factory would reach the network instead and fail.
+    """
+    provider = await _make_discovery_provider(test_db_session)
+    await test_db_session.commit()
+    issued = uuid.uuid4().hex
+
+    def handle(request: httpx.Request) -> httpx.Response:
+        if request.url.path.endswith("openid-configuration"):
+            return httpx.Response(200, json=DISCOVERY_DOCUMENT)
+        return httpx.Response(
+            200,
+            json={"access_token": issued, "token_type": "Bearer", "expires_in": 3600},
+        )
+
+    recorded = authlib_transport(handle)
+    client, _ = await _client_for(test_db_session, provider)
+
+    with patch("app.platform.security.validate_url_for_ssrf", new=AsyncMock()):
+        token = await client.fetch_access_token(
+            code=uuid.uuid4().hex, redirect_uri="https://app.example.com/callback"
+        )
+
+    assert token["access_token"] == issued
+    assert [str(request.url) for request in recorded] == [
+        DISCOVERY_URL,
+        DISCOVERY_DOCUMENT["token_endpoint"],
+    ]
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
Confirmed P2 finding from the codebase security audit of 2026-09-04 (audited commit `4e3600e37`, v1.18.0), section P2-4. Re-verified against current `main` (`cd9567fde`) with a runtime probe before anything changed here. It still reproduces.

## The finding

`_SSRFSafeOAuth2App` installed the IP-pinning transport by overriding `_get_session`. In authlib 1.7.2 that hook serves two of the four HTTP calls an OIDC login makes, the discovery fetch and the JWKS fetch, and neither of those carries a credential. The token exchange and the userinfo fetch build their client through `_get_oauth_client`, which returned a stock httpx transport, and those are the two requests that carry the client secret and the access token.

Probe against the installed authlib on `cd9567fde`:

```
_get_session transport: _SSRFGuardTransport
_get_oauth_client transport: AsyncHTTPTransport
```

The comment in `build_oauth_client` asserted the gap was closed, and the regression test called `_get_session` only, so nothing in the tree contradicted it. In the counterfactual run below, the pre-fix code attempts a real connection to a loopback token endpoint.

## The transport, decided in one place

All four authlib hooks construct `self.client_cls`, so `_SSRFSafeOAuth2Client` sets the transport in `__init__` and the app class names that client. The `_get_session` override is deleted rather than duplicated. authlib's own `_get_session` sets the same User-Agent the override was setting.

`make_safe_client()` itself cannot be used here: authlib needs an `AsyncOAuth2Client`, which is an `httpx.AsyncClient` subclass carrying `fetch_token` and the client-auth machinery, and the factory returns a plain client. The client is therefore built with `make_safe_transport()`, which is the same transport the factory installs, and the redirect question is answered a different way, below.

## What a discovery document was allowed to decide

`_get_oauth_client` merges the discovery document into the httpx client kwargs (`client_kwargs.update(metadata)`), so every key in that document is a candidate httpx client argument. Measured against the installed authlib and httpx:

| key in the document | effect before this change |
| --- | --- |
| `verify: false` | TLS verification off for the token exchange (`verify_mode` 0, `check_hostname` False) |
| `follow_redirects: true` | redirects followed on the credential-bearing requests |
| `proxy` | a mount that takes precedence over `transport`, so the guard is bypassed |
| `mounts` | the same, directly |

They are set after the merge now. `verify` and `cert` need no entry once the transport is ours, because httpx reads them only when it builds the transport itself, and the test asserts the resulting SSL context rather than the kwarg.

`follow_redirects` is pinned to httpx's own default of `False`, which is also what the code did before. That is what makes the credential-crossing question moot rather than policed: no hop happens, so neither the `Authorization` header nor a `client_secret_post` body can reach the origin a 302 names. The factory's `_revalidate_redirect` hook is deliberately not installed on top: with nothing following, it could only turn a benign 302 from an IdP into an SSRF error, and the only way to enable following is to edit the class whose comment says why not to.

## The endpoints nobody was validating

`validate_provider_server_endpoints` checks the four URL columns on the provider row. A provider configured by discovery URL leaves three of them empty and authlib reads `authorization_endpoint`, `token_endpoint`, `userinfo_endpoint` and `jwks_uri` out of the document instead, so nothing resolved the address any request actually went to.

`load_server_metadata` now validates those four, refusing the login with the 503 the row-level refusal already used. It runs only when there is a document: without one, authlib keeps the registered columns in `server_metadata`, and re-resolving them would refuse a provider the row check had just passed (`test_oauth_login_redirect` catches exactly that, and it does).

Both refusals go through one helper, so they cannot drift into different status codes or different disclosure. The response names no address, because these routes are unauthenticated and an `SSRFError` message carries the hostname it was asked to resolve. The operator log gets the provider slug, which endpoint was refused and its hostname.

The endpoint list stays matched to the calls that exist. Nothing here fetches `end_session_endpoint`, `revocation_endpoint` or the rest, and refusing a login over an endpoint nothing fetches is a false refusal rather than a defence.

## Noticed and left alone

Passing a transport at all disables httpx's reading of proxies from the environment (`allow_env_proxies = trust_env and transport is None`). Discovery, JWKS and the GitHub identity fetch were already in that position, so a provider configured by discovery URL could not complete discovery through an `HTTPS_PROXY` before this change either.

A provider configured with explicit URLs is the case this change does break. It fetches no discovery document and no JWKS, so its only two requests are the token exchange and the userinfo fetch, both of which went through `_get_oauth_client` with no transport, which left `allow_env_proxies` true. Those requests honoured an environment proxy until now, and this PR is the first thing to stop them. That is a real loss for a self-hoster whose IdP is reachable only through a proxy, and it is the trade-off the fix carries: a transport that pins the connection to a validated address for the target host cannot honour an arbitrary proxy. Worth knowing if one reports it.

## Schema, API and config impact

None. No request or response schema changed and `openapi.json` is unchanged (`dump_openapi.py --check` exits 0). No migration, no new setting, no new copy string: the refusal reuses the existing detail text.

## Verification

Run from a worktree on `cd9567fde`, host Postgres at `localhost:5434`. Every figure below is from a run at the current head.

```
uv run pytest tests/test_oauth_destination_security.py -q      28 passed
uv run pytest tests/test_oauth*.py tests/test_phase_273_oauth_referrer_policy.py \
      tests/test_settings_oauth_crud.py -q                     160 passed
uv run pytest tests/test_layering.py tests/test_rule1_structural.py \
      tests/test_rule2_structural.py -q                        158 passed
uv run pytest tests/test_auth.py -q                            38 passed
uv run pytest tests/test_domain_enforcement.py tests/test_sso_login_mode.py \
      tests/test_config_ops.py tests/test_config_ops_unit.py \
      tests/test_credential_policy.py \
      tests/test_credential_producer_structural.py \
      tests/test_saml_overlay.py -q                            360 passed, 12 skipped
uv run pytest tests/test_ssrf_redirect.py tests/test_ssrf_ip_pinning_sec008.py \
      tests/test_sec013_ssrf_cgnat.py tests/test_cross_origin_credential_1746.py \
      tests/test_phase_273_cog_redirect_revalidate.py -q       32 passed
uv run ruff check . && uv run ruff format --check .            clean
PYTHONPATH=. uv run python scripts/dump_openapi.py --check     exit 0
```

Counterfactual, with `router.py` restored from `origin/main` and the tests left as they are here: all 8 fail, the two credential-bearing ones with `httpx.ConnectError: All connection attempts failed` against the loopback endpoint, which is the finding.

```
FAILED test_authlib_sessions_receive_fresh_safe_transports
FAILED test_token_exchange_refuses_a_private_address
FAILED test_userinfo_fetch_refuses_a_private_address
FAILED test_every_discovered_endpoint_is_ssrf_validated
FAILED test_a_private_discovered_token_endpoint_refuses_the_login
FAILED test_a_discovery_document_cannot_weaken_the_client
FAILED test_the_token_exchange_client_does_not_follow_a_redirect
FAILED test_a_normal_exchange_still_succeeds_through_the_safe_client
```

Each pin was also shown load-bearing on its own: dropping `proxy = None` alone leaves a mount that the injected proxy created, and the test fails on it.

The second commit fixes a refusal path that could itself raise: `urlparse` rejects a malformed authority such as `http://[invalid/token` with `ValueError`, so `validate_url_for_ssrf` raised before reaching its own checks and deriving a hostname for the log from that same string raised again inside the handler, turning the sanitized 503 into an unhandled 500, and `test_a_malformed_discovered_endpoint_refuses_without_reparsing` now drives that document and the private-address one through a shared helper to assert both produce the same status, the same detail and the same log line shape, with the hostname left empty rather than raised over.


