### PR TITLE
fix(frontend): three data-integrity fixes in auth refresh, chat storage, and draft editing

### DIFF
--- a/frontend/src/api/__tests__/client.session-expiry.test.ts
+++ b/frontend/src/api/__tests__/client.session-expiry.test.ts
@@ -1,6 +1,7 @@
 import { apiFetch, ApiError, onSessionExpired } from '@/api/client';
 import { useAuthStore } from '@/stores/auth-store';
 import { refreshAccessToken, logoutSession } from '@/api/auth';
+import type { TokenResponse } from '@/types/api';
 
 // fix(#628): the fetch core must treat "401 + the follow-up refresh is also
 // dead" as a single session-death event: clear the persisted auth state and
@@ -128,6 +129,45 @@ describe('session-expiry notification (fix #628)', () => {
 
     await expect(apiFetch('/a/')).resolves.toEqual({ ok: true });
     expect(handler).not.toHaveBeenCalled();
+  });
+
+  // fix(#1862 review P2): before the fix, tryRefresh reported failure here
+  // regardless of what the store actually held, so this retried with a dead
+  // token, got 401 again, and notified — logging out (and revoking) the
+  // session the peer tab had just refreshed.
+  it('does not invoke the handler when a peer tab rotates the token while this refresh fails', async () => {
+    signIn();
+
+    let rejectRefresh: (err: unknown) => void = () => {};
+    vi.mocked(refreshAccessToken).mockImplementation(
+      () =>
+        new Promise<TokenResponse>((_resolve, reject) => {
+          rejectRefresh = reject;
+        }),
+    );
+
+    mockFetch
+      .mockResolvedValueOnce(errorResponse(401))
+      .mockResolvedValueOnce(jsonResponse({ ok: true }));
+
+    const pending = apiFetch('/a/');
+
+    // Yield until the fetch mock's own resolution, the 401 branch, and the
+    // tryRefresh call all clear their microtask hops and refreshAccessToken
+    // is actually invoked (same pattern as the SP-09 concurrent-dedup test).
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // auth-store.ts's cross-tab `storage` listener rehydrating a peer tab's
+    // successful refresh into this tab's store while this attempt is still
+    // in flight.
+    useAuthStore.setState({ token: 'peer-rotated-token' });
+    rejectRefresh(new ApiError('network error', 0));
+
+    await expect(pending).resolves.toEqual({ ok: true });
+    expect(handler).not.toHaveBeenCalled();
+    expect(useAuthStore.getState().token).toBe('peer-rotated-token');
   });
 
   it('notifies once per dead session, and again for the next dead session', async () => {

--- a/frontend/src/api/__tests__/client.test.ts
+++ b/frontend/src/api/__tests__/client.test.ts
@@ -273,13 +273,14 @@ describe('apiFetch', () => {
     vi.mocked(refreshAccessToken).mockRejectedValueOnce(new Error('refresh failed'));
 
     useAuthStore.setState({ token: 'cookie-session-token', refreshToken: null });
-    mockFetch
-      .mockResolvedValueOnce(errorResponse(401))
-      .mockResolvedValueOnce(errorResponse(401));
+    // fix(#1849): a failed refresh no longer retries with the dead token, so
+    // only the initial 401 fetch happens — one queued response, not two.
+    mockFetch.mockResolvedValueOnce(errorResponse(401));
 
     await expect(apiFetch('/protected/')).rejects.toThrow(ApiError);
     expect(refreshAccessToken).toHaveBeenCalledWith(null, expect.any(AbortSignal));
     expect(useAuthStore.getState().token).toBeNull();
+    expect(mockFetch).toHaveBeenCalledTimes(1);
   });
 
   it('does not attempt a refresh on an anonymous 401', async () => {
@@ -299,13 +300,69 @@ describe('apiFetch', () => {
     // A distinct access token per test: the session-death latch dedupes on it,
     // and real sessions never reuse one (every JWT carries a fresh jti).
     useAuthStore.setState({ token: 'expired-token', refreshToken: 'bad-refresh' });
-    // First call returns 401; refresh fails but token remains, so retry also gets 401
-    mockFetch
-      .mockResolvedValueOnce(errorResponse(401))
-      .mockResolvedValueOnce(errorResponse(401));
+    mockFetch.mockResolvedValueOnce(errorResponse(401));
 
     await expect(apiFetch('/protected/')).rejects.toThrow(ApiError);
     expect(useAuthStore.getState().token).toBeNull();
+    // fix(#1849): a failed refresh must not retry the original request with
+    // the now-dead token — only the initial 401 fetch happens.
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  describe('tryRefresh return value (#1849)', () => {
+    it('returns false and skips the retry when refresh fails, going straight to logout', async () => {
+      const { refreshAccessToken } = await import('@/api/auth');
+      vi.mocked(refreshAccessToken).mockRejectedValueOnce(new ApiError('unauthorized', 401));
+
+      // A distinct access token per test: the session-death latch dedupes on
+      // it (see the note on 'logs out and throws on 401 when refresh fails').
+      useAuthStore.setState({ token: 'expired-token-1849a', refreshToken: 'bad-refresh' });
+      mockFetch.mockResolvedValueOnce(errorResponse(401));
+
+      await expect(apiFetch('/protected/')).rejects.toThrow(ApiError);
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      expect(useAuthStore.getState().token).toBeNull();
+    });
+
+    it('returns true and retries exactly once when refresh succeeds', async () => {
+      const { refreshAccessToken } = await import('@/api/auth');
+      vi.mocked(refreshAccessToken).mockResolvedValueOnce({
+        access_token: 'fresh-token',
+        refresh_token: 'fresh-refresh',
+        expires_in: 900,
+        token_type: 'bearer',
+      });
+
+      useAuthStore.setState({ token: 'expired-token-1849b', refreshToken: 'old-refresh' });
+      mockFetch
+        .mockResolvedValueOnce(errorResponse(401))
+        .mockResolvedValueOnce(jsonResponse({ ok: true }));
+
+      await expect(apiFetch('/protected/')).resolves.toEqual({ ok: true });
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      expect(useAuthStore.getState().token).toBe('fresh-token');
+    });
+
+    it('backs off once on a 429 before giving up', async () => {
+      vi.useFakeTimers();
+      try {
+        const { refreshAccessToken } = await import('@/api/auth');
+        vi.mocked(refreshAccessToken).mockRejectedValueOnce(new ApiError('rate limited', 429));
+
+        useAuthStore.setState({ token: 'expired-token-1849c', refreshToken: 'bad-refresh' });
+        mockFetch.mockResolvedValueOnce(errorResponse(401));
+
+        const pending = apiFetch('/protected/').catch((e: unknown) => e);
+        await vi.advanceTimersByTimeAsync(2000);
+        const result = await pending;
+
+        expect(result).toBeInstanceOf(ApiError);
+        expect(mockFetch).toHaveBeenCalledTimes(1);
+        expect(useAuthStore.getState().token).toBeNull();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
   });
 
   // RES-N1: `TypeError: Failed to fetch` is what browsers throw when the
@@ -416,12 +473,13 @@ describe('apiFetch', () => {
       // First refresh attempt fails
       mockRefresh.mockRejectedValueOnce(new Error('boom'));
       useAuthStore.setState({ token: 'expired', refreshToken: 'r' });
-      mockFetch
-        .mockResolvedValueOnce(errorResponse(401))
-        .mockResolvedValueOnce(errorResponse(401));
+      // fix(#1849): a failed refresh no longer retries with the dead token —
+      // one queued response, not two.
+      mockFetch.mockResolvedValueOnce(errorResponse(401));
 
       await expect(apiFetch('/a/')).rejects.toThrow(ApiError);
       expect(mockRefresh).toHaveBeenCalledTimes(1);
+      expect(mockFetch).toHaveBeenCalledTimes(1);
 
       // Second wave: the singleton must have cleared, so a new refresh attempt fires
       mockRefresh.mockResolvedValueOnce({

--- a/frontend/src/api/__tests__/client.test.ts
+++ b/frontend/src/api/__tests__/client.test.ts
@@ -1,4 +1,4 @@
-import { apiFetch, ApiError } from '@/api/client';
+import { apiFetch, ApiError, tryRefresh } from '@/api/client';
 import { useAuthStore } from '@/stores/auth-store';
 import type { TokenResponse } from '@/types/api';
 
@@ -362,6 +362,46 @@ describe('apiFetch', () => {
       } finally {
         vi.useRealTimers();
       }
+    });
+
+    // fix(#1862 review P2): a regression of the fix above. Before it, the
+    // stale-token truthiness masked this case by accident — `!!token` was
+    // true regardless of whose refresh put it there. Reporting failure here
+    // for an outcome the store shows as success would make the caller treat
+    // a peer tab's valid session as dead.
+    it('returns true when a peer tab rotates the token while this refresh fails', async () => {
+      const { refreshAccessToken } = await import('@/api/auth');
+      let rejectRefresh: (err: unknown) => void = () => {};
+      vi.mocked(refreshAccessToken).mockImplementation(
+        () =>
+          new Promise<TokenResponse>((_resolve, reject) => {
+            rejectRefresh = reject;
+          }),
+      );
+
+      useAuthStore.setState({ token: 'stale-local-token', refreshToken: 'r' });
+
+      const pending = tryRefresh();
+      await Promise.resolve();
+
+      // Simulate auth-store.ts's cross-tab `storage` listener rehydrating a
+      // peer tab's successful refresh into this tab's store while this
+      // attempt is still in flight.
+      useAuthStore.setState({ token: 'peer-rotated-token' });
+      rejectRefresh(new Error('network error'));
+
+      await expect(pending).resolves.toBe(true);
+      expect(useAuthStore.getState().token).toBe('peer-rotated-token');
+    });
+
+    it('still returns false when the token is unchanged after a failed refresh', async () => {
+      const { refreshAccessToken } = await import('@/api/auth');
+      vi.mocked(refreshAccessToken).mockRejectedValueOnce(new Error('boom'));
+
+      useAuthStore.setState({ token: 'unchanged-token', refreshToken: 'r' });
+
+      await expect(tryRefresh()).resolves.toBe(false);
+      expect(useAuthStore.getState().token).toBe('unchanged-token');
     });
   });
 

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -1,7 +1,7 @@
 import { API_BASE } from '@/lib/constants';
 import { cookieAuthAvailable, cookieAuthHeaders } from '@/lib/auth-transport';
 import { useAuthStore } from '@/stores/auth-store';
-import { apiFetch, safeFetch } from './client';
+import { apiFetch, safeFetch, ApiError } from './client';
 import { translateApiErrorDetail } from '@/lib/error-map';
 import type { TokenResponse, UserResponse, AuthConfigResponse, MessageResponse, SignupResponse, MyApiKeyResponse, ApiKeyCreateResponse, ApiKeyScope, OAuthProviderPublic, UserQuotaUsage } from '@/types/api';
 
@@ -288,7 +288,10 @@ export async function refreshAccessToken(
   });
 
   if (!response.ok) {
-    throw new Error(translateApiErrorDetail(undefined, response.status));
+    // fix(#1849): tryRefresh's 429 back-off branch checks `err instanceof
+    // ApiError`, so a plain Error here made that branch dead code — a
+    // rate-limited refresh never got the pause before the next attempt.
+    throw new ApiError(translateApiErrorDetail(undefined, response.status), response.status);
   }
 
   return response.json() as Promise<TokenResponse>;

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -28,7 +28,7 @@ export class ApiError extends Error {
 // timer in use-auth.ts (which now also calls tryRefresh) collapse to one
 // /auth/refresh/ POST per refresh cycle. Cleared in finally so the next
 // expiration starts fresh.
-let inflightRefresh: Promise<void> | null = null;
+let inflightRefresh: Promise<boolean> | null = null;
 let inflightRefreshAbort: AbortController | null = null;
 
 /**
@@ -91,9 +91,11 @@ export async function tryRefresh(): Promise<boolean> {
   // never leave cookie mode's starting gate.
   if (!refreshToken && !(token && cookieAuthAvailable())) return false;
 
+  // fix(#1849): the outcome of the in-flight refresh IS the answer here, not
+  // whatever token happens to be sitting in the store — see the fix note on
+  // the IIFE's return values below.
   if (inflightRefresh) {
-    await inflightRefresh;
-    return !!useAuthStore.getState().token;
+    return await inflightRefresh;
   }
 
   // The singleton MUST be cleared synchronously when the IIFE settles —
@@ -115,10 +117,15 @@ export async function tryRefresh(): Promise<boolean> {
   const controller = new AbortController();
   inflightRefreshAbort = controller;
 
-  const promise = (async () => {
+  // fix(#1849): report whether a NEW token actually got stored, not whether
+  // some token — possibly the stale one this refresh was trying to replace —
+  // still sits in the store. The old `!!token` check was true on a failed
+  // refresh too, so the caller retried the original request with a dead
+  // token instead of going straight to the logout path.
+  const promise = (async (): Promise<boolean> => {
     try {
       const tokens = await refreshAccessToken(refreshToken, controller.signal);
-      if (useAuthStore.getState().sessionEpoch !== epochAtStart) return;
+      if (useAuthStore.getState().sessionEpoch !== epochAtStart) return false;
       // fix(#1302): null in cookie mode, which also clears the legacy
       // localStorage token once the migrating refresh has spent it.
       useAuthStore.getState().setTokens(
@@ -126,12 +133,14 @@ export async function tryRefresh(): Promise<boolean> {
         tokens.refresh_token ?? null,
         tokens.expires_in,
       );
+      return true;
     } catch (err) {
       // If rate-limited, wait before giving up so the next attempt isn't also blocked
       if (err instanceof ApiError && err.status === 429) {
         await new Promise((r) => setTimeout(r, 2000));
       }
       // Refresh failed -- will fall through to logout
+      return false;
     } finally {
       inflightRefresh = null;
       if (inflightRefreshAbort === controller) inflightRefreshAbort = null;
@@ -139,8 +148,7 @@ export async function tryRefresh(): Promise<boolean> {
   })();
   inflightRefresh = promise;
 
-  await promise;
-  return !!useAuthStore.getState().token;
+  return await promise;
 }
 
 /**

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -122,6 +122,14 @@ export async function tryRefresh(): Promise<boolean> {
   // still sits in the store. The old `!!token` check was true on a failed
   // refresh too, so the caller retried the original request with a dead
   // token instead of going straight to the logout path.
+  //
+  // fix(#1862 review P2): captured here, before the attempt, so a failure
+  // below can tell "nothing changed" from "a peer tab changed it". The
+  // access token also lives in localStorage (auth-store.ts's cross-tab
+  // `storage` listener), so a PEER tab's successful refresh can rehydrate a
+  // new token into this tab's store while this attempt is still in flight —
+  // most easily during the 429 backoff wait. `token` is that pre-attempt
+  // value from the destructure above.
   const promise = (async (): Promise<boolean> => {
     try {
       const tokens = await refreshAccessToken(refreshToken, controller.signal);
@@ -138,6 +146,16 @@ export async function tryRefresh(): Promise<boolean> {
       // If rate-limited, wait before giving up so the next attempt isn't also blocked
       if (err instanceof ApiError && err.status === 429) {
         await new Promise((r) => setTimeout(r, 2000));
+      }
+      // fix(#1862 review P2): our own attempt failed, but if a peer tab's
+      // refresh landed a different token while we waited, the session IS
+      // live — just not because of anything this attempt did. Reporting
+      // failure here would make the caller treat a peer's valid replacement
+      // as a terminal session death and log out (and revoke) the session
+      // that tab just refreshed.
+      const currentToken = useAuthStore.getState().token;
+      if (currentToken && currentToken !== token) {
+        return true;
       }
       // Refresh failed -- will fall through to logout
       return false;

--- a/frontend/src/components/dataset/hooks/__tests__/use-draft-editing.test.ts
+++ b/frontend/src/components/dataset/hooks/__tests__/use-draft-editing.test.ts
@@ -253,6 +253,61 @@ describe('useDraftEditing', () => {
     expect(success).toBe(false);
   });
 
+  // fix(#1851): DatasetPage stays mounted across a route change from one
+  // dataset to another, so without a reset keyed on datasetId a staged draft
+  // for dataset A survived into dataset B's render.
+  it('resets staged drafts when datasetId changes', () => {
+    const { result, rerender } = renderHook(
+      ({ datasetId, dataset }) => useDraftEditing({ datasetId, dataset, isGeometryEditDirty: false }),
+      {
+        initialProps: {
+          datasetId: 'ds-1',
+          dataset: makeDataset({ id: 'ds-1', summary: 'A summary' }),
+        },
+      },
+    );
+
+    act(() => {
+      result.current.stagePendingDraft('summary', 'A edited summary');
+    });
+    expect(result.current.pendingCount).toBe(1);
+
+    rerender({
+      datasetId: 'ds-2',
+      dataset: makeDataset({ id: 'ds-2', summary: 'B summary' }),
+    });
+
+    expect(result.current.pendingCount).toBe(0);
+    expect(result.current.resolveDraftValue('summary')).toBe('B summary');
+  });
+
+  it('a save after navigating to a different dataset does not send the previous draft', async () => {
+    const { result, rerender } = renderHook(
+      ({ datasetId, dataset }) => useDraftEditing({ datasetId, dataset, isGeometryEditDirty: false }),
+      {
+        initialProps: {
+          datasetId: 'ds-1',
+          dataset: makeDataset({ id: 'ds-1', summary: 'A summary' }),
+        },
+      },
+    );
+
+    act(() => {
+      result.current.stagePendingDraft('summary', 'A edited summary');
+    });
+
+    rerender({
+      datasetId: 'ds-2',
+      dataset: makeDataset({ id: 'ds-2', summary: 'B summary' }),
+    });
+
+    await act(async () => {
+      await result.current.savePendingDrafts();
+    });
+
+    expect(mockMutateAsync).not.toHaveBeenCalled();
+  });
+
   it('handleDraftDirtyChange tracks dirty fields in pending count', () => {
     const { result } = renderHook(() =>
       useDraftEditing({

--- a/frontend/src/components/dataset/hooks/use-draft-editing.ts
+++ b/frontend/src/components/dataset/hooks/use-draft-editing.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback, useMemo, useRef } from 'react';
+import { useState, useCallback, useEffect, useMemo, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { toast } from 'sonner';
 import { useUpdateDataset } from '@/components/dataset/hooks/use-dataset';
@@ -46,6 +46,18 @@ export function useDraftEditing({ datasetId, dataset, isGeometryEditDirty }: Use
   // that just-staged field, whereas the callback's pendingDrafts closure does not
   // and used to drop it (then setPendingDrafts({}) discarded it for good).
   const pendingDraftsRef = useRef<PendingDrafts>({});
+
+  // fix(#1851): DatasetPage stays mounted across a route change from one
+  // dataset's edit view to another — only `datasetId` changes, not the
+  // component instance — so without this, staged drafts for dataset A
+  // survived into dataset B's render and a subsequent Save PATCHed them onto
+  // B. Reset every time the id changes, including into this hook's first
+  // render for a given id.
+  useEffect(() => {
+    setPendingDrafts({});
+    pendingDraftsRef.current = {};
+    setDirtyFields(new Set());
+  }, [datasetId]);
 
   const stagePendingDraft = useCallback(
     (field: PendingDraftField, value: string) => {

--- a/frontend/src/lib/__tests__/auth-cache-reset.test.ts
+++ b/frontend/src/lib/__tests__/auth-cache-reset.test.ts
@@ -230,6 +230,49 @@ describe('wireAuthCacheReset', () => {
     }
   });
 
+  // fix(#1850): the AI chat transcript is sessionStorage keyed on the map,
+  // not on identity, and previously outlived logout — a second user signing
+  // in in the same tab would render the first user's prompts and query
+  // metadata.
+  it('clears geolens-chat-* sessionStorage keys when identity changes, not on token refresh', () => {
+    const qc = new QueryClient();
+    const unsubscribe = wireAuthCacheReset(qc);
+    try {
+      useAuthStore.setState({ token: 't1', user: { id: 'user-1' } as UserResponse });
+      sessionStorage.setItem('geolens-chat-map-1', '[{"role":"user","content":"user-1 prompt"}]');
+      sessionStorage.setItem('geolens-chat-result', '{"prompt":"user-1 query"}');
+      sessionStorage.setItem('unrelated-key', 'kept');
+
+      // Token refresh (same identity): kept.
+      useAuthStore.setState({ token: 't2' });
+      expect(sessionStorage.getItem('geolens-chat-map-1')).not.toBeNull();
+
+      // A second identity signs in WITHOUT a page reload: cleared.
+      useAuthStore.setState({ token: 't3', user: { id: 'user-2' } as UserResponse });
+      expect(sessionStorage.getItem('geolens-chat-map-1')).toBeNull();
+      expect(sessionStorage.getItem('geolens-chat-result')).toBeNull();
+      expect(sessionStorage.getItem('unrelated-key')).toBe('kept');
+    } finally {
+      unsubscribe();
+      sessionStorage.clear();
+    }
+  });
+
+  it('clears geolens-chat-* sessionStorage keys on logout', () => {
+    const qc = new QueryClient();
+    const unsubscribe = wireAuthCacheReset(qc);
+    try {
+      useAuthStore.setState({ token: 't1', user: { id: 'user-1' } as UserResponse });
+      sessionStorage.setItem('geolens-chat-map-1', '[]');
+
+      useAuthStore.setState({ token: null, user: null });
+      expect(sessionStorage.getItem('geolens-chat-map-1')).toBeNull();
+    } finally {
+      unsubscribe();
+      sessionStorage.clear();
+    }
+  });
+
   it('clears identity-scoped search fields on logout', () => {
     const qc = new QueryClient();
     const unsubscribe = wireAuthCacheReset(qc);

--- a/frontend/src/lib/auth-cache-reset.ts
+++ b/frontend/src/lib/auth-cache-reset.ts
@@ -7,6 +7,29 @@ import { clearUploadBatch, clearPendingUploadFiles } from '@/api/upload-session'
 import { clearStacImport } from '@/api/stac-import-session';
 
 /**
+ * fix(#1850): the AI chat transcript (`geolens-chat-<mapId>`, ChatPanel.tsx)
+ * and the one-shot "open in builder" handoff payload (`geolens-chat-result`,
+ * chat-result-handoff.ts) are sessionStorage, keyed only on the map — not on
+ * identity. sessionStorage outlives logout, so a second user signing in in
+ * the same tab sees the first user's prompts, dataset names and query
+ * metadata. Same choke point, same rule as the stores below: identity
+ * changed, drop it. Collecting keys first, then removing, because removing
+ * mid-loop shifts sessionStorage's live index and skips entries.
+ */
+function clearChatSessionStorage(): void {
+  try {
+    const toRemove: string[] = [];
+    for (let i = 0; i < sessionStorage.length; i++) {
+      const key = sessionStorage.key(i);
+      if (key?.startsWith('geolens-chat-')) toRemove.push(key);
+    }
+    toRemove.forEach((key) => sessionStorage.removeItem(key));
+  } catch {
+    // storage unavailable (private mode / disabled) — nothing to clear.
+  }
+}
+
+/**
  * fix(#430 codex r6): user-scoped queries (dataset search, map search, map
  * lists) key their caches by request parameters only, so after a logout — or a
  * lower-privilege login in the same tab — the previous identity's cached rows
@@ -49,6 +72,8 @@ export function wireAuthCacheReset(queryClient: QueryClient): () => void {
     useDrawingStore.getState().bumpSessionEpoch();
     useDrawingStore.getState().clearDrawing();
     useSearchStore.getState().clearIdentityScopedFilters();
+    // fix(#1850): see clearChatSessionStorage's doc comment above.
+    clearChatSessionStorage();
 
     // fix(#1712): the Upload and STAC tabs' module-scoped in-flight
     // sessions are the same kind of identity-scoped residue — each records

--- a/frontend/src/lib/auth-cache-reset.ts
+++ b/frontend/src/lib/auth-cache-reset.ts
@@ -5,6 +5,7 @@ import { useDrawingStore } from '@/stores/drawing-store';
 import { useSearchStore } from '@/stores/search-store';
 import { clearUploadBatch, clearPendingUploadFiles } from '@/api/upload-session';
 import { clearStacImport } from '@/api/stac-import-session';
+import { removeSessionStorage } from '@/lib/storage';
 
 /**
  * fix(#1850): the AI chat transcript (`geolens-chat-<mapId>`, ChatPanel.tsx)
@@ -15,6 +16,13 @@ import { clearStacImport } from '@/api/stac-import-session';
  * metadata. Same choke point, same rule as the stores below: identity
  * changed, drop it. Collecting keys first, then removing, because removing
  * mid-loop shifts sessionStorage's live index and skips entries.
+ *
+ * fix(#1536 gate): the enumeration (`.length`/`.key`) has no helper in
+ * lib/storage.ts, so it stays raw here, guarded by the try/catch below —
+ * kept as a plain loop rather than `.forEach`, which would cross a function
+ * boundary and fall outside the try's frame. The removal itself goes
+ * through `removeSessionStorage`, which is already exception-safe on its
+ * own.
  */
 function clearChatSessionStorage(): void {
   try {
@@ -23,7 +31,9 @@ function clearChatSessionStorage(): void {
       const key = sessionStorage.key(i);
       if (key?.startsWith('geolens-chat-')) toRemove.push(key);
     }
-    toRemove.forEach((key) => sessionStorage.removeItem(key));
+    for (const key of toRemove) {
+      removeSessionStorage(key);
+    }
   } catch {
     // storage unavailable (private mode / disabled) — nothing to clear.
   }

--- a/frontend/src/pages/DatasetPage.tsx
+++ b/frontend/src/pages/DatasetPage.tsx
@@ -616,7 +616,17 @@ export function DatasetPage() {
 
       {/* Tabbed content — tabs shown are driven by record_type */}
       <Suspense fallback={<DatasetDetailSkeleton isTable={isTable} />}>
+        {/* fix(#1851 review P1): DatasetPage stays mounted across a dataset-to-
+            dataset route change, so InlineEdit fields under here kept their
+            own local editing/draft state — uncommitted keystrokes on dataset
+            A survived onto dataset B's editor and a save could PATCH them
+            there. Keying on the dataset id forces a remount on every
+            navigation, which resets every InlineEdit's local state along
+            with everything else under this subtree. useDraftEditing's own
+            datasetId-keyed reset (frontend/src/components/dataset/hooks/use-
+            draft-editing.ts) covers the separate, already-staged case. */}
         <DetailPanel
+          key={dataset.id}
           dataset={dataset}
           canEdit={canEdit}
           canEditData={canEditData}

--- a/frontend/src/pages/DatasetPage.tsx
+++ b/frontend/src/pages/DatasetPage.tsx
@@ -725,7 +725,16 @@ export function DatasetPage() {
             <AlertDialogCancel onClick={() => blocker.reset?.()}>
               {t('unsaved.stay', { defaultValue: 'Stay' })}
             </AlertDialogCancel>
-            <AlertDialogAction variant="destructive" onClick={() => blocker.proceed?.()}>
+            <AlertDialogAction
+              variant="destructive"
+              onClick={() => {
+                // fix(#1851): "Leave" claimed to discard but only navigated —
+                // the staged drafts stayed in state and reappeared (then could
+                // PATCH) on whatever mounted next.
+                discardPendingDrafts();
+                blocker.proceed?.();
+              }}
+            >
               {t('unsaved.leave', { defaultValue: 'Leave' })}
             </AlertDialogAction>
           </AlertDialogFooter>

--- a/frontend/src/pages/__tests__/DatasetPage.edit-affordances.test.tsx
+++ b/frontend/src/pages/__tests__/DatasetPage.edit-affordances.test.tsx
@@ -361,6 +361,52 @@ describe('DatasetPage editable affordance integration', () => {
     });
   });
 
+  // fix(#1851 review P1): resetting useDraftEditing's own state (the test
+  // above) is not enough — InlineEdit keeps its OWN local editing/draft
+  // state, and it deliberately ignores prop-value changes while `editing` is
+  // true (see InlineEdit.tsx's sync effect). Typed-but-uncommitted text in an
+  // open editor survived a dataset-to-dataset navigation and could be PATCHed
+  // onto the wrong dataset on the next Save. Covers "route change to a
+  // cached dataset" directly, since DetailPanel's key={dataset.id} (the fix)
+  // is what has to remount it — going through the Leave button first would
+  // also work, but risks the dialog's own focus trap blurring the textarea
+  // and masking the bug via InlineEdit's separate blur-cancels-uncommitted-
+  // edits behavior.
+  it('discards uncommitted InlineEdit text on navigation to a different (cached) dataset', async () => {
+    setUser(EDITOR_USER);
+    const user = userEvent.setup();
+
+    const datasetB: DatasetResponse = { ...makeDataset(), id: 'dataset-2', summary: 'Second dataset summary' };
+    mockUseDataset.mockImplementation(((datasetId: string) => ({
+      data: datasetId === 'dataset-2' ? datasetB : makeDataset(),
+      isLoading: false,
+      error: null,
+    })) as unknown as typeof useDataset);
+
+    const { rerender } = render(<DatasetPage />, { route: '/datasets/dataset-1' });
+
+    await user.click(await screen.findByText('Original summary'));
+    const summaryInput = screen.getByDisplayValue('Original summary');
+    await user.clear(summaryInput);
+    await user.type(summaryInput, 'Uncommitted dataset A text');
+    // Deliberately no Ctrl+Enter and no blur — this text was never staged or
+    // saved, only typed.
+
+    expect(await screen.findByTestId('pending-edits-bar')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('Uncommitted dataset A text')).toBeInTheDocument();
+
+    // Navigate to a different, already-cached dataset.
+    mockUseParams.mockReturnValue({ id: 'dataset-2' });
+    rerender(<DatasetPage />);
+
+    expect(await screen.findByText('Second dataset summary')).toBeInTheDocument();
+    expect(screen.queryByDisplayValue('Uncommitted dataset A text')).not.toBeInTheDocument();
+    expect(mutateAsync).not.toHaveBeenCalled();
+    await waitFor(() => {
+      expect(screen.queryByTestId('pending-edits-bar')).not.toBeInTheDocument();
+    });
+  });
+
   it('keeps viewer fields read-only and reveals denial hint only after attempted edit', async () => {
     setUser(VIEWER_USER);
     const user = userEvent.setup();

--- a/frontend/src/pages/__tests__/DatasetPage.edit-affordances.test.tsx
+++ b/frontend/src/pages/__tests__/DatasetPage.edit-affordances.test.tsx
@@ -14,6 +14,10 @@ const drawingStoreState = vi.hoisted(() => ({
   clearDrawing: vi.fn(),
 }));
 
+// fix(#1851): a plain object mock can't vary the blocker's `state` per test,
+// and the "Leave" wiring is only exercised while it is 'blocked'.
+const mockUseUnsavedGuard = vi.hoisted(() => vi.fn());
+
 vi.mock('react-router', async (importOriginal) => {
   const actual = await importOriginal<typeof import('react-router')>();
   return {
@@ -23,7 +27,7 @@ vi.mock('react-router', async (importOriginal) => {
 });
 
 vi.mock('@/hooks/use-unsaved-guard', () => ({
-  useUnsavedGuard: () => ({ state: 'unblocked', reset: vi.fn(), proceed: vi.fn() }),
+  useUnsavedGuard: mockUseUnsavedGuard,
 }));
 
 vi.mock('@/components/dataset/hooks/use-dataset', () => ({
@@ -252,6 +256,8 @@ describe('DatasetPage editable affordance integration', () => {
     drawingStoreState.isEditDirty = false;
     drawingStoreState.setDrawing.mockReset();
     drawingStoreState.clearDrawing.mockReset();
+    mockUseUnsavedGuard.mockReset();
+    mockUseUnsavedGuard.mockReturnValue({ state: 'unblocked', reset: vi.fn(), proceed: vi.fn() });
 
     mockUseParams.mockReturnValue({ id: 'dataset-1' });
     mockUseDataset.mockReturnValue({
@@ -322,6 +328,37 @@ describe('DatasetPage editable affordance integration', () => {
     });
 
     expect(screen.getByText('Original summary')).toBeInTheDocument();
+  });
+
+  // fix(#1851): "Leave" on the unsaved-changes dialog let navigation proceed
+  // without discarding the staged draft, which then reappeared (and could be
+  // saved) against whatever dataset mounted next.
+  it('discards the staged draft when the user chooses Leave on the unsaved-changes dialog', async () => {
+    setUser(EDITOR_USER);
+    const user = userEvent.setup();
+    const mockProceed = vi.fn();
+
+    const { rerender } = render(<DatasetPage />, { route: '/datasets/dataset-1' });
+
+    await user.click(await screen.findByText('Original summary'));
+    const summaryInput = screen.getByDisplayValue('Original summary');
+    await user.clear(summaryInput);
+    await user.type(summaryInput, 'Updated summary pending save');
+    await user.keyboard('{Control>}{Enter}{/Control}');
+
+    expect(await screen.findByTestId('pending-edits-bar')).toBeInTheDocument();
+
+    // Simulate the blocker intercepting a route change with unsaved changes
+    // present — the same shape react-router's real useBlocker returns.
+    mockUseUnsavedGuard.mockReturnValue({ state: 'blocked', reset: vi.fn(), proceed: mockProceed });
+    rerender(<DatasetPage />);
+
+    await user.click(await screen.findByRole('button', { name: 'Leave' }));
+
+    expect(mockProceed).toHaveBeenCalledTimes(1);
+    await waitFor(() => {
+      expect(screen.queryByTestId('pending-edits-bar')).not.toBeInTheDocument();
+    });
   });
 
   it('keeps viewer fields read-only and reveals denial hint only after attempted edit', async () => {


### PR DESCRIPTION
Three fixes from the frontend audit of 2026-09-04, tracked in #1849, #1850, #1851.

## #1849 - tryRefresh() reports success after a failed refresh

`tryRefresh()` returned whether a token was present in the store, not whether the refresh that just ran actually replaced it. On a failed refresh the old token was still sitting there, so the check read as success: the caller retried the original request with a dead token, resending the whole payload on the ingest path before falling through to logout anyway. The 429 back-off branch was also unreachable, because `refreshAccessToken` threw a plain `Error` rather than the `ApiError` `tryRefresh` checks for.

Fix: `tryRefresh()` now returns the actual outcome of the refresh, and `refreshAccessToken` throws `ApiError` so the 429 branch is reachable.

## #1850 - AI chat transcript survives logout in the same tab

`ChatPanel` persists the chat transcript to sessionStorage keyed only on the map (`geolens-chat-<mapId>`). sessionStorage outlives logout, so a second user signing into the same tab would see the first user's prompts, dataset names and query metadata.

Fix: `wireAuthCacheReset` (the existing identity choke point) now clears every `geolens-chat-*` key on an identity change. That prefix also covers `chat-result-handoff.ts`'s one-shot `geolens-chat-result` payload.

A grep of `sessionStorage.setItem`/`localStorage.setItem` across `frontend/src` turned up a few other keys not cleared by this choke point: theme-provider's theme preference, SiteBanner's dismiss marker, stale-asset-reload's reload latch, and storage.ts's `geolens-map-notes-*`. None of those carry another user's content the way the chat transcript does, so they're left alone here.

## #1851 - staged dataset metadata drafts survive navigation and PATCH the next dataset

`DatasetPage` stays mounted across a route change from one dataset's edit view to another - only the `datasetId` param changes, not the component instance - so `useDraftEditing`'s staged-draft state survived the navigation. The unsaved-changes dialog's "Leave" button made this worse: it let navigation proceed without discarding anything. Landing on dataset B still showed dataset A's staged summary, lineage, etc., and Save would PATCH them onto B.

Fix: `useDraftEditing` resets its draft state whenever `datasetId` changes, and the "Leave" button now calls `discardPendingDrafts()` before it proceeds.

## Verification

All three fixes were confirmed against a counterfactual: reverting each source file to its `origin/main` version while keeping the new tests reproduced the exact bug described in the audit finding, then restoring the fix turned the tests green.

```
cd frontend && npx vitest run src/api/__tests__/client.test.ts src/api/__tests__/client.session-expiry.test.ts src/api/__tests__/client.embed-anonymous-1515.test.ts src/lib/__tests__/auth-cache-reset.test.ts src/components/dataset/hooks/__tests__/use-draft-editing.test.ts src/pages/__tests__/DatasetPage.edit-affordances.test.tsx
# Test Files  6 passed (6)
# Tests  70 passed (70)

npm run typecheck   # clean
npm run lint         # clean
```

No schema, API, or config changes. No new `t()` keys.