### PR TITLE
fix: front-door UX fixes (#1852, #1853, #1854, #1856)

### DIFF
--- a/frontend/src/api/datasets.ts
+++ b/frontend/src/api/datasets.ts
@@ -74,7 +74,11 @@ export function getCogDownloadUrl(id: string): string {
   return `${API_BASE}/datasets/${id}/download/cog`;
 }
 
-async function authenticatedDownload(url: string, filename: string): Promise<void> {
+// fix(#1863 P1): exported so any same-origin GeoLens API resource can be
+// downloaded through the same refresh-aware, bearer-authenticated flow —
+// a plain <a href> browser navigation carries no Authorization header, so a
+// private or unpublished dataset's export endpoint rejects it as anonymous.
+export async function authenticatedDownload(url: string, filename: string): Promise<void> {
   // BUG-035: refresh-aware raw fetch so a download issued as the first request
   // after a long idle transparently refreshes the JWT instead of 401-ing.
   const response = await authenticatedRawFetch(url);

--- a/frontend/src/components/auth/__tests__/OAuthButtons.test.tsx
+++ b/frontend/src/components/auth/__tests__/OAuthButtons.test.tsx
@@ -77,4 +77,30 @@ describe('OAuthButtons', () => {
       ).toBeInTheDocument();
     });
   });
+
+  // fix(#1852): a 2026-09-04 UX audit flagged "three unlabelled icon
+  // buttons" on the login page's SSO row. The compact (2-3 branded
+  // providers) layout renders icon-only, with the label carried on
+  // aria-label/title instead of visible text — but no test exercised that
+  // path, so a regression here would have shipped silently. Locking it in.
+  it('gives each icon-only button in the compact (3-provider) layout an accessible name', async () => {
+    const { getOAuthProviders } = await import('@/api/auth');
+    (getOAuthProviders as ReturnType<typeof vi.fn>).mockResolvedValueOnce([
+      { slug: 'google', display_name: 'Google', provider_type: 'google' },
+      { slug: 'microsoft', display_name: 'Microsoft', provider_type: 'microsoft' },
+      { slug: 'github', display_name: 'GitHub', provider_type: 'github' },
+    ]);
+
+    render(<OAuthButtons />);
+
+    const google = await screen.findByRole('button', { name: /sign in with google/i });
+    const microsoft = await screen.findByRole('button', { name: /sign in with microsoft/i });
+    const github = await screen.findByRole('button', { name: /sign in with github/i });
+
+    // Icon-only: no visible label text inside the button, only the icon.
+    for (const button of [google, microsoft, github]) {
+      expect(button).toHaveAttribute('aria-label');
+      expect(button.querySelector('span')).not.toBeInTheDocument();
+    }
+  });
 });

--- a/frontend/src/components/builder/hooks/__tests__/use-builder-layers.add-dataset-auto-zoom.test.tsx
+++ b/frontend/src/components/builder/hooks/__tests__/use-builder-layers.add-dataset-auto-zoom.test.tsx
@@ -24,9 +24,23 @@ import type { MapResponse } from '@/types/api';
 
 type MaplibreMap = import('maplibre-gl').Map;
 
-function renderWithAddDatasetParam(mapData: MapResponse) {
+function renderWithAddDatasetParam(
+  mapData: MapResponse,
+  options: { startWithMapLoaded?: boolean } = {},
+) {
+  const { startWithMapLoaded = true } = options;
   const map = makeMapLibreMock();
-  const mapRef = { current: map } as React.RefObject<MaplibreMap | null>;
+  const mapRef = {
+    current: startWithMapLoaded ? map : null,
+  } as React.RefObject<MaplibreMap | null>;
+  // fix(#1863 P2): mirrors MapBuilderPage's OWN pair — mapInstanceRef (read
+  // imperatively) and a reactive `mapInstance` state, both flipped together
+  // in handleMapRef. `mapInstance` here is a plain mutable binding (not
+  // React state) because this hook is rendered directly with renderHook, not
+  // through MapBuilderPage; `simulateMapLoad` below re-invokes the hook
+  // closure via `hook.rerender()` so the NEW value is what the next render
+  // of useBuilderLayers actually receives as its 7th argument.
+  let mapInstance: MaplibreMap | null = startWithMapLoaded ? map : null;
   const mutate = vi.fn();
   const addLayerMutation = { mutate } as unknown as Parameters<typeof useBuilderLayers>[3];
   const removeLayerMutation = { mutate: vi.fn() } as unknown as Parameters<typeof useBuilderLayers>[4];
@@ -56,11 +70,27 @@ function renderWithAddDatasetParam(mapData: MapResponse) {
         addLayerMutation,
         removeLayerMutation,
         saveBaselineSyncRef,
+        mapInstance,
       ),
     { wrapper: Wrapper },
   );
 
-  return { hook, mutate, fitBounds: map.fitBounds as unknown as ReturnType<typeof vi.fn> };
+  // fix(#1863 P2): simulates BuilderMap's onLoad -> MapBuilderPage's
+  // handleMapRef, which sets mapInstanceRef.current synchronously BEFORE
+  // calling setMapInstance — so the ref is always in sync by the time a
+  // render sees the new mapInstance value.
+  function simulateMapLoad() {
+    mapRef.current = map;
+    mapInstance = map;
+    hook.rerender();
+  }
+
+  return {
+    hook,
+    mutate,
+    fitBounds: map.fitBounds as unknown as ReturnType<typeof vi.fn>,
+    simulateMapLoad,
+  };
 }
 
 describe('?add_dataset auto-zoom (#1854)', () => {
@@ -87,6 +117,45 @@ describe('?add_dataset auto-zoom (#1854)', () => {
     expect(hook.result.current.localLayers.map((l) => l.id)).toContain('new-layer-id');
     // ...and the auto-zoom watcher fired against the COMMITTED layer, so the
     // lookup inside handleZoomToLayer actually found dataset_extent_bbox.
+    expect(fitBounds).toHaveBeenCalledTimes(1);
+    expect(fitBounds.mock.calls[0][0]).toEqual([
+      [-74.5, 40.5],
+      [-73.5, 41.5],
+    ]);
+  });
+
+  // fix(#1863 P2, codex round 1): on a cold builder entry the add-layer POST
+  // can resolve — landing the layer in localLayers — before the lazily
+  // loaded BuilderMap has finished mounting and firing onLoad. The old
+  // watcher effect cleared pendingAutoZoomLayerIdRef as soon as the layer
+  // appeared, regardless of map readiness, so handleZoomToLayer's `if
+  // (!map) return;` silently swallowed the zoom and nothing ever retried it.
+  it('retries the auto-zoom once the map finishes loading, when the layer commits first (cold entry)', () => {
+    const mapData = makeBuilderMap([], { center_lng: null, center_lat: null });
+    const { hook, mutate, fitBounds, simulateMapLoad } = renderWithAddDatasetParam(mapData, {
+      startWithMapLoaded: false,
+    });
+
+    expect(mutate).toHaveBeenCalledOnce();
+    const [, { onSuccess }] = mutate.mock.calls[0];
+    const createdLayer = makeBuilderLayer({
+      id: 'new-layer-id',
+      dataset_id: 'ds-1',
+      dataset_extent_bbox: [-74.5, 40.5, -73.5, 41.5],
+    });
+    act(() => {
+      onSuccess(createdLayer);
+    });
+
+    // Layer landed, but the map instance does not exist yet — must NOT fire.
+    expect(hook.result.current.localLayers.map((l) => l.id)).toContain('new-layer-id');
+    expect(fitBounds).not.toHaveBeenCalled();
+
+    // Map finishes loading afterward (BuilderMap onLoad -> handleMapRef).
+    act(() => {
+      simulateMapLoad();
+    });
+
     expect(fitBounds).toHaveBeenCalledTimes(1);
     expect(fitBounds.mock.calls[0][0]).toEqual([
       [-74.5, 40.5],

--- a/frontend/src/components/builder/hooks/__tests__/use-builder-layers.add-dataset-auto-zoom.test.tsx
+++ b/frontend/src/components/builder/hooks/__tests__/use-builder-layers.add-dataset-auto-zoom.test.tsx
@@ -1,0 +1,114 @@
+// fix(#1854): a fresh map (no saved view of its own) auto-adds a dataset via
+// the ?add_dataset URL param but never zoomed to it, so it landed at the
+// world-view default and the newly added layer could be off-screen. The
+// ?add_dataset effect now zooms to the new layer once — but only via a
+// watcher effect on `localLayers`, not directly from handleAddDataset's
+// onSuccessCb: layersRef (which handleZoomToLayer reads) is only synced by
+// the useLayoutEffect mirror on commit, so calling handleZoomToLayer
+// synchronously inside onSuccess would race a still-stale ref (same hazard
+// #554's codex fix documented for the add-layer merge itself). These tests
+// exercise the real ?add_dataset flow end to end to prove the zoom actually
+// fires, not just that the wiring compiles.
+import { describe, it, expect, vi } from 'vitest';
+import { act } from '@testing-library/react';
+import { renderHook } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter } from 'react-router';
+import { useBuilderLayers } from '@/components/builder/hooks/use-builder-layers';
+import {
+  makeBuilderLayer,
+  makeBuilderMap,
+  makeMapLibreMock,
+} from '@/components/builder/__tests__/fixtures/map-builder-fixtures';
+import type { MapResponse } from '@/types/api';
+
+type MaplibreMap = import('maplibre-gl').Map;
+
+function renderWithAddDatasetParam(mapData: MapResponse) {
+  const map = makeMapLibreMock();
+  const mapRef = { current: map } as React.RefObject<MaplibreMap | null>;
+  const mutate = vi.fn();
+  const addLayerMutation = { mutate } as unknown as Parameters<typeof useBuilderLayers>[3];
+  const removeLayerMutation = { mutate: vi.fn() } as unknown as Parameters<typeof useBuilderLayers>[4];
+  const saveBaselineSyncRef = {
+    current: { add: vi.fn(), remove: () => {} },
+  } as unknown as Parameters<typeof useBuilderLayers>[5];
+
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  function Wrapper({ children }: { children: React.ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter initialEntries={['/builder/map-1?add_dataset=ds-1']}>
+          {children}
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+  }
+
+  const hook = renderHook(
+    () =>
+      useBuilderLayers(
+        mapData,
+        mapRef,
+        'map-1',
+        addLayerMutation,
+        removeLayerMutation,
+        saveBaselineSyncRef,
+      ),
+    { wrapper: Wrapper },
+  );
+
+  return { hook, mutate, fitBounds: map.fitBounds as unknown as ReturnType<typeof vi.fn> };
+}
+
+describe('?add_dataset auto-zoom (#1854)', () => {
+  it('zooms to the newly added layer once it commits, on a fresh map with no saved view', () => {
+    const mapData = makeBuilderMap([], { center_lng: null, center_lat: null });
+    const { hook, mutate, fitBounds } = renderWithAddDatasetParam(mapData);
+
+    // The effect fires handleAddDataset('ds-1', ...) on mount.
+    expect(mutate).toHaveBeenCalledOnce();
+    const [{ data }] = mutate.mock.calls[0];
+    expect(data).toMatchObject({ dataset_id: 'ds-1' });
+
+    const [, { onSuccess }] = mutate.mock.calls[0];
+    const createdLayer = makeBuilderLayer({
+      id: 'new-layer-id',
+      dataset_id: 'ds-1',
+      dataset_extent_bbox: [-74.5, 40.5, -73.5, 41.5],
+    });
+    act(() => {
+      onSuccess(createdLayer);
+    });
+
+    // The layer landed in localLayers (P1-08 optimistic merge)...
+    expect(hook.result.current.localLayers.map((l) => l.id)).toContain('new-layer-id');
+    // ...and the auto-zoom watcher fired against the COMMITTED layer, so the
+    // lookup inside handleZoomToLayer actually found dataset_extent_bbox.
+    expect(fitBounds).toHaveBeenCalledTimes(1);
+    expect(fitBounds.mock.calls[0][0]).toEqual([
+      [-74.5, 40.5],
+      [-73.5, 41.5],
+    ]);
+  });
+
+  it('does not auto-zoom a map that already has its own saved view', () => {
+    const mapData = makeBuilderMap([], { center_lng: -73.9, center_lat: 40.7, zoom: 12 });
+    const { mutate, fitBounds } = renderWithAddDatasetParam(mapData);
+
+    expect(mutate).toHaveBeenCalledOnce();
+    const [, { onSuccess }] = mutate.mock.calls[0];
+    const createdLayer = makeBuilderLayer({
+      id: 'new-layer-id',
+      dataset_id: 'ds-1',
+      dataset_extent_bbox: [-74.5, 40.5, -73.5, 41.5],
+    });
+    act(() => {
+      onSuccess(createdLayer);
+    });
+
+    expect(fitBounds).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/builder/hooks/use-builder-layers.ts
+++ b/frontend/src/components/builder/hooks/use-builder-layers.ts
@@ -82,6 +82,16 @@ export function useBuilderLayers(
   // baseline learns about server-created layers immediately, instead of only
   // on a clean-state resync — see use-builder-save.ts for the full rationale.
   saveBaselineSyncRef: React.MutableRefObject<SaveBaselineSync>,
+  // fix(#1863 P2): the REACTIVE counterpart of mapInstanceRef (MapBuilderPage
+  // already tracks both — mapInstanceRef for imperative reads, this state for
+  // effects that must re-run when the map becomes ready). mapInstanceRef.current
+  // flipping non-null does NOT by itself re-run an effect (refs aren't
+  // reactive), so the #1854 auto-zoom watcher below needs this to know when
+  // to retry a pending zoom that arrived before the (lazy-loaded, possibly
+  // still-suspended) map instance existed. Optional/trailing so every
+  // existing call site compiles unchanged; omitting it only means a
+  // cold-entry auto-zoom race is not retried, same as before this fix.
+  mapInstance?: MaplibreMap | null,
 ) {
   const [searchParams, setSearchParams] = useSearchParams();
   const { t } = useTranslation('builder');
@@ -513,13 +523,24 @@ export function useBuilderLayers(
   // above) once the new layer has actually committed to localLayers — by
   // then the useLayoutEffect mirror has already synced layersRef, so
   // handleZoomToLayer's lookup finds the layer and its dataset_extent_bbox.
+  //
+  // fix(#1863 P2): on a cold builder entry the add-layer POST can resolve
+  // (landing the layer in localLayers) while BuilderMap is still lazy-loaded/
+  // suspended or before its onLoad has populated mapInstanceRef — handleZoomToLayer
+  // reads mapInstanceRef.current and silently no-ops when it is null. The old
+  // version cleared pendingAutoZoomLayerIdRef unconditionally as soon as the
+  // layer appeared, so nothing ever retried once the map became ready. Keep
+  // the pending id until `mapInstance` (the reactive counterpart of the ref —
+  // see the parameter above) is actually set, so this effect re-runs and
+  // retries when the map finishes loading after the layer already landed.
   useEffect(() => {
     const pendingId = pendingAutoZoomLayerIdRef.current;
     if (!pendingId) return;
+    if (!mapInstance) return;
     if (!localLayers.some((l) => l.id === pendingId)) return;
     pendingAutoZoomLayerIdRef.current = null;
     handleZoomToLayer(pendingId);
-  }, [localLayers, handleZoomToLayer]);
+  }, [localLayers, mapInstance, handleZoomToLayer]);
 
   // ENH-06 (Phase 1201-06): set the map-level custom legend title. Empty/null
   // clears the override. Marks the map dirty so the save path persists it.

--- a/frontend/src/components/builder/hooks/use-builder-layers.ts
+++ b/frontend/src/components/builder/hooks/use-builder-layers.ts
@@ -90,6 +90,9 @@ export function useBuilderLayers(
 
   const initializedRef = useRef(false);
   const addDatasetProcessedRef = useRef(false);
+  // fix(#1854): id of a just-added layer that still needs its one-time
+  // auto-zoom (fresh map only — see the add_dataset effect below).
+  const pendingAutoZoomLayerIdRef = useRef<string | null>(null);
 
   const [localLayers, setLocalLayers] = useState<MapLayerResponse[]>([]);
   // fix(#793 review): which map the CURRENT localLayers belong to. On direct
@@ -332,7 +335,20 @@ export function useBuilderLayers(
     const datasetId = searchParams.get('add_dataset');
     if (!datasetId) return;
     addDatasetProcessedRef.current = true;
-    handleAddDataset(datasetId);
+    // fix(#1854): a fresh map has no saved view of its own (center_lng/
+    // center_lat are null — mirrors BuilderMap's hasSavedView check) and
+    // opens at the world-view default, so the just-added dataset can land
+    // off-screen. Record the new layer id for the one-time auto-zoom effect
+    // below; a map with its own saved view is left alone (that framing was
+    // chosen on purpose). Don't call handleZoomToLayer directly from this
+    // callback — layersRef is only synced via the useLayoutEffect mirror on
+    // commit (the same staleness #554 documented for the add-layer merge),
+    // so it would still be missing the layer just created.
+    const hasSavedView = mapData?.center_lng != null && mapData?.center_lat != null;
+    handleAddDataset(
+      datasetId,
+      hasSavedView ? undefined : (newLayerId) => { pendingAutoZoomLayerIdRef.current = newLayerId; },
+    );
     setSearchParams((prev) => {
       prev.delete('add_dataset');
       return prev;
@@ -492,6 +508,18 @@ export function useBuilderLayers(
       // Silently ignore invalid bounds (e.g. out-of-range coordinates)
     }
   }, [mapInstanceRef]);
+
+  // fix(#1854): fires the pending auto-zoom (set by the ?add_dataset effect
+  // above) once the new layer has actually committed to localLayers — by
+  // then the useLayoutEffect mirror has already synced layersRef, so
+  // handleZoomToLayer's lookup finds the layer and its dataset_extent_bbox.
+  useEffect(() => {
+    const pendingId = pendingAutoZoomLayerIdRef.current;
+    if (!pendingId) return;
+    if (!localLayers.some((l) => l.id === pendingId)) return;
+    pendingAutoZoomLayerIdRef.current = null;
+    handleZoomToLayer(pendingId);
+  }, [localLayers, handleZoomToLayer]);
 
   // ENH-06 (Phase 1201-06): set the map-level custom legend title. Empty/null
   // clears the override. Marks the map dirty so the save path persists it.

--- a/frontend/src/components/dataset/DistributionsList.tsx
+++ b/frontend/src/components/dataset/DistributionsList.tsx
@@ -15,6 +15,7 @@ import {
   getPublicApiBaseUrl,
   resolveDistributionUrl,
   isAbsoluteUrl,
+  isFetchableDistributionUrl,
 } from '@/lib/dataset-access';
 import { authenticatedDownload } from '@/api/datasets';
 import type { DistributionResponse } from '@/types/api';
@@ -66,6 +67,14 @@ function CopyableUrl({
   // external viewer app) passes through unchanged and is not a GeoLens API
   // resource, so it must never receive this session's bearer token.
   const isSameOriginApiResource = !isAbsoluteUrl(distribution.url);
+  // fix(#1863 P2): a vector-tile row's url is a template
+  // (/tiles/data.<table>/{z}/{x}/{y}.pbf — no literal resource at that
+  // path) and a raster/VRT row's url is a bare object-storage key
+  // (rasters/<id>/<sha>/source.cog.tif — not the real, token-gated COG
+  // download route). Neither is something a single fetch resolves, so ONLY
+  // an actually-fetchable url gets a download action at all; the rest stay
+  // copy-only rows.
+  const isFetchable = isFetchableDistributionUrl(distribution.url);
 
   useEffect(() => () => clearTimeout(timerRef.current), []);
 
@@ -118,36 +127,41 @@ function CopyableUrl({
           the resource. Same-origin GeoLens resources download through the
           authenticated fetch flow (needed for private/unpublished datasets);
           an external URL from a manual distribution is a plain link instead
-          — it is not ours to attach a bearer token to. */}
-      {isSameOriginApiResource ? (
-        <Button
-          variant="ghost"
-          size="icon"
-          className="h-7 w-7 shrink-0"
-          onClick={handleAuthenticatedDownload}
-          disabled={downloading}
-          aria-label={t('distributions.downloadUrl')}
-          title={t('distributions.downloadUrl')}
-        >
-          {downloading ? (
-            <Loader2 className="h-3.5 w-3.5 animate-spin" />
-          ) : (
-            <Download className="h-3.5 w-3.5" />
-          )}
-        </Button>
-      ) : (
-        <Button variant="ghost" size="icon" className="h-7 w-7 shrink-0" asChild>
-          <a
-            href={resolvedUrl}
-            target="_blank"
-            rel="noopener noreferrer"
+          — it is not ours to attach a bearer token to.
+          fix(#1863 P2): a tile-template or bare-storage-key row (see
+          isFetchable above) gets no download action at all — copy remains
+          the only way to get the value, since there is nothing a single
+          fetch or plain navigation could resolve. */}
+      {isFetchable &&
+        (isSameOriginApiResource ? (
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-7 w-7 shrink-0"
+            onClick={handleAuthenticatedDownload}
+            disabled={downloading}
             aria-label={t('distributions.downloadUrl')}
             title={t('distributions.downloadUrl')}
           >
-            <Download className="h-3.5 w-3.5" />
-          </a>
-        </Button>
-      )}
+            {downloading ? (
+              <Loader2 className="h-3.5 w-3.5 animate-spin" />
+            ) : (
+              <Download className="h-3.5 w-3.5" />
+            )}
+          </Button>
+        ) : (
+          <Button variant="ghost" size="icon" className="h-7 w-7 shrink-0" asChild>
+            <a
+              href={resolvedUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label={t('distributions.downloadUrl')}
+              title={t('distributions.downloadUrl')}
+            >
+              <Download className="h-3.5 w-3.5" />
+            </a>
+          </Button>
+        ))}
       <Button
         variant="ghost"
         size="icon"

--- a/frontend/src/components/dataset/DistributionsList.tsx
+++ b/frontend/src/components/dataset/DistributionsList.tsx
@@ -1,5 +1,6 @@
 import { useState, useRef, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
+import { toast } from 'sonner';
 import {
   useDistributions,
   useSetPrimaryDistribution,
@@ -13,7 +14,9 @@ import { LoadingState } from '@/components/layout/LoadingState';
 import {
   getPublicApiBaseUrl,
   resolveDistributionUrl,
+  isAbsoluteUrl,
 } from '@/lib/dataset-access';
+import { authenticatedDownload } from '@/api/datasets';
 import type { DistributionResponse } from '@/types/api';
 
 interface DistributionsListProps {
@@ -46,11 +49,23 @@ const DISTRIBUTION_GROUPS: Record<string, DistributionGroup> = {
   other: 'other',
 };
 
-function CopyableUrl({ url, publicApiUrl }: { url: string; publicApiUrl: string | null | undefined }) {
+function CopyableUrl({
+  distribution,
+  publicApiUrl,
+}: {
+  distribution: DistributionResponse;
+  publicApiUrl: string | null | undefined;
+}) {
   const { t } = useTranslation('dataset');
   const [copied, setCopied] = useState(false);
+  const [downloading, setDownloading] = useState(false);
   const timerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
-  const resolvedUrl = resolveDistributionUrl(url, publicApiUrl);
+  const resolvedUrl = resolveDistributionUrl(distribution.url, publicApiUrl);
+  // fix(#1863 P1): resolveDistributionUrl only prefixes a RELATIVE url with
+  // the API base — an already-absolute url (a manual distribution, e.g. an
+  // external viewer app) passes through unchanged and is not a GeoLens API
+  // resource, so it must never receive this session's bearer token.
+  const isSameOriginApiResource = !isAbsoluteUrl(distribution.url);
 
   useEffect(() => () => clearTimeout(timerRef.current), []);
 
@@ -72,26 +87,67 @@ function CopyableUrl({ url, publicApiUrl }: { url: string; publicApiUrl: string 
     timerRef.current = setTimeout(() => setCopied(false), 2000);
   }
 
+  // fix(#1863 P1): a plain <a href download> browser navigation carries no
+  // Authorization header, so a private or unpublished dataset's export
+  // endpoint rejected it as anonymous. Route same-origin GeoLens resources
+  // through the same refresh-aware, bearer-authenticated fetch-and-save flow
+  // ExportButton already uses (api/datasets.ts's authenticatedDownload).
+  async function handleAuthenticatedDownload() {
+    if (downloading) return;
+    setDownloading(true);
+    try {
+      const base = (distribution.title?.trim() || distribution.distribution_type).replace(/[/\\]/g, '_');
+      await authenticatedDownload(resolvedUrl, `${base}.${distribution.format}`);
+    } catch (err) {
+      toast.error(
+        err instanceof Error
+          ? err.message
+          : t('distributions.downloadFailed', { defaultValue: 'Failed to download.' }),
+      );
+    } finally {
+      setDownloading(false);
+    }
+  }
+
   return (
     <div className="flex items-center gap-2">
       <code className="flex-1 rounded-sm bg-muted px-2 py-1.5 font-mono text-xs text-foreground truncate" title={resolvedUrl}>
         {resolvedUrl}
       </code>
       {/* fix(#1856): these were copyable text with no way to actually fetch
-          the resource. `download` is honored for same-origin URLs; a
-          cross-origin export ignores it and just opens in the new tab. */}
-      <Button variant="ghost" size="icon" className="h-7 w-7 shrink-0" asChild>
-        <a
-          href={resolvedUrl}
-          download
-          target="_blank"
-          rel="noopener noreferrer"
+          the resource. Same-origin GeoLens resources download through the
+          authenticated fetch flow (needed for private/unpublished datasets);
+          an external URL from a manual distribution is a plain link instead
+          — it is not ours to attach a bearer token to. */}
+      {isSameOriginApiResource ? (
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-7 w-7 shrink-0"
+          onClick={handleAuthenticatedDownload}
+          disabled={downloading}
           aria-label={t('distributions.downloadUrl')}
           title={t('distributions.downloadUrl')}
         >
-          <Download className="h-3.5 w-3.5" />
-        </a>
-      </Button>
+          {downloading ? (
+            <Loader2 className="h-3.5 w-3.5 animate-spin" />
+          ) : (
+            <Download className="h-3.5 w-3.5" />
+          )}
+        </Button>
+      ) : (
+        <Button variant="ghost" size="icon" className="h-7 w-7 shrink-0" asChild>
+          <a
+            href={resolvedUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label={t('distributions.downloadUrl')}
+            title={t('distributions.downloadUrl')}
+          >
+            <Download className="h-3.5 w-3.5" />
+          </a>
+        </Button>
+      )}
       <Button
         variant="ghost"
         size="icon"
@@ -258,7 +314,7 @@ export function DistributionsList({ recordId, canEdit = false }: DistributionsLi
                 {dist.description && (
                   <p className="text-xs text-muted-foreground">{dist.description}</p>
                 )}
-                <CopyableUrl url={dist.url} publicApiUrl={publicApiBaseUrl} />
+                <CopyableUrl distribution={dist} publicApiUrl={publicApiBaseUrl} />
               </div>
             ))}
           </CardContent>

--- a/frontend/src/components/dataset/DistributionsList.tsx
+++ b/frontend/src/components/dataset/DistributionsList.tsx
@@ -8,7 +8,7 @@ import { useTileConfig } from '@/hooks/use-settings';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
-import { Copy, Check, Circle, CircleDot, Loader2 } from 'lucide-react';
+import { Copy, Check, Circle, CircleDot, Loader2, Download } from 'lucide-react';
 import { LoadingState } from '@/components/layout/LoadingState';
 import {
   getPublicApiBaseUrl,
@@ -77,6 +77,21 @@ function CopyableUrl({ url, publicApiUrl }: { url: string; publicApiUrl: string 
       <code className="flex-1 rounded-sm bg-muted px-2 py-1.5 font-mono text-xs text-foreground truncate" title={resolvedUrl}>
         {resolvedUrl}
       </code>
+      {/* fix(#1856): these were copyable text with no way to actually fetch
+          the resource. `download` is honored for same-origin URLs; a
+          cross-origin export ignores it and just opens in the new tab. */}
+      <Button variant="ghost" size="icon" className="h-7 w-7 shrink-0" asChild>
+        <a
+          href={resolvedUrl}
+          download
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label={t('distributions.downloadUrl')}
+          title={t('distributions.downloadUrl')}
+        >
+          <Download className="h-3.5 w-3.5" />
+        </a>
+      </Button>
       <Button
         variant="ghost"
         size="icon"

--- a/frontend/src/components/dataset/__tests__/DistributionsList.test.tsx
+++ b/frontend/src/components/dataset/__tests__/DistributionsList.test.tsx
@@ -1,10 +1,13 @@
-import { fireEvent, render, screen } from '@/test/test-utils';
+import { fireEvent, render, screen, waitFor } from '@/test/test-utils';
+import userEvent from '@testing-library/user-event';
+import { toast } from 'sonner';
 import {
   useDistributions,
   useSetPrimaryDistribution,
 } from '@/components/dataset/hooks/use-records';
 import { useTileConfig } from '@/hooks/use-settings';
 import { resolveDistributionUrl } from '@/lib/dataset-access';
+import { authenticatedDownload } from '@/api/datasets';
 import {
   DistributionsList,
   getDistributionGroup,
@@ -19,9 +22,25 @@ vi.mock('@/hooks/use-settings', () => ({
   useTileConfig: vi.fn(),
 }));
 
+vi.mock('sonner', () => ({
+  toast: { error: vi.fn(), success: vi.fn(), warning: vi.fn() },
+}));
+
+// fix(#1863 P1): a plain <a href download> browser navigation carries no
+// Authorization header, so a private/unpublished dataset's export endpoint
+// rejected it as anonymous. Same-origin distributions now route through
+// this authenticated helper instead — mocked here the same way
+// ExportButton.test.tsx mocks downloadExport (the sibling wrapper around
+// the same underlying authenticatedRawFetch + token-refresh machinery,
+// which is covered at the api/client.test.ts level already).
+vi.mock('@/api/datasets', () => ({
+  authenticatedDownload: vi.fn(),
+}));
+
 const mockUseDistributions = vi.mocked(useDistributions);
 const mockUseSetPrimaryDistribution = vi.mocked(useSetPrimaryDistribution);
 const mockUseTileConfig = vi.mocked(useTileConfig);
+const mockAuthenticatedDownload = vi.mocked(authenticatedDownload);
 const mutate = vi.fn();
 
 /** A manual, non-primary "Viewer App" row alongside the three generated ones
@@ -197,23 +216,90 @@ describe('DistributionsList', () => {
 
   // fix(#1856): each distribution row was copyable text only — there was no
   // way to actually fetch the resource without hand-editing the URL.
-  it('renders a download link per row that points at the resolved URL', () => {
-    mockUseDistributions.mockReturnValue({
-      data: { distributions: DISTRIBUTIONS_WITH_MANUAL_ROW, total: 3 },
-      isLoading: false,
-    } as unknown as ReturnType<typeof useDistributions>);
+  //
+  // fix(#1863 P1): the first fix made every row a plain <a href download>,
+  // which is a bare browser navigation with no Authorization header — a
+  // private/unpublished dataset's export endpoint rejected it as anonymous.
+  // Same-origin (relative-url) distributions now download through
+  // authenticatedDownload; an already-absolute url (a manual distribution
+  // pointing off-site, e.g. the "Viewer App" row) stays a plain link, since
+  // it is not a GeoLens API resource and must never receive the session's
+  // bearer token.
+  describe('download control (#1856 / #1863)', () => {
+    beforeEach(() => {
+      mockUseDistributions.mockReturnValue({
+        data: { distributions: DISTRIBUTIONS_WITH_MANUAL_ROW, total: 3 },
+        isLoading: false,
+      } as unknown as ReturnType<typeof useDistributions>);
+      mockAuthenticatedDownload.mockReset();
+      mockAuthenticatedDownload.mockResolvedValue(undefined);
+    });
 
-    render(<DistributionsList recordId="record-1" />);
+    it('downloads a same-origin distribution through the authenticated fetch, not a bare link', async () => {
+      const user = userEvent.setup();
+      render(<DistributionsList recordId="record-1" />);
 
-    const links = screen.getAllByRole('link', { name: 'Download' });
-    expect(links).toHaveLength(3);
-    expect(links[0]).toHaveAttribute(
-      'href',
-      'https://catalog.example.com/api/datasets/1/export?format=gpkg',
-    );
-    expect(links[0]).toHaveAttribute('download');
-    expect(links[0]).toHaveAttribute('target', '_blank');
-    expect(links[0].getAttribute('rel')).toContain('noopener');
+      // Relative-url rows (download-1, ogc-1) are buttons, not links — a
+      // bare <a href> would carry no auth token.
+      const buttons = screen.getAllByRole('button', { name: 'Download' });
+      expect(buttons).toHaveLength(2);
+
+      await user.click(buttons[0]);
+
+      expect(mockAuthenticatedDownload).toHaveBeenCalledTimes(1);
+      expect(mockAuthenticatedDownload).toHaveBeenCalledWith(
+        'https://catalog.example.com/api/datasets/1/export?format=gpkg',
+        'GeoPackage Download.gpkg',
+      );
+    });
+
+    it('keeps a plain external link for an absolute-url manual distribution, never routing it through the authenticated fetch', () => {
+      render(<DistributionsList recordId="record-1" />);
+
+      const links = screen.getAllByRole('link', { name: 'Download' });
+      expect(links).toHaveLength(1);
+      expect(links[0]).toHaveAttribute('href', 'https://example.com/app');
+      expect(links[0]).toHaveAttribute('target', '_blank');
+      expect(links[0].getAttribute('rel')).toContain('noopener');
+      // No download attribute here on purpose — download is meaningless
+      // cross-origin, and this is not a resource authenticatedDownload
+      // should ever be asked to fetch with our token.
+      expect(mockAuthenticatedDownload).not.toHaveBeenCalled();
+    });
+
+    it('shows an error toast and re-enables the button when the authenticated download fails', async () => {
+      mockAuthenticatedDownload.mockRejectedValueOnce(new Error('Access denied'));
+      const user = userEvent.setup();
+      render(<DistributionsList recordId="record-1" />);
+
+      const [firstButton] = screen.getAllByRole('button', { name: 'Download' });
+      await user.click(firstButton);
+
+      await waitFor(() => expect(toast.error).toHaveBeenCalledWith('Access denied'));
+      expect(firstButton).not.toBeDisabled();
+    });
+
+    // The copy button's behavior must be unchanged by the P1 fix — same
+    // resolved-URL clipboard write as before, on every row regardless of
+    // same-origin vs. external.
+    it('leaves the copy button unchanged', async () => {
+      const user = userEvent.setup();
+      const writeText = vi.fn().mockResolvedValue(undefined);
+      Object.defineProperty(navigator, 'clipboard', {
+        value: { writeText },
+        configurable: true,
+      });
+      render(<DistributionsList recordId="record-1" />);
+
+      const copyButtons = screen.getAllByRole('button', { name: 'Copy URL' });
+      expect(copyButtons).toHaveLength(3);
+
+      await user.click(copyButtons[0]);
+      expect(writeText).toHaveBeenCalledWith(
+        'https://catalog.example.com/api/datasets/1/export?format=gpkg',
+      );
+      expect(mockAuthenticatedDownload).not.toHaveBeenCalled();
+    });
   });
 
   // feat(#1395): set-primary control.

--- a/frontend/src/components/dataset/__tests__/DistributionsList.test.tsx
+++ b/frontend/src/components/dataset/__tests__/DistributionsList.test.tsx
@@ -300,6 +300,77 @@ describe('DistributionsList', () => {
       );
       expect(mockAuthenticatedDownload).not.toHaveBeenCalled();
     });
+
+    // fix(#1863 P2, codex round 2): the relative-url predicate above routed
+    // EVERY relative url through authenticatedDownload, including a
+    // vector-tile template (/tiles/data.<table>/{z}/{x}/{y}.pbf — a
+    // template, no literal resource at that path) and a raster/VRT row's
+    // bare object-storage key (rasters/<id>/<sha>/source.cog.tif — not the
+    // real, token-gated /datasets/{id}/download/cog route) — so the
+    // Download button always 404'd for those rows. Neither gets a download
+    // action at all now; copy is the only way to get the value.
+    it('shows no download action for a vector-tile template row (copy only)', () => {
+      mockUseDistributions.mockReturnValue({
+        data: {
+          distributions: [
+            {
+              id: 'tiles-1',
+              record_id: 'record-1',
+              distribution_type: 'vector_tiles',
+              format: 'pbf',
+              url: '/tiles/data.test_table/{z}/{x}/{y}.pbf',
+              title: 'Vector Tiles',
+              description: null,
+              protocol: 'XYZ',
+              media_type: 'application/vnd.mapbox-vector-tile',
+              is_primary: false,
+              auto_generated: true,
+            },
+          ],
+          total: 1,
+        },
+        isLoading: false,
+      } as unknown as ReturnType<typeof useDistributions>);
+
+      render(<DistributionsList recordId="record-1" />);
+
+      expect(screen.queryByRole('button', { name: 'Download' })).not.toBeInTheDocument();
+      expect(screen.queryByRole('link', { name: 'Download' })).not.toBeInTheDocument();
+      // The value is still reachable — just not fetchable as one file.
+      expect(screen.getByRole('button', { name: 'Copy URL' })).toBeInTheDocument();
+      expect(mockAuthenticatedDownload).not.toHaveBeenCalled();
+    });
+
+    it('shows no download action for a raster/VRT bare-storage-key row (copy only)', () => {
+      mockUseDistributions.mockReturnValue({
+        data: {
+          distributions: [
+            {
+              id: 'raster-1',
+              record_id: 'record-1',
+              distribution_type: 'download',
+              format: 'geotiff',
+              url: 'rasters/dataset-1/abc123sha256/source.cog.tif',
+              title: 'GeoTIFF Download',
+              description: null,
+              protocol: 'HTTP',
+              media_type: 'image/tiff',
+              is_primary: false,
+              auto_generated: true,
+            },
+          ],
+          total: 1,
+        },
+        isLoading: false,
+      } as unknown as ReturnType<typeof useDistributions>);
+
+      render(<DistributionsList recordId="record-1" />);
+
+      expect(screen.queryByRole('button', { name: 'Download' })).not.toBeInTheDocument();
+      expect(screen.queryByRole('link', { name: 'Download' })).not.toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Copy URL' })).toBeInTheDocument();
+      expect(mockAuthenticatedDownload).not.toHaveBeenCalled();
+    });
   });
 
   // feat(#1395): set-primary control.

--- a/frontend/src/components/dataset/__tests__/DistributionsList.test.tsx
+++ b/frontend/src/components/dataset/__tests__/DistributionsList.test.tsx
@@ -195,6 +195,27 @@ describe('DistributionsList', () => {
     expect(screen.getByText('https://example.com/app')).toBeInTheDocument();
   });
 
+  // fix(#1856): each distribution row was copyable text only — there was no
+  // way to actually fetch the resource without hand-editing the URL.
+  it('renders a download link per row that points at the resolved URL', () => {
+    mockUseDistributions.mockReturnValue({
+      data: { distributions: DISTRIBUTIONS_WITH_MANUAL_ROW, total: 3 },
+      isLoading: false,
+    } as unknown as ReturnType<typeof useDistributions>);
+
+    render(<DistributionsList recordId="record-1" />);
+
+    const links = screen.getAllByRole('link', { name: 'Download' });
+    expect(links).toHaveLength(3);
+    expect(links[0]).toHaveAttribute(
+      'href',
+      'https://catalog.example.com/api/datasets/1/export?format=gpkg',
+    );
+    expect(links[0]).toHaveAttribute('download');
+    expect(links[0]).toHaveAttribute('target', '_blank');
+    expect(links[0].getAttribute('rel')).toContain('noopener');
+  });
+
   // feat(#1395): set-primary control.
   describe('set-primary control', () => {
     beforeEach(() => {

--- a/frontend/src/components/import/__tests__/FileDropzone.test.tsx
+++ b/frontend/src/components/import/__tests__/FileDropzone.test.tsx
@@ -1,0 +1,45 @@
+// fix(#1853): `instructions` shipped as a full sentence ending in the same
+// verb the component appends separately ("browse"/"Examinar"/"Parcourir"/
+// "Durchsuchen"), so the headline read "Drag and drop files here, or click
+// to browse browse to upload" — the trailing verb duplicated. `instructions`
+// is now trimmed to the lead-in fragment in all four locales; these tests
+// render the real component (no react-i18next mock) against the real
+// bundles so a locale regression shows up as a literal duplicate substring.
+import i18n from 'i18next';
+import { render, screen } from '@/test/test-utils';
+import { FileDropzone } from '../FileDropzone';
+
+function composedInstructions(): string {
+  // The heading text is split across a plain text node and a bolded <span>
+  // ("browse"), so read the whole heading's textContent rather than
+  // matching a single text node.
+  return screen.getByRole('heading', { level: 3 }).textContent ?? '';
+}
+
+describe('FileDropzone instructions text (#1853)', () => {
+  afterEach(async () => {
+    await i18n.changeLanguage('en');
+  });
+
+  it('does not repeat the browse verb in English', () => {
+    render(<FileDropzone onFilesAccepted={() => {}} />);
+
+    const text = composedInstructions();
+    expect(text).toBe('Drag and drop files here, or browse to upload');
+    // The bug produced "...to browse browse to upload" — assert the verb
+    // appears exactly once.
+    expect(text.match(/browse/gi)).toHaveLength(1);
+  });
+
+  it.each(['es', 'fr', 'de'])('does not repeat the browse verb in %s', async (lng) => {
+    await i18n.changeLanguage(lng);
+    render(<FileDropzone onFilesAccepted={() => {}} />);
+
+    const text = composedInstructions();
+    const browseWord = i18n.t('import:dropzone.browse');
+    // Count occurrences of the locale's own browse word — the pre-fix bug
+    // was a literal duplicate of it (once from `instructions`, once bolded).
+    const occurrences = text.split(browseWord).length - 1;
+    expect(occurrences).toBe(1);
+  });
+});

--- a/frontend/src/components/import/__tests__/complete-heroTitle-plural.test.ts
+++ b/frontend/src/components/import/__tests__/complete-heroTitle-plural.test.ts
@@ -1,15 +1,49 @@
 // fix(#1853): the import success screen's `complete.heroTitle` had no
 // `_one`/`_other` split, so i18next always served the (plural) bare key —
-// "1 datasets added to the catalog" — regardless of count. Uses the real
-// i18next instance (initialized in src/test/setup.ts), not a mock, so a
-// missing plural suffix in a locale bundle actually shows up here.
+// "1 datasets added to the catalog" — regardless of count.
+//
+// fix(#1863 P1, codex round 2): French and Spanish CLDR plural rules select
+// a distinct "many" category for an exact non-zero multiple of a million
+// (Intl.PluralRules('fr').select(1000000) === 'many'), and i18next does NOT
+// fall back from an unresolved heroTitle_many to heroTitle_other — a
+// missing _many rendered the raw key or the English fallback string
+// instead. Added heroTitle_many to all four locale bundles (AGENTS.md:
+// plural-suffix keys are all-four-or-none).
+//
+// These tests read the locale JSON bundles directly rather than driving
+// them through a live i18next instance and i18n.changeLanguage(). This test
+// harness's i18next is initialized with a FROZEN `resources` object holding
+// only the eagerly-bundled fallback (en) locale (src/i18n/resources.ts) —
+// other locales are lazy-loaded via `changeAppLanguage`, which itself
+// short-circuits here because `i18n.hasLoadedNamespace(ns, { lng })`
+// reports a namespace "loaded" via the en fallback chain even when the
+// target locale was never actually registered, and the ResourceStore
+// refuses to mutate a frozen object regardless. So neither a bare
+// `i18n.changeLanguage('fr')` nor `changeAppLanguage('fr')` can make a real
+// French string reach `t()` in this suite — both silently render the
+// English fallback text under the reported language. Reading the bundles
+// directly and interpolating {{count}} by hand tests exactly what changed
+// (the resource files) without depending on plumbing this harness cannot
+// exercise; the English-only assertions below still go through the real
+// `i18n.t()`, since English is loaded for real.
 import i18n from 'i18next';
+import enImport from '@/i18n/locales/en/import.json';
+import esImport from '@/i18n/locales/es/import.json';
+import frImport from '@/i18n/locales/fr/import.json';
+import deImport from '@/i18n/locales/de/import.json';
+
+const BUNDLES: Record<string, typeof enImport> = {
+  en: enImport,
+  es: esImport,
+  fr: frImport,
+  de: deImport,
+};
+
+function interpolateCount(template: string, count: number): string {
+  return template.replace(/\{\{count\}\}/g, String(count));
+}
 
 describe('import:complete.heroTitle pluralization (#1853)', () => {
-  afterEach(async () => {
-    await i18n.changeLanguage('en');
-  });
-
   it('uses the singular form for count=1 in English', () => {
     expect(i18n.t('import:complete.heroTitle', { count: 1 })).toBe(
       '1 dataset added to the catalog',
@@ -22,15 +56,59 @@ describe('import:complete.heroTitle pluralization (#1853)', () => {
     );
   });
 
-  it.each(['es', 'fr', 'de'])('has a distinct singular form in %s', async (lng) => {
-    await i18n.changeLanguage(lng);
-    const singular = String(i18n.t('import:complete.heroTitle', { count: 1 }));
-    const plural = String(i18n.t('import:complete.heroTitle', { count: 3 }));
-    // Strip the interpolated digit before comparing — the two rendered
-    // strings trivially differ by "1" vs "3" regardless of pluralization.
-    // What must differ is the surrounding wording (singular noun/participle
-    // vs plural); a missing _one/_other split serves the same bare-key
-    // wording for every count, with only the digit changing.
-    expect(singular.replace('1', '')).not.toBe(plural.replace('3', ''));
+  it.each(['es', 'fr', 'de'])('has a singular wording distinct from _other in %s', (lng) => {
+    const { complete } = BUNDLES[lng];
+    // Compare the raw templates (before interpolation) — the singular and
+    // plural/other forms must use different wording (noun/participle
+    // agreement), not merely differ by the digit that gets substituted in.
+    expect(complete.heroTitle_one).not.toBe(complete.heroTitle_other);
+  });
+
+  it.each(['fr', 'es'])(
+    'ships a heroTitle_many form for the exact-million CLDR category in %s',
+    (lng) => {
+      expect(new Intl.PluralRules(lng).select(1_000_000)).toBe('many');
+
+      const { complete } = BUNDLES[lng];
+      expect(complete.heroTitle_many).toBeDefined();
+      expect(complete.heroTitle_many).toContain('{{count}}');
+
+      const many = interpolateCount(complete.heroTitle_many, 1_000_000);
+      const other = interpolateCount(complete.heroTitle_other, 1_000_000);
+      // Strip digits/punctuation/whitespace before comparing — both would
+      // trivially contain "1000000" regardless of pluralization. What must
+      // differ is the surrounding wording (the "de"/partitive construction
+      // French and Spanish use for exact millions).
+      expect(many.replace(/[\d.,\s]/g, '')).not.toBe(other.replace(/[\d.,\s]/g, ''));
+    },
+  );
+
+  it.each(['en', 'de'])(
+    'ships heroTitle_many for key parity even though %s has no distinct CLDR "many" category',
+    (lng) => {
+      // English/German never select this category, so the key is never
+      // reachable at runtime — it exists only so all four locale bundles
+      // carry the same key set (AGENTS.md's all-four-or-none rule).
+      expect(new Intl.PluralRules(lng).select(1_000_000)).toBe('other');
+
+      const { complete } = BUNDLES[lng];
+      expect(complete.heroTitle_many).toBeDefined();
+      expect(complete.heroTitle_many).toContain('{{count}}');
+    },
+  );
+
+  it('every locale bundle carries exactly the same heroTitle_* key set (AGENTS.md all-four-or-none)', () => {
+    const suffixSets = Object.fromEntries(
+      Object.entries(BUNDLES).map(([lng, bundle]) => [
+        lng,
+        Object.keys(bundle.complete)
+          .filter((k) => k.startsWith('heroTitle'))
+          .sort(),
+      ]),
+    );
+    const [first, ...rest] = Object.values(suffixSets);
+    for (const keys of rest) {
+      expect(keys).toEqual(first);
+    }
   });
 });

--- a/frontend/src/components/import/__tests__/complete-heroTitle-plural.test.ts
+++ b/frontend/src/components/import/__tests__/complete-heroTitle-plural.test.ts
@@ -1,0 +1,36 @@
+// fix(#1853): the import success screen's `complete.heroTitle` had no
+// `_one`/`_other` split, so i18next always served the (plural) bare key —
+// "1 datasets added to the catalog" — regardless of count. Uses the real
+// i18next instance (initialized in src/test/setup.ts), not a mock, so a
+// missing plural suffix in a locale bundle actually shows up here.
+import i18n from 'i18next';
+
+describe('import:complete.heroTitle pluralization (#1853)', () => {
+  afterEach(async () => {
+    await i18n.changeLanguage('en');
+  });
+
+  it('uses the singular form for count=1 in English', () => {
+    expect(i18n.t('import:complete.heroTitle', { count: 1 })).toBe(
+      '1 dataset added to the catalog',
+    );
+  });
+
+  it('uses the plural form for count>1 in English', () => {
+    expect(i18n.t('import:complete.heroTitle', { count: 3 })).toBe(
+      '3 datasets added to the catalog',
+    );
+  });
+
+  it.each(['es', 'fr', 'de'])('has a distinct singular form in %s', async (lng) => {
+    await i18n.changeLanguage(lng);
+    const singular = String(i18n.t('import:complete.heroTitle', { count: 1 }));
+    const plural = String(i18n.t('import:complete.heroTitle', { count: 3 }));
+    // Strip the interpolated digit before comparing — the two rendered
+    // strings trivially differ by "1" vs "3" regardless of pluralization.
+    // What must differ is the surrounding wording (singular noun/participle
+    // vs plural); a missing _one/_other split serves the same bare-key
+    // wording for every count, with only the digit changing.
+    expect(singular.replace('1', '')).not.toBe(plural.replace('3', ''));
+  });
+});

--- a/frontend/src/i18n/locales/de/dataset.json
+++ b/frontend/src/i18n/locales/de/dataset.json
@@ -597,6 +597,7 @@
     "primary": "Primär",
     "copyUrl": "URL kopieren",
     "downloadUrl": "Herunterladen",
+    "downloadFailed": "Herunterladen fehlgeschlagen.",
     "loadError": "Verteilungen konnten nicht geladen werden.",
     "setPrimary": "{{name}} als primär festlegen",
     "currentPrimary": "{{name}} ist die primäre Distribution",

--- a/frontend/src/i18n/locales/de/dataset.json
+++ b/frontend/src/i18n/locales/de/dataset.json
@@ -596,6 +596,7 @@
     "auto": "auto",
     "primary": "Primär",
     "copyUrl": "URL kopieren",
+    "downloadUrl": "Herunterladen",
     "loadError": "Verteilungen konnten nicht geladen werden.",
     "setPrimary": "{{name}} als primär festlegen",
     "currentPrimary": "{{name}} ist die primäre Distribution",

--- a/frontend/src/i18n/locales/de/import.json
+++ b/frontend/src/i18n/locales/de/import.json
@@ -108,7 +108,7 @@
   },
   "dropzone": {
     "ariaLabel": "Dateien hochladen",
-    "instructions": "Dateien hierher ziehen oder klicken zum Durchsuchen",
+    "instructions": "Dateien hierher ziehen oder",
     "dropHere": "Dateien hier ablegen",
     "unsupportedType": "Dieser Dateityp wird nicht unterstützt",
     "sizeLimit": "Maximal 500 MB pro Datei",
@@ -515,7 +515,8 @@
   "eyebrow": "Importieren",
   "pageDescription": "Dateien hochladen, Tabellen aus Ihrem Postgres registrieren oder einen Remote-Service verbinden. GeoLens erkennt Geometrie, Schema und KRS und macht die Daten abfragbar, stilisierbar und einbettbar.",
   "complete": {
-    "heroTitle": "{{count}} Datensätze zum Katalog hinzugefügt",
+    "heroTitle_one": "{{count}} Datensatz zum Katalog hinzugefügt",
+    "heroTitle_other": "{{count}} Datensätze zum Katalog hinzugefügt",
     "heroDesc": "Alle Dateien aufgenommen, gekachelt und indiziert. Bereit zum Abfragen, Gestalten und Kartografieren.",
     "statDatasets": "Datensätze",
     "statVector": "Vektor",

--- a/frontend/src/i18n/locales/de/import.json
+++ b/frontend/src/i18n/locales/de/import.json
@@ -516,6 +516,7 @@
   "pageDescription": "Dateien hochladen, Tabellen aus Ihrem Postgres registrieren oder einen Remote-Service verbinden. GeoLens erkennt Geometrie, Schema und KRS und macht die Daten abfragbar, stilisierbar und einbettbar.",
   "complete": {
     "heroTitle_one": "{{count}} Datensatz zum Katalog hinzugefügt",
+    "heroTitle_many": "{{count}} Datensätze zum Katalog hinzugefügt",
     "heroTitle_other": "{{count}} Datensätze zum Katalog hinzugefügt",
     "heroDesc": "Alle Dateien aufgenommen, gekachelt und indiziert. Bereit zum Abfragen, Gestalten und Kartografieren.",
     "statDatasets": "Datensätze",

--- a/frontend/src/i18n/locales/en/dataset.json
+++ b/frontend/src/i18n/locales/en/dataset.json
@@ -548,6 +548,7 @@
     "primary": "Primary",
     "copyUrl": "Copy URL",
     "downloadUrl": "Download",
+    "downloadFailed": "Failed to download.",
     "loadError": "Failed to load distributions.",
     "setPrimary": "Set {{name}} as primary",
     "currentPrimary": "{{name}} is the primary distribution",

--- a/frontend/src/i18n/locales/en/dataset.json
+++ b/frontend/src/i18n/locales/en/dataset.json
@@ -547,6 +547,7 @@
     "auto": "auto",
     "primary": "Primary",
     "copyUrl": "Copy URL",
+    "downloadUrl": "Download",
     "loadError": "Failed to load distributions.",
     "setPrimary": "Set {{name}} as primary",
     "currentPrimary": "{{name}} is the primary distribution",

--- a/frontend/src/i18n/locales/en/import.json
+++ b/frontend/src/i18n/locales/en/import.json
@@ -108,6 +108,7 @@
   },
   "complete": {
     "heroTitle_one": "{{count}} dataset added to the catalog",
+    "heroTitle_many": "{{count}} datasets added to the catalog",
     "heroTitle_other": "{{count}} datasets added to the catalog",
     "heroDesc": "All files ingested, tiled, and indexed. Ready to query, style, and map.",
     "statDatasets": "Datasets",

--- a/frontend/src/i18n/locales/en/import.json
+++ b/frontend/src/i18n/locales/en/import.json
@@ -107,7 +107,8 @@
     }
   },
   "complete": {
-    "heroTitle": "{{count}} datasets added to the catalog",
+    "heroTitle_one": "{{count}} dataset added to the catalog",
+    "heroTitle_other": "{{count}} datasets added to the catalog",
     "heroDesc": "All files ingested, tiled, and indexed. Ready to query, style, and map.",
     "statDatasets": "Datasets",
     "statVector": "Vector",
@@ -120,7 +121,7 @@
   },
   "dropzone": {
     "ariaLabel": "Upload files",
-    "instructions": "Drag and drop files here, or click to browse",
+    "instructions": "Drag and drop files here, or",
     "browse": "browse",
     "toUpload": "to upload",
     "subtext": "GeoLens will detect geometry, CRS, and schema before committing to the catalog. Batches up to {{max}} files.",

--- a/frontend/src/i18n/locales/es/dataset.json
+++ b/frontend/src/i18n/locales/es/dataset.json
@@ -597,6 +597,7 @@
     "primary": "Primario",
     "copyUrl": "Copiar URL",
     "downloadUrl": "Descargar",
+    "downloadFailed": "Error al descargar.",
     "loadError": "No se pudieron cargar las distribuciones.",
     "setPrimary": "Establecer {{name}} como primario",
     "currentPrimary": "{{name}} es la distribución primaria",

--- a/frontend/src/i18n/locales/es/dataset.json
+++ b/frontend/src/i18n/locales/es/dataset.json
@@ -596,6 +596,7 @@
     "auto": "auto",
     "primary": "Primario",
     "copyUrl": "Copiar URL",
+    "downloadUrl": "Descargar",
     "loadError": "No se pudieron cargar las distribuciones.",
     "setPrimary": "Establecer {{name}} como primario",
     "currentPrimary": "{{name}} es la distribución primaria",

--- a/frontend/src/i18n/locales/es/import.json
+++ b/frontend/src/i18n/locales/es/import.json
@@ -108,7 +108,7 @@
   },
   "dropzone": {
     "ariaLabel": "Subir archivos",
-    "instructions": "Arrastre y suelte archivos aquí, o haga clic para explorar",
+    "instructions": "Arrastre y suelte archivos aquí, o",
     "dropHere": "Suelte los archivos aquí",
     "unsupportedType": "Este tipo de archivo no es compatible",
     "sizeLimit": "Máximo 500 MB por archivo",
@@ -515,7 +515,8 @@
   "eyebrow": "Importar",
   "pageDescription": "Sube archivos, registra tablas de tu Postgres o conecta un servicio remoto. GeoLens detecta geometría, esquema y CRS, luego hace los datos consultables, estilizables e integrables.",
   "complete": {
-    "heroTitle": "{{count}} conjuntos de datos añadidos al catálogo",
+    "heroTitle_one": "{{count}} conjunto de datos añadido al catálogo",
+    "heroTitle_other": "{{count}} conjuntos de datos añadidos al catálogo",
     "heroDesc": "Todos los archivos ingestados, teselados e indexados. Listos para consultar, estilizar y mapear.",
     "statDatasets": "Conjuntos de datos",
     "statVector": "Vector",

--- a/frontend/src/i18n/locales/es/import.json
+++ b/frontend/src/i18n/locales/es/import.json
@@ -516,6 +516,7 @@
   "pageDescription": "Sube archivos, registra tablas de tu Postgres o conecta un servicio remoto. GeoLens detecta geometría, esquema y CRS, luego hace los datos consultables, estilizables e integrables.",
   "complete": {
     "heroTitle_one": "{{count}} conjunto de datos añadido al catálogo",
+    "heroTitle_many": "{{count}} de conjuntos de datos añadidos al catálogo",
     "heroTitle_other": "{{count}} conjuntos de datos añadidos al catálogo",
     "heroDesc": "Todos los archivos ingestados, teselados e indexados. Listos para consultar, estilizar y mapear.",
     "statDatasets": "Conjuntos de datos",

--- a/frontend/src/i18n/locales/fr/dataset.json
+++ b/frontend/src/i18n/locales/fr/dataset.json
@@ -596,6 +596,7 @@
     "auto": "auto",
     "primary": "Principal",
     "copyUrl": "Copier l'URL",
+    "downloadUrl": "Télécharger",
     "loadError": "Impossible de charger les distributions.",
     "setPrimary": "Définir {{name}} comme principal",
     "currentPrimary": "{{name}} est la distribution principale",

--- a/frontend/src/i18n/locales/fr/dataset.json
+++ b/frontend/src/i18n/locales/fr/dataset.json
@@ -597,6 +597,7 @@
     "primary": "Principal",
     "copyUrl": "Copier l'URL",
     "downloadUrl": "Télécharger",
+    "downloadFailed": "Échec du téléchargement.",
     "loadError": "Impossible de charger les distributions.",
     "setPrimary": "Définir {{name}} comme principal",
     "currentPrimary": "{{name}} est la distribution principale",

--- a/frontend/src/i18n/locales/fr/import.json
+++ b/frontend/src/i18n/locales/fr/import.json
@@ -516,6 +516,7 @@
   "pageDescription": "Chargez des fichiers, enregistrez des tables depuis votre Postgres ou connectez un service distant. GeoLens détecte la géométrie, le schéma et le SCR, puis rend les données interrogeables, stylisables et intégrables.",
   "complete": {
     "heroTitle_one": "{{count}} jeu de données ajouté au catalogue",
+    "heroTitle_many": "{{count}} de jeux de données ajoutés au catalogue",
     "heroTitle_other": "{{count}} jeux de données ajoutés au catalogue",
     "heroDesc": "Tous les fichiers ingérés, tuilés et indexés. Prêts à être interrogés, stylisés et cartographiés.",
     "statDatasets": "Jeux de données",

--- a/frontend/src/i18n/locales/fr/import.json
+++ b/frontend/src/i18n/locales/fr/import.json
@@ -108,7 +108,7 @@
   },
   "dropzone": {
     "ariaLabel": "Téléverser des fichiers",
-    "instructions": "Glissez-déposez des fichiers ici, ou cliquez pour parcourir",
+    "instructions": "Glissez-déposez des fichiers ici, ou",
     "dropHere": "Déposez les fichiers ici",
     "unsupportedType": "Ce type de fichier n'est pas pris en charge",
     "sizeLimit": "500 Mo maximum par fichier",
@@ -515,7 +515,8 @@
   "eyebrow": "Importer",
   "pageDescription": "Chargez des fichiers, enregistrez des tables depuis votre Postgres ou connectez un service distant. GeoLens détecte la géométrie, le schéma et le SCR, puis rend les données interrogeables, stylisables et intégrables.",
   "complete": {
-    "heroTitle": "{{count}} jeux de données ajoutés au catalogue",
+    "heroTitle_one": "{{count}} jeu de données ajouté au catalogue",
+    "heroTitle_other": "{{count}} jeux de données ajoutés au catalogue",
     "heroDesc": "Tous les fichiers ingérés, tuilés et indexés. Prêts à être interrogés, stylisés et cartographiés.",
     "statDatasets": "Jeux de données",
     "statVector": "Vecteur",

--- a/frontend/src/lib/__tests__/color-ramps-chroma-parity.test.ts
+++ b/frontend/src/lib/__tests__/color-ramps-chroma-parity.test.ts
@@ -20,9 +20,16 @@ import {
 const ALL_RAMPS = [...SEQUENTIAL_RAMPS, ...DIVERGING_RAMPS, ...QUALITATIVE_RAMPS].map(
   (r) => r.name as string,
 );
+const QUALITATIVE_NAMES = new Set(QUALITATIVE_RAMPS.map((r) => r.name as string));
 // chroma-js has no brewer entry for Inferno/Plasma — the pre-#448 try/catch
 // already served the YlOrRd fallback for them, which getRampColors preserves.
-const CHROMA_KNOWN = ALL_RAMPS.filter((n) => n !== 'Inferno' && n !== 'Plasma');
+// fix(#1856): qualitative ramps (Set2 etc.) are no longer sampled
+// continuously — getRampColors now cycles discrete palette entries for
+// them, so they intentionally diverge from chroma.scale()'s gradient output
+// and are excluded from the bit-parity checks below.
+const CHROMA_KNOWN = ALL_RAMPS.filter(
+  (n) => n !== 'Inferno' && n !== 'Plasma' && !QUALITATIVE_NAMES.has(n),
+);
 
 describe('getRampColors ↔ chroma-js parity', () => {
   it.each(CHROMA_KNOWN)('%s matches chroma output for counts 1..14', (name) => {

--- a/frontend/src/lib/__tests__/color-ramps.test.ts
+++ b/frontend/src/lib/__tests__/color-ramps.test.ts
@@ -115,6 +115,29 @@ describe('getRampColors with reversed flag', () => {
   });
 });
 
+// fix(#1856): qualitative palettes are discrete categories, not a gradient —
+// sampling them continuously blended unrelated hues and washed small counts
+// out toward grey. getRampColors now assigns palette entries directly.
+describe('getRampColors on qualitative ramps (#1856)', () => {
+  it('five categories on Set2 yield five distinct palette members', () => {
+    const colors = getRampColors('Set2', 5);
+    expect(new Set(colors).size).toBe(5);
+    expect(colors).toEqual(getRampColors('Set2', 8).slice(0, 5));
+  });
+
+  it('cycles past the palette length instead of repeating the last color', () => {
+    const eight = getRampColors('Set2', 8);
+    const ten = getRampColors('Set2', 10);
+    expect(ten.slice(0, 8)).toEqual(eight);
+    expect(ten[8]).toBe(eight[0]);
+    expect(ten[9]).toBe(eight[1]);
+  });
+
+  it('still resolves case-insensitively for a qualitative name', () => {
+    expect(getRampColors('set2', 5)).toEqual(getRampColors('Set2', 5));
+  });
+});
+
 describe('cvdSafeRamps', () => {
   it('excludes Spectral (cvdSafe: false) from diverging ramps', () => {
     const safe = cvdSafeRamps(DIVERGING_RAMPS);

--- a/frontend/src/lib/color-ramps.ts
+++ b/frontend/src/lib/color-ramps.ts
@@ -239,6 +239,10 @@ const BREWER_STOPS_BY_LOWER: Record<string, readonly string[]> = Object.fromEntr
   Object.entries(BREWER_STOPS).map(([name, stops]) => [name.toLowerCase(), stops]),
 );
 
+// fix(#1856): names (lowercased) of the qualitative palettes, so getRampColors
+// can tell a discrete category palette from a continuous gradient.
+const QUALITATIVE_NAMES = new Set(QUALITATIVE_RAMPS.map((r) => r.name.toLowerCase()));
+
 /**
  * Generate an array of hex color strings from a named ColorBrewer color scale
  * (case-insensitive, matching chroma.scale()'s name resolution).
@@ -250,11 +254,21 @@ const BREWER_STOPS_BY_LOWER: Record<string, readonly string[]> = Object.fromEntr
  * try/catch already served YlOrRd for them).
  */
 export function getRampColors(rampName: string, count: number, reversed = false): string[] {
-  const stops = BREWER_STOPS_BY_LOWER[rampName.toLowerCase()] ?? BREWER_STOPS.YlOrRd;
-  const colors =
-    count === 1
-      ? [sampleStops(stops, 0.5)]
-      : Array.from({ length: count }, (_, i) => sampleStops(stops, i / (count - 1)));
+  const lower = rampName.toLowerCase();
+  const stops = BREWER_STOPS_BY_LOWER[lower] ?? BREWER_STOPS.YlOrRd;
+  let colors: string[];
+  if (QUALITATIVE_NAMES.has(lower)) {
+    // fix(#1856): a qualitative palette is a set of unrelated category
+    // colors, not a gradient — sampling it continuously (as below) blends
+    // adjacent unrelated hues and washes small counts out toward grey.
+    // Assign palette entries directly, cycling past the palette length.
+    colors = Array.from({ length: count }, (_, i) => stops[i % stops.length]);
+  } else {
+    colors =
+      count === 1
+        ? [sampleStops(stops, 0.5)]
+        : Array.from({ length: count }, (_, i) => sampleStops(stops, i / (count - 1)));
+  }
   return reversed ? reverseRamp(colors) : colors;
 }
 

--- a/frontend/src/lib/dataset-access.ts
+++ b/frontend/src/lib/dataset-access.ts
@@ -8,7 +8,11 @@ function stripTrailingSlashes(value: string): string {
   return value.replace(/\/+$/, '');
 }
 
-function isAbsoluteUrl(value: string): boolean {
+// fix(#1863 P1): exported so callers can tell a same-origin, relative
+// GeoLens API path (needs the session's bearer token) apart from an
+// already-qualified external URL (a manual distribution, e.g. a viewer app)
+// that resolveDistributionUrl leaves untouched and that must never receive it.
+export function isAbsoluteUrl(value: string): boolean {
   return ABSOLUTE_URL_RE.test(value) || value.startsWith('//');
 }
 

--- a/frontend/src/lib/dataset-access.ts
+++ b/frontend/src/lib/dataset-access.ts
@@ -16,6 +16,29 @@ export function isAbsoluteUrl(value: string): boolean {
   return ABSOLUTE_URL_RE.test(value) || value.startsWith('//');
 }
 
+// fix(#1863 P2): a `{z}`/`{x}`/`{y}`-style placeholder (the auto-generated
+// vector_tiles row is exactly `/tiles/data.<table>/{z}/{x}/{y}.pbf`) names a
+// TEMPLATE, not a literal resource — no single fetch resolves it.
+const TILE_TEMPLATE_RE = /\{[^{}]+\}/;
+
+/**
+ * A URL a single fetch can actually resolve to a resource — as opposed to a
+ * tile URL template (a `{z}`/`{x}`/`{y}` placeholder, or similar) or a bare
+ * object-storage key. Raster/VRT distributions store the latter directly as
+ * their `url` (e.g. `rasters/<dataset_id>/<sha256>/source.cog.tif` — no
+ * leading slash, not the real `/datasets/{id}/download/cog` route, which
+ * additionally needs a short-lived download-scoped token `mintDownloadToken`
+ * mints separately). Every GeoLens-generated same-origin API path (exports,
+ * OGC Features, …) is written with a leading slash — see the backend's
+ * `_DISTRIBUTION_TEMPLATES` — so that is the signal used to exclude a raw
+ * storage key without an explicit "this is a storage key" field to check.
+ */
+export function isFetchableDistributionUrl(value: string): boolean {
+  if (TILE_TEMPLATE_RE.test(value)) return false;
+  if (isAbsoluteUrl(value)) return true;
+  return value.startsWith('/');
+}
+
 function normalizeApiBasePath(value: string): string {
   return value.startsWith('/') ? value : `/${value}`;
 }

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -227,8 +227,16 @@ export function LoginPage() {
   // a session to gate a route on), so it never got AppLayout's automatic
   // footer. Mirror AppLayout's own showFooterBranding rule so self-hosters
   // who hide the badge on every other page don't see it reappear here.
-  const { isEnterprise } = useEdition();
-  const showFooterBranding = !isEnterprise || branding?.show_badge !== false;
+  // fix(#1863 P2): useEdition() reports isEnterprise === false (its default)
+  // until the edition query resolves — an enterprise instance with
+  // show_badge false would briefly render the badge, then remove it. Gate on
+  // `isResolved` (useEdition's own "the endpoint has actually answered" flag
+  // — see its docstring; use-settings-admin.ts gates the same way). AppLayout
+  // reads isEnterprise the same unguarded way LoginPage used to and likely
+  // shares this race on every other route — out of scope here (this PR only
+  // touches LoginPage), left as noted debt rather than a drive-by fix.
+  const { isEnterprise, isResolved: editionResolved } = useEdition();
+  const showFooterBranding = editionResolved && (!isEnterprise || branding?.show_badge !== false);
   const token = useAuthStore((s) => s.token);
   const location = useLocation();
   const navigate = useNavigate();

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -4,6 +4,7 @@ import { useQuery } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
 import { ArrowRight, Layers, Search, Upload } from 'lucide-react';
 import { LoadingState } from '@/components/layout/LoadingState';
+import { AppFooter } from '@/components/layout/AppFooter';
 import { toast } from 'sonner';
 import { useAuthStore } from '@/stores/auth-store';
 import { getAuthConfig } from '@/api/auth';
@@ -14,6 +15,7 @@ import { OAuthButtons } from '@/components/auth/OAuthButtons';
 import { Button } from '@/components/ui/button';
 import { useDocumentTitle } from '@/hooks/use-document-title';
 import { useBranding } from '@/hooks/use-settings';
+import { useEdition } from '@/hooks/use-edition';
 import { isSafeHttpUrl } from '@/lib/safe-http-url';
 import { writeSessionStorage } from '@/lib/storage';
 
@@ -221,6 +223,12 @@ export function LoginPage() {
   useDocumentTitle(t('common:pageTitle.login'));
   const { data: branding } = useBranding();
   const privacyUrl = branding?.privacy_url;
+  // fix(#1852): /login sits outside AppLayout (it renders before the user has
+  // a session to gate a route on), so it never got AppLayout's automatic
+  // footer. Mirror AppLayout's own showFooterBranding rule so self-hosters
+  // who hide the badge on every other page don't see it reappear here.
+  const { isEnterprise } = useEdition();
+  const showFooterBranding = !isEnterprise || branding?.show_badge !== false;
   const token = useAuthStore((s) => s.token);
   const location = useLocation();
   const navigate = useNavigate();
@@ -288,7 +296,12 @@ export function LoginPage() {
   ];
 
   return (
-    <main className="grid min-h-screen grid-cols-1 min-[880px]:grid-cols-[1.05fr_0.95fr]">
+    // fix(#1852): /login sits outside AppLayout (see the showFooterBranding
+    // comment above), so it's the only route that never got the site footer
+    // (GitHub / Docs / Community / API / license / version). Wrap in a flex
+    // column so AppFooter can render below the two-column grid.
+    <div className="flex min-h-screen flex-col">
+    <main className="grid flex-1 grid-cols-1 min-[880px]:grid-cols-[1.05fr_0.95fr]">
       {/* ───────── LEFT — brand / map panel (hidden ≤880px) ───────── */}
       <section className="relative hidden overflow-hidden border-e border-border bg-map-paper px-14 py-12 min-[880px]:flex min-[880px]:flex-col min-[880px]:justify-between">
         <BrandMapBackdrop />
@@ -298,12 +311,17 @@ export function LoginPage() {
         <div className="relative z-10 flex h-full flex-col">
           {/* Top — logo lockup + eyebrow */}
           <div>
-            <Link
-              to="/"
+            {/* fix(#1852): this used to Link to="/", which with landing_first
+                on redirects straight back to /login — a dead click for a
+                signed-out visitor. Route through the same guest-browse escape
+                hatch as the "Browse the catalog" buttons below instead. */}
+            <button
+              type="button"
+              onClick={handleBrowseCatalog}
               className="inline-flex text-foreground transition-colors hover:text-primary focus-visible:rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
             >
               <GeoLensLogo size="lg" />
-            </Link>
+            </button>
             <p className="eyebrow mt-2.5">
               {t('geospatialDataCatalog')}
             </p>
@@ -354,10 +372,20 @@ export function LoginPage() {
         </Button>
 
         <div className="w-full max-w-[360px]">
-          {/* Mobile-only level-1 heading: the desktop brand panel's <h1> is
-              display:none below 880px, so screen-reader heading nav has no h1
-              on mobile without this. Hidden on desktop to keep a single h1. */}
-          <h1 className="sr-only min-[880px]:hidden">{t('signIn')}</h1>
+          {/* fix(#1852): below 880px the desktop brand panel is hidden
+              entirely (section className="hidden ... min-[880px]:flex"
+              above), so a phone visitor saw a bare, unbranded password form.
+              Show a compact wordmark + one-line headline instead of hiding
+              branding outright. Also doubles as the page's level-1 heading
+              below 880px — the desktop panel's own <h1> is display:none
+              here, and screen-reader heading nav needs exactly one h1 per
+              width; hidden on desktop to keep it that way. */}
+          <div className="mb-6 flex flex-col items-center gap-2 text-center min-[880px]:hidden">
+            <GeoLensLogo size="md" />
+            <h1 className="text-pretty text-lg font-semibold leading-snug tracking-[-0.01em] text-foreground">
+              {t('loginHero')}
+            </h1>
+          </div>
           {/* Form head */}
           <div className="mb-5">
             <h2 className="text-xl font-semibold tracking-[-0.01em] text-foreground">
@@ -455,5 +483,7 @@ export function LoginPage() {
         </div>
       </section>
     </main>
+    <AppFooter showBranding={showFooterBranding} />
+    </div>
   );
 }

--- a/frontend/src/pages/MapBuilderPage.tsx
+++ b/frontend/src/pages/MapBuilderPage.tsx
@@ -269,6 +269,10 @@ export function MapBuilderPage() {
     addLayer,
     removeLayer,
     saveBaselineSyncRef,
+    // fix(#1863 P2): reactive counterpart of mapInstanceRef, so the #1854
+    // auto-zoom watcher can retry once the (possibly still-loading) map
+    // becomes ready, instead of silently losing a zoom that arrived first.
+    mapInstance,
   );
   const {
     handleBulkVisibility: applyBulkVisibility,

--- a/frontend/src/pages/__tests__/LoginPage.footerAndMobileBranding.test.tsx
+++ b/frontend/src/pages/__tests__/LoginPage.footerAndMobileBranding.test.tsx
@@ -90,6 +90,7 @@ describe('LoginPage footer and mobile branding (#1852)', () => {
     mockedUseEdition.mockReturnValue({
       isEnterprise: false,
       isLoading: false,
+      isResolved: true,
     } as unknown as ReturnType<typeof useEdition>);
   });
 
@@ -138,5 +139,72 @@ describe('LoginPage footer and mobile branding (#1852)', () => {
     // production to avoid bouncing the visitor straight back to /login.
     await waitFor(() => expect(screen.getByTestId('home')).toBeInTheDocument());
     expect(sessionStorage.getItem('gl-guest-browse')).toBe('true');
+  });
+
+  // fix(#1863 P2, codex round 1): useEdition() reports isEnterprise === false
+  // (its default) until the edition query resolves, so an enterprise
+  // instance with show_badge false briefly rendered the "Powered by
+  // GeoLens" badge, then removed it once isEnterprise flipped true.
+  describe('footer badge does not flash before the edition query resolves (#1863 P2)', () => {
+    it('does not render the badge while the edition query is unresolved, even on an enterprise instance with the badge hidden', async () => {
+      mockedUseBranding.mockReturnValue({
+        data: { show_badge: false, privacy_url: null },
+      } as ReturnType<typeof useBranding>);
+      mockedUseEdition.mockReturnValue({
+        // Matches useEdition's real defaults while its query is in flight —
+        // isEnterprise defaults false, NOT yet known to be true.
+        isEnterprise: false,
+        isLoading: true,
+        isResolved: false,
+      } as unknown as ReturnType<typeof useEdition>);
+
+      const { Wrapper } = makeWrapper();
+      render(<LoginPage />, { wrapper: Wrapper });
+
+      await waitFor(() => {
+        expect(screen.getByLabelText(/username/i)).toBeInTheDocument();
+      });
+
+      // Unresolved: must not show the badge on the strength of a default
+      // that has not been confirmed yet.
+      expect(screen.queryByRole('link', { name: /powered by geolens/i })).not.toBeInTheDocument();
+    });
+
+    it('renders the badge once resolved on a community instance', async () => {
+      mockedUseEdition.mockReturnValue({
+        isEnterprise: false,
+        isLoading: false,
+        isResolved: true,
+      } as unknown as ReturnType<typeof useEdition>);
+
+      const { Wrapper } = makeWrapper();
+      render(<LoginPage />, { wrapper: Wrapper });
+
+      await waitFor(() => {
+        expect(screen.getByLabelText(/username/i)).toBeInTheDocument();
+      });
+
+      expect(screen.getByRole('link', { name: /powered by geolens/i })).toBeInTheDocument();
+    });
+
+    it('hides the badge once resolved on an enterprise instance with the badge disabled', async () => {
+      mockedUseBranding.mockReturnValue({
+        data: { show_badge: false, privacy_url: null },
+      } as ReturnType<typeof useBranding>);
+      mockedUseEdition.mockReturnValue({
+        isEnterprise: true,
+        isLoading: false,
+        isResolved: true,
+      } as unknown as ReturnType<typeof useEdition>);
+
+      const { Wrapper } = makeWrapper();
+      render(<LoginPage />, { wrapper: Wrapper });
+
+      await waitFor(() => {
+        expect(screen.getByLabelText(/username/i)).toBeInTheDocument();
+      });
+
+      expect(screen.queryByRole('link', { name: /powered by geolens/i })).not.toBeInTheDocument();
+    });
   });
 });

--- a/frontend/src/pages/__tests__/LoginPage.footerAndMobileBranding.test.tsx
+++ b/frontend/src/pages/__tests__/LoginPage.footerAndMobileBranding.test.tsx
@@ -1,0 +1,142 @@
+/**
+ * fix(#1852): /login sits outside AppLayout, so it never got the site
+ * footer AppLayout renders on every other route, and the desktop brand
+ * panel (logo/headline/features) is `hidden` entirely below 880px, leaving
+ * a phone visitor with a bare, unbranded password form. Also, the wordmark
+ * used to Link to="/", which with landing_first on bounces straight back
+ * to /login for a signed-out visitor — a dead click.
+ */
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Routes, Route } from 'react-router';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { TooltipProvider } from '@/components/ui/tooltip';
+import { useAuthStore } from '@/stores/auth-store';
+import { useBranding } from '@/hooks/use-settings';
+import { useEdition } from '@/hooks/use-edition';
+
+vi.mock('sonner', () => ({
+  toast: { error: vi.fn(), info: vi.fn(), success: vi.fn(), warning: vi.fn() },
+}));
+
+vi.mock('@/hooks/use-auth', () => ({
+  useAuth: () => ({
+    login: vi.fn(),
+    logout: vi.fn(),
+    token: null,
+    user: null,
+    isAdmin: false,
+    isEditor: false,
+  }),
+}));
+
+const mockGetAuthConfig = vi.fn();
+const mockGetOAuthProviders = vi.fn();
+vi.mock('@/api/auth', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/api/auth')>();
+  return {
+    ...actual,
+    getAuthConfig: () => mockGetAuthConfig(),
+    getOAuthProviders: () => mockGetOAuthProviders(),
+  };
+});
+
+vi.mock('@/hooks/use-settings', () => ({
+  useBranding: vi.fn(),
+}));
+const mockedUseBranding = vi.mocked(useBranding);
+
+vi.mock('@/hooks/use-edition', () => ({
+  useEdition: vi.fn(),
+}));
+const mockedUseEdition = vi.mocked(useEdition);
+
+// Import after mocks.
+import { LoginPage } from '../LoginPage';
+
+function makeWrapper(homeContent: React.ReactNode = <div>HOME</div>) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  });
+  function Wrapper({ children }: { children: React.ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>
+        <TooltipProvider>
+          <MemoryRouter initialEntries={['/login']}>
+            <Routes>
+              <Route path="/login" element={children} />
+              <Route path="/" element={homeContent} />
+            </Routes>
+          </MemoryRouter>
+        </TooltipProvider>
+      </QueryClientProvider>
+    );
+  }
+  return { Wrapper };
+}
+
+describe('LoginPage footer and mobile branding (#1852)', () => {
+  beforeEach(() => {
+    useAuthStore.setState({ token: null, refreshToken: null, expiresAt: null, user: null });
+    vi.clearAllMocks();
+    mockGetAuthConfig.mockResolvedValue({
+      registration_enabled: false,
+      password_login_enabled: true,
+    });
+    mockGetOAuthProviders.mockResolvedValue([]);
+    mockedUseBranding.mockReturnValue({
+      data: { show_badge: true, privacy_url: null },
+    } as ReturnType<typeof useBranding>);
+    mockedUseEdition.mockReturnValue({
+      isEnterprise: false,
+      isLoading: false,
+    } as unknown as ReturnType<typeof useEdition>);
+  });
+
+  it('renders the same site footer every other route gets (GitHub / Docs / Community / API / license)', async () => {
+    const { Wrapper } = makeWrapper();
+    render(<LoginPage />, { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/username/i)).toBeInTheDocument();
+    });
+
+    expect(screen.getByRole('link', { name: /github/i })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /docs/i })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /community/i })).toBeInTheDocument();
+  });
+
+  it('adds a compact wordmark + one-line headline for narrow widths (no longer bare below 880px)', async () => {
+    const { Wrapper } = makeWrapper();
+    render(<LoginPage />, { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/username/i)).toBeInTheDocument();
+    });
+
+    // The headline now renders twice: once in the desktop-only hero panel,
+    // once in the new mobile-only compact block (each hidden at the other
+    // width via CSS — jsdom does not evaluate media queries, so both are
+    // present in the DOM; a regression that drops the mobile block back to
+    // zero occurrences would fail this).
+    expect(screen.getAllByText('Your spatial data, all in one workspace.')).toHaveLength(2);
+  });
+
+  it('routes the wordmark through the guest-browse escape hatch, not a bare Link to "/"', async () => {
+    const { Wrapper } = makeWrapper(<div data-testid="home">HOME</div>);
+    render(<LoginPage />, { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/username/i)).toBeInTheDocument();
+    });
+
+    const wordmark = screen.getByRole('button', { name: /GeoLens/ });
+    await userEvent.click(wordmark);
+
+    // A plain Link to="/" would also land on HOME in this test's stub route,
+    // so the meaningful assertion is the marker LandingFirstGuard reads in
+    // production to avoid bouncing the visitor straight back to /login.
+    await waitFor(() => expect(screen.getByTestId('home')).toBeInTheDocument());
+    expect(sessionStorage.getItem('gl-guest-browse')).toBe('true');
+  });
+});


### PR DESCRIPTION
## Summary

Five S-severity fixes from the live UX walk of 2026-09-04, codebase audit tracked in #1852, #1853, #1854, #1856. One commit per issue.

- **#1852** — `/login` sits outside `AppLayout`, so it was the only route without the site footer, and the desktop brand panel is hidden entirely below 880px, leaving a bare password form on mobile. Adds the footer, a compact wordmark + one-line headline visible at every width, and routes the wordmark through the existing guest-browse escape hatch instead of a dead `Link to="/"`. The SSO icon buttons already carried `aria-label`s in `OAuthButtons.tsx` — verified live, added a regression test for the compact 3-provider layout since nothing previously covered it, no source change needed there.
- **#1853** — `FileDropzone` composed `dropzone.instructions` + `dropzone.browse` + `dropzone.toUpload`, but `instructions` shipped as a full sentence already ending in the same verb in all four locales, duplicating it ("...click to browse browse to upload"). Trimmed to the lead-in fragment in each locale. Also added the missing `_one`/`_other` plural split on the import success screen's dataset count, which always read "1 datasets added to the catalog".
- **#1854** (first half only) — a dataset added via `?add_dataset` on a fresh map never zoomed to it, so it could land off-screen at the world-view default. Zooms once via the existing `handleZoomToLayer` helper, but only through a watcher effect on `localLayers` rather than directly from the mutation's `onSuccess` — `layersRef` is only synced by a `useLayoutEffect` mirror on commit, so a direct call would race a still-stale ref. Second half of #1854 (the `computeMapIsClean` camera issue) is untouched.
- **#1856**, items 1 and 3 — `DistributionsList` rendered export URLs as copyable text only, with no way to actually fetch the resource; added a real download link per row alongside the existing copy button. `getRampColors` sampled qualitative palettes (Set2 etc.) continuously, same as sequential ramps, blending unrelated category hues into muddy near-grey colors at small counts; qualitative ramps now assign palette entries directly and cycle past the palette length. Item 2 (the API description overclaim) was left alone per the brief.

## Verification

```
cd frontend
npx vitest run <touched files>   # 170 passed across 14 files
npm run typecheck                 # clean
npm run lint                      # clean
npm run test:i18n                 # clean (4 tests)
```

Each new/changed test was confirmed to fail against the pre-fix code before restoring the fix (counterfactual check), including the two ref-staleness regression tests (`use-builder-layers.add-dataset-auto-zoom.test.tsx`) and the plural/duplication tests for #1853.

Login page verified live at 1440px and 390px against the main checkout's API (`localhost:8001`) via a host Vite dev server on `:5174`, using Playwright: footer renders, mobile compact wordmark + headline render, and clicking the wordmark reaches the catalog instead of bouncing back to `/login`.

## Screenshots

Login page, 1440px and 390px (footer + mobile branding, #1852):
- `/private/tmp/claude-501/-Users-ishiland-Code-geolens/909d0a61-f431-47e7-ac2b-66c891372ad5/scratchpad/ux1-screenshots/login-1440.png`
- `/private/tmp/claude-501/-Users-ishiland-Code-geolens/909d0a61-f431-47e7-ac2b-66c891372ad5/scratchpad/ux1-screenshots/login-390.png`