### PR TITLE
fix(features): take the datasets row before the records row (#1847)

### DIFF
--- a/backend/app/api/main.py
+++ b/backend/app/api/main.py
@@ -948,7 +948,11 @@ app.add_exception_handler(RateLimitExceeded, _rate_limit_handler)
 
 from sqlalchemy.exc import DBAPIError  # noqa: E402
 
-from app.core.db.sqlstate import is_operational, sqlstate  # noqa: E402
+from app.core.db.sqlstate import (  # noqa: E402
+    is_lock_conflict,
+    is_operational,
+    sqlstate,
+)
 from app.platform.catalog_locks import (  # noqa: E402
     CATALOG_LOCK_CONFLICT_CODE,
     CatalogLockConflict,
@@ -992,14 +996,8 @@ async def _storage_quota_handler(
     )
 
 
-async def _catalog_lock_conflict_handler(
-    request: Request, exc: Exception
-) -> JSONResponse:
-    """Map a contended catalog row to 409, from wherever it was reached.
-
-    fix(#1847): one handler so the answer does not depend on which route
-    reached the acquisition. Safe to retry: the helper rolled back first.
-    """
+def _catalog_lock_conflict_response(request: Request, message: str) -> JSONResponse:
+    """The one 409 body for a contended catalog row."""
     logger.info(
         "catalog row lock conflict",
         path=safe_access_log_path(request.url.path),
@@ -1009,12 +1007,23 @@ async def _catalog_lock_conflict_handler(
         content=ProblemDetail(
             title="Catalog entry is busy",
             status=status.HTTP_409_CONFLICT,
-            # Keyed, because this is now the ONLY shape a contended row
-            # produces and a client cannot match on a title.
-            detail={"code": CATALOG_LOCK_CONFLICT_CODE, "message": str(exc)},
+            # Keyed, because this is the ONLY shape a contended row produces
+            # and a client cannot match on a title.
+            detail={"code": CATALOG_LOCK_CONFLICT_CODE, "message": message},
         ).model_dump(),
         media_type="application/problem+json",
     )
+
+
+async def _catalog_lock_conflict_handler(
+    request: Request, exc: Exception
+) -> JSONResponse:
+    """Map a contended catalog row to 409, from wherever it was reached.
+
+    fix(#1847): one handler so the answer does not depend on which route
+    reached the acquisition. Safe to retry: the helper rolled back first.
+    """
+    return _catalog_lock_conflict_response(request, str(exc))
 
 
 async def _database_error_handler(request: Request, exc: DBAPIError) -> JSONResponse:
@@ -1029,8 +1038,18 @@ async def _database_error_handler(request: Request, exc: DBAPIError) -> JSONResp
     re-raised so they keep their existing 500 path; calling a unique-constraint
     collision "database unavailable" would just invite a retry loop.
 
+    fix(#1847): a lock conflict is answered here too, not only when it arrives
+    as CatalogLockConflict from the acquisition. `SET LOCAL lock_timeout` stays
+    in effect for the whole transaction, so a later wait in the same request
+    raises 55P03 from a statement no per-site translation wraps. Closing it at
+    the boundary keeps one mapping instead of one per call site.
+
     The detail is deliberately generic: the SQLSTATE and statement go to the log.
     """
+    if is_lock_conflict(exc):
+        return _catalog_lock_conflict_response(
+            request, "Another operation is updating this dataset's catalog entry."
+        )
     if not is_operational(exc):
         raise exc
     logger.exception(

--- a/backend/app/api/main.py
+++ b/backend/app/api/main.py
@@ -956,6 +956,7 @@ from app.core.db.sqlstate import (  # noqa: E402
 from app.platform.catalog_locks import (  # noqa: E402
     CATALOG_LOCK_CONFLICT_CODE,
     CatalogLockConflict,
+    catalog_timeout_installed,
 )
 from app.modules.quota.service import (  # noqa: E402
     DatasetQuotaExceededError,
@@ -1041,12 +1042,13 @@ async def _database_error_handler(request: Request, exc: DBAPIError) -> JSONResp
     fix(#1847): a lock conflict is answered here too, not only when it arrives
     as CatalogLockConflict from the acquisition. `SET LOCAL lock_timeout` stays
     in effect for the whole transaction, so a later wait in the same request
-    raises 55P03 from a statement no per-site translation wraps. Closing it at
-    the boundary keeps one mapping instead of one per call site.
+    raises 55P03 from a statement no per-site translation wraps. Gated on this
+    request having installed that timeout, so an unrelated deadlock keeps its
+    operational classification instead of being reported as a busy dataset.
 
     The detail is deliberately generic: the SQLSTATE and statement go to the log.
     """
-    if is_lock_conflict(exc):
+    if is_lock_conflict(exc) and catalog_timeout_installed.get():
         return _catalog_lock_conflict_response(
             request, "Another operation is updating this dataset's catalog entry."
         )

--- a/backend/app/api/main.py
+++ b/backend/app/api/main.py
@@ -1006,7 +1006,9 @@ async def _catalog_lock_conflict_handler(
         content=ProblemDetail(
             title="Catalog entry is busy",
             status=status.HTTP_409_CONFLICT,
-            detail=str(exc),
+            # Keyed, because this is now the ONLY shape a contended row
+            # produces and a client cannot match on a title.
+            detail={"code": "catalog_lock_conflict", "message": str(exc)},
         ).model_dump(),
         media_type="application/problem+json",
     )

--- a/backend/app/api/main.py
+++ b/backend/app/api/main.py
@@ -1021,8 +1021,7 @@ async def _catalog_lock_conflict_handler(
 ) -> JSONResponse:
     """Map a contended catalog row to 409, from wherever it was reached.
 
-    fix(#1847): one handler so the answer does not depend on which route
-    reached the acquisition. Safe to retry: the helper rolled back first.
+    Safe to retry: the acquisition rolled its transaction back first.
     """
     return _catalog_lock_conflict_response(request, str(exc))
 

--- a/backend/app/api/main.py
+++ b/backend/app/api/main.py
@@ -1038,12 +1038,9 @@ async def _database_error_handler(request: Request, exc: DBAPIError) -> JSONResp
     re-raised so they keep their existing 500 path; calling a unique-constraint
     collision "database unavailable" would just invite a retry loop.
 
-    fix(#1847): a lock conflict is answered here too, not only when it arrives
-    as CatalogLockConflict from the acquisition. `SET LOCAL lock_timeout` stays
-    in effect for the whole transaction, so a later wait in the same request
-    raises 55P03 from a statement no per-site translation wraps. Gated on this
-    request having installed that timeout, so an unrelated deadlock keeps its
-    operational classification instead of being reported as a busy dataset.
+    fix(#1847): a lock conflict raised after the acquisition, while this
+    request's catalog lock timeout is installed, is answered 409 like one at
+    the acquisition; without that timeout it keeps its operational class.
 
     The detail is deliberately generic: the SQLSTATE and statement go to the log.
     """

--- a/backend/app/api/main.py
+++ b/backend/app/api/main.py
@@ -949,7 +949,10 @@ app.add_exception_handler(RateLimitExceeded, _rate_limit_handler)
 from sqlalchemy.exc import DBAPIError  # noqa: E402
 
 from app.core.db.sqlstate import is_operational, sqlstate  # noqa: E402
-from app.platform.catalog_locks import CatalogLockConflict  # noqa: E402
+from app.platform.catalog_locks import (  # noqa: E402
+    CATALOG_LOCK_CONFLICT_CODE,
+    CatalogLockConflict,
+)
 from app.modules.quota.service import (  # noqa: E402
     DatasetQuotaExceededError,
     StorageQuotaExceededError,
@@ -1008,7 +1011,7 @@ async def _catalog_lock_conflict_handler(
             status=status.HTTP_409_CONFLICT,
             # Keyed, because this is now the ONLY shape a contended row
             # produces and a client cannot match on a title.
-            detail={"code": "catalog_lock_conflict", "message": str(exc)},
+            detail={"code": CATALOG_LOCK_CONFLICT_CODE, "message": str(exc)},
         ).model_dump(),
         media_type="application/problem+json",
     )

--- a/backend/app/api/main.py
+++ b/backend/app/api/main.py
@@ -949,6 +949,7 @@ app.add_exception_handler(RateLimitExceeded, _rate_limit_handler)
 from sqlalchemy.exc import DBAPIError  # noqa: E402
 
 from app.core.db.sqlstate import is_operational, sqlstate  # noqa: E402
+from app.platform.catalog_locks import CatalogLockConflict  # noqa: E402
 from app.modules.quota.service import (  # noqa: E402
     DatasetQuotaExceededError,
     StorageQuotaExceededError,
@@ -982,6 +983,36 @@ async def _storage_quota_handler(
         content=ProblemDetail(
             title="Storage quota exceeded",
             status=status.HTTP_413_CONTENT_TOO_LARGE,
+            detail=str(exc),
+        ).model_dump(),
+        media_type="application/problem+json",
+    )
+
+
+async def _catalog_lock_conflict_handler(
+    request: Request, exc: Exception
+) -> JSONResponse:
+    """Map a contended catalog row to 409, from wherever it was reached.
+
+    fix(#1847 review r3): the acquisition in `app.platform.catalog_locks` is
+    now called from feature writes, metadata edits, layer DDL and dataset
+    deletion, and each of those classified a lost race differently -- 409, 503
+    and 400 for the same SQLSTATE. Handling the domain exception in one place
+    is what makes the answer the same everywhere, without every route growing
+    its own except clause.
+
+    Retryable and safe to retry: the helper rolled its transaction back before
+    raising, so nothing the request attempted survives.
+    """
+    logger.info(
+        "catalog row lock conflict",
+        path=safe_access_log_path(request.url.path),
+    )
+    return JSONResponse(
+        status_code=status.HTTP_409_CONFLICT,
+        content=ProblemDetail(
+            title="Catalog entry is busy",
+            status=status.HTTP_409_CONFLICT,
             detail=str(exc),
         ).model_dump(),
         media_type="application/problem+json",
@@ -1025,6 +1056,7 @@ async def _database_error_handler(request: Request, exc: DBAPIError) -> JSONResp
 
 app.add_exception_handler(DatasetQuotaExceededError, _dataset_quota_handler)
 app.add_exception_handler(StorageQuotaExceededError, _storage_quota_handler)
+app.add_exception_handler(CatalogLockConflict, _catalog_lock_conflict_handler)
 app.add_exception_handler(DBAPIError, _database_error_handler)
 
 # fix(#1770 round 44 P2): registered FIRST, so it ends up INNERMOST --

--- a/backend/app/api/main.py
+++ b/backend/app/api/main.py
@@ -994,15 +994,8 @@ async def _catalog_lock_conflict_handler(
 ) -> JSONResponse:
     """Map a contended catalog row to 409, from wherever it was reached.
 
-    fix(#1847 review r3): the acquisition in `app.platform.catalog_locks` is
-    now called from feature writes, metadata edits, layer DDL and dataset
-    deletion, and each of those classified a lost race differently -- 409, 503
-    and 400 for the same SQLSTATE. Handling the domain exception in one place
-    is what makes the answer the same everywhere, without every route growing
-    its own except clause.
-
-    Retryable and safe to retry: the helper rolled its transaction back before
-    raising, so nothing the request attempted survives.
+    fix(#1847): one handler so the answer does not depend on which route
+    reached the acquisition. Safe to retry: the helper rolled back first.
     """
     logger.info(
         "catalog row lock conflict",

--- a/backend/app/core/db/sqlstate.py
+++ b/backend/app/core/db/sqlstate.py
@@ -121,3 +121,53 @@ def is_operational(exc: DBAPIError) -> bool:
     if code is None:
         return True
     return code[:2] in _OPERATIONAL_CLASSES
+
+
+# Another transaction owns rows this one needs right now. Both states mean the
+# same thing to a caller: nothing was written, and a retry lands after the
+# owner commits.
+#
+# fix(#1847): one definition, because the answer had been rewritten per module.
+# `app.platform.jobs.router` carried this exact pair inline, `catalog.maps`
+# carried a 55P03-only copy whose docstring recorded that it wanted to share
+# but had nowhere layer-legal to share from, and the feature-write router had
+# no notion of a lock conflict at all -- so a deadlock victim there fell
+# through `is_operational` (class 40) and surfaced as "database temporarily
+# unavailable", which is a 503 telling the client to back off when the correct
+# advice is to retry immediately.
+#
+# 40001 (serialization_failure) is deliberately NOT here. It is unreachable at
+# READ COMMITTED, which is the only isolation level this application runs at,
+# and adding it would widen two already-reviewed predicates for a case no
+# caller can produce.
+LOCK_CONFLICT = frozenset(
+    {
+        "55P03",  # lock_not_available — SET LOCAL lock_timeout expired
+        "40P01",  # deadlock_detected — this transaction was the victim
+    }
+)
+
+
+def is_lock_conflict(exc: BaseException) -> bool:
+    """True when *exc* means "another transaction holds what this one wants".
+
+    Accepts either shape. asyncpg raises `LockNotAvailableError` /
+    `DeadlockDetectedError` directly, and `AsyncSession.execute` wraps that in
+    SQLAlchemy's `DBAPIError` with `.orig` pointing at the same exception, so a
+    helper that only unwrapped one of the two missed the other depending on
+    which layer the call bubbled through.
+
+    Narrower than a "retry this statement" test on purpose. The re-upload swap
+    in `processing/ingest/tasks_common.py` keeps its own 55P03-only predicate,
+    because retrying DDL after a *deadlock* is a different and unproven
+    decision from retrying it after a lock timeout.
+    """
+    for candidate in (exc, getattr(exc, "orig", None)):
+        if candidate is None:
+            continue
+        code = getattr(candidate, "sqlstate", None) or getattr(
+            candidate, "pgcode", None
+        )
+        if code and str(code) in LOCK_CONFLICT:
+            return True
+    return False

--- a/backend/app/core/db/sqlstate.py
+++ b/backend/app/core/db/sqlstate.py
@@ -123,23 +123,9 @@ def is_operational(exc: DBAPIError) -> bool:
     return code[:2] in _OPERATIONAL_CLASSES
 
 
-# Another transaction owns rows this one needs right now. Both states mean the
-# same thing to a caller: nothing was written, and a retry lands after the
-# owner commits.
-#
-# fix(#1847): one definition, because the answer had been rewritten per module.
-# `app.platform.jobs.router` carried this exact pair inline, `catalog.maps`
-# carried a 55P03-only copy whose docstring recorded that it wanted to share
-# but had nowhere layer-legal to share from, and the feature-write router had
-# no notion of a lock conflict at all -- so a deadlock victim there fell
-# through `is_operational` (class 40) and surfaced as "database temporarily
-# unavailable", which is a 503 telling the client to back off when the correct
-# advice is to retry immediately.
-#
-# 40001 (serialization_failure) is deliberately NOT here. It is unreachable at
-# READ COMMITTED, which is the only isolation level this application runs at,
-# and adding it would widen two already-reviewed predicates for a case no
-# caller can produce.
+# fix(#1847): another transaction owns rows this one needs. Both states mean
+# the same to a caller: nothing was written, and a retry lands after the owner
+# commits. 40001 is excluded as unreachable at READ COMMITTED.
 LOCK_CONFLICT = frozenset(
     {
         "55P03",  # lock_not_available — SET LOCAL lock_timeout expired
@@ -149,17 +135,12 @@ LOCK_CONFLICT = frozenset(
 
 
 def is_lock_conflict(exc: BaseException) -> bool:
-    """True when *exc* means "another transaction holds what this one wants".
+    """True when another transaction holds what this one wants.
 
-    Accepts either shape. asyncpg raises `LockNotAvailableError` /
-    `DeadlockDetectedError` directly, and `AsyncSession.execute` wraps that in
-    SQLAlchemy's `DBAPIError` with `.orig` pointing at the same exception, so a
-    helper that only unwrapped one of the two missed the other depending on
-    which layer the call bubbled through.
+    Accepts a bare asyncpg exception or a SQLAlchemy `DBAPIError` wrapping one.
 
-    Narrower than a "retry this statement" test on purpose. The re-upload swap
-    in `processing/ingest/tasks_common.py` keeps its own 55P03-only predicate,
-    because retrying DDL after a *deadlock* is a different and unproven
+    Narrower than "retry this statement": the re-upload swap keeps its own
+    55P03-only predicate, because retrying DDL after a deadlock is a different
     decision from retrying it after a lock timeout.
     """
     for candidate in (exc, getattr(exc, "orig", None)):

--- a/backend/app/modules/catalog/datasets/api/router.py
+++ b/backend/app/modules/catalog/datasets/api/router.py
@@ -538,8 +538,8 @@ async def bulk_delete_datasets_endpoint(
                     ip_address=request.client.host if request.client else None,
                 ),
             )
-            # Commit per-item so a later failure cannot orphan storage objects
-            # that were already deleted for successfully-committed datasets.
+            # Commit per item so one item's failure cannot roll back the rows
+            # of the items before it.
             await db.commit()
             # fix(#1847): the reap is deferred past both invalidations below;
             # awaiting object storage here would delay them per item.

--- a/backend/app/modules/catalog/datasets/api/router.py
+++ b/backend/app/modules/catalog/datasets/api/router.py
@@ -494,6 +494,7 @@ async def bulk_delete_datasets_endpoint(
 ) -> BulkDeleteResponse:
     """Delete multiple datasets in one request. Returns per-item results."""
     results: list[BulkDeleteResultItem] = []
+    pending_reaps: list = []
     deleted = 0
 
     for item in body.datasets:
@@ -540,7 +541,9 @@ async def bulk_delete_datasets_endpoint(
             # Commit per-item so a later failure cannot orphan storage objects
             # that were already deleted for successfully-committed datasets.
             await db.commit()
-            await _reap_after_commit(deletion)
+            # fix(#1847): the reap is deferred past both invalidations below;
+            # awaiting object storage here would delay them per item.
+            pending_reaps.append(deletion)
             # fix(#1429): only now is the delete visible to a concurrent tile
             # request, so only now can the tile router's table_name -> metadata
             # map be evicted without the request re-caching the deleted row.
@@ -583,6 +586,11 @@ async def bulk_delete_datasets_endpoint(
 
     if deleted > 0:
         await invalidate_catalog_cache()
+
+    # fix(#1847): last, so no storage round trip can delay or skip the
+    # invalidations above for any item in the batch.
+    for deletion in pending_reaps:
+        await _reap_after_commit(deletion)
 
     return BulkDeleteResponse(
         deleted=deleted, errors=len(results) - deleted, results=results
@@ -650,7 +658,6 @@ async def delete_dataset_endpoint(
         ),
     )
     await db.commit()
-    await _reap_after_commit(deletion)
 
     # Invalidate caches after dataset deletion
     await invalidate_catalog_cache()
@@ -660,6 +667,11 @@ async def delete_dataset_endpoint(
     # visibility, so a stale entry would authorize a successor drawing this
     # freed table name under the deleted dataset's rules.
     notify_table_invalidated(table_name)
+
+    # fix(#1847): after both invalidations. The reap awaits object storage, so
+    # a slow backend would delay them and a cancellation would skip them,
+    # leaving search and the tile map serving a deleted dataset until TTL.
+    await _reap_after_commit(deletion)
 
     return Response(status_code=status.HTTP_204_NO_CONTENT)
 

--- a/backend/app/modules/catalog/datasets/api/router.py
+++ b/backend/app/modules/catalog/datasets/api/router.py
@@ -15,7 +15,10 @@ from fastapi import (
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.identity import Identity
-from app.platform.catalog_locks import CatalogLockConflict
+from app.platform.catalog_locks import (
+    CATALOG_LOCK_CONFLICT_CODE,
+    CatalogLockConflict,
+)
 from app.core.record_types import RASTER_FAMILY_RECORD_TYPES
 from app.modules.audit.schemas import AuditLogListResponse, AuditLogResponse
 from app.modules.audit.service import AuditEvent, audit_emit, query_audit_logs
@@ -435,6 +438,21 @@ async def update_dataset_metadata(
     return response
 
 
+async def _rollback_failed_item(db: AsyncSession, user) -> None:
+    """Roll back one failed bulk-delete item without breaking the next one.
+
+    fix(#1847): `AsyncSession.rollback()` expires every instance in the
+    session, including the `user` the per-item access check reads. The next
+    item's `user.id` then lazy-loaded outside the greenlet and raised
+    MissingGreenlet, which the catch-all recorded as "Dataset deletion failed
+    unexpectedly" -- one bad item made every later item fail with a message
+    describing none of them. Reloading the actor is awaited, so the following
+    item's check runs normally.
+    """
+    await db.rollback()
+    await db.refresh(user)
+
+
 # ROUTE-01 (Phase 1092): dual-shape decorator — both trailing-slash and
 # no-trailing-slash variants register against the same handler. Slash form
 # stays canonical (already in OpenAPI); no-slash is a hidden alias closing
@@ -502,13 +520,23 @@ async def bulk_delete_datasets_endpoint(
                 BulkDeleteResultItem(dataset_id=item.dataset_id, status="deleted")
             )
             deleted += 1
-        except CatalogLockConflict:
-            # fix(#1847): the helper already rolled back. Re-raised so the one
-            # 409 mapping applies; the catch-all below would log a stack trace
-            # and report a contended row as an unexpected failure.
-            raise
+        except CatalogLockConflict as exc:
+            # fix(#1847): recorded per item, not raised. The batch commits per
+            # item, so aborting here would discard results already committed.
+            # The catch-all below would report a contended row as an
+            # unexpected failure and log a stack trace for it.
+            await _rollback_failed_item(db, user)
+            results.append(
+                BulkDeleteResultItem(
+                    dataset_id=item.dataset_id,
+                    status="error",
+                    detail=str(exc),
+                    code=CATALOG_LOCK_CONFLICT_CODE,
+                )
+            )
+            continue
         except Exception as exc:  # broad: per-item bulk-delete is isolated — any failure is recorded per-item without aborting the batch
-            await db.rollback()
+            await _rollback_failed_item(db, user)
             if isinstance(exc, (DependentVrtError, DatasetTitleMismatchError)):
                 detail = str(exc)
             else:

--- a/backend/app/modules/catalog/datasets/api/router.py
+++ b/backend/app/modules/catalog/datasets/api/router.py
@@ -444,10 +444,9 @@ async def update_dataset_metadata(
 async def _reap_after_commit(deletion) -> None:
     """Remove a deleted dataset's objects, once its rows are gone for good.
 
-    fix(#1847): the reap is irreversible and the delete's FK cascades can still
-    lose a lock race, so it runs AFTER the commit. A failure here orphans
-    objects, which costs storage; it cannot resurrect a dataset, so it is
-    logged rather than raised at a caller whose rows are already deleted.
+    Runs after the commit because it is irreversible and the delete's FK
+    cascades can still lose a lock race. A failure orphans objects and cannot
+    resurrect a dataset, so it is logged rather than raised.
     """
     from app.modules.catalog.datasets.domain.service import reap_managed_storage
 
@@ -464,19 +463,13 @@ async def _reap_after_commit(deletion) -> None:
 async def _rollback_failed_item(db: AsyncSession, user) -> None:
     """Roll back one failed bulk-delete item without breaking the next one.
 
-    fix(#1847): `AsyncSession.rollback()` expires every instance in the
-    session, including the `user` the per-item access check reads. The next
-    item's `user.id` then lazy-loaded outside the greenlet and raised
-    MissingGreenlet, which the catch-all recorded as "Dataset deletion failed
-    unexpectedly" -- one bad item made every later item fail with a message
-    describing none of them. Reloading the actor is awaited, so the following
-    item's check runs normally.
+    `rollback()` expires every instance in the session, including the actor the
+    per-item access check reads, whose next attribute read would lazy-load
+    outside the greenlet. Reloading it here is awaited.
 
     Only a PERSISTENT mapped instance is reloaded. An `IdentityExtension`
-    supplies an identity that is not a mapped `User` at all, and `refresh()`
-    raises `UnmappedInstanceError` on one -- turning the recovery path into the
-    failure it exists to prevent. Such an identity is not in the session, so
-    the rollback never expired it and there is nothing to restore.
+    identity has no mapper, so `refresh()` would raise UnmappedInstanceError on
+    it; it is also not in the session, so nothing expired it.
     """
     await db.rollback()
     try:
@@ -557,10 +550,9 @@ async def bulk_delete_datasets_endpoint(
             )
             deleted += 1
         except CatalogLockConflict as exc:
-            # fix(#1847): recorded per item, not raised. The batch commits per
-            # item, so aborting here would discard results already committed.
-            # The catch-all below would report a contended row as an
-            # unexpected failure and log a stack trace for it.
+            # fix(#1847): per item, not raised. The batch commits per item, so
+            # aborting would discard results already committed, and the
+            # catch-all would call a contended row an unexpected failure.
             await _rollback_failed_item(db, user)
             results.append(
                 BulkDeleteResultItem(

--- a/backend/app/modules/catalog/datasets/api/router.py
+++ b/backend/app/modules/catalog/datasets/api/router.py
@@ -18,6 +18,7 @@ from sqlalchemy import inspect as sa_inspect
 from sqlalchemy.exc import NoInspectionAvailable
 
 from app.core.identity import Identity
+from app.core.db.sqlstate import is_lock_conflict
 from app.platform.catalog_locks import (
     CATALOG_LOCK_CONFLICT_CODE,
     CatalogLockConflict,
@@ -568,6 +569,18 @@ async def bulk_delete_datasets_endpoint(
             continue
         except Exception as exc:  # broad: per-item bulk-delete is isolated — any failure is recorded per-item without aborting the batch
             await _rollback_failed_item(db, user)
+            if is_lock_conflict(exc):
+                # fix(#1847): a wait after the acquisition (the record cascade on
+                # a held child) is the same contended row, so the same code.
+                results.append(
+                    BulkDeleteResultItem(
+                        dataset_id=item.dataset_id,
+                        status="error",
+                        detail="Another operation is updating this dataset's catalog entry.",
+                        code=CATALOG_LOCK_CONFLICT_CODE,
+                    )
+                )
+                continue
             if isinstance(exc, (DependentVrtError, DatasetTitleMismatchError)):
                 detail = str(exc)
             else:

--- a/backend/app/modules/catalog/datasets/api/router.py
+++ b/backend/app/modules/catalog/datasets/api/router.py
@@ -14,6 +14,9 @@ from fastapi import (
 )
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from sqlalchemy import inspect as sa_inspect
+from sqlalchemy.exc import NoInspectionAvailable
+
 from app.core.identity import Identity
 from app.platform.catalog_locks import (
     CATALOG_LOCK_CONFLICT_CODE,
@@ -448,9 +451,20 @@ async def _rollback_failed_item(db: AsyncSession, user) -> None:
     unexpectedly" -- one bad item made every later item fail with a message
     describing none of them. Reloading the actor is awaited, so the following
     item's check runs normally.
+
+    Only a PERSISTENT mapped instance is reloaded. An `IdentityExtension`
+    supplies an identity that is not a mapped `User` at all, and `refresh()`
+    raises `UnmappedInstanceError` on one -- turning the recovery path into the
+    failure it exists to prevent. Such an identity is not in the session, so
+    the rollback never expired it and there is nothing to restore.
     """
     await db.rollback()
-    await db.refresh(user)
+    try:
+        state = sa_inspect(user)
+    except NoInspectionAvailable:
+        return
+    if state.persistent:
+        await db.refresh(user)
 
 
 # ROUTE-01 (Phase 1092): dual-shape decorator — both trailing-slash and

--- a/backend/app/modules/catalog/datasets/api/router.py
+++ b/backend/app/modules/catalog/datasets/api/router.py
@@ -15,6 +15,7 @@ from fastapi import (
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.identity import Identity
+from app.platform.catalog_locks import CatalogLockConflict
 from app.core.record_types import RASTER_FAMILY_RECORD_TYPES
 from app.modules.audit.schemas import AuditLogListResponse, AuditLogResponse
 from app.modules.audit.service import AuditEvent, audit_emit, query_audit_logs
@@ -501,6 +502,11 @@ async def bulk_delete_datasets_endpoint(
                 BulkDeleteResultItem(dataset_id=item.dataset_id, status="deleted")
             )
             deleted += 1
+        except CatalogLockConflict:
+            # fix(#1847): the helper already rolled back. Re-raised so the one
+            # 409 mapping applies; the catch-all below would log a stack trace
+            # and report a contended row as an unexpected failure.
+            raise
         except Exception as exc:  # broad: per-item bulk-delete is isolated — any failure is recorded per-item without aborting the batch
             await db.rollback()
             if isinstance(exc, (DependentVrtError, DatasetTitleMismatchError)):

--- a/backend/app/modules/catalog/datasets/api/router.py
+++ b/backend/app/modules/catalog/datasets/api/router.py
@@ -441,6 +441,26 @@ async def update_dataset_metadata(
     return response
 
 
+async def _reap_after_commit(deletion) -> None:
+    """Remove a deleted dataset's objects, once its rows are gone for good.
+
+    fix(#1847): the reap is irreversible and the delete's FK cascades can still
+    lose a lock race, so it runs AFTER the commit. A failure here orphans
+    objects, which costs storage; it cannot resurrect a dataset, so it is
+    logged rather than raised at a caller whose rows are already deleted.
+    """
+    from app.modules.catalog.datasets.domain.service import reap_managed_storage
+
+    try:
+        await reap_managed_storage(list(deletion.storage_prefixes), deletion.tenant_id)
+    except Exception:  # broad: the rows are already gone, so no failure here can be raised at a caller that could act on it
+        logger.exception(
+            "Dataset rows are deleted but their storage was not reaped",
+            table_name=deletion.table_name,
+            prefixes=list(deletion.storage_prefixes),
+        )
+
+
 async def _rollback_failed_item(db: AsyncSession, user) -> None:
     """Roll back one failed bulk-delete item without breaking the next one.
 
@@ -511,7 +531,8 @@ async def bulk_delete_datasets_endpoint(
                 )
                 continue
 
-            table_name = await delete_dataset(db, item.dataset_id, item.confirm_title)
+            deletion = await delete_dataset(db, item.dataset_id, item.confirm_title)
+            table_name = deletion.table_name
             await audit_emit(
                 db,
                 AuditEvent(
@@ -526,6 +547,7 @@ async def bulk_delete_datasets_endpoint(
             # Commit per-item so a later failure cannot orphan storage objects
             # that were already deleted for successfully-committed datasets.
             await db.commit()
+            await _reap_after_commit(deletion)
             # fix(#1429): only now is the delete visible to a concurrent tile
             # request, so only now can the tile router's table_name -> metadata
             # map be evicted without the request re-caching the deleted row.
@@ -594,7 +616,8 @@ async def delete_dataset_endpoint(
     await check_dataset_write_access(db, dataset, dataset_id, user)
 
     try:
-        table_name = await delete_dataset(db, dataset_id, body.confirm_title)
+        deletion = await delete_dataset(db, dataset_id, body.confirm_title)
+        table_name = deletion.table_name
     except DependentVrtError as exc:
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
@@ -635,6 +658,7 @@ async def delete_dataset_endpoint(
         ),
     )
     await db.commit()
+    await _reap_after_commit(deletion)
 
     # Invalidate caches after dataset deletion
     await invalidate_catalog_cache()

--- a/backend/app/modules/catalog/datasets/api/router_metadata.py
+++ b/backend/app/modules/catalog/datasets/api/router_metadata.py
@@ -255,7 +255,10 @@ async def reset_attribute_endpoint(
     from app.modules.catalog.datasets.domain.service import (
         get_attribute as get_attr_svc,
     )
-    from app.modules.catalog.datasets.domain.service import reset_attribute
+    from app.modules.catalog.datasets.domain.service import (
+        reset_attribute,
+        sample_example_values,
+    )
     from app.modules.catalog.features.service import lock_catalog_rows_for_write
 
     attr = await get_attr_svc(db, attribute_id)
@@ -264,9 +267,15 @@ async def reset_attribute_endpoint(
             status_code=status.HTTP_404_NOT_FOUND, detail="Attribute not found"
         )
     try:
-        # fix(#1847): the pair first here too; see update_attribute_endpoint.
+        # fix(#1847): data table, then the pair, then the attribute row: every
+        # column DDL holds its ALTER TABLE before it takes the pair.
+        examples = await sample_example_values(
+            db, dataset.table_name, attr.field_name, attr.data_type
+        )
         await lock_catalog_rows_for_write(db, dataset)
-        attr = await reset_attribute(db, attribute_id, dataset.table_name)
+        attr = await reset_attribute(
+            db, attribute_id, dataset.table_name, example_values=examples
+        )
         dataset.record.updated_by = user.id
         await audit_emit(
             db,

--- a/backend/app/modules/catalog/datasets/api/router_metadata.py
+++ b/backend/app/modules/catalog/datasets/api/router_metadata.py
@@ -196,6 +196,7 @@ async def update_attribute_endpoint(
         get_attribute as get_attr_svc,
     )
     from app.modules.catalog.datasets.domain.service import update_attribute
+    from app.modules.catalog.features.service import lock_catalog_rows_for_write
 
     attr = await get_attr_svc(db, attribute_id)
     if attr is None or attr.dataset_id != dataset.id:
@@ -206,6 +207,9 @@ async def update_attribute_endpoint(
         # Use exclude_unset (not exclude_none) so explicit null clears the field
         updates = body.model_dump(exclude_unset=True)
         if updates:
+            # fix(#1847): the pair before the attribute row, the order every
+            # column DDL holds; attribute-first is an ABBA against them.
+            await lock_catalog_rows_for_write(db, dataset)
             attr = await update_attribute(db, attribute_id, **updates)
             dataset.record.updated_by = user.id
             await audit_emit(
@@ -252,6 +256,7 @@ async def reset_attribute_endpoint(
         get_attribute as get_attr_svc,
     )
     from app.modules.catalog.datasets.domain.service import reset_attribute
+    from app.modules.catalog.features.service import lock_catalog_rows_for_write
 
     attr = await get_attr_svc(db, attribute_id)
     if attr is None or attr.dataset_id != dataset.id:
@@ -259,6 +264,8 @@ async def reset_attribute_endpoint(
             status_code=status.HTTP_404_NOT_FOUND, detail="Attribute not found"
         )
     try:
+        # fix(#1847): the pair first here too; see update_attribute_endpoint.
+        await lock_catalog_rows_for_write(db, dataset)
         attr = await reset_attribute(db, attribute_id, dataset.table_name)
         dataset.record.updated_by = user.id
         await audit_emit(

--- a/backend/app/modules/catalog/datasets/domain/schemas.py
+++ b/backend/app/modules/catalog/datasets/domain/schemas.py
@@ -551,6 +551,11 @@ class BulkDeleteResultItem(BaseModel):
     dataset_id: uuid.UUID
     status: str  # "deleted" | "error"
     detail: str | None = None
+    # fix(#1847): machine-readable where an error has a code the caller can act
+    # on. `catalog_lock_conflict` is the one the single-delete 409 carries, so
+    # a client sees the same code whichever endpoint it used. None for errors
+    # that have only prose.
+    code: str | None = None
 
 
 class BulkDeleteResponse(BaseModel):

--- a/backend/app/modules/catalog/datasets/domain/schemas.py
+++ b/backend/app/modules/catalog/datasets/domain/schemas.py
@@ -551,10 +551,9 @@ class BulkDeleteResultItem(BaseModel):
     dataset_id: uuid.UUID
     status: str  # "deleted" | "error"
     detail: str | None = None
-    # fix(#1847): machine-readable where an error has a code the caller can act
-    # on. `catalog_lock_conflict` is the one the single-delete 409 carries, so
-    # a client sees the same code whichever endpoint it used. None for errors
-    # that have only prose.
+    # fix(#1847): machine-readable where an error has a code. It carries the
+    # one the single-delete 409 does, so a client sees the same code whichever
+    # endpoint it called. None for errors that have only prose.
     code: str | None = None
 
 

--- a/backend/app/modules/catalog/datasets/domain/service.py
+++ b/backend/app/modules/catalog/datasets/domain/service.py
@@ -54,6 +54,7 @@ from app.modules.catalog.datasets.domain.service_metadata import (
     get_attribute,
     list_attributes,
     reset_attribute,
+    sample_example_values,
     update_attribute,
     update_user_metadata,
 )
@@ -103,6 +104,7 @@ __all__ = [
     "list_relationships",
     "list_relationships_with_total",
     "reset_attribute",
+    "sample_example_values",
     "resolve_source_feature_count",
     "run_analysis_preview",
     "update_attribute",

--- a/backend/app/modules/catalog/datasets/domain/service.py
+++ b/backend/app/modules/catalog/datasets/domain/service.py
@@ -42,10 +42,12 @@ from app.modules.catalog.datasets.domain.service_create import (
     create_empty_dataset,
 )
 from app.modules.catalog.datasets.domain.service_lifecycle import (
+    DatasetDeletion,
     DatasetTitleMismatchError,
     DependentVrtError,
     delete_dataset,
     get_dataset_versions,
+    reap_managed_storage,
 )
 from app.modules.catalog.datasets.domain.service_metadata import (
     compute_schema_diff,
@@ -74,6 +76,8 @@ from app.modules.catalog.datasets.domain.service_relationships import (
 )
 
 __all__ = [
+    "DatasetDeletion",
+    "reap_managed_storage",
     "DatasetTitleMismatchError",
     "DependentVrtError",
     "PREVIEW_FEATURE_CAP",

--- a/backend/app/modules/catalog/datasets/domain/service_lifecycle.py
+++ b/backend/app/modules/catalog/datasets/domain/service_lifecycle.py
@@ -127,6 +127,7 @@ async def delete_dataset(
     # Hoisting to module-top broke 7 tests in test_vrt_delete_guard_174.py
     # that patch the façade attribute (post-impl-20260501 P3 #11 partial revert).
     from app.modules.catalog.datasets.domain.service import get_dataset
+    from app.modules.catalog.features.service import lock_catalog_rows_for_write
 
     dataset = await get_dataset(session, dataset_id)
     if dataset is None:
@@ -240,6 +241,21 @@ async def delete_dataset(
             raise RuntimeError(
                 "Dataset deletion is missing tenant context in multi-tenant mode"
             )
+        # fix(#1847 review r3): BEFORE the reap below, which permanently
+        # deletes objects. The acquisition can fail with 55P03 when another
+        # writer holds the dataset row past the request budget, and a failure
+        # after the reap would roll the transaction back with the objects
+        # already gone, leaving a catalog row pointing at nothing. Taking the
+        # rows first means the only outcome of losing that race is a 409 with
+        # everything still in place. It keeps this function's original promise
+        # too -- a storage failure prevents any DB change -- because the DROP
+        # and the row delete are transactional and roll back with it.
+        #
+        # AFTER the data-table work of each branch, not before it: the reupload
+        # swap takes ACCESS EXCLUSIVE on the data table ahead of its catalog
+        # rows, so leading with the catalog rows here would invert against it.
+        await lock_catalog_rows_for_write(session, dataset)
+
         await _reap_managed_storage(prefixes, tenant_id)
     else:
         # Vector datasets: drop the PostGIS data table AND clean managed storage.
@@ -295,6 +311,10 @@ async def delete_dataset(
         # the row is going), and the linearization is not reversible at all
         # since the pre-linear geometries are gone. Re-registering the table
         # re-applies all three idempotently.
+        # fix(#1847 review r3): see the sibling acquisition in the raster
+        # branch above for why this sits ahead of the reap and behind the DROP.
+        await lock_catalog_rows_for_write(session, dataset)
+
         await _reap_managed_storage(
             [f"originals/{dataset_id}/", f"vectors/{dataset_id}/"], tenant_id
         )
@@ -396,14 +416,10 @@ async def delete_dataset(
             )
         )
 
-    # fix(#1847 review r2): the DELETE below removes the records row and the
-    # datasets row goes with it by FK CASCADE, so the database takes the pair
-    # records-first -- the inversion. Acquire in the house order first. See
-    # app.platform.catalog_locks.lock_catalog_rows.
-    from app.modules.catalog.features.service import lock_catalog_rows_for_write
-
-    await lock_catalog_rows_for_write(session, dataset)
-
+    # The DELETE below removes the records row and the datasets row goes with
+    # it by FK CASCADE, so the database takes the pair records-first. Both
+    # branches above have already acquired them in the house order, ahead of
+    # the storage reap that cannot be undone.
     # Delete the record (CASCADE handles dataset deletion)
     await session.delete(dataset.record)
 

--- a/backend/app/modules/catalog/datasets/domain/service_lifecycle.py
+++ b/backend/app/modules/catalog/datasets/domain/service_lifecycle.py
@@ -49,13 +49,10 @@ class DatasetTitleMismatchError(ValueError):
 class DatasetDeletion(NamedTuple):
     """What `delete_dataset` did, and what the caller must reap after commit.
 
-    fix(#1847): the storage reap moved OUT of the delete transaction. It is
-    irreversible, and the record delete's FK cascades reach child rows nobody
-    locks (map_layers, record_embeddings, dataset_assets), so a cascade that
-    lost a lock race rolled the row back with the bytes already gone. Deleting
-    the row first inverts the residual: a failed reap orphans objects, which
-    costs storage, where the old order left a catalog entry pointing at
-    nothing, which serves broken tiles and is invisible.
+    The reap is irreversible and the record delete's FK cascades reach child
+    rows nobody locks, so it belongs after the commit. The residual is
+    inverted, not removed: a failed reap orphans objects rather than leaving a
+    catalog entry pointing at nothing.
     """
 
     table_name: str
@@ -257,10 +254,8 @@ async def delete_dataset(
             raise RuntimeError(
                 "Dataset deletion is missing tenant context in multi-tenant mode"
             )
-        # fix(#1847): BEFORE the reap, which deletes objects permanently, and
-        # including the raster child: the record delete cascades to it, and the
-        # replace worker holds that row across its upload. Taking it after the
-        # reap left the bytes gone and the row rolled back.
+        # fix(#1847): includes the raster child, which the record delete
+        # cascades to and the replace worker holds across its upload.
         await lock_catalog_rows_for_write(session, dataset, with_raster_asset=True)
 
         storage_prefixes = tuple(prefixes)

--- a/backend/app/modules/catalog/datasets/domain/service_lifecycle.py
+++ b/backend/app/modules/catalog/datasets/domain/service_lifecycle.py
@@ -241,10 +241,11 @@ async def delete_dataset(
             raise RuntimeError(
                 "Dataset deletion is missing tenant context in multi-tenant mode"
             )
-        # fix(#1847): BEFORE the reap, which deletes objects permanently. A
-        # 55P03 after it would roll back with the bytes already gone. After the
-        # branch's data-table work, to match the reupload swap's order.
-        await lock_catalog_rows_for_write(session, dataset)
+        # fix(#1847): BEFORE the reap, which deletes objects permanently, and
+        # including the raster child: the record delete cascades to it, and the
+        # replace worker holds that row across its upload. Taking it after the
+        # reap left the bytes gone and the row rolled back.
+        await lock_catalog_rows_for_write(session, dataset, with_raster_asset=True)
 
         await _reap_managed_storage(prefixes, tenant_id)
     else:

--- a/backend/app/modules/catalog/datasets/domain/service_lifecycle.py
+++ b/backend/app/modules/catalog/datasets/domain/service_lifecycle.py
@@ -245,9 +245,9 @@ async def delete_dataset(
             # vrt_source_links cascade-deleted via ON DELETE CASCADE on vrt_dataset_id FK
             prefixes = [f"rasters/{dataset_id}/"]
 
-        # Clean up managed storage artifacts before touching the DB.
-        # If any storage delete fails the exception propagates and the
-        # caller's transaction rolls back, leaving the DB record intact.
+        # These prefixes are returned, not reaped: the caller commits first and
+        # then reaps best-effort, so a reap failure leaves orphaned objects
+        # rather than a catalog row pointing at deleted bytes.
         tenant_id = current_tenant_var.get()
         if is_multi_tenant() and tenant_id is None:
             raise RuntimeError(
@@ -452,9 +452,9 @@ async def delete_dataset(
     # transaction reads the not-yet-deleted row and re-caches the dataset we
     # just evicted. Only a commit makes the delete visible to that reader.
 
-    # Audit trail for an irreversible operation (DROP TABLE for vector,
-    # storage cleanup for raster/VRT). The DB-side row deletion is logged
-    # by the audit_emit() facade in the calling router.
+    # Audit trail for an irreversible operation (DROP TABLE for vector). The
+    # DB-side row deletion is logged by the audit_emit() facade in the calling
+    # router, which also reaps the storage prefixes after its commit.
     logger.info(
         "dataset_deleted",
         dataset_id=str(dataset_id),

--- a/backend/app/modules/catalog/datasets/domain/service_lifecycle.py
+++ b/backend/app/modules/catalog/datasets/domain/service_lifecycle.py
@@ -241,19 +241,9 @@ async def delete_dataset(
             raise RuntimeError(
                 "Dataset deletion is missing tenant context in multi-tenant mode"
             )
-        # fix(#1847 review r3): BEFORE the reap below, which permanently
-        # deletes objects. The acquisition can fail with 55P03 when another
-        # writer holds the dataset row past the request budget, and a failure
-        # after the reap would roll the transaction back with the objects
-        # already gone, leaving a catalog row pointing at nothing. Taking the
-        # rows first means the only outcome of losing that race is a 409 with
-        # everything still in place. It keeps this function's original promise
-        # too -- a storage failure prevents any DB change -- because the DROP
-        # and the row delete are transactional and roll back with it.
-        #
-        # AFTER the data-table work of each branch, not before it: the reupload
-        # swap takes ACCESS EXCLUSIVE on the data table ahead of its catalog
-        # rows, so leading with the catalog rows here would invert against it.
+        # fix(#1847): BEFORE the reap, which deletes objects permanently. A
+        # 55P03 after it would roll back with the bytes already gone. After the
+        # branch's data-table work, to match the reupload swap's order.
         await lock_catalog_rows_for_write(session, dataset)
 
         await _reap_managed_storage(prefixes, tenant_id)
@@ -311,8 +301,7 @@ async def delete_dataset(
         # the row is going), and the linearization is not reversible at all
         # since the pre-linear geometries are gone. Re-registering the table
         # re-applies all three idempotently.
-        # fix(#1847 review r3): see the sibling acquisition in the raster
-        # branch above for why this sits ahead of the reap and behind the DROP.
+        # fix(#1847): ahead of the reap, behind the DROP. See the raster branch.
         await lock_catalog_rows_for_write(session, dataset)
 
         await _reap_managed_storage(
@@ -416,11 +405,8 @@ async def delete_dataset(
             )
         )
 
-    # The DELETE below removes the records row and the datasets row goes with
-    # it by FK CASCADE, so the database takes the pair records-first. Both
-    # branches above have already acquired them in the house order, ahead of
-    # the storage reap that cannot be undone.
-    # Delete the record (CASCADE handles dataset deletion)
+    # Delete the record (CASCADE handles dataset deletion). The cascade takes
+    # the pair records-first; both branches above already hold it in order.
     await session.delete(dataset.record)
 
     if record_type not in RASTER_FAMILY_RECORD_TYPES:
@@ -441,17 +427,9 @@ async def delete_dataset(
         # and future callers get it from one place. Raster/VRT are excluded —
         # their tiles come from Titiler, and that branch drops no table.
         #
-        # fix(#1847 review r3): this Valkey round trip runs with the catalog
-        # pair held, and stays that way. Row locks are held to commit, so the
-        # only way to take it out from under them is to move it after the
-        # caller's commit -- which would undo the paragraph above, where one
-        # placement serves single delete, bulk delete and every future caller.
-        # The bound is one round trip to a cache the app already has a
-        # connection to, against a key set for one table, with no scan: the
-        # same call every sibling write path makes inside its own transaction.
-        # That is a different order of magnitude from the multi-GB upload the
-        # raster replace acquisition was moved below, and from the full-table
-        # scan the layers DDL now computes before it locks.
+        # fix(#1847): runs with the catalog pair held, and stays that way. Row
+        # locks last to commit, so moving it out means moving it past the
+        # caller's commit. Bound: one round trip, one table's keys, no scan.
         from app.platform.cache.provider import get_tile_cache
 
         tile_cache = get_tile_cache()

--- a/backend/app/modules/catalog/datasets/domain/service_lifecycle.py
+++ b/backend/app/modules/catalog/datasets/domain/service_lifecycle.py
@@ -187,6 +187,13 @@ async def delete_dataset(
     # never "no owner"; see the tombstone insert below.
     relation_oid: int | None = None
 
+    # fix(#1847): the job rows before the table and the pair; a worker holds
+    # its job row before either, and the record delete cascades into them.
+    from app.platform.catalog_locks import lock_ingest_jobs
+    from app.platform.jobs.models import IngestJob
+
+    await lock_ingest_jobs(session, job_cls=IngestJob, dataset_id=dataset.id)
+
     if record_type in RASTER_FAMILY_RECORD_TYPES:
         if record_type == "raster_dataset":
             # Guard: prevent deletion if any VRT still references this COG.

--- a/backend/app/modules/catalog/datasets/domain/service_lifecycle.py
+++ b/backend/app/modules/catalog/datasets/domain/service_lifecycle.py
@@ -396,6 +396,14 @@ async def delete_dataset(
             )
         )
 
+    # fix(#1847 review r2): the DELETE below removes the records row and the
+    # datasets row goes with it by FK CASCADE, so the database takes the pair
+    # records-first -- the inversion. Acquire in the house order first. See
+    # app.platform.catalog_locks.lock_catalog_rows.
+    from app.modules.catalog.features.service import lock_catalog_rows_for_write
+
+    await lock_catalog_rows_for_write(session, dataset)
+
     # Delete the record (CASCADE handles dataset deletion)
     await session.delete(dataset.record)
 

--- a/backend/app/modules/catalog/datasets/domain/service_lifecycle.py
+++ b/backend/app/modules/catalog/datasets/domain/service_lifecycle.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import uuid
-from typing import Any
+from typing import Any, NamedTuple
 
 import structlog
 from sqlalchemy import func, select, text
@@ -46,7 +46,24 @@ class DatasetTitleMismatchError(ValueError):
     """
 
 
-async def _reap_managed_storage(prefixes: list[str], tenant_id: str | None) -> None:
+class DatasetDeletion(NamedTuple):
+    """What `delete_dataset` did, and what the caller must reap after commit.
+
+    fix(#1847): the storage reap moved OUT of the delete transaction. It is
+    irreversible, and the record delete's FK cascades reach child rows nobody
+    locks (map_layers, record_embeddings, dataset_assets), so a cascade that
+    lost a lock race rolled the row back with the bytes already gone. Deleting
+    the row first inverts the residual: a failed reap orphans objects, which
+    costs storage, where the old order left a catalog entry pointing at
+    nothing, which serves broken tiles and is invisible.
+    """
+
+    table_name: str
+    storage_prefixes: tuple[str, ...]
+    tenant_id: str | None
+
+
+async def reap_managed_storage(prefixes: list[str], tenant_id: str | None) -> None:
     """Delete every object under GeoLens-managed prefixes for one dataset.
 
     Extracted from ``delete_dataset``'s two branches (which reaped identically
@@ -107,14 +124,13 @@ class DependentVrtError(Exception):
 
 async def delete_dataset(
     session: AsyncSession, dataset_id: uuid.UUID, confirm_title: str
-) -> str:
-    """Delete a dataset: drop data table (vector) or clean storage artifacts (raster).
+) -> DatasetDeletion:
+    """Delete a dataset's rows: drop the data table (vector) or leave it (raster).
 
-    Deleting the record cascades to the dataset via FK.
-    Returns the table_name for logging. Does NOT commit.
+    Deleting the record cascades to the dataset via FK. Does NOT commit, and
+    does NOT touch object storage: it returns the prefixes the caller must reap
+    once the delete has COMMITTED. See `DatasetDeletion` for why that order.
     Raises ValueError if dataset not found, name mismatch, or invalid table name.
-    For raster datasets, storage cleanup happens before DB deletion so that a
-    storage failure prevents any DB changes (no orphaned records).
 
     fix(#1452): a dataset registered from an existing PostGIS table is DETACHED
     rather than dropped — the catalog row, its grants, its tiles and its search
@@ -247,7 +263,7 @@ async def delete_dataset(
         # reap left the bytes gone and the row rolled back.
         await lock_catalog_rows_for_write(session, dataset, with_raster_asset=True)
 
-        await _reap_managed_storage(prefixes, tenant_id)
+        storage_prefixes = tuple(prefixes)
     else:
         # Vector datasets: drop the PostGIS data table AND clean managed storage.
         # fix(#430 BA-17): vector ingest persists originals/{id}/ (archived source) and
@@ -305,9 +321,7 @@ async def delete_dataset(
         # fix(#1847): ahead of the reap, behind the DROP. See the raster branch.
         await lock_catalog_rows_for_write(session, dataset)
 
-        await _reap_managed_storage(
-            [f"originals/{dataset_id}/", f"vectors/{dataset_id}/"], tenant_id
-        )
+        storage_prefixes = (f"originals/{dataset_id}/", f"vectors/{dataset_id}/")
 
     # fix(#1443): retire the name before releasing it. This is the one site
     # where a name a LIVE dataset row carried stops being carried by one, and
@@ -464,7 +478,7 @@ async def delete_dataset(
         name_retired=name_is_freed,
     )
 
-    return table_name
+    return DatasetDeletion(table_name, storage_prefixes, tenant_id)
 
 
 async def get_dataset_versions(

--- a/backend/app/modules/catalog/datasets/domain/service_lifecycle.py
+++ b/backend/app/modules/catalog/datasets/domain/service_lifecycle.py
@@ -47,12 +47,11 @@ class DatasetTitleMismatchError(ValueError):
 
 
 class DatasetDeletion(NamedTuple):
-    """What `delete_dataset` did, and what the caller must reap after commit.
+    """What `delete_dataset` removed, and what the caller must still reap.
 
-    The reap is irreversible and the record delete's FK cascades reach child
-    rows nobody locks, so it belongs after the commit. The residual is
-    inverted, not removed: a failed reap orphans objects rather than leaving a
-    catalog entry pointing at nothing.
+    `storage_prefixes` are GeoLens-managed object prefixes for this dataset;
+    `tenant_id` is the tenant they live under. The caller MUST reap them after
+    its commit, and only after it: nothing here touches object storage.
     """
 
     table_name: str

--- a/backend/app/modules/catalog/datasets/domain/service_lifecycle.py
+++ b/backend/app/modules/catalog/datasets/domain/service_lifecycle.py
@@ -440,6 +440,18 @@ async def delete_dataset(
         # rather than after the caller's commit so single delete, bulk delete,
         # and future callers get it from one place. Raster/VRT are excluded —
         # their tiles come from Titiler, and that branch drops no table.
+        #
+        # fix(#1847 review r3): this Valkey round trip runs with the catalog
+        # pair held, and stays that way. Row locks are held to commit, so the
+        # only way to take it out from under them is to move it after the
+        # caller's commit -- which would undo the paragraph above, where one
+        # placement serves single delete, bulk delete and every future caller.
+        # The bound is one round trip to a cache the app already has a
+        # connection to, against a key set for one table, with no scan: the
+        # same call every sibling write path makes inside its own transaction.
+        # That is a different order of magnitude from the multi-GB upload the
+        # raster replace acquisition was moved below, and from the full-table
+        # scan the layers DDL now computes before it locks.
         from app.platform.cache.provider import get_tile_cache
 
         tile_cache = get_tile_cache()

--- a/backend/app/modules/catalog/datasets/domain/service_metadata.py
+++ b/backend/app/modules/catalog/datasets/domain/service_metadata.py
@@ -310,11 +310,9 @@ async def update_user_metadata(
 
     record = dataset.record
 
-    # fix(#1847): BEFORE the first assignment below, which is what orders this
-    # function's flush. Only when the body can reach a row beyond the record:
-    # a record-only body writes one row and has no order to get wrong.
-    # `is_dem` writes raster_assets, so it extends the order to that child --
-    # the replace worker takes it first and asks for the pair afterwards.
+    # fix(#1847): BEFORE the first assignment below, and only when the body
+    # reaches beyond the record: one row has no order to get wrong. `is_dem`
+    # writes raster_assets, so it extends the order to that child.
     touches_raster = "is_dem" in meta.model_fields_set
     if touches_raster or meta.model_fields_set & _DATASET_ROW_FIELDS:
         await lock_catalog_rows_for_write(

--- a/backend/app/modules/catalog/datasets/domain/service_metadata.py
+++ b/backend/app/modules/catalog/datasets/domain/service_metadata.py
@@ -128,12 +128,9 @@ _DATASET_FIELD_MAP: dict[str, str] = {
 }
 
 
-# Request fields that reach the `catalog.datasets` row, so a body carrying any
-# of them makes this a two-row write and needs the house lock order
-# (fix(#1847 review r3)). `is_dem` is NOT here: it writes `raster_assets`,
-# a third table this pair's order says nothing about. `tile_columns` is,
-# because it writes the datasets row and because the router rolls
-# `tile_cache_version` on the same row when it changes.
+# fix(#1847): request fields that reach the `catalog.datasets` row, so a body
+# carrying one makes this a two-row write. `is_dem` is excluded: it writes
+# `raster_assets`, a third table this pair's order says nothing about.
 _DATASET_ROW_FIELDS = frozenset(_DATASET_FIELD_MAP) | {"tile_columns"}
 
 
@@ -313,20 +310,9 @@ async def update_user_metadata(
 
     record = dataset.record
 
-    # fix(#1847 review r2): BEFORE the first assignment below. This function
-    # writes record fields (title, visibility, record_status, updated_by) and
-    # dataset fields (quality_statement, source_url, tile_columns) and then
-    # flushes them together, so without this the flush took catalog.records
-    # ahead of catalog.datasets and deadlocked against any writer holding the
-    # dataset row. See app.platform.catalog_locks.lock_catalog_rows.
-    #
-    # fix(#1847 review r3): only when the body can reach the datasets row. A
-    # body that touches record fields alone writes ONE row, and a transaction
-    # that writes one row has no order to get wrong -- taking the datasets row
-    # for it would add contention to the most-used metadata endpoint to defend
-    # against a cycle it cannot be part of. Decided from `model_fields_set`
-    # rather than from what actually changed, because the acquisition has to
-    # happen before the comparisons that would tell us.
+    # fix(#1847): BEFORE the first assignment below, which is what orders this
+    # function's two-row flush. Only when the body can reach the datasets row:
+    # a record-only body writes one row and has no order to get wrong.
     if meta.model_fields_set & _DATASET_ROW_FIELDS:
         await lock_catalog_rows_for_write(session, dataset)
 

--- a/backend/app/modules/catalog/datasets/domain/service_metadata.py
+++ b/backend/app/modules/catalog/datasets/domain/service_metadata.py
@@ -32,6 +32,7 @@ __all__ = [
     "get_attribute",
     "list_attributes",
     "reset_attribute",
+    "sample_example_values",
     "update_attribute",
     "update_user_metadata",
 ]
@@ -441,21 +442,70 @@ async def update_attribute(
     return attr
 
 
+_UNSAMPLED = object()
+
+
+async def sample_example_values(
+    session: AsyncSession, table_name: str, col_name: str, data_type: str | None
+) -> list | None:
+    """Up to ten distinct non-null values of one column, or None.
+
+    Reads the data table, so call it BEFORE the catalog pair is locked: every
+    column DDL holds its ALTER TABLE before taking the pair (#1847). None for a
+    geometry column, an unsafe name, or any query failure; the read runs in a
+    savepoint so a failure leaves the transaction usable.
+    """
+    if not data_type or "geometry" in data_type.lower():
+        return None
+    if not (
+        SAFE_TABLE_NAME_RE.match(col_name) and SAFE_TABLE_NAME_RE.match(table_name)
+    ):
+        return None
+    try:
+        table_ref = get_catalog_port().quote_table(table_name)
+        async with session.begin_nested():
+            result = await session.execute(
+                text(
+                    f"SELECT DISTINCT {col_name}::text AS val "
+                    f"FROM (SELECT {col_name} FROM {table_ref} "
+                    f"WHERE {col_name} IS NOT NULL LIMIT 1000) sub LIMIT 10"
+                )
+            )
+            values = [row[0] for row in result.all() if row[0] is not None]
+    except Exception:  # broad: example-value sampling is best-effort; any DB error degrades to no examples
+        logger.warning(
+            "Failed to sample example_values for %s.%s",
+            table_name,
+            col_name,
+            exc_info=True,
+        )
+        return None
+    return values if values else None
+
+
 async def reset_attribute(
-    session: AsyncSession, attribute_id: uuid.UUID, table_name: str
+    session: AsyncSession,
+    attribute_id: uuid.UUID,
+    table_name: str,
+    *,
+    example_values: Any = _UNSAMPLED,
 ) -> AttributeMetadata:
     """Reset attribute metadata to auto-populated values.
 
-    Re-infers title, semantic_role, domain_type, units from field_name/data_type.
-    Re-samples example_values from the data table.
-    Clears user_modified_fields and description.
-    Raises ValueError if attribute not found.
+    Re-infers title, semantic_role, domain_type, units from field_name/data_type
+    and clears user_modified_fields and description. `example_values` is the
+    result of `sample_example_values`; a caller that holds the catalog pair must
+    have sampled before taking it, since sampling reads the data table (#1847).
+    Left unset, this samples first. Raises ValueError if attribute not found.
     """
     attr = await get_attribute(session, attribute_id)
     if attr is None:
         raise ValueError("Attribute not found")
+    if example_values is _UNSAMPLED:
+        example_values = await sample_example_values(
+            session, table_name, attr.field_name, attr.data_type
+        )
 
-    # Re-compute inferred values
     port = get_catalog_port()
     attr.title = port.humanize_column_name(attr.field_name)
     attr.semantic_role = port.infer_semantic_role(attr.field_name, attr.data_type or "")
@@ -463,43 +513,7 @@ async def reset_attribute(
     attr.units = port.infer_units(attr.field_name)
     attr.description = None
     attr.user_modified_fields = []
-
-    # Re-sample example_values from data table. Default to None on every
-    # rejected/error path so the inverted guards stay flat.
-    attr.example_values = None
-    col_name = attr.field_name
-
-    if not attr.data_type or "geometry" in attr.data_type.lower():
-        await session.flush()
-        return attr
-
-    if not (
-        SAFE_TABLE_NAME_RE.match(col_name) and SAFE_TABLE_NAME_RE.match(table_name)
-    ):
-        await session.flush()
-        return attr
-
-    try:
-        table_ref = port.quote_table(table_name)
-        result = await session.execute(
-            text(
-                f"SELECT DISTINCT {col_name}::text AS val "
-                f"FROM (SELECT {col_name} FROM {table_ref} "
-                f"WHERE {col_name} IS NOT NULL LIMIT 1000) sub LIMIT 10"
-            )
-        )
-        values = [row[0] for row in result.all() if row[0] is not None]
-        attr.example_values = values if values else None
-    except Exception:  # broad: example-value sampling is best-effort; any DB error degrades to no examples
-        # Sampling is best-effort; don't fail the reset because we
-        # couldn't gather example values, but do log so operators can
-        # notice if this breaks consistently (RES-N9).
-        logger.warning(
-            "Failed to sample example_values for %s.%s",
-            table_name,
-            col_name,
-            exc_info=True,
-        )
+    attr.example_values = example_values
 
     await session.flush()
     return attr

--- a/backend/app/modules/catalog/datasets/domain/service_metadata.py
+++ b/backend/app/modules/catalog/datasets/domain/service_metadata.py
@@ -128,6 +128,15 @@ _DATASET_FIELD_MAP: dict[str, str] = {
 }
 
 
+# Request fields that reach the `catalog.datasets` row, so a body carrying any
+# of them makes this a two-row write and needs the house lock order
+# (fix(#1847 review r3)). `is_dem` is NOT here: it writes `raster_assets`,
+# a third table this pair's order says nothing about. `tile_columns` is,
+# because it writes the datasets row and because the router rolls
+# `tile_cache_version` on the same row when it changes.
+_DATASET_ROW_FIELDS = frozenset(_DATASET_FIELD_MAP) | {"tile_columns"}
+
+
 # Never clearable to NULL via the PATCH: records.title is NOT NULL.
 _NON_CLEARABLE_FIELDS = {"title"}
 
@@ -310,7 +319,16 @@ async def update_user_metadata(
     # flushes them together, so without this the flush took catalog.records
     # ahead of catalog.datasets and deadlocked against any writer holding the
     # dataset row. See app.platform.catalog_locks.lock_catalog_rows.
-    await lock_catalog_rows_for_write(session, dataset)
+    #
+    # fix(#1847 review r3): only when the body can reach the datasets row. A
+    # body that touches record fields alone writes ONE row, and a transaction
+    # that writes one row has no order to get wrong -- taking the datasets row
+    # for it would add contention to the most-used metadata endpoint to defend
+    # against a cycle it cannot be part of. Decided from `model_fields_set`
+    # rather than from what actually changed, because the acquisition has to
+    # happen before the comparisons that would tell us.
+    if meta.model_fields_set & _DATASET_ROW_FIELDS:
+        await lock_catalog_rows_for_write(session, dataset)
 
     if "language" in meta.model_fields_set:
         effective_language = meta.language or "en"

--- a/backend/app/modules/catalog/datasets/domain/service_metadata.py
+++ b/backend/app/modules/catalog/datasets/domain/service_metadata.py
@@ -129,8 +129,8 @@ _DATASET_FIELD_MAP: dict[str, str] = {
 
 
 # fix(#1847): request fields that reach the `catalog.datasets` row, so a body
-# carrying one makes this a two-row write. `is_dem` is excluded: it writes
-# `raster_assets`, a third table this pair's order says nothing about.
+# carrying one makes this a two-row write. `is_dem` is handled separately: it
+# writes `raster_assets`, which is ordered ahead of the pair, not with it.
 _DATASET_ROW_FIELDS = frozenset(_DATASET_FIELD_MAP) | {"tile_columns"}
 
 
@@ -311,10 +311,15 @@ async def update_user_metadata(
     record = dataset.record
 
     # fix(#1847): BEFORE the first assignment below, which is what orders this
-    # function's two-row flush. Only when the body can reach the datasets row:
+    # function's flush. Only when the body can reach a row beyond the record:
     # a record-only body writes one row and has no order to get wrong.
-    if meta.model_fields_set & _DATASET_ROW_FIELDS:
-        await lock_catalog_rows_for_write(session, dataset)
+    # `is_dem` writes raster_assets, so it extends the order to that child --
+    # the replace worker takes it first and asks for the pair afterwards.
+    touches_raster = "is_dem" in meta.model_fields_set
+    if touches_raster or meta.model_fields_set & _DATASET_ROW_FIELDS:
+        await lock_catalog_rows_for_write(
+            session, dataset, with_raster_asset=touches_raster
+        )
 
     if "language" in meta.model_fields_set:
         effective_language = meta.language or "en"

--- a/backend/app/modules/catalog/datasets/domain/service_metadata.py
+++ b/backend/app/modules/catalog/datasets/domain/service_metadata.py
@@ -300,7 +300,17 @@ async def update_user_metadata(
     if dataset is None:
         raise ValueError(f"Dataset {dataset_id} not found.")
 
+    from app.modules.catalog.features.service import lock_catalog_rows_for_write
+
     record = dataset.record
+
+    # fix(#1847 review r2): BEFORE the first assignment below. This function
+    # writes record fields (title, visibility, record_status, updated_by) and
+    # dataset fields (quality_statement, source_url, tile_columns) and then
+    # flushes them together, so without this the flush took catalog.records
+    # ahead of catalog.datasets and deadlocked against any writer holding the
+    # dataset row. See app.platform.catalog_locks.lock_catalog_rows.
+    await lock_catalog_rows_for_write(session, dataset)
 
     if "language" in meta.model_fields_set:
         effective_language = meta.language or "en"

--- a/backend/app/modules/catalog/features/router.py
+++ b/backend/app/modules/catalog/features/router.py
@@ -61,6 +61,7 @@ from app.modules.catalog.features.service import (
     get_features,
     get_features_geojson_z,
     insert_feature,
+    lock_catalog_rows_for_write,
     number_matched_headers,
     parse_bbox,
     refresh_dataset_metadata,
@@ -163,26 +164,56 @@ def _feature_write_db_error(exc: DBAPIError) -> HTTPException:
     )
 
 
-async def _refresh_metadata_guarded(db: AsyncSession, dataset, **kwargs) -> None:
-    """`refresh_dataset_metadata` with its database errors classified.
+async def _guard(db: AsyncSession, step) -> None:
+    """Run one post-write catalog step with its database errors classified.
 
-    fix(#1847): every write handler here called the refresh AFTER its own
-    `except DBAPIError` block had closed, so the one part of the request that
-    takes catalog row locks was the one part whose database errors nothing
+    fix(#1847): every write handler here took its catalog row locks AFTER its
+    own `except DBAPIError` block had closed, so the one part of the request
+    that contends for rows was the one part whose database errors nothing
     classified. A deadlock or a lock timeout escaped to the generic database
     error handler as a bare 503, and the edit was lost with no message the
-    caller could act on. One helper rather than four copied try blocks, so the
-    next handler added here cannot pick up the old shape by imitation.
+    caller could act on. One classification for both entry points below, so a
+    conflict answers 409 whichever of them the handler reached.
 
     Deliberately narrower than the handlers' own guards: only `DBAPIError` is
     caught, so a `ValueError` raised in here still surfaces as itself rather
     than being reshaped into the 400 or the 404 the write above uses.
     """
     try:
-        await refresh_dataset_metadata(db, dataset, **kwargs)
+        await step
     except DBAPIError as exc:
         await db.rollback()
         raise _feature_write_db_error(exc)
+
+
+async def _refresh_metadata_guarded(db: AsyncSession, dataset, **kwargs) -> None:
+    """Recompute feature_count and extent, holding the catalog rows.
+
+    Takes the (datasets, records) pair itself, so a handler that reaches this
+    needs nothing else. One helper rather than four copied try blocks, so the
+    next handler added here cannot pick up the old unguarded shape by
+    imitation.
+    """
+    await _guard(db, refresh_dataset_metadata(db, dataset, **kwargs))
+
+
+async def _lock_catalog_rows_guarded(db: AsyncSession, dataset) -> None:
+    """Take the (datasets, records) pair for a write that skips the refresh.
+
+    fix(#1847 review r1): a write does not have to recompute anything to need
+    this. Every handler below stamps `record.updated_by` and rolls
+    `tile_cache_version` unconditionally, which dirties BOTH rows, and the ORM
+    flushes them at commit in records-then-datasets order. On the one path that
+    skips the metadata refresh -- a PATCH carrying properties and no geometry
+    -- that flush was the transaction's first touch of either row, so it
+    reinstated the exact inversion against `refresh_postgis` phase 3 that this
+    issue is about, and the abort landed at `commit()` where no handler was
+    classifying it.
+
+    Same acquisition as the refresh path, through the same service helper, so
+    the two cannot drift into taking the pair in two different orders.
+    """
+    await _guard(db, lock_catalog_rows_for_write(db, dataset))
 
 
 # ---------------------------------------------------------------------------
@@ -880,6 +911,12 @@ async def patch_single_feature(
                 geojson_bounds(body.geometry.model_dump()),
             ],
         )
+    else:
+        # fix(#1847 review r1): properties changed and no geometry did, so
+        # there is nothing to recompute -- but the two lines below still dirty
+        # the records row and the datasets row, and something has to take them
+        # in the house order before the flush at commit takes them in the ORM's.
+        await _lock_catalog_rows_guarded(db, dataset)
     dataset.record.updated_by = user.id
     await audit_emit(
         db,

--- a/backend/app/modules/catalog/features/router.py
+++ b/backend/app/modules/catalog/features/router.py
@@ -125,10 +125,8 @@ def _feature_write_db_error(exc: DBAPIError) -> HTTPException:
     read path reports it, and an unrecognized state (our own bad SQL, 42601) is
     an honest 500, not the caller's fault.
 
-    fix(#1847): a lock conflict RAISES, rather than returning a 409 of its own.
-    The acquisition already raises CatalogLockConflict, so returning a second
-    409 body here gave one condition two response shapes depending on which
-    statement hit it. One exception, one mapping in `app/api/main.py`.
+    fix(#1847): a lock conflict raises ``CatalogLockConflict``; the one
+    mapping in ``app/api/main.py`` answers it.
     """
     if is_lock_conflict(exc):
         raise CatalogLockConflict(

--- a/backend/app/modules/catalog/features/router.py
+++ b/backend/app/modules/catalog/features/router.py
@@ -161,9 +161,6 @@ def _feature_write_db_error(exc: DBAPIError) -> HTTPException:
 async def _guard(db: AsyncSession, step) -> None:
     """Run one post-write catalog step with its database errors classified.
 
-    fix(#1847): the handlers took their row locks after their own
-    `except DBAPIError` had closed, so a conflict escaped as a bare 503.
-
     Narrower than the handlers' own guards on purpose: only `DBAPIError` is
     caught, so a `ValueError` still surfaces as itself.
     """
@@ -185,9 +182,9 @@ async def _refresh_metadata_guarded(db: AsyncSession, dataset, **kwargs) -> None
 async def _lock_catalog_rows_guarded(db: AsyncSession, dataset) -> None:
     """Take the (datasets, records) pair for a write that skips the refresh.
 
-    fix(#1847): every handler stamps `record.updated_by` and rolls
-    `tile_cache_version`, which dirties both rows even when nothing is
-    recomputed. Same helper as the refresh path, so the two cannot drift.
+    Every handler stamps `record.updated_by` and rolls `tile_cache_version`,
+    which dirties both rows even when nothing is recomputed. Same helper as the
+    refresh path, so the two cannot drift.
     """
     await _guard(db, lock_catalog_rows_for_write(db, dataset))
 

--- a/backend/app/modules/catalog/features/router.py
+++ b/backend/app/modules/catalog/features/router.py
@@ -23,6 +23,7 @@ from app.core.db.sqlstate import (
     BAD_QUERY_INPUT,
     TABLE_ABSENT,
     is_caller_type_fault,
+    is_lock_conflict,
     is_operational,
     sqlstate,
 )
@@ -121,7 +122,23 @@ def _feature_write_db_error(exc: DBAPIError) -> HTTPException:
     missing backing table (42P01, schema-provisioning drift) is a 503 like the
     read path reports it, and an unrecognized state (our own bad SQL, 42601) is
     an honest 500, not the caller's fault.
+
+    fix(#1847): a lock conflict is classified FIRST, because 40P01 is SQLSTATE
+    class 40 and `is_operational` would otherwise send it out as "database
+    temporarily unavailable". That is the wrong advice twice over: the database
+    is fine, and 503 asks the client to back off when this edit would succeed
+    on an immediate retry. 409 is already a declared response on every write
+    endpoint here (ERROR_RESPONSES_WRITE), so this adds no API surface.
     """
+    if is_lock_conflict(exc):
+        return HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={
+                "code": "feature_write_locked",
+                "message": "This dataset's catalog entry is being updated by "
+                "another operation. Retry shortly.",
+            },
+        )
     if is_operational(exc):
         return HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
@@ -144,6 +161,28 @@ def _feature_write_db_error(exc: DBAPIError) -> HTTPException:
         status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
         detail="Feature write failed unexpectedly.",
     )
+
+
+async def _refresh_metadata_guarded(db: AsyncSession, dataset, **kwargs) -> None:
+    """`refresh_dataset_metadata` with its database errors classified.
+
+    fix(#1847): every write handler here called the refresh AFTER its own
+    `except DBAPIError` block had closed, so the one part of the request that
+    takes catalog row locks was the one part whose database errors nothing
+    classified. A deadlock or a lock timeout escaped to the generic database
+    error handler as a bare 503, and the edit was lost with no message the
+    caller could act on. One helper rather than four copied try blocks, so the
+    next handler added here cannot pick up the old shape by imitation.
+
+    Deliberately narrower than the handlers' own guards: only `DBAPIError` is
+    caught, so a `ValueError` raised in here still surfaces as itself rather
+    than being reshaped into the 400 or the 404 the write above uses.
+    """
+    try:
+        await refresh_dataset_metadata(db, dataset, **kwargs)
+    except DBAPIError as exc:
+        await db.rollback()
+        raise _feature_write_db_error(exc)
 
 
 # ---------------------------------------------------------------------------
@@ -605,7 +644,7 @@ async def create_feature(
 
     # fix(#1778): one row added, at a known envelope. No table scan when that
     # envelope is already inside the stored extent.
-    await refresh_dataset_metadata(
+    await _refresh_metadata_guarded(
         db,
         dataset,
         count_delta=1,
@@ -722,7 +761,7 @@ async def replace_single_feature(
     # fix(#1778): row count unchanged; the extent is unchanged too when both
     # the old and the new envelope sit strictly inside it. The old envelope
     # comes back from the UPDATE that overwrote it (fix(#1778 review r1)).
-    await refresh_dataset_metadata(
+    await _refresh_metadata_guarded(
         db,
         dataset,
         count_delta=0,
@@ -832,7 +871,7 @@ async def patch_single_feature(
     # Only refresh metadata if geometry changed (extent may change)
     if body.geometry is not None:
         # fix(#1778): same reasoning as replace.
-        await refresh_dataset_metadata(
+        await _refresh_metadata_guarded(
             db,
             dataset,
             count_delta=0,
@@ -919,7 +958,7 @@ async def delete_single_feature(
 
     # fix(#1778): one row removed. A row strictly inside the stored extent was
     # not defining any side of it, so the extent cannot shrink.
-    await refresh_dataset_metadata(
+    await _refresh_metadata_guarded(
         db, dataset, count_delta=-1, touched_bounds=[prior_bounds]
     )
     dataset.record.updated_by = user.id

--- a/backend/app/modules/catalog/features/router.py
+++ b/backend/app/modules/catalog/features/router.py
@@ -124,12 +124,9 @@ def _feature_write_db_error(exc: DBAPIError) -> HTTPException:
     read path reports it, and an unrecognized state (our own bad SQL, 42601) is
     an honest 500, not the caller's fault.
 
-    fix(#1847): a lock conflict is classified FIRST, because 40P01 is SQLSTATE
-    class 40 and `is_operational` would otherwise send it out as "database
-    temporarily unavailable". That is the wrong advice twice over: the database
-    is fine, and 503 asks the client to back off when this edit would succeed
-    on an immediate retry. 409 is already a declared response on every write
-    endpoint here (ERROR_RESPONSES_WRITE), so this adds no API surface.
+    fix(#1847): a lock conflict is classified FIRST. 40P01 is SQLSTATE class 40,
+    so `is_operational` would otherwise report a contended row as an outage.
+    409 is already declared on every write endpoint (ERROR_RESPONSES_WRITE).
     """
     if is_lock_conflict(exc):
         return HTTPException(
@@ -167,17 +164,11 @@ def _feature_write_db_error(exc: DBAPIError) -> HTTPException:
 async def _guard(db: AsyncSession, step) -> None:
     """Run one post-write catalog step with its database errors classified.
 
-    fix(#1847): every write handler here took its catalog row locks AFTER its
-    own `except DBAPIError` block had closed, so the one part of the request
-    that contends for rows was the one part whose database errors nothing
-    classified. A deadlock or a lock timeout escaped to the generic database
-    error handler as a bare 503, and the edit was lost with no message the
-    caller could act on. One classification for both entry points below, so a
-    conflict answers 409 whichever of them the handler reached.
+    fix(#1847): the handlers took their row locks after their own
+    `except DBAPIError` had closed, so a conflict escaped as a bare 503.
 
-    Deliberately narrower than the handlers' own guards: only `DBAPIError` is
-    caught, so a `ValueError` raised in here still surfaces as itself rather
-    than being reshaped into the 400 or the 404 the write above uses.
+    Narrower than the handlers' own guards on purpose: only `DBAPIError` is
+    caught, so a `ValueError` still surfaces as itself.
     """
     try:
         await step
@@ -189,10 +180,7 @@ async def _guard(db: AsyncSession, step) -> None:
 async def _refresh_metadata_guarded(db: AsyncSession, dataset, **kwargs) -> None:
     """Recompute feature_count and extent, holding the catalog rows.
 
-    Takes the (datasets, records) pair itself, so a handler that reaches this
-    needs nothing else. One helper rather than four copied try blocks, so the
-    next handler added here cannot pick up the old unguarded shape by
-    imitation.
+    Takes the pair itself, so a handler that reaches this needs nothing else.
     """
     await _guard(db, refresh_dataset_metadata(db, dataset, **kwargs))
 
@@ -200,18 +188,9 @@ async def _refresh_metadata_guarded(db: AsyncSession, dataset, **kwargs) -> None
 async def _lock_catalog_rows_guarded(db: AsyncSession, dataset) -> None:
     """Take the (datasets, records) pair for a write that skips the refresh.
 
-    fix(#1847 review r1): a write does not have to recompute anything to need
-    this. Every handler below stamps `record.updated_by` and rolls
-    `tile_cache_version` unconditionally, which dirties BOTH rows, and the ORM
-    flushes them at commit in records-then-datasets order. On the one path that
-    skips the metadata refresh -- a PATCH carrying properties and no geometry
-    -- that flush was the transaction's first touch of either row, so it
-    reinstated the exact inversion against `refresh_postgis` phase 3 that this
-    issue is about, and the abort landed at `commit()` where no handler was
-    classifying it.
-
-    Same acquisition as the refresh path, through the same service helper, so
-    the two cannot drift into taking the pair in two different orders.
+    fix(#1847): every handler stamps `record.updated_by` and rolls
+    `tile_cache_version`, which dirties both rows even when nothing is
+    recomputed. Same helper as the refresh path, so the two cannot drift.
     """
     await _guard(db, lock_catalog_rows_for_write(db, dataset))
 
@@ -912,10 +891,8 @@ async def patch_single_feature(
             ],
         )
     else:
-        # fix(#1847 review r1): properties changed and no geometry did, so
-        # there is nothing to recompute -- but the two lines below still dirty
-        # the records row and the datasets row, and something has to take them
-        # in the house order before the flush at commit takes them in the ORM's.
+        # fix(#1847): nothing to recompute, but the lines below still dirty
+        # both rows, so the pair has to be taken in the house order first.
         await _lock_catalog_rows_guarded(db, dataset)
     dataset.record.updated_by = user.id
     await audit_emit(

--- a/backend/app/modules/catalog/features/router.py
+++ b/backend/app/modules/catalog/features/router.py
@@ -28,6 +28,7 @@ from app.core.db.sqlstate import (
     sqlstate,
 )
 from app.core.identity import Identity
+from app.platform.catalog_locks import CatalogLockConflict
 from app.core.record_types import RASTER_FAMILY_RECORD_TYPES
 from app.modules.auth.dependencies import (
     get_current_active_user,
@@ -124,19 +125,15 @@ def _feature_write_db_error(exc: DBAPIError) -> HTTPException:
     read path reports it, and an unrecognized state (our own bad SQL, 42601) is
     an honest 500, not the caller's fault.
 
-    fix(#1847): a lock conflict is classified FIRST. 40P01 is SQLSTATE class 40,
-    so `is_operational` would otherwise report a contended row as an outage.
-    409 is already declared on every write endpoint (ERROR_RESPONSES_WRITE).
+    fix(#1847): a lock conflict RAISES, rather than returning a 409 of its own.
+    The acquisition already raises CatalogLockConflict, so returning a second
+    409 body here gave one condition two response shapes depending on which
+    statement hit it. One exception, one mapping in `app/api/main.py`.
     """
     if is_lock_conflict(exc):
-        return HTTPException(
-            status_code=status.HTTP_409_CONFLICT,
-            detail={
-                "code": "feature_write_locked",
-                "message": "This dataset's catalog entry is being updated by "
-                "another operation. Retry shortly.",
-            },
-        )
+        raise CatalogLockConflict(
+            "Another operation is updating this dataset's catalog entry."
+        ) from exc
     if is_operational(exc):
         return HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,

--- a/backend/app/modules/catalog/features/service.py
+++ b/backend/app/modules/catalog/features/service.py
@@ -1329,39 +1329,83 @@ def _update_capturing_prior_bounds(quoted_table: str, sets: list[str]) -> str:
     )
 
 
-async def _lock_stored_extent_box(
+# fix(#1847): the lock budget for a feature write that has to wait for the
+# dataset row. Matches `app.platform.jobs.router` and
+# `catalog.maps.service_crud`, which spend the same budget on the same question
+# for the same reason: a row lock still contended after two seconds is held by
+# another live writer, not by latency inside this request, and the caller is
+# better served by a retryable conflict than by an open-ended hang.
+_LOCK_TIMEOUT = "2s"
+
+
+async def _lock_dataset_then_read_extent_box(
     session: AsyncSession, dataset: Dataset
 ) -> Bounds | None:
-    """The dataset's stored extent as a box, with the record row locked.
+    """Lock this dataset's catalog rows, then read its stored extent as a box.
+
+    LOCK ORDER, for every writer of the (datasets, records) pair: **the
+    datasets row first, the records row second.** Cite this docstring from any
+    new site that takes both. The two background writers that lock the pair
+    explicitly already lead with the datasets row, and neither can be reordered
+    to follow this path instead: `processing/ingest/tasks_postgis_refresh.py`
+    and `processing/ingest/tasks_stac_refresh.py` both take it to make a
+    superseded-content check and the write that depends on it one indivisible
+    step, so the lock has to be the first thing the write transaction does.
+
+    fix(#1847): this helper took the records row first, which inverted that
+    order and made an ordinary feature edit during a `refresh_postgis` phase 3
+    an ABBA deadlock (40P01) -- worker holding datasets and wanting records,
+    request holding records and wanting datasets. The record lock is still
+    taken, and still before the extent is read; only its position moved. This
+    is the same resolution `cancel_job` reached for the VRT asset in
+    fix(#1709 review r2 P2): both transactions lead with the lock the worker
+    cannot give up, so whoever wins runs alone and the other waits at its first
+    acquisition holding nothing.
 
     None unless the stored extent is a simple POLYGON. An antimeridian-crossing
     dataset stores the two-ring MULTIPOLYGON `seam_extent_wkt_for_table`
     produces (fix(#934)), whose ST_XMin/ST_XMax are -180/180: a longitude in
     the gap would test as inside a box the geometry never occupies.
 
-    fix(#1778 review r1): FOR UPDATE, and taken by BOTH metadata paths before
+    fix(#1778 review r1): the lock is taken by BOTH metadata paths before
     either reads the extent. Otherwise two writers on one dataset can interleave
     read-decide-write: one skips the recompute because its geometry is inside
     the extent it read, while the other shrinks that extent from an aggregate
     taken before the first row landed. Every writer here goes on to update the
     dataset row anyway, so it already serialized with its peers at commit; the
     lock only moves that serialization ahead of the decision that depends on it.
-    Both paths take the record row before the dataset row, which is the order
-    the ORM flushes them in.
     """
+    from app.modules.catalog.datasets.domain.models import Dataset as DatasetModel
     from app.modules.catalog.datasets.domain.models import Record
 
-    result = await session.execute(
-        select(
-            func.GeometryType(Record.spatial_extent),
-            func.ST_XMin(Record.spatial_extent),
-            func.ST_YMin(Record.spatial_extent),
-            func.ST_XMax(Record.spatial_extent),
-            func.ST_YMax(Record.spatial_extent),
+    # `SET LOCAL` takes a literal, not a bind parameter; this interpolates a
+    # module constant, never request-supplied data.
+    await session.execute(text(f"SET LOCAL lock_timeout = '{_LOCK_TIMEOUT}'"))
+
+    # `no_autoflush` so the order above is what actually reaches PostgreSQL. An
+    # autoflush triggered by either SELECT emits the ORM's own flush order,
+    # which is records before datasets (Dataset.record_id makes Record the
+    # parent mapper) -- the exact inversion this helper exists to prevent.
+    with session.no_autoflush:
+        # Single column, on the datasets table alone: reading through a joined
+        # relationship would not lock the joined row anyway, and would put this
+        # statement on the records row ahead of the lock it is ordering.
+        await session.execute(
+            select(DatasetModel.id)
+            .where(DatasetModel.id == dataset.id)
+            .with_for_update()
         )
-        .where(Record.id == dataset.record_id)
-        .with_for_update()
-    )
+        result = await session.execute(
+            select(
+                func.GeometryType(Record.spatial_extent),
+                func.ST_XMin(Record.spatial_extent),
+                func.ST_YMin(Record.spatial_extent),
+                func.ST_XMax(Record.spatial_extent),
+                func.ST_YMax(Record.spatial_extent),
+            )
+            .where(Record.id == dataset.record_id)
+            .with_for_update()
+        )
     row = result.first()
     if row is None or row[0] != "POLYGON" or any(v is None for v in row[1:]):
         return None
@@ -1498,9 +1542,10 @@ async def refresh_dataset_metadata(
     behaviour is unchanged.
     """
     # fix(#1778 review r1): taken before EITHER branch reads the extent, so a
-    # skip decision cannot be invalidated by a concurrent recompute. See
-    # _lock_stored_extent_box.
-    stored_box = await _lock_stored_extent_box(session, dataset)
+    # skip decision cannot be invalidated by a concurrent recompute.
+    # fix(#1847): datasets row first, then the records row. See
+    # _lock_dataset_then_read_extent_box for the order and why it is that way.
+    stored_box = await _lock_dataset_then_read_extent_box(session, dataset)
 
     if count_delta is not None and await _apply_incremental_metadata(
         session,
@@ -1512,6 +1557,18 @@ async def refresh_dataset_metadata(
     ):
         return
 
+    # fix(#1847): this aggregate runs INSIDE the lock, deliberately, and the
+    # bound on what that costs a concurrent writer is the `lock_timeout` above
+    # rather than a shorter critical section. Hoisting it above the lock and
+    # re-checking a cheap predicate afterwards would reinstate exactly the
+    # interleaving fix(#1778 review r1) closed: this transaction's row is
+    # already in the table but uncommitted, so a peer's aggregate cannot see
+    # it; if that peer measured before taking the lock, it would then write a
+    # count and an extent computed as though this row did not exist. Holding
+    # the lock across the scan is what makes the loser re-decide against the
+    # extent the winner actually stored. The scan only runs when the fast path
+    # above declined, which for the digitizing case it was added for is the
+    # uncommon branch.
     feature_count, extent_wkt = await _refresh_count_and_extent(
         session, dataset.table_name
     )

--- a/backend/app/modules/catalog/features/service.py
+++ b/backend/app/modules/catalog/features/service.py
@@ -1329,49 +1329,21 @@ def _update_capturing_prior_bounds(quoted_table: str, sets: list[str]) -> str:
     )
 
 
-# fix(#1847): the lock budget for a feature write that has to wait for the
-# dataset row. Matches `app.platform.jobs.router` and
-# `catalog.maps.service_crud`, which spend the same budget on the same question
-# for the same reason: a row lock still contended after two seconds is held by
-# another live writer, not by latency inside this request, and the caller is
-# better served by a retryable conflict than by an open-ended hang.
-_LOCK_TIMEOUT = "2s"
-
-
 async def lock_catalog_rows_for_write(
     session: AsyncSession, dataset: Dataset
 ) -> Bounds | None:
-    """Lock this dataset's catalog rows, then read its stored extent as a box.
+    """Take this dataset's catalog rows in the house order, then read its extent.
 
     Call this from ANY request path that will dirty the datasets row, the
     records row, or both -- not only from the metadata refresh. Stamping
     `record.updated_by` and rolling `tile_cache_version` is already a write to
-    both rows, and the ORM flushes them at commit in records-then-datasets
-    order whether or not the caller thought of itself as locking anything.
+    both rows, and a transaction that acquires nothing takes them in the ORM's
+    records-then-datasets flush order.
 
-    LOCK ORDER, for every writer of the (datasets, records) pair: **the
-    datasets row first, the records row second.** Cite this docstring from any
-    new site that takes both. The two background writers that lock the pair
-    explicitly already lead with the datasets row, and neither can be reordered
-    to follow this path instead: `processing/ingest/tasks_postgis_refresh.py`
-    and `processing/ingest/tasks_stac_refresh.py` both take it to make a
-    superseded-content check and the write that depends on it one indivisible
-    step, so the lock has to be the first thing the write transaction does.
-
-    The stored extent comes back because the read is FUSED into the records
-    lock statement and so costs nothing extra: it is a single-row lookup by
-    primary key, not the `ST_Extent` aggregate over the data table. The
-    metadata refresh needs it; callers that only need the ordering ignore it.
-
-    fix(#1847): this helper took the records row first, which inverted that
-    order and made an ordinary feature edit during a `refresh_postgis` phase 3
-    an ABBA deadlock (40P01) -- worker holding datasets and wanting records,
-    request holding records and wanting datasets. The record lock is still
-    taken, and still before the extent is read; only its position moved. This
-    is the same resolution `cancel_job` reached for the VRT asset in
-    fix(#1709 review r2 P2): both transactions lead with the lock the worker
-    cannot give up, so whoever wins runs alone and the other waits at its first
-    acquisition holding nothing.
+    THE ORDER, and why it is that one, is stated once in
+    `app.platform.catalog_locks.lock_catalog_rows`. This is the catalog-side
+    entry point: it supplies the two mapped classes and then reads the stored
+    extent, which the metadata refresh needs and other callers ignore.
 
     None unless the stored extent is a simple POLYGON. An antimeridian-crossing
     dataset stores the two-ring MULTIPOLYGON `seam_extent_wkt_for_table`
@@ -1388,35 +1360,26 @@ async def lock_catalog_rows_for_write(
     """
     from app.modules.catalog.datasets.domain.models import Dataset as DatasetModel
     from app.modules.catalog.datasets.domain.models import Record
+    from app.platform.catalog_locks import lock_catalog_rows
 
-    # `SET LOCAL` takes a literal, not a bind parameter; this interpolates a
-    # module constant, never request-supplied data.
-    await session.execute(text(f"SET LOCAL lock_timeout = '{_LOCK_TIMEOUT}'"))
+    await lock_catalog_rows(
+        session,
+        dataset_cls=DatasetModel,
+        record_cls=Record,
+        dataset_id=dataset.id,
+        record_id=dataset.record_id,
+    )
 
-    # `no_autoflush` so the order above is what actually reaches PostgreSQL. An
-    # autoflush triggered by either SELECT emits the ORM's own flush order,
-    # which is records before datasets (Dataset.record_id makes Record the
-    # parent mapper) -- the exact inversion this helper exists to prevent.
-    with session.no_autoflush:
-        # Single column, on the datasets table alone: reading through a joined
-        # relationship would not lock the joined row anyway, and would put this
-        # statement on the records row ahead of the lock it is ordering.
-        await session.execute(
-            select(DatasetModel.id)
-            .where(DatasetModel.id == dataset.id)
-            .with_for_update()
-        )
-        result = await session.execute(
-            select(
-                func.GeometryType(Record.spatial_extent),
-                func.ST_XMin(Record.spatial_extent),
-                func.ST_YMin(Record.spatial_extent),
-                func.ST_XMax(Record.spatial_extent),
-                func.ST_YMax(Record.spatial_extent),
-            )
-            .where(Record.id == dataset.record_id)
-            .with_for_update()
-        )
+    # Both rows are held now, so this is an ordinary read.
+    result = await session.execute(
+        select(
+            func.GeometryType(Record.spatial_extent),
+            func.ST_XMin(Record.spatial_extent),
+            func.ST_YMin(Record.spatial_extent),
+            func.ST_XMax(Record.spatial_extent),
+            func.ST_YMax(Record.spatial_extent),
+        ).where(Record.id == dataset.record_id)
+    )
     row = result.first()
     if row is None or row[0] != "POLYGON" or any(v is None for v in row[1:]):
         return None

--- a/backend/app/modules/catalog/features/service.py
+++ b/backend/app/modules/catalog/features/service.py
@@ -1330,13 +1330,16 @@ def _update_capturing_prior_bounds(quoted_table: str, sets: list[str]) -> str:
 
 
 async def lock_catalog_rows_for_write(
-    session: AsyncSession, dataset: Dataset
+    session: AsyncSession, dataset: Dataset, *, with_raster_asset: bool = False
 ) -> Bounds | None:
     """Take this dataset's catalog rows in the house order, then read its extent.
 
     The catalog-side entry point to `platform.catalog_locks.lock_catalog_rows`,
     which states the order. Call it from ANY request path that will dirty
     either row, not only from the metadata refresh.
+
+    `with_raster_asset` extends the order to the raster child, for a
+    transaction whose records delete cascades to it.
 
     Returns None unless the stored extent is a simple POLYGON: an
     antimeridian-crossing dataset stores a two-ring MULTIPOLYGON (fix(#934))
@@ -1351,12 +1354,19 @@ async def lock_catalog_rows_for_write(
     from app.modules.catalog.datasets.domain.models import Record
     from app.platform.catalog_locks import lock_catalog_rows
 
+    # Through the port: `catalog/` may not import `app.processing.*`
+    # (test_layering CATPORT-02).
+    raster_asset_cls = (
+        get_catalog_port().raster_asset_orm_class() if with_raster_asset else None
+    )
+
     await lock_catalog_rows(
         session,
         dataset_cls=DatasetModel,
         record_cls=Record,
         dataset_id=dataset.id,
         record_id=dataset.record_id,
+        raster_asset_cls=raster_asset_cls,
     )
 
     # Both rows are held now, so this is an ordinary read.

--- a/backend/app/modules/catalog/features/service.py
+++ b/backend/app/modules/catalog/features/service.py
@@ -1342,13 +1342,13 @@ async def lock_catalog_rows_for_write(
     transaction whose records delete cascades to it.
 
     Returns None unless the stored extent is a simple POLYGON: an
-    antimeridian-crossing dataset stores a two-ring MULTIPOLYGON (fix(#934))
+    antimeridian-crossing dataset stores a two-ring MULTIPOLYGON (#934)
     whose ST_XMin/ST_XMax are -180/180, so a longitude in the gap would test as
     inside a box the geometry never occupies.
 
-    fix(#1778 review r1): both metadata paths take the lock before either reads
-    the extent, or two writers interleave read-decide-write and one shrinks the
-    extent from an aggregate taken before the other's row landed.
+    Both metadata paths take the lock before either reads the extent, or two
+    writers interleave read-decide-write and one shrinks the extent from an
+    aggregate taken before the other's row landed (#1778).
     """
     from app.modules.catalog.datasets.domain.models import Dataset as DatasetModel
     from app.modules.catalog.datasets.domain.models import Record

--- a/backend/app/modules/catalog/features/service.py
+++ b/backend/app/modules/catalog/features/service.py
@@ -1338,10 +1338,16 @@ def _update_capturing_prior_bounds(quoted_table: str, sets: list[str]) -> str:
 _LOCK_TIMEOUT = "2s"
 
 
-async def _lock_dataset_then_read_extent_box(
+async def lock_catalog_rows_for_write(
     session: AsyncSession, dataset: Dataset
 ) -> Bounds | None:
     """Lock this dataset's catalog rows, then read its stored extent as a box.
+
+    Call this from ANY request path that will dirty the datasets row, the
+    records row, or both -- not only from the metadata refresh. Stamping
+    `record.updated_by` and rolling `tile_cache_version` is already a write to
+    both rows, and the ORM flushes them at commit in records-then-datasets
+    order whether or not the caller thought of itself as locking anything.
 
     LOCK ORDER, for every writer of the (datasets, records) pair: **the
     datasets row first, the records row second.** Cite this docstring from any
@@ -1351,6 +1357,11 @@ async def _lock_dataset_then_read_extent_box(
     and `processing/ingest/tasks_stac_refresh.py` both take it to make a
     superseded-content check and the write that depends on it one indivisible
     step, so the lock has to be the first thing the write transaction does.
+
+    The stored extent comes back because the read is FUSED into the records
+    lock statement and so costs nothing extra: it is a single-row lookup by
+    primary key, not the `ST_Extent` aggregate over the data table. The
+    metadata refresh needs it; callers that only need the ordering ignore it.
 
     fix(#1847): this helper took the records row first, which inverted that
     order and made an ordinary feature edit during a `refresh_postgis` phase 3
@@ -1544,8 +1555,8 @@ async def refresh_dataset_metadata(
     # fix(#1778 review r1): taken before EITHER branch reads the extent, so a
     # skip decision cannot be invalidated by a concurrent recompute.
     # fix(#1847): datasets row first, then the records row. See
-    # _lock_dataset_then_read_extent_box for the order and why it is that way.
-    stored_box = await _lock_dataset_then_read_extent_box(session, dataset)
+    # lock_catalog_rows_for_write for the order and why it is that way.
+    stored_box = await lock_catalog_rows_for_write(session, dataset)
 
     if count_delta is not None and await _apply_incremental_metadata(
         session,

--- a/backend/app/modules/catalog/features/service.py
+++ b/backend/app/modules/catalog/features/service.py
@@ -1334,29 +1334,18 @@ async def lock_catalog_rows_for_write(
 ) -> Bounds | None:
     """Take this dataset's catalog rows in the house order, then read its extent.
 
-    Call this from ANY request path that will dirty the datasets row, the
-    records row, or both -- not only from the metadata refresh. Stamping
-    `record.updated_by` and rolling `tile_cache_version` is already a write to
-    both rows, and a transaction that acquires nothing takes them in the ORM's
-    records-then-datasets flush order.
+    The catalog-side entry point to `platform.catalog_locks.lock_catalog_rows`,
+    which states the order. Call it from ANY request path that will dirty
+    either row, not only from the metadata refresh.
 
-    THE ORDER, and why it is that one, is stated once in
-    `app.platform.catalog_locks.lock_catalog_rows`. This is the catalog-side
-    entry point: it supplies the two mapped classes and then reads the stored
-    extent, which the metadata refresh needs and other callers ignore.
+    Returns None unless the stored extent is a simple POLYGON: an
+    antimeridian-crossing dataset stores a two-ring MULTIPOLYGON (fix(#934))
+    whose ST_XMin/ST_XMax are -180/180, so a longitude in the gap would test as
+    inside a box the geometry never occupies.
 
-    None unless the stored extent is a simple POLYGON. An antimeridian-crossing
-    dataset stores the two-ring MULTIPOLYGON `seam_extent_wkt_for_table`
-    produces (fix(#934)), whose ST_XMin/ST_XMax are -180/180: a longitude in
-    the gap would test as inside a box the geometry never occupies.
-
-    fix(#1778 review r1): the lock is taken by BOTH metadata paths before
-    either reads the extent. Otherwise two writers on one dataset can interleave
-    read-decide-write: one skips the recompute because its geometry is inside
-    the extent it read, while the other shrinks that extent from an aggregate
-    taken before the first row landed. Every writer here goes on to update the
-    dataset row anyway, so it already serialized with its peers at commit; the
-    lock only moves that serialization ahead of the decision that depends on it.
+    fix(#1778 review r1): both metadata paths take the lock before either reads
+    the extent, or two writers interleave read-decide-write and one shrinks the
+    extent from an aggregate taken before the other's row landed.
     """
     from app.modules.catalog.datasets.domain.models import Dataset as DatasetModel
     from app.modules.catalog.datasets.domain.models import Record
@@ -1517,8 +1506,6 @@ async def refresh_dataset_metadata(
     """
     # fix(#1778 review r1): taken before EITHER branch reads the extent, so a
     # skip decision cannot be invalidated by a concurrent recompute.
-    # fix(#1847): datasets row first, then the records row. See
-    # lock_catalog_rows_for_write for the order and why it is that way.
     stored_box = await lock_catalog_rows_for_write(session, dataset)
 
     if count_delta is not None and await _apply_incremental_metadata(
@@ -1531,18 +1518,9 @@ async def refresh_dataset_metadata(
     ):
         return
 
-    # fix(#1847): this aggregate runs INSIDE the lock, deliberately, and the
-    # bound on what that costs a concurrent writer is the `lock_timeout` above
-    # rather than a shorter critical section. Hoisting it above the lock and
-    # re-checking a cheap predicate afterwards would reinstate exactly the
-    # interleaving fix(#1778 review r1) closed: this transaction's row is
-    # already in the table but uncommitted, so a peer's aggregate cannot see
-    # it; if that peer measured before taking the lock, it would then write a
-    # count and an extent computed as though this row did not exist. Holding
-    # the lock across the scan is what makes the loser re-decide against the
-    # extent the winner actually stored. The scan only runs when the fast path
-    # above declined, which for the digitizing case it was added for is the
-    # uncommon branch.
+    # fix(#1847): INSIDE the lock, deliberately. A peer that measured before
+    # taking the lock cannot see this transaction's uncommitted row, and would
+    # write a count and extent computed as though it did not exist.
     feature_count, extent_wkt = await _refresh_count_and_extent(
         session, dataset.table_name
     )

--- a/backend/app/modules/catalog/layers/router.py
+++ b/backend/app/modules/catalog/layers/router.py
@@ -64,11 +64,8 @@ async def _raise_ddl_db_error(db: AsyncSession, exc: DBAPIError, action: str) ->
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail="Database temporarily unavailable.",
         )
-    # fix(#1847 review r3): the SQLSTATE, not the driver object. Interpolating
-    # `exc.orig` put the asyncpg exception class name and its message straight
-    # into the response body, which tells a caller nothing they can act on and
-    # publishes the driver and schema internals to anyone who can provoke an
-    # error. The state goes to the log, where the operator needs it.
+    # fix(#1847): the SQLSTATE goes to the log, not the response. Interpolating
+    # `exc.orig` published the driver exception and its message to the caller.
     logger.warning(
         "layer.ddl failed", action=action, sqlstate=sqlstate(exc), exc_info=exc
     )

--- a/backend/app/modules/catalog/layers/router.py
+++ b/backend/app/modules/catalog/layers/router.py
@@ -8,7 +8,7 @@ from sqlalchemy.exc import DBAPIError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.modules.audit.service import AuditEvent, audit_emit
-from app.core.db.sqlstate import is_operational
+from app.core.db.sqlstate import is_operational, sqlstate
 from app.core.identity import Identity
 from app.modules.auth.dependencies import require_permission
 from app.core.dependencies import get_db
@@ -47,6 +47,9 @@ async def _invalidate_tiles(table_name: str) -> None:
         await tile_cache.invalidate_table(table_name)
 
 
+logger = structlog.stdlib.get_logger(__name__)
+
+
 async def _raise_ddl_db_error(db: AsyncSession, exc: DBAPIError, action: str) -> None:
     """Roll back and map a DDL DB error to the right status. Never returns.
 
@@ -61,13 +64,19 @@ async def _raise_ddl_db_error(db: AsyncSession, exc: DBAPIError, action: str) ->
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail="Database temporarily unavailable.",
         )
+    # fix(#1847 review r3): the SQLSTATE, not the driver object. Interpolating
+    # `exc.orig` put the asyncpg exception class name and its message straight
+    # into the response body, which tells a caller nothing they can act on and
+    # publishes the driver and schema internals to anyone who can provoke an
+    # error. The state goes to the log, where the operator needs it.
+    logger.warning(
+        "layer.ddl failed", action=action, sqlstate=sqlstate(exc), exc_info=exc
+    )
     raise HTTPException(
         status_code=status.HTTP_400_BAD_REQUEST,
-        detail=f"{action} failed: {exc.orig or exc}",
+        detail=f"{action} failed: the database rejected the change.",
     )
 
-
-logger = structlog.stdlib.get_logger(__name__)
 
 layers_router = APIRouter(
     prefix="/layers", tags=["Maps"], responses=ERROR_RESPONSES_WRITE

--- a/backend/app/modules/catalog/layers/service.py
+++ b/backend/app/modules/catalog/layers/service.py
@@ -48,9 +48,9 @@ async def _compute_quality_detail(
     fully-populated one, changed the real score while the displayed one stayed
     stale until the next reupload).
 
-    fix(#1847): returns rather than assigns, so the caller runs it BEFORE
-    taking the catalog rows. It is a COUNT per column over the whole data table
-    plus a geometry pass over 10,000 rows, and it needs neither catalog row.
+    Returns rather than assigns, so the caller runs it BEFORE taking the
+    catalog rows. It is a COUNT per column over the whole data table plus a
+    geometry pass over 10,000 rows, and it needs neither catalog row (#1847).
 
     `no_autoflush` because the caller has not taken the rows yet.
     """

--- a/backend/app/modules/catalog/layers/service.py
+++ b/backend/app/modules/catalog/layers/service.py
@@ -20,6 +20,7 @@ from app.modules.catalog.layers.schemas import (
     RESERVED_COLUMNS,
 )
 from app.platform.extensions import get_catalog_port
+from app.modules.catalog.features.service import lock_catalog_rows_for_write
 
 logger = structlog.stdlib.get_logger(__name__)
 
@@ -228,6 +229,13 @@ async def add_column(
 
     # Refresh column_info
     column_info = await get_catalog_port().get_column_info(session, dataset.table_name)
+    # fix(#1847 review r2): the DDL above is done; the catalog writes start
+    # here. This function dirties the datasets row and the caller then stamps
+    # `record.updated_by`, so the flush takes both. Acquire in the house order
+    # first. Placed AFTER the ALTER TABLE on purpose: the reupload swap takes
+    # its data-table ACCESS EXCLUSIVE before its catalog rows, and leading with
+    # the catalog rows here would invert against it.
+    await lock_catalog_rows_for_write(session, dataset)
     dataset.column_info = column_info
     await _refresh_quality_detail(session, dataset, column_info)
 
@@ -310,6 +318,13 @@ async def rename_column(
     await session.execute(text(ddl))
 
     column_info = await get_catalog_port().get_column_info(session, dataset.table_name)
+    # fix(#1847 review r2): the DDL above is done; the catalog writes start
+    # here. This function dirties the datasets row and the caller then stamps
+    # `record.updated_by`, so the flush takes both. Acquire in the house order
+    # first. Placed AFTER the ALTER TABLE on purpose: the reupload swap takes
+    # its data-table ACCESS EXCLUSIVE before its catalog rows, and leading with
+    # the catalog rows here would invert against it.
+    await lock_catalog_rows_for_write(session, dataset)
     dataset.column_info = column_info
 
     # fix(#458 E-43): keep the cached sample-values snapshot keyed by the new
@@ -376,6 +391,13 @@ async def alter_column_type(
     await session.execute(text(ddl))
 
     column_info = await get_catalog_port().get_column_info(session, dataset.table_name)
+    # fix(#1847 review r2): the DDL above is done; the catalog writes start
+    # here. This function dirties the datasets row and the caller then stamps
+    # `record.updated_by`, so the flush takes both. Acquire in the house order
+    # first. Placed AFTER the ALTER TABLE on purpose: the reupload swap takes
+    # its data-table ACCESS EXCLUSIVE before its catalog rows, and leading with
+    # the catalog rows here would invert against it.
+    await lock_catalog_rows_for_write(session, dataset)
     dataset.column_info = column_info
     await _refresh_quality_detail(session, dataset, column_info)
 
@@ -431,6 +453,13 @@ async def drop_column(
 
     # Refresh column_info
     column_info = await get_catalog_port().get_column_info(session, dataset.table_name)
+    # fix(#1847 review r2): the DDL above is done; the catalog writes start
+    # here. This function dirties the datasets row and the caller then stamps
+    # `record.updated_by`, so the flush takes both. Acquire in the house order
+    # first. Placed AFTER the ALTER TABLE on purpose: the reupload swap takes
+    # its data-table ACCESS EXCLUSIVE before its catalog rows, and leading with
+    # the catalog rows here would invert against it.
+    await lock_catalog_rows_for_write(session, dataset)
     dataset.column_info = column_info
     await _refresh_quality_detail(session, dataset, column_info)
 

--- a/backend/app/modules/catalog/layers/service.py
+++ b/backend/app/modules/catalog/layers/service.py
@@ -48,20 +48,11 @@ async def _compute_quality_detail(
     fully-populated one, changed the real score while the displayed one stayed
     stale until the next reupload).
 
-    fix(#1847 review r3): computes and returns rather than assigning, so the
-    caller can run it BEFORE taking the catalog rows. The score is a
-    `COUNT(<col>)` over the whole data table per non-geometry column plus a
-    geometry-validity pass over up to 10,000 rows, which on a wide layer is
-    seconds. Held under the pair, every concurrent feature edit and metadata
-    edit on that dataset waits behind it or answers 409. Nothing about the
-    computation needs the lock: it reads the data table and touches neither
-    catalog row. That is what separates it from the feature-path aggregate,
-    which has to stay inside the lock for the fix(#1778 review r1)
-    read-decide-write invariant.
+    fix(#1847): returns rather than assigns, so the caller runs it BEFORE
+    taking the catalog rows. It is a COUNT per column over the whole data table
+    plus a geometry pass over 10,000 rows, and it needs neither catalog row.
 
-    `no_autoflush` because the caller has not taken the rows yet: a flush here
-    would emit the pending catalog writes records-first, ahead of the
-    acquisition.
+    `no_autoflush` because the caller has not taken the rows yet.
     """
     with session.no_autoflush:
         return await get_catalog_port().compute_quality_score(
@@ -245,16 +236,9 @@ async def add_column(
 
     # Refresh column_info
     column_info = await get_catalog_port().get_column_info(session, dataset.table_name)
-    # fix(#1847 review r2): the DDL above is done; the catalog writes start
-    # here. This function dirties the datasets row and the caller then stamps
-    # `record.updated_by`, so the flush takes both. Acquire in the house order
-    # first. Placed AFTER the ALTER TABLE on purpose: the reupload swap takes
-    # its data-table ACCESS EXCLUSIVE before its catalog rows, and leading with
-    # the catalog rows here would invert against it.
-    # fix(#1847 review r3): scan first, then lock, then assign both fields.
-    # The score reads the data table and needs neither catalog row; running it
-    # under the pair held every concurrent edit on this dataset for the length
-    # of a full-table scan. See _compute_quality_detail.
+    # fix(#1847): scan, then lock, then assign both fields. The scan needs
+    # neither catalog row; the lock follows the ALTER because the reupload swap
+    # takes its data-table ACCESS EXCLUSIVE before its catalog rows.
     quality_detail = await _compute_quality_detail(session, dataset, column_info)
     await lock_catalog_rows_for_write(session, dataset)
     dataset.column_info = column_info
@@ -339,12 +323,9 @@ async def rename_column(
     await session.execute(text(ddl))
 
     column_info = await get_catalog_port().get_column_info(session, dataset.table_name)
-    # fix(#1847 review r2): the DDL above is done; the catalog writes start
-    # here. This function dirties the datasets row and the caller then stamps
-    # `record.updated_by`, so the flush takes both. Acquire in the house order
-    # first. Placed AFTER the ALTER TABLE on purpose: the reupload swap takes
-    # its data-table ACCESS EXCLUSIVE before its catalog rows, and leading with
-    # the catalog rows here would invert against it.
+    # fix(#1847): the catalog writes start here, and the caller then stamps
+    # `record.updated_by`. After the ALTER because the reupload swap takes its
+    # data-table ACCESS EXCLUSIVE before its catalog rows.
     await lock_catalog_rows_for_write(session, dataset)
     dataset.column_info = column_info
 
@@ -412,16 +393,9 @@ async def alter_column_type(
     await session.execute(text(ddl))
 
     column_info = await get_catalog_port().get_column_info(session, dataset.table_name)
-    # fix(#1847 review r2): the DDL above is done; the catalog writes start
-    # here. This function dirties the datasets row and the caller then stamps
-    # `record.updated_by`, so the flush takes both. Acquire in the house order
-    # first. Placed AFTER the ALTER TABLE on purpose: the reupload swap takes
-    # its data-table ACCESS EXCLUSIVE before its catalog rows, and leading with
-    # the catalog rows here would invert against it.
-    # fix(#1847 review r3): scan first, then lock, then assign both fields.
-    # The score reads the data table and needs neither catalog row; running it
-    # under the pair held every concurrent edit on this dataset for the length
-    # of a full-table scan. See _compute_quality_detail.
+    # fix(#1847): scan, then lock, then assign both fields. The scan needs
+    # neither catalog row; the lock follows the ALTER because the reupload swap
+    # takes its data-table ACCESS EXCLUSIVE before its catalog rows.
     quality_detail = await _compute_quality_detail(session, dataset, column_info)
     await lock_catalog_rows_for_write(session, dataset)
     dataset.column_info = column_info
@@ -479,16 +453,9 @@ async def drop_column(
 
     # Refresh column_info
     column_info = await get_catalog_port().get_column_info(session, dataset.table_name)
-    # fix(#1847 review r2): the DDL above is done; the catalog writes start
-    # here. This function dirties the datasets row and the caller then stamps
-    # `record.updated_by`, so the flush takes both. Acquire in the house order
-    # first. Placed AFTER the ALTER TABLE on purpose: the reupload swap takes
-    # its data-table ACCESS EXCLUSIVE before its catalog rows, and leading with
-    # the catalog rows here would invert against it.
-    # fix(#1847 review r3): scan first, then lock, then assign both fields.
-    # The score reads the data table and needs neither catalog row; running it
-    # under the pair held every concurrent edit on this dataset for the length
-    # of a full-table scan. See _compute_quality_detail.
+    # fix(#1847): scan, then lock, then assign both fields. The scan needs
+    # neither catalog row; the lock follows the ALTER because the reupload swap
+    # takes its data-table ACCESS EXCLUSIVE before its catalog rows.
     quality_detail = await _compute_quality_detail(session, dataset, column_info)
     await lock_catalog_rows_for_write(session, dataset)
     dataset.column_info = column_info

--- a/backend/app/modules/catalog/layers/service.py
+++ b/backend/app/modules/catalog/layers/service.py
@@ -38,22 +38,38 @@ def _qcol(name: str) -> str:
     return '"' + name.replace('"', '""') + '"'
 
 
-async def _refresh_quality_detail(
+async def _compute_quality_detail(
     session: AsyncSession, dataset: Dataset, column_info: list[dict]
-) -> None:
-    """Recompute the stored quality score after a schema change.
+) -> object:
+    """The quality score for a schema change, WITHOUT storing it.
 
     fix(#458 E-34): reupload recomputes quality_detail but column DDL did not,
     so attribute_completeness drifted (an all-null added column, or a dropped
     fully-populated one, changed the real score while the displayed one stayed
     stale until the next reupload).
+
+    fix(#1847 review r3): computes and returns rather than assigning, so the
+    caller can run it BEFORE taking the catalog rows. The score is a
+    `COUNT(<col>)` over the whole data table per non-geometry column plus a
+    geometry-validity pass over up to 10,000 rows, which on a wide layer is
+    seconds. Held under the pair, every concurrent feature edit and metadata
+    edit on that dataset waits behind it or answers 409. Nothing about the
+    computation needs the lock: it reads the data table and touches neither
+    catalog row. That is what separates it from the feature-path aggregate,
+    which has to stay inside the lock for the fix(#1778 review r1)
+    read-decide-write invariant.
+
+    `no_autoflush` because the caller has not taken the rows yet: a flush here
+    would emit the pending catalog writes records-first, ahead of the
+    acquisition.
     """
-    dataset.quality_detail = await get_catalog_port().compute_quality_score(
-        session,
-        dataset.table_name,
-        column_info,
-        dataset,
-    )
+    with session.no_autoflush:
+        return await get_catalog_port().compute_quality_score(
+            session,
+            dataset.table_name,
+            column_info,
+            dataset,
+        )
 
 
 async def create_layer(
@@ -235,9 +251,14 @@ async def add_column(
     # first. Placed AFTER the ALTER TABLE on purpose: the reupload swap takes
     # its data-table ACCESS EXCLUSIVE before its catalog rows, and leading with
     # the catalog rows here would invert against it.
+    # fix(#1847 review r3): scan first, then lock, then assign both fields.
+    # The score reads the data table and needs neither catalog row; running it
+    # under the pair held every concurrent edit on this dataset for the length
+    # of a full-table scan. See _compute_quality_detail.
+    quality_detail = await _compute_quality_detail(session, dataset, column_info)
     await lock_catalog_rows_for_write(session, dataset)
     dataset.column_info = column_info
-    await _refresh_quality_detail(session, dataset, column_info)
+    dataset.quality_detail = quality_detail
 
     # Create (or revive) the AttributeMetadata row for the new column.
     # fix(#458 E-12): (dataset_id, field_name) is unique, so re-adding a name
@@ -397,9 +418,14 @@ async def alter_column_type(
     # first. Placed AFTER the ALTER TABLE on purpose: the reupload swap takes
     # its data-table ACCESS EXCLUSIVE before its catalog rows, and leading with
     # the catalog rows here would invert against it.
+    # fix(#1847 review r3): scan first, then lock, then assign both fields.
+    # The score reads the data table and needs neither catalog row; running it
+    # under the pair held every concurrent edit on this dataset for the length
+    # of a full-table scan. See _compute_quality_detail.
+    quality_detail = await _compute_quality_detail(session, dataset, column_info)
     await lock_catalog_rows_for_write(session, dataset)
     dataset.column_info = column_info
-    await _refresh_quality_detail(session, dataset, column_info)
+    dataset.quality_detail = quality_detail
 
     # Refresh AttributeMetadata.data_type so quality metrics + UI labels match.
     result = await session.execute(
@@ -459,9 +485,14 @@ async def drop_column(
     # first. Placed AFTER the ALTER TABLE on purpose: the reupload swap takes
     # its data-table ACCESS EXCLUSIVE before its catalog rows, and leading with
     # the catalog rows here would invert against it.
+    # fix(#1847 review r3): scan first, then lock, then assign both fields.
+    # The score reads the data table and needs neither catalog row; running it
+    # under the pair held every concurrent edit on this dataset for the length
+    # of a full-table scan. See _compute_quality_detail.
+    quality_detail = await _compute_quality_detail(session, dataset, column_info)
     await lock_catalog_rows_for_write(session, dataset)
     dataset.column_info = column_info
-    await _refresh_quality_detail(session, dataset, column_info)
+    dataset.quality_detail = quality_detail
 
     # fix(#458 E-43): drop the removed column's cached sample values too.
     if dataset.sample_values and column_name in dataset.sample_values:

--- a/backend/app/modules/catalog/maps/service_crud.py
+++ b/backend/app/modules/catalog/maps/service_crud.py
@@ -60,15 +60,7 @@ def new_map_asset_key(prefix: str, map_id: uuid.UUID, ext: str) -> str:
 
 
 def _is_lock_timeout_error(exc: BaseException) -> bool:
-    """True when another transaction holds the map row this write needs.
-
-    fix(#1778 round 8): asyncpg raises ``LockNotAvailableError`` directly;
-    ``AsyncSession.execute`` wraps it in SQLAlchemy's ``DBAPIError`` with
-    ``.orig`` pointing at that same exception. Both shapes have to be checked.
-
-    fix(#1847): the check moved to ``app.core.db.sqlstate``, and widened with
-    it to match 40P01 too, so a deadlock victim answers 409 rather than 500.
-    """
+    """True for the shared lock-conflict states (55P03, 40P01), in either shape."""
     return is_lock_conflict(exc)
 
 

--- a/backend/app/modules/catalog/maps/service_crud.py
+++ b/backend/app/modules/catalog/maps/service_crud.py
@@ -66,17 +66,8 @@ def _is_lock_timeout_error(exc: BaseException) -> bool:
     ``AsyncSession.execute`` wraps it in SQLAlchemy's ``DBAPIError`` with
     ``.orig`` pointing at that same exception. Both shapes have to be checked.
 
-    fix(#1847): that check now lives in ``app.core.db.sqlstate``, which is the
-    layer-legal home the round-8 note said did not exist -- it rejected the
-    ingest copy for sitting behind CatalogPort and the ``jobs.router`` copy for
-    being private, and `core.db` is neither. This wrapper stays so the call
-    site below reads the same, and because the name is local vocabulary.
-
-    Widened with it, deliberately: the shared predicate also matches 40P01, so
-    a deadlock victim here answers 409 like a lock timeout does instead of
-    escaping as a 500. Same argument ``jobs.router`` recorded for its own
-    cancel path -- nothing was written either way, and a retry is the correct
-    next action either way.
+    fix(#1847): the check moved to ``app.core.db.sqlstate``, and widened with
+    it to match 40P01 too, so a deadlock victim answers 409 rather than 500.
     """
     return is_lock_conflict(exc)
 

--- a/backend/app/modules/catalog/maps/service_crud.py
+++ b/backend/app/modules/catalog/maps/service_crud.py
@@ -13,6 +13,7 @@ from sqlalchemy.exc import DBAPIError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import aliased
 
+from app.core.db.sqlstate import is_lock_conflict
 from app.core.identity import Identity
 from app.modules.auth.models import User
 from app.modules.catalog.authorization import get_user_roles
@@ -59,28 +60,25 @@ def new_map_asset_key(prefix: str, map_id: uuid.UUID, ext: str) -> str:
 
 
 def _is_lock_timeout_error(exc: BaseException) -> bool:
-    """True for PostgreSQL 55P03 (lock_timeout exceeded), asyncpg or wrapped.
+    """True when another transaction holds the map row this write needs.
 
-    fix(#1778 round 8): asyncpg raises ``LockNotAvailableError``
-    directly; ``AsyncSession.execute`` wraps it in SQLAlchemy's ``DBAPIError``
-    with ``.orig`` pointing at that same exception. Check both shapes, the way
-    a sibling helper on the ingest side and ``app.platform.jobs.router``'s
-    ``_is_lock_conflict`` already do for their own callers. This module keeps
-    its own copy rather than importing either: the ingest one sits behind the
-    CatalogPort boundary this domain is not allowed to reach past directly, and
-    the platform one is a private, unexported name. Neither is worth a shared
-    cross-domain dependency for four lines of SQLSTATE matching.
+    fix(#1778 round 8): asyncpg raises ``LockNotAvailableError`` directly;
+    ``AsyncSession.execute`` wraps it in SQLAlchemy's ``DBAPIError`` with
+    ``.orig`` pointing at that same exception. Both shapes have to be checked.
+
+    fix(#1847): that check now lives in ``app.core.db.sqlstate``, which is the
+    layer-legal home the round-8 note said did not exist -- it rejected the
+    ingest copy for sitting behind CatalogPort and the ``jobs.router`` copy for
+    being private, and `core.db` is neither. This wrapper stays so the call
+    site below reads the same, and because the name is local vocabulary.
+
+    Widened with it, deliberately: the shared predicate also matches 40P01, so
+    a deadlock victim here answers 409 like a lock timeout does instead of
+    escaping as a 500. Same argument ``jobs.router`` recorded for its own
+    cancel path -- nothing was written either way, and a retry is the correct
+    next action either way.
     """
-    try:
-        from asyncpg.exceptions import LockNotAvailableError
-
-        if isinstance(exc, LockNotAvailableError):
-            return True
-    except ImportError:
-        pass
-
-    orig = getattr(exc, "orig", None)
-    return orig is not None and getattr(orig, "sqlstate", None) == "55P03"
+    return is_lock_conflict(exc)
 
 
 async def lock_map_for_asset_write(session: AsyncSession, map_id: uuid.UUID) -> Row:

--- a/backend/app/platform/catalog_locks.py
+++ b/backend/app/platform/catalog_locks.py
@@ -25,6 +25,11 @@ REQUEST_LOCK_TIMEOUT = "2s"
 _USE_REQUEST_DEFAULT: Any = object()
 
 
+# The machine-readable code for a contended row, wherever it is reported: the
+# 409 body, and a bulk-delete item that carries its conflict instead of raising.
+CATALOG_LOCK_CONFLICT_CODE = "catalog_lock_conflict"
+
+
 class CatalogLockConflict(Exception):
     """Another transaction holds the catalog rows this one needs.
 

--- a/backend/app/platform/catalog_locks.py
+++ b/backend/app/platform/catalog_locks.py
@@ -47,6 +47,7 @@ async def lock_catalog_rows(
     dataset_id: Any,
     record_id: Any,
     lock_timeout: str | None = _USE_REQUEST_DEFAULT,
+    raster_asset_cls: Any = None,
 ) -> None:
     """Take the datasets row, then the records row.
 
@@ -66,6 +67,13 @@ async def lock_catalog_rows(
     precede the transaction's FIRST write to either row, not merely sit in the
     same flush as both.
 
+    ``raster_asset_cls`` extends the order downwards for a transaction that
+    will also reach ``raster_assets`` -- by FK cascade from the records delete,
+    say. That row is taken FIRST, because the raster replace worker takes it
+    before the pair (``tasks_raster_replace``) and holds it across its upload.
+    A caller that took the pair first would wait on the worker while holding
+    rows the worker's own acquisition needs.
+
     Raises ``CatalogLockConflict`` on 55P03 or 40P01, having rolled back.
     """
     if lock_timeout is _USE_REQUEST_DEFAULT:
@@ -79,6 +87,12 @@ async def lock_catalog_rows(
     # autoflush here emits the ORM's own order, which is the inversion.
     try:
         with session.no_autoflush:
+            if raster_asset_cls is not None:
+                await session.execute(
+                    select(raster_asset_cls.dataset_id)
+                    .where(raster_asset_cls.dataset_id == dataset_id)
+                    .with_for_update()
+                )
             # One column on each table alone; a joined relationship would not
             # lock the joined row and would touch records first.
             await session.execute(

--- a/backend/app/platform/catalog_locks.py
+++ b/backend/app/platform/catalog_locks.py
@@ -56,30 +56,16 @@ async def lock_catalog_rows(
     lock_timeout: str | None = _USE_REQUEST_DEFAULT,
     raster_asset_cls: Any = None,
 ) -> None:
-    """Take the datasets row, then the records row.
+    """Lock the catalog rows for a write: ``raster_assets`` (when given), then
+    ``datasets``, then ``records``.
 
-    **THE ORDER: datasets first, records second.** Call this from any
-    transaction that will write both rows, before it writes either, and after
-    any network I/O or data-table work it does. Cite this docstring rather than
-    restating the rule.
+    Call it before the transaction's first write to either row, and after any
+    network I/O or data-table work. A writer that touches "only" one row still
+    needs it: stamping ``record.updated_by`` and rolling ``tile_cache_version``
+    is both, and the ORM flushes ``records`` before ``datasets`` on its own.
 
-    The order is the one the refresh workers and the VRT publish already take,
-    to make a superseded-content check and its dependent write indivisible.
-
-    Calling it is not optional for a writer that "only" touches one row.
-    Stamping ``record.updated_by`` and rolling ``tile_cache_version`` is both,
-    and SQLAlchemy flushes ``catalog.records`` first because
-    ``Dataset.record_id`` makes ``Record`` the parent mapper. A transaction
-    that acquires nothing therefore inverts by default. The acquisition must
-    precede the transaction's FIRST write to either row, not merely sit in the
-    same flush as both.
-
-    ``raster_asset_cls`` extends the order downwards for a transaction that
-    will also reach ``raster_assets`` -- by FK cascade from the records delete,
-    say. That row is taken FIRST, because the raster replace worker takes it
-    before the pair (``tasks_raster_replace``) and holds it across its upload.
-    A caller that took the pair first would wait on the worker while holding
-    rows the worker's own acquisition needs.
+    ``raster_asset_cls`` puts the raster child at the front of the order, for a
+    transaction that will also reach ``raster_assets``.
 
     Raises ``CatalogLockConflict`` on 55P03 or 40P01, having rolled back.
     """

--- a/backend/app/platform/catalog_locks.py
+++ b/backend/app/platform/catalog_locks.py
@@ -69,14 +69,7 @@ async def lock_catalog_rows(
 
     Raises ``CatalogLockConflict`` on 55P03 or 40P01, having rolled back.
     """
-    if lock_timeout is _USE_REQUEST_DEFAULT:
-        lock_timeout = REQUEST_LOCK_TIMEOUT
-    if lock_timeout is not None:
-        # `SET LOCAL` takes a literal; this value is a constant, never
-        # request-supplied.
-        await session.execute(text(f"SET LOCAL lock_timeout = '{lock_timeout}'"))
-        # Each request runs in its own task, so this cannot leak across them.
-        catalog_timeout_installed.set(True)
+    await _install_lock_timeout(session, lock_timeout)
 
     # `no_autoflush` so the order below is what reaches PostgreSQL: an
     # autoflush here emits the ORM's own order, which is the inversion.
@@ -104,10 +97,54 @@ async def lock_catalog_rows(
     except DBAPIError as exc:
         if not is_lock_conflict(exc):
             raise
-        # Roll back so the caller's retry is clean. Nothing is read off an ORM
-        # instance after this: rollback expires them, and a lazy load from the
-        # exception handler would raise MissingGreenlet instead of the 409.
-        await session.rollback()
-        raise CatalogLockConflict(
-            "Another operation is updating this dataset's catalog entry."
-        ) from exc
+        await _raise_rolled_back_conflict(session, exc)
+
+
+async def lock_ingest_jobs(
+    session: AsyncSession,
+    *,
+    job_cls: Any,
+    dataset_id: Any,
+    lock_timeout: str | None = _USE_REQUEST_DEFAULT,
+) -> None:
+    """Take a dataset's ingest-job rows, ahead of :func:`lock_catalog_rows`.
+
+    For a transaction whose delete cascades into ``ingest_jobs``: a worker
+    holds its job row before any data-table or catalog lock, so the deleter
+    takes those rows before either. Same timeout and exception contract.
+    """
+    await _install_lock_timeout(session, lock_timeout)
+    try:
+        with session.no_autoflush:
+            await session.execute(
+                select(job_cls.id)
+                .where(job_cls.dataset_id == dataset_id)
+                .with_for_update()
+            )
+    except DBAPIError as exc:
+        if not is_lock_conflict(exc):
+            raise
+        await _raise_rolled_back_conflict(session, exc)
+
+
+async def _install_lock_timeout(
+    session: AsyncSession, lock_timeout: str | None
+) -> None:
+    if lock_timeout is _USE_REQUEST_DEFAULT:
+        lock_timeout = REQUEST_LOCK_TIMEOUT
+    if lock_timeout is not None:
+        # `SET LOCAL` takes a literal; this value is a constant, never
+        # request-supplied.
+        await session.execute(text(f"SET LOCAL lock_timeout = '{lock_timeout}'"))
+        # Each request runs in its own task, so this cannot leak across them.
+        catalog_timeout_installed.set(True)
+
+
+async def _raise_rolled_back_conflict(session: AsyncSession, exc: DBAPIError) -> None:
+    # Roll back so the caller's retry is clean. Nothing is read off an ORM
+    # instance after this: rollback expires them, and a lazy load from the
+    # exception handler would raise MissingGreenlet instead of the 409.
+    await session.rollback()
+    raise CatalogLockConflict(
+        "Another operation is updating this dataset's catalog entry."
+    ) from exc

--- a/backend/app/platform/catalog_locks.py
+++ b/backend/app/platform/catalog_locks.py
@@ -41,9 +41,8 @@ catalog_timeout_installed: ContextVar[bool] = ContextVar(
 class CatalogLockConflict(Exception):
     """Another transaction holds the catalog rows this one needs.
 
-    Raised instead of a bare ``DBAPIError`` so one handler
-    (``app/api/main.py``) answers 409 wherever the acquisition is reached from.
-    A worker lets it propagate and fails its job.
+    One handler (``app/api/main.py``) answers 409 for it, wherever the
+    acquisition was reached from. A worker lets it propagate and fails its job.
     """
 
 

--- a/backend/app/platform/catalog_locks.py
+++ b/backend/app/platform/catalog_locks.py
@@ -7,6 +7,7 @@ the mapped classes ``ProcessingPort`` hands them.
 
 from __future__ import annotations
 
+from contextvars import ContextVar
 from typing import Any
 
 from sqlalchemy import select, text
@@ -28,6 +29,15 @@ _USE_REQUEST_DEFAULT: Any = object()
 # The machine-readable code for a contended row, wherever it is reported: the
 # 409 body, and a bulk-delete item that carries its conflict instead of raising.
 CATALOG_LOCK_CONFLICT_CODE = "catalog_lock_conflict"
+
+
+# Set when THIS request installed the catalog timeout. fix(#1847): without it
+# the boundary handler read any 40P01, and any 55P03 from another timeout site,
+# as a busy dataset -- mislabelling an unrelated deadlock and skipping the
+# class-40 operational logging it used to get.
+catalog_timeout_installed: ContextVar[bool] = ContextVar(
+    "catalog_timeout_installed", default=False
+)
 
 
 class CatalogLockConflict(Exception):
@@ -82,6 +92,8 @@ async def lock_catalog_rows(
         # `SET LOCAL` takes a literal; this value is a constant, never
         # request-supplied.
         await session.execute(text(f"SET LOCAL lock_timeout = '{lock_timeout}'"))
+        # Each request runs in its own task, so this cannot leak across them.
+        catalog_timeout_installed.set(True)
 
     # `no_autoflush` so the order below is what reaches PostgreSQL: an
     # autoflush here emits the ORM's own order, which is the inversion.

--- a/backend/app/platform/catalog_locks.py
+++ b/backend/app/platform/catalog_locks.py
@@ -1,8 +1,8 @@
-"""The one lock order for the (datasets, records) row pair (fix(#1847)).
+"""The one lock order for the (datasets, records) row pair (#1847).
 
-Lives in ``platform/`` because both halves of the application need it:
-``processing/`` may not import ``app.modules.catalog``, so worker callers pass
-the mapped classes ``ProcessingPort`` hands them.
+Lives in ``platform/`` because ``processing/`` may not import
+``app.modules.catalog``: worker callers pass the mapped classes the port hands
+them.
 """
 
 from __future__ import annotations
@@ -31,10 +31,8 @@ _USE_REQUEST_DEFAULT: Any = object()
 CATALOG_LOCK_CONFLICT_CODE = "catalog_lock_conflict"
 
 
-# Set when THIS request installed the catalog timeout. fix(#1847): without it
-# the boundary handler read any 40P01, and any 55P03 from another timeout site,
-# as a busy dataset -- mislabelling an unrelated deadlock and skipping the
-# class-40 operational logging it used to get.
+# fix(#1847): set when THIS request installed the catalog timeout, so the
+# boundary handler does not read an unrelated 40P01 as a busy dataset.
 catalog_timeout_installed: ContextVar[bool] = ContextVar(
     "catalog_timeout_installed", default=False
 )

--- a/backend/app/platform/catalog_locks.py
+++ b/backend/app/platform/catalog_locks.py
@@ -15,7 +15,10 @@ from __future__ import annotations
 from typing import Any
 
 from sqlalchemy import select, text
+from sqlalchemy.exc import DBAPIError
 from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.db.sqlstate import is_lock_conflict
 
 # The budget a REQUEST spends waiting for the pair. Matches
 # ``app.platform.jobs.router`` and ``catalog.maps.service_crud``, which spend
@@ -32,6 +35,24 @@ REQUEST_LOCK_TIMEOUT = "2s"
 # Resolved at CALL time, not bound as a default argument, so the value above is
 # the single source of truth (a default argument would snapshot it at import).
 _USE_REQUEST_DEFAULT: Any = object()
+
+
+class CatalogLockConflict(Exception):
+    """Another transaction holds the catalog rows this request needs.
+
+    fix(#1847 review r3): raised HERE rather than left as a DBAPIError for each
+    caller to classify, because they classified it four different ways. The
+    feature router mapped 55P03 to 409; the metadata PATCH caught only
+    ValueError, so the global DBAPIError handler called it an outage and
+    answered 503; the layer DDL routes read it as the caller's bad request and
+    answered 400. One exception with one handler (``app/api/main.py``) is what
+    makes the answer the same wherever the acquisition is reached from.
+
+    A worker sees it as an ordinary exception and fails its job, which is the
+    correct outcome there: the run ledger records the failure and the operator
+    retries. Workers pass ``lock_timeout=None``, so in practice they wait
+    rather than raise this at all.
+    """
 
 
 async def lock_catalog_rows(
@@ -82,16 +103,36 @@ async def lock_catalog_rows(
     # `no_autoflush` so the order below is what actually reaches PostgreSQL. An
     # autoflush triggered by either statement emits the ORM's own flush order,
     # which is the exact inversion this function exists to prevent.
-    with session.no_autoflush:
-        # One column, on each table alone. Reading through a joined
-        # relationship would not lock the joined row anyway, and would put the
-        # statement on the records row ahead of the lock it is ordering.
-        await session.execute(
-            select(dataset_cls.id).where(dataset_cls.id == dataset_id).with_for_update()
-        )
-        if record_id is not None:
+    try:
+        with session.no_autoflush:
+            # One column, on each table alone. Reading through a joined
+            # relationship would not lock the joined row anyway, and would put
+            # the statement on the records row ahead of the lock it is ordering.
             await session.execute(
-                select(record_cls.id)
-                .where(record_cls.id == record_id)
+                select(dataset_cls.id)
+                .where(dataset_cls.id == dataset_id)
                 .with_for_update()
             )
+            if record_id is not None:
+                await session.execute(
+                    select(record_cls.id)
+                    .where(record_cls.id == record_id)
+                    .with_for_update()
+                )
+    except DBAPIError as exc:
+        if not is_lock_conflict(exc):
+            raise
+        # Roll back here rather than leaving a failed transaction for the
+        # caller to trip over. Nothing this transaction did survives, which is
+        # the whole point: a caller that loses this race has written nothing,
+        # so its retry is clean.
+        #
+        # Memory trap, and the reason nothing is read off an ORM instance
+        # after this line: `rollback()` EXPIRES every instance in the session,
+        # so touching one from the exception handler would lazy-load in a
+        # context with no greenlet and raise MissingGreenlet instead of the
+        # 409. The message below is built from nothing but literals.
+        await session.rollback()
+        raise CatalogLockConflict(
+            "Another operation is updating this dataset's catalog entry."
+        ) from exc

--- a/backend/app/platform/catalog_locks.py
+++ b/backend/app/platform/catalog_locks.py
@@ -1,0 +1,97 @@
+"""The one lock order for the (datasets, records) row pair (fix(#1847)).
+
+Shared infrastructure rather than catalog code, for the same reason
+``platform/security.py`` is: both halves of the application need it. Request
+handlers under ``modules/catalog`` reach it directly; worker tasks under
+``processing/`` reach it with the ORM classes ``ProcessingPort`` hands them,
+because ``processing/`` may not import ``app.modules.catalog``
+(``test_no_processing_imports_catalog``). Parameterising on the two mapped
+classes is what lets one function serve both without either layer reaching
+past its boundary.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from sqlalchemy import select, text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+# The budget a REQUEST spends waiting for the pair. Matches
+# ``app.platform.jobs.router`` and ``catalog.maps.service_crud``, which spend
+# the same on the same question: a row lock still contended after two seconds
+# is held by another live writer, not by latency inside this request, and the
+# caller is better served by a retryable conflict than by an open-ended hang.
+#
+# A worker passes ``lock_timeout=None``. ``SET LOCAL`` applies to every lock
+# wait for the rest of the transaction, and clamping a multi-minute ingest
+# transaction to a request's budget would fail it on contention it is supposed
+# to wait out.
+REQUEST_LOCK_TIMEOUT = "2s"
+
+# Resolved at CALL time, not bound as a default argument, so the value above is
+# the single source of truth (a default argument would snapshot it at import).
+_USE_REQUEST_DEFAULT: Any = object()
+
+
+async def lock_catalog_rows(
+    session: AsyncSession,
+    *,
+    dataset_cls: Any,
+    record_cls: Any,
+    dataset_id: Any,
+    record_id: Any,
+    lock_timeout: str | None = _USE_REQUEST_DEFAULT,
+) -> None:
+    """Take the datasets row, then the records row. In that order, always.
+
+    **THE ORDER: datasets first, records second.** Call this from any
+    transaction that will write both rows, BEFORE it writes either. Cite this
+    docstring rather than restating the rule.
+
+    Why this order and not the other one. The two background refresh writers
+    (``processing/ingest/tasks_postgis_refresh.py`` and
+    ``tasks_stac_refresh.py``) take the datasets row ``FOR UPDATE`` to make a
+    superseded-content check and the write that depends on it one indivisible
+    step, and the VRT publish transaction takes it through its asset join. Those
+    are the sites that cannot give the order up, so the order is theirs.
+
+    Why calling this is not optional for a writer that "only" touches one row.
+    It is almost never only one. Stamping ``record.updated_by`` and rolling
+    ``tile_cache_version`` is already both, and SQLAlchemy's unit of work
+    flushes ``catalog.records`` BEFORE ``catalog.datasets`` because
+    ``Dataset.record_id`` makes ``Record`` the parent mapper. So a transaction
+    that acquires nothing acquires them in the inverted order by default, and
+    deadlocks (40P01) against any of the writers above. That is #1847, and it
+    is why ``tests/test_feature_lock_order_1847.py`` gates every such site.
+
+    Splitting the two acquisitions across two flushes is the same bug. The
+    acquisition has to precede the transaction's FIRST write to either row, not
+    merely sit in the same flush as both: the feature-write handlers dirty
+    ``record.updated_by``, flush it inside ``audit_emit``, and only then roll
+    the tile version, so a rule keyed on "both dirty in one flush" would not
+    have fired at all.
+    """
+    if lock_timeout is _USE_REQUEST_DEFAULT:
+        lock_timeout = REQUEST_LOCK_TIMEOUT
+    if lock_timeout is not None:
+        # `SET LOCAL` takes a literal, not a bind parameter; the value is a
+        # module constant or a caller's literal, never request-supplied data.
+        await session.execute(text(f"SET LOCAL lock_timeout = '{lock_timeout}'"))
+
+    # `no_autoflush` so the order below is what actually reaches PostgreSQL. An
+    # autoflush triggered by either statement emits the ORM's own flush order,
+    # which is the exact inversion this function exists to prevent.
+    with session.no_autoflush:
+        # One column, on each table alone. Reading through a joined
+        # relationship would not lock the joined row anyway, and would put the
+        # statement on the records row ahead of the lock it is ordering.
+        await session.execute(
+            select(dataset_cls.id).where(dataset_cls.id == dataset_id).with_for_update()
+        )
+        if record_id is not None:
+            await session.execute(
+                select(record_cls.id)
+                .where(record_cls.id == record_id)
+                .with_for_update()
+            )

--- a/backend/app/platform/catalog_locks.py
+++ b/backend/app/platform/catalog_locks.py
@@ -1,13 +1,8 @@
 """The one lock order for the (datasets, records) row pair (fix(#1847)).
 
-Shared infrastructure rather than catalog code, for the same reason
-``platform/security.py`` is: both halves of the application need it. Request
-handlers under ``modules/catalog`` reach it directly; worker tasks under
-``processing/`` reach it with the ORM classes ``ProcessingPort`` hands them,
-because ``processing/`` may not import ``app.modules.catalog``
-(``test_no_processing_imports_catalog``). Parameterising on the two mapped
-classes is what lets one function serve both without either layer reaching
-past its boundary.
+Lives in ``platform/`` because both halves of the application need it:
+``processing/`` may not import ``app.modules.catalog``, so worker callers pass
+the mapped classes ``ProcessingPort`` hands them.
 """
 
 from __future__ import annotations
@@ -20,38 +15,22 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.db.sqlstate import is_lock_conflict
 
-# The budget a REQUEST spends waiting for the pair. Matches
-# ``app.platform.jobs.router`` and ``catalog.maps.service_crud``, which spend
-# the same on the same question: a row lock still contended after two seconds
-# is held by another live writer, not by latency inside this request, and the
-# caller is better served by a retryable conflict than by an open-ended hang.
-#
-# A worker passes ``lock_timeout=None``. ``SET LOCAL`` applies to every lock
-# wait for the rest of the transaction, and clamping a multi-minute ingest
-# transaction to a request's budget would fail it on contention it is supposed
-# to wait out.
+# The budget a REQUEST spends waiting for the pair. A worker passes
+# ``lock_timeout=None``: ``SET LOCAL`` applies for the rest of the transaction,
+# and this budget would fail an ingest on contention it must wait out.
 REQUEST_LOCK_TIMEOUT = "2s"
 
-# Resolved at CALL time, not bound as a default argument, so the value above is
-# the single source of truth (a default argument would snapshot it at import).
+# Resolved at call time, not bound as a default, so the constant above stays
+# the single source of truth.
 _USE_REQUEST_DEFAULT: Any = object()
 
 
 class CatalogLockConflict(Exception):
-    """Another transaction holds the catalog rows this request needs.
+    """Another transaction holds the catalog rows this one needs.
 
-    fix(#1847 review r3): raised HERE rather than left as a DBAPIError for each
-    caller to classify, because they classified it four different ways. The
-    feature router mapped 55P03 to 409; the metadata PATCH caught only
-    ValueError, so the global DBAPIError handler called it an outage and
-    answered 503; the layer DDL routes read it as the caller's bad request and
-    answered 400. One exception with one handler (``app/api/main.py``) is what
-    makes the answer the same wherever the acquisition is reached from.
-
-    A worker sees it as an ordinary exception and fails its job, which is the
-    correct outcome there: the run ledger records the failure and the operator
-    retries. Workers pass ``lock_timeout=None``, so in practice they wait
-    rather than raise this at all.
+    Raised instead of a bare ``DBAPIError`` so one handler
+    (``app/api/main.py``) answers 409 wherever the acquisition is reached from.
+    A worker lets it propagate and fails its job.
     """
 
 
@@ -64,50 +43,39 @@ async def lock_catalog_rows(
     record_id: Any,
     lock_timeout: str | None = _USE_REQUEST_DEFAULT,
 ) -> None:
-    """Take the datasets row, then the records row. In that order, always.
+    """Take the datasets row, then the records row.
 
     **THE ORDER: datasets first, records second.** Call this from any
-    transaction that will write both rows, BEFORE it writes either. Cite this
-    docstring rather than restating the rule.
+    transaction that will write both rows, before it writes either, and after
+    any network I/O or data-table work it does. Cite this docstring rather than
+    restating the rule.
 
-    Why this order and not the other one. The two background refresh writers
-    (``processing/ingest/tasks_postgis_refresh.py`` and
-    ``tasks_stac_refresh.py``) take the datasets row ``FOR UPDATE`` to make a
-    superseded-content check and the write that depends on it one indivisible
-    step, and the VRT publish transaction takes it through its asset join. Those
-    are the sites that cannot give the order up, so the order is theirs.
+    The order is the one the refresh workers and the VRT publish already take,
+    to make a superseded-content check and its dependent write indivisible.
 
-    Why calling this is not optional for a writer that "only" touches one row.
-    It is almost never only one. Stamping ``record.updated_by`` and rolling
-    ``tile_cache_version`` is already both, and SQLAlchemy's unit of work
-    flushes ``catalog.records`` BEFORE ``catalog.datasets`` because
-    ``Dataset.record_id`` makes ``Record`` the parent mapper. So a transaction
-    that acquires nothing acquires them in the inverted order by default, and
-    deadlocks (40P01) against any of the writers above. That is #1847, and it
-    is why ``tests/test_feature_lock_order_1847.py`` gates every such site.
+    Calling it is not optional for a writer that "only" touches one row.
+    Stamping ``record.updated_by`` and rolling ``tile_cache_version`` is both,
+    and SQLAlchemy flushes ``catalog.records`` first because
+    ``Dataset.record_id`` makes ``Record`` the parent mapper. A transaction
+    that acquires nothing therefore inverts by default. The acquisition must
+    precede the transaction's FIRST write to either row, not merely sit in the
+    same flush as both.
 
-    Splitting the two acquisitions across two flushes is the same bug. The
-    acquisition has to precede the transaction's FIRST write to either row, not
-    merely sit in the same flush as both: the feature-write handlers dirty
-    ``record.updated_by``, flush it inside ``audit_emit``, and only then roll
-    the tile version, so a rule keyed on "both dirty in one flush" would not
-    have fired at all.
+    Raises ``CatalogLockConflict`` on 55P03 or 40P01, having rolled back.
     """
     if lock_timeout is _USE_REQUEST_DEFAULT:
         lock_timeout = REQUEST_LOCK_TIMEOUT
     if lock_timeout is not None:
-        # `SET LOCAL` takes a literal, not a bind parameter; the value is a
-        # module constant or a caller's literal, never request-supplied data.
+        # `SET LOCAL` takes a literal; this value is a constant, never
+        # request-supplied.
         await session.execute(text(f"SET LOCAL lock_timeout = '{lock_timeout}'"))
 
-    # `no_autoflush` so the order below is what actually reaches PostgreSQL. An
-    # autoflush triggered by either statement emits the ORM's own flush order,
-    # which is the exact inversion this function exists to prevent.
+    # `no_autoflush` so the order below is what reaches PostgreSQL: an
+    # autoflush here emits the ORM's own order, which is the inversion.
     try:
         with session.no_autoflush:
-            # One column, on each table alone. Reading through a joined
-            # relationship would not lock the joined row anyway, and would put
-            # the statement on the records row ahead of the lock it is ordering.
+            # One column on each table alone; a joined relationship would not
+            # lock the joined row and would touch records first.
             await session.execute(
                 select(dataset_cls.id)
                 .where(dataset_cls.id == dataset_id)
@@ -122,16 +90,9 @@ async def lock_catalog_rows(
     except DBAPIError as exc:
         if not is_lock_conflict(exc):
             raise
-        # Roll back here rather than leaving a failed transaction for the
-        # caller to trip over. Nothing this transaction did survives, which is
-        # the whole point: a caller that loses this race has written nothing,
-        # so its retry is clean.
-        #
-        # Memory trap, and the reason nothing is read off an ORM instance
-        # after this line: `rollback()` EXPIRES every instance in the session,
-        # so touching one from the exception handler would lazy-load in a
-        # context with no greenlet and raise MissingGreenlet instead of the
-        # 409. The message below is built from nothing but literals.
+        # Roll back so the caller's retry is clean. Nothing is read off an ORM
+        # instance after this: rollback expires them, and a lazy load from the
+        # exception handler would raise MissingGreenlet instead of the 409.
         await session.rollback()
         raise CatalogLockConflict(
             "Another operation is updating this dataset's catalog entry."

--- a/backend/app/platform/jobs/router.py
+++ b/backend/app/platform/jobs/router.py
@@ -1197,17 +1197,9 @@ async def cancel_job(
     # transaction, which holds its row locks from its first fenced update
     # through the swap to commit.
     #
-    # fix(#1709 review r2 P2): the try covers the WHOLE transactional block,
-    # not just the job CAS — a lock conflict inside the VRT reconciliation
-    # used to escape as a 500 — and for a vrt_regenerate job the FIRST lock
-    # taken is the RasterAsset row, because that is the first lock the
-    # worker's publish transaction takes (tasks_vrt phase 2: asset FOR UPDATE
-    # -> generation flush -> fenced job update). Both transactions leading
-    # with the asset makes it the VRT mutex: whoever holds it runs alone, the
-    # other waits at its first acquisition holding nothing, and the AB-BA
-    # cycle (worker: asset->...->job vs the old cancel: job->...->asset)
-    # cannot form. Non-VRT jobs keep the job row as their first lock, which
-    # already matches every other worker's order (fenced heartbeat first).
+    # fix(#1709 review r2 P2): the try covers the WHOLE transactional block;
+    # fix(#1847): every job type leads with the job row, the order the
+    # workers and the dataset delete hold.
     previous_attempt_id = job.attempt_id
     now = datetime.now(timezone.utc)
     attempt_predicate = (
@@ -1221,16 +1213,6 @@ async def cancel_job(
     )
     try:
         await db.execute(text("SET LOCAL lock_timeout = '2s'"))
-        if is_vrt_job:
-            # Deferred by design: platform -> processing stays function-local
-            # (D-17).
-            from app.processing.raster.models import RasterAsset
-
-            await db.execute(
-                select(RasterAsset.dataset_id)
-                .where(RasterAsset.dataset_id == job.dataset_id)
-                .with_for_update()
-            )
         cancel_result = await db.execute(
             update(IngestJob)
             .where(
@@ -1271,7 +1253,7 @@ async def cancel_job(
         if is_vrt_job:
             # fix(#1709 review P1): same transaction as the job CAS, so the
             # VRT state this job stranded and the job's terminal status land
-            # together. The asset row lock above is already held.
+            # together.
             await _reconcile_cancelled_vrt_regeneration(db, job.dataset_id, now)
         # fix(#1709 review r3 P2): an embedding backfill's dispatch commits an
         # `embedding.backfill` audit event at outcome="requested" alongside

--- a/backend/app/platform/jobs/router.py
+++ b/backend/app/platform/jobs/router.py
@@ -18,6 +18,7 @@ from sqlalchemy import func, select, text, update
 from sqlalchemy.exc import DBAPIError
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.db.sqlstate import is_lock_conflict
 from app.core.dependencies import get_client_ip, get_db
 from app.core.identity import Identity
 from app.modules.auth.dependencies import (
@@ -972,8 +973,14 @@ def _is_lock_conflict(exc: DBAPIError) -> bool:
     acquisition in ``cancel_job`` — fix(#1709 review r2 P2)), but mapping it
     costs one tuple member and turns a future ordering regression into a
     clean conflict instead of a 500.
+
+    fix(#1847): the pair moved to ``app.core.db.sqlstate`` when a third caller
+    needed it (the feature-write router). This wrapper is a rename, not a
+    policy: the shared predicate matches the same two states, and additionally
+    unwraps a bare asyncpg exception, which cannot reach this call site because
+    everything here goes through ``AsyncSession``.
     """
-    return getattr(exc.orig, "sqlstate", None) in ("55P03", "40P01")
+    return is_lock_conflict(exc)
 
 
 # The three VRT regeneration dispatch sites (regenerate_vrt_endpoint,

--- a/backend/app/platform/jobs/router.py
+++ b/backend/app/platform/jobs/router.py
@@ -974,11 +974,8 @@ def _is_lock_conflict(exc: DBAPIError) -> bool:
     costs one tuple member and turns a future ordering regression into a
     clean conflict instead of a 500.
 
-    fix(#1847): the pair moved to ``app.core.db.sqlstate`` when a third caller
-    needed it (the feature-write router). This wrapper is a rename, not a
-    policy: the shared predicate matches the same two states, and additionally
-    unwraps a bare asyncpg exception, which cannot reach this call site because
-    everything here goes through ``AsyncSession``.
+    fix(#1847): moved to ``app.core.db.sqlstate`` for a third caller. A rename,
+    not a policy change: the shared predicate matches the same two states.
     """
     return is_lock_conflict(exc)
 

--- a/backend/app/processing/ingest/tasks_common.py
+++ b/backend/app/processing/ingest/tasks_common.py
@@ -2089,12 +2089,17 @@ async def bump_tile_cache_version_atomic(
 
     A writer without that lock cannot use it, and taking the lock would not
     help: the feature-edit routers (``features/router.py``) bump through a
-    plain read-modify-write and never lock the row, so an absolute write
-    computed from a read they took earlier lands on top of anything committed
-    in between. One side locking does not serialize a race the other side is
-    not playing. ``tile_cache_version = tile_cache_version + 1`` in the
-    database does, because the increment is evaluated against the row as it
-    is at write time.
+    plain read-modify-write, so an absolute write computed from a read they
+    took earlier lands on top of anything committed in between. One side
+    locking does not serialize a race the other side is not playing.
+    ``tile_cache_version = tile_cache_version + 1`` in the database does,
+    because the increment is evaluated against the row as it is at write time.
+
+    fix(#1847): that paragraph used to add "and never lock the row", which
+    stopped being true when the metadata refresh started taking the datasets
+    row ``FOR UPDATE`` (see ``_lock_dataset_then_read_extent_box``). A PATCH
+    that changes no geometry skips the refresh and still bumps unlocked, so the
+    conclusion is unchanged -- but the reason is now "not on every path".
 
     Returns the new value, so the caller reports and logs the version it
     actually published rather than the one it hoped for. Still called in the

--- a/backend/app/processing/ingest/tasks_common.py
+++ b/backend/app/processing/ingest/tasks_common.py
@@ -2095,11 +2095,6 @@ async def bump_tile_cache_version_atomic(
     ``tile_cache_version = tile_cache_version + 1`` in the database does,
     because the increment is evaluated against the row as it is at write time.
 
-    fix(#1847): the feature-write handlers DO lock the row now, and the
-    conclusion is unchanged anyway: they read the counter off an instance
-    loaded before that lock, and a lock taken after the read does not make a
-    read-modify-write atomic.
-
     Returns the new value, so the caller reports and logs the version it
     actually published rather than the one it hoped for. Still called in the
     same transaction as the tile-content change it describes, which is the

--- a/backend/app/processing/ingest/tasks_common.py
+++ b/backend/app/processing/ingest/tasks_common.py
@@ -2429,6 +2429,26 @@ async def _apply_reupload_swap(
         await ensure_geom_4326_gist_index(session, table_name, schema=_tenant_schema)
 
     # Update dataset metadata in the same transaction as swap
+    # fix(#1847 review r2): the catalog writes start here. This function
+    # dirties the datasets row and dataset.record, and the flush would take
+    # them records-first, deadlocking against a request or a refresh holding
+    # the dataset row. `lock_timeout=None`: SET LOCAL applies for the rest of
+    # the transaction, and clamping an ingest swap to a request's two seconds
+    # would fail it on contention it is supposed to wait out. See
+    # app.platform.catalog_locks.lock_catalog_rows for the order.
+    from app.platform.catalog_locks import lock_catalog_rows
+    from app.platform.extensions import get_processing_port
+
+    _port = get_processing_port()
+    await lock_catalog_rows(
+        session,
+        dataset_cls=_port.get_dataset_orm_class(),
+        record_cls=_port.get_record_orm_class(),
+        dataset_id=dataset.id,
+        record_id=dataset.record_id,
+        lock_timeout=None,
+    )
+
     dataset.srid = metadata["srid"]
     dataset.geometry_type = effective_geometry_type
     # fix(#1361): modality is derived, so keep deriving it. `service_create.py`

--- a/backend/app/processing/ingest/tasks_common.py
+++ b/backend/app/processing/ingest/tasks_common.py
@@ -2096,10 +2096,13 @@ async def bump_tile_cache_version_atomic(
     because the increment is evaluated against the row as it is at write time.
 
     fix(#1847): that paragraph used to add "and never lock the row", which
-    stopped being true when the metadata refresh started taking the datasets
-    row ``FOR UPDATE`` (see ``_lock_dataset_then_read_extent_box``). A PATCH
-    that changes no geometry skips the refresh and still bumps unlocked, so the
-    conclusion is unchanged -- but the reason is now "not on every path".
+    stopped being true: every feature-write handler now takes the datasets row
+    ``FOR UPDATE`` before it dirties either catalog row (see
+    ``lock_catalog_rows_for_write``). The conclusion above is unchanged all the
+    same, for a sharper reason than the original one. Those handlers read the
+    counter off an instance loaded BEFORE that lock, so the absolute value they
+    compute from it can still land on top of something committed in between. A
+    lock taken after the read does not make a read-modify-write atomic.
 
     Returns the new value, so the caller reports and logs the version it
     actually published rather than the one it hoped for. Still called in the

--- a/backend/app/processing/ingest/tasks_common.py
+++ b/backend/app/processing/ingest/tasks_common.py
@@ -2095,14 +2095,10 @@ async def bump_tile_cache_version_atomic(
     ``tile_cache_version = tile_cache_version + 1`` in the database does,
     because the increment is evaluated against the row as it is at write time.
 
-    fix(#1847): that paragraph used to add "and never lock the row", which
-    stopped being true: every feature-write handler now takes the datasets row
-    ``FOR UPDATE`` before it dirties either catalog row (see
-    ``lock_catalog_rows_for_write``). The conclusion above is unchanged all the
-    same, for a sharper reason than the original one. Those handlers read the
-    counter off an instance loaded BEFORE that lock, so the absolute value they
-    compute from it can still land on top of something committed in between. A
-    lock taken after the read does not make a read-modify-write atomic.
+    fix(#1847): the feature-write handlers DO lock the row now, and the
+    conclusion is unchanged anyway: they read the counter off an instance
+    loaded before that lock, and a lock taken after the read does not make a
+    read-modify-write atomic.
 
     Returns the new value, so the caller reports and logs the version it
     actually published rather than the one it hoped for. Still called in the
@@ -2429,13 +2425,9 @@ async def _apply_reupload_swap(
         await ensure_geom_4326_gist_index(session, table_name, schema=_tenant_schema)
 
     # Update dataset metadata in the same transaction as swap
-    # fix(#1847 review r2): the catalog writes start here. This function
-    # dirties the datasets row and dataset.record, and the flush would take
-    # them records-first, deadlocking against a request or a refresh holding
-    # the dataset row. `lock_timeout=None`: SET LOCAL applies for the rest of
-    # the transaction, and clamping an ingest swap to a request's two seconds
-    # would fail it on contention it is supposed to wait out. See
-    # app.platform.catalog_locks.lock_catalog_rows for the order.
+    # fix(#1847): the catalog writes start here, and this function dirties both
+    # rows. `lock_timeout=None` so SET LOCAL does not clamp an ingest swap to a
+    # request's budget.
     from app.platform.catalog_locks import lock_catalog_rows
     from app.platform.extensions import get_processing_port
 

--- a/backend/app/processing/ingest/tasks_postgis_refresh.py
+++ b/backend/app/processing/ingest/tasks_postgis_refresh.py
@@ -918,17 +918,9 @@ async def refresh_postgis(
             # Reading a single column keeps the statement off the joined
             # record, which PostgreSQL will not lock through an outer join.
             #
-            # This lock is also the FIRST half of the house lock order for the
-            # (datasets, records) pair: datasets first, records second. This
-            # transaction goes on to write the record row in `_apply_measurement`
-            # below, so the order is load-bearing rather than incidental, and it
-            # cannot be reversed without breaking the indivisibility above.
-            # fix(#1847): the feature-edit path used to take the records row
-            # first, which made an ordinary edit during this phase an ABBA
-            # deadlock. The authoritative statement of the order, and the
-            # reasoning behind choosing this one, is the docstring on
-            # `lock_catalog_rows` in `app/platform/catalog_locks.py` -- the
-            # module this layer may import, unlike the catalog-side wrapper.
+            # fix(#1847): also the first half of the house (datasets, records)
+            # order, since `_apply_measurement` writes the record row below.
+            # The order is stated in `app/platform/catalog_locks.py`.
             #
             # What this guard is NOT (review round 6): it does not detect the
             # OWNER writing to the table directly, because nothing outside

--- a/backend/app/processing/ingest/tasks_postgis_refresh.py
+++ b/backend/app/processing/ingest/tasks_postgis_refresh.py
@@ -927,8 +927,8 @@ async def refresh_postgis(
             # first, which made an ordinary edit during this phase an ABBA
             # deadlock. The authoritative statement of the order, and the
             # reasoning behind choosing this one, is the docstring on
-            # `lock_catalog_rows_for_write` in
-            # `app/modules/catalog/features/service.py`.
+            # `lock_catalog_rows` in `app/platform/catalog_locks.py` -- the
+            # module this layer may import, unlike the catalog-side wrapper.
             #
             # What this guard is NOT (review round 6): it does not detect the
             # OWNER writing to the table directly, because nothing outside

--- a/backend/app/processing/ingest/tasks_postgis_refresh.py
+++ b/backend/app/processing/ingest/tasks_postgis_refresh.py
@@ -927,7 +927,7 @@ async def refresh_postgis(
             # first, which made an ordinary edit during this phase an ABBA
             # deadlock. The authoritative statement of the order, and the
             # reasoning behind choosing this one, is the docstring on
-            # `_lock_dataset_then_read_extent_box` in
+            # `lock_catalog_rows_for_write` in
             # `app/modules/catalog/features/service.py`.
             #
             # What this guard is NOT (review round 6): it does not detect the

--- a/backend/app/processing/ingest/tasks_postgis_refresh.py
+++ b/backend/app/processing/ingest/tasks_postgis_refresh.py
@@ -935,6 +935,13 @@ async def refresh_postgis(
             # this whole feature exists to correct, on demand. What the guard
             # closes is the different and fixable problem: GeoLens rolling
             # BACK its own newer measurement.
+            # fix(#1847): the job row first, the order every worker phase and
+            # the dataset delete hold; the finalize write below touches it.
+            await session.execute(
+                select(IngestJob.id)
+                .where(IngestJob.id == job_uuid)
+                .with_for_update(key_share=True)
+            )
             locked_version = await session.scalar(
                 select(Dataset.tile_cache_version)
                 .where(Dataset.id == dataset_uuid)

--- a/backend/app/processing/ingest/tasks_postgis_refresh.py
+++ b/backend/app/processing/ingest/tasks_postgis_refresh.py
@@ -918,6 +918,18 @@ async def refresh_postgis(
             # Reading a single column keeps the statement off the joined
             # record, which PostgreSQL will not lock through an outer join.
             #
+            # This lock is also the FIRST half of the house lock order for the
+            # (datasets, records) pair: datasets first, records second. This
+            # transaction goes on to write the record row in `_apply_measurement`
+            # below, so the order is load-bearing rather than incidental, and it
+            # cannot be reversed without breaking the indivisibility above.
+            # fix(#1847): the feature-edit path used to take the records row
+            # first, which made an ordinary edit during this phase an ABBA
+            # deadlock. The authoritative statement of the order, and the
+            # reasoning behind choosing this one, is the docstring on
+            # `_lock_dataset_then_read_extent_box` in
+            # `app/modules/catalog/features/service.py`.
+            #
             # What this guard is NOT (review round 6): it does not detect the
             # OWNER writing to the table directly, because nothing outside
             # GeoLens bumps a catalog field. That is deliberate and not a gap

--- a/backend/app/processing/ingest/tasks_raster_replace.py
+++ b/backend/app/processing/ingest/tasks_raster_replace.py
@@ -620,6 +620,24 @@ async def reupload_raster(
             # that decides where this dataset lands on the map is which CRS
             # they are read under. `original_srid` is the one field still taken
             # from `source_meta`, and it wants the upload's answer by design.
+            # fix(#1847 review r2): `_write_swapped_fields` dirties the
+            # datasets row AND dataset.record, and the flush would take them
+            # records-first. The RasterAsset lock above orders this against the
+            # VRT paths but says nothing about the catalog pair. `lock_timeout=
+            # None` because SET LOCAL would otherwise clamp the rest of this
+            # ingest transaction to a request's budget. See
+            # app.platform.catalog_locks.lock_catalog_rows for the order.
+            from app.platform.catalog_locks import lock_catalog_rows
+
+            await lock_catalog_rows(
+                session,
+                dataset_cls=Dataset,
+                record_cls=type(dataset.record),
+                dataset_id=dataset.id,
+                record_id=dataset.record_id,
+                lock_timeout=None,
+            )
+
             new_version = _write_swapped_fields(
                 raster_asset,
                 dataset,

--- a/backend/app/processing/ingest/tasks_raster_replace.py
+++ b/backend/app/processing/ingest/tasks_raster_replace.py
@@ -620,11 +620,8 @@ async def reupload_raster(
             # that decides where this dataset lands on the map is which CRS
             # they are read under. `original_srid` is the one field still taken
             # from `source_meta`, and it wants the upload's answer by design.
-            # fix(#1847 review r3): this assigns attributes in memory and
-            # issues no SQL, so it is not yet a write to either catalog row.
-            # The pair is taken further down, immediately before the first
-            # statement that flushes them -- see the acquisition above
-            # `reserve_replacement_bytes`.
+            # fix(#1847): assigns in memory and issues no SQL, so the pair is
+            # taken further down, before the first statement that flushes it.
             new_version = _write_swapped_fields(
                 raster_asset,
                 dataset,
@@ -655,9 +652,8 @@ async def reupload_raster(
             # It runs HERE — before the reservation — because its bytes are
             # part of the total being admitted and because a genuinely new
             # object has to join the written set before anything can fail.
-            # See the acquisition below: the catalog rows are dirty in memory
-            # from `_write_swapped_fields` and must not be flushed out ahead of
-            # it (fix(#1847 review r3)).
+            # fix(#1847): the catalog rows are dirty in memory and must not be
+            # flushed out ahead of the acquisition below.
             with session.no_autoflush:
                 (
                     lossy_original_archived,
@@ -690,20 +686,9 @@ async def reupload_raster(
             # for why the ordering is load-bearing. Raises
             # StorageQuotaExceededError, which the task's broad handler records
             # as a failed run, leaving the previous raster serving.
-            # fix(#1847 review r3): HERE, not before `_write_swapped_fields`.
-            # Between the two sits `archive_lossy_original`, which PUTs the
-            # whole original raster to object storage. Holding both catalog
-            # rows across a multi-GB upload is the #1848 class: this worker
-            # passes `lock_timeout=None`, so it never gives the rows back, and
-            # every request-side waiter has a two-second budget. Nothing above
-            # writes either row -- the swap helper only assigns attributes --
-            # so the acquisition still precedes the first actual write, which
-            # is the autoflush `reserve_replacement_bytes` triggers below.
-            #
-            # `no_autoflush` around the archive is what makes that a guarantee
-            # rather than a measurement: without it, any statement added to the
-            # archive path later would flush the dirty attributes and take the
-            # rows records-first, ahead of this acquisition.
+            # fix(#1847): below `archive_lossy_original`, which PUTs the whole
+            # original raster; holding the pair across that upload is the #1848
+            # class. Still ahead of the first write, the autoflush below.
             from app.platform.catalog_locks import lock_catalog_rows
 
             await lock_catalog_rows(

--- a/backend/app/processing/ingest/tasks_raster_replace.py
+++ b/backend/app/processing/ingest/tasks_raster_replace.py
@@ -620,24 +620,11 @@ async def reupload_raster(
             # that decides where this dataset lands on the map is which CRS
             # they are read under. `original_srid` is the one field still taken
             # from `source_meta`, and it wants the upload's answer by design.
-            # fix(#1847 review r2): `_write_swapped_fields` dirties the
-            # datasets row AND dataset.record, and the flush would take them
-            # records-first. The RasterAsset lock above orders this against the
-            # VRT paths but says nothing about the catalog pair. `lock_timeout=
-            # None` because SET LOCAL would otherwise clamp the rest of this
-            # ingest transaction to a request's budget. See
-            # app.platform.catalog_locks.lock_catalog_rows for the order.
-            from app.platform.catalog_locks import lock_catalog_rows
-
-            await lock_catalog_rows(
-                session,
-                dataset_cls=Dataset,
-                record_cls=type(dataset.record),
-                dataset_id=dataset.id,
-                record_id=dataset.record_id,
-                lock_timeout=None,
-            )
-
+            # fix(#1847 review r3): this assigns attributes in memory and
+            # issues no SQL, so it is not yet a write to either catalog row.
+            # The pair is taken further down, immediately before the first
+            # statement that flushes them -- see the acquisition above
+            # `reserve_replacement_bytes`.
             new_version = _write_swapped_fields(
                 raster_asset,
                 dataset,
@@ -668,25 +655,29 @@ async def reupload_raster(
             # It runs HERE — before the reservation — because its bytes are
             # part of the total being admitted and because a genuinely new
             # object has to join the written set before anything can fail.
-            (
-                lossy_original_archived,
-                archived_key,
-                archived_bytes,
-                new_archive_key,
-            ) = await archive_lossy_original(
-                session,
-                job=job,
-                dataset_id=dataset.id,
-                file_path=file_path,
-                source_sha256=source_sha256,
-                filename=source_filename,
-                log_message=(
-                    "Failed to archive the lossy replacement original; the "
-                    "staged upload will be retained in place instead"
-                ),
-                needed=not source_preserved_in_cog,
-                written_storage_keys=written_storage_keys,
-            )
+            # See the acquisition below: the catalog rows are dirty in memory
+            # from `_write_swapped_fields` and must not be flushed out ahead of
+            # it (fix(#1847 review r3)).
+            with session.no_autoflush:
+                (
+                    lossy_original_archived,
+                    archived_key,
+                    archived_bytes,
+                    new_archive_key,
+                ) = await archive_lossy_original(
+                    session,
+                    job=job,
+                    dataset_id=dataset.id,
+                    file_path=file_path,
+                    source_sha256=source_sha256,
+                    filename=source_filename,
+                    log_message=(
+                        "Failed to archive the lossy replacement original; the "
+                        "staged upload will be retained in place instead"
+                    ),
+                    needed=not source_preserved_in_cog,
+                    written_storage_keys=written_storage_keys,
+                )
             # Only an object this attempt CREATED joins the written set. An
             # archive that already existed belongs to an earlier successful
             # replace, and reaping it on failure would destroy the original of
@@ -699,6 +690,31 @@ async def reupload_raster(
             # for why the ordering is load-bearing. Raises
             # StorageQuotaExceededError, which the task's broad handler records
             # as a failed run, leaving the previous raster serving.
+            # fix(#1847 review r3): HERE, not before `_write_swapped_fields`.
+            # Between the two sits `archive_lossy_original`, which PUTs the
+            # whole original raster to object storage. Holding both catalog
+            # rows across a multi-GB upload is the #1848 class: this worker
+            # passes `lock_timeout=None`, so it never gives the rows back, and
+            # every request-side waiter has a two-second budget. Nothing above
+            # writes either row -- the swap helper only assigns attributes --
+            # so the acquisition still precedes the first actual write, which
+            # is the autoflush `reserve_replacement_bytes` triggers below.
+            #
+            # `no_autoflush` around the archive is what makes that a guarantee
+            # rather than a measurement: without it, any statement added to the
+            # archive path later would flush the dirty attributes and take the
+            # rows records-first, ahead of this acquisition.
+            from app.platform.catalog_locks import lock_catalog_rows
+
+            await lock_catalog_rows(
+                session,
+                dataset_cls=Dataset,
+                record_cls=type(dataset.record),
+                dataset_id=dataset.id,
+                record_id=dataset.record_id,
+                lock_timeout=None,
+            )
+
             await reserve_replacement_bytes(
                 session,
                 dataset_id=dataset_uuid,

--- a/backend/app/processing/ingest/tasks_stac_refresh.py
+++ b/backend/app/processing/ingest/tasks_stac_refresh.py
@@ -576,11 +576,16 @@ async def refresh_stac(
             # the compare and the write one indivisible step; a single-column
             # select keeps the statement off any joined relationship, which
             # PostgreSQL will not lock through an outer join.
-            # fix(#1847): the raster child before the datasets row, the order
-            # the is_dem PATCH and the raster replace hold; the moved-asset
-            # write below touches that row after this guard.
+            # fix(#1847): the job row, then the raster child, then the
+            # datasets row: the order the replace worker and the dataset
+            # delete hold; the finalize write below touches the job row.
             from app.processing.raster.models import RasterAsset
 
+            await session.execute(
+                select(IngestJob.id)
+                .where(IngestJob.id == job_uuid)
+                .with_for_update(key_share=True)
+            )
             await session.execute(
                 select(RasterAsset.dataset_id)
                 .where(RasterAsset.dataset_id == dataset_uuid)

--- a/backend/app/processing/ingest/tasks_stac_refresh.py
+++ b/backend/app/processing/ingest/tasks_stac_refresh.py
@@ -576,6 +576,16 @@ async def refresh_stac(
             # the compare and the write one indivisible step; a single-column
             # select keeps the statement off any joined relationship, which
             # PostgreSQL will not lock through an outer join.
+            # fix(#1847): the raster child before the datasets row, the order
+            # the is_dem PATCH and the raster replace hold; the moved-asset
+            # write below touches that row after this guard.
+            from app.processing.raster.models import RasterAsset
+
+            await session.execute(
+                select(RasterAsset.dataset_id)
+                .where(RasterAsset.dataset_id == dataset_uuid)
+                .with_for_update()
+            )
             locked = (
                 await session.execute(
                     select(

--- a/backend/app/processing/ingest/tasks_vrt.py
+++ b/backend/app/processing/ingest/tasks_vrt.py
@@ -1391,15 +1391,9 @@ async def regenerate_vrt(
                 )
                 vrt_dataset = dataset_result.scalar_one_or_none()
                 if vrt_dataset is not None:
-                    # fix(#1847 review r2): the writes below dirty the datasets
-                    # row AND vrt_dataset.record. The asset SELECT above joins
-                    # Dataset under a plain FOR UPDATE, so PostgreSQL already
-                    # locks this datasets row -- but incidentally, as a property
-                    # of the join rather than by intent, and nothing here says
-                    # so to the next reader. State it. Already held, so this
-                    # costs a no-op re-lock. `lock_timeout=None` keeps SET LOCAL
-                    # out of a worker transaction. See
-                    # app.platform.catalog_locks.lock_catalog_rows.
+                    # fix(#1847): the writes below dirty both rows. The asset
+                    # SELECT above already locks this datasets row through its
+                    # join, incidentally; state it. A no-op re-lock.
                     from app.platform.catalog_locks import lock_catalog_rows
 
                     await lock_catalog_rows(

--- a/backend/app/processing/ingest/tasks_vrt.py
+++ b/backend/app/processing/ingest/tasks_vrt.py
@@ -1391,6 +1391,25 @@ async def regenerate_vrt(
                 )
                 vrt_dataset = dataset_result.scalar_one_or_none()
                 if vrt_dataset is not None:
+                    # fix(#1847 review r2): the writes below dirty the datasets
+                    # row AND vrt_dataset.record. The asset SELECT above joins
+                    # Dataset under a plain FOR UPDATE, so PostgreSQL already
+                    # locks this datasets row -- but incidentally, as a property
+                    # of the join rather than by intent, and nothing here says
+                    # so to the next reader. State it. Already held, so this
+                    # costs a no-op re-lock. `lock_timeout=None` keeps SET LOCAL
+                    # out of a worker transaction. See
+                    # app.platform.catalog_locks.lock_catalog_rows.
+                    from app.platform.catalog_locks import lock_catalog_rows
+
+                    await lock_catalog_rows(
+                        session,
+                        dataset_cls=Dataset,
+                        record_cls=type(vrt_dataset.record),
+                        dataset_id=vrt_dataset.id,
+                        record_id=vrt_dataset.record_id,
+                        lock_timeout=None,
+                    )
                     # feat(#1267) / ADR-002 Decision 5a: project the
                     # generation's completion instant into last_refreshed_at,
                     # in the SAME transaction as the generation swap, so

--- a/backend/app/processing/ingest/tasks_vrt.py
+++ b/backend/app/processing/ingest/tasks_vrt.py
@@ -1258,31 +1258,18 @@ async def regenerate_vrt(
         # separate stale-generation mechanism (`sweep_stale_vrt_assets`) on
         # their own timeout, independent of this fence.
         #
-        # fix(#1778 audit r12): deliberately NOT locked here, unlike the
-        # sibling phase-2 sites. This job row is loaded BEFORE the RasterAsset
-        # row a few lines down, and `cancel_job` (jobs/router.py) takes those
-        # two locks in the opposite order for a vrt_regenerate job (asset
-        # first, job second) specifically to avoid an AB-BA deadlock between
-        # itself and this worker -- see that function's own comment on why
-        # asset-first is the worker's invariant. Locking the job row here
-        # would put it back in job-then-asset order and reopen exactly that
-        # cycle. The residual TOCTOU this leaves is narrow and already
-        # bounded: the objects above are written either way and reaped by
-        # `sweep_stale_vrt_assets` on their own timeout regardless of this
-        # fence, and `current_generation_id` still refuses a stale publish
-        # once a newer generation exists. What a sweep-inserted status flip
-        # in this exact window could still do is let a paused-not-dead worker
-        # complete over a row the sweep just failed, the same class round 11
-        # already narrowed considerably; closing it completely here is not
-        # worth reordering these two locks.
+        # fix(#1847): the job row first, then the asset: the order every
+        # worker phase, `cancel_job` and the dataset delete hold.
         # ----------------------------------------------------------------- #
         async with async_session() as session:
             result = await session.execute(
-                select(IngestJob).where(
+                select(IngestJob)
+                .where(
                     IngestJob.id == job_uuid,
                     IngestJob.attempt_id == attempt_uuid,
                     IngestJob.status == "running",
                 )
+                .with_for_update(key_share=True)
             )
             job = result.scalar_one_or_none()
             if job is None:

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -2331,6 +2331,17 @@
               }
             ],
             "title": "Detail"
+          },
+          "code": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Code"
           }
         },
         "required": [

--- a/backend/tests/test_dataset_delete_tile_cache_purge.py
+++ b/backend/tests/test_dataset_delete_tile_cache_purge.py
@@ -97,7 +97,10 @@ async def _run_delete(dataset: MagicMock) -> str:
         ),
         patch("app.platform.storage.provider.get_storage", return_value=_MockStorage()),
     ):
-        return await delete_dataset(session, dataset.id, dataset.record.title)
+        # fix(#1847): delete_dataset returns a DatasetDeletion now; these
+        # tests are about the tile purge, so hand back the table name.
+        deletion = await delete_dataset(session, dataset.id, dataset.record.title)
+        return deletion.table_name
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_feature_lock_order_1847.py
+++ b/backend/tests/test_feature_lock_order_1847.py
@@ -97,6 +97,58 @@ async def _seed_dataset(session, *, created_by: uuid.UUID) -> Dataset:
     return dataset
 
 
+async def _seed_raster_dataset(session, *, created_by: uuid.UUID) -> Dataset:
+    """A raster dataset with its RasterAsset child, for the delete path.
+
+    No data table: `delete_dataset`'s raster branch reaps storage prefixes and
+    drops nothing, and the record delete cascades to `raster_assets`.
+    """
+    from app.processing.raster.models import RasterAsset
+
+    record = Record(
+        title=f"Lock order raster {uuid.uuid4().hex[:8]}",
+        summary="Fixture raster",
+        theme_category=["test"],
+        visibility="private",
+        record_status="published",
+        record_type="raster_dataset",
+        created_by=created_by,
+    )
+    session.add(record)
+    await session.flush()
+    dataset = Dataset(
+        record_id=record.id,
+        table_name=f"raster_{uuid.uuid4().hex[:8]}",
+        srid=4326,
+        geometry_type=None,
+        feature_count=0,
+        column_info=[],
+        source_format="geotiff",
+    )
+    session.add(dataset)
+    await session.flush()
+    session.add(
+        RasterAsset(
+            dataset_id=dataset.id,
+            asset_uri=f"rasters/{dataset.id}/source.cog.tif",
+        )
+    )
+    await session.commit()
+    await session.refresh(dataset)
+    return dataset
+
+
+@pytest.fixture
+async def locked_raster_dataset(client: AsyncClient, test_db_session):
+    admin_id = await get_user_id(test_db_session, "admin")
+    dataset = await _seed_raster_dataset(test_db_session, created_by=admin_id)
+    yield dataset
+    await test_db_session.execute(
+        text("DELETE FROM catalog.records WHERE id = :r"), {"r": dataset.record_id}
+    )
+    await test_db_session.commit()
+
+
 @pytest.fixture
 async def locked_dataset(client: AsyncClient, test_db_session):
     admin_id = await get_user_id(test_db_session, "admin")
@@ -1086,6 +1138,142 @@ class TestOneShapeForEveryContendedRow:
                     text(f"DROP TABLE IF EXISTS data.{d.table_name}")
                 )
             await test_db_session.commit()
+
+
+class TestTheRasterChildIsHeldBeforeTheReap:
+    """codex r5 P1: the delete reaps raster objects it may not get to commit.
+
+    The replace worker holds the RasterAsset row across its upload and only
+    then takes the pair. A delete that took the pair, reaped the raster prefix,
+    and met that row for the first time at the cascade would wait on the worker
+    with the bytes already gone.
+    """
+
+    async def test_a_held_raster_row_stops_the_delete_before_it_reaps(
+        self,
+        locked_raster_dataset,
+        client: AsyncClient,
+        admin_auth_header,
+        monkeypatch,
+    ):
+        monkeypatch.setattr(catalog_locks, "REQUEST_LOCK_TIMEOUT", "150ms")
+        import app.core.db as db_module
+        from app.modules.catalog.datasets.domain import service_lifecycle
+        from app.processing.raster.models import RasterAsset
+
+        reaped: list = []
+
+        async def _record_only(prefixes, tenant_id):
+            reaped.append(tuple(prefixes))
+
+        monkeypatch.setattr(service_lifecycle, "_reap_managed_storage", _record_only)
+
+        title = locked_raster_dataset.record.title
+        async with db_module.async_session() as holder:
+            # Exactly what the replace worker holds across its upload.
+            await holder.execute(
+                select(RasterAsset.dataset_id)
+                .where(RasterAsset.dataset_id == locked_raster_dataset.id)
+                .with_for_update()
+            )
+            response = await client.request(
+                "DELETE",
+                f"/datasets/{locked_raster_dataset.id}",
+                json={"confirm_title": title},
+                headers=admin_auth_header,
+            )
+            await holder.rollback()
+
+        assert response.status_code == 409, response.text
+        assert response.json()["detail"]["code"] == "catalog_lock_conflict"
+        assert reaped == [], (
+            "the delete reaped storage before it held the raster row, so those "
+            f"objects are gone and the dataset is not: {reaped}"
+        )
+
+
+class TestALaterLockWaitAnswersTheSameWay:
+    """codex r5 P2: the timeout outlives the acquisition it was set for.
+
+    `SET LOCAL lock_timeout` holds for the whole transaction, so a wait after
+    the pair is taken raises 55P03 from a statement the acquisition's own
+    translation never wrapped.
+    """
+
+    async def test_is_dem_contending_on_the_raster_row_answers_409(
+        self, locked_dataset, client: AsyncClient, admin_auth_header, monkeypatch
+    ):
+        monkeypatch.setattr(catalog_locks, "REQUEST_LOCK_TIMEOUT", "150ms")
+        import app.core.db as db_module
+        from app.processing.raster.models import RasterAsset
+
+        async with db_module.async_session() as owner:
+            owner.add(
+                RasterAsset(
+                    dataset_id=locked_dataset.id,
+                    asset_uri=f"rasters/{locked_dataset.id}/source.cog.tif",
+                )
+            )
+            await owner.commit()
+
+        try:
+            async with db_module.async_session() as holder:
+                await holder.execute(
+                    select(RasterAsset.dataset_id)
+                    .where(RasterAsset.dataset_id == locked_dataset.id)
+                    .with_for_update()
+                )
+                # tile_columns takes the pair; is_dem then writes the raster
+                # row, which the holder has.
+                response = await client.patch(
+                    f"/datasets/{locked_dataset.id}",
+                    json={"tile_columns": ["name"], "is_dem": True},
+                    headers=admin_auth_header,
+                )
+                await holder.rollback()
+
+            assert response.status_code == 409, response.text
+            assert response.json()["detail"]["code"] == "catalog_lock_conflict"
+        finally:
+            async with db_module.async_session() as cleanup:
+                await cleanup.execute(
+                    text("DELETE FROM catalog.raster_assets WHERE dataset_id = :d"),
+                    {"d": locked_dataset.id},
+                )
+                await cleanup.commit()
+
+
+class TestRecoverySurvivesANonMappedIdentity:
+    """codex r5 P2: the recovery path assumed the actor was a mapped User.
+
+    An `IdentityExtension` supplies an identity that is not a mapped instance,
+    and `AsyncSession.refresh()` raises `UnmappedInstanceError` on one -- from
+    inside the handler that exists to keep one bad item from taking the rest.
+    """
+
+    async def test_refresh_is_skipped_for_an_unmapped_identity(self):
+        from app.modules.catalog.datasets.api.router import _rollback_failed_item
+
+        class _Identity:
+            """What an overlay supplies: the protocol surface, no mapper."""
+
+            id = uuid.UUID("00000000-0000-0000-0000-0000000000aa")
+            username = "overlay"
+
+        refreshed: list = []
+
+        class _Session:
+            async def rollback(self):
+                return None
+
+            async def refresh(self, obj):
+                refreshed.append(obj)
+
+        await _rollback_failed_item(_Session(), _Identity())
+        assert refreshed == [], (
+            "refresh() was called on an identity with no mapper; it raises "
+            "UnmappedInstanceError there, aborting the recovery path"
+        )
 
 
 class TestTheOtherSitesHoldTheOrderToo:

--- a/backend/tests/test_feature_lock_order_1847.py
+++ b/backend/tests/test_feature_lock_order_1847.py
@@ -122,6 +122,35 @@ async def _await_lock_wait(probe, pid: int) -> None:
     )
 
 
+async def _await_waiter_on(probe, holder_xid: str) -> None:
+    """Block until somebody is queued behind transaction *holder_xid*.
+
+    The HTTP path runs on a connection the test never sees, so its pid cannot
+    be read up front the way the service-level tests read theirs. Waiting on
+    the HOLDER instead identifies the right event without knowing the waiter:
+    a transaction blocked on a row lock queues an ungranted ``transactionid``
+    lock naming the transaction that holds the row. Scoping to that xid also
+    keeps a sibling suite's unrelated lock wait on this shared server from
+    releasing this barrier early.
+    """
+    for _ in range(_BARRIER_POLLS):
+        waiters = await probe.scalar(
+            text(
+                "SELECT count(*) FROM pg_locks WHERE NOT granted "
+                "AND locktype = 'transactionid' AND transactionid::text = :xid"
+            ),
+            {"xid": holder_xid},
+        )
+        await probe.rollback()
+        if waiters:
+            return
+        await asyncio.sleep(_BARRIER_INTERVAL_SECONDS)
+    raise AssertionError(
+        f"nothing ever queued behind transaction {holder_xid}; the request "
+        "under test did not reach a blocking acquisition"
+    )
+
+
 async def _holds_record_lock(probe, record_id: uuid.UUID) -> bool:
     """True when some other transaction holds the records row."""
     try:
@@ -250,6 +279,166 @@ class TestLockOrderAgainstRefreshPhaseThree:
         )
 
 
+class TestPropertyOnlyPatchTakesThePairToo:
+    """The one write path that does not recompute anything still locks."""
+
+    async def test_a_property_only_patch_does_not_deadlock_with_phase_three(
+        self,
+        locked_dataset,
+        client: AsyncClient,
+        admin_auth_header,
+        test_db_session,
+        monkeypatch,
+    ):
+        """End to end, over HTTP, with the worker holding the datasets row.
+
+        The request never recomputes an extent, so before fix(#1847 review r1)
+        it took no catalog lock at all and its first touch of either row was
+        the flush at ``commit()`` -- records, then datasets. That is the
+        original inversion, on the one handler whose refresh is conditional.
+        """
+        monkeypatch.setattr(features_service, "_LOCK_TIMEOUT", "60s")
+
+        import app.core.db as db_module
+
+        create = await client.post(
+            f"/datasets/{locked_dataset.id}/features/",
+            json={
+                "geometry": {"type": "Point", "coordinates": [-73.96, 40.74]},
+                "properties": {"name": "before"},
+            },
+            headers=admin_auth_header,
+        )
+        assert create.status_code == 201, create.text
+        gid = create.json()["id"]
+
+        # The handler assigns `record.updated_by = user.id`, and the ORM emits
+        # an UPDATE only when that is a real change. The insert above already
+        # stamped this admin, so without this the PATCH would dirty the
+        # datasets row alone and the records half of the pair would go
+        # untested. Clearing it restores the ordinary case: the last editor is
+        # somebody other than the current one.
+        await test_db_session.execute(
+            text("UPDATE catalog.records SET updated_by = NULL WHERE id = :rid"),
+            {"rid": locked_dataset.record_id},
+        )
+        await test_db_session.commit()
+
+        async with (
+            db_module.async_session() as worker,
+            db_module.async_session() as probe,
+        ):
+            await worker.execute(
+                select(Dataset.tile_cache_version)
+                .where(Dataset.id == locked_dataset.id)
+                .with_for_update()
+            )
+            worker_xid = await worker.scalar(text("SELECT pg_current_xact_id()::text"))
+
+            # Properties only: no geometry key at all, so the handler's
+            # refresh branch is not taken.
+            patch = asyncio.create_task(
+                client.patch(
+                    f"/datasets/{locked_dataset.id}/features/{gid}",
+                    json={"properties": {"name": "after"}},
+                    headers=admin_auth_header,
+                )
+            )
+            try:
+                await _await_waiter_on(probe, worker_xid)
+                assert not await _holds_record_lock(probe, locked_dataset.record_id), (
+                    "the property-only PATCH is parked on a lock while holding "
+                    "catalog.records. It dirties both rows and must take them "
+                    "datasets-first like every other write."
+                )
+                # The other half of what phase 3 does under its datasets lock.
+                # On the inverted order this is where PostgreSQL aborted one.
+                await worker.execute(
+                    text(
+                        "UPDATE catalog.records SET updated_at = now() WHERE id = :rid"
+                    ),
+                    {"rid": locked_dataset.record_id},
+                )
+                await worker.commit()
+            except BaseException:
+                await worker.rollback()
+                raise
+            response = await patch
+
+        assert response.status_code == 200, response.text
+        assert response.json()["properties"]["name"] == "after"
+
+    async def test_a_property_only_patch_and_phase_three_both_complete(
+        self,
+        locked_dataset,
+        client: AsyncClient,
+        admin_auth_header,
+        test_db_session,
+        monkeypatch,
+    ):
+        """The same interleaving with the diagnostic assertion removed.
+
+        Drives both sides to completion instead of characterising the state in
+        the middle, so on the inverted order PostgreSQL reports the cycle
+        itself rather than a message this test composed.
+        """
+        monkeypatch.setattr(features_service, "_LOCK_TIMEOUT", "60s")
+
+        import app.core.db as db_module
+
+        create = await client.post(
+            f"/datasets/{locked_dataset.id}/features/",
+            json={
+                "geometry": {"type": "Point", "coordinates": [-73.97, 40.75]},
+                "properties": {"name": "before"},
+            },
+            headers=admin_auth_header,
+        )
+        assert create.status_code == 201, create.text
+        gid = create.json()["id"]
+        # See the sibling test: the assignment has to be a real change for the
+        # records half of the pair to be written at all.
+        await test_db_session.execute(
+            text("UPDATE catalog.records SET updated_by = NULL WHERE id = :rid"),
+            {"rid": locked_dataset.record_id},
+        )
+        await test_db_session.commit()
+
+        async with (
+            db_module.async_session() as worker,
+            db_module.async_session() as probe,
+        ):
+            await worker.execute(
+                select(Dataset.tile_cache_version)
+                .where(Dataset.id == locked_dataset.id)
+                .with_for_update()
+            )
+            worker_xid = await worker.scalar(text("SELECT pg_current_xact_id()::text"))
+
+            patch = asyncio.create_task(
+                client.patch(
+                    f"/datasets/{locked_dataset.id}/features/{gid}",
+                    json={"properties": {"name": "after"}},
+                    headers=admin_auth_header,
+                )
+            )
+            try:
+                await _await_waiter_on(probe, worker_xid)
+                await worker.execute(
+                    text(
+                        "UPDATE catalog.records SET updated_at = now() WHERE id = :rid"
+                    ),
+                    {"rid": locked_dataset.record_id},
+                )
+                await worker.commit()
+            except BaseException:
+                await worker.rollback()
+                raise
+            response = await patch
+
+        assert response.status_code == 200, response.text
+
+
 def _compiled(statement) -> str:
     """The SQL text a statement emits, as PostgreSQL would receive it."""
     if isinstance(statement, str):
@@ -292,9 +481,7 @@ class TestEmittedSqlPinsTheOrder:
 
     async def test_datasets_for_update_is_emitted_before_the_records_read(self):
         session = _RecordingSession()
-        await features_service._lock_dataset_then_read_extent_box(
-            session, _StubDataset()
-        )
+        await features_service.lock_catalog_rows_for_write(session, _StubDataset())
 
         locking = [
             (i, sql)
@@ -315,9 +502,7 @@ class TestEmittedSqlPinsTheOrder:
 
     async def test_lock_timeout_is_set_on_the_acquisition(self):
         session = _RecordingSession()
-        await features_service._lock_dataset_then_read_extent_box(
-            session, _StubDataset()
-        )
+        await features_service.lock_catalog_rows_for_write(session, _StubDataset())
         assert "SET LOCAL lock_timeout" in session.statements[0], (
             "the wait for the datasets row must be bounded, so a request "
             "queued behind a long refresh answers a retryable conflict rather "
@@ -399,22 +584,108 @@ class TestFeatureWriteErrorClassification:
 class TestEveryWriteHandlerGoesThroughTheGuard:
     """The refresh is inside the DBAPIError classification at all four sites."""
 
-    def test_no_handler_calls_the_refresh_unguarded(self):
+    HANDLERS = {
+        "create_feature",
+        "replace_single_feature",
+        "patch_single_feature",
+        "delete_single_feature",
+    }
+    # Reaching either of these from a handler bypasses the classification, so
+    # a lock conflict escapes as a 503 rather than the retryable 409.
+    UNGUARDED = {"refresh_dataset_metadata", "lock_catalog_rows_for_write"}
+
+    def _router_tree(self):
+        import ast
+        from pathlib import Path
+
+        return ast.parse(
+            (
+                Path(__file__).resolve().parents[1]
+                / "app/modules/catalog/features/router.py"
+            ).read_text()
+        )
+
+    def test_no_handler_reaches_past_the_guard(self):
+        import ast
+
+        seen = set()
+        for node in ast.walk(self._router_tree()):
+            if not isinstance(node, ast.AsyncFunctionDef):
+                continue
+            if node.name not in self.HANDLERS:
+                continue
+            seen.add(node.name)
+            direct = {
+                n.func.id
+                for n in ast.walk(node)
+                if isinstance(n, ast.Call)
+                and isinstance(n.func, ast.Name)
+                and n.func.id in self.UNGUARDED
+            }
+            assert not direct, (
+                f"{node.name} calls {sorted(direct)} directly. That puts the "
+                "row-lock acquisition back outside the DBAPIError "
+                "classification, where a conflict answers 503 instead of 409."
+            )
+        assert seen == self.HANDLERS, (
+            f"handlers not found: {sorted(self.HANDLERS - seen)}"
+        )
+
+    def test_every_write_handler_acquires_on_every_path(self):
+        """fix(#1847 review r1): unconditionally, or in BOTH arms of the if.
+
+        Three handlers refresh unconditionally, so they hold the pair before
+        they stamp `record.updated_by` and roll `tile_cache_version`. The PATCH
+        handler refreshes only when the body carries geometry, and a
+        property-only PATCH still dirties both rows -- so its else arm has to
+        take the pair on its own or the flush at commit takes them in the ORM's
+        records-then-datasets order and the deadlock is back.
+        """
+        import ast
         from pathlib import Path
 
         source = (
             Path(__file__).resolve().parents[1]
             / "app/modules/catalog/features/router.py"
         ).read_text()
-        bare = [
-            line
-            for line in source.splitlines()
-            if "await refresh_dataset_metadata(" in line
-        ]
-        assert len(bare) == 1, (
-            "the only call to refresh_dataset_metadata in this router should be "
-            "the one inside _refresh_metadata_guarded; a handler calling it "
-            "directly puts its row-lock acquisition back outside the "
-            f"DBAPIError guard. Found {bare}"
-        )
-        assert source.count("await _refresh_metadata_guarded(") == 4
+        tree = ast.parse(source)
+
+        acquisitions = {"_refresh_metadata_guarded", "_lock_catalog_rows_guarded"}
+
+        def acquires(nodes) -> bool:
+            return any(
+                isinstance(n, ast.Call)
+                and isinstance(n.func, ast.Name)
+                and n.func.id in acquisitions
+                for node in nodes
+                for n in ast.walk(node)
+            )
+
+        def acquires_on_every_path(body) -> bool:
+            for stmt in body:
+                if isinstance(stmt, ast.If):
+                    if acquires(stmt.body) and acquires(stmt.orelse):
+                        return True
+                    continue
+                if acquires([stmt]):
+                    return True
+            return False
+
+        handlers = {
+            "create_feature",
+            "replace_single_feature",
+            "patch_single_feature",
+            "delete_single_feature",
+        }
+        seen = set()
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.AsyncFunctionDef) or node.name not in handlers:
+                continue
+            seen.add(node.name)
+            assert acquires_on_every_path(node.body), (
+                f"{node.name} has a path that reaches db.commit() without "
+                "taking the (datasets, records) pair. Every handler here "
+                "dirties both rows, so a path that acquires nothing lets the "
+                "flush order them records-first and re-opens #1847."
+            )
+        assert seen == handlers, f"handlers not found: {sorted(handlers - seen)}"

--- a/backend/tests/test_feature_lock_order_1847.py
+++ b/backend/tests/test_feature_lock_order_1847.py
@@ -1,0 +1,420 @@
+"""Backend audit 2026-09-04 P1-1, tracked in #1847.
+
+The feature-edit metadata refresh took ``catalog.records`` FOR UPDATE and left
+``catalog.datasets`` to the flush. ``refresh_postgis`` phase 3 takes the
+datasets row FOR UPDATE first and writes the record row inside that same
+transaction, so an ordinary feature edit during a refresh was an ABBA cycle:
+PostgreSQL aborted one side with 40P01 after ``deadlock_timeout``, and because
+the refresh call sat outside the write handlers' ``except DBAPIError`` the abort
+surfaced as a generic 503 with the edit lost.
+
+The concurrency tests here assert on LOCK STATE, never on elapsed time. The
+barrier is ``pg_stat_activity.wait_event_type``, and whether a lock is held is
+settled by a third session's ``FOR UPDATE NOWAIT``, which either raises 55P03
+or does not.
+
+The DB-backed tests require the Docker test database.
+"""
+
+import asyncio
+import uuid
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import select, text
+from sqlalchemy.dialects import postgresql
+from sqlalchemy.exc import DBAPIError
+
+from app.core.db.sqlstate import is_lock_conflict
+from app.modules.catalog.datasets.domain.models import Dataset, Record
+from app.modules.catalog.features import service as features_service
+from app.modules.catalog.features.router import _feature_write_db_error
+
+from tests.factories import get_user_id
+
+pytestmark = pytest.mark.anyio
+
+# Seeded rows span (-74.00, 40.70) .. (-73.90, 40.80), so this envelope is
+# strictly inside the stored extent and the incremental fast path applies.
+INSIDE_BOUNDS = (-73.96, 40.74, -73.96, 40.74)
+
+# The barrier polls until the backend under test is parked on a lock. Bounded
+# only so a wait that will never end fails with a readable message instead of
+# hanging the suite; the bound is not an assertion about how long anything took.
+_BARRIER_POLLS = 600
+_BARRIER_INTERVAL_SECONDS = 0.01
+
+
+async def _seed_dataset(session, *, created_by: uuid.UUID) -> Dataset:
+    """A point layer with a POLYGON stored extent, seeded the honest way."""
+    table_name = f"test_lo_{uuid.uuid4().hex[:8]}"
+    await session.execute(
+        text(
+            f"CREATE TABLE data.{table_name} ("
+            "gid SERIAL PRIMARY KEY, "
+            "geom geometry(Geometry, 4326), "
+            "geom_4326 geometry(Geometry, 4326), "
+            "name TEXT)"
+        )
+    )
+    await session.execute(text(f"GRANT SELECT ON data.{table_name} TO geolens_reader"))
+    for lng, lat in ((-74.00, 40.70), (-73.90, 40.80), (-73.95, 40.75)):
+        await session.execute(
+            text(
+                f"INSERT INTO data.{table_name} (geom, geom_4326, name) VALUES ("
+                "ST_SetSRID(ST_MakePoint(:lng, :lat), 4326), "
+                "ST_SetSRID(ST_MakePoint(:lng, :lat), 4326), 'seed')"
+            ).bindparams(lng=lng, lat=lat)
+        )
+
+    record = Record(
+        title=f"Lock order {table_name}",
+        summary="Fixture layer",
+        theme_category=["test"],
+        visibility="private",
+        record_status="published",
+        created_by=created_by,
+    )
+    session.add(record)
+    await session.flush()
+    dataset = Dataset(
+        record_id=record.id,
+        table_name=table_name,
+        srid=4326,
+        geometry_type="POINT",
+        feature_count=0,
+        column_info=[{"name": "name", "type": "text"}],
+        source_format="geojson",
+    )
+    session.add(dataset)
+    await session.flush()
+    await features_service.refresh_dataset_metadata(session, dataset)
+    await session.commit()
+    await session.refresh(dataset)
+    return dataset
+
+
+@pytest.fixture
+async def locked_dataset(client: AsyncClient, test_db_session):
+    admin_id = await get_user_id(test_db_session, "admin")
+    dataset = await _seed_dataset(test_db_session, created_by=admin_id)
+    yield dataset
+    await test_db_session.execute(
+        text(f"DROP TABLE IF EXISTS data.{dataset.table_name}")
+    )
+    await test_db_session.commit()
+
+
+async def _await_lock_wait(probe, pid: int) -> None:
+    """Block until backend *pid* is parked waiting on a lock."""
+    for _ in range(_BARRIER_POLLS):
+        wait_event_type = await probe.scalar(
+            text("SELECT wait_event_type FROM pg_stat_activity WHERE pid = :pid"),
+            {"pid": pid},
+        )
+        await probe.rollback()
+        if wait_event_type == "Lock":
+            return
+        await asyncio.sleep(_BARRIER_INTERVAL_SECONDS)
+    raise AssertionError(
+        f"backend {pid} never parked on a lock; the refresh under test did not "
+        "reach its blocking acquisition"
+    )
+
+
+async def _holds_record_lock(probe, record_id: uuid.UUID) -> bool:
+    """True when some other transaction holds the records row."""
+    try:
+        await probe.execute(
+            select(Record.id).where(Record.id == record_id).with_for_update(nowait=True)
+        )
+    except DBAPIError as exc:
+        await probe.rollback()
+        if is_lock_conflict(exc):
+            return True
+        raise
+    await probe.rollback()
+    return False
+
+
+class TestLockOrderAgainstRefreshPhaseThree:
+    """The request must reach for the datasets row before the records row."""
+
+    async def test_request_holds_no_record_lock_while_waiting_for_the_dataset(
+        self, locked_dataset, monkeypatch
+    ):
+        """The whole ABBA cycle in one assertion.
+
+        A cycle needs the request to be holding one row and waiting for the
+        other. With the datasets row taken first there is nothing to hold: the
+        request parks at its very first acquisition, so the third session can
+        still take the records row. Before fix(#1847) the request was parked at
+        its flush with ``catalog.records`` already locked, and this probe raised
+        55P03.
+        """
+        # This test is about acquisition ORDER, so give the wait a budget the
+        # barrier below cannot plausibly exhaust. The 2s production value is
+        # exercised by test_lock_timeout_is_set_on_the_acquisition.
+        monkeypatch.setattr(features_service, "_LOCK_TIMEOUT", "60s")
+
+        import app.core.db as db_module
+
+        async with (
+            db_module.async_session() as worker,
+            db_module.async_session() as api,
+            db_module.async_session() as probe,
+        ):
+            # The worker's phase 3 lock, verbatim: datasets row, single column.
+            await worker.execute(
+                select(Dataset.tile_cache_version)
+                .where(Dataset.id == locked_dataset.id)
+                .with_for_update()
+            )
+
+            api_pid = await api.scalar(text("SELECT pg_backend_pid()"))
+            api_dataset = await api.get(Dataset, locked_dataset.id)
+            refresh = asyncio.create_task(
+                features_service.refresh_dataset_metadata(
+                    api,
+                    api_dataset,
+                    count_delta=1,
+                    touched_bounds=[INSIDE_BOUNDS],
+                    added_geometry_type="Point",
+                )
+            )
+            try:
+                await _await_lock_wait(probe, api_pid)
+                assert not await _holds_record_lock(probe, locked_dataset.record_id), (
+                    "the feature-edit path is parked on a lock while holding "
+                    "catalog.records. That is one half of an ABBA cycle with "
+                    "refresh_postgis phase 3, which holds catalog.datasets and "
+                    "goes on to write the record row."
+                )
+            finally:
+                await worker.rollback()
+                await refresh
+                await api.rollback()
+
+    async def test_concurrent_edit_and_phase_three_write_do_not_deadlock(
+        self, locked_dataset, monkeypatch
+    ):
+        """Drive both sides of the cycle and require neither to be aborted."""
+        monkeypatch.setattr(features_service, "_LOCK_TIMEOUT", "60s")
+
+        import app.core.db as db_module
+
+        async with (
+            db_module.async_session() as worker,
+            db_module.async_session() as api,
+            db_module.async_session() as probe,
+        ):
+            await worker.execute(
+                select(Dataset.tile_cache_version)
+                .where(Dataset.id == locked_dataset.id)
+                .with_for_update()
+            )
+
+            api_pid = await api.scalar(text("SELECT pg_backend_pid()"))
+            api_dataset = await api.get(Dataset, locked_dataset.id)
+            refresh = asyncio.create_task(
+                features_service.refresh_dataset_metadata(
+                    api,
+                    api_dataset,
+                    count_delta=1,
+                    touched_bounds=[INSIDE_BOUNDS],
+                    added_geometry_type="Point",
+                )
+            )
+            await _await_lock_wait(probe, api_pid)
+
+            # The second half of what phase 3 does under its datasets lock:
+            # write the record row. On the inverted order this is where
+            # PostgreSQL detected the cycle and aborted one of the two.
+            await worker.execute(
+                text("UPDATE catalog.records SET updated_at = now() WHERE id = :rid"),
+                {"rid": locked_dataset.record_id},
+            )
+            await worker.commit()
+
+            await refresh
+            await api.commit()
+
+        # Both sides ran to completion, so the edit is in the catalog.
+        async with db_module.async_session() as check:
+            count = await check.scalar(
+                select(Dataset.feature_count).where(Dataset.id == locked_dataset.id)
+            )
+        assert count == 4, (
+            "the incremental fast path should have added one to the seeded "
+            f"count of 3, got {count}"
+        )
+
+
+def _compiled(statement) -> str:
+    """The SQL text a statement emits, as PostgreSQL would receive it."""
+    if isinstance(statement, str):
+        return statement
+    try:
+        return str(statement.compile(dialect=postgresql.dialect()))
+    except Exception:
+        return str(statement)
+
+
+class _StubResult:
+    def first(self):
+        return None
+
+
+class _RecordingSession:
+    """Captures the statements the lock helper emits, in order."""
+
+    def __init__(self):
+        self.statements: list[str] = []
+
+    @property
+    def no_autoflush(self):
+        import contextlib
+
+        return contextlib.nullcontext()
+
+    async def execute(self, statement, *args, **kwargs):
+        self.statements.append(_compiled(statement))
+        return _StubResult()
+
+
+class _StubDataset:
+    id = uuid.UUID("00000000-0000-0000-0000-0000000000d5")
+    record_id = uuid.UUID("00000000-0000-0000-0000-0000000000fe")
+
+
+class TestEmittedSqlPinsTheOrder:
+    """Pin the order on the SQL text, so a reordering fails without a race."""
+
+    async def test_datasets_for_update_is_emitted_before_the_records_read(self):
+        session = _RecordingSession()
+        await features_service._lock_dataset_then_read_extent_box(
+            session, _StubDataset()
+        )
+
+        locking = [
+            (i, sql)
+            for i, sql in enumerate(session.statements)
+            if "FOR UPDATE" in sql.upper()
+        ]
+        assert len(locking) == 2, (
+            f"expected exactly two locking statements, got {session.statements}"
+        )
+        (first_i, first_sql), (second_i, second_sql) = locking
+        assert "datasets" in first_sql and "records" not in first_sql, (
+            f"the first FOR UPDATE must be on the datasets row, got {first_sql}"
+        )
+        assert "records" in second_sql, (
+            f"the second FOR UPDATE must be on the records row, got {second_sql}"
+        )
+        assert first_i < second_i
+
+    async def test_lock_timeout_is_set_on_the_acquisition(self):
+        session = _RecordingSession()
+        await features_service._lock_dataset_then_read_extent_box(
+            session, _StubDataset()
+        )
+        assert "SET LOCAL lock_timeout" in session.statements[0], (
+            "the wait for the datasets row must be bounded, so a request "
+            "queued behind a long refresh answers a retryable conflict rather "
+            f"than hanging. Got {session.statements[0]}"
+        )
+        assert features_service._LOCK_TIMEOUT in session.statements[0]
+
+
+class TestWorkerSitesLeadWithTheDatasetRow:
+    """The two background writers of the pair keep the order this one matched."""
+
+    def _lines(self, rel: str) -> list[str]:
+        from pathlib import Path
+
+        app_dir = Path(__file__).resolve().parents[1] / "app"
+        return (app_dir / rel).read_text().splitlines()
+
+    def test_postgis_refresh_locks_the_dataset_before_applying_the_measurement(self):
+        lines = self._lines("processing/ingest/tasks_postgis_refresh.py")
+        lock = next(
+            i
+            for i, line in enumerate(lines)
+            if "select(Dataset.tile_cache_version)" in line
+        )
+        apply_call = next(
+            i for i, line in enumerate(lines) if line.strip() == "_apply_measurement("
+        )
+        assert lock < apply_call, (
+            "phase 3 must take the datasets row before _apply_measurement "
+            "writes dataset.record. Reversing this re-opens #1847 from the "
+            "worker side."
+        )
+
+    def test_stac_refresh_locks_the_dataset_before_writing_the_record(self):
+        lines = self._lines("processing/ingest/tasks_stac_refresh.py")
+        lock = next(
+            i
+            for i, line in enumerate(lines)
+            if "select(" in line and "Dataset." in line
+        )
+        write = next(
+            i
+            for i, line in enumerate(lines)
+            if "dataset.record.spatial_extent" in line and "=" in line
+        )
+        assert lock < write
+
+
+class TestFeatureWriteErrorClassification:
+    """A lock conflict is a retryable 409, not a 503 telling clients to back off."""
+
+    class _Orig:
+        def __init__(self, code):
+            self.sqlstate = code
+
+    def _error(self, code: str) -> DBAPIError:
+        return DBAPIError("SELECT 1", {}, self._Orig(code))
+
+    @pytest.mark.parametrize(
+        "code",
+        [
+            "40P01",  # deadlock_detected
+            "55P03",  # lock_not_available
+        ],
+    )
+    def test_lock_conflict_is_a_conflict(self, code: str):
+        result = _feature_write_db_error(self._error(code))
+        assert result.status_code == 409
+        assert result.detail["code"] == "feature_write_locked"
+
+    def test_a_real_outage_is_still_unavailable(self):
+        # 08006 is connection_failure: class 08, still operational.
+        assert _feature_write_db_error(self._error("08006")).status_code == 503
+
+    def test_a_bad_value_is_still_the_callers_fault(self):
+        assert _feature_write_db_error(self._error("22P02")).status_code == 400
+
+
+class TestEveryWriteHandlerGoesThroughTheGuard:
+    """The refresh is inside the DBAPIError classification at all four sites."""
+
+    def test_no_handler_calls_the_refresh_unguarded(self):
+        from pathlib import Path
+
+        source = (
+            Path(__file__).resolve().parents[1]
+            / "app/modules/catalog/features/router.py"
+        ).read_text()
+        bare = [
+            line
+            for line in source.splitlines()
+            if "await refresh_dataset_metadata(" in line
+        ]
+        assert len(bare) == 1, (
+            "the only call to refresh_dataset_metadata in this router should be "
+            "the one inside _refresh_metadata_guarded; a handler calling it "
+            "directly puts its row-lock acquisition back outside the "
+            f"DBAPIError guard. Found {bare}"
+        )
+        assert source.count("await _refresh_metadata_guarded(") == 4

--- a/backend/tests/test_feature_lock_order_1847.py
+++ b/backend/tests/test_feature_lock_order_1847.py
@@ -757,6 +757,174 @@ class TestMetadataPatchTakesThePairToo:
         assert response.json()["title"] == "Renamed by the metadata patch"
 
 
+class TestOneAnswerForAContendedRow:
+    """fix(#1847 review r3): 409 from every caller, not 409/503/400 by route.
+
+    The acquisition is reached from feature writes, metadata edits, layer DDL
+    and dataset deletion. Each classified a lost race differently until the
+    helper started raising one domain exception with one handler.
+    """
+
+    async def _hold_dataset_row(self, session, dataset_id):
+        await session.execute(
+            select(Dataset.tile_cache_version)
+            .where(Dataset.id == dataset_id)
+            .with_for_update()
+        )
+
+    async def test_metadata_patch_answers_conflict(
+        self, locked_dataset, client: AsyncClient, admin_auth_header, monkeypatch
+    ):
+        monkeypatch.setattr(catalog_locks, "REQUEST_LOCK_TIMEOUT", "150ms")
+        import app.core.db as db_module
+
+        async with db_module.async_session() as holder:
+            await self._hold_dataset_row(holder, locked_dataset.id)
+            response = await client.patch(
+                f"/datasets/{locked_dataset.id}",
+                json={"title": "Should not land", "tile_columns": ["name"]},
+                headers=admin_auth_header,
+            )
+            await holder.rollback()
+
+        assert response.status_code == 409, response.text
+        # The metadata PATCH used to reach the global DBAPIError handler, which
+        # called a contended row an outage.
+        assert response.status_code != 503
+
+        # Rolled back: the title the request carried never landed.
+        async with db_module.async_session() as check:
+            title = await check.scalar(
+                select(Record.title).where(Record.id == locked_dataset.record_id)
+            )
+        assert title != "Should not land"
+
+    async def test_layer_ddl_answers_conflict(
+        self, locked_dataset, client: AsyncClient, admin_auth_header, monkeypatch
+    ):
+        monkeypatch.setattr(catalog_locks, "REQUEST_LOCK_TIMEOUT", "150ms")
+        import app.core.db as db_module
+
+        async with db_module.async_session() as holder:
+            await self._hold_dataset_row(holder, locked_dataset.id)
+            response = await client.post(
+                f"/layers/{locked_dataset.id}/columns/",
+                json={"column": {"name": "note_col", "type": "text"}},
+                headers=admin_auth_header,
+            )
+            await holder.rollback()
+
+        # This route read the same SQLSTATE as the caller's bad request.
+        assert response.status_code == 409, response.text
+        assert response.status_code != 400
+
+    async def test_feature_write_still_answers_conflict(
+        self, locked_dataset, client: AsyncClient, admin_auth_header, monkeypatch
+    ):
+        monkeypatch.setattr(catalog_locks, "REQUEST_LOCK_TIMEOUT", "150ms")
+        import app.core.db as db_module
+
+        async with db_module.async_session() as holder:
+            await self._hold_dataset_row(holder, locked_dataset.id)
+            response = await client.post(
+                f"/datasets/{locked_dataset.id}/features/",
+                json={
+                    "geometry": {"type": "Point", "coordinates": [-73.96, 40.74]},
+                    "properties": {"name": "blocked"},
+                },
+                headers=admin_auth_header,
+            )
+            await holder.rollback()
+
+        assert response.status_code == 409, response.text
+
+
+class TestDeleteNeverReapsStorageItCannotCommit:
+    """fix(#1847 review r3): the irreversible step must be behind the lock.
+
+    `delete_dataset` deletes the managed objects permanently and relies on the
+    transaction rolling back to keep the catalog consistent with them. An
+    acquisition that can time out placed AFTER that reap breaks the
+    arrangement: the objects are gone, the transaction rolls back, and the
+    catalog keeps a dataset whose assets no longer exist.
+    """
+
+    def test_the_lock_precedes_every_irreversible_reap(self):
+        """Source order, because the failure mode is an ordering, not a value."""
+        import ast
+        from pathlib import Path
+
+        source = (
+            Path(__file__).resolve().parents[1]
+            / "app/modules/catalog/datasets/domain/service_lifecycle.py"
+        ).read_text()
+        tree = ast.parse(source)
+        fn = next(
+            n
+            for n in ast.walk(tree)
+            if isinstance(n, ast.AsyncFunctionDef) and n.name == "delete_dataset"
+        )
+        acquisitions, reaps = [], []
+        for node in ast.walk(fn):
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
+                if node.func.id == "lock_catalog_rows_for_write":
+                    acquisitions.append(node.lineno)
+                elif node.func.id == "_reap_managed_storage":
+                    reaps.append(node.lineno)
+        assert acquisitions and reaps, (
+            f"expected both calls in delete_dataset; got {acquisitions=} {reaps=}"
+        )
+        for reap in reaps:
+            assert any(a < reap for a in acquisitions), (
+                f"_reap_managed_storage at line {reap} runs before any "
+                "lock_catalog_rows_for_write. A 55P03 after that reap rolls the "
+                "transaction back with the objects already deleted, leaving a "
+                "catalog row pointing at storage that is gone."
+            )
+
+    async def test_a_contended_delete_leaves_the_objects_alone(
+        self, locked_dataset, client: AsyncClient, admin_auth_header, monkeypatch
+    ):
+        """The whole finding end to end: 409, and nothing reaped."""
+        monkeypatch.setattr(catalog_locks, "REQUEST_LOCK_TIMEOUT", "150ms")
+        import app.core.db as db_module
+
+        reaped: list[tuple] = []
+
+        async def _record_only(prefixes, tenant_id):
+            reaped.append((tuple(prefixes), tenant_id))
+
+        from app.modules.catalog.datasets.domain import service_lifecycle
+
+        monkeypatch.setattr(service_lifecycle, "_reap_managed_storage", _record_only)
+
+        async with db_module.async_session() as holder:
+            await holder.execute(
+                select(Dataset.tile_cache_version)
+                .where(Dataset.id == locked_dataset.id)
+                .with_for_update()
+            )
+            response = await client.request(
+                "DELETE",
+                f"/datasets/{locked_dataset.id}",
+                json={"confirm_title": f"Lock order {locked_dataset.table_name}"},
+                headers=admin_auth_header,
+            )
+            await holder.rollback()
+
+        assert response.status_code == 409, response.text
+        assert reaped == [], (
+            "the delete reaped managed storage before losing the lock race, so "
+            f"those objects are gone and the catalog row is not: {reaped}"
+        )
+        # And the row really is still there.
+        async with db_module.async_session() as check:
+            still_there = await check.scalar(
+                select(Dataset.id).where(Dataset.id == locked_dataset.id)
+            )
+        assert still_there == locked_dataset.id
+
+
 # ---------------------------------------------------------------------------
 # The class gate (fix(#1847 review r2))
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_feature_lock_order_1847.py
+++ b/backend/tests/test_feature_lock_order_1847.py
@@ -96,8 +96,9 @@ async def _seed_dataset(session, *, created_by: uuid.UUID) -> Dataset:
 async def _seed_raster_dataset(session, *, created_by: uuid.UUID) -> Dataset:
     """A raster dataset with its RasterAsset child, for the delete path.
 
-    No data table: `delete_dataset`'s raster branch reaps storage prefixes and
-    drops nothing, and the record delete cascades to `raster_assets`.
+    No data table: `delete_dataset`'s raster branch drops nothing and returns
+    the storage prefixes for the router to reap after commit; the record
+    delete cascades to `raster_assets`.
     """
     from app.processing.raster.models import RasterAsset
 
@@ -2456,7 +2457,8 @@ def _acquires_raster_first(fn) -> bool:
     ]
     if not calls:
         return False
-    for call in calls:
+
+    def _extends(call) -> bool:
         for kw in call.keywords:
             if kw.arg == "with_raster_asset" and not (
                 isinstance(kw.value, ast.Constant) and kw.value.value is False
@@ -2466,7 +2468,11 @@ def _acquires_raster_first(fn) -> bool:
                 isinstance(kw.value, ast.Constant) and kw.value.value is None
             ):
                 return True
-    return False
+        return False
+
+    # Every site, not any: an arm that takes the plain pair and later writes
+    # the child is the ABBA this gate exists to reject.
+    return all(_extends(call) for call in calls)
 
 
 def _acquiring_functions() -> set[str]:
@@ -2867,7 +2873,7 @@ class TestTheGateRejectsWhatItExistsToCatch:
         assert ok, why
 
     def test_a_raster_writer_that_takes_the_pair_first_is_rejected(self):
-        """codex r6: the shape that inverts against the replace worker."""
+        """The shape that inverts against the replace worker."""
         import ast
 
         source = (
@@ -2911,6 +2917,33 @@ class TestTheGateRejectsWhatItExistsToCatch:
             if isinstance(n, ast.AsyncFunctionDef) and n.name == "probe"
         )
         assert _acquires_raster_first(fn)
+
+    def test_one_unguarded_acquisition_among_two_is_rejected(self):
+        """Every site must extend the order, not any one of them."""
+        import ast
+
+        source = (
+            "from app.modules.catalog.features.service import "
+            "lock_catalog_rows_for_write\n"
+            "async def probe(session, dataset, flag):\n"
+            "    if flag:\n"
+            "        await lock_catalog_rows_for_write(\n"
+            "            session, dataset, with_raster_asset=True\n"
+            "        )\n"
+            "    else:\n"
+            "        await lock_catalog_rows_for_write(session, dataset)\n"
+            "    ra = await get_raster_asset(session, dataset.id)\n"
+            "    ra.is_dem = True\n"
+        )
+        tree = ast.parse(source)
+        fn = next(
+            n
+            for n in ast.walk(tree)
+            if isinstance(n, ast.AsyncFunctionDef) and n.name == "probe"
+        )
+        assert not _acquires_raster_first(fn), (
+            "one arm takes the plain pair and later writes raster_assets"
+        )
 
     def test_core_update_statements_count_as_writes(self):
         """`update(Dataset)` / `delete(Record)` are invisible to an attribute scan."""

--- a/backend/tests/test_feature_lock_order_1847.py
+++ b/backend/tests/test_feature_lock_order_1847.py
@@ -1,4 +1,4 @@
-"""Backend audit 2026-09-04 P1-1, tracked in #1847.
+"""The (datasets, records) lock order, and the gate that holds it (#1847).
 
 The feature-edit metadata refresh took ``catalog.records`` FOR UPDATE and left
 ``catalog.datasets`` to the flush. ``refresh_postgis`` phase 3 takes the
@@ -230,11 +230,9 @@ class TestLockOrderAgainstRefreshPhaseThree:
         """The whole ABBA cycle in one assertion.
 
         A cycle needs the request to be holding one row and waiting for the
-        other. With the datasets row taken first there is nothing to hold: the
-        request parks at its very first acquisition, so the third session can
-        still take the records row. Before fix(#1847) the request was parked at
-        its flush with ``catalog.records`` already locked, and this probe raised
-        55P03.
+        other. With the datasets row taken first there is nothing to hold: it
+        parks at its first acquisition, so the third session can still take
+        the records row.
         """
         # This test is about acquisition ORDER, so give the wait a budget the
         # barrier below cannot plausibly exhaust. The 2s production value is
@@ -347,10 +345,8 @@ class TestPropertyOnlyPatchTakesThePairToo:
     ):
         """End to end, over HTTP, with the worker holding the datasets row.
 
-        The request never recomputes an extent, so before fix(#1847)
-        it took no catalog lock at all and its first touch of either row was
-        the flush at ``commit()`` -- records, then datasets. That is the
-        original inversion, on the one handler whose refresh is conditional.
+        This request recomputes no extent, so its only catalog writes are the
+        stamp and the tile-version roll. Both rows, in one flush.
         """
         monkeypatch.setattr(catalog_locks, "REQUEST_LOCK_TIMEOUT", "60s")
 
@@ -367,12 +363,9 @@ class TestPropertyOnlyPatchTakesThePairToo:
         assert create.status_code == 201, create.text
         gid = create.json()["id"]
 
-        # The handler assigns `record.updated_by = user.id`, and the ORM emits
-        # an UPDATE only when that is a real change. The insert above already
-        # stamped this admin, so without this the PATCH would dirty the
-        # datasets row alone and the records half of the pair would go
-        # untested. Clearing it restores the ordinary case: the last editor is
-        # somebody other than the current one.
+        # The ORM emits the records UPDATE only when `updated_by` really
+        # changes, and the insert above already stamped this admin. Clearing it
+        # restores the ordinary case: the last editor is somebody else.
         await test_db_session.execute(
             text("UPDATE catalog.records SET updated_by = NULL WHERE id = :rid"),
             {"rid": locked_dataset.record_id},
@@ -624,7 +617,7 @@ class TestFeatureWriteErrorClassification:
         ],
     )
     def test_lock_conflict_raises_the_shared_exception(self, code: str):
-        """fix(#1847): one condition, one shape.
+        """One condition, one shape.
 
         Returning a 409 of its own here gave a contended row two response
         bodies, depending on whether the acquisition or a later statement hit
@@ -693,7 +686,7 @@ class TestEveryWriteHandlerGoesThroughTheGuard:
         )
 
     def test_every_write_handler_acquires_on_every_path(self):
-        """fix(#1847): unconditionally, or in BOTH arms of the if.
+        """Unconditionally, or in BOTH arms of the if.
 
         Three handlers refresh unconditionally, so they hold the pair before
         they stamp `record.updated_by` and roll `tile_cache_version`. The PATCH
@@ -753,7 +746,7 @@ class TestEveryWriteHandlerGoesThroughTheGuard:
 
 
 class TestMetadataPatchTakesThePairToo:
-    """fix(#1847): the class from the other side.
+    """The class from the other side.
 
     `update_user_metadata` writes record fields and dataset fields and then
     flushes them together. Before this round it acquired nothing, so the flush
@@ -817,7 +810,7 @@ class TestMetadataPatchTakesThePairToo:
 
 
 class TestOneAnswerForAContendedRow:
-    """fix(#1847): 409 from every caller, not 409/503/400 by route.
+    """409 from every caller, not 409/503/400 by route.
 
     The acquisition is reached from feature writes, metadata edits, layer DDL
     and dataset deletion. Each classified a lost race differently until the
@@ -899,7 +892,7 @@ class TestOneAnswerForAContendedRow:
 
 
 class TestDeleteNeverReapsStorageItCannotCommit:
-    """fix(#1847): the irreversible step must be behind the lock.
+    """The irreversible step must be behind the lock.
 
     `delete_dataset` deletes the managed objects permanently and relies on the
     transaction rolling back to keep the catalog consistent with them. An
@@ -952,7 +945,7 @@ class TestDeleteNeverReapsStorageItCannotCommit:
 
 
 class TestOneShapeForEveryContendedRow:
-    """fix(#1847): every endpoint answers a contended row the same way.
+    """Every endpoint answers a contended row the same way.
 
     Two shapes were in play. The feature router returned its own 409 body for
     a lock conflict raised by a statement other than the acquisition, and the
@@ -993,7 +986,7 @@ class TestOneShapeForEveryContendedRow:
     async def test_one_failed_item_does_not_poison_the_rest(
         self, client: AsyncClient, test_db_session, admin_auth_header
     ):
-        """fix(#1847): found while making the conflict per-item.
+        """A pre-existing bug, found while making the conflict per-item.
 
         Any per-item failure rolled the session back, which expires every
         instance in it including the actor. The next item's access check then
@@ -1108,7 +1101,7 @@ class TestOneShapeForEveryContendedRow:
 
 
 class TestTheRasterChildIsHeldBeforeTheReap:
-    """codex r5 P1: the delete reaps raster objects it may not get to commit.
+    """The delete must not reap raster objects it may not get to commit.
 
     The replace worker holds the RasterAsset row across its upload and only
     then takes the pair. A delete that took the pair, reaped the raster prefix,
@@ -1160,7 +1153,7 @@ class TestTheRasterChildIsHeldBeforeTheReap:
 
 
 class TestALaterLockWaitAnswersTheSameWay:
-    """codex r5 P2: the timeout outlives the acquisition it was set for.
+    """The timeout outlives the acquisition it was set for.
 
     `SET LOCAL lock_timeout` holds for the whole transaction, so a wait after
     the pair is taken raises 55P03 from a statement the acquisition's own
@@ -1170,7 +1163,7 @@ class TestALaterLockWaitAnswersTheSameWay:
     async def test_is_dem_waits_at_the_raster_row_holding_nothing(
         self, locked_dataset, client: AsyncClient, admin_auth_header, monkeypatch
     ):
-        """codex r6: the request must reach for raster_assets FIRST.
+        """The request must reach for raster_assets FIRST.
 
         Holding the pair and then asking for the raster row is the opposite of
         the replace worker's order, and the worker is the side that cannot be
@@ -1285,7 +1278,7 @@ class TestALaterLockWaitAnswersTheSameWay:
 
 
 class TestRecoverySurvivesANonMappedIdentity:
-    """codex r5 P2: the recovery path assumed the actor was a mapped User.
+    """The recovery path must not assume the actor is a mapped User.
 
     An `IdentityExtension` supplies an identity that is not a mapped instance,
     and `AsyncSession.refresh()` raises `UnmappedInstanceError` on one -- from
@@ -1318,7 +1311,7 @@ class TestRecoverySurvivesANonMappedIdentity:
 
 
 class TestTheReapFollowsTheCommit:
-    """codex r7 P1: the irreversible step must not precede a cascade that can fail.
+    """The irreversible step must not precede a cascade that can fail.
 
     The record delete cascades to child rows nobody locks (map_layers,
     record_embeddings, dataset_assets). Under the request timeout a contended
@@ -1753,10 +1746,8 @@ class TestWorkerDoorsAcquireBeforeTheirWrites:
 # The class gate (fix(#1847))
 # ---------------------------------------------------------------------------
 
-# A function that writes BOTH catalog rows must acquire them in the house
-# order first, or appear here with the reason it cannot deadlock. Adding a name
-# is a decision, not a formality: read
-# app.platform.catalog_locks.lock_catalog_rows before you do.
+# A function that writes BOTH catalog rows acquires them in the house order
+# first, or appears here with the reason it cannot deadlock.
 _PAIR_WRITER_EXEMPTIONS = {
     # --- both rows are INSERTed by this transaction ------------------------
     # No other transaction can hold either one, so there is nothing to order
@@ -1777,19 +1768,17 @@ _PAIR_WRITER_EXEMPTIONS = {
     # --- writes one half; the caller owns the ordering ---------------------
     "app.processing.ingest.tasks_common.apply_manifest_record_metadata": "record only",
     "app.processing.ingest.tasks_raster_swap._write_swapped_fields": "sync, no session; reupload_raster acquires before calling it",
-    # --- takes the datasets row FOR UPDATE itself --------------------------
-    # These are the sites the house order was chosen to match. They do not go
-    # through the helper because the lock and the superseded-content check are
-    # one indivisible step.
+    # --- takes the datasets row FOR UPDATE itself -------------------------
+    # The lock and the superseded-content check are one step here, so these do
+    # not go through the helper.
     "app.processing.ingest.tasks_postgis_refresh._apply_measurement": "caller refresh_postgis holds datasets FOR UPDATE",
     "app.processing.ingest.tasks_postgis_refresh.refresh_postgis": "takes datasets FOR UPDATE for its superseded guard",
     "app.processing.ingest.tasks_stac_refresh.refresh_stac": "takes datasets FOR UPDATE for its superseded guard",
 }
 
 
-# Functions that assign catalog fields in memory before acquiring, and hold
-# those assignments under `no_autoflush` until after it, so no write reaches
-# the database first. The reason is enforced, not asserted: see
+# Assigns catalog fields in memory before acquiring, held under `no_autoflush`
+# until after it. The reason is enforced by
 # test_the_deferred_flush_exemption_still_holds.
 _INMEMORY_UNTIL_ACQUIRED = {
     "app.processing.ingest.tasks_raster_replace.reupload_raster": (
@@ -1848,11 +1837,8 @@ def _module_qualname(rel) -> str:
 def _local_bindings(tree, module: str) -> dict[str, str]:
     """Local name -> qualified target, from this module's imports and defs.
 
-    fix(#1847): the previous scan keyed everything on the bare
-    function name and merged across files, so any function that happened to
-    share a name with one of the real acquirers inherited its exemption. A
-    call is resolved through the binding that is actually in scope where it
-    appears.
+    A call resolves through the binding in scope where it appears, so a
+    function sharing a name with an acquirer does not inherit its exemption.
     """
     import ast
 
@@ -1917,10 +1903,8 @@ def _classify_base(base) -> str | None:
 def _core_statement_kind(node) -> str | None:
     """'record'/'dataset' for a Core ``update(X)`` / ``delete(X)`` on the pair.
 
-    fix(#1847): latent rather than active today -- the two
-    ``update(Dataset)`` sites write the datasets row alone -- but a Core
-    statement is a write the attribute scan cannot see at all, so the first one
-    that touches both rows would have been invisible.
+    A Core statement is a write the attribute scan cannot see, so the first
+    one to touch both rows would otherwise be invisible.
     """
     import ast
 
@@ -1972,10 +1956,9 @@ def _write_kinds(node) -> set[str]:
     import ast
 
     kinds: set[str] = set()
-    # `session.delete(dataset.record)` removes the records row AND, by the FK
-    # cascade on Dataset.record_id, the datasets row. Neither is an attribute
-    # assignment, so without this the one endpoint that deletes a dataset is
-    # invisible to the scan (fix(#1847)).
+    # `session.delete(dataset.record)` removes the records row AND, by FK
+    # cascade, the datasets row. Neither is an attribute assignment, so the
+    # delete endpoint would otherwise be invisible to the scan.
     if (
         isinstance(node, ast.Call)
         and isinstance(node.func, ast.Attribute)
@@ -2185,17 +2168,13 @@ def _acq_predicate(bindings, module, reach):
 def _write_predicate(bindings, module, is_acq, reaches_write):
     """A write here, or a call to something that writes.
 
-    fix(#1847): the scan used to see only assignments in this body, so a
-    wrapper that called a record-writing helper, acquired, then called a
-    dataset-writing helper emitted records-before-datasets and passed.
+    A body-only scan misses a wrapper whose halves are both in callees.
     """
     import ast
 
     def is_write(node) -> bool:
-        # Pair writes only. A raster_assets write belongs BEFORE the pair, not
-        # after it, so requiring the pair acquisition ahead of one would demand
-        # the inversion this file exists to prevent. That ordering is
-        # test_a_raster_writer_orders_the_child_first.
+        # Pair writes only: a raster_assets write belongs BEFORE the pair,
+        # and is ordered by test_a_raster_writer_orders_the_child_first.
         if _write_kinds(node) & {"record", "dataset"}:
             return True
         if not isinstance(node, ast.Call) or is_acq(node):
@@ -2213,11 +2192,9 @@ def acquisition_dominates_writes(
 ) -> tuple[bool, str]:
     """Does an acquisition precede every write, on every path through *fn*?
 
-    fix(#1847): merely calling the helper somewhere in the body proves nothing.
-    After the writes it orders nothing; in one arm of an `if` it orders nothing
-    on the other. *acquirers* and *writers* are the transitive sets, so a
-    handler that acquires or writes through a wrapper is judged on what that
-    wrapper does.
+    Calling the helper somewhere in the body proves nothing: after the writes
+    it orders nothing, and in one arm of an `if` it orders nothing on the
+    other. *acquirers* and *writers* are the transitive sets.
     """
     import ast
 
@@ -2293,7 +2270,7 @@ class TestEveryPairWriterTakesTheHouseOrder:
         )
 
     def test_the_acquisition_precedes_the_writes_on_every_path(self):
-        """fix(#1847): position and branch, not mere presence.
+        """Position and branch, not mere presence.
 
         Calling the helper somewhere in the body proves nothing. After the
         writes it orders nothing, and in one arm of an `if` it orders nothing
@@ -2313,11 +2290,8 @@ class TestEveryPairWriterTakesTheHouseOrder:
                 or key in _INMEMORY_UNTIL_ACQUIRED
             ):
                 continue
-            # Checked for every function that acquires OR writes both rows,
-            # whether its writes are its own or a callee's. Selecting on direct
-            # writes alone skipped the wrapper shape entirely, and selecting on
-            # pair writers alone missed a helper that writes one row and
-            # acquires after it (`layers.service.add_column`).
+            # Every acquirer OR pair writer, whether its writes are its own
+            # or a callee's: either selection alone has a blind spot.
             if key not in acquirers and key not in writers:
                 continue
             if not (_direct_writes(fn) or key in writers):
@@ -2334,12 +2308,10 @@ class TestEveryPairWriterTakesTheHouseOrder:
         )
 
     def test_a_raster_writer_orders_the_child_first(self):
-        """codex r6: the third site of this class, so the gate takes it over.
+        """The gate owns this class now, not a human reading diffs.
 
-        The replace worker holds `raster_assets` across its upload and asks for
-        the pair afterwards. Any request path that takes the pair and then
-        writes that row is the opposite order, which is an ABBA whose victim
-        can be the retry-disabled worker.
+        The replace worker holds `raster_assets` across its upload and asks
+        for the pair afterwards, so taking the pair first is an ABBA.
         """
         acquirers = _acquiring_functions()
         raster_writers = _raster_writer_report()
@@ -2496,7 +2468,7 @@ class TestTheGateRejectsWhatItExistsToCatch:
         )
 
     def test_a_wrapper_whose_writes_are_all_in_callees_is_rejected(self):
-        """fix(#1847): the shape codex round 4 found the gate blind to.
+        """The shape the gate was blind to: writes only in callees.
 
         Nothing in this body assigns a catalog field, so a scan that looked at
         direct writes alone saw no writes to order and skipped the function

--- a/backend/tests/test_feature_lock_order_1847.py
+++ b/backend/tests/test_feature_lock_order_1847.py
@@ -294,7 +294,7 @@ class TestPropertyOnlyPatchTakesThePairToo:
     ):
         """End to end, over HTTP, with the worker holding the datasets row.
 
-        The request never recomputes an extent, so before fix(#1847 review r1)
+        The request never recomputes an extent, so before fix(#1847)
         it took no catalog lock at all and its first touch of either row was
         the flush at ``commit()`` -- records, then datasets. That is the
         original inversion, on the one handler whose refresh is conditional.
@@ -634,7 +634,7 @@ class TestEveryWriteHandlerGoesThroughTheGuard:
         )
 
     def test_every_write_handler_acquires_on_every_path(self):
-        """fix(#1847 review r1): unconditionally, or in BOTH arms of the if.
+        """fix(#1847): unconditionally, or in BOTH arms of the if.
 
         Three handlers refresh unconditionally, so they hold the pair before
         they stamp `record.updated_by` and roll `tile_cache_version`. The PATCH
@@ -694,7 +694,7 @@ class TestEveryWriteHandlerGoesThroughTheGuard:
 
 
 class TestMetadataPatchTakesThePairToo:
-    """fix(#1847 review r2): the class from the other side.
+    """fix(#1847): the class from the other side.
 
     `update_user_metadata` writes record fields and dataset fields and then
     flushes them together. Before this round it acquired nothing, so the flush
@@ -758,7 +758,7 @@ class TestMetadataPatchTakesThePairToo:
 
 
 class TestOneAnswerForAContendedRow:
-    """fix(#1847 review r3): 409 from every caller, not 409/503/400 by route.
+    """fix(#1847): 409 from every caller, not 409/503/400 by route.
 
     The acquisition is reached from feature writes, metadata edits, layer DDL
     and dataset deletion. Each classified a lost race differently until the
@@ -840,7 +840,7 @@ class TestOneAnswerForAContendedRow:
 
 
 class TestDeleteNeverReapsStorageItCannotCommit:
-    """fix(#1847 review r3): the irreversible step must be behind the lock.
+    """fix(#1847): the irreversible step must be behind the lock.
 
     `delete_dataset` deletes the managed objects permanently and relies on the
     transaction rolling back to keep the catalog consistent with them. An
@@ -926,19 +926,11 @@ class TestDeleteNeverReapsStorageItCannotCommit:
 
 
 class TestTheOtherSitesHoldTheOrderToo:
-    """fix(#1847 review r3 P2-5): DB-backed coverage for the sites that had none.
+    """The layers DDL, the delete and the metadata PATCH, against a held row.
 
-    Rounds 0 to 2 shipped concurrency tests for the feature paths and the
-    metadata PATCH; the layers DDL, the delete and the worker doors were
-    carried by the static gate alone, and P2-1 showed that gate accepting the
-    wrong position and the wrong branch. These drive the real endpoints against
-    a held dataset row.
-
-    None of them monkeypatches the budget. The round-2 tests raised
-    REQUEST_LOCK_TIMEOUT to 60s to keep the interleaving deterministic, and
-    that is what hid the 500 and the 400 the round-3 P2 reports. The barrier
-    below fires in milliseconds, so the production 2s budget is not reached --
-    and if it ever were, the answer is a 409, which these tests accept.
+    None of these monkeypatches REQUEST_LOCK_TIMEOUT: raising it hides how a
+    contended row is actually answered. The barrier fires in milliseconds, so
+    the 2s budget is not reached, and a 409 is accepted if it ever is.
     """
 
     async def _drive(self, holder, probe, dataset_id, request_coro):
@@ -1053,15 +1045,12 @@ class TestTheOtherSitesHoldTheOrderToo:
 
 
 class TestWorkerDoorsAcquireBeforeTheirWrites:
-    """The three worker sites, checked on emitted SQL rather than by racing.
+    """The three worker sites, checked on emitted order rather than by racing.
 
-    A reupload, a raster replace and a VRT publish each need a staged upload
-    and a live ingest job to reach their swap, which is a fixture an order of
-    magnitude larger than the property under test. What has to be true is an
-    ordering, and the ordering is visible in the statements the transaction
-    emits -- so these read it there, the way
-    `test_reupload_swap_lock_retry.py::TestSwapLocksBeforeItWrites` does end to
-    end for the reupload door with a real session.
+    Each needs a staged upload and a live ingest job to reach its swap, and the
+    property under test is an ordering.
+    `test_reupload_swap_lock_retry.py::TestSwapLocksBeforeItWrites` drives the
+    reupload door end to end against a real session.
     """
 
     SITES = [
@@ -1127,7 +1116,7 @@ class TestWorkerDoorsAcquireBeforeTheirWrites:
 
 
 # ---------------------------------------------------------------------------
-# The class gate (fix(#1847 review r2))
+# The class gate (fix(#1847))
 # ---------------------------------------------------------------------------
 
 # A function that writes BOTH catalog rows must acquire them in the house
@@ -1197,7 +1186,7 @@ def _module_qualname(rel) -> str:
 def _local_bindings(tree, module: str) -> dict[str, str]:
     """Local name -> qualified target, from this module's imports and defs.
 
-    fix(#1847 review r3 P2-1): the previous scan keyed everything on the bare
+    fix(#1847): the previous scan keyed everything on the bare
     function name and merged across files, so any function that happened to
     share a name with one of the real acquirers inherited its exemption. A
     call is resolved through the binding that is actually in scope where it
@@ -1256,7 +1245,7 @@ def _classify_base(base) -> str | None:
 def _core_statement_kind(node) -> str | None:
     """'record'/'dataset' for a Core ``update(X)`` / ``delete(X)`` on the pair.
 
-    fix(#1847 review r3 P2-1): latent rather than active today -- the two
+    fix(#1847): latent rather than active today -- the two
     ``update(Dataset)`` sites write the datasets row alone -- but a Core
     statement is a write the attribute scan cannot see at all, so the first one
     that touches both rows would have been invisible.
@@ -1312,7 +1301,7 @@ def _write_kinds(node) -> set[str]:
     # `session.delete(dataset.record)` removes the records row AND, by the FK
     # cascade on Dataset.record_id, the datasets row. Neither is an attribute
     # assignment, so without this the one endpoint that deletes a dataset is
-    # invisible to the scan (fix(#1847 review r3 P2-1)).
+    # invisible to the scan (fix(#1847)).
     if (
         isinstance(node, ast.Call)
         and isinstance(node.func, ast.Attribute)
@@ -1467,7 +1456,7 @@ def acquisition_dominates_writes(
 ) -> tuple[bool, str]:
     """Does an acquisition precede every write, on every path through *fn*?
 
-    fix(#1847 review r3 P2-1): the round-2 check accepted a call to the helper
+    fix(#1847): the round-2 check accepted a call to the helper
     ANYWHERE in the body, so an acquisition placed after the writes, or in one
     arm of an `if`, passed. Both are the defect this gate exists to catch.
 
@@ -1530,13 +1519,10 @@ def acquisition_dominates_writes(
 
 
 class TestEveryPairWriterTakesTheHouseOrder:
-    """fix(#1847 review r2): the class, not the four handlers that started it.
+    """Every transaction that writes both catalog rows must acquire first.
 
-    SQLAlchemy flushes catalog.records before catalog.datasets, so ANY
-    transaction that writes both rows and acquires nothing takes them in the
-    inverted order and can deadlock against a writer holding the dataset row.
-    Codex round 2 found `update_user_metadata` this way; this test is what
-    stops the next one being found in production instead.
+    SQLAlchemy flushes catalog.records before catalog.datasets, so one that
+    acquires nothing inverts against every writer holding the dataset row.
     """
 
     def test_every_pair_writer_acquires_or_is_exempt(self):
@@ -1558,7 +1544,7 @@ class TestEveryPairWriterTakesTheHouseOrder:
         )
 
     def test_the_acquisition_precedes_the_writes_on_every_path(self):
-        """fix(#1847 review r3 P2-1): position and branch, not mere presence.
+        """fix(#1847): position and branch, not mere presence.
 
         Calling the helper somewhere in the body proves nothing. After the
         writes it orders nothing, and in one arm of an `if` it orders nothing
@@ -1581,7 +1567,7 @@ class TestEveryPairWriterTakesTheHouseOrder:
             # datasets row and then acquires has already let the flush order
             # the pair, even though its own body never touches the record --
             # which is how the first version of this check missed
-            # `layers.service.add_column` (fix(#1847 review r3 P2-1)).
+            # `layers.service.add_column` (fix(#1847)).
             if key not in acquirers and key not in writers:
                 continue
             ok, why = acquisition_dominates_writes(fn, bindings, module, acquirers)
@@ -1624,11 +1610,9 @@ class TestEveryPairWriterTakesTheHouseOrder:
 
 
 class TestTheGateRejectsWhatItExistsToCatch:
-    """fix(#1847 review r3 P2-1): a negative fixture per probe.
+    """A negative fixture per shape the gate must reject.
 
-    An audit probed the round-2 gate by adding functions under `app/` and found
-    it silent on four shapes. Each is reproduced here as a synthetic module, so
-    the gate's blind spots fail this file rather than a future review.
+    Each is a synthetic module, so a blind spot fails this file.
     """
 
     MODULE = "app.fixture.probe"

--- a/backend/tests/test_feature_lock_order_1847.py
+++ b/backend/tests/test_feature_lock_order_1847.py
@@ -236,6 +236,23 @@ async def _holds_attribute_lock(probe, attribute_id: uuid.UUID) -> bool:
     return False
 
 
+async def _await_relation_waiter(probe, table_name: str) -> None:
+    """Block until somebody is queued on a lock of ``data.<table_name>``."""
+    for _ in range(_BARRIER_POLLS):
+        waiters = await probe.scalar(
+            text(
+                "SELECT count(*) FROM pg_locks WHERE NOT granted "
+                "AND locktype = 'relation' AND relation = to_regclass(:rel)"
+            ),
+            {"rel": f"data.{table_name}"},
+        )
+        await probe.rollback()
+        if waiters:
+            return
+        await asyncio.sleep(_BARRIER_INTERVAL_SECONDS)
+    raise AssertionError(f"nobody queued on data.{table_name}")
+
+
 class TestLockOrderAgainstRefreshPhaseThree:
     """The request must reach for the datasets row before the records row."""
 
@@ -936,6 +953,83 @@ class TestAttributeEditsTakeThePairToo:
             assert calls["lock_catalog_rows_for_write"] < calls[writer], (
                 f"{handler} writes the attribute row before taking the pair"
             )
+        reset_calls = seen["reset_attribute_endpoint"]
+        assert "sample_example_values" in reset_calls
+        assert (
+            reset_calls["sample_example_values"]
+            < reset_calls["lock_catalog_rows_for_write"]
+        ), "reset_attribute_endpoint reads the data table after taking the pair"
+
+    async def test_reset_holds_no_catalog_row_while_waiting_for_the_table(
+        self,
+        locked_dataset,
+        client: AsyncClient,
+        test_db_session,
+        admin_auth_header,
+        monkeypatch,
+    ):
+        """The reset samples the data table; a DDL holds that table before it
+        takes the pair, so the reset must reach for the table holding nothing.
+        """
+        monkeypatch.setattr(catalog_locks, "REQUEST_LOCK_TIMEOUT", "60s")
+
+        import app.core.db as db_module
+        from app.modules.catalog.datasets.domain.models import AttributeMetadata
+
+        attr = AttributeMetadata(
+            dataset_id=locked_dataset.id,
+            field_name="name",
+            title="Name",
+            data_type="text",
+        )
+        test_db_session.add(attr)
+        await test_db_session.commit()
+        await test_db_session.refresh(attr)
+
+        async with (
+            db_module.async_session() as holder,
+            db_module.async_session() as probe,
+        ):
+            # A column DDL's first lock, held until its transaction ends.
+            await holder.execute(
+                text(
+                    f"LOCK TABLE data.{locked_dataset.table_name} "
+                    "IN ACCESS EXCLUSIVE MODE"
+                )
+            )
+            reset = asyncio.create_task(
+                client.post(
+                    f"/datasets/{locked_dataset.id}/attributes/{attr.id}/reset/",
+                    headers=admin_auth_header,
+                )
+            )
+            try:
+                await _await_relation_waiter(probe, locked_dataset.table_name)
+                assert not await _holds_record_lock(probe, locked_dataset.record_id), (
+                    "the attribute reset is parked on the data table while "
+                    "holding the catalog pair, which deadlocks against a column "
+                    "DDL holding the table and taking the pair next."
+                )
+                # The DDL's next step; NOWAIT so a held pair fails instead of
+                # deadlocking the test itself.
+                await holder.execute(
+                    select(Dataset.tile_cache_version)
+                    .where(Dataset.id == locked_dataset.id)
+                    .with_for_update(nowait=True)
+                )
+                await holder.execute(
+                    select(Record.id)
+                    .where(Record.id == locked_dataset.record_id)
+                    .with_for_update(nowait=True)
+                )
+                await holder.commit()
+            except BaseException:
+                await holder.rollback()
+                raise
+            response = await reset
+
+        assert response.status_code == 200, response.text
+        assert response.json()["example_values"] == ["seed"]
 
 
 class TestOneAnswerForAContendedRow:

--- a/backend/tests/test_feature_lock_order_1847.py
+++ b/backend/tests/test_feature_lock_order_1847.py
@@ -12,9 +12,12 @@ or does not.
 The DB-backed tests require the Docker test database.
 """
 
+import ast
 import asyncio
 import functools
+import inspect
 import uuid
+from pathlib import Path
 
 import pytest
 from httpx import AsyncClient
@@ -1542,6 +1545,85 @@ class TestDeleteLeadsWithTheJobRows:
         )
         await test_db_session.commit()
         assert response.status_code == 204, response.text
+
+
+class TestEveryJobWriterLeadsWithTheJobRow:
+    """A transaction that writes its ingest-job row and locks a catalog or
+    raster row takes the job row first, the order the dataset delete holds.
+    """
+
+    _JOB_WRITES = ("require_ingest_job_update(", "update_ingest_job_for_attempt(")
+    _ROW_LOCKS = ("lock_catalog_rows", "lock_catalog_rows_for_write")
+
+    @classmethod
+    def _first_locks(cls, body: list[ast.stmt]) -> tuple[int | None, int | None]:
+        """(first job-row lock line, first other row lock line), source order."""
+        job = other = None
+        nodes = sorted(
+            (n for stmt in body for n in ast.walk(stmt)),
+            key=lambda n: getattr(n, "lineno", 0),
+        )
+        for node in nodes:
+            if not isinstance(node, ast.Call):
+                continue
+            func = ast.unparse(node.func)
+            if func.endswith(".with_for_update"):
+                if "IngestJob" in ast.unparse(node.func.value):
+                    job = node.lineno if job is None else job
+                else:
+                    other = node.lineno if other is None else other
+            elif func.rsplit(".", 1)[-1] in cls._ROW_LOCKS:
+                other = node.lineno if other is None else other
+        return job, other
+
+    def test_every_worker_transaction_that_writes_the_job_locks_it_first(self):
+        import app
+
+        offenders: list[str] = []
+        root = Path(app.__file__).parent / "processing"
+        for path in sorted(root.rglob("*.py")):
+            for node in ast.walk(ast.parse(path.read_text())):
+                if not isinstance(node, ast.AsyncWith):
+                    continue
+                for item in node.items:
+                    call = item.context_expr
+                    if not isinstance(call, ast.Call):
+                        continue
+                    name = ast.unparse(call.func).rsplit(".", 1)[-1]
+                    if name not in ("async_session", "_job_phase_session"):
+                        continue
+                    body = "\n".join(ast.unparse(stmt) for stmt in node.body)
+                    if not any(write in body for write in self._JOB_WRITES):
+                        continue
+                    job, other = self._first_locks(node.body)
+                    if other is None:
+                        continue
+                    if name == "_job_phase_session":
+                        ok = any(k.arg == "require_status" for k in call.keywords)
+                    else:
+                        ok = job is not None and job < other
+                    if not ok:
+                        offenders.append(f"{path.relative_to(root)}:{node.lineno}")
+        assert offenders == [], offenders
+
+    def test_the_sweep_sees_the_two_phases_it_exists_for(self):
+        import app
+
+        root = Path(app.__file__).parent / "processing" / "ingest"
+        seen = 0
+        for name in ("tasks_vrt.py", "tasks_stac_refresh.py"):
+            for node in ast.walk(ast.parse((root / name).read_text())):
+                if isinstance(node, ast.AsyncWith):
+                    job, other = self._first_locks(node.body)
+                    seen += job is not None and other is not None
+        assert seen >= 2
+
+    def test_cancel_leads_with_the_job_row_for_every_job_type(self):
+        from app.platform.jobs.router import cancel_job
+
+        src = inspect.getsource(cancel_job)
+        first_row_lock = src.find(".with_for_update(")
+        assert first_row_lock == -1 or src.index("update(IngestJob)") < first_row_lock
 
 
 class TestALaterLockWaitAnswersTheSameWay:

--- a/backend/tests/test_feature_lock_order_1847.py
+++ b/backend/tests/test_feature_lock_order_1847.py
@@ -17,6 +17,7 @@ The DB-backed tests require the Docker test database.
 """
 
 import asyncio
+import functools
 import uuid
 
 import pytest
@@ -26,6 +27,7 @@ from sqlalchemy.dialects import postgresql
 from sqlalchemy.exc import DBAPIError
 
 from app.core.db.sqlstate import is_lock_conflict
+from app.platform import catalog_locks
 from app.modules.catalog.datasets.domain.models import Dataset, Record
 from app.modules.catalog.features import service as features_service
 from app.modules.catalog.features.router import _feature_write_db_error
@@ -184,7 +186,7 @@ class TestLockOrderAgainstRefreshPhaseThree:
         # This test is about acquisition ORDER, so give the wait a budget the
         # barrier below cannot plausibly exhaust. The 2s production value is
         # exercised by test_lock_timeout_is_set_on_the_acquisition.
-        monkeypatch.setattr(features_service, "_LOCK_TIMEOUT", "60s")
+        monkeypatch.setattr(catalog_locks, "REQUEST_LOCK_TIMEOUT", "60s")
 
         import app.core.db as db_module
 
@@ -228,7 +230,7 @@ class TestLockOrderAgainstRefreshPhaseThree:
         self, locked_dataset, monkeypatch
     ):
         """Drive both sides of the cycle and require neither to be aborted."""
-        monkeypatch.setattr(features_service, "_LOCK_TIMEOUT", "60s")
+        monkeypatch.setattr(catalog_locks, "REQUEST_LOCK_TIMEOUT", "60s")
 
         import app.core.db as db_module
 
@@ -297,7 +299,7 @@ class TestPropertyOnlyPatchTakesThePairToo:
         the flush at ``commit()`` -- records, then datasets. That is the
         original inversion, on the one handler whose refresh is conditional.
         """
-        monkeypatch.setattr(features_service, "_LOCK_TIMEOUT", "60s")
+        monkeypatch.setattr(catalog_locks, "REQUEST_LOCK_TIMEOUT", "60s")
 
         import app.core.db as db_module
 
@@ -382,7 +384,7 @@ class TestPropertyOnlyPatchTakesThePairToo:
         the middle, so on the inverted order PostgreSQL reports the cycle
         itself rather than a message this test composed.
         """
-        monkeypatch.setattr(features_service, "_LOCK_TIMEOUT", "60s")
+        monkeypatch.setattr(catalog_locks, "REQUEST_LOCK_TIMEOUT", "60s")
 
         import app.core.db as db_module
 
@@ -508,7 +510,7 @@ class TestEmittedSqlPinsTheOrder:
             "queued behind a long refresh answers a retryable conflict rather "
             f"than hanging. Got {session.statements[0]}"
         )
-        assert features_service._LOCK_TIMEOUT in session.statements[0]
+        assert catalog_locks.REQUEST_LOCK_TIMEOUT in session.statements[0]
 
 
 class TestWorkerSitesLeadWithTheDatasetRow:
@@ -689,3 +691,303 @@ class TestEveryWriteHandlerGoesThroughTheGuard:
                 "flush order them records-first and re-opens #1847."
             )
         assert seen == handlers, f"handlers not found: {sorted(handlers - seen)}"
+
+
+class TestMetadataPatchTakesThePairToo:
+    """fix(#1847 review r2): the class from the other side.
+
+    `update_user_metadata` writes record fields and dataset fields and then
+    flushes them together. Before this round it acquired nothing, so the flush
+    took catalog.records ahead of catalog.datasets and inverted against every
+    writer that now leads with the dataset row -- including an ordinary feature
+    edit, which is the pairing this issue exists to remove.
+    """
+
+    async def test_metadata_patch_holds_no_record_lock_while_waiting(
+        self, locked_dataset, client: AsyncClient, admin_auth_header, monkeypatch
+    ):
+        monkeypatch.setattr(catalog_locks, "REQUEST_LOCK_TIMEOUT", "60s")
+
+        import app.core.db as db_module
+
+        async with (
+            db_module.async_session() as holder,
+            db_module.async_session() as probe,
+        ):
+            # Stand in for a feature edit, which now holds the dataset row for
+            # the rest of its transaction.
+            await holder.execute(
+                select(Dataset.tile_cache_version)
+                .where(Dataset.id == locked_dataset.id)
+                .with_for_update()
+            )
+            holder_xid = await holder.scalar(text("SELECT pg_current_xact_id()::text"))
+
+            # Both halves in one body: a record field and a dataset field.
+            patch = asyncio.create_task(
+                client.patch(
+                    f"/datasets/{locked_dataset.id}",
+                    json={
+                        "title": "Renamed by the metadata patch",
+                        "tile_columns": ["name"],
+                    },
+                    headers=admin_auth_header,
+                )
+            )
+            try:
+                await _await_waiter_on(probe, holder_xid)
+                assert not await _holds_record_lock(probe, locked_dataset.record_id), (
+                    "the metadata PATCH is parked on a lock while holding "
+                    "catalog.records, which deadlocks against a feature edit "
+                    "holding catalog.datasets."
+                )
+                await holder.execute(
+                    text(
+                        "UPDATE catalog.records SET updated_at = now() WHERE id = :rid"
+                    ),
+                    {"rid": locked_dataset.record_id},
+                )
+                await holder.commit()
+            except BaseException:
+                await holder.rollback()
+                raise
+            response = await patch
+
+        assert response.status_code == 200, response.text
+        assert response.json()["title"] == "Renamed by the metadata patch"
+
+
+# ---------------------------------------------------------------------------
+# The class gate (fix(#1847 review r2))
+# ---------------------------------------------------------------------------
+
+# A function that writes BOTH catalog rows must acquire them in the house
+# order first, or appear here with the reason it cannot deadlock. Adding a name
+# is a decision, not a formality: read
+# app.platform.catalog_locks.lock_catalog_rows before you do.
+_PAIR_WRITER_EXEMPTIONS = {
+    # Both rows are INSERTed by this transaction, so no other transaction can
+    # be holding either one. There is nothing to order against.
+    "create_dataset": "creates the pair",
+    "create_empty_dataset": "delegates to create_dataset",
+    "create_layer": "creates the pair",
+    "create_raster_dataset": "creates the pair",
+    "create_vrt_dataset": "creates the pair",
+    "_finalize_ingest": "creates the pair through the port, then stamps it",
+    "ingest_raster": "creates the pair, then stamps it",
+    "stac_import": "creates one pair per item inside its own savepoint",
+    "_materialize": "registers a new pair, then applies provenance to it",
+    "materialize_analysis": "task wrapper around _materialize",
+    "ingest_file": "task wrapper around _finalize_ingest",
+    "ingest_service": "task wrapper around _finalize_ingest",
+    "apply_analysis_provenance": "writes only the record of a pair being created",
+    # Writes the record half only; every caller is enumerated above.
+    "apply_manifest_record_metadata": "record only",
+    # Sync helper. Its caller (reupload_raster) takes the pair before calling
+    # it -- asserted by test_every_pair_writer_acquires_or_is_exempt itself,
+    # which sees the acquisition in the caller.
+    "_write_swapped_fields": "caller acquires; sync, no session of its own",
+    # These two take the datasets row FOR UPDATE themselves, before writing
+    # either half, as the superseded-content guard their own comments describe.
+    # They are the reason the house order is datasets-first; they do not go
+    # through the helper because the lock and the token check are one step.
+    "_apply_measurement": "caller refresh_postgis holds datasets FOR UPDATE",
+    "refresh_postgis": "takes datasets FOR UPDATE for its superseded guard",
+    "refresh_stac": "takes datasets FOR UPDATE for its superseded guard",
+}
+
+
+def _assignment_targets(node):
+    """Every Attribute node this statement assigns to."""
+    import ast
+
+    targets = list(getattr(node, "targets", []) or [])
+    single = getattr(node, "target", None)
+    if single is not None:
+        targets.append(single)
+    return [t for t in targets if isinstance(t, ast.Attribute)]
+
+
+def _classify_base(base) -> str | None:
+    """'record', 'dataset', or None for the object being written to."""
+    import ast
+
+    if isinstance(base, ast.Attribute):
+        if base.attr == "record":
+            return "record"
+        if "dataset" in base.attr:
+            return "dataset"
+    if isinstance(base, ast.Name):
+        if base.id in ("record", "rec"):
+            return "record"
+        if "dataset" in base.id:
+            return "dataset"
+    return None
+
+
+def _direct_writes(fn) -> set[str]:
+    """Which halves of the pair this function body writes on its own."""
+    import ast
+
+    kinds: set[str] = set()
+    for node in ast.walk(fn):
+        if isinstance(node, (ast.Assign, ast.AugAssign, ast.AnnAssign)):
+            for attr in _assignment_targets(node):
+                kind = _classify_base(attr.value)
+                if kind:
+                    kinds.add(kind)
+        # `setattr(record, name, value)` is the same write by another spelling,
+        # and it is how update_user_metadata assigns most of its fields.
+        elif (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "setattr"
+            and node.args
+        ):
+            kind = _classify_base(node.args[0])
+            if kind:
+                kinds.add(kind)
+    return kinds
+
+
+def _called_names(fn) -> set[str]:
+    import ast
+
+    names = set()
+    for node in ast.walk(fn):
+        if isinstance(node, ast.Call):
+            if isinstance(node.func, ast.Name):
+                names.add(node.func.id)
+            elif isinstance(node.func, ast.Attribute):
+                names.add(node.func.attr)
+    return names
+
+
+def _walk_app_functions():
+    import ast
+    from pathlib import Path
+
+    app_dir = Path(__file__).resolve().parents[1] / "app"
+    for path in sorted(app_dir.rglob("*.py")):
+        try:
+            tree = ast.parse(path.read_text())
+        except SyntaxError:  # pragma: no cover
+            continue
+        for fn in ast.walk(tree):
+            if isinstance(fn, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                yield path.relative_to(app_dir.parent), fn
+
+
+@functools.lru_cache(maxsize=1)
+def _app_function_facts():
+    """Per function name: where it is defined, what it writes, what it calls.
+
+    Keyed by bare name. Two functions sharing a name merge, which can only
+    widen the result -- a false positive costs an exemption line, a false
+    negative costs a production deadlock.
+    """
+    writes: dict[str, set[str]] = {}
+    calls: dict[str, set[str]] = {}
+    sites: dict[str, list[str]] = {}
+    for rel, fn in _walk_app_functions():
+        writes.setdefault(fn.name, set()).update(_direct_writes(fn))
+        calls.setdefault(fn.name, set()).update(_called_names(fn))
+        sites.setdefault(fn.name, []).append(f"{rel}:{fn.lineno}")
+    return writes, calls, sites
+
+
+def _pair_writer_report() -> dict[str, list[str]]:
+    """Every function under app/ that ends up writing BOTH catalog rows.
+
+    Propagates writes through the call graph to a fixed point, because the
+    halves are routinely split across helpers: `update_user_metadata` assigns
+    `record.updated_by` itself but reaches `dataset.tile_columns` only through
+    `_apply_tile_columns`, and a scan that looked at one body at a time missed
+    exactly the site codex round 2 reported.
+
+    Heuristic and deliberately broad. A false positive costs one exemption line
+    with a reason. A false NEGATIVE costs a production deadlock.
+    """
+    writes, calls, sites = _app_function_facts()
+    effective = {name: set(kinds) for name, kinds in writes.items()}
+    for _ in range(6):  # deep enough for this codebase; converges well before
+        changed = False
+        for name, callees in calls.items():
+            for callee in callees:
+                gained = effective.get(callee, set()) - effective.setdefault(
+                    name, set()
+                )
+                if gained:
+                    effective[name] |= gained
+                    changed = True
+        if not changed:
+            break
+    return {
+        name: sites[name]
+        for name, kinds in effective.items()
+        if kinds >= {"record", "dataset"}
+    }
+
+
+def _acquiring_functions() -> set[str]:
+    """Names that take the pair, or that reach it through one of their calls."""
+    _writes, calls, _sites = _app_function_facts()
+    acquirers = {"lock_catalog_rows", "lock_catalog_rows_for_write"}
+    resolved = set(acquirers)
+    for _ in range(6):
+        grew = {n for n, c in calls.items() if c & resolved} - resolved
+        if not grew:
+            break
+        resolved |= grew
+    return resolved
+
+
+class TestEveryPairWriterTakesTheHouseOrder:
+    """fix(#1847 review r2): the class, not the four handlers that started it.
+
+    SQLAlchemy flushes catalog.records before catalog.datasets, so ANY
+    transaction that writes both rows and acquires nothing takes them in the
+    inverted order and can deadlock against a writer holding the dataset row.
+    Codex round 2 found `update_user_metadata` this way; this test is what
+    stops the next one being found in production instead.
+    """
+
+    def test_every_pair_writer_acquires_or_is_exempt(self):
+        writers = _pair_writer_report()
+        acquirers = _acquiring_functions()
+        offenders = {
+            name: sites
+            for name, sites in writers.items()
+            if name not in acquirers and name not in _PAIR_WRITER_EXEMPTIONS
+        }
+        assert not offenders, (
+            "these functions write a Record field and a Dataset field without "
+            "taking the (datasets, records) pair first:\n"
+            + "\n".join(f"  {n}: {', '.join(v)}" for n, v in sorted(offenders.items()))
+            + "\n\nCall lock_catalog_rows_for_write (catalog) or "
+            "lock_catalog_rows (processing, with lock_timeout=None) before the "
+            "first write, or add the name to _PAIR_WRITER_EXEMPTIONS with the "
+            "reason it cannot deadlock."
+        )
+
+    def test_the_gate_actually_finds_the_known_writers(self):
+        """A positive control: an empty scan would pass the test above."""
+        writers = _pair_writer_report()
+        for expected in (
+            "update_user_metadata",
+            "_apply_reupload_swap",
+            "refresh_dataset_metadata",
+        ):
+            assert expected in writers, (
+                f"{expected} writes both rows but the scan missed it, so the "
+                "gate above is passing vacuously. Widen _pair_writer_report."
+            )
+
+    def test_no_exemption_names_a_function_that_is_gone(self):
+        """The list must stay a statement about live code, not folklore."""
+        _writes, _calls, sites = _app_function_facts()
+        missing = [name for name in _PAIR_WRITER_EXEMPTIONS if name not in sites]
+        assert not missing, (
+            f"exemptions naming functions that no longer exist: {missing}. "
+            "Remove them, or the list decays into reasons nobody can check."
+        )

--- a/backend/tests/test_feature_lock_order_1847.py
+++ b/backend/tests/test_feature_lock_order_1847.py
@@ -925,6 +925,207 @@ class TestDeleteNeverReapsStorageItCannotCommit:
         assert still_there == locked_dataset.id
 
 
+class TestTheOtherSitesHoldTheOrderToo:
+    """fix(#1847 review r3 P2-5): DB-backed coverage for the sites that had none.
+
+    Rounds 0 to 2 shipped concurrency tests for the feature paths and the
+    metadata PATCH; the layers DDL, the delete and the worker doors were
+    carried by the static gate alone, and P2-1 showed that gate accepting the
+    wrong position and the wrong branch. These drive the real endpoints against
+    a held dataset row.
+
+    None of them monkeypatches the budget. The round-2 tests raised
+    REQUEST_LOCK_TIMEOUT to 60s to keep the interleaving deterministic, and
+    that is what hid the 500 and the 400 the round-3 P2 reports. The barrier
+    below fires in milliseconds, so the production 2s budget is not reached --
+    and if it ever were, the answer is a 409, which these tests accept.
+    """
+
+    async def _drive(self, holder, probe, dataset_id, request_coro):
+        """Hold the dataset row, run *request_coro*, return it once parked."""
+        await holder.execute(
+            select(Dataset.tile_cache_version)
+            .where(Dataset.id == dataset_id)
+            .with_for_update()
+        )
+        holder_xid = await holder.scalar(text("SELECT pg_current_xact_id()::text"))
+        task = asyncio.create_task(request_coro)
+        await _await_waiter_on(probe, holder_xid)
+        return task
+
+    async def test_layers_add_column_holds_no_record_lock_while_waiting(
+        self, locked_dataset, client: AsyncClient, admin_auth_header
+    ):
+        import app.core.db as db_module
+
+        async with (
+            db_module.async_session() as holder,
+            db_module.async_session() as probe,
+        ):
+            task = await self._drive(
+                holder,
+                probe,
+                locked_dataset.id,
+                client.post(
+                    f"/layers/{locked_dataset.id}/columns/",
+                    json={"column": {"name": "note_a", "type": "text"}},
+                    headers=admin_auth_header,
+                ),
+            )
+            try:
+                assert not await _holds_record_lock(probe, locked_dataset.record_id), (
+                    "the add-column DDL is parked on a lock while holding "
+                    "catalog.records"
+                )
+            finally:
+                await holder.rollback()
+                response = await task
+        assert response.status_code in (201, 409), response.text
+
+    async def test_delete_holds_no_record_lock_while_waiting(
+        self, locked_dataset, client: AsyncClient, admin_auth_header, monkeypatch
+    ):
+        import app.core.db as db_module
+        from app.modules.catalog.datasets.domain import service_lifecycle
+
+        reaped: list = []
+
+        async def _record_only(prefixes, tenant_id):
+            reaped.append(tuple(prefixes))
+
+        monkeypatch.setattr(service_lifecycle, "_reap_managed_storage", _record_only)
+
+        async with (
+            db_module.async_session() as holder,
+            db_module.async_session() as probe,
+        ):
+            task = await self._drive(
+                holder,
+                probe,
+                locked_dataset.id,
+                client.request(
+                    "DELETE",
+                    f"/datasets/{locked_dataset.id}",
+                    json={"confirm_title": f"Lock order {locked_dataset.table_name}"},
+                    headers=admin_auth_header,
+                ),
+            )
+            try:
+                assert not await _holds_record_lock(probe, locked_dataset.record_id), (
+                    "the delete is parked on a lock while holding catalog.records"
+                )
+                # And it has not reaped anything yet, which is the P1: the
+                # objects must not go until the rows are held.
+                assert reaped == [], (
+                    f"storage was reaped before the pair was held: {reaped}"
+                )
+            finally:
+                await holder.rollback()
+                response = await task
+        assert response.status_code in (200, 204, 409), response.text
+
+    async def test_metadata_patch_holds_no_record_lock_while_waiting(
+        self, locked_dataset, client: AsyncClient, admin_auth_header
+    ):
+        """The round-2 site, re-tested at the production budget."""
+        import app.core.db as db_module
+
+        async with (
+            db_module.async_session() as holder,
+            db_module.async_session() as probe,
+        ):
+            task = await self._drive(
+                holder,
+                probe,
+                locked_dataset.id,
+                client.patch(
+                    f"/datasets/{locked_dataset.id}",
+                    json={"title": "Renamed", "tile_columns": ["name"]},
+                    headers=admin_auth_header,
+                ),
+            )
+            try:
+                assert not await _holds_record_lock(probe, locked_dataset.record_id)
+            finally:
+                await holder.rollback()
+                response = await task
+        assert response.status_code in (200, 409), response.text
+
+
+class TestWorkerDoorsAcquireBeforeTheirWrites:
+    """The three worker sites, checked on emitted SQL rather than by racing.
+
+    A reupload, a raster replace and a VRT publish each need a staged upload
+    and a live ingest job to reach their swap, which is a fixture an order of
+    magnitude larger than the property under test. What has to be true is an
+    ordering, and the ordering is visible in the statements the transaction
+    emits -- so these read it there, the way
+    `test_reupload_swap_lock_retry.py::TestSwapLocksBeforeItWrites` does end to
+    end for the reupload door with a real session.
+    """
+
+    SITES = [
+        ("processing/ingest/tasks_common.py", "_apply_reupload_swap"),
+        ("processing/ingest/tasks_raster_replace.py", "reupload_raster"),
+        ("processing/ingest/tasks_vrt.py", "regenerate_vrt"),
+    ]
+
+    @pytest.mark.parametrize("rel,name", SITES)
+    def test_the_acquisition_precedes_the_first_write(self, rel: str, name: str):
+        import ast
+        from pathlib import Path
+
+        app_dir = Path(__file__).resolve().parents[1] / "app"
+        path = app_dir / rel
+        tree = ast.parse(path.read_text())
+        module = _module_qualname(path.relative_to(app_dir.parent))
+        bindings = _local_bindings(tree, module)
+        fn = next(
+            n
+            for n in ast.walk(tree)
+            if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef)) and n.name == name
+        )
+        ok, why = acquisition_dominates_writes(
+            fn, bindings, module, _acquiring_functions()
+        )
+        assert ok, f"{rel}::{name}: {why}"
+
+    def test_worker_doors_do_not_clamp_their_transaction(self):
+        """`lock_timeout=None` at each, and nowhere on a request path.
+
+        `SET LOCAL` applies for the rest of the transaction. A worker that
+        inherited the request budget would fail a multi-minute ingest on
+        contention it is supposed to wait out.
+        """
+        import ast
+        from pathlib import Path
+
+        app_dir = Path(__file__).resolve().parents[1] / "app"
+        none_sites = []
+        for path in sorted(app_dir.rglob("*.py")):
+            tree = ast.parse(path.read_text())
+            for node in ast.walk(tree):
+                if not isinstance(node, ast.Call):
+                    continue
+                fname = getattr(node.func, "id", None) or getattr(
+                    node.func, "attr", None
+                )
+                if fname != "lock_catalog_rows":
+                    continue
+                for kw in node.keywords:
+                    if kw.arg == "lock_timeout" and isinstance(kw.value, ast.Constant):
+                        if kw.value.value is None:
+                            none_sites.append(str(path.relative_to(app_dir.parent)))
+        assert sorted(set(none_sites)) == [
+            "app/processing/ingest/tasks_common.py",
+            "app/processing/ingest/tasks_raster_replace.py",
+            "app/processing/ingest/tasks_vrt.py",
+        ], (
+            "lock_timeout=None belongs to worker tasks only. A request path "
+            f"that passes it waits forever on a contended row. Found: {none_sites}"
+        )
+
+
 # ---------------------------------------------------------------------------
 # The class gate (fix(#1847 review r2))
 # ---------------------------------------------------------------------------
@@ -934,46 +1135,105 @@ class TestDeleteNeverReapsStorageItCannotCommit:
 # is a decision, not a formality: read
 # app.platform.catalog_locks.lock_catalog_rows before you do.
 _PAIR_WRITER_EXEMPTIONS = {
-    # Both rows are INSERTed by this transaction, so no other transaction can
-    # be holding either one. There is nothing to order against.
-    "create_dataset": "creates the pair",
-    "create_empty_dataset": "delegates to create_dataset",
-    "create_layer": "creates the pair",
-    "create_raster_dataset": "creates the pair",
-    "create_vrt_dataset": "creates the pair",
-    "_finalize_ingest": "creates the pair through the port, then stamps it",
-    "ingest_raster": "creates the pair, then stamps it",
-    "stac_import": "creates one pair per item inside its own savepoint",
-    "_materialize": "registers a new pair, then applies provenance to it",
-    "materialize_analysis": "task wrapper around _materialize",
-    "ingest_file": "task wrapper around _finalize_ingest",
-    "ingest_service": "task wrapper around _finalize_ingest",
-    "apply_analysis_provenance": "writes only the record of a pair being created",
-    # Writes the record half only; every caller is enumerated above.
-    "apply_manifest_record_metadata": "record only",
-    # Sync helper. Its caller (reupload_raster) takes the pair before calling
-    # it -- asserted by test_every_pair_writer_acquires_or_is_exempt itself,
-    # which sees the acquisition in the caller.
-    "_write_swapped_fields": "caller acquires; sync, no session of its own",
-    # These two take the datasets row FOR UPDATE themselves, before writing
-    # either half, as the superseded-content guard their own comments describe.
-    # They are the reason the house order is datasets-first; they do not go
-    # through the helper because the lock and the token check are one step.
-    "_apply_measurement": "caller refresh_postgis holds datasets FOR UPDATE",
-    "refresh_postgis": "takes datasets FOR UPDATE for its superseded guard",
-    "refresh_stac": "takes datasets FOR UPDATE for its superseded guard",
+    # --- both rows are INSERTed by this transaction ------------------------
+    # No other transaction can hold either one, so there is nothing to order
+    # against.
+    "app.modules.catalog.datasets.domain.service_create.create_dataset": "creates the pair",
+    "app.modules.catalog.datasets.domain.service_create.create_empty_dataset": "delegates to create_dataset",
+    "app.modules.catalog.layers.service.create_layer": "creates the pair",
+    "app.processing.ingest.tasks_raster_common.create_raster_dataset": "creates the pair",
+    "app.processing.ingest.tasks_vrt.create_vrt_dataset": "creates the pair",
+    "app.processing.ingest.tasks_common._finalize_ingest": "creates the pair, then stamps it",
+    "app.processing.ingest.tasks_raster.ingest_raster": "creates the pair, then stamps it",
+    "app.processing.ingest.tasks_vector.ingest_file": "wrapper around _finalize_ingest",
+    "app.processing.ingest.tasks_vector.ingest_service": "wrapper around _finalize_ingest",
+    "app.modules.catalog.sources.stac_router.stac_import": "one pair per item, each in its own savepoint",
+    "app.processing.analysis.tasks._materialize": "registers a new pair, then applies provenance",
+    "app.processing.analysis.tasks.materialize_analysis": "wrapper around _materialize",
+    "app.processing.analysis.provenance.apply_analysis_provenance": "record of a pair being created",
+    # --- writes one half; the caller owns the ordering ---------------------
+    "app.processing.ingest.tasks_common.apply_manifest_record_metadata": "record only",
+    "app.processing.ingest.tasks_raster_swap._write_swapped_fields": "sync, no session; reupload_raster acquires before calling it",
+    # --- takes the datasets row FOR UPDATE itself --------------------------
+    # These are the sites the house order was chosen to match. They do not go
+    # through the helper because the lock and the superseded-content check are
+    # one indivisible step.
+    "app.processing.ingest.tasks_postgis_refresh._apply_measurement": "caller refresh_postgis holds datasets FOR UPDATE",
+    "app.processing.ingest.tasks_postgis_refresh.refresh_postgis": "takes datasets FOR UPDATE for its superseded guard",
+    "app.processing.ingest.tasks_stac_refresh.refresh_stac": "takes datasets FOR UPDATE for its superseded guard",
 }
 
 
-def _assignment_targets(node):
-    """Every Attribute node this statement assigns to."""
+# Functions whose acquisition is deliberately conditional. Every other site
+# must acquire on every path; these carry the reason the unlocked path is safe.
+_CONDITIONAL_ACQUISITION = {
+    "app.modules.catalog.datasets.domain.service_metadata.update_user_metadata": (
+        "the unlocked branch writes the records row ALONE, and a one-row write "
+        "has no order to get wrong. Gated on _DATASET_ROW_FIELDS, which is the "
+        "set of request fields that reach catalog.datasets."
+    ),
+    "app.modules.catalog.features.router.patch_single_feature": (
+        "both arms acquire, one through the refresh and one directly, which "
+        "test_every_write_handler_acquires_on_every_path checks per arm."
+    ),
+}
+
+
+ACQUIRERS = frozenset(
+    {
+        "app.platform.catalog_locks.lock_catalog_rows",
+        "app.modules.catalog.features.service.lock_catalog_rows_for_write",
+    }
+)
+
+
+def _module_qualname(rel) -> str:
+    parts = list(rel.with_suffix("").parts)
+    if parts and parts[-1] == "__init__":
+        parts.pop()
+    return ".".join(parts)
+
+
+def _local_bindings(tree, module: str) -> dict[str, str]:
+    """Local name -> qualified target, from this module's imports and defs.
+
+    fix(#1847 review r3 P2-1): the previous scan keyed everything on the bare
+    function name and merged across files, so any function that happened to
+    share a name with one of the real acquirers inherited its exemption. A
+    call is resolved through the binding that is actually in scope where it
+    appears.
+    """
     import ast
 
-    targets = list(getattr(node, "targets", []) or [])
-    single = getattr(node, "target", None)
-    if single is not None:
-        targets.append(single)
-    return [t for t in targets if isinstance(t, ast.Attribute)]
+    bindings: dict[str, str] = {}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.module and not node.level:
+            for alias in node.names:
+                bindings[alias.asname or alias.name] = f"{node.module}.{alias.name}"
+        elif isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            bindings.setdefault(node.name, f"{module}.{node.name}")
+    return bindings
+
+
+def _resolve(name: str, bindings: dict[str, str], module: str) -> str:
+    return bindings.get(name) or f"{module}.{name}"
+
+
+def _is_acquisition(node, bindings, module) -> bool:
+    import ast
+
+    if not isinstance(node, ast.Call):
+        return False
+    if isinstance(node.func, ast.Name):
+        return _resolve(node.func.id, bindings, module) in ACQUIRERS
+    # `mod.lock_catalog_rows(...)` -- match on the attribute, which cannot be
+    # confused with a same-named local because the acquirers are unique words.
+    if isinstance(node.func, ast.Attribute):
+        return any(a.rsplit(".", 1)[-1] == node.func.attr for a in ACQUIRERS)
+    return False
+
+
+_PAIR_TABLES = {"Dataset", "DatasetModel", "Record", "RecordModel"}
 
 
 def _classify_base(base) -> str | None:
@@ -993,41 +1253,115 @@ def _classify_base(base) -> str | None:
     return None
 
 
+def _core_statement_kind(node) -> str | None:
+    """'record'/'dataset' for a Core ``update(X)`` / ``delete(X)`` on the pair.
+
+    fix(#1847 review r3 P2-1): latent rather than active today -- the two
+    ``update(Dataset)`` sites write the datasets row alone -- but a Core
+    statement is a write the attribute scan cannot see at all, so the first one
+    that touches both rows would have been invisible.
+    """
+    import ast
+
+    if not isinstance(node, ast.Call):
+        return None
+    fname = (
+        node.func.id
+        if isinstance(node.func, ast.Name)
+        else node.func.attr
+        if isinstance(node.func, ast.Attribute)
+        else None
+    )
+    if fname not in ("update", "delete") or not node.args:
+        return None
+    target = node.args[0]
+    name = (
+        target.id
+        if isinstance(target, ast.Name)
+        else target.attr
+        if isinstance(target, ast.Attribute)
+        else None
+    )
+    if name not in _PAIR_TABLES:
+        return None
+    return "record" if "Record" in name else "dataset"
+
+
+def _classify_object(node) -> str | None:
+    """'record'/'dataset' for the OBJECT an expression names."""
+    import ast
+
+    if isinstance(node, ast.Attribute):
+        if node.attr == "record":
+            return "record"
+        if "dataset" in node.attr:
+            return "dataset"
+    if isinstance(node, ast.Name):
+        if node.id in ("record", "rec"):
+            return "record"
+        if "dataset" in node.id:
+            return "dataset"
+    return None
+
+
+def _write_kinds(node) -> set[str]:
+    """Which halves of the pair this single AST node writes."""
+    import ast
+
+    kinds: set[str] = set()
+    # `session.delete(dataset.record)` removes the records row AND, by the FK
+    # cascade on Dataset.record_id, the datasets row. Neither is an attribute
+    # assignment, so without this the one endpoint that deletes a dataset is
+    # invisible to the scan (fix(#1847 review r3 P2-1)).
+    if (
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "delete"
+        and node.args
+        and _classify_object(node.args[0]) == "record"
+    ):
+        kinds |= {"record", "dataset"}
+    if isinstance(node, (ast.Assign, ast.AugAssign, ast.AnnAssign)):
+        targets = list(getattr(node, "targets", []) or [])
+        single = getattr(node, "target", None)
+        if single is not None:
+            targets.append(single)
+        for t in targets:
+            if isinstance(t, ast.Attribute):
+                kind = _classify_base(t.value)
+                if kind:
+                    kinds.add(kind)
+    elif isinstance(node, ast.Call):
+        if isinstance(node.func, ast.Name) and node.func.id == "setattr" and node.args:
+            kind = _classify_base(node.args[0])
+            if kind:
+                kinds.add(kind)
+        core = _core_statement_kind(node)
+        if core:
+            kinds.add(core)
+    return kinds
+
+
 def _direct_writes(fn) -> set[str]:
-    """Which halves of the pair this function body writes on its own."""
     import ast
 
     kinds: set[str] = set()
     for node in ast.walk(fn):
-        if isinstance(node, (ast.Assign, ast.AugAssign, ast.AnnAssign)):
-            for attr in _assignment_targets(node):
-                kind = _classify_base(attr.value)
-                if kind:
-                    kinds.add(kind)
-        # `setattr(record, name, value)` is the same write by another spelling,
-        # and it is how update_user_metadata assigns most of its fields.
-        elif (
-            isinstance(node, ast.Call)
-            and isinstance(node.func, ast.Name)
-            and node.func.id == "setattr"
-            and node.args
-        ):
-            kind = _classify_base(node.args[0])
-            if kind:
-                kinds.add(kind)
+        kinds |= _write_kinds(node)
     return kinds
 
 
-def _called_names(fn) -> set[str]:
+def _called_targets(fn, bindings, module) -> set[str]:
     import ast
 
     names = set()
     for node in ast.walk(fn):
-        if isinstance(node, ast.Call):
-            if isinstance(node.func, ast.Name):
-                names.add(node.func.id)
-            elif isinstance(node.func, ast.Attribute):
-                names.add(node.func.attr)
+        if not isinstance(node, ast.Call):
+            continue
+        if isinstance(node.func, ast.Name):
+            names.add(_resolve(node.func.id, bindings, module))
+        elif isinstance(node.func, ast.Attribute):
+            names.add(f"?.{node.func.attr}")
     return names
 
 
@@ -1041,44 +1375,36 @@ def _walk_app_functions():
             tree = ast.parse(path.read_text())
         except SyntaxError:  # pragma: no cover
             continue
+        rel = path.relative_to(app_dir.parent)
+        module = _module_qualname(rel)
+        bindings = _local_bindings(tree, module)
         for fn in ast.walk(tree):
             if isinstance(fn, (ast.FunctionDef, ast.AsyncFunctionDef)):
-                yield path.relative_to(app_dir.parent), fn
+                yield rel, module, bindings, fn
 
 
 @functools.lru_cache(maxsize=1)
 def _app_function_facts():
-    """Per function name: where it is defined, what it writes, what it calls.
+    """Per QUALIFIED name: what it writes, what it calls, where it is.
 
-    Keyed by bare name. Two functions sharing a name merge, which can only
-    widen the result -- a false positive costs an exemption line, a false
-    negative costs a production deadlock.
+    Keyed by ``module.name``, not by bare name. Two same-named functions in
+    different modules are two entries.
     """
     writes: dict[str, set[str]] = {}
     calls: dict[str, set[str]] = {}
-    sites: dict[str, list[str]] = {}
-    for rel, fn in _walk_app_functions():
-        writes.setdefault(fn.name, set()).update(_direct_writes(fn))
-        calls.setdefault(fn.name, set()).update(_called_names(fn))
-        sites.setdefault(fn.name, []).append(f"{rel}:{fn.lineno}")
+    sites: dict[str, str] = {}
+    for rel, module, bindings, fn in _walk_app_functions():
+        key = f"{module}.{fn.name}"
+        writes.setdefault(key, set()).update(_direct_writes(fn))
+        calls.setdefault(key, set()).update(_called_targets(fn, bindings, module))
+        sites.setdefault(key, f"{rel}:{fn.lineno}")
     return writes, calls, sites
 
 
-def _pair_writer_report() -> dict[str, list[str]]:
-    """Every function under app/ that ends up writing BOTH catalog rows.
-
-    Propagates writes through the call graph to a fixed point, because the
-    halves are routinely split across helpers: `update_user_metadata` assigns
-    `record.updated_by` itself but reaches `dataset.tile_columns` only through
-    `_apply_tile_columns`, and a scan that looked at one body at a time missed
-    exactly the site codex round 2 reported.
-
-    Heuristic and deliberately broad. A false positive costs one exemption line
-    with a reason. A false NEGATIVE costs a production deadlock.
-    """
-    writes, calls, sites = _app_function_facts()
-    effective = {name: set(kinds) for name, kinds in writes.items()}
-    for _ in range(6):  # deep enough for this codebase; converges well before
+def _closure(seeds: dict[str, set[str]], calls: dict[str, set[str]]):
+    """Propagate write kinds along call edges to a fixed point."""
+    effective = {name: set(kinds) for name, kinds in seeds.items()}
+    for _ in range(8):
         changed = False
         for name, callees in calls.items():
             for callee in callees:
@@ -1090,24 +1416,117 @@ def _pair_writer_report() -> dict[str, list[str]]:
                     changed = True
         if not changed:
             break
+    return effective
+
+
+def _pair_writer_report() -> dict[str, str]:
+    """Qualified name -> site, for every function that writes BOTH rows."""
+    writes, calls, sites = _app_function_facts()
+    effective = _closure(writes, calls)
     return {
         name: sites[name]
         for name, kinds in effective.items()
-        if kinds >= {"record", "dataset"}
+        if kinds >= {"record", "dataset"} and name in sites
     }
 
 
 def _acquiring_functions() -> set[str]:
-    """Names that take the pair, or that reach it through one of their calls."""
+    """Qualified names that acquire, or that reach an acquirer through a call."""
     _writes, calls, _sites = _app_function_facts()
-    acquirers = {"lock_catalog_rows", "lock_catalog_rows_for_write"}
-    resolved = set(acquirers)
-    for _ in range(6):
+    resolved = set(ACQUIRERS)
+    for _ in range(8):
         grew = {n for n, c in calls.items() if c & resolved} - resolved
         if not grew:
             break
         resolved |= grew
     return resolved
+
+
+def _nested_bodies(stmt):
+    """Flatten a compound statement's bodies, or None if it is not one.
+
+    `if` is handled by the caller instead, because its two arms have to be
+    analysed independently rather than concatenated.
+    """
+    import ast
+
+    if not isinstance(
+        stmt, (ast.Try, ast.For, ast.While, ast.With, ast.AsyncFor, ast.AsyncWith)
+    ):
+        return None
+    nested = list(getattr(stmt, "body", []))
+    nested += list(getattr(stmt, "orelse", []))
+    nested += list(getattr(stmt, "finalbody", []))
+    for handler in getattr(stmt, "handlers", []):
+        nested += handler.body
+    return nested
+
+
+def acquisition_dominates_writes(
+    fn, bindings, module, acquirers=None
+) -> tuple[bool, str]:
+    """Does an acquisition precede every write, on every path through *fn*?
+
+    fix(#1847 review r3 P2-1): the round-2 check accepted a call to the helper
+    ANYWHERE in the body, so an acquisition placed after the writes, or in one
+    arm of an `if`, passed. Both are the defect this gate exists to catch.
+
+    *acquirers* is the transitive set: a handler that acquires through a
+    wrapper acquires just as surely as one that calls the helper directly.
+    """
+    import ast
+
+    reach = ACQUIRERS if acquirers is None else acquirers
+
+    def is_acq(node) -> bool:
+        if not isinstance(node, ast.Call):
+            return False
+        if isinstance(node.func, ast.Name):
+            return _resolve(node.func.id, bindings, module) in reach
+        if isinstance(node.func, ast.Attribute):
+            return any(a.rsplit(".", 1)[-1] == node.func.attr for a in reach)
+        return False
+
+    def plain(stmt, acquired):
+        """One non-compound statement: acquisitions and writes by position."""
+        acq = [n.lineno for n in ast.walk(stmt) if is_acq(n)]
+        writes = [n.lineno for n in ast.walk(stmt) if _write_kinds(n)]
+        if writes and not acquired and (not acq or min(acq) > min(writes)):
+            return (
+                False,
+                acquired,
+                (
+                    f"line {min(writes)} writes a catalog row with no acquisition "
+                    "before it on this path"
+                ),
+            )
+        return True, acquired or bool(acq), ""
+
+    def scan(stmts, acquired: bool):
+        for stmt in stmts:
+            if isinstance(stmt, ast.If):
+                then_ok, then_acq, why = scan(stmt.body, acquired)
+                if not then_ok:
+                    return False, acquired, why
+                else_ok, else_acq, why = scan(stmt.orelse, acquired)
+                if not else_ok:
+                    return False, acquired, why
+                acquired = acquired or (then_acq and else_acq)
+                continue
+            nested = _nested_bodies(stmt)
+            if nested is not None:
+                ok, nested_acq, why = scan(nested, acquired)
+                if not ok:
+                    return False, acquired, why
+                acquired = acquired or nested_acq
+                continue
+            ok, acquired, why = plain(stmt, acquired)
+            if not ok:
+                return False, acquired, why
+        return True, acquired, ""
+
+    ok, _acq, why = scan(fn.body, False)
+    return ok, why
 
 
 class TestEveryPairWriterTakesTheHouseOrder:
@@ -1124,27 +1543,66 @@ class TestEveryPairWriterTakesTheHouseOrder:
         writers = _pair_writer_report()
         acquirers = _acquiring_functions()
         offenders = {
-            name: sites
-            for name, sites in writers.items()
+            name: site
+            for name, site in writers.items()
             if name not in acquirers and name not in _PAIR_WRITER_EXEMPTIONS
         }
         assert not offenders, (
             "these functions write a Record field and a Dataset field without "
             "taking the (datasets, records) pair first:\n"
-            + "\n".join(f"  {n}: {', '.join(v)}" for n, v in sorted(offenders.items()))
+            + "\n".join(f"  {n}: {v}" for n, v in sorted(offenders.items()))
             + "\n\nCall lock_catalog_rows_for_write (catalog) or "
             "lock_catalog_rows (processing, with lock_timeout=None) before the "
             "first write, or add the name to _PAIR_WRITER_EXEMPTIONS with the "
             "reason it cannot deadlock."
         )
 
+    def test_the_acquisition_precedes_the_writes_on_every_path(self):
+        """fix(#1847 review r3 P2-1): position and branch, not mere presence.
+
+        Calling the helper somewhere in the body proves nothing. After the
+        writes it orders nothing, and in one arm of an `if` it orders nothing
+        on the other arm -- which is exactly the round-1 defect.
+        """
+        writers = _pair_writer_report()
+        # A handler that acquires through a wrapper (the feature router's
+        # _refresh_metadata_guarded, say) acquires just as surely as one that
+        # calls the helper directly.
+        acquirers = _acquiring_functions()
+        failures = []
+        for rel, module, bindings, fn in _walk_app_functions():
+            key = f"{module}.{fn.name}"
+            if key in _PAIR_WRITER_EXEMPTIONS or key in _CONDITIONAL_ACQUISITION:
+                continue
+            if not _direct_writes(fn):
+                continue  # inherits its writes; the callee is checked instead
+            # Every function that acquires must do so before ITS OWN writes,
+            # not only the ones that write both rows. A helper that writes the
+            # datasets row and then acquires has already let the flush order
+            # the pair, even though its own body never touches the record --
+            # which is how the first version of this check missed
+            # `layers.service.add_column` (fix(#1847 review r3 P2-1)).
+            if key not in acquirers and key not in writers:
+                continue
+            ok, why = acquisition_dominates_writes(fn, bindings, module, acquirers)
+            if not ok:
+                failures.append(f"  {key} ({rel}:{fn.lineno}): {why}")
+        assert not failures, (
+            "the acquisition does not dominate the writes in:\n"
+            + "\n".join(sorted(failures))
+            + "\n\nMove it before the first write, on every path, or add the "
+            "name to _CONDITIONAL_ACQUISITION with the reason the unlocked "
+            "path cannot write both rows."
+        )
+
     def test_the_gate_actually_finds_the_known_writers(self):
-        """A positive control: an empty scan would pass the test above."""
+        """A positive control: an empty scan would pass the tests above."""
         writers = _pair_writer_report()
         for expected in (
-            "update_user_metadata",
-            "_apply_reupload_swap",
-            "refresh_dataset_metadata",
+            "app.modules.catalog.datasets.domain.service_metadata.update_user_metadata",
+            "app.processing.ingest.tasks_common._apply_reupload_swap",
+            "app.modules.catalog.features.service.refresh_dataset_metadata",
+            "app.modules.catalog.datasets.domain.service_lifecycle.delete_dataset",
         ):
             assert expected in writers, (
                 f"{expected} writes both rows but the scan missed it, so the "
@@ -1152,10 +1610,120 @@ class TestEveryPairWriterTakesTheHouseOrder:
             )
 
     def test_no_exemption_names_a_function_that_is_gone(self):
-        """The list must stay a statement about live code, not folklore."""
+        """The lists must stay statements about live code, not folklore."""
         _writes, _calls, sites = _app_function_facts()
-        missing = [name for name in _PAIR_WRITER_EXEMPTIONS if name not in sites]
+        missing = [
+            name
+            for name in (*_PAIR_WRITER_EXEMPTIONS, *_CONDITIONAL_ACQUISITION)
+            if name not in sites
+        ]
         assert not missing, (
             f"exemptions naming functions that no longer exist: {missing}. "
-            "Remove them, or the list decays into reasons nobody can check."
+            "Remove them, or the lists decay into reasons nobody can check."
         )
+
+
+class TestTheGateRejectsWhatItExistsToCatch:
+    """fix(#1847 review r3 P2-1): a negative fixture per probe.
+
+    An audit probed the round-2 gate by adding functions under `app/` and found
+    it silent on four shapes. Each is reproduced here as a synthetic module, so
+    the gate's blind spots fail this file rather than a future review.
+    """
+
+    MODULE = "app.fixture.probe"
+
+    def _analyse(self, source: str):
+        import ast
+
+        tree = ast.parse(source)
+        bindings = _local_bindings(tree, self.MODULE)
+        fn = next(
+            n
+            for n in ast.walk(tree)
+            if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))
+            and n.name == "probe"
+        )
+        return fn, bindings
+
+    def test_acquisition_after_the_writes_is_rejected(self):
+        fn, bindings = self._analyse(
+            "from app.platform.catalog_locks import lock_catalog_rows\n"
+            "async def probe(session, dataset):\n"
+            "    dataset.record.updated_by = 1\n"
+            "    dataset.srid = 4326\n"
+            "    await lock_catalog_rows(session)\n"
+        )
+        ok, why = acquisition_dominates_writes(fn, bindings, self.MODULE)
+        assert not ok, "an acquisition after the writes orders nothing"
+        assert "no acquisition before it" in why
+
+    def test_acquisition_in_one_arm_only_is_rejected(self):
+        fn, bindings = self._analyse(
+            "from app.platform.catalog_locks import lock_catalog_rows\n"
+            "async def probe(session, dataset, flag):\n"
+            "    if flag:\n"
+            "        await lock_catalog_rows(session)\n"
+            "    dataset.record.updated_by = 1\n"
+            "    dataset.srid = 4326\n"
+        )
+        ok, _why = acquisition_dominates_writes(fn, bindings, self.MODULE)
+        assert not ok, "the else path reaches the writes holding nothing"
+
+    def test_acquisition_in_both_arms_is_accepted(self):
+        fn, bindings = self._analyse(
+            "from app.platform.catalog_locks import lock_catalog_rows\n"
+            "async def probe(session, dataset, flag):\n"
+            "    if flag:\n"
+            "        await lock_catalog_rows(session)\n"
+            "    else:\n"
+            "        await lock_catalog_rows(session)\n"
+            "    dataset.record.updated_by = 1\n"
+            "    dataset.srid = 4326\n"
+        )
+        ok, why = acquisition_dominates_writes(fn, bindings, self.MODULE)
+        assert ok, why
+
+    def test_a_name_collision_does_not_inherit_the_exemption(self):
+        """A local `lock_catalog_rows` that is somebody else's function.
+
+        The round-2 scan keyed on bare names, so any function sharing a name
+        with one of the real acquirers was treated as acquiring.
+        """
+        fn, bindings = self._analyse(
+            "from app.somewhere.other import lock_catalog_rows\n"
+            "async def probe(session, dataset):\n"
+            "    await lock_catalog_rows(session)\n"
+            "    dataset.record.updated_by = 1\n"
+            "    dataset.srid = 4326\n"
+        )
+        ok, _why = acquisition_dominates_writes(fn, bindings, self.MODULE)
+        assert not ok, (
+            "a call resolved to app.somewhere.other.lock_catalog_rows is not an "
+            "acquisition; only the two real helpers are"
+        )
+
+    def test_core_update_statements_count_as_writes(self):
+        """`update(Dataset)` / `delete(Record)` are invisible to an attribute scan."""
+        import ast
+
+        tree = ast.parse(
+            "from sqlalchemy import update\n"
+            "from app.modules.catalog.datasets.domain.models import Dataset, Record\n"
+            "async def probe(session):\n"
+            "    await session.execute(update(Dataset).values(srid=1))\n"
+            "    await session.execute(update(Record).values(title='x'))\n"
+        )
+        fn = next(n for n in ast.walk(tree) if isinstance(n, ast.AsyncFunctionDef))
+        assert _direct_writes(fn) == {"dataset", "record"}, (
+            "Core statements against the pair are writes; the attribute scan "
+            "alone cannot see them"
+        )
+
+    def test_a_record_only_writer_is_not_named(self):
+        """The other half of the control: no false positive on one-row writes."""
+        import ast
+
+        tree = ast.parse("async def probe(record):\n    record.title = 'x'\n")
+        fn = next(n for n in ast.walk(tree) if isinstance(n, ast.AsyncFunctionDef))
+        assert _direct_writes(fn) == {"record"}

--- a/backend/tests/test_feature_lock_order_1847.py
+++ b/backend/tests/test_feature_lock_order_1847.py
@@ -1,12 +1,8 @@
 """The (datasets, records) lock order, and the gate that holds it (#1847).
 
-The feature-edit metadata refresh took ``catalog.records`` FOR UPDATE and left
-``catalog.datasets`` to the flush. ``refresh_postgis`` phase 3 takes the
-datasets row FOR UPDATE first and writes the record row inside that same
-transaction, so an ordinary feature edit during a refresh was an ABBA cycle:
-PostgreSQL aborted one side with 40P01 after ``deadlock_timeout``, and because
-the refresh call sat outside the write handlers' ``except DBAPIError`` the abort
-surfaced as a generic 503 with the edit lost.
+Every transaction that writes both catalog rows takes the datasets row and
+then the records row before its first write; a raster child comes before the
+pair, the attribute row after it. A wait on a contended row answers 409.
 
 The concurrency tests here assert on LOCK STATE, never on elapsed time. The
 barrier is ``pg_stat_activity.wait_event_type``, and whether a lock is held is

--- a/backend/tests/test_feature_lock_order_1847.py
+++ b/backend/tests/test_feature_lock_order_1847.py
@@ -1446,6 +1446,104 @@ class TestTheRasterChildIsHeldBeforeTheReap:
         )
 
 
+class TestDeleteLeadsWithTheJobRows:
+    """A worker holds its job row before any data-table or catalog lock, and
+    the record delete cascades into that row: the delete takes it first.
+    """
+
+    def test_delete_takes_the_job_rows_before_the_table_and_the_pair(self):
+        import inspect
+
+        from app.modules.catalog.datasets.domain import service_lifecycle
+
+        src = inspect.getsource(service_lifecycle.delete_dataset)
+        jobs = src.index("await lock_ingest_jobs(")
+        assert jobs < src.index("DROP TABLE")
+        assert jobs < src.index("await lock_catalog_rows_for_write(")
+
+    async def test_delete_holds_no_catalog_row_while_waiting_for_the_job(
+        self,
+        locked_raster_dataset,
+        client: AsyncClient,
+        test_db_session,
+        admin_auth_header,
+        monkeypatch,
+    ):
+        monkeypatch.setattr(catalog_locks, "REQUEST_LOCK_TIMEOUT", "60s")
+        import app.core.db as db_module
+        from app.modules.catalog.datasets.domain import service_lifecycle
+        from app.platform.jobs.models import IngestJob
+        from app.processing.raster.models import RasterAsset
+
+        async def _no_reap(prefixes, tenant_id):
+            return None
+
+        monkeypatch.setattr(service_lifecycle, "reap_managed_storage", _no_reap)
+
+        dataset_id = locked_raster_dataset.id
+        record_id = locked_raster_dataset.record_id
+        title = locked_raster_dataset.record.title
+        job = IngestJob(dataset_id=dataset_id, status="running")
+        test_db_session.add(job)
+        await test_db_session.commit()
+        job_id = job.id
+
+        async with (
+            db_module.async_session() as holder,
+            db_module.async_session() as probe,
+        ):
+            # What a phase-2 bracket holds across its upload: the job row.
+            await holder.execute(
+                select(IngestJob.id)
+                .where(IngestJob.id == job_id)
+                .with_for_update(key_share=True)
+            )
+            holder_xid = await holder.scalar(text("SELECT pg_current_xact_id()::text"))
+            delete = asyncio.create_task(
+                client.request(
+                    "DELETE",
+                    f"/datasets/{dataset_id}",
+                    json={"confirm_title": title},
+                    headers=admin_auth_header,
+                )
+            )
+            try:
+                await _await_waiter_on(probe, holder_xid)
+                assert not await _holds_record_lock(probe, record_id), (
+                    "the delete is parked on the job row while holding "
+                    "catalog.records, which deadlocks against a worker holding "
+                    "its job row and taking the pair next."
+                )
+                # The worker's next steps; NOWAIT so a held row fails instead
+                # of deadlocking the test itself.
+                await holder.execute(
+                    select(RasterAsset.dataset_id)
+                    .where(RasterAsset.dataset_id == dataset_id)
+                    .with_for_update(nowait=True)
+                )
+                await holder.execute(
+                    select(Dataset.id)
+                    .where(Dataset.id == dataset_id)
+                    .with_for_update(nowait=True)
+                )
+                await holder.execute(
+                    select(Record.id)
+                    .where(Record.id == record_id)
+                    .with_for_update(nowait=True)
+                )
+                await holder.commit()
+            except BaseException:
+                await holder.rollback()
+                raise
+            response = await delete
+
+        await test_db_session.execute(
+            text("DELETE FROM catalog.ingest_jobs WHERE id = :j"), {"j": job_id}
+        )
+        await test_db_session.commit()
+        assert response.status_code == 204, response.text
+
+
 class TestALaterLockWaitAnswersTheSameWay:
     """The timeout outlives the acquisition it was set for.
 

--- a/backend/tests/test_feature_lock_order_1847.py
+++ b/backend/tests/test_feature_lock_order_1847.py
@@ -31,6 +31,7 @@ from app.platform import catalog_locks
 from app.modules.catalog.datasets.domain.models import Dataset, Record
 from app.modules.catalog.features import service as features_service
 from app.modules.catalog.features.router import _feature_write_db_error
+from app.platform.catalog_locks import CatalogLockConflict
 
 from tests.factories import get_user_id
 
@@ -570,10 +571,16 @@ class TestFeatureWriteErrorClassification:
             "55P03",  # lock_not_available
         ],
     )
-    def test_lock_conflict_is_a_conflict(self, code: str):
-        result = _feature_write_db_error(self._error(code))
-        assert result.status_code == 409
-        assert result.detail["code"] == "feature_write_locked"
+    def test_lock_conflict_raises_the_shared_exception(self, code: str):
+        """fix(#1847): one condition, one shape.
+
+        Returning a 409 of its own here gave a contended row two response
+        bodies, depending on whether the acquisition or a later statement hit
+        it. A client keying on the local `code` never saw it on the
+        acquisition path, which raises and answers through the global handler.
+        """
+        with pytest.raises(CatalogLockConflict):
+            _feature_write_db_error(self._error(code))
 
     def test_a_real_outage_is_still_unavailable(self):
         # 08006 is connection_failure: class 08, still operational.
@@ -925,6 +932,80 @@ class TestDeleteNeverReapsStorageItCannotCommit:
         assert still_there == locked_dataset.id
 
 
+class TestOneShapeForEveryContendedRow:
+    """fix(#1847): every endpoint answers a contended row the same way.
+
+    Two shapes were in play. The feature router returned its own 409 body for
+    a lock conflict raised by a statement other than the acquisition, and the
+    bulk delete swallowed one into a per-item "failed unexpectedly" with a
+    stack trace, while single delete answered 409.
+    """
+
+    async def _hold(self, session, dataset_id):
+        await session.execute(
+            select(Dataset.tile_cache_version)
+            .where(Dataset.id == dataset_id)
+            .with_for_update()
+        )
+
+    async def test_a_feature_write_answers_the_shared_problem_detail(
+        self, locked_dataset, client: AsyncClient, admin_auth_header, monkeypatch
+    ):
+        monkeypatch.setattr(catalog_locks, "REQUEST_LOCK_TIMEOUT", "150ms")
+        import app.core.db as db_module
+
+        async with db_module.async_session() as holder:
+            await self._hold(holder, locked_dataset.id)
+            response = await client.post(
+                f"/datasets/{locked_dataset.id}/features/",
+                json={
+                    "geometry": {"type": "Point", "coordinates": [-73.96, 40.74]},
+                    "properties": {"name": "blocked"},
+                },
+                headers=admin_auth_header,
+            )
+            await holder.rollback()
+
+        assert response.status_code == 409, response.text
+        body = response.json()
+        assert body["detail"]["code"] == "catalog_lock_conflict", body
+        assert body["title"] == "Catalog entry is busy", body
+
+    async def test_bulk_delete_answers_conflict_not_unexpected_failure(
+        self, locked_dataset, client: AsyncClient, admin_auth_header, monkeypatch
+    ):
+        monkeypatch.setattr(catalog_locks, "REQUEST_LOCK_TIMEOUT", "150ms")
+        import app.core.db as db_module
+        from app.modules.catalog.datasets.domain import service_lifecycle
+
+        async def _no_reap(prefixes, tenant_id):
+            return None
+
+        monkeypatch.setattr(service_lifecycle, "_reap_managed_storage", _no_reap)
+
+        async with db_module.async_session() as holder:
+            await self._hold(holder, locked_dataset.id)
+            response = await client.post(
+                "/datasets/bulk-delete",
+                json={
+                    "datasets": [
+                        {
+                            "dataset_id": str(locked_dataset.id),
+                            "confirm_title": (
+                                f"Lock order {locked_dataset.table_name}"
+                            ),
+                        }
+                    ]
+                },
+                headers=admin_auth_header,
+            )
+            await holder.rollback()
+
+        assert response.status_code == 409, response.text
+        assert response.json()["detail"]["code"] == "catalog_lock_conflict"
+        assert "failed unexpectedly" not in response.text
+
+
 class TestTheOtherSitesHoldTheOrderToo:
     """The layers DDL, the delete and the metadata PATCH, against a held row.
 
@@ -1074,10 +1155,62 @@ class TestWorkerDoorsAcquireBeforeTheirWrites:
             for n in ast.walk(tree)
             if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef)) and n.name == name
         )
+        key = f"{module}.{name}"
+        if key in _INMEMORY_UNTIL_ACQUIRED:
+            pytest.skip(f"exempt: {_INMEMORY_UNTIL_ACQUIRED[key]}")
         ok, why = acquisition_dominates_writes(
             fn, bindings, module, _acquiring_functions()
         )
         assert ok, f"{rel}::{name}: {why}"
+
+    def test_the_deferred_flush_exemption_still_holds(self):
+        """The `no_autoflush` the exemption rests on must actually be there.
+
+        Without it the in-memory assignments reach the database at whatever
+        statement the archive path runs next, ahead of the acquisition.
+        """
+        import ast
+        from pathlib import Path
+
+        app_dir = Path(__file__).resolve().parents[1] / "app"
+        src = (app_dir / "processing/ingest/tasks_raster_replace.py").read_text()
+        tree = ast.parse(src)
+        fn = next(
+            n
+            for n in ast.walk(tree)
+            if isinstance(n, ast.AsyncFunctionDef) and n.name == "reupload_raster"
+        )
+        swap = next(
+            n.lineno
+            for n in ast.walk(fn)
+            if isinstance(n, ast.Call)
+            and isinstance(n.func, ast.Name)
+            and n.func.id == "_write_swapped_fields"
+        )
+        acquire = next(
+            n.lineno
+            for n in ast.walk(fn)
+            if isinstance(n, ast.Call)
+            and isinstance(n.func, ast.Name)
+            and n.func.id == "lock_catalog_rows"
+        )
+        guarded = [
+            n.lineno
+            for n in ast.walk(fn)
+            if isinstance(n, ast.With)
+            and any(
+                isinstance(item.context_expr, ast.Attribute)
+                and item.context_expr.attr == "no_autoflush"
+                for item in n.items
+            )
+        ]
+        assert swap < acquire, "the swap helper must precede the acquisition here"
+        assert any(swap < line < acquire for line in guarded), (
+            "reupload_raster is exempt from the ordering check because its "
+            "in-memory assignments are held under `no_autoflush` until the "
+            "acquisition. That block is gone, so the exemption is now false: "
+            f"swap at {swap}, acquisition at {acquire}, no_autoflush at {guarded}"
+        )
 
     def test_worker_doors_do_not_clamp_their_transaction(self):
         """`lock_timeout=None` at each, and nowhere on a request path.
@@ -1150,6 +1283,19 @@ _PAIR_WRITER_EXEMPTIONS = {
     "app.processing.ingest.tasks_postgis_refresh._apply_measurement": "caller refresh_postgis holds datasets FOR UPDATE",
     "app.processing.ingest.tasks_postgis_refresh.refresh_postgis": "takes datasets FOR UPDATE for its superseded guard",
     "app.processing.ingest.tasks_stac_refresh.refresh_stac": "takes datasets FOR UPDATE for its superseded guard",
+}
+
+
+# Functions that assign catalog fields in memory before acquiring, and hold
+# those assignments under `no_autoflush` until after it, so no write reaches
+# the database first. The reason is enforced, not asserted: see
+# test_the_deferred_flush_exemption_still_holds.
+_INMEMORY_UNTIL_ACQUIRED = {
+    "app.processing.ingest.tasks_raster_replace.reupload_raster": (
+        "`_write_swapped_fields` only assigns; the acquisition sits below "
+        "`archive_lossy_original`, which uploads the whole original raster, "
+        "and `no_autoflush` holds the assignments until after it."
+    ),
 }
 
 
@@ -1408,13 +1554,19 @@ def _closure(seeds: dict[str, set[str]], calls: dict[str, set[str]]):
     return effective
 
 
+@functools.lru_cache(maxsize=1)
+def _effective_writes() -> dict[str, set[str]]:
+    """Qualified name -> the write kinds it reaches, directly or via callees."""
+    writes, calls, _sites = _app_function_facts()
+    return _closure(writes, calls)
+
+
 def _pair_writer_report() -> dict[str, str]:
     """Qualified name -> site, for every function that writes BOTH rows."""
-    writes, calls, sites = _app_function_facts()
-    effective = _closure(writes, calls)
+    _writes, _calls, sites = _app_function_facts()
     return {
         name: sites[name]
-        for name, kinds in effective.items()
+        for name, kinds in _effective_writes().items()
         if kinds >= {"record", "dataset"} and name in sites
     }
 
@@ -1451,21 +1603,8 @@ def _nested_bodies(stmt):
     return nested
 
 
-def acquisition_dominates_writes(
-    fn, bindings, module, acquirers=None
-) -> tuple[bool, str]:
-    """Does an acquisition precede every write, on every path through *fn*?
-
-    fix(#1847): the round-2 check accepted a call to the helper
-    ANYWHERE in the body, so an acquisition placed after the writes, or in one
-    arm of an `if`, passed. Both are the defect this gate exists to catch.
-
-    *acquirers* is the transitive set: a handler that acquires through a
-    wrapper acquires just as surely as one that calls the helper directly.
-    """
+def _acq_predicate(bindings, module, reach):
     import ast
-
-    reach = ACQUIRERS if acquirers is None else acquirers
 
     def is_acq(node) -> bool:
         if not isinstance(node, ast.Call):
@@ -1476,18 +1615,59 @@ def acquisition_dominates_writes(
             return any(a.rsplit(".", 1)[-1] == node.func.attr for a in reach)
         return False
 
+    return is_acq
+
+
+def _write_predicate(bindings, module, is_acq, reaches_write):
+    """A write here, or a call to something that writes.
+
+    fix(#1847): the scan used to see only assignments in this body, so a
+    wrapper that called a record-writing helper, acquired, then called a
+    dataset-writing helper emitted records-before-datasets and passed.
+    """
+    import ast
+
+    def is_write(node) -> bool:
+        if _write_kinds(node):
+            return True
+        if not isinstance(node, ast.Call) or is_acq(node):
+            return False
+        if not isinstance(node.func, ast.Name):
+            return False  # unresolvable attribute call; do not guess
+        return bool(reaches_write.get(_resolve(node.func.id, bindings, module)))
+
+    return is_write
+
+
+def acquisition_dominates_writes(
+    fn, bindings, module, acquirers=None, writers=None
+) -> tuple[bool, str]:
+    """Does an acquisition precede every write, on every path through *fn*?
+
+    fix(#1847): merely calling the helper somewhere in the body proves nothing.
+    After the writes it orders nothing; in one arm of an `if` it orders nothing
+    on the other. *acquirers* and *writers* are the transitive sets, so a
+    handler that acquires or writes through a wrapper is judged on what that
+    wrapper does.
+    """
+    import ast
+
+    is_acq = _acq_predicate(
+        bindings, module, ACQUIRERS if acquirers is None else acquirers
+    )
+    is_write = _write_predicate(
+        bindings, module, is_acq, _effective_writes() if writers is None else writers
+    )
+
     def plain(stmt, acquired):
-        """One non-compound statement: acquisitions and writes by position."""
         acq = [n.lineno for n in ast.walk(stmt) if is_acq(n)]
-        writes = [n.lineno for n in ast.walk(stmt) if _write_kinds(n)]
+        writes = [n.lineno for n in ast.walk(stmt) if is_write(n)]
         if writes and not acquired and (not acq or min(acq) > min(writes)):
             return (
                 False,
                 acquired,
-                (
-                    f"line {min(writes)} writes a catalog row with no acquisition "
-                    "before it on this path"
-                ),
+                f"line {min(writes)} writes a catalog row with no acquisition "
+                "before it on this path",
             )
         return True, acquired or bool(acq), ""
 
@@ -1558,17 +1738,20 @@ class TestEveryPairWriterTakesTheHouseOrder:
         failures = []
         for rel, module, bindings, fn in _walk_app_functions():
             key = f"{module}.{fn.name}"
-            if key in _PAIR_WRITER_EXEMPTIONS or key in _CONDITIONAL_ACQUISITION:
+            if (
+                key in _PAIR_WRITER_EXEMPTIONS
+                or key in _CONDITIONAL_ACQUISITION
+                or key in _INMEMORY_UNTIL_ACQUIRED
+            ):
                 continue
-            if not _direct_writes(fn):
-                continue  # inherits its writes; the callee is checked instead
-            # Every function that acquires must do so before ITS OWN writes,
-            # not only the ones that write both rows. A helper that writes the
-            # datasets row and then acquires has already let the flush order
-            # the pair, even though its own body never touches the record --
-            # which is how the first version of this check missed
-            # `layers.service.add_column` (fix(#1847)).
+            # Checked for every function that acquires OR writes both rows,
+            # whether its writes are its own or a callee's. Selecting on direct
+            # writes alone skipped the wrapper shape entirely, and selecting on
+            # pair writers alone missed a helper that writes one row and
+            # acquires after it (`layers.service.add_column`).
             if key not in acquirers and key not in writers:
+                continue
+            if not (_direct_writes(fn) or key in writers):
                 continue
             ok, why = acquisition_dominates_writes(fn, bindings, module, acquirers)
             if not ok:
@@ -1616,6 +1799,21 @@ class TestTheGateRejectsWhatItExistsToCatch:
     """
 
     MODULE = "app.fixture.probe"
+
+    def _local_writers(self, source: str) -> dict[str, set[str]]:
+        """Effective write kinds per qualified name, for a synthetic module."""
+        import ast
+
+        tree = ast.parse(source)
+        bindings = _local_bindings(tree, self.MODULE)
+        writes, calls = {}, {}
+        for fn in ast.walk(tree):
+            if not isinstance(fn, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            key = f"{self.MODULE}.{fn.name}"
+            writes[key] = _direct_writes(fn)
+            calls[key] = _called_targets(fn, bindings, self.MODULE)
+        return _closure(writes, calls)
 
     def _analyse(self, source: str):
         import ast
@@ -1686,6 +1884,54 @@ class TestTheGateRejectsWhatItExistsToCatch:
             "a call resolved to app.somewhere.other.lock_catalog_rows is not an "
             "acquisition; only the two real helpers are"
         )
+
+    def test_a_wrapper_whose_writes_are_all_in_callees_is_rejected(self):
+        """fix(#1847): the shape codex round 4 found the gate blind to.
+
+        Nothing in this body assigns a catalog field, so a scan that looked at
+        direct writes alone saw no writes to order and skipped the function
+        entirely -- while the sequence it emits is records, then the
+        acquisition, then datasets. Exactly the inversion.
+        """
+        source = (
+            "from app.platform.catalog_locks import lock_catalog_rows\n"
+            "async def stamp_record(session, dataset):\n"
+            "    dataset.record.updated_by = 1\n"
+            "async def bump_dataset(session, dataset):\n"
+            "    dataset.srid = 4326\n"
+            "async def probe(session, dataset):\n"
+            "    await stamp_record(session, dataset)\n"
+            "    await lock_catalog_rows(session)\n"
+            "    await bump_dataset(session, dataset)\n"
+        )
+        fn, bindings = self._analyse(source)
+        writers = self._local_writers(source)
+        ok, why = acquisition_dominates_writes(fn, bindings, self.MODULE, None, writers)
+        assert not ok, (
+            "the wrapper writes catalog.records through a callee before it "
+            "acquires, which is the records-before-datasets order the gate "
+            "exists to reject"
+        )
+        assert "no acquisition before it" in why
+
+    def test_the_same_wrapper_with_the_acquisition_first_is_accepted(self):
+        """The control: only the ordering differs."""
+        source = (
+            "from app.platform.catalog_locks import lock_catalog_rows\n"
+            "async def stamp_record(session, dataset):\n"
+            "    dataset.record.updated_by = 1\n"
+            "async def bump_dataset(session, dataset):\n"
+            "    dataset.srid = 4326\n"
+            "async def probe(session, dataset):\n"
+            "    await lock_catalog_rows(session)\n"
+            "    await stamp_record(session, dataset)\n"
+            "    await bump_dataset(session, dataset)\n"
+        )
+        fn, bindings = self._analyse(source)
+        ok, why = acquisition_dominates_writes(
+            fn, bindings, self.MODULE, None, self._local_writers(source)
+        )
+        assert ok, why
 
     def test_core_update_statements_count_as_writes(self):
         """`update(Dataset)` / `delete(Record)` are invisible to an attribute scan."""

--- a/backend/tests/test_feature_lock_order_1847.py
+++ b/backend/tests/test_feature_lock_order_1847.py
@@ -630,6 +630,27 @@ class TestWorkerSitesLeadWithTheDatasetRow:
         )
         assert lock < write
 
+    def test_stac_refresh_locks_the_raster_row_before_the_dataset(self):
+        """Phase 3 writes raster_assets after its binding guard, so the child
+        row is taken first, the order the is_dem PATCH and the replace hold."""
+        lines = self._lines("processing/ingest/tasks_stac_refresh.py")
+        raster_lock = next(
+            i
+            for i, line in enumerate(lines)
+            if "select(RasterAsset.dataset_id)" in line
+        )
+        dataset_lock = next(
+            i
+            for i, line in enumerate(lines)
+            if "with_for_update" in line
+            and any("Dataset.origin_uri" in prev for prev in lines[max(0, i - 8) : i])
+        )
+        assert raster_lock < dataset_lock, (
+            "refresh_stac must take raster_assets before the datasets row; "
+            "holding datasets first and then repointing the asset is an ABBA "
+            "against the is_dem PATCH."
+        )
+
 
 class TestFeatureWriteErrorClassification:
     """A lock conflict is a retryable 409, not a 503 telling clients to back off."""
@@ -2152,6 +2173,10 @@ _ORDERS_RASTER_ITSELF = {
     "app.processing.ingest.tasks_vrt.regenerate_vrt": (
         "claims the row with an UPDATE and re-reads it FOR UPDATE through its "
         "asset join, both ahead of the pair"
+    ),
+    "app.processing.ingest.tasks_stac_refresh.refresh_stac": (
+        "takes RasterAsset FOR UPDATE ahead of the datasets FOR UPDATE that is "
+        "its binding guard; the repoint writes that row after the guard"
     ),
 }
 

--- a/backend/tests/test_feature_lock_order_1847.py
+++ b/backend/tests/test_feature_lock_order_1847.py
@@ -221,6 +221,25 @@ async def _holds_record_lock(probe, record_id: uuid.UUID) -> bool:
     return False
 
 
+async def _holds_attribute_lock(probe, attribute_id: uuid.UUID) -> bool:
+    """True when some other transaction holds the attribute_metadata row."""
+    try:
+        await probe.execute(
+            text(
+                "SELECT id FROM catalog.attribute_metadata WHERE id = :aid "
+                "FOR UPDATE NOWAIT"
+            ),
+            {"aid": attribute_id},
+        )
+    except DBAPIError as exc:
+        await probe.rollback()
+        if is_lock_conflict(exc):
+            return True
+        raise
+    await probe.rollback()
+    return False
+
+
 class TestLockOrderAgainstRefreshPhaseThree:
     """The request must reach for the datasets row before the records row."""
 
@@ -806,6 +825,123 @@ class TestMetadataPatchTakesThePairToo:
         assert response.json()["title"] == "Renamed by the metadata patch"
 
 
+class TestAttributeEditsTakeThePairToo:
+    """Attribute PATCH and reset write the attribute row, then `record.updated_by`;
+    every column DDL takes the pair, then the attribute row (#1847).
+    """
+
+    @pytest.mark.parametrize(
+        ("method", "suffix", "payload"),
+        [
+            ("PATCH", "", {"title": "Renamed by the attribute patch"}),
+            ("POST", "reset/", None),
+        ],
+        ids=["update", "reset"],
+    )
+    async def test_attribute_edit_holds_no_attribute_lock_while_waiting(
+        self,
+        locked_dataset,
+        client: AsyncClient,
+        test_db_session,
+        admin_auth_header,
+        monkeypatch,
+        method: str,
+        suffix: str,
+        payload: dict | None,
+    ):
+        monkeypatch.setattr(catalog_locks, "REQUEST_LOCK_TIMEOUT", "60s")
+
+        import app.core.db as db_module
+        from app.modules.catalog.datasets.domain.models import AttributeMetadata
+
+        attr = AttributeMetadata(
+            dataset_id=locked_dataset.id,
+            field_name="name",
+            title="Name",
+            data_type="text",
+        )
+        test_db_session.add(attr)
+        await test_db_session.commit()
+        await test_db_session.refresh(attr)
+
+        async with (
+            db_module.async_session() as holder,
+            db_module.async_session() as probe,
+        ):
+            # Stand in for a column DDL: it holds the pair, in the house order,
+            # and will write this attribute row next.
+            await holder.execute(
+                select(Dataset.tile_cache_version)
+                .where(Dataset.id == locked_dataset.id)
+                .with_for_update()
+            )
+            await holder.execute(
+                select(Record.id)
+                .where(Record.id == locked_dataset.record_id)
+                .with_for_update()
+            )
+            holder_xid = await holder.scalar(text("SELECT pg_current_xact_id()::text"))
+
+            edit = asyncio.create_task(
+                client.request(
+                    method,
+                    f"/datasets/{locked_dataset.id}/attributes/{attr.id}/{suffix}",
+                    json=payload,
+                    headers=admin_auth_header,
+                )
+            )
+            try:
+                await _await_waiter_on(probe, holder_xid)
+                assert not await _holds_attribute_lock(probe, attr.id), (
+                    "the attribute edit is parked on the pair while holding "
+                    "catalog.attribute_metadata, which deadlocks against a "
+                    "column DDL holding the pair and writing that row next."
+                )
+                # The DDL's own next step, which a held attribute row would block.
+                await holder.execute(
+                    text(
+                        "UPDATE catalog.attribute_metadata SET data_type = 'text' "
+                        "WHERE id = :aid"
+                    ),
+                    {"aid": attr.id},
+                )
+                await holder.commit()
+            except BaseException:
+                await holder.rollback()
+                raise
+            response = await edit
+
+        assert response.status_code == 200, response.text
+        assert response.json()["field_name"] == "name"
+
+    def test_both_handlers_acquire_before_the_attribute_write(self):
+        """Position, in source: the acquisition precedes the service call."""
+        import ast
+        import inspect
+
+        from app.modules.catalog.datasets.api import router_metadata
+
+        tree = ast.parse(inspect.getsource(router_metadata))
+        wanted = {
+            "update_attribute_endpoint": "update_attribute",
+            "reset_attribute_endpoint": "reset_attribute",
+        }
+        seen = {}
+        for node in ast.walk(tree):
+            if isinstance(node, ast.AsyncFunctionDef) and node.name in wanted:
+                calls = {}
+                for sub in ast.walk(node):
+                    if isinstance(sub, ast.Call) and isinstance(sub.func, ast.Name):
+                        calls.setdefault(sub.func.id, sub.lineno)
+                seen[node.name] = calls
+        for handler, writer in wanted.items():
+            calls = seen[handler]
+            assert "lock_catalog_rows_for_write" in calls, handler
+            assert calls["lock_catalog_rows_for_write"] < calls[writer], (
+                f"{handler} writes the attribute row before taking the pair"
+            )
+
+
 class TestOneAnswerForAContendedRow:
     """409 from every caller, not 409/503/400 by route.
 
@@ -1091,6 +1227,58 @@ class TestOneShapeForEveryContendedRow:
                 await test_db_session.execute(
                     text(f"DROP TABLE IF EXISTS data.{d.table_name}")
                 )
+            await test_db_session.commit()
+
+    async def test_bulk_delete_codes_a_conflict_after_the_acquisition(
+        self, client: AsyncClient, test_db_session, admin_auth_header, monkeypatch
+    ):
+        """A wait AFTER the pair is taken is the same contended row: a later
+        55P03 arrives as a plain DBAPIError and must carry the same code.
+        """
+        from app.modules.catalog.datasets.api import router as datasets_router
+        from app.modules.catalog.datasets.domain import service_lifecycle
+
+        async def _no_reap(prefixes, tenant_id):
+            return None
+
+        monkeypatch.setattr(service_lifecycle, "reap_managed_storage", _no_reap)
+
+        class _Orig:
+            sqlstate = "55P03"
+
+        async def _late_wait(*args, **kwargs):
+            raise DBAPIError("UPDATE catalog.map_layers", {}, _Orig())
+
+        # The first statement after delete_dataset returns, i.e. after the pair
+        # was acquired inside it.
+        monkeypatch.setattr(datasets_router, "audit_emit", _late_wait)
+
+        admin_id = await get_user_id(test_db_session, "admin")
+        dataset = await _seed_dataset(test_db_session, created_by=admin_id)
+        try:
+            response = await client.post(
+                "/datasets/bulk-delete",
+                json={
+                    "datasets": [
+                        {
+                            "dataset_id": str(dataset.id),
+                            "confirm_title": f"Lock order {dataset.table_name}",
+                        }
+                    ]
+                },
+                headers=admin_auth_header,
+            )
+            assert response.status_code == 200, response.text
+            body = response.json()
+            (item,) = body["results"]
+            assert item["status"] == "error", body
+            assert item["code"] == "catalog_lock_conflict", body
+            assert "failed unexpectedly" not in response.text
+            assert body["deleted"] == 0 and body["errors"] == 1, body
+        finally:
+            await test_db_session.execute(
+                text(f"DROP TABLE IF EXISTS data.{dataset.table_name}")
+            )
             await test_db_session.commit()
 
 
@@ -1489,7 +1677,8 @@ class TestInvalidationsPrecedeTheReap:
 
 
 class TestOnlyThisRequestsTimeoutIsAnswered:
-    """codex r7 P2: a 40P01 from elsewhere is not a busy dataset."""
+    """fix(#1847): a 40P01 from a request that never installed the catalog
+    timeout is not a busy dataset; only this request's own wait answers 409."""
 
     def _handler_input(self, code: str):
         import types

--- a/backend/tests/test_feature_lock_order_1847.py
+++ b/backend/tests/test_feature_lock_order_1847.py
@@ -908,39 +908,6 @@ class TestDeleteNeverReapsStorageItCannotCommit:
     catalog keeps a dataset whose assets no longer exist.
     """
 
-    def test_the_lock_precedes_every_irreversible_reap(self):
-        """Source order, because the failure mode is an ordering, not a value."""
-        import ast
-        from pathlib import Path
-
-        source = (
-            Path(__file__).resolve().parents[1]
-            / "app/modules/catalog/datasets/domain/service_lifecycle.py"
-        ).read_text()
-        tree = ast.parse(source)
-        fn = next(
-            n
-            for n in ast.walk(tree)
-            if isinstance(n, ast.AsyncFunctionDef) and n.name == "delete_dataset"
-        )
-        acquisitions, reaps = [], []
-        for node in ast.walk(fn):
-            if isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
-                if node.func.id == "lock_catalog_rows_for_write":
-                    acquisitions.append(node.lineno)
-                elif node.func.id == "_reap_managed_storage":
-                    reaps.append(node.lineno)
-        assert acquisitions and reaps, (
-            f"expected both calls in delete_dataset; got {acquisitions=} {reaps=}"
-        )
-        for reap in reaps:
-            assert any(a < reap for a in acquisitions), (
-                f"_reap_managed_storage at line {reap} runs before any "
-                "lock_catalog_rows_for_write. A 55P03 after that reap rolls the "
-                "transaction back with the objects already deleted, leaving a "
-                "catalog row pointing at storage that is gone."
-            )
-
     async def test_a_contended_delete_leaves_the_objects_alone(
         self, locked_dataset, client: AsyncClient, admin_auth_header, monkeypatch
     ):
@@ -955,7 +922,7 @@ class TestDeleteNeverReapsStorageItCannotCommit:
 
         from app.modules.catalog.datasets.domain import service_lifecycle
 
-        monkeypatch.setattr(service_lifecycle, "_reap_managed_storage", _record_only)
+        monkeypatch.setattr(service_lifecycle, "reap_managed_storage", _record_only)
 
         async with db_module.async_session() as holder:
             await holder.execute(
@@ -1092,7 +1059,7 @@ class TestOneShapeForEveryContendedRow:
         async def _no_reap(prefixes, tenant_id):
             return None
 
-        monkeypatch.setattr(service_lifecycle, "_reap_managed_storage", _no_reap)
+        monkeypatch.setattr(service_lifecycle, "reap_managed_storage", _no_reap)
 
         admin_id = await get_user_id(test_db_session, "admin")
         datasets = [
@@ -1166,7 +1133,7 @@ class TestTheRasterChildIsHeldBeforeTheReap:
         async def _record_only(prefixes, tenant_id):
             reaped.append(tuple(prefixes))
 
-        monkeypatch.setattr(service_lifecycle, "_reap_managed_storage", _record_only)
+        monkeypatch.setattr(service_lifecycle, "reap_managed_storage", _record_only)
 
         title = locked_raster_dataset.record.title
         async with db_module.async_session() as holder:
@@ -1350,6 +1317,151 @@ class TestRecoverySurvivesANonMappedIdentity:
         )
 
 
+class TestTheReapFollowsTheCommit:
+    """codex r7 P1: the irreversible step must not precede a cascade that can fail.
+
+    The record delete cascades to child rows nobody locks (map_layers,
+    record_embeddings, dataset_assets). Under the request timeout a contended
+    child raises 55P03 and the transaction rolls back, so a reap that ran first
+    left the dataset restored with its objects gone.
+    """
+
+    async def test_a_contended_cascade_child_leaves_the_objects_alone(
+        self,
+        locked_raster_dataset,
+        client: AsyncClient,
+        admin_auth_header,
+        test_db_session,
+        monkeypatch,
+    ):
+        monkeypatch.setattr(catalog_locks, "REQUEST_LOCK_TIMEOUT", "150ms")
+        import app.core.db as db_module
+        from app.modules.catalog.datasets.api import router as datasets_router
+        from app.modules.catalog.maps.models import Map, MapLayer
+
+        reaped: list = []
+
+        async def _record_only(prefixes, tenant_id):
+            reaped.append(tuple(prefixes))
+
+        monkeypatch.setattr(
+            datasets_router,
+            "_reap_after_commit",
+            lambda deletion: _record_only(deletion.storage_prefixes, None),
+        )
+
+        admin_id = await get_user_id(test_db_session, "admin")
+        the_map = Map(name="lock order map", created_by=admin_id)
+        test_db_session.add(the_map)
+        await test_db_session.flush()
+        layer = MapLayer(
+            map_id=the_map.id,
+            dataset_id=locked_raster_dataset.id,
+            sort_order=0,
+        )
+        test_db_session.add(layer)
+        await test_db_session.commit()
+
+        title = locked_raster_dataset.record.title
+        try:
+            async with db_module.async_session() as holder:
+                # A cascade child the acquisition does not lock.
+                await holder.execute(
+                    select(MapLayer.id).where(MapLayer.id == layer.id).with_for_update()
+                )
+                response = await client.request(
+                    "DELETE",
+                    f"/datasets/{locked_raster_dataset.id}",
+                    json={"confirm_title": title},
+                    headers=admin_auth_header,
+                )
+                await holder.rollback()
+
+            async with db_module.async_session() as check:
+                still_there = await check.scalar(
+                    select(Dataset.id).where(Dataset.id == locked_raster_dataset.id)
+                )
+            # Either outcome is sound; what must never happen is the dataset
+            # surviving with its objects reaped.
+            assert not (still_there is not None and reaped), (
+                f"the dataset survived ({still_there}) with storage already "
+                f"reaped ({reaped}); response was {response.status_code}"
+            )
+        finally:
+            await test_db_session.execute(
+                text("DELETE FROM catalog.maps WHERE id = :m"), {"m": the_map.id}
+            )
+            await test_db_session.commit()
+
+    def test_delete_dataset_does_not_reap(self):
+        """Source-level: the reap is the caller's, after its commit."""
+        import ast
+        from pathlib import Path
+
+        app_dir = Path(__file__).resolve().parents[1] / "app"
+        tree = ast.parse(
+            (
+                app_dir / "modules/catalog/datasets/domain/service_lifecycle.py"
+            ).read_text()
+        )
+        fn = next(
+            n
+            for n in ast.walk(tree)
+            if isinstance(n, ast.AsyncFunctionDef) and n.name == "delete_dataset"
+        )
+        reaps = [
+            n
+            for n in ast.walk(fn)
+            if isinstance(n, ast.Call)
+            and isinstance(n.func, ast.Name)
+            and "reap" in n.func.id
+        ]
+        assert not reaps, (
+            "delete_dataset reaps storage inside its own transaction again. A "
+            "cascade that loses a lock race then rolls the rows back with the "
+            "objects already gone."
+        )
+
+
+class TestOnlyThisRequestsTimeoutIsAnswered:
+    """codex r7 P2: a 40P01 from elsewhere is not a busy dataset."""
+
+    def _handler_input(self, code: str):
+        import types
+
+        class _Orig:
+            sqlstate = code
+
+        from sqlalchemy.exc import DBAPIError
+
+        return DBAPIError("SELECT 1", {}, _Orig()), types.SimpleNamespace(
+            url=types.SimpleNamespace(path="/datasets/x")
+        )
+
+    async def test_a_conflict_after_our_timeout_answers_409(self):
+        from app.api.main import _database_error_handler
+
+        token = catalog_locks.catalog_timeout_installed.set(True)
+        try:
+            exc, request = self._handler_input("40P01")
+            response = await _database_error_handler(request, exc)
+        finally:
+            catalog_locks.catalog_timeout_installed.reset(token)
+        assert response.status_code == 409
+
+    async def test_an_unrelated_conflict_keeps_its_operational_answer(self):
+        """No catalog timeout in this request, so class 40 stays a 503."""
+        from app.api.main import _database_error_handler
+
+        assert catalog_locks.catalog_timeout_installed.get() is False
+        exc, request = self._handler_input("40P01")
+        response = await _database_error_handler(request, exc)
+        assert response.status_code == 503, (
+            "a deadlock from a request that never installed the catalog "
+            "timeout was reported as a busy dataset"
+        )
+
+
 class TestTheOtherSitesHoldTheOrderToo:
     """The layers DDL, the delete and the metadata PATCH, against a held row.
 
@@ -1410,7 +1522,7 @@ class TestTheOtherSitesHoldTheOrderToo:
         async def _record_only(prefixes, tenant_id):
             reaped.append(tuple(prefixes))
 
-        monkeypatch.setattr(service_lifecycle, "_reap_managed_storage", _record_only)
+        monkeypatch.setattr(service_lifecycle, "reap_managed_storage", _record_only)
 
         async with (
             db_module.async_session() as holder,

--- a/backend/tests/test_feature_lock_order_1847.py
+++ b/backend/tests/test_feature_lock_order_1847.py
@@ -1200,6 +1200,80 @@ class TestALaterLockWaitAnswersTheSameWay:
     translation never wrapped.
     """
 
+    async def test_is_dem_waits_at_the_raster_row_holding_nothing(
+        self, locked_dataset, client: AsyncClient, admin_auth_header, monkeypatch
+    ):
+        """codex r6: the request must reach for raster_assets FIRST.
+
+        Holding the pair and then asking for the raster row is the opposite of
+        the replace worker's order, and the worker is the side that cannot be
+        retried. Parked at its first acquisition the request holds nothing, so
+        no cycle can form whichever side arrives first.
+        """
+        monkeypatch.setattr(catalog_locks, "REQUEST_LOCK_TIMEOUT", "60s")
+        import app.core.db as db_module
+        from app.processing.raster.models import RasterAsset
+
+        async with db_module.async_session() as owner:
+            owner.add(
+                RasterAsset(
+                    dataset_id=locked_dataset.id,
+                    asset_uri=f"rasters/{locked_dataset.id}/source.cog.tif",
+                )
+            )
+            await owner.commit()
+
+        try:
+            async with (
+                db_module.async_session() as holder,
+                db_module.async_session() as probe,
+            ):
+                # The worker's first lock, held across its upload.
+                await holder.execute(
+                    select(RasterAsset.dataset_id)
+                    .where(RasterAsset.dataset_id == locked_dataset.id)
+                    .with_for_update()
+                )
+                holder_xid = await holder.scalar(
+                    text("SELECT pg_current_xact_id()::text")
+                )
+                patch = asyncio.create_task(
+                    client.patch(
+                        f"/datasets/{locked_dataset.id}",
+                        json={"tile_columns": ["name"], "is_dem": True},
+                        headers=admin_auth_header,
+                    )
+                )
+                try:
+                    await _await_waiter_on(probe, holder_xid)
+                    assert not await _holds_record_lock(
+                        probe, locked_dataset.record_id
+                    ), (
+                        "the PATCH is parked on the raster row while holding "
+                        "catalog.records, which is the cycle the worker loses"
+                    )
+                    # What the worker does next, under its own raster lock.
+                    await holder.execute(
+                        text(
+                            "UPDATE catalog.records SET updated_at = now() "
+                            "WHERE id = :rid"
+                        ),
+                        {"rid": locked_dataset.record_id},
+                    )
+                    await holder.commit()
+                except BaseException:
+                    await holder.rollback()
+                    raise
+                response = await patch
+            assert response.status_code == 200, response.text
+        finally:
+            async with db_module.async_session() as cleanup:
+                await cleanup.execute(
+                    text("DELETE FROM catalog.raster_assets WHERE dataset_id = :d"),
+                    {"d": locked_dataset.id},
+                )
+                await cleanup.commit()
+
     async def test_is_dem_contending_on_the_raster_row_answers_409(
         self, locked_dataset, client: AsyncClient, admin_auth_header, monkeypatch
     ):
@@ -1482,6 +1556,51 @@ class TestWorkerDoorsAcquireBeforeTheirWrites:
             f"swap at {swap}, acquisition at {acquire}, no_autoflush at {guarded}"
         )
 
+    def test_the_worker_takes_the_raster_row_before_the_pair(self):
+        """The reason both raster exemptions rest on, checked not asserted.
+
+        Each takes `raster_assets` itself rather than through the helper. If
+        that acquisition ever moves below the pair, the exemption is false and
+        the site is the ABBA the rule exists to stop.
+        """
+        import ast
+        from pathlib import Path
+
+        app_dir = Path(__file__).resolve().parents[1] / "app"
+        for rel, name in (
+            ("processing/ingest/tasks_raster_replace.py", "reupload_raster"),
+            ("processing/ingest/tasks_vrt.py", "regenerate_vrt"),
+        ):
+            tree = ast.parse((app_dir / rel).read_text())
+            fn = next(
+                n
+                for n in ast.walk(tree)
+                if isinstance(n, ast.AsyncFunctionDef) and n.name == name
+            )
+            raster_lines = [
+                n.lineno
+                for n in ast.walk(fn)
+                if isinstance(n, ast.Call)
+                and isinstance(n.func, ast.Attribute)
+                and n.func.attr in ("with_for_update", "values")
+                and "RasterAsset" in ast.dump(n)
+            ]
+            pair_lines = [
+                n.lineno
+                for n in ast.walk(fn)
+                if isinstance(n, ast.Call)
+                and isinstance(n.func, ast.Name)
+                and n.func.id == "lock_catalog_rows"
+            ]
+            assert raster_lines, f"{rel}::{name} takes no raster row at all"
+            assert pair_lines, f"{rel}::{name} takes no pair"
+            assert min(raster_lines) < min(pair_lines), (
+                f"{rel}::{name} takes the catalog pair at line "
+                f"{min(pair_lines)} before it takes raster_assets at "
+                f"{min(raster_lines)}. Its _ORDERS_RASTER_ITSELF exemption is "
+                "now false."
+            )
+
     def test_worker_doors_do_not_clamp_their_transaction(self):
         """`lock_timeout=None` at each, and nowhere on a request path.
 
@@ -1569,6 +1688,21 @@ _INMEMORY_UNTIL_ACQUIRED = {
 }
 
 
+# Functions that write raster_assets and order it themselves, rather than
+# through the helper's `with_raster_asset`. The reason is enforced by
+# test_the_worker_takes_the_raster_row_before_the_pair.
+_ORDERS_RASTER_ITSELF = {
+    "app.processing.ingest.tasks_raster_replace.reupload_raster": (
+        "takes RasterAsset FOR UPDATE itself, ahead of the pair, which is the "
+        "order every other site is matching"
+    ),
+    "app.processing.ingest.tasks_vrt.regenerate_vrt": (
+        "claims the row with an UPDATE and re-reads it FOR UPDATE through its "
+        "asset join, both ahead of the pair"
+    ),
+}
+
+
 # Functions whose acquisition is deliberately conditional. Every other site
 # must acquire on every path; these carry the reason the unlocked path is safe.
 _CONDITIONAL_ACQUISITION = {
@@ -1638,21 +1772,31 @@ def _is_acquisition(node, bindings, module) -> bool:
     return False
 
 
-_PAIR_TABLES = {"Dataset", "DatasetModel", "Record", "RecordModel"}
+_PAIR_TABLES = {"Dataset", "DatasetModel", "Record", "RecordModel", "RasterAsset"}
+
+
+# Names that stand for a `raster_assets` row. Deliberately loose: a false
+# positive costs one exemption line, a false negative costs an ABBA against the
+# replace worker, which takes that row first and the pair afterwards.
+_RASTER_NAMES = {"ra", "raster_asset", "vrt_asset", "asset"}
 
 
 def _classify_base(base) -> str | None:
-    """'record', 'dataset', or None for the object being written to."""
+    """'record', 'dataset', 'raster', or None for the object written to."""
     import ast
 
     if isinstance(base, ast.Attribute):
         if base.attr == "record":
             return "record"
+        if base.attr in _RASTER_NAMES or "raster" in base.attr:
+            return "raster"
         if "dataset" in base.attr:
             return "dataset"
     if isinstance(base, ast.Name):
         if base.id in ("record", "rec"):
             return "record"
+        if base.id in _RASTER_NAMES or "raster" in base.id:
+            return "raster"
         if "dataset" in base.id:
             return "dataset"
     return None
@@ -1689,6 +1833,8 @@ def _core_statement_kind(node) -> str | None:
     )
     if name not in _PAIR_TABLES:
         return None
+    if "Raster" in name:
+        return "raster"
     return "record" if "Record" in name else "dataset"
 
 
@@ -1841,6 +1987,42 @@ def _pair_writer_report() -> dict[str, str]:
     }
 
 
+def _raster_writer_report() -> dict[str, str]:
+    """Qualified name -> site, for every function that writes raster_assets."""
+    _writes, _calls, sites = _app_function_facts()
+    return {
+        name: sites[name]
+        for name, kinds in _effective_writes().items()
+        if "raster" in kinds and name in sites
+    }
+
+
+def _acquires_raster_first(fn) -> bool:
+    """Does every acquisition in *fn* extend the order to the raster child?"""
+    import ast
+
+    calls = [
+        n
+        for n in ast.walk(fn)
+        if isinstance(n, ast.Call)
+        and isinstance(n.func, ast.Name)
+        and n.func.id in ("lock_catalog_rows", "lock_catalog_rows_for_write")
+    ]
+    if not calls:
+        return False
+    for call in calls:
+        for kw in call.keywords:
+            if kw.arg == "with_raster_asset" and not (
+                isinstance(kw.value, ast.Constant) and kw.value.value is False
+            ):
+                return True
+            if kw.arg == "raster_asset_cls" and not (
+                isinstance(kw.value, ast.Constant) and kw.value.value is None
+            ):
+                return True
+    return False
+
+
 def _acquiring_functions() -> set[str]:
     """Qualified names that acquire, or that reach an acquirer through a call."""
     _writes, calls, _sites = _app_function_facts()
@@ -1898,13 +2080,18 @@ def _write_predicate(bindings, module, is_acq, reaches_write):
     import ast
 
     def is_write(node) -> bool:
-        if _write_kinds(node):
+        # Pair writes only. A raster_assets write belongs BEFORE the pair, not
+        # after it, so requiring the pair acquisition ahead of one would demand
+        # the inversion this file exists to prevent. That ordering is
+        # test_a_raster_writer_orders_the_child_first.
+        if _write_kinds(node) & {"record", "dataset"}:
             return True
         if not isinstance(node, ast.Call) or is_acq(node):
             return False
         if not isinstance(node.func, ast.Name):
             return False  # unresolvable attribute call; do not guess
-        return bool(reaches_write.get(_resolve(node.func.id, bindings, module)))
+        reached = reaches_write.get(_resolve(node.func.id, bindings, module)) or set()
+        return bool(reached & {"record", "dataset"})
 
     return is_write
 
@@ -2033,6 +2220,47 @@ class TestEveryPairWriterTakesTheHouseOrder:
             "name to _CONDITIONAL_ACQUISITION with the reason the unlocked "
             "path cannot write both rows."
         )
+
+    def test_a_raster_writer_orders_the_child_first(self):
+        """codex r6: the third site of this class, so the gate takes it over.
+
+        The replace worker holds `raster_assets` across its upload and asks for
+        the pair afterwards. Any request path that takes the pair and then
+        writes that row is the opposite order, which is an ABBA whose victim
+        can be the retry-disabled worker.
+        """
+        acquirers = _acquiring_functions()
+        raster_writers = _raster_writer_report()
+        failures = []
+        for rel, module, _bindings, fn in _walk_app_functions():
+            key = f"{module}.{fn.name}"
+            if key not in acquirers or key not in raster_writers:
+                continue
+            if key in _ORDERS_RASTER_ITSELF or key in _PAIR_WRITER_EXEMPTIONS:
+                continue
+            if not _acquires_raster_first(fn):
+                failures.append(f"  {key} ({rel}:{fn.lineno})")
+        assert not failures, (
+            "these take the catalog pair and then write raster_assets, which "
+            "inverts against the replace worker:\n"
+            + "\n".join(sorted(failures))
+            + "\n\nPass with_raster_asset=True (catalog) or raster_asset_cls "
+            "(processing) so the child row is taken first, or add the name to "
+            "_ORDERS_RASTER_ITSELF with the reason it already orders it."
+        )
+
+    def test_the_raster_scan_finds_the_known_writers(self):
+        """Positive control: an empty raster scan would pass the test above."""
+        writers = _raster_writer_report()
+        for expected in (
+            "app.modules.catalog.datasets.domain.service_metadata._apply_is_dem",
+            "app.modules.catalog.datasets.domain.service_metadata.update_user_metadata",
+            "app.processing.ingest.tasks_raster_swap._write_swapped_fields",
+        ):
+            assert expected in writers, (
+                f"{expected} writes raster_assets but the scan missed it, so "
+                "the rule above is passing vacuously"
+            )
 
     def test_the_gate_actually_finds_the_known_writers(self):
         """A positive control: an empty scan would pass the tests above."""
@@ -2202,6 +2430,52 @@ class TestTheGateRejectsWhatItExistsToCatch:
             fn, bindings, self.MODULE, None, self._local_writers(source)
         )
         assert ok, why
+
+    def test_a_raster_writer_that_takes_the_pair_first_is_rejected(self):
+        """codex r6: the shape that inverts against the replace worker."""
+        import ast
+
+        source = (
+            "from app.modules.catalog.features.service import "
+            "lock_catalog_rows_for_write\n"
+            "async def probe(session, dataset):\n"
+            "    await lock_catalog_rows_for_write(session, dataset)\n"
+            "    ra = await get_raster_asset(session, dataset.id)\n"
+            "    ra.is_dem = True\n"
+        )
+        tree = ast.parse(source)
+        fn = next(
+            n
+            for n in ast.walk(tree)
+            if isinstance(n, ast.AsyncFunctionDef) and n.name == "probe"
+        )
+        assert "raster" in _direct_writes(fn), "the raster write must be seen"
+        assert not _acquires_raster_first(fn), (
+            "this takes the pair and only then writes raster_assets, which is "
+            "the opposite of the order the replace worker takes"
+        )
+
+    def test_the_same_writer_extending_the_order_is_accepted(self):
+        """The control: only the acquisition's reach differs."""
+        import ast
+
+        source = (
+            "from app.modules.catalog.features.service import "
+            "lock_catalog_rows_for_write\n"
+            "async def probe(session, dataset):\n"
+            "    await lock_catalog_rows_for_write(\n"
+            "        session, dataset, with_raster_asset=True\n"
+            "    )\n"
+            "    ra = await get_raster_asset(session, dataset.id)\n"
+            "    ra.is_dem = True\n"
+        )
+        tree = ast.parse(source)
+        fn = next(
+            n
+            for n in ast.walk(tree)
+            if isinstance(n, ast.AsyncFunctionDef) and n.name == "probe"
+        )
+        assert _acquires_raster_first(fn)
 
     def test_core_update_statements_count_as_writes(self):
         """`update(Dataset)` / `delete(Record)` are invisible to an attribute scan."""

--- a/backend/tests/test_feature_lock_order_1847.py
+++ b/backend/tests/test_feature_lock_order_1847.py
@@ -426,9 +426,8 @@ class TestPropertyOnlyPatchTakesThePairToo:
     ):
         """The same interleaving with the diagnostic assertion removed.
 
-        Drives both sides to completion instead of characterising the state in
-        the middle, so on the inverted order PostgreSQL reports the cycle
-        itself rather than a message this test composed.
+        Drives both sides to completion rather than characterising the state
+        in the middle, so PostgreSQL reports any cycle itself.
         """
         monkeypatch.setattr(catalog_locks, "REQUEST_LOCK_TIMEOUT", "60s")
 
@@ -748,11 +747,9 @@ class TestEveryWriteHandlerGoesThroughTheGuard:
 class TestMetadataPatchTakesThePairToo:
     """The class from the other side.
 
-    `update_user_metadata` writes record fields and dataset fields and then
-    flushes them together. Before this round it acquired nothing, so the flush
-    took catalog.records ahead of catalog.datasets and inverted against every
-    writer that now leads with the dataset row -- including an ordinary feature
-    edit, which is the pairing this issue exists to remove.
+    `update_user_metadata` writes record fields and dataset fields and flushes
+    them together, so it must take the pair first or invert against every
+    writer that leads with the dataset row.
     """
 
     async def test_metadata_patch_holds_no_record_lock_while_waiting(
@@ -894,11 +891,8 @@ class TestOneAnswerForAContendedRow:
 class TestDeleteNeverReapsStorageItCannotCommit:
     """The irreversible step must be behind the lock.
 
-    `delete_dataset` deletes the managed objects permanently and relies on the
-    transaction rolling back to keep the catalog consistent with them. An
-    acquisition that can time out placed AFTER that reap breaks the
-    arrangement: the objects are gone, the transaction rolls back, and the
-    catalog keeps a dataset whose assets no longer exist.
+    The reap is permanent, so anything that can fail after it leaves the
+    catalog holding a dataset whose objects are gone.
     """
 
     async def test_a_contended_delete_leaves_the_objects_alone(
@@ -1414,6 +1408,84 @@ class TestTheReapFollowsTheCommit:
             "cascade that loses a lock race then rolls the rows back with the "
             "objects already gone."
         )
+
+
+class TestInvalidationsPrecedeTheReap:
+    """Cache eviction must not wait on, or be skipped by, object storage.
+
+    The reap awaits a storage backend. Running it first lets a slow one delay
+    the invalidations, and a cancellation during it skip them, leaving search
+    and the tile map serving a deleted dataset until TTL.
+    """
+
+    async def _run(self, client, headers, dataset, monkeypatch, boom, calls):
+        from app.modules.catalog.datasets.api import router as datasets_router
+        from app.modules.catalog.datasets.domain import service as domain_service
+
+        async def _failing_reap(prefixes, tenant_id):
+            calls.append("reap")
+            raise boom()
+
+        async def _catalog(*a, **kw):
+            calls.append("invalidate_catalog_cache")
+
+        def _notify(table_name):
+            calls.append("notify_table_invalidated")
+
+        # The real `_reap_after_commit` stays, so its own error handling is
+        # what the test exercises.
+        monkeypatch.setattr(domain_service, "reap_managed_storage", _failing_reap)
+        monkeypatch.setattr(datasets_router, "invalidate_catalog_cache", _catalog)
+        monkeypatch.setattr(datasets_router, "notify_table_invalidated", _notify)
+
+        response = await client.request(
+            "DELETE",
+            f"/datasets/{dataset.id}",
+            json={"confirm_title": dataset.record.title},
+            headers=headers,
+        )
+        return response
+
+    async def test_a_failing_reap_does_not_skip_them(
+        self, locked_raster_dataset, client: AsyncClient, admin_auth_header, monkeypatch
+    ):
+        calls: list[str] = []
+        response = await self._run(
+            client,
+            admin_auth_header,
+            locked_raster_dataset,
+            monkeypatch,
+            RuntimeError,
+            calls,
+        )
+        assert response.status_code == 204, response.text
+        assert "reap" in calls, calls
+        assert calls.index("reap") > calls.index("invalidate_catalog_cache"), calls
+        assert calls.index("reap") > calls.index("notify_table_invalidated"), calls
+
+    async def test_a_cancelled_reap_does_not_skip_them(
+        self, locked_raster_dataset, client: AsyncClient, admin_auth_header, monkeypatch
+    ):
+        """Cancellation is the shutdown case, and it is a BaseException.
+
+        `_reap_after_commit` catches Exception, so this one propagates. Both
+        invalidations have already run by then, which is the point.
+        """
+        calls: list[str] = []
+        try:
+            await self._run(
+                client,
+                admin_auth_header,
+                locked_raster_dataset,
+                monkeypatch,
+                asyncio.CancelledError,
+                calls,
+            )
+        except BaseException:  # broad: the cancellation IS the scenario under test
+            pass
+        assert "reap" in calls, calls
+        assert "invalidate_catalog_cache" in calls, calls
+        assert "notify_table_invalidated" in calls, calls
 
 
 class TestOnlyThisRequestsTimeoutIsAnswered:

--- a/backend/tests/test_feature_lock_order_1847.py
+++ b/backend/tests/test_feature_lock_order_1847.py
@@ -971,9 +971,68 @@ class TestOneShapeForEveryContendedRow:
         assert body["detail"]["code"] == "catalog_lock_conflict", body
         assert body["title"] == "Catalog entry is busy", body
 
-    async def test_bulk_delete_answers_conflict_not_unexpected_failure(
-        self, locked_dataset, client: AsyncClient, admin_auth_header, monkeypatch
+    async def test_one_failed_item_does_not_poison_the_rest(
+        self, client: AsyncClient, test_db_session, admin_auth_header
     ):
+        """fix(#1847): found while making the conflict per-item.
+
+        Any per-item failure rolled the session back, which expires every
+        instance in it including the actor. The next item's access check then
+        read `user.id`, lazy-loaded outside the greenlet, and raised
+        MissingGreenlet -- recorded as "Dataset deletion failed unexpectedly".
+        One bad item made every later item fail for a reason that had nothing
+        to do with it. No lock involved: an ordinary title mismatch does it.
+        """
+        admin_id = await get_user_id(test_db_session, "admin")
+        datasets = [
+            await _seed_dataset(test_db_session, created_by=admin_id) for _ in range(3)
+        ]
+        try:
+            response = await client.post(
+                "/datasets/bulk-delete",
+                json={
+                    "datasets": [
+                        {
+                            "dataset_id": str(datasets[0].id),
+                            "confirm_title": f"Lock order {datasets[0].table_name}",
+                        },
+                        {
+                            "dataset_id": str(datasets[1].id),
+                            "confirm_title": "not the title",
+                        },
+                        {
+                            "dataset_id": str(datasets[2].id),
+                            "confirm_title": f"Lock order {datasets[2].table_name}",
+                        },
+                    ]
+                },
+                headers=admin_auth_header,
+            )
+            assert response.status_code == 200, response.text
+            body = response.json()
+            by_id = {r["dataset_id"]: r for r in body["results"]}
+            assert by_id[str(datasets[0].id)]["status"] == "deleted", body
+            assert by_id[str(datasets[2].id)]["status"] == "deleted", body
+            middle = by_id[str(datasets[1].id)]
+            assert middle["status"] == "error"
+            assert "title does not match" in middle["detail"], middle
+            assert "failed unexpectedly" not in response.text
+        finally:
+            for d in datasets:
+                await test_db_session.execute(
+                    text(f"DROP TABLE IF EXISTS data.{d.table_name}")
+                )
+            await test_db_session.commit()
+
+    async def test_bulk_delete_records_a_conflict_per_item(
+        self, client: AsyncClient, test_db_session, admin_auth_header, monkeypatch
+    ):
+        """A conflict on one item must not discard the items around it.
+
+        The endpoint commits per item and returns per-item results, so raising
+        would throw away work that is already committed. The conflicting entry
+        carries the same code the single-delete 409 does.
+        """
         monkeypatch.setattr(catalog_locks, "REQUEST_LOCK_TIMEOUT", "150ms")
         import app.core.db as db_module
         from app.modules.catalog.datasets.domain import service_lifecycle
@@ -983,27 +1042,50 @@ class TestOneShapeForEveryContendedRow:
 
         monkeypatch.setattr(service_lifecycle, "_reap_managed_storage", _no_reap)
 
-        async with db_module.async_session() as holder:
-            await self._hold(holder, locked_dataset.id)
-            response = await client.post(
-                "/datasets/bulk-delete",
-                json={
-                    "datasets": [
-                        {
-                            "dataset_id": str(locked_dataset.id),
-                            "confirm_title": (
-                                f"Lock order {locked_dataset.table_name}"
-                            ),
-                        }
-                    ]
-                },
-                headers=admin_auth_header,
-            )
-            await holder.rollback()
+        admin_id = await get_user_id(test_db_session, "admin")
+        datasets = [
+            await _seed_dataset(test_db_session, created_by=admin_id) for _ in range(3)
+        ]
+        try:
+            async with db_module.async_session() as holder:
+                # The MIDDLE one is contended; the other two are untouched.
+                await self._hold(holder, datasets[1].id)
+                response = await client.post(
+                    "/datasets/bulk-delete",
+                    json={
+                        "datasets": [
+                            {
+                                "dataset_id": str(d.id),
+                                "confirm_title": f"Lock order {d.table_name}",
+                            }
+                            for d in datasets
+                        ]
+                    },
+                    headers=admin_auth_header,
+                )
+                await holder.rollback()
 
-        assert response.status_code == 409, response.text
-        assert response.json()["detail"]["code"] == "catalog_lock_conflict"
-        assert "failed unexpectedly" not in response.text
+            assert response.status_code != 409, response.text
+            assert response.status_code == 200, response.text
+            body = response.json()
+            by_id = {r["dataset_id"]: r for r in body["results"]}
+
+            first = by_id[str(datasets[0].id)]
+            middle = by_id[str(datasets[1].id)]
+            third = by_id[str(datasets[2].id)]
+
+            assert first["status"] == "deleted", body
+            assert third["status"] == "deleted", body
+            assert middle["status"] == "error", body
+            assert middle["code"] == "catalog_lock_conflict", body
+            assert "failed unexpectedly" not in response.text
+            assert body["deleted"] == 2 and body["errors"] == 1, body
+        finally:
+            for d in datasets:
+                await test_db_session.execute(
+                    text(f"DROP TABLE IF EXISTS data.{d.table_name}")
+                )
+            await test_db_session.commit()
 
 
 class TestTheOtherSitesHoldTheOrderToo:

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -3559,8 +3559,11 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # `CancelledError` a worker shutdown delivers. It replaces two private
     # copies that had grown in tasks_vector.py and tasks_reupload.py, whose
     # bodies differed only in the task name in their docstrings.
-    # Cap 2551 -> 2581, exact.
-    "backend/app/processing/ingest/tasks_common.py": 2581,
+    # Cap 2551 -> 2581, exact.    # fix(#1847): +5 correcting `bump_tile_cache_version_atomic`'s docstring.
+    # It said the feature-edit routers "never lock the row", which stopped
+    # being true when their metadata refresh started taking the datasets row
+    # FOR UPDATE. The helper's conclusion is unchanged, its reason is not.
+    # Cap 2551 -> 2556, exact.    "backend/app/processing/ingest/tasks_common.py": 2581,
     # --- entered by the inclusion rule, feat(#1219 x #1222) ---------------
     # tasks_reupload crossed 1000 when two independently-reviewed features
     # met in one file: #1222's failed-contact bookkeeping (spawn-armed
@@ -5099,8 +5102,12 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # issue fell back to a sequential scan. Cap 1104 -> 1128, exact.
     # fix(#1755 item 11): +2. The `finally` block's heartbeat stop routes
     # through `cleanup_step`, so a failure in it logs instead of replacing the
-    # refresh exception being propagated. Cap 1128 -> 1130, exact.
-    "backend/app/processing/ingest/tasks_postgis_refresh.py": 1130,
+    # refresh exception being propagated. Cap 1128 -> 1130, exact.    # fix(#1847): +12 comment lines on the phase 3 `FOR UPDATE`, recording that
+    # it is the first half of the house (datasets, records) lock order rather
+    # than an incidental choice, and pointing at the docstring that states the
+    # order. The feature-edit path used to take the records row first, which
+    # made an ordinary edit during this phase an ABBA deadlock.
+    # Cap 1128 -> 1140, exact.    "backend/app/processing/ingest/tasks_postgis_refresh.py": 1140,
     # --- entered by the inclusion rule, feat(#765) -------------------------
     # First time this module crosses 1000. main sat at 994, six lines under the
     # gate, so it was going to fire on whoever added next; it fired here.
@@ -6066,7 +6073,16 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # is never raised, an empty page proves nothing, and a keyset page can
     # prove only the rows in hand. That reasoning is most of the added lines.
     # Cap 1507 -> 1541, exact.
-    "backend/app/modules/catalog/features/service.py": 1541,
+    # fix(#1847): +57 for the (datasets, records) lock order. The metadata
+    # refresh took the records row first while `refresh_postgis` phase 3 takes
+    # the datasets row first, so a feature edit during a refresh was an ABBA
+    # deadlock that surfaced as a 503 with the edit lost. Six of the added
+    # lines are the reordered acquisition, the `lock_timeout` and the
+    # `no_autoflush` that keeps the ORM from re-inverting the order at flush
+    # time; the rest is the docstring every other site now cites for the order,
+    # and the note on why the COUNT(*)/ST_Extent aggregate has to stay inside
+    # the lock rather than being hoisted above it. Cap 1541 -> 1598, exact.
+    "backend/app/modules/catalog/features/service.py": 1598,
 }
 
 

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -2958,7 +2958,8 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # and named three of the five families /api/conformance advertises. Cap
     # 1903 -> 1912, exact.
     # fix(#1847): the lock order, its gate and its 409 mapping. Cap 1962, exact.
-    "backend/app/api/main.py": 1962,
+    # fix(#1847): the handler docstring states its contract. Cap 1962 -> 1959.
+    "backend/app/api/main.py": 1959,
     # fix(#1005): +4 — MapSummaryResponse gains thumbnail_updated_at, the
     # thumbnail cache version split out of updated_at. Ratchet stays exact.
     # fix(#910): +1 on top of that, the fillColorSaved entry in the authoritative
@@ -4542,7 +4543,9 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # through `cleanup_step`: three in `ingest_vrt`, four in `regenerate_vrt`,
     # which stops two heartbeats. Cap 1628 -> 1640, exact.
     # fix(#1847): the lock order, its gate and its 409 mapping. Cap 1653, exact.
-    "backend/app/processing/ingest/tasks_vrt.py": 1653,
+    # fix(#1847): the phase-2 job load locks the row and the lock-order
+    # rationale left the source. Cap 1653 -> 1640, exact.
+    "backend/app/processing/ingest/tasks_vrt.py": 1640,
     # fix(#1202 review r5): +29 — sweep the presigned staging key at job end.
     # A completed presigned job points file_path at its frozen copy, so this
     # reaper never touched the key the client's PUT URL can still recreate.
@@ -5110,7 +5113,9 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # through `cleanup_step`, so a failure in it logs instead of replacing the
     # refresh exception being propagated. Cap 1128 -> 1130, exact.
     # fix(#1847): the lock order, its gate and its 409 mapping. Cap 1134, exact.
-    "backend/app/processing/ingest/tasks_postgis_refresh.py": 1134,
+    # fix(#1847): phase 3 takes the job row before the datasets row. Cap
+    # 1134 -> 1141, exact.
+    "backend/app/processing/ingest/tasks_postgis_refresh.py": 1141,
     # --- entered by the inclusion rule, feat(#765) -------------------------
     # First time this module crosses 1000. main sat at 994, six lines under the
     # gate, so it was going to fire on whoever added next; it fired here.

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -2459,8 +2459,7 @@ _OPEN_CORE_SIZE_CAPS: dict[str, int] = {
 #     body on a GET is the defect being fixed.
 #   api/main.py 1499 -> 1558. fix(#1518 codex P2): +59 for
 #     `_document_unresolvable_credential_401`, which publishes the 401 that
-#
-# 1518 made normal runtime behaviour on every credential-aware anonymous
+#     #1518 made normal runtime behaviour on every credential-aware anonymous
 #     operation. Most of it is the docstring explaining why it targets all
 #     THREE optional dependencies while `_normalize_security_contract` targets
 #     two: a 401 RESPONSE is not a security REQUIREMENT, so the no-security-

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1868,11 +1868,7 @@ def test_decomposed_service_modules_stay_within_size_budgets() -> None:
         # which invented a delta the size of whichever side was known. The
         # case that reaches it is a service preview whose collection size the
         # service never published.
-        # fix(#1847): +33. `update_user_metadata` writes record fields and
-        # dataset fields and flushes them together, so it takes the pair first,
-        # and only when the body can reach the datasets row. `is_dem` extends
-        # the order to `raster_assets`, the row the replace worker takes first.
-        # Cap 488 -> 507, exact.
+        # fix(#1847): the lock order, its gate and its 409 mapping. Cap 507, exact.
         "backend/app/modules/catalog/datasets/domain/service_metadata.py": 507,
         # fix(#435 codex r1): +6 LOC in get_dataset_rows to probe schema existence
         # before degrading a 42P01 to an empty page. Postgres reports a missing
@@ -1943,13 +1939,7 @@ def test_decomposed_service_modules_stay_within_size_budgets() -> None:
         # the retirement set (whose whole API is set membership), with the
         # reasoning for the split and for the belt-and-braces oid guard.
         # Cap 451 -> 483, exact.
-        # fix(#1847): +36. `delete_dataset` acquires ahead of the storage reap,
-        # which deletes objects permanently, and behind the DROP. The Valkey
-        # purge stays under the lock, with its bound. The acquisition includes
-        # the raster child, whose row the replace worker holds across its
-        # upload. The storage reap moved OUT to the callers, past their
-        # commit, because the record delete's FK cascades reach child rows
-        # nobody locks. Cap 483 -> 512, exact.
+        # fix(#1847): the lock order, its gate and its 409 mapping. Cap 512, exact.
         "backend/app/modules/catalog/datasets/domain/service_lifecycle.py": 512,
         # Phase 276 CODE-02: chat_*.py sub-modules are all under the 350
         # default (largest is chat_actions.py at ~245 LOC). No explicit
@@ -2964,28 +2954,8 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # It claimed the OAS 3.0 classes while the served document is OpenAPI 3.1,
     # and named three of the five families /api/conformance advertises. Cap
     # 1903 -> 1912, exact.
-    # fix(#1847 review r3): +32 for one exception handler. A contended catalog
-    # row was answered 409, 503 and 400 depending on which route reached the
-    # acquisition; the helper now raises one domain exception and this is the
-    # single place that maps it. The lines are the handler plus why it lives
-    # here rather than in four route bodies. Cap 1903 -> 1935, exact.
-    # fix(#1847): +32 for one exception handler. A contended catalog row was
-    # answered 409, 503 and 400 depending on the route; the helper raises one
-    # domain exception and this maps it. Cap 1903 -> 1928, exact.
-    # domain exception and this maps it, with a machine-readable code now that
-    # it is the only shape a contended row produces. Cap 1903 -> 1930, exact.
-    # domain exception and this maps it, with a machine-readable code now that
-    # it is the only shape a contended row produces, from one shared constant.
-    # Cap 1903 -> 1933, exact.
-    # domain exception and this maps it, with a machine-readable code now that
-    # it is the only shape a contended row produces, from one shared constant,
-    # and answered at the boundary too: SET LOCAL lock_timeout outlives the
-    # acquisition, so a later wait in the same request raises 55P03 from a
-    # statement no per-site translation wraps. Cap 1903 -> 1952, exact.
-    # statement no per-site translation wraps, gated on this request having
-    # installed that timeout. Cap 1903 -> 1954, exact.
-    # fix(#1847 rebase): re-measured on top of main. Cap 1963, exact.
-    "backend/app/api/main.py": 1963,
+    # fix(#1847): the lock order, its gate and its 409 mapping. Cap 1962, exact.
+    "backend/app/api/main.py": 1962,
     # fix(#1005): +4 — MapSummaryResponse gains thumbnail_updated_at, the
     # thumbnail cache version split out of updated_at. Ratchet stays exact.
     # fix(#910): +1 on top of that, the fillColorSaved entry in the authoritative
@@ -3594,27 +3564,7 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # copies that had grown in tasks_vector.py and tasks_reupload.py, whose
     # bodies differed only in the task name in their docstrings.
     # Cap 2551 -> 2581, exact.
-    # fix(#1847): +5 correcting `bump_tile_cache_version_atomic`'s docstring.
-    # It said the feature-edit routers "never lock the row", which stopped
-    # being true when their metadata refresh started taking the datasets row
-    # FOR UPDATE. The helper's conclusion is unchanged, its reason is not.
-    # Cap 2551 -> 2556, exact.
-    # Cap 2551 -> 2556, exact.
-    # fix(#1847 review r1): +3. Every feature-write handler now locks, so the
-    # note had to stop saying "not on every path" and give the real reason the
-    # atomic helper is still needed: those handlers read the counter BEFORE
-    # they take the lock. Cap 2556 -> 2559, exact.
-    # they take the lock. Cap 2556 -> 2559, exact.
-    # fix(#1847 review r2): +20. `_apply_reupload_swap` writes both catalog
-    # rows and acquired nothing, so its flush took them records-first and could
-    # deadlock against a request or a refresh holding the dataset row. The
-    # lines are the acquisition plus why it passes `lock_timeout=None` (SET
-    # LOCAL would clamp the rest of an ingest transaction to a request's
-    # budget). Cap 2559 -> 2579, exact.
-    # fix(#1847): +28. `_apply_reupload_swap` writes both catalog rows and
-    # acquired nothing, and `bump_tile_cache_version_atomic`'s note had to stop
-    # saying the feature routers never lock. Cap 2551 -> 2571, exact.
-    # fix(#1847 rebase): re-measured on top of main. Cap 2601, exact.
+    # fix(#1847): the lock order, its gate and its 409 mapping. Cap 2601, exact.
     "backend/app/processing/ingest/tasks_common.py": 2601,
     # --- entered by the inclusion rule, feat(#1219 x #1222) ---------------
     # tasks_reupload crossed 1000 when two independently-reviewed features
@@ -4588,15 +4538,7 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # fix(#1755 item 11): +12. Both task tails route every cleanup step
     # through `cleanup_step`: three in `ingest_vrt`, four in `regenerate_vrt`,
     # which stops two heartbeats. Cap 1628 -> 1640, exact.
-    # fix(#1847 review r2): +19 making the publish transaction's datasets lock
-    # explicit. The asset SELECT joins Dataset under a plain FOR UPDATE, so the
-    # row was already locked -- incidentally, as a property of the join, with
-    # nothing saying so before the writes to dataset.record below.
-    # Cap 1628 -> 1647, exact.
-    # fix(#1847): +19 making the publish transaction's datasets lock explicit.
-    # The asset SELECT locks that row through its join, incidentally, with
-    # nothing saying so before the record writes. Cap 1628 -> 1641, exact.
-    # fix(#1847 rebase): re-measured on top of main. Cap 1653, exact.
+    # fix(#1847): the lock order, its gate and its 409 mapping. Cap 1653, exact.
     "backend/app/processing/ingest/tasks_vrt.py": 1653,
     # fix(#1202 review r5): +29 — sweep the presigned staging key at job end.
     # A completed presigned job points file_path at its frozen copy, so this
@@ -5164,15 +5106,7 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # fix(#1755 item 11): +2. The `finally` block's heartbeat stop routes
     # through `cleanup_step`, so a failure in it logs instead of replacing the
     # refresh exception being propagated. Cap 1128 -> 1130, exact.
-    # fix(#1847): +12 comment lines on the phase 3 `FOR UPDATE`, recording that
-    # it is the first half of the house (datasets, records) lock order rather
-    # than an incidental choice, and pointing at the docstring that states the
-    # order. The feature-edit path used to take the records row first, which
-    # made an ordinary edit during this phase an ABBA deadlock.
-    # Cap 1128 -> 1140, exact.
-    # fix(#1847): +12 recording that the phase 3 `FOR UPDATE` is the first half
-    # of the house (datasets, records) order. Cap 1128 -> 1132, exact.
-    # fix(#1847 rebase): re-measured on top of main. Cap 1134, exact.
+    # fix(#1847): the lock order, its gate and its 409 mapping. Cap 1134, exact.
     "backend/app/processing/ingest/tasks_postgis_refresh.py": 1134,
     # --- entered by the inclusion rule, feat(#765) -------------------------
     # First time this module crosses 1000. main sat at 994, six lines under the
@@ -5340,8 +5274,8 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # Cap 1524 -> 1536, exact.
     # fix(#1847): +5. BulkDeleteResultItem gained an optional `code`, so a
     # per-item conflict is machine-readable with the same code the
-    # single-delete 409 carries. Cap 1536 -> 1541, exact.
-    "backend/app/modules/catalog/datasets/domain/schemas.py": 1541,
+    # single-delete 409 carries. Cap 1536 -> 1540, exact.
+    "backend/app/modules/catalog/datasets/domain/schemas.py": 1540,
     # --- entered by the inclusion rule, feat(#953/#954/#955/#956) ----------
     # tasks.py crossed 1000 for the first time here because the four operations
     # are deliberately concentrated rather than spread: it grows by one branch
@@ -6142,11 +6076,7 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # is never raised, an empty page proves nothing, and a keyset page can
     # prove only the rows in hand. That reasoning is most of the added lines.
     # Cap 1507 -> 1541, exact.
-    # fix(#1847): +65 for the (datasets, records) lock order, then -37 when the
-    # acquisition moved to app/platform/catalog_locks.py, which `processing/`
-    # can reach and this module is not. What stays is the catalog-side entry
-    # point, the extent read, and the opt-in raster child for a caller whose
-    # record delete cascades to it. Cap 1541 -> 1560, exact.
+    # fix(#1847): the lock order, its gate and its 409 mapping. Cap 1560, exact.
     "backend/app/modules/catalog/features/service.py": 1560,
 }
 

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1522,10 +1522,10 @@ def test_decomposed_service_modules_stay_within_size_budgets() -> None:
         # fix(#1778 round 1): +3 - the layer block is fenced by the shared
         # helper instead of interpolating the marker tags here, so a layer id
         # or a serialized filter cannot forge a closing tag either.
-        # Cap 488 -> 502, exact.
+        # Cap 513 -> 516, exact.
         # fix(#1778 round 3): +3 - safe_rows re-exported through the facade
         # alongside _safe_value, per the module's import contract.
-        # Cap 483 -> 497, exact.
+        # Cap 516 -> 519, exact.
         "backend/app/processing/ai/chat_service.py": 519,
         # fix(#836): defaults.py is the facade over the extensions-defaults
         # split (defaults_*.py sub-modules discovered below). Pure re-exports —
@@ -4444,7 +4444,7 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # from, and health compares what-is against what-was-built-from. Postgres
     # cannot stamp commit time from inside a transaction, so no clock scheme
     # could express "committed after my snapshot" — three rounds of timestamp
-    # fixes each left a window. Cap 1128 -> 1132, exact.
+    # fixes each left a window. Cap 1118 -> 1140, exact.
     # feat(#1267): +10 — the dataset's last_refreshed_at is stamped at the
     # generation's own completed_at instant, in the same transaction as the
     # generation swap, so source_freshness (#1224) reads a live signal for a
@@ -5474,7 +5474,7 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # concurrent uploads reap each other's key correctly instead of racing on
     # a stale read. Most of the growth is the docstring explaining why the
     # lock has to move rather than just gaining a shorter timeout of its own.
-    # Cap 1541 -> 1550, exact.
+    # Cap 1554 -> 1572, exact.
     "backend/app/modules/catalog/maps/router.py": 1572,
     # fix(#474): thread negotiated languages through catalog search, cache keys,
     # and OGC record serialization; fix(#475) adds Records array-query handling,

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1522,10 +1522,10 @@ def test_decomposed_service_modules_stay_within_size_budgets() -> None:
         # fix(#1778 round 1): +3 - the layer block is fenced by the shared
         # helper instead of interpolating the marker tags here, so a layer id
         # or a serialized filter cannot forge a closing tag either.
-        # Cap 513 -> 516, exact.
+        # Cap 488 -> 502, exact.
         # fix(#1778 round 3): +3 - safe_rows re-exported through the facade
         # alongside _safe_value, per the module's import contract.
-        # Cap 516 -> 519, exact.
+        # Cap 483 -> 497, exact.
         "backend/app/processing/ai/chat_service.py": 519,
         # fix(#836): defaults.py is the facade over the extensions-defaults
         # split (defaults_*.py sub-modules discovered below). Pure re-exports —
@@ -1868,20 +1868,11 @@ def test_decomposed_service_modules_stay_within_size_budgets() -> None:
         # which invented a delta the size of whichever side was known. The
         # case that reaches it is a service preview whose collection size the
         # service never published.
-        # fix(#1847 review r2): +10. `update_user_metadata` writes record
-        # fields and dataset fields and flushes them together, so it has to
-        # take the (datasets, records) pair in the house order first. Codex
-        # round 2 on #1864 found this by reading; the gate in
-        # tests/test_feature_lock_order_1847.py now finds the next one.
-        # Cap 488 -> 498, exact.
-        # fix(#1847 review r3, audit P2-4): +18. The acquisition is now taken
-        # only when the request body can reach the datasets row. A body that
-        # touches record fields alone writes one row, and a one-row write has
-        # no order to get wrong, so locking for it added contention to the
-        # most-used metadata endpoint against a cycle it cannot join. The lines
-        # are `_DATASET_ROW_FIELDS` and why `is_dem` is not in it.
-        # Cap 498 -> 516, exact.
-        "backend/app/modules/catalog/datasets/domain/service_metadata.py": 516,
+        # fix(#1847): +28. `update_user_metadata` writes record fields and
+        # dataset fields and flushes them together, so it takes the pair first
+        # -- and only when the body can reach the datasets row.
+        # Cap 488 -> 502, exact.
+        "backend/app/modules/catalog/datasets/domain/service_metadata.py": 502,
         # fix(#435 codex r1): +6 LOC in get_dataset_rows to probe schema existence
         # before degrading a 42P01 to an empty page. Postgres reports a missing
         # tenant data schema with the same code as a raster dataset's synthetic
@@ -1951,22 +1942,10 @@ def test_decomposed_service_modules_stay_within_size_budgets() -> None:
         # the retirement set (whose whole API is set membership), with the
         # reasoning for the split and for the belt-and-braces oid guard.
         # Cap 451 -> 483, exact.
-        # fix(#1847 review r2): +8. `delete_dataset` deletes the records row
-        # and the datasets row follows by FK CASCADE, so the database takes the
-        # pair records-first. Acquire in the house order first.
-        # Cap 483 -> 491, exact.
-        # fix(#1847 review r3): +16. The acquisition moved AHEAD of
-        # `_reap_managed_storage` in both branches, because that reap deletes
-        # objects permanently and a lock timeout after it rolled the
-        # transaction back with the objects gone and the catalog row intact.
-        # Most of the lines are the note on why it sits ahead of the reap and
-        # behind the DROP. Cap 491 -> 507, exact.
-        # fix(#1847 review r3, audit P2-3): +12 recording that the Valkey tile
-        # purge runs with the pair held and stays that way. Row locks are held
-        # to commit, so the only way out is after the caller's commit, which
-        # would undo the one-placement-serves-every-caller argument above. The
-        # comment states the bound instead. Cap 507 -> 519, exact.
-        "backend/app/modules/catalog/datasets/domain/service_lifecycle.py": 519,
+        # fix(#1847): +36. `delete_dataset` acquires ahead of the storage reap,
+        # which deletes objects permanently, and behind the DROP. The Valkey
+        # purge stays under the lock, with its bound. Cap 483 -> 497, exact.
+        "backend/app/modules/catalog/datasets/domain/service_lifecycle.py": 497,
         # Phase 276 CODE-02: chat_*.py sub-modules are all under the 350
         # default (largest is chat_actions.py at ~245 LOC). No explicit
         # per-file overrides needed; default applies.
@@ -2982,7 +2961,9 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # row was answered 409, 503 and 400 depending on which route reached the
     # acquisition; the helper now raises one domain exception and this is the
     # single place that maps it. The lines are the handler plus why it lives
-    # here rather than in four route bodies. Cap 1903 -> 1935, exact.    "backend/app/api/main.py": 1935,
+    # here rather than in four route bodies. Cap 1903 -> 1935, exact.    # fix(#1847): +32 for one exception handler. A contended catalog row was
+    # answered 409, 503 and 400 depending on the route; the helper raises one
+    # domain exception and this maps it. Cap 1903 -> 1928, exact.    "backend/app/api/main.py": 1935,
     # fix(#1005): +4 — MapSummaryResponse gains thumbnail_updated_at, the
     # thumbnail cache version split out of updated_at. Ratchet stays exact.
     # fix(#910): +1 on top of that, the fillColorSaved entry in the authoritative
@@ -3604,7 +3585,9 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # deadlock against a request or a refresh holding the dataset row. The
     # lines are the acquisition plus why it passes `lock_timeout=None` (SET
     # LOCAL would clamp the rest of an ingest transaction to a request's
-    # budget). Cap 2559 -> 2579, exact.    "backend/app/processing/ingest/tasks_common.py": 2581,
+    # budget). Cap 2559 -> 2579, exact.    # fix(#1847): +28. `_apply_reupload_swap` writes both catalog rows and
+    # acquired nothing, and `bump_tile_cache_version_atomic`'s note had to stop
+    # saying the feature routers never lock. Cap 2551 -> 2571, exact.    "backend/app/processing/ingest/tasks_common.py": 2581,
     # --- entered by the inclusion rule, feat(#1219 x #1222) ---------------
     # tasks_reupload crossed 1000 when two independently-reviewed features
     # met in one file: #1222's failed-contact bookkeeping (spawn-armed
@@ -4484,7 +4467,7 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # from, and health compares what-is against what-was-built-from. Postgres
     # cannot stamp commit time from inside a transaction, so no clock scheme
     # could express "committed after my snapshot" — three rounds of timestamp
-    # fixes each left a window. Cap 1118 -> 1140, exact.
+    # fixes each left a window. Cap 1128 -> 1132, exact.
     # feat(#1267): +10 — the dataset's last_refreshed_at is stamped at the
     # generation's own completed_at instant, in the same transaction as the
     # generation swap, so source_freshness (#1224) reads a live signal for a
@@ -4580,7 +4563,9 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # explicit. The asset SELECT joins Dataset under a plain FOR UPDATE, so the
     # row was already locked -- incidentally, as a property of the join, with
     # nothing saying so before the writes to dataset.record below.
-    # Cap 1628 -> 1647, exact.    "backend/app/processing/ingest/tasks_vrt.py": 1647,
+    # Cap 1628 -> 1647, exact.    # fix(#1847): +19 making the publish transaction's datasets lock explicit.
+    # The asset SELECT locks that row through its join, incidentally, with
+    # nothing saying so before the record writes. Cap 1628 -> 1641, exact.    "backend/app/processing/ingest/tasks_vrt.py": 1647,
     # fix(#1202 review r5): +29 — sweep the presigned staging key at job end.
     # A completed presigned job points file_path at its frozen copy, so this
     # reaper never touched the key the client's PUT URL can still recreate.
@@ -5151,7 +5136,8 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # than an incidental choice, and pointing at the docstring that states the
     # order. The feature-edit path used to take the records row first, which
     # made an ordinary edit during this phase an ABBA deadlock.
-    # Cap 1128 -> 1140, exact.    "backend/app/processing/ingest/tasks_postgis_refresh.py": 1140,
+    # Cap 1128 -> 1140, exact.    # fix(#1847): +12 recording that the phase 3 `FOR UPDATE` is the first half
+    # of the house (datasets, records) order. Cap 1128 -> 1132, exact.    "backend/app/processing/ingest/tasks_postgis_refresh.py": 1140,
     # --- entered by the inclusion rule, feat(#765) -------------------------
     # First time this module crosses 1000. main sat at 994, six lines under the
     # gate, so it was going to fire on whoever added next; it fired here.
@@ -5516,7 +5502,7 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # concurrent uploads reap each other's key correctly instead of racing on
     # a stale read. Most of the growth is the docstring explaining why the
     # lock has to move rather than just gaining a shorter timeout of its own.
-    # Cap 1554 -> 1572, exact.
+    # Cap 1541 -> 1550, exact.
     "backend/app/modules/catalog/maps/router.py": 1572,
     # fix(#474): thread negotiated languages through catalog search, cache keys,
     # and OGC record serialization; fix(#475) adds Records array-query handling,
@@ -6117,28 +6103,11 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # is never raised, an empty page proves nothing, and a keyset page can
     # prove only the rows in hand. That reasoning is most of the added lines.
     # Cap 1507 -> 1541, exact.
-    # fix(#1847): +57 for the (datasets, records) lock order. The metadata
-    # refresh took the records row first while `refresh_postgis` phase 3 takes
-    # the datasets row first, so a feature edit during a refresh was an ABBA
-    # deadlock that surfaced as a 503 with the edit lost. Six of the added
-    # lines are the reordered acquisition, the `lock_timeout` and the
-    # `no_autoflush` that keeps the ORM from re-inverting the order at flush
-    # time; the rest is the docstring every other site now cites for the order,
-    # and the note on why the COUNT(*)/ST_Extent aggregate has to stay inside
-    # the lock rather than being hoisted above it. Cap 1541 -> 1598, exact.
-    # fix(#1847 review r1): +11 more. The acquisition became a public helper
-    # the write router calls directly, because a request does not have to
-    # recompute anything to need the pair: a property-only PATCH stamps
-    # `record.updated_by` and rolls `tile_cache_version`, which dirties both
-    # rows. The added lines are that contract stated in the docstring, so the
-    # next caller knows the helper is for any write and not only for the
-    # metadata refresh. Cap 1598 -> 1609, exact.
-    # fix(#1847 review r2): -37. The acquisition itself moved to
-    # app/platform/catalog_locks.py, where `processing/` can reach it too --
-    # that layer may not import app.modules.catalog, and the reupload doors
-    # needed the same order. What stays here is the catalog-side entry point
-    # and the extent read. Cap 1609 -> 1572, exact.
-    "backend/app/modules/catalog/features/service.py": 1572,
+    # fix(#1847): +65 for the (datasets, records) lock order, then -37 when the
+    # acquisition moved to app/platform/catalog_locks.py, which `processing/`
+    # can reach and this module is not. What stays is the catalog-side entry
+    # point and the extent read. Cap 1541 -> 1550, exact.
+    "backend/app/modules/catalog/features/service.py": 1550,
 }
 
 

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1869,9 +1869,9 @@ def test_decomposed_service_modules_stay_within_size_budgets() -> None:
         # which invented a delta the size of whichever side was known. The
         # case that reaches it is a service preview whose collection size the
         # service never published.
-        # fix(#1847): the lock order, its gate and its 409 mapping. Cap 507, exact.
-        # fix(#1847): +12. sample_example_values reads the data table on its own so
-        # the reset can sample before it takes the pair. Cap 507 -> 519, exact.
+        # fix(#1847): +31. `sample_example_values` reads the data table on its
+        # own and `reset_attribute` takes the sample as an argument, so the
+        # reset samples before it takes the pair. Cap 488 -> 519, exact.
         "backend/app/modules/catalog/datasets/domain/service_metadata.py": 519,
         # fix(#435 codex r1): +6 LOC in get_dataset_rows to probe schema existence
         # before degrading a 42P01 to an empty page. Postgres reports a missing
@@ -3569,7 +3569,8 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # bodies differed only in the task name in their docstrings.
     # Cap 2551 -> 2581, exact.
     # fix(#1847): the lock order, its gate and its 409 mapping. Cap 2601, exact.
-    "backend/app/processing/ingest/tasks_common.py": 2601,
+    # fix(#1847): the cache-bump docstring states its contract. Cap 2601 -> 2596.
+    "backend/app/processing/ingest/tasks_common.py": 2596,
     # --- entered by the inclusion rule, feat(#1219 x #1222) ---------------
     # tasks_reupload crossed 1000 when two independently-reviewed features
     # met in one file: #1222's failed-contact bookkeeping (spawn-armed

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1874,7 +1874,14 @@ def test_decomposed_service_modules_stay_within_size_budgets() -> None:
         # round 2 on #1864 found this by reading; the gate in
         # tests/test_feature_lock_order_1847.py now finds the next one.
         # Cap 488 -> 498, exact.
-        "backend/app/modules/catalog/datasets/domain/service_metadata.py": 498,
+        # fix(#1847 review r3, audit P2-4): +18. The acquisition is now taken
+        # only when the request body can reach the datasets row. A body that
+        # touches record fields alone writes one row, and a one-row write has
+        # no order to get wrong, so locking for it added contention to the
+        # most-used metadata endpoint against a cycle it cannot join. The lines
+        # are `_DATASET_ROW_FIELDS` and why `is_dem` is not in it.
+        # Cap 498 -> 516, exact.
+        "backend/app/modules/catalog/datasets/domain/service_metadata.py": 516,
         # fix(#435 codex r1): +6 LOC in get_dataset_rows to probe schema existence
         # before degrading a 42P01 to an empty page. Postgres reports a missing
         # tenant data schema with the same code as a raster dataset's synthetic
@@ -1954,7 +1961,12 @@ def test_decomposed_service_modules_stay_within_size_budgets() -> None:
         # transaction back with the objects gone and the catalog row intact.
         # Most of the lines are the note on why it sits ahead of the reap and
         # behind the DROP. Cap 491 -> 507, exact.
-        "backend/app/modules/catalog/datasets/domain/service_lifecycle.py": 507,
+        # fix(#1847 review r3, audit P2-3): +12 recording that the Valkey tile
+        # purge runs with the pair held and stays that way. Row locks are held
+        # to commit, so the only way out is after the caller's commit, which
+        # would undo the one-placement-serves-every-caller argument above. The
+        # comment states the bound instead. Cap 507 -> 519, exact.
+        "backend/app/modules/catalog/datasets/domain/service_lifecycle.py": 519,
         # Phase 276 CODE-02: chat_*.py sub-modules are all under the 350
         # default (largest is chat_actions.py at ~245 LOC). No explicit
         # per-file overrides needed; default applies.

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1491,7 +1491,8 @@ def test_decomposed_service_modules_stay_within_size_budgets() -> None:
     facade_line_budgets = {
         "backend/app/modules/catalog/maps/service.py": 100,
         "backend/app/modules/catalog/search/service.py": 80,
-        "backend/app/modules/catalog/datasets/domain/service.py": 110,
+        # fix(#1847): +2, sample_example_values re-exported. Cap 110 -> 112, exact.
+        "backend/app/modules/catalog/datasets/domain/service.py": 112,
         # Phase 276 CODE-02 — chat_service.py is now a facade re-exporting
         # from chat_*.py sub-modules. 400 was the established Phase-226 cap
         # for facade modules that retain a meaty orchestrator + system-prompt
@@ -1869,7 +1870,9 @@ def test_decomposed_service_modules_stay_within_size_budgets() -> None:
         # case that reaches it is a service preview whose collection size the
         # service never published.
         # fix(#1847): the lock order, its gate and its 409 mapping. Cap 507, exact.
-        "backend/app/modules/catalog/datasets/domain/service_metadata.py": 507,
+        # fix(#1847): +12. sample_example_values reads the data table on its own so
+        # the reset can sample before it takes the pair. Cap 507 -> 519, exact.
+        "backend/app/modules/catalog/datasets/domain/service_metadata.py": 519,
         # fix(#435 codex r1): +6 LOC in get_dataset_rows to probe schema existence
         # before degrading a 42P01 to an empty page. Postgres reports a missing
         # tenant data schema with the same code as a raster dataset's synthetic

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -2963,7 +2963,8 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # single place that maps it. The lines are the handler plus why it lives
     # here rather than in four route bodies. Cap 1903 -> 1935, exact.    # fix(#1847): +32 for one exception handler. A contended catalog row was
     # answered 409, 503 and 400 depending on the route; the helper raises one
-    # domain exception and this maps it. Cap 1903 -> 1928, exact.    "backend/app/api/main.py": 1935,
+    # domain exception and this maps it. Cap 1903 -> 1928, exact.    # domain exception and this maps it, with a machine-readable code now that
+    # it is the only shape a contended row produces. Cap 1903 -> 1930, exact.    "backend/app/api/main.py": 1935,
     # fix(#1005): +4 — MapSummaryResponse gains thumbnail_updated_at, the
     # thumbnail cache version split out of updated_at. Ratchet stays exact.
     # fix(#910): +1 on top of that, the fillColorSaved entry in the authoritative

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1948,7 +1948,13 @@ def test_decomposed_service_modules_stay_within_size_budgets() -> None:
         # and the datasets row follows by FK CASCADE, so the database takes the
         # pair records-first. Acquire in the house order first.
         # Cap 483 -> 491, exact.
-        "backend/app/modules/catalog/datasets/domain/service_lifecycle.py": 491,
+        # fix(#1847 review r3): +16. The acquisition moved AHEAD of
+        # `_reap_managed_storage` in both branches, because that reap deletes
+        # objects permanently and a lock timeout after it rolled the
+        # transaction back with the objects gone and the catalog row intact.
+        # Most of the lines are the note on why it sits ahead of the reap and
+        # behind the DROP. Cap 491 -> 507, exact.
+        "backend/app/modules/catalog/datasets/domain/service_lifecycle.py": 507,
         # Phase 276 CODE-02: chat_*.py sub-modules are all under the 350
         # default (largest is chat_actions.py at ~245 LOC). No explicit
         # per-file overrides needed; default applies.
@@ -2960,8 +2966,11 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # fix(#1856 item 2): +9 for the conformance list in the API description.
     # It claimed the OAS 3.0 classes while the served document is OpenAPI 3.1,
     # and named three of the five families /api/conformance advertises. Cap
-    # 1903 -> 1912, exact.
-    "backend/app/api/main.py": 1912,
+    # 1903 -> 1912, exact.    # fix(#1847 review r3): +32 for one exception handler. A contended catalog
+    # row was answered 409, 503 and 400 depending on which route reached the
+    # acquisition; the helper now raises one domain exception and this is the
+    # single place that maps it. The lines are the handler plus why it lives
+    # here rather than in four route bodies. Cap 1903 -> 1935, exact.    "backend/app/api/main.py": 1935,
     # fix(#1005): +4 — MapSummaryResponse gains thumbnail_updated_at, the
     # thumbnail cache version split out of updated_at. Ratchet stays exact.
     # fix(#910): +1 on top of that, the fillColorSaved entry in the authoritative

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1868,11 +1868,12 @@ def test_decomposed_service_modules_stay_within_size_budgets() -> None:
         # which invented a delta the size of whichever side was known. The
         # case that reaches it is a service preview whose collection size the
         # service never published.
-        # fix(#1847): +28. `update_user_metadata` writes record fields and
-        # dataset fields and flushes them together, so it takes the pair first
-        # -- and only when the body can reach the datasets row.
-        # Cap 488 -> 502, exact.
-        "backend/app/modules/catalog/datasets/domain/service_metadata.py": 502,
+        # fix(#1847): +33. `update_user_metadata` writes record fields and
+        # dataset fields and flushes them together, so it takes the pair first,
+        # and only when the body can reach the datasets row. `is_dem` extends
+        # the order to `raster_assets`, the row the replace worker takes first.
+        # Cap 488 -> 507, exact.
+        "backend/app/modules/catalog/datasets/domain/service_metadata.py": 507,
         # fix(#435 codex r1): +6 LOC in get_dataset_rows to probe schema existence
         # before degrading a 42P01 to an empty page. Postgres reports a missing
         # tenant data schema with the same code as a raster dataset's synthetic

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -2964,7 +2964,9 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # here rather than in four route bodies. Cap 1903 -> 1935, exact.    # fix(#1847): +32 for one exception handler. A contended catalog row was
     # answered 409, 503 and 400 depending on the route; the helper raises one
     # domain exception and this maps it. Cap 1903 -> 1928, exact.    # domain exception and this maps it, with a machine-readable code now that
-    # it is the only shape a contended row produces. Cap 1903 -> 1930, exact.    "backend/app/api/main.py": 1935,
+    # it is the only shape a contended row produces. Cap 1903 -> 1930, exact.    # domain exception and this maps it, with a machine-readable code now that
+    # it is the only shape a contended row produces, from one shared constant.
+    # Cap 1903 -> 1933, exact.    "backend/app/api/main.py": 1935,
     # fix(#1005): +4 — MapSummaryResponse gains thumbnail_updated_at, the
     # thumbnail cache version split out of updated_at. Ratchet stays exact.
     # fix(#910): +1 on top of that, the fillColorSaved entry in the authoritative
@@ -5303,7 +5305,10 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # than a second spelling of the vocabulary, plus the description telling a
     # client author what the field buys and that omitting it is supported.
     # Cap 1524 -> 1536, exact.
-    "backend/app/modules/catalog/datasets/domain/schemas.py": 1536,
+    # fix(#1847): +5. BulkDeleteResultItem gained an optional `code`, so a
+    # per-item conflict is machine-readable with the same code the
+    # single-delete 409 carries. Cap 1536 -> 1541, exact.
+    "backend/app/modules/catalog/datasets/domain/schemas.py": 1541,
     # --- entered by the inclusion rule, feat(#953/#954/#955/#956) ----------
     # tasks.py crossed 1000 for the first time here because the four operations
     # are deliberately concentrated rather than spread: it grows by one branch

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1868,7 +1868,13 @@ def test_decomposed_service_modules_stay_within_size_budgets() -> None:
         # which invented a delta the size of whichever side was known. The
         # case that reaches it is a service preview whose collection size the
         # service never published.
-        "backend/app/modules/catalog/datasets/domain/service_metadata.py": 488,
+        # fix(#1847 review r2): +10. `update_user_metadata` writes record
+        # fields and dataset fields and flushes them together, so it has to
+        # take the (datasets, records) pair in the house order first. Codex
+        # round 2 on #1864 found this by reading; the gate in
+        # tests/test_feature_lock_order_1847.py now finds the next one.
+        # Cap 488 -> 498, exact.
+        "backend/app/modules/catalog/datasets/domain/service_metadata.py": 498,
         # fix(#435 codex r1): +6 LOC in get_dataset_rows to probe schema existence
         # before degrading a 42P01 to an empty page. Postgres reports a missing
         # tenant data schema with the same code as a raster dataset's synthetic
@@ -1938,7 +1944,11 @@ def test_decomposed_service_modules_stay_within_size_budgets() -> None:
         # the retirement set (whose whole API is set membership), with the
         # reasoning for the split and for the belt-and-braces oid guard.
         # Cap 451 -> 483, exact.
-        "backend/app/modules/catalog/datasets/domain/service_lifecycle.py": 483,
+        # fix(#1847 review r2): +8. `delete_dataset` deletes the records row
+        # and the datasets row follows by FK CASCADE, so the database takes the
+        # pair records-first. Acquire in the house order first.
+        # Cap 483 -> 491, exact.
+        "backend/app/modules/catalog/datasets/domain/service_lifecycle.py": 491,
         # Phase 276 CODE-02: chat_*.py sub-modules are all under the 350
         # default (largest is chat_actions.py at ~245 LOC). No explicit
         # per-file overrides needed; default applies.
@@ -3567,7 +3577,13 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # fix(#1847 review r1): +3. Every feature-write handler now locks, so the
     # note had to stop saying "not on every path" and give the real reason the
     # atomic helper is still needed: those handlers read the counter BEFORE
-    # they take the lock. Cap 2556 -> 2559, exact.    "backend/app/processing/ingest/tasks_common.py": 2581,
+    # they take the lock. Cap 2556 -> 2559, exact.    # they take the lock. Cap 2556 -> 2559, exact.
+    # fix(#1847 review r2): +20. `_apply_reupload_swap` writes both catalog
+    # rows and acquired nothing, so its flush took them records-first and could
+    # deadlock against a request or a refresh holding the dataset row. The
+    # lines are the acquisition plus why it passes `lock_timeout=None` (SET
+    # LOCAL would clamp the rest of an ingest transaction to a request's
+    # budget). Cap 2559 -> 2579, exact.    "backend/app/processing/ingest/tasks_common.py": 2581,
     # --- entered by the inclusion rule, feat(#1219 x #1222) ---------------
     # tasks_reupload crossed 1000 when two independently-reviewed features
     # met in one file: #1222's failed-contact bookkeeping (spawn-armed
@@ -4539,8 +4555,11 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # 1600 -> 1628, exact.
     # fix(#1755 item 11): +12. Both task tails route every cleanup step
     # through `cleanup_step`: three in `ingest_vrt`, four in `regenerate_vrt`,
-    # which stops two heartbeats. Cap 1628 -> 1640, exact.
-    "backend/app/processing/ingest/tasks_vrt.py": 1640,
+    # which stops two heartbeats. Cap 1628 -> 1640, exact.    # fix(#1847 review r2): +19 making the publish transaction's datasets lock
+    # explicit. The asset SELECT joins Dataset under a plain FOR UPDATE, so the
+    # row was already locked -- incidentally, as a property of the join, with
+    # nothing saying so before the writes to dataset.record below.
+    # Cap 1628 -> 1647, exact.    "backend/app/processing/ingest/tasks_vrt.py": 1647,
     # fix(#1202 review r5): +29 — sweep the presigned staging key at job end.
     # A completed presigned job points file_path at its frozen copy, so this
     # reaper never touched the key the client's PUT URL can still recreate.
@@ -6093,7 +6112,12 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # rows. The added lines are that contract stated in the docstring, so the
     # next caller knows the helper is for any write and not only for the
     # metadata refresh. Cap 1598 -> 1609, exact.
-    "backend/app/modules/catalog/features/service.py": 1609,
+    # fix(#1847 review r2): -37. The acquisition itself moved to
+    # app/platform/catalog_locks.py, where `processing/` can reach it too --
+    # that layer may not import app.modules.catalog, and the reupload doors
+    # needed the same order. What stays here is the catalog-side entry point
+    # and the extent read. Cap 1609 -> 1572, exact.
+    "backend/app/modules/catalog/features/service.py": 1572,
 }
 
 

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1944,8 +1944,10 @@ def test_decomposed_service_modules_stay_within_size_budgets() -> None:
         # Cap 451 -> 483, exact.
         # fix(#1847): +36. `delete_dataset` acquires ahead of the storage reap,
         # which deletes objects permanently, and behind the DROP. The Valkey
-        # purge stays under the lock, with its bound. Cap 483 -> 497, exact.
-        "backend/app/modules/catalog/datasets/domain/service_lifecycle.py": 497,
+        # purge stays under the lock, with its bound. The acquisition includes
+        # the raster child, whose row the replace worker holds across its
+        # upload. Cap 483 -> 498, exact.
+        "backend/app/modules/catalog/datasets/domain/service_lifecycle.py": 498,
         # Phase 276 CODE-02: chat_*.py sub-modules are all under the 350
         # default (largest is chat_actions.py at ~245 LOC). No explicit
         # per-file overrides needed; default applies.
@@ -2966,7 +2968,11 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # domain exception and this maps it. Cap 1903 -> 1928, exact.    # domain exception and this maps it, with a machine-readable code now that
     # it is the only shape a contended row produces. Cap 1903 -> 1930, exact.    # domain exception and this maps it, with a machine-readable code now that
     # it is the only shape a contended row produces, from one shared constant.
-    # Cap 1903 -> 1933, exact.    "backend/app/api/main.py": 1935,
+    # Cap 1903 -> 1933, exact.    # domain exception and this maps it, with a machine-readable code now that
+    # it is the only shape a contended row produces, from one shared constant,
+    # and answered at the boundary too: SET LOCAL lock_timeout outlives the
+    # acquisition, so a later wait in the same request raises 55P03 from a
+    # statement no per-site translation wraps. Cap 1903 -> 1952, exact.    "backend/app/api/main.py": 1952,
     # fix(#1005): +4 — MapSummaryResponse gains thumbnail_updated_at, the
     # thumbnail cache version split out of updated_at. Ratchet stays exact.
     # fix(#910): +1 on top of that, the fillColorSaved entry in the authoritative
@@ -6112,8 +6118,9 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # fix(#1847): +65 for the (datasets, records) lock order, then -37 when the
     # acquisition moved to app/platform/catalog_locks.py, which `processing/`
     # can reach and this module is not. What stays is the catalog-side entry
-    # point and the extent read. Cap 1541 -> 1550, exact.
-    "backend/app/modules/catalog/features/service.py": 1550,
+    # point, the extent read, and the opt-in raster child for a caller whose
+    # record delete cascades to it. Cap 1541 -> 1560, exact.
+    "backend/app/modules/catalog/features/service.py": 1560,
 }
 
 

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1942,8 +1942,9 @@ def test_decomposed_service_modules_stay_within_size_budgets() -> None:
         # the retirement set (whose whole API is set membership), with the
         # reasoning for the split and for the belt-and-braces oid guard.
         # Cap 451 -> 483, exact.
-        # fix(#1847): the lock order, its gate and its 409 mapping. Cap 512, exact.
-        "backend/app/modules/catalog/datasets/domain/service_lifecycle.py": 512,
+        # fix(#1847): the lock order, its gate and its 409 mapping, and the
+        # job rows ahead of the cascade. Cap 513, exact.
+        "backend/app/modules/catalog/datasets/domain/service_lifecycle.py": 513,
         # Phase 276 CODE-02: chat_*.py sub-modules are all under the 350
         # default (largest is chat_actions.py at ~245 LOC). No explicit
         # per-file overrides needed; default applies.

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1947,8 +1947,10 @@ def test_decomposed_service_modules_stay_within_size_budgets() -> None:
         # which deletes objects permanently, and behind the DROP. The Valkey
         # purge stays under the lock, with its bound. The acquisition includes
         # the raster child, whose row the replace worker holds across its
-        # upload. Cap 483 -> 498, exact.
-        "backend/app/modules/catalog/datasets/domain/service_lifecycle.py": 498,
+        # upload. The storage reap moved OUT to the callers, past their
+        # commit, because the record delete's FK cascades reach child rows
+        # nobody locks. Cap 483 -> 512, exact.
+        "backend/app/modules/catalog/datasets/domain/service_lifecycle.py": 512,
         # Phase 276 CODE-02: chat_*.py sub-modules are all under the 350
         # default (largest is chat_actions.py at ~245 LOC). No explicit
         # per-file overrides needed; default applies.
@@ -2973,7 +2975,8 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # it is the only shape a contended row produces, from one shared constant,
     # and answered at the boundary too: SET LOCAL lock_timeout outlives the
     # acquisition, so a later wait in the same request raises 55P03 from a
-    # statement no per-site translation wraps. Cap 1903 -> 1952, exact.    "backend/app/api/main.py": 1952,
+    # statement no per-site translation wraps. Cap 1903 -> 1952, exact.    # statement no per-site translation wraps, gated on this request having
+    # installed that timeout. Cap 1903 -> 1954, exact.    "backend/app/api/main.py": 1954,
     # fix(#1005): +4 — MapSummaryResponse gains thumbnail_updated_at, the
     # thumbnail cache version split out of updated_at. Ratchet stays exact.
     # fix(#910): +1 on top of that, the fillColorSaved entry in the authoritative

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -3563,7 +3563,11 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # It said the feature-edit routers "never lock the row", which stopped
     # being true when their metadata refresh started taking the datasets row
     # FOR UPDATE. The helper's conclusion is unchanged, its reason is not.
-    # Cap 2551 -> 2556, exact.    "backend/app/processing/ingest/tasks_common.py": 2581,
+    # Cap 2551 -> 2556, exact.    # Cap 2551 -> 2556, exact.
+    # fix(#1847 review r1): +3. Every feature-write handler now locks, so the
+    # note had to stop saying "not on every path" and give the real reason the
+    # atomic helper is still needed: those handlers read the counter BEFORE
+    # they take the lock. Cap 2556 -> 2559, exact.    "backend/app/processing/ingest/tasks_common.py": 2581,
     # --- entered by the inclusion rule, feat(#1219 x #1222) ---------------
     # tasks_reupload crossed 1000 when two independently-reviewed features
     # met in one file: #1222's failed-contact bookkeeping (spawn-armed
@@ -6082,7 +6086,14 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # time; the rest is the docstring every other site now cites for the order,
     # and the note on why the COUNT(*)/ST_Extent aggregate has to stay inside
     # the lock rather than being hoisted above it. Cap 1541 -> 1598, exact.
-    "backend/app/modules/catalog/features/service.py": 1598,
+    # fix(#1847 review r1): +11 more. The acquisition became a public helper
+    # the write router calls directly, because a request does not have to
+    # recompute anything to need the pair: a property-only PATCH stamps
+    # `record.updated_by` and rolls `tile_cache_version`, which dirties both
+    # rows. The added lines are that contract stated in the docstring, so the
+    # next caller knows the helper is for any write and not only for the
+    # metadata refresh. Cap 1598 -> 1609, exact.
+    "backend/app/modules/catalog/features/service.py": 1609,
 }
 
 

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -2469,7 +2469,8 @@ _OPEN_CORE_SIZE_CAPS: dict[str, int] = {
 #     body on a GET is the defect being fixed.
 #   api/main.py 1499 -> 1558. fix(#1518 codex P2): +59 for
 #     `_document_unresolvable_credential_401`, which publishes the 401 that
-#     #1518 made normal runtime behaviour on every credential-aware anonymous
+#
+# 1518 made normal runtime behaviour on every credential-aware anonymous
 #     operation. Most of it is the docstring explaining why it targets all
 #     THREE optional dependencies while `_normalize_security_contract` targets
 #     two: a 401 RESPONSE is not a security REQUIREMENT, so the no-security-
@@ -2962,21 +2963,29 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # fix(#1856 item 2): +9 for the conformance list in the API description.
     # It claimed the OAS 3.0 classes while the served document is OpenAPI 3.1,
     # and named three of the five families /api/conformance advertises. Cap
-    # 1903 -> 1912, exact.    # fix(#1847 review r3): +32 for one exception handler. A contended catalog
+    # 1903 -> 1912, exact.
+    # fix(#1847 review r3): +32 for one exception handler. A contended catalog
     # row was answered 409, 503 and 400 depending on which route reached the
     # acquisition; the helper now raises one domain exception and this is the
     # single place that maps it. The lines are the handler plus why it lives
-    # here rather than in four route bodies. Cap 1903 -> 1935, exact.    # fix(#1847): +32 for one exception handler. A contended catalog row was
+    # here rather than in four route bodies. Cap 1903 -> 1935, exact.
+    # fix(#1847): +32 for one exception handler. A contended catalog row was
     # answered 409, 503 and 400 depending on the route; the helper raises one
-    # domain exception and this maps it. Cap 1903 -> 1928, exact.    # domain exception and this maps it, with a machine-readable code now that
-    # it is the only shape a contended row produces. Cap 1903 -> 1930, exact.    # domain exception and this maps it, with a machine-readable code now that
+    # domain exception and this maps it. Cap 1903 -> 1928, exact.
+    # domain exception and this maps it, with a machine-readable code now that
+    # it is the only shape a contended row produces. Cap 1903 -> 1930, exact.
+    # domain exception and this maps it, with a machine-readable code now that
     # it is the only shape a contended row produces, from one shared constant.
-    # Cap 1903 -> 1933, exact.    # domain exception and this maps it, with a machine-readable code now that
+    # Cap 1903 -> 1933, exact.
+    # domain exception and this maps it, with a machine-readable code now that
     # it is the only shape a contended row produces, from one shared constant,
     # and answered at the boundary too: SET LOCAL lock_timeout outlives the
     # acquisition, so a later wait in the same request raises 55P03 from a
-    # statement no per-site translation wraps. Cap 1903 -> 1952, exact.    # statement no per-site translation wraps, gated on this request having
-    # installed that timeout. Cap 1903 -> 1954, exact.    "backend/app/api/main.py": 1954,
+    # statement no per-site translation wraps. Cap 1903 -> 1952, exact.
+    # statement no per-site translation wraps, gated on this request having
+    # installed that timeout. Cap 1903 -> 1954, exact.
+    # fix(#1847 rebase): re-measured on top of main. Cap 1963, exact.
+    "backend/app/api/main.py": 1963,
     # fix(#1005): +4 — MapSummaryResponse gains thumbnail_updated_at, the
     # thumbnail cache version split out of updated_at. Ratchet stays exact.
     # fix(#910): +1 on top of that, the fillColorSaved entry in the authoritative
@@ -3584,23 +3593,29 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # `CancelledError` a worker shutdown delivers. It replaces two private
     # copies that had grown in tasks_vector.py and tasks_reupload.py, whose
     # bodies differed only in the task name in their docstrings.
-    # Cap 2551 -> 2581, exact.    # fix(#1847): +5 correcting `bump_tile_cache_version_atomic`'s docstring.
+    # Cap 2551 -> 2581, exact.
+    # fix(#1847): +5 correcting `bump_tile_cache_version_atomic`'s docstring.
     # It said the feature-edit routers "never lock the row", which stopped
     # being true when their metadata refresh started taking the datasets row
     # FOR UPDATE. The helper's conclusion is unchanged, its reason is not.
-    # Cap 2551 -> 2556, exact.    # Cap 2551 -> 2556, exact.
+    # Cap 2551 -> 2556, exact.
+    # Cap 2551 -> 2556, exact.
     # fix(#1847 review r1): +3. Every feature-write handler now locks, so the
     # note had to stop saying "not on every path" and give the real reason the
     # atomic helper is still needed: those handlers read the counter BEFORE
-    # they take the lock. Cap 2556 -> 2559, exact.    # they take the lock. Cap 2556 -> 2559, exact.
+    # they take the lock. Cap 2556 -> 2559, exact.
+    # they take the lock. Cap 2556 -> 2559, exact.
     # fix(#1847 review r2): +20. `_apply_reupload_swap` writes both catalog
     # rows and acquired nothing, so its flush took them records-first and could
     # deadlock against a request or a refresh holding the dataset row. The
     # lines are the acquisition plus why it passes `lock_timeout=None` (SET
     # LOCAL would clamp the rest of an ingest transaction to a request's
-    # budget). Cap 2559 -> 2579, exact.    # fix(#1847): +28. `_apply_reupload_swap` writes both catalog rows and
+    # budget). Cap 2559 -> 2579, exact.
+    # fix(#1847): +28. `_apply_reupload_swap` writes both catalog rows and
     # acquired nothing, and `bump_tile_cache_version_atomic`'s note had to stop
-    # saying the feature routers never lock. Cap 2551 -> 2571, exact.    "backend/app/processing/ingest/tasks_common.py": 2581,
+    # saying the feature routers never lock. Cap 2551 -> 2571, exact.
+    # fix(#1847 rebase): re-measured on top of main. Cap 2601, exact.
+    "backend/app/processing/ingest/tasks_common.py": 2601,
     # --- entered by the inclusion rule, feat(#1219 x #1222) ---------------
     # tasks_reupload crossed 1000 when two independently-reviewed features
     # met in one file: #1222's failed-contact bookkeeping (spawn-armed
@@ -4572,13 +4587,17 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # 1600 -> 1628, exact.
     # fix(#1755 item 11): +12. Both task tails route every cleanup step
     # through `cleanup_step`: three in `ingest_vrt`, four in `regenerate_vrt`,
-    # which stops two heartbeats. Cap 1628 -> 1640, exact.    # fix(#1847 review r2): +19 making the publish transaction's datasets lock
+    # which stops two heartbeats. Cap 1628 -> 1640, exact.
+    # fix(#1847 review r2): +19 making the publish transaction's datasets lock
     # explicit. The asset SELECT joins Dataset under a plain FOR UPDATE, so the
     # row was already locked -- incidentally, as a property of the join, with
     # nothing saying so before the writes to dataset.record below.
-    # Cap 1628 -> 1647, exact.    # fix(#1847): +19 making the publish transaction's datasets lock explicit.
+    # Cap 1628 -> 1647, exact.
+    # fix(#1847): +19 making the publish transaction's datasets lock explicit.
     # The asset SELECT locks that row through its join, incidentally, with
-    # nothing saying so before the record writes. Cap 1628 -> 1641, exact.    "backend/app/processing/ingest/tasks_vrt.py": 1647,
+    # nothing saying so before the record writes. Cap 1628 -> 1641, exact.
+    # fix(#1847 rebase): re-measured on top of main. Cap 1653, exact.
+    "backend/app/processing/ingest/tasks_vrt.py": 1653,
     # fix(#1202 review r5): +29 — sweep the presigned staging key at job end.
     # A completed presigned job points file_path at its frozen copy, so this
     # reaper never touched the key the client's PUT URL can still recreate.
@@ -5144,13 +5163,17 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # issue fell back to a sequential scan. Cap 1104 -> 1128, exact.
     # fix(#1755 item 11): +2. The `finally` block's heartbeat stop routes
     # through `cleanup_step`, so a failure in it logs instead of replacing the
-    # refresh exception being propagated. Cap 1128 -> 1130, exact.    # fix(#1847): +12 comment lines on the phase 3 `FOR UPDATE`, recording that
+    # refresh exception being propagated. Cap 1128 -> 1130, exact.
+    # fix(#1847): +12 comment lines on the phase 3 `FOR UPDATE`, recording that
     # it is the first half of the house (datasets, records) lock order rather
     # than an incidental choice, and pointing at the docstring that states the
     # order. The feature-edit path used to take the records row first, which
     # made an ordinary edit during this phase an ABBA deadlock.
-    # Cap 1128 -> 1140, exact.    # fix(#1847): +12 recording that the phase 3 `FOR UPDATE` is the first half
-    # of the house (datasets, records) order. Cap 1128 -> 1132, exact.    "backend/app/processing/ingest/tasks_postgis_refresh.py": 1140,
+    # Cap 1128 -> 1140, exact.
+    # fix(#1847): +12 recording that the phase 3 `FOR UPDATE` is the first half
+    # of the house (datasets, records) order. Cap 1128 -> 1132, exact.
+    # fix(#1847 rebase): re-measured on top of main. Cap 1134, exact.
+    "backend/app/processing/ingest/tasks_postgis_refresh.py": 1134,
     # --- entered by the inclusion rule, feat(#765) -------------------------
     # First time this module crosses 1000. main sat at 994, six lines under the
     # gate, so it was going to fire on whoever added next; it fired here.

--- a/backend/tests/test_raster_ingest.py
+++ b/backend/tests/test_raster_ingest.py
@@ -612,11 +612,8 @@ class TestRasterDeleteCascadeRemovesStorage:
             from app.modules.catalog.datasets.domain.service import delete_dataset
 
             # fix(#1847): the reap is the CALLER's, after its commit, so a
-            # failing storage provider cannot be reached from here at all.
-            # This used to raise, and the raise was the guarantee that no DB
-            # change outlived a storage failure. The guarantee is now the other
-            # way round: the rows go first, and a failed reap orphans objects
-            # rather than restoring a dataset whose bytes are gone.
+            # failing provider is unreachable here. The guarantee is inverted:
+            # a failed reap orphans objects rather than restoring a dataset.
             result = await delete_dataset(session, dataset_id, "My Raster")
 
         assert result.storage_prefixes, "the caller is told what to reap"

--- a/backend/tests/test_raster_ingest.py
+++ b/backend/tests/test_raster_ingest.py
@@ -471,6 +471,9 @@ class _MockDataset:
         self.source_format = source_format
         self.origin_ref = None
         self.record = _MockRecord(title, record_type)
+        # fix(#1847): delete_dataset takes the (datasets, records) pair before
+        # it reaps storage, and the acquisition reads this.
+        self.record_id = uuid.uuid4()
 
 
 class _MockStorage:

--- a/backend/tests/test_raster_ingest.py
+++ b/backend/tests/test_raster_ingest.py
@@ -552,10 +552,20 @@ class TestRasterDeleteCascadeRemovesStorage:
 
             result = await delete_dataset(session, dataset_id, "My Raster")
 
-        assert result == "test_table"
+        assert result.table_name == "test_table"
 
         # All raster and original keys must be deleted
         expected_deleted = set(raster_keys + original_keys)
+        # fix(#1847): the reap is the caller's, after its commit. Run it here
+        # with what delete_dataset returned, so this still covers which objects
+        # go, in the shape the endpoints now use.
+        from app.modules.catalog.datasets.domain.service import reap_managed_storage
+
+        with mock.patch(
+            "app.platform.storage.provider.get_storage", return_value=storage
+        ):
+            await reap_managed_storage(list(result.storage_prefixes), result.tenant_id)
+
         assert set(storage.deleted_keys) == expected_deleted
 
         # No DROP TABLE should have been executed
@@ -601,11 +611,19 @@ class TestRasterDeleteCascadeRemovesStorage:
         ):
             from app.modules.catalog.datasets.domain.service import delete_dataset
 
-            with pytest.raises(RuntimeError, match="Storage delete failed"):
-                await delete_dataset(session, dataset_id, "My Raster")
+            # fix(#1847): the reap is the CALLER's, after its commit, so a
+            # failing storage provider cannot be reached from here at all.
+            # This used to raise, and the raise was the guarantee that no DB
+            # change outlived a storage failure. The guarantee is now the other
+            # way round: the rows go first, and a failed reap orphans objects
+            # rather than restoring a dataset whose bytes are gone.
+            result = await delete_dataset(session, dataset_id, "My Raster")
 
-        # DB delete must NOT have been called
-        session.delete.assert_not_called()
+        assert result.storage_prefixes, "the caller is told what to reap"
+        assert storage.deleted_keys == [], (
+            "delete_dataset touched storage; the reap belongs after the commit"
+        )
+        session.delete.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_vector_delete_still_drops_table(self):
@@ -664,13 +682,23 @@ class TestRasterDeleteCascadeRemovesStorage:
 
             result = await delete_dataset(session, dataset_id, "My Vector")
 
-        assert result == "test_table"
+        assert result.table_name == "test_table"
 
         drop_calls = [s for s in executed_sqls if "DROP TABLE" in s.upper()]
         assert len(drop_calls) == 1, f"Expected exactly 1 DROP TABLE, got: {drop_calls}"
         assert "test_table" in drop_calls[0]
 
         # fix(#430 BA-17): both managed-storage prefixes reaped
+        # fix(#1847): the reap is the caller's, after its commit. Run it here
+        # with what delete_dataset returned, so this still covers which objects
+        # go, in the shape the endpoints now use.
+        from app.modules.catalog.datasets.domain.service import reap_managed_storage
+
+        with mock.patch(
+            "app.platform.storage.provider.get_storage", return_value=storage
+        ):
+            await reap_managed_storage(list(result.storage_prefixes), result.tenant_id)
+
         assert set(storage.deleted_keys) == set(original_keys + vector_keys)
 
         session.delete.assert_called_once_with(mock_dataset.record)

--- a/backend/tests/test_reupload_swap_lock_retry.py
+++ b/backend/tests/test_reupload_swap_lock_retry.py
@@ -97,6 +97,35 @@ def _make_dataset_stub(table_name: str):
     return dataset
 
 
+def _make_port():
+    """The ProcessingPort surface ``_apply_reupload_swap`` actually reaches for.
+
+    fix(#1847 review r3): the swap takes the (datasets, records) pair before it
+    writes either row, and it resolves both mapped classes through the port
+    because ``processing/`` may not import ``app.modules.catalog``. A stub that
+    offers only ``get_dataset_version_orm_class`` therefore AttributeErrors on
+    a code path this file exists to exercise. The real classes are safe here:
+    the stub dataset carries ids no row has, so each ``FOR UPDATE`` locks
+    nothing and returns no rows.
+    """
+    from app.modules.catalog.datasets.domain.models import Dataset, Record
+
+    class _Port:
+        @staticmethod
+        def get_dataset_version_orm_class():
+            return lambda **kwargs: types.SimpleNamespace(**kwargs)
+
+        @staticmethod
+        def get_dataset_orm_class():
+            return Dataset
+
+        @staticmethod
+        def get_record_orm_class():
+            return Record
+
+    return _Port
+
+
 def _minimal_metadata():
     return {
         "srid": 4326,
@@ -105,6 +134,176 @@ def _minimal_metadata():
         "extent_wkt": None,
         "column_info": [{"name": "name", "type": "character varying"}],
     }
+
+
+class _WriteRecorder:
+    """A stub that appends to a shared trace the first time each field is set."""
+
+    def __init__(self, trace, label, **fields):
+        object.__setattr__(self, "_trace", trace)
+        object.__setattr__(self, "_label", label)
+        object.__setattr__(self, "_armed", False)
+        for name, value in fields.items():
+            object.__setattr__(self, name, value)
+
+    def arm(self):
+        object.__setattr__(self, "_armed", True)
+
+    def __setattr__(self, name, value):
+        if self._armed:
+            self._trace.append(("write", f"{self._label}.{name}"))
+        object.__setattr__(self, name, value)
+
+
+class TestSwapLocksBeforeItWrites:
+    """fix(#1847 review r3): the acquisition has to PRECEDE the first row write.
+
+    The mirror below drives the real swap against the real session and records
+    two things on one timeline: the SQL the session emits, and the moment an
+    attribute of the dataset or its record is first assigned. An acquisition
+    that lands after the writes is the round-1 defect again, and a count-based
+    assertion would not see it -- both orderings execute the same statements.
+    """
+
+    @pytest.fixture(autouse=True)
+    async def setup_tables(self, test_db_session):
+        self.session = test_db_session
+        suffix = uuid.uuid4().hex[:8]
+        self.live = f"swap_ord_{suffix}"
+        self.staging = f"swap_ords_{suffix}"
+        for tn in (self.live, self.staging, f"{self.live}_old"):
+            await self.session.execute(
+                text(f'DROP TABLE IF EXISTS data."{tn}" CASCADE')
+            )
+        await self.session.commit()
+        for tn in (self.live, self.staging):
+            await self.session.execute(
+                text(
+                    f'CREATE TABLE data."{tn}" '
+                    "(id serial PRIMARY KEY, name text, geom geometry(Point, 4326))"
+                )
+            )
+            await self.session.execute(
+                text(f"INSERT INTO data.\"{tn}\" (name) VALUES ('row')")
+            )
+        await self.session.commit()
+        yield
+        for tn in (self.live, self.staging, f"{self.live}_old"):
+            await self.session.execute(
+                text(f'DROP TABLE IF EXISTS data."{tn}" CASCADE')
+            )
+        await self.session.commit()
+
+    async def test_the_pair_is_locked_before_any_field_is_assigned(
+        self, monkeypatch
+    ) -> None:
+        trace: list[tuple[str, str]] = []
+
+        record = _WriteRecorder(
+            trace,
+            "record",
+            spatial_extent=None,
+            updated_by=None,
+            record_type="vector_dataset",
+        )
+        dataset = _WriteRecorder(
+            trace,
+            "dataset",
+            id=uuid.uuid4(),
+            record=record,
+            record_id=uuid.uuid4(),
+            table_name=self.live,
+            current_version=1,
+            tile_cache_version=1,
+            srid=4326,
+            geometry_type="Point",
+            feature_count=1,
+            column_info=[{"name": "name", "type": "character varying"}],
+            sample_values={},
+            source_format="csv",
+            source_filename="orig.csv",
+            original_srid=4326,
+            source_url=None,
+            quality_detail=None,
+        )
+        object.__setattr__(
+            dataset,
+            "bump_tile_cache_version",
+            lambda: setattr(dataset, "tile_cache_version", 2),
+        )
+
+        async def _noop(*args, **kwargs):
+            return None
+
+        async def _noop_quality(*args, **kwargs):
+            return {"score": 0.0, "issues": []}
+
+        monkeypatch.setattr(
+            "app.processing.ingest.metadata.refresh_attribute_metadata", _noop
+        )
+        monkeypatch.setattr(
+            "app.processing.ingest.metadata.compute_quality_score", _noop_quality
+        )
+        monkeypatch.setattr("app.modules.audit.service.audit_emit", _noop)
+        monkeypatch.setattr("app.platform.extensions.get_processing_port", _make_port)
+        monkeypatch.setattr(self.session, "add", lambda *a, **kw: None)
+
+        real_execute = self.session.execute
+
+        async def _recording_execute(statement, *args, **kwargs):
+            trace.append(("sql", str(statement)))
+            return await real_execute(statement, *args, **kwargs)
+
+        monkeypatch.setattr(self.session, "execute", _recording_execute)
+
+        record.arm()
+        dataset.arm()
+        await _apply_reupload_swap(
+            self.session,
+            dataset=dataset,
+            staging_table=self.staging,
+            metadata=_minimal_metadata(),
+            sample_values={},
+            user_id=str(uuid.uuid4()),
+            source_filename="x.csv",
+            source_format="csv",
+            original_srid=4326,
+        )
+
+        lock_at = next(
+            (
+                i
+                for i, (kind, payload) in enumerate(trace)
+                if kind == "sql"
+                and "FOR UPDATE" in payload.upper()
+                and "datasets" in payload
+            ),
+            None,
+        )
+        assert lock_at is not None, (
+            "the swap never took catalog.datasets FOR UPDATE. Its flush writes "
+            "both catalog rows, and the ORM emits records before datasets, so "
+            f"without the acquisition the order is inverted. trace={trace}"
+        )
+        first_write = next(
+            (i for i, (kind, _p) in enumerate(trace) if kind == "write"), None
+        )
+        assert first_write is not None, "the swap wrote no fields at all"
+        assert lock_at < first_write, (
+            "the swap assigned "
+            f"{trace[first_write][1]} before taking the pair. The acquisition "
+            "has to precede the first write to either row, not merely happen "
+            "somewhere in the same transaction."
+        )
+        # And in the house order: datasets, then records.
+        records_lock_at = next(
+            i
+            for i, (kind, payload) in enumerate(trace)
+            if kind == "sql"
+            and "FOR UPDATE" in payload.upper()
+            and "records" in payload
+        )
+        assert lock_at < records_lock_at
 
 
 class TestApplyReuploadSwapRetry:
@@ -181,14 +380,9 @@ class TestApplyReuploadSwapRetry:
         )
 
         # Stub the DatasetVersion ORM so `session.add(...)` is a no-op.
-        class _Port:
-            @staticmethod
-            def get_dataset_version_orm_class():
-                return lambda **kwargs: types.SimpleNamespace(**kwargs)
-
         monkeypatch.setattr(
             "app.platform.extensions.get_processing_port",
-            lambda: _Port,
+            _make_port,
         )
         # ``session.add`` rejects unknown types; swap to a recording shim.
         monkeypatch.setattr(self.session, "add", lambda *a, **kw: None)
@@ -279,14 +473,9 @@ class TestApplyReuploadSwapRetry:
             _noop_audit,
         )
 
-        class _Port:
-            @staticmethod
-            def get_dataset_version_orm_class():
-                return lambda **kwargs: types.SimpleNamespace(**kwargs)
-
         monkeypatch.setattr(
             "app.platform.extensions.get_processing_port",
-            lambda: _Port,
+            _make_port,
         )
         monkeypatch.setattr(self.session, "add", lambda *a, **kw: None)
 
@@ -339,14 +528,9 @@ class TestApplyReuploadSwapRetry:
             _noop_audit,
         )
 
-        class _Port:
-            @staticmethod
-            def get_dataset_version_orm_class():
-                return lambda **kwargs: types.SimpleNamespace(**kwargs)
-
         monkeypatch.setattr(
             "app.platform.extensions.get_processing_port",
-            lambda: _Port,
+            _make_port,
         )
         monkeypatch.setattr(self.session, "add", lambda *a, **kw: None)
 

--- a/backend/tests/test_reupload_swap_lock_retry.py
+++ b/backend/tests/test_reupload_swap_lock_retry.py
@@ -100,7 +100,7 @@ def _make_dataset_stub(table_name: str):
 def _make_port():
     """The ProcessingPort surface ``_apply_reupload_swap`` actually reaches for.
 
-    fix(#1847 review r3): the swap takes the (datasets, records) pair before it
+    fix(#1847): the swap takes the (datasets, records) pair before it
     writes either row, and it resolves both mapped classes through the port
     because ``processing/`` may not import ``app.modules.catalog``. A stub that
     offers only ``get_dataset_version_orm_class`` therefore AttributeErrors on
@@ -156,13 +156,11 @@ class _WriteRecorder:
 
 
 class TestSwapLocksBeforeItWrites:
-    """fix(#1847 review r3): the acquisition has to PRECEDE the first row write.
+    """The acquisition has to PRECEDE the first row write.
 
-    The mirror below drives the real swap against the real session and records
-    two things on one timeline: the SQL the session emits, and the moment an
-    attribute of the dataset or its record is first assigned. An acquisition
-    that lands after the writes is the round-1 defect again, and a count-based
-    assertion would not see it -- both orderings execute the same statements.
+    Drives the real swap against the real session and records two things on one
+    timeline: the SQL emitted, and the moment a field is first assigned. A
+    count-based assertion cannot separate the two orderings.
     """
 
     @pytest.fixture(autouse=True)

--- a/backend/tests/test_reupload_swap_lock_retry.py
+++ b/backend/tests/test_reupload_swap_lock_retry.py
@@ -100,13 +100,10 @@ def _make_dataset_stub(table_name: str):
 def _make_port():
     """The ProcessingPort surface ``_apply_reupload_swap`` actually reaches for.
 
-    fix(#1847): the swap takes the (datasets, records) pair before it
-    writes either row, and it resolves both mapped classes through the port
-    because ``processing/`` may not import ``app.modules.catalog``. A stub that
-    offers only ``get_dataset_version_orm_class`` therefore AttributeErrors on
-    a code path this file exists to exercise. The real classes are safe here:
-    the stub dataset carries ids no row has, so each ``FOR UPDATE`` locks
-    nothing and returns no rows.
+    The swap resolves both mapped classes through the port, so a stub offering
+    only ``get_dataset_version_orm_class`` AttributeErrors. The real classes
+    are safe: the stub dataset carries ids no row has, so each ``FOR UPDATE``
+    locks nothing.
     """
     from app.modules.catalog.datasets.domain.models import Dataset, Record
 

--- a/backend/tests/test_vrt_delete_guard_174.py
+++ b/backend/tests/test_vrt_delete_guard_174.py
@@ -27,7 +27,7 @@ from app.modules.catalog.datasets.domain.service import DependentVrtError
 # delete_dataset's retired-name write (#1443) into an un-awaited coroutine
 # that records nothing and raises a RuntimeWarning at garbage-collection.
 #
-# fix(#1847 review r3): and every one of them needs ``execute`` to return a
+# fix(#1847): and every one of them needs ``execute`` to return a
 # result object rather than a coroutine. delete_dataset now takes the
 # (datasets, records) pair before it reaps storage, and that acquisition
 # reads the stored extent. On a bare AsyncMock, ``result.first()`` is a

--- a/backend/tests/test_vrt_delete_guard_174.py
+++ b/backend/tests/test_vrt_delete_guard_174.py
@@ -29,12 +29,9 @@ from app.modules.catalog.datasets.domain.service import DependentVrtError
 # delete_dataset's retired-name write (#1443) into an un-awaited coroutine
 # that records nothing and raises a RuntimeWarning at garbage-collection.
 #
-# fix(#1847): and every one of them needs ``execute`` to return a
-# result object rather than a coroutine. delete_dataset now takes the
-# (datasets, records) pair before it reaps storage, and that acquisition
-# reads the stored extent. On a bare AsyncMock, ``result.first()`` is a
-# coroutine and subscripting it raises TypeError. ``_mock_session()``
-# below is the one place that shape is defined.
+# fix(#1847): each also needs ``execute`` to return a result object, not a
+# coroutine: the acquisition reads the stored extent, and on a bare AsyncMock
+# ``result.first()`` is a coroutine. ``_mock_session()`` defines that shape.
 
 
 def _mock_session() -> AsyncMock:

--- a/backend/tests/test_vrt_delete_guard_174.py
+++ b/backend/tests/test_vrt_delete_guard_174.py
@@ -26,6 +26,30 @@ from app.modules.catalog.datasets.domain.service import DependentVrtError
 # ``AsyncSession.add`` is synchronous, so an un-overridden AsyncMock turns
 # delete_dataset's retired-name write (#1443) into an un-awaited coroutine
 # that records nothing and raises a RuntimeWarning at garbage-collection.
+#
+# fix(#1847 review r3): and every one of them needs ``execute`` to return a
+# result object rather than a coroutine. delete_dataset now takes the
+# (datasets, records) pair before it reaps storage, and that acquisition
+# reads the stored extent. On a bare AsyncMock, ``result.first()`` is a
+# coroutine and subscripting it raises TypeError. ``_mock_session()``
+# below is the one place that shape is defined.
+
+
+def _mock_session() -> AsyncMock:
+    """An AsyncSession stand-in shaped for delete_dataset's real statements.
+
+    ``first()`` returns None, which reads as "this record has no stored
+    extent" -- the branch these tests do not care about, and the one that
+    keeps the lock acquisition from needing a fabricated geometry row.
+    """
+    result = MagicMock()
+    result.first = MagicMock(return_value=None)
+    result.scalar = MagicMock(return_value=None)
+    session = AsyncMock()
+    session.add = MagicMock()
+    session.delete = AsyncMock()
+    session.execute = AsyncMock(return_value=result)
+    return session
 
 
 def _make_mock_dataset(record_type: str, title: str = "Test Dataset") -> MagicMock:
@@ -333,9 +357,7 @@ class TestVrtDeletion:
         mock_storage.list = AsyncMock(side_effect=fake_list)
         mock_storage.delete = AsyncMock()
 
-        mock_session = AsyncMock()
-        mock_session.add = MagicMock()
-        mock_session.delete = AsyncMock()
+        mock_session = _mock_session()
 
         with patch(
             "app.modules.catalog.datasets.domain.service.get_dataset",
@@ -374,9 +396,7 @@ class TestVrtDeletion:
         mock_storage = AsyncMock()
         mock_storage.list = AsyncMock(return_value=[physical_key])
         mock_storage.delete = AsyncMock()
-        mock_session = AsyncMock()
-        mock_session.add = MagicMock()
-        mock_session.delete = AsyncMock()
+        mock_session = _mock_session()
 
         token = current_tenant_var.set(tenant_id)
         try:
@@ -472,9 +492,7 @@ class TestVrtDeletion:
         mock_storage.list = AsyncMock(side_effect=fake_list)
         mock_storage.delete = AsyncMock()
 
-        mock_session = AsyncMock()
-        mock_session.add = MagicMock()
-        mock_session.delete = AsyncMock()
+        mock_session = _mock_session()
 
         with patch(
             "app.modules.catalog.datasets.domain.service.get_dataset",
@@ -503,9 +521,7 @@ class TestVrtDeletion:
         mock_storage.list = AsyncMock(return_value=[])
         mock_storage.delete = AsyncMock()
 
-        mock_session = AsyncMock()
-        mock_session.add = MagicMock()
-        mock_session.delete = AsyncMock()
+        mock_session = _mock_session()
 
         with patch(
             "app.modules.catalog.datasets.domain.service.get_dataset",

--- a/backend/tests/test_vrt_delete_guard_174.py
+++ b/backend/tests/test_vrt_delete_guard_174.py
@@ -13,6 +13,8 @@ branch is SQL a mocked session cannot exercise.
 import uuid
 from unittest.mock import AsyncMock, MagicMock, patch
 
+from app.modules.catalog.datasets.domain.service import reap_managed_storage
+
 import pytest
 
 from app.modules.catalog.datasets.domain.service import DependentVrtError
@@ -109,7 +111,11 @@ class TestDeleteGuard:
             AsyncMock(return_value=mock_dataset),
         ):
             with pytest.raises(DependentVrtError) as exc_info:
-                await delete_dataset(mock_session, dataset_id, "My COG")
+                _deletion = await delete_dataset(mock_session, dataset_id, "My COG")
+                # fix(#1847): the reap is the caller's, after its commit.
+                await reap_managed_storage(
+                    list(_deletion.storage_prefixes), _deletion.tenant_id
+                )
 
         err = exc_info.value
         assert len(err.dependents) == 1
@@ -147,7 +153,7 @@ class TestDeleteGuard:
                     mock_session, dataset_id, "Standalone COG"
                 )
 
-        assert result == "test_table"
+        assert result.table_name == "test_table"
         mock_session.delete.assert_called_once_with(mock_dataset.record)
 
     @pytest.mark.asyncio
@@ -180,7 +186,11 @@ class TestDeleteGuard:
             AsyncMock(return_value=mock_dataset),
         ):
             with pytest.raises(DependentVrtError) as exc_info:
-                await delete_dataset(mock_session, dataset_id, "Shared COG")
+                _deletion = await delete_dataset(mock_session, dataset_id, "Shared COG")
+                # fix(#1847): the reap is the caller's, after its commit.
+                await reap_managed_storage(
+                    list(_deletion.storage_prefixes), _deletion.tenant_id
+                )
 
         err = exc_info.value
         assert len(err.dependents) == 3
@@ -323,7 +333,13 @@ async def test_delete_dataset_fails_closed_without_multi_tenant_context(monkeypa
             AsyncMock(return_value=mock_dataset),
         ):
             with pytest.raises(RuntimeError, match="missing tenant context"):
-                await delete_dataset(mock_session, dataset_id, "Tenant vector")
+                _deletion = await delete_dataset(
+                    mock_session, dataset_id, "Tenant vector"
+                )
+                # fix(#1847): the reap is the caller's, after its commit.
+                await reap_managed_storage(
+                    list(_deletion.storage_prefixes), _deletion.tenant_id
+                )
     finally:
         current_tenant_var.reset(token)
 
@@ -367,8 +383,12 @@ class TestVrtDeletion:
                 "app.platform.storage.provider.get_storage", return_value=mock_storage
             ):
                 result = await delete_dataset(mock_session, dataset_id, "My VRT")
+                # fix(#1847): the reap is the caller's, after its commit.
+                await reap_managed_storage(
+                    list(result.storage_prefixes), result.tenant_id
+                )
 
-        assert result == "test_table"
+        assert result.table_name == "test_table"
 
         # Should list rasters/ prefix
         list_calls = [c.args[0] for c in mock_storage.list.call_args_list]
@@ -408,7 +428,11 @@ class TestVrtDeletion:
                     "app.platform.storage.provider.get_storage",
                     return_value=mock_storage,
                 ):
-                    await delete_dataset(mock_session, dataset_id, "My VRT")
+                    _deletion = await delete_dataset(mock_session, dataset_id, "My VRT")
+                    # fix(#1847): the reap is the caller's, after its commit.
+                    await reap_managed_storage(
+                        list(_deletion.storage_prefixes), _deletion.tenant_id
+                    )
         finally:
             current_tenant_var.reset(token)
 
@@ -455,7 +479,11 @@ class TestVrtDeletion:
             with patch(
                 "app.platform.storage.provider.get_storage", return_value=mock_storage
             ):
-                await delete_dataset(mock_session, dataset_id, "My COG")
+                _deletion = await delete_dataset(mock_session, dataset_id, "My COG")
+                # fix(#1847): the reap is the caller's, after its commit.
+                await reap_managed_storage(
+                    list(_deletion.storage_prefixes), _deletion.tenant_id
+                )
 
         list_calls = [c.args[0] for c in mock_storage.list.call_args_list]
         assert f"rasters/{dataset_id}/" in list_calls
@@ -501,7 +529,11 @@ class TestVrtDeletion:
             with patch(
                 "app.platform.storage.provider.get_storage", return_value=mock_storage
             ):
-                await delete_dataset(mock_session, vrt_id, "My VRT")
+                _deletion = await delete_dataset(mock_session, vrt_id, "My VRT")
+                # fix(#1847): the reap is the caller's, after its commit.
+                await reap_managed_storage(
+                    list(_deletion.storage_prefixes), _deletion.tenant_id
+                )
 
         # Source COG key should never be deleted
         delete_calls = [c.args[0] for c in mock_storage.delete.call_args_list]
@@ -530,7 +562,11 @@ class TestVrtDeletion:
             with patch(
                 "app.platform.storage.provider.get_storage", return_value=mock_storage
             ):
-                await delete_dataset(mock_session, dataset_id, "My VRT")
+                _deletion = await delete_dataset(mock_session, dataset_id, "My VRT")
+                # fix(#1847): the reap is the caller's, after its commit.
+                await reap_managed_storage(
+                    list(_deletion.storage_prefixes), _deletion.tenant_id
+                )
 
         # Verify record deletion is invoked (CASCADE handles vrt_source_links)
         mock_session.delete.assert_called_once_with(mock_dataset.record)

--- a/frontend/src/types/api.generated.ts
+++ b/frontend/src/types/api.generated.ts
@@ -6446,6 +6446,8 @@ export interface components {
             status: string;
             /** Detail */
             detail?: string | null;
+            /** Code */
+            code?: string | null;
         };
         /** BulkRegisterItem */
         BulkRegisterItem: {

--- a/sdks/python/geolens/models/bulk_delete_result_item.py
+++ b/sdks/python/geolens/models/bulk_delete_result_item.py
@@ -22,11 +22,13 @@ class BulkDeleteResultItem:
         dataset_id (UUID):
         status (str):
         detail (None | str | Unset):
+        code (None | str | Unset):
     """
 
     dataset_id: UUID
     status: str
     detail: None | str | Unset = UNSET
+    code: None | str | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -40,6 +42,12 @@ class BulkDeleteResultItem:
         else:
             detail = self.detail
 
+        code: None | str | Unset
+        if isinstance(self.code, Unset):
+            code = UNSET
+        else:
+            code = self.code
+
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
@@ -50,6 +58,8 @@ class BulkDeleteResultItem:
         )
         if detail is not UNSET:
             field_dict["detail"] = detail
+        if code is not UNSET:
+            field_dict["code"] = code
 
         return field_dict
 
@@ -69,10 +79,20 @@ class BulkDeleteResultItem:
 
         detail = _parse_detail(d.pop("detail", UNSET))
 
+        def _parse_code(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        code = _parse_code(d.pop("code", UNSET))
+
         bulk_delete_result_item = cls(
             dataset_id=dataset_id,
             status=status,
             detail=detail,
+            code=code,
         )
 
         bulk_delete_result_item.additional_properties = d

--- a/sdks/typescript/src/client/types.gen.ts
+++ b/sdks/typescript/src/client/types.gen.ts
@@ -1438,6 +1438,10 @@ export type BulkDeleteResultItem = {
      * Detail
      */
     detail?: string | null;
+    /**
+     * Code
+     */
+    code?: string | null;
 };
 
 /**


### PR DESCRIPTION
Backend codebase audit 2026-09-04, P1-1, tracked in #1847. Verified still
present on `cd9567fde` before any change.

## The defect

`_lock_stored_extent_box` (added by #1799) took `catalog.records` FOR UPDATE and
left `catalog.datasets` to the flush that follows. `refresh_postgis` phase 3
takes the datasets row FOR UPDATE first, then writes the record row inside that
same transaction. So the worker went datasets then records and a feature edit
went records then datasets, and a routine edit landing during a refresh was an
ABBA cycle. PostgreSQL aborted one side with 40P01 after `deadlock_timeout`.

The refresh call also sat after each write handler's `except DBAPIError` had
closed, so the abort escaped to the generic database error handler as a 503 and
the edit was lost with no message the caller could act on.

## What changed

The metadata refresh takes `catalog.datasets` FOR UPDATE first, then the records
row. The record lock is still taken and still precedes the extent read; only its
position moved. Both explicit background writers of this pair already led with
the datasets row (`refresh_postgis`, `refresh_stac`), and neither can be
reordered to follow the request path instead: each takes that lock to make a
superseded-content check and the write depending on it one indivisible step, so
it has to be the first thing the write transaction does. That makes datasets
first the order every site now cites, stated once in
`_lock_dataset_then_read_extent_box`.

`no_autoflush` wraps the acquisition. The ORM's own flush order is records
before datasets, because `Dataset.record_id` makes `Record` the parent mapper,
so an autoflush during either statement would re-invert the order this helper
exists to fix.

`SET LOCAL lock_timeout = '2s'` on that acquisition, the same budget
`platform/jobs/router.py` and `catalog/maps/service_crud.py` already spend on
the same question.

One `is_lock_conflict` in `app/core/db/sqlstate.py`, matching 55P03 and 40P01.
The feature router maps it to 409 ahead of `is_operational`, which would
otherwise report a deadlock victim as "database temporarily unavailable". 409 is
already declared on every write endpoint here through `ERROR_RESPONSES_WRITE`,
so no API surface is added.

The four write handlers call the refresh through one guarded helper, so the part
of the request that takes row locks is covered by the same classification as the
write above it.

## Deliberately not done

The `COUNT(*)` + `ST_Extent` aggregate stays inside the lock. The audit records
it as a second, unconditional cost, and hoisting it above the lock with a
cheap re-check afterwards would reinstate the interleaving #1778 review r1
closed: a peer that measures before taking the lock cannot see this
transaction's uncommitted row, and would then write a count and an extent
computed as though that row did not exist. Holding the lock across the scan is
what makes the loser re-decide against the extent the winner actually stored.
The bound on what that costs a waiter is the `lock_timeout`, not a shorter
critical section. The scan only runs when the incremental fast path declined,
which for the digitizing case #1778 added it for is the uncommon branch.

`processing/ingest/tasks_common.py`'s `_is_lock_timeout_error` keeps its own
55P03-only predicate. Retrying the re-upload swap DDL after a deadlock is a
different and unproven decision from retrying it after a lock timeout.

## Sibling callers routed through the shared predicate

`platform/jobs/router.py` is a rename with no policy change: same two states.

`catalog/maps/service_crud.py` widens from lock-timeout-only to include the
deadlock victim, so 40P01 there answers 409 instead of escaping as a 500. Its
#1778 round 8 docstring said it kept a local copy because the ingest predicate
sits behind CatalogPort and the platform one is private. `core/db/sqlstate.py`
is neither, which is why the copy could go now.

## Schema, API and config impact

None. No migration, no request or response schema change. `make openapi-check`
is clean, so no SDK regeneration.

## Verification

Run from the worktree against Postgres at localhost:5434.

```
uv run pytest tests/test_feature_lock_order_1847.py -q          11 passed
uv run pytest tests/test_features_incremental_metadata.py \
  tests/test_features_crud.py tests/test_layering.py \
  tests/test_rule1_structural.py tests/test_rule2_structural.py -q   229 passed
uv run pytest tests/test_postgis_refresh_1265.py \
  tests/test_stac_refresh_1266.py tests/test_dataset_rows_db_errors.py \
  tests/test_maps_asset_object_cleanup_1778.py \
  tests/test_job_cancel_endpoint.py tests/test_job_cancel_vrt.py -q   257 passed
uv run ruff check . && uv run ruff format --check .            passed
scripts/dump_openapi.py --check                                 exit 0
```

Counterfactual, actually run: with only the two acquisitions swapped back to the
pre-fix order and everything else held constant, three of the eleven new tests
fail, and the concurrency pair fails with a real
`asyncpg.exceptions.DeadlockDetectedError` rather than an assertion I wrote.

## Tests

The two DB-backed tests assert on lock state, never on elapsed time. The barrier
is `pg_stat_activity.wait_event_type`, so the test proceeds once the backend
under test is parked on a lock; whether it is holding the records row is then
settled by a third session's `FOR UPDATE NOWAIT`, which either raises 55P03 or
does not. The first test is the cycle in one assertion, since a request parked
on a lock must be holding nothing. The second drives both sides and requires
neither to be aborted.

Also pinned: the emitted SQL, so a reordering fails without needing a race; the
`lock_timeout` on the acquisition; both worker sites still leading with the
datasets row; 40P01 and 55P03 mapping to 409 while a real outage stays 503; and
all four write handlers going through the guarded refresh helper.

## Noticed and left alone

`refresh_postgis` phase 3 says feature writes are not blocked by the refresh
admission index. That is still true and still intended. This change does not
make a feature edit wait less; it makes it wait cleanly at one acquisition
instead of racing into a cycle, and bounds the wait.

The re-upload swap in `tasks_common.py` writes both rows with no explicit lock,
so its implicit order is the ORM's records-then-datasets. It is excluded from
this cycle by the ACCESS EXCLUSIVE lock it takes on the data table first, which
a mid-flight feature edit already holds a row lock against. Left as it is: it is
older than v1.17.0 and outside this finding.

## Module LOC caps raised

Each re-measured with `wc -l` and set to the exact figure, with the reason in
the entry.

| file | cap |
| --- | --- |
| `modules/catalog/features/service.py` | 1541 to 1598 |
| `processing/ingest/tasks_postgis_refresh.py` | 1128 to 1140 |
| `processing/ingest/tasks_common.py` | 2551 to 2556 |


---

## Review round 1

One P1: the fix covered three of the four write handlers, not four.

`patch_single_feature` refreshes metadata only when the body carries geometry.
A property-only PATCH skips that and still stamps `record.updated_by` and rolls
`tile_cache_version`, which dirties both rows, so the flush at `commit()` was
the transaction's first touch of either row and took them records-first. That
is the original inversion, on the one handler whose refresh is conditional, and
the abort landed at `commit()` outside every handler's classification, so it
answered 500 rather than 409.

Reproduced before fixing. With the acquisition absent, the request sits on an
ungranted `transactionid` lock behind the worker while holding `catalog.records`,
and driving the worker's record write into it raises a real
`asyncpg.exceptions.DeadlockDetectedError`.

The acquisition is now the public `lock_catalog_rows_for_write`, reached by the
metadata refresh and by the PATCH handler's else arm through the same guard, so
the two cannot drift into taking the pair in different orders. Its docstring
says it is for any write that dirties either row, not only for a recompute. The
router's classification moved into one `_guard`, so both entry points answer 409
on a conflict.

The other three handlers reach their refresh unconditionally, so none has the
same shortcut. A new AST gate holds that: every write handler must acquire on
every path, either unconditionally or in both arms of the `if` that holds it.
It fails when the else arm is removed.

Two DB-backed tests added for this path, matching the shape of the existing
pair. The first characterises the state in the middle and fails with a message
naming the cycle; the second drives both sides to completion so PostgreSQL
reports the cycle itself. Both set `record.updated_by` back to NULL first,
because the ORM emits the records UPDATE only when the assignment is a real
change, and the insert that seeds the feature had already stamped the same user.

`bump_tile_cache_version_atomic`'s note was corrected while renaming through it.
Every feature-write handler now locks, so "never lock the row" was wrong. The
helper is still needed for a sharper reason, now recorded: those handlers read
the counter off an instance loaded before the lock, and a lock taken after the
read does not make a read-modify-write atomic.

Gates re-run at `c8a0a1933`:

```
tests/test_feature_lock_order_1847.py                          14 passed
+ features_incremental_metadata, features_crud, layering,
  rule1_structural, rule2_structural                          243 passed
postgis/stac refresh, dataset_rows_db_errors, maps asset,
  job cancel endpoint and vrt                                 257 passed
ruff check and ruff format --check                             passed
scripts/dump_openapi.py --check                                exit 0
```

Caps re-measured and set to the exact figure: `features/service.py` 1598 to
1609, `tasks_common.py` 2556 to 2559.


---

## Review round 2

One P1, and it is the earlier rounds' fix seen from the other side.

Rounds 0 and 1 made the feature-write handlers take `catalog.datasets` before
`catalog.records`. That matches the two refresh workers and the VRT publish
transaction, but it is not the order a transaction gets by default. SQLAlchemy
flushes `catalog.records` first, because `Dataset.record_id` makes `Record` the
parent mapper. So every site that dirtied both rows and acquired nothing was now
inverted against the sites that had just been corrected.

`update_user_metadata` is the one codex named. Reproduced before fixing: a
metadata PATCH carrying a record field and `tile_columns`, overlapping a holder
of the dataset row, raises a real `asyncpg.exceptions.DeadlockDetectedError` at
its own `session.flush()` on `UPDATE catalog.datasets SET tile_columns`.

### Where the order lives now

`app/platform/catalog_locks.py`. It was in the feature service, which
`processing/` may not import, and the reupload doors need the same order. The
helper takes the two mapped classes as arguments: catalog callers pass their
own, worker callers pass what `ProcessingPort` hands them. Workers pass
`lock_timeout=None`, because `SET LOCAL` applies for the rest of the transaction
and clamping an ingest swap to a request's two seconds would fail it on
contention it is meant to wait out.

### Every site that writes both rows

Acquisition added at `update_user_metadata`, the four layers DDL services,
`delete_dataset` (its records DELETE cascades to datasets, so the database takes
the pair records-first), `_apply_reupload_swap`, the raster replace swap, and the
VRT publish transaction, whose datasets lock was real but incidental to its asset
join and is now stated. The two refresh workers keep their own datasets `FOR
UPDATE`, which is the superseded-content guard the order was chosen for.

Placement is after any data-table DDL and before the first catalog write. The
reupload swap takes ACCESS EXCLUSIVE on the data table ahead of its catalog rows,
so leading with the catalog rows in the layers handlers would invert against it.

### Why per-site and not a before_flush listener

A listener keyed on "both dirty in one flush" would not have fired on the path
fixed in round 1. Those handlers dirty `record.updated_by`, flush it inside
`audit_emit`, and only then roll the tile version, so the two writes reach the
database in different flushes. The acquisition has to precede the transaction's
first write to either row, which is a property of the call site rather than of
any one flush. A listener that fired on a dirty Record instead would be sound
but would take a dataset lock on every record-only edit, which is a global
contention change I am not making in a point release.

### The gate

It now walks all of `backend/app` instead of one router, and propagates writes
through the call graph: `update_user_metadata` assigns `record.updated_by` itself
but reaches `dataset.tile_columns` only through a helper, so a per-body scan
missed exactly the site codex reported. Creation paths carry exemptions with
reasons, a positive control asserts the scan still sees the known writers so the
gate cannot pass vacuously, and a third test fails if an exemption names a
function that no longer exists.

### Verification at `cb02ceeaf`

```
tests/test_feature_lock_order_1847.py                            18 passed
+ metadata_roundtrip, tile_columns_metadata, layers, lifecycle,
  publication_lifecycle, layering                     120 passed, 4 skipped
reupload, reupload contract, record_type_guard,
  raster_replace, vrt_lifecycle, regenerate_vrt                 236 passed
features_crud, features_incremental_metadata, rule1, rule2,
  postgis_refresh, stac_refresh, analysis_preview                406 passed
ruff check and ruff format --check                                 passed
scripts/dump_openapi.py --check                                    exit 0
```

Counterfactual, actually run: removing the acquisition from
`update_user_metadata` fails the new overlap test and the class gate, and driving
the interleaving past the diagnostic assertion raises the deadlock quoted above.

### Caps, all re-measured

| file | cap |
| --- | --- |
| `features/service.py` | 1609 to 1572, it shrank when the acquisition moved out |
| `datasets/domain/service_metadata.py` | 488 to 498 |
| `datasets/domain/service_lifecycle.py` | 483 to 491 |
| `processing/ingest/tasks_common.py` | 2559 to 2579 |
| `processing/ingest/tasks_vrt.py` | 1628 to 1647 |


---

## Review round 3

Both findings follow from the class-wide acquisition added in round 2.

### P1: the delete reaped storage it could not commit

`_reap_managed_storage` deletes the managed objects permanently, and
`delete_dataset` relies on the transaction rolling back to keep the catalog
consistent with them. Round 2 put the acquisition after that reap, so a writer
holding the dataset row past the request budget produced a 55P03 with the
objects already gone and the catalog row still present.

The acquisition now runs ahead of the reap in both branches, and behind each
branch's data-table work. The reupload swap takes ACCESS EXCLUSIVE on the data
table before its catalog rows, so leading with the catalog rows here would
invert against it. The function's original promise still holds, because the DROP
and the row delete are transactional and roll back with everything else.

Audited the other sites this PR touched for the same shape. Nothing else has an
irreversible step before an acquisition that can time out. The layer DDL is
transactional, the metadata PATCH acquires before its first write, and the three
worker doors pass `lock_timeout=None`, so they wait rather than raise.

### P2: one answer for a contended row

The same SQLSTATE was reported three ways. 409 from the feature router, an
unhandled 500 from the metadata PATCH, and 400 from the layer DDL routes, the
last leaking the raw asyncpg text into the response body.

The helper now raises `CatalogLockConflict` and one handler in `app/api/main.py`
maps it to 409, so the answer no longer depends on which route reached the
acquisition. The helper rolls back before raising, so a caller that loses the
race has written nothing and its retry is clean. Nothing is read off an ORM
instance after that rollback, because rollback expires them and a lazy load from
the handler would raise MissingGreenlet instead of the 409. Workers let it
propagate and fail the job, which the run ledger already records.

### Verification at `36f72c2ad`

```
tests/test_feature_lock_order_1847.py                            23 passed
+ lifecycle, publication_lifecycle, layers, layers_authz,
  metadata_roundtrip, tile_columns_metadata, layering  126 passed, 4 skipped
delete_tile_cache_purge, registered_delete_detach,
  vrt_delete_guard, raster_replace, raster_assets, reupload      226 passed
features_crud, features_incremental_metadata, rule1, rule2,
  postgis_refresh, stac_refresh, regenerate_vrt, vrt_lifecycle   363 passed
ruff check and ruff format --check                                 passed
scripts/dump_openapi.py --check                                    exit 0
```

Counterfactuals, both actually run. Moving the acquisition back after the reap
fails the new source-order test and the end-to-end one, and the end-to-end
failure shows the real prefixes reaped with the dataset row still present.
Removing the domain exception from the helper gives an unhandled 500 on the
metadata PATCH and a 400 on the layers route carrying
`LockNotAvailableError: canceling statement due to lock timeout` in the detail.

### Two bugs of my own, caught by the new tests

The delete acquisition was imported inside one branch and used from both, which
`UnboundLocalError`d on the vector path. And the layers column route is under
`/layers`, not `/datasets`, so the first version of that test asserted against a
404. Both were found by running the tests, not by reading the diff.

`test_vrt_delete_guard_174.py` needed a real fix rather than a rename: it drives
`delete_dataset` with bare `AsyncMock` sessions, and the acquisition's extent
read made `result.first()` a coroutine that the code then subscripted. Six
near-identical mock sessions are now one `_mock_session()` helper whose `first()`
returns None, which reads as "no stored extent".

### Caps, re-measured

| file | cap |
| --- | --- |
| `datasets/domain/service_lifecycle.py` | 491 to 507 |
| `api/main.py` | 1903 to 1935 |


---

## Round 4: CI failure and adversarial audit

### CI

`tests/test_reupload_swap_lock_retry.py` mirrors `_apply_reupload_swap` with a stub
`ProcessingPort` offering only `get_dataset_version_orm_class`, so the acquisition
added in round 2 raised `AttributeError` on a path the file exists to exercise. One
shared `_make_port()` now offers the two mapper accessors too.

Rather than restore the call shape, a new test asserts what the mirror is for: the
pair is taken before the first field is assigned. It reads one timeline of emitted
SQL and recorded attribute writes, because a count assertion cannot tell the two
orderings apart, and both execute the same statements.

### Audit P1-1: the lock spanned an object-storage upload

The raster replace acquisition sat before `_write_swapped_fields`, and between that
and the flush sits `archive_lossy_original`, which PUTs the whole original raster to
object storage. Holding both catalog rows across a multi-GB upload, with
`lock_timeout=None` on the holder and 2s on every request-side waiter, is what made
the other findings fire in practice rather than in theory.

The acquisition moved to just before `reserve_replacement_bytes`, the first statement
that flushes either row. The swap helper only assigns in memory. `no_autoflush` around
the archive makes that a guarantee rather than a measurement: without it, any
statement added to the archive path later would flush the dirty attributes records
first, ahead of the acquisition.

### The sweep across the other eight sites

**P2-2, layers DDL.** They held the pair across `compute_quality_score`, a `COUNT` per
column over the whole data table plus a geometry pass over 10,000 rows. Nothing in it
needs either row, so `_refresh_quality_detail` became `_compute_quality_detail` and the
three callers scan, then lock, then assign both fields. This is what separates it from
the feature-path aggregate, which has to stay inside the lock for the #1778
read-decide-write invariant.

**P2-3, delete's Valkey purge.** It stays under the lock and now says why, with the
bound. Row locks are held to commit, so the only way out is after the caller's commit,
which would undo the one-placement-serves-every-caller argument the code already makes.
The bound is one round trip on an existing connection against one table's key set.

**P2-4, unconditional metadata lock.** Now conditional on the body reaching a
datasets-row field. A record-only body writes one row, and a one-row write has no order
to get wrong. `is_dem` is excluded: it writes `raster_assets`, a third table this
pair's order says nothing about.

### Audit P2-1: the gate accepted what it exists to catch

All four probes now fail it, and each has a negative fixture.

- Qualified names resolved through each module's import bindings, so a name collision
  no longer inherits an acquirer's exemption.
- The acquisition must precede the first write on every branch, not merely appear. It
  is checked for every function that acquires and writes, not only the pair writers,
  which is what a fifth probe of my own showed was still missing: moving the
  acquisition below the writes in `layers.service.add_column` passed until then,
  because that function writes one row and the pair writer is its caller.
- Core `update()` / `delete()` against the two tables count as writes.
- `session.delete(record)` reads as a write of both rows, since the datasets row
  follows by FK cascade. Without it the one endpoint that deletes a dataset was
  invisible to the scan.

Deliberately conditional acquisitions live in `_CONDITIONAL_ACQUISITION` with the
reason the unlocked path is safe, so a new one fails until someone writes that reason
down.

### Audit P2-5: coverage

DB-backed tests for the layers DDL, the delete and the metadata PATCH, none of them
monkeypatching the budget. Raising it to 60s is what hid the 500 and the 400 in round
2. The three worker doors are checked on emitted order rather than raced, since each
needs a staged upload and a live ingest job to reach its swap, and the property under
test is an ordering. A further gate asserts `lock_timeout=None` appears at those three
sites and nowhere else.

### Also from the audit

The layers 400 body interpolated `exc.orig`, publishing the asyncpg exception class to
the caller. The SQLSTATE goes to the log now. The postgis-refresh comment pointed at a
module `processing/` may not import.

### Verification at `59179c4e8`

```
lock_order_1847, reupload_swap_lock_retry, layers, layers_authz,
  lifecycle, publication_lifecycle, metadata_roundtrip,
  tile_columns_metadata, layering                     149 passed, 4 skipped
reupload x3, raster_replace, vrt_delete_guard, vrt_lifecycle,
  regenerate_vrt, delete_tile_cache_purge, delete_detach          285 passed
features_crud, features_incremental_metadata, rule1, rule2,
  postgis_refresh, stac_refresh                                   405 passed
test_analysis_preview.py (re-run alone)                            83 passed
ruff check and ruff format --check                                 passed
scripts/dump_openapi.py --check                                    exit 0
```

`test_analysis_preview.py` errored once at fixture setup with
`ConnectionError: unexpected connection_lost()` from asyncpg, on a Postgres shared with
other work. It passes on its own; nothing in it touches this change.

Counterfactuals re-run: restoring the round-2 delete ordering fails three tests, and
moving the acquisition below the writes in a real layers service function fails the
hardened gate.

### Caps

| file | cap |
| --- | --- |
| `datasets/domain/service_lifecycle.py` | 507 to 519 |
| `datasets/domain/service_metadata.py` | 498 to 516 |


---

## Round 5: comment trim, last CI failure, rebase

### The comment rule

Applied to the files this PR touches. An inline comment is now the anchor plus the
invariant, three lines at most; docstrings state the contract. The rounds, the
alternatives weighed, and the measurements that settled them live in this body.

The trim is not cosmetic in one respect worth flagging: it shrank five files below
the caps the earlier rounds set, so every cap is re-measured. The seven
`_MODULE_LOC_CAPS` entries this PR had accumulated are collapsed to one per file,
because the intermediate caps described states that never shipped and the ledger is
meant to be readable.

`app/platform/catalog_locks.py` went from 138 lines to 99 with no behaviour change:
most of what came out was the argument for choosing datasets-first over
records-first, which belongs here.

### Last CI failure

`tests/test_raster_ingest.py::TestRasterDeleteCascadeRemovesStorage` drives
`delete_dataset` with a `_MockDataset` carrying no `record_id`, which the acquisition
reads. Three tests in that class failed locally, not the one CI reported. The vector
branch's DROP was never affected; the stub was missing a field every real `Dataset`
has.

### DCO

All eight commits already carried `Signed-off-by: Ian Shiland <ishiland@gmail.com>`;
verified rather than assumed, by grepping each commit body.

### Rebase

The branch was five commits behind `main`. Rebased onto `95a80e88d` with no conflicts,
and the suites re-run against it.

### Verification at `74ed9f28f`

```
lock_order_1847, layering, rule1, rule2, raster_ingest,
  reupload_swap_lock_retry, vrt_delete_guard                     243 passed
features_crud, layers, lifecycle, metadata_roundtrip,
  reupload, raster_replace                            246 passed, 4 skipped
ruff check and ruff format --check                                 passed
scripts/dump_openapi.py --check                                    exit 0
```

Before the rebase, on the trimmed tree: 242, 250 (+4 skipped) and 247 passed across
the same three groupings plus the delete and VRT suites.

### Caps, re-measured after the trim

| file | cap |
| --- | --- |
| `api/main.py` | 1903 to 1928 |
| `catalog/features/service.py` | 1541 to 1550 |
| `catalog/layers/service.py` | unchanged |
| `datasets/domain/service_lifecycle.py` | 483 to 497 |
| `datasets/domain/service_metadata.py` | 488 to 502 |
| `processing/ingest/tasks_common.py` | 2551 to 2571 |
| `processing/ingest/tasks_postgis_refresh.py` | 1128 to 1132 |
| `processing/ingest/tasks_vrt.py` | 1628 to 1641 |


---

## Round 5: codex r4 gate P2, audit P2s

### Gate: ordering across transitive writer calls (codex r4)

The dominance check read only assignments in the function's own body and skipped
any function whose writes were entirely in callees. A wrapper that calls a
record-writing helper, takes the pair, then calls a dataset-writing helper emits
exactly the records-before-datasets sequence the gate exists to reject, and passed.

A call now counts as a write at the call site when the callee reaches a write,
using the transitive closure the classification already computes. Two fixtures pin
it: the wrapper shape must fail, and the same wrapper with the acquisition moved
first must pass, so only the ordering separates them. The failing one passes
against the previous predicate, which is what makes it a regression test.

The stronger check flagged one real site. `reupload_raster` calls
`_write_swapped_fields` before acquiring, and that helper only assigns in memory:
the acquisition sits below `archive_lossy_original` so the pair is not held across
the upload, and `no_autoflush` holds the assignments until after it. Recorded in
`_INMEMORY_UNTIL_ACQUIRED`, with the reason enforced rather than asserted. A test
fails if that `no_autoflush` block ever goes.

### One shape for a contended row (audit P2)

The feature router still returned its own 409 body, but the acquisition raises
`CatalogLockConflict`, which is not a `DBAPIError` and so passes `_guard` to the
global handler. One condition had two response shapes depending on which statement
hit it, and a client keying on `detail.code` never saw the local one on the
acquisition path. The classifier now raises the shared exception, and the global
ProblemDetail carries `code=catalog_lock_conflict` so the single shape stays
machine-readable. Nothing outside this PR referenced `feature_write_locked`.

### Bulk delete (audit P2)

It caught `Exception` and reported a contended row as "Dataset deletion failed
unexpectedly" with a stack trace, answering 200, while single delete answered 409.
`CatalogLockConflict` is now caught ahead of the catch-all and re-raised.

Revised after review: the conflict is recorded PER ITEM rather than raised. The
batch commits per item and returns per-item results, so aborting would discard
results already committed. The entry carries `code=catalog_lock_conflict`, the
same constant the 409 body uses, and the batch continues.

`BulkDeleteResultItem` gains an optional `code` for that, because `detail` is
prose. Additive and optional; `openapi.json`, both SDKs and the frontend types
are regenerated, `test_sdks_round_trip.py` passes and the frontend typecheck is
clean.

**A pre-existing bug had to be fixed for the per-item contract to hold.** Any
per-item failure rolled the session back, which expires every instance in it
including the actor, and the next item's access check then read `user.id`,
lazy-loaded outside the greenlet, and raised MissingGreenlet. The catch-all
recorded that as "Dataset deletion failed unexpectedly", so one bad item made
every later item fail with a message describing none of them. No lock is needed
to reach it: an ordinary title mismatch on the middle of three ids does it,
measured before fixing. Both rollback paths now go through one helper that
reloads the actor, and a second test pins the non-lock case.

### Left alone

**The audit's P3, and a correction.** `_apply_reupload_swap` acquires above
`reupload_file`'s archive PUT, asymmetric with the raster door, whose acquisition
round 4 moved below its upload. Left as is for this PR.

It was suggested that the order is safe because the PUT is idempotent and the lock
window is the swap rather than the upload. Measured against the code, that does not
hold, so it is not the justification recorded here. In `tasks_reupload.py` the swap,
`_archive_original_file` and `session.commit()` are all in one session: the
acquisition happens inside the swap, the PUT follows it, and PostgreSQL holds row
locks until commit. The window therefore spans the upload. Idempotence of the PUT
bears on retry safety, not on how long the rows are held.

So this is the same #1848 class as the raster door, and it is real: the worker passes
`lock_timeout=None` and never yields, while request-side waiters have two seconds and
answer 409. What makes it a follow-up rather than a fix here is the shape of the
change. In the raster door the acquisition and the upload sit in one function, so
moving one line fixed it. Here the acquisition is inside `_apply_reupload_swap` and
the PUT is in its caller, so closing it means either lifting the acquisition out of
the swap into both call sites or moving the archive ahead of the swap. Either is a
larger change to the ingest hot path than a point release should carry on a finding
rated P3.

The audit's third P2, that `_DATASET_ROW_FIELDS` is a request-field whitelist and
an overlay's `on_transition` writing the datasets row would reopen the inversion
unseen by the gate, is being filed as a follow-up rather than fixed here.

### Verification at `49295ac8a`

```
lock_order_1847, layering, rule1, rule2, features_crud, lifecycle
                                                     243 passed, 5 skipped
lifecycle, delete_tile_cache_purge, delete_detach, maps_asset_cleanup,
  layers, metadata_roundtrip                         119 passed, 4 skipped
ruff check and ruff format --check                                 passed
scripts/dump_openapi.py --check                                    exit 0
```

Counterfactual, actually run: reverting both P2 fixes fails four tests, and the
bulk-delete failure shows the audit's exact body,
`{"deleted":0,"errors":1,...,"detail":"Dataset deletion failed unexpectedly"}`
with status 200.

`api/main.py` cap 1928 to 1930, re-measured.




---

## Round 6: codex r5

### P1: the delete reaped raster objects it might not commit

The replace worker holds the RasterAsset row across its upload and takes the catalog
pair only afterwards. A delete that took the pair, reaped the raster prefix, and met
that row for the first time at the record-delete cascade waited on the worker with
the bytes already gone. If the delete lost, the dataset survived pointing at removed
objects.

The raster branch now takes the child row first, in the worker's own order, through
the shared helper so the gate sees it. The class comes from `CatalogPort`, because
`catalog/` may not import `processing` and the layering gate caught that on the first
attempt.

### P2: the timeout outlives the acquisition it was set for

`SET LOCAL lock_timeout` holds for the whole transaction, but only the two acquisition
SELECTs were wrapped in the translation. A metadata PATCH carrying `tile_columns` and
`is_dem` takes the pair and then writes `raster_assets`; against a held row that raised
55P03 from a statement no per-site translation covered, and it escaped as a 500.

Closed at the boundary: the database error handler answers a lock conflict with the
same 409 ProblemDetail, from one shared body. One mapping rather than one per call
site, which is what the policy-after-detection class asks for.

### P2: the recovery helper assumed a mapped actor

It called `AsyncSession.refresh(user)`. An `IdentityExtension` supplies an identity
that is not a mapped `User`, and refresh raises `UnmappedInstanceError` on one, turning
the recovery path into the failure it exists to prevent. It now reloads only a
persistent mapped instance. An unmapped identity is not in the session, so the rollback
never expired it and there is nothing to restore.

### Verification at `af2fedad7`

```
lock_order_1847, layering, rule1, rule2, lifecycle       204 passed, 5 skipped
raster_replace, raster_ingest, vrt_delete_guard,
  delete_tile_cache_purge, delete_detach, metadata_roundtrip,
  tile_columns_metadata                                            211 passed
features_crud, layers, sdks_round_trip                    84 passed, 1 skipped
ruff check and ruff format --check                                   passed
scripts/dump_openapi.py --check                              exit 0, no drift
```

Counterfactual, actually run: reverting all three fixes fails exactly the three new
tests, and the P1 failure shows the reaped prefixes with the dataset row still present.

Caps re-measured: `api/main.py` 1952, `catalog/features/service.py` 1560,
`datasets/domain/service_lifecycle.py` 498.


---

## Round 7: codex r6

### P1: the is_dem path inverted against the replace worker

A metadata PATCH combining `is_dem` with `tile_columns`, `quality_statement` or
`source_url` took Dataset then Record, and `_apply_is_dem` then updated
`raster_assets`. The replace worker locks `raster_assets` first and asks for the
pair afterwards. Opposite orders, and the victim can be the retry-disabled
replacement after its uploads have already run. The boundary 409 only classifies
whichever side PostgreSQL picks.

`is_dem` now extends the acquisition to the raster child, so the path takes
raster_assets, then datasets, then records: the order the delete already uses. The
request waits at its first acquisition holding nothing, whichever side arrives
first.

### The class, taken over by the gate

Third site, so it stops being a review finding. A raster write is now a third kind
in the transitive closure, and any function that acquires the pair and reaches a
`raster_assets` write must extend the order to it.

Two sites order that row themselves rather than through the helper:
`reupload_raster` with its own FOR UPDATE, `regenerate_vrt` with an UPDATE claim and
a FOR UPDATE join. Both are recorded with the reason enforced rather than asserted:
a test fails if either ever takes the pair first.

**One correction to the gate while adding this.** The dominance rule counts pair
writes only. A raster write belongs BEFORE the pair, so demanding the pair
acquisition ahead of one would have required the very inversion this file exists to
prevent, and it flagged `regenerate_vrt` for doing the right thing. Caught by running
it, not by reading it.

### Verification at `78388d1df`

```
lock_order_1847, layering, rule1, rule2                  210 passed, 1 skipped
metadata_roundtrip, tile_columns_metadata, raster_replace,
  regenerate_vrt, vrt_lifecycle, lifecycle               177 passed, 4 skipped
features_crud, layers, raster_ingest, delete_tile_cache_purge     100 passed
ruff check and ruff format --check                                   passed
scripts/dump_openapi.py --check                              exit 0, no drift
```

Counterfactuals, both run. Without the fix the gate names
`service_metadata.update_user_metadata` by file and line, and the runtime test fails
with the PATCH parked on the raster row while holding `catalog.records`, which is the
cycle the worker loses.

`datasets/domain/service_metadata.py` cap 502 to 507, re-measured.


---

## Round 8: codex r7

### P1: the reap preceded a cascade that could fail

The acquisition installs `SET LOCAL lock_timeout` for the whole transaction, and the
record delete's FK cascades reach child rows nobody locks: `map_layers`,
`record_embeddings`, `dataset_assets`. A contended child raised 55P03, the transaction
rolled back, and a reap that had already run left the dataset restored with its objects
gone. Locking every cascade child would be the wrong fix; the ordering is.

`delete_dataset` no longer touches object storage. It returns a `DatasetDeletion`
naming the prefixes, and both endpoints reap after their commit.

That inverts the residual rather than removing it. A failed reap now orphans objects,
which costs storage. The old order left a catalog entry pointing at nothing, which
serves broken tiles and is invisible. The failure is logged rather than raised, because
the rows are already gone and no caller can act on it.

### P2: the 409 did not establish it was our timeout

The boundary handler answered any 40P01, and any 55P03 from another timeout site, with
the catalog-specific code. A contextvar records that this request installed the catalog
timeout, and the handler maps to 409 only then; otherwise the class-40 operational path
is unchanged. Each request runs in its own task, so the marker cannot leak between them.

### The contract change rippled

Four mirror suites asserted the old return type or the reap-inside behaviour. They now
assert the returned prefixes and run the reap themselves, so the coverage of WHICH
objects go is unchanged. One existed specifically to assert that a storage failure
prevented the DB delete. That guarantee is deliberately reversed, and the test now says
so rather than being deleted.

### Verification at `35f6222d6`

```
lock_order_1847, layering, rule1, rule2, raster_ingest,
  vrt_delete_guard, lifecycle                            251 passed, 5 skipped
delete_tile_cache_purge, delete_detach, features_crud,
  metadata_roundtrip, raster_replace                               213 passed
ruff check and ruff format --check                                   passed
scripts/dump_openapi.py --check                              exit 0, no drift
```

Counterfactuals, both run. Putting the reap back inside `delete_dataset` fails the
source-level test by name, and removing the contextvar gate answers an unrelated
deadlock 409 where it should answer 503.

Caps: `datasets/domain/service_lifecycle.py` 498 to 512, `api/main.py` 1952 to 1954.
