### PR TITLE
test(ci): remove wall-clock races behind the merge-queue evictions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -512,10 +512,13 @@ jobs:
         run: node frontend/scripts/check-api-error-boundary.mjs
 
       - name: Install gitleaks
+        # fix(#1859): retries a transient download failure instead of letting
+        # it evict the whole merge-queue entry on a required job.
         run: |
           GL=8.30.1
           GL_SHA256=551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb
-          curl -sSL "https://github.com/gitleaks/gitleaks/releases/download/v${GL}/gitleaks_${GL}_linux_x64.tar.gz" \
+          curl -sSL --retry 5 --retry-all-errors --retry-delay 2 \
+            "https://github.com/gitleaks/gitleaks/releases/download/v${GL}/gitleaks_${GL}_linux_x64.tar.gz" \
             -o gitleaks.tar.gz
           echo "${GL_SHA256}  gitleaks.tar.gz" | sha256sum --check --strict
           tar -xz -f gitleaks.tar.gz gitleaks

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1197,12 +1197,23 @@ jobs:
         # apt steps, so this also gets a bound.
         timeout-minutes: 10
         run: |
-          docker build -t geolens-cli-test-db -f - . <<'DOCKERFILE'
+          # fix(#1859): the base-image pull inside `docker build` hit a
+          # transient Docker Hub token-fetch reset ("failed to fetch oauth
+          # token: ... connection reset by peer") in merge-group run
+          # 33966364665 and again on #1858's Backend Tests, evicting an
+          # otherwise-clean queue entry. Retry the whole build, since that is
+          # where the pull happens.
+          for attempt in 1 2 3 4 5; do
+          docker build -t geolens-cli-test-db -f - . <<'DOCKERFILE' && break
           FROM postgis/postgis:18-3.6
           RUN apt-get update \
               && apt-get install -y --no-install-recommends postgresql-18-pgvector \
               && rm -rf /var/lib/apt/lists/*
           DOCKERFILE
+          [ "$attempt" -eq 5 ] && exit 1
+          echo "docker build failed (attempt $attempt/5), retrying in 10s..."
+          sleep 10
+          done
           docker run -d --name cli-test-postgres \
             -e POSTGRES_DB=postgres \
             -e POSTGRES_USER=geolens \
@@ -1400,12 +1411,23 @@ jobs:
         # apt steps, so this also gets a bound.
         timeout-minutes: 10
         run: |
-          docker build -t geolens-test-db -f - . <<'DOCKERFILE'
+          # fix(#1859): the base-image pull inside `docker build` hit a
+          # transient Docker Hub token-fetch reset ("failed to fetch oauth
+          # token: ... connection reset by peer") in merge-group run
+          # 33966364665 and again on #1858's Backend Tests, evicting an
+          # otherwise-clean queue entry. Retry the whole build, since that is
+          # where the pull happens.
+          for attempt in 1 2 3 4 5; do
+          docker build -t geolens-test-db -f - . <<'DOCKERFILE' && break
           FROM postgis/postgis:18-3.6
           RUN apt-get update \
               && apt-get install -y --no-install-recommends postgresql-18-pgvector \
               && rm -rf /var/lib/apt/lists/*
           DOCKERFILE
+          [ "$attempt" -eq 5 ] && exit 1
+          echo "docker build failed (attempt $attempt/5), retrying in 10s..."
+          sleep 10
+          done
           docker run -d --name test-postgres \
             -e POSTGRES_DB=postgres \
             -e POSTGRES_USER=geolens \
@@ -2371,12 +2393,23 @@ jobs:
         # apt steps, so this also gets a bound.
         timeout-minutes: 10
         run: |
-          docker build -t geolens-test-db -f - . <<'DOCKERFILE'
+          # fix(#1859): the base-image pull inside `docker build` hit a
+          # transient Docker Hub token-fetch reset ("failed to fetch oauth
+          # token: ... connection reset by peer") in merge-group run
+          # 33966364665 and again on #1858's Backend Tests, evicting an
+          # otherwise-clean queue entry. Retry the whole build, since that is
+          # where the pull happens.
+          for attempt in 1 2 3 4 5; do
+          docker build -t geolens-test-db -f - . <<'DOCKERFILE' && break
           FROM postgis/postgis:18-3.6
           RUN apt-get update \
               && apt-get install -y --no-install-recommends postgresql-18-pgvector \
               && rm -rf /var/lib/apt/lists/*
           DOCKERFILE
+          [ "$attempt" -eq 5 ] && exit 1
+          echo "docker build failed (attempt $attempt/5), retrying in 10s..."
+          sleep 10
+          done
           docker run -d --name test-postgres \
             -e POSTGRES_DB=postgres \
             -e POSTGRES_USER=geolens \

--- a/backend/tests/test_export_artifact_cache_1532.py
+++ b/backend/tests/test_export_artifact_cache_1532.py
@@ -4572,15 +4572,17 @@ async def test_the_artifact_is_stamped_with_the_snapshot_not_the_upload(
     the snapshot, `_published_at`'s ceiling bounds build plus upload, and the
     data behind a served artifact is never older than TTL plus that ceiling.
 
-    The conversion is made to take two seconds. The key stamp is WHOLE seconds
-    (`int(built_at)` in the key), so the arithmetic has to allow for the
-    truncation: a stamp taken after the build is `int(before + 2 + ε)`, which is
-    strictly greater than `before + 1` for any ε ≥ 0; a stamp taken before it is
-    `int(before + δ)` for a δ well under a second (auth, the dataset fetch, the
-    precondition checks), which is at most `before + δ`. So `before + 1.0` is
-    the line: the old placement can never satisfy it, the new one always does.
-    (`<= before` was the first draft, and it flaked whenever a second boundary
-    fell inside δ — 0.04 s once, in CI.)
+    The conversion is made to take two seconds so a stamp taken after it would
+    be trivially distinguishable from one taken before.
+
+    fix(#1859): compares `built_at` against a timestamp the double itself
+    records when the conversion STARTS, not against `before + 1.0`. That fixed
+    margin assumed request overhead ahead of the conversion (auth, the dataset
+    fetch, the precondition checks) stays under a second, which is exactly a
+    wall-clock threshold racing a loaded CI runner — the margin, not the
+    property being tested, is what could fail. Watching the double's own start
+    time proves the same thing (the stamp precedes the conversion) without
+    guessing how long unrelated request overhead takes anywhere it runs.
     """
     import asyncio
 
@@ -4589,17 +4591,20 @@ async def test_the_artifact_is_stamped_with_the_snapshot_not_the_upload(
 
     dataset = await _dataset(test_db_session, "Snapshot Stamp")
     real_conversion = export_router.export_dataset
+    conversion_started_at: float | None = None
 
     async def _slow(*args, **kwargs):
+        nonlocal conversion_started_at
+        conversion_started_at = time.time()
         await asyncio.sleep(2.0)
         return await real_conversion(*args, **kwargs)
 
     monkeypatch.setattr(export_router, "export_dataset", _slow)
 
-    before = time.time()
     resp = await client.get(_url(dataset.id), headers=admin_auth_header)
     assert resp.status_code == 200, resp.text
     assert conversions.count == 1
+    assert conversion_started_at is not None
 
     selection = cache.selection_key(
         dataset_id=dataset.id,
@@ -4615,10 +4620,10 @@ async def test_the_artifact_is_stamped_with_the_snapshot_not_the_upload(
         dataset.id, selection, filename="x.geojson", media_type="application/geo+json"
     )
     assert artifact is not None
-    assert artifact.built_at <= before + 1.0, (
-        f"the artifact is stamped {artifact.built_at - before:.2f}s after the request "
-        f"began, i.e. AFTER a 2s conversion; the stamp must precede the read so "
-        f"the ceiling bounds the data's age, not just the upload's"
+    assert artifact.built_at <= conversion_started_at, (
+        f"the artifact is stamped {artifact.built_at - conversion_started_at:.2f}s "
+        f"after the 2s conversion began; the stamp must precede the read so the "
+        f"ceiling bounds the data's age, not just the upload's"
     )
 
 

--- a/backend/tests/test_ingest_progress.py
+++ b/backend/tests/test_ingest_progress.py
@@ -274,7 +274,6 @@ async def test_service_worker_advances_ogr2ogr_progress_while_remote_import_is_r
     test_db_session, monkeypatch
 ):
     """Service URL ingest must publish progress during the remote load window."""
-    from app.core import db as db_module
     from app.processing.ingest import tasks_vector
     from app.processing.ingest.ogr import IngestionError
 
@@ -350,6 +349,25 @@ async def test_service_worker_advances_ogr2ogr_progress_while_remote_import_is_r
         raising=False,
     )
 
+    # fix(#1859): wait on an event the heartbeat tick itself sets, instead of
+    # polling the job row on a 1-second wall-clock deadline. The poll loop
+    # opened a fresh `db_module.async_session()` every 10ms (matching the
+    # heartbeat's own mocked 0.01s interval), and under a loaded CI runner
+    # that session churn was what produced `ConnectionError: unexpected
+    # connection_lost() call`, not a real ingest bug -- the production
+    # heartbeat already shields each tick from cancellation (fix(#1778)).
+    # Watching the tick complete is both deterministic and cheaper: one read
+    # after the event fires, not up to 100 of them.
+    tick_committed = asyncio.Event()
+    real_tick = tasks_vector._service_import_heartbeat_tick
+
+    async def _tracking_tick(job_uuid, attempt_id):
+        keep_going = await real_tick(job_uuid, attempt_id)
+        tick_committed.set()
+        return keep_going
+
+    monkeypatch.setattr(tasks_vector, "_service_import_heartbeat_tick", _tracking_tick)
+
     worker_task = asyncio.create_task(
         tasks_vector.ingest_service.func(
             job_id=str(job_id),
@@ -361,21 +379,18 @@ async def test_service_worker_advances_ogr2ogr_progress_while_remote_import_is_r
     )
 
     try:
-        await asyncio.wait_for(remote_import_started.wait(), timeout=1)
+        await asyncio.wait_for(remote_import_started.wait(), timeout=5)
 
-        deadline = asyncio.get_running_loop().time() + 1
-        while asyncio.get_running_loop().time() < deadline:
-            async with db_module.async_session() as poll_session:
-                result = await poll_session.execute(
-                    select(IngestJob).where(IngestJob.id == job_id)
-                )
-                current_job = result.scalar_one()
-                last_progress = current_job.progress
-                if last_progress is not None and last_progress > 0.1:
-                    break
+        # A generous hang guard, not the source of the assertions below --
+        # the heartbeat's own mocked interval is 0.01s, so a healthy tick
+        # lands almost immediately.
+        await asyncio.wait_for(tick_committed.wait(), timeout=5)
+        assert not worker_task.done()
 
-            assert not worker_task.done()
-            await asyncio.sleep(0.01)
+        result = await test_db_session.execute(
+            select(IngestJob).where(IngestJob.id == job_id)
+        )
+        last_progress = result.scalar_one().progress
     finally:
         release_remote_import.set()
         # fix(#422): join the worker directly instead of wait_for(timeout=2).

--- a/backend/tests/test_tile_cache.py
+++ b/backend/tests/test_tile_cache.py
@@ -30,8 +30,13 @@ def _reset_label_counter(counter, label_value: str) -> None:
 
 
 @pytest.fixture
-def tile_cache():
-    """Create TileCacheProvider backed by fakeredis (binary mode)."""
+async def tile_cache():
+    """Create TileCacheProvider backed by fakeredis (binary mode).
+
+    fix(#1859): closes the fake client's connection pool afterwards. Leaving
+    one open per test leaked event-loop resources into the rest of the
+    session under `-n 4`.
+    """
     provider = TileCacheProvider.__new__(TileCacheProvider)
     provider._client = fakeredis.aioredis.FakeRedis(decode_responses=False)
     # Reset Prometheus counters for isolation. PERF-11 — counters are now
@@ -42,13 +47,15 @@ def tile_cache():
     for label in ("test_table", "t", "_other"):
         _reset_label_counter(tile_cache_hits, label)
         _reset_label_counter(tile_cache_misses, label)
-    return provider
+    try:
+        yield provider
+    finally:
+        await provider._client.aclose()
 
 
 # --- TileCacheProvider get/set tests ---
 
 
-@pytest.mark.asyncio
 async def test_tile_cache_get_miss(tile_cache):
     """Cache miss returns None and increments miss counter."""
     from app.platform.cache.tile_cache import tile_cache_misses
@@ -58,7 +65,6 @@ async def test_tile_cache_get_miss(tile_cache):
     assert _read_label_counter(tile_cache_misses, "test_table") == 1
 
 
-@pytest.mark.asyncio
 async def test_tile_cache_set_and_get(tile_cache):
     """Binary round-trip: set stores bytes, get returns exact bytes."""
     from app.platform.cache.tile_cache import tile_cache_hits
@@ -71,7 +77,6 @@ async def test_tile_cache_set_and_get(tile_cache):
     assert _read_label_counter(tile_cache_hits, "test_table") == 1
 
 
-@pytest.mark.asyncio
 async def test_tile_cache_hit_increments_counter(tile_cache):
     """Successive hits increment the hit counter."""
     from app.platform.cache.tile_cache import tile_cache_hits
@@ -83,7 +88,6 @@ async def test_tile_cache_hit_increments_counter(tile_cache):
     assert _read_label_counter(tile_cache_hits, "t") == 2
 
 
-@pytest.mark.asyncio
 async def test_tile_cache_miss_increments_counter(tile_cache):
     """Successive misses increment the miss counter."""
     from app.platform.cache.tile_cache import tile_cache_misses
@@ -96,7 +100,6 @@ async def test_tile_cache_miss_increments_counter(tile_cache):
 # --- Graceful degradation tests ---
 
 
-@pytest.mark.asyncio
 async def test_tile_cache_get_returns_none_on_redis_failure():
     """Redis failure on get returns None (graceful degradation)."""
     from app.platform.cache.tile_cache import tile_cache_misses
@@ -113,7 +116,6 @@ async def test_tile_cache_get_returns_none_on_redis_failure():
     assert _read_label_counter(tile_cache_misses, "t") == 1
 
 
-@pytest.mark.asyncio
 async def test_tile_cache_set_silent_on_redis_failure():
     """Redis failure on set is silent (no exception)."""
     provider = TileCacheProvider.__new__(TileCacheProvider)
@@ -128,7 +130,6 @@ async def test_tile_cache_set_silent_on_redis_failure():
 # --- invalidate_table tests ---
 
 
-@pytest.mark.asyncio
 async def test_invalidate_table_removes_all_tiles_for_table(tile_cache):
     """invalidate_table removes all cached tiles for the specified table."""
     data = gzip.compress(b"tile")
@@ -148,14 +149,12 @@ async def test_invalidate_table_removes_all_tiles_for_table(tile_cache):
     assert await tile_cache.get("other", 1, 0, 0) == data
 
 
-@pytest.mark.asyncio
 async def test_invalidate_table_noop_when_no_tiles(tile_cache):
     """invalidate_table is a no-op when the table has no cached tiles."""
     # Should not raise
     await tile_cache.invalidate_table("nonexistent")
 
 
-@pytest.mark.asyncio
 async def test_invalidate_table_silent_on_redis_failure():
     """Redis failure on invalidate_table is silent (graceful degradation)."""
     provider = TileCacheProvider.__new__(TileCacheProvider)
@@ -329,7 +328,6 @@ def test_multi_tenant_tile_pool_accepts_distinct_login(monkeypatch):
     pool_module._validate_tile_database_isolation()
 
 
-@pytest.mark.asyncio
 async def test_setup_tile_connection_issues_set_role():
     """_setup_tile_connection runs ``SET ROLE geolens_reader`` on every fresh
     pool checkout so tile-path queries cannot mutate or drop tables (H-10)."""
@@ -341,7 +339,6 @@ async def test_setup_tile_connection_issues_set_role():
     conn.execute.assert_awaited_once_with("SET ROLE geolens_reader")
 
 
-@pytest.mark.asyncio
 async def test_setup_tile_connection_logs_and_continues_on_postgres_error(monkeypatch):
     """If geolens_reader doesn't exist (e.g. legacy upgrade pre-v6.0), the
     setup callback logs a warning and lets the connection serve requests
@@ -358,7 +355,6 @@ async def test_setup_tile_connection_logs_and_continues_on_postgres_error(monkey
     conn.execute.assert_awaited_once_with("SET ROLE geolens_reader")
 
 
-@pytest.mark.asyncio
 async def test_init_tile_pool_passes_setup_callback(monkeypatch):
     """init_tile_pool wires ``setup=_setup_tile_connection`` into
     asyncpg.create_pool so every fresh connection drops privileges."""
@@ -404,7 +400,6 @@ def _tile_role_row(**overrides):
     return row
 
 
-@pytest.mark.asyncio
 async def test_live_tile_role_guard_accepts_only_gateway_member(monkeypatch):
     from app.processing.tiles.pool import _assert_multi_tenant_tile_role
 
@@ -414,7 +409,6 @@ async def test_live_tile_role_guard_accepts_only_gateway_member(monkeypatch):
     await _assert_multi_tenant_tile_role(conn)
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "unsafe_field",
     [
@@ -440,7 +434,6 @@ async def test_tile_role_guard_rejects_each_privilege_path(monkeypatch, unsafe_f
         await _assert_multi_tenant_tile_role(conn)
 
 
-@pytest.mark.asyncio
 async def test_tile_role_guard_rejects_missing_tile_gateway(monkeypatch):
     from app.processing.tiles.pool import _assert_multi_tenant_tile_role
 
@@ -451,7 +444,6 @@ async def test_tile_role_guard_rejects_missing_tile_gateway(monkeypatch):
         await _assert_multi_tenant_tile_role(conn)
 
 
-@pytest.mark.asyncio
 async def test_tile_role_guard_rejects_live_superuser_session(monkeypatch):
     """A renamed/distinct superuser cannot pass the live DSN validation."""
     import asyncpg
@@ -473,7 +465,6 @@ async def test_tile_role_guard_rejects_live_superuser_session(monkeypatch):
         await conn.close()
 
 
-@pytest.mark.asyncio
 async def test_tile_role_guard_rejects_live_tenant_schema_owner(monkeypatch):
     """Gateway membership cannot make a tile login safe if it owns data."""
     import asyncpg
@@ -532,7 +523,6 @@ async def test_tile_role_guard_rejects_live_tenant_schema_owner(monkeypatch):
         await admin.close()
 
 
-@pytest.mark.asyncio
 async def test_invalidate_table_purges_only_active_tenant_keys(tile_cache, monkeypatch):
     """A tenant mutation must not evict a peer's same-named tile cache."""
     from app.core.config import settings
@@ -559,7 +549,6 @@ async def test_invalidate_table_purges_only_active_tenant_keys(tile_cache, monke
     assert await tile_cache.get("other", 1, 0, 0) == data
 
 
-@pytest.mark.asyncio
 async def test_in_memory_invalidate_table_is_tenant_scoped(monkeypatch):
     """The in-memory fallback applies the same active-tenant boundary."""
     from app.core.config import settings


### PR DESCRIPTION
De-flakes the tests behind the CI health report's merge-queue-eviction list (2026-09-04), tracked in #1859. Test-only, plus two fixes in the CI workflow. No production code changes, no schema/API/config impact.

For each test: read what it protects, then replace the wall-clock or sleep-based assertion with a deterministic one, or confirm the flake no longer reproduces because an earlier PR already fixed it.

## Fixed

`test_ingest_progress.py::test_service_worker_advances_ogr2ogr_progress_while_remote_import_is_running` polled the job row on a 1-second wall-clock deadline, opening a fresh `db_module.async_session()` every 10ms to match the heartbeat's own mocked interval. Under a loaded runner that session churn produced `ConnectionError: unexpected connection_lost() call`, which had nothing to do with the ingest logic. It now waits on an event the heartbeat tick sets when it completes, then reads the job row once. 20/20 on a repeat loop.

`test_export_artifact_cache_1532.py::test_the_artifact_is_stamped_with_the_snapshot_not_the_upload` asserted `artifact.built_at <= before + 1.0`. That 1.0s margin assumed request overhead ahead of the conversion (auth, dataset fetch, precondition checks) stays under a second, and a loaded runner can push past that without the property under test actually breaking. It now records the conversion double's own start time and compares `built_at` against that directly. 20/20 on a repeat loop.

`test_tile_cache.py` had 19 tests marked `@pytest.mark.asyncio`, which hands them to pytest-asyncio's own per-function event loop instead of the anyio-owned path the rest of the suite uses. `anyio_mode` is `"auto"` project-wide, and pyproject.toml's own comment reserves `asyncio_mode = "strict"` for an explicit asyncio-only slice, which this file isn't (`test_tile_cache_generation_key_1429.py` tests the same production module and uses no marker at all). Removed the markers. Also closed the `tile_cache` fixture's fakeredis client, which held a connection pool nothing ever released. Full file green (38/38). 19 of 20 planned `-n 4` repeat runs finished clean (722 passes, 0 failures) before the local time budget on this box ran out.

`.github/workflows/ci.yml`: the gitleaks download used a bare `curl -sSL` with no retry, so a transient GitHub Releases hiccup failed a required job in the merge_group critical path. Added `--retry 5 --retry-all-errors --retry-delay 2`, matching the retry already used for the mcp-publisher download in publish-mcp.yml.

`.github/workflows/ci.yml`: the Start PostgreSQL with PostGIS + pgvector step in cli-test, backend-test, and ai-evals builds a custom image `FROM postgis/postgis:18-3.6`. This PR's own merge-queue run (33966364665) was evicted when that pull hit `failed to fetch oauth token: ... connection reset by peer`, and the same failure hit #1858's Backend Tests the same day. Wrapped the `docker build` call in a 5-attempt retry with a 10s delay between attempts, in all three jobs. Verified the retry construct against the actual YAML-dedented script with `bash -n`, then a fake `docker` binary that fails twice and succeeds on the third call, then one that fails all five, both under `bash -eo pipefail` (the default shell for `run:` steps).

The backup-roundtrip job also starts `postgis/postgis:18-3.6`, but through a native GitHub Actions `services:` container, not a `docker build` step. Actions pulls service-container images during job setup, before any of our steps run, and the `services:` syntax has no retry option, so this fix doesn't reach it. Left alone; that job wasn't the one reported failing.

## Already fixed, left as is

Verified 20/20 on a repeat loop, no code change needed:

- `test_arcgis_signin.py::test_a_discovery_failure_takes_no_lock_and_writes_no_ledger_row`: fixed by #1786 (merged 2026-09-02), which switched from watching a process-global session factory to watching the lock helper the handler actually calls.
- `test_url_import_1705.py::TestUrlImportDegradedS3Failure::test_non_timeout_failure_bounds_its_cleanup`: fixed by #1838/#1808 (merged 2026-09-04), which freezes the router clock before the budget is derived.
- `test_auth_refresh_cookies_1302.py::TestGraceWindowCannotRatchetOpen::test_concurrent_rotations_do_not_extend_the_retirement_cutoff`: fixed by #1634, which derives the race tolerance from the stall it's meant to catch instead of a literal 1s.
- `test_embedding_backfill_queue_1542.py::test_enqueue_returns_promptly_instead_of_waiting_for_the_run`: fixed by #1778, which replaced an `elapsed < 1.0` check with an event set at the top of the mocked backfill.
- `test_export_artifact_cache_1532.py::test_two_gpkg_conversions_of_unchanged_data_are_byte_identical`: the underlying cause, SQLite's change-counter pair bumping by transaction count rather than content and so diverging between two builds of identical data under CI load, was fixed by #1641 on 2026-08-24, inside the report's own 14-day window. Also passed 3/3 under `-n 4` alongside its sibling counter tests.

Left out per the brief: `test_probe_classification.py`'s `elapsed_ms < 100` bound is also a flake, but lane SEC6 owns the probe files right now.

## Verification

From the worktree, Postgres at localhost:5434:

- `uv run pytest tests/test_ingest_progress.py tests/test_export_artifact_cache_1532.py tests/test_tile_cache.py -q`: 179 passed
- `uv run pytest tests/test_layering.py -q`: 50 passed
- `uv run ruff check . && uv run ruff format --check .`: clean across the full backend tree
- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"`: parses
- Each test item above was individually repeated 20x (19/20 for `test_tile_cache.py` under `-n 4`, which ran out of local wall-clock budget rather than failing) per the brief's method.

