### PR TITLE
test(i18n): changeLanguage in vitest never loads a non-English bundle

### DIFF
--- a/frontend/src/__tests__/i18n-locale-bundle-guard.test.ts
+++ b/frontend/src/__tests__/i18n-locale-bundle-guard.test.ts
@@ -7,7 +7,9 @@
 // only; misses a renamed import or dynamic property access.
 import { describe, expect, it } from 'vitest';
 
-const TEST_FILES = import.meta.glob('/src/**/*.test.{ts,tsx}', {
+// fix(#1866 codex r1): matches vitest's own `include` in vite.config.ts,
+// which also runs *.spec.{ts,tsx}, not just *.test.{ts,tsx}.
+const TEST_FILES = import.meta.glob('/src/**/*.{test,spec}.{ts,tsx}', {
   query: '?raw',
   import: 'default',
   eager: true,
@@ -25,7 +27,10 @@ function stripComments(source: string): string {
 
 /** True when `source` calls changeLanguage/changeAppLanguage without importing the fix helper. */
 function callsWithoutHelper(source: string): boolean {
-  return CALL_PATTERN.test(stripComments(source)) && !HELPER_IMPORT.test(source);
+  // fix(#1866 codex r1): both checks run on the same stripped text, or a
+  // commented-out import satisfies HELPER_IMPORT while a real call is missed.
+  const stripped = stripComments(source);
+  return CALL_PATTERN.test(stripped) && !HELPER_IMPORT.test(stripped);
 }
 
 const violations = Object.entries(TEST_FILES)
@@ -37,6 +42,12 @@ describe('#1866: vitest language switches must load real locale bundles', () => 
   // below pass for the wrong reason.
   it('actually scanned test files', () => {
     expect(Object.keys(TEST_FILES).length).toBeGreaterThan(50);
+  });
+
+  it('reaches a .spec.tsx file, not just .test.tsx', () => {
+    expect(
+      Object.keys(TEST_FILES).some((f) => f.endsWith('spec-glob-fixture.spec.tsx')),
+    ).toBe(true);
   });
 
   it('has no changeLanguage/changeAppLanguage call without the test helper', () => {
@@ -58,6 +69,10 @@ describe('#1866: detector fixtures', () => {
     ['bare i18n.changeLanguage', `await i18n.changeLanguage('fr');`],
     ['app changeAppLanguage', `await changeAppLanguage('fr');`],
     ['changeLanguage with no await', `i18n.changeLanguage('fr');`],
+    [
+      'a commented-out helper import beside a real direct call',
+      `// import { changeTestLanguage } from '@/test/i18n';\nawait i18n.changeLanguage('fr');`,
+    ],
   ])('flags %s with no helper import', (_name, src) => {
     expect(callsWithoutHelper(src)).toBe(true);
   });

--- a/frontend/src/__tests__/i18n-locale-bundle-guard.test.ts
+++ b/frontend/src/__tests__/i18n-locale-bundle-guard.test.ts
@@ -1,0 +1,101 @@
+// fix(#1866): structural gate for the vitest-only locale-bundle bug.
+//
+// A bare `i18n.changeLanguage(lng)`, or the app's own `changeAppLanguage(lng)`,
+// silently switches `i18n.language` under vitest without ever loading that
+// locale's strings, so `t()` keeps rendering English — see `@/test/i18n.ts`
+// for the two i18next behaviours that combine to cause it. A test that
+// switches language and asserts on `t()` output is then checking English and
+// passes as long as English also satisfies the assertion, which is exactly
+// how the FileDropzone es/fr/de sub-tests and the original heroTitle
+// "distinct singular form" test in #1863 went vacuous without failing.
+//
+// The rule: any test file that calls `changeLanguage(` or
+// `changeAppLanguage(` must also import `changeTestLanguage` from
+// `@/test/i18n`, which registers the target locale's real bundles first.
+// This is a text check, not a full AST walk (contrast
+// `web-storage-guard.test.ts`, which needs one because storage denial is a
+// security invariant with adversarial-shaped call sites). Getting the
+// language-switch helper right is a testing convention, not a security
+// boundary, so a scan for the two call names — real invocations only, an
+// immediate `(` after the identifier — is proportionate. It will not catch a
+// renamed import (`import { changeLanguage as go } from 'i18next'`) or a
+// dynamic property access; neither shows up anywhere in this codebase today,
+// and either is a bug in this file the moment one does.
+import { describe, expect, it } from 'vitest';
+
+const TEST_FILES = import.meta.glob('/src/**/*.test.{ts,tsx}', {
+  query: '?raw',
+  import: 'default',
+  eager: true,
+}) as Record<string, string>;
+
+// A named import of the helper, from any specifier — `@/test/i18n` from most
+// files, `./i18n` from the co-located `src/test/i18n.test.ts`. Matching the
+// imported NAME rather than a hardcoded path is what makes both work.
+const HELPER_IMPORT = /\bimport\s*\{[^}]*\bchangeTestLanguage\b[^}]*\}\s*from/;
+const CALL_PATTERN = /\b(?:changeLanguage|changeAppLanguage)\(/;
+
+/** True when `source` calls changeLanguage/changeAppLanguage without importing the fix helper. */
+function callsWithoutHelper(source: string): boolean {
+  return CALL_PATTERN.test(source) && !HELPER_IMPORT.test(source);
+}
+
+const violations = Object.entries(TEST_FILES)
+  .filter(([, source]) => callsWithoutHelper(source))
+  .map(([file]) => file);
+
+describe('#1866: vitest language switches must load real locale bundles', () => {
+  // Vacuity guard: a glob that silently matched nothing would make the check
+  // below pass for the wrong reason.
+  it('actually scanned test files', () => {
+    expect(Object.keys(TEST_FILES).length).toBeGreaterThan(50);
+  });
+
+  it('has no changeLanguage/changeAppLanguage call without the test helper', () => {
+    expect(
+      violations,
+      violations.length === 0
+        ? ''
+        : `These test files call changeLanguage/changeAppLanguage directly, which ` +
+            `switches i18n.language without loading that locale's bundles under ` +
+            `vitest (t() keeps rendering English):\n${violations.map((f) => `  ${f}`).join('\n')}\n\n` +
+            `Import changeTestLanguage from '@/test/i18n' and use it instead of a ` +
+            `bare changeLanguage/changeAppLanguage call.`,
+    ).toEqual([]);
+  });
+});
+
+describe('#1866: detector fixtures', () => {
+  it.each([
+    ['bare i18n.changeLanguage', `await i18n.changeLanguage('fr');`],
+    ['app changeAppLanguage', `await changeAppLanguage('fr');`],
+    ['changeLanguage with no await', `i18n.changeLanguage('fr');`],
+  ])('flags %s with no helper import', (_name, src) => {
+    expect(callsWithoutHelper(src)).toBe(true);
+  });
+
+  it('flags changeLanguage even when the helper is imported for something else in the same file, if the call itself is not through it', () => {
+    // The gate cannot tell WHICH call site used the helper — it only checks
+    // that the file imports it at all. A file mixing a helper-backed switch
+    // with a stray bare call is a real gap; documented here rather than
+    // silently assumed away.
+    const src = `import { changeTestLanguage } from '@/test/i18n';\nawait i18n.changeLanguage('fr');`;
+    expect(callsWithoutHelper(src)).toBe(false);
+  });
+
+  it('does not flag a call routed through the helper', () => {
+    const src = `import { changeTestLanguage } from '@/test/i18n';\nawait changeTestLanguage('fr');`;
+    expect(callsWithoutHelper(src)).toBe(false);
+  });
+
+  it('does not flag a file with no language switch at all', () => {
+    expect(callsWithoutHelper(`const x = 1;`)).toBe(false);
+  });
+
+  it('does not flag a mock declaration that merely names changeAppLanguage', () => {
+    // No `(` immediately after the identifier, so this is a property key,
+    // not an invocation — matches src/pages/__tests__/SettingsPage.a11y.test.tsx.
+    const src = `vi.mock('@/i18n', () => ({ changeAppLanguage: vi.fn() }));`;
+    expect(callsWithoutHelper(src)).toBe(false);
+  });
+});

--- a/frontend/src/__tests__/i18n-locale-bundle-guard.test.ts
+++ b/frontend/src/__tests__/i18n-locale-bundle-guard.test.ts
@@ -1,26 +1,10 @@
-// fix(#1866): structural gate for the vitest-only locale-bundle bug.
+// fix(#1866): a test file calling changeLanguage(/changeAppLanguage( must
+// also import changeTestLanguage from @/test/i18n, or t() silently renders
+// English under vitest instead of the target locale.
 //
-// A bare `i18n.changeLanguage(lng)`, or the app's own `changeAppLanguage(lng)`,
-// silently switches `i18n.language` under vitest without ever loading that
-// locale's strings, so `t()` keeps rendering English — see `@/test/i18n.ts`
-// for the two i18next behaviours that combine to cause it. A test that
-// switches language and asserts on `t()` output is then checking English and
-// passes as long as English also satisfies the assertion, which is exactly
-// how the FileDropzone es/fr/de sub-tests and the original heroTitle
-// "distinct singular form" test in #1863 went vacuous without failing.
-//
-// The rule: any test file that calls `changeLanguage(` or
-// `changeAppLanguage(` must also import `changeTestLanguage` from
-// `@/test/i18n`, which registers the target locale's real bundles first.
-// This is a text check, not a full AST walk (contrast
-// `web-storage-guard.test.ts`, which needs one because storage denial is a
-// security invariant with adversarial-shaped call sites). Getting the
-// language-switch helper right is a testing convention, not a security
-// boundary, so a scan for the two call names — real invocations only, an
-// immediate `(` after the identifier — is proportionate. It will not catch a
-// renamed import (`import { changeLanguage as go } from 'i18next'`) or a
-// dynamic property access; neither shows up anywhere in this codebase today,
-// and either is a bug in this file the moment one does.
+// Text check, not an AST walk (contrast web-storage-guard.test.ts): this is
+// a testing convention, not a security boundary. Flags a real invocation
+// only; misses a renamed import or dynamic property access.
 import { describe, expect, it } from 'vitest';
 
 const TEST_FILES = import.meta.glob('/src/**/*.test.{ts,tsx}', {
@@ -29,15 +13,19 @@ const TEST_FILES = import.meta.glob('/src/**/*.test.{ts,tsx}', {
   eager: true,
 }) as Record<string, string>;
 
-// A named import of the helper, from any specifier — `@/test/i18n` from most
-// files, `./i18n` from the co-located `src/test/i18n.test.ts`. Matching the
-// imported NAME rather than a hardcoded path is what makes both work.
+// A named import of the helper, from any specifier (alias or relative).
 const HELPER_IMPORT = /\bimport\s*\{[^}]*\bchangeTestLanguage\b[^}]*\}\s*from/;
 const CALL_PATTERN = /\b(?:changeLanguage|changeAppLanguage)\(/;
 
+// fix(#1866): strips // and /* */ comments before matching CALL_PATTERN, so
+// prose mentioning `i18n.changeLanguage('fr')` isn't read as a real call.
+function stripComments(source: string): string {
+  return source.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/.*$/gm, '');
+}
+
 /** True when `source` calls changeLanguage/changeAppLanguage without importing the fix helper. */
 function callsWithoutHelper(source: string): boolean {
-  return CALL_PATTERN.test(source) && !HELPER_IMPORT.test(source);
+  return CALL_PATTERN.test(stripComments(source)) && !HELPER_IMPORT.test(source);
 }
 
 const violations = Object.entries(TEST_FILES)
@@ -74,11 +62,9 @@ describe('#1866: detector fixtures', () => {
     expect(callsWithoutHelper(src)).toBe(true);
   });
 
-  it('flags changeLanguage even when the helper is imported for something else in the same file, if the call itself is not through it', () => {
-    // The gate cannot tell WHICH call site used the helper — it only checks
-    // that the file imports it at all. A file mixing a helper-backed switch
-    // with a stray bare call is a real gap; documented here rather than
-    // silently assumed away.
+  it('does not flag a stray bare call once the file imports the helper for something else', () => {
+    // Known gap: the gate checks only that the file imports the helper,
+    // not that each call site uses it.
     const src = `import { changeTestLanguage } from '@/test/i18n';\nawait i18n.changeLanguage('fr');`;
     expect(callsWithoutHelper(src)).toBe(false);
   });
@@ -94,8 +80,15 @@ describe('#1866: detector fixtures', () => {
 
   it('does not flag a mock declaration that merely names changeAppLanguage', () => {
     // No `(` immediately after the identifier, so this is a property key,
-    // not an invocation — matches src/pages/__tests__/SettingsPage.a11y.test.tsx.
+    // not an invocation.
     const src = `vi.mock('@/i18n', () => ({ changeAppLanguage: vi.fn() }));`;
+    expect(callsWithoutHelper(src)).toBe(false);
+  });
+
+  it('does not flag a comment that only mentions changeLanguage in prose', () => {
+    // Real case: complete-heroTitle-plural.test.ts's comment explains why
+    // `i18n.changeLanguage('fr')` doesn't work, without ever calling it.
+    const src = `// i18n.changeLanguage('fr') can't reach t() in this suite.\nconst x = 1;`;
     expect(callsWithoutHelper(src)).toBe(false);
   });
 });

--- a/frontend/src/__tests__/spec-glob-fixture.spec.tsx
+++ b/frontend/src/__tests__/spec-glob-fixture.spec.tsx
@@ -1,0 +1,17 @@
+// fix(#1866 codex r1): a real .spec.tsx file, proving the guard's glob
+// reaches vitest's *.spec.{ts,tsx} convention, not only *.test.{ts,tsx}.
+import { afterEach, describe, expect, it } from 'vitest';
+import i18n from 'i18next';
+
+import { changeTestLanguage } from '@/test/i18n';
+
+describe('spec-glob-fixture', () => {
+  afterEach(async () => {
+    await i18n.changeLanguage('en');
+  });
+
+  it('uses changeTestLanguage, so this file must never trip the guard', async () => {
+    await changeTestLanguage('fr');
+    expect(i18n.language).toBe('fr');
+  });
+});

--- a/frontend/src/components/import/__tests__/FileDropzone.test.tsx
+++ b/frontend/src/components/import/__tests__/FileDropzone.test.tsx
@@ -7,7 +7,18 @@
 // bundles so a locale regression shows up as a literal duplicate substring.
 import i18n from 'i18next';
 import { render, screen } from '@/test/test-utils';
+import { changeTestLanguage } from '@/test/i18n';
 import { FileDropzone } from '../FileDropzone';
+import type { SupportedLng } from '@/i18n/config';
+
+// fix(#1866): the real, non-English browse word per locale, proving
+// changeTestLanguage loaded the bundle instead of falling back to English.
+const NON_ENGLISH_LOCALES: Exclude<SupportedLng, 'en'>[] = ['es', 'fr', 'de'];
+const NON_ENGLISH_BROWSE_WORD: Record<Exclude<SupportedLng, 'en'>, string> = {
+  es: 'Examinar',
+  fr: 'Parcourir',
+  de: 'Durchsuchen',
+};
 
 function composedInstructions(): string {
   // The heading text is split across a plain text node and a bolded <span>
@@ -31,14 +42,15 @@ describe('FileDropzone instructions text (#1853)', () => {
     expect(text.match(/browse/gi)).toHaveLength(1);
   });
 
-  it.each(['es', 'fr', 'de'])('does not repeat the browse verb in %s', async (lng) => {
-    await i18n.changeLanguage(lng);
+  it.each(NON_ENGLISH_LOCALES)('does not repeat the browse verb in %s', async (lng) => {
+    await changeTestLanguage(lng);
     render(<FileDropzone onFilesAccepted={() => {}} />);
 
     const text = composedInstructions();
     const browseWord = i18n.t('import:dropzone.browse');
-    // Count occurrences of the locale's own browse word — the pre-fix bug
-    // was a literal duplicate of it (once from `instructions`, once bolded).
+    expect(browseWord).toBe(NON_ENGLISH_BROWSE_WORD[lng]);
+    // The pre-fix bug duplicated the locale's own browse word (once from
+    // `instructions`, once bolded).
     const occurrences = text.split(browseWord).length - 1;
     expect(occurrences).toBe(1);
   });

--- a/frontend/src/test/i18n.test.ts
+++ b/frontend/src/test/i18n.test.ts
@@ -15,10 +15,8 @@ describe('#1866: changeTestLanguage loads real locale bundles', () => {
   });
 
   it('switches between two non-English, non-fallback locales', async () => {
-    // Registering a SECOND locale exercises the branch where the resource
-    // store's data[lng] key already exists from a previous call — the case
-    // that does not need the frozen-object workaround, only the ordinary
-    // addResourceBundle path.
+    // fix(#1866): a second locale exercises the plain addResourceBundle
+    // path (data[lng] already exists), not just the placeholder branch.
     await changeTestLanguage('de');
     expect(i18n.t('import:dropzone.browse')).toBe('Durchsuchen');
 

--- a/frontend/src/test/i18n.test.ts
+++ b/frontend/src/test/i18n.test.ts
@@ -38,4 +38,17 @@ describe('#1866: changeTestLanguage loads real locale bundles', () => {
     expect(i18n.language).toBe('en');
     expect(i18n.t('import:dropzone.browse')).toBe('browse');
   });
+
+  it('leaves the fallback map frozen after a round trip', async () => {
+    // The short-circuit fixes the throw by never touching the fallback
+    // map at all, rather than by cloning or unfreezing it. Pins that the
+    // freeze complete-heroTitle-plural.test.ts relies on is still real.
+    await changeTestLanguage('de');
+    await changeTestLanguage('en');
+    const store = i18n.services.resourceStore;
+    expect(Object.isFrozen(store.data.en)).toBe(true);
+    expect(() => {
+      store.data.en.common = {};
+    }).toThrow(TypeError);
+  });
 });

--- a/frontend/src/test/i18n.test.ts
+++ b/frontend/src/test/i18n.test.ts
@@ -29,4 +29,13 @@ describe('#1866: changeTestLanguage loads real locale bundles', () => {
     await i18n.changeLanguage('en');
     expect(i18n.t('import:dropzone.browse')).toBe('browse');
   });
+
+  it('switches back to English through the helper without throwing', async () => {
+    // fix(#1866 codex r2): English's bundle is already loaded and frozen,
+    // so registering it again (instead of just switching) used to throw.
+    await changeTestLanguage('de');
+    await expect(changeTestLanguage('en')).resolves.toBeUndefined();
+    expect(i18n.language).toBe('en');
+    expect(i18n.t('import:dropzone.browse')).toBe('browse');
+  });
 });

--- a/frontend/src/test/i18n.test.ts
+++ b/frontend/src/test/i18n.test.ts
@@ -1,0 +1,34 @@
+import i18n from 'i18next';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { changeTestLanguage } from './i18n';
+
+describe('#1866: changeTestLanguage loads real locale bundles', () => {
+  afterEach(async () => {
+    await i18n.changeLanguage('en');
+  });
+
+  it('switches to a real, translated string rather than the English fallback', async () => {
+    await changeTestLanguage('fr');
+    expect(i18n.language).toBe('fr');
+    expect(i18n.t('import:dropzone.browse')).toBe('Parcourir');
+  });
+
+  it('switches between two non-English, non-fallback locales', async () => {
+    // Registering a SECOND locale exercises the branch where the resource
+    // store's data[lng] key already exists from a previous call — the case
+    // that does not need the frozen-object workaround, only the ordinary
+    // addResourceBundle path.
+    await changeTestLanguage('de');
+    expect(i18n.t('import:dropzone.browse')).toBe('Durchsuchen');
+
+    await changeTestLanguage('fr');
+    expect(i18n.t('import:dropzone.browse')).toBe('Parcourir');
+  });
+
+  it('does not leak a registered locale into English', async () => {
+    await changeTestLanguage('fr');
+    await i18n.changeLanguage('en');
+    expect(i18n.t('import:dropzone.browse')).toBe('browse');
+  });
+});

--- a/frontend/src/test/i18n.ts
+++ b/frontend/src/test/i18n.ts
@@ -1,6 +1,6 @@
 import i18n from 'i18next';
 
-import { namespaces } from '@/i18n/config';
+import { fallbackLng, namespaces } from '@/i18n/config';
 import { loadLocaleResources } from '@/i18n/resources';
 import type { SupportedLng } from '@/i18n/config';
 
@@ -11,9 +11,16 @@ import type { SupportedLng } from '@/i18n/config';
  * A bare `i18n.changeLanguage` or `changeAppLanguage` switches
  * `i18n.language` under vitest without ever loading the target locale, so
  * `t()` keeps rendering English (#1866). Use this instead in any test that
- * switches language.
+ * switches language, including back to English.
  */
 export async function changeTestLanguage(lng: SupportedLng): Promise<void> {
+  // fix(#1866 codex r2): the fallback locale's bundles are already loaded
+  // (and frozen), so registering them again throws; just switch to it.
+  if (lng === fallbackLng) {
+    await i18n.changeLanguage(lng);
+    return;
+  }
+
   const store = i18n.services.resourceStore;
   if (!store.data[lng]) {
     store.data = { ...store.data, [lng]: {} };

--- a/frontend/src/test/i18n.ts
+++ b/frontend/src/test/i18n.ts
@@ -5,32 +5,13 @@ import { loadLocaleResources } from '@/i18n/resources';
 import type { SupportedLng } from '@/i18n/config';
 
 /**
- * Switches the running test i18next instance to `lng`, registering its
- * locale bundles first.
+ * Switches the running test i18next instance to `lng`, loading that
+ * locale's real bundles first.
  *
- * A bare `i18n.changeLanguage(lng)`, or the app's own `changeAppLanguage`,
- * silently switches `i18n.language` without ever loading that locale's
- * strings under vitest, so `t()` keeps rendering English and a
- * locale-labelled assertion passes as long as English also satisfies it
- * (#1866). Two things combine to cause it:
- *
- * 1. `i18n.hasLoadedNamespace(ns, { lng })` reports a namespace as loaded
- *    through the `en` fallback chain even when `lng` was never added, so
- *    `changeAppLanguage`'s own `!hasLoadedNamespace(...)` guard never runs
- *    and it never calls `addResourceBundle`.
- * 2. The test i18next instance is initialized with the exact frozen object
- *    `src/i18n/resources.ts` exports (i18next stores the `resources` init
- *    option by reference, not by copy — see `ResourceStore`'s
- *    constructor). Registering a locale that was never in that object
- *    means adding a brand-new top-level key, which `Object.freeze` blocks
- *    even through `i18n.addResourceBundle`: it throws
- *    "Cannot add property <lng>, object is not extensible".
- *
- * This works around both: the first time a locale is requested, it
- * replaces the resource store's `data` with a shallow copy carrying an
- * empty, non-frozen placeholder for `lng`, so the write no longer touches
- * the frozen root. Every call after that lands through the ordinary
- * `addResourceBundle` path.
+ * A bare `i18n.changeLanguage` or `changeAppLanguage` switches
+ * `i18n.language` under vitest without ever loading the target locale, so
+ * `t()` keeps rendering English (#1866). Use this instead in any test that
+ * switches language.
  */
 export async function changeTestLanguage(lng: SupportedLng): Promise<void> {
   const store = i18n.services.resourceStore;

--- a/frontend/src/test/i18n.ts
+++ b/frontend/src/test/i18n.ts
@@ -1,0 +1,47 @@
+import i18n from 'i18next';
+
+import { namespaces } from '@/i18n/config';
+import { loadLocaleResources } from '@/i18n/resources';
+import type { SupportedLng } from '@/i18n/config';
+
+/**
+ * Switches the running test i18next instance to `lng`, registering its
+ * locale bundles first.
+ *
+ * A bare `i18n.changeLanguage(lng)`, or the app's own `changeAppLanguage`,
+ * silently switches `i18n.language` without ever loading that locale's
+ * strings under vitest, so `t()` keeps rendering English and a
+ * locale-labelled assertion passes as long as English also satisfies it
+ * (#1866). Two things combine to cause it:
+ *
+ * 1. `i18n.hasLoadedNamespace(ns, { lng })` reports a namespace as loaded
+ *    through the `en` fallback chain even when `lng` was never added, so
+ *    `changeAppLanguage`'s own `!hasLoadedNamespace(...)` guard never runs
+ *    and it never calls `addResourceBundle`.
+ * 2. The test i18next instance is initialized with the exact frozen object
+ *    `src/i18n/resources.ts` exports (i18next stores the `resources` init
+ *    option by reference, not by copy — see `ResourceStore`'s
+ *    constructor). Registering a locale that was never in that object
+ *    means adding a brand-new top-level key, which `Object.freeze` blocks
+ *    even through `i18n.addResourceBundle`: it throws
+ *    "Cannot add property <lng>, object is not extensible".
+ *
+ * This works around both: the first time a locale is requested, it
+ * replaces the resource store's `data` with a shallow copy carrying an
+ * empty, non-frozen placeholder for `lng`, so the write no longer touches
+ * the frozen root. Every call after that lands through the ordinary
+ * `addResourceBundle` path.
+ */
+export async function changeTestLanguage(lng: SupportedLng): Promise<void> {
+  const store = i18n.services.resourceStore;
+  if (!store.data[lng]) {
+    store.data = { ...store.data, [lng]: {} };
+  }
+
+  const localeResources = await loadLocaleResources(lng);
+  for (const ns of namespaces) {
+    i18n.addResourceBundle(lng, ns, localeResources[ns], true, true);
+  }
+
+  await i18n.changeLanguage(lng);
+}


### PR DESCRIPTION
Fixes #1866. Test-only, no production code changes, no schema/API/config impact.

The vitest i18next instance loads only English eagerly (the frozen `resources` object in `frontend/src/i18n/resources.ts`). Neither a bare `i18n.changeLanguage(lng)` nor the app's own `changeAppLanguage(lng)` ever loads a real bundle for another locale under vitest, so a test that switches language and asserts on `t()` output is checking English and passes as long as English also satisfies the assertion.

I confirmed the exact mechanism against the real i18next build in this repo rather than assuming it from the docs. Two things combine to cause it:

1. `i18n.hasLoadedNamespace(ns, { lng })` reports every namespace loaded through the English fallback chain regardless of `lng`, so `changeAppLanguage`'s own `!hasLoadedNamespace(...)` guard against re-registering never runs, and it never calls `addResourceBundle`.
2. i18next stores the `resources` init option by reference, not by copy (`ResourceStore`'s constructor does `this.data = data`). The test instance is initialized with the exact frozen object `resources.ts` exports. Registering a locale that was never in that object means adding a brand-new top-level key, and `Object.freeze` blocks that even through `i18n.addResourceBundle`, which throws `Cannot add property fr, object is not extensible`.

## The fix

`frontend/src/test/i18n.ts` adds `changeTestLanguage(lng)`, which works around both: the first time a locale is requested it replaces the resource store's `data` with a shallow copy carrying an empty, non-frozen placeholder for that locale (so the write no longer touches the frozen root), then registers the real bundles through the ordinary `addResourceBundle` path, then switches to it.

`frontend/src/test/i18n.test.ts` pins the fix with a direct regression test asserting real translated content (`Parcourir`, `Durchsuchen`), not just that `i18n.language` changed. I proved it's not vacuous by temporarily reverting `changeTestLanguage` to a bare `i18n.changeLanguage` call, confirming the test goes red (`expected 'browse' to be 'Parcourir'`), then restoring it.

`frontend/src/__tests__/i18n-locale-bundle-guard.test.ts` is a structural gate, the same shape as `web-storage-guard.test.ts`: it scans every `*.test.{ts,tsx}` file under `src/` and fails any file that calls `changeLanguage(` or `changeAppLanguage(` without also importing `changeTestLanguage`. It's a text check rather than a full AST walk, since this is a testing convention rather than a security boundary, and that's stated in the file's own comment along with what it can't catch (a renamed import, a dynamic property access). It carries its own detector fixtures, including one pinning that a mock declaration like `vi.mock('@/i18n', () => ({ changeAppLanguage: vi.fn() }))` is not a real call and doesn't false-positive.

I picked the test-helper option over eagerly loading all four locales in the vitest setup file. Loading all locales globally would cost real time on every one of the 449 test files in this suite, whether or not that file touches i18n at all, for no benefit to the ~447 that don't.

## The two named tests

The issue names two vacuous tests: the FileDropzone es/fr/de sub-tests and the original heroTitle "distinct singular form" test, both from PR #1863. #1863 was still open when this PR was first opened, so neither file existed on main yet; it has since merged and this branch is rebased past it.

- `FileDropzone.test.tsx`'s `it.each(['es', 'fr', 'de'])` sub-test now uses `changeTestLanguage` and asserts the real translated browse word per locale (`Examinar`, `Parcourir`, `Durchsuchen`) instead of comparing the locale's own word to itself.
- The heroTitle "distinct singular form" test already reads the locale JSON bundles directly instead of driving them through i18next (its own comment documents the same root cause this PR fixes). It's not vacuous and needed no change.

Rebasing past #1863 also surfaced a false positive in the structural gate: it matched `changeLanguage(`/`changeAppLanguage(` inside a comment, which flagged `complete-heroTitle-plural.test.ts`'s own prose explaining the bug even though the file makes no such call. Fixed by stripping comments before matching, with a fixture pinning that exact case.

## Comments

Per the house rule added after this PR's first version: inline comments trimmed to anchor plus invariant, three lines at most, in every file this PR touches. Review history and rejected alternatives (the investigation into `hasLoadedNamespace` and the frozen `ResourceStore.data` reference) live in this PR body rather than in `frontend/src/test/i18n.ts`'s docstring, which now states only the contract and the one trap a caller must know.

## Verification

From the worktree, rebased onto main at 95a80e88d:

- `npx vitest run src/test/i18n.test.ts src/__tests__/i18n-locale-bundle-guard.test.ts src/components/import/__tests__/FileDropzone.test.tsx`: 17 passed
- `npx vitest run` (full suite): 453 files, 5983 tests passed
- `npm run typecheck`: clean
- `npm run lint`: clean
- `npm run test:i18n`: clean (source-key check plus `resources.test.ts`, 4 passed)
- Counterfactual: reverting `changeTestLanguage` to a bare `changeLanguage` call turns the regression test red with the exact wrong-language assertion failure, confirming it isn't a vacuous pass itself.

