### PR TITLE
docs(agents): keep inline review comments to the anchor and the invariant

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,11 +66,13 @@ Frontend code uses TypeScript, React, ESLint, React Hooks rules, and JSX accessi
 
 ### Inline review-comment convention
 
-When an in-source comment references a finding from a code review or audit, anchor it to a stable, lookup-able reference (a PR or issue number) plus a one-line context, so future readers can find the rationale:
+When an in-source comment references a finding from a code review or audit, anchor it to a stable, lookup-able reference (a PR or issue number) plus the invariant the code now holds, so future readers can find the rationale:
 
 ```
 // fix(#1234): suppress basemap row click during multi-selection
 ```
+
+Keep it to the anchor and the invariant, three lines at most. The history behind it (what the review said, what was tried, which alternative was rejected and why) goes in the PR body or the issue the anchor names, not in the source. Docstrings state the contract (inputs, outputs, errors, the one trap a caller must know) and do not carry review history either. Do not write a comment that restates what the next line does. When you edit a file, trim any comment you touch to this rule.
 
 Avoid bare, unscoped finding ids that only resolve in a private tracker.
 


### PR DESCRIPTION
Amends the inline review-comment convention in AGENTS.md: a comment carries the anchor and the invariant in at most three lines; review history, rejected alternatives and narrative go in the PR body or the anchored issue; docstrings state the contract; no comment restates the next line; a comment you touch is trimmed to the rule.

Why now: measured on main at b7478cc7a, comments and docstrings are 35% of the backend's non-blank lines and about 47% of its characters, and 46% of inline comment lines sit in blocks of eight or more consecutive lines. A dozen files are more than half prose. That is paid on every file read by a reviewer, a lane or codex, and it was the substance of a public review of the codebase on 2026-09-05. This PR changes the rule so the volume stops growing; a measured cleanup of the largest files is a separate, later change so no behaviour-free diff sits in the queue this week.

No code change. Verification: the file renders; the example line is unchanged.
