### PR TITLE
fix(dataset): await origin refetch before enabling reupload retry

### DIFF
--- a/frontend/src/components/dataset/ReuploadDialog.tsx
+++ b/frontend/src/components/dataset/ReuploadDialog.tsx
@@ -152,6 +152,10 @@ export function ReuploadDialog({
   // it to `upload` and sever that binding, so the server refuses the commit
   // when the origin it reads is no longer this one.
   const [stagedOriginKind, setStagedOriginKind] = useState<DatasetOrigin | null>(null);
+  // fix(#1822): gate "Try Again" on a landed post-refusal refetch (see
+  // handleConfirm's catch block), not just the refusal itself.
+  const [isRefreshingOrigin, setIsRefreshingOrigin] = useState(false);
+  const [originRefreshFailed, setOriginRefreshFailed] = useState(false);
   const [preview, setPreview] = useState<ReuploadPreviewResponse | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [selectedFile, setSelectedFile] = useState<File | null>(null);
@@ -186,6 +190,8 @@ export function ReuploadDialog({
     setSourceType(null);
     setJobId(null);
     setStagedOriginKind(null);
+    setIsRefreshingOrigin(false);
+    setOriginRefreshFailed(false);
     setPreview(null);
     setError(null);
     setSelectedFile(null);
@@ -480,16 +486,6 @@ export function ReuploadDialog({
       });
       setStep('tracking');
     } catch (err) {
-      // fix(#1768 round 1): an `origin_changed` refusal is proof that the
-      // `dataset` prop this dialog captured from is stale — the server just
-      // read an origin the cache is not serving. Without this, `handleRetry`
-      // clears the captured origin and the next staging re-captures the SAME
-      // stale value from the unchanged prop, so the refusal's own "start the
-      // replacement again" advice 409s forever until a manual reload. Fired
-      // here in the catch, ahead of every path that can stage another job.
-      if (isOriginChangedError(err)) {
-        queryClient.invalidateQueries({ queryKey: queryKeys.datasets.detail(dataset.id) });
-      }
       const message = err instanceof Error ? err.message : t('reupload.commitFailed');
       setError(
         sourceType === 'service_url'
@@ -497,6 +493,29 @@ export function ReuploadDialog({
           : message,
       );
       setStep('error');
+
+      // fix(#1768, #1822): origin_changed means `dataset.origin` is stale;
+      // await a refetch (throwOnError) before re-enabling retry so it can't
+      // resend the same stale value.
+      if (isOriginChangedError(err)) {
+        setIsRefreshingOrigin(true);
+        try {
+          await queryClient.refetchQueries(
+            { queryKey: queryKeys.datasets.detail(dataset.id) },
+            { throwOnError: true },
+          );
+        } catch {
+          setOriginRefreshFailed(true);
+          setError(
+            t('reupload.originRefreshFailed', {
+              defaultValue:
+                "Could not refresh the dataset's info after this conflict. Reload the page and try again.",
+            }),
+          );
+        } finally {
+          setIsRefreshingOrigin(false);
+        }
+      }
     }
   }, [dataset.id, jobId, stagedOriginKind, sourceType, serviceToken, selectedFileLayer, commitMutation, queryClient, appendRetryGuidance, t]);
 
@@ -505,6 +524,9 @@ export function ReuploadDialog({
     setPreview(null);
     setJobId(null);
     setStagedOriginKind(null);
+    // fix(#1822): reset for a second origin_changed round in this session.
+    setIsRefreshingOrigin(false);
+    setOriginRefreshFailed(false);
     if (sourceType === 'service_url') {
       setProbeResult(null);
       setSelectedLayer(null);
@@ -1078,8 +1100,17 @@ export function ReuploadDialog({
               {error ?? t('reupload.errorFallback')}
             </p>
             <DialogFooter className="w-full">
-              <Button variant="outline" onClick={handleRetry}>
-                {t('reupload.tryAgain')}
+              {/* fix(#1822): disabled while the origin refetch is pending,
+                  and permanently if it fails. */}
+              <Button
+                variant="outline"
+                onClick={handleRetry}
+                disabled={isRefreshingOrigin || originRefreshFailed}
+                data-testid="reupload-try-again"
+              >
+                {isRefreshingOrigin
+                  ? t('reupload.refreshingOrigin', { defaultValue: 'Refreshing...' })
+                  : t('reupload.tryAgain')}
               </Button>
               <Button onClick={() => handleOpenChange(false)}>{t('common:close')}</Button>
             </DialogFooter>

--- a/frontend/src/components/dataset/ReuploadDialog.tsx
+++ b/frontend/src/components/dataset/ReuploadDialog.tsx
@@ -507,6 +507,10 @@ export function ReuploadDialog({
         const generation = ++refreshGenerationRef.current;
         setIsRefreshingOrigin(true);
         try {
+          // fix(#1822 review P2 round 3): fetchQuery dedupes onto an
+          // already in-flight fetch for this key (e.g. a window-focus
+          // refetch) instead of running ours, so cancel it first.
+          await queryClient.cancelQueries({ queryKey: queryKeys.datasets.detail(dataset.id) });
           await queryClient.fetchQuery({
             queryKey: queryKeys.datasets.detail(dataset.id),
             queryFn: () => getDataset(dataset.id),

--- a/frontend/src/components/dataset/ReuploadDialog.tsx
+++ b/frontend/src/components/dataset/ReuploadDialog.tsx
@@ -37,7 +37,7 @@ import { Globe, Loader2, CheckCircle2, AlertCircle, Upload } from 'lucide-react'
 import { toast } from 'sonner';
 import { probeService } from '@/api/ingest';
 import { ApiError } from '@/api/client';
-import { reuploadPresigned } from '@/api/datasets';
+import { reuploadPresigned, getDataset } from '@/api/datasets';
 import { getGeometryTypeLabel } from '@/i18n/labels';
 import { formatNumber } from '@/lib/format';
 import type {
@@ -500,17 +500,18 @@ export function ReuploadDialog({
       );
       setStep('error');
 
-      // fix(#1768, #1822): origin_changed means `dataset.origin` is stale;
-      // await a refetch (throwOnError) before re-enabling retry so it can't
-      // resend the same stale value.
+      // fix(#1768, #1822): dataset.origin is stale; wait for a landed fetch
+      // (fetchQuery, not refetchQueries, which resolves early when paused)
+      // before re-enabling retry.
       if (isOriginChangedError(err)) {
         const generation = ++refreshGenerationRef.current;
         setIsRefreshingOrigin(true);
         try {
-          await queryClient.refetchQueries(
-            { queryKey: queryKeys.datasets.detail(dataset.id) },
-            { throwOnError: true },
-          );
+          await queryClient.fetchQuery({
+            queryKey: queryKeys.datasets.detail(dataset.id),
+            queryFn: () => getDataset(dataset.id),
+            staleTime: 0,
+          });
         } catch {
           // fix(#1822 review P2): a reset (dialog closed) or a newer attempt
           // bumped the generation — this completion is orphaned, ignore it.

--- a/frontend/src/components/dataset/ReuploadDialog.tsx
+++ b/frontend/src/components/dataset/ReuploadDialog.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useMemo, type FormEvent } from 'react';
+import { useState, useEffect, useCallback, useMemo, useRef, type FormEvent } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useDropzone } from 'react-dropzone';
 import { useQueryClient } from '@tanstack/react-query';
@@ -156,6 +156,9 @@ export function ReuploadDialog({
   // handleConfirm's catch block), not just the refusal itself.
   const [isRefreshingOrigin, setIsRefreshingOrigin] = useState(false);
   const [originRefreshFailed, setOriginRefreshFailed] = useState(false);
+  // fix(#1822 review P2): stale-completion guard for the refetch above — see
+  // handleConfirm and resetState.
+  const refreshGenerationRef = useRef(0);
   const [preview, setPreview] = useState<ReuploadPreviewResponse | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [selectedFile, setSelectedFile] = useState<File | null>(null);
@@ -192,6 +195,9 @@ export function ReuploadDialog({
     setStagedOriginKind(null);
     setIsRefreshingOrigin(false);
     setOriginRefreshFailed(false);
+    // fix(#1822 review P2): orphans any refetch still in flight from before
+    // this reset (e.g. the dialog was closed mid-refetch).
+    refreshGenerationRef.current += 1;
     setPreview(null);
     setError(null);
     setSelectedFile(null);
@@ -498,6 +504,7 @@ export function ReuploadDialog({
       // await a refetch (throwOnError) before re-enabling retry so it can't
       // resend the same stale value.
       if (isOriginChangedError(err)) {
+        const generation = ++refreshGenerationRef.current;
         setIsRefreshingOrigin(true);
         try {
           await queryClient.refetchQueries(
@@ -505,15 +512,21 @@ export function ReuploadDialog({
             { throwOnError: true },
           );
         } catch {
-          setOriginRefreshFailed(true);
-          setError(
-            t('reupload.originRefreshFailed', {
-              defaultValue:
-                "Could not refresh the dataset's info after this conflict. Reload the page and try again.",
-            }),
-          );
+          // fix(#1822 review P2): a reset (dialog closed) or a newer attempt
+          // bumped the generation — this completion is orphaned, ignore it.
+          if (generation === refreshGenerationRef.current) {
+            setOriginRefreshFailed(true);
+            setError(
+              t('reupload.originRefreshFailed', {
+                defaultValue:
+                  "Could not refresh the dataset's info after this conflict. Reload the page and try again.",
+              }),
+            );
+          }
         } finally {
-          setIsRefreshingOrigin(false);
+          if (generation === refreshGenerationRef.current) {
+            setIsRefreshingOrigin(false);
+          }
         }
       }
     }

--- a/frontend/src/components/dataset/__tests__/ReuploadDialog.test.tsx
+++ b/frontend/src/components/dataset/__tests__/ReuploadDialog.test.tsx
@@ -880,6 +880,67 @@ describe('ReuploadDialog', () => {
       onlineManager.setOnline(true);
     }
   });
+
+  // fix(#1822 review P2 round 3): a fetch already in flight for this key
+  // (e.g. window-focus) must not let its stale resolution govern retry.
+  it('cancels an in-flight detail fetch first, so the recovery never resolves with the stale value', async () => {
+    const user = userEvent.setup();
+    commitMutateAsync.mockRejectedValueOnce(
+      new ApiError('This dataset’s source changed', 409, {
+        code: 'origin_changed',
+        origin_kind: 'service',
+        expected_origin_kind: 'upload',
+      }),
+    );
+
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, gcTime: 0 }, mutations: { retry: false } },
+    });
+
+    let resolveFirst: (v: DatasetResponse) => void = () => {};
+    let resolveSecond: (v: DatasetResponse) => void = () => {};
+    mockGetDataset
+      .mockImplementationOnce(() => new Promise((resolve) => { resolveFirst = resolve; }))
+      .mockImplementationOnce(() => new Promise((resolve) => { resolveSecond = resolve; }));
+
+    // Something else (e.g. a window-focus refetch) already has this query
+    // in flight when origin_changed arrives.
+    const inFlight = queryClient.fetchQuery({
+      queryKey: queryKeys.datasets.detail('dataset-1'),
+      queryFn: () => getDataset('dataset-1'),
+    });
+    inFlight.catch(() => {}); // cancelled by the fix; expected to reject.
+
+    rtlRender(
+      <QueryClientProvider client={queryClient}>
+        <ReuploadDialog
+          dataset={{ ...makeDataset(), origin: 'upload' }}
+          open
+          onOpenChange={vi.fn()}
+        />
+      </QueryClientProvider>,
+    );
+
+    await openFileSource(user);
+    await dropFile();
+    await screen.findByRole('button', { name: 'Confirm Re-Upload' });
+    await user.click(screen.getByRole('button', { name: 'Confirm Re-Upload' }));
+
+    const retryButton = await screen.findByTestId('reupload-try-again');
+    await waitFor(() => expect(retryButton).toBeDisabled());
+    await waitFor(() => expect(mockGetDataset).toHaveBeenCalledTimes(2));
+
+    // The stale (pre-conflict) resolution must not govern the UI.
+    resolveFirst({ ...makeDataset(), origin: 'service' });
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(retryButton).toBeDisabled();
+
+    // Only the fresh, post-cancel fetch does.
+    resolveSecond({ ...makeDataset(), origin: 'upload' });
+    await waitFor(() => expect(retryButton).not.toBeDisabled());
+  });
 });
 
 // GPKG-01 Phase 1058: multi-layer file path tests

--- a/frontend/src/components/dataset/__tests__/ReuploadDialog.test.tsx
+++ b/frontend/src/components/dataset/__tests__/ReuploadDialog.test.tsx
@@ -1,6 +1,6 @@
 import { act, render as rtlRender, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { QueryClient, QueryClientProvider, onlineManager } from '@tanstack/react-query';
 import { render } from '@/test/test-utils';
 import {
   useReuploadDataset,
@@ -10,6 +10,7 @@ import {
 } from '@/components/dataset/hooks/use-dataset';
 import { useJobStatus, useUploadConfig } from '@/components/import/hooks/use-ingest';
 import { probeService } from '@/api/ingest';
+import { getDataset } from '@/api/datasets';
 import { ApiError } from '@/api/client';
 import { queryKeys } from '@/lib/query-keys';
 import { ReuploadDialog } from '../ReuploadDialog';
@@ -47,6 +48,7 @@ vi.mock('@/api/ingest', () => ({
 
 vi.mock('@/api/datasets', () => ({
   reuploadPresigned: vi.fn(),
+  getDataset: vi.fn(),
 }));
 
 vi.mock('sonner', () => ({
@@ -64,6 +66,7 @@ const mockUseReuploadCommit = vi.mocked(useReuploadCommit);
 const mockUseUploadConfig = vi.mocked(useUploadConfig);
 const mockUseJobStatus = vi.mocked(useJobStatus);
 const mockProbeService = vi.mocked(probeService);
+const mockGetDataset = vi.mocked(getDataset);
 
 const uploadMutateAsync = vi.fn();
 const previewMutateAsync = vi.fn();
@@ -617,7 +620,7 @@ describe('ReuploadDialog', () => {
       defaultOptions: { queries: { retry: false, gcTime: 0 }, mutations: { retry: false } },
     });
     let resolveRefetch: () => void = () => {};
-    const refetch = vi.spyOn(queryClient, 'refetchQueries').mockImplementation(
+    const fetchQuery = vi.spyOn(queryClient, 'fetchQuery').mockImplementation(
       () =>
         new Promise((resolve) => {
           resolveRefetch = () => resolve(undefined);
@@ -644,10 +647,11 @@ describe('ReuploadDialog', () => {
       expect(retryButton).toBeDisabled();
     });
     expect(retryButton).toHaveTextContent('Refreshing...');
-    expect(refetch).toHaveBeenCalledWith(
-      { queryKey: queryKeys.datasets.detail('dataset-1') },
-      { throwOnError: true },
-    );
+    expect(fetchQuery).toHaveBeenCalledWith({
+      queryKey: queryKeys.datasets.detail('dataset-1'),
+      queryFn: expect.any(Function),
+      staleTime: 0,
+    });
 
     // A click while disabled must not proceed — retrying now would still
     // send the stale prop's origin.
@@ -675,7 +679,7 @@ describe('ReuploadDialog', () => {
     const queryClient = new QueryClient({
       defaultOptions: { queries: { retry: false, gcTime: 0 }, mutations: { retry: false } },
     });
-    vi.spyOn(queryClient, 'refetchQueries').mockRejectedValue(new Error('network error'));
+    vi.spyOn(queryClient, 'fetchQuery').mockRejectedValue(new Error('network error'));
 
     rtlRender(
       <QueryClientProvider client={queryClient}>
@@ -715,7 +719,7 @@ describe('ReuploadDialog', () => {
     const queryClient = new QueryClient({
       defaultOptions: { queries: { retry: false, gcTime: 0 }, mutations: { retry: false } },
     });
-    const refetch = vi.spyOn(queryClient, 'refetchQueries').mockResolvedValue(undefined);
+    const fetchQuery = vi.spyOn(queryClient, 'fetchQuery').mockResolvedValue(undefined);
 
     rtlRender(
       <QueryClientProvider client={queryClient}>
@@ -736,7 +740,7 @@ describe('ReuploadDialog', () => {
     const retryButton = screen.getByTestId('reupload-try-again');
     expect(retryButton).not.toBeDisabled();
     expect(retryButton).toHaveTextContent('Try Again');
-    expect(refetch).not.toHaveBeenCalled();
+    expect(fetchQuery).not.toHaveBeenCalled();
   });
 
   // fix(#1822 review P2): DatasetPage always renders ReuploadDialog and only
@@ -759,7 +763,7 @@ describe('ReuploadDialog', () => {
     });
     let settleFirst: () => void = () => {};
     let settleSecond: () => void = () => {};
-    vi.spyOn(queryClient, 'refetchQueries')
+    vi.spyOn(queryClient, 'fetchQuery')
       .mockImplementationOnce(
         () =>
           new Promise((_resolve, reject) => {
@@ -819,6 +823,62 @@ describe('ReuploadDialog', () => {
     settleSecond();
     await waitFor(() => expect(retryButton).not.toBeDisabled());
     expect(retryButton).toHaveTextContent('Try Again');
+  });
+
+  // fix(#1822 review P2 round 2): retry stays disabled through an offline
+  // pause. Real QueryClient/fetchQuery (no spy) to exercise TanStack
+  // Query's own pause/resume.
+  it('keeps "Try Again" disabled while offline, then enables it once reconnecting lets the fetch land', async () => {
+    const user = userEvent.setup();
+    commitMutateAsync.mockRejectedValueOnce(
+      new ApiError('This dataset’s source changed', 409, {
+        code: 'origin_changed',
+        origin_kind: 'service',
+        expected_origin_kind: 'upload',
+      }),
+    );
+    mockGetDataset.mockResolvedValue({ ...makeDataset(), origin: 'upload' });
+
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, gcTime: 0 }, mutations: { retry: false } },
+    });
+
+    try {
+      onlineManager.setOnline(false);
+
+      rtlRender(
+        <QueryClientProvider client={queryClient}>
+          <ReuploadDialog
+            dataset={{ ...makeDataset(), origin: 'upload' }}
+            open
+            onOpenChange={vi.fn()}
+          />
+        </QueryClientProvider>,
+      );
+
+      await openFileSource(user);
+      await dropFile();
+      await screen.findByRole('button', { name: 'Confirm Re-Upload' });
+      await user.click(screen.getByRole('button', { name: 'Confirm Re-Upload' }));
+
+      const retryButton = await screen.findByTestId('reupload-try-again');
+      await waitFor(() => expect(retryButton).toBeDisabled());
+      // Paused: the fetch never actually runs while offline.
+      expect(mockGetDataset).not.toHaveBeenCalled();
+      expect(
+        screen.queryByText(
+          "Could not refresh the dataset's info after this conflict. Reload the page and try again.",
+        ),
+      ).not.toBeInTheDocument();
+
+      onlineManager.setOnline(true);
+
+      await waitFor(() => expect(retryButton).not.toBeDisabled());
+      expect(mockGetDataset).toHaveBeenCalled();
+      expect(retryButton).toHaveTextContent('Try Again');
+    } finally {
+      onlineManager.setOnline(true);
+    }
   });
 });
 

--- a/frontend/src/components/dataset/__tests__/ReuploadDialog.test.tsx
+++ b/frontend/src/components/dataset/__tests__/ReuploadDialog.test.tsx
@@ -602,7 +602,8 @@ describe('ReuploadDialog', () => {
   // re-captured from the `dataset` prop, which is served from the cache the
   // server just disagreed with. Without the invalidation the retry re-sends
   // the same stale kind and 409s forever.
-  it('invalidates the dataset detail query when the commit reports origin_changed', async () => {
+  // fix(#1822): "Try Again" stays disabled until the origin refetch lands.
+  it('keeps "Try Again" disabled until the origin refetch resolves, then enables it', async () => {
     const user = userEvent.setup();
     commitMutateAsync.mockRejectedValueOnce(
       new ApiError('This dataset’s source changed', 409, {
@@ -615,9 +616,13 @@ describe('ReuploadDialog', () => {
     const queryClient = new QueryClient({
       defaultOptions: { queries: { retry: false, gcTime: 0 }, mutations: { retry: false } },
     });
-    const invalidate = vi
-      .spyOn(queryClient, 'invalidateQueries')
-      .mockResolvedValue(undefined);
+    let resolveRefetch: () => void = () => {};
+    const refetch = vi.spyOn(queryClient, 'refetchQueries').mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveRefetch = () => resolve(undefined);
+        }),
+    );
 
     rtlRender(
       <QueryClientProvider client={queryClient}>
@@ -634,15 +639,73 @@ describe('ReuploadDialog', () => {
     await screen.findByRole('button', { name: 'Confirm Re-Upload' });
     await user.click(screen.getByRole('button', { name: 'Confirm Re-Upload' }));
 
+    const retryButton = await screen.findByTestId('reupload-try-again');
     await waitFor(() => {
-      expect(invalidate).toHaveBeenCalledWith({
-        queryKey: queryKeys.datasets.detail('dataset-1'),
-      });
+      expect(retryButton).toBeDisabled();
     });
+    expect(retryButton).toHaveTextContent('Refreshing...');
+    expect(refetch).toHaveBeenCalledWith(
+      { queryKey: queryKeys.datasets.detail('dataset-1') },
+      { throwOnError: true },
+    );
+
+    // A click while disabled must not proceed — retrying now would still
+    // send the stale prop's origin.
+    await user.click(retryButton);
+    expect(commitMutateAsync).toHaveBeenCalledTimes(1);
+
+    resolveRefetch();
+
+    await waitFor(() => {
+      expect(retryButton).not.toBeDisabled();
+    });
+    expect(retryButton).toHaveTextContent('Try Again');
   });
 
-  it('does not invalidate the dataset detail query for an unrelated commit failure', async () => {
-    // The counterfactual's other half: the invalidation is keyed on the
+  it('shows the refetch error and keeps "Try Again" disabled when the origin refetch fails', async () => {
+    const user = userEvent.setup();
+    commitMutateAsync.mockRejectedValueOnce(
+      new ApiError('This dataset’s source changed', 409, {
+        code: 'origin_changed',
+        origin_kind: 'service',
+        expected_origin_kind: 'upload',
+      }),
+    );
+
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, gcTime: 0 }, mutations: { retry: false } },
+    });
+    vi.spyOn(queryClient, 'refetchQueries').mockRejectedValue(new Error('network error'));
+
+    rtlRender(
+      <QueryClientProvider client={queryClient}>
+        <ReuploadDialog
+          dataset={{ ...makeDataset(), origin: 'upload' }}
+          open
+          onOpenChange={vi.fn()}
+        />
+      </QueryClientProvider>,
+    );
+
+    await openFileSource(user);
+    await dropFile();
+    await screen.findByRole('button', { name: 'Confirm Re-Upload' });
+    await user.click(screen.getByRole('button', { name: 'Confirm Re-Upload' }));
+
+    await screen.findByText(
+      "Could not refresh the dataset's info after this conflict. Reload the page and try again.",
+    );
+    // The original commit error is superseded — retrying is dead either way,
+    // and the refetch failure is the one the user needs to act on.
+    expect(screen.queryByText('This dataset’s source changed')).not.toBeInTheDocument();
+
+    const retryButton = screen.getByTestId('reupload-try-again');
+    expect(retryButton).toBeDisabled();
+    expect(retryButton).toHaveTextContent('Try Again');
+  });
+
+  it('does not touch the origin refetch or disable "Try Again" for an unrelated commit failure', async () => {
+    // The counterfactual's other half: the recovery refetch is keyed on the
     // refusal code, not fired on every commit error.
     const user = userEvent.setup();
     commitMutateAsync.mockRejectedValueOnce(
@@ -652,9 +715,7 @@ describe('ReuploadDialog', () => {
     const queryClient = new QueryClient({
       defaultOptions: { queries: { retry: false, gcTime: 0 }, mutations: { retry: false } },
     });
-    const invalidate = vi
-      .spyOn(queryClient, 'invalidateQueries')
-      .mockResolvedValue(undefined);
+    const refetch = vi.spyOn(queryClient, 'refetchQueries').mockResolvedValue(undefined);
 
     rtlRender(
       <QueryClientProvider client={queryClient}>
@@ -672,9 +733,10 @@ describe('ReuploadDialog', () => {
     await user.click(screen.getByRole('button', { name: 'Confirm Re-Upload' }));
 
     await screen.findByText('A refresh is already running');
-    expect(invalidate).not.toHaveBeenCalledWith({
-      queryKey: queryKeys.datasets.detail('dataset-1'),
-    });
+    const retryButton = screen.getByTestId('reupload-try-again');
+    expect(retryButton).not.toBeDisabled();
+    expect(retryButton).toHaveTextContent('Try Again');
+    expect(refetch).not.toHaveBeenCalled();
   });
 });
 

--- a/frontend/src/components/dataset/__tests__/ReuploadDialog.test.tsx
+++ b/frontend/src/components/dataset/__tests__/ReuploadDialog.test.tsx
@@ -1,4 +1,4 @@
-import { act, render as rtlRender, screen, waitFor } from '@testing-library/react';
+import { act, render as rtlRender, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render } from '@/test/test-utils';
@@ -737,6 +737,88 @@ describe('ReuploadDialog', () => {
     expect(retryButton).not.toBeDisabled();
     expect(retryButton).toHaveTextContent('Try Again');
     expect(refetch).not.toHaveBeenCalled();
+  });
+
+  // fix(#1822 review P2): DatasetPage always renders ReuploadDialog and only
+  // toggles its `open` prop, so closing it does not unmount the component —
+  // a refetch started before the close keeps running after resetState.
+  it('ignores a stale refetch completion from before a reset (dialog closed mid-refetch)', async () => {
+    const user = userEvent.setup();
+    const originChangedError = () =>
+      new ApiError('This dataset’s source changed', 409, {
+        code: 'origin_changed',
+        origin_kind: 'service',
+        expected_origin_kind: 'upload',
+      });
+    commitMutateAsync
+      .mockRejectedValueOnce(originChangedError())
+      .mockRejectedValueOnce(originChangedError());
+
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, gcTime: 0 }, mutations: { retry: false } },
+    });
+    let settleFirst: () => void = () => {};
+    let settleSecond: () => void = () => {};
+    vi.spyOn(queryClient, 'refetchQueries')
+      .mockImplementationOnce(
+        () =>
+          new Promise((_resolve, reject) => {
+            settleFirst = () => reject(new Error('cancelled'));
+          }),
+      )
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            settleSecond = () => resolve(undefined);
+          }),
+      );
+
+    rtlRender(
+      <QueryClientProvider client={queryClient}>
+        <ReuploadDialog
+          dataset={{ ...makeDataset(), origin: 'upload' }}
+          open
+          onOpenChange={vi.fn()}
+        />
+      </QueryClientProvider>,
+    );
+
+    // First attempt: origin_changed, refetch #1 starts and hangs.
+    await openFileSource(user);
+    await dropFile();
+    await screen.findByRole('button', { name: 'Confirm Re-Upload' });
+    await user.click(screen.getByRole('button', { name: 'Confirm Re-Upload' }));
+
+    let retryButton = await screen.findByTestId('reupload-try-again');
+    await waitFor(() => expect(retryButton).toBeDisabled());
+
+    // Close while refetch #1 is still in flight.
+    await user.click(within(retryButton.parentElement as HTMLElement).getByRole('button', { name: 'Close' }));
+
+    // Re-stage and confirm again: a second origin_changed, a second refetch.
+    await openFileSource(user);
+    await dropFile();
+    await screen.findByRole('button', { name: 'Confirm Re-Upload' });
+    await user.click(screen.getByRole('button', { name: 'Confirm Re-Upload' }));
+
+    retryButton = await screen.findByTestId('reupload-try-again');
+    await waitFor(() => expect(retryButton).toBeDisabled());
+
+    // Attempt #1 settles late (as a cancellation would) — must be ignored.
+    settleFirst();
+    await waitFor(() => {
+      expect(
+        screen.queryByText(
+          "Could not refresh the dataset's info after this conflict. Reload the page and try again.",
+        ),
+      ).not.toBeInTheDocument();
+    });
+    expect(retryButton).toBeDisabled();
+
+    // Attempt #2 succeeds — it governs the UI.
+    settleSecond();
+    await waitFor(() => expect(retryButton).not.toBeDisabled());
+    expect(retryButton).toHaveTextContent('Try Again');
   });
 });
 

--- a/frontend/src/i18n/locales/de/dataset.json
+++ b/frontend/src/i18n/locales/de/dataset.json
@@ -372,9 +372,11 @@
     "completeMessage": "Der Datensatz wurde aktualisiert.",
     "errorFallback": "Ein unerwarteter Fehler ist aufgetreten.",
     "tryAgain": "Erneut versuchen",
+    "refreshingOrigin": "Wird aktualisiert...",
     "toastSuccess": "Erneutes Hochladen abgeschlossen!",
     "uploadFailed": "Hochladen fehlgeschlagen. Bitte versuchen Sie es erneut.",
     "commitFailed": "Übernahme fehlgeschlagen. Bitte versuchen Sie es erneut.",
+    "originRefreshFailed": "Die Datensatzinformationen konnten nach diesem Konflikt nicht aktualisiert werden. Laden Sie die Seite neu und versuchen Sie es erneut.",
     "jobFailed": "Auftrag zum erneuten Hochladen fehlgeschlagen.",
     "jobCancelled": "Der erneute Upload wurde abgebrochen."
   },

--- a/frontend/src/i18n/locales/en/dataset.json
+++ b/frontend/src/i18n/locales/en/dataset.json
@@ -323,9 +323,11 @@
     "completeMessage": "The dataset has been updated.",
     "errorFallback": "An unexpected error occurred.",
     "tryAgain": "Try Again",
+    "refreshingOrigin": "Refreshing...",
     "toastSuccess": "Re-upload complete!",
     "uploadFailed": "Upload failed. Please try again.",
     "commitFailed": "Commit failed. Please try again.",
+    "originRefreshFailed": "Could not refresh the dataset's info after this conflict. Reload the page and try again.",
     "jobFailed": "Re-upload job failed.",
     "jobCancelled": "Re-upload was cancelled."
   },

--- a/frontend/src/i18n/locales/es/dataset.json
+++ b/frontend/src/i18n/locales/es/dataset.json
@@ -372,9 +372,11 @@
     "completeMessage": "El conjunto de datos ha sido actualizado.",
     "errorFallback": "Ocurrió un error inesperado.",
     "tryAgain": "Intentar de nuevo",
+    "refreshingOrigin": "Actualizando...",
     "toastSuccess": "¡Nueva subida completada!",
     "uploadFailed": "Error al subir. Inténtelo de nuevo.",
     "commitFailed": "Error de confirmación. Inténtelo de nuevo.",
+    "originRefreshFailed": "No se pudo actualizar la información del conjunto de datos después de este conflicto. Recargue la página e inténtelo de nuevo.",
     "jobFailed": "Error en el trabajo de nueva subida.",
     "jobCancelled": "La resubida se canceló."
   },

--- a/frontend/src/i18n/locales/fr/dataset.json
+++ b/frontend/src/i18n/locales/fr/dataset.json
@@ -372,9 +372,11 @@
     "completeMessage": "Le jeu de données a été mis à jour.",
     "errorFallback": "Une erreur inattendue s'est produite.",
     "tryAgain": "Réessayer",
+    "refreshingOrigin": "Actualisation...",
     "toastSuccess": "Rechargement terminé !",
     "uploadFailed": "Échec du téléchargement. Veuillez réessayer.",
     "commitFailed": "Échec de la validation. Veuillez réessayer.",
+    "originRefreshFailed": "Impossible d'actualiser les informations du jeu de données après ce conflit. Rechargez la page et réessayez.",
     "jobFailed": "La tâche de rechargement a échoué.",
     "jobCancelled": "Le renvoi a été annulé."
   },


### PR DESCRIPTION
Fixes #1822. Follow-up from #1821 (codex round 2, P2).

When a reupload commit refuses with 409 origin_changed, ReuploadDialog.handleConfirm invalidated the dataset detail query and immediately entered the error step with "Try Again" already enabled. The invalidation was fire-and-forget: a retry before it settled, or after it failed outright, still captured the stale dataset.origin from the prop and got the same 409 again.

The fix awaits a refetch of the dataset detail query (queryClient.refetchQueries with throwOnError so a failed refetch is distinguishable from a successful one) before enabling "Try Again". While it is in flight the button stays disabled and shows a refreshing label. If the refetch itself fails, that failure replaces the error message and the button stays disabled, since a retry at that point would still send the same stale origin. Every other path through the dialog is untouched.

New locale keys (reupload.refreshingOrigin, reupload.originRefreshFailed) added to all four locales (en/es/fr/de).

## Testing

Rewrote the existing origin_changed test (it asserted the old fire-and-forget invalidateQueries call, which no longer happens) and added two more:

- "Try Again" stays disabled while the refetch is in flight, shows the refreshing label, a click on it while disabled does not re-submit, and it re-enables once the refetch resolves.
- A failing refetch replaces the error message with the refetch-failure text and keeps "Try Again" permanently disabled.
- An unrelated commit failure (not origin_changed) leaves the refetch and the button untouched, confirming the happy/other-error paths are unaffected.

Commands run:
```
cd frontend && npx vitest run src/components/dataset/__tests__/ReuploadDialog.test.tsx src/__tests__/web-storage-guard.test.ts src/i18n/resources.test.ts
# 3 files passed, 172 tests passed (ReuploadDialog suite rerun 3x clean)
npm run typecheck   # clean
npm run lint         # clean
npm run test:i18n    # clean
```

## Counterfactual

Reverted only ReuploadDialog.tsx to its pre-fix state (kept the updated tests) and reran the suite. All three new/updated tests failed:

```
× keeps "Try Again" disabled until the origin refetch resolves, then enables it
× shows the refetch error and keeps "Try Again" disabled when the origin refetch fails
× does not touch the origin refetch or disable "Try Again" for an unrelated commit failure
Tests  3 failed | 34 passed (37)
```

The failures are the button never carrying the new `data-testid`/disabled state and `refetchQueries` never being called, matching the described defect: the old code enabled "Try Again" immediately, before any refetch, unconditionally. Restoring the fix returns the suite to 37/37.