### PR TITLE
chore(release): v1.18.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,76 @@ and releases use semantic versioning.
 
 ## [Unreleased]
 
+## [1.18.1] - 2026-09-05
+
+Security release. Upgrade is a plain image pull; there are no migrations.
+
+### Security
+
+- Uploaded files and archive members that GDAL would treat as instructions rather than data
+  (driver documents, and SQLite or GeoPackage schemas declaring virtual tables that reference
+  external files) could make the ingest preview and import read local files on the worker or
+  contact remote hosts, returning the contents to the uploader. Every local-upload GDAL subprocess
+  now runs under an input-driver allowlist derived from the declared upload format, a shared
+  safe-env helper that skips pointer-following and network drivers, and a content check that
+  identifies archive members by their bytes; the structural test requires all three. Reported by
+  the 2026-09-04 security audit. (#1846, GHSA-hrf5-v3cq-frx5)
+- The job context Procrastinate attaches to worker log records carried service-import credentials
+  in cleartext on installs without a credential store, because the log redactor only scrubbed the
+  message string. Structured extras are now deep-redacted, every wire shape of a registered
+  credential is scrubbed, and `credential_ref` joins the denylist. (#1844)
+- The deprecated `?api_key=` query-string lane authorized every method; it now authenticates
+  read-only requests only, as its documentation always said. Header keys are unchanged. (#1845)
+- A CQL2 filter with a large IN list made the OGC Features items endpoint rename query binds in
+  quadratic time on the event loop, so a handful of anonymous requests could stall the API. The
+  rename is a single pass, the compiled bind count is capped, and the filtered items route carries
+  its own 10 requests per second per IP limit. (#1845)
+- `GET /jobs/by-dataset/{id}` and the VRT generations listing returned another user's job fields
+  (error text, who triggered it, warnings) to any signed-in reader of a published dataset; both now
+  apply the same provenance gate as the refresh-run history, and a structural test requires a
+  disclosure predicate on every route whose response carries those fields. (#1860)
+- Minting an embed token snapshotted a map's datasets without a visibility check, so an owner who
+  had lost access to a dataset could still mint a long-lived capability for it. The mint now
+  applies the same filter as map updates and refuses with 403, matching the map routes. (#1860)
+- The OAuth sign-in exchanged tokens and fetched user info through a plain HTTP client rather than
+  the redirect-revalidating one, and never validated the endpoints a provider's discovery document
+  named. Every OAuth request now goes through the SSRF-safe transport with redirects off, the four
+  discovered endpoints are validated before use, and a malformed discovered endpoint is refused
+  with the same 503 as a private one instead of a 500. (#1861)
+- Service probes reported a blocked redirect as an invalid credential and could echo the
+  redirect's hostname, and the ArcGIS preview reported it as an ogrinfo failure; both now answer
+  the fixed refusal with one audit row. Three JSON readers lacked the depth guard, so a nested body
+  could turn a probe, a source-health check, or a sign-in into a 500. Table discovery listed
+  attempt-scoped staging tables as registrable. (#1858)
+
+### Fixed
+
+- Corrupt, encrypted, or unsupported-compression archive members are refused with the same coded
+  422 as other unsafe uploads instead of failing the job with an unhandled error. (#1846)
+- Deeply nested CQL2 filters return a coded 400 instead of a 500. (#1845)
+- A failed token refresh reported success and retried with the dead token, and a refresh that
+  failed while another tab had already rotated the token logged the tab out; the AI chat transcript
+  in the browser survived logout in the same tab; unsaved dataset metadata drafts, including text
+  still open in an editor, followed navigation and could be saved onto the next dataset. (#1862)
+- Login page keeps its branding and the site footer at every width and no longer flashes the
+  community badge before the edition setting has loaded; the import dropzone headline no longer doubles its
+  verb and the success count is pluralised; a map created from a dataset opens on that dataset,
+  including when the map loads after the layer; Downloads offers an authenticated download per
+  export format; qualitative colour palettes assign distinct colours per category. (#1863)
+
+### Upgrade notes
+
+- OAuth providers configured with explicit endpoint URLs and reachable only through an
+  `HTTPS_PROXY` lose that egress: the token exchange and user-info requests now use the same
+  connection-pinning transport as discovery, which cannot honour an environment proxy. Discovery-
+  configured providers were already in this position. (#1861)
+- The embed-token mint refuses a dataset the minter cannot see with 403 instead of 400. (#1860)
+
+- Deployments whose custom clients sent an API key in the query string for mutating requests must
+  move the key to the `X-Api-Key` header.
+- `.xlsx` and `.kmz` uploads now meet the archive safety checks at preview time rather than only at
+  commit; the checks are the same.
+
 ## [1.18.0] - 2026-09-04
 
 ### Added
@@ -3553,7 +3623,8 @@ regression-covered fixes:
 - Initial public release of the GeoLens catalog, API, map builder, CLI, SDKs,
   Docker development stack, and public documentation entrypoints.
 
-[Unreleased]: https://github.com/geolens-io/geolens/compare/v1.18.0...HEAD
+[Unreleased]: https://github.com/geolens-io/geolens/compare/v1.18.1...HEAD
+[1.18.1]: https://github.com/geolens-io/geolens/compare/v1.18.0...v1.18.1
 [1.18.0]: https://github.com/geolens-io/geolens/compare/v1.17.0...v1.18.0
 [1.17.0]: https://github.com/geolens-io/geolens/compare/v1.16.1...v1.17.0
 [1.16.1]: https://github.com/geolens-io/geolens/compare/v1.16.0...v1.16.1

--- a/README.md
+++ b/README.md
@@ -19,9 +19,18 @@ GeoLens is an open-source spatial data hub for GIS and data teams: one place to 
 [![OGC API](https://img.shields.io/badge/OGC_API-Features_%7C_Records-green.svg)](https://ogcapi.ogc.org/)
 
 ```bash
-curl -fsSL https://getgeolens.com/install.sh | sh
+git clone https://github.com/geolens-io/geolens.git && cd geolens
+bash scripts/install.sh   # read it first: it writes .env, generates secrets, runs docker compose up -d
 # Open http://localhost:8080, then log in with the credentials you chose
 ```
+
+Or the one-line form, which runs the same script and pulls the prebuilt images:
+
+```bash
+curl -fsSL https://getgeolens.com/install.sh | sh
+```
+
+Images are published for linux/amd64 and linux/arm64. A fresh install runs six containers at about 1.3 GB resident.
 
 <p align="center">
   <img src=".github/assets/geolens-manhattan-3d-hero.jpg" alt="GeoLens map builder with Manhattan building footprints extruded into a 3D skyline, colored by construction era, with the subway and the drag-orderable layer stack beside the map" width="900" />
@@ -212,18 +221,18 @@ worker run in containers (Python 3.14 bundled, no host Python needed). The
 optional CLI runs on your host and requires Python 3.11+; the Python SDK and
 seed scripts require Python 3.10+.
 
-The one-line install pulls the prebuilt, version-pinned images and starts the stack:
-
-```bash
-curl -fsSL https://getgeolens.com/install.sh | sh
-```
-
-Prefer to read the script or build from source first? Clone the repo and run the same installer. It builds the images locally instead of pulling them:
+Clone the repo and run the installer from the checkout. You can read the script before running it; from a clone it builds the images locally:
 
 ```bash
 git clone https://github.com/geolens-io/geolens.git
 cd geolens
 bash scripts/install.sh
+```
+
+The one-line form runs the same script and pulls the prebuilt, version-pinned images instead of building them:
+
+```bash
+curl -fsSL https://getgeolens.com/install.sh | sh
 ```
 
 Either way, `scripts/install.sh` copies `.env.example` to `.env`, generates a JWT signing

--- a/backend/app/api/main.py
+++ b/backend/app/api/main.py
@@ -827,7 +827,7 @@ _is_production = settings.is_production
 # no metadata to read. We fall back to the current published line so import never
 # crashes. Keep this fallback in lockstep with backend/pyproject.toml — it is one
 # of the sites `make bump` rewrites.
-_FALLBACK_APP_VERSION = "1.18.0"
+_FALLBACK_APP_VERSION = "1.18.1"
 
 
 def _resolve_app_version() -> str:

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -18984,7 +18984,7 @@
     "summary": "PostGIS-native geospatial data catalog with OGC API Features and Records support",
     "termsOfService": "https://github.com/geolens-io/geolens/blob/main/LICENSE",
     "title": "GeoLens API",
-    "version": "1.18.0"
+    "version": "1.18.1"
   },
   "openapi": "3.1.0",
   "paths": {

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geolens-backend"
-version = "1.18.0"
+version = "1.18.1"
 description = "PostGIS-native GIS data catalog"
 # Docker image (Dockerfile) ships python:3.14-slim (see the Dockerfile FROM for
 # the exact patch pin) as the project's tested runtime.

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -838,7 +838,7 @@ wheels = [
 
 [[package]]
 name = "geolens-backend"
-version = "1.18.0"
+version = "1.18.1"
 source = { virtual = "." }
 dependencies = [
     { name = "alembic" },

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "geolens-cli"
-version = "1.18.0"
+version = "1.18.1"
 description = "Apache-2.0 command-line interface for the GeoLens API. Login, scan, publish, and export STAC against any GeoLens instance."
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/docs-contract.json
+++ b/docs-contract.json
@@ -1,6 +1,6 @@
 {
   "_comment": "Canonical cross-surface facts for the GeoLens README, marketing site (getgeolens.com/src), and docs site (getgeolens.com/docs). Validated against scripts/install.sh + backend/pyproject.toml by scripts/check_docs_contract.py (geolens CI). The getgeolens.com repo vendors a copy and enforces the same `forbidden` list in its own CI. See docs-internal/DOC-CONSISTENCY-STRATEGY for the full design. Edit a fact ONCE here (and in its canonical source) — the gates make every surface follow.",
-  "version": "1.18.0",
+  "version": "1.18.1",
   "install": {
     "oneLiner": "curl -fsSL https://getgeolens.com/install.sh | sh",
     "sourceBuild": "bash scripts/install.sh",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "1.18.0",
+  "version": "1.18.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "1.18.0",
+      "version": "1.18.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.18.0",
+  "version": "1.18.1",
   "type": "module",
   "license": "Apache-2.0",
   "author": "Carto Concepts, LLC",

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "geolens-mcp"
-version = "1.18.0"
+version = "1.18.1"
 description = "Apache-2.0 read-only Model Context Protocol (MCP) server for GeoLens. Lets coding agents discover datasets, inspect schemas, and ask spatial questions against any GeoLens instance."
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/mcp/server.json
+++ b/mcp/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.geolens-io/geolens",
   "title": "GeoLens",
   "description": "Read-only access to a self-hosted GeoLens spatial catalog: datasets, features, maps, sandboxed SQL.",
-  "version": "1.18.0",
+  "version": "1.18.1",
   "websiteUrl": "https://docs.getgeolens.com/",
   "repository": {
     "url": "https://github.com/geolens-io/geolens",
@@ -14,7 +14,7 @@
     {
       "registryType": "pypi",
       "identifier": "geolens-mcp",
-      "version": "1.18.0",
+      "version": "1.18.1",
       "transport": {
         "type": "stdio"
       },

--- a/mcp/uv.lock
+++ b/mcp/uv.lock
@@ -225,7 +225,7 @@ wheels = [
 
 [[package]]
 name = "geolens"
-version = "1.18.0"
+version = "1.18.1"
 source = { editable = "../sdks/python" }
 dependencies = [
     { name = "attrs" },
@@ -244,7 +244,7 @@ requires-dist = [
 
 [[package]]
 name = "geolens-mcp"
-version = "1.18.0"
+version = "1.18.1"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "geolens",
-  "version": "1.18.0",
+  "version": "1.18.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "geolens",
-      "version": "1.18.0",
+      "version": "1.18.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@axe-core/playwright": "^4.13.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geolens",
-  "version": "1.18.0",
+  "version": "1.18.1",
   "private": true,
   "license": "Apache-2.0",
   "author": "Carto Concepts, LLC",

--- a/sdks/python/.openapi-python-client.yaml
+++ b/sdks/python/.openapi-python-client.yaml
@@ -4,7 +4,7 @@ project_name_override: geolens
 package_name_override: geolens
 # Rewritten on every `make sdks` run by scripts/sync_sdk_versions.py to match
 # backend/openapi.json info.version. Do not edit by hand.
-package_version_override: 1.18.0
+package_version_override: 1.18.1
 
 # Cleaner enum output (matches our pydantic v2 backend's enum emission).
 literal_enums: true

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "geolens"
-version = "1.18.0"
+version = "1.18.1"
 description = "Auto-generated Python SDK for the GeoLens API. Typed clients with Bearer + API-key auth helpers."
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/sdks/typescript/package-lock.json
+++ b/sdks/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@geolens/sdk",
-  "version": "1.18.0",
+  "version": "1.18.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@geolens/sdk",
-      "version": "1.18.0",
+      "version": "1.18.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@hey-api/client-fetch": "0.13.1"

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geolens/sdk",
-  "version": "1.18.0",
+  "version": "1.18.1",
   "description": "Auto-generated TypeScript SDK for the GeoLens API. Typed clients with Bearer + API-key auth helpers.",
   "license": "Apache-2.0",
   "author": "Carto Concepts, LLC",


### PR DESCRIPTION
Security release: #1844, #1845, #1846 (GHSA-hrf5-v3cq-frx5) plus the fold-ins #1860 #1861 #1858 #1862 #1863. No migrations. Verification: make version-check (21 sites agree), scripts/check_public_surface.py (clean), CHANGELOG compare links updated.