### PR TITLE
test(sources): assert the OGC API probe never calls ogrinfo directly

### DIFF
--- a/backend/tests/test_probe_classification.py
+++ b/backend/tests/test_probe_classification.py
@@ -8,7 +8,6 @@ Covers:
 """
 
 import json
-import time
 
 import httpx
 import pytest
@@ -216,11 +215,11 @@ class TestProbeOrchestratorNoEnrichment:
         return response
 
     @pytest.mark.anyio
-    async def test_ogcapi_probe_completes_fast_without_subprocess(self):
-        """PROBE-05: 17-collection OGC API probe completes in <100ms with no subprocess.
+    async def test_ogcapi_probe_never_invokes_ogrinfo(self):
+        """PROBE-05: a 17-collection OGC API probe never runs ogrinfo.
 
-        Stubs out HTTP calls so the test is pure in-process. Wall-clock assertion
-        confirms no ogrinfo subprocess is invoked (which would add ~3-4s per layer).
+        fix(#1859): asserts the short-circuit itself (run_ogrinfo is never
+        called) instead of a wall-clock ceiling, which raced a loaded runner.
         """
         import httpx
         from unittest.mock import AsyncMock, patch
@@ -244,25 +243,26 @@ class TestProbeOrchestratorNoEnrichment:
                 return _streaming_response(json_body=collections_data)
             return _streaming_response(json_body=landing_page)
 
-        with patch(
-            "app.modules.catalog.sources.adapters.ogcapi.validate_url_for_ssrf",
-            new_callable=AsyncMock,
+        with (
+            patch(
+                "app.modules.catalog.sources.adapters.ogcapi.validate_url_for_ssrf",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "app.processing.ingest.ogr.run_ogrinfo", new_callable=AsyncMock
+            ) as mock_ogrinfo,
         ):
             async with httpx.AsyncClient(
                 transport=httpx.MockTransport(handle)
             ) as client:
                 from app.modules.catalog.sources.probe import detect_service_type
 
-                start = time.perf_counter()
                 result = await detect_service_type(
                     "http://fake-ogcapi.example.com", client
                 )
-                elapsed_ms = (time.perf_counter() - start) * 1000
 
-        assert elapsed_ms < 100, (
-            f"OGC API probe took {elapsed_ms:.1f}ms — expected <100ms. "
-            "ogrinfo subprocess may have been invoked."
-        )
+            mock_ogrinfo.assert_not_called()
+
         assert result.service_type == "OGC API Features"
         assert len(result.layers) == 17
 

--- a/backend/tests/test_probe_classification.py
+++ b/backend/tests/test_probe_classification.py
@@ -216,10 +216,11 @@ class TestProbeOrchestratorNoEnrichment:
 
     @pytest.mark.anyio
     async def test_ogcapi_probe_never_invokes_ogrinfo(self):
-        """PROBE-05: a 17-collection OGC API probe never runs ogrinfo.
+        """PROBE-05: a 17-collection OGC API probe never launches ogrinfo.
 
-        fix(#1859): asserts the short-circuit itself (run_ogrinfo is never
-        called) instead of a wall-clock ceiling, which raced a loaded runner.
+        fix(#1859): asserts the short-circuit itself (no subprocess) rather
+        than a wall-clock ceiling. Patches asyncio.create_subprocess_exec,
+        the boundary run_ogrinfo calls, not run_ogrinfo's own attribute.
         """
         import httpx
         from unittest.mock import AsyncMock, patch
@@ -249,8 +250,8 @@ class TestProbeOrchestratorNoEnrichment:
                 new_callable=AsyncMock,
             ),
             patch(
-                "app.processing.ingest.ogr.run_ogrinfo", new_callable=AsyncMock
-            ) as mock_ogrinfo,
+                "asyncio.create_subprocess_exec", new_callable=AsyncMock
+            ) as mock_create_subprocess,
         ):
             async with httpx.AsyncClient(
                 transport=httpx.MockTransport(handle)
@@ -261,7 +262,7 @@ class TestProbeOrchestratorNoEnrichment:
                     "http://fake-ogcapi.example.com", client
                 )
 
-            mock_ogrinfo.assert_not_called()
+            mock_create_subprocess.assert_not_called()
 
         assert result.service_type == "OGC API Features"
         assert len(result.layers) == 17


### PR DESCRIPTION
Closes the last item in #1859: `test_probe_classification.py`'s `elapsed_ms < 100` bound, left to lane SEC6 while it owned the probe files. Test-only, no production code changes, no schema/API/config impact.

`test_ogcapi_probe_completes_fast_without_subprocess` timed a 17-collection OGC API probe and asserted it finished under 100ms, using the ceiling as a proxy for "no ogrinfo subprocess ran" (ogrinfo enrichment was removed from the probe path in Phase 1057 D-05, and a reintroduced per-layer subprocess call would add seconds). On a loaded runner that proxy is the same wall-clock race #1865 removed elsewhere: the bound can trip on scheduling noise that has nothing to do with whether ogrinfo actually ran.

Renamed to `test_ogcapi_probe_never_invokes_ogrinfo` and replaced the timing bound with the property it stood in for. The test now patches `asyncio.create_subprocess_exec` and asserts `assert_not_called()` after the probe runs, which observes the actual short-circuit instead of inferring it from elapsed time.

The first version of this fix patched `app.processing.ingest.ogr.run_ogrinfo` (the function's own module attribute) rather than the subprocess boundary. Codex round 1 caught a real gap in that: an autouse fixture already imports the OGC API adapter before the test body runs, so a regressed adapter written as `from app.processing.ingest.ogr import run_ogrinfo` would hold the pre-patch binding, and patching the attribute afterward would never touch it. `asyncio.create_subprocess_exec` is the boundary `run_ogrinfo`'s own JSON and text-fallback branches both call, so it catches the regression regardless of how the caller imported `run_ogrinfo`.

Counterfactual for the current version: capturing a `run_ogrinfo` reference via `from app.processing.ingest.ogr import run_ogrinfo` before the patch takes effect (modeling the exact stale-binding scenario codex described), then calling it inside the patched block, the assertion still catches it:

```
AssertionError: Expected 'create_subprocess_exec' to not have been called. Called 1 times.
```

Patching `run_ogrinfo`'s own attribute, by contrast, would have missed this exact case, since the captured reference bypasses that attribute entirely.

## Verification

From the worktree, Postgres at localhost:5434:

- `uv run pytest tests/test_probe_classification.py -q`: 25 passed
- `uv run pytest tests/test_probe_classification.py -q -n 4`, repeated 20 times: 20/20 clean (25 passed each run), rerun after the codex-round-1 fix
- `uv run pytest tests/test_layering.py tests/test_rule1_structural.py tests/test_rule2_structural.py -q`: 159 passed
- `uv run ruff check . && uv run ruff format --check .`: clean across the full backend tree

