### PR TITLE
fix(export): stop reading string values in a where filter as column names

### DIFF
--- a/backend/app/processing/export/service.py
+++ b/backend/app/processing/export/service.py
@@ -13,7 +13,10 @@ from app.core.async_io import run_in_thread_draining
 from app.core.config import settings
 from app.core.csv_safety import numeric_column_names
 from app.processing.export.ogr import FORMAT_MAP, run_ogr2ogr_export
-from app.processing.export.where_validator import validate_where_ast
+from app.processing.export.where_validator import (
+    mask_quoted_literals,
+    validate_where_ast,
+)
 from app.core.runtime.staging import ensure_staging_ready
 
 logger = structlog.stdlib.get_logger(__name__)
@@ -388,7 +391,10 @@ def validate_where_clause(where: str, column_info: list[dict] | None) -> str:
     # aren't in this dataset's column_info, even if they parse cleanly.
     valid_names = {col["name"].lower() for col in column_info}
 
-    identifiers = _IDENTIFIER_RE.findall(where)
+    # fix(#1870): the walk reads the code around the values, never the values.
+    # A quoted literal is never a column reference, so masking it here cannot
+    # admit an unknown column before, after or between literals.
+    identifiers = _IDENTIFIER_RE.findall(mask_quoted_literals(where))
     for ident in identifiers:
         upper = ident.upper()
         if upper in _SQL_KEYWORDS:

--- a/backend/app/processing/export/where_validator.py
+++ b/backend/app/processing/export/where_validator.py
@@ -23,6 +23,8 @@ Allowed WHERE expression types (deny-by-default — anything not in this tuple r
 
 from __future__ import annotations
 
+import re
+
 import sqlglot
 from sqlglot import exp
 
@@ -155,3 +157,27 @@ def canonical_where(where: str) -> str:
     wrapped = f"SELECT 1 FROM _t WHERE {where}"
     statements = sqlglot.parse(wrapped, dialect="postgres")
     return statements[0].args["where"].this.sql(dialect="postgres")
+
+
+# A single-quoted SQL string literal, '' being the embedded-quote escape. The
+# two branches are disjoint on their first character, so the scan is linear.
+_QUOTED_LITERAL_RE = re.compile(r"'(?:[^']|'')*'")
+
+
+def mask_quoted_literals(where: str) -> str:
+    """Blank every single-quoted literal in ``where``, preserving its length.
+
+    A caller that scans the clause for code (an identifier walk, a token
+    classifier) must not read the values as code. Each literal becomes a run
+    of spaces of the same width, so two identifiers separated by a literal
+    cannot fuse into a third.
+
+    Args:
+        where: SQL WHERE-clause fragment.
+
+    Returns:
+        The fragment with literal contents replaced by spaces. Trailing text
+        after an unterminated quote is returned unchanged; callers reject an
+        unbalanced clause before masking.
+    """
+    return _QUOTED_LITERAL_RE.sub(lambda match: " " * len(match.group(0)), where)

--- a/backend/app/processing/export/where_validator.py
+++ b/backend/app/processing/export/where_validator.py
@@ -159,9 +159,10 @@ def canonical_where(where: str) -> str:
     return statements[0].args["where"].this.sql(dialect="postgres")
 
 
-# A single-quoted SQL string literal, '' being the embedded-quote escape. The
-# two branches are disjoint on their first character, so the scan is linear.
-_QUOTED_LITERAL_RE = re.compile(r"'(?:[^']|'')*'")
+# fix(#1870 audit r1): BOTH quote kinds are scanned in one pass, because a
+# single quote inside a double-quoted identifier opens no literal in Postgres
+# and must open none here either.
+_QUOTED_RUN_RE = re.compile(r"'(?:[^']|'')*'|\"(?:[^\"]|\"\")*\"")
 
 
 def mask_quoted_literals(where: str) -> str:
@@ -172,12 +173,22 @@ def mask_quoted_literals(where: str) -> str:
     of spaces of the same width, so two identifiers separated by a literal
     cannot fuse into a third.
 
+    A double-quoted identifier IS code, so it is scanned but returned
+    unchanged: consuming it in the same pass is what stops a quote inside it
+    from opening a literal that blanks the real code after it. Dollar-quoting
+    and E'' are rejected by the AST gate and are deliberately not modelled.
+
     Args:
         where: SQL WHERE-clause fragment.
 
     Returns:
-        The fragment with literal contents replaced by spaces. Trailing text
-        after an unterminated quote is returned unchanged; callers reject an
-        unbalanced clause before masking.
+        The fragment with string-literal contents replaced by spaces. Trailing
+        text after an unterminated quote is returned unchanged; callers reject
+        an unbalanced clause before masking.
     """
-    return _QUOTED_LITERAL_RE.sub(lambda match: " " * len(match.group(0)), where)
+
+    def _blank_literals_only(match: re.Match[str]) -> str:
+        run = match.group(0)
+        return run if run.startswith('"') else " " * len(run)
+
+    return _QUOTED_RUN_RE.sub(_blank_literals_only, where)

--- a/backend/tests/test_export.py
+++ b/backend/tests/test_export.py
@@ -1104,6 +1104,116 @@ class TestExportWhereColonLiteral:
         assert resp.status_code == 413
 
 
+# ---------------------------------------------------------------------------
+# Word-shaped literal inside a where filter — fix(#1870)
+# ---------------------------------------------------------------------------
+
+
+class TestExportWhereWordLiteral:
+    """fix(#1870): the identifier walk in validate_where_clause ran over the
+    raw clause, so `name = 'Main Street'` was refused with "Unknown column:
+    Main" and text filtering was unusable through every export door.
+
+    The cap is lowered so the bounded filtered COUNT executes against a real
+    table, which is what proves the clause is applied rather than dropped.
+    """
+
+    @pytest.fixture
+    async def capped_word_dataset(self, test_db_session, monkeypatch):
+        """Real 3-row table whose varchar values are ordinary words."""
+        from sqlalchemy import text
+
+        from app.processing.export import router as export_router
+
+        monkeypatch.setattr(export_router, "_MAX_EXPORT_FEATURES", 2)
+
+        table_name = f"exp_word_{uuid.uuid4().hex[:12]}"
+        await test_db_session.execute(
+            text(
+                f"CREATE TABLE data.{table_name} "
+                "(gid serial PRIMARY KEY, name varchar, "
+                "geom geometry(Point, 4326), geom_4326 geometry(Point, 4326))"
+            )
+        )
+        await test_db_session.execute(
+            text(
+                f"INSERT INTO data.{table_name} (name, geom, geom_4326) VALUES "
+                "(:n1, ST_SetSRID(ST_MakePoint(0, 0), 4326), "
+                " ST_SetSRID(ST_MakePoint(0, 0), 4326)), "
+                "(:n2, ST_SetSRID(ST_MakePoint(1, 1), 4326), "
+                " ST_SetSRID(ST_MakePoint(1, 1), 4326)), "
+                "(:n3, ST_SetSRID(ST_MakePoint(2, 2), 4326), "
+                " ST_SetSRID(ST_MakePoint(2, 2), 4326))"
+            ).bindparams(n1="Main Street", n2="Elm Avenue", n3="O'Brien Park")
+        )
+        await test_db_session.commit()
+
+        admin_id = await get_user_id(test_db_session, "admin")
+        ds = await _create_dataset(
+            test_db_session,
+            created_by=admin_id,
+            name="WordWhereDS",
+            table_name=table_name,
+            geometry_type="Point",
+            feature_count=3,
+            column_info=[
+                {"name": "gid", "type": "integer"},
+                {"name": "name", "type": "varchar"},
+            ],
+        )
+        yield ds
+        await test_db_session.execute(text(f"DROP TABLE IF EXISTS data.{table_name}"))
+        await test_db_session.commit()
+
+    @pytest.mark.anyio
+    async def test_word_literal_with_a_space_exports(
+        self, client: AsyncClient, admin_auth_header: dict, capped_word_dataset
+    ):
+        """Selects 1 of 3 rows, under the cap of 2. This 400'd before #1870."""
+        resp = await client.get(
+            f"/datasets/{capped_word_dataset.id}/export",
+            params={"where": "name = 'Main Street'"},
+            headers=admin_auth_header,
+        )
+        assert resp.status_code == 200, resp.text
+
+    @pytest.mark.anyio
+    async def test_escaped_quote_literal_exports(
+        self, client: AsyncClient, admin_auth_header: dict, capped_word_dataset
+    ):
+        resp = await client.get(
+            f"/datasets/{capped_word_dataset.id}/export",
+            params={"where": "name = 'O''Brien Park'"},
+            headers=admin_auth_header,
+        )
+        assert resp.status_code == 200, resp.text
+
+    @pytest.mark.anyio
+    async def test_word_literal_selecting_over_cap_413(
+        self, client: AsyncClient, admin_auth_header: dict, capped_word_dataset
+    ):
+        """A word literal that fails to narrow the selection still hits the
+        cap's 413, so the clause is executed rather than silently dropped."""
+        resp = await client.get(
+            f"/datasets/{capped_word_dataset.id}/export",
+            params={"where": "name != 'Nowhere Road'"},
+            headers=admin_auth_header,
+        )
+        assert resp.status_code == 413
+
+    @pytest.mark.anyio
+    async def test_unknown_column_beside_a_literal_still_400(
+        self, client: AsyncClient, admin_auth_header: dict, capped_word_dataset
+    ):
+        resp = await client.get(
+            f"/datasets/{capped_word_dataset.id}/export",
+            params={"where": "name = 'Main Street' AND nope = 1"},
+            headers=admin_auth_header,
+        )
+        assert resp.status_code == 400
+        assert "nope" in resp.text
+
+
 class TestPmtilesMaxzoomForExtent:
     """fix(#1686 codex r1): the PMTiles writer materializes the whole pyramid,
     so MAXZOOM is budgeted from extent instead of fixed at 14."""

--- a/backend/tests/test_export_hardening.py
+++ b/backend/tests/test_export_hardening.py
@@ -20,6 +20,7 @@ import pytest
 from httpx import AsyncClient
 
 from app.processing.export.service import validate_where_clause
+from app.processing.export.where_validator import mask_quoted_literals
 from app.processing.export.ogr import FORMAT_MAP
 
 from tests.factories import create_dataset, get_user_id
@@ -74,10 +75,9 @@ class TestWhereClauseInjectionRejection:
         IA-P1-04 checks (statement terminator / comment / unbalanced quote)
         and the v1014 SEC-S09 AST allowlist.
 
-        Note: the identifier regex inside validate_where_clause may flag
-        text-inside-quotes as a candidate identifier (pre-existing v1014
-        behavior, out of IA-P1-04 scope). To exercise just the IA-P1-04
-        layer we use a quoted value that doesn't look like an identifier."""
+        fix(#1870): word-shaped values are covered by
+        TestWhereClauseStringLiterals below; these two stay as the
+        numeric-shaped IA-P1-04 cases they were written as."""
         # Numeric-only string (passes identifier check, passes IA-P1-04).
         validate_where_clause("name = '42'", COLS)
         # SQL-escaped doubled quote — IA-P1-04 must accept (collapses to even).
@@ -86,6 +86,114 @@ class TestWhereClauseInjectionRejection:
     def test_numeric_comparison_accepted(self):
         validate_where_clause("pop > 1000", COLS)
         validate_where_clause("pop BETWEEN 100 AND 200", COLS)
+
+
+# ---------------------------------------------------------------------------
+# fix(#1870): a string VALUE is not a column reference
+# ---------------------------------------------------------------------------
+
+
+class TestWhereClauseStringLiterals:
+    """The identifier walk reads the code around the values, never the values.
+
+    Before #1870 it ran over the raw clause, so any quoted value containing a
+    word was refused as an unknown column and text filtering was unusable.
+    Every case here raised ValueError on main.
+    """
+
+    def test_literal_containing_a_space_accepted(self):
+        assert (
+            validate_where_clause("name = 'Main Street'", COLS)
+            == "name = 'Main Street'"
+        )
+
+    def test_literal_in_like_pattern_accepted(self):
+        validate_where_clause("pop > 10 AND name LIKE 'Water%'", COLS)
+
+    def test_literal_equal_to_a_sql_keyword_accepted(self):
+        validate_where_clause("name = 'SELECT'", COLS)
+        validate_where_clause("name = 'DROP TABLE'", COLS)
+
+    def test_literal_naming_a_foreign_column_accepted(self):
+        """A value that happens to be some other dataset's column name is a
+        value here, not a reference to a column this dataset does not have."""
+        validate_where_clause("name = 'elevation'", COLS)
+
+    def test_literal_naming_this_datasets_own_column_accepted(self):
+        validate_where_clause("name = 'country'", COLS)
+
+    def test_escaped_quote_in_literal_accepted(self):
+        validate_where_clause("name = 'O''Brien Park'", COLS)
+
+    def test_empty_literal_accepted(self):
+        validate_where_clause("name = ''", COLS)
+
+    def test_in_list_of_literals_accepted(self):
+        validate_where_clause("name IN ('Main Street', 'Elm Ave')", COLS)
+
+    # --- counterfactuals: nothing outside a literal got looser -------------
+
+    def test_unknown_column_after_a_literal_still_refused(self):
+        with pytest.raises(ValueError, match="Unknown column: nope"):
+            validate_where_clause("name = 'x' AND nope = 1", COLS)
+
+    def test_unknown_column_before_a_literal_still_refused(self):
+        with pytest.raises(ValueError, match="Unknown column: nope"):
+            validate_where_clause("nope = 'Main Street'", COLS)
+
+    def test_unknown_column_between_two_literals_still_refused(self):
+        with pytest.raises(ValueError, match="Unknown column: nope"):
+            validate_where_clause("name = 'a' AND nope = 'b' AND pop > 1", COLS)
+
+    def test_terminator_inside_a_literal_still_refused(self):
+        """The meta-SQL checks deliberately run over the RAW clause, so a ';'
+        is refused wherever it appears. Narrowing them to code-only would be a
+        separate change with its own review."""
+        with pytest.raises(ValueError, match="terminator"):
+            validate_where_clause("name = 'a;b'", COLS)
+
+    def test_line_comment_inside_a_literal_still_refused(self):
+        with pytest.raises(ValueError, match="comment"):
+            validate_where_clause("name = 'a--b'", COLS)
+
+    def test_unbalanced_quote_still_refused(self):
+        with pytest.raises(ValueError, match="quote"):
+            validate_where_clause("name = 'Main Street", COLS)
+
+    def test_ast_gate_still_runs_before_the_walk(self):
+        with pytest.raises(ValueError) as exc:
+            validate_where_clause("name = 'a' OR 1=1 UNION SELECT 1", COLS)
+        assert "unknown column" not in str(exc.value).lower()
+
+    def test_identifiers_split_by_a_literal_do_not_fuse(self):
+        """Masking preserves width, so `na'x'me` cannot become the column
+        `name`. The AST gate rejects this shape first; the assertion is that
+        no layer accepts it."""
+        with pytest.raises(ValueError):
+            validate_where_clause("na'x'me = 1", COLS)
+
+
+class TestMaskQuotedLiterals:
+    """Unit contract of the masking helper the walk runs through."""
+
+    def test_masking_preserves_length(self):
+        where = "name = 'Main Street' AND pop > 1"
+        assert len(mask_quoted_literals(where)) == len(where)
+
+    def test_literal_contents_are_blanked(self):
+        assert mask_quoted_literals("name = 'Main Street'") == "name = " + " " * 13
+
+    def test_escaped_quote_consumed_as_one_literal(self):
+        assert mask_quoted_literals("name = 'O''Brien'") == "name = " + " " * 10
+
+    def test_code_between_literals_survives(self):
+        assert mask_quoted_literals("'a' AND nope = 'b'") == "    AND nope =    "
+
+    def test_empty_literal_blanked(self):
+        assert mask_quoted_literals("name = ''") == "name =   "
+
+    def test_no_literal_is_a_no_op(self):
+        assert mask_quoted_literals("pop > 1000") == "pop > 1000"
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_export_hardening.py
+++ b/backend/tests/test_export_hardening.py
@@ -172,6 +172,22 @@ class TestWhereClauseStringLiterals:
         with pytest.raises(ValueError):
             validate_where_clause("na'x'me = 1", COLS)
 
+    # --- a quote inside a double-quoted identifier is not a literal --------
+
+    def test_quote_in_a_double_quoted_identifier_does_not_hide_a_column(self):
+        """A single quote inside a double-quoted identifier opens no literal
+        in Postgres, so it must open no mask either: the code after it stays
+        visible to the walk."""
+        with pytest.raises(ValueError, match="Unknown column: secret"):
+            validate_where_clause('"name\'" = 1 AND secret = 1 AND "name\'" = 1', COLS)
+
+    def test_lone_quote_in_a_double_quoted_identifier_does_not_hide_a_column(self):
+        with pytest.raises(ValueError, match="Unknown column: secret"):
+            validate_where_clause('"\'" = 1 AND secret = 1 AND "\'" = 1', COLS)
+
+    def test_double_quoted_identifier_beside_a_literal_accepted(self):
+        validate_where_clause("\"name\" = 'x'", COLS)
+
 
 class TestMaskQuotedLiterals:
     """Unit contract of the masking helper the walk runs through."""
@@ -194,6 +210,18 @@ class TestMaskQuotedLiterals:
 
     def test_no_literal_is_a_no_op(self):
         assert mask_quoted_literals("pop > 1000") == "pop > 1000"
+
+    def test_double_quoted_identifier_returned_unchanged(self):
+        assert mask_quoted_literals('"name" = 1') == '"name" = 1'
+
+    def test_quote_inside_a_double_quoted_identifier_opens_no_literal(self):
+        """Two such identifiers, so a scan that saw only single quotes would
+        pair them and blank the code between."""
+        where = '"name\'" = 1 AND secret = 1 AND "name\'" = 1'
+        assert mask_quoted_literals(where) == where
+
+    def test_literal_after_a_double_quoted_identifier_still_blanked(self):
+        assert mask_quoted_literals("\"name\" = 'x'") == '"name" = ' + " " * 3
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes the defect in #1870: `validate_where_clause` ran its identifier walk over the raw WHERE fragment with quoted literals included, so any string value containing a word was refused as an unknown column.

```
name = 'Main Street'                -> ValueError: Unknown column: Main
height > 10 AND name LIKE 'Water%'  -> ValueError: Unknown column: Water
name = 'O''Brien Park'              -> ValueError: Unknown column: O
```

Reproduced on `origin/main` at 95a80e88d before changing anything.

## What changed

`mask_quoted_literals` in `backend/app/processing/export/where_validator.py` blanks every single-quoted literal, replacing it with a run of spaces of the same width. `validate_where_clause` runs its walk over the masked clause instead of the raw one. The mask preserves length so two identifiers separated by a literal cannot fuse into a third: `na'x'me` becomes `na   me`, two unknown identifiers, not the column `name`.

The identifier walk stays. It is defense in depth against a sqlglot parser gap, and the issue's suggested alternative (take the column names from the AST) would make the walk depend on the same parse it exists to back up.

A quote inside a double-quoted identifier is not a literal, and the mask scans both quote kinds in one pass so it never treats one as opening a value. An unknown column before, after, or between literals is still refused, and the error now names the real unknown column rather than the first word inside a value. The pre-parse rejection of `;`, `--` and `/* */` still reads the raw clause, so those are refused wherever they appear, inside a literal included. The AST allowlist still runs first, before any of this.

## Sibling sites

All four export doors with a `where` parameter (`export/router.py` twice, `export/service.py`, `export/parquet.py`) call `validate_where_clause`, so the single helper covers the class, and the CLI and SDK `--where` flags with it.

The other two identifier walks in `backend/app/` validate a different grammar and are left alone:

- `core/db/tenant_session.py` already masks literals and comments through its own `_mask_sql_noncode` state machine before classifying tokens. Its input is generated SQL, not a caller's fragment, and it needs the quoted-identifier masking that this helper deliberately does not do.
- `platform/sandbox/validator.py` walks the rendered target of a cast against a blocklist of OID-alias type names. That string is a type expression, never a clause carrying values, and masking there would only weaken a blocklist.

`modules/catalog/datasets/domain/column_stats.py` shares the name `_IDENTIFIER_RE` but anchors it over a single column name, not a clause.

## Left alone

A `;` or `--` inside a string value is still refused. A double-quoted identifier containing a space is still refused too, because the walk reads its parts as separate identifiers; that predates this branch and is unchanged by it. Narrowing those three checks to code-only would need the mask to run before them, which changes what the string-level layer promises, and that is a separate change with its own review. No CHANGELOG entry: the release-time pass collects these.

## Schema, API, config

None. No request or response schema moved, so `backend/openapi.json` and the SDKs are untouched. No migration, no new config, no new translation key.

## Verification

Run from the worktree against Postgres at localhost:5434.

```
uv run pytest tests/test_export.py tests/test_export_hardening.py \
  tests/test_export_where_validator.py tests/test_export_access.py \
  tests/test_export_head_1513.py -q                                  165 passed, 3 skipped
uv run pytest tests/test_export_parquet.py tests/test_export_parquet_writer.py \
  tests/test_export_parquet_row_stream_budget_1778.py \
  tests/test_export_antimeridian.py tests/test_export_artifact_cache_1532.py -q
                                                                     176 passed
uv run pytest tests/test_layering.py tests/test_rule1_structural.py \
  tests/test_rule2_structural.py -q                                  159 passed
uv run ruff check .                                                  All checks passed
uv run ruff format --check .                                         1167 files already formatted
```

Counterfactual, run for real: reverting only `export/service.py` to `origin/main` and keeping the tests fails 8 of the new unit cases and all 4 of the new endpoint cases.

```
FAILED TestWhereClauseStringLiterals::test_literal_containing_a_space_accepted
FAILED TestWhereClauseStringLiterals::test_literal_in_like_pattern_accepted
FAILED TestWhereClauseStringLiterals::test_literal_equal_to_a_sql_keyword_accepted
FAILED TestWhereClauseStringLiterals::test_literal_naming_a_foreign_column_accepted
FAILED TestWhereClauseStringLiterals::test_escaped_quote_in_literal_accepted
FAILED TestWhereClauseStringLiterals::test_in_list_of_literals_accepted
FAILED TestWhereClauseStringLiterals::test_unknown_column_after_a_literal_still_refused
FAILED TestWhereClauseStringLiterals::test_unknown_column_between_two_literals_still_refused
FAILED TestExportWhereWordLiteral::test_word_literal_with_a_space_exports
FAILED TestExportWhereWordLiteral::test_escaped_quote_literal_exports
FAILED TestExportWhereWordLiteral::test_word_literal_selecting_over_cap_413
FAILED TestExportWhereWordLiteral::test_unknown_column_beside_a_literal_still_400
```

The two unknown-column cases fail on main for the right reason: main refuses them naming the literal, so the assertion that the message names `nope` is what breaks.

## Second commit

The first commit's mask scanned for single quotes only, which made it a regression as well as a fix: a quote inside a double-quoted identifier opened a mask run that Postgres opens no literal for, and an unknown column sitting after it was blanked out of the walk and accepted, where main refused it. The scan now covers both quote kinds and blanks a run only when it opens with a single quote, so a double-quoted identifier is consumed by the same pass and handed to the walk unchanged. Dollar-quoting and `E''` are rejected at the AST gate and are not modelled here.

Three tests cover it, two on `validate_where_clause` and one on the helper. Reverting only `export/where_validator.py` to the first commit and keeping the tests fails all three:

```
FAILED TestWhereClauseStringLiterals::test_quote_in_a_double_quoted_identifier_does_not_hide_a_column
FAILED TestWhereClauseStringLiterals::test_lone_quote_in_a_double_quoted_identifier_does_not_hide_a_column
FAILED TestMaskQuotedLiterals::test_quote_inside_a_double_quoted_identifier_opens_no_literal
```

Every test from the first commit keeps its exact expected output; none was edited.

The endpoint tests lower the export cap to 2 rows against a real 3-row table, so the bounded filtered COUNT executes. The 413 case proves the clause is applied rather than dropped, and the 400 case proves an unknown column beside a valid literal is still refused. No LOC cap raised; neither `export/service.py` nor `export/where_validator.py` is in `_MODULE_LOC_CAPS`.

