### PR TITLE
fix(builder): mark the map dirty when the camera moves

### DIFF
--- a/frontend/src/components/builder/builder-camera.ts
+++ b/frontend/src/components/builder/builder-camera.ts
@@ -1,0 +1,82 @@
+import type { Map as MaplibreMap } from 'maplibre-gl';
+
+/**
+ * The five viewport fields a map save persists.
+ *
+ * The builder has no explicit "set home view" control: the stored view is the
+ * camera at the last save. `readMapCamera` and `savedMapCamera` are therefore
+ * the SAME normalizer applied to the live map and to the server row, so the
+ * dirty check can mean exactly "saving now would change the stored value".
+ * Both sides must keep using it; comparing a raw `getCenter()` against a saved
+ * float reintroduces the drift the rounding is here to absorb.
+ */
+export interface BuilderCamera {
+  center_lng: number | null;
+  center_lat: number | null;
+  zoom: number | null;
+  bearing: number;
+  pitch: number;
+}
+
+/** A map row's stored view, as the save payload and the API response carry it. */
+export interface SavedCameraFields {
+  center_lng?: number | null;
+  center_lat?: number | null;
+  zoom?: number | null;
+  bearing?: number | null;
+  pitch?: number | null;
+}
+
+// fix(#1854): 6 decimals of longitude is about 11 cm, finer than any home view
+// needs and far coarser than the float noise a round trip through the map
+// transform introduces, so a resize or a reprojection cannot read as a pan.
+const CAMERA_DECIMALS = 6;
+
+function roundCameraValue(value: number | null | undefined): number | null {
+  // A non-finite reading has to normalize to null: NaN !== NaN would pin the
+  // unsaved indicator on for the rest of the session.
+  if (value == null || !Number.isFinite(value)) return null;
+  return Number(value.toFixed(CAMERA_DECIMALS));
+}
+
+/** The live map camera, at the precision and null handling a save persists. */
+export function readMapCamera(map: MaplibreMap | null | undefined): BuilderCamera {
+  const center = map?.getCenter?.();
+  return {
+    center_lng: roundCameraValue(center?.lng),
+    center_lat: roundCameraValue(center?.lat),
+    zoom: roundCameraValue(map?.getZoom?.()),
+    bearing: roundCameraValue(map?.getBearing?.()) ?? 0,
+    pitch: roundCameraValue(map?.getPitch?.()) ?? 0,
+  };
+}
+
+/** A stored view, normalized identically to `readMapCamera`. */
+export function savedMapCamera(saved: SavedCameraFields): BuilderCamera {
+  return {
+    center_lng: roundCameraValue(saved.center_lng),
+    center_lat: roundCameraValue(saved.center_lat),
+    zoom: roundCameraValue(saved.zoom),
+    bearing: roundCameraValue(saved.bearing) ?? 0,
+    pitch: roundCameraValue(saved.pitch) ?? 0,
+  };
+}
+
+/**
+ * Whether the map has a stored view at all. A map saved before it ever had a
+ * camera keeps null center components, and BuilderMap's `hasSavedView` reads
+ * the same two fields to decide whether to position from them.
+ */
+export function hasSavedMapCamera(saved: SavedCameraFields | undefined | null): boolean {
+  return saved?.center_lng != null && saved?.center_lat != null;
+}
+
+export function sameMapCamera(a: BuilderCamera, b: BuilderCamera): boolean {
+  return (
+    a.center_lng === b.center_lng
+    && a.center_lat === b.center_lat
+    && a.zoom === b.zoom
+    && a.bearing === b.bearing
+    && a.pitch === b.pitch
+  );
+}

--- a/frontend/src/components/builder/hooks/__tests__/use-builder-layers.camera-dirty.test.ts
+++ b/frontend/src/components/builder/hooks/__tests__/use-builder-layers.camera-dirty.test.ts
@@ -272,6 +272,30 @@ describe('fix(#1854): the dirty check mirrors the persisted precision', () => {
     expect(payload.zoom).toBe(12.345679);
   });
 
+  it('keeps the flag when the camera moves during an in-flight save', async () => {
+    // editedDuringSave compares SAVE_SNAPSHOT_FIELDS and the plugin set, and
+    // the camera is in neither: it is read off the map. Without it in the
+    // comparison the save clears the flag for a view it never persisted, and a
+    // refetch that fails leaves the map falsely clean.
+    let release!: () => void;
+    mockUpdateMapMutateAsync.mockImplementation(
+      () => new Promise<void>((resolve) => { release = () => resolve(); }),
+    );
+    const { hook, moveTo } = render(savedMap());
+
+    moveTo({ lng: -71.1, lat: 42.4, zoom: 14 });
+    let saving!: Promise<void>;
+    await act(async () => {
+      saving = hook.result.current.handleSave();
+      await Promise.resolve();
+    });
+
+    moveTo({ lng: -70.2, lat: 43.6 });
+    await act(async () => { release(); await saving; });
+
+    expect(hook.result.current.hasUnsavedChanges).toBe(true);
+  });
+
   it('clears the flag on save and re-dirties on the next pan', async () => {
     const { hook, moveTo, setMapData } = render(savedMap());
 
@@ -287,6 +311,46 @@ describe('fix(#1854): the dirty check mirrors the persisted precision', () => {
     expect(hook.result.current.hasUnsavedChanges).toBe(false);
 
     moveTo({ lng: -70.2, lat: 43.6 });
+    expect(hook.result.current.hasUnsavedChanges).toBe(true);
+  });
+});
+
+describe('fix(#1854): a camera sample belongs to the map it was taken on', () => {
+  // A direct /maps/:id navigation keeps this hook and the MapGL instance
+  // mounted, and nothing repositions the instance, so the previous map's view
+  // is still on screen. It is nobody's edit on the map now being shown.
+  const OTHER: Camera = { lng: 5.5, lat: 10.25, zoom: 6 };
+  const otherMap = () => savedMap({ id: 'map-2' }, OTHER);
+
+  it('goes clean when the map identity changes under a panned camera', () => {
+    const { hook, moveTo, setMapData } = render(savedMap());
+
+    moveTo({ lng: -71.1, lat: 42.4, zoom: 14 });
+    expect(hook.result.current.hasUnsavedChanges).toBe(true);
+
+    setMapData(otherMap());
+
+    expect(hook.result.current.hasUnsavedChanges).toBe(false);
+  });
+
+  it('stays clean when the leftover view merely settles on the new map', () => {
+    // maplibre's resize() fires movestart/move/moveend with no camera change,
+    // so the switched-to map does get a sample of the previous map's position.
+    const { hook, moveTo, setMapData } = render(savedMap());
+
+    moveTo({ lng: -71.1, lat: 42.4, zoom: 14 });
+    setMapData(otherMap());
+    moveTo({});
+
+    expect(hook.result.current.hasUnsavedChanges).toBe(false);
+  });
+
+  it('still dirties on a real pan made after the switch', () => {
+    const { hook, moveTo, setMapData } = render(savedMap());
+
+    setMapData(otherMap());
+    moveTo({ lng: 12.5, lat: 41.9, zoom: 9 });
+
     expect(hook.result.current.hasUnsavedChanges).toBe(true);
   });
 });

--- a/frontend/src/components/builder/hooks/__tests__/use-builder-layers.camera-dirty.test.ts
+++ b/frontend/src/components/builder/hooks/__tests__/use-builder-layers.camera-dirty.test.ts
@@ -1,0 +1,292 @@
+/**
+ * fix(#1854): every save rewrote center/zoom/bearing/pitch from the live map,
+ * but nothing in the builder's clean check looked at the camera. A pan or zoom
+ * therefore left `hasUnsavedChanges` false, so there was no navigation
+ * blocker, no beforeunload, and the new view was lost on navigate-away, while
+ * any unrelated save silently replaced the stored home view.
+ *
+ * These tests drive the real hooks (useBuilderLayers + useBuilderSave wired the
+ * way MapBuilderPage wires them) through a map mock that emits `moveend`, so
+ * they exercise the actual signal rather than the wiring.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { act } from '@testing-library/react';
+import { useRef } from 'react';
+import { renderHook } from '@/test/test-utils';
+import { useBuilderLayers } from '@/components/builder/hooks/use-builder-layers';
+import {
+  useBuilderSave,
+  __resetThumbnailDebounceForTests,
+  type SaveBaselineSync,
+} from '@/components/builder/hooks/use-builder-save';
+import {
+  makeBuilderLayer,
+  makeBuilderMap,
+  makeMapLibreMock,
+} from '@/components/builder/__tests__/fixtures/map-builder-fixtures';
+import type { MapResponse } from '@/types/api';
+
+type MaplibreMap = import('maplibre-gl').Map;
+
+/* ── Mocks (mirrors use-builder-layers-save-integration.test.ts) ───────── */
+
+const mockUpdateMapMutateAsync = vi.fn();
+const mockPatchMapLayersMutateAsync = vi.fn();
+const mockDuplicateMapMutateAsync = vi.fn();
+
+vi.mock('@/hooks/use-maps', () => ({
+  useUpdateMap: () => ({ mutateAsync: mockUpdateMapMutateAsync, isPending: false }),
+  usePatchMapLayers: () => ({ mutateAsync: mockPatchMapLayersMutateAsync, isPending: false }),
+  useDuplicateMap: () => ({ mutateAsync: mockDuplicateMapMutateAsync, isPending: false }),
+  useAddLayer: () => ({ mutate: vi.fn() }),
+  useRemoveLayer: () => ({ mutate: vi.fn() }),
+}));
+
+vi.mock('@/hooks/use-settings', () => ({
+  useEnabledPlugins: () => ({ data: null, isLoading: false }),
+  useTileConfig: () => ({ data: { cdn_base_url: null, mvt_source_layer_prefix: 'data' } }),
+}));
+
+vi.mock('@/hooks/use-edition', () => ({
+  useEdition: () => ({ edition: 'community', features: [], isEnterprise: false, isLoading: false }),
+}));
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn(), warning: vi.fn(), info: vi.fn() },
+}));
+
+vi.mock('@/api/maps', () => ({
+  bulkDeleteLayersApi: vi.fn(),
+  getMap: vi.fn(),
+  uploadThumbnail: vi.fn(() => Promise.resolve()),
+  uploadOgImage: vi.fn(() => Promise.resolve()),
+}));
+
+// useUnsavedGuard's useBlocker needs a Data Router; the shared renderHook
+// wrapper provides MemoryRouter, so stub it as the sibling suites do.
+const mockBlocker = { state: 'unblocked' as const, reset: vi.fn(), proceed: vi.fn() };
+vi.mock('react-router', async () => {
+  const actual = await vi.importActual('react-router');
+  return { ...actual, useBlocker: () => mockBlocker };
+});
+
+/* ── A map mock whose camera moves and whose `moveend` actually fires ──── */
+
+interface Camera {
+  lng: number;
+  lat: number;
+  zoom: number;
+  bearing?: number;
+  pitch?: number;
+}
+
+function makeMovableMap(initial: Camera) {
+  const handlers = new Map<string, Set<() => void>>();
+  const camera = { bearing: 0, pitch: 0, ...initial };
+
+  const map = {
+    ...makeMapLibreMock(),
+    getCenter: () => ({ lng: camera.lng, lat: camera.lat }),
+    getZoom: () => camera.zoom,
+    getBearing: () => camera.bearing,
+    getPitch: () => camera.pitch,
+    on: (event: string, handler: () => void) => {
+      if (!handlers.has(event)) handlers.set(event, new Set());
+      handlers.get(event)!.add(handler);
+    },
+    off: (event: string, handler: () => void) => {
+      handlers.get(event)?.delete(handler);
+    },
+  } as unknown as MaplibreMap;
+
+  /** Move the camera and settle, exactly as a drag-pan or wheel-zoom does. */
+  function moveTo(next: Partial<Camera>) {
+    Object.assign(camera, next);
+    act(() => {
+      handlers.get('moveend')?.forEach((handler) => handler());
+    });
+  }
+
+  return { map, moveTo, camera };
+}
+
+/* ── Harness: the two hooks wired as MapBuilderPage wires them ─────────── */
+
+function useCombinedBuilder(mapData: MapResponse, map: MaplibreMap) {
+  const mapInstanceRef = useRef<MaplibreMap | null>(map);
+  const saveBaselineSyncRef = useRef<SaveBaselineSync>({ add: () => {}, remove: () => {} });
+
+  const layers = useBuilderLayers(
+    mapData,
+    mapInstanceRef,
+    mapData.id,
+    { mutate: vi.fn() } as unknown as Parameters<typeof useBuilderLayers>[3],
+    { mutate: vi.fn() } as unknown as Parameters<typeof useBuilderLayers>[4],
+    saveBaselineSyncRef,
+    map,
+  );
+
+  const save = useBuilderSave({
+    mapId: mapData.id,
+    localLayers: layers.localLayers,
+    groupMeta: layers.groupMeta,
+    localBasemap: layers.localBasemap,
+    showBasemapLabels: layers.showBasemapLabels,
+    basemapConfig: layers.basemapConfig,
+    terrainConfig: layers.localTerrainConfig,
+    localName: layers.localName,
+    localDescription: layers.localDescription,
+    legendTitle: layers.localLegendTitle,
+    dockNotes: '',
+    mapInstanceRef,
+    setHasUnsavedChanges: layers.setHasUnsavedChanges,
+    hasUnsavedChanges: layers.hasUnsavedChanges,
+    hasThumbnail: true,
+    saveBaselineSyncRef,
+  });
+
+  return { ...layers, ...save };
+}
+
+const SAVED: Camera = { lng: -73.9, lat: 40.7, zoom: 10, bearing: 0, pitch: 0 };
+
+function savedMap(overrides: Partial<MapResponse> = {}, camera: Camera = SAVED): MapResponse {
+  return {
+    ...makeBuilderMap([makeBuilderLayer({ id: 'layer-1' })]),
+    center_lng: camera.lng,
+    center_lat: camera.lat,
+    zoom: camera.zoom,
+    bearing: camera.bearing ?? 0,
+    pitch: camera.pitch ?? 0,
+    ...overrides,
+  } as MapResponse;
+}
+
+function render(initialMapData: MapResponse, startCamera: Camera = SAVED) {
+  const { map, moveTo } = makeMovableMap(startCamera);
+  let mapData = initialMapData;
+  const hook = renderHook(() => useCombinedBuilder(mapData, map));
+  /** Stands in for the map-detail refetch a save invalidates. */
+  function setMapData(next: MapResponse) {
+    mapData = next;
+    act(() => { hook.rerender(); });
+  }
+  return { hook, moveTo, setMapData };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  __resetThumbnailDebounceForTests();
+  mockUpdateMapMutateAsync.mockResolvedValue({});
+  mockPatchMapLayersMutateAsync.mockResolvedValue({});
+});
+
+describe('fix(#1854): an unsaved camera move is unsaved work', () => {
+  it('marks the map dirty when the camera pans away from the saved view', () => {
+    const { hook, moveTo } = render(savedMap());
+    expect(hook.result.current.hasUnsavedChanges).toBe(false);
+
+    moveTo({ lng: -71.1, lat: 42.4 });
+
+    expect(hook.result.current.hasUnsavedChanges).toBe(true);
+  });
+
+  it('marks the map dirty on a zoom, a rotation and a tilt too', () => {
+    for (const move of [{ zoom: 14 }, { bearing: 45 }, { pitch: 30 }]) {
+      const { hook, moveTo } = render(savedMap());
+      moveTo(move);
+      expect(hook.result.current.hasUnsavedChanges).toBe(true);
+    }
+  });
+
+  it('clears the flag when the camera returns to the saved view', () => {
+    const { hook, moveTo } = render(savedMap());
+
+    moveTo({ lng: -71.1, lat: 42.4, zoom: 14 });
+    expect(hook.result.current.hasUnsavedChanges).toBe(true);
+
+    moveTo({ lng: SAVED.lng, lat: SAVED.lat, zoom: SAVED.zoom });
+    expect(hook.result.current.hasUnsavedChanges).toBe(false);
+  });
+
+  it('stays clean after a pan on a map that has no saved view', () => {
+    // A map with null center components opens at the world default, which no
+    // save-time camera would match; comparing there makes every new map dirty
+    // before the user has touched anything.
+    const { hook, moveTo } = render(savedMap({ center_lng: null, center_lat: null, zoom: null }));
+
+    moveTo({ lng: -71.1, lat: 42.4, zoom: 14 });
+
+    expect(hook.result.current.hasUnsavedChanges).toBe(false);
+  });
+
+  it('keeps the flag when a layer revert leaves the camera panned', () => {
+    // requestCleanRecheck is the banner Revert path; it must not report clean
+    // while the stored view is still out of date.
+    const { hook, moveTo } = render(savedMap());
+
+    moveTo({ lng: -71.1, lat: 42.4 });
+    act(() => { hook.result.current.requestCleanRecheck(); });
+
+    expect(hook.result.current.hasUnsavedChanges).toBe(true);
+  });
+
+  it('arms beforeunload for an unsaved camera move', () => {
+    const addSpy = vi.spyOn(window, 'addEventListener');
+    const { hook, moveTo } = render(savedMap());
+    expect(addSpy.mock.calls.filter(([event]) => event === 'beforeunload')).toHaveLength(0);
+
+    moveTo({ lng: -71.1, lat: 42.4 });
+
+    expect(hook.result.current.hasUnsavedChanges).toBe(true);
+    expect(addSpy).toHaveBeenCalledWith('beforeunload', expect.any(Function));
+    addSpy.mockRestore();
+  });
+});
+
+describe('fix(#1854): the dirty check mirrors the persisted precision', () => {
+  // The save payload and the clean check share ONE normalizer
+  // (builder-camera.ts), so the comparison grid IS the persisted grid: noise
+  // finer than the stored value cannot dirty, and anything the store would
+  // keep does.
+  it.each([
+    ['noise below the persisted precision', 1e-9, false],
+    ['a change the stored value would keep', 1e-4, true],
+  ])('%s reports %s', (_name, delta, expectDirty) => {
+    const { hook, moveTo } = render(savedMap());
+
+    moveTo({ lng: SAVED.lng + (delta as number), lat: SAVED.lat + (delta as number) });
+
+    expect(hook.result.current.hasUnsavedChanges).toBe(expectDirty);
+  });
+
+  it('persists exactly the camera the dirty check compared', async () => {
+    const { hook, moveTo } = render(savedMap());
+
+    moveTo({ lng: -71.123456789, lat: 42.987654321, zoom: 12.3456789 });
+    await act(async () => { await hook.result.current.handleSave(); });
+
+    const payload = mockUpdateMapMutateAsync.mock.calls[0][0].data;
+    expect(payload.center_lng).toBe(-71.123457);
+    expect(payload.center_lat).toBe(42.987654);
+    expect(payload.zoom).toBe(12.345679);
+  });
+
+  it('clears the flag on save and re-dirties on the next pan', async () => {
+    const { hook, moveTo, setMapData } = render(savedMap());
+
+    moveTo({ lng: -71.1, lat: 42.4, zoom: 14 });
+    expect(hook.result.current.hasUnsavedChanges).toBe(true);
+
+    await act(async () => { await hook.result.current.handleSave(); });
+    expect(hook.result.current.hasUnsavedChanges).toBe(false);
+
+    // The save invalidates the map-detail query; the refetch brings back the
+    // view that was just stored.
+    setMapData(savedMap({}, { lng: -71.1, lat: 42.4, zoom: 14 }));
+    expect(hook.result.current.hasUnsavedChanges).toBe(false);
+
+    moveTo({ lng: -70.2, lat: 43.6 });
+    expect(hook.result.current.hasUnsavedChanges).toBe(true);
+  });
+});

--- a/frontend/src/components/builder/hooks/__tests__/use-builder-layers.camera-dirty.test.ts
+++ b/frontend/src/components/builder/hooks/__tests__/use-builder-layers.camera-dirty.test.ts
@@ -10,9 +10,12 @@
  * they exercise the actual signal rather than the wiring.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { act } from '@testing-library/react';
-import { useRef } from 'react';
-import { renderHook } from '@/test/test-utils';
+import { act, renderHook } from '@testing-library/react';
+import { useEffect, useRef, useState } from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter } from 'react-router';
+import { createElement, type ReactNode } from 'react';
+import { queryKeys } from '@/lib/query-keys';
 import { useBuilderLayers } from '@/components/builder/hooks/use-builder-layers';
 import {
   useBuilderSave,
@@ -112,14 +115,32 @@ function makeMovableMap(initial: Camera) {
 
 /* ── Harness: the two hooks wired as MapBuilderPage wires them ─────────── */
 
-function useCombinedBuilder(mapData: MapResponse, map: MaplibreMap) {
+/**
+ * MapBuilderPage reads mapData from the map-detail query, so the harness has to
+ * as well: the save path publishes the camera it persisted into that cache, and
+ * a plain prop would not see it. This is useQuery minus the fetching.
+ */
+function useCachedMap(client: QueryClient, mapId: string): MapResponse | undefined {
+  const key = queryKeys.maps.detail(mapId);
+  const [data, setData] = useState(() => client.getQueryData<MapResponse>(key));
+  useEffect(() => {
+    setData(client.getQueryData<MapResponse>(queryKeys.maps.detail(mapId)));
+    return client.getQueryCache().subscribe(() => {
+      setData(client.getQueryData<MapResponse>(queryKeys.maps.detail(mapId)));
+    });
+  }, [client, mapId]);
+  return data;
+}
+
+function useCombinedBuilder(client: QueryClient, mapId: string, map: MaplibreMap) {
+  const mapData = useCachedMap(client, mapId) as MapResponse;
   const mapInstanceRef = useRef<MaplibreMap | null>(map);
   const saveBaselineSyncRef = useRef<SaveBaselineSync>({ add: () => {}, remove: () => {} });
 
   const layers = useBuilderLayers(
     mapData,
     mapInstanceRef,
-    mapData.id,
+    mapId,
     { mutate: vi.fn() } as unknown as Parameters<typeof useBuilderLayers>[3],
     { mutate: vi.fn() } as unknown as Parameters<typeof useBuilderLayers>[4],
     saveBaselineSyncRef,
@@ -127,7 +148,7 @@ function useCombinedBuilder(mapData: MapResponse, map: MaplibreMap) {
   );
 
   const save = useBuilderSave({
-    mapId: mapData.id,
+    mapId,
     localLayers: layers.localLayers,
     groupMeta: layers.groupMeta,
     localBasemap: layers.localBasemap,
@@ -164,14 +185,29 @@ function savedMap(overrides: Partial<MapResponse> = {}, camera: Camera = SAVED):
 
 function render(initialMapData: MapResponse, startCamera: Camera = SAVED) {
   const { map, moveTo } = makeMovableMap(startCamera);
-  let mapData = initialMapData;
-  const hook = renderHook(() => useCombinedBuilder(mapData, map));
-  /** Stands in for the map-detail refetch a save invalidates. */
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  client.setQueryData(queryKeys.maps.detail(initialMapData.id), initialMapData);
+  let mapId = initialMapData.id;
+
+  function Wrapper({ children }: { children: ReactNode }) {
+    return createElement(
+      QueryClientProvider,
+      { client },
+      createElement(MemoryRouter, null, children),
+    );
+  }
+
+  const hook = renderHook(() => useCombinedBuilder(client, mapId, map), { wrapper: Wrapper });
+
+  /** In-app navigation to another map: this hook and the MapGL instance stay mounted. */
   function setMapData(next: MapResponse) {
-    mapData = next;
+    client.setQueryData(queryKeys.maps.detail(next.id), next);
+    mapId = next.id;
     act(() => { hook.rerender(); });
   }
-  return { hook, moveTo, setMapData };
+  return { hook, moveTo, setMapData, client };
 }
 
 beforeEach(() => {
@@ -209,15 +245,28 @@ describe('fix(#1854): an unsaved camera move is unsaved work', () => {
     expect(hook.result.current.hasUnsavedChanges).toBe(false);
   });
 
-  it('stays clean after a pan on a map that has no saved view', () => {
-    // A map with null center components opens at the world default, which no
-    // save-time camera would match; comparing there makes every new map dirty
-    // before the user has touched anything.
-    const { hook, moveTo } = render(savedMap({ center_lng: null, center_lat: null, zoom: null }));
+  // A map with null center components (new, or legacy) is still saved with a
+  // camera, so movement on one is unsaved work like anywhere else. What keeps
+  // it clean untouched is the entry camera, not the absence of a stored view.
+  describe('a map with no stored view', () => {
+    const WORLD: Camera = { lng: 0, lat: 20, zoom: 2 };
+    const centerless = () => savedMap({ center_lng: null, center_lat: null, zoom: null }, WORLD);
 
-    moveTo({ lng: -71.1, lat: 42.4, zoom: 14 });
+    it('dirties when the camera moves after entry', () => {
+      const { hook, moveTo } = render(centerless(), WORLD);
 
-    expect(hook.result.current.hasUnsavedChanges).toBe(false);
+      moveTo({ lng: -71.1, lat: 42.4, zoom: 14 });
+
+      expect(hook.result.current.hasUnsavedChanges).toBe(true);
+    });
+
+    it('stays clean when only the entry view settles', () => {
+      const { hook, moveTo } = render(centerless(), WORLD);
+
+      moveTo({});
+
+      expect(hook.result.current.hasUnsavedChanges).toBe(false);
+    });
   });
 
   it('keeps the flag when a layer revert leaves the camera panned', () => {
@@ -296,18 +345,28 @@ describe('fix(#1854): the dirty check mirrors the persisted precision', () => {
     expect(hook.result.current.hasUnsavedChanges).toBe(true);
   });
 
+  it('stays dirty when the camera returns to the pre-save view', async () => {
+    // useUpdateMap only invalidates the detail query, so mapData would keep the
+    // pre-save camera until the refetch lands, and forever if it fails. Moving
+    // back to that stale position must not read as clean.
+    const { hook, moveTo } = render(savedMap());
+
+    moveTo({ lng: -71.1, lat: 42.4, zoom: 14 });
+    await act(async () => { await hook.result.current.handleSave(); });
+    expect(hook.result.current.hasUnsavedChanges).toBe(false);
+
+    moveTo({ lng: SAVED.lng, lat: SAVED.lat, zoom: SAVED.zoom });
+
+    expect(hook.result.current.hasUnsavedChanges).toBe(true);
+  });
+
   it('clears the flag on save and re-dirties on the next pan', async () => {
-    const { hook, moveTo, setMapData } = render(savedMap());
+    const { hook, moveTo } = render(savedMap());
 
     moveTo({ lng: -71.1, lat: 42.4, zoom: 14 });
     expect(hook.result.current.hasUnsavedChanges).toBe(true);
 
     await act(async () => { await hook.result.current.handleSave(); });
-    expect(hook.result.current.hasUnsavedChanges).toBe(false);
-
-    // The save invalidates the map-detail query; the refetch brings back the
-    // view that was just stored.
-    setMapData(savedMap({}, { lng: -71.1, lat: 42.4, zoom: 14 }));
     expect(hook.result.current.hasUnsavedChanges).toBe(false);
 
     moveTo({ lng: -70.2, lat: 43.6 });

--- a/frontend/src/components/builder/hooks/use-builder-layers.ts
+++ b/frontend/src/components/builder/hooks/use-builder-layers.ts
@@ -49,6 +49,13 @@ import { useLayerStyleClipboard } from '@/components/builder/hooks/use-layer-sty
 import { useTileConfig } from '@/hooks/use-settings';
 export { buildDuplicateRenderingInput } from '@/components/builder/hooks/builder-layer-mutations';
 
+// fix(#1854): a camera reading is only meaningful together with the map it was
+// read for, so the two always travel as one value.
+interface CameraSample {
+  mapId: string | null;
+  camera: BuilderCamera;
+}
+
 // True when a local text field and its saved value would persist identically.
 // The save payload is `value.trim() || null`, and the field hydrates raw.
 function sameSavedText(local: string | null | undefined, saved: string | null | undefined): boolean {
@@ -122,10 +129,19 @@ export function useBuilderLayers(
   const layersMapIdRef = useRef<string | null>(null);
   const [localBasemap, setLocalBasemap] = useState<string>('openfreemap-positron');
   const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false);
-  // fix(#1854): the live camera, sampled on moveend. Null until the map has
-  // settled once, because a map that never moved cannot have changed the view
-  // a save would store.
-  const [liveCamera, setLiveCamera] = useState<BuilderCamera | null>(null);
+  // fix(#1854): the live camera, sampled on moveend, tagged with the map it was
+  // taken on. Null until the map has settled once, because a map that never
+  // moved cannot have changed the view a save would store. The tag matters
+  // because a direct /maps/:id navigation keeps this hook AND the MapGL
+  // instance mounted: a sample from the previous map must never be judged
+  // against the next map's saved view.
+  const [liveCamera, setLiveCamera] = useState<CameraSample | null>(null);
+  // The camera the current map was entered on. On a fresh load that is the
+  // saved view MapGL was constructed with; after in-page navigation it is
+  // still the PREVIOUS map's position, because nothing repositions the shared
+  // instance. Either way it is not an edit made here, so a sample equal to it
+  // is not unsaved work.
+  const cameraEntryRef = useRef<CameraSample | null>(null);
   // fix(#913): dirt this hook cannot re-derive from server state — plugin
   // toggles and other page-owned edits that go through markDirty. recheckClean
   // refuses to clear the flag while it is set; every reset back to "saved"
@@ -948,6 +964,22 @@ export function useBuilderLayers(
     setHasUnsavedChanges(true);
   }, []);
 
+  // fix(#1854): the live camera when it is an unsaved edit made on THIS map,
+  // and null otherwise. Null covers four cases that all mean "the stored view
+  // is not waiting on this user": the map has no stored view at all (a new map
+  // opens at the world default, which no save-time camera would match, so
+  // comparing there makes every new map dirty untouched); the sample was taken
+  // on a different map; the camera is still the one this map was entered on;
+  // and the camera already matches what is stored.
+  const unsavedCamera = useCallback((): BuilderCamera | null => {
+    if (!mapData || !hasSavedMapCamera(mapData)) return null;
+    if (!liveCamera || liveCamera.mapId !== mapData.id) return null;
+    const entry = cameraEntryRef.current;
+    if (entry?.mapId === mapData.id && sameMapCamera(liveCamera.camera, entry.camera)) return null;
+    if (sameMapCamera(liveCamera.camera, savedMapCamera(mapData))) return null;
+    return liveCamera.camera;
+  }, [liveCamera, mapData]);
+
   // fix(#913): a banner Revert restores the saved layer through the ordinary
   // mutation handlers, and every one of those marks the map dirty — so the
   // revert itself re-dirtied the map and nothing ever cleared the flag. Rather
@@ -988,12 +1020,9 @@ export function useBuilderLayers(
     if (!deepEqual(basemapConfig, mapData.basemap_config ?? null)) return false;
     if (!deepEqual(localTerrainConfig, savedTerrainConfig(mapData))) return false;
     // fix(#1854): every save rewrites center/zoom/bearing/pitch from the live
-    // map, so an unsaved pan is a real pending change to the stored view. Only
-    // compared once the map has a stored view of its own: a map that has none
-    // opens at the world default, which no save-time camera would match, and
-    // every new map would read dirty before the user touched anything.
-    if (liveCamera && hasSavedMapCamera(mapData)
-      && !sameMapCamera(liveCamera, savedMapCamera(mapData))) return false;
+    // map, so a pan this user made here and has not saved is a real pending
+    // change to the stored view.
+    if (unsavedCamera()) return false;
 
     // fix(#913 review): folder expansion is persisted (prepareLayersForPersistence
     // reads groupMeta), and handleToggleGroupExpand marks the map dirty — without
@@ -1010,7 +1039,7 @@ export function useBuilderLayers(
     return true;
   }, [
     mapData, localName, localDescription, localLegendTitle, localBasemap,
-    showBasemapLabels, basemapConfig, localTerrainConfig, groupMeta, liveCamera,
+    showBasemapLabels, basemapConfig, localTerrainConfig, groupMeta, unsavedCamera,
   ]);
 
   // The recheck must observe the reverted layers, so it runs in an effect after
@@ -1033,6 +1062,15 @@ export function useBuilderLayers(
     setHasUnsavedChanges(false);
   }, [recheckNonce, computeMapIsClean]);
 
+  // fix(#1854): the camera a change of map identity starts from. Re-read on
+  // every identity change because the shared MapGL instance is not
+  // repositioned by one, so what is on screen is still the previous map's view.
+  const currentMapId = mapData?.id ?? null;
+  useEffect(() => {
+    const map = mapInstance ?? mapInstanceRef.current;
+    cameraEntryRef.current = { mapId: currentMapId, camera: readMapCamera(map) };
+  }, [currentMapId, mapInstance, mapInstanceRef]);
+
   // fix(#1854): moveend is the canonical "the camera settled" signal. It fires
   // once per gesture rather than per frame, so no debounce of our own is
   // needed. Reads through the reactive mapInstance because a ref flipping
@@ -1042,23 +1080,22 @@ export function useBuilderLayers(
     // Partial map doubles in sibling suites carry no event emitter; without a
     // moveend there is simply no camera signal, exactly as before this fix.
     if (!map || typeof map.on !== 'function') return;
-    const handleMoveEnd = () => setLiveCamera(readMapCamera(map));
+    const handleMoveEnd = () => setLiveCamera({ mapId: currentMapId, camera: readMapCamera(map) });
     map.on('moveend', handleMoveEnd);
     return () => { map.off?.('moveend', handleMoveEnd); };
-  }, [mapInstance, mapInstanceRef]);
+  }, [currentMapId, mapInstance, mapInstanceRef]);
 
-  // fix(#1854): a pan away from the stored view is unsaved work (the navigation
-  // blocker and beforeunload both read hasUnsavedChanges); a pan back to it asks
-  // for the ordinary recheck, which clears the flag only if nothing else is
-  // outstanding.
+  // fix(#1854): an unsaved camera edit is unsaved work (the navigation blocker
+  // and beforeunload both read hasUnsavedChanges); anything else asks for the
+  // ordinary recheck, which clears the flag only if nothing else is outstanding.
   useEffect(() => {
-    if (!liveCamera || !mapData || !hasSavedMapCamera(mapData)) return;
-    if (sameMapCamera(liveCamera, savedMapCamera(mapData))) {
-      requestCleanRecheck();
+    if (!liveCamera) return;
+    if (unsavedCamera()) {
+      setHasUnsavedChanges(true);
       return;
     }
-    setHasUnsavedChanges(true);
-  }, [liveCamera, mapData, requestCleanRecheck]);
+    requestCleanRecheck();
+  }, [liveCamera, unsavedCamera, requestCleanRecheck]);
 
   // fix(v1.6.0 audit D7): identity-stable "is this row a folder group?" lookup.
   // Reads through layersRef so callers (MapBuilderPage's memoized

--- a/frontend/src/components/builder/hooks/use-builder-layers.ts
+++ b/frontend/src/components/builder/hooks/use-builder-layers.ts
@@ -136,11 +136,10 @@ export function useBuilderLayers(
   // instance mounted: a sample from the previous map must never be judged
   // against the next map's saved view.
   const [liveCamera, setLiveCamera] = useState<CameraSample | null>(null);
-  // The camera the current map was entered on. On a fresh load that is the
-  // saved view MapGL was constructed with; after in-page navigation it is
-  // still the PREVIOUS map's position, because nothing repositions the shared
-  // instance. Either way it is not an edit made here, so a sample equal to it
-  // is not unsaved work.
+  // The camera the current map was entered on, until the camera leaves it. On a
+  // fresh load that is the saved view MapGL was constructed with; after in-page
+  // navigation it is still the PREVIOUS map's position, because nothing
+  // repositions the shared instance. Either way it is not an edit made here.
   const cameraEntryRef = useRef<CameraSample | null>(null);
   // fix(#913): dirt this hook cannot re-derive from server state — plugin
   // toggles and other page-owned edits that go through markDirty. recheckClean
@@ -381,7 +380,7 @@ export function useBuilderLayers(
     // callback — layersRef is only synced via the useLayoutEffect mirror on
     // commit (the same staleness #554 documented for the add-layer merge),
     // so it would still be missing the layer just created.
-    const hasSavedView = mapData?.center_lng != null && mapData?.center_lat != null;
+    const hasSavedView = hasSavedMapCamera(mapData);
     handleAddDataset(
       datasetId,
       hasSavedView ? undefined : (newLayerId) => { pendingAutoZoomLayerIdRef.current = newLayerId; },
@@ -965,15 +964,11 @@ export function useBuilderLayers(
   }, []);
 
   // fix(#1854): the live camera when it is an unsaved edit made on THIS map,
-  // and null otherwise. Null covers four cases that all mean "the stored view
-  // is not waiting on this user": the map has no stored view at all (a new map
-  // opens at the world default, which no save-time camera would match, so
-  // comparing there makes every new map dirty untouched); the sample was taken
-  // on a different map; the camera is still the one this map was entered on;
-  // and the camera already matches what is stored.
+  // and null otherwise. The entry camera is what keeps an untouched map clean,
+  // so this applies to a map with no stored view too: handleSave persists the
+  // camera either way, so movement after entry is unsaved work on every map.
   const unsavedCamera = useCallback((): BuilderCamera | null => {
-    if (!mapData || !hasSavedMapCamera(mapData)) return null;
-    if (!liveCamera || liveCamera.mapId !== mapData.id) return null;
+    if (!mapData || !liveCamera || liveCamera.mapId !== mapData.id) return null;
     const entry = cameraEntryRef.current;
     if (entry?.mapId === mapData.id && sameMapCamera(liveCamera.camera, entry.camera)) return null;
     if (sameMapCamera(liveCamera.camera, savedMapCamera(mapData))) return null;
@@ -1080,7 +1075,17 @@ export function useBuilderLayers(
     // Partial map doubles in sibling suites carry no event emitter; without a
     // moveend there is simply no camera signal, exactly as before this fix.
     if (!map || typeof map.on !== 'function') return;
-    const handleMoveEnd = () => setLiveCamera({ mapId: currentMapId, camera: readMapCamera(map) });
+    const handleMoveEnd = () => {
+      const sample = { mapId: currentMapId, camera: readMapCamera(map) };
+      const entry = cameraEntryRef.current;
+      // The entry view excuses itself only until the camera leaves it. Coming
+      // back to that position later is a choice the user made, and after a save
+      // it is no longer what the server holds.
+      if (entry?.mapId === currentMapId && !sameMapCamera(sample.camera, entry.camera)) {
+        cameraEntryRef.current = null;
+      }
+      setLiveCamera(sample);
+    };
     map.on('moveend', handleMoveEnd);
     return () => { map.off?.('moveend', handleMoveEnd); };
   }, [currentMapId, mapInstance, mapInstanceRef]);

--- a/frontend/src/components/builder/hooks/use-builder-layers.ts
+++ b/frontend/src/components/builder/hooks/use-builder-layers.ts
@@ -11,6 +11,13 @@ import {
   type BuilderLayerAction,
 } from '@/components/builder/builder-action-contract';
 import { resolveBasemapId } from '@/lib/basemap-utils';
+import {
+  hasSavedMapCamera,
+  readMapCamera,
+  sameMapCamera,
+  savedMapCamera,
+  type BuilderCamera,
+} from '@/components/builder/builder-camera';
 import { deepEqual } from '@/components/builder/LayerStyleEditor/utils';
 import type { MapBasemapConfig, MapLayerResponse, MapResponse, MapTerrainConfig, StyleConfig } from '@/types/api';
 import type { useAddLayer, useRemoveLayer } from '@/hooks/use-maps';
@@ -115,6 +122,10 @@ export function useBuilderLayers(
   const layersMapIdRef = useRef<string | null>(null);
   const [localBasemap, setLocalBasemap] = useState<string>('openfreemap-positron');
   const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false);
+  // fix(#1854): the live camera, sampled on moveend. Null until the map has
+  // settled once, because a map that never moved cannot have changed the view
+  // a save would store.
+  const [liveCamera, setLiveCamera] = useState<BuilderCamera | null>(null);
   // fix(#913): dirt this hook cannot re-derive from server state — plugin
   // toggles and other page-owned edits that go through markDirty. recheckClean
   // refuses to clear the flag while it is set; every reset back to "saved"
@@ -976,6 +987,14 @@ export function useBuilderLayers(
     if (showBasemapLabels !== (mapData.show_basemap_labels ?? true)) return false;
     if (!deepEqual(basemapConfig, mapData.basemap_config ?? null)) return false;
     if (!deepEqual(localTerrainConfig, savedTerrainConfig(mapData))) return false;
+    // fix(#1854): every save rewrites center/zoom/bearing/pitch from the live
+    // map, so an unsaved pan is a real pending change to the stored view. Only
+    // compared once the map has a stored view of its own: a map that has none
+    // opens at the world default, which no save-time camera would match, and
+    // every new map would read dirty before the user touched anything.
+    if (liveCamera && hasSavedMapCamera(mapData)
+      && !sameMapCamera(liveCamera, savedMapCamera(mapData))) return false;
+
     // fix(#913 review): folder expansion is persisted (prepareLayersForPersistence
     // reads groupMeta), and handleToggleGroupExpand marks the map dirty — without
     // this an expand-then-revert reported clean and the expansion was lost.
@@ -991,7 +1010,7 @@ export function useBuilderLayers(
     return true;
   }, [
     mapData, localName, localDescription, localLegendTitle, localBasemap,
-    showBasemapLabels, basemapConfig, localTerrainConfig, groupMeta,
+    showBasemapLabels, basemapConfig, localTerrainConfig, groupMeta, liveCamera,
   ]);
 
   // The recheck must observe the reverted layers, so it runs in an effect after
@@ -1013,6 +1032,33 @@ export function useBuilderLayers(
     recheckPendingRef.current = false;
     setHasUnsavedChanges(false);
   }, [recheckNonce, computeMapIsClean]);
+
+  // fix(#1854): moveend is the canonical "the camera settled" signal. It fires
+  // once per gesture rather than per frame, so no debounce of our own is
+  // needed. Reads through the reactive mapInstance because a ref flipping
+  // non-null does not re-run an effect.
+  useEffect(() => {
+    const map = mapInstance ?? mapInstanceRef.current;
+    // Partial map doubles in sibling suites carry no event emitter; without a
+    // moveend there is simply no camera signal, exactly as before this fix.
+    if (!map || typeof map.on !== 'function') return;
+    const handleMoveEnd = () => setLiveCamera(readMapCamera(map));
+    map.on('moveend', handleMoveEnd);
+    return () => { map.off?.('moveend', handleMoveEnd); };
+  }, [mapInstance, mapInstanceRef]);
+
+  // fix(#1854): a pan away from the stored view is unsaved work (the navigation
+  // blocker and beforeunload both read hasUnsavedChanges); a pan back to it asks
+  // for the ordinary recheck, which clears the flag only if nothing else is
+  // outstanding.
+  useEffect(() => {
+    if (!liveCamera || !mapData || !hasSavedMapCamera(mapData)) return;
+    if (sameMapCamera(liveCamera, savedMapCamera(mapData))) {
+      requestCleanRecheck();
+      return;
+    }
+    setHasUnsavedChanges(true);
+  }, [liveCamera, mapData, requestCleanRecheck]);
 
   // fix(v1.6.0 audit D7): identity-stable "is this row a folder group?" lookup.
   // Reads through layersRef so callers (MapBuilderPage's memoized

--- a/frontend/src/components/builder/hooks/use-builder-save.ts
+++ b/frontend/src/components/builder/hooks/use-builder-save.ts
@@ -7,6 +7,7 @@ import { toast } from 'sonner';
 import { useQueryClient } from '@tanstack/react-query';
 import type { Map as MaplibreMap } from 'maplibre-gl';
 import { getSourceIdForLayer } from '@/components/builder/map-sync';
+import { readMapCamera } from '@/components/builder/builder-camera';
 import { hasGlobeSpaceBackdrop } from '@/components/builder/map-composition-sync';
 import { ApiError } from '@/api/client';
 import { useUpdateMap, useDuplicateMap, usePatchMapLayers } from '@/hooks/use-maps';
@@ -1078,10 +1079,10 @@ export function useBuilderSave(state: SaveState) {
     }
 
     const map = mapInstanceRef.current;
-    const center = map?.getCenter();
-    const zoom = map?.getZoom();
-    const bearing = map?.getBearing();
-    const pitch = map?.getPitch();
+    // fix(#1854): the persisted camera goes through the shared normalizer that
+    // the builder's dirty check also reads, so a pan that would change the
+    // stored view is exactly the pan that marks the map unsaved.
+    const camera = readMapCamera(map);
 
     // Phase 1051 UX-03: basemap_position is encoded as a field on basemapConfig
     // (MapBasemapConfig.basemap_position jsonb), so it round-trips through the
@@ -1097,11 +1098,11 @@ export function useBuilderSave(state: SaveState) {
       show_basemap_labels: showBasemapLabels,
       basemap_config: basemapConfig,
       terrain_config: terrainConfig,
-      center_lng: center?.lng ?? null,
-      center_lat: center?.lat ?? null,
-      zoom: zoom ?? null,
-      bearing: bearing ?? 0,
-      pitch: pitch ?? 0,
+      center_lng: camera.center_lng,
+      center_lat: camera.center_lat,
+      zoom: camera.zoom,
+      bearing: camera.bearing,
+      pitch: camera.pitch,
       plugins: resolvePluginsPayload(id, queryClient, enabledPluginIds),
       // ENH-06: persist the custom legend title. Empty/null clears it server-side.
       legend_title: legendTitle && legendTitle.trim() ? legendTitle.trim() : null,

--- a/frontend/src/components/builder/hooks/use-builder-save.ts
+++ b/frontend/src/components/builder/hooks/use-builder-save.ts
@@ -1089,6 +1089,16 @@ export function useBuilderSave(state: SaveState) {
     // the builder's dirty check also reads, so a pan that would change the
     // stored view is exactly the pan that marks the map unsaved.
     const camera = readMapCamera(map);
+    // fix(#1854): useUpdateMap only invalidates the detail query, so mapData
+    // keeps the pre-save camera until the refetch lands, and forever if it
+    // fails. The dirty check reads mapData, so publish what the server holds.
+    const commitSavedCamera = () => {
+      if (!id) return;
+      queryClient.setQueryData<MapResponse>(
+        queryKeys.maps.detail(id),
+        (prev) => (prev ? { ...prev, ...camera } : prev),
+      );
+    };
 
     // Phase 1051 UX-03: basemap_position is encoded as a field on basemapConfig
     // (MapBasemapConfig.basemap_position jsonb), so it round-trips through the
@@ -1156,6 +1166,7 @@ export function useBuilderSave(state: SaveState) {
               }
               await updateMap.mutateAsync({ id, data: metadataPayload });
               baselineLayersRef.current = stampPersistedFolderGroupExpanded(localLayers, groupMeta);
+              commitSavedCamera();
               toast.warning(t('toasts.mapSavedAfterRemoteChange'));
               if (!editedDuringSave(state, sentPluginSet, camera)) {
                 state.setHasUnsavedChanges(false);
@@ -1175,6 +1186,7 @@ export function useBuilderSave(state: SaveState) {
             // fix(#833 codex): baseline carries the SENT collapse state, not
             // the loaded markers — see the baseline effect above.
             baselineLayersRef.current = stampPersistedFolderGroupExpanded(localLayers, groupMeta);
+            commitSavedCamera();
             toast.warning(t('toasts.mapSavedFullResync', {
               defaultValue: 'Map saved, but required a full re-sync. Please double-check layer styling.',
             }));
@@ -1194,6 +1206,7 @@ export function useBuilderSave(state: SaveState) {
       // fix(#833 codex): baseline carries the SENT collapse state, not the
       // loaded markers — see the baseline effect above.
       baselineLayersRef.current = stampPersistedFolderGroupExpanded(localLayers, groupMeta);
+      commitSavedCamera();
       toast.success(t('toasts.mapSaved'));
       // fix(#756): the baseline above is the SENT snapshot; only clear the
       // dirty flag when nothing was edited during the network await —

--- a/frontend/src/components/builder/hooks/use-builder-save.ts
+++ b/frontend/src/components/builder/hooks/use-builder-save.ts
@@ -7,7 +7,7 @@ import { toast } from 'sonner';
 import { useQueryClient } from '@tanstack/react-query';
 import type { Map as MaplibreMap } from 'maplibre-gl';
 import { getSourceIdForLayer } from '@/components/builder/map-sync';
-import { readMapCamera } from '@/components/builder/builder-camera';
+import { readMapCamera, sameMapCamera, type BuilderCamera } from '@/components/builder/builder-camera';
 import { hasGlobeSpaceBackdrop } from '@/components/builder/map-composition-sync';
 import { ApiError } from '@/api/client';
 import { useUpdateMap, useDuplicateMap, usePatchMapLayers } from '@/hooks/use-maps';
@@ -1003,8 +1003,14 @@ export function useBuilderSave(state: SaveState) {
   function editedDuringSave(
     sent: SaveState,
     sentPluginSet: ReadonlySet<string>,
+    sentCamera: BuilderCamera,
   ): boolean {
     const latest = latestStateRef.current;
+    // fix(#1854): the camera is read off the map, not off SaveState, so a pan
+    // during the round trip changes none of the fields below. What was
+    // persisted is sentCamera; any other view on screen now is still unsaved,
+    // and clearing the flag here would hide it until a refetch that may fail.
+    if (!sameMapCamera(sentCamera, readMapCamera(latest.mapInstanceRef.current))) return true;
     // codex(#792): the plugins payload reads usePluginStore directly, not
     // SaveState, so a mid-save plugin toggle changes none of the fields
     // below — compare the store's Set identity too (every toggle produces
@@ -1151,7 +1157,7 @@ export function useBuilderSave(state: SaveState) {
               await updateMap.mutateAsync({ id, data: metadataPayload });
               baselineLayersRef.current = stampPersistedFolderGroupExpanded(localLayers, groupMeta);
               toast.warning(t('toasts.mapSavedAfterRemoteChange'));
-              if (!editedDuringSave(state, sentPluginSet)) {
+              if (!editedDuringSave(state, sentPluginSet, camera)) {
                 state.setHasUnsavedChanges(false);
               }
               if (map && id) captureThumbnail(map, id, queryClient, localLayers);
@@ -1175,7 +1181,7 @@ export function useBuilderSave(state: SaveState) {
             // fix(#756): the baseline above is the SENT snapshot; only clear
             // the dirty flag when nothing was edited during the await, so a
             // mid-save edit stays diffable and guarded.
-            if (!editedDuringSave(state, sentPluginSet)) {
+            if (!editedDuringSave(state, sentPluginSet, camera)) {
               state.setHasUnsavedChanges(false);
             }
             if (map && id) captureThumbnail(map, id, queryClient, localLayers);
@@ -1193,7 +1199,7 @@ export function useBuilderSave(state: SaveState) {
       // dirty flag when nothing was edited during the network await —
       // otherwise the baseline effect would absorb the mid-save edit and the
       // query-invalidation resync would overwrite it on screen.
-      if (!editedDuringSave(state, sentPluginSet)) {
+      if (!editedDuringSave(state, sentPluginSet, camera)) {
         state.setHasUnsavedChanges(false);
       }
 


### PR DESCRIPTION
Second half of #1854. The first half (auto-zoom on `?add_dataset`) merged in #1863 and is untouched here.

## The defect

`computeMapIsClean` in `use-builder-layers.ts` compared layers, name, description, legend title, basemap, labels, basemap config, terrain and folder expansion, but not the camera. `use-builder-save.ts` persisted `center_lng`, `center_lat`, `zoom`, `bearing` and `pitch` from the live map on every save. Two consequences:

- A pan or zoom never set `hasUnsavedChanges`. No navigation blocker, no beforeunload, and the new view was silently lost on navigate-away.
- Any unrelated save replaced the stored home view with wherever the camera happened to be.

## The fix

The builder has no "set home view" control, so by the product's current semantics the stored view is the camera at the last save. Those semantics are kept. What changes is that the clean check now tells the truth under the builder's own dirty model, where dirty means saving now would change the stored value.

`frontend/src/components/builder/builder-camera.ts` is the single normalizer for the five persisted viewport fields. `use-builder-save.ts` builds the payload through it and `use-builder-layers.ts` compares through it, so the comparison grid is the persisted grid by construction rather than by two sites agreeing to stay in step.

Three rules the comparison follows:

1. The camera is compared only when the map already has a stored view (`center_lng`/`center_lat` non-null, the same predicate `BuilderMap`'s `hasSavedView` reads). A map with no stored view opens at the world default, which no save-time camera would match, so comparing there would make every new map dirty before the user touched anything.
2. `moveend` is the signal. It fires once per gesture rather than per frame, so it needs no debounce, and it covers drag-pan inertia, wheel zoom, keyboard nav and programmatic `flyTo` alike. The listener attaches through the reactive `mapInstance` argument added in #1863, because a ref flipping non-null does not re-run an effect.
3. A pan back onto the stored view calls the existing `requestCleanRecheck`, which clears the flag only when nothing else is outstanding. The live camera is also a dependency of `computeMapIsClean`, so the `recheckNonce` effect observes it the way it observes every other field.

The payload keeps its shape. Values are now rounded to 6 decimals, about 11 cm of longitude, finer than any home view needs and coarser than the float noise a round trip through the map transform introduces. The column is `double precision`, so nothing is lost that the store was keeping. A non-finite reading normalizes to null: `NaN !== NaN` would otherwise pin the unsaved indicator on for the rest of the session.

No new control, no new setting, no new `t()` key, no API or schema change.

## On the revert path

The brief asked for the existing revert path to stay consistent. The only revert in the builder is the per-layer banner Revert (`LayerStyleEditor` -> `onRevertToSaved` -> `requestCleanRecheck`), which is layer-scoped and already does not restore the map name, description or basemap. Moving the camera from it would be the inconsistent choice. It now reports the map as still dirty when the camera is panned, which is truthful, and there is a test for that.

## Verification

Run from the worktree, all green:

```
cd frontend
npx vitest run src/components/builder/hooks/__tests__/use-builder-layers.camera-dirty.test.ts   # 10 passed
npx vitest run src/components/builder/hooks                                                     # 463 passed (30 files)
npx vitest run                                                                                  # 5980 passed (452 files)
npm run typecheck                                                                               # clean
npm run lint                                                                                    # clean
npm run test:i18n                                                                               # 4 passed
```

Counterfactual, with `use-builder-layers.ts` and `use-builder-save.ts` checked out from `origin/main` and `builder-camera.ts` deleted: 8 of the 10 new tests fail, including the payload-rounding assertion (`expected -71.123456789 to be -71.123457`). The 2 that pass on main are the two that assert clean, which is main's blanket behaviour for any camera move: the no-saved-view case and the sub-precision noise case. They are guards against the new code being over-sensitive, not regression proofs, and they are labelled as such in the file.

## Noticed and left alone

- A save made while `mapInstanceRef.current` is null still writes nulls over a stored view. That predates this change, is unreachable from the builder UI (the save button lives on a page that owns the map), and fixing it would change save behaviour rather than the dirty check.
- Rounding does not apply to the style-import path (`style_import.py`), which writes the camera server-side from an imported style document.

## Codex round 1 (two P2s, both fixed in 733d4b7f4)

**Stale camera sample across a map identity change.** A direct `/maps/:id` navigation keeps this hook and the MapGL instance mounted, and nothing repositions the instance, so the previous map's view stays on screen. The sample survived the switch and was judged against the next map's saved view, marking an untouched map dirty and arming the navigation guard.

A sample now carries the map id it was taken on and is ignored on any other map. The camera each map is entered on is recorded as well, because keying alone leaves a second way in: maplibre's `resize()` fires movestart/move/moveend with no camera change, so the switched-to map does get a sample of the leftover position, correctly tagged with its own id. A sample equal to the entry camera is not an edit anyone made here. Both conditions live in one predicate, `unsavedCamera`, which `computeMapIsClean` and the moveend effect share.

The entry camera also covers a case the first push left open. `BuilderMap`'s `defaultView` clamps the saved zoom with `Math.max(zoom, 2)`, so a map stored at zoom 1.5 renders at 2 and its first resize would have read as a pan.

**Camera moved during an in-flight save.** `editedDuringSave` compares `SAVE_SNAPSHOT_FIELDS` and the plugin set. The camera is in neither, because it is read off the map rather than off `SaveState`. A pan while the save was in flight was cleared on completion for a view that was never persisted, and a refetch that fails left the map falsely clean. The camera that was actually sent is now part of that comparison, at all three success paths.

Four tests added. Counterfactual against 130647e83: three of the four fail (`goes clean when the map identity changes under a panned camera`, `stays clean when the leftover view merely settles on the new map`, `keeps the flag when the camera moves during an in-flight save`). The fourth, `still dirties on a real pan made after the switch`, passes on that head because it dirtied on any difference; it is there to prove the new scoping does not over-suppress.

Re-run after the fixes: 14 passed in the camera suite, 5984 passed across 452 files, typecheck and lint clean.

## Codex round 2 (two P2s, both fixed in 8caf301f6)

**A map with no stored view was exempt from the whole check.** Null center fields do not mean the camera is not persisted; `handleSave` writes one either way. A deliberate pan or zoom on a new or legacy map therefore produced no unsaved indicator and no navigation warning while the save moved the stored view. The saved-view precondition is gone, and movement after entry is tracked on every map. The entry camera is what keeps an untouched map clean, which is the job the precondition was doing badly.

That exemption is now one-shot. It lasts until the camera leaves the entry view, because coming back to that position later is a choice the user made, and after a save it is no longer what the server holds. Without this the post-save case below stays broken even with the cache fix, since the pre-save position is usually also the entry position.

**The dirty check read a baseline that lagged the server.** `useUpdateMap` only invalidates the detail query, so `mapData` kept the pre-save camera until the refetch landed, and forever if it failed. Moving from the newly saved view back to that old position read as clean while the server held the newer view. A successful save now publishes the camera it persisted into the map-detail cache, at all three success paths.

The cache was chosen over a private `savedCameraRef` for two reasons. It is keyed by map id by construction, where a ref would have needed its own map-id tagging or it would reintroduce the cross-map staleness from round 1. And it keeps one baseline rather than two consulted in priority order, so `mapData` stays the single answer to "what does the server hold".

The `add_dataset` effect's own saved-view test now calls `hasSavedMapCamera` instead of repeating the field comparison.

The test harness now reads `mapData` from the map-detail query the way `MapBuilderPage` does, rather than taking it as a prop, so the published camera is actually under test.

Counterfactual against 733d4b7f4: `dirties when the camera moves after entry` and `stays dirty when the camera returns to the pre-save view` both fail. `stays clean when only the entry view settles` passes there because that head exempted centerless maps from the check entirely; it is the guard that the new tracking does not dirty an untouched map.

Re-run after the fixes: 16 passed in the camera suite, 5986 passed across 452 files, typecheck and lint clean.
