### PR TITLE
fix(sources,ingest): release the pooled DB connection before network I/O and GDAL (#1848)

### DIFF
--- a/backend/app/modules/catalog/datasets/api/router_reupload.py
+++ b/backend/app/modules/catalog/datasets/api/router_reupload.py
@@ -3,6 +3,7 @@
 import asyncio
 import math
 import uuid
+from datetime import datetime, timezone
 from pathlib import Path
 
 import structlog
@@ -345,13 +346,19 @@ async def reupload_dataset(
                 detail=str(exc),
             ) from exc
 
-        # fix(#1848 audit): the path is bound only while the row is still
-        # pending. The stale-pending sweep can reclaim it mid-upload, and an
-        # ORM flush would bind onto that terminal row and answer 201.
+        # fix(#1848): bind only while the row is pending, and stamp `staged_at`
+        # so the pending window restarts at the bind. Existing metadata is
+        # carried through: the job-binding gate reads its markers.
         bound = await db.execute(
             update(IngestJob)
             .where(IngestJob.id == job.id, IngestJob.status == "pending")
-            .values(file_path=str(saved_path))
+            .values(
+                file_path=str(saved_path),
+                user_metadata={
+                    **(job.user_metadata or {}),
+                    "staged_at": datetime.now(timezone.utc).isoformat(),
+                },
+            )
         )
         await db.commit()
         if not bound.rowcount:

--- a/backend/app/modules/catalog/datasets/api/router_reupload.py
+++ b/backend/app/modules/catalog/datasets/api/router_reupload.py
@@ -307,6 +307,11 @@ async def reupload_dataset(
 
     max_size_mb = await UPLOAD_MAX_SIZE_MB.get(db)
     max_size_bytes = max_size_mb * 1024 * 1024
+    # fix(#1848): the job is committed BEFORE the upload so the pooled
+    # connection is not held across it. The row therefore survives a failed
+    # upload as `pending` with no `file_path`, which the stale-pending sweep
+    # reaps on its one-hour abandonment policy.
+    await db.commit()
     saved_path = await get_catalog_port().save_upload_file(
         file,
         str(job.id),
@@ -326,8 +331,7 @@ async def reupload_dataset(
             get_catalog_port().validate_file_content(validation_path, file.filename)
         except ValueError as exc:
             # Preserve the existing failed-job audit trail for a user content
-            # error; provider/transport failures below roll the uncommitted job
-            # back with the request transaction.
+            # error.
             job.status = "failed"
             job.error_message = str(exc)
             await db.commit()
@@ -383,6 +387,14 @@ async def reupload_service_preview(
     # pipeline executes (vector→raster or any→VRT explodes deep otherwise).
     _assert_compatible_record_type(dataset, None, service_type=request.service_type)
 
+    # fix(#1848): hand the pooled connection back before DNS, the page fetches
+    # and ogrinfo. The rollback expires every ORM instance, so the two dataset
+    # facts the diff needs and the job's owner are read off them first.
+    prior_columns = dataset.column_info or []
+    prior_feature_count = dataset.feature_count
+    user_id = user.id
+    await db.rollback()
+
     try:
         await validate_url_for_ssrf(request.url)
     except SSRFError as exc:
@@ -423,9 +435,9 @@ async def reupload_service_preview(
         )
 
     diff = compute_schema_diff(
-        dataset.column_info or [],
+        prior_columns,
         preview_data["columns"],
-        dataset.feature_count,
+        prior_feature_count,
         preview_data["feature_count"],
     )
     schema_diff = SchemaDiff(**diff)
@@ -435,7 +447,7 @@ async def reupload_service_preview(
         source_filename=request.layer_title or request.layer_name,
         source_url=request.url,
         source_layer=request.layer_name,
-        created_by=user.id,
+        created_by=user_id,
         status="pending",
         user_metadata={
             "reupload": True,
@@ -520,12 +532,21 @@ async def reupload_preview(
             detail="Job already processed",
         )
 
-    # Resolve S3 key to local file for ogrinfo
+    # fix(#1848): hand the pooled connection back before the S3 download and
+    # ogrinfo. The rollback expires every ORM instance, so everything the
+    # response and the diff read off `dataset` and `job` is taken first.
     file_path = job.file_path
+    job_pk = job.id
+    job_source_filename = job.source_filename
+    prior_columns = dataset.column_info or []
+    prior_feature_count = dataset.feature_count
+    await db.rollback()
+
+    # Resolve S3 key to local file for ogrinfo
     downloaded_preview_path: Path | None = None
     if file_path:
         resolved_file_path = await get_catalog_port().resolve_file_path(
-            file_path, str(job.id)
+            file_path, str(job_pk)
         )
         if resolved_file_path != file_path:
             file_path = resolved_file_path
@@ -578,9 +599,9 @@ async def reupload_preview(
             )
 
     diff = compute_schema_diff(
-        dataset.column_info or [],
+        prior_columns,
         info["columns"],
-        dataset.feature_count,
+        prior_feature_count,
         info["feature_count"],
     )
     schema_diff = SchemaDiff(**diff)
@@ -603,8 +624,8 @@ async def reupload_preview(
     previous_source_layer = prior_job.source_layer if prior_job else None
 
     return ReuploadPreviewResponse(
-        job_id=job.id,
-        source_filename=job.source_filename,
+        job_id=job_pk,
+        source_filename=job_source_filename,
         columns=info["columns"],
         crs=info["srid"],
         geometry_type=info["geometry_type"],

--- a/backend/app/modules/catalog/datasets/api/router_reupload.py
+++ b/backend/app/modules/catalog/datasets/api/router_reupload.py
@@ -337,7 +337,11 @@ async def reupload_dataset(
             # already reclaimed keeps its terminal status and message.
             await db.execute(
                 update(IngestJob)
-                .where(IngestJob.id == job.id, IngestJob.status == "pending")
+                .where(
+                    IngestJob.id == job.id,
+                    IngestJob.dataset_id == dataset_id,
+                    IngestJob.status == "pending",
+                )
                 .values(status="failed", error_message=str(exc))
             )
             await db.commit()
@@ -346,12 +350,16 @@ async def reupload_dataset(
                 detail=str(exc),
             ) from exc
 
-        # fix(#1848): bind only while the row is pending, and stamp `staged_at`
-        # so the pending window restarts at the bind. Existing metadata is
-        # carried through: the job-binding gate reads its markers.
+        # fix(#1848): bind only while the row is still pending and still bound
+        # to this dataset, stamping `staged_at` so the pending window restarts
+        # here. The carried-through metadata is what the binding gate reads.
         bound = await db.execute(
             update(IngestJob)
-            .where(IngestJob.id == job.id, IngestJob.status == "pending")
+            .where(
+                IngestJob.id == job.id,
+                IngestJob.dataset_id == dataset_id,
+                IngestJob.status == "pending",
+            )
             .values(
                 file_path=str(saved_path),
                 user_metadata={
@@ -365,7 +373,8 @@ async def reupload_dataset(
             raise HTTPException(
                 status_code=status.HTTP_409_CONFLICT,
                 detail=(
-                    "This upload took too long and the job was reclaimed. "
+                    "This upload could not be attached to the dataset. It may "
+                    "have taken too long, or the dataset may no longer exist. "
                     "Start the re-upload again."
                 ),
             )

--- a/backend/app/modules/catalog/datasets/api/router_reupload.py
+++ b/backend/app/modules/catalog/datasets/api/router_reupload.py
@@ -332,16 +332,36 @@ async def reupload_dataset(
         except ValueError as exc:
             # Preserve the existing failed-job audit trail for a user content
             # error.
-            job.status = "failed"
-            job.error_message = str(exc)
+            # fix(#1848 audit): guarded like the bind below, so a row the sweep
+            # already reclaimed keeps its terminal status and message.
+            await db.execute(
+                update(IngestJob)
+                .where(IngestJob.id == job.id, IngestJob.status == "pending")
+                .values(status="failed", error_message=str(exc))
+            )
             await db.commit()
             raise HTTPException(
                 status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
                 detail=str(exc),
             ) from exc
 
-        job.file_path = str(saved_path)
+        # fix(#1848 audit): the path is bound only while the row is still
+        # pending. The stale-pending sweep can reclaim it mid-upload, and an
+        # ORM flush would bind onto that terminal row and answer 201.
+        bound = await db.execute(
+            update(IngestJob)
+            .where(IngestJob.id == job.id, IngestJob.status == "pending")
+            .values(file_path=str(saved_path))
+        )
         await db.commit()
+        if not bound.rowcount:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail=(
+                    "This upload took too long and the job was reclaimed. "
+                    "Start the re-upload again."
+                ),
+            )
     except BaseException:
         await _cleanup_uncommitted_reupload_source(saved_path, job_id=job.id)
         raise
@@ -351,6 +371,8 @@ async def reupload_dataset(
 
     return ReuploadResponse(
         job_id=job.id,
+        # fix(#1848 audit): true by construction, not assumed -- the bind above
+        # only reached here because the row was still pending.
         status="pending",
         message="File uploaded for re-upload preview",
     )

--- a/backend/app/modules/catalog/sources/router.py
+++ b/backend/app/modules/catalog/sources/router.py
@@ -974,6 +974,8 @@ async def probe_service_url(
         ),
     )
     safe_url = redact_url_credentials(request.url)
+    # fix(#1848): read off `user` before any release below expires it.
+    user_id = user.id
     # Step 1: SSRF validation
     try:
         await validate_url_for_ssrf(request.url)
@@ -981,13 +983,17 @@ async def probe_service_url(
         logger.warning("SSRF blocked", url=safe_url, reason=str(exc))
         await _probe_audit_fail(
             db,
-            user.id,
+            user_id,
             request.url,
             "ssrf_blocked",
             status.HTTP_400_BAD_REQUEST,
             str(exc),
             reason=str(exc),
         )
+
+    # fix(#1848): hand the pooled connection back before the probes. Nothing is
+    # written yet, and every value the audit rows below need is already a local.
+    await db.rollback()
 
     # Step 2: Probe with httpx client
     # NOTE: No default Authorization header on the client. Each probe function
@@ -1040,7 +1046,7 @@ async def probe_service_url(
         )
         await _probe_audit_fail(
             db,
-            user.id,
+            user_id,
             request.url,
             exc.code,
             status.HTTP_422_UNPROCESSABLE_CONTENT,
@@ -1056,7 +1062,7 @@ async def probe_service_url(
         logger.warning("Probe credential unusable", url=safe_url, code=exc.code)
         await _probe_audit_fail(
             db,
-            user.id,
+            user_id,
             request.url,
             exc.code,
             status.HTTP_422_UNPROCESSABLE_CONTENT,
@@ -1087,7 +1093,7 @@ async def probe_service_url(
         logger.warning("SSRF blocked mid-probe", url=safe_url, reason=str(exc))
         await _probe_audit_fail(
             db,
-            user.id,
+            user_id,
             request.url,
             "ssrf_blocked",
             status.HTTP_400_BAD_REQUEST,
@@ -1099,7 +1105,7 @@ async def probe_service_url(
         logger.warning("Probe timeout", url=safe_url)
         await _probe_audit_fail(
             db,
-            user.id,
+            user_id,
             request.url,
             "timeout",
             504,
@@ -1110,7 +1116,7 @@ async def probe_service_url(
         logger.warning("ArcGIS token error", url=safe_url, error=str(exc))
         await _probe_audit_fail(
             db,
-            user.id,
+            user_id,
             request.url,
             "auth_required",
             403,
@@ -1124,7 +1130,7 @@ async def probe_service_url(
             logger.warning("Probe auth required", url=safe_url, status=resp_status)
             await _probe_audit_fail(
                 db,
-                user.id,
+                user_id,
                 request.url,
                 "auth_required",
                 403,
@@ -1135,7 +1141,7 @@ async def probe_service_url(
             logger.warning("Probe remote error", url=safe_url, status=resp_status)
             await _probe_audit_fail(
                 db,
-                user.id,
+                user_id,
                 request.url,
                 "remote_error",
                 502,
@@ -1147,7 +1153,7 @@ async def probe_service_url(
         logger.warning("Probe unreachable", url=safe_url)
         await _probe_audit_fail(
             db,
-            user.id,
+            user_id,
             request.url,
             "unreachable",
             502,
@@ -1158,7 +1164,7 @@ async def probe_service_url(
         logger.info("Probe unrecognized", url=safe_url)
         await _probe_audit_fail(
             db,
-            user.id,
+            user_id,
             request.url,
             "unrecognized",
             status.HTTP_400_BAD_REQUEST,
@@ -1175,7 +1181,7 @@ async def probe_service_url(
     await audit_emit(
         db,
         AuditEvent(
-            user_id=user.id,
+            user_id=user_id,
             action="probe_service",
             resource_type="service_url",
             details={
@@ -1219,6 +1225,8 @@ async def preview_service_layer(
     # this is None and the credential travels as a header instead.
     service_token = url_query_token(service_credential)
     safe_url = redact_url_credentials(request.url)
+    # fix(#1848): read off `user` before the release below expires it.
+    user_id = user.id
     # Step 1: SSRF validation
     try:
         await validate_url_for_ssrf(request.url)
@@ -1227,7 +1235,7 @@ async def preview_service_layer(
         await audit_emit(
             db,
             AuditEvent(
-                user_id=user.id,
+                user_id=user_id,
                 action="preview_service_layer",
                 resource_type="service_url",
                 details={
@@ -1306,7 +1314,7 @@ async def preview_service_layer(
                     ),
                 ),
                 Dataset.source_format == source_format,
-                Record.created_by == user.id,
+                Record.created_by == user_id,
             )
             .limit(1)
         )
@@ -1332,6 +1340,10 @@ async def preview_service_layer(
         # resolve_service_type raises IngestionError for unknown service types —
         # skip the duplicate check and let Step 2 handle validation.
         pass
+
+    # fix(#1848): hand the pooled connection back before the page walk and
+    # ogrinfo. Every gate above has run; the writes below re-acquire lazily.
+    await db.rollback()
 
     # Step 2 (ArcGIS): derive the preview from FeatureServer/MapServer REST
     # metadata instead of running ogrinfo through GDAL's ESRIJSON driver. That
@@ -1365,7 +1377,7 @@ async def preview_service_layer(
             await audit_emit(
                 db,
                 AuditEvent(
-                    user_id=user.id,
+                    user_id=user_id,
                     action="preview_service_layer",
                     resource_type="service_url",
                     details={
@@ -1397,7 +1409,7 @@ async def preview_service_layer(
             # split this PR closed on `/probe` in `sources/probe.py`, left
             # standing on this door: one event, one classification, whichever
             # adapter met it.
-            await _refuse_preview(db, user.id, request.url, request.layer_name, exc)
+            await _refuse_preview(db, user_id, request.url, request.layer_name, exc)
             raise  # unreachable: `_preview_refusal_response` maps every `SSRFError`
         except (
             httpx.HTTPError,
@@ -1418,7 +1430,7 @@ async def preview_service_layer(
                 layer=request.layer_name,
                 error=redact_exception_text(exc),
             )
-            await _fail_preview(db, user.id, request.url, request.layer_name)
+            await _fail_preview(db, user_id, request.url, request.layer_name)
 
         # Persist the normalized base URL + effective layer id (not the original
         # request) so the commit/ingest step targets the exact previewed layer.
@@ -1426,7 +1438,7 @@ async def preview_service_layer(
             db,
             request,
             preview_data,
-            user.id,
+            user_id,
             source_url=arcgis_base,
             layer_id=arcgis_layer_id,
         )
@@ -1453,7 +1465,7 @@ async def preview_service_layer(
         await audit_emit(
             db,
             AuditEvent(
-                user_id=user.id,
+                user_id=user_id,
                 action="preview_service_layer",
                 resource_type="service_url",
                 details={
@@ -1471,7 +1483,7 @@ async def preview_service_layer(
     try:
         preview_data = await _run_service_preview_or_refuse(
             db,
-            user.id,
+            user_id,
             request.url,
             request.layer_name,
             gdal_source,
@@ -1499,7 +1511,7 @@ async def preview_service_layer(
                 )
                 preview_data = await _run_service_preview_or_refuse(
                     db,
-                    user.id,
+                    user_id,
                     request.url,
                     request.layer_name,
                     retry_source,
@@ -1512,14 +1524,14 @@ async def preview_service_layer(
                     url=safe_url,
                     layer=request.layer_name,
                 )
-                await _fail_preview(db, user.id, request.url, request.layer_name)
+                await _fail_preview(db, user_id, request.url, request.layer_name)
         else:
             logger.warning(
                 "Preview ogrinfo failed",
                 url=safe_url,
                 layer=request.layer_name,
             )
-            await _fail_preview(db, user.id, request.url, request.layer_name)
+            await _fail_preview(db, user_id, request.url, request.layer_name)
     except HTTPException:
         # fix(#1746): run_service_preview now refuses a header-auth token that
         # is outside the base64url charset with a 422, which is an answer and
@@ -1535,7 +1547,7 @@ async def preview_service_layer(
         await audit_emit(
             db,
             AuditEvent(
-                user_id=user.id,
+                user_id=user_id,
                 action="preview_service_layer",
                 resource_type="service_url",
                 details={
@@ -1570,7 +1582,7 @@ async def preview_service_layer(
             )
 
     # Step 5/6: Create IngestJob, audit-log, and build the response.
-    job = await _create_preview_job(db, request, preview_data, user.id)
+    job = await _create_preview_job(db, request, preview_data, user_id)
     return _build_preview_response(request, preview_data, job)
 
 

--- a/backend/app/modules/catalog/sources/router.py
+++ b/backend/app/modules/catalog/sources/router.py
@@ -974,8 +974,13 @@ async def probe_service_url(
         ),
     )
     safe_url = redact_url_credentials(request.url)
-    # fix(#1848): read off `user` before any release below expires it.
+    # fix(#1848): read off `user` before the release below expires it.
     user_id = user.id
+    # fix(#1848 codex r1): released ABOVE the SSRF check, not below it.
+    # `validate_url_for_ssrf` awaits `getaddrinfo` in a thread, so an
+    # unresponsive resolver pinned the connection before any probe ran.
+    await db.rollback()
+
     # Step 1: SSRF validation
     try:
         await validate_url_for_ssrf(request.url)
@@ -990,10 +995,6 @@ async def probe_service_url(
             str(exc),
             reason=str(exc),
         )
-
-    # fix(#1848): hand the pooled connection back before the probes. Nothing is
-    # written yet, and every value the audit rows below need is already a local.
-    await db.rollback()
 
     # Step 2: Probe with httpx client
     # NOTE: No default Authorization header on the client. Each probe function
@@ -1225,8 +1226,13 @@ async def preview_service_layer(
     # this is None and the credential travels as a header instead.
     service_token = url_query_token(service_credential)
     safe_url = redact_url_credentials(request.url)
-    # fix(#1848): read off `user` before the release below expires it.
+    # fix(#1848): read off `user` before either release below expires it.
     user_id = user.id
+    # fix(#1848 codex r1): released ABOVE the SSRF check, not below it.
+    # `validate_url_for_ssrf` awaits `getaddrinfo` in a thread, so an
+    # unresponsive resolver pinned the connection before any preview work.
+    await db.rollback()
+
     # Step 1: SSRF validation
     try:
         await validate_url_for_ssrf(request.url)
@@ -1341,8 +1347,8 @@ async def preview_service_layer(
         # skip the duplicate check and let Step 2 handle validation.
         pass
 
-    # fix(#1848): hand the pooled connection back before the page walk and
-    # ogrinfo. Every gate above has run; the writes below re-acquire lazily.
+    # fix(#1848): released again, because the duplicate-source query above
+    # re-acquired. Every gate has run and nothing is written yet.
     await db.rollback()
 
     # Step 2 (ArcGIS): derive the preview from FeatureServer/MapServer REST

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -4401,8 +4401,11 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # and the locals read off the ORM instances the rollback expires. The
     # audit round added the two compare-and-set writes that keep the
     # commit-first door from binding onto a row the stale-pending sweep
-    # reclaimed mid-upload, plus their refusal. Cap 1396 -> 1439, exact.
-    "backend/app/modules/catalog/datasets/api/router_reupload.py": 1439,
+    # reclaimed mid-upload, plus their refusal. Codex round 2 added the
+    # `staged_at` stamp to the same bind, which restarts the pending window
+    # for a local upload whose absolute path never reaches the sweep's
+    # completion class. Cap 1396 -> 1446, exact.
+    "backend/app/modules/catalog/datasets/api/router_reupload.py": 1446,
     # fix(#1218 review): +5 — VRT assembly stamps last_refreshed_at like every
     # other creation path, so a post-migration VRT does not report null while
     # a backfilled one carries a timestamp, with a note on why it is a Python

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -4404,8 +4404,11 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # reclaimed mid-upload, plus their refusal. Codex round 2 added the
     # `staged_at` stamp to the same bind, which restarts the pending window
     # for a local upload whose absolute path never reaches the sweep's
-    # completion class. Cap 1396 -> 1446, exact.
-    "backend/app/modules/catalog/datasets/api/router_reupload.py": 1446,
+    # completion class. Codex round 3 added the dataset binding to both
+    # guarded writes, because the early commit releases the foreign-key lock
+    # and a dataset deleted mid-upload nulls the job's binding.
+    # Cap 1396 -> 1455, exact.
+    "backend/app/modules/catalog/datasets/api/router_reupload.py": 1455,
     # fix(#1218 review): +5 — VRT assembly stamps last_refreshed_at like every
     # other creation path, so a post-migration VRT does not report null while
     # a backfilled one carries a timestamp, with a note on why it is a Python

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -2771,11 +2771,14 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # of reporting `ogrinfo_failed` for a tool that never ran. The extraction
     # is net-neutral; the lines are the helper's own docstring and the new
     # clause's comment. Cap 1791 -> 1831, exact.
-    # fix(#1848): +12. Both doors hand the pooled connection back before their
+    # fix(#1848): +18. Both doors hand the pooled connection back before their
     # network work, which costs the release itself, its comment and the
-    # `user_id` local the rollback's expiry makes necessary.
-    # Cap 1831 -> 1843, exact.
-    "backend/app/modules/catalog/sources/router.py": 1843,
+    # `user_id` local the rollback's expiry makes necessary. Codex round 1
+    # moved each release above `validate_url_for_ssrf`, whose `getaddrinfo`
+    # wait is the first of the two waits, and the preview needs a second
+    # release because its duplicate-source query re-acquires in between.
+    # Cap 1831 -> 1849, exact.
+    "backend/app/modules/catalog/sources/router.py": 1849,
     # fix(#998): the DDL ported from migration 0019 so tenant-ownership adoption
     # is reachable forward-only at head. Almost all of it is SQL text, and it is
     # one artifact on purpose — the module is reviewed line-by-line against
@@ -4393,11 +4396,13 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # sibling `preview_file` mapped it to 422. The lines are that branch and
     # the comment saying which endpoint it is matching.
     # Cap 1386 -> 1396, exact.
-    # fix(#1848): +21. Three doors release the pooled connection before their
+    # fix(#1848): +43. Three doors release the pooled connection before their
     # network or GDAL work; the added lines are the releases, their comments,
-    # and the locals read off the ORM instances the rollback expires.
-    # Cap 1396 -> 1417, exact.
-    "backend/app/modules/catalog/datasets/api/router_reupload.py": 1417,
+    # and the locals read off the ORM instances the rollback expires. The
+    # audit round added the two compare-and-set writes that keep the
+    # commit-first door from binding onto a row the stale-pending sweep
+    # reclaimed mid-upload, plus their refusal. Cap 1396 -> 1439, exact.
+    "backend/app/modules/catalog/datasets/api/router_reupload.py": 1439,
     # fix(#1218 review): +5 — VRT assembly stamps last_refreshed_at like every
     # other creation path, so a post-migration VRT does not report null while
     # a backfilled one carries a timestamp, with a note on why it is a Python

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -2771,7 +2771,11 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # of reporting `ogrinfo_failed` for a tool that never ran. The extraction
     # is net-neutral; the lines are the helper's own docstring and the new
     # clause's comment. Cap 1791 -> 1831, exact.
-    "backend/app/modules/catalog/sources/router.py": 1831,
+    # fix(#1848): +12. Both doors hand the pooled connection back before their
+    # network work, which costs the release itself, its comment and the
+    # `user_id` local the rollback's expiry makes necessary.
+    # Cap 1831 -> 1843, exact.
+    "backend/app/modules/catalog/sources/router.py": 1843,
     # fix(#998): the DDL ported from migration 0019 so tenant-ownership adoption
     # is reachable forward-only at head. Almost all of it is SQL text, and it is
     # one artifact on purpose — the module is reviewed line-by-line against
@@ -4389,7 +4393,11 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # sibling `preview_file` mapped it to 422. The lines are that branch and
     # the comment saying which endpoint it is matching.
     # Cap 1386 -> 1396, exact.
-    "backend/app/modules/catalog/datasets/api/router_reupload.py": 1396,
+    # fix(#1848): +21. Three doors release the pooled connection before their
+    # network or GDAL work; the added lines are the releases, their comments,
+    # and the locals read off the ORM instances the rollback expires.
+    # Cap 1396 -> 1417, exact.
+    "backend/app/modules/catalog/datasets/api/router_reupload.py": 1417,
     # fix(#1218 review): +5 — VRT assembly stamps last_refreshed_at like every
     # other creation path, so a post-migration VRT does not report null while
     # a backfilled one carries a timestamp, with a note on why it is a Python

--- a/backend/tests/test_pooled_connection_release_1848.py
+++ b/backend/tests/test_pooled_connection_release_1848.py
@@ -1,0 +1,462 @@
+"""fix(#1848): five doors must not hold a pooled connection across their I/O.
+
+`require_permission` queries the database before the handler body runs, so the
+request session has a connection checked out from the first line. Holding it
+across a remote service call or a GDAL subprocess pins one of the pool's
+thirteen slots for the whole of it, and thirteen concurrent slow previews make
+every other database-backed request wait out the 30 s pool timeout.
+
+Each test records `in_transaction()` on the request's own session at the moment
+the mocked I/O runs, which is the pool-independent form of the invariant: the
+test engine uses NullPool, so a checkout count here says nothing about the
+production QueuePool, while an open transaction is what pins the connection
+either way. Same assertion the earlier fixes in this class use
+(`test_analysis_preview.py`).
+"""
+
+import uuid
+from io import BytesIO
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.modules.catalog.sources.schemas import LayerInfo, ProbeResponse
+from app.platform.jobs.models import IngestJob
+from tests.factories import create_dataset, get_user_id
+
+pytestmark = pytest.mark.anyio
+
+
+@pytest.fixture
+def allow_any_url():
+    """The door's own SSRF gate, stubbed: these hostnames do not resolve."""
+    with patch(
+        "app.modules.catalog.sources.router.validate_url_for_ssrf",
+        new_callable=AsyncMock,
+    ) as mock:
+        yield mock
+
+
+@pytest.fixture
+def stub_gdal_source():
+    with patch(
+        "app.modules.catalog.sources.router.build_gdal_source",
+        return_value=("WFS:https://a2-preview.example.com/wfs", "buildings"),
+    ) as mock:
+        yield mock
+
+
+@pytest.fixture
+def request_sessions(client: AsyncClient):
+    """Every session the app hands a request, newest last.
+
+    Wraps the `client` fixture's own `get_db` override rather than replacing
+    it, so the request still gets the retrying test session factory.
+    """
+    from app.api.main import app
+    from app.core.dependencies import get_db
+
+    captured: list[AsyncSession] = []
+    original = app.dependency_overrides[get_db]
+
+    async def _capturing():
+        async for session in original():
+            captured.append(session)
+            yield session
+
+    app.dependency_overrides[get_db] = _capturing
+    try:
+        yield captured
+    finally:
+        app.dependency_overrides[get_db] = original
+
+
+def _holds_connection(captured: list[AsyncSession]) -> bool:
+    """Whether the in-flight request is still inside a transaction."""
+    assert captured, "no request session was captured"
+    return captured[-1].in_transaction()
+
+
+_PREVIEW_DATA = {
+    "srid": 4326,
+    "geometry_type": "Point",
+    "layer_name": "buildings",
+    "feature_count": 7,
+    "columns": [{"name": "name", "type": "String"}],
+    "sample_rows": [{"name": "a"}],
+    "all_layers": None,
+}
+
+
+# ---------------------------------------------------------------------------
+# sources/router.py
+# ---------------------------------------------------------------------------
+
+
+async def test_probe_releases_the_connection_before_the_adapter_probes(
+    client: AsyncClient,
+    admin_auth_header: dict,
+    allow_any_url,
+    request_sessions,
+):
+    """Three adapter probes at up to 30 s each ran on a held connection."""
+    held: list[bool] = []
+
+    async def _recording_detect(*_args, **_kwargs):
+        held.append(_holds_connection(request_sessions))
+        return ProbeResponse(
+            service_type="WFS 2.0.0",
+            url="https://a2-probe.example.com/wfs",
+            layers=[LayerInfo(name="buildings", title="Buildings", layer_id="b")],
+        )
+
+    with (
+        patch(
+            "app.modules.catalog.sources.router.detect_service_type",
+            new=_recording_detect,
+        ),
+        patch(
+            "app.modules.catalog.sources.router.assert_endpoints_stay_on_origin",
+            new_callable=AsyncMock,
+        ),
+    ):
+        resp = await client.post(
+            "/services/probe/",
+            json={"url": "https://a2-probe.example.com/wfs"},
+            headers=admin_auth_header,
+        )
+
+    assert resp.status_code == 200, resp.text
+    assert held == [False], (
+        "the request session was still in a transaction when the probes "
+        "started, so it was holding a pooled connection across them"
+    )
+    # The success audit row is written after the release, which proves the
+    # session re-acquires rather than being finished with.
+    assert resp.json()["service_type"] == "WFS 2.0.0"
+
+
+async def test_preview_releases_the_connection_before_ogrinfo(
+    client: AsyncClient,
+    admin_auth_header: dict,
+    allow_any_url,
+    stub_gdal_source,
+    request_sessions,
+):
+    """The OAPIF page walk and the ogrinfo subprocess ran on a held connection."""
+    held: list[bool] = []
+
+    async def _recording_preview(*_args, **_kwargs):
+        held.append(_holds_connection(request_sessions))
+        return dict(_PREVIEW_DATA)
+
+    with patch(
+        "app.modules.catalog.sources.router.run_service_preview",
+        new=_recording_preview,
+    ):
+        resp = await client.post(
+            "/services/preview/",
+            json={
+                "url": "https://a2-preview.example.com/wfs",
+                "service_type": "WFS 2.0.0",
+                "layer_name": "buildings",
+            },
+            headers=admin_auth_header,
+        )
+
+    assert resp.status_code == 200, resp.text
+    assert held == [False], (
+        "the request session was still in a transaction when ogrinfo ran"
+    )
+    # The pending job is written after the release.
+    assert resp.json()["job_id"]
+
+
+# ---------------------------------------------------------------------------
+# datasets/api/router_reupload.py
+# ---------------------------------------------------------------------------
+
+
+async def _vector_dataset(session: AsyncSession):
+    admin_id = await get_user_id(session, "admin")
+    return await create_dataset(
+        session,
+        created_by=admin_id,
+        name=f"A2 Reupload {uuid.uuid4().hex[:6]}",
+        column_info=[{"name": "name", "type": "String"}],
+    )
+
+
+async def test_reupload_service_preview_releases_the_connection(
+    client: AsyncClient,
+    admin_auth_header: dict,
+    test_db_session: AsyncSession,
+    request_sessions,
+):
+    """DNS validation, the page fetches and ogrinfo ran on a held connection."""
+    dataset = await _vector_dataset(test_db_session)
+    held: list[bool] = []
+
+    async def _recording_preview(*_args, **_kwargs):
+        held.append(_holds_connection(request_sessions))
+        return dict(_PREVIEW_DATA)
+
+    from app.modules.catalog.datasets.api import router_reupload
+
+    with (
+        patch.object(router_reupload, "run_service_preview", new=_recording_preview),
+        patch.object(router_reupload, "validate_url_for_ssrf", new_callable=AsyncMock),
+        patch.object(
+            router_reupload,
+            "build_gdal_source",
+            return_value=("WFS:https://a2.example.com/wfs", "buildings"),
+        ),
+    ):
+        resp = await client.post(
+            f"/datasets/{dataset.id}/reupload/service/preview",
+            json={
+                "url": "https://a2.example.com/wfs",
+                "service_type": "WFS 2.0.0",
+                "layer_name": "buildings",
+            },
+            headers=admin_auth_header,
+        )
+
+    assert resp.status_code == 200, resp.text
+    assert held == [False], (
+        "the request session was still in a transaction when the service preview ran"
+    )
+    # The diff is computed from values read off the dataset BEFORE the release.
+    # A MissingGreenlet here would mean they were read off an expired instance.
+    body = resp.json()
+    assert body["schema_diff"] is not None
+    assert body["job_id"]
+
+
+async def test_reupload_preview_releases_the_connection_before_ogrinfo(
+    client: AsyncClient,
+    admin_auth_header: dict,
+    test_db_session: AsyncSession,
+    request_sessions,
+):
+    """The S3 download and `run_ogrinfo_preview` ran on a held connection."""
+    dataset = await _vector_dataset(test_db_session)
+    admin_id = await get_user_id(test_db_session, "admin")
+    job = IngestJob(
+        dataset_id=dataset.id,
+        source_filename="replacement.geojson",
+        file_path="/tmp/a2-replacement.geojson",
+        created_by=admin_id,
+        status="pending",
+        user_metadata={"reupload": True, "dataset_id": str(dataset.id)},
+    )
+    test_db_session.add(job)
+    await test_db_session.commit()
+
+    held: list[bool] = []
+    from app.modules.catalog.datasets.api import router_reupload
+
+    port = router_reupload.get_catalog_port()
+
+    async def _recording_ogrinfo(*_args, **_kwargs):
+        held.append(_holds_connection(request_sessions))
+        return dict(_PREVIEW_DATA)
+
+    async def _resolve(path, _job_id):
+        return path
+
+    with (
+        patch.object(port, "run_ogrinfo_preview", new=_recording_ogrinfo),
+        patch.object(port, "resolve_file_path", new=_resolve),
+        patch.object(router_reupload, "get_catalog_port", return_value=port),
+    ):
+        resp = await client.post(
+            f"/datasets/{dataset.id}/reupload/{job.id}/preview",
+            json={},
+            headers=admin_auth_header,
+        )
+
+    assert resp.status_code == 200, resp.text
+    assert held == [False], (
+        "the request session was still in a transaction when ogrinfo ran"
+    )
+    body = resp.json()
+    # Both were read off ORM instances the release expires.
+    assert body["job_id"] == str(job.id)
+    assert body["source_filename"] == "replacement.geojson"
+
+
+async def test_reupload_commits_the_job_before_streaming_the_file(
+    client: AsyncClient,
+    admin_auth_header: dict,
+    test_db_session: AsyncSession,
+    request_sessions,
+    tmp_path: Path,
+):
+    """The whole multipart body streamed on a held connection.
+
+    This door cannot roll back to release: it holds an uncommitted `IngestJob`
+    by construction. It commits the row first instead, which both frees the
+    connection and leaves a `pending` row the stale-pending sweep can reap if
+    the upload never finishes.
+    """
+    dataset = await _vector_dataset(test_db_session)
+    held: list[bool] = []
+    from app.modules.catalog.datasets.api import router_reupload
+
+    port = router_reupload.get_catalog_port()
+    staged: list[str] = []
+
+    async def _recording_save(file, job_id, **_kwargs):
+        held.append(_holds_connection(request_sessions))
+        staged.append(job_id)
+        # A `Path` is the local-storage shape, which is what the test harness
+        # runs; a str would send the handler down the S3 resolve branch.
+        path = tmp_path / f"a2-staged-{job_id}.geojson"
+        path.write_bytes(b'{"type":"FeatureCollection","features":[]}')
+        return path
+
+    with (
+        patch.object(port, "save_upload_file", new=_recording_save),
+        patch.object(port, "validate_file_content", return_value=None),
+        patch.object(router_reupload, "get_catalog_port", return_value=port),
+    ):
+        resp = await client.post(
+            f"/datasets/{dataset.id}/reupload",
+            files={
+                "file": (
+                    "replacement.geojson",
+                    BytesIO(b'{"type":"FeatureCollection","features":[]}'),
+                    "application/geo+json",
+                )
+            },
+            headers=admin_auth_header,
+        )
+
+    assert resp.status_code == 201, resp.text
+    assert held == [False], (
+        "the request session was still in a transaction while the upload "
+        "streamed, so it held a pooled connection for the whole transfer"
+    )
+
+    # The committed row is the point: it exists before the upload and carries
+    # the path afterwards.
+    job_id = uuid.UUID(resp.json()["job_id"])
+    assert staged == [str(job_id)]
+    stored = await test_db_session.get(IngestJob, job_id)
+    assert stored is not None
+    assert stored.file_path == str(tmp_path / f"a2-staged-{job_id}.geojson")
+
+
+async def test_a_failed_upload_leaves_a_reapable_pending_job(
+    client: AsyncClient,
+    admin_auth_header: dict,
+    test_db_session: AsyncSession,
+):
+    """The cost of committing first, and the reason it is affordable.
+
+    Before this change a transport failure rolled the uncommitted job back with
+    the request transaction. Now the row survives. It survives in exactly the
+    shape `stale_pending_clauses` reaps on its one-hour policy: `pending`, with
+    nothing bound into `file_path`, which is the unbound half of that
+    predicate.
+    """
+    from app.modules.catalog.datasets.api import router_reupload
+    from app.platform.jobs.sweep import stale_pending_clauses
+
+    dataset = await _vector_dataset(test_db_session)
+    port = router_reupload.get_catalog_port()
+
+    async def _boom(*_args, **_kwargs):
+        raise RuntimeError("transport failed mid-upload")
+
+    with (
+        patch.object(port, "save_upload_file", new=_boom),
+        patch.object(router_reupload, "get_catalog_port", return_value=port),
+    ):
+        # The test transport re-raises whatever the app did not handle, so the
+        # failure arrives here rather than as a 500 body.
+        with pytest.raises(RuntimeError, match="transport failed mid-upload"):
+            await client.post(
+                f"/datasets/{dataset.id}/reupload",
+                files={
+                    "file": (
+                        "replacement.geojson",
+                        BytesIO(b'{"type":"FeatureCollection","features":[]}'),
+                        "application/geo+json",
+                    )
+                },
+                headers=admin_auth_header,
+            )
+
+    from sqlalchemy import select
+
+    rows = (
+        (
+            await test_db_session.execute(
+                select(IngestJob).where(IngestJob.dataset_id == dataset.id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(rows) == 1
+    assert rows[0].status == "pending"
+    # `create_ingest_job` seeds an empty path, so this is the unbound half of
+    # the sweep's discriminator rather than the completion half.
+    assert not rows[0].file_path
+    # The predicate that reaps it, evaluated on this row rather than described.
+    from datetime import datetime, timedelta, timezone
+
+    from sqlalchemy import select as _select
+
+    later = datetime.now(timezone.utc) + timedelta(days=1)
+    reapable = (
+        await test_db_session.execute(
+            _select(IngestJob.id).where(
+                IngestJob.id == rows[0].id,
+                *stale_pending_clauses(later, completion_bound=False),
+            )
+        )
+    ).scalar_one_or_none()
+    assert reapable == rows[0].id
+
+
+async def test_the_release_is_not_a_blanket_rollback_of_the_gates(
+    client: AsyncClient,
+    admin_auth_header: dict,
+    test_db_session: AsyncSession,
+):
+    """The counterfactual for every test above: the gates still refuse first.
+
+    A release placed one line too early would run the write-access check after
+    the I/O, or skip it. A viewer must still be refused before any preview
+    work happens at all.
+    """
+    dataset = await _vector_dataset(test_db_session)
+    from app.modules.catalog.datasets.api import router_reupload
+
+    ran = SimpleNamespace(called=False)
+
+    async def _should_not_run(*_args, **_kwargs):
+        ran.called = True
+        return dict(_PREVIEW_DATA)
+
+    with patch.object(router_reupload, "run_service_preview", new=_should_not_run):
+        resp = await client.post(
+            f"/datasets/{uuid.uuid4()}/reupload/service/preview",
+            json={
+                "url": "https://a2.example.com/wfs",
+                "service_type": "WFS 2.0.0",
+                "layer_name": "buildings",
+            },
+            headers=admin_auth_header,
+        )
+
+    assert resp.status_code == 404, resp.text
+    assert ran.called is False
+    assert dataset.id is not None

--- a/backend/tests/test_pooled_connection_release_1848.py
+++ b/backend/tests/test_pooled_connection_release_1848.py
@@ -596,6 +596,75 @@ async def test_a_slow_local_upload_that_binds_survives_the_next_sweep(
     assert preview.status_code != 404, preview.text
 
 
+async def test_a_dataset_deleted_during_the_upload_refuses_the_bind(
+    client: AsyncClient,
+    admin_auth_header: dict,
+    test_db_session: AsyncSession,
+    tmp_path: Path,
+):
+    """fix(#1848 codex r3): the binding is part of the guard, not just status.
+
+    The early commit released the row's foreign-key lock, and
+    `ingest_jobs.dataset_id` is `ON DELETE SET NULL`. A dataset deleted while
+    the bytes were arriving therefore left a job whose binding was gone, and a
+    guard that read only id and status bound the file and answered 201. Every
+    later re-upload endpoint then refused that job, because the binding gate
+    matches on `dataset_id`.
+    """
+    from sqlalchemy import select
+
+    from app.modules.catalog.datasets.api import router_reupload
+
+    dataset = await _vector_dataset(test_db_session)
+    dataset_id = dataset.id
+    port = router_reupload.get_catalog_port()
+    staged_file = tmp_path / "a2-orphaned.geojson"
+
+    async def _delete_dataset_mid_upload(_file, _job_id, **_kwargs):
+        await test_db_session.delete(dataset)
+        await test_db_session.commit()
+        staged_file.write_bytes(b'{"type":"FeatureCollection","features":[]}')
+        return staged_file
+
+    with (
+        patch.object(port, "save_upload_file", new=_delete_dataset_mid_upload),
+        patch.object(port, "validate_file_content", return_value=None),
+        patch.object(router_reupload, "get_catalog_port", return_value=port),
+    ):
+        resp = await client.post(
+            f"/datasets/{dataset_id}/reupload",
+            files={
+                "file": (
+                    "replacement.geojson",
+                    BytesIO(b'{"type":"FeatureCollection","features":[]}'),
+                    "application/geo+json",
+                )
+            },
+            headers=admin_auth_header,
+        )
+
+    assert resp.status_code == 409, resp.text
+    # The staged file goes with the refusal, like every other failure path.
+    assert not staged_file.exists()
+
+    rows = (
+        (
+            await test_db_session.execute(
+                select(IngestJob).where(
+                    IngestJob.source_filename == "replacement.geojson"
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    orphaned = [row for row in rows if row.dataset_id is None]
+    assert len(orphaned) == 1
+    # The premise: the FK nulled the binding, and nothing was bound onto it.
+    assert orphaned[0].status == "pending"
+    assert not orphaned[0].file_path
+
+
 async def test_a_failed_upload_leaves_a_reapable_pending_job(
     client: AsyncClient,
     admin_auth_header: dict,

--- a/backend/tests/test_pooled_connection_release_1848.py
+++ b/backend/tests/test_pooled_connection_release_1848.py
@@ -489,6 +489,113 @@ async def test_a_sweep_during_the_upload_refuses_rather_than_binding(
     assert not (tmp_path / f"a2-swept-{rows[0].id}.geojson").exists()
 
 
+async def test_only_the_local_provider_needs_the_stamp(
+    test_db_session: AsyncSession,
+):
+    """fix(#1848 codex r2): why the finding is local-only, measured.
+
+    `save_upload_file` returns `staging/{job}/{name}` under S3 and an absolute
+    path under the local provider. The sweep's two classes are split by
+    whether `file_path` matches `staging/%`, so an S3 bind lands in the
+    24-hour class while a local bind stays in the short one. The stamp is
+    written for both because it is one statement, but this is the asymmetry it
+    exists for.
+    """
+    from sqlalchemy import text
+
+    local_path = "/app/staging/abc_replacement.geojson"
+    s3_key = "staging/2f1c/replacement.geojson"
+
+    async def _is_bound_class(value: str) -> bool:
+        return await test_db_session.scalar(
+            text("SELECT coalesce(:p, '') LIKE 'staging/%'").bindparams(p=value)
+        )
+
+    assert await _is_bound_class(s3_key) is True
+    assert await _is_bound_class(local_path) is False
+
+
+async def test_a_slow_local_upload_that_binds_survives_the_next_sweep(
+    client: AsyncClient,
+    admin_auth_header: dict,
+    test_db_session: AsyncSession,
+    tmp_path: Path,
+):
+    """fix(#1848 codex r2): the bind restarts the pending window.
+
+    With the local provider the bound path is absolute, so it never matches
+    the sweep's `staging/%` completion class and the row stays in the class
+    measured from `coalesce(staged_at, created_at)`. Bound without a fresh
+    `staged_at`, an upload slower than the pending timeout returned 201 and
+    the very next sweep cancelled the job it had just accepted. Stamping at
+    the bind is what gives the caller a full window from the moment the bytes
+    landed.
+    """
+    from app.api.main import sweep_stale_jobs_once
+    from app.modules.catalog.datasets.api import router_reupload
+    from app.platform.jobs.sweep import stale_pending_cutoff_seconds
+
+    dataset = await _vector_dataset(test_db_session)
+    port = router_reupload.get_catalog_port()
+    staged_file = tmp_path / "a2-slow-upload.geojson"
+
+    async def _slow_local_upload(_file, job_id, **_kwargs):
+        # The upload outlives the pending window, which `created_at` alone
+        # would measure from.
+        cutoff = stale_pending_cutoff_seconds(completion_bound=False)
+        aged = datetime.now(timezone.utc) - timedelta(seconds=cutoff + 60)
+        row = await test_db_session.get(IngestJob, uuid.UUID(job_id))
+        assert row is not None
+        row.created_at = aged
+        await test_db_session.commit()
+        staged_file.write_bytes(b'{"type":"FeatureCollection","features":[]}')
+        return staged_file
+
+    with (
+        patch.object(port, "save_upload_file", new=_slow_local_upload),
+        patch.object(port, "validate_file_content", return_value=None),
+        patch.object(router_reupload, "get_catalog_port", return_value=port),
+    ):
+        resp = await client.post(
+            f"/datasets/{dataset.id}/reupload",
+            files={
+                "file": (
+                    "replacement.geojson",
+                    BytesIO(b'{"type":"FeatureCollection","features":[]}'),
+                    "application/geo+json",
+                )
+            },
+            headers=admin_auth_header,
+        )
+
+    assert resp.status_code == 201, resp.text
+    job_id = uuid.UUID(resp.json()["job_id"])
+
+    # The premise: an absolute path, so the `staging/%` class does not cover it.
+    stored = await test_db_session.get(IngestJob, job_id)
+    assert stored is not None
+    assert stored.file_path == str(staged_file)
+    assert not stored.file_path.startswith("staging/")
+
+    await sweep_stale_jobs_once()
+
+    await test_db_session.refresh(stored)
+    assert stored.status == "pending"
+    assert staged_file.exists()
+    # The markers the job-binding gate reads survive the metadata write.
+    assert stored.user_metadata["reupload"] is True
+    assert stored.user_metadata["dataset_id"] == str(dataset.id)
+    assert stored.user_metadata["staged_at"]
+
+    # And the door still accepts the job, which is what the user paid for.
+    preview = await client.post(
+        f"/datasets/{dataset.id}/reupload/{job_id}/preview",
+        json={},
+        headers=admin_auth_header,
+    )
+    assert preview.status_code != 404, preview.text
+
+
 async def test_a_failed_upload_leaves_a_reapable_pending_job(
     client: AsyncClient,
     admin_auth_header: dict,

--- a/backend/tests/test_pooled_connection_release_1848.py
+++ b/backend/tests/test_pooled_connection_release_1848.py
@@ -15,6 +15,7 @@ either way. Same assertion the earlier fixes in this class use
 """
 
 import uuid
+from datetime import datetime, timedelta, timezone
 from io import BytesIO
 from pathlib import Path
 from types import SimpleNamespace
@@ -32,13 +33,24 @@ pytestmark = pytest.mark.anyio
 
 
 @pytest.fixture
-def allow_any_url():
-    """The door's own SSRF gate, stubbed: these hostnames do not resolve."""
+def recording_url_validator(request_sessions):
+    """The door's SSRF gate, stubbed and recording.
+
+    fix(#1848 codex r1): `validate_url_for_ssrf` awaits `getaddrinfo` in a
+    thread, so it is one of the waits the release has to precede, not a cheap
+    gate that may sit before it. Yields the same list the I/O recorder appends
+    to, so each test reads `[validator, io]` in call order.
+    """
+    held: list[bool] = []
+
+    async def _recording_validate(_url):
+        held.append(_holds_connection(request_sessions))
+
     with patch(
         "app.modules.catalog.sources.router.validate_url_for_ssrf",
-        new_callable=AsyncMock,
-    ) as mock:
-        yield mock
+        new=_recording_validate,
+    ):
+        yield held
 
 
 @pytest.fixture
@@ -97,14 +109,14 @@ _PREVIEW_DATA = {
 # ---------------------------------------------------------------------------
 
 
-async def test_probe_releases_the_connection_before_the_adapter_probes(
+async def test_probe_releases_the_connection_before_dns_and_the_probes(
     client: AsyncClient,
     admin_auth_header: dict,
-    allow_any_url,
+    recording_url_validator,
     request_sessions,
 ):
-    """Three adapter probes at up to 30 s each ran on a held connection."""
-    held: list[bool] = []
+    """The SSRF resolver wait and three adapter probes ran on a held connection."""
+    held = recording_url_validator
 
     async def _recording_detect(*_args, **_kwargs):
         held.append(_holds_connection(request_sessions))
@@ -131,24 +143,28 @@ async def test_probe_releases_the_connection_before_the_adapter_probes(
         )
 
     assert resp.status_code == 200, resp.text
-    assert held == [False], (
-        "the request session was still in a transaction when the probes "
-        "started, so it was holding a pooled connection across them"
+    assert held == [False, False], (
+        "the request session was still in a transaction at the SSRF resolver "
+        "wait or at the probes, so it held a pooled connection across them"
     )
     # The success audit row is written after the release, which proves the
     # session re-acquires rather than being finished with.
     assert resp.json()["service_type"] == "WFS 2.0.0"
 
 
-async def test_preview_releases_the_connection_before_ogrinfo(
+async def test_preview_releases_the_connection_before_dns_and_ogrinfo(
     client: AsyncClient,
     admin_auth_header: dict,
-    allow_any_url,
+    recording_url_validator,
     stub_gdal_source,
     request_sessions,
 ):
-    """The OAPIF page walk and the ogrinfo subprocess ran on a held connection."""
-    held: list[bool] = []
+    """The resolver wait, the OAPIF page walk and ogrinfo ran on a held connection.
+
+    Two releases, not one: the duplicate-source query between them re-acquires
+    a connection of its own, so the second release is what covers the walk.
+    """
+    held = recording_url_validator
 
     async def _recording_preview(*_args, **_kwargs):
         held.append(_holds_connection(request_sessions))
@@ -169,11 +185,57 @@ async def test_preview_releases_the_connection_before_ogrinfo(
         )
 
     assert resp.status_code == 200, resp.text
-    assert held == [False], (
-        "the request session was still in a transaction when ogrinfo ran"
+    assert held == [False, False], (
+        "the request session was still in a transaction at the SSRF resolver "
+        "wait or when ogrinfo ran"
     )
     # The pending job is written after the release.
     assert resp.json()["job_id"]
+
+
+async def test_a_refused_url_still_writes_its_audit_row_after_the_release(
+    client: AsyncClient,
+    admin_auth_header: dict,
+    test_db_session: AsyncSession,
+    request_sessions,
+):
+    """The release must not cost the refusal path its audit row.
+
+    `_probe_audit_fail` runs after the rollback now, so it has to re-acquire a
+    connection and commit on it. If the release left the session unusable this
+    is where it would show.
+    """
+    from sqlalchemy import select
+
+    from app.modules.audit.models import AuditLog
+    from app.platform.security import SSRFError
+
+    probe_url = "https://a2-refused.example.com/wfs"
+
+    async def _refuse(_url):
+        raise SSRFError("URLs targeting private/internal networks are not allowed")
+
+    with patch("app.modules.catalog.sources.router.validate_url_for_ssrf", new=_refuse):
+        resp = await client.post(
+            "/services/probe/",
+            json={"url": probe_url},
+            headers=admin_auth_header,
+        )
+
+    assert resp.status_code == 400, resp.text
+    rows = (
+        (
+            await test_db_session.execute(
+                select(AuditLog).where(
+                    AuditLog.action == "probe_service",
+                    AuditLog.details["url"].astext == probe_url,
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert [row.details["result"] for row in rows] == ["ssrf_blocked"]
 
 
 # ---------------------------------------------------------------------------
@@ -352,6 +414,81 @@ async def test_reupload_commits_the_job_before_streaming_the_file(
     assert stored.file_path == str(tmp_path / f"a2-staged-{job_id}.geojson")
 
 
+async def test_a_sweep_during_the_upload_refuses_rather_than_binding(
+    client: AsyncClient,
+    admin_auth_header: dict,
+    test_db_session: AsyncSession,
+    tmp_path: Path,
+):
+    """fix(#1848 audit): the cost of committing first, bounded.
+
+    The row is visible and `pending` for the whole upload now, so the
+    stale-pending sweep can reclaim it while the bytes are still arriving. An
+    ORM flush would then bind the path onto a `cancelled` row and answer 201
+    with a job the next call refuses as already processed, losing the upload.
+    The bind is a compare-and-set on `status = 'pending'` instead, so a
+    reclaimed row is left alone and the caller is told to start again.
+    """
+    from sqlalchemy import select
+
+    from app.api.main import sweep_stale_jobs_once
+    from app.modules.catalog.datasets.api import router_reupload
+    from app.platform.jobs.sweep import stale_pending_cutoff_seconds
+
+    dataset = await _vector_dataset(test_db_session)
+    port = router_reupload.get_catalog_port()
+
+    async def _sweep_mid_upload(_file, job_id, **_kwargs):
+        # Age the row past the unbound cutoff and let the real sweep reclaim
+        # it, which is what a slow upload runs into.
+        cutoff = stale_pending_cutoff_seconds(completion_bound=False)
+        aged = datetime.now(timezone.utc) - timedelta(seconds=cutoff + 60)
+        row = await test_db_session.get(IngestJob, uuid.UUID(job_id))
+        assert row is not None, "the job must be committed before the upload"
+        row.created_at = aged
+        await test_db_session.commit()
+        await sweep_stale_jobs_once()
+        path = tmp_path / f"a2-swept-{job_id}.geojson"
+        path.write_bytes(b'{"type":"FeatureCollection","features":[]}')
+        return path
+
+    with (
+        patch.object(port, "save_upload_file", new=_sweep_mid_upload),
+        patch.object(port, "validate_file_content", return_value=None),
+        patch.object(router_reupload, "get_catalog_port", return_value=port),
+    ):
+        resp = await client.post(
+            f"/datasets/{dataset.id}/reupload",
+            files={
+                "file": (
+                    "replacement.geojson",
+                    BytesIO(b'{"type":"FeatureCollection","features":[]}'),
+                    "application/geo+json",
+                )
+            },
+            headers=admin_auth_header,
+        )
+
+    assert resp.status_code == 409, resp.text
+
+    rows = (
+        (
+            await test_db_session.execute(
+                select(IngestJob).where(IngestJob.dataset_id == dataset.id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(rows) == 1
+    await test_db_session.refresh(rows[0])
+    # The sweep's verdict stands, and no path was bound onto it.
+    assert rows[0].status == "cancelled"
+    assert not rows[0].file_path
+    # The staged file is cleaned on the refusal path, like every other failure.
+    assert not (tmp_path / f"a2-swept-{rows[0].id}.geojson").exists()
+
+
 async def test_a_failed_upload_leaves_a_reapable_pending_job(
     client: AsyncClient,
     admin_auth_header: dict,
@@ -410,8 +547,6 @@ async def test_a_failed_upload_leaves_a_reapable_pending_job(
     # the sweep's discriminator rather than the completion half.
     assert not rows[0].file_path
     # The predicate that reaps it, evaluated on this row rather than described.
-    from datetime import datetime, timedelta, timezone
-
     from sqlalchemy import select as _select
 
     later = datetime.now(timezone.utc) + timedelta(days=1)

--- a/backend/tests/test_reupload.py
+++ b/backend/tests/test_reupload.py
@@ -286,10 +286,12 @@ class TestReuploadUpload:
         job = result.scalar_one()
         assert job.dataset_id == dataset.id
         assert job.created_by == admin_id
-        assert job.user_metadata == {
-            "reupload": True,
-            "dataset_id": str(dataset.id),
-        }
+        # fix(#1848): the bind adds `staged_at`, which restarts the pending
+        # window. The two markers the job-binding gate reads are unchanged.
+        assert job.user_metadata["reupload"] is True
+        assert job.user_metadata["dataset_id"] == str(dataset.id)
+        assert job.user_metadata["staged_at"]
+        assert set(job.user_metadata) == {"reupload", "dataset_id", "staged_at"}
 
     async def test_reupload_stream_limit_error_leaves_a_reapable_job(
         self,

--- a/backend/tests/test_reupload.py
+++ b/backend/tests/test_reupload.py
@@ -45,7 +45,9 @@ async def test_reupload_commit_failure_cleans_owned_staged_file(tmp_path):
     port.validate_file_extension = MagicMock()
     port.validate_file_content = MagicMock()
     db = AsyncMock()
-    db.commit.side_effect = RuntimeError("commit failed")
+    # fix(#1848): the first commit is the one that frees the pooled connection
+    # before the upload. The failure under test is still the one after it.
+    db.commit.side_effect = [None, RuntimeError("commit failed")]
     cleanup = AsyncMock()
     upload = UploadFile(
         filename="replacement.geojson",
@@ -289,14 +291,20 @@ class TestReuploadUpload:
             "dataset_id": str(dataset.id),
         }
 
-    async def test_reupload_stream_limit_error_rolls_back_job(
+    async def test_reupload_stream_limit_error_leaves_a_reapable_job(
         self,
         client: AsyncClient,
         admin_auth_header: dict,
         test_db_session,
         mock_reupload_file_save,
     ):
-        """A streaming size rejection leaves neither a partial job nor upload."""
+        """A streaming size rejection binds no upload to the job.
+
+        fix(#1848): the job row is committed before the stream so the pooled
+        connection is not held across it, so a rejection now leaves the row
+        rather than rolling it back. It stays `pending` with nothing bound,
+        which is what `stale_pending_clauses` reaps on its one-hour policy.
+        """
         admin_id = await get_user_id(test_db_session, "admin")
         dataset = await _create_dataset(test_db_session, created_by=admin_id)
         filename = f"too-large-{uuid.uuid4()}.geojson"
@@ -316,9 +324,12 @@ class TestReuploadUpload:
         result = await test_db_session.execute(
             select(IngestJob).where(IngestJob.source_filename == filename)
         )
-        assert result.scalar_one_or_none() is None
+        job = result.scalar_one_or_none()
+        assert job is not None
+        assert job.status == "pending"
+        assert not job.file_path
 
-    async def test_s3_validation_download_failure_deletes_uncommitted_source(
+    async def test_s3_validation_download_failure_deletes_the_staged_source(
         self,
         client: AsyncClient,
         admin_auth_header: dict,
@@ -326,7 +337,12 @@ class TestReuploadUpload:
         mock_reupload_file_save,
         mock_reupload_catalog_port,
     ):
-        """A provider failure cannot orphan a reupload source without a job."""
+        """A provider failure cannot orphan the staged source.
+
+        fix(#1848): the job row is committed before the upload now, so the
+        assertion that survives is about the SOURCE. The row itself stays
+        `pending` with nothing bound, for the sweep to reap.
+        """
         admin_id = await get_user_id(test_db_session, "admin")
         dataset = await _create_dataset(test_db_session, created_by=admin_id)
         source_filename = f"resolve-failure-{uuid.uuid4()}.geojson"
@@ -360,7 +376,10 @@ class TestReuploadUpload:
         result = await test_db_session.execute(
             select(IngestJob).where(IngestJob.source_filename == source_filename)
         )
-        assert result.scalar_one_or_none() is None
+        job = result.scalar_one_or_none()
+        assert job is not None
+        assert job.status == "pending"
+        assert not job.file_path
 
     async def test_reupload_invalid_dataset_returns_404(
         self,


### PR DESCRIPTION
Closes the connection-holding class named in #1848, found by the backend audit of 2026-09-04 (P1-2). Verified on `origin/main` at 95a80e88d before anything changed.

`require_permission` queries the database before a handler body runs, so all five doors had a connection checked out from their first line and held it across the work they exist to do. The engine is `pool_size=10`, `max_overflow=3`, `pool_timeout=30`, so thirteen concurrent slow previews or large re-uploads occupy every slot and every other database-backed request waits thirty seconds and then fails as a 503. Neither `/services/probe` nor `/services/preview` is rate limited.

This wave already fixed the same class in `check_source_health`, twice in `router_refresh`, in `arcgis_signin` and in the export door. These five were not swept. The fix reuses that shape rather than inventing a second one.

## The four rollback doors

| Door | Released after | Held across, before |
| --- | --- | --- |
| `probe_service_url` | the SSRF check | three adapter probes at up to 30 s each, the ArcGIS count enrichment, the endpoint check |
| `preview_service_layer` | the duplicate-source query | the OGC API page walk, the ogrinfo subprocess, the CRS fallback |
| `reupload_service_preview` | the write-access and record-type gates | DNS validation, the page fetches, ogrinfo |
| `reupload_preview` | the job-binding gate | the S3 download, `run_ogrinfo_preview` |

Every authorization check still runs before any effect, and nothing is written before any of the four release points, so each `await db.rollback()` ends a read-only transaction. The audit rows, the pending job and the prior-job lookup that follow re-acquire a connection lazily.

The two service doors release above `validate_url_for_ssrf`, not below it. That validator awaits `socket.getaddrinfo` in a thread, so it is one of the waits the release has to precede rather than a cheap gate that may sit before it. The first version of this branch had both releases one step too late, which reproduced the same defect inside the fix; codex round 1 caught it. The preview keeps two releases, because its duplicate-source query sits between the SSRF check and the page walk and re-acquires a connection of its own.

The rollback expires every ORM instance on the session, which is the trap #716 documented when it fixed this class in the analysis preview. Each handler therefore reads what it still needs into locals first: `user.id` in all four, plus `column_info` and `feature_count` for the schema diff and the job's id and source filename for the response.

## The commit-first door

`reupload_dataset` cannot roll back. It holds an uncommitted `IngestJob` by construction, so a rollback would discard the row it is about to return. It commits that row before streaming the file instead, which is the shape the audit prescribed for it.

That changes one behaviour, and it is worth stating plainly. Before this, a transport failure mid-upload rolled the job back with the request transaction and left no row. Now the row survives as `pending` with nothing bound into `file_path`. That is exactly the unbound half of `stale_pending_clauses`, so the existing sweep reaps it on its one-hour abandonment policy with the abandoned-upload message. A test evaluates that predicate against the surviving row rather than describing it.

It also puts the row in reach of that sweep while the upload is still running, which the audit of this branch found. The sweep writes `cancelled` and `completed_at`, and the ORM flush that followed the upload marked only `file_path` dirty, so it bound the path onto the terminal row and answered 201 with a job the next call refuses as already processed. The bytes were unrecoverable. The bind is a compare-and-set on `status = 'pending'` now: a reclaimed row is left as the sweep left it, and the caller gets a 409 telling them to start again, with the staged file cleaned by the same handler every other failure path uses. The content-refusal write above it takes the same guard, so a reclaimed row keeps its terminal status and message there too. The response status stays the literal `pending`, which the compare-and-set makes true by construction rather than assumed.

The compare-and-set keeps a reclaimed row from being bound onto, but it does not help the upload that binds successfully and is then reclaimed a moment later. `save_upload_file` returns `staging/{job}/{name}` under the S3 provider and an absolute path under the local one, which is the default, and the sweep splits its two classes on whether `file_path` matches `staging/%`. So an S3 bind lands in the 24-hour class while a local bind stays in the short one, still measured from `coalesce(staged_at, created_at)`, which with no stamp is the pre-upload `created_at`. An upload slower than `pending_job_timeout_seconds` returned 201 and the next sweep cancelled the job it had just accepted. The bind stamps a fresh `staged_at` in the same guarded UPDATE now, so the window restarts at the moment the bytes landed. Written for both providers because it is one statement; only the local one needed it, and a test pins that asymmetry against the sweep's own predicate.

The early commit also releases the row's foreign-key lock, and `ingest_jobs.dataset_id` is `ON DELETE SET NULL`. A dataset deleted while the bytes were arriving left a job whose binding was gone, and a guard reading only id and status bound the file and answered 201, after which every later re-upload endpoint refused that job because the binding gate matches on `dataset_id`. Both guarded writes carry `IngestJob.dataset_id == dataset_id` now, taken from the path parameter rather than from the row, so a nulled binding matches no rows and takes the same 409 and staged-file cleanup as the timeout case. No lock is taken on the dataset.

Two things about the metadata write are worth stating. Stamping at CREATION, which an earlier round of this branch measured and dismissed, really is a no-op: the value equals `created_at`, so it moves neither the class nor the age. Stamping at BIND is a different thing, and the earlier measurement did not cover it. And the existing metadata is carried through rather than replaced, because the job-binding gate reads `reupload` and `dataset_id` off `user_metadata`; a bare replace would have made every later call on the job 404.

Three existing tests asserted the old contract by name and by assertion. They are updated to assert the new one, not removed:

- `test_reupload_stream_limit_error_rolls_back_job` becomes `..._leaves_a_reapable_job` and now asserts the row is `pending` with nothing bound.
- `test_s3_validation_download_failure_deletes_uncommitted_source` becomes `..._deletes_the_staged_source`; the assertion that survives is about the storage object, which is still cleaned.
- The unit test that makes `db.commit` raise now fails the second commit rather than the first, because the first is the one that frees the connection.

## Two consequences of committing first

Both follow from the row being durable during the upload, and both land in the bucket #1556 established for an upload nobody completed.

- A 413 oversize rejection now leaves a durable `pending` row rather than none. The sweep reaps it to `cancelled` with the abandoned-upload message, which is the right terminal state for it: nothing was ever dispatched.
- `save_upload_file` raising outside the `try` still stages no cleanup of its own. That is pre-existing and unchanged here; the provider owns whatever it wrote before it failed.

## Left as they are

Three sibling handlers in the same file hold their connection across I/O deliberately and are not touched:

- `reupload_commit` holds the `create_pending_run` reservation and the `commit_fence` row lock across the credential-store call. `_refuse_if_origin_changed`'s docstring states that the reservation is what makes its re-read decisive; releasing would drop both and break that.
- `complete_presigned_reupload` holds `lock_presigned_job`'s `SELECT ... FOR UPDATE` across the S3 assembly, and `finalize_presigned_object` takes the session and interleaves quota reads with the S3 copy. Releasing needs the callee restructured.
- `request_presigned_reupload` holds no database lock, but it signs one URL per part inside the transaction. It is the same shape as `reupload_dataset` and would be a reasonable follow-up.

The audit also notes `processing/ingest/router.py` `upload_file` as the identical multipart shape outside this issue's five. Not touched here.

## Schema, API and config impact

None. No migration, no request or response schema change, no new setting. `scripts/dump_openapi.py --check` exits 0.

## Verification

Run from the worktree against Postgres on localhost:5434.

```
tests/test_pooled_connection_release_1848.py      12 passed
tests/test_reupload.py                            44 passed
tests/test_reupload_idor.py                        7 passed
tests/test_reupload_service.py                     5 passed
tests/test_reupload_expected_origin_1768.py       14 passed
tests/test_reupload_record_type_guard.py          13 passed
tests/test_reupload_completion_contract_1207.py   12 passed
tests/test_reupload_swap_lock_retry.py             8 passed
tests/test_job_cancel_reupload_commit.py           2 passed
tests/test_services_endpoints.py                  51 passed
tests/test_service_auth_transport_1746.py        374 passed
tests/test_service_auth_contract_1746.py          55 passed
tests/test_door_token_policy_1746.py               9 passed
tests/test_import_token_lease_1676.py             16 passed
tests/test_raster_replace_1221.py                127 passed
tests/test_dataset_refresh_runs.py                76 passed
tests/test_analysis_preview.py                    83 passed
tests/test_tenant_staging_storage_keys.py         11 passed
tests/test_ingest.py                              45 passed
tests/test_1224_ingest_quota_enforcement.py        7 passed
tests/test_1184_body_limit_per_route.py           45 passed
tests/test_presigned_content_validation_1202.py   26 passed
tests/test_gdal_driver_clamp_1846.py              85 passed
tests/test_api_contract_openapi.py                23 passed
tests/test_stac_import.py                         30 passed
tests/test_preview_token_sec021.py                12 passed
tests/test_arcgis_auth.py                         38 passed
tests/test_probe_classification.py                25 passed
tests/test_layering.py + test_rule1_structural.py 57 passed
ruff check .                                      All checks passed
ruff format --check .                             1168 files already formatted
scripts/dump_openapi.py --check                   exit 0
```

`test_raster_replace_1221.py` and `test_dataset_refresh_runs.py` are the AST suites that pin the literal `dataset.record.created_by` billed identities and the exact set of `create_pending_run` callers. Both still pass, which is the check that no release was bought by hoisting one of those expressions into a local.

Counterfactuals, run per change by reverting only that change and restoring it:

- Each door's release: its test fails with `assert [True] == [False]`, meaning the request session was still inside a transaction when the mocked I/O ran. The first attempt at this stripped the comment blocks but left two of the rollbacks in place, so those two doors passed their own counterfactual; the strip was redone against the release lines alone and both then failed as expected.
- The two service releases put back below the SSRF check: `assert [True, False] == [False, False]`, which is codex round 1's finding stated exactly. Held at the resolver, released by the probes.
- The compare-and-set put back as an ORM flush: the mid-upload sweep test gets `201` with `{"status": "pending"}` on a row the sweep had already cancelled.
- The `staged_at` stamp removed from the bind: the slow-local-upload test finds the row `cancelled` immediately after a successful 201.
- The dataset binding removed from the bind guard: the deleted-dataset test gets 201 and an orphaned job with a null binding.

Every test records `in_transaction()` on the request's own session rather than a pool checkout count. The test engine uses NullPool, so a checkout count there says nothing about the production QueuePool, while an open transaction is what pins the connection either way. Same assertion `test_analysis_preview.py` uses for the earlier fix in this class.

Caps re-measured with `wc -l` and set to the exact figure: `sources/router.py` 1831 to 1849, `datasets/api/router_reupload.py` 1396 to 1455.
