### PR TITLE
fix(ingest): alembic logger flag and cleanup steps that mask the ingest exception

### DIFF
--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -32,7 +32,10 @@ import app.modules.tenancy.models  # noqa: F401 -- register tenancy models (Phas
 
 config = context.config
 if config.config_file_name is not None:
-    fileConfig(config.config_file_name)
+    # fix(#1755 item 8): the stdlib default disable_existing_loggers=True sets
+    # .disabled on every logger registered before this call and not named in
+    # alembic.ini, and nothing in the app or the test suite restores that flag.
+    fileConfig(config.config_file_name, disable_existing_loggers=False)
 
 import pathlib  # noqa: E402
 from importlib.metadata import entry_points as iter_entry_points  # noqa: E402

--- a/backend/app/processing/ingest/tasks_common.py
+++ b/backend/app/processing/ingest/tasks_common.py
@@ -26,7 +26,7 @@ from app.platform.cache.tiles import invalidate_catalog_cache
 from app.platform.dataset_origin import classify_origin, set_dataset_origin
 from app.core.config import settings
 from app.core.service_tokens import reset_registered_credential_secrets
-from app.core.url_redaction import redact_url_credentials
+from app.core.url_redaction import redact_exception_text, redact_url_credentials
 from app.processing.embeddings.helpers import defer_embedding
 from app.processing.ingest.source_format import derive_source_format
 from app.platform.storage import get_storage
@@ -330,6 +330,36 @@ def purge_token_on_failure(fn):
             raise
 
     return _wrapper
+
+
+@asynccontextmanager
+async def cleanup_step(what: str, *, job_id: str) -> AsyncGenerator[None, None]:
+    """Run one terminal-cleanup step; log a failure in it rather than raise it.
+
+    fix(#1755 item 11): a `finally`-block cleanup step must never replace the
+    exception the block is already propagating, and must never skip the steps
+    after it in the same block. Wrap ONE step per `async with` -- the isolation
+    is per block, not per `finally`.
+
+    Catches ``Exception``, not ``BaseException``: the cleanup runs during
+    worker shutdown too, and swallowing that ``CancelledError`` would strand
+    the shutdown it is running under.
+
+    ``what`` names the step for the operator; it is logged verbatim, so keep
+    it a fixed string. The failure is logged with ``exc_info`` and a redacted
+    message, since an ingest exception can carry a credentialed URL.
+    """
+    try:
+        yield
+    except (
+        Exception
+    ) as exc:  # broad: cleanup must not replace the exception it runs past
+        structlog.get_logger().exception(
+            "ingest_cleanup_step_failed",
+            step=what,
+            job_id=job_id,
+            error=redact_exception_text(exc),
+        )
 
 
 # ArcGIS esriFieldType → column_info type mapping

--- a/backend/app/processing/ingest/tasks_postgis_refresh.py
+++ b/backend/app/processing/ingest/tasks_postgis_refresh.py
@@ -60,6 +60,7 @@ from app.platform.refresh.service import (
 )
 from app.processing.ingest.tasks_common import (
     _bind_task_log_context,
+    cleanup_step,
     _current_tenant_role,
     _current_tenant_schema,
     _declared_geometry_type,
@@ -1125,4 +1126,5 @@ async def refresh_postgis(
             await err_session.commit()
         raise
     finally:
-        await stop_ingest_job_heartbeat(heartbeat_task)
+        async with cleanup_step("refresh_postgis heartbeat", job_id=job_id):
+            await stop_ingest_job_heartbeat(heartbeat_task)

--- a/backend/app/processing/ingest/tasks_raster.py
+++ b/backend/app/processing/ingest/tasks_raster.py
@@ -47,6 +47,7 @@ from app.processing.ingest.tasks_raster_common import (
 )
 from app.processing.ingest.tasks_common import (
     _bind_task_log_context,
+    cleanup_step,
     _emit_billing_event,
     _job_phase_session,
     _parse_temporal_fields,
@@ -840,17 +841,22 @@ async def ingest_raster(
         )
         raise
     finally:
-        await stop_ingest_job_heartbeat(heartbeat_task)
+        async with cleanup_step("ingest_raster heartbeat", job_id=job_id):
+            await stop_ingest_job_heartbeat(heartbeat_task)
         # GAP-017: orphan-asset cleanup. If we wrote COG/quicklook bytes to
         # storage but did NOT reach a successful terminal commit, the dataset
         # row those keys belong to was rolled back — delete_dataset will never
         # reap them. Remove them here so a crash/commit-failure mid-ingest does
         # not leave bytes under a rasters/{dataset_id}/ prefix with no DB row.
-        if not publish_committed and written_storage_keys:
-            await _cleanup_orphaned_storage_keys(written_storage_keys, job_id=job_id)
+        async with cleanup_step("ingest_raster orphaned storage keys", job_id=job_id):
+            if not publish_committed and written_storage_keys:
+                await _cleanup_orphaned_storage_keys(
+                    written_storage_keys, job_id=job_id
+                )
         # Clean up temp COG dir
-        if tmp_dir:
-            shutil.rmtree(tmp_dir, ignore_errors=True)
+        async with cleanup_step("ingest_raster temp dir", job_id=job_id):
+            if tmp_dir:
+                shutil.rmtree(tmp_dir, ignore_errors=True)
         # Clean up local staging file
         # fix(#1290 review): the local file is one of two different things and
         # only one of them is Decision 7's business. When it differs from
@@ -863,12 +869,13 @@ async def ingest_raster(
         # lossless copy, and it gets the same gate as the object-store reaper —
         # otherwise the RUNBOOK's retention promise held on S3 and quietly
         # failed on every local deployment.
-        if file_path != original_file_path:
-            _Path(file_path).unlink(missing_ok=True)
-        elif final_status == "complete" and (
-            source_preserved_in_cog or lossy_original_archived
-        ):
-            _Path(file_path).unlink(missing_ok=True)
+        async with cleanup_step("ingest_raster local file", job_id=job_id):
+            if file_path != original_file_path:
+                _Path(file_path).unlink(missing_ok=True)
+            elif final_status == "complete" and (
+                source_preserved_in_cog or lossy_original_archived
+            ):
+                _Path(file_path).unlink(missing_ok=True)
         # fix(#1202 review r5): sweep the presigned staging key. Raster has no
         # equivalent of the vector tail's #430 BA-09 block, so before this
         # nothing on this path ever deleted a storage object the client could
@@ -876,9 +883,12 @@ async def ingest_raster(
         # because it exempts the newest complete job per dataset, which is
         # exactly what a successful ingest produces. Shared with the vector
         # tail so the two cannot drift.
-        await reap_presigned_staging_object(
-            job_id, owned_staging_key, final_status=final_status
-        )
+        async with cleanup_step(
+            "ingest_raster presigned staging object", job_id=job_id
+        ):
+            await reap_presigned_staging_object(
+                job_id, owned_staging_key, final_status=final_status
+            )
         # fix(#1210), ADR-002 Decision 7: the pre-conversion source object.
         # This is the vector tail's #430 BA-09 block, which raster never had —
         # so every raster ever ingested kept its uploaded bytes forever beside
@@ -899,10 +909,11 @@ async def ingest_raster(
         # copy. It is now redundant with the gate (a failure never sets the flag)
         # and kept because it states the intent independently. RUNBOOK.md
         # section 9 states both windows for operators.
-        if source_preserved_in_cog or lossy_original_archived:
-            await reap_downloaded_staging_source(
-                job_id,
-                original_file_path=original_file_path,
-                final_status=final_status,
-                failed_source_replayable=True,
-            )
+        async with cleanup_step("ingest_raster downloaded source", job_id=job_id):
+            if source_preserved_in_cog or lossy_original_archived:
+                await reap_downloaded_staging_source(
+                    job_id,
+                    original_file_path=original_file_path,
+                    final_status=final_status,
+                    failed_source_replayable=True,
+                )

--- a/backend/app/processing/ingest/tasks_raster_replace.py
+++ b/backend/app/processing/ingest/tasks_raster_replace.py
@@ -64,6 +64,7 @@ from app.processing.raster.quicklook import generate_quicklook
 
 from app.processing.ingest.tasks_common import (
     _bind_task_log_context,
+    cleanup_step,
     _job_phase_session,
     _validate_upload_file_safety,
     reap_downloaded_staging_source,
@@ -881,7 +882,8 @@ async def reupload_raster(
         final_status = "failed"
         raise
     finally:
-        await stop_ingest_job_heartbeat(heartbeat_task)
+        async with cleanup_step("reupload_raster heartbeat", job_id=job_id):
+            await stop_ingest_job_heartbeat(heartbeat_task)
         # The failure mirror of the success reap, and the reason both filter
         # rather than delete outright: on this path the keys to remove are the
         # ones this attempt WROTE, minus any the live asset still points at.
@@ -892,13 +894,19 @@ async def reupload_raster(
         # Those diverge in exactly one place and it is the dangerous one: after
         # the swap commits, the written keys ARE the live asset, so a later
         # error must never bring the task through here to delete them.
-        if not swap_committed and written_storage_keys:
-            await _cleanup_orphaned_storage_keys(
-                [key for key in written_storage_keys if key not in prior_physical_keys],
-                job_id=job_id,
-            )
-        if tmp_dir:
-            shutil.rmtree(tmp_dir, ignore_errors=True)
+        async with cleanup_step("reupload_raster orphaned storage keys", job_id=job_id):
+            if not swap_committed and written_storage_keys:
+                await _cleanup_orphaned_storage_keys(
+                    [
+                        key
+                        for key in written_storage_keys
+                        if key not in prior_physical_keys
+                    ],
+                    job_id=job_id,
+                )
+        async with cleanup_step("reupload_raster temp dir", job_id=job_id):
+            if tmp_dir:
+                shutil.rmtree(tmp_dir, ignore_errors=True)
         # fix(#1290 review): the local file is one of two different things and
         # only one of them is Decision 7's business. When it differs from
         # `original_file_path` it is a scratch copy this task downloaded from
@@ -915,16 +923,20 @@ async def reupload_raster(
         # statement: the two branches always did the same thing, and merging
         # them is what pays for the stand-down branch above without loosening
         # the McCabe gate this function sits under.
-        if file_path != original_file_path or (
-            final_status == "complete"
-            and (source_preserved_in_cog or lossy_original_archived)
-        ):
-            Path(file_path).unlink(missing_ok=True)
+        async with cleanup_step("reupload_raster local file", job_id=job_id):
+            if file_path != original_file_path or (
+                final_status == "complete"
+                and (source_preserved_in_cog or lossy_original_archived)
+            ):
+                Path(file_path).unlink(missing_ok=True)
         # fix(#1207): the client-writable staging key, which stays recreatable
         # through an unexpired PUT URL until it is swept.
-        await reap_presigned_staging_object(
-            job_id, owned_staging_key, final_status=final_status
-        )
+        async with cleanup_step(
+            "reupload_raster presigned staging object", job_id=job_id
+        ):
+            await reap_presigned_staging_object(
+                job_id, owned_staging_key, final_status=final_status
+            )
         # fix(#1210), ADR-002 Decision 7: the pre-conversion upload, deleted on
         # success and retained on failure as the operator's only diagnostic
         # copy — bounded by the retention purge, which reaps a failed job's
@@ -936,10 +948,11 @@ async def reupload_raster(
         # carrying everything the upload did — true of DEFLATE, false of the
         # JPEG and WEBP profiles the import UI also offers. Same gate as the
         # first-ingest tail, same shared predicate, so the two cannot drift.
-        if source_preserved_in_cog or lossy_original_archived:
-            await reap_downloaded_staging_source(
-                job_id,
-                original_file_path=original_file_path,
-                final_status=final_status,
-                failed_source_replayable=True,
-            )
+        async with cleanup_step("reupload_raster downloaded source", job_id=job_id):
+            if source_preserved_in_cog or lossy_original_archived:
+                await reap_downloaded_staging_source(
+                    job_id,
+                    original_file_path=original_file_path,
+                    final_status=final_status,
+                    failed_source_replayable=True,
+                )

--- a/backend/app/processing/ingest/tasks_reupload.py
+++ b/backend/app/processing/ingest/tasks_reupload.py
@@ -9,7 +9,7 @@ import structlog
 from sqlalchemy import select, update
 
 from app.core.db.tenant_session import tenant_task
-from app.core.url_redaction import redact_exception_text, scrub_secret_from_exception
+from app.core.url_redaction import scrub_secret_from_exception
 from app.platform.cache.tiles import invalidate_catalog_cache
 from app.platform.dataset_origin import classify_origin, service_layer_identity
 from app.platform.jobs.heartbeat import (
@@ -36,6 +36,7 @@ from app.platform.refresh.service import (
 from app.processing.ingest.source_format import derive_source_format
 from app.processing.ingest.tasks_common import (
     _append_job_warning,
+    cleanup_step,
     _append_mercator_clip_warning,
     _apply_reupload_swap,
     _archive_original_file,
@@ -79,28 +80,6 @@ async def _drop_attempt_staging_table(staging_table: str) -> None:
             "attempt_staging_cleanup_failed",
             staging_table=staging_table,
             exc_info=True,
-        )
-
-
-async def _finally_cleanup(coro, *, what: str, job_id: str) -> None:
-    """Run one `finally`-block cleanup step; log rather than raise a failure.
-
-    fix(#1755 item 11): `reupload_service`'s `finally` block used to await
-    `stop_ingest_job_heartbeat` and `_drop_attempt_staging_table` bare, so an
-    exception from either replaced whatever the `try`/`except` above it was
-    already propagating -- silently turning an ingest failure into an
-    unrelated cleanup error in the queue row and the caller's `except`.
-    `_drop_attempt_staging_table` already swallows everything it raises
-    internally; routing it through here too is defence in depth against that
-    contract changing without this call site noticing.
-    """
-    try:
-        await coro
-    except Exception as exc:  # broad: a finally-block cleanup must never replace the exception it is propagating past
-        structlog.get_logger().exception(
-            f"{what} cleanup failed",
-            job_id=job_id,
-            error=redact_exception_text(exc),
         )
 
 
@@ -599,37 +578,44 @@ async def reupload_file(
         final_status = "failed"
         raise
     finally:
-        await stop_ingest_job_heartbeat(heartbeat_task)
-        await _drop_attempt_staging_table(staging_tn)
+        async with cleanup_step("reupload_file heartbeat", job_id=job_id):
+            await stop_ingest_job_heartbeat(heartbeat_task)
+        async with cleanup_step("reupload_file staging table", job_id=job_id):
+            await _drop_attempt_staging_table(staging_tn)
         # Clean up local file on success always; on failure only if it was
         # a resolve_file_path download (source of truth is S3).
-        if final_status == "complete":
-            Path(file_path).unlink(missing_ok=True)
-        elif file_path != original_file_path:
-            Path(file_path).unlink(missing_ok=True)
+        async with cleanup_step("reupload_file local file", job_id=job_id):
+            if final_status == "complete":
+                Path(file_path).unlink(missing_ok=True)
+            elif file_path != original_file_path:
+                Path(file_path).unlink(missing_ok=True)
         # fix(#1213 review r2): reap the object the task downloaded FROM, which
         # after a presigned completion is the frozen copy the job is bound to —
         # the unlinks above are local files only, so it was never deleted and a
         # successful reupload job is its dataset's latest-complete row, exempt
         # from the stale purge forever. No fan-out on this surface, so the
         # sibling-sharing guard is left at its default.
-        await reap_downloaded_staging_source(
-            job_id,
-            original_file_path=original_file_path,
-            final_status=final_status,
-            # _retry_capability refuses reupload jobs outright, so nothing
-            # else will ever reap this; reap on failure too.
-            failed_source_replayable=False,
-        )
+        async with cleanup_step("reupload_file downloaded source", job_id=job_id):
+            await reap_downloaded_staging_source(
+                job_id,
+                original_file_path=original_file_path,
+                final_status=final_status,
+                # _retry_capability refuses reupload jobs outright, so nothing
+                # else will ever reap this; reap on failure too.
+                failed_source_replayable=False,
+            )
         # fix(#1207): sweep the presigned staging key. This surface had NO
         # storage reaper at all — the unlinks above are local files only — and
         # the stale purge is not a backstop here, because a successful reupload
         # job is the per-dataset latest-complete row it exempts forever. So
         # every reupload staging object lived forever, recreatable through the
         # client's unexpired PUT URL. Shared helper, same as the ingest tails.
-        await reap_presigned_staging_object(
-            job_id, owned_staging_key, final_status=final_status
-        )
+        async with cleanup_step(
+            "reupload_file presigned staging object", job_id=job_id
+        ):
+            await reap_presigned_staging_object(
+                job_id, owned_staging_key, final_status=final_status
+            )
 
 
 async def _record_failed_origin_contact(
@@ -1315,19 +1301,10 @@ async def reupload_service(
             await err_session.commit()
         raise
     finally:
-        # fix(#1755 item 11): routed through `_finally_cleanup` so a failure
-        # in either call logs rather than replacing the ingest exception
-        # `raise` above is propagating (or the OTHER cleanup call, since each
-        # runs regardless of whether its sibling failed). `purge_token_on_
-        # failure` (`tasks_common.py`), the decorator around this task, still
-        # sees whatever exception `reupload_service` itself raised.
-        await _finally_cleanup(
-            stop_ingest_job_heartbeat(heartbeat_task),
-            what="reupload_service heartbeat",
-            job_id=str(job_uuid),
-        )
-        await _finally_cleanup(
-            _drop_attempt_staging_table(staging_tn),
-            what="reupload_service staging",
-            job_id=str(job_uuid),
-        )
+        # fix(#1755 item 11): `purge_token_on_failure` (`tasks_common.py`), the
+        # decorator around this task, must still see whatever exception
+        # `reupload_service` itself raised, not one from a cleanup step.
+        async with cleanup_step("reupload_service heartbeat", job_id=job_id):
+            await stop_ingest_job_heartbeat(heartbeat_task)
+        async with cleanup_step("reupload_service staging table", job_id=job_id):
+            await _drop_attempt_staging_table(staging_tn)

--- a/backend/app/processing/ingest/tasks_stac_refresh.py
+++ b/backend/app/processing/ingest/tasks_stac_refresh.py
@@ -62,6 +62,7 @@ from app.platform.refresh.service import (
 )
 from app.processing.ingest.tasks_common import (
     _bind_task_log_context,
+    cleanup_step,
     stamp_failed_origin_health,
     task_app,
 )
@@ -796,4 +797,5 @@ async def refresh_stac(
             await err_session.commit()
         raise
     finally:
-        await stop_ingest_job_heartbeat(heartbeat_task)
+        async with cleanup_step("refresh_stac heartbeat", job_id=job_id):
+            await stop_ingest_job_heartbeat(heartbeat_task)

--- a/backend/app/processing/ingest/tasks_vector.py
+++ b/backend/app/processing/ingest/tasks_vector.py
@@ -10,7 +10,7 @@ import structlog
 from sqlalchemy import or_, text, update
 
 from app.core.db.tenant_session import tenant_task
-from app.core.url_redaction import redact_exception_text, scrub_secret_from_exception
+from app.core.url_redaction import scrub_secret_from_exception
 from app.platform.dataset_origin import service_layer_identity
 from app.platform.jobs.heartbeat import (
     attempt_scoped_staging_table,
@@ -24,6 +24,7 @@ from app.processing.ingest.metadata import _qtable
 from app.processing.ingest.source_format import derive_source_format
 from app.processing.ingest.tasks_common import (
     IngestContext,
+    cleanup_step,
     reap_downloaded_staging_source,
     reap_presigned_staging_object,
     _append_job_warning,
@@ -115,28 +116,6 @@ async def _drop_attempt_staging_table(staging_table: str) -> None:
             "attempt_staging_cleanup_failed",
             staging_table=staging_table,
             exc_info=True,
-        )
-
-
-async def _finally_cleanup(coro, *, what: str, job_id: str) -> None:
-    """Run one `finally`-block cleanup step; log rather than raise a failure.
-
-    fix(#1755 item 11): `ingest_service`'s `finally` block used to await
-    `stop_ingest_job_heartbeat` and `_drop_attempt_staging_table` bare, so an
-    exception from either replaced whatever the `try`/`except` above it was
-    already propagating -- silently turning an ingest failure into an
-    unrelated cleanup error in the queue row and the caller's `except`.
-    `_drop_attempt_staging_table` already swallows everything it raises
-    internally; routing it through here too is defence in depth against that
-    contract changing without this call site noticing.
-    """
-    try:
-        await coro
-    except Exception as exc:  # broad: a finally-block cleanup must never replace the exception it is propagating past
-        structlog.get_logger().exception(
-            f"{what} cleanup failed",
-            job_id=job_id,
-            error=redact_exception_text(exc),
         )
 
 
@@ -888,8 +867,10 @@ async def ingest_file(
         final_status = "failed"
         raise
     finally:
-        await stop_ingest_job_heartbeat(heartbeat_task)
-        await _drop_attempt_staging_table(staging_table_name)
+        async with cleanup_step("ingest_file heartbeat", job_id=job_id):
+            await stop_ingest_job_heartbeat(heartbeat_task)
+        async with cleanup_step("ingest_file staging table", job_id=job_id):
+            await _drop_attempt_staging_table(staging_table_name)
         # Clean up local file on success always; on failure only if it was
         # a resolve_file_path download (source of truth is S3, not the
         # local copy). Local-only uploads are kept for retry.
@@ -937,35 +918,38 @@ async def ingest_file(
         except Exception:  # broad: cleanup decision is best-effort, never block completion on this query
             is_fan_out_child = True
 
-        if _should_unlink_staging(
-            file_path=file_path,
-            original_file_path=original_file_path,
-            final_status=final_status,
-            is_fan_out_child=is_fan_out_child,
-        ):
-            Path(file_path).unlink(missing_ok=True)
+        async with cleanup_step("ingest_file local file", job_id=job_id):
+            if _should_unlink_staging(
+                file_path=file_path,
+                original_file_path=original_file_path,
+                final_status=final_status,
+                is_fan_out_child=is_fan_out_child,
+            ):
+                Path(file_path).unlink(missing_ok=True)
 
         # fix(#1213 review r2): shared with the reupload tail — after a
         # presigned completion this reaps the FROZEN copy the job is bound to.
-        await reap_downloaded_staging_source(
-            job_id,
-            original_file_path=original_file_path,
-            final_status=final_status,
-            # Ordinary imports: a failed job stays retryable while its
-            # source exists (_retry_capability), so retain on failure and
-            # let the stale purge own it.
-            failed_source_replayable=True,
-            is_fan_out_child=is_fan_out_child,
-        )
+        async with cleanup_step("ingest_file downloaded source", job_id=job_id):
+            await reap_downloaded_staging_source(
+                job_id,
+                original_file_path=original_file_path,
+                final_status=final_status,
+                # Ordinary imports: a failed job stays retryable while its
+                # source exists (_retry_capability), so retain on failure and
+                # let the stale purge own it.
+                failed_source_replayable=True,
+                is_fan_out_child=is_fan_out_child,
+            )
 
         # fix(#1202 review r5): sweep the presigned staging key too. The block
         # above only reaps `original_file_path`, which after a presigned
         # completion is the FROZEN copy — so the key the client still holds a
         # PUT URL for was never touched. Shared with the raster tail so the
         # two cannot drift.
-        await reap_presigned_staging_object(
-            job_id, owned_staging_key, final_status=final_status
-        )
+        async with cleanup_step("ingest_file presigned staging object", job_id=job_id):
+            await reap_presigned_staging_object(
+                job_id, owned_staging_key, final_status=final_status
+            )
 
 
 @task_app.task(
@@ -1215,9 +1199,10 @@ async def ingest_service(
                 _do_import, source_layer, token=token
             )
         finally:
-            service_progress_task.cancel()
-            with suppress(asyncio.CancelledError):
-                await service_progress_task
+            async with cleanup_step("ingest_service progress heartbeat", job_id=job_id):
+                service_progress_task.cancel()
+                with suppress(asyncio.CancelledError):
+                    await service_progress_task
 
         # ----------------------------------------------------------------- #
         # Phase 2 (short-lived session): post-ogr2ogr finalization.
@@ -1374,19 +1359,10 @@ async def ingest_service(
                 )
         raise
     finally:
-        # fix(#1755 item 11): routed through `_finally_cleanup` so a failure
-        # in either call logs rather than replacing the ingest exception
-        # `raise` above is propagating (or the OTHER cleanup call, since each
-        # runs regardless of whether its sibling failed). `purge_token_on_
-        # failure` (`tasks_common.py`), the decorator around this task, still
-        # sees whatever exception `ingest_service` itself raised.
-        await _finally_cleanup(
-            stop_ingest_job_heartbeat(heartbeat_task),
-            what="ingest_service heartbeat",
-            job_id=job_id,
-        )
-        await _finally_cleanup(
-            _drop_attempt_staging_table(staging_table_name),
-            what="ingest_service staging",
-            job_id=job_id,
-        )
+        # fix(#1755 item 11): `purge_token_on_failure` (`tasks_common.py`), the
+        # decorator around this task, must still see whatever exception
+        # `ingest_service` itself raised, not one from a cleanup step.
+        async with cleanup_step("ingest_service heartbeat", job_id=job_id):
+            await stop_ingest_job_heartbeat(heartbeat_task)
+        async with cleanup_step("ingest_service staging table", job_id=job_id):
+            await _drop_attempt_staging_table(staging_table_name)

--- a/backend/app/processing/ingest/tasks_vrt.py
+++ b/backend/app/processing/ingest/tasks_vrt.py
@@ -42,6 +42,7 @@ from app.platform.storage import get_storage
 
 from app.processing.ingest.tasks_common import (
     _bind_task_log_context,
+    cleanup_step,
     _cleanup_staging_on_failure,
     task_app,
 )
@@ -845,17 +846,22 @@ async def ingest_vrt(
                 )
         raise
     finally:
-        await stop_ingest_job_heartbeat(heartbeat_task)
-        if tmp_dir:
-            shutil.rmtree(tmp_dir, ignore_errors=True)
+        async with cleanup_step("ingest_vrt heartbeat", job_id=job_id):
+            await stop_ingest_job_heartbeat(heartbeat_task)
+        async with cleanup_step("ingest_vrt temp dir", job_id=job_id):
+            if tmp_dir:
+                shutil.rmtree(tmp_dir, ignore_errors=True)
         # fix(#430 BA-30): reap storage bytes written before a terminal commit
         # that never became durable (mirrors ingest_raster's GAP-017 guard).
-        if not publish_committed and written_storage_keys:
-            from app.processing.ingest.tasks_raster import (
-                _cleanup_orphaned_storage_keys,
-            )
+        async with cleanup_step("ingest_vrt orphaned storage keys", job_id=job_id):
+            if not publish_committed and written_storage_keys:
+                from app.processing.ingest.tasks_raster import (
+                    _cleanup_orphaned_storage_keys,
+                )
 
-            await _cleanup_orphaned_storage_keys(written_storage_keys, job_id=job_id)
+                await _cleanup_orphaned_storage_keys(
+                    written_storage_keys, job_id=job_id
+                )
 
 
 @task_app.task(queue="raster", retry=0, aliases=["app.ingest.tasks.regenerate_vrt"])
@@ -1572,16 +1578,22 @@ async def regenerate_vrt(
             await err_session.commit()
         raise
     finally:
-        await stop_ingest_job_heartbeat(generation_heartbeat_task)
-        await stop_ingest_job_heartbeat(heartbeat_task)
-        if tmp_dir:
-            shutil.rmtree(tmp_dir, ignore_errors=True)
-        if not publish_committed and written_storage_keys:
-            from app.processing.ingest.tasks_raster import (
-                _cleanup_orphaned_storage_keys,
-            )
+        async with cleanup_step("regenerate_vrt generation heartbeat", job_id=job_id):
+            await stop_ingest_job_heartbeat(generation_heartbeat_task)
+        async with cleanup_step("regenerate_vrt heartbeat", job_id=job_id):
+            await stop_ingest_job_heartbeat(heartbeat_task)
+        async with cleanup_step("regenerate_vrt temp dir", job_id=job_id):
+            if tmp_dir:
+                shutil.rmtree(tmp_dir, ignore_errors=True)
+        async with cleanup_step("regenerate_vrt orphaned storage keys", job_id=job_id):
+            if not publish_committed and written_storage_keys:
+                from app.processing.ingest.tasks_raster import (
+                    _cleanup_orphaned_storage_keys,
+                )
 
-            await _cleanup_orphaned_storage_keys(written_storage_keys, job_id=job_id)
+                await _cleanup_orphaned_storage_keys(
+                    written_storage_keys, job_id=job_id
+                )
 
 
 # fix(#1327 codex P1): a SECOND registered name for the SAME regeneration, used

--- a/backend/tests/test_1746_stdlib_log_redaction.py
+++ b/backend/tests/test_1746_stdlib_log_redaction.py
@@ -21,9 +21,9 @@ root logger instead and read back what it actually received.
 ``tests/_logging_state.configured_logging()`` saves and restores every
 logger ``setup_logging()`` is documented to mutate — root, the three uvicorn
 loggers, and (as of fix #1746 codex r5) ``httpx``/``httpcore`` (see
-``_logging_state.py``'s own docstring). ``setup_logging()`` never touches
-``.disabled`` though, so this file still restores that one flag itself; see
-the autouse fixture below for why it needs to.
+``_logging_state.py``'s own docstring). ``.disabled`` is outside that snapshot
+because ``setup_logging()`` never touches it; fix(#1755 item 8) removed the
+only thing that did, so this file no longer restores it either.
 """
 
 import base64
@@ -72,36 +72,6 @@ class _ListHandler(logging.Handler):
 
     def emit(self, record: logging.LogRecord) -> None:
         self.lines.append(self.format(record))
-
-
-@pytest.fixture(autouse=True)
-def _restore_httpx_logger_disabled_flag():
-    """Undo alembic's `fileConfig()` disabling the "httpx" logger.
-
-    `_logging_state._MUTATED_LOGGERS` and `conftest._LOGGING_MUTATED_LOGGERS`
-    now include "httpx"/"httpcore" (fix #1746 codex r5), so `level` -- what
-    this fixture used to also save and restore -- is covered by
-    `configured_logging()` and the autouse guard already. `.disabled` is not:
-    neither snapshot reads or writes it, because `setup_logging()` itself
-    never touches it, so it was never in scope for either.
-
-    `alembic/env.py` calls `logging.config.fileConfig()` to run migrations,
-    and that defaults to `disable_existing_loggers=True`, which disables
-    every *already-registered* logger not named in alembic.ini's `[loggers]`
-    section. By the time that runs, collection has already imported plenty
-    of other test modules that import httpx, so the "httpx" logger object
-    already exists and gets silently `.disabled = True` for the rest of the
-    session -- independent of this file's own fix, and independent of
-    `setup_logging()` entirely. Restoring the flag here keeps this file
-    exercising the real fix instead of that unrelated side effect.
-    """
-    loggers = [logging.getLogger(name) for name in ("httpx", "httpcore")]
-    saved = [lg.disabled for lg in loggers]
-    for lg in loggers:
-        lg.disabled = False
-    yield
-    for lg, disabled in zip(loggers, saved):
-        lg.disabled = disabled
 
 
 def _emit_through_real_pipeline(

--- a/backend/tests/test_1755_alembic_logger_flag.py
+++ b/backend/tests/test_1755_alembic_logger_flag.py
@@ -1,0 +1,73 @@
+"""fix(#1755 item 8): running migrations must not disable the loggers already registered.
+
+``alembic/env.py`` calls ``logging.config.fileConfig()`` so a migration run gets
+alembic.ini's console handler and levels. The stdlib default for that call is
+``disable_existing_loggers=True``, which sets ``.disabled = True`` on every
+logger object that already exists and is not named in alembic.ini's
+``[loggers]`` section (root, sqlalchemy, alembic).
+
+In production that silences whatever the API imported before the migration
+step. In the test suite it is worse, because the effect outlives the call: the
+session-scoped migration fixture runs once per worker, after collection has
+already imported the modules under test, so every application and third-party
+logger registered by then stays ``.disabled`` for the rest of the session. Three
+test sites had grown their own local re-enable dance around that, and a test
+that re-enables the logger it is about to assert on is testing the dance.
+
+``.disabled`` is the one flag nothing else restores: ``setup_logging()`` never
+touches it, so neither ``tests/_logging_state.configured_logging()`` nor
+conftest's logging guard snapshots it.
+"""
+
+import ast
+import logging
+import pathlib
+
+import httpx  # noqa: F401 -- registers the "httpx" logger at collection, before the session migration fixture calls fileConfig()
+import pytest
+
+_ENV_PY = pathlib.Path(__file__).resolve().parents[1] / "alembic" / "env.py"
+
+
+def _file_config_call() -> ast.Call:
+    """The single ``fileConfig(...)`` call in alembic/env.py."""
+    tree = ast.parse(_ENV_PY.read_text())
+    calls = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "fileConfig"
+    ]
+    assert len(calls) == 1, f"expected one fileConfig call, found {len(calls)}"
+    return calls[0]
+
+
+def test_alembic_env_opts_out_of_disabling_existing_loggers():
+    """env.py must pass the flag explicitly, not inherit the stdlib default."""
+    keywords = {kw.arg: kw.value for kw in _file_config_call().keywords}
+    assert "disable_existing_loggers" in keywords, (
+        "alembic/env.py calls fileConfig() without disable_existing_loggers, so it "
+        "inherits the stdlib default True and silences every logger already "
+        "registered when a migration runs."
+    )
+    value = keywords["disable_existing_loggers"]
+    assert isinstance(value, ast.Constant) and value.value is False, (
+        "disable_existing_loggers must be the literal False"
+    )
+
+
+def test_migration_run_leaves_an_already_registered_logger_enabled():
+    """The session migration ran; the "httpx" logger it did not name still works.
+
+    The alembic logger's level is the proof that fileConfig actually ran in
+    this session (alembic.ini sets it to INFO, and nothing else in the suite
+    touches that logger). Without it this test would pass vacuously on a run
+    where Postgres was unreachable and the migration fixture never fired.
+    """
+    if logging.getLogger("alembic").level != logging.INFO:
+        pytest.skip(
+            "alembic.ini logging was never applied in this session, so there is "
+            "nothing for this test to observe"
+        )
+    assert logging.getLogger("httpx").disabled is False

--- a/backend/tests/test_1755_cleanup_step.py
+++ b/backend/tests/test_1755_cleanup_step.py
@@ -1,0 +1,97 @@
+"""fix(#1755 item 11): a cleanup step must not eat the exception it runs past.
+
+Every ingest task ends in a `finally:` block that stops its heartbeat, drops
+its attempt staging table, unlinks local scratch files and reaps staging
+objects. Each call used to be awaited bare, which gives a failing cleanup two
+ways to destroy the diagnosis:
+
+- it REPLACES whatever the `try`/`except` above was propagating, so the queue
+  row and the caller's `except` record an unrelated cleanup error, and
+- it SKIPS every remaining step in the same block, including the reaps and
+  (through the raise leaving the task) anything the caller does after.
+
+``cleanup_step`` (``processing/ingest/tasks_common.py``) is the one helper all
+seven task modules now route those steps through.
+
+structlog records are read with ``structlog.testing.capture_logs``; pytest's
+``caplog`` sees zero of them in this repo.
+"""
+
+import asyncio
+
+import pytest
+import structlog
+
+from app.processing.ingest.tasks_common import cleanup_step
+
+pytestmark = pytest.mark.anyio
+
+
+async def test_a_failing_step_is_logged_and_does_not_raise():
+    with structlog.testing.capture_logs() as captured:
+        async with cleanup_step("ingest_file heartbeat", job_id="job-77"):
+            raise ValueError("cleanup boom")
+
+    entries = [e for e in captured if e["event"] == "ingest_cleanup_step_failed"]
+    assert len(entries) == 1
+    assert entries[0]["step"] == "ingest_file heartbeat"
+    assert entries[0]["job_id"] == "job-77"
+    assert entries[0]["log_level"] == "error"
+    assert "cleanup boom" in entries[0]["error"]
+
+
+async def test_a_successful_step_logs_nothing():
+    ran = False
+    with structlog.testing.capture_logs() as captured:
+        async with cleanup_step("ingest_file staging table", job_id="job-77"):
+            ran = True
+
+    assert ran is True
+    assert [e for e in captured if e["event"] == "ingest_cleanup_step_failed"] == []
+
+
+async def test_a_failing_step_neither_masks_the_exception_nor_skips_the_next():
+    """The whole point, exercised in the shape the task tails use."""
+    later_steps: list[str] = []
+
+    with structlog.testing.capture_logs() as captured:
+        with pytest.raises(RuntimeError, match="the real ingest failure"):
+            try:
+                raise RuntimeError("the real ingest failure")
+            finally:
+                async with cleanup_step("heartbeat", job_id="job-77"):
+                    raise ValueError("cleanup boom")
+                async with cleanup_step("staging table", job_id="job-77"):
+                    later_steps.append("staging table")
+                async with cleanup_step("token purge", job_id="job-77"):
+                    later_steps.append("token purge")
+
+    assert later_steps == ["staging table", "token purge"]
+    failed = [e["step"] for e in captured if e["event"] == "ingest_cleanup_step_failed"]
+    assert failed == ["heartbeat"]
+
+
+async def test_cancellation_is_not_swallowed():
+    """A worker shutdown must still reach the task it is shutting down.
+
+    ``CancelledError`` is a ``BaseException``, so the helper's ``except
+    Exception`` has to let it through. Swallowing it would leave the worker
+    waiting on a task that reported itself finished.
+    """
+    with pytest.raises(asyncio.CancelledError):
+        async with cleanup_step("heartbeat", job_id="job-77"):
+            raise asyncio.CancelledError()
+
+
+async def test_the_logged_message_is_redacted():
+    """A cleanup exception can carry a credentialed URL; the log must not."""
+    token = "SECRETTOKEN123"
+    url = f"https://services.example.com/svc/FeatureServer/0?f=json&token={token}"
+
+    with structlog.testing.capture_logs() as captured:
+        async with cleanup_step("downloaded source", job_id="job-77"):
+            raise RuntimeError(f"Client error '401 Unauthorized' for url '{url}'")
+
+    entry = next(e for e in captured if e["event"] == "ingest_cleanup_step_failed")
+    assert token not in entry["error"]
+    assert token not in repr(entry)

--- a/backend/tests/test_failed_job_token_purge_1746.py
+++ b/backend/tests/test_failed_job_token_purge_1746.py
@@ -353,17 +353,21 @@ class TestCleanupFailuresDoNotMaskTheOriginalException:
         async def _boom_credential(*_args, **_kwargs) -> str | None:
             raise RuntimeError("simulated ingest failure")
 
+        cleanup_calls: list[str] = []
+
         async def _stop_heartbeat_and_raise(task) -> None:
             # Real cleanup first (cancels the real background task), THEN the
             # simulated failure — proves the wrapping, not merely that
             # cleanup was skipped.
             await _real_stop_heartbeat(task)
+            cleanup_calls.append("heartbeat")
             raise ValueError("cleanup boom: heartbeat")
 
         real_drop_staging = tasks_vector._drop_attempt_staging_table
 
         async def _drop_staging_and_raise(staging_table: str) -> None:
             await real_drop_staging(staging_table)
+            cleanup_calls.append("staging")
             raise KeyError("cleanup boom: staging")
 
         monkeypatch.setattr(
@@ -393,6 +397,9 @@ class TestCleanupFailuresDoNotMaskTheOriginalException:
                     token=FAKE_TOKEN,
                 )
 
+            # fix(#1755 item 11): the second step ran even though the first
+            # raised. Per-step isolation, not per-`finally`.
+            assert cleanup_calls == ["heartbeat", "staging"]
             after = await _read_args(test_db_session, row_id)
             assert "token" not in after, "the #1753 purge must still run"
         finally:

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -3548,7 +3548,15 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # fix(#1846 review round 4): +5. Same thread offload as the ogr.py sites,
     # with the comment saying why a linear walk still does not belong on the
     # loop. Cap 2546 -> 2551, exact.
-    "backend/app/processing/ingest/tasks_common.py": 2551,
+    # fix(#1755 item 11): +30. `cleanup_step`, the one helper the seven ingest
+    # task modules now route every `finally`-block cleanup step through, plus
+    # the docstring stating the two things it must never do: replace the
+    # exception the block is already propagating, and swallow the
+    # `CancelledError` a worker shutdown delivers. It replaces two private
+    # copies that had grown in tasks_vector.py and tasks_reupload.py, whose
+    # bodies differed only in the task name in their docstrings.
+    # Cap 2551 -> 2581, exact.
+    "backend/app/processing/ingest/tasks_common.py": 2581,
     # --- entered by the inclusion rule, feat(#1219 x #1222) ---------------
     # tasks_reupload crossed 1000 when two independently-reviewed features
     # met in one file: #1222's failed-contact bookkeeping (spawn-armed
@@ -3644,7 +3652,12 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # rather than replacing the ingest exception in flight; the #1753 token
     # purge still runs, since the helper never re-raises. Cap 1297 -> 1333,
     # exact.
-    "backend/app/processing/ingest/tasks_reupload.py": 1333,
+    # fix(#1755 item 11, follow-up): -23. The private `_finally_cleanup` copy
+    # moved to `tasks_common.cleanup_step` as a context manager, which is
+    # shorter at every call site than passing a coroutine, and `reupload_file`
+    # gained the same treatment its service sibling already had (5 steps).
+    # Cap 1333 -> 1310, exact.
+    "backend/app/processing/ingest/tasks_reupload.py": 1310,
     # --- entered by the inclusion rule, feat(#1266) -----------------------
     # The refresh door crossed 1000 when it gained its third execution
     # strategy. Two thirds of the addition is the STAC dispatcher, which is
@@ -4504,7 +4517,10 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # a vrt_regenerate job specifically to avoid an AB-BA deadlock with this
     # worker, so locking the job row here first would reopen that cycle. Cap
     # 1600 -> 1628, exact.
-    "backend/app/processing/ingest/tasks_vrt.py": 1628,
+    # fix(#1755 item 11): +12. Both task tails route every cleanup step
+    # through `cleanup_step`: three in `ingest_vrt`, four in `regenerate_vrt`,
+    # which stops two heartbeats. Cap 1628 -> 1640, exact.
+    "backend/app/processing/ingest/tasks_vrt.py": 1640,
     # fix(#1202 review r5): +29 — sweep the presigned staging key at job end.
     # A completed presigned job points file_path at its frozen copy, so this
     # reaper never touched the key the client's PUT URL can still recreate.
@@ -4628,7 +4644,13 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # rather than replacing the ingest exception in flight; the #1753 token
     # purge still runs, since the helper never re-raises. Cap 1356 -> 1392,
     # exact.
-    "backend/app/processing/ingest/tasks_vector.py": 1392,
+    # fix(#1755 item 11, follow-up): -24. The private `_finally_cleanup` copy
+    # moved to `tasks_common.cleanup_step`, and the two `finally` blocks the
+    # first pass left bare are routed too: `ingest_file`'s five steps, and the
+    # nested one that stops the service-import progress heartbeat, where
+    # awaiting the cancelled task re-raises anything the heartbeat body itself
+    # failed with. Cap 1392 -> 1368, exact.
+    "backend/app/processing/ingest/tasks_vector.py": 1368,
     # --- entered by the inclusion rule ------------------------------------
     # Crossed 1000 lines adding the "unable to open datasource" friendly-
     # message mapping shared by run_ogrinfo and run_ogr2ogr: the pattern
@@ -5062,7 +5084,10 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # with a valid STORED GENERATED `geom_4326` left the dataset with no
     # spatial index and every `geom_4326 && <envelope>` predicate the readers
     # issue fell back to a sequential scan. Cap 1104 -> 1128, exact.
-    "backend/app/processing/ingest/tasks_postgis_refresh.py": 1128,
+    # fix(#1755 item 11): +2. The `finally` block's heartbeat stop routes
+    # through `cleanup_step`, so a failure in it logs instead of replacing the
+    # refresh exception being propagated. Cap 1128 -> 1130, exact.
+    "backend/app/processing/ingest/tasks_postgis_refresh.py": 1130,
     # --- entered by the inclusion rule, feat(#765) -------------------------
     # First time this module crosses 1000. main sat at 994, six lines under the
     # gate, so it was going to fire on whoever added next; it fired here.

--- a/backend/tests/test_maps_style_json.py
+++ b/backend/tests/test_maps_style_json.py
@@ -881,10 +881,7 @@ def test_build_maplibre_style_drops_line_gradient_paint_on_unsupported_source_ty
 ):
     """Drop line-gradient paint when the backing source type cannot support lineMetrics.
 
-    Mirrors the Phase 251 _HILLSHADE_PAINT_KEYS silent-filter convention. The
-    `style_json` module logger is re-enabled before the test because the conftest's
-    alembic `fileConfig(...)` call defaults to `disable_existing_loggers=True`,
-    which silences module loggers loaded before alembic ran (see alembic/env.py).
+    Mirrors the Phase 251 _HILLSHADE_PAINT_KEYS silent-filter convention.
     """
     import logging
 
@@ -909,16 +906,8 @@ def test_build_maplibre_style_drops_line_gradient_paint_on_unsupported_source_ty
         filter=None,
         style_config=None,
     )
-    target_logger = logging.getLogger("app.modules.catalog.maps.style_json")
-    was_disabled = target_logger.disabled
-    target_logger.disabled = False
-    try:
-        with caplog.at_level(
-            logging.WARNING, logger="app.modules.catalog.maps.style_json"
-        ):
-            style = build_maplibre_style(_map(), [layer])
-    finally:
-        target_logger.disabled = was_disabled
+    with caplog.at_level(logging.WARNING, logger="app.modules.catalog.maps.style_json"):
+        style = build_maplibre_style(_map(), [layer])
     source = style["sources"][f"geolens-{dataset_id}"]
     assert source["type"] == "raster"
     assert "lineMetrics" not in source
@@ -959,16 +948,8 @@ def test_build_maplibre_style_warns_on_builder_line_gradient_intent_with_unsuppo
         label_config=None,
         filter=None,
     )
-    target_logger = logging.getLogger("app.modules.catalog.maps.style_json")
-    was_disabled = target_logger.disabled
-    target_logger.disabled = False
-    try:
-        with caplog.at_level(
-            logging.WARNING, logger="app.modules.catalog.maps.style_json"
-        ):
-            style = build_maplibre_style(_map(), [layer])
-    finally:
-        target_logger.disabled = was_disabled
+    with caplog.at_level(logging.WARNING, logger="app.modules.catalog.maps.style_json"):
+        style = build_maplibre_style(_map(), [layer])
     source = style["sources"][f"geolens-{dataset_id}"]
     assert source["type"] == "raster"
     assert "lineMetrics" not in source


### PR DESCRIPTION
Two of the remaining items from the #1755 audit list.

## Item 8: migrations disabled every logger already registered

`backend/alembic/env.py` called `fileConfig()` with no `disable_existing_loggers`
argument, so it inherited the stdlib default of True. That sets `.disabled` on
every logger object that existed at the time and is not named in alembic.ini's
`[loggers]` section, and nothing puts it back. `setup_logging()` never touches
that flag, so neither `tests/_logging_state.configured_logging()` nor conftest's
logging guard snapshots it.

In the test suite the session migration fixture runs after collection has already
imported the modules under test, so httpx, httpcore and application module loggers
stayed disabled for the whole session. Three sites had grown a local re-enable
dance around that, and all three are removed here:

- the autouse `_restore_httpx_logger_disabled_flag` fixture in
  `test_1746_stdlib_log_redaction.py`
- both copies of the `target_logger.disabled = False` try/finally in
  `test_maps_style_json.py`

Counterfactual actually run: with the one-line fix reverted and those workarounds
gone, `test_1746_stdlib_log_redaction.py` and `test_maps_style_json.py` report
9 failed, 183 passed. With the fix, 0 failed.

The new `test_1755_alembic_logger_flag.py` has two tests. One reads env.py's AST
and requires the keyword to be the literal False. The other asserts the flag after
the real migration ran, and skips rather than passing vacuously when it did not:
it checks that alembic.ini's logging was applied at all by looking at the alembic
logger's level, and it imports httpx at module scope so the logger exists before
the session fixture runs. Both fail on main.

## Item 11: a cleanup failure replaced the ingest exception

Each ingest task ends in a `finally:` block that stops its heartbeat, drops its
attempt staging table, unlinks scratch files and reaps staging objects. Every call
was awaited bare. A failing cleanup step therefore replaced whatever the
`try`/`except` above was propagating, and skipped every remaining step in the same
block.

`cleanup_step` in `tasks_common.py` is the one helper all seven task modules now
route those steps through. Design notes:

- An async context manager rather than a callable taking a coroutine. One
  `async with` covers a step's guard expression and its call, which the coroutine
  form cannot, and every call site is shorter.
- Wrapped per step, not per `finally`, so a failing step cannot skip its
  successors.
- `except Exception`, not `BaseException`. The cleanup runs during worker shutdown
  too, and swallowing that `CancelledError` would strand the shutdown.
- Logged with `redact_exception_text`, since an ingest exception can carry a
  credentialed URL, under a fixed structlog event `ingest_cleanup_step_failed`
  with the step name and job id as fields. The two already-routed sites logged
  under an f-string event name; a fixed key is greppable.

It replaces two private copies of `_finally_cleanup` that had grown in
`tasks_vector.py` and `tasks_reupload.py`, whose bodies differed only in the task
name in their docstrings.

All 11 `finally:` blocks in the seven modules are covered, 36 steps in total:

| module | function | steps |
| --- | --- | --- |
| tasks_postgis_refresh.py | refresh_postgis | heartbeat |
| tasks_stac_refresh.py | refresh_stac | heartbeat |
| tasks_raster.py | ingest_raster | heartbeat, orphaned storage keys, temp dir, local file, presigned staging object, downloaded source |
| tasks_raster_replace.py | reupload_raster | heartbeat, orphaned storage keys, temp dir, local file, presigned staging object, downloaded source |
| tasks_vrt.py | ingest_vrt | heartbeat, temp dir, orphaned storage keys |
| tasks_vrt.py | regenerate_vrt | generation heartbeat, heartbeat, temp dir, orphaned storage keys |
| tasks_reupload.py | reupload_file | heartbeat, staging table, local file, downloaded source, presigned staging object |
| tasks_reupload.py | reupload_service | heartbeat, staging table (converted from the private copy) |
| tasks_vector.py | ingest_file | heartbeat, staging table, local file, downloaded source, presigned staging object |
| tasks_vector.py | ingest_service (nested) | progress heartbeat |
| tasks_vector.py | ingest_service | heartbeat, staging table (converted from the private copy) |

The nested block in `ingest_service` is one the `stop_ingest_job_heartbeat` grep
does not name. It cancels the service-import progress heartbeat and awaits it
under `suppress(asyncio.CancelledError)`, which lets through anything the heartbeat
body itself failed with, so it is the same class.

One site is deliberately left alone. `ingest_file`'s fan-out lookup inside its
`finally` keeps its own `except Exception`, because it has to assign a fail-safe
default (`is_fan_out_child = True`) that the helper cannot supply.

## Already landed, so not in scope

Verified with one grep each, so #1755 can be trimmed: items 4
(`service_token_required` in the error map, `SourceRefreshAction.tsx`), 5
(`autoComplete="new-password"` on the settings secret fields), 6 (the
`unauthorized` detail copy), 7 (`origin_probe` docstring), 9 (preview classifies
typed refusals, `sources/router.py`), 10 (`DeferFailed(cause=...)`), 14
(`enrich_arcgis_feature_counts` on the shared builder), 15 (`router_refresh`
docstring). Items 1, 2, 3, 12 and 13 are product or design decisions and are left
alone.

Item 11 was also partly landed: `reupload_service` and `ingest_service` already
routed their two calls each, which is why this PR consolidates rather than
introduces.

## Schema, API, config impact

None. No migration, no request or response schema change, no new setting.

## Verification

Run from the worktree against Postgres at localhost:5434.

```
uv run pytest tests/test_1755_alembic_logger_flag.py tests/test_1755_cleanup_step.py -q
  7 passed

uv run pytest tests/test_1746_stdlib_log_redaction.py tests/test_maps_style_json.py -q
  192 passed

uv run pytest tests/test_layering.py -q
  50 passed

uv run pytest tests/test_rule1_structural.py tests/test_rule2_structural.py \
  tests/test_failed_job_token_purge_1746.py -q
  120 passed

uv run pytest tests/ -q -k "ingest or vrt or raster or reupload or refresh or vector or staging or heartbeat"
  2464 passed, 5 skipped, 10223 deselected

uv run pytest tests/ -q -k "log or redact or warn or metric or audit or observab"
  1107 passed, 3 skipped, 11582 deselected

uv run ruff check . && uv run ruff format --check .
  All checks passed, 1169 files already formatted
```

Counterfactuals actually run, not inferred:

- Item 8, described above: 9 failures with the fix reverted.
- Item 11: with `raise` added back to `cleanup_step`'s handler,
  `tests/test_1755_cleanup_step.py` reports 3 failed, 2 passed.

## Caps

Every `_MODULE_LOC_CAPS` entry touched was re-measured with `wc -l` and set to the
exact figure, each with a comment saying what the lines bought.

| module | cap |
| --- | --- |
| tasks_common.py | 2551 to 2581 |
| tasks_postgis_refresh.py | 1128 to 1130 |
| tasks_vrt.py | 1628 to 1640 |
| tasks_reupload.py | 1333 to 1310 |
| tasks_vector.py | 1392 to 1368 |

`tasks_raster.py` (919), `tasks_raster_replace.py` (958) and
`tasks_stac_refresh.py` (801) are still under the 1000-line inclusion threshold,
so none of them enters the dict.

Refs #1755
