### PR TITLE
fix(ingest): reserve a manifest entry before downloading its source (#1814)

### DIFF
--- a/backend/app/platform/jobs/defer_guard.py
+++ b/backend/app/platform/jobs/defer_guard.py
@@ -188,16 +188,8 @@ def _restore_settlement_identifiers(
 async def reset_session_for_settlement(job: IngestJob, *, db: AsyncSession) -> None:
     """Make a session usable again for the settlement that follows a failure.
 
-    A statement that failed leaves the ``AsyncSession`` in a failed
-    transaction, and SQLAlchemy refuses every further statement on it until it
-    is rolled back, so a settlement issued straight onto it raises there too
-    and the row stays ``pending``. The reset expires ``job``, so the two
-    attributes the shared settlement reads are snapshotted first and put back
-    after; the reload is best effort, for whatever a caller reads beyond them.
-
-    Call this before ``settle_ingest_job_failed`` on any path whose failure may
-    have been a database error (fix(#1774), fix(#1814)). Safe on a healthy
-    session: after the row is committed there is nothing left to discard.
+    fix(#1774, #1814): call before ``settle_ingest_job_failed`` on any database
+    error. The rollback expires ``job``, so its identifiers are snapshotted.
     """
     # Guarded because reading them is itself an attribute access: an instance
     # that arrived expired has nothing to snapshot, and the reload below is
@@ -226,10 +218,8 @@ async def _settle_after_failed_dispatch(
 ) -> bool:
     """Run the caller's rollback closure and commit it. Returns whether it landed.
 
-    fix(#1774 review, codex P2): extracted so the two ways a dispatch can fail
-    (the marker write, then the defer itself) settle the row identically. A
-    second copy of this block is how one of them would end up not committing,
-    or not logging, or reporting a `rolled_back` the other does not.
+    fix(#1774): one copy, so the two ways a dispatch can fail settle the row
+    identically rather than diverging on committing, logging or `rolled_back`.
     """
     try:
         await rollback(exc)
@@ -303,10 +293,9 @@ async def defer_with_orphan_guard(
     try:
         await stamp_commit_attempted(job, db=db)
     except Exception as stamp_exc:  # broad: a failed marker write is a failed dispatch
-        # fix(#1774 review, codex P2): a marker write that deadlocked leaves the
-        # row `pending` with no marker, the one combination the stale sweep
-        # reads as an upload nobody committed. Nothing is discarded by the
-        # reset: every caller commits the row before dispatching.
+        # fix(#1774): a deadlocked marker write leaves the row `pending` and
+        # unstamped, which the sweep reads as an upload nobody committed. The
+        # reset discards nothing: every caller commits before dispatching.
         await reset_session_for_settlement(job, db=db)
         rolled_back = await _settle_after_failed_dispatch(rollback, stamp_exc, db)
         raise DeferFailed(rolled_back=rolled_back, cause=stamp_exc) from stamp_exc

--- a/backend/app/platform/jobs/defer_guard.py
+++ b/backend/app/platform/jobs/defer_guard.py
@@ -185,6 +185,42 @@ def _restore_settlement_identifiers(
         set_committed_value(job, key, value)
 
 
+async def reset_session_for_settlement(job: IngestJob, *, db: AsyncSession) -> None:
+    """Make a session usable again for the settlement that follows a failure.
+
+    A statement that failed leaves the ``AsyncSession`` in a failed
+    transaction, and SQLAlchemy refuses every further statement on it until it
+    is rolled back, so a settlement issued straight onto it raises there too
+    and the row stays ``pending``. The reset expires ``job``, so the two
+    attributes the shared settlement reads are snapshotted first and put back
+    after; the reload is best effort, for whatever a caller reads beyond them.
+
+    Call this before ``settle_ingest_job_failed`` on any path whose failure may
+    have been a database error (fix(#1774), fix(#1814)). Safe on a healthy
+    session: after the row is committed there is nothing left to discard.
+    """
+    # Guarded because reading them is itself an attribute access: an instance
+    # that arrived expired has nothing to snapshot, and the reload below is
+    # then the only route back.
+    try:
+        identifiers: dict[str, Any] | None = {
+            "id": job.id,
+            "attempt_id": job.attempt_id,
+        }
+    except Exception:  # broad: an already-expired instance has nothing to snapshot
+        identifiers = None
+
+    try:
+        await db.rollback()
+    except Exception:  # broad: a dead connection cannot be reset here
+        logger.exception("Could not reset the session before settling a job")
+    _restore_settlement_identifiers(job, identifiers)
+    try:
+        await db.refresh(job)
+    except Exception:  # broad: best effort; the snapshot above is the guarantee
+        logger.exception("Could not reload the job before settling it")
+
+
 async def _settle_after_failed_dispatch(
     rollback: RollbackCallable, exc: BaseException, db: AsyncSession
 ) -> bool:
@@ -264,57 +300,14 @@ async def defer_with_orphan_guard(
         DeferFailed: always, when ``defer_call`` raises. Existing callers that
             catch ``HTTPException`` are unaffected; the 503 body is unchanged.
     """
-    # fix(#1774 review r2, codex P2): snapshotted BEFORE the write that can
-    # fail. A value in a local cannot be expired by the reset below, and these
-    # two are what the shared settlement reads. See
-    # `_restore_settlement_identifiers`. Guarded because reading them is itself
-    # an attribute access: an instance that arrived expired has nothing to
-    # snapshot, and the reload below is then the only route back.
-    try:
-        identifiers: dict[str, Any] | None = {
-            "id": job.id,
-            "attempt_id": job.attempt_id,
-        }
-    except Exception:  # broad: an already-expired instance has nothing to snapshot
-        identifiers = None
-
     try:
         await stamp_commit_attempted(job, db=db)
     except Exception as stamp_exc:  # broad: a failed marker write is a failed dispatch
-        # fix(#1774 review, codex P2): reset the session BEFORE settling.
-        # A serialization failure or deadlock on the marker write leaves this
-        # AsyncSession in a failed transaction, and SQLAlchemy refuses every
-        # further statement on it until it is rolled back. Handing it straight
-        # to `settle_ingest_job_failed` would raise there too, and the job
-        # would stay `pending` with no marker, which is the one combination
-        # the stale sweep reads as an upload nobody committed. It would cancel
-        # a dispatch that was genuinely attempted and take away the retry this
-        # whole guard exists to preserve.
-        #
-        # Nothing is discarded by the reset: every caller commits the row
-        # before dispatching, so at this point the session holds only the
-        # marker write that just failed.
-        try:
-            await db.rollback()
-        except Exception:  # broad: a dead connection cannot be reset here
-            logger.exception(
-                "Orphan-guard could not reset the session after a failed "
-                "dispatch marker write"
-            )
-        # fix(#1774 review r2, codex P2): the reset expires every instance it
-        # touched, so put the settlement's identifiers back before invoking a
-        # closure that reads them. The snapshot is the guarantee, because it
-        # needs no connection; the reload covers whatever a caller-supplied
-        # closure reads beyond those two, and is best-effort for the same
-        # reason the rollback above is.
-        _restore_settlement_identifiers(job, identifiers)
-        try:
-            await db.refresh(job)
-        except Exception:  # broad: best effort; the snapshot above is the guarantee
-            logger.exception(
-                "Orphan-guard could not reload the job after a failed "
-                "dispatch marker write"
-            )
+        # fix(#1774 review, codex P2): a marker write that deadlocked leaves the
+        # row `pending` with no marker, the one combination the stale sweep
+        # reads as an upload nobody committed. Nothing is discarded by the
+        # reset: every caller commits the row before dispatching.
+        await reset_session_for_settlement(job, db=db)
         rolled_back = await _settle_after_failed_dispatch(rollback, stamp_exc, db)
         raise DeferFailed(rolled_back=rolled_back, cause=stamp_exc) from stamp_exc
 

--- a/backend/app/platform/jobs/router.py
+++ b/backend/app/platform/jobs/router.py
@@ -512,6 +512,15 @@ async def _retry_capability(job: IngestJob) -> tuple[bool, str | None]:
             False,
             "Embedding backfill runs cannot be replayed as imports. Start the backfill again from Settings.",
         )
+    if (job.user_metadata or {}).get("manifest_key"):
+        # fix(#1814): generic retry runs its own failed -> pending CAS without
+        # the manifest key's advisory lock, so it can queue a second job for a
+        # key a concurrent re-apply is claiming. Re-apply owns manifest retries.
+        return (
+            False,
+            "Manifest imports cannot be replayed here. Apply the manifest "
+            "again, which is what serializes work on its own keys.",
+        )
     if job.source_url and not job.file_path:
         return True, None
     if not job.file_path:

--- a/backend/app/processing/ingest/manifest_reservation.py
+++ b/backend/app/processing/ingest/manifest_reservation.py
@@ -1,0 +1,151 @@
+"""What one manifest key currently holds, and the reservation that claims it.
+
+fix(#1814): the apply loop used to insert its ``IngestJob`` row only after the
+entry's source had been downloaded, so the check that answers "is this key
+busy" and the row that makes the answer true were separated by a network
+fetch. Everything that has to agree on that question lives in this module: the
+key lock, the in-flight read, the staleness rule, and the two fenced exits from
+the downloading stage.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from sqlalchemy import desc, select, text, update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.platform.jobs.models import IngestJob
+from app.platform.jobs.sweep import (
+    stale_pending_clauses,
+    stale_pending_unbound_values,
+)
+
+# `user_metadata` key naming the pre-queue stage a manifest job is in. Present
+# only while the row is a reservation; `bind_reservation_to_staged_source`
+# removes it, so a queued manifest job carries the same metadata shape it
+# always did.
+MANIFEST_STAGE_METADATA_KEY = "manifest_stage"
+MANIFEST_STAGE_DOWNLOADING = "downloading"
+
+# Reported on a reservation whose apply never came back to stage its source.
+# Only reached when the row was stamped as dispatch-attempted, which a
+# reservation never is; the shared settlement below picks the abandoned wording
+# for every real one. It is passed anyway so the two branches cannot disagree
+# about which message belongs to which state.
+STALE_RESERVATION_MESSAGE = "Stale: manifest source was never staged"
+
+# Returned to the caller whose reservation was settled by someone else while
+# its download ran. Names no id: the row this attempt owned is terminal, and
+# the row that replaced it belongs to a different request.
+RESERVATION_LOST_MESSAGE = (
+    "Manifest dataset apply lost its reservation while the source was being "
+    "staged; re-apply the manifest."
+)
+
+
+def downloading_stage_marker() -> dict[str, str]:
+    """The metadata a reservation carries between its insert and its staging."""
+    return {MANIFEST_STAGE_METADATA_KEY: MANIFEST_STAGE_DOWNLOADING}
+
+
+async def lock_manifest_key(db: AsyncSession, key: str) -> None:
+    """Serialize check-and-reserve for one manifest key.
+
+    fix(#1814): a transaction-scoped lock, so it is released by the commit that
+    makes the reservation visible and by the rollback the apply loop runs on a
+    rejected entry. The caller must end its transaction before any network I/O
+    and before moving on to the next entry: two manifests listing the same two
+    keys in opposite order would otherwise deadlock on each other.
+
+    Blocking rather than ``try``: the section it guards is bounded by database
+    work alone, and a waiter that gave up would have to answer the same
+    question with a weaker read.
+    """
+    await db.execute(
+        text("SELECT pg_advisory_xact_lock(hashtextextended(:lock_key, 0))"),
+        {"lock_key": f"manifest_apply:{key}"},
+    )
+
+
+async def latest_in_flight_manifest_job(db: AsyncSession, key: str) -> IngestJob | None:
+    """The newest queued, running, or reserved job for ``key``, if any."""
+    result = await db.execute(
+        select(IngestJob)
+        .where(
+            IngestJob.status.in_(["pending", "running"]),
+            IngestJob.user_metadata["manifest_key"].astext == key,
+        )
+        .order_by(desc(IngestJob.created_at))
+        .limit(1)
+    )
+    return result.scalar_one_or_none()
+
+
+async def expire_stale_manifest_reservations(
+    db: AsyncSession, key: str, *, now: datetime | None = None
+) -> int:
+    """Settle reservations for ``key`` whose apply never came back. Returns the count.
+
+    fix(#1814): an API process that dies between the reservation commit and the
+    staging bind leaves a `pending` row that would block the key until the
+    background sweep reached it. This is the same rule, narrowed to one key and
+    run under that key's lock, so the sweep and the in-flight check cannot
+    disagree about which rows are still live: the predicates and the written
+    columns both come from ``jobs/sweep.py`` rather than being restated here.
+
+    Settling rather than ignoring is what makes
+    ``bind_reservation_to_staged_source``'s fence sufficient. A merely slow
+    attempt whose reservation is expired here finds its row no longer pending
+    and drops its download instead of queueing on top of the reservation that
+    replaced it.
+    """
+    now = now or datetime.now(timezone.utc)
+    result = await db.execute(
+        update(IngestJob)
+        .where(
+            *stale_pending_clauses(now, completion_bound=False),
+            IngestJob.user_metadata["manifest_key"].astext == key,
+            IngestJob.user_metadata[MANIFEST_STAGE_METADATA_KEY].astext
+            == MANIFEST_STAGE_DOWNLOADING,
+        )
+        .values(**stale_pending_unbound_values(now, message=STALE_RESERVATION_MESSAGE))
+    )
+    return result.rowcount or 0
+
+
+async def bind_reservation_to_staged_source(
+    db: AsyncSession, job: IngestJob, *, file_path: str
+) -> bool:
+    """Fenced downloading -> staged transition. False means the row is not ours.
+
+    fix(#1814): the reservation must still be pending, under the attempt this
+    apply reserved, and still in the downloading stage. Anything else means a
+    cancel, a sweep, or a later apply's staleness settlement already owns the
+    row's terminal state, and this attempt's bytes belong to nobody.
+    """
+    metadata = {
+        name: value
+        for name, value in (job.user_metadata or {}).items()
+        if name != MANIFEST_STAGE_METADATA_KEY
+    }
+    result = await db.execute(
+        update(IngestJob)
+        .where(
+            IngestJob.id == job.id,
+            (
+                IngestJob.attempt_id == job.attempt_id
+                if job.attempt_id is not None
+                else IngestJob.attempt_id.is_(None)
+            ),
+            IngestJob.status == "pending",
+            IngestJob.user_metadata[MANIFEST_STAGE_METADATA_KEY].astext
+            == MANIFEST_STAGE_DOWNLOADING,
+        )
+        .values(file_path=file_path, user_metadata=metadata)
+    )
+    if not result.rowcount:
+        return False
+    job.file_path = file_path
+    job.user_metadata = metadata
+    return True

--- a/backend/app/processing/ingest/manifest_reservation.py
+++ b/backend/app/processing/ingest/manifest_reservation.py
@@ -1,43 +1,33 @@
-"""What one manifest key currently holds, and the reservation that claims it.
+"""Whether a manifest key is busy, and the reservation that claims it.
 
-fix(#1814): the apply loop used to insert its ``IngestJob`` row only after the
-entry's source had been downloaded, so the check that answers "is this key
-busy" and the row that makes the answer true were separated by a network
-fetch. Everything that has to agree on that question lives in this module: the
-key lock, the in-flight read, the staleness rule, and the two fenced exits from
-the downloading stage.
+fix(#1814): the key lock, the in-flight read, the staleness rule and the fenced
+exits from the downloading stage all answer that one question, so they agree by
+living together rather than by being kept in step.
 """
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
-from sqlalchemy import desc, select, text, update
+from sqlalchemy import desc, func, select, text, update
+from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm.attributes import set_committed_value
 
 from app.platform.jobs.models import IngestJob
-from app.platform.jobs.sweep import (
-    stale_pending_clauses,
-    stale_pending_unbound_values,
-)
+from app.platform.jobs.sweep import JOB_TIMEOUT_SECONDS
 
-# `user_metadata` key naming the pre-queue stage a manifest job is in. Present
-# only while the row is a reservation; `bind_reservation_to_staged_source`
-# removes it, so a queued manifest job carries the same metadata shape it
-# always did.
+# fix(#1814): present only while the row is a reservation. Every exit from the
+# stage clears it, so no queued or settled row still claims to be downloading.
 MANIFEST_STAGE_METADATA_KEY = "manifest_stage"
 MANIFEST_STAGE_DOWNLOADING = "downloading"
 
-# Reported on a reservation whose apply never came back to stage its source.
-# Only reached when the row was stamped as dispatch-attempted, which a
-# reservation never is; the shared settlement below picks the abandoned wording
-# for every real one. It is passed anyway so the two branches cannot disagree
-# about which message belongs to which state.
+# fix(#1814): what the running sweep would have written, when a later apply
+# reaches the row first.
 STALE_RESERVATION_MESSAGE = "Stale: manifest source was never staged"
 
-# Returned to the caller whose reservation was settled by someone else while
-# its download ran. Names no id: the row this attempt owned is terminal, and
-# the row that replaced it belongs to a different request.
+# fix(#1814): names no id. The row this attempt owned is terminal, and the row
+# that replaced it belongs to a different request.
 RESERVATION_LOST_MESSAGE = (
     "Manifest dataset apply lost its reservation while the source was being "
     "staged; re-apply the manifest."
@@ -52,15 +42,10 @@ def downloading_stage_marker() -> dict[str, str]:
 async def lock_manifest_key(db: AsyncSession, key: str) -> None:
     """Serialize check-and-reserve for one manifest key.
 
-    fix(#1814): a transaction-scoped lock, so it is released by the commit that
-    makes the reservation visible and by the rollback the apply loop runs on a
-    rejected entry. The caller must end its transaction before any network I/O
-    and before moving on to the next entry: two manifests listing the same two
-    keys in opposite order would otherwise deadlock on each other.
-
-    Blocking rather than ``try``: the section it guards is bounded by database
-    work alone, and a waiter that gave up would have to answer the same
-    question with a weaker read.
+    Transaction-scoped, and blocking: the section it guards is bounded by
+    database work alone. The caller must end its transaction before any network
+    I/O and before the next entry, or two manifests naming the same two keys in
+    opposite order deadlock on each other (fix(#1814)).
     """
     await db.execute(
         text("SELECT pg_advisory_xact_lock(hashtextextended(:lock_key, 0))"),
@@ -82,53 +67,80 @@ async def latest_in_flight_manifest_job(db: AsyncSession, key: str) -> IngestJob
     return result.scalar_one_or_none()
 
 
+def _reservation_lease_clauses(now: datetime, key: str) -> tuple:
+    """Every predicate that identifies an abandoned reservation for ``key``.
+
+    fix(#1814 audit): the running sweep's own predicate (`jobs/sweep.py`,
+    `status='running'` past ``coalesce(heartbeat_at, started_at)`` plus
+    ``JOB_TIMEOUT_SECONDS``), narrowed to one key's downloading stage, so the
+    sweep and the in-flight check cannot disagree about which rows are live.
+    """
+    return (
+        IngestJob.status == "running",
+        func.coalesce(IngestJob.heartbeat_at, IngestJob.started_at)
+        < now - timedelta(seconds=JOB_TIMEOUT_SECONDS),
+        IngestJob.user_metadata["manifest_key"].astext == key,
+        IngestJob.user_metadata[MANIFEST_STAGE_METADATA_KEY].astext
+        == MANIFEST_STAGE_DOWNLOADING,
+    )
+
+
+def _without_stage_marker():
+    """The row's metadata with the downloading marker removed, as SQL.
+
+    Written as a JSONB key removal rather than from the instance, because both
+    callers may hold an expired one (fix(#1814)).
+    """
+    return IngestJob.user_metadata.op("-", return_type=JSONB)(
+        MANIFEST_STAGE_METADATA_KEY
+    )
+
+
 async def expire_stale_manifest_reservations(
     db: AsyncSession, key: str, *, now: datetime | None = None
 ) -> int:
     """Settle reservations for ``key`` whose apply never came back. Returns the count.
 
-    fix(#1814): an API process that dies between the reservation commit and the
-    staging bind leaves a `pending` row that would block the key until the
-    background sweep reached it. This is the same rule, narrowed to one key and
-    run under that key's lock, so the sweep and the in-flight check cannot
-    disagree about which rows are still live: the predicates and the written
-    columns both come from ``jobs/sweep.py`` rather than being restated here.
-
-    Settling rather than ignoring is what makes
-    ``bind_reservation_to_staged_source``'s fence sufficient. A merely slow
-    attempt whose reservation is expired here finds its row no longer pending
-    and drops its download instead of queueing on top of the reservation that
-    replaced it.
+    fix(#1814): settling rather than ignoring is what lets
+    ``bind_reservation_to_staged_source``'s fence catch a slow attempt whose
+    reservation was replaced, instead of letting it queue on top.
     """
     now = now or datetime.now(timezone.utc)
     result = await db.execute(
         update(IngestJob)
-        .where(
-            *stale_pending_clauses(now, completion_bound=False),
-            IngestJob.user_metadata["manifest_key"].astext == key,
-            IngestJob.user_metadata[MANIFEST_STAGE_METADATA_KEY].astext
-            == MANIFEST_STAGE_DOWNLOADING,
+        .where(*_reservation_lease_clauses(now, key))
+        .values(
+            status="failed",
+            error_message=STALE_RESERVATION_MESSAGE,
+            completed_at=now,
+            user_metadata=_without_stage_marker(),
         )
-        .values(**stale_pending_unbound_values(now, message=STALE_RESERVATION_MESSAGE))
+        .execution_options(synchronize_session=False)
     )
     return result.rowcount or 0
 
 
 async def bind_reservation_to_staged_source(
-    db: AsyncSession, job: IngestJob, *, file_path: str
+    db: AsyncSession, job: IngestJob, *, file_path: str, now: datetime | None = None
 ) -> bool:
     """Fenced downloading -> staged transition. False means the row is not ours.
 
-    fix(#1814): the reservation must still be pending, under the attempt this
-    apply reserved, and still in the downloading stage. Anything else means a
-    cancel, a sweep, or a later apply's staleness settlement already owns the
-    row's terminal state, and this attempt's bytes belong to nobody.
+    fix(#1814 audit): running -> pending, stamping ``staged_at`` in the same
+    statement so the pending sweep measures from staging rather than from a
+    creation that predates the whole download. Anything but running, under this
+    attempt, still downloading, means a staleness settlement owns the row's
+    terminal state and this attempt's bytes belong to nobody.
     """
+    now = now or datetime.now(timezone.utc)
+    # Snapshotted before the statement: a values() clause carrying a SQL
+    # expression cannot be evaluated in Python, so the ORM would otherwise
+    # expire this attribute and the mirror below would lazy-load it.
     metadata = {
         name: value
         for name, value in (job.user_metadata or {}).items()
         if name != MANIFEST_STAGE_METADATA_KEY
     }
+    metadata["staged_at"] = now.isoformat()
     result = await db.execute(
         update(IngestJob)
         .where(
@@ -138,14 +150,68 @@ async def bind_reservation_to_staged_source(
                 if job.attempt_id is not None
                 else IngestJob.attempt_id.is_(None)
             ),
-            IngestJob.status == "pending",
+            IngestJob.status == "running",
             IngestJob.user_metadata[MANIFEST_STAGE_METADATA_KEY].astext
             == MANIFEST_STAGE_DOWNLOADING,
         )
-        .values(file_path=file_path, user_metadata=metadata)
+        .values(
+            status="pending",
+            file_path=file_path,
+            user_metadata=_without_stage_marker().op("||", return_type=JSONB)(
+                func.jsonb_build_object("staged_at", now.isoformat())
+            ),
+        )
+        .execution_options(synchronize_session=False)
     )
     if not result.rowcount:
         return False
-    job.file_path = file_path
-    job.user_metadata = metadata
+    # fix(#1814 audit): `set_committed_value`, not assignment. The instance has
+    # to describe the row, but a dirty attribute would have the caller's own
+    # commit flush a second, unfenced ORM update over the fenced one above.
+    set_committed_value(job, "status", "pending")
+    set_committed_value(job, "file_path", file_path)
+    set_committed_value(job, "user_metadata", metadata)
+    return True
+
+
+async def release_manifest_reservation(
+    db: AsyncSession, job: IngestJob, message: str, *, now: datetime | None = None
+) -> bool:
+    """Fenced running -> failed for a reservation that never staged its source.
+
+    fix(#1814 audit): the shared ``settle_ingest_job_failed`` fences on
+    ``pending``, which a reservation is not until it binds, so the lease has its
+    own exit. Fenced the same way, so a row a staleness settlement already owns
+    keeps that terminal state, and mirrored onto the instance only when the CAS
+    landed, so the object keeps describing the row. ``user_metadata`` is left
+    alone: reading it is a lazy load on a session that has just been reset, and
+    the marker is inert once the row is terminal.
+    """
+    now = now or datetime.now(timezone.utc)
+    result = await db.execute(
+        update(IngestJob)
+        .where(
+            IngestJob.id == job.id,
+            (
+                IngestJob.attempt_id == job.attempt_id
+                if job.attempt_id is not None
+                else IngestJob.attempt_id.is_(None)
+            ),
+            IngestJob.status == "running",
+            IngestJob.user_metadata[MANIFEST_STAGE_METADATA_KEY].astext
+            == MANIFEST_STAGE_DOWNLOADING,
+        )
+        .values(
+            status="failed",
+            error_message=message,
+            completed_at=now,
+            user_metadata=_without_stage_marker(),
+        )
+        .execution_options(synchronize_session=False)
+    )
+    if not result.rowcount:
+        return False
+    set_committed_value(job, "status", "failed")
+    set_committed_value(job, "error_message", message)
+    set_committed_value(job, "completed_at", now)
     return True

--- a/backend/app/processing/ingest/manifest_reservation.py
+++ b/backend/app/processing/ingest/manifest_reservation.py
@@ -7,6 +7,7 @@ living together rather than by being kept in step.
 
 from __future__ import annotations
 
+import uuid
 from datetime import datetime, timedelta, timezone
 
 from sqlalchemy import desc, func, select, text, update
@@ -17,8 +18,9 @@ from sqlalchemy.orm.attributes import set_committed_value
 from app.platform.jobs.models import IngestJob
 from app.platform.jobs.sweep import JOB_TIMEOUT_SECONDS
 
-# fix(#1814): present only while the row is a reservation. Every exit from the
-# stage clears it, so no queued or settled row still claims to be downloading.
+# fix(#1814): the pre-queue stage a manifest job is in. This module's exits
+# clear it; a row the running sweep or worker recovery settles keeps it, which
+# is inert because the in-flight read filters on status.
 MANIFEST_STAGE_METADATA_KEY = "manifest_stage"
 MANIFEST_STAGE_DOWNLOADING = "downloading"
 
@@ -70,7 +72,7 @@ async def latest_in_flight_manifest_job(db: AsyncSession, key: str) -> IngestJob
 def _reservation_lease_clauses(now: datetime, key: str) -> tuple:
     """Every predicate that identifies an abandoned reservation for ``key``.
 
-    fix(#1814 audit): the running sweep's own predicate (`jobs/sweep.py`,
+    fix(#1814): the running sweep's own predicate (`jobs/sweep.py`,
     `status='running'` past ``coalesce(heartbeat_at, started_at)`` plus
     ``JOB_TIMEOUT_SECONDS``), narrowed to one key's downloading stage, so the
     sweep and the in-flight check cannot disagree about which rows are live.
@@ -125,11 +127,9 @@ async def bind_reservation_to_staged_source(
 ) -> bool:
     """Fenced downloading -> staged transition. False means the row is not ours.
 
-    fix(#1814 audit): running -> pending, stamping ``staged_at`` in the same
-    statement so the pending sweep measures from staging rather than from a
-    creation that predates the whole download. Anything but running, under this
-    attempt, still downloading, means a staleness settlement owns the row's
-    terminal state and this attempt's bytes belong to nobody.
+    fix(#1814): ``staged_at`` is stamped in the same statement, so the pending
+    sweep measures from staging rather than from a creation that predates the
+    download. Anything but running under this attempt means another owner.
     """
     now = now or datetime.now(timezone.utc)
     # Snapshotted before the statement: a values() clause carrying a SQL
@@ -165,7 +165,7 @@ async def bind_reservation_to_staged_source(
     )
     if not result.rowcount:
         return False
-    # fix(#1814 audit): `set_committed_value`, not assignment. The instance has
+    # fix(#1814): `set_committed_value`, not assignment. The instance has
     # to describe the row, but a dirty attribute would have the caller's own
     # commit flush a second, unfenced ORM update over the fenced one above.
     set_committed_value(job, "status", "pending")
@@ -179,13 +179,10 @@ async def release_manifest_reservation(
 ) -> bool:
     """Fenced running -> failed for a reservation that never staged its source.
 
-    fix(#1814 audit): the shared ``settle_ingest_job_failed`` fences on
-    ``pending``, which a reservation is not until it binds, so the lease has its
-    own exit. Fenced the same way, so a row a staleness settlement already owns
-    keeps that terminal state, and mirrored onto the instance only when the CAS
-    landed, so the object keeps describing the row. ``user_metadata`` is left
-    alone: reading it is a lazy load on a session that has just been reset, and
-    the marker is inert once the row is terminal.
+    fix(#1814): the shared ``settle_ingest_job_failed`` fences on ``pending``,
+    which a reservation is not until it binds, so the lease has its own exit. The
+    trap: ``user_metadata`` is not mirrored, because reading it after the reset is
+    a lazy load.
     """
     now = now or datetime.now(timezone.utc)
     result = await db.execute(
@@ -215,3 +212,21 @@ async def release_manifest_reservation(
     set_committed_value(job, "error_message", message)
     set_committed_value(job, "completed_at", now)
     return True
+
+
+async def staged_source_is_referenced(
+    db: AsyncSession, job_id: uuid.UUID, *, file_path: str
+) -> bool:
+    """Does the committed row point at these staged bytes?
+
+    fix(#1814): a commit can be durable in PostgreSQL and still raise on the
+    acknowledgement, so the row decides. A read that fails answers True: orphaned
+    bytes are reclaimable, bytes a durable row points at are not.
+    """
+    try:
+        row = (
+            await db.execute(select(IngestJob.file_path).where(IngestJob.id == job_id))
+        ).one_or_none()
+    except Exception:  # broad: an unreadable row is the ambiguous case
+        return True
+    return row is not None and row.file_path == file_path

--- a/backend/app/processing/ingest/manifest_reservation.py
+++ b/backend/app/processing/ingest/manifest_reservation.py
@@ -44,10 +44,9 @@ def downloading_stage_marker() -> dict[str, str]:
 async def lock_manifest_key(db: AsyncSession, key: str) -> None:
     """Serialize check-and-reserve for one manifest key.
 
-    Transaction-scoped, and blocking: the section it guards is bounded by
+    fix(#1814): transaction-scoped and blocking, guarding a section bounded by
     database work alone. The caller must end its transaction before any network
-    I/O and before the next entry, or two manifests naming the same two keys in
-    opposite order deadlock on each other (fix(#1814)).
+    I/O and before the next entry, or two manifests deadlock on two keys.
     """
     await db.execute(
         text("SELECT pg_advisory_xact_lock(hashtextextended(:lock_key, 0))"),
@@ -72,10 +71,8 @@ async def latest_in_flight_manifest_job(db: AsyncSession, key: str) -> IngestJob
 def _reservation_lease_clauses(now: datetime, key: str) -> tuple:
     """Every predicate that identifies an abandoned reservation for ``key``.
 
-    fix(#1814): the running sweep's own predicate (`jobs/sweep.py`,
-    `status='running'` past ``coalesce(heartbeat_at, started_at)`` plus
-    ``JOB_TIMEOUT_SECONDS``), narrowed to one key's downloading stage, so the
-    sweep and the in-flight check cannot disagree about which rows are live.
+    fix(#1814): the running sweep's own predicate, narrowed to one key's
+    downloading stage, so the two cannot disagree about which rows are live.
     """
     return (
         IngestJob.status == "running",
@@ -179,10 +176,9 @@ async def release_manifest_reservation(
 ) -> bool:
     """Fenced running -> failed for a reservation that never staged its source.
 
-    fix(#1814): the shared ``settle_ingest_job_failed`` fences on ``pending``,
-    which a reservation is not until it binds, so the lease has its own exit. The
-    trap: ``user_metadata`` is not mirrored, because reading it after the reset is
-    a lazy load.
+    fix(#1814): the shared settlement fences on ``pending``, which a reservation
+    is not until it binds, so the lease has its own exit. The trap:
+    ``user_metadata`` is not mirrored, because reading it after a reset queries.
     """
     now = now or datetime.now(timezone.utc)
     result = await db.execute(

--- a/backend/app/processing/ingest/manifest_reservation.py
+++ b/backend/app/processing/ingest/manifest_reservation.py
@@ -1,8 +1,7 @@
 """Whether a manifest key is busy, and the reservation that claims it.
 
 fix(#1814): the key lock, the in-flight read, the staleness rule and the fenced
-exits from the downloading stage all answer that one question, so they agree by
-living together rather than by being kept in step.
+stage exits answer one question, so they live together rather than in step.
 """
 
 from __future__ import annotations
@@ -44,9 +43,8 @@ def downloading_stage_marker() -> dict[str, str]:
 async def lock_manifest_key(db: AsyncSession, key: str) -> None:
     """Serialize check-and-reserve for one manifest key.
 
-    fix(#1814): transaction-scoped and blocking, guarding a section bounded by
-    database work alone. The caller must end its transaction before any network
-    I/O and before the next entry, or two manifests deadlock on two keys.
+    fix(#1814): transaction-scoped and blocking. End the transaction before any
+    network I/O and before the next entry, or two manifests deadlock on two keys.
     """
     await db.execute(
         text("SELECT pg_advisory_xact_lock(hashtextextended(:lock_key, 0))"),
@@ -100,9 +98,8 @@ async def expire_stale_manifest_reservations(
 ) -> int:
     """Settle reservations for ``key`` whose apply never came back. Returns the count.
 
-    fix(#1814): settling rather than ignoring is what lets
-    ``bind_reservation_to_staged_source``'s fence catch a slow attempt whose
-    reservation was replaced, instead of letting it queue on top.
+    fix(#1814): settling rather than ignoring is what lets the staging bind's
+    fence catch a slow attempt whose reservation was replaced.
     """
     now = now or datetime.now(timezone.utc)
     result = await db.execute(
@@ -124,9 +121,8 @@ async def bind_reservation_to_staged_source(
 ) -> bool:
     """Fenced downloading -> staged transition. False means the row is not ours.
 
-    fix(#1814): ``staged_at`` is stamped in the same statement, so the pending
-    sweep measures from staging rather than from a creation that predates the
-    download. Anything but running under this attempt means another owner.
+    fix(#1814): ``staged_at`` is stamped here, so the pending sweep measures
+    from staging rather than from a creation that predates the download.
     """
     now = now or datetime.now(timezone.utc)
     # Snapshotted before the statement: a values() clause carrying a SQL
@@ -176,9 +172,8 @@ async def release_manifest_reservation(
 ) -> bool:
     """Fenced running -> failed for a reservation that never staged its source.
 
-    fix(#1814): the shared settlement fences on ``pending``, which a reservation
-    is not until it binds, so the lease has its own exit. The trap:
-    ``user_metadata`` is not mirrored, because reading it after a reset queries.
+    fix(#1814): the shared settlement fences on ``pending``, so the lease needs
+    its own exit. The trap: ``user_metadata`` is not mirrored, reading queries.
     """
     now = now or datetime.now(timezone.utc)
     result = await db.execute(
@@ -215,8 +210,7 @@ async def staged_source_is_referenced(
 ) -> bool:
     """Does the committed row point at these staged bytes?
 
-    fix(#1814): a durable but unacknowledged commit leaves live state, so the
-    row decides. Raises rather than guessing; the caller's settlement wrapper
+    fix(#1814): raises rather than guessing. The caller's settlement wrapper
     resets and retries, and keeps the bytes if neither attempt can read.
     """
     row = (

--- a/backend/app/processing/ingest/manifest_reservation.py
+++ b/backend/app/processing/ingest/manifest_reservation.py
@@ -215,14 +215,11 @@ async def staged_source_is_referenced(
 ) -> bool:
     """Does the committed row point at these staged bytes?
 
-    fix(#1814): a commit can be durable in PostgreSQL and still raise on the
-    acknowledgement, so the row decides. A read that fails answers True: orphaned
-    bytes are reclaimable, bytes a durable row points at are not.
+    fix(#1814): a durable but unacknowledged commit leaves live state, so the
+    row decides. Raises rather than guessing; the caller's settlement wrapper
+    resets and retries, and keeps the bytes if neither attempt can read.
     """
-    try:
-        row = (
-            await db.execute(select(IngestJob.file_path).where(IngestJob.id == job_id))
-        ).one_or_none()
-    except Exception:  # broad: an unreadable row is the ambiguous case
-        return True
+    row = (
+        await db.execute(select(IngestJob.file_path).where(IngestJob.id == job_id))
+    ).one_or_none()
     return row is not None and row.file_path == file_path

--- a/backend/app/processing/ingest/manifest_service.py
+++ b/backend/app/processing/ingest/manifest_service.py
@@ -13,7 +13,9 @@ from typing import cast
 import structlog
 from fastapi import HTTPException, Request
 from sqlalchemy import desc, select
+from sqlalchemy import inspect as sa_inspect
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm.attributes import set_committed_value
 from sqlalchemy.orm import joinedload
 
 from app.core.async_io import (
@@ -410,8 +412,11 @@ async def _preflight_quota(
 ) -> int | None:
     """Refuse an over-quota caller, and derive the streaming byte budget.
 
-    Runs before the reservation, so a refused entry leaves no row. The snapshot
-    also bounds streaming, so a caller at quota cannot force a whole download.
+    Runs before the reservation is inserted, so an entry that cannot be
+    admitted leaves no row behind. The same snapshot supplies a hard byte
+    budget for streaming, so a caller at or near quota cannot force the server
+    to download a whole object merely to discover that it cannot be admitted.
+    Returns None when the caller has no storage cap.
     """
     from app.modules.quota.service import get_user_quota_usage
 
@@ -732,7 +737,12 @@ async def _reserve_entry(
         await db.flush()
         await _commit_reservation(db)
     except BaseException as exc:
-        adopted = await _adopt_committed_reservation(db, job, exc)
+        # fix(#1814): a cancellation is not a failure to recover from. The
+        # durable row is reconciled either way, but staging must not run on
+        # through a shutdown, so only an ordinary exception continues.
+        adopted = await _adopt_committed_reservation(
+            db, job, exc, adopt=isinstance(exc, Exception)
+        )
         if adopted is None:
             raise
         job = adopted
@@ -746,12 +756,15 @@ async def _reserve_entry(
 
 
 async def _adopt_committed_reservation(
-    db: AsyncSession, job: IngestJob, exc: BaseException
+    db: AsyncSession, job: IngestJob, exc: BaseException, *, adopt: bool = True
 ) -> IngestJob | None:
-    """Adopt a reservation whose insert was durable but unacknowledged.
+    """Reconcile a reservation whose insert was durable but unacknowledged.
 
-    fix(#1814): the row decides, as at the staging bind. A landed insert is
-    adopted; anything else releases through the running fence first.
+    Returns the row when this request may go on using it, and None when the
+    caller must re-raise. Either way the key is not left held.
+
+    fix(#1814): the row decides, as at the staging bind. ``adopt`` is False
+    for a cancellation, which releases the landed row instead.
     """
     job_id = job.id
     adopted: IngestJob | None = None
@@ -762,7 +775,7 @@ async def _adopt_committed_reservation(
         adopted = row if row is not None and row.status == "running" else None
 
     await _settle_under_reset(db, job, _read_back, job_id=job_id)
-    if adopted is not None:
+    if adopted is not None and adopt:
         return adopted
     await _fail_reservation(db, job, exc)
     return None
@@ -798,8 +811,14 @@ async def _settle_under_reset(
     fix(#1814): any statement in a settlement can find the transaction unusable.
     The body is fenced, so one reset-and-retry lands nothing twice.
     """
+    # fix(#1814): pinned once, never re-read. A retry can rotate the token
+    # between the two attempts, and a reset reloads the new one, so the retry
+    # body would settle a fresh attempt for the previous attempt's error.
+    pinned_attempt = getattr(job, "attempt_id", None)
     for attempt in (1, 2):
         await reset_session_for_settlement(job, db=db)
+        if sa_inspect(job, raiseerr=False) is not None:
+            set_committed_value(job, "attempt_id", pinned_attempt)
         try:
             await body()
             await db.commit()

--- a/backend/app/processing/ingest/manifest_service.py
+++ b/backend/app/processing/ingest/manifest_service.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import uuid
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
@@ -760,13 +761,16 @@ async def _adopt_committed_reservation(
     releases through the running fence first.
     """
     job_id = job.id
-    await reset_session_for_settlement(job, db=db)
-    try:
-        landed = await db.get(IngestJob, job_id, populate_existing=True)
-    except Exception:  # broad: an unreadable row is the ambiguous case
-        landed = None
-    if landed is not None and landed.status == "running":
-        return landed
+    adopted: IngestJob | None = None
+
+    async def _read_back() -> None:
+        nonlocal adopted
+        row = await db.get(IngestJob, job_id, populate_existing=True)
+        adopted = row if row is not None and row.status == "running" else None
+
+    await _settle_under_reset(db, job, _read_back, job_id=job_id)
+    if adopted is not None:
+        return adopted
     await _fail_reservation(db, job, exc)
     return None
 
@@ -790,26 +794,44 @@ async def _commit_staged_bind(db: AsyncSession) -> None:
     await db.commit()
 
 
+async def _settle_under_reset(
+    db: AsyncSession,
+    job: IngestJob,
+    body: Callable[[], Awaitable[None]],
+    *,
+    job_id: uuid.UUID,
+) -> None:
+    """Run every statement of one settlement on a session that was just reset.
+
+    fix(#1814): a settlement follows a failure, so any statement in it can find
+    the transaction already unusable. The body is fenced reads and CAS writes, so
+    one reset-and-retry lands nothing twice; a second failure is the sweep's.
+    """
+    for attempt in (1, 2):
+        await reset_session_for_settlement(job, db=db)
+        try:
+            await body()
+            await db.commit()
+            return
+        except Exception:  # broad: any database error is a reset-and-retry
+            if attempt == 2:
+                log.exception("Could not settle a manifest job", job_id=str(job_id))
+                await db.rollback()
+
+
 async def _fail_reservation(
     db: AsyncSession, job: IngestJob, exc: BaseException
 ) -> None:
-    """Settle a reservation that never staged its source, freeing its key.
-
-    fix(#1814): the session is reset first, because a settlement issued onto
-    the failed transaction would raise there too and leave the key held.
-    """
-    # Read before the reset: the restore covers the identifiers, but a log line
-    # in the handler below must not be the thing that raises.
+    """Settle a reservation that never staged its source, freeing its key."""
+    # Read before the first reset: a log line must not be what raises.
     job_id = job.id
-    await reset_session_for_settlement(job, db=db)
-    try:
+
+    async def _release() -> None:
         await release_manifest_reservation(
             db, job, f"Failed to stage manifest source: {exc}"
         )
-        await db.commit()
-    except Exception:  # broad: a session this far gone is the sweep's problem
-        log.exception("Could not settle a manifest reservation", job_id=str(job_id))
-        await db.rollback()
+
+    await _settle_under_reset(db, job, _release, job_id=job_id)
 
 
 async def _settle_staged_entry(
@@ -825,24 +847,29 @@ async def _settle_staged_entry(
     fix(#1814): the row decides, not the exception, because a durable but
     unacknowledged bind leaves live catalog state. The two settlements fence on
     disjoint states, so at most one can match and the row picks it.
+
+    Read and settlement are one body, so the read cannot poison the writes.
     """
     job_id = job.id
-    await reset_session_for_settlement(job, db=db)
-    if not await staged_source_is_referenced(db, job_id, file_path=file_path):
-        # HTTP downloads are owned by this attempt. Raw operator seeds are not,
-        # and must never be deleted merely because admission was denied.
-        _cleanup_downloaded_source(prepared, file_path)
-    try:
+    # The safe default if neither attempt can read: keep the bytes, because
+    # orphaned ones are reclaimable and ones a durable row names are not.
+    referenced = True
+
+    async def _decide_and_settle() -> None:
+        nonlocal referenced
+        referenced = await staged_source_is_referenced(db, job_id, file_path=file_path)
         if not await release_manifest_reservation(
             db, job, f"Failed to stage manifest source: {exc}"
         ):
             await settle_ingest_job_failed(
                 job, exc, message_prefix="Failed to queue manifest job"
             )
-        await db.commit()
-    except Exception:  # broad: a session this far gone is the sweep's problem
-        log.exception("Could not settle a manifest job", job_id=str(job_id))
-        await db.rollback()
+
+    await _settle_under_reset(db, job, _decide_and_settle, job_id=job_id)
+    # Outside the retry: the filesystem is not part of the transaction, and an
+    # HTTP download is owned by this attempt while a raw operator seed is not.
+    if not referenced:
+        _cleanup_downloaded_source(prepared, file_path)
 
 
 async def _finalize_reserved_entry(

--- a/backend/app/processing/ingest/manifest_service.py
+++ b/backend/app/processing/ingest/manifest_service.py
@@ -733,8 +733,14 @@ async def _reserve_entry(
         user_metadata=metadata,
     )
     db.add(job)
-    await db.flush()
-    await db.commit()
+    try:
+        await db.flush()
+        await _commit_reservation(db)
+    except BaseException as exc:
+        adopted = await _adopt_committed_reservation(db, job, exc)
+        if adopted is None:
+            raise
+        job = adopted
     return _ReservedEntry(
         job=job,
         prepared=prepared,
@@ -742,6 +748,36 @@ async def _reserve_entry(
         max_size_bytes=max_size_bytes,
         quota_byte_limit=quota_byte_limit,
     )
+
+
+async def _adopt_committed_reservation(
+    db: AsyncSession, job: IngestJob, exc: BaseException
+) -> IngestJob | None:
+    """Adopt a reservation whose insert was durable but unacknowledged.
+
+    fix(#1814): the row decides, as at the staging bind. A landed insert is this
+    request's own reservation and holds the key, so it is adopted; anything else
+    releases through the running fence first.
+    """
+    job_id = job.id
+    await reset_session_for_settlement(job, db=db)
+    try:
+        landed = await db.get(IngestJob, job_id, populate_existing=True)
+    except Exception:  # broad: an unreadable row is the ambiguous case
+        landed = None
+    if landed is not None and landed.status == "running":
+        return landed
+    await _fail_reservation(db, job, exc)
+    return None
+
+
+async def _commit_reservation(db: AsyncSession) -> None:
+    """The commit that publishes the reservation, as a named seam.
+
+    fix(#1814): a test cannot ask a real session for the ambiguous shape,
+    durable in PostgreSQL and raising on the acknowledgement.
+    """
+    await db.commit()
 
 
 async def _commit_staged_bind(db: AsyncSession) -> None:
@@ -905,11 +941,9 @@ async def _reserve_or_settle_entry(
 ) -> ManifestApplyEntryResult | _ReservedEntry:
     """The locked half of one entry: classify, then either answer or reserve.
 
-    A result means the entry is answered from what the key already holds; a
-    reservation means the caller owns the key until it stages or settles that
-    row. fix(#1814): every exit ends the transaction, by committing even on the
-    answered paths, so the key lock is never held across the next entry's
-    download and the staleness settlement is not thrown away.
+    A result answers the entry from what the key already holds; a reservation
+    means the caller owns the key until it stages or settles that row.
+    fix(#1814): every exit commits, so no key lock outlives the entry.
     """
     (
         classification,

--- a/backend/app/processing/ingest/manifest_service.py
+++ b/backend/app/processing/ingest/manifest_service.py
@@ -42,6 +42,7 @@ from app.processing.ingest.manifest_reservation import (
     latest_in_flight_manifest_job,
     lock_manifest_key,
     release_manifest_reservation,
+    staged_source_is_referenced,
 )
 from app.processing.ingest.manifest_schemas import (
     ManifestApplyEntryResult,
@@ -65,10 +66,8 @@ from app.processing.ingest.service import queue_ingest_job, validate_file_extens
 # while amortizing the thread hop across ~64 chunks.
 _WRITE_BUFFER_BYTES = 4 * 1024 * 1024
 
-# fix(#1814 audit): total wall clock for staging one entry, derived from the
-# running lease the reservation is judged by so the two cannot drift. Half of
-# it, because a download that outlives its own lease is reaped mid-flight and
-# every retry repeats the loss.
+# fix(#1814): total wall clock for staging one entry. Derived from the lease the
+# reservation is judged by, so the budget and its judge cannot drift apart.
 MANIFEST_STAGE_MAX_SECONDS = JOB_TIMEOUT_SECONDS // 2
 
 log = structlog.get_logger()
@@ -318,10 +317,9 @@ async def _stage_source_if_needed(
 ) -> str | None:
     """Put one manifest source where ingest can read it, under a total deadline.
 
-    fix(#1814 audit): httpx's 60s clock is per read, so a source trickling
-    steadily has no wall-clock bound of its own. Staging that outlives the
-    reservation's lease is reaped mid-flight and every retry repeats the loss,
-    so the bound lives here, where it travels with the operation.
+    fix(#1814): httpx's 60s clock is per read, so a steadily trickling source
+    has no wall-clock bound of its own, and staging must finish inside the
+    lease the reservation is judged by.
     """
     try:
         async with asyncio.timeout(MANIFEST_STAGE_MAX_SECONDS):
@@ -603,7 +601,7 @@ async def _classify_dataset(
     # SSRF validation above is deliberately outside it.
     await lock_manifest_key(db, dataset.key)
     if not dry_run:
-        # fix(#1814 audit): a preview writes nothing, so it does not settle
+        # fix(#1814): a preview writes nothing, so it does not settle
         # another caller's abandoned reservation. The cost is that a dry run
         # can still report an entry as in flight where an apply would take it.
         await expire_stale_manifest_reservations(db, dataset.key)
@@ -699,10 +697,9 @@ async def _reserve_entry(
 ) -> _ReservedEntry:
     """Commit this key's claim, and everything staging needs, in one transaction.
 
-    fix(#1814): the row goes in before the source is fetched, so a client that
-    times out mid-download and retries sees `skip_in_flight` for its own job.
-    The commit publishes the claim and releases both the caller's key lock and
-    the pooled connection.
+    fix(#1814): the row goes in before the source is fetched, so a retry during
+    the download sees `skip_in_flight` for its own job. The commit publishes the
+    claim and releases the key lock and the connection.
     """
     creates_dataset = dataset_id is None
     quota_byte_limit = await _preflight_quota(
@@ -721,7 +718,7 @@ async def _reserve_entry(
         metadata["reupload"] = True
         metadata["dataset_id"] = str(dataset_id)
 
-    # fix(#1814 audit): `running`, not `pending`. A pending row with no
+    # fix(#1814): `running`, not `pending`. A pending row with no
     # file_path and no queue task is reapable by four actors while its source
     # is still downloading; the fixed lease is not.
     job = IngestJob(
@@ -747,15 +744,23 @@ async def _reserve_entry(
     )
 
 
+async def _commit_staged_bind(db: AsyncSession) -> None:
+    """The commit that publishes the staging bind, as a named seam.
+
+    fix(#1814): split out so a test can simulate the ambiguous shape, durable
+    in PostgreSQL and raising on the acknowledgement, which a real session
+    cannot be asked to produce. Production behaviour is exactly ``db.commit()``.
+    """
+    await db.commit()
+
+
 async def _fail_reservation(
     db: AsyncSession, job: IngestJob, exc: BaseException
 ) -> None:
     """Settle a reservation that never staged its source, freeing its key.
 
-    fix(#1814 codex r1): the session is reset first. The failure that brought
-    us here is often a database error, which leaves the transaction refusing
-    every further statement, so a settlement issued onto it would raise too and
-    leave the reservation holding its key until the lease expired.
+    fix(#1814): the session is reset first, because a settlement issued onto
+    the failed transaction would raise there too and leave the key held.
     """
     # Read before the reset: the restore covers the identifiers, but a log line
     # in the handler below must not be the thing that raises.
@@ -771,22 +776,33 @@ async def _fail_reservation(
         await db.rollback()
 
 
-async def _fail_queued_manifest_job(
-    db: AsyncSession, job: IngestJob, exc: BaseException
+async def _settle_staged_entry(
+    db: AsyncSession,
+    job: IngestJob,
+    exc: BaseException,
+    *,
+    prepared: ManifestPreparedSource,
+    file_path: str,
 ) -> None:
-    """Settle a bound row whose dispatch never reached the queue.
+    """Settle an entry that failed after its source was staged.
 
-    fix(#1814): past the staging bind the row is `pending` like every other
-    queued job, so this takes the shared settlement's own fence rather than the
-    lease's. The orphan guard has already settled it for a dispatch failure;
-    only a refusal raised before the guard ran lands here.
+    fix(#1814): the row decides, not the exception, because a durable but
+    unacknowledged bind leaves live catalog state. The two settlements fence on
+    disjoint states, so at most one can match and the row picks it.
     """
     job_id = job.id
     await reset_session_for_settlement(job, db=db)
+    if not await staged_source_is_referenced(db, job_id, file_path=file_path):
+        # HTTP downloads are owned by this attempt. Raw operator seeds are not,
+        # and must never be deleted merely because admission was denied.
+        _cleanup_downloaded_source(prepared, file_path)
     try:
-        await settle_ingest_job_failed(
-            job, exc, message_prefix="Failed to queue manifest job"
-        )
+        if not await release_manifest_reservation(
+            db, job, f"Failed to stage manifest source: {exc}"
+        ):
+            await settle_ingest_job_failed(
+                job, exc, message_prefix="Failed to queue manifest job"
+            )
         await db.commit()
     except Exception:  # broad: a session this far gone is the sweep's problem
         log.exception("Could not settle a manifest job", job_id=str(job_id))
@@ -831,17 +847,14 @@ async def _finalize_reserved_entry(
         admitted = True
         if not await bind_reservation_to_staged_source(db, job, file_path=file_path):
             raise ManifestSourceError(RESERVATION_LOST_MESSAGE)
-        await db.commit()
+        await _commit_staged_bind(db)
     except BaseException as exc:
         if admitted:
             quota.release(
                 incoming_bytes=staged.incoming_bytes,
                 creates_dataset=reserved.creates_dataset,
             )
-        # HTTP downloads are owned by this attempt. Raw operator seeds are not,
-        # and must never be deleted merely because admission was denied.
-        _cleanup_downloaded_source(prepared, file_path)
-        await _fail_reservation(db, job, exc)
+        await _settle_staged_entry(db, job, exc, prepared=prepared, file_path=file_path)
         raise
 
     try:
@@ -854,8 +867,7 @@ async def _finalize_reserved_entry(
             incoming_bytes=staged.incoming_bytes,
             creates_dataset=reserved.creates_dataset,
         )
-        _cleanup_downloaded_source(prepared, file_path)
-        await _fail_queued_manifest_job(db, job, exc)
+        await _settle_staged_entry(db, job, exc, prepared=prepared, file_path=file_path)
         raise
 
     if reserved.dataset_id is None:

--- a/backend/app/processing/ingest/manifest_service.py
+++ b/backend/app/processing/ingest/manifest_service.py
@@ -202,9 +202,8 @@ async def _download_http_source(
 ) -> str:
     """Stream one manifest source to staging. Takes no database session.
 
-    fix(#1814): a session parameter would check a pooled connection back out
-    and hold its transaction open for the length of the download, so the caller
-    reads the size ceiling before the reservation commit.
+    fix(#1814): a session here would hold a pooled connection for the length of
+    the download, so the caller reads the size ceiling before it commits.
     """
     staging_dir = Path(settings.upload_staging_dir)
     staging_dir.mkdir(parents=True, exist_ok=True)
@@ -318,9 +317,8 @@ async def _stage_source_if_needed(
 ) -> str | None:
     """Put one manifest source where ingest can read it, under a total deadline.
 
-    fix(#1814): httpx's 60s clock is per read, so a steadily trickling source
-    has no wall-clock bound of its own, and staging must finish inside the
-    lease the reservation is judged by.
+    fix(#1814): httpx's 60s clock is per read, so a trickling source has no
+    bound of its own, and staging must finish inside the reservation's lease.
     """
     try:
         async with asyncio.timeout(MANIFEST_STAGE_MAX_SECONDS):
@@ -412,11 +410,8 @@ async def _preflight_quota(
 ) -> int | None:
     """Refuse an over-quota caller, and derive the streaming byte budget.
 
-    Runs before the reservation is inserted, so an entry that cannot be
-    admitted leaves no row behind. The same snapshot supplies a hard byte
-    budget for streaming, so a caller at (or near) quota cannot force the
-    server to download a whole object merely to discover that it cannot be
-    admitted.
+    Runs before the reservation, so a refused entry leaves no row. The snapshot
+    also bounds streaming, so a caller at quota cannot force a whole download.
     """
     from app.modules.quota.service import get_user_quota_usage
 
@@ -698,9 +693,8 @@ async def _reserve_entry(
 ) -> _ReservedEntry:
     """Commit this key's claim, and everything staging needs, in one transaction.
 
-    fix(#1814): the row goes in before the source is fetched, so a retry during
-    the download sees `skip_in_flight` for its own job. The commit publishes the
-    claim and releases the key lock and the connection.
+    fix(#1814): the row goes in before the fetch, so a retry during the download
+    sees `skip_in_flight`. The commit releases the key lock and the connection.
     """
     creates_dataset = dataset_id is None
     quota_byte_limit = await _preflight_quota(
@@ -756,9 +750,8 @@ async def _adopt_committed_reservation(
 ) -> IngestJob | None:
     """Adopt a reservation whose insert was durable but unacknowledged.
 
-    fix(#1814): the row decides, as at the staging bind. A landed insert is this
-    request's own reservation and holds the key, so it is adopted; anything else
-    releases through the running fence first.
+    fix(#1814): the row decides, as at the staging bind. A landed insert is
+    adopted; anything else releases through the running fence first.
     """
     job_id = job.id
     adopted: IngestJob | None = None
@@ -787,9 +780,8 @@ async def _commit_reservation(db: AsyncSession) -> None:
 async def _commit_staged_bind(db: AsyncSession) -> None:
     """The commit that publishes the staging bind, as a named seam.
 
-    fix(#1814): split out so a test can simulate the ambiguous shape, durable
-    in PostgreSQL and raising on the acknowledgement, which a real session
-    cannot be asked to produce. Production behaviour is exactly ``db.commit()``.
+    fix(#1814): split out so a test can make it durable and then raising, which
+    a real session cannot be asked to do. Production is exactly ``db.commit()``.
     """
     await db.commit()
 
@@ -803,9 +795,8 @@ async def _settle_under_reset(
 ) -> None:
     """Run every statement of one settlement on a session that was just reset.
 
-    fix(#1814): a settlement follows a failure, so any statement in it can find
-    the transaction already unusable. The body is fenced reads and CAS writes, so
-    one reset-and-retry lands nothing twice; a second failure is the sweep's.
+    fix(#1814): any statement in a settlement can find the transaction unusable.
+    The body is fenced, so one reset-and-retry lands nothing twice.
     """
     for attempt in (1, 2):
         await reset_session_for_settlement(job, db=db)
@@ -844,11 +835,8 @@ async def _settle_staged_entry(
 ) -> None:
     """Settle an entry that failed after its source was staged.
 
-    fix(#1814): the row decides, not the exception, because a durable but
-    unacknowledged bind leaves live catalog state. The two settlements fence on
-    disjoint states, so at most one can match and the row picks it.
-
-    Read and settlement are one body, so the read cannot poison the writes.
+    fix(#1814): the row decides, not the exception. The two settlements fence on
+    disjoint states, and read and settlement share one body.
     """
     job_id = job.id
     # The safe default if neither attempt can read: keep the bytes, because
@@ -968,9 +956,8 @@ async def _reserve_or_settle_entry(
 ) -> ManifestApplyEntryResult | _ReservedEntry:
     """The locked half of one entry: classify, then either answer or reserve.
 
-    A result answers the entry from what the key already holds; a reservation
-    means the caller owns the key until it stages or settles that row.
-    fix(#1814): every exit commits, so no key lock outlives the entry.
+    A result answers from what the key holds; a reservation means the caller
+    owns it. fix(#1814): every exit commits, so no key lock outlives the entry.
     """
     (
         classification,
@@ -983,11 +970,9 @@ async def _reserve_or_settle_entry(
         raise ManifestSourceError("Manifest source could not be prepared")
 
     if classification == "skip_in_flight" and job is not None:
-        # fix(#430 codex r15): the skip paths previously returned job/dataset
-        # ids for a manifest key owned by ANOTHER user whenever the caller
-        # submitted a matching fingerprint — the same enumeration oracle
-        # BA-02 closed on the update path. Non-owners get the identical
-        # generic error the fingerprint-mismatch path raises, with no ids.
+        # fix(#430): a matching fingerprint must not turn the skip path into an
+        # enumeration oracle for another user's key. Non-owners get the generic
+        # fingerprint-mismatch error, with no ids.
         if not await _caller_owns_job(db, job, user):
             raise ManifestSourceError(
                 "Manifest dataset key already has an in-flight apply"
@@ -1020,12 +1005,9 @@ async def _reserve_or_settle_entry(
 
     update_dataset_id: uuid.UUID | None = None
     if classification == "update" and existing_dataset is not None:
-        # fix(#430 BA-02): manifest_key is globally namespaced and taken from the request
-        # body, so an editor could otherwise overwrite (or, via dry_run, enumerate
-        # the UUID of) another user's manifest-managed dataset. Gate before the
-        # dry-run response too — it otherwise leaks existing_dataset.id.
-        # Lazy import: processing/ must not import app.modules.catalog.* at module
-        # level (PROCESS-02/04 layering invariant).
+        # fix(#430): manifest_key is caller-supplied and globally namespaced, so
+        # the gate runs before the dry-run response too, which would otherwise
+        # leak another user's dataset id. Lazy import: PROCESS-02/04.
         from app.modules.catalog.authorization import check_dataset_write_access
 
         await check_dataset_write_access(

--- a/backend/app/processing/ingest/manifest_service.py
+++ b/backend/app/processing/ingest/manifest_service.py
@@ -25,9 +25,18 @@ from app.platform.extensions.entitlement import enforce_limit
 from app.platform.jobs.defer_guard import (
     defer_with_orphan_guard,
     make_ingest_job_failed_rollback,
+    settle_ingest_job_failed,
 )
 
 from app.platform.jobs.models import IngestJob
+from app.processing.ingest.manifest_reservation import (
+    RESERVATION_LOST_MESSAGE,
+    bind_reservation_to_staged_source,
+    downloading_stage_marker,
+    expire_stale_manifest_reservations,
+    latest_in_flight_manifest_job,
+    lock_manifest_key,
+)
 from app.processing.ingest.manifest_schemas import (
     ManifestApplyEntryResult,
     ManifestApplyRequest,
@@ -82,19 +91,25 @@ class _StagedManifestSource:
     incoming_bytes: int
 
 
-async def _latest_in_flight_manifest_job(
-    db: AsyncSession, key: str
-) -> IngestJob | None:
-    result = await db.execute(
-        select(IngestJob)
-        .where(
-            IngestJob.status.in_(["pending", "running"]),
-            IngestJob.user_metadata["manifest_key"].astext == key,
-        )
-        .order_by(desc(IngestJob.created_at))
-        .limit(1)
-    )
-    return result.scalar_one_or_none()
+@dataclass(frozen=True)
+class _ReservedEntry:
+    """A committed reservation plus everything staging it needs afterwards.
+
+    fix(#1814): carries plain values rather than ORM instances (beyond the job
+    row itself), because the session between the reservation commit and the
+    staging bind is free to be handed to another request.
+    """
+
+    job: IngestJob
+    prepared: ManifestPreparedSource
+    dataset_id: uuid.UUID | None
+    max_size_bytes: int
+    quota_byte_limit: int | None
+
+    @property
+    def creates_dataset(self) -> bool:
+        """An entry with no existing dataset to replace is creating one."""
+        return self.dataset_id is None
 
 
 async def _latest_completed_manifest_job(
@@ -162,13 +177,22 @@ async def _authorize_prepared_source(
         )
 
 
+async def _upload_max_size_bytes(db: AsyncSession) -> int:
+    return (await UPLOAD_MAX_SIZE_MB.get(db)) * 1024 * 1024
+
+
 async def _download_http_source(
-    db: AsyncSession,
     prepared: ManifestPreparedSource,
     *,
+    max_size_bytes: int,
     quota_byte_limit: int | None = None,
 ) -> str:
-    max_size_bytes = (await UPLOAD_MAX_SIZE_MB.get(db)) * 1024 * 1024
+    """Stream one manifest source to staging. Takes no database session.
+
+    fix(#1814): the size ceiling is read by the caller, before the reservation
+    commit. A session parameter here would check a pooled connection back out
+    and hold its transaction open for the length of the download.
+    """
     staging_dir = Path(settings.upload_staging_dir)
     staging_dir.mkdir(parents=True, exist_ok=True)
     destination = staging_dir / (
@@ -273,18 +297,18 @@ async def _download_http_source(
 
 
 async def _stage_source_if_needed(
-    db: AsyncSession,
     prepared: ManifestPreparedSource,
     *,
     dry_run: bool,
+    max_size_bytes: int,
     quota_byte_limit: int | None = None,
 ) -> str | None:
     if prepared.kind == "http":
         if dry_run:
             return None
         return await _download_http_source(
-            db,
             prepared,
+            max_size_bytes=max_size_bytes,
             quota_byte_limit=quota_byte_limit,
         )
     if prepared.kind == "local":
@@ -338,103 +362,102 @@ def _cleanup_downloaded_source(
         Path(file_path).unlink(missing_ok=True)
 
 
-async def _stage_source_and_check_quota(
+async def _preflight_quota(
     db: AsyncSession,
-    prepared: ManifestPreparedSource,
     user: Identity,
-    request: Request,
     *,
     creates_dataset: bool,
-    reservation: _ManifestQuotaReservation,
-) -> _StagedManifestSource:
-    """Preflight quota, then stage, size, and admit a manifest source."""
-    # Check the cheap aggregate before opening an untrusted remote response.
-    # The same snapshot supplies a hard byte budget for streaming, so a caller
-    # at (or near) quota cannot force the server to download a whole object
-    # merely to discover that it cannot be admitted.
+    quota: _ManifestQuotaReservation,
+) -> int | None:
+    """Refuse an over-quota caller, and derive the streaming byte budget.
+
+    Runs before the reservation is inserted, so an entry that cannot be
+    admitted leaves no row behind. The same snapshot supplies a hard byte
+    budget for streaming, so a caller at (or near) quota cannot force the
+    server to download a whole object merely to discover that it cannot be
+    admitted.
+    """
     from app.modules.quota.service import get_user_quota_usage
 
     usage = await get_user_quota_usage(db, user.id)
     if (
         creates_dataset
         and usage.count_cap > 0
-        and usage.dataset_count + reservation.datasets_admitted >= usage.count_cap
+        and usage.dataset_count + quota.datasets_admitted >= usage.count_cap
     ):
         raise HTTPException(
             status_code=422,
             detail=(
                 "Dataset quota exceeded: "
-                f"{usage.dataset_count + reservation.datasets_admitted} of "
+                f"{usage.dataset_count + quota.datasets_admitted} of "
                 f"{usage.count_cap} datasets used"
             ),
         )
 
-    quota_byte_limit = (
+    return (
         max(
-            usage.storage_cap - usage.bytes_used - reservation.bytes_admitted,
+            usage.storage_cap - usage.bytes_used - quota.bytes_admitted,
             0,
         )
         if usage.storage_cap > 0
         else None
     )
-    file_path = await _stage_source_if_needed(
-        db,
-        prepared,
-        dry_run=False,
-        quota_byte_limit=quota_byte_limit,
+
+
+async def _admit_staged_source(
+    db: AsyncSession,
+    prepared: ManifestPreparedSource,
+    user: Identity,
+    request: Request,
+    *,
+    file_path: str,
+    creates_dataset: bool,
+    quota: _ManifestQuotaReservation,
+) -> _StagedManifestSource:
+    """Size a staged manifest source and admit it against live quota."""
+    from app.modules.quota.service import get_user_quota_usage
+
+    incoming_bytes = await _manifest_source_size_bytes(prepared, file_path)
+    fresh_usage = await get_user_quota_usage(db, user.id)
+    projected_bytes = fresh_usage.bytes_used + quota.bytes_admitted + incoming_bytes
+    projected_count = (
+        fresh_usage.dataset_count
+        + quota.datasets_admitted
+        + (1 if creates_dataset else 0)
     )
-    if file_path is None:
-        raise ManifestSourceError("Manifest source could not be staged")
-
-    try:
-        incoming_bytes = await _manifest_source_size_bytes(prepared, file_path)
-        fresh_usage = await get_user_quota_usage(db, user.id)
-        projected_bytes = (
-            fresh_usage.bytes_used + reservation.bytes_admitted + incoming_bytes
+    if fresh_usage.storage_cap > 0 and projected_bytes > fresh_usage.storage_cap:
+        raise HTTPException(
+            status_code=413,
+            detail=(
+                f"Storage quota exceeded: used "
+                f"{fresh_usage.bytes_used + quota.bytes_admitted} of "
+                f"{fresh_usage.storage_cap} bytes (adding {incoming_bytes} bytes)"
+            ),
         )
-        projected_count = (
-            fresh_usage.dataset_count
-            + reservation.datasets_admitted
-            + (1 if creates_dataset else 0)
+    if (
+        creates_dataset
+        and fresh_usage.count_cap > 0
+        and projected_count > fresh_usage.count_cap
+    ):
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                f"Dataset quota exceeded: "
+                f"{fresh_usage.dataset_count + quota.datasets_admitted} of "
+                f"{fresh_usage.count_cap} datasets used"
+            ),
         )
-        if fresh_usage.storage_cap > 0 and projected_bytes > fresh_usage.storage_cap:
-            raise HTTPException(
-                status_code=413,
-                detail=(
-                    f"Storage quota exceeded: used "
-                    f"{fresh_usage.bytes_used + reservation.bytes_admitted} of "
-                    f"{fresh_usage.storage_cap} bytes (adding {incoming_bytes} bytes)"
-                ),
-            )
-        if (
-            creates_dataset
-            and fresh_usage.count_cap > 0
-            and projected_count > fresh_usage.count_cap
-        ):
-            raise HTTPException(
-                status_code=422,
-                detail=(
-                    f"Dataset quota exceeded: "
-                    f"{fresh_usage.dataset_count + reservation.datasets_admitted} of "
-                    f"{fresh_usage.count_cap} datasets used"
-                ),
-            )
 
-        # Lazy import preserves the processing -> modules layering boundary.
-        if creates_dataset:
-            from app.modules.quota.service import check_upload_quota
+    # Lazy import preserves the processing -> modules layering boundary.
+    if creates_dataset:
+        from app.modules.quota.service import check_upload_quota
 
-            await check_upload_quota(db, user.id, incoming_bytes, request)
-        await enforce_limit(request, "storage_bytes", projected_bytes)
-        if creates_dataset:
-            await enforce_limit(request, "dataset_count", projected_count)
-    except BaseException:
-        # HTTP downloads are owned by this attempt. Raw operator seeds are not,
-        # and must never be deleted merely because admission was denied.
-        _cleanup_downloaded_source(prepared, file_path)
-        raise
+        await check_upload_quota(db, user.id, incoming_bytes, request)
+    await enforce_limit(request, "storage_bytes", projected_bytes)
+    if creates_dataset:
+        await enforce_limit(request, "dataset_count", projected_count)
 
-    reservation.reserve(
+    quota.reserve(
         incoming_bytes=incoming_bytes,
         creates_dataset=creates_dataset,
     )
@@ -531,7 +554,13 @@ async def _classify_dataset(
     await _validate_prepared_source(db, prepared)
     await _authorize_prepared_source(db, prepared, user)
 
-    in_flight = await _latest_in_flight_manifest_job(db, dataset.key)
+    # fix(#1814): from here to the reservation commit is one locked critical
+    # section on this key, and nothing inside it may touch the network. The
+    # SSRF validation above is deliberately outside it.
+    await lock_manifest_key(db, dataset.key)
+    await expire_stale_manifest_reservations(db, dataset.key)
+
+    in_flight = await latest_in_flight_manifest_job(db, dataset.key)
     if in_flight is not None:
         in_flight_fingerprint = (in_flight.user_metadata or {}).get(
             "manifest_fingerprint"
@@ -610,97 +639,46 @@ def _validate_existing_dataset_update(
         )
 
 
-async def _create_job_and_queue(
+async def _reserve_entry(
     db: AsyncSession,
     dataset: ManifestDataset,
     prepared: ManifestPreparedSource,
     fingerprint: str,
     user: Identity,
-    request: Request,
-    reservation: _ManifestQuotaReservation,
-) -> ManifestApplyEntryResult:
-    staged = await _stage_source_and_check_quota(
+    *,
+    dataset_id: uuid.UUID | None,
+    quota: _ManifestQuotaReservation,
+) -> _ReservedEntry:
+    """Commit this key's claim, and everything staging needs, in one transaction.
+
+    fix(#1814): the row goes in BEFORE the source is fetched, carrying the
+    downloading stage marker, so a client that times out mid-download and
+    retries sees `skip_in_flight` for its own job instead of starting a second
+    download of the same entry. The caller holds this key's advisory lock; the
+    commit here is what publishes the claim and releases both the lock and the
+    pooled connection.
+    """
+    creates_dataset = dataset_id is None
+    quota_byte_limit = await _preflight_quota(
         db,
-        prepared,
         user,
-        request,
-        creates_dataset=True,
-        reservation=reservation,
+        creates_dataset=creates_dataset,
+        quota=quota,
     )
-    file_path = staged.file_path
-    job = IngestJob(
-        source_filename=prepared.source_filename,
-        file_path=file_path,
-        source_url=None,
-        source_layer=prepared.source_layer,
-        created_by=user.id,
-        status="pending",
-        user_metadata=manifest_job_metadata(
-            dataset,
-            prepared,
-            fingerprint=fingerprint,
-        ),
-    )
-    db.add(job)
-    try:
-        await db.flush()
-        await db.commit()
-    except BaseException:
-        # Until the job is durable, no worker/retry owns an HTTP staging file.
-        reservation.release(
-            incoming_bytes=staged.incoming_bytes,
-            creates_dataset=True,
-        )
-        _cleanup_downloaded_source(prepared, file_path)
-        raise
+    max_size_bytes = await _upload_max_size_bytes(db)
 
-    try:
-        await queue_ingest_job(job, str(user.id), db=db)
-    except BaseException:
-        reservation.release(
-            incoming_bytes=staged.incoming_bytes,
-            creates_dataset=True,
-        )
-        _cleanup_downloaded_source(prepared, file_path)
-        raise
-    return ManifestApplyEntryResult(
-        dataset_key=dataset.key,
-        action="create",
-        job_id=job.id,
-        message="Manifest dataset ingest queued.",
-    )
-
-
-async def _create_reupload_job_and_queue(
-    db: AsyncSession,
-    dataset: ManifestDataset,
-    prepared: ManifestPreparedSource,
-    fingerprint: str,
-    existing_dataset: object,
-    user: Identity,
-    request: Request,
-    reservation: _ManifestQuotaReservation,
-) -> ManifestApplyEntryResult:
-    _validate_existing_dataset_update(existing_dataset, prepared)
-    dataset_id = existing_dataset.id
-    staged = await _stage_source_and_check_quota(
-        db,
-        prepared,
-        user,
-        request,
-        creates_dataset=False,
-        reservation=reservation,
-    )
-    file_path = staged.file_path
-    metadata = {
+    metadata: dict[str, object] = {
         **manifest_job_metadata(dataset, prepared, fingerprint=fingerprint),
-        "reupload": True,
-        "dataset_id": str(dataset_id),
+        **downloading_stage_marker(),
     }
+    if dataset_id is not None:
+        metadata["reupload"] = True
+        metadata["dataset_id"] = str(dataset_id)
+
     job = IngestJob(
         dataset_id=dataset_id,
         source_filename=prepared.source_filename,
-        file_path=file_path,
+        file_path=None,
         source_url=None,
         source_layer=prepared.source_layer,
         created_by=user.id,
@@ -708,31 +686,116 @@ async def _create_reupload_job_and_queue(
         user_metadata=metadata,
     )
     db.add(job)
+    await db.flush()
+    await db.commit()
+    return _ReservedEntry(
+        job=job,
+        prepared=prepared,
+        dataset_id=dataset_id,
+        max_size_bytes=max_size_bytes,
+        quota_byte_limit=quota_byte_limit,
+    )
+
+
+async def _fail_reservation(
+    db: AsyncSession, job: IngestJob, exc: BaseException
+) -> None:
+    """Settle a reservation whose source never reached staging.
+
+    Best effort by construction: this runs while an entry is already failing,
+    and the shared settlement is fenced, so a row some other actor has already
+    settled is left exactly as that actor left it.
+    """
     try:
-        await db.flush()
-        await db.commit()
-    except BaseException:
-        reservation.release(
-            incoming_bytes=staged.incoming_bytes,
-            creates_dataset=False,
+        await settle_ingest_job_failed(
+            job, exc, message_prefix="Failed to stage manifest source"
         )
+        await db.commit()
+    except Exception:  # broad: the session may already be unusable
+        await db.rollback()
+
+
+async def _finalize_reserved_entry(
+    db: AsyncSession,
+    reserved: _ReservedEntry,
+    dataset: ManifestDataset,
+    user: Identity,
+    request: Request,
+    quota: _ManifestQuotaReservation,
+) -> ManifestApplyEntryResult:
+    """Stage the reserved entry's source, admit it, and queue the job."""
+    job = reserved.job
+    prepared = reserved.prepared
+    try:
+        file_path = await _stage_source_if_needed(
+            prepared,
+            dry_run=False,
+            max_size_bytes=reserved.max_size_bytes,
+            quota_byte_limit=reserved.quota_byte_limit,
+        )
+        if file_path is None:
+            raise ManifestSourceError("Manifest source could not be staged")
+    except BaseException as exc:
+        await _fail_reservation(db, job, exc)
+        raise
+
+    admitted = False
+    try:
+        staged = await _admit_staged_source(
+            db,
+            prepared,
+            user,
+            request,
+            file_path=file_path,
+            creates_dataset=reserved.creates_dataset,
+            quota=quota,
+        )
+        admitted = True
+        if not await bind_reservation_to_staged_source(db, job, file_path=file_path):
+            raise ManifestSourceError(RESERVATION_LOST_MESSAGE)
+        await db.commit()
+    except BaseException as exc:
+        if admitted:
+            quota.release(
+                incoming_bytes=staged.incoming_bytes,
+                creates_dataset=reserved.creates_dataset,
+            )
+        # HTTP downloads are owned by this attempt. Raw operator seeds are not,
+        # and must never be deleted merely because admission was denied.
         _cleanup_downloaded_source(prepared, file_path)
+        await _fail_reservation(db, job, exc)
         raise
 
     try:
-        await _queue_reupload_job(db, job, dataset_id, user, prepared)
-    except BaseException:
-        reservation.release(
+        if reserved.dataset_id is None:
+            await queue_ingest_job(job, str(user.id), db=db)
+        else:
+            await _queue_reupload_job(db, job, reserved.dataset_id, user, prepared)
+    except BaseException as exc:
+        quota.release(
             incoming_bytes=staged.incoming_bytes,
-            creates_dataset=False,
+            creates_dataset=reserved.creates_dataset,
         )
         _cleanup_downloaded_source(prepared, file_path)
+        # fix(#1814): an entry that did not reach the queue must not go on
+        # holding its key. The orphan guard has already settled the row for
+        # every dispatch failure, and the settlement is fenced on `pending`,
+        # so this only lands for a refusal raised before the guard ran.
+        await _fail_reservation(db, job, exc)
         raise
+
+    if reserved.dataset_id is None:
+        return ManifestApplyEntryResult(
+            dataset_key=dataset.key,
+            action="create",
+            job_id=job.id,
+            message="Manifest dataset ingest queued.",
+        )
     return ManifestApplyEntryResult(
         dataset_key=dataset.key,
         action="update",
         job_id=job.id,
-        dataset_id=dataset_id,
+        dataset_id=reserved.dataset_id,
         message="Manifest dataset reupload queued.",
     )
 
@@ -747,14 +810,29 @@ def _error_result(dataset: ManifestDataset, exc: Exception) -> ManifestApplyEntr
     )
 
 
-async def _run_entry(
+async def _reserve_or_settle_entry(
     db: AsyncSession,
     request: ManifestApplyRequest,
     user: Identity,
     dataset: ManifestDataset,
-    http_request: Request,
-    reservation: _ManifestQuotaReservation,
-) -> ManifestApplyEntryResult:
+    quota: _ManifestQuotaReservation,
+) -> ManifestApplyEntryResult | _ReservedEntry:
+    """The locked half of one entry: classify, then either answer or reserve.
+
+    fix(#1814): every exit from this function ends the transaction, because
+    `_classify_dataset` takes this key's advisory lock and a lock still held
+    when the next entry runs would sit across that entry's download, and could
+    deadlock two manifests that list the same two keys in opposite order.
+    Returning a result means the entry is answered from what the key already
+    holds; returning a reservation means the caller owns the key until it
+    stages or settles the row.
+
+    Ended by committing rather than rolling back, on the answered paths too:
+    `expire_stale_manifest_reservations` may have settled an abandoned
+    reservation for this key, a dry run has to report the same answer a real
+    apply would, and a rollback would expire every instance the caller still
+    holds.
+    """
     (
         classification,
         prepared,
@@ -775,7 +853,9 @@ async def _run_entry(
             raise ManifestSourceError(
                 "Manifest dataset key already has an in-flight apply"
             )
-        return _skip_result_for_in_flight(dataset, job)
+        result = _skip_result_for_in_flight(dataset, job)
+        await db.commit()
+        return result
 
     if classification == "skip_complete" and job is not None:
         if existing_dataset is not None:
@@ -789,14 +869,17 @@ async def _run_entry(
             await check_dataset_write_access(
                 db, existing_dataset, existing_dataset.id, user
             )
-        return ManifestApplyEntryResult(
+        result = ManifestApplyEntryResult(
             dataset_key=dataset.key,
             action="skip",
             job_id=job.id,
             dataset_id=job.dataset_id,
             message=_skip_complete_message(prepared),
         )
+        await db.commit()
+        return result
 
+    update_dataset_id: uuid.UUID | None = None
     if classification == "update" and existing_dataset is not None:
         # fix(#430 BA-02): manifest_key is globally namespaced and taken from the request
         # body, so an editor could otherwise overwrite (or, via dry_run, enumerate
@@ -812,46 +895,58 @@ async def _run_entry(
         # Run after authorization (to avoid leaking another user's dataset
         # type) but before dry-run reporting, staging, or queue creation.
         _validate_existing_dataset_update(existing_dataset, prepared)
+        update_dataset_id = existing_dataset.id
 
     if request.dry_run:
+        # fix(#1814): a preview reserves nothing, so the key is left exactly as
+        # this entry found it.
+        result = None
         if classification == "create":
-            return ManifestApplyEntryResult(
+            result = ManifestApplyEntryResult(
                 dataset_key=dataset.key,
                 action="create",
                 message="Manifest dataset would be created.",
             )
-        if classification == "update" and existing_dataset is not None:
-            return ManifestApplyEntryResult(
+        elif update_dataset_id is not None:
+            result = ManifestApplyEntryResult(
                 dataset_key=dataset.key,
                 action="update",
-                dataset_id=existing_dataset.id,
+                dataset_id=update_dataset_id,
                 message="Manifest dataset would be updated.",
             )
+        if result is not None:
+            await db.commit()
+            return result
 
-    if classification == "create":
-        return await _create_job_and_queue(
-            db,
-            dataset,
-            prepared,
-            fingerprint,
-            user,
-            http_request,
-            reservation,
-        )
+    reserves_update = classification == "update" and update_dataset_id is not None
+    if classification != "create" and not reserves_update:
+        raise ManifestSourceError("Manifest dataset could not be classified")
 
-    if classification == "update" and existing_dataset is not None:
-        return await _create_reupload_job_and_queue(
-            db,
-            dataset,
-            prepared,
-            fingerprint,
-            existing_dataset,
-            user,
-            http_request,
-            reservation,
-        )
+    return await _reserve_entry(
+        db,
+        dataset,
+        prepared,
+        fingerprint,
+        user,
+        dataset_id=update_dataset_id,
+        quota=quota,
+    )
 
-    raise ManifestSourceError("Manifest dataset could not be classified")
+
+async def _run_entry(
+    db: AsyncSession,
+    request: ManifestApplyRequest,
+    user: Identity,
+    dataset: ManifestDataset,
+    http_request: Request,
+    quota: _ManifestQuotaReservation,
+) -> ManifestApplyEntryResult:
+    outcome = await _reserve_or_settle_entry(db, request, user, dataset, quota)
+    if isinstance(outcome, ManifestApplyEntryResult):
+        return outcome
+    return await _finalize_reserved_entry(
+        db, outcome, dataset, user, http_request, quota
+    )
 
 
 async def apply_manifest(
@@ -866,7 +961,7 @@ async def apply_manifest(
     # synchronous lazy load (MissingGreenlet) while checking authorization.
     caller = cast(Identity, _ManifestCaller(id=user.id))
     results: list[ManifestApplyEntryResult] = []
-    reservation = _ManifestQuotaReservation()
+    quota = _ManifestQuotaReservation()
     for dataset in request.datasets:
         try:
             results.append(
@@ -876,10 +971,12 @@ async def apply_manifest(
                     caller,
                     dataset,
                     http_request,
-                    reservation,
+                    quota,
                 )
             )
         except (ManifestSourceError, ValueError, HTTPException) as exc:
+            # fix(#1814): also the release of this key's advisory lock, for an
+            # entry that raised while still holding it.
             await db.rollback()
             results.append(_error_result(dataset, exc))
         except Exception as exc:  # broad: per-entry isolation — any unexpected failure is recorded as that entry's error

--- a/backend/app/processing/ingest/manifest_service.py
+++ b/backend/app/processing/ingest/manifest_service.py
@@ -2,11 +2,14 @@
 
 from __future__ import annotations
 
+import asyncio
 import uuid
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import cast
 
+import structlog
 from fastapi import HTTPException, Request
 from sqlalchemy import desc, select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -25,8 +28,10 @@ from app.platform.extensions.entitlement import enforce_limit
 from app.platform.jobs.defer_guard import (
     defer_with_orphan_guard,
     make_ingest_job_failed_rollback,
+    reset_session_for_settlement,
     settle_ingest_job_failed,
 )
+from app.platform.jobs.sweep import JOB_TIMEOUT_SECONDS
 
 from app.platform.jobs.models import IngestJob
 from app.processing.ingest.manifest_reservation import (
@@ -36,6 +41,7 @@ from app.processing.ingest.manifest_reservation import (
     expire_stale_manifest_reservations,
     latest_in_flight_manifest_job,
     lock_manifest_key,
+    release_manifest_reservation,
 )
 from app.processing.ingest.manifest_schemas import (
     ManifestApplyEntryResult,
@@ -58,6 +64,14 @@ from app.processing.ingest.service import queue_ingest_job, validate_file_extens
 # one `asyncio.to_thread` handoff each. 4 MiB keeps peak buffer memory small
 # while amortizing the thread hop across ~64 chunks.
 _WRITE_BUFFER_BYTES = 4 * 1024 * 1024
+
+# fix(#1814 audit): total wall clock for staging one entry, derived from the
+# running lease the reservation is judged by so the two cannot drift. Half of
+# it, because a download that outlives its own lease is reaped mid-flight and
+# every retry repeats the loss.
+MANIFEST_STAGE_MAX_SECONDS = JOB_TIMEOUT_SECONDS // 2
+
+log = structlog.get_logger()
 
 
 @dataclass(frozen=True)
@@ -95,9 +109,8 @@ class _StagedManifestSource:
 class _ReservedEntry:
     """A committed reservation plus everything staging it needs afterwards.
 
-    fix(#1814): carries plain values rather than ORM instances (beyond the job
-    row itself), because the session between the reservation commit and the
-    staging bind is free to be handed to another request.
+    Plain values beyond the job row itself: the session is free to serve
+    another request between the reservation commit and the staging bind.
     """
 
     job: IngestJob
@@ -189,9 +202,9 @@ async def _download_http_source(
 ) -> str:
     """Stream one manifest source to staging. Takes no database session.
 
-    fix(#1814): the size ceiling is read by the caller, before the reservation
-    commit. A session parameter here would check a pooled connection back out
-    and hold its transaction open for the length of the download.
+    fix(#1814): a session parameter would check a pooled connection back out
+    and hold its transaction open for the length of the download, so the caller
+    reads the size ceiling before the reservation commit.
     """
     staging_dir = Path(settings.upload_staging_dir)
     staging_dir.mkdir(parents=True, exist_ok=True)
@@ -297,6 +310,35 @@ async def _download_http_source(
 
 
 async def _stage_source_if_needed(
+    prepared: ManifestPreparedSource,
+    *,
+    dry_run: bool,
+    max_size_bytes: int,
+    quota_byte_limit: int | None = None,
+) -> str | None:
+    """Put one manifest source where ingest can read it, under a total deadline.
+
+    fix(#1814 audit): httpx's 60s clock is per read, so a source trickling
+    steadily has no wall-clock bound of its own. Staging that outlives the
+    reservation's lease is reaped mid-flight and every retry repeats the loss,
+    so the bound lives here, where it travels with the operation.
+    """
+    try:
+        async with asyncio.timeout(MANIFEST_STAGE_MAX_SECONDS):
+            return await _stage_source(
+                prepared,
+                dry_run=dry_run,
+                max_size_bytes=max_size_bytes,
+                quota_byte_limit=quota_byte_limit,
+            )
+    except TimeoutError as exc:
+        raise ManifestSourceError(
+            "Manifest source did not finish staging within "
+            f"{MANIFEST_STAGE_MAX_SECONDS} seconds"
+        ) from exc
+
+
+async def _stage_source(
     prepared: ManifestPreparedSource,
     *,
     dry_run: bool,
@@ -530,6 +572,8 @@ async def _classify_dataset(
     db: AsyncSession,
     dataset: ManifestDataset,
     user: Identity,
+    *,
+    dry_run: bool = False,
 ) -> tuple[str, ManifestPreparedSource | None, IngestJob | None, object | None, str]:
     fingerprint = manifest_dataset_fingerprint(dataset)
     if not dataset.sources:
@@ -558,7 +602,11 @@ async def _classify_dataset(
     # section on this key, and nothing inside it may touch the network. The
     # SSRF validation above is deliberately outside it.
     await lock_manifest_key(db, dataset.key)
-    await expire_stale_manifest_reservations(db, dataset.key)
+    if not dry_run:
+        # fix(#1814 audit): a preview writes nothing, so it does not settle
+        # another caller's abandoned reservation. The cost is that a dry run
+        # can still report an entry as in flight where an apply would take it.
+        await expire_stale_manifest_reservations(db, dataset.key)
 
     in_flight = await latest_in_flight_manifest_job(db, dataset.key)
     if in_flight is not None:
@@ -651,12 +699,10 @@ async def _reserve_entry(
 ) -> _ReservedEntry:
     """Commit this key's claim, and everything staging needs, in one transaction.
 
-    fix(#1814): the row goes in BEFORE the source is fetched, carrying the
-    downloading stage marker, so a client that times out mid-download and
-    retries sees `skip_in_flight` for its own job instead of starting a second
-    download of the same entry. The caller holds this key's advisory lock; the
-    commit here is what publishes the claim and releases both the lock and the
-    pooled connection.
+    fix(#1814): the row goes in before the source is fetched, so a client that
+    times out mid-download and retries sees `skip_in_flight` for its own job.
+    The commit publishes the claim and releases both the caller's key lock and
+    the pooled connection.
     """
     creates_dataset = dataset_id is None
     quota_byte_limit = await _preflight_quota(
@@ -675,6 +721,9 @@ async def _reserve_entry(
         metadata["reupload"] = True
         metadata["dataset_id"] = str(dataset_id)
 
+    # fix(#1814 audit): `running`, not `pending`. A pending row with no
+    # file_path and no queue task is reapable by four actors while its source
+    # is still downloading; the fixed lease is not.
     job = IngestJob(
         dataset_id=dataset_id,
         source_filename=prepared.source_filename,
@@ -682,7 +731,8 @@ async def _reserve_entry(
         source_url=None,
         source_layer=prepared.source_layer,
         created_by=user.id,
-        status="pending",
+        status="running",
+        started_at=datetime.now(timezone.utc),
         user_metadata=metadata,
     )
     db.add(job)
@@ -700,18 +750,46 @@ async def _reserve_entry(
 async def _fail_reservation(
     db: AsyncSession, job: IngestJob, exc: BaseException
 ) -> None:
-    """Settle a reservation whose source never reached staging.
+    """Settle a reservation that never staged its source, freeing its key.
 
-    Best effort by construction: this runs while an entry is already failing,
-    and the shared settlement is fenced, so a row some other actor has already
-    settled is left exactly as that actor left it.
+    fix(#1814 codex r1): the session is reset first. The failure that brought
+    us here is often a database error, which leaves the transaction refusing
+    every further statement, so a settlement issued onto it would raise too and
+    leave the reservation holding its key until the lease expired.
     """
+    # Read before the reset: the restore covers the identifiers, but a log line
+    # in the handler below must not be the thing that raises.
+    job_id = job.id
+    await reset_session_for_settlement(job, db=db)
     try:
-        await settle_ingest_job_failed(
-            job, exc, message_prefix="Failed to stage manifest source"
+        await release_manifest_reservation(
+            db, job, f"Failed to stage manifest source: {exc}"
         )
         await db.commit()
-    except Exception:  # broad: the session may already be unusable
+    except Exception:  # broad: a session this far gone is the sweep's problem
+        log.exception("Could not settle a manifest reservation", job_id=str(job_id))
+        await db.rollback()
+
+
+async def _fail_queued_manifest_job(
+    db: AsyncSession, job: IngestJob, exc: BaseException
+) -> None:
+    """Settle a bound row whose dispatch never reached the queue.
+
+    fix(#1814): past the staging bind the row is `pending` like every other
+    queued job, so this takes the shared settlement's own fence rather than the
+    lease's. The orphan guard has already settled it for a dispatch failure;
+    only a refusal raised before the guard ran lands here.
+    """
+    job_id = job.id
+    await reset_session_for_settlement(job, db=db)
+    try:
+        await settle_ingest_job_failed(
+            job, exc, message_prefix="Failed to queue manifest job"
+        )
+        await db.commit()
+    except Exception:  # broad: a session this far gone is the sweep's problem
+        log.exception("Could not settle a manifest job", job_id=str(job_id))
         await db.rollback()
 
 
@@ -777,11 +855,7 @@ async def _finalize_reserved_entry(
             creates_dataset=reserved.creates_dataset,
         )
         _cleanup_downloaded_source(prepared, file_path)
-        # fix(#1814): an entry that did not reach the queue must not go on
-        # holding its key. The orphan guard has already settled the row for
-        # every dispatch failure, and the settlement is fenced on `pending`,
-        # so this only lands for a refusal raised before the guard ran.
-        await _fail_reservation(db, job, exc)
+        await _fail_queued_manifest_job(db, job, exc)
         raise
 
     if reserved.dataset_id is None:
@@ -819,19 +893,11 @@ async def _reserve_or_settle_entry(
 ) -> ManifestApplyEntryResult | _ReservedEntry:
     """The locked half of one entry: classify, then either answer or reserve.
 
-    fix(#1814): every exit from this function ends the transaction, because
-    `_classify_dataset` takes this key's advisory lock and a lock still held
-    when the next entry runs would sit across that entry's download, and could
-    deadlock two manifests that list the same two keys in opposite order.
-    Returning a result means the entry is answered from what the key already
-    holds; returning a reservation means the caller owns the key until it
-    stages or settles the row.
-
-    Ended by committing rather than rolling back, on the answered paths too:
-    `expire_stale_manifest_reservations` may have settled an abandoned
-    reservation for this key, a dry run has to report the same answer a real
-    apply would, and a rollback would expire every instance the caller still
-    holds.
+    A result means the entry is answered from what the key already holds; a
+    reservation means the caller owns the key until it stages or settles that
+    row. fix(#1814): every exit ends the transaction, by committing even on the
+    answered paths, so the key lock is never held across the next entry's
+    download and the staleness settlement is not thrown away.
     """
     (
         classification,
@@ -839,7 +905,7 @@ async def _reserve_or_settle_entry(
         job,
         existing_dataset,
         fingerprint,
-    ) = await _classify_dataset(db, dataset, user)
+    ) = await _classify_dataset(db, dataset, user, dry_run=request.dry_run)
     if prepared is None:
         raise ManifestSourceError("Manifest source could not be prepared")
 

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -2529,19 +2529,10 @@ _OPEN_CORE_SIZE_CAPS: dict[str, int] = {
 #     generated). Leaving them was the worse option — a reader who trusts a
 #     stale precondition unwinds the wrong defence.
 _MODULE_LOC_CAPS: dict[str, int] = {
-    # fix(#1814): first entry, crossed _RATCHET_INCLUSION_LOC when the manifest
-    # apply started reserving an entry's key before fetching its source. The
-    # growth is the reserve/stage/bind split of what used to be one
-    # create-and-queue function, the two settlement exits the split needs (a
-    # reservation is `running`, a bound row is `pending`, and the shared
-    # settlement fences on the latter), the quota preflight moving ahead of the
-    # reservation, and the staging deadline that keeps a download inside the
-    # lease it is judged by.
-    # fix(#1814 review): +12. The staging bind's commit is ambiguous on an
-    # acknowledgement loss, so its settlement re-reads the row instead of
-    # deciding from the exception, behind a named commit seam a test can make
-    # durable-then-raising. Cap 1056 -> 1068, exact.
-    "backend/app/processing/ingest/manifest_service.py": 1068,
+    # fix(#1814): first entry. The lines bought the reserve/stage/bind split of
+    # one create-and-queue function, its two fenced settlement exits, the quota
+    # preflight, the staging deadline, and the ambiguous-commit re-reads.
+    "backend/app/processing/ingest/manifest_service.py": 1102,
     # fix(#1770 round 43 P1): crossed _RATCHET_INCLUSION_LOC on the XML
     # streaming preflight (`_xml_preflight`, `MAX_DOCUMENT_ATTRIBUTES`,
     # `MAX_DOCUMENT_DEPTH`) that closes the attribute-bomb/deep-nesting-bomb/

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -2531,8 +2531,8 @@ _OPEN_CORE_SIZE_CAPS: dict[str, int] = {
 _MODULE_LOC_CAPS: dict[str, int] = {
     # fix(#1814): first entry. The lines bought the reserve/stage/bind split of
     # one create-and-queue function, its two fenced settlement exits, the quota
-    # preflight, the staging deadline, and the ambiguous-commit re-reads.
-    "backend/app/processing/ingest/manifest_service.py": 1102,
+    # preflight, the staging deadline, and the reset-and-retry settlement.
+    "backend/app/processing/ingest/manifest_service.py": 1129,
     # fix(#1770 round 43 P1): crossed _RATCHET_INCLUSION_LOC on the XML
     # streaming preflight (`_xml_preflight`, `MAX_DOCUMENT_ATTRIBUTES`,
     # `MAX_DOCUMENT_DEPTH`) that closes the attribute-bomb/deep-nesting-bomb/

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -2532,7 +2532,7 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # fix(#1814): first entry. The lines bought the reserve/stage/bind split of
     # one create-and-queue function, its two fenced settlement exits, the quota
     # preflight, the staging deadline, and the reset-and-retry settlement.
-    "backend/app/processing/ingest/manifest_service.py": 1129,
+    "backend/app/processing/ingest/manifest_service.py": 1111,
     # fix(#1770 round 43 P1): crossed _RATCHET_INCLUSION_LOC on the XML
     # streaming preflight (`_xml_preflight`, `MAX_DOCUMENT_ATTRIBUTES`,
     # `MAX_DOCUMENT_DEPTH`) that closes the attribute-bomb/deep-nesting-bomb/

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -2536,8 +2536,12 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # reservation is `running`, a bound row is `pending`, and the shared
     # settlement fences on the latter), the quota preflight moving ahead of the
     # reservation, and the staging deadline that keeps a download inside the
-    # lease it is judged by. Cap 1056, exact.
-    "backend/app/processing/ingest/manifest_service.py": 1056,
+    # lease it is judged by.
+    # fix(#1814 review): +12. The staging bind's commit is ambiguous on an
+    # acknowledgement loss, so its settlement re-reads the row instead of
+    # deciding from the exception, behind a named commit seam a test can make
+    # durable-then-raising. Cap 1056 -> 1068, exact.
+    "backend/app/processing/ingest/manifest_service.py": 1068,
     # fix(#1770 round 43 P1): crossed _RATCHET_INCLUSION_LOC on the XML
     # streaming preflight (`_xml_preflight`, `MAX_DOCUMENT_ATTRIBUTES`,
     # `MAX_DOCUMENT_DEPTH`) that closes the attribute-bomb/deep-nesting-bomb/

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -2532,7 +2532,7 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # fix(#1814): first entry. The lines bought the reserve/stage/bind split of
     # one create-and-queue function, its two fenced settlement exits, the quota
     # preflight, the staging deadline, and the reset-and-retry settlement.
-    "backend/app/processing/ingest/manifest_service.py": 1111,
+    "backend/app/processing/ingest/manifest_service.py": 1130,
     # fix(#1770 round 43 P1): crossed _RATCHET_INCLUSION_LOC on the XML
     # streaming preflight (`_xml_preflight`, `MAX_DOCUMENT_ATTRIBUTES`,
     # `MAX_DOCUMENT_DEPTH`) that closes the attribute-bomb/deep-nesting-bomb/

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -2529,6 +2529,15 @@ _OPEN_CORE_SIZE_CAPS: dict[str, int] = {
 #     generated). Leaving them was the worse option — a reader who trusts a
 #     stale precondition unwinds the wrong defence.
 _MODULE_LOC_CAPS: dict[str, int] = {
+    # fix(#1814): first entry, crossed _RATCHET_INCLUSION_LOC when the manifest
+    # apply started reserving an entry's key before fetching its source. The
+    # growth is the reserve/stage/bind split of what used to be one
+    # create-and-queue function, the two settlement exits the split needs (a
+    # reservation is `running`, a bound row is `pending`, and the shared
+    # settlement fences on the latter), the quota preflight moving ahead of the
+    # reservation, and the staging deadline that keeps a download inside the
+    # lease it is judged by. Cap 1056, exact.
+    "backend/app/processing/ingest/manifest_service.py": 1056,
     # fix(#1770 round 43 P1): crossed _RATCHET_INCLUSION_LOC on the XML
     # streaming preflight (`_xml_preflight`, `MAX_DOCUMENT_ATTRIBUTES`,
     # `MAX_DOCUMENT_DEPTH`) that closes the attribute-bomb/deep-nesting-bomb/

--- a/backend/tests/test_manifest_apply_service.py
+++ b/backend/tests/test_manifest_apply_service.py
@@ -344,8 +344,12 @@ class TestManifestApplyHelpers:
         dataset = _request(_manifest_dataset(uri="seed.geojson")).datasets[0]
         prepared = await classify_manifest_source(dataset.sources[0])
 
-        first = await _stage_source_if_needed(AsyncMock(), prepared, dry_run=False)
-        second = await _stage_source_if_needed(AsyncMock(), prepared, dry_run=False)
+        first = await _stage_source_if_needed(
+            prepared, dry_run=False, max_size_bytes=1024 * 1024
+        )
+        second = await _stage_source_if_needed(
+            prepared, dry_run=False, max_size_bytes=1024 * 1024
+        )
 
         assert first is not None and second is not None
         assert first != second
@@ -550,10 +554,6 @@ class TestManifestApplyHelpers:
                 "app.platform.security.make_safe_client",
                 return_value=client,
             ),
-            patch(
-                "app.processing.ingest.manifest_service.UPLOAD_MAX_SIZE_MB.get",
-                new=AsyncMock(return_value=100),
-            ),
         ):
             prepared = await classify_manifest_source(source)
             with pytest.raises(
@@ -561,8 +561,8 @@ class TestManifestApplyHelpers:
                 match="remaining storage quota",
             ):
                 await _download_http_source(
-                    test_db_session,
                     prepared,
+                    max_size_bytes=100 * 1024 * 1024,
                     quota_byte_limit=5,
                 )
 
@@ -611,14 +611,12 @@ class TestManifestApplyHelpers:
                 "app.platform.security.make_safe_client",
                 return_value=client,
             ),
-            patch(
-                "app.processing.ingest.manifest_service.UPLOAD_MAX_SIZE_MB.get",
-                new=AsyncMock(return_value=100),
-            ),
             patch.object(Path, "open", new=blocking_open),
         ):
             prepared = await classify_manifest_source(source)
-            task = asyncio.create_task(_download_http_source(test_db_session, prepared))
+            task = asyncio.create_task(
+                _download_http_source(prepared, max_size_bytes=100 * 1024 * 1024)
+            )
             assert await asyncio.to_thread(open_started.wait, 5)
             task.cancel()
             await asyncio.sleep(0)
@@ -845,7 +843,7 @@ class TestManifestApplyService:
 
         with (
             patch(
-                "app.processing.ingest.manifest_service._stage_source_and_check_quota",
+                "app.processing.ingest.manifest_service._stage_source_if_needed",
                 new=AsyncMock(),
             ) as stage,
             patch(
@@ -982,7 +980,7 @@ class TestManifestApplyService:
 
         with (
             patch(
-                "app.processing.ingest.manifest_service._stage_source_and_check_quota",
+                "app.processing.ingest.manifest_service._stage_source_if_needed",
                 new=AsyncMock(),
             ) as stage,
             patch(
@@ -1025,7 +1023,7 @@ class TestManifestApplyService:
         )
 
         with patch(
-            "app.processing.ingest.manifest_service._stage_source_and_check_quota",
+            "app.processing.ingest.manifest_service._stage_source_if_needed",
             new=AsyncMock(),
         ) as stage:
             response = await apply_manifest(
@@ -1258,7 +1256,12 @@ class TestManifestApplyService:
         assert quota_check.await_args.args[1] == user_id
         assert quota_check.await_args.args[2] == 4096
         queue.assert_not_awaited()
-        assert await test_db_session.scalar(select(func.count(IngestJob.id))) == 0
+        # fix(#1814): the reservation is inserted before the download, so a
+        # denial after it leaves that row settled rather than leaving none.
+        reservation = (await test_db_session.execute(select(IngestJob))).scalar_one()
+        assert reservation.status == "failed"
+        assert reservation.file_path is None
+        assert reservation.user_metadata["manifest_key"] == "manifest-http-quota"
 
     async def test_admin_same_bucket_seed_is_sized_and_quota_checked(
         self, test_db_session, clean_tables, monkeypatch
@@ -1301,9 +1304,12 @@ class TestManifestApplyService:
         assert quota_check.await_args.args[1:3] == (user_id, 8192)
         queue.assert_awaited_once()
 
-    async def test_downloaded_http_source_is_removed_if_job_persistence_fails(
+    async def test_downloaded_http_source_is_removed_if_staging_bind_fails(
         self, test_db_session, clean_tables, tmp_path
     ):
+        """fix(#1814): the row is durable before the download now, so the write
+        that can still fail is the one binding the staged path to it. The
+        downloaded bytes belong to that attempt and must not outlive it."""
         user = await _admin_user(test_db_session)
         request = _request(
             _manifest_dataset(
@@ -1327,9 +1333,9 @@ class TestManifestApplyService:
                 "app.modules.quota.service.check_upload_quota",
                 new=AsyncMock(),
             ),
-            patch.object(
-                test_db_session,
-                "flush",
+            patch(
+                "app.processing.ingest.manifest_service."
+                "bind_reservation_to_staged_source",
                 new=AsyncMock(side_effect=RuntimeError("database unavailable")),
             ),
             patch(
@@ -1346,6 +1352,9 @@ class TestManifestApplyService:
         assert "database unavailable" in response.results[0].message
         assert not staged.exists()
         queue.assert_not_awaited()
+        reservation = (await test_db_session.execute(select(IngestJob))).scalar_one()
+        assert reservation.status == "failed"
+        assert reservation.file_path is None
 
 
 @pytest.mark.anyio
@@ -1500,7 +1509,7 @@ class TestManifestDryRun:
         )
 
         with patch(
-            "app.processing.ingest.manifest_service._stage_source_and_check_quota",
+            "app.processing.ingest.manifest_service._stage_source_if_needed",
             new=AsyncMock(),
         ) as stage:
             response = await apply_manifest(

--- a/backend/tests/test_manifest_reservation_1814.py
+++ b/backend/tests/test_manifest_reservation_1814.py
@@ -1,12 +1,15 @@
-"""fix(#1814): a manifest entry claims its key before its source is fetched.
+"""An apply claims a manifest key before fetching that entry's source.
 
-The in-flight check and the row that makes it true were separated by a network
-fetch, so a client that timed out mid-download and retried queued it twice.
+Covers the claim itself, the fenced transitions out of the downloading stage,
+the running lease the reservation is judged by, and the reconciliation each
+ambiguous commit in the path performs.
 """
 
 from __future__ import annotations
 
 from contextlib import contextmanager
+import asyncio
+import uuid
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from shutil import copyfile
@@ -20,6 +23,7 @@ from sqlalchemy import event, func, select, text, update
 from app.core.config import settings
 from app.modules.auth.models import User
 from app.modules.quota.schemas import UserQuotaUsage
+from app.platform.jobs.defer_guard import settle_ingest_job_failed
 from app.platform.jobs.models import IngestJob
 from app.platform.jobs.sweep import (
     JOB_TIMEOUT_SECONDS,
@@ -119,8 +123,11 @@ async def _jobs_for_key(session, key: str) -> list[IngestJob]:
 def _ingest_job_writes(session):
     """Record every INSERT and UPDATE issued against ``catalog.ingest_jobs``.
 
-    Listens on the sync engine, so it sees what the database was asked to do.
-    Each entry carries its rowcount, so a caller can ask either question.
+    Yields a list of (statement, rowcount) pairs, appended as they execute.
+    Listens on the session's sync engine, so it sees what the database was
+    actually asked to do rather than what the ORM was asked to do, and the
+    rowcount lets a caller ask either question: did anything reach the table
+    at all, or did anything change a row.
     """
     bind = session.get_bind()
     engine = getattr(bind, "sync_engine", bind)
@@ -788,6 +795,100 @@ class TestReservationFailureReleasesTheKey:
 
         assert retried.results[0].action == "create"
         queue.assert_awaited_once()
+
+    async def test_the_settlement_retry_cannot_settle_a_rotated_attempt(
+        self, test_db_session, clean_tables
+    ):
+        """fix(#1814): the settlement CAS pins the attempt it started with.
+
+        A durable settlement whose acknowledgement is lost can be followed by
+        /jobs/{id}/retry rotating the token, and a reset reloads the new one.
+        """
+        user = await _admin_user(test_db_session)
+        job = IngestJob(
+            source_filename="rotate.geojson",
+            created_by=user.id,
+            status="running",
+            started_at=datetime.now(timezone.utc),
+            user_metadata={
+                "manifest_key": "manifest-1814-rotate",
+                MANIFEST_STAGE_METADATA_KEY: MANIFEST_STAGE_DOWNLOADING,
+            },
+        )
+        test_db_session.add(job)
+        await test_db_session.commit()
+        await test_db_session.refresh(job)
+        job_id, rotated = job.id, uuid.uuid4()
+        landed: list[bool] = []
+        calls = {"n": 0}
+        exc = RuntimeError("quota denied")
+
+        async def _body() -> None:
+            calls["n"] += 1
+            if calls["n"] == 1:
+                # The settlement lands, its acknowledgement is lost, and a
+                # retry rotates the token and returns the row to pending.
+                await test_db_session.execute(
+                    update(IngestJob)
+                    .where(IngestJob.id == job_id)
+                    .values(status="pending", attempt_id=rotated)
+                    .execution_options(synchronize_session=False)
+                )
+                await test_db_session.commit()
+                raise RuntimeError("acknowledgement lost")
+            landed.append(
+                await settle_ingest_job_failed(job, exc, message_prefix="Failed")
+            )
+
+        await manifest_service._settle_under_reset(
+            test_db_session, job, _body, job_id=job_id
+        )
+
+        assert calls["n"] == 2
+        assert landed == [False], "the retry settled the row under a rotated token"
+        row = await test_db_session.get(IngestJob, job_id, populate_existing=True)
+        assert row.status == "pending"
+        assert row.attempt_id == rotated
+
+    async def test_a_cancelled_reservation_commit_is_not_swallowed(
+        self, test_db_session, clean_tables
+    ):
+        """fix(#1814): a cancellation must not become a staging run.
+
+        The reservation is reconciled either way, but a request cancelled at
+        the commit stops instead of downloading through a shutdown.
+        """
+        _stage_fixture()
+        user = await _admin_user(test_db_session)
+        request = _request(_manifest_dataset(key="manifest-1814-cancelled"))
+
+        async def _durable_then_cancel(db) -> None:
+            await db.commit()
+            raise asyncio.CancelledError()
+
+        with (
+            patch(
+                "app.processing.ingest.manifest_service._commit_reservation",
+                new=_durable_then_cancel,
+            ),
+            patch(
+                "app.processing.ingest.manifest_service._stage_source_if_needed",
+                new=AsyncMock(),
+            ) as stage,
+            patch(
+                "app.processing.ingest.manifest_service.queue_ingest_job",
+                new=AsyncMock(),
+            ) as queue,
+            pytest.raises(asyncio.CancelledError),
+        ):
+            await apply_manifest(test_db_session, request, user, _http_request())
+
+        stage.assert_not_awaited()
+        queue.assert_not_awaited()
+        settled = await _jobs_for_key(test_db_session, "manifest-1814-cancelled")
+        assert len(settled) == 1
+        assert settled[0].status == "failed"
+        assert MANIFEST_STAGE_METADATA_KEY not in settled[0].user_metadata
 
     async def test_a_post_admission_failure_returns_its_bytes_to_the_batch_ledger(
         self, test_db_session, clean_tables

--- a/backend/tests/test_manifest_reservation_1814.py
+++ b/backend/tests/test_manifest_reservation_1814.py
@@ -713,6 +713,96 @@ class TestReservationFailureReleasesTheKey:
         assert retried.results[0].job_id != settled[0].id
         queue.assert_awaited_once()
 
+    async def test_a_poisoned_reconciliation_read_still_settles(
+        self, test_db_session, clean_tables
+    ):
+        """fix(#1814): any step of a settlement can find the transaction already
+        unusable, so each attempt resets first and one retry follows a database
+        error. A failure at the read cannot strand the writes behind it."""
+        request = _request(
+            _manifest_dataset(
+                key="manifest-1814-poisoned-read",
+                uri="https://data.example.test/roads.geojson",
+            )
+        )
+        staged = _staged_bytes("manifest_1814_poisoned_read.geojson")
+        real_read = manifest_service.staged_source_is_referenced
+        reads = {"n": 0}
+
+        async def _poisoning_read(db, job_id, *, file_path: str) -> bool:
+            reads["n"] += 1
+            if reads["n"] == 1:
+                # A failing statement before the read leaves the transaction
+                # refusing every statement after it.
+                try:
+                    await db.execute(text("SELECT 1 / 0"))
+                except Exception:
+                    pass
+                return True
+            return await real_read(db, job_id, file_path=file_path)
+
+        with (
+            patch("app.platform.security.validate_url_for_ssrf", new=AsyncMock()),
+            patch(
+                "app.processing.ingest.manifest_service._download_http_source",
+                new=AsyncMock(return_value=str(staged)),
+            ),
+            patch(
+                "app.modules.quota.service.check_upload_quota",
+                new=AsyncMock(
+                    side_effect=HTTPException(status_code=413, detail="quota denied")
+                ),
+            ),
+            patch(
+                "app.processing.ingest.manifest_service.staged_source_is_referenced",
+                new=_poisoning_read,
+            ),
+            patch(
+                "app.processing.ingest.manifest_service.queue_ingest_job",
+                new=AsyncMock(),
+            ) as queue,
+        ):
+            response = await apply_manifest(
+                test_db_session,
+                request,
+                await _admin_user(test_db_session),
+                _http_request(),
+            )
+
+        assert response.results[0].action == "error"
+        queue.assert_not_awaited()
+        assert reads["n"] == 2, "the settlement was not retried on a fresh transaction"
+
+        settled = await _jobs_for_key(test_db_session, "manifest-1814-poisoned-read")
+        assert len(settled) == 1
+        assert settled[0].status == "failed"
+        assert MANIFEST_STAGE_METADATA_KEY not in settled[0].user_metadata
+        # The bind never ran, so nothing references these bytes.
+        assert not staged.exists()
+
+        # The key is free: a re-apply does not attach.
+        retry_staged = _staged_bytes("manifest_1814_poisoned_read_retry.geojson")
+        with (
+            patch("app.platform.security.validate_url_for_ssrf", new=AsyncMock()),
+            patch(
+                "app.processing.ingest.manifest_service._download_http_source",
+                new=AsyncMock(return_value=str(retry_staged)),
+            ),
+            patch(
+                "app.processing.ingest.manifest_service.queue_ingest_job",
+                new=AsyncMock(),
+            ) as queue,
+        ):
+            retried = await apply_manifest(
+                test_db_session,
+                request,
+                await _admin_user(test_db_session),
+                _http_request(),
+            )
+
+        assert retried.results[0].action == "create"
+        queue.assert_awaited_once()
+
     async def test_a_post_admission_failure_returns_its_bytes_to_the_batch_ledger(
         self, test_db_session, clean_tables
     ):

--- a/backend/tests/test_manifest_reservation_1814.py
+++ b/backend/tests/test_manifest_reservation_1814.py
@@ -548,6 +548,91 @@ class TestReservationFailureReleasesTheKey:
         assert retried.results[0].action == "create"
         queue.assert_awaited_once()
 
+    async def test_a_durable_reservation_whose_commit_raises_is_adopted(
+        self, test_db_session, clean_tables
+    ):
+        """fix(#1814): the reservation insert is ambiguous too.
+
+        A durable insert whose acknowledgement is lost used to leave a running
+        row holding the key with nothing that would ever stage or queue it, and
+        every re-apply reported skip until the lease expired.
+        """
+        _stage_fixture()
+        user = await _admin_user(test_db_session)
+        request = _request(_manifest_dataset(key="manifest-1814-adopt"))
+
+        async def _durable_then_raise(db) -> None:
+            await db.commit()
+            raise RuntimeError("acknowledgement lost")
+
+        with (
+            patch(
+                "app.processing.ingest.manifest_service._commit_reservation",
+                new=_durable_then_raise,
+            ),
+            patch(
+                "app.processing.ingest.manifest_service.queue_ingest_job",
+                new=AsyncMock(),
+            ) as queue,
+        ):
+            response = await apply_manifest(
+                test_db_session, request, user, _http_request()
+            )
+
+        # Adopted, so the entry finishes rather than stranding its key.
+        assert response.results[0].action == "create"
+        queue.assert_awaited_once()
+
+        rows = await _jobs_for_key(test_db_session, "manifest-1814-adopt")
+        assert len(rows) == 1
+        assert rows[0].status == "pending"
+        assert rows[0].file_path is not None
+        assert MANIFEST_STAGE_METADATA_KEY not in rows[0].user_metadata
+
+    async def test_a_reservation_that_never_landed_leaves_the_key_free(
+        self, test_db_session, clean_tables
+    ):
+        """The other side of the same branch: nothing durable, nothing held."""
+        _stage_fixture()
+        user = await _admin_user(test_db_session)
+        request = _request(_manifest_dataset(key="manifest-1814-not-landed"))
+
+        async def _rollback_then_raise(db) -> None:
+            await db.rollback()
+            raise RuntimeError("connection reset")
+
+        with (
+            patch(
+                "app.processing.ingest.manifest_service._commit_reservation",
+                new=_rollback_then_raise,
+            ),
+            patch(
+                "app.processing.ingest.manifest_service.queue_ingest_job",
+                new=AsyncMock(),
+            ) as queue,
+        ):
+            response = await apply_manifest(
+                test_db_session, request, user, _http_request()
+            )
+
+        assert response.results[0].action == "error"
+        assert "connection reset" in response.results[0].message
+        queue.assert_not_awaited()
+        assert await _jobs_for_key(test_db_session, "manifest-1814-not-landed") == []
+
+        with patch(
+            "app.processing.ingest.manifest_service.queue_ingest_job",
+            new=AsyncMock(),
+        ) as queue:
+            retried = await apply_manifest(
+                test_db_session,
+                request,
+                await _admin_user(test_db_session),
+                _http_request(),
+            )
+        assert retried.results[0].action == "create"
+        queue.assert_awaited_once()
+
     async def test_a_durable_bind_whose_commit_raises_keeps_its_bytes(
         self, test_db_session, clean_tables
     ):
@@ -698,12 +783,9 @@ class TestReservationFailureReleasesTheKey:
 class TestStaleReservations:
     """The reservation runs under the fixed running lease, not the pending one.
 
-    fix(#1814 audit): a committed `pending` row with no file_path and no queue
-    task matches every clause of `stale_pending_clauses`, and
-    `pending_job_timeout_seconds` may legally be 61s while a manifest download
-    has no wall-clock bound of its own. The reservation was therefore reapable
-    mid-flight by the sweep, the worker's startup recovery, the status poll and
-    the next apply, and every retry repeated the loss.
+    fix(#1814): a pending row with no file_path and no queue task is reapable by
+    four actors while its source is still downloading, and
+    `pending_job_timeout_seconds` may legally be 61s. The fixed lease is not.
     """
 
     def _reservation(self, user, dataset, prepared, *, age_seconds: float) -> IngestJob:
@@ -924,10 +1006,9 @@ class TestStaleReservations:
 class TestFencedWritesAreSingleStatements:
     """One fenced UPDATE per transition, not a fenced one plus an ORM flush.
 
-    fix(#1814): the instance has to describe the row after a fenced write, but
-    plain assignment marks it dirty and the caller's own commit then flushes a
-    second, unfenced update over the fenced one. `set_committed_value` writes
-    the attribute as already-committed state instead.
+    fix(#1814): the instance must describe the row after a fenced write, but
+    plain assignment marks it dirty and the caller's commit then flushes a
+    second, unfenced update. `set_committed_value` writes committed state.
     """
 
     async def test_the_staging_bind_emits_one_update(

--- a/backend/tests/test_manifest_reservation_1814.py
+++ b/backend/tests/test_manifest_reservation_1814.py
@@ -8,6 +8,7 @@ and retried passed the check a second time and queued the same entry twice.
 
 from __future__ import annotations
 
+from contextlib import contextmanager
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from shutil import copyfile
@@ -16,7 +17,7 @@ from unittest.mock import AsyncMock, patch
 import anyio
 import pytest
 from fastapi import HTTPException, Request
-from sqlalchemy import func, select, text, update
+from sqlalchemy import event, func, select, text, update
 
 from app.core.config import settings
 from app.modules.auth.models import User
@@ -114,6 +115,43 @@ async def _jobs_for_key(session, key: str) -> list[IngestJob]:
         .execution_options(populate_existing=True)
     )
     return list(result.scalars())
+
+
+@contextmanager
+def _ingest_job_writes(session):
+    """Record every INSERT and UPDATE issued against ``catalog.ingest_jobs``.
+
+    Listens on the session's sync engine, so it sees what the database was
+    actually asked to do rather than what the ORM was asked to do. Each entry
+    carries its rowcount, so a caller can ask either question: did anything
+    reach the table at all, or did anything change a row.
+    """
+    bind = session.get_bind()
+    engine = getattr(bind, "sync_engine", bind)
+    seen: list[tuple[str, int]] = []
+
+    def _record(conn, cursor, statement, parameters, context, executemany):
+        collapsed = " ".join(statement.split())
+        if "ingest_jobs" in collapsed and collapsed.upper().startswith(
+            ("INSERT", "UPDATE")
+        ):
+            seen.append((collapsed, cursor.rowcount or 0))
+
+    event.listen(engine, "after_cursor_execute", _record)
+    try:
+        yield seen
+    finally:
+        event.remove(engine, "after_cursor_execute", _record)
+
+
+def _writes(
+    recorded: list[tuple[str, int]], verb: str, *, changed: bool = False
+) -> list[str]:
+    return [
+        statement
+        for statement, rowcount in recorded
+        if statement.upper().startswith(verb) and (rowcount > 0 or not changed)
+    ]
 
 
 class _GatedDownload:
@@ -510,6 +548,86 @@ class TestReservationFailureReleasesTheKey:
         assert retried.results[0].action == "create"
         queue.assert_awaited_once()
 
+    async def test_a_durable_bind_whose_commit_raises_keeps_its_bytes(
+        self, test_db_session, clean_tables
+    ):
+        """fix(#1814): the row decides the cleanup, not the exception.
+
+        A commit can be durable in PostgreSQL and still raise on the
+        acknowledgement. Deciding from the exception deleted the staged source
+        and left a `pending` row pointing at nothing, with no queued task, and
+        every re-apply attached to it until the sweep ran.
+        """
+        request = _request(
+            _manifest_dataset(
+                key="manifest-1814-ambiguous",
+                uri="https://data.example.test/roads.geojson",
+            )
+        )
+        staged = _staged_bytes("manifest_1814_ambiguous.geojson")
+
+        async def _durable_then_raise(db) -> None:
+            await db.commit()
+            raise RuntimeError("acknowledgement lost")
+
+        with (
+            patch("app.platform.security.validate_url_for_ssrf", new=AsyncMock()),
+            patch(
+                "app.processing.ingest.manifest_service._download_http_source",
+                new=AsyncMock(return_value=str(staged)),
+            ),
+            patch(
+                "app.processing.ingest.manifest_service._commit_staged_bind",
+                new=_durable_then_raise,
+            ),
+            patch(
+                "app.processing.ingest.manifest_service.queue_ingest_job",
+                new=AsyncMock(),
+            ) as queue,
+        ):
+            response = await apply_manifest(
+                test_db_session,
+                request,
+                await _admin_user(test_db_session),
+                _http_request(),
+            )
+
+        assert response.results[0].action == "error"
+        assert "acknowledgement lost" in response.results[0].message
+        queue.assert_not_awaited()
+        # The bind landed, so the bytes are what /jobs/{id}/retry needs.
+        assert staged.exists()
+
+        settled = await _jobs_for_key(test_db_session, "manifest-1814-ambiguous")
+        assert len(settled) == 1
+        assert settled[0].status == "failed"
+        assert settled[0].file_path == str(staged)
+        assert MANIFEST_STAGE_METADATA_KEY not in settled[0].user_metadata
+
+        # And the key is free: a re-apply does not attach to the dead job.
+        retry_staged = _staged_bytes("manifest_1814_ambiguous_retry.geojson")
+        with (
+            patch("app.platform.security.validate_url_for_ssrf", new=AsyncMock()),
+            patch(
+                "app.processing.ingest.manifest_service._download_http_source",
+                new=AsyncMock(return_value=str(retry_staged)),
+            ),
+            patch(
+                "app.processing.ingest.manifest_service.queue_ingest_job",
+                new=AsyncMock(),
+            ) as queue,
+        ):
+            retried = await apply_manifest(
+                test_db_session,
+                request,
+                await _admin_user(test_db_session),
+                _http_request(),
+            )
+
+        assert retried.results[0].action == "create"
+        assert retried.results[0].job_id != settled[0].id
+        queue.assert_awaited_once()
+
     async def test_a_post_admission_failure_returns_its_bytes_to_the_batch_ledger(
         self, test_db_session, clean_tables
     ):
@@ -803,7 +921,142 @@ class TestStaleReservations:
         )
 
 
+class TestFencedWritesAreSingleStatements:
+    """One fenced UPDATE per transition, not a fenced one plus an ORM flush.
+
+    fix(#1814): the instance has to describe the row after a fenced write, but
+    plain assignment marks it dirty and the caller's own commit then flushes a
+    second, unfenced update over the fenced one. `set_committed_value` writes
+    the attribute as already-committed state instead.
+    """
+
+    async def test_the_staging_bind_emits_one_update(
+        self, test_db_session, clean_tables
+    ):
+        _stage_fixture()
+        user = await _admin_user(test_db_session)
+        request = _request(_manifest_dataset(key="manifest-1814-one-bind"))
+
+        with (
+            patch(
+                "app.processing.ingest.manifest_service.queue_ingest_job",
+                new=AsyncMock(),
+            ),
+            _ingest_job_writes(test_db_session) as statements,
+        ):
+            response = await apply_manifest(
+                test_db_session, request, user, _http_request()
+            )
+
+        assert response.results[0].action == "create"
+        assert len(_writes(statements, "INSERT", changed=True)) == 1, statements
+        assert len(_writes(statements, "UPDATE", changed=True)) == 1, statements
+
+    async def test_the_reservation_release_emits_one_update(
+        self, test_db_session, clean_tables
+    ):
+        request = _request(
+            _manifest_dataset(
+                key="manifest-1814-one-release",
+                uri="https://data.example.test/roads.geojson",
+            )
+        )
+        staged = _staged_bytes("manifest_1814_one_release.geojson")
+
+        with (
+            patch("app.platform.security.validate_url_for_ssrf", new=AsyncMock()),
+            patch(
+                "app.processing.ingest.manifest_service._download_http_source",
+                new=AsyncMock(return_value=str(staged)),
+            ),
+            patch(
+                "app.modules.quota.service.check_upload_quota",
+                new=AsyncMock(
+                    side_effect=HTTPException(status_code=413, detail="quota denied")
+                ),
+            ),
+            patch(
+                "app.processing.ingest.manifest_service.queue_ingest_job",
+                new=AsyncMock(),
+            ),
+            _ingest_job_writes(test_db_session) as statements,
+        ):
+            response = await apply_manifest(
+                test_db_session,
+                request,
+                await _admin_user(test_db_session),
+                _http_request(),
+            )
+
+        assert response.results[0].action == "error"
+        assert len(_writes(statements, "INSERT", changed=True)) == 1, statements
+        assert len(_writes(statements, "UPDATE", changed=True)) == 1, statements
+
+
 class TestDryRunReservesNothing:
+    async def test_dry_run_writes_nothing_and_leaves_a_stale_row_alone(
+        self, test_db_session, clean_tables
+    ):
+        """fix(#1814): a preview is a read.
+
+        The staleness expiry used to run before the dry-run return, so a
+        preview settled another caller's abandoned reservation. It now runs
+        only for a real apply, at the cost that a preview can still report an
+        entry in flight where an apply would take it.
+        """
+        _stage_fixture()
+        user = await _admin_user(test_db_session)
+        request = _request(_manifest_dataset(key="manifest-1814-dry-stale"))
+        prepared = await classify_manifest_source(request.datasets[0].sources[0])
+        abandoned = IngestJob(
+            source_filename=prepared.source_filename,
+            file_path=None,
+            created_by=user.id,
+            status="running",
+            started_at=datetime.now(timezone.utc)
+            - timedelta(seconds=JOB_TIMEOUT_SECONDS + 60),
+            user_metadata={
+                **manifest_job_metadata(
+                    request.datasets[0],
+                    prepared,
+                    fingerprint=manifest_dataset_fingerprint(request.datasets[0]),
+                ),
+                MANIFEST_STAGE_METADATA_KEY: MANIFEST_STAGE_DOWNLOADING,
+            },
+        )
+        test_db_session.add(abandoned)
+        await test_db_session.commit()
+        abandoned_id = abandoned.id
+
+        preview = _request(
+            _manifest_dataset(key="manifest-1814-dry-stale"), dry_run=True
+        )
+        with (
+            patch(
+                "app.processing.ingest.manifest_service.queue_ingest_job",
+                new=AsyncMock(),
+            ),
+            _ingest_job_writes(test_db_session) as statements,
+        ):
+            response = await apply_manifest(
+                test_db_session, preview, user, _http_request()
+            )
+
+        assert response.dry_run is True
+        # Statement level, not row level: a preview must not send a write to
+        # the table at all, even one its fence would match nothing with.
+        assert statements == [], statements
+
+        untouched = await test_db_session.get(
+            IngestJob, abandoned_id, populate_existing=True
+        )
+        assert untouched.status == "running"
+        assert untouched.completed_at is None
+        assert (
+            untouched.user_metadata[MANIFEST_STAGE_METADATA_KEY]
+            == MANIFEST_STAGE_DOWNLOADING
+        )
+
     async def test_dry_run_leaves_no_reservation(self, test_db_session, clean_tables):
         _stage_fixture()
         user = await _admin_user(test_db_session)

--- a/backend/tests/test_manifest_reservation_1814.py
+++ b/backend/tests/test_manifest_reservation_1814.py
@@ -1,0 +1,644 @@
+"""fix(#1814): a manifest entry claims its key before its source is fetched.
+
+The apply loop used to insert the ``IngestJob`` row only after the entry's
+source had finished downloading, so the in-flight check and the row that makes
+it true were separated by a network fetch. A client that timed out mid-download
+and retried passed the check a second time and queued the same entry twice.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from shutil import copyfile
+from unittest.mock import AsyncMock, patch
+
+import anyio
+import pytest
+from fastapi import HTTPException, Request
+from sqlalchemy import func, select
+
+from app.core.config import settings
+from app.modules.auth.models import User
+from app.modules.quota.schemas import UserQuotaUsage
+from app.platform.jobs.models import IngestJob
+from app.platform.jobs.sweep import stale_pending_cutoff_seconds
+from app.processing.ingest import manifest_service
+from app.processing.ingest.manifest_reservation import (
+    MANIFEST_STAGE_DOWNLOADING,
+    MANIFEST_STAGE_METADATA_KEY,
+    expire_stale_manifest_reservations,
+)
+from app.processing.ingest.manifest_schemas import ManifestApplyRequest
+from app.processing.ingest.manifest_service import apply_manifest
+from app.processing.ingest.manifest_sources import (
+    classify_manifest_source,
+    manifest_dataset_fingerprint,
+    manifest_job_metadata,
+)
+
+pytestmark = pytest.mark.anyio
+
+_FIXTURE = "tests/fixtures/ingest/basic_attrs.geojson"
+
+
+def _manifest_dataset(
+    *,
+    key: str,
+    title: str = "Road centerlines",
+    uri: str = _FIXTURE,
+) -> dict:
+    return {
+        "key": key,
+        "title": title,
+        "description": f"{title} description",
+        "sources": [{"type": "vector", "uri": uri, "format": "geojson"}],
+        "metadata": {"crs": "EPSG:4326"},
+        "publication": {"intent": "draft"},
+    }
+
+
+def _request(*datasets: dict, dry_run: bool = False) -> ManifestApplyRequest:
+    return ManifestApplyRequest.model_validate(
+        {
+            "manifest_version": "1",
+            "catalog": {"title": "Manifest catalog"},
+            "datasets": list(datasets),
+            "dry_run": dry_run,
+        }
+    )
+
+
+def _http_request() -> Request:
+    return Request(
+        {
+            "type": "http",
+            "method": "POST",
+            "path": "/ingest/manifest/apply",
+            "headers": [],
+        }
+    )
+
+
+async def _admin_user(session) -> User:
+    result = await session.execute(select(User).where(User.username == "admin"))
+    return result.scalar_one()
+
+
+def _stage_fixture() -> Path:
+    destination = Path(settings.upload_staging_dir) / _FIXTURE
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    copyfile(Path(__file__).parent / "fixtures/ingest/basic_attrs.geojson", destination)
+    return destination
+
+
+def _staged_bytes(name: str, size: int = 4096) -> Path:
+    path = Path(settings.upload_staging_dir) / name
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(b"x" * size)
+    return path
+
+
+async def _jobs_for_key(session, key: str) -> list[IngestJob]:
+    result = await session.execute(
+        select(IngestJob)
+        .where(IngestJob.user_metadata["manifest_key"].astext == key)
+        .order_by(IngestJob.created_at)
+    )
+    return list(result.scalars())
+
+
+class _GatedDownload:
+    """Mocked source download that parks until the test releases it."""
+
+    def __init__(self) -> None:
+        self.started = anyio.Event()
+        self.release = anyio.Event()
+        self.calls = 0
+
+    async def __call__(
+        self,
+        prepared,
+        *,
+        max_size_bytes: int,
+        quota_byte_limit: int | None = None,
+    ) -> str:
+        self.calls += 1
+        path = _staged_bytes(f"manifest_1814_gated_{self.calls}.geojson")
+        self.started.set()
+        # A second call is the defect: it can only happen if the concurrent
+        # apply classified the same entry as new. Release both so the test
+        # fails on the count and the classification rather than on a deadline.
+        if self.calls > 1:
+            self.release.set()
+        await self.release.wait()
+        return str(path)
+
+
+class TestReservationClosesTheDownloadWindow:
+    async def test_a_retry_during_the_download_attaches_to_the_reserved_job(
+        self, client, clean_tables
+    ):
+        """The defect, end to end.
+
+        Two applies of one entry, the second submitted while the first is
+        still downloading. Before the reservation, both passed the in-flight
+        check and both downloaded and queued: the CLI's documented
+        "re-applying immediately can queue that entry twice".
+        """
+        import app.core.db as db_module
+
+        request = _request(
+            _manifest_dataset(
+                key="manifest-1814-retry",
+                uri="https://data.example.test/roads.geojson",
+            )
+        )
+        download = _GatedDownload()
+        first: dict = {}
+
+        async def _run_first() -> None:
+            async with db_module.async_session() as session:
+                user = await _admin_user(session)
+                first["response"] = await apply_manifest(
+                    session, request, user, _http_request()
+                )
+
+        with (
+            patch("app.platform.security.validate_url_for_ssrf", new=AsyncMock()),
+            patch(
+                "app.processing.ingest.manifest_service._download_http_source",
+                new=download,
+            ),
+            patch(
+                "app.processing.ingest.manifest_service.queue_ingest_job",
+                new=AsyncMock(),
+            ) as queue,
+        ):
+            try:
+                async with anyio.create_task_group() as tg:
+                    tg.start_soon(_run_first)
+                    with anyio.fail_after(30):
+                        await download.started.wait()
+                        async with db_module.async_session() as retry_session:
+                            retry_user = await _admin_user(retry_session)
+                            retry = await apply_manifest(
+                                retry_session, request, retry_user, _http_request()
+                            )
+                    download.release.set()
+            finally:
+                download.release.set()
+
+        assert download.calls == 1
+        created = first["response"].results[0]
+        assert created.action == "create"
+        assert created.job_id is not None
+        queue.assert_awaited_once()
+
+        attached = retry.results[0]
+        assert attached.action == "skip"
+        assert attached.job_id == created.job_id
+        assert "queued or running" in attached.message
+
+        async with db_module.async_session() as session:
+            jobs = await _jobs_for_key(session, "manifest-1814-retry")
+        assert [job.id for job in jobs] == [created.job_id]
+        assert jobs[0].file_path is not None
+        assert MANIFEST_STAGE_METADATA_KEY not in jobs[0].user_metadata
+
+    async def test_a_different_fingerprint_during_the_download_is_refused(
+        self, client, clean_tables
+    ):
+        """The reservation answers the conflict branch too, not only the retry.
+
+        A second entry for the same key with different content used to sail
+        past the in-flight check during the download window and queue a
+        competing job over the same manifest key.
+        """
+        import app.core.db as db_module
+
+        original = _request(
+            _manifest_dataset(
+                key="manifest-1814-conflict",
+                uri="https://data.example.test/roads.geojson",
+            )
+        )
+        competing = _request(
+            _manifest_dataset(
+                key="manifest-1814-conflict",
+                title="Competing roads",
+                uri="https://data.example.test/roads.geojson",
+            )
+        )
+        download = _GatedDownload()
+        first: dict = {}
+
+        async def _run_first() -> None:
+            async with db_module.async_session() as session:
+                user = await _admin_user(session)
+                first["response"] = await apply_manifest(
+                    session, original, user, _http_request()
+                )
+
+        with (
+            patch("app.platform.security.validate_url_for_ssrf", new=AsyncMock()),
+            patch(
+                "app.processing.ingest.manifest_service._download_http_source",
+                new=download,
+            ),
+            patch(
+                "app.processing.ingest.manifest_service.queue_ingest_job",
+                new=AsyncMock(),
+            ),
+        ):
+            try:
+                async with anyio.create_task_group() as tg:
+                    tg.start_soon(_run_first)
+                    with anyio.fail_after(30):
+                        await download.started.wait()
+                        async with db_module.async_session() as other_session:
+                            other_user = await _admin_user(other_session)
+                            conflict = await apply_manifest(
+                                other_session, competing, other_user, _http_request()
+                            )
+                    download.release.set()
+            finally:
+                download.release.set()
+
+        assert download.calls == 1
+        assert first["response"].results[0].action == "create"
+        result = conflict.results[0]
+        assert result.action == "error"
+        assert "in-flight apply" in result.message
+        assert result.job_id is None
+
+        async with db_module.async_session() as session:
+            jobs = await _jobs_for_key(session, "manifest-1814-conflict")
+        assert len(jobs) == 1
+
+
+class TestReservationFailureReleasesTheKey:
+    async def test_a_failed_download_settles_the_reservation(
+        self, test_db_session, clean_tables
+    ):
+        """A download that dies leaves a terminal row, and the key free."""
+        request = _request(
+            _manifest_dataset(
+                key="manifest-1814-download-failure",
+                uri="https://data.example.test/roads.geojson",
+            )
+        )
+
+        with (
+            patch("app.platform.security.validate_url_for_ssrf", new=AsyncMock()),
+            patch(
+                "app.processing.ingest.manifest_service._download_http_source",
+                new=AsyncMock(side_effect=RuntimeError("connection reset")),
+            ),
+            patch(
+                "app.processing.ingest.manifest_service.queue_ingest_job",
+                new=AsyncMock(),
+            ) as queue,
+        ):
+            failed = await apply_manifest(
+                test_db_session,
+                request,
+                await _admin_user(test_db_session),
+                _http_request(),
+            )
+
+        assert failed.results[0].action == "error"
+        assert "connection reset" in failed.results[0].message
+        queue.assert_not_awaited()
+
+        settled = await _jobs_for_key(test_db_session, "manifest-1814-download-failure")
+        assert len(settled) == 1
+        assert settled[0].status in {"failed", "cancelled"}
+        assert settled[0].completed_at is not None
+
+        staged = _staged_bytes("manifest_1814_after_failure.geojson")
+        with (
+            patch("app.platform.security.validate_url_for_ssrf", new=AsyncMock()),
+            patch(
+                "app.processing.ingest.manifest_service._download_http_source",
+                new=AsyncMock(return_value=str(staged)),
+            ),
+            patch(
+                "app.processing.ingest.manifest_service.queue_ingest_job",
+                new=AsyncMock(),
+            ) as queue,
+        ):
+            retried = await apply_manifest(
+                test_db_session,
+                request,
+                await _admin_user(test_db_session),
+                _http_request(),
+            )
+
+        assert retried.results[0].action == "create"
+        queue.assert_awaited_once()
+        assert (
+            len(await _jobs_for_key(test_db_session, "manifest-1814-download-failure"))
+            == 2
+        )
+
+    async def test_a_reservation_settled_under_us_never_queues(
+        self, test_db_session, clean_tables
+    ):
+        """The staging bind is fenced, so a superseded attempt drops its bytes.
+
+        This is the other half of the staleness rule: a reservation expired by
+        a later apply is terminal, and the slow attempt that still owns the
+        download must not queue on top of the row that replaced it.
+        """
+        request = _request(
+            _manifest_dataset(
+                key="manifest-1814-lost",
+                uri="https://data.example.test/roads.geojson",
+            )
+        )
+        staged = _staged_bytes("manifest_1814_lost.geojson")
+
+        with (
+            patch("app.platform.security.validate_url_for_ssrf", new=AsyncMock()),
+            patch(
+                "app.processing.ingest.manifest_service._download_http_source",
+                new=AsyncMock(return_value=str(staged)),
+            ),
+            patch(
+                "app.processing.ingest.manifest_service."
+                "bind_reservation_to_staged_source",
+                new=AsyncMock(return_value=False),
+            ),
+            patch(
+                "app.processing.ingest.manifest_service.queue_ingest_job",
+                new=AsyncMock(),
+            ) as queue,
+        ):
+            response = await apply_manifest(
+                test_db_session,
+                request,
+                await _admin_user(test_db_session),
+                _http_request(),
+            )
+
+        assert response.results[0].action == "error"
+        assert "lost its reservation" in response.results[0].message
+        queue.assert_not_awaited()
+        assert not staged.exists()
+
+    async def test_a_queue_refusal_before_dispatch_still_frees_the_key(
+        self, test_db_session, clean_tables
+    ):
+        """A row that never reached the queue must not hold its key.
+
+        The orphan guard settles the row for every dispatch failure, but a
+        refusal raised before it runs would otherwise leave the entry pending
+        until the sweep.
+        """
+        _stage_fixture()
+        user = await _admin_user(test_db_session)
+        request = _request(_manifest_dataset(key="manifest-1814-queue-refusal"))
+
+        with patch(
+            "app.processing.ingest.manifest_service.queue_ingest_job",
+            new=AsyncMock(side_effect=HTTPException(status_code=400, detail="no path")),
+        ):
+            refused = await apply_manifest(
+                test_db_session, request, user, _http_request()
+            )
+
+        assert refused.results[0].action == "error"
+        settled = await _jobs_for_key(test_db_session, "manifest-1814-queue-refusal")
+        assert len(settled) == 1
+        assert settled[0].status == "failed"
+
+        with patch(
+            "app.processing.ingest.manifest_service.queue_ingest_job",
+            new=AsyncMock(),
+        ) as queue:
+            retried = await apply_manifest(
+                test_db_session, request, user, _http_request()
+            )
+
+        assert retried.results[0].action == "create"
+        queue.assert_awaited_once()
+
+    async def test_a_post_admission_failure_returns_its_bytes_to_the_batch_ledger(
+        self, test_db_session, clean_tables
+    ):
+        """Invariant 4: the request-local ledger must not keep a failed entry's
+        bytes, or a later entry in the same manifest is refused for storage
+        nobody is using."""
+        request = _request(
+            _manifest_dataset(
+                key="manifest-1814-ledger-a",
+                uri="https://data.example.test/a.geojson",
+            ),
+            _manifest_dataset(
+                key="manifest-1814-ledger-b",
+                uri="https://data.example.test/b.geojson",
+            ),
+        )
+        usage = UserQuotaUsage(
+            bytes_used=0, dataset_count=0, storage_cap=6000, count_cap=0
+        )
+        real_bind = manifest_service.bind_reservation_to_staged_source
+        binds: list[object] = []
+
+        async def _flaky_bind(db, job, *, file_path: str) -> bool:
+            binds.append(job.id)
+            if len(binds) == 1:
+                raise RuntimeError("bind interrupted")
+            return await real_bind(db, job, file_path=file_path)
+
+        downloads = 0
+
+        async def _download(prepared, *, max_size_bytes, quota_byte_limit=None) -> str:
+            nonlocal downloads
+            downloads += 1
+            return str(_staged_bytes(f"manifest_1814_ledger_{downloads}.geojson"))
+
+        with (
+            patch("app.platform.security.validate_url_for_ssrf", new=AsyncMock()),
+            patch(
+                "app.modules.quota.service.get_user_quota_usage",
+                new=AsyncMock(return_value=usage),
+            ),
+            patch("app.modules.quota.service.check_upload_quota", new=AsyncMock()),
+            patch(
+                "app.processing.ingest.manifest_service._download_http_source",
+                new=_download,
+            ),
+            patch(
+                "app.processing.ingest.manifest_service."
+                "bind_reservation_to_staged_source",
+                new=_flaky_bind,
+            ),
+            patch(
+                "app.processing.ingest.manifest_service.queue_ingest_job",
+                new=AsyncMock(),
+            ),
+        ):
+            response = await apply_manifest(
+                test_db_session,
+                request,
+                await _admin_user(test_db_session),
+                _http_request(),
+            )
+
+        assert [result.action for result in response.results] == ["error", "create"]
+        assert "bind interrupted" in response.results[0].message
+
+
+class TestStaleReservations:
+    async def test_a_stale_reservation_does_not_block_the_key(
+        self, test_db_session, clean_tables
+    ):
+        """An API process that dies mid-download must not hold a key forever."""
+        _stage_fixture()
+        user = await _admin_user(test_db_session)
+        request = _request(_manifest_dataset(key="manifest-1814-stale"))
+        prepared = await classify_manifest_source(request.datasets[0].sources[0])
+        abandoned = IngestJob(
+            source_filename=prepared.source_filename,
+            file_path=None,
+            created_by=user.id,
+            status="pending",
+            created_at=datetime.now(timezone.utc)
+            - timedelta(
+                seconds=stale_pending_cutoff_seconds(completion_bound=False) + 60
+            ),
+            user_metadata={
+                **manifest_job_metadata(
+                    request.datasets[0],
+                    prepared,
+                    fingerprint=manifest_dataset_fingerprint(request.datasets[0]),
+                ),
+                MANIFEST_STAGE_METADATA_KEY: MANIFEST_STAGE_DOWNLOADING,
+            },
+        )
+        test_db_session.add(abandoned)
+        await test_db_session.commit()
+        abandoned_id = abandoned.id
+
+        with patch(
+            "app.processing.ingest.manifest_service.queue_ingest_job",
+            new=AsyncMock(),
+        ) as queue:
+            response = await apply_manifest(
+                test_db_session, request, user, _http_request()
+            )
+
+        result = response.results[0]
+        assert result.action == "create"
+        assert result.job_id != abandoned_id
+        queue.assert_awaited_once()
+
+        reaped = await test_db_session.get(IngestJob, abandoned_id)
+        await test_db_session.refresh(reaped)
+        assert reaped.status in {"failed", "cancelled"}
+
+    async def test_a_reservation_inside_the_budget_still_holds_the_key(
+        self, test_db_session, clean_tables
+    ):
+        """The budget is the sweep's own pending cutoff, read at call time.
+
+        Pinned from both sides against the one number, so the in-flight check
+        and the background sweep cannot start disagreeing about which rows are
+        still live.
+        """
+        _stage_fixture()
+        user = await _admin_user(test_db_session)
+        request = _request(_manifest_dataset(key="manifest-1814-budget"))
+        prepared = await classify_manifest_source(request.datasets[0].sources[0])
+        budget = stale_pending_cutoff_seconds(completion_bound=False)
+        metadata = {
+            **manifest_job_metadata(
+                request.datasets[0],
+                prepared,
+                fingerprint=manifest_dataset_fingerprint(request.datasets[0]),
+            ),
+            MANIFEST_STAGE_METADATA_KEY: MANIFEST_STAGE_DOWNLOADING,
+        }
+        fresh = IngestJob(
+            source_filename=prepared.source_filename,
+            file_path=None,
+            created_by=user.id,
+            status="pending",
+            created_at=datetime.now(timezone.utc) - timedelta(seconds=budget - 60),
+            user_metadata=metadata,
+        )
+        test_db_session.add(fresh)
+        await test_db_session.commit()
+
+        assert (
+            await expire_stale_manifest_reservations(
+                test_db_session, "manifest-1814-budget"
+            )
+            == 0
+        )
+        await test_db_session.commit()
+
+        with patch(
+            "app.processing.ingest.manifest_service.queue_ingest_job",
+            new=AsyncMock(),
+        ) as queue:
+            response = await apply_manifest(
+                test_db_session, request, user, _http_request()
+            )
+
+        assert response.results[0].action == "skip"
+        assert response.results[0].job_id == fresh.id
+        queue.assert_not_awaited()
+
+    async def test_the_expiry_leaves_a_queued_manifest_job_alone(
+        self, test_db_session, clean_tables
+    ):
+        """Only rows still in the downloading stage are the expiry's business."""
+        user = await _admin_user(test_db_session)
+        request = _request(_manifest_dataset(key="manifest-1814-queued"))
+        prepared = await classify_manifest_source(request.datasets[0].sources[0])
+        queued = IngestJob(
+            source_filename=prepared.source_filename,
+            file_path="/tmp/manifest-1814-queued.geojson",
+            created_by=user.id,
+            status="pending",
+            created_at=datetime.now(timezone.utc) - timedelta(days=30),
+            user_metadata=manifest_job_metadata(
+                request.datasets[0],
+                prepared,
+                fingerprint=manifest_dataset_fingerprint(request.datasets[0]),
+            ),
+        )
+        test_db_session.add(queued)
+        await test_db_session.commit()
+
+        assert (
+            await expire_stale_manifest_reservations(
+                test_db_session, "manifest-1814-queued"
+            )
+            == 0
+        )
+
+
+class TestDryRunReservesNothing:
+    async def test_dry_run_leaves_no_reservation(self, test_db_session, clean_tables):
+        _stage_fixture()
+        user = await _admin_user(test_db_session)
+        request = _request(_manifest_dataset(key="manifest-1814-dry"), dry_run=True)
+        before = await test_db_session.scalar(select(func.count(IngestJob.id)))
+
+        with patch(
+            "app.processing.ingest.manifest_service.queue_ingest_job",
+            new=AsyncMock(),
+        ) as queue:
+            response = await apply_manifest(
+                test_db_session, request, user, _http_request()
+            )
+
+        assert response.results[0].action == "create"
+        assert response.results[0].job_id is None
+        queue.assert_not_awaited()
+        assert await test_db_session.scalar(select(func.count(IngestJob.id))) == before
+        assert await _jobs_for_key(test_db_session, "manifest-1814-dry") == []

--- a/backend/tests/test_manifest_reservation_1814.py
+++ b/backend/tests/test_manifest_reservation_1814.py
@@ -258,8 +258,8 @@ class TestReservationClosesTheDownloadWindow:
     ):
         """The reservation answers the conflict branch too, not only the retry.
 
-        A second entry with different content used to sail past the check
-        during the download window and queue a competing job over the key.
+        A second entry with different content for the same key is refused
+        during the download window rather than queueing a competing job.
         """
         import app.core.db as db_module
 
@@ -1174,6 +1174,64 @@ class TestStaleReservations:
             )
             == 0
         )
+
+
+class TestManifestJobsAreNotGenericallyRetryable:
+    async def test_generic_retry_is_refused_for_a_manifest_keyed_job(
+        self, test_db_session, clean_tables
+    ):
+        """fix(#1814): re-apply owns retries for a manifest key.
+
+        `retry_job` runs its own failed -> pending CAS without the key's
+        advisory lock, so it can queue a second job for a key a concurrent
+        re-apply is claiming.
+        """
+        from app.platform.jobs.router import get_retry_capability
+
+        staged = _staged_bytes("manifest_1814_retryable.geojson")
+        user = await _admin_user(test_db_session)
+        job = IngestJob(
+            source_filename="retryable.geojson",
+            file_path=str(staged),
+            created_by=user.id,
+            status="failed",
+            completed_at=datetime.now(timezone.utc),
+            user_metadata={"manifest_key": "manifest-1814-retryable"},
+        )
+        test_db_session.add(job)
+        await test_db_session.commit()
+
+        can_retry, reason = await get_retry_capability(job)
+
+        assert can_retry is False
+        assert "apply the manifest again" in reason.lower()
+        # The bytes are still there, so the refusal is about ownership of the
+        # key rather than a missing source.
+        assert staged.exists()
+
+    async def test_an_ordinary_failed_import_is_still_retryable(
+        self, test_db_session, clean_tables
+    ):
+        """The refusal is scoped to manifest-keyed rows."""
+        from app.platform.jobs.router import get_retry_capability
+
+        staged = _staged_bytes("manifest_1814_plain.geojson")
+        user = await _admin_user(test_db_session)
+        job = IngestJob(
+            source_filename="plain.geojson",
+            file_path=str(staged),
+            created_by=user.id,
+            status="failed",
+            completed_at=datetime.now(timezone.utc),
+            user_metadata={},
+        )
+        test_db_session.add(job)
+        await test_db_session.commit()
+
+        can_retry, reason = await get_retry_capability(job)
+
+        assert can_retry is True
+        assert reason is None
 
 
 class TestFencedWritesAreSingleStatements:

--- a/backend/tests/test_manifest_reservation_1814.py
+++ b/backend/tests/test_manifest_reservation_1814.py
@@ -16,13 +16,17 @@ from unittest.mock import AsyncMock, patch
 import anyio
 import pytest
 from fastapi import HTTPException, Request
-from sqlalchemy import func, select
+from sqlalchemy import func, select, text, update
 
 from app.core.config import settings
 from app.modules.auth.models import User
 from app.modules.quota.schemas import UserQuotaUsage
 from app.platform.jobs.models import IngestJob
-from app.platform.jobs.sweep import stale_pending_cutoff_seconds
+from app.platform.jobs.sweep import (
+    JOB_TIMEOUT_SECONDS,
+    fail_stale_jobs,
+    stale_pending_cutoff_seconds,
+)
 from app.processing.ingest import manifest_service
 from app.processing.ingest.manifest_reservation import (
     MANIFEST_STAGE_DOWNLOADING,
@@ -100,10 +104,14 @@ def _staged_bytes(name: str, size: int = 4096) -> Path:
 
 
 async def _jobs_for_key(session, key: str) -> list[IngestJob]:
+    # populate_existing, because these assertions are about the row and a
+    # settlement written as a fenced UPDATE does not reach the identity map.
+    # Narrower than expire_all(), which would also expire the caller's own User.
     result = await session.execute(
         select(IngestJob)
         .where(IngestJob.user_metadata["manifest_key"].astext == key)
         .order_by(IngestJob.created_at)
+        .execution_options(populate_existing=True)
     )
     return list(result.scalars())
 
@@ -387,6 +395,84 @@ class TestReservationFailureReleasesTheKey:
         queue.assert_not_awaited()
         assert not staged.exists()
 
+    async def test_a_database_failure_during_the_bind_still_clears_the_key(
+        self, test_db_session, clean_tables
+    ):
+        """fix(#1814 codex r1): the settlement runs on a reset session.
+
+        A statement that failed leaves the transaction refusing every further
+        statement, so a settlement issued straight onto it raises too. Before
+        the reset, the reservation stayed pending in the downloading stage and
+        every re-apply attached to a job that would never queue.
+        """
+        request = _request(
+            _manifest_dataset(
+                key="manifest-1814-poisoned",
+                uri="https://data.example.test/roads.geojson",
+            )
+        )
+        staged = _staged_bytes("manifest_1814_poisoned.geojson")
+
+        async def _poisoning_bind(db, job, *, file_path: str) -> bool:
+            await db.execute(text("SELECT 1 / 0"))
+            return True
+
+        with (
+            patch("app.platform.security.validate_url_for_ssrf", new=AsyncMock()),
+            patch(
+                "app.processing.ingest.manifest_service._download_http_source",
+                new=AsyncMock(return_value=str(staged)),
+            ),
+            patch(
+                "app.processing.ingest.manifest_service."
+                "bind_reservation_to_staged_source",
+                new=_poisoning_bind,
+            ),
+            patch(
+                "app.processing.ingest.manifest_service.queue_ingest_job",
+                new=AsyncMock(),
+            ) as queue,
+        ):
+            response = await apply_manifest(
+                test_db_session,
+                request,
+                await _admin_user(test_db_session),
+                _http_request(),
+            )
+
+        assert response.results[0].action == "error"
+        queue.assert_not_awaited()
+        assert not staged.exists()
+
+        settled = await _jobs_for_key(test_db_session, "manifest-1814-poisoned")
+        assert len(settled) == 1
+        assert settled[0].status in {"failed", "cancelled"}
+        assert MANIFEST_STAGE_METADATA_KEY not in (settled[0].user_metadata or {})
+
+        # The key is free: a re-apply creates its own job instead of attaching.
+        retry_staged = _staged_bytes("manifest_1814_poisoned_retry.geojson")
+        with (
+            patch("app.platform.security.validate_url_for_ssrf", new=AsyncMock()),
+            patch(
+                "app.processing.ingest.manifest_service._download_http_source",
+                new=AsyncMock(return_value=str(retry_staged)),
+            ),
+            patch(
+                "app.processing.ingest.manifest_service.queue_ingest_job",
+                new=AsyncMock(),
+            ) as queue,
+        ):
+            retried = await apply_manifest(
+                test_db_session,
+                request,
+                await _admin_user(test_db_session),
+                _http_request(),
+            )
+
+        assert retried.results[0].action == "create"
+        assert retried.results[0].job_id != settled[0].id
+        queue.assert_awaited_once()
+
     async def test_a_queue_refusal_before_dispatch_still_frees_the_key(
         self, test_db_session, clean_tables
     ):
@@ -492,6 +578,122 @@ class TestReservationFailureReleasesTheKey:
 
 
 class TestStaleReservations:
+    """The reservation runs under the fixed running lease, not the pending one.
+
+    fix(#1814 audit): a committed `pending` row with no file_path and no queue
+    task matches every clause of `stale_pending_clauses`, and
+    `pending_job_timeout_seconds` may legally be 61s while a manifest download
+    has no wall-clock bound of its own. The reservation was therefore reapable
+    mid-flight by the sweep, the worker's startup recovery, the status poll and
+    the next apply, and every retry repeated the loss.
+    """
+
+    def _reservation(self, user, dataset, prepared, *, age_seconds: float) -> IngestJob:
+        return IngestJob(
+            source_filename=prepared.source_filename,
+            file_path=None,
+            created_by=user.id,
+            status="running",
+            started_at=datetime.now(timezone.utc) - timedelta(seconds=age_seconds),
+            user_metadata={
+                **manifest_job_metadata(
+                    dataset,
+                    prepared,
+                    fingerprint=manifest_dataset_fingerprint(dataset),
+                ),
+                MANIFEST_STAGE_METADATA_KEY: MANIFEST_STAGE_DOWNLOADING,
+            },
+        )
+
+    async def test_a_live_download_survives_the_pending_sweep(
+        self, client, clean_tables
+    ):
+        """The audit's counterfactual: a download older than the pending cutoff.
+
+        Aged past `pending_job_timeout_seconds` with its lease still fresh, then
+        put through the real `fail_stale_jobs`. Before the lease it came back
+        `cancelled` mid-download, the staging bind then matched nothing, and the
+        entry answered "lost its reservation" for every retry.
+        """
+        import app.core.db as db_module
+
+        key = "manifest-1814-long-download"
+        request = _request(
+            _manifest_dataset(key=key, uri="https://data.example.test/big.geojson")
+        )
+        download = _GatedDownload()
+        first: dict = {}
+        observed: dict = {}
+
+        async def _run_first() -> None:
+            async with db_module.async_session() as session:
+                user = await _admin_user(session)
+                first["response"] = await apply_manifest(
+                    session, request, user, _http_request()
+                )
+
+        with (
+            patch("app.platform.security.validate_url_for_ssrf", new=AsyncMock()),
+            patch(
+                "app.processing.ingest.manifest_service._download_http_source",
+                new=download,
+            ),
+            patch(
+                "app.processing.ingest.manifest_service.queue_ingest_job",
+                new=AsyncMock(),
+            ) as queue,
+        ):
+            try:
+                async with anyio.create_task_group() as tg:
+                    tg.start_soon(_run_first)
+                    with anyio.fail_after(60):
+                        await download.started.wait()
+                        async with db_module.async_session() as sweeper:
+                            now = datetime.now(timezone.utc)
+                            aged = now - timedelta(
+                                seconds=stale_pending_cutoff_seconds(
+                                    completion_bound=False
+                                )
+                                + 600
+                            )
+                            await sweeper.execute(
+                                update(IngestJob)
+                                .where(
+                                    IngestJob.user_metadata["manifest_key"].astext
+                                    == key
+                                )
+                                .values(created_at=aged, started_at=now)
+                                .execution_options(synchronize_session=False)
+                            )
+                            await sweeper.commit()
+                            await fail_stale_jobs(sweeper, detailed=True)
+                            sweeper.expire_all()
+                            observed["status"] = (
+                                await sweeper.execute(
+                                    select(IngestJob.status).where(
+                                        IngestJob.user_metadata["manifest_key"].astext
+                                        == key
+                                    )
+                                )
+                            ).scalar_one()
+                    download.release.set()
+            finally:
+                download.release.set()
+
+        assert observed["status"] == "running"
+        created = first["response"].results[0]
+        assert created.action == "create"
+        queue.assert_awaited_once()
+
+        async with db_module.async_session() as session:
+            bound = (await _jobs_for_key(session, key))[0]
+        assert bound.status == "pending"
+        assert bound.file_path is not None
+        assert MANIFEST_STAGE_METADATA_KEY not in bound.user_metadata
+        # The pending clock restarts at staging, not at a creation that predates
+        # the whole download.
+        assert bound.user_metadata["staged_at"] is not None
+
     async def test_a_stale_reservation_does_not_block_the_key(
         self, test_db_session, clean_tables
     ):
@@ -500,23 +702,11 @@ class TestStaleReservations:
         user = await _admin_user(test_db_session)
         request = _request(_manifest_dataset(key="manifest-1814-stale"))
         prepared = await classify_manifest_source(request.datasets[0].sources[0])
-        abandoned = IngestJob(
-            source_filename=prepared.source_filename,
-            file_path=None,
-            created_by=user.id,
-            status="pending",
-            created_at=datetime.now(timezone.utc)
-            - timedelta(
-                seconds=stale_pending_cutoff_seconds(completion_bound=False) + 60
-            ),
-            user_metadata={
-                **manifest_job_metadata(
-                    request.datasets[0],
-                    prepared,
-                    fingerprint=manifest_dataset_fingerprint(request.datasets[0]),
-                ),
-                MANIFEST_STAGE_METADATA_KEY: MANIFEST_STAGE_DOWNLOADING,
-            },
+        abandoned = self._reservation(
+            user,
+            request.datasets[0],
+            prepared,
+            age_seconds=JOB_TIMEOUT_SECONDS + 60,
         )
         test_db_session.add(abandoned)
         await test_db_session.commit()
@@ -535,14 +725,16 @@ class TestStaleReservations:
         assert result.job_id != abandoned_id
         queue.assert_awaited_once()
 
-        reaped = await test_db_session.get(IngestJob, abandoned_id)
-        await test_db_session.refresh(reaped)
-        assert reaped.status in {"failed", "cancelled"}
+        reaped = await test_db_session.get(
+            IngestJob, abandoned_id, populate_existing=True
+        )
+        assert reaped.status == "failed"
+        assert MANIFEST_STAGE_METADATA_KEY not in reaped.user_metadata
 
-    async def test_a_reservation_inside_the_budget_still_holds_the_key(
+    async def test_a_reservation_inside_the_lease_still_holds_the_key(
         self, test_db_session, clean_tables
     ):
-        """The budget is the sweep's own pending cutoff, read at call time.
+        """The budget is the running sweep's own lease, read at call time.
 
         Pinned from both sides against the one number, so the in-flight check
         and the background sweep cannot start disagreeing about which rows are
@@ -552,22 +744,11 @@ class TestStaleReservations:
         user = await _admin_user(test_db_session)
         request = _request(_manifest_dataset(key="manifest-1814-budget"))
         prepared = await classify_manifest_source(request.datasets[0].sources[0])
-        budget = stale_pending_cutoff_seconds(completion_bound=False)
-        metadata = {
-            **manifest_job_metadata(
-                request.datasets[0],
-                prepared,
-                fingerprint=manifest_dataset_fingerprint(request.datasets[0]),
-            ),
-            MANIFEST_STAGE_METADATA_KEY: MANIFEST_STAGE_DOWNLOADING,
-        }
-        fresh = IngestJob(
-            source_filename=prepared.source_filename,
-            file_path=None,
-            created_by=user.id,
-            status="pending",
-            created_at=datetime.now(timezone.utc) - timedelta(seconds=budget - 60),
-            user_metadata=metadata,
+        fresh = self._reservation(
+            user,
+            request.datasets[0],
+            prepared,
+            age_seconds=JOB_TIMEOUT_SECONDS - 60,
         )
         test_db_session.add(fresh)
         await test_db_session.commit()
@@ -603,8 +784,8 @@ class TestStaleReservations:
             source_filename=prepared.source_filename,
             file_path="/tmp/manifest-1814-queued.geojson",
             created_by=user.id,
-            status="pending",
-            created_at=datetime.now(timezone.utc) - timedelta(days=30),
+            status="running",
+            started_at=datetime.now(timezone.utc) - timedelta(days=30),
             user_metadata=manifest_job_metadata(
                 request.datasets[0],
                 prepared,

--- a/backend/tests/test_manifest_reservation_1814.py
+++ b/backend/tests/test_manifest_reservation_1814.py
@@ -1,9 +1,7 @@
 """fix(#1814): a manifest entry claims its key before its source is fetched.
 
-The apply loop used to insert the ``IngestJob`` row only after the entry's
-source had finished downloading, so the in-flight check and the row that makes
-it true were separated by a network fetch. A client that timed out mid-download
-and retried passed the check a second time and queued the same entry twice.
+The in-flight check and the row that makes it true were separated by a network
+fetch, so a client that timed out mid-download and retried queued it twice.
 """
 
 from __future__ import annotations
@@ -121,10 +119,8 @@ async def _jobs_for_key(session, key: str) -> list[IngestJob]:
 def _ingest_job_writes(session):
     """Record every INSERT and UPDATE issued against ``catalog.ingest_jobs``.
 
-    Listens on the session's sync engine, so it sees what the database was
-    actually asked to do rather than what the ORM was asked to do. Each entry
-    carries its rowcount, so a caller can ask either question: did anything
-    reach the table at all, or did anything change a row.
+    Listens on the sync engine, so it sees what the database was asked to do.
+    Each entry carries its rowcount, so a caller can ask either question.
     """
     bind = session.get_bind()
     engine = getattr(bind, "sync_engine", bind)
@@ -187,10 +183,8 @@ class TestReservationClosesTheDownloadWindow:
     ):
         """The defect, end to end.
 
-        Two applies of one entry, the second submitted while the first is
-        still downloading. Before the reservation, both passed the in-flight
-        check and both downloaded and queued: the CLI's documented
-        "re-applying immediately can queue that entry twice".
+        Two applies of one entry, the second submitted mid-download. Before
+        the reservation both passed the check, downloaded, and queued.
         """
         import app.core.db as db_module
 
@@ -257,9 +251,8 @@ class TestReservationClosesTheDownloadWindow:
     ):
         """The reservation answers the conflict branch too, not only the retry.
 
-        A second entry for the same key with different content used to sail
-        past the in-flight check during the download window and queue a
-        competing job over the same manifest key.
+        A second entry with different content used to sail past the check
+        during the download window and queue a competing job over the key.
         """
         import app.core.db as db_module
 
@@ -393,9 +386,8 @@ class TestReservationFailureReleasesTheKey:
     ):
         """The staging bind is fenced, so a superseded attempt drops its bytes.
 
-        This is the other half of the staleness rule: a reservation expired by
-        a later apply is terminal, and the slow attempt that still owns the
-        download must not queue on top of the row that replaced it.
+        The other half of the staleness rule: a slow attempt whose reservation
+        was expired must not queue on top of the row that replaced it.
         """
         request = _request(
             _manifest_dataset(
@@ -436,12 +428,10 @@ class TestReservationFailureReleasesTheKey:
     async def test_a_database_failure_during_the_bind_still_clears_the_key(
         self, test_db_session, clean_tables
     ):
-        """fix(#1814 codex r1): the settlement runs on a reset session.
+        """fix(#1814): the settlement runs on a reset session.
 
-        A statement that failed leaves the transaction refusing every further
-        statement, so a settlement issued straight onto it raises too. Before
-        the reset, the reservation stayed pending in the downloading stage and
-        every re-apply attached to a job that would never queue.
+        A failed statement leaves the transaction refusing every further one,
+        so a settlement issued straight onto it raises there too.
         """
         request = _request(
             _manifest_dataset(
@@ -516,9 +506,8 @@ class TestReservationFailureReleasesTheKey:
     ):
         """A row that never reached the queue must not hold its key.
 
-        The orphan guard settles the row for every dispatch failure, but a
-        refusal raised before it runs would otherwise leave the entry pending
-        until the sweep.
+        The orphan guard covers every dispatch failure; a refusal raised
+        before it runs would otherwise leave the entry pending until the sweep.
         """
         _stage_fixture()
         user = await _admin_user(test_db_session)
@@ -553,9 +542,8 @@ class TestReservationFailureReleasesTheKey:
     ):
         """fix(#1814): the reservation insert is ambiguous too.
 
-        A durable insert whose acknowledgement is lost used to leave a running
-        row holding the key with nothing that would ever stage or queue it, and
-        every re-apply reported skip until the lease expired.
+        A durable insert whose acknowledgement is lost left a running row
+        holding the key with nothing that would ever stage or queue it.
         """
         _stage_fixture()
         user = await _admin_user(test_db_session)
@@ -638,10 +626,8 @@ class TestReservationFailureReleasesTheKey:
     ):
         """fix(#1814): the row decides the cleanup, not the exception.
 
-        A commit can be durable in PostgreSQL and still raise on the
-        acknowledgement. Deciding from the exception deleted the staged source
-        and left a `pending` row pointing at nothing, with no queued task, and
-        every re-apply attached to it until the sweep ran.
+        Deciding from the exception deleted the staged source and left a
+        pending row pointing at nothing, with no queued task.
         """
         request = _request(
             _manifest_dataset(
@@ -873,9 +859,8 @@ class TestReservationFailureReleasesTheKey:
 class TestStaleReservations:
     """The reservation runs under the fixed running lease, not the pending one.
 
-    fix(#1814): a pending row with no file_path and no queue task is reapable by
-    four actors while its source is still downloading, and
-    `pending_job_timeout_seconds` may legally be 61s. The fixed lease is not.
+    fix(#1814): a pending row with no file_path and no queue task is reapable
+    by four actors mid-download, and the pending timeout may legally be 61s.
     """
 
     def _reservation(self, user, dataset, prepared, *, age_seconds: float) -> IngestJob:
@@ -898,12 +883,10 @@ class TestStaleReservations:
     async def test_a_live_download_survives_the_pending_sweep(
         self, client, clean_tables
     ):
-        """The audit's counterfactual: a download older than the pending cutoff.
+        """A live download older than the pending cutoff, through the real sweep.
 
-        Aged past `pending_job_timeout_seconds` with its lease still fresh, then
-        put through the real `fail_stale_jobs`. Before the lease it came back
-        `cancelled` mid-download, the staging bind then matched nothing, and the
-        entry answered "lost its reservation" for every retry.
+        Aged past the pending timeout with its lease fresh. Before the lease it
+        came back `cancelled` mid-download and the bind then matched nothing.
         """
         import app.core.db as db_module
 
@@ -1027,8 +1010,7 @@ class TestStaleReservations:
         """The budget is the running sweep's own lease, read at call time.
 
         Pinned from both sides against the one number, so the in-flight check
-        and the background sweep cannot start disagreeing about which rows are
-        still live.
+        and the sweep cannot disagree about which rows are live.
         """
         _stage_fixture()
         user = await _admin_user(test_db_session)
@@ -1096,9 +1078,8 @@ class TestStaleReservations:
 class TestFencedWritesAreSingleStatements:
     """One fenced UPDATE per transition, not a fenced one plus an ORM flush.
 
-    fix(#1814): the instance must describe the row after a fenced write, but
-    plain assignment marks it dirty and the caller's commit then flushes a
-    second, unfenced update. `set_committed_value` writes committed state.
+    fix(#1814): plain assignment marks the instance dirty, so the caller's
+    commit flushes a second, unfenced update over the fenced one.
     """
 
     async def test_the_staging_bind_emits_one_update(
@@ -1170,10 +1151,8 @@ class TestDryRunReservesNothing:
     ):
         """fix(#1814): a preview is a read.
 
-        The staleness expiry used to run before the dry-run return, so a
-        preview settled another caller's abandoned reservation. It now runs
-        only for a real apply, at the cost that a preview can still report an
-        entry in flight where an apply would take it.
+        The expiry runs only for a real apply, at the cost that a preview can
+        report an entry in flight where an apply would take it.
         """
         _stage_fixture()
         user = await _admin_user(test_db_session)

--- a/backend/tests/test_tenant_control_plane_isolation.py
+++ b/backend/tests/test_tenant_control_plane_isolation.py
@@ -13,7 +13,7 @@ from app.core.config import settings
 from app.modules.admin.service import AdminService
 from app.modules.auth.dependencies import require_mode_permission
 from app.modules.catalog.maps.service_public import revoke_share_token
-from app.processing.ingest.manifest_service import _latest_in_flight_manifest_job
+from app.processing.ingest.manifest_reservation import latest_in_flight_manifest_job
 from app.processing.ingest.service import get_job_or_404
 
 
@@ -99,7 +99,7 @@ async def test_manifest_in_flight_lookup_relies_on_durable_rls_scope(multi_tenan
     db = AsyncMock()
     db.execute.return_value = result
 
-    assert await _latest_in_flight_manifest_job(db, "shared-key") is None
+    assert await latest_in_flight_manifest_job(db, "shared-key") is None
 
     sql = str(db.execute.await_args.args[0])
     assert "catalog.ingest_jobs" in sql

--- a/cli/geolens_cli/main.py
+++ b/cli/geolens_cli/main.py
@@ -450,14 +450,11 @@ def apply_manifest_command(
         # output.error()/warn() writes bleeding into it.
         #
         # fix(#1778 review round 19): dropped the "resumable": True
-        # field -- it claimed re-running immediately was always safe,
-        # which is not true (see build_apply_timeout_message()'s
-        # docstring: an entry whose source was still downloading when
-        # the timeout hit has no job row yet, so an immediate re-apply
-        # can queue it twice). "guidance" carries the same accurate,
-        # non-blanket explanation --json gets that a human running the
+        # field, because a bare boolean cannot say which entries a
+        # re-apply would skip and which it would apply. "guidance"
+        # carries the explanation --json gets that a human running the
         # same command interactively already sees via report_apply_
-        # timeout(), instead of a bare boolean.
+        # timeout().
         if state.json_mode:
             status = _manifest_apply.attempt_apply_timeout_status_check(
                 sdk.client, payload

--- a/cli/geolens_cli/main.py
+++ b/cli/geolens_cli/main.py
@@ -436,25 +436,9 @@ def apply_manifest_command(
             sdk.client, payload, timeout=resolved_timeout
         )
     except _manifest_apply.ManifestApplyTimeout as exc:
-        # fix(#1778 review round 18): a batch-aware POST timeout is
-        # reported distinctly from a plain request failure -- the
-        # server keeps applying after this client gives up, and an
-        # entry it has already queued or completed is skipped on a
-        # later re-apply, so this is NOT the same "the operation
-        # failed" shape as ManifestApplyRequestError below. Both
-        # branches attempt the same best-effort dry-run status
-        # follow-up (report_apply_timeout / attempt_apply_timeout_
-        # status_check are the human- and json-mode halves of the
-        # same round-18 part (c) logic) so --json gets exactly one
-        # structured payload instead of report_apply_timeout's own
-        # output.error()/warn() writes bleeding into it.
-        #
-        # fix(#1778 review round 19): dropped the "resumable": True
-        # field, because a bare boolean cannot say which entries a
-        # re-apply would skip and which it would apply. "guidance"
-        # carries the explanation --json gets that a human running the
-        # same command interactively already sees via report_apply_
-        # timeout().
+        # fix(#1778): a batch-aware POST timeout is not the failure shape
+        # ManifestApplyRequestError is, because the server keeps applying. Both
+        # branches do one dry-run follow-up, so --json emits one payload.
         if state.json_mode:
             status = _manifest_apply.attempt_apply_timeout_status_check(
                 sdk.client, payload

--- a/cli/geolens_cli/manifest_apply.py
+++ b/cli/geolens_cli/manifest_apply.py
@@ -485,56 +485,31 @@ def attempt_apply_timeout_status_check(
     to report which entries the server had already reached. Returns
     ``None`` if the follow-up itself failed or timed out.
 
-    fix(#1778 review round 18) part (c): ``dry_run=True`` on this SAME
-    endpoint already classifies every entry
-    (create/update/skip_complete/skip_in_flight) WITHOUT downloading or
-    queuing anything — ``_stage_source_if_needed`` (backend/app/
-    processing/ingest/manifest_service.py) short-circuits before the
-    network fetch when ``dry_run``. That makes it materially cheaper
-    than the apply that just timed out, and it is EXACTLY the "which
-    entries completed" answer: this PR does not add a separate status
-    or job-listing endpoint (out of scope — no async job mode), because
-    the existing dry-run classification on this same endpoint already
-    covers the question.
+    ``dry_run=True`` on this same endpoint classifies every entry
+    (create/update/skip_complete/skip_in_flight) without downloading or
+    queuing anything, which makes it materially cheaper than the apply that
+    just timed out and is exactly the "which entries did the server reach"
+    answer.
 
-    fix(#1778 review round 19): bounded by
-    ``MANIFEST_APPLY_STATUS_CHECK_TIMEOUT_SECONDS`` (a short, FIXED
-    30s) rather than the entry-scaled budget the real apply needed —
-    ``dry_run`` does no download/queue work, so its own cost does not
-    grow with entry count. Best-effort either way: if the follow-up
-    ALSO fails or times out, the entry-by-entry answer just was not
-    available right now. This does NOT mean re-running is therefore
-    safe — see ``build_apply_timeout_message``'s docstring for why an
-    entry that was mid-download when the ORIGINAL request timed out is
-    invisible to this check too (no job row exists for it yet either
-    way), so its absence from a "settled" classification specifically
-    does not distinguish "not reached" from "actively downloading,
-    about to double-queue if you re-apply right now".
+    fix(#1814): an entry still being staged holds a reservation and classifies
+    ``skip_in_flight``, so absence from the answer means the server had not
+    reached that entry.
+
+    Bounded by ``MANIFEST_APPLY_STATUS_CHECK_TIMEOUT_SECONDS``, a short fixed
+    30s rather than the entry-scaled budget the real apply needed, because
+    ``dry_run`` does no download or queue work. Best-effort: if the follow-up
+    also fails or times out, the entry-by-entry answer was not available.
 
     Side-effect-free (no ``output`` printing) so a ``--json`` caller
     can build one clean structured payload from the result instead of
     inheriting rich-console/stderr writes meant for a human — see
     ``report_apply_timeout`` for that human-mode convenience wrapper.
 
-    fix(#1778 review round 21): only caught ``ManifestApplyTimeout``/
-    ``ManifestApplyRequestError`` -- both raised by
-    ``post_manifest_apply`` itself once it has a response (or a clean
-    timeout) to reason about. A plain network failure (connection
-    refused/reset) never reaches either: ``call_sdk()`` maps
-    ``httpx.NetworkError`` straight to ``typer.Exit(EXIT_NETWORK)``
-    on its own, which propagated uncaught here and blew up the whole
-    ``--json`` branch in main.py before it could ever emit the
-    promised single structured payload -- the ORIGINAL timeout's
-    result never reached the caller at all. This is best-effort
-    by design (see the module docstring above); ANY failure during the
-    follow-up must degrade to "status unavailable," not crash the
-    command that is already in its error-reporting path. Catches
-    ``typer.Exit`` explicitly (even though it is technically also an
-    ``Exception`` — ``click.exceptions.Exit`` subclasses
-    ``RuntimeError``) for clarity at the call site about exactly which
-    shape this is guarding against, alongside the deliberately broad
-    ``Exception`` catch-all for anything else the follow-up could
-    raise.
+    Catches every failure shape the follow-up can raise, including
+    ``typer.Exit`` (which ``call_sdk`` raises for a plain network error, and
+    which subclasses ``RuntimeError`` rather than ``Exception``). Any failure
+    here must degrade to "status unavailable" rather than crash a command
+    already in its error-reporting path.
     """
     status_payload = dict(payload)
     status_payload["dry_run"] = True

--- a/cli/geolens_cli/manifest_apply.py
+++ b/cli/geolens_cli/manifest_apply.py
@@ -466,22 +466,15 @@ def build_apply_timeout_message(exc: ManifestApplyTimeout) -> str:
     ``manifest_dataset_fingerprint`` — and reports ``skip_complete``
     for a matching fingerprint instead of reprocessing it).
 
-    fix(#1778 review round 19): round 18's message ALSO claimed
-    re-running the exact same command was therefore always safe
-    immediately — that is not true, and this docstring exists to make
-    sure nobody re-adds the claim. ``_classify_dataset()`` checks for
-    an in-flight job BEFORE ``_create_job_and_queue()`` downloads the
-    entry's source, and the ``IngestJob`` row is only inserted AFTER
-    that download finishes (manifest_service.py). So while an entry's
-    source is still downloading when this timeout hits, the server has
-    no job row for it yet — a second apply submitted during that exact
-    window classifies the SAME entry as ``create`` again and queues it
-    a second time. A server-side reservation that closed this window
-    would be a backend change and is OUT OF SCOPE here (no
-    ``backend/app`` files in this PR); the honest fix on the CLI side
-    is to say so, not to promise blanket idempotency the server does
-    not yet provide for an entry that was mid-download at the exact
-    moment this request gave up.
+    fix(#1814): the window round 19 had to warn about is closed. The
+    server reserves an entry's ``IngestJob`` row BEFORE fetching its
+    source, under a lock on the manifest key, so an entry that was
+    mid-download when this timeout hit is already visible as in flight.
+    A re-apply of the same manifest attaches to that job and reports it
+    as a skip instead of downloading and queueing the entry a second
+    time. The message says what a re-apply does; it still makes no
+    blanket safety claim, because an entry the server had not yet
+    reached is simply applied on the re-run.
 
     fix(#1778 review round 21): the ``budget`` this timeout used is
     only ever a HEURISTIC LOWER BOUND (see
@@ -502,17 +495,14 @@ def build_apply_timeout_message(exc: ManifestApplyTimeout) -> str:
         f"Manifest apply timed out {budget_phrase} "
         f"({exc.entry_count} dataset(s) submitted). The server does "
         "NOT stop applying when this request does -- it keeps "
-        "processing the manifest sequentially, and entries it has "
-        "already queued or completed are skipped on a later re-apply. "
-        "But the entry whose source was still downloading when this "
-        "timeout hit is NOT yet visible as queued (the server only "
-        "records it once the download finishes), so re-applying "
-        "immediately can queue that entry twice. Check the catalog for "
-        "datasets still pending, or run `geolens apply --dry-run "
-        "<path>` to see which entries the server has already settled, "
-        "before re-running this exact command. Or re-run with "
-        "`--timeout 0` to wait for the server, or a larger value, if "
-        "the manifest's own sources are just legitimately slow."
+        "processing the manifest sequentially. Every entry it has "
+        "reached is recorded before its source is downloaded, so "
+        "re-running this exact command attaches to an entry still "
+        "being staged and skips one already queued or completed. Run "
+        "`geolens apply --dry-run <path>` to see which entries the "
+        "server has already settled. Or re-run with `--timeout 0` to "
+        "wait for the server, or a larger value, if the manifest's own "
+        "sources are just legitimately slow."
     )
 
 
@@ -610,10 +600,10 @@ def report_apply_timeout(
             "Could not retrieve a completion status for this manifest "
             "right now (the status check itself failed or timed out "
             f"after {MANIFEST_APPLY_STATUS_CHECK_TIMEOUT_SECONDS:.0f}s). "
-            "Check the catalog for datasets still pending before "
-            "re-running -- an entry that was still downloading when "
-            "the original request timed out is not yet visible as "
-            "queued, and re-applying too soon can queue it twice."
+            "Re-running the same command is still the way forward: the "
+            "server records each entry before downloading its source, "
+            "so a re-apply attaches to one still being staged rather "
+            "than queueing it again."
         )
     return status
 

--- a/cli/geolens_cli/manifest_apply.py
+++ b/cli/geolens_cli/manifest_apply.py
@@ -455,30 +455,8 @@ def post_manifest_apply(
 def build_apply_timeout_message(exc: ManifestApplyTimeout) -> str:
     """Human-readable explanation for a batch-aware apply timeout.
 
-    fix(#1778 review round 18) part (b): the CLI giving up here does
-    NOT mean the apply failed. ``apply_manifest()`` (backend/app/
-    processing/ingest/manifest_service.py) keeps processing the
-    manifest SEQUENTIALLY after this client stops waiting — a POST
-    already accepted by the ASGI server runs to completion there
-    regardless of whether the CLI is still listening, so entries
-    already committed and queued stay committed and queued, and a
-    later re-apply skips them (the server fingerprints each dataset —
-    ``manifest_dataset_fingerprint`` — and reports ``skip_complete``
-    for a matching fingerprint instead of reprocessing it).
-
-    fix(#1814): the server reserves an entry's ``IngestJob`` row BEFORE
-    fetching its source, so a re-apply attaches to one still being staged.
-    The message says that, and still makes no blanket safety claim.
-
-    fix(#1778 review round 21): the ``budget`` this timeout used is
-    only ever a HEURISTIC LOWER BOUND (see
-    ``compute_manifest_apply_timeout``'s docstring) derived from the
-    API's documented per-request inactivity (read) timeout on a
-    source download — not a download deadline. A slow-but-still-active
-    large source can legitimately outlast it while the apply is still
-    succeeding server-side, so the message now names the escape hatch:
-    ``--timeout 0`` (or a larger explicit value) waits for the server
-    instead of guessing again with a bigger heuristic.
+    fix(#1778, #1814): the CLI giving up does not stop the server, which
+    reserves each entry before fetching, so a re-apply attaches or skips.
     """
     budget_phrase = (
         "with no client-side timeout"

--- a/cli/geolens_cli/manifest_apply.py
+++ b/cli/geolens_cli/manifest_apply.py
@@ -466,15 +466,9 @@ def build_apply_timeout_message(exc: ManifestApplyTimeout) -> str:
     ``manifest_dataset_fingerprint`` — and reports ``skip_complete``
     for a matching fingerprint instead of reprocessing it).
 
-    fix(#1814): the window round 19 had to warn about is closed. The
-    server reserves an entry's ``IngestJob`` row BEFORE fetching its
-    source, under a lock on the manifest key, so an entry that was
-    mid-download when this timeout hit is already visible as in flight.
-    A re-apply of the same manifest attaches to that job and reports it
-    as a skip instead of downloading and queueing the entry a second
-    time. The message says what a re-apply does; it still makes no
-    blanket safety claim, because an entry the server had not yet
-    reached is simply applied on the re-run.
+    fix(#1814): the server reserves an entry's ``IngestJob`` row BEFORE
+    fetching its source, so a re-apply attaches to one still being staged.
+    The message says that, and still makes no blanket safety claim.
 
     fix(#1778 review round 21): the ``budget`` this timeout used is
     only ever a HEURISTIC LOWER BOUND (see

--- a/cli/tests/test_manifest_apply.py
+++ b/cli/tests/test_manifest_apply.py
@@ -325,12 +325,8 @@ class TestResolveApplyTimeout:
 
 class TestManifestApplyTimeoutReporting:
     """fix(#1778 review round 18) parts (b)/(c), corrected by #1814: the
-    timeout path must be unambiguous. The server keeps applying after the
-    CLI gives up, and #1814 reserves an entry's row before downloading its
-    source, so a re-apply attaches rather than queueing it twice. A dry-run
-    follow-up on the SAME endpoint, bounded by a short fixed timeout
-    regardless of entry count (round 19 P2), reports which entries the
-    server had already reached, best-effort."""
+    server keeps applying after the CLI gives up, and reserves an entry's row
+    before downloading, so a re-apply attaches rather than queueing twice."""
 
     def _timing_out_client(self) -> FakeSdkClient:
         client = FakeSdkClient(FakeResponse(200, _apply_response()))
@@ -1034,10 +1030,9 @@ def test_apply_command_reports_timeout_with_truthful_guidance_and_status_check(
     tmp_xdg_home,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """fix(#1778 review round 18) end-to-end: the `apply` command's own
-    timeout handling prints the guidance and renders the dry-run follow-up's
-    status, rather than the old bare "Request timed out". fix(#1814): that
-    guidance now says a re-run attaches to an entry still being staged."""
+    """fix(#1778 review round 18) end-to-end: the `apply` command prints the
+    guidance and renders the dry-run follow-up's status. fix(#1814): that
+    guidance says a re-run attaches to an entry still being staged."""
     status_response = _apply_response(
         results=[
             {"dataset_key": "roads", "action": "skip", "message": "skip_complete"}

--- a/cli/tests/test_manifest_apply.py
+++ b/cli/tests/test_manifest_apply.py
@@ -324,21 +324,18 @@ class TestResolveApplyTimeout:
 
 
 class TestManifestApplyTimeoutReporting:
-    """fix(#1778 review round 18) parts (b)/(c), corrected by round 19:
-    the timeout path must be unambiguous -- the server keeps applying
-    after the CLI gives up, and an entry it has already queued or
-    completed is skipped on a later re-apply. Round 18 additionally
-    claimed re-running the SAME command was therefore always safe
-    immediately; round 19 removes that claim, because it is false: an
-    entry whose source was still downloading when the timeout hit has
-    no job row yet (_classify_dataset()'s in-flight check runs before
-    _create_job_and_queue()'s download, and the IngestJob row is only
-    inserted after it -- manifest_service.py), so re-applying right
-    away can queue that entry twice. A dry-run follow-up on the SAME
-    endpoint (no new status/job-listing endpoint -- out of scope, no
-    async job mode), bounded by a short fixed timeout regardless of
-    entry count (round 19 P2), reports which entries the server had
-    already reached, best-effort."""
+    """fix(#1778 review round 18) parts (b)/(c), corrected by #1814: the
+    timeout path must be unambiguous -- the server keeps applying after
+    the CLI gives up, and an entry it has already queued or completed is
+    skipped on a later re-apply. Round 19 had to add that an entry still
+    downloading when the timeout hit had no job row yet, so an immediate
+    re-apply could queue it twice; #1814 reserves that row before the
+    download, so the re-apply attaches to it instead. The message says
+    what a re-apply does and still makes no blanket safety claim. A
+    dry-run follow-up on the SAME endpoint (no new status/job-listing
+    endpoint -- out of scope, no async job mode), bounded by a short
+    fixed timeout regardless of entry count (round 19 P2), reports which
+    entries the server had already reached, best-effort."""
 
     def _timing_out_client(self) -> FakeSdkClient:
         client = FakeSdkClient(FakeResponse(200, _apply_response()))
@@ -378,16 +375,15 @@ class TestManifestApplyTimeoutReporting:
         assert exc.budget == compute_manifest_apply_timeout(1)
         assert exc.exit_code == EXIT_NETWORK
 
-    def test_timeout_message_explains_the_in_flight_download_window_not_blanket_safety(
+    def test_timeout_message_explains_what_a_re_apply_does_not_blanket_safety(
         self,
     ) -> None:
-        """fix(#1778 review round 19): round 18's message claimed
-        re-running immediately was always safe -- untrue, since an
-        entry whose source was still downloading when the timeout hit
-        has no job row yet and can be queued twice by an immediate
-        re-apply. The message must explain THAT risk and give
-        actionable advice (check the catalog, or dry-run first), and
-        must NOT claim blanket idempotency/safety any more."""
+        """fix(#1814): the server records an entry before downloading its
+        source, so the message must say a re-run attaches to an entry
+        still being staged rather than warning it can queue it twice. It
+        must still give actionable advice (dry-run first) and must NOT
+        claim blanket idempotency/safety, which is the round-18
+        overclaim."""
         from geolens_cli.manifest_apply import (
             ManifestApplyTimeout,
             build_apply_timeout_message,
@@ -399,11 +395,12 @@ class TestManifestApplyTimeoutReporting:
         assert "810s" in message
         assert "3 dataset" in message
         assert "does not stop" in message.lower()
-        assert "downloading" in message.lower()
-        assert "twice" in message.lower()
+        assert "before its source is downloaded" in message.lower()
+        assert "attaches" in message.lower()
         assert "dry-run" in message.lower()
         assert "re-running" in message.lower()
-        # The round-18 overclaim must not have crept back in.
+        # The stale warning, and the round-18 overclaim, must both stay out.
+        assert "twice" not in message.lower()
         assert "idempotent" not in message.lower()
         assert "is safe" not in message.lower()
         assert "safely" not in message.lower()
@@ -1051,7 +1048,8 @@ def test_apply_command_reports_timeout_with_truthful_guidance_and_status_check(
     guidance and renders the dry-run follow-up's status, rather than
     the old bare "Request timed out" -- and no longer claims an
     immediate re-run is unconditionally safe/idempotent (round 18 did;
-    it wasn't true)."""
+    it wasn't true). fix(#1814): the guidance now says a re-run attaches
+    to an entry still being staged."""
     status_response = _apply_response(
         results=[
             {"dataset_key": "roads", "action": "skip", "message": "skip_complete"}
@@ -1063,9 +1061,9 @@ def test_apply_command_reports_timeout_with_truthful_guidance_and_status_check(
 
     assert result.exit_code == EXIT_NETWORK, result.output
     assert "skip_complete" in result.output
-    assert "downloading" in result.output.lower()
-    assert "twice" in result.output.lower()
+    assert "attaches" in result.output.lower()
     assert "dry-run" in result.output.lower()
+    assert "twice" not in result.output.lower()
     assert "idempotent" not in result.output.lower()
     assert sdk.client.httpx_client.calls_made["n"] == 2, (
         "the original POST, then the dry-run status follow-up"
@@ -1101,8 +1099,9 @@ def test_apply_json_output_reports_timeout_as_one_structured_payload(
     payload = json.loads(lines[0])
     assert payload["ok"] is False
     assert "resumable" not in payload
-    assert "downloading" in payload["guidance"].lower()
-    assert "twice" in payload["guidance"].lower()
+    assert "before its source is downloaded" in payload["guidance"].lower()
+    assert "attaches" in payload["guidance"].lower()
+    assert "twice" not in payload["guidance"].lower()
     assert "idempotent" not in payload["guidance"].lower()
     assert payload["status_check"]["counts"]["skip"] == 1
 

--- a/cli/tests/test_manifest_apply.py
+++ b/cli/tests/test_manifest_apply.py
@@ -324,9 +324,9 @@ class TestResolveApplyTimeout:
 
 
 class TestManifestApplyTimeoutReporting:
-    """fix(#1778 review round 18) parts (b)/(c), corrected by #1814: the
-    server keeps applying after the CLI gives up, and reserves an entry's row
-    before downloading, so a re-apply attaches rather than queueing twice."""
+    """fix(#1814): the timeout report must be accurate about what a re-apply
+    does. The server keeps applying after the CLI gives up, and reserves each
+    entry before downloading, so a re-apply attaches rather than queueing twice."""
 
     def _timing_out_client(self) -> FakeSdkClient:
         client = FakeSdkClient(FakeResponse(200, _apply_response()))
@@ -1030,9 +1030,9 @@ def test_apply_command_reports_timeout_with_truthful_guidance_and_status_check(
     tmp_xdg_home,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """fix(#1778 review round 18) end-to-end: the `apply` command prints the
-    guidance and renders the dry-run follow-up's status. fix(#1814): that
-    guidance says a re-run attaches to an entry still being staged."""
+    """fix(#1814): end to end, the `apply` command prints the guidance and
+    renders the dry-run follow-up's status, and that guidance says a re-run
+    attaches to an entry still being staged."""
     status_response = _apply_response(
         results=[
             {"dataset_key": "roads", "action": "skip", "message": "skip_complete"}

--- a/cli/tests/test_manifest_apply.py
+++ b/cli/tests/test_manifest_apply.py
@@ -325,17 +325,12 @@ class TestResolveApplyTimeout:
 
 class TestManifestApplyTimeoutReporting:
     """fix(#1778 review round 18) parts (b)/(c), corrected by #1814: the
-    timeout path must be unambiguous -- the server keeps applying after
-    the CLI gives up, and an entry it has already queued or completed is
-    skipped on a later re-apply. Round 19 had to add that an entry still
-    downloading when the timeout hit had no job row yet, so an immediate
-    re-apply could queue it twice; #1814 reserves that row before the
-    download, so the re-apply attaches to it instead. The message says
-    what a re-apply does and still makes no blanket safety claim. A
-    dry-run follow-up on the SAME endpoint (no new status/job-listing
-    endpoint -- out of scope, no async job mode), bounded by a short
-    fixed timeout regardless of entry count (round 19 P2), reports which
-    entries the server had already reached, best-effort."""
+    timeout path must be unambiguous. The server keeps applying after the
+    CLI gives up, and #1814 reserves an entry's row before downloading its
+    source, so a re-apply attaches rather than queueing it twice. A dry-run
+    follow-up on the SAME endpoint, bounded by a short fixed timeout
+    regardless of entry count (round 19 P2), reports which entries the
+    server had already reached, best-effort."""
 
     def _timing_out_client(self) -> FakeSdkClient:
         client = FakeSdkClient(FakeResponse(200, _apply_response()))
@@ -378,12 +373,9 @@ class TestManifestApplyTimeoutReporting:
     def test_timeout_message_explains_what_a_re_apply_does_not_blanket_safety(
         self,
     ) -> None:
-        """fix(#1814): the server records an entry before downloading its
-        source, so the message must say a re-run attaches to an entry
-        still being staged rather than warning it can queue it twice. It
-        must still give actionable advice (dry-run first) and must NOT
-        claim blanket idempotency/safety, which is the round-18
-        overclaim."""
+        """fix(#1814): the message must say a re-run attaches to an entry still
+        being staged, give actionable advice (dry-run first), and make no
+        blanket idempotency claim, which is the round-18 overclaim."""
         from geolens_cli.manifest_apply import (
             ManifestApplyTimeout,
             build_apply_timeout_message,
@@ -1042,14 +1034,10 @@ def test_apply_command_reports_timeout_with_truthful_guidance_and_status_check(
     tmp_xdg_home,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """fix(#1778 review round 18) end-to-end, corrected by round 19: the
-    `apply` command's own timeout handling (not just
-    post_manifest_apply()) prints the in-flight-download-window
-    guidance and renders the dry-run follow-up's status, rather than
-    the old bare "Request timed out" -- and no longer claims an
-    immediate re-run is unconditionally safe/idempotent (round 18 did;
-    it wasn't true). fix(#1814): the guidance now says a re-run attaches
-    to an entry still being staged."""
+    """fix(#1778 review round 18) end-to-end: the `apply` command's own
+    timeout handling prints the guidance and renders the dry-run follow-up's
+    status, rather than the old bare "Request timed out". fix(#1814): that
+    guidance now says a re-run attaches to an entry still being staged."""
     status_response = _apply_response(
         results=[
             {"dataset_key": "roads", "action": "skip", "message": "skip_complete"}


### PR DESCRIPTION
`apply_manifest` checked for an in-flight job, then downloaded the entry's source, then inserted the `IngestJob` row that makes the entry visible. Everything between the check and the insert was a window in which another request saw a free key. A client that timed out mid-download and re-applied passed the check again, downloaded the same source a second time and queued the entry twice. Two concurrent first-time applies of one manifest did the same. The CLI's apply-timeout guidance documented the window truthfully.

The row now goes in before the fetch.

1. `_classify_dataset` still validates the source and runs the SSRF check first, outside any lock. It then takes a transaction-scoped advisory lock on `manifest_apply:<key>`, settles any reservation for that key past its lease, and runs the in-flight and completed reads.
2. The create and update paths insert a `running` row carrying `manifest_stage: downloading` in `user_metadata`, then commit. That commit publishes the claim and releases both the lock and the pooled connection.
3. Staging then runs with no session held, under a total deadline. The staged path is bound back onto the row by a CAS from `running` to `pending`, fenced on `(id, attempt_id, status='running', stage='downloading')` and stamping `staged_at` in the same statement, and the job is queued.

Every exit from the locked phase ends the transaction, the answered ones included, so a lock is never held across the next entry's download. Two manifests listing the same two keys in opposite order would otherwise deadlock on each other. The answered paths commit rather than roll back, because the staleness settlement is a real write and because a rollback expires every instance the caller still holds.

## The reservation shape

The `IngestJob` row itself is the reservation, which is the brief's preferred shape and needs no second table and no migration. `file_path` is already nullable and the in-flight query already keys on `user_metadata->>'manifest_key'`, so a reservation is visible to every other request the moment it commits, with no schema change and no new query. The stage marker is the only field added, and `bind_reservation_to_staged_source` removes it, so a queued manifest job carries exactly the metadata shape it carried before.

The alternative was a partial unique index on the key, the shape `dataset_refresh_runs` uses for one active run per dataset. It needs a migration on an expression over JSONB, and it answers only whether one is active rather than which one, while the skip result has to name the job.

## No session across the fetch

`_download_http_source` and `_stage_source_if_needed` no longer take an `AsyncSession`. The only thing they used it for was reading `UPLOAD_MAX_SIZE_MB`, which is now read inside the reservation transaction and passed in. This is the #1848 class. The helper from that PR had not landed when this branch started, so the shape here is the one `router_health` and `router_refresh` use: commit, do the I/O, re-acquire.

## Why the reservation is `running`

A committed `pending` row with no `file_path`, no queue task and no dispatch marker is every clause of `stale_pending_clauses`. `pending_job_timeout_seconds` may legally be 61 seconds, and a manifest download has no wall-clock bound of its own, so a first draft of this fix left the reservation reapable mid-download by four separate actors: the background sweep, the worker's startup recovery, the two-second status poll, and the next apply on the key. The bind then matched nothing, the bytes were unlinked, the entry answered "lost its reservation", and the retry repeated the loss forever.

This is the class the URL-import door already fixed in #1708, so the shape is the same one. The reservation is inserted `running` with `started_at`, judged by the fixed `JOB_TIMEOUT_SECONDS` rather than the configurable pending floor, and the bind CAS moves it to `pending` while stamping `staged_at`, so the pending clock restarts at staging rather than at a creation that predates the whole download. `_stage_source_if_needed` carries a total deadline of half the lease, because httpx's 60 second clock is per read and a source trickling steadily never trips it.

## Staleness

An API process that dies between the reservation commit and the staging bind would otherwise hold the key until the background sweep reached the row. `expire_stale_manifest_reservations` settles it under the same key lock, narrowing the running sweep's own predicate (`status='running'` past `coalesce(heartbeat_at, started_at)` plus `JOB_TIMEOUT_SECONDS`) to one key's downloading stage, so the in-flight check and the sweep cannot start disagreeing about which rows are live.

Settling rather than ignoring is what makes the bind fence sufficient. A merely slow attempt whose reservation was expired finds its row no longer running, drops its download and reports an error, instead of queueing on top of the reservation that replaced it.

## Settling on a session the failure poisoned

A statement that failed inside admission or the bind leaves the `AsyncSession` refusing every further statement until it is rolled back, so a settlement issued straight onto it raised there too and the reservation stayed live. `defer_with_orphan_guard` already had the answer for its own marker-write branch, so those four steps are one helper now, `reset_session_for_settlement`, and both callers take it: snapshot the settlement's identifiers, roll back, restore them because the rollback expires the instance, reload best effort.

A reservation is `running` and a bound row is `pending`, and the shared `settle_ingest_job_failed` fences on the latter, so the lease has its own fenced exit. Both fenced writes mirror onto the instance through `set_committed_value` rather than assignment, so the object describes the row without the caller's own commit flushing a second, unfenced update over the fenced one.

## Every commit in the apply path, against a lost acknowledgement

A commit can be durable in PostgreSQL and still raise, so each one either re-reads and reconciles or is idempotent by construction. One line per commit, so the class reads as closed rather than as a list of the ones found so far.

| Commit | Answer |
|---|---|
| the reservation insert, `_commit_reservation` | Re-reads by id. A landed insert is adopted and the entry finishes; anything else releases through the running fence before the error propagates. |
| the staging bind, `_commit_staged_bind` | Re-reads. A row that references the staged bytes keeps them and takes the pending settlement; only one that does not takes the delete. |
| the settlement in `_settle_staged_entry` | Idempotent, and retried once on a fresh transaction. Both exits are fenced CAS writes on disjoint states, so a replay after a durable settlement matches nothing. |
| the settlement in `_fail_reservation` | Idempotent, same fence and same retry. If it never landed, the running sweep reaps the row at the lease. |
| the locked phase's read-side commit | Answer-only. It carries the staleness expiry, itself a fenced settlement, and holds no key; a lost ack costs the entry its skip response, not its state. |
| the dispatch marker, `stamp_commit_attempted` | Idempotent by its own contract: a second dispatch keeps the first timestamp and issues no write. |
| the orphan guard's `_settle_after_failed_dispatch` | Idempotent, the same fenced-CAS argument. |

The Procrastinate dispatch is not a commit on this session. If its own write is durable but unacknowledged, the guard settles the row and raises, and a worker cannot then claim it, because `claim_ingest_job_attempt` fences on `pending`.

Every database statement in every settlement runs inside `_settle_under_reset`, which resets the session before its first statement and, on a database error, resets again and retries the remaining work once in a fresh transaction, so no step of a settlement can be poisoned by the one before it.

## When the staging bind's commit is ambiguous

The commit that publishes the bind can be durable in PostgreSQL and still raise on the acknowledgement. Deciding the cleanup from the exception deleted the staged source and called the running-fenced release, which cannot match a row the bind has already moved to `pending`, leaving a durable pending job with a dead `file_path` and no queued task that every re-apply attached to.

The settlement re-reads the row after resetting the session and lets the row decide. A row that references the staged bytes keeps them, which is what `/jobs/{id}/retry` needs; only a row that does not takes the delete. The two settlements fence on disjoint states, `running` for a reservation and `pending` for a bound row, so both are attempted and at most one can match. A read that fails answers "referenced", the asymmetry #1708 argued: orphaned bytes are reclaimable, bytes a durable row points at are not. That also merges the queue-failure settlement into the same helper, since a row past the bind is exactly the pending case, and it is an improvement there too, because that path used to delete the bytes and leave a `failed` row whose retry could never work.

`_commit_staged_bind` and `_commit_reservation` are named seams, the shape #1708 used for this class, so a test can make either commit durable and then raise.

## Quota

The cheap preflight moved ahead of the reservation, so an over-quota entry still leaves no row and still never opens the remote response. Admission stayed after staging, where the source's real size is known. The request-local ledger is credited there and released on every failure after that point, so a failed entry does not consume batch headroom a later entry in the same manifest needs.

`dry_run` reserves nothing and writes nothing: the staleness expiry runs only for a real apply. The cost is that a preview can still report an entry as in flight where an apply would settle the abandoned reservation and take it.

## Schema, API, config

None of the three. `backend/openapi.json` is unchanged, so no SDK or CLI regeneration. No migration: `running` is already in the `ingest_jobs` status CHECK constraint. No new settings either, and the staging deadline is derived from `JOB_TIMEOUT_SECONDS` rather than chosen, so the download budget and the lease that judges it cannot drift apart.

## CLI

`build_apply_timeout_message` warned that re-applying could queue a mid-download entry twice. It now says every entry the server has reached is recorded before its source is downloaded, so re-running attaches to one still being staged and skips one already queued or completed. The `report_apply_timeout` fallback warning and the `--json` guidance follow. The tests that pinned the old wording assert the new facts and keep the round-18 negative guards on "idempotent", "is safe" and "safely", with "twice" moved to the negative side.

## Verification

Run from the worktree against Postgres on localhost:5434.

```
uv run pytest tests/test_manifest_reservation_1814.py \
  tests/test_manifest_apply_{service,api,roundtrip,vrt}.py \
  tests/test_commit_attempted_marker_doors.py tests/test_defer_orphan_guard.py \
  tests/test_stale_pending_reaper.py tests/test_stalled_queue_sweep_624.py \
  tests/test_jobs_router.py tests/test_admin_jobs_retry_capability.py \
  tests/test_ingest_job_attempt_fencing.py \
  tests/test_job_cancel_defer_rollback.py tests/test_tenant_job_recovery.py \
  tests/test_terminal_job_retention_1778.py tests/test_layering.py \
  tests/test_rule1_structural.py tests/test_rule2_structural.py \
  tests/test_tenant_control_plane_isolation.py \
  tests/test_visibility_gate_structural.py -q            456 passed
make cli-test                              657 passed, then 8 passed 2 skipped
uv run ruff check . && uv run ruff format --check .              clean
PYTHONPATH=. uv run python scripts/dump_openapi.py --check       no drift
```

Two of those tests read the database through a listener on the session's sync
engine rather than through the ORM, because the invariants are about what the
database was asked to do: a dry run sends no INSERT or UPDATE to `ingest_jobs`
at all, and each fenced transition changes one row once.

On the first head a wider slice of every test file whose name mentions ingest,
job, quota, staging, upload, reupload, sweep, stale, worker, reaper, defer, vrt
or raster (110 files) ran 1939 passed, 5 skipped. The full backend suite has not
been run here; on this host it paces at roughly two percent in twenty-five
minutes, so CI is where that number comes from.

The sibling sweep and orphan-guard suites are in the list on purpose. This
branch changes `defer_with_orphan_guard`'s marker-write branch to call the
extracted helper, and a change that adds a `db.execute` to shared sweep code
breaks the mock-mirror suites that count awaits.

## Counterfactuals

Each measured by restoring the named files from an earlier head and rerunning.

Against `origin/main`, with only the gated download mock's signature adapted to main's `(db, prepared, ...)`, six of the first ten tests fail, including the one that reproduces the reported defect:

```
test_a_retry_during_the_download_attaches_to_the_reserved_job
E  assert download.calls == 1
E  assert 2 == 1
```

Against the first head `0932ef2f1`, where the reservation was a `pending` row:

| Test | Result on that head |
|---|---|
| a live download through the real `fail_stale_jobs` | `assert 'cancelled' == 'running'` |
| the settlement after a poisoned session | the row stays `pending` |
| a dry run writes nothing | the expiry's UPDATE reaches the table |
| the reservation release is one statement | 2 UPDATEs, the fenced one plus an ORM flush |

Against the fourth head `45091bf66`, a reconciliation read that poisons its own transaction:

```
sqlalchemy.exc.DBAPIError: InFailedSQLTransactionError: current transaction is
aborted, commands ignored until end of transaction block
[SQL: UPDATE catalog.ingest_jobs SET status=... WHERE ... status = 'running']
```

The read swallowed the error and answered "referenced", both fenced settlements then failed on the dead transaction, and the row stayed `running` in the downloading stage. With the retry the second attempt lands and the row is settled.

Against the third head `b60f82a58`, the ambiguous reservation insert, measured the same way:

| | `b60f82a58` | with the fix |
|---|---|---|
| entry outcome | `error` | `create`, staged and queued |
| the row | `running`, `downloading`, nothing will advance it | `pending`, bound |
| re-apply | `skip` on a row nobody will ever stage | `skip` on a genuinely queued job |

Against the second head `ee25e19f0`, the ambiguous bind, measured with a throwaway test that wraps the session commit rather than the seam so it runs on that code:

| | `ee25e19f0` | with the fix |
|---|---|---|
| staged file after the failure | deleted | retained |
| the row | `pending`, dead `file_path` | `failed`, `file_path` intact |
| re-apply | `skip`, attaches to the dead job | `create` |

One of the sixteen is a guard rather than a reproduction, and worth naming as such: `test_the_staging_bind_emits_one_update` passes on every pushed head, because the bind's second-flush hazard was introduced and fixed inside this branch when the update started carrying a SQL expression. Reverting just the mirror to plain assignment makes it fail with `assert 2 == 1`, so the assertion has teeth.

## Noticed and left alone

- A failed reservation appears in the admin jobs list as a `failed` job with no `file_path`. `_retry_capability` already answers "The source is no longer available. Start the import again." for that shape, and for the update path the `reupload` marker refuses first, so nothing there needed changing.
- A reservation the background sweep reaches before any later apply settles `cancelled` with the abandoned-upload wording rather than a manifest-specific one. That is the sweep's existing classification for a pending row that was never dispatched, both terminal states free the key, and giving the reservation its own wording would have meant a shared-sweep change for a message.
- `manifest_service.py` crossed `_RATCHET_INCLUSION_LOC` and takes its first `_MODULE_LOC_CAPS` entry at 1129, exact. The growth is the reserve/stage/bind split of what used to be one create-and-queue function, the two settlement exits that split needs, the quota preflight moving ahead of the reservation, and the staging deadline.
