### PR TITLE
fix(sources): record the ArcGIS sign-in outcome when a shutdown lands in the settle (#1825)

### DIFF
--- a/backend/app/modules/catalog/sources/router.py
+++ b/backend/app/modules/catalog/sources/router.py
@@ -1812,20 +1812,33 @@ async def arcgis_signin(
             # connection back. Everything after this line runs with no session
             # held, and the attempt is already spent, so a cancellation cannot
             # hand ArcGIS a failed password that GeoLens does not count.
-            await _signin_reserve(db, user_id, target, note)
+            reservation_id = await _signin_reserve(db, user_id, target, note)
             reserved = True
 
             try:
                 minted = await portal.mint(body.username, body.password)
             except ArcGISSignInError as exc:
                 try:
-                    await _signin_refusal(db, user_id, target, exc, note, reserved=True)
+                    await _signin_refusal(
+                        db,
+                        user_id,
+                        target,
+                        exc,
+                        note,
+                        reserved=True,
+                        attempt_id=reservation_id,
+                    )
                 except asyncio.CancelledError:
                     # fix(#1825): the refusal's audit write is settlement too,
                     # and it is not an `Exception`, so the rollback-and-retry
                     # clause inside the helper never saw it.
                     await _signin_settle_shielded(
-                        user_id, target, exc.audit_result, note
+                        user_id,
+                        target,
+                        exc.audit_result,
+                        note,
+                        attempt_id=reservation_id,
+                        release=db,
                     )
                     raise
             except asyncio.CancelledError:
@@ -1840,7 +1853,14 @@ async def arcgis_signin(
                 # recovers is the operator-facing row saying a password went
                 # out. It takes a session of its own, is best effort, and
                 # re-raises either way — see the helper.
-                await _signin_settle_shielded(user_id, target, AUDIT_CANCELLED, note)
+                await _signin_settle_shielded(
+                    user_id,
+                    target,
+                    AUDIT_CANCELLED,
+                    note,
+                    attempt_id=reservation_id,
+                    release=db,
+                )
                 raise
 
             # fix(#1775): SETTLE. A second short transaction, and the only one
@@ -1849,13 +1869,26 @@ async def arcgis_signin(
             logger.info("ArcGIS sign-in succeeded", token_service_host=target.host)
             try:
                 await _signin_audit(
-                    db, user_id, target, AUDIT_SUCCESS, note, reserved=True
+                    db,
+                    user_id,
+                    target,
+                    AUDIT_SUCCESS,
+                    note,
+                    reserved=True,
+                    attempt_id=reservation_id,
                 )
             except asyncio.CancelledError:
                 # fix(#1825): a shutdown cancellation here left the attempt
                 # with no row at all. Re-run through the finaliser the mint
                 # window already uses.
-                await _signin_settle_shielded(user_id, target, AUDIT_SUCCESS, note)
+                await _signin_settle_shielded(
+                    user_id,
+                    target,
+                    AUDIT_SUCCESS,
+                    note,
+                    attempt_id=reservation_id,
+                    release=db,
+                )
                 raise
     except ArcGISSignInError as exc:
         # A mint failure was already turned into an HTTPException above, so

--- a/backend/app/modules/catalog/sources/router.py
+++ b/backend/app/modules/catalog/sources/router.py
@@ -45,6 +45,7 @@ from app.modules.catalog.sources.adapters.arcgis import (
 )
 from app.modules.catalog.sources.adapters.wfs import WFS_SERVICE_FORMAT
 from app.modules.catalog.sources.arcgis_signin import (
+    AUDIT_CANCELLED,
     AUDIT_SUCCESS,
     ArcGISSignInError,
     open_portal_signin,
@@ -55,7 +56,7 @@ from app.modules.catalog.sources.signin_guard import (
     _signin_audit,
     _signin_refusal,
     _signin_reserve,
-    _signin_settle_cancelled,
+    _signin_settle_shielded,
     signin_target,
 )
 from app.modules.catalog.sources.probe import (
@@ -1817,7 +1818,16 @@ async def arcgis_signin(
             try:
                 minted = await portal.mint(body.username, body.password)
             except ArcGISSignInError as exc:
-                await _signin_refusal(db, user_id, target, exc, note, reserved=True)
+                try:
+                    await _signin_refusal(db, user_id, target, exc, note, reserved=True)
+                except asyncio.CancelledError:
+                    # fix(#1825): the refusal's audit write is settlement too,
+                    # and it is not an `Exception`, so the rollback-and-retry
+                    # clause inside the helper never saw it.
+                    await _signin_settle_shielded(
+                        user_id, target, exc.audit_result, note
+                    )
+                    raise
             except asyncio.CancelledError:
                 # fix(#1775): a cancelled task bypasses `mint`'s `except
                 # Exception` and the clause above. fix(#1775 audit): on the
@@ -1830,14 +1840,23 @@ async def arcgis_signin(
                 # recovers is the operator-facing row saying a password went
                 # out. It takes a session of its own, is best effort, and
                 # re-raises either way — see the helper.
-                await _signin_settle_cancelled(user_id, target, note)
+                await _signin_settle_shielded(user_id, target, AUDIT_CANCELLED, note)
                 raise
 
             # fix(#1775): SETTLE. A second short transaction, and the only one
             # that runs after the network. The reservation already counted the
             # attempt, so `reserved=True` keeps this from counting it twice.
             logger.info("ArcGIS sign-in succeeded", token_service_host=target.host)
-            await _signin_audit(db, user_id, target, AUDIT_SUCCESS, note, reserved=True)
+            try:
+                await _signin_audit(
+                    db, user_id, target, AUDIT_SUCCESS, note, reserved=True
+                )
+            except asyncio.CancelledError:
+                # fix(#1825): a shutdown cancellation here left the attempt
+                # with no row at all. Re-run through the finaliser the mint
+                # window already uses.
+                await _signin_settle_shielded(user_id, target, AUDIT_SUCCESS, note)
+                raise
     except ArcGISSignInError as exc:
         # A mint failure was already turned into an HTTPException above, so
         # what reaches here is a phase-one failure. `unknown` is only ever

--- a/backend/app/modules/catalog/sources/signin_guard.py
+++ b/backend/app/modules/catalog/sources/signin_guard.py
@@ -41,7 +41,6 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.modules.audit.service import AuditEvent, audit_emit
 from app.modules.catalog.sources.arcgis_signin import (
-    AUDIT_CANCELLED,
     AUDIT_CONCURRENT,
     AUDIT_RATE_LIMITED,
     UNCOUNTED_SIGNIN_RESULTS,
@@ -62,7 +61,7 @@ _ARCGIS_SIGNIN_WINDOW = timedelta(minutes=15)
 # running when the drain gives up on it, so nothing else would.
 _SETTLE_TASKS: set[asyncio.Task] = set()
 
-# fix(#1775): how long _signin_settle_cancelled will keep handing the event
+# fix(#1775): how long _signin_settle_shielded will keep handing the event
 # loop a turn so its shielded audit write can finish. One local INSERT and
 # COMMIT, so a second is three orders of magnitude of headroom; the ceiling is
 # there so a database that has stopped answering cannot hold a shutting-down
@@ -336,12 +335,13 @@ async def _signin_reserve(
         await db.commit()
 
 
-async def _write_cancelled_outcome(
+async def _write_settled_outcome(
     user_id: uuid.UUID,
     target: SignInTarget,
+    result: str,
     note: str | None = None,
 ) -> None:
-    """Write the cancelled attempt's audit row on a session of its OWN.
+    """Write one settled attempt's audit row on a session of its OWN.
 
     fix(#1775 audit): NOT the request's session. The caller below stops
     waiting at a deadline and the route then re-raises, so FastAPI runs
@@ -360,9 +360,9 @@ async def _write_cancelled_outcome(
     from app.core.db import async_session
 
     async with async_session() as session:
-        await _signin_audit(
-            session, user_id, target, AUDIT_CANCELLED, note, reserved=True
-        )
+        # `reserved=True` unconditionally: every caller of this reaches it
+        # after `_signin_reserve` committed, so the ledger row already exists.
+        await _signin_audit(session, user_id, target, result, note, reserved=True)
 
 
 def _settle_failure(settle: asyncio.Future) -> str | None:
@@ -388,12 +388,13 @@ def _settle_failure(settle: asyncio.Future) -> str | None:
     return None if exc is None else type(exc).__name__
 
 
-async def _signin_settle_cancelled(
+async def _signin_settle_shielded(
     user_id: uuid.UUID,
     target: SignInTarget,
+    result: str,
     note: str | None = None,
 ) -> None:
-    """Record the outcome of an attempt whose credential POST was cancelled.
+    """Record *result* for an attempt a cancellation interrupted.
 
     fix(#1775): a shielded finaliser rather than a bare ``finally``, and the
     distinction matters in both directions.
@@ -404,6 +405,10 @@ async def _signin_settle_cancelled(
     is the OPERATOR-facing half — the audit row that says a password went to
     this token service on this caller's say-so. Silence there reads as "no
     attempt", which is the one thing that is not true.
+
+    fix(#1825): *result* is a parameter because the gap is on both sides of
+    the mint. A cancellation in the settle loses that outcome's row exactly
+    as one in the POST loses the ``cancelled`` row.
 
     Why a shield rather than a plain await, and why the loop. The caller
     reaches here from ``except asyncio.CancelledError``, and a plain await
@@ -425,11 +430,6 @@ async def _signin_settle_cancelled(
     ceiling, and this runs at most once per request still in flight when a
     worker shuts down.
 
-    Why not a ``finally`` covering all three outcomes: success and a classified
-    refusal have to raise or return through their own paths, and the
-    single-exit refusal helper #1758 built (:func:`_signin_refusal`) would have
-    to be unpicked to route them through one block, for no gain.
-
     Still best effort, and it says so by swallowing. The database may be
     unreachable under a shutting-down worker, and there is nothing useful to do
     about that from inside a cancelled request; re-raising would only replace a
@@ -437,7 +437,9 @@ async def _signin_settle_cancelled(
     """
     loop = asyncio.get_running_loop()
     deadline = loop.time() + _SETTLE_DRAIN_SECONDS
-    settle = asyncio.ensure_future(_write_cancelled_outcome(user_id, target, note))
+    settle = asyncio.ensure_future(
+        _write_settled_outcome(user_id, target, result, note)
+    )
     # fix(#1775 audit): the event loop keeps only a WEAK reference to a task,
     # so a settle this function stops awaiting at the deadline could be
     # collected mid-write. Held here until it finishes, whichever way it

--- a/backend/app/modules/catalog/sources/signin_guard.py
+++ b/backend/app/modules/catalog/sources/signin_guard.py
@@ -39,6 +39,7 @@ from fastapi import HTTPException, status
 from sqlalchemy import delete, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.modules.audit.models import AuditLog
 from app.modules.audit.service import AuditEvent, audit_emit
 from app.modules.catalog.sources.arcgis_signin import (
     AUDIT_CONCURRENT,
@@ -108,6 +109,7 @@ async def _signin_audit(
     note: str | None = None,
     *,
     reserved: bool = False,
+    attempt_id: uuid.UUID | None = None,
 ) -> None:
     """Record one sign-in attempt: who, which portal, which account, what happened.
 
@@ -143,6 +145,10 @@ async def _signin_audit(
                 # counted on, and it is the only trace of which ArcGIS account
                 # was addressed that survives the request.
                 "account_key": target.account_key,
+                # fix(#1825 codex r1): the reservation this outcome settles.
+                # Nothing else links the two, so nothing else can tell a
+                # retry of one attempt from a second attempt.
+                **({"attempt_id": str(attempt_id)} if attempt_id else {}),
                 # fix(#1758 codex r9): present only when discovery turned up
                 # something an operator should see, so the common row keeps
                 # its shape.
@@ -273,8 +279,11 @@ async def _signin_reserve(
     user_id: uuid.UUID,
     target: SignInTarget,
     note: str | None = None,
-) -> None:
+) -> uuid.UUID:
     """Spend one attempt DURABLY, in one short transaction, before any password moves.
+
+    Returns the ledger row's id, which the settle writes carry so one attempt
+    cannot end up with two audit rows.
 
     fix(#1775): this is the whole of the issue's shape. Take both locks, read
     both budgets, insert the ledger row, commit. Everything in that sentence
@@ -319,6 +328,9 @@ async def _signin_reserve(
     the budget's own ceiling, still strictly below the five failures Esri
     locks an account on.
     """
+    # Client-side rather than the column default: the caller needs the id and
+    # a server default would cost a flush and a read back to learn it.
+    reservation_id = uuid.uuid4()
     async with _signin_locks(
         db, f"user:{user_id}:host:{target.host}", f"account:{target.account_key}"
     ) as locked:
@@ -328,11 +340,31 @@ async def _signin_reserve(
             await _signin_refusal(db, user_id, target, _signin_rate_limited(), note)
         db.add(
             ArcGISSignInAttempt(
-                account_key=target.account_key, user_scope=target.user_scope
+                id=reservation_id,
+                account_key=target.account_key,
+                user_scope=target.user_scope,
             )
         )
         await _sweep_expired_signin_attempts(db)
         await db.commit()
+    return reservation_id
+
+
+async def _settled_already(session: AsyncSession, attempt_id: uuid.UUID) -> bool:
+    """Whether this reservation already has its audit row.
+
+    fix(#1825): an interrupted commit is ambiguous, so the finaliser looks
+    before it writes or one attempt ends up with two rows.
+    """
+    found = await session.scalar(
+        select(AuditLog.id)
+        .where(
+            AuditLog.action == "arcgis_signin",
+            AuditLog.details["attempt_id"].astext == str(attempt_id),
+        )
+        .limit(1)
+    )
+    return found is not None
 
 
 async def _write_settled_outcome(
@@ -340,6 +372,7 @@ async def _write_settled_outcome(
     target: SignInTarget,
     result: str,
     note: str | None = None,
+    attempt_id: uuid.UUID | None = None,
 ) -> None:
     """Write one settled attempt's audit row on a session of its OWN.
 
@@ -360,9 +393,13 @@ async def _write_settled_outcome(
     from app.core.db import async_session
 
     async with async_session() as session:
+        if attempt_id is not None and await _settled_already(session, attempt_id):
+            return
         # `reserved=True` unconditionally: every caller of this reaches it
         # after `_signin_reserve` committed, so the ledger row already exists.
-        await _signin_audit(session, user_id, target, result, note, reserved=True)
+        await _signin_audit(
+            session, user_id, target, result, note, reserved=True, attempt_id=attempt_id
+        )
 
 
 def _settle_failure(settle: asyncio.Future) -> str | None:
@@ -388,81 +425,64 @@ def _settle_failure(settle: asyncio.Future) -> str | None:
     return None if exc is None else type(exc).__name__
 
 
+async def _drain_shielded(coro, deadline: float) -> asyncio.Future:
+    """Run *coro* under a shield until it finishes or *deadline* passes.
+
+    The caller is inside ``except asyncio.CancelledError`` and every request
+    runs under an anyio cancel scope that re-arms cancellation on every await,
+    so the shield keeps the work alive and the loop is what waits for it: one
+    shielded await per event-loop turn until the work lands or time runs out.
+
+    Returns the future, so a caller can read the outcome. Holds a strong
+    reference throughout, because the event loop keeps only a weak one, and
+    cancels at the ceiling rather than leaving the work unbounded.
+    """
+    task = asyncio.ensure_future(coro)
+    _SETTLE_TASKS.add(task)
+    task.add_done_callback(_SETTLE_TASKS.discard)
+    loop = asyncio.get_running_loop()
+    while not task.done() and loop.time() < deadline:
+        with contextlib.suppress(BaseException):  # broad: the loop decides
+            await asyncio.shield(task)
+    if not task.done():
+        task.cancel()
+    return task
+
+
 async def _signin_settle_shielded(
     user_id: uuid.UUID,
     target: SignInTarget,
     result: str,
     note: str | None = None,
+    *,
+    attempt_id: uuid.UUID | None = None,
+    release: AsyncSession | None = None,
 ) -> None:
-    """Record *result* for an attempt a cancellation interrupted.
+    """Record *result* for an attempt whose settlement a cancellation cut short.
 
-    fix(#1775): a shielded finaliser rather than a bare ``finally``, and the
-    distinction matters in both directions.
+    Best effort, and deliberately so: the ledger row is already durable, and
+    what is missing after a cancellation is the operator-facing half. A
+    failure here is logged and swallowed rather than replacing a cancellation
+    with a database error.
 
-    Why a finaliser at all, when the count is already durable: the ledger row
-    was committed by :func:`_signin_reserve` before the POST, so the budget is
-    correct whether or not this ever runs. What is missing after a cancellation
-    is the OPERATOR-facing half — the audit row that says a password went to
-    this token service on this caller's say-so. Silence there reads as "no
-    attempt", which is the one thing that is not true.
+    *release* is the request's session, rolled back first so this write does
+    not queue behind a connection FastAPI has not torn down yet. *attempt_id*
+    is the reservation, and a row already carrying it means an interrupted
+    commit landed after all, so nothing is written.
 
-    fix(#1825): *result* is a parameter because the gap is on both sides of
-    the mint. A cancellation in the settle loses that outcome's row exactly
-    as one in the POST loses the ``cancelled`` row.
-
-    Why a shield rather than a plain await, and why the loop. The caller
-    reaches here from ``except asyncio.CancelledError``, and a plain await
-    would simply be cancelled again. Measured rather than assumed: a bare
-    ``await asyncio.shield(...)`` here returns ``CancelledError``, not the
-    written row. Every request runs as a child of the anyio task group each
-    ``BaseHTTPMiddleware`` layer starts the downstream app in
-    (``task_group.start_soon(coro)``, middleware/base.py:148), and an anyio
-    cancel scope re-arms cancellation on EVERY await a task makes inside it
-    while the scope is cancelled. The same call under a bare
-    ``asyncio.Task.cancel()``, with no middleware, completes first time. So
-    the shield is necessary and not sufficient: it keeps the write itself
-    alive across those re-arms, and the loop is what waits for it.
-
-    The loop is a bounded drain, not a spin. Each pass awaits, so each pass
-    hands the event loop a turn and the shielded write is what makes progress;
-    it ends the moment that write finishes, and a wall-clock deadline ends it
-    anyway. One local INSERT and COMMIT is milliseconds against a one-second
-    ceiling, and this runs at most once per request still in flight when a
-    worker shuts down.
-
-    Still best effort, and it says so by swallowing. The database may be
-    unreachable under a shutting-down worker, and there is nothing useful to do
-    about that from inside a cancelled request; re-raising would only replace a
-    cancellation with a database error. Durability lives in the reservation.
+    Everything runs under one ceiling. A rollback that cannot finish spends
+    it, and the write is then abandoned with a warning.
     """
     loop = asyncio.get_running_loop()
     deadline = loop.time() + _SETTLE_DRAIN_SECONDS
-    settle = asyncio.ensure_future(
-        _write_settled_outcome(user_id, target, result, note)
+    if release is not None:
+        # fix(#1825 codex r1): the request session owns its connection until
+        # FastAPI's teardown, which does not run until the route re-raises, so
+        # the write below would queue behind it on a pool with no spare slot.
+        await _drain_shielded(release.rollback(), deadline)
+    settle = await _drain_shielded(
+        _write_settled_outcome(user_id, target, result, note, attempt_id), deadline
     )
-    # fix(#1775 audit): the event loop keeps only a WEAK reference to a task,
-    # so a settle this function stops awaiting at the deadline could be
-    # collected mid-write. Held here until it finishes, whichever way it
-    # finishes, which is also what keeps the abandoned case a task that
-    # completes rather than one that vanishes.
-    _SETTLE_TASKS.add(settle)
-    settle.add_done_callback(_SETTLE_TASKS.discard)
-    while not settle.done() and loop.time() < deadline:
-        # One shield future per event-loop turn, which is the price of
-        # surviving anyio's re-arm and is only paid while a re-arm is
-        # happening: with no cancel scope re-arming this awaits ONCE and
-        # blocks there until the write finishes. Every outcome is handled by
-        # the loop condition rather than here — a completed write ends it, a
-        # failed one ends it with `settle.done()` true and is reported below,
-        # and a re-armed cancellation is the thing this exists to absorb.
-        with contextlib.suppress(BaseException):  # broad: the loop decides
-            await asyncio.shield(settle)
-    if not settle.done():
-        # fix(#1775 audit): the task keeps a session of its own, so leaving it
-        # to unwind after this returns cannot fault against a session somebody
-        # else closed. Cancelling is still right: a write that lands after the
-        # request is gone is a row nobody is waiting for.
-        settle.cancel()
     failure = _settle_failure(settle)
     if failure is not None:
         # No credential, no token and no username in this line: the scope is
@@ -567,6 +587,7 @@ async def _signin_refusal(
     note: str | None = None,
     *,
     reserved: bool = False,
+    attempt_id: uuid.UUID | None = None,
 ) -> NoReturn:
     """Log, audit and raise one classified refusal.
 
@@ -586,7 +607,13 @@ async def _signin_refusal(
     )
     try:
         await _signin_audit(
-            db, user_id, target, exc.audit_result, note, reserved=reserved
+            db,
+            user_id,
+            target,
+            exc.audit_result,
+            note,
+            reserved=reserved,
+            attempt_id=attempt_id,
         )
     except Exception:  # broad: any failed transaction, whatever poisoned it
         # fix(#1758 codex r11): a refusal has to be recorded even when the
@@ -598,7 +625,13 @@ async def _signin_refusal(
         # so there is never uncommitted work of ours to discard.
         await db.rollback()
         await _signin_audit(
-            db, user_id, target, exc.audit_result, note, reserved=reserved
+            db,
+            user_id,
+            target,
+            exc.audit_result,
+            note,
+            reserved=reserved,
+            attempt_id=attempt_id,
         )
     # `from None`: the chained cause of a transport failure is an httpx error
     # holding the request whose encoded body is the password, and nothing

--- a/backend/tests/test_arcgis_signin.py
+++ b/backend/tests/test_arcgis_signin.py
@@ -3323,3 +3323,109 @@ async def test_a_portal_url_carrying_credentials_is_refused(
         headers=admin_auth_header,
     )
     assert resp.status_code == 422
+
+
+async def _cancel_the_first_audit(monkeypatch, entered, never):
+    """Hang the first settle write; delegate the finaliser's own to the real one.
+
+    Both bindings: the success settle reaches the helper through the router's
+    import, the refusal settle through signin_guard's own global.
+    """
+    real_audit = signin_guard._signin_audit
+    calls = []
+
+    async def _hang_once(*args, **kwargs):
+        calls.append(1)
+        if len(calls) == 1:
+            entered.set()
+            await never.wait()
+            raise AssertionError("unreachable: the wait above is never released")
+        return await real_audit(*args, **kwargs)
+
+    monkeypatch.setattr(signin_guard, "_signin_audit", _hang_once)
+    monkeypatch.setattr(sources_router, "_signin_audit", _hang_once)
+    return calls
+
+
+async def _cancel_during_settle(client, admin_auth_header, exchange, monkeypatch):
+    """Drive one sign-in and cancel it while the settle write is in flight."""
+    entered = asyncio.Event()
+    never = asyncio.Event()
+    await _cancel_the_first_audit(monkeypatch, entered, never)
+    with _install(exchange):
+        call = asyncio.create_task(
+            client.post(SIGNIN_URL, json=_body(), headers=admin_auth_header)
+        )
+        async with asyncio.timeout(30):
+            await entered.wait()
+        call.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await call
+
+
+async def test_a_cancellation_during_the_success_settle_still_records_it(
+    client: AsyncClient,
+    admin_auth_header: dict,
+    allow_ssrf,
+    test_db_session,
+    monkeypatch,
+):
+    """fix(#1825): a shutdown landing in the success settle keeps its row."""
+    await _cancel_during_settle(
+        client,
+        admin_auth_header,
+        _Exchange(
+            {
+                "info": _json_response(_info_payload()),
+                "generateToken": _json_response(_token_payload()),
+            }
+        ),
+        monkeypatch,
+    )
+
+    account_key = signin_account_key(_scope(), FIXTURE_USERNAME)
+    rows = await _audit_rows(test_db_session)
+    assert [row.details["result"] for row in rows] == ["success"]
+    assert rows[0].details["account_key"] == account_key
+    ledger = await test_db_session.scalar(
+        select(func.count())
+        .select_from(ArcGISSignInAttempt)
+        .where(ArcGISSignInAttempt.account_key == account_key)
+    )
+    # The reservation stands and is not spent twice: the finaliser counts none.
+    assert ledger == 1
+
+
+async def test_a_cancellation_during_the_refusal_settle_still_records_it(
+    client: AsyncClient,
+    admin_auth_header: dict,
+    allow_ssrf,
+    test_db_session,
+    monkeypatch,
+):
+    """fix(#1825): the same window on the refusal side of the mint."""
+    await _cancel_during_settle(
+        client,
+        admin_auth_header,
+        _Exchange(
+            {
+                "info": _json_response(_info_payload()),
+                "generateToken": _json_response(
+                    _error_payload(400, "Unable to generate token.")
+                ),
+                "self": _json_response({"canSignInArcGIS": True}),
+            }
+        ),
+        monkeypatch,
+    )
+
+    account_key = signin_account_key(_scope(), FIXTURE_USERNAME)
+    rows = await _audit_rows(test_db_session)
+    # The classified outcome, not `cancelled`: the mint answered before this.
+    assert [row.details["result"] for row in rows] == ["invalid_credentials"]
+    ledger = await test_db_session.scalar(
+        select(func.count())
+        .select_from(ArcGISSignInAttempt)
+        .where(ArcGISSignInAttempt.account_key == account_key)
+    )
+    assert ledger == 1

--- a/backend/tests/test_arcgis_signin.py
+++ b/backend/tests/test_arcgis_signin.py
@@ -33,7 +33,7 @@ import httpx
 import idna
 import pytest
 from httpx import AsyncClient
-from sqlalchemy import delete, exc as sa_exc, func, select
+from sqlalchemy import delete, exc as sa_exc, func, select, text
 
 from app.modules.audit.models import AuditLog
 from app.modules.catalog.sources.models import ArcGISSignInAttempt
@@ -3207,11 +3207,15 @@ async def test_a_successful_signin_leaks_nothing_into_logs_or_the_audit_row(
     rows = await _audit_rows(test_db_session)
     assert len(rows) == 1
     recorded = json.dumps(rows[0].details)
+    # fix(#1825): `attempt_id` joins the closed set. It is the ledger row's
+    # random id, which stands for the attempt and for nothing else.
     assert rows[0].details == {
         "token_service_host": _scope(),
         "result": "success",
         "account_key": signin_account_key(_scope(), FIXTURE_USERNAME),
+        "attempt_id": rows[0].details["attempt_id"],
     }
+    assert uuid.UUID(rows[0].details["attempt_id"]).version == 4
     assert FIXTURE_SECRET not in recorded
     assert FIXTURE_TOKEN not in recorded
     assert FIXTURE_USERNAME not in recorded
@@ -3334,13 +3338,17 @@ async def _cancel_the_first_audit(monkeypatch, entered, never):
     real_audit = signin_guard._signin_audit
     calls = []
 
-    async def _hang_once(*args, **kwargs):
+    async def _hang_once(db, *args, **kwargs):
         calls.append(1)
         if len(calls) == 1:
+            # Open a transaction first, so the session holds its connection
+            # when the cancellation lands. That is the state the real write
+            # is in, and without it the release has nothing to release.
+            await db.execute(text("SELECT 1"))
             entered.set()
             await never.wait()
             raise AssertionError("unreachable: the wait above is never released")
-        return await real_audit(*args, **kwargs)
+        return await real_audit(db, *args, **kwargs)
 
     monkeypatch.setattr(signin_guard, "_signin_audit", _hang_once)
     monkeypatch.setattr(sources_router, "_signin_audit", _hang_once)
@@ -3429,3 +3437,173 @@ async def test_a_cancellation_during_the_refusal_settle_still_records_it(
         .where(ArcGISSignInAttempt.account_key == account_key)
     )
     assert ledger == 1
+
+
+async def test_the_finaliser_does_not_wait_on_the_request_connection(
+    client: AsyncClient,
+    admin_auth_header: dict,
+    allow_ssrf,
+    test_db_session,
+    monkeypatch,
+):
+    """fix(#1825 codex r1): the request session is released before the write.
+
+    FastAPI's teardown does not run until the route re-raises, so the settle
+    write would queue behind the request's own connection. On a pool with no
+    spare capacity it waits out the drain and the row is lost anyway.
+    """
+    import app.core.db as core_db
+    from app.api.main import app
+    from app.core.dependencies import get_db
+
+    request_sessions: list = []
+    original = app.dependency_overrides[get_db]
+
+    async def _capturing():
+        async for session in original():
+            request_sessions.append(session)
+            yield session
+
+    app.dependency_overrides[get_db] = _capturing
+    held: list[bool] = []
+    real_factory = core_db.async_session
+
+    def _recording_factory(*args, **kwargs):
+        held.append(request_sessions[-1].in_transaction())
+        return real_factory(*args, **kwargs)
+
+    monkeypatch.setattr(core_db, "async_session", _recording_factory)
+    try:
+        await _cancel_during_settle(
+            client,
+            admin_auth_header,
+            _Exchange(
+                {
+                    "info": _json_response(_info_payload()),
+                    "generateToken": _json_response(_token_payload()),
+                }
+            ),
+            monkeypatch,
+        )
+    finally:
+        app.dependency_overrides[get_db] = original
+
+    rows = await _audit_rows(test_db_session)
+    assert [row.details["result"] for row in rows] == ["success"]
+    # The pool-independent form: an open transaction is what pins the
+    # connection, and the test engine's NullPool makes a checkout count moot.
+    assert held == [False], (
+        "the finaliser opened its session while the request still held one"
+    )
+
+
+def _settle_exchange(result: str) -> "_Exchange":
+    """The exchange that drives the mint to *result*."""
+    routes = {"info": _json_response(_info_payload())}
+    if result == "success":
+        routes["generateToken"] = _json_response(_token_payload())
+    else:
+        routes["generateToken"] = _json_response(
+            _error_payload(400, "Unable to generate token.")
+        )
+        routes["self"] = _json_response({"canSignInArcGIS": True})
+    return _Exchange(routes)
+
+
+async def _drive_and_cancel(client, admin_auth_header, exchange, entered):
+    """Run one sign-in and cancel it once *entered* is set."""
+    with _install(exchange):
+        call = asyncio.create_task(
+            client.post(SIGNIN_URL, json=_body(), headers=admin_auth_header)
+        )
+        async with asyncio.timeout(30):
+            await entered.wait()
+        call.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await call
+
+
+async def _assert_one_row(test_db_session, result: str) -> None:
+    """Exactly one audit row with *result*, and one counted attempt."""
+    rows = await _audit_rows(test_db_session)
+    assert [row.details["result"] for row in rows] == [result]
+    account_key = signin_account_key(_scope(), FIXTURE_USERNAME)
+    ledger = await test_db_session.scalar(
+        select(func.count())
+        .select_from(ArcGISSignInAttempt)
+        .where(ArcGISSignInAttempt.account_key == account_key)
+    )
+    assert ledger == 1
+
+
+@pytest.mark.parametrize("result", ["success", "invalid_credentials"])
+async def test_a_commit_that_landed_before_the_cancellation_is_not_written_twice(
+    client: AsyncClient,
+    admin_auth_header: dict,
+    allow_ssrf,
+    test_db_session,
+    monkeypatch,
+    result: str,
+):
+    """fix(#1825): an interrupted commit is ambiguous, not failed.
+
+    PostgreSQL can apply the commit while the client sees `CancelledError`, so
+    the finaliser looks for this reservation before writing.
+    """
+    real_audit = signin_guard._signin_audit
+    committed = asyncio.Event()
+    never = asyncio.Event()
+    calls = []
+
+    async def _commit_then_hang(*args, **kwargs):
+        calls.append(1)
+        if len(calls) == 1:
+            # Durable first, then cancelled from outside: the ambiguous commit.
+            await real_audit(*args, **kwargs)
+            committed.set()
+            await never.wait()
+            raise AssertionError("unreachable: the wait above is never released")
+        return await real_audit(*args, **kwargs)
+
+    monkeypatch.setattr(signin_guard, "_signin_audit", _commit_then_hang)
+    monkeypatch.setattr(sources_router, "_signin_audit", _commit_then_hang)
+
+    await _drive_and_cancel(
+        client, admin_auth_header, _settle_exchange(result), committed
+    )
+    await _assert_one_row(test_db_session, result)
+
+
+@pytest.mark.parametrize("result", ["success", "invalid_credentials"])
+async def test_a_flush_cancelled_before_its_commit_is_written_once(
+    client: AsyncClient,
+    admin_auth_header: dict,
+    allow_ssrf,
+    test_db_session,
+    monkeypatch,
+    result: str,
+):
+    """fix(#1825): the other side of the ambiguous commit.
+
+    Here the INSERT is on the wire inside its savepoint and the transaction is
+    still open, so teardown rolls it back and the finaliser must write the row.
+    """
+    real_emit = signin_guard.audit_emit
+    flushed = asyncio.Event()
+    never = asyncio.Event()
+    calls = []
+
+    async def _flush_then_hang(session, event):
+        calls.append(1)
+        await real_emit(session, event)
+        if len(calls) == 1:
+            flushed.set()
+            await never.wait()
+            raise AssertionError("unreachable: the wait above is never released")
+
+    monkeypatch.setattr(signin_guard, "audit_emit", _flush_then_hang)
+
+    await _drive_and_cancel(
+        client, admin_auth_header, _settle_exchange(result), flushed
+    )
+    await _assert_one_row(test_db_session, result)

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -2778,9 +2778,10 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # wait is the first of the two waits, and the preview needs a second
     # release because its duplicate-source query re-acquires in between.
     # Cap 1831 -> 1849, exact.
-    # fix(#1825): +19. Both settlement writes carry a cancellation clause that
-    # re-runs the outcome through the sign-in finaliser. Cap 1849 -> 1868, exact.
-    "backend/app/modules/catalog/sources/router.py": 1868,
+    # fix(#1825): +52. A cancellation clause on both settlement writes, and
+    # the reservation id threaded to all three finaliser call sites.
+    # Cap 1849 -> 1901, exact.
+    "backend/app/modules/catalog/sources/router.py": 1901,
     # fix(#998): the DDL ported from migration 0019 so tenant-ownership adoption
     # is reachable forward-only at head. Almost all of it is SQL text, and it is
     # one artifact on purpose — the module is reviewed line-by-line against

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -2778,7 +2778,9 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # wait is the first of the two waits, and the preview needs a second
     # release because its duplicate-source query re-acquires in between.
     # Cap 1831 -> 1849, exact.
-    "backend/app/modules/catalog/sources/router.py": 1849,
+    # fix(#1825): +19. Both settlement writes carry a cancellation clause that
+    # re-runs the outcome through the sign-in finaliser. Cap 1849 -> 1868, exact.
+    "backend/app/modules/catalog/sources/router.py": 1868,
     # fix(#998): the DDL ported from migration 0019 so tenant-ownership adoption
     # is reachable forward-only at head. Almost all of it is SQL text, and it is
     # one artifact on purpose — the module is reviewed line-by-line against


### PR DESCRIPTION
Closes the audit-completeness gap in #1825, filed off #1820's codex P2. Reproduced on `origin/main` at d17445969 before anything changed.

## The gap

`_signin_settle_cancelled` covered the credential POST only. A worker shutdown arriving after the mint returned, while the success audit or the mint refusal was committing, fell outside that clause. The reservation was already durable, so the budget stayed correct, but the attempt ended with no success, refusal or cancelled row. An operator reading the history saw nothing where a password had gone to a token service, which is the one reading that is not true.

It is two writes, not one. The success audit runs on the request session with no cover, and so does the mint refusal. `_signin_refusal` already retries after a rollback when its write hits a broken transaction, but that clause catches `Exception`, and `CancelledError` is not one, so the refusal side lost its row for the same reason the success side did.

## The fix

One mechanism, generalised rather than duplicated. `_signin_settle_cancelled` becomes `_signin_settle_shielded` and takes the outcome to record; `_write_cancelled_outcome` becomes `_write_settled_outcome`. The drain loop, the shield, the deadline, the weak-reference task set and `_settle_failure` are untouched. Each of the three call sites now passes its own result. Neither old name was referenced by any test or any other module, so the rename touches one import and one call.

Each settlement write is wrapped in `except asyncio.CancelledError` that re-runs the outcome through that finaliser. Two properties made this the shape to pick over moving the writes onto their own session outright:

- The normal path is unchanged. A database failure on a successful sign-in still surfaces the way it does today, rather than being downgraded to a best-effort warning on the one outcome where a token has already been minted.
- There is no await between the audit's commit and the end of either block. That does not make the settle exactly-once: a commit already in flight when the cancellation lands can still be applied, which is what the reservation-keyed dedupe below is for.

The docstring paragraph arguing that a `finally` covering all three outcomes was not worth unpicking the single-exit refusal helper is removed, because the fix now covers all three through one helper and leaving that text would make the file argue against itself.

## Two more, from codex round 1 and the branch audit

**The finaliser queued behind the request's own connection.** It opened its own session while the request session still owned one, because FastAPI's teardown does not run until the route re-raises. On a pool with no spare slot the settle write waits out the drain and the row is lost anyway, which is the outcome this change exists to prevent. The request session is released first now, through the same drain the write uses, extracted as `_drain_shielded` rather than written twice. One residual case remains and the docstring says so: a rollback that cannot finish spends the ceiling and the write is abandoned with a warning.

A suppressed one-shot `asyncio.shield(rollback())` was not enough. It returns before the rollback completes under anyio's re-arm, and the test still saw the connection held, which is why the drain is shared rather than the release being a single await.

**An interrupted commit is ambiguous, not failed.** PostgreSQL can apply it while the client sees `CancelledError`, so the finaliser wrote the same outcome again, and nothing linked a reservation to its audit row. `_signin_reserve` returns its ledger row's id, the settle writes record it as `attempt_id`, and the finaliser looks for that id before inserting. The id is generated client-side so the caller learns it without a flush and a read back.

The claim in the first version of this body that no such window existed was wrong. It reasoned that cancellation at an await means the operation did not happen, which is not true of a commit already in flight. The settle is at-least-once, deduplicated on `attempt_id` for the windows that were measured; the check-then-insert itself is not atomic, and a commit that becomes visible between the finaliser's look and its insert can still leave two rows. Closing that needs a unique partial index and a conflict-safe insert, which is #1889. Four tests are the evidence for the measured windows rather than the reasoning: a commit that lands before the cancellation, and a flush cancelled before its commit, each on the success and the refusal path, all asserting one row and one counted attempt.

`attempt_id` is the ledger row's random uuid. It stands for the attempt and for nothing else: no username, no token, no user id, no tenant id, and the row it points at carries none either.

## The measurement behind the shield and the drain

Moved here out of the source, where it was review history rather than contract, and it is worth keeping because it is not derivable from the code.

A plain await inside `except asyncio.CancelledError` is simply cancelled again. Measured rather than assumed: a bare `await asyncio.shield(...)` there returns `CancelledError`, not the written row. Every request runs as a child of the anyio task group each `BaseHTTPMiddleware` layer starts the downstream app in, and an anyio cancel scope re-arms cancellation on every await a task makes inside it while the scope is cancelled. The same call under a bare `asyncio.Task.cancel()`, with no middleware, completes first time. So the shield is necessary and not sufficient: it keeps the work alive across those re-arms, and the loop is what waits for it, one shielded await per event-loop turn.

The loop holds a strong reference because the event loop keeps only a weak one, so a task the drain stops awaiting could otherwise be collected mid-write. Cancelling at the ceiling is right rather than merely safe: each caller's work keeps a session of its own, so unwinding after the drain returns cannot fault against a session somebody else closed.

## Follow-up, not in this PR

- #1889: enforce the `attempt_id` dedupe atomically (unique partial index plus `ON CONFLICT DO NOTHING`), which closes the check-then-insert window above.

`_signin_reserve`'s own commit has the same commit-versus-ack class: a cancellation there can spend a ledger row whose audit row never lands. That is outside #1825, which is about settlement, and the conservative direction anyway, since the attempt is charged rather than lost.

## Not widened

Phase-one refusals, the ones before the mint, keep the request session and no cancellation clause. The finaliser exists for the row that says a password went to a token service, and on those paths no password has gone out yet. Settlement is the boundary the issue names and the boundary the helper's own docstring justifies.

## Security and scope

No token, password or username reaches a log line or a row. The finaliser records the same host, account digest and outcome every other row here already carries. No budget change: the reservation is committed before the POST and the finaliser counts nothing, so a cancellation neither refunds nor double-spends. No schema, API or config impact; `scripts/dump_openapi.py --check` exits 0.

## Verification

Run from the worktree against Postgres on localhost:5434.

```
tests/test_arcgis_signin.py                      186 passed
tests/test_arcgis_signin_tenancy.py                3 passed
tests/test_services_endpoints.py                  51 passed
tests/test_service_auth_transport_1746.py        374 passed
tests/test_service_auth_contract_1746.py          55 passed
tests/test_layering.py + rule1 + rule2           165 passed
ruff check .                                     All checks passed
ruff format --check .                            1174 files already formatted
scripts/dump_openapi.py --check                  exit 0
```

The two existing cancellation tests still pass: the one that cancels mid-mint, and the one that drives the drain past its deadline and checks the caller still sees a `CancelledError`.

Both new tests cancel the request from outside while the settle write is in flight, which is what uvicorn does to an in-flight handler on shutdown, rather than raising `CancelledError` from inside the handler. Each asserts exactly one row with the right outcome and an unchanged ledger count.

One thing that shape cost, worth recording because the next person will hit it: the two settle writes reach `_signin_audit` by different names. The success one goes through the router's own import, the refusal one through `signin_guard`'s global, so a test that patches only the module under test intercepts the refusal and silently misses the success. The helper patches both.

Counterfactuals, each reverting only that change and keeping the tests:

- The two settlement clauses: `assert [] == ['success']` and `assert [] == ['invalid_credentials']`, the missing row the issue describes.
- The connection release: `assert [True] == [False]`, the finaliser opening its session while the request still held one.
- The reservation dedupe: one attempt gets two rows, on both the success and the refusal path.

Two of the tests here were vacuous before they were right, which is worth recording. The release test first hung before the audit write, so no transaction was ever open and it passed against its own counterfactual; the helper opens one first now, which is the state the real write is in. The ambiguous-commit test first raised `CancelledError` inside the handler, which breaks the ASGI transport rather than cancelling anything; it commits durably and is cancelled from outside now.

Cap re-measured with `wc -l` and set to the exact figure: `sources/router.py` 1849 to 1901.

