### PR TITLE
fix(sandbox): fold an unquoted DATA schema before the tenant rewrite (#1891)

### DIFF
--- a/backend/app/platform/sandbox/executor.py
+++ b/backend/app/platform/sandbox/executor.py
@@ -70,6 +70,15 @@ def _swap_operator_tokens(sql: str, token_type: TokenType, replacement: str) -> 
     return out
 
 
+def _is_logical_data_schema(identifier: exp.Expression | None) -> bool:
+    """True when ``identifier`` folds to the logical ``data`` schema: unquoted
+    folds to lowercase, quoted keeps its case, so quoted ``"DATA"`` is not it."""
+    if not isinstance(identifier, exp.Identifier):
+        return False
+    name = identifier.name if identifier.quoted else identifier.name.lower()
+    return name == "data"
+
+
 def _rewrite_logical_data_schema(sql: str, physical_schema: str) -> str:
     """Rewrite validated ``data.*`` references to one physical tenant schema.
 
@@ -96,12 +105,13 @@ def _rewrite_logical_data_schema(sql: str, physical_schema: str) -> str:
     # quoting form) tokenizes as a string and leaves `guarded` unchanged.
     protect_cosine = guarded != sql
 
+    # fix(#1891): fold like the validator, so unquoted DATA is rewritten too.
     for table in statement.find_all(exp.Table):
-        if table.db == "data":
+        if _is_logical_data_schema(table.args.get("db")):
             table.set("db", exp.to_identifier(physical_schema, quoted=True))
 
     for column in statement.find_all(exp.Column):
-        if column.db == "data":
+        if _is_logical_data_schema(column.args.get("db")):
             column.set("db", exp.to_identifier(physical_schema, quoted=True))
 
     rendered = statement.sql(dialect="postgres")

--- a/backend/tests/test_sandbox_tenant_schema.py
+++ b/backend/tests/test_sandbox_tenant_schema.py
@@ -141,19 +141,23 @@ def test_schema_rewrite_preserves_non_single_quoted_literals():
     assert out2.count("<=>") == 1
 
 
-@pytest.mark.parametrize("spelling", ["DATA", "Data"])
-def test_schema_rewrite_folds_unquoted_logical_schema(spelling):
+@pytest.mark.parametrize(
+    ("schema", "table"), [("DATA", "roads"), ("Data", "roads"), ("Data", "Roads")]
+)
+def test_schema_rewrite_folds_unquoted_logical_schema(schema, table):
     """fix(#1891): an unquoted schema folds to lowercase, as PostgreSQL and the
-    validator fold it, so ``DATA.roads`` is the logical schema and must reach
-    the physical tenant schema instead of the shared one."""
+    validator fold it, so any spelling of ``data`` is the logical schema and must
+    reach the physical tenant schema; the table part is left as written."""
     from app.platform.sandbox.executor import _rewrite_logical_data_schema
+    from app.platform.sandbox.validator import validate_sql
 
-    rewritten = _rewrite_logical_data_schema(
-        f"SELECT * FROM {spelling}.roads", _SCHEMA_A
-    )
+    sql = f"SELECT * FROM {schema}.{table}"
+    assert validate_sql(sql).tables == {("data", "roads")}
 
-    assert f'FROM "{_SCHEMA_A}".roads' in rewritten
-    assert f"{spelling}.roads" not in rewritten
+    rewritten = _rewrite_logical_data_schema(sql, _SCHEMA_A)
+
+    assert f'FROM "{_SCHEMA_A}".{table}' in rewritten
+    assert f"{schema}.{table}" not in rewritten
 
 
 def test_schema_rewrite_folds_unquoted_three_part_column():

--- a/backend/tests/test_sandbox_tenant_schema.py
+++ b/backend/tests/test_sandbox_tenant_schema.py
@@ -141,6 +141,53 @@ def test_schema_rewrite_preserves_non_single_quoted_literals():
     assert out2.count("<=>") == 1
 
 
+@pytest.mark.parametrize("spelling", ["DATA", "Data"])
+def test_schema_rewrite_folds_unquoted_logical_schema(spelling):
+    """fix(#1891): an unquoted schema folds to lowercase, as PostgreSQL and the
+    validator fold it, so ``DATA.roads`` is the logical schema and must reach
+    the physical tenant schema instead of the shared one."""
+    from app.platform.sandbox.executor import _rewrite_logical_data_schema
+
+    rewritten = _rewrite_logical_data_schema(
+        f"SELECT * FROM {spelling}.roads", _SCHEMA_A
+    )
+
+    assert f'FROM "{_SCHEMA_A}".roads' in rewritten
+    assert f"{spelling}.roads" not in rewritten
+
+
+def test_schema_rewrite_folds_unquoted_three_part_column():
+    """fix(#1891): a schema-qualified column reference folds the same way as a
+    table reference."""
+    from app.platform.sandbox.executor import _rewrite_logical_data_schema
+
+    rewritten = _rewrite_logical_data_schema(
+        "SELECT DATA.roads.geom FROM DATA.roads", _SCHEMA_A
+    )
+
+    assert f'"{_SCHEMA_A}".roads.geom' in rewritten
+    assert f'FROM "{_SCHEMA_A}".roads' in rewritten
+    assert "DATA." not in rewritten
+
+
+def test_schema_rewrite_leaves_quoted_uppercase_schema_alone():
+    """fix(#1891): quoted ``"DATA"`` keeps its case, so it is another schema:
+    the rewrite leaves it in place and the access check refuses it."""
+    from app.platform.sandbox.executor import _rewrite_logical_data_schema
+    from app.platform.sandbox.validator import check_table_access, validate_sql
+
+    sql = 'SELECT * FROM "DATA".roads'
+    rewritten = _rewrite_logical_data_schema(sql, _SCHEMA_A)
+    assert '"DATA".roads' in rewritten
+    assert _SCHEMA_A not in rewritten
+
+    validated = validate_sql(sql)
+    assert validated.tables == {("DATA", "roads")}
+    with pytest.raises(SandboxError) as exc_info:
+        check_table_access(validated.tables, {"roads"}, validated.cte_names)
+    assert exc_info.value.category == "table_not_accessible"
+
+
 @pytest.mark.asyncio
 async def test_multi_tenant_rewrites_only_logical_data_schema(monkeypatch):
     monkeypatch.setattr("app.platform.sandbox.executor.is_multi_tenant", lambda: True)


### PR DESCRIPTION
Issue: #1891 (found by the 2026-09-05 tenant SQL routing investigation).

## Defect

`validate_sql` folds an unquoted schema identifier the way PostgreSQL does, so `SELECT * FROM DATA.roads` passes the allowlist as `data.roads`. The multi-tenant rewrite in `backend/app/platform/sandbox/executor.py` (`_rewrite_logical_data_schema`) then compared `table.db == "data"` and `column.db == "data"` with no folding, so any non-lowercase unquoted spelling (`DATA`, `Data`, `Data.Roads`) stayed in place and PostgreSQL resolved it to the shared `data` schema.

Severity: the tenant reader role holds USAGE on its own tenant schema only. The provisioning function from migrations 0019 and 0024 revokes each tenant schema from PUBLIC and grants USAGE to that tenant's reader alone, and no tenant reader is granted anything on the shared schema (the baseline's `GRANT USAGE ON SCHEMA data` goes to the single-tenant `geolens_readonly` role). A mis-routed query is therefore refused with 42501 and is never served from the shared schema. This is a correctness defect, not an isolation gap. Single-tenant mode does not rewrite and was not affected.

Reproduced on main at 56aa03abe before the change: `_rewrite_logical_data_schema("SELECT * FROM DATA.roads", schema)` returned its input unchanged, and so did `Data.roads` and `SELECT DATA.roads.geom FROM DATA.roads`, while lowercase `data.roads` was rewritten.

## Fix

Both loops read the identifier node (`table.args.get("db")`, `column.args.get("db")`) and pass it to a new `_is_logical_data_schema` helper in the executor. It folds the way PostgreSQL and the validator's `_folded_identifier` do: an unquoted name to lowercase, a quoted name verbatim, and it matches on `data`. A `db` argument that is not an identifier is not rewritten. Only the schema identifier is replaced; the table part stays as written and PostgreSQL folds it on its own. Quoted `"DATA"` is therefore still not rewritten and `check_table_access` still refuses it. The physical replacement stays `exp.to_identifier(physical_schema, quoted=True)` and the cosine sentinel is untouched.

## Tests

Five regression cases in `backend/tests/test_sandbox_tenant_schema.py`, next to the existing rewrite tests, assert on the rendered SQL the way that file already does. Unquoted `DATA.roads`, `Data.roads` and `Data.Roads` (parametrized; each spelling is first checked to validate as `("data", "roads")`, and `Roads` is left as written in the output) and the three-part column `DATA.roads.geom` rewrite to the physical schema. Quoted `"DATA".roads` is not rewritten; `validate_sql` extracts it as `("DATA", "roads")` and `check_table_access` refuses it with `table_not_accessible`.

Counterfactual: tests in place, executor at main, so only the folding is missing.

```
E   assert 'FROM "data_t_00000000_0000_0000_0000_000000000001".roads' in 'SELECT * FROM DATA.roads'
E   assert 'FROM "data_t_00000000_0000_0000_0000_000000000001".roads' in 'SELECT * FROM Data.roads'
E   assert 'FROM "data_t_00000000_0000_0000_0000_000000000001".Roads' in 'SELECT * FROM Data.Roads'
E   assert '"data_t_00000000_0000_0000_0000_000000000001".roads.geom' in 'SELECT DATA.roads.geom FROM DATA.roads'
FAILED tests/test_sandbox_tenant_schema.py::test_schema_rewrite_folds_unquoted_logical_schema[DATA-roads]
FAILED tests/test_sandbox_tenant_schema.py::test_schema_rewrite_folds_unquoted_logical_schema[Data-roads]
FAILED tests/test_sandbox_tenant_schema.py::test_schema_rewrite_folds_unquoted_logical_schema[Data-Roads]
FAILED tests/test_sandbox_tenant_schema.py::test_schema_rewrite_folds_unquoted_three_part_column
4 failed, 1 passed
```

The one pass is the quoted `"DATA"` test, which pins behaviour main already has.

## Impact

No request or response schema change, no migration, no new setting. `executor.py` is not in `_MODULE_LOC_CAPS`, so no cap moved.

## Verification

Run on the host from the worktree, Postgres at localhost:5434.

```
cd backend && set -a && source ../.env.test && set +a
uv run pytest tests/test_sandbox_tenant_schema.py tests/test_sandbox.py -q      # 81 passed
uv run pytest tests/test_layering.py -q                                         # 50 passed
uv run pytest tests/test_rule1_structural.py tests/test_rule2_structural.py -q  # 115 passed
uv run ruff check . && uv run ruff format --check .                             # clean
```

## Left alone

The validator keeps its private `_folded_identifier`. Sharing it would mean a rename across the capped validator for no behaviour change, and the executor helper is four lines. The span-rewrite refactor and the trailing-semicolon handling are #1892 and are not started here.
