### PR TITLE
test(rule2): model keyword-bound program and unheaded execv sequence tails in the argv collectors (#1884)

### DIFF
--- a/backend/tests/test_rule2_structural.py
+++ b/backend/tests/test_rule2_structural.py
@@ -2582,16 +2582,44 @@ _SEQUENCE_ARGV_SPAWNERS: dict[str, int] = {
     "execvpe": 0,
 }
 
+# fix(#1884): the parameters a keyword-bound program and argv sequence bind to.
+# os.execv is positional-only, and a keyword-bound os.execl* leaves the empty
+# argv that execv refuses, so neither has a keyword spelling that runs.
+_SPAWN_KEYWORDS: dict[str, tuple[str, str | None]] = {
+    "create_subprocess_exec": ("program", None),
+    "subprocess_exec": ("program", None),
+    "execve": ("path", "argv"),
+    "execvp": ("file", "args"),
+    "execvpe": ("file", "args"),
+}
 
-def _positional_argv_tool(node: ast.AST) -> tuple[str, int, bool] | None:
-    """(tool, program-argument index, whether argv follows as one sequence).
+
+def _spawn_argument(node: ast.Call, index: int, keyword: str | None) -> ast.expr | None:
+    """The argument at ``index``, or the one bound to ``keyword`` when that
+    positional slot is absent; None when neither is present."""
+    if len(node.args) > index:
+        return node.args[index]
+    if keyword is not None:
+        for kw in node.keywords:
+            if kw.arg == keyword:
+                return kw.value
+    return None
+
+
+def _positional_argv_tool(
+    node: ast.AST,
+) -> tuple[str, int, ast.expr | None] | None:
+    """(tool, program-argument index, the argv sequence of a sequence callee).
 
     Matched on the callee's terminal name, so `asyncio.create_subprocess_exec`,
     a `from asyncio import create_subprocess_exec` and `loop.subprocess_exec`
     all read the same. Looser than the identity resolution helper credit uses,
     deliberately: this side decides what to LOOK at, where a false positive
     costs a reviewed allowlist entry, while credit decides what to EXEMPT,
-    where one costs the guarantee.
+    where one costs the guarantee. The program and the sequence are read from
+    their positional slot, or from the keyword the callee binds them to when
+    the slot is absent (``create_subprocess_exec(program="ogrinfo")``). The
+    sequence is None for a varargs callee, and for a sequence callee given none.
     """
     if not isinstance(node, ast.Call):
         return None
@@ -2606,13 +2634,19 @@ def _positional_argv_tool(node: ast.AST) -> tuple[str, int, bool] | None:
     index = _SEQUENCE_ARGV_SPAWNERS.get(callee)
     if index is None:
         index = _VARARGS_ARGV_SPAWNERS.get(callee)
-    if index is None or len(node.args) <= index:
+    if index is None:
         return None
-    head = node.args[index]
+    program_keyword, sequence_keyword = _SPAWN_KEYWORDS.get(callee, (None, None))
+    head = _spawn_argument(node, index, program_keyword)
     if not isinstance(head, ast.Constant):
         return None
     tool = _gdal_cli_tool_name(head.value)
-    return None if tool is None else (tool, index, takes_sequence)
+    if tool is None:
+        return None
+    sequence = (
+        _spawn_argument(node, index + 1, sequence_keyword) if takes_sequence else None
+    )
+    return tool, index, sequence
 
 
 def _display_argv_tool(node: ast.AST, rel: str) -> str | None:
@@ -2658,15 +2692,20 @@ def _iter_argv_sites(rel: str, tree: ast.Module):
         spawn = _positional_argv_tool(node)
         if spawn is None:
             continue
-        tool, index, takes_sequence = spawn
-        if takes_sequence:
-            argv_arg = node.args[index + 1] if len(node.args) > index + 1 else None
-            if argv_arg is not None and _display_argv_tool(argv_arg, rel) is not None:
+        tool, index, sequence = spawn
+        tail: list[ast.expr] = node.args[index + 1 :]
+        if isinstance(sequence, (ast.List, ast.Tuple)):
+            if _display_argv_tool(sequence, rel) is not None:
                 # The sequence is a site in its own right, so yielding the call
                 # too would count one subprocess twice.
                 continue
+            # fix(#1884): the display's elements are the tail, so a remote
+            # literal behind a flag head is judged as it is in a headed display.
+            tail = list(sequence.elts)
+        elif sequence is not None:
+            tail = [sequence]
         # No escape test and no name-list exemption: this node is the spawn.
-        yield tool, node, node.args[index + 1 :]
+        yield tool, node, tail
 
 
 def _collect_gdal_cli_violations(
@@ -3185,6 +3224,145 @@ def test_a_sequence_the_display_rule_refuses_still_leaves_one_site():
         violations, total = collect(_fixture_modules(_SEQUENCE_SPAWN_UNHEADED), {})
         assert total == 1, f"{collect.__name__} counted {total} sites, not 1"
         assert len(violations) == 1, violations
+
+
+# fix(#1884): the program bound by keyword sits outside ``node.args``.
+_KEYWORD_PROGRAM_SPAWN = """
+import asyncio
+
+
+async def probe():
+    return await asyncio.create_subprocess_exec(program="ogrinfo")
+"""
+
+_KEYWORD_PROGRAM_SPAWN_CLAMPED = """
+import asyncio
+
+from app.processing.raster.vrt import gdal_vector_safe_env
+
+
+async def probe():
+    return await asyncio.create_subprocess_exec(
+        program="ogrinfo", env=gdal_vector_safe_env()
+    )
+"""
+
+_KEYWORD_PROGRAM_EVENT_LOOP_SPAWN = """
+import asyncio
+
+
+async def probe(loop, factory):
+    return await loop.subprocess_exec(factory, program="ogrinfo")
+"""
+
+_KEYWORD_SEQUENCE_SPAWN = """
+import os
+
+
+def probe(path):
+    os.execvp(file="ogrinfo", args=["ogrinfo", "-so", path])
+"""
+
+_KEYWORD_SEQUENCE_SPAWN_DYNAMIC = """
+import os
+
+
+def probe(cmd):
+    os.execvp(file="ogrinfo", args=cmd)
+"""
+
+
+def test_a_keyword_bound_program_is_still_the_program():
+    """fix(#1884): ``create_subprocess_exec(program="ogrinfo")`` and
+    ``loop.subprocess_exec(factory, program="ogrinfo")`` are one argv site
+    each for both gates. The clamped twin passing is what makes it a
+    measurement: the keyword form is judged, not merely counted.
+    """
+    for source in (_KEYWORD_PROGRAM_SPAWN, _KEYWORD_PROGRAM_EVENT_LOOP_SPAWN):
+        for collect in (
+            _collect_gdal_cli_violations,
+            _collect_vector_driver_violations,
+        ):
+            violations, total = collect(_fixture_modules(source), {})
+            assert total == 1, f"{collect.__name__} counted {total} sites, not 1"
+            assert len(violations) == 1, violations
+            assert "ogrinfo" in violations[0] and "probe" in violations[0]
+
+    violations, total = _collect_gdal_cli_violations(
+        _fixture_modules(_KEYWORD_PROGRAM_SPAWN_CLAMPED), {}
+    )
+    assert total == 1, total
+    assert not violations, violations
+
+
+def test_a_keyword_bound_sequence_counts_once():
+    """fix(#1884): ``os.execvp(file="ogrinfo", args=...)`` binds both halves
+    by keyword. A literal sequence is the site and the call is not a second
+    one; a dynamic sequence leaves the call as the only site.
+    """
+    for source in (_KEYWORD_SEQUENCE_SPAWN, _KEYWORD_SEQUENCE_SPAWN_DYNAMIC):
+        for collect in (
+            _collect_gdal_cli_violations,
+            _collect_vector_driver_violations,
+        ):
+            violations, total = collect(_fixture_modules(source), {})
+            assert total == 1, f"{collect.__name__} counted {total} sites, not 1"
+            assert len(violations) == 1, violations
+
+
+# fix(#1884): a remote literal behind a flag head, which the display rule
+# refuses, so only the call's tail can carry it to the remote check.
+_SEQUENCE_SPAWN_UNHEADED_REMOTE = """
+import os
+
+from app.processing.raster.vrt import gdal_vector_safe_env
+
+
+def probe():
+    env = gdal_vector_safe_env()
+    os.execve("ogrinfo", ["-so", "https://example.com/a.gpkg"], env)
+"""
+
+_SEQUENCE_SPAWN_UNHEADED_LOCAL = """
+import os
+
+from app.processing.raster.vrt import gdal_vector_safe_env
+
+
+def probe(path):
+    env = gdal_vector_safe_env()
+    os.execve("ogrinfo", ["-so", path], env)
+"""
+
+_KEYWORD_SEQUENCE_SPAWN_REMOTE = """
+import os
+
+from app.processing.raster.vrt import gdal_vector_safe_env
+
+
+def probe():
+    env = gdal_vector_safe_env()
+    os.execvpe(file="ogrinfo", args=["-so", "https://example.com/a.gpkg"], env=env)
+"""
+
+
+def test_an_unheaded_sequence_tail_is_its_elements():
+    """fix(#1884): the remote literal inside ``["-so", url]`` gets no safe-env
+    credit, exactly as it would not in a headed display, whether the sequence
+    is positional or keyword-bound. The local twin keeps its credit, so the
+    difference is the element, not the shape.
+    """
+    for source in (_SEQUENCE_SPAWN_UNHEADED_REMOTE, _KEYWORD_SEQUENCE_SPAWN_REMOTE):
+        violations, total = _collect_gdal_cli_violations(_fixture_modules(source), {})
+        assert total == 1, total
+        assert len(violations) == 1, violations
+        assert "literally-remote" in violations[0] and "#937" in violations[0]
+
+    violations, total = _collect_gdal_cli_violations(
+        _fixture_modules(_SEQUENCE_SPAWN_UNHEADED_LOCAL), {}
+    )
+    assert total == 1, total
+    assert not violations, violations
 
 
 def test_positional_argv_is_seen_by_the_vector_driver_policy():

--- a/backend/tests/test_rule2_structural.py
+++ b/backend/tests/test_rule2_structural.py
@@ -2582,9 +2582,9 @@ _SEQUENCE_ARGV_SPAWNERS: dict[str, int] = {
     "execvpe": 0,
 }
 
-# fix(#1884): the parameters a keyword-bound program and argv sequence bind to.
-# os.execv is positional-only, and a keyword-bound os.execl* leaves the empty
-# argv that execv refuses, so neither has a keyword spelling that runs.
+# fix(#1884): the keyword each callee binds its program and argv sequence to.
+# os.execv is positional-only and a keyword-bound os.execl* has the empty argv
+# execv refuses, so neither runs from a keyword spelling and neither is listed.
 _SPAWN_KEYWORDS: dict[str, tuple[str, str | None]] = {
     "create_subprocess_exec": ("program", None),
     "subprocess_exec": ("program", None),
@@ -3226,7 +3226,7 @@ def test_a_sequence_the_display_rule_refuses_still_leaves_one_site():
         assert len(violations) == 1, violations
 
 
-# fix(#1884): the program bound by keyword sits outside ``node.args``.
+# fix(#1884): a keyword-bound program is an argv site like a positional one.
 _KEYWORD_PROGRAM_SPAWN = """
 import asyncio
 
@@ -3273,11 +3273,8 @@ def probe(cmd):
 
 
 def test_a_keyword_bound_program_is_still_the_program():
-    """fix(#1884): ``create_subprocess_exec(program="ogrinfo")`` and
-    ``loop.subprocess_exec(factory, program="ogrinfo")`` are one argv site
-    each for both gates. The clamped twin passing is what makes it a
-    measurement: the keyword form is judged, not merely counted.
-    """
+    """fix(#1884): a keyword-bound program is one argv site for both gates,
+    reported without a safe env and passed with the vector one."""
     for source in (_KEYWORD_PROGRAM_SPAWN, _KEYWORD_PROGRAM_EVENT_LOOP_SPAWN):
         for collect in (
             _collect_gdal_cli_violations,
@@ -3296,10 +3293,8 @@ def test_a_keyword_bound_program_is_still_the_program():
 
 
 def test_a_keyword_bound_sequence_counts_once():
-    """fix(#1884): ``os.execvp(file="ogrinfo", args=...)`` binds both halves
-    by keyword. A literal sequence is the site and the call is not a second
-    one; a dynamic sequence leaves the call as the only site.
-    """
+    """fix(#1884): a keyword-bound sequence spawn is exactly one site, whether
+    the sequence is a literal (the display) or a name (the call)."""
     for source in (_KEYWORD_SEQUENCE_SPAWN, _KEYWORD_SEQUENCE_SPAWN_DYNAMIC):
         for collect in (
             _collect_gdal_cli_violations,
@@ -3310,8 +3305,7 @@ def test_a_keyword_bound_sequence_counts_once():
             assert len(violations) == 1, violations
 
 
-# fix(#1884): a remote literal behind a flag head, which the display rule
-# refuses, so only the call's tail can carry it to the remote check.
+# fix(#1884): a remote literal in an unheaded sequence gets no safe-env credit.
 _SEQUENCE_SPAWN_UNHEADED_REMOTE = """
 import os
 
@@ -3347,11 +3341,8 @@ def probe():
 
 
 def test_an_unheaded_sequence_tail_is_its_elements():
-    """fix(#1884): the remote literal inside ``["-so", url]`` gets no safe-env
-    credit, exactly as it would not in a headed display, whether the sequence
-    is positional or keyword-bound. The local twin keeps its credit, so the
-    difference is the element, not the shape.
-    """
+    """fix(#1884): a remote literal in an unheaded sequence gets no safe-env
+    credit, positional or keyword-bound; a local element keeps it."""
     for source in (_SEQUENCE_SPAWN_UNHEADED_REMOTE, _KEYWORD_SEQUENCE_SPAWN_REMOTE):
         violations, total = _collect_gdal_cli_violations(_fixture_modules(source), {})
         assert total == 1, total


### PR DESCRIPTION
Follow-up to #1868. Tracked in #1884.

## What changed

Test module only: `backend/tests/test_rule2_structural.py`. The argv collectors did not model two spellings. Neither is present under `backend/app`, so the real-tree counts and the allowlists are unchanged.

Keyword-bound program. `asyncio.create_subprocess_exec(program="ogrinfo")` and `loop.subprocess_exec(factory, program="ogrinfo")` put the program outside `node.args`, so `_positional_argv_tool` returned None and both collectors reported zero sites. A new `_spawn_argument` helper reads an argument from its positional slot, or from the keyword the callee binds it to when that slot is absent, and `_SPAWN_KEYWORDS` names the keyword per callee. I checked the signatures on the CPython the suite runs on (3.14.5): `program` for the asyncio pair; `path` and `argv` for `os.execve`; `file` and `args` for `os.execvp` and `os.execvpe`. Each of those binds by keyword and goes on to exec. `os.execv` is positional-only (TypeError), and a keyword-bound `os.execl*` leaves the empty argv that execv refuses (ValueError), so those two have no keyword spelling that runs and are not in the table.

Unheaded sequence tail. For `os.execve("ogrinfo", ["-so", url], env)` the display rule refuses the list because its head is a flag, so the call is the site, and its tail was `node.args[1:]`: the whole list plus env. `_is_remote_literal` on a List is always False, so a safe env in the same function credited the site and the remote literal never reached the allowlist review. The tail is now the display's elements, which is how a headed display has always been judged. The same path serves a keyword-bound sequence such as `os.execvpe(file="ogrinfo", args=[...], env=env)`.

## Fixtures

- `test_a_keyword_bound_program_is_still_the_program`: both asyncio spellings count as one site for both gates and report. The clamped twin with `env=gdal_vector_safe_env()` passes, so the site is judged rather than merely tallied.
- `test_a_keyword_bound_sequence_counts_once`: `os.execvp(file=..., args=[literal])` counts once, because the display is the site and the call is skipped. `os.execvp(file=..., args=cmd)` counts once, because the call is the only site.
- `test_an_unheaded_sequence_tail_is_its_elements`: the remote literal behind a flag head reports as literally-remote with #937 in the message, for a positional and for a keyword-bound sequence. The local twin keeps its credit.

## Counterfactual

The new fixtures run against the collectors as they are on origin/main (a copy of the module with the tests added and no collector change):

```
FAILED test_a_keyword_bound_program_is_still_the_program
  AssertionError: _collect_gdal_cli_violations counted 0 sites, not 1
FAILED test_a_keyword_bound_sequence_counts_once
  AssertionError: _collect_gdal_cli_violations counted 0 sites, not 1
FAILED test_an_unheaded_sequence_tail_is_its_elements
  AssertionError: []
  (no violation reported: the remote literal received safe-env credit)
3 failed, 108 deselected in 10.53s
```

## Verification

Run from the worktree with `.env.test` sourced:

```
cd backend && set -a && source ../.env.test && set +a
uv run pytest tests/test_rule2_structural.py -q
  origin/main: 108 passed in 16.27s
  this branch: 111 passed in 15.61s
uv run ruff check tests/test_rule2_structural.py
  All checks passed!
uv run ruff format --check tests/test_rule2_structural.py
  1 file already formatted
grep -rn -E 'program=|\bos\.exec|\.subprocess_exec\(' backend/app
  no hits (positive control: 7 positional create_subprocess_exec sites)
```

Schema, API and config impact: none. Nothing under `backend/app` changed, so no LOC cap moved.

## Noticed and left alone

A sequence built by concatenation, `os.execv("ogrinfo", ["-so"] + [url])`, still hides the literal: the tail is a BinOp whose left arm is a list, and `_leading_literal` reads only a string constant, an f-string head, or the left arm of a string concatenation. A starred element inside the display is invisible in the same way. Both belong to the same class as the `shlex.split` and `functools.partial` spellings listed in #1868, and neither is in the tree.
