### PR TITLE
fix(ai): fold the table reference before the chat geometry append (#1891)

### DIFF
--- a/backend/app/platform/sandbox/__init__.py
+++ b/backend/app/platform/sandbox/__init__.py
@@ -21,6 +21,7 @@ from app.core.identity import Identity
 from app.platform.sandbox.executor import DEFAULT_TIMEOUT_MS, execute_safe
 from app.platform.sandbox.schemas import SandboxError, SandboxResult
 from app.platform.sandbox.validator import (
+    _folded_identifier as folded_identifier,
     build_table_allowlist,
     check_table_access,
     validate_sql,
@@ -28,7 +29,7 @@ from app.platform.sandbox.validator import (
 
 logger = structlog.stdlib.get_logger(__name__)
 
-__all__ = ["validate_and_execute", "SandboxResult", "SandboxError"]
+__all__ = ["validate_and_execute", "SandboxResult", "SandboxError", "folded_identifier"]
 
 
 async def validate_and_execute(

--- a/backend/app/processing/ai/chat_geojson.py
+++ b/backend/app/processing/ai/chat_geojson.py
@@ -16,6 +16,8 @@ import structlog
 from shapely.geometry import shape as shapely_shape
 from sqlglot import exp
 
+from app.platform.sandbox import folded_identifier
+
 logger = structlog.stdlib.get_logger(__name__)
 
 _GEOM_NAMES = {"geom_4326", "geom", "geometry", "the_geom", "wkb_geometry"}
@@ -114,10 +116,11 @@ def ensure_geometry_selected(sql: str, layers) -> str:
     if from_clause is None:
         return sql
     table = from_clause.this
+    # fix(#1891): fold both parts the PostgreSQL way before comparing.
     if (
         not isinstance(table, exp.Table)
-        or table.db != "data"
-        or table.name not in geom_tables
+        or folded_identifier(table.args.get("db")) != "data"
+        or folded_identifier(table.this) not in geom_tables
     ):
         return sql
     for item in stmt.expressions:

--- a/backend/tests/test_ephemeral_geojson.py
+++ b/backend/tests/test_ephemeral_geojson.py
@@ -501,6 +501,26 @@ class TestEnsureGeometrySelected:
         )
         assert "parks.geom_4326" in sql
 
+    def test_folds_unquoted_uppercase_schema(self):
+        # fix(#1891): unquoted DATA folds to data, as PostgreSQL resolves it.
+        sql = ensure_geometry_selected("SELECT name FROM DATA.parks", [_layer()])
+        assert sql == "SELECT name, parks.geom_4326 FROM DATA.parks"
+
+    def test_folds_unquoted_mixed_case_schema_and_table(self):
+        # fix(#1891): both parts fold; the qualifier keeps the spelling written.
+        sql = ensure_geometry_selected("SELECT name FROM Data.Parks", [_layer()])
+        assert sql == "SELECT name, Parks.geom_4326 FROM Data.Parks"
+
+    def test_quoted_uppercase_schema_left_unchanged(self):
+        # fix(#1891): quoted "DATA" keeps its case, so it is another schema.
+        sql = 'SELECT name FROM "DATA".parks'
+        assert ensure_geometry_selected(sql, [_layer()]) == sql
+
+    def test_quoted_mixed_case_table_left_unchanged(self):
+        # fix(#1891): quoted "Parks" keeps its case and is not the catalog table.
+        sql = 'SELECT name FROM data."Parks"'
+        assert ensure_geometry_selected(sql, [_layer()]) == sql
+
 
 class TestStripGeometryColumns:
     def test_strips_wkb_column(self):

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1992,7 +1992,9 @@ def test_decomposed_service_modules_stay_within_size_budgets() -> None:
         # _safe_value. Round 0 normalized only the GeoJSON property copy, so a
         # NaN in an ordinary column still reached the SSE frame as a bare token
         # and the browser dropped the whole frame. Cap 420 -> 437, exact.
-        "backend/app/processing/ai/chat_geojson.py": 437,
+        # fix(#1891): +3. The geometry append folds both table parts through
+        # the sandbox's folded_identifier before comparing. Cap 437 -> 440, exact.
+        "backend/app/processing/ai/chat_geojson.py": 440,
         # fix(#836): extensions-defaults sub-modules over the 350 default at
         # split time. Caps exact (zero headroom): each class moved verbatim
         # from the 1815-LOC defaults.py, and regrowth toward another god


### PR DESCRIPTION
Issue: #1891, second site of the same bug class. The executor fold is PR #1893.

## Defect

`ensure_geometry_selected` in `backend/app/processing/ai/chat_geojson.py` decides whether to append `geom_4326` by testing `table.db != "data"` and `table.name not in geom_tables` on the raw sqlglot text. The sandbox validator folds the same reference the PostgreSQL way and accepts it, so an AI chat query spelled `DATA.parks` or `Data.Parks` ran and returned rows, but the geometry auto-append was skipped and the answer carried no map overlay. Graceful degradation: no routing or access impact.

Reproduced on main at 56aa03abe: with a `parks` layer, `SELECT name FROM data.parks` gained `parks.geom_4326`, while `DATA.parks`, `Data.Parks` and `data.Parks` came back unchanged.

## Fix

Both parts of the table reference go through the validator's fold before the comparison: `folded_identifier(table.args.get("db")) != "data"` and `folded_identifier(table.this) not in geom_tables`. An unquoted name folds to lowercase, a quoted name stays verbatim, and a missing or non-identifier part folds to None and fails the check as before. The appended qualifier is still built from the identifier as written, so `Data.Parks` renders `Parks.geom_4326`, which PostgreSQL folds to the same table as the FROM.

The helper is the validator's existing `_folded_identifier`, exposed from the sandbox package as `folded_identifier` (one import line and one `__all__` entry) rather than a third copy of the fold. `processing/ai/router.py` already imports from that module, so this adds no new layering edge.

How `geom_tables` is populated: it is the set of `layer.dataset_table_name` for layers with a geometry type, and `router.py` fills that field from the catalog's `datasets.table_name` column. That column only ever holds lowercase names: the ingest path validates through `_TABLE_NAME_RE` in `processing/ingest/metadata_sql.py` and the datasets domain through `SAFE_TABLE_NAME_RE` in `_sql_safety.py`, both `^[a-z0-9_]+$`. So a folded unquoted name matches what the catalog stores, and a quoted mixed-case table such as `data."Parks"` can never match and is correctly left alone.

## Tests

Four cases in `TestEnsureGeometrySelected` in `backend/tests/test_ephemeral_geojson.py`, next to the existing append tests: unquoted `DATA.parks` and `Data.Parks` get the geometry column appended exactly as lowercase does; quoted `"DATA".parks` and `data."Parks"` are left unchanged.

Counterfactual: tests in place, `chat_geojson.py` at main, so only the fold is missing.

```
E       AssertionError: assert 'SELECT name FROM DATA.parks' == 'SELECT name,...OM DATA.parks'
E         - SELECT name, parks.geom_4326 FROM DATA.parks
E         + SELECT name FROM DATA.parks
E       AssertionError: assert 'SELECT name FROM Data.Parks' == 'SELECT name,...OM Data.Parks'
E         - SELECT name, Parks.geom_4326 FROM Data.Parks
E         + SELECT name FROM Data.Parks
FAILED tests/test_ephemeral_geojson.py::TestEnsureGeometrySelected::test_folds_unquoted_uppercase_schema
FAILED tests/test_ephemeral_geojson.py::TestEnsureGeometrySelected::test_folds_unquoted_mixed_case_schema_and_table
2 failed, 2 passed
```

The two passes are the quoted cases, which pin behaviour main already has.

## Impact

No request or response schema change, no migration, no new setting. `chat_geojson.py` sat at its cap of 437 with zero headroom; the import, its blank line and the one anchored comment add three lines, so `_MODULE_LOC_CAPS` moves to 440, exact, with an anchored comment.

## Verification

Run on the host from the worktree, Postgres at localhost:5434.

```
cd backend && set -a && source ../.env.test && set +a
uv run pytest tests/test_ephemeral_geojson.py -q                                                           # 90 passed
uv run pytest tests/test_ai_buffer_marker_1589.py tests/test_sandbox.py tests/test_sandbox_tenant_schema.py -q   # 164 passed
uv run pytest tests/test_layering.py -q                                                                    # 50 passed
uv run pytest tests/test_rule1_structural.py tests/test_rule2_structural.py -q                             # 115 passed
uv run ruff check . && uv run ruff format --check .                                                        # clean
```

## Left alone

The executor's `_is_logical_data_schema` from #1893 is a second copy of the same fold. It could use `folded_identifier` once both PRs are in, but #1893 is audit-clean and queued, so it is not touched here. Nothing from #1892.
