### PR TITLE
fix(scripts): validate the encryption keys Compose will actually pass (#1886)

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -84,7 +84,7 @@ needs the `upload` and `export` capabilities on the seeding account.
 | Script | Purpose |
 |--------|---------|
 | `install.sh` | First-run installer (see below) |
-| `preflight-env.sh` | Statically validate `.env` (JWT secret, admin creds) before boot via `make preflight` / `make dev` |
+| `preflight-env.sh` | Validate the boot-required settings (JWT secret, admin creds, encryption key shape) as Compose will resolve them, shell environment first and then `.env`, via `make preflight` / `make dev` |
 | `check-env.sh` | Probe the running stack's env, DB connectivity, and GDAL via `make doctor` (requires the stack up) |
 | `init-db.sh` | Initialize the PostGIS database schema (mounted into the db container's init) |
 | `init-test-db.sh` | Initialize a host-accessible `geolens_test` database (extensions, schemas, roles) for local `psql` debugging. Not used by CI. CI and pytest each bootstrap their own test databases. |

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -1755,9 +1755,23 @@ env_is_exported() {
   _env_snapshot_has "$1"
 }
 
+# True when FILE's KEY= line is one Compose refuses to load: an unterminated
+# quote, or a value whose interpolation fails (`${NAME:?msg}` on an unset
+# NAME). A bare `KEY` line inherits from the environment and never counts.
+env_file_refuses_key() {
+  [ -f "$2" ] || return 1
+  _efrk_records="$(_env_tokenize "$2")" || return 1
+  _env_select_record "$_efrk_records" "$1" 0
+  case "${_esr_found}${_esr_type}" in
+    2*) return 0 ;;
+    1A) ! get_env_value "$1" "$2" >/dev/null 2>&1 ;;
+    *) return 1 ;;
+  esac
+}
+
 # fix(#1886): assigns into $1 what a plain ${KEY} interpolates to under
-# Compose: the exported environment when it sets KEY (even to ""), else
-# FILE's last KEY= line. Target validation and rc contract as env_value_into.
+# Compose (the export when set, even to "", else FILE's last KEY= line);
+# rc 1 when neither has KEY, rc 2 when FILE's line is one Compose refuses.
 effective_env_value_into() {
   _eevi_var="$1"
   _eevi_key="$2"
@@ -1765,13 +1779,22 @@ effective_env_value_into() {
 
   _env_assert_var_name "$_eevi_var" effective_env_value_into
 
+  # Compose loads the whole file before any override applies, so a refused
+  # line fails here exported or not; the target stays untouched on rc 2.
+  _eevi_in_file=0
+  if env_value_into "$_eevi_var" "$_eevi_key" "$_eevi_file"; then
+    _eevi_in_file=1
+  elif env_file_refuses_key "$_eevi_key" "$_eevi_file"; then
+    return 2
+  fi
+
   if env_is_exported "$_eevi_key"; then
     _eevi_val="$(_env_snapshot_value "$_eevi_key" && printf x)"
     _eevi_val="${_eevi_val%x}"
     eval "$_eevi_var=\$_eevi_val"
     return 0
   fi
-  env_value_into "$_eevi_var" "$_eevi_key" "$_eevi_file"
+  [ "$_eevi_in_file" -eq 1 ]
 }
 
 # Replace `KEY=...` in .env (or append if missing). Pass the value via ENVIRON

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -1722,13 +1722,7 @@ env_value_into() {
   _evi_key="$2"
   _evi_file="$3"
 
-  case "$_evi_var" in
-    [A-Za-z_]*) : ;;
-    *) fail "env_value_into: invalid target variable name: '$_evi_var'" ;;
-  esac
-  case "$_evi_var" in
-    *[!A-Za-z0-9_]*) fail "env_value_into: invalid target variable name: '$_evi_var'" ;;
-  esac
+  _env_assert_var_name "$_evi_var" env_value_into
 
   # Sentinel-protected for the SAME reason every decode capture in this
   # file is (see _env_dequote's callers, get_env_value's own quoted-value
@@ -1741,6 +1735,43 @@ env_value_into() {
   _evi_val="$(get_env_value "$_evi_key" "$_evi_file" && printf x)" || return 1
   _evi_val="${_evi_val%x}"
   eval "$_evi_var=\$_evi_val"
+}
+
+# Aborts unless $1 is a valid shell identifier; $2 names the caller for the
+# message. Guards every `eval "$name=..."` in this file.
+_env_assert_var_name() {
+  case "$1" in
+    [A-Za-z_]*) : ;;
+    *) fail "$2: invalid target variable name: '$1'" ;;
+  esac
+  case "$1" in
+    *[!A-Za-z0-9_]*) fail "$2: invalid target variable name: '$1'" ;;
+  esac
+}
+
+# True when NAME was in the exported environment this file was sourced
+# under, which is the environment Compose itself interpolates from.
+env_is_exported() {
+  _env_snapshot_has "$1"
+}
+
+# fix(#1886): assigns into $1 what a plain ${KEY} interpolates to under
+# Compose: the exported environment when it sets KEY (even to ""), else
+# FILE's last KEY= line. Target validation and rc contract as env_value_into.
+effective_env_value_into() {
+  _eevi_var="$1"
+  _eevi_key="$2"
+  _eevi_file="$3"
+
+  _env_assert_var_name "$_eevi_var" effective_env_value_into
+
+  if env_is_exported "$_eevi_key"; then
+    _eevi_val="$(_env_snapshot_value "$_eevi_key" && printf x)"
+    _eevi_val="${_eevi_val%x}"
+    eval "$_eevi_var=\$_eevi_val"
+    return 0
+  fi
+  env_value_into "$_eevi_var" "$_eevi_key" "$_eevi_file"
 }
 
 # Replace `KEY=...` in .env (or append if missing). Pass the value via ENVIRON

--- a/scripts/preflight-env.sh
+++ b/scripts/preflight-env.sh
@@ -57,12 +57,35 @@ value_source() {
     fi
 }
 
+# fix(#1886): a line Compose cannot load stops `docker compose up` before any
+# override applies, so it is refused here whether or not $1 is exported.
+refuse_unloadable_line() {
+    cat >&2 <<EOF
+Pre-flight: the $1 line in .env cannot be loaded by docker compose.
+
+Compose reads every line of .env before it applies your shell environment, so
+an unterminated quote, or a \${NAME:?message} reference to a NAME that is not
+set, stops \`docker compose up\` on this line even when $1 is exported. Fix or
+remove the line in .env.
+EOF
+    exit 1
+}
+
+# Sets \`value\` to what Compose will pass for $1, or refuses the .env line.
+read_effective() {
+    value=""
+    rc=0
+    effective_env_value_into value "$1" "$ENV_FILE" || rc=$?
+    if [ "$rc" -eq 2 ]; then
+        refuse_unloadable_line "$1"
+    fi
+}
+
 REQUIRED=(JWT_SECRET_KEY GEOLENS_ADMIN_USERNAME GEOLENS_ADMIN_PASSWORD)
 MISSING=()
 
 for var in "${REQUIRED[@]}"; do
-    value=""
-    effective_env_value_into value "$var" "$ENV_FILE" || true
+    read_effective "$var"
     if [ -z "$value" ]; then
         MISSING+=("$var, read from $(value_source "$var")")
     fi
@@ -89,8 +112,7 @@ fi
 # Accept the standard alphabet too (`+/`), because base64.urlsafe_b64decode
 # does, and refusing a value the app takes would be a false failure.
 for var in SECRET_ENCRYPTION_KEY SECRET_ENCRYPTION_KEY_PREVIOUS; do
-    value=""
-    effective_env_value_into value "$var" "$ENV_FILE" || true
+    read_effective "$var"
     if [ -n "$value" ] && ! printf '%s' "$value" | grep -Eq '^[A-Za-z0-9+/_-]{43}=$'; then
         cat >&2 <<EOF
 Pre-flight: $var in $(value_source "$var") is not a valid encryption key.

--- a/scripts/preflight-env.sh
+++ b/scripts/preflight-env.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Pre-flight: verify boot-required env vars are non-empty in .env BEFORE running
+# Pre-flight: verify boot-required env vars are non-empty BEFORE running
 # `docker compose up` (which takes 5-10 minutes on a cold cache only to crash
 # at startup if these are empty).
 #
@@ -14,6 +14,9 @@
 # Both must be url-safe base64 of 32 random bytes, and a malformed value fails
 # API boot. Leaving them unset is fine; the app derives a key from
 # JWT_SECRET_KEY instead. See RUNBOOK.md section 11.
+#
+# Each value is read the way Compose resolves it: from the exported
+# environment when that sets the name (even to an empty string), else .env.
 #
 # Run automatically by `make dev` unless SKIP_PREFLIGHT=1.
 
@@ -44,24 +47,37 @@ fi
 # shellcheck source=scripts/lib/common.sh
 . "$PROJECT_ROOT/scripts/lib/common.sh"
 
+# fix(#1886): an exported name overrides its .env line for Compose, so every
+# check below runs on the value the API container will actually receive.
+value_source() {
+    if env_is_exported "$1"; then
+        echo "your shell environment (which overrides .env)"
+    else
+        echo ".env"
+    fi
+}
+
 REQUIRED=(JWT_SECRET_KEY GEOLENS_ADMIN_USERNAME GEOLENS_ADMIN_PASSWORD)
 MISSING=()
 
 for var in "${REQUIRED[@]}"; do
-    value="$(get_env_value "$var" "$ENV_FILE" || true)"
+    value=""
+    effective_env_value_into value "$var" "$ENV_FILE" || true
     if [ -z "$value" ]; then
-        MISSING+=("$var")
+        MISSING+=("$var, read from $(value_source "$var")")
     fi
 done
 
 if [ ${#MISSING[@]} -gt 0 ]; then
     cat >&2 <<EOF
-Pre-flight: the following required vars are empty in .env:
+Pre-flight: the following required vars are empty:
 
 $(printf '  - %s\n' "${MISSING[@]}")
 
 The API container will fail to boot. To fix:
     bash scripts/install.sh        # generates secrets and prompts for admin creds
+
+A name exported in your shell overrides its .env line; unset it to use .env.
 
 To bypass this check (e.g., for unusual deployment paths):
     make dev SKIP_PREFLIGHT=1
@@ -73,10 +89,11 @@ fi
 # Accept the standard alphabet too (`+/`), because base64.urlsafe_b64decode
 # does, and refusing a value the app takes would be a false failure.
 for var in SECRET_ENCRYPTION_KEY SECRET_ENCRYPTION_KEY_PREVIOUS; do
-    value="$(get_env_value "$var" "$ENV_FILE" || true)"
+    value=""
+    effective_env_value_into value "$var" "$ENV_FILE" || true
     if [ -n "$value" ] && ! printf '%s' "$value" | grep -Eq '^[A-Za-z0-9+/_-]{43}=$'; then
         cat >&2 <<EOF
-Pre-flight: $var in .env is not a valid encryption key.
+Pre-flight: $var in $(value_source "$var") is not a valid encryption key.
 
 The API refuses to boot on a malformed value. It must be url-safe base64 of 32
 random bytes, which is not what \`openssl rand -hex 32\` produces:
@@ -90,4 +107,4 @@ EOF
     fi
 done
 
-echo "Pre-flight: .env required vars OK (JWT_SECRET_KEY, GEOLENS_ADMIN_USERNAME, GEOLENS_ADMIN_PASSWORD)"
+echo "Pre-flight: required vars OK (JWT_SECRET_KEY, GEOLENS_ADMIN_USERNAME, GEOLENS_ADMIN_PASSWORD)"

--- a/scripts/tests/test-env-file-compose-oracle.sh
+++ b/scripts/tests/test-env-file-compose-oracle.sh
@@ -113,6 +113,44 @@ _our_value_via_env_value_into() {
   ( . "$REPO_ROOT/lib/common.sh" && env_value_into _test_target "$1" "$2" && printf '%s' "$_test_target" )
 }
 
+# effective_env_value_into's resolution, the same way: source in a subshell,
+# assign into a scratch variable, read it back.
+_our_effective_value() {
+  # shellcheck disable=SC2154  # _test_effective is assigned by the eval
+  # inside effective_env_value_into (scripts/lib/common.sh).
+  ( . "$REPO_ROOT/lib/common.sh" && effective_env_value_into _test_effective "$1" "$2" && printf '%s' "$_test_effective" )
+}
+
+# fix(#1886): a top-level ${KEY} resolves from the process environment first,
+# so this compares effective_env_value_into against the oracle (get_env_value
+# keeps its file-only contract and is not what preflight-env.sh reads).
+_assert_effective_matches_compose() {
+  _aem_key="$1"
+  _aem_file="$2"
+  _aem_desc="$3"
+
+  _aem_ours="$(_our_effective_value "$_aem_key" "$_aem_file" && printf x)"
+  _aem_ours_rc=$?
+  _aem_ours="${_aem_ours%x}"
+
+  if [ "$_aem_ours_rc" -ne 0 ]; then
+    bad "$_aem_desc (effective_env_value_into itself failed unexpectedly, rc=$_aem_ours_rc)"
+    return
+  fi
+
+  _aem_theirs="$(_compose_value "$_aem_key" "$_aem_file" && printf x)" || {
+    bad "$_aem_desc (docker compose config itself failed to resolve $_aem_key)"
+    return
+  }
+  _aem_theirs="${_aem_theirs%x}"
+
+  if [ "$_aem_ours" = "$_aem_theirs" ]; then
+    ok "$_aem_desc (both resolve to [$_aem_ours])"
+  else
+    bad "$_aem_desc (effective_env_value_into=[$_aem_ours] Compose=[$_aem_theirs])"
+  fi
+}
+
 # Compares get_env_value's resolution of KEY in FILE against Compose's own.
 # Both captures are sentinel-protected so neither side loses a real
 # trailing newline before the comparison even runs.
@@ -444,6 +482,18 @@ unset TARGETVAR
 _assert_matches_compose USES_PLAIN "$PREC_ENV"   "env unset + file key set (fromfile): falls back to the file"
 
 _assert_matches_compose USES_UNSET_COLON_DASH "$PREC_ENV"   "env unset + file key also unset + \${X:-default}: the default applies"
+
+# fix(#1886): the key ITSELF, not a reference to it, resolves the same way
+# for a plain ${TARGETVAR}; this is the read preflight-env.sh now performs.
+export TARGETVAR=fromenv
+_assert_effective_matches_compose TARGETVAR "$PREC_ENV"   "env set (fromenv) + the same key in the file (fromfile): effective_env_value_into takes the environment, like Compose"
+unset TARGETVAR
+
+export TARGETVAR=
+_assert_effective_matches_compose TARGETVAR "$PREC_ENV"   "env set but EMPTY + the same key in the file: the empty environment value wins over the file line"
+unset TARGETVAR
+
+_assert_effective_matches_compose TARGETVAR "$PREC_ENV"   "env unset + the key in the file: effective_env_value_into falls back to the file line"
 
 
 # ============================================================================

--- a/scripts/tests/test-env-file-compose-oracle.sh
+++ b/scripts/tests/test-env-file-compose-oracle.sh
@@ -265,20 +265,22 @@ _assert_errors_like_compose() {
   _aelc_key="$1"
   _aelc_file="$2"
   _aelc_desc="$3"
+  # fix(#1886): optional resolver, default get_env_value's own path.
+  _aelc_resolve="${4:-_our_value}"
 
-  if _our_value "$_aelc_key" "$_aelc_file" >/dev/null 2>&1; then
-    bad "$_aelc_desc (get_env_value succeeded, expected it to fail closed)"
+  if "$_aelc_resolve" "$_aelc_key" "$_aelc_file" >/dev/null 2>&1; then
+    bad "$_aelc_desc ($_aelc_resolve succeeded, expected it to fail closed)"
     return
   fi
 
   _aelc_compose_rc=0
   _compose_resolve_json "$_aelc_key" "$_aelc_file" >/dev/null 2>&1 || _aelc_compose_rc=$?
   if [ "$_aelc_compose_rc" -eq 0 ]; then
-    bad "$_aelc_desc (get_env_value failed closed, but real Compose did NOT — the pinned expectation may be wrong)"
+    bad "$_aelc_desc ($_aelc_resolve failed closed, but real Compose did NOT. The pinned expectation may be wrong)"
     return
   fi
 
-  ok "$_aelc_desc (both get_env_value and Compose itself fail to resolve it)"
+  ok "$_aelc_desc (both $_aelc_resolve and Compose itself fail to resolve it)"
 }
 
 # fix(#1778 round 22, P2): _compose_value/_assert_matches_compose cannot
@@ -494,6 +496,21 @@ _assert_effective_matches_compose TARGETVAR "$PREC_ENV"   "env set but EMPTY + t
 unset TARGETVAR
 
 _assert_effective_matches_compose TARGETVAR "$PREC_ENV"   "env unset + the key in the file: effective_env_value_into falls back to the file line"
+
+# fix(#1886): Compose loads the whole file before the override applies, so
+# a line it refuses fails even with the key exported; a bare line does not.
+REFUSED_ENV="$WORK/.env.refused"
+printf 'TARGETVAR=${NO_SUCH_VAR:?boom}\n' > "$REFUSED_ENV"
+export TARGETVAR=fromenv
+_assert_errors_like_compose TARGETVAR "$REFUSED_ENV"   "env set (fromenv) + the same key's file line is \${NO_SUCH_VAR:?boom}: the exported value does not rescue a file Compose refuses to load" _our_effective_value
+unset TARGETVAR
+_assert_errors_like_compose TARGETVAR "$REFUSED_ENV"   "env unset + the same refused line: effective_env_value_into fails closed like Compose" _our_effective_value
+
+BARE_ENV="$WORK/.env.bare"
+printf 'TARGETVAR\n' > "$BARE_ENV"
+export TARGETVAR=fromenv
+_assert_effective_matches_compose TARGETVAR "$BARE_ENV"   "env set (fromenv) + a bare TARGETVAR line: the line inherits the export and is not refused"
+unset TARGETVAR
 
 
 # ============================================================================

--- a/scripts/tests/test-preflight-env.sh
+++ b/scripts/tests/test-preflight-env.sh
@@ -259,6 +259,44 @@ REQUIRED_LINES="JWT_SECRET_KEY=$NONEMPTY
 GEOLENS_ADMIN_USERNAME=admin
 GEOLENS_ADMIN_PASSWORD=$NONEMPTY"
 
+# ============================================================================
+# CASE 7 (fix(#1886)): a line Compose refuses to load is refused, exported or not.
+# ============================================================================
+run_preflight_env SECRET_ENCRYPTION_KEY "$VALID_KEY" 'SECRET_ENCRYPTION_KEY=${NO_SUCH_VAR:?boom}'
+if [ "$STATUS" -ne 0 ] && grep -q "SECRET_ENCRYPTION_KEY line in .env" "$WORK/out.txt"; then
+    ok "a valid exported key over a line Compose refuses is refused, naming the .env line"
+else
+    bad "a valid exported key masked a line Compose refuses (exit $STATUS): $(cat "$WORK/out.txt")"
+fi
+
+run_preflight 'SECRET_ENCRYPTION_KEY=${NO_SUCH_VAR:?boom}'
+if [ "$STATUS" -ne 0 ] && grep -q "SECRET_ENCRYPTION_KEY line in .env" "$WORK/out.txt"; then
+    ok "the same line is refused with nothing exported"
+else
+    bad "a line Compose refuses passed with nothing exported (exit $STATUS): $(cat "$WORK/out.txt")"
+fi
+
+run_preflight_env SECRET_ENCRYPTION_KEY "$VALID_KEY" 'SECRET_ENCRYPTION_KEY="unterminated'
+if [ "$STATUS" -ne 0 ] && grep -q "SECRET_ENCRYPTION_KEY line in .env" "$WORK/out.txt"; then
+    ok "an unterminated quote is refused under a valid exported key too"
+else
+    bad "a valid exported key masked an unterminated quote (exit $STATUS): $(cat "$WORK/out.txt")"
+fi
+
+run_preflight_env SECRET_ENCRYPTION_KEY "$VALID_KEY" "SECRET_ENCRYPTION_KEY"
+if [ "$STATUS" -eq 0 ]; then
+    ok "a bare KEY line inherits the exported key and is not refused"
+else
+    bad "a bare KEY line was refused under an exported key: $(cat "$WORK/out.txt")"
+fi
+
+run_preflight "SECRET_ENCRYPTION_KEY"
+if [ "$STATUS" -eq 0 ]; then
+    ok "a bare KEY line with nothing exported reads as unset and passes"
+else
+    bad "a bare KEY line with nothing exported was refused: $(cat "$WORK/out.txt")"
+fi
+
 echo "1..$((PASS + FAIL))"
 echo "# ${PASS} passed, ${FAIL} failed"
 [ "$FAIL" -eq 0 ]

--- a/scripts/tests/test-preflight-env.sh
+++ b/scripts/tests/test-preflight-env.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# Regression test for scripts/preflight-env.sh (fix(#1882)).
+# Regression test for scripts/preflight-env.sh (fix(#1882), fix(#1886)).
 #
 # `make dev` runs preflight before any Compose build, so a false failure here
 # blocks the stack on a well-formed .env. The encryption-key shape check added
@@ -64,6 +64,17 @@ run_preflight() {
         printf '%s\n' "$1" >> "$FAKE/.env"
     fi
     bash "$FAKE/scripts/preflight-env.sh" > "$WORK/out.txt" 2>&1
+    STATUS=$?
+}
+
+# Same, with NAME=VALUE exported into preflight's environment, the way an
+# operator's shell hands it to `make dev` and then to Compose.
+run_preflight_env() {
+    printf '%s\n' "$REQUIRED_LINES" > "$FAKE/.env"
+    if [ $# -gt 2 ]; then
+        printf '%s\n' "$3" >> "$FAKE/.env"
+    fi
+    env "$1=$2" bash "$FAKE/scripts/preflight-env.sh" > "$WORK/out.txt" 2>&1
     STATUS=$?
 }
 
@@ -185,6 +196,68 @@ if [ "$STATUS" -ne 0 ] && grep -q "not found" "$WORK/out.txt"; then
 else
     bad "a missing .env did not fail as expected (exit $STATUS)"
 fi
+
+# ============================================================================
+# CASE 6 (fix(#1886)): an exported name overrides its .env line for Compose.
+# ============================================================================
+run_preflight_env SECRET_ENCRYPTION_KEY "$HEX_VALUE" "SECRET_ENCRYPTION_KEY=$VALID_KEY"
+if [ "$STATUS" -ne 0 ] && grep -q "SECRET_ENCRYPTION_KEY" "$WORK/out.txt" && grep -q "environment" "$WORK/out.txt"; then
+    ok "a malformed exported key is refused over a valid .env line, naming the environment as the source"
+else
+    bad "a malformed exported key was masked by a valid .env line (exit $STATUS): $(cat "$WORK/out.txt")"
+fi
+
+run_preflight_env SECRET_ENCRYPTION_KEY "$VALID_KEY" "SECRET_ENCRYPTION_KEY=$HEX_VALUE"
+if [ "$STATUS" -eq 0 ]; then
+    ok "a valid exported key passes over a malformed .env line"
+else
+    bad "a valid exported key was rejected because of the .env line: $(cat "$WORK/out.txt")"
+fi
+
+run_preflight_env SECRET_ENCRYPTION_KEY_PREVIOUS not-a-key "SECRET_ENCRYPTION_KEY_PREVIOUS=$VALID_KEY"
+if [ "$STATUS" -ne 0 ] && grep -q "SECRET_ENCRYPTION_KEY_PREVIOUS" "$WORK/out.txt"; then
+    ok "the previous key is checked from the environment too"
+else
+    bad "a malformed exported previous key was accepted over a valid .env line (exit $STATUS)"
+fi
+
+run_preflight_env SECRET_ENCRYPTION_KEY "$HEX_VALUE"
+if [ "$STATUS" -ne 0 ] && grep -q "SECRET_ENCRYPTION_KEY" "$WORK/out.txt"; then
+    ok "a malformed exported key is refused when .env has no line for it"
+else
+    bad "a malformed exported key was accepted when .env had no line for it (exit $STATUS)"
+fi
+
+# Compose passes the key as "${SECRET_ENCRYPTION_KEY:-}", so an exported empty
+# value reaches the app as unset even when .env holds a line.
+run_preflight_env SECRET_ENCRYPTION_KEY "" "SECRET_ENCRYPTION_KEY=$HEX_VALUE"
+if [ "$STATUS" -eq 0 ]; then
+    ok "an exported empty key passes over a malformed .env line (Compose sends the empty value)"
+else
+    bad "an exported empty key did not mask the .env line: $(cat "$WORK/out.txt")"
+fi
+
+# The required trio reaches Compose as a plain ${VAR}, so an exported empty
+# value is what the container gets.
+run_preflight_env JWT_SECRET_KEY ""
+if [ "$STATUS" -ne 0 ] && grep -q "JWT_SECRET_KEY" "$WORK/out.txt" && grep -q "environment" "$WORK/out.txt"; then
+    ok "an exported empty JWT_SECRET_KEY is refused over a non-empty .env line, naming the environment"
+else
+    bad "an exported empty JWT_SECRET_KEY was masked by the .env line (exit $STATUS): $(cat "$WORK/out.txt")"
+fi
+
+REQUIRED_LINES="JWT_SECRET_KEY=
+GEOLENS_ADMIN_USERNAME=admin
+GEOLENS_ADMIN_PASSWORD=$NONEMPTY"
+run_preflight_env JWT_SECRET_KEY "$NONEMPTY"
+if [ "$STATUS" -eq 0 ]; then
+    ok "an exported JWT_SECRET_KEY satisfies the check over an empty .env line"
+else
+    bad "an exported JWT_SECRET_KEY was ignored over an empty .env line: $(cat "$WORK/out.txt")"
+fi
+REQUIRED_LINES="JWT_SECRET_KEY=$NONEMPTY
+GEOLENS_ADMIN_USERNAME=admin
+GEOLENS_ADMIN_PASSWORD=$NONEMPTY"
 
 echo "1..$((PASS + FAIL))"
 echo "# ${PASS} passed, ${FAIL} failed"


### PR DESCRIPTION
Tracked in #1886, follow-up to #1882.

## Defect

`scripts/preflight-env.sh` read `SECRET_ENCRYPTION_KEY` and `SECRET_ENCRYPTION_KEY_PREVIOUS` from the top-level `.env` line only. Both compose manifests pass them as `"${SECRET_ENCRYPTION_KEY:-}"`, and Compose resolves that from the exported environment before the file (pinned in the precedence corpus of `scripts/tests/test-env-file-compose-oracle.sh`). Two wrong outcomes followed. A valid `.env` line with a malformed exported override passed preflight, then the API refused to boot. A malformed `.env` line with a valid exported override was refused for no reason.

The required trio had the same gap. The manifests pass it as a plain `${JWT_SECRET_KEY}`, so an exported empty value reaches the container empty while preflight read the non-empty `.env` line and passed.

Reproduced on main (56aa03abe) against a throwaway tree with a valid key in `.env` and `openssl rand -hex 32` exported:

```
$ SECRET_ENCRYPTION_KEY=<hex> bash scripts/preflight-env.sh
Pre-flight: .env required vars OK (JWT_SECRET_KEY, GEOLENS_ADMIN_USERNAME, GEOLENS_ADMIN_PASSWORD)
exit=0
```

and the other way round, hex in `.env` and a valid key exported:

```
$ SECRET_ENCRYPTION_KEY=<valid> bash scripts/preflight-env.sh
Pre-flight: SECRET_ENCRYPTION_KEY in .env is not a valid encryption key.
exit=1
```

Compose itself, with the exact manifest forms and `fromfile` for both names in the env file:

```
exported fromenv:  {'JWT_SECRET_KEY': 'fromenv', 'SECRET_ENCRYPTION_KEY': 'fromenv'}
exported empty:    {'JWT_SECRET_KEY': '', 'SECRET_ENCRYPTION_KEY': ''}
nothing exported:  {'JWT_SECRET_KEY': 'fromfile', 'SECRET_ENCRYPTION_KEY': 'fromfile'}
```

## Fix

`scripts/lib/common.sh` gains `effective_env_value_into VAR KEY FILE`. It takes the exported environment when that sets KEY, even to an empty string, and otherwise the file's last `KEY=` line through `env_value_into`. The environment read uses the frozen snapshot `get_env_value` already consults for a bare `KEY` line, so it sees what Compose was handed rather than a shell variable set later in the script. `env_is_exported NAME` exposes the predicate. The identifier guard `env_value_into` had inline moved to `_env_assert_var_name` so both functions share it, with the same messages.

`scripts/preflight-env.sh` routes all five lookups through the helper. Each failure now names the source, ".env" or "your shell environment (which overrides .env)", so an operator edits the right place. One rule covers both checks because of the manifest forms: under `${KEY:-}` an exported empty value means no key, which the shape check already lets through; under a plain `${VAR}` it means empty, which the required check refuses.

`scripts/README.md` gets a one-line description update.

`get_env_value` keeps its file-only contract. `restore.sh`, `check-env.sh` and `upgrade.sh` build on it: they assign when the key is present in the file and keep an inherited value only when the file has no line. For a key that is in both places that is the opposite of Compose's precedence, the same class as this issue, but on the disaster-recovery path. I left it alone since #1886 does not ask for it; it deserves its own issue.

The boot guard in `backend/app/core/config.py` is untouched and remains the real refusal.

## Tests

`scripts/tests/test-preflight-env.sh` CASE 6 adds seven cases: a malformed override over a valid line is refused and the message names the environment; a valid override over a malformed line passes; the previous key is checked from the environment too; a malformed override with no `.env` line is refused; an exported empty key over a malformed line passes; an exported empty `JWT_SECRET_KEY` over a non-empty line is refused; an exported `JWT_SECRET_KEY` over an empty line passes.

`scripts/tests/test-env-file-compose-oracle.sh` compares `effective_env_value_into` against real `docker compose config` for the key itself with the environment set, set but empty, and unset.

## Verification

Run from the worktree at 69b8b5bd5, once with macOS `sh` and once with `dash` (CI's `sh`), which exercises both branches of the environment snapshot:

| command | result |
|---|---|
| `sh scripts/tests/test-preflight-env.sh` | 20 passed, 0 failed |
| `sh scripts/tests/test-env-file-compose-oracle.sh` | 103 passed, 0 failed |
| `sh scripts/tests/test-restore-env-sourcing-safety.sh` | 54 passed, 0 failed |
| `sh scripts/tests/test-runbook-env-value-guarded.sh` | 4 passed, 0 failed |
| `sh scripts/tests/test-upgrade-order.sh` | 102 passed, 0 failed |
| `sh scripts/tests/test-restore-trap-safety.sh` | 10 passed, 0 failed |

`shellcheck` on the five files reports only findings that exist on main.

Counterfactual, with `scripts/preflight-env.sh` and `scripts/lib/common.sh` reset to origin/main and the tests kept:

```
$ sh scripts/tests/test-preflight-env.sh
not ok 14 - a malformed exported key was masked by a valid .env line (exit 0): Pre-flight: .env required vars OK ...
not ok 15 - a valid exported key was rejected because of the .env line: Pre-flight: SECRET_ENCRYPTION_KEY in .env is not a valid encryption key.
not ok 16 - a malformed exported previous key was accepted over a valid .env line (exit 0)
not ok 17 - a malformed exported key was accepted when .env had no line for it (exit 0)
not ok 18 - an exported empty key did not mask the .env line: Pre-flight: SECRET_ENCRYPTION_KEY in .env is not a valid encryption key.
not ok 19 - an exported empty JWT_SECRET_KEY was masked by the .env line (exit 0): Pre-flight: .env required vars OK ...
not ok 20 - an exported JWT_SECRET_KEY was ignored over an empty .env line: Pre-flight: the following required vars are empty in .env:
# 13 passed, 7 failed

$ sh scripts/tests/test-env-file-compose-oracle.sh
not ok 22 ... (effective_env_value_into itself failed unexpectedly, rc=127)
not ok 23 ... (effective_env_value_into itself failed unexpectedly, rc=127)
not ok 24 ... (effective_env_value_into itself failed unexpectedly, rc=127)
# 100 passed, 3 failed
```

## Impact

Scripts only. No schema, API or config change. `make dev` behaves differently only when a checked name is exported in the operator's shell, and in that case it now agrees with Compose.

## Round 1 (codex P2)

The round-1 helper returned the exported value without parsing the `.env` line. Compose reads every line of `.env` before the shell environment applies, so a line it refuses to load (an unterminated quote, or `${NAME:?msg}` on an unset NAME) aborts `docker compose up` even when the checked name is exported, and preflight let it through. Checked against real Compose with that exact shape:

```
$ SECRET_ENCRYPTION_KEY=fromenv docker compose -f oracle.yml --env-file .env.fatal config
failed to read .env.fatal: required variable NO_SUCH_VAR is missing a value: boom
```

One more fact turned up while reproducing. On main the same line already passed preflight with nothing exported: `get_env_value` returns 1 silently for a refused line, and preflight read that as absent. So this was a gap for the checked keys with or without an override.

Fix in 2da6493c5. `effective_env_value_into` now parses the file line first and returns rc 2, target untouched, when the new `env_file_refuses_key` says the line is one Compose rejects (a value line that does not resolve, or an unterminated quote). A bare `KEY` line inherits from the environment and never counts. preflight maps rc 2 to a refusal that names the `.env` line, exported or not. A refused line on a key preflight does not check still passes preflight; that is unchanged and out of scope here.

Tests: CASE 7 in `scripts/tests/test-preflight-env.sh`, five cases. An exported valid key over `${NO_SUCH_VAR:?boom}` is refused and the message names the line; the same line is refused with nothing exported; an unterminated quote is refused under an exported key; a bare line is accepted with and without an export. In the oracle, `_assert_errors_like_compose` takes an optional resolver, and three cases pin `effective_env_value_into` against real `docker compose config` for the refused line exported and unexported, plus the bare line exported.

Verification at 2da6493c5, once with macOS `sh` and once with `dash`:

| command | result |
|---|---|
| `sh scripts/tests/test-preflight-env.sh` | 25 passed, 0 failed |
| `sh scripts/tests/test-env-file-compose-oracle.sh` | 106 passed, 0 failed |
| `sh scripts/tests/test-restore-env-sourcing-safety.sh` | 54 passed, 0 failed |
| `sh scripts/tests/test-runbook-env-value-guarded.sh` | 4 passed, 0 failed |
| `sh scripts/tests/test-upgrade-order.sh` | 102 passed, 0 failed |
| `sh scripts/tests/test-restore-trap-safety.sh` | 10 passed, 0 failed |

`shellcheck` adds one SC1091 info on the new sourcing line and three SC2016 info on deliberate `${...}` literals in tests. Both classes are already present in these files on main.

Counterfactual, with `scripts/lib/common.sh` and `scripts/preflight-env.sh` reset to the round-1 commit 69b8b5bd5 and the tests kept:

```
$ sh scripts/tests/test-preflight-env.sh
not ok 21 - a valid exported key masked a line Compose refuses (exit 0): Pre-flight: required vars OK ...
not ok 22 - a line Compose refuses passed with nothing exported (exit 0): Pre-flight: required vars OK ...
not ok 23 - a valid exported key masked an unterminated quote (exit 0): Pre-flight: required vars OK ...
# 22 passed, 3 failed

$ sh scripts/tests/test-env-file-compose-oracle.sh
not ok 25 - env set (fromenv) + the same key's file line is ${NO_SUCH_VAR:?boom}: ... (_our_effective_value succeeded, expected it to fail closed)
# 105 passed, 1 failed
```
