### PR TITLE
fix(search): count facets over the results' candidate set (#1855)

### DIFF
--- a/backend/app/core/persistent_config.py
+++ b/backend/app/core/persistent_config.py
@@ -70,7 +70,7 @@ def _get_cache_safe() -> CacheProvider | None:
 _sync_rate_limit_cache: dict[str, tuple[Any, float]] = {}
 _DEFAULT_LOGIN_RATE_LIMIT = 5
 _DEFAULT_GLOBAL_RATE_LIMIT = 60
-_DEFAULT_SEMANTIC_SEARCH_RATE_LIMIT = 60
+_DEFAULT_SEMANTIC_SEARCH_RATE_LIMIT = 30
 _DEFAULT_BASEMAP_PROXY_RATE_LIMIT = 120
 # Ceiling for the OGC API Features items page size (`limit`). Conservative by
 # default (#665 review): the offset path is O(N) and the response is built fully
@@ -1020,9 +1020,7 @@ def get_cached_semantic_search_rate_limit() -> int:
     """Sync accessor for slowapi callable -- reads from sync cache, falls back to default.
 
     SEC-S11: caps OpenAI embedding cost-DoS by limiting unique novel queries per IP.
-    /search/datasets/ and /search/facets/ draw on one shared bucket (fix(#1855))
-    and the SPA hits them as a pair per query change, so the default is 60/min:
-    twice the audit's 30 per endpoint, the same 30 query changes per minute.
+    Default 30/min matches the audit recommendation for cost-sensitive endpoints.
     Configurable at runtime via the admin Settings UI / PUT /settings/ with key
     `semantic_search_rate_limit` (there is no SEMANTIC_SEARCH_RATE_LIMIT env var;
     Settings uses extra="ignore").

--- a/backend/app/core/persistent_config.py
+++ b/backend/app/core/persistent_config.py
@@ -70,7 +70,7 @@ def _get_cache_safe() -> CacheProvider | None:
 _sync_rate_limit_cache: dict[str, tuple[Any, float]] = {}
 _DEFAULT_LOGIN_RATE_LIMIT = 5
 _DEFAULT_GLOBAL_RATE_LIMIT = 60
-_DEFAULT_SEMANTIC_SEARCH_RATE_LIMIT = 30
+_DEFAULT_SEMANTIC_SEARCH_RATE_LIMIT = 60
 _DEFAULT_BASEMAP_PROXY_RATE_LIMIT = 120
 # Ceiling for the OGC API Features items page size (`limit`). Conservative by
 # default (#665 review): the offset path is O(N) and the response is built fully
@@ -1020,7 +1020,9 @@ def get_cached_semantic_search_rate_limit() -> int:
     """Sync accessor for slowapi callable -- reads from sync cache, falls back to default.
 
     SEC-S11: caps OpenAI embedding cost-DoS by limiting unique novel queries per IP.
-    Default 30/min matches the audit recommendation for cost-sensitive endpoints.
+    /search/datasets/ and /search/facets/ draw on one shared bucket (fix(#1855))
+    and the SPA hits them as a pair per query change, so the default is 60/min:
+    twice the audit's 30 per endpoint, the same 30 query changes per minute.
     Configurable at runtime via the admin Settings UI / PUT /settings/ with key
     `semantic_search_rate_limit` (there is no SEMANTIC_SEARCH_RATE_LIMIT env var;
     Settings uses extra="ignore").

--- a/backend/app/modules/catalog/search/cache.py
+++ b/backend/app/modules/catalog/search/cache.py
@@ -87,9 +87,10 @@ def build_cache_key(
     handles ``date``/``UUID`` fields on the dataclass; ``sort_keys=True`` makes
     the digest stable across Python versions.
 
-    ``public_api_url``, ``public_app_url`` and ``semantic_enabled`` are included
-    only for the "search" endpoint — facets responses carry no URLs and do not
-    run semantic ranking, so passing ``None`` keeps facet keys stable.
+    ``public_api_url`` and ``public_app_url`` are included only for the
+    "search" endpoint, since facets responses carry no URLs. ``semantic_enabled``
+    is part of both keys: fix(#1855) made facets count over the same
+    semantic-or-lexical candidate set as the results.
     ``public_app_url`` is in the key because raster_tiles asset hrefs are built
     against the app origin (fix(#315)); a multi-origin deployment with a fixed
     PUBLIC_API_URL but request-derived PUBLIC_APP_URL would otherwise serve a

--- a/backend/app/modules/catalog/search/router.py
+++ b/backend/app/modules/catalog/search/router.py
@@ -462,10 +462,9 @@ def _semantic_search_rate_limit(_request: Request | None = None) -> str:
     "/facets", response_model=FacetCountResponse, include_in_schema=False
 )
 @search_router.get("/facets/", response_model=FacetCountResponse)
-# WR-02: no semantic-search rate limit on /facets/ — this endpoint does pure
-# SQL aggregation and never calls the embedding model. Applying the 30/min
-# embedding cost-cap (SEC-S11) here would silently throttle SPA users who
-# refresh the search UI more than 30 times per minute.
+# fix(#1855): facets embed the query to count over the results' candidate set,
+# so they carry the same SEC-S11 embedding-cost limit as /datasets/.
+@limiter.limit(_semantic_search_rate_limit)
 async def search_facets_endpoint(
     request: Request,
     q: str | None = Query(None, max_length=1000, description="Full-text search query"),
@@ -523,7 +522,7 @@ async def search_facets_endpoint(
             filters=facet_filters,
             user_roles=user_roles,
             public_api_url=None,
-            semantic_enabled=None,
+            semantic_enabled=await SEMANTIC_SEARCH_ENABLED.get(db),
         )
         cached = await search_cache.get_cached(facet_cache_key)
         if cached is not None:

--- a/backend/app/modules/catalog/search/router.py
+++ b/backend/app/modules/catalog/search/router.py
@@ -462,9 +462,9 @@ def _semantic_search_rate_limit(_request: Request | None = None) -> str:
     "/facets", response_model=FacetCountResponse, include_in_schema=False
 )
 @search_router.get("/facets/", response_model=FacetCountResponse)
-# fix(#1855): facets embed the query to count over the results' candidate set,
-# so they carry the same SEC-S11 embedding-cost limit as /datasets/.
-@limiter.limit(_semantic_search_rate_limit)
+# fix(#1855): facets embed the query, so both search routes draw on ONE SEC-S11
+# bucket; two buckets let a caller alternating them embed twice the cap.
+@limiter.shared_limit(_semantic_search_rate_limit, scope="semantic_search")
 async def search_facets_endpoint(
     request: Request,
     q: str | None = Query(None, max_length=1000, description="Full-text search query"),
@@ -551,7 +551,7 @@ async def search_facets_endpoint(
     response_model=OGCFeatureCollectionResponse,
     responses={400: BAD_REQUEST_RESPONSE},
 )
-@limiter.limit(_semantic_search_rate_limit)
+@limiter.shared_limit(_semantic_search_rate_limit, scope="semantic_search")
 async def search_datasets_endpoint(
     request: Request,
     response: Response,

--- a/backend/app/modules/catalog/search/service_candidates.py
+++ b/backend/app/modules/catalog/search/service_candidates.py
@@ -1,0 +1,140 @@
+"""Candidate selection shared by dataset search and facet counts.
+
+fix(#1855): the results and facets endpoints must agree on which records a
+query matches, so both build their candidate set through ``select_candidates``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from sqlalchemy import Select, and_, or_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.sql.elements import ColumnElement
+
+from app.core.identity import Identity
+from app.modules.catalog.authorization import apply_visibility_filter
+from app.modules.catalog.datasets.domain.models import Dataset, DatasetGrant, Record
+from app.modules.catalog.search.service_filters import (
+    SearchFilters,
+    _apply_common_filters,
+    _build_text_filter,
+)
+from app.modules.catalog.search.service_semantic import (
+    SemanticArm,
+    resolve_semantic_arm,
+)
+
+
+def _apply_search_only_filters(stmt: Select, filters: SearchFilters) -> Select:
+    """Apply filters that belong to /search but NOT to /facets.
+
+    Handles record_type, record_ids, external_ids, date_from, date_to,
+    vintage_start, vintage_end, and cql2_filter. Spatial / keyword / org /
+    srid filters are already applied via _apply_common_filters and stay shared.
+    """
+    if filters.record_type:
+        stmt = stmt.where(Record.record_type == filters.record_type)
+    if filters.record_ids is not None:
+        # An empty tuple (a standards type filter excluded every type this
+        # collection emits) renders as a false predicate: an empty page.
+        stmt = stmt.where(Dataset.id.in_(filters.record_ids))
+    if filters.external_ids is not None:
+        # externalIds names the resource in its SOURCE system. Only STAC imports
+        # keep that id in source_filename; service imports store a layer title
+        # there, so they stay excluded until their layer id is persisted.
+        remote_formats = ("stac",)
+        stmt = stmt.where(
+            and_(
+                Dataset.source_format.in_(remote_formats),
+                Dataset.source_filename.in_(filters.external_ids),
+            )
+        )
+    if filters.date_from:
+        stmt = stmt.where(Record.created_at >= filters.date_from)
+    if filters.date_to:
+        stmt = stmt.where(Record.created_at <= filters.date_to)
+    if filters.vintage_start:
+        stmt = stmt.where(Record.temporal_start >= filters.vintage_start)
+    if filters.vintage_end:
+        stmt = stmt.where(Record.temporal_end <= filters.vintage_end)
+
+    # CQL2 structured filter (applied AFTER visibility + facets)
+    if filters.cql2_filter:
+        from app.standards.ogc.filtering import apply_cql2_filter
+
+        stmt = apply_cql2_filter(stmt, filters.cql2_filter, filters.cql2_filter_lang)
+    return stmt
+
+
+def vetting_filters(
+    stmt: Select,
+    user: Identity | None,
+    user_roles: set[str],
+    filters: SearchFilters,
+    *,
+    search_only: bool,
+) -> Select:
+    """Apply what every candidate must satisfy, however it matched the query.
+
+    Visibility (Rule 1) and the shared filters always; the result-only filters
+    (record type, dates, CQL2) when ``search_only`` is set. Facets leave those
+    off so the type counts cover every type.
+    """
+    stmt = apply_visibility_filter(stmt, user, user_roles, Record, DatasetGrant)
+    stmt = _apply_common_filters(stmt, filters, skip_text=True)
+    if search_only:
+        stmt = _apply_search_only_filters(stmt, filters)
+    return stmt
+
+
+@dataclass(frozen=True, slots=True)
+class Candidates:
+    """A query's candidate set and how its rows matched.
+
+    ``stmt`` is the caller's base statement with the vetting filters and the
+    match clause applied. ``text_clause``/``text_parts`` are None without a
+    text query; ``semantic`` is None in lexical mode.
+    """
+
+    stmt: Select
+    text_clause: ColumnElement[bool] | None
+    text_parts: dict[str, Any] | None
+    semantic: SemanticArm | None
+
+
+async def select_candidates(
+    session: AsyncSession,
+    base: Select,
+    user: Identity | None,
+    user_roles: set[str],
+    filters: SearchFilters,
+    *,
+    search_only: bool,
+    depth: int,
+) -> Candidates:
+    """Apply the shared candidate selection to ``base``.
+
+    Both /search/datasets/ and /search/facets/ call this, so they take the same
+    visibility filter, the same shared filters, the same text clause and the
+    same semantic mode decision for a query. In semantic mode a row matches by
+    text OR by vector; ``depth`` is how many nearest vector ids the caller
+    needs, at least 1.
+    """
+    stmt = vetting_filters(base, user, user_roles, filters, search_only=search_only)
+    if not (filters.q and filters.q.strip()):
+        return Candidates(stmt, None, None, None)
+    text_clause, text_parts = _build_text_filter(filters.q)
+    vet_stmt = vetting_filters(
+        select(Record.id)
+        .select_from(Dataset)
+        .join(Record, Dataset.record_id == Record.id),
+        user,
+        user_roles,
+        filters,
+        search_only=search_only,
+    )
+    semantic = await resolve_semantic_arm(session, filters, vet_stmt, depth=depth)
+    match = text_clause if semantic is None else or_(text_clause, semantic.clause())
+    return Candidates(stmt.where(match), text_clause, text_parts, semantic)

--- a/backend/app/modules/catalog/search/service_datasets.py
+++ b/backend/app/modules/catalog/search/service_datasets.py
@@ -4,40 +4,36 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 
-from sqlalchemy import Select, and_, case, collate, func, literal, or_, select, text
+from typing import Any
+
+from sqlalchemy import Select, case, collate, func, literal, or_, select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 from sqlalchemy.sql.elements import ColumnElement, Label
 
 from app.core.identity import Identity
-from app.core.persistent_config import SEMANTIC_SEARCH_ENABLED
-from app.modules.catalog.authorization import apply_visibility_filter
 from app.modules.catalog.datasets.domain.models import (
     Dataset,
-    DatasetGrant,
     Record,
     RecordTranslation,
 )
-from app.modules.catalog.search.service_filters import (
-    SearchFilters,
-    _apply_common_filters,
-    _build_text_filter,
+from app.modules.catalog.search.service_candidates import (
+    select_candidates,
+    vetting_filters,
 )
+from app.modules.catalog.search.service_filters import SearchFilters
 from app.modules.catalog.search.service_semantic import (
     _attach_updated_actor_identities,
     _run_rrf_merge,
 )
 
 
-def _build_fts_rank_col(
-    filters: SearchFilters,
-) -> tuple[ColumnElement[bool], Label[float]]:
-    """Build the FTS composite rank column + matching WHERE clause.
+def _build_fts_rank_col(parts: dict[str, Any]) -> Label[float]:
+    """Build the FTS composite rank column from ``_build_text_filter`` parts.
 
-    Returns ``(text_clause, rank_col)``. Caller should attach both to the
-    base SELECT via ``.add_columns(rank_col).where(text_clause)``.
+    The caller attaches it next to the text clause the parts came from via
+    ``.add_columns(rank_col).where(text_clause)``.
     """
-    text_clause, parts = _build_text_filter(filters.q)
     ts_query = parts["ts_query"]
     ts_query_simple = parts["ts_query_simple"]
     vector_match = parts["english_vector_match"]
@@ -81,54 +77,7 @@ def _build_fts_rank_col(
         + case((translation_exists, literal(0.3)), else_=literal(0.0))
         + case((translation_partial_exists, literal(0.2)), else_=literal(0.0))
     ).label("rank")
-    return text_clause, rank_col
-
-
-def _apply_search_only_filters(stmt: Select, filters: SearchFilters) -> Select:
-    """Apply filters that belong to /search but NOT to /facets.
-
-    Handles record_type, date_from, date_to, vintage_start, vintage_end,
-    and cql2_filter. Spatial / keyword / org / srid filters are already
-    applied via _apply_common_filters and stay shared.
-    """
-    if filters.record_type:
-        stmt = stmt.where(Record.record_type == filters.record_type)
-    if filters.record_ids is not None:
-        # ``in_`` deliberately receives an empty tuple when a standards type
-        # filter excludes every resource type emitted by this collection;
-        # SQLAlchemy renders a portable false predicate and the response stays
-        # a normal empty FeatureCollection.
-        stmt = stmt.where(Dataset.id.in_(filters.record_ids))
-    if filters.external_ids is not None:
-        # OGC ``externalIds`` identifies the described resource in its source
-        # system; it is distinct from the server-assigned record UUID.  Remote
-        # STAC imports retain the canonical source Item ID in
-        # ``source_filename``. Service imports may store a friendly layer title
-        # there, so WFS/ArcGIS/OAPIF are intentionally excluded until their
-        # canonical layer identifier is persisted on Dataset. Source URLs are
-        # not identifiers because they may contain non-public connection data.
-        remote_formats = ("stac",)
-        stmt = stmt.where(
-            and_(
-                Dataset.source_format.in_(remote_formats),
-                Dataset.source_filename.in_(filters.external_ids),
-            )
-        )
-    if filters.date_from:
-        stmt = stmt.where(Record.created_at >= filters.date_from)
-    if filters.date_to:
-        stmt = stmt.where(Record.created_at <= filters.date_to)
-    if filters.vintage_start:
-        stmt = stmt.where(Record.temporal_start >= filters.vintage_start)
-    if filters.vintage_end:
-        stmt = stmt.where(Record.temporal_end <= filters.vintage_end)
-
-    # CQL2 structured filter (applied AFTER visibility + facets)
-    if filters.cql2_filter:
-        from app.standards.ogc.filtering import apply_cql2_filter
-
-        stmt = apply_cql2_filter(stmt, filters.cql2_filter, filters.cql2_filter_lang)
-    return stmt
+    return rank_col
 
 
 def _resolve_sort_order(
@@ -277,16 +226,29 @@ async def search_datasets(
 ) -> tuple[list[Dataset], int]:
     """Search datasets with combined FTS + spatial + faceted filtering.
 
-    When SEMANTIC_SEARCH_ENABLED is on and a text query is provided,
-    automatically augments FTS results with vector similarity via
-    Reciprocal Rank Fusion (k=60).
+    The candidate set (and so ``total``) comes from ``select_candidates``, the
+    same selection /search/facets/ counts over. In semantic mode the page is
+    the RRF merge of FTS ranks and the vector arm.
 
     Returns a tuple of (matching_datasets, total_count).
     """
-    has_text_search = False
+    candidates = await select_candidates(
+        session,
+        select(func.count())
+        .select_from(Dataset)
+        .join(Record, Dataset.record_id == Record.id),
+        user,
+        user_roles,
+        filters,
+        search_only=True,
+        depth=filters.skip + filters.limit,
+    )
+    total = (await session.execute(candidates.stmt)).scalar_one()
+
+    has_text_search = candidates.text_clause is not None
     rank_col = None
     # Base query always joins Record with eager-loaded keywords/contacts/distributions
-    base_join = (
+    stmt = (
         select(Dataset)
         .join(Record, Dataset.record_id == Record.id)
         .options(
@@ -296,58 +258,18 @@ async def search_datasets(
             selectinload(Dataset.record).selectinload(Record.translations),
         )
     )
-    # 1. Full-text search (search_vector now on Record + child-table EXISTS)
-    if filters.q and filters.q.strip():
-        text_clause, rank_col = _build_fts_rank_col(filters)
-        stmt = base_join.add_columns(rank_col).where(text_clause)
-        has_text_search = True
-    else:
-        stmt = base_join
-    # 2. RBAC visibility filter (uses Record.visibility/created_by)
-    stmt = apply_visibility_filter(stmt, user, user_roles, Record, DatasetGrant)
-    # 3. Shared filters (spatial, keywords, geometry_type, srid, org, datetime, etc.)
-    # skip_text=True because text search is already applied above with ranking
-    stmt = _apply_common_filters(stmt, filters, skip_text=True)
-    # 4. Search-only filters (not applied to facet counts)
-    stmt = _apply_search_only_filters(stmt, filters)
-    # 5. Count total matches -- lightweight query without eager loads or ORDER BY.
-    # Re-apply the same WHERE clauses from stmt (stored on the compiled whereclause).
-    count_base = (
-        select(func.count())
-        .select_from(Dataset)
-        .join(Record, Dataset.record_id == Record.id)
-    )
-    if stmt.whereclause is not None:
-        count_base = count_base.where(stmt.whereclause)
-    total = (await session.execute(count_base)).scalar_one()
-    # -- Hybrid semantic search with RRF --
-    semantic_enabled = await SEMANTIC_SEARCH_ENABLED.get(session)
-    if semantic_enabled and has_text_search and filters.q and filters.q.strip():
-        # Vetting query for semantic vector-only candidates: identical visibility +
-        # common + search-only filters as the FTS `stmt`, but WITHOUT the text
-        # clause (vector-only hits match by meaning, not lexically). _run_rrf_merge
-        # constrains it to the candidate ids so a surfaced vector-only match
-        # satisfies every active filter (visibility, bbox, geometry_type, srid,
-        # keywords, dates, CQL) -- never leaking or violating a filter.
-        vet_stmt = (
-            select(Record.id)
-            .select_from(Dataset)
-            .join(Record, Dataset.record_id == Record.id)
+    if has_text_search:
+        rank_col = _build_fts_rank_col(candidates.text_parts)
+        stmt = stmt.add_columns(rank_col).where(candidates.text_clause)
+    stmt = vetting_filters(stmt, user, user_roles, filters, search_only=True)
+
+    if candidates.semantic is not None:
+        return await _run_rrf_merge(
+            session, filters, stmt, rank_col, total, candidates.semantic
         )
-        vet_stmt = apply_visibility_filter(
-            vet_stmt, user, user_roles, Record, DatasetGrant
-        )
-        vet_stmt = _apply_common_filters(vet_stmt, filters, skip_text=True)
-        vet_stmt = _apply_search_only_filters(vet_stmt, filters)
-        if rrf_result := await _run_rrf_merge(
-            session, filters, stmt, rank_col, total, vet_stmt
-        ):
-            return rrf_result
-    # 6. Sort (standard FTS-only path or semantic=False)
     stmt = _resolve_sort_order(
         stmt, filters, has_text_search, rank_col, preferred_languages
     )
-    # 7. Paginate + execute
     stmt = stmt.offset(filters.skip).limit(filters.limit)
     result = await session.execute(stmt)
     if has_text_search:

--- a/backend/app/modules/catalog/search/service_facets.py
+++ b/backend/app/modules/catalog/search/service_facets.py
@@ -6,19 +6,14 @@ from sqlalchemy import String as SAString, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.identity import Identity
-from app.modules.catalog.authorization import apply_visibility_filter
 from app.modules.catalog.collections.models import Collection, CollectionDataset
 from app.modules.catalog.datasets.domain.models import (
     Dataset,
-    DatasetGrant,
     Record,
     RecordKeyword,
 )
-from app.modules.catalog.search.service_filters import (
-    FacetCounts,
-    SearchFilters,
-    _apply_common_filters,
-)
+from app.modules.catalog.search.service_candidates import select_candidates
+from app.modules.catalog.search.service_filters import FacetCounts, SearchFilters
 
 
 async def get_facet_counts(
@@ -27,25 +22,28 @@ async def get_facet_counts(
     user_roles: set[str],
     filters: SearchFilters,
 ) -> FacetCounts:
-    """Return multi-group facet counts for datasets matching the given filters.
+    """Return multi-group facet counts over the query's candidate set.
 
-    Returns dict with keys: record_type, keywords, source_organization, srid.
-    Does NOT filter by record_type itself (facets show counts for all types).
-    Separately counts matching collections from the collections table.
+    Returns dict with keys: record_type, keywords, source_organization, srid,
+    collections. The candidate set is the one /search/datasets/ counts
+    (fix(#1855)), minus the result-only filters: record_type is never applied,
+    so the type counts cover every type.
     """
-    # Build a CTE that materializes the filtered (dataset_id, record_id) pairs
-    # once. Both the record_type counts and per-facet queries join against it
-    # instead of each independently re-evaluating the full filter stack.
-    filtered_base = (
+    # One CTE of the candidate (dataset_id, record_id) pairs; every facet query
+    # joins it instead of re-evaluating the filter stack.
+    candidates = await select_candidates(
+        session,
         select(Dataset.id.label("dataset_id"), Record.id.label("record_id"))
         .select_from(Dataset)
-        .join(Record, Dataset.record_id == Record.id)
+        .join(Record, Dataset.record_id == Record.id),
+        user,
+        user_roles,
+        filters,
+        search_only=False,
+        # Facets need no ranks; depth 1 is the probe that decides the mode.
+        depth=1,
     )
-    filtered_base = apply_visibility_filter(
-        filtered_base, user, user_roles, Record, DatasetGrant
-    )
-    filtered_base = _apply_common_filters(filtered_base, filters)
-    filtered_cte = filtered_base.cte("filtered_ids")
+    filtered_cte = candidates.stmt.cte("filtered_ids")
 
     # Record-type counts from the CTE (replaces duplicate filter stack)
     type_stmt = (

--- a/backend/app/modules/catalog/search/service_semantic.py
+++ b/backend/app/modules/catalog/search/service_semantic.py
@@ -92,11 +92,9 @@ def _embedding_cache_clear() -> None:
     _embedding_cache.clear()
 
 
-# fix(#448): this module embeds INSIDE a search request. The provider default
-# timeout (130s) is sized for background ingest/backfill; a hung embedding
-# provider must not hold a search request when _get_vector_ranks silently
-# falls back to FTS on any error. asyncio.wait_for (rather than a port
-# signature change) keeps enterprise CatalogPort overlays source-compatible.
+# fix(#448): the provider default timeout (130s) is sized for backfill; a hung
+# provider must not hold a search request, and resolve_semantic_arm degrades to
+# FTS on any error. wait_for keeps CatalogPort overlays source-compatible.
 _QUERY_EMBED_TIMEOUT_SECONDS = 8.0
 
 

--- a/backend/app/modules/catalog/search/service_semantic.py
+++ b/backend/app/modules/catalog/search/service_semantic.py
@@ -46,8 +46,8 @@ EmbeddingUnavailableError = get_catalog_port().embedding_unavailable_error_class
 _EMBEDDING_CACHE_TTL_SECONDS = 300.0
 _EMBEDDING_CACHE_MAX_SIZE = 512
 
-# fix(#448): above this many stored embeddings the exact vector-only count (a
-# full cosine scan) is skipped and the vector arm is a nearest-first window.
+# fix(#448): above this many stored embeddings the exact vector arm (a full
+# cosine scan) gives way to a nearest-first window.
 _EXACT_SEMANTIC_COUNT_MAX_ROWS = 5000
 
 # fix(#1855): above the row gate results and facets take the same window, so
@@ -197,8 +197,9 @@ class SemanticArm:
     """The vector arm of a query's candidate set, resolved once per request.
 
     ``ordered_ids`` are the nearest-first vetted record ids within the cosine
-    cutoff, ``window`` deep. Below the row gate (``exact``) the candidate
-    clause is every usable embedding within the cutoff; above it, the window.
+    cutoff: every one of them below the row gate (``exact``), the nearest
+    ``window`` above it. One scan per request; the clause is a list of ids, so
+    the statements it lands in never touch the embeddings table.
     """
 
     query_vector: list[float]
@@ -218,16 +219,6 @@ class SemanticArm:
 
     def clause(self) -> ColumnElement[bool]:
         """Record.id predicate for the vector arm; the caller applies vetting."""
-        RecordEmbedding = get_catalog_port().record_embedding_orm_class()
-        if self.exact:
-            return Record.id.in_(
-                select(RecordEmbedding.record_id).where(
-                    RecordEmbedding.usable_by_config(
-                        self.model_name, self.config_fingerprint
-                    ),
-                    RecordEmbedding.embedding.cosine_distance(self.query_vector) <= 0.7,
-                )
-            )
         return Record.id.in_([uuid_mod.UUID(rid) for rid in self.ordered_ids])
 
 
@@ -244,7 +235,8 @@ async def resolve_semantic_arm(
     shorter than ``_MIN_SEMANTIC_QUERY_LEN``, no embeddings exist, the
     configuration cannot be resolved, embedding or the vector query fails, or
     no row of ``vet_stmt`` (a ``select(Record.id)``) is within the cosine
-    cutoff. ``depth`` is how many nearest ids the caller needs, at least 1.
+    cutoff. ``depth`` is how many nearest ids the caller needs, at least 1;
+    below the row gate every match is fetched regardless.
     """
     query_text = (filters.q or "").strip()
     if len(query_text) < _MIN_SEMANTIC_QUERY_LEN:
@@ -294,18 +286,15 @@ async def resolve_semantic_arm(
         distance = RecordEmbedding.embedding.cosine_distance(query_vector)
         # Restricting to the vetted set BEFORE the top-k cut keeps a nearer
         # private or filtered-out row from displacing a valid match.
-        rows = (
-            await session.execute(
-                select(RecordEmbedding.record_id)
-                .where(
-                    usable,
-                    distance <= 0.7,
-                    RecordEmbedding.record_id.in_(vet_stmt),
-                )
-                .order_by(distance)
-                .limit(window)
-            )
-        ).all()
+        vector_stmt = (
+            select(RecordEmbedding.record_id)
+            .where(usable, distance <= 0.7, RecordEmbedding.record_id.in_(vet_stmt))
+            .order_by(distance)
+        )
+        # Exact: every match, bounded by the row gate. The one scan per request.
+        if not exact:
+            vector_stmt = vector_stmt.limit(window)
+        rows = (await session.execute(vector_stmt)).all()
     except Exception:  # broad: pgvector/HNSW failures are diverse; degrade to FTS rather than 500 the search
         logger.warning(
             "Vector similarity query failed, falling back to FTS", exc_info=True

--- a/backend/app/modules/catalog/search/service_semantic.py
+++ b/backend/app/modules/catalog/search/service_semantic.py
@@ -6,14 +6,16 @@ import asyncio
 import time
 import uuid as uuid_mod
 from collections import OrderedDict
+from dataclasses import dataclass
 
 import structlog
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
-from sqlalchemy.sql.elements import Label
+from sqlalchemy.sql.elements import ColumnElement, Label
 from sqlalchemy.sql.selectable import Select
 
+from app.core.persistent_config import SEMANTIC_SEARCH_ENABLED
 from app.modules.auth.models import User
 from app.modules.catalog.datasets.domain.models import Dataset, Record
 from app.modules.catalog.search.service_filters import SearchFilters
@@ -44,10 +46,13 @@ EmbeddingUnavailableError = get_catalog_port().embedding_unavailable_error_class
 _EMBEDDING_CACHE_TTL_SECONDS = 300.0
 _EMBEDDING_CACHE_MAX_SIZE = 512
 
-# fix(#448): above this many stored embeddings, _run_rrf_merge stops running
-# the exact vector-only match COUNT (a full cosine scan) and approximates
-# from the already-fetched top-k ranks instead.
+# fix(#448): above this many stored embeddings the exact vector-only count (a
+# full cosine scan) is skipped and the vector arm is a nearest-first window.
 _EXACT_SEMANTIC_COUNT_MAX_ROWS = 5000
+
+# fix(#1855): above the row gate results and facets take the same window, so
+# a first page of any size agrees with the facet counts.
+_APPROXIMATE_CANDIDATE_WINDOW = 200
 
 # fix(#625): search-as-you-type spent one paid embedding call per keystroke
 # prefix ("u", "us", "usa"), each missing the 0.7 cutoff and falling back to FTS
@@ -189,110 +194,138 @@ async def _attach_updated_actor_identities(
         setattr(record, "_provenance_updated_user", users_by_id.get(actor_id))
 
 
-async def _get_vector_ranks(
-    session: AsyncSession,
-    query_text: str,
-    limit: int,
-    restrict_stmt: Select | None = None,
-) -> tuple[dict[str, int], list[float] | None, tuple[str, str] | None]:
-    """Run vector similarity search.
+@dataclass(frozen=True, slots=True)
+class SemanticArm:
+    """The vector arm of a query's candidate set, resolved once per request.
 
-    ``restrict_stmt`` is a ``select(Record.id)`` carrying the active visibility +
-    search filters; when provided, the cosine top-k is computed ONLY over records
-    in that set, so a nearer but non-visible / filtered-out embedding cannot crowd
-    a valid match out of the top ``limit`` rows.
-
-    Returns ``({record_id_hex: rank}, query_vector, identity)``. The query vector is
-    returned so the caller can run an accurate total-match COUNT (which the
-    ``limit``-bounded ranks cannot provide); fix(#1546) added the identity for the
-    same reason, so that COUNT filters on the configuration these ranks were taken
-    under. Returns ``({}, None, None)`` on any failure (silent fallback).
+    ``ordered_ids`` are the nearest-first vetted record ids within the cosine
+    cutoff, ``window`` deep. Below the row gate (``exact``) the candidate
+    clause is every usable embedding within the cutoff; above it, the window.
     """
-    # Check if any embeddings exist at all
-    if not await get_catalog_port().has_embeddings(session):
-        return {}, None, None
 
-    # Generate query embedding
+    query_vector: list[float]
+    model_name: str
+    config_fingerprint: str
+    ordered_ids: tuple[str, ...]
+    window: int
+    exact: bool
+
+    @property
+    def window_full(self) -> bool:
+        return len(self.ordered_ids) >= self.window
+
+    def ranks(self, depth: int) -> dict[str, int]:
+        """Positional (1-based) ranks of the nearest ``depth`` ids."""
+        return {rid: rank + 1 for rank, rid in enumerate(self.ordered_ids[:depth])}
+
+    def clause(self) -> ColumnElement[bool]:
+        """Record.id predicate for the vector arm; the caller applies vetting."""
+        RecordEmbedding = get_catalog_port().record_embedding_orm_class()
+        if self.exact:
+            return Record.id.in_(
+                select(RecordEmbedding.record_id).where(
+                    RecordEmbedding.usable_by_config(
+                        self.model_name, self.config_fingerprint
+                    ),
+                    RecordEmbedding.embedding.cosine_distance(self.query_vector) <= 0.7,
+                )
+            )
+        return Record.id.in_([uuid_mod.UUID(rid) for rid in self.ordered_ids])
+
+
+async def resolve_semantic_arm(
+    session: AsyncSession,
+    filters: SearchFilters,
+    vet_stmt: Select,
+    *,
+    depth: int,
+) -> SemanticArm | None:
+    """Decide whether a query runs in semantic mode and resolve its vector arm.
+
+    Returns None (lexical mode) when semantic search is off, the query is
+    shorter than ``_MIN_SEMANTIC_QUERY_LEN``, no embeddings exist, the
+    configuration cannot be resolved, embedding or the vector query fails, or
+    no row of ``vet_stmt`` (a ``select(Record.id)``) is within the cosine
+    cutoff. ``depth`` is how many nearest ids the caller needs, at least 1.
+    """
+    query_text = (filters.q or "").strip()
+    if len(query_text) < _MIN_SEMANTIC_QUERY_LEN:
+        return None
+    if not await SEMANTIC_SEARCH_ENABLED.get(session):
+        return None
+    if not await get_catalog_port().has_embeddings(session):
+        return None
+
     try:
-        # fix(#1546): the query vector and the row filter must come from ONE
-        # reading of the configuration. Resolved once, here, below the
-        # has_embeddings gate so a catalog with no vectors does not pay for it,
-        # and handed back to the caller so a settings change landing mid-request
-        # cannot rank under one configuration and count under another.
-        #
-        # fix(#1546 review r1, codex P2): INSIDE this guard, not above it.
-        # Resolving reads persistent config, which can raise on a cache miss or
-        # a transient database failure, and above the guard that raise escaped
-        # the whole search request. Model resolution used to happen inside
-        # `generate_embedding`, where it degraded to FTS like every other
-        # failure on this path; hoisting it silently made it fatal. Same
-        # failure, same degradation.
+        # fix(#1546): the query vector and the row filter come from ONE reading
+        # of the configuration, resolved under the fallback guard.
         config = await get_catalog_port().resolve_embedding_config(session)
         if config is None:
             logger.warning(
                 "Embedding configuration unresolved for semantic search, "
                 "falling back to FTS"
             )
-            return {}, None, None
-        query_vector = await generate_embedding(
-            query_text.strip(), session, config=config
-        )
+            return None
+        query_vector = await generate_embedding(query_text, session, config=config)
     except EmbeddingUnavailableError:
         logger.warning("Embedding unavailable for semantic search, falling back to FTS")
-        return {}, None, None
+        return None
     except Exception:  # broad: third-party embedding SDK can throw provider-specific errors; fall back to FTS
         logger.warning(
             "Failed to generate query embedding, falling back to FTS", exc_info=True
         )
-        return {}, None, None
+        return None
 
     model_name, _dimensions, _base_url, config_fingerprint = config
-    identity = (model_name, config_fingerprint)
-
+    RecordEmbedding = get_catalog_port().record_embedding_orm_class()
+    usable = RecordEmbedding.usable_by_config(model_name, config_fingerprint)
     try:
-        # Tune HNSW recall -- default ef_search=40 may miss relevant results
-        await get_catalog_port().set_hnsw_recall(session)
-        RecordEmbedding = get_catalog_port().record_embedding_orm_class()
-
-        # Vector similarity query: cosine distance <= 0.7 means similarity >= 0.3
-        # fix(#1546): scoped to rows the live configuration can be compared
-        # against, not merely to rows carrying its model name. A model served
-        # from two endpoints is two vector spaces under one label, and cosine
-        # distance across them comes back well-formed and meaningless. Rows from
-        # another configuration are now invisible rather than wrong;
-        # `usable_by_config` is where an unstamped legacy row keeps the old
-        # model-name-only guarantee.
-        vector_stmt = select(
-            RecordEmbedding.record_id,
-            RecordEmbedding.embedding.cosine_distance(query_vector).label("distance"),
-        ).where(
-            RecordEmbedding.usable_by_config(model_name, config_fingerprint),
-            RecordEmbedding.embedding.cosine_distance(query_vector) <= 0.7,
-        )
-        if restrict_stmt is not None:
-            # Restrict candidates to the visibility/filter-vetted record set BEFORE
-            # the top-k cut, so private/filtered nearer neighbours can't displace a
-            # valid visible match out of the limit.
-            vector_stmt = vector_stmt.where(
-                RecordEmbedding.record_id.in_(restrict_stmt)
+        # fix(#448): the row gate is measured under the same predicate the
+        # ranks and counts use, so foreign-configuration rows cannot trip it.
+        emb_rows = (
+            await session.execute(
+                select(func.count())
+                .select_from(RecordEmbedding)
+                .join(Record, RecordEmbedding.record_id == Record.id)
+                .where(usable)
             )
-        vector_stmt = vector_stmt.order_by("distance").limit(limit)
-
-        result = await session.execute(vector_stmt)
-        rows = result.all()
-    except Exception:  # broad: pgvector/HNSW failures are diverse — degrade to FTS rather than 500 the search
-        # pgvector extension missing, HNSW SET error, or DB execute failure --
-        # honor the docstring contract and degrade to FTS-only
+        ).scalar_one()
+        exact = emb_rows <= _EXACT_SEMANTIC_COUNT_MAX_ROWS
+        window = depth if exact else max(depth, _APPROXIMATE_CANDIDATE_WINDOW)
+        await get_catalog_port().set_hnsw_recall(session)
+        distance = RecordEmbedding.embedding.cosine_distance(query_vector)
+        # Restricting to the vetted set BEFORE the top-k cut keeps a nearer
+        # private or filtered-out row from displacing a valid match.
+        rows = (
+            await session.execute(
+                select(RecordEmbedding.record_id)
+                .where(
+                    usable,
+                    distance <= 0.7,
+                    RecordEmbedding.record_id.in_(vet_stmt),
+                )
+                .order_by(distance)
+                .limit(window)
+            )
+        ).all()
+    except Exception:  # broad: pgvector/HNSW failures are diverse; degrade to FTS rather than 500 the search
         logger.warning(
             "Vector similarity query failed, falling back to FTS", exc_info=True
         )
-        return {}, None, None
-
-    # Assign positional ranks (1-based)
-    return (
-        {str(row.record_id): rank + 1 for rank, row in enumerate(rows)},
-        query_vector,
-        identity,
+        return None
+    if not rows:
+        logger.info(
+            "rrf_fallback_to_fts",
+            extra={"reason": "empty_vector_ranks", "q_prefix": query_text[:50]},
+        )
+        return None
+    return SemanticArm(
+        query_vector=query_vector,
+        model_name=model_name,
+        config_fingerprint=config_fingerprint,
+        ordered_ids=tuple(str(row.record_id) for row in rows),
+        window=window,
+        exact=exact,
     )
 
 
@@ -325,60 +358,19 @@ async def _run_rrf_merge(
     stmt: Select,
     rank_col: Label[float],
     total: int,
-    vet_stmt: Select,
-) -> tuple[list[Dataset], int] | None:
-    """Execute hybrid FTS+vector RRF merge and return paginated results.
+    semantic: SemanticArm,
+) -> tuple[list[Dataset], int]:
+    """Merge FTS ranks with the vector arm through RRF and return one page.
 
-    Surfaces vector-only matches (records that are semantically similar but do
-    not lexically match the FTS query) IN ADDITION to re-ranking FTS hits. Since
-    ``_get_vector_ranks`` applies neither RBAC visibility nor the active search
-    filters, ``vet_stmt`` (a ``select(Record.id)`` with the same visibility +
-    bbox/geometry_type/srid/keywords/date/CQL filters as the FTS query, minus the
-    text clause) is passed as the vector query's ``restrict_stmt`` so the cosine
-    top-k is taken only over records the caller may see that satisfy every active
-    filter. This prevents leaking private/restricted datasets, returning records
-    that violate an active filter (e.g. a polygon under ``geometry_type=Point``),
-    AND a nearer non-visible neighbour displacing a valid match out of the top-k.
-
-    Returns ``None`` when RRF doesn't apply (vector backend empty/failed, or the
-    query is shorter than ``_MIN_SEMANTIC_QUERY_LEN``). Caller falls through to
-    the standard sort path on None.
-
-    Returns ``([], total)`` rather than ``None`` when the FTS-cap query
-    yields zero ids -- caller returns that tuple as-is. Preserved from
-    pre-refactor behavior; do not change to ``None`` (would alter
-    observable behavior by falling through to the standard sort path).
+    ``stmt`` is the vetted FTS statement (text clause only) and ``total`` the
+    count over the shared candidate set. Above the row gate a full vector
+    window reports one more than was counted so the router keeps emitting the
+    ``next`` link; a non-full window is the exact tail.
     """
-    if filters.q is None:
-        raise ValueError("_run_rrf_merge requires filters.q to be non-None")
-    q_stripped = filters.q.strip()
-    if len(q_stripped) < _MIN_SEMANTIC_QUERY_LEN:
-        return None
-    # The RRF-ordered list is sliced [skip:skip+limit], so both candidate pools must
-    # reach at least skip+limit deep or a later page comes back empty.
     page_end = filters.skip + filters.limit
-    # Vector similarity ranks, restricted to the visibility/filter-vetted set so the
-    # cosine top-k contains only records the caller may see that satisfy every active
-    # filter (empty dict on any failure = FTS-only). The query vector is returned for
-    # the total-match count below, and fix(#1546) the embedding configuration those
-    # ranks were taken under, so the counts filter on the same one rather than
-    # resolving it a second time and possibly counting rows they did not rank.
-    vector_ranks, query_vector, identity = await _get_vector_ranks(
-        session, q_stripped, page_end, restrict_stmt=vet_stmt
-    )
+    vector_ranks = semantic.ranks(page_end)
 
-    if not vector_ranks or identity is None:
-        logger.info(
-            "rrf_fallback_to_fts",
-            extra={"reason": "empty_vector_ranks", "q_prefix": q_stripped[:50]},
-        )
-        return None
-
-    # Get FTS-ranked record IDs (up to a reasonable cap for merging).
-    # Strip the inherited eager-loads -- only record_id is needed at
-    # this stage, so 4 wasted selectinload queries per request are
-    # avoided (PERF-8). Cap must cover the requested page end (skip+limit) so
-    # offset pages aren't truncated, plus headroom for RRF re-ranking.
+    # FTS-ranked ids, deep enough to cover the requested page plus RRF headroom.
     fts_cap = max(page_end * 3, 100)
     fts_stmt = (
         stmt.with_only_columns(Dataset.record_id)
@@ -388,76 +380,13 @@ async def _run_rrf_merge(
     fts_result = await session.execute(fts_stmt)
     fts_ids = [str(row[0]) for row in fts_result.all()]
 
-    # RRF over FTS results UNION the (already vetted) vector matches. vector_ranks
-    # is pre-filtered for visibility + every active filter via restrict_stmt, so it
-    # can be unioned directly. (Only the top page_end ranks are fetched -- enough to
-    # fill the requested page; the accurate match total is computed separately.)
-    #
-    # numberMatched must count ALL semantic matches, not just the page_end window, or
-    # a semantic-only search drops its `next` link (offset+limit >= total) while later
-    # pages still have results. Count vetted vector matches that are NOT also FTS
-    # matches (those are already in `total`) via a single COUNT -- record_embeddings
-    # holds one row per record, so this scans the catalog, not feature rows.
-    fts_match_subq = (
-        select(Record.id)
-        .select_from(Dataset)
-        .join(Record, Dataset.record_id == Record.id)
-        .where(stmt.whereclause)
-    )
-    model_name, config_fingerprint = identity
-    RecordEmbedding = get_catalog_port().record_embedding_orm_class()
-    # fix(#448): the exact COUNT below re-computes cosine distance against
-    # EVERY stored embedding — a second full O(N)·dims vector scan per search
-    # that no ANN index can serve (aggregate over a distance predicate).
-    # Exact and cheap at today's catalog size; past the row gate, approximate
-    # the vector-only surplus from the vetted top-k ranks already in hand.
-    # numberMatched becomes a lower bound (may under-report distant tail
-    # matches); a full-window sentinel below keeps `next` links alive.
-    # fix(#1546): both counts below use the same predicate the ranks were taken
-    # under. The row gate decides whether the exact count is affordable, so
-    # counting rows the ranking cannot see would push a catalog over the gate on
-    # the strength of vectors no search will ever return.
-    emb_rows = (
-        await session.execute(
-            select(func.count())
-            .select_from(RecordEmbedding)
-            .join(Record, RecordEmbedding.record_id == Record.id)
-            .where(RecordEmbedding.usable_by_config(model_name, config_fingerprint))
-        )
-    ).scalar_one()
-    if emb_rows <= _EXACT_SEMANTIC_COUNT_MAX_ROWS:
-        new_count_stmt = (
-            select(func.count())
-            .select_from(RecordEmbedding)
-            .where(
-                RecordEmbedding.usable_by_config(model_name, config_fingerprint),
-                RecordEmbedding.embedding.cosine_distance(query_vector) <= 0.7,
-                RecordEmbedding.record_id.in_(vet_stmt),
-                RecordEmbedding.record_id.notin_(fts_match_subq),
-            )
-        )
-        total += (await session.execute(new_count_stmt)).scalar_one()
-    else:
-        fts_id_set = set(fts_ids)
-        vector_only = sum(1 for rid in vector_ranks if rid not in fts_id_set)
-        # fix(#448, codex P2): a FULL top-k window means deeper matches may
-        # exist beyond what was fetched, but reporting exactly page_end as the
-        # total makes the router's `offset + limit < total` check suppress the
-        # rel="next" link on a semantic-only page. Report one past the window
-        # so paging continues; each deeper page fetches a deeper window until
-        # a non-full window yields the exact tail. Worst case the final next
-        # link lands on one empty page — acceptable for an approximation.
-        if len(vector_ranks) >= page_end:
-            vector_only += 1
-        total += vector_only
+    if not semantic.exact and semantic.window_full:
+        total += 1
 
     rrf_ordered = _compute_rrf_scores(fts_ids, vector_ranks)
-
-    # Apply pagination to RRF-ordered list
-    page_ids = rrf_ordered[filters.skip : filters.skip + filters.limit]
+    page_ids = rrf_ordered[filters.skip : page_end]
 
     if page_ids:
-        # Fetch full Dataset objects for the final page
         fetch_stmt = (
             select(Dataset)
             .join(Record, Dataset.record_id == Record.id)

--- a/backend/tests/test_hybrid_search.py
+++ b/backend/tests/test_hybrid_search.py
@@ -886,6 +886,12 @@ async def test_semantic_approximate_count_keeps_next_link(
                 "app.modules.catalog.search.service_semantic._EXACT_SEMANTIC_COUNT_MAX_ROWS",
                 0,
             ),
+            # fix(#1855): the shared window floor would hold all five matches;
+            # drop it so the window is the page and the sentinel is exercised.
+            patch(
+                "app.modules.catalog.search.service_semantic._APPROXIMATE_CANDIDATE_WINDOW",
+                0,
+            ),
         ):
             r = await client.get(
                 "/search/datasets/",

--- a/backend/tests/test_hybrid_search.py
+++ b/backend/tests/test_hybrid_search.py
@@ -613,10 +613,10 @@ async def test_semantic_vector_only_does_not_leak_private(
 ):
     """A PRIVATE vector-only match must never surface to an anonymous caller.
 
-    The vector query (_get_vector_ranks) is not visibility-filtered, so the RRF
-    union must run vector-only candidates through apply_visibility_filter. A
-    private record with a near-perfect embedding match + a non-lexical title is
-    the exact leak this guards against.
+    The vector window is taken over the vetted set (apply_visibility_filter)
+    before the top-k cut, and the candidate clause is applied under the same
+    filter. A private record with a near-perfect embedding match and a
+    non-lexical title is the exact leak this guards against.
     """
     session = test_db_session
     admin_id = await get_user_id(session, "admin")

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1797,9 +1797,9 @@ def test_decomposed_service_modules_stay_within_size_budgets() -> None:
         # persistent-config read degrades instead of failing the search. Most of
         # the lines are the two rationales, including why verify-after-the-fact
         # was rejected. Cap 456 -> 482, exact.
-        # fix(#1855): -71. The vector arm is resolved once into SemanticArm and
-        # counted through the shared candidate set. Cap 482 -> 411, exact.
-        "backend/app/modules/catalog/search/service_semantic.py": 411,
+        # fix(#1855): -73. The vector arm is resolved once into SemanticArm and
+        # counted through the shared candidate set. Cap 482 -> 409, exact.
+        "backend/app/modules/catalog/search/service_semantic.py": 409,
         # fix(#430 V-14): _replace_layers now reconciles layers by id (update-in-place
         # + create/delete) instead of delete-all-then-recreate, so a PUT preserves
         # layer UUIDs. +~35 LOC over the 350 default. Cap → 400 (~34 headroom).
@@ -4196,7 +4196,9 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # apply_http_logger_levels() (logging_config.py) after raising root's
     # level, so httpx/httpcore's WARNING floor tracks a LOG_LEVEL change made
     # through the admin settings UI, not just one made at boot.
-    "backend/app/core/persistent_config.py": 1047,
+    # fix(#1855): +2. The semantic search rate limit docstring says why the
+    # default is 60 for one bucket shared by two routes. Cap 1047 -> 1049, exact.
+    "backend/app/core/persistent_config.py": 1049,
     # fix(#1533): first entry — crossed _RATCHET_INCLUSION_LOC on the change
     # that made the run notice the embedding column moving under it. Two
     # guards, both small: _live_column_dims (one pg_attribute read, shared with

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -875,6 +875,7 @@ def test_no_external_imports_of_search_private_service_modules() -> None:
         "service_semantic",
         "service_datasets",
         "service_records",
+        "service_candidates",
     }
     offenders = _private_service_import_offenders(
         package="app.modules.catalog.search",
@@ -1670,7 +1671,9 @@ def test_decomposed_service_modules_stay_within_size_budgets() -> None:
         # fix(#474, #475): localized ranking/eager loading plus the OGC
         # ids/externalIds filters cross the default by nine lines. Keep the
         # carve-out exact so further growth requires another review.
-        "backend/app/modules/catalog/search/service_datasets.py": 359,
+        # fix(#1855): -78. The search-only filters and the count moved into
+        # service_candidates.py, the selection facets now share. Cap 359 -> 281.
+        "backend/app/modules/catalog/search/service_datasets.py": 281,
         # Phase 1062 CR-04: +13 lines from non-expiring embed-token CSP fix
         # (or_ IS NULL predicate, _create_non_expiring_embed_token helper).
         # Cap raised from 575 → 600 to allow ~12 lines of headroom above 588.
@@ -1794,7 +1797,9 @@ def test_decomposed_service_modules_stay_within_size_budgets() -> None:
         # persistent-config read degrades instead of failing the search. Most of
         # the lines are the two rationales, including why verify-after-the-fact
         # was rejected. Cap 456 -> 482, exact.
-        "backend/app/modules/catalog/search/service_semantic.py": 482,
+        # fix(#1855): -71. The vector arm is resolved once into SemanticArm and
+        # counted through the shared candidate set. Cap 482 -> 411, exact.
+        "backend/app/modules/catalog/search/service_semantic.py": 411,
         # fix(#430 V-14): _replace_layers now reconciles layers by id (update-in-place
         # + create/delete) instead of delete-all-then-recreate, so a PUT preserves
         # layer UUIDs. +~35 LOC over the 350 default. Cap → 400 (~34 headroom).
@@ -5527,7 +5532,9 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # 1536 -> 1489, exact.
     # fix(#1778): +4 -- deterministic ORDER BY tiebreaker on the paginated
     # per-dataset OGC collections query. Cap 1489 -> 1493, exact.
-    "backend/app/modules/catalog/search/router.py": 1493,
+    # fix(#1855): -1. The facets rate-limit note shrank when the endpoint
+    # gained the SEC-S11 limiter. Cap 1493 -> 1492, exact.
+    "backend/app/modules/catalog/search/router.py": 1492,
     # fix(#474): negotiate localized STAC record text; fix(#475) adds the
     # unassigned Collection and matching HTTP Link navigation. fix(#506): keep
     # validated STAC item responses wire-compatible with serializer output.

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1797,9 +1797,9 @@ def test_decomposed_service_modules_stay_within_size_budgets() -> None:
         # persistent-config read degrades instead of failing the search. Most of
         # the lines are the two rationales, including why verify-after-the-fact
         # was rejected. Cap 456 -> 482, exact.
-        # fix(#1855): -73. The vector arm is resolved once into SemanticArm and
-        # counted through the shared candidate set. Cap 482 -> 409, exact.
-        "backend/app/modules/catalog/search/service_semantic.py": 409,
+        # fix(#1855): -84. The vector arm is resolved once into SemanticArm and
+        # counted through the shared candidate set. Cap 482 -> 398, exact.
+        "backend/app/modules/catalog/search/service_semantic.py": 398,
         # fix(#430 V-14): _replace_layers now reconciles layers by id (update-in-place
         # + create/delete) instead of delete-all-then-recreate, so a PUT preserves
         # layer UUIDs. +~35 LOC over the 350 default. Cap → 400 (~34 headroom).
@@ -4196,9 +4196,7 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # apply_http_logger_levels() (logging_config.py) after raising root's
     # level, so httpx/httpcore's WARNING floor tracks a LOG_LEVEL change made
     # through the admin settings UI, not just one made at boot.
-    # fix(#1855): +2. The semantic search rate limit docstring says why the
-    # default is 60 for one bucket shared by two routes. Cap 1047 -> 1049, exact.
-    "backend/app/core/persistent_config.py": 1049,
+    "backend/app/core/persistent_config.py": 1047,
     # fix(#1533): first entry — crossed _RATCHET_INCLUSION_LOC on the change
     # that made the run notice the embedding column moving under it. Two
     # guards, both small: _live_column_dims (one pg_attribute read, shared with

--- a/backend/tests/test_rate_limits.py
+++ b/backend/tests/test_rate_limits.py
@@ -118,19 +118,14 @@ async def test_semantic_search_rate_limit_returns_429(client: AsyncClient):
         _reset_limiter_storage()
 
 
-async def test_search_facets_not_rate_limited(client: AsyncClient):
-    """GET /search/facets/ is NOT rate-limited — negative-control regression pin.
+async def test_search_facets_rate_limited(client: AsyncClient):
+    """GET /search/facets/?q=<unique-N> returns 429 after threshold is exceeded.
 
-    WR-02 (Phase 1062-review): the @limiter.limit(_semantic_search_rate_limit)
-    decorator was intentionally removed from /search/facets/ because the
-    endpoint performs pure SQL aggregation and never invokes the embedding
-    model. Throttling at 30/min (SEC-S11) incorrectly restricted normal SPA
-    users who refresh the search UI more than 30 times per minute.
-
-    This test verifies that even with the limiter enabled at a low threshold,
-    /search/facets/ never returns 429.
+    fix(#1855): facets embed the query to count over the same candidate set as
+    /search/datasets/, so an unlimited /search/facets/ would be a way around
+    the SEC-S11 embedding-cost cap. The endpoint carries the same limit.
     """
-    _set_cache_limit("semantic_search_rate_limit", 3)
+    _set_cache_limit("semantic_search_rate_limit", 5)
     limiter.enabled = True
     _reset_limiter_storage()
 
@@ -138,14 +133,14 @@ async def test_search_facets_not_rate_limited(client: AsyncClient):
         statuses = []
         for i in range(7):
             resp = await client.get(
-                f"/search/facets/?q=sec-facets-norlimit-{uuid.uuid4().hex}"
+                f"/search/facets/?q=sec-facets-ratelimit-{uuid.uuid4().hex}"
             )
             statuses.append(resp.status_code)
 
         rate_limited = [s for s in statuses if s == 429]
-        assert len(rate_limited) == 0, (
-            f"/search/facets/ must not be rate-limited (WR-02 Phase 1062-review). "
-            f"Got 429 responses: {rate_limited}. All statuses: {statuses}"
+        assert len(rate_limited) >= 2, (
+            f"Expected >= 2 rate-limited responses with threshold=5/7 requests, "
+            f"got {len(rate_limited)}. Statuses: {statuses}"
         )
     finally:
         limiter.enabled = False

--- a/backend/tests/test_rate_limits.py
+++ b/backend/tests/test_rate_limits.py
@@ -2,7 +2,7 @@
 
 Phase 1062 Plan 02: per-route @limiter.limit decorators on:
   - /search/datasets/   (SEC-S11, caps OpenAI embedding cost-DoS)
-  - /search/facets/     (SEC-S11, same embedding cache code path)
+  - /search/facets/     (SEC-S11, one bucket shared with /search/datasets/)
   - /datasets/{id}/related/  (SEC-S11, same embedding cost surface)
   - /settings/basemaps/      (SEC-S10, caps commercial-tier basemap key replay)
 
@@ -40,14 +40,14 @@ pytestmark = pytest.mark.anyio
 # ---------------------------------------------------------------------------
 
 
-def test_default_semantic_search_limit_is_30():
-    """get_cached_semantic_search_rate_limit() returns 30 when cache is empty.
+def test_default_semantic_search_limit_is_60():
+    """get_cached_semantic_search_rate_limit() returns 60 when cache is empty.
 
     Clears the cache entry before calling to avoid interference from other
     tests that may have set a low monkeypatched value.
     """
     _sync_rate_limit_cache.pop("semantic_search_rate_limit", None)
-    assert get_cached_semantic_search_rate_limit() == 30
+    assert get_cached_semantic_search_rate_limit() == 60
 
 
 def test_default_basemap_proxy_limit_is_120():
@@ -141,6 +141,41 @@ async def test_search_facets_rate_limited(client: AsyncClient):
         assert len(rate_limited) >= 2, (
             f"Expected >= 2 rate-limited responses with threshold=5/7 requests, "
             f"got {len(rate_limited)}. Statuses: {statuses}"
+        )
+    finally:
+        limiter.enabled = False
+        _clear_cache_limit("semantic_search_rate_limit")
+        _reset_limiter_storage()
+
+
+@pytest.mark.parametrize("first", ["/search/datasets/", "/search/facets/"])
+async def test_search_datasets_and_facets_share_one_bucket(
+    client: AsyncClient, first: str
+):
+    """Alternating the two search routes cannot embed twice the advertised cap.
+
+    fix(#1855): both routes embed a novel ``q``, and slowapi scopes a plain
+    ``@limiter.limit`` to the handler, so two buckets let a caller alternate
+    them for 2x the limit. With one shared bucket the (limit + 1)th call is a
+    429 whichever route it lands on, and the same 429 starting from either.
+    """
+    routes = ["/search/datasets/", "/search/facets/"]
+    if first != routes[0]:
+        routes.reverse()
+    _set_cache_limit("semantic_search_rate_limit", 5)
+    limiter.enabled = True
+    _reset_limiter_storage()
+
+    try:
+        statuses = []
+        for i in range(6):
+            resp = await client.get(
+                f"{routes[i % 2]}?q=sec-shared-bucket-{uuid.uuid4().hex}"
+            )
+            statuses.append(resp.status_code)
+        assert statuses == [200] * 5 + [429], (
+            f"one shared 5/min bucket must 429 the sixth call across both routes "
+            f"(starting from {first}); got {statuses}"
         )
     finally:
         limiter.enabled = False

--- a/backend/tests/test_rate_limits.py
+++ b/backend/tests/test_rate_limits.py
@@ -40,14 +40,14 @@ pytestmark = pytest.mark.anyio
 # ---------------------------------------------------------------------------
 
 
-def test_default_semantic_search_limit_is_60():
-    """get_cached_semantic_search_rate_limit() returns 60 when cache is empty.
+def test_default_semantic_search_limit_is_30():
+    """get_cached_semantic_search_rate_limit() returns 30 when cache is empty.
 
     Clears the cache entry before calling to avoid interference from other
     tests that may have set a low monkeypatched value.
     """
     _sync_rate_limit_cache.pop("semantic_search_rate_limit", None)
-    assert get_cached_semantic_search_rate_limit() == 60
+    assert get_cached_semantic_search_rate_limit() == 30
 
 
 def test_default_basemap_proxy_limit_is_120():

--- a/backend/tests/test_rule1_structural.py
+++ b/backend/tests/test_rule1_structural.py
@@ -118,6 +118,10 @@ _DELEGATED_GUARDS = (
     # for the tile-token minting endpoints; delegates non-public RBAC to
     # port.check_dataset_access and 404s unpublished-public for non-owners.
     "_enforce_tile_token_access",
+    # search: app/modules/catalog/search/service_candidates.py, fix(#1855):
+    # the candidate selection /search/datasets/ and /search/facets/ share;
+    # applies apply_visibility_filter through vetting_filters.
+    "select_candidates",
 )
 
 # Guards that deny by RAISING (404/403) — a bare ``await guard(...)``
@@ -147,6 +151,7 @@ _VALUE_GUARDS = frozenset(
         "apply_visibility_filter",
         "_apply_map_visibility_filter",
         "bulk_check_dataset_access",
+        "select_candidates",
     }
 )
 
@@ -173,6 +178,7 @@ def _guard_objects() -> dict[str, Any]:
         service_shared,
     )
     from app.modules.catalog.records import router as records_router
+    from app.modules.catalog.search import service_candidates
     from app.processing.tiles import router as tiles_router
 
     guard_objects = {
@@ -191,6 +197,7 @@ def _guard_objects() -> dict[str, Any]:
         "_check_record_ownership": records_router._check_record_ownership,
         "_authorize_vector_tile_request": tiles_router._authorize_vector_tile_request,
         "_enforce_tile_token_access": tiles_router._enforce_tile_token_access,
+        "select_candidates": service_candidates.select_candidates,
     }
     assert set(guard_objects) == _RAISING_GUARDS | _VALUE_GUARDS
     return guard_objects
@@ -1679,6 +1686,23 @@ def test_delegated_guards_still_enforce_access() -> None:
     assert "DatasetGrant" in bulk, (
         "maps bulk_check_dataset_access no longer passes DatasetGrant, so "
         "restricted grants would stop resolving"
+    )
+
+    from app.modules.catalog.search import service_candidates
+
+    # fix(#1855): the shared candidate selection is credited as a guard only
+    # while it still routes every base statement through apply_visibility_filter.
+    assert "vetting_filters" in _calls_in(service_candidates.select_candidates), (
+        "search select_candidates no longer applies vetting_filters"
+    )
+    vetting_calls = _calls_in(service_candidates.vetting_filters)
+    assert "apply_visibility_filter" in vetting_calls, (
+        "search vetting_filters no longer delegates to apply_visibility_filter"
+    )
+    vetting = _source_of(service_candidates.vetting_filters)
+    assert "DatasetGrant" in vetting, (
+        "search vetting_filters no longer passes DatasetGrant, so restricted "
+        "grants would stop resolving"
     )
 
     tile_auth_calls = _calls_in(tiles_router._authorize_vector_tile_request)

--- a/backend/tests/test_rule1_structural.py
+++ b/backend/tests/test_rule1_structural.py
@@ -1688,12 +1688,17 @@ def test_delegated_guards_still_enforce_access() -> None:
         "restricted grants would stop resolving"
     )
 
-    from app.modules.catalog.search import service_candidates
+    from app.modules.catalog.search import service_candidates, service_datasets
 
     # fix(#1855): the shared candidate selection is credited as a guard only
     # while it still routes every base statement through apply_visibility_filter.
     assert "vetting_filters" in _calls_in(service_candidates.select_candidates), (
         "search select_candidates no longer applies vetting_filters"
+    )
+    # The results PAGE statement is vetted by its own direct call, which the
+    # count's credited select_candidates call does not cover.
+    assert "vetting_filters" in _calls_in(service_datasets.search_datasets), (
+        "search search_datasets no longer vets its page statement"
     )
     vetting_calls = _calls_in(service_candidates.vetting_filters)
     assert "apply_visibility_filter" in vetting_calls, (

--- a/backend/tests/test_search_facets.py
+++ b/backend/tests/test_search_facets.py
@@ -1,11 +1,12 @@
 """Integration tests for /search/facets endpoint and facet counting."""
 
 import uuid
+from contextlib import contextmanager
 from unittest.mock import AsyncMock, patch
 
 import pytest
 from httpx import AsyncClient
-from sqlalchemy import select, text, update
+from sqlalchemy import event, select, text, update
 
 from app.core.db.models import AppSetting
 from app.core.persistent_config import EMBEDDING_MODEL
@@ -503,3 +504,55 @@ async def test_facets_semantic_candidates_keep_the_visibility_filter(
         await session.commit()
     assert facets.status_code == 200
     assert facets.json()["record_type"] == {"vector_dataset": 2, "raster_dataset": 1}
+
+
+@contextmanager
+def _count_cosine_scans():
+    """Count executed statements carrying pgvector's cosine operator (``<=>``).
+
+    Listens on the engine the API client runs against; every statement that
+    evaluates a cosine distance is one scan over the embeddings table.
+    """
+    import app.core.db as db_module
+
+    seen: list[str] = []
+
+    def _before(_conn, _cursor, statement, *_args):
+        if "<=>" in statement:
+            seen.append(statement)
+
+    sync_engine = db_module.engine.sync_engine
+    event.listen(sync_engine, "before_cursor_execute", _before)
+    try:
+        yield seen
+    finally:
+        event.remove(sync_engine, "before_cursor_execute", _before)
+
+
+@pytest.mark.anyio
+async def test_facets_scan_the_embeddings_once_per_request(
+    client: AsyncClient,
+    admin_auth_header: dict,
+    semantic_facet_datasets: dict,
+):
+    """fix(#1855): one cosine scan per facets request, whatever the facet count.
+
+    The candidate CTE feeds five separately executed aggregates, so a cosine
+    subquery inside it ran once per aggregate; the vector arm is materialised
+    once and the aggregates see a list of ids.
+    """
+    with (
+        _patched_embedding(semantic_facet_datasets["query_vector"]),
+        _count_cosine_scans() as scans,
+    ):
+        facets = await client.get(
+            "/search/facets/",
+            params={"q": _SEMANTIC_ONLY_QUERY},
+            headers=admin_auth_header,
+        )
+    assert facets.status_code == 200
+    # Non-vacuity: the vector arm ran, so the counts are over the band records.
+    assert facets.json()["record_type"] == {"vector_dataset": 2, "raster_dataset": 1}
+    assert len(scans) == 1, (
+        f"expected one cosine scan per facets request, got {len(scans)}"
+    )

--- a/backend/tests/test_search_facets.py
+++ b/backend/tests/test_search_facets.py
@@ -9,7 +9,7 @@ from httpx import AsyncClient
 from sqlalchemy import event, select, text, update
 
 from app.core.db.models import AppSetting
-from app.core.persistent_config import EMBEDDING_MODEL
+from app.core.persistent_config import EMBEDDING_MODEL, SEMANTIC_SEARCH_ENABLED
 from app.modules.catalog.collections.models import Collection
 from app.modules.catalog.datasets.domain.models import Dataset, Record, RecordKeyword
 from app.processing.embeddings import helpers as embedding_helpers
@@ -371,6 +371,7 @@ async def semantic_facet_datasets(test_db_session) -> dict:
             await session.commit()
         await _embed(session, ds, _band_vector(0.99 - index * 0.02, dim))
         datasets.append(ds)
+    previous = await SEMANTIC_SEARCH_ENABLED.get(session)
     await _set_semantic_search(session, True)
     yield {
         "datasets": datasets,
@@ -383,6 +384,7 @@ async def semantic_facet_datasets(test_db_session) -> dict:
         {"ids": [ds.record_id for ds in datasets]},
     )
     await session.commit()
+    await _set_semantic_search(session, previous)
 
 
 def _patched_embedding(vector: list[float]):

--- a/backend/tests/test_search_facets.py
+++ b/backend/tests/test_search_facets.py
@@ -1,15 +1,24 @@
 """Integration tests for /search/facets endpoint and facet counting."""
 
 import uuid
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from httpx import AsyncClient
-from sqlalchemy import update
+from sqlalchemy import select, text, update
 
+from app.core.db.models import AppSetting
+from app.core.persistent_config import EMBEDDING_MODEL
 from app.modules.catalog.collections.models import Collection
 from app.modules.catalog.datasets.domain.models import Dataset, Record, RecordKeyword
+from app.processing.embeddings import helpers as embedding_helpers
+from app.processing.embeddings.models import RecordEmbedding
 
 from tests.factories import get_user_id
+
+# Vector band this file owns; the other search suites use 40, 70, 90 and 800+.
+_BAND_LO = 130
+_SEMANTIC_ONLY_QUERY = "zzznolexicalfacetsxyz"
 
 
 # ---------------------------------------------------------------------------
@@ -257,3 +266,240 @@ async def test_facets_returns_keyword_groups(
     if len(data["srid"]) > 0:
         assert "value" in data["srid"][0]
         assert "count" in data["srid"][0]
+
+
+# ---------------------------------------------------------------------------
+# fix(#1855): facet counts are taken over the results' candidate set
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _fresh_has_embeddings_cache():
+    """The 30 s has_embeddings cache must not carry a False from an earlier test."""
+    embedding_helpers._has_embeddings_cache.clear()
+    yield
+    embedding_helpers._has_embeddings_cache.clear()
+
+
+async def _embedding_dim(session) -> int:
+    result = await session.execute(
+        text(
+            "SELECT atttypmod FROM pg_attribute "
+            "WHERE attrelid = 'catalog.record_embeddings'::regclass "
+            "AND attname = 'embedding'"
+        )
+    )
+    dim = result.scalar_one_or_none()
+    return dim if dim and dim > 0 else 1536
+
+
+def _band_vector(base_value: float, dim: int) -> list[float]:
+    """Unit vector with its signal in dims [_BAND_LO, _BAND_LO + 10), zeros elsewhere."""
+    vec = [0.0] * dim
+    for i in range(_BAND_LO, _BAND_LO + 10):
+        vec[i] = base_value + ((i - _BAND_LO) * 0.01)
+    magnitude = sum(v * v for v in vec) ** 0.5
+    return [v / magnitude for v in vec]
+
+
+async def _set_semantic_search(session, enabled: bool) -> None:
+    result = await session.execute(
+        select(AppSetting).where(AppSetting.key == "semantic_search_enabled")
+    )
+    existing = result.scalar_one_or_none()
+    if existing is None:
+        session.add(AppSetting(key="semantic_search_enabled", value={"v": enabled}))
+    else:
+        existing.value = {"v": enabled}
+    await session.commit()
+
+    from app.platform.cache import get_cache
+
+    try:
+        await get_cache().delete("config:semantic_search_enabled")
+    except RuntimeError:
+        pass
+
+
+async def _embed(session, dataset: Dataset, vector: list[float]) -> None:
+    session.add(
+        RecordEmbedding(
+            record_id=dataset.record_id,
+            embedding=vector,
+            model_name=await EMBEDDING_MODEL.get(session),
+            content_hash=uuid.uuid4().hex[:64],
+        )
+    )
+    await session.commit()
+
+
+@pytest.fixture
+async def semantic_facet_datasets(test_db_session) -> dict:
+    """Three datasets a band query matches by meaning only: two vector, one raster.
+
+    Their titles share no word with ``_SEMANTIC_ONLY_QUERY``, so whatever the
+    facets count for that query is the vector arm and nothing else. The
+    embeddings are deleted on teardown so the band holds one test's rows at a
+    time; ``slug`` keeps the titles unique for the lexical control.
+    """
+    session = test_db_session
+    admin_id = await get_user_id(session, "admin")
+    dim = await _embedding_dim(session)
+    slug = f"zq{uuid.uuid4().hex[:8]}"
+    datasets = []
+    for index, (name, record_type) in enumerate(
+        (
+            (f"Zqfacet Alpha {slug}", "vector_dataset"),
+            (f"Zqfacet Beta {slug}", "vector_dataset"),
+            (f"Zqfacet Gamma {slug}", "raster_dataset"),
+        )
+    ):
+        ds = await _create_search_dataset(
+            session,
+            created_by=admin_id,
+            name=name,
+            keywords=[f"zqfacetband{index}"],
+            description="matched by meaning rather than by its words",
+        )
+        if record_type != "vector_dataset":
+            await session.execute(
+                update(Record)
+                .where(Record.id == ds.record_id)
+                .values(record_type=record_type)
+            )
+            await session.commit()
+        await _embed(session, ds, _band_vector(0.99 - index * 0.02, dim))
+        datasets.append(ds)
+    await _set_semantic_search(session, True)
+    yield {
+        "datasets": datasets,
+        "slug": slug,
+        "dim": dim,
+        "query_vector": _band_vector(1.0, dim),
+    }
+    await session.execute(
+        text("DELETE FROM catalog.record_embeddings WHERE record_id = ANY(:ids)"),
+        {"ids": [ds.record_id for ds in datasets]},
+    )
+    await session.commit()
+
+
+def _patched_embedding(vector: list[float]):
+    return patch(
+        "app.modules.catalog.search.service_semantic.generate_embedding",
+        new_callable=AsyncMock,
+        return_value=vector,
+    )
+
+
+@pytest.mark.anyio
+async def test_facets_count_the_semantic_candidate_set(
+    client: AsyncClient,
+    admin_auth_header: dict,
+    semantic_facet_datasets: dict,
+):
+    """fix(#1855): with semantic mode on, facets count what the results return.
+
+    The query matches nothing lexically, so on the lexical-only facets this
+    read record_type {} beside three results.
+    """
+    with _patched_embedding(semantic_facet_datasets["query_vector"]):
+        results = await client.get(
+            "/search/datasets/",
+            params={"q": _SEMANTIC_ONLY_QUERY},
+            headers=admin_auth_header,
+        )
+        facets = await client.get(
+            "/search/facets/",
+            params={"q": _SEMANTIC_ONLY_QUERY},
+            headers=admin_auth_header,
+        )
+    assert results.status_code == 200
+    assert facets.status_code == 200
+
+    body = results.json()
+    titles = {f["properties"]["title"] for f in body["features"]}
+    slug = semantic_facet_datasets["slug"]
+    # Non-vacuity: the vector arm ran and the results are the three band records.
+    assert titles == {f"Zqfacet {n} {slug}" for n in ("Alpha", "Beta", "Gamma")}
+    assert body["numberMatched"] == 3
+
+    payload = facets.json()
+    assert payload["record_type"] == {"vector_dataset": 2, "raster_dataset": 1}
+    assert sum(payload["record_type"].values()) == body["numberMatched"]
+    assert {k["value"] for k in payload["keywords"]} == {
+        "zqfacetband0",
+        "zqfacetband1",
+        "zqfacetband2",
+    }
+
+
+@pytest.mark.anyio
+async def test_facets_count_the_lexical_candidate_set(
+    client: AsyncClient,
+    admin_auth_header: dict,
+    semantic_facet_datasets: dict,
+    test_db_session,
+):
+    """Control: with semantic search off both endpoints are lexical and agree."""
+    lexical_q = f"Zqfacet Alpha {semantic_facet_datasets['slug']}"
+    await _set_semantic_search(test_db_session, False)
+    try:
+        with _patched_embedding(semantic_facet_datasets["query_vector"]) as embed:
+            results = await client.get(
+                "/search/datasets/",
+                params={"q": lexical_q},
+                headers=admin_auth_header,
+            )
+            facets = await client.get(
+                "/search/facets/",
+                params={"q": lexical_q},
+                headers=admin_auth_header,
+            )
+        embed.assert_not_called()
+    finally:
+        await _set_semantic_search(test_db_session, True)
+
+    assert results.status_code == 200
+    assert facets.status_code == 200
+    body = results.json()
+    assert {f["properties"]["title"] for f in body["features"]} == {lexical_q}
+    counts = facets.json()["record_type"]
+    assert counts == {"vector_dataset": 1}
+    assert sum(counts.values()) == body["numberMatched"] == 1
+
+
+@pytest.mark.anyio
+async def test_facets_semantic_candidates_keep_the_visibility_filter(
+    client: AsyncClient,
+    semantic_facet_datasets: dict,
+    test_db_session,
+):
+    """Rule 1: a private record the vector arm would match is not counted for anon."""
+    session = test_db_session
+    admin_id = await get_user_id(session, "admin")
+    slug = semantic_facet_datasets["slug"]
+    private_ds = await _create_search_dataset(
+        session,
+        created_by=admin_id,
+        name=f"Zqfacet Private Delta {slug}",
+        visibility="private",
+        description="nearest to the query, visible to its owner only",
+    )
+    await _embed(
+        session, private_ds, _band_vector(0.999, semantic_facet_datasets["dim"])
+    )
+    try:
+        with _patched_embedding(semantic_facet_datasets["query_vector"]):
+            # The slug keeps this anonymous (cacheable) request off any earlier key.
+            facets = await client.get(
+                "/search/facets/", params={"q": f"{_SEMANTIC_ONLY_QUERY} {slug}"}
+            )
+    finally:
+        await session.execute(
+            text("DELETE FROM catalog.record_embeddings WHERE record_id = :rid"),
+            {"rid": private_ds.record_id},
+        )
+        await session.commit()
+    assert facets.status_code == 200
+    assert facets.json()["record_type"] == {"vector_dataset": 2, "raster_dataset": 1}

--- a/backend/tests/test_semantic_hnsw_post_filter_1546.py
+++ b/backend/tests/test_semantic_hnsw_post_filter_1546.py
@@ -70,6 +70,14 @@ _EF_SEARCH = 100
 _FOREIGN_URL = "https://starved-endpoint.invalid/v1"
 
 
+@pytest.fixture
+async def semantic_search_on(test_db_session):
+    previous = await SEMANTIC_SEARCH_ENABLED.get(test_db_session)
+    await SEMANTIC_SEARCH_ENABLED.set(test_db_session, True)
+    yield
+    await SEMANTIC_SEARCH_ENABLED.set(test_db_session, previous)
+
+
 @pytest.fixture(autouse=True)
 def _fresh_has_embeddings_cache():
     helpers._has_embeddings_cache.clear()
@@ -110,12 +118,10 @@ async def _seed(session, name: str, *, fingerprint: str, angle: float) -> uuid.U
 @pytest.mark.anyio
 async def test_foreign_rows_nearer_than_live_ones_do_not_starve_the_scan(
     test_db_session,
+    semantic_search_on,
 ):
     """150 rejected neighbours in front of 5 usable ones, window of 100."""
     session = test_db_session
-    # fix(#1855): resolve_semantic_arm gates on the flag itself, so the test
-    # sets it rather than inheriting whatever an earlier test left cached.
-    await SEMANTIC_SEARCH_ENABLED.set(session, True)
     model_name = await EMBEDDING_MODEL.get(session)
     dimensions = await EMBEDDING_DIMS.get(session)
     base_url = await resolve_embedding_base_url(session)

--- a/backend/tests/test_semantic_hnsw_post_filter_1546.py
+++ b/backend/tests/test_semantic_hnsw_post_filter_1546.py
@@ -16,7 +16,7 @@ on a catalog holding two models' rows in one index, which is the state #1506
 was written for. #1546 made the predicate more selective, so it made the window
 easier to exhaust, and the fix covers both.
 
-WHY THIS TESTS `_get_vector_ranks` AND NOT THE SEARCH ENDPOINT: the defect only
+WHY THIS TESTS `resolve_semantic_arm` AND NOT THE SEARCH ENDPOINT: the defect only
 exists when the plan actually uses the HNSW index, and on a table this size
 Postgres will not choose it unless pushed. `enable_seqscan = off` alone is not
 enough and the first draft of this test was vacuous because of it: the planner
@@ -44,10 +44,12 @@ import uuid
 from unittest.mock import AsyncMock, patch
 
 import pytest
-from sqlalchemy import text
+from sqlalchemy import select, text
 
 from app.core.persistent_config import EMBEDDING_DIMS, EMBEDDING_MODEL
+from app.modules.catalog.datasets.domain.models import Record
 from app.modules.catalog.search import service_semantic
+from app.modules.catalog.search.service_filters import SearchFilters
 from app.processing.embeddings import helpers
 from app.processing.embeddings.helpers import embedding_config_fingerprint
 from app.processing.embeddings.models import RecordEmbedding
@@ -142,7 +144,7 @@ async def test_foreign_rows_nearer_than_live_ones_do_not_starve_the_scan(
 
     # Non-vacuity, part one: the plan really does go through the HNSW index, so
     # a post-filter window exists to be starved. Explained against the same
-    # shape `_get_vector_ranks` builds — the configuration predicate, the 0.7
+    # shape `resolve_semantic_arm` builds — the configuration predicate, the 0.7
     # cutoff, ordered by distance with a limit — because a simpler query can
     # take a different plan, which is exactly how the earlier draft fooled
     # itself.
@@ -173,13 +175,17 @@ async def test_foreign_rows_nearer_than_live_ones_do_not_starve_the_scan(
         "generate_embedding",
         new=AsyncMock(return_value=query_vector),
     ):
-        ranks, returned_vector, identity = await service_semantic._get_vector_ranks(
-            session, "starvation query", _LIVE_ROWS
+        arm = await service_semantic.resolve_semantic_arm(
+            session,
+            SearchFilters(q="starvation query"),
+            select(Record.id),
+            depth=_LIVE_ROWS,
         )
 
     # Non-vacuity, part two: the vector arm ran rather than bailing early.
-    assert returned_vector == query_vector
-    assert identity is not None
+    assert arm is not None
+    assert arm.query_vector == query_vector
+    ranks = arm.ranks(_LIVE_ROWS)
 
     returned = {uuid.UUID(record_id) for record_id in ranks}
     assert returned & live_ids, (

--- a/backend/tests/test_semantic_hnsw_post_filter_1546.py
+++ b/backend/tests/test_semantic_hnsw_post_filter_1546.py
@@ -46,7 +46,11 @@ from unittest.mock import AsyncMock, patch
 import pytest
 from sqlalchemy import select, text
 
-from app.core.persistent_config import EMBEDDING_DIMS, EMBEDDING_MODEL
+from app.core.persistent_config import (
+    EMBEDDING_DIMS,
+    EMBEDDING_MODEL,
+    SEMANTIC_SEARCH_ENABLED,
+)
 from app.modules.catalog.datasets.domain.models import Record
 from app.modules.catalog.search import service_semantic
 from app.modules.catalog.search.service_filters import SearchFilters
@@ -109,6 +113,9 @@ async def test_foreign_rows_nearer_than_live_ones_do_not_starve_the_scan(
 ):
     """150 rejected neighbours in front of 5 usable ones, window of 100."""
     session = test_db_session
+    # fix(#1855): resolve_semantic_arm gates on the flag itself, so the test
+    # sets it rather than inheriting whatever an earlier test left cached.
+    await SEMANTIC_SEARCH_ENABLED.set(session, True)
     model_name = await EMBEDDING_MODEL.get(session)
     dimensions = await EMBEDDING_DIMS.get(session)
     base_url = await resolve_embedding_base_url(session)


### PR DESCRIPTION
Fixes the facet counts contradicting the result count reported in #1855 (live UX walk of 2026-09-04 on the demo).

## Defect

`GET /api/search/datasets/?q=buildings in manhattan` answers `numberMatched: 4` in semantic mode while `GET /api/search/facets/?q=…` answers `record_type: {vector_dataset: 1}`, because the facets query only ever applied the lexical text clause. The filter panel then read "All 1 / Vector 1" beside four results, and clicking "Vector 1" still returned four.

## Fix

Both endpoints now build their candidate set through one function, `select_candidates` in the new `backend/app/modules/catalog/search/service_candidates.py`. It applies the visibility filter (Rule 1), the shared filters, the text clause and the semantic mode decision in one place, and returns the filtered statement plus how the rows matched. `search_datasets` counts `numberMatched` over it and keeps its own ranking statement (FTS rank and text clause only) for the page; `get_facet_counts` builds its CTE from it with the result-only filters (record type, dates, CQL2) left off, as before, so the type counts still cover every type.

The semantic mode decision moved out of `search_datasets` and `_run_rrf_merge` into `resolve_semantic_arm` in `service_semantic.py`, which replaces `_get_vector_ranks`. It runs the same gates in the same order as before (flag, query length, embeddings present, configuration resolvable, embedding succeeds, vector query succeeds, at least one vetted row within the cutoff) and returns a `SemanticArm` holding the query vector, the configuration identity and the nearest-first vetted ids. Every failure still degrades to lexical mode, now for facets as well as results.

The #448 row gate lives in the same place, and the vector arm is one scan per request in both regimes. Below the gate `resolve_semantic_arm` fetches every vetted embedding within the cosine cutoff, nearest first, bounded by the gate itself (at most 5000 rows, under asyncpg's 32767-parameter cap); above it the nearest window of vetted rows, with results and facets taking the same window (`_APPROXIMATE_CANDIDATE_WINDOW = 200`, the offset-paged page-size ceiling, widened to `skip + limit` when a page reaches deeper) so a first page of any size agrees with the facet counts. Either way the candidate clause is `Record.id IN (<ids>)`, so the count statement and the five facet aggregates never touch the embeddings table. The first cut of this PR put the exact arm in the clause as a cosine subquery, and because the facets CTE feeds five separately executed aggregates, one facets request scanned the embeddings six times (the probe plus five); codex round 1 caught it, and `test_facets_scan_the_embeddings_once_per_request` now counts statements carrying pgvector's `<=>` operator through the client's engine and asserts one. The full-window sentinel that keeps the `next` link alive stays in `_run_rrf_merge`; it is the one number facets cannot attribute to a type, so above the gate a full window reads one higher on the results header than on the facets.

Above the gate `offset` is unbounded, so the window is caller-chosen, but the window query is an ordered HNSW scan and `set_hnsw_recall` caps `hnsw.max_scan_tuples` at 20000, so the id list stays under the parameter cap. Only a plan that abandons the index on a catalog with more than 32767 usable embeddings inside the cutoff, asked for a page past the 32767th result, could exceed it.

Two consequences of facets embedding the query:

- `/search/facets/` now carries the SEC-S11 embedding rate limit. Without it the endpoint would have been a way around the cap on `/search/datasets/` (a novel `q` per request costs one provider call). slowapi scopes a plain `@limiter.limit` to the handler, so two decorated routes would be two buckets and a caller alternating them could embed twice the advertised cap; both routes therefore use `@limiter.shared_limit(_semantic_search_rate_limit, scope="semantic_search")`, one bucket per IP. The WR-02 negative control in `test_rate_limits.py` is flipped into a positive pin, and a second test alternates the two routes and asserts the (limit + 1)th call is a 429 whichever route it lands on, starting from either.
- The trade-off: the SPA fires both requests per query change, so the shared bucket counts two tokens per change and at the default of 30 per minute an SPA user gets 15 query changes a minute per IP. The default stays at 30. Raising it to 60 was tried and reverted in codex round 1: a non-SPA client calling one route would get 60 novel embeddings a minute, double the cap the setting advertises, and the SPA pairing does not constrain that client. An operator fronting many users behind one NAT raises the stored `semantic_search_rate_limit`. The facets half of the pair should stop spending a token (the provider is paid for one embedding per change; the second request is a cache hit when it lands after the first), tracked in #1903 with the two candidate mechanisms and the shared bucket named as the constraint.
- The anonymous facets cache key now includes the semantic flag, as the search key already did.

`_apply_search_only_filters` moved from `service_datasets.py` into `service_candidates.py` unchanged apart from trimmed comments; `service_datasets.py` and `service_semantic.py` shrank by 78 and 71 lines and their caps in `test_layering.py` are set to the measured figures. `test_rule1_structural.py` credits `select_candidates` as a delegated value guard (its `apply_visibility_filter` call is two levels below the facets handler now) and pins the delegation chain in `test_delegated_guards_still_enforce_access`, including the results page statement's own `vetting_filters` call in `search_datasets`, which the credited count call does not cover.

No frontend change: `FilterPanel.tsx` sums the `record_type` counts for "All", and those now equal `numberMatched` for the same query.

## Schema, API and config impact

No request or response schema changes (`scripts/dump_openapi.py --check` exit 0). No setting changes: `semantic_search_rate_limit` keeps its 30 per minute default; `/search/datasets/` and `/search/facets/` now share that bucket per IP, and `/search/facets/` loses the global per-second default on that route, as `/search/datasets/` already did. `/datasets/{id}/related/` is unchanged.

## Tests

- `test_search_facets.py::test_facets_count_the_semantic_candidate_set`: semantic mode with `generate_embedding` patched to a band vector and three embedded records (two vector, one raster) that match nothing lexically; asserts the results return exactly those three, facets read `{vector_dataset: 2, raster_dataset: 1}`, the sum equals `numberMatched`, and the keyword facets are the three records' keywords.
- `test_search_facets.py::test_facets_count_the_lexical_candidate_set`: semantic search off; both endpoints lexical, embedding never called, counts agree.
- `test_search_facets.py::test_facets_semantic_candidates_keep_the_visibility_filter`: a private record nearest to the query is not counted for an anonymous caller (Rule 1).
- `test_rate_limits.py::test_search_facets_rate_limited`: 7 novel queries at a 5/min limit produce at least two 429s.
- `test_rate_limits.py::test_search_datasets_and_facets_share_one_bucket` (both starting routes): six alternating novel queries at a 5/min limit give five 200s and a 429, whichever route the sixth lands on. `test_default_semantic_search_limit_is_30` is unchanged.
- `test_search_facets.py::test_facets_scan_the_embeddings_once_per_request`: a `before_cursor_execute` listener on the client's engine counts statements containing `<=>` during one semantic facets request and asserts exactly one, with the counts checked so the vector arm provably ran.
- `test_hybrid_search.py::test_semantic_approximate_count_keeps_next_link` additionally patches the shared window to 0 so the full-window sentinel stays exercised.
- `test_semantic_hnsw_post_filter_1546.py` calls `resolve_semantic_arm` instead of `_get_vector_ranks`; same query shape, same assertions.

## Counterfactual

With `backend/app/modules/catalog/search/` checked out from `origin/main` and the tests kept:

```
FAILED tests/test_search_facets.py::test_facets_count_the_semantic_candidate_set
E       AssertionError: assert {} == {'vector_data...r_dataset': 1}
E         Right contains 2 more items:
E         {'raster_dataset': 1, 'vector_dataset': 2}
FAILED tests/test_search_facets.py::test_facets_semantic_candidates_keep_the_visibility_filter
E       AssertionError: assert {} == {'vector_data...r_dataset': 1}
FAILED tests/test_rate_limits.py::test_search_facets_rate_limited
E       AssertionError: Expected >= 2 rate-limited responses with threshold=5/7 requests, got 0. Statuses: [200, 200, 200, 200, 200, 200, 200]
3 failed, 1 passed, 10 deselected
```

The lexical control is the one that passed.

With the two routes on separate `@limiter.limit` buckets (the first commit of this PR) and the shared-bucket test kept:

```
FAILED test_search_datasets_and_facets_share_one_bucket[/search/datasets/]
E  AssertionError: one shared 5/min bucket must 429 the sixth call across both routes (starting from /search/datasets/); got [200, 200, 200, 200, 200, 200]
FAILED test_search_datasets_and_facets_share_one_bucket[/search/facets/]
E  ... (starting from /search/facets/); got [200, 200, 200, 200, 200, 200]
```

With the exact vector arm still a cosine subquery inside the candidate clause (the head codex round 1 reviewed) and the scan-count test kept:

```
FAILED tests/test_search_facets.py::test_facets_scan_the_embeddings_once_per_request
E  AssertionError: expected one cosine scan per facets request, got 6
E  assert 6 == 1
```

The six are the probe window query plus the type, keyword, organization, SRID and collection aggregates, each re-running the subquery through the CTE.

## Verification

From the worktree, Postgres at localhost:5434:

```
cd backend && set -a && source ../.env.test && set +a
uv run pytest tests/test_search_facets.py tests/test_hybrid_search.py tests/test_embedding_config_stamp_1546.py tests/test_semantic_hnsw_post_filter_1546.py tests/test_rate_limits.py tests/test_search_cache.py tests/test_search_embedding_cache.py tests/test_semantic_search_rate_limit_1778.py tests/test_search_facets_input_cap.py -q
  67 passed
uv run pytest tests/test_search.py tests/test_search_datetime.py tests/test_search_pagination.py tests/test_ogc_features.py tests/test_stac_search_validation.py tests/test_stac_search_dos_sec023.py tests/test_attribute_search.py tests/test_catalog_search_ilike_escape.py tests/test_search_simple_regconfig.py tests/test_search_trgm_expression_pinning.py tests/test_redirect_slashes.py tests/test_saved_searches.py tests/test_search_cors_1596.py tests/test_datasets.py -q
  243 passed
uv run pytest tests/test_rule1_structural.py tests/test_rule2_structural.py tests/test_layering.py -q
  165 passed
uv run pytest <all of the above> tests/test_cache.py tests/test_rule1_structural.py tests/test_rule2_structural.py tests/test_layering.py -q
  522 passed (rerun after the codex round 1 fold-in, one invocation)
uv run ruff check . && uv run ruff format --check .
  All checks passed
PYTHONPATH=. uv run python scripts/dump_openapi.py --check
  exit 0
```

## Noticed and left alone

- `useFacets` in the SPA strips `record_type` and `collection_id` before calling `/facets/`, so "All N" and `numberMatched` still differ by design while a type or collection filter is active. That is the facets contract, not this defect.
- Facets ignore `date_from`, `date_to`, `vintage_*` and `filter` because the endpoint does not accept them; the SPA does not send them to facets either.
